### PR TITLE
refactor(app): extract pure helpers from sendMessage (CC 47 → <15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,17 @@ e2e/
 3. Use URL assertions for router behaviour (`expect(page.url()).toContain(...)`)
 4. Override specific API responses per test by adding a `page.route()` AFTER `mockAllApis` (Playwright checks last-registered first)
 
+### When to add E2E coverage
+
+**Whenever a `.vue` component is modified**, consider whether the change needs a new E2E test. Unit tests cover the extracted pure helpers; E2E tests are the regression safety-net for the Vue component's wiring (template bindings, event handlers, reactive state flow, router integration). Concrete triggers:
+
+- Touching `src/App.vue` — almost always add / extend a scenario in `e2e/tests/chat-flow.spec.ts` (the refactor flow).
+- Touching a plugin's `View.vue` / `Preview.vue` — add or extend the plugin-specific spec (e.g. `file-explorer.spec.ts`, `image-plugins.spec.ts`).
+- Adding a new route or changing guard logic — `router-navigation.spec.ts` / `router-guards.spec.ts`.
+- Changing SSE event handling, session loading, or sidebar session merging — `chat-flow.spec.ts` already exercises these; add a case if a new event type / selection rule / merge path is introduced.
+
+Skip if the change is purely cosmetic (Tailwind class tweaks, copy fixes, emoji swaps) with no behavioural path touched.
+
 ### Gotchas
 
 - **Route order is reversed**: Playwright checks routes last-registered-first. Register catch-all FIRST, specific routes AFTER.

--- a/e2e/tests/chat-flow.spec.ts
+++ b/e2e/tests/chat-flow.spec.ts
@@ -1,0 +1,202 @@
+// E2E regression tests for the chat-send / session-load flow.
+// Exercises the code paths touched by the .vue cognitive-complexity
+// refactors (PR #177 sendMessage split + #178 session-helpers
+// extraction). Each test targets a behaviour that was either
+// hand-coded inline in the Vue component before, or a specific
+// regression the refactor could silently re-introduce.
+//
+// Tracks #175.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { SESSION_A, SESSION_B } from "../fixtures/sessions";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+// Build an SSE response body from a list of event objects. Each
+// event becomes one `data: <json>\n` line; an empty trailing line
+// terminates the last record. Mirrors what `server/routes/agent.ts`
+// sends the frontend.
+function buildSseBody(events: readonly unknown[]): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}`).join("\n") + "\n";
+}
+
+async function mockAgentSse(
+  page: Page,
+  events: readonly unknown[],
+): Promise<void> {
+  await page.route(urlEndsWith("/api/agent"), (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    return route.fulfill({
+      body: buildSseBody(events),
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+}
+
+// -------- Session load (refactor target: loadSession → parseSessionEntries + resolveSelectedUuid + resolveSessionTimestamps) --------
+
+test.describe("loading an existing session", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("renders the assistant's text reply from the server payload", async ({
+    page,
+  }) => {
+    // SESSION_A's fixture ends with `{source: "assistant", message: "Hi there!"}`
+    // — parseSessionEntries must wrap it as a text-response and hand
+    // it to the chat list.
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await expect(page.locator("text=Hi there!").first()).toBeVisible();
+  });
+
+  test("URL ?result=<uuid> restores the exact result", async ({ page }) => {
+    // Override sessions fixture to include a named tool_result
+    // whose uuid we can target via the URL.
+    await page.route(
+      (url) =>
+        url.pathname.startsWith("/api/sessions/") &&
+        url.pathname !== "/api/sessions",
+      (route) => {
+        return route.fulfill({
+          json: [
+            { type: "session_meta", roleId: "general", sessionId: "s-select" },
+            { type: "text", source: "user", message: "what's 2+2?" },
+            { type: "text", source: "assistant", message: "four" },
+          ],
+        });
+      },
+    );
+    // Navigate with a non-existent ?result=<uuid>; resolveSelectedUuid
+    // should fall through to the heuristic (last non-text → last text →
+    // final uuid). We primarily check the page doesn't 500 and the
+    // text still renders.
+    await page.goto(`/chat/s-select?result=does-not-exist`);
+    await expect(page.locator("text=four").first()).toBeVisible();
+  });
+});
+
+// -------- Sidebar history merge (refactor target: mergedSessions → mergeSessionLists) --------
+
+test.describe("session history sidebar", () => {
+  test("orders server sessions newest updatedAt first", async ({ page }) => {
+    // SESSION_B.updatedAt is 2026-04-11, SESSION_A is 2026-04-10.
+    // compareSessionsByRecency should put B before A. (A newly-
+    // created live session appears at position 0 with updatedAt=now;
+    // we only care about the relative order of the two server
+    // entries, since that's what mergeSessionLists controls for the
+    // persisted history.)
+    await mockAllApis(page, { sessions: [SESSION_A, SESSION_B] });
+    await page.goto("/");
+    await page.getByTestId("history-btn").click();
+
+    const items = page.locator('[data-testid^="session-item-"]');
+    const ids = await items.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid") ?? ""),
+    );
+    const indexA = ids.indexOf(`session-item-${SESSION_A.id}`);
+    const indexB = ids.indexOf(`session-item-${SESSION_B.id}`);
+    expect(indexA).toBeGreaterThanOrEqual(0);
+    expect(indexB).toBeGreaterThanOrEqual(0);
+    expect(indexB).toBeLessThan(indexA);
+  });
+
+  test("prefers server-side AI title over first-user-message preview", async ({
+    page,
+  }) => {
+    // The mergeSessionLists rule: when the server summary has a
+    // `preview` (treated as the AI-generated title), it wins over
+    // the live session's first user message.
+    const customSession = {
+      id: "ai-titled",
+      title: "AI Titled",
+      roleId: "general",
+      startedAt: "2026-04-12T10:00:00Z",
+      updatedAt: "2026-04-12T10:05:00Z",
+      preview: "AI-generated session title",
+    };
+    await mockAllApis(page, { sessions: [customSession] });
+    await page.goto("/");
+    await page.getByTestId("history-btn").click();
+    // The preview line in each history row is the AI title, not
+    // the first message.
+    await expect(page.locator("text=AI-generated session title")).toBeVisible();
+  });
+});
+
+// -------- Send message + SSE parsing (refactor target: sendMessage split + parseSSEChunk + applyAgentEvent) --------
+
+test.describe("sending a chat message", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("streams the assistant's text event into the chat list", async ({
+    page,
+  }) => {
+    // The happy-path regression: user sends a message, the server
+    // streams back one text event, the client parses the chunk and
+    // applyAgentEvent pushes it to the session's toolResults.
+    await mockAgentSse(page, [
+      { type: "status", message: "Thinking..." },
+      { type: "text", message: "Pong from the server" },
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("user-input").fill("ping");
+    await page.getByTestId("send-btn").click();
+
+    await expect(page.locator("text=Pong from the server").first()).toBeVisible();
+    // The user's own message should also be in the list.
+    await expect(page.locator("text=ping").first()).toBeVisible();
+  });
+
+  test("malformed SSE events are skipped without killing the stream", async ({
+    page,
+  }) => {
+    // CodeRabbit regression on #177: a `{"type":"tool_result"}` packet
+    // without a `result` field used to crash the stream when
+    // applyAgentEvent reached `event.result.uuid`. isSseEvent now
+    // rejects the malformed packet in decodeSSELine, so the valid
+    // text event that follows still renders.
+    await mockAgentSse(page, [
+      // Malformed — rejected by the variant-shape validator.
+      { type: "tool_result" },
+      // Also malformed — no uuid inside result.
+      { type: "tool_result", result: {} },
+      // Valid text event. Must still render.
+      { type: "text", message: "survivor message" },
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("user-input").fill("hi");
+    await page.getByTestId("send-btn").click();
+
+    await expect(page.locator("text=survivor message").first()).toBeVisible();
+  });
+
+  test("SSE event split across chunk boundaries still parses", async ({
+    page,
+  }) => {
+    // parseSSEChunk's buffer-remainder behaviour — indirectly
+    // exercised by chunked SSE. Playwright's mock fulfill delivers
+    // the whole body in one response but the Vue app's
+    // response.body.getReader() may still yield the chunk in
+    // multiple reads depending on buffer size. Either way a valid
+    // event at the end of a large body must render.
+    const longStatus = "x".repeat(2048);
+    await mockAgentSse(page, [
+      { type: "status", message: longStatus },
+      { type: "text", message: "final message" },
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("user-input").fill("chunk test");
+    await page.getByTestId("send-btn").click();
+
+    await expect(page.locator("text=final message").first()).toBeVisible();
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -502,14 +502,8 @@ import {
   type SessionSummary,
   type SessionEntry,
   type ActiveSession,
-  isTextEntry,
-  isToolResultEntry,
 } from "./types/session";
-import {
-  isUserTextResponse,
-  extractImageData,
-  makeTextResult,
-} from "./utils/tools/result";
+import { extractImageData, makeTextResult } from "./utils/tools/result";
 import {
   roleIcon as roleIconLookup,
   roleName as roleNameLookup,
@@ -522,6 +516,12 @@ import {
   findPendingToolCall,
   shouldSelectAssistantText,
 } from "./utils/agent/toolCalls";
+import { mergeSessionLists } from "./utils/session/mergeSessions";
+import {
+  parseSessionEntries,
+  resolveSelectedUuid,
+  resolveSessionTimestamps,
+} from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
@@ -758,36 +758,9 @@ const selectedResult = computed(
 // the sidebar, not regress to the raw first user message. Without
 // this merge, opening an indexed session immediately clobbered its
 // sidebar row with the first-user-message preview.
-const mergedSessions = computed((): SessionSummary[] => {
-  const liveIds = new Set(sessionMap.keys());
-  const serverById = new Map<string, SessionSummary>(
-    sessions.value.map((s) => [s.id, s]),
-  );
-  const liveSummaries: SessionSummary[] = [...sessionMap.values()].map((s) => {
-    const firstUserMsg = s.toolResults.find(isUserTextResponse);
-    const serverEntry = serverById.get(s.id);
-    return {
-      id: s.id,
-      roleId: s.roleId,
-      startedAt: s.startedAt,
-      updatedAt: s.updatedAt,
-      preview: serverEntry?.preview || (firstUserMsg?.message ?? ""),
-      ...(serverEntry?.summary !== undefined && {
-        summary: serverEntry.summary,
-      }),
-      ...(serverEntry?.keywords !== undefined && {
-        keywords: serverEntry.keywords,
-      }),
-    };
-  });
-  const serverOnly = sessions.value.filter((s) => !liveIds.has(s.id));
-  return [...liveSummaries, ...serverOnly].sort((a, b) => {
-    const byUpdated =
-      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-    if (byUpdated !== 0) return byUpdated;
-    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime();
-  });
-});
+const mergedSessions = computed((): SessionSummary[] =>
+  mergeSessionLists([...sessionMap.values()], sessions.value),
+);
 
 const tabSessions = computed(() => mergedSessions.value.slice(0, 6));
 
@@ -1050,40 +1023,15 @@ async function loadSession(id: string) {
 
   const meta = entries.find((e) => e.type === "session_meta");
   const roleId = meta?.roleId ?? currentRoleId.value;
-
-  const toolResultsList: ToolResultComplete[] = [];
-  for (const entry of entries) {
-    if (entry.type === "session_meta") continue;
-    if (isTextEntry(entry)) {
-      toolResultsList.push(makeTextResult(entry.message, entry.source));
-    } else if (isToolResultEntry(entry)) {
-      toolResultsList.push(entry.result);
-    }
-  }
-
-  // If the URL specifies ?result=, prefer it over the heuristic
-  // (which picks the last non-text tool result). This lets bookmarks
-  // restore the exact result the user was looking at.
+  const toolResultsList = parseSessionEntries(entries);
   const urlResult =
     typeof route.query.result === "string" ? route.query.result : null;
-  const lastTool = [...toolResultsList]
-    .reverse()
-    .find((r) => r.toolName !== "text-response");
-  const heuristicUuid =
-    lastTool?.uuid ?? toolResultsList[toolResultsList.length - 1]?.uuid ?? null;
-  const resolvedSelectedUuid =
-    urlResult && toolResultsList.some((r) => r.uuid === urlResult)
-      ? urlResult
-      : heuristicUuid;
-
+  const resolvedSelectedUuid = resolveSelectedUuid(toolResultsList, urlResult);
   const serverSummary = sessions.value.find((s) => s.id === id);
-  const nowIso = new Date().toISOString();
-  const originalStartedAt = serverSummary?.startedAt ?? nowIso;
-  // Prefer the server's mtime-derived updatedAt so the loaded
-  // session keeps its place in the most-recently-touched sort;
-  // fall back to startedAt or now if the server summary is absent.
-  const originalUpdatedAt =
-    serverSummary?.updatedAt ?? originalStartedAt ?? nowIso;
+  const { startedAt, updatedAt } = resolveSessionTimestamps(
+    serverSummary,
+    new Date().toISOString(),
+  );
 
   sessionMap.set(id, {
     id,
@@ -1095,8 +1043,8 @@ async function loadSession(id: string) {
     selectedResultUuid: resolvedSelectedUuid,
     hasUnread: false,
     abortController: markRaw(new AbortController()),
-    startedAt: originalStartedAt,
-    updatedAt: originalUpdatedAt,
+    startedAt,
+    updatedAt,
   });
   navigateToSession(id, replaced);
   currentRoleId.value = roleId;

--- a/src/App.vue
+++ b/src/App.vue
@@ -516,6 +516,12 @@ import {
 } from "./utils/role/icon";
 import { formatDate } from "./utils/format/date";
 import { findScrollableChild } from "./utils/dom/scrollable";
+import { buildAgentRequestBody } from "./utils/agent/request";
+import { parseSSEChunk } from "./utils/agent/sse";
+import {
+  findPendingToolCall,
+  shouldSelectAssistantText,
+} from "./utils/agent/toolCalls";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
@@ -1097,15 +1103,13 @@ async function loadSession(id: string) {
   showHistory.value = false;
 }
 
-async function sendMessage(text?: string) {
-  const message = typeof text === "string" ? text : userInput.value.trim();
-  if (!message || isRunning.value) return;
-  userInput.value = "";
-
-  // Capture the session this message belongs to
-  const session = sessionMap.get(currentSessionId.value);
-  if (!session) return;
-
+// Seed the session state for a fresh user turn. Not pure (mutates
+// session), but isolated so sendMessage doesn't have the init
+// pattern inline. Returns `runStartIndex` — the index into
+// toolResults at which this run's outputs start, used later to
+// decide whether a trailing text response becomes the selected
+// canvas result.
+function beginUserTurn(session: ActiveSession, message: string): number {
   session.isRunning = true;
   session.statusMessage = "Thinking...";
   // Bump updatedAt so the session floats to the top of the
@@ -1114,142 +1118,207 @@ async function sendMessage(text?: string) {
   // on the next fetchSessions() after the run ends.
   session.updatedAt = new Date().toISOString();
   session.toolResults.push(makeTextResult(message, "user"));
-  const runStartIndex = session.toolResults.length;
-
   // Fresh AbortController for this run
   session.abortController = markRaw(new AbortController());
+  return session.toolResults.length;
+}
 
+// HTTP-level error check. Posts a user-visible error and returns
+// false so the caller can early-return. Separate function so the
+// branch count in sendMessage stays low.
+async function checkAgentResponseOk(
+  session: ActiveSession,
+  response: Response,
+): Promise<boolean> {
+  if (!response.ok) {
+    const errBody = await response.text().catch(() => "");
+    console.error(
+      "[agent] HTTP error:",
+      response.status,
+      response.statusText,
+      errBody,
+    );
+    pushErrorMessage(
+      session,
+      `Server error ${response.status}: ${errBody.slice(0, 200)}`,
+    );
+    return false;
+  }
+  if (!response.body) {
+    pushErrorMessage(session, "No response body received from server.");
+    return false;
+  }
+  return true;
+}
+
+// Dispatch a single SSE event from the agent stream against an
+// active session. Hoisted out of sendMessage so its 8-way switch
+// counts toward its own cognitive-complexity budget rather than
+// ballooning sendMessage's score. Reactive refs / callbacks that
+// live in the setup scope are passed via `ctx` — this keeps the
+// handler a regular named function with a clear signature.
+interface AgentEventContext {
+  session: ActiveSession;
+  runStartIndex: number;
+  setCurrentRoleId: (roleId: string) => void;
+  onRoleChange: () => void;
+  refreshRoles: () => Promise<void>;
+  scrollSidebarToBottom: () => void;
+}
+
+async function applyAgentEvent(
+  event: SseEvent,
+  ctx: AgentEventContext,
+): Promise<void> {
+  const { session, runStartIndex } = ctx;
+  switch (event.type) {
+    case "tool_call":
+      session.toolCallHistory.push({
+        toolUseId: event.toolUseId,
+        toolName: event.toolName,
+        args: event.args,
+        timestamp: Date.now(),
+      });
+      ctx.scrollSidebarToBottom();
+      return;
+    case "tool_call_result": {
+      const entry = findPendingToolCall(
+        session.toolCallHistory,
+        event.toolUseId,
+      );
+      if (entry) entry.result = event.content;
+      ctx.scrollSidebarToBottom();
+      return;
+    }
+    case "status":
+      session.statusMessage = event.message;
+      return;
+    case "switch_role":
+      setTimeout(() => {
+        ctx.setCurrentRoleId(event.roleId);
+        ctx.onRoleChange();
+      }, 0);
+      return;
+    case "roles_updated":
+      await ctx.refreshRoles();
+      return;
+    case "text": {
+      const textResult = makeTextResult(event.message, "assistant");
+      session.toolResults.push(textResult);
+      if (shouldSelectAssistantText(session.toolResults, runStartIndex)) {
+        session.selectedResultUuid = textResult.uuid;
+      }
+      return;
+    }
+    case "tool_result": {
+      const { result } = event;
+      const existing = session.toolResults.findIndex(
+        (r) => r.uuid === result.uuid,
+      );
+      if (existing >= 0) {
+        session.toolResults[existing] = result;
+      } else {
+        session.toolResults.push(result);
+        session.selectedResultUuid = result.uuid;
+      }
+      return;
+    }
+    case "error":
+      console.error("[agent] error event:", event.message);
+      pushErrorMessage(session, event.message);
+      return;
+  }
+}
+
+// Read the SSE stream from `/api/agent` to completion, dispatching
+// every event into the given context. Extracted so sendMessage's
+// own cognitive complexity stays under the threshold — the
+// while-loop + nested for-loop + chunk decoding contributes ~5 to
+// the parent's score when inlined.
+async function streamAgentEvents(
+  body: ReadableStream<Uint8Array>,
+  ctx: AgentEventContext,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let sseBuffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value, { stream: true });
+    const parsed = parseSSEChunk(sseBuffer, chunk);
+    sseBuffer = parsed.remaining;
+    for (const event of parsed.events) {
+      await applyAgentEvent(event, ctx);
+    }
+  }
+}
+
+// Translate an error caught from the agent fetch + stream loop
+// into the user-visible sidebar. Aborts are intentional (the user
+// switched sessions or hit stop) and get swallowed silently;
+// everything else surfaces as a pushErrorMessage entry. Extracted
+// so sendMessage's catch block is a single call.
+function reportAgentError(session: ActiveSession, e: unknown): void {
+  if (e instanceof DOMException && e.name === "AbortError") return;
+  console.error("[agent] fetch error:", e);
+  pushErrorMessage(
+    session,
+    e instanceof Error ? e.message : "Connection error.",
+  );
+}
+
+async function sendMessage(text?: string) {
+  const message = typeof text === "string" ? text : userInput.value.trim();
+  if (!message || isRunning.value) return;
+  userInput.value = "";
+
+  const session = sessionMap.get(currentSessionId.value);
+  if (!session) return;
+
+  const runStartIndex = beginUserTurn(session, message);
   const sessionRole =
     roles.value.find((r) => r.id === session.roleId) ?? roles.value[0];
   const selectedRes =
     session.toolResults.find((r) => r.uuid === session.selectedResultUuid) ??
     undefined;
 
+  // Context for the SSE event dispatcher. Callbacks wrap reactive
+  // refs + Vue setup-scope functions so `applyAgentEvent` stays a
+  // regular named function with its own cognitive-complexity
+  // budget (the 8-way switch would otherwise pile onto sendMessage).
+  const eventCtx: AgentEventContext = {
+    session,
+    runStartIndex,
+    setCurrentRoleId: (roleId) => {
+      currentRoleId.value = roleId;
+    },
+    onRoleChange,
+    refreshRoles,
+    scrollSidebarToBottom: () => rightSidebarRef.value?.scrollToBottom(),
+  };
+
   try {
     const response = await fetch("/api/agent", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        message,
-        roleId: session.roleId,
-        chatSessionId: session.id,
-        selectedImageData: extractImageData(selectedRes),
-        systemPrompt: SYSTEM_PROMPT,
-        pluginPrompts: Object.fromEntries(
-          sessionRole.availablePlugins
-            .map((name) => [name, getPlugin(name)?.systemPrompt])
-            .filter(
-              (entry): entry is [string, string] =>
-                typeof entry[1] === "string",
-            ),
-        ),
-      }),
+      body: JSON.stringify(
+        buildAgentRequestBody({
+          message,
+          role: sessionRole,
+          chatSessionId: session.id,
+          systemPrompt: SYSTEM_PROMPT,
+          selectedImageData: extractImageData(selectedRes),
+          getPluginSystemPrompt: (name) => getPlugin(name)?.systemPrompt,
+        }),
+      ),
       signal: session.abortController.signal,
     });
 
-    if (!response.ok) {
-      const errBody = await response.text().catch(() => "");
-      console.error(
-        "[agent] HTTP error:",
-        response.status,
-        response.statusText,
-        errBody,
-      );
-      pushErrorMessage(
-        session,
-        `Server error ${response.status}: ${errBody.slice(0, 200)}`,
-      );
-      return;
-    }
-    if (!response.body) {
-      pushErrorMessage(session, "No response body received from server.");
-      return;
-    }
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let sseBuffer = "";
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      sseBuffer += decoder.decode(value, { stream: true });
-      const lines = sseBuffer.split("\n");
-      sseBuffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
-        let data: SseEvent;
-        try {
-          data = JSON.parse(line.slice(6));
-        } catch {
-          continue;
-        }
-
-        if (data.type === "tool_call") {
-          session.toolCallHistory.push({
-            toolUseId: data.toolUseId,
-            toolName: data.toolName,
-            args: data.args,
-            timestamp: Date.now(),
-          });
-          rightSidebarRef.value?.scrollToBottom();
-        } else if (data.type === "tool_call_result") {
-          const entry = session.toolCallHistory
-            .slice()
-            .reverse()
-            .find(
-              (c) =>
-                c.toolUseId === data.toolUseId &&
-                c.result === undefined &&
-                c.error === undefined,
-            );
-          if (entry) entry.result = data.content;
-          rightSidebarRef.value?.scrollToBottom();
-        } else if (data.type === "status") {
-          session.statusMessage = data.message;
-        } else if (data.type === "switch_role") {
-          setTimeout(() => {
-            currentRoleId.value = data.roleId;
-            onRoleChange();
-          }, 0);
-        } else if (data.type === "roles_updated") {
-          await refreshRoles();
-        } else if (data.type === "text") {
-          const textResult = makeTextResult(data.message, "assistant");
-          session.toolResults.push(textResult);
-          const hasPluginResult = session.toolResults
-            .slice(runStartIndex)
-            .some((r) => r.toolName !== "text-response");
-          if (!hasPluginResult) {
-            session.selectedResultUuid = textResult.uuid;
-          }
-        } else if (data.type === "tool_result") {
-          const { result } = data;
-          const existing = session.toolResults.findIndex(
-            (r) => r.uuid === result.uuid,
-          );
-          if (existing >= 0) {
-            session.toolResults[existing] = result;
-          } else {
-            session.toolResults.push(result);
-            session.selectedResultUuid = result.uuid;
-          }
-        } else if (data.type === "error") {
-          console.error("[agent] error event:", data.message);
-          pushErrorMessage(session, data.message);
-        }
-      }
-    }
+    if (!(await checkAgentResponseOk(session, response))) return;
+    await streamAgentEvents(response.body!, eventCtx);
   } catch (e) {
-    if (!(e instanceof DOMException && e.name === "AbortError")) {
-      console.error("[agent] fetch error:", e);
-      pushErrorMessage(
-        session,
-        e instanceof Error ? e.message : "Connection error.",
-      );
-    }
+    reportAgentError(session, e);
   } finally {
     session.isRunning = false;
     session.statusMessage = "";

--- a/src/utils/agent/request.ts
+++ b/src/utils/agent/request.ts
@@ -1,0 +1,72 @@
+// Request-body construction for `POST /api/agent`.
+//
+// Extracted from `src/App.vue#sendMessage` as part of the
+// cognitive-complexity refactor tracked in #175. The inline
+// `Object.fromEntries(...filter(entry is [string, string]))`
+// pluginPrompts pipeline accounted for a chunk of sendMessage's
+// CC score and was hard to exercise without standing up the
+// whole Vue component. Pure helpers here, tested in isolation.
+
+import type { Role } from "../../config/roles";
+
+export interface AgentRequestBodyParams {
+  message: string;
+  role: Role;
+  chatSessionId: string;
+  systemPrompt: string;
+  selectedImageData?: string;
+  /**
+   * Looks up a plugin by name. Returns an object with an optional
+   * `systemPrompt` string. Kept as a narrow interface so callers
+   * don't need to drag the whole plugin registry type in.
+   */
+  getPluginSystemPrompt: (name: string) => string | undefined;
+}
+
+export interface AgentRequestBody {
+  message: string;
+  roleId: string;
+  chatSessionId: string;
+  selectedImageData: string | undefined;
+  systemPrompt: string;
+  pluginPrompts: Record<string, string>;
+}
+
+// Build the `pluginPrompts` map from a role's `availablePlugins`
+// list. For each plugin with a defined `systemPrompt` string we
+// emit `[name, prompt]`; plugins without a prompt are skipped
+// entirely (not emitted with `undefined`, not emitted with empty
+// string). Pure.
+export function buildPluginPromptsMap(
+  availablePlugins: readonly string[],
+  getPluginSystemPrompt: (name: string) => string | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const name of availablePlugins) {
+    const prompt = getPluginSystemPrompt(name);
+    if (typeof prompt === "string" && prompt.length > 0) {
+      out[name] = prompt;
+    }
+  }
+  return out;
+}
+
+// Assemble the full request body. Pure — the caller passes in
+// everything it needs (no reactive refs read inside here). Mostly
+// a named-field adapter but it also handles the pluginPrompts
+// construction and the `selectedImageData` pass-through.
+export function buildAgentRequestBody(
+  params: AgentRequestBodyParams,
+): AgentRequestBody {
+  return {
+    message: params.message,
+    roleId: params.role.id,
+    chatSessionId: params.chatSessionId,
+    selectedImageData: params.selectedImageData,
+    systemPrompt: params.systemPrompt,
+    pluginPrompts: buildPluginPromptsMap(
+      params.role.availablePlugins,
+      params.getPluginSystemPrompt,
+    ),
+  };
+}

--- a/src/utils/agent/sse.ts
+++ b/src/utils/agent/sse.ts
@@ -66,22 +66,50 @@ export function decodeSSELine(line: string): SseEvent | null {
   return parsed;
 }
 
-// Runtime shape check for an SSE event. Only validates the
-// discriminator (`type`) — the downstream dispatch handles each
-// shape's specific fields. If we ever add structural validation it
-// should live here, not scatter across every consumer.
+// Runtime shape check for an SSE event. Validates both the
+// discriminator AND each variant's required fields — a partial
+// payload like `{"type":"tool_result"}` (no `result` field) used
+// to slip through this guard, then crash `applyAgentEvent` when
+// it dereferenced `event.result.uuid`. Addressing the one brittle
+// trust point here is cheaper than spreading defensive checks
+// across every dispatch branch.
+//
+// The field list mirrors the per-variant interfaces in
+// `src/types/sse.ts`; keep them in sync if new SSE events land.
 function isSseEvent(value: unknown): value is SseEvent {
   if (typeof value !== "object" || value === null) return false;
-  const type = (value as { type?: unknown }).type;
+  const candidate = value as Record<string, unknown>;
+  const type = candidate.type;
   if (typeof type !== "string") return false;
-  return (
-    type === "tool_call" ||
-    type === "tool_call_result" ||
-    type === "status" ||
-    type === "switch_role" ||
-    type === "text" ||
-    type === "tool_result" ||
-    type === "roles_updated" ||
-    type === "error"
-  );
+  switch (type) {
+    case "status":
+    case "text":
+    case "error":
+      return typeof candidate.message === "string";
+    case "switch_role":
+      return typeof candidate.roleId === "string";
+    case "tool_call":
+      return (
+        typeof candidate.toolUseId === "string" &&
+        typeof candidate.toolName === "string" &&
+        "args" in candidate
+      );
+    case "tool_call_result":
+      return (
+        typeof candidate.toolUseId === "string" &&
+        typeof candidate.content === "string"
+      );
+    case "tool_result": {
+      const result = candidate.result;
+      return (
+        typeof result === "object" &&
+        result !== null &&
+        typeof (result as { uuid?: unknown }).uuid === "string"
+      );
+    }
+    case "roles_updated":
+      return true;
+    default:
+      return false;
+  }
 }

--- a/src/utils/agent/sse.ts
+++ b/src/utils/agent/sse.ts
@@ -1,0 +1,87 @@
+// Server-Sent-Event line parsing for the agent SSE stream.
+//
+// Extracted from `src/App.vue#sendMessage` as part of the
+// cognitive-complexity refactor tracked in #175. The pure-parsing
+// pieces were the biggest contributor to that function's CC score
+// (the outer while-loop + inner for-loop + JSON.parse + type
+// dispatch, all nested). Pulling the pre-dispatch half — buffer
+// management + line splitting + JSON decode — into a named helper
+// drops the sendMessage score substantially while giving us a
+// clean surface to table-test.
+
+import type { SseEvent } from "../../types/sse";
+
+export interface ParsedSseChunk {
+  /** Complete SSE events decoded from the buffer + new chunk. */
+  events: SseEvent[];
+  /**
+   * Text that wasn't a full line yet — hand it back into the next
+   * call as the `buffer` parameter. Empty string when the stream
+   * naturally broke on a newline.
+   */
+  remaining: string;
+}
+
+// Walk a chunk of decoded SSE text appended to an existing buffer
+// and extract every fully-delivered event line. Partial trailing
+// text is returned as `remaining` so the caller can prepend it to
+// the next read. Silently skips:
+//
+//   - blank / keep-alive lines (no `data: ` prefix)
+//   - lines whose payload fails `JSON.parse`
+//   - lines whose payload parses but isn't a recognised event
+//     shape (`type` missing or unknown) — surfacing those would
+//     be noise, since the server is the only producer and new
+//     event types roll out as additive features
+//
+// The function does NO I/O and never throws. Pure.
+export function parseSSEChunk(
+  buffer: string,
+  chunkText: string,
+): ParsedSseChunk {
+  const combined = buffer + chunkText;
+  const lines = combined.split("\n");
+  const remaining = lines.pop() ?? "";
+  const events: SseEvent[] = [];
+  for (const line of lines) {
+    const event = decodeSSELine(line);
+    if (event !== null) events.push(event);
+  }
+  return { events, remaining };
+}
+
+// Decode a single SSE `data: ...` line into an event, or null to
+// signal "skip". Exported so tests can exercise each reject-reason
+// path independently of the buffer state.
+export function decodeSSELine(line: string): SseEvent | null {
+  if (!line.startsWith("data: ")) return null;
+  const payload = line.slice("data: ".length);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+  if (!isSseEvent(parsed)) return null;
+  return parsed;
+}
+
+// Runtime shape check for an SSE event. Only validates the
+// discriminator (`type`) — the downstream dispatch handles each
+// shape's specific fields. If we ever add structural validation it
+// should live here, not scatter across every consumer.
+function isSseEvent(value: unknown): value is SseEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const type = (value as { type?: unknown }).type;
+  if (typeof type !== "string") return false;
+  return (
+    type === "tool_call" ||
+    type === "tool_call_result" ||
+    type === "status" ||
+    type === "switch_role" ||
+    type === "text" ||
+    type === "tool_result" ||
+    type === "roles_updated" ||
+    type === "error"
+  );
+}

--- a/src/utils/agent/toolCalls.ts
+++ b/src/utils/agent/toolCalls.ts
@@ -1,0 +1,60 @@
+// Pure helpers for the agent's tool-call history manipulation
+// pulled out of `src/App.vue#sendMessage`. Each function is
+// single-purpose, testable in isolation, and side-effect-free.
+//
+// Extracted as part of the cognitive-complexity refactor tracked
+// in #175.
+
+import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// When an SSE `tool_call_result` event arrives, the server tells
+// us which tool call it belongs to via `toolUseId`. Find the most
+// recent matching history entry that's still **pending** (no
+// result, no error) and return it so the caller can attach the
+// payload.
+//
+// Newest-first: scanning in reverse is intentional — two calls to
+// the same tool within one run would otherwise attach the new
+// result to the earlier entry. Reverse scan always picks the
+// freshest pending entry, matching the server's LIFO ordering.
+//
+// Returns `undefined` when no pending call matches (race / retry /
+// late-arriving event). Pure.
+export function findPendingToolCall(
+  history: readonly ToolCallHistoryItem[],
+  toolUseId: string,
+): ToolCallHistoryItem | undefined {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const entry = history[i];
+    if (
+      entry.toolUseId === toolUseId &&
+      entry.result === undefined &&
+      entry.error === undefined
+    ) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+// Decide whether a newly-arrived assistant text message should
+// become the selected canvas result. Rule: yes, iff no plugin
+// tool result has landed during this run. A plugin result — e.g.
+// an image, a todo list update — is visually richer than a bare
+// text response and should stay selected once emitted.
+//
+// `runStartIndex` is the index into `toolResults` at which the
+// current run's outputs begin. Results before that index belong
+// to previous turns and don't count.
+//
+// Pure — returns a boolean for the caller to act on.
+export function shouldSelectAssistantText(
+  toolResults: readonly ToolResultComplete[],
+  runStartIndex: number,
+): boolean {
+  for (let i = runStartIndex; i < toolResults.length; i++) {
+    if (toolResults[i].toolName !== "text-response") return false;
+  }
+  return true;
+}

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -1,0 +1,76 @@
+// Pure helper: merge the two views of "sessions" that the sidebar
+// history pane shows — live in-memory sessions (from `sessionMap`)
+// and server-persisted summaries (from `/api/sessions`). Extracted
+// from `src/App.vue` as part of the cognitive-complexity refactor
+// tracked in #175.
+//
+// The merge is deterministic given the inputs: the test suite pins
+// every edge case we've hit (live-only, server-only, overlap,
+// server-side AI title vs local first-user-message, sort tie-breaks).
+
+import { isUserTextResponse } from "../tools/result";
+import type { SessionSummary, ActiveSession } from "../../types/session";
+
+// Build the summary shape the sidebar expects for a single live
+// session. Server-side data (AI-generated title, summary,
+// keywords) takes precedence over the local first-user-message
+// heuristic — otherwise opening an indexed session in a new tab
+// would regress the sidebar row to the raw first message.
+function buildLiveSummary(
+  live: ActiveSession,
+  serverEntry: SessionSummary | undefined,
+): SessionSummary {
+  const firstUserMsg = live.toolResults.find(isUserTextResponse);
+  const preview = serverEntry?.preview || (firstUserMsg?.message ?? "");
+  const base: SessionSummary = {
+    id: live.id,
+    roleId: live.roleId,
+    startedAt: live.startedAt,
+    updatedAt: live.updatedAt,
+    preview,
+  };
+  // Carry summary / keywords ONLY if the server already has them.
+  // Object-spread with a conditional object keeps us from adding
+  // `undefined` values that would otherwise show up as explicit
+  // `summary: undefined` in a later shallow-copy.
+  return {
+    ...base,
+    ...(serverEntry?.summary !== undefined && { summary: serverEntry.summary }),
+    ...(serverEntry?.keywords !== undefined && {
+      keywords: serverEntry.keywords,
+    }),
+  };
+}
+
+// Compare two summaries for sort order. Newest `updatedAt` wins;
+// if updatedAt ties (same second-granularity mtime on two
+// server-only rows, say), fall back to `startedAt`. Exported so
+// tests can exercise the tie-break directly.
+export function compareSessionsByRecency(
+  a: SessionSummary,
+  b: SessionSummary,
+): number {
+  const byUpdated = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+  if (byUpdated !== 0) return byUpdated;
+  return Date.parse(b.startedAt) - Date.parse(a.startedAt);
+}
+
+// Merge live sessions (in-memory, still editable) with server
+// summaries (from /api/sessions). Live sessions always win for
+// the same id — we prefer the local state we know is current —
+// but pull over the server's AI title / summary / keywords when
+// present. Pure, returns a new array; does not mutate inputs.
+export function mergeSessionLists(
+  liveSessions: readonly ActiveSession[],
+  serverSessions: readonly SessionSummary[],
+): SessionSummary[] {
+  const liveIds = new Set(liveSessions.map((s) => s.id));
+  const serverById = new Map<string, SessionSummary>(
+    serverSessions.map((s) => [s.id, s]),
+  );
+  const liveSummaries = liveSessions.map((live) =>
+    buildLiveSummary(live, serverById.get(live.id)),
+  );
+  const serverOnly = serverSessions.filter((s) => !liveIds.has(s.id));
+  return [...liveSummaries, ...serverOnly].sort(compareSessionsByRecency);
+}

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -1,0 +1,83 @@
+// Pure helpers for reconstructing an `ActiveSession`'s runtime
+// shape from the `/api/sessions/:id` JSONL payload. Extracted from
+// `src/App.vue#loadSession` so the parse / select / timestamp-
+// resolution logic is unit-testable without mocking `fetch`.
+//
+// Tracks #175.
+
+import { makeTextResult } from "../tools/result";
+import {
+  isTextEntry,
+  isToolResultEntry,
+  type SessionEntry,
+  type SessionSummary,
+} from "../../types/session";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// Walk the server's session entries and produce the flat
+// `toolResults` array the client keeps in `ActiveSession`. Drops
+// `session_meta` rows (they're metadata, not a result), converts
+// text entries into tool-result-shaped envelopes via
+// `makeTextResult`, and passes tool_result entries through verbatim.
+export function parseSessionEntries(
+  entries: readonly SessionEntry[],
+): ToolResultComplete[] {
+  const out: ToolResultComplete[] = [];
+  for (const entry of entries) {
+    if (entry.type === "session_meta") continue;
+    if (isTextEntry(entry)) {
+      out.push(makeTextResult(entry.message, entry.source));
+    } else if (isToolResultEntry(entry)) {
+      out.push(entry.result);
+    }
+  }
+  return out;
+}
+
+// Pick the `selectedResultUuid` the session should restore to.
+// Rules:
+//   1. If the URL carries `?result=<uuid>` AND that uuid actually
+//      exists in the loaded list, honour it verbatim. This lets
+//      bookmarks restore the exact result the user was viewing.
+//   2. Otherwise fall back to the heuristic: the most recent
+//      non-text tool result (images, wiki pages, etc. carry more
+//      visual information than bare text).
+//   3. If there are no non-text results, use the last result of
+//      any kind.
+//   4. If the list is empty, return null.
+export function resolveSelectedUuid(
+  toolResults: readonly ToolResultComplete[],
+  urlResult: string | null,
+): string | null {
+  if (urlResult && toolResults.some((r) => r.uuid === urlResult)) {
+    return urlResult;
+  }
+  // Iterate backwards for the "last non-text" lookup so callers
+  // don't pay for an intermediate reverse copy.
+  for (let i = toolResults.length - 1; i >= 0; i--) {
+    if (toolResults[i].toolName !== "text-response") {
+      return toolResults[i].uuid;
+    }
+  }
+  const last = toolResults[toolResults.length - 1];
+  return last?.uuid ?? null;
+}
+
+// Decide the `startedAt` / `updatedAt` to seed the in-memory
+// ActiveSession with. We prefer the server summary's timestamps
+// so the restored session keeps its existing sidebar ordering;
+// we fall through to the current clock only if the server
+// summary is missing (e.g. freshly-created session that hasn't
+// round-tripped through `/api/sessions` yet).
+//
+// Keeping this logic named lets the test suite pin the
+// "updatedAt missing → fall back to startedAt" rule explicitly,
+// which was previously a fragile `??` chain buried in loadSession.
+export function resolveSessionTimestamps(
+  serverSummary: SessionSummary | undefined,
+  nowIso: string,
+): { startedAt: string; updatedAt: string } {
+  const startedAt = serverSummary?.startedAt ?? nowIso;
+  const updatedAt = serverSummary?.updatedAt ?? startedAt;
+  return { startedAt, updatedAt };
+}

--- a/test/utils/agent/test_request.ts
+++ b/test/utils/agent/test_request.ts
@@ -1,0 +1,167 @@
+// Unit tests for the pure request-body builder extracted from
+// `src/App.vue#sendMessage`. See plans/refactor-vue-cognitive-complexity.md
+// and issue #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPluginPromptsMap,
+  buildAgentRequestBody,
+} from "../../../src/utils/agent/request.js";
+import type { Role } from "../../../src/config/roles.js";
+
+function makeRole(overrides: Partial<Role> = {}): Role {
+  return {
+    id: "test-role",
+    name: "Test Role",
+    icon: "bolt",
+    prompt: "",
+    availablePlugins: [],
+    ...overrides,
+  };
+}
+
+describe("buildPluginPromptsMap", () => {
+  it("returns {} for empty availablePlugins", () => {
+    assert.deepEqual(
+      buildPluginPromptsMap([], () => "anything"),
+      {},
+    );
+  });
+
+  it("maps plugins whose lookup returns a non-empty string", () => {
+    const prompts: Record<string, string> = {
+      alpha: "prompt for alpha",
+      beta: "prompt for beta",
+    };
+    const out = buildPluginPromptsMap(
+      ["alpha", "beta"],
+      (name) => prompts[name],
+    );
+    assert.deepEqual(out, prompts);
+  });
+
+  it("skips plugins whose lookup returns undefined", () => {
+    const out = buildPluginPromptsMap(["alpha", "unknown", "beta"], (name) =>
+      name === "alpha" ? "P-alpha" : undefined,
+    );
+    assert.deepEqual(out, { alpha: "P-alpha" });
+  });
+
+  it("skips plugins whose lookup returns an empty string", () => {
+    // Empty string carries no meaningful prompt content and would
+    // only clutter the LLM's system section.
+    const out = buildPluginPromptsMap(["alpha"], () => "");
+    assert.deepEqual(out, {});
+  });
+
+  it("preserves first-occurrence order of availablePlugins", () => {
+    const out = buildPluginPromptsMap(["c", "a", "b"], (name) => `P-${name}`);
+    assert.deepEqual(Object.keys(out), ["c", "a", "b"]);
+  });
+
+  it("handles a plugin name that appears twice (second wins via object assignment)", () => {
+    // Object keys are unique — the second entry overwrites the
+    // first. We document current behaviour here so a future
+    // dedup refactor doesn't silently change the outcome.
+    let count = 0;
+    const out = buildPluginPromptsMap(["alpha", "alpha"], () => `P-${++count}`);
+    assert.deepEqual(out, { alpha: "P-2" });
+  });
+
+  it("tolerates a lookup that throws (no wrapping — throws escape)", () => {
+    // Document current contract: the helper does not shield
+    // callers from a broken lookup. If this ever changes (e.g.
+    // add a try/catch + skip), update the test and the docs.
+    const role = makeRole({ availablePlugins: ["bad"] });
+    assert.throws(() =>
+      buildPluginPromptsMap(role.availablePlugins, () => {
+        throw new Error("boom");
+      }),
+    );
+  });
+});
+
+describe("buildAgentRequestBody — happy path", () => {
+  it("assembles every field in the shape the server expects", () => {
+    const role = makeRole({
+      id: "coder",
+      availablePlugins: ["todo", "wiki"],
+    });
+    const body = buildAgentRequestBody({
+      message: "hello",
+      role,
+      chatSessionId: "sess-1",
+      systemPrompt: "SYS",
+      selectedImageData: "data:image/png;base64,AAA",
+      getPluginSystemPrompt: (name) =>
+        name === "todo" ? "todo-prompt" : undefined,
+    });
+    assert.deepEqual(body, {
+      message: "hello",
+      roleId: "coder",
+      chatSessionId: "sess-1",
+      selectedImageData: "data:image/png;base64,AAA",
+      systemPrompt: "SYS",
+      pluginPrompts: { todo: "todo-prompt" },
+    });
+  });
+
+  it("leaves selectedImageData as undefined when not provided", () => {
+    const body = buildAgentRequestBody({
+      message: "hi",
+      role: makeRole(),
+      chatSessionId: "s",
+      systemPrompt: "",
+      getPluginSystemPrompt: () => undefined,
+    });
+    assert.equal(body.selectedImageData, undefined);
+  });
+
+  it("returns an empty pluginPrompts object when the role has no plugins", () => {
+    const body = buildAgentRequestBody({
+      message: "hi",
+      role: makeRole({ availablePlugins: [] }),
+      chatSessionId: "s",
+      systemPrompt: "",
+      getPluginSystemPrompt: () => "ignored",
+    });
+    assert.deepEqual(body.pluginPrompts, {});
+  });
+});
+
+describe("buildAgentRequestBody — edge cases", () => {
+  it("accepts an empty message (sendMessage guards upstream; this helper doesn't)", () => {
+    const body = buildAgentRequestBody({
+      message: "",
+      role: makeRole(),
+      chatSessionId: "s",
+      systemPrompt: "",
+      getPluginSystemPrompt: () => undefined,
+    });
+    assert.equal(body.message, "");
+  });
+
+  it("passes the role's id through regardless of role name/icon", () => {
+    const role = makeRole({ id: "abc-123", name: "Name", icon: "bolt" });
+    const body = buildAgentRequestBody({
+      message: "m",
+      role,
+      chatSessionId: "s",
+      systemPrompt: "",
+      getPluginSystemPrompt: () => undefined,
+    });
+    assert.equal(body.roleId, "abc-123");
+  });
+
+  it("passes systemPrompt verbatim (does not trim or modify)", () => {
+    const body = buildAgentRequestBody({
+      message: "m",
+      role: makeRole(),
+      chatSessionId: "s",
+      systemPrompt: "  leading whitespace intentional  ",
+      getPluginSystemPrompt: () => undefined,
+    });
+    assert.equal(body.systemPrompt, "  leading whitespace intentional  ");
+  });
+});

--- a/test/utils/agent/test_sse.ts
+++ b/test/utils/agent/test_sse.ts
@@ -89,6 +89,107 @@ describe("decodeSSELine — rejects noise", () => {
   });
 });
 
+describe("decodeSSELine — rejects malformed variant shapes (per-field validation)", () => {
+  // Addresses the PR #177 CodeRabbit finding: the type-guard used
+  // to trust the discriminator alone, so a payload like
+  // `{"type":"tool_result"}` would pass here and crash
+  // `applyAgentEvent` when it dereferenced `event.result.uuid`.
+  //
+  // Every case below is a payload that has the correct `type`
+  // string but is missing (or malforming) at least one required
+  // field per the `SseEvent` variant interfaces in
+  // `src/types/sse.ts`. All should return null.
+
+  function rejectPayload(obj: Record<string, unknown>): void {
+    const line = `data: ${JSON.stringify(obj)}`;
+    assert.equal(decodeSSELine(line), null);
+  }
+
+  it("rejects `status` without a message", () => {
+    rejectPayload({ type: "status" });
+    rejectPayload({ type: "status", message: 42 });
+    rejectPayload({ type: "status", message: null });
+  });
+
+  it("rejects `text` without a message", () => {
+    rejectPayload({ type: "text" });
+    rejectPayload({ type: "text", message: [] });
+  });
+
+  it("rejects `error` without a message", () => {
+    rejectPayload({ type: "error" });
+    rejectPayload({ type: "error", message: 500 });
+  });
+
+  it("rejects `switch_role` without a roleId", () => {
+    rejectPayload({ type: "switch_role" });
+    rejectPayload({ type: "switch_role", roleId: 0 });
+  });
+
+  it("rejects `tool_call` missing required fields", () => {
+    rejectPayload({ type: "tool_call" });
+    rejectPayload({ type: "tool_call", toolUseId: "u" });
+    rejectPayload({ type: "tool_call", toolUseId: "u", toolName: "t" });
+    rejectPayload({
+      type: "tool_call",
+      toolUseId: 1,
+      toolName: "t",
+      args: {},
+    });
+    rejectPayload({
+      type: "tool_call",
+      toolUseId: "u",
+      toolName: true,
+      args: {},
+    });
+  });
+
+  it("accepts `tool_call` with any `args` value (including null/primitive)", () => {
+    // `args` is `unknown` in the SseToolCall interface — content
+    // varies per tool, so we only require the KEY exists. This
+    // test pins that contract.
+    const sample = {
+      type: "tool_call",
+      toolUseId: "u",
+      toolName: "t",
+      args: null,
+    };
+    assert.ok(decodeSSELine(`data: ${JSON.stringify(sample)}`));
+  });
+
+  it("rejects `tool_call_result` missing toolUseId or content", () => {
+    rejectPayload({ type: "tool_call_result" });
+    rejectPayload({ type: "tool_call_result", toolUseId: "u" });
+    rejectPayload({ type: "tool_call_result", content: "c" });
+    rejectPayload({
+      type: "tool_call_result",
+      toolUseId: "u",
+      content: 123,
+    });
+  });
+
+  it("rejects `tool_result` with a missing / malformed result", () => {
+    // THE specific payload CodeRabbit called out:
+    // `{"type":"tool_result"}` with no `result` at all.
+    rejectPayload({ type: "tool_result" });
+    rejectPayload({ type: "tool_result", result: null });
+    rejectPayload({ type: "tool_result", result: "not an object" });
+    rejectPayload({ type: "tool_result", result: {} }); // missing uuid
+    rejectPayload({ type: "tool_result", result: { uuid: 42 } }); // non-string uuid
+  });
+
+  it("accepts `tool_result` with the minimum valid shape", () => {
+    const sample = { type: "tool_result", result: { uuid: "r-1" } };
+    assert.ok(decodeSSELine(`data: ${JSON.stringify(sample)}`));
+  });
+
+  it("accepts `roles_updated` with no fields (it's just a pulse)", () => {
+    assert.ok(
+      decodeSSELine(`data: ${JSON.stringify({ type: "roles_updated" })}`),
+    );
+  });
+});
+
 describe("parseSSEChunk — buffer management", () => {
   it("returns empty events and empty remaining for empty input", () => {
     assert.deepEqual(parseSSEChunk("", ""), { events: [], remaining: "" });

--- a/test/utils/agent/test_sse.ts
+++ b/test/utils/agent/test_sse.ts
@@ -1,0 +1,179 @@
+// Unit tests for the pure SSE parsing helpers extracted from
+// `src/App.vue#sendMessage`. See plans/refactor-vue-cognitive-complexity.md
+// and issue #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseSSEChunk, decodeSSELine } from "../../../src/utils/agent/sse.js";
+
+describe("decodeSSELine — happy path", () => {
+  it("decodes a status event", () => {
+    const line = `data: ${JSON.stringify({ type: "status", message: "Hi" })}`;
+    assert.deepEqual(decodeSSELine(line), { type: "status", message: "Hi" });
+  });
+
+  it("decodes a text event", () => {
+    const line = `data: ${JSON.stringify({ type: "text", message: "ok" })}`;
+    assert.deepEqual(decodeSSELine(line), { type: "text", message: "ok" });
+  });
+
+  it("decodes a tool_call event with complex args", () => {
+    const event = {
+      type: "tool_call",
+      toolUseId: "use-1",
+      toolName: "doStuff",
+      args: { nested: { x: 1 }, list: [1, "two"] },
+    };
+    const line = `data: ${JSON.stringify(event)}`;
+    assert.deepEqual(decodeSSELine(line), event);
+  });
+
+  it("decodes every known event type", () => {
+    const samples = [
+      { type: "tool_call", toolUseId: "u", toolName: "t", args: {} },
+      { type: "tool_call_result", toolUseId: "u", content: "c" },
+      { type: "status", message: "m" },
+      { type: "switch_role", roleId: "r" },
+      { type: "text", message: "m" },
+      { type: "tool_result", result: { uuid: "x" } },
+      { type: "roles_updated" },
+      { type: "error", message: "oops" },
+    ];
+    for (const sample of samples) {
+      const line = `data: ${JSON.stringify(sample)}`;
+      assert.ok(decodeSSELine(line), `${sample.type} should decode`);
+    }
+  });
+});
+
+describe("decodeSSELine — rejects noise", () => {
+  it("returns null for a non-data line (SSE comment)", () => {
+    assert.equal(decodeSSELine(":keepalive"), null);
+  });
+
+  it("returns null for a blank line", () => {
+    assert.equal(decodeSSELine(""), null);
+  });
+
+  it("returns null for an `event:` SSE field without `data: ` prefix", () => {
+    assert.equal(decodeSSELine("event: status"), null);
+  });
+
+  it("returns null for `data:` without the required space", () => {
+    // We intentionally match `data: ` (trailing space). `data:foo`
+    // is spec-legal SSE but our server never emits it, so treating
+    // it as noise is simpler than accepting both forms.
+    assert.equal(decodeSSELine('data:{"type":"status"}'), null);
+  });
+
+  it("returns null for malformed JSON", () => {
+    assert.equal(decodeSSELine("data: { broken"), null);
+  });
+
+  it("returns null for non-object JSON payloads", () => {
+    assert.equal(decodeSSELine("data: 42"), null);
+    assert.equal(decodeSSELine("data: null"), null);
+    assert.equal(decodeSSELine("data: [1,2,3]"), null);
+    assert.equal(decodeSSELine('data: "just a string"'), null);
+  });
+
+  it("returns null when `type` is missing", () => {
+    assert.equal(decodeSSELine('data: {"message":"hi"}'), null);
+  });
+
+  it("returns null for unknown `type` (future event type)", () => {
+    assert.equal(
+      decodeSSELine('data: {"type":"mystery","message":"new"}'),
+      null,
+    );
+  });
+});
+
+describe("parseSSEChunk — buffer management", () => {
+  it("returns empty events and empty remaining for empty input", () => {
+    assert.deepEqual(parseSSEChunk("", ""), { events: [], remaining: "" });
+  });
+
+  it("returns one event when the chunk ends exactly on a newline", () => {
+    const chunk = `data: ${JSON.stringify({ type: "status", message: "a" })}\n`;
+    const out = parseSSEChunk("", chunk);
+    assert.equal(out.events.length, 1);
+    assert.equal(out.events[0].type, "status");
+    assert.equal(out.remaining, "");
+  });
+
+  it("holds a partial trailing line in `remaining`", () => {
+    const chunk = `data: ${JSON.stringify({ type: "status", message: "a" })}\ndata: {"type":"text","mess`;
+    const out = parseSSEChunk("", chunk);
+    assert.equal(out.events.length, 1);
+    assert.equal(out.remaining, 'data: {"type":"text","mess');
+  });
+
+  it("completes a message split across two chunks", () => {
+    const first = parseSSEChunk("", 'data: {"type":"text","mess');
+    assert.equal(first.events.length, 0);
+    assert.equal(first.remaining, 'data: {"type":"text","mess');
+    const second = parseSSEChunk(first.remaining, 'age":"ok"}\n');
+    assert.equal(second.events.length, 1);
+    assert.equal(second.events[0].type, "text");
+    assert.equal(second.remaining, "");
+  });
+
+  it("returns multiple events in a single chunk", () => {
+    const chunk = [
+      `data: ${JSON.stringify({ type: "status", message: "a" })}`,
+      `data: ${JSON.stringify({ type: "text", message: "b" })}`,
+      `data: ${JSON.stringify({ type: "status", message: "c" })}`,
+      "",
+    ].join("\n");
+    const out = parseSSEChunk("", chunk);
+    assert.equal(out.events.length, 3);
+    assert.equal(out.events[0].type, "status");
+    assert.equal(out.events[1].type, "text");
+    assert.equal(out.events[2].type, "status");
+  });
+
+  it("preserves events before a malformed line and skips the malformed one", () => {
+    const chunk = [
+      `data: ${JSON.stringify({ type: "status", message: "ok" })}`,
+      "data: { not json",
+      `data: ${JSON.stringify({ type: "text", message: "next" })}`,
+      "",
+    ].join("\n");
+    const out = parseSSEChunk("", chunk);
+    // 2 valid events, the malformed one is dropped.
+    assert.equal(out.events.length, 2);
+    assert.equal(out.events[0].type, "status");
+    assert.equal(out.events[1].type, "text");
+  });
+
+  it("passes keep-alive comments through without emitting events", () => {
+    const chunk =
+      ":ping\n" +
+      `data: ${JSON.stringify({ type: "status", message: "ok" })}\n`;
+    const out = parseSSEChunk("", chunk);
+    assert.equal(out.events.length, 1);
+    assert.equal(out.events[0].type, "status");
+  });
+
+  it("handles a series of small chunks that together form two events", () => {
+    // Byte-by-byte delivery is realistic with Server-Sent-Events
+    // over flaky networks. The decoder state must survive every
+    // sub-newline split.
+    const stream = [
+      `data: ${JSON.stringify({ type: "status", message: "a" })}\n`,
+      `data: ${JSON.stringify({ type: "text", message: "b" })}\n`,
+    ].join("");
+    let buffer = "";
+    const seen: string[] = [];
+    // Feed 7 chars at a time
+    for (let i = 0; i < stream.length; i += 7) {
+      const slice = stream.slice(i, i + 7);
+      const parsed = parseSSEChunk(buffer, slice);
+      buffer = parsed.remaining;
+      for (const event of parsed.events) seen.push(event.type);
+    }
+    assert.deepEqual(seen, ["status", "text"]);
+    assert.equal(buffer, "");
+  });
+});

--- a/test/utils/agent/test_toolCalls.ts
+++ b/test/utils/agent/test_toolCalls.ts
@@ -1,0 +1,155 @@
+// Unit tests for the pure helpers extracted from
+// `src/App.vue#sendMessage` around tool-call-history management
+// and text-result selection heuristics. See
+// plans/refactor-vue-cognitive-complexity.md and issue #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  findPendingToolCall,
+  shouldSelectAssistantText,
+} from "../../../src/utils/agent/toolCalls.js";
+import type { ToolCallHistoryItem } from "../../../src/types/toolCallHistory.js";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+function makeHistoryEntry(
+  toolUseId: string,
+  overrides: Partial<ToolCallHistoryItem> = {},
+): ToolCallHistoryItem {
+  return {
+    toolUseId,
+    toolName: "test",
+    args: {},
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("findPendingToolCall — basic matching", () => {
+  it("returns undefined for empty history", () => {
+    assert.equal(findPendingToolCall([], "any"), undefined);
+  });
+
+  it("returns undefined when no entry matches the toolUseId", () => {
+    const history = [makeHistoryEntry("id-1"), makeHistoryEntry("id-2")];
+    assert.equal(findPendingToolCall(history, "id-3"), undefined);
+  });
+
+  it("returns the pending entry when toolUseId matches", () => {
+    const entry = makeHistoryEntry("id-1");
+    const result = findPendingToolCall([entry], "id-1");
+    assert.equal(result, entry);
+  });
+});
+
+describe("findPendingToolCall — pending vs resolved", () => {
+  it("skips entries that already have a result", () => {
+    const history = [makeHistoryEntry("id-1", { result: "already done" })];
+    assert.equal(findPendingToolCall(history, "id-1"), undefined);
+  });
+
+  it("skips entries that already have an error", () => {
+    const history = [makeHistoryEntry("id-1", { error: "already failed" })];
+    assert.equal(findPendingToolCall(history, "id-1"), undefined);
+  });
+
+  it("distinguishes pending from resolved at the same toolUseId", () => {
+    // Race / retry scenario: two calls with the same id, one done
+    // and one still pending. Should find the pending one.
+    const pending = makeHistoryEntry("id-1");
+    const history = [makeHistoryEntry("id-1", { result: "old" }), pending];
+    const result = findPendingToolCall(history, "id-1");
+    assert.equal(result, pending);
+  });
+});
+
+describe("findPendingToolCall — reverse-scan semantics", () => {
+  it("returns the NEWEST pending match (reverse scan)", () => {
+    // Two pending entries with the same toolUseId. The later
+    // entry in the array is more recent and should win — this
+    // mirrors LIFO ordering on the server side.
+    const newer = makeHistoryEntry("id-1", { timestamp: 100 });
+    const older = makeHistoryEntry("id-1", { timestamp: 50 });
+    const result = findPendingToolCall([older, newer], "id-1");
+    assert.equal(result, newer);
+  });
+
+  it("returns the pending match among a mix of ids and states", () => {
+    const target = makeHistoryEntry("id-2");
+    const history = [
+      makeHistoryEntry("id-1"),
+      makeHistoryEntry("id-2", { result: "done" }),
+      makeHistoryEntry("id-1", { result: "done" }),
+      target,
+      makeHistoryEntry("id-3"),
+    ];
+    const result = findPendingToolCall(history, "id-2");
+    assert.equal(result, target);
+  });
+});
+
+// --- shouldSelectAssistantText ------------------------------------
+
+function makeToolResult(uuid: string, toolName: string): ToolResultComplete {
+  // Minimal shape — only `uuid` and `toolName` matter for this helper.
+  return { uuid, toolName } as ToolResultComplete;
+}
+
+describe("shouldSelectAssistantText — returns true when run is text-only", () => {
+  it("true for empty run tail (fresh run, nothing pushed yet)", () => {
+    assert.equal(shouldSelectAssistantText([], 0), true);
+  });
+
+  it("true when every result in the run is text-response", () => {
+    const results = [
+      makeToolResult("u1", "text-response"),
+      makeToolResult("u2", "text-response"),
+    ];
+    assert.equal(shouldSelectAssistantText(results, 0), true);
+  });
+
+  it("true when plugin results exist but predate the run (ignored)", () => {
+    // Two text-response results after runStartIndex, a plugin
+    // result before it — the pre-run result is irrelevant.
+    const results = [
+      makeToolResult("prev", "generateImage"),
+      makeToolResult("u1", "text-response"),
+    ];
+    assert.equal(shouldSelectAssistantText(results, 1), true);
+  });
+});
+
+describe("shouldSelectAssistantText — returns false when a plugin result is in the run", () => {
+  it("false when a single plugin result is the only entry", () => {
+    const results = [makeToolResult("u1", "generateImage")];
+    assert.equal(shouldSelectAssistantText(results, 0), false);
+  });
+
+  it("false when a plugin result comes after a text-response", () => {
+    const results = [
+      makeToolResult("u1", "text-response"),
+      makeToolResult("u2", "generateImage"),
+    ];
+    assert.equal(shouldSelectAssistantText(results, 0), false);
+  });
+
+  it("false when a plugin result comes before a text-response", () => {
+    const results = [
+      makeToolResult("u1", "generateImage"),
+      makeToolResult("u2", "text-response"),
+    ];
+    assert.equal(shouldSelectAssistantText(results, 0), false);
+  });
+});
+
+describe("shouldSelectAssistantText — boundary conditions", () => {
+  it("runStartIndex at end of array → true (nothing to inspect)", () => {
+    const results = [makeToolResult("prev", "generateImage")];
+    assert.equal(shouldSelectAssistantText(results, results.length), true);
+  });
+
+  it("runStartIndex past end → true (defensive, shouldn't happen)", () => {
+    const results = [makeToolResult("prev", "generateImage")];
+    assert.equal(shouldSelectAssistantText(results, 99), true);
+  });
+});

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -1,0 +1,254 @@
+// Unit tests for `mergeSessionLists` + `compareSessionsByRecency`.
+// Extracted from `src/App.vue`'s `mergedSessions` computed — see
+// plans/refactor-vue-cognitive-complexity.md and issue #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mergeSessionLists,
+  compareSessionsByRecency,
+} from "../../../src/utils/session/mergeSessions.js";
+import type {
+  ActiveSession,
+  SessionSummary,
+} from "../../../src/types/session.js";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+function makeActive(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    id: "live-1",
+    roleId: "general",
+    toolResults: [],
+    isRunning: false,
+    statusMessage: "",
+    toolCallHistory: [],
+    selectedResultUuid: null,
+    hasUnread: false,
+    abortController: new AbortController(),
+    startedAt: "2026-04-10T10:00:00.000Z",
+    updatedAt: "2026-04-10T10:05:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: "srv-1",
+    roleId: "general",
+    startedAt: "2026-04-09T10:00:00.000Z",
+    updatedAt: "2026-04-09T10:05:00.000Z",
+    preview: "first user message",
+    ...overrides,
+  };
+}
+
+function makeUserTextResult(message: string): ToolResultComplete {
+  // Matches what `makeTextResult(message, "user")` produces.
+  // `message` lives at the top level (that's what the sidebar
+  // preview reads) AND on `data` alongside the `role: "user"`
+  // discriminator that `isUserTextResponse` keys off.
+  return {
+    uuid: `u-${message}`,
+    toolName: "text-response",
+    message,
+    data: { role: "user", message },
+  } as unknown as ToolResultComplete;
+}
+
+describe("compareSessionsByRecency", () => {
+  it("returns negative when a is more recently updated", () => {
+    const a = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    const b = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(a, b) < 0);
+  });
+
+  it("returns positive when b is more recently updated", () => {
+    const a = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    const b = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(a, b) > 0);
+  });
+
+  it("falls back to startedAt on updatedAt tie", () => {
+    const a = makeSummary({
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-08T10:00:00.000Z",
+    });
+    const b = makeSummary({
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-09T10:00:00.000Z",
+    });
+    // b has newer startedAt, so b should come first
+    assert.ok(compareSessionsByRecency(a, b) > 0);
+  });
+
+  it("returns 0 when both updatedAt and startedAt match", () => {
+    const a = makeSummary({ id: "a" });
+    const b = makeSummary({ id: "b" });
+    assert.equal(compareSessionsByRecency(a, b), 0);
+  });
+});
+
+describe("mergeSessionLists — basic cases", () => {
+  it("returns empty array when both inputs are empty", () => {
+    assert.deepEqual(mergeSessionLists([], []), []);
+  });
+
+  it("returns only the server summary when there are no live sessions", () => {
+    const summary = makeSummary({ id: "srv-1" });
+    assert.deepEqual(mergeSessionLists([], [summary]), [summary]);
+  });
+
+  it("returns the live summary when there are no server entries", () => {
+    const live = makeActive({
+      id: "live-1",
+      toolResults: [makeUserTextResult("hello")],
+    });
+    const result = mergeSessionLists([live], []);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "live-1");
+    assert.equal(result[0].preview, "hello");
+    assert.equal(result[0].summary, undefined);
+    assert.equal(result[0].keywords, undefined);
+  });
+});
+
+describe("mergeSessionLists — live + server overlap", () => {
+  it("live wins when a session appears on both sides", () => {
+    const live = makeActive({
+      id: "both",
+      updatedAt: "2026-04-12T10:00:00.000Z",
+      toolResults: [makeUserTextResult("live message")],
+    });
+    const server = makeSummary({
+      id: "both",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+      preview: "server preview",
+    });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result.length, 1, "session should not be duplicated");
+    assert.equal(result[0].id, "both");
+    // Server preview wins over first-user-message heuristic — the
+    // AI-generated title is more informative
+    assert.equal(result[0].preview, "server preview");
+    // updatedAt comes from the live side (it's the fresher source)
+    assert.equal(result[0].updatedAt, "2026-04-12T10:00:00.000Z");
+  });
+
+  it("carries over server summary + keywords to the live entry", () => {
+    const live = makeActive({ id: "both" });
+    const server = makeSummary({
+      id: "both",
+      preview: "Plan a project",
+      summary: "User wants help planning.",
+      keywords: ["plan", "project"],
+    });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "Plan a project");
+    assert.equal(result[0].summary, "User wants help planning.");
+    assert.deepEqual(result[0].keywords, ["plan", "project"]);
+  });
+
+  it("falls back to first-user-message when server preview is empty", () => {
+    const live = makeActive({
+      id: "both",
+      toolResults: [makeUserTextResult("hello from live")],
+    });
+    const server = makeSummary({ id: "both", preview: "" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "hello from live");
+  });
+
+  it("uses empty preview when neither server nor live has text", () => {
+    const live = makeActive({ id: "both", toolResults: [] });
+    const server = makeSummary({ id: "both", preview: "" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "");
+  });
+});
+
+describe("mergeSessionLists — server-only entries", () => {
+  it("includes server-only entries untouched", () => {
+    const live = makeActive({ id: "live-only" });
+    const server = makeSummary({ id: "srv-only" });
+    const result = mergeSessionLists([live], [server]);
+    const serverEntry = result.find((s) => s.id === "srv-only");
+    assert.equal(serverEntry, server);
+  });
+
+  it("dedupes: a server entry with matching live id does not duplicate", () => {
+    const live = makeActive({ id: "shared" });
+    const server = makeSummary({ id: "shared" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result.length, 1);
+  });
+});
+
+describe("mergeSessionLists — sort order", () => {
+  it("sorts by updatedAt descending (most recent first)", () => {
+    const recent = makeSummary({
+      id: "recent",
+      updatedAt: "2026-04-12T10:00:00.000Z",
+    });
+    const older = makeSummary({
+      id: "older",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    });
+    const result = mergeSessionLists([], [older, recent]);
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["recent", "older"],
+    );
+  });
+
+  it("mixes live and server-only entries in the same sort", () => {
+    const live = makeActive({
+      id: "live",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+    const server = makeSummary({
+      id: "srv",
+      updatedAt: "2026-04-12T00:00:00.000Z",
+    });
+    const result = mergeSessionLists([live], [server]);
+    // srv is newer → comes first
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["srv", "live"],
+    );
+  });
+
+  it("breaks updatedAt ties with startedAt", () => {
+    const a = makeSummary({
+      id: "a",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-08T10:00:00.000Z",
+    });
+    const b = makeSummary({
+      id: "b",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-09T10:00:00.000Z",
+    });
+    const result = mergeSessionLists([], [a, b]);
+    // b has newer startedAt → b first
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["b", "a"],
+    );
+  });
+});
+
+describe("mergeSessionLists — does not mutate inputs", () => {
+  it("returns a new array without modifying the live list", () => {
+    const live = [makeActive({ id: "a" }), makeActive({ id: "b" })];
+    const liveSnapshot = live.slice();
+    mergeSessionLists(live, []);
+    assert.deepEqual(live, liveSnapshot);
+  });
+
+  it("returns a new array without modifying the server list", () => {
+    const server = [makeSummary({ id: "a" }), makeSummary({ id: "b" })];
+    const snapshot = server.slice();
+    mergeSessionLists([], server);
+    assert.deepEqual(server, snapshot);
+  });
+});

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -1,0 +1,242 @@
+// Unit tests for the pure helpers extracted from
+// `src/App.vue#loadSession`. Tracks #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseSessionEntries,
+  resolveSelectedUuid,
+  resolveSessionTimestamps,
+} from "../../../src/utils/session/sessionEntries.js";
+import type {
+  SessionEntry,
+  SessionSummary,
+} from "../../../src/types/session.js";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// --- parseSessionEntries ------------------------------------------
+
+describe("parseSessionEntries", () => {
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parseSessionEntries([]), []);
+  });
+
+  it("skips session_meta entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        type: "session_meta",
+        roleId: "general",
+      } as SessionEntry,
+    ];
+    assert.deepEqual(parseSessionEntries(entries), []);
+  });
+
+  it("converts user text entries into tool-result envelopes", () => {
+    const entries: SessionEntry[] = [
+      {
+        source: "user",
+        type: "text",
+        message: "hello",
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].toolName, "text-response");
+  });
+
+  it("converts assistant text entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        source: "assistant",
+        type: "text",
+        message: "ok",
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].toolName, "text-response");
+  });
+
+  it("passes tool_result entries through verbatim", () => {
+    const toolResult = {
+      uuid: "r1",
+      toolName: "generateImage",
+    } as unknown as ToolResultComplete;
+    const entries: SessionEntry[] = [
+      {
+        source: "tool",
+        type: "tool_result",
+        result: toolResult,
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0], toolResult);
+  });
+
+  it("preserves ordering across a mixed feed", () => {
+    const toolResult = {
+      uuid: "tool-1",
+      toolName: "generateImage",
+    } as unknown as ToolResultComplete;
+    const entries: SessionEntry[] = [
+      { source: "user", type: "text", message: "make an image" },
+      { source: "tool", type: "tool_result", result: toolResult },
+      { source: "assistant", type: "text", message: "done" },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 3);
+    assert.equal(out[0].toolName, "text-response");
+    assert.equal(out[1], toolResult);
+    assert.equal(out[2].toolName, "text-response");
+  });
+
+  it("skips entries that are neither text nor tool_result", () => {
+    const entries = [
+      { source: "unknown", type: "unknown-kind", message: "x" },
+    ] as unknown as SessionEntry[];
+    assert.deepEqual(parseSessionEntries(entries), []);
+  });
+
+  it("tolerates session_meta mixed with real entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        type: "session_meta",
+        roleId: "general",
+      } as SessionEntry,
+      { source: "user", type: "text", message: "hi" },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+  });
+});
+
+// --- resolveSelectedUuid ------------------------------------------
+
+function makeResult(uuid: string, toolName: string): ToolResultComplete {
+  return { uuid, toolName } as unknown as ToolResultComplete;
+}
+
+describe("resolveSelectedUuid — empty list", () => {
+  it("returns null for empty list regardless of urlResult", () => {
+    assert.equal(resolveSelectedUuid([], null), null);
+    assert.equal(resolveSelectedUuid([], "any"), null);
+  });
+});
+
+describe("resolveSelectedUuid — URL override", () => {
+  it("honours url-specified uuid when it exists in the list", () => {
+    const results = [
+      makeResult("a", "text-response"),
+      makeResult("b", "generateImage"),
+      makeResult("c", "text-response"),
+    ];
+    assert.equal(resolveSelectedUuid(results, "a"), "a");
+    assert.equal(resolveSelectedUuid(results, "b"), "b");
+    assert.equal(resolveSelectedUuid(results, "c"), "c");
+  });
+
+  it("ignores url uuid when it doesn't exist in the list", () => {
+    const results = [makeResult("a", "generateImage")];
+    assert.equal(resolveSelectedUuid(results, "missing"), "a");
+  });
+
+  it("ignores url uuid when null", () => {
+    const results = [makeResult("a", "generateImage")];
+    assert.equal(resolveSelectedUuid(results, null), "a");
+  });
+});
+
+describe("resolveSelectedUuid — heuristic (last non-text)", () => {
+  it("picks the last non-text result when no url override", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("img-1", "generateImage"),
+      makeResult("text-2", "text-response"),
+      makeResult("img-2", "generateImage"),
+      makeResult("text-3", "text-response"),
+    ];
+    // The last non-text is img-2
+    assert.equal(resolveSelectedUuid(results, null), "img-2");
+  });
+
+  it("picks a non-text result even at the end of the list", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("img-1", "generateImage"),
+    ];
+    assert.equal(resolveSelectedUuid(results, null), "img-1");
+  });
+
+  it("falls back to the last text result when all results are text", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("text-2", "text-response"),
+    ];
+    assert.equal(resolveSelectedUuid(results, null), "text-2");
+  });
+
+  it("returns the only result regardless of type", () => {
+    assert.equal(
+      resolveSelectedUuid([makeResult("only", "text-response")], null),
+      "only",
+    );
+  });
+});
+
+// --- resolveSessionTimestamps -------------------------------------
+
+describe("resolveSessionTimestamps", () => {
+  const now = "2026-04-13T10:00:00.000Z";
+
+  it("uses server summary timestamps when available", () => {
+    const summary = {
+      id: "s",
+      roleId: "g",
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+      preview: "",
+    } as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to now when summary is undefined", () => {
+    assert.deepEqual(resolveSessionTimestamps(undefined, now), {
+      startedAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it("falls back updatedAt to startedAt when summary lacks updatedAt", () => {
+    // The SessionSummary interface requires updatedAt, but defensive
+    // programming: if it's missing at runtime (corrupt persistence),
+    // prefer startedAt over the current clock — the session's
+    // sidebar position should stay stable rather than jumping to
+    // "just updated".
+    const summary = {
+      id: "s",
+      roleId: "g",
+      startedAt: "2026-04-10T10:00:00.000Z",
+      preview: "",
+    } as unknown as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to now when summary lacks both timestamps (pathological)", () => {
+    const summary = {
+      id: "s",
+      roleId: "g",
+      preview: "",
+    } as unknown as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: now,
+      updatedAt: now,
+    });
+  });
+});


### PR DESCRIPTION
Second of six cognitive-complexity follow-ups tracked in #175. Plan: \`plans/refactor-vue-cognitive-complexity.md\`.

\`sendMessage\` was the highest-risk of the remaining \`.vue\` CC targets — 47 points of complexity carrying the entire chat-send flow in one 164-line function. Abort controller lifetime, request body assembly, SSE parsing, per-event dispatch, error routing, and finally-block cleanup all intermingled. The threat model for a function this complex: unhandled branch + state-mutation race across \`await\` + leaked AbortController across an early \`return\` — plausibly all three.

## Before / after

\`\`\`
Before:
  CC 47, 164 lines, 8 inline event-dispatch branches,
  inline pluginPrompts filter + SSE JSON parse + reverse-slice-find

After:
  CC < 15, linear narrative:
    1. Validate input + session
    2. beginUserTurn
    3. Resolve role + selected result
    4. Build event context
    5. try { fetch → check → stream } catch { report } finally { reset }
\`\`\`

## New pure modules (src/utils/agent/)

### \`request.ts\` — request-body construction

\`\`\`ts
export function buildPluginPromptsMap(availablePlugins, getPluginSystemPrompt): Record<string, string>
export function buildAgentRequestBody(params): AgentRequestBody
\`\`\`

Formerly the inline \`Object.fromEntries(...filter((entry): entry is [string, string] => ...))\` pluginPrompts pipeline plus the adjacent request-body object literal.

### \`sse.ts\` — Server-Sent-Event parsing

\`\`\`ts
export function parseSSEChunk(buffer, chunkText): { events, remaining }
export function decodeSSELine(line): SseEvent | null
\`\`\`

Splits the SSE byte stream into events and returns the unparseable trailing partial-line for the next call. Tightens shape validation — rejects non-object JSON payloads and unknown \`type\` discriminators so the downstream dispatcher can trust its input.

### \`toolCalls.ts\` — tool-call history + selection heuristic

\`\`\`ts
export function findPendingToolCall(history, toolUseId): ToolCallHistoryItem | undefined
export function shouldSelectAssistantText(toolResults, runStartIndex): boolean
\`\`\`

Replaces the inline \`slice().reverse().find(predicate)\` pattern (which buried a subtle race-correctness property inside a closure) and the \`.slice(runStartIndex).some(...)\` selection heuristic. Both now have named contracts and edge-case tests.

## In-file helpers promoted to module scope (still in App.vue)

These can't be extracted (they use Vue setup-scope refs / imports with Vue-specific binding) but they CAN be hoisted out of \`sendMessage\` to shed cognitive-complexity from the parent:

| Helper | Role |
|---|---|
| \`beginUserTurn\` | seed session state for a fresh user turn, return \`runStartIndex\` |
| \`checkAgentResponseOk\` | HTTP 200 + body check with error reporting |
| \`applyAgentEvent\` | 8-way SSE dispatch switch, takes an \`AgentEventContext\` with callbacks so it stays a plain named function |
| \`streamAgentEvents\` | reader loop + decode + dispatch |
| \`reportAgentError\` | catch-clause logic (abort-swallow + pushErrorMessage) |

## Tests — 53 new cases

All in the new \`test/utils/agent/\` directory:

- **\`test_sse.ts\`** (18): \`decodeSSELine\` happy path + 8 rejection modes (non-data line, blank, no-space-after-colon, malformed JSON, non-object payload, missing type, unknown type); \`parseSSEChunk\` buffer management including byte-by-byte feed simulation.

- **\`test_request.ts\`** (12): \`buildPluginPromptsMap\` (empty, full, missing, empty-string, order preservation, duplicate keys, throwing lookup contract); \`buildAgentRequestBody\` (full happy path, optional image, no-plugins role, empty message, role.id pass-through, systemPrompt verbatim).

- **\`test_toolCalls.ts\`** (23): \`findPendingToolCall\` (empty / no match / basic match / skip resolved / skip errored / pending-vs-resolved / reverse scan / mix of ids); \`shouldSelectAssistantText\` (empty tail / all text / plugin after text / plugin before text / lone plugin / runStartIndex at end / past-end defensive).

Tests: 885 → **938** (+53).

## Behaviour — zero intended change

Two semantic tightenings documented in commit message but behaviour-preserving in practice:

1. SSE decoder now rejects non-object JSON payloads and unknown \`type\` values. The previous dispatcher's if-chain already silently ignored those cases — output identical.
2. \`data:\` without trailing space is rejected. The server never emits that shape.

No call sites outside \`App.vue\` need updating.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` — 0 errors, 13 warnings (all pre-existing non-App.vue files)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — 938/938 pass (was 885, +53 new)
- [ ] Manual: send a chat message, verify text responses + tool results + status updates all still render
- [ ] Manual: abort an in-flight message mid-stream, verify no error toast (intentional)
- [ ] Manual: trigger a server 500, verify error message appears
- [ ] Manual: switch role mid-stream via a \`switch_role\` event, verify role changes after tick

## What's left from #175 after this PR

CC warnings in \`.vue\` drop from 5 to 4:

  spreadsheet/View.vue:597  CC 163  handleTableClick (monster, last)
  spreadsheet/View.vue:788  CC 30   watch callback
  spreadsheet/View.vue:510  CC 20   saveMiniEditor
  spreadsheet/View.vue:215  CC 23   (appeared after main's changes)
  presentMulmoScript/View.vue:1035  CC 18  generateMovie

Plan's recommended next: \`generateMovie\` (warm-up, just over threshold).

Refs #175, #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for attaching/selecting image data when sending messages.

* **Bug Fixes**
  * Improved user-visible error reporting for agent/message failures.

* **Refactor**
  * More reliable session history and sidebar ordering, plus improved session restore behavior.
  * Robust server-event streaming and agent response handling for steadier message delivery.
  * Cleaner plugin prompt handling and more reliable tool-call resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->