### PR TITLE
feat: md headers + json syntax coloring in files mode

### DIFF
--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -14,6 +14,8 @@ const TEXT_EXTENSIONS = new Set([
   ".markdown",
   ".txt",
   ".json",
+  ".jsonl",
+  ".ndjson",
   ".yaml",
   ".yml",
   ".js",

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -22,13 +22,21 @@
         v-if="selectedPath"
         class="px-4 py-2 border-b border-gray-200 text-xs text-gray-500 font-mono shrink-0 flex items-center gap-2"
       >
-        <span class="truncate">{{ selectedPath }}</span>
+        <span class="truncate min-w-0">{{ selectedPath }}</span>
         <span v-if="content" class="text-gray-400 shrink-0"
           >· {{ formatBytes(content.size) }}</span
         >
         <span v-if="content?.modifiedMs" class="text-gray-400 shrink-0"
           >· {{ formatTime(content.modifiedMs) }}</span
         >
+        <button
+          v-if="isMarkdown"
+          class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
+          :title="mdRawMode ? 'Show rendered Markdown' : 'Show raw source'"
+          @click="toggleMdRaw"
+        >
+          {{ mdRawMode ? "Rendered" : "Raw" }}
+        </button>
       </div>
       <div class="flex-1 overflow-auto min-h-0">
         <div
@@ -45,12 +53,55 @@
         </div>
         <template v-else-if="content">
           <template v-if="content.kind === 'text'">
-            <!-- Markdown: use the same renderer as chat responses -->
-            <div v-if="isMarkdown" class="h-full">
-              <TextResponseView
-                :selected-result="markdownResult(content.content)"
-              />
+            <!-- Markdown rendered: frontmatter panel + body -->
+            <div
+              v-if="isMarkdown && !mdRawMode"
+              class="h-full flex flex-col overflow-auto"
+            >
+              <div
+                v-if="mdFrontmatter && mdFrontmatter.fields.length > 0"
+                class="shrink-0 m-4 mb-0 rounded border border-gray-200 bg-gray-50 p-3 text-xs"
+              >
+                <div
+                  v-for="field in mdFrontmatter.fields"
+                  :key="field.key"
+                  class="flex items-baseline gap-2 py-0.5"
+                >
+                  <span class="font-semibold text-gray-600 shrink-0"
+                    >{{ field.key }}:</span
+                  >
+                  <template v-if="Array.isArray(field.value)">
+                    <span class="flex flex-wrap gap-1">
+                      <span
+                        v-for="item in field.value"
+                        :key="item"
+                        class="rounded-full bg-white border border-gray-300 px-2 py-0.5 text-gray-700"
+                      >
+                        {{ item }}
+                      </span>
+                    </span>
+                  </template>
+                  <span v-else class="text-gray-800 break-words">{{
+                    field.value
+                  }}</span>
+                </div>
+              </div>
+              <div class="flex-1 min-h-0">
+                <TextResponseView
+                  :selected-result="
+                    markdownResult(
+                      mdFrontmatter ? mdFrontmatter.body : content.content,
+                    )
+                  "
+                />
+              </div>
             </div>
+            <!-- Markdown raw source (includes frontmatter) -->
+            <pre
+              v-else-if="isMarkdown && mdRawMode"
+              class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
+              >{{ content.content }}</pre
+            >
             <!-- HTML: sandboxed iframe preview (scripts disabled) -->
             <iframe
               v-else-if="isHtml"
@@ -110,8 +161,15 @@ import FileTree, { type TreeNode } from "./FileTree.vue";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
+import {
+  tokenizeJson,
+  prettyJson,
+  JSON_TOKEN_CLASS,
+} from "../utils/jsonSyntax";
+import { extractFrontmatter } from "../utils/frontmatter";
 
 const STORAGE_KEY = "files_selected_path";
+const MD_RAW_STORAGE_KEY = "files_md_raw_mode";
 const RECENT_THRESHOLD_MS = 60 * 1000;
 
 interface TextContent {
@@ -153,91 +211,25 @@ function hasExt(filePath: string | null, exts: string[]): boolean {
 const isMarkdown = computed(() =>
   hasExt(selectedPath.value, [".md", ".markdown"]),
 );
+
+const mdRawMode = ref(localStorage.getItem(MD_RAW_STORAGE_KEY) === "true");
+
+function toggleMdRaw(): void {
+  mdRawMode.value = !mdRawMode.value;
+  localStorage.setItem(MD_RAW_STORAGE_KEY, String(mdRawMode.value));
+}
 const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
 const isJson = computed(() => hasExt(selectedPath.value, [".json"]));
-
-function prettyJson(raw: string): string {
-  try {
-    return JSON.stringify(JSON.parse(raw), null, 2);
-  } catch {
-    // Malformed JSON — show the raw text so the user can still read it
-    return raw;
-  }
-}
-
-type JsonTokenType =
-  | "key"
-  | "string"
-  | "number"
-  | "keyword"
-  | "punct"
-  | "whitespace";
-
-interface JsonToken {
-  type: JsonTokenType;
-  value: string;
-}
-
-const JSON_TOKEN_CLASS: Record<JsonTokenType, string> = {
-  key: "text-blue-700",
-  string: "text-green-700",
-  number: "text-orange-600",
-  keyword: "text-purple-700",
-  punct: "text-gray-500",
-  whitespace: "",
-};
-
-// Regex splits a JSON document into recognisable tokens. Strings are
-// matched before numbers/keywords so escaped quotes inside strings
-// stay together. Anything that doesn't match (syntax errors, stray
-// chars) is emitted as a "punct" token so the user still sees it.
-const JSON_TOKEN_RE =
-  /("(?:[^"\\]|\\.)*")|(\btrue\b|\bfalse\b|\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\s+)|([{}[\]:,])/g;
-
-function tokenizeJson(raw: string): JsonToken[] {
-  const tokens: JsonToken[] = [];
-  JSON_TOKEN_RE.lastIndex = 0;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null = JSON_TOKEN_RE.exec(raw);
-  while (match !== null) {
-    if (match.index > lastIndex) {
-      tokens.push({ type: "punct", value: raw.slice(lastIndex, match.index) });
-    }
-    if (match[1] !== undefined)
-      tokens.push({ type: "string", value: match[1] });
-    else if (match[2] !== undefined)
-      tokens.push({ type: "keyword", value: match[2] });
-    else if (match[3] !== undefined)
-      tokens.push({ type: "number", value: match[3] });
-    else if (match[4] !== undefined)
-      tokens.push({ type: "whitespace", value: match[4] });
-    else if (match[5] !== undefined)
-      tokens.push({ type: "punct", value: match[5] });
-    lastIndex = JSON_TOKEN_RE.lastIndex;
-    match = JSON_TOKEN_RE.exec(raw);
-  }
-  if (lastIndex < raw.length) {
-    tokens.push({ type: "punct", value: raw.slice(lastIndex) });
-  }
-  // A string that precedes ":" (skipping whitespace) is an object key.
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].type !== "string") continue;
-    let j = i + 1;
-    while (j < tokens.length && tokens[j].type === "whitespace") j++;
-    if (
-      j < tokens.length &&
-      tokens[j].type === "punct" &&
-      tokens[j].value === ":"
-    ) {
-      tokens[i] = { type: "key", value: tokens[i].value };
-    }
-  }
-  return tokens;
-}
 
 const jsonTokens = computed(() => {
   if (!content.value || content.value.kind !== "text") return [];
   return tokenizeJson(prettyJson(content.value.content));
+});
+
+const mdFrontmatter = computed(() => {
+  if (!content.value || content.value.kind !== "text") return null;
+  if (!isMarkdown.value) return null;
+  return extractFrontmatter(content.value.content);
 });
 
 function markdownResult(text: string): ToolResultComplete<TextResponseData> {

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -120,6 +120,29 @@
               :key="i"
               :class="JSON_TOKEN_CLASS[tok.type]"
             >{{ tok.value }}</span></pre>
+            <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
+            <div v-else-if="isJsonl" class="p-4 space-y-2">
+              <div
+                v-for="(line, i) in jsonlLines"
+                :key="i"
+                class="rounded border bg-gray-50 p-3"
+                :class="line.parseError ? 'border-red-300' : 'border-gray-200'"
+              >
+                <div
+                  v-if="line.parseError"
+                  class="text-xs text-red-600 mb-1 font-sans"
+                >
+                  parse error
+                </div>
+                <pre
+                  class="text-xs font-mono text-gray-800 whitespace-pre-wrap"
+                ><span
+                  v-for="(tok, j) in line.tokens"
+                  :key="j"
+                  :class="JSON_TOKEN_CLASS[tok.type]"
+                >{{ tok.value }}</span></pre>
+              </div>
+            </div>
             <!-- Plain text fallback -->
             <pre
               v-else
@@ -163,6 +186,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
 import {
   tokenizeJson,
+  tokenizeJsonl,
   prettyJson,
   JSON_TOKEN_CLASS,
 } from "../utils/jsonSyntax";
@@ -220,10 +244,18 @@ function toggleMdRaw(): void {
 }
 const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
 const isJson = computed(() => hasExt(selectedPath.value, [".json"]));
+const isJsonl = computed(() =>
+  hasExt(selectedPath.value, [".jsonl", ".ndjson"]),
+);
 
 const jsonTokens = computed(() => {
   if (!content.value || content.value.kind !== "text") return [];
   return tokenizeJson(prettyJson(content.value.content));
+});
+
+const jsonlLines = computed(() => {
+  if (!content.value || content.value.kind !== "text") return [];
+  return tokenizeJsonl(content.value.content);
 });
 
 const mdFrontmatter = computed(() => {

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -59,12 +59,16 @@
               sandbox=""
               title="HTML preview"
             />
-            <!-- JSON: pretty-printed, or raw if parse fails -->
+            <!-- JSON: pretty-printed with simple syntax coloring. Fall
+                 back to raw content if the file is malformed. -->
             <pre
               v-else-if="isJson"
               class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
-              >{{ prettyJson(content.content) }}</pre
-            >
+            ><span
+              v-for="(tok, i) in jsonTokens"
+              :key="i"
+              :class="JSON_TOKEN_CLASS[tok.type]"
+            >{{ tok.value }}</span></pre>
             <!-- Plain text fallback -->
             <pre
               v-else
@@ -160,6 +164,81 @@ function prettyJson(raw: string): string {
     return raw;
   }
 }
+
+type JsonTokenType =
+  | "key"
+  | "string"
+  | "number"
+  | "keyword"
+  | "punct"
+  | "whitespace";
+
+interface JsonToken {
+  type: JsonTokenType;
+  value: string;
+}
+
+const JSON_TOKEN_CLASS: Record<JsonTokenType, string> = {
+  key: "text-blue-700",
+  string: "text-green-700",
+  number: "text-orange-600",
+  keyword: "text-purple-700",
+  punct: "text-gray-500",
+  whitespace: "",
+};
+
+// Regex splits a JSON document into recognisable tokens. Strings are
+// matched before numbers/keywords so escaped quotes inside strings
+// stay together. Anything that doesn't match (syntax errors, stray
+// chars) is emitted as a "punct" token so the user still sees it.
+const JSON_TOKEN_RE =
+  /("(?:[^"\\]|\\.)*")|(\btrue\b|\bfalse\b|\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\s+)|([{}[\]:,])/g;
+
+function tokenizeJson(raw: string): JsonToken[] {
+  const tokens: JsonToken[] = [];
+  JSON_TOKEN_RE.lastIndex = 0;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = JSON_TOKEN_RE.exec(raw);
+  while (match !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({ type: "punct", value: raw.slice(lastIndex, match.index) });
+    }
+    if (match[1] !== undefined)
+      tokens.push({ type: "string", value: match[1] });
+    else if (match[2] !== undefined)
+      tokens.push({ type: "keyword", value: match[2] });
+    else if (match[3] !== undefined)
+      tokens.push({ type: "number", value: match[3] });
+    else if (match[4] !== undefined)
+      tokens.push({ type: "whitespace", value: match[4] });
+    else if (match[5] !== undefined)
+      tokens.push({ type: "punct", value: match[5] });
+    lastIndex = JSON_TOKEN_RE.lastIndex;
+    match = JSON_TOKEN_RE.exec(raw);
+  }
+  if (lastIndex < raw.length) {
+    tokens.push({ type: "punct", value: raw.slice(lastIndex) });
+  }
+  // A string that precedes ":" (skipping whitespace) is an object key.
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type !== "string") continue;
+    let j = i + 1;
+    while (j < tokens.length && tokens[j].type === "whitespace") j++;
+    if (
+      j < tokens.length &&
+      tokens[j].type === "punct" &&
+      tokens[j].value === ":"
+    ) {
+      tokens[i] = { type: "key", value: tokens[i].value };
+    }
+  }
+  return tokens;
+}
+
+const jsonTokens = computed(() => {
+  if (!content.value || content.value.kind !== "text") return [];
+  return tokenizeJson(prettyJson(content.value.content));
+});
 
 function markdownResult(text: string): ToolResultComplete<TextResponseData> {
   return {

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,107 @@
 @import "tailwindcss";
+
+/* Markdown content styles.
+   `@gui-chat-plugin/text-response` wraps rendered Markdown in a
+   `.markdown-content` container with `prose prose-slate` classes, but
+   Tailwind Typography isn't installed here so those classes don't do
+   anything. Provide a minimal baseline so headings, lists, code blocks
+   etc. look right in both chat responses and the Files-mode preview. */
+.markdown-content h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: #111827;
+}
+.markdown-content h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #1f2937;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 0.25rem;
+}
+.markdown-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  color: #374151;
+}
+.markdown-content h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+  color: #374151;
+}
+.markdown-content p {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+}
+.markdown-content ul,
+.markdown-content ol {
+  margin-left: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+.markdown-content ul {
+  list-style-type: disc;
+}
+.markdown-content ol {
+  list-style-type: decimal;
+}
+.markdown-content li {
+  margin-bottom: 0.25rem;
+  line-height: 1.5;
+}
+.markdown-content code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+.markdown-content pre {
+  background: #f3f4f6;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
+  margin-bottom: 0.75rem;
+}
+.markdown-content pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+}
+.markdown-content blockquote {
+  border-left: 3px solid #d1d5db;
+  padding-left: 1rem;
+  color: #6b7280;
+  margin: 0.75rem 0;
+}
+.markdown-content a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+.markdown-content hr {
+  border: none;
+  border-top: 1px solid #e5e7eb;
+  margin: 1rem 0;
+}
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 0.75rem;
+  font-size: 0.875rem;
+}
+.markdown-content th,
+.markdown-content td {
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+.markdown-content th {
+  background: #f9fafb;
+  font-weight: 600;
+}

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,83 @@
+// Minimal YAML-frontmatter extractor for Markdown files. Only covers
+// the shapes we actually display in the Files-mode preview:
+//
+//   ---
+//   title: さくらインターネット
+//   created: 2026-04-06
+//   tags: [クラウド, インフラ, 日本企業]
+//   ---
+//
+// Values are returned either as a string or, for inline arrays
+// (`[a, b, c]`), as a string[]. Anything more exotic (block lists,
+// nested maps, multi-line strings) is treated as an opaque string so
+// the user still sees the raw value.
+
+export type FrontmatterValue = string | string[];
+
+export interface FrontmatterField {
+  key: string;
+  value: FrontmatterValue;
+}
+
+export interface Frontmatter {
+  fields: FrontmatterField[];
+  body: string;
+}
+
+const FRONTMATTER_DELIM = /^---\r?\n/;
+const FRONTMATTER_CLOSE = /\r?\n---\s*(\r?\n|$)/;
+
+export function extractFrontmatter(raw: string): Frontmatter {
+  if (!FRONTMATTER_DELIM.test(raw)) {
+    return { fields: [], body: raw };
+  }
+  const afterOpen = raw.replace(FRONTMATTER_DELIM, "");
+  const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return { fields: [], body: raw };
+  }
+  const fmText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  return { fields: parseFields(fmText), body };
+}
+
+function parseFields(fmText: string): FrontmatterField[] {
+  const fields: FrontmatterField[] = [];
+  for (const line of fmText.split(/\r?\n/)) {
+    const field = parseLine(line);
+    if (field) fields.push(field);
+  }
+  return fields;
+}
+
+function parseLine(line: string): FrontmatterField | null {
+  if (!line.trim() || line.trimStart().startsWith("#")) return null;
+  const colonIdx = line.indexOf(":");
+  if (colonIdx <= 0) return null;
+  const key = line.slice(0, colonIdx).trim();
+  const rawValue = line.slice(colonIdx + 1).trim();
+  if (!key) return null;
+  return { key, value: parseValue(rawValue) };
+}
+
+function parseValue(raw: string): FrontmatterValue {
+  if (!raw) return "";
+  const arrayMatch = /^\[(.*)\]$/.exec(raw);
+  if (arrayMatch) {
+    return arrayMatch[1]
+      .split(",")
+      .map((s) => unquote(s.trim()))
+      .filter((s) => s.length > 0);
+  }
+  return unquote(raw);
+}
+
+function unquote(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/src/utils/jsonSyntax.ts
+++ b/src/utils/jsonSyntax.ts
@@ -95,3 +95,25 @@ export function prettyJson(raw: string): string {
     return raw;
   }
 }
+
+export interface JsonlLine {
+  tokens: JsonToken[];
+  parseError: boolean;
+}
+
+// Tokenize a JSON Lines document: one JSON value per non-empty line.
+// Each parseable line is pretty-printed before tokenization so the
+// output shows a readable multi-line record per entry. Malformed
+// lines are tokenized as-is with `parseError: true` so the caller
+// can mark them visually.
+export function tokenizeJsonl(raw: string): JsonlLine[] {
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return lines.map((line) => {
+    try {
+      const pretty = JSON.stringify(JSON.parse(line), null, 2);
+      return { tokens: tokenizeJson(pretty), parseError: false };
+    } catch {
+      return { tokens: tokenizeJson(line), parseError: true };
+    }
+  });
+}

--- a/src/utils/jsonSyntax.ts
+++ b/src/utils/jsonSyntax.ts
@@ -1,0 +1,97 @@
+// Tiny regex-based JSON tokenizer used by the Files-mode preview for
+// syntax coloring. Keeps itself dependency-free so it can be reused
+// and unit-tested without pulling in Vue or Tailwind.
+
+export type JsonTokenType =
+  | "key"
+  | "string"
+  | "number"
+  | "keyword"
+  | "punct"
+  | "whitespace";
+
+export interface JsonToken {
+  type: JsonTokenType;
+  value: string;
+}
+
+// Tailwind class for each token type. Kept alongside the tokenizer so
+// callers that want colored output can just import and use it directly.
+export const JSON_TOKEN_CLASS: Record<JsonTokenType, string> = {
+  key: "text-blue-700",
+  string: "text-green-700",
+  number: "text-orange-600",
+  keyword: "text-purple-700",
+  punct: "text-gray-500",
+  whitespace: "",
+};
+
+// Individually simple patterns combined by `nextToken` below. Keeping
+// them separate avoids a single combined regex that trips
+// sonarjs/regex-complexity and is easier to reason about.
+const STRING_RE = /^"(?:[^"\\]|\\.)*"/;
+const KEYWORD_RE = /^(?:true|false|null)\b/;
+const NUMBER_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const WS_RE = /^\s+/;
+const PUNCT_RE = /^[{}[\]:,]/;
+
+const MATCHERS: { type: JsonTokenType; re: RegExp }[] = [
+  { type: "string", re: STRING_RE },
+  { type: "keyword", re: KEYWORD_RE },
+  { type: "number", re: NUMBER_RE },
+  { type: "whitespace", re: WS_RE },
+  { type: "punct", re: PUNCT_RE },
+];
+
+function nextToken(slice: string): JsonToken | null {
+  for (const { type, re } of MATCHERS) {
+    const m = re.exec(slice);
+    if (m) return { type, value: m[0] };
+  }
+  return null;
+}
+
+export function tokenizeJson(raw: string): JsonToken[] {
+  const tokens: JsonToken[] = [];
+  let pos = 0;
+  while (pos < raw.length) {
+    const token = nextToken(raw.slice(pos));
+    if (!token) {
+      // Unknown char (syntax error / stray bytes). Emit verbatim so
+      // the user still sees it, then advance one character.
+      tokens.push({ type: "punct", value: raw[pos] });
+      pos++;
+      continue;
+    }
+    tokens.push(token);
+    pos += token.value.length;
+  }
+  markKeys(tokens);
+  return tokens;
+}
+
+// A string that precedes ":" (skipping whitespace) is an object key.
+function markKeys(tokens: JsonToken[]): void {
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type !== "string") continue;
+    let j = i + 1;
+    while (j < tokens.length && tokens[j].type === "whitespace") j++;
+    if (
+      j < tokens.length &&
+      tokens[j].type === "punct" &&
+      tokens[j].value === ":"
+    ) {
+      tokens[i] = { type: "key", value: tokens[i].value };
+    }
+  }
+}
+
+// Pretty-print JSON with 2-space indentation, falling back to the raw
+// source on parse error so the user can still read malformed files.
+export function prettyJson(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}


### PR DESCRIPTION
## User Prompt

> file エクスプローラー、json, md, htmlを開いたときは見やすい形式で。
> json 色つけたりできる？
> mdはheader部分は正しく成型できるとよいなぁ

## Summary

Two readability improvements for Files mode previews:

### Markdown headers

\`@gui-chat-plugin/text-response\` wraps rendered Markdown in a
\`.markdown-content prose prose-slate\` container, but \`@tailwindcss/typography\`
isn't installed in this project so the \`prose\` classes are inactive. That's
why \`h1\`/\`h2\`/\`h3\` all looked flat.

Fix: add baseline \`.markdown-content\` styles in \`src/index.css\` mirroring the
wiki plugin's approach. Covers headings, lists, code blocks, tables,
blockquotes, links, hr. Fixes Markdown rendering everywhere the class is used
(chat responses + Files-mode preview).

### JSON syntax coloring

Added a small regex-based tokenizer in \`FilesView.vue\` that splits
pretty-printed JSON into \`key / string / number / keyword / punct / whitespace\`
tokens, rendered via \`v-for\` with Tailwind color classes. No new dependencies,
no \`v-html\`.

Colors (Tailwind):
- key → \`text-blue-700\`
- string → \`text-green-700\`
- number → \`text-orange-600\`
- keyword (\`true\` / \`false\` / \`null\`) → \`text-purple-700\`
- punct → \`text-gray-500\`

Malformed JSON still falls through to raw text via the existing \`prettyJson\`
try/catch.

## Note on branching

The immediate parent of this branch (commit \`d777f85\`) was accidentally pushed
directly to \`main\` in the previous session. Per the user's explicit choice, it
was left in place rather than reverted. This PR is now on a proper feature
branch as it should have been.

## Test plan

- [ ] Open a Markdown file with \`#\`, \`##\`, \`###\` headers in Files mode → headers render with distinct sizes
- [ ] Open a JSON file (e.g. \`todos/todos.json\`) → keys, strings, numbers, booleans colored
- [ ] Malformed JSON → still shown as raw text (not broken)
- [ ] Chat response with Markdown headers → also benefits from the global CSS fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON syntax highlighting with color-coded tokens for improved readability when viewing JSON files.

* **Improvements**
  * Enhanced markdown content styling with improved typography for headings, paragraphs, lists, code blocks, blockquotes, links, horizontal rules, and tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->