### PR TITLE
feat: Todo file explorer view (kanban / table / list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,30 @@ All data is stored as plain files in the workspace directory:
 ```
 ~/mulmoclaude/
   chat/        ← conversation history (one .jsonl per session)
-  todos/        ← todo items
+  todos/        ← todo items (todos.json) and kanban columns (columns.json)
   memory.md     ← persistent facts Claude always has in context
   wiki/         ← personal knowledge base (see above)
   ...
 ```
+
+### Todo explorer
+
+Selecting `todos/todos.json` in the file explorer opens a full **Todo
+Explorer** with three view modes:
+
+- **Kanban** — GitHub Projects-style columns. Drag cards between
+  columns to change status. Each column has a menu to rename, mark as
+  done, or delete. New columns can be added from the toolbar.
+- **Table** — sortable table with status / priority / labels / due
+  date / created columns. Click a row to inline-edit.
+- **List** — flat checklist with the same inline editor.
+
+Status columns are stored in `todos/columns.json` and default to
+`Backlog / Todo / In Progress / Done`. Each todo carries optional
+`status`, `priority` (low / medium / high / urgent), and `dueDate`
+fields in addition to the original text / note / labels / completed
+fields.
+
+The chat-side `manageTodoList` MCP tool keeps its existing behaviour
+unchanged — it can read and edit text / note / labels / completed
+todos, and the explorer's extra fields are preserved across MCP edits.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vue": "^3.5.32",
     "vue-drawing-canvas": "^1.0.14",
     "vue-router": "^5.0.3",
+    "vuedraggable": "^4.1.0",
     "ws": "^8.20.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.3.6"

--- a/plans/feat-todo-explorer.md
+++ b/plans/feat-todo-explorer.md
@@ -58,7 +58,7 @@ interface TodoItem {
   text: string;
   note?: string;
   labels?: string[];
-  completed: boolean;        // 後方互換のため残す（status === doneColumnId と同期）
+  completed: boolean;        // status とは独立に扱う（後述）
   createdAt: number;
   // ── new ──
   status?: string;           // ステータス column の id（未設定時は最初の non-done column）
@@ -67,6 +67,16 @@ interface TodoItem {
   order?: number;            // 同一ステータス内の並び順（小さいほど上）
 }
 ```
+
+> **`completed` と `status` の関係**: 当初は読み込みのたびに `status === doneColumnId` から `completed` を再同期する設計でしたが、これだとレガシー MCP `check` action（`completed=true` を立てるだけで status は触らない）が次の GET で revert されてしまうため廃止。
+>
+> 現在は **storage 層では完全に独立** に扱い、両者を同期するのは以下の **明示的なユーザ操作** のみ:
+> - REST `PATCH /api/todos/items/:id` で `status` を変えると `completed` も sync
+> - REST `PATCH` で `completed` を flip すると status を done 列 / default 開いた列に移動
+> - REST `POST /api/todos/items/:id/move` で done 列に入った item は `completed=true`
+> - 列の add (`isDone:true`) / patch (`isDone:true`) / delete (done 列を消す) は影響範囲の item を `resyncDoneMembership` で sync
+>
+> migration on read（`migrateItems`）は status の **backfill** はするが completed の **resync は一切しない**。
 
 ### ステータスカラム (`workspace/todos/columns.json` — 新規)
 
@@ -213,7 +223,7 @@ Scheduler パターンを踏襲。`todos/todos.json` を選択した時に、`to
   - priority（左ボーダー or アイコン: low=灰 / medium=青 / high=橙 / urgent=赤）
   - dueDate（バッジ。期限切れは赤、当日はオレンジ）
   - クリックで詳細パネル展開（既存 View.vue の YAML editor を再利用 or 新ダイアログ）
-- drag 終了時に `move` action を `/api/todos` に POST して永続化。失敗時は state を rollback。
+- drag 終了時に `POST /api/todos/items/:id/move` を呼んで永続化。失敗時は state を rollback。
 
 #### `src/components/todo/TodoTableView.vue` (新規)
 

--- a/plans/feat-todo-explorer.md
+++ b/plans/feat-todo-explorer.md
@@ -1,0 +1,366 @@
+# feat: Todo file explorer view (kanban / table / list)
+
+## User Prompt
+
+> issueたてる
+> ファイルエクスプローラーでtodoのviewをつくる。ラベルで切り替えと、カンバン、表などのviewを切り替えの２つの切り替えと、ステータスを追加する。他にもtodoとして必要な機能があったら盛り込んでplanを作って。githubのカンバンが個人的には使いやすい。チャットからの操作を考慮して作ってね
+
+確認した追加要件:
+
+- ステータスは GitHub 標準4列 (`Backlog` / `Todo` / `In Progress` / `Done`) を初期値として、**ユーザがカラム自体を追加・削除・並び替え**できるようにする。
+- Kanban の **drag & drop**（ステータス変更・列内並べ替え）は Phase 1 に含める。
+- 追加フィールドは `priority` と `dueDate` の 2 つ。`assignee` / `subtasks` は今回スコープ外。
+- **チャット (MCP) からの操作は今回スコープ外**。`manageTodoList` MCP ツールの定義は変更しない。Web UI の操作が REST 経由で永続化されるだけでよい。LLM からの新フィールド操作対応は将来 issue で扱う。
+
+---
+
+## 目的 / Goal
+
+ファイルエクスプローラ (`FilesView.vue`) で `todos/todos.json` を選択した時に、専用の **TODO エクスプローラ** を表示する。GitHub Projects 風の Kanban を中心に、Table / List への切替とラベル / ステータスフィルタを提供する。Web UI 上の操作は専用 REST 経由で永続化される。
+
+> 既存パターン: Scheduler の `items.json` を選択した時に `SchedulerView` を描画する仕組み (`src/components/FilesView.vue:58-60`) と同じ統合方式を採る。
+
+> **MCP ツールには手を付けない**: 既存 `manageTodoList` (`src/plugins/todo/definition.ts`) は無変更。LLM からは引き続き旧フィールド (`text` / `note` / `labels` / `completed`) のみが見える。新フィールド (`status` / `priority` / `dueDate`) を LLM が操作しようとすると無視されるが、Web UI 上は問題なく見える / 編集できる。LLM 連携は別 issue。
+
+## ノンゴール / Non-goals
+
+- **MCP `manageTodoList` ツールの拡張**（チャットから新フィールドを操作する機能）
+- Subtasks / チェックリスト機能
+- Assignee / 複数ユーザ対応
+- 通知 / リマインダ
+- Recurring todo（繰り返し）
+- 過去の completed の集計ビュー（履歴グラフ等）
+
+これらは後続の issue / PR で扱う。
+
+---
+
+## データモデル
+
+### 現状 (`server/routes/todos.ts:9-16`, `src/plugins/todo/index.ts:6-13`)
+
+```ts
+interface TodoItem {
+  id: string;
+  text: string;
+  note?: string;
+  labels?: string[];
+  completed: boolean;
+  createdAt: number;
+}
+```
+
+### 拡張後
+
+```ts
+interface TodoItem {
+  id: string;
+  text: string;
+  note?: string;
+  labels?: string[];
+  completed: boolean;        // 後方互換のため残す（status === doneColumnId と同期）
+  createdAt: number;
+  // ── new ──
+  status?: string;           // ステータス column の id（未設定時は最初の non-done column）
+  priority?: "low" | "medium" | "high" | "urgent";
+  dueDate?: string;          // ISO 8601 (YYYY-MM-DD)
+  order?: number;            // 同一ステータス内の並び順（小さいほど上）
+}
+```
+
+### ステータスカラム (`workspace/todos/columns.json` — 新規)
+
+カラムをユーザが編集できるよう、**items とは別ファイル**に保存する。items.json を膨らませない & マイグレーションが楽。
+
+```ts
+interface StatusColumn {
+  id: string;        // "backlog" など URL-safe slug。安定した参照キー
+  label: string;     // "Backlog" — 表示名（i18n は将来）
+  isDone?: boolean;  // true の列に入った item は completed: true と同期
+}
+
+interface ColumnsFile {
+  columns: StatusColumn[];
+  // ファイルが存在しない/壊れている場合は DEFAULT_COLUMNS にフォールバック
+}
+```
+
+**初期値**:
+
+```ts
+const DEFAULT_COLUMNS: StatusColumn[] = [
+  { id: "backlog",     label: "Backlog" },
+  { id: "todo",        label: "Todo" },
+  { id: "in_progress", label: "In Progress" },
+  { id: "done",        label: "Done", isDone: true },
+];
+```
+
+### マイグレーション
+
+既存 `todos.json` を初回ロード時に変換する（破壊的書き換えはしない、読み込み時に補完）:
+
+| 既存値                          | 補完される値                              |
+| ------------------------------- | ----------------------------------------- |
+| `status` 未設定 & `completed`   | `status = "done"` (= `isDone: true` 列の id) |
+| `status` 未設定 & `!completed`  | `status = "todo"`                         |
+| `order` 未設定                  | `createdAt` の昇順で 1000, 2000, ... を割振 |
+
+書き込みが発生したタイミングで normalize 後の値が永続化される。`columns.json` が無ければ `DEFAULT_COLUMNS` を返す。
+
+### `done` 列削除時の扱い
+
+ユーザが `isDone: true` の列を削除した場合:
+
+- 残りの列のうち先頭を新たな `isDone: true` にする（少なくとも 1 つは done 列を維持）
+- 削除を許可しない場合のエラー文言を返す（最後の done 列は削除不可）
+- 削除対象の列にあった item は最後尾の列へ移動する
+
+`isDone` を別の列に切り替えた場合は、その列にいる item の `completed` を `true` に同期する。
+
+---
+
+## API (Web UI 専用 REST)
+
+> MCP ツール (`manageTodoList`) は無変更。新フィールドの読み書きは Web UI 専用の REST エンドポイントだけが扱う。
+
+### 既存 (互換のため変更しない)
+
+- `GET /api/todos` — 既存形を維持。**`columns` を同梱**するためにレスポンスを `{ data: { items, columns } }` に拡張する（既存の View/Preview は `data.items` を読んでいるだけなので破壊しない）。
+- `POST /api/todos` — 既存 MCP 経由の action ディスパッチ。**ハンドラは触らない**（既存 add / check / update / labels 系がそのまま動く）。
+
+### 新規
+
+REST 風に items とカラムを別リソースとして扱う。Express の `Request<Params, ResBody, ReqBody>` 型付けで実装する。
+
+#### Items
+
+| Method | Path                       | Body                                                                     | 動作                                                  |
+| ------ | -------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| PATCH  | `/api/todos/items/:id`     | `{ text?, note?, status?, priority?, dueDate?, labels?, completed? }`    | 部分更新。`undefined` 不在キーは保持、`null` は削除   |
+| POST   | `/api/todos/items/:id/move`| `{ status?: string, position?: number }`                                 | drag & drop の永続化（列移動 + 列内位置）             |
+| DELETE | `/api/todos/items/:id`     | -                                                                        | 削除                                                  |
+| POST   | `/api/todos/items`         | `{ text, note?, status?, priority?, dueDate?, labels? }`                 | 新規追加                                              |
+
+`PATCH` を id ベースで提供することで「text 部分マッチで対象を探す」既存 MCP 経路の弱点（重複ヒット / 改名後に見つからない）を回避する。Web UI は item id を直接知っているので問題ない。
+
+#### Columns
+
+| Method | Path                          | Body                                          | 動作                                                       |
+| ------ | ----------------------------- | --------------------------------------------- | ---------------------------------------------------------- |
+| GET    | `/api/todos/columns`          | -                                             | 現在の columns.json（無ければ DEFAULT_COLUMNS）            |
+| POST   | `/api/todos/columns`          | `{ label: string, isDone?: boolean }`         | 列追加。id は label を slug 化して生成、衝突時は `_2` 付与 |
+| PATCH  | `/api/todos/columns/:id`      | `{ label?: string, isDone?: boolean }`        | リネーム / done フラグ切替                                 |
+| DELETE | `/api/todos/columns/:id`      | -                                             | 削除（中の item は最後尾の列へ退避、最後の done 列は不可） |
+| PUT    | `/api/todos/columns/order`    | `{ ids: string[] }`                           | カラムの並び順を上書き                                     |
+
+### ハンドラ実装方針
+
+- `server/routes/todos.ts` を router 単位で分割し、items / columns 用の純粋ハンドラを `server/routes/todosItemsHandlers.ts` / `server/routes/todosColumnsHandlers.ts` (新規) に切り出す。`todosHandlers.ts` (既存 MCP action 用) はそのまま温存。
+- すべてのハンドラは `(state, input) => result` の純粋関数として書き、route handler は I/O だけ担当する（既存 `dispatchTodos` パターンを踏襲）。
+- I/O は引き続き `server/utils/file.ts` の `loadJsonFile` / `saveJsonFile` を使う。
+
+### 永続化
+
+- `workspace/todos/todos.json` — 既存。新フィールド追加。
+- `workspace/todos/columns.json` — 新規。
+
+---
+
+## フロントエンド
+
+### 統合ポイント — `src/components/FilesView.vue`
+
+Scheduler パターンを踏襲。`todos/todos.json` を選択した時に、`todoExplorerResult` を合成して `<TodoExplorer>` を描画する:
+
+```vue
+<div v-if="schedulerResult" class="h-full">
+  <SchedulerView :selected-result="schedulerResult" />
+</div>
+<div v-else-if="todoExplorerResult" class="h-full">
+  <TodoExplorer :selected-result="todoExplorerResult" />
+</div>
+```
+
+`todoExplorerResult` computed:
+
+- `selectedPath.value === "todos/todos.json"` のとき
+- パース成功時に `{ uuid: "files-todo-preview", toolName: "manageTodoList", data: { items, columns } }` を返す
+- columns は別途 `/api/todos/columns` から取得（または `/api/todos` 統一エンドポイントで一緒に返す ← こちらを採用）
+
+### 新コンポーネント
+
+#### `src/components/TodoExplorer.vue` (新規)
+
+ファイルエクスプローラ用のフル画面 todo ビュー。中身:
+
+- **ヘッダ**:
+  - View モード切替タブ: `Kanban` / `Table` / `List`（localStorage `todo_explorer_view_mode` に保存）
+  - ラベルフィルタチップ（既存 `View.vue` のロジックを抽出して再利用）
+  - 検索ボックス（text / note の case-insensitive substring 検索）
+  - 「+ Add」ボタン: 新規 item ダイアログ
+  - 「+ Column」ボタン (Kanban view 時のみ表示): 列追加ダイアログ
+- **ボディ**: 選択中の view モードに応じて子コンポーネントを描画
+  - `<TodoKanbanView>` / `<TodoTableView>` / `<TodoListView>`
+
+#### `src/components/todo/TodoKanbanView.vue` (新規)
+
+- `vuedraggable` (`yarn add vuedraggable@next`) で列内 / 列間 drag & drop。
+- 各列ヘッダ: column.label + count + メニュー（rename / delete / 「右に列を追加」）
+- カード:
+  - text（1行・truncate）
+  - labels（チップ）
+  - priority（左ボーダー or アイコン: low=灰 / medium=青 / high=橙 / urgent=赤）
+  - dueDate（バッジ。期限切れは赤、当日はオレンジ）
+  - クリックで詳細パネル展開（既存 View.vue の YAML editor を再利用 or 新ダイアログ）
+- drag 終了時に `move` action を `/api/todos` に POST して永続化。失敗時は state を rollback。
+
+#### `src/components/todo/TodoTableView.vue` (新規)
+
+- 列: text / status / priority / labels / dueDate / created
+- ヘッダクリックでソート（client-side）
+- 行クリックで詳細パネル展開
+- インライン編集（status / priority は select、dueDate は date input）
+
+#### `src/components/todo/TodoListView.vue` (新規 or 既存 View.vue を流用)
+
+- 既存 `src/plugins/todo/View.vue` のロジックをそのまま使う。
+- 既存 plugin View はチャット内で tool result として描画される時にも使うので、共通ロジックは `src/plugins/todo/composables/useTodos.ts` に切り出して両方から呼ぶ。
+
+#### `src/plugins/todo/View.vue` (既存)
+
+- 既存のチャット内 view は維持。`useTodos` composable に置き換えて、`TodoExplorer` と共通ロジック化。
+
+### Composable: `src/plugins/todo/composables/useTodos.ts` (新規)
+
+- `loadTodos()` / `loadColumns()` / `callApi(action, body)` / `optimisticUpdate()` を提供
+- `useFreshPluginData` を内包し、items + columns を ref で公開
+- `applyMove(itemId, statusId, position)` / `applySetStatus()` / `applySetPriority()` / `applySetDueDate()` などの操作を提供
+- view component は表示のみに集中できる
+
+### 色 / アイコン
+
+- ラベル色: 既存 `src/plugins/todo/labels.ts` の `colorForLabel()` を流用。
+- ステータス列の色: `colorForLabel(column.id)` を流用 or 専用 palette を作る（後者を採用）。
+- priority 色: `low` 灰 / `medium` 青 / `high` 橙 / `urgent` 赤 — `src/plugins/todo/priority.ts` (新規) で定数化。
+- dueDate 色: 過去 = 赤、当日 = 橙、3 日以内 = 黄、それ以外 = 灰。
+
+---
+
+## 既存 LLM 経路への影響
+
+`manageTodoList` MCP ツール (`src/plugins/todo/definition.ts`) は **無変更**。既存の `add` / `check` / `update` / `add_label` などはそのまま使える。
+
+ただし、**マイグレーション**（後述）によって既存 item にも `status` / `order` フィールドが付与される。LLM はこれらの新フィールドを知らないが、`update` で `text` / `note` だけを書き換える限り、新フィールドは保持される（ハンドラ実装で `...target` のスプレッドを徹底する）。
+
+将来 LLM 経路にも新フィールドを伝えたくなったら、別 issue として `definition.ts` を拡張する。
+
+---
+
+## 実装フェーズ
+
+### Phase 1 — データモデル & REST API
+
+1. `TodoItem` に `status` / `priority` / `dueDate` / `order` を追加（`server/routes/todos.ts` と `src/plugins/todo/index.ts` の両方）
+2. `workspace/todos/columns.json` の load / save と `DEFAULT_COLUMNS` 定数を `server/routes/todosColumnsHandlers.ts` (新規) に実装
+3. マイグレーションロジック（loadTodos 時に既存 item に status / order を補完）— 既存 MCP 経路の挙動が壊れないことを既存テストで担保
+4. 新 REST ルートの実装:
+   - `server/routes/todosItemsHandlers.ts` — items 用純粋ハンドラ
+   - `server/routes/todosColumnsHandlers.ts` — columns 用純粋ハンドラ
+   - `server/routes/todos.ts` に `PATCH /items/:id` / `POST /items/:id/move` / `DELETE /items/:id` / `POST /items` / `GET|POST|PATCH|DELETE /columns(/:id)` / `PUT /columns/order` を追加
+5. `GET /api/todos` のレスポンスに `columns` を含める
+6. `manageTodoList` MCP の既存ハンドラ (`server/routes/todosHandlers.ts`) は触らないが、**新フィールド保持**のための regression test を追加（`update` を呼んでも `status` / `priority` / `dueDate` が消えないこと）
+7. **テスト**:
+   - `test/test_todos_items_handlers.ts` (新規) — 新 REST ハンドラのハッピーパス + バリデーション + マイグレーション
+   - `test/test_todos_columns_handlers.ts` (新規) — 列追加 / 削除（done 列維持ルール含む）/ リネーム / 並び替え
+   - 既存 MCP ハンドラの regression テストを追加
+
+### Phase 2 — TodoExplorer 基本 UI
+
+1. `useTodos` composable の作成 — 新 REST 経路 (`PATCH /items/:id` 等) を呼ぶ薄いラッパ。items + columns を ref で公開
+2. 既存 `src/plugins/todo/View.vue` は **触らない**（チャット tool result 用は現状維持。Phase 4 で必要なら refactor を検討）
+3. `TodoExplorer.vue` シェル（ヘッダ + view 切替 + ラベルフィルタ + 検索）
+4. `FilesView.vue` の特殊ケース追加（todos/todos.json → TodoExplorer）
+5. `TodoListView.vue` 描画（最初は List だけで動かす）
+6. `TodoTableView.vue` 描画（ソート + インライン編集）
+
+### Phase 3 — Kanban + drag & drop
+
+1. `yarn add vuedraggable@next`
+2. `TodoKanbanView.vue` 実装（列描画 + カード描画）
+3. drag & drop ハンドラ → `move` action 呼出
+4. 列追加 / 削除 / リネームの UI（カラムヘッダのメニュー）
+5. priority / dueDate のカード上での視覚化
+
+### Phase 4 — 仕上げ
+
+1. localStorage への view モード / アクティブフィルタ永続化
+2. キーボード操作（矢印キーで card 移動など — オプション）
+3. README.md / CLAUDE.md の更新（todo plugin の節）
+4. `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` を全部緑に
+
+---
+
+## 影響範囲（変更ファイル一覧）
+
+### 新規
+
+- `src/components/TodoExplorer.vue`
+- `src/components/todo/TodoKanbanView.vue`
+- `src/components/todo/TodoTableView.vue`
+- `src/components/todo/TodoListView.vue`
+- `src/plugins/todo/composables/useTodos.ts`
+- `src/plugins/todo/priority.ts`
+- `server/routes/todosItemsHandlers.ts`
+- `server/routes/todosColumnsHandlers.ts`
+- `test/test_todos_items_handlers.ts`
+- `test/test_todos_columns_handlers.ts`
+
+### 編集
+
+- `server/routes/todos.ts` — 新 REST ルート追加・`GET` レスポンスに columns 同梱
+- `server/routes/todosHandlers.ts` — マイグレーション後の新フィールドを保持するよう既存 `update` ハンドラを微調整 + regression test
+- `src/plugins/todo/index.ts` — TodoItem 拡張（`status` / `priority` / `dueDate` / `order`）
+- `src/plugins/todo/Preview.vue` — status / priority / dueDate の小バッジ追加（オプション）
+- `src/components/FilesView.vue` — TodoExplorer 統合
+- `package.json` — vuedraggable 追加
+- `README.md` — todo セクション更新
+
+### 触らない
+
+- `src/plugins/todo/definition.ts` — **MCP ツール定義は無変更**
+- `src/plugins/todo/View.vue` — 既存チャット内 view は無変更（必要なら Phase 4 で refactor）
+- `server/agent.ts` (`MCP_PLUGINS` には既に `manageTodoList` がいる前提)
+- `src/tools/index.ts` (todo plugin 登録済み)
+- `src/config/roles.ts` (既存ロールに含まれている前提 — 要確認)
+
+---
+
+## オープンな決定事項
+
+1. **drag & drop ライブラリ**: `vuedraggable@next` か `vue-draggable-plus` か。前者は SortableJS ベースで成熟。**判断**: `vuedraggable@next` を採用。
+2. **詳細編集 UI**: 既存 YAML editor を継続するか、フォーム化するか。**判断**: Phase 2 までは既存の YAML editor を継続。Phase 4 でフォーム化を検討。
+3. **column id の生成**: ユーザが label を入れた時に slug 化（小文字 + `_` 置換）。重複は `_2` を付与。
+4. **キーボード操作**: out of scope (Phase 4 でオプション)。
+
+---
+
+## リスク / 注意
+
+- **`completed` フィールドとの二重管理**: 後方互換のため残すが、`isDone` 列との同期を間違えると view が壊れる。Phase 1 のテストで全パターンを golden test する。
+- **drag & drop の競合**: 楽観的更新後にサーバが reject した場合の rollback。`useTodos.applyMove` で前状態を保持して失敗時に戻す。
+- **既存 MCP ハンドラとの併存**: マイグレーションで追加された `status` / `order` を、既存 `update` ハンドラ (`server/routes/todosHandlers.ts:132-161`) が上書きで消してしまう罠がある。`...target` のスプレッドが効いていることを regression test で確認する。
+- **既存 chat view (`src/plugins/todo/View.vue`) との回帰**: 触らない方針だが、`GET /api/todos` のレスポンス形 `{ data: { items, columns } }` に変わるため、フロントが `data.items` を読んでいる箇所が壊れないかを実機で確認する（既存実装は `result.data?.items` を読んでいるので問題ないはず）。
+
+---
+
+## 参考 (関連ファイル)
+
+- `src/plugins/todo/View.vue` — 既存リスト + YAML editor
+- `src/plugins/todo/labels.ts` — 既存ラベルロジック (色 / フィルタ / 集計)
+- `src/plugins/todo/Preview.vue` — sidebar preview
+- `server/routes/todos.ts:9-16` — TodoItem
+- `server/routes/todosHandlers.ts:302-316` — HANDLERS map（新 action 追加先）
+- `src/components/FilesView.vue:58-60` / `src/components/FilesView.vue:298-317` — Scheduler の特殊ケース統合パターン
+- `src/plugins/scheduler/View.vue` — full-canvas plugin view の参考実装
+- `plans/feat-todo-labels.md` — labels 機能の前 PR の設計（流儀の参考）

--- a/server/routes/todos.ts
+++ b/server/routes/todos.ts
@@ -3,8 +3,29 @@ import path from "path";
 import { workspacePath } from "../workspace.js";
 import { loadJsonFile, saveJsonFile } from "../utils/file.js";
 import { dispatchTodos, type TodosActionInput } from "./todosHandlers.js";
+import {
+  type StatusColumn,
+  DEFAULT_COLUMNS,
+  handleAddColumn,
+  handleDeleteColumn,
+  handlePatchColumn,
+  handleReorderColumns,
+  normalizeColumns,
+} from "./todosColumnsHandlers.js";
+import {
+  handleCreate,
+  handleDeleteItem,
+  handleMove,
+  handlePatch,
+  migrateItems,
+  type CreateInput,
+  type MoveInput,
+  type PatchInput,
+} from "./todosItemsHandlers.js";
 
 const router = Router();
+
+export type TodoPriority = "low" | "medium" | "high" | "urgent";
 
 export interface TodoItem {
   id: string;
@@ -13,24 +34,59 @@ export interface TodoItem {
   labels?: string[];
   completed: boolean;
   createdAt: number;
+  // ── Added for the file-explorer kanban view ──
+  // status: id of a column from columns.json. Optional on the wire so
+  // legacy items load cleanly; migrateTodos() backfills it on read.
+  status?: string;
+  priority?: TodoPriority;
+  dueDate?: string; // ISO YYYY-MM-DD
+  order?: number; // sort key within the same status column
 }
 
-const todosFile = () => path.join(workspacePath, "todos", "todos.json");
+const todosFile = (): string => path.join(workspacePath, "todos", "todos.json");
+const columnsFile = (): string =>
+  path.join(workspacePath, "todos", "columns.json");
 
+function loadColumns(): StatusColumn[] {
+  return normalizeColumns(
+    loadJsonFile<unknown>(columnsFile(), DEFAULT_COLUMNS),
+  );
+}
+
+function saveColumns(columns: StatusColumn[]): void {
+  saveJsonFile(columnsFile(), columns);
+}
+
+// Reads todos.json and migrates the result so callers always see a
+// fully-populated TodoItem (status / order backfilled). Migration is
+// done on every read; we only persist the migrated form when an
+// action mutates state, which keeps the on-disk format unchanged
+// for users who never touch the kanban view.
 function loadTodos(): TodoItem[] {
-  return loadJsonFile<TodoItem[]>(todosFile(), []);
+  const raw = loadJsonFile<TodoItem[]>(todosFile(), []);
+  const columns = loadColumns();
+  return migrateItems(raw, columns);
 }
 
 function saveTodos(items: TodoItem[]): void {
   saveJsonFile(todosFile(), items);
 }
 
-router.get(
-  "/todos",
-  (_req: Request, res: Response<{ data: { items: TodoItem[] } }>) => {
-    res.json({ data: { items: loadTodos() } });
-  },
-);
+// ── GET /api/todos ───────────────────────────────────────────────
+//
+// Returns the migrated items + the current status columns. The
+// columns field is new; existing chat-side consumers only read
+// `data.items` so adding a sibling key is non-breaking.
+
+interface TodosListResponse {
+  data: { items: TodoItem[]; columns: StatusColumn[] };
+}
+
+router.get("/todos", (_req: Request, res: Response<TodosListResponse>) => {
+  res.json({ data: { items: loadTodos(), columns: loadColumns() } });
+});
+
+// ── POST /api/todos (legacy MCP action route) ────────────────────
 
 interface TodoBody extends TodosActionInput {
   action: string;
@@ -41,7 +97,7 @@ interface ErrorResponse {
 }
 
 interface TodoResponse {
-  data: { items: TodoItem[] };
+  data: { items: TodoItem[]; columns: StatusColumn[] };
   message: string;
   jsonData: Record<string, unknown>;
   instructions: string;
@@ -72,12 +128,214 @@ router.post(
     }
 
     res.json({
-      data: { items: result.items },
+      data: { items: result.items, columns: loadColumns() },
       message: result.message,
       jsonData: result.jsonData,
       instructions: "Display the updated todo list to the user.",
       updating: true,
     });
+  },
+);
+
+// ── New REST routes for the file-explorer todo view ──────────────
+//
+// These are id-based and used exclusively by the web UI. They live
+// alongside the legacy MCP action route so the LLM-facing contract
+// stays unchanged.
+
+interface ItemResponse {
+  data: { items: TodoItem[]; columns: StatusColumn[] };
+  item?: TodoItem;
+}
+
+interface ItemIdParams {
+  id: string;
+}
+
+interface ColumnIdParams {
+  id: string;
+}
+
+// POST /api/todos/items — create a new todo
+router.post(
+  "/todos/items",
+  (
+    req: Request<object, unknown, CreateInput>,
+    res: Response<ItemResponse | ErrorResponse>,
+  ) => {
+    const items = loadTodos();
+    const columns = loadColumns();
+    const result = handleCreate(items, columns, req.body);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveTodos(result.items);
+    res.json({
+      data: { items: result.items, columns },
+      ...(result.item && { item: result.item }),
+    });
+  },
+);
+
+// PATCH /api/todos/items/:id — partial update
+router.patch(
+  "/todos/items/:id",
+  (
+    req: Request<ItemIdParams, unknown, PatchInput>,
+    res: Response<ItemResponse | ErrorResponse>,
+  ) => {
+    const items = loadTodos();
+    const columns = loadColumns();
+    const result = handlePatch(items, columns, req.params.id, req.body);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveTodos(result.items);
+    res.json({
+      data: { items: result.items, columns },
+      ...(result.item && { item: result.item }),
+    });
+  },
+);
+
+// POST /api/todos/items/:id/move — drag & drop persistence
+router.post(
+  "/todos/items/:id/move",
+  (
+    req: Request<ItemIdParams, unknown, MoveInput>,
+    res: Response<ItemResponse | ErrorResponse>,
+  ) => {
+    const items = loadTodos();
+    const columns = loadColumns();
+    const result = handleMove(items, columns, req.params.id, req.body);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveTodos(result.items);
+    res.json({
+      data: { items: result.items, columns },
+      ...(result.item && { item: result.item }),
+    });
+  },
+);
+
+// DELETE /api/todos/items/:id
+router.delete(
+  "/todos/items/:id",
+  (req: Request<ItemIdParams>, res: Response<ItemResponse | ErrorResponse>) => {
+    const items = loadTodos();
+    const columns = loadColumns();
+    const result = handleDeleteItem(items, req.params.id);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveTodos(result.items);
+    res.json({ data: { items: result.items, columns } });
+  },
+);
+
+// ── Columns ──────────────────────────────────────────────────────
+
+interface ColumnsResponse {
+  data: { items: TodoItem[]; columns: StatusColumn[] };
+}
+
+interface AddColumnBody {
+  label?: string;
+  isDone?: boolean;
+}
+
+interface PatchColumnBody {
+  label?: string;
+  isDone?: boolean;
+}
+
+interface ReorderColumnsBody {
+  ids?: string[];
+}
+
+router.get(
+  "/todos/columns",
+  (_req: Request, res: Response<ColumnsResponse>) => {
+    res.json({ data: { items: loadTodos(), columns: loadColumns() } });
+  },
+);
+
+router.post(
+  "/todos/columns",
+  (
+    req: Request<object, unknown, AddColumnBody>,
+    res: Response<ColumnsResponse | ErrorResponse>,
+  ) => {
+    const result = handleAddColumn(loadColumns(), req.body);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveColumns(result.columns);
+    if (result.items) saveTodos(result.items);
+    res.json({ data: { items: loadTodos(), columns: result.columns } });
+  },
+);
+
+router.patch(
+  "/todos/columns/:id",
+  (
+    req: Request<ColumnIdParams, unknown, PatchColumnBody>,
+    res: Response<ColumnsResponse | ErrorResponse>,
+  ) => {
+    const items = loadTodos();
+    const result = handlePatchColumn(
+      loadColumns(),
+      req.params.id,
+      req.body,
+      items,
+    );
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveColumns(result.columns);
+    if (result.items) saveTodos(result.items);
+    res.json({ data: { items: loadTodos(), columns: result.columns } });
+  },
+);
+
+router.delete(
+  "/todos/columns/:id",
+  (
+    req: Request<ColumnIdParams>,
+    res: Response<ColumnsResponse | ErrorResponse>,
+  ) => {
+    const items = loadTodos();
+    const result = handleDeleteColumn(loadColumns(), req.params.id, items);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveColumns(result.columns);
+    if (result.items) saveTodos(result.items);
+    res.json({ data: { items: loadTodos(), columns: result.columns } });
+  },
+);
+
+router.put(
+  "/todos/columns/order",
+  (
+    req: Request<object, unknown, ReorderColumnsBody>,
+    res: Response<ColumnsResponse | ErrorResponse>,
+  ) => {
+    const result = handleReorderColumns(loadColumns(), req.body.ids ?? []);
+    if (result.kind === "error") {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+    saveColumns(result.columns);
+    res.json({ data: { items: loadTodos(), columns: result.columns } });
   },
 );
 

--- a/server/routes/todos.ts
+++ b/server/routes/todos.ts
@@ -271,7 +271,8 @@ router.post(
     req: Request<object, unknown, AddColumnBody>,
     res: Response<ColumnsResponse | ErrorResponse>,
   ) => {
-    const result = handleAddColumn(loadColumns(), req.body);
+    const items = loadTodos();
+    const result = handleAddColumn(loadColumns(), items, req.body);
     if (result.kind === "error") {
       res.status(result.status).json({ error: result.error });
       return;

--- a/server/routes/todosColumnsHandlers.ts
+++ b/server/routes/todosColumnsHandlers.ts
@@ -149,6 +149,52 @@ export function defaultStatusId(columns: StatusColumn[]): string {
   return open ? open.id : doneColumnId(columns);
 }
 
+// Reconcile each item's `completed` boolean with the new done-column
+// id. Items in the new done column are completed=true, items
+// elsewhere are completed=false. Returns [updatedItems, changed]
+// where `changed` says whether any item was actually rewritten —
+// callers use that to decide whether to persist items along with
+// the column change.
+//
+// This is the *only* place that mass-mutates `completed` based on
+// status. The migration on read deliberately does NOT do this any
+// more (so the legacy MCP `check` action's plain boolean flips keep
+// working). Column operations are explicit user intent so it's safe
+// to sync at that point.
+export function resyncDoneMembership(
+  items: TodoItem[],
+  newDoneId: string,
+): { items: TodoItem[]; changed: boolean } {
+  let changed = false;
+  const next = items.map((it): TodoItem => {
+    const shouldBeDone = it.status === newDoneId;
+    if (it.completed === shouldBeDone) return it;
+    changed = true;
+    return { ...it, completed: shouldBeDone };
+  });
+  return { items: next, changed };
+}
+
+// Re-stripe order values for every item in `columnId`. Items already
+// sorted by their existing `order` get reassigned to 1000, 2000, ...
+// so two columns being merged together (handleDeleteColumn's refuge
+// case) end up with unique, contiguous orders rather than colliding
+// 1000s from each side.
+function rebuildColumnOrder(items: TodoItem[], columnId: string): TodoItem[] {
+  const inColumn = items
+    .filter((it) => it.status === columnId)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  const newOrders = new Map<string, number>();
+  inColumn.forEach((it, i) => newOrders.set(it.id, (i + 1) * ORDER_STEP));
+  return items.map((it): TodoItem => {
+    const o = newOrders.get(it.id);
+    if (o === undefined) return it;
+    return { ...it, order: o };
+  });
+}
+
+const ORDER_STEP = 1000;
+
 // ── Action handlers ───────────────────────────────────────────────
 
 export interface AddColumnInput {
@@ -158,6 +204,7 @@ export interface AddColumnInput {
 
 export function handleAddColumn(
   columns: StatusColumn[],
+  items: TodoItem[],
   input: AddColumnInput,
 ): ColumnsActionResult {
   if (!input.label || input.label.trim().length === 0) {
@@ -167,12 +214,20 @@ export function handleAddColumn(
   const id = uniqueId(baseId, new Set(columns.map((c) => c.id)));
   const col: StatusColumn = { id, label: input.label.trim() };
   if (input.isDone === true) col.isDone = true;
-  // If the new column is flagged done, demote any existing done columns
-  // (only one is allowed at a time).
-  const next = input.isDone
-    ? [...columns.map((c) => ({ ...c, isDone: false })), col]
-    : [...columns, col];
-  return { kind: "success", columns: next };
+  // If the new column is flagged done, demote any existing done
+  // columns (only one is allowed at a time) and resync items so the
+  // old done column's items are no longer marked completed. The new
+  // column itself is empty so there's nothing on its side to sync.
+  if (input.isDone === true) {
+    const nextColumns = [...columns.map((c) => ({ ...c, isDone: false })), col];
+    const { items: nextItems, changed } = resyncDoneMembership(items, id);
+    return {
+      kind: "success",
+      columns: nextColumns,
+      ...(changed ? { items: nextItems } : {}),
+    };
+  }
+  return { kind: "success", columns: [...columns, col] };
 }
 
 export interface PatchColumnInput {
@@ -204,11 +259,13 @@ export function handlePatchColumn(
     nextColumns = nextColumns.map((c) =>
       c.id === id ? { ...c, isDone: true } : { id: c.id, label: c.label },
     );
-    // Sync `completed` for items in the new done column.
-    nextItems = items.map((it) =>
-      it.status === id ? { ...it, completed: true } : it,
-    );
-    itemsChanged = true;
+    // Resync `completed` across all items: the new done column's
+    // items become true, the old done column's items become false.
+    // Doing this with the helper rather than a one-sided pass means
+    // both ends of the swap stay consistent.
+    const synced = resyncDoneMembership(items, id);
+    nextItems = synced.items;
+    itemsChanged = synced.changed;
   } else if (input.isDone === false && target.isDone) {
     // Refuse to demote the only done column — there must always be one.
     return {
@@ -253,13 +310,31 @@ export function handleDeleteColumn(
   // deleted column was done; otherwise to the new default open column.
   const refugeId = target.isDone ? newDoneId : defaultStatusId(nextColumns);
   let itemsChanged = false;
-  const nextItems = items.map((it) => {
+  let nextItems = items.map((it): TodoItem => {
     if (it.status !== id) return it;
     itemsChanged = true;
-    const updated: TodoItem = { ...it, status: refugeId };
-    if (refugeId === newDoneId) updated.completed = true;
-    return updated;
+    return { ...it, status: refugeId };
   });
+  if (itemsChanged) {
+    // The refuge column might have already had items in it; the ones
+    // we just merged in came with their original order values from
+    // the deleted column, which can collide with the refuge's
+    // existing orders. Re-stripe the whole refuge column to 1000,
+    // 2000, ... so the kanban sort stays unique and stable.
+    nextItems = rebuildColumnOrder(nextItems, refugeId);
+  }
+  // Resync the done flag across the result. Necessary in two
+  // scenarios: (a) we deleted the done column, so the new last column
+  // is now done and its existing items should flip to completed=true;
+  // (b) we deleted any other column whose items happened to be the
+  // refuge target — already handled by the migration above, but
+  // running the helper unconditionally keeps the rest of the items
+  // consistent too.
+  if (target.isDone) {
+    const synced = resyncDoneMembership(nextItems, newDoneId);
+    nextItems = synced.items;
+    itemsChanged = itemsChanged || synced.changed;
+  }
   return {
     kind: "success",
     columns: nextColumns,

--- a/server/routes/todosColumnsHandlers.ts
+++ b/server/routes/todosColumnsHandlers.ts
@@ -1,0 +1,299 @@
+// Pure handlers for status columns used by the file-explorer todo
+// view. Same shape as todosHandlers / schedulerHandlers: each function
+// takes the current state + an input record and returns either an
+// error or the next state. The Express route is responsible for
+// loading / saving the underlying JSON files.
+//
+// Storage layout:
+//   workspace/todos/columns.json   ← StatusColumn[]
+//
+// At least one column must always carry `isDone: true` so completed
+// items have somewhere to live and the legacy `completed` boolean has
+// something to map to.
+
+import type { TodoItem } from "./todos.js";
+
+export interface StatusColumn {
+  id: string;
+  label: string;
+  // True for the column whose items are considered "completed".
+  // Exactly one column should have isDone: true at any given time;
+  // remove_column / patch_column rules enforce this.
+  isDone?: boolean;
+}
+
+export const DEFAULT_COLUMNS: StatusColumn[] = [
+  { id: "backlog", label: "Backlog" },
+  { id: "todo", label: "Todo" },
+  { id: "in_progress", label: "In Progress" },
+  { id: "done", label: "Done", isDone: true },
+];
+
+// ── Result types ──────────────────────────────────────────────────
+
+export type ColumnsActionResult =
+  | { kind: "error"; status: number; error: string }
+  | {
+      kind: "success";
+      columns: StatusColumn[];
+      // Some operations also need to mutate items (e.g. removing a
+      // column reassigns its items to another column). When set, the
+      // route persists this items array as well.
+      items?: TodoItem[];
+    };
+
+// ── id slug generation ────────────────────────────────────────────
+
+// Convert a free-text label into a URL-safe id. Lowercased ASCII
+// letters/numbers/underscore only; everything else collapses to "_".
+// Empty result falls back to "column".
+function slugify(label: string): string {
+  // Lowercased, with all non-alphanumeric runs collapsed to "_". The
+  // single regex pass is intentional: doing the trim separately with
+  // a leading/trailing _+ regex is flagged by sonarjs as potentially
+  // super-linear, so trim the underscores manually instead.
+  let slug = label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start++;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end--;
+  slug = slug.slice(start, end);
+  return slug.length > 0 ? slug : "column";
+}
+
+// Pick an id that doesn't collide with `existingIds`. Tries the bare
+// slug first, then `_2`, `_3`, ... until something is free.
+function uniqueId(base: string, existingIds: ReadonlySet<string>): string {
+  if (!existingIds.has(base)) return base;
+  let n = 2;
+  while (existingIds.has(`${base}_${n}`)) n++;
+  return `${base}_${n}`;
+}
+
+// ── Validation helpers ────────────────────────────────────────────
+
+function findColumn(
+  columns: StatusColumn[],
+  id: string,
+): StatusColumn | undefined {
+  return columns.find((c) => c.id === id);
+}
+
+function ensureColumnsValid(columns: StatusColumn[]): StatusColumn[] {
+  // Guarantee invariants when reading: at least one column, exactly
+  // one isDone column, ids are unique. If anything is off, fall back
+  // to DEFAULT_COLUMNS rather than try to repair partial state.
+  if (columns.length === 0) return [...DEFAULT_COLUMNS];
+  const seen = new Set<string>();
+  for (const c of columns) {
+    if (seen.has(c.id)) return [...DEFAULT_COLUMNS];
+    seen.add(c.id);
+  }
+  const doneCount = columns.filter((c) => c.isDone).length;
+  if (doneCount === 0) {
+    // Promote the last column to done so the invariant holds.
+    const fixed = columns.map((c, i) =>
+      i === columns.length - 1 ? { ...c, isDone: true } : c,
+    );
+    return fixed;
+  }
+  if (doneCount > 1) {
+    // Keep only the first done flag.
+    let kept = false;
+    return columns.map((c) => {
+      if (!c.isDone) return c;
+      if (kept) {
+        const next: StatusColumn = { id: c.id, label: c.label };
+        return next;
+      }
+      kept = true;
+      return c;
+    });
+  }
+  return columns;
+}
+
+// Public: load-time normaliser. Use this when parsing columns.json so
+// the rest of the system never has to think about invalid shapes.
+export function normalizeColumns(raw: unknown): StatusColumn[] {
+  if (!Array.isArray(raw)) return [...DEFAULT_COLUMNS];
+  const cleaned: StatusColumn[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e["id"] !== "string" || typeof e["label"] !== "string") continue;
+    const col: StatusColumn = { id: e["id"], label: e["label"] };
+    if (e["isDone"] === true) col.isDone = true;
+    cleaned.push(col);
+  }
+  return ensureColumnsValid(cleaned);
+}
+
+// ── Item helpers tied to columns ──────────────────────────────────
+
+// id of the first column flagged isDone. Guaranteed to exist after
+// normalizeColumns.
+export function doneColumnId(columns: StatusColumn[]): string {
+  const done = columns.find((c) => c.isDone);
+  return done ? done.id : columns[columns.length - 1]!.id;
+}
+
+// id of the first non-done column, used as the default status when
+// adding new items. Falls back to the done column if everything is
+// somehow flagged done.
+export function defaultStatusId(columns: StatusColumn[]): string {
+  const open = columns.find((c) => !c.isDone);
+  return open ? open.id : doneColumnId(columns);
+}
+
+// ── Action handlers ───────────────────────────────────────────────
+
+export interface AddColumnInput {
+  label?: string;
+  isDone?: boolean;
+}
+
+export function handleAddColumn(
+  columns: StatusColumn[],
+  input: AddColumnInput,
+): ColumnsActionResult {
+  if (!input.label || input.label.trim().length === 0) {
+    return { kind: "error", status: 400, error: "label required" };
+  }
+  const baseId = slugify(input.label);
+  const id = uniqueId(baseId, new Set(columns.map((c) => c.id)));
+  const col: StatusColumn = { id, label: input.label.trim() };
+  if (input.isDone === true) col.isDone = true;
+  // If the new column is flagged done, demote any existing done columns
+  // (only one is allowed at a time).
+  const next = input.isDone
+    ? [...columns.map((c) => ({ ...c, isDone: false })), col]
+    : [...columns, col];
+  return { kind: "success", columns: next };
+}
+
+export interface PatchColumnInput {
+  label?: string;
+  isDone?: boolean;
+}
+
+export function handlePatchColumn(
+  columns: StatusColumn[],
+  id: string,
+  input: PatchColumnInput,
+  items: TodoItem[],
+): ColumnsActionResult {
+  const target = findColumn(columns, id);
+  if (!target) {
+    return { kind: "error", status: 404, error: `column not found: ${id}` };
+  }
+  const patched: StatusColumn = { id: target.id, label: target.label };
+  if (target.isDone) patched.isDone = true;
+  if (typeof input.label === "string" && input.label.trim().length > 0) {
+    patched.label = input.label.trim();
+  }
+  let nextColumns = columns.map((c) => (c.id === id ? patched : c));
+  // Toggling done flag is non-trivial: only one column may be done.
+  let itemsChanged = false;
+  let nextItems = items;
+  if (input.isDone === true && !target.isDone) {
+    // Promote this column to done; demote everyone else.
+    nextColumns = nextColumns.map((c) =>
+      c.id === id ? { ...c, isDone: true } : { id: c.id, label: c.label },
+    );
+    // Sync `completed` for items in the new done column.
+    nextItems = items.map((it) =>
+      it.status === id ? { ...it, completed: true } : it,
+    );
+    itemsChanged = true;
+  } else if (input.isDone === false && target.isDone) {
+    // Refuse to demote the only done column — there must always be one.
+    return {
+      kind: "error",
+      status: 400,
+      error: "at least one column must be marked as done",
+    };
+  }
+  return {
+    kind: "success",
+    columns: nextColumns,
+    ...(itemsChanged ? { items: nextItems } : {}),
+  };
+}
+
+export function handleDeleteColumn(
+  columns: StatusColumn[],
+  id: string,
+  items: TodoItem[],
+): ColumnsActionResult {
+  if (columns.length <= 1) {
+    return {
+      kind: "error",
+      status: 400,
+      error: "cannot delete the last remaining column",
+    };
+  }
+  const target = findColumn(columns, id);
+  if (!target) {
+    return { kind: "error", status: 404, error: `column not found: ${id}` };
+  }
+  const remaining = columns.filter((c) => c.id !== id);
+  // If we just removed the done column, promote the new last column.
+  let nextColumns = remaining;
+  if (target.isDone) {
+    nextColumns = remaining.map((c, i) =>
+      i === remaining.length - 1 ? { ...c, isDone: true } : c,
+    );
+  }
+  const newDoneId = doneColumnId(nextColumns);
+  // Reassign orphaned items to the (possibly new) done column if the
+  // deleted column was done; otherwise to the new default open column.
+  const refugeId = target.isDone ? newDoneId : defaultStatusId(nextColumns);
+  let itemsChanged = false;
+  const nextItems = items.map((it) => {
+    if (it.status !== id) return it;
+    itemsChanged = true;
+    const updated: TodoItem = { ...it, status: refugeId };
+    if (refugeId === newDoneId) updated.completed = true;
+    return updated;
+  });
+  return {
+    kind: "success",
+    columns: nextColumns,
+    ...(itemsChanged ? { items: nextItems } : {}),
+  };
+}
+
+export function handleReorderColumns(
+  columns: StatusColumn[],
+  ids: string[],
+): ColumnsActionResult {
+  if (!Array.isArray(ids)) {
+    return { kind: "error", status: 400, error: "ids array required" };
+  }
+  if (ids.length !== columns.length) {
+    return {
+      kind: "error",
+      status: 400,
+      error: "ids must contain every existing column id exactly once",
+    };
+  }
+  const known = new Set(columns.map((c) => c.id));
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!known.has(id) || seen.has(id)) {
+      return {
+        kind: "error",
+        status: 400,
+        error: "ids must contain every existing column id exactly once",
+      };
+    }
+    seen.add(id);
+  }
+  const byId = new Map(columns.map((c) => [c.id, c]));
+  const next = ids.map((id) => byId.get(id)!);
+  return { kind: "success", columns: next };
+}

--- a/server/routes/todosItemsHandlers.ts
+++ b/server/routes/todosItemsHandlers.ts
@@ -56,6 +56,15 @@ export function migrateItems(
   // First pass: backfill status. Items pointing at a column that no
   // longer exists are reassigned to the default open or done column
   // depending on `completed`.
+  //
+  // Note: we deliberately do NOT re-sync `completed` to status on
+  // every read. Earlier versions of this function did, but that
+  // overrode the legacy MCP `check` / `uncheck` actions — those
+  // actions only flip the boolean, never touch status, so a sync
+  // pass kept reverting them on the next read. Treating the two
+  // fields as independent at the storage layer leaves both the REST
+  // PATCH path (which keeps them in sync explicitly) and the legacy
+  // MCP actions (which only touch `completed`) working correctly.
   const withStatus = rawItems.map((it): TodoItem => {
     const hasValidStatus =
       typeof it.status === "string" && validStatusIds.has(it.status);
@@ -64,20 +73,11 @@ export function migrateItems(
     return { ...it, status };
   });
 
-  // Sync `completed` to status: items in the done column are completed,
-  // items elsewhere are not. This makes the two fields agree even when
-  // legacy data was inconsistent.
-  const withCompletedSync = withStatus.map((it): TodoItem => {
-    const shouldBeDone = it.status === doneId;
-    if (it.completed === shouldBeDone) return it;
-    return { ...it, completed: shouldBeDone };
-  });
-
   // Second pass: backfill order per column. Sort by createdAt within
   // each column, then assign 1000 / 2000 / 3000 ... so drag-drop has
   // room to insert between any two existing items.
   const byStatus = new Map<string, TodoItem[]>();
-  for (const it of withCompletedSync) {
+  for (const it of withStatus) {
     const key = it.status ?? openId;
     if (!byStatus.has(key)) byStatus.set(key, []);
     byStatus.get(key)!.push(it);
@@ -92,7 +92,7 @@ export function migrateItems(
     const sorted = [...group].sort((a, b) => a.createdAt - b.createdAt);
     sorted.forEach((it, i) => orderById.set(it.id, (i + 1) * ORDER_STEP));
   }
-  return withCompletedSync.map((it): TodoItem => {
+  return withStatus.map((it): TodoItem => {
     const next = orderById.get(it.id);
     if (next === undefined) return it;
     return { ...it, order: next };

--- a/server/routes/todosItemsHandlers.ts
+++ b/server/routes/todosItemsHandlers.ts
@@ -73,9 +73,12 @@ export function migrateItems(
     return { ...it, status };
   });
 
-  // Second pass: backfill order per column. Sort by createdAt within
-  // each column, then assign 1000 / 2000 / 3000 ... so drag-drop has
-  // room to insert between any two existing items.
+  // Second pass: backfill order per column. Items that already have
+  // an order keep it untouched — only items missing order get one
+  // assigned, and they go after the column's current max so they
+  // sort to the bottom in createdAt order. This preserves any
+  // hand-managed ordering even when a column is a mix of legacy
+  // and kanban-aware items.
   const byStatus = new Map<string, TodoItem[]>();
   for (const it of withStatus) {
     const key = it.status ?? openId;
@@ -84,13 +87,15 @@ export function migrateItems(
   }
   const orderById = new Map<string, number>();
   for (const [, group] of byStatus) {
-    // If every item already has an order, leave them alone — they
-    // were saved by a kanban-aware client and we shouldn't trample
-    // their hand-set ordering.
-    const allHaveOrder = group.every((it) => typeof it.order === "number");
-    if (allHaveOrder) continue;
-    const sorted = [...group].sort((a, b) => a.createdAt - b.createdAt);
-    sorted.forEach((it, i) => orderById.set(it.id, (i + 1) * ORDER_STEP));
+    const missing = group.filter((it) => typeof it.order !== "number");
+    if (missing.length === 0) continue;
+    const existingMax = group
+      .filter((it) => typeof it.order === "number")
+      .reduce((acc, it) => Math.max(acc, it.order!), 0);
+    const sorted = [...missing].sort((a, b) => a.createdAt - b.createdAt);
+    sorted.forEach((it, i) => {
+      orderById.set(it.id, existingMax + (i + 1) * ORDER_STEP);
+    });
   }
   return withStatus.map((it): TodoItem => {
     const next = orderById.get(it.id);
@@ -137,11 +142,22 @@ export function handleCreate(
   if (!input.text || input.text.trim().length === 0) {
     return { kind: "error", status: 400, error: "text required" };
   }
+  // Resolve status. An explicit but unknown status is a 400, not a
+  // silent fallback to the default — silently rewriting the user's
+  // intent has bitten us before with sibling MCP routes.
   const validStatusIds = new Set(columns.map((c) => c.id));
-  const status =
-    input.status && validStatusIds.has(input.status)
-      ? input.status
-      : defaultStatusId(columns);
+  let status: string;
+  if (input.status === undefined || input.status === "") {
+    status = defaultStatusId(columns);
+  } else if (validStatusIds.has(input.status)) {
+    status = input.status;
+  } else {
+    return {
+      kind: "error",
+      status: 400,
+      error: `unknown status: ${input.status}`,
+    };
+  }
   const isDone = status === doneColumnId(columns);
   const item: TodoItem = {
     id: makeId(),

--- a/server/routes/todosItemsHandlers.ts
+++ b/server/routes/todosItemsHandlers.ts
@@ -1,0 +1,418 @@
+// Pure handlers for the id-based REST routes used by the file-explorer
+// todo view (TodoExplorer.vue). The MCP `manageTodoList` action route
+// continues to live in todosHandlers.ts; these handlers are intended
+// for the web UI which knows item ids directly and doesn't need the
+// substring-match contract that the MCP handlers use.
+//
+// Each function takes the current items + columns + an input record
+// and returns a result. The Express route is responsible for loading
+// and saving JSON to disk.
+
+import { randomBytes } from "crypto";
+import type { TodoItem, TodoPriority } from "./todos.js";
+import {
+  type StatusColumn,
+  defaultStatusId,
+  doneColumnId,
+} from "./todosColumnsHandlers.js";
+import { mergeLabels } from "../../src/plugins/todo/labels.js";
+
+const ORDER_STEP = 1000;
+const PRIORITIES: readonly TodoPriority[] = ["low", "medium", "high", "urgent"];
+
+// ── Result type ───────────────────────────────────────────────────
+
+export type ItemsActionResult =
+  | { kind: "error"; status: number; error: string }
+  | { kind: "success"; items: TodoItem[]; item?: TodoItem };
+
+// ── id generation ─────────────────────────────────────────────────
+
+function makeId(): string {
+  return `todo_${Date.now()}_${randomBytes(3).toString("hex")}`;
+}
+
+// ── Migration ─────────────────────────────────────────────────────
+
+// Backfill `status` and `order` on items that pre-date the kanban
+// extension. Pure / idempotent: items that already have valid values
+// pass through unchanged. Done via a single forward pass that assigns
+// monotonically-increasing order values per status column so the
+// kanban view has a stable initial sort.
+//
+// Reasoning for the order assignment: legacy items only carry a
+// `createdAt`, and we want oldest-first within each column. We can't
+// just use createdAt as the order key because it's a milliseconds
+// number which makes hand-editing painful and conflicts with the
+// 1000-step convention drag-drop uses for new items.
+export function migrateItems(
+  rawItems: TodoItem[],
+  columns: StatusColumn[],
+): TodoItem[] {
+  const doneId = doneColumnId(columns);
+  const openId = defaultStatusId(columns);
+  const validStatusIds = new Set(columns.map((c) => c.id));
+
+  // First pass: backfill status. Items pointing at a column that no
+  // longer exists are reassigned to the default open or done column
+  // depending on `completed`.
+  const withStatus = rawItems.map((it): TodoItem => {
+    const hasValidStatus =
+      typeof it.status === "string" && validStatusIds.has(it.status);
+    if (hasValidStatus) return it;
+    const status = it.completed ? doneId : openId;
+    return { ...it, status };
+  });
+
+  // Sync `completed` to status: items in the done column are completed,
+  // items elsewhere are not. This makes the two fields agree even when
+  // legacy data was inconsistent.
+  const withCompletedSync = withStatus.map((it): TodoItem => {
+    const shouldBeDone = it.status === doneId;
+    if (it.completed === shouldBeDone) return it;
+    return { ...it, completed: shouldBeDone };
+  });
+
+  // Second pass: backfill order per column. Sort by createdAt within
+  // each column, then assign 1000 / 2000 / 3000 ... so drag-drop has
+  // room to insert between any two existing items.
+  const byStatus = new Map<string, TodoItem[]>();
+  for (const it of withCompletedSync) {
+    const key = it.status ?? openId;
+    if (!byStatus.has(key)) byStatus.set(key, []);
+    byStatus.get(key)!.push(it);
+  }
+  const orderById = new Map<string, number>();
+  for (const [, group] of byStatus) {
+    // If every item already has an order, leave them alone — they
+    // were saved by a kanban-aware client and we shouldn't trample
+    // their hand-set ordering.
+    const allHaveOrder = group.every((it) => typeof it.order === "number");
+    if (allHaveOrder) continue;
+    const sorted = [...group].sort((a, b) => a.createdAt - b.createdAt);
+    sorted.forEach((it, i) => orderById.set(it.id, (i + 1) * ORDER_STEP));
+  }
+  return withCompletedSync.map((it): TodoItem => {
+    const next = orderById.get(it.id);
+    if (next === undefined) return it;
+    return { ...it, order: next };
+  });
+}
+
+// ── Validators ────────────────────────────────────────────────────
+
+function isPriority(v: unknown): v is TodoPriority {
+  return typeof v === "string" && PRIORITIES.includes(v as TodoPriority);
+}
+
+// YYYY-MM-DD only — keep it boring so the column is sortable as text.
+function isDueDate(v: unknown): v is string {
+  return typeof v === "string" && /^\d{4}-\d{2}-\d{2}$/.test(v);
+}
+
+function nextOrder(items: TodoItem[], statusId: string): number {
+  const inColumn = items
+    .filter((i) => i.status === statusId)
+    .map((i) => i.order ?? 0);
+  if (inColumn.length === 0) return ORDER_STEP;
+  return Math.max(...inColumn) + ORDER_STEP;
+}
+
+// ── Create ────────────────────────────────────────────────────────
+
+export interface CreateInput {
+  text?: string;
+  note?: string;
+  status?: string;
+  priority?: string;
+  dueDate?: string;
+  labels?: string[];
+}
+
+export function handleCreate(
+  items: TodoItem[],
+  columns: StatusColumn[],
+  input: CreateInput,
+): ItemsActionResult {
+  if (!input.text || input.text.trim().length === 0) {
+    return { kind: "error", status: 400, error: "text required" };
+  }
+  const validStatusIds = new Set(columns.map((c) => c.id));
+  const status =
+    input.status && validStatusIds.has(input.status)
+      ? input.status
+      : defaultStatusId(columns);
+  const isDone = status === doneColumnId(columns);
+  const item: TodoItem = {
+    id: makeId(),
+    text: input.text.trim(),
+    completed: isDone,
+    createdAt: Date.now(),
+    status,
+    order: nextOrder(items, status),
+  };
+  if (input.note !== undefined && input.note !== "") item.note = input.note;
+  const normalizedLabels = mergeLabels([], input.labels ?? []);
+  if (normalizedLabels.length > 0) item.labels = normalizedLabels;
+  if (input.priority !== undefined) {
+    if (input.priority === "") {
+      // explicit clear — leave undefined
+    } else if (isPriority(input.priority)) {
+      item.priority = input.priority;
+    } else {
+      return { kind: "error", status: 400, error: "invalid priority" };
+    }
+  }
+  if (input.dueDate !== undefined && input.dueDate !== "") {
+    if (!isDueDate(input.dueDate)) {
+      return {
+        kind: "error",
+        status: 400,
+        error: "dueDate must be YYYY-MM-DD",
+      };
+    }
+    item.dueDate = input.dueDate;
+  }
+  return { kind: "success", items: [...items, item], item };
+}
+
+// ── Patch ─────────────────────────────────────────────────────────
+
+export interface PatchInput {
+  text?: string;
+  note?: string | null;
+  status?: string;
+  priority?: string | null;
+  dueDate?: string | null;
+  labels?: string[];
+  completed?: boolean;
+}
+
+// Each `applyXxx` helper mutates `updated` in place and returns either
+// `null` (success) or an error result. Splitting them out keeps the
+// top-level `handlePatch` linear so it stays under the cognitive
+// complexity threshold and so each field's edit semantics live in one
+// obvious place.
+
+function applyTextPatch(
+  updated: TodoItem,
+  input: PatchInput,
+): ItemsActionResult | null {
+  if (typeof input.text !== "string") return null;
+  if (input.text.trim().length === 0) {
+    return { kind: "error", status: 400, error: "text cannot be empty" };
+  }
+  updated.text = input.text.trim();
+  return null;
+}
+
+function applyNotePatch(updated: TodoItem, input: PatchInput): void {
+  if (input.note === null || input.note === "") {
+    delete updated.note;
+    return;
+  }
+  if (typeof input.note === "string") updated.note = input.note;
+}
+
+function applyLabelsPatch(updated: TodoItem, input: PatchInput): void {
+  if (!Array.isArray(input.labels)) return;
+  const merged = mergeLabels([], input.labels);
+  if (merged.length > 0) updated.labels = merged;
+  else delete updated.labels;
+}
+
+function applyPriorityPatch(
+  updated: TodoItem,
+  input: PatchInput,
+): ItemsActionResult | null {
+  if (input.priority === null || input.priority === "") {
+    delete updated.priority;
+    return null;
+  }
+  if (input.priority === undefined) return null;
+  if (!isPriority(input.priority)) {
+    return { kind: "error", status: 400, error: "invalid priority" };
+  }
+  updated.priority = input.priority;
+  return null;
+}
+
+function applyDueDatePatch(
+  updated: TodoItem,
+  input: PatchInput,
+): ItemsActionResult | null {
+  if (input.dueDate === null || input.dueDate === "") {
+    delete updated.dueDate;
+    return null;
+  }
+  if (input.dueDate === undefined) return null;
+  if (!isDueDate(input.dueDate)) {
+    return { kind: "error", status: 400, error: "dueDate must be YYYY-MM-DD" };
+  }
+  updated.dueDate = input.dueDate;
+  return null;
+}
+
+function applyStatusPatch(
+  updated: TodoItem,
+  target: TodoItem,
+  items: TodoItem[],
+  columns: StatusColumn[],
+  input: PatchInput,
+): ItemsActionResult | null {
+  if (typeof input.status !== "string" || input.status === target.status) {
+    return null;
+  }
+  const validStatusIds = new Set(columns.map((c) => c.id));
+  if (!validStatusIds.has(input.status)) {
+    return {
+      kind: "error",
+      status: 400,
+      error: `unknown status: ${input.status}`,
+    };
+  }
+  updated.status = input.status;
+  updated.order = nextOrder(items, input.status);
+  updated.completed = input.status === doneColumnId(columns);
+  return null;
+}
+
+// Explicit `completed` toggle without changing status: lets the user
+// check / uncheck a card and have it move between the done column and
+// a default open column the obvious way.
+function applyCompletedPatch(
+  updated: TodoItem,
+  items: TodoItem[],
+  columns: StatusColumn[],
+  input: PatchInput,
+): void {
+  if (typeof input.completed !== "boolean") return;
+  if (input.completed === updated.completed) return;
+  updated.completed = input.completed;
+  const targetStatus = input.completed
+    ? doneColumnId(columns)
+    : defaultStatusId(columns);
+  if (targetStatus !== updated.status) {
+    updated.status = targetStatus;
+    updated.order = nextOrder(items, targetStatus);
+  }
+}
+
+export function handlePatch(
+  items: TodoItem[],
+  columns: StatusColumn[],
+  id: string,
+  input: PatchInput,
+): ItemsActionResult {
+  const target = items.find((i) => i.id === id);
+  if (!target) {
+    return { kind: "error", status: 404, error: `item not found: ${id}` };
+  }
+  const updated: TodoItem = { ...target };
+
+  // Each step short-circuits on validation failure. Order matters:
+  // status changes happen before completed-toggling so an explicit
+  // completed: true alongside a non-done status doesn't fight itself.
+  const steps: Array<() => ItemsActionResult | null | void> = [
+    () => applyTextPatch(updated, input),
+    () => applyNotePatch(updated, input),
+    () => applyLabelsPatch(updated, input),
+    () => applyPriorityPatch(updated, input),
+    () => applyDueDatePatch(updated, input),
+    () => applyStatusPatch(updated, target, items, columns, input),
+    () => applyCompletedPatch(updated, items, columns, input),
+  ];
+  for (const step of steps) {
+    const err = step();
+    if (err) return err;
+  }
+
+  const next = items.map((it) => (it.id === id ? updated : it));
+  return { kind: "success", items: next, item: updated };
+}
+
+// ── Move (drag & drop) ────────────────────────────────────────────
+
+// Reorder + cross-column move in a single call. `position` is the
+// 0-based index the item should occupy in its target column AFTER
+// the move (with the moving item itself excluded from the count).
+//
+// We rebuild the entire target column's order field for simplicity:
+// it's O(n) per column, which for a kanban with hundreds of items is
+// negligible and makes the math obviously correct.
+export interface MoveInput {
+  status?: string;
+  position?: number;
+}
+
+export function handleMove(
+  items: TodoItem[],
+  columns: StatusColumn[],
+  id: string,
+  input: MoveInput,
+): ItemsActionResult {
+  const target = items.find((i) => i.id === id);
+  if (!target) {
+    return { kind: "error", status: 404, error: `item not found: ${id}` };
+  }
+  const validStatusIds = new Set(columns.map((c) => c.id));
+  const newStatus = input.status ?? target.status ?? defaultStatusId(columns);
+  if (!validStatusIds.has(newStatus)) {
+    return {
+      kind: "error",
+      status: 400,
+      error: `unknown status: ${newStatus}`,
+    };
+  }
+  const isDone = newStatus === doneColumnId(columns);
+  const updatedSelf: TodoItem = {
+    ...target,
+    status: newStatus,
+    completed: isDone,
+  };
+  // Re-collect the items in the target column with the moving item
+  // pulled out, then splice it back in at `position`.
+  const others = items
+    .filter((it) => it.id !== id && it.status === newStatus)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  const insertAt = clampPosition(input.position, others.length);
+  const reordered = [...others];
+  reordered.splice(insertAt, 0, updatedSelf);
+  // Reassign order values 1000 / 2000 / 3000 ...
+  const reorderedById = new Map<string, number>();
+  reordered.forEach((it, i) => reorderedById.set(it.id, (i + 1) * ORDER_STEP));
+  const nextItems = items.map((it): TodoItem => {
+    const newOrder = reorderedById.get(it.id);
+    if (it.id === id) {
+      const out: TodoItem = {
+        ...updatedSelf,
+        order: newOrder ?? updatedSelf.order ?? ORDER_STEP,
+      };
+      return out;
+    }
+    if (newOrder !== undefined) return { ...it, order: newOrder };
+    return it;
+  });
+  const finalSelf = nextItems.find((it) => it.id === id)!;
+  return { kind: "success", items: nextItems, item: finalSelf };
+}
+
+function clampPosition(raw: number | undefined, max: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return max;
+  if (raw < 0) return 0;
+  if (raw > max) return max;
+  return Math.floor(raw);
+}
+
+// ── Delete ────────────────────────────────────────────────────────
+
+export function handleDeleteItem(
+  items: TodoItem[],
+  id: string,
+): ItemsActionResult {
+  const target = items.find((i) => i.id === id);
+  if (!target) {
+    return { kind: "error", status: 404, error: `item not found: ${id}` };
+  }
+  return { kind: "success", items: items.filter((it) => it.id !== id) };
+}

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -58,6 +58,10 @@
             <div v-if="schedulerResult" class="h-full">
               <SchedulerView :selected-result="schedulerResult" />
             </div>
+            <!-- Todos todos.json: full kanban / table / list explorer. -->
+            <div v-else-if="todoExplorerResult" class="h-full">
+              <TodoExplorer :selected-result="todoExplorerResult" />
+            </div>
             <!-- Markdown rendered: frontmatter panel + body -->
             <div
               v-else-if="isMarkdown && !mdRawMode"
@@ -191,9 +195,11 @@ import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import FileTree, { type TreeNode } from "./FileTree.vue";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SchedulerView from "../plugins/scheduler/View.vue";
+import TodoExplorer from "./TodoExplorer.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
 import type { SchedulerData, ScheduledItem } from "../plugins/scheduler/index";
+import type { StatusColumn, TodoData, TodoItem } from "../plugins/todo/index";
 import {
   tokenizeJson,
   tokenizeJsonl,
@@ -315,6 +321,41 @@ const schedulerResult = computed(
     };
   },
 );
+
+// Same idea as schedulerResult: when the user opens todos/todos.json
+// we render it as a full TodoExplorer (kanban / table / list) instead
+// of a raw JSON blob. The TodoExplorer fetches its own state from
+// /api/todos so the data we synthesize here is just a starter — the
+// columns array might be empty until the first refresh lands.
+function isTodoItem(x: unknown): x is TodoItem {
+  if (typeof x !== "object" || x === null) return false;
+  const o = x as Record<string, unknown>;
+  return typeof o["id"] === "string" && typeof o["text"] === "string";
+}
+
+function isTodoItemArray(x: unknown): x is TodoItem[] {
+  return Array.isArray(x) && x.every(isTodoItem);
+}
+
+const todoExplorerResult = computed((): ToolResultComplete<TodoData> | null => {
+  if (selectedPath.value !== "todos/todos.json") return null;
+  if (!content.value || content.value.kind !== "text") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content.value.content);
+  } catch {
+    return null;
+  }
+  const items: TodoItem[] = isTodoItemArray(parsed) ? parsed : [];
+  const columns: StatusColumn[] = [];
+  return {
+    uuid: "files-todo-preview",
+    toolName: "manageTodoList",
+    message: "todos/todos.json",
+    title: "Todo",
+    data: { items, columns },
+  };
+});
 
 const mdFrontmatter = computed(() => {
   if (!content.value || content.value.kind !== "text") return null;

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -330,7 +330,11 @@ const schedulerResult = computed(
 function isTodoItem(x: unknown): x is TodoItem {
   if (typeof x !== "object" || x === null) return false;
   const o = x as Record<string, unknown>;
-  return typeof o["id"] === "string" && typeof o["text"] === "string";
+  if (typeof o["id"] !== "string" || typeof o["text"] !== "string")
+    return false;
+  if (typeof o["completed"] !== "boolean") return false;
+  if (typeof o["createdAt"] !== "number") return false;
+  return true;
 }
 
 function isTodoItemArray(x: unknown): x is TodoItem[] {

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -1,0 +1,382 @@
+<template>
+  <div class="h-full bg-white flex flex-col">
+    <!-- Header -->
+    <div
+      class="flex items-center justify-between px-4 py-2 border-b border-gray-100 shrink-0 gap-3"
+    >
+      <div class="flex items-center gap-3 min-w-0">
+        <h2 class="text-base font-semibold text-gray-800 shrink-0">Todo</h2>
+        <span class="text-xs text-gray-500 shrink-0"
+          >{{ completedCount }}/{{ items.length }} done</span
+        >
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Search..."
+          class="px-2 py-1 text-xs border border-gray-200 rounded w-44 focus:outline-none focus:border-blue-400"
+        />
+      </div>
+      <div class="flex items-center gap-2">
+        <!-- Add button -->
+        <button
+          class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600"
+          @click="addOpen = true"
+        >
+          + Add
+        </button>
+        <!-- Add column button (kanban only) -->
+        <button
+          v-if="viewMode === 'kanban'"
+          class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          @click="addColumnOpen = true"
+        >
+          + Column
+        </button>
+        <!-- View mode toggle -->
+        <div
+          class="flex border border-gray-300 rounded overflow-hidden text-xs"
+        >
+          <button
+            v-for="mode in VIEW_MODES"
+            :key="mode.key"
+            class="px-2.5 py-1"
+            :class="
+              viewMode === mode.key
+                ? 'bg-blue-500 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-50'
+            "
+            :title="mode.label"
+            @click="setViewMode(mode.key)"
+          >
+            <span class="material-icons text-sm">{{ mode.icon }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Label filter chips -->
+    <div
+      v-if="labelInventory.length > 0"
+      class="flex flex-wrap items-center gap-1.5 px-4 py-1.5 border-b border-gray-100 bg-gray-50 shrink-0"
+    >
+      <span class="text-[11px] text-gray-500 mr-1">Labels:</span>
+      <button
+        v-for="entry in labelInventory"
+        :key="entry.label"
+        class="px-2 py-0.5 rounded-full text-[10px] font-medium transition-all"
+        :class="
+          activeFilters.has(entry.label.toLowerCase())
+            ? 'ring-2 ring-blue-400 ' + colorForLabel(entry.label)
+            : colorForLabel(entry.label) + ' opacity-70 hover:opacity-100'
+        "
+        @click="toggleFilter(entry.label)"
+      >
+        {{ entry.label }}
+        <span class="opacity-60">{{ entry.count }}</span>
+      </button>
+      <button
+        v-if="activeFilters.size > 0"
+        class="ml-auto text-[11px] text-gray-500 hover:text-gray-700"
+        title="Clear label filters"
+        @click="clearFilters"
+      >
+        Clear ✕
+      </button>
+    </div>
+
+    <!-- Error banner -->
+    <div
+      v-if="error"
+      class="px-4 py-2 text-xs text-red-600 bg-red-50 border-b border-red-100 shrink-0"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Body -->
+    <div class="flex-1 min-h-0">
+      <div
+        v-if="items.length === 0"
+        class="h-full flex items-center justify-center text-gray-400 text-sm"
+      >
+        No todo items yet. Click "+ Add" to create one.
+      </div>
+      <template v-else>
+        <TodoKanbanView
+          v-if="viewMode === 'kanban'"
+          :filtered-items="filteredItems"
+          :columns="columns"
+          @move="onMove"
+          @open="onOpenItem"
+          @toggle-complete="onToggleComplete"
+          @quick-add="quickAddInColumn"
+          @rename-column="onRenameColumn"
+          @delete-column="onDeleteColumn"
+          @mark-done="onMarkDone"
+        />
+        <TodoTableView
+          v-else-if="viewMode === 'table'"
+          :filtered-items="filteredItems"
+          :columns="columns"
+          @patch="onPatchItem"
+          @delete="onDeleteItem"
+          @toggle-complete="onToggleComplete"
+        />
+        <TodoListView
+          v-else
+          :filtered-items="filteredItems"
+          :columns="columns"
+          @patch="onPatchItem"
+          @delete="onDeleteItem"
+          @toggle-complete="onToggleComplete"
+        />
+      </template>
+    </div>
+
+    <!-- Add item dialog -->
+    <TodoAddDialog
+      v-if="addOpen"
+      :columns="columns"
+      :default-status="addDefaultStatus"
+      @cancel="addOpen = false"
+      @create="onCreateItem"
+    />
+
+    <!-- Add column dialog -->
+    <div
+      v-if="addColumnOpen"
+      class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center"
+      @click="addColumnOpen = false"
+    >
+      <div class="bg-white rounded-lg shadow-xl w-80 p-5 space-y-3" @click.stop>
+        <h3 class="text-base font-semibold text-gray-800">Add Column</h3>
+        <label class="block text-xs text-gray-600">
+          Label
+          <input
+            v-model="newColumnLabel"
+            type="text"
+            placeholder="Review"
+            class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+            @keydown.enter="commitNewColumn"
+          />
+        </label>
+        <div class="flex justify-end gap-2 pt-1">
+          <button
+            class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+            @click="addColumnOpen = false"
+          >
+            Cancel
+          </button>
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+            @click="commitNewColumn"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type { TodoData, TodoItem } from "../plugins/todo/index";
+import {
+  colorForLabel,
+  filterByLabels,
+  listLabelsWithCount,
+} from "../plugins/todo/labels";
+import {
+  useTodos,
+  type CreateItemInput,
+  type PatchItemInput,
+} from "../plugins/todo/composables/useTodos";
+import TodoKanbanView from "./todo/TodoKanbanView.vue";
+import TodoTableView from "./todo/TodoTableView.vue";
+import TodoListView from "./todo/TodoListView.vue";
+import TodoAddDialog from "./todo/TodoAddDialog.vue";
+
+type ViewMode = "kanban" | "table" | "list";
+
+interface ViewModeOption {
+  key: ViewMode;
+  label: string;
+  icon: string;
+}
+
+const VIEW_MODES: ViewModeOption[] = [
+  { key: "kanban", label: "Kanban", icon: "view_kanban" },
+  { key: "table", label: "Table", icon: "table_rows" },
+  { key: "list", label: "List", icon: "view_list" },
+];
+
+const VIEW_MODE_KEY = "todo_explorer_view_mode";
+
+const props = defineProps<{
+  selectedResult: ToolResultComplete<TodoData>;
+}>();
+
+const {
+  items,
+  columns,
+  error,
+  refresh,
+  createItem,
+  patchItem,
+  moveItem,
+  deleteItem,
+  addColumn,
+  patchColumn,
+  deleteColumn,
+} = useTodos(
+  props.selectedResult.data?.items ?? [],
+  props.selectedResult.data?.columns ?? [],
+);
+
+// When the parent swaps in a different tool result, reseed the local
+// state and re-fetch from the server. Watching the uuid (not items)
+// so empty-result swaps still trigger.
+watch(
+  () => props.selectedResult.uuid,
+  () => {
+    items.value = props.selectedResult.data?.items ?? [];
+    columns.value = props.selectedResult.data?.columns ?? [];
+    void refresh();
+  },
+);
+
+// ── View mode (persisted in localStorage) ───────────────────────
+
+const viewMode = ref<ViewMode>(loadViewMode());
+
+function loadViewMode(): ViewMode {
+  const stored = localStorage.getItem(VIEW_MODE_KEY);
+  if (stored === "kanban" || stored === "table" || stored === "list") {
+    return stored;
+  }
+  return "kanban";
+}
+
+function setViewMode(next: ViewMode): void {
+  viewMode.value = next;
+  localStorage.setItem(VIEW_MODE_KEY, next);
+}
+
+// ── Filtering ──────────────────────────────────────────────────
+
+const search = ref("");
+const activeFilters = ref<Set<string>>(new Set());
+
+const labelInventory = computed(() => listLabelsWithCount(items.value));
+
+function toggleFilter(label: string): void {
+  const key = label.toLowerCase();
+  const next = new Set(activeFilters.value);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  activeFilters.value = next;
+}
+
+function clearFilters(): void {
+  activeFilters.value = new Set();
+}
+
+const filteredItems = computed(() => {
+  const byLabels = filterByLabels(items.value, [...activeFilters.value]);
+  const q = search.value.trim().toLowerCase();
+  if (q.length === 0) return byLabels;
+  return byLabels.filter((item) => {
+    if (item.text.toLowerCase().includes(q)) return true;
+    if (item.note?.toLowerCase().includes(q)) return true;
+    return false;
+  });
+});
+
+const completedCount = computed(
+  () => items.value.filter((i) => i.completed).length,
+);
+
+// ── Add dialog ─────────────────────────────────────────────────
+
+const addOpen = ref(false);
+const addDefaultStatus = ref<string | undefined>(undefined);
+
+function quickAddInColumn(statusId: string): void {
+  addDefaultStatus.value = statusId;
+  addOpen.value = true;
+}
+
+async function onCreateItem(input: CreateItemInput): Promise<void> {
+  const ok = await createItem(input);
+  if (ok) {
+    addOpen.value = false;
+    addDefaultStatus.value = undefined;
+  }
+}
+
+// ── Add column dialog ──────────────────────────────────────────
+
+const addColumnOpen = ref(false);
+const newColumnLabel = ref("");
+
+async function commitNewColumn(): Promise<void> {
+  const label = newColumnLabel.value.trim();
+  if (label.length === 0) return;
+  const ok = await addColumn({ label });
+  if (ok) {
+    addColumnOpen.value = false;
+    newColumnLabel.value = "";
+  }
+}
+
+// ── Item handlers ──────────────────────────────────────────────
+
+function onPatchItem(id: string, input: PatchItemInput): void {
+  void patchItem(id, input);
+}
+
+function onDeleteItem(id: string): void {
+  void deleteItem(id);
+}
+
+function onToggleComplete(item: TodoItem): void {
+  void patchItem(item.id, { completed: !item.completed });
+}
+
+function onMove(id: string, statusId: string, position: number): void {
+  void moveItem(id, { status: statusId, position });
+}
+
+function onOpenItem(_item: TodoItem): void {
+  // Kanban click: switch to list/table view to expose the inline
+  // editor. Without this, kanban becomes drag-only and there's no
+  // way to edit a card's text. Picks list because it's the gentlest
+  // visual jump from a card grid.
+  setViewMode("list");
+}
+
+// ── Column handlers ────────────────────────────────────────────
+
+function onRenameColumn(id: string, label: string): void {
+  void patchColumn(id, { label });
+}
+
+function onDeleteColumn(id: string): void {
+  // Use a native confirm dialog: deleting a column reassigns its
+  // items, which is reversible but worth a beat. The other column
+  // operations (rename, mark-done) are inexpensive enough not to need
+  // confirmation.
+  const col = columns.value.find((c) => c.id === id);
+  if (!col) return;
+  const ok = window.confirm(
+    `Delete column "${col.label}"? Items in this column will be moved to another column.`,
+  );
+  if (!ok) return;
+  void deleteColumn(id);
+}
+
+function onMarkDone(id: string): void {
+  void patchColumn(id, { isDone: true });
+}
+</script>

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -141,6 +141,17 @@
       @create="onCreateItem"
     />
 
+    <!-- Edit item dialog (used by kanban click; list/table use the
+         inline edit panel and don't need to open this) -->
+    <TodoEditDialog
+      v-if="editingItem"
+      :item="editingItem"
+      :columns="columns"
+      @cancel="editingItem = null"
+      @save="onEditDialogSave"
+      @delete="onEditDialogDelete"
+    />
+
     <!-- Add column dialog -->
     <div
       v-if="addColumnOpen"
@@ -196,6 +207,7 @@ import TodoKanbanView from "./todo/TodoKanbanView.vue";
 import TodoTableView from "./todo/TodoTableView.vue";
 import TodoListView from "./todo/TodoListView.vue";
 import TodoAddDialog from "./todo/TodoAddDialog.vue";
+import TodoEditDialog from "./todo/TodoEditDialog.vue";
 
 type ViewMode = "kanban" | "table" | "list";
 
@@ -348,12 +360,26 @@ function onMove(id: string, statusId: string, position: number): void {
   void moveItem(id, { status: statusId, position });
 }
 
-function onOpenItem(_item: TodoItem): void {
-  // Kanban click: switch to list/table view to expose the inline
-  // editor. Without this, kanban becomes drag-only and there's no
-  // way to edit a card's text. Picks list because it's the gentlest
-  // visual jump from a card grid.
-  setViewMode("list");
+// ── Edit dialog (kanban click) ─────────────────────────────────
+
+const editingItem = ref<TodoItem | null>(null);
+
+function onOpenItem(item: TodoItem): void {
+  // Kanban cards open the modal edit dialog. List and Table views
+  // have their own inline edit panels and don't go through here.
+  editingItem.value = item;
+}
+
+async function onEditDialogSave(input: PatchItemInput): Promise<void> {
+  const target = editingItem.value;
+  if (!target) return;
+  const ok = await patchItem(target.id, input);
+  if (ok) editingItem.value = null;
+}
+
+function onEditDialogDelete(id: string): void {
+  void deleteItem(id);
+  editingItem.value = null;
 }
 
 // ── Column handlers ────────────────────────────────────────────

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -112,6 +112,7 @@
           @rename-column="onRenameColumn"
           @delete-column="onDeleteColumn"
           @mark-done="onMarkDone"
+          @reorder-columns="onReorderColumns"
         />
         <TodoTableView
           v-else-if="viewMode === 'table'"
@@ -241,6 +242,7 @@ const {
   addColumn,
   patchColumn,
   deleteColumn,
+  reorderColumns,
 } = useTodos(
   props.selectedResult.data?.items ?? [],
   props.selectedResult.data?.columns ?? [],
@@ -348,8 +350,21 @@ function onPatchItem(id: string, input: PatchItemInput): void {
   void patchItem(id, input);
 }
 
-function onDeleteItem(id: string): void {
+// Single confirm gate for every item deletion path: row "✕" buttons
+// in list/table, the kanban edit dialog's delete button, anything
+// else that wants to remove an item. Centralised so we never
+// accidentally bypass the confirm in a future caller.
+function confirmAndDelete(id: string): boolean {
+  const item = items.value.find((i) => i.id === id);
+  if (!item) return false;
+  const ok = window.confirm(`Delete "${item.text}"?`);
+  if (!ok) return false;
   void deleteItem(id);
+  return true;
+}
+
+function onDeleteItem(id: string): void {
+  confirmAndDelete(id);
 }
 
 function onToggleComplete(item: TodoItem): void {
@@ -378,8 +393,10 @@ async function onEditDialogSave(input: PatchItemInput): Promise<void> {
 }
 
 function onEditDialogDelete(id: string): void {
-  void deleteItem(id);
-  editingItem.value = null;
+  // Funnel through the same confirm gate as the inline ✕ buttons.
+  // The dialog only closes if the user confirmed; if they cancelled
+  // the confirm, the dialog stays open so they can keep editing.
+  if (confirmAndDelete(id)) editingItem.value = null;
 }
 
 // ── Column handlers ────────────────────────────────────────────
@@ -404,5 +421,9 @@ function onDeleteColumn(id: string): void {
 
 function onMarkDone(id: string): void {
   void patchColumn(id, { isDone: true });
+}
+
+function onReorderColumns(ids: string[]): void {
+  void reorderColumns(ids);
 }
 </script>

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -159,8 +159,19 @@
       class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center"
       @click="addColumnOpen = false"
     >
-      <div class="bg-white rounded-lg shadow-xl w-80 p-5 space-y-3" @click.stop>
-        <h3 class="text-base font-semibold text-gray-800">Add Column</h3>
+      <div
+        class="bg-white rounded-lg shadow-xl w-80 p-5 space-y-3"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="todo-add-column-title"
+        @click.stop
+      >
+        <h3
+          id="todo-add-column-title"
+          class="text-base font-semibold text-gray-800"
+        >
+          Add Column
+        </h3>
         <label class="block text-xs text-gray-600">
           Label
           <input
@@ -191,7 +202,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem } from "../plugins/todo/index";
 import {
@@ -343,6 +354,18 @@ async function commitNewColumn(): Promise<void> {
     newColumnLabel.value = "";
   }
 }
+
+// Escape closes the inline add-column dialog. The Add and Edit
+// dialogs handle their own Escape via document listeners; this one
+// is owned by the explorer template directly so it lives here.
+function onExplorerKeydown(event: KeyboardEvent): void {
+  if (event.key !== "Escape") return;
+  if (addColumnOpen.value) {
+    addColumnOpen.value = false;
+  }
+}
+onMounted(() => document.addEventListener("keydown", onExplorerKeydown));
+onUnmounted(() => document.removeEventListener("keydown", onExplorerKeydown));
 
 // ── Item handlers ──────────────────────────────────────────────
 

--- a/src/components/todo/TodoAddDialog.vue
+++ b/src/components/todo/TodoAddDialog.vue
@@ -1,0 +1,134 @@
+<template>
+  <div
+    class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center"
+    @click="emit('cancel')"
+  >
+    <div
+      class="bg-white rounded-lg shadow-xl w-96 max-w-[90vw] p-5 space-y-3"
+      @click.stop
+    >
+      <h3 class="text-base font-semibold text-gray-800">Add Todo</h3>
+      <label class="block text-xs text-gray-600">
+        Text
+        <input
+          ref="textInput"
+          v-model="text"
+          type="text"
+          placeholder="What needs doing?"
+          class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          @keydown.enter="submit"
+        />
+      </label>
+      <label class="block text-xs text-gray-600">
+        Note
+        <textarea
+          v-model="note"
+          rows="2"
+          class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+        />
+      </label>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="block text-xs text-gray-600">
+          Status
+          <select
+            v-model="status"
+            class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          >
+            <option v-for="col in columns" :key="col.id" :value="col.id">
+              {{ col.label }}
+            </option>
+          </select>
+        </label>
+        <label class="block text-xs text-gray-600">
+          Priority
+          <select
+            v-model="priority"
+            class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          >
+            <option value="">— None —</option>
+            <option v-for="p in PRIORITIES" :key="p" :value="p">
+              {{ PRIORITY_LABELS[p] }}
+            </option>
+          </select>
+        </label>
+        <label class="block text-xs text-gray-600">
+          Due date
+          <input
+            v-model="dueDate"
+            type="date"
+            class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          />
+        </label>
+        <label class="block text-xs text-gray-600">
+          Labels
+          <input
+            v-model="labelsText"
+            type="text"
+            placeholder="work, urgent"
+            class="mt-1 w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          />
+        </label>
+      </div>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          @click="emit('cancel')"
+        >
+          Cancel
+        </button>
+        <button
+          class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+          @click="submit"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import type { StatusColumn } from "../../plugins/todo/index";
+import { PRIORITIES, PRIORITY_LABELS } from "../../plugins/todo/priority";
+import type { CreateItemInput } from "../../plugins/todo/composables/useTodos";
+
+const props = defineProps<{
+  columns: StatusColumn[];
+  defaultStatus?: string;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  create: [input: CreateItemInput];
+}>();
+
+const text = ref("");
+const note = ref("");
+const status = ref<string>(props.defaultStatus ?? props.columns[0]?.id ?? "");
+const priority = ref<string>("");
+const dueDate = ref("");
+const labelsText = ref("");
+
+const textInput = ref<HTMLInputElement | null>(null);
+
+onMounted(() => {
+  textInput.value?.focus();
+});
+
+function submit(): void {
+  const trimmed = text.value.trim();
+  if (trimmed.length === 0) return;
+  const input: CreateItemInput = { text: trimmed };
+  if (note.value !== "") input.note = note.value;
+  if (status.value !== "") input.status = status.value;
+  if (priority.value !== "") input.priority = priority.value;
+  if (dueDate.value !== "") input.dueDate = dueDate.value;
+  const labels = labelsText.value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (labels.length > 0) input.labels = labels;
+  emit("create", input);
+}
+</script>

--- a/src/components/todo/TodoAddDialog.vue
+++ b/src/components/todo/TodoAddDialog.vue
@@ -5,9 +5,17 @@
   >
     <div
       class="bg-white rounded-lg shadow-xl w-96 max-w-[90vw] p-5 space-y-3"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="todo-add-dialog-title"
       @click.stop
     >
-      <h3 class="text-base font-semibold text-gray-800">Add Todo</h3>
+      <h3
+        id="todo-add-dialog-title"
+        class="text-base font-semibold text-gray-800"
+      >
+        Add Todo
+      </h3>
       <label class="block text-xs text-gray-600">
         Text
         <input
@@ -88,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import type { StatusColumn } from "../../plugins/todo/index";
 import { PRIORITIES, PRIORITY_LABELS } from "../../plugins/todo/priority";
 import type { CreateItemInput } from "../../plugins/todo/composables/useTodos";
@@ -112,8 +120,21 @@ const labelsText = ref("");
 
 const textInput = ref<HTMLInputElement | null>(null);
 
+// Escape closes the dialog. Bound at the document level rather than
+// on the modal div so it works no matter where focus is — Vue's
+// `@keydown.esc` only fires when the modal owns focus, which it
+// loses as soon as the user tabs into one of the form inputs.
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === "Escape") emit("cancel");
+}
+
 onMounted(() => {
   textInput.value?.focus();
+  document.addEventListener("keydown", onKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", onKeydown);
 });
 
 function submit(): void {

--- a/src/components/todo/TodoEditDialog.vue
+++ b/src/components/todo/TodoEditDialog.vue
@@ -1,0 +1,55 @@
+<template>
+  <div
+    class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center"
+    @click="emit('cancel')"
+  >
+    <div
+      class="bg-white rounded-lg shadow-xl w-[28rem] max-w-[92vw] overflow-hidden"
+      @click.stop
+    >
+      <div
+        class="flex items-center justify-between px-4 py-2 border-b border-gray-100"
+      >
+        <h3 class="text-base font-semibold text-gray-800">Edit Todo</h3>
+        <button
+          class="text-gray-400 hover:text-red-500 text-xs px-2 py-0.5"
+          title="Delete this item"
+          @click="confirmDelete"
+        >
+          Delete
+        </button>
+      </div>
+      <TodoEditPanel
+        :item="item"
+        :columns="columns"
+        @save="(input) => emit('save', input)"
+        @cancel="emit('cancel')"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
+import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
+import TodoEditPanel from "./TodoEditPanel.vue";
+
+const props = defineProps<{
+  item: TodoItem;
+  columns: StatusColumn[];
+}>();
+
+const emit = defineEmits<{
+  save: [input: PatchItemInput];
+  cancel: [];
+  delete: [id: string];
+}>();
+
+function confirmDelete(): void {
+  // Same UX as the column delete: native confirm because deletion is
+  // reversible (the next save would re-create) but worth a beat.
+  const ok = window.confirm(`Delete "${props.item.text}"?`);
+  if (!ok) return;
+  emit("delete", props.item.id);
+}
+</script>

--- a/src/components/todo/TodoEditDialog.vue
+++ b/src/components/todo/TodoEditDialog.vue
@@ -5,12 +5,20 @@
   >
     <div
       class="bg-white rounded-lg shadow-xl w-[28rem] max-w-[92vw] overflow-hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="todo-edit-dialog-title"
       @click.stop
     >
       <div
         class="flex items-center justify-between px-4 py-2 border-b border-gray-100"
       >
-        <h3 class="text-base font-semibold text-gray-800">Edit Todo</h3>
+        <h3
+          id="todo-edit-dialog-title"
+          class="text-base font-semibold text-gray-800"
+        >
+          Edit Todo
+        </h3>
         <button
           class="text-gray-400 hover:text-red-500 text-xs px-2 py-0.5"
           title="Delete this item"
@@ -30,6 +38,7 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
 import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
 import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
 import TodoEditPanel from "./TodoEditPanel.vue";
@@ -47,4 +56,13 @@ const emit = defineEmits<{
 // The parent (TodoExplorer) gates deletion behind a single confirm
 // helper, so this dialog just emits the delete intent and lets the
 // caller decide whether to actually remove the item.
+
+// Escape closes the dialog. Document-level listener so it works even
+// when focus is inside the form (Vue's @keydown.esc only fires on
+// the element that owns focus).
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === "Escape") emit("cancel");
+}
+onMounted(() => document.addEventListener("keydown", onKeydown));
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>

--- a/src/components/todo/TodoEditDialog.vue
+++ b/src/components/todo/TodoEditDialog.vue
@@ -14,7 +14,7 @@
         <button
           class="text-gray-400 hover:text-red-500 text-xs px-2 py-0.5"
           title="Delete this item"
-          @click="confirmDelete"
+          @click="emit('delete', item.id)"
         >
           Delete
         </button>
@@ -34,7 +34,7 @@ import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
 import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
 import TodoEditPanel from "./TodoEditPanel.vue";
 
-const props = defineProps<{
+defineProps<{
   item: TodoItem;
   columns: StatusColumn[];
 }>();
@@ -44,12 +44,7 @@ const emit = defineEmits<{
   cancel: [];
   delete: [id: string];
 }>();
-
-function confirmDelete(): void {
-  // Same UX as the column delete: native confirm because deletion is
-  // reversible (the next save would re-create) but worth a beat.
-  const ok = window.confirm(`Delete "${props.item.text}"?`);
-  if (!ok) return;
-  emit("delete", props.item.id);
-}
+// The parent (TodoExplorer) gates deletion behind a single confirm
+// helper, so this dialog just emits the delete intent and lets the
+// caller decide whether to actually remove the item.
 </script>

--- a/src/components/todo/TodoEditPanel.vue
+++ b/src/components/todo/TodoEditPanel.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <label class="block text-xs text-gray-600 sm:col-span-2">
+        Text
+        <input
+          v-model="text"
+          type="text"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded focus:outline-none focus:border-blue-500"
+        />
+      </label>
+      <label class="block text-xs text-gray-600 sm:col-span-2">
+        Note
+        <textarea
+          v-model="note"
+          rows="2"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded resize-y focus:outline-none focus:border-blue-500"
+        />
+      </label>
+      <label class="block text-xs text-gray-600">
+        Status
+        <select
+          v-model="status"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded focus:outline-none focus:border-blue-500"
+        >
+          <option v-for="col in columns" :key="col.id" :value="col.id">
+            {{ col.label }}
+          </option>
+        </select>
+      </label>
+      <label class="block text-xs text-gray-600">
+        Priority
+        <select
+          v-model="priority"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded focus:outline-none focus:border-blue-500"
+        >
+          <option value="">— None —</option>
+          <option v-for="p in PRIORITIES" :key="p" :value="p">
+            {{ PRIORITY_LABELS[p] }}
+          </option>
+        </select>
+      </label>
+      <label class="block text-xs text-gray-600">
+        Due date
+        <input
+          v-model="dueDate"
+          type="date"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded focus:outline-none focus:border-blue-500"
+        />
+      </label>
+      <label class="block text-xs text-gray-600">
+        Labels (comma-separated)
+        <input
+          v-model="labelsText"
+          type="text"
+          placeholder="work, urgent"
+          class="mt-1 w-full px-2 py-1.5 text-sm bg-white border border-blue-300 rounded focus:outline-none focus:border-blue-500"
+        />
+      </label>
+    </div>
+    <div class="flex items-center gap-2 pt-1">
+      <button
+        class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+        @click="save"
+      >
+        Save
+      </button>
+      <button
+        class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+        @click="emit('cancel')"
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type {
+  StatusColumn,
+  TodoItem,
+  TodoPriority,
+} from "../../plugins/todo/index";
+import { PRIORITIES, PRIORITY_LABELS } from "../../plugins/todo/priority";
+import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
+
+const props = defineProps<{
+  item: TodoItem;
+  columns: StatusColumn[];
+}>();
+
+const emit = defineEmits<{
+  save: [input: PatchItemInput];
+  cancel: [];
+}>();
+
+const text = ref(props.item.text);
+const note = ref(props.item.note ?? "");
+const status = ref<string>(props.item.status ?? props.columns[0]?.id ?? "");
+const priority = ref<string>(props.item.priority ?? "");
+const dueDate = ref(props.item.dueDate ?? "");
+const labelsText = ref((props.item.labels ?? []).join(", "));
+
+function parseLabels(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function save(): void {
+  const input: PatchItemInput = {
+    text: text.value,
+    note: note.value === "" ? null : note.value,
+    status: status.value,
+    labels: parseLabels(labelsText.value),
+  };
+  // Priority: empty string clears, valid priority sets, anything else
+  // is silently ignored (the dropdown ensures we never send garbage).
+  if (priority.value === "") {
+    input.priority = null;
+  } else {
+    input.priority = priority.value as TodoPriority;
+  }
+  if (dueDate.value === "") {
+    input.dueDate = null;
+  } else {
+    input.dueDate = dueDate.value;
+  }
+  emit("save", input);
+}
+</script>

--- a/src/components/todo/TodoKanbanView.vue
+++ b/src/components/todo/TodoKanbanView.vue
@@ -1,0 +1,276 @@
+<template>
+  <div class="h-full overflow-x-auto overflow-y-hidden">
+    <div class="flex gap-3 h-full p-3 min-w-max">
+      <div
+        v-for="col in columns"
+        :key="col.id"
+        class="w-72 shrink-0 flex flex-col bg-gray-100 rounded-lg"
+      >
+        <!-- Column header -->
+        <div
+          class="flex items-center justify-between px-3 py-2 border-b border-gray-200"
+        >
+          <div class="flex items-center gap-2 min-w-0">
+            <span
+              class="w-2 h-2 rounded-full shrink-0"
+              :class="col.isDone ? 'bg-green-500' : 'bg-gray-400'"
+            />
+            <span
+              v-if="renamingId !== col.id"
+              class="font-semibold text-sm text-gray-700 truncate"
+              :title="col.label"
+              >{{ col.label }}</span
+            >
+            <input
+              v-else
+              ref="renameInput"
+              v-model="renameDraft"
+              class="px-1 py-0.5 text-sm bg-white border border-blue-400 rounded w-32"
+              @keydown.enter="commitRename(col.id)"
+              @keydown.escape="renamingId = null"
+              @blur="commitRename(col.id)"
+            />
+            <span class="text-xs text-gray-500 shrink-0">{{
+              itemsByColumn(col.id).length
+            }}</span>
+          </div>
+          <div class="relative">
+            <button
+              class="text-gray-400 hover:text-gray-600 px-1"
+              title="Column actions"
+              @click="toggleMenu(col.id)"
+            >
+              <span class="material-icons text-base">more_horiz</span>
+            </button>
+            <div
+              v-if="menuOpenId === col.id"
+              class="absolute right-0 top-6 z-20 bg-white border border-gray-200 rounded shadow-md text-xs w-40 py-1"
+              @click.stop
+            >
+              <button
+                class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
+                @click="startRename(col)"
+              >
+                Rename
+              </button>
+              <button
+                class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
+                @click="markAsDone(col.id)"
+              >
+                {{ col.isDone ? "Already done column" : "Mark as done column" }}
+              </button>
+              <button
+                class="w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50"
+                @click="deleteColumn(col.id)"
+              >
+                Delete column
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Cards -->
+        <draggable
+          :model-value="itemsByColumn(col.id)"
+          item-key="id"
+          group="todos"
+          class="flex-1 overflow-y-auto p-2 space-y-2 min-h-[2rem]"
+          :animation="150"
+          @change="(e: DragChangeEvent) => onDragChange(col.id, e)"
+        >
+          <template #item="{ element }: { element: TodoItem }">
+            <div
+              class="bg-white border border-l-4 border-gray-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing"
+              :class="
+                element.priority
+                  ? PRIORITY_BORDER[element.priority]
+                  : 'border-l-gray-200'
+              "
+              @click="emit('open', element)"
+            >
+              <div class="flex items-start gap-2">
+                <input
+                  type="checkbox"
+                  :checked="element.completed"
+                  class="mt-0.5 cursor-pointer shrink-0"
+                  @click.stop
+                  @change="emit('toggleComplete', element)"
+                />
+                <div class="flex-1 min-w-0">
+                  <div
+                    class="text-sm"
+                    :class="
+                      element.completed
+                        ? 'line-through text-gray-400'
+                        : 'text-gray-800'
+                    "
+                  >
+                    {{ element.text }}
+                  </div>
+                  <div
+                    v-if="element.note"
+                    class="text-[11px] text-gray-400 mt-0.5 line-clamp-2"
+                  >
+                    {{ element.note }}
+                  </div>
+                  <div
+                    v-if="
+                      (element.labels && element.labels.length > 0) ||
+                      element.priority ||
+                      element.dueDate
+                    "
+                    class="flex flex-wrap gap-1 mt-1.5"
+                  >
+                    <span
+                      v-if="element.priority"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                      :class="PRIORITY_CLASSES[element.priority]"
+                      >{{ PRIORITY_LABELS[element.priority] }}</span
+                    >
+                    <span
+                      v-if="element.dueDate"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                      :class="dueDateClasses(element.dueDate)"
+                      >{{ formatDueLabel(element.dueDate) }}</span
+                    >
+                    <span
+                      v-for="label in element.labels ?? []"
+                      :key="label"
+                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                      :class="colorForLabel(label)"
+                      >{{ label }}</span
+                    >
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </draggable>
+
+        <!-- Add card stub -->
+        <button
+          class="m-2 text-xs text-gray-500 hover:text-gray-800 hover:bg-gray-200 rounded py-1.5 transition-colors"
+          @click="emit('quickAdd', col.id)"
+        >
+          + Add card
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref } from "vue";
+import draggable from "vuedraggable";
+import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
+import { colorForLabel } from "../../plugins/todo/labels";
+import {
+  PRIORITY_BORDER,
+  PRIORITY_CLASSES,
+  PRIORITY_LABELS,
+  dueDateClasses,
+  formatDueLabel,
+} from "../../plugins/todo/priority";
+
+// vuedraggable @change event shape. The library emits one of these
+// three keys depending on whether the move was within the same list,
+// added from another list, or removed from the current list. We only
+// react to "added" (the destination column) and "moved" (reorder
+// within a single column) — "removed" is the source side and is
+// always paired with an "added" on the destination, so handling it
+// would double the API calls.
+interface DragChangeEvent {
+  added?: { newIndex: number; element: TodoItem };
+  moved?: { newIndex: number; oldIndex: number; element: TodoItem };
+  removed?: { oldIndex: number; element: TodoItem };
+}
+
+const props = defineProps<{
+  filteredItems: TodoItem[];
+  columns: StatusColumn[];
+}>();
+
+const emit = defineEmits<{
+  move: [id: string, statusId: string, position: number];
+  open: [item: TodoItem];
+  toggleComplete: [item: TodoItem];
+  quickAdd: [statusId: string];
+  renameColumn: [id: string, label: string];
+  deleteColumn: [id: string];
+  markDone: [id: string];
+}>();
+
+// Group filtered items by status, sorted by `order`. Computed so the
+// kanban re-derives whenever items / filter changes.
+const itemsByStatus = computed(() => {
+  const map = new Map<string, TodoItem[]>();
+  for (const col of props.columns) map.set(col.id, []);
+  for (const item of props.filteredItems) {
+    const id = item.status ?? props.columns[0]?.id;
+    if (!id) continue;
+    if (!map.has(id)) map.set(id, []);
+    map.get(id)!.push(item);
+  }
+  for (const list of map.values()) {
+    list.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  }
+  return map;
+});
+
+function itemsByColumn(id: string): TodoItem[] {
+  return itemsByStatus.value.get(id) ?? [];
+}
+
+function onDragChange(columnId: string, event: DragChangeEvent): void {
+  if (event.added) {
+    emit("move", event.added.element.id, columnId, event.added.newIndex);
+    return;
+  }
+  if (event.moved) {
+    emit("move", event.moved.element.id, columnId, event.moved.newIndex);
+  }
+}
+
+// ── Column menu / rename ─────────────────────────────────────────
+
+const menuOpenId = ref<string | null>(null);
+const renamingId = ref<string | null>(null);
+const renameDraft = ref("");
+const renameInput = ref<HTMLInputElement[] | HTMLInputElement | null>(null);
+
+function toggleMenu(id: string): void {
+  menuOpenId.value = menuOpenId.value === id ? null : id;
+}
+
+function startRename(col: StatusColumn): void {
+  menuOpenId.value = null;
+  renamingId.value = col.id;
+  renameDraft.value = col.label;
+  void nextTick(() => {
+    const ref = renameInput.value;
+    const el = Array.isArray(ref) ? ref[0] : ref;
+    el?.focus();
+    el?.select();
+  });
+}
+
+function commitRename(id: string): void {
+  if (renamingId.value !== id) return;
+  const next = renameDraft.value.trim();
+  renamingId.value = null;
+  if (next.length === 0) return;
+  const current = props.columns.find((c) => c.id === id);
+  if (!current || current.label === next) return;
+  emit("renameColumn", id, next);
+}
+
+function deleteColumn(id: string): void {
+  menuOpenId.value = null;
+  emit("deleteColumn", id);
+}
+
+function markAsDone(id: string): void {
+  menuOpenId.value = null;
+  emit("markDone", id);
+}
+</script>

--- a/src/components/todo/TodoKanbanView.vue
+++ b/src/components/todo/TodoKanbanView.vue
@@ -1,166 +1,178 @@
 <template>
   <div class="h-full overflow-x-auto overflow-y-hidden">
-    <div class="flex gap-3 h-full p-3 min-w-max">
-      <div
-        v-for="col in columns"
-        :key="col.id"
-        class="w-72 shrink-0 flex flex-col bg-gray-100 rounded-lg"
-      >
-        <!-- Column header -->
-        <div
-          class="flex items-center justify-between px-3 py-2 border-b border-gray-200"
-        >
-          <div class="flex items-center gap-2 min-w-0">
-            <span
-              class="w-2 h-2 rounded-full shrink-0"
-              :class="col.isDone ? 'bg-green-500' : 'bg-gray-400'"
-            />
-            <span
-              v-if="renamingId !== col.id"
-              class="font-semibold text-sm text-gray-700 truncate"
-              :title="col.label"
-              >{{ col.label }}</span
-            >
-            <input
-              v-else
-              ref="renameInput"
-              v-model="renameDraft"
-              class="px-1 py-0.5 text-sm bg-white border border-blue-400 rounded w-32"
-              @keydown.enter="commitRename(col.id)"
-              @keydown.escape="renamingId = null"
-              @blur="commitRename(col.id)"
-            />
-            <span class="text-xs text-gray-500 shrink-0">{{
-              itemsByColumn(col.id).length
-            }}</span>
-          </div>
-          <div class="relative">
-            <button
-              class="text-gray-400 hover:text-gray-600 px-1"
-              title="Column actions"
-              @click="toggleMenu(col.id)"
-            >
-              <span class="material-icons text-base">more_horiz</span>
-            </button>
-            <div
-              v-if="menuOpenId === col.id"
-              class="absolute right-0 top-6 z-20 bg-white border border-gray-200 rounded shadow-md text-xs w-40 py-1"
-              @click.stop
-            >
-              <button
-                class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
-                @click="startRename(col)"
+    <draggable
+      :list="columnsLocal"
+      item-key="id"
+      group="todo-columns"
+      handle=".col-handle"
+      :animation="150"
+      class="flex gap-3 h-full p-3 min-w-max"
+      @end="onColumnDragEnd"
+    >
+      <template #item="{ element: col }: { element: StatusColumn }">
+        <div class="w-72 shrink-0 flex flex-col bg-gray-100 rounded-lg">
+          <!-- Column header. The whole header is the drag handle —
+             clicking the menu button still works because the menu
+             button has its own @click handler that doesn't kick off
+             a drag, but pressing-and-holding anywhere on the header
+             starts a column drag. -->
+          <div
+            class="flex items-center justify-between px-3 py-2 border-b border-gray-200 col-handle cursor-grab active:cursor-grabbing"
+          >
+            <div class="flex items-center gap-2 min-w-0">
+              <span
+                class="w-2 h-2 rounded-full shrink-0"
+                :class="col.isDone ? 'bg-green-500' : 'bg-gray-400'"
+              />
+              <span
+                v-if="renamingId !== col.id"
+                class="font-semibold text-sm text-gray-700 truncate"
+                :title="col.label"
+                >{{ col.label }}</span
               >
-                Rename
-              </button>
+              <input
+                v-else
+                ref="renameInput"
+                v-model="renameDraft"
+                class="px-1 py-0.5 text-sm bg-white border border-blue-400 rounded w-32"
+                @keydown.enter="commitRename(col.id)"
+                @keydown.escape="renamingId = null"
+                @blur="commitRename(col.id)"
+              />
+              <span class="text-xs text-gray-500 shrink-0">{{
+                itemsByColumn(col.id).length
+              }}</span>
+            </div>
+            <div class="relative">
               <button
-                class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
-                @click="markAsDone(col.id)"
+                class="text-gray-400 hover:text-gray-600 px-1"
+                title="Column actions"
+                @click="toggleMenu(col.id)"
               >
-                {{ col.isDone ? "Already done column" : "Mark as done column" }}
+                <span class="material-icons text-base">more_horiz</span>
               </button>
-              <button
-                class="w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50"
-                @click="deleteColumn(col.id)"
+              <div
+                v-if="menuOpenId === col.id"
+                class="absolute right-0 top-6 z-20 bg-white border border-gray-200 rounded shadow-md text-xs w-40 py-1"
+                @click.stop
               >
-                Delete column
-              </button>
+                <button
+                  class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
+                  @click="startRename(col)"
+                >
+                  Rename
+                </button>
+                <button
+                  class="w-full text-left px-3 py-1.5 hover:bg-gray-50"
+                  @click="markAsDone(col.id)"
+                >
+                  {{
+                    col.isDone ? "Already done column" : "Mark as done column"
+                  }}
+                </button>
+                <button
+                  class="w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50"
+                  @click="deleteColumn(col.id)"
+                >
+                  Delete column
+                </button>
+              </div>
             </div>
           </div>
-        </div>
 
-        <!-- Cards -->
-        <draggable
-          :model-value="itemsByColumn(col.id)"
-          item-key="id"
-          group="todos"
-          class="flex-1 overflow-y-auto p-2 space-y-2 min-h-[2rem]"
-          :animation="150"
-          @change="(e: DragChangeEvent) => onDragChange(col.id, e)"
-        >
-          <template #item="{ element }: { element: TodoItem }">
-            <div
-              class="bg-white border border-l-4 border-gray-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing"
-              :class="
-                element.priority
-                  ? PRIORITY_BORDER[element.priority]
-                  : 'border-l-gray-200'
-              "
-              @click="emit('open', element)"
-            >
-              <div class="flex items-start gap-2">
-                <input
-                  type="checkbox"
-                  :checked="element.completed"
-                  class="mt-0.5 cursor-pointer shrink-0"
-                  @click.stop
-                  @change="emit('toggleComplete', element)"
-                />
-                <div class="flex-1 min-w-0">
-                  <div
-                    class="text-sm"
-                    :class="
-                      element.completed
-                        ? 'line-through text-gray-400'
-                        : 'text-gray-800'
-                    "
-                  >
-                    {{ element.text }}
-                  </div>
-                  <div
-                    v-if="element.note"
-                    class="text-[11px] text-gray-400 mt-0.5 line-clamp-2"
-                  >
-                    {{ element.note }}
-                  </div>
-                  <div
-                    v-if="
-                      (element.labels && element.labels.length > 0) ||
-                      element.priority ||
-                      element.dueDate
-                    "
-                    class="flex flex-wrap gap-1 mt-1.5"
-                  >
-                    <span
-                      v-if="element.priority"
-                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
-                      :class="PRIORITY_CLASSES[element.priority]"
-                      >{{ PRIORITY_LABELS[element.priority] }}</span
+          <!-- Cards -->
+          <draggable
+            :model-value="itemsByColumn(col.id)"
+            item-key="id"
+            group="todos"
+            class="flex-1 overflow-y-auto p-2 space-y-2 min-h-[2rem]"
+            :animation="150"
+            @change="(e: DragChangeEvent) => onDragChange(col.id, e)"
+          >
+            <template #item="{ element }: { element: TodoItem }">
+              <div
+                class="bg-white border border-l-4 border-gray-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing"
+                :class="
+                  element.priority
+                    ? PRIORITY_BORDER[element.priority]
+                    : 'border-l-gray-200'
+                "
+                @click="emit('open', element)"
+              >
+                <div class="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    :checked="element.completed"
+                    class="mt-0.5 cursor-pointer shrink-0"
+                    @click.stop
+                    @change="emit('toggleComplete', element)"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <div
+                      class="text-sm"
+                      :class="
+                        element.completed
+                          ? 'line-through text-gray-400'
+                          : 'text-gray-800'
+                      "
                     >
-                    <span
-                      v-if="element.dueDate"
-                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
-                      :class="dueDateClasses(element.dueDate)"
-                      >{{ formatDueLabel(element.dueDate) }}</span
+                      {{ element.text }}
+                    </div>
+                    <div
+                      v-if="element.note"
+                      class="text-[11px] text-gray-400 mt-0.5 line-clamp-2"
                     >
-                    <span
-                      v-for="label in element.labels ?? []"
-                      :key="label"
-                      class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
-                      :class="colorForLabel(label)"
-                      >{{ label }}</span
+                      {{ element.note }}
+                    </div>
+                    <div
+                      v-if="
+                        (element.labels && element.labels.length > 0) ||
+                        element.priority ||
+                        element.dueDate
+                      "
+                      class="flex flex-wrap gap-1 mt-1.5"
                     >
+                      <span
+                        v-if="element.priority"
+                        class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                        :class="PRIORITY_CLASSES[element.priority]"
+                        >{{ PRIORITY_LABELS[element.priority] }}</span
+                      >
+                      <span
+                        v-if="element.dueDate"
+                        class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                        :class="dueDateClasses(element.dueDate)"
+                        >{{ formatDueLabel(element.dueDate) }}</span
+                      >
+                      <span
+                        v-for="label in element.labels ?? []"
+                        :key="label"
+                        class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                        :class="colorForLabel(label)"
+                        >{{ label }}</span
+                      >
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </template>
-        </draggable>
+            </template>
+          </draggable>
 
-        <!-- Add card stub -->
-        <button
-          class="m-2 text-xs text-gray-500 hover:text-gray-800 hover:bg-gray-200 rounded py-1.5 transition-colors"
-          @click="emit('quickAdd', col.id)"
-        >
-          + Add card
-        </button>
-      </div>
-    </div>
+          <!-- Add card stub -->
+          <button
+            class="m-2 text-xs text-gray-500 hover:text-gray-800 hover:bg-gray-200 rounded py-1.5 transition-colors"
+            @click="emit('quickAdd', col.id)"
+          >
+            + Add card
+          </button>
+        </div>
+      </template>
+    </draggable>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import draggable from "vuedraggable";
 import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
 import { colorForLabel } from "../../plugins/todo/labels";
@@ -198,7 +210,37 @@ const emit = defineEmits<{
   renameColumn: [id: string, label: string];
   deleteColumn: [id: string];
   markDone: [id: string];
+  reorderColumns: [ids: string[]];
 }>();
+
+// Local mirror of props.columns so vuedraggable can reorder it in
+// place (`:list` mode mutates the bound array). When the parent
+// updates props.columns — either after we successfully persist a
+// reorder, or because some other action changed the column set —
+// we copy the new array in. This also rolls the kanban back if the
+// API call fails: the parent's columns ref stays at the old order,
+// the watch fires, and columnsLocal snaps back.
+const columnsLocal = ref<StatusColumn[]>([...props.columns]);
+watch(
+  () => props.columns,
+  (next) => {
+    columnsLocal.value = [...next];
+  },
+);
+
+function onColumnDragEnd(): void {
+  const before = props.columns.map((c) => c.id);
+  const after = columnsLocal.value.map((c) => c.id);
+  // No-op drops: avoid an unnecessary network round-trip when the
+  // drop position equals the original.
+  if (
+    before.length === after.length &&
+    before.every((id, i) => id === after[i])
+  ) {
+    return;
+  }
+  emit("reorderColumns", after);
+}
 
 // Group filtered items by status, sorted by `order`. Computed so the
 // kanban re-derives whenever items / filter changes.

--- a/src/components/todo/TodoListView.vue
+++ b/src/components/todo/TodoListView.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="h-full overflow-y-auto p-4">
+    <div
+      v-if="filteredItems.length === 0"
+      class="h-full flex items-center justify-center text-gray-400 text-sm"
+    >
+      No items match the current filter
+    </div>
+    <ul v-else class="space-y-2 max-w-3xl mx-auto">
+      <li
+        v-for="item in filteredItems"
+        :key="item.id"
+        class="rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+      >
+        <div
+          class="flex items-center gap-3 p-3 cursor-pointer group"
+          @click="toggleExpand(item.id)"
+        >
+          <input
+            type="checkbox"
+            :checked="item.completed"
+            class="cursor-pointer shrink-0"
+            @click.stop
+            @change="toggleComplete(item)"
+          />
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span
+                class="text-sm"
+                :class="
+                  item.completed
+                    ? 'line-through text-gray-400'
+                    : 'text-gray-800'
+                "
+                >{{ item.text }}</span
+              >
+              <span
+                v-if="statusLabel(item)"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-600"
+                >{{ statusLabel(item) }}</span
+              >
+              <span
+                v-if="item.priority"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                :class="PRIORITY_CLASSES[item.priority]"
+                >{{ PRIORITY_LABELS[item.priority] }}</span
+              >
+              <span
+                v-if="item.dueDate"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                :class="dueDateClasses(item.dueDate)"
+                >{{ formatDueLabel(item.dueDate) }}</span
+              >
+              <span
+                v-for="label in item.labels ?? []"
+                :key="label"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                :class="colorForLabel(label)"
+                >{{ label }}</span
+              >
+            </div>
+            <div v-if="item.note" class="text-xs text-gray-400 mt-0.5">
+              {{ item.note }}
+            </div>
+          </div>
+          <button
+            class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 shrink-0"
+            title="Delete item"
+            @click.stop="emit('delete', item.id)"
+          >
+            ✕
+          </button>
+        </div>
+        <TodoEditPanel
+          v-if="expandedId === item.id"
+          :item="item"
+          :columns="columns"
+          @save="(input) => onSave(item.id, input)"
+          @cancel="expandedId = null"
+        />
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
+import { colorForLabel } from "../../plugins/todo/labels";
+import {
+  PRIORITY_CLASSES,
+  PRIORITY_LABELS,
+  dueDateClasses,
+  formatDueLabel,
+} from "../../plugins/todo/priority";
+import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
+import TodoEditPanel from "./TodoEditPanel.vue";
+
+const props = defineProps<{
+  filteredItems: TodoItem[];
+  columns: StatusColumn[];
+}>();
+
+const emit = defineEmits<{
+  patch: [id: string, input: PatchItemInput];
+  delete: [id: string];
+  toggleComplete: [item: TodoItem];
+}>();
+
+const expandedId = ref<string | null>(null);
+
+function toggleExpand(id: string): void {
+  expandedId.value = expandedId.value === id ? null : id;
+}
+
+function toggleComplete(item: TodoItem): void {
+  emit("toggleComplete", item);
+}
+
+function onSave(id: string, input: PatchItemInput): void {
+  emit("patch", id, input);
+  expandedId.value = null;
+}
+
+function statusLabel(item: TodoItem): string {
+  if (!item.status) return "";
+  const col = props.columns.find((c) => c.id === item.status);
+  return col?.label ?? "";
+}
+</script>

--- a/src/components/todo/TodoTableView.vue
+++ b/src/components/todo/TodoTableView.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="h-full overflow-auto">
+    <div
+      v-if="filteredItems.length === 0"
+      class="h-full flex items-center justify-center text-gray-400 text-sm"
+    >
+      No items match the current filter
+    </div>
+    <table v-else class="min-w-full text-sm">
+      <thead class="bg-gray-50 sticky top-0 z-10">
+        <tr class="text-left text-xs font-medium text-gray-500 uppercase">
+          <th
+            v-for="col in COLUMNS"
+            :key="col.key"
+            class="px-3 py-2 cursor-pointer hover:bg-gray-100 select-none"
+            @click="setSort(col.key)"
+          >
+            {{ col.label }}
+            <span
+              v-if="sortKey === col.key"
+              class="material-icons text-xs align-middle"
+              >{{ sortDir === "asc" ? "arrow_upward" : "arrow_downward" }}</span
+            >
+          </th>
+          <th class="px-3 py-2"></th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-100">
+        <template v-for="item in sortedItems" :key="item.id">
+          <tr class="hover:bg-gray-50">
+            <td class="px-3 py-2">
+              <input
+                type="checkbox"
+                :checked="item.completed"
+                @change="emit('toggleComplete', item)"
+              />
+            </td>
+            <td
+              class="px-3 py-2 max-w-md cursor-pointer"
+              @click="toggleExpand(item.id)"
+            >
+              <div
+                :class="
+                  item.completed
+                    ? 'line-through text-gray-400'
+                    : 'text-gray-800'
+                "
+              >
+                {{ item.text }}
+              </div>
+              <div
+                v-if="item.note"
+                class="text-xs text-gray-400 truncate max-w-xs"
+              >
+                {{ item.note }}
+              </div>
+            </td>
+            <td class="px-3 py-2 text-xs text-gray-600">
+              {{ statusLabel(item) }}
+            </td>
+            <td class="px-3 py-2">
+              <span
+                v-if="item.priority"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                :class="PRIORITY_CLASSES[item.priority]"
+                >{{ PRIORITY_LABELS[item.priority] }}</span
+              >
+            </td>
+            <td class="px-3 py-2">
+              <div class="flex flex-wrap gap-1">
+                <span
+                  v-for="label in item.labels ?? []"
+                  :key="label"
+                  class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                  :class="colorForLabel(label)"
+                  >{{ label }}</span
+                >
+              </div>
+            </td>
+            <td class="px-3 py-2 text-xs">
+              <span
+                v-if="item.dueDate"
+                class="px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+                :class="dueDateClasses(item.dueDate)"
+                >{{ formatDueLabel(item.dueDate) }}</span
+              >
+            </td>
+            <td class="px-3 py-2 text-xs text-gray-400">
+              {{ formatCreated(item.createdAt) }}
+            </td>
+            <td class="px-3 py-2 text-right">
+              <button
+                class="text-gray-300 hover:text-red-500 text-xs"
+                title="Delete item"
+                @click="emit('delete', item.id)"
+              >
+                ✕
+              </button>
+            </td>
+          </tr>
+          <tr v-if="expandedId === item.id">
+            <td colspan="8" class="bg-blue-50 p-0">
+              <TodoEditPanel
+                :item="item"
+                :columns="columns"
+                @save="(input) => onSave(item.id, input)"
+                @cancel="expandedId = null"
+              />
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { StatusColumn, TodoItem } from "../../plugins/todo/index";
+import { colorForLabel } from "../../plugins/todo/labels";
+import {
+  PRIORITY_CLASSES,
+  PRIORITY_LABELS,
+  PRIORITY_ORDER,
+  dueDateClasses,
+  formatDueLabel,
+} from "../../plugins/todo/priority";
+import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
+import TodoEditPanel from "./TodoEditPanel.vue";
+
+type SortKey =
+  | "completed"
+  | "text"
+  | "status"
+  | "priority"
+  | "labels"
+  | "dueDate"
+  | "createdAt";
+type SortDir = "asc" | "desc";
+
+interface ColumnDef {
+  key: SortKey;
+  label: string;
+}
+
+const COLUMNS: ColumnDef[] = [
+  { key: "completed", label: "" },
+  { key: "text", label: "Text" },
+  { key: "status", label: "Status" },
+  { key: "priority", label: "Priority" },
+  { key: "labels", label: "Labels" },
+  { key: "dueDate", label: "Due" },
+  { key: "createdAt", label: "Created" },
+];
+
+const props = defineProps<{
+  filteredItems: TodoItem[];
+  columns: StatusColumn[];
+}>();
+
+const emit = defineEmits<{
+  patch: [id: string, input: PatchItemInput];
+  delete: [id: string];
+  toggleComplete: [item: TodoItem];
+}>();
+
+const sortKey = ref<SortKey>("createdAt");
+const sortDir = ref<SortDir>("desc");
+const expandedId = ref<string | null>(null);
+
+function setSort(key: SortKey): void {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === "asc" ? "desc" : "asc";
+  } else {
+    sortKey.value = key;
+    sortDir.value = key === "createdAt" ? "desc" : "asc";
+  }
+}
+
+function toggleExpand(id: string): void {
+  expandedId.value = expandedId.value === id ? null : id;
+}
+
+function onSave(id: string, input: PatchItemInput): void {
+  emit("patch", id, input);
+  expandedId.value = null;
+}
+
+function statusLabel(item: TodoItem): string {
+  if (!item.status) return "";
+  return props.columns.find((c) => c.id === item.status)?.label ?? "";
+}
+
+function compareValues(a: unknown, b: unknown): number {
+  // Undefined sorts last regardless of direction so empty cells stay
+  // at the bottom of the list (ascending) or top (descending — flipped
+  // by the caller). This matches GitHub's "issues with no due date"
+  // ordering, which I find the least surprising.
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    return a === b ? 0 : a ? 1 : -1;
+  }
+  return String(a).localeCompare(String(b));
+}
+
+function sortValueOf(item: TodoItem, key: SortKey): unknown {
+  switch (key) {
+    case "completed":
+      return item.completed;
+    case "text":
+      return item.text.toLowerCase();
+    case "status":
+      return statusLabel(item).toLowerCase();
+    case "priority":
+      return item.priority ? PRIORITY_ORDER[item.priority] : undefined;
+    case "labels":
+      return (item.labels ?? []).join(",").toLowerCase();
+    case "dueDate":
+      return item.dueDate;
+    case "createdAt":
+      return item.createdAt;
+  }
+}
+
+const sortedItems = computed(() => {
+  const list = [...props.filteredItems];
+  list.sort((x, y) => {
+    const result = compareValues(
+      sortValueOf(x, sortKey.value),
+      sortValueOf(y, sortKey.value),
+    );
+    return sortDir.value === "asc" ? result : -result;
+  });
+  return list;
+});
+
+function formatCreated(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+</script>

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -1,0 +1,212 @@
+// Shared state + REST helpers for the file-explorer Todo views
+// (TodoExplorer.vue, TodoKanbanView.vue, TodoTableView.vue,
+// TodoListView.vue). Centralising the data layer here keeps each view
+// focused on rendering, and means there's only one place to add
+// optimistic-update / error-recovery logic.
+//
+// All mutating helpers POST/PATCH against the Web-UI REST routes added
+// in Phase 1 (server/routes/todos.ts) — the MCP `manageTodoList`
+// action route is intentionally NOT used by the explorer.
+
+import { ref, type Ref } from "vue";
+import { useFreshPluginData } from "../../../composables/useFreshPluginData";
+import type { StatusColumn, TodoItem } from "../index";
+
+interface TodosResponse {
+  data?: { items?: TodoItem[]; columns?: StatusColumn[] };
+}
+
+function isTodoItemArray(x: unknown): x is TodoItem[] {
+  return Array.isArray(x);
+}
+
+function isStatusColumnArray(x: unknown): x is StatusColumn[] {
+  return Array.isArray(x);
+}
+
+function extractItems(json: unknown): TodoItem[] | null {
+  const items = (json as TodosResponse).data?.items;
+  return isTodoItemArray(items) ? items : null;
+}
+
+function extractColumns(json: unknown): StatusColumn[] | null {
+  const cols = (json as TodosResponse).data?.columns;
+  return isStatusColumnArray(cols) ? cols : null;
+}
+
+// Apply server response (always { data: { items, columns } } for the
+// new REST routes) into the local refs. Centralised so every helper
+// uses the same parser and error guard. Returns false on a non-OK
+// status, malformed JSON, or a payload missing the items array.
+async function applyResponse(
+  response: Awaited<ReturnType<typeof fetch>>,
+  items: Ref<TodoItem[]>,
+  columns: Ref<StatusColumn[]>,
+): Promise<boolean> {
+  if (!response.ok) return false;
+  try {
+    const json: unknown = await response.json();
+    const nextItems = extractItems(json);
+    const nextColumns = extractColumns(json);
+    if (nextItems) items.value = nextItems;
+    if (nextColumns) columns.value = nextColumns;
+    return nextItems !== null;
+  } catch {
+    return false;
+  }
+}
+
+export interface UseTodosHandle {
+  items: Ref<TodoItem[]>;
+  columns: Ref<StatusColumn[]>;
+  error: Ref<string | null>;
+  refresh: () => Promise<boolean>;
+  // ── item ops ──
+  createItem: (input: CreateItemInput) => Promise<boolean>;
+  patchItem: (id: string, input: PatchItemInput) => Promise<boolean>;
+  moveItem: (id: string, input: MoveItemInput) => Promise<boolean>;
+  deleteItem: (id: string) => Promise<boolean>;
+  // ── column ops ──
+  addColumn: (input: AddColumnInput) => Promise<boolean>;
+  patchColumn: (id: string, input: PatchColumnInput) => Promise<boolean>;
+  deleteColumn: (id: string) => Promise<boolean>;
+  reorderColumns: (ids: string[]) => Promise<boolean>;
+}
+
+export interface CreateItemInput {
+  text: string;
+  note?: string;
+  status?: string;
+  priority?: string;
+  dueDate?: string;
+  labels?: string[];
+}
+
+export interface PatchItemInput {
+  text?: string;
+  note?: string | null;
+  status?: string;
+  priority?: string | null;
+  dueDate?: string | null;
+  labels?: string[];
+  completed?: boolean;
+}
+
+export interface MoveItemInput {
+  status?: string;
+  position?: number;
+}
+
+export interface AddColumnInput {
+  label: string;
+  isDone?: boolean;
+}
+
+export interface PatchColumnInput {
+  label?: string;
+  isDone?: boolean;
+}
+
+// Initial values come from the caller (e.g. the parent View receives
+// items via its `selectedResult` prop). The composable then refreshes
+// from the server on mount and updates the refs in place.
+export function useTodos(
+  initialItems: TodoItem[] = [],
+  initialColumns: StatusColumn[] = [],
+): UseTodosHandle {
+  const items = ref<TodoItem[]>(initialItems);
+  const columns = ref<StatusColumn[]>(initialColumns);
+  const error = ref<string | null>(null);
+
+  const { refresh } = useFreshPluginData<{
+    items: TodoItem[];
+    columns: StatusColumn[];
+  }>({
+    endpoint: () => "/api/todos",
+    extract: (json) => {
+      const i = extractItems(json);
+      const c = extractColumns(json);
+      if (!i) return null;
+      return { items: i, columns: c ?? [] };
+    },
+    apply: ({ items: nextItems, columns: nextColumns }) => {
+      items.value = nextItems;
+      if (nextColumns.length > 0) columns.value = nextColumns;
+    },
+  });
+
+  // Use Parameters<typeof fetch> rather than the global RequestInit
+  // type so this file doesn't depend on the DOM lib being in the
+  // ESLint globals (which it isn't outside src/composables/).
+  type FetchInit = Parameters<typeof fetch>[1];
+
+  async function call(url: string, init: FetchInit): Promise<boolean> {
+    error.value = null;
+    try {
+      const res = await fetch(url, init);
+      const ok = await applyResponse(res, items, columns);
+      if (!ok) {
+        // Try to surface a server error message if the body looks
+        // like one. Falls back to a generic message.
+        let message = `Request failed (${res.status})`;
+        try {
+          const body: unknown = await res.clone().json();
+          if (
+            typeof body === "object" &&
+            body !== null &&
+            typeof (body as { error?: unknown }).error === "string"
+          ) {
+            message = (body as { error: string }).error;
+          }
+        } catch {
+          // ignore — keep the generic message
+        }
+        error.value = message;
+      }
+      return ok;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
+  function jsonInit(method: string, body: unknown): FetchInit {
+    return {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    };
+  }
+
+  return {
+    items,
+    columns,
+    error,
+    refresh,
+    createItem: (input) => call("/api/todos/items", jsonInit("POST", input)),
+    patchItem: (id, input) =>
+      call(
+        `/api/todos/items/${encodeURIComponent(id)}`,
+        jsonInit("PATCH", input),
+      ),
+    moveItem: (id, input) =>
+      call(
+        `/api/todos/items/${encodeURIComponent(id)}/move`,
+        jsonInit("POST", input),
+      ),
+    deleteItem: (id) =>
+      call(`/api/todos/items/${encodeURIComponent(id)}`, { method: "DELETE" }),
+    addColumn: (input) => call("/api/todos/columns", jsonInit("POST", input)),
+    patchColumn: (id, input) =>
+      call(
+        `/api/todos/columns/${encodeURIComponent(id)}`,
+        jsonInit("PATCH", input),
+      ),
+    deleteColumn: (id) =>
+      call(`/api/todos/columns/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      }),
+    reorderColumns: (ids) =>
+      call("/api/todos/columns/order", jsonInit("PUT", { ids })),
+  };
+}

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -118,7 +118,7 @@ export function useTodos(
   const columns = ref<StatusColumn[]>(initialColumns);
   const error = ref<string | null>(null);
 
-  const { refresh } = useFreshPluginData<{
+  const { refresh: rawRefresh } = useFreshPluginData<{
     items: TodoItem[];
     columns: StatusColumn[];
   }>({
@@ -134,6 +134,17 @@ export function useTodos(
       if (nextColumns.length > 0) columns.value = nextColumns;
     },
   });
+
+  // useFreshPluginData swallows fetch errors silently — its refresh
+  // returns false on failure but never updates anything callers can
+  // observe. Wrap it so the initial GET / manual reloads surface
+  // through the same `error` ref the rest of the composable uses.
+  async function refresh(): Promise<boolean> {
+    error.value = null;
+    const ok = await rawRefresh();
+    if (!ok) error.value = "Failed to load todos";
+    return ok;
+  }
 
   // Use Parameters<typeof fetch> rather than the global RequestInit
   // type so this file doesn't depend on the DOM lib being in the

--- a/src/plugins/todo/index.ts
+++ b/src/plugins/todo/index.ts
@@ -3,6 +3,8 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 
+export type TodoPriority = "low" | "medium" | "high" | "urgent";
+
 export interface TodoItem {
   id: string;
   text: string;
@@ -10,10 +12,22 @@ export interface TodoItem {
   labels?: string[];
   completed: boolean;
   createdAt: number;
+  // ── Added for the file-explorer kanban view ──
+  status?: string;
+  priority?: TodoPriority;
+  dueDate?: string;
+  order?: number;
+}
+
+export interface StatusColumn {
+  id: string;
+  label: string;
+  isDone?: boolean;
 }
 
 export interface TodoData {
   items: TodoItem[];
+  columns?: StatusColumn[];
 }
 
 const todoPlugin: ToolPlugin<TodoData> = {

--- a/src/plugins/todo/priority.ts
+++ b/src/plugins/todo/priority.ts
@@ -1,0 +1,100 @@
+// Pure helpers for the todo `priority` field. Used by the kanban
+// cards, the table view, and any future plugin code that needs to
+// render a priority badge — kept dependency-free so both the server
+// and the browser can import it.
+
+import type { TodoPriority } from "./index";
+
+export const PRIORITY_ORDER: Record<TodoPriority, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  urgent: 3,
+};
+
+// Display label for each priority level. Capitalised so it reads well
+// in chips / dropdowns without further formatting at the call site.
+export const PRIORITY_LABELS: Record<TodoPriority, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  urgent: "Urgent",
+};
+
+// Tailwind classes for the priority chip backgrounds. Picked to be
+// distinguishable at small sizes without competing too hard with the
+// label colours from labels.ts.
+export const PRIORITY_CLASSES: Record<TodoPriority, string> = {
+  low: "bg-slate-100 text-slate-600",
+  medium: "bg-sky-100 text-sky-700",
+  high: "bg-orange-100 text-orange-700",
+  urgent: "bg-red-100 text-red-700",
+};
+
+// Tailwind border-color classes for the kanban card left border.
+// Slightly bolder than the chip palette so a card with no labels still
+// shows priority at a glance.
+export const PRIORITY_BORDER: Record<TodoPriority, string> = {
+  low: "border-l-slate-300",
+  medium: "border-l-sky-400",
+  high: "border-l-orange-400",
+  urgent: "border-l-red-500",
+};
+
+export const PRIORITIES: readonly TodoPriority[] = [
+  "low",
+  "medium",
+  "high",
+  "urgent",
+];
+
+export function isPriority(v: unknown): v is TodoPriority {
+  return typeof v === "string" && (v as TodoPriority) in PRIORITY_ORDER;
+}
+
+// ── due date helpers ─────────────────────────────────────────────
+
+// Returns a Tailwind class string for a due-date badge based on how
+// far the date is from today. The 4 buckets match what GitHub
+// Projects shows in its kanban view.
+export function dueDateClasses(dueDate: string | undefined): string {
+  if (!dueDate) return "";
+  const today = todayISO();
+  if (dueDate < today) return "bg-red-100 text-red-700";
+  if (dueDate === today) return "bg-orange-100 text-orange-700";
+  // Within 3 days?
+  const t = new Date(today);
+  const d = new Date(dueDate);
+  const diffDays = Math.round(
+    (d.getTime() - t.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  if (diffDays <= 3) return "bg-yellow-100 text-yellow-700";
+  return "bg-gray-100 text-gray-600";
+}
+
+// Today's date as YYYY-MM-DD in the user's local timezone. Avoiding
+// `toISOString` here on purpose: that returns UTC, which would flip
+// the day boundary for users west of UTC and lead to "due today"
+// flickering at midnight.
+export function todayISO(): string {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+// Pretty short label for the kanban card badges. "2026-04-12" →
+// "Apr 12". Year is omitted unless it differs from the current one.
+export function formatDueLabel(dueDate: string | undefined): string {
+  if (!dueDate) return "";
+  const d = new Date(`${dueDate}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return dueDate;
+  const today = new Date();
+  const sameYear = d.getFullYear() === today.getFullYear();
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}

--- a/src/plugins/todo/priority.ts
+++ b/src/plugins/todo/priority.ts
@@ -49,7 +49,15 @@ export const PRIORITIES: readonly TodoPriority[] = [
 ];
 
 export function isPriority(v: unknown): v is TodoPriority {
-  return typeof v === "string" && (v as TodoPriority) in PRIORITY_ORDER;
+  // Use hasOwnProperty rather than the `in` operator: `in` walks the
+  // prototype chain, so `"toString" in PRIORITY_ORDER` would return
+  // true and incorrectly narrow `"toString"` to TodoPriority. We use
+  // the .call form (rather than Object.hasOwn) because the project's
+  // client tsconfig targets ES2021, and Object.hasOwn is ES2022.
+  return (
+    typeof v === "string" &&
+    Object.prototype.hasOwnProperty.call(PRIORITY_ORDER, v)
+  );
 }
 
 // ── due date helpers ─────────────────────────────────────────────

--- a/test/plugins/todo/test_priority.ts
+++ b/test/plugins/todo/test_priority.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PRIORITIES,
+  PRIORITY_LABELS,
+  isPriority,
+} from "../../../src/plugins/todo/priority.js";
+
+describe("isPriority", () => {
+  it("accepts every value in PRIORITIES", () => {
+    for (const p of PRIORITIES) {
+      assert.equal(isPriority(p), true);
+    }
+  });
+
+  it("rejects non-string inputs", () => {
+    assert.equal(isPriority(undefined), false);
+    assert.equal(isPriority(null), false);
+    assert.equal(isPriority(0), false);
+    assert.equal(isPriority({}), false);
+    assert.equal(isPriority([]), false);
+  });
+
+  it("rejects unknown strings", () => {
+    assert.equal(isPriority("huge"), false);
+    assert.equal(isPriority(""), false);
+    assert.equal(isPriority("LOW"), false);
+  });
+
+  it("rejects inherited Object.prototype keys (regression)", () => {
+    // The previous implementation used the `in` operator which walks
+    // the prototype chain. That meant `"toString" in PRIORITY_ORDER`
+    // returned true and isPriority falsely accepted built-in
+    // Object.prototype keys. The fix uses Object.prototype.hasOwnProperty
+    // .call so only own properties qualify.
+    assert.equal(isPriority("toString"), false);
+    assert.equal(isPriority("hasOwnProperty"), false);
+    assert.equal(isPriority("constructor"), false);
+    assert.equal(isPriority("valueOf"), false);
+  });
+});
+
+describe("PRIORITY_LABELS", () => {
+  it("has a label for every priority", () => {
+    for (const p of PRIORITIES) {
+      assert.equal(typeof PRIORITY_LABELS[p], "string");
+      assert.ok(PRIORITY_LABELS[p].length > 0);
+    }
+  });
+});

--- a/test/routes/test_todosColumnsHandlers.ts
+++ b/test/routes/test_todosColumnsHandlers.ts
@@ -1,0 +1,279 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_COLUMNS,
+  defaultStatusId,
+  doneColumnId,
+  handleAddColumn,
+  handleDeleteColumn,
+  handlePatchColumn,
+  handleReorderColumns,
+  normalizeColumns,
+  type StatusColumn,
+} from "../../server/routes/todosColumnsHandlers.js";
+import type { TodoItem } from "../../server/routes/todos.js";
+
+function cols(): StatusColumn[] {
+  // Fresh copy each call so mutations in one test don't bleed.
+  return DEFAULT_COLUMNS.map((c) => ({ ...c }));
+}
+
+function makeItem(overrides: Partial<TodoItem> = {}): TodoItem {
+  return {
+    id: "todo_test_1",
+    text: "Default item",
+    completed: false,
+    createdAt: 1_000_000,
+    status: "todo",
+    order: 1000,
+    ...overrides,
+  };
+}
+
+describe("normalizeColumns", () => {
+  it("returns DEFAULT_COLUMNS when input is not an array", () => {
+    assert.deepEqual(normalizeColumns(null), DEFAULT_COLUMNS);
+    assert.deepEqual(normalizeColumns({}), DEFAULT_COLUMNS);
+    assert.deepEqual(normalizeColumns("nope"), DEFAULT_COLUMNS);
+  });
+
+  it("returns DEFAULT_COLUMNS for an empty array", () => {
+    assert.deepEqual(normalizeColumns([]), DEFAULT_COLUMNS);
+  });
+
+  it("strips entries missing id or label", () => {
+    const result = normalizeColumns([
+      { id: "a", label: "A" },
+      { id: 5, label: "B" },
+      { id: "c" },
+      { label: "D" },
+      { id: "e", label: "E" },
+    ]);
+    assert.deepEqual(
+      result.map((c) => c.id),
+      ["a", "e"],
+    );
+  });
+
+  it("falls back to defaults if ids collide", () => {
+    const result = normalizeColumns([
+      { id: "a", label: "A" },
+      { id: "a", label: "A2" },
+    ]);
+    assert.deepEqual(result, DEFAULT_COLUMNS);
+  });
+
+  it("promotes the last column to isDone if no done flag is set", () => {
+    const result = normalizeColumns([
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ]);
+    assert.equal(result[result.length - 1]?.isDone, true);
+  });
+
+  it("keeps only the first isDone flag when multiple are set", () => {
+    const result = normalizeColumns([
+      { id: "a", label: "A", isDone: true },
+      { id: "b", label: "B", isDone: true },
+    ]);
+    assert.equal(result[0]?.isDone, true);
+    assert.equal(result[1]?.isDone, undefined);
+  });
+});
+
+describe("doneColumnId / defaultStatusId", () => {
+  it("returns the isDone column id and the first non-done id", () => {
+    assert.equal(doneColumnId(cols()), "done");
+    assert.equal(defaultStatusId(cols()), "backlog");
+  });
+});
+
+describe("handleAddColumn", () => {
+  it("rejects empty label", () => {
+    const result = handleAddColumn(cols(), { label: "  " });
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 400);
+  });
+
+  it("appends a slugified column", () => {
+    const result = handleAddColumn(cols(), { label: "In Review!" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.columns.length, 5);
+    assert.equal(result.columns[4]?.id, "in_review");
+    assert.equal(result.columns[4]?.label, "In Review!");
+  });
+
+  it("disambiguates colliding ids", () => {
+    const start = [
+      ...cols(),
+      { id: "review", label: "Review" } as StatusColumn,
+    ];
+    const result = handleAddColumn(start, { label: "Review" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.columns[result.columns.length - 1]?.id, "review_2");
+  });
+
+  it("demotes existing done columns when isDone is true", () => {
+    const result = handleAddColumn(cols(), {
+      label: "Archived",
+      isDone: true,
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const doneIds = result.columns.filter((c) => c.isDone).map((c) => c.id);
+    assert.deepEqual(doneIds, ["archived"]);
+  });
+});
+
+describe("handlePatchColumn", () => {
+  it("renames a column without touching items", () => {
+    const items = [makeItem({ status: "todo" })];
+    const result = handlePatchColumn(
+      cols(),
+      "todo",
+      { label: "Up Next" },
+      items,
+    );
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.columns.find((c) => c.id === "todo")?.label, "Up Next");
+    assert.equal(result.items, undefined);
+  });
+
+  it("returns 404 for an unknown column id", () => {
+    const result = handlePatchColumn(cols(), "ghost", { label: "x" }, []);
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 404);
+  });
+
+  it("promoting a column to done demotes the prior done column and syncs items", () => {
+    const items = [
+      makeItem({ id: "a", status: "in_progress", completed: false }),
+      makeItem({ id: "b", status: "done", completed: true }),
+    ];
+    const result = handlePatchColumn(
+      cols(),
+      "in_progress",
+      { isDone: true },
+      items,
+    );
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const inProgress = result.columns.find((c) => c.id === "in_progress");
+    const done = result.columns.find((c) => c.id === "done");
+    assert.equal(inProgress?.isDone, true);
+    assert.equal(done?.isDone, undefined);
+    assert.equal(result.items?.find((i) => i.id === "a")?.completed, true);
+    // Item "b" was in the now-non-done column; we don't unilaterally
+    // un-complete it (it kept its completed flag from before).
+    assert.equal(result.items?.find((i) => i.id === "b")?.completed, true);
+  });
+
+  it("refuses to demote the only done column", () => {
+    const result = handlePatchColumn(cols(), "done", { isDone: false }, []);
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 400);
+  });
+});
+
+describe("handleDeleteColumn", () => {
+  it("returns 404 for an unknown column id", () => {
+    const result = handleDeleteColumn(cols(), "ghost", []);
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 404);
+  });
+
+  it("refuses to delete the last remaining column", () => {
+    const result = handleDeleteColumn(
+      [{ id: "only", label: "Only", isDone: true }],
+      "only",
+      [],
+    );
+    assert.equal(result.kind, "error");
+  });
+
+  it("removes a non-done column and migrates its items to the open default", () => {
+    const items = [
+      makeItem({ id: "a", status: "backlog" }),
+      makeItem({ id: "b", status: "todo" }),
+    ];
+    const result = handleDeleteColumn(cols(), "backlog", items);
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(
+      result.columns.find((c) => c.id === "backlog"),
+      undefined,
+    );
+    // "a" was in backlog → moves to first non-done column (now "todo")
+    assert.equal(result.items?.find((i) => i.id === "a")?.status, "todo");
+    assert.equal(result.items?.find((i) => i.id === "a")?.completed, false);
+  });
+
+  it("removing the done column promotes a new done column and marks orphans complete", () => {
+    const items = [
+      makeItem({ id: "a", status: "done", completed: true }),
+      makeItem({ id: "b", status: "todo", completed: false }),
+    ];
+    const result = handleDeleteColumn(cols(), "done", items);
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(
+      result.columns.find((c) => c.id === "done"),
+      undefined,
+    );
+    const last = result.columns[result.columns.length - 1];
+    assert.equal(last?.isDone, true);
+    // Orphan from old done column moved to new done column.
+    const a = result.items?.find((i) => i.id === "a");
+    assert.equal(a?.status, last?.id);
+    assert.equal(a?.completed, true);
+  });
+});
+
+describe("handleReorderColumns", () => {
+  it("rejects when ids count differs", () => {
+    const result = handleReorderColumns(cols(), ["todo", "done"]);
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects unknown ids", () => {
+    const result = handleReorderColumns(cols(), [
+      "todo",
+      "done",
+      "in_progress",
+      "ghost",
+    ]);
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects duplicate ids", () => {
+    const result = handleReorderColumns(cols(), [
+      "todo",
+      "todo",
+      "in_progress",
+      "done",
+    ]);
+    assert.equal(result.kind, "error");
+  });
+
+  it("returns columns in the requested order", () => {
+    const result = handleReorderColumns(cols(), [
+      "done",
+      "in_progress",
+      "todo",
+      "backlog",
+    ]);
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.deepEqual(
+      result.columns.map((c) => c.id),
+      ["done", "in_progress", "todo", "backlog"],
+    );
+  });
+});

--- a/test/routes/test_todosColumnsHandlers.ts
+++ b/test/routes/test_todosColumnsHandlers.ts
@@ -90,14 +90,14 @@ describe("doneColumnId / defaultStatusId", () => {
 
 describe("handleAddColumn", () => {
   it("rejects empty label", () => {
-    const result = handleAddColumn(cols(), { label: "  " });
+    const result = handleAddColumn(cols(), [], { label: "  " });
     assert.equal(result.kind, "error");
     if (result.kind !== "error") return;
     assert.equal(result.status, 400);
   });
 
   it("appends a slugified column", () => {
-    const result = handleAddColumn(cols(), { label: "In Review!" });
+    const result = handleAddColumn(cols(), [], { label: "In Review!" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.columns.length, 5);
@@ -110,14 +110,14 @@ describe("handleAddColumn", () => {
       ...cols(),
       { id: "review", label: "Review" } as StatusColumn,
     ];
-    const result = handleAddColumn(start, { label: "Review" });
+    const result = handleAddColumn(start, [], { label: "Review" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.columns[result.columns.length - 1]?.id, "review_2");
   });
 
   it("demotes existing done columns when isDone is true", () => {
-    const result = handleAddColumn(cols(), {
+    const result = handleAddColumn(cols(), [], {
       label: "Archived",
       isDone: true,
     });
@@ -125,6 +125,36 @@ describe("handleAddColumn", () => {
     if (result.kind !== "success") return;
     const doneIds = result.columns.filter((c) => c.isDone).map((c) => c.id);
     assert.deepEqual(doneIds, ["archived"]);
+  });
+
+  it("resyncs `completed` on items in the old done column when adding a new isDone column", () => {
+    // Items in the original "done" column carry completed=true. When
+    // a brand-new column is promoted to be the done column, the old
+    // ones should flip back to completed=false because their column
+    // is no longer the done column.
+    const items = [
+      makeItem({ id: "a", status: "done", completed: true }),
+      makeItem({ id: "b", status: "todo", completed: false }),
+    ];
+    const result = handleAddColumn(cols(), items, {
+      label: "Archived",
+      isDone: true,
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const a = result.items?.find((i) => i.id === "a");
+    const b = result.items?.find((i) => i.id === "b");
+    assert.equal(a?.completed, false);
+    assert.equal(b?.completed, false);
+  });
+
+  it("does not resync items when adding a non-done column", () => {
+    const items = [makeItem({ id: "a", status: "done", completed: true })];
+    const result = handleAddColumn(cols(), items, { label: "Review" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    // No items field on the result because nothing changed.
+    assert.equal(result.items, undefined);
   });
 });
 
@@ -150,7 +180,7 @@ describe("handlePatchColumn", () => {
     assert.equal(result.status, 404);
   });
 
-  it("promoting a column to done demotes the prior done column and syncs items", () => {
+  it("promoting a column to done demotes the prior done column and syncs items in BOTH directions", () => {
     const items = [
       makeItem({ id: "a", status: "in_progress", completed: false }),
       makeItem({ id: "b", status: "done", completed: true }),
@@ -167,10 +197,13 @@ describe("handlePatchColumn", () => {
     const done = result.columns.find((c) => c.id === "done");
     assert.equal(inProgress?.isDone, true);
     assert.equal(done?.isDone, undefined);
+    // "a" is now in the new done column → completed should be true.
     assert.equal(result.items?.find((i) => i.id === "a")?.completed, true);
-    // Item "b" was in the now-non-done column; we don't unilaterally
-    // un-complete it (it kept its completed flag from before).
-    assert.equal(result.items?.find((i) => i.id === "b")?.completed, true);
+    // "b" stayed in the old (now non-done) "done" column → completed
+    // should flip to false. Symmetrical: column-level intent is
+    // explicit user action so we sync both ends, unlike the legacy
+    // MCP `check` action which only flips the boolean.
+    assert.equal(result.items?.find((i) => i.id === "b")?.completed, false);
   });
 
   it("refuses to demote the only done column", () => {
@@ -213,6 +246,31 @@ describe("handleDeleteColumn", () => {
     // "a" was in backlog → moves to first non-done column (now "todo")
     assert.equal(result.items?.find((i) => i.id === "a")?.status, "todo");
     assert.equal(result.items?.find((i) => i.id === "a")?.completed, false);
+  });
+
+  it("rebuilds the refuge column's order so merged items don't collide", () => {
+    // Both source and destination columns happen to have items at
+    // orders 1000/2000. Naively merging would leave duplicate orders
+    // in the destination, breaking the kanban sort. The handler
+    // should re-stripe the refuge column.
+    const items = [
+      makeItem({ id: "a", status: "backlog", order: 1000 }),
+      makeItem({ id: "b", status: "backlog", order: 2000 }),
+      makeItem({ id: "c", status: "todo", order: 1000 }),
+      makeItem({ id: "d", status: "todo", order: 2000 }),
+    ];
+    const result = handleDeleteColumn(cols(), "backlog", items);
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    // All four items now live in "todo" with unique, contiguous orders.
+    const todoItems = result
+      .items!.filter((i) => i.status === "todo")
+      .sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    const orders = todoItems.map((i) => i.order);
+    // No duplicates.
+    assert.equal(new Set(orders).size, 4);
+    // Stripe is 1000, 2000, 3000, 4000.
+    assert.deepEqual(orders, [1000, 2000, 3000, 4000]);
   });
 
   it("removing the done column promotes a new done column and marks orphans complete", () => {

--- a/test/routes/test_todosHandlers.ts
+++ b/test/routes/test_todosHandlers.ts
@@ -513,3 +513,71 @@ describe("dispatchTodos", () => {
     assert.equal(dispatchTodos("list_labels", items, {}).kind, "success");
   });
 });
+
+// Regression: the kanban view stores extra fields (status / priority /
+// dueDate / order) on TodoItem. The MCP `update` handler must keep
+// those fields when changing text / note, otherwise an LLM editing a
+// label-only field would silently strip the kanban metadata.
+describe("kanban field preservation", () => {
+  it("handleUpdate preserves status / priority / dueDate / order", () => {
+    const item = makeTodo({
+      id: "a",
+      text: "Old",
+      status: "in_progress",
+      priority: "high",
+      dueDate: "2026-04-20",
+      order: 2500,
+    });
+    const result = handleUpdate([item], { text: "old", newText: "New" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const updated = result.items[0];
+    assert.equal(updated?.text, "New");
+    assert.equal(updated?.status, "in_progress");
+    assert.equal(updated?.priority, "high");
+    assert.equal(updated?.dueDate, "2026-04-20");
+    assert.equal(updated?.order, 2500);
+  });
+
+  it("handleCheck preserves status / priority / dueDate / order", () => {
+    const item = makeTodo({
+      id: "a",
+      text: "x",
+      completed: false,
+      status: "in_progress",
+      priority: "urgent",
+      dueDate: "2026-05-01",
+      order: 4500,
+    });
+    const result = handleCheck([item], { text: "x" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const updated = result.items[0];
+    assert.equal(updated?.completed, true);
+    assert.equal(updated?.status, "in_progress");
+    assert.equal(updated?.priority, "urgent");
+    assert.equal(updated?.dueDate, "2026-05-01");
+    assert.equal(updated?.order, 4500);
+  });
+
+  it("handleAddLabel preserves status / priority / dueDate / order", () => {
+    const item = makeTodo({
+      id: "a",
+      text: "x",
+      labels: ["work"],
+      status: "todo",
+      priority: "medium",
+      dueDate: "2026-06-01",
+      order: 1500,
+    });
+    const result = handleAddLabel([item], { text: "x", labels: ["urgent"] });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const updated = result.items[0];
+    assert.deepEqual(updated?.labels, ["work", "urgent"]);
+    assert.equal(updated?.status, "todo");
+    assert.equal(updated?.priority, "medium");
+    assert.equal(updated?.dueDate, "2026-06-01");
+    assert.equal(updated?.order, 1500);
+  });
+});

--- a/test/routes/test_todosItemsHandlers.ts
+++ b/test/routes/test_todosItemsHandlers.ts
@@ -68,12 +68,17 @@ describe("migrateItems", () => {
     assert.equal(result[0]?.status, "backlog");
   });
 
-  it("syncs completed to done column membership", () => {
+  it("does NOT re-sync completed against status on read", () => {
+    // Migration treats `status` and `completed` as independent at
+    // the storage layer so the legacy MCP `check`/`uncheck` actions
+    // (which only flip the boolean and never touch status) keep
+    // working. Re-syncing here used to revert their effect on the
+    // very next read.
     const items: TodoItem[] = [
       {
         id: "a",
         text: "x",
-        completed: false, // out-of-sync; status says done
+        completed: false,
         createdAt: 100,
         status: "done",
         order: 1000,
@@ -81,15 +86,15 @@ describe("migrateItems", () => {
       {
         id: "b",
         text: "y",
-        completed: true, // out-of-sync; status says todo
+        completed: true,
         createdAt: 200,
         status: "todo",
         order: 1000,
       },
     ];
     const result = migrateItems(items, cols());
-    assert.equal(result.find((i) => i.id === "a")?.completed, true);
-    assert.equal(result.find((i) => i.id === "b")?.completed, false);
+    assert.equal(result.find((i) => i.id === "a")?.completed, false);
+    assert.equal(result.find((i) => i.id === "b")?.completed, true);
   });
 
   it("preserves existing order values when every item in a column has one", () => {

--- a/test/routes/test_todosItemsHandlers.ts
+++ b/test/routes/test_todosItemsHandlers.ts
@@ -1,0 +1,362 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  handleCreate,
+  handleDeleteItem,
+  handleMove,
+  handlePatch,
+  migrateItems,
+} from "../../server/routes/todosItemsHandlers.js";
+import { DEFAULT_COLUMNS } from "../../server/routes/todosColumnsHandlers.js";
+import type { TodoItem } from "../../server/routes/todos.js";
+
+function cols() {
+  return DEFAULT_COLUMNS.map((c) => ({ ...c }));
+}
+
+function makeItem(overrides: Partial<TodoItem> = {}): TodoItem {
+  return {
+    id: "todo_test_1",
+    text: "Default item",
+    completed: false,
+    createdAt: 1_000_000,
+    status: "todo",
+    order: 1000,
+    ...overrides,
+  };
+}
+
+describe("migrateItems", () => {
+  it("backfills status and order on legacy items", () => {
+    const legacy: TodoItem[] = [
+      {
+        id: "a",
+        text: "Done item",
+        completed: true,
+        createdAt: 100,
+      },
+      {
+        id: "b",
+        text: "Open item",
+        completed: false,
+        createdAt: 200,
+      },
+    ];
+    const result = migrateItems(legacy, cols());
+    const a = result.find((i) => i.id === "a");
+    const b = result.find((i) => i.id === "b");
+    assert.equal(a?.status, "done");
+    assert.equal(a?.completed, true);
+    assert.equal(b?.status, "backlog");
+    assert.equal(b?.completed, false);
+    assert.equal(typeof a?.order, "number");
+    assert.equal(typeof b?.order, "number");
+  });
+
+  it("reassigns items pointing at unknown columns", () => {
+    const items: TodoItem[] = [
+      {
+        id: "a",
+        text: "x",
+        completed: false,
+        createdAt: 100,
+        status: "ghost-column",
+        order: 500,
+      },
+    ];
+    const result = migrateItems(items, cols());
+    assert.equal(result[0]?.status, "backlog");
+  });
+
+  it("syncs completed to done column membership", () => {
+    const items: TodoItem[] = [
+      {
+        id: "a",
+        text: "x",
+        completed: false, // out-of-sync; status says done
+        createdAt: 100,
+        status: "done",
+        order: 1000,
+      },
+      {
+        id: "b",
+        text: "y",
+        completed: true, // out-of-sync; status says todo
+        createdAt: 200,
+        status: "todo",
+        order: 1000,
+      },
+    ];
+    const result = migrateItems(items, cols());
+    assert.equal(result.find((i) => i.id === "a")?.completed, true);
+    assert.equal(result.find((i) => i.id === "b")?.completed, false);
+  });
+
+  it("preserves existing order values when every item in a column has one", () => {
+    const items: TodoItem[] = [
+      {
+        id: "a",
+        text: "x",
+        completed: false,
+        createdAt: 100,
+        status: "todo",
+        order: 5,
+      },
+      {
+        id: "b",
+        text: "y",
+        completed: false,
+        createdAt: 200,
+        status: "todo",
+        order: 7,
+      },
+    ];
+    const result = migrateItems(items, cols());
+    assert.equal(result.find((i) => i.id === "a")?.order, 5);
+    assert.equal(result.find((i) => i.id === "b")?.order, 7);
+  });
+
+  it("backfills order even when some items in a column have it", () => {
+    // Mixed group: at least one missing order → entire column gets re-ordered.
+    const items: TodoItem[] = [
+      {
+        id: "a",
+        text: "x",
+        completed: false,
+        createdAt: 100,
+        status: "todo",
+        order: 5,
+      },
+      {
+        id: "b",
+        text: "y",
+        completed: false,
+        createdAt: 200,
+        status: "todo",
+      },
+    ];
+    const result = migrateItems(items, cols());
+    assert.equal(result.find((i) => i.id === "a")?.order, 1000);
+    assert.equal(result.find((i) => i.id === "b")?.order, 2000);
+  });
+});
+
+describe("handleCreate", () => {
+  it("rejects empty text", () => {
+    const result = handleCreate([], cols(), { text: "  " });
+    assert.equal(result.kind, "error");
+  });
+
+  it("creates with default status when none specified", () => {
+    const result = handleCreate([], cols(), { text: "New" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.status, "backlog");
+    assert.equal(result.item?.completed, false);
+    assert.equal(result.item?.order, 1000);
+  });
+
+  it("creates in done column → completed true", () => {
+    const result = handleCreate([], cols(), { text: "Did it", status: "done" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.completed, true);
+  });
+
+  it("rejects invalid priority", () => {
+    const result = handleCreate([], cols(), { text: "x", priority: "huge" });
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects malformed dueDate", () => {
+    const result = handleCreate([], cols(), {
+      text: "x",
+      dueDate: "next tuesday",
+    });
+    assert.equal(result.kind, "error");
+  });
+
+  it("normalises labels", () => {
+    const result = handleCreate([], cols(), {
+      text: "x",
+      labels: ["  Work ", "WORK", "Urgent"],
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.deepEqual(result.item?.labels, ["Work", "Urgent"]);
+  });
+
+  it("places new items at the end of their column", () => {
+    const items = [
+      makeItem({ id: "a", status: "todo", order: 1000 }),
+      makeItem({ id: "b", status: "todo", order: 2500 }),
+    ];
+    const result = handleCreate(items, cols(), { text: "z", status: "todo" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.order, 3500);
+  });
+});
+
+describe("handlePatch", () => {
+  it("returns 404 for unknown id", () => {
+    const result = handlePatch([], cols(), "ghost", { text: "x" });
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 404);
+  });
+
+  it("rejects empty text", () => {
+    const items = [makeItem({ id: "a" })];
+    const result = handlePatch(items, cols(), "a", { text: "  " });
+    assert.equal(result.kind, "error");
+  });
+
+  it("clears note when set to empty string", () => {
+    const items = [makeItem({ id: "a", note: "old" })];
+    const result = handlePatch(items, cols(), "a", { note: "" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.note, undefined);
+  });
+
+  it("changes status and resyncs completed", () => {
+    const items = [makeItem({ id: "a", status: "todo", completed: false })];
+    const result = handlePatch(items, cols(), "a", { status: "done" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.status, "done");
+    assert.equal(result.item?.completed, true);
+  });
+
+  it("rejects unknown status", () => {
+    const items = [makeItem({ id: "a" })];
+    const result = handlePatch(items, cols(), "a", { status: "ghost" });
+    assert.equal(result.kind, "error");
+  });
+
+  it("toggling completed=true moves the item into the done column", () => {
+    const items = [makeItem({ id: "a", status: "todo", completed: false })];
+    const result = handlePatch(items, cols(), "a", { completed: true });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.completed, true);
+    assert.equal(result.item?.status, "done");
+  });
+
+  it("toggling completed=false moves the item to the default open column", () => {
+    const items = [makeItem({ id: "a", status: "done", completed: true })];
+    const result = handlePatch(items, cols(), "a", { completed: false });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.completed, false);
+    assert.equal(result.item?.status, "backlog");
+  });
+
+  it("rejects invalid priority", () => {
+    const items = [makeItem({ id: "a" })];
+    const result = handlePatch(items, cols(), "a", { priority: "huge" });
+    assert.equal(result.kind, "error");
+  });
+
+  it("clears priority when set to null", () => {
+    const items = [makeItem({ id: "a", priority: "high" })];
+    const result = handlePatch(items, cols(), "a", { priority: null });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.priority, undefined);
+  });
+
+  it("clears dueDate when set to empty string", () => {
+    const items = [makeItem({ id: "a", dueDate: "2026-01-01" })];
+    const result = handlePatch(items, cols(), "a", { dueDate: "" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.dueDate, undefined);
+  });
+});
+
+describe("handleMove", () => {
+  it("returns 404 for unknown id", () => {
+    const result = handleMove([], cols(), "ghost", { position: 0 });
+    assert.equal(result.kind, "error");
+  });
+
+  it("moves an item across columns and updates completed", () => {
+    const items = [
+      makeItem({ id: "a", status: "todo", order: 1000, completed: false }),
+    ];
+    const result = handleMove(items, cols(), "a", {
+      status: "done",
+      position: 0,
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.status, "done");
+    assert.equal(result.item?.completed, true);
+  });
+
+  it("reorders within a single column", () => {
+    const items = [
+      makeItem({ id: "a", status: "todo", order: 1000 }),
+      makeItem({ id: "b", status: "todo", order: 2000 }),
+      makeItem({ id: "c", status: "todo", order: 3000 }),
+    ];
+    // Move "a" to the end of the todo column.
+    const result = handleMove(items, cols(), "a", {
+      status: "todo",
+      position: 2,
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const todoItems = result.items
+      .filter((i) => i.status === "todo")
+      .sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    assert.deepEqual(
+      todoItems.map((i) => i.id),
+      ["b", "c", "a"],
+    );
+  });
+
+  it("clamps a position past the end", () => {
+    const items = [
+      makeItem({ id: "a", status: "todo", order: 1000 }),
+      makeItem({ id: "b", status: "todo", order: 2000 }),
+    ];
+    const result = handleMove(items, cols(), "a", {
+      status: "todo",
+      position: 999,
+    });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    const todoItems = result.items
+      .filter((i) => i.status === "todo")
+      .sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    assert.deepEqual(
+      todoItems.map((i) => i.id),
+      ["b", "a"],
+    );
+  });
+
+  it("rejects unknown status", () => {
+    const items = [makeItem({ id: "a" })];
+    const result = handleMove(items, cols(), "a", { status: "ghost" });
+    assert.equal(result.kind, "error");
+  });
+});
+
+describe("handleDeleteItem", () => {
+  it("returns 404 for unknown id", () => {
+    const result = handleDeleteItem([], "ghost");
+    assert.equal(result.kind, "error");
+  });
+
+  it("removes the matching item", () => {
+    const items = [makeItem({ id: "a" }), makeItem({ id: "b" })];
+    const result = handleDeleteItem(items, "a");
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.items.length, 1);
+    assert.equal(result.items[0]?.id, "b");
+  });
+});

--- a/test/routes/test_todosItemsHandlers.ts
+++ b/test/routes/test_todosItemsHandlers.ts
@@ -121,8 +121,11 @@ describe("migrateItems", () => {
     assert.equal(result.find((i) => i.id === "b")?.order, 7);
   });
 
-  it("backfills order even when some items in a column have it", () => {
-    // Mixed group: at least one missing order → entire column gets re-ordered.
+  it("preserves existing orders and appends missing-order items at the end", () => {
+    // Mixed group: items with order keep their values; items without
+    // get assigned values strictly greater than the existing max so
+    // they sort to the bottom in createdAt order. This avoids
+    // clobbering hand-managed orders just because one item lacks one.
     const items: TodoItem[] = [
       {
         id: "a",
@@ -139,10 +142,20 @@ describe("migrateItems", () => {
         createdAt: 200,
         status: "todo",
       },
+      {
+        id: "c",
+        text: "z",
+        completed: false,
+        createdAt: 50,
+        status: "todo",
+      },
     ];
     const result = migrateItems(items, cols());
-    assert.equal(result.find((i) => i.id === "a")?.order, 1000);
-    assert.equal(result.find((i) => i.id === "b")?.order, 2000);
+    assert.equal(result.find((i) => i.id === "a")?.order, 5);
+    // c is missing order; createdAt 50 < b's 200 → c gets the smaller
+    // appended slot. Existing max in column = 5, so c=1005, b=2005.
+    assert.equal(result.find((i) => i.id === "c")?.order, 1005);
+    assert.equal(result.find((i) => i.id === "b")?.order, 2005);
   });
 });
 
@@ -166,6 +179,20 @@ describe("handleCreate", () => {
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.item?.completed, true);
+  });
+
+  it("rejects an explicitly-unknown status with 400 (no silent fallback)", () => {
+    const result = handleCreate([], cols(), { text: "x", status: "ghost" });
+    assert.equal(result.kind, "error");
+    if (result.kind !== "error") return;
+    assert.equal(result.status, 400);
+  });
+
+  it("falls back to default status when status is undefined", () => {
+    const result = handleCreate([], cols(), { text: "x" });
+    assert.equal(result.kind, "success");
+    if (result.kind !== "success") return;
+    assert.equal(result.item?.status, "backlog");
   });
 
   it("rejects invalid priority", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5929,6 +5929,11 @@ socks@^2.8.3:
     ip-address "^10.0.1"
     smart-buffer "^4.2.0"
 
+sortablejs@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
 soundfont-player@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/soundfont-player/-/soundfont-player-0.12.0.tgz#2b26149f28aba471d2285d3df9a2e1e5793ceaf1"
@@ -6731,6 +6736,13 @@ vue@^3.5.32:
     "@vue/runtime-dom" "3.5.32"
     "@vue/server-renderer" "3.5.32"
     "@vue/shared" "3.5.32"
+
+vuedraggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
+  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
+  dependencies:
+    sortablejs "1.14.0"
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Closes #131.

## User Prompt

> issueたてる
> ファイルエクスプローラーでtodoのviewをつくる。ラベルで切り替えと、カンバン、表などのviewを切り替えの２つの切り替えと、ステータスを追加する。他にもtodoとして必要な機能があったら盛り込んでplanを作って。githubのカンバンが個人的には使いやすい。チャットからの操作を考慮して作ってね
>
> とりあえずチャット操作、mcpは不要かも。web uiで操作したらそれが反映されるだけでよい
>
> 実装して。

## Summary

Adds a full **Todo Explorer** that opens when you select `todos/todos.json` in the file tree, mirroring how `scheduler/items.json` opens the scheduler view today.

- **Kanban** (default) — GitHub Projects-style columns with vuedraggable drag & drop. Each column has a menu (rename, mark-as-done, delete). New columns can be added from the toolbar.
- **Table** — sortable table with text / status / priority / labels / due / created columns and inline editing.
- **List** — flat checklist with the same inline editor.

Cross-cutting: label filter chips, full-text search, view-mode persistence in `localStorage`, status / priority (low/medium/high/urgent) / due date fields, configurable status columns stored in `workspace/todos/columns.json`.

The MCP tool (`manageTodoList`) is **unchanged** by design — chat-side operations were taken out of scope per the latest requirement. The new fields are preserved across MCP `update` / `check` / label edits via regression tests, so the LLM can keep editing legacy fields without stripping kanban metadata.

## Implementation phases

1. **Phase 1 — data + REST API** (commit `0ae393a`)
   - `TodoItem` extended with `status` / `priority` / `dueDate` / `order`
   - New `workspace/todos/columns.json` (`StatusColumn[]`) with default `Backlog / Todo / In Progress / Done`
   - Pure handlers in `server/routes/todosItemsHandlers.ts` (create / patch / move / delete) and `server/routes/todosColumnsHandlers.ts` (add / patch / delete / reorder)
   - `migrateItems()` backfills `status` / `order` on legacy items, idempotently
   - New REST routes on `/api/todos/items` and `/api/todos/columns`
   - Legacy `POST /api/todos` MCP route untouched
   - **49 new test cases** + regression tests for the existing MCP `update` / `check` / `add_label` handlers

2. **Phase 2+3 — UI** (commit `8c6e435`)
   - `useTodos` composable wraps the new REST endpoints
   - `TodoExplorer.vue` shell with view switcher, label filters, search, error banner
   - `TodoKanbanView.vue` with `vuedraggable@4.1.0` drag & drop, column management menus, quick-add per column
   - `TodoTableView.vue` with sortable columns + inline edit
   - `TodoListView.vue` with checkbox + inline edit
   - `TodoEditPanel.vue` / `TodoAddDialog.vue` shared edit / create UI
   - `FilesView.vue` special-case for `todos/todos.json`

3. **Phase 4 — docs** (commit `0ee3b52`)
   - README workspace section updated with the explorer description

## Plan file

`plans/feat-todo-explorer.md` is committed in this PR with the full design (data model, REST routes, phases, risks).

## Test plan

- [x] `yarn test` — 622 / 622 pass (49 new cases for items / columns / migration / regression)
- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] **Manual UI smoke (please verify in your dev session)**
  - [x] Open the file tree, click `todos/todos.json` → TodoExplorer mounts
  - [ ] Kanban view: drag a card between columns; refresh → still moved
  - [ ] Kanban view: rename a column; delete a non-done column (items get migrated to first open column)
  - [ ] Kanban view: delete the done column; the new last column is promoted
  - [ ] Table view: sort by each column; inline edit a row (status / priority / due date)
  - [ ] List view: check / uncheck a card; verify it moves to/from the done column
  - [ ] Label filter + search work in all three views
  - [ ] Chat: ask Claude to `add` a todo with the legacy MCP — verify it shows up in the explorer with default `status` and `order` backfilled
  - [ ] Chat: ask Claude to `update` text on a todo that has `priority` / `dueDate` set — verify those fields are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced Todo Explorer view with multiple display modes (Kanban, Table, List)
  * Added priority levels and due dates for organizing todos
  * Enabled drag-and-drop functionality to organize todos across columns
  * Added search and label-based filtering capabilities

* **Documentation**
  * Updated README with Todo Explorer feature documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->