### PR TITLE
feat(e2e): Playwright test infrastructure + CI job

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -31,3 +31,25 @@ jobs:
     - run: yarn run lint
     - run: yarn run build
     - run: yarn run test:coverage
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v6
+      with:
+        node-version: 22.x
+        cache: 'yarn'
+    - run: yarn install
+    - name: Install Playwright browsers
+      run: npx playwright install chromium --with-deps
+    - name: Run E2E tests
+      run: yarn test:e2e
+    - name: Upload test results on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-results
+        path: test-results/
+        retention-days: 7

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,0 +1,114 @@
+// Shared API mock helpers for Playwright tests.
+//
+// IMPORTANT: Playwright matches routes in REVERSE registration order
+// (last registered is checked first). So we register the catch-all
+// FIRST and specific routes AFTER, ensuring specific handlers take
+// priority.
+
+import type { Page, Route } from "@playwright/test";
+import {
+  SESSION_A,
+  SESSION_B,
+  makeSessionEntries,
+  type SessionFixture,
+} from "./sessions";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+function urlStartsWith(prefix: string): (url: URL) => boolean {
+  return (url) => url.pathname.startsWith(prefix);
+}
+
+const DEFAULT_ROLES: unknown[] = [];
+
+const DEFAULT_TODOS = {
+  data: {
+    items: [],
+    columns: [
+      { id: "backlog", label: "Backlog" },
+      { id: "todo", label: "Todo" },
+      { id: "in_progress", label: "In Progress" },
+      { id: "done", label: "Done", isDone: true },
+    ],
+  },
+};
+
+const DEFAULT_HEALTH = {
+  status: "OK",
+  geminiAvailable: false,
+  sandboxEnabled: false,
+};
+
+export interface MockApiOptions {
+  sessions?: SessionFixture[];
+}
+
+export async function mockAllApis(
+  page: Page,
+  opts: MockApiOptions = {},
+): Promise<void> {
+  const sessions = opts.sessions ?? [SESSION_A, SESSION_B];
+
+  // Catch-all FIRST (checked last by Playwright)
+  await page.route(urlStartsWith("/api/"), (route: Route) => {
+    console.warn(
+      `[mock] unhandled: ${route.request().method()} ${route.request().url()}`,
+    );
+    return route.fulfill({ json: {} });
+  });
+
+  // Specific routes AFTER (checked first by Playwright)
+  await page.route(urlEndsWith("/api/health"), (route) =>
+    route.fulfill({ json: DEFAULT_HEALTH }),
+  );
+
+  await page.route(urlEndsWith("/api/roles"), (route) =>
+    route.fulfill({ json: DEFAULT_ROLES }),
+  );
+
+  await page.route(urlEndsWith("/api/sessions"), (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: sessions });
+    }
+    return route.fallback();
+  });
+
+  await page.route(
+    (url) =>
+      url.pathname.startsWith("/api/sessions/") &&
+      url.pathname !== "/api/sessions",
+    (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      const id = route.request().url().split("/api/sessions/").pop() ?? "";
+      const match = sessions.find((s) => s.id === id);
+      if (match) {
+        return route.fulfill({ json: makeSessionEntries(match.id) });
+      }
+      return route.fulfill({ status: 404, json: { error: "not found" } });
+    },
+  );
+
+  await page.route(urlEndsWith("/api/todos"), (route) =>
+    route.fulfill({ json: DEFAULT_TODOS }),
+  );
+
+  await page.route(urlStartsWith("/api/todos/"), (route) =>
+    route.fulfill({ json: DEFAULT_TODOS }),
+  );
+
+  await page.route(urlStartsWith("/api/mcp-tools"), (route) =>
+    route.fulfill({ json: { tools: [], disabled: [] } }),
+  );
+
+  await page.route(urlStartsWith("/api/chat-index"), (route) =>
+    route.fulfill({ json: {} }),
+  );
+
+  await page.route(urlEndsWith("/api/files/tree"), (route) =>
+    route.fulfill({
+      json: { name: "", path: "", type: "dir", children: [] },
+    }),
+  );
+}

--- a/e2e/fixtures/sessions.ts
+++ b/e2e/fixtures/sessions.ts
@@ -1,0 +1,34 @@
+export interface SessionFixture {
+  id: string;
+  title: string;
+  roleId: string;
+  startedAt: string;
+  updatedAt: string;
+  preview?: string;
+}
+
+export const SESSION_A: SessionFixture = {
+  id: "session-aaa-111",
+  title: "Session A",
+  roleId: "general",
+  startedAt: "2026-04-10T10:00:00Z",
+  updatedAt: "2026-04-10T10:05:00Z",
+  preview: "Hello from session A",
+};
+
+export const SESSION_B: SessionFixture = {
+  id: "session-bbb-222",
+  title: "Session B",
+  roleId: "general",
+  startedAt: "2026-04-11T14:00:00Z",
+  updatedAt: "2026-04-11T14:10:00Z",
+  preview: "Hello from session B",
+};
+
+export function makeSessionEntries(sessionId: string) {
+  return [
+    { type: "session_meta", roleId: "general", sessionId },
+    { type: "text", source: "user", message: "Hello" },
+    { type: "text", source: "assistant", message: "Hi there!" },
+  ];
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  webServer: {
+    command: "yarn dev:client",
+    port: 5173,
+    reuseExistingServer: true,
+    timeout: 15_000,
+  },
+});

--- a/e2e/tests/router-guards.spec.ts
+++ b/e2e/tests/router-guards.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+});
+
+test.describe("URL injection defence", () => {
+  test("XSS in path → app renders normally (no crash)", async ({ page }) => {
+    // Even with a garbage path, the app should not crash.
+    // The catch-all redirect sends it to /chat.
+    await page.goto("/chat/<script>alert(1)</script>");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+  });
+
+  test("path traversal → app renders normally", async ({ page }) => {
+    await page.goto("/chat/..%2F..%2Fetc%2Fpasswd");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+  });
+
+  test("extremely long path segment → app renders normally", async ({
+    page,
+  }) => {
+    const longStr = "a".repeat(200);
+    await page.goto(`/chat/${longStr}`);
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+  });
+
+  test("unknown route → redirected to /chat, app loads", async ({ page }) => {
+    await page.goto("/admin/secret");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    expect(page.url()).toContain("/chat");
+  });
+
+  test("special chars in path → app does not crash", async ({ page }) => {
+    await page.goto('/chat/test"onmouseover="alert(1)');
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+  });
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+});
+
+test("app loads and shows the title", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("MulmoClaude")).toBeVisible();
+});
+
+test("send button and input are visible and enabled", async ({ page }) => {
+  await page.goto("/");
+  const input = page.locator("textarea");
+  await expect(input).toBeVisible();
+  const sendBtn = page.locator('button:has(span.material-icons:text("send"))');
+  await expect(sendBtn).toBeEnabled();
+});
+
+test("unknown route still shows the app (catch-all redirect)", async ({
+  page,
+}) => {
+  await page.goto("/some/random/path");
+  await expect(page.getByText("MulmoClaude")).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:client": "vite build",
     "build": "vite build && tsc -p server/tsconfig.json --noEmit",
     "test": "tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts",
+    "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,6 +792,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@^1.59.1":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3307,6 +3314,11 @@ fs-minipass@^3.0.0:
   dependencies:
     minipass "^7.0.3"
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -5209,6 +5221,20 @@ pkg-types@^2.3.0:
     confbox "^0.2.2"
     exsolve "^1.0.7"
     pathe "^2.0.3"
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 png-js@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Playwright E2E テスト基盤の導入。サーバ不要 — 全 API は `page.route()` でモック。

## 構成

- `e2e/playwright.config.ts` — Chromium only, vite dev client 自動起動
- `e2e/fixtures/api.ts` — 共通 API モック (`mockAllApis(page)`)
- `e2e/fixtures/sessions.ts` — セッション fixture
- `package.json` — `test:e2e` スクリプト追加
- `.github/workflows/pull_request.yaml` — `e2e` ジョブ追加 (ubuntu, Node 22, Chromium)

## テスト (8 cases)

**smoke.spec.ts** (3): アプリ読み込み、入力/送信の表示、unknown route のリダイレクト

**router-guards.spec.ts** (5): XSS / path traversal / 長大値 / unknown route / special chars — 全てアプリがクラッシュしないことを確認

## CI 確認ポイント

この PR で確認したいこと: **GitHub Actions 上で Playwright が正常に動くか**

🤖 Generated with [Claude Code](https://claude.com/claude-code)