### PR TITLE
docs(developer): address CodeRabbit nits from #204

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -157,9 +157,9 @@ Three independent Node processes cooperate at runtime:
 
 ## Workspace layout (`~/mulmoclaude/`)
 
-`initWorkspace()` creates / refreshes this on every server start (`server/workspace.ts`). Everything is plain files committed to a private git repo:
+`initWorkspace()` creates / refreshes this on every server start (`server/workspace.ts`). Everything is plain files tracked in a private git repo:
 
-```
+```text
 ~/mulmoclaude/
   chat/               session ToolResults (.jsonl per session)
   chat/index/         per-session title/summary cache
@@ -229,7 +229,7 @@ When to add E2E coverage is documented in [CLAUDE.md](../CLAUDE.md#when-to-add-e
 
 Two jobs gate every PR:
 
-- **`lint_test`** — matrix: Node 22.x & 24.x × {ubuntu, windows, macos}. Runs `typecheck`, `typecheck:server`, `lint`, `build`, `test:coverage`.
+- **`lint_test`** — matrix: Node 22.x & 24.x × {ubuntu, windows, macOS}. Runs `typecheck`, `typecheck:server`, `lint`, `build`, `test:coverage`.
 - **`e2e`** — Ubuntu / Node 22.x. Runs `playwright install chromium` then `test:e2e`. Failed runs upload `test-results/` as an artifact for 7 days.
 
 Cross-platform compatibility is a hard requirement — use `node:path` joins, `node:url` for file URL conversions, no shell-specific syntax in scripts.


### PR DESCRIPTION
## Summary

Three minor docs tweaks in \`docs/developer.md\`:

- Line 160: \"committed\" → \"tracked in\" (\`initWorkspace()\` writes files and \`git init\`s but does not auto-commit)
- Line 162: add \`text\` language tag to the workspace-layout fenced block (markdownlint MD040)
- Line 232: \"macos\" → \"macOS\" (platform-name capitalization)

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。nit（ファイル名以外）も対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)