### PR TITLE
fix: create workspacePath at module load to prevent ENOENT

### DIFF
--- a/server/workspace.ts
+++ b/server/workspace.ts
@@ -9,6 +9,9 @@ const TEMPLATES_DIR = path.join(__dirname, "helps");
 
 export const workspacePath = path.join(os.homedir(), "mulmoclaude");
 
+// Must exist before downstream modules call realpathSync(workspacePath) at their own module-load time.
+fs.mkdirSync(workspacePath, { recursive: true });
+
 const SUBDIRS = [
   "chat",
   "todos",
@@ -21,7 +24,6 @@ const SUBDIRS = [
 
 export function initWorkspace(): string {
   // Create directory structure if needed
-  fs.mkdirSync(workspacePath, { recursive: true });
   for (const dir of SUBDIRS) {
     fs.mkdirSync(path.join(workspacePath, dir), { recursive: true });
   }


### PR DESCRIPTION
## 問題

新規ユーザー環境では `~/mulmoclaude` が存在しない。
本来は `initWorkspace()` がこのディレクトリを作成してからサーバーが起動する。

しかし `server/routes/files.ts` がモジュールロード時に `realpathSync(workspacePath)` を呼んでいる。
ES Modules の評価順序により、これは `initWorkspace()` よりも先に走る。結果として ENOENT で起動失敗する。

回避するには事前にユーザーが手動で `mkdir ~/mulmoclaude` する必要があった。

## 修正

`server/workspace.ts` のトップレベルで `mkdirSync(workspacePath, { recursive: true })` を呼ぶように順番を入れ替えた。これにより import チェーンで `files.ts` の `realpathSync` よりも先にディレクトリが作られる。

`initWorkspace()` 内の重複した呼び出しは削除。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced workspace directory initialization process for improved efficiency during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->