### PR TITLE
fix(image): use marked lexer for image-ref rewrite (parens + code blocks)

### DIFF
--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -1,3 +1,5 @@
+import { marked } from "marked";
+import type { Token, Tokens } from "marked";
 import { resolveImageSrc } from "./resolve";
 
 // Pre-`marked` pass that rewrites workspace-relative image references
@@ -8,6 +10,14 @@ import { resolveImageSrc } from "./resolve";
 // the SPA page URL (e.g. `/chat/…foo.png`) and 404s. After this
 // pass, the src becomes `/api/files/raw?path=images/foo.png` which
 // the workspace file server serves.
+//
+// Uses marked's tokenizer to find image refs rather than a raw regex
+// over the source. The regex approach had two problems:
+//   - URLs containing `)` (e.g. `Foo_(bar).png`) were truncated at
+//     the first close paren.
+//   - `![x](y)` inside fenced code blocks or inline code spans was
+//     rewritten even though it's not meant to render as an image.
+// The lexer handles both correctly.
 //
 // Callers that know the markdown file's directory (`basePath`) get
 // correct resolution for `./` and `../` relative refs. Callers that
@@ -21,10 +31,6 @@ import { resolveImageSrc } from "./resolve";
 //   - `src/plugins/wiki/View.vue`
 //   - `src/components/FilesView.vue` (when previewing a .md file)
 //   - `src/plugins/markdown/View.vue` (via post-`marked` HTML rewriter)
-
-// Match `![alt](url)`. Single character class per span, no
-// overlapping backtracking surface (linear-time matching).
-const IMAGE_REF_RE = /!\[([^\]]*)\]\(([^)]*)\)/g;
 
 function shouldSkip(url: string): boolean {
   if (url.startsWith("data:")) return true;
@@ -64,6 +70,65 @@ function resolveWorkspacePath(basePath: string, url: string): string | null {
   return segs.join("/");
 }
 
+interface Replacement {
+  raw: string;
+  replacement: string;
+}
+
+function rewriteImageToken(
+  token: Tokens.Image,
+  basePath: string,
+): string | null {
+  const href = (token.href ?? "").trim();
+  if (href === "" || shouldSkip(href)) return null;
+  const resolved = resolveWorkspacePath(basePath, href);
+  if (resolved === null) return null;
+  const newHref = resolveImageSrc(resolved);
+  // Preserve alt text verbatim — read from the raw so any special
+  // characters (brackets, entities) survive unmodified.
+  const m = token.raw.match(/^!\[([^\]]*)\]/);
+  const alt = m ? m[1] : (token.text ?? "");
+  if (token.title) {
+    const escapedTitle = token.title.replace(/"/g, '\\"');
+    return `![${alt}](${newHref} "${escapedTitle}")`;
+  }
+  return `![${alt}](${newHref})`;
+}
+
+function collectImageReplacements(
+  tokens: Token[],
+  basePath: string,
+  out: Replacement[],
+): void {
+  for (const token of tokens) {
+    // Don't descend into code — `![x](y)` inside a fenced block or
+    // backtick span is literal, not an image.
+    if (
+      token.type === "code" ||
+      token.type === "codespan" ||
+      token.type === "html"
+    ) {
+      continue;
+    }
+    if (token.type === "image") {
+      const replacement = rewriteImageToken(token as Tokens.Image, basePath);
+      if (replacement !== null) {
+        out.push({ raw: token.raw, replacement });
+      }
+      continue;
+    }
+    // Container tokens carry children in `.tokens` (paragraph, heading,
+    // blockquote, em, strong, …) or `.items` (list → list_item[]).
+    const container = token as { tokens?: Token[]; items?: Token[] };
+    if (Array.isArray(container.tokens)) {
+      collectImageReplacements(container.tokens, basePath, out);
+    }
+    if (Array.isArray(container.items)) {
+      collectImageReplacements(container.items, basePath, out);
+    }
+  }
+}
+
 /**
  * Rewrite `![alt](path)` image refs in markdown text so workspace-
  * relative paths render through `/api/files/raw`.
@@ -77,17 +142,30 @@ function resolveWorkspacePath(basePath: string, url: string): string | null {
  * untouched. Refs that would escape the workspace root (more `..`
  * than `basePath` depth) also pass through untouched — they would
  * 404 regardless, and passing through lets the user see the broken
- * ref instead of silently re-pointing it.
+ * ref instead of silently re-pointing it. Image-ref syntax inside
+ * code blocks / inline code spans is left alone.
  */
 export function rewriteMarkdownImageRefs(
   markdown: string,
   basePath: string = "",
 ): string {
-  return markdown.replace(IMAGE_REF_RE, (match, alt: string, url: string) => {
-    const trimmedUrl = url.trim();
-    if (trimmedUrl === "" || shouldSkip(trimmedUrl)) return match;
-    const resolved = resolveWorkspacePath(basePath, trimmedUrl);
-    if (resolved === null) return match;
-    return `![${alt}](${resolveImageSrc(resolved)})`;
-  });
+  const tokens = marked.lexer(markdown);
+  const replacements: Replacement[] = [];
+  collectImageReplacements(tokens, basePath, replacements);
+  if (replacements.length === 0) return markdown;
+
+  // Apply replacements in document order. `indexOf` forward from the
+  // cursor is safe across duplicate raws: marked enumerates tokens in
+  // source order, so the next occurrence we want is always at-or-after
+  // the cursor.
+  let cursor = 0;
+  const parts: string[] = [];
+  for (const { raw, replacement } of replacements) {
+    const idx = markdown.indexOf(raw, cursor);
+    if (idx < 0) continue;
+    parts.push(markdown.slice(cursor, idx), replacement);
+    cursor = idx + raw.length;
+  }
+  parts.push(markdown.slice(cursor));
+  return parts.join("");
 }

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -121,3 +121,82 @@ describe("rewriteMarkdownImageRefs — with basePath", () => {
     assert.equal(rewriteMarkdownImageRefs(src, "wiki/pages"), src);
   });
 });
+
+describe("rewriteMarkdownImageRefs — code blocks and special chars", () => {
+  it("leaves image-ref syntax inside a fenced code block untouched", () => {
+    const src = [
+      "Before",
+      "",
+      "```",
+      "![example](images/foo.png)",
+      "```",
+      "",
+      "After ![real](images/bar.png)",
+    ].join("\n");
+    const out = rewriteMarkdownImageRefs(src);
+    // The one inside the code block stays literal.
+    assert.ok(out.includes("![example](images/foo.png)"));
+    // The one outside gets rewritten.
+    assert.ok(out.includes("path=images%2Fbar.png"));
+  });
+
+  it("leaves image-ref syntax inside an inline code span untouched", () => {
+    const src =
+      "Use `![example](images/foo.png)` in a doc; ![real](images/bar.png) renders.";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("`![example](images/foo.png)`"));
+    assert.ok(out.includes("path=images%2Fbar.png"));
+  });
+
+  it("leaves image-ref syntax inside a ~~~ fenced block untouched", () => {
+    const src = "~~~\n![example](images/foo.png)\n~~~\n![real](x.png)";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("![example](images/foo.png)"));
+    assert.ok(out.includes("path=x.png"));
+  });
+
+  it("correctly rewrites an image URL that contains `)` inside the path (Wikipedia-style)", () => {
+    // The old regex stopped at the first `)` and truncated the href
+    // to `wiki/Foo_(bar`. marked's lexer parses balanced parens
+    // correctly, so the full `Foo_(bar).png` lands in the href.
+    // encodeURIComponent preserves `(` and `)` as literal chars (they
+    // are in its "unreserved mark" set) — the resulting URL round-
+    // trips through marked because balanced parens stay balanced.
+    const src = "![wikilink](wiki/Foo_(bar).png)";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.equal(out, "![wikilink](/api/files/raw?path=wiki%2FFoo_(bar).png)");
+  });
+
+  it("passes through https URLs with balanced parens untouched", () => {
+    const src = "![w](https://en.wikipedia.org/wiki/Foo_(bar))";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("preserves markdown title when rewriting", () => {
+    const out = rewriteMarkdownImageRefs(
+      '![alt](images/foo.png "a title")',
+      "",
+    );
+    assert.equal(out, '![alt](/api/files/raw?path=images%2Ffoo.png "a title")');
+  });
+
+  it("rewrites multiple refs across paragraphs, lists, and blockquotes", () => {
+    const src = [
+      "# Page",
+      "",
+      "- one ![a](images/a.png)",
+      "- two ![b](images/b.png)",
+      "",
+      "> quoted ![c](images/c.png)",
+      "",
+      "```",
+      "![skipme](images/skip.png)",
+      "```",
+    ].join("\n");
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("path=images%2Fa.png"));
+    assert.ok(out.includes("path=images%2Fb.png"));
+    assert.ok(out.includes("path=images%2Fc.png"));
+    assert.ok(out.includes("![skipme](images/skip.png)"));
+  });
+});


### PR DESCRIPTION
## Summary

`rewriteMarkdownImageRefs` を regex ベースから marked の lexer ベースに変更。以下の既知の不具合を解消:

1. **URL内の `)` で href が切れる** — `![a](wiki/Foo_(bar).png)` のようなケースで、旧 regex `[^)]*` は最初の `)` で href を `wiki/Foo_(bar` と切ってしまっていた。marked は balanced parens を正しく解釈する。
2. **コードブロック内の `![x](y)` が rewrite される** — ドキュメント用のマークダウン記法サンプルが意図せず API URL に書き換えられていた。marked は ``` ブロックや `` ` `` 内を `code` / `codespan` トークンとして返すので、walk が自然にスキップする。

## Items to Confirm / Review

- **実装方針**: lexer で AST を取得 → image トークンだけ集めて `{raw, replacement}` に → 元文字列に対して順に `indexOf` 前方検索で置換。マークダウン→マークダウンの pure transform を維持（HTML 化しない / 他トークンの raw を改変しない）。
- **エンコーディングの注意**: `encodeURIComponent` は `(` `)` を unreserved として literal のまま残す仕様なので、`path=wiki%2FFoo_(bar).png` のような URL が生成される。marked は balanced parens を正しくパースするので round-trip は問題ないが、この仕様はテストでも明記。
- **外観 API は不変**: シグネチャ `rewriteMarkdownImageRefs(markdown, basePath?)` は変更なし。呼び出し側の修正は不要。
- **Stacked on #226**: ベースが `fix/markdown-image-path-resolution`。#226 マージ後にこちらを main に retarget してください。

## User Prompt

> 24時間以内のPRでcode rabbitのコメントをみてないものがある。一応一通り確認してほしい

CodeRabbit が #216 に対して指摘していた3項目の最後（image-ref regex の誤爆）に対応。これで #216 のレビュー指摘は全部解消。

## Test plan

- [x] `yarn test` — 1293 passed (新規 7 テスト追加: fenced block / inline code / `~~~` 変種 / URL balanced parens / pass-through https+parens / title 保持 / 複合シナリオ)
- [x] `yarn test:e2e -- tests/files-html-preview.spec.ts` — 5 passed
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch markdown image reference rewriting to use marked's lexer for safer, structure-aware transforms while preserving existing API.

Bug Fixes:
- Prevent truncation of image URLs that contain closing parentheses in their paths.
- Avoid rewriting image-reference syntax that appears inside fenced code blocks or inline code spans.

Enhancements:
- Preserve markdown image titles and alt text more robustly when rewriting image references.
- Support consistent image reference rewriting across mixed markdown structures such as paragraphs, lists, and blockquotes.

Tests:
- Add unit tests covering code blocks, inline code, alternative fenced syntaxes, URLs with balanced parentheses, HTTPS passthrough, title preservation, and multi-context scenarios for image references.