### PR TITLE
docs(releases): archive v0.1.0 release notes under docs/releases/

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,59 @@
+# MulmoClaude v0.1.0 — first tagged release
+
+GUI-chat with Claude Code — chat with Claude and get back not just text but interactive visual tools, persistent knowledge, and a growing library of skills.
+
+## ✨ Highlights
+
+- **9 specialised roles** — General / Office / Guide & Planner / Artist / Game / Tutor / Storyteller / Musician / Role Manager. Each ships its own prompt + tool palette + sample queries; switching resets context.
+- **Personal wiki long-term memory** — Claude builds and maintains a `wiki/index.md` + `wiki/pages/*.md` knowledge base that grows with every conversation. Cross-references via `[[wiki link]]` syntax.
+- **Skills (phase 0)** — list and invoke any `~/.claude/skills/*/SKILL.md` from the canvas via `/<skill-name>` slash-command. Project-scope override at `~/mulmoclaude/.claude/skills/`.
+- **Charts** — Apache ECharts plugin with bar / line / candlestick / sankey / network / heatmap. PNG export per chart.
+- **Documents / Spreadsheets / Forms / Mind maps / 3D / Music / HTML** — rich plugin palette covering most "I want to make X" requests.
+- **Image generation** — Gemini 3.1 Flash Image (nano banana) for generation + Ghibli-style transforms.
+- **MulmoScript storyboards** — write multi-beat presentations with per-beat audio + image + movie generation pipeline.
+- **Docker sandbox by default** — Claude Code runs in a sandboxed container with `--cap-drop ALL`, non-root, your `~/.claude` mounted. Falls back transparently when Docker isn't available.
+- **Web settings UI** — manage allowed tools and MCP servers from the browser (no JSON editing required). Auto-reload, no server restart.
+- **Web-based MCP server management** — add Slack, GitHub, filesystem, etc. MCP servers via the settings UI.
+- **X (Twitter) tools** — `readXPost` + `searchX` via the official X API.
+
+## 🧠 Architecture & Infrastructure
+
+- **vue-router with history mode** for deep-linkable session URLs (`/chat/:sessionId`, `?view=stack|files`, etc.).
+- **Server-side session state** — pub/sub channel keeps multiple browser tabs in sync without polling.
+- **Per-session pluggable MCP server** — only the active role's plugins are exposed to Claude, keeping the tool list focused.
+- **Tool trace persistence** — every Claude tool call/result is appended to `chat/<id>.jsonl` so reload restores the exact sidebar history.
+- **Wiki backlinks** — pages auto-link back to the chat that created them.
+- **Auto-journal** — daily summaries under `summaries/` give Claude historical context without ballooning the context window.
+- **Structured server logger** — `log.{info,warn,error}(prefix, msg, data)` with console + rotating file sinks.
+
+## 🧪 Quality
+
+- **1300+ unit tests** (node:test) + **140+ E2E tests** (Playwright Chromium).
+- ESLint with cognitive-complexity gate (>15 = error).
+- Cross-platform CI (Ubuntu / macOS / Windows × Node 22 / 24).
+- TypeScript strict mode end-to-end.
+
+## 🔒 Security
+
+- Localhost-only bind (`127.0.0.1`) — no LAN exposure.
+- CSRF guard on state-changing routes.
+- Path-traversal-safe slug validation across sources, skills, wiki.
+- Sandbox isolation for Claude CLI (Docker mode, default).
+
+## 📋 Known limitations
+
+- **Skills in Docker + symlinked `~/.claude/skills`** — dangling links in the container; use `DISABLE_SANDBOX=1` or flatten symlinks. README has the full workaround set.
+- **Conversation → skill capture (phase 1, #234)** — landed on a feature branch but not in this tag. Will ship in 0.2.0.
+- **No Electron packaging yet** — browser-only for now (#84 tracks this).
+
+## 📚 Documentation
+
+- `README.md` — installation, role catalog, skills, wiki, charts, X tools, settings UI, sandbox notes.
+- `docs/developer.md` — env vars, scripts, sandbox layout, contributor guide.
+- `docs/logging.md` — log levels, formats, rotation.
+- `docs/manual-testing.md` — out-of-E2E smoke checklist.
+- `plans/` — design docs for every feature.
+
+## 🙏 Thanks
+
+Inspired by Andrej Karpathy's [LLM Knowledge Bases idea](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) and built on top of [Claude Code](https://claude.ai/code).


### PR DESCRIPTION
## Summary

GitHub Release page (https://github.com/receptron/mulmoclaude/releases/tag/v0.1.0) のノートをリポジトリ内 \`docs/releases/v0.1.0.md\` にも置く。

## なぜ

- Release page は GitHub の UI を経由しないと読めない / diff も取りづらい
- 今後のバージョンは \`docs/releases/<tag>.md\` で追記していくパターンを確立しておく
- README や CLAUDE.md からリンクしやすい
- オフラインで読める

## 内容

\`docs/releases/v0.1.0.md\` 1 ファイル追加のみ。Release page と同じ Markdown。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document the v0.1.0 tagged release in docs/releases/v0.1.0.md, mirroring the GitHub Release notes for offline and in-repo access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released comprehensive v0.1.0 release notes documenting core features: specialized roles with prompt and tool palettes, persistent wiki with backlink support, skills invoked via slash commands, charting with export options, extensible plugins, image generation, storyboards, Docker sandbox, web UI management, and platform integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->