### PR TITLE
Run Sandbox as non root user

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,3 +1,4 @@
 FROM node:22-slim
 RUN npm install -g @anthropic-ai/claude-code tsx
-WORKDIR /workspace
+USER node
+WORKDIR /home/node/mulmoclaude

--- a/plan/non_root.md
+++ b/plan/non_root.md
@@ -1,0 +1,147 @@
+# Non-Root Sandbox User
+
+## Current State
+
+`Dockerfile.sandbox` has no `USER` directive. `node:22-slim` defaults to root, so `claude` runs as UID 0 inside the container.
+
+The root dependency is structural: `server/agent.ts` mounts `~/.claude` to `/root/.claude`. If the container user were non-root, that path would not exist and Claude Code would fail to authenticate.
+
+```
+-v ~/.claude:/root/.claude     ← only works for UID 0
+```
+
+**Workspace path inconsistency**: The workspace is hardcoded to `~/mulmoclaude` (`server/workspace.ts`), but inside the container it is mounted as `/workspace`. Claude therefore sees a different path depending on whether the sandbox is active or not — the system prompt reflects this (`server/agent/prompt.ts:107`). This creates inconsistency in tool calls, file references, and session continuity across sandboxed and non-sandboxed runs.
+
+---
+
+## Security Review
+
+### Running as Root — Risks
+
+**Container escape amplification**
+Docker's isolation is strong but not perfect (kernel exploits, misconfigured mounts, runc CVEs). If Claude escapes the container while running as root, it lands on the host as root — full machine compromise. A non-root escape would be contained to the user's own files.
+
+**Writable mounts owned by root**
+`/workspace` is read-write and bind-mounted from the host. Files created by Claude inside the container are owned by root on the host. The user must `sudo chown` to recover ownership of their own workspace files.
+
+**Principle of least privilege violated**
+Claude only needs to read/write `/workspace` and read `/app`. It has no legitimate need for root capabilities (raw sockets, `CAP_NET_ADMIN`, `CAP_SYS_ADMIN`, etc.), yet it holds all of them.
+
+**No `--cap-drop` or `--security-opt`**
+The current `docker run` invocation does not drop Linux capabilities or enable seccomp/AppArmor profiles. Combined with root, this is a maximally permissive container environment.
+
+### Running as Root — Mitigating Factors
+
+- All app-code mounts (`node_modules`, `server/`, `src/`) are `:ro`, limiting write surface.
+- `--rm` ensures no persistent container state.
+- Docker's namespacing still isolates the filesystem from the host (absent an escape).
+- Claude Code's own `--allowedTools` flag limits what commands Claude can issue.
+
+### Non-Root — Security Gains
+
+- Container escape yields only user-level access on the host (same as the user who started the server).
+- Workspace files created inside the container would be owned by the mapped UID, not root.
+- Linux capabilities can be dropped to near-zero (`--cap-drop ALL`) without breaking functionality.
+- Aligns with CIS Docker Benchmark recommendation 4.1 ("Ensure a non-root user is used").
+
+---
+
+## User Experience Review
+
+### Current UX (Root)
+
+**Con: Workspace path inconsistency**
+Inside the sandbox, Claude sees the workspace as `/workspace`. Outside, it is `~/mulmoclaude`. This means file paths in tool calls, memory, and session context differ depending on whether Docker is running — undermining the goal of a consistent workspace experience.
+
+**Con: Workspace file ownership corruption (Linux only)**
+On Linux, files Claude creates in `/workspace` appear on the host as owned by root. The user must `sudo chown` to recover ownership. This is a real day-to-day friction point on Linux.
+
+**macOS exception**: Docker Desktop uses virtiofs for bind mounts, which transparently maps the container's root UID to the macOS user who owns the mount. Files written by root inside the container appear owned by the host user in Finder and the terminal. File ownership corruption is **not a practical issue on macOS**.
+
+**Pro: Zero setup**
+Works out of the box. No UID mapping required. The `~/.claude` mount just works.
+
+**Pro: No permission errors inside the container**
+Root can read/write anything it encounters, so Claude never hits unexpected permission denied errors on app files.
+
+### Non-Root UX (Proposed)
+
+**Pro: Consistent workspace path**
+Mount the workspace at its real host path instead of `/workspace`:
+```ts
+`${toDockerPath(workspacePath)}:${toDockerPath(workspacePath)}`
+```
+Claude always sees `~/mulmoclaude` regardless of sandbox state. File references, memory, and session context are portable between sandboxed and non-sandboxed runs.
+
+**Pro: Correct file ownership on Linux**
+Files Claude creates belong to the host user (with UID mapping). Normal editing workflow is preserved on Linux.
+
+**Pro: Cleaner security posture**
+Users who care about security can trust the sandbox is properly locked down.
+
+**Con: File ownership gain is moot on macOS**
+Since Docker Desktop + virtiofs already maps root writes to the host user, switching to non-root provides no ownership improvement on macOS — the main UX motivation disappears.
+
+**Con: UID mismatch problem (Linux)**
+The `node` user inside `node:22-slim` is UID 1000. If the host user is a different UID, files in `/workspace` will be owned by 1000 on the host. Requires `--user $(id -u):$(id -g)` at runtime to fix.
+
+**Con: `.claude` mount path changes**
+Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root home is), and ensure the mount is readable by that user.
+
+**Con: Possible permission errors on `:ro` mounts**
+`/app/node_modules` and `/app/server` are mounted read-only but owned by the host user. A non-root container user can still read them as long as the files have world-readable permissions (`644`/`755`), which is typical for npm packages. Unlikely to be an issue in practice.
+
+---
+
+## Pros and Cons Summary
+
+| Dimension | Root (current) | Non-root |
+|---|---|---|
+| Container escape impact | Full host root compromise | Host user-level access only |
+| Linux capabilities | All (unrestricted) | Can drop to near-zero |
+| Workspace file ownership | Owned by root on host (Linux); host user on macOS via virtiofs | Owned by host user with UID mapping (Linux); no change on macOS |
+| Workspace path | `/workspace` in container, `~/mulmoclaude` on host — inconsistent | `~/mulmoclaude` everywhere — consistent |
+| `.claude` mount | `/root/.claude` — works trivially | `/home/node/.claude` — requires Dockerfile change |
+| UID mismatch on macOS | Not applicable | Partially mitigated by Docker Desktop's virtiofs |
+| Setup complexity | None | Requires `--user $(id -u):$(id -g)` at runtime |
+| CIS Docker Benchmark | Fails 4.1 | Passes 4.1 |
+
+---
+
+## Recommended Implementation
+
+1. **`Dockerfile.sandbox`** — add `USER node` (UID 1000, already exists in `node:22-slim`). Ensure `/workspace` dir is pre-created with correct ownership:
+   ```dockerfile
+   FROM node:22-slim
+   RUN npm install -g @anthropic-ai/claude-code tsx
+   RUN mkdir -p /workspace && chown node:node /workspace
+   USER node
+   WORKDIR /workspace
+   ```
+
+2. **`server/agent.ts`** — three changes:
+   - Mount the workspace at its real path instead of `/workspace`:
+     ```ts
+     `${toDockerPath(workspacePath)}:${toDockerPath(workspacePath)}`,
+     ```
+   - Update the MCP config arg path (currently hardcoded to `/workspace/...`) to use the real path:
+     ```ts
+     mcpConfigArgPath = join(mcpConfigDir, `mcp-${sessionId}.json`); // same as host path
+     ```
+   - Change the `.claude` mount target and add `--user` flag:
+     ```ts
+     `${toDockerPath(homedir())}/.claude:/home/node/.claude:ro`,
+     "--user", `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
+     ```
+   Note: `process.getuid()` is not available on Windows; guard accordingly.
+
+3. **`server/docker.ts`** — add `--cap-drop ALL` to further harden (optional but recommended):
+   ```ts
+   "--cap-drop", "ALL",
+   ```
+
+4. **Rebuild the sandbox image** — since `Dockerfile.sandbox` changes, `ensureSandboxImage()` will not detect the stale image automatically. Users need to `docker rmi mulmoclaude-sandbox` to force a rebuild, or the build step should check image labels/digests.
+
+### macOS Note
+
+Docker Desktop's virtiofs already maps root writes in the container to the host user on macOS — confirmed by inspection of sandbox-created files. The primary UX motivation for this change (file ownership) only applies to Linux users. The security motivation (limiting container escape impact) applies on both platforms.

--- a/plan/non_root.md
+++ b/plan/non_root.md
@@ -118,7 +118,7 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
    WORKDIR /home/node/mulmoclaude
    ```
 
-2. **`server/agent.ts`** — three changes:
+2. **`server/agent.ts`** — four changes:
    - Mount the workspace at `/home/node/mulmoclaude` instead of `/workspace`:
      ```ts
      `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
@@ -132,9 +132,15 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
      `${toDockerPath(homedir())}/.claude:/home/node/.claude:ro`,
      "--user", `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
      ```
+   - Set `HOME` explicitly so `claude` can find its credentials regardless of effective UID:
+     ```ts
+     "-e", "HOME=/home/node",
+     ```
+     **Why this is required**: `--user UID:GID` passes the host UID (e.g. 501 on macOS), which has no entry in the container's `/etc/passwd`. Without a passwd entry the shell never sets `HOME`, so `claude` cannot locate `~/.claude` and hangs waiting for auth (with stdin closed, it never completes).
+
    Note: `process.getuid()` is not available on Windows; guard accordingly.
 
-3. **`server/docker.ts`** — add `--cap-drop ALL` to further harden (optional but recommended):
+3. **`server/agent.ts`** — add `--cap-drop ALL` to further harden:
    ```ts
    "--cap-drop", "ALL",
    ```
@@ -149,7 +155,7 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
 | `/home/node/mulmoclaude` | `workspacePath` | rw |
 | `/home/node/.claude` | `~/.claude` | ro |
 
-4. **Rebuild the sandbox image** — since `Dockerfile.sandbox` changes, `ensureSandboxImage()` will not detect the stale image automatically. Users need to `docker rmi mulmoclaude-sandbox` to force a rebuild, or the build step should check image labels/digests.
+4. **Automatic image rebuild** — `ensureSandboxImage()` in `server/docker.ts` detects stale images automatically. At build time it embeds a SHA-256 hash of `Dockerfile.sandbox` as an image label (`mulmoclaude.dockerfile.sha256`). On every server start it compares the label against the current file hash and rebuilds if they differ, streaming `docker build` output to the server console in real time. Users never need to run `docker rmi` manually.
 
 ### macOS Note
 

--- a/plan/non_root.md
+++ b/plan/non_root.md
@@ -67,9 +67,9 @@ Root can read/write anything it encounters, so Claude never hits unexpected perm
 ### Non-Root UX (Proposed)
 
 **Pro: Consistent workspace path**
-Mount the workspace at its real host path instead of `/workspace`:
+Mount the workspace at `/home/node/mulmoclaude` (i.e. `~/mulmoclaude` for the `node` user):
 ```ts
-`${toDockerPath(workspacePath)}:${toDockerPath(workspacePath)}`
+`${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
 ```
 Claude always sees `~/mulmoclaude` regardless of sandbox state. File references, memory, and session context are portable between sandboxed and non-sandboxed runs.
 
@@ -100,7 +100,7 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
 | Container escape impact | Full host root compromise | Host user-level access only |
 | Linux capabilities | All (unrestricted) | Can drop to near-zero |
 | Workspace file ownership | Owned by root on host (Linux); host user on macOS via virtiofs | Owned by host user with UID mapping (Linux); no change on macOS |
-| Workspace path | `/workspace` in container, `~/mulmoclaude` on host — inconsistent | `~/mulmoclaude` everywhere — consistent |
+| Workspace path | `/workspace` in container, `~/mulmoclaude` on host — inconsistent | `/home/node/mulmoclaude` = `~/mulmoclaude` in container — consistent |
 | `.claude` mount | `/root/.claude` — works trivially | `/home/node/.claude` — requires Dockerfile change |
 | UID mismatch on macOS | Not applicable | Partially mitigated by Docker Desktop's virtiofs |
 | Setup complexity | None | Requires `--user $(id -u):$(id -g)` at runtime |
@@ -110,23 +110,22 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
 
 ## Recommended Implementation
 
-1. **`Dockerfile.sandbox`** — add `USER node` (UID 1000, already exists in `node:22-slim`). Ensure `/workspace` dir is pre-created with correct ownership:
+1. **`Dockerfile.sandbox`** — add `USER node` and set `WORKDIR` to `~/mulmoclaude` for the `node` user. Dockerfiles do not expand `~`, so use the explicit path:
    ```dockerfile
    FROM node:22-slim
    RUN npm install -g @anthropic-ai/claude-code tsx
-   RUN mkdir -p /workspace && chown node:node /workspace
    USER node
-   WORKDIR /workspace
+   WORKDIR /home/node/mulmoclaude
    ```
 
 2. **`server/agent.ts`** — three changes:
-   - Mount the workspace at its real path instead of `/workspace`:
+   - Mount the workspace at `/home/node/mulmoclaude` instead of `/workspace`:
      ```ts
-     `${toDockerPath(workspacePath)}:${toDockerPath(workspacePath)}`,
+     `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
      ```
-   - Update the MCP config arg path (currently hardcoded to `/workspace/...`) to use the real path:
+   - Update the MCP config arg path (currently hardcoded to `/workspace/...`):
      ```ts
-     mcpConfigArgPath = join(mcpConfigDir, `mcp-${sessionId}.json`); // same as host path
+     mcpConfigArgPath = `/home/node/mulmoclaude/.mulmoclaude/mcp-${sessionId}.json`;
      ```
    - Change the `.claude` mount target and add `--user` flag:
      ```ts
@@ -139,6 +138,16 @@ Must change `/root/.claude` → `/home/node/.claude` (or wherever the non-root h
    ```ts
    "--cap-drop", "ALL",
    ```
+
+### Container Mount Layout
+
+| Container path | Source | Access |
+|---|---|---|
+| `/app/node_modules` | `projectRoot/node_modules` | ro |
+| `/app/server` | `projectRoot/server` | ro |
+| `/app/src` | `projectRoot/src` | ro |
+| `/home/node/mulmoclaude` | `workspacePath` | rw |
+| `/home/node/.claude` | `~/.claude` | ro |
 
 4. **Rebuild the sandbox image** — since `Dockerfile.sandbox` changes, `ensureSandboxImage()` will not detect the stale image automatically. Users need to `docker rmi mulmoclaude-sandbox` to force a rebuild, or the build step should check image labels/digests.
 

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -26,15 +26,16 @@ export async function* runAgent(
   claudeSessionId?: string,
   pluginPrompts?: Record<string, string>,
 ): AsyncGenerator<AgentEvent> {
-  const systemPrompt = buildSystemPrompt({
-    role,
-    workspacePath,
-    pluginPrompts,
-  });
-
   const activePlugins = getActivePlugins(role);
   const hasMcp = activePlugins.length > 0;
   const useDocker = await isDockerAvailable();
+
+  const containerWorkspacePath = "/home/node/mulmoclaude";
+  const systemPrompt = buildSystemPrompt({
+    role,
+    workspacePath: useDocker ? containerWorkspacePath : workspacePath,
+    pluginPrompts,
+  });
 
   // Compute MCP config paths — host path for writing/cleanup,
   // arg path for what gets passed to the claude CLI (container path if docker).
@@ -44,7 +45,7 @@ export async function* runAgent(
     const mcpConfigDir = join(workspacePath, ".mulmoclaude");
     await mkdir(mcpConfigDir, { recursive: true });
     mcpConfigHostPath = join(mcpConfigDir, `mcp-${sessionId}.json`);
-    mcpConfigArgPath = `/workspace/.mulmoclaude/mcp-${sessionId}.json`;
+    mcpConfigArgPath = `/home/node/mulmoclaude/.mulmoclaude/mcp-${sessionId}.json`;
   } else {
     mcpConfigHostPath = join(tmpdir(), `mulmoclaude-mcp-${sessionId}.json`);
     mcpConfigArgPath = mcpConfigHostPath;
@@ -75,6 +76,8 @@ export async function* runAgent(
       ? ["--add-host", "host.docker.internal:host-gateway"]
       : [];
 
+  const uid = process.getuid?.() ?? 1000;
+  const gid = process.getgid?.() ?? 1000;
   const projectRoot = process.cwd();
   const proc = useDocker
     ? spawn(
@@ -82,6 +85,12 @@ export async function* runAgent(
         [
           "run",
           "--rm",
+          "--cap-drop",
+          "ALL",
+          "--user",
+          `${uid}:${gid}`,
+          "-e",
+          "HOME=/home/node",
           "-v",
           `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
           "-v",
@@ -89,9 +98,11 @@ export async function* runAgent(
           "-v",
           `${toDockerPath(projectRoot)}/src:/app/src:ro`,
           "-v",
-          `${toDockerPath(workspacePath)}:/workspace`,
+          `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
           "-v",
-          `${toDockerPath(homedir())}/.claude:/root/.claude`,
+          `${toDockerPath(homedir())}/.claude:/home/node/.claude`,
+          "-v",
+          `${toDockerPath(homedir())}/.claude.json:/home/node/.claude.json`,
           ...extraHosts,
           "mulmoclaude-sandbox",
           "claude",

--- a/server/docker.ts
+++ b/server/docker.ts
@@ -1,8 +1,9 @@
 import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import { createHash } from "crypto";
-import { readFileSync } from "fs";
-import { resolve as resolvePath } from "path";
+import { readFileSync, statSync } from "fs";
+import { homedir } from "os";
+import { join, resolve as resolvePath } from "path";
 
 const execFileAsync = promisify(execFile);
 
@@ -12,9 +13,39 @@ const LABEL_KEY = "mulmoclaude.dockerfile.sha256";
 
 let _dockerEnabled: boolean | null = null;
 
+function assertClaudeFiles(): void {
+  const claudeDir = join(homedir(), ".claude");
+  const claudeJson = join(homedir(), ".claude.json");
+
+  try {
+    if (!statSync(claudeDir).isDirectory()) {
+      console.error(`[sandbox] ${claudeDir} exists but is not a directory.`);
+      process.exit(1);
+    }
+  } catch {
+    console.error(
+      `[sandbox] ${claudeDir} not found. Run 'claude' once to initialize.`,
+    );
+    process.exit(1);
+  }
+
+  try {
+    if (!statSync(claudeJson).isFile()) {
+      console.error(`[sandbox] ${claudeJson} exists but is not a file.`);
+      process.exit(1);
+    }
+  } catch {
+    console.error(
+      `[sandbox] ${claudeJson} not found. Run 'claude' once to initialize.`,
+    );
+    process.exit(1);
+  }
+}
+
 export async function isDockerAvailable(): Promise<boolean> {
   if (process.env.DISABLE_SANDBOX === "1") return false;
   if (_dockerEnabled !== null) return _dockerEnabled;
+  assertClaudeFiles();
   try {
     await execFileAsync("docker", ["ps", "-q"], { timeout: 5000 });
     _dockerEnabled = true;

--- a/server/docker.ts
+++ b/server/docker.ts
@@ -77,6 +77,7 @@ async function buildImage(sha: string): Promise<void> {
       ],
       { cwd: process.cwd(), stdio: ["ignore", "inherit", "inherit"] },
     );
+    proc.on("error", reject);
     proc.on("close", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`docker build exited with code ${code}`));

--- a/server/docker.ts
+++ b/server/docker.ts
@@ -1,9 +1,14 @@
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { promisify } from "util";
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { resolve as resolvePath } from "path";
 
 const execFileAsync = promisify(execFile);
 
 const IMAGE_NAME = "mulmoclaude-sandbox";
+const DOCKERFILE = "Dockerfile.sandbox";
+const LABEL_KEY = "mulmoclaude.dockerfile.sha256";
 
 let _dockerEnabled: boolean | null = null;
 
@@ -19,18 +24,62 @@ export async function isDockerAvailable(): Promise<boolean> {
   return _dockerEnabled;
 }
 
+function getDockerfileSha256(): string {
+  const content = readFileSync(resolvePath(process.cwd(), DOCKERFILE));
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function buildImage(sha: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      "docker",
+      [
+        "build",
+        "-t",
+        IMAGE_NAME,
+        "--label",
+        `${LABEL_KEY}=${sha}`,
+        "-f",
+        DOCKERFILE,
+        "--load",
+        ".",
+      ],
+      { cwd: process.cwd(), stdio: ["ignore", "inherit", "inherit"] },
+    );
+    proc.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`docker build exited with code ${code}`));
+    });
+  });
+}
+
 export async function ensureSandboxImage(): Promise<void> {
+  const expectedSha = getDockerfileSha256();
+
+  let needsBuild = false;
   try {
-    await execFileAsync("docker", ["image", "inspect", IMAGE_NAME]);
+    const { stdout } = await execFileAsync("docker", [
+      "image",
+      "inspect",
+      IMAGE_NAME,
+      "--format",
+      `{{index .Config.Labels "${LABEL_KEY}"}}`,
+    ]);
+    if (stdout.trim() !== expectedSha) {
+      console.log(
+        "[sandbox] Dockerfile.sandbox changed, rebuilding sandbox image...",
+      );
+      needsBuild = true;
+    }
   } catch {
     console.log(
       "[sandbox] Building sandbox image (first time only, may take a minute)...",
     );
-    await execFileAsync(
-      "docker",
-      ["build", "-t", IMAGE_NAME, "-f", "Dockerfile.sandbox", "--load", "."],
-      { cwd: process.cwd() },
-    );
+    needsBuild = true;
+  }
+
+  if (needsBuild) {
+    await buildImage(expectedSha);
     console.log("[sandbox] Sandbox image built.");
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Sandbox now runs as a non-root user, uses non-root workspace locations, remaps credential/state mounts into that non-root home, and drops unnecessary container capabilities.
  * Docker startup now validates required credential files before proceeding.

* **Reliability**
  * Sandbox image is automatically rebuilt when its container configuration changes.

* **Documentation**
  * Added a planning document detailing non-root sandbox behavior, security review, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->