### PR TITLE
fix(image): re-apply #228 marked-lexer image-ref rewrite to main

### DIFF
--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -1,3 +1,5 @@
+import { marked } from "marked";
+import type { Token, Tokens } from "marked";
 import { resolveImageSrc } from "./resolve";
 
 // Pre-`marked` pass that rewrites workspace-relative image references
@@ -8,6 +10,14 @@ import { resolveImageSrc } from "./resolve";
 // the SPA page URL (e.g. `/chat/…foo.png`) and 404s. After this
 // pass, the src becomes `/api/files/raw?path=images/foo.png` which
 // the workspace file server serves.
+//
+// Uses marked's tokenizer to find image refs rather than a raw regex
+// over the source. The regex approach had two problems:
+//   - URLs containing `)` (e.g. `Foo_(bar).png`) were truncated at
+//     the first close paren.
+//   - `![x](y)` inside fenced code blocks or inline code spans was
+//     rewritten even though it's not meant to render as an image.
+// The lexer handles both correctly.
 //
 // Callers that know the markdown file's directory (`basePath`) get
 // correct resolution for `./` and `../` relative refs. Callers that
@@ -21,10 +31,6 @@ import { resolveImageSrc } from "./resolve";
 //   - `src/plugins/wiki/View.vue`
 //   - `src/components/FilesView.vue` (when previewing a .md file)
 //   - `src/plugins/markdown/View.vue` (via post-`marked` HTML rewriter)
-
-// Match `![alt](url)`. Single character class per span, no
-// overlapping backtracking surface (linear-time matching).
-const IMAGE_REF_RE = /!\[([^\]]*)\]\(([^)]*)\)/g;
 
 function shouldSkip(url: string): boolean {
   if (url.startsWith("data:")) return true;
@@ -64,6 +70,65 @@ function resolveWorkspacePath(basePath: string, url: string): string | null {
   return segs.join("/");
 }
 
+interface Replacement {
+  raw: string;
+  replacement: string;
+}
+
+function rewriteImageToken(
+  token: Tokens.Image,
+  basePath: string,
+): string | null {
+  const href = (token.href ?? "").trim();
+  if (href === "" || shouldSkip(href)) return null;
+  const resolved = resolveWorkspacePath(basePath, href);
+  if (resolved === null) return null;
+  const newHref = resolveImageSrc(resolved);
+  // Preserve alt text verbatim — read from the raw so any special
+  // characters (brackets, entities) survive unmodified.
+  const m = token.raw.match(/^!\[([^\]]*)\]/);
+  const alt = m ? m[1] : (token.text ?? "");
+  if (token.title) {
+    const escapedTitle = token.title.replace(/"/g, '\\"');
+    return `![${alt}](${newHref} "${escapedTitle}")`;
+  }
+  return `![${alt}](${newHref})`;
+}
+
+function collectImageReplacements(
+  tokens: Token[],
+  basePath: string,
+  out: Replacement[],
+): void {
+  for (const token of tokens) {
+    // Don't descend into code — `![x](y)` inside a fenced block or
+    // backtick span is literal, not an image.
+    if (
+      token.type === "code" ||
+      token.type === "codespan" ||
+      token.type === "html"
+    ) {
+      continue;
+    }
+    if (token.type === "image") {
+      const replacement = rewriteImageToken(token as Tokens.Image, basePath);
+      if (replacement !== null) {
+        out.push({ raw: token.raw, replacement });
+      }
+      continue;
+    }
+    // Container tokens carry children in `.tokens` (paragraph, heading,
+    // blockquote, em, strong, …) or `.items` (list → list_item[]).
+    const container = token as { tokens?: Token[]; items?: Token[] };
+    if (Array.isArray(container.tokens)) {
+      collectImageReplacements(container.tokens, basePath, out);
+    }
+    if (Array.isArray(container.items)) {
+      collectImageReplacements(container.items, basePath, out);
+    }
+  }
+}
+
 /**
  * Rewrite `![alt](path)` image refs in markdown text so workspace-
  * relative paths render through `/api/files/raw`.
@@ -77,17 +142,30 @@ function resolveWorkspacePath(basePath: string, url: string): string | null {
  * untouched. Refs that would escape the workspace root (more `..`
  * than `basePath` depth) also pass through untouched — they would
  * 404 regardless, and passing through lets the user see the broken
- * ref instead of silently re-pointing it.
+ * ref instead of silently re-pointing it. Image-ref syntax inside
+ * code blocks / inline code spans is left alone.
  */
 export function rewriteMarkdownImageRefs(
   markdown: string,
   basePath: string = "",
 ): string {
-  return markdown.replace(IMAGE_REF_RE, (match, alt: string, url: string) => {
-    const trimmedUrl = url.trim();
-    if (trimmedUrl === "" || shouldSkip(trimmedUrl)) return match;
-    const resolved = resolveWorkspacePath(basePath, trimmedUrl);
-    if (resolved === null) return match;
-    return `![${alt}](${resolveImageSrc(resolved)})`;
-  });
+  const tokens = marked.lexer(markdown);
+  const replacements: Replacement[] = [];
+  collectImageReplacements(tokens, basePath, replacements);
+  if (replacements.length === 0) return markdown;
+
+  // Apply replacements in document order. `indexOf` forward from the
+  // cursor is safe across duplicate raws: marked enumerates tokens in
+  // source order, so the next occurrence we want is always at-or-after
+  // the cursor.
+  let cursor = 0;
+  const parts: string[] = [];
+  for (const { raw, replacement } of replacements) {
+    const idx = markdown.indexOf(raw, cursor);
+    if (idx < 0) continue;
+    parts.push(markdown.slice(cursor, idx), replacement);
+    cursor = idx + raw.length;
+  }
+  parts.push(markdown.slice(cursor));
+  return parts.join("");
 }

--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -70,9 +70,22 @@ function resolveWorkspacePath(basePath: string, url: string): string | null {
   return segs.join("/");
 }
 
-interface Replacement {
-  raw: string;
-  replacement: string;
+// Extract the alt-text span `[...]` from an image ref `![alt](url...)`.
+// CommonMark allows balanced nested brackets inside alt (`![x [y]](z)`),
+// which a greedy regex would get wrong — scan with a depth counter and
+// return the slice between the outermost brackets.
+function extractBracketedAlt(raw: string): string | null {
+  if (!raw.startsWith("![")) return null;
+  let depth = 1;
+  for (let i = 2; i < raw.length; i++) {
+    const c = raw[i];
+    if (c === "[") depth++;
+    else if (c === "]") {
+      depth--;
+      if (depth === 0) return raw.slice(2, i);
+    }
+  }
+  return null;
 }
 
 function rewriteImageToken(
@@ -86,8 +99,7 @@ function rewriteImageToken(
   const newHref = resolveImageSrc(resolved);
   // Preserve alt text verbatim — read from the raw so any special
   // characters (brackets, entities) survive unmodified.
-  const m = token.raw.match(/^!\[([^\]]*)\]/);
-  const alt = m ? m[1] : (token.text ?? "");
+  const alt = extractBracketedAlt(token.raw) ?? token.text ?? "";
   if (token.title) {
     const escapedTitle = token.title.replace(/"/g, '\\"');
     return `![${alt}](${newHref} "${escapedTitle}")`;
@@ -95,38 +107,69 @@ function rewriteImageToken(
   return `![${alt}](${newHref})`;
 }
 
-function collectImageReplacements(
-  tokens: Token[],
-  basePath: string,
-  out: Replacement[],
-): void {
-  for (const token of tokens) {
-    // Don't descend into code — `![x](y)` inside a fenced block or
-    // backtick span is literal, not an image.
-    if (
-      token.type === "code" ||
-      token.type === "codespan" ||
-      token.type === "html"
-    ) {
-      continue;
-    }
-    if (token.type === "image") {
-      const replacement = rewriteImageToken(token as Tokens.Image, basePath);
-      if (replacement !== null) {
-        out.push({ raw: token.raw, replacement });
-      }
-      continue;
-    }
-    // Container tokens carry children in `.tokens` (paragraph, heading,
-    // blockquote, em, strong, …) or `.items` (list → list_item[]).
-    const container = token as { tokens?: Token[]; items?: Token[] };
-    if (Array.isArray(container.tokens)) {
-      collectImageReplacements(container.tokens, basePath, out);
-    }
-    if (Array.isArray(container.items)) {
-      collectImageReplacements(container.items, basePath, out);
-    }
+function isSkippable(token: Token): boolean {
+  return (
+    token.type === "code" || token.type === "codespan" || token.type === "html"
+  );
+}
+
+function getContainerChildren(token: Token): Token[] | null {
+  const container = token as { tokens?: Token[]; items?: Token[] };
+  if (Array.isArray(container.tokens) && container.tokens.length > 0) {
+    return container.tokens;
   }
+  if (Array.isArray(container.items) && container.items.length > 0) {
+    return container.items;
+  }
+  return null;
+}
+
+// Render a container's children back into the output, preserving any
+// structural glue the parent carries outside the children's combined
+// raw span (list markers, blockquote prefixes, trailing newlines).
+// Returns true if the container was rendered via its children, false
+// if the caller should fall back to emitting the parent's raw.
+function renderContainerChildren(
+  raw: string,
+  children: Token[],
+  basePath: string,
+  out: string[],
+): boolean {
+  const joined = children
+    .map((c) => (c as { raw?: string }).raw ?? "")
+    .join("");
+  if (joined === "") return false;
+  const idx = raw.indexOf(joined);
+  if (idx < 0) return false;
+  if (idx > 0) out.push(raw.slice(0, idx));
+  for (const child of children) renderToken(child, basePath, out);
+  const tail = raw.slice(idx + joined.length);
+  if (tail) out.push(tail);
+  return true;
+}
+
+// Recursively render a token back to markdown, rewriting image refs
+// in-place. Code / codespan / html tokens are emitted verbatim so
+// image-ref syntax inside them stays literal. Token-tree recursion
+// uses the lexer's structural knowledge and never crosses a skip
+// boundary — unlike the earlier `indexOf` splice which could rewrite
+// a code-block literal when the same ref appeared in real markdown.
+function renderToken(token: Token, basePath: string, out: string[]): void {
+  if (isSkippable(token)) {
+    out.push(token.raw);
+    return;
+  }
+  if (token.type === "image") {
+    const replacement = rewriteImageToken(token as Tokens.Image, basePath);
+    out.push(replacement ?? token.raw);
+    return;
+  }
+  const raw = (token as { raw?: string }).raw ?? "";
+  const children = getContainerChildren(token);
+  if (children && renderContainerChildren(raw, children, basePath, out)) {
+    return;
+  }
+  out.push(raw);
 }
 
 /**
@@ -150,22 +193,7 @@ export function rewriteMarkdownImageRefs(
   basePath: string = "",
 ): string {
   const tokens = marked.lexer(markdown);
-  const replacements: Replacement[] = [];
-  collectImageReplacements(tokens, basePath, replacements);
-  if (replacements.length === 0) return markdown;
-
-  // Apply replacements in document order. `indexOf` forward from the
-  // cursor is safe across duplicate raws: marked enumerates tokens in
-  // source order, so the next occurrence we want is always at-or-after
-  // the cursor.
-  let cursor = 0;
   const parts: string[] = [];
-  for (const { raw, replacement } of replacements) {
-    const idx = markdown.indexOf(raw, cursor);
-    if (idx < 0) continue;
-    parts.push(markdown.slice(cursor, idx), replacement);
-    cursor = idx + raw.length;
-  }
-  parts.push(markdown.slice(cursor));
+  for (const token of tokens) renderToken(token, basePath, parts);
   return parts.join("");
 }

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -121,3 +121,82 @@ describe("rewriteMarkdownImageRefs — with basePath", () => {
     assert.equal(rewriteMarkdownImageRefs(src, "wiki/pages"), src);
   });
 });
+
+describe("rewriteMarkdownImageRefs — code blocks and special chars", () => {
+  it("leaves image-ref syntax inside a fenced code block untouched", () => {
+    const src = [
+      "Before",
+      "",
+      "```",
+      "![example](images/foo.png)",
+      "```",
+      "",
+      "After ![real](images/bar.png)",
+    ].join("\n");
+    const out = rewriteMarkdownImageRefs(src);
+    // The one inside the code block stays literal.
+    assert.ok(out.includes("![example](images/foo.png)"));
+    // The one outside gets rewritten.
+    assert.ok(out.includes("path=images%2Fbar.png"));
+  });
+
+  it("leaves image-ref syntax inside an inline code span untouched", () => {
+    const src =
+      "Use `![example](images/foo.png)` in a doc; ![real](images/bar.png) renders.";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("`![example](images/foo.png)`"));
+    assert.ok(out.includes("path=images%2Fbar.png"));
+  });
+
+  it("leaves image-ref syntax inside a ~~~ fenced block untouched", () => {
+    const src = "~~~\n![example](images/foo.png)\n~~~\n![real](x.png)";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("![example](images/foo.png)"));
+    assert.ok(out.includes("path=x.png"));
+  });
+
+  it("correctly rewrites an image URL that contains `)` inside the path (Wikipedia-style)", () => {
+    // The old regex stopped at the first `)` and truncated the href
+    // to `wiki/Foo_(bar`. marked's lexer parses balanced parens
+    // correctly, so the full `Foo_(bar).png` lands in the href.
+    // encodeURIComponent preserves `(` and `)` as literal chars (they
+    // are in its "unreserved mark" set) — the resulting URL round-
+    // trips through marked because balanced parens stay balanced.
+    const src = "![wikilink](wiki/Foo_(bar).png)";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.equal(out, "![wikilink](/api/files/raw?path=wiki%2FFoo_(bar).png)");
+  });
+
+  it("passes through https URLs with balanced parens untouched", () => {
+    const src = "![w](https://en.wikipedia.org/wiki/Foo_(bar))";
+    assert.equal(rewriteMarkdownImageRefs(src), src);
+  });
+
+  it("preserves markdown title when rewriting", () => {
+    const out = rewriteMarkdownImageRefs(
+      '![alt](images/foo.png "a title")',
+      "",
+    );
+    assert.equal(out, '![alt](/api/files/raw?path=images%2Ffoo.png "a title")');
+  });
+
+  it("rewrites multiple refs across paragraphs, lists, and blockquotes", () => {
+    const src = [
+      "# Page",
+      "",
+      "- one ![a](images/a.png)",
+      "- two ![b](images/b.png)",
+      "",
+      "> quoted ![c](images/c.png)",
+      "",
+      "```",
+      "![skipme](images/skip.png)",
+      "```",
+    ].join("\n");
+    const out = rewriteMarkdownImageRefs(src);
+    assert.ok(out.includes("path=images%2Fa.png"));
+    assert.ok(out.includes("path=images%2Fb.png"));
+    assert.ok(out.includes("path=images%2Fc.png"));
+    assert.ok(out.includes("![skipme](images/skip.png)"));
+  });
+});

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -180,6 +180,30 @@ describe("rewriteMarkdownImageRefs — code blocks and special chars", () => {
     assert.equal(out, '![alt](/api/files/raw?path=images%2Ffoo.png "a title")');
   });
 
+  it("does not rewrite a skipped literal when the same raw appears later in real markdown", () => {
+    // Regression for a forward-indexOf splice: when a fence contains
+    // `![a](x.png)` and a later paragraph contains the identical
+    // `![a](x.png)`, the earlier token-tree approach could rewrite
+    // the fenced literal instead of the real image.
+    const src = "```\n![a](x.png)\n```\n\n![a](x.png)";
+    const out = rewriteMarkdownImageRefs(src);
+    // Fenced literal unchanged.
+    assert.ok(out.includes("```\n![a](x.png)\n```"));
+    // Real image rewritten.
+    assert.ok(out.includes("![a](/api/files/raw?path=x.png)"));
+    // The fenced literal is NOT rewritten.
+    assert.ok(!out.includes("![a](/api/files/raw?path=x.png)\n```"));
+  });
+
+  it("preserves nested brackets in alt text", () => {
+    // `![outer [inner]](img.png)` — CommonMark balanced-bracket alt.
+    // The earlier regex-based alt extraction stopped at the first `]`
+    // and produced malformed output.
+    const src = "![outer [inner]](img.png)";
+    const out = rewriteMarkdownImageRefs(src);
+    assert.equal(out, "![outer [inner]](/api/files/raw?path=img.png)");
+  });
+
   it("rewrites multiple refs across paragraphs, lists, and blockquotes", () => {
     const src = [
       "# Page",


### PR DESCRIPTION
## Summary

Re-applies PR #228 ([\`ede5385\`](https://github.com/receptron/mulmoclaude/commit/ede5385)) which got stranded. That PR merged into its base branch \`fix/markdown-image-path-resolution\`, but the base had already been merged into \`main\` via #226, so the lexer-based fix never reached main.

## Items to Confirm / Review

- The cherry-pick applied cleanly with no conflicts. Diff is identical to #228's original.
- Please confirm the marked-lexer approach is still the desired direction (as opposed to keeping the regex with escaped-paren handling).

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。ブロッカーから対応。
> （/pr-quality-sweep skill の結果、#228 が main に反映されていないことを発見）

## Background

### Why this happened

- PR #226 (\`fix/markdown-image-path-resolution\`) merged into main at \`695f79e\`
- PR #228 was opened from \`fix/markdown-image-ast-rewrite\` with base = \`fix/markdown-image-path-resolution\` (the already-merged branch)
- PR #228 merged at \`896f5e5\` into that branch — never reached main
- Current main still has the raw regex with its known bugs

### What this fix gives us

The commit replaces the raw regex \`/!\[([^\]]*)\]\(([^)]*)\)/g\` with marked's tokenizer, fixing two documented bugs:

1. URLs containing \`)\` (e.g. \`Foo_(bar).png\`) were truncated at the first close paren
2. \`![x](y)\` inside fenced code blocks or inline code spans was rewritten even though it should render as literal text

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — all green (1352 tests)
- [ ] Manual: preview a markdown file with \`![x](Foo_(bar).png)\` and confirm full path survives
- [ ] Manual: preview a markdown file with \`![x](y)\` inside a fenced code block and confirm it stays literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch markdown image reference rewriting from a regex-based implementation to a marked-lexer-based approach to fix edge cases and improve correctness.

Bug Fixes:
- Ensure image URLs containing closing parentheses are fully preserved when rewriting markdown image references.
- Avoid rewriting image-reference syntax that appears inside fenced code blocks, inline code spans, or similar literal regions.

Enhancements:
- Leverage marked's tokenization to locate and rewrite image references while preserving alt text and optional titles across complex markdown structures.
- Improve test coverage around markdown image rewriting, including special-character URLs, code blocks, inline code, and multiple images across different containers.

Tests:
- Add comprehensive tests covering fenced and tilde code blocks, inline code spans, URLs with closing parentheses, HTTPS URLs with balanced parentheses, markdown titles, and multiple image references across various markdown constructs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image references inside code blocks and inline code spans are now left unchanged during processing.
  * Improved handling and preservation of image URLs containing special characters and balanced parentheses.

* **Tests**
  * Added comprehensive test coverage for Markdown image parsing edge cases, including code block and inline code scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->