### PR TITLE
fix: clicking a sidebar item exits files mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -224,7 +224,7 @@
           :class="
             result.uuid === selectedResultUuid ? 'ring-2 ring-blue-500' : ''
           "
-          @click="selectedResultUuid = result.uuid"
+          @click="onSidebarItemClick(result.uuid)"
         >
           <component
             :is="getPlugin(result.toolName)?.previewComponent"
@@ -859,6 +859,18 @@ function handleUpdateResult(updatedResult: ToolResultComplete) {
   const index = results.findIndex((r) => r.uuid === updatedResult.uuid);
   if (index !== -1) {
     Object.assign(results[index], updatedResult);
+  }
+}
+
+// When the user clicks an item in the sidebar while the canvas is
+// showing the file explorer, the previously-selected file would
+// otherwise stay on screen and the click would have no visible
+// effect. Auto-switch back to single mode so the clicked item
+// actually shows up in the canvas.
+function onSidebarItemClick(uuid: string) {
+  selectedResultUuid.value = uuid;
+  if (canvasViewMode.value === "files") {
+    setCanvasViewMode("single");
   }
 }
 


### PR DESCRIPTION
## User Prompt

> fileエクスプローラーを開いているときにサイドバーでitemをクリックしたときに、itemひらくようにしたい。いまはファイルのままなので。

## Problem

When the canvas is showing the file explorer (\`canvasViewMode === \"files\"\`), clicking a tool result in the left sidebar updates \`selectedResultUuid\` but the canvas stays on the file viewer. The click looks like it did nothing — the user is still staring at whatever file they had open.

## Fix

Wrap the inline \`@click\` handler in a tiny helper:

\`\`\`ts
function onSidebarItemClick(uuid: string) {
  selectedResultUuid.value = uuid;
  if (canvasViewMode.value === \"files\") {
    setCanvasViewMode(\"single\");
  }
}
\`\`\`

So clicking a sidebar item in files mode now both:
1. Selects the item (same as before).
2. Flips the canvas back to **single** mode so the selected result is actually rendered.

Stack mode is intentionally left alone — its scroll-spy already follows the new selection on its own (PR #83), and the user explicitly only mentioned files mode.

## Files changed

- \`src/App.vue\` — only

## Test plan

- [ ] Open the file explorer (canvas mode = files), click a sidebar item → canvas switches to single mode and shows the item
- [ ] Open the file explorer, click the currently-selected sidebar item → canvas still switches to single mode (no harm)
- [ ] In single mode, clicking a sidebar item still works as before (no mode change)
- [ ] In stack mode, clicking a sidebar item still scrolls the stack to that item without leaving stack mode (scroll-spy unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed sidebar item selection behavior when the file explorer view is active. Clicking sidebar items now automatically switches the view back to single mode, ensuring selections are immediately visible and providing better user experience during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->