### PR TITLE
refactor(pubsub): central sessionChannel() + PUBSUB_CHANNELS (#289 item 6)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import { isDockerAvailable, ensureSandboxImage } from "./docker.js";
 import { maybeRunJournal } from "./journal/index.js";
 import { backfillAllSessions } from "./chat-index/index.js";
 import { createPubSub } from "./pub-sub/index.js";
+import { PUBSUB_CHANNELS } from "../src/config/pubsubChannels.js";
 import { createTaskManager } from "./task-manager/index.js";
 import type { ITaskManager } from "./task-manager/index.js";
 import type { IPubSub } from "./pub-sub/index.js";
@@ -294,7 +295,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
       tick++;
       const last = tick === 10;
       log.info("debug", `auto-chat countdown ${tick}/10`);
-      pubsub.publish("debug.beat", { count: tick, last });
+      pubsub.publish(PUBSUB_CHANNELS.debugBeat, { count: tick, last });
 
       if (!last) return;
 

--- a/server/session-store/index.ts
+++ b/server/session-store/index.ts
@@ -7,6 +7,10 @@
 import { appendFile, readFile, writeFile } from "fs/promises";
 import path from "path";
 import type { IPubSub } from "../pub-sub/index.js";
+import {
+  PUBSUB_CHANNELS,
+  sessionChannel,
+} from "../../src/config/pubsubChannels.js";
 import { log } from "../logger/index.js";
 import { workspacePath } from "../workspace.js";
 
@@ -260,7 +264,7 @@ function persistHasUnread(chatSessionId: string, hasUnread: boolean): void {
 }
 
 function publishToSessionChannel(chatSessionId: string, data: unknown): void {
-  pubsub?.publish(`session.${chatSessionId}`, data);
+  pubsub?.publish(sessionChannel(chatSessionId), data);
   const listeners = sessionListeners.get(chatSessionId);
   if (listeners) {
     for (const listener of listeners) {
@@ -271,7 +275,7 @@ function publishToSessionChannel(chatSessionId: string, data: unknown): void {
 
 /** Notify all clients that session state has changed — refetch via REST. */
 function notifySessionsChanged(): void {
-  pubsub?.publish("sessions", {});
+  pubsub?.publish(PUBSUB_CHANNELS.sessions, {});
 }
 
 function evictIdleSessions(): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -364,6 +364,7 @@ import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
+import { PUBSUB_CHANNELS, sessionChannel } from "./config/pubsubChannels";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
@@ -379,7 +380,7 @@ const debugTitleStyle = computed(() =>
 );
 
 const { subscribe: pubsubSubscribe } = usePubSub();
-pubsubSubscribe("debug.beat", (data) => {
+pubsubSubscribe(PUBSUB_CHANNELS.debugBeat, (data) => {
   const msg = data as { count: number; last?: boolean };
   if (msg.last) {
     debugBeatColor.value = null;
@@ -393,7 +394,7 @@ pubsubSubscribe("debug.beat", (data) => {
 // bare notification (no data) whenever any session's state changes.
 // The client refetches the session list via REST — the server is the
 // single source of truth for isRunning, hasUnread, etc.
-pubsubSubscribe("sessions", () => {
+pubsubSubscribe(PUBSUB_CHANNELS.sessions, () => {
   refreshSessionStates();
 });
 
@@ -1131,7 +1132,7 @@ function ensureSessionSubscription(
     scrollSidebarToBottom: () => rightSidebarRef.value?.scrollToBottom(),
   };
 
-  const channel = `session.${session.id}`;
+  const channel = sessionChannel(session.id);
   const unsub = pubsubSubscribe(channel, (data) => {
     const event = data as SseEvent;
     if (!event || typeof event !== "object") return;

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -1,0 +1,39 @@
+// Single source of truth for every WebSocket pub/sub channel name
+// the app publishes to or subscribes to. Keeping these in one file
+// means:
+//
+//   - a rename is one edit instead of a grep-and-edit across
+//     server + client
+//   - typo-wise, publisher and subscriber can't drift (both import
+//     the same const / factory)
+//   - a new channel gets declared here first, then wired — the
+//     declaration serves as a lightweight registry / audit list
+//
+// First slice of issue #289 (item 6: pub-sub channels).
+
+/**
+ * Channel for the per-session event stream. One per chat session.
+ * Publishers: `server/session-store/index.ts` (tool results, status,
+ * text chunks, switch-role, session_finished, …).
+ * Subscribers: `src/App.vue` (one subscription per actively-viewed
+ * session).
+ */
+export function sessionChannel(chatSessionId: string): string {
+  return `session.${chatSessionId}`;
+}
+
+/** Static pub/sub channel names. Factories for parameterised channels
+ *  (e.g. `sessionChannel(id)`) live alongside as named helpers. */
+export const PUBSUB_CHANNELS = {
+  /** Sidebar "a session updated, please refetch" notification.
+   *  Publisher: `server/session-store/index.ts#notifySessionsChanged`.
+   *  Subscriber: `src/App.vue`. */
+  sessions: "sessions",
+  /** Server-side debug heartbeat — wired through the task-manager
+   *  demo counter. Useful for sanity-checking that the WS pipe is
+   *  alive end-to-end. */
+  debugBeat: "debug.beat",
+} as const;
+
+export type StaticPubSubChannel =
+  (typeof PUBSUB_CHANNELS)[keyof typeof PUBSUB_CHANNELS];

--- a/test/config/test_pubsubChannels.ts
+++ b/test/config/test_pubsubChannels.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PUBSUB_CHANNELS,
+  sessionChannel,
+} from "../../src/config/pubsubChannels.js";
+
+describe("sessionChannel", () => {
+  it("prefixes the session id with `session.`", () => {
+    assert.equal(sessionChannel("abc"), "session.abc");
+  });
+
+  it("passes the id through verbatim (no encoding / sanitisation)", () => {
+    // chatSessionId is already filesystem-safe upstream; the
+    // factory's job is strictly to prepend the prefix.
+    assert.equal(
+      sessionChannel("my-session-12345"),
+      "session.my-session-12345",
+    );
+    assert.equal(
+      sessionChannel("telegram-999-1713100000"),
+      "session.telegram-999-1713100000",
+    );
+  });
+
+  it("works on an empty id (produces the bare prefix)", () => {
+    // Edge case — not something callers should rely on, but the
+    // factory shouldn't surprise them with a throw.
+    assert.equal(sessionChannel(""), "session.");
+  });
+});
+
+describe("PUBSUB_CHANNELS", () => {
+  it("exposes the sidebar-refresh notification channel", () => {
+    assert.equal(PUBSUB_CHANNELS.sessions, "sessions");
+  });
+
+  it("exposes the debug heartbeat channel", () => {
+    assert.equal(PUBSUB_CHANNELS.debugBeat, "debug.beat");
+  });
+
+  it("static channel names don't collide with the session. prefix", () => {
+    // Defensive: if anyone adds a static channel called "session.X",
+    // it could be confused for a per-session one on the subscriber
+    // side. Keep them disjoint.
+    for (const value of Object.values(PUBSUB_CHANNELS)) {
+      assert.equal(
+        value.startsWith("session."),
+        false,
+        `static channel "${value}" must not reuse the session. prefix`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Item 6 of #289. Pub/sub channel names were scattered free-form strings across publisher (session-store, server/index.ts) and subscriber (App.vue), including the template literal \`\`session.\${chatSessionId}\`\` duplicated between them. Channel renames required multi-file grep-and-edit, and publisher / subscriber could silently drift.

## What changed

### New: \`src/config/pubsubChannels.ts\`

- **\`sessionChannel(chatSessionId)\`** — factory for the per-session channel (\`\`session.\${id}\`\`). Both ends import the same helper so the prefix format can't diverge.
- **\`PUBSUB_CHANNELS\`** const — \`sessions\` (sidebar refresh notification) and \`debugBeat\` (debug heartbeat). Acts as a lightweight registry of every static channel.

### Wired into every call site

| Side | File | Before | After |
|---|---|---|---|
| Publisher | \`server/session-store/index.ts\` | \`\`pubsub?.publish(\`session.\${chatSessionId}\`, data)\`\` | \`pubsub?.publish(sessionChannel(chatSessionId), data)\` |
| Publisher | \`server/session-store/index.ts\` | \`pubsub?.publish(\"sessions\", {})\` | \`pubsub?.publish(PUBSUB_CHANNELS.sessions, {})\` |
| Publisher | \`server/index.ts\` | \`pubsub.publish(\"debug.beat\", ...)\` | \`pubsub.publish(PUBSUB_CHANNELS.debugBeat, ...)\` |
| Subscriber | \`src/App.vue\` | \`pubsubSubscribe(\"debug.beat\", ...)\` | \`pubsubSubscribe(PUBSUB_CHANNELS.debugBeat, ...)\` |
| Subscriber | \`src/App.vue\` | \`pubsubSubscribe(\"sessions\", ...)\` | \`pubsubSubscribe(PUBSUB_CHANNELS.sessions, ...)\` |
| Subscriber | \`src/App.vue\` | \`\`const channel = \`session.\${session.id}\`\`\` | \`const channel = sessionChannel(session.id)\` |

### Tests

- \`test/config/test_pubsubChannels.ts\` (new, 6 cases) — factory contract (prefix format, id passthrough, empty-id edge case) + disjointness check that static channels don't accidentally reuse the \`\`session.\`\` prefix.

No runtime behaviour change — wire format is identical.

## Items to Confirm / Review

- **Static channel naming**: kept \`\"sessions\"\` and \`\"debug.beat\"\` as-is. They're well-known, documented elsewhere, and changing them would require a migration. The disjointness test ensures no static channel can ever collide with \`\`session.\*\`\`.
- **Shared location**: placed in \`src/config/\` (not \`server/\`) because the server imports it via \`../../src/config/…\` — same convention as \`roles.ts\` and \`toolNames.ts\`.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/289の4を対応して。
> つぎは６

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn typecheck:server && yarn build\` — green
- [x] \`yarn test\` — 1844 tests pass (+6 new \`sessionChannel\` / \`PUBSUB_CHANNELS\` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)