### PR TITLE
fix(wiki): derive index.md slug from href, not from title

### DIFF
--- a/server/helps/wiki.md
+++ b/server/helps/wiki.md
@@ -30,14 +30,17 @@ You never write the wiki yourself — Claude writes and maintains all of it. You
 ## Three Operations
 
 ### Ingest
+
 Drop a source (article, URL, text) and ask Claude to process it.
 
 Claude will: read the source, identify key entities and concepts, create or update 5–15 wiki pages, add cross-references, append a log entry, and refresh the index. Show the updated index in the canvas when done.
 
 ### Query
+
 Ask any question. Claude searches `wiki/index.md` for relevant pages, reads them, and synthesizes a grounded answer with citations. Good answers can be filed back into the wiki as new pages — a comparison you asked for, an analysis, a connection you discovered — so they don't disappear into chat history.
 
 ### Lint
+
 Ask Claude to health-check the wiki. It scans for contradictions, stale claims, orphan pages, missing cross-references, and concepts that deserve their own page, then fixes issues automatically.
 
 ## Folder Layout
@@ -83,6 +86,32 @@ Brief summary paragraph...
 
 Cross-references use `[[Page Name]]` wiki-link syntax. Slugs are lowercase, hyphen-separated (e.g. `transformer-architecture.md`).
 
+## `index.md` Format
+
+`wiki/index.md` is the catalog — one bullet per page using standard markdown link syntax with the slug embedded in the href. This format works both in-app (the canvas parses it) and in any plain markdown viewer (GitHub, VS Code preview, etc.).
+
+```markdown
+# Wiki Index
+
+## ページ一覧
+
+- [Transformer Architecture](pages/transformer-architecture.md) — machine-learning, architecture, attention (2026-04-05)
+- [さくらインターネット](pages/sakura-internet.md) — クラウド, 日本企業, データセンター (2026-04-06)
+- [ECharts DataZoom](pages/echarts-datazoom.md) — ECharts, データ可視化 (2026-04-13)
+
+## タグ一覧
+
+- **AI**: [Transformer Architecture](pages/transformer-architecture.md), [さくらインターネット](pages/sakura-internet.md)
+- **日本企業**: [さくらインターネット](pages/sakura-internet.md)
+```
+
+Key rules:
+
+- Always write bullet items as `[Title](pages/<slug>.md) — description (YYYY-MM-DD)` — **no** `[[slug]]` wiki-link form, and **no** markdown tables. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug.
+- Slugs are lowercase ASCII, hyphen-separated. They match the page filename one-to-one (`pages/sakura-internet.md` → slug `sakura-internet`).
+- Group by category if useful, then include a "タグ一覧" / "Tags" section with the same `[Title](pages/<slug>.md)` link form so every mention is clickable.
+- Keep the index in sync with `pages/` — when you add a page, add a row; when you rename a file, update every link that points at it.
+
 ## Canvas Tool
 
 Use the `manageWiki` tool to display wiki content in the canvas:
@@ -94,9 +123,9 @@ Use the `manageWiki` tool to display wiki content in the canvas:
 
 ## Relationship to `memory.md`
 
-| | `memory.md` | `wiki/` |
-|---|---|---|
-| Scope | Brief distilled facts, always in context | Deep structured knowledge, loaded on demand |
-| Growth | Intentionally small | Grows unboundedly |
+|        | `memory.md`                              | `wiki/`                                     |
+| ------ | ---------------------------------------- | ------------------------------------------- |
+| Scope  | Brief distilled facts, always in context | Deep structured knowledge, loaded on demand |
+| Growth | Intentionally small                      | Grows unboundedly                           |
 
 Over time, Claude can distill key insights from the wiki back into `memory.md` as compact ambient context for all roles.

--- a/server/routes/wiki.ts
+++ b/server/routes/wiki.ts
@@ -37,7 +37,12 @@ export function wikiSlugify(text: string): string {
 }
 
 const TABLE_SEPARATOR_PATTERN = /^\|[\s|:-]+\|$/;
-const BULLET_LINK_PATTERN = /^[-*]\s+\[([^\]]+)\]\([^)]*\)(?:\s*[—–-]\s*(.*))?/;
+// Capture the href (group 2) alongside the title (group 1) so we can
+// derive the slug from the file name instead of re-slugifying the
+// title. This matters for non-ASCII titles like "さくらインターネット"
+// where `wikiSlugify` returns "" and the slug would otherwise be lost.
+const BULLET_LINK_PATTERN =
+  /^[-*]\s+\[([^\]]+)\]\(([^)]*)\)(?:\s*[—–-]\s*(.*))?/;
 const BULLET_WIKI_LINK_PATTERN = /^[-*]\s+\[\[([^\]]+)\]\](?:\s*[—–-]\s*(.*))?/;
 
 // Each parser returns the entry it produced (if any). The parent
@@ -55,12 +60,32 @@ function parseTableRow(trimmed: string): WikiPageEntry | null {
   return { title, slug, description: desc };
 }
 
+// Extract the slug segment from a bullet link's href. Accepts the
+// canonical `pages/<slug>.md`, a bare `<slug>.md`, or just `<slug>`
+// — the three forms produced by different historical writers of
+// index.md. Returns "" for hrefs that don't look like a wiki page
+// reference (e.g. `https://example.com`) so the caller can fall
+// back to title-based slugification.
+export function extractSlugFromBulletHref(rawHref: string): string {
+  const href = rawHref.trim();
+  if (!href) return "";
+  if (/^[a-z]+:\/\//i.test(href)) return "";
+  const lastSegment = href.split("/").pop() ?? href;
+  return lastSegment.replace(/\.md$/i, "");
+}
+
 function parseBulletLinkRow(trimmed: string): WikiPageEntry | null {
   const m = BULLET_LINK_PATTERN.exec(trimmed);
   if (!m) return null;
   const title = m[1].trim();
-  const desc = m[2]?.trim() ?? "";
-  return { title, slug: wikiSlugify(title), description: desc };
+  const href = m[2] ?? "";
+  const desc = m[3]?.trim() ?? "";
+  // Prefer the slug embedded in the href so non-ASCII titles keep
+  // a navigable slug. Fall back to slugifying the title only when
+  // the href has no recognisable slug (rare — usually means the
+  // author put an external URL here).
+  const slug = extractSlugFromBulletHref(href) || wikiSlugify(title);
+  return { title, slug, description: desc };
 }
 
 function parseBulletWikiLinkRow(trimmed: string): WikiPageEntry | null {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -113,7 +113,7 @@
         v-for="entry in pageEntries"
         :key="entry.slug"
         class="rounded-lg border border-gray-200 p-3 cursor-pointer hover:border-blue-300 hover:bg-blue-50 transition-colors"
-        @click="navigatePage(entry.title)"
+        @click="navigatePage(entry.slug || entry.title)"
       >
         <div class="font-medium text-sm text-gray-800">{{ entry.title }}</div>
         <div v-if="entry.description" class="text-xs text-gray-500 mt-0.5">

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  extractSlugFromBulletHref,
   findBrokenLinksInPage,
   findMissingFiles,
   findOrphanPages,
@@ -34,6 +35,42 @@ describe("wikiSlugify", () => {
 
   it("handles empty input", () => {
     assert.equal(wikiSlugify(""), "");
+  });
+});
+
+describe("extractSlugFromBulletHref", () => {
+  it("extracts slug from pages/<slug>.md", () => {
+    assert.equal(
+      extractSlugFromBulletHref("pages/sakura-internet.md"),
+      "sakura-internet",
+    );
+  });
+
+  it("handles leading ./ and deeper prefixes", () => {
+    assert.equal(extractSlugFromBulletHref("./pages/foo.md"), "foo");
+    assert.equal(extractSlugFromBulletHref("wiki/pages/foo.md"), "foo");
+  });
+
+  it("accepts a bare <slug>.md without the pages prefix", () => {
+    assert.equal(extractSlugFromBulletHref("foo.md"), "foo");
+  });
+
+  it("accepts just <slug> with no .md extension", () => {
+    assert.equal(extractSlugFromBulletHref("foo"), "foo");
+  });
+
+  it("strips surrounding whitespace", () => {
+    assert.equal(extractSlugFromBulletHref("  pages/foo.md  "), "foo");
+  });
+
+  it("returns empty for absolute URLs (caller should fall back)", () => {
+    assert.equal(extractSlugFromBulletHref("https://example.com/foo"), "");
+    assert.equal(extractSlugFromBulletHref("http://x/foo.md"), "");
+  });
+
+  it("returns empty for an empty input", () => {
+    assert.equal(extractSlugFromBulletHref(""), "");
+    assert.equal(extractSlugFromBulletHref("   "), "");
   });
 });
 
@@ -74,6 +111,45 @@ describe("parseIndexEntries", () => {
       slug: "video-generation",
       description: "about video",
     });
+  });
+
+  it("derives slug from href for non-ASCII titles", () => {
+    // Regression for the Japanese-wiki case: before, the slug was
+    // `wikiSlugify(title)` which stripped every non-ASCII character
+    // and returned "", breaking in-canvas navigation. The slug must
+    // now come from the href segment.
+    const md =
+      "- [さくらインターネット](pages/sakura-internet.md) — クラウド事業者";
+    const entries = parseIndexEntries(md);
+    assert.deepEqual(entries[0], {
+      title: "さくらインターネット",
+      slug: "sakura-internet",
+      description: "クラウド事業者",
+    });
+  });
+
+  it("derives slug from a bare filename href", () => {
+    // Some historical index.md files used `[Title](slug.md)` without
+    // the `pages/` prefix. Still valid — use the filename as slug.
+    const md = "- [Video Generation](video-generation.md) — about video";
+    const entries = parseIndexEntries(md);
+    assert.equal(entries[0]?.slug, "video-generation");
+  });
+
+  it("derives slug from a plain filename with no extension", () => {
+    const md = "- [Video Generation](video-generation) — about video";
+    const entries = parseIndexEntries(md);
+    assert.equal(entries[0]?.slug, "video-generation");
+  });
+
+  it("falls back to slugifying the title when the href is an external URL", () => {
+    // External URLs have no wiki-page slug, so the old title-derived
+    // slug is the only reasonable choice. For non-ASCII titles this
+    // still produces "" — but that's fine: such a row isn't a
+    // real wiki page entry in the first place.
+    const md = "- [Video Generation](https://example.com/xyz) — about video";
+    const entries = parseIndexEntries(md);
+    assert.equal(entries[0]?.slug, "video-generation");
   });
 
   it("parses bullet wiki links", () => {


### PR DESCRIPTION
## Summary

日本語タイトルの wiki page がクリック navigation で壊れていた問題を修正。`index.md` のパーサが title を `wikiSlugify` して slug を作っていて、非 ASCII 文字が全部剥がれて slug="" → fuzzy lookup で別ページに飛ぶ、という silent failure。

## 原因

`server/routes/wiki.ts#parseBulletLinkRow` の実装:

```ts
// before
return { title, slug: wikiSlugify(title), description: desc };
```

- `wikiSlugify("さくらインターネット")` → `""` (non-ASCII を全部 strip)
- Index view の card クリックで `navigatePage(entry.title)` → backend `resolvePagePath` が再度 `wikiSlugify` → 空 slug
- 空 slug での fuzzy match `key.includes("")` は全 key に true → pageIndex の最初のエントリが返る → 別ページに飛ぶ

## 修正

- **`parseBulletLinkRow`**: slug を href (`pages/<slug>.md`) から抽出するように変更。`extractSlugFromBulletHref` を export して純粋関数としてテスト可能に
- **`src/plugins/wiki/View.vue`**: index card クリックで `entry.slug` を優先 (`entry.title` は fallback)
- **`server/helps/wiki.md`**: canonical な `index.md` フォーマット (`- [Title](pages/<slug>.md) — desc`) を新セクションで明記。Claude が次から正しい形式で書くようになる

`[[Page]]` bullet (title-only form) には触っていない — href を持たないので title-slugify しか手がない。日本語タイトルは `[Title](pages/slug.md)` 形式を使うことで解決する。

## Items to Confirm / Review

- **`extractSlugFromBulletHref` の受け入れパターン** — `pages/foo.md` / `./pages/foo.md` / `wiki/pages/foo.md` / `foo.md` / `foo` の 5 形式。外部 URL は空文字を返して caller fallback
- **View.vue の fallback 優先度** — `entry.slug || entry.title`。slug が確実にあるなら title は使わない。空文字でも過去データがあり得るので `||` にした
- **`helps/wiki.md` のガイド** — 既存の `[[Page]]` セクションは残し、index.md 専用セクションを追加

## User Prompt

> wikiのindex.mdが各ページに正しくリンクになってない。[[~~]]でパーサーがリンクになってないのと、pagesのパスが抜けている。まずはデータだけ直して。で、うまく表示されるか確認して。そのあとコードを修正して。

(データ修正 → UI 表示確認 OK → 本 PR でコード修正)

## Test plan

- [x] `yarn test` pass (1849 件、+9 新規)
- [x] ローカルで `~/mulmoclaude/wiki/index.md` を `- [日本語タイトル](pages/slug.md) — desc` 形式に書き直し → Canvas の index card クリックで正しいページに遷移
- [ ] `[[Page]]` 形式の既存 bullet は従来通り動作 (title-slugify でも ASCII タイトルは問題なし)
- [ ] `helps/wiki.md` を読ませて Claude が次回 `index.md` 更新時に新形式で書くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)