### PR TITLE
chore(ci): report test coverage in CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,4 +30,4 @@ jobs:
     - run: yarn run typecheck:server
     - run: yarn run lint
     - run: yarn run build
-    - run: yarn test
+    - run: yarn run test:coverage

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:client": "vite build",
     "build": "vite build && tsc -p server/tsconfig.json --noEmit",
     "test": "tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts",
+    "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",
     "sandbox:logout": "rm -f ~/.claude/.credentials.json && echo 'Credentials file removed'"


### PR DESCRIPTION
## User Prompt

> ciでカバレッジとってたっけ?
>
> (Option A) Node built-in test coverage(Node 22+)

## 概要

CI に **Node 標準のテストカバレッジ計測** を追加します。新しい依存は一切追加せず、既存の \`tsx --test\` 実行に \`--experimental-test-coverage\` フラグを付けるだけ。

## 変更点

### \`package.json\`
\`\`\`json
"test":          "tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts",
"test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts",
\`\`\`

\`yarn test\` は従来通り(ローカル dev での高速実行)、\`yarn test:coverage\` は CI 用。

### \`.github/workflows/pull_request.yaml\`
\`\`\`diff
-    - run: yarn test
+    - run: yarn run test:coverage
\`\`\`

既存のテスト実行をそのまま置き換え。テストは 1 回だけ走り、最後にカバレッジ summary が追記される形。

## 挙動

Node 22/24 の built-in coverage は以下を text table で出力します:
- ファイルごとの line / branch / function カバレッジ
- 未 cover な line 番号
- 全体の aggregate 行

サンプル:
\`\`\`
ℹ start of coverage report
ℹ ----------------------------------------------------------------------------------------------------------------------
ℹ file                   | line % | branch % | funcs % | uncovered lines
ℹ ----------------------------------------------------------------------------------------------------------------------
ℹ server                 |        |          |         |
ℹ  journal               |        |          |         |
ℹ   paths.ts             |  99.18 |    77.27 |  100.00 | 13
ℹ   state.ts             | 100.00 |   100.00 |  100.00 |
ℹ ...
ℹ src                    |        |          |         |
ℹ  utils                 |        |          |         |
ℹ   path                 |        |          |         |
ℹ    relativeLink.ts     | 100.00 |    96.55 |  100.00 |
ℹ ----------------------------------------------------------------------------------------------------------------------
ℹ all files              |  84.91 |    92.08 |   73.42 |
ℹ ----------------------------------------------------------------------------------------------------------------------
ℹ end of coverage report
\`\`\`

**現在のベースライン**:
- Lines: **84.91%**
- Branches: **92.08%**
- Functions: **73.42%**

## 閾値ゲーティングは入れていない

本 PR ではカバレッジ低下で CI を fail させる設定は **入れていません**。まずは「見える化」が目的で、閾値を厳しくしすぎるとリファクタリング時のノイズが増えるため。将来 \`--test-coverage-lines=<threshold>\` 等で gating を追加するのは別 PR で議論できます。

## 依存追加なし

- \`c8\` / \`nyc\` / \`istanbul\` 等の外部依存は入れない
- \`--experimental-test-coverage\` は Node 22+ で built-in
- CI matrix(Node 22.x / 24.x)のすべての組み合わせで動く

## Vue component テストは対象外

現状テストは pure 関数中心で Vue component テストは無いため、フロントエンド component のカバレッジは計測されません。Vitest 等の導入は別 PR / 別 Issue で議論。

## Test plan

- [x] \`yarn run test:coverage\` ローカル実行 — 306/306 passing + coverage 出力
- [x] \`yarn format\`
- [x] \`yarn lint\` — 0 errors / 61 warnings(既存)
- [ ] CI 実行で coverage summary がログに出ることを確認(PR push 後)

## 備考

CI の \`yarn build\` / \`yarn typecheck:server\` ステップが main 時点で **pre-existing で失敗** する状態のようです(\`server/pub-sub/index.ts\` が \`@types/ws\` 無しで strict mode に引っかかっている、PR #111 merge 後の状態)。これは **本 PR の範囲外** で、PR #117 に同梱した fix コミット(\`175224c\`)が merge されれば解消します。本 PR の coverage 計測自体は独立して動作します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled test coverage reporting in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->