### PR TITLE
fix(mulmo-script): validate update-script + update-beat bodies with zod

### DIFF
--- a/server/routes/mulmo-script.ts
+++ b/server/routes/mulmo-script.ts
@@ -25,6 +25,10 @@ import { slugify } from "../utils/slug.js";
 import { resolveWithinRoot } from "../utils/fs.js";
 import { errorMessage } from "../utils/errors.js";
 import { log } from "../logger/index.js";
+import {
+  validateUpdateBeatBody,
+  validateUpdateScriptBody,
+} from "./mulmoScriptValidate.js";
 
 const router = Router();
 const storiesDir = path.resolve(workspacePath, "stories");
@@ -60,12 +64,6 @@ interface UploadBeatImageBody {
   filePath: string;
   beatIndex: number;
   imageData: string; // base64 data URI
-}
-
-interface UpdateBeatBody {
-  filePath: string;
-  beatIndex: number;
-  beat: MulmoBeat;
 }
 
 type ErrorResponse = { error: string };
@@ -113,15 +111,13 @@ router.post(
 
 router.post(
   "/mulmo-script/update-beat",
-  (req: Request<object, object, UpdateBeatBody>, res: Response) => {
-    const { filePath, beatIndex, beat } = req.body;
-
-    if (!filePath || beatIndex === undefined || !beat) {
-      res
-        .status(400)
-        .json({ error: "filePath, beatIndex, and beat are required" });
+  (req: Request<object, object, unknown>, res: Response) => {
+    const validation = validateUpdateBeatBody(req.body);
+    if (!validation.ok) {
+      res.status(400).json({ error: validation.error });
       return;
     }
+    const { filePath, beatIndex, beat } = validation.value;
 
     const absoluteFilePath = resolveStoryPath(filePath, res);
     if (!absoluteFilePath) return;
@@ -135,27 +131,22 @@ router.post(
       return;
     }
 
-    script.beats[beatIndex] = beat;
+    script.beats[beatIndex] = beat as MulmoBeat;
     fs.writeFileSync(absoluteFilePath, JSON.stringify(script, null, 2));
 
     res.json({ ok: true });
   },
 );
 
-interface UpdateScriptBody {
-  filePath: string;
-  script: MulmoScript;
-}
-
 router.post(
   "/mulmo-script/update-script",
-  (req: Request<object, object, UpdateScriptBody>, res: Response) => {
-    const { filePath, script: updatedScript } = req.body;
-
-    if (!filePath || !updatedScript) {
-      res.status(400).json({ error: "filePath and script are required" });
+  (req: Request<object, object, unknown>, res: Response) => {
+    const validation = validateUpdateScriptBody(req.body);
+    if (!validation.ok) {
+      res.status(400).json({ error: validation.error });
       return;
     }
+    const { filePath, script: updatedScript } = validation.value;
 
     const absoluteFilePath = resolveStoryPath(filePath, res);
     if (!absoluteFilePath) return;

--- a/server/routes/mulmoScriptValidate.ts
+++ b/server/routes/mulmoScriptValidate.ts
@@ -15,16 +15,19 @@ export type ValidationResult<T> =
   | { ok: false; error: string };
 
 function formatZodIssues(
-  issues: ReadonlyArray<{
-    message: string;
-    path: ReadonlyArray<string | number>;
-  }>,
+  // Zod's `$ZodIssue.path` is `PropertyKey[]` (includes `symbol`).
+  // Accept the wider type so callers can pass `safeParse().error.issues`
+  // directly; stringify any non-string/number segments at format time.
+  issues: ReadonlyArray<{ message: string; path: ReadonlyArray<PropertyKey> }>,
 ): string {
   if (issues.length === 0) return "invalid shape";
   const head = issues
     .slice(0, 3)
     .map((i) => {
-      const pathStr = i.path.length > 0 ? i.path.join(".") : "<root>";
+      const pathStr =
+        i.path.length > 0
+          ? i.path.map((seg) => String(seg)).join(".")
+          : "<root>";
       return `${pathStr}: ${i.message}`;
     })
     .join("; ");

--- a/server/routes/mulmoScriptValidate.ts
+++ b/server/routes/mulmoScriptValidate.ts
@@ -1,0 +1,108 @@
+// Request-body validators for the mulmo-script PUT endpoints. Split
+// from `mulmo-script.ts` so the pure shape checks can be unit-tested
+// without spinning up Express.
+//
+// The `@mulmocast/types` package exports zod schemas that mirror the
+// canonical MulmoScript / MulmoBeat shapes. Using them here keeps the
+// server and client agreeing on what a "valid script" is — the same
+// schemas back client-side edit-time validation in
+// `src/plugins/presentMulmoScript/View.vue`.
+
+import { mulmoBeatSchema, mulmoScriptSchema } from "@mulmocast/types";
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function formatZodIssues(
+  issues: ReadonlyArray<{
+    message: string;
+    path: ReadonlyArray<string | number>;
+  }>,
+): string {
+  if (issues.length === 0) return "invalid shape";
+  const head = issues
+    .slice(0, 3)
+    .map((i) => {
+      const pathStr = i.path.length > 0 ? i.path.join(".") : "<root>";
+      return `${pathStr}: ${i.message}`;
+    })
+    .join("; ");
+  return issues.length > 3 ? `${head} (+${issues.length - 3} more)` : head;
+}
+
+/**
+ * Validate the `update-script` request body. Returns the parsed,
+ * schema-conformant script on success, or a human-readable error
+ * suitable for sending back as a 400 response.
+ */
+export function validateUpdateScriptBody(body: unknown): ValidationResult<{
+  filePath: string;
+  script: unknown;
+}> {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "body must be an object" };
+  }
+  const record = body as Record<string, unknown>;
+  if (typeof record.filePath !== "string" || record.filePath === "") {
+    return { ok: false, error: "filePath must be a non-empty string" };
+  }
+  if (record.script === undefined) {
+    return { ok: false, error: "script is required" };
+  }
+  const parsed = mulmoScriptSchema.safeParse(record.script);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: `invalid script: ${formatZodIssues(parsed.error.issues)}`,
+    };
+  }
+  return {
+    ok: true,
+    value: { filePath: record.filePath, script: parsed.data },
+  };
+}
+
+/**
+ * Validate the `update-beat` request body. `beatIndex` is allowed
+ * to be any non-negative integer; the handler still bounds-checks
+ * against the actual script length after reading the file.
+ */
+export function validateUpdateBeatBody(body: unknown): ValidationResult<{
+  filePath: string;
+  beatIndex: number;
+  beat: unknown;
+}> {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "body must be an object" };
+  }
+  const record = body as Record<string, unknown>;
+  if (typeof record.filePath !== "string" || record.filePath === "") {
+    return { ok: false, error: "filePath must be a non-empty string" };
+  }
+  if (
+    typeof record.beatIndex !== "number" ||
+    !Number.isInteger(record.beatIndex) ||
+    record.beatIndex < 0
+  ) {
+    return { ok: false, error: "beatIndex must be a non-negative integer" };
+  }
+  if (record.beat === undefined) {
+    return { ok: false, error: "beat is required" };
+  }
+  const parsed = mulmoBeatSchema.safeParse(record.beat);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: `invalid beat: ${formatZodIssues(parsed.error.issues)}`,
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      filePath: record.filePath,
+      beatIndex: record.beatIndex,
+      beat: parsed.data,
+    },
+  };
+}

--- a/test/routes/test_mulmoScriptValidate.ts
+++ b/test/routes/test_mulmoScriptValidate.ts
@@ -1,0 +1,161 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateUpdateBeatBody,
+  validateUpdateScriptBody,
+} from "../../server/routes/mulmoScriptValidate.ts";
+
+// Minimal script / beat objects that satisfy the zod schemas from
+// `@mulmocast/types`. If `@mulmocast/types` tightens its schemas, the
+// exact shape below may need updating — use a schema diff to sync.
+const VALID_BEAT = {
+  speaker: "Narrator",
+  text: "Beat one.",
+  image: {
+    type: "textSlide",
+    slide: { title: "Slide 1", bullets: ["one"] },
+  },
+};
+
+const VALID_SCRIPT = {
+  $mulmocast: { version: "1.1" },
+  title: "Test",
+  description: "A test script",
+  lang: "en",
+  beats: [VALID_BEAT],
+  imageParams: {},
+};
+
+describe("validateUpdateScriptBody", () => {
+  it("accepts a valid body and returns the parsed value", () => {
+    const out = validateUpdateScriptBody({
+      filePath: "stories/x.json",
+      script: VALID_SCRIPT,
+    });
+    assert.equal(out.ok, true);
+    if (out.ok) {
+      assert.equal(out.value.filePath, "stories/x.json");
+      assert.ok(out.value.script);
+    }
+  });
+
+  it("rejects a null body", () => {
+    const out = validateUpdateScriptBody(null);
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /object/);
+  });
+
+  it("rejects a primitive body", () => {
+    assert.equal(validateUpdateScriptBody("oops").ok, false);
+    assert.equal(validateUpdateScriptBody(42).ok, false);
+    assert.equal(validateUpdateScriptBody(true).ok, false);
+  });
+
+  it("rejects a body missing filePath", () => {
+    const out = validateUpdateScriptBody({ script: VALID_SCRIPT });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /filePath/);
+  });
+
+  it("rejects a body with empty-string filePath", () => {
+    const out = validateUpdateScriptBody({
+      filePath: "",
+      script: VALID_SCRIPT,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /filePath/);
+  });
+
+  it("rejects a body missing script", () => {
+    const out = validateUpdateScriptBody({ filePath: "stories/x.json" });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /script is required/);
+  });
+
+  it("rejects a body whose script is not schema-conformant", () => {
+    const out = validateUpdateScriptBody({
+      filePath: "stories/x.json",
+      script: { completelyBogus: true },
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /invalid script/);
+  });
+
+  it("rejects a garbage JSON blob entirely", () => {
+    const out = validateUpdateScriptBody({
+      filePath: "stories/x.json",
+      script: "not-an-object",
+    });
+    assert.equal(out.ok, false);
+  });
+});
+
+describe("validateUpdateBeatBody", () => {
+  it("accepts a valid body", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: 0,
+      beat: VALID_BEAT,
+    });
+    assert.equal(out.ok, true);
+    if (out.ok) {
+      assert.equal(out.value.beatIndex, 0);
+      assert.ok(out.value.beat);
+    }
+  });
+
+  it("rejects a negative beatIndex", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: -1,
+      beat: VALID_BEAT,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /beatIndex/);
+  });
+
+  it("rejects a non-integer beatIndex", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: 1.5,
+      beat: VALID_BEAT,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /beatIndex/);
+  });
+
+  it("rejects a string beatIndex", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: "0",
+      beat: VALID_BEAT,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /beatIndex/);
+  });
+
+  it("rejects a body missing beat", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: 0,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /beat is required/);
+  });
+
+  it("rejects a body whose beat is not schema-conformant", () => {
+    const out = validateUpdateBeatBody({
+      filePath: "stories/x.json",
+      beatIndex: 0,
+      beat: { completelyBogus: true },
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.match(out.error, /invalid beat/);
+  });
+
+  it("rejects null / primitive bodies", () => {
+    assert.equal(validateUpdateBeatBody(null).ok, false);
+    assert.equal(validateUpdateBeatBody("oops").ok, false);
+    assert.equal(validateUpdateBeatBody(42).ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

`update-script` / `update-beat` エンドポイントが `req.body` の中身をほとんど検証せずディスクに書き込んでいたのを、`@mulmocast/types` の zod スキーマで検証するよう修正。

形状違反 (`null`, プリミティブ, 未知フィールドだらけ, 壊れた script shape) を 400 で拒否し、人間が読めるエラーメッセージを返す。

## Items to Confirm / Review

- **`@mulmocast/types` 採用の妥当性**: 同じ `mulmoScriptSchema` / `mulmoBeatSchema` を `src/plugins/presentMulmoScript/View.vue` の edit-time validation でも使っているため、server / client で "valid な script" の定義が常に一致する。schema が将来変わっても両端が一緒にズレる = 片方だけの drift が起きない。
- **バリデータを別ファイルに切り出した理由**: `server/routes/mulmoScriptValidate.ts` として分離。pure function なので Express を立ち上げずに unit test できる。15個のテストでハッピー/null/プリミティブ/欠損フィールド/非整数 beatIndex/不正 shape を網羅。
- **エラーメッセージ形式**: `invalid script: title: required; beats.0.image: required (+3 more)` のように zod issues の先頭3件を path 付きで展開。長大なスタックトレースは返さない。
- **`beatIndex` の扱い**: バリデータでは `>= 0 の整数` だけチェック。配列長との境界チェックはハンドラ側で引き続き行う（script を先に読む必要があるため）。

## User Prompt

> 24時間以内のPRでcode rabbitのコメントをみてないものがある。一応一通り確認してほしい

CodeRabbit が #208 に対して指摘していた2項目の最後（サーバ側の入力検証）に対応するPR。これで #208 の指摘は全部解消。

## Test plan

- [x] `yarn test test/routes/test_mulmoScriptValidate.ts` — 1293 passed（新規 15 テスト）
- [x] `yarn format` / `yarn lint` / `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate mulmo-script update endpoints with shared schemas and add targeted tests for request body validation.

Bug Fixes:
- Reject invalid or malformed request bodies for /mulmo-script/update-beat and /mulmo-script/update-script with proper 400 responses instead of writing unchecked data to disk.

Enhancements:
- Introduce a dedicated mulmoScriptValidate module that validates update-beat and update-script request bodies using @mulmocast/types Zod schemas and returns concise, human-readable error messages.

Tests:
- Add unit tests covering valid, null, primitive, malformed, and schema-violating bodies for update-beat and update-script validators.