### PR TITLE
refactor(workspace): centralize top-level dir names into workspace-paths.ts

### DIFF
--- a/server/chat-service/chat-state.ts
+++ b/server/chat-service/chat-state.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { log } from "../logger/index.js";
 
 // ── Types ────────────────────────────────────────────────────
@@ -25,7 +25,7 @@ function isSafeId(id: string): boolean {
 }
 
 function getTransportDir(transportId: string): string {
-  return path.join(workspacePath, "transports", transportId, "chats");
+  return path.join(WORKSPACE_PATHS.transports, transportId, "chats");
 }
 
 function getStatePath(transportId: string, externalChatId: string): string {

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -14,6 +14,7 @@ import {
   getActiveSessionIds,
 } from "../session-store/index.js";
 import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { maybeRunJournal } from "../journal/index.js";
 import { maybeIndexSession } from "../chat-index/index.js";
 import { maybeAppendWikiBacklinks } from "../wiki-backlinks/index.js";
@@ -126,7 +127,7 @@ export async function startChat(
     };
   }
 
-  const chatDir = path.join(workspacePath, "chat");
+  const chatDir = WORKSPACE_PATHS.chat;
   await mkdir(chatDir, { recursive: true });
   const resultsFilePath = path.join(chatDir, `${chatSessionId}.jsonl`);
   const metaFilePath = path.join(chatDir, `${chatSessionId}.json`);

--- a/server/routes/chart.ts
+++ b/server/routes/chart.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../workspace-paths.js";
 import { slugify } from "../utils/slug.js";
 import { errorMessage } from "../utils/errors.js";
 
@@ -95,7 +95,7 @@ router.post(
       const baseLabel = title ?? document.title ?? "chart";
       const slug = slugify(baseLabel) || "chart";
       const fname = `${slug}-${Date.now()}.chart.json`;
-      const chartsDir = path.join(workspacePath, "charts");
+      const chartsDir = WORKSPACE_PATHS.charts;
       await mkdir(chartsDir, { recursive: true });
       await writeFile(
         path.join(chartsDir, fname),
@@ -103,7 +103,7 @@ router.post(
         "utf-8",
       );
 
-      const filePath = `charts/${fname}`;
+      const filePath = `${WORKSPACE_DIRS.charts}/${fname}`;
       res.json({
         message: `Saved chart document to ${filePath}`,
         instructions:

--- a/server/routes/html.ts
+++ b/server/routes/html.ts
@@ -1,12 +1,12 @@
 import { Router, Request, Response } from "express";
 import { readFile, writeFile, mkdir } from "fs/promises";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { getGeminiClient, isGeminiAvailable } from "../utils/gemini.js";
 import { errorMessage } from "../utils/errors.js";
 
 const router = Router();
-const HTML_FILE = () => path.join(workspacePath, "html", "current.html");
+const HTML_FILE = () => path.join(WORKSPACE_PATHS.html, "current.html");
 
 async function callGemini(prompt: string): Promise<string> {
   const ai = getGeminiClient();
@@ -59,7 +59,7 @@ router.post(
     try {
       const fullPrompt = `Generate a complete, standalone HTML page based on this description: ${prompt}\n\nRequirements:\n- Self-contained with all CSS and JS inline\n- Use Tailwind CSS via CDN if needed\n- Return only the HTML code, no explanation`;
       const html = await callGemini(fullPrompt);
-      const htmlDir = path.join(workspacePath, "html");
+      const htmlDir = WORKSPACE_PATHS.html;
       await mkdir(htmlDir, { recursive: true });
       await writeFile(HTML_FILE(), html, "utf-8");
       res.json({

--- a/server/routes/presentHtml.ts
+++ b/server/routes/presentHtml.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../workspace-paths.js";
 import { slugify } from "../utils/slug.js";
 import { errorMessage } from "../utils/errors.js";
 
@@ -41,11 +41,11 @@ router.post(
     try {
       const slug = title ? slugify(title) : "page";
       const fname = `${slug}-${Date.now()}.html`;
-      const htmlDir = path.join(workspacePath, "HTMLs");
+      const htmlDir = WORKSPACE_PATHS.htmls;
       await mkdir(htmlDir, { recursive: true });
       await writeFile(path.join(htmlDir, fname), html, "utf-8");
 
-      const filePath = `HTMLs/${fname}`;
+      const filePath = `${WORKSPACE_DIRS.htmls}/${fname}`;
       res.json({
         message: `Saved HTML to ${filePath}`,
         instructions:

--- a/server/routes/scheduler.ts
+++ b/server/routes/scheduler.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { loadJsonFile, saveJsonFile } from "../utils/file.js";
 import {
   dispatchScheduler,
@@ -21,7 +21,7 @@ export interface ScheduledItem {
   props: Record<string, string | number | boolean | null>;
 }
 
-const schedulerFile = () => path.join(workspacePath, "scheduler", "items.json");
+const schedulerFile = () => path.join(WORKSPACE_PATHS.scheduler, "items.json");
 
 function loadItems(): ScheduledItem[] {
   return loadJsonFile<ScheduledItem[]>(schedulerFile(), []);

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { readManifest } from "../chat-index/indexer.js";
 import { resolveWithinRoot } from "../utils/fs.js";
 import type { ChatIndexEntry } from "../chat-index/types.js";
@@ -74,7 +75,7 @@ const WINDOW_MS =
 router.get(
   "/sessions",
   async (_req: Request, res: Response<SessionSummary[]>) => {
-    const chatDir = path.join(workspacePath, "chat");
+    const chatDir = WORKSPACE_PATHS.chat;
     const manifest = await readManifest(workspacePath);
     const indexById = new Map<string, ChatIndexEntry>(
       manifest.entries.map((e) => [e.id, e]),
@@ -158,7 +159,7 @@ router.get(
     res: Response<unknown[] | SessionErrorResponse>,
   ) => {
     const { id } = req.params;
-    const chatDir = path.join(workspacePath, "chat");
+    const chatDir = WORKSPACE_PATHS.chat;
     const filePath = path.join(chatDir, `${id}.jsonl`);
     try {
       const meta = await readSessionMeta(chatDir, id);
@@ -190,7 +191,7 @@ router.get(
                     // Resolve the stories dir's realpath so the
                     // boundary check works even when stories/ itself
                     // is a legitimate symlink to another disk.
-                    const storiesDir = path.resolve(workspacePath, "stories");
+                    const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
                     let storiesReal: string;
                     try {
                       storiesReal = fs.realpathSync(storiesDir);

--- a/server/routes/todos.ts
+++ b/server/routes/todos.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { loadJsonFile, saveJsonFile } from "../utils/file.js";
 import { dispatchTodos, type TodosActionInput } from "./todosHandlers.js";
 import {
@@ -48,9 +48,9 @@ export interface TodoItem {
   order?: number; // sort key within the same status column
 }
 
-const todosFile = (): string => path.join(workspacePath, "todos", "todos.json");
+const todosFile = (): string => path.join(WORKSPACE_PATHS.todos, "todos.json");
 const columnsFile = (): string =>
-  path.join(workspacePath, "todos", "columns.json");
+  path.join(WORKSPACE_PATHS.todos, "columns.json");
 
 function loadColumns(): StatusColumn[] {
   return normalizeColumns(

--- a/server/routes/wiki.ts
+++ b/server/routes/wiki.ts
@@ -2,12 +2,12 @@ import { Router, Request, Response } from "express";
 import fs from "fs";
 import fsp from "node:fs/promises";
 import path from "path";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_PATHS } from "../workspace-paths.js";
 import { getPageIndex } from "./wiki/pageIndex.js";
 
 const router = Router();
 
-const wikiDir = () => path.join(workspacePath, "wiki");
+const wikiDir = () => WORKSPACE_PATHS.wiki;
 const pagesDir = () => path.join(wikiDir(), "pages");
 const indexFile = () => path.join(wikiDir(), "index.md");
 const logFile = () => path.join(wikiDir(), "log.md");

--- a/server/utils/image-store.ts
+++ b/server/utils/image-store.ts
@@ -1,10 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../workspace-paths.js";
 import { resolveWithinRoot } from "./fs.js";
 
-const IMAGES_DIR = path.join(workspacePath, "images");
+const IMAGES_DIR = WORKSPACE_PATHS.images;
 
 // Cached realpath of the images directory. resolveWithinRoot requires
 // its root argument to be a realpath so symlinks are handled correctly.
@@ -24,7 +24,10 @@ async function safeResolve(relativePath: string): Promise<string> {
   const root = await ensureImagesDir();
   // Strip the leading "images/" prefix so the caller can pass either
   // "images/abc.png" (the stored form) or just "abc.png".
-  const name = relativePath.replace(/^images\//, "");
+  const name = relativePath.replace(
+    new RegExp(`^${WORKSPACE_DIRS.images}/`),
+    "",
+  );
   const result = resolveWithinRoot(root, name);
   if (!result) {
     throw new Error(`path traversal rejected: ${relativePath}`);
@@ -39,7 +42,7 @@ export async function saveImage(base64Data: string): Promise<string> {
   const filename = `${id}.png`;
   const absPath = path.join(IMAGES_DIR, filename);
   await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
-  return `images/${filename}`;
+  return `${WORKSPACE_DIRS.images}/${filename}`;
 }
 
 /** Overwrite an existing image file. The relativePath must start with "images/". */
@@ -65,5 +68,7 @@ export function stripDataUri(dataUri: string): string {
 
 /** Check if a string is a file reference (not a data URI). */
 export function isImagePath(value: string): boolean {
-  return value.startsWith("images/") && value.endsWith(".png");
+  return (
+    value.startsWith(`${WORKSPACE_DIRS.images}/`) && value.endsWith(".png")
+  );
 }

--- a/server/utils/markdown-store.ts
+++ b/server/utils/markdown-store.ts
@@ -2,15 +2,18 @@ import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { workspacePath } from "../workspace.js";
-
-const MARKDOWNS_DIR = path.join(workspacePath, "markdowns");
+import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../workspace-paths.js";
 
 /** Save markdown content as a file. Returns the workspace-relative path. */
 export async function saveMarkdown(content: string): Promise<string> {
   const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
   const filename = `${id}.md`;
-  await fs.writeFile(path.join(MARKDOWNS_DIR, filename), content, "utf-8");
-  return `markdowns/${filename}`;
+  await fs.writeFile(
+    path.join(WORKSPACE_PATHS.markdowns, filename),
+    content,
+    "utf-8",
+  );
+  return `${WORKSPACE_DIRS.markdowns}/${filename}`;
 }
 
 /** Read a markdown file and return its content. */
@@ -30,5 +33,7 @@ export async function overwriteMarkdown(
 
 /** Check if a string is a markdown file path (not inline content). */
 export function isMarkdownPath(value: string): boolean {
-  return value.startsWith("markdowns/") && value.endsWith(".md");
+  return (
+    value.startsWith(`${WORKSPACE_DIRS.markdowns}/`) && value.endsWith(".md")
+  );
 }

--- a/server/utils/spreadsheet-store.ts
+++ b/server/utils/spreadsheet-store.ts
@@ -1,10 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
-import { workspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../workspace-paths.js";
 import { resolveWithinRoot } from "./fs.js";
 
-const SPREADSHEETS_DIR = path.join(workspacePath, "spreadsheets");
+const SPREADSHEETS_DIR = WORKSPACE_PATHS.spreadsheets;
 
 // Cached realpath of the spreadsheets directory. resolveWithinRoot
 // requires its root argument to be a realpath so symlinks are handled
@@ -25,7 +25,10 @@ async function safeResolve(relativePath: string): Promise<string> {
   const root = await ensureSpreadsheetsDir();
   // Strip the leading "spreadsheets/" prefix so callers can pass either
   // the stored form or just the filename.
-  const name = relativePath.replace(/^spreadsheets\//, "");
+  const name = relativePath.replace(
+    new RegExp(`^${WORKSPACE_DIRS.spreadsheets}/`),
+    "",
+  );
   const result = resolveWithinRoot(root, name);
   if (!result) {
     throw new Error(`path traversal rejected: ${relativePath}`);
@@ -43,7 +46,7 @@ export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
     JSON.stringify(sheets),
     "utf-8",
   );
-  return `spreadsheets/${filename}`;
+  return `${WORKSPACE_DIRS.spreadsheets}/${filename}`;
 }
 
 /** Overwrite an existing spreadsheet file. */
@@ -59,7 +62,7 @@ export async function overwriteSpreadsheet(
  *  Rejects traversal attempts like "spreadsheets/../outside.json"
  *  so the caller can't rely on the prefix/suffix alone. */
 export function isSpreadsheetPath(value: string): boolean {
-  if (!value.startsWith("spreadsheets/")) return false;
+  if (!value.startsWith(`${WORKSPACE_DIRS.spreadsheets}/`)) return false;
   if (!value.endsWith(".json")) return false;
   // Forbid .. segments anywhere in the path — a realpath check still
   // happens server-side, but this catches obvious cases early.

--- a/server/wiki-backlinks/index.ts
+++ b/server/wiki-backlinks/index.ts
@@ -18,6 +18,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS } from "../workspace-paths.js";
 import { log } from "../logger/index.js";
 import { updateSessionBacklinks } from "./sessionBacklinks.js";
 
@@ -53,7 +54,7 @@ export async function maybeAppendWikiBacklinks(
   if (!opts.chatSessionId) return;
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
   const deps: WikiBacklinksDeps = { ...defaultDeps, ...(opts.deps ?? {}) };
-  const pagesDir = path.join(workspaceRoot, "wiki", "pages");
+  const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wiki, "pages");
 
   const files = await listPageFiles(pagesDir, deps);
   if (files.length === 0) return;

--- a/server/workspace-paths.ts
+++ b/server/workspace-paths.ts
@@ -1,0 +1,111 @@
+// Single source of truth for workspace directory / file names and
+// their absolute paths. Before this module, ~15 call sites each
+// wrote `path.join(workspacePath, "wiki")` / "markdowns" / etc. by
+// hand — renaming a directory meant grep-and-edit across the
+// server, with no typecheck help against typos.
+//
+// **This module does not change any paths.** Every name here is
+// the string that was previously baked into its call site, so
+// centralizing is a pure source-level refactor — no files move.
+// The layout rethink + migration that issue #284 proposes will
+// happen on top of this, by re-mapping the values below.
+//
+// When adding a new top-level directory: add the name to the
+// `WORKSPACE_DIRS` record below. The absolute path is derived
+// automatically via `WORKSPACE_PATHS`.
+
+import os from "os";
+import path from "path";
+
+// Workspace root. Hard-coded to `~/mulmoclaude` — there is no
+// WORKSPACE_PATH env override today; changing the location
+// requires a code edit or a symlink. Re-exported by
+// `server/workspace.ts` for backwards compatibility of existing
+// callers that `import { workspacePath } from "./workspace.js"`.
+export const workspacePath = path.join(os.homedir(), "mulmoclaude");
+
+// Top-level directory *names*. Use these when you need the bare
+// name (e.g. a relative path in a response envelope): most code
+// should reach for `WORKSPACE_PATHS` instead.
+export const WORKSPACE_DIRS = {
+  chat: "chat",
+  todos: "todos",
+  calendar: "calendar",
+  contacts: "contacts",
+  scheduler: "scheduler",
+  roles: "roles",
+  stories: "stories",
+  images: "images",
+  markdowns: "markdowns",
+  spreadsheets: "spreadsheets",
+  charts: "charts",
+  configs: "configs",
+  helps: "helps",
+  wiki: "wiki",
+  news: "news",
+  sources: "sources",
+  summaries: "summaries",
+  // presentHtml plugin writes here. Note the legacy capitalization
+  // — issue #284 will consider normalizing to lower-case `html/`.
+  htmls: "HTMLs",
+  // Distinct from `htmls` above: transient render output by the
+  // raw `html` route (server/routes/html.ts). Co-exists with
+  // `HTMLs/` on disk today.
+  html: "html",
+  transports: "transports",
+} as const;
+
+// File names at the workspace root (not under a subdirectory).
+export const WORKSPACE_FILES = {
+  memory: "memory.md",
+} as const;
+
+// Absolute paths, built once at module load from `workspacePath`.
+// The `workspacePath` const is itself fixed (reads `os.homedir()`
+// at process start — no env override, see `server/workspace.ts`),
+// so freezing these paths is safe.
+export const WORKSPACE_PATHS = {
+  chat: path.join(workspacePath, WORKSPACE_DIRS.chat),
+  todos: path.join(workspacePath, WORKSPACE_DIRS.todos),
+  calendar: path.join(workspacePath, WORKSPACE_DIRS.calendar),
+  contacts: path.join(workspacePath, WORKSPACE_DIRS.contacts),
+  scheduler: path.join(workspacePath, WORKSPACE_DIRS.scheduler),
+  roles: path.join(workspacePath, WORKSPACE_DIRS.roles),
+  stories: path.join(workspacePath, WORKSPACE_DIRS.stories),
+  images: path.join(workspacePath, WORKSPACE_DIRS.images),
+  markdowns: path.join(workspacePath, WORKSPACE_DIRS.markdowns),
+  spreadsheets: path.join(workspacePath, WORKSPACE_DIRS.spreadsheets),
+  charts: path.join(workspacePath, WORKSPACE_DIRS.charts),
+  configs: path.join(workspacePath, WORKSPACE_DIRS.configs),
+  helps: path.join(workspacePath, WORKSPACE_DIRS.helps),
+  wiki: path.join(workspacePath, WORKSPACE_DIRS.wiki),
+  news: path.join(workspacePath, WORKSPACE_DIRS.news),
+  sources: path.join(workspacePath, WORKSPACE_DIRS.sources),
+  summaries: path.join(workspacePath, WORKSPACE_DIRS.summaries),
+  htmls: path.join(workspacePath, WORKSPACE_DIRS.htmls),
+  html: path.join(workspacePath, WORKSPACE_DIRS.html),
+  transports: path.join(workspacePath, WORKSPACE_DIRS.transports),
+  memory: path.join(workspacePath, WORKSPACE_FILES.memory),
+} as const;
+
+export type WorkspaceDirKey = keyof typeof WORKSPACE_DIRS;
+export type WorkspacePathKey = keyof typeof WORKSPACE_PATHS;
+
+// Directories `initWorkspace()` creates eagerly on server start.
+// Kept as a subset of `WORKSPACE_DIRS` so new entries are additive
+// without touching `server/workspace.ts`. Everything *not* on this
+// list is created lazily (first write) by its owning module.
+export const EAGER_WORKSPACE_DIRS: readonly WorkspaceDirKey[] = [
+  "chat",
+  "todos",
+  "calendar",
+  "contacts",
+  "scheduler",
+  "roles",
+  "stories",
+  "images",
+  "markdowns",
+  "spreadsheets",
+  "charts",
+  "configs",
+];

--- a/server/workspace.ts
+++ b/server/workspace.ts
@@ -1,60 +1,45 @@
 import { execSync } from "child_process";
 import fs from "fs";
-import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { log } from "./logger/index.js";
+import {
+  EAGER_WORKSPACE_DIRS,
+  WORKSPACE_PATHS,
+  workspacePath,
+} from "./workspace-paths.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, "helps");
 
-export const workspacePath = path.join(os.homedir(), "mulmoclaude");
+// Re-exported so existing callers (`import { workspacePath } from
+// "./workspace.js"`) keep working. See workspace-paths.ts for the
+// definitive source.
+export { workspacePath };
 
 // Must exist before downstream modules call realpathSync(workspacePath) at their own module-load time.
 fs.mkdirSync(workspacePath, { recursive: true });
 
-const SUBDIRS = [
-  "chat",
-  "todos",
-  "calendar",
-  "contacts",
-  "scheduler",
-  "roles",
-  "stories",
-  "images",
-  "markdowns",
-  "spreadsheets",
-  // Chart documents saved by the `presentChart` plugin. One file per
-  // invocation; each file can hold multiple charts.
-  "charts",
-  // Web-configurable settings (app-wide) and user-defined MCP servers
-  // live under this dir so future import/export can ship them as a
-  // unit. See plans/done/feat-web-settings-ui.md.
-  "configs",
-];
-
 export function initWorkspace(): string {
   // Create directory structure if needed
-  for (const dir of SUBDIRS) {
-    fs.mkdirSync(path.join(workspacePath, dir), { recursive: true });
+  for (const key of EAGER_WORKSPACE_DIRS) {
+    fs.mkdirSync(WORKSPACE_PATHS[key], { recursive: true });
   }
 
   // Create memory.md if it doesn't exist
-  const memoryFile = path.join(workspacePath, "memory.md");
-  if (!fs.existsSync(memoryFile)) {
+  if (!fs.existsSync(WORKSPACE_PATHS.memory)) {
     fs.writeFileSync(
-      memoryFile,
+      WORKSPACE_PATHS.memory,
       "# Memory\n\nDistilled facts about you and your work.\n",
     );
   }
 
   // Always sync all files from server/helps/ into workspace/helps/
-  const helpsDestDir = path.join(workspacePath, "helps");
-  fs.mkdirSync(helpsDestDir, { recursive: true });
+  fs.mkdirSync(WORKSPACE_PATHS.helps, { recursive: true });
   for (const file of fs.readdirSync(TEMPLATES_DIR)) {
     fs.copyFileSync(
       path.join(TEMPLATES_DIR, file),
-      path.join(helpsDestDir, file),
+      path.join(WORKSPACE_PATHS.helps, file),
     );
   }
 


### PR DESCRIPTION
## Summary

Every module that built workspace paths via `path.join(workspacePath, "x")` now reaches for `WORKSPACE_PATHS.x` / `WORKSPACE_DIRS.x`. Renaming a top-level dir was a grep-and-edit across ~15 files before — now it's a one-file change in `server/workspace-paths.ts`.

**Part 1 of #284**. PR #265-style "plans/done archive" of settled refactor: no files move, no runtime behaviour change. Every constant value equals the string it replaces.

## Items to Confirm / Review

- **循環 import の回避**: `workspacePath` を `server/workspace-paths.ts` に移動し、`server/workspace.ts` が re-export する形にして一方向依存に。`import { workspacePath } from "./workspace.js"` の既存 caller は無修正で動く
- **`workspace-paths.ts` のキー命名**: 既存の dir 名に合わせたので `htmls` (HTMLs) / `markdowns` など plural / singular ・大文字混在がそのまま残っている。#284 の A (階層化) で一緒に統一する想定
- **未統合の local dir 定数**: `server/sources/paths.ts` (SOURCES_DIR / NEWS_DIR)、`server/journal/paths.ts` (SUMMARIES_DIR)、`server/chat-index/paths.ts` (CHAT_DIR) は既に localized されているため今回触らず。別 follow-up で WORKSPACE_DIRS に寄せるか判断
- **相対 path 文字列も定数化**: `image-store.ts` の `` \`images/${filename}\` `` 返り値なども `` \`${WORKSPACE_DIRS.images}/${filename}\` `` に変更。dir 名改名時の取りこぼしを防ぐため

## User Prompt

> Aは既存のデータを移動させるマイグレーションスクリプトも必要だね。で、まずはBかな。Bで既存コードの動作をかえないようにすすめよう。

(#284 の B を Part 1 として実装、A はマイグレーション込みの別 PR)

## 変更内容

### 新規

**`server/workspace-paths.ts`**:
- `workspacePath` (ここに移動、workspace.ts から re-export)
- `WORKSPACE_DIRS` — bare directory name map (`{ chat: "chat", todos: "todos", ... }`)
- `WORKSPACE_PATHS` — 絶対パス map
- `WORKSPACE_FILES` — root 直下のファイル (`memory: "memory.md"`)
- `EAGER_WORKSPACE_DIRS` — `initWorkspace()` で起動時に eager 作成するキーの配列
- `WorkspaceDirKey` / `WorkspacePathKey` 型

### 修正 (~15 call sites)

| File | 対応 |
|---|---|
| `server/workspace.ts` | SUBDIRS ループ → `EAGER_WORKSPACE_DIRS`、memory/helps path → `WORKSPACE_PATHS` |
| `server/chat-service/chat-state.ts` | `transports` → `WORKSPACE_PATHS.transports` |
| `server/wiki-backlinks/index.ts` | `"wiki"` → `WORKSPACE_DIRS.wiki` (workspaceRoot 注入は保持) |
| `server/utils/image-store.ts` | 絶対 path + 返り値の `images/...` 両方 |
| `server/utils/markdown-store.ts` | 絶対 path + 返り値 + `isMarkdownPath` prefix check |
| `server/utils/spreadsheet-store.ts` | 同上 |
| `server/routes/agent.ts` | `chat` dir |
| `server/routes/chart.ts` | `charts` dir + 返り値 |
| `server/routes/html.ts` | `html` dir (HTML_FILE と htmlDir 両方) |
| `server/routes/presentHtml.ts` | `HTMLs` dir (`WORKSPACE_DIRS.htmls`) + 返り値 |
| `server/routes/scheduler.ts` | `scheduler/items.json` |
| `server/routes/sessions.ts` | 2 箇所の `chat` + `stories` |
| `server/routes/todos.ts` | `todos/todos.json` / `todos/columns.json` |
| `server/routes/wiki.ts` | `wiki` dir |

### 未変更 (意図的)

- `server/sources/paths.ts`, `server/journal/paths.ts`, `server/chat-index/paths.ts` — 既に local dir const (`SOURCES_DIR` / `SUMMARIES_DIR` / `CHAT_DIR`) を持っているので今回は触らず
- `server/config.ts` — 既に `CONFIGS_DIR_NAME` 定数を持っている
- `server/utils/markdown-store.ts#loadMarkdown` / `overwriteMarkdown` — `relativePath` 引数 (caller から) をそのまま join するだけなので dir 名解決が不要

## Test plan

- [ ] `yarn typecheck` / `yarn typecheck:server` clean
- [ ] `yarn lint` (0 errors, 既存の v-html warning 5 件のみ)
- [ ] `yarn test` 1838/1838 pass (自分で実行済)
- [ ] `yarn build` clean
- [ ] 実サーバー起動して 1 回 agent 実行 → `~/mulmoclaude/` 下のパスが従来と同じ (chat/, todos/, markdowns/ 等のファイルが同じ場所に書かれる)

## Next steps (out of scope)

- #284 A: 階層グルーピング (`config/` / `data/` / `artifacts/`) + 既存データ移行スクリプト
- `sources/paths.ts` 等の local const を `WORKSPACE_DIRS` に寄せる (重複を整理)
- 命名統一 (`HTMLs` → `html`、`markdowns` → `documents` 等) は A と一緒にやる

🤖 Generated with [Claude Code](https://claude.com/claude-code)