### PR TITLE
refactor(markdown): use shared rewriteMarkdownImageRefs helper

### DIFF
--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -88,7 +88,7 @@ import { computed, ref, watch, nextTick } from "vue";
 import { marked } from "marked";
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
-import { resolveImageSrc } from "../../utils/image/resolve";
+import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 
 const props = defineProps<{
@@ -149,24 +149,21 @@ const hasChanges = computed(() => {
   return editableMarkdown.value !== markdownContent.value;
 });
 
-// Resolve image paths in rendered HTML so workspace-relative paths become URLs.
-// Markdown files use "../images/xyz.png" (relative from markdowns/ dir);
-// strip the "../" prefix to get the workspace-relative path for resolveImageSrc.
-function resolveImagesInHtml(html: string): string {
-  return html.replace(
-    /(<img\s[^>]*src=")([^"]+)(")/g,
-    (_match, before: string, src: string, after: string) => {
-      if (src.startsWith("data:") || src.startsWith("http")) return _match;
-      const normalized = src.replace(/^\.\.\//, "");
-      return `${before}${resolveImageSrc(normalized)}${after}`;
-    },
-  );
-}
-
 const renderedHtml = computed(() => {
   if (!markdownContent.value) return "";
-  const html = marked(markdownContent.value) as string;
-  return resolveImagesInHtml(html);
+  // Rewrite workspace-relative image refs BEFORE marked parses them —
+  // same approach as wiki/View.vue and FilesView.vue. Markdown files
+  // under `markdowns/<year>/foo.md` typically use `../images/x.png`,
+  // so the basePath is the directory of the file; for inline legacy
+  // content we have no path, so basePath is empty and only rooted
+  // references get rewritten.
+  const raw = props.selectedResult.data?.markdown;
+  const basePath =
+    typeof raw === "string" && isFilePath(raw)
+      ? raw.slice(0, raw.lastIndexOf("/"))
+      : "";
+  const withImages = rewriteMarkdownImageRefs(markdownContent.value, basePath);
+  return marked(withImages) as string;
 });
 
 // Watch for scroll requests from viewState


### PR DESCRIPTION
## Summary

\`markdown/View.vue\` の独自 \`resolveImagesInHtml(html)\` (marked 後の regex) を削除し、他の surface (wiki/View.vue, FilesView.vue) と同じ \`rewriteMarkdownImageRefs(markdown, basePath)\` (marked 前の rewriter) に統一。

## Why

- \`rewriteMarkdownImageRefs\` (canonical helper, PR #228 で整備) は code block / 相対パス (\`./\`, \`../\`) / workspace-rooted (\`/\`) を正しく扱う
- 旧 inline regex は \`../\` を単純に strip するだけで、edge case で誤動作していた

## basePath 導出

\`data.markdown\` の file path から basePath を計算:
- \`markdowns/2026/report.md\` → basePath = \`markdowns/2026\` → \`../images/x.png\` は \`markdowns/images/x.png\` に解決
- inline legacy content (non-file) → basePath = 空文字、rooted ref のみ rewrite、\`../\` 系は 404 可視化 (silent wrong より良い)

## Test plan

- [x] \`yarn format\` / \`yarn typecheck\` / \`yarn lint\` — clean
- [x] \`yarn test:e2e -- tests/files-html-preview.spec.ts\` — 5 passed（image path rewrite の回帰確認）

## Related

- PR #228 で \`rewriteMarkdownImageRefs\` を marked lexer 化 + code block スキップ対応