### PR TITLE
docs(messaging): resolve #273 open contract questions + apply CR fixes

### DIFF
--- a/bridges/cli/index.ts
+++ b/bridges/cli/index.ts
@@ -19,7 +19,7 @@ function prompt(): void {
 
     try {
       const res = await fetch(
-        `${API_URL}/api/chat/${TRANSPORT_ID}/${CHAT_ID}`,
+        `${API_URL}/api/transports/${TRANSPORT_ID}/chats/${CHAT_ID}`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/plans/messaging_layers_guide.md
+++ b/plans/messaging_layers_guide.md
@@ -5,6 +5,9 @@ plan doc is terse and assumes you already understand the architecture. This
 guide explains the layer structure from the ground up so a newcomer can read
 the plan and contribute to it.
 
+> **Contract decisions (resolved in #273)** — see the plan doc for the authoritative list. Short version:
+> URL prefix `/api/transports/…`; state field `chatSessionId`; `startChat()` returns `{ kind: "started" | "error", … }` and kicks post-processing from `runAgentInBackground()`'s `finally`; text chunks arrive as `event.message`; `/role` resets; transport polling uses `setInterval`, not the task-manager.
+
 ---
 
 ## Why have layers at all?
@@ -48,7 +51,7 @@ and talk to MulmoClaude via HTTP, just like the Web UI does.
 
 ## The five layers at a glance
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │ Layer 1: External platforms                                │
 │   Telegram / LINE / WhatsApp / Slack / Twitter             │
@@ -63,7 +66,7 @@ and talk to MulmoClaude via HTTP, just like the Web UI does.
 │   Speaks one platform's protocol, and ONLY that protocol.  │
 │   Stateless — knows nothing about sessions or roles.       │
 └─────────────┬──────────────────────────────────────────────┘
-              │ HTTP: POST /api/chat/{transportId}/{externalChatId}
+              │ HTTP: POST /api/transports/{transportId}/chats/{externalChatId}
 ┌─────────────▼──────────────────────────────────────────────┐
 │ Layer 3: Chat Service API + state (server-side)            │
 │   server/chat-service/index.ts    ← HTTP endpoints         │
@@ -75,9 +78,10 @@ and talk to MulmoClaude via HTTP, just like the Web UI does.
 ┌─────────────▼──────────────────────────────────────────────┐
 │ Layer 4: MulmoClaude core (already exists, not modified)   │
 │   startChat() — session creation, jsonl persistence,       │
-│                 background agent launch, post-processing   │
+│                 background agent launch                    │
+│                 (post-processing runs in finally, detached)│
 │   runAgent() — Claude CLI subprocess orchestration         │
-│   session-store — in-memory sessionId → state              │
+│   session-store — in-memory chatSessionId → state          │
 │   pub/sub — session event distribution                     │
 └─────────────┬──────────────────────────────────────────────┘
               │ subprocess calls
@@ -122,7 +126,7 @@ above this layer is under our control.
 Per-platform code running as **separate child processes** of MulmoClaude.
 Each bridge is a small, self-contained program:
 
-```
+```text
 bridges/telegram/
   index.ts   ← Poll loop: getUpdates → POST to Chat Service API → sendMessage
   api.ts     ← Telegram API wrappers (sendMessage, getUpdates, sendTyping)
@@ -131,7 +135,7 @@ bridges/telegram/
 **A bridge's entire job:**
 
 1. **Inbound**: receive a message from the platform → extract chat ID
-   and text → `POST /api/chat/{transportId}/{chatId}` with `{ text }`
+   and text → `POST /api/transports/{transportId}/chats/{externalChatId}` with `{ text }`
 2. **Outbound**: receive the response → send it back via the platform's
    API
 
@@ -165,7 +169,7 @@ async function poll() {
     await telegramSendTyping(BOT_TOKEN, chatId);
 
     const res = await fetch(
-      `${API_URL}/api/chat/${TRANSPORT_ID}/${chatId}`,
+      `${API_URL}/api/transports/${TRANSPORT_ID}/chats/${chatId}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -178,6 +182,10 @@ async function poll() {
   }
 }
 
+// Polling cadence is a per-transport concern, driven by a plain
+// setInterval inside the bridge process. We don't register this with
+// the server-side task-manager because that's for cron-like workspace
+// maintenance (default tick 60s) and would miss sub-minute polls.
 setInterval(poll, 5000);
 ```
 
@@ -188,7 +196,7 @@ unaffected.
 ### Layer 3 — Chat Service API + state (server-side)
 
 This is the brain. When a bridge sends
-`POST /api/chat/telegram/123 { text: "hello" }`, Layer 3:
+`POST /api/transports/telegram/chats/123 { text: "hello" }`, Layer 3:
 
 1. Looks up chat state for `telegram/123` on disk
 2. If no state exists, creates a new session `telegram-123-{timestamp}`
@@ -210,7 +218,7 @@ persisted as a JSON file:
 // ~/mulmoclaude/transports/telegram/chats/123.json
 {
   "externalChatId": "123",
-  "sessionId": "telegram-123-1713100000",
+  "chatSessionId": "telegram-123-1713100000",
   "roleId": "general",
   "claudeSessionId": "xyz-789",
   "startedAt": "2026-04-14T12:00:00Z",
@@ -218,16 +226,18 @@ persisted as a JSON file:
 }
 ```
 
+The field name `chatSessionId` matches the `startChat()` parameter name, so the value can be forwarded without renaming.
+
 The state store API:
 
 - `get(transportId, externalChatId)` — load or return null
 - `set(transportId, state)` — persist (atomic write)
 - `reset(transportId, externalChatId, roleId?)` — create a fresh
-  session (new ID), move the pointer. The old session is **not deleted**
-  — it stays in the sidebar for reference
-- `connect(transportId, chatSessionId)` — point this transport at an
-  existing MulmoClaude session (called from the Web UI's "Connect to
-  Telegram" action)
+  session (new `chatSessionId`), move the pointer. The old session is
+  **not deleted** — it stays in the sidebar for reference
+- `connect(transportId, externalChatId, chatSessionId)` — point this
+  transport+externalChatId at an existing MulmoClaude session (called
+  from the Web UI's "Connect to Telegram" action)
 
 **Session ID format**: `{transportId}-{externalChatId}-{timestamp}`
 (e.g. `telegram-123-1713100000`). This makes the origin visible in the
@@ -250,10 +260,25 @@ if (command) {
   if (result.nextState) await chatStateStore.set(transportId, result.nextState);
   return res.json({ reply: result.reply });
 }
-// Not a command — fall through to startChat()
+
+// Not a command — relay through startChat(). Contract:
+//   StartChatParams = { message, roleId, chatSessionId, selectedImageData? }
+//   StartChatResult = { kind: "started", chatSessionId } | { kind: "error", error, status? }
+const result = await startChat({
+  message: text,
+  roleId: chatState.roleId,
+  chatSessionId: chatState.chatSessionId,
+});
+if (result.kind === "error") {
+  return res.status(result.status ?? 500).json({ reply: `Error: ${result.error}` });
+}
+// Agent is running in the background — subscribe to the session
+// channel, concatenate `event.message` chunks, and return the full
+// text on session_finished.
 ```
 
 Available commands: `/reset`, `/help`, `/roles`, `/role <id>`, `/status`.
+`/role <id>` follows the same "new session on switch" rule as the Web UI (see `src/config/roles.ts`): switching role resets conversation context.
 
 #### 3c. Session model — one pointer per chat
 
@@ -264,11 +289,11 @@ these two worlds?
 **Each messaging chat has exactly one "active session pointer"**, managed
 entirely by the server. The bridge never sees session IDs.
 
-```
+```text
 Telegram chat 123
   ┌──────────────────────────────────────────┐
   │ active session pointer:                  │
-  │   sessionId = "telegram-123-1713100000"  │───► jsonl, sidebar, etc.
+  │   chatSessionId = "telegram-123-1713100000"  │───► jsonl, sidebar, etc.
   │                                          │
   │ Previous sessions:                       │
   │   (still in sidebar,                     │
@@ -290,8 +315,8 @@ Telegram chat 123
 
 - Any messaging session appears in the sidebar like a normal session.
   The user can open it and continue the conversation from the browser
-- "Connect to Telegram" (calls `POST /api/chat/telegram/connect`) →
-  reassigns the pointer to the currently-open browser session
+- "Connect to Telegram" (calls `POST /api/transports/telegram/chats/{externalChatId}/connect`) →
+  reassigns the pointer for that chat to the currently-open browser session
 
 **Why the server owns this, not the bridge:** the `/connect` flow
 originates from the Web UI and needs to update the pointer. If the
@@ -306,23 +331,30 @@ We don't touch this layer in the messaging work — we just use it.
 
 `startChat()` is the public entry point:
 
-```
-startChat()
-  ├─ Validate session / create if new
+```text
+startChat()          // returns { kind: "started", chatSessionId } immediately
+  ├─ Validate params ({ message, roleId, chatSessionId, selectedImageData? })
+  ├─ Write / backfill the meta file with firstUserMessage
   ├─ Append user message to jsonl
   ├─ Register in session-store (so the sidebar can see it)
-  ├─ Mark session as running
-  ├─ Launch runAgentInBackground()
-  │    └─ runAgent()
-  │         ├─ spawn claude CLI subprocess
-  │         ├─ emit text events to pub/sub as tokens stream in
-  │         ├─ emit tool_result events when plugins execute
-  │         └─ emit done event on completion
-  └─ After completion:
-      ├─ Trigger journal daily-pass update
-      ├─ Trigger chat-index summary
-      └─ Trigger wiki-backlinks sweep
+  ├─ beginRun() — mark session running (409 if already running)
+  └─ runAgentInBackground()   // detached; errors surface via pub/sub
+       ├─ runAgent()
+       │    ├─ spawn claude CLI subprocess
+       │    ├─ emit text events (event.message) to pub/sub as tokens arrive
+       │    ├─ emit tool_call / tool_call_result events as plugins run
+       │    └─ emit tool_result + session_finished on completion
+       └─ finally:            // fire-and-forget, NOT awaited by startChat
+            ├─ endRun() + publish session_finished
+            ├─ maybeRunJournal()       ← journal daily-pass
+            ├─ maybeIndexSession()     ← chat-index title/summary
+            └─ maybeAppendWikiBacklinks()  ← wiki backlinks sweep
 ```
+
+The post-processing step (journal / chat-index / wiki-backlinks) runs
+in `runAgentInBackground()`'s `finally` block as detached promises —
+callers of `startChat()` do **not** await the pipeline, and a failure
+in any of those hooks is logged but never propagates up.
 
 The Web UI uses this same entry point — the only difference is how the
 caller subscribes to the resulting events (WebSocket in the browser,
@@ -349,7 +381,7 @@ exists — Layer 3's Chat Service API covers everything.
 
 Sending a text message from your phone triggers this sequence:
 
-```
+```text
 [Phone — Telegram app]
   │  User types "What's the weather today?"
   ▼
@@ -359,19 +391,20 @@ Sending a text message from your phone triggers this sequence:
 [Layer 2: telegram bridge process]
   │  Poll fires, calls getUpdates
   │  Gets {chatId: 123, text: "What's the weather today?"}
-  │  POST http://localhost:3001/api/chat/telegram/123
+  │  POST http://localhost:3001/api/transports/telegram/chats/123
   │       body: { text: "What's the weather today?" }
   ▼
 [Layer 3: Chat Service API]
   │  Loads ~/mulmoclaude/transports/telegram/chats/123.json
-  │  → sessionId = "telegram-123-1713100000", role = "general"
+  │  → chatSessionId = "telegram-123-1713100000", role = "general"
   │  Text doesn't start with "/" → not a command
   │  Calls startChat({ chatSessionId: "telegram-123-...", message: "...", roleId: "general" })
+  │  → returns { kind: "started", chatSessionId } immediately; agent runs in background
   ▼
 [Layer 4: startChat]
   │  Appends user message to the session jsonl
-  │  Marks session running in session-store
-  │  Spawns runAgentInBackground()
+  │  Marks session running in session-store (beginRun)
+  │  Spawns runAgentInBackground() and returns { kind: "started" }
   ▼
 [Layer 5: Claude CLI subprocess]
   │  Receives prompt, decides to call the web_search plugin
@@ -379,13 +412,18 @@ Sending a text message from your phone triggers this sequence:
   │  Claude drafts a reply and emits text chunks
   ▼
 [Layer 4: pub/sub]
-  │  Each text chunk publishes to the "session:telegram-123-..." channel
-  │  Final done event on completion
+  │  Each text event (event.message) publishes to the
+  │  "session.telegram-123-..." channel; tool_call / tool_call_result
+  │  events publish too. A session_finished event fires when the
+  │  runAgent generator drains.
   ▼
 [Layer 3: Chat Service API]
-  │  In-process subscriber collects chunks into fullReply = "Sunny with some clouds"
-  │  Done event triggers finalize
+  │  In-process subscriber concatenates `event.message` chunks into
+  │  fullReply = "Sunny with some clouds"
+  │  session_finished resolves the pending request promise
   │  Returns HTTP response: { reply: "Sunny with some clouds" }
+  │  (journal / chat-index / wiki-backlinks run separately in
+  │   runAgentInBackground's finally, not awaited here)
   ▼
 [Layer 2: telegram bridge process]
   │  Calls telegramSendMessage(chatId: 123, text: "Sunny…")
@@ -410,17 +448,17 @@ endpoint.
 One detail that trips up new contributors: MulmoClaude carries **two**
 session IDs, and they live at different layers with different lifetimes.
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │ Layer 3 chat-state (~/mulmoclaude/transports/…) │
 │   externalChatId: "123"                         │
-│   sessionId: "telegram-123-…"     ──┐            │
+│   chatSessionId: "telegram-123-…" ──┐            │
 │   claudeSessionId: "xyz-789" ──┐  │             │
 └──────────────────────────────┼──┼──────────────┘
                                │  │
 ┌──────────────────────────────┼──▼──────────────┐
 │ Layer 4 session-store + jsonl   │               │
-│   sessionId "telegram-123-…"    │               │
+│   chatSessionId "telegram-123-…"│               │
 │   Persistent — lives as long    │               │
 │   as the jsonl file exists.     │               │
 │   Shared between the bridge     │               │
@@ -436,8 +474,8 @@ session IDs, and they live at different layers with different lifetimes.
 └─────────────────────────────────────────────────┘
 ```
 
-- **`sessionId`** is the MulmoClaude identity of the conversation. It
-  owns the jsonl file, appears in the sidebar, and persists forever
+- **`chatSessionId`** is the MulmoClaude identity of the conversation.
+  It owns the jsonl file, appears in the sidebar, and persists forever
   unless explicitly deleted.
 - **`claudeSessionId`** is the Claude CLI's identifier for resuming
   its own in-memory conversation state. It's optional — if we pass
@@ -446,7 +484,7 @@ session IDs, and they live at different layers with different lifetimes.
 
 When `claudeSessionId` becomes stale (CLI restarted between messages,
 process crashed, TTL elapsed), the CLI returns `"No conversation found
-with session ID: xyz-789"`. The `sessionId` is still intact — we just
+with session ID: xyz-789"`. The `chatSessionId` is still intact — we just
 need to drop the stale claudeSessionId and let the CLI start a new
 conversation. This recovery logic lives in Layer 3's Chat Service API
 so every transport benefits automatically.
@@ -544,10 +582,10 @@ HTTP overhead is negligible compared to the agent execution time.
 5. **Layer 4 is untouched.** Bridges invoke the agent via the Chat
    Service API, which calls `startChat()` internally — the same entry
    point the Web UI uses.
-6. **Two session IDs, two layers.** `sessionId` = persistent, lives in
+6. **Two session IDs, two layers.** `chatSessionId` = persistent, lives in
    Layer 4's jsonl. `claudeSessionId` = volatile, lives in Layer 5's CLI
    process. Recovery when the volatile one dies belongs in Layer 3.
    Bridges never see either ID.
 7. **Adding a new platform = writing a bridge.** No server changes.
    The bridge just needs to speak the platform's protocol and POST
-   text to `/api/chat/{transportId}/{externalChatId}`.
+   text to `/api/transports/{transportId}/chats/{externalChatId}`.

--- a/plans/messaging_transports.md
+++ b/plans/messaging_transports.md
@@ -1,5 +1,15 @@
 # Messaging Transport Layer — Design Document
 
+> **Contract decisions (resolved in #273)**
+>
+> - **URL namespace**: `/api/transports/:transportId/chats/:externalChatId[/connect]` — dedicated `transports` prefix, separate from the Web UI's `/api/sessions`. `GET /api/transports` lists registered transports.
+> - **State field**: `chatSessionId` (matches `startChat()`'s parameter; renamed from the earlier draft's `sessionId`).
+> - **`startChat()` shape**: `{ kind: "started", chatSessionId } | { kind: "error", error, status? }`. Post-processing (journal / chat-index / wiki-backlinks) runs in `runAgentInBackground()`'s `finally`, not inline.
+> - **SSE event payload**: text chunks arrive as `event.message`.
+> - **`/role <id>`**: creates a new session with the new role (context reset). Matches the Web UI's role-switch semantics.
+> - **Poll cadence**: each transport drives its own `setInterval(poll, …)`. The server-side task-manager is not used (its tick is 60 s and its purpose is workspace maintenance, not I/O polls).
+> - **Session ID naming**: see the dedicated subsection in §4.2.
+
 ## 1) User Experience — Remote Access to MulmoClaude
 
 ### The Problem We're Solving
@@ -87,7 +97,7 @@ The web UI already communicates with MulmoClaude via HTTP (`POST /api/agent`) an
 
 ### Overview
 
-```
+```text
 MulmoClaude server (single process)
   ├─ Express (existing Web UI API)
   ├─ Chat Service API (new — thin layer over startChat + chat-state)
@@ -105,32 +115,38 @@ The bridges are **completely separate processes**. They share no memory, no impo
 
 The API that bridges call. Two endpoints handle the core flow:
 
-```
-POST /api/chat/:transportId/:externalChatId
+```text
+POST /api/transports/:transportId/chats/:externalChatId
   Body: { text: string }
   Response: { reply: string }
 
   The server:
-  1. Looks up the active session for this transport+chatId
+  1. Looks up the active session for this transport+externalChatId
   2. If none exists, creates a new session (e.g. "telegram-123-1713100000")
   3. Checks if text is a command (/reset, /role, /roles, /help, /status)
      - If command: executes it, returns the result as reply
   4. If not a command: calls startChat() with the active session
-  5. Subscribes to pub/sub, collects text events
-  6. Returns the full agent reply as response
+  5. Subscribes to pub/sub, collects text events (event.message)
+  6. Returns the concatenated text reply as response
+
+  Note: `startChat()` kicks off the agent run and returns immediately
+  ({ kind: "started", chatSessionId }) — the post-processing pipeline
+  (journal, chat-index, wiki-backlinks) runs as fire-and-forget from
+  runAgentInBackground()'s finally block, NOT inline here.
 ```
 
-```
-POST /api/chat/:transportId/connect
+```text
+POST /api/transports/:transportId/chats/:externalChatId/connect
   Body: { chatSessionId: string }
   Response: { ok: true }
 
-  Reassigns the active session pointer for a transport.
-  Called from the Web UI's "Connect to Telegram" action.
+  Reassigns the active session pointer for this transport+externalChatId
+  to an existing MulmoClaude session. Called from the Web UI's
+  "Connect to Telegram" action.
 ```
 
-```
-GET /api/chat/transports
+```text
+GET /api/transports
   Response: { transports: [{ id: "telegram", enabled: true }, ...] }
 
   Lists registered transports and their status.
@@ -143,7 +159,7 @@ GET /api/chat/transports
 
 The server manages all chat state. One JSON file per external chat, stored in the workspace:
 
-```
+```text
 ~/mulmoclaude/transports/
   telegram/
     chats/{chatId}.json
@@ -160,8 +176,8 @@ export interface TransportChatState {
   /** External platform's chat/channel/DM ID */
   externalChatId: string;
 
-  /** Active MulmoClaude session ID */
-  sessionId: string;
+  /** Active MulmoClaude session ID (matches startChat's chatSessionId param) */
+  chatSessionId: string;
 
   /** Active role ID */
   roleId: string;
@@ -179,10 +195,22 @@ Operations:
 - `get(transportId, externalChatId)` — read state, return null if not found
 - `set(transportId, state)` — write state
 - `reset(transportId, externalChatId, roleId?)` — create a fresh session, move the pointer. Old session stays in sidebar
-- `connect(transportId, chatSessionId)` — point this transport at an existing session
+- `connect(transportId, externalChatId, chatSessionId)` — point this transport+externalChatId at an existing session
 - Path safety via `resolveWithinRoot()` for all file operations
 
-**Session ID format**: `{transportId}-{externalChatId}-{timestamp}` (e.g. `telegram-123-1713100000`).
+### Session ID naming rules
+
+`chatSessionId` is used both as a filename segment (`chat/<chatSessionId>.jsonl`) and as a URL path segment, so it has to be filesystem-safe **and** URL-safe. `externalChatId` comes from the platform (Telegram numeric, Slack channel name, Discord snowflake, …) and its character set varies, so we sanitize before composing.
+
+Rules for `chatSessionId`:
+
+- **Format**: `{transportId}-{sanitizedExternalChatId}-{timestampMs}` — e.g. `telegram-123-1713100000`.
+- **Character set**: `[A-Za-z0-9._-]+`. Anything outside this set is replaced with `_` during sanitization. This matches the regex the chat-state store already enforces via `isSafeId()`.
+- **Length**: ≤ 200 characters. Enforced by `isSafeId()`. If a platform returns something unreasonably long (a Slack workspace ID plus channel ID plus thread ts), truncate before sanitization and append a short hash so collisions stay rare.
+- **Stability**: the sanitized `chatSessionId` is written into the jsonl filename and the sidebar URL. Once issued for a turn, it never changes. `/reset` and `/role` create a **new** `chatSessionId`; they don't rename the old one.
+- **Origin visibility**: keeping `transportId` as the first segment lets readers see at a glance where a session came from when scanning the sidebar or the chat/ directory.
+
+`externalChatId` itself is stored verbatim in the state JSON (not sanitized) so the mapping back to the platform is lossless. Only the composition into `chatSessionId` goes through sanitization.
 
 ### 4.3 Command Handling (server-side)
 
@@ -190,13 +218,15 @@ The server parses and executes commands before they reach the agent. The bridge 
 
 | Command | Action |
 |---|---|
-| `/reset` | Create a fresh session, make it active |
+| `/reset` | Create a fresh session with the current role, make it active. Old session stays in the sidebar. |
 | `/help` | Return list of available commands |
 | `/roles` | Return list of available roles |
-| `/role <id>` | Switch role and create a new session |
+| `/role <id>` | Switch role **and** create a new session with that role. Conversation context is reset — treat it as "/reset with a different role". |
 | `/status` | Return current role and last activity |
 
 Since command handling is server-side, every platform gets the same behavior with zero bridge code.
+
+**Why `/role` resets the session instead of editing the existing one**: role defines the system prompt, available plugins, and the context-reset-on-switch semantics the Web UI already uses (see `src/config/roles.ts`). Keeping messaging-transport role changes consistent with the Web UI means history is scoped to one role per session, avoiding "half of this transcript is general-mode, half is artist-mode" confusion. If a user wants continuity, they can `/role general` to reset, send "continue from where we left off" — the new session can reference the old one via the normal conversation tools.
 
 ### 4.4 Bridge Process Management
 
@@ -278,11 +308,14 @@ function prompt() {
   rl.question("You: ", async (text) => {
     if (!text.trim()) return prompt();
 
-    const res = await fetch(`${API_URL}/api/chat/${TRANSPORT_ID}/${CHAT_ID}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: text.trim() }),
-    });
+    const res = await fetch(
+      `${API_URL}/api/transports/${TRANSPORT_ID}/chats/${CHAT_ID}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: text.trim() }),
+      },
+    );
     const { reply } = await res.json();
 
     console.log(`\nAssistant: ${reply}\n`);
@@ -325,17 +358,25 @@ async function poll() {
 
     await telegramSendTyping(BOT_TOKEN, chatId);
 
-    const res = await fetch(`${API_URL}/api/chat/${TRANSPORT_ID}/${chatId}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-    });
+    const res = await fetch(
+      `${API_URL}/api/transports/${TRANSPORT_ID}/chats/${chatId}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      },
+    );
     const { reply } = await res.json();
 
     await telegramSendMessage(BOT_TOKEN, chatId, reply);
   }
 }
 
+// Polling cadence is a per-transport concern, so we drive it with a
+// plain setInterval inside the bridge process rather than registering
+// a task with the server-side task-manager (whose default tick is 60s
+// and whose purpose is cron-like workspace maintenance, not
+// sub-minute I/O loops).
 setInterval(poll, 5000);
 ```
 
@@ -392,7 +433,7 @@ setInterval(poll, 5000);
 
 Some platforms (LINE, WhatsApp, Slack in webhook mode) push events to an HTTP endpoint. These bridges run their own small HTTP server:
 
-```
+```text
 Internet
   │
   ├─ LINE webhook ──────► line-bridge (port 3002) ──► MulmoClaude API (port 3001)
@@ -412,7 +453,7 @@ Internet
 
 ### Server-Side Files
 
-```
+```text
 server/
   chat-service/
     index.ts            ← Chat Service API routes
@@ -425,7 +466,7 @@ No `server/transports/` directory. No platform-specific code in the server at al
 
 ### Bridge Files (separate from server)
 
-```
+```text
 bridges/
   cli/
     index.ts            ← Reference implementation: readline → API → console
@@ -445,7 +486,7 @@ bridges/
 
 ### Workspace Storage
 
-```
+```text
 ~/mulmoclaude/transports/
   telegram/chats/       ← Per-chat state JSON files (managed by server)
   line/chats/
@@ -492,7 +533,7 @@ bridges/
 ### Phase 0: Chat Service API + CLI Bridge
 1. Create `server/chat-service/chat-state.ts` — state store with `resolveWithinRoot()`
 2. Create `server/chat-service/commands.ts` — server-side `/reset`, `/help`, `/roles`, `/role`, `/status`
-3. Create `server/chat-service/index.ts` — `POST /api/chat/:transportId/:externalChatId`, `POST /api/chat/:transportId/connect`, `GET /api/chat/transports`
+3. Create `server/chat-service/index.ts` — `POST /api/transports/:transportId/chats/:externalChatId`, `POST /api/transports/:transportId/chats/:externalChatId/connect`, `GET /api/transports`
 4. Create `bridges/cli/index.ts` — reference implementation (~20 lines)
 5. Wire into `server/index.ts` — mount chat-service routes
 6. Unit tests: `test/chat-service/test_chat-state.ts`, `test/chat-service/test_commands.ts`
@@ -506,9 +547,9 @@ bridges/
 5. Update `README.md` with setup instructions
 
 ### Phase 1.5: Web UI Connect Support
-1. Add "Connect to {transport}" action in session header/context menu (calls `POST /api/chat/:transportId/connect`)
+1. Add "Connect to {transport}" action in session header/context menu (calls `POST /api/transports/:transportId/chats/:externalChatId/connect`)
 2. Show transport badge on sidebar sessions whose IDs start with a transport prefix
-3. Use `GET /api/chat/transports` to determine which transports are available
+3. Use `GET /api/transports` to determine which transports are available
 
 ### Phase 2: LINE Bridge
 1. Create `bridges/line/` — webhook HTTP server + LINE API

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -39,10 +39,15 @@ export const API_ROUTES = {
   },
 
   chatService: {
-    // POST /api/chat/:transportId/:externalChatId           — send a message
-    // POST /api/chat/:transportId/:externalChatId/connect   — set active session
-    message: "/api/chat/:transportId/:externalChatId",
-    connect: "/api/chat/:transportId/:externalChatId/connect",
+    // POST /api/transports/:transportId/chats/:externalChatId           — send a message
+    // POST /api/transports/:transportId/chats/:externalChatId/connect   — set active session
+    //
+    // Namespace is deliberately separate from /api/chat/ so the word
+    // "chat" is not overloaded (the Web UI's /api/sessions is the
+    // conversation concept; /api/transports/* is the external-
+    // platform-to-session pointer concept). See plans/messaging_transports.md.
+    message: "/api/transports/:transportId/chats/:externalChatId",
+    connect: "/api/transports/:transportId/chats/:externalChatId/connect",
   },
 
   config: {


### PR DESCRIPTION
## Summary

Closes the five open contract questions in #273, lands the eight factual CodeRabbit corrections, and aligns the shipped URL namespace with the decisions.

## Decisions applied

| Q | Decision | Rationale |
|---|---|---|
| Q1 — state field | \`chatSessionId\` | Matches \`startChat()\`'s parameter, so the value can be forwarded without renaming. |
| Q2 — URL shape | \`/api/transports/:transportId/chats/:externalChatId[/connect]\` (option B2) | Dedicated \`transports\` namespace; avoids overloading the word \"chat\" against the Web UI's \`/api/sessions\`. Only the CLI bridge and \`src/config/apiRoutes.ts\` needed to move — no external bridges exist yet, so the migration cost is minimal and the long-term shape is cleaner. |
| Q3 — session ID naming rules | New \"Session ID naming rules\" subsection in \`messaging_transports.md\` §4.2 | Future implementors grep for it; inline notes would scatter. |
| Q4 — \`/role <id>\` | Resets conversation context (creates a fresh session with the new role) | Matches the Web UI's role-switch behaviour in \`src/config/roles.ts\` and the already-shipped \`commands.ts\` implementation. |
| Q5 — polling cadence | Transport-internal \`setInterval(poll, …)\` | Server-side task-manager default tick is 60 s and its purpose is workspace maintenance, not sub-minute I/O loops. |

## Items to Confirm / Review

1. **URL migration**: this PR renames \`/api/chat/:transportId/:externalChatId\` to \`/api/transports/:transportId/chats/:externalChatId\`. Affected live code is \`src/config/apiRoutes.ts\` + \`bridges/cli/index.ts\`. No tests referenced the old URL. Any work-in-progress branches touching \`chat-service\` will need to pick up the new \`API_ROUTES.chatService.*\` constants.
2. **\`/role\` semantics** (Q4): confirming \"fresh session on switch\" is what we want. \`commands.ts\` already does this; PR just documents it.
3. **Session ID naming rules** (Q3): new subsection enforces \`[A-Za-z0-9._-]+\` / ≤ 200 chars via the existing \`isSafeId()\` check. If a platform returns an ID that violates this, the section says to sanitize + hash-suffix — this is forward guidance for implementors, nothing to implement here.

## Eight CodeRabbit factual fixes applied

1. \`relayMessage\` example now uses \`startChat({ chatSessionId, message, roleId })\` and destructures the discriminated \`StartChatResult\`.
2. Post-processing wording corrected: journal / chat-index / wiki-backlinks run in \`runAgentInBackground().finally\` (fire-and-forget), **not** synchronously in \`startChat()\`.
3. \`event.chunk\` → \`event.message\` in streaming-collection example.
4. \`TransportContext\` / startup examples aligned with the real \`Router\`-based shape (no stale signatures found in current text).
5. All MD040 unlabelled fences labelled (\`text\` / \`ts\` / etc.).
6. \`startChat\` responsibility wording no longer overstates what the function does (multiple sections).
7. State-example field naming unified on \`chatSessionId\` (Q1).
8. \`/connect\` docstring rewritten to match Q2 URL shape.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/273 できる限り最善の方法で決めていって。その中でどうしても判断が必要なものだけ効いて。documentに反映し、もし必要なら実装変更も。

## Verification

typecheck / typecheck:server / lint (0 errors) / 1937 tests / build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)