### PR TITLE
feat(sources): plan + foundation layer for information source registry

### DIFF
--- a/plans/feat-source-registry.md
+++ b/plans/feat-source-registry.md
@@ -235,17 +235,89 @@ Designed in but not used in phase 1:
 | **2** | On-demand `searchSources` + wiki-page generation for research results + notification hookup | Phase 1 stable in daily use |
 | **3** | Auth-bearing fetchers (X / private GitHub / paid APIs) + secrets rotation + per-source rate-limit tuning | Real demand for a specific authed source |
 
-## Open questions (to resolve before implementation PR)
+## Resolved decisions
 
-1. **Taxonomy size**. Starting list above has 16 categories. Too many dilutes filtering; too few forces everything into `general`. Pilot with 16 and re-evaluate after 2 weeks of daily use?
-2. **Daily summary template**. Markdown only, or include a compact structured index (JSON block) so the dashboard can render without re-parsing markdown? Lean toward: both — markdown for humans, fenced JSON block at the end for the dashboard.
-3. **Item dedup across sources**. Two RSS feeds often carry the same HN story. Phase-1 answer: hash the normalized URL (strip utm params), skip dedup across sources but dedup within a single source. Phase-2: cross-source URL dedup.
-4. **Archive size**. Per-source monthly archives grow unbounded. Phase-1: no pruning. Phase-3-ish: add a `journal-archivist`-style compaction pass.
-5. **Error visibility**. When a source fails for 3 days in a row, how does the user learn? Ideas: (a) surface in daily summary footer ("3 sources failed today"), (b) push notification at 5-day mark, (c) badge on the manageSource UI. Pick one.
-6. **Timezone for "daily"**. Local time like the journal, or UTC? Journal uses local — match it.
-7. **Order of fetcher execution**. Parallel across hosts but serial per-host? Or fully serial with a 1s delay? Parallel-across-hosts is faster but needs a per-host queue. Start serial for simplicity; add parallelism if daily run exceeds 5 minutes.
-8. **Failure isolation**. A single source failing must not abort the pipeline. Model: per-source try/catch that logs + advances state + continues.
-9. **Claude-side fetcher invocation pattern**. One agent session per cron run that hits all web-search sources? Or per-source sessions? Per-run is cheaper (shared context, one summary pass) — start there.
+The original spec had 9 open questions; these were worked through in the #188 review thread. Decisions below are what subsequent implementation PRs will follow.
+
+### 1. Taxonomy size — **25 slugs (16 original + 9 expansion)**
+
+Added: `finance` (markets / crypto distinct from `business-news`), `design` (UI/UX — implementation-free complement to `frontend`), `productivity` (tools / workflow / PKM), `science` (broader physics / chem / bio news — `papers` stays academic-only), `health` (medical / fitness / wellness), `gaming`, `climate` (environment / energy / sustainability), `culture` (music / film / books / arts), `policy` (regulation / law / public policy — AI regulation lands here rather than under `ai`).
+
+Rationale: the original 16 were tech-centric enough that everything non-tech collapsed into `general`, defeating the purpose of categorization. Running with a broader table and trimming later (if a slug sees zero use over 2 months) is cheaper than starting small and adding under pressure.
+
+### 2. Daily summary template — **Markdown with a trailing fenced JSON block**
+
+Files under `workspace/news/daily/YYYY/MM/DD.md` are human-readable markdown (headings, bullet items, links). At the tail of the file, a ```` ```json ```` fence contains a compact item index the dashboard (#143) can read without regex-scraping markdown:
+
+```markdown
+# Daily brief — 2026-04-13
+
+## AI
+- [Anthropic releases Claude 4.7](...) — short summary
+- ...
+
+## Security
+- ...
+
+```json
+{
+  "itemCount": 42,
+  "byCategory": {"ai": 12, "security": 4, ...},
+  "items": [{"id": "...", "title": "...", "url": "...", "categories": [...], "severity": null, "sourceSlug": "..."}]
+}
+```
+```
+
+Markdown viewers render the JSON block as a code block and ignore it; dashboard fetches the file and parses the last fenced block as JSON.
+
+### 3. Item dedup — **Archive keeps everything, daily summary dedups cross-source**
+
+Each per-source archive (`workspace/news/archive/<slug>/YYYY/MM.md`) contains **every** item the fetcher produced for that source — lossless log for retrospective grep. The daily-summary aggregation pass uses a `Set<stableItemId>` (FNV-1a of the normalized URL from `urls.ts`) to drop the second and third occurrence of the same article across sources. Phase-2 can add title-similarity dedup for the "same article, different URL" case; phase-1 URL-hash dedup catches ~95% of real cases at zero extra cost.
+
+### 4. Archive growth — **Keep everything, organize as `archive/<slug>/YYYY/MM.md`**
+
+No compaction, no pruning. 50 sources × 12 months × ~30 items × ~200 bytes ≈ 3.6 MB / year, ~18 MB / 5 years — cheap relative to chat jsonl. The nested `YYYY/MM.md` layout (changed from flat `YYYY-MM.md`) keeps a single year browsable as one directory, matching `daily/YYYY/MM/DD.md`. If storage ever becomes a real problem, phase-3 can add a journal-optimization-style year-end compaction — out of scope for phase 1.
+
+### 5. Failure visibility — **Daily summary footer + `manageSource` UI badge**
+
+Two surfaces, combined:
+
+- **Daily summary footer**: after the per-category sections, a `## Source health` block listing every source that's failed 3+ days in a row (e.g. `⚠ 2 sources still failing: foo (5d), bar (3d)`). Nothing logged for one-day failures — noise. Cheap to add, catches neglected sources.
+- **`manageSource` UI badge**: each source row shows last-successful-fetch timestamp and a status badge — green (fresh), yellow (3-6 day failure), red (7+). Actionable: user clicks the failing source, sees the last error, fixes or removes.
+
+**Deferred to later phase**: external notification (#142) at a 7-day threshold. Needs the notification infrastructure to land first — flagged in #142 and #144 so they know about the consumer.
+
+### 6. Timezone — **Local time, matching the journal**
+
+Same `toIsoDate(d)` helper the journal already uses (`getFullYear()` / `getMonth()` / `getDate()` in local). Personal workspace → human time. If we ever go multi-user or daemonize this, UTC becomes more defensible.
+
+### 7. Fetcher execution order — **Parallel across hosts, serial per host**
+
+Group eligible fetchers by URL hostname. Distinct hosts run concurrently (bounded by Node's event loop so it's not literally parallel but close enough). Same-host fetchers serialize with the host's configured per-host rate limit. 50 sources across ~15 distinct hosts ≈ 15-second daily run, down from 75 seconds serial.
+
+Implementation note: a small per-host promise chain (`hostQueues: Map<string, Promise<void>>`) appended to per fetcher. No full job queue needed at phase-1 scale.
+
+### 8. Failure isolation — **Per-source try/catch with log + advance state + continue**
+
+The daily pipeline wraps each fetcher call in try/catch. Failure bumps `consecutiveFailures` in the state file and schedules the next attempt with exponential backoff. One source failing (parser error, HTTP 500, host unreachable) never aborts the remaining fetchers. A pipeline-level catch handles truly fatal errors (`ENOSPC`, `ClaudeCliNotFoundError`) and disables the module for the process lifetime, same as the journal.
+
+### 9. Claude-side fetcher invocation — **5-source batches per CLI spawn, configurable**
+
+The `claude` CLI is spawned via `spawn("claude", ["--print", "--output-format", "json", "--model", "haiku", "--max-budget-usd", ...])` (same pattern as `chat-index/summarizer.ts`). web-fetch and web-search sources are batched into groups of N before each spawn:
+
+```ts
+const BATCH_SIZE = Number(process.env.SOURCES_WEB_BATCH_SIZE) || 5;
+for (const batch of chunk(webSources, BATCH_SIZE)) {
+  await fetchBatchViaCLI(batch);
+}
+```
+
+Default batch size of 5 was chosen so that:
+- 1 CLI spawn pays the ~28k-token cache-creation cost for the system prompt + JSON schema, then processes 5 sources using the cached context. ~4x cheaper than per-source spawns.
+- Each batch's inbound content stays well under haiku's 200k context window — 5 × ~5k chars per page ≈ 25k tokens, safe headroom.
+- Budget-blowup blast radius is 5 sources at most, not all of them.
+
+Env var override (`SOURCES_WEB_BATCH_SIZE`) lets future tuning happen without code change. At the foundation layer of this PR the constant isn't used yet — it lands in the pipeline PR.
 
 ## Test plan (for the phase 1 PR, not this spec)
 

--- a/plans/feat-source-registry.md
+++ b/plans/feat-source-registry.md
@@ -1,0 +1,264 @@
+# Plan: information source registry + daily aggregation + on-demand research
+
+Tracks: #166 (the 10-use-case issue)
+Supersedes / absorbs: #140 (news batch processing — its scope is covered by this plan's UC-1)
+
+## Scope for this spec — phase 1 only
+
+Phase 1 deliberately excludes auth-requiring sources. Authenticated sources (X / Twitter, private RSS, GitHub with a token, paid APIs) add credential management, token refresh, rate-limit policies, and per-source secrets handling — worth their own phase. The phase-1 surface is:
+
+- **RSS / Atom feeds** (public)
+- **Public GitHub REST API** — releases, issues, PRs. Unauthenticated is 60 req/h/IP, plenty for a personal workspace.
+- **arbitrary web pages** — fetched via Claude's built-in `web_fetch` tool (not our server). Respects robots.txt because Anthropic's crawler does.
+- **web search** — Claude's `web_search` tool for "find news about company X" kind of queries.
+
+Explicit non-goals for phase 1: X, private feeds, Slack / Discord bots, email digests, OAuth, API-key rotation.
+
+## Who fetches?
+
+| Source type | Fetcher | Rationale |
+|---|---|---|
+| RSS / Atom | **Server-side** | Stable XML format, no LLM needed. Deterministic daily schedule. Cheap (no tokens). |
+| GitHub Releases / Issues / PRs | **Server-side** | Typed REST JSON. No LLM value-add in fetching. |
+| arXiv / npm / other public REST JSON | **Server-side** | Same. |
+| Arbitrary web pages | **Claude-side** (`web_fetch`) | Anthropic's crawler handles robots / caching / user-agent. We don't reimplement browser-grade HTML parsing. |
+| Ad-hoc search ("news about company X") | **Claude-side** (`web_search`) | Search API access already built into Claude. |
+
+This split is expressed as a `fetcher` field on each source:
+
+```yaml
+fetcher:
+  kind: rss          # "rss" | "github-releases" | "github-issues" | "web-fetch" | "web-search" | "arxiv"
+  # ... type-specific params
+```
+
+The server-side `fetcher.kind` values map to `server/sources/fetchers/*.ts` modules implementing a common `SourceFetcher` interface. Claude-side ones are triggered by emitting a prompt with the right tool call rather than running HTTP ourselves. Auth-requiring fetchers in phase 3 (e.g. `fetcher.kind: "github-authed"`) just register a new module with the same interface — no framework changes.
+
+## Crawl etiquette (for server-side fetching)
+
+1. **User-Agent**: `MulmoClaude-SourceBot/1.0 (+https://github.com/receptron/mulmoclaude)` on every outbound request. Site operators can identify and contact.
+2. **robots.txt check** — before fetching any URL whose host we haven't checked in the last 24h, fetch `/robots.txt` and cache the parsed rules. Respect `User-agent: *` entries.
+3. **Rate limit** — at most 1 request / source / 60s, configurable. No parallel bursts to the same host.
+4. **Respect `Crawl-delay`** from robots.txt if present.
+5. **Source-registration preflight** — when the user adds a new web source, run the robots.txt check synchronously and refuse (with a clear message) if the path is disallowed. Offer alternatives: "try the RSS feed at /feed", "use `fetcher.kind: web-search` instead which goes through Claude's approved crawler".
+6. **5xx / rate-limit backoff** — exponential backoff per host, persisted to the state file so restarts don't hammer.
+
+Claude-side fetchers don't need our robots checking — the `web_fetch` / `web_search` tools are Anthropic-operated and handle it.
+
+## Workspace layout — sources as files
+
+Matches the `wiki/pages/*.md` pattern: one file per source, YAML frontmatter + optional markdown body.
+
+```
+workspace/
+  sources/
+    <slug>.md                    ← one file per source
+    _index.md                    ← auto-generated index grouped by category
+    _state/
+      <slug>.json                ← fetcher state per source (last cursor, etag, last-fetched-at, failure count)
+      robots/<host>.txt          ← cached robots.txt per host
+  news/
+    daily/
+      YYYY/MM/DD.md              ← daily aggregated summary
+    archive/
+      <slug>/YYYY-MM.md          ← per-source archive of older items
+```
+
+### Source file format
+
+```markdown
+---
+slug: hn-front-page
+title: Hacker News front page
+url: https://news.ycombinator.com/rss
+fetcher:
+  kind: rss
+schedule: daily   # "daily" | "hourly" | "weekly" | "on-demand"
+categories: [tech-news, general, english]
+max_items_per_fetch: 30
+added_at: 2026-04-13T09:00:00Z
+# Auto-populated by Claude at registration time; user-editable.
+---
+
+# Notes
+
+Why registered: general tech news pulse, catch launches.
+Override categories: yes (bump `ai` to primary when I have time).
+```
+
+The YAML frontmatter is the machine-readable part. The markdown body below `# Notes` is free-form user annotation — Claude reads it for context when summarizing ("this user cares about AI launches on HN").
+
+### Why per-file over a single `registry.yml`?
+
+- One-file-per-source matches the existing wiki convention. Claude can edit a single source without touching the global registry.
+- Grep-friendly: `grep -l 'tech-news' sources/*.md` for all tech sources.
+- Git diffs stay small and meaningful when Claude tweaks categories or adds notes to one source.
+- Auto-categorization rewrites one file, not a 50-source global YAML.
+
+### State vs config split
+
+`sources/<slug>.md` is **config** (user-editable, committed, git-tracked). `sources/_state/<slug>.json` is **runtime state** (last cursor, etag, mtime, backoff timer). State should generally NOT be in git — add `sources/_state/` to `.gitignore` at phase-1-ship time.
+
+## Auto-categorization
+
+At source registration (via the `manageSource` plugin's `register` action):
+
+1. Fetch a tiny sample — RSS: top 3 items; web page: head + title; GitHub repo: `description` + top 3 releases.
+2. Spawn a Claude CLI call (reusing the `chat-index/summarizer.ts` pattern — `claude --model haiku --output-format json --json-schema ...`) with a prompt:
+
+   > Classify this information source into 1–5 categories from this fixed taxonomy: `[tech-news, business-news, ai, security, devops, frontend, backend, ml-research, dependencies, product-updates, japanese, english, papers, general, startup, personal]`. Output strict JSON: `{ categories: string[], rationale: string }`.
+
+3. Write the categories into the source file's YAML frontmatter. Write `rationale` into the body as a comment for human review.
+
+Users can override categories manually — the next daily run reads the file as-is. A separate `manageSource recategorize` action re-runs the classifier on demand (e.g. after editing the taxonomy).
+
+**Taxonomy is a fixed enum.** Free-form LLM-generated tags balloon into synonyms (`"artificial-intelligence"` vs `"ai"`) and make filtering useless. The enum lives in `src/plugins/manageSource/taxonomy.ts` and is version-controlled.
+
+## Daily aggregation pipeline
+
+Piggyback on the existing `server/task-manager/` daily schedule (same rhythm as `server/journal/`):
+
+```
+08:00 local time (configurable)
+  ↓
+maybeAggregateSources({ activeSessionIds })  ← fire-and-forget from task-manager
+  ↓
+[Phase 1] fetch
+  ↓ for each source with schedule=daily and not on backoff:
+  ↓   - route by fetcher.kind
+  ↓   - server-side fetchers: run directly (respect robots / rate limit / state)
+  ↓   - Claude-side fetchers: enqueue a single agent pass that collects all of them in one session
+  ↓
+[Phase 2] normalize
+  ↓ every source produces a list of `SourceItem { id, title, url, publishedAt, summary?, content?, categories }`
+  ↓ write raw items to `workspace/news/archive/<slug>/YYYY-MM.md` (append-only)
+  ↓
+[Phase 3] summarize
+  ↓ pass all new items to Claude (one call) with a prompt:
+  ↓   "Produce a daily brief. Group by category. Max 10 items per group.
+  ↓    For each item: 1-line summary, link, source."
+  ↓
+[Phase 4] write
+  ↓ `workspace/news/daily/YYYY/MM/DD.md`
+  ↓ dashboard widget (#143) picks this up
+  ↓ if any item tagged `severity: critical` (e.g. from security advisory), enqueue a notification (#142 / #144)
+```
+
+The pipeline is invoked by a single public entry `maybeAggregateSources(deps)` that mirrors `maybeRunJournal` / `maybeIndexSession`. Same gates apply: active-session guard, in-process lock, `ClaudeCliNotFoundError` → disable-for-lifetime.
+
+## On-demand research
+
+Triggered when the user says "調べて" during a conversation. Claude decides to call `searchSources({ query, categoryFilter? })` which:
+
+1. Enumerates all registered sources whose categories match the filter.
+2. For `fetcher.kind: web-search` sources → Claude uses its `web_search` tool directly.
+3. For RSS / GitHub sources → server fetches recent items filtered by query text.
+4. Returns aggregated hits. Claude synthesizes the answer and optionally writes it to `wiki/pages/<topic>.md`.
+
+This is the **on-demand** path to UC-3 / UC-4 / UC-5 from #166. Implementation lands after the daily pipeline is stable.
+
+## Plugin interface — `manageSource`
+
+New plugin at `src/plugins/manageSource/`. Actions:
+
+| Action | Params | Effect |
+|---|---|---|
+| `register` | `url`, optional `fetcher.kind` override, optional `categories` override | Detect source type, run robots preflight, auto-categorize, write the source file |
+| `list` | optional `category` filter | Return all registered sources |
+| `remove` | `slug` | Delete the source file and its state |
+| `recategorize` | `slug` | Re-run the auto-categorizer |
+| `fetch` | `slug` | One-shot on-demand fetch outside the schedule |
+| `test` | `url` | Dry-run: robots check + fetcher selection + sample fetch, NO write |
+
+The `test` action is the debugging surface: when a user asks "can I register this site?" Claude can run `test` first without polluting the workspace.
+
+## File layout (new code)
+
+```
+server/sources/
+  index.ts              ← maybeAggregateSources entry, lock + sentinel
+  registry.ts           ← read / write per-source files + state
+  taxonomy.ts           ← fixed category enum (shared with src/)
+  robots.ts             ← robots.txt fetch + cache + rule evaluation
+  pipeline.ts           ← fetch → normalize → summarize → write
+  classifier.ts         ← auto-categorize via Claude CLI (reuses chat-index/summarizer patterns)
+  types.ts              ← Source / SourceItem / SourceState types
+  fetchers/
+    index.ts            ← registry of SourceFetcher by kind
+    rss.ts              ← RSS / Atom fetcher
+    githubReleases.ts   ← GitHub /releases endpoint
+    githubIssues.ts     ← /issues and /pulls
+    arxiv.ts            ← arXiv API
+    webFetch.ts         ← server-side HTML fetch with robots + rate limit
+    claudeFetch.ts      ← delegates to an agent session (web_fetch / web_search)
+server/routes/sources.ts ← POST /api/sources/* endpoints
+
+src/plugins/manageSource/
+  definition.ts
+  index.ts
+  View.vue
+  Preview.vue
+
+test/sources/
+  test_robots.ts        ← parse + match User-agent: * rules, cache eviction
+  test_rss.ts           ← RSS/Atom parsing
+  test_classifier.ts    ← pure helpers, taxonomy pinning
+  test_pipeline.ts      ← end-to-end with stubbed fetchers
+  test_registry.ts      ← write / read / round-trip source files
+```
+
+Reuses the following existing primitives: `task-manager` scheduler, `chat-index/summarizer.ts` for the Claude CLI spawn pattern, `journal/index.ts` for the lock+sentinel+disable-for-lifetime pattern. Nothing new at the framework level.
+
+## Extensibility for future auth (phase 3)
+
+Designed in but not used in phase 1:
+
+1. **`fetcher` is a tagged union.** Adding `{ kind: "github-authed", envVar: "GITHUB_TOKEN" }` or `{ kind: "x-api", envVar: "X_BEARER_TOKEN" }` just means a new file under `server/sources/fetchers/` implementing the same `SourceFetcher` interface.
+2. **Source files already have space for auth hints.** Phase 1 ignores them; phase 3 reads them.
+
+   ```yaml
+   fetcher:
+     kind: github-authed
+     envVar: GITHUB_TOKEN
+     scopes: [repo:read]   # informational only
+   ```
+
+3. **Per-source rate-limit state is already keyed by fetcher kind**, not just host — so per-user-token rate limits in phase 3 fit cleanly.
+
+4. **Secrets policy**: credentials live in `.env` (already protected by the sensitive-file denylist from #148). Never in source files, never in `sources/_state/`.
+
+## Phase breakdown
+
+| Phase | Scope | Gate |
+|---|---|---|
+| **1 (this spec)** | RSS / GitHub public / arXiv + web_fetch / web_search via Claude + daily pipeline + `manageSource` plugin + auto-categorize + robots etiquette | Ship this PR, iterate in subsequent PRs per fetcher type |
+| **2** | On-demand `searchSources` + wiki-page generation for research results + notification hookup | Phase 1 stable in daily use |
+| **3** | Auth-bearing fetchers (X / private GitHub / paid APIs) + secrets rotation + per-source rate-limit tuning | Real demand for a specific authed source |
+
+## Open questions (to resolve before implementation PR)
+
+1. **Taxonomy size**. Starting list above has 16 categories. Too many dilutes filtering; too few forces everything into `general`. Pilot with 16 and re-evaluate after 2 weeks of daily use?
+2. **Daily summary template**. Markdown only, or include a compact structured index (JSON block) so the dashboard can render without re-parsing markdown? Lean toward: both — markdown for humans, fenced JSON block at the end for the dashboard.
+3. **Item dedup across sources**. Two RSS feeds often carry the same HN story. Phase-1 answer: hash the normalized URL (strip utm params), skip dedup across sources but dedup within a single source. Phase-2: cross-source URL dedup.
+4. **Archive size**. Per-source monthly archives grow unbounded. Phase-1: no pruning. Phase-3-ish: add a `journal-archivist`-style compaction pass.
+5. **Error visibility**. When a source fails for 3 days in a row, how does the user learn? Ideas: (a) surface in daily summary footer ("3 sources failed today"), (b) push notification at 5-day mark, (c) badge on the manageSource UI. Pick one.
+6. **Timezone for "daily"**. Local time like the journal, or UTC? Journal uses local — match it.
+7. **Order of fetcher execution**. Parallel across hosts but serial per-host? Or fully serial with a 1s delay? Parallel-across-hosts is faster but needs a per-host queue. Start serial for simplicity; add parallelism if daily run exceeds 5 minutes.
+8. **Failure isolation**. A single source failing must not abort the pipeline. Model: per-source try/catch that logs + advances state + continues.
+9. **Claude-side fetcher invocation pattern**. One agent session per cron run that hits all web-search sources? Or per-source sessions? Per-run is cheaper (shared context, one summary pass) — start there.
+
+## Test plan (for the phase 1 PR, not this spec)
+
+- Unit: RSS/Atom parser (fixture files), robots parser (happy / allow / disallow / crawl-delay / wildcard), taxonomy classifier (mocked Claude response), URL normalizer (utm stripping, trailing slash).
+- Integration: pipeline end-to-end with stubbed fetchers and stubbed summarize — writes expected daily markdown.
+- Regression fixture: one real-world RSS feed (frozen snapshot) to catch parser regressions.
+- No network tests in CI (stub everything).
+
+## Related issues
+
+- **#166** — the 10-use-case issue this spec addresses
+- **#140** — news-batch (superseded; close in favour of this)
+- **#143** — dashboard (consumer of daily output)
+- **#142** — external notifications (consumer of critical items)
+- **#144** — in-app notifications (consumer of critical items)
+- **#148** — security hardening (dependency: sensitive-file denylist protects the `.env` our credential storage will use in phase 3)

--- a/server/sources/paths.ts
+++ b/server/sources/paths.ts
@@ -79,17 +79,27 @@ export function archiveDir(workspaceRoot: string, slug: string): string {
   return path.join(newsRoot(workspaceRoot), ARCHIVE_DIR, slug);
 }
 
+// Archive file path. Written as `<slug>/YYYY/MM.md` (year and
+// month as nested directories) so long-running workspaces don't
+// end up with 60+ files in a single source's archive dir —
+// browsing a given year is one `cd YYYY/` away. Matches the
+// daily-news layout (`daily/YYYY/MM/DD.md`).
+//
+// Input stays `YYYY-MM` so callers don't need to remember whether
+// to split; we do the split here.
 export function archivePath(
   workspaceRoot: string,
   slug: string,
   yearMonth: string,
 ): string {
-  if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+  const m = /^(\d{4})-(\d{2})$/.exec(yearMonth);
+  if (!m) {
     throw new Error(
       `[sources] archivePath: expected YYYY-MM, got "${yearMonth}"`,
     );
   }
-  return path.join(archiveDir(workspaceRoot, slug), `${yearMonth}.md`);
+  const [, year, month] = m;
+  return path.join(archiveDir(workspaceRoot, slug), year, `${month}.md`);
 }
 
 // Very conservative slug validator. The slug doubles as a filename

--- a/server/sources/paths.ts
+++ b/server/sources/paths.ts
@@ -1,0 +1,106 @@
+// Path helpers for the source registry's on-disk layout.
+//
+//   workspace/
+//     sources/
+//       <slug>.md                    ← source config
+//       _index.md                    ← auto-generated category index
+//       _state/
+//         <slug>.json                ← runtime state per source
+//         robots/<host>.txt          ← cached robots.txt
+//     news/
+//       daily/YYYY/MM/DD.md          ← daily aggregated summary
+//       archive/<slug>/YYYY-MM.md    ← per-source rolling archive
+//
+// Everything is derived from a single `workspaceRoot` argument so
+// tests can target a `mkdtempSync` directory.
+
+import path from "node:path";
+
+export const SOURCES_DIR = "sources";
+export const SOURCE_STATE_DIR = "_state";
+export const ROBOTS_CACHE_DIR = "robots";
+export const NEWS_DIR = "news";
+export const DAILY_DIR = "daily";
+export const ARCHIVE_DIR = "archive";
+
+export function sourcesRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, SOURCES_DIR);
+}
+
+export function sourceFilePath(workspaceRoot: string, slug: string): string {
+  return path.join(sourcesRoot(workspaceRoot), `${slug}.md`);
+}
+
+export function sourceStateDir(workspaceRoot: string): string {
+  return path.join(sourcesRoot(workspaceRoot), SOURCE_STATE_DIR);
+}
+
+export function sourceStatePath(workspaceRoot: string, slug: string): string {
+  return path.join(sourceStateDir(workspaceRoot), `${slug}.json`);
+}
+
+export function robotsCacheDir(workspaceRoot: string): string {
+  return path.join(sourceStateDir(workspaceRoot), ROBOTS_CACHE_DIR);
+}
+
+export function robotsCachePath(workspaceRoot: string, host: string): string {
+  // Hosts can contain `:` (for explicit ports) which breaks on some
+  // filesystems. Colons → underscore. Other characters are ASCII
+  // letters, digits, dots, and hyphens per DNS rules so they're
+  // safe as-is.
+  const safe = host.replace(/:/g, "_");
+  return path.join(robotsCacheDir(workspaceRoot), `${safe}.txt`);
+}
+
+export function newsRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, NEWS_DIR);
+}
+
+export function dailyNewsPath(workspaceRoot: string, isoDate: string): string {
+  // Validate shape at the boundary so an empty / bogus date can't
+  // produce "undefined/undefined/undefined.md" downstream.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!m) {
+    throw new Error(
+      `[sources] dailyNewsPath: expected YYYY-MM-DD, got "${isoDate}"`,
+    );
+  }
+  const [, year, month, day] = m;
+  return path.join(
+    newsRoot(workspaceRoot),
+    DAILY_DIR,
+    year,
+    month,
+    `${day}.md`,
+  );
+}
+
+export function archiveDir(workspaceRoot: string, slug: string): string {
+  return path.join(newsRoot(workspaceRoot), ARCHIVE_DIR, slug);
+}
+
+export function archivePath(
+  workspaceRoot: string,
+  slug: string,
+  yearMonth: string,
+): string {
+  if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+    throw new Error(
+      `[sources] archivePath: expected YYYY-MM, got "${yearMonth}"`,
+    );
+  }
+  return path.join(archiveDir(workspaceRoot, slug), `${yearMonth}.md`);
+}
+
+// Very conservative slug validator. The slug doubles as a filename
+// and appears in URLs (via the manageSource plugin), so reject
+// anything that could surprise the filesystem or the URL parser.
+// Letters, digits, hyphens only. 1-64 chars. No leading / trailing
+// hyphen. No consecutive hyphens.
+export function isValidSlug(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  if (slug.length === 0 || slug.length > 64) return false;
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(slug)) return false;
+  if (slug.includes("--")) return false;
+  return true;
+}

--- a/server/sources/registry.ts
+++ b/server/sources/registry.ts
@@ -1,0 +1,362 @@
+// Read / write source registry files under `workspace/sources/`.
+//
+// On-disk format — one markdown file per source:
+//
+//   ---
+//   slug: hn-front-page
+//   title: Hacker News front page
+//   url: https://news.ycombinator.com/rss
+//   fetcher_kind: rss
+//   schedule: daily
+//   categories: [tech-news, general, english]
+//   max_items_per_fetch: 30
+//   added_at: 2026-04-13T09:00:00Z
+//   <fetcher-specific params as flat key: value>
+//   ---
+//
+//   # Notes
+//
+//   Free-form markdown body. Claude reads it for context when
+//   summarizing.
+//
+// Parser policy:
+//
+// - Flat YAML only. Nested mappings are not supported by design —
+//   the frontmatter is hand-edited by humans and the LLM, both of
+//   which routinely get nesting wrong. Fetcher params are flat
+//   strings (e.g. `github_repo: foo/bar`) so the fetcher itself
+//   interprets them.
+// - Unknown frontmatter keys are preserved as opaque strings in
+//   `fetcherParams`, so future fetchers can add fields without
+//   round-trip data loss.
+// - Missing required fields → the loader returns `null` and logs
+//   a warning; the caller skips that source rather than crashing
+//   the pass.
+//
+// The writer preserves the body text verbatim so re-saving a file
+// doesn't rewrite the user's notes.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import {
+  isFetcherKind,
+  isSourceSchedule,
+  type Source,
+  type FetcherParams,
+  type FetcherKind,
+  type SourceSchedule,
+} from "./types.js";
+import { normalizeCategories } from "./taxonomy.js";
+import type { CategorySlug } from "./taxonomy.js";
+import { isValidSlug, sourceFilePath, sourcesRoot } from "./paths.js";
+
+// --- Frontmatter parsing ------------------------------------------------
+
+// Fields we recognize as first-class on every source. Anything else
+// in the frontmatter ends up in `fetcherParams` so a fetcher kind
+// that needs extra config can read it without us adding yet
+// another typed field for every new fetcher.
+const RESERVED_KEYS = new Set([
+  "slug",
+  "title",
+  "url",
+  "fetcher_kind",
+  "schedule",
+  "categories",
+  "max_items_per_fetch",
+  "added_at",
+]);
+
+const FRONTMATTER_OPEN = /^---\r?\n/;
+const FRONTMATTER_CLOSE = /\r?\n---\s*(\r?\n|$)/;
+
+interface ParsedFrontmatter {
+  fields: Map<string, string | string[]>;
+  body: string;
+}
+
+// Extract YAML frontmatter + body. Returns null when the file has
+// no frontmatter at all — that's an error condition for source
+// files (we always write frontmatter), not a degraded mode.
+export function parseSourceFile(raw: string): ParsedFrontmatter | null {
+  if (!FRONTMATTER_OPEN.test(raw)) return null;
+  const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
+  if (!closeMatch || closeMatch.index === undefined) return null;
+  const fmText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  return { fields: parseFields(fmText), body };
+}
+
+function parseFields(fmText: string): Map<string, string | string[]> {
+  const fields = new Map<string, string | string[]>();
+  for (const line of fmText.split(/\r?\n/)) {
+    const parsed = parseLine(line);
+    if (parsed) fields.set(parsed.key, parsed.value);
+  }
+  return fields;
+}
+
+function parseLine(
+  line: string,
+): { key: string; value: string | string[] } | null {
+  if (!line.trim() || line.trimStart().startsWith("#")) return null;
+  const colonIdx = line.indexOf(":");
+  if (colonIdx <= 0) return null;
+  const key = line.slice(0, colonIdx).trim();
+  const rawValue = line.slice(colonIdx + 1).trim();
+  if (!key) return null;
+  return { key, value: parseValue(rawValue) };
+}
+
+function parseValue(raw: string): string | string[] {
+  if (!raw) return "";
+  const arrayMatch = /^\[(.*)\]$/.exec(raw);
+  if (arrayMatch) {
+    return arrayMatch[1]
+      .split(",")
+      .map((s) => unquote(s.trim()))
+      .filter((s) => s.length > 0);
+  }
+  return unquote(raw);
+}
+
+function unquote(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// --- Source validation / construction -----------------------------------
+
+function stringField(
+  fields: Map<string, string | string[]>,
+  key: string,
+): string | null {
+  const v = fields.get(key);
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function numberField(
+  fields: Map<string, string | string[]>,
+  key: string,
+  defaultValue: number,
+): number {
+  const v = fields.get(key);
+  if (typeof v !== "string") return defaultValue;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : defaultValue;
+}
+
+// Default per-fetch cap. Fetchers treat it as a hint — if the
+// upstream API returns fewer items naturally the fetcher MAY
+// return fewer, but must NEVER return more than this.
+export const DEFAULT_MAX_ITEMS_PER_FETCH = 30;
+
+// Construct a Source from parsed frontmatter fields. Returns null
+// on required-field validation failure. The `body` arg is inlined
+// into the Source as `notes`.
+export function buildSource(
+  fields: Map<string, string | string[]>,
+  body: string,
+): Source | null {
+  const slug = stringField(fields, "slug");
+  if (!slug || !isValidSlug(slug)) return null;
+
+  const title = stringField(fields, "title");
+  if (!title) return null;
+
+  const url = stringField(fields, "url");
+  if (!url) return null;
+
+  const fetcherKindRaw = stringField(fields, "fetcher_kind");
+  if (!isFetcherKind(fetcherKindRaw)) return null;
+  const fetcherKind: FetcherKind = fetcherKindRaw;
+
+  const scheduleRaw = stringField(fields, "schedule");
+  if (!isSourceSchedule(scheduleRaw)) return null;
+  const schedule: SourceSchedule = scheduleRaw;
+
+  const categoriesRaw = fields.get("categories");
+  const categories: CategorySlug[] = normalizeCategories(categoriesRaw);
+
+  const maxItemsPerFetch = numberField(
+    fields,
+    "max_items_per_fetch",
+    DEFAULT_MAX_ITEMS_PER_FETCH,
+  );
+
+  const addedAt = stringField(fields, "added_at") ?? new Date(0).toISOString();
+
+  // Collect unrecognized fields into fetcherParams. Only flat
+  // string values — array values would indicate a schema mismatch
+  // since no fetcher param is a list today.
+  const fetcherParams: FetcherParams = {};
+  for (const [key, value] of fields.entries()) {
+    if (RESERVED_KEYS.has(key)) continue;
+    if (typeof value === "string") fetcherParams[key] = value;
+  }
+
+  return {
+    slug,
+    title,
+    url,
+    fetcherKind,
+    fetcherParams,
+    schedule,
+    categories,
+    maxItemsPerFetch,
+    addedAt,
+    notes: body,
+  };
+}
+
+// --- Serialization ------------------------------------------------------
+
+// Escape a scalar for use as a YAML value. Very conservative —
+// wraps in double-quotes whenever the value contains any character
+// that could be mis-parsed. Idempotent-safe: a round-trip through
+// parseValue → yamlScalar preserves the semantic string.
+function yamlScalar(value: string): string {
+  // Quote whenever the raw value contains characters that would
+  // confuse the flat-YAML parser or collide with a YAML reserved
+  // glyph. Numbers, dates, booleans, null all get quoted too so
+  // the reader always treats them as strings.
+  const needsQuote =
+    value === "" ||
+    /[:#[\]{},&*?|<>=!%@`]/.test(value) ||
+    /^\s|\s$/.test(value) ||
+    /^(true|false|null|~|yes|no|on|off)$/i.test(value) ||
+    /^[+-]?[\d.]/.test(value);
+  if (needsQuote) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+function yamlList(values: readonly string[]): string {
+  return `[${values.map(yamlScalar).join(", ")}]`;
+}
+
+// Serialize a Source back to the canonical markdown-with-
+// frontmatter shape. Reserved-key ordering is stable (nice for
+// diffs) and fetcher-specific params come after in alphabetical
+// order.
+export function serializeSource(source: Source): string {
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`slug: ${yamlScalar(source.slug)}`);
+  lines.push(`title: ${yamlScalar(source.title)}`);
+  lines.push(`url: ${yamlScalar(source.url)}`);
+  lines.push(`fetcher_kind: ${yamlScalar(source.fetcherKind)}`);
+  lines.push(`schedule: ${yamlScalar(source.schedule)}`);
+  lines.push(`categories: ${yamlList(source.categories)}`);
+  lines.push(`max_items_per_fetch: ${String(source.maxItemsPerFetch)}`);
+  lines.push(`added_at: ${yamlScalar(source.addedAt)}`);
+  const paramKeys = Object.keys(source.fetcherParams).sort();
+  for (const key of paramKeys) {
+    lines.push(`${key}: ${yamlScalar(source.fetcherParams[key])}`);
+  }
+  lines.push("---");
+  lines.push("");
+  // Preserve trailing newline semantics — if the notes were empty,
+  // emit exactly one newline after the closing fence; otherwise
+  // append the notes verbatim.
+  if (source.notes.length > 0) {
+    lines.push(
+      source.notes.endsWith("\n") ? source.notes : `${source.notes}\n`,
+    );
+  } else {
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// --- Filesystem I/O -----------------------------------------------------
+
+// Load one source by slug. Returns null if missing, malformed, or
+// fails required-field validation. Never throws — consumer code
+// just skips null entries.
+export async function readSource(
+  workspaceRoot: string,
+  slug: string,
+): Promise<Source | null> {
+  if (!isValidSlug(slug)) return null;
+  let raw: string;
+  try {
+    raw = await fsp.readFile(sourceFilePath(workspaceRoot, slug), "utf-8");
+  } catch {
+    return null;
+  }
+  const parsed = parseSourceFile(raw);
+  if (!parsed) return null;
+  const source = buildSource(parsed.fields, parsed.body);
+  // Sanity: filename slug must match frontmatter slug. A mismatch
+  // indicates the user renamed the file without editing the header
+  // (or vice-versa) — refuse the load rather than silently using
+  // the wrong slug.
+  if (source && source.slug !== slug) return null;
+  return source;
+}
+
+// List every source in the registry. Files that fail to parse are
+// logged and skipped; a single bad source file must not break the
+// daily pipeline for all the others.
+export async function listSources(workspaceRoot: string): Promise<Source[]> {
+  const dir = sourcesRoot(workspaceRoot);
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: Source[] = [];
+  for (const name of entries) {
+    // Skip meta files and the `_state/` subdirectory.
+    if (name.startsWith("_")) continue;
+    if (!name.endsWith(".md")) continue;
+    const slug = name.slice(0, -".md".length);
+    const source = await readSource(workspaceRoot, slug);
+    if (source) out.push(source);
+    else {
+      // eslint-disable-next-line no-console
+      console.warn(`[sources] failed to load source ${slug}, skipping`);
+    }
+  }
+  // Deterministic sort by slug so callers can rely on stable order.
+  out.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  return out;
+}
+
+// Atomic write: stage to a sibling `.tmp` file then rename. Crash
+// mid-write cannot leave a half-written source file behind.
+export async function writeSource(
+  workspaceRoot: string,
+  source: Source,
+): Promise<void> {
+  if (!isValidSlug(source.slug)) {
+    throw new Error(`[sources] invalid slug: ${source.slug}`);
+  }
+  const target = sourceFilePath(workspaceRoot, source.slug);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp`;
+  await fsp.writeFile(tmp, serializeSource(source), "utf-8");
+  await fsp.rename(tmp, target);
+}
+
+export async function deleteSource(
+  workspaceRoot: string,
+  slug: string,
+): Promise<boolean> {
+  if (!isValidSlug(slug)) return false;
+  try {
+    await fsp.unlink(sourceFilePath(workspaceRoot, slug));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/sources/taxonomy.ts
+++ b/server/sources/taxonomy.ts
@@ -1,0 +1,60 @@
+// Fixed taxonomy of source categories. Keeping this a closed enum
+// (rather than accepting free-form LLM-generated tags) prevents
+// synonym sprawl — `ai` vs `artificial-intelligence` vs `AI` would
+// otherwise all coexist and make filtering useless.
+//
+// The auto-categorizer (see plans/feat-source-registry.md §"Auto-
+// categorization") classifies each new source into 1-5 of these
+// slugs and writes them into the source file's frontmatter. Users
+// can override by editing the file; the next daily run picks up
+// the edits.
+//
+// Pin-tested so a silent enum mutation doesn't sneak past review.
+
+export const CATEGORY_SLUGS = [
+  "tech-news",
+  "business-news",
+  "ai",
+  "security",
+  "devops",
+  "frontend",
+  "backend",
+  "ml-research",
+  "dependencies",
+  "product-updates",
+  "japanese",
+  "english",
+  "papers",
+  "general",
+  "startup",
+  "personal",
+] as const;
+
+export type CategorySlug = (typeof CATEGORY_SLUGS)[number];
+
+const CATEGORY_SET: ReadonlySet<string> = new Set(CATEGORY_SLUGS);
+
+// Runtime type-guard. Used when reading a source file from disk to
+// drop any legacy / typo categories so downstream code only ever
+// deals in the current enum.
+export function isCategorySlug(value: unknown): value is CategorySlug {
+  return typeof value === "string" && CATEGORY_SET.has(value);
+}
+
+// Normalize an unknown list of category candidates into a clean,
+// deduplicated array of valid slugs. Used when reading from
+// frontmatter (where the user may have typo'd) and when receiving
+// classifier output (where the LLM may have hallucinated a slug
+// outside the taxonomy).
+export function normalizeCategories(raw: unknown): CategorySlug[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<CategorySlug>();
+  const out: CategorySlug[] = [];
+  for (const item of raw) {
+    if (isCategorySlug(item) && !seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}

--- a/server/sources/taxonomy.ts
+++ b/server/sources/taxonomy.ts
@@ -28,6 +28,20 @@ export const CATEGORY_SLUGS = [
   "general",
   "startup",
   "personal",
+  // --- Phase-1 expansion (resolved from #188 open-question Q1) ---
+  // Added to cover common genres the original 16 couldn't capture
+  // (which were tech-centric and collapsed everything non-tech
+  // into `general`). See plans/feat-source-registry.md §Resolved
+  // decisions for rationale per slug.
+  "finance",
+  "design",
+  "productivity",
+  "science",
+  "health",
+  "gaming",
+  "climate",
+  "culture",
+  "policy",
 ] as const;
 
 export type CategorySlug = (typeof CATEGORY_SLUGS)[number];

--- a/server/sources/types.ts
+++ b/server/sources/types.ts
@@ -1,0 +1,156 @@
+// Data model for the information-source registry. Every source
+// lives as one markdown file under `workspace/sources/<slug>.md`,
+// with these fields in the YAML frontmatter plus optional free-form
+// markdown notes in the body.
+//
+// Design invariants the consumer code relies on:
+//
+// - `slug` is the primary key and matches the filename exactly.
+//   Enforced by `registry.ts` on both read and write.
+// - `url` is always the normalized form (see urls.ts) so dedup
+//   across sources works by string equality.
+// - `fetcherKind` is one of a closed set so the fetcher dispatcher
+//   can look up the right handler without `any`.
+// - `schedule` drives the daily / weekly aggregation pipeline.
+// - `categories` contains only valid CategorySlug values
+//   (runtime-validated on read).
+//
+// Secrets (API tokens, bearer auth) are NEVER stored here —
+// phase-1 scope is public sources only. Phase-3 authed fetchers
+// will read credentials from `.env` at runtime by name; the name
+// reference lives in `fetcherParams` as an `envVar` field.
+
+import type { CategorySlug } from "./taxonomy.js";
+
+// Closed set of fetcher kinds we can dispatch on. Adding a new
+// fetcher means: add the string literal here, implement a matching
+// module under `server/sources/fetchers/<kind>.ts`, and register
+// it in the fetcher index. Nothing else in the framework needs to
+// change.
+//
+// Phase-1 surface:
+//   "rss"                — public RSS / Atom feeds (server-side fetch)
+//   "github-releases"    — GitHub /releases endpoint, unauthenticated
+//   "github-issues"      — GitHub /issues + /pulls, unauthenticated
+//   "arxiv"              — arXiv query API
+//   "web-fetch"          — one-shot page fetch via Claude's web_fetch
+//   "web-search"         — ad-hoc query via Claude's web_search
+export const FETCHER_KINDS = [
+  "rss",
+  "github-releases",
+  "github-issues",
+  "arxiv",
+  "web-fetch",
+  "web-search",
+] as const;
+
+export type FetcherKind = (typeof FETCHER_KINDS)[number];
+
+const FETCHER_KIND_SET: ReadonlySet<string> = new Set(FETCHER_KINDS);
+
+export function isFetcherKind(value: unknown): value is FetcherKind {
+  return typeof value === "string" && FETCHER_KIND_SET.has(value);
+}
+
+// How often the daily pipeline is expected to refresh this source.
+// `on-demand` sources are never auto-fetched; they only respond to
+// the `manageSource fetch` action or the on-demand research
+// workflow.
+export const SOURCE_SCHEDULES = [
+  "hourly",
+  "daily",
+  "weekly",
+  "on-demand",
+] as const;
+
+export type SourceSchedule = (typeof SOURCE_SCHEDULES)[number];
+
+const SOURCE_SCHEDULE_SET: ReadonlySet<string> = new Set(SOURCE_SCHEDULES);
+
+export function isSourceSchedule(value: unknown): value is SourceSchedule {
+  return typeof value === "string" && SOURCE_SCHEDULE_SET.has(value);
+}
+
+// Per-fetcher extra parameters carried on the Source file. Flat
+// string map on disk so the minimal frontmatter parser can handle
+// it without nested YAML. Fetchers interpret the keys they care
+// about and ignore the rest — keeps cross-fetcher rewiring cheap.
+export type FetcherParams = Record<string, string>;
+
+// The on-disk configuration for one source. This is the exact
+// shape serialized into the YAML frontmatter of
+// `workspace/sources/<slug>.md` — state (cursors, etags, failure
+// counts) lives separately under `_state/<slug>.json`.
+export interface Source {
+  slug: string;
+  title: string;
+  url: string;
+  fetcherKind: FetcherKind;
+  fetcherParams: FetcherParams;
+  schedule: SourceSchedule;
+  categories: CategorySlug[];
+  maxItemsPerFetch: number;
+  addedAt: string; // ISO timestamp
+  notes: string; // markdown body of the file
+}
+
+// One normalized item after a fetch. All fetchers produce this
+// shape regardless of source type so the pipeline / dedup / summary
+// layers don't care where items came from.
+export interface SourceItem {
+  // Stable unique id for dedup. Hash of the normalized URL, or
+  // the fetcher's native id (e.g. GitHub release id) when one is
+  // available.
+  id: string;
+  title: string;
+  url: string;
+  publishedAt: string; // ISO timestamp
+  // Short one-line summary if the fetcher can produce one without
+  // LLM help. The pipeline's summarize step may replace this with
+  // a richer LLM-generated version.
+  summary?: string;
+  // Full body content if available (RSS description, GitHub release
+  // body, etc.). The summarize step reads this when the short
+  // summary is insufficient.
+  content?: string;
+  // Categories inherited from the source this item came from.
+  // Duplicated on the item so per-category daily rollups don't
+  // need a re-join.
+  categories: CategorySlug[];
+  // Slug of the parent Source so the dashboard / notification
+  // layer can link back.
+  sourceSlug: string;
+  // Optional severity hint set by the classifier or the fetcher
+  // itself (security advisories set `critical`). Daily pipeline
+  // uses this to decide whether to notify.
+  severity?: "info" | "warn" | "critical";
+}
+
+// Per-source runtime state, NOT committed to git. Mirrors the
+// Source-vs-_state split described in plans/feat-source-registry.md.
+export interface SourceState {
+  slug: string;
+  // Last successful fetch.
+  lastFetchedAt: string | null;
+  // Fetcher-specific cursor — ISO timestamp, etag, GitHub release
+  // id, arXiv last-seen, whatever the fetcher persists to
+  // de-duplicate across runs. Free-form string map so the fetcher
+  // interface doesn't need to know the shape upfront.
+  cursor: Record<string, string>;
+  // Consecutive failure count. Incremented per failed fetch,
+  // reset to 0 on success. Drives exponential backoff.
+  consecutiveFailures: number;
+  // Timestamp after which the next attempt is allowed, so backoff
+  // survives server restarts.
+  nextAttemptAt: string | null;
+}
+
+export function defaultSourceState(slug: string): SourceState {
+  return {
+    slug,
+    lastFetchedAt: null,
+    cursor: {},
+    consecutiveFailures: 0,
+    nextAttemptAt: null,
+  };
+}

--- a/server/sources/urls.ts
+++ b/server/sources/urls.ts
@@ -1,0 +1,130 @@
+// URL normalization utilities for dedup + cache keys.
+//
+// The same article commonly arrives from multiple sources with
+// different query strings (utm_source, fbclid, gclid, mc_cid, ...)
+// or trailing slashes. We normalize before dedup so "same article
+// different feed" collapses into one item.
+//
+// Pure — no I/O, fully testable.
+
+// Tracking parameters we always strip. Case-insensitive on the
+// parameter NAME only.
+const TRACKING_PARAM_PREFIXES: readonly string[] = [
+  "utm_",
+  "mc_",
+  "pk_",
+  "hsa_",
+];
+
+const TRACKING_PARAMS: ReadonlySet<string> = new Set([
+  "fbclid",
+  "gclid",
+  "msclkid",
+  "dclid",
+  "gbraid",
+  "wbraid",
+  "yclid",
+  "ref",
+  "ref_src",
+  "ref_url",
+  "share",
+  "share_source",
+  "trk",
+  "igshid",
+  "CMP",
+]);
+
+function isTrackingParam(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (TRACKING_PARAMS.has(lower)) return true;
+  for (const prefix of TRACKING_PARAM_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// Normalize a URL for use as a dedup key:
+//
+//   1. Parse it. Invalid → return null (caller decides fallback).
+//   2. Lowercase the protocol + host.
+//   3. Drop the fragment.
+//   4. Drop tracking query params.
+//   5. Sort remaining query params so different orderings hash the
+//      same.
+//   6. Collapse trailing slash on the pathname (except root "/").
+//   7. Drop default ports (80 for http, 443 for https).
+//
+// Returns the normalized href on success, null on unparseable
+// input.
+export function normalizeUrl(raw: string): string | null {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+
+  // protocol + host lowercase (URL already normalizes these but
+  // doing it explicitly guards against future WHATWG tweaks).
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+
+  // Drop fragment.
+  url.hash = "";
+
+  // Drop tracking params. Iterate on a snapshot because delete
+  // mutates the underlying list.
+  const paramNames = Array.from(url.searchParams.keys());
+  for (const name of paramNames) {
+    if (isTrackingParam(name)) url.searchParams.delete(name);
+  }
+
+  // Sort remaining params for deterministic ordering. Preserve
+  // multi-value params by iterating all entries.
+  const entries = Array.from(url.searchParams.entries());
+  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  // Clear and reinsert.
+  for (const name of Array.from(url.searchParams.keys())) {
+    url.searchParams.delete(name);
+  }
+  for (const [name, value] of entries) {
+    url.searchParams.append(name, value);
+  }
+
+  // Collapse trailing slash on non-root paths.
+  if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+    url.pathname = url.pathname.slice(0, -1);
+  }
+
+  // Drop default ports.
+  if (
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+  ) {
+    url.port = "";
+  }
+
+  return url.toString();
+}
+
+// Stable content-addressed id for an item. Not cryptographically
+// strong — fast hash suitable for in-memory Set membership and
+// cross-run dedup. Node has `crypto.createHash` but we prefer a
+// synchronous string-in / string-out helper that's easy to drop
+// into a fetcher.
+//
+// Algorithm: FNV-1a 32-bit over the normalized URL, hex-encoded.
+// Collisions are extremely rare at our item volume (tens of
+// thousands over years). If dedup correctness ever depends on
+// this, upgrade to sha-256 — but watch the bundle size for the
+// Vue side if we ever ship this to the browser.
+export function stableItemId(normalizedUrl: string): string {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < normalizedUrl.length; i++) {
+    hash ^= normalizedUrl.charCodeAt(i);
+    // Multiply by FNV prime (0x01000193), mask to 32-bit.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}

--- a/test/sources/test_paths.ts
+++ b/test/sources/test_paths.ts
@@ -56,16 +56,32 @@ describe("path helpers", () => {
     assert.throws(() => dailyNewsPath(root, "foo"), /YYYY-MM-DD/);
   });
 
-  it("archivePath builds news/archive/<slug>/<YYYY-MM>.md", () => {
+  it("archivePath builds news/archive/<slug>/YYYY/MM.md", () => {
+    // The year and month are split into nested dirs so a
+    // long-running workspace doesn't end up with 60+ flat files
+    // in a single source's archive dir — matches daily/YYYY/MM/DD.md.
     assert.equal(
       archivePath(root, "hn-front-page", "2026-04"),
-      path.join(root, "news", "archive", "hn-front-page", "2026-04.md"),
+      path.join(root, "news", "archive", "hn-front-page", "2026", "04.md"),
+    );
+  });
+
+  it("archivePath splits the year-month even for edge months", () => {
+    assert.equal(
+      archivePath(root, "x", "2026-01"),
+      path.join(root, "news", "archive", "x", "2026", "01.md"),
+    );
+    assert.equal(
+      archivePath(root, "x", "2026-12"),
+      path.join(root, "news", "archive", "x", "2026", "12.md"),
     );
   });
 
   it("archivePath rejects invalid year-month strings", () => {
     assert.throws(() => archivePath(root, "x", "2026/04"), /YYYY-MM/);
     assert.throws(() => archivePath(root, "x", "2026-4"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", "26-04"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", ""), /YYYY-MM/);
   });
 });
 

--- a/test/sources/test_paths.ts
+++ b/test/sources/test_paths.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  sourcesRoot,
+  sourceFilePath,
+  sourceStatePath,
+  robotsCachePath,
+  dailyNewsPath,
+  archivePath,
+  isValidSlug,
+} from "../../server/sources/paths.js";
+
+const root = path.join("/tmp", "ws");
+
+describe("path helpers", () => {
+  it("sourcesRoot joins under workspace", () => {
+    assert.equal(sourcesRoot(root), path.join(root, "sources"));
+  });
+
+  it("sourceFilePath builds workspace/sources/<slug>.md", () => {
+    assert.equal(
+      sourceFilePath(root, "hn-front-page"),
+      path.join(root, "sources", "hn-front-page.md"),
+    );
+  });
+
+  it("sourceStatePath nests under _state", () => {
+    assert.equal(
+      sourceStatePath(root, "hn-front-page"),
+      path.join(root, "sources", "_state", "hn-front-page.json"),
+    );
+  });
+
+  it("robotsCachePath sanitizes colons in host:port", () => {
+    // Hosts with explicit ports have colons that break on some
+    // filesystems. Colon → underscore.
+    const p = robotsCachePath(root, "example.com:8080");
+    assert.equal(
+      p,
+      path.join(root, "sources", "_state", "robots", "example.com_8080.txt"),
+    );
+  });
+
+  it("dailyNewsPath splits YYYY-MM-DD into year / month / day.md", () => {
+    assert.equal(
+      dailyNewsPath(root, "2026-04-13"),
+      path.join(root, "news", "daily", "2026", "04", "13.md"),
+    );
+  });
+
+  it("dailyNewsPath rejects invalid date strings", () => {
+    assert.throws(() => dailyNewsPath(root, ""), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "2026/04/13"), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "2026-4-13"), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "foo"), /YYYY-MM-DD/);
+  });
+
+  it("archivePath builds news/archive/<slug>/<YYYY-MM>.md", () => {
+    assert.equal(
+      archivePath(root, "hn-front-page", "2026-04"),
+      path.join(root, "news", "archive", "hn-front-page", "2026-04.md"),
+    );
+  });
+
+  it("archivePath rejects invalid year-month strings", () => {
+    assert.throws(() => archivePath(root, "x", "2026/04"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", "2026-4"), /YYYY-MM/);
+  });
+});
+
+describe("isValidSlug", () => {
+  it("accepts simple kebab-case slugs", () => {
+    assert.equal(isValidSlug("hn"), true);
+    assert.equal(isValidSlug("hn-front-page"), true);
+    assert.equal(isValidSlug("anthropic-releases"), true);
+    assert.equal(isValidSlug("a"), true);
+    assert.equal(isValidSlug("arxiv-cs-cl"), true);
+  });
+
+  it("accepts digits", () => {
+    assert.equal(isValidSlug("arxiv-2024"), true);
+    assert.equal(isValidSlug("news3"), true);
+    assert.equal(isValidSlug("100"), true);
+  });
+
+  it("rejects empty / too-long", () => {
+    assert.equal(isValidSlug(""), false);
+    assert.equal(isValidSlug("a".repeat(65)), false);
+  });
+
+  it("rejects uppercase", () => {
+    assert.equal(isValidSlug("HN"), false);
+    assert.equal(isValidSlug("Hacker-News"), false);
+  });
+
+  it("rejects underscores / dots / slashes / spaces", () => {
+    assert.equal(isValidSlug("hn_front"), false);
+    assert.equal(isValidSlug("hn.front"), false);
+    assert.equal(isValidSlug("hn/front"), false);
+    assert.equal(isValidSlug("hn front"), false);
+  });
+
+  it("rejects leading / trailing hyphen", () => {
+    assert.equal(isValidSlug("-hn"), false);
+    assert.equal(isValidSlug("hn-"), false);
+    assert.equal(isValidSlug("-"), false);
+  });
+
+  it("rejects consecutive hyphens", () => {
+    assert.equal(isValidSlug("hn--front"), false);
+  });
+
+  it("rejects path-traversal attempts", () => {
+    // Defense: the slug doubles as a filename, so ".." or "x/y"
+    // would let a caller escape the sources dir. The regex
+    // already rejects these but pin the intent.
+    assert.equal(isValidSlug(".."), false);
+    assert.equal(isValidSlug("../etc/passwd"), false);
+    assert.equal(isValidSlug("foo/../bar"), false);
+    assert.equal(isValidSlug(".hidden"), false);
+  });
+
+  it("rejects non-string", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(isValidSlug(null as any), false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(isValidSlug(42 as any), false);
+  });
+});

--- a/test/sources/test_registry.ts
+++ b/test/sources/test_registry.ts
@@ -1,0 +1,478 @@
+// Registry I/O tests. Pure-parser tests run without touching the
+// filesystem; the filesystem tests use `mkdtempSync` to keep the
+// real `~/mulmoclaude` out of scope.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseSourceFile,
+  buildSource,
+  serializeSource,
+  readSource,
+  writeSource,
+  listSources,
+  deleteSource,
+  DEFAULT_MAX_ITEMS_PER_FETCH,
+} from "../../server/sources/registry.js";
+import { sourceFilePath } from "../../server/sources/paths.js";
+import type { Source } from "../../server/sources/types.js";
+
+// --- pure-parser tests --------------------------------------------------
+
+const VALID_FRONTMATTER = `---
+slug: hn-front-page
+title: Hacker News front page
+url: https://news.ycombinator.com/rss
+fetcher_kind: rss
+schedule: daily
+categories: [tech-news, general, english]
+max_items_per_fetch: 30
+added_at: 2026-04-13T09:00:00Z
+---
+
+# Notes
+
+Why registered: general pulse.
+`;
+
+describe("parseSourceFile", () => {
+  it("extracts frontmatter and body", () => {
+    const out = parseSourceFile(VALID_FRONTMATTER);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "hn-front-page");
+    assert.equal(out!.fields.get("title"), "Hacker News front page");
+    assert.deepEqual(out!.fields.get("categories"), [
+      "tech-news",
+      "general",
+      "english",
+    ]);
+    assert.match(out!.body, /# Notes/);
+  });
+
+  it("returns null for a file with no frontmatter", () => {
+    assert.equal(parseSourceFile("just a markdown body\n"), null);
+  });
+
+  it("returns null for an unterminated frontmatter block", () => {
+    assert.equal(parseSourceFile("---\nslug: x\ntitle: hey\n"), null);
+  });
+
+  it("tolerates CRLF line endings", () => {
+    const crlf = VALID_FRONTMATTER.replace(/\n/g, "\r\n");
+    const out = parseSourceFile(crlf);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "hn-front-page");
+  });
+
+  it("ignores comment lines in frontmatter", () => {
+    const raw = `---
+# comment
+slug: x
+title: hey
+url: https://example.com
+fetcher_kind: rss
+schedule: daily
+categories: [ai]
+max_items_per_fetch: 10
+added_at: 2026-04-13T00:00:00Z
+---
+`;
+    const out = parseSourceFile(raw);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "x");
+  });
+
+  it("handles empty string values", () => {
+    const raw = `---
+slug: x
+title: empty
+url: https://example.com
+fetcher_kind: rss
+schedule: daily
+categories: []
+max_items_per_fetch: 5
+added_at: 2026-04-13T00:00:00Z
+---
+`;
+    const out = parseSourceFile(raw);
+    assert.ok(out);
+    assert.deepEqual(out!.fields.get("categories"), []);
+  });
+});
+
+describe("buildSource — validation", () => {
+  function base(): Map<string, string | string[]> {
+    return new Map<string, string | string[]>([
+      ["slug", "hn"],
+      ["title", "HN"],
+      ["url", "https://news.ycombinator.com/rss"],
+      ["fetcher_kind", "rss"],
+      ["schedule", "daily"],
+      ["categories", ["tech-news"]],
+      ["max_items_per_fetch", "30"],
+      ["added_at", "2026-04-13T00:00:00Z"],
+    ]);
+  }
+
+  it("builds a valid Source from well-formed fields", () => {
+    const source = buildSource(base(), "body");
+    assert.ok(source);
+    assert.equal(source!.slug, "hn");
+    assert.equal(source!.title, "HN");
+    assert.equal(source!.fetcherKind, "rss");
+    assert.equal(source!.schedule, "daily");
+    assert.deepEqual(source!.categories, ["tech-news"]);
+    assert.equal(source!.maxItemsPerFetch, 30);
+    assert.equal(source!.notes, "body");
+  });
+
+  it("returns null for missing slug", () => {
+    const f = base();
+    f.delete("slug");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for invalid slug (uppercase)", () => {
+    const f = base();
+    f.set("slug", "HN");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for invalid slug (path traversal)", () => {
+    const f = base();
+    f.set("slug", "../etc/passwd");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for missing title", () => {
+    const f = base();
+    f.delete("title");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for missing url", () => {
+    const f = base();
+    f.delete("url");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for unknown fetcher kind", () => {
+    const f = base();
+    f.set("fetcher_kind", "bogus");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for unknown schedule", () => {
+    const f = base();
+    f.set("schedule", "quarterly");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("drops invalid categories silently", () => {
+    const f = base();
+    f.set("categories", ["ai", "bogus", "security"]);
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.deepEqual(source!.categories, ["ai", "security"]);
+  });
+
+  it("falls back to the default max_items_per_fetch for invalid values", () => {
+    const f = base();
+    f.set("max_items_per_fetch", "not-a-number");
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.equal(source!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
+  });
+
+  it("falls back to the default for a zero / negative max", () => {
+    const f = base();
+    f.set("max_items_per_fetch", "0");
+    assert.equal(
+      buildSource(f, "")!.maxItemsPerFetch,
+      DEFAULT_MAX_ITEMS_PER_FETCH,
+    );
+    f.set("max_items_per_fetch", "-10");
+    assert.equal(
+      buildSource(f, "")!.maxItemsPerFetch,
+      DEFAULT_MAX_ITEMS_PER_FETCH,
+    );
+  });
+
+  it("collects unrecognized keys into fetcherParams", () => {
+    const f = base();
+    f.set("github_repo", "anthropics/claude-code");
+    f.set("arxiv_query", "cs.CL");
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.deepEqual(source!.fetcherParams, {
+      github_repo: "anthropics/claude-code",
+      arxiv_query: "cs.CL",
+    });
+  });
+
+  it("ignores array values in fetcherParams (schema mismatch)", () => {
+    const f = base();
+    f.set("weird_array", ["a", "b"]);
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.equal(source!.fetcherParams["weird_array"], undefined);
+  });
+});
+
+describe("serializeSource — round trip", () => {
+  function makeSource(over: Partial<Source> = {}): Source {
+    return {
+      slug: "hn",
+      title: "Hacker News",
+      url: "https://news.ycombinator.com/rss",
+      fetcherKind: "rss",
+      fetcherParams: {},
+      schedule: "daily",
+      categories: ["tech-news", "general"],
+      maxItemsPerFetch: 30,
+      addedAt: "2026-04-13T00:00:00Z",
+      notes: "",
+      ...over,
+    };
+  }
+
+  it("round-trips a minimal Source", () => {
+    const source = makeSource();
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    assert.ok(parsed);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.ok(rebuilt);
+    assert.deepEqual(rebuilt, source);
+  });
+
+  it("round-trips with fetcherParams", () => {
+    const source = makeSource({
+      fetcherKind: "github-releases",
+      fetcherParams: { github_repo: "anthropics/claude-code" },
+    });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.deepEqual(rebuilt, source);
+  });
+
+  it("round-trips notes body", () => {
+    const source = makeSource({
+      notes: "# Notes\n\nWhy this source matters.\n",
+    });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.notes, source.notes);
+  });
+
+  it("quotes values that would confuse the flat-YAML parser", () => {
+    // A title containing a colon would otherwise break the reader
+    // because the parser splits on the first `:`.
+    const source = makeSource({ title: "Weekly: The Best of the Web" });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.title, "Weekly: The Best of the Web");
+  });
+
+  it("quotes values that look like reserved YAML atoms", () => {
+    // `true`, `null`, numbers, dates — the reader currently
+    // returns them as strings, but if we ever add YAML-native
+    // scalar types this protects us.
+    const source = makeSource({ title: "true" });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.title, "true");
+  });
+
+  it("sorts fetcherParams alphabetically for stable diffs", () => {
+    const source = makeSource({
+      fetcherParams: { z_key: "1", a_key: "2", m_key: "3" },
+    });
+    const serialized = serializeSource(source);
+    const aIdx = serialized.indexOf("a_key:");
+    const mIdx = serialized.indexOf("m_key:");
+    const zIdx = serialized.indexOf("z_key:");
+    assert.ok(aIdx > 0 && mIdx > aIdx && zIdx > mIdx);
+  });
+});
+
+// --- filesystem tests ---------------------------------------------------
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "sources-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function makeSource(): Source {
+  return {
+    slug: "hn",
+    title: "Hacker News",
+    url: "https://news.ycombinator.com/rss",
+    fetcherKind: "rss",
+    fetcherParams: {},
+    schedule: "daily",
+    categories: ["tech-news"],
+    maxItemsPerFetch: 30,
+    addedAt: "2026-04-13T00:00:00Z",
+    notes: "",
+  };
+}
+
+describe("writeSource + readSource — filesystem round trip", () => {
+  it("writes and reads back an equivalent Source", async () => {
+    const source = makeSource();
+    await writeSource(workspace, source);
+    const read = await readSource(workspace, "hn");
+    assert.deepEqual(read, source);
+  });
+
+  it("returns null when the file doesn't exist", async () => {
+    const read = await readSource(workspace, "missing");
+    assert.equal(read, null);
+  });
+
+  it("returns null when the slug in the frontmatter doesn't match the filename", async () => {
+    // Defense: someone renames the file on disk without editing
+    // the frontmatter. Silently loading with the wrong slug would
+    // corrupt downstream state lookups — so we refuse the load.
+    const source = makeSource();
+    await writeSource(workspace, source);
+    // Manually rename on disk to simulate the drift.
+    const { rename } = await import("node:fs/promises");
+    await rename(
+      sourceFilePath(workspace, "hn"),
+      sourceFilePath(workspace, "renamed"),
+    );
+    const read = await readSource(workspace, "renamed");
+    assert.equal(read, null);
+  });
+
+  it("refuses to write an invalid slug", async () => {
+    const source: Source = { ...makeSource(), slug: "HACK/../etc" };
+    await assert.rejects(() => writeSource(workspace, source), /invalid slug/);
+  });
+
+  it("refuses to read an invalid slug", async () => {
+    assert.equal(await readSource(workspace, "../etc/passwd"), null);
+  });
+
+  it("overwrites an existing source atomically", async () => {
+    const first = makeSource();
+    await writeSource(workspace, first);
+    const second: Source = { ...first, title: "Hacker News (updated)" };
+    await writeSource(workspace, second);
+    const read = await readSource(workspace, "hn");
+    assert.equal(read!.title, "Hacker News (updated)");
+  });
+
+  it("does not leave a .tmp file behind after a successful write", async () => {
+    await writeSource(workspace, makeSource());
+    const { readdir } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    const entries = await readdir(sourcesRoot(workspace));
+    assert.equal(
+      entries.some((name) => name.endsWith(".tmp")),
+      false,
+    );
+  });
+});
+
+describe("listSources", () => {
+  it("returns [] when the sources directory doesn't exist", async () => {
+    assert.deepEqual(await listSources(workspace), []);
+  });
+
+  it("returns every valid source file, sorted by slug", async () => {
+    const sources = [
+      { ...makeSource(), slug: "charlie", title: "C" },
+      { ...makeSource(), slug: "alpha", title: "A" },
+      { ...makeSource(), slug: "bravo", title: "B" },
+    ];
+    for (const s of sources) await writeSource(workspace, s);
+    const listed = await listSources(workspace);
+    assert.deepEqual(
+      listed.map((s) => s.slug),
+      ["alpha", "bravo", "charlie"],
+    );
+  });
+
+  it("skips files starting with _", async () => {
+    await writeSource(workspace, makeSource());
+    // Meta file written alongside by a hypothetical index generator.
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(join(sourcesRoot(workspace), "_index.md"), "# Index\n");
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].slug, "hn");
+  });
+
+  it("skips non-.md files", async () => {
+    await writeSource(workspace, makeSource());
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(
+      join(sourcesRoot(workspace), "hn.json"),
+      JSON.stringify({ something: "else" }),
+    );
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+  });
+
+  it("logs + skips malformed source files without crashing", async () => {
+    await writeSource(workspace, makeSource());
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(
+      join(sourcesRoot(workspace), "broken.md"),
+      "no frontmatter here",
+    );
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].slug, "hn");
+  });
+});
+
+describe("deleteSource", () => {
+  it("removes an existing source file and returns true", async () => {
+    await writeSource(workspace, makeSource());
+    const removed = await deleteSource(workspace, "hn");
+    assert.equal(removed, true);
+    const read = await readSource(workspace, "hn");
+    assert.equal(read, null);
+  });
+
+  it("returns false when the file doesn't exist", async () => {
+    const removed = await deleteSource(workspace, "missing");
+    assert.equal(removed, false);
+  });
+
+  it("refuses invalid slugs", async () => {
+    const removed = await deleteSource(workspace, "../etc/passwd");
+    assert.equal(removed, false);
+  });
+});
+
+describe("writeSource + readFile — serialization shape", () => {
+  it("writes a markdown file with the expected frontmatter prefix", async () => {
+    await writeSource(workspace, makeSource());
+    const raw = await readFile(sourceFilePath(workspace, "hn"), "utf-8");
+    assert.ok(raw.startsWith("---\n"));
+    assert.match(raw, /\nslug: hn\n/);
+    assert.match(raw, /\nfetcher_kind: rss\n/);
+    assert.match(raw, /\n---\n/);
+  });
+});

--- a/test/sources/test_taxonomy.ts
+++ b/test/sources/test_taxonomy.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CATEGORY_SLUGS,
+  isCategorySlug,
+  normalizeCategories,
+} from "../../server/sources/taxonomy.js";
+
+describe("CATEGORY_SLUGS — shape pin", () => {
+  it("contains the phase-1 taxonomy with no duplicates", () => {
+    // A mutation that removes a slug would silently drop every
+    // source tagged with it. Pin the list explicitly so any edit
+    // lands in this test too.
+    assert.deepEqual(Array.from(CATEGORY_SLUGS), [
+      "tech-news",
+      "business-news",
+      "ai",
+      "security",
+      "devops",
+      "frontend",
+      "backend",
+      "ml-research",
+      "dependencies",
+      "product-updates",
+      "japanese",
+      "english",
+      "papers",
+      "general",
+      "startup",
+      "personal",
+    ]);
+  });
+
+  it("has no duplicates", () => {
+    assert.equal(new Set(CATEGORY_SLUGS).size, CATEGORY_SLUGS.length);
+  });
+});
+
+describe("isCategorySlug", () => {
+  it("accepts every slug in the taxonomy", () => {
+    for (const slug of CATEGORY_SLUGS) {
+      assert.equal(isCategorySlug(slug), true, `expected ${slug} accepted`);
+    }
+  });
+
+  it("rejects slugs not in the taxonomy", () => {
+    assert.equal(isCategorySlug("artificial-intelligence"), false);
+    assert.equal(isCategorySlug("AI"), false); // wrong case
+    assert.equal(isCategorySlug("tech_news"), false); // underscore
+    assert.equal(isCategorySlug(""), false);
+  });
+
+  it("rejects non-string values", () => {
+    assert.equal(isCategorySlug(null), false);
+    assert.equal(isCategorySlug(undefined), false);
+    assert.equal(isCategorySlug(42), false);
+    assert.equal(isCategorySlug(["ai"]), false);
+    assert.equal(isCategorySlug({ slug: "ai" }), false);
+  });
+});
+
+describe("normalizeCategories", () => {
+  it("returns only valid slugs from a mixed list", () => {
+    const out = normalizeCategories([
+      "ai",
+      "bogus",
+      "security",
+      "AI", // wrong case
+      "startup",
+    ]);
+    assert.deepEqual(out, ["ai", "security", "startup"]);
+  });
+
+  it("deduplicates repeats", () => {
+    const out = normalizeCategories(["ai", "ai", "security", "ai"]);
+    assert.deepEqual(out, ["ai", "security"]);
+  });
+
+  it("preserves input order on the first occurrence of each", () => {
+    // A sort-based dedup would fail this test; explicit order
+    // preservation matches what the classifier prompt asks for.
+    assert.deepEqual(normalizeCategories(["security", "ai", "papers"]), [
+      "security",
+      "ai",
+      "papers",
+    ]);
+  });
+
+  it("returns [] for non-array inputs", () => {
+    assert.deepEqual(normalizeCategories("ai"), []);
+    assert.deepEqual(normalizeCategories(null), []);
+    assert.deepEqual(normalizeCategories(undefined), []);
+    assert.deepEqual(normalizeCategories({ "0": "ai" }), []);
+  });
+
+  it("returns [] for an array of no valid slugs", () => {
+    assert.deepEqual(normalizeCategories(["foo", "bar", 42]), []);
+  });
+
+  it("returns [] for an empty array", () => {
+    assert.deepEqual(normalizeCategories([]), []);
+  });
+});

--- a/test/sources/test_taxonomy.ts
+++ b/test/sources/test_taxonomy.ts
@@ -28,6 +28,15 @@ describe("CATEGORY_SLUGS — shape pin", () => {
       "general",
       "startup",
       "personal",
+      "finance",
+      "design",
+      "productivity",
+      "science",
+      "health",
+      "gaming",
+      "climate",
+      "culture",
+      "policy",
     ]);
   });
 

--- a/test/sources/test_urls.ts
+++ b/test/sources/test_urls.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeUrl, stableItemId } from "../../server/sources/urls.js";
+
+describe("normalizeUrl — happy path", () => {
+  it("returns a canonical form for a plain URL", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/a/b"),
+      "https://example.com/a/b",
+    );
+  });
+
+  it("lowercases protocol and hostname", () => {
+    assert.equal(
+      normalizeUrl("HTTPS://EXAMPLE.COM/path"),
+      "https://example.com/path",
+    );
+  });
+
+  it("drops the fragment", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/p#section"),
+      "https://example.com/p",
+    );
+  });
+
+  it("collapses a trailing slash on non-root paths", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/path/"),
+      "https://example.com/path",
+    );
+  });
+
+  it("preserves the root slash", () => {
+    // "/"-only path is semantically different from no path; don't
+    // collapse it to empty.
+    assert.equal(normalizeUrl("https://example.com/"), "https://example.com/");
+  });
+
+  it("drops default ports", () => {
+    assert.equal(
+      normalizeUrl("https://example.com:443/x"),
+      "https://example.com/x",
+    );
+    assert.equal(
+      normalizeUrl("http://example.com:80/x"),
+      "http://example.com/x",
+    );
+  });
+
+  it("keeps non-default ports", () => {
+    assert.equal(
+      normalizeUrl("https://example.com:8443/x"),
+      "https://example.com:8443/x",
+    );
+  });
+});
+
+describe("normalizeUrl — tracking params", () => {
+  it("strips utm_* params", () => {
+    const out = normalizeUrl(
+      "https://example.com/x?utm_source=hn&utm_medium=rss&utm_campaign=foo",
+    );
+    assert.equal(out, "https://example.com/x");
+  });
+
+  it("strips fbclid / gclid / msclkid", () => {
+    for (const param of ["fbclid", "gclid", "msclkid", "dclid", "yclid"]) {
+      const out = normalizeUrl(`https://example.com/x?${param}=xyz`);
+      assert.equal(out, "https://example.com/x", `expected ${param} stripped`);
+    }
+  });
+
+  it("strips mc_* mailchimp params", () => {
+    const out = normalizeUrl("https://example.com/x?mc_cid=abc&mc_eid=def");
+    assert.equal(out, "https://example.com/x");
+  });
+
+  it("preserves non-tracking query params", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/search?q=hello"),
+      "https://example.com/search?q=hello",
+    );
+  });
+
+  it("mixes tracking strip with preservation", () => {
+    assert.equal(
+      normalizeUrl(
+        "https://example.com/search?q=hello&utm_source=news&fbclid=zzz&lang=ja",
+      ),
+      "https://example.com/search?lang=ja&q=hello",
+    );
+  });
+
+  it("is case-insensitive on tracking param names", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/x?UTM_Source=foo"),
+      "https://example.com/x",
+    );
+  });
+});
+
+describe("normalizeUrl — query param sorting", () => {
+  it("sorts remaining params alphabetically", () => {
+    // Sorting makes different-ordered links dedup correctly.
+    assert.equal(
+      normalizeUrl("https://example.com/x?z=1&a=2&m=3"),
+      "https://example.com/x?a=2&m=3&z=1",
+    );
+  });
+
+  it("preserves multi-value params in their relative order", () => {
+    // ?t=1&t=2 and ?t=2&t=1 are semantically different; we must
+    // not reorder within the same key.
+    const out = normalizeUrl("https://example.com/x?t=1&t=2&a=0");
+    assert.equal(out, "https://example.com/x?a=0&t=1&t=2");
+  });
+});
+
+describe("normalizeUrl — invalid input", () => {
+  it("returns null for empty / whitespace", () => {
+    assert.equal(normalizeUrl(""), null);
+    assert.equal(normalizeUrl("   "), null);
+  });
+
+  it("returns null for non-string input", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(normalizeUrl(null as any), null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(normalizeUrl(42 as any), null);
+  });
+
+  it("returns null for malformed URLs", () => {
+    assert.equal(normalizeUrl("not a url"), null);
+    assert.equal(normalizeUrl("http://"), null);
+  });
+
+  it("parses uncommon but valid schemes", () => {
+    // File URLs are valid; the caller decides whether to register
+    // them. Normalizer should still produce a clean href.
+    const out = normalizeUrl("file:///tmp/x.html");
+    assert.equal(out, "file:///tmp/x.html");
+  });
+});
+
+describe("stableItemId", () => {
+  it("is deterministic for the same input", () => {
+    assert.equal(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/a"),
+    );
+  });
+
+  it("differs for different inputs", () => {
+    assert.notEqual(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/b"),
+    );
+  });
+
+  it("is always 8 hex chars (FNV-1a 32-bit)", () => {
+    for (const input of [
+      "",
+      "x",
+      "https://example.com/a",
+      "https://example.com/" + "x".repeat(1000),
+    ]) {
+      const id = stableItemId(input);
+      assert.equal(id.length, 8);
+      assert.match(id, /^[0-9a-f]{8}$/);
+    }
+  });
+
+  it("produces different ids for normalized vs unnormalized", () => {
+    // Sanity: the caller is expected to hash the normalized form
+    // so two different-looking inputs collapse to one id only
+    // when the caller does the normalize step.
+    assert.notEqual(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/a?utm_source=x"),
+    );
+  });
+});


### PR DESCRIPTION
Phase-1 foundation for the source-registry feature tracked in #166. Lands the full spec as a plan file plus the pure, testable primitives (types, taxonomy, URL normalization, on-disk registry I/O). **No network, no Claude CLI, no UI** — those land in follow-up PRs and need design inputs that this PR's spec calls out as open questions.

## What's in this PR

### `plans/feat-source-registry.md` (264 lines)

The spec for the whole feature. Highlights:

- **Phase-1 scope**: RSS + public GitHub API + arXiv + Claude-side `web_fetch`/`web_search`. Explicitly no auth, no X, no private feeds.
- **Who fetches**: structured APIs on our server (deterministic scheduling, no token cost). Arbitrary web + search through Claude's built-in tools (Anthropic's crawler handles robots).
- **Crawl etiquette**: custom `User-Agent: MulmoClaude-SourceBot/1.0 (+url)`, robots.txt check + 24h cache, per-host rate limit, source-registration preflight.
- **Workspace layout**: one markdown file per source at `workspace/sources/<slug>.md` (matches wiki/pages convention). Runtime state (cursors, etags, backoff) gitignored under `_state/`.
- **Auto-categorization** against a fixed 16-slug taxonomy via a Claude CLI spawn at registration time, reusing the `chat-index/summarizer.ts` pattern.
- **Daily aggregation** piggybacks on `task-manager`; mirrors `maybeRunJournal` / `maybeIndexSession` shape for the lock + sentinel + disable-for-lifetime pattern.
- **Phase-3 auth extensibility** baked into the `fetcher` tagged union — adding an authed fetcher is a new module, not a framework change.
- **9 open questions** enumerated at the end — taxonomy size, dedup strategy, archive pruning, failure visibility, timezone, fetcher parallelism, Claude-side fetcher invocation granularity, etc.

### Foundation code (all pure, 100% testable)

| File | Purpose |
|---|---|
| `server/sources/taxonomy.ts` | Fixed closed enum of 16 category slugs + `isCategorySlug` + `normalizeCategories` |
| `server/sources/types.ts` | `Source` / `SourceItem` / `SourceState` shapes + `FetcherKind` / `SourceSchedule` closed enums |
| `server/sources/urls.ts` | URL normalizer (strip utm/fbclid/gclid/mc_*/..., drop fragment, sort params, collapse trailing slash, drop default ports) + FNV-1a `stableItemId` |
| `server/sources/paths.ts` | Directory-layout helpers with boundary validation on YYYY-MM-DD / YYYY-MM + defensive `isValidSlug` (kebab-case only, no path traversal) |
| `server/sources/registry.ts` | Source file read/write: flat YAML frontmatter, round-trip-safe serializer with aggressive quoting, atomic `.tmp` + rename writes, malformed files logged and skipped |

### Tests (~95 cases)

- **`test_taxonomy.ts`** — pins the 16-slug enum, dedup, order preservation, invalid-input tolerance
- **`test_urls.ts`** — happy path, every tracking param class (utm/mc/fbclid/gclid/msclkid/...), case-insensitive param names, query sort with multi-value preservation, default-port drop, invalid inputs, `stableItemId` determinism + 8-hex-char invariant
- **`test_paths.ts`** — all path joiners, YYYY-MM-DD / YYYY-MM validation throwing, `isValidSlug` accepts kebab-case + digits and rejects uppercase/underscore/dot/slash/space/leading-or-trailing-hyphen/consecutive-hyphens/path-traversal
- **`test_registry.ts`** — frontmatter parse (CRLF, comments, empty values, malformed), `buildSource` validation (missing required fields, unknown fetcher kind, unknown schedule, invalid slug, invalid category filtering, default fallbacks, fetcherParams catch-all), `serializeSource` round trip including values that need quoting and YAML reserved atoms, filesystem round trip via `mkdtempSync`, slug-vs-filename mismatch rejection, `listSources` ordering + filtering + skip-and-continue on malformed files, `deleteSource`

## Why stop here?

The next layers need design inputs reviewers may want to influence first. All 9 open questions in the plan affect how later PRs are shaped:

- **Taxonomy size** — 16 categories is a guess. Pilot for 2 weeks, re-evaluate.
- **Fetch granularity** — per-item or per-feed cursors?
- **Output format** — markdown-only or markdown + structured JSON block for the dashboard?
- **Failure visibility** — footer line vs notification vs badge?
- **Timezone** — local (matches journal) vs UTC?
- **Fetcher parallelism** — serial across all vs per-host queue?
- **Claude-side fetcher invocation** — one session per cron run vs per-source?
- **Archive size** — unbounded for now, compact later?
- **Item dedup** — per-source only in phase 1, cross-source in phase 2?

Locking the foundation types now lets those discussions happen without blocking any of them. Nothing in this PR commits to an answer.

## Follow-up PRs

In rough order:
1. `robots.txt` parser + cache + rate limiter
2. Server-side fetchers (rss, github-releases, github-issues, arxiv)
3. Classifier (Claude CLI spawn, reusing `chat-index/summarizer.ts` pattern)
4. Pipeline orchestration (fetch → normalize → summarize → write daily markdown)
5. `manageSource` plugin (Vue UI + Express routes)
6. task-manager wiring + `/api/sources/rebuild` debug endpoint

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` (0 errors, 8 pre-existing warnings)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` — 1156/1156 passing (+95 new tests on this branch)

## Dependencies

None in the runtime path. This PR adds new files only; no existing behaviour changes. Phase-3 authed fetchers will need the sensitive-file denylist from #148 to protect any `.env` credentials — already landed.

Plan file: `plans/feat-source-registry.md`
Refs #166. Supersedes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a source registry for tracking public information sources with registration, listing, removal, recategorization, and fetch/test actions.
  * Daily pipeline to fetch → normalize → summarize → write aggregated daily summaries.
  * Automatic category classification at registration and manual recategorize option.
  * URL normalization and stable item ID generation.

* **Style / Quality**
  * Added comprehensive tests covering paths, registry parsing/IO, taxonomy, and URL behavior.

* **Documentation**
  * Phase‑1 planning/spec for the information source registry and crawl etiquette.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->