### PR TITLE
refactor(app): extract session-merge + load-session helpers (App.vue -52 lines)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -502,14 +502,8 @@ import {
   type SessionSummary,
   type SessionEntry,
   type ActiveSession,
-  isTextEntry,
-  isToolResultEntry,
 } from "./types/session";
-import {
-  isUserTextResponse,
-  extractImageData,
-  makeTextResult,
-} from "./utils/tools/result";
+import { extractImageData, makeTextResult } from "./utils/tools/result";
 import {
   roleIcon as roleIconLookup,
   roleName as roleNameLookup,
@@ -522,6 +516,12 @@ import {
   findPendingToolCall,
   shouldSelectAssistantText,
 } from "./utils/agent/toolCalls";
+import { mergeSessionLists } from "./utils/session/mergeSessions";
+import {
+  parseSessionEntries,
+  resolveSelectedUuid,
+  resolveSessionTimestamps,
+} from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
@@ -758,36 +758,9 @@ const selectedResult = computed(
 // the sidebar, not regress to the raw first user message. Without
 // this merge, opening an indexed session immediately clobbered its
 // sidebar row with the first-user-message preview.
-const mergedSessions = computed((): SessionSummary[] => {
-  const liveIds = new Set(sessionMap.keys());
-  const serverById = new Map<string, SessionSummary>(
-    sessions.value.map((s) => [s.id, s]),
-  );
-  const liveSummaries: SessionSummary[] = [...sessionMap.values()].map((s) => {
-    const firstUserMsg = s.toolResults.find(isUserTextResponse);
-    const serverEntry = serverById.get(s.id);
-    return {
-      id: s.id,
-      roleId: s.roleId,
-      startedAt: s.startedAt,
-      updatedAt: s.updatedAt,
-      preview: serverEntry?.preview || (firstUserMsg?.message ?? ""),
-      ...(serverEntry?.summary !== undefined && {
-        summary: serverEntry.summary,
-      }),
-      ...(serverEntry?.keywords !== undefined && {
-        keywords: serverEntry.keywords,
-      }),
-    };
-  });
-  const serverOnly = sessions.value.filter((s) => !liveIds.has(s.id));
-  return [...liveSummaries, ...serverOnly].sort((a, b) => {
-    const byUpdated =
-      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-    if (byUpdated !== 0) return byUpdated;
-    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime();
-  });
-});
+const mergedSessions = computed((): SessionSummary[] =>
+  mergeSessionLists([...sessionMap.values()], sessions.value),
+);
 
 const tabSessions = computed(() => mergedSessions.value.slice(0, 6));
 
@@ -1050,40 +1023,15 @@ async function loadSession(id: string) {
 
   const meta = entries.find((e) => e.type === "session_meta");
   const roleId = meta?.roleId ?? currentRoleId.value;
-
-  const toolResultsList: ToolResultComplete[] = [];
-  for (const entry of entries) {
-    if (entry.type === "session_meta") continue;
-    if (isTextEntry(entry)) {
-      toolResultsList.push(makeTextResult(entry.message, entry.source));
-    } else if (isToolResultEntry(entry)) {
-      toolResultsList.push(entry.result);
-    }
-  }
-
-  // If the URL specifies ?result=, prefer it over the heuristic
-  // (which picks the last non-text tool result). This lets bookmarks
-  // restore the exact result the user was looking at.
+  const toolResultsList = parseSessionEntries(entries);
   const urlResult =
     typeof route.query.result === "string" ? route.query.result : null;
-  const lastTool = [...toolResultsList]
-    .reverse()
-    .find((r) => r.toolName !== "text-response");
-  const heuristicUuid =
-    lastTool?.uuid ?? toolResultsList[toolResultsList.length - 1]?.uuid ?? null;
-  const resolvedSelectedUuid =
-    urlResult && toolResultsList.some((r) => r.uuid === urlResult)
-      ? urlResult
-      : heuristicUuid;
-
+  const resolvedSelectedUuid = resolveSelectedUuid(toolResultsList, urlResult);
   const serverSummary = sessions.value.find((s) => s.id === id);
-  const nowIso = new Date().toISOString();
-  const originalStartedAt = serverSummary?.startedAt ?? nowIso;
-  // Prefer the server's mtime-derived updatedAt so the loaded
-  // session keeps its place in the most-recently-touched sort;
-  // fall back to startedAt or now if the server summary is absent.
-  const originalUpdatedAt =
-    serverSummary?.updatedAt ?? originalStartedAt ?? nowIso;
+  const { startedAt, updatedAt } = resolveSessionTimestamps(
+    serverSummary,
+    new Date().toISOString(),
+  );
 
   sessionMap.set(id, {
     id,
@@ -1095,8 +1043,8 @@ async function loadSession(id: string) {
     selectedResultUuid: resolvedSelectedUuid,
     hasUnread: false,
     abortController: markRaw(new AbortController()),
-    startedAt: originalStartedAt,
-    updatedAt: originalUpdatedAt,
+    startedAt,
+    updatedAt,
   });
   navigateToSession(id, replaced);
   currentRoleId.value = roleId;

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -1,0 +1,76 @@
+// Pure helper: merge the two views of "sessions" that the sidebar
+// history pane shows — live in-memory sessions (from `sessionMap`)
+// and server-persisted summaries (from `/api/sessions`). Extracted
+// from `src/App.vue` as part of the cognitive-complexity refactor
+// tracked in #175.
+//
+// The merge is deterministic given the inputs: the test suite pins
+// every edge case we've hit (live-only, server-only, overlap,
+// server-side AI title vs local first-user-message, sort tie-breaks).
+
+import { isUserTextResponse } from "../tools/result";
+import type { SessionSummary, ActiveSession } from "../../types/session";
+
+// Build the summary shape the sidebar expects for a single live
+// session. Server-side data (AI-generated title, summary,
+// keywords) takes precedence over the local first-user-message
+// heuristic — otherwise opening an indexed session in a new tab
+// would regress the sidebar row to the raw first message.
+function buildLiveSummary(
+  live: ActiveSession,
+  serverEntry: SessionSummary | undefined,
+): SessionSummary {
+  const firstUserMsg = live.toolResults.find(isUserTextResponse);
+  const preview = serverEntry?.preview || (firstUserMsg?.message ?? "");
+  const base: SessionSummary = {
+    id: live.id,
+    roleId: live.roleId,
+    startedAt: live.startedAt,
+    updatedAt: live.updatedAt,
+    preview,
+  };
+  // Carry summary / keywords ONLY if the server already has them.
+  // Object-spread with a conditional object keeps us from adding
+  // `undefined` values that would otherwise show up as explicit
+  // `summary: undefined` in a later shallow-copy.
+  return {
+    ...base,
+    ...(serverEntry?.summary !== undefined && { summary: serverEntry.summary }),
+    ...(serverEntry?.keywords !== undefined && {
+      keywords: serverEntry.keywords,
+    }),
+  };
+}
+
+// Compare two summaries for sort order. Newest `updatedAt` wins;
+// if updatedAt ties (same second-granularity mtime on two
+// server-only rows, say), fall back to `startedAt`. Exported so
+// tests can exercise the tie-break directly.
+export function compareSessionsByRecency(
+  a: SessionSummary,
+  b: SessionSummary,
+): number {
+  const byUpdated = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+  if (byUpdated !== 0) return byUpdated;
+  return Date.parse(b.startedAt) - Date.parse(a.startedAt);
+}
+
+// Merge live sessions (in-memory, still editable) with server
+// summaries (from /api/sessions). Live sessions always win for
+// the same id — we prefer the local state we know is current —
+// but pull over the server's AI title / summary / keywords when
+// present. Pure, returns a new array; does not mutate inputs.
+export function mergeSessionLists(
+  liveSessions: readonly ActiveSession[],
+  serverSessions: readonly SessionSummary[],
+): SessionSummary[] {
+  const liveIds = new Set(liveSessions.map((s) => s.id));
+  const serverById = new Map<string, SessionSummary>(
+    serverSessions.map((s) => [s.id, s]),
+  );
+  const liveSummaries = liveSessions.map((live) =>
+    buildLiveSummary(live, serverById.get(live.id)),
+  );
+  const serverOnly = serverSessions.filter((s) => !liveIds.has(s.id));
+  return [...liveSummaries, ...serverOnly].sort(compareSessionsByRecency);
+}

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -1,0 +1,83 @@
+// Pure helpers for reconstructing an `ActiveSession`'s runtime
+// shape from the `/api/sessions/:id` JSONL payload. Extracted from
+// `src/App.vue#loadSession` so the parse / select / timestamp-
+// resolution logic is unit-testable without mocking `fetch`.
+//
+// Tracks #175.
+
+import { makeTextResult } from "../tools/result";
+import {
+  isTextEntry,
+  isToolResultEntry,
+  type SessionEntry,
+  type SessionSummary,
+} from "../../types/session";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// Walk the server's session entries and produce the flat
+// `toolResults` array the client keeps in `ActiveSession`. Drops
+// `session_meta` rows (they're metadata, not a result), converts
+// text entries into tool-result-shaped envelopes via
+// `makeTextResult`, and passes tool_result entries through verbatim.
+export function parseSessionEntries(
+  entries: readonly SessionEntry[],
+): ToolResultComplete[] {
+  const out: ToolResultComplete[] = [];
+  for (const entry of entries) {
+    if (entry.type === "session_meta") continue;
+    if (isTextEntry(entry)) {
+      out.push(makeTextResult(entry.message, entry.source));
+    } else if (isToolResultEntry(entry)) {
+      out.push(entry.result);
+    }
+  }
+  return out;
+}
+
+// Pick the `selectedResultUuid` the session should restore to.
+// Rules:
+//   1. If the URL carries `?result=<uuid>` AND that uuid actually
+//      exists in the loaded list, honour it verbatim. This lets
+//      bookmarks restore the exact result the user was viewing.
+//   2. Otherwise fall back to the heuristic: the most recent
+//      non-text tool result (images, wiki pages, etc. carry more
+//      visual information than bare text).
+//   3. If there are no non-text results, use the last result of
+//      any kind.
+//   4. If the list is empty, return null.
+export function resolveSelectedUuid(
+  toolResults: readonly ToolResultComplete[],
+  urlResult: string | null,
+): string | null {
+  if (urlResult && toolResults.some((r) => r.uuid === urlResult)) {
+    return urlResult;
+  }
+  // Iterate backwards for the "last non-text" lookup so callers
+  // don't pay for an intermediate reverse copy.
+  for (let i = toolResults.length - 1; i >= 0; i--) {
+    if (toolResults[i].toolName !== "text-response") {
+      return toolResults[i].uuid;
+    }
+  }
+  const last = toolResults[toolResults.length - 1];
+  return last?.uuid ?? null;
+}
+
+// Decide the `startedAt` / `updatedAt` to seed the in-memory
+// ActiveSession with. We prefer the server summary's timestamps
+// so the restored session keeps its existing sidebar ordering;
+// we fall through to the current clock only if the server
+// summary is missing (e.g. freshly-created session that hasn't
+// round-tripped through `/api/sessions` yet).
+//
+// Keeping this logic named lets the test suite pin the
+// "updatedAt missing → fall back to startedAt" rule explicitly,
+// which was previously a fragile `??` chain buried in loadSession.
+export function resolveSessionTimestamps(
+  serverSummary: SessionSummary | undefined,
+  nowIso: string,
+): { startedAt: string; updatedAt: string } {
+  const startedAt = serverSummary?.startedAt ?? nowIso;
+  const updatedAt = serverSummary?.updatedAt ?? startedAt;
+  return { startedAt, updatedAt };
+}

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -1,0 +1,254 @@
+// Unit tests for `mergeSessionLists` + `compareSessionsByRecency`.
+// Extracted from `src/App.vue`'s `mergedSessions` computed — see
+// plans/refactor-vue-cognitive-complexity.md and issue #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mergeSessionLists,
+  compareSessionsByRecency,
+} from "../../../src/utils/session/mergeSessions.js";
+import type {
+  ActiveSession,
+  SessionSummary,
+} from "../../../src/types/session.js";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+function makeActive(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    id: "live-1",
+    roleId: "general",
+    toolResults: [],
+    isRunning: false,
+    statusMessage: "",
+    toolCallHistory: [],
+    selectedResultUuid: null,
+    hasUnread: false,
+    abortController: new AbortController(),
+    startedAt: "2026-04-10T10:00:00.000Z",
+    updatedAt: "2026-04-10T10:05:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: "srv-1",
+    roleId: "general",
+    startedAt: "2026-04-09T10:00:00.000Z",
+    updatedAt: "2026-04-09T10:05:00.000Z",
+    preview: "first user message",
+    ...overrides,
+  };
+}
+
+function makeUserTextResult(message: string): ToolResultComplete {
+  // Matches what `makeTextResult(message, "user")` produces.
+  // `message` lives at the top level (that's what the sidebar
+  // preview reads) AND on `data` alongside the `role: "user"`
+  // discriminator that `isUserTextResponse` keys off.
+  return {
+    uuid: `u-${message}`,
+    toolName: "text-response",
+    message,
+    data: { role: "user", message },
+  } as unknown as ToolResultComplete;
+}
+
+describe("compareSessionsByRecency", () => {
+  it("returns negative when a is more recently updated", () => {
+    const a = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    const b = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(a, b) < 0);
+  });
+
+  it("returns positive when b is more recently updated", () => {
+    const a = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    const b = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(a, b) > 0);
+  });
+
+  it("falls back to startedAt on updatedAt tie", () => {
+    const a = makeSummary({
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-08T10:00:00.000Z",
+    });
+    const b = makeSummary({
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-09T10:00:00.000Z",
+    });
+    // b has newer startedAt, so b should come first
+    assert.ok(compareSessionsByRecency(a, b) > 0);
+  });
+
+  it("returns 0 when both updatedAt and startedAt match", () => {
+    const a = makeSummary({ id: "a" });
+    const b = makeSummary({ id: "b" });
+    assert.equal(compareSessionsByRecency(a, b), 0);
+  });
+});
+
+describe("mergeSessionLists — basic cases", () => {
+  it("returns empty array when both inputs are empty", () => {
+    assert.deepEqual(mergeSessionLists([], []), []);
+  });
+
+  it("returns only the server summary when there are no live sessions", () => {
+    const summary = makeSummary({ id: "srv-1" });
+    assert.deepEqual(mergeSessionLists([], [summary]), [summary]);
+  });
+
+  it("returns the live summary when there are no server entries", () => {
+    const live = makeActive({
+      id: "live-1",
+      toolResults: [makeUserTextResult("hello")],
+    });
+    const result = mergeSessionLists([live], []);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "live-1");
+    assert.equal(result[0].preview, "hello");
+    assert.equal(result[0].summary, undefined);
+    assert.equal(result[0].keywords, undefined);
+  });
+});
+
+describe("mergeSessionLists — live + server overlap", () => {
+  it("live wins when a session appears on both sides", () => {
+    const live = makeActive({
+      id: "both",
+      updatedAt: "2026-04-12T10:00:00.000Z",
+      toolResults: [makeUserTextResult("live message")],
+    });
+    const server = makeSummary({
+      id: "both",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+      preview: "server preview",
+    });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result.length, 1, "session should not be duplicated");
+    assert.equal(result[0].id, "both");
+    // Server preview wins over first-user-message heuristic — the
+    // AI-generated title is more informative
+    assert.equal(result[0].preview, "server preview");
+    // updatedAt comes from the live side (it's the fresher source)
+    assert.equal(result[0].updatedAt, "2026-04-12T10:00:00.000Z");
+  });
+
+  it("carries over server summary + keywords to the live entry", () => {
+    const live = makeActive({ id: "both" });
+    const server = makeSummary({
+      id: "both",
+      preview: "Plan a project",
+      summary: "User wants help planning.",
+      keywords: ["plan", "project"],
+    });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "Plan a project");
+    assert.equal(result[0].summary, "User wants help planning.");
+    assert.deepEqual(result[0].keywords, ["plan", "project"]);
+  });
+
+  it("falls back to first-user-message when server preview is empty", () => {
+    const live = makeActive({
+      id: "both",
+      toolResults: [makeUserTextResult("hello from live")],
+    });
+    const server = makeSummary({ id: "both", preview: "" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "hello from live");
+  });
+
+  it("uses empty preview when neither server nor live has text", () => {
+    const live = makeActive({ id: "both", toolResults: [] });
+    const server = makeSummary({ id: "both", preview: "" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result[0].preview, "");
+  });
+});
+
+describe("mergeSessionLists — server-only entries", () => {
+  it("includes server-only entries untouched", () => {
+    const live = makeActive({ id: "live-only" });
+    const server = makeSummary({ id: "srv-only" });
+    const result = mergeSessionLists([live], [server]);
+    const serverEntry = result.find((s) => s.id === "srv-only");
+    assert.equal(serverEntry, server);
+  });
+
+  it("dedupes: a server entry with matching live id does not duplicate", () => {
+    const live = makeActive({ id: "shared" });
+    const server = makeSummary({ id: "shared" });
+    const result = mergeSessionLists([live], [server]);
+    assert.equal(result.length, 1);
+  });
+});
+
+describe("mergeSessionLists — sort order", () => {
+  it("sorts by updatedAt descending (most recent first)", () => {
+    const recent = makeSummary({
+      id: "recent",
+      updatedAt: "2026-04-12T10:00:00.000Z",
+    });
+    const older = makeSummary({
+      id: "older",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    });
+    const result = mergeSessionLists([], [older, recent]);
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["recent", "older"],
+    );
+  });
+
+  it("mixes live and server-only entries in the same sort", () => {
+    const live = makeActive({
+      id: "live",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+    const server = makeSummary({
+      id: "srv",
+      updatedAt: "2026-04-12T00:00:00.000Z",
+    });
+    const result = mergeSessionLists([live], [server]);
+    // srv is newer → comes first
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["srv", "live"],
+    );
+  });
+
+  it("breaks updatedAt ties with startedAt", () => {
+    const a = makeSummary({
+      id: "a",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-08T10:00:00.000Z",
+    });
+    const b = makeSummary({
+      id: "b",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+      startedAt: "2026-04-09T10:00:00.000Z",
+    });
+    const result = mergeSessionLists([], [a, b]);
+    // b has newer startedAt → b first
+    assert.deepEqual(
+      result.map((s) => s.id),
+      ["b", "a"],
+    );
+  });
+});
+
+describe("mergeSessionLists — does not mutate inputs", () => {
+  it("returns a new array without modifying the live list", () => {
+    const live = [makeActive({ id: "a" }), makeActive({ id: "b" })];
+    const liveSnapshot = live.slice();
+    mergeSessionLists(live, []);
+    assert.deepEqual(live, liveSnapshot);
+  });
+
+  it("returns a new array without modifying the server list", () => {
+    const server = [makeSummary({ id: "a" }), makeSummary({ id: "b" })];
+    const snapshot = server.slice();
+    mergeSessionLists([], server);
+    assert.deepEqual(server, snapshot);
+  });
+});

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -1,0 +1,242 @@
+// Unit tests for the pure helpers extracted from
+// `src/App.vue#loadSession`. Tracks #175.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseSessionEntries,
+  resolveSelectedUuid,
+  resolveSessionTimestamps,
+} from "../../../src/utils/session/sessionEntries.js";
+import type {
+  SessionEntry,
+  SessionSummary,
+} from "../../../src/types/session.js";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// --- parseSessionEntries ------------------------------------------
+
+describe("parseSessionEntries", () => {
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parseSessionEntries([]), []);
+  });
+
+  it("skips session_meta entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        type: "session_meta",
+        roleId: "general",
+      } as SessionEntry,
+    ];
+    assert.deepEqual(parseSessionEntries(entries), []);
+  });
+
+  it("converts user text entries into tool-result envelopes", () => {
+    const entries: SessionEntry[] = [
+      {
+        source: "user",
+        type: "text",
+        message: "hello",
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].toolName, "text-response");
+  });
+
+  it("converts assistant text entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        source: "assistant",
+        type: "text",
+        message: "ok",
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].toolName, "text-response");
+  });
+
+  it("passes tool_result entries through verbatim", () => {
+    const toolResult = {
+      uuid: "r1",
+      toolName: "generateImage",
+    } as unknown as ToolResultComplete;
+    const entries: SessionEntry[] = [
+      {
+        source: "tool",
+        type: "tool_result",
+        result: toolResult,
+      },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+    assert.equal(out[0], toolResult);
+  });
+
+  it("preserves ordering across a mixed feed", () => {
+    const toolResult = {
+      uuid: "tool-1",
+      toolName: "generateImage",
+    } as unknown as ToolResultComplete;
+    const entries: SessionEntry[] = [
+      { source: "user", type: "text", message: "make an image" },
+      { source: "tool", type: "tool_result", result: toolResult },
+      { source: "assistant", type: "text", message: "done" },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 3);
+    assert.equal(out[0].toolName, "text-response");
+    assert.equal(out[1], toolResult);
+    assert.equal(out[2].toolName, "text-response");
+  });
+
+  it("skips entries that are neither text nor tool_result", () => {
+    const entries = [
+      { source: "unknown", type: "unknown-kind", message: "x" },
+    ] as unknown as SessionEntry[];
+    assert.deepEqual(parseSessionEntries(entries), []);
+  });
+
+  it("tolerates session_meta mixed with real entries", () => {
+    const entries: SessionEntry[] = [
+      {
+        type: "session_meta",
+        roleId: "general",
+      } as SessionEntry,
+      { source: "user", type: "text", message: "hi" },
+    ];
+    const out = parseSessionEntries(entries);
+    assert.equal(out.length, 1);
+  });
+});
+
+// --- resolveSelectedUuid ------------------------------------------
+
+function makeResult(uuid: string, toolName: string): ToolResultComplete {
+  return { uuid, toolName } as unknown as ToolResultComplete;
+}
+
+describe("resolveSelectedUuid — empty list", () => {
+  it("returns null for empty list regardless of urlResult", () => {
+    assert.equal(resolveSelectedUuid([], null), null);
+    assert.equal(resolveSelectedUuid([], "any"), null);
+  });
+});
+
+describe("resolveSelectedUuid — URL override", () => {
+  it("honours url-specified uuid when it exists in the list", () => {
+    const results = [
+      makeResult("a", "text-response"),
+      makeResult("b", "generateImage"),
+      makeResult("c", "text-response"),
+    ];
+    assert.equal(resolveSelectedUuid(results, "a"), "a");
+    assert.equal(resolveSelectedUuid(results, "b"), "b");
+    assert.equal(resolveSelectedUuid(results, "c"), "c");
+  });
+
+  it("ignores url uuid when it doesn't exist in the list", () => {
+    const results = [makeResult("a", "generateImage")];
+    assert.equal(resolveSelectedUuid(results, "missing"), "a");
+  });
+
+  it("ignores url uuid when null", () => {
+    const results = [makeResult("a", "generateImage")];
+    assert.equal(resolveSelectedUuid(results, null), "a");
+  });
+});
+
+describe("resolveSelectedUuid — heuristic (last non-text)", () => {
+  it("picks the last non-text result when no url override", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("img-1", "generateImage"),
+      makeResult("text-2", "text-response"),
+      makeResult("img-2", "generateImage"),
+      makeResult("text-3", "text-response"),
+    ];
+    // The last non-text is img-2
+    assert.equal(resolveSelectedUuid(results, null), "img-2");
+  });
+
+  it("picks a non-text result even at the end of the list", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("img-1", "generateImage"),
+    ];
+    assert.equal(resolveSelectedUuid(results, null), "img-1");
+  });
+
+  it("falls back to the last text result when all results are text", () => {
+    const results = [
+      makeResult("text-1", "text-response"),
+      makeResult("text-2", "text-response"),
+    ];
+    assert.equal(resolveSelectedUuid(results, null), "text-2");
+  });
+
+  it("returns the only result regardless of type", () => {
+    assert.equal(
+      resolveSelectedUuid([makeResult("only", "text-response")], null),
+      "only",
+    );
+  });
+});
+
+// --- resolveSessionTimestamps -------------------------------------
+
+describe("resolveSessionTimestamps", () => {
+  const now = "2026-04-13T10:00:00.000Z";
+
+  it("uses server summary timestamps when available", () => {
+    const summary = {
+      id: "s",
+      roleId: "g",
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+      preview: "",
+    } as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-11T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to now when summary is undefined", () => {
+    assert.deepEqual(resolveSessionTimestamps(undefined, now), {
+      startedAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it("falls back updatedAt to startedAt when summary lacks updatedAt", () => {
+    // The SessionSummary interface requires updatedAt, but defensive
+    // programming: if it's missing at runtime (corrupt persistence),
+    // prefer startedAt over the current clock — the session's
+    // sidebar position should stay stable rather than jumping to
+    // "just updated".
+    const summary = {
+      id: "s",
+      roleId: "g",
+      startedAt: "2026-04-10T10:00:00.000Z",
+      preview: "",
+    } as unknown as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: "2026-04-10T10:00:00.000Z",
+      updatedAt: "2026-04-10T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to now when summary lacks both timestamps (pathological)", () => {
+    const summary = {
+      id: "s",
+      roleId: "g",
+      preview: "",
+    } as unknown as SessionSummary;
+    assert.deepEqual(resolveSessionTimestamps(summary, now), {
+      startedAt: now,
+      updatedAt: now,
+    });
+  });
+});


### PR DESCRIPTION
Stacks on **#177**. Targets \`refactor/send-message-cognitive-complexity\` as base so the diff shows only this PR's changes.

Third size / cognitive-complexity follow-up on \`src/App.vue\`. Pulls two more pieces of pure logic out into named, tested modules.

## What moved

### \`src/utils/session/mergeSessions.ts\`

\`\`\`ts
export function mergeSessionLists(liveSessions, serverSessions): SessionSummary[]
export function compareSessionsByRecency(a, b): number
\`\`\`

Replaces the body of the \`mergedSessions\` computed — 30 lines of Map building + first-user-message heuristic + server-preview override + newest-first sort with \`startedAt\` tie-break. The merge rule ("live wins for same id, but inherit server-side AI title / summary / keywords when present") is now a documented function contract rather than a buried property of one computed.

### \`src/utils/session/sessionEntries.ts\`

\`\`\`ts
export function parseSessionEntries(entries): ToolResultComplete[]
export function resolveSelectedUuid(toolResults, urlResult): string | null
export function resolveSessionTimestamps(serverSummary, nowIso): { startedAt, updatedAt }
\`\`\`

Takes the pure pieces of \`loadSession\`:
- jsonl → toolResults conversion (session_meta filter + \`makeTextResult\` wrap + tool_result passthrough)
- selected-uuid resolution (URL override > last non-text heuristic > last result > null)
- \`startedAt\` / \`updatedAt\` resolution (defensive rule: \`updatedAt\` falls back to \`startedAt\` when missing — previously buried in a fragile \`??\` chain)

## App.vue wiring

- \`mergedSessions\` computed body replaced with a single \`mergeSessionLists([...sessionMap.values()], sessions.value)\` call.
- \`loadSession\` no longer handles parsing / selection / timestamp logic inline — three helper calls in sequence. The function now reads linearly: fetch → parse → resolve-select → resolve-timestamps → set → navigate.
- Dropped imports that became dead: \`isTextEntry\`, \`isToolResultEntry\`, \`isUserTextResponse\`.

**Total**: \`src/App.vue\` 1399 → **1347** lines (-52).

## Tests — 38 new cases

### \`test_mergeSessions.ts\` (14)

\`compareSessionsByRecency\`: updatedAt desc / tie-break / equal.

\`mergeSessionLists\`: empty / server-only / live-only / overlap with live-wins / carries server summary+keywords / falls back to first-user-message when server preview empty / empty preview when neither source has text / server-only entries pass through untouched / dedup on id / sort order incl. mixed live+server / startedAt tie-break / input immutability (live) / input immutability (server).

### \`test_sessionEntries.ts\` (24)

\`parseSessionEntries\`: empty / session_meta skip / user+assistant text / tool_result passthrough / mixed order / unknown kind / meta+real mix.

\`resolveSelectedUuid\`: empty / url honoured (3 targets) / missing url uuid / null url / last-non-text heuristic / last-non-text at end / all-text fallback / single-result.

\`resolveSessionTimestamps\`: full summary / undefined summary / summary lacks updatedAt → fall back to \`startedAt\` / summary lacks both → now fallback.

Tests: 948 → **986** (+38).

## Dependency note

Stacks on #177 (sendMessage refactor). Both PRs touch App.vue's import list but no other lines overlap. If #177 merges first this PR rebases cleanly; if this merges first #177 needs a trivial import-list merge.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` — 0 errors, 13 warnings (all pre-existing)
- [x] \`yarn typecheck\` clean
- [x] \`yarn build\` clean
- [x] \`yarn test\` — 986/986 pass (was 948, +38)
- [ ] Manual: open history sidebar, verify live + server-only sessions render with correct titles / summaries / order
- [ ] Manual: load an existing session via sidebar, verify all tool_results + text render in order with the right one selected
- [ ] Manual: bookmarked URL with \`?result=<uuid>\` opens that exact result

Refs #175, #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)