### PR TITLE
chore(log): add WebSearch progress + CSRF rejection logs

### DIFF
--- a/server/csrfGuard.ts
+++ b/server/csrfGuard.ts
@@ -17,6 +17,7 @@
 // Full design + threat model: plans/fix-server-csrf-origin-check.md
 
 import type { Request, Response, NextFunction } from "express";
+import { log } from "./logger/index.js";
 
 const SAFE_METHODS: ReadonlySet<string> = new Set(["GET", "HEAD", "OPTIONS"]);
 
@@ -74,5 +75,14 @@ export function requireSameOrigin(
     next();
     return;
   }
+  // Security-relevant event: an upstream caller just hit us from
+  // off-localhost with a state-changing method. Log it at warn so
+  // operators see it in both the console and the rotating file
+  // log even if the attack is otherwise silent on the wire.
+  log.warn("csrf", "rejected cross-origin request", {
+    origin,
+    method: req.method,
+    path: req.path,
+  });
   res.status(403).json({ error: "Forbidden: cross-origin request rejected" });
 }

--- a/server/tool-trace/index.ts
+++ b/server/tool-trace/index.ts
@@ -85,6 +85,85 @@ async function handleToolCall(
     ts: now.toISOString(),
   };
   await appendRecord(deps, record);
+  logToolCall(event);
+}
+
+// Emit an info-level log when a tool fires. WebSearch and WebFetch
+// get a little extra context (the query / URL) because those are the
+// two tools whose progress users most often want to watch in real
+// time.
+function logToolCall(event: ToolCallEvent): void {
+  if (event.toolName === "WebSearch") {
+    const query = extractQuery(event.args);
+    log.info("tool-trace", "web_search starting", {
+      toolUseId: event.toolUseId,
+      query: query ?? "<missing>",
+    });
+    return;
+  }
+  if (event.toolName === "WebFetch") {
+    const url = extractUrl(event.args);
+    log.info("tool-trace", "web_fetch starting", {
+      toolUseId: event.toolUseId,
+      url: url ?? "<missing>",
+    });
+    return;
+  }
+  log.debug("tool-trace", "tool_call", {
+    toolUseId: event.toolUseId,
+    toolName: event.toolName,
+  });
+}
+
+function extractUrl(args: unknown): string | null {
+  if (!args || typeof args !== "object") return null;
+  const record = args as Record<string, unknown>;
+  const raw = record.url;
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+// Emit progress on the result side. For WebSearch we specifically
+// log the saved `contentRef` so operators can follow the breadcrumb
+// from the server log straight to the on-disk search file.
+function logToolCallResult(
+  toolName: string,
+  event: ToolCallResultEvent,
+  classification:
+    | { kind: "pointer"; contentRef: string }
+    | { kind: "inline"; content: string; truncated: boolean },
+  searchContentRef: string | undefined,
+): void {
+  if (toolName === "WebSearch" && searchContentRef) {
+    log.info("tool-trace", "web_search saved", {
+      toolUseId: event.toolUseId,
+      contentRef: searchContentRef,
+      bodyLen: event.content.length,
+    });
+    return;
+  }
+  if (toolName === "WebSearch") {
+    // Save failed earlier → we already emitted a warn; record
+    // inline-fallback landing at info so the pair stays matched.
+    log.info("tool-trace", "web_search inlined (save failed)", {
+      toolUseId: event.toolUseId,
+      bodyLen: event.content.length,
+    });
+    return;
+  }
+  if (classification.kind === "pointer") {
+    log.debug("tool-trace", "tool_call_result pointer", {
+      toolUseId: event.toolUseId,
+      toolName,
+      contentRef: classification.contentRef,
+    });
+    return;
+  }
+  log.debug("tool-trace", "tool_call_result inline", {
+    toolUseId: event.toolUseId,
+    toolName,
+    bodyLen: event.content.length,
+    truncated: classification.truncated,
+  });
 }
 
 async function handleToolCallResult(
@@ -129,6 +208,7 @@ async function handleToolCallResult(
           truncated: classification.truncated,
         };
   await appendRecord(deps, record);
+  logToolCallResult(toolName, event, classification, searchContentRef);
 
   // Release the cache entry once consumed so long-lived sessions
   // don't accumulate stale tool_use ids.


### PR DESCRIPTION
## Summary

Adds log points the user flagged as missing after running #195 and reviewing the server output — specifically WebSearch real-time progress — and fixes one silent security event (CSRF rejection) found while auditing log coverage.

**Stacked on #195** (\`feat/tool-trace-persistence\`). Rebase / merge once #195 lands.

## Items to Confirm / Review

- **WebSearch log noise**: three info lines per search (starting / saved / [rare] inline-fallback). For a burst of parallel searches (8 in the kumamoto test) that's ~24 lines — acceptable for a personal dev tool, but flag if you want it quieter (move to debug).
- **CSRF log level**: warn. Could argue for info (it's the guard doing its job), but since this is an attack signal I lean warn so it shows on the default console.
- **Debug-level fallback for non-WebSearch tools**: keeps the default console clean while still recording everything in the JSON file sink (which is debug-level by default).

## User Prompt

> websearchの進捗状況もサーバログに出ると良いね。他、ログが足りないのもついでに補強して。

## Details

### tool-trace/index.ts

New log points in the driver, all structured with `log.<level>("tool-trace", msg, data)`:

| Event | Level | Payload |
|---|---|---|
| WebSearch tool_call arrives | info | `toolUseId`, `query` |
| WebSearch save succeeds | info | `toolUseId`, `contentRef`, `bodyLen` |
| WebSearch save failed, inlining | info | `toolUseId`, `bodyLen` |
| WebFetch tool_call arrives | info | `toolUseId`, `url` |
| Other tool_call | debug | `toolUseId`, `toolName` |
| tool_call_result (pointer) | debug | `toolUseId`, `toolName`, `contentRef` |
| tool_call_result (inline) | debug | `toolUseId`, `toolName`, `bodyLen`, `truncated` |

### csrfGuard.ts

Previously a silent 403 — with the rotating JSON file sink now live, adding a `log.warn("csrf", ...)` means the event is recoverable from `server/logs/server-YYYY-MM-DD.log` even if the attack otherwise leaves no trace. Payload: `origin`, `method`, `path`.

## Test plan

- [x] \`yarn format / lint / typecheck / build\` — 0 errors, 7 pre-existing \`.vue\` warnings only
- [x] \`yarn test\` — 1167 pass (no new tests in this PR — the additions are thin log calls on already-covered code paths)
- [x] Local server startup verified — standard workspace/sandbox/mcp/server lines render cleanly with the new format

## Out of scope

Other log gaps noticed during the audit (sessions.ts / roles.ts have zero logs; mcp-server.ts stdio subprocess needs its own strategy because stdout is reserved for JSON-RPC). Call out explicitly as follow-ups if you want them tackled next.