### PR TITLE
no empty session in history

### DIFF
--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -67,6 +67,9 @@ test.describe("session navigation via URL", () => {
   });
 
   test("browser forward works after going back", async ({ page }) => {
+    // Navigate through two real (non-empty) sessions so both are in
+    // browser history — the initial empty session is intentionally
+    // replaced out of history by removeCurrentIfEmpty.
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
 
@@ -76,11 +79,19 @@ test.describe("session navigation via URL", () => {
       .click();
     await page.waitForURL(new RegExp(SESSION_A.id));
 
-    await page.goBack();
-    await page.waitForURL(/\/chat\//);
+    await openHistoryWithSessions(page);
+    await page
+      .locator(`[data-testid="session-item-${SESSION_B.id}"]`)
+      .click();
+    await page.waitForURL(new RegExp(SESSION_B.id));
 
-    await page.goForward();
+    // Back → session A
+    await page.goBack();
     await page.waitForURL(new RegExp(SESSION_A.id));
+
+    // Forward → session B
+    await page.goForward();
+    await page.waitForURL(new RegExp(SESSION_B.id));
   });
 
   test("direct URL to an existing session loads it", async ({ page }) => {

--- a/plan/cleanup_empty_sessions.md
+++ b/plan/cleanup_empty_sessions.md
@@ -1,0 +1,50 @@
+# Cleanup Empty Sessions on Navigation
+
+## Problem
+
+When a user is on a new empty session (no messages sent) and switches to another session via history or tab click, the empty session remains in:
+
+1. **Chat history** (`sessionMap`) — it shows up in the sidebar and tab bar as a blank entry
+2. **Browser navigation history** — pressing the back button returns to the empty session URL
+
+This creates clutter in the session list and a confusing back-button experience.
+
+## Prior Art
+
+`createNewSession()` already had logic to remove the most-recently-touched empty session before creating a new one. However, `loadSession()` (triggered by clicking an existing session in history/tabs) did not perform this cleanup.
+
+## Solution
+
+### Extract `removeCurrentIfEmpty()`
+
+A shared helper that checks whether the current session (`currentSessionId`) has zero `toolResults`. If so, it deletes the session from `sessionMap` and returns `true`.
+
+```typescript
+function removeCurrentIfEmpty(): boolean {
+  const id = currentSessionId.value;
+  if (!id) return false;
+  const session = sessionMap.get(id);
+  if (session && session.toolResults.length === 0) {
+    sessionMap.delete(id);
+    return true;
+  }
+  return false;
+}
+```
+
+### Call from both `createNewSession()` and `loadSession()`
+
+- **`createNewSession()`** — replaces the previous inline cleanup (which searched all sessions by sort order) with `removeCurrentIfEmpty()`. Simpler and more precise: the session being left is always the current one.
+
+- **`loadSession()`** — calls `removeCurrentIfEmpty()` at the top, before any navigation. The returned boolean (`replaced`) is passed to `navigateToSession(id, replaced)`, which uses `router.replace` instead of `router.push` when an empty session was removed. This keeps the empty session URL out of browser history.
+
+### Effect on browser history
+
+| Scenario | Before | After |
+|---|---|---|
+| New empty session → click existing session | Back button returns to empty session | Back button skips the empty session |
+| New empty session → create new session | Empty session removed (existing behavior) | Same, now via shared helper |
+
+## Files Changed
+
+- `src/App.vue` — added `removeCurrentIfEmpty()`, updated `createNewSession()` and `loadSession()`

--- a/plan/cleanup_empty_sessions.md
+++ b/plan/cleanup_empty_sessions.md
@@ -38,6 +38,16 @@ function removeCurrentIfEmpty(): boolean {
 
 - **`loadSession()`** — calls `removeCurrentIfEmpty()` at the top, before any navigation. The returned boolean (`replaced`) is passed to `navigateToSession(id, replaced)`, which uses `router.replace` instead of `router.push` when an empty session was removed. This keeps the empty session URL out of browser history.
 
+### Early-return guard in `loadSession()`
+
+`loadSession()` has an early return to avoid re-loading the already-active session:
+
+```typescript
+if (id === currentSessionId.value && sessionMap.has(id)) return;
+```
+
+The `sessionMap.has(id)` check is essential. The route watcher sets `currentSessionId.value = newId` **before** calling `loadSession(newId)`. Without the `sessionMap.has` check, the guard would always match and bail out — preventing direct-URL navigation (`page.goto("/chat/<id>")`) and page reloads from loading the session data from the server.
+
 ### Effect on browser history
 
 | Scenario | Before | After |
@@ -48,3 +58,4 @@ function removeCurrentIfEmpty(): boolean {
 ## Files Changed
 
 - `src/App.vue` — added `removeCurrentIfEmpty()`, updated `createNewSession()` and `loadSession()`
+- `e2e/tests/router-navigation.spec.ts` — updated "browser forward works after going back" test to navigate between two non-empty sessions (the initial empty session is now intentionally replaced out of browser history)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1023,6 +1023,9 @@ async function toggleHistory() {
 }
 
 async function loadSession(id: string) {
+  // Re-selecting the already-active session is a no-op.
+  if (id === currentSessionId.value) return;
+
   // If the current session is empty, remove it from memory and use
   // replace-navigation so the empty session doesn't linger in
   // browser history (back button won't revisit it).

--- a/src/App.vue
+++ b/src/App.vue
@@ -947,16 +947,24 @@ function toggleRightSidebar() {
   localStorage.setItem("right_sidebar_visible", String(showRightSidebar.value));
 }
 
-function createNewSession(roleId?: string): ActiveSession {
-  // Remove the latest session if it's empty (no messages exchanged).
-  // "Latest" here means most-recently-touched, matching the sort
-  // order the user sees in the sidebar.
-  const latest = [...sessionMap.values()].sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-  )[0];
-  if (latest && latest.toolResults.length === 0) {
-    sessionMap.delete(latest.id);
+// Remove the current session from sessionMap if it's empty (no messages).
+// Returns true if a session was removed, so the caller can use
+// router.replace instead of router.push to keep the empty session out
+// of browser navigation history.
+function removeCurrentIfEmpty(): boolean {
+  const id = currentSessionId.value;
+  if (!id) return false;
+  const session = sessionMap.get(id);
+  if (session && session.toolResults.length === 0) {
+    sessionMap.delete(id);
+    return true;
   }
+  return false;
+}
+
+function createNewSession(roleId?: string): ActiveSession {
+  // Remove the current session if it's empty (no messages exchanged).
+  removeCurrentIfEmpty();
 
   const id = uuidv4();
   const rId = roleId ?? currentRoleId.value;
@@ -1015,11 +1023,16 @@ async function toggleHistory() {
 }
 
 async function loadSession(id: string) {
+  // If the current session is empty, remove it from memory and use
+  // replace-navigation so the empty session doesn't linger in
+  // browser history (back button won't revisit it).
+  const replaced = removeCurrentIfEmpty();
+
   // Already live in memory — just switch to it. The watch on
   // currentSessionId clears the unread flag automatically.
   const live = sessionMap.get(id);
   if (live) {
-    navigateToSession(id);
+    navigateToSession(id, replaced);
     currentRoleId.value = live.roleId;
     showHistory.value = false;
     return;
@@ -1080,7 +1093,7 @@ async function loadSession(id: string) {
     startedAt: originalStartedAt,
     updatedAt: originalUpdatedAt,
   });
-  navigateToSession(id);
+  navigateToSession(id, replaced);
   currentRoleId.value = roleId;
   showHistory.value = false;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1023,8 +1023,11 @@ async function toggleHistory() {
 }
 
 async function loadSession(id: string) {
-  // Re-selecting the already-active session is a no-op.
-  if (id === currentSessionId.value) return;
+  // Re-selecting the already-active, loaded session is a no-op.
+  // The sessionMap check is needed because the route watcher sets
+  // currentSessionId before calling loadSession — without it the
+  // guard would bail before the session data is fetched.
+  if (id === currentSessionId.value && sessionMap.has(id)) return;
 
   // If the current session is empty, remove it from memory and use
   // replace-navigation so the empty session doesn't linger in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty sessions are now automatically removed when navigating away, preventing them from cluttering your session history and improving back/forward navigation.
  * Back/forward behavior now correctly skips temporary empty sessions so browser history lands on meaningful sessions.

* **Documentation**
  * Added internal guidance describing the navigation and empty-session cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->