### PR TITLE
persist unread state

### DIFF
--- a/plans/persist-has-unread.md
+++ b/plans/persist-has-unread.md
@@ -1,0 +1,37 @@
+# Persist `hasUnread` in session metadata
+
+## Context
+
+The `hasUnread` flag currently lives only in the in-memory `ServerSession` store (`server/session-store/index.ts`). When the server restarts, all unread state is lost. This change persists the flag in the per-session metadata file (`chat/{sessionId}.json`) so it survives restarts.
+
+## Approach
+
+Reuse the existing per-session metadata file (`~/mulmoclaude/chat/{sessionId}.json`), which already holds `roleId`, `startedAt`, `firstUserMessage`, and `claudeSessionId`. The read-merge-write pattern is already established (see `updateClaudeSessionId` and `backfillFirstUserMessage` in `server/routes/agent.ts`).
+
+## Files to modify
+
+### 1. `server/routes/sessions.ts`
+
+- Add `hasUnread?: boolean` to the `SessionMeta` interface (line 11).
+- In `GET /api/sessions` (line 73): when no live session exists in the in-memory store, fall back to `meta.hasUnread ?? false` instead of omitting the field.
+
+### 2. `server/session-store/index.ts`
+
+- Add a helper `persistHasUnread(chatSessionId, hasUnread)` that reads the `{chatSessionId}.json` metadata file, merges `{ hasUnread }`, and writes it back. Needs `workspacePath` to build the path.
+- **`endRun()`** (line 112): after setting `session.hasUnread = true`, call `persistHasUnread(chatSessionId, true)`.
+- **`markRead()`** (line 133): after setting `session.hasUnread = false`, call `persistHasUnread(chatSessionId, false)`.
+- **`getOrCreateSession()`** (line 58): accept an optional `hasUnread` param so the caller can seed the in-memory store from the persisted value.
+
+### 3. `server/routes/agent.ts`
+
+- In `startChat()`, after reading/writing the metadata file, pass `meta.hasUnread` into `getOrCreateSession()` so the in-memory store starts with the persisted value.
+
+## Verification
+
+1. `yarn format && yarn lint && yarn typecheck && yarn build`
+2. `yarn test` — existing unit tests pass
+3. Manual test:
+   - Start the dev server, send a message in session A, switch to session B
+   - Wait for session A to finish — verify unread badge appears
+   - Restart the server — verify the unread badge still shows for session A
+   - Click session A — verify the badge clears and stays cleared after another restart

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -154,6 +154,18 @@ export async function startChat(
     await backfillFirstUserMessage(metaFilePath, message);
   }
 
+  // Read persisted hasUnread so the in-memory store starts with the
+  // correct value (survives server restarts).
+  let persistedHasUnread: boolean | undefined;
+  if (!isFirstTurn) {
+    try {
+      const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
+      persistedHasUnread = meta.hasUnread === true;
+    } catch {
+      // ignore — meta file may be missing or malformed
+    }
+  }
+
   // Append user message for this turn
   await appendFile(
     resultsFilePath,
@@ -167,6 +179,7 @@ export async function startChat(
     selectedImageData,
     startedAt: now,
     updatedAt: now,
+    hasUnread: persistedHasUnread,
   });
 
   // Register abort callback and mark running. If the session is

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -12,6 +12,7 @@ interface SessionMeta {
   roleId: string;
   startedAt: string;
   firstUserMessage?: string;
+  hasUnread?: boolean;
 }
 
 async function readSessionMeta(
@@ -103,24 +104,23 @@ router.get(
               const preview = indexEntry?.title ?? meta.firstUserMessage ?? "";
 
               const live = getSession(id);
-              return {
+              const summary: SessionSummary = {
                 id,
                 roleId: meta.roleId,
                 startedAt: meta.startedAt,
                 updatedAt: new Date(fileStat.mtimeMs).toISOString(),
                 preview,
-                ...(indexEntry?.summary !== undefined && {
-                  summary: indexEntry.summary,
-                }),
-                ...(indexEntry?.keywords !== undefined && {
-                  keywords: indexEntry.keywords,
-                }),
-                ...(live && {
-                  isRunning: live.isRunning,
-                  hasUnread: live.hasUnread,
-                  statusMessage: live.statusMessage,
-                }),
+                hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
               };
+              if (indexEntry?.summary !== undefined)
+                summary.summary = indexEntry.summary;
+              if (indexEntry?.keywords !== undefined)
+                summary.keywords = indexEntry.keywords;
+              if (live) {
+                summary.isRunning = live.isRunning;
+                summary.statusMessage = live.statusMessage;
+              }
+              return summary;
             } catch {
               return null;
             }

--- a/server/session-store/index.ts
+++ b/server/session-store/index.ts
@@ -4,9 +4,11 @@
 // clients can subscribe to the same session channel and receive
 // identical events.
 
-import { appendFile } from "fs/promises";
+import { appendFile, readFile, writeFile } from "fs/promises";
+import path from "path";
 import type { IPubSub } from "../pub-sub/index.js";
 import { log } from "../logger/index.js";
+import { workspacePath } from "../workspace.js";
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -63,6 +65,7 @@ export function getOrCreateSession(
     selectedImageData?: string;
     startedAt: string;
     updatedAt: string;
+    hasUnread?: boolean;
   },
 ): ServerSession {
   const existing = store.get(chatSessionId);
@@ -75,7 +78,7 @@ export function getOrCreateSession(
     chatSessionId,
     roleId: opts.roleId,
     isRunning: false,
-    hasUnread: false,
+    hasUnread: opts.hasUnread ?? false,
     statusMessage: "",
     toolCallHistory: [],
     resultsFilePath: opts.resultsFilePath,
@@ -117,6 +120,7 @@ export function endRun(chatSessionId: string): void {
   session.statusMessage = "";
   session.abortRun = undefined;
   session.updatedAt = new Date().toISOString();
+  persistHasUnread(chatSessionId, true);
   publishToSessionChannel(chatSessionId, { type: "session_finished" });
   notifySessionsChanged();
 }
@@ -132,9 +136,15 @@ export function cancelRun(chatSessionId: string): boolean {
 /** Clear the unread flag (called when a client views the session). */
 export function markRead(chatSessionId: string): boolean {
   const session = store.get(chatSessionId);
-  if (!session) return false;
+  if (!session) {
+    // No in-memory session — still persist to disk so the flag is
+    // cleared for the next server restart / session listing.
+    persistHasUnread(chatSessionId, false);
+    return false;
+  }
   if (!session.hasUnread) return true;
   session.hasUnread = false;
+  persistHasUnread(chatSessionId, false);
   notifySessionsChanged();
   return true;
 }
@@ -232,6 +242,22 @@ export function onSessionEvent(
 }
 
 // ── Internal helpers ───────────────────────────────────────────
+
+function persistHasUnread(chatSessionId: string, hasUnread: boolean): void {
+  const metaFilePath = path.join(
+    workspacePath,
+    "chat",
+    `${chatSessionId}.json`,
+  );
+  readFile(metaFilePath, "utf-8")
+    .then((raw) => {
+      const meta = JSON.parse(raw);
+      return writeFile(metaFilePath, JSON.stringify({ ...meta, hasUnread }));
+    })
+    .catch(() => {
+      // Meta file missing or malformed — nothing to persist into.
+    });
+}
 
 function publishToSessionChannel(chatSessionId: string, data: unknown): void {
   pubsub?.publish(`session.${chatSessionId}`, data);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sessions now preserve their unread message status across server restarts. Users will no longer lose track of which conversations contain unread messages. Session metadata is automatically synchronized to ensure message tracking remains accurate and continuous after any server restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->