### PR TITLE
refactor(chat-service): DI middleware factory for future extraction (#269)

### DIFF
--- a/plans/refactor-chat-service-middleware.md
+++ b/plans/refactor-chat-service-middleware.md
@@ -1,0 +1,123 @@
+# Refactor chat-service to a DI middleware factory (#269 / #305)
+
+## Goal
+
+Keep `server/chat-service/` inside the mulmoclaude repo for now, but make it shaped exactly like a future standalone npm package (`@mulmoclaude/chat-service`). Nothing inside the module should import from the host app — all host-specific behaviour (startChat, session subscription, role lookup, workspace dir, logger) is passed in via a `ChatServiceDeps` interface.
+
+**Load-bearing rule**: once the refactor lands, the chat-service directory is frozen against "just add another import from `../routes/…` or `../roles.js`". Every new dependency MUST be added to `ChatServiceDeps` and threaded through `createChatService(deps)`. This is called out at the top of each chat-service file via a `@package-contract` header comment so future contributors (human or agent) do not silently break the extractability invariant.
+
+## Today's import surface (to be replaced with DI)
+
+`server/chat-service/index.ts`:
+
+- `../logger/index.js` → `log`
+- `../roles.js` → `getRole`
+- `../../src/config/roles.js` → `DEFAULT_ROLE_ID`
+- `../routes/agent.js` → `startChat`, `StartChatParams`, `StartChatResult`
+- `../session-store/index.js` → `onSessionEvent`
+- `../utils/httpError.js` → `badRequest`, `notFound`
+- `../../src/config/apiRoutes.js` → `API_ROUTES`
+- `../../src/types/events.js` → `EVENT_TYPES`
+
+`server/chat-service/chat-state.ts`:
+
+- `../workspace-paths.js` → `WORKSPACE_PATHS.transports`
+- `../logger/index.js` → `log`
+
+`server/chat-service/commands.ts`:
+
+- `../roles.js` → `getRole`, `loadAllRoles`
+- `./chat-state.js` → `resetChatState`
+
+## After the refactor
+
+New `ChatServiceDeps` interface (in `server/chat-service/types.ts`):
+
+```ts
+export interface ChatServiceDeps {
+  startChat: (params: StartChatParams) => Promise<StartChatResult>;
+  onSessionEvent: (sessionId: string, listener: SessionEventListener) => () => void;
+  loadAllRoles: () => Role[];
+  getRole: (roleId: string) => Role;
+  defaultRoleId: string;
+  transportsDir: string;
+  logger: Logger;
+}
+```
+
+`StartChatParams` / `StartChatResult` / `SessionEventListener` / `Role` / `Logger` are re-declared as structural types in `server/chat-service/types.ts` so the module can eventually be extracted without importing from the host app's types.
+
+`server/chat-service/index.ts` exports:
+
+```ts
+export function createChatService(deps: ChatServiceDeps): Router { ... }
+```
+
+`chat-state.ts` becomes a factory:
+
+```ts
+export function createChatState(opts: { transportsDir: string; logger: Logger }) {
+  return { getChatState, setChatState, resetChatState, connectSession, generateSessionId };
+}
+```
+
+`commands.ts` becomes a factory:
+
+```ts
+export function createCommandHandler(opts: {
+  loadAllRoles: () => Role[];
+  getRole: (id: string) => Role;
+  resetChatState: ResetChatStateFn;
+}) {
+  return { handleCommand };
+}
+```
+
+`server/index.ts` wires everything up:
+
+```ts
+import { createChatService } from "./chat-service/index.js";
+import { startChat } from "./routes/agent.js";
+import { onSessionEvent } from "./session-store/index.js";
+import { getRole, loadAllRoles } from "./roles.js";
+import { DEFAULT_ROLE_ID } from "../src/config/roles.js";
+import { WORKSPACE_PATHS } from "./workspace-paths.js";
+import { log } from "./logger/index.js";
+
+app.use(
+  createChatService({
+    startChat,
+    onSessionEvent,
+    loadAllRoles,
+    getRole,
+    defaultRoleId: DEFAULT_ROLE_ID,
+    transportsDir: WORKSPACE_PATHS.transports,
+    logger: log,
+  }),
+);
+```
+
+## Files touched
+
+- **new** `server/chat-service/types.ts` — `ChatServiceDeps` + structural types
+- **edit** `server/chat-service/index.ts` — factory, keep routes unchanged
+- **edit** `server/chat-service/chat-state.ts` — factory accepting `{ transportsDir, logger }`
+- **edit** `server/chat-service/commands.ts` — factory accepting `{ loadAllRoles, getRole, resetChatState }`
+- **edit** `server/index.ts` — build deps, mount via factory
+- each chat-service file gets a `@package-contract` header comment
+
+## Behaviour
+
+No functional change. Same routes, same payloads, same logging prefix, same timeout. Unit tests (none exist for chat-service today) can now inject stubs; adding coverage is a follow-up PR.
+
+## Non-goals
+
+- npm publish — deferred
+- Moving the module out of the repo — deferred
+- Adding WebSocket support — blocked on this (#268 sits on top)
+
+## Verification
+
+- `yarn typecheck` / `yarn typecheck:server` / `yarn test` / `yarn lint` / `yarn build` all green
+- Manual smoke: send a `/status` command through the existing Slack / CLI bridge to confirm the chat-service routes still reply
+- No grep hits for `chat-service/` internal files importing from outside the directory after the refactor (other than `../../src/types/events.js` and `../../src/config/apiRoutes.js` which are type / route-path constants, not host logic)

--- a/server/chat-service/chat-state.ts
+++ b/server/chat-service/chat-state.ts
@@ -1,7 +1,14 @@
+// @package-contract — see ./types.ts
+//
+// Persists per-transport chat state (which session a given
+// external chat id currently points at, which role, timestamps).
+// Kept DI-pure so the module can be extracted as a standalone npm
+// package: the transports directory path and logger arrive via the
+// factory, never through a direct `../workspace-paths.js` import.
+
 import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
-import { WORKSPACE_PATHS } from "../workspace-paths.js";
-import { log } from "../logger/index.js";
+import type { Logger } from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -14,109 +21,132 @@ export interface TransportChatState {
   updatedAt: string;
 }
 
-// ── Path helpers ─────────────────────────────────────────────
+export interface ChatStateStore {
+  getChatState(
+    transportId: string,
+    externalChatId: string,
+  ): Promise<TransportChatState | null>;
+  setChatState(transportId: string, state: TransportChatState): Promise<void>;
+  resetChatState(
+    transportId: string,
+    externalChatId: string,
+    roleId: string,
+  ): Promise<TransportChatState>;
+  connectSession(
+    transportId: string,
+    externalChatId: string,
+    chatSessionId: string,
+  ): Promise<TransportChatState | null>;
+  generateSessionId(transportId: string, externalChatId: string): string;
+}
 
-/**
- * Validate that an external ID is safe for use in file paths.
- * Only allows alphanumeric, hyphens, underscores, and dots.
- */
+// ── Path / id helpers ────────────────────────────────────────
+
+// Allow alphanumeric, hyphen, underscore, dot. Rejects empty
+// strings and anything >200 chars so we never let a transport id
+// escape the transports directory via path traversal.
 function isSafeId(id: string): boolean {
   return /^[\w.-]+$/.test(id) && id.length > 0 && id.length <= 200;
 }
 
-function getTransportDir(transportId: string): string {
-  return path.join(WORKSPACE_PATHS.transports, transportId, "chats");
-}
+// ── Factory ──────────────────────────────────────────────────
 
-function getStatePath(transportId: string, externalChatId: string): string {
-  return path.join(getTransportDir(transportId), `${externalChatId}.json`);
-}
+export function createChatStateStore(opts: {
+  transportsDir: string;
+  logger: Logger;
+}): ChatStateStore {
+  const { transportsDir, logger } = opts;
 
-// ── Session ID generation ────────────────────────────────────
+  const transportDir = (transportId: string) =>
+    path.join(transportsDir, transportId, "chats");
 
-export function generateSessionId(
-  transportId: string,
-  externalChatId: string,
-): string {
-  return `${transportId}-${externalChatId}-${Date.now()}`;
-}
+  const statePath = (transportId: string, externalChatId: string) =>
+    path.join(transportDir(transportId), `${externalChatId}.json`);
 
-// ── CRUD operations ──────────────────────────────────────────
+  const generateSessionId = (
+    transportId: string,
+    externalChatId: string,
+  ): string => `${transportId}-${externalChatId}-${Date.now()}`;
 
-export async function getChatState(
-  transportId: string,
-  externalChatId: string,
-): Promise<TransportChatState | null> {
-  if (!isSafeId(transportId) || !isSafeId(externalChatId)) return null;
+  const getChatState = async (
+    transportId: string,
+    externalChatId: string,
+  ): Promise<TransportChatState | null> => {
+    if (!isSafeId(transportId) || !isSafeId(externalChatId)) return null;
+    try {
+      const raw = await readFile(
+        statePath(transportId, externalChatId),
+        "utf-8",
+      );
+      const parsed: TransportChatState = JSON.parse(raw);
+      return parsed;
+    } catch {
+      return null;
+    }
+  };
 
-  try {
-    const raw = await readFile(
-      getStatePath(transportId, externalChatId),
-      "utf-8",
+  const setChatState = async (
+    transportId: string,
+    state: TransportChatState,
+  ): Promise<void> => {
+    if (!isSafeId(transportId) || !isSafeId(state.externalChatId)) {
+      throw new Error("Invalid transport or chat ID");
+    }
+    await mkdir(transportDir(transportId), { recursive: true });
+    await writeFile(
+      statePath(transportId, state.externalChatId),
+      JSON.stringify(state, null, 2),
     );
-    const parsed: TransportChatState = JSON.parse(raw);
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-export async function setChatState(
-  transportId: string,
-  state: TransportChatState,
-): Promise<void> {
-  if (!isSafeId(transportId) || !isSafeId(state.externalChatId)) {
-    throw new Error("Invalid transport or chat ID");
-  }
-
-  const dir = getTransportDir(transportId);
-  await mkdir(dir, { recursive: true });
-  await writeFile(
-    getStatePath(transportId, state.externalChatId),
-    JSON.stringify(state, null, 2),
-  );
-}
-
-export async function resetChatState(
-  transportId: string,
-  externalChatId: string,
-  roleId: string,
-): Promise<TransportChatState> {
-  const now = new Date().toISOString();
-  const state: TransportChatState = {
-    externalChatId,
-    sessionId: generateSessionId(transportId, externalChatId),
-    roleId,
-    startedAt: now,
-    updatedAt: now,
   };
-  await setChatState(transportId, state);
-  log.info("chat-state", "reset", {
-    transportId,
-    externalChatId,
-    sessionId: state.sessionId,
-  });
-  return state;
-}
 
-export async function connectSession(
-  transportId: string,
-  externalChatId: string,
-  chatSessionId: string,
-): Promise<TransportChatState | null> {
-  const existing = await getChatState(transportId, externalChatId);
-  if (!existing) return null;
-
-  const updated: TransportChatState = {
-    ...existing,
-    sessionId: chatSessionId,
-    updatedAt: new Date().toISOString(),
+  const resetChatState = async (
+    transportId: string,
+    externalChatId: string,
+    roleId: string,
+  ): Promise<TransportChatState> => {
+    const now = new Date().toISOString();
+    const state: TransportChatState = {
+      externalChatId,
+      sessionId: generateSessionId(transportId, externalChatId),
+      roleId,
+      startedAt: now,
+      updatedAt: now,
+    };
+    await setChatState(transportId, state);
+    logger.info("chat-state", "reset", {
+      transportId,
+      externalChatId,
+      sessionId: state.sessionId,
+    });
+    return state;
   };
-  await setChatState(transportId, updated);
-  log.info("chat-state", "connected", {
-    transportId,
-    externalChatId,
-    sessionId: chatSessionId,
-  });
-  return updated;
+
+  const connectSession = async (
+    transportId: string,
+    externalChatId: string,
+    chatSessionId: string,
+  ): Promise<TransportChatState | null> => {
+    const existing = await getChatState(transportId, externalChatId);
+    if (!existing) return null;
+    const updated: TransportChatState = {
+      ...existing,
+      sessionId: chatSessionId,
+      updatedAt: new Date().toISOString(),
+    };
+    await setChatState(transportId, updated);
+    logger.info("chat-state", "connected", {
+      transportId,
+      externalChatId,
+      sessionId: chatSessionId,
+    });
+    return updated;
+  };
+
+  return {
+    getChatState,
+    setChatState,
+    resetChatState,
+    connectSession,
+    generateSessionId,
+  };
 }

--- a/server/chat-service/commands.ts
+++ b/server/chat-service/commands.ts
@@ -1,6 +1,12 @@
-import { getRole, loadAllRoles } from "../roles.js";
-import type { TransportChatState } from "./chat-state.js";
-import { resetChatState } from "./chat-state.js";
+// @package-contract — see ./types.ts
+//
+// Parses and executes slash commands (/reset, /help, /roles, /role,
+// /status) for the transport chat bridge. Role lookups and state
+// reset arrive via the factory so this file has zero imports from
+// the host app — only sibling module types.
+
+import type { Role } from "./types.js";
+import type { ChatStateStore, TransportChatState } from "./chat-state.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -9,109 +15,111 @@ export interface CommandResult {
   nextState?: TransportChatState;
 }
 
-// ── Command handler ──────────────────────────────────────────
-
-/**
- * Parse and execute a slash command.
- * Returns null if the text is not a command (doesn't start with `/`).
- */
-export async function handleCommand(
+export type CommandHandler = (
   text: string,
   transportId: string,
   chatState: TransportChatState,
-): Promise<CommandResult | null> {
-  if (!text.startsWith("/")) return null;
+) => Promise<CommandResult | null>;
 
-  const [command, ...args] = text.split(/\s+/);
+// ── Factory ──────────────────────────────────────────────────
 
-  switch (command) {
-    case "/reset":
-      return handleReset(transportId, chatState);
-    case "/help":
-      return { reply: getHelpText() };
-    case "/roles":
-      return { reply: getRolesText() };
-    case "/role":
-      return handleRole(transportId, chatState, args[0]);
-    case "/status":
-      return handleStatus(chatState);
-    default:
-      return { reply: `Unknown command: ${command}\n\n${getHelpText()}` };
-  }
-}
+export function createCommandHandler(opts: {
+  loadAllRoles: () => Role[];
+  getRole: (roleId: string) => Role;
+  resetChatState: ChatStateStore["resetChatState"];
+}): CommandHandler {
+  const { loadAllRoles, getRole, resetChatState } = opts;
 
-// ── Individual commands ──────────────────────────────────────
+  const getRolesText = (): string =>
+    [
+      "Available roles:",
+      ...loadAllRoles().map((r) => `  ${r.id} — ${r.name}`),
+    ].join("\n");
 
-async function handleReset(
-  transportId: string,
-  chatState: TransportChatState,
-): Promise<CommandResult> {
-  const nextState = await resetChatState(
+  const getHelpText = (): string =>
+    [
+      "Commands:",
+      "  /reset  — Start a new session",
+      "  /help   — Show this help",
+      "  /roles  — List available roles",
+      "  /role <id> — Switch role",
+      "  /status — Show current session info",
+      "",
+      "Send any other text to chat with the assistant.",
+    ].join("\n");
+
+  const handleReset = async (
+    transportId: string,
+    chatState: TransportChatState,
+  ): Promise<CommandResult> => {
+    const nextState = await resetChatState(
+      transportId,
+      chatState.externalChatId,
+      chatState.roleId,
+    );
+    return {
+      reply: `Session reset. Role: ${nextState.roleId}`,
+      nextState,
+    };
+  };
+
+  const handleRole = async (
+    transportId: string,
+    chatState: TransportChatState,
+    requestedRoleId: string | undefined,
+  ): Promise<CommandResult> => {
+    if (!requestedRoleId) {
+      return { reply: `Usage: /role <id>\n\n${getRolesText()}` };
+    }
+    const role = loadAllRoles().find((r) => r.id === requestedRoleId);
+    if (!role) {
+      return { reply: `Unknown role: ${requestedRoleId}\n\n${getRolesText()}` };
+    }
+    const nextState = await resetChatState(
+      transportId,
+      chatState.externalChatId,
+      role.id,
+    );
+    return {
+      reply: `Switched to ${role.name} (${role.id}). New session started.`,
+      nextState,
+    };
+  };
+
+  const handleStatus = (chatState: TransportChatState): CommandResult => {
+    const role = getRole(chatState.roleId);
+    return {
+      reply: [
+        `Role: ${role.name} (${role.id})`,
+        `Session: ${chatState.sessionId}`,
+        `Last activity: ${chatState.updatedAt}`,
+      ].join("\n"),
+    };
+  };
+
+  const handleCommand: CommandHandler = async (
+    text,
     transportId,
-    chatState.externalChatId,
-    chatState.roleId,
-  );
-  return {
-    reply: `Session reset. Role: ${nextState.roleId}`,
-    nextState,
+    chatState,
+  ) => {
+    if (!text.startsWith("/")) return null;
+    const [command, ...args] = text.split(/\s+/);
+
+    switch (command) {
+      case "/reset":
+        return handleReset(transportId, chatState);
+      case "/help":
+        return { reply: getHelpText() };
+      case "/roles":
+        return { reply: getRolesText() };
+      case "/role":
+        return handleRole(transportId, chatState, args[0]);
+      case "/status":
+        return handleStatus(chatState);
+      default:
+        return { reply: `Unknown command: ${command}\n\n${getHelpText()}` };
+    }
   };
-}
 
-async function handleRole(
-  transportId: string,
-  chatState: TransportChatState,
-  requestedRoleId: string | undefined,
-): Promise<CommandResult> {
-  if (!requestedRoleId) {
-    return { reply: `Usage: /role <id>\n\n${getRolesText()}` };
-  }
-
-  const allRoles = loadAllRoles();
-  const role = allRoles.find((r) => r.id === requestedRoleId);
-  if (!role) {
-    return { reply: `Unknown role: ${requestedRoleId}\n\n${getRolesText()}` };
-  }
-
-  const nextState = await resetChatState(
-    transportId,
-    chatState.externalChatId,
-    role.id,
-  );
-  return {
-    reply: `Switched to ${role.name} (${role.id}). New session started.`,
-    nextState,
-  };
-}
-
-function handleStatus(chatState: TransportChatState): CommandResult {
-  const role = getRole(chatState.roleId);
-  return {
-    reply: [
-      `Role: ${role.name} (${role.id})`,
-      `Session: ${chatState.sessionId}`,
-      `Last activity: ${chatState.updatedAt}`,
-    ].join("\n"),
-  };
-}
-
-// ── Helpers ──────────────────────────────────────────────────
-
-function getHelpText(): string {
-  return [
-    "Commands:",
-    "  /reset  — Start a new session",
-    "  /help   — Show this help",
-    "  /roles  — List available roles",
-    "  /role <id> — Switch role",
-    "  /status — Show current session info",
-    "",
-    "Send any other text to chat with the assistant.",
-  ].join("\n");
-}
-
-function getRolesText(): string {
-  return [
-    "Available roles:",
-    ...loadAllRoles().map((r) => `  ${r.id} — ${r.name}`),
-  ].join("\n");
+  return handleCommand;
 }

--- a/server/chat-service/index.ts
+++ b/server/chat-service/index.ts
@@ -1,22 +1,20 @@
+// @package-contract — see ./types.ts
+//
+// Express middleware factory for the transport chat bridge.
+// `createChatService(deps)` returns a Router you mount with
+// `app.use(createChatService(deps))`. All host-app dependencies
+// arrive through `deps`; the module has no direct imports from
+// `../routes/…`, `../roles.js`, `../session-store/…`, or `../logger/…`
+// so it can be lifted into a standalone npm package without
+// internal edits. See #269 / #305.
+
 import { Router } from "express";
 import type { Request, Response } from "express";
-import { log } from "../logger/index.js";
-import { getRole } from "../roles.js";
-import { DEFAULT_ROLE_ID } from "../../src/config/roles.js";
-import { startChat } from "../routes/agent.js";
-import { onSessionEvent } from "../session-store/index.js";
-import {
-  getChatState,
-  setChatState,
-  resetChatState,
-  connectSession,
-} from "./chat-state.js";
-import { handleCommand } from "./commands.js";
-import { badRequest, notFound } from "../utils/httpError.js";
 import { API_ROUTES } from "../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../src/types/events.js";
-
-const router = Router();
+import { createChatStateStore } from "./chat-state.js";
+import { createCommandHandler } from "./commands.js";
+import type { ChatServiceDeps, OnSessionEventFn } from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -38,135 +36,164 @@ interface ConnectRequestParams {
   externalChatId: string;
 }
 
-// ── POST /api/chat/:transportId/:externalChatId ──────────────
-//
-// The main endpoint bridges call. Send text, get a reply.
-
-router.post(
-  API_ROUTES.chatService.message,
-  async (
-    req: Request<ChatRequestParams, unknown, ChatRequestBody>,
-    res: Response,
-  ) => {
-    const { transportId, externalChatId } = req.params;
-    const text = typeof req.body?.text === "string" ? req.body.text.trim() : "";
-
-    if (!text) {
-      badRequest(res, "text is required");
-      return;
-    }
-
-    log.info("chat-service", "message received", {
-      transportId,
-      externalChatId,
-      textLength: text.length,
-    });
-
-    // Load or create chat state
-    let chatState = await getChatState(transportId, externalChatId);
-    if (!chatState) {
-      const defaultRole = getRole(DEFAULT_ROLE_ID);
-      chatState = await resetChatState(
-        transportId,
-        externalChatId,
-        defaultRole.id,
-      );
-    }
-
-    // Check for slash commands
-    const commandResult = await handleCommand(text, transportId, chatState);
-    if (commandResult) {
-      res.json({ reply: commandResult.reply });
-      return;
-    }
-
-    // Relay message through startChat()
-    const result = await startChat({
-      message: text,
-      roleId: chatState.roleId,
-      chatSessionId: chatState.sessionId,
-    });
-
-    if (result.kind === "error") {
-      // Session may be busy (409) — tell the bridge
-      const status = result.status ?? 500;
-      if (status === 409) {
-        res.status(409).json({
-          reply: "A previous message is still being processed. Please wait.",
-        });
-        return;
-      }
-      log.error("chat-service", "startChat failed", {
-        transportId,
-        externalChatId,
-        error: result.error,
-      });
-      res.status(status).json({ reply: `Error: ${result.error}` });
-      return;
-    }
-
-    // Collect agent response via in-process event listener
-    try {
-      const reply = await collectAgentReply(chatState.sessionId);
-
-      // Update chat state timestamp
-      await setChatState(transportId, {
-        ...chatState,
-        updatedAt: new Date().toISOString(),
-      });
-
-      res.json({ reply });
-    } catch (err) {
-      log.error("chat-service", "reply collection failed", {
-        transportId,
-        externalChatId,
-        error: String(err),
-      });
-      res.status(500).json({ reply: "Error: failed to collect agent reply" });
-    }
-  },
-);
-
-// ── POST /api/chat/:transportId/:externalChatId/connect ──────
-//
-// Reassign the active session pointer for a transport chat.
-
-router.post(
-  API_ROUTES.chatService.connect,
-  async (
-    req: Request<ConnectRequestParams, unknown, ConnectRequestBody>,
-    res: Response,
-  ) => {
-    const { transportId, externalChatId } = req.params;
-    const chatSessionId =
-      typeof req.body?.chatSessionId === "string"
-        ? req.body.chatSessionId.trim()
-        : "";
-
-    if (!chatSessionId) {
-      badRequest(res, "chatSessionId is required");
-      return;
-    }
-
-    const updated = await connectSession(
-      transportId,
-      externalChatId,
-      chatSessionId,
-    );
-    if (!updated) {
-      notFound(res, "No chat state found for this transport");
-      return;
-    }
-
-    res.json({ ok: true });
-  },
-);
-
-// ── Event collection helper ──────────────────────────────────
+// ── Constants ────────────────────────────────────────────────
 
 const REPLY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
-function collectAgentReply(chatSessionId: string): Promise<string> {
+// Inlined (not imported from `../utils/httpError.js`) so the module
+// has no outbound dependency on the host app's utility modules.
+// See `@package-contract` in ./types.ts.
+const badRequest = (res: Response, error: string) =>
+  res.status(400).json({ error });
+const notFound = (res: Response, error: string) =>
+  res.status(404).json({ error });
+
+// ── Factory ──────────────────────────────────────────────────
+
+export function createChatService(deps: ChatServiceDeps): Router {
+  const { startChat, onSessionEvent, loadAllRoles, getRole, defaultRoleId } =
+    deps;
+  const logger = deps.logger;
+  const store = createChatStateStore({
+    transportsDir: deps.transportsDir,
+    logger,
+  });
+  const handleCommand = createCommandHandler({
+    loadAllRoles,
+    getRole,
+    resetChatState: store.resetChatState,
+  });
+
+  const router = Router();
+
+  // POST /api/chat/:transportId/:externalChatId — send text, get a reply.
+  router.post(
+    API_ROUTES.chatService.message,
+    async (
+      req: Request<ChatRequestParams, unknown, ChatRequestBody>,
+      res: Response,
+    ) => {
+      const { transportId, externalChatId } = req.params;
+      const text =
+        typeof req.body?.text === "string" ? req.body.text.trim() : "";
+
+      if (!text) {
+        badRequest(res, "text is required");
+        return;
+      }
+
+      logger.info("chat-service", "message received", {
+        transportId,
+        externalChatId,
+        textLength: text.length,
+      });
+
+      let chatState = await store.getChatState(transportId, externalChatId);
+      if (!chatState) {
+        const defaultRole = getRole(defaultRoleId);
+        chatState = await store.resetChatState(
+          transportId,
+          externalChatId,
+          defaultRole.id,
+        );
+      }
+
+      const commandResult = await handleCommand(text, transportId, chatState);
+      if (commandResult) {
+        res.json({ reply: commandResult.reply });
+        return;
+      }
+
+      const result = await startChat({
+        message: text,
+        roleId: chatState.roleId,
+        chatSessionId: chatState.sessionId,
+      });
+
+      if (result.kind === "error") {
+        const status = result.status ?? 500;
+        if (status === 409) {
+          // Session busy — tell the bridge to retry.
+          res.status(409).json({
+            reply: "A previous message is still being processed. Please wait.",
+          });
+          return;
+        }
+        logger.error("chat-service", "startChat failed", {
+          transportId,
+          externalChatId,
+          error: result.error,
+        });
+        res.status(status).json({ reply: `Error: ${result.error}` });
+        return;
+      }
+
+      try {
+        const reply = await collectAgentReply(
+          onSessionEvent,
+          chatState.sessionId,
+        );
+        await store.setChatState(transportId, {
+          ...chatState,
+          updatedAt: new Date().toISOString(),
+        });
+        res.json({ reply });
+      } catch (err) {
+        logger.error("chat-service", "reply collection failed", {
+          transportId,
+          externalChatId,
+          error: String(err),
+        });
+        res.status(500).json({ reply: "Error: failed to collect agent reply" });
+      }
+    },
+  );
+
+  // POST /api/chat/:transportId/:externalChatId/connect — reassign
+  // the active session pointer for a transport chat.
+  router.post(
+    API_ROUTES.chatService.connect,
+    async (
+      req: Request<ConnectRequestParams, unknown, ConnectRequestBody>,
+      res: Response,
+    ) => {
+      const { transportId, externalChatId } = req.params;
+      const chatSessionId =
+        typeof req.body?.chatSessionId === "string"
+          ? req.body.chatSessionId.trim()
+          : "";
+
+      if (!chatSessionId) {
+        badRequest(res, "chatSessionId is required");
+        return;
+      }
+
+      const updated = await store.connectSession(
+        transportId,
+        externalChatId,
+        chatSessionId,
+      );
+      if (!updated) {
+        notFound(res, "No chat state found for this transport");
+        return;
+      }
+
+      res.json({ ok: true });
+    },
+  );
+
+  return router;
+}
+
+// Startable independent of the host app — `startChat` is the only
+// outward call, and it's a plain function reference from deps.
+// Keeping this helper free of closure over deps (taking
+// `onSessionEvent` as a parameter) means future packaging doesn't
+// need to re-capture anything.
+function collectAgentReply(
+  onSessionEvent: OnSessionEventFn,
+  chatSessionId: string,
+): Promise<string> {
   return new Promise((resolve) => {
     const textChunks: string[] = [];
 
@@ -203,4 +230,8 @@ function collectAgentReply(chatSessionId: string): Promise<string> {
   });
 }
 
-export default router;
+export type {
+  ChatServiceDeps,
+  StartChatFn,
+  OnSessionEventFn,
+} from "./types.js";

--- a/server/chat-service/types.ts
+++ b/server/chat-service/types.ts
@@ -1,0 +1,64 @@
+// @package-contract
+//
+// This module is designed to be extractable as a standalone npm
+// package (e.g. `@mulmoclaude/chat-service`) at any time. To keep
+// that path open, the rules are:
+//
+//  1. NO raw imports from `../` outside this directory — all host
+//     dependencies MUST be passed through `ChatServiceDeps`.
+//  2. Types declared here are STRUCTURAL duplicates of what the
+//     host app uses. They look like the real `Role` / `Logger` /
+//     `StartChatParams` types so the same functions plug in, but
+//     they are defined here so the package has no compile-time
+//     link back to the host.
+//  3. When you add a new dependency, extend `ChatServiceDeps` and
+//     thread it through the factory functions — do NOT reach out
+//     to a module import. See #269 / #305 for the rationale.
+
+export interface Role {
+  id: string;
+  name: string;
+}
+
+export interface Logger {
+  error(prefix: string, message: string, data?: Record<string, unknown>): void;
+  warn(prefix: string, message: string, data?: Record<string, unknown>): void;
+  info(prefix: string, message: string, data?: Record<string, unknown>): void;
+  debug(prefix: string, message: string, data?: Record<string, unknown>): void;
+}
+
+export interface StartChatParams {
+  message: string;
+  roleId: string;
+  chatSessionId: string;
+  selectedImageData?: string;
+}
+
+export type StartChatResult =
+  | { kind: "started"; chatSessionId: string }
+  | { kind: "error"; error: string; status?: number };
+
+export type StartChatFn = (params: StartChatParams) => Promise<StartChatResult>;
+
+export type SessionEventListener = (event: Record<string, unknown>) => void;
+
+export type OnSessionEventFn = (
+  sessionId: string,
+  listener: SessionEventListener,
+) => () => void;
+
+export interface ChatServiceDeps {
+  /** Relay a user turn into the agent loop. */
+  startChat: StartChatFn;
+  /** Subscribe to a session's event stream; returns an unsubscribe function. */
+  onSessionEvent: OnSessionEventFn;
+  /** All roles (built-in + custom). */
+  loadAllRoles: () => Role[];
+  /** Look up a single role by id; MUST fall back to default if unknown. */
+  getRole: (roleId: string) => Role;
+  /** Id used when a fresh transport chat has no role selected yet. */
+  defaultRoleId: string;
+  /** Absolute path to the transports workspace dir (one subdir per transportId). */
+  transportsDir: string;
+  logger: Logger;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,10 @@ import pdfRoutes from "./routes/pdf.js";
 import filesRoutes from "./routes/files.js";
 import configRoutes from "./routes/config.js";
 import skillsRoutes from "./routes/skills.js";
-import chatServiceRoutes from "./chat-service/index.js";
+import { createChatService } from "./chat-service/index.js";
+import { onSessionEvent } from "./session-store/index.js";
+import { getRole, loadAllRoles } from "./roles.js";
+import { WORKSPACE_PATHS } from "./workspace-paths.js";
 import { serverError } from "./utils/httpError.js";
 import {
   mcpToolsRouter,
@@ -107,7 +110,17 @@ app.use(pdfRoutes);
 app.use(filesRoutes);
 app.use(configRoutes);
 app.use(skillsRoutes);
-app.use(chatServiceRoutes);
+app.use(
+  createChatService({
+    startChat,
+    onSessionEvent,
+    loadAllRoles,
+    getRole,
+    defaultRoleId: DEFAULT_ROLE_ID,
+    transportsDir: WORKSPACE_PATHS.transports,
+    logger: log,
+  }),
+);
 app.use(mcpToolsRouter);
 
 if (env.isProduction) {


### PR DESCRIPTION
## Summary

- `server/chat-service/` is now a DI middleware factory: `createChatService(deps)` returns an Express Router, all host-app dependencies arrive through `ChatServiceDeps`.
- Stays inside the repo for now, but shaped exactly like a standalone npm package — no outbound imports from `../routes/`, `../roles.js`, `../session-store/`, `../logger/`, or `../utils/` remain.
- Each chat-service file carries a `@package-contract` header comment so future edits don't silently reach back into the host app.

## Items to Confirm / Review

1. `@package-contract` header enforces the invariant via documentation, not lint. If we want stronger enforcement, a follow-up can add an ESLint `no-restricted-imports` rule scoped to `server/chat-service/**`.
2. `badRequest` / `notFound` were inlined (two lines each) rather than kept as an import from `../utils/httpError.js`, to keep the module truly self-contained.
3. Remaining `../../` imports are `src/config/apiRoutes.ts` (route path constants) and `src/types/events.ts` (event type literals). Both are cross-module contracts, not host logic — same category as EVENT_TYPES in #298.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/269 できる？
> 内部refactorでよいけど、middlewareとして使うようにしていつでも切り出せるようにしてね。コメントなどでもそうする予定とかいておいて、変更されないようにね

## Implementation

Plan: [`plans/refactor-chat-service-middleware.md`](./plans/refactor-chat-service-middleware.md)

- **new** `server/chat-service/types.ts` — `ChatServiceDeps` interface + structural types (`Role`, `Logger`, `StartChatParams`, `StartChatResult`, `SessionEventListener`, etc.) declared here so the package has no compile-time dependency on host types.
- **refactor** `server/chat-service/chat-state.ts` — factory `createChatStateStore({ transportsDir, logger })` returns a `ChatStateStore` object. No more `../workspace-paths.js` / `../logger/` imports.
- **refactor** `server/chat-service/commands.ts` — factory `createCommandHandler({ loadAllRoles, getRole, resetChatState })` returns the command handler. No more `../roles.js` imports.
- **refactor** `server/chat-service/index.ts` — exports `createChatService(deps)` which wires everything up and returns a Router.
- **edit** `server/index.ts` — builds `deps` from host modules and mounts via `app.use(createChatService({...}))`.

No behavioural change: same routes, same payloads, same logging, same timeout.

## Blocks / unblocks

- Blocks: #268 (WebSocket transport) — now easier to add on top of this DI structure.
- Out of scope: npm publish setup (deferred per issue #269).

Closes #305, addresses #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)