### PR TITLE
feat(auth): MULMOCLAUDE_AUTH_TOKEN env override on the server (#316)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -201,6 +201,8 @@ Every HTTP call to `/api/*` requires `Authorization: Bearer <token>`. Layered on
 
 **Dev-mode escape hatch**: setting `MULMOCLAUDE_AUTH_TOKEN=…` before `yarn dev:client` makes the Vite plugin use that value instead of reading the file. Used by `e2e/playwright.config.ts` to inject a predictable token in E2E; also handy for debugging without a running server. Production (Express serving built HTML) never reads env — the in-memory token from `generateAndWriteToken()` is the sole source.
 
+**Server-side pinning (#316)**: setting `MULMOCLAUDE_AUTH_TOKEN=…` before `yarn dev` (or any process that starts Express) makes `generateAndWriteToken()` use that value verbatim instead of generating a fresh random token. The same var is already honoured by the Vite dev plugin and the CLI bridge, so pinning it once in a shared shell / `.env` / docker-compose file keeps the token consistent across a server restart — long-running bridges no longer need a relaunch every time the dev server bounces. A warning logs if the override is shorter than 32 chars; no other validation. Use random-per-startup (the default) for casual dev and the env override only when the restart pain outweighs the leak surface (CI, docker, multi-bridge setups).
+
 **Current scope** (#272 Phase 1+2): Vue client, Express middleware, and the CLI bridge (`yarn cli`). The bridge reads the same `.session-token` file (or `MULMOCLAUDE_AUTH_TOKEN` env var) on startup and attaches the header to its `fetch` calls.
 
 **Files**

--- a/plans/feat-auth-token-env-override.md
+++ b/plans/feat-auth-token-env-override.md
@@ -1,0 +1,81 @@
+# feat(auth): MULMOCLAUDE_AUTH_TOKEN server-side override
+
+Tracks issue #316.
+
+## Goal
+
+Let the operator pin a fixed bearer token via the environment instead
+of having one regenerated on every server startup. Specifically: honour
+`MULMOCLAUDE_AUTH_TOKEN` in `generateAndWriteToken()`, matching the
+name the client-side helpers (`bridges/cli/token.ts`, the Vite dev
+plugin) already use.
+
+## Why
+
+`PR #315` (socket.io bridge) surfaced an operational quirk during
+manual testing: every server restart invalidates the in-memory token
+every bridge is holding. A CLI bridge — and later, Telegram / LINE /
+… bridges — silently die until they're relaunched. This has always
+been the behavior (since #272), but adding more bridges makes it
+more visible.
+
+Setting the same env var on both sides means the token survives
+server restarts for as long as the shell / docker-compose / CI
+environment holds it.
+
+## Design
+
+1. `server/env.ts` — extend the frozen `env` snapshot with
+   ```ts
+   authTokenOverride: process.env.MULMOCLAUDE_AUTH_TOKEN
+   ```
+   (stored as `string | undefined` so the default-generation code can
+   do a plain truthy check). This is the "one place env vars live"
+   that `docs/developer.md` already points at.
+
+2. `server/auth/token.ts` — `generateAndWriteToken()` gets an optional
+   second parameter `override?: string` for testability. In production
+   `server/index.ts` passes `env.authTokenOverride`. Inside the
+   function:
+   - If `override` is a non-empty string: use it verbatim as
+     `currentToken`, then write the file atomically with mode 0600.
+     Emit one warning log line if the override is shorter than
+     32 chars (cheap operator sanity check; we don't block startup).
+   - Otherwise: existing `randomBytes(32)` path.
+   - The file-write / in-memory-state path is unchanged regardless —
+     the Vite plugin and the CLI bridge both read from disk by default
+     (`readBridgeToken()` falls back to the file).
+
+3. `server/index.ts` — pass `env.authTokenOverride` at the one site
+   that calls `generateAndWriteToken()`. No other callers in prod
+   code.
+
+4. Tests (`test/server/test_auth_token.ts`) add:
+   - override is used verbatim and written to disk
+   - override does not rotate across calls (same value in, same value
+     out)
+   - explicit empty-string override behaves like no override
+     (random-generation path)
+   - unset → still random (regression guard for #272)
+
+5. Docs — `docs/developer.md` Auth section grows an "env-var
+   override" subsection calling out the tradeoff (env-var leak
+   surface vs. restart pain) and the symmetry with the client-side
+   override that already exists.
+
+## Validation stance
+
+- Non-empty check only. Same as the client-side override since #272.
+- Warning log when length < 32 — operator mistake detector, not a
+  hard rule.
+- No charset restrictions: someone using a word-based pass-phrase
+  in dev shouldn't have to hex-encode it.
+
+## Out of scope
+
+- Rotation while the server runs (`POST /api/auth/rotate`) — separate
+  ticket.
+- Client-side changes — `readBridgeToken()` and the Vite plugin
+  already read the env var.
+- Hard length / charset enforcement — callers who want that can wrap
+  their own check around the env var before exporting.

--- a/server/auth/token.ts
+++ b/server/auth/token.ts
@@ -1,5 +1,5 @@
-// Bearer auth token (#272). One random 32-byte hex token per server
-// startup, held in memory and mirrored to a 0600 file at
+// Bearer auth token (#272). One 32-byte hex token per server startup,
+// held in memory and mirrored to a 0600 file at
 // `WORKSPACE_PATHS.sessionToken`.
 //
 // **Why file-backed**: the token must travel out-of-process to (a) the
@@ -13,13 +13,25 @@
 // shutdown. A stale file after a crash is harmless — the next startup
 // generates a fresh in-memory token and overwrites, so a stolen stale
 // file value fails 401 against the running server.
+//
+// **Env override (#316)**: `MULMOCLAUDE_AUTH_TOKEN` (read via `env.ts`)
+// pins the token across restarts so long-running bridges don't need a
+// relaunch every time the server bounces. The client-side readers
+// (`bridges/cli/token.ts`, Vite plugin) already honour the same var;
+// setting it once on both sides survives restarts.
 
 import { randomBytes } from "crypto";
 import fs from "fs";
 import { writeFileAtomic } from "../utils/file.js";
 import { WORKSPACE_PATHS } from "../workspace-paths.js";
+import { log } from "../logger/index.js";
 
 const TOKEN_BYTES = 32; // 64 hex chars
+// Below this length a random 32-byte token would be 64 hex chars;
+// anything shorter from the env override is almost certainly a
+// placeholder like "test" that leaked into production. Warn, don't
+// block — the operator might have reasons we don't see.
+const MIN_RECOMMENDED_CHARS = 32;
 
 let currentToken: string | null = null;
 
@@ -33,18 +45,41 @@ export function getCurrentToken(): string | null {
 }
 
 /**
- * Generate a fresh random token, store it in memory, and mirror to the
- * workspace file (mode 0600, atomic). The `tokenPath` parameter is
- * injected for tests so they can target a tmp directory; production
- * callers rely on the default `WORKSPACE_PATHS.sessionToken`.
+ * Generate (or take from the env override) the startup token, store
+ * it in memory, and mirror it to the workspace file (mode 0600,
+ * atomic).
+ *
+ * @param tokenPath Injected for tests so they can target a tmp
+ *   directory; production callers rely on the default
+ *   `WORKSPACE_PATHS.sessionToken`.
+ * @param override Injected for tests. Production callers pass
+ *   `env.authTokenOverride` from `server/env.ts`. When non-empty the
+ *   override is used verbatim instead of generating random bytes.
  */
 export async function generateAndWriteToken(
   tokenPath: string = WORKSPACE_PATHS.sessionToken,
+  override?: string,
 ): Promise<string> {
-  const token = randomBytes(TOKEN_BYTES).toString("hex");
+  const token = resolveToken(override);
   currentToken = token;
   await writeFileAtomic(tokenPath, token, { mode: 0o600 });
   return token;
+}
+
+function resolveToken(override: string | undefined): string {
+  if (typeof override === "string" && override.length > 0) {
+    if (override.length < MIN_RECOMMENDED_CHARS) {
+      // Visible on startup so a half-typed override doesn't silently
+      // become a security hole in dev.
+      log.warn(
+        "auth",
+        "MULMOCLAUDE_AUTH_TOKEN is shorter than the recommended 32 characters",
+        { length: override.length },
+      );
+    }
+    return override;
+  }
+  return randomBytes(TOKEN_BYTES).toString("hex");
 }
 
 /**

--- a/server/env.ts
+++ b/server/env.ts
@@ -67,6 +67,13 @@ export const env = Object.freeze({
   geminiApiKey: process.env.GEMINI_API_KEY,
   xBearerToken: process.env.X_BEARER_TOKEN,
 
+  // Bearer auth token (#272, #316): if set, the server uses this
+  // verbatim instead of generating a fresh random token at startup.
+  // Matches the env var already honoured by `bridges/cli/token.ts`
+  // and the Vite dev plugin, so pinning on both sides survives a
+  // server restart. Undefined / empty → random-per-startup path.
+  authTokenOverride: process.env.MULMOCLAUDE_AUTH_TOKEN,
+
   // Sessions index API
   sessionsListWindowDays: asInt(process.env.SESSIONS_LIST_WINDOW_DAYS, 90, {
     min: 0,

--- a/server/index.ts
+++ b/server/index.ts
@@ -346,9 +346,12 @@ process.on("SIGTERM", () => {
   // Generate the bearer token before `app.listen` so the first
   // request cannot race an uninitialised `getCurrentToken()`. The
   // middleware defensively handles the null case anyway (401).
-  await generateAndWriteToken();
+  // `env.authTokenOverride` (#316) pins the token across restarts
+  // when set; otherwise a fresh random one is written.
+  await generateAndWriteToken(undefined, env.authTokenOverride);
   log.info("auth", "bearer token written", {
     path: WORKSPACE_PATHS.sessionToken,
+    source: env.authTokenOverride ? "env" : "random",
   });
 
   sandboxEnabled = await setupSandbox();

--- a/test/server/test_auth_token.ts
+++ b/test/server/test_auth_token.ts
@@ -64,6 +64,41 @@ describe("generateAndWriteToken", () => {
   });
 });
 
+describe("generateAndWriteToken — env override (#316)", () => {
+  it("uses the override verbatim when non-empty", async () => {
+    const override = "pinned-token-1234567890abcdef1234567890abcdef12";
+    const token = await generateAndWriteToken(tokenPath, override);
+    assert.equal(token, override);
+    assert.equal(getCurrentToken(), override);
+    assert.equal(fs.readFileSync(tokenPath, "utf-8"), override);
+  });
+
+  it("does not rotate — repeated calls with the same override return it each time", async () => {
+    const override = "stable-token-abcdefabcdefabcdefabcdefabcdef";
+    const first = await generateAndWriteToken(tokenPath, override);
+    const second = await generateAndWriteToken(tokenPath, override);
+    assert.equal(first, override);
+    assert.equal(second, override);
+  });
+
+  it("treats empty string as no override (falls back to random)", async () => {
+    const token = await generateAndWriteToken(tokenPath, "");
+    assert.match(token, /^[0-9a-f]{64}$/);
+    assert.notEqual(token, "");
+  });
+
+  it("treats undefined as no override (falls back to random)", async () => {
+    const token = await generateAndWriteToken(tokenPath, undefined);
+    assert.match(token, /^[0-9a-f]{64}$/);
+  });
+
+  it("accepts a short override but still uses it (warning is logged, not an error)", async () => {
+    const token = await generateAndWriteToken(tokenPath, "short");
+    assert.equal(token, "short");
+    assert.equal(getCurrentToken(), "short");
+  });
+});
+
 describe("deleteTokenFile", () => {
   it("removes the token file", async () => {
     await generateAndWriteToken(tokenPath);

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -14,6 +14,7 @@ interface EnvSnapshot {
     disableSandbox: boolean;
     geminiApiKey: string | undefined;
     xBearerToken: string | undefined;
+    authTokenOverride: string | undefined;
     sessionsListWindowDays: number;
     journalForceRunOnStartup: boolean;
     chatIndexForceRunOnStartup: boolean;
@@ -40,6 +41,7 @@ const ENV_KEYS = [
   "DISABLE_SANDBOX",
   "GEMINI_API_KEY",
   "X_BEARER_TOKEN",
+  "MULMOCLAUDE_AUTH_TOKEN",
   "SESSIONS_LIST_WINDOW_DAYS",
   "JOURNAL_FORCE_RUN_ON_STARTUP",
   "CHAT_INDEX_FORCE_RUN_ON_STARTUP",
@@ -74,6 +76,7 @@ describe("env defaults", () => {
     assert.equal(env.disableSandbox, false);
     assert.equal(env.geminiApiKey, undefined);
     assert.equal(env.xBearerToken, undefined);
+    assert.equal(env.authTokenOverride, undefined);
     assert.equal(env.sessionsListWindowDays, 90);
     assert.equal(env.journalForceRunOnStartup, false);
     assert.equal(env.chatIndexForceRunOnStartup, false);
@@ -142,6 +145,12 @@ describe("env coercion", () => {
     process.env.SESSIONS_LIST_WINDOW_DAYS = "30";
     const { env } = await loadEnvFresh();
     assert.equal(env.sessionsListWindowDays, 30);
+  });
+
+  it("MULMOCLAUDE_AUTH_TOKEN is passed through verbatim when set", async () => {
+    process.env.MULMOCLAUDE_AUTH_TOKEN = "pinned-value";
+    const { env } = await loadEnvFresh();
+    assert.equal(env.authTokenOverride, "pinned-value");
   });
 });
 


### PR DESCRIPTION
## Summary

- Lets the operator pin the bearer token across server restarts via `MULMOCLAUDE_AUTH_TOKEN` (same var name the CLI bridge and Vite dev plugin already honour — now symmetric)
- Default behavior unchanged: unset env → random per startup (as before)
- Bridges pinning the same value on their side survive server restarts

## Items to Confirm / Review

- **Symmetric env name** — `MULMOCLAUDE_AUTH_TOKEN` is reused, not something like `MULMOCLAUDE_SERVER_AUTH_TOKEN`. Setting it once in a shared shell pins both sides; if that asymmetric name is preferred, happy to rename.
- **No length/charset enforcement**, only a warn log when `<32` chars — matches the stance the client-side override has had since #272. If a hard minimum is wanted, call it out.
- **File is still written** even when the override is used. The Vite plugin and the CLI bridge both read from disk by default; keeping the file in sync means the env-var path doesn't create a second configuration surface.
- **Docs tradeoff note** — added "Use random-per-startup for casual dev and the env override only when the restart pain outweighs the leak surface (CI, docker, multi-bridge setups)" in `docs/developer.md`. Wording open to revision.

## User Prompt

PR #315 の手動テスト中に「サーバ再起動すると bridge 側の token が古くなるため再起動が必要」という運用上の痛み点が顕在化した。サーバ起動時にユーザが任意の token を固定で指定できるように、環境変数で対応してほしい。情報は環境変数をまとめているところ (`server/env.ts`) に置き、document の更新も含める。

## Implementation

See ``plans/feat-auth-token-env-override.md``.

**Modified:**
- ``server/env.ts`` — add ``authTokenOverride: process.env.MULMOCLAUDE_AUTH_TOKEN``
- ``server/auth/token.ts`` — ``generateAndWriteToken(tokenPath, override?)`` uses override verbatim; warns if shorter than 32 chars
- ``server/index.ts`` — one call site: ``generateAndWriteToken(undefined, env.authTokenOverride)`` + ``source=env|random`` in the startup log
- ``test/server/test_auth_token.ts`` — 5 new cases covering verbatim use, no-rotation, empty/undefined fallback, short-override warn-but-accept
- ``test/server/test_env.ts`` — snapshot + round-trip assertion for the new field
- ``docs/developer.md`` — Auth section adds the "Server-side pinning (#316)" subsection

**New:**
- ``plans/feat-auth-token-env-override.md``

## Test plan

- [x] ``npx tsx --test test/server/test_auth_token.ts test/server/test_env.ts`` — 37/37 pass
- [x] ``yarn test`` — 1972/1972 pass
- [x] ``yarn format`` / ``yarn lint`` / ``yarn typecheck`` / ``yarn build`` — clean
- [ ] Manual: ``MULMOCLAUDE_AUTH_TOKEN=mysharedtokenvalue1234567890 yarn dev``, then ``yarn cli`` in another terminal — restart the server, CLI should keep working without ``yarn cli`` re-run

## Related

- #272 — bearer token design
- #268 / #315 — socket.io bridge that made the restart-pain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)