### PR TITLE
feat(agent): prompt Claude to proactively update memory.md

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -23,6 +23,23 @@ All data lives in the workspace directory as plain files:
 - \`wiki/\` — personal knowledge wiki (index.md, pages/, sources/, log.md)
 - \`helps/\` — built-in help documents for the app
 - \`memory.md\` — distilled facts always loaded as context
+
+## Memory Management
+
+When you learn something from the conversation that would be useful to remember in future sessions, silently append it to \`memory.md\` using the Edit tool. Do not ask permission — just write it.
+
+Organize entries under these \`##\` sections (create the section if missing):
+
+- \`## User\` — facts about the user (role, environment, skills, background)
+- \`## Feedback\` — how the user wants you to work (corrections, preferences, conventions)
+- \`## Project\` — ongoing goals, constraints, deadlines, stakeholders
+- \`## Reference\` — pointers to external systems (dashboards, issue trackers, docs)
+
+Write when: the fact is durable (still true next week), not derivable from code or git history, and not already covered by an existing entry.
+
+Skip when: it is ephemeral task state, sensitive (credentials, \`~/.ssh\`, tokens), a duplicate, or something the user explicitly asked you to forget.
+
+Keep entries as short bullet lines. Prefer updating an existing bullet over adding a near-duplicate. Bias toward fewer high-signal entries rather than exhaustive logging.
 `;
 
 // Prepend a pointer to the auto-generated workspace journal to the


### PR DESCRIPTION
## Summary

- Adds a \`## Memory Management\` section to the base system prompt in \`server/agent/prompt.ts\`, instructing Claude to silently append durable facts to \`memory.md\` under \`## User\` / \`## Feedback\` / \`## Project\` / \`## Reference\` sections using the Edit tool — no explicit "remember this" request required.
- Pure prompt change. No new code paths, no new tests.

## Items to Confirm / Review

- **Wording of the new section** (\`server/agent/prompt.ts:26-44\`) — does it strike the right balance between "proactive enough" and "not so eager that memory.md bloats"?
- **Section taxonomy** — User / Feedback / Project / Reference chosen to match the conventions of this kind of distilled-memory file. OK?
- **Skip list** — currently excludes ephemeral task state, credentials, \`~/.ssh\`, duplicates, and things the user asked to forget. Anything missing?

## User Prompt

> memory.md ってどういうタイミングで更新されるの？
>
> うーーん、覚えておいて、なんていちいち言わないよね。サマリーを作るときに、重要な情報はsummaryできちんと覚えておいてほしいね。今ってtopicになるけど、それ以外で覚えておいたほうが良いことを自動的に認識して書く方法ってない？
>
> （PR #237 を検討した後、会話中の Edit ツール経由で既に memory.md が書かれていることを確認し、そちらの動作を強化する方針に転換）
>
> 覚えてねって言わなくても重要だと思うものを勝手に覚えるように prompt を変更することはできる？

## Background

PR #237 (journal-side memory distill) was considered and closed because Claude already writes to \`memory.md\` via the Edit tool during conversations. This PR strengthens that existing path rather than adding a parallel async one.

## Test Plan

- [ ] Start a session with a fresh \`~/mulmoclaude/memory.md\` containing only the stub preamble
- [ ] Have a short conversation where durable facts surface (e.g. "I'm working on Project X this quarter", "I prefer yarn over npm")
- [ ] Verify Claude appends them to the appropriate \`##\` section without being asked
- [ ] Mention a sensitive fact (e.g. a mock credential) and verify it is NOT written to memory.md
- [ ] Repeat a fact already in memory.md and verify no duplicate is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen the agent’s base prompt to proactively manage long-term conversational memory via memory.md without requiring explicit user requests.

New Features:
- Introduce a Memory Management section in the base system prompt that instructs the agent to persist durable conversational facts into memory.md.
- Define a standard taxonomy for stored memories, organizing them under User, Feedback, Project, and Reference sections in memory.md.

Enhancements:
- Clarify criteria for when to write, skip, or update memory entries to keep memory.md concise and high-signal rather than exhaustive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the assistant with persistent memory management—it now automatically retains and organizes important information from conversations across sessions, selectively storing durable facts while excluding sensitive or redundant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->