### PR TITLE
feat: render scheduler/items.json as calendar in files mode

### DIFF
--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -53,9 +53,14 @@
         </div>
         <template v-else-if="content">
           <template v-if="content.kind === 'text'">
+            <!-- Scheduler items.json: render with the scheduler plugin's
+                 calendar/list view by synthesizing a fake tool result. -->
+            <div v-if="schedulerResult" class="h-full">
+              <SchedulerView :selected-result="schedulerResult" />
+            </div>
             <!-- Markdown rendered: frontmatter panel + body -->
             <div
-              v-if="isMarkdown && !mdRawMode"
+              v-else-if="isMarkdown && !mdRawMode"
               class="h-full flex flex-col overflow-auto"
             >
               <div
@@ -182,8 +187,10 @@
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import FileTree, { type TreeNode } from "./FileTree.vue";
 import TextResponseView from "../plugins/textResponse/View.vue";
+import SchedulerView from "../plugins/scheduler/View.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
+import type { SchedulerData, ScheduledItem } from "../plugins/scheduler/index";
 import {
   tokenizeJson,
   tokenizeJsonl,
@@ -257,6 +264,42 @@ const jsonlLines = computed(() => {
   if (!content.value || content.value.kind !== "text") return [];
   return tokenizeJsonl(content.value.content);
 });
+
+function isScheduledItem(x: unknown): x is ScheduledItem {
+  if (typeof x !== "object" || x === null) return false;
+  if (!("id" in x) || typeof x.id !== "string") return false;
+  if (!("title" in x) || typeof x.title !== "string") return false;
+  return true;
+}
+
+function isScheduledItemArray(x: unknown): x is ScheduledItem[] {
+  return Array.isArray(x) && x.every(isScheduledItem);
+}
+
+// When the user opens scheduler/items.json, render it with the
+// scheduler plugin's calendar view instead of as a JSON blob. We
+// synthesize a fake ToolResultComplete<SchedulerData> so the View
+// component receives the same shape it normally gets in chat mode.
+const schedulerResult = computed(
+  (): ToolResultComplete<SchedulerData> | null => {
+    if (selectedPath.value !== "scheduler/items.json") return null;
+    if (!content.value || content.value.kind !== "text") return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content.value.content);
+    } catch {
+      return null;
+    }
+    if (!isScheduledItemArray(parsed)) return null;
+    return {
+      uuid: "files-scheduler-preview",
+      toolName: "manageScheduler",
+      message: "scheduler/items.json",
+      title: "Scheduler",
+      data: { items: parsed },
+    };
+  },
+);
 
 const mdFrontmatter = computed(() => {
   if (!content.value || content.value.kind !== "text") return null;

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -347,15 +347,15 @@ const items = computed(() => props.selectedResult.data?.items ?? []);
 type ViewMode = "list" | "week" | "month";
 
 const VIEW_MODES: { key: ViewMode; label: string; icon: string }[] = [
-  { key: "list", label: "List", icon: "view_list" },
-  { key: "week", label: "Week", icon: "view_week" },
   { key: "month", label: "Month", icon: "calendar_month" },
+  { key: "week", label: "Week", icon: "view_week" },
+  { key: "list", label: "List", icon: "view_list" },
 ];
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const MAX_MONTH_ITEMS = 3;
 
-const viewMode = ref<ViewMode>("list");
+const viewMode = ref<ViewMode>("month");
 const currentDate = ref(new Date());
 
 // ── Calendar utilities ─────────────────────────────────────────────────────


### PR DESCRIPTION
## User Prompt

> file エクスプローラー。スケジュールを開くとカレンダーで表示が良いね
> カレンダーって月のviewが標準で左が良いね。月、週、個別

## Summary

When the user clicks \`scheduler/items.json\` in the file explorer, the
file is now rendered with the scheduler plugin's own
calendar / week / list View instead of as a raw JSON blob. The same
View is what chat mode already uses, so opening the file from either
entry point looks identical.

The default view mode is also bumped from \`list\` to \`month\` and the
toggle order is reordered to **Month / Week / List** (left-to-right),
matching the user's request. This applies to both the new files-mode
preview and the existing chat-mode rendering.

## Changes

### \`src/components/FilesView.vue\`

- Import \`SchedulerView\` from \`src/plugins/scheduler/View.vue\` and
  the \`SchedulerData\` / \`ScheduledItem\` types.
- Add \`isScheduledItem\` and \`isScheduledItemArray\` type guards so
  the JSON content can be narrowed to \`ScheduledItem[]\` without an
  \`as\` cast.
- New \`schedulerResult\` computed: when \`selectedPath\` is exactly
  \`scheduler/items.json\` and the body parses as a valid
  \`ScheduledItem[]\`, build a synthetic
  \`ToolResultComplete<SchedulerData>\` with
  \`{ uuid: \"files-scheduler-preview\", toolName: \"manageScheduler\",
  data: { items } }\`. Falls back to \`null\` (and the existing JSON
  branch) on parse error or shape mismatch.
- New template branch in front of the markdown branch:
  \`<SchedulerView :selected-result=\"schedulerResult\" />\` when the
  computed is non-null. Other \`.json\` files still hit the existing
  syntax-coloring branch.

### \`src/plugins/scheduler/View.vue\`

- Reorder \`VIEW_MODES\` to \`[month, week, list]\` so the toggle reads
  Month / Week / List left-to-right.
- Initial \`viewMode\` is now \`\"month\"\` instead of \`\"list\"\`.

## Files changed

- \`src/components/FilesView.vue\`
- \`src/plugins/scheduler/View.vue\`

## Notes

- The synthetic result has a fixed \`uuid\` (\`files-scheduler-preview\`)
  because there's no upstream chain for files-mode rendering. Any
  emit-based update from inside SchedulerView (e.g., the YAML editor
  panel) still goes through \`POST /api/scheduler\`, which writes the
  workspace file directly. The next click on the file will see the
  fresh data via the existing content fetch.
- Other JSON files in the workspace are completely unaffected — they
  still render with the JSON syntax-coloring view.

## Test plan

- [ ] Click \`scheduler/items.json\` in the file explorer → calendar (month) view shows the existing items
- [ ] Toggle to Week / List → both work
- [ ] Open the same file in chat mode (via the scheduler plugin) → same calendar view, default month
- [ ] Click any other \`.json\` file (e.g., \`todos/todos.json\`) → still renders with JSON syntax coloring
- [ ] Malformed \`scheduler/items.json\` → falls through to JSON view (no crash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a specialized scheduler view for calendar data files with dedicated rendering and navigation controls.
  * Changed default calendar view from list to month view.
  * Reorganized calendar view mode options in the toggle menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->