### PR TITLE
refactor: extract useClipboardCopy composable (DRY clipboard pattern)

### DIFF
--- a/src/composables/useClipboardCopy.ts
+++ b/src/composables/useClipboardCopy.ts
@@ -1,0 +1,44 @@
+// "Copy to clipboard with a transient confirmation flag" — the
+// same 9-line pattern was copied into 3 plugin views
+// (markdown / presentMulmoScript / textResponse) before this
+// composable existed.
+//
+// Usage:
+//
+//   const { copied, copy } = useClipboardCopy();
+//
+//   async function copyText() {
+//     await copy(textToCopy.value);
+//   }
+//
+// `copied` flips to true on success and back to false after
+// `resetMs` (default 2000ms) so the UI can show a ✓ / "Copied!"
+// hint. Clipboard failures (permissions, insecure context) are
+// swallowed on purpose — there's no useful UI action beyond letting
+// the hint stay off, which is exactly what the ref signals.
+
+import { ref, type Ref } from "vue";
+
+export interface UseClipboardCopyHandle {
+  copied: Ref<boolean>;
+  copy: (text: string) => Promise<void>;
+}
+
+export function useClipboardCopy(resetMs = 2000): UseClipboardCopyHandle {
+  const copied = ref(false);
+
+  async function copy(text: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(text);
+      copied.value = true;
+      setTimeout(() => {
+        copied.value = false;
+      }, resetMs);
+    } catch {
+      // Clipboard API may be blocked in some contexts (e.g. iframe
+      // without permissions, non-HTTPS origin). Leave `copied` false.
+    }
+  }
+
+  return { copied, copy };
+}

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -90,6 +90,7 @@ import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { resolveImageSrc } from "../../utils/image/resolve";
 import { usePdfDownload } from "../../composables/usePdfDownload";
+import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
 const props = defineProps<{
   selectedResult: ToolResult<MarkdownToolData>;
@@ -187,7 +188,7 @@ watch(
 
 const sourceDetails = ref<HTMLDetailsElement>();
 const editing = ref(false);
-const copied = ref(false);
+const { copied, copy } = useClipboardCopy();
 
 function onDetailsToggle(e: Event) {
   const open = (e.target as HTMLDetailsElement).open;
@@ -203,15 +204,7 @@ function cancelEdit() {
 }
 
 async function copyText() {
-  try {
-    await navigator.clipboard.writeText(markdownContent.value);
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 2000);
-  } catch {
-    // clipboard API may be blocked in some contexts
-  }
+  await copy(markdownContent.value);
 }
 
 const {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -574,6 +574,7 @@ import {
   streamMovieEvents,
   validateBeatJSON,
 } from "./helpers";
+import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
 interface Beat {
   speaker?: string;
@@ -704,7 +705,7 @@ function lightboxMove(delta: number) {
 const sourceDetails = ref<HTMLDetailsElement>();
 const editing = ref(false);
 const editableSource = ref("");
-const copied = ref(false);
+const { copied, copy } = useClipboardCopy();
 
 // Beats may be edited in-place via `updateBeat()` and rendered through
 // `effectiveBeat()`, so the Copy / source-view text must read the merged
@@ -790,15 +791,7 @@ async function applySource() {
 }
 
 async function copyText() {
-  try {
-    await navigator.clipboard.writeText(scriptSourceText.value);
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 2000);
-  } catch {
-    // clipboard API may be blocked in some contexts
-  }
+  await copy(scriptSourceText.value);
 }
 
 function effectiveBeat(index: number): Beat {

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -57,6 +57,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "@gui-chat-plugin/text-response";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { usePdfDownload } from "../../composables/usePdfDownload";
+import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<TextResponseData>;
@@ -119,19 +120,10 @@ function onApply(r: unknown) {
   if (details) details.open = false;
 }
 
-const copied = ref(false);
+const { copied, copy } = useClipboardCopy();
 
 async function copyText() {
-  const text = props.selectedResult.data?.text ?? "";
-  try {
-    await navigator.clipboard.writeText(text);
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 2000);
-  } catch {
-    // Fallback: clipboard API may be blocked in some contexts
-  }
+  await copy(props.selectedResult.data?.text ?? "");
 }
 
 async function downloadPdf() {

--- a/test/composables/test_useClipboardCopy.ts
+++ b/test/composables/test_useClipboardCopy.ts
@@ -1,0 +1,112 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { useClipboardCopy } from "../../src/composables/useClipboardCopy.ts";
+
+// Stub `navigator.clipboard` so the composable can be exercised
+// without jsdom. Tests restore the pre-existing `navigator` in
+// afterEach.
+
+interface ClipboardStub {
+  writeText: (text: string) => Promise<void>;
+}
+interface NavigatorStub {
+  clipboard: ClipboardStub;
+}
+
+// Node exposes `navigator` as a getter-only property from v24+, so
+// a plain assignment throws. `Object.defineProperty` overrides that.
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+
+let clipboardWrites: string[] = [];
+let clipboardShouldFail = false;
+
+function installStubNavigator(): void {
+  clipboardWrites = [];
+  clipboardShouldFail = false;
+  const stub: NavigatorStub = {
+    clipboard: {
+      writeText(text) {
+        if (clipboardShouldFail) {
+          return Promise.reject(new Error("clipboard blocked"));
+        }
+        clipboardWrites.push(text);
+        return Promise.resolve();
+      },
+    },
+  };
+  Object.defineProperty(globalThis, "navigator", {
+    value: stub,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreNavigator(): void {
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(globalThis, "navigator", originalNavigatorDescriptor);
+  } else {
+    delete (globalThis as { navigator?: unknown }).navigator;
+  }
+}
+
+describe("useClipboardCopy", () => {
+  beforeEach(() => {
+    installStubNavigator();
+    mock.timers.enable({ apis: ["setTimeout"] });
+  });
+  afterEach(() => {
+    mock.timers.reset();
+    restoreNavigator();
+  });
+
+  it("writes the text to the clipboard and flips `copied` to true", async () => {
+    const { copied, copy } = useClipboardCopy();
+    assert.equal(copied.value, false);
+    await copy("hello world");
+    assert.deepEqual(clipboardWrites, ["hello world"]);
+    assert.equal(copied.value, true);
+  });
+
+  it("resets `copied` back to false after the default 2s window", async () => {
+    const { copied, copy } = useClipboardCopy();
+    await copy("x");
+    assert.equal(copied.value, true);
+    mock.timers.tick(1999);
+    assert.equal(copied.value, true);
+    mock.timers.tick(1);
+    assert.equal(copied.value, false);
+  });
+
+  it("honours a custom resetMs argument", async () => {
+    const { copied, copy } = useClipboardCopy(500);
+    await copy("x");
+    mock.timers.tick(499);
+    assert.equal(copied.value, true);
+    mock.timers.tick(1);
+    assert.equal(copied.value, false);
+  });
+
+  it("swallows clipboard failures and leaves `copied` false", async () => {
+    clipboardShouldFail = true;
+    const { copied, copy } = useClipboardCopy();
+    await copy("x");
+    assert.deepEqual(clipboardWrites, []);
+    assert.equal(copied.value, false);
+  });
+
+  it("multiple copies extend the visible-true window to the latest call", async () => {
+    const { copied, copy } = useClipboardCopy(1000);
+    await copy("first");
+    mock.timers.tick(500);
+    await copy("second");
+    // The second copy scheduled a new 1000ms timer. The first timer
+    // still fires at t=1000 (500ms from now) and sets copied=false.
+    // This is the documented behaviour — callers that need strict
+    // reset-on-repeat semantics would need a different design.
+    mock.timers.tick(500);
+    assert.equal(copied.value, false);
+  });
+});


### PR DESCRIPTION
## Summary

3 plugin view に散らばっていた「clipboard copy + copied flag + 2s reset」の完全重複コード（9行×3箇所）を \`src/composables/useClipboardCopy.ts\` 1 箇所に集約。

## Before / After

\`\`\`ts
// Before (3 箇所で同じコード):
const copied = ref(false);
async function copyText() {
  try {
    await navigator.clipboard.writeText(text);
    copied.value = true;
    setTimeout(() => { copied.value = false; }, 2000);
  } catch { /* ... */ }
}

// After:
const { copied, copy } = useClipboardCopy();
async function copyText() { await copy(text); }
\`\`\`

## Files

- **新規**: \`src/composables/useClipboardCopy.ts\` (~40行)
- **新規**: \`test/composables/test_useClipboardCopy.ts\` (5 tests)
- **移行**: \`src/plugins/markdown/View.vue\`
- **移行**: \`src/plugins/presentMulmoScript/View.vue\`
- **移行**: \`src/plugins/textResponse/View.vue\`

## Items to Confirm / Review

- **\`resetMs\` パラメータ** — デフォルト 2000ms。既存 3 箇所は全部 2000ms だったので互換。
- **エラー時の挙動** — \`navigator.clipboard.writeText\` が失敗したら silent に \`copied=false\` のまま。元の挙動と一致（iframe / 非 HTTPS での clipboard block を想定、UI 的には "hint が出ない" で意図通り）。
- **同時複数 copy の window** — 後続 copy の timer は前のものを上書きしない。strict な reset-on-repeat が必要なら別設計が必要だが、現実的に問題ないはず（test で挙動を明文化）。

## Test plan

- [x] \`yarn format\` / \`yarn typecheck\` / \`yarn lint\` — clean
- [x] \`node --test test/composables/test_useClipboardCopy.ts\` — 5/5 passed
- [x] \`yarn test:e2e -- tests/present-mulmo-script.spec.ts\` — 5 passed（テキスト読み込み / 表示系、copy 系の回帰なし）