### PR TITLE
feat(ui): surface fetch failures uniformly (#280)

### DIFF
--- a/e2e/tests/fetch-error-surfaces.spec.ts
+++ b/e2e/tests/fetch-error-surfaces.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// Regression net for issue #280 — every surface listed there must
+// produce a visible, inline banner when its backing fetch fails, so
+// the user can tell "server broken" apart from "nothing to show yet".
+//
+// We mock specific `/api/*` endpoints to return HTTP 500 *after* the
+// shared `mockAllApis` has already registered its healthy catch-alls.
+// Playwright matches routes in REVERSE registration order, so the
+// per-test 500 override wins over the catch-all.
+
+test.describe("fetch failure → inline error banner (#280)", () => {
+  test("Settings modal: GET /api/config 500 shows loadError + disables Save", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+
+    // Make the config load fail. Registered AFTER mockAllApis so it
+    // wins Playwright's last-registered-first match order over the
+    // fixture's default 200 handler.
+    await page.route(
+      (url) => url.pathname === "/api/config",
+      (route) => {
+        if (route.request().method() === "GET") {
+          return route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "config daemon is on fire" }),
+          });
+        }
+        return route.fallback();
+      },
+    );
+
+    await page.goto("/chat");
+    // Arrange: wait for the failing GET to land before asserting on UI.
+    const failedGet = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/config") &&
+        r.request().method() === "GET" &&
+        r.status() === 500,
+    );
+    await page.locator('[data-testid="settings-btn"]').click();
+    await failedGet;
+
+    // Banner surfaces the server error (text is "Failed to load
+    // settings (HTTP 500)" — the SettingsModal collapses server
+    // messages to a canonical phrasing, so we assert on the HTTP code
+    // instead of the raw body).
+    const loadError = page.locator('[data-testid="settings-load-error"]');
+    await expect(loadError).toBeVisible();
+    await expect(loadError).toContainText("HTTP 500");
+
+    // Save button must be disabled so the user can't submit the
+    // (empty) default form over their real config.
+    const saveBtn = page.locator('[data-testid="settings-save-btn"]');
+    await expect(saveBtn).toBeDisabled();
+  });
+
+  test("SessionHistoryPanel: GET /api/sessions 500 shows error banner", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+
+    // Override the sessions list to return 500 on every call.
+    await page.route(
+      (url) => url.pathname === "/api/sessions",
+      (route) =>
+        route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "sessions index corrupted" }),
+        }),
+    );
+
+    await page.goto("/chat");
+
+    // Open the history popup — this is what calls fetchSessions().
+    const failedGet = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/sessions") &&
+        r.request().method() === "GET" &&
+        r.status() === 500,
+    );
+    await page.locator('[data-testid="history-btn"]').click();
+    await failedGet;
+
+    const banner = page.locator('[data-testid="session-history-error"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("sessions index corrupted");
+  });
+});

--- a/plans/feat-surface-fetch-errors.md
+++ b/plans/feat-surface-fetch-errors.md
@@ -1,0 +1,68 @@
+# feat(ui): surface fetch failures uniformly (#280)
+
+## Context
+
+Issue [#280](https://github.com/receptron/mulmoclaude/issues/280) — CodeRabbit's review on PR #279 (Vue fetch consolidation) flagged **6 surfaces** that silently swallow fetch failures. User sees "nothing happened" instead of an error, so diagnosing network / server problems is guesswork. CLAUDE.md already requires "error handling for all fetch calls" — this PR audits the remaining silent paths and wires them up.
+
+## Approach (same pattern across all 6 surfaces)
+
+1. Add `xxxError: Ref<string | null>` (null when healthy).
+2. Clear to `null` on every successful API response.
+3. Set to `result.error` (from the `ApiResult<T>` union in `src/utils/api.ts`) on failure.
+4. Template renders an inline banner — red bg, not a toast — only when `xxxError.value` is non-null. Banner is not dismissable; it clears naturally on the next successful call.
+
+## Surfaces (implementation order per issue #280)
+
+### D. `src/plugins/markdown/View.vue` (GET markdown content)
+
+Currently: on error sets `markdownContent = ""` — indistinguishable from a legit empty document.
+Fix: add `loadError` ref. Template: if `loadError` show red banner + "Retry" text; else if empty show the existing "Empty" placeholder; else render markdown.
+
+### C. `src/components/SettingsModal.vue` (GET /api/config on open)
+
+Currently: on load fail leaves partially-populated form + enables Save button — user can submit stale state and clobber real config.
+Fix: keep existing `loadError` ref, but also gate `canSave` on `loadError === null`. Show banner at top of modal. Disable Save button when loadError.
+
+### B. `src/composables/useSessionHistory.ts` (GET /api/sessions)
+
+Currently: on error wipes `sessions.value = []` — sidebar goes blank.
+Fix: add `historyError: Ref<string | null>`. On error, **keep** existing `sessions.value` untouched and set `historyError`. UI renders a subtle warning above the list.
+
+### E. `src/plugins/scheduler/View.vue` (`callApi` helper, ~L630)
+
+Currently: `callApi` returns `false` on error, UI does nothing.
+Fix: add `apiError: Ref<string | null>`. `callApi` sets it on failure. Template renders banner near the controls (same location as existing `yamlError` / `parseError`).
+
+### F. `src/plugins/todo/View.vue` (`callApi` helper, ~L413)
+
+Same pattern as E. Add `todoApiError` ref + inline banner above controls.
+
+### A. `src/composables/useMcpTools.ts` (GET /api/mcp-tools)
+
+Currently: on error keeps "all tools visible" fallback — masks real failures.
+Fix: add `mcpToolsError: Ref<string | null>`. Keep the fallback (so the UI doesn't break) but expose the error so consumers (SettingsModal's MCP section) can show a small warning strip.
+
+## Not in scope
+
+- Creating a shared `<ErrorBanner>` component — each surface has slightly different wording + placement constraints, and abstracting prematurely will need undoing. Revisit if a third variant wants the same styling.
+- Toast / alert popups — every error here is *persistent* (the failure doesn't auto-resolve), so inline banners are the right UX.
+- i18n — no strings are translated in the app today.
+
+## Testing
+
+- **Unit**: where composables already have tests, add one new case per surface: mock the api util to return `{ ok: false, error: "..." }` and assert the error ref is populated. No test for plain components (View.vue) without existing suites.
+- **E2E**: not expanded — the error paths require backend failure injection which Playwright mocks handle but we'd need a dedicated spec per surface. Follow up if regressions appear.
+- Manual: start dev server, briefly stop backend, verify each surface surfaces the error.
+
+## Checklist
+
+- [ ] D markdown View: loadError + inline banner
+- [ ] C SettingsModal: gate Save on loadError + banner
+- [ ] B useSessionHistory: historyError, preserve existing sessions on failure
+- [ ] E scheduler View: apiError ref + banner
+- [ ] F todo View: todoApiError + banner
+- [ ] A useMcpTools: mcpToolsError exposed for consumers
+- [ ] `yarn format && yarn lint && yarn typecheck && yarn build`
+- [ ] `yarn test` (+ new cases where composables have tests)
+- [ ] `yarn test:e2e`
+- [ ] PR referencing #280

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,6 +74,7 @@
         :current-session-id="currentSessionId"
         :roles="roles"
         :top-offset="headerRef?.offsetHeight"
+        :error-message="historyError"
         @load-session="loadSession"
       />
 
@@ -319,6 +320,7 @@
     <SettingsModal
       :open="showSettings"
       :docker-mode="sandboxEnabled"
+      :mcp-tools-error="mcpToolsError"
       @update:open="showSettings = $event"
     />
   </div>
@@ -657,7 +659,7 @@ function onTextareaKeydown(event: KeyboardEvent) {
   sendMessage();
 }
 
-const { sessions, showHistory, fetchSessions, toggleHistory } =
+const { sessions, showHistory, historyError, fetchSessions, toggleHistory } =
   useSessionHistory();
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
@@ -844,10 +846,11 @@ async function onPluginNavigate(target: PluginLauncherTarget): Promise<void> {
   }
 }
 
-const { availableTools, toolDescriptions, fetchMcpToolsStatus } = useMcpTools({
-  currentRole,
-  getDefinition: (name) => getPlugin(name)?.toolDefinition ?? null,
-});
+const { availableTools, toolDescriptions, mcpToolsError, fetchMcpToolsStatus } =
+  useMcpTools({
+    currentRole,
+    getDefinition: (name) => getPlugin(name)?.toolDefinition ?? null,
+  });
 
 const { pendingCalls, teardown: teardownPendingCalls } = usePendingCalls({
   isRunning,

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -5,6 +5,15 @@
     :style="{ top: topOffset != null ? topOffset + 'px' : '4rem' }"
   >
     <div class="p-2 space-y-1">
+      <div
+        v-if="errorMessage"
+        class="text-xs text-red-700 bg-red-50 border border-red-200 rounded px-2 py-1 mb-1"
+        role="alert"
+        data-testid="session-history-error"
+      >
+        ⚠ Failed to refresh: {{ errorMessage }}
+        <span v-if="sessions.length > 0"> — showing last known list.</span>
+      </div>
       <p v-if="sessions.length === 0" class="text-xs text-gray-400 p-2">
         No sessions yet.
       </p>
@@ -65,6 +74,8 @@ const props = defineProps<{
   currentSessionId: string;
   roles: Role[];
   topOffset?: number;
+  // Latest fetch error from useSessionHistory, or null when healthy.
+  errorMessage?: string | null;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -60,8 +60,13 @@
       </div>
 
       <div class="px-5 py-4 overflow-y-auto flex-1 space-y-4 text-gray-900">
-        <div v-if="loadError" class="text-sm text-red-600">
-          {{ loadError }}
+        <div
+          v-if="loadError"
+          class="text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2"
+          role="alert"
+          data-testid="settings-load-error"
+        >
+          ⚠ {{ loadError }}
         </div>
 
         <div v-if="activeTab === 'tools'" class="space-y-3">
@@ -90,6 +95,15 @@
         </div>
 
         <div v-else-if="activeTab === 'mcp'" class="space-y-3">
+          <div
+            v-if="mcpToolsError"
+            class="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded px-2 py-1"
+            role="alert"
+            data-testid="mcp-tools-error"
+          >
+            ⚠ Could not fetch MCP tool status: {{ mcpToolsError }}. Showing all
+            tools regardless of enablement.
+          </div>
           <SettingsMcpTab
             ref="mcpTabRef"
             :servers="mcpServers"
@@ -124,8 +138,13 @@
             Cancel
           </button>
           <button
-            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300"
-            :disabled="saving || loading"
+            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+            :disabled="saving || loading || !!loadError"
+            :title="
+              loadError
+                ? 'Cannot save until settings load successfully'
+                : undefined
+            "
             data-testid="settings-save-btn"
             @click="save"
           >
@@ -147,9 +166,16 @@ import { API_ROUTES } from "../config/apiRoutes";
 interface Props {
   open: boolean;
   dockerMode?: boolean;
+  // Forwarded from useMcpTools — if non-null, the MCP tab shows a
+  // small warning strip so the user knows "all tools visible" is a
+  // fallback rather than an accurate listing.
+  mcpToolsError?: string | null;
 }
 
-const props = withDefaults(defineProps<Props>(), { dockerMode: false });
+const props = withDefaults(defineProps<Props>(), {
+  dockerMode: false,
+  mcpToolsError: null,
+});
 const emit = defineEmits<{
   "update:open": [value: boolean];
   saved: [];

--- a/src/composables/useMcpTools.ts
+++ b/src/composables/useMcpTools.ts
@@ -25,6 +25,12 @@ interface UseMcpToolsOptions {
 export function useMcpTools(opts: UseMcpToolsOptions) {
   const disabledMcpTools = ref(new Set<string>());
   const mcpToolDescriptions = ref<Record<string, string>>({});
+  // Surfaces the most recent GET /api/mcp-tools failure so consumers
+  // (e.g. the Settings modal's MCP tab) can render a small warning.
+  // We intentionally keep the "all tools visible" fallback below so
+  // the UI stays usable; this ref lets the UI tell the user *why* the
+  // list looks incomplete / unfiltered.
+  const mcpToolsError = ref<string | null>(null);
 
   const availableTools = computed(() =>
     availableToolsFor(
@@ -55,11 +61,17 @@ export function useMcpTools(opts: UseMcpToolsOptions) {
 
   async function fetchMcpToolsStatus(): Promise<void> {
     const result = await apiGet<McpToolStatus[]>(API_ROUTES.mcpTools.list);
-    // Ignore failures and unexpected shapes — all tools remain visible
-    // if anything goes wrong. The Array.isArray guard makes explicit
-    // the previous behaviour (a try/catch used to silently swallow a
-    // .filter TypeError when the response wasn't an array).
-    if (!result.ok || !Array.isArray(result.data)) return;
+    if (!result.ok) {
+      mcpToolsError.value = result.error;
+      // Keep the "all tools visible" fallback — not clearing
+      // disabledMcpTools or descriptions means the UI remains usable.
+      return;
+    }
+    if (!Array.isArray(result.data)) {
+      mcpToolsError.value = "Unexpected response shape from /api/mcp-tools";
+      return;
+    }
+    mcpToolsError.value = null;
     const tools = result.data;
     disabledMcpTools.value = new Set(
       tools.filter((t) => !t.enabled).map((t) => t.name),
@@ -72,6 +84,7 @@ export function useMcpTools(opts: UseMcpToolsOptions) {
   return {
     disabledMcpTools,
     mcpToolDescriptions,
+    mcpToolsError,
     availableTools,
     toolDescriptions,
     fetchMcpToolsStatus,

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -14,18 +14,27 @@ import { apiGet } from "../utils/api";
 export function useSessionHistory(): {
   sessions: Ref<SessionSummary[]>;
   showHistory: Ref<boolean>;
+  historyError: Ref<string | null>;
   fetchSessions: () => Promise<SessionSummary[]>;
   toggleHistory: () => Promise<void>;
 } {
   const sessions = ref<SessionSummary[]>([]);
   const showHistory = ref(false);
+  // Surfaces the most recent fetch failure. Kept alongside the (stale)
+  // sessions list rather than wiping it — a dropdown that goes blank
+  // the moment the network hiccups is worse UX than one that shows
+  // "⚠ using cached list" with the last-known good entries.
+  const historyError = ref<string | null>(null);
 
   async function fetchSessions(): Promise<SessionSummary[]> {
     const result = await apiGet<SessionSummary[]>(API_ROUTES.sessions.list);
     if (!result.ok) {
-      sessions.value = [];
-      return [];
+      historyError.value = result.error;
+      // Intentionally preserve `sessions.value` — callers keep showing
+      // whatever list was last known to work.
+      return sessions.value;
     }
+    historyError.value = null;
     sessions.value = result.data;
     return result.data;
   }
@@ -35,5 +44,11 @@ export function useSessionHistory(): {
     if (showHistory.value) await fetchSessions();
   }
 
-  return { sessions, showHistory, fetchSessions, toggleHistory };
+  return {
+    sessions,
+    showHistory,
+    historyError,
+    fetchSessions,
+    toggleHistory,
+  };
 }

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -4,12 +4,24 @@
       <div class="text-gray-500">Loading document...</div>
     </div>
     <div
+      v-else-if="loadError && !markdownContent"
+      class="min-h-full p-8 flex items-center justify-center"
+    >
+      <div class="load-error-banner" role="alert">
+        ⚠ Failed to load document: {{ loadError }}
+      </div>
+    </div>
+    <div
       v-else-if="!markdownContent"
       class="min-h-full p-8 flex items-center justify-center"
     >
       <div class="text-gray-500">No markdown content available</div>
     </div>
     <template v-else>
+      <div v-if="loadError" class="load-error-banner" role="alert">
+        ⚠ Failed to refresh document: {{ loadError }} — showing last
+        successfully loaded content.
+      </div>
       <div class="markdown-content-wrapper">
         <div class="p-4">
           <div class="header-row">
@@ -107,11 +119,16 @@ const saving = ref(false);
 // Human-readable message shown next to the Save button when a PUT
 // fails. null while the editor is idle or the last save succeeded.
 const saveError = ref<string | null>(null);
+// Error loading the markdown content from the server. Distinct from an
+// intentionally empty document — we used to wipe `markdownContent` on
+// failure, which made "fetch failed" look like "no content available".
+const loadError = ref<string | null>(null);
 // The actual markdown content (fetched from server or inline)
 const markdownContent = ref("");
 const editableMarkdown = ref("");
 
 async function fetchMarkdownContent(): Promise<void> {
+  loadError.value = null;
   const raw = props.selectedResult.data?.markdown;
   if (!raw) {
     markdownContent.value = "";
@@ -127,9 +144,11 @@ async function fetchMarkdownContent(): Promise<void> {
       },
     );
     if (!result.ok) {
-      console.error("Failed to fetch markdown:", result.error);
-      markdownContent.value = "";
-      editableMarkdown.value = "";
+      // Preserve any previously-loaded content instead of wiping it —
+      // the user sees the banner AND whatever they were reading, not
+      // a blank canvas. editableMarkdown is left in sync so the editor
+      // (if open) doesn't flip between states.
+      loadError.value = result.error;
       loading.value = false;
       return;
     }
@@ -486,6 +505,16 @@ watch(
   border: 1px solid #f5c2c7;
   border-radius: 4px;
   font-size: 0.85rem;
+}
+
+.load-error-banner {
+  margin: 0.75rem 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c2c7;
+  border-radius: 4px;
+  font-size: 0.875rem;
 }
 
 .cancel-btn {

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="h-full bg-white flex flex-col">
+    <!-- API error banner — surfaces POST /api/scheduler failures so a
+         delete/add/replace that silently no-ops becomes diagnosable. -->
+    <div
+      v-if="apiError"
+      class="px-4 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700"
+      role="alert"
+      data-testid="scheduler-api-error"
+    >
+      ⚠ Failed to update scheduler: {{ apiError }}
+    </div>
     <!-- Header -->
     <div
       class="flex items-center justify-between px-6 py-3 border-b border-gray-100"
@@ -626,6 +636,9 @@ function toJson(its: ScheduledItem[]) {
 
 const editorText = ref(toJson(items.value));
 const parseError = ref("");
+// Last POST /api/scheduler failure. Cleared on the next successful call
+// so the banner disappears as soon as things recover.
+const apiError = ref<string | null>(null);
 const isModified = computed(() => editorText.value !== toJson(items.value));
 
 async function callApi(body: Record<string, unknown>): Promise<boolean> {
@@ -633,7 +646,11 @@ async function callApi(body: Record<string, unknown>): Promise<boolean> {
     API_ROUTES.scheduler.base,
     body,
   );
-  if (!response.ok) return false;
+  if (!response.ok) {
+    apiError.value = response.error;
+    return false;
+  }
+  apiError.value = null;
   const result = response.data;
   items.value = result.data?.items ?? [];
   emit("updateResult", {

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="h-full bg-white flex flex-col">
+    <!-- API error banner — surfaces POST /api/todos failures so a
+         silent add/remove/toggle becomes diagnosable. -->
+    <div
+      v-if="todoApiError"
+      class="px-4 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700"
+      role="alert"
+      data-testid="todo-api-error"
+    >
+      ⚠ Failed to update todos: {{ todoApiError }}
+    </div>
     <div
       class="flex items-center justify-between px-6 py-4 border-b border-gray-100"
     >
@@ -411,12 +421,20 @@ async function applyItemEdit() {
 
 // ── API ───────────────────────────────────────────────────────────────────────
 
+// Last POST /api/todos failure. Cleared on the next successful call so
+// the banner disappears as soon as things recover.
+const todoApiError = ref<string | null>(null);
+
 async function callApi(body: Record<string, unknown>): Promise<boolean> {
   const response = await apiPost<{ data?: { items?: TodoItem[] } }>(
     API_ROUTES.todos.dispatch,
     body,
   );
-  if (!response.ok) return false;
+  if (!response.ok) {
+    todoApiError.value = response.error;
+    return false;
+  }
+  todoApiError.value = null;
   const result = response.data;
   items.value = result.data?.items ?? [];
   emit("updateResult", {

--- a/test/composables/test_useMcpTools.ts
+++ b/test/composables/test_useMcpTools.ts
@@ -1,0 +1,98 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { computed } from "vue";
+import { useMcpTools } from "../../src/composables/useMcpTools.js";
+import type { Role } from "../../src/config/roles.js";
+
+// Error-surfacing tests for issue #280 surface (A). The composable
+// must expose `mcpToolsError` while keeping its "all tools visible"
+// fallback (disabled set unchanged on failure).
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const originalFetch: any = (globalThis as any).fetch;
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = originalFetch;
+});
+
+function stubFetch(
+  impl: (input: unknown, init?: unknown) => Promise<Response>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = impl;
+}
+
+function mockJsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const fakeRole = computed<Role>(() => ({
+  id: "test",
+  name: "Test",
+  icon: "",
+  prompt: "",
+  availablePlugins: [],
+}));
+
+function makeComposable() {
+  return useMcpTools({
+    currentRole: fakeRole,
+    getDefinition: () => null,
+  });
+}
+
+describe("useMcpTools — error surfacing (#280)", () => {
+  it("sets mcpToolsError on HTTP failure and keeps the fallback", async () => {
+    const { mcpToolsError, disabledMcpTools, fetchMcpToolsStatus } =
+      makeComposable();
+
+    stubFetch(async () => mockJsonResponse(500, { error: "tool svc down" }));
+    await fetchMcpToolsStatus();
+
+    assert.ok(mcpToolsError.value, "error surfaced");
+    assert.equal(
+      disabledMcpTools.value.size,
+      0,
+      "fallback preserved — no tools marked disabled",
+    );
+  });
+
+  it("sets a shape-error message on non-array payloads", async () => {
+    const { mcpToolsError, fetchMcpToolsStatus } = makeComposable();
+
+    stubFetch(async () => mockJsonResponse(200, { unexpected: true }));
+    await fetchMcpToolsStatus();
+
+    assert.ok(
+      mcpToolsError.value && /Unexpected response shape/.test(mcpToolsError.value),
+      "shape-error populated",
+    );
+  });
+
+  it("clears mcpToolsError on the next successful fetch", async () => {
+    const { mcpToolsError, disabledMcpTools, fetchMcpToolsStatus } =
+      makeComposable();
+
+    stubFetch(async () => mockJsonResponse(500, { error: "bad" }));
+    await fetchMcpToolsStatus();
+    assert.ok(mcpToolsError.value);
+
+    stubFetch(async () =>
+      mockJsonResponse(200, [
+        { name: "a", enabled: true },
+        { name: "b", enabled: false },
+      ]),
+    );
+    await fetchMcpToolsStatus();
+    assert.equal(mcpToolsError.value, null);
+    assert.equal(disabledMcpTools.value.has("b"), true);
+    assert.equal(disabledMcpTools.value.has("a"), false);
+  });
+});

--- a/test/composables/test_useMcpTools.ts
+++ b/test/composables/test_useMcpTools.ts
@@ -71,7 +71,8 @@ describe("useMcpTools — error surfacing (#280)", () => {
     await fetchMcpToolsStatus();
 
     assert.ok(
-      mcpToolsError.value && /Unexpected response shape/.test(mcpToolsError.value),
+      mcpToolsError.value &&
+        /Unexpected response shape/.test(mcpToolsError.value),
       "shape-error populated",
     );
   });

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -1,0 +1,94 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { useSessionHistory } from "../../src/composables/useSessionHistory.js";
+
+// These tests exercise the error-surfacing added for issue #280:
+// a fetch failure must set `historyError` but leave `sessions`
+// untouched so the sidebar keeps showing its last known list.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const originalFetch: any = (globalThis as any).fetch;
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = originalFetch;
+});
+
+function stubFetch(
+  impl: (input: unknown, init?: unknown) => Promise<Response>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = impl;
+}
+
+function mockJsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("useSessionHistory — error surfacing (#280)", () => {
+  it("sets historyError and keeps existing sessions on failure", async () => {
+    const { sessions, historyError, fetchSessions } = useSessionHistory();
+
+    // Prime the list with a successful fetch.
+    stubFetch(async () =>
+      mockJsonResponse(200, [
+        { id: "s1", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
+      ]),
+    );
+    await fetchSessions();
+    assert.equal(sessions.value.length, 1);
+    assert.equal(historyError.value, null);
+
+    // Simulate a 500 — the existing list must survive.
+    stubFetch(async () =>
+      mockJsonResponse(500, { error: "server exploded" }),
+    );
+    const result = await fetchSessions();
+
+    assert.equal(sessions.value.length, 1, "sessions preserved on failure");
+    assert.equal(result.length, 1);
+    assert.ok(
+      historyError.value && historyError.value.length > 0,
+      "historyError populated",
+    );
+  });
+
+  it("clears historyError on the next successful fetch", async () => {
+    const { historyError, fetchSessions } = useSessionHistory();
+
+    stubFetch(async () =>
+      mockJsonResponse(500, { error: "transient failure" }),
+    );
+    await fetchSessions();
+    assert.ok(historyError.value);
+
+    stubFetch(async () => mockJsonResponse(200, []));
+    await fetchSessions();
+    assert.equal(historyError.value, null);
+  });
+
+  it("returns the stale list (not empty) when a failure follows success", async () => {
+    const { fetchSessions } = useSessionHistory();
+
+    stubFetch(async () =>
+      mockJsonResponse(200, [
+        { id: "a", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
+        { id: "b", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
+      ]),
+    );
+    const first = await fetchSessions();
+    assert.equal(first.length, 2);
+
+    stubFetch(async () => mockJsonResponse(503, { error: "down" }));
+    const second = await fetchSessions();
+    // Previous behaviour returned []; new behaviour returns the stale
+    // list so the caller doesn't have to re-read `.sessions` separately.
+    assert.equal(second.length, 2);
+  });
+});

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -38,7 +38,13 @@ describe("useSessionHistory — error surfacing (#280)", () => {
     // Prime the list with a successful fetch.
     stubFetch(async () =>
       mockJsonResponse(200, [
-        { id: "s1", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
+        {
+          id: "s1",
+          roleId: "general",
+          startedAt: "",
+          updatedAt: "",
+          preview: "",
+        },
       ]),
     );
     await fetchSessions();
@@ -46,9 +52,7 @@ describe("useSessionHistory — error surfacing (#280)", () => {
     assert.equal(historyError.value, null);
 
     // Simulate a 500 — the existing list must survive.
-    stubFetch(async () =>
-      mockJsonResponse(500, { error: "server exploded" }),
-    );
+    stubFetch(async () => mockJsonResponse(500, { error: "server exploded" }));
     const result = await fetchSessions();
 
     assert.equal(sessions.value.length, 1, "sessions preserved on failure");
@@ -78,8 +82,20 @@ describe("useSessionHistory — error surfacing (#280)", () => {
 
     stubFetch(async () =>
       mockJsonResponse(200, [
-        { id: "a", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
-        { id: "b", roleId: "general", startedAt: "", updatedAt: "", preview: "" },
+        {
+          id: "a",
+          roleId: "general",
+          startedAt: "",
+          updatedAt: "",
+          preview: "",
+        },
+        {
+          id: "b",
+          roleId: "general",
+          startedAt: "",
+          updatedAt: "",
+          preview: "",
+        },
       ]),
     );
     const first = await fetchSessions();


### PR DESCRIPTION
## Summary

- Fixes the 6 UI surfaces flagged by CodeRabbit on PR #279 where fetch failures silently no-op.
- Each surface now owns a dedicated `xxxError: Ref<string | null>`, cleared on success and populated with `ApiResult<T>.error` on failure.
- Inline banners (red — not toasts) surface the error above the relevant UI section. Fallback behaviour preserved where it exists (e.g. MCP tool list stays visible).
- Net: `11 files, +415 / -23`.

## Items to Confirm / Review

1. **Preservation semantics in `useSessionHistory`**: on failure we **keep** the previous `sessions.value` rather than wiping it. The test suite asserts this. If you'd rather the sidebar go blank on persistent failures (say, 5× in a row), we'd need to add a retry counter — out of scope for this PR.
2. **SettingsModal Save disabled on `loadError`**: prevents submitting a stale empty form over good config. The banner now carries the `⚠` + red styling so the reason is obvious even if the user clicks Save anyway (blocked + tooltip).
3. **`markdown/View.vue` keeps last-loaded content on a refresh failure**: if the initial mount fails we show only the banner; if a *later* fetch (e.g. re-open of the same result) fails we show banner + last-known content. Verify this matches the intended UX.
4. **`useMcpTools` fallback kept intentionally**: when the `/api/mcp-tools` fetch fails we leave `disabledMcpTools` untouched so nothing disappears from the role builder. The new warning strip in SettingsModal makes the "possibly inaccurate" state visible.
5. **No shared `<ErrorBanner>` component** — each surface has different placement / wording constraints (scheduler + todo use a top strip, sessions uses an inline warning inside the dropdown, markdown has a dedicated empty-state variant, settings modal banner sits above the form). Abstracting them prematurely would need undoing. Revisit if a third variant wants the same styling.
6. **No E2E spec added**. The error paths require backend-failure injection + mock overrides; none of the existing spec files cover this surface cleanly. Follow up if regressions appear.

## User Prompt

> \`https://github.com/receptron/mulmoclaude/issues/280\` これの対応

## Files touched

| Surface | File | Change |
|---|---|---|
| D | `src/plugins/markdown/View.vue` | `loadError` ref + banner, preserves previous content |
| C | `src/components/SettingsModal.vue` | Save disabled on loadError + banner restyle + MCP error strip |
| B | `src/composables/useSessionHistory.ts` + `src/components/SessionHistoryPanel.vue` + `src/App.vue` | `historyError` ref, preserves sessions, inline warning |
| E | `src/plugins/scheduler/View.vue` | `apiError` ref + banner |
| F | `src/plugins/todo/View.vue` | `todoApiError` ref + banner |
| A | `src/composables/useMcpTools.ts` + `src/App.vue` + `src/components/SettingsModal.vue` | `mcpToolsError` ref exposed + warning strip in MCP tab |
| — | `test/composables/test_useSessionHistory.ts` | 3 new cases |
| — | `test/composables/test_useMcpTools.ts` | 3 new cases |
| — | `plans/feat-surface-fetch-errors.md` | Plan |

## Verification

- `yarn format` — clean
- `yarn typecheck` — clean
- `yarn lint` — 10 pre-existing warnings, 0 errors
- `yarn build` — clean
- `yarn test` — **1937 / 1937** (+6 new cases)
- `yarn test:e2e` — **157 / 157**

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)