### PR TITLE
Mac/Docker: Auto renew Claude credential

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "marked": "^18.0.0",
     "material-icons": "^1.13.14",
     "mulmocast": "^2.6.7",
+    "node-pty": "^1.1.0",
     "puppeteer": "^24.40.0",
     "uuid": "^13.0.0",
     "vue": "^3.5.32",

--- a/plan/auto_renew_credentials.md
+++ b/plan/auto_renew_credentials.md
@@ -1,0 +1,102 @@
+# Auto-Renew Expired OAuth Credentials via PTY
+
+## Problem
+
+The existing `refreshCredentials()` in `server/credentials.ts` copies the OAuth token from macOS Keychain to `~/.claude/.credentials.json` for the Docker sandbox. However, when the **access token stored in the Keychain itself is expired**, copying it to the file just copies an expired token — the 401 error persists.
+
+The host Claude CLI normally refreshes expired tokens automatically when it runs, but our code never triggers that refresh.
+
+## Solution
+
+Before copying credentials from Keychain, check whether the access token is expired. If it is, spawn `claude` in interactive mode via a PTY to force the CLI to refresh its own token. Once the CLI responds, the Keychain contains a fresh token, and we can proceed with the existing copy-to-file logic.
+
+### Why a PTY?
+
+The Claude CLI requires a TTY to run interactively. A plain `child_process.spawn` won't work because the CLI detects it's not attached to a terminal and behaves differently. `node-pty` provides a pseudo-terminal that satisfies this requirement.
+
+## Implementation
+
+### 1. Add `node-pty` dependency
+
+```bash
+yarn add node-pty
+```
+
+`node-pty` is a native module — it compiles on install. It works on macOS, Linux, and Windows. Since this credential renewal is macOS-only (`process.platform === "darwin"`), the PTY spawn only runs on macOS.
+
+### 2. Update `server/credentials.ts`
+
+#### New helper: `isTokenExpired(credentialsJson: string): boolean`
+
+Parse the Keychain JSON, extract `claudeAiOauth.expiresAt` (epoch ms), and return `true` if the current time is past that timestamp (with a small margin, e.g. 60 seconds).
+
+#### New helper: `renewTokenViaPty(): Promise<boolean>`
+
+Spawn `claude` interactively via `node-pty`:
+
+```typescript
+import pty from "node-pty";
+
+function renewTokenViaPty(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = pty.spawn("claude", [], {
+      name: "xterm-color",
+      cols: 80,
+      rows: 30,
+      cwd: process.cwd(),
+    });
+
+    let responded = false;
+    let buffer = "";
+    const timeout = setTimeout(() => {
+      proc.kill();
+      resolve(false);
+    }, 30_000); // 30s safety timeout
+
+    proc.onData((data: string) => {
+      buffer += data;
+
+      if (!responded && buffer.includes("hi")) {
+        responded = true;
+        return;
+      }
+
+      if (responded) {
+        clearTimeout(timeout);
+        proc.kill();
+        resolve(true);
+      }
+    });
+
+    // Wait for initial prompt before sending input
+    setTimeout(() => {
+      proc.write("hi\r");
+    }, 3000);
+  });
+}
+```
+
+#### Updated `refreshCredentials()` flow
+
+```
+1. Read credentials JSON from Keychain (existing logic)
+2. If empty → return false
+3. Parse and check expiresAt → if NOT expired, write to file and return true (fast path)
+4. If expired:
+   a. Log that token is expired, attempting renewal
+   b. Call renewTokenViaPty()
+   c. If renewal succeeded, re-read from Keychain (now has fresh token)
+   d. Write the fresh credentials to file
+   e. Return true/false based on success
+```
+
+### 3. No changes needed in `server/agent.ts`
+
+The call site (`agent.ts:127-128`) already calls `refreshCredentials()` before each agent run. The new expiry check and PTY renewal are internal to `refreshCredentials()`.
+
+## Considerations
+
+- **Timeout**: The PTY spawn has a 30-second timeout. If `claude` hangs or fails to respond, we kill it and return false (falling back to the existing stale-token behavior).
+- **Concurrency**: `refreshCredentials()` is called once per agent run. No concurrent PTY spawns expected, but could add a mutex if needed later.
+- **Non-macOS**: The entire flow is guarded by `process.platform === "darwin"`. No impact on other platforms.
+- **First-time login**: If there are no credentials at all in the Keychain, the existing early-return (`if (!credentials) return false`) still applies — the PTY renewal only activates when credentials exist but the access token is expired.

--- a/plan/auto_renew_credentials.md
+++ b/plan/auto_renew_credentials.md
@@ -94,6 +94,22 @@ function renewTokenViaPty(): Promise<boolean> {
 
 The call site (`agent.ts:127-128`) already calls `refreshCredentials()` before each agent run. The new expiry check and PTY renewal are internal to `refreshCredentials()`.
 
+### 4. Server console logging
+
+Every step of the renewal flow must be visible in the server console via the structured logger (`log.*` from `server/logger/`). Use prefix `"credentials"`.
+
+| Situation | Level | Example message |
+|---|---|---|
+| Token is valid (fast path) | `info` | `"Access token is valid, expires at 2026-04-13T18:00:00Z"` |
+| Token is expired, starting PTY renewal | `warn` | `"Access token expired at 2026-04-13T12:00:00Z, launching claude CLI to renew..."` |
+| PTY renewal succeeded | `info` | `"Token renewed successfully via claude CLI"` |
+| PTY renewal timed out | `error` | `"Token renewal timed out after 30s"` |
+| PTY renewal failed (other) | `error` | `"Token renewal via claude CLI failed"` |
+| Re-read from Keychain after renewal | `info` | `"Fresh credentials written to ~/.claude/.credentials.json"` |
+| Credentials JSON parse error | `error` | `"Failed to parse credentials JSON from Keychain"` |
+
+This ensures the operator can see exactly what happened when a 401 occurs — whether the token was expired, whether renewal was attempted, and whether it succeeded.
+
 ## Considerations
 
 - **Timeout**: The PTY spawn has a 30-second timeout. If `claude` hangs or fails to respond, we kill it and return false (falling back to the existing stale-token behavior).

--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -10,16 +10,25 @@ const execFileAsync = promisify(execFile);
 const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
 
-/**
- * Extract the current OAuth credentials from the macOS Keychain and write them
- * to ~/.claude/.credentials.json so that the Docker-based sandbox can read them.
- *
- * Returns true if credentials were successfully refreshed, false otherwise.
- * Only works on macOS (darwin).
- */
-export async function refreshCredentials(): Promise<boolean> {
-  if (process.platform !== "darwin") return false;
+/** Safety margin — treat tokens as expired 60s before actual expiry. */
+const EXPIRY_MARGIN_MS = 60_000;
+/** Maximum time to wait for the claude CLI to respond. */
+const PTY_TIMEOUT_MS = 30_000;
+/** Delay before sending input to the claude CLI. */
+const PTY_INPUT_DELAY_MS = 3_000;
 
+interface CredentialsJson {
+  claudeAiOauth?: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: string;
+  };
+}
+
+/**
+ * Read the raw credentials string from macOS Keychain.
+ */
+async function readFromKeychain(): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync("security", [
       "find-generic-password",
@@ -28,13 +37,170 @@ export async function refreshCredentials(): Promise<boolean> {
       "-w",
     ]);
     const credentials = stdout.trim();
-    if (!credentials) return false;
+    return credentials || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether the access token in the credentials JSON is expired.
+ */
+function isTokenExpired(raw: string): boolean {
+  try {
+    const creds: CredentialsJson = JSON.parse(raw);
+    const expiresAt = creds.claudeAiOauth?.expiresAt;
+    if (!expiresAt) return true; // no expiry info — treat as expired
+
+    const expiresMs = new Date(expiresAt).getTime();
+    if (isNaN(expiresMs)) return true;
+
+    return Date.now() >= expiresMs - EXPIRY_MARGIN_MS;
+  } catch {
+    log.error("credentials", "Failed to parse credentials JSON from Keychain");
+    return true;
+  }
+}
+
+/**
+ * Spawn `claude` interactively via a PTY to force the CLI to refresh its
+ * OAuth token. The CLI handles the refresh internally and writes the new
+ * token back to the macOS Keychain.
+ */
+async function renewTokenViaPty(): Promise<boolean> {
+  // Dynamic import — node-pty is a native module that may not be present
+  // on all platforms. Guard with try/catch.
+  let pty: typeof import("node-pty");
+  try {
+    pty = await import("node-pty");
+  } catch {
+    log.error("credentials", "node-pty not available, cannot renew token");
+    return false;
+  }
+
+  return new Promise((resolve) => {
+    const proc = pty.spawn("claude", [], {
+      name: "xterm-color",
+      cols: 80,
+      rows: 30,
+      cwd: process.cwd(),
+    });
+
+    let responded = false;
+    let buffer = "";
+    let settled = false;
+
+    const finish = (success: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      proc.kill();
+      resolve(success);
+    };
+
+    const timeout = setTimeout(() => {
+      log.error("credentials", "Token renewal timed out after 30s");
+      finish(false);
+    }, PTY_TIMEOUT_MS);
+
+    proc.onData((data: string) => {
+      buffer += data;
+
+      if (!responded && buffer.includes("hi")) {
+        // Claude echoed our "hi" — now wait for the actual response
+        responded = true;
+        return;
+      }
+
+      if (responded) {
+        // Got something after "hi" — credentials renewed
+        finish(true);
+      }
+    });
+
+    // Wait for initial prompt before sending input
+    setTimeout(() => {
+      if (!settled) {
+        proc.write("hi\r");
+      }
+    }, PTY_INPUT_DELAY_MS);
+  });
+}
+
+/**
+ * Extract the current OAuth credentials from the macOS Keychain and write them
+ * to ~/.claude/.credentials.json so that the Docker-based sandbox can read them.
+ *
+ * If the access token is expired, spawns `claude` interactively via a PTY to
+ * force the CLI to refresh its token, then re-reads the fresh credentials.
+ *
+ * Returns true if credentials were successfully refreshed, false otherwise.
+ * Only works on macOS (darwin).
+ */
+export async function refreshCredentials(): Promise<boolean> {
+  if (process.platform !== "darwin") return false;
+
+  try {
+    let credentials = await readFromKeychain();
+    if (!credentials) {
+      log.error("credentials", "No credentials found in macOS Keychain");
+      return false;
+    }
+
+    if (isTokenExpired(credentials)) {
+      // Extract expiry for logging
+      try {
+        const creds: CredentialsJson = JSON.parse(credentials);
+        const expiresAt = creds.claudeAiOauth?.expiresAt ?? "unknown";
+        log.warn(
+          "credentials",
+          `Access token expired at ${expiresAt}, launching claude CLI to renew...`,
+        );
+      } catch {
+        log.warn(
+          "credentials",
+          "Access token expired (could not parse expiry), launching claude CLI to renew...",
+        );
+      }
+
+      const renewed = await renewTokenViaPty();
+      if (!renewed) {
+        log.error("credentials", "Token renewal via claude CLI failed");
+        return false;
+      }
+
+      log.info("credentials", "Token renewed successfully via claude CLI");
+
+      // Re-read the now-fresh credentials from Keychain
+      credentials = await readFromKeychain();
+      if (!credentials) {
+        log.error(
+          "credentials",
+          "No credentials in Keychain after renewal — unexpected",
+        );
+        return false;
+      }
+    } else {
+      try {
+        const creds: CredentialsJson = JSON.parse(credentials);
+        const expiresAt = creds.claudeAiOauth?.expiresAt ?? "unknown";
+        log.info(
+          "credentials",
+          `Access token is valid, expires at ${expiresAt}`,
+        );
+      } catch {
+        log.info("credentials", "Access token appears valid");
+      }
+    }
 
     await writeFile(CREDENTIALS_PATH, credentials + "\n");
-    log.info("sandbox", "Credentials refreshed from macOS Keychain.");
+    log.info(
+      "credentials",
+      "Fresh credentials written to ~/.claude/.credentials.json",
+    );
     return true;
   } catch (err) {
-    log.error("sandbox", "Failed to refresh credentials from Keychain", {
+    log.error("credentials", "Failed to refresh credentials from Keychain", {
       error: String(err),
     });
     return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4797,6 +4797,11 @@ node-abi@^3.3.0, node-abi@^3.71.0:
   dependencies:
     semver "^7.3.5"
 
+node-addon-api@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
+
 node-domexception@1.0.0, node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
@@ -4833,6 +4838,13 @@ node-gyp@^10.2.0:
     semver "^7.3.5"
     tar "^6.2.1"
     which "^4.0.0"
+
+node-pty@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0.tgz#161936d45a47751c2e3b694c365e73017417a887"
+  integrity sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==
+  dependencies:
+    node-addon-api "^7.1.0"
 
 nopt@^7.0.0:
   version "7.2.1"


### PR DESCRIPTION
## Summary by Sourcery

Automatically refresh and export Claude OAuth credentials on macOS when they are expired so Docker-based sandboxes always receive a valid token.

Enhancements:
- Add token expiry parsing and checks for macOS-stored Claude OAuth credentials with safety margin handling.
- Introduce an interactive PTY-based flow using the Claude CLI to renew expired access tokens and re-read updated credentials from the macOS Keychain.
- Improve structured logging around credential validity, renewal attempts, and write-out to the local credentials file.

Build:
- Add node-pty as a runtime dependency for interactive Claude CLI token renewal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic renewal of expired OAuth access tokens. Credentials are now validated during operation and automatically refreshed when needed, preventing authentication failures from token expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->