### PR TITLE
fix(sessions): refetch when mark-read returns { ok: false }

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -417,7 +417,27 @@ async function markSessionRead(id: string): Promise<void> {
       `/api/sessions/${encodeURIComponent(id)}/mark-read`,
       { method: "POST" },
     );
-    if (!res.ok) {
+    // The server returns `{ ok: boolean }` — a 200 with `ok: false`
+    // means the endpoint was reached but the flag wasn't actually
+    // cleared (e.g. session not found). Treat that the same as a
+    // transport failure and refetch so the sidebar doesn't go stale.
+    let appLevelOk = true;
+    if (res.ok) {
+      try {
+        const body: unknown = await res.json();
+        if (
+          body !== null &&
+          typeof body === "object" &&
+          (body as { ok?: unknown }).ok === false
+        ) {
+          appLevelOk = false;
+        }
+      } catch {
+        // Body wasn't JSON — treat as failure.
+        appLevelOk = false;
+      }
+    }
+    if (!res.ok || !appLevelOk) {
       // Server didn't clear the flag — refetch to restore truth.
       await refreshSessionStates();
     }


### PR DESCRIPTION
## Summary

`markSessionRead` が `res.ok` しか見ていなかったので、200 + `{ ok: false }` を返すケース（例: セッションが見つからず server がフラグを実際には落としていない）で、サイドバーの未読状態だけクライアント側で既読になってしまう問題を修正。

body を JSON としてパースし、`ok === false` なら transport 失敗と同じ扱いで `refreshSessionStates()` を呼ぶ。非 JSON body も failure 扱い。

## Items to Confirm / Review

- **挙動変化**: 成功パス（200 + `{ok: true}`）は従来通り refetch なし。唯一変わるのは `{ok:false}` / 非 JSON のケースで refetch が追加される点。
- **ネットワーク失敗（catch）**: 既存通り refetch。
- **HTTP failure（`!res.ok`）**: 既存通り refetch。
- **Body パースの安全性**: `typeof body === "object"` + `body !== null` で型ガード → `as { ok?: unknown }` で ok フィールドだけ読む。CLAUDE.md の「`as` cast を避ける」ルールは境界での narrow は許容範囲と判断。

## User Prompt

> 24時間以内のPRでcode rabbitのコメントをみてないものがある。一応一通り確認してほしい

CodeRabbit が #192 に対して指摘していた軽微な項目の1つ。これで24時間以内の CR 指摘で残っているのは #215 の generateImage prompt 文言（issue #231 で snakajima さんにアサイン済）のみ。

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` — clean
- [ ] **Manual**: devtools で `mark-read` のレスポンスを `{ok:false}` に書き換えて、サイドバー未読数が次のタブ切替で正しく戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure sessions are refetched when the mark-read endpoint returns a successful HTTP status but a body indicating `{ ok: false }` or an invalid JSON response, preventing stale unread indicators in the sidebar.