### PR TITLE
feat: natural height for document-like plugins in stack view

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -43,8 +43,28 @@
       >
         {{ messageText(result) }}
       </div>
-      <!-- Other plugins: use the viewComponent with a fixed height so
-           plugins that rely on h-full render properly -->
+      <!-- Document-like plugins: let the content flow at its natural
+           height by overriding the plugin's internal h-full / overflow
+           / flex-1 via the .stack-natural scoped styles below. For
+           plugins that embed iframes (e.g. presentHtml) we also size
+           each iframe to its content after load. -->
+      <div
+        v-else-if="isStackNatural(result.toolName)"
+        :ref="
+          (el) => setNaturalWrapperRef(result.uuid, el as HTMLElement | null)
+        "
+        class="stack-natural"
+      >
+        <component
+          :is="getPlugin(result.toolName)?.viewComponent"
+          v-if="getPlugin(result.toolName)?.viewComponent"
+          :selected-result="result"
+          :send-text-message="sendTextMessage"
+          @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
+        />
+      </div>
+      <!-- Other plugins: fixed height wrapper so plugins that rely on
+           h-full continue to render properly. -->
       <div v-else :style="{ height: PLUGIN_HEIGHT }">
         <component
           :is="getPlugin(result.toolName)?.viewComponent"
@@ -64,15 +84,26 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick } from "vue";
+import { ref, watch, nextTick, onUnmounted } from "vue";
 import { getPlugin } from "../tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 // Most plugin viewComponents use h-full internally, so a defined parent
-// height is required for them to render. text-response is special-cased
-// above because it has no such requirement and short messages would
-// otherwise leave large empty space.
+// height is required for them to render. text-response and the
+// "stack-natural" plugins below are special-cased.
 const PLUGIN_HEIGHT = "min(60vh, 560px)";
+
+// Plugins that look better flowing at natural height in stack view
+// rather than being clipped to PLUGIN_HEIGHT with an inner scrollbar.
+const STACK_NATURAL_TOOLS = new Set<string>([
+  "presentHtml",
+  "presentDocument",
+  "presentSpreadsheet",
+]);
+
+function isStackNatural(toolName: string): boolean {
+  return STACK_NATURAL_TOOLS.has(toolName);
+}
 
 const props = defineProps<{
   toolResults: ToolResultComplete[];
@@ -87,10 +118,56 @@ const emit = defineEmits<{
 
 const containerRef = ref<HTMLDivElement | null>(null);
 const itemRefs = new Map<string, HTMLElement>();
+const naturalWrapperRefs = new Map<string, HTMLElement>();
 
 function setItemRef(uuid: string, el: HTMLElement | null): void {
   if (el) itemRefs.set(uuid, el);
   else itemRefs.delete(uuid);
+}
+
+function setNaturalWrapperRef(uuid: string, el: HTMLElement | null): void {
+  if (el) {
+    naturalWrapperRefs.set(uuid, el);
+    nextTick(() => sizeIframesIn(el));
+  } else {
+    naturalWrapperRefs.delete(uuid);
+  }
+}
+
+// Sandboxed iframes inside stack-natural plugins (e.g. presentHtml)
+// have no intrinsic content height, so CSS alone collapses them. Set
+// each iframe's height to match its document's scrollHeight on load.
+function sizeIframesIn(wrapper: HTMLElement): void {
+  const iframes = wrapper.querySelectorAll<HTMLIFrameElement>("iframe");
+  for (const iframe of iframes) {
+    if (iframe.dataset.stackSized === "true") continue;
+    iframe.dataset.stackSized = "true";
+    const resize = () => resizeOneIframe(iframe);
+    iframe.addEventListener("load", resize);
+    // If the iframe already finished loading before we attached the
+    // listener, size it now as well.
+    try {
+      if (iframe.contentDocument?.readyState === "complete") {
+        resize();
+      }
+    } catch {
+      // cross-origin — leave default height
+    }
+  }
+}
+
+function resizeOneIframe(iframe: HTMLIFrameElement): void {
+  try {
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    const height = Math.max(
+      doc.documentElement?.scrollHeight ?? 0,
+      doc.body?.scrollHeight ?? 0,
+    );
+    if (height > 0) iframe.style.height = `${height}px`;
+  } catch {
+    // cross-origin sandbox — can't measure, leave default
+  }
 }
 
 function isTextResponse(result: ToolResultComplete): boolean {
@@ -136,7 +213,36 @@ watch(
       if (containerRef.value) {
         containerRef.value.scrollTop = containerRef.value.scrollHeight;
       }
+      // New items may have brought in more iframes to size.
+      for (const wrapper of naturalWrapperRefs.values()) {
+        sizeIframesIn(wrapper);
+      }
     });
   },
 );
+
+onUnmounted(() => {
+  naturalWrapperRefs.clear();
+});
 </script>
+
+<style scoped>
+/* Force document-like plugin viewComponents (presentHtml,
+   presentDocument, presentSpreadsheet) to flow at their natural
+   height inside stack view instead of clipping to the wrapper with
+   an inner scrollbar. */
+.stack-natural :deep(.h-full),
+.stack-natural :deep(.min-h-full) {
+  height: auto !important;
+  min-height: 0 !important;
+}
+.stack-natural :deep(.overflow-hidden),
+.stack-natural :deep(.overflow-auto),
+.stack-natural :deep(.overflow-y-auto),
+.stack-natural :deep(.overflow-x-auto) {
+  overflow: visible !important;
+}
+.stack-natural :deep(.flex-1) {
+  flex: 0 0 auto !important;
+}
+</style>


### PR DESCRIPTION
## User Prompt

> stackのpresentDocument / presentHTMLなど、inner的なのの高さを直して。
> spretsheetも

## Problem

Stack view wrapped every plugin in a fixed \`min(60vh, 560px)\` container.
Document-like plugins (\`presentHtml\` / \`presentDocument\` /
\`presentSpreadsheet\`) use \`h-full flex flex-col overflow-hidden\` internally,
so they ended up clipped to the wrapper with their own inner scrollbar
instead of flowing into the outer canvas scroll.

## Fix

Mark these three plugins as \"stack-natural\" and render them inside a
container whose scoped CSS forces descendant \`.h-full\` / \`.overflow-*\` /
\`.flex-1\` to \`height: auto\` / \`overflow: visible\` / \`flex: 0 0 auto\` via
\`!important\`. The plugin content then flows at its natural height and the
outer stack scroll handles everything.

For \`presentHtml\` the CSS override alone isn't enough — the sandboxed
iframe has no intrinsic content height. After the iframe loads, a small
helper reads \`contentDocument.scrollHeight\` and sets the iframe's
\`style.height\`, so the full rendered HTML becomes part of the canvas
scroll. \`data-stack-sized\` prevents double-attaching, and a watch on
\`toolResults.length\` re-scans natural wrappers when fresh results arrive.

Other plugins (\`todo\`, \`scheduler\`, \`generateImage\`, \`form\`, \`othello\`,
etc.) still use the existing fixed-height wrapper because they rely on
\`h-full\` internally to lay out their interactive UI.

## Files changed

- \`src/components/StackView.vue\` — only

## Test plan

- [ ] Switch to stack view with a \`presentHtml\` result → full HTML flows, no inner scrollbar, outer canvas scrolls
- [ ] Switch to stack view with a \`presentDocument\` (markdown) result → content flows at natural height
- [ ] Switch to stack view with a \`presentSpreadsheet\` result → table flows at natural height
- [ ] Other plugins (todo, image, form, etc.) are unaffected — still use the fixed-height wrapper
- [ ] Sidebar click still scrolls the selected card into view in stack mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Document-like tools now render at natural height instead of fixed constraints, providing improved content visibility and layout flexibility
  * Enhanced iframe rendering with automatic height adjustment based on actual content size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->