### PR TITLE
fix: surface agent errors in chat instead of failing silently

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -487,6 +487,11 @@ interface SseRolesUpdated {
   type: "roles_updated";
 }
 
+interface SseError {
+  type: "error";
+  message: string;
+}
+
 type SseEvent =
   | SseToolCall
   | SseToolCallResult
@@ -494,7 +499,8 @@ type SseEvent =
   | SseSwitchRole
   | SseText
   | SseToolResult
-  | SseRolesUpdated;
+  | SseRolesUpdated
+  | SseError;
 
 interface ActiveSession {
   id: string;
@@ -830,6 +836,23 @@ function makeTextResult(
   };
 }
 
+// Surface a server-side or transport-level error as a card in the
+// session's chat so the user actually sees it. The status-message
+// channel can't be used because `finally` clears it the moment the
+// run ends.
+function pushErrorMessage(session: ActiveSession, message: string): void {
+  const text = `[Error] ${message}`;
+  const errorResult: ToolResultComplete = {
+    uuid: uuidv4(),
+    toolName: "text-response",
+    message: text,
+    title: "Error",
+    data: { text, role: "assistant", transportKind: "text-rest" },
+  };
+  session.toolResults.push(errorResult);
+  session.selectedResultUuid = errorResult.uuid;
+}
+
 function handleUpdateResult(updatedResult: ToolResultComplete) {
   const results = activeSession.value?.toolResults;
   if (!results) return;
@@ -1032,8 +1055,22 @@ async function sendMessage(text?: string) {
       signal: session.abortController.signal,
     });
 
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      console.error(
+        "[agent] HTTP error:",
+        response.status,
+        response.statusText,
+        errBody,
+      );
+      pushErrorMessage(
+        session,
+        `Server error ${response.status}: ${errBody.slice(0, 200)}`,
+      );
+      return;
+    }
     if (!response.body) {
-      session.statusMessage = "No response body received from server.";
+      pushErrorMessage(session, "No response body received from server.");
       return;
     }
 
@@ -1107,12 +1144,19 @@ async function sendMessage(text?: string) {
             session.toolResults.push(result);
             session.selectedResultUuid = result.uuid;
           }
+        } else if (data.type === "error") {
+          console.error("[agent] error event:", data.message);
+          pushErrorMessage(session, data.message);
         }
       }
     }
   } catch (e) {
     if (!(e instanceof DOMException && e.name === "AbortError")) {
-      session.statusMessage = "Connection error.";
+      console.error("[agent] fetch error:", e);
+      pushErrorMessage(
+        session,
+        e instanceof Error ? e.message : "Connection error.",
+      );
     }
   } finally {
     session.isRunning = false;


### PR DESCRIPTION
## User Prompt

> 過去の履歴を呼び出して、続きの会話をsubmitしても、動作中に一瞬なるんだけどレスポンスがなく新しい返答がない。新規のchatはできる
>
> まず最初のaだけ進めて。

## Background

While debugging "load past session, send a continuation, briefly
shows running, then nothing happens" we found that the frontend SSE
event loop in \`sendMessage\` was dropping any \`error\` event the
server emits.

The server's \`runAgent\` (\`server/agent.ts\`) yields
\`{ type: \"error\", message: stderrOutput }\` whenever the spawned
\`claude\` CLI exits non-zero (the most common trigger right now is a
stale \`--resume <claudeSessionId>\` after the workspace cwd changed
between runs). The agent route forwards that event over SSE. The
client received it, parsed the JSON, and then fell off the end of the
\`else if\` chain because no branch matched \`data.type === \"error\"\`.
The stream ended, \`finally\` reset \`isRunning\`, and the user saw a
brief \"running\" state with no output, no toast, no console message,
no clue.

The SSE union type itself didn't even include an error variant, so
TypeScript wasn't warning either.

This PR is the minimum needed so the next failure is at least
visible. The deeper resume root cause is being investigated
separately.

## Changes

\`src/App.vue\` only:

- Add \`SseError\` interface and include it in the \`SseEvent\` union.
- Handle \`data.type === \"error\"\` in the SSE event loop, route the
  message through the new \`pushErrorMessage()\` helper, and
  \`console.error\` it.
- Add an \`if (!response.ok)\` HTTP check ahead of \`response.body\` so
  4xx/5xx replies are surfaced too (with the response body included
  in the message and the console log).
- The \`catch\` block around \`fetch\` now also routes to
  \`pushErrorMessage()\` instead of writing to \`statusMessage\`.
- Add \`pushErrorMessage(session, message)\`: pushes a synthetic
  text-response card titled \"Error\" with body \`[Error] <message>\`
  into the active session's \`toolResults\` and selects it.

## Why \`pushErrorMessage\` instead of \`statusMessage\`

\`session.statusMessage\` is cleared in the \`finally\` block at the end
of every run, so any error written there vanishes before the user
reads it. Pushing the error as an actual chat card keeps it visible,
makes it part of the persisted session view, and matches how other
events (\`text\`, \`tool_result\`) already render.

## What this does NOT fix

- The underlying \`--resume\` failure for sessions saved against an
  older sandbox cwd. Tracking and root-causing separately.
- Server-side agent logging is still missing — the server console is
  silent during \`/api/agent\`. Will add in a follow-up PR.

## Files changed

- \`src/App.vue\` — only

## Test plan

- [ ] Send a message in a chat where \`--resume\` fails (e.g. a session whose \`claudeSessionId\` is missing from \`~/.claude/projects/<cwd>/\`) → an \"Error\" card with the claude stderr appears in the chat instead of silent failure
- [ ] Stop the server, send a message → \"Error\" card with the fetch error appears
- [ ] Hit \`/api/agent\` with a malformed body so the server returns 400 → \"Error\" card with the HTTP status + body
- [ ] Normal happy-path chat is unaffected (text + tool_result events still render as before)
- [ ] Aborting a run via the stop button still goes through the \`AbortError\` branch silently (no spurious error card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and visibility across the application. Network connectivity failures, server errors, and message processing issues are now displayed consistently and prominently. Users receive immediate, clear feedback when problems occur, making it easier to understand what went wrong and when to retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->