### PR TITLE
fix(credentials): tighten PTY renewal success detection (CR follow-up #241)

### DIFF
--- a/server/credentials.ts
+++ b/server/credentials.ts
@@ -99,7 +99,10 @@ async function renewTokenViaPty(): Promise<boolean> {
     };
 
     const timeout = setTimeout(() => {
-      log.error("credentials", "Token renewal timed out after 30s");
+      log.error(
+        "credentials",
+        `Token renewal timed out after ${PTY_TIMEOUT_MS / 1000}s`,
+      );
       finish(false);
     }, PTY_TIMEOUT_MS);
 
@@ -108,17 +111,39 @@ async function renewTokenViaPty(): Promise<boolean> {
     // false-positive the echo detection.
     const ECHO_RE = /\bhi\b/;
 
+    // After the echo, only treat output as a successful renewal when
+    // it looks like a real Claude response — a conversational opener
+    // (Hello / Hi / I'm / …) AND a non-trivial amount of text. Error
+    // chunks ("Please log in", "Invalid credentials", network blips)
+    // don't match both conditions, so they fall through to the
+    // 30-second timeout and we treat the renewal as failed. A final
+    // safety net: `refreshCredentials()` re-reads the Keychain and
+    // calls `isTokenExpired()` before writing, so even a false
+    // positive here can't persist a stale token.
+    const RESPONSE_PATTERN_RE = /\b(Hello|Hi|I['’]m|I can|How can)\b/i;
+    const MIN_RESPONSE_CHARS = 20;
+    let echoEndIdx = -1;
+
     proc.onData((data: string) => {
       buffer += data;
 
-      if (!responded && ECHO_RE.test(buffer)) {
-        // Claude echoed our "hi" — now wait for the actual response
-        responded = true;
+      if (!responded) {
+        const m = ECHO_RE.exec(buffer);
+        if (m) {
+          // Claude echoed our "hi" — remember where the response
+          // window starts so the success check looks only at bytes
+          // that arrived AFTER the echo.
+          responded = true;
+          echoEndIdx = m.index + m[0].length;
+        }
         return;
       }
 
-      if (responded) {
-        // Got something after "hi" — credentials renewed
+      const response = buffer.slice(echoEndIdx);
+      if (
+        response.length >= MIN_RESPONSE_CHARS &&
+        RESPONSE_PATTERN_RE.test(response)
+      ) {
         finish(true);
       }
     });


### PR DESCRIPTION
## Summary

Address two sourcery-ai review comments from #241:

**1. Success detection too permissive** (`server/credentials.ts:117`)
- Before: any output chunk after the echoed \"hi\" triggered \`finish(true)\`. CLI error messages (\"Please log in\", auth failures, network blips) would also resolve success.
- After: the post-echo response must both (a) match a conversational-opener pattern (\`/\b(Hello|Hi|I['’]m|I can|How can)\b/i\`) AND (b) exceed a minimum length (20 chars). Error chunks don't hit both conditions, so they fall through to the 30-second timeout and the renewal is treated as failed.
- Tracks \`echoEndIdx\` so the pattern check slices only bytes that arrived AFTER the echo — prevents the pattern matching the echo itself.

**2. Hardcoded \"30s\" in log message** (`server/credentials.ts:102`)
- Derive seconds from \`PTY_TIMEOUT_MS\` so changing the timeout doesn't require touching the log string.

## Items to Confirm / Review

- **Pattern set**: `Hello|Hi|I'm|I can|How can` covers the typical Claude opener. If Claude's default greeting changes, pattern may need updating. Easy to extend.
- **Safety net**: `refreshCredentials()` still re-reads the Keychain and calls `isTokenExpired()` before writing, so even a false-positive here can't persist a stale token. This PR just tightens the first line of defence.
- **20-char minimum**: chosen to exceed the echo itself and short confirmations. If CLI is ever terse (e.g., returns just \"Hi.\"), this threshold should be re-evaluated.

## User Prompt

> 今日追加した部分のcode rabbitなどのbotのコメントの見直しと、refactoringして重複が減らせる部分がないか全部チェックして。

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build` — green
- [x] `yarn test` — no new regressions (7 pre-existing failures in sources/ are unrelated)
- [ ] Manual (macOS, expired token): run server, confirm Claude's response triggers finish(true) and fresh token is written
- [ ] Manual (simulated error): inject `proc.onData(\"\nPlease log in first.\n\")` and confirm renewal stays unresolved until timeout → returns `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)