### PR TITLE
fix(mulmo-script): copy button reflects edited beats (CR follow-up #208)

### DIFF
--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -706,7 +706,17 @@ const editing = ref(false);
 const editableSource = ref("");
 const copied = ref(false);
 
-const scriptSourceText = computed(() => JSON.stringify(script.value, null, 2));
+// Beats may be edited in-place via `updateBeat()` and rendered through
+// `effectiveBeat()`, so the Copy / source-view text must read the merged
+// shape — otherwise the clipboard returns the original prop snapshot
+// until the full result is reloaded.
+const effectiveScript = computed<MulmoScript>(() => ({
+  ...script.value,
+  beats: beats.value.map((beat, i) => localOverrides[i] ?? beat),
+}));
+const scriptSourceText = computed(() =>
+  JSON.stringify(effectiveScript.value, null, 2),
+);
 const loadedSource = ref("");
 const sourceChanged = computed(
   () => editableSource.value !== loadedSource.value,


### PR DESCRIPTION
## Summary

Copy button in the MulmoScript present view now reflects in-place beat edits (\`src/plugins/presentMulmoScript/View.vue:709\`). \`scriptSourceText\` previously stringified the original prop snapshot; now it reads from an \`effectiveScript\` computed that merges \`localOverrides\` into \`beats\`.

## Items to Confirm / Review

- The merge uses \`localOverrides[i] ?? beat\` which matches the existing \`effectiveBeat()\` helper. Behavior should be identical to what the UI already renders.

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — all green
- [ ] Manual: open a MulmoScript result, edit a beat, click Copy, verify the pasted JSON contains the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)