### PR TITLE
fix(wiki): open external links in a new tab

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -39,8 +39,18 @@
            underlying plugin View. The .stack-text-response class below
            collapses the plugin's own card chrome (outer p-6, inner
            rounded/border/shadow box, role header) so only the stack
-           card's own border shows. -->
-      <div v-if="isTextResponse(result)" class="stack-text-response">
+           card's own border shows.
+
+           We render the upstream OriginalView directly rather than our
+           local TextResponseView wrapper, so we lose the wrapper's
+           "open external links in a new tab" click handler. Attach
+           the same handler here via @click.capture so cross-origin
+           links in assistant Markdown don't navigate the SPA away. -->
+      <div
+        v-if="isTextResponse(result)"
+        class="stack-text-response"
+        @click.capture="handleExternalLinkClick"
+      >
         <TextResponseOriginalView :selected-result="result" />
       </div>
       <!-- Document-like plugins: let the content flow at its natural
@@ -88,6 +98,7 @@ import { ref, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { getPlugin } from "../tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { View as TextResponseOriginalView } from "@gui-chat-plugin/text-response/vue";
+import { handleExternalLinkClick } from "../utils/dom/externalLink";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
 
 // Most plugin viewComponents use h-full internally, so a defined parent

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -56,6 +56,7 @@ import { computed, ref } from "vue";
 import { View as OriginalView } from "@gui-chat-plugin/text-response/vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<TextResponseData>;
@@ -66,17 +67,13 @@ const isAssistant = computed(
   () => (props.selectedResult.data?.role ?? "assistant") === "assistant",
 );
 
-function openLinksInNewTab(event: MouseEvent) {
-  if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey)
-    return;
-  const target = event.target as HTMLElement;
-  const anchor = target.closest("a");
-  if (!anchor) return;
-  const url = anchor.href;
-  if (!url.startsWith("http://") && !url.startsWith("https://")) return;
-  if (new URL(url).origin === window.location.origin) return;
-  event.preventDefault();
-  window.open(url, "_blank", "noopener,noreferrer");
+// The shared helper returns a boolean indicating whether it
+// consumed the click. In this component we don't have any other
+// click behaviour to cascade to, so the return value is ignored —
+// but we keep the helper call because it does the `event.preventDefault()`
+// and `window.open()` internally.
+function openLinksInNewTab(event: MouseEvent): void {
+  handleExternalLinkClick(event);
 }
 
 const pdfDownloading = ref(false);

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -137,6 +137,7 @@ import { computed, ref } from "vue";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<WikiData>;
@@ -237,11 +238,20 @@ async function downloadPdf() {
 }
 
 function handleContentClick(e: MouseEvent) {
+  // 1. Internal wiki links: `[[Page Name]]` was rewritten to a
+  //    `<span class="wiki-link">` during markdown pre-processing,
+  //    so it doesn't overlap with regular `<a>` handling.
   const target = e.target as HTMLElement;
   const link = target.closest(".wiki-link") as HTMLElement | null;
   if (link?.dataset.page) {
     navigatePage(link.dataset.page);
+    return;
   }
+  // 2. External http(s) links in the rendered markdown body: open
+  //    in a new tab so clicking them doesn't navigate the whole
+  //    SPA away from MulmoClaude. Same-origin and non-http links
+  //    (mailto:, tel:, anchors) fall through to the browser default.
+  handleExternalLinkClick(e);
 }
 </script>
 

--- a/src/utils/dom/externalLink.ts
+++ b/src/utils/dom/externalLink.ts
@@ -1,0 +1,60 @@
+// Click handler for rendered markdown / HTML bodies that opens
+// external (cross-origin) http(s) links in a new tab instead of
+// navigating the SPA away from itself.
+//
+// Split into a pure predicate (`isCrossOriginHttpUrl`) that's
+// exhaustively unit-tested, and a thin DOM wrapper
+// (`handleExternalLinkClick`) that reads the click event. Callers
+// invoke the wrapper from their own `@click` handler and check the
+// return value to decide whether to fall through to plugin-specific
+// navigation.
+
+// Pure predicate: is `href` an absolute http(s) URL pointing at an
+// origin different from `currentOrigin`? Used by
+// `handleExternalLinkClick` below, and directly by tests.
+//
+// Returns `false` for:
+//   - non-http schemes (mailto:, tel:, javascript:, file: …) — the
+//     browser's default behaviour is appropriate for those
+//   - same-origin URLs (including hash anchors resolved against the
+//     current page, which `anchor.href` normalises to a full URL)
+//   - malformed input that `URL` can't parse
+export function isCrossOriginHttpUrl(
+  href: string,
+  currentOrigin: string,
+): boolean {
+  if (!href.startsWith("http://") && !href.startsWith("https://")) {
+    return false;
+  }
+  try {
+    return new URL(href).origin !== currentOrigin;
+  } catch {
+    return false;
+  }
+}
+
+// DOM click handler. Invoke from a view's `@click` listener on a
+// rendered-markdown container. If the event targets an external
+// http(s) link, the default navigation is cancelled and the link
+// opens in a new tab with `noopener,noreferrer`; returns `true` so
+// the caller knows the click was consumed. Returns `false` for
+// every other case (not an anchor, internal link, modifier-key
+// click, non-left-button, …) so the caller can continue with its
+// own plugin-specific click handling (e.g. wiki internal links).
+export function handleExternalLinkClick(event: MouseEvent): boolean {
+  if (event.button !== 0) return false;
+  if (event.ctrlKey || event.metaKey || event.shiftKey) return false;
+  const target = event.target as HTMLElement | null;
+  if (!target) return false;
+  const anchor = target.closest("a");
+  if (!anchor) return false;
+  // `.href` (DOM property) is always a fully-resolved URL; contrast
+  // `getAttribute("href")` which returns the raw attribute string.
+  // Using the resolved form gives us reliable origin checks and
+  // normalises relative paths away.
+  const url = anchor.href;
+  if (!isCrossOriginHttpUrl(url, window.location.origin)) return false;
+  event.preventDefault();
+  window.open(url, "_blank", "noopener,noreferrer");
+  return true;
+}

--- a/test/utils/dom/test_externalLink.ts
+++ b/test/utils/dom/test_externalLink.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isCrossOriginHttpUrl } from "../../../src/utils/dom/externalLink.js";
+
+const ORIGIN = "http://localhost:3001";
+
+describe("isCrossOriginHttpUrl", () => {
+  it("returns true for an http URL with a different origin", () => {
+    assert.equal(isCrossOriginHttpUrl("http://example.com/page", ORIGIN), true);
+  });
+
+  it("returns true for an https URL with a different origin", () => {
+    assert.equal(
+      isCrossOriginHttpUrl("https://example.com/page", ORIGIN),
+      true,
+    );
+  });
+
+  it("returns true for a different port on the same host", () => {
+    // Different port → different origin per the web platform's
+    // same-origin policy.
+    assert.equal(
+      isCrossOriginHttpUrl("http://localhost:8080/foo", ORIGIN),
+      true,
+    );
+  });
+
+  it("returns false for a same-origin http URL", () => {
+    assert.equal(
+      isCrossOriginHttpUrl("http://localhost:3001/files/foo", ORIGIN),
+      false,
+    );
+  });
+
+  it("returns false for a same-origin hash anchor (after href resolution)", () => {
+    // `anchor.href` in the browser resolves `#section` to a full
+    // URL like "http://localhost:3001/#section", which is
+    // same-origin, so it should NOT be opened in a new tab — let
+    // the browser scroll to the fragment instead.
+    assert.equal(
+      isCrossOriginHttpUrl("http://localhost:3001/#section", ORIGIN),
+      false,
+    );
+  });
+
+  it("returns false for mailto: links", () => {
+    assert.equal(
+      isCrossOriginHttpUrl("mailto:alice@example.com", ORIGIN),
+      false,
+    );
+  });
+
+  it("returns false for tel: links", () => {
+    assert.equal(isCrossOriginHttpUrl("tel:+81-90-1234-5678", ORIGIN), false);
+  });
+
+  it("returns false for javascript: links (defensive)", () => {
+    assert.equal(isCrossOriginHttpUrl("javascript:void(0)", ORIGIN), false);
+  });
+
+  it("returns false for an empty string", () => {
+    assert.equal(isCrossOriginHttpUrl("", ORIGIN), false);
+  });
+
+  it("returns false for a malformed URL that can't be parsed", () => {
+    // "http://" alone is not a valid URL for the URL constructor.
+    assert.equal(isCrossOriginHttpUrl("http://", ORIGIN), false);
+  });
+
+  it("returns false for a URL with no scheme (already relative)", () => {
+    // Relative paths never reach this function from the click
+    // handler (because `anchor.href` resolves them to an absolute
+    // URL first), but the predicate should still reject them if
+    // called directly.
+    assert.equal(isCrossOriginHttpUrl("/files/foo.md", ORIGIN), false);
+  });
+
+  it("handles https origin correctly", () => {
+    const httpsOrigin = "https://app.mulmoclaude.test";
+    assert.equal(
+      isCrossOriginHttpUrl("https://app.mulmoclaude.test/page", httpsOrigin),
+      false,
+    );
+    assert.equal(
+      isCrossOriginHttpUrl("https://external.example.com/page", httpsOrigin),
+      true,
+    );
+  });
+
+  it("treats http vs https on the same host as cross-origin", () => {
+    // Scheme is part of the origin in the web platform.
+    assert.equal(
+      isCrossOriginHttpUrl(
+        "https://localhost:3001/foo",
+        "http://localhost:3001",
+      ),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## User Prompt

> wiki などで external な link があるときに遷移すると mulmo から離れてしまう。新しいタブで開いてほしい

## 概要

wiki ページ内の http(s) リンクをクリックすると SPA ごと離脱してしまっていた。会話途中でリンクを踏んだらセッションコンテキストが消し飛ぶ体験になる。**new tab で開く** ように修正。

既に TextResponseView に同じ目的の inline ロジックがあったので、**共通ヘルパーに抽出** して両方で使う形にしました。

## 変更

### 新規: \`src/utils/dom/externalLink.ts\`

純粋関数と DOM ラッパーの 2 層:

- **\`isCrossOriginHttpUrl(href, currentOrigin): boolean\`** — pure 述語
  - http/https 以外(mailto/tel/javascript/file/…): \`false\`
  - Same-origin: \`false\`
  - Malformed URL: \`false\`(\`URL\` コンストラクタで try/catch)
  - Cross-origin http(s): \`true\`
  - ユニットテスト 13 ケース
- **\`handleExternalLinkClick(event): boolean\`** — DOM ラッパー
  - 左クリック + 修飾キーなしのみ処理
  - \`event.target.closest("a")\` で anchor 抽出
  - 述語が true なら \`preventDefault()\` + \`window.open(href, "_blank", "noopener,noreferrer")\`
  - 消費した場合 \`true\` を返すので、呼び出し側は独自 click ハンドラと cascade できる

### \`src/plugins/wiki/View.vue\`

\`handleContentClick\` に 2 層の処理を追加:

1. **内部 \`.wiki-link\` span**(既存) → \`navigatePage(pageName)\` で wiki 内遷移
2. **通常の \`<a>\` リンク**(新規) → \`handleExternalLinkClick\` で cross-origin なら new tab、それ以外はブラウザ既定動作

### \`src/plugins/textResponse/View.vue\`

既存の inline \`openLinksInNewTab\` を **共通ヘルパー呼び出しに置き換え**(ロジック変わらず、重複解消)。

## 対象範囲(今回 触らないもの)

- **\`presentHtml/View.vue\`** — iframe 内のコンテンツなので click インターセプトが効かない。sandbox 属性が \`allow-top-navigation\` を含まないので現在はリンクが静かに死ぬ動作。これは別の UX 課題として残すが、今回のスコープ外
- **\`presentMulmoScript/View.vue\`** — mulmoscript エディタで user 生成コンテンツは基本表示しない
- **FilesView の markdown レンダリング** — TextResponseView 経由なので refactor の恩恵を自動で受ける

## Test plan

- [x] \`yarn format\`
- [x] \`yarn lint\` — 0 errors / 40 warnings(既存)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — **135/135 passing**(既存 122 + 新規 13)
- [ ] 手動スモーク:
  - [ ] wiki ページを開いて外部 URL(https://...)のリンクをクリック → 新しいタブで開く、現在のウィンドウはそのまま
  - [ ] wiki ページ内の \`[[内部ページ]]\` リンクをクリック → 従来通り wiki 内遷移
  - [ ] assistant の text-response に含まれる https リンクをクリック → 新しいタブ(refactor で挙動変わらないことの確認)
  - [ ] Cmd+Click / Ctrl+Click が従来通り「バックグラウンドで新タブ」を開けるか(\`event.metaKey\` / \`ctrlKey\` チェックで処理スキップする設計)
  - [ ] ページ内 \`#anchor\` リンク → 従来通りページ内スクロール

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated external-link handling into a shared handler so external links consistently open in a new tab and no longer trigger in-app navigation.

* **Tests**
  * Added comprehensive tests covering cross-origin and non-http link behaviors to ensure consistent link-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->