### PR TITLE
feat(todo): multi-label support with filter UI and LLM actions

### DIFF
--- a/plans/feat-todo-labels.md
+++ b/plans/feat-todo-labels.md
@@ -1,0 +1,409 @@
+# Feature: labels on todos, with filtering
+
+## Goal
+
+Add optional labels (tags) to todo items so users can categorise tasks
+(`Work`, `Groceries`, `Urgent`, …) and filter the list to one or more
+labels at read time.
+
+The feature is purely additive at the data layer — existing todos and
+their storage file stay valid with zero migration.
+
+## Non-goals
+
+- **Single-label-per-item**: we support multiple labels per item.
+- **Global label registry**: labels are derived from the items that exist
+  (no separate `labels.json`). When the last item using a label is deleted,
+  the label simply disappears from the filter bar.
+- **Colour customisation**: label colours are deterministic from a hash of
+  the label string against an 8-slot Tailwind palette. Users don't pick.
+- **Nested / hierarchical labels**: flat set only. No `Work/Frontend`.
+- **Label rename cascades**: rename a label on an item and you're really
+  editing that one item. Batch rename is a future follow-up.
+- **Sort by label**: filter yes, sort no.
+- **Migration tooling**: not needed — `labels?: string[]` is optional, old
+  items load as `labels === undefined` (empty).
+
+## Data model
+
+```ts
+// server/routes/todos.ts and src/plugins/todo/index.ts
+export interface TodoItem {
+  id: string;
+  text: string;
+  note?: string;
+  labels?: string[];     // NEW: 0+ labels, case preserved as typed
+  completed: boolean;
+  createdAt: number;
+}
+```
+
+- Labels are arbitrary strings, trimmed at the helper layer.
+- **Storage**: case-preserving ("Work" stays "Work").
+- **Matching / deduplication**: case-insensitive (`Work` and `work` are the
+  same label for filter and `add_label` semantics).
+- Empty string and all-whitespace labels are rejected at the helper layer.
+- Duplicate labels within a single item are de-duped on add.
+
+## LLM API (`manageTodoList`)
+
+Existing actions stay, with two that gain new optional parameters, plus
+three new actions.
+
+### Extended existing actions
+
+- `add` gains `labels?: string[]`:
+  `{ action: "add", text: "Buy milk", labels: ["Groceries"] }`
+- `show` gains `filterLabels?: string[]`:
+  `{ action: "show", filterLabels: ["Work", "Urgent"] }`
+  Semantics: **OR** (returns items that have *any* of the given labels).
+  Matching is case-insensitive.
+
+### New actions
+
+- `add_label` — `{ action: "add_label", text: "...", labels: ["Urgent"] }`
+  Finds the item by partial text match (same convention as `check` /
+  `update`) and unions the new labels into its existing set.
+- `remove_label` — symmetrical removal.
+- `list_labels` — returns an object listing every label currently in use
+  and the number of items carrying it:
+  `{ labels: [{ label: "Work", count: 3 }, { label: "Urgent", count: 1 }] }`.
+  Results are sorted by count descending, then by label ascending.
+
+### Unchanged behaviour
+
+- `delete` / `check` / `uncheck` / `update` / `clear_completed`: no new
+  parameters. `update`'s `text`/`note` contract is unchanged.
+- `update` does NOT touch labels. Use `add_label` / `remove_label` for
+  label edits — this keeps each LLM call single-purpose.
+
+## Pure helpers
+
+All label logic lives in one new pure file so it's exhaustively
+unit-testable without touching filesystem or Vue reactivity.
+
+```ts
+// src/plugins/todo/labels.ts
+
+// Normalise a raw user-typed label for storage:
+//   - trim leading/trailing whitespace
+//   - collapse internal whitespace runs to single spaces
+//   - reject empty or whitespace-only → returns null
+export function normalizeLabel(raw: string): string | null;
+
+// Return true iff two labels are considered equal (case-insensitive
+// after normalization). Used by add_label / remove_label / filter.
+export function labelsEqual(a: string, b: string): boolean;
+
+// Deterministic colour class assignment. Hash the label, pick one of
+// LABEL_PALETTE. Same label → same colour, every time.
+export const LABEL_PALETTE: readonly string[];
+export function colorForLabel(label: string): string;
+
+// Client- and server-side filter. `filterLabels` is OR semantics,
+// case-insensitive. If `filterLabels` is empty, return `items` unchanged.
+export function filterByLabels<T extends { labels?: string[] }>(
+  items: readonly T[],
+  filterLabels: readonly string[],
+): T[];
+
+// Build the "list_labels" output: distinct labels in use + counts,
+// sorted by count desc then alpha asc. Case-insensitive grouping; the
+// displayed form is the most-frequent case variant of each group.
+export function listLabelsWithCount(
+  items: readonly { labels?: string[] }[],
+): Array<{ label: string; count: number }>;
+
+// Add labels to an existing set without duplicates (case-insensitive).
+export function mergeLabels(
+  existing: readonly string[],
+  adding: readonly string[],
+): string[];
+
+// Remove labels from an existing set (case-insensitive match).
+export function subtractLabels(
+  existing: readonly string[],
+  removing: readonly string[],
+): string[];
+```
+
+### `LABEL_PALETTE` choice
+
+Eight Tailwind pastel classes — enough visual variety without being
+garish, consistent with existing MulmoClaude UI tone:
+
+```ts
+export const LABEL_PALETTE = [
+  "bg-blue-100 text-blue-700",
+  "bg-green-100 text-green-700",
+  "bg-purple-100 text-purple-700",
+  "bg-yellow-100 text-yellow-700",
+  "bg-pink-100 text-pink-700",
+  "bg-indigo-100 text-indigo-700",
+  "bg-red-100 text-red-700",
+  "bg-teal-100 text-teal-700",
+] as const;
+```
+
+### Hash for colour
+
+Simple deterministic string hash:
+
+```ts
+export function colorForLabel(label: string): string {
+  const key = label.toLowerCase();
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return LABEL_PALETTE[hash % LABEL_PALETTE.length];
+}
+```
+
+Important property: case-insensitive on input so `Work` and `work`
+get the same colour even if stored in different items.
+
+## View.vue changes
+
+### Filter bar (new, at the top)
+
+Appears only when at least one label is in use:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Filter:  [ Work ×5 ] [ Urgent ×2 ] [ Groceries ×3 ]  ✕    │
+└────────────────────────────────────────────────────────────┘
+```
+
+- Each chip is a toggleable button (clicking adds/removes from the
+  active filter set).
+- Count is from `listLabelsWithCount(items)`.
+- `✕` clears all active filters.
+- Colours match `colorForLabel`; active filters gain a ring or
+  inversion (`bg-blue-700 text-white` instead of `bg-blue-100 text-blue-700`).
+- Local state only — not persisted across sessions.
+
+### Item row
+
+Each todo row already has text + note. Labels render as small chips
+between the text and the delete button:
+
+```
+☐  Buy milk   [Groceries] [Urgent]                    ✕ ▾
+```
+
+- Chip colour via `colorForLabel`.
+- Chips wrap if there are many on a narrow screen.
+
+### Filtered list
+
+`filteredItems = filterByLabels(items, [...activeFilters])`. The rest of
+the existing render logic iterates over `filteredItems` instead of `items`.
+
+The completed counter stays based on the *unfiltered* items, so it
+represents the whole list ("5/12 completed") regardless of which filter
+the user is viewing. Alternative: filtered counter. Starting with
+unfiltered because it's less surprising when filters are toggled.
+
+### Inline YAML editor
+
+Add a `labels:` field. YAML list of strings:
+
+```yaml
+text: "Buy milk"
+note: ""
+labels: [Groceries, Urgent]
+```
+
+The existing parser is simplistic; we extend it to handle one more key
+with a comma-separated or bracket-delimited list. If parse fails, the
+existing error-banner pattern shows.
+
+The edit operation saves via an existing flow — BUT `update` action in
+the server doesn't touch labels (decision above). So editing labels from
+the YAML editor issues **`add_label` + `remove_label`** as a diff against
+the prior state, not a single `update`.
+
+Alternative: extend `update` to accept `labels` and do replace-semantics.
+Simpler server side, but asymmetric with LLM ergonomics. I prefer keeping
+the LLM's action set narrow and having the View compute the diff.
+
+Actually on reflection: the View can just call both add_label and
+remove_label in sequence. If the diff is empty on one side, skip that
+call. Two POSTs instead of one is fine.
+
+### `add` flow from user typing
+
+Out of scope for this PR — the current View doesn't have an "add todo"
+text field; adds are LLM-driven. If we add a manual add later, labels
+would be a natural part of that.
+
+## Preview.vue changes
+
+- Each preview item shows a mini-chip strip of its labels (first 2 labels,
+  then `+N` if more). Colours from `colorForLabel`.
+- The `+N more…` footer stays as is.
+- The `{completedCount}/{items.length} completed` header stays as is.
+
+## Server route changes
+
+### `server/routes/todos.ts`
+
+- Add `labels?: string[]` to `TodoItem`.
+- Add `filterLabels` and `labels` fields to `TodoBody`:
+  ```ts
+  interface TodoBody {
+    action: string;
+    text?: string;
+    newText?: string;
+    note?: string;
+    labels?: string[];       // NEW: for add / add_label / remove_label
+    filterLabels?: string[]; // NEW: for show
+  }
+  ```
+- Extend `add` case: set `labels` on the new item if provided, passing
+  through `normalizeLabel` + de-dup.
+- Extend `show` case: apply `filterByLabels(items, filterLabels ?? [])`
+  before building the response.
+- Add `add_label` case: find item by text match, call `mergeLabels`.
+- Add `remove_label` case: find item by text match, call `subtractLabels`.
+- Add `list_labels` case: return `listLabelsWithCount(items)` in `jsonData`.
+
+Server imports the pure helpers from `src/plugins/todo/labels.ts` —
+the same file the Vue layer uses. This file is already imported by
+other server code (via `src/plugins/*/definition.ts`), so cross-tree
+import is precedented in `server/tsconfig.json`'s `include`.
+
+### `src/plugins/todo/definition.ts`
+
+Update the tool schema:
+
+```ts
+actions: [
+  "show", "add", "delete", "update",
+  "check", "uncheck", "clear_completed",
+  "add_label", "remove_label", "list_labels",  // NEW
+],
+parameters: {
+  // ... existing
+  labels: {
+    type: "array",
+    items: { type: "string" },
+    description:
+      "For 'add': labels to tag the new item with. For 'add_label' / 'remove_label': labels to add/remove from the matched item. Labels are case-insensitive for matching but stored with their original case.",
+  },
+  filterLabels: {
+    type: "array",
+    items: { type: "string" },
+    description:
+      "For 'show' only: only return items that have at least one of these labels (case-insensitive). Omit to show all.",
+  },
+},
+```
+
+## Test plan
+
+### Unit tests (`test/plugins/todo/test_labels.ts`)
+
+Covered by the new pure helpers, no filesystem / no Vue:
+
+1. **normalizeLabel**
+   - Trims whitespace
+   - Collapses internal whitespace runs
+   - Rejects empty and whitespace-only (returns null)
+   - Preserves case
+
+2. **labelsEqual**
+   - Case-insensitive match
+   - Normalisation-aware (`" Work "` == `"work"`)
+
+3. **colorForLabel**
+   - Deterministic: same input → same output
+   - Case-insensitive: `Work` and `work` → same colour
+   - Returns a value from `LABEL_PALETTE`
+   - Different labels likely → different colours (spot check)
+
+4. **filterByLabels**
+   - Empty filter → pass-through
+   - Single label → OR semantics (matches any item with that label)
+   - Multiple labels → OR semantics (matches items with ANY of them)
+   - Case-insensitive
+   - Items without `labels` are excluded from non-empty filter
+
+5. **listLabelsWithCount**
+   - Counts case-insensitive groups
+   - Chooses a consistent display form per group (first seen or
+     most-frequent case, document the choice)
+   - Sorted by count desc, then label asc
+   - Items without labels contribute nothing
+
+6. **mergeLabels**
+   - Adds new labels
+   - No duplicates when adding an existing label (case-insensitive)
+   - Preserves existing order, appends new labels
+
+7. **subtractLabels**
+   - Removes matching labels (case-insensitive)
+   - Removing a non-existent label is a no-op
+   - Preserves order of surviving labels
+
+Roughly 20–25 test cases total.
+
+### No server integration tests in this PR
+
+The server routes wrapping these helpers are thin — the helpers are the
+complex bit, and they're fully covered. Route-level tests would require
+a test harness we don't have for todos right now.
+
+### Manual smoke (post-merge, noted)
+
+- Add a todo with labels via LLM → labels show in View and Preview
+- `add_label` / `remove_label` flows work
+- `show` with `filterLabels` narrows the result to only OR-matched items
+- `list_labels` returns the expected shape
+- View filter bar toggles and clears correctly
+- YAML editor shows labels, edits apply as add_label + remove_label diffs
+
+## File changes
+
+| File | Type | Lines (approx) |
+|---|---|---|
+| `plans/feat-todo-labels.md` | new | — (this file) |
+| `src/plugins/todo/labels.ts` | new | 80 |
+| `server/routes/todos.ts` | modified | +90 |
+| `src/plugins/todo/definition.ts` | modified | +30 |
+| `src/plugins/todo/index.ts` | modified | +1 |
+| `src/plugins/todo/View.vue` | modified | +120 |
+| `src/plugins/todo/Preview.vue` | modified | +15 |
+| `test/plugins/todo/test_labels.ts` | new | 180 |
+
+Total ~515 lines.
+
+## Out of scope / follow-ups
+
+- **Batch label rename**: "rename Work → Office everywhere" is a common
+  request that deserves its own action (`rename_label`). Doable after
+  this PR lands.
+- **Manual "add todo" text field in View**: would be a natural pairing
+  with label input but blocks on a broader UI decision. Separate PR.
+- **Per-role default label set**: some roles might want to auto-tag
+  items (`office` role → auto "Work"). Out of scope.
+- **Label suggestion based on item text**: LLM can already do this
+  during the `add` call; no extra wiring needed.
+- **Sort by label**: filter is enough for v1.
+
+## Risks & mitigations
+
+- **Label name hygiene**: users / LLM may create dozens of near-duplicate
+  labels ("work", "Work", "WORK", "ワーク"). Case-insensitive matching +
+  the `list_labels` action give the LLM a way to self-audit and
+  consolidate with `add_label` / `remove_label`. No automatic dedup.
+- **Filter performance**: all operations are O(n) where n is total
+  todos. For reasonable list sizes (< 1000 items) this is fine. No
+  indexing needed.
+- **Filter state lost on session switch**: intentional. Filters are
+  view-local, not persisted. Consistent with how MulmoClaude handles
+  other transient UI state.
+- **LLM inventing labels**: no hard schema — the LLM can tag anything.
+  That's the point. If clutter becomes a problem, the rename
+  follow-up handles cleanup.

--- a/server/routes/todos.ts
+++ b/server/routes/todos.ts
@@ -2,6 +2,12 @@ import { Router, Request, Response } from "express";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 import { loadJsonFile, saveJsonFile } from "../utils/file.js";
+import {
+  filterByLabels,
+  listLabelsWithCount,
+  mergeLabels,
+  subtractLabels,
+} from "../../src/plugins/todo/labels.js";
 
 const router = Router();
 
@@ -9,6 +15,7 @@ export interface TodoItem {
   id: string;
   text: string;
   note?: string;
+  labels?: string[];
   completed: boolean;
   createdAt: number;
 }
@@ -28,6 +35,13 @@ interface TodoBody {
   text?: string;
   newText?: string;
   note?: string;
+  // For `add`: labels to tag the new item with.
+  // For `add_label` / `remove_label`: labels to add to / remove from the
+  // item matched by `text`.
+  labels?: string[];
+  // For `show`: OR-semantics filter that restricts the returned list
+  // to items carrying at least one of these labels (case-insensitive).
+  filterLabels?: string[];
 }
 
 interface ErrorResponse {
@@ -48,7 +62,7 @@ router.post(
     req: Request<object, unknown, TodoBody>,
     res: Response<TodoResponse | ErrorResponse>,
   ) => {
-    const { action, text, newText, note } = req.body;
+    const { action, text, newText, note, labels, filterLabels } = req.body;
 
     let items = loadTodos();
     // eslint-disable-next-line no-useless-assignment
@@ -56,29 +70,53 @@ router.post(
     let jsonData: Record<string, unknown> = {};
 
     switch (action) {
-      case "show":
-        message = `Showing ${items.length} todo item(s)`;
+      case "show": {
+        // Optional OR-semantics filter via labels. When no filter is
+        // given, `filterByLabels` is a pass-through.
+        const filtered = filterByLabels(items, filterLabels ?? []);
+        if (filterLabels && filterLabels.length > 0) {
+          message = `Showing ${filtered.length} of ${items.length} todo item(s) filtered by: ${filterLabels.join(", ")}`;
+        } else {
+          message = `Showing ${items.length} todo item(s)`;
+        }
         jsonData = {
-          items: items.map((i) => ({ text: i.text, completed: i.completed })),
+          items: filtered.map((i) => ({
+            text: i.text,
+            completed: i.completed,
+            ...(i.labels && i.labels.length > 0 && { labels: i.labels }),
+          })),
         };
+        // Return the filtered view to the client too, so the UI can
+        // honour server-side filters when the LLM used them. The
+        // client-side filter bar still works on top of this.
+        items = filtered;
         break;
+      }
 
       case "add": {
         if (!text) {
           res.status(400).json({ error: "text required" });
           return;
         }
+        // Normalise incoming labels by routing them through
+        // `mergeLabels([], labels ?? [])` — that handles trim /
+        // collapse / case-insensitive dedup in one shot.
+        const normalizedLabels = mergeLabels([], labels ?? []);
         const item: TodoItem = {
           id: `todo_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
           text,
           ...(note !== undefined && { note }),
+          ...(normalizedLabels.length > 0 && { labels: normalizedLabels }),
           completed: false,
           createdAt: Date.now(),
         };
         items.push(item);
         saveTodos(items);
-        message = `Added: "${text}"`;
-        jsonData = { added: text };
+        message =
+          normalizedLabels.length > 0
+            ? `Added: "${text}" [${normalizedLabels.join(", ")}]`
+            : `Added: "${text}"`;
+        jsonData = { added: text, labels: normalizedLabels };
         break;
       }
 
@@ -165,6 +203,71 @@ router.post(
         saveTodos(items);
         message = `Cleared ${count} completed item(s)`;
         jsonData = { clearedCount: count };
+        break;
+      }
+
+      case "add_label": {
+        if (!text || !labels || labels.length === 0) {
+          res
+            .status(400)
+            .json({ error: "text and a non-empty labels array required" });
+          return;
+        }
+        const item = items.find((i) =>
+          i.text.toLowerCase().includes(text.toLowerCase()),
+        );
+        if (item) {
+          const before = item.labels ?? [];
+          item.labels = mergeLabels(before, labels);
+          saveTodos(items);
+          message = `Labels on "${item.text}": ${item.labels.join(", ")}`;
+          jsonData = { item: item.text, labels: item.labels };
+        } else {
+          message = `Item not found: "${text}"`;
+          jsonData = { notFound: text };
+        }
+        break;
+      }
+
+      case "remove_label": {
+        if (!text || !labels || labels.length === 0) {
+          res
+            .status(400)
+            .json({ error: "text and a non-empty labels array required" });
+          return;
+        }
+        const item = items.find((i) =>
+          i.text.toLowerCase().includes(text.toLowerCase()),
+        );
+        if (item) {
+          const next = subtractLabels(item.labels ?? [], labels);
+          if (next.length > 0) {
+            item.labels = next;
+          } else {
+            delete item.labels;
+          }
+          saveTodos(items);
+          message =
+            next.length > 0
+              ? `Labels on "${item.text}": ${next.join(", ")}`
+              : `"${item.text}" now has no labels`;
+          jsonData = { item: item.text, labels: next };
+        } else {
+          message = `Item not found: "${text}"`;
+          jsonData = { notFound: text };
+        }
+        break;
+      }
+
+      case "list_labels": {
+        const inventory = listLabelsWithCount(items);
+        message =
+          inventory.length === 0
+            ? "No labels in use"
+            : `${inventory.length} label(s) in use: ${inventory
+                .map((l) => `${l.label} (${l.count})`)
+                .join(", ")}`;
+        jsonData = { labels: inventory };
         break;
       }
 

--- a/src/plugins/todo/Preview.vue
+++ b/src/plugins/todo/Preview.vue
@@ -7,10 +7,25 @@
     <div
       v-for="item in preview"
       :key="item.id"
-      class="text-xs truncate"
+      class="text-xs truncate flex items-center gap-1"
       :class="item.completed ? 'line-through text-gray-400' : 'text-gray-600'"
     >
-      {{ item.completed ? "✓" : "○" }} {{ item.text }}
+      <span class="shrink-0">{{ item.completed ? "✓" : "○" }}</span>
+      <span class="truncate">{{ item.text }}</span>
+      <template v-if="(item.labels?.length ?? 0) > 0">
+        <span
+          v-for="label in (item.labels ?? []).slice(0, 2)"
+          :key="label"
+          class="px-1 rounded-full text-[9px] font-medium shrink-0"
+          :class="colorForLabel(label)"
+          >{{ label }}</span
+        >
+        <span
+          v-if="(item.labels?.length ?? 0) > 2"
+          class="text-[9px] text-gray-400 shrink-0"
+          >+{{ (item.labels?.length ?? 0) - 2 }}</span
+        >
+      </template>
     </div>
     <div v-if="more > 0" class="text-xs text-gray-400">+ {{ more }} more…</div>
   </div>
@@ -20,6 +35,7 @@
 import { computed } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData } from "./index";
+import { colorForLabel } from "./labels";
 
 const props = defineProps<{ result: ToolResultComplete<TodoData> }>();
 

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -9,6 +9,36 @@
       >
     </div>
 
+    <!-- Filter bar: only shown when at least one label is in use. -->
+    <div
+      v-if="labelInventory.length > 0"
+      class="flex flex-wrap items-center gap-1.5 px-6 py-2 border-b border-gray-100 bg-gray-50"
+    >
+      <span class="text-xs text-gray-500 mr-1">Filter:</span>
+      <button
+        v-for="entry in labelInventory"
+        :key="entry.label"
+        class="px-2 py-0.5 rounded-full text-xs font-medium transition-all"
+        :class="
+          activeFilters.has(entry.label.toLowerCase())
+            ? 'ring-2 ring-blue-400 ' + colorForLabel(entry.label)
+            : colorForLabel(entry.label) + ' opacity-70 hover:opacity-100'
+        "
+        @click="toggleFilter(entry.label)"
+      >
+        {{ entry.label }}
+        <span class="opacity-60">{{ entry.count }}</span>
+      </button>
+      <button
+        v-if="activeFilters.size > 0"
+        class="ml-auto text-xs text-gray-500 hover:text-gray-700"
+        title="Clear all filters"
+        @click="clearFilters"
+      >
+        Clear ✕
+      </button>
+    </div>
+
     <div
       v-if="items.length === 0"
       class="flex-1 flex items-center justify-center text-gray-400"
@@ -16,9 +46,16 @@
       No todo items yet
     </div>
 
+    <div
+      v-else-if="filteredItems.length === 0"
+      class="flex-1 flex items-center justify-center text-gray-400 text-sm"
+    >
+      No items match the active filter
+    </div>
+
     <ul v-else class="flex-1 overflow-y-auto p-4 space-y-2">
       <li
-        v-for="item in items"
+        v-for="item in filteredItems"
         :key="item.id"
         class="rounded-lg border"
         :class="selectedId === item.id ? 'border-blue-400' : 'border-gray-200'"
@@ -37,13 +74,24 @@
             @change="toggle(item)"
           />
           <div class="flex-1 min-w-0">
-            <span
-              class="text-sm"
-              :class="
-                item.completed ? 'line-through text-gray-400' : 'text-gray-800'
-              "
-              >{{ item.text }}</span
-            >
+            <div class="flex items-center gap-2 flex-wrap">
+              <span
+                class="text-sm"
+                :class="
+                  item.completed
+                    ? 'line-through text-gray-400'
+                    : 'text-gray-800'
+                "
+                >{{ item.text }}</span
+              >
+              <span
+                v-for="label in item.labels ?? []"
+                :key="label"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium shrink-0"
+                :class="colorForLabel(label)"
+                >{{ label }}</span
+              >
+            </div>
             <div v-if="item.note" class="text-xs text-gray-400 mt-0.5">
               {{ item.note }}
             </div>
@@ -108,6 +156,12 @@
 import { computed, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem } from "./index";
+import {
+  colorForLabel,
+  filterByLabels,
+  listLabelsWithCount,
+  subtractLabels,
+} from "./labels";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<TodoData>;
@@ -119,6 +173,35 @@ const completedCount = computed(
   () => items.value.filter((i) => i.completed).length,
 );
 const hasCompleted = computed(() => items.value.some((i) => i.completed));
+
+// ── Label filter state ──────────────────────────────────────────────────────
+// Filters are local to this View instance — intentional, so that
+// switching sessions or reopening a tool result doesn't drag state
+// across contexts. Active filters are stored lowercased to match
+// `filterByLabels`' case-insensitive semantics.
+
+const activeFilters = ref<Set<string>>(new Set());
+
+const labelInventory = computed(() => listLabelsWithCount(items.value));
+
+const filteredItems = computed(() =>
+  filterByLabels(items.value, [...activeFilters.value]),
+);
+
+function toggleFilter(label: string): void {
+  const key = label.toLowerCase();
+  const next = new Set(activeFilters.value);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  activeFilters.value = next;
+}
+
+function clearFilters(): void {
+  activeFilters.value = new Set();
+}
 
 // ── YAML helpers ─────────────────────────────────────────────────────────────
 
@@ -136,10 +219,49 @@ function yamlStringValue(v: string): string {
 }
 
 function serializeYaml(item: TodoItem): string {
+  const labels = item.labels ?? [];
+  const labelsLine =
+    labels.length > 0
+      ? `labels: [${labels.map(yamlStringValue).join(", ")}]`
+      : "labels: []";
   return [
     `text: ${yamlStringValue(item.text)}`,
     `note: ${item.note ? yamlStringValue(item.note) : ""}`,
+    labelsLine,
   ].join("\n");
+}
+
+// Parse a YAML flow sequence `[a, "b", c]` into an array of strings.
+// Handles quoted and unquoted entries. Whitespace-only input → empty.
+function parseFlowSequence(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "[]") return [];
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return [];
+  const inner = trimmed.slice(1, -1);
+  // Split on commas that are NOT inside double quotes. Cheap scan;
+  // fine for our label use case where items don't contain commas
+  // (stored labels are normalised strings without commas).
+  const result: string[] = [];
+  let buffer = "";
+  let inQuotes = false;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '"' && inner[i - 1] !== "\\") {
+      inQuotes = !inQuotes;
+      buffer += ch;
+      continue;
+    }
+    if (ch === "," && !inQuotes) {
+      const piece = parseYamlValue(buffer.trim());
+      if (piece) result.push(piece);
+      buffer = "";
+      continue;
+    }
+    buffer += ch;
+  }
+  const last = parseYamlValue(buffer.trim());
+  if (last) result.push(last);
+  return result;
 }
 
 function parseYamlValue(raw: string): string {
@@ -152,7 +274,9 @@ function parseYamlValue(raw: string): string {
   return raw;
 }
 
-function parseYaml(text: string): { text: string; note: string } | null {
+function parseYaml(
+  text: string,
+): { text: string; note: string; labels: string[] } | null {
   const result: Record<string, string> = {};
   for (const line of text.split("\n")) {
     const trimmed = line.trim();
@@ -164,18 +288,31 @@ function parseYaml(text: string): { text: string; note: string } | null {
       if (colonEnd !== -1) result[line.slice(0, colonEnd).trim()] = "";
       continue;
     }
-    result[line.slice(0, colonIdx).trim()] = parseYamlValue(
-      line.slice(colonIdx + 2).trim(),
-    );
+    // `labels:` is a flow sequence (`[a, b]`) — parse it as a list
+    // instead of running it through `parseYamlValue` which strips
+    // brackets as if they were quotes.
+    const key = line.slice(0, colonIdx).trim();
+    const raw = line.slice(colonIdx + 2).trim();
+    if (key === "labels") {
+      result[key] = raw;
+      continue;
+    }
+    result[key] = parseYamlValue(raw);
   }
   if (typeof result["text"] !== "string" || !result["text"]) return null;
-  return { text: result["text"], note: result["note"] ?? "" };
+  const labels = parseFlowSequence(result["labels"] ?? "[]");
+  return {
+    text: result["text"],
+    note: result["note"] ?? "",
+    labels,
+  };
 }
 
 // ── Item selection & YAML edit ────────────────────────────────────────────────
 
 const selectedId = ref<string | null>(null);
 const selectedOriginalText = ref<string>("");
+const selectedOriginalLabels = ref<string[]>([]);
 const yamlText = ref("");
 const yamlError = ref("");
 
@@ -186,6 +323,7 @@ function selectItem(item: TodoItem) {
   }
   selectedId.value = item.id;
   selectedOriginalText.value = item.text;
+  selectedOriginalLabels.value = [...(item.labels ?? [])];
   yamlText.value = serializeYaml(item);
   yamlError.value = "";
 }
@@ -198,6 +336,7 @@ watch(
       if (item) {
         yamlText.value = serializeYaml(item);
         selectedOriginalText.value = item.text;
+        selectedOriginalLabels.value = [...(item.labels ?? [])];
       } else {
         selectedId.value = null;
       }
@@ -212,12 +351,36 @@ async function applyItemEdit() {
     yamlError.value = "Could not parse YAML — 'text' field is required";
     return;
   }
+  // 1. text / note go through `update` (label-agnostic on the server).
   await callApi({
     action: "update",
     text: selectedOriginalText.value,
     newText: parsed.text,
     note: parsed.note,
   });
+  // 2. labels are diffed against the prior state and applied as
+  //    `add_label` / `remove_label` calls. `update` deliberately
+  //    does not touch labels — this keeps each LLM action
+  //    single-purpose and matches the add_label/remove_label
+  //    semantics the LLM uses.
+  const originalLabels = selectedOriginalLabels.value;
+  const removed = subtractLabels(originalLabels, parsed.labels);
+  const added = subtractLabels(parsed.labels, originalLabels);
+  // Use the already-renamed `parsed.text` to match the updated item.
+  if (removed.length > 0) {
+    await callApi({
+      action: "remove_label",
+      text: parsed.text,
+      labels: removed,
+    });
+  }
+  if (added.length > 0) {
+    await callApi({
+      action: "add_label",
+      text: parsed.text,
+      labels: added,
+    });
+  }
   selectedId.value = null;
 }
 

--- a/src/plugins/todo/definition.ts
+++ b/src/plugins/todo/definition.ts
@@ -4,7 +4,7 @@ const toolDefinition: ToolDefinition = {
   type: "function",
   name: "manageTodoList",
   description:
-    "Manage a todo list — show items, add, update, check/uncheck, or delete them. Use this whenever the user mentions tasks, todos, or things to remember.",
+    "Manage a todo list — show items, add, update, check/uncheck, or delete them. Items can optionally carry labels (tags) for categorisation; use labels to group related todos (e.g. 'Work', 'Groceries', 'Urgent') and filter the list at read time.",
   parameters: {
     type: "object",
     properties: {
@@ -18,13 +18,16 @@ const toolDefinition: ToolDefinition = {
           "check",
           "uncheck",
           "clear_completed",
+          "add_label",
+          "remove_label",
+          "list_labels",
         ],
         description: "Action to perform on the todo list.",
       },
       text: {
         type: "string",
         description:
-          "For 'add': the todo item text. For 'delete', 'update', 'check', 'uncheck': partial text to find the item.",
+          "For 'add': the todo item text. For 'delete', 'update', 'check', 'uncheck', 'add_label', 'remove_label': partial text to find the item.",
       },
       newText: {
         type: "string",
@@ -34,6 +37,18 @@ const toolDefinition: ToolDefinition = {
         type: "string",
         description:
           "For 'add' or 'update': an optional note or extra detail for the item.",
+      },
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "For 'add': labels to tag the new item with. For 'add_label' / 'remove_label': labels to add to / remove from the item matched by 'text'. Labels are case-insensitive for matching but stored with their original case.",
+      },
+      filterLabels: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "For 'show' only: return only items that have at least one of these labels (OR semantics, case-insensitive). Omit to show all items.",
       },
     },
     required: ["action"],

--- a/src/plugins/todo/index.ts
+++ b/src/plugins/todo/index.ts
@@ -7,6 +7,7 @@ export interface TodoItem {
   id: string;
   text: string;
   note?: string;
+  labels?: string[];
   completed: boolean;
   createdAt: number;
 }

--- a/src/plugins/todo/labels.ts
+++ b/src/plugins/todo/labels.ts
@@ -1,0 +1,178 @@
+// Pure helpers for todo labels. Used by both the server route
+// (server/routes/todos.ts) and the Vue views (View.vue / Preview.vue),
+// so the file is kept free of Node-only and browser-only APIs.
+//
+// Storage contract:
+//   - Labels are case-preserving strings (e.g. "Work", "Groceries")
+//   - Matching / deduplication is case-insensitive
+//   - Whitespace is trimmed and collapsed on normalise
+//   - Empty / whitespace-only labels are rejected
+
+// ── Normalisation and comparison ──────────────────────────────────
+
+// Trim leading/trailing whitespace and collapse internal whitespace
+// runs to single spaces. Returns `null` for empty / whitespace-only
+// input so callers can filter out bad entries at the boundary.
+export function normalizeLabel(raw: string): string | null {
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  return collapsed.length > 0 ? collapsed : null;
+}
+
+// Case-insensitive label equality. Both inputs are normalised first
+// so `" Work "` and `"work"` compare equal.
+export function labelsEqual(a: string, b: string): boolean {
+  const na = normalizeLabel(a);
+  const nb = normalizeLabel(b);
+  if (na === null || nb === null) return false;
+  return na.toLowerCase() === nb.toLowerCase();
+}
+
+// ── Colour assignment ─────────────────────────────────────────────
+
+// Eight Tailwind pastel chip styles. Enough visual variety without
+// turning the UI into a rainbow. Every label maps deterministically
+// to one of these via `colorForLabel`.
+export const LABEL_PALETTE: readonly string[] = [
+  "bg-blue-100 text-blue-700",
+  "bg-green-100 text-green-700",
+  "bg-purple-100 text-purple-700",
+  "bg-yellow-100 text-yellow-700",
+  "bg-pink-100 text-pink-700",
+  "bg-indigo-100 text-indigo-700",
+  "bg-red-100 text-red-700",
+  "bg-teal-100 text-teal-700",
+] as const;
+
+// Deterministic colour class for a label. Same label → same colour
+// across sessions and across clients. Case-insensitive so that
+// `"Work"` and `"work"` look identical even if they drift in
+// different items over time.
+export function colorForLabel(label: string): string {
+  const key = label.toLowerCase();
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    // Classic 31-multiplier string hash. Kept as unsigned via >>> 0
+    // so the modulo at the end doesn't produce negatives.
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return LABEL_PALETTE[hash % LABEL_PALETTE.length];
+}
+
+// ── Filtering ─────────────────────────────────────────────────────
+
+// OR-semantics filter: return items that have at least one label in
+// `filterLabels`. Matching is case-insensitive. An empty filter list
+// is a pass-through — callers don't need to special-case "no filter"
+// themselves.
+//
+// Items whose `labels` is `undefined` or `[]` are excluded when
+// `filterLabels` is non-empty, since they have nothing to match.
+export function filterByLabels<T extends { labels?: string[] }>(
+  items: readonly T[],
+  filterLabels: readonly string[],
+): T[] {
+  if (filterLabels.length === 0) return [...items];
+  const wanted = new Set(
+    filterLabels
+      .map(normalizeLabel)
+      .filter((l): l is string => l !== null)
+      .map((l) => l.toLowerCase()),
+  );
+  if (wanted.size === 0) return [...items];
+  return items.filter((item) => {
+    const itemLabels = item.labels ?? [];
+    return itemLabels.some((l) => {
+      const n = normalizeLabel(l);
+      return n !== null && wanted.has(n.toLowerCase());
+    });
+  });
+}
+
+// ── Label inventory ──────────────────────────────────────────────
+
+// Distinct-label summary for the whole collection. Counts are
+// case-insensitive: `"Work"` and `"work"` merge into one row. The
+// displayed form is the first spelling encountered while scanning,
+// which is usually the most recently added item at the top of the
+// list — stable enough in practice and avoids a second full pass.
+//
+// Sorted by count desc, then by the displayed label asc (case-
+// insensitive) for deterministic output.
+export function listLabelsWithCount(
+  items: readonly { labels?: string[] }[],
+): Array<{ label: string; count: number }> {
+  const groups = new Map<string, { label: string; count: number }>();
+  for (const item of items) {
+    const seenInItem = new Set<string>();
+    for (const raw of item.labels ?? []) {
+      const normalized = normalizeLabel(raw);
+      if (normalized === null) continue;
+      const key = normalized.toLowerCase();
+      // Guard against the same label appearing twice within one item
+      // (shouldn't happen post-mergeLabels but be safe).
+      if (seenInItem.has(key)) continue;
+      seenInItem.add(key);
+      const existing = groups.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        groups.set(key, { label: normalized, count: 1 });
+      }
+    }
+  }
+  return [...groups.values()].sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.label.toLowerCase() < b.label.toLowerCase()
+      ? -1
+      : a.label.toLowerCase() > b.label.toLowerCase()
+        ? 1
+        : 0;
+  });
+}
+
+// ── Set operations (for add_label / remove_label) ────────────────
+
+// Union of `existing` and `adding`, de-duped case-insensitively.
+// Preserves the order of `existing`, then appends newly-introduced
+// labels in the order they appear in `adding`. Normalises both
+// sides (trim/collapse) before comparison and storage.
+export function mergeLabels(
+  existing: readonly string[],
+  adding: readonly string[],
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  const push = (label: string): void => {
+    const normalized = normalizeLabel(label);
+    if (normalized === null) return;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(normalized);
+  };
+  for (const label of existing) push(label);
+  for (const label of adding) push(label);
+  return result;
+}
+
+// Remove `removing` labels from `existing`, case-insensitively.
+// Removing a label that isn't present is a no-op. The order of
+// surviving labels is preserved. Normalises both sides first.
+export function subtractLabels(
+  existing: readonly string[],
+  removing: readonly string[],
+): string[] {
+  const toRemove = new Set(
+    removing
+      .map(normalizeLabel)
+      .filter((l): l is string => l !== null)
+      .map((l) => l.toLowerCase()),
+  );
+  if (toRemove.size === 0) {
+    return existing.map(normalizeLabel).filter((l): l is string => l !== null);
+  }
+  return existing
+    .map(normalizeLabel)
+    .filter((l): l is string => l !== null)
+    .filter((l) => !toRemove.has(l.toLowerCase()));
+}

--- a/test/plugins/todo/test_labels.ts
+++ b/test/plugins/todo/test_labels.ts
@@ -1,0 +1,305 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeLabel,
+  labelsEqual,
+  colorForLabel,
+  LABEL_PALETTE,
+  filterByLabels,
+  listLabelsWithCount,
+  mergeLabels,
+  subtractLabels,
+} from "../../../src/plugins/todo/labels.js";
+
+describe("normalizeLabel", () => {
+  it("trims leading and trailing whitespace", () => {
+    assert.equal(normalizeLabel("  Work  "), "Work");
+  });
+
+  it("collapses internal whitespace runs to single space", () => {
+    assert.equal(normalizeLabel("High   Priority"), "High Priority");
+  });
+
+  it("preserves case", () => {
+    assert.equal(normalizeLabel("ShoppingList"), "ShoppingList");
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(normalizeLabel(""), null);
+  });
+
+  it("returns null for whitespace-only", () => {
+    assert.equal(normalizeLabel("   "), null);
+    assert.equal(normalizeLabel("\t\n  "), null);
+  });
+
+  it("handles a multi-byte character label", () => {
+    assert.equal(normalizeLabel("仕事"), "仕事");
+  });
+});
+
+describe("labelsEqual", () => {
+  it("matches identical labels", () => {
+    assert.equal(labelsEqual("Work", "Work"), true);
+  });
+
+  it("matches case-insensitively", () => {
+    assert.equal(labelsEqual("Work", "work"), true);
+    assert.equal(labelsEqual("WORK", "Work"), true);
+  });
+
+  it("treats normalised whitespace as equal", () => {
+    assert.equal(labelsEqual(" Work ", "work"), true);
+    assert.equal(labelsEqual("High  Priority", "high priority"), true);
+  });
+
+  it("rejects different labels", () => {
+    assert.equal(labelsEqual("Work", "Personal"), false);
+  });
+
+  it("returns false when either side is empty", () => {
+    assert.equal(labelsEqual("", "Work"), false);
+    assert.equal(labelsEqual("Work", ""), false);
+  });
+});
+
+describe("colorForLabel", () => {
+  it("always returns a value from LABEL_PALETTE", () => {
+    for (const input of ["Work", "", "abc", "ZZZZZZ", "仕事", "1"]) {
+      const color = colorForLabel(input);
+      assert.ok(
+        LABEL_PALETTE.includes(color),
+        `expected palette entry, got "${color}" for "${input}"`,
+      );
+    }
+  });
+
+  it("is deterministic for the same input", () => {
+    const a = colorForLabel("Urgent");
+    const b = colorForLabel("Urgent");
+    assert.equal(a, b);
+  });
+
+  it("is case-insensitive", () => {
+    assert.equal(colorForLabel("Work"), colorForLabel("work"));
+    assert.equal(colorForLabel("WORK"), colorForLabel("Work"));
+  });
+
+  it("maps visibly different labels to varied colours (spot check)", () => {
+    // Not required to be unique, but a handful of common labels
+    // shouldn't all collide on the same slot.
+    const samples = [
+      "Work",
+      "Personal",
+      "Urgent",
+      "Groceries",
+      "Shopping",
+      "Books",
+    ];
+    const colors = new Set(samples.map(colorForLabel));
+    assert.ok(
+      colors.size >= 3,
+      `expected at least 3 distinct colours from ${samples.length} samples, got ${colors.size}`,
+    );
+  });
+});
+
+describe("filterByLabels", () => {
+  const items = [
+    { id: "a", labels: ["Work", "Urgent"] },
+    { id: "b", labels: ["Personal"] },
+    { id: "c", labels: ["Work"] },
+    { id: "d" /* no labels */ },
+    { id: "e", labels: [] },
+  ];
+
+  it("returns all items when filter is empty", () => {
+    const result = filterByLabels(items, []);
+    assert.equal(result.length, items.length);
+  });
+
+  it("returns all items when filter contains only empty strings", () => {
+    const result = filterByLabels(items, ["", "   "]);
+    assert.equal(result.length, items.length);
+  });
+
+  it("matches items by single label", () => {
+    const result = filterByLabels(items, ["Work"]);
+    assert.deepEqual(
+      result.map((i) => i.id),
+      ["a", "c"],
+    );
+  });
+
+  it("uses OR semantics with multiple labels", () => {
+    const result = filterByLabels(items, ["Work", "Personal"]);
+    assert.deepEqual(
+      result.map((i) => i.id),
+      ["a", "b", "c"],
+    );
+  });
+
+  it("is case-insensitive", () => {
+    const lower = filterByLabels(items, ["work"]);
+    const upper = filterByLabels(items, ["WORK"]);
+    assert.deepEqual(
+      lower.map((i) => i.id),
+      upper.map((i) => i.id),
+    );
+    assert.deepEqual(
+      lower.map((i) => i.id),
+      ["a", "c"],
+    );
+  });
+
+  it("excludes items without labels when filter is non-empty", () => {
+    const result = filterByLabels(items, ["Work"]);
+    assert.ok(!result.find((i) => i.id === "d"));
+    assert.ok(!result.find((i) => i.id === "e"));
+  });
+
+  it("does not mutate the input array", () => {
+    const original = items.slice();
+    filterByLabels(items, ["Work"]);
+    assert.deepEqual(items, original);
+  });
+});
+
+describe("listLabelsWithCount", () => {
+  it("returns empty for an empty collection", () => {
+    assert.deepEqual(listLabelsWithCount([]), []);
+  });
+
+  it("returns empty when no item has labels", () => {
+    const items = [{ id: "a" }, { id: "b", labels: [] }];
+    assert.deepEqual(listLabelsWithCount(items), []);
+  });
+
+  it("counts labels across items", () => {
+    const items = [
+      { labels: ["Work", "Urgent"] },
+      { labels: ["Work"] },
+      { labels: ["Personal"] },
+    ];
+    const result = listLabelsWithCount(items);
+    // Sorted by count desc, then label asc
+    assert.deepEqual(result, [
+      { label: "Work", count: 2 },
+      { label: "Personal", count: 1 },
+      { label: "Urgent", count: 1 },
+    ]);
+  });
+
+  it("groups case-insensitively", () => {
+    const items = [
+      { labels: ["Work"] },
+      { labels: ["work"] },
+      { labels: ["WORK"] },
+    ];
+    const result = listLabelsWithCount(items);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].count, 3);
+    // Display form is the first-seen case
+    assert.equal(result[0].label, "Work");
+  });
+
+  it("de-duplicates labels repeated within a single item", () => {
+    // Shouldn't happen post-mergeLabels, but be defensive
+    const items = [{ labels: ["Urgent", "urgent", "URGENT"] }];
+    const result = listLabelsWithCount(items);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].count, 1);
+  });
+
+  it("sorts alphabetically (case-insensitive) when counts are equal", () => {
+    const items = [
+      { labels: ["Zebra"] },
+      { labels: ["apple"] },
+      { labels: ["Mango"] },
+    ];
+    const result = listLabelsWithCount(items);
+    assert.deepEqual(
+      result.map((r) => r.label),
+      ["apple", "Mango", "Zebra"],
+    );
+  });
+});
+
+describe("mergeLabels", () => {
+  it("adds new labels to an empty existing set", () => {
+    assert.deepEqual(mergeLabels([], ["Work", "Urgent"]), ["Work", "Urgent"]);
+  });
+
+  it("preserves existing labels when nothing is added", () => {
+    assert.deepEqual(mergeLabels(["Work"], []), ["Work"]);
+  });
+
+  it("appends new labels without disturbing existing order", () => {
+    assert.deepEqual(mergeLabels(["Work", "Personal"], ["Urgent"]), [
+      "Work",
+      "Personal",
+      "Urgent",
+    ]);
+  });
+
+  it("de-duplicates case-insensitively", () => {
+    assert.deepEqual(mergeLabels(["Work"], ["work", "WORK"]), ["Work"]);
+  });
+
+  it("keeps the existing case when a duplicate-in-other-case is added", () => {
+    // "Work" stays, "work" doesn't replace it
+    assert.deepEqual(mergeLabels(["Work"], ["work"]), ["Work"]);
+  });
+
+  it("normalises whitespace on both sides", () => {
+    assert.deepEqual(mergeLabels(["  Work  "], [" Urgent "]), [
+      "Work",
+      "Urgent",
+    ]);
+  });
+
+  it("rejects empty additions silently", () => {
+    assert.deepEqual(mergeLabels(["Work"], ["", "   "]), ["Work"]);
+  });
+});
+
+describe("subtractLabels", () => {
+  it("removes matching labels (case-insensitive)", () => {
+    assert.deepEqual(subtractLabels(["Work", "Urgent", "Personal"], ["work"]), [
+      "Urgent",
+      "Personal",
+    ]);
+  });
+
+  it("is a no-op when removing a label that isn't there", () => {
+    assert.deepEqual(subtractLabels(["Work"], ["Nonexistent"]), ["Work"]);
+  });
+
+  it("preserves the order of surviving labels", () => {
+    assert.deepEqual(subtractLabels(["A", "B", "C", "D"], ["B", "D"]), [
+      "A",
+      "C",
+    ]);
+  });
+
+  it("returns existing set unchanged when removing empty list", () => {
+    assert.deepEqual(subtractLabels(["Work", "Urgent"], []), [
+      "Work",
+      "Urgent",
+    ]);
+  });
+
+  it("normalises whitespace on existing entries even when not removing", () => {
+    assert.deepEqual(subtractLabels(["  Work  ", "Urgent"], []), [
+      "Work",
+      "Urgent",
+    ]);
+  });
+
+  it("drops invalid entries from existing side", () => {
+    assert.deepEqual(subtractLabels(["Work", "", "   ", "Urgent"], []), [
+      "Work",
+      "Urgent",
+    ]);
+  });
+});


### PR DESCRIPTION
## User Prompt

> さて、次はtodo機能。今は全てのtodoが１つのファイルでラベルもないので仕訳ができない。複数のラベルをつけられるようにして追加時や参照時にfilterできるようにしたい。

## 概要

Todo アイテムに **オプションの複数ラベル** を追加できるようにし、**追加時・参照時にラベルでフィルタ** できるようにしました。

データモデルは additive で **migration 不要**(既存の `todos.json` に `labels` フィールドが無くてもそのまま読める)。

詳細は [\`plans/feat-todo-labels.md\`](./plans/feat-todo-labels.md) 参照。

## 変更点

### データモデル (additive)
\`\`\`ts
interface TodoItem {
  id: string;
  text: string;
  note?: string;
  labels?: string[];  // ← NEW
  completed: boolean;
  createdAt: number;
}
\`\`\`

- **保存時は case-preserving**(ユーザが \`Work\` と書けばそのまま)
- **マッチ時は case-insensitive**(\`Work\` / \`work\` / \`WORK\` は同じ扱い)
- 空文字列・空白のみのラベルは normalise 段階で reject

### LLM API (\`manageTodoList\`)

**既存 action の拡張**:
- \`add\` に \`labels: string[]\` を追加 — 作成時にタグ付け
- \`show\` に \`filterLabels: string[]\` を追加 — **OR セマンティクス**(case-insensitive)で返される list を絞る

**新 action 3 つ**:
- \`add_label\` — 既存アイテムに label を追加(text match + labels)
- \`remove_label\` — 既存アイテムから label を削除
- \`list_labels\` — 使用中の全ラベルとカウントを返す(count 降順 → label 昇順)

**\`update\` は意図的に labels を触らない** — 各 LLM action を single-purpose に保つため、label 編集は \`add_label\` / \`remove_label\` で差分操作する設計。View の YAML エディタからの label 変更も同じパターンで diff して発行。

### Pure helpers(\`src/plugins/todo/labels.ts\`)

server route と Vue views の両方から使う共通ヘルパー:

- \`normalizeLabel\`: trim / whitespace collapse / empty reject
- \`labelsEqual\`: case-insensitive 等価
- \`LABEL_PALETTE\` + \`colorForLabel\`: deterministic hash → 8 色の Tailwind pastel palette。同じラベルは常に同じ色(case-insensitive)
- \`filterByLabels\`: OR semantics、pass-through-on-empty
- \`listLabelsWithCount\`: case-insensitive grouping、stable sort
- \`mergeLabels\` / \`subtractLabels\`: 集合演算(normalise + dedup)

### UI

**View.vue**:
- **上部にフィルタバー**(ラベルが 1 つでも使われていれば表示)
  - 各ラベル chip に使用数を添えて並べる
  - クリックで toggle、複数選択 = OR で絞り込み
  - \`Clear ✕\` ボタン
- 各アイテム行にラベル chip をインライン表示
- YAML エディタに \`labels: [...]\` フィールド追加(flow sequence 形式)
- YAML 編集は \`update\`(text/note)+ \`add_label\` / \`remove_label\`(差分)に分解して送信
- 色は \`colorForLabel\` で自動割当

**Preview.vue**:
- 各プレビューアイテムに **最初の 2 ラベルの chip** を表示、超過分は \`+N\`

### 色の決定アルゴリズム

```ts
export const LABEL_PALETTE = [
  "bg-blue-100 text-blue-700",
  "bg-green-100 text-green-700",
  "bg-purple-100 text-purple-700",
  "bg-yellow-100 text-yellow-700",
  "bg-pink-100 text-pink-700",
  "bg-indigo-100 text-indigo-700",
  "bg-red-100 text-red-700",
  "bg-teal-100 text-teal-700",
] as const;

export function colorForLabel(label: string): string {
  const key = label.toLowerCase();
  let hash = 0;
  for (let i = 0; i < key.length; i++) {
    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
  }
  return LABEL_PALETTE[hash % LABEL_PALETTE.length];
}
\`\`\`

deterministic、case-insensitive、決定的にカラーが割当される。

## テスト

**新規ユニットテスト 40 ケース** (\`test/plugins/todo/test_labels.ts\`):

| describe | cases |
|---|---|
| normalizeLabel | 6(trim / collapse / case preserve / empty reject / multi-byte) |
| labelsEqual | 5(identical / case-insensitive / whitespace-aware / empty) |
| colorForLabel | 4(palette slot / deterministic / case-insensitive / diversity) |
| filterByLabels | 7(empty / single / OR / case-insensitive / exclude no-labels / no-mutate) |
| listLabelsWithCount | 5(empty / case grouping / in-item dedup / sort) |
| mergeLabels | 7(empty add / no-op / order / case dedup / whitespace / reject empty) |
| subtractLabels | 6(case-insensitive remove / no-op / order / normalise) |

全体: **341 / 341 tests passing**(既存 301 + 新規 40)

## 既存データへの影響

**なし**。\`labels?: string[]\` は optional なので:
- 既存の \`todos.json\` はそのまま読める
- \`labels === undefined\` のアイテムは「空ラベル」として扱われる
- フィルタ時、filter が空なら全アイテム通す(pass-through)
- filter が非空で item の labels が undefined なら除外される(ロジック的に正しい)

## Test plan

- [x] \`yarn format\`
- [x] \`yarn lint\` — 0 errors / 61 warnings(既存の server/ 警告)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — **341/341 passing**
- [ ] 手動スモーク(merge 前):
  - [ ] LLM に「買い物メモを追加、groceries タグ付きで」と頼む → アイテムに label が付いた状態で表示
  - [ ] LLM に「全 todo を show、work タグで filter」と頼む → filtered list が返る
  - [ ] LLM に「list_labels」と頼む → 使用中ラベル一覧が返る
  - [ ] View の filter bar で複数 chip クリック → OR 絞り込み
  - [ ] View の YAML エディタで labels を編集(追加・削除) → 反映される
  - [ ] Preview のカードに label chip が表示される

## スコープ外(follow-up)

- \`rename_label\` action(全 item にまたがる一括リネーム)
- Per-role default label set(office role → 自動で Work)
- Sort by label
- Manual "add todo" text field + label input UI(LLM 経由じゃなく手動追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)