### PR TITLE
docs: add Centralized Constants guide to CLAUDE.md and developer.md (#289)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 | `server/utils/` | Shared helpers: `fs.ts`, `errors.ts` |
 | `server/logger/` | Structured logger (console + rotating file + telemetry stub) |
 | `server/csrfGuard.ts` | CSRF origin-check middleware |
-| `src/api-routes.ts` | Central `/api/*` endpoint path constants (shared by server + frontend) |
+| `src/config/apiRoutes.ts` | Central `/api/*` endpoint path constants (shared by server + frontend) |
 | `src/config/roles.ts` | Role definitions |
 | `src/tools/index.ts` | Plugin registry |
 | `src/router/index.ts` | Vue-router setup (history mode, route definitions) |
@@ -119,11 +119,11 @@ Import the canonical `TOOL_DEFINITION` directly — **do not copy or re-type the
 3. `src/config/roles.ts` — add to relevant role's `availablePlugins`
 4. `server/agent.ts` — add to `MCP_PLUGINS`
 
-Route handler goes in `server/routes/plugins.ts`. Add the endpoint path to `src/api-routes.ts`.
+Route handler goes in `server/routes/plugins.ts`. Add the endpoint path to `src/config/apiRoutes.ts`.
 
 ### Adding a local plugin (`src/plugins/<name>/`)
 
-Local plugins import Vue components, so `toolDefinition` must be in a **separate file** (`definition.ts`) to allow server-side imports without pulling in Vue. Update **8 places**: `definition.ts`, `index.ts`, `server/routes/<name>.ts`, `server/mcp-server.ts`, `src/tools/index.ts`, `src/config/roles.ts`, `server/agent.ts`, `src/api-routes.ts`.
+Local plugins import Vue components, so `toolDefinition` must be in a **separate file** (`definition.ts`) to allow server-side imports without pulling in Vue. Update **8 places**: `definition.ts`, `index.ts`, `server/routes/<name>.ts`, `server/mcp-server.ts`, `src/tools/index.ts`, `src/config/roles.ts`, `server/agent.ts`, `src/config/apiRoutes.ts`.
 
 > If a plugin is in `availablePlugins` but absent from `MCP_PLUGINS` or `ALL_TOOLS`, it will be silently dropped.
 
@@ -150,13 +150,13 @@ String literals that form cross-module contracts (endpoint paths, event types, t
 
 | What | Source of truth | Pattern |
 |---|---|---|
-| API endpoint paths | `src/api-routes.ts` → `API_ROUTES` | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
+| API endpoint paths | `src/config/apiRoutes.ts` → `API_ROUTES` | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
 | Workspace directories | `server/workspace-paths.ts` → `WORKSPACE_PATHS` | `path.join(WORKSPACE_PATHS.wiki, "pages")` |
 | Tool names | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName` | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]` |
 | Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
 | Pub-sub channels | `src/config/pubsubChannels.ts` → `sessionChannel()` | `pubsub.publish(sessionChannel(id), event)` |
 
-**Adding a new endpoint**: add the path to `src/api-routes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
+**Adding a new endpoint**: add the path to `src/config/apiRoutes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
 
 ## Cross-platform considerations
 
@@ -210,7 +210,7 @@ Key shared helpers in this repo:
 
 | Helper | Location |
 |---|---|
-| `API_ROUTES` | `src/api-routes.ts` |
+| `API_ROUTES` | `src/config/apiRoutes.ts` |
 | `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` |
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 | `server/utils/` | Shared helpers: `fs.ts`, `errors.ts` |
 | `server/logger/` | Structured logger (console + rotating file + telemetry stub) |
 | `server/csrfGuard.ts` | CSRF origin-check middleware |
+| `src/api-routes.ts` | Central `/api/*` endpoint path constants (shared by server + frontend) |
 | `src/config/roles.ts` | Role definitions |
 | `src/tools/index.ts` | Plugin registry |
 | `src/router/index.ts` | Vue-router setup (history mode, route definitions) |
@@ -118,11 +119,11 @@ Import the canonical `TOOL_DEFINITION` directly — **do not copy or re-type the
 3. `src/config/roles.ts` — add to relevant role's `availablePlugins`
 4. `server/agent.ts` — add to `MCP_PLUGINS`
 
-Route handler goes in `server/routes/plugins.ts`.
+Route handler goes in `server/routes/plugins.ts`. Add the endpoint path to `src/api-routes.ts`.
 
 ### Adding a local plugin (`src/plugins/<name>/`)
 
-Local plugins import Vue components, so `toolDefinition` must be in a **separate file** (`definition.ts`) to allow server-side imports without pulling in Vue. Update **7 places**: `definition.ts`, `index.ts`, `server/routes/<name>.ts`, `server/mcp-server.ts`, `src/tools/index.ts`, `src/config/roles.ts`, `server/agent.ts`.
+Local plugins import Vue components, so `toolDefinition` must be in a **separate file** (`definition.ts`) to allow server-side imports without pulling in Vue. Update **8 places**: `definition.ts`, `index.ts`, `server/routes/<name>.ts`, `server/mcp-server.ts`, `src/tools/index.ts`, `src/config/roles.ts`, `server/agent.ts`, `src/api-routes.ts`.
 
 > If a plugin is in `availablePlugins` but absent from `MCP_PLUGINS` or `ALL_TOOLS`, it will be silently dropped.
 
@@ -142,6 +143,20 @@ router.post("/items/:id", (req: Request, res: Response) => { const x = req.body 
 
 - NEVER cast `req.query` — use `typeof req.query.x === "string" ? req.query.x : undefined`
 - Use type annotation (`const data: MyType = JSON.parse(raw)`) instead of `as` cast
+
+## Centralized Constants
+
+String literals that form cross-module contracts (endpoint paths, event types, tool names, role IDs, pub-sub channels, workspace directory names) MUST be defined once in a shared `as const` module and referenced everywhere else. NEVER introduce a new raw string literal for something that already has a constant.
+
+| What | Source of truth | Pattern |
+|---|---|---|
+| API endpoint paths | `src/api-routes.ts` → `API_ROUTES` | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
+| Workspace directories | `server/workspace-paths.ts` → `WORKSPACE_PATHS` | `path.join(WORKSPACE_PATHS.wiki, "pages")` |
+| Tool names | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName` | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]` |
+| Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
+| Pub-sub channels | `src/config/pubsubChannels.ts` → `sessionChannel()` | `pubsub.publish(sessionChannel(id), event)` |
+
+**Adding a new endpoint**: add the path to `src/api-routes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
 
 ## Cross-platform considerations
 
@@ -195,6 +210,11 @@ Key shared helpers in this repo:
 
 | Helper | Location |
 |---|---|
+| `API_ROUTES` | `src/api-routes.ts` |
+| `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` |
+| `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` |
+| `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` |
+| `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` |
 | `resolveWithinRoot(root, relPath)` | `server/utils/fs.ts` |
 | `errorMessage(err)` | `server/utils/errors.ts` |
 | `statSafe` / `readDirSafe` | `server/utils/fs.ts` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ String literals that form cross-module contracts (endpoint paths, event types, t
 | Tool names | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName` | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]` |
 | Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
 | Pub-sub channels | `src/config/pubsubChannels.ts` → `sessionChannel()` | `pubsub.publish(sessionChannel(id), event)` |
+| SSE event types | `src/types/events.ts` → `EVENT_TYPES` / `EventType` | `event.type === EVENT_TYPES.toolCall` |
 
 **Adding a new endpoint**: add the path to `src/config/apiRoutes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
 
@@ -215,6 +216,7 @@ Key shared helpers in this repo:
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` |
 | `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` |
+| `EVENT_TYPES` / `EventType` | `src/types/events.ts` |
 | `resolveWithinRoot(root, relPath)` | `server/utils/fs.ts` |
 | `errorMessage(err)` | `server/utils/errors.ts` |
 | `statSafe` / `readDirSafe` | `server/utils/fs.ts` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ String literals that form cross-module contracts (endpoint paths, event types, t
 | What | Source of truth | Pattern |
 |---|---|---|
 | API endpoint paths | `src/config/apiRoutes.ts` → `API_ROUTES` | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
+| SSE / event types | `src/types/events.ts` → `EVENT_TYPES` / `EventType` | `{ type: EVENT_TYPES.toolResult, ... }` — also used in `AgentEvent` union |
 | Workspace directories | `server/workspace-paths.ts` → `WORKSPACE_PATHS` | `path.join(WORKSPACE_PATHS.wiki, "pages")` |
 | Tool names | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName` | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]` |
 | Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
@@ -212,6 +213,7 @@ Key shared helpers in this repo:
 | Helper | Location |
 |---|---|
 | `API_ROUTES` | `src/config/apiRoutes.ts` |
+| `EVENT_TYPES` / `EventType` | `src/types/events.ts` |
 | `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` |
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` |

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -189,7 +189,7 @@ Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are de
 
 | Constant | Module | Consumers |
 |---|---|---|
-| `API_ROUTES` | `src/api-routes.ts` | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
+| `API_ROUTES` | `src/config/apiRoutes.ts` | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
 | `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` | Every server module that reads or writes workspace files |
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` | Role definitions (`availablePlugins`), plugin registry, session-store tool matching |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` | Anywhere a built-in role ID appears outside the role definition itself |

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -183,6 +183,22 @@ The `configs/` dir is the home for the [web Settings UI](../README.md#configurin
 
 ---
 
+## Centralized constants (`as const` modules)
+
+Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are defined once and imported everywhere. A typo in an import key fails typecheck; a typo in a raw string literal silently produces a runtime 404 or broken channel.
+
+| Constant | Module | Consumers |
+|---|---|---|
+| `API_ROUTES` | `src/api-routes.ts` | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
+| `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` | Every server module that reads or writes workspace files |
+| `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` | Role definitions (`availablePlugins`), plugin registry, session-store tool matching |
+| `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` | Anywhere a built-in role ID appears outside the role definition itself |
+| `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` | Pub-sub publish/subscribe sites in session-store and task-manager |
+
+**Convention**: add new entries to the appropriate module before writing the first consumer. Keep the `as const` assertion so TypeScript infers literal types, not `string`.
+
+---
+
 ## Docker sandbox (`Dockerfile.sandbox`)
 
 Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazily on first Docker-mode run; rebuilt when `Dockerfile.sandbox` changes (image SHA pinned in code). `yarn sandbox:remove` forces a rebuild.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -194,6 +194,7 @@ Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are de
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` | Role definitions (`availablePlugins`), plugin registry, session-store tool matching |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` | Anywhere a built-in role ID appears outside the role definition itself |
 | `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` | Pub-sub publish/subscribe sites in session-store and task-manager |
+| `EVENT_TYPES` / `EventType` | `src/types/events.ts` | SSE event type discriminants in agent loop, session store, and frontend dispatch |
 
 **Convention**: add new entries to the appropriate module before writing the first consumer. Keep the `as const` assertion so TypeScript infers literal types, not `string`.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -190,6 +190,7 @@ Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are de
 | Constant | Module | Consumers |
 |---|---|---|
 | `API_ROUTES` | `src/config/apiRoutes.ts` | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
+| `EVENT_TYPES` / `EventType` | `src/types/events.ts` | SSE stream emitters, pub-sub session events, chat jsonl parsers, `AgentEvent` union discriminators |
 | `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace-paths.ts` | Every server module that reads or writes workspace files |
 | `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` | Role definitions (`availablePlugins`), plugin registry, session-store tool matching |
 | `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` | Anywhere a built-in role ID appears outside the role definition itself |


### PR DESCRIPTION
## Summary

- Adds a **Centralized Constants** section to both `CLAUDE.md` and `docs/developer.md` documenting the 5 `as const` modules: `API_ROUTES`, `WORKSPACE_PATHS`, `TOOL_NAMES`, `BUILTIN_ROLE_IDS`, `PUBSUB_CHANNELS`.
- Updates the Key Files table and shared-helpers table in `CLAUDE.md` to include the new modules.
- Updates Plugin Development checklist from 7 to 8 places (adds `src/api-routes.ts`).
- Doc-only change, no code modifications.

## Items to Confirm / Review

1. This PR assumes `src/api-routes.ts` (PR #296) and Vue-side migration (after #279) will both land. If #296 is dropped, remove `API_ROUTES` from the tables before merging this.
2. The table lists all 5 modules even though items 2 (event types) and 3 (env vars) from #289 haven't landed yet — the modules for those don't exist yet. The table is forward-looking; verify the other PRs land before this doc becomes stale.

## User Prompt

> \`https://github.com/receptron/mulmoclaude/issues/289\` PR含めて進捗を更新するとともに、vueも対応したとして、claude.mdと開発者向けdocumentを更新して、新しいPRを作って。

## Related

- Meta issue: #289
- Progress comment posted: https://github.com/receptron/mulmoclaude/issues/289#issuecomment-4256747289

🤖 Generated with [Claude Code](https://claude.com/claude-code)