### PR TITLE
refactor(App.vue): extract composables + components to hit <500 lines (#183)

### DIFF
--- a/e2e/tests/health-check.spec.ts
+++ b/e2e/tests/health-check.spec.ts
@@ -1,0 +1,72 @@
+// E2E for useHealth — the /api/health fetch that populates the
+// geminiAvailable + sandboxEnabled refs. The refs drive UI affordances
+// in the header (lock icon + tooltip) and elsewhere. We exercise the
+// two response shapes and verify the lock-button tooltip reflects
+// them.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+async function mockHealth(
+  page: Page,
+  body: { geminiAvailable: boolean; sandboxEnabled: boolean },
+) {
+  await page.route(urlEndsWith("/api/health"), (route: Route) =>
+    route.fulfill({ json: body }),
+  );
+}
+
+test.describe("health check (useHealth)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("sandboxEnabled=true → lock button shows 'Sandbox enabled' tooltip", async ({
+    page,
+  }) => {
+    await mockHealth(page, { geminiAvailable: true, sandboxEnabled: true });
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const lockBtn = page.getByTestId("sandbox-lock-button");
+    await expect(lockBtn).toHaveAttribute(
+      "title",
+      "Sandbox enabled (Docker)",
+      { timeout: 3000 },
+    );
+  });
+
+  test("sandboxEnabled=false → lock button shows 'No sandbox' tooltip", async ({
+    page,
+  }) => {
+    await mockHealth(page, { geminiAvailable: false, sandboxEnabled: false });
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const lockBtn = page.getByTestId("sandbox-lock-button");
+    await expect(lockBtn).toHaveAttribute(
+      "title",
+      "No sandbox (Docker not found)",
+      { timeout: 3000 },
+    );
+  });
+
+  test("fetch failure defaults gemini off + keeps sandbox displayed", async ({
+    page,
+  }) => {
+    // Return 500 so the try/catch in useHealth falls into the catch
+    // branch (geminiAvailable → false, sandboxEnabled unchanged).
+    await page.route(urlEndsWith("/api/health"), (route: Route) =>
+      route.fulfill({ status: 500 }),
+    );
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Page didn't crash — lock button still rendered.
+    await expect(page.getByTestId("sandbox-lock-button")).toBeVisible();
+  });
+});

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -1,0 +1,95 @@
+// E2E for the session-history dropdown — the button-triggered popup
+// that lists past sessions. Covers:
+// - lazy fetch: /api/sessions is fetched when the button is clicked
+// - click-outside guard: popup dismisses when clicking elsewhere
+// - session click → navigate to /chat/:id
+//
+// Companion to chat-flow.spec.ts (which covers list sort order and
+// AI-title preference): this file focuses on the button+popup UX
+// extracted into useSessionHistory + SessionHistoryPanel.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { SESSION_A, SESSION_B } from "../fixtures/sessions";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+test.describe("history panel (useSessionHistory)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("clicking the history button opens the panel with server sessions", async ({
+    page,
+  }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Panel is closed initially — session items should not be in DOM.
+    await expect(
+      page.getByTestId(`session-item-${SESSION_A.id}`),
+    ).toBeHidden();
+
+    await page.getByTestId("history-btn").click();
+
+    await expect(
+      page.getByTestId(`session-item-${SESSION_A.id}`),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId(`session-item-${SESSION_B.id}`),
+    ).toBeVisible();
+  });
+
+  test("clicking a session navigates to /chat/:id", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByTestId("history-btn").click();
+    await page.getByTestId(`session-item-${SESSION_A.id}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
+  });
+
+  test("clicking outside closes the panel", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByTestId("history-btn").click();
+    const item = page.getByTestId(`session-item-${SESSION_A.id}`);
+    await expect(item).toBeVisible();
+
+    // Click somewhere neutral (main chat canvas area, far from the header).
+    await page.locator("body").click({ position: { x: 600, y: 500 } });
+    await expect(item).toBeHidden();
+  });
+
+  test("button click triggers a fresh /api/sessions fetch", async ({
+    page,
+  }) => {
+    // Count /api/sessions GETs so we can verify the button fires a
+    // lazy fetch (not just the onMount one).
+    let sessionFetchCount = 0;
+    await page.route(urlEndsWith("/api/sessions"), (route: Route) => {
+      if (route.request().method() === "GET") {
+        sessionFetchCount++;
+      }
+      return route.fulfill({ json: [SESSION_A, SESSION_B] });
+    });
+
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    // Let onMount fetches settle.
+    await page.waitForTimeout(200);
+    const countAfterMount = sessionFetchCount;
+
+    await page.getByTestId("history-btn").click();
+    await expect(
+      page.getByTestId(`session-item-${SESSION_A.id}`),
+    ).toBeVisible();
+
+    // One additional fetch should have happened on button click.
+    expect(sessionFetchCount).toBeGreaterThan(countAfterMount);
+  });
+});

--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -1,0 +1,54 @@
+// E2E for the Cmd/Ctrl + 1/2/3 canvas view-mode shortcut wired via
+// useEventListeners (window keydown). Cmd on macOS, Ctrl elsewhere —
+// Playwright's `page.keyboard.press("Meta+2")` targets Meta which
+// Vue's handleViewModeShortcut treats the same as Ctrl.
+//
+// View-mode URL sync is owned by useCanvasViewMode: "single" (the
+// default) omits ?view=, "stack" / "files" add it.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// Determine the modifier key per-platform. Playwright exposes the
+// target platform via the browser context user agent — easier to
+// just try Meta first and fall back to Control if the URL doesn't
+// change. Keep the shortcut helper explicit so tests stay readable.
+async function pressViewShortcut(page: Page, key: "1" | "2" | "3") {
+  await page.keyboard.press(`Meta+${key}`);
+}
+
+test.describe("view-mode keyboard shortcuts (useEventListeners)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("Cmd/Ctrl+2 switches to stack view (?view=stack)", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await pressViewShortcut(page, "2");
+    await expect(page).toHaveURL(/[?&]view=stack/);
+  });
+
+  test("Cmd/Ctrl+3 switches to files view (?view=files)", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await pressViewShortcut(page, "3");
+    await expect(page).toHaveURL(/[?&]view=files/);
+  });
+
+  test("Cmd/Ctrl+1 returns to single view (?view= removed)", async ({
+    page,
+  }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // First go to stack, then back to single.
+    await pressViewShortcut(page, "2");
+    await expect(page).toHaveURL(/[?&]view=stack/);
+
+    await pressViewShortcut(page, "1");
+    await expect(page).not.toHaveURL(/[?&]view=/);
+  });
+});

--- a/e2e/tests/lock-status-popup.spec.ts
+++ b/e2e/tests/lock-status-popup.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.describe("LockStatusPopup", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("clicking the lock button opens the popup", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const lockBtn = page.getByTestId("sandbox-lock-button");
+    await expect(lockBtn).toBeVisible();
+
+    // Popup is not visible initially.
+    await expect(page.getByTestId("sandbox-test-query").first()).toBeHidden();
+
+    await lockBtn.click();
+
+    // Sandbox test query buttons appear.
+    const queries = page.getByTestId("sandbox-test-query");
+    await expect(queries.first()).toBeVisible();
+    expect(await queries.count()).toBe(4);
+  });
+
+  test("clicking a test query closes the popup", async ({ page }) => {
+    // Block the agent route so sendMessage doesn't try to stream —
+    // we only care that the popup closes after the click.
+    await page.route(
+      (url) => url.pathname === "/api/agent",
+      (route) => route.fulfill({ status: 500, body: "" }),
+    );
+
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByTestId("sandbox-lock-button").click();
+
+    const firstQuery = page.getByTestId("sandbox-test-query").first();
+    await expect(firstQuery).toBeVisible();
+    await firstQuery.click();
+
+    await expect(firstQuery).toBeHidden();
+  });
+
+  test("clicking outside closes the popup", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByTestId("sandbox-lock-button").click();
+
+    const firstQuery = page.getByTestId("sandbox-test-query").first();
+    await expect(firstQuery).toBeVisible();
+
+    // Click somewhere neutral (the main chat area, not the button /
+    // popup) — the click-outside guard should close the popup.
+    await page.locator("body").click({ position: { x: 400, y: 400 } });
+
+    await expect(firstQuery).toBeHidden();
+  });
+});

--- a/e2e/tests/queries-panel.spec.ts
+++ b/e2e/tests/queries-panel.spec.ts
@@ -1,0 +1,101 @@
+// E2E for the role-specific "quick queries" panel extracted into
+// useQueriesPanel. The default role has a non-empty `queries` array
+// so the Suggestions button is rendered on every session mount.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+// Capture the POST body sent to /api/agent so we can assert that a
+// click on a quick-query actually fired sendMessage with the right
+// text.
+async function captureAgentPost(
+  page: Page,
+): Promise<{ getBody: () => string | null }> {
+  let capturedBody: string | null = null;
+  await page.route(urlEndsWith("/api/agent"), (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    capturedBody = route.request().postData();
+    // Return an empty SSE stream so sendMessage resolves cleanly.
+    return route.fulfill({
+      body: "\n",
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+  return { getBody: () => capturedBody };
+}
+
+test.describe("queries panel (useQueriesPanel)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("Suggestions button toggles the query list", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const toggle = page.getByRole("button", { name: /Suggestions/ });
+    await expect(toggle).toBeVisible();
+
+    // Pick a known query from the default role (see src/config/roles.ts).
+    const firstQuery = page.getByRole("button", {
+      name: "Tell me about this app, MulmoClaude.",
+    });
+    await expect(firstQuery).toBeHidden();
+
+    await toggle.click();
+    await expect(firstQuery).toBeVisible();
+
+    await toggle.click();
+    await expect(firstQuery).toBeHidden();
+  });
+
+  test("plain click on a query sends it as a message", async ({ page }) => {
+    const captured = await captureAgentPost(page);
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByRole("button", { name: /Suggestions/ }).click();
+    const query = page.getByRole("button", {
+      name: "Tell me about this app, MulmoClaude.",
+    });
+    await expect(query).toBeVisible();
+    await query.click();
+
+    // sendMessage posts to /api/agent with the query text in the body.
+    await expect
+      .poll(() => captured.getBody(), { timeout: 3000 })
+      .not.toBeNull();
+    const body = captured.getBody();
+    expect(body).toContain("Tell me about this app, MulmoClaude.");
+
+    // Panel collapses after click.
+    await expect(query).toBeHidden();
+  });
+
+  test("Shift+click on a query fills the input without sending", async ({
+    page,
+  }) => {
+    const captured = await captureAgentPost(page);
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByRole("button", { name: /Suggestions/ }).click();
+    const query = page.getByRole("button", {
+      name: "Tell me about this app, MulmoClaude.",
+    });
+    await expect(query).toBeVisible();
+    await query.click({ modifiers: ["Shift"] });
+
+    // Textarea now contains the query text…
+    const textarea = page.getByTestId("user-input");
+    await expect(textarea).toHaveValue("Tell me about this app, MulmoClaude.");
+
+    // …and no message was sent.
+    await page.waitForTimeout(300);
+    expect(captured.getBody()).toBeNull();
+  });
+});

--- a/e2e/tests/right-sidebar-toggle.spec.ts
+++ b/e2e/tests/right-sidebar-toggle.spec.ts
@@ -1,0 +1,55 @@
+// E2E for useRightSidebar — the button that opens/closes the Tool
+// Call History sidebar, and the localStorage persistence of that
+// preference. Companion to localstorage.spec.ts, which covers the
+// reload path; this file covers the interactive toggle path.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.describe("right sidebar toggle (useRightSidebar)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("clicking the header button shows/hides the sidebar", async ({
+    page,
+  }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // The sidebar has a unique heading "Tool Call History" (h2).
+    const sidebarHeading = page.getByRole("heading", {
+      name: "Tool Call History",
+    });
+    await expect(sidebarHeading).toBeHidden();
+
+    const toggleBtn = page.getByTitle("Tool call history");
+    await toggleBtn.click();
+    await expect(sidebarHeading).toBeVisible();
+
+    await toggleBtn.click();
+    await expect(sidebarHeading).toBeHidden();
+  });
+
+  test("toggle state persists to localStorage", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByTitle("Tool call history").click();
+    await expect(
+      page.getByRole("heading", { name: "Tool Call History" }),
+    ).toBeVisible();
+
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("right_sidebar_visible"),
+    );
+    expect(stored).toBe("true");
+
+    // Close → stored becomes "false".
+    await page.getByTitle("Tool call history").click();
+    const stored2 = await page.evaluate(() =>
+      localStorage.getItem("right_sidebar_visible"),
+    );
+    expect(stored2).toBe("false");
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -529,6 +529,7 @@ import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
 import { useHealth } from "./composables/useHealth";
+import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -708,8 +709,8 @@ const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
 const userInput = ref("");
 const activePane = ref<"sidebar" | "main">("sidebar");
 
-const showHistory = ref(false);
-const sessions = ref<SessionSummary[]>([]);
+const { sessions, showHistory, fetchSessions, toggleHistory } =
+  useSessionHistory();
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
 
@@ -1010,23 +1011,6 @@ function createNewSession(roleId?: string): ActiveSession {
 
 function onRoleChange() {
   createNewSession(currentRoleId.value);
-}
-
-async function fetchSessions(): Promise<SessionSummary[]> {
-  try {
-    const res = await fetch("/api/sessions");
-    const data: SessionSummary[] = await res.json();
-    sessions.value = data;
-    return data;
-  } catch {
-    sessions.value = [];
-    return [];
-  }
-}
-
-async function toggleHistory() {
-  showHistory.value = !showHistory.value;
-  if (showHistory.value) await fetchSessions();
 }
 
 async function loadSession(id: string) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -528,6 +528,7 @@ import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
+import { useHealth } from "./composables/useHealth";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -709,8 +710,7 @@ const activePane = ref<"sidebar" | "main">("sidebar");
 
 const showHistory = ref(false);
 const sessions = ref<SessionSummary[]>([]);
-const geminiAvailable = ref(true);
-const sandboxEnabled = ref(true);
+const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
 
 const sandboxTestQueries = [
@@ -1010,18 +1010,6 @@ function createNewSession(roleId?: string): ActiveSession {
 
 function onRoleChange() {
   createNewSession(currentRoleId.value);
-}
-
-async function fetchHealth() {
-  try {
-    const res = await fetch("/api/health");
-    if (!res.ok) throw new Error("health check failed");
-    const data = await res.json();
-    geminiAvailable.value = !!data.geminiAvailable;
-    sandboxEnabled.value = !!data.sandboxEnabled;
-  } catch {
-    geminiAvailable.value = false;
-  }
 }
 
 async function fetchSessions(): Promise<SessionSummary[]> {

--- a/src/App.vue
+++ b/src/App.vue
@@ -530,6 +530,7 @@ import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
+import { useRightSidebar } from "./composables/useRightSidebar";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -750,9 +751,7 @@ watch(isRunning, (running) => {
   }
 });
 
-const showRightSidebar = ref(
-  localStorage.getItem("right_sidebar_visible") === "true",
-);
+const { showRightSidebar, toggleRightSidebar } = useRightSidebar();
 
 const {
   canvasViewMode,
@@ -961,11 +960,6 @@ const needsGemini = (roleId: string) =>
   (roles.value.find((r) => r.id === roleId)?.availablePlugins ?? []).some((p) =>
     GEMINI_PLUGINS.has(p),
   );
-
-function toggleRightSidebar() {
-  showRightSidebar.value = !showRightSidebar.value;
-  localStorage.setItem("right_sidebar_visible", String(showRightSidebar.value));
-}
 
 // Remove the current session from sessionMap if it's empty (no messages).
 // Returns true if a session was removed, so the caller can use

--- a/src/App.vue
+++ b/src/App.vue
@@ -531,6 +531,7 @@ import { usePubSub } from "./composables/usePubSub";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
+import { useQueriesPanel } from "./composables/useQueriesPanel";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -866,30 +867,17 @@ function handleKeyNavigation(e: KeyboardEvent) {
   selectedResultUuid.value = results[nextIndex].uuid;
 }
 
-const queriesExpanded = ref(false);
-const queriesListRef = ref<HTMLDivElement | null>(null);
-
-watch(queriesExpanded, (expanded) => {
-  if (expanded) {
-    nextTick(() => {
-      if (queriesListRef.value) {
-        queriesListRef.value.scrollTop = queriesListRef.value.scrollHeight;
-      }
-    });
-  }
+// The sendMessage wrapper defers resolution until call time so the
+// composable can be instantiated here, before sendMessage is
+// declared further down. Function declarations are hoisted so the
+// reference is valid at click time.
+const { queriesExpanded, queriesListRef, onQueryClick } = useQueriesPanel({
+  userInput,
+  textareaRef,
+  sendMessage: (msg) => sendMessage(msg),
 });
 
 const showQueries = computed(() => !!currentRole.value.queries?.length);
-
-function onQueryClick(e: MouseEvent, query: string) {
-  queriesExpanded.value = false;
-  if (e.shiftKey) {
-    userInput.value = query;
-    nextTick(() => textareaRef.value?.focus());
-  } else {
-    sendMessage(query);
-  }
-}
 
 // Local wrappers that thread the reactive `roles.value` into the
 // pure helpers in src/utils/role.ts. Template bindings keep the

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,83 +125,16 @@
         </div>
       </div>
       <!-- History popup -->
-      <div
+      <SessionHistoryPanel
         v-if="showHistory"
-        ref="historyPopupRef"
-        class="absolute left-0 right-0 bottom-0 bg-white border-b border-gray-200 shadow-lg z-50 overflow-y-auto"
-        :style="{ top: headerRef ? headerRef.offsetHeight + 'px' : '4rem' }"
-      >
-        <div class="p-2 space-y-1">
-          <p
-            v-if="mergedSessions.length === 0"
-            class="text-xs text-gray-400 p-2"
-          >
-            No sessions yet.
-          </p>
-          <div
-            v-for="session in mergedSessions"
-            :key="session.id"
-            class="cursor-pointer rounded border p-2 text-sm transition-colors"
-            :class="
-              sessionMap.get(session.id)?.isRunning
-                ? 'border-yellow-400 bg-yellow-50 hover:bg-yellow-100'
-                : sessionMap.get(session.id)?.hasUnread
-                  ? 'border-gray-400 bg-white hover:bg-gray-50'
-                  : session.id === currentSessionId
-                    ? 'border-blue-400 bg-blue-50 hover:bg-blue-100'
-                    : 'border-gray-200 hover:bg-gray-50'
-            "
-            :data-testid="`session-item-${session.id}`"
-            @click="loadSession(session.id)"
-          >
-            <div class="flex items-center gap-1 text-xs text-gray-500 mb-1">
-              <span class="material-icons text-xs">{{
-                roleIcon(session.roleId)
-              }}</span>
-              <span>{{ roleName(session.roleId) }}</span>
-              <span class="ml-auto flex items-center gap-1.5">
-                <span
-                  v-if="sessionMap.get(session.id)?.isRunning"
-                  class="flex items-center gap-0.5 text-yellow-600 font-medium"
-                >
-                  <span
-                    class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse"
-                  />
-                  Running
-                </span>
-                <span
-                  v-else-if="sessionMap.get(session.id)?.hasUnread"
-                  class="flex items-center gap-0.5 text-gray-900 font-bold"
-                >
-                  Unread
-                </span>
-                <span v-else>{{ formatDate(session.updatedAt) }}</span>
-              </span>
-            </div>
-            <p
-              class="truncate"
-              :class="
-                sessionMap.get(session.id)?.isRunning
-                  ? 'text-yellow-800'
-                  : sessionMap.get(session.id)?.hasUnread
-                    ? 'text-gray-900 font-bold'
-                    : 'text-gray-700'
-              "
-            >
-              {{ session.preview || "(no messages)" }}
-            </p>
-            <!-- Optional second line: AI-generated summary of the
-                 session, populated by the chat indexer (#123).
-                 Older sessions with no index entry simply omit this. -->
-            <p
-              v-if="session.summary"
-              class="text-xs text-gray-500 truncate mt-0.5"
-            >
-              {{ session.summary }}
-            </p>
-          </div>
-        </div>
-      </div>
+        ref="historyPanelRef"
+        :sessions="mergedSessions"
+        :session-map="sessionMap"
+        :current-session-id="currentSessionId"
+        :roles="roles"
+        :top-offset="headerRef?.offsetHeight"
+        @load-session="loadSession"
+      />
 
       <!-- Role selector -->
       <div
@@ -493,6 +426,7 @@ import { SYSTEM_PROMPT } from "./config/system-prompt";
 import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import RightSidebar from "./components/RightSidebar.vue";
+import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import CanvasViewToggle from "./components/CanvasViewToggle.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
@@ -507,7 +441,6 @@ import {
   roleIcon as roleIconLookup,
   roleName as roleNameLookup,
 } from "./utils/role/icon";
-import { formatDate } from "./utils/format/date";
 import { findScrollableChild } from "./utils/dom/scrollable";
 import { buildAgentRequestBody } from "./utils/agent/request";
 import { parseSSEChunk } from "./utils/agent/sse";
@@ -727,7 +660,10 @@ const chatListRef = ref<HTMLDivElement | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const historyButtonRef = ref<HTMLButtonElement | null>(null);
-const historyPopupRef = ref<HTMLDivElement | null>(null);
+// Exposed `root` from SessionHistoryPanel — the click-outside guard
+// needs the actual popup DOM element (not the component instance).
+const historyPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
+const historyPopupRef = computed(() => historyPanelRef.value?.root ?? null);
 const lockButtonRef = ref<HTMLButtonElement | null>(null);
 const lockPopupRef = ref<HTMLDivElement | null>(null);
 const headerRef = ref<HTMLDivElement | null>(null);

--- a/src/App.vue
+++ b/src/App.vue
@@ -485,7 +485,6 @@ import {
   watch,
   nextTick,
   onMounted,
-  onUnmounted,
   reactive,
   markRaw,
 } from "vue";
@@ -532,6 +531,7 @@ import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
 import { useQueriesPanel } from "./composables/useQueriesPanel";
+import { useEventListeners } from "./composables/useEventListeners";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -1296,15 +1296,17 @@ const { handler: handleClickOutsideRoleDropdown } = useClickOutside({
   popupRef: roleDropdownRef,
 });
 
+useEventListeners({
+  onRolesUpdated: refreshRoles,
+  onKeyNavigation: handleKeyNavigation,
+  onViewModeShortcut: handleViewModeShortcut,
+  onClickOutsideHistory: handleClickOutsideHistory,
+  onClickOutsideLock: handleClickOutsideLock,
+  onClickOutsideRoleDropdown: handleClickOutsideRoleDropdown,
+  onTeardown: teardownPendingCalls,
+});
+
 onMounted(async () => {
-  // Listeners first so the UI responds to interactions even if the
-  // async fetches below take a moment.
-  window.addEventListener("roles-updated", refreshRoles);
-  window.addEventListener("keydown", handleKeyNavigation);
-  window.addEventListener("mousedown", handleClickOutsideHistory);
-  window.addEventListener("mousedown", handleClickOutsideLock);
-  window.addEventListener("mousedown", handleClickOutsideRoleDropdown);
-  window.addEventListener("keydown", handleViewModeShortcut);
   // Fire-and-forget side fetches.
   fetchHealth();
   fetchMcpToolsStatus();
@@ -1334,15 +1336,5 @@ onMounted(async () => {
   } else {
     createNewSession();
   }
-});
-
-onUnmounted(() => {
-  window.removeEventListener("roles-updated", refreshRoles);
-  window.removeEventListener("keydown", handleKeyNavigation);
-  window.removeEventListener("mousedown", handleClickOutsideHistory);
-  window.removeEventListener("mousedown", handleClickOutsideLock);
-  window.removeEventListener("mousedown", handleClickOutsideRoleDropdown);
-  window.removeEventListener("keydown", handleViewModeShortcut);
-  teardownPendingCalls();
 });
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,72 +48,13 @@
               >{{ unreadCount }}</span
             >
           </button>
-          <div class="relative">
-            <button
-              ref="lockButtonRef"
-              :class="
-                sandboxEnabled
-                  ? 'text-green-500 hover:text-green-700'
-                  : 'text-amber-400 hover:text-amber-500'
-              "
-              :title="
-                sandboxEnabled
-                  ? 'Sandbox enabled (Docker)'
-                  : 'No sandbox (Docker not found)'
-              "
-              @click="showLockPopup = !showLockPopup"
-            >
-              <span class="material-icons">{{
-                sandboxEnabled ? "lock" : "lock_open"
-              }}</span>
-            </button>
-            <div
-              v-if="showLockPopup"
-              ref="lockPopupRef"
-              class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-3 text-xs"
-            >
-              <p
-                class="mb-2"
-                :class="sandboxEnabled ? 'text-green-800' : 'text-amber-500'"
-              >
-                <template v-if="sandboxEnabled">
-                  <span class="material-icons text-xs align-middle mr-1"
-                    >lock</span
-                  >
-                  <strong>Sandbox enabled:</strong> Docker is running.
-                  Filesystem access is isolated.
-                </template>
-                <template v-else>
-                  <span class="material-icons text-xs align-middle mr-1"
-                    >warning</span
-                  >
-                  <strong>No sandbox:</strong> Claude can access all files on
-                  your machine. Install
-                  <a
-                    href="https://www.docker.com/products/docker-desktop/"
-                    target="_blank"
-                    class="underline"
-                    >Docker Desktop</a
-                  >
-                  to enable filesystem isolation.
-                </template>
-              </p>
-              <p class="text-gray-400 mb-1">Test sandbox isolation:</p>
-              <div class="flex flex-col gap-1">
-                <button
-                  v-for="q in sandboxTestQueries"
-                  :key="q"
-                  class="text-left rounded px-2 py-1 bg-gray-100 hover:bg-gray-200 text-gray-700 transition-colors"
-                  @click="
-                    showLockPopup = false;
-                    sendMessage(q);
-                  "
-                >
-                  {{ q }}
-                </button>
-              </div>
-            </div>
-          </div>
+          <LockStatusPopup
+            ref="lockPopupRef"
+            :sandbox-enabled="sandboxEnabled"
+            :open="showLockPopup"
+            @update:open="showLockPopup = $event"
+            @test-query="sendMessage"
+          />
           <button
             class="text-gray-400 hover:text-gray-700"
             :class="{ 'text-blue-500': showRightSidebar }"
@@ -427,6 +368,7 @@ import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import RightSidebar from "./components/RightSidebar.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
+import LockStatusPopup from "./components/LockStatusPopup.vue";
 import CanvasViewToggle from "./components/CanvasViewToggle.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
@@ -649,13 +591,6 @@ const { sessions, showHistory, fetchSessions, toggleHistory } =
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
 
-const sandboxTestQueries = [
-  "Run `whoami` and show the result",
-  "Run `hostname` and show the result",
-  "Try to list files in ~/Library",
-  "Read helps/sandbox.md and explain how the sandbox works",
-];
-
 const chatListRef = ref<HTMLDivElement | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
@@ -664,8 +599,14 @@ const historyButtonRef = ref<HTMLButtonElement | null>(null);
 // needs the actual popup DOM element (not the component instance).
 const historyPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const historyPopupRef = computed(() => historyPanelRef.value?.root ?? null);
-const lockButtonRef = ref<HTMLButtonElement | null>(null);
-const lockPopupRef = ref<HTMLDivElement | null>(null);
+// Lock popup exposes its button + popup DOM via defineExpose so the
+// click-outside guard has both references without poking the template.
+const lockPopupRef = ref<{
+  button: HTMLButtonElement | null;
+  popup: HTMLDivElement | null;
+} | null>(null);
+const lockButtonRef = computed(() => lockPopupRef.value?.button ?? null);
+const lockPopupElRef = computed(() => lockPopupRef.value?.popup ?? null);
 const headerRef = ref<HTMLDivElement | null>(null);
 const roleButtonRef = ref<HTMLButtonElement | null>(null);
 const roleDropdownRef = ref<HTMLDivElement | null>(null);
@@ -1224,7 +1165,7 @@ const { handler: handleClickOutsideHistory } = useClickOutside({
 const { handler: handleClickOutsideLock } = useClickOutside({
   isOpen: showLockPopup,
   buttonRef: lockButtonRef,
-  popupRef: lockPopupRef,
+  popupRef: lockPopupElRef,
 });
 const { handler: handleClickOutsideRoleDropdown } = useClickOutside({
   isOpen: showRoleDropdown,

--- a/src/App.vue
+++ b/src/App.vue
@@ -159,62 +159,16 @@
       </div>
 
       <!-- Tool result previews -->
-      <div
-        ref="chatListRef"
-        class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 bg-gray-100 outline-none"
-        tabindex="0"
-        @mousedown="activePane = 'sidebar'"
-      >
-        <div
-          v-for="result in sidebarResults"
-          :key="result.uuid"
-          class="cursor-pointer rounded border border-gray-300 p-2 text-sm text-gray-900 hover:opacity-75 transition-opacity"
-          :class="
-            result.uuid === selectedResultUuid ? 'ring-2 ring-blue-500' : ''
-          "
-          @click="onSidebarItemClick(result.uuid)"
-        >
-          <component
-            :is="getPlugin(result.toolName)?.previewComponent"
-            v-if="getPlugin(result.toolName)?.previewComponent"
-            :result="result"
-          />
-          <span v-else>{{ result.title || result.toolName }}</span>
-        </div>
-
-        <!-- Thinking indicator -->
-        <div v-if="isRunning" class="px-2 py-1 text-sm">
-          <div class="flex items-center gap-2 text-gray-500">
-            <span class="text-xs">{{ statusMessage }}</span>
-            <span class="flex gap-1">
-              <span
-                class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
-                style="animation-delay: 0ms"
-              />
-              <span
-                class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
-                style="animation-delay: 150ms"
-              />
-              <span
-                class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
-                style="animation-delay: 300ms"
-              />
-            </span>
-          </div>
-          <div v-if="pendingCalls.length > 0" class="mt-1 space-y-0.5">
-            <div
-              v-for="call in pendingCalls"
-              :key="call.toolUseId"
-              class="flex items-center gap-1.5 text-xs text-gray-400"
-            >
-              <span
-                class="w-1.5 h-1.5 rounded-full bg-blue-300 shrink-0 animate-pulse"
-              />
-              <span class="font-mono truncate">{{ call.toolName }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <ToolResultsPanel
+        ref="toolResultsPanelRef"
+        :results="sidebarResults"
+        :selected-uuid="selectedResultUuid"
+        :is-running="isRunning"
+        :status-message="statusMessage"
+        :pending-calls="pendingCalls"
+        @select="onSidebarItemClick"
+        @activate="activePane = 'sidebar'"
+      />
 
       <!-- Sample queries (expandable pane) -->
       <div v-if="showQueries" class="border-t border-gray-200">
@@ -369,6 +323,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import RightSidebar from "./components/RightSidebar.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import LockStatusPopup from "./components/LockStatusPopup.vue";
+import ToolResultsPanel from "./components/ToolResultsPanel.vue";
 import CanvasViewToggle from "./components/CanvasViewToggle.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
@@ -591,7 +546,8 @@ const { sessions, showHistory, fetchSessions, toggleHistory } =
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
 
-const chatListRef = ref<HTMLDivElement | null>(null);
+const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
+const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const historyButtonRef = ref<HTMLButtonElement | null>(null);

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="relative">
+    <button
+      ref="button"
+      data-testid="sandbox-lock-button"
+      :class="
+        sandboxEnabled
+          ? 'text-green-500 hover:text-green-700'
+          : 'text-amber-400 hover:text-amber-500'
+      "
+      :title="
+        sandboxEnabled
+          ? 'Sandbox enabled (Docker)'
+          : 'No sandbox (Docker not found)'
+      "
+      @click="emit('update:open', !open)"
+    >
+      <span class="material-icons">{{
+        sandboxEnabled ? "lock" : "lock_open"
+      }}</span>
+    </button>
+    <div
+      v-if="open"
+      ref="popup"
+      class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-3 text-xs"
+    >
+      <p
+        class="mb-2"
+        :class="sandboxEnabled ? 'text-green-800' : 'text-amber-500'"
+      >
+        <template v-if="sandboxEnabled">
+          <span class="material-icons text-xs align-middle mr-1">lock</span>
+          <strong>Sandbox enabled:</strong> Docker is running. Filesystem access
+          is isolated.
+        </template>
+        <template v-else>
+          <span class="material-icons text-xs align-middle mr-1">warning</span>
+          <strong>No sandbox:</strong> Claude can access all files on your
+          machine. Install
+          <a
+            href="https://www.docker.com/products/docker-desktop/"
+            target="_blank"
+            class="underline"
+            >Docker Desktop</a
+          >
+          to enable filesystem isolation.
+        </template>
+      </p>
+      <p class="text-gray-400 mb-1">Test sandbox isolation:</p>
+      <div class="flex flex-col gap-1">
+        <button
+          v-for="q in SANDBOX_TEST_QUERIES"
+          :key="q"
+          data-testid="sandbox-test-query"
+          class="text-left rounded px-2 py-1 bg-gray-100 hover:bg-gray-200 text-gray-700 transition-colors"
+          @click="onTestQuery(q)"
+        >
+          {{ q }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+defineProps<{
+  sandboxEnabled: boolean;
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:open": [value: boolean];
+  testQuery: [query: string];
+}>();
+
+// Canned queries that demonstrate what the sandbox does / doesn't
+// allow. Kept here (not passed as a prop) because they are specific
+// to this popup and nothing else in the app needs them.
+const SANDBOX_TEST_QUERIES = [
+  "Run `whoami` and show the result",
+  "Run `hostname` and show the result",
+  "Try to list files in ~/Library",
+  "Read helps/sandbox.md and explain how the sandbox works",
+];
+
+const button = ref<HTMLButtonElement | null>(null);
+const popup = ref<HTMLDivElement | null>(null);
+defineExpose({ button, popup });
+
+function onTestQuery(q: string): void {
+  emit("update:open", false);
+  emit("testQuery", q);
+}
+</script>

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -1,0 +1,101 @@
+<template>
+  <div
+    ref="root"
+    class="absolute left-0 right-0 bottom-0 bg-white border-b border-gray-200 shadow-lg z-50 overflow-y-auto"
+    :style="{ top: topOffset != null ? topOffset + 'px' : '4rem' }"
+  >
+    <div class="p-2 space-y-1">
+      <p v-if="sessions.length === 0" class="text-xs text-gray-400 p-2">
+        No sessions yet.
+      </p>
+      <div
+        v-for="session in sessions"
+        :key="session.id"
+        class="cursor-pointer rounded border p-2 text-sm transition-colors"
+        :class="rowClasses(session)"
+        :data-testid="`session-item-${session.id}`"
+        @click="emit('loadSession', session.id)"
+      >
+        <div class="flex items-center gap-1 text-xs text-gray-500 mb-1">
+          <span class="material-icons text-xs">{{
+            roleIconFor(session.roleId)
+          }}</span>
+          <span>{{ roleNameFor(session.roleId) }}</span>
+          <span class="ml-auto flex items-center gap-1.5">
+            <span
+              v-if="sessionMap.get(session.id)?.isRunning"
+              class="flex items-center gap-0.5 text-yellow-600 font-medium"
+            >
+              <span
+                class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse"
+              />
+              Running
+            </span>
+            <span
+              v-else-if="sessionMap.get(session.id)?.hasUnread"
+              class="flex items-center gap-0.5 text-gray-900 font-bold"
+            >
+              Unread
+            </span>
+            <span v-else>{{ formatDate(session.updatedAt) }}</span>
+          </span>
+        </div>
+        <p class="truncate" :class="previewClasses(session)">
+          {{ session.preview || "(no messages)" }}
+        </p>
+        <!-- Optional second line: AI-generated summary of the
+             session, populated by the chat indexer (#123). -->
+        <p v-if="session.summary" class="text-xs text-gray-500 truncate mt-0.5">
+          {{ session.summary }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type { Role } from "../config/roles";
+import type { SessionSummary, ActiveSession } from "../types/session";
+import { formatDate } from "../utils/format/date";
+import { roleIcon, roleName } from "../utils/role/icon";
+
+const props = defineProps<{
+  sessions: SessionSummary[];
+  sessionMap: Map<string, ActiveSession>;
+  currentSessionId: string;
+  roles: Role[];
+  topOffset?: number;
+}>();
+
+const emit = defineEmits<{
+  loadSession: [id: string];
+}>();
+
+const root = ref<HTMLDivElement | null>(null);
+defineExpose({ root });
+
+function roleIconFor(id: string): string {
+  return roleIcon(props.roles, id);
+}
+function roleNameFor(id: string): string {
+  return roleName(props.roles, id);
+}
+
+function rowClasses(session: SessionSummary): string {
+  const live = props.sessionMap.get(session.id);
+  if (live?.isRunning)
+    return "border-yellow-400 bg-yellow-50 hover:bg-yellow-100";
+  if (live?.hasUnread) return "border-gray-400 bg-white hover:bg-gray-50";
+  if (session.id === props.currentSessionId)
+    return "border-blue-400 bg-blue-50 hover:bg-blue-100";
+  return "border-gray-200 hover:bg-gray-50";
+}
+
+function previewClasses(session: SessionSummary): string {
+  const live = props.sessionMap.get(session.id);
+  if (live?.isRunning) return "text-yellow-800";
+  if (live?.hasUnread) return "text-gray-900 font-bold";
+  return "text-gray-700";
+}
+</script>

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -1,0 +1,83 @@
+<template>
+  <div
+    ref="root"
+    class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 bg-gray-100 outline-none"
+    tabindex="0"
+    @mousedown="emit('activate')"
+  >
+    <div
+      v-for="result in results"
+      :key="result.uuid"
+      class="cursor-pointer rounded border border-gray-300 p-2 text-sm text-gray-900 hover:opacity-75 transition-opacity"
+      :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
+      @click="emit('select', result.uuid)"
+    >
+      <component
+        :is="getPlugin(result.toolName)?.previewComponent"
+        v-if="getPlugin(result.toolName)?.previewComponent"
+        :result="result"
+      />
+      <span v-else>{{ result.title || result.toolName }}</span>
+    </div>
+
+    <!-- Thinking indicator -->
+    <div v-if="isRunning" class="px-2 py-1 text-sm">
+      <div class="flex items-center gap-2 text-gray-500">
+        <span class="text-xs">{{ statusMessage }}</span>
+        <span class="flex gap-1">
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
+            style="animation-delay: 0ms"
+          />
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
+            style="animation-delay: 150ms"
+          />
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce"
+            style="animation-delay: 300ms"
+          />
+        </span>
+      </div>
+      <div v-if="pendingCalls.length > 0" class="mt-1 space-y-0.5">
+        <div
+          v-for="call in pendingCalls"
+          :key="call.toolUseId"
+          class="flex items-center gap-1.5 text-xs text-gray-400"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-blue-300 shrink-0 animate-pulse"
+          />
+          <span class="font-mono truncate">{{ call.toolName }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { getPlugin } from "../tools";
+
+interface PendingCall {
+  toolUseId: string;
+  toolName: string;
+}
+
+defineProps<{
+  results: ToolResultComplete[];
+  selectedUuid: string | null;
+  isRunning: boolean;
+  statusMessage: string;
+  pendingCalls: PendingCall[];
+}>();
+
+const emit = defineEmits<{
+  select: [uuid: string];
+  activate: [];
+}>();
+
+const root = ref<HTMLDivElement | null>(null);
+defineExpose({ root });
+</script>

--- a/src/composables/useEventListeners.ts
+++ b/src/composables/useEventListeners.ts
@@ -1,0 +1,49 @@
+// Composable that wires all the window-level event listeners used by
+// App.vue (click-outside handlers for 3 popups, global keydown for
+// navigation + view-mode shortcuts, and the `roles-updated` custom
+// event) and tears them down on unmount.
+//
+// Each listener is supplied as an option so the composable stays
+// independent of App.vue's local state; the caller passes the
+// already-bound handlers.
+
+import { onMounted, onUnmounted } from "vue";
+
+export interface EventListenerHandlers {
+  /** Called when the manageRoles plugin dispatches a `roles-updated` CustomEvent. */
+  onRolesUpdated: () => void | Promise<void>;
+  /** Global keydown for arrow-key navigation / Esc handling. */
+  onKeyNavigation: (e: KeyboardEvent) => void;
+  /** Global keydown for Cmd/Ctrl+1/2/3 view-mode shortcut. */
+  onViewModeShortcut: (e: KeyboardEvent) => void;
+  /** mousedown click-outside handlers for each popup. */
+  onClickOutsideHistory: (e: MouseEvent) => void;
+  onClickOutsideLock: (e: MouseEvent) => void;
+  onClickOutsideRoleDropdown: (e: MouseEvent) => void;
+  /** Called in onUnmounted after all window listeners are removed. */
+  onTeardown?: () => void;
+}
+
+export function useEventListeners(handlers: EventListenerHandlers): void {
+  onMounted(() => {
+    window.addEventListener("roles-updated", handlers.onRolesUpdated);
+    window.addEventListener("keydown", handlers.onKeyNavigation);
+    window.addEventListener("keydown", handlers.onViewModeShortcut);
+    window.addEventListener("mousedown", handlers.onClickOutsideHistory);
+    window.addEventListener("mousedown", handlers.onClickOutsideLock);
+    window.addEventListener("mousedown", handlers.onClickOutsideRoleDropdown);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("roles-updated", handlers.onRolesUpdated);
+    window.removeEventListener("keydown", handlers.onKeyNavigation);
+    window.removeEventListener("keydown", handlers.onViewModeShortcut);
+    window.removeEventListener("mousedown", handlers.onClickOutsideHistory);
+    window.removeEventListener("mousedown", handlers.onClickOutsideLock);
+    window.removeEventListener(
+      "mousedown",
+      handlers.onClickOutsideRoleDropdown,
+    );
+    handlers.onTeardown?.();
+  });
+}

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -1,0 +1,38 @@
+// Composable for the server /api/health probe.
+//
+// Owns two refs that the UI reads (gemini key availability + sandbox
+// toggle) plus the one-shot fetch that populates them on mount. On
+// fetch failure we assume Gemini is unavailable so dependent UI
+// (e.g. the "generate image" plugin buttons) falls back gracefully
+// — the sandbox flag keeps its initial `true` so the lock indicator
+// doesn't momentarily flash "sandbox disabled" on a transient error.
+
+import { ref, type Ref } from "vue";
+
+interface HealthResponse {
+  geminiAvailable?: unknown;
+  sandboxEnabled?: unknown;
+}
+
+export function useHealth(): {
+  geminiAvailable: Ref<boolean>;
+  sandboxEnabled: Ref<boolean>;
+  fetchHealth: () => Promise<void>;
+} {
+  const geminiAvailable = ref(true);
+  const sandboxEnabled = ref(true);
+
+  async function fetchHealth(): Promise<void> {
+    try {
+      const res = await fetch("/api/health");
+      if (!res.ok) throw new Error("health check failed");
+      const data: HealthResponse = await res.json();
+      geminiAvailable.value = !!data.geminiAvailable;
+      sandboxEnabled.value = !!data.sandboxEnabled;
+    } catch {
+      geminiAvailable.value = false;
+    }
+  }
+
+  return { geminiAvailable, sandboxEnabled, fetchHealth };
+}

--- a/src/composables/useQueriesPanel.ts
+++ b/src/composables/useQueriesPanel.ts
@@ -1,0 +1,49 @@
+// Composable for the role-specific "quick queries" panel in the
+// chat footer.
+//
+// Owns the expanded/collapsed flag, the scrollable list's template
+// ref, and the click handler. When expanded, the list auto-scrolls
+// to its bottom so the most recent/relevant query is visible. On
+// click, Shift fills the input (for editing) and plain click
+// submits the query immediately.
+
+import { nextTick, ref, watch, type Ref } from "vue";
+
+interface UseQueriesPanelDeps {
+  /** The chat input ref, populated on Shift+click. */
+  userInput: Ref<string>;
+  /** The textarea DOM ref, focused after Shift+click. */
+  textareaRef: Ref<HTMLTextAreaElement | null>;
+  /** Invoked on plain click to send the query as a message. */
+  sendMessage: (message: string) => void;
+}
+
+export function useQueriesPanel(deps: UseQueriesPanelDeps): {
+  queriesExpanded: Ref<boolean>;
+  queriesListRef: Ref<HTMLDivElement | null>;
+  onQueryClick: (e: MouseEvent, query: string) => void;
+} {
+  const queriesExpanded = ref(false);
+  const queriesListRef = ref<HTMLDivElement | null>(null);
+
+  watch(queriesExpanded, (expanded) => {
+    if (!expanded) return;
+    nextTick(() => {
+      if (queriesListRef.value) {
+        queriesListRef.value.scrollTop = queriesListRef.value.scrollHeight;
+      }
+    });
+  });
+
+  function onQueryClick(e: MouseEvent, query: string): void {
+    queriesExpanded.value = false;
+    if (e.shiftKey) {
+      deps.userInput.value = query;
+      nextTick(() => deps.textareaRef.value?.focus());
+      return;
+    }
+    deps.sendMessage(query);
+  }
+
+  return { queriesExpanded, queriesListRef, onQueryClick };
+}

--- a/src/composables/useRightSidebar.ts
+++ b/src/composables/useRightSidebar.ts
@@ -1,0 +1,23 @@
+// Composable for the right-sidebar (tool-history) visibility toggle.
+//
+// Persists the open/closed state to localStorage so user preference
+// survives reloads. Kept out of the URL — this is pure "my personal
+// UI choice" rather than a shareable view of the session.
+
+import { ref, type Ref } from "vue";
+
+const STORAGE_KEY = "right_sidebar_visible";
+
+export function useRightSidebar(): {
+  showRightSidebar: Ref<boolean>;
+  toggleRightSidebar: () => void;
+} {
+  const showRightSidebar = ref(localStorage.getItem(STORAGE_KEY) === "true");
+
+  function toggleRightSidebar(): void {
+    showRightSidebar.value = !showRightSidebar.value;
+    localStorage.setItem(STORAGE_KEY, String(showRightSidebar.value));
+  }
+
+  return { showRightSidebar, toggleRightSidebar };
+}

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -1,0 +1,39 @@
+// Composable for the session-history dropdown in the header.
+//
+// Owns the `sessions` list (what the server knows about) and the
+// `showHistory` open/closed flag, plus the fetch + toggle helpers.
+// The dropdown lazy-loads the list only when opened, and callers
+// can invoke `fetchSessions()` directly after an end-of-run so the
+// sidebar title cache stays fresh.
+
+import { ref, type Ref } from "vue";
+import type { SessionSummary } from "../types/session";
+
+export function useSessionHistory(): {
+  sessions: Ref<SessionSummary[]>;
+  showHistory: Ref<boolean>;
+  fetchSessions: () => Promise<SessionSummary[]>;
+  toggleHistory: () => Promise<void>;
+} {
+  const sessions = ref<SessionSummary[]>([]);
+  const showHistory = ref(false);
+
+  async function fetchSessions(): Promise<SessionSummary[]> {
+    try {
+      const res = await fetch("/api/sessions");
+      const data: SessionSummary[] = await res.json();
+      sessions.value = data;
+      return data;
+    } catch {
+      sessions.value = [];
+      return [];
+    }
+  }
+
+  async function toggleHistory(): Promise<void> {
+    showHistory.value = !showHistory.value;
+    if (showHistory.value) await fetchSessions();
+  }
+
+  return { sessions, showHistory, fetchSessions, toggleHistory };
+}


### PR DESCRIPTION
## 関連

Closes #183 (段階的 App.vue 縮小プラン)

## User Prompt

> app.vueをもっと小さくしたい。理想は500 lines以下。
> 日本語で良いのでissue化して。そして１つ１つ進めよう。

## Status

**このPR は WIP (Draft)** です。Phase ごとにコミットを積み上げ、全 Phase 完了後に Draft を外してレビューに回します。

### 進捗

- [x] `useHealth` (e7715ce)
- [x] `useSessionHistory` (d3673ff)
- [x] `useRightSidebar` (c6f424a)
- [x] `useQueriesPanel` (6d3e9b7)
- [ ] Phase A: `useEventListeners`
- [ ] Phase B: `SessionHistoryPanel.vue`
- [ ] Phase C: `LockStatusPopup.vue`
- [ ] Phase D: `ToolResultsPanel.vue`
- [ ] Phase E: `useResultSelection`
- [ ] Phase F: `useAgentPipeline`
- [ ] Phase G: `useSessionNavigation`
- [ ] Phase H: `CanvasArea.vue`
- [ ] Phase I: `ChatInputArea.vue`

**開始時点:** 1394 行  
**現在:** 1348 行  
**目標:** <500 行

## 方針

- 1 コミット = 1 Phase
- 各 Phase 完了時に `yarn format` / `lint` / `typecheck` / `test` / `test:e2e` 全緑を確認
- HIGH risk Phase (G〜I) は E2E 走行で挙動保証

詳細な plan は #183 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)