### PR TITLE
fix(agent): don't persist user message when startChat rejects with 409 (closes #281)

### DIFF
--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -131,16 +131,56 @@ export async function startChat(
   const resultsFilePath = path.join(chatDir, `${chatSessionId}.jsonl`);
   const metaFilePath = path.join(chatDir, `${chatSessionId}.json`);
 
-  // Write or update metadata. On the first message we create the file
-  // with firstUserMessage so GET /api/sessions never needs to read the
-  // jsonl content. On subsequent turns we backfill firstUserMessage if
-  // missing (migrates pre-existing sessions).
+  // Check whether this is a brand-new session up front so we can both
+  // (a) decide whether to read persisted hasUnread (skipped for first
+  // turn — nothing on disk yet) and (b) pick meta-write vs backfill
+  // after beginRun succeeds.
   let isFirstTurn = false;
   try {
     await access(metaFilePath);
   } catch {
     isFirstTurn = true;
   }
+
+  // Read persisted hasUnread so the in-memory store starts with the
+  // correct value (survives server restarts). Must happen before
+  // getOrCreateSession; for the first turn the meta file doesn't
+  // exist yet so the value stays undefined.
+  let persistedHasUnread: boolean | undefined;
+  if (!isFirstTurn) {
+    try {
+      const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
+      persistedHasUnread = meta.hasUnread === true;
+    } catch {
+      // ignore — meta file may be missing or malformed
+    }
+  }
+
+  const now = new Date().toISOString();
+  getOrCreateSession(chatSessionId, {
+    roleId,
+    resultsFilePath,
+    selectedImageData,
+    startedAt: now,
+    updatedAt: now,
+    hasUnread: persistedHasUnread,
+  });
+
+  // Register abort callback and mark running FIRST. If the session
+  // is already running, reject with 409 before we persist anything.
+  // Writing the user message to jsonl or broadcasting it before this
+  // check leaves an orphan message on disk + in every viewing tab
+  // when the run is rejected — see #281.
+  const abortController = new AbortController();
+  const started = beginRun(chatSessionId, () => abortController.abort());
+  if (!started) {
+    return { kind: "error", error: "Session is already running", status: 409 };
+  }
+
+  // Run is committed. Now persist the user message so callers (and
+  // other tabs) see the turn. Metadata first — it powers the sidebar
+  // title cache; the append follows so the jsonl is always a
+  // superset of what metadata advertised.
   if (isFirstTurn) {
     await writeFile(
       metaFilePath,
@@ -154,50 +194,20 @@ export async function startChat(
     await backfillFirstUserMessage(metaFilePath, message);
   }
 
-  // Read persisted hasUnread so the in-memory store starts with the
-  // correct value (survives server restarts).
-  let persistedHasUnread: boolean | undefined;
-  if (!isFirstTurn) {
-    try {
-      const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-      persistedHasUnread = meta.hasUnread === true;
-    } catch {
-      // ignore — meta file may be missing or malformed
-    }
-  }
-
   // Append user message for this turn
   await appendFile(
     resultsFilePath,
     JSON.stringify({ source: "user", type: "text", message }) + "\n",
   );
 
-  const now = new Date().toISOString();
-  getOrCreateSession(chatSessionId, {
-    roleId,
-    resultsFilePath,
-    selectedImageData,
-    startedAt: now,
-    updatedAt: now,
-    hasUnread: persistedHasUnread,
-  });
-
   // Broadcast the user message so other tabs viewing this session
-  // see the input in real time. Must come after getOrCreateSession
-  // so the session exists in the store.
+  // see the input in real time. Runs AFTER beginRun so a 409 never
+  // produces a phantom user message in other clients.
   pushSessionEvent(chatSessionId, {
     type: "text",
     source: "user",
     message,
   });
-
-  // Register abort callback and mark running. If the session is
-  // already running, reject with 409 Conflict.
-  const abortController = new AbortController();
-  const started = beginRun(chatSessionId, () => abortController.abort());
-  if (!started) {
-    return { kind: "error", error: "Session is already running", status: 409 };
-  }
 
   const role = getRole(roleId);
   const claudeSessionId = await readClaudeSessionId(


### PR DESCRIPTION
## Summary

Closes #281.

\`startChat()\` was writing \`meta.json\` and appending the user message to the session jsonl **before** checking whether a run could start. When the session was already running and \`beginRun()\` rejected with 409, the user message still ended up on disk — and, after #278 merges, would get broadcast to every viewing tab. Every client would see a turn that never gets an assistant response.

## Fix

Reorder so the 409 check happens before anything is persisted:

\`\`\`
getOrCreateSession()        ← in-memory only, safe to call regardless
beginRun() → 409 if busy    ← reject here, no disk / broadcast damage
writeFile(meta)             ← only from here on
appendFile(jsonl)
\`\`\`

The jsonl becomes a strict subset of committed turns, and the broadcast (once #278 lands) only fires for accepted messages.

## Why \`getOrCreateSession\` stays before \`beginRun\`

\`beginRun\` needs the session to exist in the registry before it can register the abort callback against it. \`getOrCreateSession\` is pure in-memory state — it doesn't mutate disk and doesn't care whether a run is about to start. Leaving an empty session entry is harmless and matches what happens today for a freshly-navigated session that never sends a message.

## Relationship to PR #278

- #278 adds the real-time broadcast of the user message via \`pushSessionEvent\`.
- This PR reorders the block so that broadcast location (once #278 merges) lands after \`beginRun\` instead of before — the same block move that fixes the disk orphan.
- Merge order doesn't matter; whichever lands second will have a trivial rebase (one block moves together).

## Items to Confirm / Review

- Check that moving \`getOrCreateSession\` before \`beginRun\` doesn't create a race with another in-flight run that also calls \`getOrCreateSession\` concurrently. The session store uses a plain Map and \`getOrCreateSession\` is idempotent, so two concurrent calls land at the same entry — fine.
- Metadata / jsonl ordering kept intact: meta.json first (powers sidebar title cache), then jsonl append (so jsonl is always a superset of what metadata references).

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/278 これ問題ない？複数のできちんと動く？
> そのうえで対応をつくろう

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — green (1730 pass, 7 pre-existing failures in \`test/sources/*\` unrelated)
- [ ] Manual: start a long-running message in Tab A, send a second message from Tab B while A is running → Tab B gets 409, and neither A nor B sees Tab B's message on disk or in the UI
- [ ] Manual (post-merge of #278): same scenario — Tab B's message is neither broadcast nor persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced session state tracking to prevent message loss
  * Improved handling of concurrent message attempts with clearer error responses
  * Better reliability in chat session initialization and message persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->