### PR TITLE
fix(files): sandbox /files/raw with CSP to defuse SVG / HTML XSS

### DIFF
--- a/plans/fix-files-raw-csp-sandbox.md
+++ b/plans/fix-files-raw-csp-sandbox.md
@@ -1,0 +1,72 @@
+# Plan: defuse SVG XSS on `/api/files/raw` with a CSP sandbox header
+
+Follow-up to #146 (which fixed two PR #134 review findings but intentionally left this one out as a pre-existing concern).
+
+## Problem
+
+`/api/files/raw` serves any workspace file with its declared Content-Type. For `.svg` that's `image/svg+xml`, which means a SVG file with an inline `<script>` element executes in the localhost:3001 origin when loaded as a top-level document or inside an `<iframe>`.
+
+The `FilesView.vue` component currently loads images via `<img :src="rawUrl(...)">`, and `<img>` does **not** execute scripts in loaded SVGs — so the main preview surface is safe. But two attack vectors remain:
+
+1. **Direct navigation**: `http://localhost:3001/api/files/raw?path=evil.svg` in the URL bar runs scripts. Any link to a raw workspace URL is a footgun.
+2. **Future `<iframe>` use**: PDFs already use `<iframe :src="rawUrl(...)">` (line 173 in `FilesView.vue`). An `.svg` rendered via iframe would execute its scripts in the localhost origin, with access to session storage / cookies / fetch. PDFs themselves can carry JavaScript too.
+
+Threat model: a malicious `.svg` / `.html` / `.pdf` lands in the workspace (via an automated tool result, a wiki import, a downloaded file, etc.), and the user either clicks a direct link to it or previews it in the file explorer. The script gains localhost:3001 origin privileges — which means it can call every `/api/*` endpoint, read every workspace file, exfiltrate credentials from `.env`.
+
+## Fix
+
+Add two response headers on every `/api/files/raw` response:
+
+- `Content-Security-Policy: sandbox` — the `sandbox` directive creates an opaque origin for the response. Scripts can't access the parent page, can't read same-origin data, can't submit forms, can't run at all by default. SVG rendering still works visually; PDF rendering still works because the PDF reader doesn't rely on same-origin access to the parent.
+- `X-Content-Type-Options: nosniff` — stop browsers from second-guessing our declared Content-Type and running HTML sniffed out of a `.txt` download.
+
+CSP `sandbox` alone (no allow-flags) is the strictest setting and the right default for untrusted content previews. If a future feature needs JS inside the preview (e.g. an interactive HTML preview), the opt-in is to add `allow-scripts` etc. on a per-route basis.
+
+### Why not stronger / weaker options?
+
+- **`Content-Disposition: attachment`** would force download instead of inline preview — breaks the file explorer's raison d'être.
+- **Denylist `.svg` entirely** — same problem, breaks legitimate SVG preview.
+- **Strip `<script>` from SVG server-side** — whack-a-mole (event handlers, `xlink:href="data:..."`, foreign objects). CSP sandbox defeats all of them at once.
+- **Serve SVG as `text/plain`** — defeats rendering.
+- **Rewrite to `image/png`** — requires a rasterizer dependency. Overkill.
+
+`sandbox` is the industry-standard fix for exactly this scenario (static file servers hosting untrusted content).
+
+## Tradeoffs
+
+- **PDF iframe loses same-origin access to its parent Vue app.** We don't postMessage anything or otherwise rely on cross-frame communication, so nothing breaks. The PDF still renders, scrolls, zooms.
+- **Future "edit file inline" feature** (if anyone writes one using `contenteditable` in an iframe) would need to remove sandbox for that specific route. Not a concern today.
+- **SVG in `<img>`** is unaffected because browsers don't apply response CSP to image loads in `<img>` — the image renders as a bitmap and scripts are inert regardless. This fix is strict defense-in-depth for the iframe / direct-navigation cases.
+
+## Code change
+
+Single file: `server/routes/files.ts`, inside the `/files/raw` handler.
+
+```ts
+res.setHeader("Accept-Ranges", "bytes");
+res.setHeader("Content-Type", mime);
+// Defuse XSS in SVG / HTML / PDF-with-JS previews. The `sandbox`
+// directive with no flags creates an opaque origin for the
+// response, blocking scripts, forms, and same-origin access
+// even if the file content tries to run them.
+res.setHeader("Content-Security-Policy", "sandbox");
+// Prevent the browser from re-sniffing Content-Type on files it
+// thinks look like HTML.
+res.setHeader("X-Content-Type-Options", "nosniff");
+```
+
+Factor the two security headers into a tiny helper + export it so a unit test can pin the exact strings.
+
+## Tests
+
+- `test/routes/test_filesRoute.ts` — add a describe block for the new `RAW_SECURITY_HEADERS` constant / helper, asserting it contains both headers with the expected values. This doesn't exercise Express (the route-level tests would need supertest, which isn't in the repo), but it pin-tests the shape so a future edit can't accidentally drop the headers.
+- Manual: open an SVG / PDF / mp3 in the file explorer and confirm everything still works; check DevTools Network tab for the new response headers.
+
+## Commit structure
+
+Single commit on branch `fix/files-raw-csp-sandbox`, plan + code + test together.
+
+## Out of scope
+
+- CORS lockdown, listen-binding, `.env` blocklist → separate follow-up
+- CSRF origin check → separate follow-up after CORS lockdown lands

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -200,6 +200,33 @@ export function parseRange(header: string, size: number): ByteRange | null {
   return { start, end };
 }
 
+// Security headers applied to every `/files/raw` response. Exported
+// so a regression test can pin the exact strings down — a silent
+// regression here reopens a real XSS surface (see plans/
+// fix-files-raw-csp-sandbox.md for the full threat model).
+//
+// `sandbox` (no allow-flags) creates an opaque origin for the
+// response. Even if an SVG / HTML / PDF with embedded JavaScript
+// gets loaded as a top-level document or inside an iframe, its
+// scripts can't access the localhost:3001 origin's cookies,
+// session storage, or hit the `/api/*` endpoints. Frames rendering
+// the response become sandboxed too — PDFs still work because
+// they don't rely on same-origin access to the parent.
+//
+// `nosniff` stops Chrome / Firefox from re-guessing Content-Type
+// on files the server declared but the browser might want to
+// re-interpret as HTML.
+export const RAW_SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "Content-Security-Policy": "sandbox",
+  "X-Content-Type-Options": "nosniff",
+};
+
+function applyRawSecurityHeaders(res: Response): void {
+  for (const [name, value] of Object.entries(RAW_SECURITY_HEADERS)) {
+    res.setHeader(name, value);
+  }
+}
+
 // If the read stream errors mid-flight (file deleted, disk error,
 // permissions changed), surface a clean failure to the client instead
 // of leaving the connection hanging.
@@ -405,6 +432,11 @@ router.get(
     const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
     res.setHeader("Accept-Ranges", "bytes");
     res.setHeader("Content-Type", mime);
+    // Sandbox the response so an `.svg` / `.html` / `.pdf` with
+    // embedded JavaScript can't escape into the localhost:3001
+    // origin via direct navigation or <iframe>. See
+    // plans/fix-files-raw-csp-sandbox.md for the threat model.
+    applyRawSecurityHeaders(res);
 
     // Range support is required for `<video>` playback (Safari refuses
     // to play media without 206 responses) and for seek-past-buffered

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -108,9 +108,17 @@ interface FileContentMeta {
 
 type FileContentResponse = FileContentText | FileContentMeta;
 
-type ContentKind = "text" | "image" | "pdf" | "audio" | "video" | "binary";
+export type ContentKind =
+  | "text"
+  | "image"
+  | "pdf"
+  | "audio"
+  | "video"
+  | "binary";
 
-function classify(filename: string): ContentKind {
+// Exported for unit tests. Classification is purely extension-based
+// and case-insensitive (via `path.extname(...).toLowerCase()`).
+export function classify(filename: string): ContentKind {
   const ext = path.extname(filename).toLowerCase();
   if (TEXT_EXTENSIONS.has(ext)) return "text";
   if (IMAGE_EXTENSIONS.has(ext)) return "image";
@@ -155,7 +163,7 @@ function resolveSafe(relPath: string): string | null {
   return resolvedReal;
 }
 
-interface ByteRange {
+export interface ByteRange {
   start: number;
   end: number;
 }
@@ -165,8 +173,18 @@ interface ByteRange {
 // so the caller can respond 416. We deliberately reject multi-range
 // requests (`bytes=0-99,200-299`) since browsers don't issue them for
 // media playback and supporting them would complicate the response.
-function parseRange(header: string, size: number): ByteRange | null {
-  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+//
+// Exported for unit tests — this is the most security-sensitive piece
+// of the file-serving surface, so it's covered exhaustively in
+// `test/routes/test_filesRoute.ts`.
+export function parseRange(header: string, size: number): ByteRange | null {
+  // RFC 7233 §2.1: "A Range request on a representation whose current
+  // length is 0 cannot be satisfied". We also need this guard at the
+  // top because the naive suffix-range math below produces `end = -1`
+  // for zero-byte files, which then crashes `fs.createReadStream`
+  // with `ERR_OUT_OF_RANGE`.
+  if (size <= 0) return null;
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(header.trim());
   if (!match) return null;
   const [, startStr, endStr] = match;
   if (startStr === "" && endStr === "") return null;
@@ -396,6 +414,11 @@ router.get(
     if (rangeHeader) {
       const range = parseRange(rangeHeader, stat.size);
       if (!range) {
+        // The media MIME was set above so the 206 success path
+        // doesn't have to repeat it, but on a 416 we want JSON so
+        // `res.json` doesn't lie about the body's content-type. Set
+        // the Content-Range per RFC 7233 §4.4 before sending.
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
         res.setHeader("Content-Range", `bytes */${stat.size}`);
         res.status(416).json({ error: "Range not satisfiable" });
         return;

--- a/test/routes/test_filesRoute.ts
+++ b/test/routes/test_filesRoute.ts
@@ -11,7 +11,11 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseRange, classify } from "../../server/routes/files.js";
+import {
+  parseRange,
+  classify,
+  RAW_SECURITY_HEADERS,
+} from "../../server/routes/files.js";
 
 describe("parseRange — happy path", () => {
   it("parses a basic start-end range", () => {
@@ -246,5 +250,38 @@ describe("classify", () => {
   it("handles paths with directories", () => {
     assert.equal(classify("/path/to/song.mp3"), "audio");
     assert.equal(classify("dir\\windows\\file.png"), "image");
+  });
+});
+
+describe("RAW_SECURITY_HEADERS", () => {
+  // These tests don't exercise Express — supertest isn't in the
+  // dependency tree — but they pin the exact header strings down.
+  // Silently dropping the CSP header would reopen the SVG / HTML /
+  // PDF-with-JS XSS surface documented in
+  // plans/fix-files-raw-csp-sandbox.md.
+
+  it("sets Content-Security-Policy to `sandbox` (no allow flags)", () => {
+    // The bare `sandbox` directive is the strictest setting — it
+    // creates an opaque origin, blocks scripts, forms, and
+    // same-origin access. If a future edit weakens this to
+    // `sandbox allow-scripts` or similar, this assertion fires.
+    assert.equal(RAW_SECURITY_HEADERS["Content-Security-Policy"], "sandbox");
+  });
+
+  it("sets X-Content-Type-Options to nosniff", () => {
+    assert.equal(RAW_SECURITY_HEADERS["X-Content-Type-Options"], "nosniff");
+  });
+
+  it("does not set any allow-listing header that would defeat sandbox", () => {
+    // Guardrails: if someone adds a future header that opens the
+    // sandbox back up, this catches it early.
+    assert.equal(
+      RAW_SECURITY_HEADERS["Access-Control-Allow-Origin"],
+      undefined,
+    );
+    assert.equal(
+      RAW_SECURITY_HEADERS["Cross-Origin-Resource-Policy"],
+      undefined,
+    );
   });
 });

--- a/test/routes/test_filesRoute.ts
+++ b/test/routes/test_filesRoute.ts
@@ -1,0 +1,250 @@
+// Unit tests for the pure helpers in `server/routes/files.ts`.
+// `parseRange` is the most security-sensitive piece of new code on
+// PR #134 — a naive implementation crashes the server on
+// `bytes=-N` against a zero-byte file because Node's
+// `fs.createReadStream({end: -1})` throws ERR_OUT_OF_RANGE
+// synchronously. The whole function is covered here, including
+// the zero-byte edge case and the usual happy / unhappy paths.
+//
+// `classify` is simpler but regresses easily when a new extension
+// is added in the wrong set — keep the table honest.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseRange, classify } from "../../server/routes/files.js";
+
+describe("parseRange — happy path", () => {
+  it("parses a basic start-end range", () => {
+    assert.deepEqual(parseRange("bytes=0-99", 200), { start: 0, end: 99 });
+  });
+
+  it("parses an open-ended start-end range", () => {
+    assert.deepEqual(parseRange("bytes=100-", 200), { start: 100, end: 199 });
+  });
+
+  it("parses a start-end range covering just the last byte", () => {
+    assert.deepEqual(parseRange("bytes=199-199", 200), {
+      start: 199,
+      end: 199,
+    });
+  });
+
+  it("parses a start-end range covering the whole file", () => {
+    assert.deepEqual(parseRange("bytes=0-199", 200), { start: 0, end: 199 });
+  });
+
+  it("parses a suffix range that fits inside the file", () => {
+    assert.deepEqual(parseRange("bytes=-50", 200), { start: 150, end: 199 });
+  });
+
+  it("clamps a suffix range longer than the file to the whole file", () => {
+    // RFC 7233: a suffix-length longer than the representation → whole thing.
+    assert.deepEqual(parseRange("bytes=-500", 30), { start: 0, end: 29 });
+  });
+
+  it("parses a single-byte suffix", () => {
+    assert.deepEqual(parseRange("bytes=-1", 10), { start: 9, end: 9 });
+  });
+
+  it("accepts case-insensitive token (defensive — browsers send lowercase)", () => {
+    assert.deepEqual(parseRange("BYTES=0-99", 200), { start: 0, end: 99 });
+    assert.deepEqual(parseRange("Bytes=0-99", 200), { start: 0, end: 99 });
+  });
+
+  it("accepts leading/trailing whitespace", () => {
+    assert.deepEqual(parseRange("  bytes=0-99  ", 200), { start: 0, end: 99 });
+  });
+});
+
+describe("parseRange — unsatisfiable ranges (returns null for 416)", () => {
+  it("rejects start >= size", () => {
+    assert.equal(parseRange("bytes=200-300", 200), null);
+  });
+
+  it("rejects end >= size (inclusive check)", () => {
+    assert.equal(parseRange("bytes=0-200", 200), null);
+  });
+
+  it("rejects start > end", () => {
+    assert.equal(parseRange("bytes=100-50", 200), null);
+  });
+
+  it("rejects past-EOF start with open end", () => {
+    // bytes=200- with size=200: end = 199, start = 200, end < start → null
+    assert.equal(parseRange("bytes=200-", 200), null);
+  });
+});
+
+describe("parseRange — malformed input (returns null)", () => {
+  it("rejects multi-range requests", () => {
+    assert.equal(parseRange("bytes=0-99,200-299", 500), null);
+  });
+
+  it("rejects non-numeric values", () => {
+    assert.equal(parseRange("bytes=abc-def", 200), null);
+  });
+
+  it("rejects the wrong unit token", () => {
+    assert.equal(parseRange("pixels=0-99", 200), null);
+  });
+
+  it("rejects an entirely empty spec", () => {
+    assert.equal(parseRange("bytes=-", 200), null);
+  });
+
+  it("rejects a missing range body", () => {
+    assert.equal(parseRange("bytes=", 200), null);
+  });
+
+  it("rejects a zero-length suffix", () => {
+    // bytes=-0 is malformed per RFC 7233 §2.1 (suffix-length must be > 0).
+    assert.equal(parseRange("bytes=-0", 200), null);
+  });
+
+  it("rejects a negative-looking start", () => {
+    // -99-199 fails the regex (\d* doesn't match `-`)
+    assert.equal(parseRange("bytes=-99-199", 200), null);
+  });
+
+  it("rejects garbage wrapping a valid-looking range", () => {
+    assert.equal(parseRange("x bytes=0-99", 200), null);
+    assert.equal(parseRange("bytes=0-99 junk", 200), null);
+  });
+});
+
+describe("parseRange — zero-byte file (regression: PR #134 review)", () => {
+  // A naive suffix-range implementation produces {start: 0, end: -1}
+  // for a zero-byte file, which then crashes `fs.createReadStream`
+  // synchronously with `ERR_OUT_OF_RANGE`. This was a live 500-error
+  // bug on the PR; the regression test below pins every flavor of
+  // range spec against size=0 so it can't creep back.
+
+  it("rejects a suffix range on a zero-byte file (the bug)", () => {
+    assert.equal(parseRange("bytes=-1", 0), null);
+    assert.equal(parseRange("bytes=-100", 0), null);
+  });
+
+  it("rejects a start-end range on a zero-byte file", () => {
+    assert.equal(parseRange("bytes=0-0", 0), null);
+    assert.equal(parseRange("bytes=0-", 0), null);
+  });
+
+  it("rejects any range on a zero-byte file uniformly", () => {
+    for (const header of [
+      "bytes=0-0",
+      "bytes=0-",
+      "bytes=-1",
+      "bytes=-100",
+      "bytes=0-99",
+    ]) {
+      assert.equal(
+        parseRange(header, 0),
+        null,
+        `expected null for ${header} on empty file`,
+      );
+    }
+  });
+});
+
+describe("parseRange — integer / precision boundaries", () => {
+  it("accepts very large finite numbers that are still in-range", () => {
+    // Double-precision can represent integers up to 2^53 exactly. A
+    // 50 MB file is far below that, but the parser shouldn't choke
+    // on big numbers per se — only on ones that fall outside the
+    // file bounds.
+    assert.deepEqual(parseRange("bytes=0-49", 50), { start: 0, end: 49 });
+  });
+
+  it("rejects very large out-of-range numbers", () => {
+    assert.equal(parseRange("bytes=9999-99999", 200), null);
+  });
+});
+
+describe("classify", () => {
+  it("classifies common audio extensions", () => {
+    for (const name of [
+      "foo.mp3",
+      "foo.wav",
+      "foo.m4a",
+      "foo.ogg",
+      "foo.oga",
+      "foo.flac",
+      "foo.aac",
+    ]) {
+      assert.equal(classify(name), "audio", `expected audio for ${name}`);
+    }
+  });
+
+  it("classifies common video extensions", () => {
+    for (const name of [
+      "foo.mp4",
+      "foo.webm",
+      "foo.mov",
+      "foo.m4v",
+      "foo.ogv",
+    ]) {
+      assert.equal(classify(name), "video", `expected video for ${name}`);
+    }
+  });
+
+  it("is case-insensitive on the extension", () => {
+    assert.equal(classify("SONG.MP3"), "audio");
+    assert.equal(classify("MOVIE.MP4"), "video");
+    assert.equal(classify("Photo.PNG"), "image");
+  });
+
+  it("classifies PDFs", () => {
+    assert.equal(classify("doc.pdf"), "pdf");
+  });
+
+  it("classifies images", () => {
+    for (const name of [
+      "a.png",
+      "a.jpg",
+      "a.jpeg",
+      "a.gif",
+      "a.webp",
+      "a.svg",
+    ]) {
+      assert.equal(classify(name), "image");
+    }
+  });
+
+  it("classifies common text extensions", () => {
+    for (const name of [
+      "README.md",
+      "notes.txt",
+      "data.json",
+      "config.yaml",
+      "index.ts",
+      "app.vue",
+    ]) {
+      assert.equal(classify(name), "text");
+    }
+  });
+
+  it("treats files with no extension as text (README, LICENSE, etc.)", () => {
+    assert.equal(classify("README"), "text");
+    assert.equal(classify("LICENSE"), "text");
+    assert.equal(classify(""), "text");
+  });
+
+  it("classifies unknown extensions as binary", () => {
+    assert.equal(classify("archive.zip"), "binary");
+    assert.equal(classify("image.bmp"), "binary");
+    assert.equal(classify("data.bin"), "binary");
+    assert.equal(classify("font.ttf"), "binary");
+  });
+
+  it("uses the LAST extension when multiple dots are present", () => {
+    // path.extname semantics.
+    assert.equal(classify("report.final.pdf"), "pdf");
+    assert.equal(classify("jingle.txt.mp3"), "audio");
+    assert.equal(classify("archive.tar.gz"), "binary");
+  });
+
+  it("handles paths with directories", () => {
+    assert.equal(classify("/path/to/song.mp3"), "audio");
+    assert.equal(classify("dir\\windows\\file.png"), "image");
+  });
+});


### PR DESCRIPTION
First of three pre-existing security follow-ups to the merged #134 / #146.

## Problem

`/api/files/raw` serves any workspace file with its declared Content-Type. For `.svg` that's `image/svg+xml` — so a SVG with an inline `<script>` executes in the localhost:3001 origin when loaded as a top-level document or inside an `<iframe>`.

`FilesView.vue` loads images via `<img :src=...>` which is safe (browsers don't execute SVG scripts in image contexts), but two attack vectors remain:

1. **Direct navigation**: `http://localhost:3001/api/files/raw?path=evil.svg` in the URL bar runs the script in the page origin
2. **Iframe rendering**: PDFs already use `<iframe :src=...>` (line 173 in `FilesView.vue`). A future `.svg` / `.html` preview via iframe would execute scripts in the localhost origin with access to session storage, fetch, and every `/api/*` endpoint — including the `.env` leak via `/files/content`

Threat model: malicious content lands in the workspace via tool output / wiki import / downloaded file, user previews it, script gains full localhost privileges.

## Fix

Add two response headers on every `/files/raw` response via a new `applyRawSecurityHeaders(res)` helper:

- **`Content-Security-Policy: sandbox`** — the bare `sandbox` directive (no allow-flags) creates an opaque origin for the response. Scripts, forms, and same-origin access are all blocked. SVG still renders visually. PDF still works in the iframe viewer (we don't rely on cross-frame postMessage between the preview iframe and the Vue app).
- **`X-Content-Type-Options: nosniff`** — stops Chrome / Firefox from re-guessing the declared Content-Type on content that happens to look like HTML.

The header strings live in an exported `RAW_SECURITY_HEADERS` constant so a regression test can pin them down. A silent weakening (e.g. `sandbox allow-scripts`) would reopen the whole surface, so the unit test fails fast on any edit.

## Why `sandbox` (not a custom CSP)?

| Alternative | Why rejected |
|---|---|
| `Content-Disposition: attachment` | Forces download — breaks the file explorer's inline preview |
| Denylist `.svg` entirely | Breaks legitimate SVG preview |
| Strip `<script>` server-side | Whack-a-mole (event handlers, xlink:href=\"data:...\", foreign objects) |
| Serve SVG as `text/plain` | Defeats rendering |
| Rasterize to PNG | Requires a rasterizer dep, overkill |

\`sandbox\` is the industry standard for static file servers hosting untrusted content.

## Tradeoffs

- **PDF iframe loses same-origin access to its parent Vue app.** We don't postMessage anything or otherwise rely on cross-frame communication, so nothing breaks. The PDF still renders, scrolls, zooms.
- **SVG in `<img>`** is unaffected because browsers don't apply response CSP to image loads — this is strict defense-in-depth for the iframe / direct-navigation paths.
- **Future \"edit file inline\" feature** would need to remove sandbox for that specific route. Not a concern today.

## Tests

3 new tests on `RAW_SECURITY_HEADERS`:

\`\`\`ts
it(\"sets Content-Security-Policy to `sandbox` (no allow flags)\", () => {
  assert.equal(RAW_SECURITY_HEADERS[\"Content-Security-Policy\"], \"sandbox\");
});

it(\"sets X-Content-Type-Options to nosniff\", () => {
  assert.equal(RAW_SECURITY_HEADERS[\"X-Content-Type-Options\"], \"nosniff\");
});

it(\"does not set any allow-listing header that would defeat sandbox\", () => {
  // Guardrail: catches future CORS / CORP additions
  assert.equal(RAW_SECURITY_HEADERS[\"Access-Control-Allow-Origin\"], undefined);
  assert.equal(RAW_SECURITY_HEADERS[\"Cross-Origin-Resource-Policy\"], undefined);
});
\`\`\`

Route-level integration tests would need `supertest` (not in the dependency tree) — pinning the constant is the next-best thing.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` (0 errors, 8 pre-existing warnings)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` — **647/647** passing (was 644, +3)
- [ ] Manual: open an SVG in the file explorer → verify it renders
- [ ] Manual: open a PDF in the file explorer → verify it renders in the iframe
- [ ] Manual: in DevTools Network tab, check `/api/files/raw` response for `Content-Security-Policy: sandbox` and `X-Content-Type-Options: nosniff`
- [ ] Manual: `curl -i \"http://localhost:3001/api/files/raw?path=some.svg\"` and visually confirm headers

## Out of scope (separate PRs)

- **PR 2** — `cors()` wide open, server listening on 0.0.0.0, `.env` readable via `/files/content`. Fix with CORS whitelist + localhost bind + sensitive-file denylist.
- **PR 3** — CSRF origin check on state-changing routes. Builds on PR 2's whitelist.

Plan file: `plans/fix-files-raw-csp-sandbox.md`

Refs #134, #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)