### PR TITLE
fix(server): bind localhost + drop cors() + deny sensitive files

### DIFF
--- a/plans/fix-server-lockdown-cors-localhost.md
+++ b/plans/fix-server-lockdown-cors-localhost.md
@@ -1,0 +1,94 @@
+# Plan: lock the Express server to localhost + restrict CORS + deny sensitive files
+
+Second of three pre-existing security follow-ups to the merged #134 (see also #147 for the SVG CSP sandbox and the upcoming CSRF origin-check PR).
+
+## Problem — drive-by credential theft
+
+Three defects compound into a single concrete attack: a malicious web page the user visits while the dev server is running can read `~/mulmoclaude/.env`.
+
+### Defect A — server binds to `0.0.0.0`
+
+`server/index.ts` calls `app.listen(PORT, "0.0.0.0", ...)` and `net.createServer().listen(port, "0.0.0.0")` for the port probe. `0.0.0.0` means "every interface on this machine" — the dev server is exposed to the entire LAN. Anyone on the same Wi-Fi can reach `http://<laptop-ip>:3001/api/files/content?path=.env`. No browser required.
+
+### Defect B — `cors()` is wide open
+
+`app.use(cors())` with no arguments enables the permissive default: `Access-Control-Allow-Origin: *`, all methods, all headers. A page at `http://evil.example` can `fetch("http://localhost:3001/api/files/content?path=.env")` and read the response. Vite's dev proxy means no legitimate caller needs cross-origin headers — all real traffic is same-origin (or server-to-server, which doesn't use CORS at all).
+
+### Defect C — `.env` is in the TEXT_EXTENSIONS whitelist
+
+`server/routes/files.ts:31` includes `.env` in `TEXT_EXTENSIONS`, so `/files/content?path=.env` returns its contents as JSON text. Other sensitive files (`*.pem`, `*.key`, SSH private keys) aren't in the whitelist but are still reachable via `/files/raw` as "binary" — the binary is octet-stream, which a fetch client can still read byte-for-byte.
+
+## Fix — defense in depth, one PR
+
+### 1. Bind to `127.0.0.1` only
+
+Two sites in `server/index.ts`:
+
+```ts
+// isPortFree — the probe listener that checks if the port is taken
+server.listen(port, "127.0.0.1");
+
+// main app.listen
+const httpServer = app.listen(PORT, "127.0.0.1", () => { ... });
+```
+
+Consequence: the server is no longer reachable from other machines on the LAN. Dev workflow is unaffected — Vite's proxy runs on the same machine. If anyone actually needs LAN access (unlikely for a personal dev tool), they can set `PORT=` and bind explicitly via an opt-in env var — out of scope for this fix.
+
+### 2. Drop `cors()` entirely
+
+The Vite dev proxy in `vite.config.ts` forwards `/api/*` from `localhost:5173` to `localhost:3001` server-side, so the browser only ever sees one origin (`:5173` in dev, `:3001` in prod via Express's static server). No legitimate request needs CORS headers. Removing `app.use(cors())` means:
+
+- Browser requests to `:3001` from a foreign origin (`evil.example`) → response has no `Access-Control-Allow-Origin` → browser blocks the response from the calling script.
+- Same-origin requests (via Vite proxy or direct from Express-served client) work unchanged because same-origin requests don't need CORS headers.
+- Server-to-server calls (MCP tools, curl, CLI) are unaffected — CORS is a browser mechanism, not HTTP-level enforcement.
+
+Also drop the `import cors from "cors"` line. The `cors` npm package stays in the dep tree for now (could be removed separately), but nothing imports it.
+
+### 3. Add a sensitive-path denylist to `server/routes/files.ts`
+
+New helper `isSensitivePath(relPath)` that returns `true` for:
+
+- `.env` and `.env.*` (e.g. `.env.local`, `.env.production`)
+- `*.pem`, `*.key`, `*.crt` — TLS / SSH keys
+- `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa` — and their `.pub` variants are fine (public keys)
+- `credentials.json` — the Claude Code credentials file that `server/credentials.ts` writes
+- `.npmrc` — often holds npm tokens
+- `.htpasswd` — Apache auth file
+
+Applied in three places:
+
+1. **`resolveSafe`** returns `null` for sensitive paths → all three endpoints (`/files/content`, `/files/raw`, any future consumer) get a 400 "Path outside workspace" response. The error is intentionally vague so we don't confirm existence.
+2. **`buildTree`** skips sensitive entries so they don't appear in `/files/tree` at all. The file explorer won't show them.
+3. **Remove `.env` from `TEXT_EXTENSIONS`** — defense in depth in case `isSensitivePath` misses a variant; the resulting fallback is "binary" with a preview-not-supported message.
+
+### Test coverage
+
+`test/routes/test_filesRoute.ts` gains a describe block for `isSensitivePath`:
+
+- `.env` → blocked
+- `.env.local`, `.env.production`, `.env.staging` → blocked
+- `.environment` (not actually sensitive) → NOT blocked (shouldn't false-positive on lookalikes)
+- `subdir/.env` → blocked (matches on the basename, not the full path)
+- `notes.txt` → not blocked
+- `id_rsa`, `id_rsa.pub` — private blocked, public NOT blocked
+- `cert.pem`, `server.key` → blocked
+- `README.md` → not blocked
+- case-insensitive on Windows-friendly filesystems (`.ENV`, `ID_RSA`) — blocked
+
+`isSensitivePath` is exported so the test can exercise it directly.
+
+## Tradeoffs
+
+- **LAN access**: if someone was relying on `0.0.0.0` to access the dev server from their phone / another laptop, this PR breaks that. It's an unusual dev workflow and out of scope here — can be re-added behind an explicit opt-in env var if anyone asks.
+- **CORS removal**: any tooling that directly hits the API from a cross-origin web page (not via Vite proxy) will break. Grepping the repo: nothing currently does this. The closed PR #106 (Telegram bot) was server-side and wouldn't have been affected.
+- **Sensitive path false positives**: if a user legitimately wants to preview a `.env` file in the file explorer, they can't. They can still `cat` it from a terminal. The safety margin wins.
+
+## Out of scope
+
+- **CSRF origin check** on state-changing routes — separate PR building on this one's same-origin posture
+- **Removing `cors` from package.json** — leave it installed in case it's needed later for a deliberate cross-origin integration
+- **Additional sensitive patterns** like `aws/credentials`, `.ssh/` (whole dir), `.gnupg/` — can add incrementally if real need arises
+
+## Commit structure
+
+Single commit on branch `fix/server-lockdown-cors-localhost`. Plan + code + tests together, because the three defects form one layered defense and splitting them would leave the tree in an intermediate state.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import express, { Request, Response, NextFunction } from "express";
-import cors from "cors";
 import net from "net";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -46,7 +45,17 @@ const app = express();
 const PORT = Number(process.env.PORT) || 3001;
 
 app.disable("x-powered-by");
-app.use(cors());
+// No `cors()` middleware. The Vite dev proxy forwards `/api/*`
+// from :5173 to :3001 server-side, and in production Express
+// serves the built client from the same origin, so every
+// legitimate request is same-origin and doesn't need CORS
+// headers at all. Dropping the middleware means a page at
+// `http://evil.example` can still send a request to
+// `localhost:3001` but the browser refuses to expose the
+// response to the calling script (no
+// `Access-Control-Allow-Origin` header). See
+// plans/fix-server-lockdown-cors-localhost.md for the threat
+// model.
 app.use(express.json({ limit: "50mb" }));
 
 app.get("/api/health", (_req: Request, res: Response) => {
@@ -91,7 +100,10 @@ function isPortFree(port: number): Promise<boolean> {
     server.once("listening", () => {
       server.close(() => resolve(true));
     });
-    server.listen(port, "0.0.0.0");
+    // Probe the same interface we'll actually bind to so a port
+    // held by a different process on a different interface doesn't
+    // give us a false "free" reading.
+    server.listen(port, "127.0.0.1");
   });
 }
 
@@ -233,7 +245,12 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
   sandboxEnabled = await setupSandbox();
   logMcpStatus();
 
-  const httpServer = app.listen(PORT, "0.0.0.0", () => {
+  // Bind to localhost-only. Using `0.0.0.0` would expose the dev
+  // server to the entire LAN (anyone on the same Wi-Fi could reach
+  // `http://<laptop-ip>:3001/api/*`), which combined with the
+  // workspace file API is a credential-theft risk. Personal dev
+  // tool — localhost is the right default.
+  const httpServer = app.listen(PORT, "127.0.0.1", () => {
     startRuntimeServices(httpServer);
   });
 })();

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -9,6 +9,56 @@ const MAX_PREVIEW_BYTES = 1024 * 1024; // 1 MB — text content embedded in JSON
 const MAX_RAW_BYTES = 50 * 1024 * 1024; // 50 MB — cap for binary streaming
 const HIDDEN_DIRS = new Set([".git"]);
 
+// Files whose basename exactly matches one of these is refused by
+// every file-API endpoint. Used to keep workspace secrets
+// (credentials, API keys, SSH / TLS private keys) off the HTTP
+// surface. Compared against `path.basename(...).toLowerCase()`.
+const SENSITIVE_BASENAMES = new Set([
+  "credentials.json",
+  // Claude Code credentials file written by server/credentials.ts.
+  ".npmrc",
+  ".htpasswd",
+  "id_rsa",
+  "id_ecdsa",
+  "id_ed25519",
+  "id_dsa",
+]);
+
+// File extensions whose contents are almost always secret. Compared
+// against `path.extname(...).toLowerCase()`. Note: `.env` is matched
+// separately below because `path.extname(".env")` returns "" —
+// dotfiles with no second extension don't carry an extname.
+const SENSITIVE_EXTENSIONS = new Set([".pem", ".key", ".crt"]);
+
+// Decide whether `relPath` names a file whose contents should NEVER
+// be served by the file API. Applied in three places:
+//
+// 1. `resolveSafe` returns null for sensitive paths so every
+//    endpoint (content, raw, anything future) rejects them with a
+//    generic 400.
+// 2. `buildTree` filters them out of `/files/tree`, so the file
+//    explorer never lists them in the first place.
+// 3. The `.env` blocklist below is what keeps `/files/content`
+//    from leaking credentials on a matching-name lookup.
+//
+// Exported so `test/routes/test_filesRoute.ts` can pin the matching
+// rules down table-driven — regressions here silently reopen a
+// credential-exfil surface.
+export function isSensitivePath(relPath: string): boolean {
+  const base = path.basename(relPath).toLowerCase();
+  if (SENSITIVE_BASENAMES.has(base)) return true;
+  // `.env` and every `.env.<something>` variant
+  // (`.env.local`, `.env.production`, ...). The startsWith check
+  // is scoped to `.env` to avoid false-positives on names like
+  // `.environment-notes` — we only match `.env` exact or
+  // `.env.<suffix>`.
+  if (base === ".env") return true;
+  if (base.startsWith(".env.")) return true;
+  const ext = path.extname(base);
+  if (SENSITIVE_EXTENSIONS.has(ext)) return true;
+  return false;
+}
+
 const TEXT_EXTENSIONS = new Set([
   ".md",
   ".markdown",
@@ -28,7 +78,11 @@ const TEXT_EXTENSIONS = new Set([
   ".css",
   ".csv",
   ".log",
-  ".env",
+  // `.env` intentionally removed — see `isSensitivePath` below.
+  // It used to be here, making `/files/content?path=.env` return
+  // the workspace credentials as JSON text over an open CORS
+  // endpoint. The file API now refuses sensitive paths outright;
+  // this set is kept for genuine plain-text previews only.
   ".gitignore",
   ".sh",
   ".py",
@@ -152,6 +206,10 @@ function resolveSafe(relPath: string): string | null {
       if (HIDDEN_DIRS.has(seg)) return null;
     }
   }
+  // Reject workspace-sensitive filenames outright. `isSensitivePath`
+  // matches on the basename so it catches `.env`, `id_rsa`, and
+  // friends regardless of which directory they sit in.
+  if (isSensitivePath(resolvedReal)) return null;
   return resolvedReal;
 }
 
@@ -230,6 +288,11 @@ function buildTree(absPath: string, relPath: string): TreeNode {
   const children: TreeNode[] = [];
   for (const entry of entries) {
     if (HIDDEN_DIRS.has(entry.name)) continue;
+    // Hide sensitive files (`.env`, `id_rsa`, `*.pem`, etc.) from
+    // the tree so they don't even show up in the file explorer
+    // for the user to click on. `resolveSafe` would refuse them
+    // too, but keeping them out of the listing is cleaner.
+    if (!entry.isDirectory() && isSensitivePath(entry.name)) continue;
     if (entry.isSymbolicLink()) continue; // avoid escaping the workspace
     const childAbs = path.join(absPath, entry.name);
     const childRel = relPath ? path.join(relPath, entry.name) : entry.name;

--- a/test/routes/test_filesRoute.ts
+++ b/test/routes/test_filesRoute.ts
@@ -1,0 +1,92 @@
+// Unit tests for the pure helpers in `server/routes/files.ts`.
+//
+// Adjacent PRs (#146, #147) also add tests here for `parseRange`,
+// `classify`, and `RAW_SECURITY_HEADERS`. Merge conflicts across
+// those PRs are expected and should be resolved by combining the
+// import list and the describe blocks — all tests are independent.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isSensitivePath } from "../../server/routes/files.js";
+
+describe("isSensitivePath — blocks secret files", () => {
+  it("blocks a bare .env", () => {
+    assert.equal(isSensitivePath(".env"), true);
+  });
+
+  it("blocks .env.<variant> files", () => {
+    for (const name of [
+      ".env.local",
+      ".env.production",
+      ".env.development",
+      ".env.staging",
+      ".env.test",
+    ]) {
+      assert.equal(isSensitivePath(name), true, `expected ${name} blocked`);
+    }
+  });
+
+  it("blocks .env variants nested under subdirectories", () => {
+    // The check is basename-based so it follows the file wherever
+    // it lives in the tree.
+    assert.equal(isSensitivePath("config/.env"), true);
+    assert.equal(isSensitivePath("subdir/deeper/.env.local"), true);
+  });
+
+  it("is case-insensitive on .env", () => {
+    // macOS / Windows are case-insensitive by default; a malicious
+    // `.ENV` on either FS should still be rejected.
+    assert.equal(isSensitivePath(".ENV"), true);
+    assert.equal(isSensitivePath(".Env.Local"), true);
+  });
+
+  it("blocks SSH private keys but NOT their .pub counterparts", () => {
+    for (const priv of ["id_rsa", "id_ecdsa", "id_ed25519", "id_dsa"]) {
+      assert.equal(isSensitivePath(priv), true, `expected ${priv} blocked`);
+    }
+    // .pub files are public and safe to preview.
+    assert.equal(isSensitivePath("id_rsa.pub"), false);
+    assert.equal(isSensitivePath("id_ed25519.pub"), false);
+  });
+
+  it("blocks TLS / cert extensions", () => {
+    assert.equal(isSensitivePath("cert.pem"), true);
+    assert.equal(isSensitivePath("server.key"), true);
+    assert.equal(isSensitivePath("ca.crt"), true);
+    assert.equal(isSensitivePath("some/path/to/cert.PEM"), true);
+  });
+
+  it("blocks known credential filenames", () => {
+    assert.equal(isSensitivePath("credentials.json"), true);
+    assert.equal(isSensitivePath(".npmrc"), true);
+    assert.equal(isSensitivePath(".htpasswd"), true);
+  });
+});
+
+describe("isSensitivePath — does not over-block", () => {
+  it("allows .env lookalikes that are not actually env files", () => {
+    // `.environment` / `.envoy.yaml` / etc. should not match.
+    assert.equal(isSensitivePath(".environment"), false);
+    assert.equal(isSensitivePath(".envoy"), false);
+    assert.equal(isSensitivePath("envelope.md"), false);
+    assert.equal(isSensitivePath("env.json"), false);
+  });
+
+  it("allows ordinary source and document files", () => {
+    assert.equal(isSensitivePath("README.md"), false);
+    assert.equal(isSensitivePath("notes.txt"), false);
+    assert.equal(isSensitivePath("server/routes/files.ts"), false);
+    assert.equal(isSensitivePath("wiki/pages/sakura.md"), false);
+  });
+
+  it("allows files with similar but non-sensitive extensions", () => {
+    assert.equal(isSensitivePath("foo.pkm"), false);
+    assert.equal(isSensitivePath("foo.keypress"), false);
+    // `.cert.ts` is a TypeScript file, extname is `.ts` not `.cert`.
+    assert.equal(isSensitivePath("server.cert.ts"), false);
+  });
+
+  it("allows an empty path (resolveSafe guards those separately)", () => {
+    assert.equal(isSensitivePath(""), false);
+  });
+});


### PR DESCRIPTION
Second of three pre-existing security follow-ups to the merged #134 (see also #147 for the SVG CSP sandbox; CSRF origin-check follow-up will go on top of this).

## The attack chain

A page the user visits at `http://evil.example` while the dev server is running can read `~/mulmoclaude/.env`:

\`\`\`js
await fetch(\"http://localhost:3001/api/files/content?path=.env\")
  .then(r => r.json())
  // { kind: 'text', content: 'ANTHROPIC_API_KEY=...\\nGEMINI_API_KEY=...' }
\`\`\`

Three defects compound into this single attack:

| # | Defect | Location |
|---|---|---|
| A | Server binds to `0.0.0.0` | `server/index.ts` x2 |
| B | `cors()` wide open (`Access-Control-Allow-Origin: *`) | `server/index.ts` |
| C | `.env` in TEXT_EXTENSIONS → returned as JSON text | `server/routes/files.ts` |

## Fixes — defense in depth, one PR

### 1. Bind to `127.0.0.1`

Both the `isPortFree` probe and the main `app.listen` now use `\"127.0.0.1\"`. LAN access is gone — the Vite dev proxy runs on the same machine so dev isn't affected, and nobody on the same Wi-Fi can reach `http://<laptop-ip>:3001/*` anymore.

### 2. Drop `cors()` entirely

The Vite dev proxy forwards `/api/*` from `:5173` to `:3001` server-side, so the browser only ever sees one origin (\`:5173\` in dev, \`:3001\` in prod via Express's static server). No legitimate caller needs CORS headers.

Foreign-origin fetches now fail at the browser level — no \`Access-Control-Allow-Origin\` header means no response exposure to the calling script. Server-to-server callers (MCP tools, curl, CLI) are unaffected because CORS is a browser-side mechanism.

\`import cors from \"cors\"\` is also dropped. The npm package stays installed for now (removing it is a separate housekeeping PR).

### 3. New \`isSensitivePath\` helper

Exported from \`server/routes/files.ts\`, matches on the basename (lowercased) so it catches a sensitive file wherever it sits in the tree:

- \`.env\` exact + \`.env.<variant>\` (local / production / staging / ...)
- Known credential filenames: \`credentials.json\`, \`.npmrc\`, \`.htpasswd\`
- SSH private key basenames: \`id_rsa\`, \`id_ecdsa\`, \`id_ed25519\`, \`id_dsa\` — explicitly NOT their \`.pub\` counterparts
- TLS / cert extensions: \`.pem\`, \`.key\`, \`.crt\`

Applied in two places:

- **\`resolveSafe\`** returns \`null\` for sensitive paths → all three endpoints (\`/files/content\`, \`/files/raw\`, any future consumer) reject with a generic 400. The error stays intentionally vague so we don't confirm existence.
- **\`buildTree\`** skips sensitive entries so they don't appear in \`/files/tree\` at all.

Plus: **\`.env\` is removed from \`TEXT_EXTENSIONS\`** — defense in depth in case \`isSensitivePath\` ever misses a variant, the worst-case fallback is \"binary, preview not supported\" rather than a JSON text leak.

## Tests — 11 new cases

\`test/routes/test_filesRoute.ts\` (new file on this branch — see note below) pins \`isSensitivePath\` table-driven:

- \`.env\` blocked
- \`.env.<variant>\` blocked (5 variants)
- Nested under subdirectories
- Case-insensitive on Windows-friendly filesystems
- SSH private key basenames blocked, \`.pub\` counterparts allowed
- TLS / cert extensions blocked (mixed case)
- Credential filenames blocked
- Lookalikes NOT blocked: \`.environment\`, \`.envoy\`, \`envelope.md\`, \`env.json\`
- Ordinary source files not blocked
- Similar-but-distinct extensions not blocked (\`.pkm\`, \`.keypress\`, \`server.cert.ts\`)
- Empty path not flagged

Tests: 608 → 619 (+11).

## Note: merge conflicts with #146 and #147

This PR creates \`test/routes/test_filesRoute.ts\` and exports \`isSensitivePath\` from \`server/routes/files.ts\`. PR #146 (still open) also creates that test file with \`parseRange\` / \`classify\` coverage, and PR #147 (still open) adds \`RAW_SECURITY_HEADERS\` tests.

Whichever PR merges first owns the file; the other two will need trivial merges:

- Combine the \`import ... from \"../../server/routes/files.js\"\` lines
- Append the new describe blocks — none of them overlap

The PR descriptions for #146 and #147 already flag this — resolution is mechanical.

## Tradeoffs

- **LAN access gone**: if someone relied on \`0.0.0.0\` to reach the dev server from their phone, this breaks it. Can be re-added behind an opt-in env var later if actually needed.
- **Cross-origin API clients gone**: nothing in-repo does this.
- **\`.env\` not previewable from the file explorer**: users can still \`cat\` it from a terminal. Safety wins.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` (0 errors, 8 pre-existing warnings)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — 608 → 619 (+11)
- [ ] Manual: \`curl -v http://localhost:3001/api/files/content?path=.env\` → 400
- [ ] Manual: \`curl -v http://localhost:3001/api/files/raw?path=.env\` → 400
- [ ] Manual: \`curl -v http://localhost:3001/api/files/tree\` → \`.env\` not in the output
- [ ] Manual: on another machine on the same Wi-Fi, \`curl -v http://<laptop-ip>:3001/api/health\` → connection refused
- [ ] Manual: \`yarn dev\` → Vite proxy still works, browser loads Vue app and file explorer

## Out of scope

- **CSRF origin check** on state-changing POSTs — follow-up PR on top of this.
- **Removing the \`cors\` npm package** from package.json — separate housekeeping.
- **Additional sensitive patterns** (\`.aws/credentials\`, \`.gnupg/\` dir, etc.) — add incrementally as real needs surface.

Plan file: \`plans/fix-server-lockdown-cors-localhost.md\`

Refs #134, #146, #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)