### PR TITLE
chore(roles): consolidate built-in role id literals (#289 part 5)

### DIFF
--- a/server/chat-index/indexer.ts
+++ b/server/chat-index/indexer.ts
@@ -24,6 +24,7 @@ import {
   sessionMetaPathFor,
 } from "./paths.js";
 import type { ChatIndexEntry, ChatIndexManifest } from "./types.js";
+import { DEFAULT_ROLE_ID } from "../../src/config/roles.js";
 
 // Freshness throttle: a session whose existing index entry is
 // newer than this is skipped. The 15-minute window is a compromise
@@ -219,7 +220,7 @@ export async function indexSession(
 
   const entry: ChatIndexEntry = {
     id: sessionId,
-    roleId: meta.roleId ?? "general",
+    roleId: meta.roleId ?? DEFAULT_ROLE_ID,
     startedAt: meta.startedAt ?? new Date(now).toISOString(),
     indexedAt: new Date(now).toISOString(),
     title: summary.title,

--- a/server/chat-service/index.ts
+++ b/server/chat-service/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import type { Request, Response } from "express";
 import { log } from "../logger/index.js";
 import { getRole } from "../roles.js";
+import { DEFAULT_ROLE_ID } from "../../src/config/roles.js";
 import { startChat } from "../routes/agent.js";
 import { onSessionEvent } from "../session-store/index.js";
 import {
@@ -61,7 +62,7 @@ router.post(
     // Load or create chat state
     let chatState = await getChatState(transportId, externalChatId);
     if (!chatState) {
-      const defaultRole = getRole("general");
+      const defaultRole = getRole(DEFAULT_ROLE_ID);
       chatState = await resetChatState(
         transportId,
         externalChatId,

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import imageRoutes from "./routes/image.js";
 import presentHtmlRoutes from "./routes/presentHtml.js";
 import chartRoutes from "./routes/chart.js";
 import rolesRoutes from "./routes/roles.js";
+import { DEFAULT_ROLE_ID } from "../src/config/roles.js";
 import mulmoScriptRoutes from "./routes/mulmo-script.js";
 import wikiRoutes from "./routes/wiki.js";
 import pdfRoutes from "./routes/pdf.js";
@@ -303,7 +304,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
       log.info("debug", "starting auto-chat", { chatSessionId });
       const result = await startChat({
         message: "Tell me about this app, MulmoClaude.",
-        roleId: "general",
+        roleId: DEFAULT_ROLE_ID,
         chatSessionId,
       });
       log.info("debug", "auto-chat result", { kind: result.kind });

--- a/src/App.vue
+++ b/src/App.vue
@@ -363,6 +363,7 @@ import { useClickOutside } from "./composables/useClickOutside";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
+import { BUILTIN_ROLE_IDS } from "./config/roles";
 import { usePubSub } from "./composables/usePubSub";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
@@ -987,7 +988,7 @@ function onRoleChange() {
 // (never persisted server-side) — any subsequent LLM tool call will
 // replace / augment it in the normal way.
 async function maybeSeedRoleDefault(session: ActiveSession): Promise<void> {
-  if (session.roleId !== "sourceManager") return;
+  if (session.roleId !== BUILTIN_ROLE_IDS.sourceManager) return;
   try {
     const res = await fetch("/api/sources");
     if (!res.ok) {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -401,7 +401,31 @@ export const ROLES: Role[] = [
 
 export const BUILTIN_ROLES = ROLES;
 
-export const DEFAULT_ROLE_ID = "general";
+// String-literal constants for every built-in role id. Use these
+// instead of inline `"general"` / `"sourceManager"` etc. so that
+// renaming a role id is one place to change and `BuiltInRoleId`
+// catches typos at compile time.
+//
+// Test `test/config/test_roles.ts` asserts these keys/values stay in
+// sync with `ROLES[].id` — adding a new role to ROLES without
+// updating this map fails the test.
+export const BUILTIN_ROLE_IDS = {
+  general: "general",
+  office: "office",
+  guide: "guide",
+  artist: "artist",
+  tutor: "tutor",
+  storyteller: "storyteller",
+  storytellerPlus: "storytellerPlus",
+  musician: "musician",
+  roleManager: "roleManager",
+  sourceManager: "sourceManager",
+} as const;
+
+export type BuiltInRoleId =
+  (typeof BUILTIN_ROLE_IDS)[keyof typeof BUILTIN_ROLE_IDS];
+
+export const DEFAULT_ROLE_ID: BuiltInRoleId = BUILTIN_ROLE_IDS.general;
 
 export function getRole(id: string): Role {
   return ROLES.find((r) => r.id === id) ?? ROLES[0];

--- a/test/roles/test_builtin_role_ids.ts
+++ b/test/roles/test_builtin_role_ids.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ROLES,
+  BUILTIN_ROLE_IDS,
+  DEFAULT_ROLE_ID,
+} from "../../src/config/roles.ts";
+
+// Guards that the literal-id map stays in sync with the actual
+// ROLES array. If someone adds / renames a role in ROLES without
+// updating BUILTIN_ROLE_IDS, these tests fail loudly.
+
+describe("BUILTIN_ROLE_IDS", () => {
+  it("has one entry per ROLES element", () => {
+    const idsFromMap = Object.values(BUILTIN_ROLE_IDS).sort();
+    const idsFromArray = ROLES.map((r) => r.id).sort();
+    assert.deepEqual(idsFromMap, idsFromArray);
+  });
+
+  it("uses the same string for key and value (so refactors are obvious)", () => {
+    for (const [key, value] of Object.entries(BUILTIN_ROLE_IDS)) {
+      assert.equal(
+        key,
+        value,
+        `BUILTIN_ROLE_IDS.${key} should equal "${key}", got "${value}"`,
+      );
+    }
+  });
+
+  it("every BUILTIN_ROLE_IDS value resolves to an actual role via ROLES.find", () => {
+    for (const id of Object.values(BUILTIN_ROLE_IDS)) {
+      const role = ROLES.find((r) => r.id === id);
+      assert.ok(role, `no role found for id "${id}"`);
+    }
+  });
+});
+
+describe("DEFAULT_ROLE_ID", () => {
+  it("is one of the BUILTIN_ROLE_IDS values", () => {
+    const ids = Object.values(BUILTIN_ROLE_IDS) as readonly string[];
+    assert.ok(
+      ids.includes(DEFAULT_ROLE_ID),
+      `DEFAULT_ROLE_ID "${DEFAULT_ROLE_ID}" is not a builtin role id`,
+    );
+  });
+
+  it("resolves to an actual role", () => {
+    const role = ROLES.find((r) => r.id === DEFAULT_ROLE_ID);
+    assert.ok(role, "DEFAULT_ROLE_ID does not match any role in ROLES");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `BUILTIN_ROLE_IDS` map + `BuiltInRoleId` literal-union type in `src/config/roles.ts` so callers reference role ids by typed constant, not by string literal.
- Re-type `DEFAULT_ROLE_ID` as `BuiltInRoleId` (previously `string`).
- Migrate the 4 hardcoded role-id occurrences across the codebase.
- Add a sync test in `test/roles/test_builtin_role_ids.ts` that fails loudly if the map drifts from `ROLES[]`.

## Items to Confirm / Review
- The `BUILTIN_ROLE_IDS` keys mirror the role ids verbatim (key === value). This is intentional so refactors that rename a role surface in both spots, and the sync test enforces it.
- Server-side imports go through `src/config/roles.js` (the existing pattern — `roles.ts` is plain TypeScript that the server bundles). No new module boundary is introduced.
- The test file uses the `.ts` import (`../../src/config/roles.ts`) consistent with existing tests in this repo.
- No new `as` casts.

## User Prompt
> つぎは５
>
> (Continuing #289 — \"Role IDs\" part of the literal-consolidation meta-issue.)

## Implementation
Files migrated (4 inline literals → typed constants):
- `src/App.vue`: `\"sourceManager\"` → `BUILTIN_ROLE_IDS.sourceManager`
- `server/chat-service/index.ts`: `getRole(\"general\")` → `getRole(DEFAULT_ROLE_ID)`
- `server/index.ts`: debug-task `roleId: \"general\"` → `DEFAULT_ROLE_ID`
- `server/chat-index/indexer.ts`: `meta.roleId ?? \"general\"` → `meta.roleId ?? DEFAULT_ROLE_ID`

Drift detector added at `test/roles/test_builtin_role_ids.ts` covers:
- `BUILTIN_ROLE_IDS` keys/values match `ROLES.map(r => r.id)`
- Each key equals its value (so `git grep` for a renamed id finds both spots)
- Every value resolves via `ROLES.find`
- `DEFAULT_ROLE_ID` is in `BUILTIN_ROLE_IDS` and resolves to a real role

## Verification
- \`yarn format\` clean
- \`yarn typecheck\` + \`yarn typecheck:server\` clean
- \`yarn lint\` clean (only pre-existing warnings)
- \`yarn test\` all pass (5 new tests in `test/roles/`)

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)