### PR TITLE
UI changes: copy clipboard, cancel edit, validate script, ...

### DIFF
--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -142,6 +142,29 @@ router.post(
   },
 );
 
+interface UpdateScriptBody {
+  filePath: string;
+  script: MulmoScript;
+}
+
+router.post(
+  "/mulmo-script/update-script",
+  (req: Request<object, object, UpdateScriptBody>, res: Response) => {
+    const { filePath, script: updatedScript } = req.body;
+
+    if (!filePath || !updatedScript) {
+      res.status(400).json({ error: "filePath and script are required" });
+      return;
+    }
+
+    const absoluteFilePath = resolveStoryPath(filePath, res);
+    if (!absoluteFilePath) return;
+
+    fs.writeFileSync(absoluteFilePath, JSON.stringify(updatedScript, null, 2));
+    res.json({ ok: true });
+  },
+);
+
 router.get(
   "/mulmo-script/beat-image",
   async (

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -42,21 +42,32 @@
         </div>
       </div>
 
-      <details class="markdown-source">
-        <summary>Edit Markdown Source</summary>
-        <textarea
-          v-model="editableMarkdown"
-          class="markdown-editor"
-          spellcheck="false"
-        ></textarea>
+      <div class="bottom-bar-wrapper">
+        <details class="markdown-source">
+          <summary>Edit Markdown Source</summary>
+          <textarea
+            v-model="editableMarkdown"
+            class="markdown-editor"
+            spellcheck="false"
+          ></textarea>
+          <button
+            class="apply-btn"
+            :disabled="!hasChanges || saving"
+            @click="applyMarkdown"
+          >
+            {{ saving ? "Saving..." : "Apply Changes" }}
+          </button>
+        </details>
         <button
-          class="apply-btn"
-          :disabled="!hasChanges || saving"
-          @click="applyMarkdown"
+          class="copy-btn"
+          :title="copied ? 'Copied!' : 'Copy'"
+          @click="copyText"
         >
-          {{ saving ? "Saving..." : "Apply Changes" }}
+          <span class="material-icons">{{
+            copied ? "check" : "content_copy"
+          }}</span>
         </button>
-      </details>
+      </div>
     </template>
   </div>
 </template>
@@ -159,6 +170,20 @@ watch(
     });
   },
 );
+
+const copied = ref(false);
+
+async function copyText() {
+  try {
+    await navigator.clipboard.writeText(markdownContent.value);
+    copied.value = true;
+    setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  } catch {
+    // clipboard API may be blocked in some contexts
+  }
+}
 
 const {
   pdfDownloading,
@@ -324,6 +349,31 @@ watch(
   font-weight: bold;
   margin-top: 1em;
   margin-bottom: 0.5em;
+}
+
+.bottom-bar-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.copy-btn {
+  position: absolute;
+  bottom: 0.3rem;
+  right: 0.65rem;
+  padding: 0.4rem;
+  background: none;
+  border: none;
+  color: #333;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.copy-btn:hover {
+  color: #000;
+}
+
+.copy-btn .material-icons {
+  font-size: 1.15rem;
 }
 
 .markdown-source {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -43,22 +43,30 @@
       </div>
 
       <div class="bottom-bar-wrapper">
-        <details class="markdown-source">
+        <details
+          ref="sourceDetails"
+          class="markdown-source"
+          @toggle="onDetailsToggle"
+        >
           <summary>Edit Markdown Source</summary>
           <textarea
             v-model="editableMarkdown"
             class="markdown-editor"
             spellcheck="false"
           ></textarea>
-          <button
-            class="apply-btn"
-            :disabled="!hasChanges || saving"
-            @click="applyMarkdown"
-          >
-            {{ saving ? "Saving..." : "Apply Changes" }}
-          </button>
+          <div class="editor-actions">
+            <button
+              class="apply-btn"
+              :disabled="!hasChanges || saving"
+              @click="applyMarkdown"
+            >
+              {{ saving ? "Saving..." : "Apply Changes" }}
+            </button>
+            <button class="cancel-btn" @click="cancelEdit">Cancel</button>
+          </div>
         </details>
         <button
+          v-show="!editing"
           class="copy-btn"
           :title="copied ? 'Copied!' : 'Copy'"
           @click="copyText"
@@ -171,7 +179,19 @@ watch(
   },
 );
 
+const sourceDetails = ref<HTMLDetailsElement>();
+const editing = ref(false);
 const copied = ref(false);
+
+function onDetailsToggle(e: Event) {
+  const open = (e.target as HTMLDetailsElement).open;
+  editing.value = open;
+  if (!open) editableMarkdown.value = markdownContent.value;
+}
+
+function cancelEdit() {
+  if (sourceDetails.value) sourceDetails.value.open = false;
+}
 
 async function copyText() {
   try {
@@ -241,6 +261,9 @@ async function applyMarkdown() {
     },
   };
   emit("updateResult", updatedResult);
+
+  // Close the edit panel
+  if (sourceDetails.value) sourceDetails.value.open = false;
 }
 
 // Watch for external changes to selectedResult (when user clicks different result)
@@ -453,5 +476,26 @@ watch(
 
 .apply-btn:disabled:hover {
   background: #cccccc;
+}
+
+.editor-actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cancel-btn {
+  padding: 0.5rem 1rem;
+  background: #e0e0e0;
+  color: #333;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s;
+  font-weight: 500;
+}
+
+.cancel-btn:hover {
+  background: #d0d0d0;
 }
 </style>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -431,7 +431,12 @@
         <div v-if="sourceOpen[index]" class="border-t border-gray-100">
           <textarea
             v-model="sourceText[index]"
-            class="w-full text-xs text-gray-600 bg-gray-50 p-2 font-mono resize-none outline-none"
+            class="w-full text-xs text-gray-600 bg-gray-50 p-2 font-mono resize-none"
+            :class="
+              isValidBeat(index)
+                ? 'outline-none'
+                : 'outline outline-2 outline-red-400'
+            "
             rows="8"
             spellcheck="false"
           />
@@ -471,6 +476,7 @@
         <textarea
           v-model="editableSource"
           class="script-editor"
+          :class="{ 'script-editor-invalid': sourceChanged && !sourceValid }"
           spellcheck="false"
         ></textarea>
         <div class="editor-actions">
@@ -1214,6 +1220,15 @@ async function generateMovie() {
   outline: none;
   border-color: #4caf50;
   box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
+}
+
+.script-editor-invalid {
+  border-color: #ef4444;
+}
+
+.script-editor-invalid:focus {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1);
 }
 
 .editor-actions {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -21,12 +21,6 @@
           <span v-if="script.lang">{{ script.lang }}</span>
           <span v-if="filePath" class="truncate">{{ filePath }}</span>
         </div>
-        <button
-          class="mt-2 px-2 py-1 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 self-start"
-          @click="toggleScriptSource"
-        >
-          {{ scriptSourceOpen ? "Hide Source <>" : "Show Source <>" }}
-        </button>
       </div>
       <div class="ml-4 shrink-0 flex gap-2">
         <!-- Download Movie -->
@@ -72,17 +66,6 @@
           </template>
         </button>
       </div>
-    </div>
-
-    <!-- Source code panel -->
-    <div v-if="scriptSourceOpen" class="border-b border-gray-100 shrink-0">
-      <textarea
-        :value="scriptSourceText"
-        readonly
-        class="w-full text-xs text-gray-600 bg-gray-50 p-3 font-mono resize-none outline-none"
-        rows="16"
-        spellcheck="false"
-      />
     </div>
 
     <!-- Characters section -->
@@ -477,6 +460,42 @@
       </div>
     </div>
 
+    <!-- Bottom bar: Edit Script Source + Copy -->
+    <div class="bottom-bar-wrapper">
+      <details
+        ref="sourceDetails"
+        class="script-source"
+        @toggle="onSourceToggle(($event.target as HTMLDetailsElement).open)"
+      >
+        <summary>Edit Script Source</summary>
+        <textarea
+          v-model="editableSource"
+          class="script-editor"
+          spellcheck="false"
+        ></textarea>
+        <div class="editor-actions">
+          <button
+            class="apply-btn"
+            :disabled="!sourceChanged"
+            @click="applySource"
+          >
+            Apply Changes
+          </button>
+          <button class="cancel-btn" @click="cancelSourceEdit">Cancel</button>
+        </div>
+      </details>
+      <button
+        v-show="!editing"
+        class="copy-btn"
+        :title="copied ? 'Copied!' : 'Copy'"
+        @click="copyText"
+      >
+        <span class="material-icons">{{
+          copied ? "check" : "content_copy"
+        }}</span>
+      </button>
+    </div>
+
     <!-- Lightbox -->
     <div
       v-if="lightbox"
@@ -573,6 +592,7 @@ interface MulmoScript {
 const props = defineProps<{
   selectedResult: ToolResultComplete<MulmoScriptData>;
 }>();
+const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
 const data = computed(() => props.selectedResult.data);
 const script = computed<MulmoScript>(() => data.value?.script ?? {});
@@ -665,11 +685,86 @@ function lightboxMove(delta: number) {
     i += delta;
   }
 }
-const scriptSourceOpen = ref(false);
-const scriptSourceText = computed(() => JSON.stringify(script.value, null, 2));
+const sourceDetails = ref<HTMLDetailsElement>();
+const editing = ref(false);
+const editableSource = ref("");
+const copied = ref(false);
 
-function toggleScriptSource() {
-  scriptSourceOpen.value = !scriptSourceOpen.value;
+const scriptSourceText = computed(() => JSON.stringify(script.value, null, 2));
+const loadedSource = ref("");
+const sourceChanged = computed(
+  () => editableSource.value !== loadedSource.value,
+);
+
+async function onSourceToggle(open: boolean) {
+  editing.value = open;
+  if (open) {
+    let text = scriptSourceText.value;
+    // Read the current file from disk so beat-level edits are reflected
+    if (filePath.value) {
+      try {
+        const res = await fetch(
+          `/api/files/content?path=${encodeURIComponent(filePath.value)}`,
+        );
+        if (res.ok) {
+          const json: { content?: string } = await res.json();
+          if (json.content) text = json.content;
+        }
+      } catch {
+        // fall through to in-memory script
+      }
+    }
+    editableSource.value = text;
+    loadedSource.value = text;
+  }
+}
+
+function cancelSourceEdit() {
+  if (sourceDetails.value) sourceDetails.value.open = false;
+}
+
+async function applySource() {
+  let parsed: MulmoScript;
+  try {
+    parsed = JSON.parse(editableSource.value);
+    const res = await fetch("/api/mulmo-script/update-script", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: filePath.value, script: parsed }),
+    });
+    if (!res.ok) {
+      const json = await res.json();
+      throw new Error(json.error ?? "Update failed");
+    }
+  } catch (err) {
+    alert(extractErrorMessage(err));
+    return;
+  }
+
+  // Update the UI with the new script.
+  // Note: the parent's handleUpdateResult uses Object.assign (in-place
+  // mutation), so the watcher on props.selectedResult won't fire.
+  // We emit first so the parent data is updated, then manually
+  // re-initialize the view.
+  emit("updateResult", {
+    ...props.selectedResult,
+    data: { ...props.selectedResult.data, script: parsed },
+  });
+
+  if (sourceDetails.value) sourceDetails.value.open = false;
+  await initializeScript();
+}
+
+async function copyText() {
+  try {
+    await navigator.clipboard.writeText(scriptSourceText.value);
+    copied.value = true;
+    setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  } catch {
+    // clipboard API may be blocked in some contexts
+  }
 }
 
 function effectiveBeat(index: number): Beat {
@@ -696,6 +791,7 @@ async function updateBeat(index: number) {
     body: JSON.stringify({ filePath: filePath.value, beatIndex: index, beat }),
   });
   localOverrides[index] = beat;
+  sourceOpen[index] = false;
 
   if (JSON.stringify(beat.image) !== prevImage) {
     delete renderedImages[index];
@@ -996,7 +1092,7 @@ async function initializeScript() {
   Object.keys(charErrors).forEach((k) => delete charErrors[k]);
   Object.keys(beatDragOver).forEach((k) => delete beatDragOver[+k]);
   moviePath.value = null;
-  scriptSourceOpen.value = false;
+  if (sourceDetails.value) sourceDetails.value.open = false;
 
   const AUTO_RENDER_TYPES = [
     "textSlide",
@@ -1058,3 +1154,121 @@ async function generateMovie() {
   }
 }
 </script>
+
+<style scoped>
+.bottom-bar-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.script-source {
+  padding: 0.5rem;
+  background: #f5f5f5;
+  border-top: 1px solid #e0e0e0;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.script-source summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 0.5rem;
+  background: #e8e8e8;
+  border-radius: 4px;
+  font-weight: 500;
+  color: #333;
+}
+
+.script-source[open] summary {
+  margin-bottom: 0.5rem;
+}
+
+.script-source summary:hover {
+  background: #d8d8d8;
+}
+
+.script-editor {
+  width: 100%;
+  height: 40vh;
+  padding: 1rem;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: #333;
+  font-family: "Courier New", monospace;
+  font-size: 0.9rem;
+  resize: vertical;
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.script-editor:focus {
+  outline: none;
+  border-color: #4caf50;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
+}
+
+.editor-actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.apply-btn {
+  padding: 0.5rem 1rem;
+  background: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s;
+  font-weight: 500;
+}
+
+.apply-btn:hover {
+  background: #45a049;
+}
+
+.apply-btn:disabled {
+  background: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.cancel-btn {
+  padding: 0.5rem 1rem;
+  background: #e0e0e0;
+  color: #333;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s;
+  font-weight: 500;
+}
+
+.cancel-btn:hover {
+  background: #d0d0d0;
+}
+
+.copy-btn {
+  position: absolute;
+  bottom: 0.3rem;
+  right: 0.65rem;
+  padding: 0.4rem;
+  background: none;
+  border: none;
+  color: #333;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.copy-btn:hover {
+  color: #000;
+}
+
+.copy-btn .material-icons {
+  font-size: 1.15rem;
+}
+</style>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -476,7 +476,7 @@
         <div class="editor-actions">
           <button
             class="apply-btn"
-            :disabled="!sourceChanged"
+            :disabled="!sourceChanged || !sourceValid"
             @click="applySource"
           >
             Apply Changes
@@ -554,7 +554,7 @@
 import { computed, onMounted, reactive, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { MulmoScriptData } from "./index";
-import { mulmoBeatSchema } from "@mulmocast/types";
+import { mulmoBeatSchema, mulmoScriptSchema } from "@mulmocast/types";
 import {
   extractErrorMessage,
   getMissingCharacterKeys,
@@ -695,6 +695,14 @@ const loadedSource = ref("");
 const sourceChanged = computed(
   () => editableSource.value !== loadedSource.value,
 );
+const sourceValid = computed(() => {
+  try {
+    const parsed = JSON.parse(editableSource.value);
+    return mulmoScriptSchema.safeParse(parsed).success;
+  } catch {
+    return false;
+  }
+});
 
 async function onSourceToggle(open: boolean) {
   editing.value = open;

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -23,17 +23,29 @@
         >⚠ PDF failed</span
       >
     </div>
-    <div class="flex-1 overflow-hidden" @click.capture="openLinksInNewTab">
+    <div
+      class="flex-1 overflow-hidden relative"
+      @click.capture="openLinksInNewTab"
+    >
       <OriginalView
         :selected-result="selectedResult"
         @update-result="(r) => emit('updateResult', r as ToolResultComplete)"
       />
+      <button
+        class="copy-btn"
+        :title="copied ? 'Copied!' : 'Copy'"
+        @click="copyText"
+      >
+        <span class="material-icons">{{
+          copied ? "check" : "content_copy"
+        }}</span>
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { View as OriginalView } from "@gui-chat-plugin/text-response/vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
@@ -63,6 +75,21 @@ const {
   pdfError,
   downloadPdf: rawDownloadPdf,
 } = usePdfDownload();
+
+const copied = ref(false);
+
+async function copyText() {
+  const text = props.selectedResult.data?.text ?? "";
+  try {
+    await navigator.clipboard.writeText(text);
+    copied.value = true;
+    setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  } catch {
+    // Fallback: clipboard API may be blocked in some contexts
+  }
+}
 
 async function downloadPdf() {
   const text = props.selectedResult.data?.text ?? "";
@@ -100,5 +127,25 @@ async function downloadPdf() {
 .download-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.copy-btn {
+  position: absolute;
+  bottom: 0.3rem;
+  right: 0.65rem;
+  padding: 0.4rem;
+  background: none;
+  border: none;
+  color: #333;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.copy-btn:hover {
+  color: #000;
+}
+
+.copy-btn .material-icons {
+  font-size: 1.15rem;
 }
 </style>

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -24,14 +24,17 @@
       >
     </div>
     <div
+      ref="contentWrapper"
       class="flex-1 overflow-hidden relative"
       @click.capture="openLinksInNewTab"
     >
       <OriginalView
+        :key="viewKey"
         :selected-result="selectedResult"
-        @update-result="(r) => emit('updateResult', r as ToolResultComplete)"
+        @update-result="onApply"
       />
       <button
+        v-show="!editing"
         class="copy-btn"
         :title="copied ? 'Copied!' : 'Copy'"
         @click="copyText"
@@ -40,12 +43,15 @@
           copied ? "check" : "content_copy"
         }}</span>
       </button>
+      <button v-show="editing" class="cancel-btn" @click="cancelEdit">
+        Cancel
+      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { View as OriginalView } from "@gui-chat-plugin/text-response/vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
@@ -75,6 +81,43 @@ const {
   pdfError,
   downloadPdf: rawDownloadPdf,
 } = usePdfDownload();
+
+const contentWrapper = ref<HTMLElement>();
+const editing = ref(false);
+const viewKey = ref(0);
+
+function attachToggleListener() {
+  const details = contentWrapper.value?.querySelector("details");
+  details?.addEventListener("toggle", onDetailsToggle);
+}
+
+function onDetailsToggle(e: Event) {
+  const open = (e.target as HTMLDetailsElement).open;
+  editing.value = open;
+  if (!open) {
+    // Re-mount OriginalView to discard textarea edits
+    viewKey.value++;
+    nextTick(attachToggleListener);
+  }
+}
+
+onMounted(attachToggleListener);
+
+onBeforeUnmount(() => {
+  const details = contentWrapper.value?.querySelector("details");
+  details?.removeEventListener("toggle", onDetailsToggle);
+});
+
+function cancelEdit() {
+  const details = contentWrapper.value?.querySelector("details");
+  if (details) details.open = false;
+}
+
+function onApply(r: unknown) {
+  emit("updateResult", r as ToolResultComplete);
+  const details = contentWrapper.value?.querySelector("details");
+  if (details) details.open = false;
+}
 
 const copied = ref(false);
 
@@ -147,5 +190,24 @@ async function downloadPdf() {
 
 .copy-btn .material-icons {
   font-size: 1.15rem;
+}
+
+.cancel-btn {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.65rem;
+  padding: 0.5rem 1rem;
+  background: #e0e0e0;
+  color: #333;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  z-index: 1;
+}
+
+.cancel-btn:hover {
+  background: #d0d0d0;
 }
 </style>


### PR DESCRIPTION
## Summary by Sourcery

Add unified bottom-bar editing and clipboard controls for script, markdown, and text response views, including backend support for updating Mulmo scripts on disk.

New Features:
- Introduce an expandable script source editor for Mulmo scripts with validation and apply/cancel controls, backed by a new API to persist script updates to disk.
- Add copy-to-clipboard actions with transient visual feedback to Mulmo script, markdown, and text response views.
- Allow cancelling in-progress edits for markdown and text response content, restoring the last saved state.

Enhancements:
- Validate full Mulmo scripts against mulmoScriptSchema and surface invalid beats with visual highlighting.
- Ensure beat-level updates close their source editor panels and keep UI state in sync when scripts are updated.
- Refine layout and styling for bottom editing bars and action buttons across views for a more consistent UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy-to-clipboard functionality added to all content editors with visual "Copied!" feedback
  * Script editor now validates JSON edits and persists changes directly to file
  * Improved editor layouts with bottom-bar panels, apply/cancel actions, and better state tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->