### PR TITLE
fix(sidebar): sort chat history by most-recently-updated

### DIFF
--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 
@@ -40,6 +40,10 @@ interface SessionSummary {
   id: string;
   roleId: string;
   startedAt: string;
+  // ISO timestamp of the jsonl file's most recent mtime — i.e. the
+  // last time the session had an event appended. Clients sort the
+  // sidebar history list by this so active sessions float to the top.
+  updatedAt: string;
   preview: string;
 }
 
@@ -60,7 +64,14 @@ router.get(
             try {
               const meta = await readSessionMeta(chatDir, id);
               if (!meta) return null;
-              const content = await readFile(path.join(chatDir, file), "utf-8");
+              const fullPath = path.join(chatDir, file);
+              // Fetch file content and stat in parallel — content
+              // for the first-user-message preview, stat for the
+              // "last appended" mtime that drives client sort.
+              const [content, fileStat] = await Promise.all([
+                readFile(fullPath, "utf-8"),
+                stat(fullPath),
+              ]);
               const firstUserLine: SessionEntry | undefined = content
                 .split("\n")
                 .filter(Boolean)
@@ -76,6 +87,7 @@ router.get(
                 id,
                 roleId: meta.roleId,
                 startedAt: meta.startedAt,
+                updatedAt: new Date(fileStat.mtimeMs).toISOString(),
                 preview: firstUserLine?.message ?? "",
               };
             } catch {
@@ -85,10 +97,17 @@ router.get(
         )
       ).filter((s): s is SessionSummary => s !== null);
 
-      sessions.sort(
-        (a, b) =>
-          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-      );
+      // Sort by most-recently-updated first. Falls back to
+      // startedAt if two sessions share the same mtime (e.g. a
+      // file-system with second-granularity timestamps).
+      sessions.sort((a, b) => {
+        const byUpdated =
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+        if (byUpdated !== 0) return byUpdated;
+        return (
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+        );
+      });
       res.json(sessions);
     } catch {
       res.json([]);

--- a/src/App.vue
+++ b/src/App.vue
@@ -613,7 +613,10 @@ const selectedResult = computed(
 // to surface the first user message as a preview for live sessions
 // that haven't been persisted to disk yet.
 // Merged list for the history pane: live sessions in `sessionMap`
-// merged with server-only sessions, sorted newest-first by startedAt.
+// merged with server-only sessions, sorted newest-first by
+// `updatedAt` (most recently touched floats to the top). `updatedAt`
+// is bumped in `sendMessage` for live sessions and taken from the
+// jsonl file mtime for server-only sessions.
 const mergedSessions = computed((): SessionSummary[] => {
   const liveIds = new Set(sessionMap.keys());
   const liveSummaries: SessionSummary[] = [...sessionMap.values()].map((s) => {
@@ -622,13 +625,17 @@ const mergedSessions = computed((): SessionSummary[] => {
       id: s.id,
       roleId: s.roleId,
       startedAt: s.startedAt,
+      updatedAt: s.updatedAt,
       preview: firstUserMsg?.message ?? "",
     };
   });
   const serverOnly = sessions.value.filter((s) => !liveIds.has(s.id));
-  return [...liveSummaries, ...serverOnly].sort(
-    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-  );
+  return [...liveSummaries, ...serverOnly].sort((a, b) => {
+    const byUpdated =
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    if (byUpdated !== 0) return byUpdated;
+    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime();
+  });
 });
 
 const tabSessions = computed(() => mergedSessions.value.slice(0, 6));
@@ -774,9 +781,11 @@ function toggleRightSidebar() {
 }
 
 function createNewSession(roleId?: string): ActiveSession {
-  // Remove the latest session if it's empty (no messages exchanged)
+  // Remove the latest session if it's empty (no messages exchanged).
+  // "Latest" here means most-recently-touched, matching the sort
+  // order the user sees in the sidebar.
   const latest = [...sessionMap.values()].sort(
-    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
   )[0];
   if (latest && latest.toolResults.length === 0) {
     sessionMap.delete(latest.id);
@@ -784,6 +793,7 @@ function createNewSession(roleId?: string): ActiveSession {
 
   const id = uuidv4();
   const rId = roleId ?? currentRoleId.value;
+  const now = new Date().toISOString();
   const session: ActiveSession = {
     id,
     roleId: rId,
@@ -794,7 +804,8 @@ function createNewSession(roleId?: string): ActiveSession {
     selectedResultUuid: null,
     hasUnread: false,
     abortController: markRaw(new AbortController()),
-    startedAt: new Date().toISOString(),
+    startedAt: now,
+    updatedAt: now,
   };
   sessionMap.set(id, session);
   currentSessionId.value = id;
@@ -871,9 +882,14 @@ async function loadSession(id: string) {
   const resolvedSelectedUuid =
     lastTool?.uuid ?? toolResultsList[toolResultsList.length - 1]?.uuid ?? null;
 
-  const originalStartedAt =
-    sessions.value.find((s) => s.id === id)?.startedAt ??
-    new Date().toISOString();
+  const serverSummary = sessions.value.find((s) => s.id === id);
+  const nowIso = new Date().toISOString();
+  const originalStartedAt = serverSummary?.startedAt ?? nowIso;
+  // Prefer the server's mtime-derived updatedAt so the loaded
+  // session keeps its place in the most-recently-touched sort;
+  // fall back to startedAt or now if the server summary is absent.
+  const originalUpdatedAt =
+    serverSummary?.updatedAt ?? originalStartedAt ?? nowIso;
 
   sessionMap.set(id, {
     id,
@@ -886,6 +902,7 @@ async function loadSession(id: string) {
     hasUnread: false,
     abortController: markRaw(new AbortController()),
     startedAt: originalStartedAt,
+    updatedAt: originalUpdatedAt,
   });
   currentSessionId.value = id;
   currentRoleId.value = roleId;
@@ -903,6 +920,11 @@ async function sendMessage(text?: string) {
 
   session.isRunning = true;
   session.statusMessage = "Thinking...";
+  // Bump updatedAt so the session floats to the top of the
+  // "most recently touched" sort in the sidebar as soon as the
+  // user submits a message. The server's jsonl mtime will match
+  // on the next fetchSessions() after the run ends.
+  session.updatedAt = new Date().toISOString();
   session.toolResults.push(makeTextResult(message, "user"));
   const runStartIndex = session.toolResults.length;
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -166,7 +166,7 @@
                 >
                   Unread
                 </span>
-                <span v-else>{{ formatDate(session.startedAt) }}</span>
+                <span v-else>{{ formatDate(session.updatedAt) }}</span>
               </span>
             </div>
             <p

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -6,10 +6,18 @@ import type { ToolCallHistoryItem } from "./toolCallHistory";
 
 // Server `/api/sessions` summary. Optional `summary` and `keywords`
 // are populated by the chat indexer (PR #94) when present.
+//
+// `updatedAt` is the most recent activity timestamp — taken from the
+// jsonl file's mtime on the server side and bumped whenever the
+// client appends a message in-memory. Used for the "most recently
+// touched" sort order in the session history sidebar (users expect
+// active sessions to float to the top, not to stay pinned in
+// creation order).
 export interface SessionSummary {
   id: string;
   roleId: string;
   startedAt: string;
+  updatedAt: string;
   preview: string;
   summary?: string;
   keywords?: string[];
@@ -59,4 +67,8 @@ export interface ActiveSession {
   hasUnread: boolean;
   abortController: AbortController;
   startedAt: string;
+  // Bumped whenever the user sends a new message in this session.
+  // Used by `mergedSessions` to sort the sidebar history list by
+  // "most recently touched" rather than "created first".
+  updatedAt: string;
 }


### PR DESCRIPTION
## User Prompt

> chatの履歴(セッション)の一覧がサイドバーにでるけど、作成順じゃない?更新順のほうが便利だと思う。

## 概要

サイドバーのチャット履歴は現在 \`startedAt\`(作成時刻)で降順ソートされている。古いセッションを再開しても順位が上がらないので、ユーザは「さっき触ったはずなのにどこにあるんだ」と探すことになる。

これを **\"most recently updated\"**(直近で触られた)順に変更する。現在走っているセッションや再開したセッションが自然に先頭に来るようになる。

## 変更点

### Type (\`src/types/session.ts\`)

- \`SessionSummary\` と \`ActiveSession\` に \`updatedAt: string\` を追加

### Server (\`server/routes/sessions.ts\`)

- 各 \`chat/<id>.jsonl\` を \`fs.stat\` → mtime を \`updatedAt\` として返す
- プライマリソート: \`updatedAt\` desc、同着時は \`startedAt\` desc をタイブレーク
- 既存の \`readFile\`(preview 抽出用)と \`Promise.all\` で並列化し余計な I/O は無し

### Client (\`src/App.vue\`)

- **createNewSession**: \`updatedAt\` を \`startedAt\` と同時刻で初期化
- **loadSession**: サーバサマリの \`updatedAt\` を引き継ぐ(無ければ \`startedAt\` → \`now\` にフォールバック)
- **sendMessage**: ユーザがメッセージを送った瞬間に \`session.updatedAt = new Date().toISOString()\` を bump。サーバ mtime が追いつく前から UI 上は即座に先頭へ移動する
- **mergedSessions**: ソート基準を \`updatedAt\` desc に変更、\`startedAt\` はタイブレーク
- **createNewSession の "empty latest を消す" cleanup**: 可視化されているソート順と揃えるため \`updatedAt\` ベースに変更

### その他

- 既存ユニットテストへの影響なし
- sort ロジックは inline computed なので単体テストなし(追加の価値なし)

## なぜ単に mtime を使うか

- セッションログは append-only の jsonl で、何か書き込まれる = mtime が進む
- サーバ側 \`appendFile\` で user メッセージ / assistant テキスト / tool_result 全てが jsonl に書かれる
- つまり mtime は自動的に「最後にセッションで何かが起きた時刻」を反映する
- 新しいフィールドをメタデータ側に足す必要なし、マイグレーション不要

## Test plan

- [x] \`yarn format\`
- [x] \`yarn lint\` — 0 errors / 40 warnings(既存)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — 122/122 passing
- [ ] 手動スモーク:
  - [ ] 既存の古いセッションを loadSession で再開 → サイドバー先頭に来るか
  - [ ] 複数セッションを切り替えてメッセージを送る → 送った瞬間に先頭に来るか
  - [ ] ブラウザリロード後も順序が保たれるか(fetchSessions が新 mtime を返す)
  - [ ] 全く触ってないサーバ側セッションは作成順で並び続けるか(既存挙動互換)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sessions now show a last-updated timestamp.
  * Sidebar reorders sessions by most-recent activity (updated time) rather than creation time.
  * Sending a message immediately updates the session’s timestamp and repositions it in the sidebar.
  * New sessions initialize with both start and last-updated times; empty latest sessions are removed based on last-updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->