### PR TITLE
refactor(chat-service): centralize socket event names (CHAT_SOCKET_EVENTS)

### DIFF
--- a/bridges/cli/index.ts
+++ b/bridges/cli/index.ts
@@ -1,5 +1,6 @@
 import * as readline from "readline";
 import { io, Socket } from "socket.io-client";
+import { CHAT_SOCKET_EVENTS } from "../../server/chat-service/socket.js";
 import { readBridgeToken, TOKEN_FILE_PATH } from "./token.js";
 
 const API_URL = process.env.MULMOCLAUDE_API_URL ?? "http://localhost:3001";
@@ -69,7 +70,7 @@ function installSocketLogging(socket: Socket): void {
   // the message into their platform's send API (Telegram
   // sendMessage etc.); the CLI prints it so the human operator can
   // see scheduled / event-driven messages arrive.
-  socket.on("push", (event: PushEvent) => {
+  socket.on(CHAT_SOCKET_EVENTS.push, (event: PushEvent) => {
     console.log(`\n[push] ${event.chatId}: ${event.message}\n`);
   });
 }
@@ -79,7 +80,7 @@ function send(socket: Socket, text: string): Promise<MessageAck> {
     socket
       .timeout(REPLY_TIMEOUT_MS)
       .emit(
-        "message",
+        CHAT_SOCKET_EVENTS.message,
         { externalChatId: CHAT_ID, text },
         (err: Error | null, ack: MessageAck | undefined) => {
           if (err) {

--- a/plans/feat-chat-socketio-phase-b.md
+++ b/plans/feat-chat-socketio-phase-b.md
@@ -61,7 +61,7 @@ changing the `pushToBridge` call site.
 
 Server → bridge, on `/ws/chat`:
 
-```
+```ts
 socket.emit("push", { chatId: string, message: string });
 ```
 

--- a/server/chat-service/socket.ts
+++ b/server/chat-service/socket.ts
@@ -35,6 +35,25 @@ import type { Logger } from "./types.js";
 
 export const CHAT_SOCKET_PATH = "/ws/chat";
 
+/**
+ * Custom socket.io events the chat transport defines. Keys mirror
+ * values so grep-and-rename is safe; the union type is what every
+ * on/emit site should reference instead of raw string literals.
+ * Socket.io built-ins (`connect`, `disconnect`, `connect_error`) are
+ * intentionally omitted — those are part of socket.io's own contract,
+ * not ours to rename.
+ */
+export const CHAT_SOCKET_EVENTS = {
+  /** bridge → server request (body: `{ externalChatId, text }`); ack
+   *  carries `{ ok, reply, error?, status? }`. */
+  message: "message",
+  /** server → bridge async push (Phase B of #268); body:
+   *  `{ chatId, message }`. */
+  push: "push",
+} as const;
+export type ChatSocketEvent =
+  (typeof CHAT_SOCKET_EVENTS)[keyof typeof CHAT_SOCKET_EVENTS];
+
 export type PushFn = (
   transportId: string,
   chatId: string,
@@ -124,7 +143,10 @@ export function attachChatSocket(
         count: queued.length,
       });
       for (const item of queued) {
-        socket.emit("push", { chatId: item.chatId, message: item.message });
+        socket.emit(CHAT_SOCKET_EVENTS.push, {
+          chatId: item.chatId,
+          message: item.message,
+        });
       }
     }
 
@@ -142,7 +164,7 @@ export function attachChatSocket(
     });
 
     socket.on(
-      "message",
+      CHAT_SOCKET_EVENTS.message,
       async (payload: MessagePayload, ack?: (reply: MessageAck) => void) => {
         if (typeof ack !== "function") {
           logger.warn("chat-service", "socket message missing ack", {
@@ -181,7 +203,7 @@ export function attachChatSocket(
     // about what socket.io actually knows.
     const hasLive = (io.sockets.adapter.rooms.get(room)?.size ?? 0) > 0;
     if (hasLive) {
-      io.to(room).emit("push", { chatId, message });
+      io.to(room).emit(CHAT_SOCKET_EVENTS.push, { chatId, message });
       return;
     }
     queue.enqueue(transportId, { chatId, message, enqueuedAt: Date.now() });

--- a/test/chat-service/test_push.ts
+++ b/test/chat-service/test_push.ts
@@ -5,6 +5,7 @@ import express from "express";
 import { io as ioClient, Socket as ClientSocket } from "socket.io-client";
 import {
   attachChatSocket,
+  CHAT_SOCKET_EVENTS,
   CHAT_SOCKET_PATH,
   type ChatSocketHandle,
 } from "../../server/chat-service/socket.ts";
@@ -101,7 +102,7 @@ function collectPushes(
         ),
       timeoutMs,
     );
-    socket.on("push", (ev: PushEvent) => {
+    socket.on(CHAT_SOCKET_EVENTS.push, (ev: PushEvent) => {
       received.push(ev);
       if (received.length >= count) {
         clearTimeout(timer);
@@ -160,7 +161,7 @@ describe("pushToBridge — live", () => {
     await waitConnect(cli);
 
     let received = false;
-    cli.on("push", () => {
+    cli.on(CHAT_SOCKET_EVENTS.push, () => {
       received = true;
     });
     harness.handle.pushToBridge("telegram", "chat-99", "not for cli");
@@ -224,7 +225,7 @@ describe("pushToBridge — offline queue + flush on reconnect", () => {
     // Second socket joins after the drain — should get nothing.
     const b = connectClient(harness.url);
     let bReceived = false;
-    b.on("push", () => {
+    b.on(CHAT_SOCKET_EVENTS.push, () => {
       bReceived = true;
     });
     await waitConnect(b);

--- a/test/chat-service/test_socket.ts
+++ b/test/chat-service/test_socket.ts
@@ -6,6 +6,7 @@ import { io as ioClient, Socket as ClientSocket } from "socket.io-client";
 import { Server as SocketServer } from "socket.io";
 import {
   attachChatSocket,
+  CHAT_SOCKET_EVENTS,
   CHAT_SOCKET_PATH,
 } from "../../server/chat-service/socket.ts";
 import { createPushQueue } from "../../server/chat-service/push-queue.ts";
@@ -100,7 +101,7 @@ function emitMessage(
   payload: unknown,
 ): Promise<{ ok: boolean; reply?: string; error?: string; status?: number }> {
   return new Promise((resolve) => {
-    client.emit("message", payload, resolve);
+    client.emit(CHAT_SOCKET_EVENTS.message, payload, resolve);
   });
 }
 


### PR DESCRIPTION
## Summary
Addresses CodeRabbit's Major finding on #318 and extends the same consolidation to the pre-existing `"message"` literal from Phase A. Stacked on \`feat/chat-socketio-phase-b\` so the review diff is just the refactor.

## Items to Confirm / Review
- **Scope extended beyond CodeRabbit's ask.** CodeRabbit flagged only `"push"`; this PR also consolidates `"message"` because it's the same cross-module-contract pattern that was missed in Phase A. The decision aligns with the #289 \"centralize string literals\" convention and keeps the events module a single source of truth.
- **Socket.io built-ins NOT aliased**: \`connect\`, \`disconnect\`, \`connect_error\` are intentionally left as literals because they're part of socket.io's own contract. Only events this codebase defines (\`message\`, \`push\`) go into \`CHAT_SOCKET_EVENTS\`.
- **Keys mirror values** (\`message: \"message\"\`, \`push: \"push\"\`) — matches \`BUILTIN_ROLE_IDS\` / \`TOOL_NAMES\` conventions, so grep-and-rename stays safe.
- **Markdown nitpick also applied**: \`ts\` language fence added to \`plans/feat-chat-socketio-phase-b.md\` (other CodeRabbit item).

## User Prompt
> はい、定数化必要ですね。他のところでも抜けがあれば対応してね
> あ、新しいブランチでね。

## Verification
- \`yarn format\` / \`yarn typecheck\` / \`yarn typecheck:server\` clean
- \`yarn lint\` 0 errors (5 pre-existing warnings)
- \`yarn test\` 1994/1994 pass

## Notes
- Base branch: \`feat/chat-socketio-phase-b\` (#318). Once #318 merges to main, this PR simplifies to a fix-only diff and can retarget main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)