### PR TITLE
refactor(e2e): selector stabilization for upcoming top-page layout shift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,9 +254,22 @@ e2e/
 ### Writing tests
 
 1. Call `await mockAllApis(page)` before `page.goto()` — it intercepts all API routes
-2. Use `data-testid` attributes for element selection (change-resistant)
+2. Use `data-testid` attributes for element selection (change-resistant) — see "Selector stability" below
 3. Use URL assertions for router behaviour (`expect(page.url()).toContain(...)`)
 4. Override specific API responses per test by adding a `page.route()` AFTER `mockAllApis` (Playwright checks last-registered first)
+
+### Selector stability — avoid layout-dependent tests
+
+E2E tests MUST survive **layout** changes (moving an element from sidebar to canvas, regrouping buttons, etc.) without being rewritten. Tests break the moment they walk the DOM structure instead of addressing elements by role.
+
+**Rules:**
+
+1. **Every element that an E2E test touches MUST carry a `data-testid`.** Source of truth is the Vue template — add the testid when you add the element, not when a test needs it. Missing testid = add it in the same PR.
+2. **Name testids by function, not position.** `chat-input`, `send-btn`, `role-selector-btn`, `plugin-toolbar-todos` — not `left-sidebar-input`, `top-bar-right-button`. The whole point is that layout can change without renaming.
+3. **Never use raw tag / structural CSS locators** (`page.locator("textarea")`, `page.locator('button:has(span.material-icons:text("send"))')`, `page.locator("div > div:nth-child(2)")`). These break on any layout tweak.
+4. **Layout-shift PRs (moving an element) MUST NOT rename testids.** Move the DOM node; the testid travels with it. If a rename is genuinely needed, do it in a separate PR so the layout diff stays minimal.
+5. **Reusable interactions go in `e2e/fixtures/chat.ts`** (and sibling fixture files). Tests call `sendChatMessage(page, "hi")`, `switchRole(page, "general")` etc. — when a layout change breaks the underlying testid hunt, only the helper needs updating, not every test. Drop to `page.getByTestId(...)` inline only when the interaction is one-off and no helper fits.
+6. **Content-based locators** (`page.locator("text=Hello")`, `img[alt='chart']`) are fine for asserting rendered output, but NOT for navigation. Prefer testid for clicks / fills; content selectors for `toBeVisible` / `toHaveText` assertions.
 
 ### When to add E2E coverage
 

--- a/e2e/fixtures/chat.ts
+++ b/e2e/fixtures/chat.ts
@@ -1,0 +1,82 @@
+// Playwright helpers that abstract user-facing chat interactions so
+// tests don't hard-code the current layout of the app.
+//
+// The top-page UX is planned to shift (chat input moves from the left
+// sidebar to the canvas bottom, etc. — see issue #253). Tests that
+// call these helpers keep working across that shift because only the
+// helper implementations need updating. Tests that go straight to
+// `page.locator("textarea")` or walk DOM structure will break.
+//
+// **Rule of thumb for new tests**: reach for a helper here first.
+// Drop to `page.getByTestId(...)` only when none of these fit, and
+// never use raw tag / CSS selectors for chat / nav / role / session
+// interactions.
+
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Fill the chat input with text. Does not submit — pair with
+ * {@link clickSend} or {@link sendChatMessage} to actually send.
+ */
+export async function fillChatInput(page: Page, text: string): Promise<void> {
+  await page.getByTestId("user-input").fill(text);
+}
+
+/** Click the send button. Assumes a non-empty input is already filled. */
+export async function clickSend(page: Page): Promise<void> {
+  await page.getByTestId("send-btn").click();
+}
+
+/** Fill + send in one call. */
+export async function sendChatMessage(page: Page, text: string): Promise<void> {
+  await fillChatInput(page, text);
+  await clickSend(page);
+}
+
+/** Locator for the chat input textarea itself. Useful for
+ *  `expect(...).toHaveValue(...)` assertions. */
+export function chatInput(page: Page): Locator {
+  return page.getByTestId("user-input");
+}
+
+/** Locator for the send button. Useful for `toBeEnabled()` checks. */
+export function sendButton(page: Page): Locator {
+  return page.getByTestId("send-btn");
+}
+
+/** Click the "New session" button (top-left plus icon). */
+export async function startNewSession(page: Page): Promise<void> {
+  await page.getByTestId("new-session-btn").click();
+}
+
+/** Open the session history popup (clock icon). */
+export async function openSessionHistory(page: Page): Promise<void> {
+  await page.getByTestId("history-btn").click();
+}
+
+/** Click an existing session tab by id (appears after opening a session). */
+export async function selectSessionTab(
+  page: Page,
+  sessionId: string,
+): Promise<void> {
+  await page.getByTestId(`session-tab-${sessionId}`).click();
+}
+
+/** Open the Role selector dropdown. */
+export async function openRoleSelector(page: Page): Promise<void> {
+  await page.getByTestId("role-selector-btn").click();
+}
+
+/**
+ * Switch to a different role by id. Opens the dropdown, clicks the
+ * option, which also triggers the role-change handler in App.vue.
+ */
+export async function switchRole(page: Page, roleId: string): Promise<void> {
+  await openRoleSelector(page);
+  await page.getByTestId(`role-option-${roleId}`).click();
+}
+
+/** Open the Settings modal (gear icon). */
+export async function openSettings(page: Page): Promise<void> {
+  await page.getByTestId("settings-btn").click();
+}

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -7,20 +7,18 @@ test.beforeEach(async ({ page }) => {
 
 test("app loads and shows the title", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByText("MulmoClaude")).toBeVisible();
+  await expect(page.getByTestId("app-title")).toBeVisible();
 });
 
 test("send button and input are visible and enabled", async ({ page }) => {
   await page.goto("/");
-  const input = page.locator("textarea");
-  await expect(input).toBeVisible();
-  const sendBtn = page.locator('button:has(span.material-icons:text("send"))');
-  await expect(sendBtn).toBeEnabled();
+  await expect(page.getByTestId("user-input")).toBeVisible();
+  await expect(page.getByTestId("send-btn")).toBeEnabled();
 });
 
 test("unknown route still shows the app (catch-all redirect)", async ({
   page,
 }) => {
   await page.goto("/some/random/path");
-  await expect(page.getByText("MulmoClaude")).toBeVisible();
+  await expect(page.getByTestId("app-title")).toBeVisible();
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -93,6 +93,7 @@
         <button
           ref="roleButtonRef"
           class="flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 text-left"
+          data-testid="role-selector-btn"
           @click="showRoleDropdown = !showRoleDropdown"
         >
           <span class="material-icons text-base text-gray-500">{{
@@ -109,6 +110,7 @@
           <button
             v-for="role in roles"
             :key="role.id"
+            :data-testid="`role-option-${role.id}`"
             class="w-full flex items-center gap-1.5 px-3 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
             @click="
               currentRoleId = role.id;


### PR DESCRIPTION
## Summary

Phase 0.5 of #253 — prepare E2E selectors so the upcoming top-page layout shift doesn't rewrite every test file.

Changes:

1. **\`src/App.vue\`** — add \`data-testid\` to role selector button (\`role-selector-btn\`) and each role option (\`role-option-<id>\`). These are the main elements that physically move in Phase 1a (sidebar → top bar).
2. **\`e2e/tests/smoke.spec.ts\`** — replace \`page.locator(\"textarea\")\` and the structural \`button:has(span.material-icons:text(\"send\"))\` with testid lookups. Title check now uses \`getByTestId(\"app-title\")\` instead of \`getByText(\"MulmoClaude\")\`.
3. **\`e2e/fixtures/chat.ts\`** (new) — helper module: \`sendChatMessage\`, \`fillChatInput\`, \`clickSend\`, \`switchRole\`, \`openSessionHistory\`, \`selectSessionTab\`, \`openSettings\`, etc. Tests that call these survive layout moves because only the helper file has to change.
4. **\`CLAUDE.md\`** — new \"Selector stability — avoid layout-dependent tests\" section under E2E Testing with 6 enforceable rules.

All 148 existing E2E tests pass unchanged — this PR only tightens what's already there and adds helpers for future use.

## The 6 rules (codified in CLAUDE.md)

1. Every E2E-touched element **MUST** carry a \`data-testid\` — added at template time, not when a test needs it
2. Name testids by **function, not position** (\`chat-input\`, not \`left-sidebar-input\`)
3. **Never** use raw tag / structural CSS locators — they break on any layout tweak
4. Layout-shift PRs **MUST NOT** rename testids — the DOM node moves, the id travels with it
5. Reusable interactions go in \`e2e/fixtures/chat.ts\` — tests call helpers, helpers can be updated once when testid hunting has to change
6. Content-based locators (\`text=Hello\`, \`img[alt='...']\`) fine for \`toBeVisible\` / \`toHaveText\` assertions, but not for clicks / fills

## Items to Confirm / Review

- **Scope**: kept it minimal (only the clearly-fragile \`smoke.spec.ts\` + role selector testids). Other specs already use testids. If you want me to pre-add testids for elements that'll be added in Phase 1a (plugin-toolbar icons, dashboard widgets), happy to extend — but those don't exist yet so I left them out.
- **Helper API**: \`sendChatMessage\`, \`fillChatInput\`, \`clickSend\` separation is deliberate (some tests want to assert the input has a value before sending). If you'd rather collapse to one, easy to trim.

## User Prompt

> まずe2eの変更は進めたほうが良いね。ブランチ作ってすすめて。claude.mdにもきちんとかく。

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — green
- [x] \`yarn test:e2e\` — all 148 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)