### PR TITLE
fix: DRY + security followup for #151 image-ref PR

### DIFF
--- a/plan/images.md
+++ b/plan/images.md
@@ -6,7 +6,7 @@ Generated/edited/drawn images are stored as base64-encoded data URIs directly in
 
 ## Goal
 
-Store all images as PNG files in `{workspace}/images/` and replace inline base64 with file references (e.g. `"/images/{uuid}.png"`). The frontend fetches images via the existing `/api/files/raw` route.
+Store all images as PNG files in `{workspace}/images/` and replace inline base64 with file references (e.g. `"images/{uuid}.png"` — no leading slash). The frontend fetches images via the existing `/api/files/raw?path=...` route.
 
 ## Design
 
@@ -106,7 +106,7 @@ export function isImagePath(value: string): boolean {
 /** Convert an imageData value to a displayable URL. */
 export function resolveImageSrc(imageData: string): string {
   if (imageData.startsWith("data:")) return imageData; // legacy data URI
-  return `/api/files/raw/${imageData}`;                 // file reference
+  return `/api/files/raw?path=${encodeURIComponent(imageData)}`;  // file reference
 }
 ```
 

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -15,10 +15,7 @@ import {
 
 const router = Router();
 
-interface GenerateImageBody {
-  prompt: string;
-  model?: string;
-}
+// ── Shared response helpers ──────────────────────────────────────
 
 interface ImageSuccessResponse {
   message: string;
@@ -34,6 +31,65 @@ interface ImageErrorResponse {
 
 type ImageResponse = ImageSuccessResponse | ImageErrorResponse;
 
+// Shared save-and-respond for /generate-image and /edit-image. The
+// only difference between the two routes is how they obtain the raw
+// imageData from Gemini — once that's done, the "save to disk and
+// build the JSON response" step is identical.
+async function respondWithImage(
+  res: Response<ImageResponse>,
+  imageData: string | undefined,
+  fallbackMessage: string | undefined,
+  prompt: string,
+  kind: "generation" | "edit",
+): Promise<void> {
+  if (!imageData) {
+    res.json({ message: fallbackMessage ?? "no image data in response" });
+    return;
+  }
+  const imagePath = await saveImage(imageData);
+  const label = kind === "generation" ? "Generated" : "Edited";
+  res.json({
+    message: `image ${kind} succeeded`,
+    instructions: `Acknowledge that the image was ${kind === "generation" ? "generated" : "edited"} and has been presented to the user.`,
+    title: `${label} Image`,
+    data: { imageData: imagePath, prompt },
+  });
+}
+
+// ── Canvas image storage routes ──────────────────────────────────
+
+interface CanvasImageBody {
+  imageData: string;
+}
+
+interface CanvasImageResponse {
+  path: string;
+}
+
+interface CanvasImageError {
+  error: string;
+}
+
+async function saveCanvasImage(
+  res: Response<CanvasImageResponse | CanvasImageError>,
+  base64: string,
+  writeFn: (b64: string) => Promise<string>,
+): Promise<void> {
+  try {
+    const imagePath = await writeFn(base64);
+    res.json({ path: imagePath });
+  } catch (err) {
+    res.status(500).json({ error: errorMessage(err) });
+  }
+}
+
+// ── Routes ───────────────────────────────────────────────────────
+
+interface GenerateImageBody {
+  prompt: string;
+  model?: string;
+}
+
 router.post(
   "/generate-image",
   async (
@@ -41,32 +97,16 @@ router.post(
     res: Response<ImageResponse>,
   ) => {
     const { prompt, model } = req.body;
-
     if (!prompt) {
       res.status(400).json({ success: false, message: "prompt is required" });
       return;
     }
-
     try {
       const { imageData, message } = await generateGeminiImageFromPrompt(
         prompt,
         model,
       );
-      if (imageData) {
-        const imagePath = await saveImage(imageData);
-        res.json({
-          message: "image generation succeeded",
-          instructions:
-            "Acknowledge that the image was generated and has been presented to the user.",
-          title: "Generated Image",
-          data: {
-            imageData: imagePath,
-            prompt,
-          },
-        });
-      } else {
-        res.json({ message: message ?? "no image data in response" });
-      }
+      await respondWithImage(res, imageData, message, prompt, "generation");
     } catch (err) {
       res.status(500).json({ success: false, message: errorMessage(err) });
     }
@@ -86,12 +126,10 @@ router.post(
     const { prompt } = req.body;
     const session =
       typeof req.query.session === "string" ? req.query.session : undefined;
-
     if (!prompt) {
       res.status(400).json({ success: false, message: "prompt is required" });
       return;
     }
-
     const currentImageData = session ? getSessionImageData(session) : undefined;
     if (!currentImageData) {
       res.status(400).json({
@@ -101,7 +139,6 @@ router.post(
       });
       return;
     }
-
     try {
       // Resolve input image to raw base64 — supports both file paths and legacy data URIs
       const base64Data = isImagePath(currentImageData)
@@ -117,40 +154,14 @@ router.post(
           ],
         },
       ]);
-      if (imageData) {
-        const imagePath = await saveImage(imageData);
-        res.json({
-          message: "image edit succeeded",
-          instructions:
-            "Acknowledge that the image was edited and has been presented to the user.",
-          title: "Edited Image",
-          data: {
-            imageData: imagePath,
-            prompt,
-          },
-        });
-      } else {
-        res.json({ message: message ?? "no image data in response" });
-      }
+      await respondWithImage(res, imageData, message, prompt, "edit");
     } catch (err) {
       res.status(500).json({ success: false, message: errorMessage(err) });
     }
   },
 );
 
-// Canvas image storage — POST creates a new file, PUT overwrites existing
-
-interface CanvasImageBody {
-  imageData: string;
-}
-
-interface CanvasImageResponse {
-  path: string;
-}
-
-interface CanvasImageError {
-  error: string;
-}
+// Canvas image persistence — POST creates a new file, PUT overwrites.
 
 router.post(
   "/images",
@@ -163,13 +174,8 @@ router.post(
       res.status(400).json({ error: "imageData is required" });
       return;
     }
-    try {
-      const base64 = stripDataUri(imageData);
-      const imagePath = await saveImage(base64);
-      res.json({ path: imagePath });
-    } catch (err) {
-      res.status(500).json({ error: errorMessage(err) });
-    }
+    const base64 = stripDataUri(imageData);
+    await saveCanvasImage(res, base64, async (b64) => saveImage(b64));
   },
 );
 
@@ -189,13 +195,11 @@ router.put(
       res.status(400).json({ error: "invalid image path" });
       return;
     }
-    try {
-      const base64 = stripDataUri(imageData);
-      await overwriteImage(relativePath, base64);
-      res.json({ path: relativePath });
-    } catch (err) {
-      res.status(500).json({ error: errorMessage(err) });
-    }
+    const base64 = stripDataUri(imageData);
+    await saveCanvasImage(res, base64, async (b64) => {
+      await overwriteImage(relativePath, b64);
+      return relativePath;
+    });
   },
 );
 

--- a/server/utils/image-store.ts
+++ b/server/utils/image-store.ts
@@ -2,11 +2,39 @@ import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { workspacePath } from "../workspace.js";
+import { resolveWithinRoot } from "./fs.js";
 
 const IMAGES_DIR = path.join(workspacePath, "images");
 
+// Cached realpath of the images directory. resolveWithinRoot requires
+// its root argument to be a realpath so symlinks are handled correctly.
+let imagesDirReal: string | null = null;
+
+async function ensureImagesDir(): Promise<string> {
+  if (imagesDirReal) return imagesDirReal;
+  await fs.mkdir(IMAGES_DIR, { recursive: true });
+  imagesDirReal = await fs.realpath(IMAGES_DIR);
+  return imagesDirReal;
+}
+
+// Resolve a workspace-relative image path (e.g. "images/abc123.png")
+// into an absolute path that is guaranteed to be inside the images
+// directory. Throws on traversal attempts or non-existent files.
+async function safeResolve(relativePath: string): Promise<string> {
+  const root = await ensureImagesDir();
+  // Strip the leading "images/" prefix so the caller can pass either
+  // "images/abc.png" (the stored form) or just "abc.png".
+  const name = relativePath.replace(/^images\//, "");
+  const result = resolveWithinRoot(root, name);
+  if (!result) {
+    throw new Error(`path traversal rejected: ${relativePath}`);
+  }
+  return result;
+}
+
 /** Save raw base64 (no data URI prefix) as a PNG file. Returns the workspace-relative path. */
 export async function saveImage(base64Data: string): Promise<string> {
+  await ensureImagesDir();
   const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
   const filename = `${id}.png`;
   const absPath = path.join(IMAGES_DIR, filename);
@@ -19,13 +47,13 @@ export async function overwriteImage(
   relativePath: string,
   base64Data: string,
 ): Promise<void> {
-  const absPath = path.join(workspacePath, relativePath);
+  const absPath = await safeResolve(relativePath);
   await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
 }
 
 /** Read an image file and return raw base64 (no data URI prefix). */
 export async function loadImageBase64(relativePath: string): Promise<string> {
-  const absPath = path.join(workspacePath, relativePath);
+  const absPath = await safeResolve(relativePath);
   const buf = await fs.readFile(absPath);
   return buf.toString("base64");
 }

--- a/src/plugins/canvas/Preview.vue
+++ b/src/plugins/canvas/Preview.vue
@@ -1,28 +1,13 @@
 <template>
-  <div class="min-h-24 flex items-center justify-center">
-    <img
-      v-if="result.data?.imageData"
-      :src="resolvedSrc"
-      class="max-w-full h-auto rounded"
-      alt="Canvas drawing"
-    />
-    <div v-else class="text-gray-400 text-sm">No drawing yet</div>
-  </div>
+  <ImagePreview :result="result" alt="Canvas drawing" />
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ImagePreview } from "../ui-image";
 import type { ToolResult } from "gui-chat-protocol/vue";
 import type { ImageToolData } from "./definition";
-import { resolveImageSrc } from "../../utils/image/resolve";
 
-const props = defineProps<{
+defineProps<{
   result: ToolResult<ImageToolData>;
 }>();
-
-const resolvedSrc = computed(() =>
-  props.result.data?.imageData
-    ? resolveImageSrc(props.result.data.imageData)
-    : "",
-);
 </script>

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -135,7 +135,8 @@ const artStyles = [
 ];
 
 const applyStyle = async (style: { id: string; label: string }) => {
-  await saveDrawingState();
+  const saved = await saveDrawingState();
+  if (!saved) return;
   if (props.sendTextMessage) {
     props.sendTextMessage(
       `Turn my drawing on the canvas into a ${style.label} style image.`,
@@ -162,6 +163,7 @@ const imagePath = ref(
     : "",
 );
 let uploadInFlight = false;
+let pendingSave = false;
 
 const restoreDrawingState = () => {
   if (props.selectedResult?.viewState?.drawingState) {
@@ -181,6 +183,13 @@ const restoreDrawingState = () => {
   } else {
     initialStrokes.value = [];
   }
+  // Reinitialise imagePath from the incoming result so autosaves
+  // after a selectedResult change don't upload against the old path.
+  imagePath.value =
+    props.selectedResult?.data?.imageData &&
+    !props.selectedResult.data.imageData.startsWith("data:")
+      ? props.selectedResult.data.imageData
+      : "";
 };
 restoreDrawingState();
 
@@ -223,33 +232,24 @@ const handleDrawingEnd = () => {
   saveDrawingState();
 };
 
-const uploadImage = async (dataUri: string): Promise<string> => {
-  if (imagePath.value) {
-    // Overwrite existing file
-    const filename = imagePath.value.replace(/^images\//, "");
-    const res = await fetch(`/api/images/${filename}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ imageData: dataUri }),
-    });
-    if (!res.ok) throw new Error(`PUT failed: ${res.statusText}`);
-    const json: { path: string } = await res.json();
-    return json.path;
-  } else {
-    // Create new file
-    const res = await fetch("/api/images", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ imageData: dataUri }),
-    });
-    if (!res.ok) throw new Error(`POST failed: ${res.statusText}`);
-    const json: { path: string } = await res.json();
-    return json.path;
+// Returns true if the drawing was successfully persisted, false
+// otherwise. Callers like applyStyle check the return value to avoid
+// sending a style request against stale image data.
+//
+// Captures a local snapshot of props.selectedResult and imagePath at
+// the start so an async upload never accidentally writes against a
+// different result that was swapped in mid-flight.
+const saveDrawingState = async (): Promise<boolean> => {
+  if (!canvasRef.value || !props.selectedResult) return false;
+  if (uploadInFlight) {
+    pendingSave = true;
+    return false;
   }
-};
-
-const saveDrawingState = async () => {
-  if (!canvasRef.value || !props.selectedResult || uploadInFlight) return;
+  // Snapshot the current result and path *before* any await so a
+  // concurrent selectedResult swap doesn't silently redirect the
+  // upload.
+  const boundResult = props.selectedResult;
+  const boundImagePath = imagePath.value;
   uploadInFlight = true;
   try {
     const imageDataUri: string = await canvasRef.value.save();
@@ -262,25 +262,55 @@ const saveDrawingState = async () => {
       canvasHeight: canvasHeight.value,
     };
 
-    const path = await uploadImage(imageDataUri);
-    imagePath.value = path;
+    // If selectedResult changed while we were saving the canvas
+    // bitmap, abort — the upload would go to the wrong session.
+    if (boundResult !== props.selectedResult) return false;
+
+    const savedPath = boundImagePath
+      ? await (async () => {
+          const filename = boundImagePath.replace(/^images\//, "");
+          const res = await fetch(`/api/images/${filename}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ imageData: imageDataUri }),
+          });
+          if (!res.ok) throw new Error(`PUT failed: ${res.statusText}`);
+          const json: { path: string } = await res.json();
+          return json.path;
+        })()
+      : await (async () => {
+          const res = await fetch("/api/images", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ imageData: imageDataUri }),
+          });
+          if (!res.ok) throw new Error(`POST failed: ${res.statusText}`);
+          const json: { path: string } = await res.json();
+          return json.path;
+        })();
+
+    imagePath.value = savedPath;
 
     const updatedResult: ToolResult<ImageToolData> = {
-      ...props.selectedResult,
+      ...boundResult,
       data: {
-        prompt: props.selectedResult.data?.prompt || "",
-        imageData: path,
+        prompt: boundResult.data?.prompt || "",
+        imageData: savedPath,
       },
-      viewState: {
-        drawingState,
-      },
+      viewState: { drawingState },
     };
 
     emit("updateResult", updatedResult);
+    return true;
   } catch (error) {
     console.error("Failed to save drawing state:", error);
+    return false;
   } finally {
     uploadInFlight = false;
+    if (pendingSave) {
+      pendingSave = false;
+      void saveDrawingState();
+    }
   }
 };
 

--- a/src/plugins/editImage/Preview.vue
+++ b/src/plugins/editImage/Preview.vue
@@ -1,28 +1,13 @@
 <template>
-  <div class="min-h-24 flex items-center justify-center">
-    <img
-      v-if="result.data?.imageData"
-      :src="resolvedSrc"
-      class="max-w-full h-auto rounded"
-      alt="Edited image"
-    />
-    <div v-else class="text-gray-400 text-sm">No image yet</div>
-  </div>
+  <ImagePreview :result="result" alt="Edited image" />
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ImagePreview } from "../ui-image";
 import type { ToolResult } from "gui-chat-protocol";
 import type { ImageToolData } from "./definition";
-import { resolveImageSrc } from "../../utils/image/resolve";
 
-const props = defineProps<{
+defineProps<{
   result: ToolResult<ImageToolData>;
 }>();
-
-const resolvedSrc = computed(() =>
-  props.result.data?.imageData
-    ? resolveImageSrc(props.result.data.imageData)
-    : "",
-);
 </script>

--- a/src/plugins/editImage/View.vue
+++ b/src/plugins/editImage/View.vue
@@ -1,39 +1,18 @@
 <template>
-  <div class="w-full h-full overflow-y-auto">
-    <div class="min-h-full flex flex-col items-center justify-center p-4">
-      <div class="flex-1 flex items-center justify-center min-h-0">
-        <img
-          :src="resolvedSrc"
-          class="max-w-full max-h-full object-contain rounded"
-          alt="Edited image"
-        />
-      </div>
-      <div
-        v-if="selectedResult.data?.prompt"
-        class="mt-4 p-3 bg-gray-100 rounded-lg max-w-full flex-shrink-0"
-      >
-        <p class="text-sm text-gray-700">
-          <span class="font-medium">Edit prompt:</span>
-          {{ selectedResult.data.prompt }}
-        </p>
-      </div>
-    </div>
-  </div>
+  <ImageView
+    v-if="selectedResult"
+    :selectedResult="selectedResult"
+    alt="Edited image"
+    prompt-label="Edit prompt"
+  />
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ImageView } from "../ui-image";
 import type { ToolResult } from "gui-chat-protocol";
 import type { ImageToolData } from "./definition";
-import { resolveImageSrc } from "../../utils/image/resolve";
 
-const props = defineProps<{
+defineProps<{
   selectedResult: ToolResult<ImageToolData>;
 }>();
-
-const resolvedSrc = computed(() =>
-  props.selectedResult.data?.imageData
-    ? resolveImageSrc(props.selectedResult.data.imageData)
-    : "",
-);
 </script>

--- a/src/plugins/ui-image/ImagePreview.vue
+++ b/src/plugins/ui-image/ImagePreview.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="min-h-24 flex items-center justify-center">
     <img
-      v-if="result.data?.imageData"
+      v-if="resolvedSrc"
       :src="resolvedSrc"
       class="max-w-full h-auto rounded"
-      alt="Generated image"
+      :alt="alt"
     />
     <div v-else class="text-gray-400 text-sm">No image yet</div>
   </div>
@@ -12,12 +12,17 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ToolResult, ImageToolData } from "./types";
+import type { ToolResult } from "gui-chat-protocol/vue";
+import type { ImageToolData } from "./types";
 import { resolveImageSrc } from "../../utils/image/resolve";
 
-const props = defineProps<{
-  result: ToolResult<ImageToolData>;
-}>();
+const props = withDefaults(
+  defineProps<{
+    result: ToolResult<ImageToolData>;
+    alt?: string;
+  }>(),
+  { alt: "Image" },
+);
 
 const resolvedSrc = computed(() =>
   props.result.data?.imageData

--- a/src/plugins/ui-image/ImageView.vue
+++ b/src/plugins/ui-image/ImageView.vue
@@ -1,19 +1,28 @@
 <template>
   <div class="w-full h-full overflow-y-auto">
     <div class="min-h-full flex flex-col items-center justify-center p-4">
-      <div class="flex-1 flex items-center justify-center min-h-0">
+      <div
+        v-if="resolvedSrc"
+        class="flex-1 flex items-center justify-center min-h-0"
+      >
         <img
           :src="resolvedSrc"
           class="max-w-full max-h-full object-contain rounded"
-          alt="Current generated image"
+          :alt="alt"
         />
+      </div>
+      <div
+        v-else
+        class="flex-1 flex items-center justify-center text-gray-400 text-sm"
+      >
+        No image yet
       </div>
       <div
         v-if="selectedResult.data?.prompt"
         class="mt-4 p-3 bg-gray-100 rounded-lg max-w-full flex-shrink-0"
       >
         <p class="text-sm text-gray-700">
-          <span class="font-medium">Prompt:</span>
+          <span class="font-medium">{{ promptLabel }}:</span>
           {{ selectedResult.data.prompt }}
         </p>
       </div>
@@ -23,12 +32,18 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ToolResult, ImageToolData } from "./types";
+import type { ToolResult } from "gui-chat-protocol/vue";
+import type { ImageToolData } from "./types";
 import { resolveImageSrc } from "../../utils/image/resolve";
 
-const props = defineProps<{
-  selectedResult: ToolResult<ImageToolData>;
-}>();
+const props = withDefaults(
+  defineProps<{
+    selectedResult: ToolResult<ImageToolData>;
+    alt?: string;
+    promptLabel?: string;
+  }>(),
+  { alt: "Image", promptLabel: "Prompt" },
+);
 
 const resolvedSrc = computed(() =>
   props.selectedResult.data?.imageData

--- a/src/plugins/ui-image/index.ts
+++ b/src/plugins/ui-image/index.ts
@@ -1,3 +1,3 @@
 export { default as ImageView } from "./ImageView.vue";
 export { default as ImagePreview } from "./ImagePreview.vue";
-export type { ImageToolData, ToolResult } from "./types";
+export type { ImageToolData } from "./types";

--- a/src/plugins/ui-image/types.ts
+++ b/src/plugins/ui-image/types.ts
@@ -2,9 +2,3 @@ export interface ImageToolData {
   imageData: string;
   prompt?: string;
 }
-
-export interface ToolResult<T = unknown> {
-  toolName?: string;
-  message: string;
-  data?: T;
-}


### PR DESCRIPTION
Closes #153.

## User Prompt

> #151 をとりこんだけど145みたいなDRY漏れある？
> CodeRabbitの指摘も含め、全部直して。reexportするくらいなら直接参照してほしい

## Summary

- CodeRabbit #151 レビューの actionable 5 個 + nitpick 1 個を全部対応
- 自前のコードレビューで見つけた DRY 漏れ 3 箇所 + path traversal セキュリティギャップを修正
- re-export は使わず、各ファイルで `gui-chat-protocol/vue` を直接参照 (ユーザ指示)

## Changes

### CodeRabbit fixes

| # | ファイル | 問題 | 対応 |
|---|---|---|---|
| 1 | `canvas/View.vue` | `applyStyle` が save 失敗を無視して style request を投げる | `saveDrawingState` を boolean 返却に。呼び出し元が false なら中断 |
| 2 | `canvas/View.vue` | `saveDrawingState` が await 中に live props を読むので別 result に適用される race | local snapshot を capture、結果が変わったら bail |
| 3 | `image-store.ts` | path traversal (`images/../../etc/passwd.png` が通る) | `resolveWithinRoot` (server/utils/fs.ts) で containment check |
| 4 | `editImage/View.vue` | `<img>` が空 src でも render → broken image icon | shared ImageView に v-if 追加 (DRY migration で自動解消) |
| 5 | `ui-image/ImageView.vue` | 同じ broken-image bug | `v-if="resolvedSrc"` + else で "No image yet" |
| 6 | `ui-image/types.ts` | `ToolResult` を local 再定義 | 削除。各ファイルで `gui-chat-protocol/vue` を直接 import |
| 7 | `plan/images.md` | パス表記が実装と合ってない | no-leading-slash + `?path=` query に修正 |

### DRY improvements

**フロントエンド** — 3 ファイルのコピペを共通コンポーネントに delegate:

| ファイル | Before | After |
|---|---|---|
| `canvas/Preview.vue` | 27 行 (ImagePreview と alt 1 文字違い) | 13 行 delegate |
| `editImage/Preview.vue` | 28 行 (同) | 13 行 delegate |
| `editImage/View.vue` | 39 行 (ImageView と prompt label 1 文字違い) | 16 行 delegate |

`ImagePreview` / `ImageView` に optional `alt` / `promptLabel` props を追加。`generateImage/*` は PR #151 で既に migrate 済み。

**バックエンド** — `server/routes/image.ts`:
- `respondWithImage()` helper 抽出 (`/generate-image` と `/edit-image` の save→respond を共通化)
- `saveCanvasImage()` helper 抽出 (`POST /images` と `PUT /images/:filename` の try/catch を共通化)

## Test plan

- [x] `yarn test` — 773/773 pass
- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] Manual UI: canvas で描画 → style 適用 → image が保存されてからリクエストが飛ぶか
- [ ] editImage: 画像編集 → Preview に broken image icon が出ないか
- [ ] generateImage: 生成 → 同じく正常表示されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image file path security and validation to prevent unauthorized access

* **Refactor**
  * Consolidated image rendering and display logic across tools for improved consistency
  * Improved image upload and save handling with better concurrent operation management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->