### PR TITLE
fix(present-document): replace unfilled image placeholders + log gaps

### DIFF
--- a/server/routes/plugins.ts
+++ b/server/routes/plugins.ts
@@ -14,6 +14,7 @@ import {
   isGeminiAvailable,
 } from "../utils/gemini.js";
 import { errorMessage } from "../utils/errors.js";
+import { log } from "../logger/index.js";
 import { saveImage } from "../utils/image-store.js";
 import {
   saveMarkdown,
@@ -66,28 +67,67 @@ async function generateImageFile(prompt: string): Promise<string | null> {
   try {
     const { imageData } = await generateGeminiImageFromPrompt(prompt);
     if (imageData) return saveImage(imageData);
-  } catch {
-    // leave placeholder if generation fails
+    log.warn("present-document", "Gemini returned no image data for prompt", {
+      promptPreview: prompt.slice(0, 80),
+    });
+  } catch (err) {
+    // Surface the failure so missing-image symptoms in the canvas
+    // are debuggable from the server log instead of vanishing.
+    log.warn("present-document", "Gemini image generation failed", {
+      error: errorMessage(err),
+      promptPreview: prompt.slice(0, 80),
+    });
   }
   return null;
 }
 
 async function fillImagePlaceholders(markdown: string): Promise<string> {
-  if (!isGeminiAvailable()) return markdown;
   const matches = [...markdown.matchAll(IMAGE_PLACEHOLDER)];
   if (matches.length === 0) return markdown;
+  // Only attempt generation when Gemini is wired up; otherwise the
+  // placeholder still gets stripped below so we don't leak a broken
+  // <img src="...__too_be_replaced_image_path__"> into the rendered
+  // document.
+  const geminiOk = isGeminiAvailable();
+  if (!geminiOk) {
+    log.warn(
+      "present-document",
+      "GEMINI_API_KEY not set — image placeholders will render as text markers",
+      { placeholderCount: matches.length },
+    );
+  }
 
   const results = await Promise.all(
     matches.map(async (m) => ({
       full: m[0],
       prompt: m[1],
-      url: await generateImageFile(m[1]),
+      url: geminiOk ? await generateImageFile(m[1]) : null,
     })),
   );
 
+  // Surface a single tally line so the operator can see the
+  // success rate even when most calls go through. The per-call
+  // error already lands at warn from generateImageFile's catch.
+  if (geminiOk) {
+    const failed = results.filter((r) => !r.url).length;
+    if (failed > 0) {
+      log.warn("present-document", "image generation had failures", {
+        failed,
+        total: results.length,
+      });
+    }
+  }
+
   let filled = markdown;
   for (const { full, prompt, url } of results) {
-    if (url) filled = filled.replace(full, `![${prompt}](../${url})`);
+    // On success → real image. On failure / no key → italic text
+    // marker so the alt prompt still surfaces but no broken image
+    // 404s through the View. The user can re-render later once
+    // GEMINI_API_KEY is set.
+    filled = filled.replace(
+      full,
+      url ? `![${prompt}](../${url})` : `*🖼️ Image: ${prompt}*`,
+    );
   }
   return filled;
 }


### PR DESCRIPTION
## Summary

`presentDocument` で生成された markdown 内の画像 placeholder が、Gemini 不在 / 失敗時にそのまま残って `<img src=\"/api/files/raw?path=__too_be_replaced_image_path__\">` として render されていた。レポート: [chat URL](http://localhost:5173/chat/417dfc69-c875-4b07-8042-767323122fc7?role=sourceManager&view=stack&result=78ef54fa-fa92-42c4-ba62-59772a160e30) で broken image (alt text だけ表示)。

修正内容:
1. 生成不能時は placeholder を `*🖼️ Image: <prompt>*` (italic text) に置換 → broken `<img>` を出さず、何が来るはずだったかは伝わる
2. `GEMINI_API_KEY` 未設定 / Gemini 失敗を `log.warn(\"present-document\", ...)` で出力 → 「画像が出ない」報告時にサーバーログから原因が分かる

## Items to Confirm / Review

- **`*🖼️ Image: <prompt>*` のフォーマット** — 絵文字 + italic にしたが、もっと地味に `*[Image: <prompt>]*` とかでも可。好み次第
- **ログレベル warn の妥当性** — 「key が無い」は warn、「呼び出し失敗」も warn。誤って毎リクエスト鳴らないよう、placeholder ありの request だけで rate-limit 効果あり
- **scope** — `fillImagePlaceholders` だけ修正。今後 `presentMulmoScript` など別経路でも同じ placeholder を扱う可能性ある (今回の修正は presentDocument だけ)

## User Prompt

> presentDocumentで画像が出てない。http://localhost:5173/api/files/raw?path=__too_be_replaced_image_path__ となっている。
> プロンプトが表示されているな。テキストで。
> コンソールのログにもキーがないと出そうね

## Root cause

`server/routes/plugins.ts#fillImagePlaceholders` の 2 つの silent failure path:

1. `if (!isGeminiAvailable()) return markdown;` — early-return で placeholder 全件未処理のまま markdown 保存 → View で broken image
2. `try { ... } catch {}` — Gemini エラー (network / quota) を握り潰し、`url` が null → loop で `replace` skip → placeholder 残置

両方とも UI 上は broken image、サーバーログにも痕跡なし。

## Test plan

- [ ] `GEMINI_API_KEY` を一時的に外して `presentDocument` を呼ぶ → 画像が italic text に置換され、broken image が出ないこと
- [ ] サーバーログに `WARN [present-document] GEMINI_API_KEY not set ...` が 1 行出ること
- [ ] `GEMINI_API_KEY` 設定済みで、無効な prompt (生成失敗ケース) → text marker に fallback + per-call warn ログ
- [ ] 既存挙動 (key あり + 成功) は変化なし — `![${prompt}](../${url})` のまま

## CI 注意

`yarn typecheck:server` で `server/sources/fetchers/rssParser.ts(61,13): error TS7006` が出るが、これは main 上の既存エラーで本 PR とは無関係。stash して main で再確認済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image placeholders when Gemini image generation is unavailable—placeholders now display as visual markers showing the prompt instead of remaining as raw placeholders
  * Enhanced error logging for image generation failures to aid in troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->