### PR TITLE
test(e2e): wiki renderer image-ref rewrite (CR follow-up #216)

### DIFF
--- a/e2e/tests/wiki-plugin.spec.ts
+++ b/e2e/tests/wiki-plugin.spec.ts
@@ -1,0 +1,96 @@
+// Regression guard for the wiki renderer's full path:
+//
+//   rewriteMarkdownImageRefs(...) -> renderWikiLinks(...) -> marked.parse(...)
+//
+// `files-html-preview.spec.ts` covers the rewrite-through-FilesView
+// path; this spec exercises the wiki plugin's own View so the three
+// transformers can't drift independently (e.g. if someone reorders
+// them and accidentally feeds marked's HTML into rewriteMarkdownImageRefs
+// which expects raw markdown).
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const WIKI_PAGE = {
+  action: "page",
+  title: "Onboarding",
+  pageName: "onboarding",
+  content:
+    "# Onboarding\n\nSee the [[setup]] guide.\n\n" +
+    "![flow](../images/flow.png)\n",
+};
+
+test.describe("wiki plugin — rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page, {
+      sessions: [
+        {
+          id: "wiki-session",
+          title: "Wiki Session",
+          roleId: "general",
+          startedAt: "2026-04-12T10:00:00Z",
+          updatedAt: "2026-04-12T10:05:00Z",
+        },
+      ],
+    });
+
+    // Session transcript with a manageWiki tool result whose data
+    // includes a page with a relative-up image ref.
+    await page.route(
+      (url) =>
+        url.pathname.startsWith("/api/sessions/") &&
+        url.pathname !== "/api/sessions",
+      (route) =>
+        route.fulfill({
+          json: [
+            {
+              type: "session_meta",
+              roleId: "general",
+              sessionId: "wiki-session",
+            },
+            { type: "text", source: "user", message: "Open onboarding" },
+            {
+              type: "tool_result",
+              source: "tool",
+              result: {
+                uuid: "wiki-result-1",
+                toolName: "manageWiki",
+                title: WIKI_PAGE.title,
+                message: "Page loaded",
+                data: WIKI_PAGE,
+              },
+            },
+          ],
+        }),
+    );
+
+    // useFreshPluginData re-fetches on mount; hand it back the same
+    // page payload so the watch-triggered refresh doesn't blank the
+    // content.
+    await page.route(
+      (url) => url.pathname === "/api/wiki",
+      (route) => route.fulfill({ json: { data: WIKI_PAGE } }),
+    );
+  });
+
+  test("renders a relative image ref via /api/files/raw", async ({ page }) => {
+    await page.goto("/chat/wiki-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Select the wiki tool result in the sidebar → mounts the wiki View.
+    // Preview renders as "Wiki: <title>".
+    await page.getByText(`Wiki: ${WIKI_PAGE.title}`).click();
+
+    // marked.parse turns `![flow](...)` into an <img alt="flow">.
+    const img = page.locator("img[alt='flow']");
+    await expect(img).toBeVisible();
+    const src = await img.getAttribute("src");
+    // basePath for a wiki page is `wiki/pages`, so `../images/flow.png`
+    // resolves to `wiki/images/flow.png` and is routed through the
+    // workspace file server.
+    expect(src).toContain("/api/files/raw");
+    expect(src).toContain("flow.png");
+    // Relative-up prefix stripped.
+    expect(src).not.toContain("..");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an E2E test for the wiki plugin's render path — \`rewriteMarkdownImageRefs → renderWikiLinks → marked.parse\` — so the three transformers can't drift independently. Asserts that a relative-up image ref \`![flow](../images/flow.png)\` in a wiki page resolves to an \`<img src=/api/files/raw?path=wiki/images/flow.png>\` when the wiki plugin's View is the one rendering the markdown.

## Items to Confirm / Review

- The existing \`files-html-preview.spec.ts\` already exercises this through FilesView. The CR comment was that wiki's own View is a separate consumer and deserves its own regression test — this PR is only about coverage, not a code change.

## User Prompt

> 24時間以内のPR全部をレビューして未対応のCodeRabbit指摘とリファクタ候補を洗い出し、修正して。nit（ファイル名以外）も対応。

## Test plan

- [x] \`yarn test:e2e -- e2e/tests/wiki-plugin.spec.ts\` — passes locally
- [x] \`yarn format && yarn lint && yarn typecheck\` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)