### PR TITLE
fix: prevent message submission during IME composition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,7 +139,7 @@
             :disabled="
               isRunning || (!geminiAvailable && needsGemini(currentRoleId))
             "
-            @keydown.enter="sendMessage()"
+            @keydown.enter="$event.isComposing || sendMessage()"
           />
           <button
             class="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
- IME変換中（日本語・中国語・韓国語など）のEnterキーでメッセージが送信されてしまう問題を修正
- `KeyboardEvent.isComposing` チェックを追加し、変換確定のEnterを無視するようにした

## Changes
- `src/App.vue`: `@keydown.enter` に `isComposing` ガードを追加（1行変更）

## Test plan
- [x] 日本語IMEで変換中にEnterを押して、送信されないことを確認
- [x] 変換確定後にEnterを押して、正常に送信されることを確認
- [x] 英語入力でEnterを押して、正常に送信されることを確認
