### PR TITLE
chore: remove unused eslint-disable no-console comments

### DIFF
--- a/server/chat-index/index.ts
+++ b/server/chat-index/index.ts
@@ -74,11 +74,9 @@ export async function maybeIndexSession(
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) {
       disabled = true;
-      // eslint-disable-next-line no-console
       console.warn(err.message);
       return;
     }
-    // eslint-disable-next-line no-console
     console.warn("[chat-index] unexpected failure, continuing:", err);
   } finally {
     running.delete(sessionId);
@@ -125,7 +123,6 @@ export async function backfillAllSessions(
       });
       if (entry) {
         result.indexed++;
-        // eslint-disable-next-line no-console
         console.log(`[chat-index] indexed ${sessionId}: ${entry.title}`);
       } else {
         result.skipped++;
@@ -133,13 +130,11 @@ export async function backfillAllSessions(
     } catch (err) {
       if (err instanceof ClaudeCliNotFoundError) {
         disabled = true;
-        // eslint-disable-next-line no-console
         console.warn(err.message);
         result.skipped++;
         continue;
       }
       result.skipped++;
-      // eslint-disable-next-line no-console
       console.warn(`[chat-index] failed to index ${sessionId}:`, err);
     }
   }

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -195,7 +195,6 @@ router.post(
         sessionId,
         activeSessionIds: getActiveSessionIds(),
       }).catch((err) => {
-        // eslint-disable-next-line no-console
         console.warn("[chat-index] unexpected error in background:", err);
       });
     }

--- a/server/routes/chat-index.ts
+++ b/server/routes/chat-index.ts
@@ -31,16 +31,13 @@ router.post(
     res: Response<RebuildResponse | RebuildErrorResponse>,
   ) => {
     try {
-      // eslint-disable-next-line no-console
       console.log("[chat-index] manual rebuild triggered");
       const result = await backfillAllSessions();
-      // eslint-disable-next-line no-console
       console.log(
         `[chat-index] rebuild complete: ${result.indexed}/${result.total} indexed, ${result.skipped} skipped`,
       );
       res.json(result);
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn("[chat-index] rebuild failed:", err);
       res.status(500).json({
         error: err instanceof Error ? err.message : "unknown error",


### PR DESCRIPTION
## Summary
- `no-console` is set to `"off"` in `eslint.config.mjs`, so the `// eslint-disable-next-line no-console` directives were unused and produced `Unused eslint-disable directive` warnings
- Removed 9 unused directives across 3 files

## User Prompt
> 43:7  warning  Unused eslint-disable directive (no problems were reported from 'no-console') 減らせる？
> PRしてマージ

## Test plan
- [x] `yarn format`
- [x] `yarn typecheck`
- [x] `yarn lint` (the specific warning is gone; unrelated warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed inline linting suppressions from logging statements across server modules to align with standard code quality practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->