### PR TITLE
refactor(server): DRY low-risk batch + path-traversal hardening

### DIFF
--- a/plans/refactor-server-dry-low-risk.md
+++ b/plans/refactor-server-dry-low-risk.md
@@ -1,0 +1,125 @@
+# server/ DRY refactor — low-risk batch
+
+Closes the low-risk recommendations from the audit in
+receptron/mulmoclaude#136. The medium-risk
+mulmo-script handler scaffolding (#1 in the audit) is **out of scope**
+and will be a follow-up PR.
+
+## What ships in this PR
+
+In suggested order — each is its own commit on this branch.
+
+### 1. `server/utils/fs.ts` (audit #7) + security fix
+
+Promote the workspace-fs helpers out of `routes/files.ts`:
+
+- `statSafe(absPath): fs.Stats | null`
+- `readDirSafe(absPath): fs.Dirent[]`
+- `readTextOrNull(file): Promise<string | null>`
+- `resolveWithinRoot(rootReal, relPath): string | null`
+
+`resolveWithinRoot` is the realpath-based path-traversal check that
+already lives in `routes/files.ts:105-130`. Move it; then adopt it in
+**`routes/mulmo-script.ts:219-230` (`resolveStoryPath`)** and
+**`routes/sessions.ts:187-194`** which both currently use a weaker
+`path.resolve` + `startsWith` check that a malicious symlink under
+`stories/` could bypass.
+
+`routes/files.ts` keeps a thin `resolveSafe` wrapper that adds the
+hidden-dir (`.git`) traversal check on top of `resolveWithinRoot`.
+
+`journal/dailyPass.ts` already has its own `readTextOrNull` (lines
+503-509); replace it with the shared one.
+
+### 2. `server/utils/errors.ts` (audit #6)
+
+Promote `err instanceof Error ? err.message : String(err)` to
+`errorMessage(err)`. 14 sites across 9 files. Adopt in:
+
+- `routes/files.ts` (×2)
+- `routes/presentHtml.ts`
+- `routes/html.ts` (×2)
+- `routes/mulmo-script.ts` (delete the local copy at line 214)
+- `routes/pdf.ts`
+- `routes/image.ts` (×2)
+- `chat-index/summarizer.ts`
+- `mcp-tools/index.ts`
+- `mcp-tools/x.ts` (×3)
+
+### 3. `routes/plugins.ts` `wrapPluginExecute` (audit #2)
+
+Collapse 7 `try { res.json(await executeX(null, body)) } catch (e) {
+res.status(500).json({ message: String(e) }) }` handlers into:
+
+```typescript
+const wrapPluginExecute =
+  <T>(executeFn: (..._: never[]) => Promise<T>) =>
+  async (req: Request, res: Response<T | PluginErrorResponse>) => { ... };
+```
+
+Each handler becomes one line.
+
+### 4. `routes/files.ts` shared validation preamble (audit #5)
+
+Extract the 17-line clone (`/files/content` and `/files/raw` both do
+relPath → resolveSafe → statSafe → isFile-check) into a helper
+`resolveAndStatFile(req, res): { absPath, stat } | null`.
+
+### 5. `server/mcp-server.ts` `postJson` helper (audit #3)
+
+Replace 6 raw `fetch(url, { method: "POST", headers: {...}, body:
+JSON.stringify(...) })` calls with one `postJson(path, body)` closure
+capturing `BASE_URL` + `SESSION_ID`.
+
+### 6. Gemini image-generation helper (audit #4)
+
+`server/utils/gemini.ts` already exports `getGeminiClient`. Add
+`generateGeminiImage(prompt, opts?)` that wraps the
+`generateContent` + `parts.find(inlineData)` boilerplate. Three
+copies in `routes/image.ts:43`, `routes/image.ts:119`, and
+`routes/plugins.ts:22` collapse to one call site each.
+
+### 7. Dispatcher plumbing for todos/scheduler (audit #8)
+
+`routes/todos.ts:55-82` and `routes/scheduler.ts:52-83` both translate
+a `{ kind: "error" | "success", ... }` dispatch result into HTTP.
+Extract `respondWithDispatchResult(res, result, opts)` taking
+`{ instructions, persist }` to capture the per-route differences
+(todos has a `READ_ONLY_ACTIONS` set, scheduler has `action !== "show"`).
+
+Both routes are covered by `test/routes/test_todosHandlers.ts` and
+`test/routes/test_schedulerHandlers.ts` so the refactor is verifiable.
+
+### 8. `appendOrCreate` in `dailyPass.ts` (audit #9)
+
+`applyTopicUpdate`'s `create` and `append` branches at
+`journal/dailyPass.ts:521-560` both end with the same "if existing is
+null write fresh, else write trimmed + append" sequence. Collapse
+into one helper. Test-covered.
+
+## Out of scope
+
+- **Audit #1** (`mulmo-script.ts` handler scaffolding) — biggest payoff
+  but medium risk. Saved for a follow-up PR once the small utilities
+  in this batch land.
+- Migrating `journal/index.ts`, `journal/state.ts`,
+  `journal/optimizationPass.ts` to the new `fs.ts` helpers — those
+  call sites use `fsp` (async `node:fs/promises`) and the helpers
+  exposed here are sync. Would need an async variant; defer until
+  there's an actual reason.
+- Broader adoption of `loadJsonFile` / `saveJsonFile` outside todos
+  and scheduler. Mentioned in the audit as under-used; deferred.
+
+## Verification
+
+After every commit:
+
+- `yarn format`
+- `yarn lint` (must report 0 errors)
+- `yarn typecheck`
+- `yarn build`
+- `yarn test` (must stay at 567/567 pass)
+
+The dispatcher and `appendOrCreate` refactors have direct unit-test
+coverage; the others are mechanical and rely on type-checking +
+manual smoke testing.

--- a/server/chat-index/summarizer.ts
+++ b/server/chat-index/summarizer.ts
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
+import { errorMessage } from "../utils/errors.js";
 import type { SummaryResult } from "./types.js";
 
 const SYSTEM_PROMPT =
@@ -110,9 +111,7 @@ export function parseClaudeJsonResult(stdout: string): SummaryResult {
     parsed = JSON.parse(stdout.trim());
   } catch (err) {
     throw new Error(
-      `[chat-index] failed to parse claude json output: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `[chat-index] failed to parse claude json output: ${errorMessage(err)}`,
     );
   }
   if (parsed.is_error) {

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -511,6 +511,26 @@ async function writeDailySummary(
   await fsp.writeFile(p, content, "utf-8");
 }
 
+// If the file doesn't exist, write `content` fresh; otherwise append
+// it after a blank line. Returns "created" or "updated" so the caller
+// can report which action was taken.
+async function appendOrCreate(
+  filePath: string,
+  content: string,
+): Promise<"created" | "updated"> {
+  const existing = await readTextOrNull(filePath);
+  if (existing === null) {
+    await fsp.writeFile(filePath, content, "utf-8");
+    return "created";
+  }
+  await fsp.writeFile(
+    filePath,
+    `${existing.trimEnd()}\n\n${content}\n`,
+    "utf-8",
+  );
+  return "updated";
+}
+
 async function applyTopicUpdate(
   workspaceRoot: string,
   update: TopicUpdate,
@@ -521,17 +541,7 @@ async function applyTopicUpdate(
   if (update.action === "create") {
     // If the file already exists (e.g. the LLM mis-classified), treat
     // it as an append so we don't clobber prior content.
-    const existing = await readTextOrNull(p);
-    if (existing === null) {
-      await fsp.writeFile(p, update.content, "utf-8");
-      return "created";
-    }
-    await fsp.writeFile(
-      p,
-      `${existing.trimEnd()}\n\n${update.content}\n`,
-      "utf-8",
-    );
-    return "updated";
+    return appendOrCreate(p, update.content);
   }
   if (update.action === "rewrite") {
     const existed = (await readTextOrNull(p)) !== null;
@@ -539,15 +549,5 @@ async function applyTopicUpdate(
     return existed ? "updated" : "created";
   }
   // append
-  const existing = await readTextOrNull(p);
-  if (existing === null) {
-    await fsp.writeFile(p, update.content, "utf-8");
-    return "created";
-  }
-  await fsp.writeFile(
-    p,
-    `${existing.trimEnd()}\n\n${update.content}\n`,
-    "utf-8",
-  );
-  return "updated";
+  return appendOrCreate(p, update.content);
 }

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -514,14 +514,28 @@ async function writeDailySummary(
 // If the file doesn't exist, write `content` fresh; otherwise append
 // it after a blank line. Returns "created" or "updated" so the caller
 // can report which action was taken.
+//
+// Distinguishes a true missing file (ENOENT) from other read errors
+// (permission denied, I/O failure) — without this, a transient EACCES
+// on an existing topic would silently overwrite it.
 async function appendOrCreate(
   filePath: string,
   content: string,
 ): Promise<"created" | "updated"> {
-  const existing = await readTextOrNull(filePath);
-  if (existing === null) {
-    await fsp.writeFile(filePath, content, "utf-8");
-    return "created";
+  let existing: string;
+  try {
+    existing = await fsp.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      await fsp.writeFile(filePath, content, "utf-8");
+      return "created";
+    }
+    throw err;
   }
   await fsp.writeFile(
     filePath,

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -39,6 +39,7 @@ import {
 } from "./diff.js";
 import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import { writeState, type JournalState } from "./state.js";
+import { readTextOrNull } from "../utils/fs.js";
 
 // --- Constants ------------------------------------------------------
 
@@ -498,14 +499,6 @@ async function readAllTopics(
     }
   }
   return out;
-}
-
-async function readTextOrNull(file: string): Promise<string | null> {
-  try {
-    return await fsp.readFile(file, "utf-8");
-  } catch {
-    return null;
-  }
 }
 
 async function writeDailySummary(

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -266,6 +266,10 @@ async function writeDailySummaryForDate(
 // Apply every topic update the archivist asked for, keeping the
 // in-memory `existingTopics` snapshot in sync so the next day in
 // this same pass sees fresh content. Mutates `existingTopics`.
+//
+// Per-update failures (EACCES, EIO, etc. surfaced by appendOrCreate)
+// are logged and skipped so a single broken topic file doesn't kill
+// the whole pass after days of progress have already been committed.
 async function processTopicUpdatesForDay(
   workspaceRoot: string,
   updates: readonly TopicUpdate[],
@@ -275,10 +279,21 @@ async function processTopicUpdatesForDay(
   const updated: string[] = [];
   for (const update of updates) {
     const normalized = normalizeTopicAction(update, existingTopics);
-    const outcome = await applyTopicUpdate(workspaceRoot, normalized);
-    if (outcome === "created") created.push(normalized.slug);
-    else if (outcome === "updated") updated.push(normalized.slug);
-    await refreshTopicSnapshot(workspaceRoot, normalized.slug, existingTopics);
+    try {
+      const outcome = await applyTopicUpdate(workspaceRoot, normalized);
+      if (outcome === "created") created.push(normalized.slug);
+      else if (outcome === "updated") updated.push(normalized.slug);
+      await refreshTopicSnapshot(
+        workspaceRoot,
+        normalized.slug,
+        existingTopics,
+      );
+    } catch (err) {
+      console.warn(
+        `[journal] failed to apply topic update for ${normalized.slug}:`,
+        err,
+      );
+    }
   }
   return { created, updated };
 }
@@ -740,7 +755,9 @@ async function writeDailySummary(
 // Distinguishes a true missing file (ENOENT) from other read errors
 // (permission denied, I/O failure) — without this, a transient EACCES
 // on an existing topic would silently overwrite it.
-async function appendOrCreate(
+//
+// Exported for unit testing in test/journal/test_appendOrCreate.ts.
+export async function appendOrCreate(
   filePath: string,
   content: string,
 ): Promise<"created" | "updated"> {

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -101,12 +101,23 @@ function respond(msg: unknown): void {
 //
 // `path` is the absolute server path (e.g. /api/internal/tool-result)
 // — the session query string is appended automatically.
+//
+// Network errors (DNS failure, connection refused, etc.) are wrapped
+// in a descriptive Error so the outer catch in handleToolCall reports
+// them as the failed tool call instead of a bare TypeError. HTTP
+// status checking (`!res.ok`) is left to call sites that need it,
+// since several callers fire-and-forget for the result push.
 async function postJson(path: string, body: unknown): Promise<Response> {
-  return fetch(`${BASE_URL}${path}?session=${SESSION_ID}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  try {
+    return await fetch(`${BASE_URL}${path}?session=${SESSION_ID}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Network error calling ${path}: ${message}`);
+  }
 }
 
 async function handleToolCall(

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -94,44 +94,41 @@ function respond(msg: unknown): void {
   process.stdout.write(JSON.stringify(msg) + "\n");
 }
 
+// All bridge calls go to the same backend on the same session, so
+// every fetch was duplicating the same headers, method, and
+// stringify boilerplate. `postJson` captures BASE_URL + SESSION_ID
+// once and lets handleToolCall focus on what it's calling, not how.
+//
+// `path` is the absolute server path (e.g. /api/internal/tool-result)
+// — the session query string is appended automatically.
+async function postJson(path: string, body: unknown): Promise<Response> {
+  return fetch(`${BASE_URL}${path}?session=${SESSION_ID}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 async function handleToolCall(
   name: string,
   args: Record<string, unknown>,
 ): Promise<string> {
   if (name === "switchRole") {
-    await fetch(`${BASE_URL}/api/internal/switch-role?session=${SESSION_ID}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ roleId: args.roleId }),
-    });
+    await postJson("/api/internal/switch-role", { roleId: args.roleId });
     return `Switching to ${args.roleId} role`;
   }
 
   if (name === "manageRoles") {
-    const res = await fetch(
-      `${BASE_URL}/api/roles/manage?session=${SESSION_ID}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(args),
-      },
-    );
+    const res = await postJson("/api/roles/manage", args);
     const result = await res.json();
 
     // For the list action, push a visual canvas result so the viewer renders
     if (args.action === "list" && result.success) {
-      await fetch(
-        `${BASE_URL}/api/internal/tool-result?session=${SESSION_ID}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            toolName: "manageRoles",
-            uuid: crypto.randomUUID(),
-            ...result,
-          }),
-        },
-      );
+      await postJson("/api/internal/tool-result", {
+        toolName: "manageRoles",
+        uuid: crypto.randomUUID(),
+        ...result,
+      });
     }
 
     return result.message ?? (result.error ? `Error: ${result.error}` : "Done");
@@ -140,14 +137,7 @@ async function handleToolCall(
   // Pure MCP tools — call via /api/mcp-tools/:tool, return text directly (no frontend push)
   const mcpTool = mcpTools.find((t) => t.definition.name === name);
   if (mcpTool) {
-    const res = await fetch(
-      `${BASE_URL}/api/mcp-tools/${name}?session=${SESSION_ID}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(args),
-      },
-    );
+    const res = await postJson(`/api/mcp-tools/${name}`, args);
     const json = await res.json();
     if (!res.ok) return `Error: ${json.error ?? res.status}`;
     return typeof json.result === "string"
@@ -158,23 +148,14 @@ async function handleToolCall(
   const tool = tools.find((t) => t.name === name);
   if (!tool) throw new Error(`Unknown tool: ${name}`);
 
-  const res = await fetch(`${BASE_URL}${tool.endpoint}?session=${SESSION_ID}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(args),
-  });
+  const res = await postJson(tool.endpoint!, args);
   const result = await res.json();
 
   // Push visual ToolResult to the frontend via the session
-  const toolResult = {
+  await postJson("/api/internal/tool-result", {
     toolName: name,
     uuid: crypto.randomUUID(),
     ...result,
-  };
-  await fetch(`${BASE_URL}/api/internal/tool-result?session=${SESSION_ID}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(toolResult),
   });
 
   const parts = [result.message, result.instructions].filter(Boolean);

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -102,22 +102,46 @@ function respond(msg: unknown): void {
 // `path` is the absolute server path (e.g. /api/internal/tool-result)
 // — the session query string is appended automatically.
 //
-// Network errors (DNS failure, connection refused, etc.) are wrapped
-// in a descriptive Error so the outer catch in handleToolCall reports
-// them as the failed tool call instead of a bare TypeError. HTTP
-// status checking (`!res.ok`) is left to call sites that need it,
-// since several callers fire-and-forget for the result push.
-async function postJson(path: string, body: unknown): Promise<Response> {
+// Both network errors and HTTP failures (4xx/5xx) are converted into
+// a descriptive Error by default, so the outer catch in handleToolCall
+// reports them as the failed tool call instead of a silent success.
+// Pass `allowHttpError: true` for callers that want to inspect the
+// response themselves (e.g. /api/mcp-tools/* which has its own
+// status-aware result handling).
+interface PostJsonOpts {
+  allowHttpError?: boolean;
+}
+
+async function postJson(
+  path: string,
+  body: unknown,
+  opts: PostJsonOpts = {},
+): Promise<Response> {
+  // SESSION_ID comes from the parent process env so it's effectively
+  // trusted, but encode it anyway — defense in depth against future
+  // callers passing unexpected characters (`&`, `#`, newlines, etc.).
+  // The path arg is used as-is because all current call sites pass
+  // hardcoded literals.
+  let res: Response;
   try {
-    return await fetch(`${BASE_URL}${path}?session=${SESSION_ID}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    res = await fetch(
+      `${BASE_URL}${path}?session=${encodeURIComponent(SESSION_ID)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Network error calling ${path}: ${message}`);
   }
+  if (!opts.allowHttpError && !res.ok) {
+    const text = await res.text().catch(() => "");
+    const detail = text ? `: ${text.slice(0, 500)}` : "";
+    throw new Error(`HTTP ${res.status} calling ${path}${detail}`);
+  }
+  return res;
 }
 
 async function handleToolCall(
@@ -145,10 +169,14 @@ async function handleToolCall(
     return result.message ?? (result.error ? `Error: ${result.error}` : "Done");
   }
 
-  // Pure MCP tools — call via /api/mcp-tools/:tool, return text directly (no frontend push)
+  // Pure MCP tools — call via /api/mcp-tools/:tool, return text directly
+  // (no frontend push). Opt out of postJson's HTTP error throw because
+  // we want to surface the JSON error body to the caller as a string.
   const mcpTool = mcpTools.find((t) => t.definition.name === name);
   if (mcpTool) {
-    const res = await postJson(`/api/mcp-tools/${name}`, args);
+    const res = await postJson(`/api/mcp-tools/${name}`, args, {
+      allowHttpError: true,
+    });
     const json = await res.json();
     if (!res.ok) return `Error: ${json.error ?? res.status}`;
     return typeof json.result === "string"

--- a/server/mcp-tools/index.ts
+++ b/server/mcp-tools/index.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { readXPost, searchX } from "./x.js";
+import { errorMessage } from "../utils/errors.js";
 
 export interface McpTool {
   definition: {
@@ -62,8 +63,7 @@ mcpToolsRouter.post(
       const result = await tool.handler(req.body);
       res.json({ result });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: message });
+      res.status(500).json({ error: errorMessage(err) });
     }
   },
 );

--- a/server/mcp-tools/x.ts
+++ b/server/mcp-tools/x.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from "../utils/errors.js";
+
 const X_API_BASE = "https://api.twitter.com/2";
 const TWEET_FIELDS =
   "tweet.fields=created_at,author_id,public_metrics,entities";
@@ -39,8 +41,7 @@ async function fetchX(path: string): Promise<XApiResponse> {
       headers: { Authorization: `Bearer ${token}` },
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`Network error calling X API: ${msg}`);
+    throw new Error(`Network error calling X API: ${errorMessage(err)}`);
   }
 
   if (response.status === 401)
@@ -113,7 +114,7 @@ export const readXPost = {
         `/tweets/${tweetId}?${TWEET_FIELDS}&${EXPANSIONS}&${USER_FIELDS}`,
       );
     } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+      return errorMessage(err);
     }
 
     if (data.errors?.length)
@@ -187,7 +188,7 @@ export const searchX = {
       params.append("user.fields", "name,username");
       data = await fetchX(`/tweets/search/recent?${params.toString()}`);
     } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+      return errorMessage(err);
     }
 
     if (data.errors?.length)

--- a/server/routes/dispatchResponse.ts
+++ b/server/routes/dispatchResponse.ts
@@ -1,0 +1,66 @@
+// Shared HTTP response plumbing for dispatcher-style POST routes
+// (currently todos and scheduler). Both routes follow the same
+// pattern: load items, run a pure dispatch function that returns a
+// discriminated `{ kind: "error" | "success" }` result, persist on
+// success when applicable, and translate to JSON. This module owns
+// the translation step so each route handler stays a few lines.
+
+import type { Response } from "express";
+
+export type DispatchResult<T> =
+  | { kind: "error"; status: number; error: string }
+  | {
+      kind: "success";
+      items: T[];
+      message: string;
+      jsonData: Record<string, unknown>;
+    };
+
+export interface DispatchSuccessResponse<T> {
+  data: { items: T[] };
+  message: string;
+  jsonData: Record<string, unknown>;
+  instructions: string;
+  updating: boolean;
+}
+
+export interface DispatchErrorResponse {
+  error: string;
+}
+
+export interface RespondOptions<T> {
+  // Whether to call the persist callback before responding. Different
+  // routes have different read-only action rules (e.g. todos has a
+  // READ_ONLY_ACTIONS set, scheduler exempts only "show"), so the
+  // caller decides per-request.
+  shouldPersist: boolean;
+  // Per-route instructions string baked into the response.
+  instructions: string;
+  // Persistence callback. Called with the post-dispatch items only
+  // when shouldPersist is true.
+  persist: (items: T[]) => void;
+}
+
+// Translate a DispatchResult into the JSON response shape used by
+// dispatcher-style routes. Side-effects: calls `options.persist` on
+// success when `options.shouldPersist` is true; writes the response.
+export function respondWithDispatchResult<T>(
+  res: Response<DispatchSuccessResponse<T> | DispatchErrorResponse>,
+  result: DispatchResult<T>,
+  options: RespondOptions<T>,
+): void {
+  if (result.kind === "error") {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+  if (options.shouldPersist) {
+    options.persist(result.items);
+  }
+  res.json({
+    data: { items: result.items },
+    message: result.message,
+    jsonData: result.jsonData,
+    instructions: options.instructions,
+    updating: true,
+  });
+}

--- a/server/routes/dispatchResponse.ts
+++ b/server/routes/dispatchResponse.ts
@@ -6,6 +6,7 @@
 // the translation step so each route handler stays a few lines.
 
 import type { Response } from "express";
+import { errorMessage } from "../utils/errors.js";
 
 export type DispatchResult<T> =
   | { kind: "error"; status: number; error: string }
@@ -44,6 +45,12 @@ export interface RespondOptions<T> {
 // Translate a DispatchResult into the JSON response shape used by
 // dispatcher-style routes. Side-effects: calls `options.persist` on
 // success when `options.shouldPersist` is true; writes the response.
+//
+// Persistence failures are caught and translated into a structured
+// 500 JSON error so the route's response contract stays consistent —
+// otherwise an fs.writeFileSync throw would bubble out and trigger
+// Express's default HTML error page instead of the JSON shape that
+// clients expect.
 export function respondWithDispatchResult<T>(
   res: Response<DispatchSuccessResponse<T> | DispatchErrorResponse>,
   result: DispatchResult<T>,
@@ -54,7 +61,14 @@ export function respondWithDispatchResult<T>(
     return;
   }
   if (options.shouldPersist) {
-    options.persist(result.items);
+    try {
+      options.persist(result.items);
+    } catch (err) {
+      res.status(500).json({
+        error: `Failed to persist changes: ${errorMessage(err)}`,
+      });
+      return;
+    }
   }
   res.json({
     data: { items: result.items },

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -180,9 +180,13 @@ interface PathQuery {
 // resolveSafe, stat it, and confirm it's a regular file. On any
 // failure this writes the appropriate 4xx response and returns null;
 // the caller bails out.
-function resolveAndStatFile(
+//
+// `T` lets each caller's Response type stay precise — both endpoints
+// have different success-shape unions and we just need ErrorResponse
+// to be one of the alternatives.
+function resolveAndStatFile<T>(
   req: Request<object, unknown, unknown, PathQuery>,
-  res: Response<ErrorResponse | unknown>,
+  res: Response<T | ErrorResponse>,
 ): { relPath: string; absPath: string; stat: fs.Stats } | null {
   const relPath = typeof req.query.path === "string" ? req.query.path : "";
   if (!relPath) {

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import fs from "fs";
 import path from "path";
 import { workspacePath } from "../workspace.js";
+import { statSafe, readDirSafe, resolveWithinRoot } from "../utils/fs.js";
 
 const router = Router();
 
@@ -96,53 +97,25 @@ function classify(filename: string): ContentKind {
   return "binary";
 }
 
-// Realpath of the workspace, computed once at module load. Using the
-// realpath defeats symlink-based escapes — `path.resolve` + `startsWith`
-// alone is insufficient because a symlink inside the workspace could
-// point at `/etc/passwd` and still pass the prefix check.
+// Cached realpath of the workspace. Computed once at module load so
+// every request avoids the syscall. resolveWithinRoot needs an
+// already-realpath'd root.
 const workspaceReal = fs.realpathSync(workspacePath);
 
+// Wraps the shared resolveWithinRoot helper with the additional
+// hidden-dir traversal check (e.g. `.git/config`). buildTree already
+// hides these from the listing, but the URL endpoints are reachable
+// directly so they need their own check.
 function resolveSafe(relPath: string): string | null {
-  const normalized = path.normalize(relPath || "");
-  const resolved = path.resolve(workspaceReal, normalized);
-  let resolvedReal: string;
-  try {
-    resolvedReal = fs.realpathSync(resolved);
-  } catch {
-    return null;
-  }
-  if (
-    resolvedReal !== workspaceReal &&
-    !resolvedReal.startsWith(workspaceReal + path.sep)
-  ) {
-    return null;
-  }
-  // Reject paths that traverse a hidden directory (e.g. `.git/config`).
-  // buildTree already hides these from the listing, but the URL endpoints
-  // are reachable directly so they need their own check.
-  const relativeFromWorkspace = path.relative(workspaceReal, resolvedReal);
+  const resolved = resolveWithinRoot(workspaceReal, relPath);
+  if (!resolved) return null;
+  const relativeFromWorkspace = path.relative(workspaceReal, resolved);
   if (relativeFromWorkspace) {
     for (const seg of relativeFromWorkspace.split(path.sep)) {
       if (HIDDEN_DIRS.has(seg)) return null;
     }
   }
-  return resolvedReal;
-}
-
-function readDirSafe(absPath: string): fs.Dirent[] {
-  try {
-    return fs.readdirSync(absPath, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-}
-
-function statSafe(absPath: string): fs.Stats | null {
-  try {
-    return fs.statSync(absPath);
-  } catch {
-    return null;
-  }
+  return resolved;
 }
 
 function buildTree(absPath: string, relPath: string): TreeNode {

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -175,31 +175,46 @@ interface PathQuery {
   path?: string;
 }
 
+// Shared validation preamble for /files/content and /files/raw. Both
+// endpoints need to: read `path` from the query, run it through
+// resolveSafe, stat it, and confirm it's a regular file. On any
+// failure this writes the appropriate 4xx response and returns null;
+// the caller bails out.
+function resolveAndStatFile(
+  req: Request<object, unknown, unknown, PathQuery>,
+  res: Response<ErrorResponse | unknown>,
+): { relPath: string; absPath: string; stat: fs.Stats } | null {
+  const relPath = typeof req.query.path === "string" ? req.query.path : "";
+  if (!relPath) {
+    res.status(400).json({ error: "path required" });
+    return null;
+  }
+  const absPath = resolveSafe(relPath);
+  if (!absPath) {
+    res.status(400).json({ error: "Path outside workspace" });
+    return null;
+  }
+  const stat = statSafe(absPath);
+  if (!stat) {
+    res.status(404).json({ error: "File not found" });
+    return null;
+  }
+  if (!stat.isFile()) {
+    res.status(400).json({ error: "Not a file" });
+    return null;
+  }
+  return { relPath, absPath, stat };
+}
+
 router.get(
   "/files/content",
   (
     req: Request<object, unknown, unknown, PathQuery>,
     res: Response<FileContentResponse | ErrorResponse>,
   ) => {
-    const relPath = typeof req.query.path === "string" ? req.query.path : "";
-    if (!relPath) {
-      res.status(400).json({ error: "path required" });
-      return;
-    }
-    const absPath = resolveSafe(relPath);
-    if (!absPath) {
-      res.status(400).json({ error: "Path outside workspace" });
-      return;
-    }
-    const stat = statSafe(absPath);
-    if (!stat) {
-      res.status(404).json({ error: "File not found" });
-      return;
-    }
-    if (!stat.isFile()) {
-      res.status(400).json({ error: "Not a file" });
-      return;
-    }
+    const ctx = resolveAndStatFile(req, res);
+    if (!ctx) return;
+    const { relPath, absPath, stat } = ctx;
 
     const meta = {
       path: relPath,
@@ -259,25 +274,10 @@ router.get(
     req: Request<object, unknown, unknown, PathQuery>,
     res: Response<ErrorResponse>,
   ) => {
-    const relPath = typeof req.query.path === "string" ? req.query.path : "";
-    if (!relPath) {
-      res.status(400).json({ error: "path required" });
-      return;
-    }
-    const absPath = resolveSafe(relPath);
-    if (!absPath) {
-      res.status(400).json({ error: "Path outside workspace" });
-      return;
-    }
-    const stat = statSafe(absPath);
-    if (!stat) {
-      res.status(404).json({ error: "File not found" });
-      return;
-    }
-    if (!stat.isFile()) {
-      res.status(400).json({ error: "Not a file" });
-      return;
-    }
+    const ctx = resolveAndStatFile(req, res);
+    if (!ctx) return;
+    const { absPath, stat } = ctx;
+
     if (stat.size > MAX_RAW_BYTES) {
       res.status(413).json({
         error: `File too large to stream (${stat.size} bytes, limit ${MAX_RAW_BYTES})`,

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 import { statSafe, readDirSafe, resolveWithinRoot } from "../utils/fs.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 
@@ -163,8 +164,9 @@ router.get(
       const tree = buildTree(workspaceReal, "");
       res.json(tree);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: `Failed to read workspace: ${message}` });
+      res
+        .status(500)
+        .json({ error: `Failed to read workspace: ${errorMessage(err)}` });
     }
   },
 );
@@ -242,8 +244,9 @@ router.get(
     try {
       content = fs.readFileSync(absPath, "utf-8");
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: `Failed to read file: ${message}` });
+      res
+        .status(500)
+        .json({ error: `Failed to read file: ${errorMessage(err)}` });
       return;
     }
     res.json({ kind: "text", ...meta, content });

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -246,14 +246,20 @@ interface PathQuery {
 }
 
 // Shared validation preamble for /files/content and /files/raw. Both
-// endpoints need to: read `path` from the query, run it through
-// resolveSafe, stat it, and confirm it's a regular file. On any
-// failure this writes the appropriate 4xx response and returns null;
-// the caller bails out.
+// endpoints need to: read `path` from the query, validate it's
+// inside the workspace (with symlink hardening), stat it, and
+// confirm it's a regular file. On any failure this writes the
+// appropriate 4xx response and returns null; the caller bails out.
 //
 // `T` lets each caller's Response type stay precise — both endpoints
 // have different success-shape unions and we just need ErrorResponse
 // to be one of the alternatives.
+//
+// Order matters: stat the syntactic candidate first so a missing
+// file gets a 404, then run the realpath-hardened resolveSafe check
+// for symlink escapes (which would return 400). Doing them in this
+// order keeps 404 reachable for the common "file not found" case
+// instead of conflating it with traversal attempts.
 function resolveAndStatFile<T>(
   req: Request<object, unknown, unknown, PathQuery>,
   res: Response<T | ErrorResponse>,
@@ -263,18 +269,35 @@ function resolveAndStatFile<T>(
     res.status(400).json({ error: "path required" });
     return null;
   }
-  const absPath = resolveSafe(relPath);
-  if (!absPath) {
-    res.status(400).json({ error: "Path outside workspace" });
-    return null;
-  }
-  const stat = statSafe(absPath);
+  // Syntactic candidate (no symlink resolution yet).
+  const candidate = path.resolve(workspaceReal, path.normalize(relPath));
+  const stat = statSafe(candidate);
   if (!stat) {
-    res.status(404).json({ error: "File not found" });
+    // Distinguish "missing file under workspace" (404) from "path
+    // syntactically outside workspace" (400). We check the
+    // syntactic relative form, NOT realpath, because the file
+    // doesn't exist so realpath would throw anyway.
+    const relativeFromWorkspace = path.relative(workspaceReal, candidate);
+    const escapesSyntactically =
+      relativeFromWorkspace === ".." ||
+      relativeFromWorkspace.startsWith(`..${path.sep}`);
+    if (escapesSyntactically) {
+      res.status(400).json({ error: "Path outside workspace" });
+    } else {
+      res.status(404).json({ error: "File not found" });
+    }
     return null;
   }
   if (!stat.isFile()) {
     res.status(400).json({ error: "Not a file" });
+    return null;
+  }
+  // File exists — run the realpath-hardened check to defeat
+  // symlink-escape attempts (e.g. workspace/secret → /etc/passwd).
+  // resolveSafe also rejects paths that traverse a hidden dir.
+  const absPath = resolveSafe(relPath);
+  if (!absPath) {
+    res.status(400).json({ error: "Path outside workspace" });
     return null;
   }
   return { relPath, absPath, stat };

--- a/server/routes/html.ts
+++ b/server/routes/html.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 import { getGeminiClient, isGeminiAvailable } from "../utils/gemini.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 const HTML_FILE = () => path.join(workspacePath, "html", "current.html");
@@ -69,9 +70,7 @@ router.post(
         data: { html, type: "tailwind" },
       });
     } catch (err) {
-      res
-        .status(500)
-        .json({ message: err instanceof Error ? err.message : String(err) });
+      res.status(500).json({ message: errorMessage(err) });
     }
   },
 );
@@ -114,9 +113,7 @@ router.post(
         updating: true,
       });
     } catch (err) {
-      res
-        .status(500)
-        .json({ message: err instanceof Error ? err.message : String(err) });
+      res.status(500).json({ message: errorMessage(err) });
     }
   },
 );

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -74,9 +74,7 @@ router.post(
         res.json({ message: message ?? "no image data in response" });
       }
     } catch (err) {
-      res
-        .status(500)
-        .json({ success: false, message: errorMessage(err) });
+      res.status(500).json({ success: false, message: errorMessage(err) });
     }
   },
 );
@@ -154,9 +152,7 @@ router.post(
         res.json({ message: message ?? "no image data in response" });
       }
     } catch (err) {
-      res
-        .status(500)
-        .json({ success: false, message: errorMessage(err) });
+      res.status(500).json({ success: false, message: errorMessage(err) });
     }
   },
 );

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -1,6 +1,9 @@
 import { Router, Request, Response } from "express";
 import { getSessionImageData } from "../sessions.js";
-import { getGeminiClient } from "../utils/gemini.js";
+import {
+  generateGeminiImageContent,
+  generateGeminiImageFromPrompt,
+} from "../utils/gemini.js";
 import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
@@ -38,27 +41,10 @@ router.post(
     }
 
     try {
-      const ai = getGeminiClient();
-      const modelName = model ?? "gemini-3.1-flash-image-preview";
-
-      const response = await ai.models.generateContent({
-        model: modelName,
-        contents: [{ text: prompt }],
-        config: {
-          responseModalities: ["TEXT", "IMAGE"],
-          imageConfig: { aspectRatio: "16:9" },
-        },
-      });
-
-      const parts = response.candidates?.[0]?.content?.parts ?? [];
-      let imageData: string | undefined;
-      let message: string | undefined;
-
-      for (const part of parts) {
-        if (part.text) message = part.text;
-        if (part.inlineData?.data) imageData = part.inlineData.data;
-      }
-
+      const { imageData, message } = await generateGeminiImageFromPrompt(
+        prompt,
+        model,
+      );
       if (imageData) {
         res.json({
           message: "image generation succeeded",
@@ -109,34 +95,20 @@ router.post(
     }
 
     try {
-      const ai = getGeminiClient();
-      const modelName = "gemini-3.1-flash-image-preview";
       const base64Data = currentImageData.replace(
         /^data:image\/[^;]+;base64,/,
         "",
       );
-
-      const response = await ai.models.generateContent({
-        model: modelName,
-        contents: [
-          {
-            parts: [
-              { inlineData: { mimeType: "image/png", data: base64Data } },
-              { text: prompt },
-            ],
-          },
-        ],
-      });
-
-      const parts = response.candidates?.[0]?.content?.parts ?? [];
-      let imageData: string | undefined;
-      let message: string | undefined;
-
-      for (const part of parts) {
-        if (part.text) message = part.text;
-        if (part.inlineData?.data) imageData = part.inlineData.data;
-      }
-
+      // /edit-image deliberately omits `config` (no aspectRatio) so
+      // Gemini preserves the input image's dimensions.
+      const { imageData, message } = await generateGeminiImageContent([
+        {
+          parts: [
+            { inlineData: { mimeType: "image/png", data: base64Data } },
+            { text: prompt },
+          ],
+        },
+      ]);
       if (imageData) {
         res.json({
           message: "image edit succeeded",

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { getSessionImageData } from "../sessions.js";
 import { getGeminiClient } from "../utils/gemini.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 
@@ -73,8 +74,9 @@ router.post(
         res.json({ message: message ?? "no image data in response" });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ success: false, message: msg });
+      res
+        .status(500)
+        .json({ success: false, message: errorMessage(err) });
     }
   },
 );
@@ -152,8 +154,9 @@ router.post(
         res.json({ message: message ?? "no image data in response" });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ success: false, message: msg });
+      res
+        .status(500)
+        .json({ success: false, message: errorMessage(err) });
     }
   },
 );

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -28,6 +28,13 @@ import { errorMessage } from "../utils/errors.js";
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
 
+// Realpath of the workspace, computed once at module load. Needed
+// because the stories realpath check below has to compare against a
+// candidate path built from the same realpath form — otherwise on
+// macOS where /tmp → /private/tmp, a workspace under /tmp would have
+// every legitimate request rejected.
+const workspaceReal = fs.realpathSync(workspacePath);
+
 // Lazily realpath the stories dir on first use. We can't realpath at
 // module load because the directory may not exist yet (it's created
 // on demand by /mulmo-script POST). The cache is invalidated never —
@@ -244,7 +251,9 @@ function resolveStoryPath(filePath: string, res: Response): string | null {
   // Syntactic stories/ membership check first, on the unresolved
   // candidate path. Distinguishes "outside stories" (400) from
   // "missing file" (404) and short-circuits before we hit realpath.
-  const candidate = path.resolve(workspacePath, filePath);
+  // Builds the candidate from the workspace's realpath so the
+  // comparison against storiesReal (also realpath'd) is symmetric.
+  const candidate = path.resolve(workspaceReal, filePath);
   if (
     candidate !== storiesReal &&
     !candidate.startsWith(storiesReal + path.sep)

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -253,7 +253,10 @@ function resolveStoryPath(filePath: string, res: Response): string | null {
     return null;
   }
   // realpath check — defeats symlink escapes (stories/foo → /etc/passwd).
-  const resolved = resolveWithinRoot(storiesReal, path.relative(storiesReal, candidate));
+  const resolved = resolveWithinRoot(
+    storiesReal,
+    path.relative(storiesReal, candidate),
+  );
   if (!resolved) {
     res.status(404).json({ error: `File not found: ${filePath}` });
     return null;

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -22,9 +22,26 @@ import {
 } from "mulmocast";
 import type { MulmoBeat, MulmoImagePromptMedia } from "@mulmocast/types";
 import { slugify } from "../utils/slug.js";
+import { resolveWithinRoot } from "../utils/fs.js";
 
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
+
+// Lazily realpath the stories dir on first use. We can't realpath at
+// module load because the directory may not exist yet (it's created
+// on demand by /mulmo-script POST). The cache is invalidated never —
+// once the dir exists, its realpath is stable.
+let storiesRealCache: string | null = null;
+function ensureStoriesReal(): string | null {
+  if (storiesRealCache) return storiesRealCache;
+  try {
+    fs.mkdirSync(storiesDir, { recursive: true });
+    storiesRealCache = fs.realpathSync(storiesDir);
+    return storiesRealCache;
+  } catch {
+    return null;
+  }
+}
 
 interface SaveMulmoScriptBody {
   script: MulmoScript;
@@ -216,17 +233,35 @@ function errorMessage(err: unknown): string {
 }
 
 // Helper: resolve and validate a stories filePath, returns absoluteFilePath or null
+//
+// Uses the realpath-based resolveWithinRoot helper to defeat
+// symlink-based escapes. The previous implementation used a plain
+// `path.resolve` + `startsWith` check, which a malicious symlink
+// under stories/ could bypass.
 function resolveStoryPath(filePath: string, res: Response): string | null {
-  const absoluteFilePath = path.resolve(workspacePath, filePath);
-  if (!absoluteFilePath.startsWith(storiesDir + path.sep)) {
+  const storiesReal = ensureStoriesReal();
+  if (!storiesReal) {
+    res.status(500).json({ error: "stories directory not available" });
+    return null;
+  }
+  // Syntactic stories/ membership check first, on the unresolved
+  // candidate path. Distinguishes "outside stories" (400) from
+  // "missing file" (404) and short-circuits before we hit realpath.
+  const candidate = path.resolve(workspacePath, filePath);
+  if (
+    candidate !== storiesReal &&
+    !candidate.startsWith(storiesReal + path.sep)
+  ) {
     res.status(400).json({ error: "Invalid filePath" });
     return null;
   }
-  if (!fs.existsSync(absoluteFilePath)) {
+  // realpath check — defeats symlink escapes (stories/foo → /etc/passwd).
+  const resolved = resolveWithinRoot(storiesReal, path.relative(storiesReal, candidate));
+  if (!resolved) {
     res.status(404).json({ error: `File not found: ${filePath}` });
     return null;
   }
-  return absoluteFilePath;
+  return resolved;
 }
 
 // Helper: build mulmo context for a story file

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -23,6 +23,7 @@ import {
 import type { MulmoBeat, MulmoImagePromptMedia } from "@mulmocast/types";
 import { slugify } from "../utils/slug.js";
 import { resolveWithinRoot } from "../utils/fs.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
@@ -226,10 +227,6 @@ router.get(
 function fileToDataUri(filePath: string, mimeType: string): string {
   const data = fs.readFileSync(filePath);
   return `data:${mimeType};base64,${data.toString("base64")}`;
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 // Helper: resolve and validate a stories filePath, returns absoluteFilePath or null

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -28,13 +28,6 @@ import { errorMessage } from "../utils/errors.js";
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
 
-// Realpath of the workspace, computed once at module load. Needed
-// because the stories realpath check below has to compare against a
-// candidate path built from the same realpath form — otherwise on
-// macOS where /tmp → /private/tmp, a workspace under /tmp would have
-// every legitimate request rejected.
-const workspaceReal = fs.realpathSync(workspacePath);
-
 // Lazily realpath the stories dir on first use. We can't realpath at
 // module load because the directory may not exist yet (it's created
 // on demand by /mulmo-script POST). The cache is invalidated never —
@@ -242,32 +235,46 @@ function fileToDataUri(filePath: string, mimeType: string): string {
 // symlink-based escapes. The previous implementation used a plain
 // `path.resolve` + `startsWith` check, which a malicious symlink
 // under stories/ could bypass.
+//
+// Callers pass workspace-relative paths like "stories/foo.json" or
+// "stories/__movies__/bar.mp4". We strip the leading "stories/"
+// segment and resolve the remainder against the realpath of the
+// stories directory itself — this works whether stories/ is a
+// regular directory or a legitimate symlink to another location
+// (e.g. workspace/stories → /ext/stories on a different disk).
 function resolveStoryPath(filePath: string, res: Response): string | null {
   const storiesReal = ensureStoriesReal();
   if (!storiesReal) {
     res.status(500).json({ error: "stories directory not available" });
     return null;
   }
-  // Syntactic stories/ membership check first, on the unresolved
-  // candidate path. Distinguishes "outside stories" (400) from
-  // "missing file" (404) and short-circuits before we hit realpath.
-  // Builds the candidate from the workspace's realpath so the
-  // comparison against storiesReal (also realpath'd) is symmetric.
-  const candidate = path.resolve(workspaceReal, filePath);
-  if (
-    candidate !== storiesReal &&
-    !candidate.startsWith(storiesReal + path.sep)
-  ) {
+  // Reject absolute paths and parent traversal at the syntactic
+  // level — defense in depth on top of the realpath check below.
+  if (path.isAbsolute(filePath)) {
     res.status(400).json({ error: "Invalid filePath" });
     return null;
   }
-  // realpath check — defeats symlink escapes (stories/foo → /etc/passwd).
-  const resolved = resolveWithinRoot(
-    storiesReal,
-    path.relative(storiesReal, candidate),
-  );
+  // Strip the optional "stories/" prefix so the remainder is a path
+  // relative to storiesReal. Accepts both "stories/foo.json" (the
+  // canonical caller convention) and bare "foo.json".
+  const STORIES_PREFIX = "stories" + path.sep;
+  const relFromStories =
+    filePath === "stories"
+      ? ""
+      : filePath.startsWith(STORIES_PREFIX) || filePath.startsWith("stories/")
+        ? filePath.slice("stories/".length)
+        : filePath;
+  // resolveWithinRoot enforces both the realpath boundary AND
+  // existence; ENOENT and traversal both produce null. Distinguish
+  // them via a follow-up existsSync so 404 vs 400 stays accurate.
+  const resolved = resolveWithinRoot(storiesReal, relFromStories);
   if (!resolved) {
-    res.status(404).json({ error: `File not found: ${filePath}` });
+    const candidate = path.resolve(storiesReal, relFromStories);
+    if (!fs.existsSync(candidate)) {
+      res.status(404).json({ error: `File not found: ${filePath}` });
+    } else {
+      res.status(400).json({ error: "Invalid filePath" });
+    }
     return null;
   }
   return resolved;

--- a/server/routes/pdf.ts
+++ b/server/routes/pdf.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { marked } from "marked";
 import puppeteer from "puppeteer";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 
@@ -98,9 +99,10 @@ router.post(
       const buffer = await renderPdf(wrapHtml(html, MARKDOWN_CSS), format);
       sendPdf(res, buffer, filename);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
       console.error("[pdf] generation failed:", err);
-      res.status(500).json({ error: `PDF generation failed: ${message}` });
+      res
+        .status(500)
+        .json({ error: `PDF generation failed: ${errorMessage(err)}` });
     }
   },
 );

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -18,17 +18,25 @@ interface PluginErrorResponse {
   message: string;
 }
 
-// Wraps a plugin's `execute*` function in an Express handler. Each
+// Wraps a plugin's `execute*` invocation in an Express handler. Each
 // plugin route used to inline the same try/catch + 500 response shell;
-// this collapses them to one line per route. The plugin function
-// receives the request body and returns whatever the plugin's
-// ToolResult shape is — typed as `T` so the response stays type-safe.
-function wrapPluginExecute<T>(
-  execute: (body: unknown) => Promise<T>,
-): (req: Request, res: Response<T | PluginErrorResponse>) => Promise<void> {
+// this collapses them to one line per route.
+//
+// The callback receives the Express request and is responsible for
+// pulling whatever it needs out of `req.body` and forwarding it to
+// the plugin's execute function. `req.body` is `any` by Express
+// default and each plugin's execute function does its own runtime
+// validation — matching the behavior of the inline handlers this
+// replaces.
+function wrapPluginExecute<TResult>(
+  execute: (req: Request) => Promise<TResult>,
+): (
+  req: Request,
+  res: Response<TResult | PluginErrorResponse>,
+) => Promise<void> {
   return async (req, res) => {
     try {
-      const result = await execute(req.body);
+      const result = await execute(req);
       res.json(result);
     } catch (err) {
       res.status(500).json({ message: errorMessage(err) });
@@ -99,24 +107,27 @@ router.post(
 );
 
 // presentSpreadsheet — uses package execute for validation/processing
-router.post("/present-spreadsheet", wrapPluginExecute(executeSpreadsheet));
+router.post(
+  "/present-spreadsheet",
+  wrapPluginExecute((req) => executeSpreadsheet(req.body)),
+);
 
 // createMindMap — uses package execute for node layout computation
 router.post(
   "/mindmap",
-  wrapPluginExecute((body) => executeMindMap(null as never, body)),
+  wrapPluginExecute((req) => executeMindMap(null as never, req.body)),
 );
 
 // putQuestions — quiz
 router.post(
   "/quiz",
-  wrapPluginExecute((body) => executeQuiz(null as never, body)),
+  wrapPluginExecute((req) => executeQuiz(null as never, req.body)),
 );
 
 // presentForm — form
 router.post(
   "/form",
-  wrapPluginExecute((body) => executeForm(null as never, body)),
+  wrapPluginExecute((req) => executeForm(null as never, req.body)),
 );
 
 // openCanvas — drawing canvas
@@ -128,13 +139,13 @@ router.post(
 // present3d — 3D visualization
 router.post(
   "/present3d",
-  wrapPluginExecute((body) => executePresent3D(null as never, body)),
+  wrapPluginExecute((req) => executePresent3D(null as never, req.body)),
 );
 
 // showMusic — sheet music display
 router.post(
   "/music",
-  wrapPluginExecute((body) => showMusic(null as never, body)),
+  wrapPluginExecute((req) => showMusic(null as never, req.body)),
 );
 
 export default router;

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -106,6 +106,13 @@ router.post(
   },
 );
 
+// `null as never` in the calls below: each plugin's `execute*`
+// function expects a client-side context object as its first
+// argument. The server-side bridge has no such context — these
+// functions only touch their second arg (the request body) on this
+// path — so we satisfy the type signature with a never cast rather
+// than fabricating a fake context.
+
 // presentSpreadsheet — uses package execute for validation/processing
 router.post(
   "/present-spreadsheet",

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -130,7 +130,10 @@ router.post(
 );
 
 // openCanvas — drawing canvas
-router.post("/canvas", wrapPluginExecute(() => executeOpenCanvas()));
+router.post(
+  "/canvas",
+  wrapPluginExecute(() => executeOpenCanvas()),
+);
 
 // present3d — 3D visualization
 router.post(

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -6,7 +6,10 @@ import { executeForm } from "@mulmochat-plugin/form";
 import { executeOpenCanvas } from "../../src/plugins/canvas/definition.js";
 import { executePresent3D } from "@gui-chat-plugin/present3d";
 import { showMusic } from "@gui-chat-plugin/music";
-import { getGeminiClient, isGeminiAvailable } from "../utils/gemini.js";
+import {
+  generateGeminiImageFromPrompt,
+  isGeminiAvailable,
+} from "../utils/gemini.js";
 import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
@@ -38,21 +41,8 @@ const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
 async function generateInlineImage(prompt: string): Promise<string | null> {
   if (!isGeminiAvailable()) return null;
   try {
-    const ai = getGeminiClient();
-    const response = await ai.models.generateContent({
-      model: "gemini-3.1-flash-image-preview",
-      contents: [{ text: prompt }],
-      config: {
-        responseModalities: ["TEXT", "IMAGE"],
-        imageConfig: { aspectRatio: "16:9" },
-      },
-    });
-    const parts = response.candidates?.[0]?.content?.parts ?? [];
-    for (const part of parts) {
-      if (part.inlineData?.data) {
-        return `data:image/png;base64,${part.inlineData.data}`;
-      }
-    }
+    const { imageData } = await generateGeminiImageFromPrompt(prompt);
+    if (imageData) return `data:image/png;base64,${imageData}`;
   } catch {
     // leave placeholder if generation fails
   }

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -7,11 +7,30 @@ import { executeOpenCanvas } from "../../src/plugins/canvas/definition.js";
 import { executePresent3D } from "@gui-chat-plugin/present3d";
 import { showMusic } from "@gui-chat-plugin/music";
 import { getGeminiClient, isGeminiAvailable } from "../utils/gemini.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 
 interface PluginErrorResponse {
   message: string;
+}
+
+// Wraps a plugin's `execute*` function in an Express handler. Each
+// plugin route used to inline the same try/catch + 500 response shell;
+// this collapses them to one line per route. The plugin function
+// receives the request body and returns whatever the plugin's
+// ToolResult shape is — typed as `T` so the response stays type-safe.
+function wrapPluginExecute<T>(
+  execute: (body: unknown) => Promise<T>,
+): (req: Request, res: Response<T | PluginErrorResponse>) => Promise<void> {
+  return async (req, res) => {
+    try {
+      const result = await execute(req.body);
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ message: errorMessage(err) });
+    }
+  };
 }
 
 const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
@@ -90,94 +109,39 @@ router.post(
 );
 
 // presentSpreadsheet — uses package execute for validation/processing
-router.post(
-  "/present-spreadsheet",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executeSpreadsheet(_req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
-);
+router.post("/present-spreadsheet", wrapPluginExecute(executeSpreadsheet));
 
 // createMindMap — uses package execute for node layout computation
 router.post(
   "/mindmap",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executeMindMap(null as never, _req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
+  wrapPluginExecute((body) => executeMindMap(null as never, body)),
 );
 
 // putQuestions — quiz
 router.post(
   "/quiz",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executeQuiz(null as never, _req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
+  wrapPluginExecute((body) => executeQuiz(null as never, body)),
 );
 
 // presentForm — form
 router.post(
   "/form",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executeForm(null as never, _req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
+  wrapPluginExecute((body) => executeForm(null as never, body)),
 );
 
 // openCanvas — drawing canvas
-router.post(
-  "/canvas",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executeOpenCanvas();
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
-);
+router.post("/canvas", wrapPluginExecute(() => executeOpenCanvas()));
 
 // present3d — 3D visualization
 router.post(
   "/present3d",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await executePresent3D(null as never, _req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
+  wrapPluginExecute((body) => executePresent3D(null as never, body)),
 );
 
 // showMusic — sheet music display
 router.post(
   "/music",
-  async (_req: Request, res: Response<PluginErrorResponse>) => {
-    try {
-      const result = await showMusic(null as never, _req.body);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ message: String(err) });
-    }
-  },
+  wrapPluginExecute((body) => showMusic(null as never, body)),
 );
 
 export default router;

--- a/server/routes/presentHtml.ts
+++ b/server/routes/presentHtml.ts
@@ -3,6 +3,7 @@ import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 import { slugify } from "../utils/slug.js";
+import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
 
@@ -52,9 +53,7 @@ router.post(
         data: { html, title, filePath },
       });
     } catch (err) {
-      res.status(500).json({
-        error: err instanceof Error ? err.message : String(err),
-      });
+      res.status(500).json({ error: errorMessage(err) });
     }
   },
 );

--- a/server/routes/scheduler.ts
+++ b/server/routes/scheduler.ts
@@ -6,6 +6,11 @@ import {
   dispatchScheduler,
   type SchedulerActionInput,
 } from "./schedulerHandlers.js";
+import {
+  respondWithDispatchResult,
+  type DispatchSuccessResponse,
+  type DispatchErrorResponse,
+} from "./dispatchResponse.js";
 
 const router = Router();
 
@@ -37,46 +42,22 @@ interface SchedulerBody extends SchedulerActionInput {
   action: string;
 }
 
-interface ErrorResponse {
-  error: string;
-}
-
-interface SchedulerResponse {
-  data: { items: ScheduledItem[] };
-  message: string;
-  jsonData: Record<string, unknown>;
-  instructions: string;
-  updating: boolean;
-}
-
 router.post(
   "/scheduler",
   (
     req: Request<object, unknown, SchedulerBody>,
-    res: Response<SchedulerResponse | ErrorResponse>,
+    res: Response<
+      DispatchSuccessResponse<ScheduledItem> | DispatchErrorResponse
+    >,
   ) => {
     const { action, ...input } = req.body;
     const items = loadItems();
-
     const result = dispatchScheduler(action, items, input);
-    if (result.kind === "error") {
-      res.status(result.status).json({ error: result.error });
-      return;
-    }
-
-    // Persist whenever the action mutated state. "show" returns the
-    // same array reference unchanged, so this no-ops in that case
-    // (saveItems is idempotent for equal content anyway).
-    if (action !== "show") {
-      saveItems(result.items);
-    }
-
-    res.json({
-      data: { items: result.items },
-      message: result.message,
-      jsonData: result.jsonData,
+    // "show" is the only read-only action; everything else mutates.
+    respondWithDispatchResult(res, result, {
+      shouldPersist: action !== "show",
       instructions: "Display the updated scheduler to the user.",
-      updating: true,
+      persist: saveItems,
     });
   },
 );

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -195,8 +195,11 @@ router.get(
                     } catch {
                       return entry;
                     }
-                    const filePath: string = entry.result.data.filePath;
-                    const candidate = path.resolve(workspacePath, filePath);
+                    const scriptRelPath: string = entry.result.data.filePath;
+                    const candidate = path.resolve(
+                      workspacePath,
+                      scriptRelPath,
+                    );
                     if (
                       candidate !== storiesReal &&
                       !candidate.startsWith(storiesReal + path.sep)

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,8 +1,10 @@
 import { Router, Request, Response } from "express";
+import fs from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../workspace.js";
 import { readManifest } from "../chat-index/indexer.js";
+import { resolveWithinRoot } from "../utils/fs.js";
 import type { ChatIndexEntry } from "../chat-index/types.js";
 
 async function readSessionMeta(
@@ -184,14 +186,28 @@ router.get(
                   entry.result?.data?.filePath
                 ) {
                   try {
+                    // Realpath-based traversal check defeats symlink
+                    // escapes — see resolveWithinRoot in utils/fs.ts.
                     const storiesDir = path.resolve(workspacePath, "stories");
-                    const scriptPath = path.resolve(
-                      workspacePath,
-                      entry.result.data.filePath,
-                    );
-                    if (!scriptPath.startsWith(storiesDir + path.sep)) {
+                    let storiesReal: string;
+                    try {
+                      storiesReal = fs.realpathSync(storiesDir);
+                    } catch {
                       return entry;
                     }
+                    const filePath: string = entry.result.data.filePath;
+                    const candidate = path.resolve(workspacePath, filePath);
+                    if (
+                      candidate !== storiesReal &&
+                      !candidate.startsWith(storiesReal + path.sep)
+                    ) {
+                      return entry;
+                    }
+                    const scriptPath = resolveWithinRoot(
+                      storiesReal,
+                      path.relative(storiesReal, candidate),
+                    );
+                    if (!scriptPath) return entry;
                     const scriptJson = await readFile(scriptPath, "utf-8");
                     return {
                       ...entry,

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -188,6 +188,9 @@ router.get(
                   try {
                     // Realpath-based traversal check defeats symlink
                     // escapes — see resolveWithinRoot in utils/fs.ts.
+                    // Resolve the stories dir's realpath so the
+                    // boundary check works even when stories/ itself
+                    // is a legitimate symlink to another disk.
                     const storiesDir = path.resolve(workspacePath, "stories");
                     let storiesReal: string;
                     try {
@@ -196,19 +199,15 @@ router.get(
                       return entry;
                     }
                     const scriptRelPath: string = entry.result.data.filePath;
-                    const candidate = path.resolve(
-                      workspacePath,
-                      scriptRelPath,
-                    );
-                    if (
-                      candidate !== storiesReal &&
-                      !candidate.startsWith(storiesReal + path.sep)
-                    ) {
-                      return entry;
-                    }
+                    if (path.isAbsolute(scriptRelPath)) return entry;
+                    // Strip optional "stories/" prefix so the
+                    // remainder is relative to storiesReal.
+                    const relFromStories = scriptRelPath.startsWith("stories/")
+                      ? scriptRelPath.slice("stories/".length)
+                      : scriptRelPath;
                     const scriptPath = resolveWithinRoot(
                       storiesReal,
-                      path.relative(storiesReal, candidate),
+                      relFromStories,
                     );
                     if (!scriptPath) return entry;
                     const scriptJson = await readFile(scriptPath, "utf-8");

--- a/server/routes/todos.ts
+++ b/server/routes/todos.ts
@@ -3,6 +3,11 @@ import path from "path";
 import { workspacePath } from "../workspace.js";
 import { loadJsonFile, saveJsonFile } from "../utils/file.js";
 import { dispatchTodos, type TodosActionInput } from "./todosHandlers.js";
+import {
+  respondWithDispatchResult,
+  type DispatchSuccessResponse,
+  type DispatchErrorResponse,
+} from "./dispatchResponse.js";
 
 const router = Router();
 
@@ -36,18 +41,6 @@ interface TodoBody extends TodosActionInput {
   action: string;
 }
 
-interface ErrorResponse {
-  error: string;
-}
-
-interface TodoResponse {
-  data: { items: TodoItem[] };
-  message: string;
-  jsonData: Record<string, unknown>;
-  instructions: string;
-  updating: boolean;
-}
-
 // Actions whose handlers may mutate state. "show" / "list_labels"
 // are read-only views; persisting their result would be a no-op.
 const READ_ONLY_ACTIONS = new Set(["show", "list_labels"]);
@@ -56,27 +49,15 @@ router.post(
   "/todos",
   (
     req: Request<object, unknown, TodoBody>,
-    res: Response<TodoResponse | ErrorResponse>,
+    res: Response<DispatchSuccessResponse<TodoItem> | DispatchErrorResponse>,
   ) => {
     const { action, ...input } = req.body;
     const items = loadTodos();
-
     const result = dispatchTodos(action, items, input);
-    if (result.kind === "error") {
-      res.status(result.status).json({ error: result.error });
-      return;
-    }
-
-    if (!READ_ONLY_ACTIONS.has(action)) {
-      saveTodos(result.items);
-    }
-
-    res.json({
-      data: { items: result.items },
-      message: result.message,
-      jsonData: result.jsonData,
+    respondWithDispatchResult(res, result, {
+      shouldPersist: !READ_ONLY_ACTIONS.has(action),
       instructions: "Display the updated todo list to the user.",
-      updating: true,
+      persist: saveTodos,
     });
   },
 );

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -1,0 +1,7 @@
+// Shared error helpers. Use `errorMessage(err)` instead of inlining
+// `err instanceof Error ? err.message : String(err)` — searching for
+// one canonical helper is easier than grepping for the inline form.
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/server/utils/fs.ts
+++ b/server/utils/fs.ts
@@ -1,0 +1,66 @@
+// Filesystem helpers shared across the server. Most are safe wrappers
+// around fs/fsp calls that swallow ENOENT/EACCES so the caller can do
+// `if (result === null)` instead of try/catch boilerplate.
+//
+// `resolveWithinRoot` is the realpath-based path-traversal check that
+// underpins every endpoint serving files out of the workspace. Use it
+// any time a relative path comes from an HTTP body or query string.
+
+import fs from "fs";
+import path from "path";
+
+export function statSafe(absPath: string): fs.Stats | null {
+  try {
+    return fs.statSync(absPath);
+  } catch {
+    return null;
+  }
+}
+
+export function readDirSafe(absPath: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(absPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+export async function readTextOrNull(file: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(file, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+// Resolve a relative path against a root, ensuring the result stays
+// inside the root after symlink resolution. Returns null on traversal
+// or if either path doesn't exist on disk.
+//
+// Defeats symlink-based escapes — `path.resolve` + `startsWith` alone
+// is insufficient because a symlink inside the root could point at
+// `/etc/passwd` and still pass the prefix check.
+//
+// `rootReal` MUST already be a realpath. Callers that have a
+// long-lived root (e.g. the workspace) typically realpath it once at
+// module load and pass the cached value here.
+export function resolveWithinRoot(
+  rootReal: string,
+  relPath: string,
+): string | null {
+  const normalized = path.normalize(relPath || "");
+  const resolved = path.resolve(rootReal, normalized);
+  let resolvedReal: string;
+  try {
+    resolvedReal = fs.realpathSync(resolved);
+  } catch {
+    return null;
+  }
+  if (
+    resolvedReal !== rootReal &&
+    !resolvedReal.startsWith(rootReal + path.sep)
+  ) {
+    return null;
+  }
+  return resolvedReal;
+}

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from "@google/genai";
+import { GoogleGenAI, type GenerateContentParameters } from "@google/genai";
 
 export function getGeminiClient(): GoogleGenAI {
   const apiKey = process.env.GEMINI_API_KEY;
@@ -8,4 +8,60 @@ export function getGeminiClient(): GoogleGenAI {
 
 export function isGeminiAvailable(): boolean {
   return !!process.env.GEMINI_API_KEY;
+}
+
+// --- Image generation -----------------------------------------------
+
+const DEFAULT_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
+
+const DEFAULT_IMAGE_CONFIG: GenerateContentParameters["config"] = {
+  responseModalities: ["TEXT", "IMAGE"],
+  imageConfig: { aspectRatio: "16:9" },
+};
+
+export interface GeminiImageResult {
+  // Raw base64 payload (no `data:` prefix). Undefined if Gemini
+  // declined to return an image, e.g. because the prompt was filtered.
+  imageData?: string;
+  // Optional text part returned alongside the image (or in lieu of
+  // it). Used as a fallback message when imageData is empty.
+  message?: string;
+}
+
+// Low-level wrapper around `ai.models.generateContent` that pulls
+// the first inline image and text part out of the response. Use this
+// when you need to pass custom `contents` (e.g. text + reference
+// image for /edit-image). Pass `undefined` for `config` to omit it
+// entirely from the request.
+export async function generateGeminiImageContent(
+  contents: GenerateContentParameters["contents"],
+  config?: GenerateContentParameters["config"],
+  model: string = DEFAULT_IMAGE_MODEL,
+): Promise<GeminiImageResult> {
+  const ai = getGeminiClient();
+  const response = await ai.models.generateContent({
+    model,
+    contents,
+    ...(config && { config }),
+  });
+  const parts = response.candidates?.[0]?.content?.parts ?? [];
+  const result: GeminiImageResult = {};
+  for (const part of parts) {
+    if (part.text) result.message = part.text;
+    if (part.inlineData?.data) result.imageData = part.inlineData.data;
+  }
+  return result;
+}
+
+// Convenience wrapper for the common "text prompt → image" path.
+// Uses the standard 16:9 image config.
+export async function generateGeminiImageFromPrompt(
+  prompt: string,
+  model?: string,
+): Promise<GeminiImageResult> {
+  return generateGeminiImageContent(
+    [{ text: prompt }],
+    DEFAULT_IMAGE_CONFIG,
+    model,
+  );
 }

--- a/test/journal/test_appendOrCreate.ts
+++ b/test/journal/test_appendOrCreate.ts
@@ -1,0 +1,103 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { appendOrCreate } from "../../server/journal/dailyPass.js";
+
+function makeScratch(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmoclaude-aoc-"));
+  return fs.realpathSync(dir);
+}
+
+function rm(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("appendOrCreate — happy paths", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch();
+  });
+  after(() => rm(scratch));
+
+  it("writes a fresh file when missing and reports 'created'", async () => {
+    const p = path.join(scratch, "topic-a.md");
+    const outcome = await appendOrCreate(p, "first line");
+    assert.equal(outcome, "created");
+    assert.equal(fs.readFileSync(p, "utf-8"), "first line");
+  });
+
+  it("appends with a blank-line separator and reports 'updated'", async () => {
+    const p = path.join(scratch, "topic-b.md");
+    fs.writeFileSync(p, "existing line");
+    const outcome = await appendOrCreate(p, "new line");
+    assert.equal(outcome, "updated");
+    assert.equal(fs.readFileSync(p, "utf-8"), "existing line\n\nnew line\n");
+  });
+
+  it("trims trailing whitespace from existing content before appending", async () => {
+    const p = path.join(scratch, "topic-c.md");
+    fs.writeFileSync(p, "existing\n\n\n");
+    await appendOrCreate(p, "added");
+    assert.equal(fs.readFileSync(p, "utf-8"), "existing\n\nadded\n");
+  });
+
+  it("appends correctly across multiple calls (trimEnd before each join)", async () => {
+    const p = path.join(scratch, "topic-d.md");
+    await appendOrCreate(p, "one");
+    await appendOrCreate(p, "two");
+    await appendOrCreate(p, "three");
+    // Each append trims the previous trailing newline before joining
+    // with "\n\n", so blank lines never multiply.
+    assert.equal(fs.readFileSync(p, "utf-8"), "one\n\ntwo\n\nthree\n");
+  });
+});
+
+// REGRESSION GUARD for the data-loss bug CodeRabbit caught:
+// readTextOrNull-based versions returned null on ANY read error, so
+// a transient EACCES on an existing topic file would cause
+// appendOrCreate to clobber it. The fixed version distinguishes
+// ENOENT and rethrows everything else.
+describe("appendOrCreate — non-ENOENT read errors", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch();
+  });
+  after(() => {
+    // Restore mode in case the test failed mid-flight, otherwise rm
+    // can't traverse the dir.
+    try {
+      fs.chmodSync(scratch, 0o755);
+    } catch {
+      /* ignore */
+    }
+    rm(scratch);
+  });
+
+  it("rethrows EACCES instead of clobbering an unreadable file", async (t) => {
+    if (process.platform === "win32" || process.getuid?.() === 0) {
+      // Windows perms don't behave the same way; root bypasses chmod.
+      t.skip("requires POSIX permissions and a non-root user");
+      return;
+    }
+    const p = path.join(scratch, "locked.md");
+    fs.writeFileSync(p, "important content");
+    fs.chmodSync(p, 0o000);
+    try {
+      await assert.rejects(
+        () => appendOrCreate(p, "would clobber"),
+        /EACCES|EPERM/,
+      );
+      // Restore perms and verify the file was NOT touched.
+      fs.chmodSync(p, 0o644);
+      assert.equal(fs.readFileSync(p, "utf-8"), "important content");
+    } finally {
+      try {
+        fs.chmodSync(p, 0o644);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+});

--- a/test/routes/test_dispatchResponse.ts
+++ b/test/routes/test_dispatchResponse.ts
@@ -1,0 +1,228 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Response } from "express";
+import {
+  respondWithDispatchResult,
+  type DispatchResult,
+} from "../../server/routes/dispatchResponse.js";
+
+// Minimal Response mock that records the status + JSON body the
+// helper writes. We don't pull in supertest because the helper is a
+// pure function over (response, result, options) — no routing needed.
+interface RecordedResponse {
+  statusCode: number;
+  body: unknown;
+  status(code: number): RecordedResponse;
+  json(payload: unknown): RecordedResponse;
+}
+
+function makeRes(): RecordedResponse {
+  const rec: RecordedResponse = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return rec;
+}
+
+interface Item {
+  id: string;
+  value: number;
+}
+
+const ITEMS: Item[] = [
+  { id: "a", value: 1 },
+  { id: "b", value: 2 },
+];
+
+describe("respondWithDispatchResult — error result", () => {
+  it("writes the dispatch error status and body", () => {
+    const res = makeRes();
+    const result: DispatchResult<Item> = {
+      kind: "error",
+      status: 400,
+      error: "bad request",
+    };
+    let persistCalled = false;
+    respondWithDispatchResult(res as unknown as Response, result, {
+      shouldPersist: true,
+      instructions: "should not be sent",
+      persist: () => {
+        persistCalled = true;
+      },
+    });
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, { error: "bad request" });
+    assert.equal(persistCalled, false, "persist must not run on error");
+  });
+
+  it("preserves the dispatch error status (e.g. 404)", () => {
+    const res = makeRes();
+    respondWithDispatchResult(
+      res as unknown as Response,
+      { kind: "error", status: 404, error: "not found" },
+      {
+        shouldPersist: false,
+        instructions: "x",
+        persist: () => {},
+      },
+    );
+    assert.equal(res.statusCode, 404);
+  });
+});
+
+describe("respondWithDispatchResult — success result", () => {
+  it("writes the success body without persisting when shouldPersist is false", () => {
+    const res = makeRes();
+    let persistCalled = false;
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: ITEMS,
+        message: "ok",
+        jsonData: { count: 2 },
+      },
+      {
+        shouldPersist: false,
+        instructions: "render the list",
+        persist: () => {
+          persistCalled = true;
+        },
+      },
+    );
+    assert.equal(persistCalled, false);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, {
+      data: { items: ITEMS },
+      message: "ok",
+      jsonData: { count: 2 },
+      instructions: "render the list",
+      updating: true,
+    });
+  });
+
+  it("calls persist with the result items when shouldPersist is true", () => {
+    const res = makeRes();
+    let persistedItems: Item[] | null = null;
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: ITEMS,
+        message: "saved",
+        jsonData: {},
+      },
+      {
+        shouldPersist: true,
+        instructions: "render",
+        persist: (items) => {
+          persistedItems = items;
+        },
+      },
+    );
+    assert.deepEqual(persistedItems, ITEMS);
+    assert.equal(res.statusCode, 200);
+  });
+
+  it("always sets updating: true on the success response", () => {
+    const res = makeRes();
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: [],
+        message: "",
+        jsonData: {},
+      },
+      {
+        shouldPersist: false,
+        instructions: "x",
+        persist: () => {},
+      },
+    );
+    const body = res.body as { updating: boolean };
+    assert.equal(body.updating, true);
+  });
+});
+
+describe("respondWithDispatchResult — persist throws", () => {
+  it("translates a persist throw into a 500 JSON error response", () => {
+    const res = makeRes();
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: ITEMS,
+        message: "ok",
+        jsonData: {},
+      },
+      {
+        shouldPersist: true,
+        instructions: "x",
+        persist: () => {
+          throw new Error("disk full");
+        },
+      },
+    );
+    assert.equal(res.statusCode, 500);
+    const body = res.body as { error: string };
+    assert.match(body.error, /Failed to persist changes/);
+    assert.match(body.error, /disk full/);
+  });
+
+  it("does not write the success body when persist throws", () => {
+    const res = makeRes();
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: ITEMS,
+        message: "should not appear",
+        jsonData: {},
+      },
+      {
+        shouldPersist: true,
+        instructions: "should not appear",
+        persist: () => {
+          throw new Error("nope");
+        },
+      },
+    );
+    const body = res.body as Record<string, unknown>;
+    assert.equal(body.message, undefined);
+    assert.equal(body.instructions, undefined);
+    assert.equal(body.updating, undefined);
+    assert.ok(body.error);
+  });
+
+  it("handles a persist throw with a non-Error value", () => {
+    const res = makeRes();
+    respondWithDispatchResult<Item>(
+      res as unknown as Response,
+      {
+        kind: "success",
+        items: ITEMS,
+        message: "ok",
+        jsonData: {},
+      },
+      {
+        shouldPersist: true,
+        instructions: "x",
+        persist: () => {
+          throw "string thrown directly";
+        },
+      },
+    );
+    assert.equal(res.statusCode, 500);
+    const body = res.body as { error: string };
+    assert.match(body.error, /string thrown directly/);
+  });
+});

--- a/test/utils/test_errors.ts
+++ b/test/utils/test_errors.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { errorMessage } from "../../server/utils/errors.js";
+
+describe("errorMessage", () => {
+  it("returns .message for an Error instance", () => {
+    assert.equal(errorMessage(new Error("boom")), "boom");
+  });
+
+  it("returns .message for a subclass of Error", () => {
+    class CustomError extends Error {}
+    assert.equal(errorMessage(new CustomError("specific")), "specific");
+  });
+
+  it("returns the string for a plain string", () => {
+    assert.equal(errorMessage("oops"), "oops");
+  });
+
+  it("returns 'null' for null", () => {
+    assert.equal(errorMessage(null), "null");
+  });
+
+  it("returns 'undefined' for undefined", () => {
+    assert.equal(errorMessage(undefined), "undefined");
+  });
+
+  it("returns numeric string for a number", () => {
+    assert.equal(errorMessage(42), "42");
+  });
+
+  it("returns '[object Object]' for a plain object without toString", () => {
+    // String() on a plain object falls through to Object.prototype.toString,
+    // which produces "[object Object]". We don't unwrap .message because
+    // an arbitrary object that happens to have a `message` field is not
+    // necessarily an Error and could be misleading.
+    assert.equal(errorMessage({ message: "trick" }), "[object Object]");
+  });
+
+  it("returns the empty string for an empty Error message", () => {
+    assert.equal(errorMessage(new Error("")), "");
+  });
+});

--- a/test/utils/test_fs.ts
+++ b/test/utils/test_fs.ts
@@ -1,0 +1,323 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  statSafe,
+  readDirSafe,
+  readTextOrNull,
+  resolveWithinRoot,
+} from "../../server/utils/fs.js";
+
+// Each test gets its own scratch dir so they can run in parallel and
+// don't have to clean up after each other. We realpath the dir up
+// front because the OS-level temp dir on macOS lives at /var/folders
+// (a symlink target of /tmp on some configs) and resolveWithinRoot
+// requires its `rootReal` arg to already be a realpath.
+function makeScratch(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `mulmoclaude-${prefix}-`));
+  return fs.realpathSync(dir);
+}
+
+function rm(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("statSafe", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch("statSafe");
+    fs.writeFileSync(path.join(scratch, "file.txt"), "hi");
+    fs.mkdirSync(path.join(scratch, "subdir"));
+  });
+  after(() => rm(scratch));
+
+  it("returns Stats for an existing file", () => {
+    const s = statSafe(path.join(scratch, "file.txt"));
+    assert.ok(s);
+    assert.ok(s!.isFile());
+  });
+
+  it("returns Stats for an existing directory", () => {
+    const s = statSafe(path.join(scratch, "subdir"));
+    assert.ok(s);
+    assert.ok(s!.isDirectory());
+  });
+
+  it("returns null for a missing path (ENOENT)", () => {
+    assert.equal(statSafe(path.join(scratch, "nope")), null);
+  });
+
+  it("returns null for an empty path string", () => {
+    assert.equal(statSafe(""), null);
+  });
+});
+
+describe("readDirSafe", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch("readDirSafe");
+    fs.writeFileSync(path.join(scratch, "a.txt"), "");
+    fs.writeFileSync(path.join(scratch, "b.txt"), "");
+    fs.mkdirSync(path.join(scratch, "sub"));
+  });
+  after(() => rm(scratch));
+
+  it("returns the directory entries with file types", () => {
+    const entries = readDirSafe(scratch)
+      .map((e) => e.name)
+      .sort();
+    assert.deepEqual(entries, ["a.txt", "b.txt", "sub"]);
+  });
+
+  it("returns [] for a missing directory", () => {
+    assert.deepEqual(readDirSafe(path.join(scratch, "nope")), []);
+  });
+
+  it("returns [] for a path that is a file (not a directory)", () => {
+    assert.deepEqual(readDirSafe(path.join(scratch, "a.txt")), []);
+  });
+
+  it("returns [] for an empty directory", () => {
+    const empty = path.join(scratch, "empty-dir");
+    fs.mkdirSync(empty);
+    assert.deepEqual(readDirSafe(empty), []);
+  });
+});
+
+describe("readTextOrNull", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch("readTextOrNull");
+    fs.writeFileSync(path.join(scratch, "hi.txt"), "hello world");
+  });
+  after(() => rm(scratch));
+
+  it("returns the file contents as a string", async () => {
+    assert.equal(
+      await readTextOrNull(path.join(scratch, "hi.txt")),
+      "hello world",
+    );
+  });
+
+  it("returns null for a missing file", async () => {
+    assert.equal(await readTextOrNull(path.join(scratch, "nope.txt")), null);
+  });
+
+  it("returns null for a directory", async () => {
+    assert.equal(await readTextOrNull(scratch), null);
+  });
+});
+
+describe("resolveWithinRoot — happy path", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch("resolveWithinRoot-happy");
+    fs.writeFileSync(path.join(scratch, "file.txt"), "");
+    fs.mkdirSync(path.join(scratch, "sub"));
+    fs.writeFileSync(path.join(scratch, "sub", "nested.txt"), "");
+  });
+  after(() => rm(scratch));
+
+  it("resolves a top-level file under the root", () => {
+    const out = resolveWithinRoot(scratch, "file.txt");
+    assert.equal(out, path.join(scratch, "file.txt"));
+  });
+
+  it("resolves a nested file under the root", () => {
+    const out = resolveWithinRoot(scratch, "sub/nested.txt");
+    assert.equal(out, path.join(scratch, "sub", "nested.txt"));
+  });
+
+  it("returns the root itself for empty relPath", () => {
+    assert.equal(resolveWithinRoot(scratch, ""), scratch);
+  });
+
+  it("returns the root itself for '.'", () => {
+    assert.equal(resolveWithinRoot(scratch, "."), scratch);
+  });
+
+  it("normalizes redundant separators and ./", () => {
+    assert.equal(
+      resolveWithinRoot(scratch, "./sub/./nested.txt"),
+      path.join(scratch, "sub", "nested.txt"),
+    );
+  });
+});
+
+describe("resolveWithinRoot — security: traversal", () => {
+  let scratch: string;
+  let outsideFile: string;
+  before(() => {
+    scratch = makeScratch("resolveWithinRoot-traversal");
+    fs.writeFileSync(path.join(scratch, "ok.txt"), "");
+    // Create a file OUTSIDE the root that traversal attacks would
+    // try to reach. Put it next to scratch so realpath can find it.
+    outsideFile = path.join(path.dirname(scratch), "outside.txt");
+    fs.writeFileSync(outsideFile, "secret");
+  });
+  after(() => {
+    fs.rmSync(outsideFile, { force: true });
+    rm(scratch);
+  });
+
+  it("rejects ../ traversal that lands outside the root", () => {
+    const out = resolveWithinRoot(scratch, "../outside.txt");
+    assert.equal(out, null);
+  });
+
+  it("rejects deeply nested ../ traversal", () => {
+    assert.equal(resolveWithinRoot(scratch, "../../../etc/passwd"), null);
+  });
+
+  it("rejects an absolute path that escapes the root", () => {
+    assert.equal(resolveWithinRoot(scratch, "/etc/passwd"), null);
+  });
+
+  it("rejects an absolute path that lands inside the root", () => {
+    // Even if the absolute path happens to be inside root, this is
+    // not a relative-path resolution and should fail. Per Node's
+    // path.resolve semantics, an absolute relPath wins, so the
+    // result IS scratch + ok.txt — and the realpath check passes.
+    // This documents the current behavior: callers should reject
+    // absolute paths separately if their semantics require it.
+    const inside = path.join(scratch, "ok.txt");
+    assert.equal(resolveWithinRoot(scratch, inside), inside);
+  });
+});
+
+describe("resolveWithinRoot — security: symlinks", () => {
+  let scratch: string;
+  let outsideFile: string;
+  before(() => {
+    scratch = makeScratch("resolveWithinRoot-symlinks");
+    fs.writeFileSync(path.join(scratch, "real.txt"), "");
+    outsideFile = path.join(path.dirname(scratch), "outside-target.txt");
+    fs.writeFileSync(outsideFile, "secret");
+    // Symlink inside scratch pointing OUTSIDE — the attack we
+    // designed resolveWithinRoot to defeat.
+    try {
+      fs.symlinkSync(outsideFile, path.join(scratch, "escape"));
+    } catch {
+      // Some CI environments (e.g. Windows without dev mode) can't
+      // create symlinks. Tests below will be skipped via the marker.
+    }
+    // Symlink inside scratch pointing to another file inside scratch
+    // — a legitimate symlink that should resolve normally.
+    try {
+      fs.symlinkSync(
+        path.join(scratch, "real.txt"),
+        path.join(scratch, "alias.txt"),
+      );
+    } catch {
+      /* ignore */
+    }
+  });
+  after(() => {
+    fs.rmSync(outsideFile, { force: true });
+    rm(scratch);
+  });
+
+  it("rejects a symlink that resolves outside the root", () => {
+    const escapeLink = path.join(scratch, "escape");
+    if (!fs.existsSync(escapeLink)) return; // platform skip
+    assert.equal(resolveWithinRoot(scratch, "escape"), null);
+  });
+
+  it("accepts a symlink that resolves inside the root", () => {
+    const aliasLink = path.join(scratch, "alias.txt");
+    if (!fs.existsSync(aliasLink)) return; // platform skip
+    // The alias is followed to its target — both are inside scratch.
+    assert.equal(
+      resolveWithinRoot(scratch, "alias.txt"),
+      path.join(scratch, "real.txt"),
+    );
+  });
+});
+
+// Regression: when the "root" passed to resolveWithinRoot is itself
+// the realpath of a symlinked directory (e.g. workspace/stories →
+// /ext/stories), child paths should still resolve correctly. The
+// previous bug in routes/mulmo-script.ts compared a candidate built
+// from the non-realpath workspace against the realpath stories dir,
+// rejecting every legitimate request.
+describe("resolveWithinRoot — symlinked root directory (A1 regression)", () => {
+  let realRoot: string;
+  let symlinkRoot: string;
+  before(() => {
+    realRoot = makeScratch("symlinkRoot-real");
+    fs.writeFileSync(path.join(realRoot, "story.json"), "{}");
+    fs.mkdirSync(path.join(realRoot, "sub"));
+    fs.writeFileSync(path.join(realRoot, "sub", "nested.mp4"), "");
+    // Create a symlink elsewhere that points at realRoot
+    const linkParent = makeScratch("symlinkRoot-link");
+    symlinkRoot = path.join(linkParent, "stories-link");
+    try {
+      fs.symlinkSync(realRoot, symlinkRoot);
+    } catch {
+      // Platform without symlink support — tests will skip via marker.
+    }
+  });
+  after(() => {
+    if (symlinkRoot) {
+      try {
+        fs.rmSync(path.dirname(symlinkRoot), { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+    rm(realRoot);
+  });
+
+  it("resolves child paths against the realpath of a symlinked root", () => {
+    if (!fs.existsSync(symlinkRoot)) return; // platform skip
+    // Caller realpaths the root once at module load — this is the
+    // pattern routes/mulmo-script.ts uses for ensureStoriesReal().
+    const rootReal = fs.realpathSync(symlinkRoot);
+    assert.equal(rootReal, realRoot, "sanity: realpath should follow symlink");
+    const out = resolveWithinRoot(rootReal, "story.json");
+    assert.equal(out, path.join(realRoot, "story.json"));
+  });
+
+  it("resolves nested paths under a symlinked root", () => {
+    if (!fs.existsSync(symlinkRoot)) return;
+    const rootReal = fs.realpathSync(symlinkRoot);
+    const out = resolveWithinRoot(rootReal, "sub/nested.mp4");
+    assert.equal(out, path.join(realRoot, "sub", "nested.mp4"));
+  });
+
+  it("rejects traversal even when the root is the realpath of a symlink", () => {
+    if (!fs.existsSync(symlinkRoot)) return;
+    const rootReal = fs.realpathSync(symlinkRoot);
+    assert.equal(resolveWithinRoot(rootReal, "../../etc/passwd"), null);
+  });
+});
+
+describe("resolveWithinRoot — missing files and edge cases", () => {
+  let scratch: string;
+  before(() => {
+    scratch = makeScratch("resolveWithinRoot-missing");
+  });
+  after(() => rm(scratch));
+
+  it("returns null for a non-existent leaf path", () => {
+    assert.equal(resolveWithinRoot(scratch, "nope.txt"), null);
+  });
+
+  it("returns null for a non-existent nested path", () => {
+    assert.equal(resolveWithinRoot(scratch, "a/b/c/d.txt"), null);
+  });
+
+  it("returns null when the root itself does not exist", () => {
+    const fake = path.join(scratch, "does-not-exist");
+    assert.equal(resolveWithinRoot(fake, "anything"), null);
+  });
+
+  it("rejects a path containing a null byte", () => {
+    // Node's fs.realpathSync throws on null bytes, which our catch
+    // converts to null. This protects against C-string truncation
+    // tricks even though Node itself isn't vulnerable.
+    assert.equal(resolveWithinRoot(scratch, "foo\0.txt"), null);
+  });
+});


### PR DESCRIPTION
Closes the low-risk recommendations from receptron/mulmoclaude#136.
The medium-risk `mulmo-script.ts` handler scaffolding (audit #1) is
**out of scope** and will be a follow-up PR.

## User Prompt

> server以下でDRYにできるものないか徹底的に調べて。重複しらべるツールをつかってもよいよ
> (Thoroughly check the server/ directory for things that can be made DRY-er. You can use a duplicate-detection tool.)
>
> とりあえず、それをそのままissueに転載して。そして、まずはリスクが低いものをまとめて実行。
> (For now, transcribe that as-is into an issue. Then bundle the low-risk items together and execute them.)

## What ships

In execution order — each is its own commit on this branch.

| # | Audit | Commit | Net |
|---|---|---|---|
| 1 | #7 | `refactor(server): extract fs helpers to server/utils/fs.ts` | +new utils file |
| 2 | sec | `fix(server): harden path-traversal checks in mulmo-script and sessions` | +44 |
| 3 | #6 | `refactor(server): adopt shared errorMessage helper` | +8 |
| 4 | #2 | `refactor(plugins): collapse boilerplate with wrapPluginExecute` | -36 |
| 5 | #5 | `refactor(files): share /files/content and /files/raw validation preamble` | wash |
| 6 | #3 | `refactor(mcp-server): consolidate fetch-POST-JSON into postJson helper` | -14 |
| 7 | #4 | `refactor(gemini): consolidate image generation helpers` | +18 |
| 8 | #8 | `refactor(routes): share dispatcher response plumbing across todos/scheduler` | +28 |
| 9 | #9 | `refactor(journal): extract appendOrCreate in dailyPass` | wash |
| 10 | — | `fix(server): make wrapPluginExecute and resolveAndStatFile generic-friendly` | +15 |

Net diff: 20 files, +595 / -368. The "added" lines are mostly the new shared helper files (`utils/fs.ts`, `utils/errors.ts`, `routes/dispatchResponse.ts`) and JSDoc comments documenting the rationale; per-call-site code shrank.

## Security finding addressed

`routes/mulmo-script.ts:219-230` (`resolveStoryPath`) and `routes/sessions.ts:187-194` did path-traversal checks with plain `path.resolve` + `startsWith(storiesDir + sep)` — **no `realpathSync`**. A malicious symlink under `stories/` pointing at `/etc/passwd` would have passed the check and let an attacker read arbitrary files outside the workspace. `routes/files.ts` already had a comment explaining why string-prefix checks are insufficient.

Both routes now adopt the realpath-based `resolveWithinRoot` helper from `server/utils/fs.ts`. The stories directory is realpath'd lazily on first use because it may not exist at module load.

## New shared helpers

- **`server/utils/fs.ts`** — `statSafe`, `readDirSafe`, `readTextOrNull`, `resolveWithinRoot`. Promoted out of `routes/files.ts`. `journal/dailyPass.ts` drops its local `readTextOrNull` copy in favor of the shared one.
- **`server/utils/errors.ts`** — `errorMessage(err)`. Adopted in 14 sites across 9 files (\`routes/files.ts\` ×2, \`presentHtml.ts\`, \`html.ts\` ×2, \`mulmo-script.ts\`, \`pdf.ts\`, \`image.ts\` ×2, \`chat-index/summarizer.ts\`, \`mcp-tools/index.ts\`, \`mcp-tools/x.ts\` ×3).
- **`server/utils/gemini.ts`** — added `generateGeminiImageContent` (low-level) and `generateGeminiImageFromPrompt` (text-prompt convenience). Replaces 3 copies of the SDK call + parts iteration in `routes/image.ts` (×2) and `routes/plugins.ts`.
- **`server/routes/dispatchResponse.ts`** — `respondWithDispatchResult` shared between `routes/todos.ts` and `routes/scheduler.ts`. Both routes had the same `{ kind: "error" | "success" }` → HTTP translation, differing only in their per-route persistence rule and instructions string.

## In-place refactors

- **`routes/plugins.ts`** — `wrapPluginExecute(req → execute(req.body))` collapses 7 try/catch handlers to one line each (~36 lines saved). Type-fixed in commit 10 to pass `req` instead of `req.body` so each callback's typed plugin function can pull the body itself.
- **`routes/files.ts`** — `resolveAndStatFile(req, res)` extracts the 17-line validation preamble shared by `/files/content` and `/files/raw`.
- **`mcp-server.ts`** — `postJson(path, body)` closure captures `BASE_URL` + `SESSION_ID`. 6 raw fetch sites collapse to one-liners.
- **`journal/dailyPass.ts`** — `appendOrCreate(filePath, content)` collapses `applyTopicUpdate`'s `create` and `append` branches.

## Out of scope

- **Audit #1** (`mulmo-script.ts` handler scaffolding, ~200 lines) — biggest payoff but medium risk. Saved for a follow-up PR now that the small utilities exist.
- Migrating `journal/index.ts`, `journal/state.ts`, `journal/optimizationPass.ts` to the new `fs.ts` helpers — those use async `fsp` and the helpers exposed here are sync. Defer until there's an actual reason.

## Verification

- `yarn format` ✓
- `yarn lint` ✓ (0 errors, 10 pre-existing warnings — none new)
- `yarn typecheck` ✓
- `yarn build` ✓
- `yarn test` ✓ (567/567 pass)

The dispatcher and `appendOrCreate` refactors are covered by `test/routes/test_todosHandlers.ts`, `test/routes/test_schedulerHandlers.ts`, and `test/journal/test_dailyPass.ts`. The other refactors are mechanical and rely on type-checking + the existing test suite.

## Test plan

- [x] yarn format / lint / typecheck / build / test
- [ ] Manual smoke: hit `/api/files/content?path=README.md` and `/api/files/raw?path=README.md` — confirm same response shape as before
- [ ] Manual smoke: open mulmo-script POST → render-beat round trip — confirm `resolveStoryPath` accepts legitimate paths
- [ ] Manual smoke: try `?path=../../etc/passwd` against `/api/files/content` — should still 400
- [ ] Manual smoke: open todos and scheduler views, add/remove items — confirm dispatch responses still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized error formatting, shared filesystem and Gemini/image helpers, unified plugin execution wrapper, and consolidated POST handling for more consistent behavior.
  * Standardized dispatcher-style responses and conditional persistence used by scheduler/todos.

* **New Features**
  * Shared image-generation helper for consistent image creation from prompts.

* **Bug Fixes**
  * Strengthened path resolution and symlink checks to prevent unsafe file access.
  * Removed duplicated file-append logic for more reliable journal updates.

* **Tests**
  * Added unit tests covering filesystem utilities, error formatting, dispatcher responses, and append-or-create behavior.

* **Documentation**
  * Added a low-risk refactor plan describing sequencing, verification, and scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->