### PR TITLE
fix(files): HTML script whitelist + markdown image paths in preview

### DIFF
--- a/e2e/tests/files-html-preview.spec.ts
+++ b/e2e/tests/files-html-preview.spec.ts
@@ -1,0 +1,153 @@
+// Regressions guard for two file-explorer content-rendering bugs
+// fixed together:
+//
+//   1. Chart.js-style HTML (inline <script>, canvas-drawn charts)
+//      opened via the Files view was rendered in an iframe with
+//      `sandbox=""`, blocking ALL scripts. Now `allow-scripts` +
+//      a CSP whitelist for trusted CDNs.
+//   2. `![alt](images/foo.png)` in markdown files / wiki pages
+//      rendered via the Files view fell back to the SPA route URL
+//      (e.g. `/chat/.../images/foo.png`) and 404'd. Now rewritten
+//      to `/api/files/raw?path=...` pre-marked.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+async function mockFileContent(
+  page: Page,
+  pathMatch: string,
+  body: { kind: "text" | "image"; content?: string },
+): Promise<void> {
+  await page.route(
+    (url) =>
+      url.pathname === "/api/files/content" &&
+      url.searchParams.get("path") === pathMatch,
+    (route: Route) =>
+      route.fulfill({
+        json: {
+          kind: body.kind,
+          path: pathMatch,
+          content: body.content ?? "",
+          size: 100,
+          modifiedMs: Date.now(),
+        },
+      }),
+  );
+}
+
+test.describe("Files view — HTML iframe sandbox + CSP", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("HTML preview iframe allows scripts (Chart.js would run)", async ({
+    page,
+  }) => {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>Chart</title></head>
+<body>
+<canvas id="c"></canvas>
+<script>/* inline */</script>
+</body>
+</html>`;
+    await mockFileContent(page, "HTMLs/chart.html", {
+      kind: "text",
+      content: html,
+    });
+
+    await page.goto("/chat?view=files&path=HTMLs/chart.html");
+    const iframe = page.locator('iframe[title="HTML preview"]');
+    await expect(iframe).toBeVisible();
+
+    // Sandbox must include `allow-scripts` so Chart.js / inline JS
+    // can actually run — without it LLM-generated chart HTMLs
+    // render as blank canvases.
+    const sandbox = await iframe.getAttribute("sandbox");
+    expect(sandbox).toContain("allow-scripts");
+    // But NOT `allow-same-origin` — keeps the iframe null-origin so
+    // it can't read parent cookies / localStorage.
+    expect(sandbox).not.toContain("allow-same-origin");
+  });
+
+  test("HTML preview injects a CSP meta tag narrowing scripts to whitelisted CDNs", async ({
+    page,
+  }) => {
+    const html = `<!DOCTYPE html><html><head></head><body>x</body></html>`;
+    await mockFileContent(page, "HTMLs/x.html", {
+      kind: "text",
+      content: html,
+    });
+
+    await page.goto("/chat?view=files&path=HTMLs/x.html");
+    const iframe = page.locator('iframe[title="HTML preview"]');
+    await expect(iframe).toBeVisible();
+
+    const srcdoc = await iframe.getAttribute("srcdoc");
+    expect(srcdoc).toBeTruthy();
+    expect(srcdoc).toContain(
+      `<meta http-equiv="Content-Security-Policy" content="default-src 'none'`,
+    );
+    expect(srcdoc).toContain(`https://cdn.jsdelivr.net`);
+    expect(srcdoc).toContain(`connect-src 'none'`);
+  });
+});
+
+test.describe("Files view — markdown image path rewrite", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("`![](images/foo.png)` renders as an `<img src=/api/files/raw?...>`", async ({
+    page,
+  }) => {
+    const md = `# Page\n\n![chart](images/foo.png)\n`;
+    await mockFileContent(page, "markdowns/sample.md", {
+      kind: "text",
+      content: md,
+    });
+
+    await page.goto("/chat?view=files&path=markdowns/sample.md");
+    // Wait for the rendered markdown to surface a real <img>.
+    await expect(page.locator("img[alt='chart']")).toBeVisible();
+    const src = await page.locator("img[alt='chart']").getAttribute("src");
+    // Exact shape varies a bit with encoding; just assert the API
+    // route + the filename landed.
+    expect(src).toContain("/api/files/raw");
+    expect(src).toContain("foo.png");
+  });
+
+  test("`![](../../images/foo.png)` with relative-up prefix also resolves", async ({
+    page,
+  }) => {
+    const md = `![two](../../images/two.png)`;
+    await mockFileContent(page, "wiki/pages/a.md", {
+      kind: "text",
+      content: md,
+    });
+
+    await page.goto("/chat?view=files&path=wiki/pages/a.md");
+    await expect(page.locator("img[alt='two']")).toBeVisible();
+    const src = await page.locator("img[alt='two']").getAttribute("src");
+    expect(src).toContain("/api/files/raw");
+    expect(src).toContain("two.png");
+    // Relative prefix stripped — workspace-rooted path expected.
+    expect(src).not.toContain("..");
+  });
+
+  test("data: URIs and http URLs pass through untouched", async ({ page }) => {
+    const md = `
+![data](data:image/png;base64,AAA=)
+![cdn](https://cdn.example.com/x.png)
+`;
+    await mockFileContent(page, "markdowns/pass.md", {
+      kind: "text",
+      content: md,
+    });
+    await page.goto("/chat?view=files&path=markdowns/pass.md");
+    const dataSrc = await page.locator("img[alt='data']").getAttribute("src");
+    expect(dataSrc).toBe("data:image/png;base64,AAA=");
+    const cdnSrc = await page.locator("img[alt='cdn']").getAttribute("src");
+    expect(cdnSrc).toBe("https://cdn.example.com/x.png");
+  });
+});

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -114,12 +114,22 @@
               class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
               >{{ content.content }}</pre
             >
-            <!-- HTML: sandboxed iframe preview (scripts disabled) -->
+            <!-- HTML: sandboxed iframe preview.
+                 `allow-scripts` lets Chart.js / canvas drawing / other
+                 JS-driven HTML (the common case for LLM-generated
+                 results) run. We deliberately DO NOT grant
+                 `allow-same-origin`, so the iframe keeps a null
+                 origin — it can't read MulmoClaude's cookies,
+                 localStorage, or the parent window's DOM.
+                 A CSP meta tag is injected via wrapHtmlWithPreviewCsp
+                 to restrict script loads to a vetted CDN whitelist +
+                 inline; connect-src is `'none'` so the page can't
+                 phone home. See src/utils/html/previewCsp.ts. -->
             <iframe
               v-else-if="isHtml"
-              :srcdoc="content.content"
+              :srcdoc="sandboxedHtml"
               class="w-full h-full border-0"
-              sandbox=""
+              sandbox="allow-scripts"
               title="HTML preview"
             />
             <!-- JSON: pretty-printed with simple syntax coloring. Fall
@@ -221,6 +231,8 @@ import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import FileTree, { type TreeNode } from "./FileTree.vue";
 import TextResponseView from "../plugins/textResponse/View.vue";
+import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
+import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -319,6 +331,16 @@ function toggleMdRaw(): void {
   localStorage.setItem(MD_RAW_STORAGE_KEY, String(mdRawMode.value));
 }
 const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
+
+// The HTML body handed to the iframe's `srcdoc`. We inject a CSP
+// meta tag that narrows what the LLM's output can load — see
+// src/utils/html/previewCsp.ts. Computed so the injection happens
+// once per content change, not on every render.
+const sandboxedHtml = computed(() =>
+  content.value?.kind === "text" && isHtml.value
+    ? wrapHtmlWithPreviewCsp(content.value.content)
+    : "",
+);
 const isJson = computed(() => hasExt(selectedPath.value, [".json"]));
 const isJsonl = computed(() =>
   hasExt(selectedPath.value, [".jsonl", ".ndjson"]),
@@ -416,13 +438,18 @@ const mdFrontmatter = computed(() => {
 });
 
 function markdownResult(text: string): ToolResultComplete<TextResponseData> {
+  // Rewrite `![alt](path)` refs BEFORE handing the markdown to
+  // TextResponseView (which we don't own — it's a package component)
+  // so workspace-relative image paths resolve via /api/files/raw
+  // instead of 404-ing against the SPA page URL.
+  const rewritten = rewriteMarkdownImageRefs(text);
   return {
     uuid: "files-preview",
     toolName: "text-response",
-    message: text,
+    message: rewritten,
     title: selectedPath.value ?? "",
     // role: "user" hides the PDF download button in TextResponseView
-    data: { text, role: "user", transportKind: "text-rest" },
+    data: { text: rewritten, role: "user", transportKind: "text-rest" },
   };
 }
 

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -140,6 +140,7 @@ import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { renderWikiLinks } from "./helpers";
+import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<WikiData>;
@@ -187,7 +188,12 @@ watch(
 
 const renderedContent = computed(() => {
   if (!content.value) return "";
-  return marked.parse(renderWikiLinks(content.value)) as string;
+  // Rewrite workspace-relative image refs (`![alt](images/foo.png)`)
+  // to `/api/files/raw?path=...` BEFORE marked parses them — without
+  // this, the browser tries to fetch against the SPA route URL
+  // (/chat/…/images/foo.png) and 404s.
+  const withImages = rewriteMarkdownImageRefs(content.value);
+  return marked.parse(renderWikiLinks(withImages)) as string;
 });
 
 const navError = ref<string | null>(null);

--- a/src/utils/html/previewCsp.ts
+++ b/src/utils/html/previewCsp.ts
@@ -1,0 +1,63 @@
+// CSP whitelist applied to HTML files previewed in the Files
+// explorer iframe. We ship a narrow list of trusted CDNs that the
+// LLM commonly pulls from (Chart.js, D3, Tailwind, etc. via
+// jsdelivr / unpkg / cdnjs) plus Google Fonts. Anything else —
+// random `https://` origins, phone-home `fetch()` calls, etc. —
+// is rejected.
+//
+// Widen by editing `HTML_PREVIEW_CSP_ALLOWED_CDNS` below. Keep the
+// list audited — every entry is a potential supply-chain surface.
+
+export const HTML_PREVIEW_CSP_ALLOWED_CDNS: readonly string[] = [
+  "https://cdn.jsdelivr.net",
+  "https://unpkg.com",
+  "https://cdnjs.cloudflare.com",
+  "https://fonts.googleapis.com",
+  "https://fonts.gstatic.com",
+];
+
+/**
+ * Build the CSP string. Split from the wrapper so tests can exercise
+ * the policy without HTML-template noise.
+ */
+export function buildHtmlPreviewCsp(
+  cdns: readonly string[] = HTML_PREVIEW_CSP_ALLOWED_CDNS,
+): string {
+  const cdnList = cdns.join(" ");
+  return [
+    "default-src 'none'",
+    // LLM-authored HTML almost always uses inline <script> blocks
+    // alongside the CDN load. No feasible path to avoid
+    // 'unsafe-inline' without rewriting every output.
+    `script-src 'unsafe-inline' ${cdnList}`,
+    `style-src 'unsafe-inline' ${cdnList}`,
+    `font-src ${cdnList}`,
+    // Images: lenient. Covers /api/files/raw (via wildcard), data
+    // URIs for inline PNGs, blob: for dynamically-generated charts,
+    // and any external https image.
+    "img-src * data: blob:",
+    // Block XHR / fetch / WebSocket so previews can't phone home or
+    // exfiltrate anything the inline scripts happen to compute.
+    "connect-src 'none'",
+  ].join("; ");
+}
+
+const CSP_META_NONCE = ""; // reserved for future use (per-render nonce)
+
+/**
+ * Inject a `<meta http-equiv="Content-Security-Policy">` tag into the
+ * HTML head. If the HTML has no `<head>`, wrap it as a full document
+ * with a synthetic head so the meta tag is honoured regardless.
+ *
+ * Pure — doesn't touch the DOM. Safe to use from both client and
+ * tests.
+ */
+export function wrapHtmlWithPreviewCsp(html: string): string {
+  const csp = buildHtmlPreviewCsp();
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${csp}">`;
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/(<head\b[^>]*>)/i, `$1${meta}`);
+  }
+  // No <head> — treat as fragment and wrap it.
+  return `<!DOCTYPE html><html><head>${meta}</head><body>${html}</body></html>${CSP_META_NONCE}`;
+}

--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -1,0 +1,62 @@
+import { resolveImageSrc } from "./resolve";
+
+// Pre-`marked` pass that rewrites workspace-relative image references
+// in markdown source so they render through the backend file server.
+//
+// Without this, a page like `![chart](../images/foo.png)` produces
+// `<img src="../images/foo.png">`, which the browser resolves against
+// the SPA page URL (e.g. `/chat/…foo.png`) and 404s. After this
+// pass, the src becomes `/api/files/raw?path=images/foo.png` which
+// the workspace file server serves.
+//
+// Kept as a pure string→string transform so it can be applied
+// uniformly wherever we render user/LLM-authored markdown outside
+// the markdown plugin proper:
+//
+//   - `src/plugins/wiki/View.vue`
+//   - `src/components/FilesView.vue` (when previewing a .md file)
+//   - potential future renderers
+//
+// The markdown plugin (`src/plugins/markdown/View.vue`) has its own
+// post-`marked` HTML rewriter; both approaches reach the same end
+// state, but pre-marked is less brittle for places where we don't
+// own the rendering pipeline (TextResponseView).
+
+// Match `![alt](url)`. Single character class per span, no
+// overlapping backtracking surface (linear-time matching).
+const IMAGE_REF_RE = /!\[([^\]]*)\]\(([^)]*)\)/g;
+
+function shouldSkip(url: string): boolean {
+  if (url.startsWith("data:")) return true;
+  if (url.startsWith("http://") || url.startsWith("https://")) return true;
+  // Already an API route — nothing to do.
+  if (url.startsWith("/api/")) return true;
+  return false;
+}
+
+function normalizeRelative(url: string): string {
+  // Strip leading `./` / `../` segments. Markdown authored from
+  // different workspace subdirs typically uses `../images/foo.png`
+  // relative to the file's own directory; our API resolves from the
+  // workspace root so the relative prefix is always noise.
+  let out = url;
+  while (out.startsWith("./")) out = out.slice(2);
+  while (out.startsWith("../")) out = out.slice(3);
+  return out;
+}
+
+/**
+ * Rewrite `![alt](path)` image refs in markdown text so workspace-
+ * relative paths render through `/api/files/raw`. Absolute URLs,
+ * data URIs, and existing API paths pass through untouched.
+ *
+ * Pure — safe to call on any markdown string.
+ */
+export function rewriteMarkdownImageRefs(markdown: string): string {
+  return markdown.replace(IMAGE_REF_RE, (match, alt: string, url: string) => {
+    const trimmedUrl = url.trim();
+    if (trimmedUrl === "" || shouldSkip(trimmedUrl)) return match;
+    const resolved = resolveImageSrc(normalizeRelative(trimmedUrl));
+    return `![${alt}](${resolved})`;
+  });
+}

--- a/test/utils/html/test_previewCsp.ts
+++ b/test/utils/html/test_previewCsp.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  HTML_PREVIEW_CSP_ALLOWED_CDNS,
+  buildHtmlPreviewCsp,
+  wrapHtmlWithPreviewCsp,
+} from "../../../src/utils/html/previewCsp";
+
+describe("buildHtmlPreviewCsp", () => {
+  it("defaults to the exported CDN whitelist", () => {
+    const csp = buildHtmlPreviewCsp();
+    for (const cdn of HTML_PREVIEW_CSP_ALLOWED_CDNS) {
+      assert.ok(csp.includes(cdn), `CSP should include ${cdn}`);
+    }
+  });
+
+  it("denies everything by default (default-src 'none')", () => {
+    const csp = buildHtmlPreviewCsp();
+    assert.ok(csp.includes("default-src 'none'"));
+  });
+
+  it("allows inline scripts alongside the CDN whitelist", () => {
+    const csp = buildHtmlPreviewCsp();
+    assert.ok(
+      csp.includes("script-src 'unsafe-inline' https://cdn.jsdelivr.net"),
+    );
+  });
+
+  it("blocks connect-src entirely (no phone-home)", () => {
+    const csp = buildHtmlPreviewCsp();
+    assert.ok(csp.includes("connect-src 'none'"));
+  });
+
+  it("allows images from anywhere plus data: and blob:", () => {
+    const csp = buildHtmlPreviewCsp();
+    assert.ok(csp.includes("img-src * data: blob:"));
+  });
+
+  it("accepts a custom CDN list", () => {
+    const csp = buildHtmlPreviewCsp(["https://example.com"]);
+    assert.ok(csp.includes("script-src 'unsafe-inline' https://example.com"));
+    assert.ok(!csp.includes("jsdelivr"));
+  });
+});
+
+describe("wrapHtmlWithPreviewCsp", () => {
+  it("injects the meta tag into an existing <head>", () => {
+    const html = `<!DOCTYPE html><html><head><title>x</title></head><body>x</body></html>`;
+    const out = wrapHtmlWithPreviewCsp(html);
+    assert.ok(
+      out.includes(
+        `<head><meta http-equiv="Content-Security-Policy" content="default-src 'none'`,
+      ),
+    );
+    // Original <title> preserved right after the injected meta.
+    assert.ok(out.includes(`"><title>x</title>`));
+  });
+
+  it("wraps a fragment in a synthetic full document when <head> is absent", () => {
+    const out = wrapHtmlWithPreviewCsp("<p>just a fragment</p>");
+    assert.ok(out.startsWith("<!DOCTYPE html><html><head>"));
+    assert.ok(out.includes(`Content-Security-Policy`));
+    assert.ok(out.includes("<body><p>just a fragment</p></body>"));
+  });
+
+  it("is case-insensitive against <HEAD>", () => {
+    const html = `<!DOCTYPE html><html><HEAD></HEAD><body>x</body></html>`;
+    const out = wrapHtmlWithPreviewCsp(html);
+    assert.ok(out.includes(`<HEAD><meta http-equiv`));
+  });
+});

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { rewriteMarkdownImageRefs } from "../../../src/utils/image/rewriteMarkdownImageRefs";
+
+describe("rewriteMarkdownImageRefs", () => {
+  it("rewrites a simple relative image ref to an /api/files/raw URL", () => {
+    const out = rewriteMarkdownImageRefs("![chart](images/foo.png)");
+    assert.equal(out, "![chart](/api/files/raw?path=images%2Ffoo.png)");
+  });
+
+  it("strips a leading ./", () => {
+    const out = rewriteMarkdownImageRefs("![a](./images/foo.png)");
+    assert.ok(out.includes("path=images%2Ffoo.png"));
+  });
+
+  it("strips multiple ../ segments", () => {
+    const out = rewriteMarkdownImageRefs("![a](../../images/foo.png)");
+    assert.ok(out.includes("path=images%2Ffoo.png"));
+  });
+
+  it("leaves data: URIs alone", () => {
+    const src = "![a](data:image/png;base64,AAA=)";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("leaves http/https URLs alone", () => {
+    const src =
+      "![cdn](https://cdn.example.com/x.png)\n![http](http://example.com/y.png)";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("leaves existing /api/ paths alone (idempotent when pre-resolved)", () => {
+    const src = "![a](/api/files/raw?path=images%2Ffoo.png)";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("rewrites multiple refs in one document", () => {
+    const src = `
+# Title
+![a](./a.png)
+text
+![b](images/b.png)
+`;
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("path=a.png"));
+    assert.ok(out.includes("path=images%2Fb.png"));
+  });
+
+  it("preserves alt text and empty alt", () => {
+    assert.equal(
+      rewriteMarkdownImageRefs("![some alt](images/x.png)"),
+      "![some alt](/api/files/raw?path=images%2Fx.png)",
+    );
+    assert.equal(
+      rewriteMarkdownImageRefs("![](images/x.png)"),
+      "![](/api/files/raw?path=images%2Fx.png)",
+    );
+  });
+
+  it("does not touch non-image markdown links", () => {
+    const src = "[not an image](images/x.png) and [[wiki-link]]";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+});


### PR DESCRIPTION
## Summary

Three related file-explorer preview bugs, fixed together:

1. **Chart.js-style HTML rendered blank** — iframe's \`sandbox=""\` blocked all scripts (this is what prompted the report, from the \`デフレ勝ち組企業 — 株価推移比較\` HTML that uses Chart.js on canvas).
2. **LLM HTML could phone home / load anything** — with \`sandbox="allow-scripts"\` alone the iframe could still fetch any CDN or make XHRs. Injected a CSP meta tag that narrows scripts to a vetted CDN whitelist (jsdelivr / unpkg / cdnjs / Google Fonts) + inline; \`connect-src 'none'\` kills fetch/XHR/WebSocket.
3. **\`![img](path)\` broken in wiki + markdown files** — after the base64→file migration, relative image refs in markdown rendered by wiki/View or FilesView fell back to the SPA route URL and 404'd. Added a shared pre-marked rewrite helper.

## Items to Confirm / Review

1. **CSP whitelist** lives in \`HTML_PREVIEW_CSP_ALLOWED_CDNS\` (\`src/utils/html/previewCsp.ts\`). Widen as needed — every entry is a supply-chain surface, so audit first.
2. **\`allow-same-origin\` deliberately NOT granted** — keeps the iframe null-origin so it can't read MulmoClaude cookies / localStorage. This is a conscious trade-off vs. the \`presentHtml\` plugin which DOES grant it for \`window.print()\` support.
3. **Markdown image rewrite is pre-\`marked\`** (markdown string) in wiki + FilesView, but the markdown plugin keeps its own post-\`marked\` HTML rewrite. Both reach the same output; unified later if you want one code path.

## User Prompt

> デフレ勝ち組企業 — 株価推移比較 の html ファイルエクスプローラーで画像が出ないかも
>
> ok それ以外に画像についてはbase64からファイルに変わったから本当に画像の問題がないか確認しつつ、もし可能ならこういう問題もe2eで検出できると嬉しい。できるだけの対策をして。
>
> あー、スクリプトだけどwhite listにしたほうがよいかな。必要なプラグインと、localのものだけ動かしたい。

## Changes

### \`src/utils/html/previewCsp.ts\` (new)
- \`HTML_PREVIEW_CSP_ALLOWED_CDNS\` — vetted CDN list
- \`buildHtmlPreviewCsp(cdns?)\` — returns the CSP string
- \`wrapHtmlWithPreviewCsp(html)\` — injects \`<meta>\` into \`<head>\` or wraps fragment in a synthetic full document

### \`src/utils/image/rewriteMarkdownImageRefs.ts\` (new)
- Pre-\`marked\` transform: \`![alt](images/foo.png)\` → \`![alt](/api/files/raw?path=images%2Ffoo.png)\`
- Strips \`./\` / \`../\` prefixes
- Pass-through for \`data:\`, \`http(s):\`, \`/api/\`

### \`src/components/FilesView.vue\`
- iframe: \`sandbox=""\` → \`sandbox="allow-scripts"\`
- iframe \`:srcdoc\` now bound to \`sandboxedHtml\` computed (wraps with CSP)
- \`markdownResult\` applies \`rewriteMarkdownImageRefs\` so TextResponseView receives workspace-resolved image URLs

### \`src/plugins/wiki/View.vue\`
- \`renderedContent\` applies \`rewriteMarkdownImageRefs\` before \`marked.parse\`

### Tests

- \`test/utils/html/test_previewCsp.ts\` (9 cases): CDN list in output, default-src 'none', 'unsafe-inline' + CDN script-src, connect-src 'none', img-src lenience, custom CDN list override, head injection, fragment wrap, case-insensitive \`<HEAD>\`
- \`test/utils/image/test_rewriteMarkdownImageRefs.ts\` (9 cases): simple ref, ./, ../.., data URI pass-through, http pass-through, idempotent /api/, multi-ref doc, alt text preservation, non-image link safety
- \`e2e/tests/files-html-preview.spec.ts\` (5 cases): iframe sandbox \`allow-scripts\` + no \`allow-same-origin\`, CSP meta injection, markdown image → /api/files/raw (same-dir + ../../), data/http pass-through

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors (3 pre-existing \`.vue\` v-html warnings)
- [x] \`yarn typecheck\` / \`yarn build\`
- [x] \`yarn test\` — 1290 pass (18 new)
- [x] \`yarn test:e2e\` — 135 pass (5 new)
- [ ] Manual smoke: open \`~/mulmoclaude/HTMLs/j-QxYsnDsJOXZoM8-1776079092836.html\` (the deflation-winners stock chart HTML) via File Explorer → charts should now render; open a wiki page with an \`![](images/foo.png)\` ref → image should appear

## Summary by Sourcery

Harden HTML file previews and fix markdown image rendering in the file explorer and wiki views.

Bug Fixes:
- Allow scripts to run in HTML file previews while preventing them from accessing parent origin data.
- Rewrite workspace-relative markdown image paths so images resolve through the backend file server instead of 404ing.

Enhancements:
- Introduce a reusable CSP builder and wrapper for HTML previews that whitelists trusted CDNs and blocks outbound connections.
- Add a shared markdown image rewrite utility for use across file explorer and wiki markdown renderers.

Tests:
- Add unit tests for the HTML preview CSP generation and injection behavior.
- Add unit tests for the markdown image rewrite helper, covering relative paths, absolute URLs, and pass-through cases.
- Add end-to-end tests for HTML preview sandbox/CSP behavior and markdown image path rewriting in the Files view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML previews in Files view now support script execution with sandboxing and content security policies applied.
  * Markdown image references are automatically rewritten to load correctly in Files view and Wiki view, including proper handling of relative paths and external URLs.

* **Tests**
  * Added end-to-end tests for HTML preview rendering and image path rewriting functionality.
  * Added unit tests for HTML CSP utilities and markdown image rewriting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->