### PR TITLE
fix: address bot review comments from PR #285

### DIFF
--- a/test/utils/test_file.ts
+++ b/test/utils/test_file.ts
@@ -65,7 +65,7 @@ describe("writeFileAtomic", () => {
     assert.ok(fs.existsSync(p));
   });
 
-  it("uses `${path}.tmp` by default and cleans it up on success", async () => {
+  it("uses a .tmp suffix by default and cleans it up on success", async () => {
     const p = path.join(tmpDir, "out.txt");
     await writeFileAtomic(p, "hello");
     assert.ok(!fs.existsSync(`${p}.tmp`), "tmp file should not remain");
@@ -93,18 +93,10 @@ describe("writeFileAtomic", () => {
 
   it("leaves the existing target untouched if the tmp write fails", async () => {
     const p = path.join(tmpDir, "out.txt");
-    // Pre-existing file with known contents.
     fs.writeFileSync(p, "ORIGINAL");
-    // Force a failure by making the parent directory read-only would
-    // be brittle across platforms. Instead simulate by passing a
-    // giant mode bit that's invalid — but node accepts that. Use a
-    // path-outside-existing-dir-after-mkdir trick instead: write to
-    // a path whose tmp parent we first delete between mkdir and
-    // writeFile — complex. Simplest test: assert happy-path
-    // overwrite works (partial-failure handling is covered by the
-    // unlink-on-throw contract in the code, verified visually).
-    await writeFileAtomic(p, "NEW");
-    assert.equal(fs.readFileSync(p, "utf-8"), "NEW");
+    fs.mkdirSync(`${p}.tmp`);
+    await assert.rejects(writeFileAtomic(p, "NEW"));
+    assert.equal(fs.readFileSync(p, "utf-8"), "ORIGINAL");
   });
 
   it("overwrites an existing file atomically", async () => {


### PR DESCRIPTION
## Summary

- **Test failure-path fix**: The test "leaves the existing target untouched if the tmp write fails" was testing the happy path (successful overwrite), not the failure path. Now injects a real failure by pre-creating the `.tmp` path as a directory (causes EISDIR), then asserts the original file is preserved.
- **CodeQL fix**: Removed `${path}.tmp` template-literal syntax from a plain string test description — replaced with `"uses a .tmp suffix by default..."`.

## Items to Confirm / Review

- The failure injection technique (`mkdirSync` on the tmp path) works cross-platform: EISDIR on POSIX, EPERM on Windows — both cause `writeFile` to throw.

## Bot comments addressed

| Comment | Source | Action |
|---|---|---|
| Test name/behavior diverge in tmp-write-failure case | CodeRabbit | Fixed — real failure injection |
| Template syntax in string literal (CodeQL) | github-code-quality | Fixed — rewording |
| `readJsonOrNull` should return discriminated union | CodeRabbit (nitpick) | Skipped — zero production callers; designing for hypothetical needs |
| Sourcery rate-limited | Sourcery | Skipped — no review content |

## User Prompt

PR #285 のボットレビューコメントを確認し、未対応のものを修正する。

## Test plan

- [x] `npx tsx --test test/utils/test_file.ts` — 16/16 pass
- [x] `yarn format` / `yarn lint` / `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)