### PR TITLE
refactor: eliminate sonarjs/slow-regex warnings in .vue files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -123,10 +123,6 @@ export default [
       // isn't blocked — follow-up PRs should refactor each and
       // re-raise to error. See CLAUDE.md's Functions section.
       "sonarjs/cognitive-complexity": "warn",
-      // Pre-existing slow-regex hits in `.vue` files; demote to
-      // warn for the same reason. Each case needs a targeted
-      // regex rewrite in a follow-up.
-      "sonarjs/slow-regex": "warn",
       // `wiki/View.vue` uses `v-html` intentionally to render
       // sanitised markdown. Warn so the justified usage doesn't
       // block CI — audit per-use at review time.

--- a/server/journal/index.ts
+++ b/server/journal/index.ts
@@ -35,6 +35,9 @@ import {
   ClaudeCliNotFoundError,
   type Summarize,
 } from "./archivist.js";
+import { extractFirstH1 } from "../../src/utils/markdown/extractFirstH1.js";
+
+export { extractFirstH1 };
 
 // Module-level lock. A boolean is enough for the single-process
 // single-user MulmoClaude server; if two sessions finish at the
@@ -256,21 +259,4 @@ async function countArchivedTopics(workspaceRoot: string): Promise<number> {
   } catch {
     return 0;
   }
-}
-
-// Extract the first `# Heading` line from a markdown body. Returns
-// null if there isn't one. Used for topic row labels.
-//
-// Implemented without a regex to satisfy sonarjs/slow-regex — a
-// prefix check is just as readable for this small grammar and has
-// zero backtracking risk.
-export function extractFirstH1(markdown: string): string | null {
-  for (const line of markdown.split("\n")) {
-    // H1 requires "#" followed by a space, which also naturally
-    // excludes H2 ("## ") and H3 ("### ") etc.
-    if (!line.startsWith("# ")) continue;
-    const text = line.slice(2).trim();
-    if (text.length > 0) return text;
-  }
-  return null;
 }

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -16,6 +16,7 @@
 import { computed, ref, watch } from "vue";
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
+import { extractFirstH1 } from "../../utils/markdown/extractFirstH1";
 
 const props = defineProps<{
   result: ToolResult<MarkdownToolData>;
@@ -53,10 +54,8 @@ const displayTitle = computed(() => {
   }
   const md = resolvedMarkdown.value;
   if (md) {
-    const match = md.match(/^#\s+(.+)$/m);
-    if (match) {
-      return match[1];
-    }
+    const h1 = extractFirstH1(md);
+    if (h1) return h1;
   }
   return "Markdown Document";
 });

--- a/src/plugins/presentHtml/Preview.vue
+++ b/src/plugins/presentHtml/Preview.vue
@@ -13,17 +13,15 @@
 import { computed } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { PresentHtmlData } from "./index";
+import { stripHtmlToPreview } from "./helpers";
+
+const HINT_MAX_LENGTH = 60;
 
 const props = defineProps<{ result: ToolResultComplete<PresentHtmlData> }>();
 
 const data = computed(() => props.result.data);
 const title = computed(() => data.value?.title ?? "HTML Page");
-const hint = computed(() => {
-  const raw = data.value?.html ?? "";
-  const stripped = raw
-    .replace(/<[^>]*>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return stripped.slice(0, 60);
-});
+const hint = computed(() =>
+  stripHtmlToPreview(data.value?.html ?? "", HINT_MAX_LENGTH),
+);
 </script>

--- a/src/plugins/presentHtml/helpers.ts
+++ b/src/plugins/presentHtml/helpers.ts
@@ -1,12 +1,15 @@
 // Pure helpers for presentHtml/Preview.vue. Replaces the former
 // `/<[^>]*>/g` + `/\s+/g` regex pair — both flagged by
 // `sonarjs/slow-regex` for backtracking risk — with a single
-// linear walker.
+// linear walker that produces the exact same output.
 
 /**
  * Produce a short plain-text preview from an HTML fragment:
  *
- * - all `<...>` tag spans are removed (replaced by a single space)
+ * - every `<...>` span (a `<` with a later `>`) is replaced by a
+ *   single space
+ * - a bare `<` with no matching `>` is kept as a literal character
+ *   (matches the old regex, which required both brackets to match)
  * - runs of whitespace are collapsed to one space
  * - the result is trimmed and truncated to `maxLength` characters
  *
@@ -20,19 +23,21 @@ export function stripHtmlToPreview(html: string, maxLength: number): string {
     // and a leading tag both get trimmed without a separate pass.
     lastWasSpace: true,
   };
-  let inTag = false;
-  for (let i = 0; i < html.length; i++) {
+  let i = 0;
+  while (i < html.length) {
     const c = html[i];
-    if (inTag) {
-      if (c === ">") inTag = false;
-      continue;
-    }
     if (c === "<") {
-      inTag = true;
-      emitSeparator(state);
-      continue;
+      const close = html.indexOf(">", i + 1);
+      if (close !== -1) {
+        // Real tag span `<...>` — skip it, emit a separator.
+        emitSeparator(state);
+        i = close + 1;
+        continue;
+      }
+      // No closing `>` anywhere after — treat as literal.
     }
     emitChar(state, c);
+    i++;
   }
   trimTrailingSpace(state.out);
   return state.out.join("").slice(0, maxLength);

--- a/src/plugins/presentHtml/helpers.ts
+++ b/src/plugins/presentHtml/helpers.ts
@@ -1,0 +1,74 @@
+// Pure helpers for presentHtml/Preview.vue. Replaces the former
+// `/<[^>]*>/g` + `/\s+/g` regex pair — both flagged by
+// `sonarjs/slow-regex` for backtracking risk — with a single
+// linear walker.
+
+/**
+ * Produce a short plain-text preview from an HTML fragment:
+ *
+ * - all `<...>` tag spans are removed (replaced by a single space)
+ * - runs of whitespace are collapsed to one space
+ * - the result is trimmed and truncated to `maxLength` characters
+ *
+ * The walker is O(n) in the input length and does no regex
+ * backtracking.
+ */
+export function stripHtmlToPreview(html: string, maxLength: number): string {
+  const state: WalkerState = {
+    out: [],
+    // Start as if we just emitted a space so leading whitespace
+    // and a leading tag both get trimmed without a separate pass.
+    lastWasSpace: true,
+  };
+  let inTag = false;
+  for (let i = 0; i < html.length; i++) {
+    const c = html[i];
+    if (inTag) {
+      if (c === ">") inTag = false;
+      continue;
+    }
+    if (c === "<") {
+      inTag = true;
+      emitSeparator(state);
+      continue;
+    }
+    emitChar(state, c);
+  }
+  trimTrailingSpace(state.out);
+  return state.out.join("").slice(0, maxLength);
+}
+
+interface WalkerState {
+  out: string[];
+  lastWasSpace: boolean;
+}
+
+function emitChar(state: WalkerState, c: string): void {
+  if (isWhitespace(c)) {
+    emitSeparator(state);
+    return;
+  }
+  state.out.push(c);
+  state.lastWasSpace = false;
+}
+
+function emitSeparator(state: WalkerState): void {
+  if (state.lastWasSpace) return;
+  state.out.push(" ");
+  state.lastWasSpace = true;
+}
+
+function trimTrailingSpace(out: string[]): void {
+  if (out.length > 0 && out[out.length - 1] === " ") out.pop();
+}
+
+function isWhitespace(c: string): boolean {
+  return (
+    c === " " ||
+    c === "\t" ||
+    c === "\n" ||
+    c === "\r" ||
+    c === "\v" ||
+    c === "\f"
+  );
+}

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -139,6 +139,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { renderWikiLinks } from "./helpers";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<WikiData>;
@@ -186,12 +187,7 @@ watch(
 
 const renderedContent = computed(() => {
   if (!content.value) return "";
-  // Replace [[wiki links]] with styled spans before parsing
-  const withLinks = content.value.replace(
-    /\[\[([^\]]+)\]\]/g,
-    '<span class="wiki-link" data-page="$1">$1</span>',
-  );
-  return marked.parse(withLinks) as string;
+  return marked.parse(renderWikiLinks(content.value)) as string;
 });
 
 const navError = ref<string | null>(null);

--- a/src/plugins/wiki/helpers.ts
+++ b/src/plugins/wiki/helpers.ts
@@ -1,0 +1,59 @@
+// Pure helpers for wiki/View.vue. Replaces the former
+// `/\[\[([^\]]+)\]\]/g` regex — flagged by `sonarjs/slow-regex`
+// for backtracking risk — with a linear walker.
+
+/**
+ * Replace every `[[page name]]` occurrence in `content` with a
+ * `<span class="wiki-link" data-page="…">…</span>` element. The
+ * page name may not contain `]`; an opening `[[` that is not
+ * followed later by `]]` (with no bare `]` in between) is left
+ * untouched so malformed text renders as-is — matching the
+ * previous regex's non-match behaviour.
+ *
+ * The page-name text is used both as the `data-page` attribute
+ * value and as the span's visible text, identical to the old
+ * replacement string `'<span class="wiki-link" data-page="$1">$1</span>'`.
+ */
+export function renderWikiLinks(content: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === "[" && content[i + 1] === "[") {
+      const closeStart = findNextCloseBrackets(content, i + 2);
+      if (closeStart !== -1) {
+        const page = content.slice(i + 2, closeStart);
+        out.push(`<span class="wiki-link" data-page="${page}">${page}</span>`);
+        i = closeStart + 2;
+        continue;
+      }
+    }
+    out.push(content[i]);
+    i++;
+  }
+  return out.join("");
+}
+
+/**
+ * Starting at `from`, scan forward for a `]]` sequence. Returns
+ * the index of the first `]` of that pair, or -1 if a bare `]`
+ * (one not immediately followed by a second `]`) is encountered
+ * first — mirroring the old regex's `[^\]]+` constraint that the
+ * page name must contain no `]` characters. Also returns -1 if
+ * nothing matched before the end of input, or if the pair sits
+ * immediately after `from` (zero-length page name, which the old
+ * regex rejected via the `+` quantifier).
+ */
+function findNextCloseBrackets(s: string, from: number): number {
+  let j = from;
+  while (j < s.length) {
+    if (s[j] === "]") {
+      if (s[j + 1] === "]" && j > from) return j;
+      // Bare `]` inside the page-name span — old regex would not
+      // match here, so we bail and let the caller emit the `[[`
+      // as literal text.
+      return -1;
+    }
+    j++;
+  }
+  return -1;
+}

--- a/src/utils/markdown/extractFirstH1.ts
+++ b/src/utils/markdown/extractFirstH1.ts
@@ -4,18 +4,36 @@
 //   - src/plugins/markdown/Preview.vue (document title)
 //
 // Implemented as a line walker rather than a regex so it avoids
-// the backtracking risk that trips `sonarjs/slow-regex`.
+// the backtracking risk that trips `sonarjs/slow-regex`. The
+// accepted heading grammar matches the plugin's old regex
+// `/^#\s+(.+)$/m`: `#`, at least one inline whitespace char, then
+// non-empty content.
 
 /**
  * Return the trimmed text of the first H1 line, or null if none
- * exists. An H1 is a line starting with `# ` (hash + space);
- * `##` and deeper headings are skipped.
+ * exists. An H1 is a line that starts with `#` followed by at
+ * least one whitespace char (space or tab) and at least one
+ * non-whitespace content char. `##` and deeper headings are
+ * skipped. Lines are separated by `\n`, `\r`, or `\r\n` —
+ * mirroring the old regex's `m`-flag `$` anchor which stops at
+ * either CR or LF.
  */
 export function extractFirstH1(markdown: string): string | null {
-  for (const line of markdown.split("\n")) {
-    if (!line.startsWith("# ")) continue;
+  for (const line of splitLines(markdown)) {
+    if (line.length < 2 || line[0] !== "#") continue;
+    // Second char must be inline whitespace, not another `#`.
+    // That's what excludes `## H2` / `### H3` / etc.
+    if (!isInlineSpace(line.charCodeAt(1))) continue;
     const text = line.slice(2).trim();
     if (text.length > 0) return text;
   }
   return null;
+}
+
+function splitLines(s: string): string[] {
+  return s.split(/\r\n|\r|\n/);
+}
+
+function isInlineSpace(code: number): boolean {
+  return code === 0x20 || code === 0x09; // space or tab
 }

--- a/src/utils/markdown/extractFirstH1.ts
+++ b/src/utils/markdown/extractFirstH1.ts
@@ -1,0 +1,21 @@
+// Extract the first ATX-style H1 heading (`# title`) from a
+// markdown string. Used by both:
+//   - server/journal/index.ts (topic row labels)
+//   - src/plugins/markdown/Preview.vue (document title)
+//
+// Implemented as a line walker rather than a regex so it avoids
+// the backtracking risk that trips `sonarjs/slow-regex`.
+
+/**
+ * Return the trimmed text of the first H1 line, or null if none
+ * exists. An H1 is a line starting with `# ` (hash + space);
+ * `##` and deeper headings are skipped.
+ */
+export function extractFirstH1(markdown: string): string | null {
+  for (const line of markdown.split("\n")) {
+    if (!line.startsWith("# ")) continue;
+    const text = line.slice(2).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}

--- a/test/journal/test_indexWalkers.ts
+++ b/test/journal/test_indexWalkers.ts
@@ -1,39 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import {
-  extractFirstH1,
-  parseDailyFilename,
-} from "../../server/journal/index.js";
+import { parseDailyFilename } from "../../server/journal/index.js";
 
-describe("extractFirstH1", () => {
-  it("returns the first H1 heading text", () => {
-    const md = "intro\n# Video Generation\nmore body";
-    assert.equal(extractFirstH1(md), "Video Generation");
-  });
-
-  it("prefers the first H1 even when later ones exist", () => {
-    const md = "# First\ntext\n# Second";
-    assert.equal(extractFirstH1(md), "First");
-  });
-
-  it("ignores H2 and deeper headings", () => {
-    const md = "## Not an H1\n### Also not\n# Actual H1";
-    assert.equal(extractFirstH1(md), "Actual H1");
-  });
-
-  it("returns null when no H1 is present", () => {
-    assert.equal(extractFirstH1("## Only H2\ntext"), null);
-    assert.equal(extractFirstH1("plain body no heading"), null);
-  });
-
-  it("trims trailing whitespace from the heading", () => {
-    assert.equal(extractFirstH1("#   spaced heading   "), "spaced heading");
-  });
-
-  it("handles empty input", () => {
-    assert.equal(extractFirstH1(""), null);
-  });
-});
+// `extractFirstH1` lives at src/utils/markdown/extractFirstH1.ts —
+// its tests are in test/utils/markdown/test_extractFirstH1.ts.
 
 describe("parseDailyFilename", () => {
   it("returns the two-digit day for valid DD.md filenames", () => {

--- a/test/plugins/presentHtml/test_helpers.ts
+++ b/test/plugins/presentHtml/test_helpers.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { stripHtmlToPreview } from "../../../src/plugins/presentHtml/helpers.js";
+
+describe("stripHtmlToPreview", () => {
+  it("removes tags and keeps the inner text", () => {
+    assert.equal(stripHtmlToPreview("<b>hello</b>", 60), "hello");
+  });
+
+  it("inserts a space where a tag sat between two text runs", () => {
+    assert.equal(stripHtmlToPreview("hello<br>world", 60), "hello world");
+  });
+
+  it("collapses runs of whitespace into a single space", () => {
+    assert.equal(stripHtmlToPreview("a    b\n\n\tc", 60), "a b c");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    assert.equal(stripHtmlToPreview("   hello   ", 60), "hello");
+  });
+
+  it("trims away a leading or trailing tag cleanly", () => {
+    assert.equal(
+      stripHtmlToPreview("<p>hello</p>", 60),
+      "hello",
+      "leading+trailing tags should not leave stray spaces",
+    );
+  });
+
+  it("collapses empty tag pairs to an empty string", () => {
+    assert.equal(stripHtmlToPreview("<b></b>", 60), "");
+  });
+
+  it("truncates to the requested length", () => {
+    const longText = "word ".repeat(100); // 500 chars
+    assert.equal(stripHtmlToPreview(longText, 10).length, 10);
+  });
+
+  it("returns empty string for empty input", () => {
+    assert.equal(stripHtmlToPreview("", 60), "");
+  });
+
+  it("returns empty string for all-whitespace input", () => {
+    assert.equal(stripHtmlToPreview("   \n\t  ", 60), "");
+  });
+
+  it("returns empty string for a document with only tags", () => {
+    assert.equal(stripHtmlToPreview("<div><span></span></div>", 60), "");
+  });
+
+  it("tolerates an unterminated tag at end of input", () => {
+    // A malformed `<...` at the end has no closing `>`; the
+    // walker stays in-tag for the rest of the input, which
+    // effectively drops the trailing garbage rather than crashing.
+    assert.equal(stripHtmlToPreview("hello<unterminated", 60), "hello");
+  });
+
+  it("handles tags with attributes containing whitespace", () => {
+    assert.equal(
+      stripHtmlToPreview('<a href="x" target="_blank">click</a> here', 60),
+      "click here",
+    );
+  });
+
+  it("does not expand entities (raw characters pass through)", () => {
+    // Former regex didn't decode entities either — `&amp;` comes
+    // out literal. Documented so future readers know the boundary.
+    assert.equal(stripHtmlToPreview("a &amp; b", 60), "a &amp; b");
+  });
+});

--- a/test/plugins/presentHtml/test_helpers.ts
+++ b/test/plugins/presentHtml/test_helpers.ts
@@ -48,11 +48,29 @@ describe("stripHtmlToPreview", () => {
     assert.equal(stripHtmlToPreview("<div><span></span></div>", 60), "");
   });
 
-  it("tolerates an unterminated tag at end of input", () => {
-    // A malformed `<...` at the end has no closing `>`; the
-    // walker stays in-tag for the rest of the input, which
-    // effectively drops the trailing garbage rather than crashing.
-    assert.equal(stripHtmlToPreview("hello<unterminated", 60), "hello");
+  it("keeps a bare `<` with no later `>` as a literal character", () => {
+    // This matches the old `/<[^>]*>/g` regex, which only stripped
+    // `<...>` spans when the closing `>` was present. A bare `<`
+    // in user-authored prose (e.g. `1 < 2`) must survive the
+    // preview pass or the visible text gets truncated.
+    assert.equal(stripHtmlToPreview("1 < 2 is true", 60), "1 < 2 is true");
+    assert.equal(stripHtmlToPreview("a < b", 60), "a < b");
+    assert.equal(stripHtmlToPreview("<", 60), "<");
+  });
+
+  it("keeps an unterminated tag fragment as literal text", () => {
+    // `"hello<unterminated"` has no closing `>`; the old regex
+    // would not match it, so the literal chars survive.
+    assert.equal(
+      stripHtmlToPreview("hello<unterminated", 60),
+      "hello<unterminated",
+    );
+  });
+
+  it("strips only the real tag when mixed with a later bare `<`", () => {
+    // `<tag>` has a `>`, it gets stripped. The later `< c` has no
+    // `>`, it stays literal.
+    assert.equal(stripHtmlToPreview("a <tag> b < c", 60), "a b < c");
   });
 
   it("handles tags with attributes containing whitespace", () => {

--- a/test/plugins/wiki/test_helpers.ts
+++ b/test/plugins/wiki/test_helpers.ts
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { renderWikiLinks } from "../../../src/plugins/wiki/helpers.js";
+
+describe("renderWikiLinks", () => {
+  it("replaces a simple wiki link", () => {
+    assert.equal(
+      renderWikiLinks("See [[Home]] for details."),
+      'See <span class="wiki-link" data-page="Home">Home</span> for details.',
+    );
+  });
+
+  it("replaces multiple wiki links in one string", () => {
+    assert.equal(
+      renderWikiLinks("[[a]] and [[b]]"),
+      '<span class="wiki-link" data-page="a">a</span> and <span class="wiki-link" data-page="b">b</span>',
+    );
+  });
+
+  it("leaves content without wiki links unchanged", () => {
+    assert.equal(renderWikiLinks("just prose"), "just prose");
+  });
+
+  it("returns empty string for empty input", () => {
+    assert.equal(renderWikiLinks(""), "");
+  });
+
+  it("leaves an empty bracket pair untouched", () => {
+    // The old regex required at least one non-`]` char between
+    // `[[` and `]]`. An empty `[[]]` is malformed and stays as-is.
+    assert.equal(renderWikiLinks("[[]]"), "[[]]");
+  });
+
+  it("leaves a bare `[[` with no closing `]]` as literal text", () => {
+    assert.equal(
+      renderWikiLinks("open [[ but no close"),
+      "open [[ but no close",
+    );
+  });
+
+  it("leaves `[[foo]bar]]` as literal — page name cannot contain `]`", () => {
+    // The old `[^\]]+` made `]` illegal in the capture group;
+    // the overall regex didn't match so the string was unchanged.
+    assert.equal(renderWikiLinks("x [[foo]bar]] y"), "x [[foo]bar]] y");
+  });
+
+  it("handles triple brackets the same way the old regex did", () => {
+    // `[[[foo]]]` → the old regex matched `[[[foo]]` greedily so
+    // the page name became `[foo` (including the third `[`) and
+    // the last `]` remained as trailing text. Preserve that quirk.
+    assert.equal(
+      renderWikiLinks("[[[foo]]]"),
+      '<span class="wiki-link" data-page="[foo">[foo</span>]',
+    );
+  });
+
+  it("handles wiki links with spaces in the page name", () => {
+    assert.equal(
+      renderWikiLinks("[[My Page]]"),
+      '<span class="wiki-link" data-page="My Page">My Page</span>',
+    );
+  });
+
+  it("handles adjacent wiki links with no separator", () => {
+    assert.equal(
+      renderWikiLinks("[[a]][[b]]"),
+      '<span class="wiki-link" data-page="a">a</span><span class="wiki-link" data-page="b">b</span>',
+    );
+  });
+
+  it("preserves surrounding markdown syntax", () => {
+    assert.equal(
+      renderWikiLinks("- item: [[x]]"),
+      '- item: <span class="wiki-link" data-page="x">x</span>',
+    );
+  });
+});

--- a/test/utils/markdown/test_extractFirstH1.ts
+++ b/test/utils/markdown/test_extractFirstH1.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractFirstH1 } from "../../../src/utils/markdown/extractFirstH1.js";
+
+describe("extractFirstH1", () => {
+  it("returns the text of the first H1", () => {
+    assert.equal(extractFirstH1("# Hello"), "Hello");
+  });
+
+  it("returns null when there is no heading", () => {
+    assert.equal(extractFirstH1("just text\nmore text"), null);
+  });
+
+  it("returns null for an empty string", () => {
+    assert.equal(extractFirstH1(""), null);
+  });
+
+  it("skips H2 and deeper headings", () => {
+    assert.equal(extractFirstH1("## Subheading\n### Deeper"), null);
+  });
+
+  it("picks the first H1 when multiple are present", () => {
+    assert.equal(extractFirstH1("# First\n# Second"), "First");
+  });
+
+  it("skips intermediate non-H1 lines before finding the H1", () => {
+    assert.equal(
+      extractFirstH1("Intro paragraph\n## Section\n# Real Title\nbody"),
+      "Real Title",
+    );
+  });
+
+  it("trims surrounding whitespace from the heading text", () => {
+    assert.equal(extractFirstH1("#   spaced heading   "), "spaced heading");
+  });
+
+  it("returns null for a bare `#` with no content", () => {
+    assert.equal(extractFirstH1("#"), null);
+  });
+
+  it("returns null for `# ` with only whitespace after", () => {
+    assert.equal(extractFirstH1("#   "), null);
+  });
+
+  it("does not match `#foo` without a separator", () => {
+    assert.equal(extractFirstH1("#foo"), null);
+  });
+
+  it("handles CRLF line endings by trimming the trailing \\r", () => {
+    // Split on `\n` leaves `\r` attached; `.trim()` removes it.
+    assert.equal(extractFirstH1("# Title\r\nbody"), "Title");
+  });
+});

--- a/test/utils/markdown/test_extractFirstH1.ts
+++ b/test/utils/markdown/test_extractFirstH1.ts
@@ -46,8 +46,24 @@ describe("extractFirstH1", () => {
     assert.equal(extractFirstH1("#foo"), null);
   });
 
-  it("handles CRLF line endings by trimming the trailing \\r", () => {
-    // Split on `\n` leaves `\r` attached; `.trim()` removes it.
+  it("handles CRLF line endings", () => {
     assert.equal(extractFirstH1("# Title\r\nbody"), "Title");
+  });
+
+  it("handles CR-only (Mac Classic) line endings", () => {
+    // The old `/^#\s+(.+)$/m` regex's `$` anchor under the `m`
+    // flag stops at either `\r` or `\n`. Preserve that by splitting
+    // on both.
+    assert.equal(extractFirstH1("# Title\rbody"), "Title");
+  });
+
+  it("accepts a tab between `#` and title", () => {
+    // The old `\s+` matched any whitespace including tab; preserve
+    // that so `#\tTitle` still yields `Title`.
+    assert.equal(extractFirstH1("#\tTab after hash"), "Tab after hash");
+  });
+
+  it("returns null when only tabs follow `#`", () => {
+    assert.equal(extractFirstH1("#\t\t"), null);
   });
 });


### PR DESCRIPTION
## User Prompt

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
> sonarjs/slow-regexってなくせる？別PRで。

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
## Summary

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
Eliminates all three `sonarjs/slow-regex` warnings from `.vue` files by replacing backtracking regexes with linear walkers, and removes the `sonarjs/slow-regex: "warn"` demote from `eslint.config.mjs`'s `.vue` override so the rule runs at the same `error` severity as everywhere else.

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
## Changes

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- **`src/plugins/markdown/Preview.vue`** — `/^#\s+(.+)\$/m` replaced with a shared `extractFirstH1` helper. An identical helper already existed at `server/journal/index.ts:267`, so the two were consolidated into `src/utils/markdown/extractFirstH1.ts`; `server/journal/index.ts` now re-exports it to keep its public surface unchanged.

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- **`src/plugins/presentHtml/Preview.vue`** — `/<[^>]*>/g` + `/\s+/g` replaced with `stripHtmlToPreview` (`src/plugins/presentHtml/helpers.ts`), a single-pass walker that strips tags, collapses whitespace, trims, and truncates.

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- **`src/plugins/wiki/View.vue`** — `/\[\[([^\]]+)\]\]/g` replaced with `renderWikiLinks` (`src/plugins/wiki/helpers.ts`), a walker that matches `[[page]]` occurrences with no backtracking. Preserves the old regex's edge-case behaviour (rejects empty pairs, rejects `]` inside the page name, keeps `[[[foo]]]` → `data-page="[foo">[foo</span>]`).

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- **`eslint.config.mjs`** — removed the `.vue` override's `sonarjs/slow-regex: "warn"` line.

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
## Tests

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- Added `test/utils/markdown/test_extractFirstH1.ts` (11 cases), `test/plugins/presentHtml/test_helpers.ts` (13 cases), `test/plugins/wiki/test_helpers.ts` (11 cases) covering happy / edge / malformed / boundary / empty paths.

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- Removed the now-duplicate `extractFirstH1` describe block from `test/journal/test_indexWalkers.ts` (the server test file still exercises `parseDailyFilename`).

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
## Test plan

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn format` clean

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn lint` — 0 errors, only pre-existing unrelated warnings (`vue/no-v-html`, `presentMulmoScript/View.vue` cognitive-complexity)

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn typecheck` passes

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn build` succeeds

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn test` — 1093/1093 pass

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
- [x] `yarn test:e2e` — 92/92 pass

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).


Refs #175 (`sonarjs/slow-regex` フォローアップトラック).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Markdown title detection, improved HTML preview text extraction, and more robust wiki-link rendering for edge cases.

* **Refactor**
  * Shared utilities introduced and components updated to use them (reducing duplicated inline parsing logic).

* **Chore**
  * Linting rule override removed so files follow the recommended SonarJS severity.

* **Tests**
  * Added comprehensive tests for Markdown, HTML preview, and wiki-link helpers; adjusted test locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Refs #175 (`sonarjs/slow-regex` フォローアップトラック).