### PR TITLE
fix(server): reject cross-origin state-changing requests (CSRF guard)

### DIFF
--- a/plans/fix-server-csrf-origin-check.md
+++ b/plans/fix-server-csrf-origin-check.md
@@ -1,0 +1,138 @@
+# Plan: reject cross-origin state-changing requests with an Origin guard
+
+Third of three pre-existing security follow-ups to the merged #134. This one builds on the same-origin posture established by #148 (CORS + localhost bind + sensitive-file denylist).
+
+## Why this is needed on top of #148
+
+#148 drops `cors()` entirely, so a cross-origin `fetch` from `http://evil.example` can't *read the response* — the browser refuses to expose it to the calling script. That defends against the data-exfil attack (reading `.env`, reading chat history, reading workspace files).
+
+But CORS doesn't block the **request itself** from being sent. A few classes of request still slip through:
+
+1. **Simple-CORS POST requests** — `application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain` don't trigger preflight. A `<form action="http://localhost:3001/api/chat-index/rebuild" method="post">` on an attacker page submits the request on user click (or auto-submit via JS). The response is invisible but the *side effect* happens.
+
+2. **Simple-CORS GET requests with side effects** — `<img src="http://localhost:3001/api/whatever">` fires a GET. Our GETs are all read-only today, but a future endpoint that accidentally has side effects would be exploitable.
+
+3. **Fetches from sandboxed iframes / `file://` pages** — origin is `null`, same-origin policy still blocks response reading, but the request goes through.
+
+Concrete CSRF target today: `POST /api/chat-index/rebuild` (spawns `claude` CLI for every session, real resource cost). Trigger it from an attacker form submission → user's machine spends minutes summarizing, paying claude budget, with no visible indicator.
+
+#148 and this PR together are defense in depth:
+
+- **#148 (CORS + bind)**: blocks response reading → no data exfil
+- **This PR (Origin check)**: blocks side-effectful cross-origin hits → no CSRF
+
+## Design — Origin-header middleware
+
+A single Express middleware applied globally before any route:
+
+```ts
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+export function requireSameOrigin(req, res, next) {
+  if (SAFE_METHODS.has(req.method)) return next();
+  const origin = req.headers.origin;
+  // Missing Origin: allowed. Server-to-server callers (MCP
+  // tools, curl, CLI scripts) don't set Origin. This is only
+  // safe because #148 binds the server to 127.0.0.1 — remote
+  // traffic can't reach us at all, so a missing Origin
+  // necessarily comes from a local process.
+  if (!origin) return next();
+  if (isLocalhostOrigin(origin)) return next();
+  res.status(403).json({ error: "Forbidden: cross-origin request rejected" });
+}
+```
+
+`isLocalhostOrigin(origin)` returns `true` when:
+
+- `origin` parses as a URL (else `false`)
+- Hostname is exactly one of `localhost`, `127.0.0.1`, `::1`
+
+Any other value — including `null`, `http://localhost.evil.com` (subdomain attack), `http://example.com`, malformed strings — is rejected.
+
+### Why "missing Origin = allowed"
+
+The Origin header is set by browsers on every request except same-origin GET/HEAD/OPTIONS in some older engines. Non-browser clients (curl, MCP tools, Node HTTP libraries by default) don't set it. We have two choices:
+
+1. **Require Origin on every non-safe request.** Breaks every server-to-server caller and every curl-based script.
+2. **Allow missing Origin, reject foreign Origin.** Works for every caller that matters and is only safe because we're bound to localhost.
+
+#148's localhost bind makes option 2 safe: remote traffic can't reach the server, so a missing Origin necessarily means the request came from a process on the same machine. That process is the user's own (malware at that level is game-over anyway).
+
+If #148 lands first (as expected), this reasoning holds. If somehow this PR lands first, there's a theoretical window where a LAN attacker could issue a CSRF POST with no Origin header. Documenting the dependency in the PR description.
+
+### Safe methods
+
+`GET`, `HEAD`, `OPTIONS` pass through unchecked. RFC 9110 calls these "safe" methods (no side effects). `OPTIONS` also covers CORS preflights, which browsers issue with `Origin` but we don't want to reject.
+
+If a future GET endpoint is introduced that has side effects, either:
+- Convert it to POST (correct), or
+- Document the gap and add a targeted origin check on that specific route.
+
+The middleware itself intentionally doesn't try to detect "GET with side effects" — that's semantic and would need per-route annotations.
+
+### Where to hook it in
+
+Right after `express.json()` in `server/index.ts`, before any `app.use("/api", ...)` call. Applies globally to every route.
+
+### Structure
+
+- New file `server/csrfGuard.ts` — exports `requireSameOrigin` and its helper `isLocalhostOrigin` for test.
+- `server/index.ts` imports and wires it in.
+- New test file `test/server/test_csrfGuard.ts` exercises the middleware with fake Req/Res objects.
+
+## Tests
+
+Table-driven on `isLocalhostOrigin` + behavioural tests on `requireSameOrigin`:
+
+**`isLocalhostOrigin`:**
+- `http://localhost` → true
+- `http://localhost:5173` → true
+- `http://localhost:3001` → true
+- `https://localhost` → true (scheme-agnostic)
+- `http://127.0.0.1` → true
+- `http://127.0.0.1:8080` → true
+- `http://[::1]:5173` → true (IPv6 loopback)
+- `http://example.com` → false
+- `http://localhost.evil.com` → false (subdomain attack)
+- `http://evillocalhost` → false (no dot, not localhost)
+- `http://attacker.com/path?x=localhost` → false
+- `null` → false
+- `""` → false
+- `not a url` → false
+- `javascript:alert(1)` → false (hostname is empty)
+- `file:///tmp/evil.html` → false
+
+**`requireSameOrigin`:**
+- GET with no Origin → `next()` called
+- GET with foreign Origin → `next()` called (GET is safe)
+- HEAD with foreign Origin → `next()` called
+- OPTIONS with foreign Origin → `next()` called (preflight)
+- POST with no Origin → `next()` called (local process)
+- POST with `http://localhost:5173` → `next()`
+- POST with `http://127.0.0.1:3001` → `next()`
+- POST with `http://example.com` → 403 + JSON error, `next()` NOT called
+- POST with malformed Origin → 403, `next()` NOT called
+- POST with `null` string Origin → 403, `next()` NOT called
+- PUT / PATCH / DELETE with foreign Origin → 403
+
+### Test harness
+
+The middleware signature takes `Request`, `Response`, `NextFunction`. We don't need full Express — fake objects with just `headers`, `method`, `status`, `json`, `_statusCode` tracking, and a `next` spy are enough. Standard pattern for Express middleware unit tests, no supertest required.
+
+## Tradeoffs
+
+- **Non-browser API clients without Origin headers work freely.** This is intentional (see "missing Origin = allowed"). If that's too permissive for a future deployment (e.g. exposing the server beyond localhost), the fix is to require Origin there, not to complicate this middleware.
+- **`null` string Origin is rejected.** Sandboxed iframes, `file://` pages, and some Chrome extensions send `Origin: null`. They can't POST to the server. That's the right call: there's no trusted context that sends `null`.
+- **IPv6 loopback matching** is included (`[::1]`) in case the user's browser resolves `localhost` to IPv6.
+- **No CSRF token fallback** — Origin-based CSRF defense is simpler and works for our use case. Token-based defense (double-submit cookie, synchronizer token) adds complexity and requires session state we don't have.
+
+## Out of scope
+
+- Request rate limiting / per-client throttling.
+- Auth / user sessions.
+- Removing the `cors` npm package from `package.json`.
+- Scanning all routes to reclassify GETs that shouldn't be — out of scope for a security guard, belongs in a code-review pass.
+
+## Commit structure
+
+Single commit on branch `fix/server-csrf-origin-check`. Plan + middleware + tests + wiring together.

--- a/server/csrfGuard.ts
+++ b/server/csrfGuard.ts
@@ -1,0 +1,78 @@
+// CSRF defense: reject cross-origin state-changing requests.
+//
+// Complements the CORS / localhost-bind hardening in #148. With
+// those in place, the browser refuses to expose response bodies
+// to cross-origin callers, but the **request itself** still
+// reaches the server. That's enough for a fire-and-forget side
+// effect (e.g. `POST /api/chat-index/rebuild` spawning claude CLI
+// in the background) to be triggered from an attacker page.
+//
+// This middleware checks the Origin header on every non-safe
+// method and rejects anything that didn't come from localhost.
+// Requests with NO Origin header are allowed — that's how
+// non-browser callers (MCP tools, curl, CLI scripts) look, and
+// they're trustable only because the server binds to 127.0.0.1
+// (#148) so remote traffic can't reach us at all.
+//
+// Full design + threat model: plans/fix-server-csrf-origin-check.md
+
+import type { Request, Response, NextFunction } from "express";
+
+const SAFE_METHODS: ReadonlySet<string> = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const LOCALHOST_HOSTNAMES: ReadonlySet<string> = new Set([
+  "localhost",
+  "127.0.0.1",
+  // IPv6 loopback. Note `new URL("http://[::1]:5173").hostname`
+  // returns the literal string `[::1]` **with brackets** (the
+  // Node URL parser preserves them). So that's what we match.
+  // The un-bracketed `::1` is kept alongside as belt-and-
+  // suspenders in case a different parser implementation (older
+  // Node, a shim) ever strips them.
+  "[::1]",
+  "::1",
+]);
+
+// Decide whether an Origin header value points at the same
+// machine. Accepts scheme + hostname + optional port; rejects
+// `null`, empty, malformed, subdomain-lookalikes, non-loopback
+// IPs, and non-HTTP schemes. Exported for test.
+export function isLocalhostOrigin(origin: string): boolean {
+  if (!origin) return false;
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  return LOCALHOST_HOSTNAMES.has(url.hostname);
+}
+
+// Express middleware. Safe-method requests (GET / HEAD / OPTIONS)
+// pass through unchecked — they have no side effects per RFC 9110,
+// and OPTIONS is required for CORS preflights anyway (even though
+// we no longer advertise CORS, browsers still issue the preflight
+// before some requests). Non-safe requests need an Origin header
+// that resolves to localhost OR no Origin header at all.
+export function requireSameOrigin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (SAFE_METHODS.has(req.method)) {
+    next();
+    return;
+  }
+  const origin = req.headers.origin;
+  if (typeof origin !== "string") {
+    // Missing Origin: non-browser caller (curl, MCP, Node HTTP
+    // libraries). Trusted because the server binds to 127.0.0.1.
+    next();
+    return;
+  }
+  if (isLocalhostOrigin(origin)) {
+    next();
+    return;
+  }
+  res.status(403).json({ error: "Forbidden: cross-origin request rejected" });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import { createPubSub } from "./pub-sub/index.js";
 import { createTaskManager } from "./task-manager/index.js";
 import type { ITaskManager } from "./task-manager/index.js";
 import type { IPubSub } from "./pub-sub/index.js";
+import { requireSameOrigin } from "./csrfGuard.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +49,12 @@ const PORT = Number(process.env.PORT) || 3001;
 app.disable("x-powered-by");
 app.use(cors());
 app.use(express.json({ limit: "50mb" }));
+// CSRF guard: reject state-changing requests that arrive with a
+// non-localhost Origin header. Allows missing Origin (server-to-
+// server / CLI callers) because the listener is already bound to
+// localhost (#148); if that ever changes, tighten this middleware
+// too. See plans/fix-server-csrf-origin-check.md.
+app.use(requireSameOrigin);
 
 app.get("/api/health", (_req: Request, res: Response) => {
   res.json({

--- a/test/server/test_csrfGuard.ts
+++ b/test/server/test_csrfGuard.ts
@@ -1,0 +1,309 @@
+// Unit tests for the CSRF origin guard middleware. The middleware
+// sits in front of every route and rejects state-changing requests
+// that carry a non-localhost Origin header — our defense against
+// cross-origin CSRF attacks that survive the CORS lockdown in
+// #148.
+//
+// Full design: plans/fix-server-csrf-origin-check.md
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Request, Response, NextFunction } from "express";
+import {
+  isLocalhostOrigin,
+  requireSameOrigin,
+} from "../../server/csrfGuard.js";
+
+// --- isLocalhostOrigin: the pure check --------------------------
+
+describe("isLocalhostOrigin — accepts local variants", () => {
+  it("accepts plain http://localhost", () => {
+    assert.equal(isLocalhostOrigin("http://localhost"), true);
+  });
+
+  it("accepts http://localhost with a port", () => {
+    assert.equal(isLocalhostOrigin("http://localhost:5173"), true);
+    assert.equal(isLocalhostOrigin("http://localhost:3001"), true);
+    assert.equal(isLocalhostOrigin("http://localhost:4173"), true);
+  });
+
+  it("accepts https://localhost (scheme-agnostic)", () => {
+    assert.equal(isLocalhostOrigin("https://localhost"), true);
+  });
+
+  it("accepts http://127.0.0.1 with and without port", () => {
+    assert.equal(isLocalhostOrigin("http://127.0.0.1"), true);
+    assert.equal(isLocalhostOrigin("http://127.0.0.1:8080"), true);
+  });
+
+  it("accepts IPv6 loopback http://[::1]", () => {
+    assert.equal(isLocalhostOrigin("http://[::1]"), true);
+    assert.equal(isLocalhostOrigin("http://[::1]:5173"), true);
+  });
+});
+
+describe("isLocalhostOrigin — rejects everything else", () => {
+  it("rejects a foreign hostname", () => {
+    assert.equal(isLocalhostOrigin("http://example.com"), false);
+    assert.equal(isLocalhostOrigin("https://attacker.example"), false);
+  });
+
+  it("rejects localhost-lookalikes (subdomain attack)", () => {
+    // The classic CSRF bypass: register `localhost.evil.com`,
+    // hope the check is a substring / suffix match. URL.hostname
+    // returns the FULL hostname so a Set membership check is
+    // immune.
+    assert.equal(isLocalhostOrigin("http://localhost.evil.com"), false);
+    assert.equal(isLocalhostOrigin("http://127.0.0.1.nip.io"), false);
+  });
+
+  it("rejects evil-prefixed hostnames that lack the dot", () => {
+    // `evillocalhost` would match a naive `includes("localhost")`
+    // check. Set membership rejects it.
+    assert.equal(isLocalhostOrigin("http://evillocalhost"), false);
+    assert.equal(isLocalhostOrigin("http://notlocalhost"), false);
+  });
+
+  it("rejects a URL that only contains `localhost` in the path", () => {
+    assert.equal(
+      isLocalhostOrigin("http://attacker.com/path?host=localhost"),
+      false,
+    );
+  });
+
+  it("rejects the string `null`", () => {
+    // Browsers set `Origin: null` for sandboxed iframes, file://,
+    // data: URLs, and some cross-origin redirects. None of those
+    // should be trusted to hit the API.
+    assert.equal(isLocalhostOrigin("null"), false);
+  });
+
+  it("rejects empty string", () => {
+    assert.equal(isLocalhostOrigin(""), false);
+  });
+
+  it("rejects non-URL garbage", () => {
+    assert.equal(isLocalhostOrigin("not a url"), false);
+    assert.equal(isLocalhostOrigin("http://"), false);
+  });
+
+  it("rejects a javascript: URI", () => {
+    // `new URL("javascript:alert(1)").hostname` is "" — not in
+    // the loopback set, so rejected.
+    assert.equal(isLocalhostOrigin("javascript:alert(1)"), false);
+  });
+
+  it("rejects file:// origins", () => {
+    // file:// URLs usually get `Origin: null` in practice, but
+    // just in case one arrives as a literal file:// value:
+    assert.equal(isLocalhostOrigin("file:///tmp/evil.html"), false);
+  });
+
+  it("rejects non-loopback IPs including private LAN addresses", () => {
+    // If the server ever re-binds to 0.0.0.0 (don't), a LAN
+    // attacker with its own HTTP server could use its own
+    // address as Origin. Explicitly rejected.
+    assert.equal(isLocalhostOrigin("http://192.168.1.10"), false);
+    assert.equal(isLocalhostOrigin("http://10.0.0.1"), false);
+    assert.equal(isLocalhostOrigin("http://172.16.0.5"), false);
+    assert.equal(isLocalhostOrigin("http://0.0.0.0"), false);
+  });
+});
+
+// --- requireSameOrigin: Express middleware behaviour ------------
+
+// Minimal fake Request/Response/NextFunction for middleware
+// testing — avoids pulling in supertest.
+interface FakeReq {
+  method: string;
+  headers: Record<string, string | undefined>;
+}
+
+interface FakeRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): FakeRes;
+  json(payload: unknown): FakeRes;
+}
+
+function makeReq(method: string, origin?: string): FakeReq {
+  return {
+    method,
+    headers: origin === undefined ? {} : { origin },
+  };
+}
+
+function makeRes(): FakeRes {
+  const res: FakeRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+function run(
+  req: FakeReq,
+  res: FakeRes,
+): { nextCalled: boolean; statusCode: number; body: unknown } {
+  let nextCalled = false;
+  const next: NextFunction = () => {
+    nextCalled = true;
+  };
+  // The types differ slightly from real Express — cast through
+  // `unknown` since the middleware only touches `method`,
+  // `headers`, `status`, `json`.
+  requireSameOrigin(
+    req as unknown as Request,
+    res as unknown as Response,
+    next,
+  );
+  return {
+    nextCalled,
+    statusCode: res.statusCode,
+    body: res.body,
+  };
+}
+
+describe("requireSameOrigin — safe methods pass through", () => {
+  it("lets GET through regardless of Origin", () => {
+    for (const origin of [
+      undefined,
+      "http://localhost",
+      "http://example.com",
+      "null",
+    ]) {
+      const { nextCalled, statusCode } = run(makeReq("GET", origin), makeRes());
+      assert.equal(nextCalled, true, `expected next() for Origin=${origin}`);
+      assert.equal(statusCode, 200);
+    }
+  });
+
+  it("lets HEAD through regardless of Origin", () => {
+    const { nextCalled } = run(
+      makeReq("HEAD", "http://example.com"),
+      makeRes(),
+    );
+    assert.equal(nextCalled, true);
+  });
+
+  it("lets OPTIONS through (CORS preflight shouldn't be CSRF-checked)", () => {
+    const { nextCalled } = run(
+      makeReq("OPTIONS", "http://example.com"),
+      makeRes(),
+    );
+    assert.equal(nextCalled, true);
+  });
+});
+
+describe("requireSameOrigin — state-changing methods, missing Origin", () => {
+  // Non-browser callers (curl, MCP tools, Node HTTP libraries)
+  // don't set Origin. They're trusted because #148 binds to
+  // localhost.
+
+  it("allows POST with no Origin header", () => {
+    const { nextCalled, statusCode } = run(makeReq("POST"), makeRes());
+    assert.equal(nextCalled, true);
+    assert.equal(statusCode, 200);
+  });
+
+  it("allows PUT / PATCH / DELETE with no Origin header", () => {
+    for (const method of ["PUT", "PATCH", "DELETE"]) {
+      const { nextCalled } = run(makeReq(method), makeRes());
+      assert.equal(nextCalled, true, `expected next() for ${method}`);
+    }
+  });
+});
+
+describe("requireSameOrigin — state-changing methods, localhost Origin", () => {
+  it("allows POST from http://localhost:5173 (Vite dev)", () => {
+    const { nextCalled } = run(
+      makeReq("POST", "http://localhost:5173"),
+      makeRes(),
+    );
+    assert.equal(nextCalled, true);
+  });
+
+  it("allows POST from http://localhost:3001 (production Express)", () => {
+    const { nextCalled } = run(
+      makeReq("POST", "http://localhost:3001"),
+      makeRes(),
+    );
+    assert.equal(nextCalled, true);
+  });
+
+  it("allows POST from http://127.0.0.1 variants", () => {
+    const { nextCalled } = run(
+      makeReq("POST", "http://127.0.0.1:5173"),
+      makeRes(),
+    );
+    assert.equal(nextCalled, true);
+  });
+
+  it("allows POST from http://[::1] (IPv6 loopback)", () => {
+    const { nextCalled } = run(makeReq("POST", "http://[::1]:5173"), makeRes());
+    assert.equal(nextCalled, true);
+  });
+});
+
+describe("requireSameOrigin — state-changing methods, foreign Origin (blocked)", () => {
+  function assertBlocked(method: string, origin: string) {
+    const { nextCalled, statusCode, body } = run(
+      makeReq(method, origin),
+      makeRes(),
+    );
+    assert.equal(
+      nextCalled,
+      false,
+      `${method} from ${origin} should be blocked`,
+    );
+    assert.equal(statusCode, 403);
+    assert.ok(
+      body && typeof body === "object" && "error" in body,
+      "response body should include an error field",
+    );
+  }
+
+  it("blocks POST from an arbitrary foreign origin", () => {
+    assertBlocked("POST", "http://evil.example");
+  });
+
+  it("blocks POST from a localhost subdomain lookalike", () => {
+    // The classic CSRF bypass: register `localhost.evil.com`,
+    // hope the hostname check is a substring match.
+    assertBlocked("POST", "http://localhost.evil.com");
+  });
+
+  it("blocks POST from `http://evillocalhost` (no-dot lookalike)", () => {
+    assertBlocked("POST", "http://evillocalhost");
+  });
+
+  it("blocks POST with Origin `null` (sandboxed iframe / file:// / data:)", () => {
+    assertBlocked("POST", "null");
+  });
+
+  it("blocks POST with a malformed Origin", () => {
+    assertBlocked("POST", "not a url");
+  });
+
+  it("blocks PUT / PATCH / DELETE with a foreign Origin", () => {
+    assertBlocked("PUT", "http://evil.example");
+    assertBlocked("PATCH", "http://evil.example");
+    assertBlocked("DELETE", "http://evil.example");
+  });
+
+  it("blocks POST from a private-LAN IP (defensive for future re-bind)", () => {
+    // Even if the server is re-bound to 0.0.0.0 in the future,
+    // a LAN attacker can't use its own address as a trusted
+    // Origin.
+    assertBlocked("POST", "http://192.168.1.10");
+    assertBlocked("POST", "http://10.0.0.1");
+  });
+});


### PR DESCRIPTION
Third and final pre-existing security follow-up to the merged #134 (see also #147 for the SVG CSP sandbox and #148 for the CORS + localhost-bind + sensitive-file hardening).

## Why CORS lockdown (#148) isn't enough

#148 drops \`cors()\`, so a cross-origin fetch from \`http://evil.example\` can't *read* the response — browser refuses to expose it to the calling script. That defends against **data exfil** (reading \`.env\`, chat history, etc.).

But CORS doesn't block the **request from being sent**. Three classes of request still reach the server:

1. **Simple-CORS POST** — \`application/x-www-form-urlencoded\`, \`multipart/form-data\`, \`text/plain\` don't trigger preflight. A \`<form action=\"http://localhost:3001/api/chat-index/rebuild\" method=\"post\">\` on an attacker page submits the request on user click (or via auto-submit JS). The server happily spawns \`claude\` CLI for every session in the background — **user sees nothing, but their budget burns**.
2. **Simple-CORS GET with side effects** — \`<img src=...>\` fires a GET. Our GETs are all read-only today, but a future endpoint with accidental side effects would be exploitable.
3. **Sandboxed iframes / `file://` origins** — \`Origin: null\`, same-origin policy blocks response reading but the request goes through.

#148 and this PR together are defense in depth:

| PR | Blocks |
|---|---|
| **#148** | Response reading → no data exfil |
| **#149 (this one)** | Cross-origin side effects → no CSRF |

## Design — Origin-header middleware

New \`server/csrfGuard.ts\` module exporting \`requireSameOrigin\` (Express middleware) and \`isLocalhostOrigin\` (pure helper, test target).

\`\`\`ts
const SAFE_METHODS = new Set([\"GET\", \"HEAD\", \"OPTIONS\"]);

export function requireSameOrigin(req, res, next) {
  if (SAFE_METHODS.has(req.method)) return next();
  const origin = req.headers.origin;
  if (typeof origin !== \"string\") return next();  // non-browser caller
  if (isLocalhostOrigin(origin)) return next();
  res.status(403).json({ error: \"Forbidden: cross-origin request rejected\" });
}
\`\`\`

**Safe methods pass through unchecked** — RFC 9110 defines GET / HEAD / OPTIONS as side-effect-free, and OPTIONS is also how CORS preflights arrive.

**Missing Origin → allowed**. Non-browser callers (curl, MCP tools, Node HTTP libraries by default) don't set Origin. They're trustable only because #148 binds the server to \`127.0.0.1\` — remote traffic can't reach us at all, so a missing Origin necessarily comes from a process on the same machine. **Documented loudly in the module doc-comment so a future edit that loosens the bind doesn't silently reopen CSRF.**

**Localhost Origin → allowed**. Parsed with \`new URL(...)\`, hostname checked against a Set. Key subtlety caught during test: Node's URL parser returns IPv6 loopback as the literal string \`[::1]\` **with brackets** (not \`::1\`) — so both forms are in the set, belt-and-suspenders.

**Anything else → 403 + JSON error.** This includes:
- Foreign hostnames
- Localhost subdomain lookalikes (\`localhost.evil.com\`, \`evillocalhost\`, \`notlocalhost\`)
- The literal string \`null\` (sandboxed iframe, file://, data: URL)
- Malformed Origin strings
- Private-LAN IPs (\`192.168.x.x\`, \`10.x.x.x\`, \`172.16.x.x\`, \`0.0.0.0\`) — future-proof for any accidental rebind

## Wiring

\`server/index.ts\` imports \`requireSameOrigin\` and installs it as global middleware right after \`express.json(...)\`, before any route mount. Applies to every route automatically.

## Tests — 31 new cases

Unit tests in \`test/server/test_csrfGuard.ts\` with a minimal fake-Req/Res harness (no supertest dependency):

### \`isLocalhostOrigin\` (20 cases)

- **Accepts**: \`http://localhost\`, \`http://localhost:5173\`, \`http://localhost:3001\`, \`https://localhost\`, \`http://127.0.0.1\`, \`http://127.0.0.1:8080\`, \`http://[::1]\`, \`http://[::1]:5173\`
- **Rejects foreign**: \`http://example.com\`, \`https://attacker.example\`
- **Rejects lookalikes**: \`http://localhost.evil.com\`, \`http://127.0.0.1.nip.io\`, \`http://evillocalhost\`, \`http://notlocalhost\`, \`http://attacker.com/path?host=localhost\`
- **Rejects special values**: the literal string \`null\`, empty string, \`not a url\`, \`http://\`, \`javascript:alert(1)\`, \`file:///tmp/evil.html\`
- **Rejects non-loopback IPs**: \`http://192.168.1.10\`, \`http://10.0.0.1\`, \`http://172.16.0.5\`, \`http://0.0.0.0\`

### \`requireSameOrigin\` middleware (11 cases)

- Safe methods (GET / HEAD / OPTIONS) pass through regardless of Origin
- POST / PUT / PATCH / DELETE with no Origin → \`next()\`
- POST from \`localhost:5173\` / \`localhost:3001\` / \`127.0.0.1\` / IPv6 loopback → \`next()\`
- POST from foreign origin → 403 + error body, \`next()\` NOT called
- POST from localhost subdomain lookalike → 403
- POST with \`null\` Origin → 403
- POST with malformed Origin → 403
- PUT / PATCH / DELETE from foreign origin → 403
- POST from private-LAN IPs → 403

Tests: 608 → 639 (+31).

## Tradeoffs

- **Missing Origin = allowed** — only safe because #148 binds to localhost. Documented in the module header.
- **\`null\` Origin = rejected** — sandboxed iframes, file:// pages, data: URLs can't POST. Right call.
- **No CSRF token fallback** — origin-based defense is simpler and fits our stateless architecture. Synchronizer / double-submit tokens would need session state we don't have.

## Dependency note

This PR technically stacks on #148 (which adds the localhost bind that makes \"missing Origin = allowed\" safe). **If #148 lands first**, everything works as intended. If this PR lands first, there's a theoretical window where a LAN attacker could issue a no-Origin CSRF POST — worth landing #148 first but not a blocker.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` (0 errors, 8 pre-existing warnings)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — 608 → 639 (+31)
- [ ] Manual: \`yarn dev\` → Vite proxy still works, browser loads Vue app, chat / todos / file explorer all function
- [ ] Manual: \`curl -X POST -H \"Origin: http://evil.example\" http://localhost:3001/api/chat-index/rebuild\` → 403
- [ ] Manual: \`curl -X POST http://localhost:3001/api/chat-index/rebuild\` (no Origin) → 200 (allowed for curl)

Plan file: \`plans/fix-server-csrf-origin-check.md\`

Refs #134, #146, #147, #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)