### PR TITLE
Auto login for Mac with sandbox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ MulmoClaude uses Claude Code as its AI backend, which has access to tools includ
 5. Wait for Docker Desktop to finish starting — the whale icon in the menu bar / system tray should turn steady (not animated)
 6. Restart MulmoClaude — it will detect Docker and build the sandbox image on first run (one-time, takes about a minute)
 
-On macOS, credentials are managed automatically — the app extracts OAuth tokens from the system Keychain at startup and refreshes them on 401 errors, so no manual steps are needed.
+When the Docker sandbox is active on macOS, credentials are managed automatically — the app extracts OAuth tokens from the system Keychain at startup and refreshes them on 401 errors, so no manual steps are needed.
 
 If Docker is not installed, the app shows a warning banner and continues to work without sandboxing.
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,10 @@ MulmoClaude uses Claude Code as its AI backend, which has access to tools includ
 4. **Linux**: follow the [Linux install guide](https://docs.docker.com/desktop/install/linux/)
 5. Wait for Docker Desktop to finish starting — the whale icon in the menu bar / system tray should turn steady (not animated)
 6. Restart MulmoClaude — it will detect Docker and build the sandbox image on first run (one-time, takes about a minute)
-7. Export your Claude Code credentials for the sandbox:
-   ```bash
-   npm run sandbox:login
-   ```
-   This extracts your OAuth token from macOS Keychain and writes it to `~/.claude/.credentials.json`, which the Docker container reads via bind mount. Re-run this command whenever you get a 401 authentication error (tokens expire every few hours).
+
+On macOS, credentials are managed automatically — the app extracts OAuth tokens from the system Keychain at startup and refreshes them on 401 errors, so no manual steps are needed.
 
 If Docker is not installed, the app shows a warning banner and continues to work without sandboxing.
-
-> **Why is this needed?** On macOS, Claude Code stores and refreshes OAuth tokens in the system Keychain. The Docker container (a Linux environment) cannot access the Keychain, so it reads credentials from `~/.claude/.credentials.json` instead. The `sandbox:login` script bridges the gap by copying the current token from Keychain to that file. Running `claude auth login` inside the Docker container does not work on macOS because the OAuth callback requires a local HTTP server that is unreachable from the host browser due to Docker Desktop's VM-based networking.
 
 > **Debug mode**: To run without the sandbox even when Docker is installed, set `DISABLE_SANDBOX=1` before starting the server.
 

--- a/plan/auto_credential_refresh.md
+++ b/plan/auto_credential_refresh.md
@@ -1,0 +1,24 @@
+# Auto-Refresh Credentials on 401 (macOS Sandbox)
+
+## Problem
+
+When running MulmoClaude in sandbox mode on macOS, the Claude CLI inside the Docker container authenticates using `~/.claude/.credentials.json`. However, the host Claude CLI stores and refreshes OAuth tokens in **macOS Keychain**, not in this file. The credentials file goes stale after a few hours, causing `401 authentication_error` failures.
+
+Currently, the user must manually run `npm run sandbox:login` to export fresh tokens from Keychain every time this happens — a poor experience.
+
+## Solution
+
+Detect the 401 authentication error in the agent's stderr output, automatically re-export credentials from macOS Keychain (the same `security find-generic-password` command that `npm run sandbox:login` uses), and retry the agent call — all transparently.
+
+### Conditions
+
+This logic activates **only when all three are true**:
+
+1. The platform is `darwin` (macOS)
+2. The app is running in sandbox mode (Docker enabled)
+3. The claude CLI exits with a stderr message containing `401` or `authentication_error`
+
+### Implementation
+
+- **`server/credentials.ts`** — new module with a `refreshCredentials()` function that extracts the OAuth token from macOS Keychain and writes it to `~/.claude/.credentials.json`. Returns `true` on success, `false` on failure.
+- **`server/agent.ts`** — after detecting a 401 error on first attempt, call `refreshCredentials()`, and if successful, retry `runAgent` once. If the retry also fails, yield the error as before.

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile, unlink } from "fs/promises";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { isDockerAvailable } from "./docker.js";
+import { refreshCredentials, isAuthError } from "./credentials.js";
 import type { Role } from "../src/config/roles.js";
 import { loadAllRoles } from "./roles.js";
 import { buildSystemPrompt } from "./agent/prompt.js";
@@ -16,6 +17,122 @@ import {
   type AgentEvent,
   type RawStreamEvent,
 } from "./agent/stream.js";
+
+interface AgentRunResult {
+  events: AgentEvent[];
+  stderrOutput: string;
+  exitCode: number;
+}
+
+/**
+ * Check whether any collected events or stderr indicate a 401 auth error.
+ * The Claude CLI may report the error via stderr, via a "text" result event,
+ * or via an "error" event on stdout.
+ */
+function hasAuthFailure(result: AgentRunResult): boolean {
+  if (isAuthError(result.stderrOutput)) return true;
+  for (const event of result.events) {
+    if (
+      (event.type === "text" || event.type === "error") &&
+      isAuthError(event.message)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Spawn the claude CLI and collect all events and exit info.
+ * This is the inner execution that does NOT handle retries.
+ */
+async function execAgent(
+  args: string[],
+  useDocker: boolean,
+  workspacePath: string,
+): Promise<AgentRunResult> {
+  const toDockerPath = (p: string) => p.replace(/\\/g, "/");
+  const extraHosts: string[] =
+    process.platform === "linux"
+      ? ["--add-host", "host.docker.internal:host-gateway"]
+      : [];
+
+  const uid = process.getuid?.() ?? 1000;
+  const gid = process.getgid?.() ?? 1000;
+  const projectRoot = process.cwd();
+  const proc = useDocker
+    ? spawn(
+        "docker",
+        [
+          "run",
+          "--rm",
+          "--cap-drop",
+          "ALL",
+          "--user",
+          `${uid}:${gid}`,
+          "-e",
+          "HOME=/home/node",
+          "-v",
+          `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
+          "-v",
+          `${toDockerPath(projectRoot)}/server:/app/server:ro`,
+          "-v",
+          `${toDockerPath(projectRoot)}/src:/app/src:ro`,
+          "-v",
+          `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
+          "-v",
+          `${toDockerPath(homedir())}/.claude:/home/node/.claude`,
+          "-v",
+          `${toDockerPath(homedir())}/.claude.json:/home/node/.claude.json`,
+          ...extraHosts,
+          "mulmoclaude-sandbox",
+          "claude",
+          ...args,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+    : spawn("claude", args, {
+        cwd: workspacePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+  const events: AgentEvent[] = [];
+  let stderrOutput = "";
+
+  try {
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderrOutput += chunk.toString();
+    });
+
+    let buffer = "";
+    for await (const chunk of proc.stdout) {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let event: RawStreamEvent;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        for (const agentEvent of parseStreamEvent(event)) {
+          events.push(agentEvent);
+        }
+      }
+    }
+
+    const exitCode = await new Promise<number>((resolve) =>
+      proc.on("close", resolve),
+    );
+
+    return { events, stderrOutput, exitCode };
+  } finally {
+    if (!proc.killed) proc.kill();
+  }
+}
 
 export async function* runAgent(
   message: string,
@@ -72,89 +189,35 @@ export async function* runAgent(
     mcpConfigPath: hasMcp ? mcpConfigArgPath : undefined,
   });
 
-  const toDockerPath = (p: string) => p.replace(/\\/g, "/");
-  const extraHosts: string[] =
-    process.platform === "linux"
-      ? ["--add-host", "host.docker.internal:host-gateway"]
-      : [];
-
-  const uid = process.getuid?.() ?? 1000;
-  const gid = process.getgid?.() ?? 1000;
-  const projectRoot = process.cwd();
-  const proc = useDocker
-    ? spawn(
-        "docker",
-        [
-          "run",
-          "--rm",
-          "--cap-drop",
-          "ALL",
-          "--user",
-          `${uid}:${gid}`,
-          "-e",
-          "HOME=/home/node",
-          "-v",
-          `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
-          "-v",
-          `${toDockerPath(projectRoot)}/server:/app/server:ro`,
-          "-v",
-          `${toDockerPath(projectRoot)}/src:/app/src:ro`,
-          "-v",
-          `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
-          "-v",
-          `${toDockerPath(homedir())}/.claude:/home/node/.claude`,
-          "-v",
-          `${toDockerPath(homedir())}/.claude.json:/home/node/.claude.json`,
-          ...extraHosts,
-          "mulmoclaude-sandbox",
-          "claude",
-          ...args,
-        ],
-        { stdio: ["ignore", "pipe", "pipe"] },
-      )
-    : spawn("claude", args, {
-        cwd: workspacePath,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-
   try {
-    let stderrOutput = "";
-    proc.stderr.on("data", (chunk: Buffer) => {
-      stderrOutput += chunk.toString();
-    });
+    let result = await execAgent(args, useDocker, workspacePath);
 
-    let buffer = "";
-    for await (const chunk of proc.stdout) {
-      buffer += chunk.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        let event: RawStreamEvent;
-        try {
-          event = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        for (const agentEvent of parseStreamEvent(event)) {
-          yield agentEvent;
-        }
+    // On macOS sandbox, if the CLI failed with a 401 auth error, try to
+    // auto-refresh credentials from macOS Keychain and retry once.
+    // The auth error may surface via stderr, a "text" result event, or an
+    // "error" event — so we check all of them.
+    if (useDocker && process.platform === "darwin" && hasAuthFailure(result)) {
+      console.log(
+        "[sandbox] Authentication error detected — refreshing credentials and retrying...",
+      );
+      const refreshed = await refreshCredentials();
+      if (refreshed) {
+        result = await execAgent(args, useDocker, workspacePath);
       }
     }
 
-    const exitCode = await new Promise<number>((resolve) =>
-      proc.on("close", resolve),
-    );
+    for (const event of result.events) {
+      yield event;
+    }
 
-    if (exitCode !== 0) {
+    if (result.exitCode !== 0) {
       yield {
         type: "error",
-        message: stderrOutput || `claude exited with code ${exitCode}`,
+        message:
+          result.stderrOutput || `claude exited with code ${result.exitCode}`,
       };
     }
   } finally {
-    if (!proc.killed) proc.kill();
     if (hasMcp) unlink(mcpConfigHostPath).catch(() => {});
   }
 }

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,9 +1,9 @@
-import { spawn, type ChildProcess } from "child_process";
+import { spawn } from "child_process";
 import { mkdir, writeFile, unlink } from "fs/promises";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { isDockerAvailable } from "./docker.js";
-import { refreshCredentials, isAuthError } from "./credentials.js";
+import { refreshCredentials } from "./credentials.js";
 import type { Role } from "../src/config/roles.js";
 import { loadAllRoles } from "./roles.js";
 import { buildSystemPrompt } from "./agent/prompt.js";
@@ -18,57 +18,6 @@ import {
   type RawStreamEvent,
 } from "./agent/stream.js";
 
-function spawnClaude(
-  args: string[],
-  useDocker: boolean,
-  workspacePath: string,
-): ChildProcess {
-  const toDockerPath = (p: string) => p.replace(/\\/g, "/");
-  const extraHosts: string[] =
-    process.platform === "linux"
-      ? ["--add-host", "host.docker.internal:host-gateway"]
-      : [];
-
-  const uid = process.getuid?.() ?? 1000;
-  const gid = process.getgid?.() ?? 1000;
-  const projectRoot = process.cwd();
-  return useDocker
-    ? spawn(
-        "docker",
-        [
-          "run",
-          "--rm",
-          "--cap-drop",
-          "ALL",
-          "--user",
-          `${uid}:${gid}`,
-          "-e",
-          "HOME=/home/node",
-          "-v",
-          `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
-          "-v",
-          `${toDockerPath(projectRoot)}/server:/app/server:ro`,
-          "-v",
-          `${toDockerPath(projectRoot)}/src:/app/src:ro`,
-          "-v",
-          `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
-          "-v",
-          `${toDockerPath(homedir())}/.claude:/home/node/.claude`,
-          "-v",
-          `${toDockerPath(homedir())}/.claude.json:/home/node/.claude.json`,
-          ...extraHosts,
-          "mulmoclaude-sandbox",
-          "claude",
-          ...args,
-        ],
-        { stdio: ["ignore", "pipe", "pipe"] },
-      )
-    : spawn("claude", args, {
-        cwd: workspacePath,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-}
-
 export async function* runAgent(
   message: string,
   role: Role,
@@ -82,6 +31,12 @@ export async function* runAgent(
   const activePlugins = getActivePlugins(role);
   const hasMcp = activePlugins.length > 0;
   const useDocker = await isDockerAvailable();
+
+  // On macOS sandbox, always refresh credentials from Keychain before each
+  // agent run so that expired OAuth tokens are replaced transparently.
+  if (useDocker && process.platform === "darwin") {
+    await refreshCredentials();
+  }
 
   const containerWorkspacePath = "/home/node/mulmoclaude";
   const fullSystemPrompt = buildSystemPrompt({
@@ -124,37 +79,59 @@ export async function* runAgent(
     mcpConfigPath: hasMcp ? mcpConfigArgPath : undefined,
   });
 
-  // On macOS sandbox, if the first attempt fails with a 401 auth error,
-  // refresh credentials from Keychain and retry. Auth errors cause the CLI
-  // to fail fast with no useful events, so pre-checking avoids the need to
-  // buffer the entire stream.
-  const canRetryAuth = useDocker && process.platform === "darwin";
+  const toDockerPath = (p: string) => p.replace(/\\/g, "/");
+  const extraHosts: string[] =
+    process.platform === "linux"
+      ? ["--add-host", "host.docker.internal:host-gateway"]
+      : [];
+
+  const uid = process.getuid?.() ?? 1000;
+  const gid = process.getgid?.() ?? 1000;
+  const projectRoot = process.cwd();
+  const proc = useDocker
+    ? spawn(
+        "docker",
+        [
+          "run",
+          "--rm",
+          "--cap-drop",
+          "ALL",
+          "--user",
+          `${uid}:${gid}`,
+          "-e",
+          "HOME=/home/node",
+          "-v",
+          `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
+          "-v",
+          `${toDockerPath(projectRoot)}/server:/app/server:ro`,
+          "-v",
+          `${toDockerPath(projectRoot)}/src:/app/src:ro`,
+          "-v",
+          `${toDockerPath(workspacePath)}:/home/node/mulmoclaude`,
+          "-v",
+          `${toDockerPath(homedir())}/.claude:/home/node/.claude`,
+          "-v",
+          `${toDockerPath(homedir())}/.claude.json:/home/node/.claude.json`,
+          ...extraHosts,
+          "mulmoclaude-sandbox",
+          "claude",
+          ...args,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+    : spawn("claude", args, {
+        cwd: workspacePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
 
   try {
-    yield* streamAgent(args, useDocker, workspacePath, canRetryAuth);
-  } finally {
-    if (hasMcp) unlink(mcpConfigHostPath).catch(() => {});
-  }
-}
-
-async function* streamAgent(
-  args: string[],
-  useDocker: boolean,
-  workspacePath: string,
-  canRetryAuth: boolean,
-): AsyncGenerator<AgentEvent> {
-  const proc = spawnClaude(args, useDocker, workspacePath);
-
-  let stderrOutput = "";
-  let authErrorDetected = false;
-
-  try {
-    proc.stderr?.on("data", (chunk: Buffer) => {
+    let stderrOutput = "";
+    proc.stderr.on("data", (chunk: Buffer) => {
       stderrOutput += chunk.toString();
     });
 
     let buffer = "";
-    for await (const chunk of proc.stdout!) {
+    for await (const chunk of proc.stdout) {
       buffer += chunk.toString();
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";
@@ -168,13 +145,6 @@ async function* streamAgent(
           continue;
         }
         for (const agentEvent of parseStreamEvent(event)) {
-          if (
-            canRetryAuth &&
-            (agentEvent.type === "text" || agentEvent.type === "error") &&
-            isAuthError(agentEvent.message)
-          ) {
-            authErrorDetected = true;
-          }
           yield agentEvent;
         }
       }
@@ -184,21 +154,6 @@ async function* streamAgent(
       proc.on("close", resolve),
     );
 
-    if (canRetryAuth && !authErrorDetected && isAuthError(stderrOutput)) {
-      authErrorDetected = true;
-    }
-
-    if (authErrorDetected) {
-      console.log(
-        "[sandbox] Authentication error detected — refreshing credentials and retrying...",
-      );
-      const refreshed = await refreshCredentials();
-      if (refreshed) {
-        yield* streamAgent(args, useDocker, workspacePath, false);
-        return;
-      }
-    }
-
     if (exitCode !== 0) {
       yield {
         type: "error",
@@ -207,5 +162,6 @@ async function* streamAgent(
     }
   } finally {
     if (!proc.killed) proc.kill();
+    if (hasMcp) unlink(mcpConfigHostPath).catch(() => {});
   }
 }

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn, type ChildProcess } from "child_process";
 import { mkdir, writeFile, unlink } from "fs/promises";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
@@ -18,39 +18,11 @@ import {
   type RawStreamEvent,
 } from "./agent/stream.js";
 
-interface AgentRunResult {
-  events: AgentEvent[];
-  stderrOutput: string;
-  exitCode: number;
-}
-
-/**
- * Check whether any collected events or stderr indicate a 401 auth error.
- * The Claude CLI may report the error via stderr, via a "text" result event,
- * or via an "error" event on stdout.
- */
-function hasAuthFailure(result: AgentRunResult): boolean {
-  if (isAuthError(result.stderrOutput)) return true;
-  for (const event of result.events) {
-    if (
-      (event.type === "text" || event.type === "error") &&
-      isAuthError(event.message)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Spawn the claude CLI and collect all events and exit info.
- * This is the inner execution that does NOT handle retries.
- */
-async function execAgent(
+function spawnClaude(
   args: string[],
   useDocker: boolean,
   workspacePath: string,
-): Promise<AgentRunResult> {
+): ChildProcess {
   const toDockerPath = (p: string) => p.replace(/\\/g, "/");
   const extraHosts: string[] =
     process.platform === "linux"
@@ -60,7 +32,7 @@ async function execAgent(
   const uid = process.getuid?.() ?? 1000;
   const gid = process.getgid?.() ?? 1000;
   const projectRoot = process.cwd();
-  const proc = useDocker
+  return useDocker
     ? spawn(
         "docker",
         [
@@ -95,43 +67,6 @@ async function execAgent(
         cwd: workspacePath,
         stdio: ["ignore", "pipe", "pipe"],
       });
-
-  const events: AgentEvent[] = [];
-  let stderrOutput = "";
-
-  try {
-    proc.stderr.on("data", (chunk: Buffer) => {
-      stderrOutput += chunk.toString();
-    });
-
-    let buffer = "";
-    for await (const chunk of proc.stdout) {
-      buffer += chunk.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        let event: RawStreamEvent;
-        try {
-          event = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        for (const agentEvent of parseStreamEvent(event)) {
-          events.push(agentEvent);
-        }
-      }
-    }
-
-    const exitCode = await new Promise<number>((resolve) =>
-      proc.on("close", resolve),
-    );
-
-    return { events, stderrOutput, exitCode };
-  } finally {
-    if (!proc.killed) proc.kill();
-  }
 }
 
 export async function* runAgent(
@@ -189,35 +124,88 @@ export async function* runAgent(
     mcpConfigPath: hasMcp ? mcpConfigArgPath : undefined,
   });
 
-  try {
-    let result = await execAgent(args, useDocker, workspacePath);
+  // On macOS sandbox, if the first attempt fails with a 401 auth error,
+  // refresh credentials from Keychain and retry. Auth errors cause the CLI
+  // to fail fast with no useful events, so pre-checking avoids the need to
+  // buffer the entire stream.
+  const canRetryAuth = useDocker && process.platform === "darwin";
 
-    // On macOS sandbox, if the CLI failed with a 401 auth error, try to
-    // auto-refresh credentials from macOS Keychain and retry once.
-    // The auth error may surface via stderr, a "text" result event, or an
-    // "error" event — so we check all of them.
-    if (useDocker && process.platform === "darwin" && hasAuthFailure(result)) {
+  try {
+    yield* streamAgent(args, useDocker, workspacePath, canRetryAuth);
+  } finally {
+    if (hasMcp) unlink(mcpConfigHostPath).catch(() => {});
+  }
+}
+
+async function* streamAgent(
+  args: string[],
+  useDocker: boolean,
+  workspacePath: string,
+  canRetryAuth: boolean,
+): AsyncGenerator<AgentEvent> {
+  const proc = spawnClaude(args, useDocker, workspacePath);
+
+  let stderrOutput = "";
+  let authErrorDetected = false;
+
+  try {
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      stderrOutput += chunk.toString();
+    });
+
+    let buffer = "";
+    for await (const chunk of proc.stdout!) {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let event: RawStreamEvent;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        for (const agentEvent of parseStreamEvent(event)) {
+          if (
+            canRetryAuth &&
+            (agentEvent.type === "text" || agentEvent.type === "error") &&
+            isAuthError(agentEvent.message)
+          ) {
+            authErrorDetected = true;
+          }
+          yield agentEvent;
+        }
+      }
+    }
+
+    const exitCode = await new Promise<number>((resolve) =>
+      proc.on("close", resolve),
+    );
+
+    if (canRetryAuth && !authErrorDetected && isAuthError(stderrOutput)) {
+      authErrorDetected = true;
+    }
+
+    if (authErrorDetected) {
       console.log(
         "[sandbox] Authentication error detected — refreshing credentials and retrying...",
       );
       const refreshed = await refreshCredentials();
       if (refreshed) {
-        result = await execAgent(args, useDocker, workspacePath);
+        yield* streamAgent(args, useDocker, workspacePath, false);
+        return;
       }
     }
 
-    for (const event of result.events) {
-      yield event;
-    }
-
-    if (result.exitCode !== 0) {
+    if (exitCode !== 0) {
       yield {
         type: "error",
-        message:
-          result.stderrOutput || `claude exited with code ${result.exitCode}`,
+        message: stderrOutput || `claude exited with code ${exitCode}`,
       };
     }
   } finally {
-    if (hasMcp) unlink(mcpConfigHostPath).catch(() => {});
+    if (!proc.killed) proc.kill();
   }
 }

--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -40,16 +40,3 @@ export async function refreshCredentials(): Promise<boolean> {
     return false;
   }
 }
-
-/**
- * Check whether an error message from the claude CLI indicates an
- * authentication failure (expired or invalid OAuth token).
- */
-export function isAuthError(stderr: string): boolean {
-  return (
-    stderr.includes("authentication_error") ||
-    stderr.includes("Invalid authentication credentials") ||
-    /API Error:\s*401/.test(stderr) ||
-    /Failed to authenticate/.test(stderr)
-  );
-}

--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -1,0 +1,55 @@
+import { execFile } from "child_process";
+import { writeFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+/**
+ * Extract the current OAuth credentials from the macOS Keychain and write them
+ * to ~/.claude/.credentials.json so that the Docker-based sandbox can read them.
+ *
+ * Returns true if credentials were successfully refreshed, false otherwise.
+ * Only works on macOS (darwin).
+ */
+export async function refreshCredentials(): Promise<boolean> {
+  if (process.platform !== "darwin") return false;
+
+  try {
+    const { stdout } = await execFileAsync("security", [
+      "find-generic-password",
+      "-s",
+      KEYCHAIN_SERVICE,
+      "-w",
+    ]);
+    const credentials = stdout.trim();
+    if (!credentials) return false;
+
+    await writeFile(CREDENTIALS_PATH, credentials + "\n");
+    console.log("[sandbox] Credentials refreshed from macOS Keychain.");
+    return true;
+  } catch (err) {
+    console.error(
+      "[sandbox] Failed to refresh credentials from Keychain:",
+      err,
+    );
+    return false;
+  }
+}
+
+/**
+ * Check whether an error message from the claude CLI indicates an
+ * authentication failure (expired or invalid OAuth token).
+ */
+export function isAuthError(stderr: string): boolean {
+  return (
+    stderr.includes("authentication_error") ||
+    stderr.includes("Invalid authentication credentials") ||
+    /API Error:\s*401/.test(stderr) ||
+    /Failed to authenticate/.test(stderr)
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -108,19 +108,25 @@ function isPortFree(port: number): Promise<boolean> {
           ".credentials.json",
         );
         if (!fs.existsSync(credentialsPath)) {
-          console.error(
-            "[sandbox] Missing credentials file: ~/.claude/.credentials.json",
-          );
           if (process.platform === "darwin") {
-            console.error(
-              "[sandbox] Run `npm run sandbox:login` to export credentials from Keychain.",
-            );
+            const { refreshCredentials } = await import("./credentials.js");
+            const ok = await refreshCredentials();
+            if (!ok) {
+              console.error(
+                "[sandbox] Failed to export credentials from macOS Keychain.",
+              );
+              console.error("[sandbox] Run `npm run sandbox:login` manually.");
+              process.exit(1);
+            }
           } else {
+            console.error(
+              "[sandbox] Missing credentials file: ~/.claude/.credentials.json",
+            );
             console.error(
               "[sandbox] Run `claude auth login` to authenticate Claude Code.",
             );
+            process.exit(1);
           }
-          process.exit(1);
         }
         console.log(
           "[sandbox] Docker available — building sandbox image if needed",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS sandbox docs: clarified credential behavior, reordered warnings, and added an automated refresh guide.
* **New Features**
  * macOS: OAuth tokens are automatically sourced from Keychain at sandbox startup and refreshed on 401 errors; manual export/login steps removed.
* **Behavior**
  * Startup now attempts an automatic credential refresh on macOS and exits with a clear error if refresh fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->