### PR TITLE
feat(sandbox): pre-install core + data + doc tools (#162 phases 1-3)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,4 +1,77 @@
 FROM node:22-slim
+
+# Sandbox tool set (see #162). Grouped into layers by purpose so the
+# rationale is obvious from the diff:
+#
+# 1. Core CLI — read local git history, fetch over HTTP, pipeline JSON,
+#    run Makefile-driven workspaces, handle archives, query SQLite.
+#    `ca-certificates` is needed because `node:22-slim` ships without
+#    a trust store. `ripgrep` backs Claude's grep tool.
+# 2. Data analysis + plotting — Python with pandas/numpy/matplotlib
+#    and `requests` for API fetches. Graphviz for structural diagrams.
+#    ImageMagick for raster ops. Covers the "investment / data / chart"
+#    and "visualize this workflow" use cases in the issue.
+# 3. Document + media conversion — pandoc bridges Markdown ↔ PDF/DOCX/
+#    HTML/EPUB for report output. ffmpeg covers audio/video transcode
+#    and probing. poppler-utils extracts text / images from PDFs.
+# 4. Small extras — `tree` for directory listing, `bc` for arbitrary-
+#    precision arithmetic, `less` for pagers.
+#
+# Deferred on purpose:
+#
+# - `@mermaid-js/mermaid-cli` — pulls in headless Chromium (~300MB).
+#   Revisit as a separate layer if diagram generation becomes common.
+# - `texlive-*` — ~150MB+ for marginal PDF quality gains over pandoc's
+#   default LaTeX-free path; add when a user actually needs math/
+#   journal-style typesetting.
+# - `gh` CLI + auth mount — tracked in #162 Phase 4, needs a code
+#   change in `server/agent/config.ts` to mount `~/.config/gh:ro`.
+#
+# Runtime `pip install` is intentionally NOT wired up. Everything the
+# agent might need for data work is preinstalled at build time so
+# supply-chain risk stays out of the sandbox.
+
+# Layer 1: core CLI
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      curl \
+      jq \
+      make \
+      ca-certificates \
+      sqlite3 \
+      zip \
+      unzip \
+      ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 2: data analysis + plotting
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 \
+      python3-pip \
+      graphviz \
+      imagemagick \
+    && rm -rf /var/lib/apt/lists/* \
+ && pip3 install --no-cache-dir --break-system-packages \
+      pandas \
+      numpy \
+      matplotlib \
+      requests
+
+# Layer 3: document + media conversion
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pandoc \
+      ffmpeg \
+      poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 4: small extras
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tree \
+      bc \
+      less \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g @anthropic-ai/claude-code tsx
+
 USER node
 WORKDIR /home/node/mulmoclaude


### PR DESCRIPTION
## Summary

Covers #162 Phases 1-3 in a single slice. Image grows from 365MB → **~1.44GB**, trading size for a sandbox that handles the common workflows (data analysis, chart/diagram generation, document conversion, dev-style bash) without needing a workspace-specific image.

Organised into four explicit layers in the Dockerfile so future add / remove diffs stay obvious:

| Layer | Tools | Covers |
|---|---|---|
| **Core CLI** | git, curl, jq, make, ca-certificates, sqlite3, zip, unzip, ripgrep | Read local history, HTTP fetches, JSON pipelining, archive handling, local analytical queries. \`ripgrep\` backs Claude's grep tool. |
| **Data analysis + plotting** | python3, pip + (pandas, numpy, matplotlib, requests), graphviz, imagemagick | \"Investment / reporting / chart\" use cases. Preinstalled Python packages mean no runtime \`pip install\`. |
| **Document + media conversion** | pandoc, ffmpeg, poppler-utils | Markdown ↔ PDF/DOCX/HTML/EPUB, audio/video transcode + probe, PDF text/image extract. |
| **Small extras** | tree, bc, less | Directory tree, arbitrary-precision math, pager. |

## What's deferred (on purpose)

- \`@mermaid-js/mermaid-cli\` — pulls in headless Chromium (~300MB). Worth its own PR once diagram generation becomes a common ask.
- \`texlive-*\` — ~150MB+ for marginal quality gains over pandoc's default LaTeX-free path.
- \`gh\` CLI + \`~/.config/gh:ro\` auth mount — Phase 4 of #162, needs a code change in \`server/agent/config.ts\`.

## Why runtime pip is off

\`pip install <anything>\` inside the sandbox would be the easiest supply-chain attack surface. Everything the agent might reach for is preinstalled at build time, and a workspace-specific \`Dockerfile.sandbox.local\` is the planned escape hatch (issue #162 Phase 4).

## Items to Confirm / Review

- **Image size**: 1.44GB. Hefty, but each tool has a clear reason. If you'd rather split into multiple images (core vs. enriched, with a build-time \`SANDBOX_TIER\` arg), easy to pivot.
- **Python package set** (pandas/numpy/matplotlib/requests) — is that the right default, or does it miss something common (e.g. \`scipy\`, \`pyyaml\`, \`beautifulsoup4\`)?
- **ImageMagick**'s default policy ships with PDF / EPS / SVG / coder restrictions on Debian bookworm; we don't override \`/etc/ImageMagick-6/policy.xml\`. Fine for most image-to-image ops; tell me if we need PDF-in support (edit policy + commit together).
- **ffmpeg** (~200MB on aarch64) is the single heaviest entry. Keep or drop? The issue called it out as general-user useful.

## Verification

Built locally on aarch64 (\`docker build -f Dockerfile.sandbox -t ... --load .\`), all 18 tool binaries reported:

\`\`\`
git curl jq make sqlite3 zip unzip rg python3 pip
pandoc ffmpeg convert dot pdftotext tree bc less
python packages: pandas 3.0.2, numpy 2.4.4, matplotlib 3.10.8, requests 2.33.1
\`\`\`

End-to-end smoke tests inside a one-off container:

- **pandas + matplotlib**: DataFrame → mean → bar chart → PNG (11254 bytes written)
- **pandoc**: Markdown → HTML
- **graphviz**: DOT → SVG (valid XML prefix)
- **curl | jq** (carried over from the earlier revision): fetched this repo's GitHub public API, extracted \`{name, stargazers_count, open_issues}\`
- **sqlite3 :memory:**: \`CREATE / INSERT / SELECT SUM, GROUP_CONCAT\` returned \`6|alpha,beta,gamma\`

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/162 これをおこなう。dockerに必要なツールを一通り入れてlocalでそれらが入っていて、１，２こ使えるか確認をして。そしてPRを。
> このPRでもっとアグレッシブにツールをいれられない？

## Test plan

- [x] Image builds cleanly on aarch64
- [x] Every tool binary reports a version
- [x] End-to-end: Python data pipeline (pandas → matplotlib PNG)
- [x] End-to-end: pandoc + graphviz
- [x] End-to-end: curl | jq against GitHub API
- [x] End-to-end: sqlite3 in-memory query
- [ ] x86_64 CI build + agent-driven smoke (next agent run rebuilds the image via \`server/docker.ts\`'s hash watcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)