### PR TITLE
chore(api-routes): migrate Vue client fetch calls to API_ROUTES (#289 part 1)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -380,6 +380,7 @@ import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import { apiGet, apiPost, apiFetchRaw } from "./utils/api";
+import { API_ROUTES } from "./config/apiRoutes";
 
 // --- Debug beat (pub/sub) ---
 const debugBeatColor = ref<string | null>(null);
@@ -424,7 +425,7 @@ async function refreshSessionStates(): Promise<void> {
 
 async function markSessionRead(id: string): Promise<void> {
   const result = await apiPost<{ ok: boolean }>(
-    `/api/sessions/${encodeURIComponent(id)}/mark-read`,
+    API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(id)),
   );
   // The server returns `{ ok: boolean }` — a 200 with `ok: false`
   // means the endpoint was reached but the flag wasn't actually
@@ -735,28 +736,28 @@ const LAUNCHER_INVOKE_SPECS: Record<
   }
 > = {
   todos: {
-    endpoint: "/api/todos",
+    endpoint: API_ROUTES.todos.dispatch,
     method: "POST",
     body: { action: "show" },
     toolName: "manageTodoList",
     defaultTitle: "Todos",
   },
   scheduler: {
-    endpoint: "/api/scheduler",
+    endpoint: API_ROUTES.scheduler.base,
     method: "POST",
     body: { action: "show" },
     toolName: "manageScheduler",
     defaultTitle: "Schedule",
   },
   skills: {
-    endpoint: "/api/skills",
+    endpoint: API_ROUTES.skills.list,
     method: "GET",
     toolName: "manageSkills",
     defaultTitle: "Skills",
     wrapData: (json) => ({ skills: json.skills ?? [] }),
   },
   wiki: {
-    endpoint: "/api/wiki",
+    endpoint: API_ROUTES.wiki.base,
     method: "POST",
     body: { action: "index" },
     toolName: "manageWiki",
@@ -1108,7 +1109,9 @@ function onRoleChange() {
 // replace / augment it in the normal way.
 async function maybeSeedRoleDefault(session: ActiveSession): Promise<void> {
   if (session.roleId !== BUILTIN_ROLE_IDS.sourceManager) return;
-  const response = await apiGet<{ sources?: unknown[] }>("/api/sources");
+  const response = await apiGet<{ sources?: unknown[] }>(
+    API_ROUTES.sources.list,
+  );
   if (!response.ok) {
     // Non-fatal: the Add / Rebuild buttons remain reachable via
     // chat as soon as the user sends any message. Still surface
@@ -1160,7 +1163,9 @@ async function loadSession(id: string) {
   }
 
   // Load from server
-  const response = await apiGet<SessionEntry[]>(`/api/sessions/${id}`);
+  const response = await apiGet<SessionEntry[]>(
+    API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(id)),
+  );
   if (!response.ok) return;
   const entries = response.data;
 
@@ -1397,7 +1402,7 @@ async function sendMessage(text?: string) {
   ensureSessionSubscription(session, runStartIndex);
 
   try {
-    const response = await apiFetchRaw("/api/agent", {
+    const response = await apiFetchRaw(API_ROUTES.agent.run, {
       method: "POST",
       body: JSON.stringify(
         buildAgentRequestBody({

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -238,6 +238,7 @@ import { useExpandedDirs } from "../composables/useExpandedDirs";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
 import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
@@ -497,7 +498,7 @@ const recentPaths = computed(() => {
 });
 
 function rawUrl(filePath: string): string {
-  return `/api/files/raw?path=${encodeURIComponent(filePath)}`;
+  return `${API_ROUTES.files.raw}?path=${encodeURIComponent(filePath)}`;
 }
 
 function formatBytes(bytes: number): string {
@@ -529,7 +530,7 @@ async function loadDirChildren(path: string): Promise<void> {
   next.set(path, null);
   childrenByPath.value = next;
 
-  const result = await apiGet<TreeNode>("/api/files/dir", { path });
+  const result = await apiGet<TreeNode>(API_ROUTES.files.dir, { path });
   if (!result.ok) {
     // Drop the `null` marker so the user can retry (e.g. via the
     // refresh-token watcher). Keep the error visible too.
@@ -589,7 +590,7 @@ async function loadContent(filePath: string): Promise<void> {
   contentError.value = null;
   content.value = null;
   const result = await apiGet<FileContent>(
-    "/api/files/content",
+    API_ROUTES.files.content,
     { path: filePath },
     { signal: controller.signal },
   );

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -142,6 +142,7 @@ import { computed, ref, watch } from "vue";
 import SettingsMcpTab from "./SettingsMcpTab.vue";
 import type { McpServerEntry } from "./SettingsMcpTab.vue";
 import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
 
 interface Props {
   open: boolean;
@@ -207,7 +208,7 @@ async function loadConfig(): Promise<void> {
   const response = await apiGet<{
     settings: { extraAllowedTools: string[] };
     mcp?: { servers: McpServerEntry[] };
-  }>("/api/config");
+  }>(API_ROUTES.config.base);
   // A newer open() has already started another load — drop this one.
   if (token !== loadToken) return;
   if (!response.ok) {
@@ -241,7 +242,7 @@ async function save(): Promise<void> {
   statusError.value = false;
   // Single atomic endpoint — avoids the partial-save state where
   // extraAllowedTools is persisted but MCP config write fails.
-  const response = await apiPut<unknown>("/api/config", {
+  const response = await apiPut<unknown>(API_ROUTES.config.base, {
     settings: { extraAllowedTools: parsedToolNames.value },
     mcp: { servers: mcpServers.value },
   });

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -8,6 +8,7 @@
 // doesn't momentarily flash "sandbox disabled" on a transient error.
 
 import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
 import { apiGet } from "../utils/api";
 
 interface HealthResponse {
@@ -24,7 +25,7 @@ export function useHealth(): {
   const sandboxEnabled = ref(true);
 
   async function fetchHealth(): Promise<void> {
-    const result = await apiGet<HealthResponse>("/api/health");
+    const result = await apiGet<HealthResponse>(API_ROUTES.health);
     if (!result.ok) {
       geminiAvailable.value = false;
       return;

--- a/src/composables/useMcpTools.ts
+++ b/src/composables/useMcpTools.ts
@@ -5,6 +5,7 @@
 // independently of fetch / Vue.
 
 import { computed, ref, type ComputedRef } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
 import type { Role } from "../config/roles";
 import {
   availableToolsFor,
@@ -53,7 +54,7 @@ export function useMcpTools(opts: UseMcpToolsOptions) {
   }
 
   async function fetchMcpToolsStatus(): Promise<void> {
-    const result = await apiGet<McpToolStatus[]>("/api/mcp-tools");
+    const result = await apiGet<McpToolStatus[]>(API_ROUTES.mcpTools.list);
     // Ignore failures and unexpected shapes — all tools remain visible
     // if anything goes wrong. The Array.isArray guard makes explicit
     // the previous behaviour (a try/catch used to silently swallow a

--- a/src/composables/usePdfDownload.ts
+++ b/src/composables/usePdfDownload.ts
@@ -9,6 +9,7 @@
 // below the download button.
 
 import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
 import { apiFetchRaw } from "../utils/api";
 import { errorMessage } from "../utils/errors";
 
@@ -32,7 +33,7 @@ export function usePdfDownload(): UsePdfDownloadHandle {
     try {
       // PDF endpoint returns a binary blob, not JSON — use the raw
       // Response escape hatch so we can call `.blob()` ourselves.
-      const response = await apiFetchRaw("/api/pdf/markdown", {
+      const response = await apiFetchRaw(API_ROUTES.pdf.markdown, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ markdown, filename }),

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -4,6 +4,7 @@
 // independently.
 
 import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
 import { ROLES, type Role } from "../config/roles";
 import { mergeRoles } from "../utils/role/merge";
 import { apiGet } from "../utils/api";
@@ -22,7 +23,7 @@ export function useRoles(): {
   );
 
   async function refreshRoles(): Promise<void> {
-    const result = await apiGet<Role[]>("/api/roles");
+    const result = await apiGet<Role[]>(API_ROUTES.roles.list);
     if (!result.ok) {
       // Keep the current role list on failure — losing custom roles
       // is preferable to crashing the UI on a transient API hiccup.

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -7,6 +7,7 @@
 // sidebar title cache stays fresh.
 
 import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
 import type { SessionSummary } from "../types/session";
 import { apiGet } from "../utils/api";
 
@@ -20,7 +21,7 @@ export function useSessionHistory(): {
   const showHistory = ref(false);
 
   async function fetchSessions(): Promise<SessionSummary[]> {
-    const result = await apiGet<SessionSummary[]>("/api/sessions");
+    const result = await apiGet<SessionSummary[]>(API_ROUTES.sessions.list);
     if (!result.ok) {
       sessions.value = [];
       return [];

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -110,6 +110,7 @@ import VueDrawingCanvas from "vue-drawing-canvas";
 import type { ToolResult } from "gui-chat-protocol/vue";
 import type { ImageToolData, CanvasDrawingState } from "./definition";
 import { apiPost, apiPut } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{
   selectedResult: ToolResult<ImageToolData> | null;
@@ -271,16 +272,19 @@ const saveDrawingState = async (): Promise<boolean> => {
       ? await (async () => {
           const filename = boundImagePath.replace(/^images\//, "");
           const result = await apiPut<{ path: string }>(
-            `/api/images/${filename}`,
+            API_ROUTES.image.update.replace(":filename", filename),
             { imageData: imageDataUri },
           );
           if (!result.ok) throw new Error(`PUT failed: ${result.error}`);
           return result.data.path;
         })()
       : await (async () => {
-          const result = await apiPost<{ path: string }>("/api/images", {
-            imageData: imageDataUri,
-          });
+          const result = await apiPost<{ path: string }>(
+            API_ROUTES.image.upload,
+            {
+              imageData: imageDataUri,
+            },
+          );
           if (!result.ok) throw new Error(`POST failed: ${result.error}`);
           return result.data.path;
         })();

--- a/src/plugins/canvas/index.ts
+++ b/src/plugins/canvas/index.ts
@@ -5,13 +5,14 @@ import type { ImageToolData } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const canvasPlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<ImageToolData>>(
-      "/api/canvas",
+      API_ROUTES.plugins.canvas,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/chart/index.ts
+++ b/src/plugins/chart/index.ts
@@ -4,6 +4,7 @@ import toolDefinition, { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface ChartEntry {
   title?: string;
@@ -27,7 +28,7 @@ const presentChartPlugin: ToolPlugin<PresentChartData> = {
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<PresentChartData>>(
-      "/api/present-chart",
+      API_ROUTES.chart.present,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/editImage/index.ts
+++ b/src/plugins/editImage/index.ts
@@ -5,13 +5,14 @@ import type { ImageToolData } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const editImagePlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<ImageToolData>>(
-      "/api/edit-image",
+      API_ROUTES.image.edit,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/generateImage/index.ts
+++ b/src/plugins/generateImage/index.ts
@@ -5,6 +5,7 @@ import type { ImageToolData } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 function createUploadedImageResult(
   imageData: string,
@@ -24,7 +25,7 @@ const generateImagePlugin: ToolPlugin<ImageToolData> = {
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<ImageToolData>>(
-      "/api/generate-image",
+      API_ROUTES.image.generate,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/manageRoles/Preview.vue
+++ b/src/plugins/manageRoles/Preview.vue
@@ -28,12 +28,13 @@ import { ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageRolesData, CustomRole } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{ result: ToolResultComplete<ManageRolesData> }>();
 const customRoles = ref<CustomRole[]>(props.result.data?.customRoles ?? []);
 
 const { refresh } = useFreshPluginData<CustomRole[]>({
-  endpoint: () => "/api/roles",
+  endpoint: () => API_ROUTES.roles.list,
   extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
   apply: (data) => {
     customRoles.value = data;

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -186,6 +186,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { CustomRole, ManageRolesData } from "./index";
 import { getAllPluginNames } from "../../tools/index";
 import { apiGet, apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 interface PluginEntry {
   name: string;
@@ -202,7 +203,7 @@ const guiPlugins: PluginEntry[] = getAllPluginNames()
 const availablePlugins = ref<PluginEntry[]>(guiPlugins);
 
 onMounted(async () => {
-  const result = await apiGet<PluginEntry[]>("/api/mcp-tools");
+  const result = await apiGet<PluginEntry[]>(API_ROUTES.mcpTools.list);
   if (result.ok) {
     availablePlugins.value = [...guiPlugins, ...result.data];
   }
@@ -221,7 +222,7 @@ const customRoles = ref<CustomRole[]>(
 );
 
 const { refresh: refreshCustomRoles } = useFreshPluginData<CustomRole[]>({
-  endpoint: () => "/api/roles",
+  endpoint: () => API_ROUTES.roles.list,
   extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
   apply: (data) => {
     customRoles.value = data;
@@ -289,7 +290,7 @@ interface ManageResult {
 async function callManage(
   body: Record<string, unknown>,
 ): Promise<ManageResult> {
-  const result = await apiPost<ManageResult>("/api/roles/manage", body);
+  const result = await apiPost<ManageResult>(API_ROUTES.roles.manage, body);
   if (!result.ok) {
     // Prefer the backend's error message (e.g. validation failure
     // details). Fall back to a status code only when the server didn't

--- a/src/plugins/manageRoles/index.ts
+++ b/src/plugins/manageRoles/index.ts
@@ -5,6 +5,7 @@ import { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface CustomRole {
   id: string;
@@ -23,7 +24,7 @@ const manageRolesPlugin: ToolPlugin = {
   toolDefinition,
   async execute(_context, args) {
     const result = await apiPost<ToolResult<ManageRolesData>>(
-      "/api/roles/manage",
+      API_ROUTES.roles.manage,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -105,6 +105,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
 import { apiGet, apiDelete } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 interface SkillDetail {
   name: string;
@@ -158,7 +159,7 @@ watch(
     detailLoading.value = true;
     detailError.value = null;
     const response = await apiGet<{ skill: SkillDetail }>(
-      `/api/skills/${encodeURIComponent(name)}`,
+      API_ROUTES.skills.detail.replace(":name", encodeURIComponent(name)),
     );
     if (selectedName.value !== name) {
       // Selection changed while this request was in flight — drop it.
@@ -202,7 +203,7 @@ async function deleteSkill(): Promise<void> {
   }
   deleting.value = true;
   const result = await apiDelete<unknown>(
-    `/api/skills/${encodeURIComponent(name)}`,
+    API_ROUTES.skills.remove.replace(":name", encodeURIComponent(name)),
   );
   deleting.value = false;
   if (!result.ok) {

--- a/src/plugins/manageSkills/index.ts
+++ b/src/plugins/manageSkills/index.ts
@@ -3,6 +3,7 @@ import toolDefinition, { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiGet } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface SkillSummary {
   name: string;
@@ -20,7 +21,9 @@ const manageSkillsPlugin: ToolPlugin<ManageSkillsData> = {
     // Claude invokes this tool to show the user their skills list.
     // The server exposes GET /api/skills (discovery + merge); we just
     // shape it for the View component.
-    const result = await apiGet<{ skills: SkillSummary[] }>("/api/skills");
+    const result = await apiGet<{ skills: SkillSummary[] }>(
+      API_ROUTES.skills.list,
+    );
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,

--- a/src/plugins/manageSource/View.vue
+++ b/src/plugins/manageSource/View.vue
@@ -272,6 +272,7 @@ import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSourceData, RebuildSummary, Source } from "./index";
 import { apiGet, apiPost, apiDelete } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<ManageSourceData>;
@@ -429,7 +430,7 @@ async function commitAdd(): Promise<void> {
   }
   draftError.value = "";
   busy.value = "add";
-  const response = await apiPost<unknown>("/api/sources", payload);
+  const response = await apiPost<unknown>(API_ROUTES.sources.create, payload);
   if (!response.ok) {
     draftError.value = response.error || "Failed to register source";
     busy.value = null;
@@ -531,7 +532,7 @@ async function installPreset(preset: Preset): Promise<void> {
   }
   const failures: string[] = [];
   for (const entry of toRegister) {
-    const response = await apiPost<unknown>("/api/sources", {
+    const response = await apiPost<unknown>(API_ROUTES.sources.create, {
       slug: entry.slug,
       title: entry.title,
       url: entry.url,
@@ -564,7 +565,7 @@ async function installPreset(preset: Preset): Promise<void> {
 // Rebuild step extracted so commitAdd can chain it without recursing
 // into rebuild()'s own busy-state machine.
 async function rebuildInline(): Promise<void> {
-  const response = await apiPost<RebuildSummary>("/api/sources/rebuild");
+  const response = await apiPost<RebuildSummary>(API_ROUTES.sources.rebuild);
   if (!response.ok) {
     flash(`Register succeeded but rebuild failed: ${response.error}`, true);
     return;
@@ -654,7 +655,7 @@ function flash(message: string, isError = false): void {
 }
 
 async function refreshList(): Promise<void> {
-  const response = await apiGet<{ sources: Source[] }>("/api/sources");
+  const response = await apiGet<{ sources: Source[] }>(API_ROUTES.sources.list);
   if (!response.ok) {
     flash(`Failed to refresh sources: ${response.error}`, true);
     return;
@@ -666,7 +667,7 @@ async function remove(slug: string): Promise<void> {
   if (!confirm(`Remove source "${slug}"?`)) return;
   busy.value = slug;
   const response = await apiDelete<unknown>(
-    `/api/sources/${encodeURIComponent(slug)}`,
+    API_ROUTES.sources.remove.replace(":slug", encodeURIComponent(slug)),
   );
   busy.value = null;
   if (!response.ok) {
@@ -679,7 +680,7 @@ async function remove(slug: string): Promise<void> {
 
 async function rebuild(): Promise<void> {
   busy.value = "rebuild";
-  const response = await apiPost<RebuildSummary>("/api/sources/rebuild");
+  const response = await apiPost<RebuildSummary>(API_ROUTES.sources.rebuild);
   if (!response.ok) {
     flash(`Rebuild failed: ${response.error}`, true);
     busy.value = null;
@@ -735,7 +736,7 @@ async function loadBrief(isoDate: string): Promise<void> {
   const relPath = dailyPathFor(isoDate);
   briefFilePath.value = relPath;
   const response = await apiGet<{ content?: string; kind?: string }>(
-    "/api/files/content",
+    API_ROUTES.files.content,
     { path: relPath },
   );
   if (token !== briefLoadToken) return;

--- a/src/plugins/manageSource/index.ts
+++ b/src/plugins/manageSource/index.ts
@@ -4,6 +4,7 @@ import toolDefinition, { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 // Mirrors server/sources/types.ts#Source. Re-declared here so the
 // frontend doesn't have to import a server package.
@@ -42,7 +43,7 @@ const manageSourcePlugin: ToolPlugin<ManageSourceData> = {
   toolDefinition,
   async execute(_context, args) {
     const result = await apiPost<ToolResult<ManageSourceData>>(
-      "/api/sources/manage",
+      API_ROUTES.sources.manage,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -18,6 +18,7 @@ import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { extractFirstH1 } from "../../utils/markdown/extractFirstH1";
 import { apiGet } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{
   result: ToolResult<MarkdownToolData>;
@@ -31,7 +32,7 @@ async function fetchContent(): Promise<void> {
     fetchedContent.value = "";
     return;
   }
-  const result = await apiGet<{ content?: string }>("/api/files/content", {
+  const result = await apiGet<{ content?: string }>(API_ROUTES.files.content, {
     path: raw,
   });
   if (!result.ok) {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -91,6 +91,7 @@ import { isFilePath, type MarkdownToolData } from "./definition";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { apiGet, apiPut } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
 const props = defineProps<{
@@ -119,9 +120,12 @@ async function fetchMarkdownContent(): Promise<void> {
   }
   if (isFilePath(raw)) {
     loading.value = true;
-    const result = await apiGet<{ content?: string }>("/api/files/content", {
-      path: raw,
-    });
+    const result = await apiGet<{ content?: string }>(
+      API_ROUTES.files.content,
+      {
+        path: raw,
+      },
+    );
     if (!result.ok) {
       console.error("Failed to fetch markdown:", result.error);
       markdownContent.value = "";
@@ -226,9 +230,12 @@ async function applyMarkdown() {
   if (isFilePath(raw)) {
     saving.value = true;
     const filename = raw.replace(/^markdowns\//, "");
-    const result = await apiPut<unknown>(`/api/markdowns/${filename}`, {
-      markdown: editableMarkdown.value,
-    });
+    const result = await apiPut<unknown>(
+      API_ROUTES.plugins.updateMarkdown.replace(":filename", filename),
+      {
+        markdown: editableMarkdown.value,
+      },
+    );
     saving.value = false;
     if (!result.ok) {
       saveError.value = `Save failed: ${result.error}`;

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -5,13 +5,14 @@ import type { MarkdownToolData } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const markdownPlugin: ToolPlugin<MarkdownToolData> = {
   toolDefinition,
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<MarkdownToolData>>(
-      "/api/present-document",
+      API_ROUTES.plugins.presentDocument,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/presentHtml/index.ts
+++ b/src/plugins/presentHtml/index.ts
@@ -4,6 +4,7 @@ import toolDefinition, { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface PresentHtmlData {
   html: string;
@@ -16,7 +17,7 @@ const presentHtmlPlugin: ToolPlugin<PresentHtmlData> = {
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<PresentHtmlData>>(
-      "/api/present-html",
+      API_ROUTES.html.present,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -26,7 +26,7 @@
         <!-- Download Movie -->
         <a
           v-if="moviePath && !movieGenerating"
-          :href="`/api/mulmo-script/download-movie?moviePath=${encodeURIComponent(moviePath)}`"
+          :href="`${downloadMovieBase}?moviePath=${encodeURIComponent(moviePath)}`"
           download
           class="px-3 py-1 text-xs rounded-full border transition-colors border-gray-200 text-gray-500 hover:bg-gray-50 flex items-center justify-center gap-1"
         >
@@ -575,6 +575,7 @@ import {
   validateBeatJSON,
 } from "./helpers";
 import { apiGet, apiPost, apiFetchRaw } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
@@ -613,6 +614,10 @@ const data = computed(() => props.selectedResult.data);
 const script = computed<MulmoScript>(() => data.value?.script ?? {});
 const filePath = computed(() => data.value?.filePath ?? "");
 const beats = computed<Beat[]>(() => script.value.beats ?? []);
+
+// Exposed to the template so the `<a :href="...">` download button
+// can compose a query-string URL without inlining the API path.
+const downloadMovieBase = API_ROUTES.mulmoScript.downloadMovie;
 
 // Per-beat render state
 type RenderState = "idle" | "rendering" | "done" | "error";
@@ -740,7 +745,7 @@ async function onSourceToggle(open: boolean) {
     // Read the current file from disk so beat-level edits are reflected
     if (filePath.value) {
       const response = await apiGet<{ content?: string }>(
-        "/api/files/content",
+        API_ROUTES.files.content,
         { path: filePath.value },
       );
       if (response.ok && response.data.content) {
@@ -765,7 +770,7 @@ async function applySource() {
     alert(extractErrorMessage(err));
     return;
   }
-  const response = await apiPost<unknown>("/api/mulmo-script/update-script", {
+  const response = await apiPost<unknown>(API_ROUTES.mulmoScript.updateScript, {
     filePath: filePath.value,
     script: parsed,
   });
@@ -820,7 +825,7 @@ async function updateBeat(index: number) {
 
   delete beatSaveErrors[index];
   beatSaving[index] = true;
-  const response = await apiPost<unknown>("/api/mulmo-script/update-beat", {
+  const response = await apiPost<unknown>(API_ROUTES.mulmoScript.updateBeat, {
     filePath: filePath.value,
     beatIndex: index,
     beat,
@@ -843,7 +848,7 @@ async function updateBeat(index: number) {
 async function renderBeat(index: number) {
   renderState[index] = "rendering";
   const response = await apiPost<{ image?: string; error?: string }>(
-    "/api/mulmo-script/render-beat",
+    API_ROUTES.mulmoScript.renderBeat,
     { filePath: filePath.value, beatIndex: index },
   );
   if (!response.ok) {
@@ -865,7 +870,7 @@ async function regenerateBeat(index: number) {
   delete renderedImages[index];
   renderState[index] = "rendering";
   const response = await apiPost<{ image?: string; error?: string }>(
-    "/api/mulmo-script/render-beat",
+    API_ROUTES.mulmoScript.renderBeat,
     { filePath: filePath.value, beatIndex: index, force: true },
   );
   if (!response.ok) {
@@ -884,7 +889,7 @@ async function regenerateBeat(index: number) {
 
 async function loadExistingBeatImage(index: number) {
   const response = await apiGet<{ image?: string }>(
-    "/api/mulmo-script/beat-image",
+    API_ROUTES.mulmoScript.beatImage,
     { filePath: filePath.value, beatIndex: String(index) },
   );
   // silently ignore errors — image simply hasn't been generated yet
@@ -896,7 +901,7 @@ async function loadExistingBeatImage(index: number) {
 
 async function loadExistingBeatAudio(index: number) {
   const response = await apiGet<{ audio?: string }>(
-    "/api/mulmo-script/beat-audio",
+    API_ROUTES.mulmoScript.beatAudio,
     { filePath: filePath.value, beatIndex: String(index) },
   );
   // silently ignore errors
@@ -910,7 +915,7 @@ async function generateAudio(index: number) {
   audioState[index] = "generating";
   delete audioErrors[index];
   const response = await apiPost<{ audio?: string; error?: string }>(
-    "/api/mulmo-script/generate-beat-audio",
+    API_ROUTES.mulmoScript.generateBeatAudio,
     { filePath: filePath.value, beatIndex: index },
   );
   if (!response.ok) {
@@ -988,7 +993,7 @@ async function onBeatDrop(event: DragEvent, index: number) {
     return;
   }
   const response = await apiPost<{ image?: string; error?: string }>(
-    "/api/mulmo-script/upload-beat-image",
+    API_ROUTES.mulmoScript.uploadBeatImage,
     { filePath: filePath.value, beatIndex: index, imageData },
   );
   if (!response.ok) {
@@ -1037,7 +1042,7 @@ async function onCharDrop(event: DragEvent, key: string) {
     return;
   }
   const response = await apiPost<{ image?: string; error?: string }>(
-    "/api/mulmo-script/upload-character-image",
+    API_ROUTES.mulmoScript.uploadCharacterImage,
     { filePath: filePath.value, key, imageData },
   );
   if (!response.ok) {
@@ -1069,7 +1074,7 @@ function openCharacterLightbox(key: string) {
 
 async function loadExistingCharacterImage(key: string) {
   const response = await apiGet<{ image?: string }>(
-    "/api/mulmo-script/character-image",
+    API_ROUTES.mulmoScript.characterImage,
     { filePath: filePath.value, key },
   );
   // silently ignore errors
@@ -1091,7 +1096,7 @@ async function renderCharacter(key: string, force: boolean) {
   charRenderState[key] = "rendering";
   delete charErrors[key];
   const response = await apiPost<{ image?: string; error?: string }>(
-    "/api/mulmo-script/render-character",
+    API_ROUTES.mulmoScript.renderCharacter,
     { filePath: filePath.value, key, force },
   );
   if (!response.ok) {
@@ -1159,7 +1164,7 @@ async function initializeScript() {
 
   if (filePath.value) {
     const response = await apiGet<{ moviePath?: string }>(
-      "/api/mulmo-script/movie-status",
+      API_ROUTES.mulmoScript.movieStatus,
       { filePath: filePath.value },
     );
     if (response.ok && response.data.moviePath) {
@@ -1175,7 +1180,7 @@ watch(() => props.selectedResult, initializeScript);
 async function generateMovie() {
   movieGenerating.value = true;
   try {
-    const res = await apiFetchRaw("/api/mulmo-script/generate-movie", {
+    const res = await apiFetchRaw(API_ROUTES.mulmoScript.generateMovie, {
       method: "POST",
       body: JSON.stringify({ filePath: filePath.value }),
       headers: { "Content-Type": "application/json" },

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -5,6 +5,7 @@ import toolDefinition, { TOOL_NAME } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface MulmoScriptData {
   script: MulmoScript;
@@ -16,7 +17,7 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<MulmoScriptData>>(
-      "/api/mulmo-script",
+      API_ROUTES.mulmoScript.save,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/scheduler/Preview.vue
+++ b/src/plugins/scheduler/Preview.vue
@@ -23,13 +23,14 @@ import { computed, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SchedulerData, ScheduledItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{ result: ToolResultComplete<SchedulerData> }>();
 
 const items = ref<ScheduledItem[]>(props.result.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
-  endpoint: () => "/api/scheduler",
+  endpoint: () => API_ROUTES.scheduler.base,
   extract: (json) => {
     const v = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
     return Array.isArray(v) ? v : null;

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -336,6 +336,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SchedulerData, ScheduledItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 type YamlScalar = string | number | boolean | null;
 
@@ -347,7 +348,7 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const items = ref<ScheduledItem[]>(props.selectedResult.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
-  endpoint: () => "/api/scheduler",
+  endpoint: () => API_ROUTES.scheduler.base,
   extract: (json) => {
     const v = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
     return Array.isArray(v) ? v : null;
@@ -629,7 +630,7 @@ const isModified = computed(() => editorText.value !== toJson(items.value));
 
 async function callApi(body: Record<string, unknown>): Promise<boolean> {
   const response = await apiPost<{ data?: { items?: ScheduledItem[] } }>(
-    "/api/scheduler",
+    API_ROUTES.scheduler.base,
     body,
   );
   if (!response.ok) return false;

--- a/src/plugins/scheduler/index.ts
+++ b/src/plugins/scheduler/index.ts
@@ -4,6 +4,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface ScheduledItem {
   id: string;
@@ -21,7 +22,7 @@ const schedulerPlugin: ToolPlugin<SchedulerData> = {
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<SchedulerData>>(
-      "/api/scheduler",
+      API_ROUTES.scheduler.base,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -146,6 +146,7 @@ import { applyCellHighlights, clearCellHighlights } from "./cellHighlights";
 // Import all spreadsheet functions to populate the function registry
 import "./engine/functions";
 import { apiGet, apiPut } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 import type { FilesContentResponseLike } from "./engine/responseDecoder";
 
 /**
@@ -235,7 +236,7 @@ async function fetchSheets(): Promise<void> {
   }
   loading.value = true;
   const response = await apiGet<FilesContentResponseLike>(
-    "/api/files/content",
+    API_ROUTES.files.content,
     { path: raw },
   );
   if (!response.ok) {
@@ -267,9 +268,12 @@ async function persistSheets(sheets: SpreadsheetSheet[]): Promise<void> {
   const raw = props.selectedResult.data?.sheets;
   if (isFilePath(raw)) {
     const filename = raw.replace(/^spreadsheets\//, "");
-    const result = await apiPut<unknown>(`/api/spreadsheets/${filename}`, {
-      sheets,
-    });
+    const result = await apiPut<unknown>(
+      API_ROUTES.plugins.updateSpreadsheet.replace(":filename", filename),
+      {
+        sheets,
+      },
+    );
     if (!result.ok) {
       errorMessage.value = `Failed to save spreadsheet: ${result.error}`;
       return;

--- a/src/plugins/spreadsheet/index.ts
+++ b/src/plugins/spreadsheet/index.ts
@@ -5,13 +5,14 @@ import type { SpreadsheetToolData } from "./definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const spreadsheetPlugin: ToolPlugin<SpreadsheetToolData> = {
   toolDefinition,
 
   async execute(_context, args) {
     const result = await apiPost<ToolResult<SpreadsheetToolData>>(
-      "/api/present-spreadsheet",
+      API_ROUTES.plugins.presentSpreadsheet,
       args,
     );
     if (!result.ok) {

--- a/src/plugins/todo/Preview.vue
+++ b/src/plugins/todo/Preview.vue
@@ -36,6 +36,7 @@ import { computed, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { API_ROUTES } from "../../config/apiRoutes";
 import { colorForLabel } from "./labels";
 
 const props = defineProps<{ result: ToolResultComplete<TodoData> }>();
@@ -43,7 +44,7 @@ const props = defineProps<{ result: ToolResultComplete<TodoData> }>();
 const items = ref<TodoItem[]>(props.result.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<TodoItem[]>({
-  endpoint: () => "/api/todos",
+  endpoint: () => API_ROUTES.todos.list,
   extract: (json) => {
     const v = (json as { data?: { items?: TodoItem[] } }).data?.items;
     return Array.isArray(v) ? v : null;

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -158,6 +158,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 import {
   colorForLabel,
   filterByLabels,
@@ -173,7 +174,7 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const items = ref<TodoItem[]>(props.selectedResult.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<TodoItem[]>({
-  endpoint: () => "/api/todos",
+  endpoint: () => API_ROUTES.todos.list,
   extract: (json) => {
     const v = (json as { data?: { items?: TodoItem[] } }).data?.items;
     return Array.isArray(v) ? v : null;
@@ -412,7 +413,7 @@ async function applyItemEdit() {
 
 async function callApi(body: Record<string, unknown>): Promise<boolean> {
   const response = await apiPost<{ data?: { items?: TodoItem[] } }>(
-    "/api/todos",
+    API_ROUTES.todos.dispatch,
     body,
   );
   if (!response.ok) return false;

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -9,6 +9,7 @@
 // action route is intentionally NOT used by the explorer.
 
 import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../../../config/apiRoutes";
 import { useFreshPluginData } from "../../../composables/useFreshPluginData";
 import { errorMessage } from "../../../utils/errors";
 import type { StatusColumn, TodoItem } from "../index";
@@ -123,7 +124,7 @@ export function useTodos(
     items: TodoItem[];
     columns: StatusColumn[];
   }>({
-    endpoint: () => "/api/todos",
+    endpoint: () => API_ROUTES.todos.list,
     extract: (json) => {
       const i = extractItems(json);
       const c = extractColumns(json);
@@ -195,30 +196,34 @@ export function useTodos(
     columns,
     error,
     refresh,
-    createItem: (input) => call("/api/todos/items", jsonInit("POST", input)),
+    createItem: (input) =>
+      call(API_ROUTES.todos.items, jsonInit("POST", input)),
     patchItem: (id, input) =>
       call(
-        `/api/todos/items/${encodeURIComponent(id)}`,
+        API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)),
         jsonInit("PATCH", input),
       ),
     moveItem: (id, input) =>
       call(
-        `/api/todos/items/${encodeURIComponent(id)}/move`,
+        API_ROUTES.todos.itemMove.replace(":id", encodeURIComponent(id)),
         jsonInit("POST", input),
       ),
     deleteItem: (id) =>
-      call(`/api/todos/items/${encodeURIComponent(id)}`, { method: "DELETE" }),
-    addColumn: (input) => call("/api/todos/columns", jsonInit("POST", input)),
+      call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)), {
+        method: "DELETE",
+      }),
+    addColumn: (input) =>
+      call(API_ROUTES.todos.columns, jsonInit("POST", input)),
     patchColumn: (id, input) =>
       call(
-        `/api/todos/columns/${encodeURIComponent(id)}`,
+        API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)),
         jsonInit("PATCH", input),
       ),
     deleteColumn: (id) =>
-      call(`/api/todos/columns/${encodeURIComponent(id)}`, {
+      call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)), {
         method: "DELETE",
       }),
     reorderColumns: (ids) =>
-      call("/api/todos/columns/order", jsonInit("PUT", { ids })),
+      call(API_ROUTES.todos.columnsOrder, jsonInit("PUT", { ids })),
   };
 }

--- a/src/plugins/todo/index.ts
+++ b/src/plugins/todo/index.ts
@@ -4,6 +4,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export type TodoPriority = "low" | "medium" | "high" | "urgent";
 
@@ -36,7 +37,10 @@ const todoPlugin: ToolPlugin<TodoData> = {
   toolDefinition,
 
   async execute(_context, args) {
-    const result = await apiPost<ToolResult<TodoData>>("/api/todos", args);
+    const result = await apiPost<ToolResult<TodoData>>(
+      API_ROUTES.todos.dispatch,
+      args,
+    );
     if (!result.ok) {
       return {
         toolName: "manageTodoList",

--- a/src/plugins/wiki/Preview.vue
+++ b/src/plugins/wiki/Preview.vue
@@ -20,6 +20,7 @@ import { computed, ref, watch } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 const props = defineProps<{ result: ToolResultComplete<WikiData> }>();
 
@@ -28,7 +29,7 @@ const title = ref(props.result.data?.title ?? "Wiki");
 const pageEntries = ref<WikiPageEntry[]>(props.result.data?.pageEntries ?? []);
 
 const { refresh } = useFreshPluginData<WikiData>({
-  endpoint: () => "/api/wiki",
+  endpoint: () => API_ROUTES.wiki.base,
   extract: (json) => (json as { data?: WikiData }).data ?? null,
   apply: (data) => {
     // Bug fix (CodeRabbit V1 #6): /api/wiki (no slug) always

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -142,6 +142,7 @@ import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { renderWikiLinks } from "./helpers";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { apiPost, apiFetchRaw } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
 
 const props = defineProps<{
@@ -163,7 +164,9 @@ const { refresh } = useFreshPluginData<WikiData>({
   endpoint: () => {
     const slug =
       action.value === "page" ? props.selectedResult.data?.pageName : undefined;
-    return slug ? `/api/wiki?slug=${encodeURIComponent(slug)}` : "/api/wiki";
+    return slug
+      ? `${API_ROUTES.wiki.base}?slug=${encodeURIComponent(slug)}`
+      : API_ROUTES.wiki.base;
   },
   extract: (json) => (json as { data?: WikiData }).data ?? null,
   apply: (data) => {
@@ -213,7 +216,7 @@ async function callApi(body: Record<string, unknown>) {
       content?: string;
       pageEntries?: WikiPageEntry[];
     };
-  }>("/api/wiki", body);
+  }>(API_ROUTES.wiki.base, body);
   if (!response.ok) {
     navError.value =
       response.status === 0
@@ -247,7 +250,7 @@ async function downloadPdf() {
   pdfDownloading.value = true;
   let response: Response;
   try {
-    response = await apiFetchRaw("/api/pdf/markdown", {
+    response = await apiFetchRaw(API_ROUTES.pdf.markdown, {
       method: "POST",
       body: JSON.stringify({
         markdown: content.value,

--- a/src/plugins/wiki/index.ts
+++ b/src/plugins/wiki/index.ts
@@ -4,6 +4,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 export interface WikiPageEntry {
   title: string;
@@ -23,7 +24,10 @@ const wikiPlugin: ToolPlugin<WikiData> = {
   toolDefinition,
 
   async execute(_context, args) {
-    const result = await apiPost<ToolResult<WikiData>>("/api/wiki", args);
+    const result = await apiPost<ToolResult<WikiData>>(
+      API_ROUTES.wiki.base,
+      args,
+    );
     if (!result.ok) {
       // Return an error ToolResult instead of throwing so execute()
       // stays symmetric with every other plugin in this repo. Callers

--- a/src/utils/image/resolve.ts
+++ b/src/utils/image/resolve.ts
@@ -1,6 +1,8 @@
+import { API_ROUTES } from "../../config/apiRoutes";
+
 /** Convert an imageData value to a displayable URL.
  *  Handles both legacy data URIs and workspace-relative file paths. */
 export function resolveImageSrc(imageData: string): string {
   if (imageData.startsWith("data:")) return imageData;
-  return `/api/files/raw?path=${encodeURIComponent(imageData)}`;
+  return `${API_ROUTES.files.raw}?path=${encodeURIComponent(imageData)}`;
 }


### PR DESCRIPTION
## Summary
- 73 hardcoded \`\"/api/...\"\` strings in src/ replaced with \`API_ROUTES.x.y\` references from \`src/config/apiRoutes\`.
- 39 files touched (composables, components, App.vue, 14 plugin \`index.ts\`, 9 plugin \`View.vue\`, 4 plugin \`Preview.vue\`, \`src/utils/image/resolve.ts\`).
- Completes the client-side portion of #289 part 1. Server side was done in #296.

## Items to Confirm / Review
- **Express-style params** (\`:id\` / \`:filename\` / \`:tool\` / \`:name\` / \`:slug\`) are resolved inline via \`.replace(\":id\", encodeURIComponent(id))\` — no helper abstraction added. Rationale: matches issue #289's stated plan (\"Client-side URL builders are deliberately NOT added here until the frontend migration lands\").
- **Query-string sub-paths** not modeled in \`API_ROUTES\` (e.g. \`wiki.base?slug=...\`, \`files.raw?path=...\`) use template literals combining the known base with the extension. Did not fabricate new \`API_ROUTES\` entries for query variants.
- **\`src/utils/image/rewriteMarkdownImageRefs.ts\` intentionally untouched** — its \`\"/api/\"\` is a \`url.startsWith(\"/api/\")\` guard against arbitrary markdown image URLs, not an endpoint reference.
- **Vue SFC constants**: \`presentMulmoScript/View.vue\` exposes \`downloadMovieBase = API_ROUTES.mulmoScript.downloadMovie\` as a script-block constant for use in a template \`<a :href>\` binding (Vue templates can't directly import).
- No new \`as\` casts; all imports are relative per repo convention.

## User Prompt
> https://github.com/receptron/mulmoclaude/issues/289 1のvue部分がまだだよね。対応して

## Verification
- \`yarn format\` clean
- \`yarn typecheck\` clean
- \`yarn lint\` 0 errors (6 pre-existing warnings, none introduced by this PR)
- \`yarn build\` success
- \`yarn test\` 1931/1931 pass
- \`grep -rn '\"/api/' src/ --include=\"*.ts\" --include=\"*.vue\" | grep -v apiRoutes.ts\` → only documentation comments + the intentional substring guard above

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized API endpoint configuration across the app to standardize network routing; no changes to UI behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->