### PR TITLE
fix(credentials): address CodeRabbit review comments from #241

### DIFF
--- a/plan/auto_renew_credentials.md
+++ b/plan/auto_renew_credentials.md
@@ -78,7 +78,7 @@ function renewTokenViaPty(): Promise<boolean> {
 
 #### Updated `refreshCredentials()` flow
 
-```
+```text
 1. Read credentials JSON from Keychain (existing logic)
 2. If empty → return false
 3. Parse and check expiresAt → if NOT expired, write to file and return true (fast path)

--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -103,10 +103,15 @@ async function renewTokenViaPty(): Promise<boolean> {
       finish(false);
     }, PTY_TIMEOUT_MS);
 
+    // Match "hi" as a whole token so unrelated output containing those
+    // bytes (e.g. ANSI sequences, words like "This" or "high") can't
+    // false-positive the echo detection.
+    const ECHO_RE = /\bhi\b/;
+
     proc.onData((data: string) => {
       buffer += data;
 
-      if (!responded && buffer.includes("hi")) {
+      if (!responded && ECHO_RE.test(buffer)) {
         // Claude echoed our "hi" — now wait for the actual response
         responded = true;
         return;
@@ -177,6 +182,16 @@ export async function refreshCredentials(): Promise<boolean> {
         log.error(
           "credentials",
           "No credentials in Keychain after renewal — unexpected",
+        );
+        return false;
+      }
+      // Guard against writing a still-expired token as "fresh": the PTY
+      // echo check is a proxy for "Claude responded", not proof that the
+      // Keychain entry was actually refreshed.
+      if (isTokenExpired(credentials)) {
+        log.error(
+          "credentials",
+          "Token still expired after renewal — Keychain was not refreshed",
         );
         return false;
       }


### PR DESCRIPTION
## Summary

- Replace weak \`buffer.includes(\"hi\")\` echo detection with \`/\bhi\b/\` word-boundary match (\`server/credentials.ts:109\`).
- Add post-renewal \`isTokenExpired\` guard so a still-expired token isn't written as \"fresh\" when the Keychain wasn't actually refreshed (\`server/credentials.ts:177\`).
- MD040 fix for the fenced block in \`plan/auto_renew_credentials.md:91\`.

## Items to Confirm / Review

- The new \`isTokenExpired\` guard is strictly defensive — in practice the renewal flow works, but it protects against regressions where Claude responds without actually refreshing the token.
- Word-boundary regex \`/\bhi\b/\` still matches the echoed \"hi\\r\" correctly in the PTY stream. If Claude's response starts with text containing \"hi\" as a subword (e.g. \"High there\"), it won't false-match since \`\b\` requires a word boundary.

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。ブロッカー + 要修正 + nit（ファイル名以外）。

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — all green
- [ ] Manual (macOS, expired token): run server, confirm credential refresh succeeds and fresh token is written
- [ ] Manual (macOS, force failure): temporarily return unchanged Keychain entry from renewal; confirm \`refreshCredentials()\` returns \`false\` with the new \"Token still expired after renewal\" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)