### PR TITLE
feat(chat-index): force + backfill for manual verification

### DIFF
--- a/plans/feat-session-index-titles.md
+++ b/plans/feat-session-index-titles.md
@@ -57,7 +57,25 @@ No `setInterval`. No `server/index.ts` registration. No `CHAT_INDEX_REFRESH_HOUR
 
 ## Backfill
 
-Legacy sessions (created before this feature lands) will be indexed lazily as the user revisits and continues them. For an immediate one-shot backfill, users can run the server with an env var (out of scope for this PR — add later if the lazy backfill turns out to be too slow in practice). The sidebar gracefully falls back to the first-user-message preview for any session without an index entry.
+Legacy sessions (created before this feature lands) are indexed lazily as the user revisits and continues them. The sidebar gracefully falls back to the first-user-message preview for any session without an index entry.
+
+For an immediate one-shot backfill over every existing session — useful the first time the feature is rolled out, or for debugging the indexer itself — there are two manual triggers:
+
+**Startup switch** (mirrors the journal's `JOURNAL_FORCE_RUN_ON_STARTUP=1`):
+
+```bash
+CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 yarn dev
+```
+
+The server boots, walks every `chat/*.jsonl`, spawns claude for each, and logs each indexed session. The `force: true` flag propagated through the indexer bypasses both the freshness throttle and the `activeSessionIds` guard.
+
+**Runtime endpoint** (no restart required):
+
+```bash
+curl -X POST http://localhost:3000/api/chat-index/rebuild
+```
+
+`POST /api/chat-index/rebuild` calls `backfillAllSessions()` and returns `{ total, indexed, skipped }`. Server logs each indexed session as it goes so progress is visible in the terminal.
 
 ## File layout (proposed)
 

--- a/server/chat-index/index.ts
+++ b/server/chat-index/index.ts
@@ -15,7 +15,7 @@
 
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
-import { indexSession, type IndexerDeps } from "./indexer.js";
+import { indexSession, listSessionIds, type IndexerDeps } from "./indexer.js";
 
 // Per-session lock. Indexing different sessions in parallel is
 // fine; indexing the same session twice concurrently would just
@@ -31,9 +31,18 @@ export interface MaybeIndexSessionOptions {
   sessionId: string;
   // Skip indexing if the session is still being appended to by a
   // concurrent /api/agent request — the jsonl may be mid-write.
+  // Ignored when `force` is true so manual rebuild runs can
+  // re-index even a live session (accepting that the transcript
+  // may be slightly out of date).
   activeSessionIds?: ReadonlySet<string>;
   workspaceRoot?: string;
   deps?: IndexerDeps;
+  // Bypass the activeSessionIds guard and the isFresh throttle
+  // for this call. The per-session lock and the `disabled`
+  // sentinel are still respected — forcing doesn't help if the
+  // claude CLI is missing or the same session is already in
+  // flight.
+  force?: boolean;
 }
 
 // Fire-and-forget entry point. Errors are swallowed here; a
@@ -44,15 +53,23 @@ export async function maybeIndexSession(
   if (disabled) return;
 
   const { sessionId } = opts;
-  if (opts.activeSessionIds?.has(sessionId)) return;
+  const force = opts.force === true;
+  if (!force && opts.activeSessionIds?.has(sessionId)) return;
   if (running.has(sessionId)) return;
+
+  // Thread `force` through the indexer via IndexerDeps so the
+  // freshness throttle is also bypassed on forced runs.
+  const effectiveDeps: IndexerDeps = {
+    ...(opts.deps ?? {}),
+    ...(force ? { force: true } : {}),
+  };
 
   running.add(sessionId);
   try {
     await indexSession(
       opts.workspaceRoot ?? defaultWorkspacePath,
       sessionId,
-      opts.deps,
+      effectiveDeps,
     );
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) {
@@ -66,6 +83,67 @@ export async function maybeIndexSession(
   } finally {
     running.delete(sessionId);
   }
+}
+
+// Debug helper: index every session jsonl under workspace/chat/
+// sequentially with `force: true`. Used by the manual rebuild
+// endpoint and the CHAT_INDEX_FORCE_RUN_ON_STARTUP switch so the
+// user can populate titles for existing sessions without waiting
+// for each one to be revisited.
+//
+// Returns counts for logging. Errors on individual sessions do
+// not stop the walk — the failure is logged and processing
+// continues.
+export interface BackfillResult {
+  total: number;
+  indexed: number;
+  skipped: number;
+}
+
+export async function backfillAllSessions(
+  opts: {
+    workspaceRoot?: string;
+    deps?: IndexerDeps;
+  } = {},
+): Promise<BackfillResult> {
+  const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
+  const ids = await listSessionIds(workspaceRoot);
+  const result: BackfillResult = {
+    total: ids.length,
+    indexed: 0,
+    skipped: 0,
+  };
+  for (const sessionId of ids) {
+    if (disabled) {
+      result.skipped++;
+      continue;
+    }
+    try {
+      const entry = await indexSession(workspaceRoot, sessionId, {
+        ...(opts.deps ?? {}),
+        force: true,
+      });
+      if (entry) {
+        result.indexed++;
+        // eslint-disable-next-line no-console
+        console.log(`[chat-index] indexed ${sessionId}: ${entry.title}`);
+      } else {
+        result.skipped++;
+      }
+    } catch (err) {
+      if (err instanceof ClaudeCliNotFoundError) {
+        disabled = true;
+        // eslint-disable-next-line no-console
+        console.warn(err.message);
+        result.skipped++;
+        continue;
+      }
+      result.skipped++;
+      // eslint-disable-next-line no-console
+      console.warn(`[chat-index] failed to index ${sessionId}:`, err);
+    }
+  }
+  return result;
 }
 
 // Internal hook: tests need to reset the module-level `disabled`

--- a/server/chat-index/indexer.ts
+++ b/server/chat-index/indexer.ts
@@ -8,7 +8,7 @@
 // at a `mkdtempSync` directory without touching the real
 // ~/mulmoclaude.
 
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import {
   defaultSummarize,
@@ -16,6 +16,7 @@ import {
   type SummarizeFn,
 } from "./summarizer.js";
 import {
+  chatDirFor,
   indexDirFor,
   indexEntryPathFor,
   manifestPathFor,
@@ -37,6 +38,11 @@ export interface IndexerDeps {
   summarize?: SummarizeFn;
   now?: () => number;
   minIntervalMs?: number;
+  // Bypass the `isFresh` freshness throttle. Used by the
+  // backfill helper and the debug trigger endpoint so a manual
+  // "rebuild everything" run doesn't silently skip entries that
+  // happen to be within the 15-minute window.
+  force?: boolean;
 }
 
 // --- manifest I/O ---------------------------------------------------
@@ -169,6 +175,19 @@ async function readSessionMeta(
   }
 }
 
+// List every session id that has a .jsonl file in the workspace
+// chat dir. Used by the backfill helper.
+export async function listSessionIds(workspaceRoot: string): Promise<string[]> {
+  try {
+    const files = await readdir(chatDirFor(workspaceRoot));
+    return files
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => f.slice(0, -".jsonl".length));
+  } catch {
+    return [];
+  }
+}
+
 // --- the core indexSession call ------------------------------------
 
 // Index (or re-index) a single session. Returns the entry on
@@ -184,8 +203,9 @@ export async function indexSession(
   const summarize = deps.summarize ?? defaultSummarize;
   const now = (deps.now ?? Date.now)();
   const minInterval = deps.minIntervalMs ?? MIN_INDEX_INTERVAL_MS;
+  const force = deps.force === true;
 
-  if (await isFresh(workspaceRoot, sessionId, now, minInterval)) {
+  if (!force && (await isFresh(workspaceRoot, sessionId, now, minInterval))) {
     return null;
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import agentRoutes from "./routes/agent.js";
 import todosRoutes from "./routes/todos.js";
 import schedulerRoutes from "./routes/scheduler.js";
 import sessionsRoutes from "./routes/sessions.js";
+import chatIndexRoutes from "./routes/chat-index.js";
 import pluginsRoutes from "./routes/plugins.js";
 import imageRoutes from "./routes/image.js";
 import presentHtmlRoutes from "./routes/presentHtml.js";
@@ -26,6 +27,7 @@ import fs from "fs";
 import os from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./docker.js";
 import { maybeRunJournal } from "./journal/index.js";
+import { backfillAllSessions } from "./chat-index/index.js";
 import { createPubSub } from "./pub-sub/index.js";
 import { createTaskManager } from "./task-manager/index.js";
 import type { ITaskManager } from "./task-manager/index.js";
@@ -59,6 +61,7 @@ app.use("/api", agentRoutes);
 app.use("/api", todosRoutes);
 app.use("/api", schedulerRoutes);
 app.use("/api", sessionsRoutes);
+app.use("/api", chatIndexRoutes);
 app.use("/api", pluginsRoutes);
 app.use("/api", imageRoutes);
 app.use("/api", presentHtmlRoutes);
@@ -197,6 +200,25 @@ function isPortFree(port: number): Promise<boolean> {
       maybeRunJournal({ force: true }).catch((err) => {
         console.warn("[journal] forced startup run failed:", err);
       });
+    }
+
+    // Companion switch for the chat indexer: force-rebuild every
+    // session's title summary on startup. Useful the first time
+    // the feature is rolled out over an existing workspace, or
+    // when debugging the indexer itself.
+    if (process.env.CHAT_INDEX_FORCE_RUN_ON_STARTUP === "1") {
+      console.log(
+        "[chat-index] CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 — running now",
+      );
+      backfillAllSessions()
+        .then((result) => {
+          console.log(
+            `[chat-index] startup backfill complete: ${result.indexed}/${result.total} indexed, ${result.skipped} skipped`,
+          );
+        })
+        .catch((err) => {
+          console.warn("[chat-index] forced startup backfill failed:", err);
+        });
     }
   });
 })();

--- a/server/routes/chat-index.ts
+++ b/server/routes/chat-index.ts
@@ -1,0 +1,52 @@
+// Debug trigger endpoint for the chat indexer. The normal path is
+// the agent `finally` hook in server/routes/agent.ts — one session
+// at a time, with a 15-minute freshness throttle. This endpoint
+// exists so the user can force-rebuild every session's summary on
+// demand without restarting the server, which is useful for
+// testing the feature against an existing workspace full of
+// never-indexed sessions.
+//
+// Usage:
+//   curl -X POST http://localhost:3000/api/chat-index/rebuild
+
+import { Router, Request, Response } from "express";
+import { backfillAllSessions } from "../chat-index/index.js";
+
+interface RebuildResponse {
+  total: number;
+  indexed: number;
+  skipped: number;
+}
+
+interface RebuildErrorResponse {
+  error: string;
+}
+
+const router = Router();
+
+router.post(
+  "/chat-index/rebuild",
+  async (
+    _req: Request,
+    res: Response<RebuildResponse | RebuildErrorResponse>,
+  ) => {
+    try {
+      // eslint-disable-next-line no-console
+      console.log("[chat-index] manual rebuild triggered");
+      const result = await backfillAllSessions();
+      // eslint-disable-next-line no-console
+      console.log(
+        `[chat-index] rebuild complete: ${result.indexed}/${result.total} indexed, ${result.skipped} skipped`,
+      );
+      res.json(result);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[chat-index] rebuild failed:", err);
+      res.status(500).json({
+        error: err instanceof Error ? err.message : "unknown error",
+      });
+    }
+  },
+);
+
+export default router;

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -174,6 +174,28 @@ describe("indexSession — freshness throttle", () => {
     assert.equal(stub.calls.length, 2);
   });
 
+  it("force: true bypasses the freshness throttle", async () => {
+    seedSession("sess-force");
+    const stub = makeStubSummarize();
+
+    // Seed a fresh entry at t=0.
+    await indexSession(workspace, "sess-force", {
+      summarize: stub.fn,
+      now: () => 0,
+    });
+    assert.equal(stub.calls.length, 1);
+
+    // Second call 1 second later — normally skipped, but
+    // force: true re-indexes anyway.
+    const refreshed = await indexSession(workspace, "sess-force", {
+      summarize: stub.fn,
+      now: () => 1000,
+      force: true,
+    });
+    assert.ok(refreshed !== null);
+    assert.equal(stub.calls.length, 2);
+  });
+
   it("respects a custom minIntervalMs", async () => {
     seedSession("sess-D");
     const stub = makeStubSummarize();

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   maybeIndexSession,
+  backfillAllSessions,
   __resetForTests,
 } from "../../server/chat-index/index.js";
 import { indexEntryPathFor } from "../../server/chat-index/paths.js";
@@ -219,5 +220,127 @@ describe("maybeIndexSession — unexpected error swallowing", () => {
       deps: { summarize: stub.fn, now: () => 0 },
     });
     assert.equal(stub.calls, 1);
+  });
+});
+
+describe("maybeIndexSession — force option", () => {
+  it("bypasses the activeSessionIds guard when force is true", async () => {
+    seedSession("live-force");
+    const stub = stubSummarize();
+
+    await maybeIndexSession({
+      sessionId: "live-force",
+      activeSessionIds: new Set(["live-force"]),
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+      force: true,
+    });
+
+    assert.equal(stub.calls, 1);
+  });
+
+  it("bypasses the freshness throttle when force is true", async () => {
+    seedSession("fresh-force");
+    const stub = stubSummarize();
+
+    // Seed a fresh entry.
+    await maybeIndexSession({
+      sessionId: "fresh-force",
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+    });
+    assert.equal(stub.calls, 1);
+
+    // Normal second call: skipped by freshness.
+    await maybeIndexSession({
+      sessionId: "fresh-force",
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 500 },
+    });
+    assert.equal(stub.calls, 1);
+
+    // Forced second call: re-indexes.
+    await maybeIndexSession({
+      sessionId: "fresh-force",
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 500 },
+      force: true,
+    });
+    assert.equal(stub.calls, 2);
+  });
+});
+
+describe("backfillAllSessions", () => {
+  it("indexes every session jsonl in the workspace", async () => {
+    seedSession("bf-1");
+    seedSession("bf-2");
+    seedSession("bf-3");
+    const stub = stubSummarize();
+
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+    });
+
+    assert.equal(result.total, 3);
+    assert.equal(result.indexed, 3);
+    assert.equal(result.skipped, 0);
+    assert.equal(stub.calls, 3);
+  });
+
+  it("returns an empty result when there are no session jsonls", async () => {
+    const stub = stubSummarize();
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+    });
+    assert.equal(result.total, 0);
+    assert.equal(result.indexed, 0);
+    assert.equal(result.skipped, 0);
+    assert.equal(stub.calls, 0);
+  });
+
+  it("skips sessions that throw and keeps processing the rest", async () => {
+    seedSession("ok-1");
+    seedSession("boom");
+    seedSession("ok-2");
+    let callCount = 0;
+    const mixedSummarize = async (): Promise<SummaryResult> => {
+      callCount++;
+      if (callCount === 2) throw new Error("boom on second call");
+      return { title: "t", summary: "s", keywords: [] };
+    };
+
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: mixedSummarize, now: () => 0 },
+    });
+
+    assert.equal(result.total, 3);
+    assert.equal(result.indexed, 2);
+    assert.equal(result.skipped, 1);
+  });
+
+  it("re-indexes sessions even when they are already fresh (force)", async () => {
+    seedSession("warm-1");
+    const stub = stubSummarize();
+
+    // First pass seeds the entry.
+    await maybeIndexSession({
+      sessionId: "warm-1",
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+    });
+    assert.equal(stub.calls, 1);
+
+    // Second pass via backfill with the same now() — a normal
+    // maybeIndexSession call would be skipped by freshness, but
+    // backfill sets force: true.
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 0 },
+    });
+    assert.equal(result.indexed, 1);
+    assert.equal(stub.calls, 2);
   });
 });


### PR DESCRIPTION
Follow-up to #126 (merged). The force / backfill commit I pushed while #126 was in review didn't make it into the merge, so this PR lands it on its own.

## User Prompt

> 強制的でも良いので、トリガーしてwebで動作確認したい
> あ、まーじされているかな。だったら新しいブランチで。

The chat indexer normally fires from the agent `finally` hook, one session at a time, throttled to re-summarize each session at most once per 15 minutes. That's fine for everyday use, but it makes the feature hard to verify against an existing workspace full of never-indexed sessions — you'd have to visit each session to trigger a re-index. This PR adds two manual trigger paths so the feature can be exercised on demand.

## Summary

- `IndexerDeps.force?: boolean` — when true, `indexSession` skips the `isFresh` 15-minute throttle
- `MaybeIndexSessionOptions.force?: boolean` — when true, `maybeIndexSession` also bypasses the `activeSessionIds` guard (so a currently-live session still gets indexed) and threads `force` through to the indexer. Per-session lock and `ClaudeCliNotFoundError` sentinel still apply.
- `listSessionIds(workspaceRoot)` — walks `chat/*.jsonl`, used by the backfill helper
- `backfillAllSessions({ workspaceRoot?, deps? })` — iterates every session with `force: true`, returns `{ total, indexed, skipped }`, logs each success and swallows per-session errors so one failure doesn't stop the walk
- `POST /api/chat-index/rebuild` — runtime trigger, no restart needed
- `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1` env var — mirrors the existing `JOURNAL_FORCE_RUN_ON_STARTUP=1` pattern for boot-time backfill

## Usage

**Runtime (no restart):**

```bash
curl -X POST http://localhost:3000/api/chat-index/rebuild
```

Server logs each indexed session as it goes:

```
[chat-index] manual rebuild triggered
[chat-index] indexed abc-def-ghi: Plan a two-week project
[chat-index] indexed xyz-uvw-rst: Billy Bootcamp schedule
...
[chat-index] rebuild complete: 42/42 indexed, 0 skipped
```

Then refresh the browser sidebar — AI-generated titles replace the first-user-message previews, and a smaller grey second line shows the summary.

**Startup (fire-and-forget after `app.listen`):**

```bash
CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 yarn dev
```

## What `force: true` bypasses

| Guard | Bypassed? |
|---|---|
| Freshness throttle (15 min) | ✅ yes |
| `activeSessionIds` guard | ✅ yes |
| Per-session lock | ❌ no (no point double-indexing the same session) |
| `ClaudeCliNotFoundError` sentinel | ❌ no (forcing can't help if the CLI is missing) |

## Files

- `server/chat-index/indexer.ts` — `IndexerDeps.force`, `listSessionIds`
- `server/chat-index/index.ts` — `MaybeIndexSessionOptions.force`, `backfillAllSessions`
- `server/routes/chat-index.ts` — `POST /api/chat-index/rebuild` (new file)
- `server/index.ts` — registers the route + `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1` switch
- `plans/feat-session-index-titles.md` — "Backfill" section documents both triggers
- `test/chat-index/test_indexer.ts` — `force: true` bypasses throttle
- `test/chat-index/test_maybe_index_session.ts` — force bypasses activeSessionIds, force bypasses freshness, backfill happy path, empty workspace, per-session error isolation, force re-indexes fresh entries

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (0 errors; 3 new `no-console` warnings in the `CHAT_INDEX_FORCE_RUN_ON_STARTUP` block of `server/index.ts` match the existing `JOURNAL_FORCE_RUN_ON_STARTUP` pattern)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 419/419 passing (7 new chat-index tests)
- [ ] Manual: `curl -X POST http://localhost:3000/api/chat-index/rebuild` and confirm titles appear in the sidebar
- [ ] Manual: `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 yarn dev` and confirm the same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup control flag (`CHAT_INDEX_FORCE_RUN_ON_STARTUP=1`) to trigger full session reindexing on server startup.
  * Added HTTP endpoint (`POST /api/chat-index/rebuild`) for manual session reindexing with progress counts.
  * Sessions can now be force-reindexed even during active edits.

* **Documentation**
  * Updated backfill strategy documentation to clarify lazy session indexing and manual rebuild options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->