### PR TITLE
Store generated markdown files as well as images in {workspace}

### DIFF
--- a/plan/markdowns.md
+++ b/plan/markdowns.md
@@ -1,0 +1,147 @@
+# Plan: File-Based Markdown & Image Storage for presentDocument
+
+## Problem
+
+The `presentDocument` plugin stores the full markdown (including base64-embedded images) inline in the ToolResult, which lives in the chat JSONL file. A document with 3-4 images can be 10+ MB of base64 text.
+
+## Goal
+
+1. Store generated markdown files in `{workspace}/markdowns/{uuid}.md`
+2. Store generated images in `{workspace}/images/{uuid}.png` (reusing the image-store infrastructure)
+3. Replace inline base64 image URLs in markdown with workspace-relative paths
+4. When the user edits markdown in the View, update the file on disk
+5. The ToolResult `data.markdown` field changes from inline content to a file path reference
+
+## Design
+
+### Storage layout
+
+```
+~/mulmoclaude/
+  markdowns/
+    a1b2c3d4.md          ← full markdown with image references
+  images/
+    e5f6g7h8.png         ← generated images (already exists from image plan)
+```
+
+### Markdown file content
+
+The markdown file on disk contains image references as relative paths:
+
+```markdown
+# My Guide
+
+![A scenic mountain](../images/e5f6g7h8.png)
+
+Some text here...
+```
+
+### ToolResult data change
+
+```
+Before: { markdown: "# Title\n![prompt](data:image/png;base64,...)\n..." }
+After:  { markdown: "markdowns/a1b2c3d4.md" }
+```
+
+The frontend detects whether `data.markdown` is a file path or inline content for backward compatibility.
+
+## Implementation Steps
+
+### Step 1: Add `markdowns/` to workspace
+
+**File: `server/workspace.ts`**
+
+Add `"markdowns"` to the `SUBDIRS` array.
+
+### Step 2: Create markdown storage utility
+
+**New file: `server/utils/markdown-store.ts`**
+
+```typescript
+import fs from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+import { workspacePath } from "../workspace.js";
+
+const MARKDOWNS_DIR = path.join(workspacePath, "markdowns");
+
+export async function saveMarkdown(content: string): Promise<string> {
+  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const filename = `${id}.md`;
+  await fs.writeFile(path.join(MARKDOWNS_DIR, filename), content, "utf-8");
+  return `markdowns/${filename}`;
+}
+
+export async function loadMarkdown(relativePath: string): Promise<string> {
+  const absPath = path.join(workspacePath, relativePath);
+  return fs.readFile(absPath, "utf-8");
+}
+
+export async function overwriteMarkdown(relativePath: string, content: string): Promise<void> {
+  const absPath = path.join(workspacePath, relativePath);
+  await fs.writeFile(absPath, content, "utf-8");
+}
+
+export function isMarkdownPath(value: string): boolean {
+  return value.startsWith("markdowns/") && value.endsWith(".md");
+}
+```
+
+### Step 3: Update `fillImagePlaceholders` to save images as files
+
+**File: `server/routes/plugins.ts`**
+
+Change `generateInlineImage()` to save the PNG to disk via `saveImage()` and return a workspace-relative path instead of a data URI. The markdown will contain `![prompt](images/abc123.png)` instead of base64.
+
+### Step 4: Update `/api/present-document` to save markdown to disk
+
+**File: `server/routes/plugins.ts`**
+
+After filling image placeholders, save the filled markdown to disk via `saveMarkdown()`. Return the path in `data.markdown` instead of the full content.
+
+### Step 5: Add markdown update endpoint
+
+**File: `server/routes/plugins.ts`** (or new route)
+
+```
+PUT /api/markdowns/:filename
+Body: { markdown: "..." }
+```
+
+Called when user edits markdown in the View — overwrites the file on disk.
+
+### Step 6: Update frontend View.vue
+
+**File: `src/plugins/markdown/View.vue`**
+
+- On mount / selectedResult change: if `data.markdown` is a path, fetch the content via `GET /api/files/content?path=...`
+- Render the fetched markdown content
+- Images in the markdown use relative paths like `images/abc123.png` — these need to be resolved to `/api/files/raw?path=images/abc123.png` before rendering
+- **Edit + Apply**: PUT the updated markdown to `/api/markdowns/:filename`, then re-fetch to confirm
+- **Download**: fetch content first if it's a path, then download
+
+### Step 7: Update frontend Preview.vue
+
+**File: `src/plugins/markdown/Preview.vue`**
+
+The preview shows the title, which comes from the ToolResult `title` field (not from the markdown content), so no change needed unless the preview shows a markdown snippet.
+
+### Step 8: Resolve image paths in rendered markdown
+
+When rendering markdown with `marked()`, image src attributes will be relative paths like `images/abc123.png`. Add a custom `marked` renderer or post-process the HTML to rewrite image `src` attributes to `/api/files/raw?path=images/abc123.png`.
+
+## Backward Compatibility
+
+- If `data.markdown` starts with `markdowns/`, treat as file path — fetch from server
+- Otherwise treat as inline content (legacy sessions)
+- Images: `marked` renderer handles both `data:` URIs and relative paths
+
+## File Changes Summary
+
+| File | Action |
+|---|---|
+| `server/workspace.ts` | Add `"markdowns"` to SUBDIRS |
+| `server/utils/markdown-store.ts` | **New** — save/load/overwrite markdown files |
+| `server/routes/plugins.ts` | Save images as files, save markdown as file, add PUT endpoint |
+| `src/plugins/markdown/View.vue` | Fetch markdown from server, resolve image paths, save edits to server |
+| `src/plugins/markdown/Preview.vue` | Possibly no change |

--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -11,6 +11,12 @@ import {
   isGeminiAvailable,
 } from "../utils/gemini.js";
 import { errorMessage } from "../utils/errors.js";
+import { saveImage } from "../utils/image-store.js";
+import {
+  saveMarkdown,
+  overwriteMarkdown,
+  isMarkdownPath,
+} from "../utils/markdown-store.js";
 
 const router = Router();
 
@@ -46,11 +52,11 @@ function wrapPluginExecute<TResult>(
 
 const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
 
-async function generateInlineImage(prompt: string): Promise<string | null> {
+async function generateImageFile(prompt: string): Promise<string | null> {
   if (!isGeminiAvailable()) return null;
   try {
     const { imageData } = await generateGeminiImageFromPrompt(prompt);
-    if (imageData) return `data:image/png;base64,${imageData}`;
+    if (imageData) return saveImage(imageData);
   } catch {
     // leave placeholder if generation fails
   }
@@ -66,13 +72,13 @@ async function fillImagePlaceholders(markdown: string): Promise<string> {
     matches.map(async (m) => ({
       full: m[0],
       prompt: m[1],
-      url: await generateInlineImage(m[1]),
+      url: await generateImageFile(m[1]),
     })),
   );
 
   let filled = markdown;
   for (const { full, prompt, url } of results) {
-    if (url) filled = filled.replace(full, `![${prompt}](${url})`);
+    if (url) filled = filled.replace(full, `![${prompt}](../${url})`);
   }
   return filled;
 }
@@ -98,11 +104,50 @@ router.post(
   ) => {
     const { title, markdown, filenameHint } = req.body;
     const filledMarkdown = await fillImagePlaceholders(markdown);
+    const markdownPath = await saveMarkdown(filledMarkdown);
     res.json({
       message: `Document "${title}" is ready.`,
       title,
-      data: { markdown: filledMarkdown, filenameHint },
+      data: { markdown: markdownPath, filenameHint },
     });
+  },
+);
+
+// Update markdown file on disk (user edits in View)
+interface UpdateMarkdownBody {
+  markdown: string;
+}
+
+interface UpdateMarkdownResponse {
+  path: string;
+}
+
+interface UpdateMarkdownError {
+  error: string;
+}
+
+router.put(
+  "/markdowns/:filename",
+  async (
+    req: Request<{ filename: string }, unknown, UpdateMarkdownBody>,
+    res: Response<UpdateMarkdownResponse | UpdateMarkdownError>,
+  ) => {
+    const relativePath = `markdowns/${req.params.filename}`;
+    const { markdown } = req.body;
+    if (!markdown) {
+      res.status(400).json({ error: "markdown is required" });
+      return;
+    }
+    if (!isMarkdownPath(relativePath)) {
+      res.status(400).json({ error: "invalid markdown path" });
+      return;
+    }
+    try {
+      await overwriteMarkdown(relativePath, markdown);
+      res.json({ path: relativePath });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
   },
 );
 

--- a/server/utils/markdown-store.ts
+++ b/server/utils/markdown-store.ts
@@ -1,0 +1,34 @@
+import fs from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+import { workspacePath } from "../workspace.js";
+
+const MARKDOWNS_DIR = path.join(workspacePath, "markdowns");
+
+/** Save markdown content as a file. Returns the workspace-relative path. */
+export async function saveMarkdown(content: string): Promise<string> {
+  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const filename = `${id}.md`;
+  await fs.writeFile(path.join(MARKDOWNS_DIR, filename), content, "utf-8");
+  return `markdowns/${filename}`;
+}
+
+/** Read a markdown file and return its content. */
+export async function loadMarkdown(relativePath: string): Promise<string> {
+  const absPath = path.join(workspacePath, relativePath);
+  return fs.readFile(absPath, "utf-8");
+}
+
+/** Overwrite an existing markdown file. */
+export async function overwriteMarkdown(
+  relativePath: string,
+  content: string,
+): Promise<void> {
+  const absPath = path.join(workspacePath, relativePath);
+  await fs.writeFile(absPath, content, "utf-8");
+}
+
+/** Check if a string is a markdown file path (not inline content). */
+export function isMarkdownPath(value: string): boolean {
+  return value.startsWith("markdowns/") && value.endsWith(".md");
+}

--- a/server/workspace.ts
+++ b/server/workspace.ts
@@ -21,6 +21,7 @@ const SUBDIRS = [
   "roles",
   "stories",
   "images",
+  "markdowns",
 ];
 
 export function initWorkspace(): string {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="markdown-container">
+    <div v-if="loading" class="min-h-full p-8 flex items-center justify-center">
+      <div class="text-gray-500">Loading document...</div>
+    </div>
     <div
-      v-if="!selectedResult.data?.markdown"
+      v-else-if="!markdownContent"
       class="min-h-full p-8 flex items-center justify-center"
     >
       <div class="text-gray-500">No markdown content available</div>
@@ -40,9 +43,9 @@
         <button
           @click="applyMarkdown"
           class="apply-btn"
-          :disabled="!hasChanges"
+          :disabled="!hasChanges || saving"
         >
-          Apply Changes
+          {{ saving ? "Saving..." : "Apply Changes" }}
         </button>
       </details>
     </template>
@@ -54,6 +57,7 @@ import { computed, ref, watch, nextTick } from "vue";
 import { marked } from "marked";
 import type { ToolResult } from "gui-chat-protocol";
 import type { MarkdownToolData } from "./definition";
+import { resolveImageSrc } from "../../utils/image/resolve";
 
 const props = defineProps<{
   selectedResult: ToolResult<MarkdownToolData>;
@@ -63,19 +67,75 @@ const emit = defineEmits<{
   updateResult: [result: ToolResult<MarkdownToolData>];
 }>();
 
-const editableMarkdown = ref(props.selectedResult.data?.markdown || "");
+const loading = ref(false);
+const saving = ref(false);
+// The actual markdown content (fetched from server or inline)
+const markdownContent = ref("");
+const editableMarkdown = ref("");
 
-// Check if markdown has been modified
+function isFilePath(value: string): boolean {
+  return value.startsWith("markdowns/") && value.endsWith(".md");
+}
+
+async function fetchMarkdownContent(): Promise<void> {
+  const raw = props.selectedResult.data?.markdown;
+  if (!raw) {
+    markdownContent.value = "";
+    editableMarkdown.value = "";
+    return;
+  }
+  if (isFilePath(raw)) {
+    loading.value = true;
+    try {
+      const res = await fetch(
+        `/api/files/content?path=${encodeURIComponent(raw)}`,
+      );
+      if (!res.ok) {
+        console.error("Failed to fetch markdown:", res.statusText);
+        markdownContent.value = "";
+        editableMarkdown.value = "";
+        return;
+      }
+      const json: { content?: string } = await res.json();
+      markdownContent.value = json.content ?? "";
+    } catch (err) {
+      console.error("Failed to fetch markdown:", err);
+      markdownContent.value = "";
+    } finally {
+      loading.value = false;
+    }
+  } else {
+    // Legacy inline content
+    markdownContent.value = raw;
+  }
+  editableMarkdown.value = markdownContent.value;
+}
+
+// Fetch on mount
+fetchMarkdownContent();
+
 const hasChanges = computed(() => {
-  return editableMarkdown.value !== props.selectedResult.data?.markdown;
+  return editableMarkdown.value !== markdownContent.value;
 });
 
+// Resolve image paths in rendered HTML so workspace-relative paths become URLs.
+// Markdown files use "../images/xyz.png" (relative from markdowns/ dir);
+// strip the "../" prefix to get the workspace-relative path for resolveImageSrc.
+function resolveImagesInHtml(html: string): string {
+  return html.replace(
+    /(<img\s[^>]*src=")([^"]+)(")/g,
+    (_match, before: string, src: string, after: string) => {
+      if (src.startsWith("data:") || src.startsWith("http")) return _match;
+      const normalized = src.replace(/^\.\.\//, "");
+      return `${before}${resolveImageSrc(normalized)}${after}`;
+    },
+  );
+}
+
 const renderedHtml = computed(() => {
-  if (!props.selectedResult.data?.markdown) {
-    console.error("No markdown data in result:", props.selectedResult);
-    return "";
-  }
-  return marked(props.selectedResult.data.markdown);
+  if (!markdownContent.value) return "";
+  const html = marked(markdownContent.value) as string;
+  return resolveImagesInHtml(html);
 });
 
 // Watch for scroll requests from viewState
@@ -83,8 +143,6 @@ watch(
   () => props.selectedResult?.viewState?.scrollToAnchor as string | undefined,
   (anchorId) => {
     if (!anchorId) return;
-
-    // Use nextTick to ensure the DOM is updated
     nextTick(() => {
       const element = document.getElementById(anchorId);
       if (element) {
@@ -97,11 +155,9 @@ watch(
 );
 
 const downloadMarkdown = () => {
-  if (!props.selectedResult?.data?.markdown) return;
+  if (!markdownContent.value) return;
 
-  const blob = new Blob([props.selectedResult.data.markdown], {
-    type: "text/markdown",
-  });
+  const blob = new Blob([markdownContent.value], { type: "text/markdown" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
@@ -118,26 +174,52 @@ const downloadMarkdown = () => {
   URL.revokeObjectURL(url);
 };
 
-function applyMarkdown() {
-  // Update the result with new markdown content
+async function applyMarkdown() {
+  const raw = props.selectedResult.data?.markdown;
+  if (!raw) return;
+
+  // If file-based, save to server
+  if (isFilePath(raw)) {
+    saving.value = true;
+    try {
+      const filename = raw.replace(/^markdowns\//, "");
+      const res = await fetch(`/api/markdowns/${filename}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ markdown: editableMarkdown.value }),
+      });
+      if (!res.ok) {
+        console.error("Failed to save markdown:", res.statusText);
+        return;
+      }
+    } catch (err) {
+      console.error("Failed to save markdown:", err);
+      return;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  // Update local state
+  markdownContent.value = editableMarkdown.value;
+
+  // Emit update to parent (clears pdfPath since content changed)
   const updatedResult: ToolResult<MarkdownToolData> = {
     ...props.selectedResult,
     data: {
       ...props.selectedResult.data,
-      markdown: editableMarkdown.value,
-      // Reset pdfPath since markdown has changed
+      markdown: isFilePath(raw) ? raw : editableMarkdown.value,
       pdfPath: undefined,
     },
   };
-
   emit("updateResult", updatedResult);
 }
 
 // Watch for external changes to selectedResult (when user clicks different result)
 watch(
   () => props.selectedResult.data?.markdown,
-  (newMarkdown) => {
-    editableMarkdown.value = newMarkdown || "";
+  () => {
+    fetchMarkdownContent();
   },
 );
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown documents are now file-backed and persist to disk
  * Users can edit markdown directly in the UI with save functionality
  * Images are stored as files instead of embedded data URIs for improved performance
  * Maintains compatibility with legacy inline markdown content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->