### PR TITLE
feat: render text-response as markdown in stack view

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -35,12 +35,12 @@
           result.toolName
         }}</span>
       </button>
-      <!-- text-response: render the message as Markdown so headings,
-           lists, code blocks etc. look the same as in single view.
-           TextResponseOriginalView is the underlying renderer from
-           @gui-chat-plugin/text-response — using it directly skips the
-           PDF-download wrapper and keeps the card at natural height. -->
-      <div v-if="isTextResponse(result)" class="px-4 py-3 text-sm">
+      <!-- text-response: render the message as Markdown via the
+           underlying plugin View. The .stack-text-response class below
+           collapses the plugin's own card chrome (outer p-6, inner
+           rounded/border/shadow box, role header) so only the stack
+           card's own border shows. -->
+      <div v-if="isTextResponse(result)" class="stack-text-response">
         <TextResponseOriginalView :selected-result="result" />
       </div>
       <!-- Document-like plugins: let the content flow at its natural
@@ -238,5 +238,28 @@ onUnmounted(() => {
 }
 .stack-natural :deep(.flex-1) {
   flex: 0 0 auto !important;
+}
+
+/* Collapse the nested chrome that @gui-chat-plugin/text-response
+   draws around its Markdown output so it reads like plain content
+   inside our stack card instead of creating a second border/shadow
+   "card" inside ours. */
+.stack-text-response :deep(.text-response-content-wrapper > .p-6) {
+  padding: 0.5rem 0.75rem;
+}
+.stack-text-response :deep(.text-response-container .max-w-3xl) {
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+}
+.stack-text-response :deep(.text-response-container .mb-2) {
+  display: none; /* redundant role header — stack card header shows it already */
+}
+.stack-text-response :deep(.text-response-container .shadow-sm) {
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
 }
 </style>

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -35,13 +35,13 @@
           result.toolName
         }}</span>
       </button>
-      <!-- text-response: render the message directly so the card sizes
-           naturally to its text content -->
-      <div
-        v-if="isTextResponse(result)"
-        class="px-4 py-3 text-sm text-gray-800 whitespace-pre-wrap break-words"
-      >
-        {{ messageText(result) }}
+      <!-- text-response: render the message as Markdown so headings,
+           lists, code blocks etc. look the same as in single view.
+           TextResponseOriginalView is the underlying renderer from
+           @gui-chat-plugin/text-response — using it directly skips the
+           PDF-download wrapper and keeps the card at natural height. -->
+      <div v-if="isTextResponse(result)" class="px-4 py-3 text-sm">
+        <TextResponseOriginalView :selected-result="result" />
       </div>
       <!-- Document-like plugins: let the content flow at its natural
            height by overriding the plugin's internal h-full / overflow
@@ -87,6 +87,8 @@
 import { ref, watch, nextTick, onUnmounted } from "vue";
 import { getPlugin } from "../tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { View as TextResponseOriginalView } from "@gui-chat-plugin/text-response/vue";
+import type { TextResponseData } from "@gui-chat-plugin/text-response";
 
 // Most plugin viewComponents use h-full internally, so a defined parent
 // height is required for them to render. text-response and the
@@ -170,22 +172,14 @@ function resizeOneIframe(iframe: HTMLIFrameElement): void {
   }
 }
 
-function isTextResponse(result: ToolResultComplete): boolean {
-  return result.toolName === "text-response";
-}
-
-function messageText(result: ToolResultComplete): string {
-  if (typeof result.message === "string") return result.message;
+function isTextResponse(
+  result: ToolResultComplete,
+): result is ToolResultComplete<TextResponseData> {
+  if (result.toolName !== "text-response") return false;
   const data = result.data;
-  if (
-    typeof data === "object" &&
-    data !== null &&
-    "text" in data &&
-    typeof (data as { text: unknown }).text === "string"
-  ) {
-    return (data as { text: string }).text;
-  }
-  return "";
+  if (typeof data !== "object" || data === null) return false;
+  if (!("text" in data)) return false;
+  return typeof data.text === "string";
 }
 
 function iconFor(toolName: string): string {


### PR DESCRIPTION
## User Prompt

> assistantのtext-responseもmarkdownだよね。mainからPRつくって。

## Problem

In stack view, \`text-response\` cards were rendered as plain
\`whitespace-pre-wrap\` text. Assistant responses containing headings,
lists, code blocks or inline formatting all looked flat — unlike
single view, which uses the plugin's Markdown renderer.

## Fix

Render \`text-response\` cards with the underlying Markdown renderer
from \`@gui-chat-plugin/text-response/vue\` so they look the same as in
single view.

- Import \`View as TextResponseOriginalView\` directly from the plugin
  instead of the in-app \`TextResponseView\` wrapper. The wrapper adds
  a PDF-download bar (which would stack up on every assistant card)
  and forces \`h-full\`; the underlying \`View\` stays at its natural
  height and applies \`marked\` with \`{ breaks: true, gfm: true }\`.
- \`isTextResponse\` is now a type guard
  (\`result is ToolResultComplete<TextResponseData>\`) so the template
  can pass the result straight through without any \`as\` cast. Guard
  checks the \`toolName\` and the \`data.text\` shape.
- Drop the now-unused \`messageText()\` helper.

Global \`.markdown-content\` styles (already on main from PR #80)
handle heading sizes, lists, code blocks, tables etc. so the
rendered output matches what users see in single view.

## Files changed

- \`src/components/StackView.vue\` — only

## Test plan

- [ ] Send an assistant response with \`#\`, \`##\`, \`###\` headings → renders with distinct sizes in stack view
- [ ] Inline formatting (\`**bold**\`, \`*italic*\`, \`\\\`code\\\`\`) renders in stack view
- [ ] Fenced code blocks render as preformatted blocks
- [ ] User messages (plain text, possibly with newlines) still render correctly (breaks:true preserves single newlines)
- [ ] No PDF-download button on each assistant card
- [ ] Single-view text-response rendering is unchanged (still uses the wrapper)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Text responses now render with enhanced Markdown formatting capabilities, providing improved readability and consistent visual presentation across the interface.
  * Refined styling optimizations deliver a cleaner, more streamlined layout for text responses in the stack view, with improved spacing, framing, and overall visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->