### PR TITLE
refactor(markdown): use shared rewriteMarkdownImageRefs helper

### DIFF
--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -85,7 +85,7 @@ import { computed, ref, watch, nextTick } from "vue";
 import { marked } from "marked";
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
-import { resolveImageSrc } from "../../utils/image/resolve";
+import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 
 const props = defineProps<{
@@ -143,24 +143,14 @@ const hasChanges = computed(() => {
   return editableMarkdown.value !== markdownContent.value;
 });
 
-// Resolve image paths in rendered HTML so workspace-relative paths become URLs.
-// Markdown files use "../images/xyz.png" (relative from markdowns/ dir);
-// strip the "../" prefix to get the workspace-relative path for resolveImageSrc.
-function resolveImagesInHtml(html: string): string {
-  return html.replace(
-    /(<img\s[^>]*src=")([^"]+)(")/g,
-    (_match, before: string, src: string, after: string) => {
-      if (src.startsWith("data:") || src.startsWith("http")) return _match;
-      const normalized = src.replace(/^\.\.\//, "");
-      return `${before}${resolveImageSrc(normalized)}${after}`;
-    },
-  );
-}
-
+// Rewrite workspace-relative image refs `![alt](../images/foo.png)`
+// to `/api/files/raw?path=...` via the shared helper BEFORE marked
+// runs. Keeps the image-resolving rules in one place (shared with
+// wiki/View and FilesView's markdown preview).
 const renderedHtml = computed(() => {
   if (!markdownContent.value) return "";
-  const html = marked(markdownContent.value) as string;
-  return resolveImagesInHtml(html);
+  const withImages = rewriteMarkdownImageRefs(markdownContent.value);
+  return marked(withImages) as string;
 });
 
 // Watch for scroll requests from viewState


### PR DESCRIPTION
## Summary

Consolidates the markdown plugin's local \`resolveImagesInHtml\` (post-\`marked\` HTML rewrite) into the shared \`rewriteMarkdownImageRefs\` (pre-\`marked\` markdown rewrite) helper #216 added. Same skip rules, same normalisation, same output — one place to maintain instead of two.

**Stacked on #216** (its branch \`fix/html-scripts-and-image-paths\` provides the shared helper). Rebase onto main once #216 lands.

## Items to Confirm / Review

- Stage flip: the plugin used to rewrite **after** marked on the HTML output; now it rewrites **before** marked on the markdown source. Output is equivalent for the cases covered by the helper's unit tests (9 cases in #216's test file). If you have markdown that depends on the exact post-marked behaviour (unlikely) flag it.

## User Prompt

> ここ１日に追加した内容で、DRYとか、関数化とか、テストでrefactoringする必要のある箇所がないか確認して。きれいなコードを保ちたい
>
> 1,2,3,4,5を全部別々のPRで。

This is PR 2 of 5 in the DRY audit sweep.

## Changes

\`src/plugins/markdown/View.vue\`:
- Drops local \`resolveImagesInHtml\` function (~10 lines)
- Drops \`resolveImageSrc\` import (no longer used directly)
- \`renderedHtml\` computed now pre-rewrites the markdown via \`rewriteMarkdownImageRefs\`, then passes to \`marked\`

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors
- [x] \`yarn test\` — 1281 pass (helper's 9 unit cases cover the transform)
- Note: no new test in this PR — behaviour is exercised by #216's \`test_rewriteMarkdownImageRefs.ts\` + the existing markdown-plugin E2E still works

## Summary by Sourcery

Enhancements:
- Replace the markdown plugin's local HTML-based image resolution logic with the shared rewriteMarkdownImageRefs helper that operates on markdown before rendering.