### PR TITLE
feat(journal): automatic workspace summarization via claude CLI

### DIFF
--- a/plans/feat-auto-journal.md
+++ b/plans/feat-auto-journal.md
@@ -29,7 +29,7 @@ The system is **fully automatic**:
 
 ## Storage layout
 
-```
+```text
 workspace/
   chat/                              # EXISTING — raw session logs
     <sessionId>.jsonl                # append-only event log
@@ -202,7 +202,7 @@ Pure filesystem derivation — no LLM. Rebuilt at the end of every journal pass.
 
 ## File layout (code)
 
-```
+```text
 server/
   journal/
     index.ts              # public entry: maybeRunJournal()
@@ -230,7 +230,7 @@ All non-LLM logic is extracted into pure functions and lives in files designed t
 The LLM wrapper `archivist.ts` takes an injected `summarize: (systemPrompt, userPrompt) => Promise<string>` so tests can pass a fake. The default exports `runClaudeCli` which shells out to the `claude` binary. Tests never spawn a subprocess; they supply a deterministic fake that returns canned JSON.
 
 Test files:
-```
+```text
 test/journal/
   test_paths.ts
   test_diff.ts

--- a/plans/feat-auto-journal.md
+++ b/plans/feat-auto-journal.md
@@ -91,19 +91,22 @@ Why not a `setInterval` timer?
 - Users who don't touch MulmoClaude for a week don't want a 7-day-old summary generated the moment they open it — fine, they'll get it on the next session-end
 
 Why not trigger on startup?
-- Nice to have, but redundant with session-end. Possible Phase 1.5 if needed.
+- Nice to have, but redundant with session-end for production flows.
+- **Debug opt-in added post-initial-design**: set the env var `JOURNAL_FORCE_RUN_ON_STARTUP=1` and `maybeRunJournal({ force: true })` runs immediately after `app.listen`, bypassing the interval gate. The CLI-missing / in-process-lock guards still apply. Used for debugging and for deliberate backfill runs.
 
 ## Daily pass — `runDailyPass()`
 
 1. **Discover new/changed sessions**: scan `chat/*.jsonl`, compare mtime against `processedSessions[sessionId].lastMtimeMs`. Collect a list of "dirty" sessions.
 2. **Group by day**: for each dirty session, bucket events by their `timestamp` into `YYYY-MM-DD` buckets. A single session resumed across midnight contributes to multiple days.
-3. **Read existing state**: for each affected day, read `daily/YYYY/MM/DD.md` if it exists. For topic updates, read `topics/<slug>.md` for any known topics the new content might touch.
-4. **Single LLM call per affected day** (keeps token cost predictable):
-   - Input: raw session excerpts for that day + existing day summary (if any) + current topic list
+3. **Pre-compute per-session pending day set**: `sessionToDays: Map<sessionId, Set<date>>` — used to decide when a session is "fully processed" after each day write.
+4. **Read existing state**: for each affected day, read `daily/YYYY/MM/DD.md` if it exists. For topic updates, read `topics/<slug>.md` for any known topics the new content might touch.
+5. **Single LLM call per affected day** (keeps token cost predictable):
+   - Input: raw session excerpts for that day (each with `artifactPaths`) + existing day summary (if any) + current topic list
    - Output: structured JSON — `{ dailySummaryMarkdown, topicUpdates: [{ slug, action: "create"|"append"|"rewrite", content }] }`
-5. **Apply updates**: write `daily/.../DD.md`, create/append/rewrite `topics/<slug>.md` per LLM instructions
-6. **Rebuild `_index.md`** from current filesystem state (no LLM needed — pure filesystem walk + sort)
-7. **Update `_state.json`**: bump `lastDailyRunAt`, update `processedSessions` mtimes, append any newly-created topic slugs to `knownTopics`
+6. **Apply updates**: rewrite `/workspace-absolute` links to true-relative, then write `daily/.../DD.md`, create/append/rewrite `topics/<slug>.md` per LLM instructions.
+7. **Per-day incremental state checkpoint**: after each day is written successfully, decrement `sessionToDays` for that date; any session whose pending set just became empty is "fully processed" and its record gets added to `processedSessions`. `knownTopics` is also merged in. **`writeState(workspaceRoot, nextState)` is called after every day**, not at the end of the pass, so a mid-run crash only loses work in days still queued — everything up to the last checkpoint survives.
+8. **Rebuild `_index.md`** from current filesystem state (no LLM needed — pure filesystem walk + sort).
+9. **Final `_state.json` write** in `runJournalPass` bumps `lastDailyRunAt` (only if no days were skipped) and captures optimization-pass output.
 
 ### LLM invocation — `claude` CLI subprocess
 
@@ -159,6 +162,31 @@ The archivist runs with no MCP plugins, no tools — pure text in, structured te
 > Match the language of the source session (Japanese stays Japanese, English stays English). Be terse — no filler.
 
 Response is parsed as JSON; on parse failure, skip the day and log the error (don't crash the journal). All subprocess failure modes (ENOENT, timeout, non-zero exit, auth error) are caught inside `archivist.ts` and converted into logged warnings — the journal module never throws into the agent route's `finally` block.
+
+## Cross-linking from summaries
+
+The archivist system prompt has two extra sections that let summaries link back into the workspace rather than being plain-text wall-of-text:
+
+### Artifact links (A)
+
+- The user prompt includes an `ARTIFACTS REFERENCED` section listing workspace-relative file paths produced by the day's sessions. Paths come from `extractArtifactPaths()` in `dailyPass.ts`, which knows:
+  - `data.filePath` for plugins that stash one (presentMulmoScript, presentHtml)
+  - `wiki/pages/<pageName>.md` synthesised from `manageWiki` results
+  - Defensive filters reject absolute, parent-escape, and scheme-like paths
+- The archivist is instructed to emit markdown links using **workspace-absolute paths** (`[wiki](/wiki/pages/foo.md)`) so it doesn't have to do relative-path math.
+- `linkRewrite.rewriteWorkspaceLinks(currentFileWsPath, content)` post-processes the archivist output before writing the file to disk, converting each `/wiki/foo.md` to the correct `../../wiki/foo.md` for that file's location. No regex — character-level walker to satisfy sonarjs/slow-regex. Preserves `#fragment` suffixes.
+- Frontend: `FilesView.vue` intercepts clicks on rendered markdown links via `@click.capture`. Workspace-absolute (`/wiki/foo.md`) and true-relative (`../../wiki/foo.md`) links are resolved against the current file's path with `resolveWorkspaceLink()` and passed to `selectFile()`. External URLs / `#anchor` / `..`-escaping-workspace are passed through or rejected.
+
+### Session links (B)
+
+- The archivist is also told to link sessions it mentions using `/chat/<sessionId>.jsonl`. `linkRewrite` converts these the same way as artifact paths.
+- `FilesView` has a specialised branch: after resolving a clicked link, `extractSessionIdFromPath()` checks whether the target is a `chat/<id>.jsonl` and, if so, emits a `loadSession` event instead of opening the raw jsonl as a file.
+- `App.vue` binds `@load-session` to a bridge function that calls `loadSession(id)` AND flips `canvasViewMode` out of `files` so the reader actually sees the newly-loaded chat instead of staying on the file tree.
+- File-tree clicks on `chat/*.jsonl` are unaffected — they still show the raw jsonl. Only markdown-link clicks take the specialised path.
+
+### Why not vue-router?
+
+This is the narrow case of cross-cutting in-app navigation. Introducing `vue-router` would cover it elegantly along with several other cases (bookmarking, browser back/forward, deep-linking). We deliberately deferred that in favour of the click-handler approach so this PR stays focused. See issue #108 for the comprehensive router-adoption discussion.
 
 ## Optimization pass — `runOptimizationPass()`
 
@@ -245,7 +273,7 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 - **Token cost** — mitigated by routing through the `claude` CLI (subscription quota) instead of the API SDK. Default interval is 1h so a heavily-used workspace triggers ~24 passes per day worst case, but each pass only invokes the CLI if sessions have actually changed since the last run. Grouping by day keeps the per-pass cost at O(days_touched), not O(sessions). User can raise `dailyIntervalHours` in `_state.json` if they want even less chatter.
 - **`claude` CLI dependency** — the feature silently disables itself (with a single warning log) if the `claude` binary isn't installed or authenticated. Existing MulmoClaude functionality is unaffected.
 - **Concurrent runs** — two sessions ending simultaneously could race. Mitigation: in-process module-level lock flag (`running: boolean`). Good enough for single-user single-instance MulmoClaude.
-- **Partial writes on crash** — write `_state.json` atomically (write to `_state.json.tmp`, rename). Per-topic/per-day file writes are idempotent because the dirty-session detection re-ingests on next run until `_state.json` is persisted.
+- **Partial writes on crash** — write `_state.json` atomically (write to `_state.json.tmp`, rename), AND checkpoint after **every** daily-pass day rather than once at end-of-pass. A mid-pass crash loses only the days still queued; everything up to the last checkpoint is already committed and the next run picks up exactly from the next day. Per-topic/per-day file writes are idempotent because `processedSessions` only advances for sessions whose pending-day set has emptied.
 - **Runaway topic creation** — LLM invents a new topic for every session. Mitigation: system prompt instructs "prefer existing topics; create new only when no existing topic fits". Optimization pass merges duplicates as a safety net.
 - **Clock skew** — `lastDailyRunAt` is local wall-clock. If the user travels timezones, daily buckets could shift. Accept this — it's a personal workspace, not a distributed system.
 - **Non-JSON response from LLM** — parse failures are caught per-day; the day is skipped and the next pass retries. Logged to console for debugging.
@@ -260,12 +288,17 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 3. `server/journal/diff.ts` + tests
 4. `server/journal/indexFile.ts` + tests
 5. `server/journal/archivist.ts` — `claude` CLI subprocess wrapper with injectable `summarize`
-6. `server/journal/dailyPass.ts` — ties the above together for daily + topic updates
+6. `server/journal/dailyPass.ts` — ties the above together for daily + topic updates, checkpointing `_state.json` after every day
 7. `server/journal/optimizationPass.ts` + tests for classification logic
-8. `server/journal/index.ts` — `maybeRunJournal()` entry with lock, chains daily then optimization
-9. `server/routes/agent.ts` — call `maybeRunJournal()` in `finally` block (fire-and-forget)
-10. Run format / lint / typecheck / build / test
-11. Manual smoke: lower `dailyIntervalHours` to near-zero in `_state.json`, trigger a session, verify `summaries/` gets written
+8. `server/journal/linkRewrite.ts` + tests — `/wiki/foo.md` → `../../wiki/foo.md` post-processor
+9. `server/journal/index.ts` — `maybeRunJournal()` entry with lock, chains daily then optimization, supports `{ force: true }` for debug
+10. `server/routes/agent.ts` — call `maybeRunJournal()` in `finally` block (fire-and-forget)
+11. `server/index.ts` — honour `JOURNAL_FORCE_RUN_ON_STARTUP=1` for debug startup run
+12. `src/utils/path/relativeLink.ts` + tests — `isExternalHref`, `resolveWorkspaceLink`, `extractSessionIdFromPath`
+13. `src/components/FilesView.vue` — markdown link click handler, emits `loadSession` for chat jsonl targets
+14. `src/App.vue` — binds `@load-session` to a bridge that flips `canvasViewMode` out of `files` and calls existing `loadSession(id)`
+15. Run format / lint / typecheck / build / test
+16. Manual smoke: set `JOURNAL_FORCE_RUN_ON_STARTUP=1`, verify `summaries/` gets written; click a session link inside a summary and verify the sidebar chat switches
 
 ## Deferred / not in scope
 
@@ -277,10 +310,13 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 ## Test plan
 
 **Unit (automated):**
-- `paths.ts` — slugify edge cases (unicode, spaces, punctuation), daily path leap years, month boundary
+- `paths.ts` — slugify edge cases (unicode, spaces, punctuation), daily path leap years, month boundary, dailyPathFor input validation
 - `state.ts` — default state creation, corrupted JSON recovery, interval elapsed boundary, atomic write
 - `diff.ts` — no processed state (first run), session removed since last run, appended events (mtime bumped)
-- `indexFile.ts` — empty journal, 1 topic + 1 day, nested YYYY/MM structure, sort order
+- `indexFile.ts` — empty journal, 1 topic + 1 day, nested YYYY/MM structure, sort order, slug tie-break on equal timestamps
+- `linkRewrite.ts` — `/wiki/foo.md` → `../../wiki/foo.md`, external URL pass-through, `#fragment` preservation, edge cases
+- `relativeLink.ts` (frontend) — external href detection, workspace link resolution, session id extraction, `..`-escape rejection
+- `archivist.ts` — prompt building (with `ARTIFACTS REFERENCED` block), tolerant JSON extraction, output validation type guards
 
 **Integration (manual):**
 - Lower `dailyIntervalHours` to `0.01` in `_state.json`, trigger a session, verify journal files appear

--- a/plans/feat-auto-journal.md
+++ b/plans/feat-auto-journal.md
@@ -1,0 +1,259 @@
+# Feature: automatic workspace journal (daily + topic summaries)
+
+## Goal
+
+Automatically distill raw session logs (`workspace/chat/*.jsonl`) into categorised, browseable summaries that the user can skim later — without requiring any manual trigger or "please summarise this" ask.
+
+Two axes of organisation:
+
+- **By day** — `summaries/daily/YYYY/MM/DD.md`: what happened on each day across all sessions
+- **By topic** — `summaries/topics/<slug>.md`: long-running topic notes that accrete information as related sessions happen
+
+A top-level `summaries/_index.md` ties both together for quick navigation.
+
+The system is **fully automatic**:
+
+- No user action required to trigger summarisation
+- Runs at a configurable interval (default 24h for daily/topic updates, 7d for optimization)
+- Remembers what it has already processed and only touches new/changed sessions
+- Self-organising: topic taxonomy is discovered by the LLM from session content, not hand-configured
+- Self-optimising: a periodic pass merges near-duplicate topics and archives stale ones
+
+## Non-goals
+
+- Not a real-time streaming summariser — batch-only, lag of hours is fine
+- Not a search UI — filesystem is the UI; `grep` and the index file are how you navigate
+- Not multi-user — assumes a single-user workspace
+- Not cross-workspace — summaries stay inside the workspace they describe
+
+## Storage layout
+
+```
+workspace/
+  chat/                              # EXISTING — raw session logs
+    <sessionId>.jsonl                # append-only event log
+    <sessionId>.json                 # session metadata
+  memory.md                          # EXISTING — distilled facts loaded as context
+  summaries/                         # NEW
+    _index.md                        # top-level browseable index
+    _state.json                      # journal state (see schema below)
+    daily/
+      2026/
+        04/
+          11.md                      # summary for 2026-04-11
+    topics/
+      refactoring.md                 # long-running topic summary
+      video-generation.md
+      mulmocast.md
+    archive/
+      topics/
+        old-topic-name.md            # topics merged / archived by optimizer
+```
+
+### `_state.json` schema
+
+```ts
+interface JournalState {
+  version: 1;
+  // Timestamps of the last successful pass of each kind (ISO 8601).
+  lastDailyRunAt: string | null;
+  lastOptimizationRunAt: string | null;
+  // Intervals between passes. Stored in state so the user can edit
+  // them without rebuilding; defaults applied if absent.
+  dailyIntervalHours: number;           // default 24
+  optimizationIntervalDays: number;     // default 7
+  // Sessions whose jsonl has already been ingested, with the last
+  // mtime we saw, so we can detect appended events on resumed sessions.
+  processedSessions: Record<string, { lastMtimeMs: number }>;
+  // Rolling topic slugs known to the journal. The LLM reads these
+  // before classifying new sessions so it merges into existing topics
+  // rather than inventing near-duplicates.
+  knownTopics: string[];
+}
+```
+
+## Trigger model
+
+**Piggyback on existing session-end events** — the agent loop in `server/routes/agent.ts` already has a `finally { removeSession(); res.end(); }` block. Add a fire-and-forget call to `maybeRunJournal()` there.
+
+`maybeRunJournal()`:
+1. Read `_state.json` (create with defaults if absent)
+2. If `now - lastDailyRunAt < dailyIntervalHours * 3600e3`, **return** (not due)
+3. Otherwise acquire an in-process lock (flag-on-module) so concurrent sessions don't double-run
+4. Kick off `runDailyPass()` asynchronously; do not await from the request handler
+5. On completion, maybe chain `runOptimizationPass()` if due
+6. Release lock, write state
+
+Why not a `setInterval` timer?
+- MulmoClaude is idle most of the time; a timer wastes cycles and fires on empty workspaces
+- Running at session-end guarantees freshly-written jsonl is available
+- Users who don't touch MulmoClaude for a week don't want a 7-day-old summary generated the moment they open it — fine, they'll get it on the next session-end
+
+Why not trigger on startup?
+- Nice to have, but redundant with session-end. Possible Phase 1.5 if needed.
+
+## Daily pass — `runDailyPass()`
+
+1. **Discover new/changed sessions**: scan `chat/*.jsonl`, compare mtime against `processedSessions[sessionId].lastMtimeMs`. Collect a list of "dirty" sessions.
+2. **Group by day**: for each dirty session, bucket events by their `timestamp` into `YYYY-MM-DD` buckets. A single session resumed across midnight contributes to multiple days.
+3. **Read existing state**: for each affected day, read `daily/YYYY/MM/DD.md` if it exists. For topic updates, read `topics/<slug>.md` for any known topics the new content might touch.
+4. **Single LLM call per affected day** (keeps token cost predictable):
+   - Input: raw session excerpts for that day + existing day summary (if any) + current topic list
+   - Output: structured JSON — `{ dailySummaryMarkdown, topicUpdates: [{ slug, action: "create"|"append"|"rewrite", content }] }`
+5. **Apply updates**: write `daily/.../DD.md`, create/append/rewrite `topics/<slug>.md` per LLM instructions
+6. **Rebuild `_index.md`** from current filesystem state (no LLM needed — pure filesystem walk + sort)
+7. **Update `_state.json`**: bump `lastDailyRunAt`, update `processedSessions` mtimes, append any newly-created topic slugs to `knownTopics`
+
+### LLM prompt shape
+
+The archivist is a single `query()` call to the Claude Agent SDK (no MCP plugins, no tools — pure text in, structured text out). System prompt:
+
+> You are the journal archivist for this MulmoClaude workspace. Your job is to distill raw session logs into two artifacts:
+> (1) a daily summary capturing what happened on the given date, and
+> (2) updates to long-running topic notes.
+>
+> You receive: a list of session excerpts for a specific day, any existing daily summary for that day, and the current topic list.
+>
+> You return structured JSON with `dailySummaryMarkdown` and `topicUpdates[]`.
+> For each topic update, decide whether to `create`, `append`, or `rewrite`. Prefer `append` for incremental facts; use `rewrite` only if the existing topic has become incoherent.
+>
+> Match the language of the source session (Japanese stays Japanese, English stays English). Be terse — no filler.
+
+Response is parsed as JSON; on parse failure, skip the day and log the error (don't crash the journal).
+
+## Optimization pass — `runOptimizationPass()`
+
+Triggered when `now - lastOptimizationRunAt >= optimizationIntervalDays * 86400e3`.
+
+1. Read all `topics/*.md`
+2. Single LLM call with the full topic list:
+   - Input: slug + first ~500 chars of each topic
+   - Output: `{ merges: [{ from: [slugs], into: slug, newContent }], archives: [slug] }`
+3. Apply merges: write merged content into target, move sources to `archive/topics/`
+4. Apply archives: move to `archive/topics/`
+5. Rebuild `_index.md`
+6. Update `_state.json` (bump `lastOptimizationRunAt`, prune merged slugs from `knownTopics`)
+
+## `_index.md` format
+
+```markdown
+# Workspace Journal
+
+*Last updated: 2026-04-11T09:30:00Z*
+
+## Topics
+
+- [Refactoring](topics/refactoring.md) — 12 entries, last updated 2026-04-11
+- [Video generation](topics/video-generation.md) — 8 entries, last updated 2026-04-10
+- ...
+
+## Recent days
+
+- [2026-04-11](daily/2026/04/11.md)
+- [2026-04-10](daily/2026/04/10.md)
+- [2026-04-09](daily/2026/04/09.md)
+- ...
+
+## Archive
+
+- [Archived topics](archive/topics/) — 3 merged topics
+```
+
+Pure filesystem derivation — no LLM. Rebuilt at the end of every journal pass.
+
+## File layout (code)
+
+```
+server/
+  journal/
+    index.ts              # public entry: maybeRunJournal()
+    state.ts              # _state.json read/write + schema
+    dailyPass.ts          # runDailyPass implementation
+    optimizationPass.ts   # runOptimizationPass implementation
+    archivist.ts          # LLM call wrapper
+    indexFile.ts          # _index.md regeneration
+    paths.ts              # pure path helpers (daily path, topic path, slug)
+    diff.ts               # pure "what sessions changed since last run" logic
+```
+
+Hooked from:
+- `server/routes/agent.ts` — `finally` block calls `maybeRunJournal()` (fire-and-forget)
+
+## Testability
+
+All non-LLM logic is extracted into pure functions and lives in files designed to be unit-tested:
+
+- `paths.ts` — `dailyPathFor(date)`, `topicPathFor(slug)`, `slugify(topicName)`
+- `diff.ts` — `findDirtySessions(currentMeta, processedState)` takes in-memory data, returns the dirty list
+- `state.ts` — `defaultState()`, parse/validate round-trip, `isDailyDue(state, now)`, `isOptimizationDue(state, now)`
+- `indexFile.ts` — `buildIndexMarkdown(dirListing, lastUpdatedIso)` pure string builder
+
+The LLM wrapper `archivist.ts` takes an injected `summarize: (prompt) => Promise<string>` so tests can pass a fake. The default exports a real Claude Agent SDK call.
+
+Test files:
+```
+test/journal/
+  test_paths.ts
+  test_diff.ts
+  test_state.ts
+  test_indexFile.ts
+```
+
+At minimum each file covers: happy path, empty case, boundary case (interval exactly elapsed), invalid state file (should recover with defaults).
+
+## Risks & mitigations
+
+- **Token cost** — default interval is 24h so worst case is 1 LLM call per day per active workspace. Grouping by day in a single call keeps the ceiling at O(days_touched), not O(sessions). Mitigation: configurable interval in `_state.json`; user can raise it to 72h or lower to 6h.
+- **Concurrent runs** — two sessions ending simultaneously could race. Mitigation: in-process module-level lock flag (`running: boolean`). Good enough for single-user single-instance MulmoClaude.
+- **Partial writes on crash** — write `_state.json` atomically (write to `_state.json.tmp`, rename). Per-topic/per-day file writes are idempotent because the dirty-session detection re-ingests on next run until `_state.json` is persisted.
+- **Runaway topic creation** — LLM invents a new topic for every session. Mitigation: system prompt instructs "prefer existing topics; create new only when no existing topic fits". Optimization pass merges duplicates as a safety net.
+- **Clock skew** — `lastDailyRunAt` is local wall-clock. If the user travels timezones, daily buckets could shift. Accept this — it's a personal workspace, not a distributed system.
+- **Non-JSON response from LLM** — parse failures are caught per-day; the day is skipped and the next pass retries. Logged to console for debugging.
+- **Sessions in progress** — if a session is still active (agent running) when `maybeRunJournal()` fires, its jsonl may be mid-write. Mitigation: skip sessions whose id is in the live registry (`registerSession` in `server/sessions.ts` tracks active ones).
+
+## Implementation order
+
+**Phase 1 — Daily + topic passes + index + hook (this PR):**
+
+1. `server/journal/paths.ts` + tests
+2. `server/journal/state.ts` + tests (including atomic write)
+3. `server/journal/diff.ts` + tests
+4. `server/journal/indexFile.ts` + tests
+5. `server/journal/archivist.ts` — LLM wrapper with injectable `summarize`
+6. `server/journal/dailyPass.ts` — ties the above together
+7. `server/journal/index.ts` — `maybeRunJournal()` entry with lock
+8. `server/routes/agent.ts` — call `maybeRunJournal()` in `finally` block (fire-and-forget)
+9. Run format / lint / typecheck / build / test
+10. Manual smoke: trigger a session, verify `summaries/` gets written on the next session-end after the 24h default (or lower the interval in `_state.json` first for testing)
+
+**Phase 2 — Optimization pass (separate PR):**
+
+11. `server/journal/optimizationPass.ts` + tests for classification logic
+12. Chain from `maybeRunJournal` after the daily pass
+
+## Deferred / not in scope
+
+- **Memory.md integration** — `memory.md` is a separate existing concept (distilled facts loaded as context). We leave it alone for now. A future pass could cross-link, e.g. "this topic mentions the fact in memory.md:L23", but it's orthogonal.
+- **Retroactive ingest** — on first run, every historical session gets ingested. That's a one-time cost but could be expensive for long-running workspaces. If it becomes a problem, add a `--since` cli flag. Not blocking.
+- **Topic pinning / manual tagging** — user might want to mark a topic as "do not archive". Phase 3 idea.
+- **UI for browsing summaries** — filesystem is the UI in MulmoClaude's philosophy. Any UI would be Phase 3.
+
+## Test plan
+
+**Unit (automated):**
+- `paths.ts` — slugify edge cases (unicode, spaces, punctuation), daily path leap years, month boundary
+- `state.ts` — default state creation, corrupted JSON recovery, interval elapsed boundary, atomic write
+- `diff.ts` — no processed state (first run), session removed since last run, appended events (mtime bumped)
+- `indexFile.ts` — empty journal, 1 topic + 1 day, nested YYYY/MM structure, sort order
+
+**Integration (manual):**
+- Lower `dailyIntervalHours` to `0.01` in `_state.json`, trigger a session, verify journal files appear
+- Delete `summaries/_state.json`, verify next run recreates it and ingests all sessions
+- Corrupt `summaries/_state.json` (invalid JSON), verify the pass falls back to defaults and logs an error
+- Two concurrent session-end events: verify only one pass actually runs (lock holds)
+
+**LLM integration (manual, requires API key):**
+- Run one real pass, eyeball the resulting `daily/*.md` and `topics/*.md` for quality
+- Confirm language preservation (Japanese session → Japanese summary)
+
+No new golden tests — the LLM output is non-deterministic and not golden-testable. Non-LLM logic is covered by unit tests.

--- a/plans/feat-auto-journal.md
+++ b/plans/feat-auto-journal.md
@@ -14,10 +14,11 @@ A top-level `summaries/_index.md` ties both together for quick navigation.
 The system is **fully automatic**:
 
 - No user action required to trigger summarisation
-- Runs at a configurable interval (default 24h for daily/topic updates, 7d for optimization)
+- Runs at a configurable interval (default 1h for daily/topic updates, 7d for optimization)
 - Remembers what it has already processed and only touches new/changed sessions
 - Self-organising: topic taxonomy is discovered by the LLM from session content, not hand-configured
 - Self-optimising: a periodic pass merges near-duplicate topics and archives stale ones
+- Uses the user's `claude` CLI subprocess (not the Claude Agent SDK), so summarisation draws from the user's Claude subscription quota rather than API tokens
 
 ## Non-goals
 
@@ -60,7 +61,7 @@ interface JournalState {
   lastOptimizationRunAt: string | null;
   // Intervals between passes. Stored in state so the user can edit
   // them without rebuilding; defaults applied if absent.
-  dailyIntervalHours: number;           // default 24
+  dailyIntervalHours: number;           // default 1
   optimizationIntervalDays: number;     // default 7
   // Sessions whose jsonl has already been ingested, with the last
   // mtime we saw, so we can detect appended events on resumed sessions.
@@ -104,9 +105,47 @@ Why not trigger on startup?
 6. **Rebuild `_index.md`** from current filesystem state (no LLM needed — pure filesystem walk + sort)
 7. **Update `_state.json`**: bump `lastDailyRunAt`, update `processedSessions` mtimes, append any newly-created topic slugs to `knownTopics`
 
-### LLM prompt shape
+### LLM invocation — `claude` CLI subprocess
 
-The archivist is a single `query()` call to the Claude Agent SDK (no MCP plugins, no tools — pure text in, structured text out). System prompt:
+Rather than calling the Claude Agent SDK (which bills through the API key and burns tokens per-run), the archivist shells out to the user's **`claude` CLI binary**. That routes through the user's Claude subscription quota instead, which is effectively free for this kind of background batch work.
+
+```ts
+// Simplified shape. Real code adds timeouts and stderr handling.
+import { spawn } from "node:child_process";
+
+async function runClaudeCli(systemPrompt: string, userPrompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("claude", ["-p", "--output-format", "text"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d.toString()));
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`claude exited ${code}: ${stderr}`));
+    });
+    // Send the full archivist prompt via stdin so we don't hit
+    // shell argv length limits for large day excerpts.
+    child.stdin.write(`${systemPrompt}\n\n---\n\n${userPrompt}`);
+    child.stdin.end();
+  });
+}
+```
+
+Constraints and caveats the wrapper must handle:
+
+- **Timeout** — spawn gets a 5-minute wall-clock timeout per invocation. On timeout, kill the child and fail the day (next pass retries).
+- **`claude` not on PATH** — on `ENOENT`, log a clear one-liner and disable the journal for the current server lifetime (do not keep retrying on every session-end).
+- **Not authenticated / quota exhausted** — surfaces as a non-zero exit with a stderr message; log it and skip the day, retry next pass.
+- **stdin piping** — the archivist prompt can include thousands of lines of jsonl excerpts; passing via argv would blow past OS arg limits. Always use stdin.
+- **Structured output** — ask the prompt to emit a JSON code fence; parse with a tolerant extractor (`/```json\n([\s\S]*?)\n```/`) and fall back to scanning for the first `{` ... balanced `}` if the fence is missing.
+
+### Prompt shape
+
+The archivist runs with no MCP plugins, no tools — pure text in, structured text out. System prompt:
 
 > You are the journal archivist for this MulmoClaude workspace. Your job is to distill raw session logs into two artifacts:
 > (1) a daily summary capturing what happened on the given date, and
@@ -119,7 +158,7 @@ The archivist is a single `query()` call to the Claude Agent SDK (no MCP plugins
 >
 > Match the language of the source session (Japanese stays Japanese, English stays English). Be terse — no filler.
 
-Response is parsed as JSON; on parse failure, skip the day and log the error (don't crash the journal).
+Response is parsed as JSON; on parse failure, skip the day and log the error (don't crash the journal). All subprocess failure modes (ENOENT, timeout, non-zero exit, auth error) are caught inside `archivist.ts` and converted into logged warnings — the journal module never throws into the agent route's `finally` block.
 
 ## Optimization pass — `runOptimizationPass()`
 
@@ -188,7 +227,7 @@ All non-LLM logic is extracted into pure functions and lives in files designed t
 - `state.ts` — `defaultState()`, parse/validate round-trip, `isDailyDue(state, now)`, `isOptimizationDue(state, now)`
 - `indexFile.ts` — `buildIndexMarkdown(dirListing, lastUpdatedIso)` pure string builder
 
-The LLM wrapper `archivist.ts` takes an injected `summarize: (prompt) => Promise<string>` so tests can pass a fake. The default exports a real Claude Agent SDK call.
+The LLM wrapper `archivist.ts` takes an injected `summarize: (systemPrompt, userPrompt) => Promise<string>` so tests can pass a fake. The default exports `runClaudeCli` which shells out to the `claude` binary. Tests never spawn a subprocess; they supply a deterministic fake that returns canned JSON.
 
 Test files:
 ```
@@ -203,7 +242,8 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 
 ## Risks & mitigations
 
-- **Token cost** — default interval is 24h so worst case is 1 LLM call per day per active workspace. Grouping by day in a single call keeps the ceiling at O(days_touched), not O(sessions). Mitigation: configurable interval in `_state.json`; user can raise it to 72h or lower to 6h.
+- **Token cost** — mitigated by routing through the `claude` CLI (subscription quota) instead of the API SDK. Default interval is 1h so a heavily-used workspace triggers ~24 passes per day worst case, but each pass only invokes the CLI if sessions have actually changed since the last run. Grouping by day keeps the per-pass cost at O(days_touched), not O(sessions). User can raise `dailyIntervalHours` in `_state.json` if they want even less chatter.
+- **`claude` CLI dependency** — the feature silently disables itself (with a single warning log) if the `claude` binary isn't installed or authenticated. Existing MulmoClaude functionality is unaffected.
 - **Concurrent runs** — two sessions ending simultaneously could race. Mitigation: in-process module-level lock flag (`running: boolean`). Good enough for single-user single-instance MulmoClaude.
 - **Partial writes on crash** — write `_state.json` atomically (write to `_state.json.tmp`, rename). Per-topic/per-day file writes are idempotent because the dirty-session detection re-ingests on next run until `_state.json` is persisted.
 - **Runaway topic creation** — LLM invents a new topic for every session. Mitigation: system prompt instructs "prefer existing topics; create new only when no existing topic fits". Optimization pass merges duplicates as a safety net.
@@ -213,23 +253,19 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 
 ## Implementation order
 
-**Phase 1 — Daily + topic passes + index + hook (this PR):**
+**All in this PR** — Phase 1 (daily + topic) and Phase 2 (optimization) ship together:
 
 1. `server/journal/paths.ts` + tests
 2. `server/journal/state.ts` + tests (including atomic write)
 3. `server/journal/diff.ts` + tests
 4. `server/journal/indexFile.ts` + tests
-5. `server/journal/archivist.ts` — LLM wrapper with injectable `summarize`
-6. `server/journal/dailyPass.ts` — ties the above together
-7. `server/journal/index.ts` — `maybeRunJournal()` entry with lock
-8. `server/routes/agent.ts` — call `maybeRunJournal()` in `finally` block (fire-and-forget)
-9. Run format / lint / typecheck / build / test
-10. Manual smoke: trigger a session, verify `summaries/` gets written on the next session-end after the 24h default (or lower the interval in `_state.json` first for testing)
-
-**Phase 2 — Optimization pass (separate PR):**
-
-11. `server/journal/optimizationPass.ts` + tests for classification logic
-12. Chain from `maybeRunJournal` after the daily pass
+5. `server/journal/archivist.ts` — `claude` CLI subprocess wrapper with injectable `summarize`
+6. `server/journal/dailyPass.ts` — ties the above together for daily + topic updates
+7. `server/journal/optimizationPass.ts` + tests for classification logic
+8. `server/journal/index.ts` — `maybeRunJournal()` entry with lock, chains daily then optimization
+9. `server/routes/agent.ts` — call `maybeRunJournal()` in `finally` block (fire-and-forget)
+10. Run format / lint / typecheck / build / test
+11. Manual smoke: lower `dailyIntervalHours` to near-zero in `_state.json`, trigger a session, verify `summaries/` gets written
 
 ## Deferred / not in scope
 
@@ -252,8 +288,9 @@ At minimum each file covers: happy path, empty case, boundary case (interval exa
 - Corrupt `summaries/_state.json` (invalid JSON), verify the pass falls back to defaults and logs an error
 - Two concurrent session-end events: verify only one pass actually runs (lock holds)
 
-**LLM integration (manual, requires API key):**
+**LLM integration (manual, requires `claude` CLI installed and authenticated):**
 - Run one real pass, eyeball the resulting `daily/*.md` and `topics/*.md` for quality
 - Confirm language preservation (Japanese session → Japanese summary)
+- Confirm the feature silently no-ops (with one warning log) if `claude` is missing from PATH
 
 No new golden tests — the LLM output is non-deterministic and not golden-testable. Non-LLM logic is covered by unit tests.

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import { initWorkspace } from "./workspace.js";
 import fs from "fs";
 import os from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./docker.js";
+import { maybeRunJournal } from "./journal/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -160,5 +161,15 @@ function isPortFree(port: number): Promise<boolean> {
 
   app.listen(PORT, "0.0.0.0", () => {
     console.log(`Server running on port ${PORT}`);
+    // Debug switch: set JOURNAL_FORCE_RUN_ON_STARTUP=1 to run a full
+    // journal pass immediately without waiting for a session end or
+    // the hourly interval. Fire-and-forget — journal errors never
+    // propagate out of maybeRunJournal.
+    if (process.env.JOURNAL_FORCE_RUN_ON_STARTUP === "1") {
+      console.log("[journal] JOURNAL_FORCE_RUN_ON_STARTUP=1 — running now");
+      maybeRunJournal({ force: true }).catch((err) => {
+        console.warn("[journal] forced startup run failed:", err);
+      });
+    }
   });
 })();

--- a/server/journal/archivist.ts
+++ b/server/journal/archivist.ts
@@ -105,10 +105,28 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
       }
     });
 
-    // Write everything in one shot, then close stdin so the CLI
-    // knows input is complete.
-    child.stdin.write(`${systemPrompt}\n\n---\n\n${userPrompt}`);
-    child.stdin.end();
+    // Surface stdin write errors (e.g. EPIPE if the child exited
+    // before we finished writing) instead of silently dropping them.
+    child.stdin.on("error", (err: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    // Send the full prompt in one write. If Node's stream layer
+    // signals backpressure (write returns false), wait for "drain"
+    // before calling end() so we don't close stdin while the buffer
+    // still has data to flush. For typical archivist prompts this
+    // path rarely fires, but very large session excerpts can reach
+    // it.
+    const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
+    const flushed = child.stdin.write(payload);
+    if (flushed) {
+      child.stdin.end();
+    } else {
+      child.stdin.once("drain", () => child.stdin.end());
+    }
   });
 };
 

--- a/server/journal/archivist.ts
+++ b/server/journal/archivist.ts
@@ -218,6 +218,12 @@ ARTIFACT LINKS
 - The post-processor converts these to true relative paths before writing the file to disk, so don't do the relative-path math yourself.
 - Only link to artifacts listed in "ARTIFACTS REFERENCED". Don't invent paths.
 
+SESSION LINKS
+- When your summary refers to a specific session (the ones listed under "SESSION EXCERPTS" with their \`session <id>\` header), link to that session using \`/chat/<sessionId>.jsonl\`.
+  - Example: "— discussed in [session 550e8400](/chat/550e8400-e29b-41d4-a716-446655440000.jsonl)"
+- The file viewer recognises this pattern and switches the sidebar chat to that session when the link is clicked, so the reader can pick up where the session left off.
+- You do not have to link every session you mention, but linking at least the first reference per session is helpful.
+
 LANGUAGE
 - Match the language of the source sessions. Always.`;
 

--- a/server/journal/archivist.ts
+++ b/server/journal/archivist.ts
@@ -1,0 +1,412 @@
+// Thin wrapper around the Claude Code CLI used as the journal's
+// summarizer. The default `runClaudeCli` spawns `claude -p` as a
+// subprocess so summarization draws from the user's subscription
+// quota rather than the API key budget.
+//
+// The rest of the journal module receives a `Summarize` function
+// via dependency injection — tests supply a deterministic fake, the
+// production path supplies `runClaudeCli`.
+
+import { spawn } from "node:child_process";
+
+// (systemPrompt, userPrompt) → raw model output as a string.
+// The daily/optimization passes parse JSON out of the string
+// themselves; this layer stays transport-only.
+export type Summarize = (
+  systemPrompt: string,
+  userPrompt: string,
+) => Promise<string>;
+
+// Wall-clock cap per CLI invocation. 5 minutes is comfortably above
+// the worst-case summarization run we've seen and still short enough
+// that a wedged subprocess doesn't tie up resources forever.
+const CLI_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Sentinel we throw on ENOENT so maybeRunJournal can disable the
+// feature for the rest of the server lifetime instead of retrying
+// on every session-end.
+export class ClaudeCliNotFoundError extends Error {
+  constructor() {
+    super("[journal] `claude` CLI is not available on PATH — journal disabled");
+    this.name = "ClaudeCliNotFoundError";
+  }
+}
+
+export class ClaudeCliFailedError extends Error {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  constructor(exitCode: number | null, stderr: string) {
+    super(
+      `[journal] \`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(
+        0,
+        500,
+      )}`,
+    );
+    this.name = "ClaudeCliFailedError";
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+// Default summarizer. Spawns `claude -p` and pipes the combined
+// system + user prompt to stdin so we don't hit shell-argv limits
+// for large day excerpts.
+export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
+  return new Promise((resolve, reject) => {
+    const child = spawn("claude", ["-p", "--output-format", "text"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, CLI_TIMEOUT_MS);
+
+    child.stdout.on("data", (d: Buffer) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    child.on("error", (err: Error & { code?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (err.code === "ENOENT") {
+        reject(new ClaudeCliNotFoundError());
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(
+          new ClaudeCliFailedError(
+            null,
+            `timed out after ${CLI_TIMEOUT_MS}ms\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new ClaudeCliFailedError(code, stderr));
+      }
+    });
+
+    // Write everything in one shot, then close stdin so the CLI
+    // knows input is complete.
+    child.stdin.write(`${systemPrompt}\n\n---\n\n${userPrompt}`);
+    child.stdin.end();
+  });
+};
+
+// --- Daily archivist contract ---------------------------------------
+
+export interface SessionEventExcerpt {
+  source: string; // "user" | "assistant" | "tool" | ...
+  type: string; // "text" | "tool_result" | ...
+  // One-line human-readable rendering of the event, already
+  // truncated to a sane length by the caller.
+  content: string;
+}
+
+export interface SessionExcerpt {
+  sessionId: string;
+  roleId: string;
+  events: SessionEventExcerpt[];
+}
+
+export interface ExistingTopicSnapshot {
+  slug: string;
+  content: string;
+}
+
+export interface DailyArchivistInput {
+  date: string; // YYYY-MM-DD
+  existingDailySummary: string | null;
+  existingTopicSummaries: ExistingTopicSnapshot[];
+  sessionExcerpts: SessionExcerpt[];
+}
+
+export type TopicUpdateAction = "create" | "append" | "rewrite";
+
+export interface TopicUpdate {
+  slug: string;
+  action: TopicUpdateAction;
+  content: string;
+}
+
+export interface DailyArchivistOutput {
+  dailySummaryMarkdown: string;
+  topicUpdates: TopicUpdate[];
+}
+
+// System prompt for the daily pass. Written long-form because the
+// model does a much better job with explicit rules and an example
+// than with a terse instruction.
+export const DAILY_SYSTEM_PROMPT = `You are the journal archivist for a personal MulmoClaude workspace.
+Your job: given raw session excerpts for a single day, produce
+(1) a daily summary and (2) updates to long-running topic notes.
+
+OUTPUT FORMAT
+You must emit a single JSON object wrapped in a \`\`\`json code fence.
+Schema:
+{
+  "dailySummaryMarkdown": "...",
+  "topicUpdates": [
+    { "slug": "kebab-case-slug", "action": "create" | "append" | "rewrite", "content": "..." }
+  ]
+}
+No prose outside the fence. No extra keys.
+
+DAILY SUMMARY RULES
+- Write in the same language as the source sessions. Japanese stays Japanese. English stays English.
+- Start with a top-level \`# <date>\` heading using the date passed in.
+- Use short bullet sections per theme or per session, not a prose wall.
+- If an existing daily summary was provided, treat it as a prior draft to REWRITE, not append to — your output replaces it entirely.
+- Be terse. Facts and decisions only, no filler.
+
+TOPIC UPDATE RULES
+- Prefer the existing topic list. Only invent a new slug if nothing fits.
+- Slugs are lowercase kebab-case ASCII (e.g. "video-generation"). No spaces, no unicode.
+- Use \`append\` for incremental facts: your content will be concatenated to the existing topic file after a blank line.
+- Use \`create\` only when the slug is new.
+- Use \`rewrite\` sparingly — only when the existing topic has become incoherent and needs a full replacement.
+- If a session has no clear topical hook, emit zero topic updates rather than forcing one.
+
+LANGUAGE
+- Match the language of the source sessions. Always.`;
+
+// Build the user-side prompt for one day's worth of content.
+// Pure string construction — safe to unit test if we ever want to.
+export function buildDailyUserPrompt(input: DailyArchivistInput): string {
+  const parts: string[] = [];
+  parts.push(`DATE: ${input.date}`);
+  parts.push("");
+
+  if (input.existingDailySummary !== null) {
+    parts.push("EXISTING DAILY SUMMARY (replace this with your new version):");
+    parts.push("```md");
+    parts.push(input.existingDailySummary);
+    parts.push("```");
+    parts.push("");
+  }
+
+  parts.push("EXISTING TOPICS:");
+  if (input.existingTopicSummaries.length === 0) {
+    parts.push("(none yet)");
+  } else {
+    for (const t of input.existingTopicSummaries) {
+      parts.push(`- ${t.slug}`);
+    }
+  }
+  parts.push("");
+
+  parts.push("SESSION EXCERPTS:");
+  for (const s of input.sessionExcerpts) {
+    parts.push(`### session ${s.sessionId} (role: ${s.roleId})`);
+    for (const e of s.events) {
+      parts.push(`- [${e.source}/${e.type}] ${e.content}`);
+    }
+    parts.push("");
+  }
+
+  parts.push("Produce the JSON described in the system prompt now.");
+  return parts.join("\n");
+}
+
+// --- Optimization archivist contract --------------------------------
+
+export interface OptimizationTopicSnapshot {
+  slug: string;
+  // First ~500 chars of the topic file, enough for the model to
+  // judge similarity without blowing up prompt size.
+  headContent: string;
+}
+
+export interface OptimizationInput {
+  topics: OptimizationTopicSnapshot[];
+}
+
+export interface TopicMerge {
+  from: string[];
+  into: string;
+  newContent: string;
+}
+
+export interface OptimizationOutput {
+  merges: TopicMerge[];
+  archives: string[];
+}
+
+export const OPTIMIZATION_SYSTEM_PROMPT = `You are the journal optimizer for a personal MulmoClaude workspace.
+Your job: review the current topic list and decide which topics should be merged together and which should be archived.
+
+OUTPUT FORMAT
+A single JSON object wrapped in a \`\`\`json code fence:
+{
+  "merges": [
+    { "from": ["slug-a", "slug-b"], "into": "merged-slug", "newContent": "..." }
+  ],
+  "archives": ["stale-slug"]
+}
+No prose outside the fence.
+
+MERGE RULES
+- Only merge topics that are clearly duplicates or near-duplicates (e.g. "video-gen" and "video-generation").
+- "into" may be one of the "from" slugs (keeping an existing file) or a brand-new slug (creating a new file).
+- "newContent" is the full replacement body for the target file, in markdown.
+- Be conservative: if in doubt, leave things alone.
+
+ARCHIVE RULES
+- Archive only topics that look stale AND uninteresting. Err on the side of keeping things.
+- Do not archive a topic you also listed in a merge's "from" — the merge already moves it.
+
+LANGUAGE
+- Match the language of the source content for "newContent".
+- If no changes are needed, return \`{ "merges": [], "archives": [] }\`. That is a valid and expected outcome.`;
+
+export function buildOptimizationUserPrompt(input: OptimizationInput): string {
+  const parts: string[] = [];
+  parts.push("CURRENT TOPICS:");
+  for (const t of input.topics) {
+    parts.push(`### ${t.slug}`);
+    parts.push("```md");
+    parts.push(t.headContent);
+    parts.push("```");
+    parts.push("");
+  }
+  parts.push("Produce the JSON described in the system prompt now.");
+  return parts.join("\n");
+}
+
+// --- JSON extraction ------------------------------------------------
+
+// Tolerant JSON extractor: prefers a ```json fenced block; falls back
+// to scanning for the first balanced `{ ... }` block. Returns `null`
+// on failure so callers can log-and-skip instead of crash.
+//
+// The fenced-block path is written with indexOf rather than a regex
+// to avoid sonarjs/slow-regex; the balanced-brace path uses a single
+// pass with character-level state tracking.
+export function extractJsonObject(raw: string): unknown | null {
+  // 1. Fenced block — locate with indexOf, no regex backtracking risk.
+  const fencedBody = findFencedJsonBody(raw);
+  if (fencedBody !== null) {
+    try {
+      return JSON.parse(fencedBody);
+    } catch {
+      // fall through to scan
+    }
+  }
+  // 2. First balanced `{...}` block
+  const start = raw.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(raw.slice(start, i + 1));
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// Pull the body out of a ```json ... ``` fenced block using indexOf
+// only — no regex so we don't need to worry about backtracking.
+// Returns null if no complete fence pair is present.
+function findFencedJsonBody(raw: string): string | null {
+  const OPEN = "```json";
+  const CLOSE = "```";
+  const openIdx = raw.indexOf(OPEN);
+  if (openIdx === -1) return null;
+  // Body starts after the first newline following the opener so we
+  // skip any trailing whitespace on the opening line.
+  const afterOpen = openIdx + OPEN.length;
+  const bodyStart = raw.indexOf("\n", afterOpen);
+  if (bodyStart === -1) return null;
+  const closeIdx = raw.indexOf(CLOSE, bodyStart + 1);
+  if (closeIdx === -1) return null;
+  // Strip the newline immediately before the closing fence if
+  // present so JSON.parse doesn't see a trailing blank.
+  const bodyEnd = raw[closeIdx - 1] === "\n" ? closeIdx - 1 : closeIdx;
+  return raw.slice(bodyStart + 1, bodyEnd);
+}
+
+// Type guards used by callers to validate parsed output. Written as
+// guards rather than `as` casts per project conventions.
+export function isDailyArchivistOutput(
+  value: unknown,
+): value is DailyArchivistOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.dailySummaryMarkdown !== "string") return false;
+  if (!Array.isArray(v.topicUpdates)) return false;
+  return v.topicUpdates.every(isTopicUpdate);
+}
+
+function isTopicUpdate(value: unknown): value is TopicUpdate {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.slug !== "string") return false;
+  if (typeof v.content !== "string") return false;
+  return (
+    v.action === "create" || v.action === "append" || v.action === "rewrite"
+  );
+}
+
+export function isOptimizationOutput(
+  value: unknown,
+): value is OptimizationOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (!Array.isArray(v.merges)) return false;
+  if (!Array.isArray(v.archives)) return false;
+  if (!v.merges.every(isTopicMerge)) return false;
+  return v.archives.every((a: unknown) => typeof a === "string");
+}
+
+function isTopicMerge(value: unknown): value is TopicMerge {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (!Array.isArray(v.from)) return false;
+  if (!v.from.every((f: unknown) => typeof f === "string")) return false;
+  if (typeof v.into !== "string") return false;
+  if (typeof v.newContent !== "string") return false;
+  return true;
+}

--- a/server/journal/archivist.ts
+++ b/server/journal/archivist.ts
@@ -126,6 +126,11 @@ export interface SessionExcerpt {
   sessionId: string;
   roleId: string;
   events: SessionEventExcerpt[];
+  // Workspace-relative file paths produced by the session's tool
+  // calls (e.g. "stories/foo.json", "HTMLs/bar.html",
+  // "wiki/pages/baz.md"). Surfaced so the archivist can emit
+  // navigable markdown links to them in the summaries.
+  artifactPaths: string[];
 }
 
 export interface ExistingTopicSnapshot {
@@ -186,6 +191,15 @@ TOPIC UPDATE RULES
 - Use \`rewrite\` sparingly — only when the existing topic has become incoherent and needs a full replacement.
 - If a session has no clear topical hook, emit zero topic updates rather than forcing one.
 
+ARTIFACT LINKS
+- The prompt may list "ARTIFACTS REFERENCED" — workspace-relative paths produced by the day's sessions (e.g. \`stories/foo.json\`, \`wiki/pages/bar.md\`, \`HTMLs/baz.html\`).
+- When your summary mentions one of those artifacts, embed a markdown link to it using a **workspace-absolute path** beginning with a single forward slash.
+  - Correct:   \`[wiki page on X](/wiki/pages/x.md)\`
+  - Wrong:     \`[wiki page](wiki/pages/x.md)\` (missing leading slash)
+  - Wrong:     \`[wiki page](/home/user/.../x.md)\` (filesystem absolute)
+- The post-processor converts these to true relative paths before writing the file to disk, so don't do the relative-path math yourself.
+- Only link to artifacts listed in "ARTIFACTS REFERENCED". Don't invent paths.
+
 LANGUAGE
 - Match the language of the source sessions. Always.`;
 
@@ -210,6 +224,23 @@ export function buildDailyUserPrompt(input: DailyArchivistInput): string {
   } else {
     for (const t of input.existingTopicSummaries) {
       parts.push(`- ${t.slug}`);
+    }
+  }
+  parts.push("");
+
+  // Union of all workspace-relative artifact paths the day's
+  // sessions produced, deduped and sorted. Given to the archivist
+  // so it can link to them from the summary text.
+  const allArtifacts = new Set<string>();
+  for (const s of input.sessionExcerpts) {
+    for (const p of s.artifactPaths) allArtifacts.add(p);
+  }
+  parts.push("ARTIFACTS REFERENCED:");
+  if (allArtifacts.size === 0) {
+    parts.push("(none)");
+  } else {
+    for (const p of [...allArtifacts].sort()) {
+      parts.push(`- ${p}`);
     }
   }
   parts.push("");

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -214,8 +214,19 @@ export async function runDailyPass(
     }
   }
 
-  // Mark all dirty sessions as processed (with their observed mtime).
+  // Only mark a dirty session as processed if none of the days it
+  // contributed to were skipped. A session whose day we failed to
+  // summarize must stay "dirty" so the next pass retries it —
+  // otherwise a transient LLM failure would permanently hide those
+  // events from the journal.
+  const skippedSessionIds = new Set<string>();
+  for (const skip of result.skipped) {
+    const bucket = dayBuckets.get(skip.date);
+    if (!bucket) continue;
+    for (const excerpt of bucket) skippedSessionIds.add(excerpt.sessionId);
+  }
   const justProcessed: SessionFileMeta[] = dirty
+    .filter((id) => !skippedSessionIds.has(id))
     .map((id) => dirtyMetaById.get(id))
     .filter((m): m is SessionFileMeta => m !== undefined);
   result.sessionsIngested = justProcessed.map((m) => m.id);
@@ -352,7 +363,14 @@ export function entryToExcerpt(
     };
   }
   // tool_result entries: {source: "tool", type: "tool_result", result: {toolName, message, ...}}
-  if (type === "tool_result" && typeof entry.result === "object") {
+  // `typeof null === "object"` so we must explicitly reject null
+  // to avoid a NullPointerException-style crash when accessing
+  // r.toolName below.
+  if (
+    type === "tool_result" &&
+    typeof entry.result === "object" &&
+    entry.result !== null
+  ) {
     const r = entry.result as Record<string, unknown>;
     const toolName = typeof r.toolName === "string" ? r.toolName : "tool";
     const label =

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -1,0 +1,421 @@
+// The daily pass: walk chat/*.jsonl, find sessions changed since
+// the last run, bucket events by local-date, call the archivist
+// once per affected day, and apply its output (write daily/*.md,
+// create/append/rewrite topics/*.md).
+//
+// This file is the only one in the journal module that combines
+// filesystem side-effects with LLM calls. Pure bits (event parsing,
+// bucketing) are factored into small exported helpers so tests can
+// exercise them without touching disk.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import {
+  type Summarize,
+  type SessionExcerpt,
+  type SessionEventExcerpt,
+  type ExistingTopicSnapshot,
+  type DailyArchivistInput,
+  type TopicUpdate,
+  DAILY_SYSTEM_PROMPT,
+  buildDailyUserPrompt,
+  extractJsonObject,
+  isDailyArchivistOutput,
+  ClaudeCliNotFoundError,
+} from "./archivist.js";
+import {
+  summariesRoot,
+  dailyPathFor,
+  topicPathFor,
+  toIsoDate,
+  slugify,
+  TOPICS_DIR,
+} from "./paths.js";
+import {
+  findDirtySessions,
+  applyProcessed,
+  type SessionFileMeta,
+} from "./diff.js";
+import type { JournalState } from "./state.js";
+
+// --- Constants ------------------------------------------------------
+
+// Per-event content is truncated before handing to the archivist so
+// an accidentally huge tool result (e.g. base64 image data) doesn't
+// blow past the CLI's context window.
+const MAX_EVENT_CONTENT_CHARS = 600;
+
+// Hard cap on events per session included in the prompt. Sessions
+// with thousands of events get their head kept — the archivist can
+// generally get the gist from the opening.
+const MAX_EVENTS_PER_SESSION = 80;
+
+// --- Public entry ---------------------------------------------------
+
+export interface DailyPassDeps {
+  workspaceRoot?: string;
+  summarize: Summarize;
+  // Active session ids to skip (mid-write). Caller passes the
+  // live session registry to avoid ingesting jsonl files that the
+  // agent is still appending to.
+  activeSessionIds: ReadonlySet<string>;
+}
+
+export interface DailyPassResult {
+  daysTouched: string[]; // YYYY-MM-DD values actually written
+  sessionsIngested: string[];
+  topicsCreated: string[];
+  topicsUpdated: string[];
+  skipped: Array<{ date: string; reason: string }>;
+}
+
+export async function runDailyPass(
+  state: JournalState,
+  deps: DailyPassDeps,
+): Promise<{ nextState: JournalState; result: DailyPassResult }> {
+  const workspaceRoot = deps.workspaceRoot ?? defaultWorkspacePath;
+  const chatDir = path.join(workspaceRoot, "chat");
+  const result: DailyPassResult = {
+    daysTouched: [],
+    sessionsIngested: [],
+    topicsCreated: [],
+    topicsUpdated: [],
+    skipped: [],
+  };
+
+  const currentMetas = await listSessionMetas(chatDir);
+  // Skip sessions the agent is currently writing to.
+  const eligible = currentMetas.filter((m) => !deps.activeSessionIds.has(m.id));
+
+  const { dirty } = findDirtySessions(eligible, state.processedSessions);
+  if (dirty.length === 0) {
+    return { nextState: { ...state }, result };
+  }
+
+  // Load the dirty sessions and bucket every event by its local date.
+  const dayBuckets = new Map<string, SessionExcerpt[]>();
+  const dirtyMetaById = new Map(eligible.map((m) => [m.id, m]));
+
+  for (const sessionId of dirty) {
+    try {
+      const excerpts = await loadSessionExcerptsByDate(chatDir, sessionId);
+      for (const [date, excerpt] of excerpts) {
+        const bucket = dayBuckets.get(date) ?? [];
+        bucket.push(excerpt);
+        dayBuckets.set(date, bucket);
+      }
+    } catch (err) {
+      // Malformed jsonl — skip this session, don't crash the pass.
+      // eslint-disable-next-line no-console
+      console.warn(`[journal] failed to load session ${sessionId}:`, err);
+    }
+  }
+
+  // Read existing topic summaries once (shared across all day calls).
+  const existingTopics = await readAllTopics(workspaceRoot);
+
+  // Process days in chronological order so topic state accumulates
+  // naturally: an earlier day's update is visible to the next day.
+  const orderedDays = [...dayBuckets.keys()].sort();
+  const newTopicsSeen = new Set<string>(state.knownTopics);
+
+  for (const date of orderedDays) {
+    const excerpts = dayBuckets.get(date) ?? [];
+    const existingDaily = await readTextOrNull(
+      dailyPathFor(workspaceRoot, date),
+    );
+    const input: DailyArchivistInput = {
+      date,
+      existingDailySummary: existingDaily,
+      existingTopicSummaries: existingTopics,
+      sessionExcerpts: excerpts,
+    };
+
+    let rawOutput: string;
+    try {
+      rawOutput = await deps.summarize(
+        DAILY_SYSTEM_PROMPT,
+        buildDailyUserPrompt(input),
+      );
+    } catch (err) {
+      if (err instanceof ClaudeCliNotFoundError) {
+        // Propagate so the outer runner can disable the feature.
+        throw err;
+      }
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[journal] summarize failed for ${date}, skipping day:`,
+        err,
+      );
+      result.skipped.push({ date, reason: "summarize failed" });
+      continue;
+    }
+
+    const parsed = extractJsonObject(rawOutput);
+    if (!isDailyArchivistOutput(parsed)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[journal] archivist returned unusable JSON for ${date}, skipping`,
+      );
+      result.skipped.push({ date, reason: "unusable archivist JSON" });
+      continue;
+    }
+
+    await writeDailySummary(workspaceRoot, date, parsed.dailySummaryMarkdown);
+    result.daysTouched.push(date);
+
+    for (const update of parsed.topicUpdates) {
+      const canonicalSlug = slugify(update.slug);
+      const exists = existingTopics.some((t) => t.slug === canonicalSlug);
+      const normalized: TopicUpdate = {
+        slug: canonicalSlug,
+        // Guard: if the archivist asked to "append" to a slug that
+        // doesn't exist yet, treat it as "create". Cheap defensive
+        // handling that removes a whole class of LLM mistakes.
+        action:
+          !exists && update.action === "append" ? "create" : update.action,
+        content: update.content,
+      };
+      const outcome = await applyTopicUpdate(workspaceRoot, normalized);
+      if (outcome === "created") result.topicsCreated.push(canonicalSlug);
+      else if (outcome === "updated") result.topicsUpdated.push(canonicalSlug);
+      newTopicsSeen.add(canonicalSlug);
+
+      // Reflect the update in the in-memory topic snapshot so the
+      // next day in this same pass sees the fresh content.
+      const newBody = await readTextOrNull(
+        topicPathFor(workspaceRoot, canonicalSlug),
+      );
+      if (newBody !== null) {
+        const idx = existingTopics.findIndex((t) => t.slug === canonicalSlug);
+        const snapshot: ExistingTopicSnapshot = {
+          slug: canonicalSlug,
+          content: newBody,
+        };
+        if (idx === -1) existingTopics.push(snapshot);
+        else existingTopics[idx] = snapshot;
+      }
+    }
+  }
+
+  // Mark all dirty sessions as processed (with their observed mtime).
+  const justProcessed: SessionFileMeta[] = dirty
+    .map((id) => dirtyMetaById.get(id))
+    .filter((m): m is SessionFileMeta => m !== undefined);
+  result.sessionsIngested = justProcessed.map((m) => m.id);
+
+  const nextState: JournalState = {
+    ...state,
+    processedSessions: applyProcessed(state.processedSessions, justProcessed),
+    knownTopics: [...newTopicsSeen].sort(),
+  };
+
+  return { nextState, result };
+}
+
+// --- Filesystem helpers ---------------------------------------------
+
+async function listSessionMetas(chatDir: string): Promise<SessionFileMeta[]> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(chatDir);
+  } catch {
+    return [];
+  }
+  const out: SessionFileMeta[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const full = path.join(chatDir, name);
+    try {
+      const st = await fsp.stat(full);
+      out.push({
+        id: name.replace(/\.jsonl$/, ""),
+        mtimeMs: st.mtimeMs,
+      });
+    } catch {
+      // file vanished between readdir and stat — ignore
+    }
+  }
+  return out;
+}
+
+async function loadSessionExcerptsByDate(
+  chatDir: string,
+  sessionId: string,
+): Promise<Map<string, SessionExcerpt>> {
+  const jsonlPath = path.join(chatDir, `${sessionId}.jsonl`);
+  const metaPath = path.join(chatDir, `${sessionId}.json`);
+
+  const roleId = await readRoleId(metaPath);
+  const raw = await fsp.readFile(jsonlPath, "utf-8");
+
+  // One bucket per local-date this session touched.
+  const buckets = new Map<string, SessionExcerpt>();
+
+  // We don't have per-event timestamps in the legacy jsonl format,
+  // so fall back to the file's mtime for unscoped events. If the
+  // session spans midnight we still bucket everything into whichever
+  // date the mtime lands in — acceptable for a personal workspace
+  // where most sessions are short-lived.
+  const fallbackDate = toIsoDate((await fsp.stat(jsonlPath)).mtimeMs);
+
+  let count = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    if (count >= MAX_EVENTS_PER_SESSION) break;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.type === "session_meta" || entry.type === "claude_session_id") {
+      continue;
+    }
+    const excerpt = entryToExcerpt(entry);
+    if (!excerpt) continue;
+    count++;
+
+    const date = fallbackDate;
+    let bucket = buckets.get(date);
+    if (!bucket) {
+      bucket = { sessionId, roleId, events: [] };
+      buckets.set(date, bucket);
+    }
+    bucket.events.push(excerpt);
+  }
+  return buckets;
+}
+
+async function readRoleId(metaPath: string): Promise<string> {
+  try {
+    const meta = JSON.parse(await fsp.readFile(metaPath, "utf-8"));
+    if (typeof meta.roleId === "string") return meta.roleId;
+  } catch {
+    // ignore
+  }
+  return "unknown";
+}
+
+// Convert one jsonl entry into a flat excerpt the archivist can read.
+// Exported so tests can exercise it with fabricated entries.
+export function entryToExcerpt(
+  entry: Record<string, unknown>,
+): SessionEventExcerpt | null {
+  const source = typeof entry.source === "string" ? entry.source : "unknown";
+  const type = typeof entry.type === "string" ? entry.type : "unknown";
+
+  // text entries: {source, type: "text", message}
+  if (type === "text" && typeof entry.message === "string") {
+    return {
+      source,
+      type,
+      content: truncate(entry.message, MAX_EVENT_CONTENT_CHARS),
+    };
+  }
+  // tool_result entries: {source: "tool", type: "tool_result", result: {toolName, message, ...}}
+  if (type === "tool_result" && typeof entry.result === "object") {
+    const r = entry.result as Record<string, unknown>;
+    const toolName = typeof r.toolName === "string" ? r.toolName : "tool";
+    const label =
+      (typeof r.title === "string" && r.title) ||
+      (typeof r.message === "string" && r.message) ||
+      "(no message)";
+    return {
+      source,
+      type,
+      content: `${toolName}: ${truncate(String(label), MAX_EVENT_CONTENT_CHARS - toolName.length - 2)}`,
+    };
+  }
+  return null;
+}
+
+function truncate(s: string, max: number): string {
+  if (max <= 0) return "";
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+async function readAllTopics(
+  workspaceRoot: string,
+): Promise<ExistingTopicSnapshot[]> {
+  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: ExistingTopicSnapshot[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".md")) continue;
+    const slug = name.replace(/\.md$/, "");
+    try {
+      const content = await fsp.readFile(path.join(dir, name), "utf-8");
+      out.push({ slug, content });
+    } catch {
+      // ignore
+    }
+  }
+  return out;
+}
+
+async function readTextOrNull(file: string): Promise<string | null> {
+  try {
+    return await fsp.readFile(file, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function writeDailySummary(
+  workspaceRoot: string,
+  date: string,
+  content: string,
+): Promise<void> {
+  const p = dailyPathFor(workspaceRoot, date);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  await fsp.writeFile(p, content, "utf-8");
+}
+
+async function applyTopicUpdate(
+  workspaceRoot: string,
+  update: TopicUpdate,
+): Promise<"created" | "updated"> {
+  const p = topicPathFor(workspaceRoot, update.slug);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+
+  if (update.action === "create") {
+    // If the file already exists (e.g. the LLM mis-classified), treat
+    // it as an append so we don't clobber prior content.
+    const existing = await readTextOrNull(p);
+    if (existing === null) {
+      await fsp.writeFile(p, update.content, "utf-8");
+      return "created";
+    }
+    await fsp.writeFile(
+      p,
+      `${existing.trimEnd()}\n\n${update.content}\n`,
+      "utf-8",
+    );
+    return "updated";
+  }
+  if (update.action === "rewrite") {
+    const existed = (await readTextOrNull(p)) !== null;
+    await fsp.writeFile(p, update.content, "utf-8");
+    return existed ? "updated" : "created";
+  }
+  // append
+  const existing = await readTextOrNull(p);
+  if (existing === null) {
+    await fsp.writeFile(p, update.content, "utf-8");
+    return "created";
+  }
+  await fsp.writeFile(
+    p,
+    `${existing.trimEnd()}\n\n${update.content}\n`,
+    "utf-8",
+  );
+  return "updated";
+}

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -37,6 +37,7 @@ import {
   applyProcessed,
   type SessionFileMeta,
 } from "./diff.js";
+import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import type { JournalState } from "./state.js";
 
 // --- Constants ------------------------------------------------------
@@ -162,12 +163,26 @@ export async function runDailyPass(
       continue;
     }
 
-    await writeDailySummary(workspaceRoot, date, parsed.dailySummaryMarkdown);
+    // Rewrite any /workspace-absolute links in the archivist's output
+    // into true-relative links from the daily summary's location
+    // before writing to disk. Same treatment below for topic files.
+    const [yearPart, monthPart, dayPart] = date.split("-");
+    const dailyFileWsPath = `summaries/daily/${yearPart}/${monthPart}/${dayPart}.md`;
+    const dailyContent = rewriteWorkspaceLinks(
+      dailyFileWsPath,
+      parsed.dailySummaryMarkdown,
+    );
+    await writeDailySummary(workspaceRoot, date, dailyContent);
     result.daysTouched.push(date);
 
     for (const update of parsed.topicUpdates) {
       const canonicalSlug = slugify(update.slug);
       const exists = existingTopics.some((t) => t.slug === canonicalSlug);
+      const topicFileWsPath = path.posix.join(
+        "summaries",
+        "topics",
+        `${canonicalSlug}.md`,
+      );
       const normalized: TopicUpdate = {
         slug: canonicalSlug,
         // Guard: if the archivist asked to "append" to a slug that
@@ -175,7 +190,7 @@ export async function runDailyPass(
         // handling that removes a whole class of LLM mistakes.
         action:
           !exists && update.action === "append" ? "create" : update.action,
-        content: update.content,
+        content: rewriteWorkspaceLinks(topicFileWsPath, update.content),
       };
       const outcome = await applyTopicUpdate(workspaceRoot, normalized);
       if (outcome === "created") result.topicsCreated.push(canonicalSlug);
@@ -273,17 +288,20 @@ async function loadSessionExcerptsByDate(
     if (entry.type === "session_meta" || entry.type === "claude_session_id") {
       continue;
     }
-    const excerpt = entryToExcerpt(entry);
-    if (!excerpt) continue;
+    const parsed = parseEntry(entry);
+    if (!parsed) continue;
     count++;
 
     const date = fallbackDate;
     let bucket = buckets.get(date);
     if (!bucket) {
-      bucket = { sessionId, roleId, events: [] };
+      bucket = { sessionId, roleId, events: [], artifactPaths: [] };
       buckets.set(date, bucket);
     }
-    bucket.events.push(excerpt);
+    bucket.events.push(parsed.excerpt);
+    for (const p of parsed.artifactPaths) {
+      if (!bucket.artifactPaths.includes(p)) bucket.artifactPaths.push(p);
+    }
   }
   return buckets;
 }
@@ -298,8 +316,27 @@ async function readRoleId(metaPath: string): Promise<string> {
   return "unknown";
 }
 
-// Convert one jsonl entry into a flat excerpt the archivist can read.
+// Convert one jsonl entry into a flat excerpt the archivist can read,
+// plus any workspace-relative artifact paths the entry references.
 // Exported so tests can exercise it with fabricated entries.
+export interface ParsedEntry {
+  excerpt: SessionEventExcerpt;
+  // 0+ workspace-relative artifact paths referenced by this entry.
+  // Used to build the ARTIFACTS REFERENCED prompt section.
+  artifactPaths: string[];
+}
+
+export function parseEntry(entry: Record<string, unknown>): ParsedEntry | null {
+  const excerpt = entryToExcerpt(entry);
+  if (!excerpt) return null;
+  return {
+    excerpt,
+    artifactPaths: extractArtifactPaths(entry),
+  };
+}
+
+// Legacy single-purpose form used by the existing unit tests.
+// Prefer `parseEntry` for code that also wants artifact paths.
 export function entryToExcerpt(
   entry: Record<string, unknown>,
 ): SessionEventExcerpt | null {
@@ -329,6 +366,49 @@ export function entryToExcerpt(
     };
   }
   return null;
+}
+
+// Pull workspace-relative artifact paths out of a jsonl entry. The
+// extraction is tool-aware: different plugins stash file paths in
+// different places inside their tool_result data. Exported for
+// tests.
+export function extractArtifactPaths(entry: Record<string, unknown>): string[] {
+  if (entry.type !== "tool_result") return [];
+  const result = entry.result;
+  if (typeof result !== "object" || result === null) return [];
+  const r = result as Record<string, unknown>;
+  const data = r.data;
+  if (typeof data !== "object" || data === null) return [];
+  const d = data as Record<string, unknown>;
+  const paths: string[] = [];
+
+  // Direct `filePath: string` — presentMulmoScript, presentHtml.
+  if (typeof d.filePath === "string" && d.filePath.length > 0) {
+    paths.push(d.filePath);
+  }
+
+  // Wiki uses `pageName: string` and stores the page at
+  // `wiki/pages/<pageName>.md`. The plugin itself doesn't surface
+  // the full path in the result, so we synthesise it from the
+  // convention established in server/routes/wiki.ts.
+  if (r.toolName === "manageWiki" && typeof d.pageName === "string") {
+    paths.push(`wiki/pages/${d.pageName}.md`);
+  }
+
+  // Paths must be workspace-relative (not absolute, no escape).
+  // Drop anything suspicious rather than link to it.
+  return paths.filter(isSafeWorkspacePath);
+}
+
+// Defensive: refuse absolute paths, parent-escapes, or scheme-like
+// strings. Protects against a malformed tool result wedging a
+// filesystem-absolute path into the archivist prompt.
+function isSafeWorkspacePath(p: string): boolean {
+  if (!p) return false;
+  if (p.startsWith("/")) return false;
+  if (p.startsWith("..")) return false;
+  if (p.includes("://")) return false;
+  return true;
 }
 
 function truncate(s: string, max: number): string {

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -38,7 +38,7 @@ import {
   type SessionFileMeta,
 } from "./diff.js";
 import { rewriteWorkspaceLinks } from "./linkRewrite.js";
-import type { JournalState } from "./state.js";
+import { writeState, type JournalState } from "./state.js";
 
 // --- Constants ------------------------------------------------------
 
@@ -116,10 +116,37 @@ export async function runDailyPass(
   // Read existing topic summaries once (shared across all day calls).
   const existingTopics = await readAllTopics(workspaceRoot);
 
+  // Pre-compute: per-session, the set of days it contributes to.
+  // We decrement this set as days succeed so we can mark a session
+  // "fully processed" the moment its LAST day is written, and
+  // persist that incrementally — a mid-run crash then only costs
+  // the days written after the last checkpoint, not the whole pass.
+  const sessionToDays = new Map<string, Set<string>>();
+  for (const [date, bucket] of dayBuckets) {
+    for (const excerpt of bucket) {
+      let set = sessionToDays.get(excerpt.sessionId);
+      if (!set) {
+        set = new Set<string>();
+        sessionToDays.set(excerpt.sessionId, set);
+      }
+      set.add(date);
+    }
+  }
+
+  // `nextState` is mutated through the day loop and persisted after
+  // each successful day via writeState (atomic tmp+rename). We do
+  // NOT bump lastDailyRunAt here — that's the outer runner's job
+  // after the whole pass (including optimization) finishes, so
+  // partial progress doesn't look like a complete pass.
+  const newTopicsSeen = new Set<string>(state.knownTopics);
+  let nextState: JournalState = {
+    ...state,
+    knownTopics: [...newTopicsSeen].sort(),
+  };
+
   // Process days in chronological order so topic state accumulates
   // naturally: an earlier day's update is visible to the next day.
   const orderedDays = [...dayBuckets.keys()].sort();
-  const newTopicsSeen = new Set<string>(state.knownTopics);
 
   for (const date of orderedDays) {
     const excerpts = dayBuckets.get(date) ?? [];
@@ -212,30 +239,47 @@ export async function runDailyPass(
         else existingTopics[idx] = snapshot;
       }
     }
-  }
 
-  // Only mark a dirty session as processed if none of the days it
-  // contributed to were skipped. A session whose day we failed to
-  // summarize must stay "dirty" so the next pass retries it —
-  // otherwise a transient LLM failure would permanently hide those
-  // events from the journal.
-  const skippedSessionIds = new Set<string>();
-  for (const skip of result.skipped) {
-    const bucket = dayBuckets.get(skip.date);
-    if (!bucket) continue;
-    for (const excerpt of bucket) skippedSessionIds.add(excerpt.sessionId);
+    // Per-day incremental state update. Sessions whose pending day
+    // set just became empty are now fully processed and get their
+    // record written. Sessions still carrying pending days stay
+    // dirty so the next pass retries them if the loop is interrupted.
+    const justCompleted: SessionFileMeta[] = [];
+    for (const excerpt of excerpts) {
+      const pending = sessionToDays.get(excerpt.sessionId);
+      if (!pending) continue;
+      pending.delete(date);
+      if (pending.size === 0) {
+        sessionToDays.delete(excerpt.sessionId);
+        const meta = dirtyMetaById.get(excerpt.sessionId);
+        if (meta) justCompleted.push(meta);
+      }
+    }
+    if (justCompleted.length > 0) {
+      result.sessionsIngested.push(...justCompleted.map((m) => m.id));
+    }
+    nextState = {
+      ...nextState,
+      processedSessions: applyProcessed(
+        nextState.processedSessions,
+        justCompleted,
+      ),
+      knownTopics: [...newTopicsSeen].sort(),
+    };
+    // Persist after every day. The atomic tmp+rename inside
+    // writeState means a crash mid-write can't corrupt state.json,
+    // and everything up to and including `date` is safely
+    // committed: the next run picks up exactly from the next day.
+    try {
+      await writeState(workspaceRoot, nextState);
+    } catch (err) {
+      // A write failure is not fatal for the pass itself — we've
+      // already written the day's markdown — but we want it loud
+      // in the logs so a broken filesystem doesn't hide.
+      // eslint-disable-next-line no-console
+      console.warn(`[journal] failed to persist state after ${date}:`, err);
+    }
   }
-  const justProcessed: SessionFileMeta[] = dirty
-    .filter((id) => !skippedSessionIds.has(id))
-    .map((id) => dirtyMetaById.get(id))
-    .filter((m): m is SessionFileMeta => m !== undefined);
-  result.sessionsIngested = justProcessed.map((m) => m.id);
-
-  const nextState: JournalState = {
-    ...state,
-    processedSessions: applyProcessed(state.processedSessions, justProcessed),
-    knownTopics: [...newTopicsSeen].sort(),
-  };
 
   return { nextState, result };
 }

--- a/server/journal/diff.ts
+++ b/server/journal/diff.ts
@@ -1,0 +1,77 @@
+// "Which sessions are new or have changed since the last journal
+// run?" — pure logic that takes in-memory representations of the
+// current filesystem and the persisted state, and returns the list
+// of session ids that need re-ingest.
+//
+// Extracted from the filesystem layer so tests can exercise it with
+// hand-rolled inputs instead of mocking `fs`.
+
+import type { JournalState, ProcessedSessionRecord } from "./state.js";
+
+export interface SessionFileMeta {
+  // Session id (matches the .jsonl filename without extension).
+  id: string;
+  // mtime in ms since epoch. The only signal we use to detect
+  // appends — sessions don't have a version counter.
+  mtimeMs: number;
+}
+
+export interface DirtySessionDecision {
+  dirty: string[];
+  // Sessions already in state whose files have vanished from disk.
+  // We keep them in the state record (no harm) but the caller may
+  // choose to prune them separately.
+  missing: string[];
+}
+
+// Core diff. Given the current directory listing and the persisted
+// processed-sessions record, return:
+//   - `dirty`: sessions that were never seen, or whose mtime has
+//     advanced since we last ingested them, or whose mtime we don't
+//     have a record of (treat as dirty — safer to re-ingest than miss).
+//   - `missing`: sessions we had previously processed that no longer
+//     exist on disk. Not an error, just information.
+//
+// The caller may additionally exclude currently-active sessions
+// (whose jsonl could be mid-write); that's a separate concern and
+// kept out of the pure diff.
+export function findDirtySessions(
+  current: readonly SessionFileMeta[],
+  processed: Record<string, ProcessedSessionRecord>,
+): DirtySessionDecision {
+  const dirty: string[] = [];
+  const seenNow = new Set<string>();
+
+  for (const meta of current) {
+    seenNow.add(meta.id);
+    const prev = processed[meta.id];
+    if (!prev) {
+      dirty.push(meta.id);
+      continue;
+    }
+    if (meta.mtimeMs > prev.lastMtimeMs) {
+      dirty.push(meta.id);
+    }
+  }
+
+  const missing: string[] = [];
+  for (const id of Object.keys(processed)) {
+    if (!seenNow.has(id)) missing.push(id);
+  }
+
+  return { dirty, missing };
+}
+
+// Produce the next processedSessions map after a successful ingest
+// of the given dirty ids. Pure — doesn't mutate input. Sessions not
+// in the dirty list keep their existing record.
+export function applyProcessed(
+  previous: JournalState["processedSessions"],
+  justProcessed: readonly SessionFileMeta[],
+): JournalState["processedSessions"] {
+  const next: JournalState["processedSessions"] = { ...previous };
+  for (const meta of justProcessed) {
+    next[meta.id] = { lastMtimeMs: meta.mtimeMs };
+  }
+  return next;
+}

--- a/server/journal/index.ts
+++ b/server/journal/index.ts
@@ -102,13 +102,22 @@ async function runJournalPass(opts: {
       summarize,
       activeSessionIds,
     });
+    // Only advance lastDailyRunAt when no days were skipped —
+    // otherwise we'd wait a full interval before retrying a failed
+    // day, letting transient archivist failures silently lose events.
     nextState = {
       ...afterDaily,
-      lastDailyRunAt: new Date(now).toISOString(),
+      ...(result.skipped.length === 0 && {
+        lastDailyRunAt: new Date(now).toISOString(),
+      }),
     };
+    const skipSuffix =
+      result.skipped.length > 0
+        ? ` (${result.skipped.length} days skipped, will retry)`
+        : "";
     // eslint-disable-next-line no-console
     console.log(
-      `[journal] daily pass done: ${result.sessionsIngested.length} sessions, ${result.daysTouched.length} days, ${result.topicsCreated.length} topics created, ${result.topicsUpdated.length} updated`,
+      `[journal] daily pass done: ${result.sessionsIngested.length} sessions, ${result.daysTouched.length} days, ${result.topicsCreated.length} topics created, ${result.topicsUpdated.length} updated${skipSuffix}`,
     );
   }
 
@@ -119,9 +128,18 @@ async function runJournalPass(opts: {
       nextState,
       { workspaceRoot, summarize },
     );
+    // Same rule as daily: only advance the timestamp when the pass
+    // actually ran to completion. A "skipped: too few topics" case
+    // is still considered successful — there was simply nothing to
+    // do — and we allow it to bump so we don't re-check on every
+    // session-end.
+    const optimizationSucceeded =
+      !result.skipped || result.skippedReason === "fewer than 2 topics";
     nextState = {
       ...afterOpt,
-      lastOptimizationRunAt: new Date(now).toISOString(),
+      ...(optimizationSucceeded && {
+        lastOptimizationRunAt: new Date(now).toISOString(),
+      }),
     };
     if (result.skipped) {
       // eslint-disable-next-line no-console

--- a/server/journal/index.ts
+++ b/server/journal/index.ts
@@ -1,0 +1,252 @@
+// Public entry point for the workspace journal. The agent route
+// calls `maybeRunJournal()` from its `finally` block — fire-and-
+// forget. This module decides whether a pass is actually due, holds
+// an in-process lock so concurrent sessions don't double-run,
+// orchestrates daily + optimization passes, and rebuilds _index.md.
+//
+// All failures are caught and logged here; nothing ever bubbles
+// back to the request handler.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import {
+  readState,
+  writeState,
+  isDailyDue,
+  isOptimizationDue,
+} from "./state.js";
+import { runDailyPass } from "./dailyPass.js";
+import { runOptimizationPass } from "./optimizationPass.js";
+import {
+  buildIndexMarkdown,
+  type IndexTopicEntry,
+  type IndexDailyEntry,
+} from "./indexFile.js";
+import {
+  summariesRoot,
+  DAILY_DIR,
+  TOPICS_DIR,
+  ARCHIVE_DIR,
+  INDEX_FILE,
+} from "./paths.js";
+import {
+  runClaudeCli,
+  ClaudeCliNotFoundError,
+  type Summarize,
+} from "./archivist.js";
+
+// Module-level lock. A boolean is enough for the single-process
+// single-user MulmoClaude server; if two sessions finish at the
+// same instant, the second call returns immediately.
+let running = false;
+
+// Once we hit ENOENT on the `claude` CLI we disable the journal
+// for the rest of the server lifetime to avoid spamming warnings
+// on every session-end. Reset on server restart.
+let disabled = false;
+
+// The agent route calls this as `maybeRunJournal().catch(...)`.
+// Everything inside swallows its own errors so the promise never
+// rejects in practice, but we still attach a catch at the call
+// site defensively.
+export async function maybeRunJournal(
+  opts: {
+    summarize?: Summarize;
+    workspaceRoot?: string;
+    activeSessionIds?: ReadonlySet<string>;
+  } = {},
+): Promise<void> {
+  if (disabled) return;
+  if (running) return;
+  running = true;
+  try {
+    await runJournalPass(opts);
+  } catch (err) {
+    if (err instanceof ClaudeCliNotFoundError) {
+      disabled = true;
+      // eslint-disable-next-line no-console
+      console.warn(err.message);
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn("[journal] unexpected failure, continuing:", err);
+  } finally {
+    running = false;
+  }
+}
+
+async function runJournalPass(opts: {
+  summarize?: Summarize;
+  workspaceRoot?: string;
+  activeSessionIds?: ReadonlySet<string>;
+}): Promise<void> {
+  const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
+  const summarize = opts.summarize ?? runClaudeCli;
+  const activeSessionIds = opts.activeSessionIds ?? new Set<string>();
+
+  const state = await readState(workspaceRoot);
+  const now = Date.now();
+
+  const daily = isDailyDue(state, now);
+  const optimize = isOptimizationDue(state, now);
+  if (!daily && !optimize) return;
+
+  let nextState = state;
+
+  if (daily) {
+    // eslint-disable-next-line no-console
+    console.log("[journal] running daily pass");
+    const { nextState: afterDaily, result } = await runDailyPass(nextState, {
+      workspaceRoot,
+      summarize,
+      activeSessionIds,
+    });
+    nextState = {
+      ...afterDaily,
+      lastDailyRunAt: new Date(now).toISOString(),
+    };
+    // eslint-disable-next-line no-console
+    console.log(
+      `[journal] daily pass done: ${result.sessionsIngested.length} sessions, ${result.daysTouched.length} days, ${result.topicsCreated.length} topics created, ${result.topicsUpdated.length} updated`,
+    );
+  }
+
+  if (optimize) {
+    // eslint-disable-next-line no-console
+    console.log("[journal] running optimization pass");
+    const { nextState: afterOpt, result } = await runOptimizationPass(
+      nextState,
+      { workspaceRoot, summarize },
+    );
+    nextState = {
+      ...afterOpt,
+      lastOptimizationRunAt: new Date(now).toISOString(),
+    };
+    if (result.skipped) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[journal] optimization pass skipped: ${result.skippedReason}`,
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[journal] optimization pass done: ${result.mergedSlugs.length} merged, ${result.archivedSlugs.length} archived`,
+      );
+    }
+  }
+
+  await rebuildIndex(workspaceRoot);
+  await writeState(workspaceRoot, nextState);
+}
+
+// --- Index rebuild -------------------------------------------------
+
+async function rebuildIndex(workspaceRoot: string): Promise<void> {
+  const topics = await walkTopics(workspaceRoot);
+  const days = await walkDailyFiles(workspaceRoot);
+  const archivedCount = await countArchivedTopics(workspaceRoot);
+  const md = buildIndexMarkdown({
+    topics,
+    days,
+    archivedTopicCount: archivedCount,
+    builtAtIso: new Date().toISOString(),
+  });
+  const p = path.join(summariesRoot(workspaceRoot), INDEX_FILE);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  await fsp.writeFile(p, md, "utf-8");
+}
+
+async function walkTopics(workspaceRoot: string): Promise<IndexTopicEntry[]> {
+  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
+  let names: string[];
+  try {
+    names = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: IndexTopicEntry[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".md")) continue;
+    const slug = name.replace(/\.md$/, "");
+    const full = path.join(dir, name);
+    try {
+      const [stat, content] = await Promise.all([
+        fsp.stat(full),
+        fsp.readFile(full, "utf-8"),
+      ]);
+      out.push({
+        slug,
+        title: extractFirstH1(content) ?? undefined,
+        lastUpdatedIso: new Date(stat.mtimeMs).toISOString(),
+      });
+    } catch {
+      out.push({ slug });
+    }
+  }
+  return out;
+}
+
+async function walkDailyFiles(
+  workspaceRoot: string,
+): Promise<IndexDailyEntry[]> {
+  const root = path.join(summariesRoot(workspaceRoot), DAILY_DIR);
+  const out: IndexDailyEntry[] = [];
+  let years: string[];
+  try {
+    years = await fsp.readdir(root);
+  } catch {
+    return [];
+  }
+  for (const y of years) {
+    if (!/^\d{4}$/.test(y)) continue;
+    let months: string[];
+    try {
+      months = await fsp.readdir(path.join(root, y));
+    } catch {
+      continue;
+    }
+    for (const m of months) {
+      if (!/^\d{2}$/.test(m)) continue;
+      let days: string[];
+      try {
+        days = await fsp.readdir(path.join(root, y, m));
+      } catch {
+        continue;
+      }
+      for (const d of days) {
+        const match = d.match(/^(\d{2})\.md$/);
+        if (!match) continue;
+        out.push({ date: `${y}-${m}-${match[1]}` });
+      }
+    }
+  }
+  return out;
+}
+
+async function countArchivedTopics(workspaceRoot: string): Promise<number> {
+  const dir = path.join(summariesRoot(workspaceRoot), ARCHIVE_DIR, TOPICS_DIR);
+  try {
+    const entries = await fsp.readdir(dir);
+    return entries.filter((e) => e.endsWith(".md")).length;
+  } catch {
+    return 0;
+  }
+}
+
+// Extract the first `# Heading` line from a markdown body. Returns
+// null if there isn't one. Used for topic row labels.
+//
+// Implemented without a regex to satisfy sonarjs/slow-regex — a
+// prefix check is just as readable for this small grammar and has
+// zero backtracking risk.
+export function extractFirstH1(markdown: string): string | null {
+  for (const line of markdown.split("\n")) {
+    // H1 requires "#" followed by a space, which also naturally
+    // excludes H2 ("## ") and H3 ("### ") etc.
+    if (!line.startsWith("# ")) continue;
+    const text = line.slice(2).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}

--- a/server/journal/index.ts
+++ b/server/journal/index.ts
@@ -47,15 +47,21 @@ let running = false;
 let disabled = false;
 
 // The agent route calls this as `maybeRunJournal().catch(...)`.
+export interface MaybeRunJournalOptions {
+  summarize?: Summarize;
+  workspaceRoot?: string;
+  activeSessionIds?: ReadonlySet<string>;
+  // Skip the interval check and run both passes unconditionally.
+  // Useful for debugging / CLI-driven manual runs — the feature's
+  // disable flags (claude CLI missing, in-process lock) still apply.
+  force?: boolean;
+}
+
 // Everything inside swallows its own errors so the promise never
 // rejects in practice, but we still attach a catch at the call
 // site defensively.
 export async function maybeRunJournal(
-  opts: {
-    summarize?: Summarize;
-    workspaceRoot?: string;
-    activeSessionIds?: ReadonlySet<string>;
-  } = {},
+  opts: MaybeRunJournalOptions = {},
 ): Promise<void> {
   if (disabled) return;
   if (running) return;
@@ -76,11 +82,7 @@ export async function maybeRunJournal(
   }
 }
 
-async function runJournalPass(opts: {
-  summarize?: Summarize;
-  workspaceRoot?: string;
-  activeSessionIds?: ReadonlySet<string>;
-}): Promise<void> {
+async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
   const summarize = opts.summarize ?? runClaudeCli;
   const activeSessionIds = opts.activeSessionIds ?? new Set<string>();
@@ -88,9 +90,16 @@ async function runJournalPass(opts: {
   const state = await readState(workspaceRoot);
   const now = Date.now();
 
-  const daily = isDailyDue(state, now);
-  const optimize = isOptimizationDue(state, now);
+  // `force: true` bypasses the interval gate entirely so debug /
+  // startup flows can trigger a full pass even when nothing is
+  // technically due.
+  const daily = opts.force === true || isDailyDue(state, now);
+  const optimize = opts.force === true || isOptimizationDue(state, now);
   if (!daily && !optimize) return;
+  if (opts.force === true) {
+    // eslint-disable-next-line no-console
+    console.log("[journal] force-run: skipping interval gates");
+  }
 
   let nextState = state;
 

--- a/server/journal/indexFile.ts
+++ b/server/journal/indexFile.ts
@@ -99,7 +99,14 @@ function compareTopicsNewestFirst(
   const bt = b.lastUpdatedIso ? Date.parse(b.lastUpdatedIso) : NaN;
   const aValid = !Number.isNaN(at);
   const bValid = !Number.isNaN(bt);
-  if (aValid && bValid) return bt - at;
+  if (aValid && bValid) {
+    // Tie-break on slug when timestamps are identical so the index
+    // output is deterministic across repeated rebuilds. Without this,
+    // equal-mtime topics fall back to input order, which depends on
+    // readdir ordering and varies by filesystem.
+    if (bt !== at) return bt - at;
+    return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+  }
   if (aValid) return -1;
   if (bValid) return 1;
   return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;

--- a/server/journal/indexFile.ts
+++ b/server/journal/indexFile.ts
@@ -1,0 +1,125 @@
+// Pure builder for summaries/_index.md. Takes in-memory listings of
+// the journal's current topic / daily files and returns the full
+// markdown for the index. All filesystem walking happens in the
+// caller; this function is deterministic and easy to snapshot-test.
+
+export interface IndexTopicEntry {
+  // Filesystem slug (matches topics/<slug>.md).
+  slug: string;
+  // Optional human-readable title extracted from the topic file's
+  // first H1 heading. Falls back to `slug` if absent so the index
+  // row always reads sensibly.
+  title?: string;
+  // ISO timestamp of the last write to the topic file. Rendered
+  // for "stale topic" visibility.
+  lastUpdatedIso?: string;
+}
+
+export interface IndexDailyEntry {
+  // YYYY-MM-DD in local time. Matches the folder layout.
+  date: string;
+}
+
+export interface IndexInputs {
+  topics: readonly IndexTopicEntry[];
+  days: readonly IndexDailyEntry[];
+  archivedTopicCount: number;
+  builtAtIso: string;
+  // How many "Recent days" rows to list before collapsing the
+  // remainder. The full listing still lives under daily/ on disk.
+  maxRecentDays?: number;
+}
+
+export const DEFAULT_MAX_RECENT_DAYS = 14;
+
+export function buildIndexMarkdown(input: IndexInputs): string {
+  const maxRecent = input.maxRecentDays ?? DEFAULT_MAX_RECENT_DAYS;
+  const lines: string[] = [];
+  lines.push("# Workspace Journal");
+  lines.push("");
+  lines.push(`*Last updated: ${input.builtAtIso}*`);
+  lines.push("");
+
+  lines.push("## Topics");
+  lines.push("");
+  if (input.topics.length === 0) {
+    lines.push("_No topics yet._");
+  } else {
+    // Newest-first by last update (topics with no timestamp sort
+    // last, ordered alphabetically among themselves for stability).
+    const sorted = [...input.topics].sort(compareTopicsNewestFirst);
+    for (const t of sorted) {
+      lines.push(renderTopicRow(t));
+    }
+  }
+  lines.push("");
+
+  lines.push("## Recent days");
+  lines.push("");
+  if (input.days.length === 0) {
+    lines.push("_No daily entries yet._");
+  } else {
+    // Newest-first by date string (YYYY-MM-DD sorts lexically).
+    const sorted = [...input.days].sort((a, b) =>
+      a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
+    );
+    const head = sorted.slice(0, maxRecent);
+    for (const d of head) {
+      lines.push(renderDailyRow(d));
+    }
+    const rest = sorted.length - head.length;
+    if (rest > 0) {
+      lines.push("");
+      lines.push(`_…and ${rest} earlier day${rest === 1 ? "" : "s"}._`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Archive");
+  lines.push("");
+  if (input.archivedTopicCount === 0) {
+    lines.push("_No archived topics._");
+  } else {
+    const noun =
+      input.archivedTopicCount === 1 ? "archived topic" : "archived topics";
+    lines.push(
+      `- [Archived topics](archive/topics/) — ${input.archivedTopicCount} ${noun}`,
+    );
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function compareTopicsNewestFirst(
+  a: IndexTopicEntry,
+  b: IndexTopicEntry,
+): number {
+  const at = a.lastUpdatedIso ? Date.parse(a.lastUpdatedIso) : NaN;
+  const bt = b.lastUpdatedIso ? Date.parse(b.lastUpdatedIso) : NaN;
+  const aValid = !Number.isNaN(at);
+  const bValid = !Number.isNaN(bt);
+  if (aValid && bValid) return bt - at;
+  if (aValid) return -1;
+  if (bValid) return 1;
+  return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+}
+
+function renderTopicRow(t: IndexTopicEntry): string {
+  const label = t.title && t.title.trim().length > 0 ? t.title : t.slug;
+  const stamp = t.lastUpdatedIso
+    ? ` — updated ${formatShortDate(t.lastUpdatedIso)}`
+    : "";
+  return `- [${label}](topics/${t.slug}.md)${stamp}`;
+}
+
+function renderDailyRow(d: IndexDailyEntry): string {
+  const [year, month, day] = d.date.split("-");
+  return `- [${d.date}](daily/${year}/${month}/${day}.md)`;
+}
+
+// Strip ISO time portion for compactness — "updated 2026-04-11" is
+// plenty; the full timestamp is in _state.json if anyone needs it.
+function formatShortDate(iso: string): string {
+  return iso.slice(0, 10);
+}

--- a/server/journal/linkRewrite.ts
+++ b/server/journal/linkRewrite.ts
@@ -1,0 +1,107 @@
+// Post-processing for archivist output: the archivist is instructed
+// to emit workspace-absolute links like [wiki](/wiki/pages/foo.md),
+// and we rewrite those to true-relative paths before writing the
+// file to disk. That keeps the archivist's prompt simple (one rule:
+// paths start with "/") and keeps the on-disk files viewable in any
+// standard markdown renderer (because true-relative paths work).
+//
+// Both helpers are pure functions — no filesystem access — so the
+// full logic is unit-testable.
+
+import path from "node:path";
+
+// Rewrite every `[text](/workspace/path)` link in `content` to a
+// true-relative path computed from the given current-file location.
+// Non-workspace-absolute links (true relative, external URLs,
+// anchors) are left untouched.
+export function rewriteWorkspaceLinks(
+  currentFileWsPath: string,
+  content: string,
+): string {
+  const currentDir = path.posix.dirname(currentFileWsPath);
+  return rewriteMarkdownLinks(content, (href) => {
+    // Leave protocol-relative URLs (//example.com) alone.
+    if (href.startsWith("//")) return href;
+    // Only rewrite hrefs that start with a single "/"
+    if (!href.startsWith("/")) return href;
+    const target = href.slice(1);
+    if (target.length === 0) return href;
+    // Split off optional #fragment / ?query so we only rewrite the
+    // path portion. Files in the workspace don't use queries, but
+    // fragments to scroll to a heading are fair game.
+    const { pathPart, suffix } = splitFragmentAndQuery(target);
+    const rel = path.posix.relative(currentDir, pathPart);
+    // If the target happens to be the current file itself, emit "."
+    // rather than an empty string so the link stays syntactically
+    // valid markdown.
+    const safeRel = rel.length > 0 ? rel : ".";
+    return `${safeRel}${suffix}`;
+  });
+}
+
+// Low-level rewriter: walks through `input` and invokes `rewrite`
+// for every `[text](href)` it encounters, substituting the returned
+// href. Implemented with a character-level scan (no regex) so
+// sonarjs/slow-regex is happy and nested-paren heuristics don't
+// misfire.
+//
+// Exported so other journal modules (optimization pass, index
+// builder) can reuse it if they ever need link rewriting.
+export function rewriteMarkdownLinks(
+  input: string,
+  rewrite: (href: string) => string,
+): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] !== "[") {
+      out += input[i];
+      i++;
+      continue;
+    }
+    // Found "[". Scan for the matching "]". We intentionally don't
+    // support nested brackets in link text — archivist-generated
+    // content doesn't use them and supporting nesting would require
+    // full markdown parsing.
+    const closeBracket = input.indexOf("]", i + 1);
+    if (closeBracket === -1) {
+      // Unterminated "[" — copy the rest verbatim and bail.
+      out += input.slice(i);
+      break;
+    }
+    // A valid markdown link requires "(" immediately after "]".
+    if (input[closeBracket + 1] !== "(") {
+      out += input.slice(i, closeBracket + 1);
+      i = closeBracket + 1;
+      continue;
+    }
+    const openParen = closeBracket + 1;
+    const closeParen = input.indexOf(")", openParen + 1);
+    if (closeParen === -1) {
+      out += input.slice(i);
+      break;
+    }
+    const linkText = input.slice(i + 1, closeBracket);
+    const href = input.slice(openParen + 1, closeParen);
+    out += `[${linkText}](${rewrite(href)})`;
+    i = closeParen + 1;
+  }
+  return out;
+}
+
+// Pull a trailing "#fragment" or "?query" off a path. Returned as
+// `{ pathPart, suffix }` so the caller can concatenate the suffix
+// back onto a rewritten path.
+function splitFragmentAndQuery(s: string): {
+  pathPart: string;
+  suffix: string;
+} {
+  const hashIdx = s.indexOf("#");
+  const queryIdx = s.indexOf("?");
+  // Whichever marker comes first wins.
+  let cut = -1;
+  if (hashIdx !== -1) cut = hashIdx;
+  if (queryIdx !== -1 && (cut === -1 || queryIdx < cut)) cut = queryIdx;
+  if (cut === -1) return { pathPart: s, suffix: "" };
+  return { pathPart: s.slice(0, cut), suffix: s.slice(cut) };
+}

--- a/server/journal/optimizationPass.ts
+++ b/server/journal/optimizationPass.ts
@@ -105,7 +105,12 @@ export async function runOptimizationPass(
     );
 
     for (const src of fromSlugs) {
-      await moveToArchive(workspaceRoot, src);
+      // Only record the merge as successful if the source file
+      // actually moved. If moveToArchive fails (missing file, IO
+      // error) we leave the source out of the removed set so the
+      // in-memory knownTopics state stays accurate.
+      const moved = await moveToArchive(workspaceRoot, src);
+      if (!moved) continue;
       removed.add(src);
       result.mergedSlugs.push(src);
     }
@@ -115,7 +120,8 @@ export async function runOptimizationPass(
   for (const rawSlug of parsed.archives) {
     const slug = slugify(rawSlug);
     if (removed.has(slug)) continue;
-    await moveToArchive(workspaceRoot, slug);
+    const moved = await moveToArchive(workspaceRoot, slug);
+    if (!moved) continue;
     removed.add(slug);
     result.archivedSlugs.push(slug);
   }
@@ -156,19 +162,26 @@ async function loadTopicHeads(
   return out;
 }
 
+// Move a topic file into archive/topics/. Returns true on success,
+// false if the source didn't exist or rename failed — the caller
+// uses the boolean to decide whether to update state for this slug.
 async function moveToArchive(
   workspaceRoot: string,
   slug: string,
-): Promise<void> {
+): Promise<boolean> {
   const src = topicPathFor(workspaceRoot, slug);
   const dst = archivedTopicPathFor(workspaceRoot, slug);
   try {
     await fsp.mkdir(path.dirname(dst), { recursive: true });
     await fsp.rename(src, dst);
+    return true;
   } catch (err) {
     // Source may not exist (e.g. the LLM named a slug that was
-    // never a real file). Log and continue — non-fatal.
+    // never a real file) or the rename hit an unexpected IO error.
+    // Log and return false — the caller leaves state untouched for
+    // this slug so the in-memory knownTopics stays accurate.
     // eslint-disable-next-line no-console
     console.warn(`[journal] could not archive ${slug}:`, err);
+    return false;
   }
 }

--- a/server/journal/optimizationPass.ts
+++ b/server/journal/optimizationPass.ts
@@ -1,0 +1,174 @@
+// Weekly-ish topic optimization pass: merge near-duplicates, move
+// stale topics into archive/. Separate file from dailyPass so the
+// two can evolve independently and so the optimizer stays opt-in
+// from the top-level runner.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import {
+  type Summarize,
+  type OptimizationTopicSnapshot,
+  OPTIMIZATION_SYSTEM_PROMPT,
+  buildOptimizationUserPrompt,
+  extractJsonObject,
+  isOptimizationOutput,
+  ClaudeCliNotFoundError,
+} from "./archivist.js";
+import {
+  summariesRoot,
+  topicPathFor,
+  archivedTopicPathFor,
+  slugify,
+  TOPICS_DIR,
+} from "./paths.js";
+import type { JournalState } from "./state.js";
+
+// How many characters of each topic file we hand to the optimizer.
+// Enough to judge duplication without blowing up the prompt.
+const OPTIMIZER_HEAD_CHARS = 500;
+
+export interface OptimizationPassDeps {
+  workspaceRoot?: string;
+  summarize: Summarize;
+}
+
+export interface OptimizationPassResult {
+  mergedSlugs: string[];
+  archivedSlugs: string[];
+  skipped: boolean;
+  skippedReason?: string;
+}
+
+export async function runOptimizationPass(
+  state: JournalState,
+  deps: OptimizationPassDeps,
+): Promise<{ nextState: JournalState; result: OptimizationPassResult }> {
+  const workspaceRoot = deps.workspaceRoot ?? defaultWorkspacePath;
+  const result: OptimizationPassResult = {
+    mergedSlugs: [],
+    archivedSlugs: [],
+    skipped: false,
+  };
+
+  const topics = await loadTopicHeads(workspaceRoot);
+  if (topics.length < 2) {
+    // Nothing to optimise — need at least 2 topics for a merge to
+    // be meaningful, and archiving a single topic would leave an
+    // empty journal which feels wrong.
+    result.skipped = true;
+    result.skippedReason = "fewer than 2 topics";
+    return { nextState: { ...state }, result };
+  }
+
+  let raw: string;
+  try {
+    raw = await deps.summarize(
+      OPTIMIZATION_SYSTEM_PROMPT,
+      buildOptimizationUserPrompt({ topics }),
+    );
+  } catch (err) {
+    if (err instanceof ClaudeCliNotFoundError) throw err;
+    // eslint-disable-next-line no-console
+    console.warn(`[journal] optimization summarize failed:`, err);
+    result.skipped = true;
+    result.skippedReason = "summarize failed";
+    return { nextState: { ...state }, result };
+  }
+
+  const parsed = extractJsonObject(raw);
+  if (!isOptimizationOutput(parsed)) {
+    // eslint-disable-next-line no-console
+    console.warn(`[journal] optimizer returned unusable JSON, skipping`);
+    result.skipped = true;
+    result.skippedReason = "unusable optimizer JSON";
+    return { nextState: { ...state }, result };
+  }
+
+  const removed = new Set<string>();
+
+  // Apply merges first. If multiple merges reference the same slug,
+  // the later merge wins — shouldn't happen in practice but
+  // deterministic if it does.
+  for (const merge of parsed.merges) {
+    const intoSlug = slugify(merge.into);
+    const fromSlugs = merge.from.map(slugify).filter((s) => s !== intoSlug);
+    if (fromSlugs.length === 0) continue;
+
+    await fsp.mkdir(path.dirname(topicPathFor(workspaceRoot, intoSlug)), {
+      recursive: true,
+    });
+    await fsp.writeFile(
+      topicPathFor(workspaceRoot, intoSlug),
+      merge.newContent,
+      "utf-8",
+    );
+
+    for (const src of fromSlugs) {
+      await moveToArchive(workspaceRoot, src);
+      removed.add(src);
+      result.mergedSlugs.push(src);
+    }
+  }
+
+  // Apply archives (skip any already removed by a merge).
+  for (const rawSlug of parsed.archives) {
+    const slug = slugify(rawSlug);
+    if (removed.has(slug)) continue;
+    await moveToArchive(workspaceRoot, slug);
+    removed.add(slug);
+    result.archivedSlugs.push(slug);
+  }
+
+  const nextKnownTopics = state.knownTopics.filter((t) => !removed.has(t));
+  const nextState: JournalState = {
+    ...state,
+    knownTopics: nextKnownTopics,
+  };
+
+  return { nextState, result };
+}
+
+async function loadTopicHeads(
+  workspaceRoot: string,
+): Promise<OptimizationTopicSnapshot[]> {
+  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: OptimizationTopicSnapshot[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".md")) continue;
+    const slug = name.replace(/\.md$/, "");
+    try {
+      const full = await fsp.readFile(path.join(dir, name), "utf-8");
+      out.push({
+        slug,
+        headContent: full.slice(0, OPTIMIZER_HEAD_CHARS),
+      });
+    } catch {
+      // ignore
+    }
+  }
+  return out;
+}
+
+async function moveToArchive(
+  workspaceRoot: string,
+  slug: string,
+): Promise<void> {
+  const src = topicPathFor(workspaceRoot, slug);
+  const dst = archivedTopicPathFor(workspaceRoot, slug);
+  try {
+    await fsp.mkdir(path.dirname(dst), { recursive: true });
+    await fsp.rename(src, dst);
+  } catch (err) {
+    // Source may not exist (e.g. the LLM named a slug that was
+    // never a real file). Log and continue — non-fatal.
+    // eslint-disable-next-line no-console
+    console.warn(`[journal] could not archive ${slug}:`, err);
+  }
+}

--- a/server/journal/paths.ts
+++ b/server/journal/paths.ts
@@ -20,9 +20,15 @@ export function summariesRoot(workspaceRoot: string): string {
 }
 
 // summaries/daily/YYYY/MM/DD.md for a given ISO-ish date ("YYYY-MM-DD").
-// Input is validated only minimally — callers should supply already-
-// formatted strings produced by toIsoDate().
+// Throws if `isoDate` is not exactly YYYY-MM-DD — catches typos at
+// the boundary instead of producing "undefined/undefined.md" paths
+// downstream.
 export function dailyPathFor(workspaceRoot: string, isoDate: string): string {
+  if (!isValidIsoDate(isoDate)) {
+    throw new Error(
+      `[journal] dailyPathFor: expected YYYY-MM-DD, got "${isoDate}"`,
+    );
+  }
   const [year, month, day] = isoDate.split("-");
   return path.join(
     summariesRoot(workspaceRoot),
@@ -31,6 +37,30 @@ export function dailyPathFor(workspaceRoot: string, isoDate: string): string {
     month,
     `${day}.md`,
   );
+}
+
+// Strict YYYY-MM-DD check without a regex (sonarjs/slow-regex). We
+// deliberately don't validate that the date is real (no "2026-02-31"
+// rejection) — that's the LLM's / caller's job; we only make sure
+// the string can be split into 3 numeric components so the
+// downstream path math won't produce garbage.
+function isValidIsoDate(s: string): boolean {
+  if (s.length !== 10) return false;
+  if (s[4] !== "-" || s[7] !== "-") return false;
+  return (
+    isNumeric(s.slice(0, 4)) &&
+    isNumeric(s.slice(5, 7)) &&
+    isNumeric(s.slice(8, 10))
+  );
+}
+
+function isNumeric(s: string): boolean {
+  if (s.length === 0) return false;
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
 }
 
 // summaries/topics/<slug>.md

--- a/server/journal/paths.ts
+++ b/server/journal/paths.ts
@@ -1,0 +1,92 @@
+// Pure path / slug helpers for the workspace journal. Nothing here
+// touches the filesystem — every function is a straightforward
+// string transformation so it can be exhaustively unit-tested.
+
+import path from "node:path";
+
+// Directory layout under workspace/summaries/ is an implementation
+// detail of the journal module; keep it centralised here so tests
+// and callers all agree on the structure.
+export const SUMMARIES_DIR = "summaries";
+export const STATE_FILE = "_state.json";
+export const INDEX_FILE = "_index.md";
+export const DAILY_DIR = "daily";
+export const TOPICS_DIR = "topics";
+export const ARCHIVE_DIR = "archive";
+
+// Absolute path to the summaries root inside a workspace.
+export function summariesRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, SUMMARIES_DIR);
+}
+
+// summaries/daily/YYYY/MM/DD.md for a given ISO-ish date ("YYYY-MM-DD").
+// Input is validated only minimally — callers should supply already-
+// formatted strings produced by toIsoDate().
+export function dailyPathFor(workspaceRoot: string, isoDate: string): string {
+  const [year, month, day] = isoDate.split("-");
+  return path.join(
+    summariesRoot(workspaceRoot),
+    DAILY_DIR,
+    year,
+    month,
+    `${day}.md`,
+  );
+}
+
+// summaries/topics/<slug>.md
+export function topicPathFor(workspaceRoot: string, slug: string): string {
+  return path.join(summariesRoot(workspaceRoot), TOPICS_DIR, `${slug}.md`);
+}
+
+// summaries/archive/topics/<slug>.md — where the optimizer moves
+// merged or stale topic files.
+export function archivedTopicPathFor(
+  workspaceRoot: string,
+  slug: string,
+): string {
+  return path.join(
+    summariesRoot(workspaceRoot),
+    ARCHIVE_DIR,
+    TOPICS_DIR,
+    `${slug}.md`,
+  );
+}
+
+// Convert a Date (or ms timestamp) to a YYYY-MM-DD string in LOCAL
+// time. We intentionally use the local wall clock: this is a personal
+// workspace, not a distributed system, and "what did I do on 2026-04-11"
+// is a human-timezone question, not a UTC-offset question.
+export function toIsoDate(input: Date | number): string {
+  const d = typeof input === "number" ? new Date(input) : input;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// Convert a free-form topic name into a filesystem-safe slug.
+// Rules:
+//   - Lowercase ASCII letters, digits, and hyphens only
+//   - Whitespace and punctuation collapse to a single hyphen
+//   - Non-ASCII characters (Japanese, emoji) are dropped; if the
+//     result is empty we fall back to "topic" so we always yield a
+//     valid filename (LLMs occasionally emit pure-Japanese topic
+//     names; the markdown body still holds the original title for
+//     display, this slug is only the filesystem key)
+//   - Leading/trailing hyphens stripped
+//   - Empty-string input yields "topic"
+export function slugify(raw: string): string {
+  const lowered = raw.toLowerCase();
+  // Replace runs of non-ASCII-alnum with a single hyphen. Because
+  // we use `+` on a character class, this single pass already
+  // collapses runs — no second dedupe pass needed.
+  const hyphenated = lowered.replace(/[^a-z0-9]+/g, "-");
+  // Trim leading/trailing hyphens without a regex — sonarjs/slow-regex
+  // flags `^-+` / `-+$` patterns even though these inputs are tiny.
+  let start = 0;
+  let end = hyphenated.length;
+  while (start < end && hyphenated[start] === "-") start++;
+  while (end > start && hyphenated[end - 1] === "-") end--;
+  const trimmed = hyphenated.slice(start, end);
+  return trimmed.length > 0 ? trimmed : "topic";
+}

--- a/server/journal/state.ts
+++ b/server/journal/state.ts
@@ -1,0 +1,173 @@
+// Journal state file schema + persistence. The state file tracks
+// what the archivist has already done so we only re-process new or
+// changed sessions on each run.
+//
+// The pure bits (default creation, schema validation, interval
+// arithmetic) live at the top of the file so tests can exercise
+// them without touching disk. Filesystem helpers at the bottom wrap
+// those pure functions with atomic read/write.
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { summariesRoot, STATE_FILE } from "./paths.js";
+
+// Bump this when the schema changes in a backwards-incompatible way.
+// Older state files are treated as corrupted and replaced with a
+// fresh default (ingest everything from scratch) — cheap because it
+// only costs one extra archivist pass.
+export const JOURNAL_STATE_VERSION = 1;
+
+export interface ProcessedSessionRecord {
+  // mtime (ms since epoch) of the session's .jsonl file when we
+  // last ingested it. If mtime advances on the next run, the session
+  // has appended events and needs re-ingest.
+  lastMtimeMs: number;
+}
+
+export interface JournalState {
+  version: number;
+  lastDailyRunAt: string | null;
+  lastOptimizationRunAt: string | null;
+  dailyIntervalHours: number;
+  optimizationIntervalDays: number;
+  processedSessions: Record<string, ProcessedSessionRecord>;
+  knownTopics: string[];
+}
+
+export const DEFAULT_DAILY_INTERVAL_HOURS = 1;
+export const DEFAULT_OPTIMIZATION_INTERVAL_DAYS = 7;
+
+// --- Pure helpers (unit-testable without disk) ---------------------
+
+export function defaultState(): JournalState {
+  return {
+    version: JOURNAL_STATE_VERSION,
+    lastDailyRunAt: null,
+    lastOptimizationRunAt: null,
+    dailyIntervalHours: DEFAULT_DAILY_INTERVAL_HOURS,
+    optimizationIntervalDays: DEFAULT_OPTIMIZATION_INTERVAL_DAYS,
+    processedSessions: {},
+    knownTopics: [],
+  };
+}
+
+// Narrow an `unknown` into a JournalState. Accepts partial / missing
+// fields and fills defaults — users can hand-edit the file to change
+// intervals and we want to be forgiving.
+export function parseState(raw: unknown): JournalState {
+  if (typeof raw !== "object" || raw === null) return defaultState();
+  const obj = raw as Record<string, unknown>;
+
+  // Version mismatch → throw it all out. Cheap to rebuild.
+  if (obj.version !== JOURNAL_STATE_VERSION) return defaultState();
+
+  const d = defaultState();
+  return {
+    version: JOURNAL_STATE_VERSION,
+    lastDailyRunAt:
+      typeof obj.lastDailyRunAt === "string" ? obj.lastDailyRunAt : null,
+    lastOptimizationRunAt:
+      typeof obj.lastOptimizationRunAt === "string"
+        ? obj.lastOptimizationRunAt
+        : null,
+    dailyIntervalHours:
+      typeof obj.dailyIntervalHours === "number" && obj.dailyIntervalHours > 0
+        ? obj.dailyIntervalHours
+        : d.dailyIntervalHours,
+    optimizationIntervalDays:
+      typeof obj.optimizationIntervalDays === "number" &&
+      obj.optimizationIntervalDays > 0
+        ? obj.optimizationIntervalDays
+        : d.optimizationIntervalDays,
+    processedSessions: parseProcessedSessions(obj.processedSessions),
+    knownTopics: Array.isArray(obj.knownTopics)
+      ? obj.knownTopics.filter((t): t is string => typeof t === "string")
+      : [],
+  };
+}
+
+function parseProcessedSessions(
+  raw: unknown,
+): Record<string, ProcessedSessionRecord> {
+  if (typeof raw !== "object" || raw === null) return {};
+  const out: Record<string, ProcessedSessionRecord> = {};
+  for (const [id, rec] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof rec !== "object" || rec === null) continue;
+    const mtime = (rec as Record<string, unknown>).lastMtimeMs;
+    if (typeof mtime === "number" && mtime >= 0) {
+      out[id] = { lastMtimeMs: mtime };
+    }
+  }
+  return out;
+}
+
+// Has the configured daily interval elapsed since the last run? A
+// null lastDailyRunAt means "never run" → always due.
+export function isDailyDue(state: JournalState, nowMs: number): boolean {
+  if (state.lastDailyRunAt === null) return true;
+  const last = Date.parse(state.lastDailyRunAt);
+  if (Number.isNaN(last)) return true;
+  const intervalMs = state.dailyIntervalHours * 60 * 60 * 1000;
+  return nowMs - last >= intervalMs;
+}
+
+export function isOptimizationDue(state: JournalState, nowMs: number): boolean {
+  if (state.lastOptimizationRunAt === null) return true;
+  const last = Date.parse(state.lastOptimizationRunAt);
+  if (Number.isNaN(last)) return true;
+  const intervalMs = state.optimizationIntervalDays * 24 * 60 * 60 * 1000;
+  return nowMs - last >= intervalMs;
+}
+
+// --- Filesystem helpers --------------------------------------------
+
+export function statePathFor(workspaceRoot: string): string {
+  return path.join(summariesRoot(workspaceRoot), STATE_FILE);
+}
+
+export async function readState(workspaceRoot: string): Promise<JournalState> {
+  const p = statePathFor(workspaceRoot);
+  try {
+    const raw = await fsp.readFile(p, "utf-8");
+    return parseState(JSON.parse(raw));
+  } catch (err) {
+    if (isFileNotFound(err)) {
+      return defaultState();
+    }
+    // Corrupted JSON or any other read error — fall back to defaults
+    // and log a warning. Better to rebuild from scratch than to
+    // crash the journal module.
+    // eslint-disable-next-line no-console
+    console.warn(`[journal] state file unreadable, using defaults:`, err);
+    return defaultState();
+  }
+}
+
+// Atomic write: write to a tmp file and rename, so a crash mid-write
+// can't leave a half-written state.json behind.
+export async function writeState(
+  workspaceRoot: string,
+  state: JournalState,
+): Promise<void> {
+  const p = statePathFor(workspaceRoot);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp`;
+  await fsp.writeFile(tmp, JSON.stringify(state, null, 2), "utf-8");
+  await fsp.rename(tmp, p);
+}
+
+// Tiny helper so callers don't need to import `fs` directly just to
+// check if the state file exists yet.
+export function stateFileExists(workspaceRoot: string): boolean {
+  return fs.existsSync(statePathFor(workspaceRoot));
+}
+
+// Narrow an unknown error value into "is this an ENOENT?". Written
+// without the NodeJS.ErrnoException global so we don't depend on
+// @types/node globals from this file.
+function isFileNotFound(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (!("code" in err)) return false;
+  return (err as Error & { code?: unknown }).code === "ENOENT";
+}

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -4,8 +4,14 @@ import path from "path";
 import { Router, Request, Response } from "express";
 import { getRole } from "../roles.js";
 import { runAgent } from "../agent.js";
-import { registerSession, removeSession, pushToSession } from "../sessions.js";
+import {
+  registerSession,
+  removeSession,
+  pushToSession,
+  getActiveSessionIds,
+} from "../sessions.js";
 import { workspacePath } from "../workspace.js";
+import { maybeRunJournal } from "../journal/index.js";
 
 const router = Router();
 const PORT = Number(process.env.PORT) || 3001;
@@ -156,6 +162,18 @@ router.post(
     } finally {
       removeSession(sessionId);
       res.end();
+      // Fire-and-forget: the journal module decides whether the
+      // interval has elapsed and is self-locking. We pass the
+      // active-session set so the pass skips any jsonl file still
+      // being written by a concurrent request.
+      maybeRunJournal({ activeSessionIds: getActiveSessionIds() }).catch(
+        (err) => {
+          // Should not actually happen — maybeRunJournal swallows
+          // its own errors — but belt-and-suspenders.
+          // eslint-disable-next-line no-console
+          console.warn("[journal] unexpected error in background:", err);
+        },
+      );
     }
   },
 );

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -38,6 +38,12 @@ export function removeSession(id: string): void {
   sessions.delete(id);
 }
 
+// Snapshot of currently-live session ids. The journal module uses
+// this to skip ingesting jsonl files that are still being written.
+export function getActiveSessionIds(): Set<string> {
+  return new Set(sessions.keys());
+}
+
 export async function pushToSession(
   id: string,
   data: unknown,

--- a/src/App.vue
+++ b/src/App.vue
@@ -432,7 +432,11 @@
           @update-result="handleUpdateResult"
         />
         <!-- Files mode -->
-        <FilesView v-else :refresh-token="filesRefreshToken" />
+        <FilesView
+          v-else
+          :refresh-token="filesRefreshToken"
+          @load-session="onFilesViewLoadSession"
+        />
       </div>
     </div>
     <!-- Right sidebar: tool call history -->
@@ -732,6 +736,18 @@ function handleUpdateResult(updatedResult: ToolResultComplete) {
 // actually shows up in the canvas.
 function onSidebarItemClick(uuid: string) {
   selectedResultUuid.value = uuid;
+  if (canvasViewMode.value === "files") {
+    setCanvasViewMode("single");
+  }
+}
+
+// Bridge from FilesView: a user clicked a markdown link to a chat
+// session (e.g. "[session abc](../../chat/abc-123.jsonl)" inside
+// a journal summary). Switch the active session AND pop the canvas
+// out of files mode, otherwise they'd still be staring at the file
+// tree after the session loaded.
+function onFilesViewLoadSession(sessionId: string): void {
+  loadSession(sessionId);
   if (canvasViewMode.value === "files") {
     setCanvasViewMode("single");
   }

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -204,6 +204,7 @@ import { extractFrontmatter } from "../utils/format/frontmatter";
 import {
   isExternalHref,
   resolveWorkspaceLink,
+  extractSessionIdFromPath,
 } from "../utils/path/relativeLink";
 
 const STORAGE_KEY = "files_selected_path";
@@ -230,6 +231,13 @@ type FileContent = TextContent | MetaContent;
 
 const props = defineProps<{
   refreshToken?: number;
+}>();
+
+const emit = defineEmits<{
+  // Emitted when the user clicks a markdown link whose target is
+  // a chat session jsonl; App.vue should load that session into
+  // the active chat view rather than opening the raw jsonl.
+  loadSession: [sessionId: string];
 }>();
 
 const tree = ref<TreeNode | null>(null);
@@ -441,6 +449,15 @@ function handleMarkdownLinkClick(event: MouseEvent): void {
   if (!resolved) return;
   event.preventDefault();
   event.stopPropagation();
+  // Chat session link: hand off to App.vue so the sidebar chat
+  // switches to that session instead of opening the raw jsonl
+  // as a file. Direct clicks in the file tree still open the
+  // jsonl in raw view — only markdown link clicks route here.
+  const sessionId = extractSessionIdFromPath(resolved);
+  if (sessionId !== null) {
+    emit("loadSession", sessionId);
+    return;
+  }
   selectFile(resolved);
 }
 

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -91,7 +91,10 @@
                   }}</span>
                 </div>
               </div>
-              <div class="flex-1 min-h-0">
+              <div
+                class="flex-1 min-h-0"
+                @click.capture="handleMarkdownLinkClick"
+              >
                 <TextResponseView
                   :selected-result="
                     markdownResult(
@@ -198,6 +201,10 @@ import {
   JSON_TOKEN_CLASS,
 } from "../utils/format/jsonSyntax";
 import { extractFrontmatter } from "../utils/format/frontmatter";
+import {
+  isExternalHref,
+  resolveWorkspaceLink,
+} from "../utils/path/relativeLink";
 
 const STORAGE_KEY = "files_selected_path";
 const MD_RAW_STORAGE_KEY = "files_md_raw_mode";
@@ -406,6 +413,35 @@ function selectFile(filePath: string): void {
   selectedPath.value = filePath;
   localStorage.setItem(STORAGE_KEY, filePath);
   loadContent(filePath);
+}
+
+// When the user clicks an <a> inside a rendered markdown body, check
+// if it's a workspace-internal relative/absolute link. If so, resolve
+// it against the current file and navigate inside FilesView instead
+// of letting the browser follow the (meaningless) relative href.
+//
+// Uses click.capture so we intercept before TextResponseView's own
+// handler (which only knows about absolute URLs) sees the event.
+function handleMarkdownLinkClick(event: MouseEvent): void {
+  if (event.button !== 0) return;
+  if (event.ctrlKey || event.metaKey || event.shiftKey) return;
+  const target = event.target as HTMLElement | null;
+  if (!target) return;
+  const anchor = target.closest("a");
+  if (!anchor) return;
+  const href = anchor.getAttribute("href");
+  if (!href) return;
+  // External URLs and mailto/tel: let TextResponseView's existing
+  // handler open them in a new tab.
+  if (isExternalHref(href)) return;
+  // Anchor-only (#section): let the browser handle in-page scroll.
+  if (href.startsWith("#")) return;
+  if (!selectedPath.value) return;
+  const resolved = resolveWorkspaceLink(selectedPath.value, href);
+  if (!resolved) return;
+  event.preventDefault();
+  event.stopPropagation();
+  selectFile(resolved);
 }
 
 watch(

--- a/src/utils/path/relativeLink.ts
+++ b/src/utils/path/relativeLink.ts
@@ -91,6 +91,28 @@ function stripFragmentAndQuery(s: string): string {
   return s.slice(0, end);
 }
 
+// If `resolvedPath` points at a chat session log (e.g.
+// `chat/abc-123.jsonl`), return the session id. Used by the file
+// viewer to recognise when a clicked markdown link should switch
+// the active chat instead of opening the raw jsonl as a file.
+//
+// Nested paths under `chat/` (e.g. `chat/subdir/foo.jsonl`) return
+// null — session ids cannot contain slashes, and we don't want to
+// mis-identify unrelated files.
+export function extractSessionIdFromPath(resolvedPath: string): string | null {
+  const CHAT_PREFIX = "chat/";
+  const JSONL_SUFFIX = ".jsonl";
+  if (!resolvedPath.startsWith(CHAT_PREFIX)) return null;
+  if (!resolvedPath.endsWith(JSONL_SUFFIX)) return null;
+  const id = resolvedPath.slice(
+    CHAT_PREFIX.length,
+    resolvedPath.length - JSONL_SUFFIX.length,
+  );
+  if (id.length === 0) return null;
+  if (id.includes("/")) return null;
+  return id;
+}
+
 // POSIX-style dirname. The file viewer always uses "/" separators
 // so we don't need to worry about Windows paths.
 function posixDirname(p: string): string {

--- a/src/utils/path/relativeLink.ts
+++ b/src/utils/path/relativeLink.ts
@@ -1,0 +1,120 @@
+// Pure helpers used by FilesView to decide how to handle a click on
+// an <a> inside rendered markdown. Kept free of DOM types so it can
+// be exhaustively unit-tested.
+//
+// The two shipped functions are:
+//
+//   - isExternalHref(href): should this click escape to the browser?
+//   - resolveWorkspaceLink(currentFile, href): resolve a markdown
+//     href to a workspace-relative path the file viewer can open.
+
+// --- External URL detection ---------------------------------------
+
+// Return true when `href` points at something that isn't inside the
+// workspace (http/https/mailto/tel/custom schemes, protocol-relative
+// URLs). The file viewer uses this to decide whether to let the
+// default browser behaviour take over.
+export function isExternalHref(href: string): boolean {
+  if (!href) return true;
+  // Protocol-relative (//example.com/foo) → external.
+  if (href.startsWith("//")) return true;
+  // Fast-path for the common schemes.
+  if (
+    href.startsWith("http://") ||
+    href.startsWith("https://") ||
+    href.startsWith("mailto:") ||
+    href.startsWith("tel:") ||
+    href.startsWith("ftp://")
+  ) {
+    return true;
+  }
+  // Generic scheme detection: any "scheme:" prefix where the colon
+  // comes before the first slash is an external URL. Avoid a regex
+  // so we don't trip sonarjs/slow-regex.
+  const colonIdx = href.indexOf(":");
+  if (colonIdx > 0) {
+    const slashIdx = href.indexOf("/");
+    if (slashIdx === -1 || slashIdx > colonIdx) return true;
+  }
+  return false;
+}
+
+// --- Workspace link resolution ------------------------------------
+
+// Given the workspace-relative path of the file currently being
+// viewed (`currentFilePath`, e.g. "summaries/topics/refactoring.md")
+// and the raw href of a clicked link, return the resolved workspace-
+// relative path of the target file, or null if the link:
+//
+//   - is external (handled by the browser instead)
+//   - is an anchor-only link (scroll, let the browser handle it)
+//   - would escape the workspace root via "../"
+//   - is empty or a pure query/fragment
+//
+// `#fragment` / `?query` suffixes are stripped — the file viewer
+// only navigates by path.
+export function resolveWorkspaceLink(
+  currentFilePath: string,
+  href: string,
+): string | null {
+  if (!href) return null;
+  if (isExternalHref(href)) return null;
+  if (href.startsWith("#")) return null;
+
+  // Strip #fragment and ?query BEFORE joining so a pure-query href
+  // like "?foo=1" isn't smuggled into the current directory and
+  // resolved to the parent.
+  const cleaned = stripFragmentAndQuery(href);
+  if (cleaned.length === 0) return null;
+
+  // Workspace-absolute (starts with a single "/"): strip the slash
+  // and treat the rest as workspace-relative.
+  let joined: string;
+  if (cleaned.startsWith("/")) {
+    joined = cleaned.slice(1);
+  } else {
+    const currentDir = posixDirname(currentFilePath);
+    joined = currentDir === "" ? cleaned : `${currentDir}/${cleaned}`;
+  }
+
+  return normalizeWorkspacePath(joined);
+}
+
+// Drop any trailing #fragment or ?query from a path-like string.
+// Whichever marker comes first wins.
+function stripFragmentAndQuery(s: string): string {
+  const hashIdx = s.indexOf("#");
+  const queryIdx = s.indexOf("?");
+  let end = s.length;
+  if (hashIdx !== -1 && hashIdx < end) end = hashIdx;
+  if (queryIdx !== -1 && queryIdx < end) end = queryIdx;
+  return s.slice(0, end);
+}
+
+// POSIX-style dirname. The file viewer always uses "/" separators
+// so we don't need to worry about Windows paths.
+function posixDirname(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? "" : p.slice(0, i);
+}
+
+// Collapse "./" and "../" in a workspace path. Rejects paths that
+// escape above the workspace root. Returns null for the empty-path
+// case so the caller can bail out. Callers are expected to strip
+// #fragment / ?query before invoking this function.
+function normalizeWorkspacePath(p: string): string | null {
+  if (p.length === 0) return null;
+  const parts = p.split("/");
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (stack.length === 0) return null; // escape attempt
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  if (stack.length === 0) return null;
+  return stack.join("/");
+}

--- a/test/journal/test_archivist.ts
+++ b/test/journal/test_archivist.ts
@@ -1,0 +1,220 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildDailyUserPrompt,
+  buildOptimizationUserPrompt,
+  extractJsonObject,
+  isDailyArchivistOutput,
+  isOptimizationOutput,
+  type DailyArchivistInput,
+  type OptimizationInput,
+} from "../../server/journal/archivist.js";
+
+describe("buildDailyUserPrompt", () => {
+  const baseInput = (
+    over: Partial<DailyArchivistInput> = {},
+  ): DailyArchivistInput => ({
+    date: "2026-04-11",
+    existingDailySummary: null,
+    existingTopicSummaries: [],
+    sessionExcerpts: [],
+    ...over,
+  });
+
+  it("includes the date header", () => {
+    const out = buildDailyUserPrompt(baseInput());
+    assert.match(out, /DATE: 2026-04-11/);
+  });
+
+  it("omits the existing-summary block when null", () => {
+    const out = buildDailyUserPrompt(baseInput());
+    assert.doesNotMatch(out, /EXISTING DAILY SUMMARY/);
+  });
+
+  it("includes the existing-summary block when provided", () => {
+    const out = buildDailyUserPrompt(
+      baseInput({ existingDailySummary: "# old summary" }),
+    );
+    assert.match(out, /EXISTING DAILY SUMMARY/);
+    assert.match(out, /# old summary/);
+  });
+
+  it("shows '(none yet)' for an empty topic list", () => {
+    const out = buildDailyUserPrompt(baseInput());
+    assert.match(out, /EXISTING TOPICS:\n\(none yet\)/);
+  });
+
+  it("lists topic slugs when provided", () => {
+    const out = buildDailyUserPrompt(
+      baseInput({
+        existingTopicSummaries: [
+          { slug: "refactoring", content: "..." },
+          { slug: "video-generation", content: "..." },
+        ],
+      }),
+    );
+    assert.match(out, /- refactoring/);
+    assert.match(out, /- video-generation/);
+  });
+
+  it("renders session excerpts with role and events", () => {
+    const out = buildDailyUserPrompt(
+      baseInput({
+        sessionExcerpts: [
+          {
+            sessionId: "sess-abc",
+            roleId: "default",
+            events: [
+              { source: "user", type: "text", content: "hello" },
+              { source: "assistant", type: "text", content: "world" },
+            ],
+          },
+        ],
+      }),
+    );
+    assert.match(out, /### session sess-abc \(role: default\)/);
+    assert.match(out, /\[user\/text\] hello/);
+    assert.match(out, /\[assistant\/text\] world/);
+  });
+});
+
+describe("buildOptimizationUserPrompt", () => {
+  it("renders each topic with slug heading and fenced head content", () => {
+    const input: OptimizationInput = {
+      topics: [
+        { slug: "topic-a", headContent: "first topic body" },
+        { slug: "topic-b", headContent: "second topic body" },
+      ],
+    };
+    const out = buildOptimizationUserPrompt(input);
+    assert.match(out, /### topic-a/);
+    assert.match(out, /first topic body/);
+    assert.match(out, /### topic-b/);
+    assert.match(out, /second topic body/);
+  });
+});
+
+describe("extractJsonObject", () => {
+  it("parses a fenced ```json block", () => {
+    const raw = 'Here you go:\n```json\n{"hello":"world"}\n```\nDone.';
+    assert.deepEqual(extractJsonObject(raw), { hello: "world" });
+  });
+
+  it("parses a bare balanced { ... } block", () => {
+    const raw = 'Response: {"a":1,"b":2} — done';
+    assert.deepEqual(extractJsonObject(raw), { a: 1, b: 2 });
+  });
+
+  it("handles nested braces", () => {
+    const raw = '```json\n{"outer":{"inner":[1,2,3]}}\n```';
+    assert.deepEqual(extractJsonObject(raw), { outer: { inner: [1, 2, 3] } });
+  });
+
+  it("handles braces inside string values without getting confused", () => {
+    const raw = '{"template":"{{placeholder}}","value":42}';
+    assert.deepEqual(extractJsonObject(raw), {
+      template: "{{placeholder}}",
+      value: 42,
+    });
+  });
+
+  it("handles escaped quotes inside strings", () => {
+    const raw = '{"q":"she said \\"hi\\"","n":1}';
+    assert.deepEqual(extractJsonObject(raw), { q: 'she said "hi"', n: 1 });
+  });
+
+  it("falls back to bare scan when fenced content is invalid", () => {
+    const raw = '```json\nnot valid json\n```\n{"recovered":true}';
+    assert.deepEqual(extractJsonObject(raw), { recovered: true });
+  });
+
+  it("returns null when no object is present", () => {
+    assert.equal(extractJsonObject("just prose, no json"), null);
+  });
+
+  it("returns null on unbalanced braces", () => {
+    assert.equal(extractJsonObject("{ unterminated"), null);
+  });
+});
+
+describe("isDailyArchivistOutput", () => {
+  it("accepts a valid minimal output", () => {
+    assert.equal(
+      isDailyArchivistOutput({ dailySummaryMarkdown: "x", topicUpdates: [] }),
+      true,
+    );
+  });
+
+  it("accepts topic updates with each valid action", () => {
+    const out = {
+      dailySummaryMarkdown: "x",
+      topicUpdates: [
+        { slug: "a", action: "create", content: "..." },
+        { slug: "b", action: "append", content: "..." },
+        { slug: "c", action: "rewrite", content: "..." },
+      ],
+    };
+    assert.equal(isDailyArchivistOutput(out), true);
+  });
+
+  it("rejects missing dailySummaryMarkdown", () => {
+    assert.equal(isDailyArchivistOutput({ topicUpdates: [] }), false);
+  });
+
+  it("rejects non-array topicUpdates", () => {
+    assert.equal(
+      isDailyArchivistOutput({ dailySummaryMarkdown: "x", topicUpdates: {} }),
+      false,
+    );
+  });
+
+  it("rejects topic updates with an unknown action", () => {
+    assert.equal(
+      isDailyArchivistOutput({
+        dailySummaryMarkdown: "x",
+        topicUpdates: [{ slug: "a", action: "delete", content: "" }],
+      }),
+      false,
+    );
+  });
+
+  it("rejects non-object input", () => {
+    assert.equal(isDailyArchivistOutput(null), false);
+    assert.equal(isDailyArchivistOutput("str"), false);
+    assert.equal(isDailyArchivistOutput(42), false);
+  });
+});
+
+describe("isOptimizationOutput", () => {
+  it("accepts an empty valid output", () => {
+    assert.equal(isOptimizationOutput({ merges: [], archives: [] }), true);
+  });
+
+  it("accepts a populated valid output", () => {
+    assert.equal(
+      isOptimizationOutput({
+        merges: [{ from: ["a", "b"], into: "c", newContent: "..." }],
+        archives: ["stale"],
+      }),
+      true,
+    );
+  });
+
+  it("rejects merges with non-string from array elements", () => {
+    assert.equal(
+      isOptimizationOutput({
+        merges: [{ from: [1, 2], into: "c", newContent: "..." }],
+        archives: [],
+      }),
+      false,
+    );
+  });
+
+  it("rejects archives with non-string entries", () => {
+    assert.equal(isOptimizationOutput({ merges: [], archives: [1, 2] }), false);
+  });
+
+  it("rejects non-object input", () => {
+    assert.equal(isOptimizationOutput(null), false);
+  });
+});

--- a/test/journal/test_archivist.ts
+++ b/test/journal/test_archivist.ts
@@ -68,6 +68,7 @@ describe("buildDailyUserPrompt", () => {
               { source: "user", type: "text", content: "hello" },
               { source: "assistant", type: "text", content: "world" },
             ],
+            artifactPaths: [],
           },
         ],
       }),
@@ -75,6 +76,44 @@ describe("buildDailyUserPrompt", () => {
     assert.match(out, /### session sess-abc \(role: default\)/);
     assert.match(out, /\[user\/text\] hello/);
     assert.match(out, /\[assistant\/text\] world/);
+  });
+
+  it("shows '(none)' for an empty artifact set", () => {
+    const out = buildDailyUserPrompt(baseInput());
+    assert.match(out, /ARTIFACTS REFERENCED:\n\(none\)/);
+  });
+
+  it("aggregates artifact paths across sessions and sorts them", () => {
+    const out = buildDailyUserPrompt(
+      baseInput({
+        sessionExcerpts: [
+          {
+            sessionId: "s1",
+            roleId: "r",
+            events: [],
+            artifactPaths: ["stories/b.json", "wiki/pages/a.md"],
+          },
+          {
+            sessionId: "s2",
+            roleId: "r",
+            events: [],
+            artifactPaths: ["stories/b.json", "HTMLs/x.html"],
+          },
+        ],
+      }),
+    );
+    // All three paths appear, sorted, each only once.
+    const artifactsSection = out.slice(out.indexOf("ARTIFACTS REFERENCED:"));
+    const htmlIdx = artifactsSection.indexOf("- HTMLs/x.html");
+    const storiesIdx = artifactsSection.indexOf("- stories/b.json");
+    const wikiIdx = artifactsSection.indexOf("- wiki/pages/a.md");
+    assert.ok(htmlIdx !== -1, "HTMLs path should appear");
+    assert.ok(storiesIdx !== -1, "stories path should appear");
+    assert.ok(wikiIdx !== -1, "wiki path should appear");
+    assert.ok(htmlIdx < storiesIdx && storiesIdx < wikiIdx, "sorted ascending");
+    // Dedup check: stories/b.json should only appear once.
+    const matches = artifactsSection.match(/- stories\/b\.json/g);
+    assert.equal(matches?.length, 1);
   });
 });
 

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { entryToExcerpt } from "../../server/journal/dailyPass.js";
+
+describe("entryToExcerpt", () => {
+  it("converts a text entry", () => {
+    const out = entryToExcerpt({
+      source: "user",
+      type: "text",
+      message: "hello",
+    });
+    assert.deepEqual(out, {
+      source: "user",
+      type: "text",
+      content: "hello",
+    });
+  });
+
+  it("truncates very long text messages", () => {
+    const longMsg = "x".repeat(2000);
+    const out = entryToExcerpt({
+      source: "assistant",
+      type: "text",
+      message: longMsg,
+    });
+    assert.ok(out);
+    assert.ok(out!.content.length < longMsg.length);
+    assert.ok(out!.content.endsWith("…"));
+  });
+
+  it("converts a tool_result entry using toolName + title", () => {
+    const out = entryToExcerpt({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "generateImage",
+        title: "a sunset",
+        message: "full message",
+      },
+    });
+    assert.ok(out);
+    assert.match(out!.content, /generateImage: a sunset/);
+  });
+
+  it("falls back to message when title is missing", () => {
+    const out = entryToExcerpt({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "searchX",
+        message: "got 10 results",
+      },
+    });
+    assert.ok(out);
+    assert.match(out!.content, /searchX: got 10 results/);
+  });
+
+  it("falls back to '(no message)' when both title and message are missing", () => {
+    const out = entryToExcerpt({
+      source: "tool",
+      type: "tool_result",
+      result: { toolName: "weird" },
+    });
+    assert.ok(out);
+    assert.match(out!.content, /weird: \(no message\)/);
+  });
+
+  it("returns null for unrecognised entry types", () => {
+    assert.equal(
+      entryToExcerpt({ source: "user", type: "mystery", message: "x" }),
+      null,
+    );
+  });
+
+  it("returns null for text entries with no message", () => {
+    assert.equal(entryToExcerpt({ source: "user", type: "text" }), null);
+  });
+
+  it("returns null for tool_result with non-object result", () => {
+    assert.equal(
+      entryToExcerpt({ source: "tool", type: "tool_result", result: "str" }),
+      null,
+    );
+  });
+
+  it("handles missing source/type by using 'unknown'", () => {
+    const out = entryToExcerpt({ message: "hi", type: "text" });
+    assert.ok(out);
+    assert.equal(out!.source, "unknown");
+  });
+});

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { entryToExcerpt } from "../../server/journal/dailyPass.js";
+import {
+  entryToExcerpt,
+  extractArtifactPaths,
+  parseEntry,
+} from "../../server/journal/dailyPass.js";
 
 describe("entryToExcerpt", () => {
   it("converts a text entry", () => {
@@ -87,5 +91,137 @@ describe("entryToExcerpt", () => {
     const out = entryToExcerpt({ message: "hi", type: "text" });
     assert.ok(out);
     assert.equal(out!.source, "unknown");
+  });
+});
+
+describe("extractArtifactPaths", () => {
+  it("returns [] for text entries", () => {
+    assert.deepEqual(
+      extractArtifactPaths({ source: "user", type: "text", message: "hi" }),
+      [],
+    );
+  });
+
+  it("extracts data.filePath from a tool_result", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "presentMulmoScript",
+        data: { filePath: "stories/foo.json" },
+      },
+    });
+    assert.deepEqual(paths, ["stories/foo.json"]);
+  });
+
+  it("synthesises a wiki page path from manageWiki + pageName", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "manageWiki",
+        data: { action: "view", pageName: "refactoring" },
+      },
+    });
+    assert.deepEqual(paths, ["wiki/pages/refactoring.md"]);
+  });
+
+  it("extracts from presentHtml via data.filePath", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "presentHtml",
+        data: { filePath: "HTMLs/report.html" },
+      },
+    });
+    assert.deepEqual(paths, ["HTMLs/report.html"]);
+  });
+
+  it("rejects absolute paths in filePath", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "presentHtml",
+        data: { filePath: "/etc/passwd" },
+      },
+    });
+    assert.deepEqual(paths, []);
+  });
+
+  it("rejects parent-escape paths in filePath", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "presentHtml",
+        data: { filePath: "../../etc/passwd" },
+      },
+    });
+    assert.deepEqual(paths, []);
+  });
+
+  it("rejects scheme-looking paths in filePath", () => {
+    const paths = extractArtifactPaths({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "foo",
+        data: { filePath: "https://example.com/x" },
+      },
+    });
+    assert.deepEqual(paths, []);
+  });
+
+  it("returns [] when data is missing", () => {
+    assert.deepEqual(
+      extractArtifactPaths({
+        source: "tool",
+        type: "tool_result",
+        result: { toolName: "presentHtml" },
+      }),
+      [],
+    );
+  });
+
+  it("returns [] for non-tool_result entries", () => {
+    assert.deepEqual(
+      extractArtifactPaths({
+        type: "other",
+        result: { data: { filePath: "x" } },
+      }),
+      [],
+    );
+  });
+});
+
+describe("parseEntry", () => {
+  it("returns excerpt plus artifactPaths for a tool_result", () => {
+    const parsed = parseEntry({
+      source: "tool",
+      type: "tool_result",
+      result: {
+        toolName: "presentMulmoScript",
+        title: "story about a cat",
+        data: { filePath: "stories/cat.json" },
+      },
+    });
+    assert.ok(parsed);
+    assert.match(
+      parsed!.excerpt.content,
+      /presentMulmoScript: story about a cat/,
+    );
+    assert.deepEqual(parsed!.artifactPaths, ["stories/cat.json"]);
+  });
+
+  it("returns empty artifactPaths for a text entry", () => {
+    const parsed = parseEntry({ source: "user", type: "text", message: "hi" });
+    assert.ok(parsed);
+    assert.deepEqual(parsed!.artifactPaths, []);
+  });
+
+  it("returns null for entries that don't produce an excerpt", () => {
+    assert.equal(parseEntry({ source: "x", type: "mystery" }), null);
   });
 });

--- a/test/journal/test_diff.ts
+++ b/test/journal/test_diff.ts
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  findDirtySessions,
+  applyProcessed,
+  type SessionFileMeta,
+} from "../../server/journal/diff.js";
+
+describe("findDirtySessions", () => {
+  it("treats every session as dirty when processed state is empty", () => {
+    const current: SessionFileMeta[] = [
+      { id: "a", mtimeMs: 1000 },
+      { id: "b", mtimeMs: 2000 },
+    ];
+    const { dirty, missing } = findDirtySessions(current, {});
+    assert.deepEqual(dirty.sort(), ["a", "b"]);
+    assert.deepEqual(missing, []);
+  });
+
+  it("returns no dirty sessions when every mtime matches", () => {
+    const current: SessionFileMeta[] = [
+      { id: "a", mtimeMs: 1000 },
+      { id: "b", mtimeMs: 2000 },
+    ];
+    const { dirty } = findDirtySessions(current, {
+      a: { lastMtimeMs: 1000 },
+      b: { lastMtimeMs: 2000 },
+    });
+    assert.deepEqual(dirty, []);
+  });
+
+  it("flags a session whose mtime has advanced", () => {
+    const current: SessionFileMeta[] = [{ id: "a", mtimeMs: 2500 }];
+    const { dirty } = findDirtySessions(current, {
+      a: { lastMtimeMs: 1000 },
+    });
+    assert.deepEqual(dirty, ["a"]);
+  });
+
+  it("does not flag a session whose mtime is unchanged but flags a sibling that moved", () => {
+    const current: SessionFileMeta[] = [
+      { id: "stable", mtimeMs: 1000 },
+      { id: "moved", mtimeMs: 3000 },
+    ];
+    const { dirty } = findDirtySessions(current, {
+      stable: { lastMtimeMs: 1000 },
+      moved: { lastMtimeMs: 2000 },
+    });
+    assert.deepEqual(dirty, ["moved"]);
+  });
+
+  it("reports processed sessions that no longer exist on disk as missing", () => {
+    const current: SessionFileMeta[] = [{ id: "a", mtimeMs: 1000 }];
+    const { dirty, missing } = findDirtySessions(current, {
+      a: { lastMtimeMs: 1000 },
+      "b-gone": { lastMtimeMs: 500 },
+    });
+    assert.deepEqual(dirty, []);
+    assert.deepEqual(missing, ["b-gone"]);
+  });
+
+  it("handles the combined case of new, changed, unchanged, and missing", () => {
+    const current: SessionFileMeta[] = [
+      { id: "new", mtimeMs: 5000 },
+      { id: "changed", mtimeMs: 4000 },
+      { id: "unchanged", mtimeMs: 1000 },
+    ];
+    const { dirty, missing } = findDirtySessions(current, {
+      changed: { lastMtimeMs: 2000 },
+      unchanged: { lastMtimeMs: 1000 },
+      deleted: { lastMtimeMs: 100 },
+    });
+    assert.deepEqual(dirty.sort(), ["changed", "new"]);
+    assert.deepEqual(missing, ["deleted"]);
+  });
+});
+
+describe("applyProcessed", () => {
+  it("inserts new records for previously-unknown sessions", () => {
+    const result = applyProcessed({}, [{ id: "a", mtimeMs: 1000 }]);
+    assert.deepEqual(result, { a: { lastMtimeMs: 1000 } });
+  });
+
+  it("overwrites mtime for already-known sessions", () => {
+    const result = applyProcessed({ a: { lastMtimeMs: 500 } }, [
+      { id: "a", mtimeMs: 2000 },
+    ]);
+    assert.deepEqual(result, { a: { lastMtimeMs: 2000 } });
+  });
+
+  it("preserves records for sessions not in the just-processed list", () => {
+    const result = applyProcessed({ kept: { lastMtimeMs: 111 } }, [
+      { id: "new", mtimeMs: 222 },
+    ]);
+    assert.deepEqual(result, {
+      kept: { lastMtimeMs: 111 },
+      new: { lastMtimeMs: 222 },
+    });
+  });
+
+  it("does not mutate the previous map", () => {
+    const previous = { a: { lastMtimeMs: 1 } };
+    applyProcessed(previous, [{ id: "a", mtimeMs: 999 }]);
+    assert.deepEqual(previous, { a: { lastMtimeMs: 1 } });
+  });
+});

--- a/test/journal/test_indexFile.ts
+++ b/test/journal/test_indexFile.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildIndexMarkdown,
+  DEFAULT_MAX_RECENT_DAYS,
+  type IndexInputs,
+} from "../../server/journal/indexFile.js";
+
+function baseInput(over: Partial<IndexInputs> = {}): IndexInputs {
+  return {
+    topics: [],
+    days: [],
+    archivedTopicCount: 0,
+    builtAtIso: "2026-04-11T09:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("buildIndexMarkdown", () => {
+  it("renders empty placeholders when there is nothing to index", () => {
+    const out = buildIndexMarkdown(baseInput());
+    assert.match(out, /# Workspace Journal/);
+    assert.match(out, /Last updated: 2026-04-11T09:00:00\.000Z/);
+    assert.match(out, /_No topics yet\._/);
+    assert.match(out, /_No daily entries yet\._/);
+    assert.match(out, /_No archived topics\._/);
+  });
+
+  it("sorts topics newest-first by lastUpdatedIso", () => {
+    const out = buildIndexMarkdown(
+      baseInput({
+        topics: [
+          { slug: "older", lastUpdatedIso: "2026-04-01T00:00:00Z" },
+          { slug: "newer", lastUpdatedIso: "2026-04-10T00:00:00Z" },
+          { slug: "mid", lastUpdatedIso: "2026-04-05T00:00:00Z" },
+        ],
+      }),
+    );
+    const newerIdx = out.indexOf("newer");
+    const midIdx = out.indexOf("mid");
+    const olderIdx = out.indexOf("older");
+    assert.ok(newerIdx < midIdx && midIdx < olderIdx, "expected newest first");
+  });
+
+  it("sorts topics with no timestamp after timestamped ones, alphabetically", () => {
+    const out = buildIndexMarkdown(
+      baseInput({
+        topics: [
+          { slug: "zebra" },
+          { slug: "alpha" },
+          { slug: "dated", lastUpdatedIso: "2026-04-01T00:00:00Z" },
+        ],
+      }),
+    );
+    const datedIdx = out.indexOf("dated");
+    const alphaIdx = out.indexOf("alpha");
+    const zebraIdx = out.indexOf("zebra");
+    assert.ok(datedIdx < alphaIdx, "dated topic should come first");
+    assert.ok(alphaIdx < zebraIdx, "alpha should precede zebra among undated");
+  });
+
+  it("uses the topic title when present and falls back to slug otherwise", () => {
+    const out = buildIndexMarkdown(
+      baseInput({
+        topics: [
+          { slug: "video-generation", title: "Video Generation" },
+          { slug: "bare-slug" },
+        ],
+      }),
+    );
+    assert.match(out, /\[Video Generation\]\(topics\/video-generation\.md\)/);
+    assert.match(out, /\[bare-slug\]\(topics\/bare-slug\.md\)/);
+  });
+
+  it("sorts daily entries newest-first", () => {
+    const out = buildIndexMarkdown(
+      baseInput({
+        days: [
+          { date: "2026-04-09" },
+          { date: "2026-04-11" },
+          { date: "2026-04-10" },
+        ],
+      }),
+    );
+    const d11 = out.indexOf("2026-04-11");
+    const d10 = out.indexOf("2026-04-10");
+    const d09 = out.indexOf("2026-04-09");
+    assert.ok(d11 < d10 && d10 < d09);
+  });
+
+  it("collapses older days beyond maxRecentDays with a footer", () => {
+    const days = Array.from({ length: DEFAULT_MAX_RECENT_DAYS + 5 }, (_, i) => {
+      const day = String(i + 1).padStart(2, "0");
+      return { date: `2026-04-${day}` };
+    });
+    const out = buildIndexMarkdown(baseInput({ days }));
+    assert.match(out, /…and 5 earlier days\./);
+  });
+
+  it("uses singular 'day' when exactly one is collapsed", () => {
+    const days = Array.from({ length: DEFAULT_MAX_RECENT_DAYS + 1 }, (_, i) => {
+      const day = String(i + 1).padStart(2, "0");
+      return { date: `2026-04-${day}` };
+    });
+    const out = buildIndexMarkdown(baseInput({ days }));
+    assert.match(out, /…and 1 earlier day\./);
+  });
+
+  it("renders the archive count when > 0", () => {
+    const out = buildIndexMarkdown(baseInput({ archivedTopicCount: 3 }));
+    assert.match(out, /Archived topics.*3 archived topics/);
+  });
+
+  it("uses singular noun when exactly one topic is archived", () => {
+    const out = buildIndexMarkdown(baseInput({ archivedTopicCount: 1 }));
+    assert.match(out, /1 archived topic\b/);
+  });
+
+  it("renders daily row with nested YYYY/MM/DD path", () => {
+    const out = buildIndexMarkdown(
+      baseInput({ days: [{ date: "2026-04-11" }] }),
+    );
+    assert.match(out, /\[2026-04-11\]\(daily\/2026\/04\/11\.md\)/);
+  });
+});

--- a/test/journal/test_indexWalkers.ts
+++ b/test/journal/test_indexWalkers.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractFirstH1 } from "../../server/journal/index.js";
+
+describe("extractFirstH1", () => {
+  it("returns the first H1 heading text", () => {
+    const md = "intro\n# Video Generation\nmore body";
+    assert.equal(extractFirstH1(md), "Video Generation");
+  });
+
+  it("prefers the first H1 even when later ones exist", () => {
+    const md = "# First\ntext\n# Second";
+    assert.equal(extractFirstH1(md), "First");
+  });
+
+  it("ignores H2 and deeper headings", () => {
+    const md = "## Not an H1\n### Also not\n# Actual H1";
+    assert.equal(extractFirstH1(md), "Actual H1");
+  });
+
+  it("returns null when no H1 is present", () => {
+    assert.equal(extractFirstH1("## Only H2\ntext"), null);
+    assert.equal(extractFirstH1("plain body no heading"), null);
+  });
+
+  it("trims trailing whitespace from the heading", () => {
+    assert.equal(extractFirstH1("#   spaced heading   "), "spaced heading");
+  });
+
+  it("handles empty input", () => {
+    assert.equal(extractFirstH1(""), null);
+  });
+});

--- a/test/journal/test_linkRewrite.ts
+++ b/test/journal/test_linkRewrite.ts
@@ -1,0 +1,185 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  rewriteWorkspaceLinks,
+  rewriteMarkdownLinks,
+} from "../../server/journal/linkRewrite.js";
+
+describe("rewriteWorkspaceLinks", () => {
+  it("rewrites a workspace-absolute link from a topic file", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/refactoring.md",
+      "See [wiki](/wiki/pages/foo.md) for details.",
+    );
+    assert.equal(out, "See [wiki](../../wiki/pages/foo.md) for details.");
+  });
+
+  it("rewrites from a nested daily file", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/daily/2026/04/11.md",
+      "Today: [html](/HTMLs/report.html)",
+    );
+    assert.equal(out, "Today: [html](../../../../HTMLs/report.html)");
+  });
+
+  it("leaves true-relative links alone", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "See [other](../daily/2026/04/11.md)",
+    );
+    assert.equal(out, "See [other](../daily/2026/04/11.md)");
+  });
+
+  it("leaves external URLs alone", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "See [docs](https://example.com/foo)",
+    );
+    assert.equal(out, "See [docs](https://example.com/foo)");
+  });
+
+  it("leaves protocol-relative URLs alone", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "See [cdn](//cdn.example.com/foo)",
+    );
+    assert.equal(out, "See [cdn](//cdn.example.com/foo)");
+  });
+
+  it("leaves anchor-only links alone", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "Jump to [section](#details)",
+    );
+    assert.equal(out, "Jump to [section](#details)");
+  });
+
+  it("preserves #fragment on rewritten links", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "See [wiki heading](/wiki/pages/foo.md#section-2)",
+    );
+    assert.equal(out, "See [wiki heading](../../wiki/pages/foo.md#section-2)");
+  });
+
+  it("handles multiple links in one document", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "[a](/wiki/a.md) and [b](/wiki/b.md) and [c](https://x.com) and [d](../bar.md)",
+    );
+    assert.equal(
+      out,
+      "[a](../../wiki/a.md) and [b](../../wiki/b.md) and [c](https://x.com) and [d](../bar.md)",
+    );
+  });
+
+  it("handles a link at the start of a line", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "- [wiki](/wiki/foo.md) — updated today",
+    );
+    assert.equal(out, "- [wiki](../../wiki/foo.md) — updated today");
+  });
+
+  it("handles markdown headings and prose around links", () => {
+    const md = [
+      "# Title",
+      "",
+      "Some [link](/wiki/pages/topic.md) in prose.",
+      "",
+      "## Subheading",
+      "",
+      "- bullet [two](/HTMLs/report.html) here",
+    ].join("\n");
+    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.md", md);
+    assert.match(
+      out,
+      /\[link\]\(\.\.\/\.\.\/\.\.\/\.\.\/wiki\/pages\/topic\.md\)/,
+    );
+    assert.match(out, /\[two\]\(\.\.\/\.\.\/\.\.\/\.\.\/HTMLs\/report\.html\)/);
+  });
+
+  it("does not touch square brackets that are not links", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "TODO item: [x] done, [ ] pending",
+    );
+    assert.equal(out, "TODO item: [x] done, [ ] pending");
+  });
+
+  it("handles '/' (root) href by returning '.' relative", () => {
+    // Edge case: link to the workspace root itself. Not useful in
+    // practice but must not crash.
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[root](/)");
+    assert.equal(out, "[root](/)");
+  });
+
+  it("emits '.' for a self-reference", () => {
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "[self](/summaries/topics/foo.md)",
+    );
+    // relative from "summaries/topics" to "summaries/topics/foo.md"
+    // is "foo.md" — not a self-reference; let me rewrite the test.
+    assert.equal(out, "[self](foo.md)");
+  });
+
+  it("emits '.' when target equals current directory", () => {
+    // current = "summaries/topics/foo.md", link to "/summaries/topics"
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.md",
+      "[dir](/summaries/topics)",
+    );
+    assert.equal(out, "[dir](.)");
+  });
+});
+
+describe("rewriteMarkdownLinks", () => {
+  it("invokes the rewrite callback for each link href", () => {
+    const seen: string[] = [];
+    rewriteMarkdownLinks("[a](/one) and [b](/two)", (href) => {
+      seen.push(href);
+      return href;
+    });
+    assert.deepEqual(seen, ["/one", "/two"]);
+  });
+
+  it("replaces hrefs with the callback return value", () => {
+    const out = rewriteMarkdownLinks("[x](old) and [y](keep)", (href) =>
+      href === "old" ? "NEW" : href,
+    );
+    assert.equal(out, "[x](NEW) and [y](keep)");
+  });
+
+  it("leaves unterminated '[' alone", () => {
+    const out = rewriteMarkdownLinks("[unclosed text", (href) => href);
+    assert.equal(out, "[unclosed text");
+  });
+
+  it("leaves unterminated '(' alone", () => {
+    const out = rewriteMarkdownLinks("[text](unclosed", (href) => href);
+    assert.equal(out, "[text](unclosed");
+  });
+
+  it("passes through plain bracketed text that is not a link", () => {
+    const out = rewriteMarkdownLinks("[not a link] followed by text", (h) => h);
+    assert.equal(out, "[not a link] followed by text");
+  });
+
+  it("handles an empty input", () => {
+    assert.equal(
+      rewriteMarkdownLinks("", (h) => h),
+      "",
+    );
+  });
+
+  it("handles input with no links at all", () => {
+    const out = rewriteMarkdownLinks("plain prose without links", (h) => h);
+    assert.equal(out, "plain prose without links");
+  });
+
+  it("handles adjacent links with no separator", () => {
+    const out = rewriteMarkdownLinks("[a](1)[b](2)", (href) => `NEW-${href}`);
+    assert.equal(out, "[a](NEW-1)[b](NEW-2)");
+  });
+});

--- a/test/journal/test_paths.ts
+++ b/test/journal/test_paths.ts
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  summariesRoot,
+  dailyPathFor,
+  topicPathFor,
+  archivedTopicPathFor,
+  toIsoDate,
+  slugify,
+} from "../../server/journal/paths.js";
+
+const WS = "/fake/workspace";
+
+describe("summariesRoot", () => {
+  it("joins workspace root with the summaries dir", () => {
+    assert.equal(summariesRoot(WS), path.join(WS, "summaries"));
+  });
+});
+
+describe("dailyPathFor", () => {
+  it("builds summaries/daily/YYYY/MM/DD.md", () => {
+    assert.equal(
+      dailyPathFor(WS, "2026-04-11"),
+      path.join(WS, "summaries", "daily", "2026", "04", "11.md"),
+    );
+  });
+
+  it("preserves leading zeros", () => {
+    assert.equal(
+      dailyPathFor(WS, "2026-01-03"),
+      path.join(WS, "summaries", "daily", "2026", "01", "03.md"),
+    );
+  });
+});
+
+describe("topicPathFor", () => {
+  it("builds summaries/topics/<slug>.md", () => {
+    assert.equal(
+      topicPathFor(WS, "refactoring"),
+      path.join(WS, "summaries", "topics", "refactoring.md"),
+    );
+  });
+});
+
+describe("archivedTopicPathFor", () => {
+  it("builds summaries/archive/topics/<slug>.md", () => {
+    assert.equal(
+      archivedTopicPathFor(WS, "old-topic"),
+      path.join(WS, "summaries", "archive", "topics", "old-topic.md"),
+    );
+  });
+});
+
+describe("toIsoDate", () => {
+  it("formats a Date in local time as YYYY-MM-DD", () => {
+    // Pick a date in the middle of a month to avoid timezone edge
+    // cases flipping the result. April 15 at noon local is April 15
+    // in every timezone on Earth.
+    const d = new Date(2026, 3, 15, 12, 0, 0); // month is 0-indexed
+    assert.equal(toIsoDate(d), "2026-04-15");
+  });
+
+  it("pads single-digit months and days", () => {
+    const d = new Date(2026, 0, 3, 12, 0, 0);
+    assert.equal(toIsoDate(d), "2026-01-03");
+  });
+
+  it("accepts a ms timestamp", () => {
+    const d = new Date(2026, 5, 20, 12, 0, 0);
+    assert.equal(toIsoDate(d.getTime()), "2026-06-20");
+  });
+});
+
+describe("slugify", () => {
+  it("lowercases ASCII input", () => {
+    assert.equal(slugify("Refactoring"), "refactoring");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    assert.equal(slugify("video generation"), "video-generation");
+  });
+
+  it("collapses runs of separators", () => {
+    assert.equal(slugify("foo   bar___baz"), "foo-bar-baz");
+  });
+
+  it("strips leading and trailing separators", () => {
+    assert.equal(slugify("--hello--"), "hello");
+  });
+
+  it("keeps digits", () => {
+    assert.equal(slugify("v2 release"), "v2-release");
+  });
+
+  it("strips punctuation", () => {
+    assert.equal(slugify("Q&A: notes!"), "q-a-notes");
+  });
+
+  it("drops non-ASCII characters", () => {
+    // "リファクタリング" drops entirely; fallback kicks in.
+    assert.equal(slugify("リファクタリング"), "topic");
+  });
+
+  it("keeps ASCII portions when mixed with non-ASCII", () => {
+    assert.equal(slugify("mulmo リファクタ"), "mulmo");
+  });
+
+  it("falls back to 'topic' for empty input", () => {
+    assert.equal(slugify(""), "topic");
+  });
+
+  it("falls back to 'topic' for whitespace-only input", () => {
+    assert.equal(slugify("   "), "topic");
+  });
+
+  it("is idempotent for already-slugged input", () => {
+    assert.equal(slugify("already-slugged"), "already-slugged");
+  });
+});

--- a/test/journal/test_state.ts
+++ b/test/journal/test_state.ts
@@ -1,0 +1,157 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  defaultState,
+  parseState,
+  isDailyDue,
+  isOptimizationDue,
+  JOURNAL_STATE_VERSION,
+  DEFAULT_DAILY_INTERVAL_HOURS,
+  DEFAULT_OPTIMIZATION_INTERVAL_DAYS,
+  type JournalState,
+} from "../../server/journal/state.js";
+
+describe("defaultState", () => {
+  it("produces a valid fresh state with the current schema version", () => {
+    const s = defaultState();
+    assert.equal(s.version, JOURNAL_STATE_VERSION);
+    assert.equal(s.lastDailyRunAt, null);
+    assert.equal(s.lastOptimizationRunAt, null);
+    assert.equal(s.dailyIntervalHours, DEFAULT_DAILY_INTERVAL_HOURS);
+    assert.equal(
+      s.optimizationIntervalDays,
+      DEFAULT_OPTIMIZATION_INTERVAL_DAYS,
+    );
+    assert.deepEqual(s.processedSessions, {});
+    assert.deepEqual(s.knownTopics, []);
+  });
+});
+
+describe("parseState", () => {
+  it("returns defaults for null / non-object input", () => {
+    assert.deepEqual(parseState(null), defaultState());
+    assert.deepEqual(parseState("foo"), defaultState());
+    assert.deepEqual(parseState(42), defaultState());
+  });
+
+  it("returns defaults when the version mismatches", () => {
+    const parsed = parseState({ version: 999, lastDailyRunAt: "ignored" });
+    assert.equal(parsed.lastDailyRunAt, null);
+  });
+
+  it("round-trips a well-formed state", () => {
+    const s: JournalState = {
+      version: JOURNAL_STATE_VERSION,
+      lastDailyRunAt: "2026-04-11T09:00:00.000Z",
+      lastOptimizationRunAt: "2026-04-05T09:00:00.000Z",
+      dailyIntervalHours: 2,
+      optimizationIntervalDays: 14,
+      processedSessions: { "abc-123": { lastMtimeMs: 1710000000000 } },
+      knownTopics: ["refactoring", "video-generation"],
+    };
+    assert.deepEqual(parseState(s), s);
+  });
+
+  it("restores default intervals when stored values are non-positive", () => {
+    const parsed = parseState({
+      version: JOURNAL_STATE_VERSION,
+      dailyIntervalHours: 0,
+      optimizationIntervalDays: -3,
+    });
+    assert.equal(parsed.dailyIntervalHours, DEFAULT_DAILY_INTERVAL_HOURS);
+    assert.equal(
+      parsed.optimizationIntervalDays,
+      DEFAULT_OPTIMIZATION_INTERVAL_DAYS,
+    );
+  });
+
+  it("drops processedSessions entries with invalid mtime", () => {
+    const parsed = parseState({
+      version: JOURNAL_STATE_VERSION,
+      processedSessions: {
+        good: { lastMtimeMs: 1000 },
+        "bad-string": { lastMtimeMs: "nope" },
+        "bad-negative": { lastMtimeMs: -5 },
+        "bad-shape": "not an object",
+      },
+    });
+    assert.deepEqual(parsed.processedSessions, {
+      good: { lastMtimeMs: 1000 },
+    });
+  });
+
+  it("filters non-string entries out of knownTopics", () => {
+    const parsed = parseState({
+      version: JOURNAL_STATE_VERSION,
+      knownTopics: ["ok", 42, null, "also-ok"],
+    });
+    assert.deepEqual(parsed.knownTopics, ["ok", "also-ok"]);
+  });
+});
+
+describe("isDailyDue", () => {
+  const base = defaultState();
+  base.dailyIntervalHours = 1;
+  const HOUR = 60 * 60 * 1000;
+
+  it("is true when lastDailyRunAt is null (never run)", () => {
+    assert.equal(isDailyDue(base, Date.now()), true);
+  });
+
+  it("is true when an unparseable string is stored", () => {
+    const s = { ...base, lastDailyRunAt: "not a date" };
+    assert.equal(isDailyDue(s, Date.now()), true);
+  });
+
+  it("is false when less than one interval has elapsed", () => {
+    const anchor = new Date("2026-04-11T09:00:00Z");
+    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(s, anchor.getTime() + 30 * 60 * 1000), false);
+  });
+
+  it("is true at exactly one interval elapsed", () => {
+    const anchor = new Date("2026-04-11T09:00:00Z");
+    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(s, anchor.getTime() + HOUR), true);
+  });
+
+  it("is true after more than one interval", () => {
+    const anchor = new Date("2026-04-11T09:00:00Z");
+    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(s, anchor.getTime() + 2 * HOUR), true);
+  });
+
+  it("respects a custom interval stored in state", () => {
+    const anchor = new Date("2026-04-11T09:00:00Z");
+    const s = {
+      ...base,
+      dailyIntervalHours: 6,
+      lastDailyRunAt: anchor.toISOString(),
+    };
+    // 3 hours later — not due with a 6h interval
+    assert.equal(isDailyDue(s, anchor.getTime() + 3 * HOUR), false);
+    // 6 hours later — exactly due
+    assert.equal(isDailyDue(s, anchor.getTime() + 6 * HOUR), true);
+  });
+});
+
+describe("isOptimizationDue", () => {
+  const base = defaultState();
+  const DAY = 24 * 60 * 60 * 1000;
+
+  it("is true when lastOptimizationRunAt is null", () => {
+    assert.equal(isOptimizationDue(base, Date.now()), true);
+  });
+
+  it("is false until the full interval has passed", () => {
+    const anchor = new Date("2026-04-01T00:00:00Z");
+    const s = { ...base, lastOptimizationRunAt: anchor.toISOString() };
+    assert.equal(isOptimizationDue(s, anchor.getTime() + 6 * DAY), false);
+  });
+
+  it("is true exactly at the interval boundary", () => {
+    const anchor = new Date("2026-04-01T00:00:00Z");
+    const s = { ...base, lastOptimizationRunAt: anchor.toISOString() };
+    assert.equal(isOptimizationDue(s, anchor.getTime() + 7 * DAY), true);
+  });
+});

--- a/test/utils/path/test_relativeLink.ts
+++ b/test/utils/path/test_relativeLink.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   isExternalHref,
   resolveWorkspaceLink,
+  extractSessionIdFromPath,
 } from "../../../src/utils/path/relativeLink.js";
 
 describe("isExternalHref", () => {
@@ -164,5 +165,43 @@ describe("resolveWorkspaceLink", () => {
       resolveWorkspaceLink("summaries/topics/foo.md", "?query=1"),
       null,
     );
+  });
+});
+
+describe("extractSessionIdFromPath", () => {
+  it("extracts a session id from chat/<id>.jsonl", () => {
+    assert.equal(
+      extractSessionIdFromPath("chat/abc-123-def.jsonl"),
+      "abc-123-def",
+    );
+  });
+
+  it("handles a full UUID", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    assert.equal(extractSessionIdFromPath(`chat/${uuid}.jsonl`), uuid);
+  });
+
+  it("returns null for paths outside chat/", () => {
+    assert.equal(extractSessionIdFromPath("wiki/foo.jsonl"), null);
+    assert.equal(extractSessionIdFromPath("foo/chat/abc.jsonl"), null);
+  });
+
+  it("returns null for non-jsonl extensions", () => {
+    assert.equal(extractSessionIdFromPath("chat/abc.md"), null);
+    assert.equal(extractSessionIdFromPath("chat/abc.json"), null);
+    assert.equal(extractSessionIdFromPath("chat/abc"), null);
+  });
+
+  it("returns null when the id portion is empty", () => {
+    assert.equal(extractSessionIdFromPath("chat/.jsonl"), null);
+  });
+
+  it("returns null for nested paths under chat/", () => {
+    assert.equal(extractSessionIdFromPath("chat/subdir/foo.jsonl"), null);
+  });
+
+  it("returns null for the bare chat/ directory", () => {
+    assert.equal(extractSessionIdFromPath("chat/"), null);
+    assert.equal(extractSessionIdFromPath("chat"), null);
   });
 });

--- a/test/utils/path/test_relativeLink.ts
+++ b/test/utils/path/test_relativeLink.ts
@@ -1,0 +1,168 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isExternalHref,
+  resolveWorkspaceLink,
+} from "../../../src/utils/path/relativeLink.js";
+
+describe("isExternalHref", () => {
+  it("treats http and https as external", () => {
+    assert.equal(isExternalHref("http://example.com"), true);
+    assert.equal(isExternalHref("https://example.com/path"), true);
+  });
+
+  it("treats mailto and tel as external", () => {
+    assert.equal(isExternalHref("mailto:alice@example.com"), true);
+    assert.equal(isExternalHref("tel:+123456"), true);
+  });
+
+  it("treats ftp as external", () => {
+    assert.equal(isExternalHref("ftp://files.example.com"), true);
+  });
+
+  it("treats protocol-relative URLs as external", () => {
+    assert.equal(isExternalHref("//cdn.example.com/x.js"), true);
+  });
+
+  it("treats an unknown scheme as external", () => {
+    assert.equal(isExternalHref("vscode://foo"), true);
+  });
+
+  it("treats relative paths as internal", () => {
+    assert.equal(isExternalHref("../wiki/foo.md"), false);
+    assert.equal(isExternalHref("foo.md"), false);
+    assert.equal(isExternalHref("./bar.md"), false);
+  });
+
+  it("treats workspace-absolute paths as internal", () => {
+    assert.equal(isExternalHref("/wiki/foo.md"), false);
+    assert.equal(isExternalHref("/html/current.html"), false);
+  });
+
+  it("treats anchor-only as internal (the caller handles #)", () => {
+    assert.equal(isExternalHref("#section"), false);
+  });
+
+  it("treats empty as external (no sense in navigating)", () => {
+    assert.equal(isExternalHref(""), true);
+  });
+
+  it("treats a path with ':' after a '/' as internal", () => {
+    // e.g. "foo/bar:baz.md" — unusual filename but not a URL scheme.
+    assert.equal(isExternalHref("foo/bar:baz.md"), false);
+  });
+});
+
+describe("resolveWorkspaceLink", () => {
+  it("resolves a relative link from a topic file into a sibling folder", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "../../wiki/foo.md"),
+      "wiki/foo.md",
+    );
+  });
+
+  it("resolves a workspace-absolute link", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "/wiki/foo.md"),
+      "wiki/foo.md",
+    );
+  });
+
+  it("resolves ./sibling.md correctly", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "./bar.md"),
+      "summaries/topics/bar.md",
+    );
+  });
+
+  it("resolves a bare filename as a sibling", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "bar.md"),
+      "summaries/topics/bar.md",
+    );
+  });
+
+  it("strips #fragment from the resolved path", () => {
+    assert.equal(
+      resolveWorkspaceLink(
+        "summaries/topics/foo.md",
+        "../../wiki/foo.md#heading",
+      ),
+      "wiki/foo.md",
+    );
+  });
+
+  it("strips ?query from the resolved path", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "../../wiki/foo.md?v=2"),
+      "wiki/foo.md",
+    );
+  });
+
+  it("returns null for external URLs", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "https://example.com"),
+      null,
+    );
+  });
+
+  it("returns null for anchor-only links", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "#section"),
+      null,
+    );
+  });
+
+  it("returns null for an empty href", () => {
+    assert.equal(resolveWorkspaceLink("summaries/topics/foo.md", ""), null);
+  });
+
+  it("returns null when ../ escapes the workspace root", () => {
+    assert.equal(resolveWorkspaceLink("foo.md", "../../../etc/passwd"), null);
+  });
+
+  it("returns null when workspace-absolute ../ escapes", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "/../../etc/passwd"),
+      null,
+    );
+  });
+
+  it("resolves from a deeply-nested daily file", () => {
+    assert.equal(
+      resolveWorkspaceLink(
+        "summaries/daily/2026/04/11.md",
+        "../../../../wiki/foo.md",
+      ),
+      "wiki/foo.md",
+    );
+  });
+
+  it("handles a file at the workspace root", () => {
+    assert.equal(
+      resolveWorkspaceLink("memory.md", "wiki/foo.md"),
+      "wiki/foo.md",
+    );
+  });
+
+  it("handles dot-dot that lands on a sibling", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "../daily/2026/04/11.md"),
+      "summaries/daily/2026/04/11.md",
+    );
+  });
+
+  it("collapses redundant ./ segments", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "./././bar.md"),
+      "summaries/topics/bar.md",
+    );
+  });
+
+  it("returns null for a pure fragment after stripping", () => {
+    assert.equal(
+      resolveWorkspaceLink("summaries/topics/foo.md", "?query=1"),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## User Prompt

> もっと対話の結果をファイルに保存していきたい。ユーザの関心に合わせてカテゴリーを作って、サマリーを保存するのと、毎日の会話のサマリーをyyyy/mm/dd的なdirに保存する感じで。会話をトリガーに裏側で自動的にまとめて保存するのとdir構成なんかは勝手に考えて定期的に最適化してほしい。
>
> Scope: MulmoClaude の機能として実装。基本は全自動。リアルタイムじゃなくてよい、前に実行した時間を覚えておいて、一定時間感覚に差分があればそれを更新。indexもつくって参照しやすく。
>
> Settings: daily interval は 1 時間、Phase 1+2 両方、LLM 呼び出しは SDK じゃなく `claude` CLI を subprocess で(サブスク枠を使う)。
>
> (後続) 起動時に強制的にサマリー作れる?デバッグ用。
>
> (後続) サマリーで wiki や html など生成物について書いてあるものは、相対リンクでリンクを張ってほしい。ファイルエクスプローラーもそれに対応してくれるとなお嬉しい。vue-router を使って URL 化するとそのへんもうまくいくのかな?
>
> (後続) daily のログに session id があるけど、これでそのチャットにリンクを貼ることはできる?chat log じゃなくてサイドメニューのチャットをその状態にしたい。
>
> (後続) `_state.json` は最後にまとめて更新するんじゃなくて、一つひとつ処理が終わるたびに更新するのがよいかも。

## 概要

会話ログ (`workspace/chat/*.jsonl`) を自動で読み、**日次** と **トピック別** に要約をファイル化していく仕組みを追加。ワークスペースが自己管理するジャーナルになります。

設計の全容は [`plans/feat-auto-journal.md`](./plans/feat-auto-journal.md) 参照。

## 保存先のレイアウト

```text
workspace/
  chat/                      # 既存(生ログ)
  memory.md                  # 既存
  summaries/                 # ← 新規
    _index.md                # トピック + 最近の日の index
    _state.json              # lastRunAt / processedSessions / intervals
    daily/
      2026/04/11.md          # 日次要約
    topics/
      refactoring.md         # 長期トピック(LLM が自動分類)
      video-generation.md
    archive/
      topics/                # optimization pass が移したもの
```

## 動作モデル

- **トリガ**: `server/routes/agent.ts` の `finally` ブロックから fire-and-forget で `maybeRunJournal()` を呼ぶ。間隔が経過してなければ即 return
- **Daily pass** (デフォルト 1 時間おき): dirty セッション検出 → 日付ごとにバケット → archivist に投げる → `daily/*.md` 書き / `topics/*.md` 作成・追記・書き換え → **day ごとに `_state.json` を incremental 更新**(後述)
- **Optimization pass** (デフォルト 7 日おき): 全トピックヘッドを LLM に投げて「マージすべき」「アーカイブすべき」を判定させる
- **Index 再生成**: フィルシステムを walk するだけ(LLM なし)、各 pass 終端で実行
- **デバッグ用 force run**: `JOURNAL_FORCE_RUN_ON_STARTUP=1` でサーバ起動直後に間隔チェックを skip して即時実行

## LLM 呼び出し

API SDK の代わりに **`claude` CLI を subprocess spawn** で呼ぶ。stdin でプロンプト丸ごと流すので argv 長制限に引っかからない。

- 5 分タイムアウト、stdin backpressure + error ハンドリング
- `ENOENT` → そのサーバ起動中はジャーナル全体を自動 disable(スパムログ回避)
- 認証切れ / 非 0 exit → 当該日だけスキップ、次回リトライ
- 応答は ``` ```json ... ``` ``` を探す(regex なし、indexOf パース)→ JSON 解析

## サマリから成果物へのクロスリンク (A + B)

[Issue #108](../../issues/108) で議論した「vue-router を入れるかどうか」の案件。vue-router 導入は保留して、このPRでは以下 2 点だけ対応:

### A. Archivist が相対リンクを出す

- Tool result から **アーティファクトファイルパスを抽出** して `ARTIFACTS REFERENCED` プロンプトセクションに渡す
  - `data.filePath` 直接(`presentMulmoScript` / `presentHtml`)
  - `manageWiki` は `pageName` から `wiki/pages/<name>.md` を合成
  - 絶対パス / 親エスケープ / scheme-like は defensive に弾く
- Archivist は **workspace-absolute** パス (`[wiki](/wiki/foo.md)`) を出すよう system prompt で指示
- **Session 参照も同様に** `[session abc](/chat/<sessionId>.jsonl)` で出すよう追加指示
- `linkRewrite.rewriteWorkspaceLinks(currentFileWsPath, content)` が post-process で `../../wiki/foo.md` 形式に変換して書き込み
  - 純関数、character-level 解析(regex なし)、`#fragment` 保持、ユニットテスト済み

### B. FilesView が相対リンククリックを解釈

- markdown レンダラの `<a>` クリックを `@click.capture` でインターセプト
- `isExternalHref` / `resolveWorkspaceLink` / `extractSessionIdFromPath` の pure 関数で判別
- アーティファクトパス → FilesView 内でファイル切替
- **session jsonl パス → `loadSession` イベント emit**:
  - App.vue の bridge 関数が `loadSession(id)` を呼んでサイドバーのチャットを切替
  - かつ `canvasViewMode` を `files` から `single` に戻すので、クリック後にチャット本体が見える
- ファイルツリー直接クリックは従来通り raw jsonl 表示(入口ごとに挙動分け)

## 頑健性

- **`_state.json` は atomic (tmp + rename) AND per-day incremental**
  - 旧: pass の最後にまとめて 1 回書き込み → 途中クラッシュで全progress ロスト
  - 新: `sessionToDays: Map<sessionId, Set<date>>` を事前計算し、各 day 成功直後に「その session が触る残り day が 0 になった」ものだけ processed マーク + `writeState` 呼び出し
  - 中断耐性: N 日分処理中に kill されても、次回は N+1 日目から再開
  - 副次的な bug fix: jsonl ロード失敗した session が誤って processed マークされる latent bug が解消
- 重複実行防止: モジュールレベルの `running` ブール
- アクティブセッションの jsonl は `getActiveSessionIds()` でスキップ(書き込み中のファイルを触らない)
- Archivist が `"append"` を未存在 slug に対して指示 → `"create"` に正規化
- トピックスラッグは LLM 出力を再 `slugify()` で正規化(kebab-case ASCII 強制)
- Daily pass で skipped day があれば該当 session を retry、`lastDailyRunAt` は bump しない
- Optimization pass の `moveToArchive` はエラー時 `false` を返し、state に反映しない

## デバッグ機能

```bash
JOURNAL_FORCE_RUN_ON_STARTUP=1 yarn dev:server
```

起動直後に `maybeRunJournal({ force: true })` を実行。interval チェックをバイパスする(CLI 無し / lock / ENOENT disable のガードは効く)。

## テスト

新規ユニットテスト **165 ケース**(既存 122 + 新規合計 165 で **287/287 passing**)。全部 pure 関数対応で、LLM サブプロセスは `summarize` を DI して mock、フィルシステムアクセスはメタデータ構造に分離。

| ファイル | 対象 |
|---|---|
| `test/journal/test_paths.ts` | パス生成、slugify、dailyPathFor バリデーション |
| `test/journal/test_state.ts` | デフォルト生成、パース寛容性、間隔判定、境界 |
| `test/journal/test_diff.ts` | 差分セッション検出、mtime 進行、missing |
| `test/journal/test_indexFile.ts` | index markdown builder、ソート、slug tie-break |
| `test/journal/test_indexWalkers.ts` | `extractFirstH1` |
| `test/journal/test_archivist.ts` | プロンプト組立(ARTIFACTS セクション含む)、JSON 抽出、type guards |
| `test/journal/test_dailyPass.ts` | entry → excerpt 変換、`extractArtifactPaths`、`parseEntry` |
| `test/journal/test_linkRewrite.ts` | workspace-absolute → relative、external 無視、fragment 保持、edge cases |
| `test/utils/path/test_relativeLink.ts` | `isExternalHref`、`resolveWorkspaceLink`、`extractSessionIdFromPath` |

## Test plan

- [x] `yarn format`
- [x] `yarn lint` — 0 errors / 50 warnings(全て既存の server/ 警告)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` — **287/287 passing**
- [x] 手動スモーク(一部済):
  - [x] `workspace/summaries/_state.json` に `"dailyIntervalHours": 0.001` を入れてセッションを終了 → `daily/YYYY/MM/DD.md` と `topics/*.md` が出る
  - [x] 日本語セッションの要約が日本語で出る(言語保持)
  - [ ] `claude` CLI をパスから外して起動 → 一度だけ warning ログ、以降の session-end で無警告
  - [ ] `_state.json` を削除 → 次 run で再生成、全セッションが再取り込み
  - [ ] 連続 session-end でロックが効いて 2 重実行されない
  - [ ] `JOURNAL_FORCE_RUN_ON_STARTUP=1` で起動 → journal が即時走る
  - [ ] サマリ内の wiki / html / stories リンクをクリック → FilesView が該当ファイルに遷移する
  - [ ] サマリ内の `/chat/<id>.jsonl` リンクをクリック → サイドバーのチャットが該当セッションに切替 + canvas が single に戻る
  - [ ] ファイルツリーから直接 `chat/xxx.jsonl` クリック → 従来通り raw JSONL 表示(特殊化されない)
  - [ ] Daily pass を走らせて `_state.json` が day 単位で差分更新されるのを確認(watch しながら日単位の mtime 更新が見えるはず)

## 意図的に見送り(このPR)

- `memory.md` との統合(別概念として残す)
- 手動トピックピン留め(Phase 3)
- サマリ閲覧 UI(ファイルシステムがそのまま UI)
- 巨大ワークスペースでの初回 retroactive ingest のチャンク化(現状は全 ingest で一発)
- **vue-router 導入** — Issue #108 で継続議論。今回は click ハンドラ方式で A+B を解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic workspace journaling: session logs → daily summaries, topic pages, and rebuilt index; scheduled daily and optimization passes (background trigger after sessions end; optional forced run on startup).
  * Topic management: deduplication, merges, archiving, and index updates.
  * Files view: workspace-internal markdown links resolve and can open chat sessions directly.

* **Documentation**
  * Added a detailed feature spec for the automatic journal.

* **Tests**
  * Comprehensive unit tests for journaling, path/link utilities, state, and index generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
