### PR TITLE
feat(sources): RSS / Atom / RDF fetcher + cursor-based dedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "fast-xml-parser": "^5.5.12",
     "gui-chat-protocol": "^0.0.4",
     "marked": "^18.0.0",
     "material-icons": "^1.13.14",

--- a/plans/feat-source-registry.md
+++ b/plans/feat-source-registry.md
@@ -235,17 +235,89 @@ Designed in but not used in phase 1:
 | **2** | On-demand `searchSources` + wiki-page generation for research results + notification hookup | Phase 1 stable in daily use |
 | **3** | Auth-bearing fetchers (X / private GitHub / paid APIs) + secrets rotation + per-source rate-limit tuning | Real demand for a specific authed source |
 
-## Open questions (to resolve before implementation PR)
+## Resolved decisions
 
-1. **Taxonomy size**. Starting list above has 16 categories. Too many dilutes filtering; too few forces everything into `general`. Pilot with 16 and re-evaluate after 2 weeks of daily use?
-2. **Daily summary template**. Markdown only, or include a compact structured index (JSON block) so the dashboard can render without re-parsing markdown? Lean toward: both — markdown for humans, fenced JSON block at the end for the dashboard.
-3. **Item dedup across sources**. Two RSS feeds often carry the same HN story. Phase-1 answer: hash the normalized URL (strip utm params), skip dedup across sources but dedup within a single source. Phase-2: cross-source URL dedup.
-4. **Archive size**. Per-source monthly archives grow unbounded. Phase-1: no pruning. Phase-3-ish: add a `journal-archivist`-style compaction pass.
-5. **Error visibility**. When a source fails for 3 days in a row, how does the user learn? Ideas: (a) surface in daily summary footer ("3 sources failed today"), (b) push notification at 5-day mark, (c) badge on the manageSource UI. Pick one.
-6. **Timezone for "daily"**. Local time like the journal, or UTC? Journal uses local — match it.
-7. **Order of fetcher execution**. Parallel across hosts but serial per-host? Or fully serial with a 1s delay? Parallel-across-hosts is faster but needs a per-host queue. Start serial for simplicity; add parallelism if daily run exceeds 5 minutes.
-8. **Failure isolation**. A single source failing must not abort the pipeline. Model: per-source try/catch that logs + advances state + continues.
-9. **Claude-side fetcher invocation pattern**. One agent session per cron run that hits all web-search sources? Or per-source sessions? Per-run is cheaper (shared context, one summary pass) — start there.
+The original spec had 9 open questions; these were worked through in the #188 review thread. Decisions below are what subsequent implementation PRs will follow.
+
+### 1. Taxonomy size — **25 slugs (16 original + 9 expansion)**
+
+Added: `finance` (markets / crypto distinct from `business-news`), `design` (UI/UX — implementation-free complement to `frontend`), `productivity` (tools / workflow / PKM), `science` (broader physics / chem / bio news — `papers` stays academic-only), `health` (medical / fitness / wellness), `gaming`, `climate` (environment / energy / sustainability), `culture` (music / film / books / arts), `policy` (regulation / law / public policy — AI regulation lands here rather than under `ai`).
+
+Rationale: the original 16 were tech-centric enough that everything non-tech collapsed into `general`, defeating the purpose of categorization. Running with a broader table and trimming later (if a slug sees zero use over 2 months) is cheaper than starting small and adding under pressure.
+
+### 2. Daily summary template — **Markdown with a trailing fenced JSON block**
+
+Files under `workspace/news/daily/YYYY/MM/DD.md` are human-readable markdown (headings, bullet items, links). At the tail of the file, a ```` ```json ```` fence contains a compact item index the dashboard (#143) can read without regex-scraping markdown:
+
+```markdown
+# Daily brief — 2026-04-13
+
+## AI
+- [Anthropic releases Claude 4.7](...) — short summary
+- ...
+
+## Security
+- ...
+
+```json
+{
+  "itemCount": 42,
+  "byCategory": {"ai": 12, "security": 4, ...},
+  "items": [{"id": "...", "title": "...", "url": "...", "categories": [...], "severity": null, "sourceSlug": "..."}]
+}
+```
+```
+
+Markdown viewers render the JSON block as a code block and ignore it; dashboard fetches the file and parses the last fenced block as JSON.
+
+### 3. Item dedup — **Archive keeps everything, daily summary dedups cross-source**
+
+Each per-source archive (`workspace/news/archive/<slug>/YYYY/MM.md`) contains **every** item the fetcher produced for that source — lossless log for retrospective grep. The daily-summary aggregation pass uses a `Set<stableItemId>` (FNV-1a of the normalized URL from `urls.ts`) to drop the second and third occurrence of the same article across sources. Phase-2 can add title-similarity dedup for the "same article, different URL" case; phase-1 URL-hash dedup catches ~95% of real cases at zero extra cost.
+
+### 4. Archive growth — **Keep everything, organize as `archive/<slug>/YYYY/MM.md`**
+
+No compaction, no pruning. 50 sources × 12 months × ~30 items × ~200 bytes ≈ 3.6 MB / year, ~18 MB / 5 years — cheap relative to chat jsonl. The nested `YYYY/MM.md` layout (changed from flat `YYYY-MM.md`) keeps a single year browsable as one directory, matching `daily/YYYY/MM/DD.md`. If storage ever becomes a real problem, phase-3 can add a journal-optimization-style year-end compaction — out of scope for phase 1.
+
+### 5. Failure visibility — **Daily summary footer + `manageSource` UI badge**
+
+Two surfaces, combined:
+
+- **Daily summary footer**: after the per-category sections, a `## Source health` block listing every source that's failed 3+ days in a row (e.g. `⚠ 2 sources still failing: foo (5d), bar (3d)`). Nothing logged for one-day failures — noise. Cheap to add, catches neglected sources.
+- **`manageSource` UI badge**: each source row shows last-successful-fetch timestamp and a status badge — green (fresh), yellow (3-6 day failure), red (7+). Actionable: user clicks the failing source, sees the last error, fixes or removes.
+
+**Deferred to later phase**: external notification (#142) at a 7-day threshold. Needs the notification infrastructure to land first — flagged in #142 and #144 so they know about the consumer.
+
+### 6. Timezone — **Local time, matching the journal**
+
+Same `toIsoDate(d)` helper the journal already uses (`getFullYear()` / `getMonth()` / `getDate()` in local). Personal workspace → human time. If we ever go multi-user or daemonize this, UTC becomes more defensible.
+
+### 7. Fetcher execution order — **Parallel across hosts, serial per host**
+
+Group eligible fetchers by URL hostname. Distinct hosts run concurrently (bounded by Node's event loop so it's not literally parallel but close enough). Same-host fetchers serialize with the host's configured per-host rate limit. 50 sources across ~15 distinct hosts ≈ 15-second daily run, down from 75 seconds serial.
+
+Implementation note: a small per-host promise chain (`hostQueues: Map<string, Promise<void>>`) appended to per fetcher. No full job queue needed at phase-1 scale.
+
+### 8. Failure isolation — **Per-source try/catch with log + advance state + continue**
+
+The daily pipeline wraps each fetcher call in try/catch. Failure bumps `consecutiveFailures` in the state file and schedules the next attempt with exponential backoff. One source failing (parser error, HTTP 500, host unreachable) never aborts the remaining fetchers. A pipeline-level catch handles truly fatal errors (`ENOSPC`, `ClaudeCliNotFoundError`) and disables the module for the process lifetime, same as the journal.
+
+### 9. Claude-side fetcher invocation — **5-source batches per CLI spawn, configurable**
+
+The `claude` CLI is spawned via `spawn("claude", ["--print", "--output-format", "json", "--model", "haiku", "--max-budget-usd", ...])` (same pattern as `chat-index/summarizer.ts`). web-fetch and web-search sources are batched into groups of N before each spawn:
+
+```ts
+const BATCH_SIZE = Number(process.env.SOURCES_WEB_BATCH_SIZE) || 5;
+for (const batch of chunk(webSources, BATCH_SIZE)) {
+  await fetchBatchViaCLI(batch);
+}
+```
+
+Default batch size of 5 was chosen so that:
+- 1 CLI spawn pays the ~28k-token cache-creation cost for the system prompt + JSON schema, then processes 5 sources using the cached context. ~4x cheaper than per-source spawns.
+- Each batch's inbound content stays well under haiku's 200k context window — 5 × ~5k chars per page ≈ 25k tokens, safe headroom.
+- Budget-blowup blast radius is 5 sources at most, not all of them.
+
+Env var override (`SOURCES_WEB_BATCH_SIZE`) lets future tuning happen without code change. At the foundation layer of this PR the constant isn't used yet — it lands in the pipeline PR.
 
 ## Test plan (for the phase 1 PR, not this spec)
 

--- a/plans/feat-source-registry.md
+++ b/plans/feat-source-registry.md
@@ -1,0 +1,264 @@
+# Plan: information source registry + daily aggregation + on-demand research
+
+Tracks: #166 (the 10-use-case issue)
+Supersedes / absorbs: #140 (news batch processing — its scope is covered by this plan's UC-1)
+
+## Scope for this spec — phase 1 only
+
+Phase 1 deliberately excludes auth-requiring sources. Authenticated sources (X / Twitter, private RSS, GitHub with a token, paid APIs) add credential management, token refresh, rate-limit policies, and per-source secrets handling — worth their own phase. The phase-1 surface is:
+
+- **RSS / Atom feeds** (public)
+- **Public GitHub REST API** — releases, issues, PRs. Unauthenticated is 60 req/h/IP, plenty for a personal workspace.
+- **arbitrary web pages** — fetched via Claude's built-in `web_fetch` tool (not our server). Respects robots.txt because Anthropic's crawler does.
+- **web search** — Claude's `web_search` tool for "find news about company X" kind of queries.
+
+Explicit non-goals for phase 1: X, private feeds, Slack / Discord bots, email digests, OAuth, API-key rotation.
+
+## Who fetches?
+
+| Source type | Fetcher | Rationale |
+|---|---|---|
+| RSS / Atom | **Server-side** | Stable XML format, no LLM needed. Deterministic daily schedule. Cheap (no tokens). |
+| GitHub Releases / Issues / PRs | **Server-side** | Typed REST JSON. No LLM value-add in fetching. |
+| arXiv / npm / other public REST JSON | **Server-side** | Same. |
+| Arbitrary web pages | **Claude-side** (`web_fetch`) | Anthropic's crawler handles robots / caching / user-agent. We don't reimplement browser-grade HTML parsing. |
+| Ad-hoc search ("news about company X") | **Claude-side** (`web_search`) | Search API access already built into Claude. |
+
+This split is expressed as a `fetcher` field on each source:
+
+```yaml
+fetcher:
+  kind: rss          # "rss" | "github-releases" | "github-issues" | "web-fetch" | "web-search" | "arxiv"
+  # ... type-specific params
+```
+
+The server-side `fetcher.kind` values map to `server/sources/fetchers/*.ts` modules implementing a common `SourceFetcher` interface. Claude-side ones are triggered by emitting a prompt with the right tool call rather than running HTTP ourselves. Auth-requiring fetchers in phase 3 (e.g. `fetcher.kind: "github-authed"`) just register a new module with the same interface — no framework changes.
+
+## Crawl etiquette (for server-side fetching)
+
+1. **User-Agent**: `MulmoClaude-SourceBot/1.0 (+https://github.com/receptron/mulmoclaude)` on every outbound request. Site operators can identify and contact.
+2. **robots.txt check** — before fetching any URL whose host we haven't checked in the last 24h, fetch `/robots.txt` and cache the parsed rules. Respect `User-agent: *` entries.
+3. **Rate limit** — at most 1 request / source / 60s, configurable. No parallel bursts to the same host.
+4. **Respect `Crawl-delay`** from robots.txt if present.
+5. **Source-registration preflight** — when the user adds a new web source, run the robots.txt check synchronously and refuse (with a clear message) if the path is disallowed. Offer alternatives: "try the RSS feed at /feed", "use `fetcher.kind: web-search` instead which goes through Claude's approved crawler".
+6. **5xx / rate-limit backoff** — exponential backoff per host, persisted to the state file so restarts don't hammer.
+
+Claude-side fetchers don't need our robots checking — the `web_fetch` / `web_search` tools are Anthropic-operated and handle it.
+
+## Workspace layout — sources as files
+
+Matches the `wiki/pages/*.md` pattern: one file per source, YAML frontmatter + optional markdown body.
+
+```
+workspace/
+  sources/
+    <slug>.md                    ← one file per source
+    _index.md                    ← auto-generated index grouped by category
+    _state/
+      <slug>.json                ← fetcher state per source (last cursor, etag, last-fetched-at, failure count)
+      robots/<host>.txt          ← cached robots.txt per host
+  news/
+    daily/
+      YYYY/MM/DD.md              ← daily aggregated summary
+    archive/
+      <slug>/YYYY-MM.md          ← per-source archive of older items
+```
+
+### Source file format
+
+```markdown
+---
+slug: hn-front-page
+title: Hacker News front page
+url: https://news.ycombinator.com/rss
+fetcher:
+  kind: rss
+schedule: daily   # "daily" | "hourly" | "weekly" | "on-demand"
+categories: [tech-news, general, english]
+max_items_per_fetch: 30
+added_at: 2026-04-13T09:00:00Z
+# Auto-populated by Claude at registration time; user-editable.
+---
+
+# Notes
+
+Why registered: general tech news pulse, catch launches.
+Override categories: yes (bump `ai` to primary when I have time).
+```
+
+The YAML frontmatter is the machine-readable part. The markdown body below `# Notes` is free-form user annotation — Claude reads it for context when summarizing ("this user cares about AI launches on HN").
+
+### Why per-file over a single `registry.yml`?
+
+- One-file-per-source matches the existing wiki convention. Claude can edit a single source without touching the global registry.
+- Grep-friendly: `grep -l 'tech-news' sources/*.md` for all tech sources.
+- Git diffs stay small and meaningful when Claude tweaks categories or adds notes to one source.
+- Auto-categorization rewrites one file, not a 50-source global YAML.
+
+### State vs config split
+
+`sources/<slug>.md` is **config** (user-editable, committed, git-tracked). `sources/_state/<slug>.json` is **runtime state** (last cursor, etag, mtime, backoff timer). State should generally NOT be in git — add `sources/_state/` to `.gitignore` at phase-1-ship time.
+
+## Auto-categorization
+
+At source registration (via the `manageSource` plugin's `register` action):
+
+1. Fetch a tiny sample — RSS: top 3 items; web page: head + title; GitHub repo: `description` + top 3 releases.
+2. Spawn a Claude CLI call (reusing the `chat-index/summarizer.ts` pattern — `claude --model haiku --output-format json --json-schema ...`) with a prompt:
+
+   > Classify this information source into 1–5 categories from this fixed taxonomy: `[tech-news, business-news, ai, security, devops, frontend, backend, ml-research, dependencies, product-updates, japanese, english, papers, general, startup, personal]`. Output strict JSON: `{ categories: string[], rationale: string }`.
+
+3. Write the categories into the source file's YAML frontmatter. Write `rationale` into the body as a comment for human review.
+
+Users can override categories manually — the next daily run reads the file as-is. A separate `manageSource recategorize` action re-runs the classifier on demand (e.g. after editing the taxonomy).
+
+**Taxonomy is a fixed enum.** Free-form LLM-generated tags balloon into synonyms (`"artificial-intelligence"` vs `"ai"`) and make filtering useless. The enum lives in `src/plugins/manageSource/taxonomy.ts` and is version-controlled.
+
+## Daily aggregation pipeline
+
+Piggyback on the existing `server/task-manager/` daily schedule (same rhythm as `server/journal/`):
+
+```
+08:00 local time (configurable)
+  ↓
+maybeAggregateSources({ activeSessionIds })  ← fire-and-forget from task-manager
+  ↓
+[Phase 1] fetch
+  ↓ for each source with schedule=daily and not on backoff:
+  ↓   - route by fetcher.kind
+  ↓   - server-side fetchers: run directly (respect robots / rate limit / state)
+  ↓   - Claude-side fetchers: enqueue a single agent pass that collects all of them in one session
+  ↓
+[Phase 2] normalize
+  ↓ every source produces a list of `SourceItem { id, title, url, publishedAt, summary?, content?, categories }`
+  ↓ write raw items to `workspace/news/archive/<slug>/YYYY-MM.md` (append-only)
+  ↓
+[Phase 3] summarize
+  ↓ pass all new items to Claude (one call) with a prompt:
+  ↓   "Produce a daily brief. Group by category. Max 10 items per group.
+  ↓    For each item: 1-line summary, link, source."
+  ↓
+[Phase 4] write
+  ↓ `workspace/news/daily/YYYY/MM/DD.md`
+  ↓ dashboard widget (#143) picks this up
+  ↓ if any item tagged `severity: critical` (e.g. from security advisory), enqueue a notification (#142 / #144)
+```
+
+The pipeline is invoked by a single public entry `maybeAggregateSources(deps)` that mirrors `maybeRunJournal` / `maybeIndexSession`. Same gates apply: active-session guard, in-process lock, `ClaudeCliNotFoundError` → disable-for-lifetime.
+
+## On-demand research
+
+Triggered when the user says "調べて" during a conversation. Claude decides to call `searchSources({ query, categoryFilter? })` which:
+
+1. Enumerates all registered sources whose categories match the filter.
+2. For `fetcher.kind: web-search` sources → Claude uses its `web_search` tool directly.
+3. For RSS / GitHub sources → server fetches recent items filtered by query text.
+4. Returns aggregated hits. Claude synthesizes the answer and optionally writes it to `wiki/pages/<topic>.md`.
+
+This is the **on-demand** path to UC-3 / UC-4 / UC-5 from #166. Implementation lands after the daily pipeline is stable.
+
+## Plugin interface — `manageSource`
+
+New plugin at `src/plugins/manageSource/`. Actions:
+
+| Action | Params | Effect |
+|---|---|---|
+| `register` | `url`, optional `fetcher.kind` override, optional `categories` override | Detect source type, run robots preflight, auto-categorize, write the source file |
+| `list` | optional `category` filter | Return all registered sources |
+| `remove` | `slug` | Delete the source file and its state |
+| `recategorize` | `slug` | Re-run the auto-categorizer |
+| `fetch` | `slug` | One-shot on-demand fetch outside the schedule |
+| `test` | `url` | Dry-run: robots check + fetcher selection + sample fetch, NO write |
+
+The `test` action is the debugging surface: when a user asks "can I register this site?" Claude can run `test` first without polluting the workspace.
+
+## File layout (new code)
+
+```
+server/sources/
+  index.ts              ← maybeAggregateSources entry, lock + sentinel
+  registry.ts           ← read / write per-source files + state
+  taxonomy.ts           ← fixed category enum (shared with src/)
+  robots.ts             ← robots.txt fetch + cache + rule evaluation
+  pipeline.ts           ← fetch → normalize → summarize → write
+  classifier.ts         ← auto-categorize via Claude CLI (reuses chat-index/summarizer patterns)
+  types.ts              ← Source / SourceItem / SourceState types
+  fetchers/
+    index.ts            ← registry of SourceFetcher by kind
+    rss.ts              ← RSS / Atom fetcher
+    githubReleases.ts   ← GitHub /releases endpoint
+    githubIssues.ts     ← /issues and /pulls
+    arxiv.ts            ← arXiv API
+    webFetch.ts         ← server-side HTML fetch with robots + rate limit
+    claudeFetch.ts      ← delegates to an agent session (web_fetch / web_search)
+server/routes/sources.ts ← POST /api/sources/* endpoints
+
+src/plugins/manageSource/
+  definition.ts
+  index.ts
+  View.vue
+  Preview.vue
+
+test/sources/
+  test_robots.ts        ← parse + match User-agent: * rules, cache eviction
+  test_rss.ts           ← RSS/Atom parsing
+  test_classifier.ts    ← pure helpers, taxonomy pinning
+  test_pipeline.ts      ← end-to-end with stubbed fetchers
+  test_registry.ts      ← write / read / round-trip source files
+```
+
+Reuses the following existing primitives: `task-manager` scheduler, `chat-index/summarizer.ts` for the Claude CLI spawn pattern, `journal/index.ts` for the lock+sentinel+disable-for-lifetime pattern. Nothing new at the framework level.
+
+## Extensibility for future auth (phase 3)
+
+Designed in but not used in phase 1:
+
+1. **`fetcher` is a tagged union.** Adding `{ kind: "github-authed", envVar: "GITHUB_TOKEN" }` or `{ kind: "x-api", envVar: "X_BEARER_TOKEN" }` just means a new file under `server/sources/fetchers/` implementing the same `SourceFetcher` interface.
+2. **Source files already have space for auth hints.** Phase 1 ignores them; phase 3 reads them.
+
+   ```yaml
+   fetcher:
+     kind: github-authed
+     envVar: GITHUB_TOKEN
+     scopes: [repo:read]   # informational only
+   ```
+
+3. **Per-source rate-limit state is already keyed by fetcher kind**, not just host — so per-user-token rate limits in phase 3 fit cleanly.
+
+4. **Secrets policy**: credentials live in `.env` (already protected by the sensitive-file denylist from #148). Never in source files, never in `sources/_state/`.
+
+## Phase breakdown
+
+| Phase | Scope | Gate |
+|---|---|---|
+| **1 (this spec)** | RSS / GitHub public / arXiv + web_fetch / web_search via Claude + daily pipeline + `manageSource` plugin + auto-categorize + robots etiquette | Ship this PR, iterate in subsequent PRs per fetcher type |
+| **2** | On-demand `searchSources` + wiki-page generation for research results + notification hookup | Phase 1 stable in daily use |
+| **3** | Auth-bearing fetchers (X / private GitHub / paid APIs) + secrets rotation + per-source rate-limit tuning | Real demand for a specific authed source |
+
+## Open questions (to resolve before implementation PR)
+
+1. **Taxonomy size**. Starting list above has 16 categories. Too many dilutes filtering; too few forces everything into `general`. Pilot with 16 and re-evaluate after 2 weeks of daily use?
+2. **Daily summary template**. Markdown only, or include a compact structured index (JSON block) so the dashboard can render without re-parsing markdown? Lean toward: both — markdown for humans, fenced JSON block at the end for the dashboard.
+3. **Item dedup across sources**. Two RSS feeds often carry the same HN story. Phase-1 answer: hash the normalized URL (strip utm params), skip dedup across sources but dedup within a single source. Phase-2: cross-source URL dedup.
+4. **Archive size**. Per-source monthly archives grow unbounded. Phase-1: no pruning. Phase-3-ish: add a `journal-archivist`-style compaction pass.
+5. **Error visibility**. When a source fails for 3 days in a row, how does the user learn? Ideas: (a) surface in daily summary footer ("3 sources failed today"), (b) push notification at 5-day mark, (c) badge on the manageSource UI. Pick one.
+6. **Timezone for "daily"**. Local time like the journal, or UTC? Journal uses local — match it.
+7. **Order of fetcher execution**. Parallel across hosts but serial per-host? Or fully serial with a 1s delay? Parallel-across-hosts is faster but needs a per-host queue. Start serial for simplicity; add parallelism if daily run exceeds 5 minutes.
+8. **Failure isolation**. A single source failing must not abort the pipeline. Model: per-source try/catch that logs + advances state + continues.
+9. **Claude-side fetcher invocation pattern**. One agent session per cron run that hits all web-search sources? Or per-source sessions? Per-run is cheaper (shared context, one summary pass) — start there.
+
+## Test plan (for the phase 1 PR, not this spec)
+
+- Unit: RSS/Atom parser (fixture files), robots parser (happy / allow / disallow / crawl-delay / wildcard), taxonomy classifier (mocked Claude response), URL normalizer (utm stripping, trailing slash).
+- Integration: pipeline end-to-end with stubbed fetchers and stubbed summarize — writes expected daily markdown.
+- Regression fixture: one real-world RSS feed (frozen snapshot) to catch parser regressions.
+- No network tests in CI (stub everything).
+
+## Related issues
+
+- **#166** — the 10-use-case issue this spec addresses
+- **#140** — news-batch (superseded; close in favour of this)
+- **#143** — dashboard (consumer of daily output)
+- **#142** — external notifications (consumer of critical items)
+- **#144** — in-app notifications (consumer of critical items)
+- **#148** — security hardening (dependency: sensitive-file denylist protects the `.env` our credential storage will use in phase 3)

--- a/server/sources/fetchers/index.ts
+++ b/server/sources/fetchers/index.ts
@@ -1,0 +1,69 @@
+// Fetcher dispatcher.
+//
+// Each source in the registry has a `fetcherKind` that maps to a
+// module under `server/sources/fetchers/<kind>.ts` implementing
+// the `SourceFetcher` interface. The pipeline looks up the right
+// fetcher via `getFetcher(kind)`, then calls `fetcher.fetch(...)`.
+//
+// Adding a new fetcher kind in phase 2 / 3 / later:
+//   1. Create `server/sources/fetchers/<new-kind>.ts` exporting
+//      a `SourceFetcher`.
+//   2. Add the string to `FETCHER_KINDS` in `../types.ts`.
+//   3. Register it in the `FETCHERS` table below.
+// No other framework change is required.
+
+import type { HttpFetcherDeps } from "../httpFetcher.js";
+import type { FetcherKind, Source, SourceItem, SourceState } from "../types.js";
+
+// Per-run dependencies threaded into every fetcher so all I/O
+// goes through injectable hooks (tests never touch the network).
+export interface FetcherDeps {
+  // Wiring for `fetchPolite` — robots provider, rate limiter,
+  // fetch impl, timeout. Shared across fetchers in one pipeline
+  // run so their per-host rate limits serialize together.
+  http: HttpFetcherDeps;
+  // Monotonic wall-clock. Fetchers timestamp new items and update
+  // the cursor with it.
+  now: () => number;
+  // Pipeline-wide abort (e.g. server shutdown). Separate from
+  // the per-fetch timeout that lives inside `http`.
+  signal?: AbortSignal;
+}
+
+export interface FetchResult {
+  // Newly-discovered items (already filtered against the cursor).
+  // Empty array is a valid outcome — "no new items since last run".
+  items: SourceItem[];
+  // Replacement cursor for SourceState. Fetchers return only the
+  // keys they own; the caller merges this into the existing state.
+  cursor: Record<string, string>;
+}
+
+export interface SourceFetcher {
+  readonly kind: FetcherKind;
+  fetch(
+    source: Source,
+    state: SourceState,
+    deps: FetcherDeps,
+  ): Promise<FetchResult>;
+}
+
+// Registry of all known fetchers. Populated lazily via
+// `registerFetcher` so each fetcher module is responsible for
+// adding itself at import time — keeps the dispatcher free of
+// hard dependencies on modules that may pull heavy deps
+// (fast-xml-parser etc).
+const FETCHERS = new Map<FetcherKind, SourceFetcher>();
+
+export function registerFetcher(fetcher: SourceFetcher): void {
+  FETCHERS.set(fetcher.kind, fetcher);
+}
+
+export function getFetcher(kind: FetcherKind): SourceFetcher | null {
+  return FETCHERS.get(kind) ?? null;
+}
+
+// Test-only: clear the registry between cases.
+export function __resetFetchersForTests(): void {
+  FETCHERS.clear();
+}

--- a/server/sources/fetchers/rss.ts
+++ b/server/sources/fetchers/rss.ts
@@ -1,0 +1,176 @@
+// RSS / Atom source fetcher.
+//
+// Flow:
+//   1. fetchPolite(source.url) — respects robots, User-Agent,
+//      rate limit, timeout
+//   2. parseFeed(bodyText) — pure XML → ParsedFeed
+//   3. normalizeToSourceItems(...) — ParsedFeedItem[] → SourceItem[]
+//      with cursor filtering so we only emit items newer than the
+//      last-seen pubDate
+//   4. updateCursor(...) — advance the cursor to the most-recent
+//      publishedAt across ALL items in this response (not just
+//      the emitted ones) so a quiet feed doesn't keep replaying
+//      old items after a one-shot republish
+//
+// The parser / normalizer / cursor logic are pure functions
+// exported for direct unit tests. The `rssFetcher` object is the
+// Promise-aware orchestrator that stitches them together.
+
+import { fetchPolite } from "../httpFetcher.js";
+import { normalizeUrl, stableItemId } from "../urls.js";
+import type { Source, SourceItem, SourceState } from "../types.js";
+import type { FetcherDeps, FetchResult, SourceFetcher } from "./index.js";
+import { registerFetcher } from "./index.js";
+import {
+  parseFeed,
+  type ParsedFeed,
+  type ParsedFeedItem,
+} from "./rssParser.js";
+
+// Cursor key we store in SourceState.cursor for RSS feeds.
+// ISO timestamp of the most-recent item's publishedAt we've seen.
+// Items whose publishedAt is <= this value are skipped on the
+// next run. Separate key name from other fetchers so adding
+// GitHub / arXiv cursors next to RSS ones on the same source
+// never conflicts.
+export const RSS_CURSOR_KEY = "rss_last_seen_at";
+
+export class RssFetcherError extends Error {
+  readonly url: string;
+  readonly status: number | null;
+  constructor(url: string, status: number | null, message: string) {
+    super(message);
+    this.name = "RssFetcherError";
+    this.url = url;
+    this.status = status;
+  }
+}
+
+// Filter raw parsed items against the cursor and normalize into
+// the pipeline's `SourceItem` shape. Pure — exported so tests
+// can exercise cursor semantics with fabricated ParsedFeed
+// structures without spinning up HTTP.
+export function normalizeToSourceItems(
+  feed: ParsedFeed,
+  source: Source,
+  cursor: Record<string, string>,
+  maxItems: number,
+): SourceItem[] {
+  const lastSeen = cursor[RSS_CURSOR_KEY] ?? null;
+  const lastSeenTs = lastSeen ? Date.parse(lastSeen) : null;
+  const items: SourceItem[] = [];
+
+  for (const entry of feed.items) {
+    if (items.length >= maxItems) break;
+    const item = entryToSourceItem(entry, source, lastSeenTs);
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+function entryToSourceItem(
+  entry: ParsedFeedItem,
+  source: Source,
+  lastSeenTs: number | null,
+): SourceItem | null {
+  if (!entry.link) return null;
+  const normalizedUrl = normalizeUrl(entry.link);
+  if (!normalizedUrl) return null;
+  // Cursor comparison: drop items at or older than the last-seen
+  // timestamp. Null publishedAt → keep (rare but happens with
+  // misformatted feeds; we'd rather emit a dup once than lose
+  // an item forever).
+  if (entry.publishedAt && lastSeenTs !== null) {
+    const itemTs = Date.parse(entry.publishedAt);
+    if (Number.isFinite(itemTs) && itemTs <= lastSeenTs) return null;
+  }
+  // Use the feed's own id as a hint, but always derive the
+  // SourceItem.id from the normalized URL so cross-source dedup
+  // (see #188 Q3) lines up regardless of feed conventions.
+  const id = stableItemId(normalizedUrl);
+  const publishedAt =
+    entry.publishedAt ??
+    // Synthesize a fetch-time timestamp when the feed didn't
+    // provide one, so downstream sorting has a monotonic key.
+    new Date().toISOString();
+
+  // Build the SourceItem with conditional spreads so we don't
+  // carry `undefined` fields that break exactOptionalPropertyTypes
+  // on the server tsconfig.
+  return {
+    id,
+    title: entry.title,
+    url: normalizedUrl,
+    publishedAt,
+    ...(entry.summary !== null && { summary: entry.summary }),
+    ...(entry.content !== null && { content: entry.content }),
+    categories: source.categories,
+    sourceSlug: source.slug,
+  };
+}
+
+// After filtering, advance the cursor to the newest publishedAt
+// in the full ParsedFeed (not just the emitted items). Doing
+// this on the full set prevents a feed that republishes older
+// items without updating pubDate from causing us to re-emit
+// them forever.
+//
+// Exported pure so tests can pin the advancement policy down.
+export function updateCursor(
+  current: Record<string, string>,
+  feed: ParsedFeed,
+): Record<string, string> {
+  let newest: number | null = null;
+  for (const entry of feed.items) {
+    if (!entry.publishedAt) continue;
+    const ts = Date.parse(entry.publishedAt);
+    if (!Number.isFinite(ts)) continue;
+    if (newest === null || ts > newest) newest = ts;
+  }
+  if (newest === null) return current;
+  // Only advance forwards. A feed whose newest item is older
+  // than our cursor should leave the cursor where it was so
+  // we don't retroactively re-emit everything on the next run.
+  const currentTs = current[RSS_CURSOR_KEY]
+    ? Date.parse(current[RSS_CURSOR_KEY])
+    : -Infinity;
+  if (newest <= currentTs) return current;
+  return { ...current, [RSS_CURSOR_KEY]: new Date(newest).toISOString() };
+}
+
+export const rssFetcher: SourceFetcher = {
+  kind: "rss",
+  async fetch(
+    source: Source,
+    state: SourceState,
+    deps: FetcherDeps,
+  ): Promise<FetchResult> {
+    const res = await fetchPolite(source.url, deps.http);
+    if (!res.ok) {
+      throw new RssFetcherError(
+        source.url,
+        res.status,
+        `RSS fetch ${source.url} failed with HTTP ${res.status}`,
+      );
+    }
+    const body = await res.text();
+    const feed = parseFeed(body);
+    if (!feed) {
+      throw new RssFetcherError(
+        source.url,
+        res.status,
+        `RSS body at ${source.url} did not parse as RSS / Atom / RDF`,
+      );
+    }
+    const items = normalizeToSourceItems(
+      feed,
+      source,
+      state.cursor,
+      source.maxItemsPerFetch,
+    );
+    const cursor = updateCursor(state.cursor, feed);
+    return { items, cursor };
+  },
+};
+
+registerFetcher(rssFetcher);

--- a/server/sources/fetchers/rssParser.ts
+++ b/server/sources/fetchers/rssParser.ts
@@ -1,0 +1,294 @@
+// Pure RSS 2.0 + Atom 1.0 parser.
+//
+// Uses `fast-xml-parser` for the XML-decoding plumbing (CDATA,
+// entity decoding, namespaces) and layers a feed-specific
+// normalization on top. The output shape is format-agnostic:
+// both RSS and Atom resolve into the same `ParsedFeedItem[]`.
+//
+// Pure — no I/O. Unit-testable with fixture strings.
+
+import { XMLParser } from "fast-xml-parser";
+
+export interface ParsedFeedItem {
+  // Best-effort stable identity from the feed itself. For RSS
+  // this is <guid>; for Atom it's <id>. Falls back to <link>
+  // when neither is present. The caller normalizes via
+  // `stableItemId(normalizedUrl)` when dedup across sources is
+  // needed, so this id is informational only.
+  feedId: string | null;
+  title: string;
+  link: string | null;
+  // RFC-822-ish date string from RSS <pubDate>, or RFC-3339
+  // from Atom <updated>/<published>. Pre-normalized to a
+  // JavaScript-parseable ISO string when possible; otherwise
+  // passed through verbatim for the consumer to handle.
+  publishedAt: string | null;
+  // Short description. RSS <description> or Atom
+  // <summary>/<content>. May contain HTML — the pipeline's
+  // summarizer step will flatten it.
+  summary: string | null;
+  // Full HTML/text body when the feed provides one separately
+  // from summary. Otherwise null.
+  content: string | null;
+}
+
+export interface ParsedFeed {
+  // "rss" or "atom" — callers rarely care but logging benefits
+  // from knowing which branch parsed.
+  kind: "rss" | "atom";
+  title: string | null;
+  items: ParsedFeedItem[];
+}
+
+// Configure the XML parser once at module load.
+// - preserveOrder=false: we access elements by name, not by order
+// - ignoreAttributes=false: Atom's <link href=...> matters
+// - cdataPropName="#cdata": CDATA content lands in a predictable
+//   key; we coalesce it with plain text content below
+// - parseTagValue/parseAttributeValue=false: keep everything as
+//   strings so weird "dates" like "2026/13/45" don't silently
+//   become NaN
+const xml = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  cdataPropName: "#cdata",
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+  // Some feeds emit arrays of <item>/<entry> and some emit a
+  // single one. alwaysCreateTextNode=false + isArray callbacks
+  // below normalize both shapes to arrays.
+  isArray: (name) => name === "item" || name === "entry" || name === "link",
+});
+
+// Parse an RSS or Atom feed body. Returns null when the input
+// doesn't look like a feed we understand (wrong root element,
+// unparseable XML). The pipeline treats null the same way it
+// treats "zero new items" — logged + skipped.
+export function parseFeed(body: string): ParsedFeed | null {
+  const text = stripBom(body);
+  if (!text.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = xml.parse(text);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+
+  if (isRecord(parsed.rss)) return parseRss(parsed.rss);
+  if (isRecord(parsed.feed)) return parseAtom(parsed.feed);
+  // RDF 1.0 (RSS 1.0) uses <rdf:RDF> as the root. fast-xml-parser
+  // keeps the namespace prefix on the key by default, so check
+  // both the prefixed form and the unprefixed fallback.
+  const rdf = parsed["rdf:RDF"] ?? parsed.RDF;
+  if (isRecord(rdf)) return parseRss10(rdf);
+  return null;
+}
+
+// --- RSS 2.0 ------------------------------------------------------------
+
+function parseRss(rss: Record<string, unknown>): ParsedFeed | null {
+  const channel = rss.channel;
+  if (!isRecord(channel)) return null;
+  const rawItems = Array.isArray(channel.item) ? channel.item : [];
+  const items: ParsedFeedItem[] = [];
+  for (const raw of rawItems) {
+    if (!isRecord(raw)) continue;
+    const parsed = parseRssItem(raw);
+    if (parsed) items.push(parsed);
+  }
+  return {
+    kind: "rss",
+    title: readString(channel.title),
+    items,
+  };
+}
+
+function parseRssItem(raw: Record<string, unknown>): ParsedFeedItem | null {
+  const title = readString(raw.title);
+  // <guid> can be a plain string or `{ "#text": "...",
+  // "@_isPermaLink": "false" }` depending on attributes.
+  const guid = readString(raw.guid);
+  const link = readString(raw.link);
+  // <pubDate> is RFC 822. Convert to ISO for easier downstream
+  // comparisons; fall back to the raw value if the conversion
+  // fails (a malformed date is better than no date).
+  const publishedAt = normalizeDate(readString(raw.pubDate));
+  // <description> is the short summary. Some feeds also emit
+  // <content:encoded> for the full HTML body. fast-xml-parser
+  // keeps the namespace prefix on the key by default, so we
+  // read both `content:encoded` (prefixed, the common case)
+  // and a bare `encoded` key as a fallback for parsers that
+  // stripped the namespace.
+  const summary = readString(raw.description);
+  const content = readString(raw["content:encoded"]) ?? readString(raw.encoded);
+  if (!title) return null;
+  return {
+    feedId: guid ?? link ?? null,
+    title,
+    link,
+    publishedAt,
+    summary,
+    content,
+  };
+}
+
+// --- RSS 1.0 (RDF) ------------------------------------------------------
+
+function parseRss10(rdf: Record<string, unknown>): ParsedFeed | null {
+  // RDF feeds put <item> directly under <rdf:RDF>, not under a
+  // <channel>. Items are the same shape as RSS 2.0 otherwise.
+  const rawItems = Array.isArray(rdf.item) ? rdf.item : [];
+  const items: ParsedFeedItem[] = [];
+  for (const raw of rawItems) {
+    if (!isRecord(raw)) continue;
+    const parsed = parseRssItem(raw);
+    if (parsed) items.push(parsed);
+  }
+  const channel = isRecord(rdf.channel) ? rdf.channel : null;
+  return {
+    kind: "rss",
+    title: channel ? readString(channel.title) : null,
+    items,
+  };
+}
+
+// --- Atom 1.0 -----------------------------------------------------------
+
+function parseAtom(feed: Record<string, unknown>): ParsedFeed | null {
+  const rawEntries = Array.isArray(feed.entry) ? feed.entry : [];
+  const items: ParsedFeedItem[] = [];
+  for (const raw of rawEntries) {
+    if (!isRecord(raw)) continue;
+    const parsed = parseAtomEntry(raw);
+    if (parsed) items.push(parsed);
+  }
+  return {
+    kind: "atom",
+    title: readString(feed.title),
+    items,
+  };
+}
+
+function parseAtomEntry(raw: Record<string, unknown>): ParsedFeedItem | null {
+  const title = readString(raw.title);
+  const id = readString(raw.id);
+  const link = resolveAtomLink(raw.link);
+  const published =
+    readString(raw.published) ?? readString(raw.updated) ?? null;
+  const publishedAt = published ? normalizeDate(published) : null;
+  const summary = readString(raw.summary);
+  const content = readString(raw.content);
+  if (!title) return null;
+  return {
+    feedId: id ?? link ?? null,
+    title,
+    link,
+    publishedAt,
+    summary,
+    content,
+  };
+}
+
+// Atom <link> has three shapes in the wild:
+//   1. `<link>https://x.com/</link>` — plain string body (rare but
+//      real, e.g. hand-written atom feeds)
+//   2. `<link href="..." rel="alternate"/>` — attribute-bearing
+//      element, which is the spec-canonical form
+//   3. Multiple `<link>` elements with different `rel` values, a
+//      mix of the above
+//
+// Because we set `isArray: name === "link"` on the parser, every
+// link form arrives wrapped in an array. Within the array we may
+// see plain strings (form 1) and objects with `@_href` (forms 2/3).
+//
+// Preference: rel="alternate" wins (canonical web URL). Otherwise
+// we fall back to the first candidate that has a usable href /
+// string value.
+function resolveAtomLink(raw: unknown): string | null {
+  if (typeof raw === "string") return raw;
+  const candidates = Array.isArray(raw) ? raw : [raw];
+  let fallback: string | null = null;
+  for (const candidate of candidates) {
+    const outcome = classifyAtomLinkCandidate(candidate);
+    if (outcome.kind === "alternate") return outcome.href;
+    if (outcome.kind === "fallback") fallback ??= outcome.href;
+  }
+  return fallback;
+}
+
+type AtomLinkOutcome =
+  | { kind: "alternate"; href: string }
+  | { kind: "fallback"; href: string }
+  | { kind: "skip" };
+
+// Inspect one candidate from Atom's `<link>` list (which may be a
+// plain string or an object carrying `@_href` / `@_rel` attrs)
+// and report whether it's a rel="alternate" winner, a usable
+// fallback, or nothing we can use.
+function classifyAtomLinkCandidate(candidate: unknown): AtomLinkOutcome {
+  if (typeof candidate === "string" && candidate.length > 0) {
+    // Form 1: bare `<link>url</link>`. Unattributed → fallback.
+    return { kind: "fallback", href: candidate };
+  }
+  if (!isRecord(candidate)) return { kind: "skip" };
+  const href = readString(candidate["@_href"]);
+  if (!href) return { kind: "skip" };
+  const rel = readString(candidate["@_rel"]);
+  if (rel === "alternate" || rel === null) {
+    return { kind: "alternate", href };
+  }
+  return { kind: "fallback", href };
+}
+
+// --- helpers ------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Extract a string from a value that might be:
+//   - a plain string
+//   - an object with `#text` (tag with attributes + body text)
+//   - an object with `#cdata` (CDATA-wrapped body)
+//   - an array (pick the first non-empty)
+// Returns null when nothing plausibly-textual is found.
+function readString(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.length > 0 ? value : null;
+  }
+  if (isRecord(value)) return readStringFromRecord(value);
+  if (Array.isArray(value)) return readStringFromArray(value);
+  return null;
+}
+
+function readStringFromRecord(record: Record<string, unknown>): string | null {
+  const text = record["#text"];
+  if (typeof text === "string" && text.length > 0) return text;
+  const cdata = record["#cdata"];
+  if (typeof cdata === "string" && cdata.length > 0) return cdata;
+  return null;
+}
+
+function readStringFromArray(array: readonly unknown[]): string | null {
+  for (const entry of array) {
+    const resolved = readString(entry);
+    if (resolved !== null) return resolved;
+  }
+  return null;
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+// Convert a date string into ISO 8601 if possible; otherwise
+// return the original. We never throw — a weird but non-empty
+// date is more useful to the pipeline than a null.
+function normalizeDate(raw: string | null): string | null {
+  if (!raw) return null;
+  const ts = Date.parse(raw);
+  if (Number.isFinite(ts)) return new Date(ts).toISOString();
+  return raw;
+}

--- a/server/sources/httpFetcher.ts
+++ b/server/sources/httpFetcher.ts
@@ -1,0 +1,195 @@
+// Etiquette-respecting HTTP fetcher for server-side source
+// fetchers (RSS, GitHub API, arXiv, etc.).
+//
+// Wraps `fetch` with four things phase-1 fetchers would otherwise
+// all have to reimplement:
+//
+//   1. User-Agent: `MulmoClaude-SourceBot/1.0 (+<repo url>)` on every
+//      request, so site operators can identify and contact.
+//   2. robots.txt check: before fetching `<scheme>://<host>/<path>`,
+//      read the cached robots.txt for `<host>` and consult
+//      `isAllowedByRobots`. Disallowed paths 400-reject at the
+//      library boundary — fetcher sees `RobotsDisallowedError` and
+//      can log / skip.
+//   3. Per-host rate limit: HostRateLimiter serializes same-host
+//      requests with a `Crawl-delay`-aware minimum gap.
+//   4. Timeout: each request gets a finite AbortController so a
+//      hung server can't wedge the daily pipeline.
+//
+// The robots.txt cache itself is NOT owned by this module — it's
+// a pluggable `RobotsProvider` so tests can stub it and the real
+// cache (filesystem-backed, 24h TTL) lives elsewhere.
+//
+// Every moving part has an injectable dep so tests can drive the
+// whole flow without network or disk.
+
+import {
+  DEFAULT_MIN_DELAY_MS,
+  HostRateLimiter,
+  defaultRateLimiterDeps,
+  type RateLimiterDeps,
+} from "./rateLimiter.js";
+import { isAllowedByRobots, parseRobots } from "./robots.js";
+
+// The User-Agent value sent on every fetch. Identifies us clearly
+// enough for a site operator to find the project and contact us.
+// Update the URL if the repo ever moves.
+export const USER_AGENT =
+  "MulmoClaude-SourceBot/1.0 (+https://github.com/receptron/mulmoclaude)";
+
+// Per-request wall-clock cap. Fetchers can still cancel earlier
+// via a passed-in AbortSignal; this is the outer safety net so a
+// hung server never holds a rate-limit slot forever.
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+// Thrown when a URL would violate the target host's robots.txt
+// policy for our User-Agent. Caught by fetchers so a single
+// disallowed source doesn't look like a generic HTTP error.
+export class RobotsDisallowedError extends Error {
+  readonly url: string;
+  constructor(url: string) {
+    super(`[sources] robots.txt disallows ${url} for our User-Agent`);
+    this.name = "RobotsDisallowedError";
+    this.url = url;
+  }
+}
+
+// How the fetcher gets robots.txt for a given host. The real
+// implementation (phase-2-ish) will read from
+// `workspace/sources/_state/robots/<host>.txt` with a 24h TTL,
+// falling back to an HTTP GET. Tests inject an in-memory map.
+//
+// Returns null to signal "no robots.txt found" (or "404-equivalent")
+// which the evaluator treats as permissive — the usual convention.
+export type RobotsProvider = (host: string) => Promise<string | null>;
+
+export interface HttpFetcherDeps {
+  // HTTP client. Defaults to global `fetch`; tests inject a
+  // response-map function.
+  fetchImpl: typeof fetch;
+  // robots.txt source. See RobotsProvider.
+  robots: RobotsProvider;
+  // Shared rate limiter so fetchers going through the same
+  // HttpFetcher instance all serialize per-host together.
+  rateLimiter: HostRateLimiter;
+  // Rate-limiter clock / sleep — usually pass through from
+  // `rateLimiter`'s deps when constructing both.
+  rateLimiterDeps: RateLimiterDeps;
+  // Per-host crawl-delay override, looked up per request. Returns
+  // null when the fetcher should fall back to its
+  // `DEFAULT_MIN_DELAY_MS`. Normally implemented by caching the
+  // robots.txt `Crawl-delay` value per host.
+  crawlDelayMs: (host: string) => number | null;
+  // Extra abort signal the caller can provide to cancel a fetch
+  // early (e.g. pipeline shutdown). Combined with the internal
+  // timeout via any-of.
+  externalSignal?: AbortSignal;
+  // Request timeout. DEFAULT_FETCH_TIMEOUT_MS unless overridden.
+  timeoutMs: number;
+  // For tests: called exactly once with every resolved URL right
+  // before `fetchImpl` runs. Production passes a no-op.
+  onWillFetch: (url: string) => void;
+}
+
+export function defaultHttpFetcherDeps(
+  robots: RobotsProvider,
+  rateLimiter?: HostRateLimiter,
+  rateLimiterDeps: RateLimiterDeps = defaultRateLimiterDeps(),
+): HttpFetcherDeps {
+  return {
+    fetchImpl: globalThis.fetch.bind(globalThis),
+    robots,
+    rateLimiter: rateLimiter ?? new HostRateLimiter(rateLimiterDeps),
+    rateLimiterDeps,
+    crawlDelayMs: () => null,
+    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+    onWillFetch: () => {},
+  };
+}
+
+// Fetch a URL politely. Resolves with the Response object (caller
+// decides whether to `.text()` / `.json()`); rejects with
+// `RobotsDisallowedError` when robots says no, `DOMException`
+// (AbortError) when the external signal or the internal timeout
+// fires, or whatever `fetchImpl` throws otherwise.
+export async function fetchPolite(
+  rawUrl: string,
+  deps: HttpFetcherDeps,
+): Promise<Response> {
+  const url = new URL(rawUrl);
+  // Only http(s) reach the fetch — file://, data:, mailto: would
+  // never be legitimate source URLs and robots.txt doesn't cover
+  // them. Reject at the boundary.
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      `[sources] fetchPolite: refusing non-http(s) URL ${rawUrl}`,
+    );
+  }
+  const host = url.host.toLowerCase();
+
+  // 1. robots.txt check.
+  const robotsText = await deps.robots(host);
+  if (robotsText !== null) {
+    const parsed = parseRobots(robotsText);
+    const pathAndQuery = url.pathname + url.search;
+    if (!isAllowedByRobots(parsed, USER_AGENT, pathAndQuery)) {
+      throw new RobotsDisallowedError(rawUrl);
+    }
+  }
+
+  // 2. Per-host rate-limited HTTP call. The task body builds and
+  // executes the fetch; the limiter owns ordering + minimum gap.
+  const minDelay = deps.crawlDelayMs(host) ?? DEFAULT_MIN_DELAY_MS;
+  return deps.rateLimiter.run(
+    host,
+    () => fetchWithTimeout(rawUrl, deps),
+    minDelay,
+  );
+}
+
+async function fetchWithTimeout(
+  rawUrl: string,
+  deps: HttpFetcherDeps,
+): Promise<Response> {
+  // Combine the caller's signal with an internal timeout. Each
+  // fetch gets its own AbortController so a slow request doesn't
+  // affect the next caller.
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => {
+    controller.abort(
+      new DOMException(
+        `[sources] fetch timed out after ${deps.timeoutMs}ms`,
+        "TimeoutError",
+      ),
+    );
+  }, deps.timeoutMs);
+
+  const external = deps.externalSignal;
+  let externalUnsub: (() => void) | null = null;
+  if (external) {
+    if (external.aborted) {
+      clearTimeout(timeoutHandle);
+      throw (
+        (external as AbortSignal & { reason?: unknown }).reason ??
+        new DOMException("Aborted", "AbortError")
+      );
+    }
+    const onAbort = () => {
+      controller.abort((external as AbortSignal & { reason?: unknown }).reason);
+    };
+    external.addEventListener("abort", onAbort, { once: true });
+    externalUnsub = () => external.removeEventListener("abort", onAbort);
+  }
+
+  deps.onWillFetch(rawUrl);
+  try {
+    return await deps.fetchImpl(rawUrl, {
+      headers: { "User-Agent": USER_AGENT },
+      signal: controller.signal,
+      redirect: "follow",
+    });
+  } finally {
+    clearTimeout(timeoutHandle);
+    externalUnsub?.();
+  }
+}

--- a/server/sources/paths.ts
+++ b/server/sources/paths.ts
@@ -79,17 +79,27 @@ export function archiveDir(workspaceRoot: string, slug: string): string {
   return path.join(newsRoot(workspaceRoot), ARCHIVE_DIR, slug);
 }
 
+// Archive file path. Written as `<slug>/YYYY/MM.md` (year and
+// month as nested directories) so long-running workspaces don't
+// end up with 60+ files in a single source's archive dir —
+// browsing a given year is one `cd YYYY/` away. Matches the
+// daily-news layout (`daily/YYYY/MM/DD.md`).
+//
+// Input stays `YYYY-MM` so callers don't need to remember whether
+// to split; we do the split here.
 export function archivePath(
   workspaceRoot: string,
   slug: string,
   yearMonth: string,
 ): string {
-  if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+  const m = /^(\d{4})-(\d{2})$/.exec(yearMonth);
+  if (!m) {
     throw new Error(
       `[sources] archivePath: expected YYYY-MM, got "${yearMonth}"`,
     );
   }
-  return path.join(archiveDir(workspaceRoot, slug), `${yearMonth}.md`);
+  const [, year, month] = m;
+  return path.join(archiveDir(workspaceRoot, slug), year, `${month}.md`);
 }
 
 // Very conservative slug validator. The slug doubles as a filename

--- a/server/sources/paths.ts
+++ b/server/sources/paths.ts
@@ -1,0 +1,106 @@
+// Path helpers for the source registry's on-disk layout.
+//
+//   workspace/
+//     sources/
+//       <slug>.md                    ← source config
+//       _index.md                    ← auto-generated category index
+//       _state/
+//         <slug>.json                ← runtime state per source
+//         robots/<host>.txt          ← cached robots.txt
+//     news/
+//       daily/YYYY/MM/DD.md          ← daily aggregated summary
+//       archive/<slug>/YYYY-MM.md    ← per-source rolling archive
+//
+// Everything is derived from a single `workspaceRoot` argument so
+// tests can target a `mkdtempSync` directory.
+
+import path from "node:path";
+
+export const SOURCES_DIR = "sources";
+export const SOURCE_STATE_DIR = "_state";
+export const ROBOTS_CACHE_DIR = "robots";
+export const NEWS_DIR = "news";
+export const DAILY_DIR = "daily";
+export const ARCHIVE_DIR = "archive";
+
+export function sourcesRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, SOURCES_DIR);
+}
+
+export function sourceFilePath(workspaceRoot: string, slug: string): string {
+  return path.join(sourcesRoot(workspaceRoot), `${slug}.md`);
+}
+
+export function sourceStateDir(workspaceRoot: string): string {
+  return path.join(sourcesRoot(workspaceRoot), SOURCE_STATE_DIR);
+}
+
+export function sourceStatePath(workspaceRoot: string, slug: string): string {
+  return path.join(sourceStateDir(workspaceRoot), `${slug}.json`);
+}
+
+export function robotsCacheDir(workspaceRoot: string): string {
+  return path.join(sourceStateDir(workspaceRoot), ROBOTS_CACHE_DIR);
+}
+
+export function robotsCachePath(workspaceRoot: string, host: string): string {
+  // Hosts can contain `:` (for explicit ports) which breaks on some
+  // filesystems. Colons → underscore. Other characters are ASCII
+  // letters, digits, dots, and hyphens per DNS rules so they're
+  // safe as-is.
+  const safe = host.replace(/:/g, "_");
+  return path.join(robotsCacheDir(workspaceRoot), `${safe}.txt`);
+}
+
+export function newsRoot(workspaceRoot: string): string {
+  return path.join(workspaceRoot, NEWS_DIR);
+}
+
+export function dailyNewsPath(workspaceRoot: string, isoDate: string): string {
+  // Validate shape at the boundary so an empty / bogus date can't
+  // produce "undefined/undefined/undefined.md" downstream.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!m) {
+    throw new Error(
+      `[sources] dailyNewsPath: expected YYYY-MM-DD, got "${isoDate}"`,
+    );
+  }
+  const [, year, month, day] = m;
+  return path.join(
+    newsRoot(workspaceRoot),
+    DAILY_DIR,
+    year,
+    month,
+    `${day}.md`,
+  );
+}
+
+export function archiveDir(workspaceRoot: string, slug: string): string {
+  return path.join(newsRoot(workspaceRoot), ARCHIVE_DIR, slug);
+}
+
+export function archivePath(
+  workspaceRoot: string,
+  slug: string,
+  yearMonth: string,
+): string {
+  if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+    throw new Error(
+      `[sources] archivePath: expected YYYY-MM, got "${yearMonth}"`,
+    );
+  }
+  return path.join(archiveDir(workspaceRoot, slug), `${yearMonth}.md`);
+}
+
+// Very conservative slug validator. The slug doubles as a filename
+// and appears in URLs (via the manageSource plugin), so reject
+// anything that could surprise the filesystem or the URL parser.
+// Letters, digits, hyphens only. 1-64 chars. No leading / trailing
+// hyphen. No consecutive hyphens.
+export function isValidSlug(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  if (slug.length === 0 || slug.length > 64) return false;
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(slug)) return false;
+  if (slug.includes("--")) return false;
+  return true;
+}

--- a/server/sources/rateLimiter.ts
+++ b/server/sources/rateLimiter.ts
@@ -1,0 +1,138 @@
+// Per-host rate limiter for outbound HTTP fetches.
+//
+// Design decision from #188 Q7: fetchers run parallel across hosts
+// but serial per host. This module is the "serial per host" part.
+// Two concurrent requests to the same hostname wait in FIFO order;
+// different hostnames proceed independently.
+//
+// Mechanism:
+//
+// - Per-host chain: one `Promise<void>` per hostname. Each new
+//   request `await`s the previous promise, runs the work, then
+//   releases the next waiter.
+// - Minimum delay: optional per-host floor between the end of one
+//   request and the start of the next. Defaults to
+//   DEFAULT_MIN_DELAY_MS to keep us well-behaved on cooperative
+//   hosts; robots.txt `Crawl-delay` callers pass their host's
+//   value.
+// - Clock-injectable: the `now` + `sleep` deps make this testable
+//   without wall-clock waits.
+//
+// Pure in the sense that all state is captured in the limiter
+// instance — no module-level globals. Tests can spin up a fresh
+// limiter per case and fully observe the ordering.
+
+// Seconds of quiet between requests to the same host when the
+// caller doesn't specify an explicit `minDelayMs` for the host.
+// One second is polite-default for public feeds.
+export const DEFAULT_MIN_DELAY_MS = 1000;
+
+export interface RateLimiterDeps {
+  // Returns current wall-clock milliseconds. `Date.now` in prod,
+  // tests inject a controllable counter.
+  now: () => number;
+  // Sleep for `ms` milliseconds. `setTimeout` wrapper in prod,
+  // tests inject a faketimer-backed implementation.
+  sleep: (ms: number) => Promise<void>;
+}
+
+export function defaultRateLimiterDeps(): RateLimiterDeps {
+  return {
+    now: () => Date.now(),
+    sleep: (ms: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, ms)),
+  };
+}
+
+interface HostState {
+  // Tail of the per-host promise chain. New work waits for this,
+  // then replaces it with its own completion promise.
+  tail: Promise<void>;
+  // Wall-clock time the most-recent completed request returned,
+  // or `null` when no request has completed yet. Using `null`
+  // rather than 0 as the sentinel avoids ambiguity against fake
+  // test clocks that legitimately start at t=0.
+  lastFinishedAt: number | null;
+}
+
+export class HostRateLimiter {
+  private readonly hosts = new Map<string, HostState>();
+  private readonly deps: RateLimiterDeps;
+
+  constructor(deps: RateLimiterDeps = defaultRateLimiterDeps()) {
+    this.deps = deps;
+  }
+
+  // Run `task` under the host's rate-limit slot. Resolves with the
+  // task's return value, or rejects with the task's error (without
+  // poisoning the queue — the next waiter still gets to run).
+  //
+  // `minDelayMs` is the minimum ms between the END of the previous
+  // request to this host and the START of this one. Defaults to
+  // DEFAULT_MIN_DELAY_MS.
+  run<T>(
+    host: string,
+    task: () => Promise<T>,
+    minDelayMs: number = DEFAULT_MIN_DELAY_MS,
+  ): Promise<T> {
+    const key = host.toLowerCase();
+    const state: HostState = this.hosts.get(key) ?? {
+      tail: Promise.resolve(),
+      lastFinishedAt: null,
+    };
+    const prev = state.tail;
+
+    // Build the new tail: wait for prev, enforce delay, run task.
+    let resolveTail: () => void = () => {};
+    const newTail = new Promise<void>((resolve) => {
+      resolveTail = resolve;
+    });
+    state.tail = newTail;
+    this.hosts.set(key, state);
+
+    return (async () => {
+      try {
+        await prev;
+        const wait =
+          state.lastFinishedAt === null
+            ? 0
+            : minDelayMs - (this.deps.now() - state.lastFinishedAt);
+        if (wait > 0) await this.deps.sleep(wait);
+        try {
+          return await task();
+        } finally {
+          // Mark finished time even on error so a flapping host
+          // doesn't get spammed with retries. Read state from the
+          // map (rather than the closure-captured variable) in
+          // case a parallel call has since updated it.
+          const fresh = this.hosts.get(key);
+          if (fresh) fresh.lastFinishedAt = this.deps.now();
+        }
+      } finally {
+        resolveTail();
+      }
+    })();
+  }
+
+  // Test / debug: how many hosts currently have a chain. Returns
+  // 0 when the limiter is fresh.
+  hostCount(): number {
+    return this.hosts.size;
+  }
+
+  // Release internal state for hosts that have been idle longer
+  // than `idleMs`. Not strictly required for correctness (the
+  // map grows linearly with distinct hosts, which is bounded for
+  // any real workspace), but handy for long-lived processes.
+  evictIdle(idleMs: number): number {
+    const cutoff = this.deps.now() - idleMs;
+    let removed = 0;
+    for (const [key, state] of this.hosts) {
+      if (state.lastFinishedAt !== null && state.lastFinishedAt < cutoff) {
+        this.hosts.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+}

--- a/server/sources/registry.ts
+++ b/server/sources/registry.ts
@@ -1,0 +1,362 @@
+// Read / write source registry files under `workspace/sources/`.
+//
+// On-disk format — one markdown file per source:
+//
+//   ---
+//   slug: hn-front-page
+//   title: Hacker News front page
+//   url: https://news.ycombinator.com/rss
+//   fetcher_kind: rss
+//   schedule: daily
+//   categories: [tech-news, general, english]
+//   max_items_per_fetch: 30
+//   added_at: 2026-04-13T09:00:00Z
+//   <fetcher-specific params as flat key: value>
+//   ---
+//
+//   # Notes
+//
+//   Free-form markdown body. Claude reads it for context when
+//   summarizing.
+//
+// Parser policy:
+//
+// - Flat YAML only. Nested mappings are not supported by design —
+//   the frontmatter is hand-edited by humans and the LLM, both of
+//   which routinely get nesting wrong. Fetcher params are flat
+//   strings (e.g. `github_repo: foo/bar`) so the fetcher itself
+//   interprets them.
+// - Unknown frontmatter keys are preserved as opaque strings in
+//   `fetcherParams`, so future fetchers can add fields without
+//   round-trip data loss.
+// - Missing required fields → the loader returns `null` and logs
+//   a warning; the caller skips that source rather than crashing
+//   the pass.
+//
+// The writer preserves the body text verbatim so re-saving a file
+// doesn't rewrite the user's notes.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import {
+  isFetcherKind,
+  isSourceSchedule,
+  type Source,
+  type FetcherParams,
+  type FetcherKind,
+  type SourceSchedule,
+} from "./types.js";
+import { normalizeCategories } from "./taxonomy.js";
+import type { CategorySlug } from "./taxonomy.js";
+import { isValidSlug, sourceFilePath, sourcesRoot } from "./paths.js";
+
+// --- Frontmatter parsing ------------------------------------------------
+
+// Fields we recognize as first-class on every source. Anything else
+// in the frontmatter ends up in `fetcherParams` so a fetcher kind
+// that needs extra config can read it without us adding yet
+// another typed field for every new fetcher.
+const RESERVED_KEYS = new Set([
+  "slug",
+  "title",
+  "url",
+  "fetcher_kind",
+  "schedule",
+  "categories",
+  "max_items_per_fetch",
+  "added_at",
+]);
+
+const FRONTMATTER_OPEN = /^---\r?\n/;
+const FRONTMATTER_CLOSE = /\r?\n---\s*(\r?\n|$)/;
+
+interface ParsedFrontmatter {
+  fields: Map<string, string | string[]>;
+  body: string;
+}
+
+// Extract YAML frontmatter + body. Returns null when the file has
+// no frontmatter at all — that's an error condition for source
+// files (we always write frontmatter), not a degraded mode.
+export function parseSourceFile(raw: string): ParsedFrontmatter | null {
+  if (!FRONTMATTER_OPEN.test(raw)) return null;
+  const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
+  if (!closeMatch || closeMatch.index === undefined) return null;
+  const fmText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  return { fields: parseFields(fmText), body };
+}
+
+function parseFields(fmText: string): Map<string, string | string[]> {
+  const fields = new Map<string, string | string[]>();
+  for (const line of fmText.split(/\r?\n/)) {
+    const parsed = parseLine(line);
+    if (parsed) fields.set(parsed.key, parsed.value);
+  }
+  return fields;
+}
+
+function parseLine(
+  line: string,
+): { key: string; value: string | string[] } | null {
+  if (!line.trim() || line.trimStart().startsWith("#")) return null;
+  const colonIdx = line.indexOf(":");
+  if (colonIdx <= 0) return null;
+  const key = line.slice(0, colonIdx).trim();
+  const rawValue = line.slice(colonIdx + 1).trim();
+  if (!key) return null;
+  return { key, value: parseValue(rawValue) };
+}
+
+function parseValue(raw: string): string | string[] {
+  if (!raw) return "";
+  const arrayMatch = /^\[(.*)\]$/.exec(raw);
+  if (arrayMatch) {
+    return arrayMatch[1]
+      .split(",")
+      .map((s) => unquote(s.trim()))
+      .filter((s) => s.length > 0);
+  }
+  return unquote(raw);
+}
+
+function unquote(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// --- Source validation / construction -----------------------------------
+
+function stringField(
+  fields: Map<string, string | string[]>,
+  key: string,
+): string | null {
+  const v = fields.get(key);
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function numberField(
+  fields: Map<string, string | string[]>,
+  key: string,
+  defaultValue: number,
+): number {
+  const v = fields.get(key);
+  if (typeof v !== "string") return defaultValue;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : defaultValue;
+}
+
+// Default per-fetch cap. Fetchers treat it as a hint — if the
+// upstream API returns fewer items naturally the fetcher MAY
+// return fewer, but must NEVER return more than this.
+export const DEFAULT_MAX_ITEMS_PER_FETCH = 30;
+
+// Construct a Source from parsed frontmatter fields. Returns null
+// on required-field validation failure. The `body` arg is inlined
+// into the Source as `notes`.
+export function buildSource(
+  fields: Map<string, string | string[]>,
+  body: string,
+): Source | null {
+  const slug = stringField(fields, "slug");
+  if (!slug || !isValidSlug(slug)) return null;
+
+  const title = stringField(fields, "title");
+  if (!title) return null;
+
+  const url = stringField(fields, "url");
+  if (!url) return null;
+
+  const fetcherKindRaw = stringField(fields, "fetcher_kind");
+  if (!isFetcherKind(fetcherKindRaw)) return null;
+  const fetcherKind: FetcherKind = fetcherKindRaw;
+
+  const scheduleRaw = stringField(fields, "schedule");
+  if (!isSourceSchedule(scheduleRaw)) return null;
+  const schedule: SourceSchedule = scheduleRaw;
+
+  const categoriesRaw = fields.get("categories");
+  const categories: CategorySlug[] = normalizeCategories(categoriesRaw);
+
+  const maxItemsPerFetch = numberField(
+    fields,
+    "max_items_per_fetch",
+    DEFAULT_MAX_ITEMS_PER_FETCH,
+  );
+
+  const addedAt = stringField(fields, "added_at") ?? new Date(0).toISOString();
+
+  // Collect unrecognized fields into fetcherParams. Only flat
+  // string values — array values would indicate a schema mismatch
+  // since no fetcher param is a list today.
+  const fetcherParams: FetcherParams = {};
+  for (const [key, value] of fields.entries()) {
+    if (RESERVED_KEYS.has(key)) continue;
+    if (typeof value === "string") fetcherParams[key] = value;
+  }
+
+  return {
+    slug,
+    title,
+    url,
+    fetcherKind,
+    fetcherParams,
+    schedule,
+    categories,
+    maxItemsPerFetch,
+    addedAt,
+    notes: body,
+  };
+}
+
+// --- Serialization ------------------------------------------------------
+
+// Escape a scalar for use as a YAML value. Very conservative —
+// wraps in double-quotes whenever the value contains any character
+// that could be mis-parsed. Idempotent-safe: a round-trip through
+// parseValue → yamlScalar preserves the semantic string.
+function yamlScalar(value: string): string {
+  // Quote whenever the raw value contains characters that would
+  // confuse the flat-YAML parser or collide with a YAML reserved
+  // glyph. Numbers, dates, booleans, null all get quoted too so
+  // the reader always treats them as strings.
+  const needsQuote =
+    value === "" ||
+    /[:#[\]{},&*?|<>=!%@`]/.test(value) ||
+    /^\s|\s$/.test(value) ||
+    /^(true|false|null|~|yes|no|on|off)$/i.test(value) ||
+    /^[+-]?[\d.]/.test(value);
+  if (needsQuote) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+function yamlList(values: readonly string[]): string {
+  return `[${values.map(yamlScalar).join(", ")}]`;
+}
+
+// Serialize a Source back to the canonical markdown-with-
+// frontmatter shape. Reserved-key ordering is stable (nice for
+// diffs) and fetcher-specific params come after in alphabetical
+// order.
+export function serializeSource(source: Source): string {
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`slug: ${yamlScalar(source.slug)}`);
+  lines.push(`title: ${yamlScalar(source.title)}`);
+  lines.push(`url: ${yamlScalar(source.url)}`);
+  lines.push(`fetcher_kind: ${yamlScalar(source.fetcherKind)}`);
+  lines.push(`schedule: ${yamlScalar(source.schedule)}`);
+  lines.push(`categories: ${yamlList(source.categories)}`);
+  lines.push(`max_items_per_fetch: ${String(source.maxItemsPerFetch)}`);
+  lines.push(`added_at: ${yamlScalar(source.addedAt)}`);
+  const paramKeys = Object.keys(source.fetcherParams).sort();
+  for (const key of paramKeys) {
+    lines.push(`${key}: ${yamlScalar(source.fetcherParams[key])}`);
+  }
+  lines.push("---");
+  lines.push("");
+  // Preserve trailing newline semantics — if the notes were empty,
+  // emit exactly one newline after the closing fence; otherwise
+  // append the notes verbatim.
+  if (source.notes.length > 0) {
+    lines.push(
+      source.notes.endsWith("\n") ? source.notes : `${source.notes}\n`,
+    );
+  } else {
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// --- Filesystem I/O -----------------------------------------------------
+
+// Load one source by slug. Returns null if missing, malformed, or
+// fails required-field validation. Never throws — consumer code
+// just skips null entries.
+export async function readSource(
+  workspaceRoot: string,
+  slug: string,
+): Promise<Source | null> {
+  if (!isValidSlug(slug)) return null;
+  let raw: string;
+  try {
+    raw = await fsp.readFile(sourceFilePath(workspaceRoot, slug), "utf-8");
+  } catch {
+    return null;
+  }
+  const parsed = parseSourceFile(raw);
+  if (!parsed) return null;
+  const source = buildSource(parsed.fields, parsed.body);
+  // Sanity: filename slug must match frontmatter slug. A mismatch
+  // indicates the user renamed the file without editing the header
+  // (or vice-versa) — refuse the load rather than silently using
+  // the wrong slug.
+  if (source && source.slug !== slug) return null;
+  return source;
+}
+
+// List every source in the registry. Files that fail to parse are
+// logged and skipped; a single bad source file must not break the
+// daily pipeline for all the others.
+export async function listSources(workspaceRoot: string): Promise<Source[]> {
+  const dir = sourcesRoot(workspaceRoot);
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: Source[] = [];
+  for (const name of entries) {
+    // Skip meta files and the `_state/` subdirectory.
+    if (name.startsWith("_")) continue;
+    if (!name.endsWith(".md")) continue;
+    const slug = name.slice(0, -".md".length);
+    const source = await readSource(workspaceRoot, slug);
+    if (source) out.push(source);
+    else {
+      // eslint-disable-next-line no-console
+      console.warn(`[sources] failed to load source ${slug}, skipping`);
+    }
+  }
+  // Deterministic sort by slug so callers can rely on stable order.
+  out.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  return out;
+}
+
+// Atomic write: stage to a sibling `.tmp` file then rename. Crash
+// mid-write cannot leave a half-written source file behind.
+export async function writeSource(
+  workspaceRoot: string,
+  source: Source,
+): Promise<void> {
+  if (!isValidSlug(source.slug)) {
+    throw new Error(`[sources] invalid slug: ${source.slug}`);
+  }
+  const target = sourceFilePath(workspaceRoot, source.slug);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp`;
+  await fsp.writeFile(tmp, serializeSource(source), "utf-8");
+  await fsp.rename(tmp, target);
+}
+
+export async function deleteSource(
+  workspaceRoot: string,
+  slug: string,
+): Promise<boolean> {
+  if (!isValidSlug(slug)) return false;
+  try {
+    await fsp.unlink(sourceFilePath(workspaceRoot, slug));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/sources/robots.ts
+++ b/server/sources/robots.ts
@@ -1,0 +1,252 @@
+// robots.txt parser + rule evaluator.
+//
+// Phase-1 fetchers call `isAllowedByRobots(robotsText, userAgent, path)`
+// before GET-ing a URL on a host we haven't fetched from recently.
+// The robots text itself comes from a 24h cache populated elsewhere —
+// this module only deals with parsing and rule evaluation.
+//
+// Supported directives:
+//   User-agent: <name>   — group selector
+//   Disallow:   <path>   — path-prefix block (empty value == allow all)
+//   Allow:      <path>   — path-prefix exception
+//   Crawl-delay: <secs>  — minimum seconds between fetches for this UA
+//
+// Deliberately NOT supported:
+//   Sitemap:             — irrelevant for fetchers
+//   Request-rate:        — rarely used in the wild
+//   Visit-time:          — same
+//   Host:                — Yandex-only extension
+//
+// Matching semantics follow the de-facto Google robots.txt rules
+// (draft IETF "robotstxt-00"): longest-prefix wins between Allow
+// and Disallow; `*` in paths is treated as a wildcard; `$` at
+// end-of-path anchors to end-of-URL.
+//
+// Pure — no I/O, no network, fully testable.
+
+export interface RobotsGroup {
+  // Lowercased user-agent names this group applies to. May contain
+  // "*" meaning "any agent not matched by a more-specific group".
+  userAgents: string[];
+  rules: RobotsRule[];
+  crawlDelaySec: number | null;
+}
+
+export interface RobotsRule {
+  kind: "allow" | "disallow";
+  // Raw path pattern as it appeared in the file, minus the leading
+  // directive. Wildcards preserved.
+  pattern: string;
+}
+
+export interface ParsedRobots {
+  groups: RobotsGroup[];
+}
+
+// Parse a robots.txt body into structured groups. Completely
+// lenient: unknown directives are skipped, malformed lines are
+// skipped, empty input yields an empty group list (which means
+// "everything allowed" downstream).
+export function parseRobots(text: string): ParsedRobots {
+  // State machine driven by one helper per directive kind — keeps
+  // the main loop free of nested branching.
+  //
+  // `collectingAgents` is true while we're inside a run of
+  // consecutive User-agent lines before the first rule. Additional
+  // User-agent lines extend the same group; once a rule appears,
+  // the next User-agent starts a new group.
+  const state: ParseState = {
+    groups: [],
+    current: null,
+    collectingAgents: false,
+  };
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripComment(rawLine).trim();
+    if (!line) continue;
+    const parsed = parseDirective(line);
+    if (!parsed) continue;
+    applyDirective(state, parsed.name, parsed.value);
+  }
+  return { groups: state.groups };
+}
+
+interface ParseState {
+  groups: RobotsGroup[];
+  current: RobotsGroup | null;
+  collectingAgents: boolean;
+}
+
+function applyDirective(state: ParseState, name: string, value: string): void {
+  if (name === "user-agent") {
+    applyUserAgent(state, value);
+    return;
+  }
+  // Any non-user-agent directive ends the "collecting agents"
+  // window. If we see a rule before any User-agent (malformed),
+  // drop it — robots.txt without a User-agent scope is
+  // meaningless.
+  state.collectingAgents = false;
+  if (!state.current) return;
+  applyRule(state.current, name, value);
+}
+
+function applyUserAgent(state: ParseState, value: string): void {
+  if (!state.collectingAgents || state.current === null) {
+    state.current = { userAgents: [], rules: [], crawlDelaySec: null };
+    state.groups.push(state.current);
+    state.collectingAgents = true;
+  }
+  state.current.userAgents.push(value.toLowerCase());
+}
+
+function applyRule(group: RobotsGroup, name: string, value: string): void {
+  if (name === "disallow") {
+    group.rules.push({ kind: "disallow", pattern: value });
+  } else if (name === "allow") {
+    group.rules.push({ kind: "allow", pattern: value });
+  } else if (name === "crawl-delay") {
+    const n = Number(value);
+    if (Number.isFinite(n) && n >= 0) group.crawlDelaySec = n;
+  }
+  // Any other directive: ignored.
+}
+
+function stripComment(line: string): string {
+  const hashIdx = line.indexOf("#");
+  return hashIdx === -1 ? line : line.slice(0, hashIdx);
+}
+
+function parseDirective(line: string): { name: string; value: string } | null {
+  const colonIdx = line.indexOf(":");
+  if (colonIdx <= 0) return null;
+  const name = line.slice(0, colonIdx).trim().toLowerCase();
+  const value = line.slice(colonIdx + 1).trim();
+  return { name, value };
+}
+
+// Pick the group whose User-agent directive best matches `userAgent`.
+// Ordering of preference:
+//   1. Exact match on the UA string (case-insensitive).
+//   2. Longest prefix match (so `Googlebot-News` beats `Googlebot`).
+//   3. Fall back to the `*` group.
+//   4. No group at all → null (caller treats as "everything allowed").
+export function selectGroup(
+  robots: ParsedRobots,
+  userAgent: string,
+): RobotsGroup | null {
+  const ua = userAgent.toLowerCase();
+  // Three tiers: exact match short-circuits, longest prefix wins
+  // among non-star groups, `*` is the ultimate fallback. Inner
+  // logic factored into a per-group helper so this function stays
+  // under cognitive-complexity threshold.
+  let best: { group: RobotsGroup; score: number } | null = null;
+  let star: RobotsGroup | null = null;
+  for (const group of robots.groups) {
+    const outcome = scoreGroupAgainstAgent(group, ua);
+    if (outcome.kind === "exact") return outcome.group;
+    if (outcome.kind === "star") star = outcome.group;
+    else if (outcome.kind === "prefix") {
+      if (!best || outcome.score > best.score) {
+        best = { group: outcome.group, score: outcome.score };
+      }
+    }
+  }
+  return best?.group ?? star;
+}
+
+type AgentMatch =
+  | { kind: "exact"; group: RobotsGroup }
+  | { kind: "prefix"; group: RobotsGroup; score: number }
+  | { kind: "star"; group: RobotsGroup }
+  | { kind: "none" };
+
+function scoreGroupAgainstAgent(group: RobotsGroup, ua: string): AgentMatch {
+  let bestPrefix = -1;
+  let hasStar = false;
+  for (const listed of group.userAgents) {
+    if (listed === "*") {
+      hasStar = true;
+      continue;
+    }
+    if (listed === ua) return { kind: "exact", group };
+    if (ua.startsWith(listed) && listed.length > bestPrefix) {
+      bestPrefix = listed.length;
+    }
+  }
+  if (bestPrefix >= 0) return { kind: "prefix", group, score: bestPrefix };
+  if (hasStar) return { kind: "star", group };
+  return { kind: "none" };
+}
+
+// Decide whether `path` (the URL's path + query, e.g. "/a/b?c=d")
+// is permitted for `userAgent` by the parsed robots text. Returns
+// `true` when allowed, `false` when disallowed. Empty / missing
+// groups default to allowed, matching the robots.txt convention.
+//
+// Rule resolution follows the Google / IETF robots draft:
+// longest-prefix match wins between Allow and Disallow; tie goes
+// to Allow (the more permissive outcome).
+export function isAllowedByRobots(
+  robots: ParsedRobots,
+  userAgent: string,
+  path: string,
+): boolean {
+  const group = selectGroup(robots, userAgent);
+  if (!group) return true;
+  const { bestAllow, bestDisallow } = scoreRules(group, path);
+  if (bestAllow < 0 && bestDisallow < 0) return true;
+  return bestAllow >= bestDisallow;
+}
+
+// For each rule in `group`, compute the length of the longest
+// matching prefix; return the best Allow and Disallow lengths.
+// Returns -1 in either slot when no rule of that kind matched.
+// Empty patterns (from `Disallow:` with no value) never match in
+// `matchesPattern`, so they correctly fall through to the
+// allow-all default.
+function scoreRules(
+  group: RobotsGroup,
+  path: string,
+): { bestAllow: number; bestDisallow: number } {
+  let bestAllow = -1;
+  let bestDisallow = -1;
+  for (const rule of group.rules) {
+    const matchLen = matchesPattern(rule.pattern, path);
+    if (matchLen < 0) continue;
+    if (rule.kind === "allow" && matchLen > bestAllow) bestAllow = matchLen;
+    else if (rule.kind === "disallow" && matchLen > bestDisallow) {
+      bestDisallow = matchLen;
+    }
+  }
+  return { bestAllow, bestDisallow };
+}
+
+// Returns the length of the matched prefix (for longest-prefix
+// arbitration), or -1 if the pattern doesn't match. An empty
+// pattern never matches (special-cased so `Disallow:` with empty
+// value doesn't block everything). Wildcards:
+//
+//   `*`  — matches any sequence of characters
+//   `$`  — at end of pattern, anchors the match to end-of-path
+//
+// The return value is the length of the pattern consumed (i.e.
+// pattern length with wildcards counted literally). This ranking
+// isn't perfect for patterns with multiple `*` but good enough
+// for real-world robots.txt where rule specificity rarely
+// depends on wildcard placement.
+export function matchesPattern(pattern: string, path: string): number {
+  if (pattern === "") return -1;
+  // Fast path: no wildcards means literal prefix match.
+  if (!pattern.includes("*") && !pattern.endsWith("$")) {
+    return path.startsWith(pattern) ? pattern.length : -1;
+  }
+  // Compile to a regex. Escape everything except `*` / end-$.
+  const endAnchored = pattern.endsWith("$");
+  const body = endAnchored ? pattern.slice(0, -1) : pattern;
+  const regexBody = body
+    .split("*")
+    .map((chunk) => chunk.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  const re = new RegExp("^" + regexBody + (endAnchored ? "$" : ""));
+  return re.test(path) ? pattern.length : -1;
+}

--- a/server/sources/taxonomy.ts
+++ b/server/sources/taxonomy.ts
@@ -1,0 +1,60 @@
+// Fixed taxonomy of source categories. Keeping this a closed enum
+// (rather than accepting free-form LLM-generated tags) prevents
+// synonym sprawl — `ai` vs `artificial-intelligence` vs `AI` would
+// otherwise all coexist and make filtering useless.
+//
+// The auto-categorizer (see plans/feat-source-registry.md §"Auto-
+// categorization") classifies each new source into 1-5 of these
+// slugs and writes them into the source file's frontmatter. Users
+// can override by editing the file; the next daily run picks up
+// the edits.
+//
+// Pin-tested so a silent enum mutation doesn't sneak past review.
+
+export const CATEGORY_SLUGS = [
+  "tech-news",
+  "business-news",
+  "ai",
+  "security",
+  "devops",
+  "frontend",
+  "backend",
+  "ml-research",
+  "dependencies",
+  "product-updates",
+  "japanese",
+  "english",
+  "papers",
+  "general",
+  "startup",
+  "personal",
+] as const;
+
+export type CategorySlug = (typeof CATEGORY_SLUGS)[number];
+
+const CATEGORY_SET: ReadonlySet<string> = new Set(CATEGORY_SLUGS);
+
+// Runtime type-guard. Used when reading a source file from disk to
+// drop any legacy / typo categories so downstream code only ever
+// deals in the current enum.
+export function isCategorySlug(value: unknown): value is CategorySlug {
+  return typeof value === "string" && CATEGORY_SET.has(value);
+}
+
+// Normalize an unknown list of category candidates into a clean,
+// deduplicated array of valid slugs. Used when reading from
+// frontmatter (where the user may have typo'd) and when receiving
+// classifier output (where the LLM may have hallucinated a slug
+// outside the taxonomy).
+export function normalizeCategories(raw: unknown): CategorySlug[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<CategorySlug>();
+  const out: CategorySlug[] = [];
+  for (const item of raw) {
+    if (isCategorySlug(item) && !seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}

--- a/server/sources/taxonomy.ts
+++ b/server/sources/taxonomy.ts
@@ -28,6 +28,20 @@ export const CATEGORY_SLUGS = [
   "general",
   "startup",
   "personal",
+  // --- Phase-1 expansion (resolved from #188 open-question Q1) ---
+  // Added to cover common genres the original 16 couldn't capture
+  // (which were tech-centric and collapsed everything non-tech
+  // into `general`). See plans/feat-source-registry.md §Resolved
+  // decisions for rationale per slug.
+  "finance",
+  "design",
+  "productivity",
+  "science",
+  "health",
+  "gaming",
+  "climate",
+  "culture",
+  "policy",
 ] as const;
 
 export type CategorySlug = (typeof CATEGORY_SLUGS)[number];

--- a/server/sources/types.ts
+++ b/server/sources/types.ts
@@ -1,0 +1,156 @@
+// Data model for the information-source registry. Every source
+// lives as one markdown file under `workspace/sources/<slug>.md`,
+// with these fields in the YAML frontmatter plus optional free-form
+// markdown notes in the body.
+//
+// Design invariants the consumer code relies on:
+//
+// - `slug` is the primary key and matches the filename exactly.
+//   Enforced by `registry.ts` on both read and write.
+// - `url` is always the normalized form (see urls.ts) so dedup
+//   across sources works by string equality.
+// - `fetcherKind` is one of a closed set so the fetcher dispatcher
+//   can look up the right handler without `any`.
+// - `schedule` drives the daily / weekly aggregation pipeline.
+// - `categories` contains only valid CategorySlug values
+//   (runtime-validated on read).
+//
+// Secrets (API tokens, bearer auth) are NEVER stored here —
+// phase-1 scope is public sources only. Phase-3 authed fetchers
+// will read credentials from `.env` at runtime by name; the name
+// reference lives in `fetcherParams` as an `envVar` field.
+
+import type { CategorySlug } from "./taxonomy.js";
+
+// Closed set of fetcher kinds we can dispatch on. Adding a new
+// fetcher means: add the string literal here, implement a matching
+// module under `server/sources/fetchers/<kind>.ts`, and register
+// it in the fetcher index. Nothing else in the framework needs to
+// change.
+//
+// Phase-1 surface:
+//   "rss"                — public RSS / Atom feeds (server-side fetch)
+//   "github-releases"    — GitHub /releases endpoint, unauthenticated
+//   "github-issues"      — GitHub /issues + /pulls, unauthenticated
+//   "arxiv"              — arXiv query API
+//   "web-fetch"          — one-shot page fetch via Claude's web_fetch
+//   "web-search"         — ad-hoc query via Claude's web_search
+export const FETCHER_KINDS = [
+  "rss",
+  "github-releases",
+  "github-issues",
+  "arxiv",
+  "web-fetch",
+  "web-search",
+] as const;
+
+export type FetcherKind = (typeof FETCHER_KINDS)[number];
+
+const FETCHER_KIND_SET: ReadonlySet<string> = new Set(FETCHER_KINDS);
+
+export function isFetcherKind(value: unknown): value is FetcherKind {
+  return typeof value === "string" && FETCHER_KIND_SET.has(value);
+}
+
+// How often the daily pipeline is expected to refresh this source.
+// `on-demand` sources are never auto-fetched; they only respond to
+// the `manageSource fetch` action or the on-demand research
+// workflow.
+export const SOURCE_SCHEDULES = [
+  "hourly",
+  "daily",
+  "weekly",
+  "on-demand",
+] as const;
+
+export type SourceSchedule = (typeof SOURCE_SCHEDULES)[number];
+
+const SOURCE_SCHEDULE_SET: ReadonlySet<string> = new Set(SOURCE_SCHEDULES);
+
+export function isSourceSchedule(value: unknown): value is SourceSchedule {
+  return typeof value === "string" && SOURCE_SCHEDULE_SET.has(value);
+}
+
+// Per-fetcher extra parameters carried on the Source file. Flat
+// string map on disk so the minimal frontmatter parser can handle
+// it without nested YAML. Fetchers interpret the keys they care
+// about and ignore the rest — keeps cross-fetcher rewiring cheap.
+export type FetcherParams = Record<string, string>;
+
+// The on-disk configuration for one source. This is the exact
+// shape serialized into the YAML frontmatter of
+// `workspace/sources/<slug>.md` — state (cursors, etags, failure
+// counts) lives separately under `_state/<slug>.json`.
+export interface Source {
+  slug: string;
+  title: string;
+  url: string;
+  fetcherKind: FetcherKind;
+  fetcherParams: FetcherParams;
+  schedule: SourceSchedule;
+  categories: CategorySlug[];
+  maxItemsPerFetch: number;
+  addedAt: string; // ISO timestamp
+  notes: string; // markdown body of the file
+}
+
+// One normalized item after a fetch. All fetchers produce this
+// shape regardless of source type so the pipeline / dedup / summary
+// layers don't care where items came from.
+export interface SourceItem {
+  // Stable unique id for dedup. Hash of the normalized URL, or
+  // the fetcher's native id (e.g. GitHub release id) when one is
+  // available.
+  id: string;
+  title: string;
+  url: string;
+  publishedAt: string; // ISO timestamp
+  // Short one-line summary if the fetcher can produce one without
+  // LLM help. The pipeline's summarize step may replace this with
+  // a richer LLM-generated version.
+  summary?: string;
+  // Full body content if available (RSS description, GitHub release
+  // body, etc.). The summarize step reads this when the short
+  // summary is insufficient.
+  content?: string;
+  // Categories inherited from the source this item came from.
+  // Duplicated on the item so per-category daily rollups don't
+  // need a re-join.
+  categories: CategorySlug[];
+  // Slug of the parent Source so the dashboard / notification
+  // layer can link back.
+  sourceSlug: string;
+  // Optional severity hint set by the classifier or the fetcher
+  // itself (security advisories set `critical`). Daily pipeline
+  // uses this to decide whether to notify.
+  severity?: "info" | "warn" | "critical";
+}
+
+// Per-source runtime state, NOT committed to git. Mirrors the
+// Source-vs-_state split described in plans/feat-source-registry.md.
+export interface SourceState {
+  slug: string;
+  // Last successful fetch.
+  lastFetchedAt: string | null;
+  // Fetcher-specific cursor — ISO timestamp, etag, GitHub release
+  // id, arXiv last-seen, whatever the fetcher persists to
+  // de-duplicate across runs. Free-form string map so the fetcher
+  // interface doesn't need to know the shape upfront.
+  cursor: Record<string, string>;
+  // Consecutive failure count. Incremented per failed fetch,
+  // reset to 0 on success. Drives exponential backoff.
+  consecutiveFailures: number;
+  // Timestamp after which the next attempt is allowed, so backoff
+  // survives server restarts.
+  nextAttemptAt: string | null;
+}
+
+export function defaultSourceState(slug: string): SourceState {
+  return {
+    slug,
+    lastFetchedAt: null,
+    cursor: {},
+    consecutiveFailures: 0,
+    nextAttemptAt: null,
+  };
+}

--- a/server/sources/urls.ts
+++ b/server/sources/urls.ts
@@ -1,0 +1,130 @@
+// URL normalization utilities for dedup + cache keys.
+//
+// The same article commonly arrives from multiple sources with
+// different query strings (utm_source, fbclid, gclid, mc_cid, ...)
+// or trailing slashes. We normalize before dedup so "same article
+// different feed" collapses into one item.
+//
+// Pure — no I/O, fully testable.
+
+// Tracking parameters we always strip. Case-insensitive on the
+// parameter NAME only.
+const TRACKING_PARAM_PREFIXES: readonly string[] = [
+  "utm_",
+  "mc_",
+  "pk_",
+  "hsa_",
+];
+
+const TRACKING_PARAMS: ReadonlySet<string> = new Set([
+  "fbclid",
+  "gclid",
+  "msclkid",
+  "dclid",
+  "gbraid",
+  "wbraid",
+  "yclid",
+  "ref",
+  "ref_src",
+  "ref_url",
+  "share",
+  "share_source",
+  "trk",
+  "igshid",
+  "CMP",
+]);
+
+function isTrackingParam(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (TRACKING_PARAMS.has(lower)) return true;
+  for (const prefix of TRACKING_PARAM_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// Normalize a URL for use as a dedup key:
+//
+//   1. Parse it. Invalid → return null (caller decides fallback).
+//   2. Lowercase the protocol + host.
+//   3. Drop the fragment.
+//   4. Drop tracking query params.
+//   5. Sort remaining query params so different orderings hash the
+//      same.
+//   6. Collapse trailing slash on the pathname (except root "/").
+//   7. Drop default ports (80 for http, 443 for https).
+//
+// Returns the normalized href on success, null on unparseable
+// input.
+export function normalizeUrl(raw: string): string | null {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+
+  // protocol + host lowercase (URL already normalizes these but
+  // doing it explicitly guards against future WHATWG tweaks).
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+
+  // Drop fragment.
+  url.hash = "";
+
+  // Drop tracking params. Iterate on a snapshot because delete
+  // mutates the underlying list.
+  const paramNames = Array.from(url.searchParams.keys());
+  for (const name of paramNames) {
+    if (isTrackingParam(name)) url.searchParams.delete(name);
+  }
+
+  // Sort remaining params for deterministic ordering. Preserve
+  // multi-value params by iterating all entries.
+  const entries = Array.from(url.searchParams.entries());
+  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  // Clear and reinsert.
+  for (const name of Array.from(url.searchParams.keys())) {
+    url.searchParams.delete(name);
+  }
+  for (const [name, value] of entries) {
+    url.searchParams.append(name, value);
+  }
+
+  // Collapse trailing slash on non-root paths.
+  if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+    url.pathname = url.pathname.slice(0, -1);
+  }
+
+  // Drop default ports.
+  if (
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+  ) {
+    url.port = "";
+  }
+
+  return url.toString();
+}
+
+// Stable content-addressed id for an item. Not cryptographically
+// strong — fast hash suitable for in-memory Set membership and
+// cross-run dedup. Node has `crypto.createHash` but we prefer a
+// synchronous string-in / string-out helper that's easy to drop
+// into a fetcher.
+//
+// Algorithm: FNV-1a 32-bit over the normalized URL, hex-encoded.
+// Collisions are extremely rare at our item volume (tens of
+// thousands over years). If dedup correctness ever depends on
+// this, upgrade to sha-256 — but watch the bundle size for the
+// Vue side if we ever ship this to the browser.
+export function stableItemId(normalizedUrl: string): string {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < normalizedUrl.length; i++) {
+    hash ^= normalizedUrl.charCodeAt(i);
+    // Multiply by FNV prime (0x01000193), mask to 32-bit.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}

--- a/test/sources/test_httpFetcher.ts
+++ b/test/sources/test_httpFetcher.ts
@@ -1,0 +1,284 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  fetchPolite,
+  RobotsDisallowedError,
+  USER_AGENT,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  type HttpFetcherDeps,
+  type RobotsProvider,
+} from "../../server/sources/httpFetcher.js";
+import {
+  HostRateLimiter,
+  type RateLimiterDeps,
+} from "../../server/sources/rateLimiter.js";
+
+// Controllable clock for the rate limiter.
+function controllableClock(start = 0): {
+  deps: RateLimiterDeps;
+  tick: (ms: number) => void;
+  read: () => number;
+} {
+  const state = { t: start };
+  return {
+    deps: {
+      now: () => state.t,
+      sleep: (ms) => {
+        state.t += ms;
+        return Promise.resolve();
+      },
+    },
+    tick: (ms) => {
+      state.t += ms;
+    },
+    read: () => state.t,
+  };
+}
+
+// Build a stub fetch that returns prebuilt responses keyed by URL,
+// tracking which headers arrived and when each request fired.
+interface StubCall {
+  url: string;
+  headers: Record<string, string>;
+  signal: AbortSignal | null;
+}
+
+function makeStubFetch(responses: Record<string, Response | Error>): {
+  fetchImpl: typeof fetch;
+  calls: StubCall[];
+} {
+  const calls: StubCall[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = String(input);
+    const headers: Record<string, string> = {};
+    const rawHeaders = init?.headers as Record<string, string> | undefined;
+    if (rawHeaders) {
+      for (const [k, v] of Object.entries(rawHeaders)) {
+        headers[k] = v;
+      }
+    }
+    calls.push({ url, headers, signal: init?.signal ?? null });
+    const resp = responses[url];
+    if (!resp) throw new Error(`unexpected URL in test: ${url}`);
+    if (resp instanceof Error) throw resp;
+    return resp;
+  };
+  return { fetchImpl, calls };
+}
+
+function makeDeps(over: Partial<HttpFetcherDeps> = {}): HttpFetcherDeps {
+  const clock = controllableClock();
+  const rateLimiter = new HostRateLimiter(clock.deps);
+  const stub = makeStubFetch({});
+  return {
+    fetchImpl: stub.fetchImpl,
+    robots: async () => null, // no robots by default → allow all
+    rateLimiter,
+    rateLimiterDeps: clock.deps,
+    crawlDelayMs: () => 0, // disable delay by default
+    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+    onWillFetch: () => {},
+    ...over,
+  };
+}
+
+describe("fetchPolite — User-Agent + scheme guard", () => {
+  it("sends the MulmoClaude-SourceBot User-Agent on every request", async () => {
+    const url = "https://example.com/feed";
+    const stub = makeStubFetch({
+      [url]: new Response("<rss/>", { status: 200 }),
+    });
+    const deps = makeDeps({ fetchImpl: stub.fetchImpl });
+    const res = await fetchPolite(url, deps);
+    assert.equal(res.status, 200);
+    assert.equal(stub.calls.length, 1);
+    assert.equal(stub.calls[0].headers["User-Agent"], USER_AGENT);
+  });
+
+  it("rejects non-http(s) URLs", async () => {
+    const deps = makeDeps();
+    await assert.rejects(
+      () => fetchPolite("file:///etc/passwd", deps),
+      /refusing non-http/,
+    );
+    await assert.rejects(
+      () => fetchPolite("ftp://example.com/feed", deps),
+      /refusing non-http/,
+    );
+    await assert.rejects(
+      () => fetchPolite("javascript:alert(1)", deps),
+      /refusing non-http/,
+    );
+  });
+});
+
+describe("fetchPolite — robots.txt enforcement", () => {
+  it("throws RobotsDisallowedError for a disallowed path", async () => {
+    const url = "https://example.com/private";
+    const robots: RobotsProvider = async (host) =>
+      host === "example.com" ? "User-agent: *\nDisallow: /private\n" : null;
+    const deps = makeDeps({ robots });
+    await assert.rejects(
+      () => fetchPolite(url, deps),
+      (err: unknown) => err instanceof RobotsDisallowedError && err.url === url,
+    );
+  });
+
+  it("allows a path with Allow overriding a broader Disallow", async () => {
+    const url = "https://example.com/api/public/feed";
+    const stub = makeStubFetch({
+      [url]: new Response("{}", { status: 200 }),
+    });
+    const robots: RobotsProvider = async () =>
+      "User-agent: *\nDisallow: /api/\nAllow: /api/public/\n";
+    const deps = makeDeps({ fetchImpl: stub.fetchImpl, robots });
+    const res = await fetchPolite(url, deps);
+    assert.equal(res.status, 200);
+  });
+
+  it("proceeds when robots returns null (no robots.txt)", async () => {
+    const url = "https://example.com/any";
+    const stub = makeStubFetch({
+      [url]: new Response("ok", { status: 200 }),
+    });
+    const deps = makeDeps({
+      fetchImpl: stub.fetchImpl,
+      robots: async () => null,
+    });
+    const res = await fetchPolite(url, deps);
+    assert.equal(res.status, 200);
+  });
+
+  it("checks robots using the full path + query string", async () => {
+    // Some robots.txt disallow specific query patterns, e.g.
+    // `Disallow: /*?*session_id=`. We pass path+query, so the
+    // evaluator sees the query.
+    const url = "https://example.com/page?session_id=abc";
+    const robots: RobotsProvider = async () =>
+      "User-agent: *\nDisallow: /*?*session_id=\n";
+    const deps = makeDeps({ robots });
+    await assert.rejects(() => fetchPolite(url, deps), RobotsDisallowedError);
+  });
+});
+
+describe("fetchPolite — rate limiting", () => {
+  it("serializes same-host requests", async () => {
+    const clock = controllableClock();
+    const limiter = new HostRateLimiter(clock.deps);
+    const order: string[] = [];
+    let releaseA: () => void = () => {};
+    const stub: typeof fetch = async (input) => {
+      const url = String(input);
+      order.push(`start:${url}`);
+      if (url.endsWith("a")) {
+        await new Promise<void>((r) => {
+          releaseA = r;
+        });
+      }
+      order.push(`end:${url}`);
+      return new Response("", { status: 200 });
+    };
+    const deps = makeDeps({
+      fetchImpl: stub,
+      rateLimiter: limiter,
+      rateLimiterDeps: clock.deps,
+      crawlDelayMs: () => 0,
+    });
+    const a = fetchPolite("https://example.com/a", deps);
+    const b = fetchPolite("https://example.com/b", deps);
+    await Promise.resolve();
+    await Promise.resolve();
+    // Only a has started; b is queued.
+    assert.deepEqual(order, ["start:https://example.com/a"]);
+    releaseA();
+    await Promise.all([a, b]);
+    // b starts only after a ends.
+    assert.deepEqual(order, [
+      "start:https://example.com/a",
+      "end:https://example.com/a",
+      "start:https://example.com/b",
+      "end:https://example.com/b",
+    ]);
+  });
+
+  it("uses crawlDelayMs() per host", async () => {
+    const clock = controllableClock();
+    const limiter = new HostRateLimiter(clock.deps);
+    const stub = makeStubFetch({
+      "https://slow.com/1": new Response("", { status: 200 }),
+      "https://slow.com/2": new Response("", { status: 200 }),
+    });
+    const deps = makeDeps({
+      fetchImpl: stub.fetchImpl,
+      rateLimiter: limiter,
+      rateLimiterDeps: clock.deps,
+      // Host-specific delay: slow.com gets 5s between requests.
+      crawlDelayMs: (host) => (host === "slow.com" ? 5_000 : 0),
+    });
+    await fetchPolite("https://slow.com/1", deps);
+    const before = clock.read();
+    await fetchPolite("https://slow.com/2", deps);
+    assert.ok(
+      clock.read() - before >= 5_000,
+      `expected ≥5000ms gap, got ${clock.read() - before}`,
+    );
+  });
+});
+
+describe("fetchPolite — timeout + abort", () => {
+  it("aborts when the external signal fires mid-fetch", async () => {
+    const controller = new AbortController();
+    const url = "https://example.com/slow";
+    const stub: typeof fetch = (_input, init) =>
+      new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(init!.signal!.reason ?? new DOMException("", "AbortError"));
+        });
+      });
+    const deps = makeDeps({
+      fetchImpl: stub,
+      externalSignal: controller.signal,
+    });
+    const promise = fetchPolite(url, deps);
+    // Cancel right away.
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    await assert.rejects(() => promise, /cancelled|AbortError/);
+  });
+
+  it("rejects immediately when the external signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new DOMException("pre", "AbortError"));
+    const deps = makeDeps({
+      externalSignal: controller.signal,
+    });
+    await assert.rejects(
+      () => fetchPolite("https://example.com/x", deps),
+      /pre/,
+    );
+  });
+
+  it("calls onWillFetch right before the fetch fires", async () => {
+    const url = "https://example.com/x";
+    const stub = makeStubFetch({
+      [url]: new Response("", { status: 200 }),
+    });
+    const calls: string[] = [];
+    const deps = makeDeps({
+      fetchImpl: stub.fetchImpl,
+      onWillFetch: (u) => calls.push(u),
+    });
+    await fetchPolite(url, deps);
+    assert.deepEqual(calls, [url]);
+  });
+
+  it("surfaces HTTP error responses as-is (no throwing)", async () => {
+    const url = "https://example.com/404";
+    const stub = makeStubFetch({
+      [url]: new Response("not found", { status: 404 }),
+    });
+    const deps = makeDeps({ fetchImpl: stub.fetchImpl });
+    const res = await fetchPolite(url, deps);
+    // 4xx/5xx are not thrown — the fetcher inspects status.
+    assert.equal(res.status, 404);
+  });
+});

--- a/test/sources/test_paths.ts
+++ b/test/sources/test_paths.ts
@@ -56,16 +56,32 @@ describe("path helpers", () => {
     assert.throws(() => dailyNewsPath(root, "foo"), /YYYY-MM-DD/);
   });
 
-  it("archivePath builds news/archive/<slug>/<YYYY-MM>.md", () => {
+  it("archivePath builds news/archive/<slug>/YYYY/MM.md", () => {
+    // The year and month are split into nested dirs so a
+    // long-running workspace doesn't end up with 60+ flat files
+    // in a single source's archive dir — matches daily/YYYY/MM/DD.md.
     assert.equal(
       archivePath(root, "hn-front-page", "2026-04"),
-      path.join(root, "news", "archive", "hn-front-page", "2026-04.md"),
+      path.join(root, "news", "archive", "hn-front-page", "2026", "04.md"),
+    );
+  });
+
+  it("archivePath splits the year-month even for edge months", () => {
+    assert.equal(
+      archivePath(root, "x", "2026-01"),
+      path.join(root, "news", "archive", "x", "2026", "01.md"),
+    );
+    assert.equal(
+      archivePath(root, "x", "2026-12"),
+      path.join(root, "news", "archive", "x", "2026", "12.md"),
     );
   });
 
   it("archivePath rejects invalid year-month strings", () => {
     assert.throws(() => archivePath(root, "x", "2026/04"), /YYYY-MM/);
     assert.throws(() => archivePath(root, "x", "2026-4"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", "26-04"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", ""), /YYYY-MM/);
   });
 });
 

--- a/test/sources/test_paths.ts
+++ b/test/sources/test_paths.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  sourcesRoot,
+  sourceFilePath,
+  sourceStatePath,
+  robotsCachePath,
+  dailyNewsPath,
+  archivePath,
+  isValidSlug,
+} from "../../server/sources/paths.js";
+
+const root = path.join("/tmp", "ws");
+
+describe("path helpers", () => {
+  it("sourcesRoot joins under workspace", () => {
+    assert.equal(sourcesRoot(root), path.join(root, "sources"));
+  });
+
+  it("sourceFilePath builds workspace/sources/<slug>.md", () => {
+    assert.equal(
+      sourceFilePath(root, "hn-front-page"),
+      path.join(root, "sources", "hn-front-page.md"),
+    );
+  });
+
+  it("sourceStatePath nests under _state", () => {
+    assert.equal(
+      sourceStatePath(root, "hn-front-page"),
+      path.join(root, "sources", "_state", "hn-front-page.json"),
+    );
+  });
+
+  it("robotsCachePath sanitizes colons in host:port", () => {
+    // Hosts with explicit ports have colons that break on some
+    // filesystems. Colon → underscore.
+    const p = robotsCachePath(root, "example.com:8080");
+    assert.equal(
+      p,
+      path.join(root, "sources", "_state", "robots", "example.com_8080.txt"),
+    );
+  });
+
+  it("dailyNewsPath splits YYYY-MM-DD into year / month / day.md", () => {
+    assert.equal(
+      dailyNewsPath(root, "2026-04-13"),
+      path.join(root, "news", "daily", "2026", "04", "13.md"),
+    );
+  });
+
+  it("dailyNewsPath rejects invalid date strings", () => {
+    assert.throws(() => dailyNewsPath(root, ""), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "2026/04/13"), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "2026-4-13"), /YYYY-MM-DD/);
+    assert.throws(() => dailyNewsPath(root, "foo"), /YYYY-MM-DD/);
+  });
+
+  it("archivePath builds news/archive/<slug>/<YYYY-MM>.md", () => {
+    assert.equal(
+      archivePath(root, "hn-front-page", "2026-04"),
+      path.join(root, "news", "archive", "hn-front-page", "2026-04.md"),
+    );
+  });
+
+  it("archivePath rejects invalid year-month strings", () => {
+    assert.throws(() => archivePath(root, "x", "2026/04"), /YYYY-MM/);
+    assert.throws(() => archivePath(root, "x", "2026-4"), /YYYY-MM/);
+  });
+});
+
+describe("isValidSlug", () => {
+  it("accepts simple kebab-case slugs", () => {
+    assert.equal(isValidSlug("hn"), true);
+    assert.equal(isValidSlug("hn-front-page"), true);
+    assert.equal(isValidSlug("anthropic-releases"), true);
+    assert.equal(isValidSlug("a"), true);
+    assert.equal(isValidSlug("arxiv-cs-cl"), true);
+  });
+
+  it("accepts digits", () => {
+    assert.equal(isValidSlug("arxiv-2024"), true);
+    assert.equal(isValidSlug("news3"), true);
+    assert.equal(isValidSlug("100"), true);
+  });
+
+  it("rejects empty / too-long", () => {
+    assert.equal(isValidSlug(""), false);
+    assert.equal(isValidSlug("a".repeat(65)), false);
+  });
+
+  it("rejects uppercase", () => {
+    assert.equal(isValidSlug("HN"), false);
+    assert.equal(isValidSlug("Hacker-News"), false);
+  });
+
+  it("rejects underscores / dots / slashes / spaces", () => {
+    assert.equal(isValidSlug("hn_front"), false);
+    assert.equal(isValidSlug("hn.front"), false);
+    assert.equal(isValidSlug("hn/front"), false);
+    assert.equal(isValidSlug("hn front"), false);
+  });
+
+  it("rejects leading / trailing hyphen", () => {
+    assert.equal(isValidSlug("-hn"), false);
+    assert.equal(isValidSlug("hn-"), false);
+    assert.equal(isValidSlug("-"), false);
+  });
+
+  it("rejects consecutive hyphens", () => {
+    assert.equal(isValidSlug("hn--front"), false);
+  });
+
+  it("rejects path-traversal attempts", () => {
+    // Defense: the slug doubles as a filename, so ".." or "x/y"
+    // would let a caller escape the sources dir. The regex
+    // already rejects these but pin the intent.
+    assert.equal(isValidSlug(".."), false);
+    assert.equal(isValidSlug("../etc/passwd"), false);
+    assert.equal(isValidSlug("foo/../bar"), false);
+    assert.equal(isValidSlug(".hidden"), false);
+  });
+
+  it("rejects non-string", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(isValidSlug(null as any), false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(isValidSlug(42 as any), false);
+  });
+});

--- a/test/sources/test_rateLimiter.ts
+++ b/test/sources/test_rateLimiter.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  HostRateLimiter,
+  DEFAULT_MIN_DELAY_MS,
+  type RateLimiterDeps,
+} from "../../server/sources/rateLimiter.js";
+
+// Build a controllable clock + sleep for deterministic tests.
+// `now()` returns a mutable counter; `sleep(ms)` advances the
+// counter synchronously and resolves on the next microtask so
+// task ordering is preserved without real timers.
+function makeFakeClock(start = 0): {
+  deps: RateLimiterDeps;
+  advance: (ms: number) => void;
+  readonly current: number;
+} {
+  const state = { current: start };
+  return {
+    current: 0,
+    get deps() {
+      return {
+        now: () => state.current,
+        sleep: (ms: number) => {
+          state.current += ms;
+          return Promise.resolve();
+        },
+      };
+    },
+    advance(ms: number) {
+      state.current += ms;
+    },
+    // Proxy so `current` reflects state live.
+    ...Object.defineProperty(
+      { advance: (ms: number) => (state.current += ms) },
+      "current",
+      { get: () => state.current },
+    ),
+  };
+}
+
+// Simpler alternative when we don't need live-binding; returns a
+// deps object plus direct state access.
+function controllableClock(start = 0): {
+  deps: RateLimiterDeps;
+  tick: (ms: number) => void;
+  read: () => number;
+} {
+  const state = { t: start };
+  return {
+    deps: {
+      now: () => state.t,
+      sleep: (ms) => {
+        state.t += ms;
+        return Promise.resolve();
+      },
+    },
+    tick: (ms) => {
+      state.t += ms;
+    },
+    read: () => state.t,
+  };
+}
+
+describe("HostRateLimiter — basic behaviour", () => {
+  it("runs a single task and returns its value", async () => {
+    const { deps } = controllableClock();
+    const lim = new HostRateLimiter(deps);
+    const result = await lim.run("example.com", async () => 42);
+    assert.equal(result, 42);
+  });
+
+  it("propagates task errors without poisoning the queue", async () => {
+    const { deps } = controllableClock();
+    const lim = new HostRateLimiter(deps);
+    await assert.rejects(
+      () =>
+        lim.run("example.com", async () => {
+          throw new Error("boom");
+        }),
+      /boom/,
+    );
+    // Second call on the same host still runs.
+    const result = await lim.run("example.com", async () => "ok");
+    assert.equal(result, "ok");
+  });
+
+  it("tracks host count as new hosts are used", async () => {
+    const { deps } = controllableClock();
+    const lim = new HostRateLimiter(deps);
+    assert.equal(lim.hostCount(), 0);
+    await lim.run("a.com", async () => "a");
+    await lim.run("b.com", async () => "b");
+    await lim.run("a.com", async () => "a2");
+    assert.equal(lim.hostCount(), 2);
+  });
+});
+
+describe("HostRateLimiter — serialization per host", () => {
+  it("serializes concurrent calls to the same host", async () => {
+    const { deps } = controllableClock();
+    const lim = new HostRateLimiter(deps, ...[].slice()); // eslint noise
+    // The semaphore-like invariant: if two run() calls are issued
+    // back-to-back on the same host, the second task must not
+    // start until the first has completed.
+    const events: string[] = [];
+    let releaseFirst: () => void = () => {};
+    const first = lim.run(
+      "example.com",
+      async () => {
+        events.push("first:start");
+        await new Promise<void>((r) => {
+          releaseFirst = r;
+        });
+        events.push("first:end");
+        return 1;
+      },
+      0,
+    );
+    const second = lim.run(
+      "example.com",
+      async () => {
+        events.push("second:start");
+        return 2;
+      },
+      0,
+    );
+    // Let first's body start. It's now awaiting releaseFirst.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Second hasn't started yet.
+    assert.deepEqual(events, ["first:start"]);
+    releaseFirst();
+    const [a, b] = await Promise.all([first, second]);
+    assert.equal(a, 1);
+    assert.equal(b, 2);
+    assert.deepEqual(events, ["first:start", "first:end", "second:start"]);
+  });
+
+  it("allows different hosts to run concurrently", async () => {
+    const { deps } = controllableClock();
+    const lim = new HostRateLimiter(deps);
+    const events: string[] = [];
+    let releaseA: () => void = () => {};
+    const a = lim.run(
+      "a.com",
+      async () => {
+        events.push("a:start");
+        await new Promise<void>((r) => {
+          releaseA = r;
+        });
+        events.push("a:end");
+        return "a";
+      },
+      0,
+    );
+    const b = lim.run(
+      "b.com",
+      async () => {
+        events.push("b:start");
+        return "b";
+      },
+      0,
+    );
+    // Let both tasks schedule. a is still awaiting; b should
+    // have completed.
+    const bResult = await b;
+    assert.equal(bResult, "b");
+    // b:start must have happened BEFORE a finishes — distinct
+    // hosts don't serialize.
+    assert.deepEqual(events, ["a:start", "b:start"]);
+    releaseA();
+    await a;
+  });
+});
+
+describe("HostRateLimiter — minimum delay enforcement", () => {
+  it("honours minDelayMs between consecutive same-host calls", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    // Task 1 takes "instant" (no clock advance inside task). Finishes at t=0.
+    await lim.run("a.com", async () => "first", 100);
+    // Task 2 should wait 100ms via sleep before running. Since
+    // our fake sleep advances the clock synchronously, we can
+    // observe the advance.
+    const before = clock.read();
+    await lim.run("a.com", async () => "second", 100);
+    const elapsed = clock.read() - before;
+    assert.ok(elapsed >= 100, `expected ≥100ms elapsed, got ${elapsed}`);
+  });
+
+  it("doesn't wait when the previous call finished long ago", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await lim.run("a.com", async () => "first", 100);
+    clock.tick(500); // simulated 500ms pass before next call
+    const before = clock.read();
+    await lim.run("a.com", async () => "second", 100);
+    // Second call shouldn't have slept — 500ms > 100ms already elapsed.
+    assert.equal(clock.read() - before, 0);
+  });
+
+  it("uses DEFAULT_MIN_DELAY_MS when no delay is specified", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await lim.run("a.com", async () => "first");
+    const before = clock.read();
+    await lim.run("a.com", async () => "second");
+    assert.ok(
+      clock.read() - before >= DEFAULT_MIN_DELAY_MS,
+      `expected default ${DEFAULT_MIN_DELAY_MS}ms delay, got ${clock.read() - before}`,
+    );
+  });
+
+  it("marks finishedAt even on error so the next retry waits", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await assert.rejects(() =>
+      lim.run(
+        "a.com",
+        async () => {
+          throw new Error("nope");
+        },
+        200,
+      ),
+    );
+    const before = clock.read();
+    await lim.run("a.com", async () => "ok", 200);
+    // Second call still waits the full delay.
+    assert.ok(clock.read() - before >= 200);
+  });
+
+  it("host matching is case-insensitive", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await lim.run("Example.COM", async () => "first", 100);
+    const before = clock.read();
+    await lim.run("example.com", async () => "second", 100);
+    // Same host under different case → still gated by delay.
+    assert.ok(clock.read() - before >= 100);
+  });
+});
+
+describe("HostRateLimiter — evictIdle", () => {
+  it("removes hosts whose last finish is older than idleMs", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await lim.run("old.com", async () => "x", 0);
+    clock.tick(5_000);
+    await lim.run("fresh.com", async () => "y", 0);
+    assert.equal(lim.hostCount(), 2);
+    const removed = lim.evictIdle(1_000);
+    assert.equal(removed, 1);
+    assert.equal(lim.hostCount(), 1);
+  });
+
+  it("returns 0 when nothing is idle", async () => {
+    const clock = controllableClock(0);
+    const lim = new HostRateLimiter(clock.deps);
+    await lim.run("x.com", async () => null, 0);
+    const removed = lim.evictIdle(60_000);
+    assert.equal(removed, 0);
+  });
+});

--- a/test/sources/test_registry.ts
+++ b/test/sources/test_registry.ts
@@ -1,0 +1,478 @@
+// Registry I/O tests. Pure-parser tests run without touching the
+// filesystem; the filesystem tests use `mkdtempSync` to keep the
+// real `~/mulmoclaude` out of scope.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseSourceFile,
+  buildSource,
+  serializeSource,
+  readSource,
+  writeSource,
+  listSources,
+  deleteSource,
+  DEFAULT_MAX_ITEMS_PER_FETCH,
+} from "../../server/sources/registry.js";
+import { sourceFilePath } from "../../server/sources/paths.js";
+import type { Source } from "../../server/sources/types.js";
+
+// --- pure-parser tests --------------------------------------------------
+
+const VALID_FRONTMATTER = `---
+slug: hn-front-page
+title: Hacker News front page
+url: https://news.ycombinator.com/rss
+fetcher_kind: rss
+schedule: daily
+categories: [tech-news, general, english]
+max_items_per_fetch: 30
+added_at: 2026-04-13T09:00:00Z
+---
+
+# Notes
+
+Why registered: general pulse.
+`;
+
+describe("parseSourceFile", () => {
+  it("extracts frontmatter and body", () => {
+    const out = parseSourceFile(VALID_FRONTMATTER);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "hn-front-page");
+    assert.equal(out!.fields.get("title"), "Hacker News front page");
+    assert.deepEqual(out!.fields.get("categories"), [
+      "tech-news",
+      "general",
+      "english",
+    ]);
+    assert.match(out!.body, /# Notes/);
+  });
+
+  it("returns null for a file with no frontmatter", () => {
+    assert.equal(parseSourceFile("just a markdown body\n"), null);
+  });
+
+  it("returns null for an unterminated frontmatter block", () => {
+    assert.equal(parseSourceFile("---\nslug: x\ntitle: hey\n"), null);
+  });
+
+  it("tolerates CRLF line endings", () => {
+    const crlf = VALID_FRONTMATTER.replace(/\n/g, "\r\n");
+    const out = parseSourceFile(crlf);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "hn-front-page");
+  });
+
+  it("ignores comment lines in frontmatter", () => {
+    const raw = `---
+# comment
+slug: x
+title: hey
+url: https://example.com
+fetcher_kind: rss
+schedule: daily
+categories: [ai]
+max_items_per_fetch: 10
+added_at: 2026-04-13T00:00:00Z
+---
+`;
+    const out = parseSourceFile(raw);
+    assert.ok(out);
+    assert.equal(out!.fields.get("slug"), "x");
+  });
+
+  it("handles empty string values", () => {
+    const raw = `---
+slug: x
+title: empty
+url: https://example.com
+fetcher_kind: rss
+schedule: daily
+categories: []
+max_items_per_fetch: 5
+added_at: 2026-04-13T00:00:00Z
+---
+`;
+    const out = parseSourceFile(raw);
+    assert.ok(out);
+    assert.deepEqual(out!.fields.get("categories"), []);
+  });
+});
+
+describe("buildSource — validation", () => {
+  function base(): Map<string, string | string[]> {
+    return new Map<string, string | string[]>([
+      ["slug", "hn"],
+      ["title", "HN"],
+      ["url", "https://news.ycombinator.com/rss"],
+      ["fetcher_kind", "rss"],
+      ["schedule", "daily"],
+      ["categories", ["tech-news"]],
+      ["max_items_per_fetch", "30"],
+      ["added_at", "2026-04-13T00:00:00Z"],
+    ]);
+  }
+
+  it("builds a valid Source from well-formed fields", () => {
+    const source = buildSource(base(), "body");
+    assert.ok(source);
+    assert.equal(source!.slug, "hn");
+    assert.equal(source!.title, "HN");
+    assert.equal(source!.fetcherKind, "rss");
+    assert.equal(source!.schedule, "daily");
+    assert.deepEqual(source!.categories, ["tech-news"]);
+    assert.equal(source!.maxItemsPerFetch, 30);
+    assert.equal(source!.notes, "body");
+  });
+
+  it("returns null for missing slug", () => {
+    const f = base();
+    f.delete("slug");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for invalid slug (uppercase)", () => {
+    const f = base();
+    f.set("slug", "HN");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for invalid slug (path traversal)", () => {
+    const f = base();
+    f.set("slug", "../etc/passwd");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for missing title", () => {
+    const f = base();
+    f.delete("title");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for missing url", () => {
+    const f = base();
+    f.delete("url");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for unknown fetcher kind", () => {
+    const f = base();
+    f.set("fetcher_kind", "bogus");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("returns null for unknown schedule", () => {
+    const f = base();
+    f.set("schedule", "quarterly");
+    assert.equal(buildSource(f, ""), null);
+  });
+
+  it("drops invalid categories silently", () => {
+    const f = base();
+    f.set("categories", ["ai", "bogus", "security"]);
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.deepEqual(source!.categories, ["ai", "security"]);
+  });
+
+  it("falls back to the default max_items_per_fetch for invalid values", () => {
+    const f = base();
+    f.set("max_items_per_fetch", "not-a-number");
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.equal(source!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
+  });
+
+  it("falls back to the default for a zero / negative max", () => {
+    const f = base();
+    f.set("max_items_per_fetch", "0");
+    assert.equal(
+      buildSource(f, "")!.maxItemsPerFetch,
+      DEFAULT_MAX_ITEMS_PER_FETCH,
+    );
+    f.set("max_items_per_fetch", "-10");
+    assert.equal(
+      buildSource(f, "")!.maxItemsPerFetch,
+      DEFAULT_MAX_ITEMS_PER_FETCH,
+    );
+  });
+
+  it("collects unrecognized keys into fetcherParams", () => {
+    const f = base();
+    f.set("github_repo", "anthropics/claude-code");
+    f.set("arxiv_query", "cs.CL");
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.deepEqual(source!.fetcherParams, {
+      github_repo: "anthropics/claude-code",
+      arxiv_query: "cs.CL",
+    });
+  });
+
+  it("ignores array values in fetcherParams (schema mismatch)", () => {
+    const f = base();
+    f.set("weird_array", ["a", "b"]);
+    const source = buildSource(f, "");
+    assert.ok(source);
+    assert.equal(source!.fetcherParams["weird_array"], undefined);
+  });
+});
+
+describe("serializeSource — round trip", () => {
+  function makeSource(over: Partial<Source> = {}): Source {
+    return {
+      slug: "hn",
+      title: "Hacker News",
+      url: "https://news.ycombinator.com/rss",
+      fetcherKind: "rss",
+      fetcherParams: {},
+      schedule: "daily",
+      categories: ["tech-news", "general"],
+      maxItemsPerFetch: 30,
+      addedAt: "2026-04-13T00:00:00Z",
+      notes: "",
+      ...over,
+    };
+  }
+
+  it("round-trips a minimal Source", () => {
+    const source = makeSource();
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    assert.ok(parsed);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.ok(rebuilt);
+    assert.deepEqual(rebuilt, source);
+  });
+
+  it("round-trips with fetcherParams", () => {
+    const source = makeSource({
+      fetcherKind: "github-releases",
+      fetcherParams: { github_repo: "anthropics/claude-code" },
+    });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.deepEqual(rebuilt, source);
+  });
+
+  it("round-trips notes body", () => {
+    const source = makeSource({
+      notes: "# Notes\n\nWhy this source matters.\n",
+    });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.notes, source.notes);
+  });
+
+  it("quotes values that would confuse the flat-YAML parser", () => {
+    // A title containing a colon would otherwise break the reader
+    // because the parser splits on the first `:`.
+    const source = makeSource({ title: "Weekly: The Best of the Web" });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.title, "Weekly: The Best of the Web");
+  });
+
+  it("quotes values that look like reserved YAML atoms", () => {
+    // `true`, `null`, numbers, dates — the reader currently
+    // returns them as strings, but if we ever add YAML-native
+    // scalar types this protects us.
+    const source = makeSource({ title: "true" });
+    const serialized = serializeSource(source);
+    const parsed = parseSourceFile(serialized);
+    const rebuilt = buildSource(parsed!.fields, parsed!.body);
+    assert.equal(rebuilt!.title, "true");
+  });
+
+  it("sorts fetcherParams alphabetically for stable diffs", () => {
+    const source = makeSource({
+      fetcherParams: { z_key: "1", a_key: "2", m_key: "3" },
+    });
+    const serialized = serializeSource(source);
+    const aIdx = serialized.indexOf("a_key:");
+    const mIdx = serialized.indexOf("m_key:");
+    const zIdx = serialized.indexOf("z_key:");
+    assert.ok(aIdx > 0 && mIdx > aIdx && zIdx > mIdx);
+  });
+});
+
+// --- filesystem tests ---------------------------------------------------
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "sources-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function makeSource(): Source {
+  return {
+    slug: "hn",
+    title: "Hacker News",
+    url: "https://news.ycombinator.com/rss",
+    fetcherKind: "rss",
+    fetcherParams: {},
+    schedule: "daily",
+    categories: ["tech-news"],
+    maxItemsPerFetch: 30,
+    addedAt: "2026-04-13T00:00:00Z",
+    notes: "",
+  };
+}
+
+describe("writeSource + readSource — filesystem round trip", () => {
+  it("writes and reads back an equivalent Source", async () => {
+    const source = makeSource();
+    await writeSource(workspace, source);
+    const read = await readSource(workspace, "hn");
+    assert.deepEqual(read, source);
+  });
+
+  it("returns null when the file doesn't exist", async () => {
+    const read = await readSource(workspace, "missing");
+    assert.equal(read, null);
+  });
+
+  it("returns null when the slug in the frontmatter doesn't match the filename", async () => {
+    // Defense: someone renames the file on disk without editing
+    // the frontmatter. Silently loading with the wrong slug would
+    // corrupt downstream state lookups — so we refuse the load.
+    const source = makeSource();
+    await writeSource(workspace, source);
+    // Manually rename on disk to simulate the drift.
+    const { rename } = await import("node:fs/promises");
+    await rename(
+      sourceFilePath(workspace, "hn"),
+      sourceFilePath(workspace, "renamed"),
+    );
+    const read = await readSource(workspace, "renamed");
+    assert.equal(read, null);
+  });
+
+  it("refuses to write an invalid slug", async () => {
+    const source: Source = { ...makeSource(), slug: "HACK/../etc" };
+    await assert.rejects(() => writeSource(workspace, source), /invalid slug/);
+  });
+
+  it("refuses to read an invalid slug", async () => {
+    assert.equal(await readSource(workspace, "../etc/passwd"), null);
+  });
+
+  it("overwrites an existing source atomically", async () => {
+    const first = makeSource();
+    await writeSource(workspace, first);
+    const second: Source = { ...first, title: "Hacker News (updated)" };
+    await writeSource(workspace, second);
+    const read = await readSource(workspace, "hn");
+    assert.equal(read!.title, "Hacker News (updated)");
+  });
+
+  it("does not leave a .tmp file behind after a successful write", async () => {
+    await writeSource(workspace, makeSource());
+    const { readdir } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    const entries = await readdir(sourcesRoot(workspace));
+    assert.equal(
+      entries.some((name) => name.endsWith(".tmp")),
+      false,
+    );
+  });
+});
+
+describe("listSources", () => {
+  it("returns [] when the sources directory doesn't exist", async () => {
+    assert.deepEqual(await listSources(workspace), []);
+  });
+
+  it("returns every valid source file, sorted by slug", async () => {
+    const sources = [
+      { ...makeSource(), slug: "charlie", title: "C" },
+      { ...makeSource(), slug: "alpha", title: "A" },
+      { ...makeSource(), slug: "bravo", title: "B" },
+    ];
+    for (const s of sources) await writeSource(workspace, s);
+    const listed = await listSources(workspace);
+    assert.deepEqual(
+      listed.map((s) => s.slug),
+      ["alpha", "bravo", "charlie"],
+    );
+  });
+
+  it("skips files starting with _", async () => {
+    await writeSource(workspace, makeSource());
+    // Meta file written alongside by a hypothetical index generator.
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(join(sourcesRoot(workspace), "_index.md"), "# Index\n");
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].slug, "hn");
+  });
+
+  it("skips non-.md files", async () => {
+    await writeSource(workspace, makeSource());
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(
+      join(sourcesRoot(workspace), "hn.json"),
+      JSON.stringify({ something: "else" }),
+    );
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+  });
+
+  it("logs + skips malformed source files without crashing", async () => {
+    await writeSource(workspace, makeSource());
+    const { writeFile } = await import("node:fs/promises");
+    const { sourcesRoot } = await import("../../server/sources/paths.js");
+    await writeFile(
+      join(sourcesRoot(workspace), "broken.md"),
+      "no frontmatter here",
+    );
+    const listed = await listSources(workspace);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].slug, "hn");
+  });
+});
+
+describe("deleteSource", () => {
+  it("removes an existing source file and returns true", async () => {
+    await writeSource(workspace, makeSource());
+    const removed = await deleteSource(workspace, "hn");
+    assert.equal(removed, true);
+    const read = await readSource(workspace, "hn");
+    assert.equal(read, null);
+  });
+
+  it("returns false when the file doesn't exist", async () => {
+    const removed = await deleteSource(workspace, "missing");
+    assert.equal(removed, false);
+  });
+
+  it("refuses invalid slugs", async () => {
+    const removed = await deleteSource(workspace, "../etc/passwd");
+    assert.equal(removed, false);
+  });
+});
+
+describe("writeSource + readFile — serialization shape", () => {
+  it("writes a markdown file with the expected frontmatter prefix", async () => {
+    await writeSource(workspace, makeSource());
+    const raw = await readFile(sourceFilePath(workspace, "hn"), "utf-8");
+    assert.ok(raw.startsWith("---\n"));
+    assert.match(raw, /\nslug: hn\n/);
+    assert.match(raw, /\nfetcher_kind: rss\n/);
+    assert.match(raw, /\n---\n/);
+  });
+});

--- a/test/sources/test_robots.ts
+++ b/test/sources/test_robots.ts
@@ -1,0 +1,291 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseRobots,
+  selectGroup,
+  isAllowedByRobots,
+  matchesPattern,
+} from "../../server/sources/robots.js";
+
+// --- parseRobots -----------------------------------------------------------
+
+describe("parseRobots — structural", () => {
+  it("returns an empty group list for empty input", () => {
+    assert.deepEqual(parseRobots("").groups, []);
+    assert.deepEqual(parseRobots("\n\n\n").groups, []);
+  });
+
+  it("strips comments and blank lines", () => {
+    const out = parseRobots(`
+# this is a comment
+User-agent: *   # trailing comment
+Disallow: /private
+`);
+    assert.equal(out.groups.length, 1);
+    assert.deepEqual(out.groups[0].userAgents, ["*"]);
+    assert.equal(out.groups[0].rules.length, 1);
+    assert.equal(out.groups[0].rules[0].kind, "disallow");
+    assert.equal(out.groups[0].rules[0].pattern, "/private");
+  });
+
+  it("groups multiple User-agent lines before the first rule", () => {
+    // robots.txt allows `User-agent: A\nUser-agent: B\nDisallow: /`
+    // to share one group — both agents see the same rules.
+    const out = parseRobots(`
+User-agent: Googlebot
+User-agent: Bingbot
+Disallow: /search
+`);
+    assert.equal(out.groups.length, 1);
+    assert.deepEqual(out.groups[0].userAgents, ["googlebot", "bingbot"]);
+  });
+
+  it("starts a new group when a User-agent appears after rules", () => {
+    const out = parseRobots(`
+User-agent: A
+Disallow: /x
+User-agent: B
+Disallow: /y
+`);
+    assert.equal(out.groups.length, 2);
+    assert.deepEqual(out.groups[0].userAgents, ["a"]);
+    assert.deepEqual(out.groups[1].userAgents, ["b"]);
+  });
+
+  it("captures Crawl-delay per group", () => {
+    const out = parseRobots(`
+User-agent: *
+Crawl-delay: 5
+Disallow: /slow
+`);
+    assert.equal(out.groups[0].crawlDelaySec, 5);
+  });
+
+  it("ignores unknown directives", () => {
+    const out = parseRobots(`
+User-agent: *
+Sitemap: https://example.com/sitemap.xml
+Request-rate: 1/10s
+Host: example.com
+Disallow: /x
+`);
+    assert.equal(out.groups.length, 1);
+    assert.equal(out.groups[0].rules.length, 1);
+  });
+
+  it("tolerates CRLF line endings", () => {
+    const crlf = "User-agent: *\r\nDisallow: /x\r\n";
+    const out = parseRobots(crlf);
+    assert.equal(out.groups[0].userAgents[0], "*");
+    assert.equal(out.groups[0].rules[0].pattern, "/x");
+  });
+
+  it("is case-insensitive on directive names but not on values", () => {
+    const out = parseRobots(`
+USER-AGENT: Googlebot
+DISALLOW: /Search
+`);
+    assert.equal(out.groups[0].userAgents[0], "googlebot");
+    assert.equal(out.groups[0].rules[0].pattern, "/Search"); // case preserved
+  });
+
+  it("skips malformed lines (no colon, empty directive)", () => {
+    const out = parseRobots(`
+garbage
+User-agent: *
+: empty directive
+Disallow: /ok
+`);
+    assert.equal(out.groups.length, 1);
+    assert.equal(out.groups[0].rules.length, 1);
+    assert.equal(out.groups[0].rules[0].pattern, "/ok");
+  });
+});
+
+// --- selectGroup -----------------------------------------------------------
+
+describe("selectGroup — agent selection", () => {
+  const robots = parseRobots(`
+User-agent: *
+Disallow: /wildcard
+
+User-agent: Googlebot
+Disallow: /google
+
+User-agent: Googlebot-News
+Disallow: /googlenews
+`);
+
+  it("picks the exact-match group first", () => {
+    const group = selectGroup(robots, "Googlebot");
+    assert.ok(group);
+    assert.deepEqual(group!.userAgents, ["googlebot"]);
+  });
+
+  it("is case-insensitive on the input agent", () => {
+    const group = selectGroup(robots, "GOOGLEBOT");
+    assert.ok(group);
+    assert.deepEqual(group!.userAgents, ["googlebot"]);
+  });
+
+  it("picks the longest-prefix group when no exact match", () => {
+    // Googlebot-News-Images isn't listed; Googlebot-News is the
+    // longest matching prefix.
+    const group = selectGroup(robots, "Googlebot-News-Images");
+    assert.ok(group);
+    assert.deepEqual(group!.userAgents, ["googlebot-news"]);
+  });
+
+  it("falls back to `*` when no prefix matches", () => {
+    const group = selectGroup(robots, "MyBot/1.0");
+    assert.ok(group);
+    assert.deepEqual(group!.userAgents, ["*"]);
+  });
+
+  it("returns null when robots has no groups at all", () => {
+    assert.equal(selectGroup(parseRobots(""), "anyone"), null);
+  });
+
+  it("returns null when no group matches and no `*` exists", () => {
+    const onlySpecific = parseRobots(`
+User-agent: Googlebot
+Disallow: /
+`);
+    assert.equal(selectGroup(onlySpecific, "MyBot"), null);
+  });
+});
+
+// --- isAllowedByRobots -----------------------------------------------------
+
+describe("isAllowedByRobots — rule evaluation", () => {
+  it("defaults to allowed when robots is empty", () => {
+    const robots = parseRobots("");
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/anything"), true);
+  });
+
+  it("blocks a plain prefix Disallow", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /private
+`);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/private/a"), false);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/public"), true);
+  });
+
+  it("allows when Allow and Disallow tie", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /foo
+Allow: /foo
+`);
+    // Tie goes to Allow, matching the IETF draft's resolution.
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/foo/bar"), true);
+  });
+
+  it("picks longer-prefix rule on conflict", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /foo
+Allow: /foo/public
+`);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/foo/private"), false);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/foo/public/x"), true);
+  });
+
+  it("treats an empty `Disallow:` as allow-all", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow:
+`);
+    // Per spec: `Disallow:` with empty value means nothing is
+    // disallowed. Our parser normalizes this and the evaluator
+    // must still allow everything.
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/anything"), true);
+  });
+
+  it("blocks everything on `Disallow: /`", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /
+`);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/a"), false);
+    assert.equal(isAllowedByRobots(robots, "MyBot", "/"), false);
+  });
+
+  it("applies the group selected by longest-prefix agent", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /star
+
+User-agent: Special
+Disallow: /special
+`);
+    // Special bot sees its own group's rules, not the `*`
+    // rules — robots.txt semantics don't union groups.
+    assert.equal(isAllowedByRobots(robots, "Special", "/star"), true);
+    assert.equal(isAllowedByRobots(robots, "Special", "/special"), false);
+    // Other bots fall back to `*`.
+    assert.equal(isAllowedByRobots(robots, "Other", "/star"), false);
+    assert.equal(isAllowedByRobots(robots, "Other", "/special"), true);
+  });
+});
+
+// --- matchesPattern (wildcards) --------------------------------------------
+
+describe("matchesPattern — wildcards + anchors", () => {
+  it("treats `*` as any-char-sequence", () => {
+    assert.notEqual(matchesPattern("/a/*/c", "/a/b/c"), -1);
+    assert.notEqual(matchesPattern("/a/*/c", "/a/bbb/c"), -1);
+    assert.notEqual(matchesPattern("/*.php", "/foo/bar.php"), -1);
+  });
+
+  it("treats end-anchor `$` as exact-end match", () => {
+    assert.notEqual(matchesPattern("/foo$", "/foo"), -1);
+    assert.equal(matchesPattern("/foo$", "/foo/"), -1);
+    assert.equal(matchesPattern("/foo$", "/foo/bar"), -1);
+    assert.notEqual(matchesPattern("/foo.php$", "/foo.php"), -1);
+    assert.equal(matchesPattern("/foo.php$", "/foo.php?q=1"), -1);
+  });
+
+  it("escapes regex metacharacters in literal portions", () => {
+    // `.` in the pattern must match literal dot, not any char.
+    assert.notEqual(matchesPattern("/foo.bar", "/foo.bar"), -1);
+    assert.equal(matchesPattern("/foo.bar", "/fooXbar"), -1);
+  });
+
+  it("returns -1 for an empty pattern (Disallow: allow-all)", () => {
+    assert.equal(matchesPattern("", "/anything"), -1);
+  });
+
+  it("ranks longer patterns higher", () => {
+    const short = matchesPattern("/a", "/a/b/c");
+    const long = matchesPattern("/a/b", "/a/b/c");
+    assert.ok(short > 0);
+    assert.ok(long > short);
+  });
+});
+
+describe("isAllowedByRobots — wildcards + anchors", () => {
+  it("handles wildcard Disallow", () => {
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /*.pdf$
+`);
+    assert.equal(isAllowedByRobots(robots, "B", "/report.pdf"), false);
+    assert.equal(isAllowedByRobots(robots, "B", "/report.html"), true);
+    // Query string → doesn't end in .pdf, allowed.
+    assert.equal(isAllowedByRobots(robots, "B", "/report.pdf?v=1"), true);
+  });
+
+  it("blocks tracker-style paths with wildcard Allow", () => {
+    // Classic pattern: block everything under /api/, but allow
+    // public subtrees.
+    const robots = parseRobots(`
+User-agent: *
+Disallow: /api/
+Allow: /api/public/
+`);
+    assert.equal(isAllowedByRobots(robots, "B", "/api/private"), false);
+    assert.equal(isAllowedByRobots(robots, "B", "/api/public/x"), true);
+  });
+});

--- a/test/sources/test_rss.ts
+++ b/test/sources/test_rss.ts
@@ -1,0 +1,426 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  rssFetcher,
+  normalizeToSourceItems,
+  updateCursor,
+  RSS_CURSOR_KEY,
+  RssFetcherError,
+} from "../../server/sources/fetchers/rss.js";
+import type { Source, SourceState } from "../../server/sources/types.js";
+import type { FetcherDeps } from "../../server/sources/fetchers/index.js";
+import {
+  HostRateLimiter,
+  type RateLimiterDeps,
+} from "../../server/sources/rateLimiter.js";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  type HttpFetcherDeps,
+  type RobotsProvider,
+} from "../../server/sources/httpFetcher.js";
+import type { ParsedFeed } from "../../server/sources/fetchers/rssParser.js";
+
+// --- helpers -------------------------------------------------------------
+
+function makeSource(over: Partial<Source> = {}): Source {
+  return {
+    slug: "test-feed",
+    title: "Test Feed",
+    url: "https://example.com/feed.xml",
+    fetcherKind: "rss",
+    fetcherParams: {},
+    schedule: "daily",
+    categories: ["tech-news", "general"],
+    maxItemsPerFetch: 30,
+    addedAt: "2026-04-01T00:00:00Z",
+    notes: "",
+    ...over,
+  };
+}
+
+function makeState(over: Partial<SourceState> = {}): SourceState {
+  return {
+    slug: "test-feed",
+    lastFetchedAt: null,
+    cursor: {},
+    consecutiveFailures: 0,
+    nextAttemptAt: null,
+    ...over,
+  };
+}
+
+function makeFeed(
+  items: Array<{
+    title: string;
+    link: string | null;
+    publishedAt?: string | null;
+    summary?: string | null;
+    content?: string | null;
+    feedId?: string | null;
+  }>,
+): ParsedFeed {
+  return {
+    kind: "rss",
+    title: "Test",
+    items: items.map((i) => ({
+      feedId: i.feedId ?? null,
+      title: i.title,
+      link: i.link,
+      publishedAt: i.publishedAt ?? null,
+      summary: i.summary ?? null,
+      content: i.content ?? null,
+    })),
+  };
+}
+
+// --- normalizeToSourceItems ---------------------------------------------
+
+describe("normalizeToSourceItems — basic", () => {
+  it("converts ParsedFeed items into SourceItems with categories", () => {
+    const feed = makeFeed([
+      {
+        title: "One",
+        link: "https://example.com/1",
+        publishedAt: "2026-04-02T12:00:00Z",
+        summary: "s1",
+      },
+    ]);
+    const source = makeSource();
+    const items = normalizeToSourceItems(feed, source, {}, 30);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "One");
+    assert.equal(items[0].url, "https://example.com/1");
+    assert.deepEqual(items[0].categories, ["tech-news", "general"]);
+    assert.equal(items[0].sourceSlug, "test-feed");
+    assert.equal(items[0].summary, "s1");
+  });
+
+  it("computes a stableItemId from the normalized URL, not the feedId", () => {
+    // Two items with different feedIds but the same canonical URL
+    // (e.g. utm stripped) should share an id.
+    const feed = makeFeed([
+      {
+        title: "A",
+        link: "https://example.com/1?utm_source=hn",
+        feedId: "id-1",
+        publishedAt: "2026-04-02T12:00:00Z",
+      },
+      {
+        title: "B",
+        link: "https://example.com/1?utm_source=twitter",
+        feedId: "id-2",
+        publishedAt: "2026-04-02T13:00:00Z",
+      },
+    ]);
+    const source = makeSource();
+    const items = normalizeToSourceItems(feed, source, {}, 30);
+    assert.equal(items.length, 2);
+    // Normalized URL strips utm_*, so both items hash to the same id.
+    assert.equal(items[0].id, items[1].id);
+    assert.equal(items[0].url, items[1].url);
+  });
+
+  it("drops items with no link", () => {
+    const feed = makeFeed([
+      { title: "no link", link: null },
+      {
+        title: "has link",
+        link: "https://example.com/1",
+        publishedAt: "2026-04-02T12:00:00Z",
+      },
+    ]);
+    const items = normalizeToSourceItems(feed, makeSource(), {}, 30);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "has link");
+  });
+
+  it("drops items with an unparseable link", () => {
+    const feed = makeFeed([
+      { title: "bad", link: "not a url" },
+      { title: "good", link: "https://example.com/1" },
+    ]);
+    const items = normalizeToSourceItems(feed, makeSource(), {}, 30);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "good");
+  });
+
+  it("caps output to maxItemsPerFetch", () => {
+    const feed = makeFeed(
+      Array.from({ length: 50 }, (_, i) => ({
+        title: `item${i}`,
+        link: `https://example.com/${i}`,
+        publishedAt: new Date(Date.UTC(2026, 3, i + 1)).toISOString(),
+      })),
+    );
+    const items = normalizeToSourceItems(feed, makeSource(), {}, 10);
+    assert.equal(items.length, 10);
+  });
+
+  it("synthesizes a fetch-time publishedAt when the feed omits one", () => {
+    const feed = makeFeed([
+      { title: "no date", link: "https://example.com/1", publishedAt: null },
+    ]);
+    const items = normalizeToSourceItems(feed, makeSource(), {}, 30);
+    assert.equal(items.length, 1);
+    // Must be a valid ISO timestamp.
+    assert.ok(Number.isFinite(Date.parse(items[0].publishedAt)));
+  });
+});
+
+describe("normalizeToSourceItems — cursor filtering", () => {
+  it("drops items at or older than the cursor timestamp", () => {
+    const feed = makeFeed([
+      {
+        title: "old",
+        link: "https://example.com/old",
+        publishedAt: "2026-04-01T00:00:00Z",
+      },
+      {
+        title: "equal",
+        link: "https://example.com/equal",
+        publishedAt: "2026-04-02T00:00:00Z",
+      },
+      {
+        title: "new",
+        link: "https://example.com/new",
+        publishedAt: "2026-04-03T00:00:00Z",
+      },
+    ]);
+    const cursor = { [RSS_CURSOR_KEY]: "2026-04-02T00:00:00Z" };
+    const items = normalizeToSourceItems(feed, makeSource(), cursor, 30);
+    assert.deepEqual(
+      items.map((i) => i.title),
+      ["new"],
+    );
+  });
+
+  it("keeps items with no publishedAt even when cursor is set", () => {
+    // Don't lose items forever just because the feed omitted a date.
+    const feed = makeFeed([
+      { title: "no date", link: "https://example.com/1", publishedAt: null },
+    ]);
+    const cursor = { [RSS_CURSOR_KEY]: "2026-04-01T00:00:00Z" };
+    const items = normalizeToSourceItems(feed, makeSource(), cursor, 30);
+    assert.equal(items.length, 1);
+  });
+
+  it("treats a malformed cursor timestamp as no cursor (everything passes)", () => {
+    const feed = makeFeed([
+      {
+        title: "one",
+        link: "https://example.com/1",
+        publishedAt: "2026-04-01T00:00:00Z",
+      },
+    ]);
+    const cursor = { [RSS_CURSOR_KEY]: "not-a-date" };
+    const items = normalizeToSourceItems(feed, makeSource(), cursor, 30);
+    assert.equal(items.length, 1);
+  });
+
+  it("passes everything when cursor is empty", () => {
+    const feed = makeFeed([
+      {
+        title: "one",
+        link: "https://example.com/1",
+        publishedAt: "2026-04-01T00:00:00Z",
+      },
+      {
+        title: "two",
+        link: "https://example.com/2",
+        publishedAt: "2026-04-02T00:00:00Z",
+      },
+    ]);
+    const items = normalizeToSourceItems(feed, makeSource(), {}, 30);
+    assert.equal(items.length, 2);
+  });
+});
+
+// --- updateCursor --------------------------------------------------------
+
+describe("updateCursor", () => {
+  it("advances to the newest publishedAt across all items", () => {
+    const feed = makeFeed([
+      { title: "a", link: "x", publishedAt: "2026-04-01T00:00:00Z" },
+      { title: "b", link: "x", publishedAt: "2026-04-03T00:00:00Z" },
+      { title: "c", link: "x", publishedAt: "2026-04-02T00:00:00Z" },
+    ]);
+    const cursor = updateCursor({}, feed);
+    assert.equal(cursor[RSS_CURSOR_KEY], "2026-04-03T00:00:00.000Z");
+  });
+
+  it("considers filtered-out items too, preventing infinite re-emission", () => {
+    // Even if `normalizeToSourceItems` emitted nothing (all
+    // items were already seen), the cursor should advance to
+    // the newest observed timestamp so we don't re-check.
+    const feed = makeFeed([
+      { title: "a", link: "x", publishedAt: "2026-04-01T00:00:00Z" },
+    ]);
+    const cursor = updateCursor(
+      { [RSS_CURSOR_KEY]: "2026-03-15T00:00:00Z" },
+      feed,
+    );
+    assert.equal(cursor[RSS_CURSOR_KEY], "2026-04-01T00:00:00.000Z");
+  });
+
+  it("leaves an already-newer cursor alone", () => {
+    const feed = makeFeed([
+      { title: "old", link: "x", publishedAt: "2026-04-01T00:00:00Z" },
+    ]);
+    const existing = { [RSS_CURSOR_KEY]: "2026-04-10T00:00:00Z" };
+    const cursor = updateCursor(existing, feed);
+    // Must not roll backwards even if the feed republished older items.
+    assert.equal(cursor[RSS_CURSOR_KEY], "2026-04-10T00:00:00Z");
+  });
+
+  it("returns the unchanged cursor when no items carry a date", () => {
+    const feed = makeFeed([
+      { title: "a", link: "x", publishedAt: null },
+      { title: "b", link: "x", publishedAt: null },
+    ]);
+    const existing = { [RSS_CURSOR_KEY]: "2026-04-01T00:00:00Z" };
+    const cursor = updateCursor(existing, feed);
+    assert.equal(cursor[RSS_CURSOR_KEY], "2026-04-01T00:00:00Z");
+  });
+
+  it("preserves unrelated cursor keys", () => {
+    const feed = makeFeed([
+      { title: "a", link: "x", publishedAt: "2026-04-03T00:00:00Z" },
+    ]);
+    const existing = { [RSS_CURSOR_KEY]: "2026-04-01T00:00:00Z", etag: "abc" };
+    const cursor = updateCursor(existing, feed);
+    assert.equal(cursor.etag, "abc");
+    assert.equal(cursor[RSS_CURSOR_KEY], "2026-04-03T00:00:00.000Z");
+  });
+});
+
+// --- rssFetcher.fetch (end-to-end with stubbed HTTP) --------------------
+
+function controllableClock(start = 0): {
+  deps: RateLimiterDeps;
+  tick: (ms: number) => void;
+} {
+  const state = { t: start };
+  return {
+    deps: {
+      now: () => state.t,
+      sleep: (ms) => {
+        state.t += ms;
+        return Promise.resolve();
+      },
+    },
+    tick: (ms) => {
+      state.t += ms;
+    },
+  };
+}
+
+function makeFetcherDeps(
+  fetchImpl: typeof fetch,
+  robots: RobotsProvider = async () => null,
+): FetcherDeps {
+  const clock = controllableClock();
+  return {
+    http: {
+      fetchImpl,
+      robots,
+      rateLimiter: new HostRateLimiter(clock.deps),
+      rateLimiterDeps: clock.deps,
+      crawlDelayMs: () => 0,
+      timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+      onWillFetch: () => {},
+    } as HttpFetcherDeps,
+    now: () => Date.now(),
+  };
+}
+
+const RSS_BODY = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example</title>
+    <item>
+      <title>Hello</title>
+      <link>https://example.com/1</link>
+      <pubDate>Wed, 01 Apr 2026 12:00:00 GMT</pubDate>
+      <description>greeting</description>
+    </item>
+  </channel>
+</rss>`;
+
+describe("rssFetcher.fetch", () => {
+  it("fetches, parses, and returns a SourceItem + updated cursor", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(RSS_BODY, { status: 200 });
+    const source = makeSource();
+    const state = makeState();
+    const result = await rssFetcher.fetch(
+      source,
+      state,
+      makeFetcherDeps(fetchImpl),
+    );
+    assert.equal(result.items.length, 1);
+    assert.equal(result.items[0].title, "Hello");
+    assert.equal(result.items[0].url, "https://example.com/1");
+    assert.equal(result.cursor[RSS_CURSOR_KEY], "2026-04-01T12:00:00.000Z");
+  });
+
+  it("respects the cursor across successive fetches", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(RSS_BODY, { status: 200 });
+    const deps = makeFetcherDeps(fetchImpl);
+    const source = makeSource();
+    // First call: no cursor, emit the one item.
+    const first = await rssFetcher.fetch(source, makeState(), deps);
+    assert.equal(first.items.length, 1);
+    // Second call: cursor advanced, same body returns no new items.
+    const second = await rssFetcher.fetch(
+      source,
+      makeState({ cursor: first.cursor }),
+      deps,
+    );
+    assert.equal(second.items.length, 0);
+  });
+
+  it("throws RssFetcherError on non-2xx response", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("not found", { status: 404 });
+    await assert.rejects(
+      () =>
+        rssFetcher.fetch(makeSource(), makeState(), makeFetcherDeps(fetchImpl)),
+      (err: unknown) => err instanceof RssFetcherError && err.status === 404,
+    );
+  });
+
+  it("throws RssFetcherError when the body is not parseable as a feed", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("<html>not a feed</html>", { status: 200 });
+    await assert.rejects(
+      () =>
+        rssFetcher.fetch(makeSource(), makeState(), makeFetcherDeps(fetchImpl)),
+      /did not parse as RSS/,
+    );
+  });
+
+  it("propagates RobotsDisallowedError via fetchPolite", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(RSS_BODY, { status: 200 });
+    const robots: RobotsProvider = async () =>
+      "User-agent: *\nDisallow: /feed.xml\n";
+    await assert.rejects(
+      () =>
+        rssFetcher.fetch(
+          makeSource(),
+          makeState(),
+          makeFetcherDeps(fetchImpl, robots),
+        ),
+      /robots.txt disallows/,
+    );
+  });
+
+  it("registers itself as the `rss` fetcher on import", async () => {
+    const { getFetcher } =
+      await import("../../server/sources/fetchers/index.js");
+    const fetcher = getFetcher("rss");
+    assert.ok(fetcher);
+    assert.equal(fetcher!.kind, "rss");
+  });
+});

--- a/test/sources/test_rssParser.ts
+++ b/test/sources/test_rssParser.ts
@@ -1,0 +1,338 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseFeed } from "../../server/sources/fetchers/rssParser.js";
+
+// --- RSS 2.0 ------------------------------------------------------------
+
+describe("parseFeed — RSS 2.0", () => {
+  const RSS_BASIC = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>First post</title>
+      <link>https://example.com/1</link>
+      <guid>https://example.com/1</guid>
+      <pubDate>Wed, 01 Apr 2026 12:00:00 GMT</pubDate>
+      <description>Short summary of first post.</description>
+    </item>
+    <item>
+      <title>Second post</title>
+      <link>https://example.com/2</link>
+      <guid>https://example.com/2</guid>
+      <pubDate>Thu, 02 Apr 2026 09:30:00 GMT</pubDate>
+      <description>Summary for second.</description>
+    </item>
+  </channel>
+</rss>`;
+
+  it("parses basic RSS 2.0", () => {
+    const feed = parseFeed(RSS_BASIC);
+    assert.ok(feed);
+    assert.equal(feed!.kind, "rss");
+    assert.equal(feed!.title, "Example Feed");
+    assert.equal(feed!.items.length, 2);
+    assert.equal(feed!.items[0].title, "First post");
+    assert.equal(feed!.items[0].link, "https://example.com/1");
+    assert.equal(feed!.items[0].feedId, "https://example.com/1");
+    assert.equal(feed!.items[0].summary, "Short summary of first post.");
+    // RFC 822 → ISO 8601 conversion
+    assert.match(feed!.items[0].publishedAt!, /2026-04-01T12:00:00/);
+  });
+
+  it("normalizes multiple date formats to ISO", () => {
+    // A feed in the wild with a non-standard date — we pass
+    // through whatever Date.parse can handle.
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>item</title>
+      <link>https://x.com/1</link>
+      <pubDate>2026-04-01T12:00:00Z</pubDate>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items[0].publishedAt, "2026-04-01T12:00:00.000Z");
+  });
+
+  it("preserves the raw date string when parsing fails", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>item</title>
+      <link>https://x.com/1</link>
+      <pubDate>not-a-date</pubDate>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    // Fallback: passes the junk through rather than dropping.
+    assert.equal(feed!.items[0].publishedAt, "not-a-date");
+  });
+
+  it("handles CDATA-wrapped description", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>item</title>
+      <link>https://x.com/1</link>
+      <description><![CDATA[<p>HTML <strong>body</strong>.</p>]]></description>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.match(feed!.items[0].summary!, /HTML.*body/);
+  });
+
+  it("picks up content:encoded as the full content body", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>item</title>
+      <link>https://x.com/1</link>
+      <description>short summary</description>
+      <content:encoded><![CDATA[<p>Full body HTML.</p>]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items[0].summary, "short summary");
+    assert.match(feed!.items[0].content!, /Full body/);
+  });
+
+  it("drops entries with no title", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <link>https://x.com/titleless</link>
+    </item>
+    <item>
+      <title>has title</title>
+      <link>https://x.com/1</link>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items.length, 1);
+    assert.equal(feed!.items[0].title, "has title");
+  });
+
+  it("handles feeds with a single item (not wrapped in array)", () => {
+    // Without `isArray` hinting, fast-xml-parser collapses
+    // single-element lists into objects. The parser must coerce
+    // to an array.
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>only one</title>
+      <link>https://x.com/1</link>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items.length, 1);
+  });
+
+  it("falls back to link when guid is absent", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>x</title>
+      <link>https://x.com/1</link>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items[0].feedId, "https://x.com/1");
+  });
+});
+
+// --- RSS 1.0 / RDF ------------------------------------------------------
+
+describe("parseFeed — RSS 1.0 (RDF)", () => {
+  it("parses an RDF feed with top-level items", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns="http://purl.org/rss/1.0/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel rdf:about="https://example.com">
+    <title>RDF Feed</title>
+    <link>https://example.com</link>
+  </channel>
+  <item rdf:about="https://example.com/1">
+    <title>RDF item</title>
+    <link>https://example.com/1</link>
+    <description>summary</description>
+  </item>
+</rdf:RDF>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.kind, "rss");
+    assert.equal(feed!.title, "RDF Feed");
+    assert.equal(feed!.items.length, 1);
+    assert.equal(feed!.items[0].title, "RDF item");
+  });
+});
+
+// --- Atom 1.0 -----------------------------------------------------------
+
+describe("parseFeed — Atom 1.0", () => {
+  const ATOM_BASIC = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>Atom post</title>
+    <id>urn:uuid:1</id>
+    <link rel="alternate" href="https://example.com/1" />
+    <link rel="self" href="https://example.com/1.atom" />
+    <published>2026-04-01T12:00:00Z</published>
+    <summary>short</summary>
+    <content type="html">full body</content>
+  </entry>
+</feed>`;
+
+  it("parses basic Atom", () => {
+    const feed = parseFeed(ATOM_BASIC);
+    assert.ok(feed);
+    assert.equal(feed!.kind, "atom");
+    assert.equal(feed!.title, "Atom Feed");
+    assert.equal(feed!.items.length, 1);
+    assert.equal(feed!.items[0].title, "Atom post");
+    assert.equal(feed!.items[0].feedId, "urn:uuid:1");
+    assert.equal(feed!.items[0].summary, "short");
+    assert.equal(feed!.items[0].content, "full body");
+  });
+
+  it("prefers rel=alternate over rel=self for the link", () => {
+    const feed = parseFeed(ATOM_BASIC);
+    assert.ok(feed);
+    // Alternate (web URL) wins; self (feed URL) is ignored.
+    assert.equal(feed!.items[0].link, "https://example.com/1");
+  });
+
+  it("falls back to the first link when no rel=alternate present", () => {
+    const xml = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title>
+  <entry>
+    <title>x</title>
+    <id>u1</id>
+    <link rel="related" href="https://example.com/related" />
+    <link rel="enclosure" href="https://example.com/audio.mp3" />
+  </entry>
+</feed>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    // First link wins when none is "alternate".
+    assert.equal(feed!.items[0].link, "https://example.com/related");
+  });
+
+  it("uses <updated> when <published> is missing", () => {
+    const xml = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title>
+  <entry>
+    <title>x</title>
+    <id>u1</id>
+    <link href="https://example.com/1" />
+    <updated>2026-04-01T12:00:00Z</updated>
+  </entry>
+</feed>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items[0].publishedAt, "2026-04-01T12:00:00.000Z");
+  });
+
+  it("handles a plain <link>some-url</link> (no attrs)", () => {
+    // Some feeds are hand-written and don't use the attribute form.
+    const xml = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title>
+  <entry>
+    <title>x</title>
+    <id>u1</id>
+    <link>https://example.com/1</link>
+  </entry>
+</feed>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items[0].link, "https://example.com/1");
+  });
+});
+
+// --- malformed / edge cases --------------------------------------------
+
+describe("parseFeed — malformed / unusual input", () => {
+  it("returns null for empty input", () => {
+    assert.equal(parseFeed(""), null);
+    assert.equal(parseFeed("   \n   "), null);
+  });
+
+  it("returns null for non-XML garbage", () => {
+    assert.equal(parseFeed("not xml at all"), null);
+  });
+
+  it("returns null for well-formed XML that isn't a feed", () => {
+    assert.equal(parseFeed("<root><nope/></root>"), null);
+  });
+
+  it("tolerates a UTF-8 BOM at the start", () => {
+    const bom = "\uFEFF";
+    const xml = `${bom}<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>x</title>
+      <link>https://x.com/1</link>
+    </item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.equal(feed!.items.length, 1);
+  });
+
+  it("tolerates malformed XML that still has a feed-looking root", () => {
+    // fast-xml-parser is fairly lenient; we rely on that.
+    const xml = `<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item><title>x</title><link>https://x.com/1</link></item>
+  </channel>
+</rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+  });
+
+  it("returns an empty items array for a feed with no items", () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0"><channel><title>empty</title></channel></rss>`;
+    const feed = parseFeed(xml);
+    assert.ok(feed);
+    assert.deepEqual(feed!.items, []);
+  });
+});

--- a/test/sources/test_taxonomy.ts
+++ b/test/sources/test_taxonomy.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CATEGORY_SLUGS,
+  isCategorySlug,
+  normalizeCategories,
+} from "../../server/sources/taxonomy.js";
+
+describe("CATEGORY_SLUGS — shape pin", () => {
+  it("contains the phase-1 taxonomy with no duplicates", () => {
+    // A mutation that removes a slug would silently drop every
+    // source tagged with it. Pin the list explicitly so any edit
+    // lands in this test too.
+    assert.deepEqual(Array.from(CATEGORY_SLUGS), [
+      "tech-news",
+      "business-news",
+      "ai",
+      "security",
+      "devops",
+      "frontend",
+      "backend",
+      "ml-research",
+      "dependencies",
+      "product-updates",
+      "japanese",
+      "english",
+      "papers",
+      "general",
+      "startup",
+      "personal",
+    ]);
+  });
+
+  it("has no duplicates", () => {
+    assert.equal(new Set(CATEGORY_SLUGS).size, CATEGORY_SLUGS.length);
+  });
+});
+
+describe("isCategorySlug", () => {
+  it("accepts every slug in the taxonomy", () => {
+    for (const slug of CATEGORY_SLUGS) {
+      assert.equal(isCategorySlug(slug), true, `expected ${slug} accepted`);
+    }
+  });
+
+  it("rejects slugs not in the taxonomy", () => {
+    assert.equal(isCategorySlug("artificial-intelligence"), false);
+    assert.equal(isCategorySlug("AI"), false); // wrong case
+    assert.equal(isCategorySlug("tech_news"), false); // underscore
+    assert.equal(isCategorySlug(""), false);
+  });
+
+  it("rejects non-string values", () => {
+    assert.equal(isCategorySlug(null), false);
+    assert.equal(isCategorySlug(undefined), false);
+    assert.equal(isCategorySlug(42), false);
+    assert.equal(isCategorySlug(["ai"]), false);
+    assert.equal(isCategorySlug({ slug: "ai" }), false);
+  });
+});
+
+describe("normalizeCategories", () => {
+  it("returns only valid slugs from a mixed list", () => {
+    const out = normalizeCategories([
+      "ai",
+      "bogus",
+      "security",
+      "AI", // wrong case
+      "startup",
+    ]);
+    assert.deepEqual(out, ["ai", "security", "startup"]);
+  });
+
+  it("deduplicates repeats", () => {
+    const out = normalizeCategories(["ai", "ai", "security", "ai"]);
+    assert.deepEqual(out, ["ai", "security"]);
+  });
+
+  it("preserves input order on the first occurrence of each", () => {
+    // A sort-based dedup would fail this test; explicit order
+    // preservation matches what the classifier prompt asks for.
+    assert.deepEqual(normalizeCategories(["security", "ai", "papers"]), [
+      "security",
+      "ai",
+      "papers",
+    ]);
+  });
+
+  it("returns [] for non-array inputs", () => {
+    assert.deepEqual(normalizeCategories("ai"), []);
+    assert.deepEqual(normalizeCategories(null), []);
+    assert.deepEqual(normalizeCategories(undefined), []);
+    assert.deepEqual(normalizeCategories({ "0": "ai" }), []);
+  });
+
+  it("returns [] for an array of no valid slugs", () => {
+    assert.deepEqual(normalizeCategories(["foo", "bar", 42]), []);
+  });
+
+  it("returns [] for an empty array", () => {
+    assert.deepEqual(normalizeCategories([]), []);
+  });
+});

--- a/test/sources/test_taxonomy.ts
+++ b/test/sources/test_taxonomy.ts
@@ -28,6 +28,15 @@ describe("CATEGORY_SLUGS — shape pin", () => {
       "general",
       "startup",
       "personal",
+      "finance",
+      "design",
+      "productivity",
+      "science",
+      "health",
+      "gaming",
+      "climate",
+      "culture",
+      "policy",
     ]);
   });
 

--- a/test/sources/test_urls.ts
+++ b/test/sources/test_urls.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeUrl, stableItemId } from "../../server/sources/urls.js";
+
+describe("normalizeUrl — happy path", () => {
+  it("returns a canonical form for a plain URL", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/a/b"),
+      "https://example.com/a/b",
+    );
+  });
+
+  it("lowercases protocol and hostname", () => {
+    assert.equal(
+      normalizeUrl("HTTPS://EXAMPLE.COM/path"),
+      "https://example.com/path",
+    );
+  });
+
+  it("drops the fragment", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/p#section"),
+      "https://example.com/p",
+    );
+  });
+
+  it("collapses a trailing slash on non-root paths", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/path/"),
+      "https://example.com/path",
+    );
+  });
+
+  it("preserves the root slash", () => {
+    // "/"-only path is semantically different from no path; don't
+    // collapse it to empty.
+    assert.equal(normalizeUrl("https://example.com/"), "https://example.com/");
+  });
+
+  it("drops default ports", () => {
+    assert.equal(
+      normalizeUrl("https://example.com:443/x"),
+      "https://example.com/x",
+    );
+    assert.equal(
+      normalizeUrl("http://example.com:80/x"),
+      "http://example.com/x",
+    );
+  });
+
+  it("keeps non-default ports", () => {
+    assert.equal(
+      normalizeUrl("https://example.com:8443/x"),
+      "https://example.com:8443/x",
+    );
+  });
+});
+
+describe("normalizeUrl — tracking params", () => {
+  it("strips utm_* params", () => {
+    const out = normalizeUrl(
+      "https://example.com/x?utm_source=hn&utm_medium=rss&utm_campaign=foo",
+    );
+    assert.equal(out, "https://example.com/x");
+  });
+
+  it("strips fbclid / gclid / msclkid", () => {
+    for (const param of ["fbclid", "gclid", "msclkid", "dclid", "yclid"]) {
+      const out = normalizeUrl(`https://example.com/x?${param}=xyz`);
+      assert.equal(out, "https://example.com/x", `expected ${param} stripped`);
+    }
+  });
+
+  it("strips mc_* mailchimp params", () => {
+    const out = normalizeUrl("https://example.com/x?mc_cid=abc&mc_eid=def");
+    assert.equal(out, "https://example.com/x");
+  });
+
+  it("preserves non-tracking query params", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/search?q=hello"),
+      "https://example.com/search?q=hello",
+    );
+  });
+
+  it("mixes tracking strip with preservation", () => {
+    assert.equal(
+      normalizeUrl(
+        "https://example.com/search?q=hello&utm_source=news&fbclid=zzz&lang=ja",
+      ),
+      "https://example.com/search?lang=ja&q=hello",
+    );
+  });
+
+  it("is case-insensitive on tracking param names", () => {
+    assert.equal(
+      normalizeUrl("https://example.com/x?UTM_Source=foo"),
+      "https://example.com/x",
+    );
+  });
+});
+
+describe("normalizeUrl — query param sorting", () => {
+  it("sorts remaining params alphabetically", () => {
+    // Sorting makes different-ordered links dedup correctly.
+    assert.equal(
+      normalizeUrl("https://example.com/x?z=1&a=2&m=3"),
+      "https://example.com/x?a=2&m=3&z=1",
+    );
+  });
+
+  it("preserves multi-value params in their relative order", () => {
+    // ?t=1&t=2 and ?t=2&t=1 are semantically different; we must
+    // not reorder within the same key.
+    const out = normalizeUrl("https://example.com/x?t=1&t=2&a=0");
+    assert.equal(out, "https://example.com/x?a=0&t=1&t=2");
+  });
+});
+
+describe("normalizeUrl — invalid input", () => {
+  it("returns null for empty / whitespace", () => {
+    assert.equal(normalizeUrl(""), null);
+    assert.equal(normalizeUrl("   "), null);
+  });
+
+  it("returns null for non-string input", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(normalizeUrl(null as any), null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.equal(normalizeUrl(42 as any), null);
+  });
+
+  it("returns null for malformed URLs", () => {
+    assert.equal(normalizeUrl("not a url"), null);
+    assert.equal(normalizeUrl("http://"), null);
+  });
+
+  it("parses uncommon but valid schemes", () => {
+    // File URLs are valid; the caller decides whether to register
+    // them. Normalizer should still produce a clean href.
+    const out = normalizeUrl("file:///tmp/x.html");
+    assert.equal(out, "file:///tmp/x.html");
+  });
+});
+
+describe("stableItemId", () => {
+  it("is deterministic for the same input", () => {
+    assert.equal(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/a"),
+    );
+  });
+
+  it("differs for different inputs", () => {
+    assert.notEqual(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/b"),
+    );
+  });
+
+  it("is always 8 hex chars (FNV-1a 32-bit)", () => {
+    for (const input of [
+      "",
+      "x",
+      "https://example.com/a",
+      "https://example.com/" + "x".repeat(1000),
+    ]) {
+      const id = stableItemId(input);
+      assert.equal(id.length, 8);
+      assert.match(id, /^[0-9a-f]{8}$/);
+    }
+  });
+
+  it("produces different ids for normalized vs unnormalized", () => {
+    // Sanity: the caller is expected to hash the normalized form
+    // so two different-looking inputs collapse to one id only
+    // when the caller does the normalize step.
+    assert.notEqual(
+      stableItemId("https://example.com/a"),
+      stableItemId("https://example.com/a?utm_source=x"),
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,6 +3151,22 @@ fast-wrap-ansi@^0.2.0:
   dependencies:
     fast-string-width "^3.0.2"
 
+fast-xml-builder@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
+  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+  dependencies:
+    path-expression-matcher "^1.1.3"
+
+fast-xml-parser@^5.5.12:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz#6e50e5a5bbb03c1dc72a9268a9bfe677b1b623b2"
+  integrity sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==
+  dependencies:
+    fast-xml-builder "^1.1.4"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
+
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
@@ -5157,6 +5173,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.1.3, path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -6214,6 +6235,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
 
 stubs@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Phase-1 follow-up **#2 of 5** to the source-registry foundation. Branches off **#190** (HTTP etiquette layer) which branches off **#188** (foundation). Adds the first concrete `SourceFetcher` — consumes RSS 2.0, Atom 1.0, and RSS 1.0 (RDF) feeds, normalizes every dialect into a single \`ParsedFeedItem\` shape, and emits only items newer than the cursor so the pipeline doesn't re-process old posts every run.

> **Depends on #188 + #190.** Stacks on #190 directly. Merge order: #188 → #190 → this.

## Dependency added

**`fast-xml-parser`** — zero-runtime-dep, ~5KB gzipped, battle-tested. Preferred over a handwritten minimal parser because correct XML entity / CDATA / namespace handling is genuinely tricky and real-world feeds vary too much for a tight regex parser. 50-line glue + 1 tiny dep beats 200 lines of fragile handwritten code.

## Module layout

| File | Role |
|---|---|
| `server/sources/fetchers/index.ts` | \`SourceFetcher\` interface + \`registerFetcher\` / \`getFetcher\` dispatcher |
| `server/sources/fetchers/rssParser.ts` | **Pure** XML → \`ParsedFeed\`. RSS 2.0, Atom 1.0, RSS 1.0 (RDF) all resolve to the same shape |
| `server/sources/fetchers/rss.ts` | Promise orchestrator: fetchPolite → parse → normalize → cursor |

## Parser coverage

- **RSS 2.0**: \`<item>\`, \`<title>\`, \`<link>\`, \`<guid>\`, \`<pubDate>\`, \`<description>\`, \`<content:encoded>\` for full-HTML body
- **Atom 1.0**: \`<entry>\`, \`<title>\`, \`<id>\`, \`<link href= rel=>\` (prefers \`rel=\"alternate\"\`, falls back to first usable \`href\`, also handles plain \`<link>url</link>\` string bodies), \`<published>\` / \`<updated>\`, \`<summary>\`, \`<content>\`
- **RDF**: reuses RSS 2.0 item parsing under \`<rdf:RDF>\`

Dates normalized to ISO-8601 via \`Date.parse\`; malformed dates fall through verbatim rather than disappearing. CDATA, attribute-bearing objects, and arrays all resolve transparently through the \`readString\` helper. Returns null on unparseable input or a non-feed root — pipeline treats null the same as \"no new items\".

## Cursor semantics (per #188 Q3)

Phase-1 dedup is per-source only; cross-source dedup is a later pipeline stage via \`stableItemId\`:

- Key: \`rss_last_seen_at\` (ISO string in \`SourceState.cursor\`)
- Items with \`publishedAt <= cursor\` are **dropped**
- Items with **no** \`publishedAt\` are **always kept** (don't lose items forever because a feed omitted a date)
- Cursor **only advances forwards** — a feed republishing older items never rolls the cursor back
- Cursor advances against the FULL parsed feed, not just the emitted items, so a quiet feed doesn't replay old posts after one republish

## Tests — 41 new cases

### `test_rssParser.ts` (~20)

- RSS 2.0 basic, date normalization (RFC 822 → ISO, RFC 3339, malformed passes through), CDATA description, content:encoded, titleless entries dropped, single-item feeds (isArray normalization), guid → link fallback for feedId
- RDF feeds with top-level items
- Atom basic, rel=alternate preference, first-link fallback, \`<updated>\` as publishedAt fallback, plain \`<link>url</link>\` body
- Malformed: empty, non-XML, valid XML that isn't a feed, BOM tolerance, missing items

### `test_rss.ts` (~21)

- \`normalizeToSourceItems\`: stableItemId from normalized URL not feedId (so utm-stripped duplicates collapse), null-link drop, unparseable-URL drop, \`maxItemsPerFetch\` cap, synthesized publishedAt
- Cursor filtering: at-or-older dropped, null-date kept, malformed cursor = pass-through, empty cursor passes all
- \`updateCursor\`: advances to newest, catches filtered-out items, never rolls backwards, preserves unrelated cursor keys, no-op when no dates
- End-to-end \`rssFetcher.fetch\` with stubbed HTTP: happy path, cursor carries across runs, non-2xx → RssFetcherError, unparseable body → error, robots disallow propagates, self-registration

## Issues caught during test authoring

1. **fast-xml-parser keeps namespace prefixes by default** → \`<content:encoded>\` lands as \`\"content:encoded\"\` (not \`encoded\`) and \`<rdf:RDF>\` as \`\"rdf:RDF\"\` (not \`RDF\`). Both now read the prefixed key first and fall back to the unprefixed form, so a future parser config change won't silently break these.
2. **With \`isArray: \"link\"\`, a bare \`<link>url</link>\` (no attrs) becomes a one-element array of STRINGS**. Initial \`resolveAtomLink\` skipped these because it only inspected records. Now handles strings in the candidate array too.
3. **Cognitive-complexity pushback** on the link resolver and the \`readString\` helper — refactored into discriminated-union outcome types and separate record / array helpers, each well under threshold.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` (0 errors, 2 pre-existing warnings inherited from #188's registry.ts)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — **1316/1316** passing (was 1275 on #190's branch; +41)

## Follow-ups (phase 1 continued)

- **#3** — github-releases + github-issues fetchers (REST JSON, same SourceFetcher interface)
- **#4** — arxiv fetcher (XML, reuses fast-xml-parser + parseFeed helpers) + Claude-side web-fetch / web-search
- **#5** — Classifier (Claude CLI spawn, 25-slug taxonomy)
- **#6** — Pipeline orchestration (fetch → dedup → summarize → write daily markdown)
- **#7** — \`manageSource\` plugin (Vue + Express)

Plan file: \`plans/feat-source-registry.md\`
Refs #166, #188, #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added source registry for registering and managing RSS/Atom feed sources with automatic categorization
  * Implemented daily automatic news aggregation from registered sources
  * Added web crawling compliance features including robots.txt respect and rate limiting
  * Added source archival system for organizing historical content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->