### PR TITLE
refactor(ui): replace window CustomEvent bus with provide/inject (#227)

### DIFF
--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -158,31 +158,38 @@ test.describe("manageSkills plugin", () => {
     await expect(page.locator("pre")).toContainText("## Publish");
   });
 
-  test("Run button dispatches a skill-run event carrying the body", async ({
+  test("Run button sends the skill invocation as a slash command", async ({
     page,
   }) => {
+    // Capture the body of the agent POST so we can assert what
+    // sendMessage forwarded. Registered AFTER mockAllApis so this
+    // route wins (Playwright matches last-registered first).
+    const agentPosts: Array<Record<string, unknown>> = [];
+    await page.route(urlEndsWith("/api/agent"), async (route: Route) => {
+      if (route.request().method() === "POST") {
+        agentPosts.push(route.request().postDataJSON());
+        return route.fulfill({
+          status: 202,
+          json: { chatSessionId: "skills-session" },
+        });
+      }
+      return route.fallback();
+    });
+
     await page.goto("/chat/skills-session?result=skills-result-1");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-
-    // Attach a listener so we can observe the CustomEvent content.
-    await page.evaluate(() => {
-      window.addEventListener("skill-run", (e: Event) => {
-        const custom = e as CustomEvent<{ message: string }>;
-        (window as unknown as { __lastSkillRun: string }).__lastSkillRun =
-          custom.detail.message;
-      });
-    });
 
     // Wait for the detail endpoint to resolve before clicking Run.
     await expect(page.locator("pre")).toContainText("## CI Enable");
     await page.getByTestId("skill-run-btn").click();
 
-    const dispatched = await page.evaluate(
-      () => (window as unknown as { __lastSkillRun?: string }).__lastSkillRun,
-    );
-    // Run button sends the skill invocation as a Claude Code slash
-    // command — Claude CLI resolves /<name> against ~/.claude/skills/
-    // natively, so we don't need to ship the body.
-    expect(dispatched).toBe("/ci_enable");
+    // Run button routes through App.vue's sendMessage via the
+    // useAppApi() provide/inject contract (#227). The slash command
+    // form (`/<name>`) is what Claude CLI resolves against
+    // ~/.claude/skills/ natively, so we don't need to ship the body.
+    await expect
+      .poll(() => agentPosts.length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+    expect(agentPosts[0]?.message).toBe("/ci_enable");
   });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -368,6 +368,7 @@ import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
 import { useQueriesPanel } from "./composables/useQueriesPanel";
 import { useEventListeners } from "./composables/useEventListeners";
+import { provideAppApi } from "./composables/useAppApi";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 
 // --- Debug beat (pub/sub) ---
@@ -1201,9 +1202,13 @@ const { handler: handleClickOutsideRoleDropdown } = useClickOutside({
   popupRef: roleDropdownRef,
 });
 
+// Plugin Views call back into App.vue via provide/inject (#227).
+provideAppApi({
+  refreshRoles,
+  sendMessage: (message: string) => sendMessage(message),
+});
+
 useEventListeners({
-  onRolesUpdated: refreshRoles,
-  onSkillRun: (message: string) => sendMessage(message),
   onKeyNavigation: handleKeyNavigation,
   onViewModeShortcut: handleViewModeShortcut,
   onClickOutsideHistory: handleClickOutsideHistory,

--- a/src/composables/useAppApi.ts
+++ b/src/composables/useAppApi.ts
@@ -1,0 +1,47 @@
+// Vue provide/inject contract that lets plugin Views call back into
+// App.vue without going through window-level CustomEvents.
+//
+// Background: plugins like manageRoles and manageSkills used to
+// dispatch `roles-updated` / `skill-run` on `window` and App.vue
+// listened with `addEventListener`. That worked but routed
+// component-to-component communication through a global side channel,
+// which got hard to follow as more plugins came online (#227).
+//
+// `provide` / `inject` is the Vue-native equivalent: App.vue provides
+// a small typed API surface, plugins inject and call methods directly.
+// No string event names, full type-checking, no chance of a typo
+// silently failing.
+
+import { inject, provide } from "vue";
+
+/** API surface that plugin Views can call on App.vue. */
+export interface AppApi {
+  /** Refresh the role dropdown — call after the roles list changes. */
+  refreshRoles: () => void | Promise<void>;
+  /** Send a chat message through App.vue's normal sendMessage pipeline. */
+  sendMessage: (message: string) => void;
+}
+
+const APP_API_KEY = Symbol("appApi");
+
+/** Called once in App.vue setup to expose the API to descendants. */
+export function provideAppApi(api: AppApi): void {
+  provide(APP_API_KEY, api);
+}
+
+/**
+ * Called by plugin Views (any descendant of App.vue) to access the API.
+ *
+ * Throws if used outside an App.vue subtree — if you need a no-op
+ * fallback (e.g. a plugin rendered in isolation in a test), pass a
+ * default-returning callback to `inject` directly instead.
+ */
+export function useAppApi(): AppApi {
+  const api = inject<AppApi>(APP_API_KEY);
+  if (!api) {
+    throw new Error(
+      "useAppApi() called outside an App.vue subtree — provideAppApi must run first.",
+    );
+  }
+  return api;
+}

--- a/src/composables/useEventListeners.ts
+++ b/src/composables/useEventListeners.ts
@@ -1,7 +1,13 @@
-// Composable that wires all the window-level event listeners used by
-// App.vue (click-outside handlers for 3 popups, global keydown for
-// navigation + view-mode shortcuts, and the `roles-updated` custom
-// event) and tears them down on unmount.
+// Composable that wires the window-level event listeners used by
+// App.vue (click-outside handlers for 3 popups + global keydown for
+// navigation + view-mode shortcuts) and tears them down on unmount.
+//
+// Plugin → App.vue communication used to live here too via
+// `roles-updated` / `skill-run` CustomEvents on `window`. That now
+// flows through `useAppApi` (provide/inject) — see #227. Anything
+// remaining in this composable is genuinely a window-level concern
+// (keyboard / mouse events that don't have a single "owning"
+// component).
 //
 // Each listener is supplied as an option so the composable stays
 // independent of App.vue's local state; the caller passes the
@@ -10,11 +16,6 @@
 import { onMounted, onUnmounted } from "vue";
 
 export interface EventListenerHandlers {
-  /** Called when the manageRoles plugin dispatches a `roles-updated` CustomEvent. */
-  onRolesUpdated: () => void | Promise<void>;
-  /** Called when the manageSkills View dispatches a `skill-run` CustomEvent —
-   *  detail.message is the composed prompt to send via the chat pipeline. */
-  onSkillRun?: (message: string) => void;
   /** Global keydown for arrow-key navigation / Esc handling. */
   onKeyNavigation: (e: KeyboardEvent) => void;
   /** Global keydown for Cmd/Ctrl+1/2/3 view-mode shortcut. */
@@ -28,30 +29,15 @@ export interface EventListenerHandlers {
 }
 
 export function useEventListeners(handlers: EventListenerHandlers): void {
-  // `skill-run` is a CustomEvent<{ message: string }>. We wrap the
-  // caller's onSkillRun in a typed dispatcher so callers stay
-  // unaware of the event shape.
-  const skillRunWrapper = (e: Event): void => {
-    if (!handlers.onSkillRun) return;
-    const custom = e as CustomEvent<{ message?: unknown }>;
-    const msg = custom.detail?.message;
-    if (typeof msg === "string") handlers.onSkillRun(msg);
-  };
-
   onMounted(() => {
-    window.addEventListener("roles-updated", handlers.onRolesUpdated);
     window.addEventListener("keydown", handlers.onKeyNavigation);
     window.addEventListener("keydown", handlers.onViewModeShortcut);
     window.addEventListener("mousedown", handlers.onClickOutsideHistory);
     window.addEventListener("mousedown", handlers.onClickOutsideLock);
     window.addEventListener("mousedown", handlers.onClickOutsideRoleDropdown);
-    if (handlers.onSkillRun) {
-      window.addEventListener("skill-run", skillRunWrapper);
-    }
   });
 
   onUnmounted(() => {
-    window.removeEventListener("roles-updated", handlers.onRolesUpdated);
     window.removeEventListener("keydown", handlers.onKeyNavigation);
     window.removeEventListener("keydown", handlers.onViewModeShortcut);
     window.removeEventListener("mousedown", handlers.onClickOutsideHistory);
@@ -60,9 +46,6 @@ export function useEventListeners(handlers: EventListenerHandlers): void {
       "mousedown",
       handlers.onClickOutsideRoleDropdown,
     );
-    if (handlers.onSkillRun) {
-      window.removeEventListener("skill-run", skillRunWrapper);
-    }
     handlers.onTeardown?.();
   });
 }

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -181,6 +181,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from "vue";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { useAppApi } from "../../composables/useAppApi";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { CustomRole, ManageRolesData } from "./index";
 import { getAllPluginNames } from "../../tools/index";
@@ -215,6 +216,8 @@ const props = defineProps<{
   selectedResult: ToolResultComplete<ManageRolesData>;
 }>();
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
+
+const appApi = useAppApi();
 
 const customRoles = ref<CustomRole[]>(
   props.selectedResult.data?.customRoles ?? [],
@@ -316,8 +319,8 @@ async function refreshList() {
       ...result,
       uuid: props.selectedResult.uuid,
     });
-    // Let App.vue know the dropdown needs to refresh
-    window.dispatchEvent(new CustomEvent("roles-updated"));
+    // Let App.vue know the dropdown needs to refresh.
+    await Promise.resolve(appApi.refreshRoles());
   }
 }
 

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -90,6 +90,7 @@
 import { computed, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
+import { useAppApi } from "../../composables/useAppApi";
 
 interface SkillDetail {
   name: string;
@@ -156,15 +157,12 @@ watch(
 
 // Run = send the skill invocation as a Claude Code slash command.
 // Claude CLI already knows about every ~/.claude/skills/<name>/SKILL.md
-// at spawn, so sending `/<name>` is enough — no need to ship the
-// body. App.vue listens for the `skill-run` window event and routes
-// to its existing sendMessage pipeline. (See論点 1 on PR #224.)
+// at spawn, so sending `/<name>` is enough — no need to ship the body.
+// Routes through App.vue's sendMessage via provide/inject (#227).
+const appApi = useAppApi();
+
 function runSkill(): void {
   if (!selectedName.value) return;
-  window.dispatchEvent(
-    new CustomEvent("skill-run", {
-      detail: { message: `/${selectedName.value}` },
-    }),
-  );
+  appApi.sendMessage(`/${selectedName.value}`);
 }
 </script>

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -7,8 +7,8 @@
       <div>
         <h2 class="text-lg font-semibold text-gray-800">Skills</h2>
         <p class="text-xs text-gray-400 mt-0.5">
-          {{ skills.length }} available · click one to view · "Run" sends its
-          SKILL.md as a message
+          {{ skills.length }} available · click one to view · "Run" invokes it
+          as /&lt;name&gt;
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

プラグイン View → App.vue のコールバック経路を **window CustomEvent** から **Vue 3 ネイティブの provide/inject** に置き換え。Closes #227.

- 新規 \`src/composables/useAppApi.ts\` — \`AppApi\` 型 + \`provideAppApi()\` / \`useAppApi()\` ペア
- App.vue 側で \`provideAppApi({ refreshRoles, sendMessage })\` 一回だけ
- \`manageRoles/View.vue\` の \`window.dispatchEvent(new CustomEvent("roles-updated"))\` → \`appApi.refreshRoles()\`
- \`manageSkills/View.vue\` の \`skill-run\` dispatch → \`appApi.sendMessage("/<name>")\`
- \`useEventListeners.ts\` から該当ハンドラと \`skillRunWrapper\` を削除（キーボード + click-outside ハンドラは残す）

## Items to Confirm / Review

- **インターフェイスの粒度**: \`AppApi\` は \`refreshRoles\` と \`sendMessage\` の2つだけに絞った。今後プラグインから App.vue を呼びたいケースが出たらここに追加する設計。最初から大きな型を作るより、必要に応じて足す方向。
- **\`useAppApi()\` の throw 挙動**: App.vue サブツリー外で呼ぶと throw する。プラグインを単独テストするときは inject 直接 + デフォルト値で逃げてくださいと doc コメントに明記。
- **E2E テスト書き換え**: \`skills.spec.ts\` の Run ボタンテストが内部実装（CustomEvent dispatch）に依存していたので、\`POST /api/agent\` の payload を assert する形に変更（user-facing behavior をテストする方が refactor 耐性が高い）。
- **App.vue の影響範囲**: provide 1行追加 + \`useEventListeners()\` のハンドラ2つ削除のみ。他のロジックは無変更。

## User Prompt

> issueを全部確認して閉じれるものは閉じる。簡単にできそうなものは実装したい
> [...]
> 227は、置き換えるか。じゃぁ、進めよう

issue triage の結果、easy-win として #227 を採択し実装。

## Test plan

- [x] \`yarn test:e2e -- tests/skills.spec.ts\` — 4 passed（Run ボタンのテストを刷新済）
- [x] \`yarn test:e2e\` — 144 passed（フル E2E、回帰なし）
- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn typecheck:server\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal component communication architecture for improved maintainability and clearer data flow patterns.

* **Tests**
  * Enhanced end-to-end test coverage and verification methods for core application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->