### PR TITLE
feat(files): play audio and video inside the file explorer

### DIFF
--- a/plans/feat-files-audio-video-playback.md
+++ b/plans/feat-files-audio-video-playback.md
@@ -1,0 +1,82 @@
+# Audio / Video Playback in File Explorer
+
+## User Request
+
+> fileエクスプローラーで音声や動画ファイルはそこで再生したい
+> (I want audio and video files to play directly inside the file explorer.)
+
+## Goal
+
+When the user clicks an audio or video file in `FilesView.vue`, render a
+native `<audio>` / `<video>` player in the content pane instead of the
+current "Binary file — preview not supported" message.
+
+## Supported formats
+
+- **Audio:** `.mp3`, `.wav`, `.m4a`, `.ogg`, `.oga`, `.flac`, `.aac`
+- **Video:** `.mp4`, `.webm`, `.mov`, `.m4v`, `.ogv`
+
+These cover the common container/codec combinations that browsers play
+natively without extra plugins.
+
+## Implementation
+
+### 1. `server/routes/files.ts`
+
+- Add `AUDIO_EXTENSIONS` and `VIDEO_EXTENSIONS` sets alongside the
+  existing `IMAGE_EXTENSIONS`.
+- Extend `MIME_BY_EXT` with audio/video MIME types (`audio/mpeg`,
+  `video/mp4`, etc.) so the raw endpoint serves them with a
+  browser-recognized `Content-Type`.
+- Extend the `ContentKind` type and `FileContentMeta` discriminated
+  union to include `"audio" | "video"`.
+- Update `classify()` to return `"audio"` / `"video"` for the new
+  extensions.
+- `/files/content` returns the new kinds as metadata-only
+  (`{ kind, path, size, modifiedMs }`); the actual bytes are served via
+  `/files/raw`, matching how images and PDFs already work.
+
+### 2. HTTP Range support on `/files/raw`
+
+Safari refuses to play `<video>` over HTTP unless the server responds
+with a 206 Partial Content to a `Range` request, and Chrome needs it
+for seek-past-buffered to work. Current handler only does full-file
+pipes, which is fine for images/PDFs/audio but breaks video.
+
+Changes:
+
+- Parse `Range: bytes=START-END` (and `bytes=-SUFFIX`) into a validated
+  `{start, end}` range.
+- When a satisfiable range is present: respond `206`, set
+  `Content-Range`, `Content-Length`, `Content-Type`, `Accept-Ranges:
+  bytes`, and stream the requested slice with `fs.createReadStream(p,
+  {start, end})`.
+- When the range header is malformed or unsatisfiable: respond `416`
+  with `Content-Range: bytes */<size>`.
+- When no range header: existing full-file behaviour, but still set
+  `Accept-Ranges: bytes` so clients know they can request ranges.
+- Extract the existing stream-error handler into a small helper so both
+  the range and full-file branches can share it.
+
+Keeping helpers small (Range parsing, pipe-with-error) so the route
+handler stays readable.
+
+### 3. `src/components/FilesView.vue`
+
+- Extend the local `MetaContent` type to include `"audio" | "video"`.
+- Add two new template blocks after the existing PDF block:
+  - `<audio controls preload="metadata" :src="rawUrl(selectedPath)">`
+  - `<video controls preload="metadata" :src="rawUrl(selectedPath)">`
+
+Switching files automatically unmounts the previous media element
+(Vue's `v-else-if` swap on `content.kind`), so the old one stops
+playing without any extra handler.
+
+## Out of scope
+
+- Raising `MAX_RAW_BYTES` above 50 MB. Files over that still show the
+  existing "too-large" message. Can revisit if needed for large video
+  files.
+- Waveform / thumbnail preview, playback-speed controls, playlists,
+  custom chrome. Native `<audio>`/`<video>` already exposes play,
+  pause, seek, volume, fullscreen, and speed.

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -43,6 +43,18 @@ const IMAGE_EXTENSIONS = new Set([
   ".svg",
 ]);
 
+const AUDIO_EXTENSIONS = new Set([
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".ogg",
+  ".oga",
+  ".flac",
+  ".aac",
+]);
+
+const VIDEO_EXTENSIONS = new Set([".mp4", ".webm", ".mov", ".m4v", ".ogv"]);
+
 const MIME_BY_EXT: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
@@ -51,6 +63,18 @@ const MIME_BY_EXT: Record<string, string> = {
   ".webp": "image/webp",
   ".svg": "image/svg+xml",
   ".pdf": "application/pdf",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".m4a": "audio/mp4",
+  ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".flac": "audio/flac",
+  ".aac": "audio/aac",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".m4v": "video/x-m4v",
+  ".ogv": "video/ogg",
 };
 
 export interface TreeNode {
@@ -75,7 +99,7 @@ interface FileContentText {
 }
 
 interface FileContentMeta {
-  kind: "image" | "pdf" | "binary" | "too-large";
+  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
   path: string;
   size: number;
   modifiedMs: number;
@@ -84,12 +108,14 @@ interface FileContentMeta {
 
 type FileContentResponse = FileContentText | FileContentMeta;
 
-type ContentKind = "text" | "image" | "pdf" | "binary";
+type ContentKind = "text" | "image" | "pdf" | "audio" | "video" | "binary";
 
 function classify(filename: string): ContentKind {
   const ext = path.extname(filename).toLowerCase();
   if (TEXT_EXTENSIONS.has(ext)) return "text";
   if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
   if (ext === ".pdf") return "pdf";
   // Files with no extension (e.g. README, LICENSE) — treat as text
   if (!ext) return "text";
@@ -127,6 +153,50 @@ function resolveSafe(relPath: string): string | null {
     }
   }
   return resolvedReal;
+}
+
+interface ByteRange {
+  start: number;
+  end: number;
+}
+
+// Parse an HTTP Range header of the form `bytes=START-END` or
+// `bytes=-SUFFIX`. Returns null for malformed or unsatisfiable ranges
+// so the caller can respond 416. We deliberately reject multi-range
+// requests (`bytes=0-99,200-299`) since browsers don't issue them for
+// media playback and supporting them would complicate the response.
+function parseRange(header: string, size: number): ByteRange | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return null;
+  const [, startStr, endStr] = match;
+  if (startStr === "" && endStr === "") return null;
+  if (startStr === "") {
+    const suffix = Number(endStr);
+    if (!Number.isFinite(suffix) || suffix <= 0) return null;
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+  const start = Number(startStr);
+  const end = endStr === "" ? size - 1 : Number(endStr);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (start < 0 || end < start || end >= size) return null;
+  return { start, end };
+}
+
+// If the read stream errors mid-flight (file deleted, disk error,
+// permissions changed), surface a clean failure to the client instead
+// of leaving the connection hanging.
+function pipeWithErrorHandling(
+  stream: fs.ReadStream,
+  res: Response<ErrorResponse>,
+): void {
+  stream.on("error", (err) => {
+    if (res.headersSent) {
+      res.destroy(err);
+      return;
+    }
+    res.status(500).json({ error: `Failed to read file: ${err.message}` });
+  });
+  stream.pipe(res);
 }
 
 function readDirSafe(absPath: string): fs.Dirent[] {
@@ -245,7 +315,12 @@ router.get(
     }
 
     const kind = classify(absPath);
-    if (kind === "image" || kind === "pdf") {
+    if (
+      kind === "image" ||
+      kind === "pdf" ||
+      kind === "audio" ||
+      kind === "video"
+    ) {
       res.json({ kind, ...meta });
       return;
     }
@@ -310,20 +385,36 @@ router.get(
     }
     const ext = path.extname(absPath).toLowerCase();
     const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+    res.setHeader("Accept-Ranges", "bytes");
     res.setHeader("Content-Type", mime);
-    res.setHeader("Content-Length", String(stat.size));
-    const stream = fs.createReadStream(absPath);
-    // If the read stream errors mid-flight (file deleted, disk error,
-    // permissions changed), surface a clean failure to the client
-    // instead of leaving the connection hanging.
-    stream.on("error", (err) => {
-      if (res.headersSent) {
-        res.destroy(err);
+
+    // Range support is required for `<video>` playback (Safari refuses
+    // to play media without 206 responses) and for seek-past-buffered
+    // in `<audio>`. When no Range header is sent we fall through to
+    // the existing full-file pipe.
+    const rangeHeader = req.headers.range;
+    if (rangeHeader) {
+      const range = parseRange(rangeHeader, stat.size);
+      if (!range) {
+        res.setHeader("Content-Range", `bytes */${stat.size}`);
+        res.status(416).json({ error: "Range not satisfiable" });
         return;
       }
-      res.status(500).json({ error: `Failed to read file: ${err.message}` });
-    });
-    stream.pipe(res);
+      res.status(206);
+      res.setHeader(
+        "Content-Range",
+        `bytes ${range.start}-${range.end}/${stat.size}`,
+      );
+      res.setHeader("Content-Length", String(range.end - range.start + 1));
+      pipeWithErrorHandling(
+        fs.createReadStream(absPath, { start: range.start, end: range.end }),
+        res,
+      );
+      return;
+    }
+
+    res.setHeader("Content-Length", String(stat.size));
+    pipeWithErrorHandling(fs.createReadStream(absPath), res);
   },
 );
 

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -176,6 +176,32 @@
             class="w-full h-full border-0"
             title="PDF preview"
           />
+          <!-- Audio -->
+          <div
+            v-else-if="content.kind === 'audio'"
+            class="h-full flex items-center justify-center p-4"
+          >
+            <audio
+              :key="selectedPath"
+              :src="rawUrl(selectedPath)"
+              controls
+              preload="metadata"
+              class="w-full max-w-2xl"
+            />
+          </div>
+          <!-- Video -->
+          <div
+            v-else-if="content.kind === 'video'"
+            class="h-full flex items-center justify-center p-4 bg-black"
+          >
+            <video
+              :key="selectedPath"
+              :src="rawUrl(selectedPath)"
+              controls
+              preload="metadata"
+              class="max-w-full max-h-full"
+            />
+          </div>
           <!-- Binary or too-large -->
           <div v-else class="p-4 text-sm text-gray-500">
             {{ content.message }}
@@ -220,7 +246,7 @@ interface TextContent {
 }
 
 interface MetaContent {
-  kind: "image" | "pdf" | "binary" | "too-large";
+  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
   path: string;
   size: number;
   modifiedMs: number;


### PR DESCRIPTION
## User Prompt

> fileエクスプローラーで音声や動画ファイルはそこで再生したい
> (I want audio and video files to play directly inside the file explorer.)

Follow-up: **PR** — create the pull request.

## Summary

- Render native HTML5 `<audio>` / `<video>` players in `FilesView` when an audio/video file is selected, replacing the "preview not supported" fallback.
- Classify common audio (`.mp3`, `.wav`, `.m4a`, `.ogg`, `.oga`, `.flac`, `.aac`) and video (`.mp4`, `.webm`, `.mov`, `.m4v`, `.ogv`) extensions on the server, register their MIME types, and expose `"audio" | "video"` as new `kind`s on `/api/files/content`.
- Add HTTP Range support to `/api/files/raw` so Safari will play `<video>` and seek-past-buffered works in Chrome.

## Implementation

### `server/routes/files.ts`

- New `AUDIO_EXTENSIONS` and `VIDEO_EXTENSIONS` sets next to the existing `IMAGE_EXTENSIONS`.
- Extended `MIME_BY_EXT` with `audio/mpeg`, `video/mp4`, etc.
- Extended the `ContentKind` type and `FileContentMeta` discriminated union with `"audio" | "video"`. `classify()` returns the new kinds.
- `/files/content` returns audio/video as metadata-only (`{ kind, path, size, modifiedMs }`); the actual bytes are served via `/files/raw`, identical to how images and PDFs already work.
- **HTTP Range support on `/files/raw`** — required for Safari `<video>` playback and for seek-past-buffered in any browser:
  - `parseRange()` helper handles `bytes=START-END` and `bytes=-SUFFIX`, rejects multi-range and out-of-bounds requests.
  - `pipeWithErrorHandling()` helper consolidates the existing stream-error logic so both range and full-file branches share it.
  - Range present → `206` with `Content-Range`, sliced `fs.createReadStream(p, {start, end})`.
  - Malformed/unsatisfiable → `416` with `Content-Range: bytes */<size>`.
  - No range header → existing full-file pipe, but always advertises `Accept-Ranges: bytes`.

### `src/components/FilesView.vue`

- Extended local `MetaContent` type with `"audio" | "video"`.
- Added two new template branches after the PDF block: native `<audio controls preload=\"metadata\">` and `<video controls preload=\"metadata\">`, both using the existing `rawUrl()` helper.
- `:key=\"selectedPath\"` on each element forces Vue to unmount/remount when switching files — guarantees the previous track stops and the new file is reloaded cleanly.

## Out of scope

- The 50 MB `MAX_RAW_BYTES` cap is unchanged. Files larger than that still show the existing \"too-large\" message. Easy to lift later if it bites.
- No waveform, thumbnail, custom chrome, or playlist UI. Native `<audio>`/`<video>` already exposes play, pause, seek, volume, fullscreen, and speed.
- No multi-range request support — browsers don't issue them for media playback and supporting them would complicate the response.

## Test plan

- [x] `yarn format`
- [x] `yarn lint` (0 errors; only pre-existing warnings)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` (567/567 pass)
- [ ] Manual: open an `.mp3` in the file explorer → audio player appears and plays.
- [ ] Manual: open a `.mp4` in the file explorer → video player appears, plays, and seeks correctly in both Safari and Chrome.
- [ ] Manual: switch between two audio files → previous one stops when the new one mounts.
- [ ] Manual: confirm a `.bin`/`.zip` still shows the \"Binary file — preview not supported\" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)