### PR TITLE
Claude credential under Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ MulmoClaude uses Claude Code as its AI backend, which has access to tools includ
 4. **Linux**: follow the [Linux install guide](https://docs.docker.com/desktop/install/linux/)
 5. Wait for Docker Desktop to finish starting — the whale icon in the menu bar / system tray should turn steady (not animated)
 6. Restart MulmoClaude — it will detect Docker and build the sandbox image on first run (one-time, takes about a minute)
-7. Authenticate Claude Code inside the sandbox (one-time):
+7. Export your Claude Code credentials for the sandbox:
    ```bash
-   yarn sandbox:login
+   npm run sandbox:login
    ```
-   This opens a browser for the standard Claude Code OAuth flow. Your credentials are saved in `~/.claude` and persist across all future runs — you won't need to do this again.
+   This extracts your OAuth token from macOS Keychain and writes it to `~/.claude/.credentials.json`, which the Docker container reads via bind mount. Re-run this command whenever you get a 401 authentication error (tokens expire every few hours).
 
 If Docker is not installed, the app shows a warning banner and continues to work without sandboxing.
 
-> **Why a separate login?** On macOS and Windows, Claude Code stores OAuth tokens in the system keychain. The Docker container (a Linux environment) cannot access the host keychain, so a one-time login inside the container is required. The credentials are stored as files in `~/.claude`, which is mounted into the container on every run.
+> **Why is this needed?** On macOS, Claude Code stores and refreshes OAuth tokens in the system Keychain. The Docker container (a Linux environment) cannot access the Keychain, so it reads credentials from `~/.claude/.credentials.json` instead. The `sandbox:login` script bridges the gap by copying the current token from Keychain to that file. Running `claude auth login` inside the Docker container does not work on macOS because the OAuth callback requires a local HTTP server that is unreachable from the host browser due to Docker Desktop's VM-based networking.
 
 > **Debug mode**: To run without the sandbox even when Docker is installed, set `DISABLE_SANDBOX=1` before starting the server.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "vite build && tsc -p server/tsconfig.json --noEmit",
     "test": "tsx --test ./test/*/test_*.ts",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
-    "sandbox:login": "docker run --rm -it -v ~/.claude:/root/.claude mulmoclaude-sandbox claude login"
+    "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",
+    "sandbox:logout": "rm -f ~/.claude/.credentials.json && echo 'Credentials file removed'"
   },
   "resolutions": {
     "tar": "7.5.13"

--- a/plan/credential_issue.md
+++ b/plan/credential_issue.md
@@ -1,0 +1,55 @@
+# Docker Container Credential Issue
+
+## Summary
+
+The app spawns the `claude` CLI inside a Docker sandbox. The container mounts the host's credential files:
+
+```
+~/.claude      → /home/node/.claude
+~/.claude.json → /home/node/.claude.json
+```
+
+## Root Cause
+
+The Claude Code CLI on macOS stores and refreshes OAuth tokens via **macOS Keychain** — it does NOT write updated tokens to `~/.claude/.credentials.json`. The Docker container has no Keychain access, so it reads the stale/missing credentials file and fails with a 401.
+
+## Symptoms
+
+```
+Failed to authenticate. API Error: 401
+```
+or
+```
+Not logged in · Please run /login
+```
+
+## Fix
+
+```
+npm run sandbox:login
+```
+
+This extracts the current OAuth credentials from macOS Keychain (`security find-generic-password -s 'Claude Code-credentials'`) and writes them to `~/.claude/.credentials.json`, which the Docker container reads via bind mount.
+
+Run this whenever the token expires (typically every few hours).
+
+To remove the credentials file:
+
+```
+npm run sandbox:logout
+```
+
+## Why `claude auth login` Inside Docker Does Not Work
+
+On macOS Docker Desktop, containers run inside a Linux VM. The `claude auth login` CLI starts a local HTTP server on a random port for the OAuth callback, but:
+
+- **`--network host`** shares the VM's network, not the Mac's — the browser can't reach the container's HTTP server
+- **`-p PORT:PORT`** requires knowing the port in advance — the CLI picks a random port
+- **Code-based flow** (pasting a code) — the CLI doesn't read from stdin; it waits for the HTTP callback
+
+Running `claude auth login` on the host writes only to Keychain, not to the credentials file.
+
+## Keychain Entry
+
+- **Service**: `Claude Code-credentials`
+- **Format**: JSON with `claudeAiOauth.accessToken`, `refreshToken`, `expiresAt`, `scopes`, `subscriptionType`

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,8 @@ import {
   isMcpToolEnabled,
 } from "./mcp-tools/index.js";
 import { initWorkspace } from "./workspace.js";
+import fs from "fs";
+import os from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./docker.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -100,6 +102,26 @@ function isPortFree(port: number): Promise<boolean> {
     try {
       sandboxEnabled = await isDockerAvailable();
       if (sandboxEnabled) {
+        const credentialsPath = path.join(
+          os.homedir(),
+          ".claude",
+          ".credentials.json",
+        );
+        if (!fs.existsSync(credentialsPath)) {
+          console.error(
+            "[sandbox] Missing credentials file: ~/.claude/.credentials.json",
+          );
+          if (process.platform === "darwin") {
+            console.error(
+              "[sandbox] Run `npm run sandbox:login` to export credentials from Keychain.",
+            );
+          } else {
+            console.error(
+              "[sandbox] Run `claude auth login` to authenticate Claude Code.",
+            );
+          }
+          process.exit(1);
+        }
         console.log(
           "[sandbox] Docker available — building sandbox image if needed",
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified sandbox credential and authentication guidance, including macOS-specific notes and troubleshooting steps.

* **New Features**
  * Added a sandbox logout command to remove exported sandbox credentials.

* **Improvements**
  * Updated sandbox login workflow to export host credentials for container use and added checks that surface missing-credentials errors earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->