### PR TITLE
feat(journal): auto-distill user-level memory entries during daily pass (closes #236)

### DIFF
--- a/plans/feat-journal-memory-distill.md
+++ b/plans/feat-journal-memory-distill.md
@@ -1,0 +1,148 @@
+# feat: auto-distill user-level memory entries during daily pass
+
+Tracks #236.
+
+## Goal
+
+Extend the daily journal pass so the archivist also produces user-level memory entries — facts the LLM should "remember about the user" across sessions. These flow into `~/mulmoclaude/memory.md`, which is already inlined into every Claude system prompt by `server/agent/prompt.ts#buildMemoryContext`.
+
+Today the archivist outputs a daily summary + topic notes. There is no automatic path for capturing things like "the user prefers yarn" or "mulmoclaude phase 1 is in flight" — those have to be put into `memory.md` by hand.
+
+## Non-goals
+
+- **Optimization / pruning** of memory.md (deferred to a follow-up that mirrors `optimizationPass.ts`).
+- **Manual edit UI** — users edit memory.md via the file system / Claude Edit tool, same as today.
+- **Semantic dedup** — we trust the LLM to skip facts already present in the input we hand it.
+- **Per-session capture** — memory entries land via the daily pass like everything else, not on every turn.
+
+## Categories
+
+Same four-bucket scheme used by Claude Code's auto-memory system globally:
+
+| type | What goes in it |
+|---|---|
+| **user** | Who the user is, role, expertise, environment ("macOS + Docker", "OSS maintainer at receptron") |
+| **feedback** | Corrections / preferences ("don't blindly accept all CodeRabbit suggestions", "prefer yarn over npm", "PR descriptions in Japanese") |
+| **project** | Ongoing work / deadlines / status ("skills phase 1 in PR #234", "v0.1.0 tagged 2026-04-14") |
+| **reference** | External systems / paths / dashboards ("skills repo at ~/ss/dotfiles/claude/skills/", "Linear project INGEST tracks pipeline bugs") |
+
+## Storage layout
+
+memory.md is a single file with one `##`-headed section per category, in the canonical order above. Section bodies are bullet lists. Empty sections are omitted from the file (re-added when the first entry of that type lands).
+
+```markdown
+# Memory
+
+Distilled facts about you and your work.
+
+## User
+
+- macOS + Docker Desktop environment
+- Primary repos: receptron/mulmoclaude
+
+## Feedback
+
+- Prefer yarn over npm; never suggest npm commands
+- PR descriptions in Japanese
+
+## Project
+
+- skills phase 1 PR #234 awaiting review
+- v0.1.0 tagged 2026-04-14
+
+## Reference
+
+- External skill repo: ~/ss/dotfiles/claude/skills/ (symlink)
+```
+
+Plain bullet lines, no per-entry frontmatter, no IDs. Keeps memory.md hand-editable.
+
+## Architecture
+
+### New module — `server/journal/memory.ts`
+
+Pure helpers, no I/O:
+
+```ts
+type MemoryType = "user" | "feedback" | "project" | "reference";
+
+interface MemoryEntry { type: MemoryType; body: string; }
+
+// Parse memory.md into per-section bullet lists. Tolerates the
+// stub form (just the H1 + intro), arbitrary other top-level
+// headings (preserved as-is), and empty sections.
+parseMemory(raw: string): {
+  preamble: string;          // Everything before the first known section
+  sections: Record<MemoryType, string[]>;  // Section bullets in source order
+  trailing: string;          // Anything after the last known section (preserved verbatim)
+}
+
+// Append entries to the right sections, creating sections that
+// don't yet exist. Idempotent if the same entry is already a
+// substring of an existing bullet (cheap dedup; the LLM is
+// expected to be the primary dedup mechanism).
+appendEntries(parsed, entries: MemoryEntry[]): updatedParsed
+
+// Render back to markdown.
+renderMemory(parsed): string
+```
+
+These helpers stay in their own file so they're trivially unit-testable with golden-file inputs/outputs.
+
+### Archivist contract changes (`archivist.ts`)
+
+- New type `MemoryEntry` exported.
+- `DailyArchivistInput` gains `existingMemory: string` (current memory.md content, passed to the LLM as context).
+- `DailyArchivistOutput` gains `memoryEntries: MemoryEntry[]` (always present; empty array means "no new facts worth remembering today").
+- `DAILY_SYSTEM_PROMPT` extended with a new "MEMORY ENTRIES" section explaining the four types, when to emit (cross-session value), when to skip (one-off chitchat / topical knowledge / facts already in memory.md).
+- `buildDailyUserPrompt` includes an "EXISTING MEMORY" block.
+- `isDailyArchivistOutput` validates `memoryEntries` is a `MemoryEntry[]`.
+
+### dailyPass orchestration (`dailyPass.ts`)
+
+After `summarize(...)` returns, before/after the existing topic-write loop:
+
+1. Read current `memory.md` via `fsp.readFile`.
+2. Pass to archivist as `existingMemory`.
+3. On the way back: `parseMemory` → `appendEntries(parsed, output.memoryEntries)` → `renderMemory` → atomic write to `memory.md`.
+
+Skip the write entirely if `memoryEntries` is empty (avoids rewriting the file with identical content every day).
+
+### Backward compatibility
+
+`memoryEntries` is **required** in the new schema. Older archivist responses (without the field) would fail validation. We don't have any persisted output to migrate — the archivist is invoked fresh every run — so there's nothing to migrate. Tests cover a "model returns empty array" case so we know the happy path with zero entries works.
+
+## Tests
+
+- `test/journal/test_memory.ts` — `parseMemory` (stub form, full form, sections out of order, unknown headings preserved) / `appendEntries` (creates missing sections, dedup short-circuit) / `renderMemory` round-trip.
+- `test/journal/test_archivist.ts` extension — JSON validation accepts a memoryEntries array, rejects malformed members.
+- `test/journal/test_dailyPass.ts` extension — golden test: given a fixture day with archivist returning a few memory entries, `memory.md` is updated correctly. Empty-array case: file is **not** rewritten.
+
+## Quality / safety
+
+- All writes go through the existing atomic-write pattern in `dailyPass.ts` (tmp file + rename if applicable; otherwise `fsp.writeFile` is fine because the daily pass holds a lock).
+- memory.md preamble + trailing content (anything outside the four known sections) is preserved verbatim — the user can still hand-edit between auto-runs without losing changes.
+- LLM-side errors (malformed JSON, missing field) fall back to "skip the memory step", same pattern the existing topic loop uses.
+
+## Phase 2 follow-up
+
+- **memory.md optimization pass** — monthly, mirrors `optimizationPass.ts`: ask the LLM to merge / archive stale entries, drop duplicates, etc.
+- **memory-archive.md** — pruned entries land here so nothing is ever truly lost.
+
+## File map
+
+```text
+server/journal/
+  memory.ts          ← NEW: pure parse / append / render
+  archivist.ts       ← extend types + prompt + validator
+  dailyPass.ts       ← read+write memory.md around archivist call
+
+test/journal/
+  test_memory.ts     ← NEW
+  test_archivist.ts  ← extend (memoryEntries validation)
+  test_dailyPass.ts  ← extend (golden integration)
+```
+
+## Estimated size
+
+400-500 lines code + 200 lines tests.

--- a/server/journal/archivist.ts
+++ b/server/journal/archivist.ts
@@ -161,6 +161,11 @@ export interface DailyArchivistInput {
   existingDailySummary: string | null;
   existingTopicSummaries: ExistingTopicSnapshot[];
   sessionExcerpts: SessionExcerpt[];
+  /** Current `~/mulmoclaude/memory.md` content. Passed to the LLM
+   *  so it can dedup against existing user-level facts before
+   *  emitting new memoryEntries. May be empty when the file is the
+   *  workspace stub. */
+  existingMemory: string;
 }
 
 export type TopicUpdateAction = "create" | "append" | "rewrite";
@@ -171,9 +176,23 @@ export interface TopicUpdate {
   content: string;
 }
 
+export type MemoryEntryType = "user" | "feedback" | "project" | "reference";
+
+export interface MemoryEntry {
+  type: MemoryEntryType;
+  /** One short bullet (1-3 sentences). Rendered as `- <body>` under
+   *  the matching `## User` / `## Feedback` / `## Project` /
+   *  `## Reference` section in memory.md. */
+  body: string;
+}
+
 export interface DailyArchivistOutput {
   dailySummaryMarkdown: string;
   topicUpdates: TopicUpdate[];
+  /** User-level facts to remember across sessions. Empty array when
+   *  the day produced nothing worth distilling — that's the common
+   *  case and not an error. */
+  memoryEntries: MemoryEntry[];
 }
 
 // System prompt for the daily pass. Written long-form because the
@@ -181,7 +200,8 @@ export interface DailyArchivistOutput {
 // than with a terse instruction.
 export const DAILY_SYSTEM_PROMPT = `You are the journal archivist for a personal MulmoClaude workspace.
 Your job: given raw session excerpts for a single day, produce
-(1) a daily summary and (2) updates to long-running topic notes.
+(1) a daily summary, (2) updates to long-running topic notes, and
+(3) user-level memory entries to remember across sessions.
 
 OUTPUT FORMAT
 You must emit a single JSON object wrapped in a \`\`\`json code fence.
@@ -190,9 +210,12 @@ Schema:
   "dailySummaryMarkdown": "...",
   "topicUpdates": [
     { "slug": "kebab-case-slug", "action": "create" | "append" | "rewrite", "content": "..." }
+  ],
+  "memoryEntries": [
+    { "type": "user" | "feedback" | "project" | "reference", "body": "..." }
   ]
 }
-No prose outside the fence. No extra keys.
+No prose outside the fence. No extra keys. \`memoryEntries\` MUST be present — emit \`[]\` when nothing is worth distilling, which is the common case.
 
 DAILY SUMMARY RULES
 - Write in the same language as the source sessions. Japanese stays Japanese. English stays English.
@@ -224,8 +247,34 @@ SESSION LINKS
 - The file viewer recognises this pattern and switches the sidebar chat to that session when the link is clicked, so the reader can pick up where the session left off.
 - You do not have to link every session you mention, but linking at least the first reference per session is helpful.
 
+MEMORY ENTRIES
+- These end up in \`memory.md\`, which is **inlined into every Claude system prompt** for this workspace. Be selective: only entries with cross-session value belong here. Topical knowledge belongs in topics; what-happened-today belongs in the daily summary; this is for things future-you needs to know about the user up front.
+- Four types, each with its own discipline:
+  - **user**: Who the user is, their environment, role, expertise, ongoing context. Examples: "macOS + Docker Desktop environment", "Primary repos: receptron/mulmoclaude", "OSS maintainer".
+  - **feedback**: Corrections / preferences the user has expressed (do this; don't do that). Examples: "Prefer yarn over npm", "PR descriptions in Japanese", "Don't blindly accept all CodeRabbit suggestions — triage each one".
+  - **project**: Current work / status / deadlines / decisions in flight. Examples: "skills phase 1 in PR #234", "v0.1.0 tagged 2026-04-14".
+  - **reference**: External systems / paths / dashboards / docs the user mentioned. Examples: "Linear project INGEST tracks pipeline bugs", "Skill repo at ~/ss/dotfiles/claude/skills/ (symlink)".
+- Skip these (do NOT emit a memory entry):
+  - Facts already present in the EXISTING MEMORY block (the user passed it to you for dedup).
+  - One-off chitchat, debugging output, throwaway code samples.
+  - Topical / domain knowledge — that goes in topicUpdates.
+  - "What happened today" — that's in dailySummaryMarkdown.
+- Each \`body\` is one short bullet (1-3 sentences max). Write in the user's language. No leading dash or bullet character — just the body text.
+
 LANGUAGE
 - Match the language of the source sessions. Always.`;
+
+// Render the EXISTING MEMORY section of the user prompt. Empty input
+// becomes a single `(empty)` line; non-empty memory is wrapped in a
+// fenced markdown block for the LLM. Extracted to keep
+// buildDailyUserPrompt under the cognitive-complexity threshold.
+function formatExistingMemoryBlock(existingMemory: string): string[] {
+  const header = "EXISTING MEMORY (do not re-emit facts already covered here):";
+  if (existingMemory.trim().length === 0) {
+    return [header, "(empty)"];
+  }
+  return [header, "```md", existingMemory.trimEnd(), "```"];
+}
 
 // Build the user-side prompt for one day's worth of content.
 // Pure string construction — safe to unit test if we ever want to.
@@ -267,6 +316,9 @@ export function buildDailyUserPrompt(input: DailyArchivistInput): string {
       parts.push(`- ${p}`);
     }
   }
+  parts.push("");
+
+  parts.push(...formatExistingMemoryBlock(input.existingMemory));
   parts.push("");
 
   parts.push("SESSION EXCERPTS:");
@@ -437,7 +489,9 @@ export function isDailyArchivistOutput(
   const v = value as Record<string, unknown>;
   if (typeof v.dailySummaryMarkdown !== "string") return false;
   if (!Array.isArray(v.topicUpdates)) return false;
-  return v.topicUpdates.every(isTopicUpdate);
+  if (!v.topicUpdates.every(isTopicUpdate)) return false;
+  if (!Array.isArray(v.memoryEntries)) return false;
+  return v.memoryEntries.every(isMemoryEntry);
 }
 
 function isTopicUpdate(value: unknown): value is TopicUpdate {
@@ -447,6 +501,18 @@ function isTopicUpdate(value: unknown): value is TopicUpdate {
   if (typeof v.content !== "string") return false;
   return (
     v.action === "create" || v.action === "append" || v.action === "rewrite"
+  );
+}
+
+function isMemoryEntry(value: unknown): value is MemoryEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.body !== "string") return false;
+  return (
+    v.type === "user" ||
+    v.type === "feedback" ||
+    v.type === "project" ||
+    v.type === "reference"
   );
 }
 

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -40,6 +40,8 @@ import {
 } from "./diff.js";
 import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import { writeState, type JournalState } from "./state.js";
+import { appendEntries, parseMemory, renderMemory } from "./memory.js";
+import type { MemoryEntry } from "./archivist.js";
 import { readTextOrNull } from "../utils/fs.js";
 import { log } from "../logger/index.js";
 
@@ -188,11 +190,14 @@ async function processOneDay(
   summarize: Summarize,
 ): Promise<DayOutcome> {
   const existingDaily = await readTextOrNull(dailyPathFor(workspaceRoot, date));
+  const memoryPath = path.join(workspaceRoot, "memory.md");
+  const existingMemory = (await readTextOrNull(memoryPath)) ?? "";
   const input: DailyArchivistInput = {
     date,
     existingDailySummary: existingDaily,
     existingTopicSummaries: existingTopics,
     sessionExcerpts: excerpts,
+    existingMemory,
   };
 
   const rawOutput = await callSummarizeForDay(date, input, summarize);
@@ -219,6 +224,8 @@ async function processOneDay(
     parsed.topicUpdates,
     existingTopics,
   );
+
+  await applyMemoryEntries(memoryPath, existingMemory, parsed.memoryEntries);
 
   return {
     kind: "processed",
@@ -813,4 +820,24 @@ async function applyTopicUpdate(
   }
   // append
   return appendOrCreate(p, update.content);
+}
+
+// Apply distilled memory entries from the archivist back into
+// `~/mulmoclaude/memory.md`. Skips the write entirely when the LLM
+// emits no entries (the common case) so the file's mtime doesn't
+// churn on quiet days. The parse → append → render path keeps any
+// preamble or user-added content outside the four known sections
+// intact.
+async function applyMemoryEntries(
+  memoryPath: string,
+  existingMemory: string,
+  entries: readonly MemoryEntry[],
+): Promise<void> {
+  if (entries.length === 0) return;
+  const parsed = parseMemory(existingMemory);
+  const updated = appendEntries(parsed, entries);
+  const rendered = renderMemory(updated);
+  if (rendered === existingMemory) return;
+  await fsp.writeFile(memoryPath, rendered, "utf-8");
+  log.info("journal", "memory.md updated", { entries: entries.length });
 }

--- a/server/journal/memory.ts
+++ b/server/journal/memory.ts
@@ -1,0 +1,191 @@
+// Pure helpers for parsing and updating ~/mulmoclaude/memory.md.
+//
+// The file is a single markdown document with one `##` section per
+// memory category: User / Feedback / Project / Reference. Section
+// bodies are bullet lists; each bullet is one memory entry.
+//
+// Anything outside those four known sections is preserved verbatim
+// (preamble before the first known section, trailing content after
+// the last). This lets the user hand-edit memory.md between auto
+// runs without losing additions.
+
+export type MemoryType = "user" | "feedback" | "project" | "reference";
+
+export const MEMORY_TYPES: readonly MemoryType[] = [
+  "user",
+  "feedback",
+  "project",
+  "reference",
+];
+
+export interface MemoryEntry {
+  type: MemoryType;
+  /** Single-line bullet text. Renders as `- <body>`. */
+  body: string;
+}
+
+export interface ParsedMemory {
+  /** Everything before the first known section heading, verbatim. */
+  preamble: string;
+  /** Bullet lines per section, in source order, with the leading
+   *  `- ` stripped. */
+  sections: Record<MemoryType, string[]>;
+  /** Anything after the last known section that isn't itself a
+   *  known section. Preserved verbatim so user-added headings /
+   *  prose at the bottom survive an auto-write. */
+  trailing: string;
+}
+
+const SECTION_HEADINGS: Record<MemoryType, string> = {
+  user: "## User",
+  feedback: "## Feedback",
+  project: "## Project",
+  reference: "## Reference",
+};
+
+const HEADING_TO_TYPE: ReadonlyMap<string, MemoryType> = new Map(
+  (Object.entries(SECTION_HEADINGS) as [MemoryType, string][]).map(
+    ([type, heading]) => [heading.toLowerCase(), type],
+  ),
+);
+
+function emptySections(): Record<MemoryType, string[]> {
+  return { user: [], feedback: [], project: [], reference: [] };
+}
+
+/** Parse memory.md into preamble + per-type bullet lists + trailing. */
+export function parseMemory(raw: string): ParsedMemory {
+  const lines = raw.replace(/\r\n/g, "\n").split("\n");
+  const sections = emptySections();
+  const preambleLines: string[] = [];
+  const trailingLines: string[] = [];
+
+  let currentType: MemoryType | null = null;
+  let sawAnyKnownSection = false;
+
+  for (const line of lines) {
+    const headingType = matchSectionHeading(line);
+    if (headingType !== null) {
+      currentType = headingType;
+      sawAnyKnownSection = true;
+      continue;
+    }
+    // A non-known `##` heading after we've started consuming
+    // sections means we're past the auto-managed area; everything
+    // from here to EOF goes into trailing.
+    if (sawAnyKnownSection && /^##\s/.test(line) && currentType !== null) {
+      trailingLines.push(line);
+      currentType = null;
+      continue;
+    }
+    if (currentType === null) {
+      if (sawAnyKnownSection) {
+        trailingLines.push(line);
+      } else {
+        preambleLines.push(line);
+      }
+      continue;
+    }
+    const bullet = matchBullet(line);
+    if (bullet !== null) {
+      sections[currentType].push(bullet);
+    }
+    // Non-bullet content inside a known section is dropped — we
+    // own the body of those sections. If a user wants prose, they
+    // can put it in preamble or in their own custom heading.
+  }
+
+  return {
+    preamble: stripTrailingBlankLines(preambleLines.join("\n")),
+    sections,
+    trailing: stripLeadingBlankLines(trailingLines.join("\n")).trimEnd(),
+  };
+}
+
+/** Add new entries to the right sections. Skips entries whose body
+ *  is already present (case-insensitive substring match) so the
+ *  file doesn't grow with duplicates the LLM happens to re-emit. */
+export function appendEntries(
+  parsed: ParsedMemory,
+  entries: readonly MemoryEntry[],
+): ParsedMemory {
+  if (entries.length === 0) return parsed;
+  const next: ParsedMemory = {
+    preamble: parsed.preamble,
+    sections: {
+      user: [...parsed.sections.user],
+      feedback: [...parsed.sections.feedback],
+      project: [...parsed.sections.project],
+      reference: [...parsed.sections.reference],
+    },
+    trailing: parsed.trailing,
+  };
+  for (const entry of entries) {
+    const body = entry.body.trim();
+    if (body.length === 0) continue;
+    const list = next.sections[entry.type];
+    const lower = body.toLowerCase();
+    const isDup = list.some((existing) =>
+      existing.toLowerCase().includes(lower),
+    );
+    if (!isDup) list.push(body);
+  }
+  return next;
+}
+
+/** Render parsed memory back to markdown. Empty sections are
+ *  omitted (re-added the next time an entry of that type lands).
+ *  The four known sections are emitted in canonical order
+ *  (User → Feedback → Project → Reference) regardless of the
+ *  order they appeared in the input file. */
+export function renderMemory(parsed: ParsedMemory): string {
+  const blocks: string[] = [];
+  if (parsed.preamble.trim().length > 0) {
+    blocks.push(parsed.preamble);
+  }
+  for (const type of MEMORY_TYPES) {
+    const items = parsed.sections[type];
+    if (items.length === 0) continue;
+    const heading = SECTION_HEADINGS[type];
+    const body = items.map((b) => `- ${b}`).join("\n");
+    blocks.push(`${heading}\n\n${body}`);
+  }
+  if (parsed.trailing.trim().length > 0) {
+    blocks.push(parsed.trailing);
+  }
+  return blocks.join("\n\n") + "\n";
+}
+
+function matchSectionHeading(line: string): MemoryType | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("## ")) return null;
+  return HEADING_TO_TYPE.get(trimmed.toLowerCase()) ?? null;
+}
+
+// Recognises `- foo` and `* foo` bullets. Returns the body without
+// the marker; null when the line is not a bullet. Hand-rolled
+// linear scan so sonarjs/slow-regex doesn't flag the obvious
+// `^\s*[-*]\s+(.*)$` regex form (which is fine but tripwires the
+// lint rule on capture-after-quantifier).
+function matchBullet(line: string): string | null {
+  let i = 0;
+  while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+  if (i >= line.length) return null;
+  if (line[i] !== "-" && line[i] !== "*") return null;
+  i++;
+  if (i >= line.length || (line[i] !== " " && line[i] !== "\t")) return null;
+  while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+  return line.slice(i).trimEnd();
+}
+
+function stripTrailingBlankLines(s: string): string {
+  let end = s.length;
+  while (end > 0 && s[end - 1] === "\n") end--;
+  return s.slice(0, end);
+}
+
+function stripLeadingBlankLines(s: string): string {
+  let i = 0;
+  while (i < s.length && s[i] === "\n") i++;
+  return s.slice(i);
+}

--- a/test/journal/test_archivist.ts
+++ b/test/journal/test_archivist.ts
@@ -18,6 +18,7 @@ describe("buildDailyUserPrompt", () => {
     existingDailySummary: null,
     existingTopicSummaries: [],
     sessionExcerpts: [],
+    existingMemory: "",
     ...over,
   });
 
@@ -115,6 +116,22 @@ describe("buildDailyUserPrompt", () => {
     const matches = artifactsSection.match(/- stories\/b\.json/g);
     assert.equal(matches?.length, 1);
   });
+
+  it("shows '(empty)' for the EXISTING MEMORY block when memory.md is blank", () => {
+    const out = buildDailyUserPrompt(baseInput());
+    assert.match(out, /EXISTING MEMORY .*:\n\(empty\)/s);
+  });
+
+  it("includes existingMemory verbatim when provided", () => {
+    const out = buildDailyUserPrompt(
+      baseInput({
+        existingMemory: "## User\n\n- macOS + Docker\n- OSS maintainer\n",
+      }),
+    );
+    assert.match(out, /EXISTING MEMORY/);
+    assert.match(out, /- macOS \+ Docker/);
+    assert.match(out, /- OSS maintainer/);
+  });
 });
 
 describe("buildOptimizationUserPrompt", () => {
@@ -179,7 +196,11 @@ describe("extractJsonObject", () => {
 describe("isDailyArchivistOutput", () => {
   it("accepts a valid minimal output", () => {
     assert.equal(
-      isDailyArchivistOutput({ dailySummaryMarkdown: "x", topicUpdates: [] }),
+      isDailyArchivistOutput({
+        dailySummaryMarkdown: "x",
+        topicUpdates: [],
+        memoryEntries: [],
+      }),
       true,
     );
   });
@@ -192,17 +213,68 @@ describe("isDailyArchivistOutput", () => {
         { slug: "b", action: "append", content: "..." },
         { slug: "c", action: "rewrite", content: "..." },
       ],
+      memoryEntries: [],
     };
     assert.equal(isDailyArchivistOutput(out), true);
   });
 
+  it("accepts memory entries of each valid type", () => {
+    const out = {
+      dailySummaryMarkdown: "x",
+      topicUpdates: [],
+      memoryEntries: [
+        { type: "user", body: "macOS" },
+        { type: "feedback", body: "Prefer yarn" },
+        { type: "project", body: "phase 1 in flight" },
+        { type: "reference", body: "Linear INGEST tracks bugs" },
+      ],
+    };
+    assert.equal(isDailyArchivistOutput(out), true);
+  });
+
+  it("rejects missing memoryEntries field", () => {
+    assert.equal(
+      isDailyArchivistOutput({ dailySummaryMarkdown: "x", topicUpdates: [] }),
+      false,
+    );
+  });
+
+  it("rejects memory entries with an unknown type", () => {
+    assert.equal(
+      isDailyArchivistOutput({
+        dailySummaryMarkdown: "x",
+        topicUpdates: [],
+        memoryEntries: [{ type: "todo", body: "x" }],
+      }),
+      false,
+    );
+  });
+
+  it("rejects memory entries with a non-string body", () => {
+    assert.equal(
+      isDailyArchivistOutput({
+        dailySummaryMarkdown: "x",
+        topicUpdates: [],
+        memoryEntries: [{ type: "user", body: 42 }],
+      }),
+      false,
+    );
+  });
+
   it("rejects missing dailySummaryMarkdown", () => {
-    assert.equal(isDailyArchivistOutput({ topicUpdates: [] }), false);
+    assert.equal(
+      isDailyArchivistOutput({ topicUpdates: [], memoryEntries: [] }),
+      false,
+    );
   });
 
   it("rejects non-array topicUpdates", () => {
     assert.equal(
-      isDailyArchivistOutput({ dailySummaryMarkdown: "x", topicUpdates: {} }),
+      isDailyArchivistOutput({
+        dailySummaryMarkdown: "x",
+        topicUpdates: {},
+        memoryEntries: [],
+      }),
       false,
     );
   });
@@ -212,6 +284,7 @@ describe("isDailyArchivistOutput", () => {
       isDailyArchivistOutput({
         dailySummaryMarkdown: "x",
         topicUpdates: [{ slug: "a", action: "delete", content: "" }],
+        memoryEntries: [],
       }),
       false,
     );

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -369,6 +369,7 @@ describe("parseArchivistOutput", () => {
     topicUpdates: [
       { slug: "refactoring", action: "append", content: "more progress" },
     ],
+    memoryEntries: [],
   };
 
   it("returns the parsed output for a well-formed JSON fence", () => {

--- a/test/journal/test_memory.ts
+++ b/test/journal/test_memory.ts
@@ -1,0 +1,261 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  appendEntries,
+  parseMemory,
+  renderMemory,
+  type MemoryEntry,
+} from "../../server/journal/memory.js";
+
+describe("parseMemory", () => {
+  it("returns empty sections + preamble for the stub form", () => {
+    const raw = `# Memory\n\nDistilled facts about you and your work.\n`;
+    const parsed = parseMemory(raw);
+    assert.equal(parsed.preamble.includes("# Memory"), true);
+    assert.deepEqual(parsed.sections.user, []);
+    assert.deepEqual(parsed.sections.feedback, []);
+    assert.deepEqual(parsed.sections.project, []);
+    assert.deepEqual(parsed.sections.reference, []);
+    assert.equal(parsed.trailing, "");
+  });
+
+  it("captures bullets per section in source order", () => {
+    const raw = `# Memory
+
+## User
+
+- macOS + Docker
+- OSS maintainer
+
+## Feedback
+
+- Prefer yarn
+
+## Project
+
+- mulmoclaude phase 1
+`;
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, [
+      "macOS + Docker",
+      "OSS maintainer",
+    ]);
+    assert.deepEqual(parsed.sections.feedback, ["Prefer yarn"]);
+    assert.deepEqual(parsed.sections.project, ["mulmoclaude phase 1"]);
+    assert.deepEqual(parsed.sections.reference, []);
+  });
+
+  it("accepts sections out of canonical order (rendered output sorts them)", () => {
+    const raw = `# Memory
+
+## Project
+
+- foo
+
+## User
+
+- bar
+`;
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, ["bar"]);
+    assert.deepEqual(parsed.sections.project, ["foo"]);
+  });
+
+  it("preserves preamble verbatim (apart from trailing blank lines)", () => {
+    const raw = `# Memory
+
+> Important: this file is auto-distilled. Edit carefully.
+
+## User
+
+- a
+`;
+    const parsed = parseMemory(raw);
+    assert.match(parsed.preamble, /Important: this file/);
+    assert.deepEqual(parsed.sections.user, ["a"]);
+  });
+
+  it("preserves trailing content when an unknown ## heading appears after sections", () => {
+    const raw = `# Memory
+
+## User
+
+- known section
+
+## Customs
+
+Hand-written prose I want to keep.
+
+- and a bullet
+`;
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, ["known section"]);
+    assert.match(parsed.trailing, /## Customs/);
+    assert.match(parsed.trailing, /Hand-written prose/);
+  });
+
+  it("handles CRLF line endings", () => {
+    const raw = "# Memory\r\n\r\n## User\r\n\r\n- macOS\r\n";
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, ["macOS"]);
+  });
+
+  it("ignores non-bullet content inside a known section", () => {
+    const raw = `# Memory
+
+## User
+
+Some prose Claude tried to write here.
+
+- the bullet survives
+`;
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, ["the bullet survives"]);
+  });
+
+  it("recognises both `-` and `*` bullet markers", () => {
+    const raw = `# Memory
+
+## User
+
+- dash
+* asterisk
+`;
+    const parsed = parseMemory(raw);
+    assert.deepEqual(parsed.sections.user, ["dash", "asterisk"]);
+  });
+
+  it("returns empty arrays for an empty input", () => {
+    const parsed = parseMemory("");
+    assert.deepEqual(parsed.sections.user, []);
+    assert.equal(parsed.preamble, "");
+    assert.equal(parsed.trailing, "");
+  });
+});
+
+describe("appendEntries", () => {
+  function freshParsed() {
+    return parseMemory(`# Memory\n\n## User\n\n- macOS\n`);
+  }
+
+  it("adds a new entry to the right section", () => {
+    const entries: MemoryEntry[] = [
+      { type: "user", body: "OSS maintainer at receptron" },
+    ];
+    const next = appendEntries(freshParsed(), entries);
+    assert.deepEqual(next.sections.user, [
+      "macOS",
+      "OSS maintainer at receptron",
+    ]);
+  });
+
+  it("creates a section for an entry whose type isn't yet present", () => {
+    const entries: MemoryEntry[] = [
+      { type: "feedback", body: "Prefer yarn over npm" },
+    ];
+    const next = appendEntries(freshParsed(), entries);
+    assert.deepEqual(next.sections.feedback, ["Prefer yarn over npm"]);
+  });
+
+  it("skips an entry whose body is already a substring of an existing bullet", () => {
+    const parsed = parseMemory(
+      `# Memory\n\n## User\n\n- macOS + Docker Desktop environment\n`,
+    );
+    const entries: MemoryEntry[] = [{ type: "user", body: "macOS + Docker" }];
+    const next = appendEntries(parsed, entries);
+    assert.equal(next.sections.user.length, 1);
+  });
+
+  it("dedup is case-insensitive", () => {
+    const parsed = parseMemory(
+      `# Memory\n\n## Feedback\n\n- Prefer YARN over npm\n`,
+    );
+    const entries: MemoryEntry[] = [
+      { type: "feedback", body: "prefer yarn over npm" },
+    ];
+    const next = appendEntries(parsed, entries);
+    assert.equal(next.sections.feedback.length, 1);
+  });
+
+  it("returns the input untouched when entries is empty", () => {
+    const parsed = freshParsed();
+    const result = appendEntries(parsed, []);
+    assert.equal(result, parsed);
+  });
+
+  it("ignores entries whose body is empty / whitespace-only", () => {
+    const entries: MemoryEntry[] = [
+      { type: "user", body: "   " },
+      { type: "user", body: "" },
+      { type: "user", body: "real one" },
+    ];
+    const next = appendEntries(freshParsed(), entries);
+    assert.deepEqual(next.sections.user, ["macOS", "real one"]);
+  });
+
+  it("does not mutate the input parsed object", () => {
+    const parsed = freshParsed();
+    const before = [...parsed.sections.user];
+    appendEntries(parsed, [{ type: "user", body: "added" }]);
+    assert.deepEqual(parsed.sections.user, before);
+  });
+});
+
+describe("renderMemory", () => {
+  it("emits sections in canonical order regardless of input order", () => {
+    const parsed = parseMemory(
+      `# Memory\n\n## Project\n\n- p\n\n## User\n\n- u\n`,
+    );
+    const out = renderMemory(parsed);
+    const userIdx = out.indexOf("## User");
+    const projectIdx = out.indexOf("## Project");
+    assert.ok(userIdx >= 0 && projectIdx >= 0);
+    assert.ok(userIdx < projectIdx, "User must come before Project");
+  });
+
+  it("omits empty sections", () => {
+    const parsed = parseMemory(`# Memory\n\n## User\n\n- only one\n`);
+    const out = renderMemory(parsed);
+    assert.doesNotMatch(out, /## Feedback/);
+    assert.doesNotMatch(out, /## Project/);
+    assert.doesNotMatch(out, /## Reference/);
+    assert.match(out, /## User/);
+  });
+
+  it("renders bullets with `- ` prefix and ends with a single newline", () => {
+    const parsed = parseMemory(`# Memory\n\n## User\n\n- a\n- b\n`);
+    const out = renderMemory(parsed);
+    assert.match(out, /## User\n\n- a\n- b/);
+    assert.equal(out.endsWith("\n"), true);
+    assert.equal(out.endsWith("\n\n"), false);
+  });
+
+  it("preserves trailing custom content when re-rendering", () => {
+    const parsed = parseMemory(
+      `# Memory\n\n## User\n\n- a\n\n## Customs\n\nhand-written\n`,
+    );
+    const out = renderMemory(parsed);
+    assert.match(out, /## User\n\n- a/);
+    assert.match(out, /## Customs/);
+    assert.match(out, /hand-written/);
+  });
+
+  it("round-trips a stub file (renders preamble alone)", () => {
+    const raw = `# Memory\n\nDistilled facts about you and your work.\n`;
+    const out = renderMemory(parseMemory(raw));
+    assert.match(out, /# Memory/);
+    assert.match(out, /Distilled facts/);
+  });
+
+  it("integrates parse → append → render round-trip", () => {
+    const raw = `# Memory\n\n## User\n\n- macOS\n`;
+    const parsed = parseMemory(raw);
+    const next = appendEntries(parsed, [
+      { type: "feedback", body: "Prefer yarn" },
+      { type: "user", body: "OSS maintainer" },
+    ]);
+    const out = renderMemory(next);
+    assert.match(out, /## User\n\n- macOS\n- OSS maintainer/);
+    assert.match(out, /## Feedback\n\n- Prefer yarn/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #236. The daily archivist now produces a third output stream alongside daily summaries and topic notes: short bullet entries that flow into \`~/mulmoclaude/memory.md\` under one of four sections (User / Feedback / Project / Reference). Since memory.md is already inlined into every Claude system prompt by \`buildMemoryContext\`, those facts become part of the durable context for every future session — no more needing to say "remember this".

## User Prompt

> サマリーを作るときに、重要な情報は summary できちんと覚えておいてほしいね。今って topic になるけど、それ以外で覚えておいたほうが良いことを自動的に認識して書く方法ってない？

## 4 種類の memory entry

| type | 何が入る |
|---|---|
| **user** | ユーザは誰か / 環境 / 役割 (例: "macOS + Docker Desktop", "OSS maintainer") |
| **feedback** | ユーザから受けた指摘・好み (例: "Prefer yarn", "PR description in Japanese") |
| **project** | 進行中の作業 / 状態 (例: "skills phase 1 in PR #234") |
| **reference** | 外部システム / パス (例: "Skills repo at ~/ss/dotfiles/claude/skills/") |

## memory.md の構造

\`\`\`markdown
# Memory

Distilled facts about you and your work.

## User
- macOS + Docker Desktop environment
- Primary repos: receptron/mulmoclaude

## Feedback
- Prefer yarn over npm
- PR descriptions in Japanese

## Project
- skills phase 1 PR #234 awaiting review
\`\`\`

セクション headings (## User / ## Feedback / ## Project / ## Reference) 以外の content (preamble + 末尾の手書きセクション) は **保持される** ので、ユーザが手動で編集しても次回 auto-write で消えない。

## 仕組み

1. **dailyPass** が archivist 呼び出し前に memory.md を読み込み
2. archivist プロンプトに \`EXISTING MEMORY\` block として渡す → LLM 側で重複排除
3. archivist が \`memoryEntries: MemoryEntry[]\` を返す (新規 entry が無ければ \`[]\`)
4. \`parseMemory\` → \`appendEntries\` (case-insensitive substring dedup) → \`renderMemory\` で書き戻し
5. entries が空の日は **書き込み skip** (mtime が無駄に進まない)

## 既存 wiki / topics との棲み分け

| 場所 | 内容 | 更新方法 |
|---|---|---|
| \`memory.md\` | 常駐 fact (1-3 文 bullet) | **archivist 自動 (新規)** |
| \`wiki/pages/*.md\` | ドメイン知識 | Claude が会話中に明示作成 |
| \`summaries/topics/*.md\` | 長期 topic | archivist 自動 (既存) |
| \`summaries/daily/*.md\` | 日次出来事 | archivist 自動 (既存) |

## 主な変更ファイル

| ファイル | 変更 |
|---|---|
| \`server/journal/memory.ts\` (新規) | parse / appendEntries / render の pure helpers |
| \`server/journal/archivist.ts\` | MemoryEntry 型追加、prompt 拡張、validator 拡張 |
| \`server/journal/dailyPass.ts\` | memory.md 読み書きロジック (\`applyMemoryEntries\`) |
| \`test/journal/test_memory.ts\` (新規) | parser/render 23 cases |
| \`test/journal/test_archivist.ts\` | memoryEntries validator + EXISTING MEMORY block 4 cases 追加 |
| \`test/journal/test_dailyPass.ts\` | fixture に memoryEntries: [] 追加 |
| \`plans/feat-journal-memory-distill.md\` (新規) | 設計 |

## Tests

- node:test: **1373 passing** (+23 新規)
- lint / typecheck / build all green

## Phase 2 follow-up (out of scope)

- memory.md optimization pass — 古い entry の archive (optimizationPass.ts と同パターン)
- semantic dedup
- メニュー / UI から memory entry 削除

## 関連

- Closes #236
- 既存 \`server/agent/prompt.ts#buildMemoryContext\` (memory.md → system prompt 注入) が変更不要で活きてくる
- 参考: \`server/journal/optimizationPass.ts\` (将来の archive 機構の雛形)

🤖 Generated with [Claude Code](https://claude.com/claude-code)