### PR TITLE
fix: don't disable chat input when GEMINI_API_KEY is missing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -378,9 +378,7 @@
             placeholder="Type a task..."
             rows="2"
             class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
-            :disabled="
-              isRunning || (!geminiAvailable && needsGemini(currentRoleId))
-            "
+            :disabled="isRunning"
             @keydown.enter="
               !$event.isComposing && !$event.shiftKey
                 ? (sendMessage(), $event.preventDefault())
@@ -389,9 +387,7 @@
           />
           <button
             class="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-            :disabled="
-              isRunning || (!geminiAvailable && needsGemini(currentRoleId))
-            "
+            :disabled="isRunning"
             @click="sendMessage()"
           >
             <span class="material-icons text-base">send</span>


### PR DESCRIPTION
## User Prompt

> gemini api keyがないと動かない？なくても動いてほしいのだけど。
> テキスト入力、sendボタンは非活性化。

## Summary

GEMINI_API_KEY が未設定の場合、テキスト入力と送信ボタンが disabled になっていた。原因は General ロールが `generateImage` プラグインを含んでおり、`:disabled="isRunning || (!geminiAvailable && needsGemini(currentRoleId))"` の条件に引っかかっていたため。

Gemini key は画像生成にのみ必要でテキストチャットには不要なので、disabled 条件から Gemini チェックを除去。警告バナー（「Image generation requires GEMINI_API_KEY」）はそのまま残す。

## Test plan

- [x] `yarn typecheck / lint / build` — clean
- [ ] GEMINI_API_KEY なしで起動 → テキスト入力・送信が有効であること
- [ ] GEMINI_API_KEY ありで起動 → 動作変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of text input and send button controls. These elements are now available in more scenarios, allowing users to interact with the app even when certain optional features are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->