### PR TITLE
fix(config): atomic PUT /config endpoint (CR follow-up #197)

### DIFF
--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -36,7 +36,18 @@ async function mockConfigApi(
   await page.route(
     (url) => url.pathname === "/api/config",
     (route) => {
-      if (route.request().method() === "GET") {
+      const method = route.request().method();
+      if (method === "GET") {
+        return route.fulfill({ json: state });
+      }
+      if (method === "PUT") {
+        // Atomic endpoint: payload is { settings, mcp } together.
+        const body = route.request().postDataJSON() as {
+          settings: Settings;
+          mcp: { servers: McpEntry[] };
+        };
+        state.settings = body.settings;
+        state.mcp = { servers: body.mcp.servers };
         return route.fulfill({ json: state });
       }
       return route.fallback();

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -47,6 +47,71 @@ router.get("/config", (_req: Request, res: Response<ConfigResponse>) => {
   res.json(buildFullResponse());
 });
 
+// Atomic save for both settings and MCP. Validates both payloads first
+// (no writes happen until every input is known-good), then writes
+// settings and captures the previous state so a subsequent saveMcpConfig
+// failure can roll back. This is the endpoint the Settings modal should
+// use; the per-section PUTs below remain for targeted updates.
+interface PutConfigBody {
+  settings: AppSettings;
+  mcp: { servers: McpServerEntry[] };
+}
+
+function isPutConfigBody(value: unknown): value is PutConfigBody {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return isAppSettings(c.settings) && isMcpPutBody(c.mcp);
+}
+
+router.put(
+  "/config",
+  (
+    req: Request<unknown, unknown, PutConfigBody>,
+    res: Response<ConfigResponse | ConfigErrorResponse>,
+  ) => {
+    const body = req.body;
+    if (!isPutConfigBody(body)) {
+      res.status(400).json({ error: "Invalid config payload" });
+      return;
+    }
+    let mcpCfg;
+    try {
+      mcpCfg = fromMcpEntries(body.mcp.servers);
+    } catch (err) {
+      res.status(400).json({
+        error: err instanceof Error ? err.message : "invalid mcp entries",
+      });
+      return;
+    }
+    // Snapshot previous settings so we can roll back if the second
+    // write fails — a cross-file atomic write isn't possible, but
+    // rollback keeps the pair consistent from the user's perspective.
+    const previousSettings = loadSettings();
+    try {
+      saveSettings(body.settings);
+    } catch (err) {
+      res.status(500).json({
+        error: err instanceof Error ? err.message : "saveSettings failed",
+      });
+      return;
+    }
+    try {
+      saveMcpConfig(mcpCfg);
+    } catch (err) {
+      try {
+        saveSettings(previousSettings);
+      } catch {
+        // If rollback fails too, surface the original mcp error.
+      }
+      res.status(500).json({
+        error: err instanceof Error ? err.message : "saveMcpConfig failed",
+      });
+      return;
+    }
+    res.json(buildFullResponse());
+  },
+);
+
 router.put(
   "/config/settings",
   (

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -244,24 +244,19 @@ async function save(): Promise<void> {
   statusMessage.value = "";
   statusError.value = false;
   try {
-    const settingsResponse = await fetch("/api/config/settings", {
+    // Single atomic endpoint — avoids the partial-save state where
+    // extraAllowedTools is persisted but MCP config write fails.
+    const response = await fetch("/api/config", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ extraAllowedTools: parsedToolNames.value }),
+      body: JSON.stringify({
+        settings: { extraAllowedTools: parsedToolNames.value },
+        mcp: { servers: mcpServers.value },
+      }),
     });
-    if (!settingsResponse.ok) {
-      const text = await settingsResponse.text();
-      throw new Error(text || `HTTP ${settingsResponse.status}`);
-    }
-
-    const mcpResponse = await fetch("/api/config/mcp", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ servers: mcpServers.value }),
-    });
-    if (!mcpResponse.ok) {
-      const text = await mcpResponse.text();
-      throw new Error(text || `HTTP ${mcpResponse.status}`);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `HTTP ${response.status}`);
     }
 
     emit("saved");

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -33,6 +33,7 @@ let routeMod: RouteModule;
 type Handler = (req: Request, res: Response) => void;
 let getHandler: Handler;
 let putSettingsHandler: Handler;
+let putConfigHandler: Handler;
 
 interface StackFrame {
   route?: {
@@ -51,11 +52,14 @@ function extractRouteHandler(
   method: "get" | "put",
 ): Handler {
   const router = mod.default as unknown as RouterInternals;
-  const frame = router.stack.find((f) => f.route?.path === routePath);
-  if (!frame?.route) throw new Error(`route ${routePath} not registered`);
-  const layer = frame.route.stack.find((s) => s.method === method);
-  if (!layer) throw new Error(`method ${method} not found on ${routePath}`);
-  return layer.handle;
+  // Each router.get/put() registers its own stack frame, so find the
+  // frame matching BOTH path and method rather than the first path hit.
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((s) => s.method === method);
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
 }
 
 function mockRes() {
@@ -90,6 +94,7 @@ before(async () => {
   routeMod = await import("../../server/routes/config.js");
   getHandler = extractRouteHandler(routeMod, "/config", "get");
   putSettingsHandler = extractRouteHandler(routeMod, "/config/settings", "put");
+  putConfigHandler = extractRouteHandler(routeMod, "/config", "put");
 });
 
 after(async () => {
@@ -177,5 +182,68 @@ describe("PUT /config/settings", () => {
     );
     assert.equal(state.status, 200);
     assert.deepEqual(configMod.loadSettings().extraAllowedTools, ["new"]);
+  });
+});
+
+describe("PUT /config (atomic)", () => {
+  beforeEach(() => {
+    fs.rmSync(configMod.configsDir(), { recursive: true, force: true });
+  });
+
+  it("persists settings and mcp together in a single call", () => {
+    const body = {
+      settings: { extraAllowedTools: ["alpha"] },
+      mcp: {
+        servers: [
+          {
+            id: "gh",
+            spec: { type: "http", url: "https://example.com", enabled: true },
+          },
+        ],
+      },
+    };
+    const { state, res } = mockRes();
+    putConfigHandler({ body } as Request, res);
+    assert.equal(state.status, 200);
+    assert.deepEqual(
+      (state.body as { settings: { extraAllowedTools: string[] } }).settings
+        .extraAllowedTools,
+      ["alpha"],
+    );
+    assert.deepEqual(configMod.loadSettings().extraAllowedTools, ["alpha"]);
+  });
+
+  it("rejects when settings shape is invalid", () => {
+    const body = {
+      settings: { extraAllowedTools: "not-an-array" },
+      mcp: { servers: [] },
+    };
+    const { state, res } = mockRes();
+    putConfigHandler({ body } as Request, res);
+    assert.equal(state.status, 400);
+  });
+
+  it("rejects when mcp shape is invalid", () => {
+    const body = {
+      settings: { extraAllowedTools: [] },
+      mcp: { servers: "nope" },
+    };
+    const { state, res } = mockRes();
+    putConfigHandler({ body } as Request, res);
+    assert.equal(state.status, 400);
+  });
+
+  it("does not persist settings when mcp payload fails validation", () => {
+    configMod.saveSettings({ extraAllowedTools: ["before"] });
+    const body = {
+      settings: { extraAllowedTools: ["after"] },
+      // Missing required fields → fromMcpEntries throws
+      mcp: { servers: [{ id: "x", spec: { type: "bogus" } }] },
+    };
+    const { state, res } = mockRes();
+    putConfigHandler({ body } as Request, res);
+    assert.equal(state.status, 400);
+    // Validation happens before any write — previous state unchanged
+    assert.deepEqual(configMod.loadSettings().extraAllowedTools, ["before"]);
   });
 });


### PR DESCRIPTION
## Summary

- New \`PUT /api/config\` endpoint in \`server/routes/config.ts\` that takes both \`settings\` and \`mcp\` payloads, validates both together, then writes them sequentially with a rollback step if the second write fails.
- \`src/components/SettingsModal.vue\` \`save()\` now fires the single combined request instead of two sequential requests — eliminates the partial-save state where \`extraAllowedTools\` was persisted but \`mcp.json\` failed.
- 4 new tests in \`test/routes/test_configRoute.ts\` cover happy path, invalid settings shape, invalid mcp shape, and no-persist-on-validation-failure.
- Small \`extractRouteHandler\` test helper fix: same path can have multiple methods (GET + PUT), so match on both path and method instead of first-path-hit.

## Items to Confirm / Review

- True cross-file atomicity isn't possible; the rollback path (snapshot previous settings, restore on mcp failure) is the best we can do on top of plain fs writes. If rollback itself fails, the original mcp error is still surfaced.
- The per-section \`PUT /config/settings\` and \`PUT /config/mcp\` endpoints remain untouched. Any caller that prefers targeted updates keeps working.

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — all green (1349 tests, +4 new)
- [ ] Manual: open Settings modal, edit both allowed-tools and an MCP entry, save, confirm both persist
- [ ] Manual: simulate mcp write failure (e.g., chmod \`configs/mcp.json\` to read-only before save), confirm the modal reports error AND \`settings.json\` is unchanged on next reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)