### PR TITLE
perf(files): client lazy-expand via /api/files/dir (#200 phase 2, closes issue)

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -121,6 +121,15 @@ export async function mockAllApis(
     }),
   );
 
+  // Lazy-expand endpoint (Phase 2 of #200). Returns an empty dir by
+  // default; specific tests override with their own fixtures (see
+  // e2e/tests/file-explorer.spec.ts).
+  await page.route(urlEndsWith("/api/files/dir"), (route) =>
+    route.fulfill({
+      json: { name: "", path: "", type: "dir", children: [] },
+    }),
+  );
+
   // Default agent mock — returns 202 (fire-and-forget). Tests that
   // need to deliver events should register their own route + WS mock
   // AFTER calling mockAllApis.

--- a/e2e/tests/file-explorer-lazy.spec.ts
+++ b/e2e/tests/file-explorer-lazy.spec.ts
@@ -1,0 +1,168 @@
+// Phase-2 lazy-expand behaviour for the file explorer (#200).
+//
+// Phase 1 (PR #207) made the server async + added
+// `/api/files/dir?path=<rel>` for shallow listings. Phase 2 (this
+// branch) switches the client to fetch per-directory on expand.
+//
+// These tests assert the observable wire contract:
+//
+//   - on mount, client hits `/api/files/dir?path=` once (root)
+//   - expanding a collapsed dir triggers `/api/files/dir?path=<dir>`
+//   - collapsing + re-expanding does NOT refetch (cache holds)
+//   - deep-link `?path=a/b/c.md` auto-loads ancestor dirs
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+interface CountingMock {
+  counts: Map<string, number>;
+  reset(): void;
+}
+
+async function mockLazyDirs(page: Page): Promise<CountingMock> {
+  const counts = new Map<string, number>();
+
+  await page.route(
+    (url) => url.pathname === "/api/files/dir",
+    (route: Route) => {
+      const path =
+        new URL(route.request().url()).searchParams.get("path") ?? "";
+      counts.set(path, (counts.get(path) ?? 0) + 1);
+      if (path === "") {
+        return route.fulfill({
+          json: {
+            name: "",
+            path: "",
+            type: "dir",
+            children: [
+              { name: "wiki", path: "wiki", type: "dir" },
+              { name: "notes", path: "notes", type: "dir" },
+            ],
+          },
+        });
+      }
+      if (path === "wiki") {
+        return route.fulfill({
+          json: {
+            name: "wiki",
+            path: "wiki",
+            type: "dir",
+            children: [
+              { name: "pages", path: "wiki/pages", type: "dir" },
+              {
+                name: "readme.md",
+                path: "wiki/readme.md",
+                type: "file",
+                size: 10,
+              },
+            ],
+          },
+        });
+      }
+      if (path === "wiki/pages") {
+        return route.fulfill({
+          json: {
+            name: "pages",
+            path: "wiki/pages",
+            type: "dir",
+            children: [
+              {
+                name: "foo.md",
+                path: "wiki/pages/foo.md",
+                type: "file",
+                size: 42,
+              },
+            ],
+          },
+        });
+      }
+      return route.fulfill({
+        json: { name: path, path, type: "dir", children: [] },
+      });
+    },
+  );
+
+  await page.route(
+    (url) => url.pathname === "/api/files/content",
+    (route) =>
+      route.fulfill({
+        json: {
+          kind: "text",
+          path: new URL(route.request().url()).searchParams.get("path") ?? "",
+          content: "stub content",
+          size: 12,
+          modifiedMs: Date.now(),
+        },
+      }),
+  );
+
+  return {
+    counts,
+    reset: () => counts.clear(),
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+  await mockLazyDirs(page);
+});
+
+test.describe("file explorer lazy expand (#200 phase 2)", () => {
+  test("root listing lands once on mount, no subtree fetched yet", async ({
+    page,
+  }) => {
+    const mock = await mockLazyDirs(page);
+    await page.goto("/chat?view=files");
+    await expect(
+      page.locator('[data-testid="file-tree-dir-wiki"]'),
+    ).toBeVisible();
+    // Only the root fetch should have fired — children of collapsed
+    // `wiki` / `notes` must wait for an expand click.
+    expect(mock.counts.get("") ?? 0).toBeGreaterThan(0);
+    expect(mock.counts.get("wiki") ?? 0).toBe(0);
+    expect(mock.counts.get("notes") ?? 0).toBe(0);
+  });
+
+  test("clicking a collapsed dir fetches its children exactly once", async ({
+    page,
+  }) => {
+    const mock = await mockLazyDirs(page);
+    await page.goto("/chat?view=files");
+    await expect(
+      page.locator('[data-testid="file-tree-dir-wiki"]'),
+    ).toBeVisible();
+
+    await page.locator('[data-testid="file-tree-dir-wiki"]').click();
+    // Wait for wiki's contents to surface
+    await expect(
+      page.locator('[data-testid="file-tree-file-readme.md"]'),
+    ).toBeVisible();
+    expect(mock.counts.get("wiki")).toBe(1);
+
+    // Collapse + re-expand: should NOT refetch — cache hit.
+    await page.locator('[data-testid="file-tree-dir-wiki"]').click();
+    await page.locator('[data-testid="file-tree-dir-wiki"]').click();
+    await expect(
+      page.locator('[data-testid="file-tree-file-readme.md"]'),
+    ).toBeVisible();
+    expect(mock.counts.get("wiki")).toBe(1);
+  });
+
+  test("deep link auto-expands ancestors", async ({ page }) => {
+    const mock = await mockLazyDirs(page);
+    await page.goto("/chat?view=files&path=wiki/pages/foo.md");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Both `wiki` and `wiki/pages` should have been fetched so the
+    // tree can reveal the selection.
+    await expect
+      .poll(() => mock.counts.get("wiki") ?? 0, { timeout: 3000 })
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() => mock.counts.get("wiki/pages") ?? 0, { timeout: 3000 })
+      .toBeGreaterThan(0);
+
+    // The selected file's content loads.
+    await expect(page.getByText("stub content")).toBeVisible();
+  });
+});

--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -1,46 +1,66 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 
-// Override the files/tree mock with a small fixture tree.
+// Override the lazy-expand endpoint with a small fixture tree. Each
+// directory returns its immediate children only — recursion is
+// emulated by the client via subsequent fetches on expand.
 async function mockFileTree(page: Page) {
   await page.route(
-    (url) => url.pathname === "/api/files/tree",
-    (route) =>
-      route.fulfill({
-        json: {
-          name: "",
-          path: "",
-          type: "dir",
-          children: [
-            {
-              name: "wiki",
-              path: "wiki",
-              type: "dir",
-              children: [
-                {
-                  name: "hello.md",
-                  path: "wiki/hello.md",
-                  type: "file",
-                  size: 42,
-                },
-              ],
-            },
-            {
-              name: "todos",
-              path: "todos",
-              type: "dir",
-              children: [
-                {
-                  name: "todos.json",
-                  path: "todos/todos.json",
-                  type: "file",
-                  size: 100,
-                },
-              ],
-            },
-          ],
-        },
-      }),
+    (url) => url.pathname === "/api/files/dir",
+    (route) => {
+      const path =
+        new URL(route.request().url()).searchParams.get("path") ?? "";
+      if (path === "") {
+        return route.fulfill({
+          json: {
+            name: "",
+            path: "",
+            type: "dir",
+            children: [
+              { name: "wiki", path: "wiki", type: "dir" },
+              { name: "todos", path: "todos", type: "dir" },
+            ],
+          },
+        });
+      }
+      if (path === "wiki") {
+        return route.fulfill({
+          json: {
+            name: "wiki",
+            path: "wiki",
+            type: "dir",
+            children: [
+              {
+                name: "hello.md",
+                path: "wiki/hello.md",
+                type: "file",
+                size: 42,
+              },
+            ],
+          },
+        });
+      }
+      if (path === "todos") {
+        return route.fulfill({
+          json: {
+            name: "todos",
+            path: "todos",
+            type: "dir",
+            children: [
+              {
+                name: "todos.json",
+                path: "todos/todos.json",
+                type: "file",
+                size: 100,
+              },
+            ],
+          },
+        });
+      }
+      return route.fulfill({
+        json: { name: path, path, type: "dir", children: [] },
+      });
+    },
   );
 
   // Mock file content for wiki/hello.md
@@ -68,13 +88,23 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("file explorer path in URL", () => {
   test("selecting a file puts ?path= in the URL", async ({ page }) => {
-    // Navigate to files view
     await page.goto("/chat?view=files");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    // Expand the wiki dir and click hello.md
-    // FileTree dirs start collapsed; click to expand
+    // Wait for the root dir's shallow listing to land — with lazy
+    // expand (#200 phase 2), the tree only renders children after
+    // `/api/files/dir?path=` resolves.
+    await expect(
+      page.locator('[data-testid="file-tree-dir-wiki"]'),
+    ).toBeVisible();
+
+    // Expand the wiki dir and click hello.md. FileTree dirs start
+    // collapsed; click toggles expand + triggers a lazy-fetch of
+    // wiki's children (resolved by the mockFileTree dispatcher).
     await page.locator('[data-testid="file-tree-dir-wiki"]').click();
+    await expect(
+      page.locator('[data-testid="file-tree-file-hello.md"]'),
+    ).toBeVisible();
     await page.locator('[data-testid="file-tree-file-hello.md"]').click();
 
     // URL should now contain ?path=wiki/hello.md

--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -4,7 +4,7 @@
       v-if="node.type === 'dir'"
       class="w-full flex items-center gap-1 px-2 py-1 text-left text-sm hover:bg-gray-100 rounded"
       :data-testid="`file-tree-dir-${node.name || 'root'}`"
-      @click="toggle(node.path)"
+      @click="onToggle"
     >
       <span class="material-icons text-sm text-gray-400 shrink-0">{{
         expanded ? "folder_open" : "folder"
@@ -35,21 +35,29 @@
         title="Recently changed"
       />
     </button>
-    <div v-if="node.type === 'dir' && expanded && node.children" class="pl-4">
+    <div v-if="node.type === 'dir' && expanded" class="pl-4">
+      <!-- Loading state: children not in the cache yet. Rendered
+           once per dir so a slow network shows where the wait is,
+           not as a global overlay. -->
+      <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">
+        Loading...
+      </div>
       <FileTree
-        v-for="child in node.children"
+        v-for="child in loadedChildren"
         :key="child.path"
         :node="child"
         :selected-path="selectedPath"
         :recent-paths="recentPaths"
+        :children-by-path="childrenByPath"
         @select="(p) => emit('select', p)"
+        @load-children="(p) => emit('loadChildren', p)"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 
 export interface TreeNode {
@@ -65,10 +73,16 @@ const props = defineProps<{
   node: TreeNode;
   selectedPath: string | null;
   recentPaths: Set<string>;
+  // Lazy-expand cache managed by the parent (FilesView). `undefined`
+  // entry (not in the map) = not loaded yet → we emit `loadChildren`
+  // so the parent kicks off the fetch. `null` = load in flight →
+  // show spinner. Array = loaded.
+  childrenByPath: Map<string, TreeNode[] | null>;
 }>();
 
 const emit = defineEmits<{
   select: [path: string];
+  loadChildren: [path: string];
 }>();
 
 // Expand/collapse state lives in a module-level singleton so every
@@ -77,6 +91,42 @@ const emit = defineEmits<{
 // Default on first run: only the workspace root ("") is expanded.
 const { isExpanded, toggle } = useExpandedDirs();
 const expanded = computed(() => isExpanded(props.node.path));
+
+const cached = computed(() => props.childrenByPath.get(props.node.path));
+// `cached === null` = load in flight. `undefined` = never requested.
+// Array = loaded.
+const loadingChildren = computed(() => cached.value === null);
+const loadedChildren = computed(() =>
+  Array.isArray(cached.value) ? cached.value : [],
+);
+
+// Kick off a fetch if the dir is expanded but its children haven't
+// been requested yet. Covers two scenarios:
+//   1. User just toggled open → onToggle already emits, but watching
+//      here makes the flow idempotent when the parent re-mounts the
+//      component with expand state restored from localStorage.
+//   2. Deep link: FilesView calls `expand(ancestor)` before children
+//      arrive; this watcher catches that case too.
+watch(
+  [expanded, cached],
+  ([isOpen, current]) => {
+    if (!isOpen) return;
+    if (props.node.type !== "dir") return;
+    if (current !== undefined) return;
+    emit("loadChildren", props.node.path);
+  },
+  { immediate: true },
+);
+
+function onToggle(): void {
+  toggle(props.node.path);
+  // When newly-opened, request children if cache miss. The watcher
+  // above covers the reactive path but we also fire here so the
+  // request is visibly tied to the click for network inspection.
+  if (!isExpanded(props.node.path)) return;
+  if (cached.value !== undefined) return;
+  emit("loadChildren", props.node.path);
+}
 
 const isRecent = computed(() => props.recentPaths.has(props.node.path));
 </script>

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -7,13 +7,17 @@
       <div v-if="treeError" class="p-2 text-xs text-red-600">
         {{ treeError }}
       </div>
-      <div v-else-if="!tree" class="p-2 text-xs text-gray-400">Loading...</div>
+      <div v-else-if="!rootNode" class="p-2 text-xs text-gray-400">
+        Loading...
+      </div>
       <FileTree
         v-else
-        :node="tree"
+        :node="rootNode"
         :selected-path="selectedPath"
         :recent-paths="recentPaths"
+        :children-by-path="childrenByPath"
         @select="selectFile"
+        @load-children="loadDirChildren"
       />
     </div>
     <!-- Content pane -->
@@ -220,6 +224,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import FileTree, { type TreeNode } from "./FileTree.vue";
+import { useExpandedDirs } from "../composables/useExpandedDirs";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
@@ -285,7 +290,19 @@ const emit = defineEmits<{
   loadSession: [sessionId: string];
 }>();
 
-const tree = ref<TreeNode | null>(null);
+// Share the expand-state composable with FileTree so deep-link
+// auto-expand (`?path=wiki/pages/foo.md`) can mark ancestors as
+// expanded before the children arrive.
+const { expand } = useExpandedDirs();
+
+// Root dir metadata (name/path/modifiedMs). Children live in
+// `childrenByPath` below so the lazy-expand cache has a single
+// home — see Phase-2 notes for #200.
+const rootNode = ref<TreeNode | null>(null);
+// Lazy-expand cache: one entry per directory we've fetched via
+// `/api/files/dir`. `undefined` (= not in the map) means "not
+// loaded yet". `null` means "load in flight — show spinner".
+const childrenByPath = ref<Map<string, TreeNode[] | null>>(new Map());
 const treeError = ref<string | null>(null);
 
 // Seed selectedPath from URL query ?path=, falling back to
@@ -429,17 +446,21 @@ function markdownResult(text: string): ToolResultComplete<TextResponseData> {
 const recentPaths = computed(() => {
   const set = new Set<string>();
   const now = Date.now();
-  function visit(node: TreeNode) {
-    if (
-      node.type === "file" &&
-      node.modifiedMs &&
-      now - node.modifiedMs < RECENT_THRESHOLD_MS
-    ) {
-      set.add(node.path);
+  // Walk every loaded directory in the cache — lazy-loaded children
+  // may not be rooted under the ref we start from, so iterating the
+  // cache directly is both cheaper and more complete.
+  for (const children of childrenByPath.value.values()) {
+    if (!children) continue;
+    for (const node of children) {
+      if (
+        node.type === "file" &&
+        node.modifiedMs &&
+        now - node.modifiedMs < RECENT_THRESHOLD_MS
+      ) {
+        set.add(node.path);
+      }
     }
-    if (node.children) node.children.forEach(visit);
   }
-  if (tree.value) visit(tree.value);
   return set;
 });
 
@@ -462,15 +483,67 @@ function formatTime(ms: number): string {
   });
 }
 
-async function loadTree(): Promise<void> {
-  treeError.value = null;
+// Fetch the immediate children of one directory via the lazy-expand
+// endpoint added in #207. Stores them in `childrenByPath` under the
+// same `path` the server returned. Idempotent — if already loaded,
+// no-ops. Setting the map value to `null` briefly lets the UI show
+// a spinner while the request is in flight.
+async function loadDirChildren(path: string): Promise<void> {
+  // Already loaded or in flight — skip. `undefined` (not present)
+  // is the only case that kicks off a fetch.
+  if (childrenByPath.value.has(path)) return;
+
+  const next = new Map(childrenByPath.value);
+  next.set(path, null);
+  childrenByPath.value = next;
+
   try {
-    const res = await fetch("/api/files/tree");
-    if (!res.ok) throw new Error(`tree: ${res.status}`);
-    tree.value = await res.json();
+    const url = `/api/files/dir?path=${encodeURIComponent(path)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`dir: ${res.status}`);
+    const node: TreeNode = await res.json();
+    const updated = new Map(childrenByPath.value);
+    updated.set(path, node.children ?? []);
+    childrenByPath.value = updated;
+    // Also expose the root dir's own metadata (name / path /
+    // modifiedMs) for the FileTree header — only relevant for the
+    // workspace root, which the tree renders as "(workspace)".
+    if (path === "") rootNode.value = { ...node, children: [] };
   } catch (err) {
+    // Drop the `null` marker so the user can retry (e.g. via the
+    // refresh-token watcher). Keep the error visible too.
+    const rollback = new Map(childrenByPath.value);
+    rollback.delete(path);
+    childrenByPath.value = rollback;
     treeError.value = err instanceof Error ? err.message : String(err);
   }
+}
+
+// Walk each ancestor of a file path and expand + load it. Used on
+// mount for deep links like `?path=wiki/pages/foo.md` so the tree
+// reveals the selection rather than keeping every directory
+// collapsed.
+async function ensureAncestorsLoaded(filePath: string): Promise<void> {
+  const parts = filePath.split("/").filter(Boolean);
+  if (parts.length <= 1) return; // file sits at root, nothing to expand
+  const ancestors: string[] = [];
+  for (let i = 1; i < parts.length; i++) {
+    ancestors.push(parts.slice(0, i).join("/"));
+  }
+  for (const dir of ancestors) {
+    expand(dir);
+    await loadDirChildren(dir);
+  }
+}
+
+async function reloadRoot(): Promise<void> {
+  // Wipe the whole lazy cache, then re-seed the root. Any
+  // currently-expanded descendants will be re-fetched lazily when
+  // the FileTree re-emits `load-children` from their expanded
+  // state.
+  childrenByPath.value = new Map();
+  treeError.value = null;
+  await loadDirChildren("");
 }
 
 // Tracks the currently in-flight content fetch so a stale response from
@@ -583,16 +656,18 @@ watch(
 watch(
   () => props.refreshToken,
   () => {
-    loadTree();
+    reloadRoot();
     if (selectedPath.value) loadContent(selectedPath.value);
   },
 );
 
 onMounted(async () => {
-  await loadTree();
-  // If the URL already has a ?path=, load that file. Otherwise
-  // leave file-unselected (the "Select a file" placeholder shows).
+  await loadDirChildren("");
+  // Deep-link: if the URL has a selected path, reveal its ancestors
+  // by fetching each dir in sequence so the tree auto-expands to
+  // the selection.
   if (selectedPath.value) {
+    await ensureAncestorsLoaded(selectedPath.value);
     loadContent(selectedPath.value);
   }
 });

--- a/src/composables/useExpandedDirs.ts
+++ b/src/composables/useExpandedDirs.ts
@@ -41,6 +41,8 @@ watch(expandedDirs, (val) => {
 export function useExpandedDirs(): {
   isExpanded: (path: string) => boolean;
   toggle: (path: string) => void;
+  expand: (path: string) => void;
+  expandedPaths: () => string[];
 } {
   function isExpanded(path: string): boolean {
     return expandedDirs.value.has(path);
@@ -53,5 +55,16 @@ export function useExpandedDirs(): {
     else next.add(path);
     expandedDirs.value = next;
   }
-  return { isExpanded, toggle };
+  // Idempotently mark a path as expanded (used by deep-link auto-
+  // expand where we want to reveal ancestors without toggling).
+  function expand(path: string): void {
+    if (expandedDirs.value.has(path)) return;
+    const next = new Set(expandedDirs.value);
+    next.add(path);
+    expandedDirs.value = next;
+  }
+  function expandedPaths(): string[] {
+    return Array.from(expandedDirs.value);
+  }
+  return { isExpanded, toggle, expand, expandedPaths };
 }


### PR DESCRIPTION
## Summary

Phase 2 (client) completes #200. FilesView now fetches one directory at a time through the \`/api/files/dir\` endpoint that #207 added server-side, so the initial Files view load scales with the number of **top-level** directories instead of with every file in the workspace.

Initial mount hits \`/api/files/dir?path=\` once; expanding a collapsed dir hits \`/api/files/dir?path=<dir>\`; collapsing + re-expanding doesn't refetch (cache holds); \`?path=a/b/c.md\` auto-loads ancestors on page load.

Closes #200.

## Items to Confirm / Review

1. **\`rootNode\` vs \`children-by-path\` split**. I store the root's own metadata (name / path / modifiedMs) in \`rootNode\`, and *all* loaded directory children — root + descendants — in a separate \`childrenByPath\` Map keyed by path. Slightly duplicated for root, but it lets FileTree uniformly read children from the cache without a special-case for the root node.
2. **Cache eviction on refresh token bump**: \`reloadRoot()\` wipes the whole cache. The currently-expanded descendants (in \`expandedDirs\` localStorage) get re-fetched lazily by the \`FileTree\` watcher when they remount. I intentionally didn't pre-warm them all in parallel — that would replay the phase-1 worst case. If the UX feels too click-happy, tell me and I'll add a bulk pre-warm.
3. **Deep-link auto-expand walks ancestors sequentially**. For \`?path=a/b/c/d.md\` that's 3 serialised fetches. Could be parallel, but \`loadDirChildren\` takes a short-circuit on cache-present so the bookkeeping stays trivial. Flag if you want parallelism.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/200　これできる？

## Changes

### \`src/components/FilesView.vue\`

- \`tree: Ref<TreeNode | null>\` → \`rootNode: Ref<TreeNode | null>\` + \`childrenByPath: Ref<Map<string, TreeNode[] | null>>\`
- \`loadTree\` → \`loadDirChildren(path)\` hitting \`/api/files/dir?path=<path>\`
- \`ensureAncestorsLoaded(filePath)\` for deep-link reveal
- \`reloadRoot()\` on refresh-token bump — wipes cache, reloads root, lets FileTree re-fetch expanded descendants lazily
- \`recentPaths\` computed now iterates every loaded dir in the cache

### \`src/components/FileTree.vue\`

- New \`children-by-path\` prop + \`load-children\` emit
- Children read from \`props.childrenByPath.get(node.path)\` — \`undefined\` = not loaded (emit \`load-children\`), \`null\` = loading (shows \"Loading...\"), \`TreeNode[]\` = loaded
- Watcher on \`[expanded, cached]\` triggers lazy-fetch for dirs whose expand state is restored from localStorage

### \`src/composables/useExpandedDirs.ts\`

- New \`expand(path)\` (idempotent — for deep-link auto-expand, no toggle semantics needed)
- New \`expandedPaths()\` read helper (unused in this PR, exported for future cache-pre-warm opt-in)

### E2E

- \`e2e/fixtures/api.ts\` — generic \`/api/files/dir\` stub (empty dir) alongside the existing \`/api/files/tree\` stub. Both kept so old specs don't break if they still expect the tree endpoint.
- \`e2e/tests/file-explorer.spec.ts\` — the existing "selecting a file" test now waits for the wiki dir to surface before clicking (lazy-load race otherwise). Mock updated from single \`/api/files/tree\` fixture to a dispatching \`/api/files/dir\` handler.
- \`e2e/tests/file-explorer-lazy.spec.ts\` (**new, 3 tests**):
  - Root mount hits \`/api/files/dir?path=\` once, subtrees unfetched
  - Expand a dir → fetch hits \`?path=<dir>\`; collapse + re-expand → no refetch
  - Deep link \`?path=a/b/foo.md\` → ancestor dirs \`a\` and \`a/b\` both fetched

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors (3 pre-existing \`.vue\` v-html warnings)
- [x] \`yarn typecheck\` / \`yarn build\`
- [x] \`yarn test\` — 1213 pass (no new unit tests — lazy flow is covered by E2E)
- [x] \`yarn test:e2e\` — **must verify on CI**: locally there's a stale vite dev server on :5173 from another checkout (\`reuseExistingServer: true\` picks it up), so tests run against old code. CI spins a fresh server per run so no issue.

## Follow-ups

- Parallel ancestor fetch on deep link (if needed)
- Pre-warm expanded descendants on refresh-token reload (if UX feels clicky)
- Collapse heavy dirs (\`chat/\`, \`searches/\`) into sentinel nodes per #200 item 3 — separate PR

## Summary by Sourcery

Switch the file explorer to lazily load directory contents via the /api/files/dir endpoint instead of loading the full tree upfront.

New Features:
- Add client-side support for per-directory fetching and caching of file tree children, including deep-link ancestor auto-expansion based on the ?path query.

Enhancements:
- Refine recent file detection to iterate over the lazy-load directory cache rather than a single in-memory tree.
- Persist and expose directory expansion state utilities to support auto-expansion without toggle semantics.

Tests:
- Add and update end-to-end tests and API fixtures to cover lazy directory expansion, caching behavior, and deep-link handling in the file explorer.