### PR TITLE
refactor(prompt): normalize buildSystemPrompt orchestrator + extract headingSection

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -245,29 +245,40 @@ function buildInlinedHelpFiles(
     .filter((s): s is string => s !== null);
 }
 
+// Wrap a list of sub-entries under a single markdown heading, or
+// return null when the list is empty so the caller can skip the
+// whole section. Used for "## Reference Files" / "## Plugin
+// Instructions" style blocks. Exported so unit tests can exercise
+// the pure formatter without spinning up the whole prompt builder.
+export function headingSection(
+  heading: string,
+  items: string[],
+): string | null {
+  if (items.length === 0) return null;
+  return `## ${heading}\n\n${items.join("\n\n")}`;
+}
+
 export function buildSystemPrompt(params: SystemPromptParams): string {
   const { role, workspacePath, useDocker } = params;
 
-  const memoryContext = buildMemoryContext(workspacePath);
-  const wikiContext = buildWikiContext(workspacePath);
-  const sourcesContext = buildSourcesContext(workspacePath);
-  const pluginSections = buildPluginPromptSections(role);
-  const helpSections = buildInlinedHelpFiles(role.prompt, workspacePath);
-
-  return [
+  // Every section builder returns either its content or null. The
+  // orchestrator just filters out nulls and joins — no per-section
+  // `...(cond ? [x] : [])` ceremony at the bottom.
+  const sections: Array<string | null> = [
     SYSTEM_PROMPT,
     role.prompt,
     `Workspace directory: ${workspacePath}`,
     `Today's date: ${new Date().toISOString().split("T")[0]}`,
-    memoryContext,
-    ...(useDocker ? [SANDBOX_TOOLS_HINT] : []),
-    ...(wikiContext ? [wikiContext] : []),
-    ...(sourcesContext ? [sourcesContext] : []),
-    ...(helpSections.length
-      ? [`## Reference Files\n\n${helpSections.join("\n\n")}`]
-      : []),
-    ...(pluginSections.length
-      ? [`## Plugin Instructions\n\n${pluginSections.join("\n\n")}`]
-      : []),
-  ].join("\n\n");
+    buildMemoryContext(workspacePath),
+    useDocker ? SANDBOX_TOOLS_HINT : null,
+    buildWikiContext(workspacePath),
+    buildSourcesContext(workspacePath),
+    headingSection(
+      "Reference Files",
+      buildInlinedHelpFiles(role.prompt, workspacePath),
+    ),
+    headingSection("Plugin Instructions", buildPluginPromptSections(role)),
+  ];
+
+  return sections.filter((s): s is string => s !== null).join("\n\n");
 }

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -7,6 +7,7 @@ import {
   buildMemoryContext,
   buildWikiContext,
   buildSystemPrompt,
+  headingSection,
   prependJournalPointer,
 } from "../../server/agent/prompt.js";
 import type { Role } from "../../src/config/roles.js";
@@ -30,6 +31,37 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("headingSection", () => {
+  it("wraps items under a ## heading joined by blank lines", () => {
+    const out = headingSection("Plugin Instructions", [
+      "### a\n\nbody a",
+      "### b\n\nbody b",
+    ]);
+    assert.equal(
+      out,
+      "## Plugin Instructions\n\n### a\n\nbody a\n\n### b\n\nbody b",
+    );
+  });
+
+  it("returns null when the list is empty so callers can skip the section", () => {
+    assert.equal(headingSection("Whatever", []), null);
+  });
+
+  it("keeps a single item verbatim under the heading", () => {
+    const out = headingSection("Reference Files", [
+      "### helps/index.md\n\ncontent",
+    ]);
+    assert.equal(out, "## Reference Files\n\n### helps/index.md\n\ncontent");
+  });
+
+  it("preserves embedded blank lines inside items", () => {
+    // Items can contain their own paragraph breaks; join should use
+    // exactly \n\n between items and not touch the item text.
+    const out = headingSection("Section", ["line1\n\nline2", "line3"]);
+    assert.equal(out, "## Section\n\nline1\n\nline2\n\nline3");
+  });
 });
 
 describe("buildMemoryContext", () => {


### PR DESCRIPTION
## Summary

Small refactor to \`server/agent/prompt.ts\`:

1. Extract \`headingSection(heading, items)\` as a pure helper — the \"## heading + joined list, or skip if empty\" pattern was duplicated for the Reference Files and Plugin Instructions blocks.
2. Normalize \`buildSystemPrompt\`'s orchestrator to \`Array<string | null>\`. Every section builder returns either its content or \`null\`; the orchestrator just filters and joins. No more mix of \`...(cond ? [x] : [])\` shapes.
3. Add 4 unit tests for \`headingSection\`.

### Before
```ts
return [
  SYSTEM_PROMPT,
  role.prompt,
  ...,
  ...(useDocker ? [SANDBOX_TOOLS_HINT] : []),
  ...(wikiContext ? [wikiContext] : []),
  ...(helpSections.length
    ? [\`## Reference Files\\n\\n${helpSections.join(\"\\n\\n\")}\`]
    : []),
  ...(pluginSections.length
    ? [\`## Plugin Instructions\\n\\n${pluginSections.join(\"\\n\\n\")}\`]
    : []),
].join(\"\\n\\n\");
```

### After
```ts
const sections: Array<string | null> = [
  SYSTEM_PROMPT,
  role.prompt,
  ...,
  useDocker ? SANDBOX_TOOLS_HINT : null,
  buildWikiContext(workspacePath),
  headingSection(\"Reference Files\", buildInlinedHelpFiles(role.prompt, workspacePath)),
  headingSection(\"Plugin Instructions\", buildPluginPromptSections(role)),
];
return sections.filter((s): s is string => s !== null).join(\"\\n\\n\");
```

## Scope note

I considered splitting \`server/agent/prompt.ts\` (273 lines) into separate files per section builder, but decided against it:
- The file is coherent (one concern: the system prompt).
- Split across 5+ files would hurt locality — you'd have to open several files to see what goes into the prompt.
- CLAUDE.md's threshold is ~500 lines; we're well under.

The user confirmed \"if you split, add unit tests for pure functions\" — we didn't split, but the one pure function we extracted (\`headingSection\`) now has unit tests anyway.

## Items to Confirm / Review

- **\`Array<string | null>\`** approach is idiomatic enough; if you'd prefer an explicit \`sections.push()\` pattern, happy to switch.
- **\`headingSection\` naming**: could be \`sectionWithHeading\` / \`markdownSection\` / \`listUnderHeading\`. Current name is concise.

## User Prompt

> 今日追加した部分のcode rabbitなどのbotのコメントの見直しと、refactoringして重複が減らせる部分がないか全部チェックして。
> もし分割したら、pure関数はunitテストを追加してね

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` — green
- [x] \`yarn test\` — \`headingSection\` (+4 new tests) and \`buildSystemPrompt\` pass. Pre-existing 7 failures in \`test/sources/*\` unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)