### PR TITLE
feat(server): structured logger with console+file sinks (#91)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 .DS_Store
 *~*.tgz
 *~
+server/logs/
+test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 | `server/journal/` | Workspace journal (daily + optimization passes) |
 | `server/chat-index/` | Per-session summarizer + sidebar title cache |
 | `server/utils/` | Shared helpers: `fs.ts`, `errors.ts` |
+| `server/logger/` | Structured logger (console + rotating file + telemetry stub) |
 | `server/csrfGuard.ts` | CSRF origin-check middleware |
 | `src/config/roles.ts` | Role definitions |
 | `src/tools/index.ts` | Plugin registry |
@@ -237,6 +238,24 @@ e2e/
 - **Route order is reversed**: Playwright checks routes last-registered-first. Register catch-all FIRST, specific routes AFTER.
 - **URL predicate functions > globs**: `**/api/roles` doesn't reliably match `http://host/api/roles`. Use `(url) => url.pathname === "/api/roles"` instead.
 - **Hash vs history mode**: Tests that assert URL query params behave differently between hash mode (`/#/chat?view=x`) and history mode (`/chat?view=x`). Write tests against the rendered UI state rather than raw URL strings when possible.
+
+## Server Logging
+
+The server uses the structured logger at `server/logger/`. **Never call `console.*` directly outside that module** — import and use `log.{error,warn,info,debug}(prefix, msg, data?)` instead.
+
+```ts
+import { log } from "../logger/index.js";
+
+log.info("my-module", "did a thing", { count: 3 });
+log.error("my-module", "operation failed", { error: String(err) });
+```
+
+- `prefix` is lowercase, hyphenated, no brackets (the text formatter adds `[ ]`)
+- Put structured values in the `data` payload, not interpolated into `msg` — the JSON file format depends on it
+- Console default is `info`/`text`; file default is `debug`/`json` rotating daily under `server/logs/`
+- Full reference (env vars, formats, rotation, recipes): [`docs/logging.md`](docs/logging.md)
+
+The only remaining `console.*` call is `server/logger/sinks.ts`'s fallback path for when the file sink itself errors.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ If Docker is not installed, the app shows a warning banner and continues to work
 
 > **Debug mode**: To run without the sandbox even when Docker is installed, set `DISABLE_SANDBOX=1` before starting the server.
 
+## Logging
+
+The server writes readable text to the console and full-fidelity JSON
+to rotating daily files under `server/logs/`. Everything is
+configurable via `LOG_LEVEL`, `LOG_*_FORMAT`, `LOG_FILE_DIR`, etc.
+
+See [docs/logging.md](docs/logging.md) for the full reference, format
+examples, rotation behaviour, and recipes.
+
 ## Roles
 
 Each role gives Claude a different persona, tool palette, and focus area:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,188 @@
+# Server Logging
+
+The MulmoClaude server has a small, dependency-free structured logger at
+`server/logger/`. It writes to the console **and** to rotating files
+under `server/logs/` by default, with independent configuration for
+each sink.
+
+Format, level, destination, and retention are all configurable via
+environment variables — no code changes required to tune output for
+development, debugging, or deployment.
+
+## Defaults
+
+Out of the box:
+
+| Sink | Enabled | Level | Format | Destination |
+|---|---|---|---|---|
+| Console | yes | `info` | `text` | stdout (info/debug) + stderr (warn/error) |
+| File | yes | `debug` | `json` | `server/logs/server-YYYY-MM-DD.log` (14-day retention) |
+| Telemetry | no | `error` | `json` | *(stub, reserved for future)* |
+
+The console stays human-readable while the file captures every
+`debug`-level line as JSON Lines so you can `grep` / `jq` past
+incidents. `server/logs/` is git-ignored.
+
+## Formats
+
+### Text (`format: "text"`)
+
+```text
+2026-04-13T07:12:45.123Z INFO  [agent] request received sessionId=abc roleId=general messageLen=42
+2026-04-13T07:12:45.301Z ERROR [agent-stderr] claude: failed to resume stale session
+2026-04-13T07:12:45.812Z INFO  [agent] request completed sessionId=abc durationMs=512
+```
+
+Fields: `<ISO-timestamp> <PADDED-LEVEL> [<prefix>] <message> [k=v ...]`
+
+Strings with whitespace are auto-quoted; nested objects are serialized as JSON.
+
+### JSON (`format: "json"`)
+
+One JSON object per line (JSONL):
+
+```json
+{"ts":"2026-04-13T07:12:45.123Z","level":"info","prefix":"agent","message":"request received","data":{"sessionId":"abc","roleId":"general","messageLen":42}}
+```
+
+The `data` key is omitted when no structured payload was supplied.
+
+## Log levels
+
+`error` < `warn` < `info` < `debug` (lowest number = most severe).
+
+A sink writes a record only if the record's level is at-or-above the
+sink's configured threshold. So `level: "warn"` emits `error` and
+`warn` but drops `info` and `debug`.
+
+## Environment variables
+
+All are optional; omitted values fall back to the defaults table above.
+
+| Variable | Values | Applies to |
+|---|---|---|
+| `LOG_LEVEL` | `error` / `warn` / `info` / `debug` | **both** console + file (coarse knob) |
+| `LOG_CONSOLE_LEVEL` | same | console only (overrides `LOG_LEVEL`) |
+| `LOG_FILE_LEVEL` | same | file only (overrides `LOG_LEVEL`) |
+| `LOG_CONSOLE_FORMAT` | `text` / `json` | console |
+| `LOG_FILE_FORMAT` | `text` / `json` | file |
+| `LOG_CONSOLE_ENABLED` | `true` / `false` / `1` / `0` / `yes` / `no` | console |
+| `LOG_FILE_ENABLED` | same | file |
+| `LOG_FILE_DIR` | directory path | file sink output directory |
+| `LOG_FILE_MAX_FILES` | positive integer | rotation retention (default `14`) |
+| `LOG_TELEMETRY_ENABLED` | boolean | telemetry sink (currently a no-op stub) |
+| `LOG_TELEMETRY_LEVEL` | level | telemetry |
+| `LOG_TELEMETRY_FORMAT` | `text` / `json` | telemetry |
+
+Invalid values (e.g. `LOG_LEVEL=chatty`) are silently ignored — the
+logger falls back to the default for that knob rather than crashing
+on startup.
+
+## Rotation
+
+The file sink uses **daily rotation** keyed on UTC date:
+
+- Each day's records go to `server-YYYY-MM-DD.log` under `LOG_FILE_DIR`.
+- On rollover, the current file is closed and the oldest files beyond
+  `LOG_FILE_MAX_FILES` are deleted.
+- Retention is strictly name-based (our filenames are ISO-sortable),
+  so unrelated files in the log directory are never touched.
+- There is **no size-based rotation** — if a single day exceeds what
+  you expect, lower the log level or set `LOG_FILE_ENABLED=false` and
+  pipe stdout elsewhere.
+
+## Common recipes
+
+### Keep console quiet, preserve full history on disk
+
+```bash
+LOG_CONSOLE_LEVEL=warn yarn dev
+```
+
+Console shows only warnings/errors; the `server/logs/*.log` file still
+captures every `debug` line.
+
+### Console-only (no files)
+
+```bash
+LOG_FILE_ENABLED=false yarn dev
+```
+
+### File-only (silent console)
+
+```bash
+LOG_CONSOLE_ENABLED=false yarn dev
+```
+
+### Route logs to `/var/log/mulmoclaude`
+
+```bash
+LOG_FILE_DIR=/var/log/mulmoclaude LOG_FILE_MAX_FILES=30 yarn dev
+```
+
+### Ship JSON to stdout (e.g. for a log collector)
+
+```bash
+LOG_CONSOLE_FORMAT=json LOG_FILE_ENABLED=false yarn dev
+```
+
+### Debug a flaky session
+
+```bash
+LOG_LEVEL=debug yarn dev
+```
+
+## What is logged
+
+### Agent path (`server/agent.ts` + `server/routes/agent.ts`)
+
+- **Request received** — sessionId, chatSessionId, roleId, messageLen, whether the session is being resumed
+- **Claude CLI spawn** — roleId, useDocker, hasMcp, resumed, sessionId
+- **Claude CLI stderr** — streamed **line by line** as `error` records (so hung / failed CLI runs are visible in real time, not only on exit)
+- **Claude CLI exit** — exit code
+- **Request completed** — durationMs
+- **Request failed** — captured error
+
+### Other subsystems
+
+Each uses its own prefix so filtering is easy:
+
+- `[server]` — listen, unhandled error
+- `[workspace]` — initial setup
+- `[sandbox]` — Docker/container state, credential refresh
+- `[mcp]` — MCP tool availability
+- `[task-manager]` — task registration, ticks, failures
+- `[journal]` — daily + optimization passes
+- `[chat-index]` — session title/summary indexing
+- `[pdf]`, `[generate-beat-audio]` — route-specific
+
+## Extending
+
+### Adding a log call
+
+```ts
+import { log } from "./logger/index.js";
+
+log.info("my-module", "did a thing", { count: 3, name: "foo" });
+log.error("my-module", "operation failed", { error: String(err) });
+```
+
+- `prefix` conventions: lowercase, hyphenated, no brackets — the text
+  formatter adds `[ ]` itself.
+- `data` payload keys should be scalar when possible so the text
+  format renders cleanly; nested objects are JSON-serialized.
+- Never call `console.*` directly outside `server/logger/`.
+
+### Adding a new sink
+
+Implement the `Sink` interface from `server/logger/types.ts`, then
+wire it into `createLogger` in `server/logger/index.ts`. A sink's
+`write` **must not throw** — errors should be caught and logged out
+of band (see `createFileSink`'s `onError` callback for the pattern).
+
+### Enabling telemetry (future)
+
+The `TelemetrySink` is currently a no-op stub. When a transport is
+added, it will be driven by the same `LOG_TELEMETRY_*` env vars listed
+above — so downstream code that already calls `log.*` will
+automatically feed it.

--- a/plans/feat-server-logger.md
+++ b/plans/feat-server-logger.md
@@ -1,0 +1,158 @@
+# feat: server-side structured logger (#91)
+
+## Motivation
+
+Server's agent path is currently silent in the console — when the spawned `claude` CLI fails (e.g. `--resume` against a stale session), nothing is printed. Existing `[sandbox]` / `[mcp]` prefixed logs are ad-hoc `console.log` calls. We want a small, typed, dependency-free logger with:
+
+- Console + file output out of the box (debuggability-first)
+- Per-sink level + per-sink format (text vs JSON)
+- Daily file rotation with retention
+- A telemetry sink interface reserved for the future
+
+## Design
+
+### Module layout
+
+```
+server/logger/
+  index.ts         — public API: log.{error,warn,info,debug}(prefix, msg, data?)
+  types.ts         — LogLevel, LogRecord, Sink, Formatter
+  config.ts        — typed config, defaults, env-var overrides
+  formatters.ts    — text + json formatters (pure)
+  sinks.ts         — console sink, file sink, telemetry stub
+  rotation.ts      — daily rotation + maxFiles retention
+```
+
+Tests mirror layout under `test/logger/`.
+
+### Public API
+
+```ts
+export const log = {
+  error(prefix: string, msg: string, data?: Record<string, unknown>): void;
+  warn (prefix: string, msg: string, data?: Record<string, unknown>): void;
+  info (prefix: string, msg: string, data?: Record<string, unknown>): void;
+  debug(prefix: string, msg: string, data?: Record<string, unknown>): void;
+};
+```
+
+`prefix` is the existing `[sandbox]` / `[mcp]` / `[agent]` convention. `data` is an optional object serialized into the structured form.
+
+### Record shape
+
+```ts
+interface LogRecord {
+  ts: string;             // ISO timestamp
+  level: LogLevel;        // "error" | "warn" | "info" | "debug"
+  prefix: string;         // "agent", "sandbox", "mcp", "chatIndex"…
+  message: string;
+  data?: Record<string, unknown>;
+}
+```
+
+Each `log.*` call builds one record and fans it out to every enabled sink whose `level` threshold admits it.
+
+### Config
+
+`LoggerConfig` type defined in `config.ts`. Defaults:
+
+```ts
+{
+  sinks: {
+    console:   { level: "info",  format: "text", enabled: true },
+    file:      { level: "debug", format: "json", dir: "server/logs",
+                 rotation: { kind: "daily", maxFiles: 14 }, enabled: true },
+    telemetry: { level: "error", format: "json", enabled: false },
+  },
+}
+```
+
+Env overrides (all optional):
+
+| Var | Target |
+|---|---|
+| `LOG_LEVEL` | overrides **both** console+file level (coarse knob, matches original issue) |
+| `LOG_CONSOLE_LEVEL` | per-sink override |
+| `LOG_FILE_LEVEL` | per-sink override |
+| `LOG_CONSOLE_FORMAT` | `text` / `json` |
+| `LOG_FILE_FORMAT` | `text` / `json` |
+| `LOG_CONSOLE_ENABLED` | `true` / `false` |
+| `LOG_FILE_ENABLED` | `true` / `false` |
+| `LOG_FILE_DIR` | directory for rotated files |
+| `LOG_FILE_MAX_FILES` | retention count |
+
+Config resolved **once** at module load (pure function on `process.env`). Exported `resolveConfig(env)` function for tests.
+
+### Formatters
+
+- `formatText(record)` → `2026-04-13T07:12:45.123Z INFO  [agent] request received sessionId=abc role=default`
+- `formatJson(record)` → `{"ts":"2026-04-13T…","level":"info","prefix":"agent","message":"request received","data":{"sessionId":"abc","roleId":"default"}}`
+
+Formatters are **pure** — they take a record, return a string. Easy to unit test.
+
+### Sinks
+
+Each sink implements:
+
+```ts
+interface Sink {
+  level: LogLevel;
+  write(record: LogRecord): void; // fire-and-forget; MUST NOT throw
+}
+```
+
+- **ConsoleSink** — `process.stderr.write` for warn/error, `process.stdout.write` for info/debug (so redirecting stderr captures only problems).
+- **FileSink** — owns a rotating file handle; appends newline-terminated formatted strings. On first use creates dir (`mkdir -p`). Errors are caught and rerouted to `process.stderr` with a one-liner (never throw back into caller).
+- **TelemetrySink** — stub that exposes the interface and a `configure(endpoint)` no-op. Disabled by default.
+
+### Rotation
+
+Daily: file name = `server-YYYY-MM-DD.log`. Check date on every write; if the date has rolled over, swap the handle to the new filename, then enforce `maxFiles` by listing the dir, sorting by name desc, deleting anything beyond `maxFiles`. Rotation is atomic per-write (no background timer).
+
+Kept dependency-free by using `fs.promises.appendFile` (fire-and-forget). Concurrency: writes are queued through a simple per-sink promise chain so interleaved rotations don't race.
+
+### Wiring
+
+1. `server/routes/agent.ts` — log on: request received (sessionId, roleId, messageLen), streaming start, completion (duration ms, eventCount), error. Prefix `agent`.
+2. `server/agent.ts` — already streams `proc.stderr` via a buffer; additionally `log.error("agent-stderr", line)` per line. Log process exit code on close. Log session start (abs path, role, cwd). Prefix `agent`.
+3. Migrate existing console lines:
+   - `[sandbox]` / `[mcp]` / `[chatIndex]` / `[docker]` / `[csrf]` → `log.info(prefix, ...)` (or `.warn` / `.error` depending on semantics).
+4. `eslint-disable-next-line no-console` allowed **only** inside `server/logger/sinks.ts` (fallback error path). Rest of server disallowed via eslint override.
+
+### Tests (node:test)
+
+- `test/logger/test_formatters.ts` — happy + unicode + empty data + level casing
+- `test/logger/test_config.ts` — defaults, each env var override, invalid values fall back
+- `test/logger/test_sinks_file.ts` — writes to tmp dir, creates dir, rotates on date rollover (fake clock), enforces maxFiles
+- `test/logger/test_log.ts` — fan-out: record hits only sinks whose level admits it; disabled sinks get no write
+
+All tests use tmp dirs via `fs.mkdtempSync(os.tmpdir() + "/log-")` and clean up in `after`.
+
+### Acceptance (matches issue + scope expansion)
+
+- [x] server agent path emits ≥1 info line per `/api/agent` request + completion
+- [x] claude CLI stderr forwarded as it arrives
+- [x] `LOG_CONSOLE_ENABLED=false LOG_FILE_ENABLED=true` writes only to file
+- [x] `LOG_LEVEL=debug` enables verbose lines
+- [x] existing `[sandbox]` / `[mcp]` lines still appear (via new logger)
+- [x] no external deps added
+- [x] daily rotation + maxFiles retention
+- [x] per-sink format (text vs json)
+- [x] telemetry sink interface exists, disabled by default
+- [x] `server/logs/` is git-ignored
+
+## Out of scope
+
+- Size-based rotation (daily + retention is enough for now)
+- Log shipping / actual telemetry implementation (stub only)
+- Per-route overrides
+
+## Rollout steps
+
+1. Branch `feat/server-logger` from `main` ✅
+2. Write this plan ✅
+3. Implement `server/logger/` + tests
+4. Wire into agent paths
+5. Migrate existing console calls
+6. `yarn format && yarn lint && yarn typecheck && yarn build && yarn test && yarn test:e2e`
+7. Commit by concern; open PR to `main`

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -20,6 +20,7 @@ import {
   type AgentEvent,
   type RawStreamEvent,
 } from "./agent/stream.js";
+import { log } from "./logger/index.js";
 
 type ClaudeProc = ChildProcessByStdio<null, Readable, Readable>;
 
@@ -46,8 +47,16 @@ function spawnClaude(
 
 async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
+  let stderrBuffer = "";
   proc.stderr.on("data", (chunk: Buffer) => {
-    stderrOutput += chunk.toString();
+    const text = chunk.toString();
+    stderrOutput += text;
+    stderrBuffer += text;
+    const lines = stderrBuffer.split("\n");
+    stderrBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) log.error("agent-stderr", line);
+    }
   });
 
   let buffer = "";
@@ -73,6 +82,9 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   const exitCode = await new Promise<number>((resolve) =>
     proc.on("close", resolve),
   );
+
+  if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
+  log.info("agent", "claude exited", { exitCode });
 
   if (exitCode !== 0) {
     yield {
@@ -137,6 +149,13 @@ export async function* runAgent(
     mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
   });
 
+  log.info("agent", "spawning claude", {
+    roleId: role.id,
+    useDocker,
+    hasMcp,
+    resumed: Boolean(claudeSessionId),
+    sessionId,
+  });
   const proc = spawnClaude(useDocker, workspacePath, cliArgs);
 
   try {

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -149,12 +149,16 @@ export async function* runAgent(
     mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
   });
 
+  // Don't persist raw sessionId into log sinks (esp. the retained
+  // file sink). A boolean presence flag is enough for operational
+  // debugging and avoids writing identifiers that route back to a
+  // specific session into long-lived log files.
   log.info("agent", "spawning claude", {
     roleId: role.id,
     useDocker,
     hasMcp,
     resumed: Boolean(claudeSessionId),
-    sessionId,
+    hasSessionId: Boolean(sessionId),
   });
   const proc = spawnClaude(useDocker, workspacePath, cliArgs);
 

--- a/server/chat-index/index.ts
+++ b/server/chat-index/index.ts
@@ -16,6 +16,7 @@
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
 import { indexSession, listSessionIds, type IndexerDeps } from "./indexer.js";
+import { log } from "../logger/index.js";
 
 // Per-session lock. Indexing different sessions in parallel is
 // fine; indexing the same session twice concurrently would just
@@ -74,10 +75,12 @@ export async function maybeIndexSession(
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) {
       disabled = true;
-      console.warn(err.message);
+      log.warn("chat-index", err.message);
       return;
     }
-    console.warn("[chat-index] unexpected failure, continuing:", err);
+    log.warn("chat-index", "unexpected failure, continuing", {
+      error: String(err),
+    });
   } finally {
     running.delete(sessionId);
   }
@@ -123,19 +126,25 @@ export async function backfillAllSessions(
       });
       if (entry) {
         result.indexed++;
-        console.log(`[chat-index] indexed ${sessionId}: ${entry.title}`);
+        log.info("chat-index", "indexed", {
+          sessionId,
+          title: entry.title,
+        });
       } else {
         result.skipped++;
       }
     } catch (err) {
       if (err instanceof ClaudeCliNotFoundError) {
         disabled = true;
-        console.warn(err.message);
+        log.warn("chat-index", err.message);
         result.skipped++;
         continue;
       }
       result.skipped++;
-      console.warn(`[chat-index] failed to index ${sessionId}:`, err);
+      log.warn("chat-index", "failed to index", {
+        sessionId,
+        error: String(err),
+      });
     }
   }
   return result;

--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -3,6 +3,7 @@ import { writeFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import { promisify } from "util";
+import { log } from "./logger/index.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -30,13 +31,12 @@ export async function refreshCredentials(): Promise<boolean> {
     if (!credentials) return false;
 
     await writeFile(CREDENTIALS_PATH, credentials + "\n");
-    console.log("[sandbox] Credentials refreshed from macOS Keychain.");
+    log.info("sandbox", "Credentials refreshed from macOS Keychain.");
     return true;
   } catch (err) {
-    console.error(
-      "[sandbox] Failed to refresh credentials from Keychain:",
-      err,
-    );
+    log.error("sandbox", "Failed to refresh credentials from Keychain", {
+      error: String(err),
+    });
     return false;
   }
 }

--- a/server/docker.ts
+++ b/server/docker.ts
@@ -4,6 +4,7 @@ import { createHash } from "crypto";
 import { readFileSync, statSync } from "fs";
 import { homedir } from "os";
 import { join, resolve as resolvePath } from "path";
+import { log } from "./logger/index.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -19,24 +20,26 @@ function assertClaudeFiles(): void {
 
   try {
     if (!statSync(claudeDir).isDirectory()) {
-      console.error(`[sandbox] ${claudeDir} exists but is not a directory.`);
+      log.error("sandbox", `${claudeDir} exists but is not a directory.`);
       process.exit(1);
     }
   } catch {
-    console.error(
-      `[sandbox] ${claudeDir} not found. Run 'claude' once to initialize.`,
+    log.error(
+      "sandbox",
+      `${claudeDir} not found. Run 'claude' once to initialize.`,
     );
     process.exit(1);
   }
 
   try {
     if (!statSync(claudeJson).isFile()) {
-      console.error(`[sandbox] ${claudeJson} exists but is not a file.`);
+      log.error("sandbox", `${claudeJson} exists but is not a file.`);
       process.exit(1);
     }
   } catch {
-    console.error(
-      `[sandbox] ${claudeJson} not found. Run 'claude' once to initialize.`,
+    log.error(
+      "sandbox",
+      `${claudeJson} not found. Run 'claude' once to initialize.`,
     );
     process.exit(1);
   }
@@ -98,20 +101,22 @@ export async function ensureSandboxImage(): Promise<void> {
       `{{index .Config.Labels "${LABEL_KEY}"}}`,
     ]);
     if (stdout.trim() !== expectedSha) {
-      console.log(
-        "[sandbox] Dockerfile.sandbox changed, rebuilding sandbox image...",
+      log.info(
+        "sandbox",
+        "Dockerfile.sandbox changed, rebuilding sandbox image...",
       );
       needsBuild = true;
     }
   } catch {
-    console.log(
-      "[sandbox] Building sandbox image (first time only, may take a minute)...",
+    log.info(
+      "sandbox",
+      "Building sandbox image (first time only, may take a minute)...",
     );
     needsBuild = true;
   }
 
   if (needsBuild) {
     await buildImage(expectedSha);
-    console.log("[sandbox] Sandbox image built.");
+    log.info("sandbox", "Sandbox image built.");
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import { createTaskManager } from "./task-manager/index.js";
 import type { ITaskManager } from "./task-manager/index.js";
 import type { IPubSub } from "./pub-sub/index.js";
 import { requireSameOrigin } from "./csrfGuard.js";
+import { log } from "./logger/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -96,7 +97,10 @@ if (process.env.NODE_ENV === "production") {
 }
 
 app.use((err: Error, _req: Request, res: Response, __next: NextFunction) => {
-  console.error(err);
+  log.error("express", "unhandled error", {
+    error: err.message,
+    stack: err.stack,
+  });
   res.status(500).json({ error: "Internal Server Error" });
 });
 
@@ -126,46 +130,42 @@ async function ensureCredentialsAvailable(): Promise<void> {
     const { refreshCredentials } = await import("./credentials.js");
     const ok = await refreshCredentials();
     if (ok) return;
-    console.error(
-      "[sandbox] Failed to export credentials from macOS Keychain.",
+    log.error(
+      "sandbox",
+      "Failed to export credentials from macOS Keychain. Run `npm run sandbox:login` manually.",
     );
-    console.error("[sandbox] Run `npm run sandbox:login` manually.");
     process.exit(1);
   }
-  console.error(
-    "[sandbox] Missing credentials file: ~/.claude/.credentials.json",
-  );
-  console.error(
-    "[sandbox] Run `claude auth login` to authenticate Claude Code.",
+  log.error(
+    "sandbox",
+    "Missing credentials file at ~/.claude/.credentials.json. Run `claude auth login` to authenticate Claude Code.",
   );
   process.exit(1);
 }
 
 async function setupSandbox(): Promise<boolean> {
   if (process.env.DISABLE_SANDBOX === "1") {
-    console.log(
-      "[sandbox] DISABLE_SANDBOX=1 — running unrestricted (debug mode)",
+    log.info(
+      "sandbox",
+      "DISABLE_SANDBOX=1 — running unrestricted (debug mode)",
     );
     return false;
   }
   try {
     const dockerAvailable = await isDockerAvailable();
     if (!dockerAvailable) {
-      console.log("[sandbox] Docker not found — claude will run unrestricted");
+      log.info("sandbox", "Docker not found — claude will run unrestricted");
       return false;
     }
     await ensureCredentialsAvailable();
-    console.log(
-      "[sandbox] Docker available — building sandbox image if needed",
-    );
+    log.info("sandbox", "Docker available — building sandbox image if needed");
     await ensureSandboxImage();
-    console.log("[sandbox] Sandbox ready");
+    log.info("sandbox", "Sandbox ready");
     return true;
   } catch (err) {
-    console.error(
-      "[sandbox] Failed to set up sandbox, running unrestricted:",
-      err,
-    );
+    log.error("sandbox", "Failed to set up sandbox, running unrestricted", {
+      error: String(err),
+    });
     return false;
   }
 }
@@ -174,9 +174,9 @@ function logMcpStatus(): void {
   const enabledMcpTools = mcpTools.filter(isMcpToolEnabled);
   const disabledMcpTools = mcpTools.filter((t) => !isMcpToolEnabled(t));
   if (enabledMcpTools.length > 0) {
-    console.log(
-      `[mcp] Available: ${enabledMcpTools.map((t) => t.definition.name).join(", ")}`,
-    );
+    log.info("mcp", "Available", {
+      tools: enabledMcpTools.map((t) => t.definition.name).join(", "),
+    });
   }
   if (disabledMcpTools.length > 0) {
     const names = disabledMcpTools
@@ -185,7 +185,7 @@ function logMcpStatus(): void {
           t.definition.name + " (" + (t.requiredEnv ?? []).join(", ") + ")",
       )
       .join(", ");
-    console.log(`[mcp] Unavailable (missing env): ${names}`);
+    log.info("mcp", "Unavailable (missing env)", { tools: names });
   }
 }
 
@@ -195,9 +195,9 @@ function maybeForceJournalRun(): void {
   // the hourly interval. Fire-and-forget — journal errors never
   // propagate out of maybeRunJournal.
   if (process.env.JOURNAL_FORCE_RUN_ON_STARTUP !== "1") return;
-  console.log("[journal] JOURNAL_FORCE_RUN_ON_STARTUP=1 — running now");
+  log.info("journal", "JOURNAL_FORCE_RUN_ON_STARTUP=1 — running now");
   maybeRunJournal({ force: true }).catch((err) => {
-    console.warn("[journal] forced startup run failed:", err);
+    log.warn("journal", "forced startup run failed", { error: String(err) });
   });
 }
 
@@ -207,20 +207,24 @@ function maybeForceChatIndexBackfill(): void {
   // feature is rolled out over an existing workspace, or when
   // debugging the indexer itself.
   if (process.env.CHAT_INDEX_FORCE_RUN_ON_STARTUP !== "1") return;
-  console.log("[chat-index] CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 — running now");
+  log.info("chat-index", "CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 — running now");
   backfillAllSessions()
     .then((result) => {
-      console.log(
-        `[chat-index] startup backfill complete: ${result.indexed}/${result.total} indexed, ${result.skipped} skipped`,
-      );
+      log.info("chat-index", "startup backfill complete", {
+        indexed: result.indexed,
+        total: result.total,
+        skipped: result.skipped,
+      });
     })
     .catch((err) => {
-      console.warn("[chat-index] forced startup backfill failed:", err);
+      log.warn("chat-index", "forced startup backfill failed", {
+        error: String(err),
+      });
     });
 }
 
 function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
-  console.log(`Server running on port ${PORT}`);
+  log.info("server", "listening", { port: PORT });
 
   // --- Pub/Sub ---
   const pubsub = createPubSub(httpServer);
@@ -243,8 +247,9 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
 (async () => {
   const portFree = await isPortFree(PORT);
   if (!portFree) {
-    console.error(
-      `[error] Port ${PORT} is already in use. Stop the other process and try again.`,
+    log.error(
+      "server",
+      `Port ${PORT} is already in use. Stop the other process and try again.`,
     );
     process.exit(1);
   }
@@ -273,7 +278,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
     run: async () => {
       count++;
       const last = count === 10;
-      console.log(`[task-manager] debug.counter: ${count}`);
+      log.debug("task-manager", "debug.counter tick", { count });
       pubsub.publish("debug.beat", { count, last });
       if (last) {
         taskManager.removeTask("debug.counter");
@@ -282,7 +287,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
     },
   });
 
-  console.log("[debug] Debug mode active — registered debug tasks");
+  log.info("debug", "Debug mode active — registered debug tasks");
 }
 
 function registerDebugCounter2(taskManager: ITaskManager, pubsub: IPubSub) {
@@ -295,7 +300,7 @@ function registerDebugCounter2(taskManager: ITaskManager, pubsub: IPubSub) {
     run: async () => {
       count++;
       const last = count === 10;
-      console.log(`[task-manager] debug.counter2: ${count}`);
+      log.debug("task-manager", "debug.counter2 tick", { count });
       pubsub.publish("debug.beat", { count, last });
       if (last) {
         taskManager.removeTask("debug.counter2");

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -41,6 +41,7 @@ import {
 import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import { writeState, type JournalState } from "./state.js";
 import { readTextOrNull } from "../utils/fs.js";
+import { log } from "../logger/index.js";
 
 // --- Constants ------------------------------------------------------
 
@@ -201,9 +202,9 @@ async function processOneDay(
 
   const parsed = parseArchivistOutput(rawOutput);
   if (parsed === null) {
-    console.warn(
-      `[journal] archivist returned unusable JSON for ${date}, skipping`,
-    );
+    log.warn("journal", "archivist returned unusable JSON, skipping", {
+      date,
+    });
     return { kind: "skipped", reason: "unusable archivist JSON" };
   }
 
@@ -240,7 +241,10 @@ async function callSummarizeForDay(
     return await summarize(DAILY_SYSTEM_PROMPT, buildDailyUserPrompt(input));
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) throw err;
-    console.warn(`[journal] summarize failed for ${date}, skipping day:`, err);
+    log.warn("journal", "summarize failed, skipping day", {
+      date,
+      error: String(err),
+    });
     return null;
   }
 }
@@ -289,10 +293,10 @@ async function processTopicUpdatesForDay(
         existingTopics,
       );
     } catch (err) {
-      console.warn(
-        `[journal] failed to apply topic update for ${normalized.slug}:`,
-        err,
-      );
+      log.warn("journal", "failed to apply topic update", {
+        slug: normalized.slug,
+        error: String(err),
+      });
     }
   }
   return { created, updated };
@@ -327,7 +331,10 @@ async function persistStateAfterDay(
   try {
     await writeState(workspaceRoot, state);
   } catch (err) {
-    console.warn(`[journal] failed to persist state after ${date}:`, err);
+    log.warn("journal", "failed to persist state after day", {
+      date,
+      error: String(err),
+    });
   }
 }
 
@@ -474,7 +481,10 @@ async function loadDirtySessionExcerpts(
       const excerpts = await loadSessionExcerptsByDate(chatDir, sessionId);
       if (excerpts.size > 0) perSession.set(sessionId, excerpts);
     } catch (err) {
-      console.warn(`[journal] failed to load session ${sessionId}:`, err);
+      log.warn("journal", "failed to load session", {
+        sessionId,
+        error: String(err),
+      });
     }
   }
   return perSession;

--- a/server/journal/index.ts
+++ b/server/journal/index.ts
@@ -35,6 +35,7 @@ import {
   ClaudeCliNotFoundError,
   type Summarize,
 } from "./archivist.js";
+import { log } from "../logger/index.js";
 
 // Module-level lock. A boolean is enough for the single-process
 // single-user MulmoClaude server; if two sessions finish at the
@@ -71,10 +72,12 @@ export async function maybeRunJournal(
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) {
       disabled = true;
-      console.warn(err.message);
+      log.warn("journal", err.message);
       return;
     }
-    console.warn("[journal] unexpected failure, continuing:", err);
+    log.warn("journal", "unexpected failure, continuing", {
+      error: String(err),
+    });
   } finally {
     running = false;
   }
@@ -95,13 +98,13 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
   const optimize = opts.force === true || isOptimizationDue(state, now);
   if (!daily && !optimize) return;
   if (opts.force === true) {
-    console.log("[journal] force-run: skipping interval gates");
+    log.info("journal", "force-run: skipping interval gates");
   }
 
   let nextState = state;
 
   if (daily) {
-    console.log("[journal] running daily pass");
+    log.info("journal", "running daily pass");
     const { nextState: afterDaily, result } = await runDailyPass(nextState, {
       workspaceRoot,
       summarize,
@@ -116,17 +119,17 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
         lastDailyRunAt: new Date(now).toISOString(),
       }),
     };
-    const skipSuffix =
-      result.skipped.length > 0
-        ? ` (${result.skipped.length} days skipped, will retry)`
-        : "";
-    console.log(
-      `[journal] daily pass done: ${result.sessionsIngested.length} sessions, ${result.daysTouched.length} days, ${result.topicsCreated.length} topics created, ${result.topicsUpdated.length} updated${skipSuffix}`,
-    );
+    log.info("journal", "daily pass done", {
+      sessions: result.sessionsIngested.length,
+      days: result.daysTouched.length,
+      topicsCreated: result.topicsCreated.length,
+      topicsUpdated: result.topicsUpdated.length,
+      daysSkipped: result.skipped.length,
+    });
   }
 
   if (optimize) {
-    console.log("[journal] running optimization pass");
+    log.info("journal", "running optimization pass");
     const { nextState: afterOpt, result } = await runOptimizationPass(
       nextState,
       { workspaceRoot, summarize },
@@ -145,13 +148,14 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
       }),
     };
     if (result.skipped) {
-      console.log(
-        `[journal] optimization pass skipped: ${result.skippedReason}`,
-      );
+      log.info("journal", "optimization pass skipped", {
+        reason: result.skippedReason,
+      });
     } else {
-      console.log(
-        `[journal] optimization pass done: ${result.mergedSlugs.length} merged, ${result.archivedSlugs.length} archived`,
-      );
+      log.info("journal", "optimization pass done", {
+        merged: result.mergedSlugs.length,
+        archived: result.archivedSlugs.length,
+      });
     }
   }
 

--- a/server/journal/optimizationPass.ts
+++ b/server/journal/optimizationPass.ts
@@ -23,6 +23,7 @@ import {
   TOPICS_DIR,
 } from "./paths.js";
 import type { JournalState } from "./state.js";
+import { log } from "../logger/index.js";
 
 // How many characters of each topic file we hand to the optimizer.
 // Enough to judge duplication without blowing up the prompt.
@@ -150,7 +151,9 @@ export async function runOptimizationPass(
     );
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) throw err;
-    console.warn(`[journal] optimization summarize failed:`, err);
+    log.warn("journal", "optimization summarize failed", {
+      error: String(err),
+    });
     result.skipped = true;
     result.skippedReason = "summarize failed";
     return { nextState: { ...state }, result };
@@ -158,7 +161,7 @@ export async function runOptimizationPass(
 
   const parsed = extractJsonObject(raw);
   if (!isOptimizationOutput(parsed)) {
-    console.warn(`[journal] optimizer returned unusable JSON, skipping`);
+    log.warn("journal", "optimizer returned unusable JSON, skipping");
     result.skipped = true;
     result.skippedReason = "unusable optimizer JSON";
     return { nextState: { ...state }, result };
@@ -229,7 +232,7 @@ async function moveToArchive(
     // never a real file) or the rename hit an unexpected IO error.
     // Log and return false — the caller leaves state untouched for
     // this slug so the in-memory knownTopics stays accurate.
-    console.warn(`[journal] could not archive ${slug}:`, err);
+    log.warn("journal", "could not archive", { slug, error: String(err) });
     return false;
   }
 }

--- a/server/journal/state.ts
+++ b/server/journal/state.ts
@@ -11,6 +11,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { summariesRoot, STATE_FILE } from "./paths.js";
+import { log } from "../logger/index.js";
 
 // Bump this when the schema changes in a backwards-incompatible way.
 // Older state files are treated as corrupted and replaced with a
@@ -138,7 +139,9 @@ export async function readState(workspaceRoot: string): Promise<JournalState> {
     // Corrupted JSON or any other read error — fall back to defaults
     // and log a warning. Better to rebuild from scratch than to
     // crash the journal module.
-    console.warn(`[journal] state file unreadable, using defaults:`, err);
+    log.warn("journal", "state file unreadable, using defaults", {
+      error: String(err),
+    });
     return defaultState();
   }
 }

--- a/server/logger/config.ts
+++ b/server/logger/config.ts
@@ -1,0 +1,126 @@
+import path from "path";
+import type { LogFormat, LogLevel } from "./types.js";
+import { LEVEL_PRIORITY } from "./types.js";
+
+export interface FileRotationConfig {
+  kind: "daily";
+  maxFiles: number;
+}
+
+export interface ConsoleSinkConfig {
+  enabled: boolean;
+  level: LogLevel;
+  format: LogFormat;
+}
+
+export interface FileSinkConfig {
+  enabled: boolean;
+  level: LogLevel;
+  format: LogFormat;
+  dir: string;
+  rotation: FileRotationConfig;
+}
+
+export interface TelemetrySinkConfig {
+  enabled: boolean;
+  level: LogLevel;
+  format: LogFormat;
+}
+
+export interface LoggerConfig {
+  sinks: {
+    console: ConsoleSinkConfig;
+    file: FileSinkConfig;
+    telemetry: TelemetrySinkConfig;
+  };
+}
+
+const DEFAULT_FILE_DIR = path.join("server", "logs");
+const DEFAULT_MAX_FILES = 14;
+
+export const DEFAULT_CONFIG: LoggerConfig = {
+  sinks: {
+    console: { enabled: true, level: "info", format: "text" },
+    file: {
+      enabled: true,
+      level: "debug",
+      format: "json",
+      dir: DEFAULT_FILE_DIR,
+      rotation: { kind: "daily", maxFiles: DEFAULT_MAX_FILES },
+    },
+    telemetry: { enabled: false, level: "error", format: "json" },
+  },
+};
+
+function parseLevel(raw: string | undefined): LogLevel | undefined {
+  if (!raw) return undefined;
+  const v = raw.toLowerCase();
+  return v in LEVEL_PRIORITY ? (v as LogLevel) : undefined;
+}
+
+function parseFormat(raw: string | undefined): LogFormat | undefined {
+  if (!raw) return undefined;
+  const v = raw.toLowerCase();
+  return v === "text" || v === "json" ? v : undefined;
+}
+
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  return undefined;
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+export type Env = Partial<Record<string, string>>;
+
+export function resolveConfig(env: Env): LoggerConfig {
+  const coarseLevel = parseLevel(env.LOG_LEVEL);
+  const consoleLevel = parseLevel(env.LOG_CONSOLE_LEVEL) ?? coarseLevel;
+  const fileLevel = parseLevel(env.LOG_FILE_LEVEL) ?? coarseLevel;
+
+  return {
+    sinks: {
+      console: {
+        enabled:
+          parseBool(env.LOG_CONSOLE_ENABLED) ??
+          DEFAULT_CONFIG.sinks.console.enabled,
+        level: consoleLevel ?? DEFAULT_CONFIG.sinks.console.level,
+        format:
+          parseFormat(env.LOG_CONSOLE_FORMAT) ??
+          DEFAULT_CONFIG.sinks.console.format,
+      },
+      file: {
+        enabled:
+          parseBool(env.LOG_FILE_ENABLED) ?? DEFAULT_CONFIG.sinks.file.enabled,
+        level: fileLevel ?? DEFAULT_CONFIG.sinks.file.level,
+        format:
+          parseFormat(env.LOG_FILE_FORMAT) ?? DEFAULT_CONFIG.sinks.file.format,
+        dir: env.LOG_FILE_DIR ?? DEFAULT_CONFIG.sinks.file.dir,
+        rotation: {
+          kind: "daily",
+          maxFiles:
+            parsePositiveInt(env.LOG_FILE_MAX_FILES) ??
+            DEFAULT_CONFIG.sinks.file.rotation.maxFiles,
+        },
+      },
+      telemetry: {
+        enabled:
+          parseBool(env.LOG_TELEMETRY_ENABLED) ??
+          DEFAULT_CONFIG.sinks.telemetry.enabled,
+        level:
+          parseLevel(env.LOG_TELEMETRY_LEVEL) ??
+          DEFAULT_CONFIG.sinks.telemetry.level,
+        format:
+          parseFormat(env.LOG_TELEMETRY_FORMAT) ??
+          DEFAULT_CONFIG.sinks.telemetry.format,
+      },
+    },
+  };
+}

--- a/server/logger/formatters.ts
+++ b/server/logger/formatters.ts
@@ -1,0 +1,40 @@
+import type { Formatter, LogRecord } from "./types.js";
+
+function formatData(data: Record<string, unknown> | undefined): string {
+  if (!data) return "";
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(data)) {
+    parts.push(`${k}=${stringifyScalar(v)}`);
+  }
+  return parts.length ? ` ${parts.join(" ")}` : "";
+}
+
+function stringifyScalar(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "string") {
+    return /\s/.test(v) ? JSON.stringify(v) : v;
+  }
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+export const formatText: Formatter = (record: LogRecord): string => {
+  const level = record.level.toUpperCase().padEnd(5);
+  return `${record.ts} ${level} [${record.prefix}] ${record.message}${formatData(record.data)}`;
+};
+
+export const formatJson: Formatter = (record: LogRecord): string => {
+  const payload: Record<string, unknown> = {
+    ts: record.ts,
+    level: record.level,
+    prefix: record.prefix,
+    message: record.message,
+  };
+  if (record.data) payload.data = record.data;
+  return JSON.stringify(payload);
+};

--- a/server/logger/index.ts
+++ b/server/logger/index.ts
@@ -1,0 +1,64 @@
+import type { LoggerConfig } from "./config.js";
+import { resolveConfig } from "./config.js";
+import {
+  createConsoleSink,
+  createFileSink,
+  createTelemetrySink,
+} from "./sinks.js";
+import type { LogLevel, LogRecord, Sink } from "./types.js";
+import { LEVEL_PRIORITY } from "./types.js";
+
+export type { LogLevel, LogRecord } from "./types.js";
+export type { LoggerConfig } from "./config.js";
+export { resolveConfig, DEFAULT_CONFIG } from "./config.js";
+
+export interface Logger {
+  error(prefix: string, message: string, data?: Record<string, unknown>): void;
+  warn(prefix: string, message: string, data?: Record<string, unknown>): void;
+  info(prefix: string, message: string, data?: Record<string, unknown>): void;
+  debug(prefix: string, message: string, data?: Record<string, unknown>): void;
+}
+
+export function createLogger(config: LoggerConfig): Logger {
+  const sinks: Sink[] = [];
+  if (config.sinks.console.enabled)
+    sinks.push(createConsoleSink(config.sinks.console));
+  if (config.sinks.file.enabled) sinks.push(createFileSink(config.sinks.file));
+  if (config.sinks.telemetry.enabled)
+    sinks.push(createTelemetrySink(config.sinks.telemetry));
+
+  function emit(
+    level: LogLevel,
+    prefix: string,
+    message: string,
+    data?: Record<string, unknown>,
+  ): void {
+    const record: LogRecord = {
+      ts: new Date().toISOString(),
+      level,
+      prefix,
+      message,
+      ...(data ? { data } : {}),
+    };
+    const recordPriority = LEVEL_PRIORITY[level];
+    for (const sink of sinks) {
+      if (recordPriority <= LEVEL_PRIORITY[sink.level]) {
+        try {
+          sink.write(record);
+        } catch {
+          // Per contract, sinks swallow their own errors; belt-and-suspenders here.
+        }
+      }
+    }
+  }
+
+  return {
+    error: (p, m, d) => emit("error", p, m, d),
+    warn: (p, m, d) => emit("warn", p, m, d),
+    info: (p, m, d) => emit("info", p, m, d),
+    debug: (p, m, d) => emit("debug", p, m, d),
+  };
+}
+
+// Default module-level logger resolved from process.env.
+export const log: Logger = createLogger(resolveConfig(process.env));

--- a/server/logger/rotation.ts
+++ b/server/logger/rotation.ts
@@ -1,0 +1,42 @@
+import { mkdir, readdir, unlink } from "fs/promises";
+import path from "path";
+
+export function dailyFileName(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `server-${y}-${m}-${d}.log`;
+}
+
+const LOG_FILENAME_RE = /^server-\d{4}-\d{2}-\d{2}\.log$/;
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}
+
+// List log files in `dir`, newest first (by file name — our names are
+// ISO-sortable so string desc = chronological desc).
+export async function listLogFiles(dir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => LOG_FILENAME_RE.test(e))
+    .sort()
+    .reverse();
+}
+
+export async function enforceMaxFiles(
+  dir: string,
+  maxFiles: number,
+): Promise<void> {
+  if (maxFiles <= 0) return;
+  const files = await listLogFiles(dir);
+  const toDelete = files.slice(maxFiles);
+  await Promise.all(
+    toDelete.map((f) => unlink(path.join(dir, f)).catch(() => {})),
+  );
+}

--- a/server/logger/sinks.ts
+++ b/server/logger/sinks.ts
@@ -68,15 +68,15 @@ export function createFileSink(
     return `${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`;
   }
 
-  function maybeRotate(ts: Date): void {
+  function maybeRotate(ts: Date): boolean {
     const key = dateKey(ts);
-    if (key === currentDateKey) return;
+    if (key === currentDateKey) return false;
     currentDateKey = key;
     currentPath = path.join(config.dir, dailyFileName(ts));
     enqueue(async () => {
       await ensureDir(config.dir);
-      await enforceMaxFiles(config.dir, config.rotation.maxFiles);
     });
+    return true;
   }
 
   return {
@@ -84,10 +84,16 @@ export function createFileSink(
     level: config.level,
     write(record: LogRecord) {
       const ts = now();
-      maybeRotate(ts);
+      const rotated = maybeRotate(ts);
       const line = fmt(record) + "\n";
       const filePath = currentPath;
       enqueue(() => writeLine(filePath, line));
+      // Enforce retention AFTER the write so maxFiles counts include
+      // the file we just touched. Enforcing before rotation would
+      // leave N-1 existing files plus the fresh one (off-by-one).
+      if (rotated) {
+        enqueue(() => enforceMaxFiles(config.dir, config.rotation.maxFiles));
+      }
     },
     flush() {
       return queue;

--- a/server/logger/sinks.ts
+++ b/server/logger/sinks.ts
@@ -1,0 +1,108 @@
+import { appendFile } from "fs/promises";
+import path from "path";
+import type {
+  ConsoleSinkConfig,
+  FileSinkConfig,
+  TelemetrySinkConfig,
+} from "./config.js";
+import { formatJson, formatText } from "./formatters.js";
+import { dailyFileName, enforceMaxFiles, ensureDir } from "./rotation.js";
+import type { Formatter, LogRecord, Sink } from "./types.js";
+
+function pickFormatter(kind: "text" | "json"): Formatter {
+  return kind === "json" ? formatJson : formatText;
+}
+
+export function createConsoleSink(config: ConsoleSinkConfig): Sink {
+  const fmt = pickFormatter(config.format);
+  return {
+    name: "console",
+    level: config.level,
+    write(record: LogRecord) {
+      const line = fmt(record) + "\n";
+      const stream =
+        record.level === "error" || record.level === "warn"
+          ? process.stderr
+          : process.stdout;
+      stream.write(line);
+    },
+  };
+}
+
+export interface FileSinkDeps {
+  now?: () => Date;
+  writeLine?: (filePath: string, line: string) => Promise<void>;
+  onError?: (err: unknown) => void;
+}
+
+// Factory for the rotating file sink. `deps` is only used by tests to
+// inject a fake clock and an in-memory writer.
+export function createFileSink(
+  config: FileSinkConfig,
+  deps: FileSinkDeps = {},
+): Sink {
+  const now = deps.now ?? (() => new Date());
+  const writeLine =
+    deps.writeLine ??
+    ((p: string, line: string) => appendFile(p, line, "utf-8"));
+  const onError =
+    deps.onError ??
+    ((err: unknown) => {
+      // Fallback — never throw back into the caller.
+      // eslint-disable-next-line no-console
+      console.error("[logger] file sink error:", err);
+    });
+
+  const fmt = pickFormatter(config.format);
+  let currentDateKey = "";
+  let currentPath = "";
+  // Per-sink write queue: chains all pending I/O so rotations can't
+  // interleave with a previous write.
+  let queue: Promise<void> = Promise.resolve();
+
+  function enqueue(op: () => Promise<void>): void {
+    queue = queue.then(op).catch(onError);
+  }
+
+  function dateKey(d: Date): string {
+    return `${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`;
+  }
+
+  function maybeRotate(ts: Date): void {
+    const key = dateKey(ts);
+    if (key === currentDateKey) return;
+    currentDateKey = key;
+    currentPath = path.join(config.dir, dailyFileName(ts));
+    enqueue(async () => {
+      await ensureDir(config.dir);
+      await enforceMaxFiles(config.dir, config.rotation.maxFiles);
+    });
+  }
+
+  return {
+    name: "file",
+    level: config.level,
+    write(record: LogRecord) {
+      const ts = now();
+      maybeRotate(ts);
+      const line = fmt(record) + "\n";
+      const filePath = currentPath;
+      enqueue(() => writeLine(filePath, line));
+    },
+    flush() {
+      return queue;
+    },
+  };
+}
+
+// Telemetry sink is a placeholder for a future remote-shipping
+// implementation. Keeping the interface here so wiring is ready.
+export function createTelemetrySink(config: TelemetrySinkConfig): Sink {
+  return {
+    name: "telemetry",
+    level: config.level,
+    write(__record: LogRecord) {
+      // no-op until a transport is added
+    },
+  };
+}

--- a/server/logger/types.ts
+++ b/server/logger/types.ts
@@ -1,0 +1,29 @@
+export type LogLevel = "error" | "warn" | "info" | "debug";
+
+export type LogFormat = "text" | "json";
+
+// Numeric priorities for level filtering. Lower = more important.
+export const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+export interface LogRecord {
+  ts: string;
+  level: LogLevel;
+  prefix: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+export interface Sink {
+  name: string;
+  level: LogLevel;
+  write(record: LogRecord): void;
+  // Drains any pending async I/O. Tests call this; production can ignore.
+  flush?(): Promise<void>;
+}
+
+export type Formatter = (record: LogRecord) => string;

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -14,6 +14,7 @@ import {
 import { workspacePath } from "../workspace.js";
 import { maybeRunJournal } from "../journal/index.js";
 import { maybeIndexSession } from "../chat-index/index.js";
+import { log } from "../logger/index.js";
 
 const router = Router();
 const PORT = Number(process.env.PORT) || 3001;
@@ -130,6 +131,15 @@ router.post(
       claudeSessionMap.get(chatSessionId) ??
       (await readClaudeSessionId(metaFilePath, resultsFilePath));
 
+    const requestStartedAt = Date.now();
+    log.info("agent", "request received", {
+      sessionId,
+      chatSessionId,
+      roleId,
+      messageLen: message.length,
+      resumed: Boolean(claudeSessionId),
+    });
+
     // First-turn only: prepend a pointer to the workspace journal so
     // the LLM knows where to find historical context if the user's
     // question benefits from it. On resumed turns the pointer is
@@ -170,7 +180,17 @@ router.post(
         }
       }
       send({ type: "status", message: "Done" });
+      log.info("agent", "request completed", {
+        sessionId,
+        chatSessionId,
+        durationMs: Date.now() - requestStartedAt,
+      });
     } catch (err) {
+      log.error("agent", "request failed", {
+        sessionId,
+        chatSessionId,
+        error: String(err),
+      });
       send({ type: "error", message: String(err) });
     } finally {
       removeSession(sessionId);
@@ -183,7 +203,9 @@ router.post(
         (err) => {
           // Should not actually happen — maybeRunJournal swallows
           // its own errors — but belt-and-suspenders.
-          console.warn("[journal] unexpected error in background:", err);
+          log.warn("journal", "unexpected error in background", {
+            error: String(err),
+          });
         },
       );
       // Same fire-and-forget pattern as the journal above. The
@@ -195,7 +217,9 @@ router.post(
         sessionId,
         activeSessionIds: getActiveSessionIds(),
       }).catch((err) => {
-        console.warn("[chat-index] unexpected error in background:", err);
+        log.warn("chat-index", "unexpected error in background", {
+          error: String(err),
+        });
       });
     }
   },

--- a/server/routes/chat-index.ts
+++ b/server/routes/chat-index.ts
@@ -11,6 +11,7 @@
 
 import { Router, Request, Response } from "express";
 import { backfillAllSessions } from "../chat-index/index.js";
+import { log } from "../logger/index.js";
 
 interface RebuildResponse {
   total: number;
@@ -31,14 +32,16 @@ router.post(
     res: Response<RebuildResponse | RebuildErrorResponse>,
   ) => {
     try {
-      console.log("[chat-index] manual rebuild triggered");
+      log.info("chat-index", "manual rebuild triggered");
       const result = await backfillAllSessions();
-      console.log(
-        `[chat-index] rebuild complete: ${result.indexed}/${result.total} indexed, ${result.skipped} skipped`,
-      );
+      log.info("chat-index", "rebuild complete", {
+        indexed: result.indexed,
+        total: result.total,
+        skipped: result.skipped,
+      });
       res.json(result);
     } catch (err) {
-      console.warn("[chat-index] rebuild failed:", err);
+      log.warn("chat-index", "rebuild failed", { error: String(err) });
       res.status(500).json({
         error: err instanceof Error ? err.message : "unknown error",
       });

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -24,6 +24,7 @@ import type { MulmoBeat, MulmoImagePromptMedia } from "@mulmocast/types";
 import { slugify } from "../utils/slug.js";
 import { resolveWithinRoot } from "../utils/fs.js";
 import { errorMessage } from "../utils/errors.js";
+import { log } from "../logger/index.js";
 
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
@@ -372,19 +373,20 @@ router.post(
         getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
 
       if (!audioPath || !fs.existsSync(audioPath)) {
-        console.error(
-          `[generate-beat-audio] failed: beatIndex=${beatIndex} audioPath=${audioPath} exists=${audioPath ? fs.existsSync(audioPath) : false}`,
-        );
-        console.error(
-          `[generate-beat-audio] beat.text=${JSON.stringify(beat.text)} audioFile=${context.studio.beats[beatIndex]?.audioFile}`,
-        );
+        log.error("generate-beat-audio", "audio was not generated", {
+          beatIndex,
+          audioPath,
+          exists: audioPath ? fs.existsSync(audioPath) : false,
+          beatText: beat.text,
+          audioFile: context.studio.beats[beatIndex]?.audioFile,
+        });
         res.status(500).json({ error: "Audio was not generated" });
         return;
       }
 
       res.json({ audio: fileToDataUri(audioPath, "audio/mpeg") });
     } catch (err) {
-      console.error("[generate-beat-audio] error:", err);
+      log.error("generate-beat-audio", "error", { error: String(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   },

--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -373,12 +373,15 @@ router.post(
         getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
 
       if (!audioPath || !fs.existsSync(audioPath)) {
+        // Don't write raw `beat.text` into persistent logs — it's
+        // free-form user content and can contain sensitive data.
+        // Operational debug can use length + presence instead.
         log.error("generate-beat-audio", "audio was not generated", {
           beatIndex,
           audioPath,
           exists: audioPath ? fs.existsSync(audioPath) : false,
-          beatText: beat.text,
-          audioFile: context.studio.beats[beatIndex]?.audioFile,
+          beatTextLength: typeof beat?.text === "string" ? beat.text.length : 0,
+          audioFilePresent: Boolean(context.studio.beats[beatIndex]?.audioFile),
         });
         res.status(500).json({ error: "Audio was not generated" });
         return;

--- a/server/routes/pdf.ts
+++ b/server/routes/pdf.ts
@@ -6,6 +6,7 @@ import puppeteer from "puppeteer";
 import { errorMessage } from "../utils/errors.js";
 import { workspacePath } from "../workspace.js";
 import { resolveWithinRoot } from "../utils/fs.js";
+import { log } from "../logger/index.js";
 
 const router = Router();
 
@@ -80,12 +81,12 @@ function inlineImages(html: string): string {
       // resolveWithinRoot check (it expects a relative path).
       const relToWorkspace = path.relative(workspaceReal, unsafeAbs);
       if (relToWorkspace.startsWith("..") || path.isAbsolute(relToWorkspace)) {
-        console.warn(`[pdf] image path escapes workspace: ${src}`);
+        log.warn("pdf", "image path escapes workspace", { src });
         return _match;
       }
       const abs = resolveWithinRoot(workspaceReal, relToWorkspace);
       if (!abs) {
-        console.warn(`[pdf] image path rejected by safe-resolve: ${src}`);
+        log.warn("pdf", "image path rejected by safe-resolve", { src });
         return _match;
       }
       try {
@@ -94,7 +95,7 @@ function inlineImages(html: string): string {
         const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
         return `${before}data:${mime};base64,${buf.toString("base64")}${after}`;
       } catch {
-        console.warn(`[pdf] could not read image: ${abs}`);
+        log.warn("pdf", "could not read image", { abs });
         return _match;
       }
     },
@@ -158,14 +159,12 @@ router.post(
     }
 
     try {
-      console.log(
-        `[pdf] markdown: filename="${filename}" length=${markdown.length}`,
-      );
+      log.info("pdf", "markdown", { filename, length: markdown.length });
       const html = inlineImages(await marked.parse(markdown));
       const buffer = await renderPdf(wrapHtml(html, MARKDOWN_CSS), format);
       sendPdf(res, buffer, filename);
     } catch (err) {
-      console.error("[pdf] generation failed:", err);
+      log.error("pdf", "generation failed", { error: String(err) });
       res
         .status(500)
         .json({ error: `PDF generation failed: ${errorMessage(err)}` });

--- a/server/task-manager/index.ts
+++ b/server/task-manager/index.ts
@@ -1,3 +1,5 @@
+import { log } from "../logger/index.js";
+
 export type TaskSchedule =
   | { type: "interval"; intervalMs: number }
   | { type: "daily"; time: string }; // time: "HH:MM" in UTC
@@ -70,7 +72,10 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
       if (!isDue(currentTime, def.schedule, tickMs)) continue;
 
       def.run({ taskId: def.id, now: currentTime }).catch((err) => {
-        console.error(`[task-manager] ${def.id} failed:`, err);
+        log.error("task-manager", "task failed", {
+          id: def.id,
+          error: String(err),
+        });
       });
     }
   }
@@ -83,26 +88,26 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
         );
       }
       registry.set(def.id, def);
-      console.log(`[task-manager] Registered: ${def.id}`);
+      log.info("task-manager", "registered", { id: def.id });
     },
 
     removeTask(taskId: string) {
       if (registry.delete(taskId)) {
-        console.log(`[task-manager] Removed: ${taskId}`);
+        log.info("task-manager", "removed", { id: taskId });
       }
     },
 
     start() {
       if (timer) return;
       timer = setInterval(onTick, tickMs);
-      console.log(`[task-manager] Started (tick: ${tickMs}ms)`);
+      log.info("task-manager", "started", { tickMs });
     },
 
     stop() {
       if (timer) {
         clearInterval(timer);
         timer = null;
-        console.log("[task-manager] Stopped");
+        log.info("task-manager", "stopped");
       }
     },
 

--- a/server/workspace.ts
+++ b/server/workspace.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
+import { log } from "./logger/index.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, "helps");
@@ -54,9 +55,9 @@ export function initWorkspace(): string {
   const gitDir = path.join(workspacePath, ".git");
   if (!fs.existsSync(gitDir)) {
     execSync("git init", { cwd: workspacePath });
-    console.log(`Initialized git repository in ${workspacePath}`);
+    log.info("workspace", "initialized git repository", { workspacePath });
   }
 
-  console.log(`Workspace: ${workspacePath}`);
+  log.info("workspace", "ready", { workspacePath });
   return workspacePath;
 }

--- a/test/logger/test_config.ts
+++ b/test/logger/test_config.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DEFAULT_CONFIG, resolveConfig } from "../../server/logger/config.js";
+
+describe("resolveConfig", () => {
+  it("returns defaults when env is empty", () => {
+    const config = resolveConfig({});
+    assert.deepEqual(config, DEFAULT_CONFIG);
+  });
+
+  it("applies LOG_LEVEL to both console and file levels", () => {
+    const config = resolveConfig({ LOG_LEVEL: "debug" });
+    assert.equal(config.sinks.console.level, "debug");
+    assert.equal(config.sinks.file.level, "debug");
+  });
+
+  it("per-sink levels override the coarse LOG_LEVEL", () => {
+    const config = resolveConfig({
+      LOG_LEVEL: "debug",
+      LOG_CONSOLE_LEVEL: "warn",
+    });
+    assert.equal(config.sinks.console.level, "warn");
+    assert.equal(config.sinks.file.level, "debug");
+  });
+
+  it("ignores invalid level and falls back to default", () => {
+    const config = resolveConfig({ LOG_LEVEL: "chatty" });
+    assert.equal(
+      config.sinks.console.level,
+      DEFAULT_CONFIG.sinks.console.level,
+    );
+  });
+
+  it("accepts format overrides per sink", () => {
+    const config = resolveConfig({
+      LOG_CONSOLE_FORMAT: "json",
+      LOG_FILE_FORMAT: "text",
+    });
+    assert.equal(config.sinks.console.format, "json");
+    assert.equal(config.sinks.file.format, "text");
+  });
+
+  it("ignores invalid format and keeps default", () => {
+    const config = resolveConfig({ LOG_CONSOLE_FORMAT: "xml" });
+    assert.equal(
+      config.sinks.console.format,
+      DEFAULT_CONFIG.sinks.console.format,
+    );
+  });
+
+  it("parses enabled flags (true/false/1/0/yes/no)", () => {
+    assert.equal(
+      resolveConfig({ LOG_FILE_ENABLED: "false" }).sinks.file.enabled,
+      false,
+    );
+    assert.equal(
+      resolveConfig({ LOG_FILE_ENABLED: "0" }).sinks.file.enabled,
+      false,
+    );
+    assert.equal(
+      resolveConfig({ LOG_CONSOLE_ENABLED: "no" }).sinks.console.enabled,
+      false,
+    );
+    assert.equal(
+      resolveConfig({ LOG_CONSOLE_ENABLED: "yes" }).sinks.console.enabled,
+      true,
+    );
+  });
+
+  it("ignores invalid enabled flag and keeps default", () => {
+    const config = resolveConfig({ LOG_CONSOLE_ENABLED: "maybe" });
+    assert.equal(config.sinks.console.enabled, true);
+  });
+
+  it("accepts LOG_FILE_DIR override", () => {
+    const config = resolveConfig({ LOG_FILE_DIR: "/tmp/logs" });
+    assert.equal(config.sinks.file.dir, "/tmp/logs");
+  });
+
+  it("accepts a positive integer for LOG_FILE_MAX_FILES", () => {
+    const config = resolveConfig({ LOG_FILE_MAX_FILES: "7" });
+    assert.equal(config.sinks.file.rotation.maxFiles, 7);
+  });
+
+  it("ignores non-positive or non-integer maxFiles", () => {
+    assert.equal(
+      resolveConfig({ LOG_FILE_MAX_FILES: "0" }).sinks.file.rotation.maxFiles,
+      DEFAULT_CONFIG.sinks.file.rotation.maxFiles,
+    );
+    assert.equal(
+      resolveConfig({ LOG_FILE_MAX_FILES: "-3" }).sinks.file.rotation.maxFiles,
+      DEFAULT_CONFIG.sinks.file.rotation.maxFiles,
+    );
+    assert.equal(
+      resolveConfig({ LOG_FILE_MAX_FILES: "abc" }).sinks.file.rotation.maxFiles,
+      DEFAULT_CONFIG.sinks.file.rotation.maxFiles,
+    );
+  });
+
+  it("supports telemetry enabled + level override", () => {
+    const config = resolveConfig({
+      LOG_TELEMETRY_ENABLED: "true",
+      LOG_TELEMETRY_LEVEL: "warn",
+    });
+    assert.equal(config.sinks.telemetry.enabled, true);
+    assert.equal(config.sinks.telemetry.level, "warn");
+  });
+});

--- a/test/logger/test_formatters.ts
+++ b/test/logger/test_formatters.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatJson, formatText } from "../../server/logger/formatters.js";
+import type { LogRecord } from "../../server/logger/types.js";
+
+function record(overrides: Partial<LogRecord> = {}): LogRecord {
+  return {
+    ts: "2026-04-13T07:12:45.123Z",
+    level: "info",
+    prefix: "agent",
+    message: "request received",
+    ...overrides,
+  };
+}
+
+describe("formatText", () => {
+  it("formats a basic record with padded level and prefix", () => {
+    assert.equal(
+      formatText(record()),
+      "2026-04-13T07:12:45.123Z INFO  [agent] request received",
+    );
+  });
+
+  it("pads shorter levels (warn/info) and leaves 5-char levels alone", () => {
+    assert.equal(
+      formatText(record({ level: "warn" })),
+      "2026-04-13T07:12:45.123Z WARN  [agent] request received",
+    );
+    assert.equal(
+      formatText(record({ level: "error" })),
+      "2026-04-13T07:12:45.123Z ERROR [agent] request received",
+    );
+    assert.equal(
+      formatText(record({ level: "debug" })),
+      "2026-04-13T07:12:45.123Z DEBUG [agent] request received",
+    );
+  });
+
+  it("appends scalar data as k=v pairs", () => {
+    const out = formatText(
+      record({
+        data: { sessionId: "abc123", code: 0, ok: true, nothing: null },
+      }),
+    );
+    assert.ok(out.endsWith("sessionId=abc123 code=0 ok=true nothing=null"));
+  });
+
+  it("quotes string values containing whitespace", () => {
+    const out = formatText(
+      record({ data: { note: "with space", short: "plain" } }),
+    );
+    assert.ok(out.includes('note="with space"'));
+    assert.ok(out.includes("short=plain"));
+  });
+
+  it("handles empty data object (no trailing space)", () => {
+    const out = formatText(record({ data: {} }));
+    assert.equal(
+      out,
+      "2026-04-13T07:12:45.123Z INFO  [agent] request received",
+    );
+  });
+
+  it("serialises nested objects as JSON", () => {
+    const out = formatText(record({ data: { meta: { a: 1, b: [2, 3] } } }));
+    assert.ok(out.includes('meta={"a":1,"b":[2,3]}'));
+  });
+});
+
+describe("formatJson", () => {
+  it("emits a JSON object with required keys only", () => {
+    const out = formatJson(record());
+    assert.equal(
+      out,
+      '{"ts":"2026-04-13T07:12:45.123Z","level":"info","prefix":"agent","message":"request received"}',
+    );
+  });
+
+  it("includes a data block when provided", () => {
+    const out = formatJson(record({ data: { foo: "bar" } }));
+    const parsed: { data?: Record<string, unknown> } = JSON.parse(out);
+    assert.deepEqual(parsed.data, { foo: "bar" });
+  });
+
+  it("omits data block when undefined", () => {
+    const out = formatJson(record());
+    assert.ok(!out.includes('"data"'));
+  });
+});

--- a/test/logger/test_logger.ts
+++ b/test/logger/test_logger.ts
@@ -54,23 +54,41 @@ describe("createLogger level filtering", () => {
   });
 
   it("produces no output when all sinks are disabled", () => {
-    const logger = createLogger({
-      sinks: {
-        console: { enabled: false, level: "debug", format: "text" },
-        file: {
-          enabled: false,
-          level: "debug",
-          format: "text",
-          dir: "/tmp",
-          rotation: { kind: "daily", maxFiles: 1 },
+    // Capture writes to both streams so we can assert nothing is
+    // emitted. Prior to this tightening the test only verified
+    // "does not throw" — it would have passed even if the
+    // all-disabled config leaked through to the console sink.
+    const originalOut = process.stdout.write.bind(process.stdout);
+    const originalErr = process.stderr.write.bind(process.stderr);
+    const captured: string[] = [];
+    const recordWrite = (chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+    process.stdout.write = recordWrite as typeof process.stdout.write;
+    process.stderr.write = recordWrite as typeof process.stderr.write;
+    try {
+      const logger = createLogger({
+        sinks: {
+          console: { enabled: false, level: "debug", format: "text" },
+          file: {
+            enabled: false,
+            level: "debug",
+            format: "text",
+            dir: "/tmp",
+            rotation: { kind: "daily", maxFiles: 1 },
+          },
+          telemetry: { enabled: false, level: "error", format: "json" },
         },
-        telemetry: { enabled: false, level: "error", format: "json" },
-      },
-    });
-    // Should not throw.
-    logger.error("x", "nowhere");
-    logger.warn("x", "nowhere");
-    logger.info("x", "nowhere");
-    logger.debug("x", "nowhere");
+      });
+      logger.error("x", "nowhere");
+      logger.warn("x", "nowhere");
+      logger.info("x", "nowhere");
+      logger.debug("x", "nowhere");
+      assert.equal(captured.length, 0);
+    } finally {
+      process.stdout.write = originalOut;
+      process.stderr.write = originalErr;
+    }
   });
 });

--- a/test/logger/test_logger.ts
+++ b/test/logger/test_logger.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createLogger } from "../../server/logger/index.js";
+
+describe("createLogger level filtering", () => {
+  it("respects per-sink level thresholds when routing records", () => {
+    const captured: { level: string; message: string }[] = [];
+    // Build a logger that routes everything to an in-memory sink by
+    // disabling the default console/file/telemetry sinks and attaching
+    // a spy via a custom console-sink stdout override. Simplest way:
+    // swap process.stdout.write for a spy and enable only console.
+    const originalOut = process.stdout.write.bind(process.stdout);
+    const originalErr = process.stderr.write.bind(process.stderr);
+    const lines: string[] = [];
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const logger = createLogger({
+        sinks: {
+          console: { enabled: true, level: "warn", format: "json" },
+          file: {
+            enabled: false,
+            level: "debug",
+            format: "json",
+            dir: "/tmp",
+            rotation: { kind: "daily", maxFiles: 1 },
+          },
+          telemetry: { enabled: false, level: "error", format: "json" },
+        },
+      });
+      logger.debug("x", "should be dropped");
+      logger.info("x", "should be dropped");
+      logger.warn("x", "kept-warn");
+      logger.error("x", "kept-error");
+      for (const line of lines) {
+        const parsed: { level: string; message: string } = JSON.parse(
+          line.trim(),
+        );
+        captured.push(parsed);
+      }
+    } finally {
+      process.stdout.write = originalOut;
+      process.stderr.write = originalErr;
+    }
+    assert.equal(captured.length, 2);
+    assert.equal(captured[0].message, "kept-warn");
+    assert.equal(captured[1].message, "kept-error");
+  });
+
+  it("produces no output when all sinks are disabled", () => {
+    const logger = createLogger({
+      sinks: {
+        console: { enabled: false, level: "debug", format: "text" },
+        file: {
+          enabled: false,
+          level: "debug",
+          format: "text",
+          dir: "/tmp",
+          rotation: { kind: "daily", maxFiles: 1 },
+        },
+        telemetry: { enabled: false, level: "error", format: "json" },
+      },
+    });
+    // Should not throw.
+    logger.error("x", "nowhere");
+    logger.warn("x", "nowhere");
+    logger.info("x", "nowhere");
+    logger.debug("x", "nowhere");
+  });
+});

--- a/test/logger/test_rotation.ts
+++ b/test/logger/test_rotation.ts
@@ -64,10 +64,13 @@ describe("listLogFiles / enforceMaxFiles", () => {
   });
 
   it("is a no-op when maxFiles is 0 or negative", async () => {
-    const before = await readdir(dir);
+    // Local bindings were previously named `before` / `after`,
+    // which shadow the `node:test` lifecycle imports at the top
+    // of the file and fail the `no-shadow` lint rule.
+    const filesBefore = await readdir(dir);
     await enforceMaxFiles(dir, 0);
     await enforceMaxFiles(dir, -5);
-    const after = await readdir(dir);
-    assert.deepEqual(after.sort(), before.sort());
+    const filesAfter = await readdir(dir);
+    assert.deepEqual(filesAfter.sort(), filesBefore.sort());
   });
 });

--- a/test/logger/test_rotation.ts
+++ b/test/logger/test_rotation.ts
@@ -1,0 +1,73 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  dailyFileName,
+  enforceMaxFiles,
+  listLogFiles,
+} from "../../server/logger/rotation.js";
+
+describe("dailyFileName", () => {
+  it("formats a UTC date into server-YYYY-MM-DD.log", () => {
+    assert.equal(
+      dailyFileName(new Date("2026-04-13T07:12:45.123Z")),
+      "server-2026-04-13.log",
+    );
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    assert.equal(
+      dailyFileName(new Date("2026-01-02T00:00:00Z")),
+      "server-2026-01-02.log",
+    );
+  });
+});
+
+describe("listLogFiles / enforceMaxFiles", () => {
+  let dir: string;
+
+  before(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "log-rot-"));
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty when dir doesn't exist", async () => {
+    const files = await listLogFiles(path.join(dir, "nope"));
+    assert.deepEqual(files, []);
+  });
+
+  it("lists only log-named files, newest first", async () => {
+    await writeFile(path.join(dir, "server-2026-04-10.log"), "a");
+    await writeFile(path.join(dir, "server-2026-04-11.log"), "b");
+    await writeFile(path.join(dir, "server-2026-04-12.log"), "c");
+    await writeFile(path.join(dir, "unrelated.txt"), "x");
+    const files = await listLogFiles(dir);
+    assert.deepEqual(files, [
+      "server-2026-04-12.log",
+      "server-2026-04-11.log",
+      "server-2026-04-10.log",
+    ]);
+  });
+
+  it("deletes oldest files beyond maxFiles", async () => {
+    await enforceMaxFiles(dir, 2);
+    const remaining = await readdir(dir);
+    assert.ok(remaining.includes("server-2026-04-12.log"));
+    assert.ok(remaining.includes("server-2026-04-11.log"));
+    assert.ok(!remaining.includes("server-2026-04-10.log"));
+    assert.ok(remaining.includes("unrelated.txt")); // non-log files untouched
+  });
+
+  it("is a no-op when maxFiles is 0 or negative", async () => {
+    const before = await readdir(dir);
+    await enforceMaxFiles(dir, 0);
+    await enforceMaxFiles(dir, -5);
+    const after = await readdir(dir);
+    assert.deepEqual(after.sort(), before.sort());
+  });
+});

--- a/test/logger/test_sinks.ts
+++ b/test/logger/test_sinks.ts
@@ -106,9 +106,15 @@ describe("createFileSink", () => {
     sink.write(record({ message: "fresh" }));
     await sink.flush?.();
     const files = (await readdir(retDir)).sort();
-    // maxFiles=2 keeps the 2 newest log files (including the new one).
+    // maxFiles=2 keeps EXACTLY the 2 newest log files (including
+    // the fresh one). Asserting just "includes newest" and "not
+    // oldest" previously could pass even when retention left an
+    // extra middle log behind — tighten to count + exact set.
+    const logFiles = files.filter((f) => f.startsWith("server-"));
+    assert.equal(logFiles.length, 2);
     assert.ok(files.includes("server-2026-01-04.log"));
     assert.ok(files.includes("server-2026-01-03.log"));
+    assert.ok(!files.includes("server-2026-01-02.log"));
     assert.ok(!files.includes("server-2026-01-01.log"));
     await rm(retDir, { recursive: true, force: true });
   });

--- a/test/logger/test_sinks.ts
+++ b/test/logger/test_sinks.ts
@@ -1,0 +1,115 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { createFileSink } from "../../server/logger/sinks.js";
+import type { LogRecord } from "../../server/logger/types.js";
+
+function record(overrides: Partial<LogRecord> = {}): LogRecord {
+  return {
+    ts: "2026-04-13T07:12:45.123Z",
+    level: "info",
+    prefix: "agent",
+    message: "hello",
+    ...overrides,
+  };
+}
+
+describe("createFileSink", () => {
+  let dir: string;
+
+  before(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "log-sink-"));
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes JSON records to the current day's file", async () => {
+    const sink = createFileSink(
+      {
+        enabled: true,
+        level: "debug",
+        format: "json",
+        dir,
+        rotation: { kind: "daily", maxFiles: 7 },
+      },
+      { now: () => new Date("2026-04-13T10:00:00Z") },
+    );
+    sink.write(record({ message: "first" }));
+    sink.write(record({ message: "second" }));
+    await sink.flush?.();
+    const contents = await readFile(
+      path.join(dir, "server-2026-04-13.log"),
+      "utf-8",
+    );
+    const lines = contents.trim().split("\n");
+    assert.equal(lines.length, 2);
+    const parsed0: { message: string } = JSON.parse(lines[0]);
+    const parsed1: { message: string } = JSON.parse(lines[1]);
+    assert.equal(parsed0.message, "first");
+    assert.equal(parsed1.message, "second");
+  });
+
+  it("rotates to a new file when the UTC day changes", async () => {
+    const rotDir = await mkdtemp(path.join(os.tmpdir(), "log-rot-"));
+    let fake = new Date("2026-05-01T10:00:00Z");
+    const sink = createFileSink(
+      {
+        enabled: true,
+        level: "debug",
+        format: "text",
+        dir: rotDir,
+        rotation: { kind: "daily", maxFiles: 7 },
+      },
+      { now: () => fake },
+    );
+    sink.write(record({ message: "day1" }));
+    await sink.flush?.();
+    fake = new Date("2026-05-02T00:05:00Z");
+    sink.write(record({ message: "day2" }));
+    await sink.flush?.();
+    const files = await readdir(rotDir);
+    assert.ok(files.includes("server-2026-05-01.log"));
+    assert.ok(files.includes("server-2026-05-02.log"));
+    const day1 = await readFile(
+      path.join(rotDir, "server-2026-05-01.log"),
+      "utf-8",
+    );
+    const day2 = await readFile(
+      path.join(rotDir, "server-2026-05-02.log"),
+      "utf-8",
+    );
+    assert.ok(day1.includes("day1"));
+    assert.ok(day2.includes("day2"));
+    await rm(rotDir, { recursive: true, force: true });
+  });
+
+  it("enforces maxFiles retention on rotation", async () => {
+    const retDir = await mkdtemp(path.join(os.tmpdir(), "log-ret-"));
+    // Pre-create 3 old files
+    await writeFile(path.join(retDir, "server-2026-01-01.log"), "a");
+    await writeFile(path.join(retDir, "server-2026-01-02.log"), "b");
+    await writeFile(path.join(retDir, "server-2026-01-03.log"), "c");
+    const sink = createFileSink(
+      {
+        enabled: true,
+        level: "debug",
+        format: "text",
+        dir: retDir,
+        rotation: { kind: "daily", maxFiles: 2 },
+      },
+      { now: () => new Date("2026-01-04T00:00:00Z") },
+    );
+    sink.write(record({ message: "fresh" }));
+    await sink.flush?.();
+    const files = (await readdir(retDir)).sort();
+    // maxFiles=2 keeps the 2 newest log files (including the new one).
+    assert.ok(files.includes("server-2026-01-04.log"));
+    assert.ok(files.includes("server-2026-01-03.log"));
+    assert.ok(!files.includes("server-2026-01-01.log"));
+    await rm(retDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Closes #91.

## User Prompt

> issue #91 を進めたい。custom loggerと設定ファイルを作って、consoleとファイルへのログ出力をサポート。設定でログのレベルごとの挙動を指定できるのと、ファイルの書き出し先、ローテーションを指定できる。将来的にはテレメトリーもサポートするかもしれない。サーバのログね。defaultではコンソールに出しつつ、server/logs以下に書き出してローテーションして。でバックしやすいさを優先的に考えてね。で、formatも変更可能にして日付＋ログの場合とjsonで出す場合の制御できるように。コンソールとテレメトリーではformatはかえたいよね。チケットに反映しつつplanを作って新しいブランチで実装して。

## Summary

Introduces a typed, dependency-free structured logger and migrates the server's ad-hoc `console.*` calls onto it. Defaults are tuned for debuggability: readable text in the console + full-fidelity JSON in rotating daily files under `server/logs/`.

## Design

### Module layout (`server/logger/`)

| file | responsibility |
|---|---|
| `types.ts` | `LogLevel`, `LogRecord`, `Sink`, `Formatter` |
| `config.ts` | typed config, defaults, env-var overrides |
| `formatters.ts` | `text` (`ISO LEVEL [prefix] msg k=v`) + `json` (JSONL) |
| `sinks.ts` | console sink, rotating file sink, telemetry stub |
| `rotation.ts` | daily rotation + `maxFiles` retention |
| `index.ts` | public `log.{error,warn,info,debug}` API |

### Per-sink config (format is per-sink, not global)

```ts
{
  sinks: {
    console:   { enabled: true,  level: "info",  format: "text" },
    file:      { enabled: true,  level: "debug", format: "json",
                 dir: "server/logs",
                 rotation: { kind: "daily", maxFiles: 14 } },
    telemetry: { enabled: false, level: "error", format: "json" }, // stub
  },
}
```

Each log call fans out to every enabled sink whose level threshold admits it — so the console stays readable while the file captures full structured debug data.

### Env-var override surface

`LOG_LEVEL` (coarse), `LOG_CONSOLE_LEVEL`, `LOG_FILE_LEVEL`, `LOG_CONSOLE_FORMAT`, `LOG_FILE_FORMAT`, `LOG_CONSOLE_ENABLED`, `LOG_FILE_ENABLED`, `LOG_FILE_DIR`, `LOG_FILE_MAX_FILES`, `LOG_TELEMETRY_ENABLED`, `LOG_TELEMETRY_LEVEL`, `LOG_TELEMETRY_FORMAT`.

### Agent-path visibility (the original #91 motivation)

- `server/agent.ts` streams `claude` CLI stderr line-by-line to `log.error` as it arrives, instead of only surfacing it on non-zero exit. Exit code is always logged.
- `server/routes/agent.ts` logs request-in (sessionId, roleId, messageLen, resumed), completion (durationMs), and errors.

### Migration

~60 ad-hoc `console.log/warn/error` calls across `agent`, `journal`, `chat-index`, `sandbox`, `mcp`, `task-manager`, `workspace`, `pdf`, `mulmo-script` moved to `log.{info,warn,error}(prefix, msg, data?)`. Existing prefix conventions (`[sandbox]` / `[mcp]` / `[journal]` / etc.) preserved; structured values moved into the `data` payload so JSON-formatted file logs are machine-readable.

Only `server/logger/sinks.ts` retains a `console.*` call (fallback for when the file sink itself fails).

## Plan

`plans/feat-server-logger.md` (committed with the feature).

## Test plan

- [x] `yarn format`
- [x] `yarn lint` — 0 errors (15 pre-existing `.vue` warnings)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` — 921 pass (includes 5 new logger test suites)
- [x] `yarn test:e2e` — 55 pass
- [x] Smoke test: `LOG_FILE_DIR=/tmp/logger-smoke tsx server/index.ts` produces readable console output AND a `server-YYYY-MM-DD.log` JSONL file in the configured directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured server logging added: console plus daily-rotating log files with text/JSON formats; logging emitted across server runtime and routes and configurable via environment variables.

* **Documentation**
  * README “Logging” section and a detailed logging guide added, with examples and configuration reference.

* **Tests**
  * New unit and integration tests covering config parsing, formatters, sinks, rotation, and logger behavior.

* **Chore**
  * Updated ignore entries and fixed trailing newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->