### PR TITLE
chore(env): consolidate process.env reads into server/env.ts (#289 part 3)

### DIFF
--- a/server/docker.ts
+++ b/server/docker.ts
@@ -5,6 +5,7 @@ import { readFileSync, statSync } from "fs";
 import { homedir } from "os";
 import { join, resolve as resolvePath } from "path";
 import { log } from "./logger/index.js";
+import { env } from "./env.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -46,7 +47,7 @@ function assertClaudeFiles(): void {
 }
 
 export async function isDockerAvailable(): Promise<boolean> {
-  if (process.env.DISABLE_SANDBOX === "1") return false;
+  if (env.disableSandbox) return false;
   if (_dockerEnabled !== null) return _dockerEnabled;
   assertClaudeFiles();
   try {

--- a/server/env.ts
+++ b/server/env.ts
@@ -17,10 +17,17 @@
 
 // ── Type coercion helpers ───────────────────────────────────────────
 
-function asInt(value: string | undefined, fallback: number): number {
+function asInt(
+  value: string | undefined,
+  fallback: number,
+  opts: { min?: number; max?: number } = {},
+): number {
   if (value === undefined || value === "") return fallback;
   const n = Number(value);
-  return Number.isFinite(n) ? n : fallback;
+  if (!Number.isInteger(n)) return fallback;
+  if (opts.min !== undefined && n < opts.min) return fallback;
+  if (opts.max !== undefined && n > opts.max) return fallback;
+  return n;
 }
 
 function asFlag(value: string | undefined): boolean {
@@ -30,8 +37,13 @@ function asFlag(value: string | undefined): boolean {
   return value === "1";
 }
 
-function asCsv(value: string | undefined): string[] {
-  return (value ?? "").split(",").filter(Boolean);
+function asCsv(value: string | undefined): readonly string[] {
+  return Object.freeze(
+    (value ?? "")
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
 }
 
 // ── Snapshot ────────────────────────────────────────────────────────
@@ -44,7 +56,7 @@ function asCsv(value: string | undefined): string[] {
  */
 export const env = Object.freeze({
   // HTTP server
-  port: asInt(process.env.PORT, 3001),
+  port: asInt(process.env.PORT, 3001, { min: 0, max: 65_535 }),
   nodeEnv: process.env.NODE_ENV ?? "development",
   isProduction: process.env.NODE_ENV === "production",
 
@@ -56,7 +68,9 @@ export const env = Object.freeze({
   xBearerToken: process.env.X_BEARER_TOKEN,
 
   // Sessions index API
-  sessionsListWindowDays: asInt(process.env.SESSIONS_LIST_WINDOW_DAYS, 90),
+  sessionsListWindowDays: asInt(process.env.SESSIONS_LIST_WINDOW_DAYS, 90, {
+    min: 0,
+  }),
 
   // Debug-only force-run flags. Off by default; `=1` triggers an
   // immediate run on startup instead of waiting for the scheduled

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,84 @@
+// Single source of truth for environment-variable reads.
+//
+// Before this module existed, `process.env.X` calls were sprinkled
+// across 8 files with each call site doing its own type coercion
+// (`Number(process.env.PORT) || 3001`, `process.env.X === "1"`, …).
+// Renaming an env var, changing a default, or auditing what we read
+// from the environment all required grepping the codebase.
+//
+// All env-var reads should now go through `env.*`. The exception is
+// `server/logger/config.ts` which has its own self-contained env
+// reader (`resolveConfig(env)`) — that subsystem stays independent
+// because it's loaded at extremely early bootstrap and accepts an
+// arbitrary `env`-shaped object for testability.
+//
+// `docs/developer.md` lists every env var and what it does; this
+// module is the runtime side of that table.
+
+// ── Type coercion helpers ───────────────────────────────────────────
+
+function asInt(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === "") return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function asFlag(value: string | undefined): boolean {
+  // Established convention in this project: env flags are "1"
+  // (truthy) vs anything else (falsy). Avoids the trap of
+  // `process.env.FOO === "false"` evaluating truthy as a string.
+  return value === "1";
+}
+
+function asCsv(value: string | undefined): string[] {
+  return (value ?? "").split(",").filter(Boolean);
+}
+
+// ── Snapshot ────────────────────────────────────────────────────────
+
+/**
+ * Frozen snapshot of every env var the app reads, with type coercion
+ * and defaults baked in. Read at module load time so tests can
+ * import a stable view without re-reading process.env on every
+ * access.
+ */
+export const env = Object.freeze({
+  // HTTP server
+  port: asInt(process.env.PORT, 3001),
+  nodeEnv: process.env.NODE_ENV ?? "development",
+  isProduction: process.env.NODE_ENV === "production",
+
+  // Sandbox / Docker
+  disableSandbox: asFlag(process.env.DISABLE_SANDBOX),
+
+  // API credentials (undefined when not configured)
+  geminiApiKey: process.env.GEMINI_API_KEY,
+  xBearerToken: process.env.X_BEARER_TOKEN,
+
+  // Sessions index API
+  sessionsListWindowDays: asInt(process.env.SESSIONS_LIST_WINDOW_DAYS, 90),
+
+  // Debug-only force-run flags. Off by default; `=1` triggers an
+  // immediate run on startup instead of waiting for the scheduled
+  // interval.
+  journalForceRunOnStartup: asFlag(process.env.JOURNAL_FORCE_RUN_ON_STARTUP),
+  chatIndexForceRunOnStartup: asFlag(
+    process.env.CHAT_INDEX_FORCE_RUN_ON_STARTUP,
+  ),
+
+  // MCP subprocess: set by the parent server when spawning
+  // mcp-server.ts. The MCP process reads them via this same module —
+  // OS-level env vars are shared across both processes.
+  mcpSessionId: process.env.SESSION_ID ?? "",
+  mcpHost: process.env.MCP_HOST ?? "localhost",
+  mcpPluginNames: asCsv(process.env.PLUGIN_NAMES),
+  mcpRoleIds: asCsv(process.env.ROLE_IDS),
+});
+
+// ── Derived helpers ─────────────────────────────────────────────────
+
+/** True iff a Gemini API key is configured. Drives the "image
+ *  generation available" hint in the UI. */
+export function isGeminiAvailable(): boolean {
+  return env.geminiApiKey !== undefined && env.geminiApiKey !== "";
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,6 +27,7 @@ import {
   isMcpToolEnabled,
 } from "./mcp-tools/index.js";
 import { initWorkspace } from "./workspace.js";
+import { env, isGeminiAvailable } from "./env.js";
 import fs from "fs";
 import os from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./docker.js";
@@ -51,7 +52,7 @@ initWorkspace();
 let sandboxEnabled = false;
 
 const app = express();
-const PORT = Number(process.env.PORT) || 3001;
+const PORT = env.port;
 
 app.disable("x-powered-by");
 // No `cors()` middleware. The Vite dev proxy forwards `/api/*`
@@ -76,7 +77,7 @@ app.use(requireSameOrigin);
 app.get("/api/health", (_req: Request, res: Response) => {
   res.json({
     status: "OK",
-    geminiAvailable: !!process.env.GEMINI_API_KEY,
+    geminiAvailable: isGeminiAvailable(),
     sandboxEnabled,
   });
 });
@@ -101,7 +102,7 @@ app.use("/api", skillsRoutes);
 app.use("/api", chatServiceRoutes);
 app.use("/api/mcp-tools", mcpToolsRouter);
 
-if (process.env.NODE_ENV === "production") {
+if (env.isProduction) {
   app.use(express.static(path.join(__dirname, "../client")));
   app.get("*", (_req: Request, res: Response) => {
     res.sendFile(path.join(__dirname, "../client/index.html"));
@@ -156,7 +157,7 @@ async function ensureCredentialsAvailable(): Promise<void> {
 }
 
 async function setupSandbox(): Promise<boolean> {
-  if (process.env.DISABLE_SANDBOX === "1") {
+  if (env.disableSandbox) {
     log.info(
       "sandbox",
       "DISABLE_SANDBOX=1 — running unrestricted (debug mode)",
@@ -206,7 +207,7 @@ function maybeForceJournalRun(): void {
   // journal pass immediately without waiting for a session end or
   // the hourly interval. Fire-and-forget — journal errors never
   // propagate out of maybeRunJournal.
-  if (process.env.JOURNAL_FORCE_RUN_ON_STARTUP !== "1") return;
+  if (!env.journalForceRunOnStartup) return;
   log.info("journal", "JOURNAL_FORCE_RUN_ON_STARTUP=1 — running now");
   maybeRunJournal({ force: true }).catch((err) => {
     log.warn("journal", "forced startup run failed", { error: String(err) });
@@ -218,7 +219,7 @@ function maybeForceChatIndexBackfill(): void {
   // session's title summary on startup. Useful the first time the
   // feature is rolled out over an existing workspace, or when
   // debugging the indexer itself.
-  if (process.env.CHAT_INDEX_FORCE_RUN_ON_STARTUP !== "1") return;
+  if (!env.chatIndexForceRunOnStartup) return;
   log.info("chat-index", "CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 — running now");
   backfillAllSessions()
     .then((result) => {

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -7,6 +7,7 @@
 import type { ToolDefinition } from "gui-chat-protocol";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { TOOL_ENDPOINTS, PLUGIN_DEFS } from "./plugin-names.js";
+import { env } from "./env.js";
 
 type JsonRpcId = string | number | null;
 
@@ -25,13 +26,11 @@ interface JsonRpcMessage {
 const isJsonRpcMessage = (v: unknown): v is JsonRpcMessage =>
   typeof v === "object" && v !== null && !Array.isArray(v) && "method" in v;
 
-const SESSION_ID = process.env.SESSION_ID ?? "";
-const PORT = process.env.PORT ?? "3001";
-const PLUGIN_NAMES = (process.env.PLUGIN_NAMES ?? "")
-  .split(",")
-  .filter(Boolean);
-const ROLE_IDS = (process.env.ROLE_IDS ?? "").split(",").filter(Boolean);
-const MCP_HOST = process.env.MCP_HOST ?? "localhost";
+const SESSION_ID = env.mcpSessionId;
+const PORT = env.port;
+const PLUGIN_NAMES = env.mcpPluginNames;
+const ROLE_IDS = env.mcpRoleIds;
+const MCP_HOST = env.mcpHost;
 const BASE_URL = `http://${MCP_HOST}:${PORT}`;
 
 interface ToolDef {

--- a/server/mcp-tools/x.ts
+++ b/server/mcp-tools/x.ts
@@ -1,4 +1,5 @@
 import { errorMessage } from "../utils/errors.js";
+import { env } from "../env.js";
 
 const X_API_BASE = "https://api.twitter.com/2";
 const TWEET_FIELDS =
@@ -32,7 +33,7 @@ interface XApiResponse {
 }
 
 async function fetchX(path: string): Promise<XApiResponse> {
-  const token = process.env.X_BEARER_TOKEN;
+  const token = env.xBearerToken;
   if (!token) throw new Error("X_BEARER_TOKEN is not configured in .env");
 
   let response: Response;

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -20,9 +20,10 @@ import { maybeAppendWikiBacklinks } from "../wiki-backlinks/index.js";
 import { log } from "../logger/index.js";
 import { logBackgroundError } from "../utils/logBackgroundError.js";
 import { createArgsCache, recordToolEvent } from "../tool-trace/index.js";
+import { env } from "../env.js";
 
 const router = Router();
-const PORT = Number(process.env.PORT) || 3001;
+const PORT = env.port;
 
 // Short, safe preview of tool args for logs. Full payload may contain
 // base64 images or large blobs, so we cap it. The goal is to make a

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -7,6 +7,7 @@ import { readManifest } from "../chat-index/indexer.js";
 import { resolveWithinRoot } from "../utils/fs.js";
 import type { ChatIndexEntry } from "../chat-index/types.js";
 import { markRead, getSession } from "../session-store/index.js";
+import { env } from "../env.js";
 
 interface SessionMeta {
   roleId: string;
@@ -68,8 +69,7 @@ const router = Router();
 
 // Sessions older than this are excluded from the listing. Set
 // SESSIONS_LIST_WINDOW_DAYS to override (0 = no cutoff).
-const WINDOW_MS =
-  (Number(process.env.SESSIONS_LIST_WINDOW_DAYS) || 90) * 86_400_000;
+const WINDOW_MS = env.sessionsListWindowDays * 86_400_000;
 
 router.get(
   "/sessions",

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -1,13 +1,12 @@
 import { GoogleGenAI, type GenerateContentParameters } from "@google/genai";
+import { env } from "../env.js";
+
+export { isGeminiAvailable } from "../env.js";
 
 export function getGeminiClient(): GoogleGenAI {
-  const apiKey = process.env.GEMINI_API_KEY;
+  const apiKey = env.geminiApiKey;
   if (!apiKey) throw new Error("GEMINI_API_KEY is not set");
   return new GoogleGenAI({ apiKey });
-}
-
-export function isGeminiAvailable(): boolean {
-  return !!process.env.GEMINI_API_KEY;
 }
 
 // --- Image generation -----------------------------------------------

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -19,8 +19,8 @@ interface EnvSnapshot {
     chatIndexForceRunOnStartup: boolean;
     mcpSessionId: string;
     mcpHost: string;
-    mcpPluginNames: string[];
-    mcpRoleIds: string[];
+    mcpPluginNames: readonly string[];
+    mcpRoleIds: readonly string[];
   }>;
   isGeminiAvailable: () => boolean;
 }
@@ -164,9 +164,61 @@ describe("isGeminiAvailable", () => {
   });
 });
 
+describe("asInt edge cases", () => {
+  it("falls back when PORT is a decimal", async () => {
+    process.env.PORT = "3001.5";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+  });
+
+  it("falls back when PORT is negative", async () => {
+    process.env.PORT = "-1";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+  });
+
+  it("falls back when PORT exceeds 65535", async () => {
+    process.env.PORT = "70000";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+  });
+
+  it("falls back when SESSIONS_LIST_WINDOW_DAYS is negative", async () => {
+    process.env.SESSIONS_LIST_WINDOW_DAYS = "-7";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.sessionsListWindowDays, 90);
+  });
+});
+
+describe("asCsv edge cases", () => {
+  it("trims surrounding whitespace from entries", async () => {
+    process.env.PLUGIN_NAMES = "a, b , c";
+    const { env } = await loadEnvFresh();
+    assert.deepEqual(env.mcpPluginNames, ["a", "b", "c"]);
+  });
+
+  it("trims whitespace-only entries to empty and drops them", async () => {
+    process.env.ROLE_IDS = " , a , , b , ";
+    const { env } = await loadEnvFresh();
+    assert.deepEqual(env.mcpRoleIds, ["a", "b"]);
+  });
+});
+
 describe("env immutability", () => {
   it("env is frozen", async () => {
     const { env } = await loadEnvFresh();
     assert.equal(Object.isFrozen(env), true);
+  });
+
+  it("mcpPluginNames array is frozen", async () => {
+    process.env.PLUGIN_NAMES = "a,b";
+    const { env } = await loadEnvFresh();
+    assert.equal(Object.isFrozen(env.mcpPluginNames), true);
+  });
+
+  it("mcpRoleIds array is frozen", async () => {
+    process.env.ROLE_IDS = "x,y";
+    const { env } = await loadEnvFresh();
+    assert.equal(Object.isFrozen(env.mcpRoleIds), true);
   });
 });

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -1,0 +1,172 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+// `env` is a frozen module-level snapshot, so we re-import the
+// module under different process.env states by clearing the require
+// cache. Easiest in node:test land is to import via dynamic import
+// with a cache-busting query string.
+
+interface EnvSnapshot {
+  env: Readonly<{
+    port: number;
+    nodeEnv: string;
+    isProduction: boolean;
+    disableSandbox: boolean;
+    geminiApiKey: string | undefined;
+    xBearerToken: string | undefined;
+    sessionsListWindowDays: number;
+    journalForceRunOnStartup: boolean;
+    chatIndexForceRunOnStartup: boolean;
+    mcpSessionId: string;
+    mcpHost: string;
+    mcpPluginNames: string[];
+    mcpRoleIds: string[];
+  }>;
+  isGeminiAvailable: () => boolean;
+}
+
+let cacheBuster = 0;
+async function loadEnvFresh(): Promise<EnvSnapshot> {
+  cacheBuster++;
+  // tsx uses esbuild's import resolver which respects query strings
+  // for cache-busting. Each import returns a fresh module instance.
+  const mod = await import(`../../server/env.ts?t=${cacheBuster}`);
+  return mod as EnvSnapshot;
+}
+
+const ENV_KEYS = [
+  "PORT",
+  "NODE_ENV",
+  "DISABLE_SANDBOX",
+  "GEMINI_API_KEY",
+  "X_BEARER_TOKEN",
+  "SESSIONS_LIST_WINDOW_DAYS",
+  "JOURNAL_FORCE_RUN_ON_STARTUP",
+  "CHAT_INDEX_FORCE_RUN_ON_STARTUP",
+  "SESSION_ID",
+  "MCP_HOST",
+  "PLUGIN_NAMES",
+  "ROLE_IDS",
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("env defaults", () => {
+  it("falls back to documented defaults when nothing is set", async () => {
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.isProduction, false);
+    assert.equal(env.disableSandbox, false);
+    assert.equal(env.geminiApiKey, undefined);
+    assert.equal(env.xBearerToken, undefined);
+    assert.equal(env.sessionsListWindowDays, 90);
+    assert.equal(env.journalForceRunOnStartup, false);
+    assert.equal(env.chatIndexForceRunOnStartup, false);
+    assert.equal(env.mcpSessionId, "");
+    assert.equal(env.mcpHost, "localhost");
+    assert.deepEqual(env.mcpPluginNames, []);
+    assert.deepEqual(env.mcpRoleIds, []);
+  });
+});
+
+describe("env coercion", () => {
+  it("parses PORT as an integer", async () => {
+    process.env.PORT = "8080";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 8080);
+  });
+
+  it("falls back to default when PORT is non-numeric", async () => {
+    process.env.PORT = "not-a-number";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+  });
+
+  it("falls back to default when PORT is empty string", async () => {
+    process.env.PORT = "";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.port, 3001);
+  });
+
+  it("treats DISABLE_SANDBOX=1 as true; anything else as false", async () => {
+    process.env.DISABLE_SANDBOX = "1";
+    const a = await loadEnvFresh();
+    assert.equal(a.env.disableSandbox, true);
+
+    process.env.DISABLE_SANDBOX = "true";
+    const b = await loadEnvFresh();
+    assert.equal(b.env.disableSandbox, false, "string 'true' should not flip");
+
+    process.env.DISABLE_SANDBOX = "0";
+    const c = await loadEnvFresh();
+    assert.equal(c.env.disableSandbox, false);
+  });
+
+  it("isProduction reflects NODE_ENV=production", async () => {
+    process.env.NODE_ENV = "production";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.isProduction, true);
+  });
+
+  it("parses CSV env vars (PLUGIN_NAMES / ROLE_IDS)", async () => {
+    process.env.PLUGIN_NAMES = "a,b,c";
+    process.env.ROLE_IDS = "general,office";
+    const { env } = await loadEnvFresh();
+    assert.deepEqual(env.mcpPluginNames, ["a", "b", "c"]);
+    assert.deepEqual(env.mcpRoleIds, ["general", "office"]);
+  });
+
+  it("CSV parsing drops empty segments (so trailing commas don't yield '')", async () => {
+    process.env.PLUGIN_NAMES = "a,,b,";
+    const { env } = await loadEnvFresh();
+    assert.deepEqual(env.mcpPluginNames, ["a", "b"]);
+  });
+
+  it("SESSIONS_LIST_WINDOW_DAYS parses to integer", async () => {
+    process.env.SESSIONS_LIST_WINDOW_DAYS = "30";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.sessionsListWindowDays, 30);
+  });
+});
+
+describe("isGeminiAvailable", () => {
+  it("returns false when GEMINI_API_KEY is unset", async () => {
+    const { isGeminiAvailable } = await loadEnvFresh();
+    assert.equal(isGeminiAvailable(), false);
+  });
+
+  it("returns false when GEMINI_API_KEY is empty string", async () => {
+    process.env.GEMINI_API_KEY = "";
+    const { isGeminiAvailable } = await loadEnvFresh();
+    assert.equal(isGeminiAvailable(), false);
+  });
+
+  it("returns true when GEMINI_API_KEY is set to a non-empty value", async () => {
+    process.env.GEMINI_API_KEY = "fake-key";
+    const { isGeminiAvailable } = await loadEnvFresh();
+    assert.equal(isGeminiAvailable(), true);
+  });
+});
+
+describe("env immutability", () => {
+  it("env is frozen", async () => {
+    const { env } = await loadEnvFresh();
+    assert.equal(Object.isFrozen(env), true);
+  });
+});


### PR DESCRIPTION
## Summary

#289 part 3 を実装。8 ファイルに散らばっていた \`process.env.*\` の参照と各自の型変換 (\`Number(process.env.PORT) || 3001\`, \`process.env.X === "1"\`, …) を \`server/env.ts\` 1 箇所に集約。

## env.ts API

frozen module-level snapshot:

\`\`\`ts
env.port                          // PORT, default 3001
env.nodeEnv                       // "development" / "production" / etc.
env.isProduction                  // derived
env.disableSandbox                // DISABLE_SANDBOX === "1"
env.geminiApiKey                  // string | undefined
env.xBearerToken                  // string | undefined
env.sessionsListWindowDays        // default 90
env.journalForceRunOnStartup      // boolean
env.chatIndexForceRunOnStartup    // boolean
env.mcpSessionId                  // SESSION_ID
env.mcpHost                       // default "localhost"
env.mcpPluginNames                // string[] (CSV)
env.mcpRoleIds                    // string[] (CSV)

isGeminiAvailable()               // derived helper
\`\`\`

## Migrated

- \`server/index.ts\` — PORT / NODE_ENV / DISABLE_SANDBOX / 2 force-run flags / GEMINI_API_KEY
- \`server/docker.ts\` — DISABLE_SANDBOX
- \`server/utils/gemini.ts\` — GEMINI_API_KEY × 2 (re-exports isGeminiAvailable from env.ts so importers don't break)
- \`server/mcp-tools/x.ts\` — X_BEARER_TOKEN
- \`server/routes/agent.ts\` — PORT
- \`server/routes/sessions.ts\` — SESSIONS_LIST_WINDOW_DAYS
- \`server/mcp-server.ts\` — SESSION_ID / PORT / PLUGIN_NAMES / ROLE_IDS / MCP_HOST

## Out of scope

- \`server/logger/config.ts\` の \`resolveConfig(env)\` は自前の env reader を持つ。logger は超 early bootstrap で読まれるため、shared env.ts に通すと circular load risk あり → そのまま温存
- \`bridges/cli/index.ts\` の \`MULMOCLAUDE_API_URL\` は別プロセス(bridge) で env.ts は server 専用なので未対応

## Verification

- \`grep -rn "process\\.env\\." server/ | grep -v env.ts | grep -v logger\` → 0 hits
- \`yarn test\` — 1851/1851 passed (test/server/test_env.ts に 13 新規テスト)
- \`yarn typecheck:server\` / \`yarn lint\` — clean
- 新規 \`as\` キャスト無し

## Test coverage

\`test/server/test_env.ts\`:
- defaults (全項目の値確認)
- coercion: int / flag / CSV
- \`isGeminiAvailable\` (未設定 / 空文字 / 値あり)
- immutability (\`Object.isFrozen\`)
- module re-import で \`process.env\` 変化を反映 (cache-bust 経由)

## Related

- #289 (meta issue) — part 3 of 6
- #284 で workspace パスを集約したのと同じパターン

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated environment variable handling into a centralized configuration system for improved consistency and maintainability across the application.
  * Enhanced the API health endpoint to accurately report Gemini API availability.

* **Tests**
  * Added comprehensive test coverage for environment variable parsing and default value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->