### PR TITLE
refactor: centralize SSE/event type literals into EVENT_TYPES

### DIFF
--- a/server/agent.ts
+++ b/server/agent.ts
@@ -25,6 +25,7 @@ import {
   type RawStreamEvent,
 } from "./agent/stream.js";
 import { log } from "./logger/index.js";
+import { EVENT_TYPES } from "../src/types/events.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
 
@@ -92,7 +93,7 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
 
   if (exitCode !== 0) {
     yield {
-      type: "error",
+      type: EVENT_TYPES.error,
       message: stderrOutput || `claude exited with code ${exitCode}`,
     };
   }

--- a/server/agent/stream.ts
+++ b/server/agent/stream.ts
@@ -1,12 +1,23 @@
+import { EVENT_TYPES } from "../../src/types/events.js";
+
 export type AgentEvent =
-  | { type: "status"; message: string }
-  | { type: "text"; message: string }
-  | { type: "tool_result"; result: unknown }
-  | { type: "switch_role"; roleId: string }
-  | { type: "error"; message: string }
-  | { type: "tool_call"; toolUseId: string; toolName: string; args: unknown }
-  | { type: "tool_call_result"; toolUseId: string; content: string }
-  | { type: "claude_session_id"; id: string };
+  | { type: typeof EVENT_TYPES.status; message: string }
+  | { type: typeof EVENT_TYPES.text; message: string }
+  | { type: typeof EVENT_TYPES.toolResult; result: unknown }
+  | { type: typeof EVENT_TYPES.switchRole; roleId: string }
+  | { type: typeof EVENT_TYPES.error; message: string }
+  | {
+      type: typeof EVENT_TYPES.toolCall;
+      toolUseId: string;
+      toolName: string;
+      args: unknown;
+    }
+  | {
+      type: typeof EVENT_TYPES.toolCallResult;
+      toolUseId: string;
+      content: string;
+    }
+  | { type: typeof EVENT_TYPES.claudeSessionId; id: string };
 
 export interface ClaudeContentBlock {
   type: string;
@@ -36,7 +47,7 @@ export interface RawStreamEvent {
 export function blockToEvent(block: ClaudeContentBlock): AgentEvent | null {
   if (block.type === "tool_use" && block.id && block.name) {
     return {
-      type: "tool_call",
+      type: EVENT_TYPES.toolCall,
       toolUseId: block.id,
       toolName: block.name,
       args: block.input,
@@ -51,7 +62,7 @@ export function blockToEvent(block: ClaudeContentBlock): AgentEvent | null {
           ? ""
           : JSON.stringify(raw);
     return {
-      type: "tool_call_result",
+      type: EVENT_TYPES.toolCallResult,
       toolUseId: block.tool_use_id,
       content,
     };
@@ -61,9 +72,14 @@ export function blockToEvent(block: ClaudeContentBlock): AgentEvent | null {
 
 export function parseStreamEvent(event: RawStreamEvent): AgentEvent[] {
   if (event.type === "result" && event.result) {
-    const events: AgentEvent[] = [{ type: "text", message: event.result }];
+    const events: AgentEvent[] = [
+      { type: EVENT_TYPES.text, message: event.result },
+    ];
     if (event.session_id) {
-      events.push({ type: "claude_session_id", id: event.session_id });
+      events.push({
+        type: EVENT_TYPES.claudeSessionId,
+        id: event.session_id,
+      });
     }
     return events;
   }
@@ -78,7 +94,10 @@ export function parseStreamEvent(event: RawStreamEvent): AgentEvent[] {
     : [];
 
   if (event.type === "assistant") {
-    return [{ type: "status", message: "Thinking..." }, ...blockEvents];
+    return [
+      { type: EVENT_TYPES.status, message: "Thinking..." },
+      ...blockEvents,
+    ];
   }
   return blockEvents;
 }

--- a/server/chat-index/summarizer.ts
+++ b/server/chat-index/summarizer.ts
@@ -13,6 +13,7 @@
 // inject their own SummarizeFn via `IndexerDeps.summarize`.
 
 import { spawn } from "node:child_process";
+import { EVENT_TYPES } from "../../src/types/events.js";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
@@ -85,7 +86,7 @@ export function extractText(jsonlContent: string): string {
     const source = entry.source;
     if (
       (source === "user" || source === "assistant") &&
-      entry.type === "text" &&
+      entry.type === EVENT_TYPES.text &&
       typeof entry.message === "string"
     ) {
       parts.push(`[${source}] ${trimMessage(entry.message)}`);

--- a/server/chat-service/index.ts
+++ b/server/chat-service/index.ts
@@ -11,6 +11,7 @@ import {
   connectSession,
 } from "./chat-state.js";
 import { handleCommand } from "./commands.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 const router = Router();
 
@@ -177,17 +178,17 @@ function collectAgentReply(chatSessionId: string): Promise<string> {
     const unsubscribe = onSessionEvent(chatSessionId, (event) => {
       const type = event.type as string;
 
-      if (type === "text") {
+      if (type === EVENT_TYPES.text) {
         textChunks.push(event.message as string);
       }
 
-      if (type === "error") {
+      if (type === EVENT_TYPES.error) {
         clearTimeout(timer);
         unsubscribe();
         resolve(`Error: ${event.message as string}`);
       }
 
-      if (type === "session_finished") {
+      if (type === EVENT_TYPES.sessionFinished) {
         clearTimeout(timer);
         unsubscribe();
         resolve(

--- a/server/journal/dailyPass.ts
+++ b/server/journal/dailyPass.ts
@@ -42,6 +42,7 @@ import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import { writeState, type JournalState } from "./state.js";
 import { readTextOrNull } from "../utils/fs.js";
 import { log } from "../logger/index.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 // --- Constants ------------------------------------------------------
 
@@ -578,7 +579,10 @@ function parseJsonlLine(line: string): Record<string, unknown> | null {
 }
 
 function isMetadataEntry(entry: Record<string, unknown>): boolean {
-  return entry.type === "session_meta" || entry.type === "claude_session_id";
+  return (
+    entry.type === EVENT_TYPES.sessionMeta ||
+    entry.type === EVENT_TYPES.claudeSessionId
+  );
 }
 
 // Collect parsed events into per-date buckets using `fallbackDate`
@@ -644,7 +648,7 @@ export function entryToExcerpt(
   const type = typeof entry.type === "string" ? entry.type : "unknown";
 
   // text entries: {source, type: "text", message}
-  if (type === "text" && typeof entry.message === "string") {
+  if (type === EVENT_TYPES.text && typeof entry.message === "string") {
     return {
       source,
       type,
@@ -656,7 +660,7 @@ export function entryToExcerpt(
   // to avoid a NullPointerException-style crash when accessing
   // r.toolName below.
   if (
-    type === "tool_result" &&
+    type === EVENT_TYPES.toolResult &&
     typeof entry.result === "object" &&
     entry.result !== null
   ) {

--- a/server/routes/agent.ts
+++ b/server/routes/agent.ts
@@ -21,6 +21,7 @@ import { maybeAppendWikiBacklinks } from "../wiki-backlinks/index.js";
 import { log } from "../logger/index.js";
 import { logBackgroundError } from "../utils/logBackgroundError.js";
 import { createArgsCache, recordToolEvent } from "../tool-trace/index.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 const router = Router();
 const PORT = Number(process.env.PORT) || 3001;
@@ -73,7 +74,7 @@ router.post(
   ) => {
     const chatSessionId = String(req.query.session ?? "");
     pushSessionEvent(chatSessionId, {
-      type: "switch_role",
+      type: EVENT_TYPES.switchRole,
       roleId: req.body.roleId,
     });
     res.json({ ok: true });
@@ -170,7 +171,7 @@ export async function startChat(
   // Append user message for this turn
   await appendFile(
     resultsFilePath,
-    JSON.stringify({ source: "user", type: "text", message }) + "\n",
+    JSON.stringify({ source: "user", type: EVENT_TYPES.text, message }) + "\n",
   );
 
   const now = new Date().toISOString();
@@ -187,7 +188,7 @@ export async function startChat(
   // see the input in real time. Must come after getOrCreateSession
   // so the session exists in the store.
   pushSessionEvent(chatSessionId, {
-    type: "text",
+    type: EVENT_TYPES.text,
     source: "user",
     message,
   });
@@ -305,23 +306,23 @@ async function runAgentInBackground(
       claudeSessionId,
       abortSignal,
     )) {
-      if (event.type === "claude_session_id") {
+      if (event.type === EVENT_TYPES.claudeSessionId) {
         await updateClaudeSessionId(metaFilePath, event.id);
         continue;
       }
       pushSessionEvent(chatSessionId, event as Record<string, unknown>);
 
-      if (event.type === "text") {
+      if (event.type === EVENT_TYPES.text) {
         await appendFile(
           resultsFilePath,
           JSON.stringify({
             source: "assistant",
-            type: "text",
+            type: EVENT_TYPES.text,
             message: event.message,
           }) + "\n",
         );
       }
-      if (event.type === "tool_call") {
+      if (event.type === EVENT_TYPES.toolCall) {
         log.info("agent-tool", "call", {
           chatSessionId,
           toolName: event.toolName,
@@ -329,7 +330,7 @@ async function runAgentInBackground(
           argsPreview: previewJson(event.args),
         });
       }
-      if (event.type === "tool_call_result") {
+      if (event.type === EVENT_TYPES.toolCallResult) {
         // Look up the toolName from the cache *before* recordToolEvent
         // runs (it deletes the cache entry on result).
         const cached = toolArgsCache.get(event.toolUseId);
@@ -340,7 +341,10 @@ async function runAgentInBackground(
           contentBytes: event.content.length,
         });
       }
-      if (event.type === "tool_call" || event.type === "tool_call_result") {
+      if (
+        event.type === EVENT_TYPES.toolCall ||
+        event.type === EVENT_TYPES.toolCallResult
+      ) {
         // Fire-and-forget: tool-trace persistence failures must not
         // block the agent loop. Errors are log.warn'd by
         // recordToolEvent itself.
@@ -361,7 +365,10 @@ async function runAgentInBackground(
       chatSessionId,
       error: String(err),
     });
-    pushSessionEvent(chatSessionId, { type: "error", message: String(err) });
+    pushSessionEvent(chatSessionId, {
+      type: EVENT_TYPES.error,
+      message: String(err),
+    });
   } finally {
     endRun(chatSessionId);
     // Fire-and-forget: journal + chat-index post-processing
@@ -400,7 +407,8 @@ async function readClaudeSessionId(
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const entry = JSON.parse(lines[i]);
-        if (entry.type === "claude_session_id" && entry.id) return entry.id;
+        if (entry.type === EVENT_TYPES.claudeSessionId && entry.id)
+          return entry.id;
       } catch {
         // skip malformed lines
       }

--- a/server/routes/roles.ts
+++ b/server/routes/roles.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { loadCustomRoles } from "../roles.js";
 import { BUILTIN_ROLES, type Role } from "../../src/config/roles.js";
 import { pushSessionEvent } from "../session-store/index.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 const rolesDir = path.join(os.homedir(), "mulmoclaude", "roles");
 const BUILTIN_IDS = new Set(BUILTIN_ROLES.map((r) => r.id));
@@ -27,7 +28,7 @@ router.post(
 export default router;
 
 function notifyRolesUpdated(chatSessionId: string): void {
-  pushSessionEvent(chatSessionId, { type: "roles_updated" });
+  pushSessionEvent(chatSessionId, { type: EVENT_TYPES.rolesUpdated });
 }
 
 interface ManageRolesInput {

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -8,6 +8,7 @@ import { readManifest } from "../chat-index/indexer.js";
 import { resolveWithinRoot } from "../utils/fs.js";
 import type { ChatIndexEntry } from "../chat-index/types.js";
 import { markRead, getSession } from "../session-store/index.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 interface SessionMeta {
   roleId: string;
@@ -174,14 +175,14 @@ router.get(
                 const entry = JSON.parse(line);
                 // Skip legacy metadata entries now stored in .json
                 if (
-                  entry.type === "session_meta" ||
-                  entry.type === "claude_session_id"
+                  entry.type === EVENT_TYPES.sessionMeta ||
+                  entry.type === EVENT_TYPES.claudeSessionId
                 )
                   return null;
                 // For presentMulmoScript results, re-read the script from disk
                 if (
                   entry.source === "tool" &&
-                  entry.type === "tool_result" &&
+                  entry.type === EVENT_TYPES.toolResult &&
                   entry.result?.toolName === "presentMulmoScript" &&
                   entry.result?.data?.filePath
                 ) {
@@ -234,7 +235,7 @@ router.get(
       ).filter(Boolean);
       // Prepend metadata as session_meta entry for the frontend
       const result = meta
-        ? [{ type: "session_meta", ...meta }, ...entries]
+        ? [{ type: EVENT_TYPES.sessionMeta, ...meta }, ...entries]
         : entries;
       res.json(result);
     } catch {

--- a/server/session-store/index.ts
+++ b/server/session-store/index.ts
@@ -9,6 +9,7 @@ import path from "path";
 import type { IPubSub } from "../pub-sub/index.js";
 import { log } from "../logger/index.js";
 import { workspacePath } from "../workspace.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -121,7 +122,9 @@ export function endRun(chatSessionId: string): void {
   session.abortRun = undefined;
   session.updatedAt = new Date().toISOString();
   persistHasUnread(chatSessionId, true);
-  publishToSessionChannel(chatSessionId, { type: "session_finished" });
+  publishToSessionChannel(chatSessionId, {
+    type: EVENT_TYPES.sessionFinished,
+  });
   notifySessionsChanged();
 }
 
@@ -161,19 +164,19 @@ export function pushSessionEvent(
 
   const type = event.type as string;
 
-  if (type === "tool_call") {
+  if (type === EVENT_TYPES.toolCall) {
     session.toolCallHistory.push({
       toolUseId: event.toolUseId as string,
       toolName: event.toolName as string,
       args: event.args,
       timestamp: Date.now(),
     });
-  } else if (type === "tool_call_result") {
+  } else if (type === EVENT_TYPES.toolCallResult) {
     const entry = session.toolCallHistory.find(
       (e) => e.toolUseId === event.toolUseId,
     );
     if (entry) entry.result = event.content as string;
-  } else if (type === "status") {
+  } else if (type === EVENT_TYPES.status) {
     session.statusMessage = event.message as string;
     // No notifySessionsChanged() here — status updates are high-frequency
     // and flow to subscribed clients via the session.<id> channel directly.
@@ -196,9 +199,16 @@ export async function pushToolResult(
 
   await appendFile(
     session.resultsFilePath,
-    JSON.stringify({ source: "tool", type: "tool_result", result }) + "\n",
+    JSON.stringify({
+      source: "tool",
+      type: EVENT_TYPES.toolResult,
+      result,
+    }) + "\n",
   );
-  publishToSessionChannel(chatSessionId, { type: "tool_result", result });
+  publishToSessionChannel(chatSessionId, {
+    type: EVENT_TYPES.toolResult,
+    result,
+  });
   return { kind: "processed" };
 }
 

--- a/server/tool-trace/index.ts
+++ b/server/tool-trace/index.ts
@@ -7,16 +7,17 @@ import { appendFile } from "node:fs/promises";
 import { log } from "../logger/index.js";
 import { WEB_SEARCH_TOOL_NAME, classifyToolResult } from "./classify.js";
 import { writeSearchResult } from "./writeSearch.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
 
 export interface ToolCallEvent {
-  type: "tool_call";
+  type: typeof EVENT_TYPES.toolCall;
   toolUseId: string;
   toolName: string;
   args: unknown;
 }
 
 export interface ToolCallResultEvent {
-  type: "tool_call_result";
+  type: typeof EVENT_TYPES.toolCallResult;
   toolUseId: string;
   content: string;
 }
@@ -53,7 +54,7 @@ export async function recordToolEvent(
   deps: RecordToolEventDeps,
 ): Promise<void> {
   try {
-    if (event.type === "tool_call") {
+    if (event.type === EVENT_TYPES.toolCall) {
       await handleToolCall(event, deps);
       return;
     }
@@ -78,7 +79,7 @@ async function handleToolCall(
   const now = (deps.now ?? (() => new Date()))();
   const record = {
     source: "tool",
-    type: "tool_call",
+    type: EVENT_TYPES.toolCall,
     toolUseId: event.toolUseId,
     toolName: event.toolName,
     args: event.args,
@@ -194,7 +195,7 @@ async function handleToolCallResult(
 
   const base = {
     source: "tool",
-    type: "tool_call_result",
+    type: EVENT_TYPES.toolCallResult,
     toolUseId: event.toolUseId,
     toolName,
     ts: now.toISOString(),

--- a/src/App.vue
+++ b/src/App.vue
@@ -341,6 +341,7 @@ import {
   type SessionEntry,
   type ActiveSession,
 } from "./types/session";
+import { EVENT_TYPES } from "./types/events";
 import { extractImageData, makeTextResult } from "./utils/tools/result";
 import {
   roleIcon as roleIconLookup,
@@ -1052,7 +1053,7 @@ async function loadSession(id: string) {
   if (!res.ok) return;
   const entries: SessionEntry[] = await res.json();
 
-  const meta = entries.find((e) => e.type === "session_meta");
+  const meta = entries.find((e) => e.type === EVENT_TYPES.sessionMeta);
   const roleId = meta?.roleId ?? currentRoleId.value;
   const toolResultsList = parseSessionEntries(entries);
   const urlResult =
@@ -1141,7 +1142,7 @@ function ensureSessionSubscription(
     // we receive events if another tab starts a new run. Only
     // unsubscribe sessions the user is NOT currently viewing — the
     // watch(currentSessionId) handler cleans up when switching away.
-    if (event.type === "session_finished") {
+    if (event.type === EVENT_TYPES.sessionFinished) {
       if (currentSessionId.value === session.id) {
         markSessionRead(session.id);
       } else {
@@ -1185,7 +1186,7 @@ async function applyAgentEvent(
 ): Promise<void> {
   const { session, runStartIndex } = ctx;
   switch (event.type) {
-    case "tool_call":
+    case EVENT_TYPES.toolCall:
       session.toolCallHistory.push({
         toolUseId: event.toolUseId,
         toolName: event.toolName,
@@ -1194,7 +1195,7 @@ async function applyAgentEvent(
       });
       ctx.scrollSidebarToBottom();
       return;
-    case "tool_call_result": {
+    case EVENT_TYPES.toolCallResult: {
       const entry = findPendingToolCall(
         session.toolCallHistory,
         event.toolUseId,
@@ -1203,19 +1204,19 @@ async function applyAgentEvent(
       ctx.scrollSidebarToBottom();
       return;
     }
-    case "status":
+    case EVENT_TYPES.status:
       session.statusMessage = event.message;
       return;
-    case "switch_role":
+    case EVENT_TYPES.switchRole:
       setTimeout(() => {
         ctx.setCurrentRoleId(event.roleId);
         ctx.onRoleChange();
       }, 0);
       return;
-    case "roles_updated":
+    case EVENT_TYPES.rolesUpdated:
       await ctx.refreshRoles();
       return;
-    case "text": {
+    case EVENT_TYPES.text: {
       const source = event.source ?? "assistant";
       if (source === "user") {
         // The tab that sent the message already added it locally via
@@ -1241,7 +1242,7 @@ async function applyAgentEvent(
       }
       return;
     }
-    case "tool_result": {
+    case EVENT_TYPES.toolResult: {
       const { result } = event;
       const existing = session.toolResults.findIndex(
         (r) => r.uuid === result.uuid,
@@ -1254,11 +1255,11 @@ async function applyAgentEvent(
       }
       return;
     }
-    case "error":
+    case EVENT_TYPES.error:
       console.error("[agent] error event:", event.message);
       pushErrorMessage(session, event.message);
       return;
-    case "session_finished":
+    case EVENT_TYPES.sessionFinished:
       // Handled in the subscription callback — no-op here.
       return;
   }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,39 @@
+// Single source of truth for the event / entry `type` discriminators
+// used across SSE streams, pub-sub session channels, and on-disk
+// chat jsonl entries. Before this module, these strings were
+// baked into ~200 inline literals — renaming any of them was a
+// grep-and-edit across frontend + backend + tests, and a typo
+// would silently misroute events without any typecheck failure.
+//
+// Part of the scatter-cleanup work tracked in #289. This file is
+// safe to import from both the Vue frontend and the Node server
+// since it's plain TypeScript with no runtime dependencies.
+
+// The `as const` assertion makes each value its own literal type so
+// `EVENT_TYPES.toolResult` has type `"tool_result"`, not `string`.
+// That preserves TypeScript's discriminated-union narrowing at call
+// sites that check `event.type === EVENT_TYPES.toolResult`.
+export const EVENT_TYPES = {
+  // Agent-run lifecycle + streaming payloads (SSE channel).
+  status: "status",
+  text: "text",
+  toolCall: "tool_call",
+  toolCallResult: "tool_call_result",
+  toolResult: "tool_result",
+  switchRole: "switch_role",
+  error: "error",
+  claudeSessionId: "claude_session_id",
+  sessionFinished: "session_finished",
+  // Legacy / on-disk only — chat jsonl used to inline metadata as a
+  // first-line entry. New sessions store this in `<id>.json` instead
+  // but the parser still has to skip stale entries in old files.
+  sessionMeta: "session_meta",
+  // Broadcast when the Role Manager creates / edits / deletes a
+  // custom role, so every open tab can refresh its role palette.
+  rolesUpdated: "roles_updated",
+} as const;
+
+// Union of every event-type string defined above. Use this as the
+// type of the discriminator field on event / entry records so the
+// constant and the union stay in lockstep.
+export type EventType = (typeof EVENT_TYPES)[keyof typeof EVENT_TYPES];

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -2,6 +2,7 @@
 // returned by the server's session routes.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { EVENT_TYPES } from "./events";
 import type { ToolCallHistoryItem } from "./toolCallHistory";
 
 // Server `/api/sessions` summary. Optional `summary` and `keywords`
@@ -40,23 +41,25 @@ export interface SessionEntry {
 
 export interface TextEntry extends SessionEntry {
   source: "user" | "assistant";
-  type: "text";
+  type: typeof EVENT_TYPES.text;
   message: string;
 }
 
 export interface ToolResultEntry extends SessionEntry {
   source: "tool";
-  type: "tool_result";
+  type: typeof EVENT_TYPES.toolResult;
   result: ToolResultComplete;
 }
 
 export const isTextEntry = (e: SessionEntry): e is TextEntry =>
   (e.source === "user" || e.source === "assistant") &&
-  e.type === "text" &&
+  e.type === EVENT_TYPES.text &&
   typeof e.message === "string";
 
 export const isToolResultEntry = (e: SessionEntry): e is ToolResultEntry =>
-  e.source === "tool" && e.type === "tool_result" && e.result !== undefined;
+  e.source === "tool" &&
+  e.type === EVENT_TYPES.toolResult &&
+  e.result !== undefined;
 
 // In-memory session held in `sessionMap`. PR #88 introduced this so
 // multiple chats can run concurrently — `id` matches the `chatSessionId`

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -3,53 +3,54 @@
 // session's state.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { EVENT_TYPES } from "./events";
 
 export interface SseToolCall {
-  type: "tool_call";
+  type: typeof EVENT_TYPES.toolCall;
   toolUseId: string;
   toolName: string;
   args: unknown;
 }
 
 export interface SseToolCallResult {
-  type: "tool_call_result";
+  type: typeof EVENT_TYPES.toolCallResult;
   toolUseId: string;
   content: string;
 }
 
 export interface SseStatus {
-  type: "status";
+  type: typeof EVENT_TYPES.status;
   message: string;
 }
 
 export interface SseSwitchRole {
-  type: "switch_role";
+  type: typeof EVENT_TYPES.switchRole;
   roleId: string;
 }
 
 export interface SseText {
-  type: "text";
+  type: typeof EVENT_TYPES.text;
   message: string;
   source?: "user" | "assistant";
 }
 
 export interface SseToolResult {
-  type: "tool_result";
+  type: typeof EVENT_TYPES.toolResult;
   result: ToolResultComplete;
 }
 
 export interface SseRolesUpdated {
-  type: "roles_updated";
+  type: typeof EVENT_TYPES.rolesUpdated;
 }
 
 export interface SseError {
-  type: "error";
+  type: typeof EVENT_TYPES.error;
   message: string;
 }
 
 /** Sent on the session channel when the agent run finishes. */
 export interface SseSessionFinished {
-  type: "session_finished";
+  type: typeof EVENT_TYPES.sessionFinished;
 }
 
 export type SseEvent =

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -12,6 +12,7 @@ import {
   type SessionEntry,
   type SessionSummary,
 } from "../../types/session";
+import { EVENT_TYPES } from "../../types/events";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 // Walk the server's session entries and produce the flat
@@ -24,7 +25,7 @@ export function parseSessionEntries(
 ): ToolResultComplete[] {
   const out: ToolResultComplete[] = [];
   for (const entry of entries) {
-    if (entry.type === "session_meta") continue;
+    if (entry.type === EVENT_TYPES.sessionMeta) continue;
     if (isTextEntry(entry)) {
       out.push(makeTextResult(entry.message, entry.source));
     } else if (isToolResultEntry(entry)) {


### PR DESCRIPTION
## Summary

Addresses item (2) of #289. Introduces `src/types/events.ts` with a single `EVENT_TYPES` const object, then replaces scattered string literals (`"tool_call"`, `"session_finished"`, `"roles_updated"`, etc.) across 14 production files with imports from this constant. All type interfaces (`SseEvent`, `AgentEvent`, `SessionEntry`) now use `typeof EVENT_TYPES.xxx` for their discriminant fields.

## Items to Confirm / Review

- Test files and E2E fixtures intentionally keep string literals for assertion readability — they verify the emitted string values match expectations
- `server/agent/stream.ts:56` (`block.type === "tool_result"`) is the Claude API wire format, **not** our event type — left as-is
- `src/plugins/presentMulmoScript/helpers.ts` uses a separate SSE protocol (`beat_image_done`, `done`, `error`) for movie generation — not part of this refactor

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/289 2をすすめて。

## Changes

| File | What changed |
|---|---|
| `src/types/events.ts` | **New** — `EVENT_TYPES` const + `EventType` union |
| `server/agent/stream.ts` | `AgentEvent` union + `blockToEvent` / `parseStreamEvent` |
| `src/types/sse.ts` | All `Sse*` interface type fields |
| `src/types/session.ts` | `TextEntry` / `ToolResultEntry` + type guards |
| `server/session-store/index.ts` | `pushSessionEvent` dispatch + `endRun` |
| `server/routes/agent.ts` | Event consumption loop + user message emit |
| `server/routes/sessions.ts` | jsonl metadata filtering |
| `server/routes/roles.ts` | `roles_updated` push |
| `server/tool-trace/index.ts` | `ToolCallEvent` / `ToolCallResultEvent` interfaces + record writes |
| `server/chat-service/index.ts` | Event listener dispatch |
| `server/chat-index/summarizer.ts` | jsonl text entry check |
| `server/journal/dailyPass.ts` | Metadata filter + `entryToExcerpt` |
| `server/agent.ts` | Error yield on non-zero exit |
| `src/App.vue` | `loadSession` meta find + `applyAgentEvent` switch |
| `src/utils/session/sessionEntries.ts` | `session_meta` skip |

Closes item (2) of #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)