### PR TITLE
fix(image): resolve markdown image paths via basePath

### DIFF
--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -458,8 +458,12 @@ function markdownResult(text: string): ToolResultComplete<TextResponseData> {
   // Rewrite `![alt](path)` refs BEFORE handing the markdown to
   // TextResponseView (which we don't own — it's a package component)
   // so workspace-relative image paths resolve via /api/files/raw
-  // instead of 404-ing against the SPA page URL.
-  const rewritten = rewriteMarkdownImageRefs(text);
+  // instead of 404-ing against the SPA page URL. basePath is the
+  // directory of the current file so `../` refs resolve correctly.
+  const current = selectedPath.value ?? "";
+  const slash = current.lastIndexOf("/");
+  const basePath = slash >= 0 ? current.slice(0, slash) : "";
+  const rewritten = rewriteMarkdownImageRefs(text, basePath);
   return {
     uuid: "files-preview",
     toolName: "text-response",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -191,8 +191,10 @@ const renderedContent = computed(() => {
   // Rewrite workspace-relative image refs (`![alt](images/foo.png)`)
   // to `/api/files/raw?path=...` BEFORE marked parses them — without
   // this, the browser tries to fetch against the SPA route URL
-  // (/chat/…/images/foo.png) and 404s.
-  const withImages = rewriteMarkdownImageRefs(content.value);
+  // (/chat/…/images/foo.png) and 404s. basePath = wiki/pages for
+  // individual pages so `../images/foo.png` resolves correctly.
+  const basePath = action.value === "page" ? "wiki/pages" : "wiki";
+  const withImages = rewriteMarkdownImageRefs(content.value, basePath);
   return marked.parse(renderWikiLinks(withImages)) as string;
 });
 

--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -9,18 +9,18 @@ import { resolveImageSrc } from "./resolve";
 // pass, the src becomes `/api/files/raw?path=images/foo.png` which
 // the workspace file server serves.
 //
-// Kept as a pure string→string transform so it can be applied
-// uniformly wherever we render user/LLM-authored markdown outside
-// the markdown plugin proper:
+// Callers that know the markdown file's directory (`basePath`) get
+// correct resolution for `./` and `../` relative refs. Callers that
+// omit `basePath` only resolve refs that are already workspace-rooted
+// (no leading `./` or `../`); relative-with-traversal refs without
+// context would be ambiguous, so they pass through untouched rather
+// than silently pointing at the wrong file.
+//
+// Used by:
 //
 //   - `src/plugins/wiki/View.vue`
 //   - `src/components/FilesView.vue` (when previewing a .md file)
-//   - potential future renderers
-//
-// The markdown plugin (`src/plugins/markdown/View.vue`) has its own
-// post-`marked` HTML rewriter; both approaches reach the same end
-// state, but pre-marked is less brittle for places where we don't
-// own the rendering pipeline (TextResponseView).
+//   - `src/plugins/markdown/View.vue` (via post-`marked` HTML rewriter)
 
 // Match `![alt](url)`. Single character class per span, no
 // overlapping backtracking surface (linear-time matching).
@@ -34,29 +34,60 @@ function shouldSkip(url: string): boolean {
   return false;
 }
 
-function normalizeRelative(url: string): string {
-  // Strip leading `./` / `../` segments. Markdown authored from
-  // different workspace subdirs typically uses `../images/foo.png`
-  // relative to the file's own directory; our API resolves from the
-  // workspace root so the relative prefix is always noise.
-  let out = url;
-  while (out.startsWith("./")) out = out.slice(2);
-  while (out.startsWith("../")) out = out.slice(3);
-  return out;
+/**
+ * Resolve `url` relative to `basePath` using posix segment arithmetic.
+ * Returns the resolved workspace-relative path, or `null` if the URL
+ * escapes the workspace root (more `..` than `basePath` depth).
+ *
+ * Pure string operation — does not touch the filesystem or use Node's
+ * `path` module (this file runs in the browser).
+ */
+function resolveWorkspacePath(basePath: string, url: string): string | null {
+  // Absolute-within-workspace (e.g. "/images/foo.png") — reset base.
+  const isAbsolute = url.startsWith("/");
+  const baseSegs = isAbsolute
+    ? []
+    : basePath.split("/").filter((s) => s !== "" && s !== ".");
+  const segs = [...baseSegs];
+
+  const urlSegs = (isAbsolute ? url.slice(1) : url).split("/");
+  for (const seg of urlSegs) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (segs.length === 0) return null;
+      segs.pop();
+      continue;
+    }
+    segs.push(seg);
+  }
+  if (segs.length === 0) return null;
+  return segs.join("/");
 }
 
 /**
  * Rewrite `![alt](path)` image refs in markdown text so workspace-
- * relative paths render through `/api/files/raw`. Absolute URLs,
- * data URIs, and existing API paths pass through untouched.
+ * relative paths render through `/api/files/raw`.
  *
- * Pure — safe to call on any markdown string.
+ * @param markdown Markdown source text.
+ * @param basePath The workspace-relative directory of the markdown
+ *   file (e.g. `"wiki/pages"` for `wiki/pages/foo.md`). Omit or pass
+ *   `""` when resolving refs against the workspace root.
+ *
+ * Absolute URLs, data URIs, and existing API paths pass through
+ * untouched. Refs that would escape the workspace root (more `..`
+ * than `basePath` depth) also pass through untouched — they would
+ * 404 regardless, and passing through lets the user see the broken
+ * ref instead of silently re-pointing it.
  */
-export function rewriteMarkdownImageRefs(markdown: string): string {
+export function rewriteMarkdownImageRefs(
+  markdown: string,
+  basePath: string = "",
+): string {
   return markdown.replace(IMAGE_REF_RE, (match, alt: string, url: string) => {
     const trimmedUrl = url.trim();
     if (trimmedUrl === "" || shouldSkip(trimmedUrl)) return match;
-    const resolved = resolveImageSrc(normalizeRelative(trimmedUrl));
-    return `![${alt}](${resolved})`;
+    const resolved = resolveWorkspacePath(basePath, trimmedUrl);
+    if (resolved === null) return match;
+    return `![${alt}](${resolveImageSrc(resolved)})`;
   });
 }

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { rewriteMarkdownImageRefs } from "../../../src/utils/image/rewriteMarkdownImageRefs";
 
-describe("rewriteMarkdownImageRefs", () => {
+describe("rewriteMarkdownImageRefs — no basePath", () => {
   it("rewrites a simple relative image ref to an /api/files/raw URL", () => {
     const out = rewriteMarkdownImageRefs("![chart](images/foo.png)");
     assert.equal(out, "![chart](/api/files/raw?path=images%2Ffoo.png)");
@@ -10,11 +10,6 @@ describe("rewriteMarkdownImageRefs", () => {
 
   it("strips a leading ./", () => {
     const out = rewriteMarkdownImageRefs("![a](./images/foo.png)");
-    assert.ok(out.includes("path=images%2Ffoo.png"));
-  });
-
-  it("strips multiple ../ segments", () => {
-    const out = rewriteMarkdownImageRefs("![a](../../images/foo.png)");
     assert.ok(out.includes("path=images%2Ffoo.png"));
   });
 
@@ -60,5 +55,69 @@ text
   it("does not touch non-image markdown links", () => {
     const src = "[not an image](images/x.png) and [[wiki-link]]";
     assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("passes through refs with `..` when basePath is unknown (escapes workspace root)", () => {
+    // Without basePath, `../images/foo.png` can't be resolved — any
+    // answer would be wrong half the time. Leave the ref alone so the
+    // user sees a 404 rather than a silently-wrong image.
+    const src = "![a](../images/foo.png)";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+});
+
+describe("rewriteMarkdownImageRefs — with basePath", () => {
+  it("resolves `../images/foo.png` from wiki/pages to wiki/images/foo.png", () => {
+    const out = rewriteMarkdownImageRefs(
+      "![a](../images/foo.png)",
+      "wiki/pages",
+    );
+    assert.equal(out, "![a](/api/files/raw?path=wiki%2Fimages%2Ffoo.png)");
+  });
+
+  it("resolves `../../images/foo.png` from markdowns/2026 to images/foo.png", () => {
+    const out = rewriteMarkdownImageRefs(
+      "![a](../../images/foo.png)",
+      "markdowns/2026",
+    );
+    assert.equal(out, "![a](/api/files/raw?path=images%2Ffoo.png)");
+  });
+
+  it("resolves `./foo.png` from wiki/pages to wiki/pages/foo.png", () => {
+    const out = rewriteMarkdownImageRefs("![a](./foo.png)", "wiki/pages");
+    assert.equal(out, "![a](/api/files/raw?path=wiki%2Fpages%2Ffoo.png)");
+  });
+
+  it("resolves bare `foo.png` from wiki/pages to wiki/pages/foo.png", () => {
+    const out = rewriteMarkdownImageRefs("![a](foo.png)", "wiki/pages");
+    assert.equal(out, "![a](/api/files/raw?path=wiki%2Fpages%2Ffoo.png)");
+  });
+
+  it("treats a leading `/` as workspace-root absolute, ignoring basePath", () => {
+    const out = rewriteMarkdownImageRefs("![a](/images/foo.png)", "wiki/pages");
+    assert.equal(out, "![a](/api/files/raw?path=images%2Ffoo.png)");
+  });
+
+  it("passes through refs that escape the workspace root", () => {
+    // `../../../foo.png` from `wiki/pages` (depth 2) escapes.
+    const src = "![a](../../../foo.png)";
+    assert.equal(rewriteMarkdownImageRefs(src, "wiki/pages"), src);
+  });
+
+  it("normalizes redundant `./` and `..` segments mid-path", () => {
+    const out = rewriteMarkdownImageRefs(
+      "![a](./sub/../images/foo.png)",
+      "wiki/pages",
+    );
+    assert.equal(
+      out,
+      "![a](/api/files/raw?path=wiki%2Fpages%2Fimages%2Ffoo.png)",
+    );
+  });
+
+  it("leaves data/http/api refs untouched even when basePath is given", () => {
+    const src =
+      "![a](data:image/png;base64,AAA=) ![b](https://ex.com/x.png) ![c](/api/files/raw?path=x)";
+    assert.equal(rewriteMarkdownImageRefs(src, "wiki/pages"), src);
   });
 });


### PR DESCRIPTION
## Summary

`rewriteMarkdownImageRefs` の `../` 処理を修正。これまでは markdown ファイルの位置を知らずに `../` を単純に剥がしていたため、ファイルの場所によっては間違ったパスを workspace ルート相対として解決していた。

オプション引数 `basePath`（markdown ファイルの workspace 相対ディレクトリ）を追加し、posix セグメント演算で正しく解決するようにした。workspace 外に出る参照（`..` が `basePath` の深さより多い）は rewrite せずそのまま返し、ユーザーに 404 を見せる（silently wrong より正しい）。

## Items to Confirm / Review

- **挙動変化のポイント**:
  - `FilesView.vue` は `selectedPath` から basePath を導出
  - `wiki/View.vue` は個別ページ表示時 `wiki/pages` を basePath にする（インデックスは `wiki`）
  - `basePath` 省略時に `../foo.png` は rewrite されない（以前は `foo.png` として workspace ルートに解決していた）— これは正しい動作だが、万一この挙動に依存していた呼び出しがあれば挙動変化
- **既存 E2E (`files-html-preview.spec.ts`)**: `wiki/pages/a.md` 内の `../../images/two.png` が `images/two.png` に解決されることを既に assert しており、そのまま pass
- **実装方針**: Node の `path` モジュールを使わずブラウザで動く純粋な文字列演算にした（このファイルはブラウザバンドルに入るため）

## User Prompt

> 24時間以内のPRでcode rabbitのコメントをみてないものがある。一応一通り確認してほしい

CodeRabbit が #216 に対して指摘していた3項目のうち2つ目に対応するPR。残り1つ（image-ref regex のコードブロック誤爆）は別PR。

## Test plan

- [x] `yarn test test/utils/image/test_rewriteMarkdownImageRefs.ts` — 1286 passed (新規 9 テスト追加: basePath あり/なし両ケース、workspace escape 検出、正規化)
- [x] `yarn test:e2e -- tests/files-html-preview.spec.ts` — 5 passed
- [x] `yarn format` / `yarn lint` / `yarn typecheck` — clean
- [ ] **Manual**: wiki の個別ページで `../images/...` を含むページが正しく画像表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix markdown image URL rewriting to resolve relative image paths based on the markdown file’s directory and avoid silently mis-resolving paths that escape the workspace root.

Bug Fixes:
- Correct resolution of markdown image refs using `./` and `../` so they are resolved relative to the markdown file’s directory instead of being incorrectly treated as workspace-root relative.
- Ensure image refs that would escape the workspace root are left untouched so they surface as visible 404s rather than silently pointing to the wrong file.

Enhancements:
- Add a `basePath` parameter and workspace-path resolver for markdown image rewriting, using pure string-based posix-style segment arithmetic suitable for browser execution.
- Update FilesView and wiki page rendering to provide the appropriate base directory when rewriting markdown image refs so wiki and file previews handle relative image paths consistently.

Tests:
- Extend unit tests for markdown image rewriting to cover basePath-aware resolution, workspace-root escapes, and path normalization cases.