### PR TITLE
fix(stack-view): embed wiki at natural height in Stack view

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -117,6 +117,7 @@ const STACK_NATURAL_TOOLS = new Set<string>([
   "presentHtml",
   "presentDocument",
   "presentSpreadsheet",
+  "manageWiki",
 ]);
 
 function isStackNatural(toolName: string): boolean {


### PR DESCRIPTION
## Summary

In Stack view, wiki pages were wrapped in the fixed-height `PLUGIN_HEIGHT` container which produced an inner scrollbar and an iframe-like double-scroll UX. This 1-line fix adds `manageWiki` to the `STACK_NATURAL_TOOLS` allowlist so the existing \`stack-natural\` scoped CSS overrides (h-full → auto, overflow → visible, flex-1 → 0 0 auto) apply to wiki just like \`presentHtml\` / \`presentDocument\` / \`presentSpreadsheet\`. Wiki content now flows into the stack card at its full height.

## Items to Confirm / Review

- Only \`StackView.vue\` changed. All of wiki's own \`h-full\` / \`flex-1\` / \`overflow-y-auto\` classes get overridden by the existing scoped selectors — no wiki-side changes needed.
- Behaviour in the **single** view and the wiki plugin's Preview is untouched.

## User Prompt

> stack viewでwikiがiframe的にスクロールする。見づらいので高さを合わせて埋め込んでほしい

## Test plan

- [x] format / lint (0 errors) / typecheck / build
- [x] \`yarn test\` — 1149 pass (no new tests; pure allowlist addition)
- [x] \`yarn test:e2e\` — 112 pass
- [x] Manual browser check: open a chat in Stack view that has a wiki result → confirm the wiki card flows at full content height without an inner scrollbar (same feel as presentHtml / spreadsheet cards already in the allowlist)