### PR TITLE
fix: cleanup multi-chat review nits

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -668,15 +668,23 @@ const selectedResult = computed(
     toolResults.value.find((r) => r.uuid === selectedResultUuid.value) ?? null,
 );
 
-// Merged list for history pane: live sessions first, then server-only sessions
+// Type-guard for the user-side branch of a text-response result. Used
+// to surface the first user message as a preview for live sessions
+// that haven't been persisted to disk yet.
+function isUserTextResponse(r: ToolResultComplete): boolean {
+  if (r.toolName !== "text-response") return false;
+  const data = r.data;
+  if (typeof data !== "object" || data === null) return false;
+  if (!("role" in data)) return false;
+  return data.role === "user";
+}
+
+// Merged list for the history pane: live sessions in `sessionMap`
+// merged with server-only sessions, sorted newest-first by startedAt.
 const mergedSessions = computed((): SessionSummary[] => {
   const liveIds = new Set(sessionMap.keys());
   const liveSummaries: SessionSummary[] = [...sessionMap.values()].map((s) => {
-    const firstUserMsg = s.toolResults.find(
-      (r) =>
-        r.toolName === "text-response" &&
-        (r.data as { role?: string } | null)?.role === "user",
-    );
+    const firstUserMsg = s.toolResults.find(isUserTextResponse);
     return {
       id: s.id,
       roleId: s.roleId,
@@ -685,7 +693,17 @@ const mergedSessions = computed((): SessionSummary[] => {
     };
   });
   const serverOnly = sessions.value.filter((s) => !liveIds.has(s.id));
-  return [...liveSummaries, ...serverOnly];
+  return [...liveSummaries, ...serverOnly].sort(
+    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+  );
+});
+
+// Centralised hasUnread reset: whenever the user switches to a session
+// (either by clicking it in history, by creating a new one, or by
+// loading one from the server), clear that session's unread flag.
+watch(currentSessionId, (id) => {
+  const session = sessionMap.get(id);
+  if (session) session.hasUnread = false;
 });
 
 const SCROLL_AMOUNT = 60;
@@ -919,10 +937,10 @@ async function toggleHistory() {
 }
 
 async function loadSession(id: string) {
-  // Already live in memory — just switch to it
+  // Already live in memory — just switch to it. The watch on
+  // currentSessionId clears the unread flag automatically.
   const live = sessionMap.get(id);
   if (live) {
-    live.hasUnread = false;
     currentSessionId.value = id;
     currentRoleId.value = live.roleId;
     showHistory.value = false;
@@ -1127,15 +1145,21 @@ function handleClickOutsideLock(e: MouseEvent) {
 }
 
 onMounted(async () => {
-  createNewSession();
-  fetchHealth();
-  fetchMcpToolsStatus();
-  refreshRoles();
+  // Listeners first so the UI responds to interactions even if the
+  // async fetches below take a moment.
   window.addEventListener("roles-updated", refreshRoles);
   window.addEventListener("keydown", handleKeyNavigation);
   window.addEventListener("mousedown", handleClickOutsideHistory);
   window.addEventListener("mousedown", handleClickOutsideLock);
   window.addEventListener("keydown", handleViewModeShortcut);
+  // Fire-and-forget side fetches.
+  fetchHealth();
+  fetchMcpToolsStatus();
+  // Roles must be loaded before the first session is created, so
+  // createNewSession() picks a roleId that exists in the merged
+  // role list (built-in + custom).
+  await refreshRoles();
+  createNewSession();
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## User Prompt

> 気になる点はあとでこっちで検証して直そう。とりこんだ。
> localStorage 自動復元の扱いは意図的。他は直していこう。

Follow-up to #88 (Allows concurrent chat sessions). Cleans up the four
review nits I raised after that PR was merged. The localStorage
auto-restore removal is intentional per the author and is left as-is.

## Changes

### 1. Drop `as` cast in \`mergedSessions\`

\`mergedSessions\` was reading the user/assistant role off the live
session's first text-response with an \`as { role?: string }\` cast.
Replaced with an \`isUserTextResponse(r)\` type guard that uses
\`typeof\` / \`in\` narrowing on the unknown \`r.data\`, keeping it within
the project's no-\`as\` rule.

### 2. Centralise \`hasUnread\` clear

Multiple paths set \`currentSessionId.value\` (\`createNewSession\`,
\`loadSession\` live branch, \`loadSession\` server branch). The unread
flag was only being cleared in one of them. Replaced the inline reset
with a single \`watch(currentSessionId, …)\` that clears the new
session's flag whenever the current pointer moves, so future call
sites can't forget.

### 3. Sort \`mergedSessions\` newest-first

The history pane was rendering live sessions on top followed by
server-only sessions, which broke the global newest-first ordering
when a freshly loaded server session had a more recent \`startedAt\`
than a live one. Now the merged list is sorted by \`startedAt\` desc
after combining both groups.

### 4. Reorder \`onMounted\`

\`createNewSession()\` was being called before \`refreshRoles()\` resolved,
so the first session was always created against the built-in
\`ROLES[0]\` even when a custom role with the same id existed. Reordered
to:

1. Register window listeners (UI stays responsive)
2. Fire \`fetchHealth\` / \`fetchMcpToolsStatus\` (fire-and-forget)
3. \`await refreshRoles()\`
4. \`createNewSession()\`

## Files changed

- \`src/App.vue\` — only

## Test plan

- [ ] Send a message in session A, switch to a new session B → A keeps running, B is empty
- [ ] Switch back to A while it's still running → green badge clears, A's selection resumes
- [ ] Wait for A to finish while viewing B → A's row in history shows the red Unread badge
- [ ] Click A in history → unread clears, A becomes current
- [ ] History pane order: a freshly server-loaded session with newer \`startedAt\` than a live one appears above the live one
- [ ] First session on app launch picks the right role from the merged role list (built-in + custom)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Unread indicators are now consistently cleared when switching between sessions

## Refactor
* Sessions in history now display in newest-first order
* Startup sequence optimized with improved async operation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->