### PR TITLE
feat: stack view scroll-spy syncs sidebar selection

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -202,18 +202,19 @@ function iconFor(toolName: string): string {
 // a `select` for whichever card currently occupies the top, so the
 // sidebar selection always tracks what's on screen.
 //
-// Two flags coordinate the feedback loop:
+// Coordination between scroll and selection:
 //   - `suppressScrollSync` is set while the component programmatically
 //     scrolls (sidebar click → scrollIntoView, auto-scroll on new
 //     result) so the spy doesn't fire on its own scroll.
-//   - `selectionFromScrollSpy` is set right before the spy emits a
-//     `select`, so the watch on `selectedResultUuid` knows the change
-//     came from the user scrolling and skips the scrollIntoView (which
-//     would otherwise jerk the view to the start of the next card).
+//   - `scrollSpyEmittedUuid` holds the exact uuid the spy most
+//     recently emitted. The watch on `selectedResultUuid` only skips
+//     its scrollIntoView when the incoming uuid matches, so a
+//     sidebar click that arrives right after a spy emit still gets
+//     its normal scroll behaviour.
 let suppressScrollSync = false;
 let suppressScrollTimeout: ReturnType<typeof setTimeout> | null = null;
 let scrollSpyRafId: number | null = null;
-let selectionFromScrollSpy = false;
+let scrollSpyEmittedUuid: string | null = null;
 
 function beginSuppressScrollSync(): void {
   suppressScrollSync = true;
@@ -224,17 +225,27 @@ function beginSuppressScrollSync(): void {
   }, SCROLL_SPY_SUPPRESS_MS);
 }
 
+function readPaddingTop(el: HTMLElement): number {
+  const value = parseFloat(getComputedStyle(el).paddingTop);
+  return Number.isFinite(value) ? value : 0;
+}
+
 // Walk items in order and return the last one whose top edge is at or
-// above the container's visible top. Iterating in DOM order lets us
-// break early once an item is below the line.
+// above the padded content top of the container. Accounting for the
+// container's padding-top means the handoff happens at the visual
+// start of the cards rather than the invisible border of the
+// container itself. Iterating in DOM order lets us break early once
+// an item is below the line.
 function computeActiveUuidFromScroll(): string | null {
   if (!containerRef.value) return null;
-  const containerTop = containerRef.value.getBoundingClientRect().top;
+  const container = containerRef.value;
+  const paddedTop =
+    container.getBoundingClientRect().top + readPaddingTop(container);
   let activeUuid: string | null = null;
   for (const result of props.toolResults) {
     const el = itemRefs.get(result.uuid);
     if (!el) continue;
-    if (el.getBoundingClientRect().top <= containerTop) {
+    if (el.getBoundingClientRect().top <= paddedTop) {
       activeUuid = result.uuid;
     } else {
       break;
@@ -251,24 +262,26 @@ function onContainerScroll(): void {
     if (suppressScrollSync) return;
     const activeUuid = computeActiveUuidFromScroll();
     if (activeUuid && activeUuid !== props.selectedResultUuid) {
-      selectionFromScrollSpy = true;
+      scrollSpyEmittedUuid = activeUuid;
       emit("select", activeUuid);
     }
   });
 }
 
 // Scroll the selected card to the top whenever the external selection
-// changes (sidebar click, initial load). Skip the scroll when the
-// change was initiated by the spy itself — the viewport is already in
-// the right place, and scrolling again would jerk to the next card.
+// changes (sidebar click, initial load). Skip the scroll only when the
+// incoming uuid matches the one we just emitted from the spy — that
+// means the viewport is already in the right place. Any other change
+// (sidebar click, new result) still gets its normal scrollIntoView.
 watch(
   () => props.selectedResultUuid,
   (uuid) => {
     if (!uuid) return;
-    if (selectionFromScrollSpy) {
-      selectionFromScrollSpy = false;
+    if (scrollSpyEmittedUuid === uuid) {
+      scrollSpyEmittedUuid = null;
       return;
     }
+    scrollSpyEmittedUuid = null;
     nextTick(() => {
       const el = itemRefs.get(uuid);
       if (!el) return;

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -84,7 +84,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick, onUnmounted } from "vue";
+import { ref, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { getPlugin } from "../tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
@@ -92,6 +92,11 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 // height is required for them to render. text-response and the
 // "stack-natural" plugins below are special-cased.
 const PLUGIN_HEIGHT = "min(60vh, 560px)";
+
+// How long to ignore scroll-spy after a programmatic scroll (sidebar
+// click, auto-scroll on new result). Keeps the spy from emitting a
+// stale uuid while the scroll is still settling.
+const SCROLL_SPY_SUPPRESS_MS = 150;
 
 // Plugins that look better flowing at natural height in stack view
 // rather than being clipped to PLUGIN_HEIGHT with an inner scrollbar.
@@ -193,15 +198,82 @@ function iconFor(toolName: string): string {
   return "extension";
 }
 
+// Scroll-spy state: as the user scrolls the stack container we emit
+// a `select` for whichever card currently occupies the top, so the
+// sidebar selection always tracks what's on screen.
+//
+// Two flags coordinate the feedback loop:
+//   - `suppressScrollSync` is set while the component programmatically
+//     scrolls (sidebar click → scrollIntoView, auto-scroll on new
+//     result) so the spy doesn't fire on its own scroll.
+//   - `selectionFromScrollSpy` is set right before the spy emits a
+//     `select`, so the watch on `selectedResultUuid` knows the change
+//     came from the user scrolling and skips the scrollIntoView (which
+//     would otherwise jerk the view to the start of the next card).
+let suppressScrollSync = false;
+let suppressScrollTimeout: ReturnType<typeof setTimeout> | null = null;
+let scrollSpyRafId: number | null = null;
+let selectionFromScrollSpy = false;
+
+function beginSuppressScrollSync(): void {
+  suppressScrollSync = true;
+  if (suppressScrollTimeout !== null) clearTimeout(suppressScrollTimeout);
+  suppressScrollTimeout = setTimeout(() => {
+    suppressScrollSync = false;
+    suppressScrollTimeout = null;
+  }, SCROLL_SPY_SUPPRESS_MS);
+}
+
+// Walk items in order and return the last one whose top edge is at or
+// above the container's visible top. Iterating in DOM order lets us
+// break early once an item is below the line.
+function computeActiveUuidFromScroll(): string | null {
+  if (!containerRef.value) return null;
+  const containerTop = containerRef.value.getBoundingClientRect().top;
+  let activeUuid: string | null = null;
+  for (const result of props.toolResults) {
+    const el = itemRefs.get(result.uuid);
+    if (!el) continue;
+    if (el.getBoundingClientRect().top <= containerTop) {
+      activeUuid = result.uuid;
+    } else {
+      break;
+    }
+  }
+  return activeUuid;
+}
+
+function onContainerScroll(): void {
+  if (suppressScrollSync) return;
+  if (scrollSpyRafId !== null) return;
+  scrollSpyRafId = requestAnimationFrame(() => {
+    scrollSpyRafId = null;
+    if (suppressScrollSync) return;
+    const activeUuid = computeActiveUuidFromScroll();
+    if (activeUuid && activeUuid !== props.selectedResultUuid) {
+      selectionFromScrollSpy = true;
+      emit("select", activeUuid);
+    }
+  });
+}
+
+// Scroll the selected card to the top whenever the external selection
+// changes (sidebar click, initial load). Skip the scroll when the
+// change was initiated by the spy itself — the viewport is already in
+// the right place, and scrolling again would jerk to the next card.
 watch(
   () => props.selectedResultUuid,
   (uuid) => {
     if (!uuid) return;
+    if (selectionFromScrollSpy) {
+      selectionFromScrollSpy = false;
+      return;
+    }
     nextTick(() => {
       const el = itemRefs.get(uuid);
-      if (el) {
-        el.scrollIntoView({ block: "nearest", behavior: "smooth" });
-      }
+      if (!el) return;
+      beginSuppressScrollSync();
+      el.scrollIntoView({ block: "start", behavior: "auto" });
     });
   },
 );
@@ -211,6 +283,7 @@ watch(
   () => {
     nextTick(() => {
       if (containerRef.value) {
+        beginSuppressScrollSync();
         containerRef.value.scrollTop = containerRef.value.scrollHeight;
       }
       // New items may have brought in more iframes to size.
@@ -221,7 +294,25 @@ watch(
   },
 );
 
+onMounted(() => {
+  containerRef.value?.addEventListener("scroll", onContainerScroll, {
+    passive: true,
+  });
+  // Align the initial scroll position with the externally selected
+  // item so the sidebar and stack start in sync on mount.
+  nextTick(() => {
+    if (!props.selectedResultUuid) return;
+    const el = itemRefs.get(props.selectedResultUuid);
+    if (!el) return;
+    beginSuppressScrollSync();
+    el.scrollIntoView({ block: "start", behavior: "auto" });
+  });
+});
+
 onUnmounted(() => {
+  containerRef.value?.removeEventListener("scroll", onContainerScroll);
+  if (scrollSpyRafId !== null) cancelAnimationFrame(scrollSpyRafId);
+  if (suppressScrollTimeout !== null) clearTimeout(suppressScrollTimeout);
   naturalWrapperRefs.clear();
 });
 </script>


### PR DESCRIPTION
## User Prompt

> canvasをスクロールするときに左のsideバーを同期するの。前の実装少しダメだった。スクロールしても選択が変わらないケースがあった。きちんと上部の位置を判断して判定し、常時同期させてね
>
> canvasスクロール中に次と判定さて、次にジャンプする。オフセット的なのはいらないかな。スクロール中も処理は不要？

## Summary

In stack view the sidebar selection now follows whatever card is
currently at the top of the canvas as the user scrolls. The two panes
stay in sync in real time instead of drifting apart.

## Algorithm

On each scroll event (throttled via \`requestAnimationFrame\`), walk
\`toolResults\` in DOM order and pick the last card whose
\`getBoundingClientRect().top\` is at or above the container's visible
top. No offset — selection switches the instant a card's top edge
crosses the top of the viewport. Iterating in DOM order lets the loop
break early once an item is below the line.

## Feedback-loop handling

Two flags coordinate scroll ↔ selection updates:

- **\`suppressScrollSync\`** — set while the component programmatically
  scrolls (sidebar click → \`scrollIntoView\`, auto-scroll on new result)
  so the spy doesn't fire on its own scroll.
- **\`selectionFromScrollSpy\`** — set right before the spy emits
  \`select\`, telling the watch on \`selectedResultUuid\` to skip the
  \`scrollIntoView\` it would normally trigger. Without this the view
  jerked to the start of the newly-active card every time the spy
  fired, making ordinary scrolling unusable (this was the regression
  in the first attempt).

## Other changes

- \`scrollIntoView\` for external selection changes is now
  \`{ block: \"start\", behavior: \"auto\" }\` so the scroll lands in one
  frame. \"smooth\" produced multiple intermediate positions that the
  spy picked up mid-animation.
- \`onMounted\` aligns the initial scroll position with the incoming
  \`selectedResultUuid\` so the two panes start in sync on first render.

## Files changed

- \`src/components/StackView.vue\` — only

## Test plan

- [ ] Scroll the stack down slowly — sidebar selection follows card-by-card with no jump-back
- [ ] Scroll back up — selection updates just as smoothly
- [ ] Click a card in the sidebar — stack scrolls to it with no feedback loop
- [ ] New result arrives → auto-scroll to bottom, sidebar shows the new item selected
- [ ] Switch away from stack view and back — initial state is in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stack view now detects which card is at the top of the scroll viewport and emits selection events as you scroll.
  * Initial selection is auto-aligned on mount.

* **Bug Fixes**
  * Prevented feedback loops between programmatic scrolling and scroll-driven selection so manual and automatic scrolls no longer conflict.
  * Improved cleanup to avoid leftover scroll listeners or pending scroll actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->