### PR TITLE
feat(ui): plugin launcher above canvas — invoke plugins locally (#253)

### DIFF
--- a/e2e/tests/plugin-launcher.spec.ts
+++ b/e2e/tests/plugin-launcher.spec.ts
@@ -1,0 +1,176 @@
+// Plugin launcher buttons that sit above the canvas, to the left of
+// the view-mode toggle. Each "invoke" button calls the matching
+// plugin's REST endpoint locally (no LLM round-trip), pushes the
+// resulting ToolResult into the current session, and switches the
+// canvas to single view so the plugin's native View component takes
+// the stage. The "files" button just switches to files view.
+//
+// First slice of issue #253.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+});
+
+test.describe("plugin launcher — invoke path", () => {
+  test("Todos button hits POST /api/todos + surfaces the todo View", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/todos",
+      (route) =>
+        route.fulfill({
+          json: {
+            data: {
+              items: [
+                {
+                  id: "t-1",
+                  text: "Ship the plugin launcher",
+                  completed: false,
+                  createdAt: Date.now(),
+                },
+              ],
+              columns: [],
+            },
+            title: "Todos",
+            message: "1 todo",
+          },
+        }),
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-todos").click();
+
+    await expect(
+      page.getByText("Ship the plugin launcher").first(),
+    ).toBeVisible();
+  });
+
+  test("Skills button hits GET /api/skills + surfaces the skills View", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/skills",
+      (route) =>
+        route.fulfill({
+          json: {
+            skills: [
+              {
+                name: "daily-plan",
+                description: "Generate a daily plan",
+                source: "user",
+              },
+            ],
+          },
+        }),
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-skills").click();
+
+    // The skills View renders each skill with its own testid.
+    await expect(page.getByTestId("skill-item-daily-plan")).toBeVisible();
+  });
+
+  test("Wiki button hits POST /api/wiki + surfaces page entries", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/wiki",
+      (route) =>
+        route.fulfill({
+          json: {
+            data: {
+              action: "index",
+              title: "Wiki",
+              content: "",
+              pageEntries: [
+                {
+                  slug: "home",
+                  title: "Welcome home page",
+                  description: "",
+                },
+              ],
+            },
+            title: "Wiki",
+            message: "1 page",
+          },
+        }),
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-wiki").click();
+
+    // The wiki View renders page entries as cards containing the title.
+    await expect(page.getByText("Welcome home page").first()).toBeVisible();
+  });
+
+  test("Scheduler button hits POST /api/scheduler", async ({ page }) => {
+    let schedCalled = false;
+    await page.route(
+      (url) => url.pathname === "/api/scheduler",
+      (route) => {
+        schedCalled = true;
+        return route.fulfill({
+          json: {
+            data: { items: [] },
+            title: "Schedule",
+            message: "no items",
+          },
+        });
+      },
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-scheduler").click();
+
+    // Give the fetch a moment to land.
+    await page.waitForTimeout(200);
+    expect(schedCalled).toBe(true);
+  });
+
+  test("endpoint error surfaces as a text-response in the stack", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/todos",
+      (route) =>
+        route.fulfill({
+          status: 500,
+          json: { error: "boom" },
+        }),
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-todos").click();
+
+    await expect(
+      page.getByText("manageTodoList failed: boom").first(),
+    ).toBeVisible();
+  });
+});
+
+test.describe("plugin launcher — files path", () => {
+  test("Files button switches canvas to files view", async ({ page }) => {
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+
+    await page.getByTestId("plugin-launcher-files").click();
+
+    await page.waitForURL(/view=files/);
+    expect(page.url()).toContain("view=files");
+    expect(page.url()).not.toContain("path=");
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -248,8 +248,9 @@
       class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden"
     >
       <div
-        class="flex items-center justify-end px-3 py-2 border-b border-gray-100 shrink-0"
+        class="flex items-center justify-between px-3 py-2 border-b border-gray-100 shrink-0 gap-2"
       >
+        <PluginLauncher @navigate="onPluginNavigate" />
         <CanvasViewToggle
           :model-value="canvasViewMode"
           @update:model-value="setCanvasViewMode"
@@ -332,6 +333,9 @@ import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import LockStatusPopup from "./components/LockStatusPopup.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";
 import CanvasViewToggle from "./components/CanvasViewToggle.vue";
+import PluginLauncher, {
+  type PluginLauncherTarget,
+} from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
@@ -723,6 +727,137 @@ const {
   handleViewModeShortcut,
 } = useCanvasViewMode({ isRunning });
 const rightSidebarRef = ref<InstanceType<typeof RightSidebar> | null>(null);
+
+// Default HTTP call (endpoint + body + resulting toolName) for each
+// "invoke" launcher target. Mirrors what each plugin's `execute()`
+// does — duplicated here intentionally so the launcher doesn't drag
+// the Vue components into this synchronous code path.
+//
+// Most endpoints already return a `{ data: ... }` envelope that the
+// plugin View expects. Skills is the odd one out — its REST surface
+// returns `{ skills: [...] }` flat, so `wrapData` lifts the payload
+// under `data` before the ToolResult reaches the View.
+const LAUNCHER_INVOKE_SPECS: Record<
+  "todos" | "scheduler" | "skills" | "wiki",
+  {
+    endpoint: string;
+    method: "GET" | "POST";
+    body?: unknown;
+    toolName: string;
+    defaultTitle: string;
+    /** Optional response-shape transform: when set, the ToolResult
+     *  gets `data = wrapData(json)` overlaid on top of the spread. */
+    wrapData?: (json: Record<string, unknown>) => unknown;
+  }
+> = {
+  todos: {
+    endpoint: "/api/todos",
+    method: "POST",
+    body: { action: "show" },
+    toolName: "manageTodoList",
+    defaultTitle: "Todos",
+  },
+  scheduler: {
+    endpoint: "/api/scheduler",
+    method: "POST",
+    body: { action: "show" },
+    toolName: "manageScheduler",
+    defaultTitle: "Schedule",
+  },
+  skills: {
+    endpoint: "/api/skills",
+    method: "GET",
+    toolName: "manageSkills",
+    defaultTitle: "Skills",
+    wrapData: (json) => ({ skills: json.skills ?? [] }),
+  },
+  wiki: {
+    endpoint: "/api/wiki",
+    method: "POST",
+    body: { action: "index" },
+    toolName: "manageWiki",
+    defaultTitle: "Wiki",
+  },
+};
+
+type LauncherInvokeKey = keyof typeof LAUNCHER_INVOKE_SPECS;
+
+function isLauncherInvokeKey(key: string): key is LauncherInvokeKey {
+  return key in LAUNCHER_INVOKE_SPECS;
+}
+
+// Call a plugin's REST endpoint locally and shape the response into
+// a ToolResultComplete so the canvas renders it through the plugin's
+// own View component. Throws on HTTP / network failure; caller is
+// responsible for surfacing the error to the user.
+async function invokePluginForLauncher(
+  key: LauncherInvokeKey,
+): Promise<ToolResultComplete> {
+  const spec = LAUNCHER_INVOKE_SPECS[key];
+  const res = await fetch(spec.endpoint, {
+    method: spec.method,
+    headers:
+      spec.method === "POST" ? { "Content-Type": "application/json" } : {},
+    body: spec.method === "POST" ? JSON.stringify(spec.body ?? {}) : undefined,
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const detail =
+      typeof json.error === "string" ? json.error : `HTTP ${res.status}`;
+    throw new Error(`${spec.toolName} failed: ${detail}`);
+  }
+  const data = spec.wrapData ? spec.wrapData(json) : json.data;
+  return {
+    ...json,
+    data,
+    toolName: spec.toolName,
+    uuid: typeof json.uuid === "string" ? json.uuid : crypto.randomUUID(),
+    title: typeof json.title === "string" ? json.title : spec.defaultTitle,
+    message:
+      typeof json.message === "string"
+        ? json.message
+        : `Opened ${spec.defaultTitle}`,
+  } as ToolResultComplete;
+}
+
+// Plugin-launcher click:
+// - "files" target → switch canvas to files view (no plugin call).
+// - "invoke" target → call the plugin locally, push the result into
+//   the current session, select it, switch canvas to single view so
+//   the plugin's View component takes the stage.
+async function onPluginNavigate(target: PluginLauncherTarget): Promise<void> {
+  if (target.kind === "files") {
+    setCanvasViewMode("files");
+    const base = buildViewQuery();
+    const query: Record<string, string> = {};
+    for (const [k, v] of Object.entries(base)) {
+      if (typeof v === "string") query[k] = v;
+    }
+    delete query.path;
+    router.replace({ query }).catch((err: unknown) => {
+      if (!isNavigationFailure(err)) {
+        // eslint-disable-next-line no-console
+        console.error("[plugin-launcher] navigation failed:", err);
+      }
+    });
+    return;
+  }
+
+  const session = sessionMap.get(currentSessionId.value);
+  if (!session) return;
+  if (!isLauncherInvokeKey(target.key)) return;
+
+  try {
+    const result = await invokePluginForLauncher(target.key);
+    session.toolResults.push(result);
+    session.selectedResultUuid = result.uuid;
+    // Single view so the plugin's View takes the full canvas —
+    // stack view would bury the fresh result below older entries.
+    setCanvasViewMode("single");
+  } catch (err) {
+    pushErrorMessage(session, err instanceof Error ? err.message : String(err));
+  }
+}
 
 const { availableTools, toolDescriptions, fetchMcpToolsStatus } = useMcpTools({
   currentRole,

--- a/src/components/CanvasViewToggle.vue
+++ b/src/components/CanvasViewToggle.vue
@@ -36,6 +36,10 @@ const emit = defineEmits<{
   "update:modelValue": [mode: CanvasViewMode];
 }>();
 
+// Files view is no longer exposed through this toggle — the plugin
+// launcher (src/components/PluginLauncher.vue) is the entry point,
+// with dedicated buttons for todos / scheduler / wiki / skills plus
+// a generic "Files" button for the workspace root.
 const MODES: ModeOption[] = [
   {
     key: "single",
@@ -48,12 +52,6 @@ const MODES: ModeOption[] = [
     icon: "view_stream",
     label: "Stack",
     title: "All results stacked (⌘2)",
-  },
-  {
-    key: "files",
-    icon: "folder",
-    label: "Files",
-    title: "Workspace files (⌘3)",
   },
 ];
 </script>

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -1,0 +1,87 @@
+<template>
+  <div
+    class="flex border border-gray-300 rounded overflow-hidden text-xs"
+    data-testid="plugin-launcher"
+  >
+    <button
+      v-for="target in TARGETS"
+      :key="target.key"
+      class="px-2.5 py-1 flex items-center gap-1 bg-white text-gray-600 hover:bg-gray-50 border-r border-gray-200 last:border-r-0"
+      :title="target.title"
+      :data-testid="`plugin-launcher-${target.key}`"
+      @click="emit('navigate', target)"
+    >
+      <span class="material-icons text-sm">{{ target.icon }}</span>
+      <span>{{ target.label }}</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Quick-access toolbar sitting above the canvas. Each button either
+// invokes a plugin locally (no LLM round-trip) and surfaces its
+// native View, or — for "files" — switches the canvas to the
+// workspace file tree.
+//
+// First slice of issue #253. The list of targets is declared here so
+// the launcher can be swapped for a customisable per-role palette
+// later without touching the App.vue wiring.
+
+export type PluginLauncherKind =
+  | "invoke" // Call the matching plugin's client endpoint and push the ToolResult into the current session
+  | "files"; // Switch the canvas to files view (no plugin call)
+
+export interface PluginLauncherTarget {
+  /** Stable key for testid + dispatch in App.vue. */
+  key: "todos" | "scheduler" | "skills" | "wiki" | "files";
+  kind: PluginLauncherKind;
+  /** Material-icons glyph. */
+  icon: string;
+  /** Visible label next to the icon. */
+  label: string;
+  /** Tooltip on hover. */
+  title: string;
+}
+
+const TARGETS: PluginLauncherTarget[] = [
+  {
+    key: "todos",
+    kind: "invoke",
+    icon: "checklist",
+    label: "Todos",
+    title: "Open todos",
+  },
+  {
+    key: "scheduler",
+    kind: "invoke",
+    icon: "event",
+    label: "Schedule",
+    title: "Open schedule",
+  },
+  {
+    key: "skills",
+    kind: "invoke",
+    icon: "psychology",
+    label: "Skills",
+    title: "Open skills",
+  },
+  {
+    key: "wiki",
+    kind: "invoke",
+    icon: "menu_book",
+    label: "Wiki",
+    title: "Open wiki",
+  },
+  {
+    key: "files",
+    kind: "files",
+    icon: "folder",
+    label: "Files",
+    title: "Open workspace files",
+  },
+];
+
+const emit = defineEmits<{
+  navigate: [target: PluginLauncherTarget];
+}>();
+</script>


### PR DESCRIPTION
## Summary

First slice of #253. Adds a \`PluginLauncher\` component in the canvas toolbar (left of the view-mode toggle) with 5 one-click entry points:

| Icon | Kind | Action |
|---|---|---|
| ✅ Todos | invoke | POST \`/api/todos\` { action: \"show\" } → manageTodoList View |
| 📅 Schedule | invoke | POST \`/api/scheduler\` { action: \"show\" } → manageScheduler View |
| 🧠 Skills | invoke | GET \`/api/skills\` → manageSkills View |
| 📚 Wiki | invoke | POST \`/api/wiki\` { action: \"index\" } → wiki View |
| 📁 Files | files | Switch canvas to files view (no plugin call) |

The \"invoke\" buttons call the plugin's REST endpoint **locally** (no LLM round-trip), shape the response into a \`ToolResultComplete\`, push it into the current session, select it, and switch to \`single\` view so the plugin's native \`View.vue\` component takes the stage.

Matches the original #251 intent: \"skill launcher without asking Claude\", generalised across 4 plugins.

## Why invoke-then-render rather than deep-link-to-files

- Each plugin already ships a rich \`View.vue\` (todo kanban, skills list + Run button, wiki page catalog, scheduler timeline). Files view would just dump the underlying JSON — strictly worse UX.
- The plugin's \`execute()\` already knows how to hit the right endpoint; this launcher mirrors that logic in \`App.vue\`'s \`LAUNCHER_INVOKE_SPECS\` registry. Keeping it in App.vue (rather than calling \`plugin.execute()\`) means the launcher doesn't drag Vue component types into the synchronous click path.

## Response-shape quirk

Most endpoints envelope their payload as \`{ data: ... }\` — the \`...json\` spread into the ToolResult handles those naturally. The \`/api/skills\` endpoint returns \`{ skills: [...] }\` flat, so its spec entry has a \`wrapData\` fn that lifts the payload under \`data\` before the View receives it. Documented inline; isolated to one spec entry.

## Removed

- \"Files\" button from \`CanvasViewToggle\`. The launcher now owns that entry point. \`view=files\` URL and Cmd/Ctrl+3 shortcut still work.

## Files changed

- \`src/components/PluginLauncher.vue\` (new, ~85 lines) — 5 buttons, emits \`navigate\` with a \`PluginLauncherTarget\` descriptor tagged \`invoke\` or \`files\`.
- \`src/App.vue\` — \`LAUNCHER_INVOKE_SPECS\` registry, \`invokePluginForLauncher\`, \`onPluginNavigate\` handler. Plumbs the invoke path through \`pushErrorMessage\` (existing helper) so endpoint failures surface as visible error messages in the stack.
- \`src/components/CanvasViewToggle.vue\` — drop \`files\` option.
- \`e2e/tests/plugin-launcher.spec.ts\` (new, 6 tests) — invoke path for each plugin + endpoint-error path + files-button path.

## Items to Confirm / Review

- **invoke spec registry lives in App.vue**: pro = keeps the Vue plugin classes out of App.vue's click path, con = the specs duplicate what \`plugin.execute()\` already does. If you'd prefer calling \`plugin.execute()\` directly (or moving specs into each plugin's \`index.ts\`), easy to refactor. Current form is least-coupled.
- **Switching to \`single\` view** on invoke — chose this over \`stack\` so the freshly-pushed result owns the canvas instead of scrolling below older results. If you'd rather see the thread, easy to flip.
- **Error surface** uses \`pushErrorMessage\` → text-response with \`[Error]\` prefix, matches existing error UX.

## User Prompt

> プラグインランチャーはほしいね。まずはコンポーネントつくってcanvasの上に埋め込む？今、stack, filesってなっている部分の左に。
> todos / scheduler / skills / wiki / fileにして、既存のファイルのアイコンは消す。動作はその該当データのファイルエクスプローラーにまずはとばそう。
> 288ですすめて。（plugin viewer を使う版に upgrade）

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` — green
- [x] \`yarn test\` — unit tests pass
- [x] \`yarn test:e2e\` — 157/157 pass including 6 new \`plugin-launcher.spec.ts\` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plugin launcher toolbar providing quick access to todos, scheduler, skills, wiki, and files functionality.
  * Implemented error handling that displays failure messages when plugin operations encounter issues.

* **Bug Fixes**
  * Reorganized canvas view controls by moving files access to the new launcher and streamlining the view toggle.

* **Tests**
  * Added comprehensive end-to-end tests for plugin launcher interactions and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
