### PR TITLE
refactor(wiki): use statSafeAsync/readDirSafeAsync in pageIndex

### DIFF
--- a/server/routes/wiki/pageIndex.ts
+++ b/server/routes/wiki/pageIndex.ts
@@ -8,7 +8,7 @@
 // Eliminates the sync `readdirSync` + linear `find()` in the old
 // `resolvePagePath` — see #201.
 
-import fsp from "node:fs/promises";
+import { readDirSafeAsync, statSafeAsync } from "../../utils/fs.js";
 
 export interface PageIndex {
   mtimeMs: number;
@@ -25,7 +25,7 @@ let cache: PageIndex | null = null;
  * Safe to call concurrently — racing builds produce the same result.
  */
 export async function getPageIndex(pagesDir: string): Promise<PageIndex> {
-  const stat = await fsp.stat(pagesDir).catch(() => null);
+  const stat = await statSafeAsync(pagesDir);
   if (!stat) {
     // Dir doesn't exist yet (never ingested). Return empty but
     // don't cache a stale-forever value — the next call will
@@ -35,9 +35,11 @@ export async function getPageIndex(pagesDir: string): Promise<PageIndex> {
   if (cache && cache.mtimeMs >= stat.mtimeMs) {
     return cache;
   }
-  const entries = await fsp.readdir(pagesDir).catch(() => []);
+  const entries = await readDirSafeAsync(pagesDir);
   const slugs = new Map<string, string>();
-  for (const name of entries) {
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const name = entry.name;
     if (!name.endsWith(".md")) continue;
     slugs.set(name.slice(0, -".md".length), name);
   }


### PR DESCRIPTION
## Summary

Replaces raw `fsp.stat` / `fsp.readdir` + inline `.catch(() => null)` / `.catch(() => [])` in `server/routes/wiki/pageIndex.ts` with the existing `statSafeAsync` / `readDirSafeAsync` helpers from `server/utils/fs.ts`. Both helpers already swallow ENOENT/EACCES and have the same fallback contract this code was manually re-implementing.

## Items to Confirm / Review

- **Subtle behaviour tweak** — `readDirSafeAsync` uses `withFileTypes: true`, so the loop now iterates `Dirent[]` and adds an `entry.isFile()` guard before the `.md` suffix filter. This is a strict improvement: before, a directory literally named `foo.md` would have been indexed as a page slug and any read-by-slug would then fail; now such directories are skipped at index time. No real-world impact expected (nothing in the wiki writer creates `.md`-suffixed directories) but worth noting.
- **Cache key unchanged** — still module-level, unscoped by `pagesDir`. Same behaviour as before.

## User Prompt

> ここ１日に追加した内容で、DRYとか、関数化とか、テストでrefactoringする必要のある箇所がないか確認して。きれいなコードを保ちたい

> 1,2,3,4,5を全部別々のPRで。

This is PR 5 of 5 from the DRY/refactor audit.

## Test plan

- [x] `yarn test` — 1278 passed, 0 failed
- [x] `yarn format` / `yarn lint` — clean (3 pre-existing v-html warnings unchanged)
- [x] `yarn typecheck` — 7 pre-existing errors on main confirmed not introduced by this change

## Note

The 7 `'prompt' does not exist in type 'ToolDefinition'` errors exist on main and are out of scope here — they need a separate fix against `gui-chat-protocol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor wiki page index generation to reuse shared filesystem helper utilities for safer directory and stat handling while preserving existing caching behavior.

Enhancements:
- Replace direct fs.promises usage in wiki page index with statSafeAsync/readDirSafeAsync helpers to centralize ENOENT/EACCES handling and align with existing filesystem abstractions.
- Tighten page discovery by iterating Dirent entries and only indexing .md files that are regular files, avoiding accidental indexing of .md-named directories.