### PR TITLE
docs: add manual testing guide + maintenance contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,18 @@ Skip if the change is purely cosmetic (Tailwind class tweaks, copy fixes, emoji 
 - **URL predicate functions > globs**: `**/api/roles` doesn't reliably match `http://host/api/roles`. Use `(url) => url.pathname === "/api/roles"` instead.
 - **Hash vs history mode**: Tests that assert URL query params behave differently between hash mode (`/#/chat?view=x`) and history mode (`/chat?view=x`). Write tests against the rendered UI state rather than raw URL strings when possible.
 
+## Manual Testing
+
+Some behaviours can't be covered by E2E — drag-and-drop via `vuedraggable` / Sortable, HTML canvas pixel state, iframe-sandboxed content, LLM-driven agent flows that require a real backend, etc. Those live in [`docs/manual-testing.md`](docs/manual-testing.md), which is the single source of truth for the out-of-E2E surface.
+
+**Contract for PRs**:
+
+- MUST update [`docs/manual-testing.md`](docs/manual-testing.md) whenever a change deliberately leaves a scenario uncovered by E2E — add an entry with the flow, the reason it can't be automated, and how to smoke-check it.
+- MUST remove / strike-through an entry when a change brings a previously-manual scenario under E2E coverage.
+- Per-PR smoke-test notes go in the PR description, NOT in this doc. The doc is for *persistent* manual-test obligations only.
+
+See `plans/` entries and past PR descriptions (#193 wiki-backlinks, #195 tool-trace, #209 todo-items-crud) for examples of cleanly separating "E2E covers this" from "manual check after each release covers this".
+
 ## Server Logging
 
 The server uses the structured logger at `server/logger/`. **Never call `console.*` directly outside that module** — import and use `log.{error,warn,info,debug}(prefix, msg, data?)` instead.

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,143 @@
+# Manual Testing Guide
+
+Things that E2E (`yarn test:e2e`) **cannot** cover reliably, and must be
+checked by hand before a release or after a change that touches the
+relevant area.
+
+The goal of this doc is to keep the list of "manual-only" responsibilities
+*finite and maintained* — if something moves into E2E coverage, strike it
+out; if a new thing proves untestable, add it here with a reason.
+
+> **Contributor note**: any PR that deliberately leaves a scenario uncovered
+> by E2E (because the testing framework can't reach it) **must add an entry
+> here** with the scenario, the reason it's untestable, and how to smoke-check
+> it. See [CLAUDE.md → Manual Testing](../CLAUDE.md#manual-testing) for the
+> workflow contract.
+
+---
+
+## 1. Drag-and-drop interactions
+
+**Why manual**: `vuedraggable` wraps `Sortable.js`, which relies on native
+HTML5 drag events. Playwright's synthetic mouse events (`page.mouse.down/move/up`,
+`page.dragTo()`) don't trigger `dragstart` reliably on Sortable's listeners,
+and the library's internal clone-swap isn't visible through standard DOM
+assertions even when the drag does fire. Attempts consistently flake.
+
+### What to check
+
+| Surface | Flow |
+|---|---|
+| **Todo Kanban — card between columns** | Open `todos/todos.json`, drag a card from one column to another, verify it lands in the drop target + refreshes with the new status |
+| **Todo Kanban — card reorder within column** | Drag a card up/down inside the same column, verify the new order persists after refresh |
+| **Todo Kanban — column reorder** | Drag a column header sideways, verify `order` persists |
+
+**Server contract is already covered**: `POST /api/todos/items/:id/move` is
+exercised by the list-view checkbox toggle test in
+`e2e/tests/todo-items-crud.spec.ts`, so the API wiring is not in question —
+only the UI wiring of the drag itself.
+
+## 2. Canvas-based UI
+
+**Why manual**: HTML `<canvas>` pixel state isn't accessible to Playwright's
+assertion APIs in a deterministic way (`getImageData` needs the test to
+understand the exact pixel layout, which is brittle to rendering differences
+across OS/GPU).
+
+### What to check
+
+- **Image plugin — draw to canvas**: enter a canvas view, draw with the
+  brush, verify strokes appear visibly
+- **Image plugin — save after drawing**: click Save, verify the image
+  persists (reopen the session → image reloads with strokes intact)
+- **Style application**: apply a style preset, save, reopen → style stays
+
+## 3. Iframe-sandboxed content rendering
+
+**Why manual**: `presentHtml` (and any future HTML rendering plugin) uses a
+CSP-sandboxed iframe. Playwright can see the iframe element exists but
+can't introspect content behind the sandbox boundary, and auto-height
+sizing relies on the iframe's own `load` event firing against its rendered
+document.
+
+### What to check
+
+- **Stack view — presentHtml natural height**: a multi-screen HTML result
+  should expand to its full content height, no inner scrollbar. Same for
+  `presentDocument` / `presentSpreadsheet` / `manageWiki`.
+- **Single view — iframe scroll**: long HTML scrolls internally without
+  breaking the host page layout.
+
+## 4. LLM + agent driven flows (require real backend)
+
+**Why manual**: E2E mocks `/api/agent` entirely. Anything that exercises
+the Claude CLI + MCP + real file system side effects needs an actual
+`yarn dev` run.
+
+### What to check after changes to agent / MCP / plugins
+
+- **Session jsonl contents**: inspect `~/mulmoclaude/chat/<id>.jsonl`
+  after a turn, verify:
+  - User + assistant text appended
+  - `tool_call` and `tool_call_result` records present (tool-trace #195)
+  - WebSearch results stored as `contentRef` to `workspace/searches/*.md`,
+    not inline base64
+- **Wiki backlinks**: after a turn that creates/edits a wiki page, the
+  page ends with `<!-- journal-session-backlinks -->` + a `## History`
+  section linking to the originating `chat/<id>.jsonl` (#193)
+- **Workspace artifact pointers**: image plugin saves to
+  `workspace/images/<hash>.png` and the tool result carries the path, not
+  base64; wiki pages reference images via path, not base64
+- **Role switching**: switch role mid-session → context resets, correct
+  MCP tool palette loads (check `claude mcp list` output)
+- **Journal daily pass**: run with `JOURNAL_FORCE_RUN_ON_STARTUP=1` and
+  verify `workspace/summaries/daily/YYYY/MM/DD.md` gets written
+
+## 5. Log output (not asserted by E2E)
+
+**Why manual**: the file-sink log goes to `server/logs/` and is not
+wired into the test assertions. Spot-checking is usually enough.
+
+### What to check after logger changes
+
+- **Startup**: `yarn dev` → console shows `[workspace] / [sandbox] /
+  [mcp] / [server] / [task-manager]` info lines at normal ISO timestamps
+- **Agent path**: `server/logs/server-YYYY-MM-DD.log` contains `[agent]`
+  request received / completed / CLI stderr line-by-line entries
+- **Tool-trace**: `[tool-trace] web_search starting` + `web_search saved`
+  pair for a WebSearch turn; debug-level entries visible only under
+  `LOG_CONSOLE_LEVEL=debug`
+- **CSRF reject**: hit the server from a non-localhost Origin →
+  `[csrf] rejected cross-origin request` warn entry
+
+See [`docs/logging.md`](logging.md) for the full logger reference.
+
+## 6. Cross-browser / responsive (beyond Chromium)
+
+**Why manual**: E2E runs only Chromium (see `e2e/playwright.config.ts`).
+
+### What to check before a release
+
+- Safari / Firefox smoke: app loads, sessions list, sending a message, file
+  explorer expands, no console errors
+- Window resize: sidebar collapses / re-expands, canvas view scales
+
+---
+
+## Updating this document
+
+When you land a PR:
+
+1. If the change adds E2E coverage for a scenario previously listed here →
+   **remove** the entry (or strike it through with a link to the covering
+   test).
+2. If the change introduces a new UI surface or backend behaviour that
+   E2E can't reach → **add** an entry with the flow + the reason it's
+   untestable.
+3. Keep this doc focused on *persistent* manual-test obligations, not
+   per-PR smoke-test notes (those belong in the PR description).
+
+The enforcement is on the honour system — no automation ensures this doc
+stays current. But it's the only place that keeps the out-of-E2E surface
+from silently growing, so treat entries here as first-class test
+artifacts.


### PR DESCRIPTION
## Summary

New \`docs/manual-testing.md\` collects the set of behaviours that E2E cannot reach — drag-and-drop, canvas pixels, iframe-sandbox content, LLM/backend-driven flows, cross-browser checks — and puts a maintenance contract around it so the list stays finite instead of silently growing.

\`CLAUDE.md\` gains a "Manual Testing" section that wires the doc into the PR workflow: contributors MUST update \`docs/manual-testing.md\` when they deliberately leave a scenario uncovered by E2E, and strike entries when coverage catches up.

## Items to Confirm / Review

1. **Initial entry set** — pulled from recent real cases (Todo Kanban drag / #160, canvas / #160, iframe-sandbox / #199, agent-path side effects / #193 + #195, log output, non-Chromium browsers). Any category I missed?
2. **Tone / depth** — kept entries actionable ("what to check" + "why manual") rather than exhaustive scripts. If you want per-entry step-by-step instructions instead, flag it.
3. **Contract strength** — MUST-level in CLAUDE.md. If you'd rather keep it SHOULD so the doc doesn't gate PRs, I can demote.

## User Prompt

> docs以下に手動テストすべき内容をまとめて。それに関してもclaude.mdに記載して、e2eでできないテストはdocumentに追記してメンテしていくように。

## Changes

- \`docs/manual-testing.md\` (new, ~150 lines) — 6 categories × entries each (flow + why untestable)
- \`CLAUDE.md\` — new "Manual Testing" section right after "E2E Testing (Playwright)", pointing at the doc + setting the "add entry if you leave a gap" contract

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors (3 pre-existing \`.vue\` v-html warnings)
- [x] No code changes — docs only, so no test / build / typecheck risk

## Summary by Sourcery

Add a maintained manual testing guide and wire it into the contributor workflow as the single source of truth for scenarios not covered by E2E tests.

Documentation:
- Introduce docs/manual-testing.md documenting manual-only test scenarios, their rationale, and how to validate them.
- Document a Manual Testing section in CLAUDE.md that links to the guide and explains contributor responsibilities for keeping it up to date.