### PR TITLE
refactor(server): extract logBackgroundError helper

### DIFF
--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -18,6 +18,7 @@ import { maybeRunJournal } from "../journal/index.js";
 import { maybeIndexSession } from "../chat-index/index.js";
 import { maybeAppendWikiBacklinks } from "../wiki-backlinks/index.js";
 import { log } from "../logger/index.js";
+import { logBackgroundError } from "../utils/logBackgroundError.js";
 import { createArgsCache, recordToolEvent } from "../tool-trace/index.js";
 
 const router = Router();
@@ -325,11 +326,7 @@ async function runAgentInBackground(
           chatSessionId,
           resultsFilePath,
           argsCache: toolArgsCache,
-        }).catch((err) => {
-          log.warn("tool-trace", "unexpected error in background", {
-            error: String(err),
-          });
-        });
+        }).catch(logBackgroundError("tool-trace"));
       }
     }
     log.info("agent", "request completed", {
@@ -346,20 +343,12 @@ async function runAgentInBackground(
     endRun(chatSessionId);
     // Fire-and-forget: journal + chat-index post-processing
     maybeRunJournal({ activeSessionIds: getActiveSessionIds() }).catch(
-      (err) => {
-        log.warn("journal", "unexpected error in background", {
-          error: String(err),
-        });
-      },
+      logBackgroundError("journal"),
     );
     maybeIndexSession({
       sessionId: chatSessionId,
       activeSessionIds: getActiveSessionIds(),
-    }).catch((err) => {
-      log.warn("chat-index", "unexpected error in background", {
-        error: String(err),
-      });
-    });
+    }).catch(logBackgroundError("chat-index"));
     // Walks wiki/pages/ for files modified during this turn and
     // appends a backlink to the originating chat session so the
     // user can jump back from a wiki page to the conversation
@@ -367,11 +356,7 @@ async function runAgentInBackground(
     maybeAppendWikiBacklinks({
       chatSessionId,
       turnStartedAt: requestStartedAt,
-    }).catch((err) => {
-      log.warn("wiki-backlinks", "unexpected error in background", {
-        error: String(err),
-      });
-    });
+    }).catch(logBackgroundError("wiki-backlinks"));
   }
 }
 

--- a/server/utils/logBackgroundError.ts
+++ b/server/utils/logBackgroundError.ts
@@ -1,0 +1,22 @@
+import { log } from "../logger/index.js";
+
+/**
+ * Build a `.catch` handler for a fire-and-forget background job that
+ * logs the failure under the given prefix. Consolidates the
+ * "unexpected error in background" pattern used across journal,
+ * chat-index, wiki-backlinks, tool-trace, etc.
+ *
+ * Usage:
+ *
+ *   maybeRunJournal({ ... }).catch(logBackgroundError("journal"));
+ *
+ * The handler never rethrows — the caller's promise chain is
+ * terminated cleanly so nothing propagates into the request path.
+ */
+export function logBackgroundError(prefix: string): (err: unknown) => void {
+  return (err) => {
+    log.warn(prefix, "unexpected error in background", {
+      error: String(err),
+    });
+  };
+}

--- a/test/utils/test_logBackgroundError.ts
+++ b/test/utils/test_logBackgroundError.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { logBackgroundError } from "../../server/utils/logBackgroundError.js";
+
+// The helper returns a callback. We capture stderr (the logger's
+// warn level target) so we can assert what lands without wiring
+// dependency injection into the logger itself.
+function captureStderr<T>(fn: () => T): { result: T; out: string } {
+  const chunks: string[] = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((c: string | Uint8Array) => {
+    chunks.push(typeof c === "string" ? c : c.toString());
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = fn();
+    return { result, out: chunks.join("") };
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+}
+
+describe("logBackgroundError", () => {
+  it("returns a function that logs a warn with the given prefix", () => {
+    const handler = logBackgroundError("journal");
+    assert.equal(typeof handler, "function");
+    const { out } = captureStderr(() => handler(new Error("boom")));
+    assert.ok(out.includes("[journal]"), `missing prefix in: ${out}`);
+    assert.ok(out.includes("unexpected error in background"));
+    assert.ok(out.includes("boom"));
+  });
+
+  it("stringifies non-Error thrown values", () => {
+    const handler = logBackgroundError("chat-index");
+    const { out } = captureStderr(() => handler("plain string"));
+    assert.ok(out.includes("plain string"));
+  });
+
+  it("does not throw back to the caller", () => {
+    const handler = logBackgroundError("tool-trace");
+    captureStderr(() => {
+      assert.doesNotThrow(() => handler(new Error("x")));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

\`server/routes/agent.ts\` had 4 near-identical \`.catch\` blocks for fire-and-forget background jobs (journal / chat-index / wiki-backlinks / tool-trace) — each reconstructed the same closure inline. Extracted to \`server/utils/logBackgroundError.ts\`:

\`\`\`ts
.catch(logBackgroundError("journal"))
.catch(logBackgroundError("chat-index"))
.catch(logBackgroundError("wiki-backlinks"))
.catch(logBackgroundError("tool-trace"))
\`\`\`

No behavioural change. Same prefix, same message, same payload shape.

## Items to Confirm / Review

1. **Prefix strings preserved exactly** — \`journal\` / \`chat-index\` / \`wiki-backlinks\` / \`tool-trace\`. Log dashboards filtering on these still work.
2. **Test uses stderr capture** — warn-level logs hit stderr per the console sink (\`server/logger/sinks.ts\`). Capturing globally during the test should be safe since it's synchronous.

## User Prompt

> ここ１日に追加した内容で、DRYとか、関数化とか、テストでrefactoringする必要のある箇所がないか確認して。きれいなコードを保ちたい
>
> 1,2,3,4,5を全部別々のPRで。

This is PR 1 of 5.

## Changes

- \`server/utils/logBackgroundError.ts\` (new, 17 lines) — exported \`logBackgroundError(prefix)\` returning a \`.catch\`-compatible handler
- \`server/routes/agent.ts\` — 4 inline closures replaced with one-liners; ~14 lines of boilerplate removed
- \`test/utils/test_logBackgroundError.ts\` (new, 3 cases) — happy path, non-Error stringification, no-throw contract

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors
- [x] \`yarn test\` — 1281 pass (3 new \`logBackgroundError\` cases)
- Note: \`yarn build\` has pre-existing TS errors in \`src/plugins/{scheduler,spreadsheet,todo}/definition.ts\` unrelated to this PR (\`ToolDefinition\` 'prompt' field) — same errors appear on \`main\`

## Summary by Sourcery

Extract a reusable helper for logging background job errors and update callers to use it.

Enhancements:
- Introduce a logBackgroundError utility to centralize warn-level logging for fire-and-forget background jobs.
- Refactor agent background processing routes to use the shared logging helper, reducing duplicated catch blocks.

Tests:
- Add unit tests for logBackgroundError covering logging behavior, non-Error inputs, and non-throwing contract.