### PR TITLE
feat(router): phase 0 — install vue-router with zero rendering changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import router from "./router/index";
+import { installGuards } from "./router/guards";
 import "./index.css";
 import "material-icons/iconfont/material-icons.css";
 
@@ -11,4 +13,8 @@ import.meta.glob(
   { eager: true },
 );
 
-createApp(App).mount("#app");
+installGuards(router);
+
+const app = createApp(App);
+app.use(router);
+app.mount("#app");

--- a/src/router/guards.ts
+++ b/src/router/guards.ts
@@ -1,0 +1,31 @@
+// Navigation guard: validates and sanitizes URL parameters.
+//
+// All incoming route params / query values are untrusted — they could
+// come from a user-typed URL, a pasted link, or a malicious redirect.
+// This guard runs before every navigation and rewrites invalid state
+// to safe defaults without the user noticing (router.replace, which
+// doesn't push a history entry).
+//
+// Phase 0: only the `view` query whitelist is enforced. Later phases
+// will add sessionId existence checks, path traversal rejection, etc.
+
+import type { Router } from "vue-router";
+
+const VALID_VIEW_MODES = new Set(["single", "stack", "files"]);
+
+export function installGuards(router: Router): void {
+  router.beforeEach((to) => {
+    // Only run guards on the chat route — other routes (redirect, etc.)
+    // don't carry parameters that need sanitizing.
+    if (to.name !== "chat") return;
+
+    // ── view mode whitelist ──────────────────────────────────────
+    const view = to.query.view;
+    if (typeof view === "string" && !VALID_VIEW_MODES.has(view)) {
+      // Strip the bad value and fall through to the default (single).
+      const cleaned = { ...to.query };
+      delete cleaned.view;
+      return { ...to, query: cleaned, replace: true };
+    }
+  });
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,55 @@
+// Phase 0: minimal vue-router setup.
+//
+// Hash mode so no server-side rewrite rules are needed. The only
+// route is /chat/:sessionId? which captures the session the user was
+// looking at. Everything else (view mode, file path, result uuid,
+// role) lives in query parameters and will be wired in later phases.
+//
+// The "/" → "/chat" redirect ensures a fresh browser tab always lands
+// on the chat view with the default (new) session, matching the
+// current pre-router behaviour.
+//
+// Phase 0 does NOT add <router-view> to App.vue — the existing
+// rendering is completely untouched. The router just manages the URL
+// and makes `useRoute()` available for later phases to start reading
+// params/query. The route components are no-op stubs.
+
+import { defineComponent, h } from "vue";
+import {
+  createRouter,
+  createWebHashHistory,
+  type RouteRecordRaw,
+} from "vue-router";
+
+// Stub component that renders nothing. Required by vue-router (every
+// route needs a component) but never actually mounted because App.vue
+// doesn't contain <router-view> in Phase 0.
+const Stub = defineComponent({ render: () => h("div") });
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: "/",
+    redirect: "/chat",
+  },
+  {
+    // sessionId is optional — /chat with no param means "new session"
+    // (the App.vue logic that auto-creates a session continues to
+    // handle this).
+    path: "/chat/:sessionId?",
+    name: "chat",
+    component: Stub,
+  },
+  {
+    // Catch-all: unknown paths redirect to /chat so a stale bookmark
+    // or a typo doesn't show a blank page.
+    path: "/:pathMatch(.*)*",
+    redirect: "/chat",
+  },
+];
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes,
+});
+
+export default router;


### PR DESCRIPTION
Part of #108.

## User Prompt

> できる限り、様々な機能、状態をurlにあてて、ユーザがurlを指定すればその状態になるようにしたい
> そとからurlをinjectionされたときに暴走しないようにもね
> 小さな部分から少しずつ進めていきたい

## Summary

Phase 0: vue-router を hash mode で導入する。**既存の動作は一切変えない**。

- `src/router/index.ts` — ルート定義 (`/` → `/chat` redirect, `/chat/:sessionId?`, catch-all)
- `src/router/guards.ts` — `beforeEach` で `?view=` の whitelist validation (不正値は strip + replace)
- `src/main.ts` — `app.use(router)` + guard 登録

**変えないもの**: App.vue のテンプレート / スクリプト / state / localStorage — diff ゼロ。`<router-view>` もまだ無い。後続 Phase で段階的に ref を route params に移行する。

## URL injection 対策 (Phase 0 scope)

- `?view=` が whitelist (`single|stack|files`) にない → query 削除 + `router.replace`
- `/#/<script>alert(1)</script>` → catch-all redirect to `/chat`
- `/#/../../etc/passwd` → catch-all redirect to `/chat`

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — clean
- [x] `yarn test` — all pass
- [x] curl smoke: `/`, `/#/chat`, `/#/chat/test-session?view=files&path=wiki/foo.md`, `/#/garbage` 全部 200
- [x] API proxy (`/api/health`) 影響なし
- [x] **手動**: ブラウザで開いて既存の操作 (セッション選択、ビュー切替、ファイル選択) が壊れていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled routing throughout the application with support for parameterized navigation
  * Implemented automatic query parameter validation that sanitizes invalid values and redirects to valid states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->