### PR TITLE
perf(files): async tree walk + lazy-expand endpoint (#200, phase 1)

### DIFF
--- a/plans/perf-files-tree-async-200.md
+++ b/plans/perf-files-tree-async-200.md
@@ -1,0 +1,87 @@
+# perf(files): async `/api/files/tree` + new lazy-expand endpoint (#200)
+
+## Motivation
+
+`GET /api/files/tree` (`server/routes/files.ts:335`) recursively walks the entire workspace with `fs.statSync` + `fs.readdirSync` and returns one monolithic `TreeNode` JSON. Sync I/O **blocks the event loop** during the walk — all in-flight `/api/*` requests stall. Workspaces grow unbounded under `chat/`, `searches/`, `images/`, etc., so this gets worse over time.
+
+Issue #200's MVP: **(1) make it async** + **(2) add a lazy-expand endpoint** so the client can render top-level on load and fetch children on expand.
+
+## Phased plan
+
+### Phase 1 — this PR (server only)
+
+- `buildTree` → `buildTreeAsync` using `fs.promises` (no sync calls in the hot path).
+- New endpoint `GET /api/files/dir?path=<rel>` returning **shallow** listing (one directory's immediate children, no recursion).
+- Existing `GET /api/files/tree` kept for backwards compatibility, now also async. No response-shape change.
+- Unit tests for both paths (tmp dir fixture).
+
+Client untouched in phase 1. The event-loop-blocking risk — the actual operational concern — is fully addressed because the walk no longer holds the thread.
+
+### Phase 2 — follow-up PR (client)
+
+- `FilesView.vue` switches to lazy expand: mount → fetch root via `/api/files/dir?path=` → render top-level; on expand a dir node, fetch its children via `/api/files/dir?path=<rel>`, cache.
+- `TreeNode` children shape becomes `undefined | TreeNode[]` (undefined = not loaded yet).
+- E2E coverage for expand/collapse + cached-children behaviour.
+
+## Design details (phase 1)
+
+### `buildTreeAsync`
+
+Same traversal rules as the old sync version — identical security filters (`HIDDEN_DIRS`, `isSensitivePath`, no symlinks) and ordering (dirs before files, alphabetical within). Just swaps:
+
+```ts
+fs.statSync(absPath)   → await fsp.stat(absPath)
+readDirSafe(absPath)   → await readDirSafeAsync(absPath)
+statSafe(childAbs)     → await statSafeAsync(childAbs)
+```
+
+Children discovered in parallel via `Promise.all` on the mapped child-build promises. Ordering is re-applied after await because `Promise.all` preserves input order but our input is `readdir`'s raw order which may not match `stat`'s insertion.
+
+### `GET /api/files/dir?path=<rel>`
+
+Shallow variant — reads one directory, returns its immediate children only. Each child node has the same `TreeNode` shape minus the `children` field:
+
+```json
+{
+  "name": "chat",
+  "path": "chat",
+  "type": "dir",
+  "modifiedMs": 1712345678000,
+  "children": [
+    { "name": "foo.jsonl", "path": "chat/foo.jsonl", "type": "file", "size": 1234, "modifiedMs": ... },
+    { "name": "bar",       "path": "chat/bar",       "type": "dir",  "modifiedMs": ... }
+    // Note: no nested `children` — caller fetches those on demand.
+  ]
+}
+```
+
+- Empty `path` param (or missing) = workspace root.
+- Uses `resolveSafe` for traversal + sensitive-file rejection (same as every other endpoint).
+- Returns 404 if `path` resolves outside workspace / to a sensitive file / to a non-existent entry.
+- Returns 400 if `path` resolves to a file rather than a directory.
+
+### Backwards compatibility
+
+`GET /api/files/tree` response shape unchanged. Client gets the same full tree, just served async. Phase 2 changes the client; phase 1 is a pure optimisation.
+
+## Tests
+
+`test/routes/test_filesRoute.ts` already exists — extend:
+
+- `buildTreeAsync`: tmp dir with nested structure → assert order, hidden-dir filter, sensitive-file filter, symlink skip (all parity with existing sync tests if any)
+- `/api/files/dir`: shallow listing, traversal safety (`../`), missing path → 404, file path → 400, sensitive path → 404
+
+## Non-goals (phase 1)
+
+- Client-side lazy expand (phase 2)
+- Mtime cutoff / date windowing (#200 item 4, defer)
+- Collapsing heavy directories in tree view (#200 item 3, defer)
+- Streaming / paginated listing of huge directories (not needed until actually hit)
+
+## Rollout
+
+1. Branch `perf/files-tree-async-200` ✅
+2. Plan (this file) ✅
+3. Implement `buildTreeAsync` + `/api/files/dir` + tests
+4. Quality gates
+5. PR + follow-up issue for phase 2

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -2,7 +2,12 @@ import { Router, Request, Response } from "express";
 import fs from "fs";
 import path from "path";
 import { workspacePath } from "../workspace.js";
-import { statSafe, readDirSafe, resolveWithinRoot } from "../utils/fs.js";
+import {
+  statSafe,
+  statSafeAsync,
+  readDirSafeAsync,
+  resolveWithinRoot,
+} from "../utils/fs.js";
 import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
@@ -38,8 +43,9 @@ const SENSITIVE_EXTENSIONS = new Set([".pem", ".key", ".crt"]);
 // 1. `resolveSafe` returns null for sensitive paths so every
 //    endpoint (content, raw, anything future) rejects them with a
 //    generic 400.
-// 2. `buildTree` filters them out of `/files/tree`, so the file
-//    explorer never lists them in the first place.
+// 2. `buildTreeAsync` / `listDirShallow` filter them out of
+//    `/files/tree` and `/files/dir`, so the file explorer never
+//    lists them in the first place.
 // 3. The `.env` blocklist below is what keeps `/files/content`
 //    from leaking credentials on a matching-name lookup.
 //
@@ -192,9 +198,9 @@ export function classify(filename: string): ContentKind {
 const workspaceReal = fs.realpathSync(workspacePath);
 
 // Wraps the shared resolveWithinRoot helper with the additional
-// hidden-dir traversal check (e.g. `.git/config`). buildTree already
-// hides these from the listing, but the URL endpoints are reachable
-// directly so they need their own check.
+// hidden-dir traversal check (e.g. `.git/config`). `buildTreeAsync`
+// / `listDirShallow` hide these from the listing, but the URL
+// endpoints are reachable directly so they need their own check.
 function resolveSafe(relPath: string): string | null {
   const resolved = resolveWithinRoot(workspaceReal, relPath);
   if (!resolved) return null;
@@ -292,8 +298,30 @@ function pipeWithErrorHandling(
   stream.pipe(res);
 }
 
-function buildTree(absPath: string, relPath: string): TreeNode {
-  const stat = fs.statSync(absPath);
+// Async workspace tree walker — recurses through the workspace with
+// the same security filters as the original sync implementation
+// (hidden dirs, sensitive files, symlinks all rejected) and the same
+// ordering (dirs before files, alphabetical within type). Uses
+// `fs.promises` throughout so the walk never blocks the event loop,
+// and fans out each directory's children in parallel via
+// `Promise.all`.
+//
+// Exported so unit tests can point it at a tmp dir fixture.
+export async function buildTreeAsync(
+  absPath: string,
+  relPath: string,
+): Promise<TreeNode> {
+  const stat = await statSafeAsync(absPath);
+  if (!stat) {
+    // Caller is expected to have resolved `absPath` beforehand; if it
+    // vanished between resolve and walk, surface an empty dir node.
+    return {
+      name: path.basename(absPath),
+      path: relPath,
+      type: "dir",
+      children: [],
+    };
+  }
   if (!stat.isDirectory()) {
     return {
       name: path.basename(absPath),
@@ -303,22 +331,88 @@ function buildTree(absPath: string, relPath: string): TreeNode {
       modifiedMs: stat.mtimeMs,
     };
   }
-  const entries = readDirSafe(absPath);
-  const children: TreeNode[] = [];
-  for (const entry of entries) {
-    if (HIDDEN_DIRS.has(entry.name)) continue;
-    // Hide sensitive files (`.env`, `id_rsa`, `*.pem`, etc.) from
-    // the tree so they don't even show up in the file explorer
-    // for the user to click on. `resolveSafe` would refuse them
-    // too, but keeping them out of the listing is cleaner.
-    if (!entry.isDirectory() && isSensitivePath(entry.name)) continue;
-    if (entry.isSymbolicLink()) continue; // avoid escaping the workspace
-    const childAbs = path.join(absPath, entry.name);
-    const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
-    const childStat = statSafe(childAbs);
-    if (!childStat) continue;
-    children.push(buildTree(childAbs, childRel));
+  const entries = await readDirSafeAsync(absPath);
+  // Build every surviving child concurrently. Filter:
+  // skip hidden dirs, sensitive files, symlinks,
+  // and entries that fail to stat.
+  const childPromises: Promise<TreeNode | null>[] = entries.map(
+    async (entry): Promise<TreeNode | null> => {
+      if (HIDDEN_DIRS.has(entry.name)) return null;
+      if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
+      if (entry.isSymbolicLink()) return null;
+      const childAbs = path.join(absPath, entry.name);
+      const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
+      const childStat = await statSafeAsync(childAbs);
+      if (!childStat) return null;
+      return buildTreeAsync(childAbs, childRel);
+    },
+  );
+  const resolved = await Promise.all(childPromises);
+  const children = resolved.filter((c): c is TreeNode => c !== null);
+  children.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return {
+    name: relPath ? path.basename(relPath) : "",
+    path: relPath,
+    type: "dir",
+    modifiedMs: stat.mtimeMs,
+    children,
+  };
+}
+
+// Shallow variant: return the given directory's immediate children
+// only (no recursion). Used by the lazy-expand endpoint below — the
+// client fetches one level at a time as the user expands nodes,
+// so the initial Files view load cost is O(root entries) rather than
+// O(all workspace files).
+//
+// Exported for unit tests.
+export async function listDirShallow(
+  absPath: string,
+  relPath: string,
+): Promise<TreeNode> {
+  const stat = await statSafeAsync(absPath);
+  if (!stat || !stat.isDirectory()) {
+    return {
+      name: relPath ? path.basename(relPath) : "",
+      path: relPath,
+      type: "dir",
+      children: [],
+    };
   }
+  const entries = await readDirSafeAsync(absPath);
+  const childPromises: Promise<TreeNode | null>[] = entries.map(
+    async (entry): Promise<TreeNode | null> => {
+      if (HIDDEN_DIRS.has(entry.name)) return null;
+      if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
+      if (entry.isSymbolicLink()) return null;
+      const childAbs = path.join(absPath, entry.name);
+      const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
+      const childStat = await statSafeAsync(childAbs);
+      if (!childStat) return null;
+      if (childStat.isDirectory()) {
+        return {
+          name: entry.name,
+          path: childRel,
+          type: "dir",
+          modifiedMs: childStat.mtimeMs,
+          // No `children` field — caller fetches via another
+          // /api/files/dir call on expand.
+        };
+      }
+      return {
+        name: entry.name,
+        path: childRel,
+        type: "file",
+        size: childStat.size,
+        modifiedMs: childStat.mtimeMs,
+      };
+    },
+  );
+  const resolved = await Promise.all(childPromises);
+  const children = resolved.filter((c): c is TreeNode => c !== null);
   children.sort((a, b) => {
     if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
     return a.name.localeCompare(b.name);
@@ -334,17 +428,57 @@ function buildTree(absPath: string, relPath: string): TreeNode {
 
 router.get(
   "/files/tree",
-  (
+  async (
     _req: Request<object, unknown, unknown, object>,
     res: Response<TreeNode | ErrorResponse>,
   ) => {
     try {
-      const tree = buildTree(workspaceReal, "");
+      const tree = await buildTreeAsync(workspaceReal, "");
       res.json(tree);
     } catch (err) {
       res
         .status(500)
         .json({ error: `Failed to read workspace: ${errorMessage(err)}` });
+    }
+  },
+);
+
+// Lazy-expand endpoint. Returns one directory's immediate children
+// (no recursion) so the client can render the tree incrementally.
+// `path` is optional; empty / missing = workspace root.
+router.get(
+  "/files/dir",
+  async (
+    req: Request<object, unknown, unknown, PathQuery>,
+    res: Response<TreeNode | ErrorResponse>,
+  ) => {
+    const relPath = typeof req.query.path === "string" ? req.query.path : "";
+    // Empty path = root. resolveSafe handles "" by returning the
+    // workspace root; any traversal / sensitive / missing path → null.
+    const absPath = resolveSafe(relPath);
+    if (!absPath) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    const stat = await statSafeAsync(absPath);
+    if (!stat) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    if (!stat.isDirectory()) {
+      res.status(400).json({ error: "path is not a directory" });
+      return;
+    }
+    try {
+      const listing = await listDirShallow(
+        absPath,
+        path.relative(workspaceReal, absPath),
+      );
+      res.json(listing);
+    } catch (err) {
+      res
+        .status(500)
+        .json({ error: `Failed to read directory: ${errorMessage(err)}` });
     }
   },
 );

--- a/server/utils/fs.ts
+++ b/server/utils/fs.ts
@@ -17,9 +17,30 @@ export function statSafe(absPath: string): fs.Stats | null {
   }
 }
 
+// Async counterpart of `statSafe` for callers that want to stay off
+// the synchronous I/O path (e.g. tree-walk endpoints that would
+// otherwise block the event loop for the whole workspace).
+export async function statSafeAsync(absPath: string): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(absPath);
+  } catch {
+    return null;
+  }
+}
+
 export function readDirSafe(absPath: string): fs.Dirent[] {
   try {
     return fs.readdirSync(absPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+// Async counterpart of `readDirSafe`. Same "swallow ENOENT/EACCES,
+// return empty" contract.
+export async function readDirSafeAsync(absPath: string): Promise<fs.Dirent[]> {
+  try {
+    return await fs.promises.readdir(absPath, { withFileTypes: true });
   } catch {
     return [];
   }

--- a/test/routes/test_filesTreeAsync.ts
+++ b/test/routes/test_filesTreeAsync.ts
@@ -1,0 +1,190 @@
+// Unit tests for the async tree walk + shallow-listing helpers
+// extracted from `server/routes/files.ts` in #200.
+//
+// Both helpers are pure in the sense that they take an absolute path
+// + relative path and return a TreeNode — no Express coupling — so we
+// can exercise them against a tmp dir fixture without a running
+// server.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { buildTreeAsync, listDirShallow } from "../../server/routes/files.js";
+
+// Rough shape — the real TreeNode type isn't exported so we match on
+// the fields we assert against.
+interface TreeNodeShape {
+  name: string;
+  path: string;
+  type: "dir" | "file";
+  size?: number;
+  children?: TreeNodeShape[];
+}
+
+async function setupFixture(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "files-tree-"));
+  // root/
+  //   a.md
+  //   dir1/
+  //     b.md
+  //     sub/
+  //       c.md
+  //   .git/           ← hidden, should NOT appear
+  //     config
+  //   .env            ← sensitive, should NOT appear
+  //   id_rsa          ← sensitive, should NOT appear
+  //   ok.key          ← sensitive (ext), should NOT appear
+  await writeFile(path.join(root, "a.md"), "a");
+  await mkdir(path.join(root, "dir1", "sub"), { recursive: true });
+  await writeFile(path.join(root, "dir1", "b.md"), "b");
+  await writeFile(path.join(root, "dir1", "sub", "c.md"), "c");
+  await mkdir(path.join(root, ".git"));
+  await writeFile(path.join(root, ".git", "config"), "hidden");
+  await writeFile(path.join(root, ".env"), "SECRET=1");
+  await writeFile(path.join(root, "id_rsa"), "private");
+  await writeFile(path.join(root, "ok.key"), "key");
+  return root;
+}
+
+describe("buildTreeAsync", () => {
+  let root: string;
+
+  before(async () => {
+    root = await setupFixture();
+  });
+
+  after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("walks the workspace recursively and returns a rooted TreeNode", async () => {
+    const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+    assert.equal(tree.type, "dir");
+    assert.equal(tree.path, "");
+    assert.ok(Array.isArray(tree.children));
+  });
+
+  it("orders dirs before files, alphabetically within type", async () => {
+    const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+    const names = (tree.children ?? []).map((c) => c.name);
+    // dir1 (dir) should come before a.md (file).
+    assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
+  });
+
+  it("hides `.git/` hidden dir", async () => {
+    const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+    const names = (tree.children ?? []).map((c) => c.name);
+    assert.ok(!names.includes(".git"));
+  });
+
+  it("hides `.env`, `id_rsa`, and `*.key` sensitive files", async () => {
+    const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+    const names = (tree.children ?? []).map((c) => c.name);
+    assert.ok(!names.includes(".env"));
+    assert.ok(!names.includes("id_rsa"));
+    assert.ok(!names.includes("ok.key"));
+  });
+
+  it("recurses into subdirs (sub/c.md reachable via dir1/sub)", async () => {
+    const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+    const dir1 = (tree.children ?? []).find((c) => c.name === "dir1");
+    assert.ok(dir1);
+    const sub = (dir1.children ?? []).find((c) => c.name === "sub");
+    assert.ok(sub);
+    const c = (sub.children ?? []).find((n) => n.name === "c.md");
+    assert.ok(c);
+    assert.equal(c.type, "file");
+  });
+
+  it("skips symlinks (no workspace escape)", async () => {
+    // Create a symlink AFTER the fixture so it lives alongside the
+    // other children; buildTreeAsync should ignore it.
+    const linkTarget = await mkdtemp(path.join(os.tmpdir(), "files-link-"));
+    const linkPath = path.join(root, "escape");
+    try {
+      await symlink(linkTarget, linkPath);
+      const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
+      const names = (tree.children ?? []).map((c) => c.name);
+      assert.ok(!names.includes("escape"));
+    } finally {
+      await rm(linkPath, { force: true });
+      await rm(linkTarget, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a file node for a non-directory target", async () => {
+    const fileAbs = path.join(root, "a.md");
+    const node = (await buildTreeAsync(fileAbs, "a.md")) as TreeNodeShape;
+    assert.equal(node.type, "file");
+    assert.equal(node.path, "a.md");
+  });
+});
+
+describe("listDirShallow", () => {
+  let root: string;
+
+  before(async () => {
+    root = await setupFixture();
+  });
+
+  after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns only the immediate children, no nested `children` field on sub-dirs", async () => {
+    const node = (await listDirShallow(root, "")) as TreeNodeShape;
+    assert.equal(node.type, "dir");
+    const dir1 = (node.children ?? []).find((c) => c.name === "dir1");
+    assert.ok(dir1);
+    assert.equal(dir1.type, "dir");
+    // Shallow → no grandchildren materialised.
+    assert.equal(dir1.children, undefined);
+  });
+
+  it("applies the same hidden/sensitive filters as the recursive walk", async () => {
+    const node = (await listDirShallow(root, "")) as TreeNodeShape;
+    const names = (node.children ?? []).map((c) => c.name);
+    assert.ok(!names.includes(".git"));
+    assert.ok(!names.includes(".env"));
+    assert.ok(!names.includes("id_rsa"));
+    assert.ok(!names.includes("ok.key"));
+  });
+
+  it("orders dirs before files, alphabetically", async () => {
+    const node = (await listDirShallow(root, "")) as TreeNodeShape;
+    const names = (node.children ?? []).map((c) => c.name);
+    assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
+  });
+
+  it("reads a sub-directory when given its path", async () => {
+    const subAbs = path.join(root, "dir1");
+    const node = (await listDirShallow(subAbs, "dir1")) as TreeNodeShape;
+    const names = (node.children ?? []).map((c) => c.name);
+    // dir1 contains `b.md` (file) and `sub/` (dir).
+    assert.ok(names.includes("b.md"));
+    assert.ok(names.includes("sub"));
+    // sub/ reported as a dir, not expanded.
+    const sub = (node.children ?? []).find((c) => c.name === "sub");
+    assert.equal(sub?.type, "dir");
+    assert.equal(sub?.children, undefined);
+  });
+
+  it("returns an empty-dir node when the target is a file", async () => {
+    const fileAbs = path.join(root, "a.md");
+    const node = (await listDirShallow(fileAbs, "a.md")) as TreeNodeShape;
+    assert.equal(node.type, "dir");
+    assert.deepEqual(node.children, []);
+  });
+
+  it("returns an empty-dir node when the target doesn't exist", async () => {
+    const missing = path.join(root, "does-not-exist");
+    const node = (await listDirShallow(
+      missing,
+      "does-not-exist",
+    )) as TreeNodeShape;
+    assert.equal(node.type, "dir");
+    assert.deepEqual(node.children, []);
+  });
+});


### PR DESCRIPTION
## Summary

Unblock the event loop on \`GET /api/files/tree\` and ship the endpoint the phase-2 client change will consume. Client is **unchanged** in this PR — same response shape, same behaviour, the walk just no longer freezes the Node event loop.

This is **phase 1 of 2** per the plan in \`plans/perf-files-tree-async-200.md\`. Phase 2 will rewrite \`FilesView.vue\` to lazy-expand via the new \`/api/files/dir\` endpoint.

## Items to Confirm / Review

1. **Traversal-rule parity with the old sync walker**: hidden dirs (\`.git\`), sensitive files (\`.env\`, \`id_rsa\`, \`*.pem\`, \`*.key\`, \`credentials.json\`, etc.), and symlinks are all still rejected. Dirs-before-files alphabetical ordering preserved. Tests pin this.
2. **`listDirShallow` does not set a `children` field on sub-directory entries** — that's the phase-1 contract: "not loaded yet". Phase-2 client will treat \`children === undefined\` as "needs fetch" and \`children: []\` as "empty dir". OK to you?
3. **Old sync `buildTree` deleted** (not deprecated) since nothing else consumes it and the response shape of \`/api/files/tree\` is identical. Scream if you want a deprecation path.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/200　これ実装できる？

## Motivation

Measured on the current \`~/mulmoclaude/\` (38 chat sessions / 24MB, largest jsonl 16MB, plus \`searches/\` / \`images/\` / etc.): \`buildTree\` blocks the event loop for hundreds of ms on every Files view load. At year-scale workspace sizes (thousands of files) this stalls the whole server — not just \`/api/files/tree\`, but every concurrent \`/api/*\` call — for seconds at a time.

## Changes

### \`server/utils/fs.ts\`
- Added \`statSafeAsync\` + \`readDirSafeAsync\` as async counterparts of the existing sync helpers (same "swallow ENOENT/EACCES, return null / empty").

### \`server/routes/files.ts\`
- Replaced sync \`buildTree\` with async \`buildTreeAsync\`. Same security filters + ordering. Children fanned out via \`Promise.all\`.
- New \`listDirShallow\` — pure helper returning one directory's immediate children (no recursion), used by the new endpoint.
- New route \`GET /api/files/dir?path=<rel>\`:
  - empty/missing \`path\` → workspace root
  - traversal escape / sensitive path / missing → 404
  - non-directory target → 400
  - otherwise → shallow listing
- \`GET /api/files/tree\` now \`async\` but response shape unchanged (still returns the full tree).

### \`test/routes/test_filesTreeAsync.ts\` (new)

13 cases — all pure-helper, no Express coupling, tmp-dir fixture:

- \`buildTreeAsync\`: rooted walk / ordering / hidden-dir filter / sensitive-file filter / recursion / symlink skip / file target
- \`listDirShallow\`: shallow contract (no nested \`children\`) / filters parity / ordering / sub-directory lookup / file or missing target

### \`plans/perf-files-tree-async-200.md\` (new)

Design rationale, phase split, non-goals.

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors, 3 pre-existing \`.vue\` v-html warnings)
- [x] \`yarn typecheck\` / \`yarn build\`
- [x] \`yarn test\` — 1204 pass (13 new)
- [x] \`yarn test:e2e\` — 112 pass

## Phase 2 (follow-up)

- \`FilesView.vue\` switches to lazy-expand via \`/api/files/dir\`
- TreeNode shape becomes \`children: TreeNode[] | undefined\` on the client
- E2E coverage for expand / collapse / cached-children behaviour

## Summary by Sourcery

Convert the files API tree walker to an asynchronous implementation and introduce a shallow directory-listing endpoint to support future lazy-loading in the file explorer while preserving existing behaviour.

New Features:
- Add async workspace tree walker `buildTreeAsync` that mirrors existing traversal rules for the files API.
- Introduce `GET /api/files/dir` endpoint returning a shallow listing of a single directory for lazy expansion in the client.

Enhancements:
- Update `GET /api/files/tree` to use the async tree walker without changing its response shape.
- Add async filesystem helpers `statSafeAsync` and `readDirSafeAsync` to avoid blocking the Node event loop.
- Document the phased plan and design for the async tree walk and lazy-expand endpoint in a new plan file.

Tests:
- Add unit tests covering the async tree walker and shallow directory-listing helper, including ordering, filtering, recursion, and symlink handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new lazy-loading directory endpoint enabling on-demand file tree expansion with shallow, single-level directory listings.
  * Replaced synchronous file tree traversal with asynchronous implementation using concurrent directory operations and non-blocking filesystem calls.
  * Maintained existing `/files/tree` endpoint response format while leveraging new async infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->