### PR TITLE
feat(bridges): Telegram bridge (#321)

### DIFF
--- a/bridges/telegram/allowlist.ts
+++ b/bridges/telegram/allowlist.ts
@@ -1,0 +1,54 @@
+// Telegram chat-ID allowlist. Telegram bots accept messages from any
+// user who knows the bot's username — this is the one gate that keeps
+// the operator's MulmoClaude from being driven by the entire
+// internet. Default = empty set = deny everyone.
+//
+// Chat IDs are Telegram integers (positive for user chats, negative
+// for group chats). We parse strictly: a non-integer entry in the
+// CSV is a misconfiguration and should halt startup, not get silently
+// dropped.
+
+export interface Allowlist {
+  allows(chatId: number): boolean;
+  size(): number;
+  /** For logging — never returns a mutable reference. */
+  snapshot(): readonly number[];
+}
+
+/**
+ * Parse a comma-separated list of integer chat IDs. Throws if any
+ * entry isn't a valid integer so the operator notices a typo at
+ * startup instead of silently denying messages.
+ */
+export function parseAllowlist(raw: string | undefined): Allowlist {
+  const ids = new Set<number>();
+  if (raw && raw.trim().length > 0) {
+    for (const part of raw.split(",")) {
+      const trimmed = part.trim();
+      if (trimmed.length === 0) continue;
+      const n = Number(trimmed);
+      if (!Number.isInteger(n)) {
+        throw new Error(
+          `TELEGRAM_ALLOWED_CHAT_IDS: "${trimmed}" is not an integer chat id`,
+        );
+      }
+      ids.add(n);
+    }
+  }
+  return createAllowlist(ids);
+}
+
+export function createAllowlist(ids: Iterable<number>): Allowlist {
+  const set = new Set(ids);
+  return {
+    allows(chatId) {
+      return set.has(chatId);
+    },
+    size() {
+      return set.size;
+    },
+    snapshot() {
+      return Array.from(set).sort((a, b) => a - b);
+    },
+  };
+}

--- a/bridges/telegram/api.ts
+++ b/bridges/telegram/api.ts
@@ -1,0 +1,125 @@
+// Raw `fetch` wrapper for the Telegram Bot API. Only the two methods
+// the bridge actually uses (`getUpdates`, `sendMessage`) are exposed.
+//
+// Why raw fetch + no dep: the Telegram client-lib ecosystem is heavy
+// (event buses, middleware pipelines, type trees). We're driving two
+// endpoints; ~60 lines of fetch is cheaper than a dep's security-
+// review / lockfile footprint, and it leaves no doubt about which
+// methods touch the network.
+//
+// Message-length handling (4096 char cap, markdown mode, media
+// uploads) is deliberately out of scope for this file — the caller
+// in `bridges/telegram/index.ts` decides how to chunk long replies.
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+export interface TelegramMessage {
+  message_id: number;
+  chat: TelegramChat;
+  from?: TelegramUser;
+  text?: string;
+  date: number;
+}
+
+export interface TelegramChat {
+  id: number;
+  type: "private" | "group" | "supergroup" | "channel";
+  username?: string;
+  title?: string;
+}
+
+export interface TelegramUser {
+  id: number;
+  is_bot: boolean;
+  username?: string;
+  first_name: string;
+}
+
+export interface TelegramApiOptions {
+  botToken: string;
+  /** Base URL override for tests / self-hosted Telegram Bot API. */
+  baseUrl?: string;
+  /** Injectable fetch for tests — defaults to global. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface GetUpdatesOptions {
+  offset?: number;
+  timeoutSec?: number;
+  signal?: AbortSignal;
+}
+
+export interface TelegramApi {
+  getUpdates(opts?: GetUpdatesOptions): Promise<TelegramUpdate[]>;
+  sendMessage(chatId: number, text: string): Promise<void>;
+}
+
+const DEFAULT_BASE = "https://api.telegram.org";
+
+export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
+  const baseUrl = opts.baseUrl ?? DEFAULT_BASE;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const base = `${baseUrl}/bot${opts.botToken}`;
+
+  return {
+    async getUpdates(gu: GetUpdatesOptions = {}) {
+      const params = new URLSearchParams();
+      if (gu.offset !== undefined) params.set("offset", String(gu.offset));
+      if (gu.timeoutSec !== undefined) {
+        params.set("timeout", String(gu.timeoutSec));
+      }
+      const url = `${base}/getUpdates?${params.toString()}`;
+
+      const res = await fetchImpl(url, { signal: gu.signal });
+      if (!res.ok) {
+        throw new Error(
+          `getUpdates failed: ${res.status} ${await safeText(res)}`,
+        );
+      }
+      const body = (await res.json()) as {
+        ok: boolean;
+        description?: string;
+        result?: TelegramUpdate[];
+      };
+      if (!body.ok || !Array.isArray(body.result)) {
+        throw new Error(
+          `getUpdates API error: ${body.description ?? "unknown"}`,
+        );
+      }
+      return body.result;
+    },
+
+    async sendMessage(chatId, text) {
+      const res = await fetchImpl(`${base}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `sendMessage failed: ${res.status} ${await safeText(res)}`,
+        );
+      }
+      const body = (await res.json()) as {
+        ok: boolean;
+        description?: string;
+      };
+      if (!body.ok) {
+        throw new Error(
+          `sendMessage API error: ${body.description ?? "unknown"}`,
+        );
+      }
+    },
+  };
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "<unreadable body>";
+  }
+}

--- a/bridges/telegram/index.ts
+++ b/bridges/telegram/index.ts
@@ -1,0 +1,130 @@
+// Telegram bridge (issue #321). Polls Telegram for incoming
+// messages and dispatches them through the shared message router,
+// which enforces the chat-ID allowlist, forwards to MulmoClaude,
+// and delivers Phase-B pushes back through sendMessage.
+//
+// Env surface (see docs/message_apps/telegram/README.md):
+//   TELEGRAM_BOT_TOKEN          — BotFather token (required)
+//   TELEGRAM_ALLOWED_CHAT_IDS   — CSV of integer chat IDs (required
+//                                 in practice; empty = deny everyone)
+//   MULMOCLAUDE_API_URL         — optional override
+//   MULMOCLAUDE_AUTH_TOKEN      — optional override
+//   TELEGRAM_POLL_TIMEOUT_SEC   — optional, default 25
+
+import { createBridgeClient } from "../_lib/client.js";
+import { createTelegramApi, type TelegramApi } from "./api.js";
+import { parseAllowlist, type Allowlist } from "./allowlist.js";
+import { createMessageRouter, type MessageRouter } from "./router.js";
+
+const TRANSPORT_ID = "telegram";
+
+interface EnvConfig {
+  botToken: string;
+  allowlist: Allowlist;
+  pollTimeoutSec: number;
+}
+
+function readEnv(): EnvConfig {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  if (!botToken || botToken.trim().length === 0) {
+    console.error(
+      "TELEGRAM_BOT_TOKEN is required. See docs/message_apps/telegram/.",
+    );
+    process.exit(1);
+  }
+  let allowlist: Allowlist;
+  try {
+    allowlist = parseAllowlist(process.env.TELEGRAM_ALLOWED_CHAT_IDS);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+  const pollTimeoutSec = Number(process.env.TELEGRAM_POLL_TIMEOUT_SEC ?? "25");
+  if (!Number.isInteger(pollTimeoutSec) || pollTimeoutSec < 0) {
+    console.error("TELEGRAM_POLL_TIMEOUT_SEC must be a non-negative integer");
+    process.exit(1);
+  }
+  return { botToken, allowlist, pollTimeoutSec };
+}
+
+async function pollLoop(
+  api: TelegramApi,
+  router: MessageRouter,
+  opts: { pollTimeoutSec: number; abortSignal: AbortSignal },
+): Promise<void> {
+  let offset: number | undefined;
+  while (!opts.abortSignal.aborted) {
+    let updates;
+    try {
+      updates = await api.getUpdates({
+        offset,
+        timeoutSec: opts.pollTimeoutSec,
+        signal: opts.abortSignal,
+      });
+    } catch (err) {
+      if (opts.abortSignal.aborted) return;
+      console.error(`[telegram] getUpdates error: ${String(err)}`);
+      // Back off briefly so a broken network doesn't busy-loop.
+      await delay(1000);
+      continue;
+    }
+    for (const update of updates) {
+      offset = update.update_id + 1;
+      if (update.message) {
+        await router.handleMessage(update.message);
+      }
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const { botToken, allowlist, pollTimeoutSec } = readEnv();
+
+  console.log("MulmoClaude Telegram bridge");
+  console.log(
+    `Allowlist: ${
+      allowlist.size() > 0
+        ? allowlist.snapshot().join(", ")
+        : "(empty — all chats will be denied)"
+    }`,
+  );
+
+  const api = createTelegramApi({ botToken });
+  const client = createBridgeClient({ transportId: TRANSPORT_ID });
+  const router = createMessageRouter({
+    api,
+    allowlist,
+    sendToMulmo: (chatId, text) => client.send(chatId, text),
+  });
+
+  // Server → Telegram async push (Phase B of #268).
+  client.onPush((ev) => {
+    router
+      .handlePush(ev)
+      .catch((err) =>
+        console.error(`[telegram] handlePush failed: ${String(err)}`),
+      );
+  });
+
+  const abortController = new AbortController();
+  process.on("SIGINT", () => {
+    console.log("\nShutting down...");
+    abortController.abort();
+    client.close();
+    process.exit(0);
+  });
+
+  await pollLoop(api, router, {
+    pollTimeoutSec,
+    abortSignal: abortController.signal,
+  });
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/bridges/telegram/router.ts
+++ b/bridges/telegram/router.ts
@@ -1,0 +1,152 @@
+// Message-routing logic for the Telegram bridge. Kept separate from
+// `index.ts` so it can be exercised with stubbed deps (no real
+// Telegram API, no real MulmoClaude socket, no env reads). The
+// entrypoint in index.ts is then just: read env → wire real deps →
+// drive the polling loop.
+
+import type { TelegramApi, TelegramMessage } from "./api.js";
+import type { Allowlist } from "./allowlist.js";
+import type { MessageAck, PushEvent } from "../_lib/client.js";
+
+// Telegram caps a single message at 4096 chars. We split long
+// replies naively; pretty formatting (preserve markdown, break on
+// sentence boundaries) is a follow-up.
+const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
+
+export type SendToMulmoFn = (
+  externalChatId: string,
+  text: string,
+) => Promise<MessageAck>;
+
+export interface RouterDeps {
+  api: TelegramApi;
+  allowlist: Allowlist;
+  sendToMulmo: SendToMulmoFn;
+  /** Structured logger. Console-compatible shape — `[telegram]`
+   *  prefix is the router's responsibility. */
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export interface MessageRouter {
+  handleMessage(msg: TelegramMessage): Promise<void>;
+  handlePush(ev: PushEvent): Promise<void>;
+  /** For tests / debugging: chat IDs we've already sent the
+   *  access-denied notice to. */
+  deniedAlreadyNotified(): ReadonlySet<number>;
+}
+
+const defaultLog = {
+  info: (m: string) => console.log(m),
+  warn: (m: string) => console.warn(m),
+  error: (m: string) => console.error(m),
+};
+
+export function createMessageRouter(deps: RouterDeps): MessageRouter {
+  const { api, allowlist, sendToMulmo } = deps;
+  const log = deps.log ?? defaultLog;
+
+  // One denial reply per chat per bridge lifetime — restart clears.
+  // Prevents a sender from spamming the operator (and Telegram's
+  // rate limits) by repeatedly messaging a denied bot.
+  const deniedAlreadyNotified = new Set<number>();
+
+  async function handleAllowed(msg: TelegramMessage): Promise<void> {
+    const chatId = msg.chat.id;
+    const text = msg.text ?? "";
+    if (text.trim().length === 0) return;
+    const user = userLabel(msg);
+    log.info(
+      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}`,
+    );
+
+    const ack = await sendToMulmo(String(chatId), text);
+    if (ack.ok) {
+      await sendChunked(api, chatId, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await sendChunked(
+        api,
+        chatId,
+        `Error${status}: ${ack.error ?? "unknown"}`,
+      );
+    }
+  }
+
+  async function handleDenied(msg: TelegramMessage): Promise<void> {
+    const chatId = msg.chat.id;
+    const user = userLabel(msg);
+    log.warn(
+      `[telegram] denied chat=${chatId} user=@${user} — not on allowlist`,
+    );
+    if (deniedAlreadyNotified.has(chatId)) return;
+    deniedAlreadyNotified.add(chatId);
+    try {
+      await api.sendMessage(
+        chatId,
+        "Access denied. Contact the operator to be added to the allowlist.",
+      );
+    } catch (err) {
+      log.error(`[telegram] access-denied reply failed: ${String(err)}`);
+    }
+  }
+
+  return {
+    async handleMessage(msg) {
+      if (allowlist.allows(msg.chat.id)) {
+        await handleAllowed(msg);
+      } else {
+        await handleDenied(msg);
+      }
+    },
+
+    async handlePush(ev) {
+      const chatId = Number(ev.chatId);
+      if (!Number.isInteger(chatId)) {
+        log.warn(`[telegram] push chatId is not integer: ${ev.chatId}`);
+        return;
+      }
+      // Defense in depth: never sendMessage to a non-allowlisted
+      // chat, even when the push comes from our own server. A
+      // buggy task-manager or a compromised server shouldn't be
+      // able to reach arbitrary Telegram users.
+      if (!allowlist.allows(chatId)) {
+        log.warn(`[telegram] push denied: chat ${chatId} not on allowlist`);
+        return;
+      }
+      try {
+        await sendChunked(api, chatId, ev.message);
+      } catch (err) {
+        log.error(`[telegram] push sendMessage failed: ${String(err)}`);
+      }
+    },
+
+    deniedAlreadyNotified() {
+      return deniedAlreadyNotified;
+    },
+  };
+}
+
+async function sendChunked(
+  api: TelegramApi,
+  chatId: number,
+  text: string,
+): Promise<void> {
+  if (text.length === 0) {
+    await api.sendMessage(chatId, "(empty reply)");
+    return;
+  }
+  for (let i = 0; i < text.length; i += TELEGRAM_MAX_MESSAGE_CHARS) {
+    await api.sendMessage(
+      chatId,
+      text.slice(i, i + TELEGRAM_MAX_MESSAGE_CHARS),
+    );
+  }
+}
+
+function userLabel(msg: TelegramMessage): string {
+  return msg.from?.username ?? msg.from?.first_name ?? "unknown";
+}

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -50,6 +50,9 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 |---|---|---|
 | `GEMINI_API_KEY` | `server/utils/gemini.ts` | Enables Gemini image generation / editing. Without it, image plugins surface a UI warning. The `geminiAvailable` flag in `GET /api/health` mirrors this. |
 | `X_BEARER_TOKEN` | `server/mcp-tools/x.ts` | **Required** to enable `readXPost` / `searchX` MCP tools. Tools are silently disabled if absent. |
+| `TELEGRAM_BOT_TOKEN` | `bridges/telegram/` | **Required** for the Telegram bridge. BotFather token. Treat like a password. See [`message_apps/telegram/`](message_apps/telegram/). |
+| `TELEGRAM_ALLOWED_CHAT_IDS` | `bridges/telegram/` | CSV of integer Telegram chat IDs allowed to message the bot. Empty / unset → deny everyone. A non-integer entry halts startup. |
+| `TELEGRAM_POLL_TIMEOUT_SEC` | `bridges/telegram/` | Long-polling timeout in seconds. Defaults `25` (Telegram's recommended max). |
 
 ### Runtime
 
@@ -113,6 +116,8 @@ You never set these by hand; the server constructs them when spawning Claude ins
 | `yarn dev:client` | Vite client only — useful when you've already started the server elsewhere. |
 | `yarn dev:server` / `yarn server` | Express server only. |
 | `yarn server:debug` | Server with `--debug` flag. |
+| `yarn cli` | CLI bridge — REPL in your terminal that talks to the running server (see [`bridge-protocol.md`](bridge-protocol.md)). |
+| `yarn telegram` | Telegram bridge — operator guide at [`message_apps/telegram/`](message_apps/telegram/) (JP: [`README.ja.md`](message_apps/telegram/README.ja.md) / EN: [`README.md`](message_apps/telegram/README.md)). |
 
 ### Static checks
 

--- a/docs/message_apps/telegram/README.ja.md
+++ b/docs/message_apps/telegram/README.ja.md
@@ -1,0 +1,182 @@
+# MulmoClaude — Telegram ブリッジ
+
+自分の PC で動かしている MulmoClaude と Telegram アプリから会話
+できるようにします。このドキュメントは **運用者** 向け — MulmoClaude
+をホストしていて、bot を家族・友人と共有したい人を想定。
+
+English: [`README.md`](README.md)
+
+---
+
+## 完成した状態
+
+- 自作の Telegram bot (名前も画像も自由) が、自分の PC 上で
+  動く MulmoClaude にメッセージを中継する。
+- その bot に話しかけられる Telegram アカウントの **許可リスト**
+  (allowlist) を管理する。リスト外の人には `"Access denied"` が
+  返る。
+- ターミナル A で `yarn dev`、ターミナル B で `yarn telegram` を
+  同時に動かしている状態。
+
+PC を閉じたりネットを切ったりすると bot は沈黙します。
+
+---
+
+## ステップ 1 — BotFather で bot を作る
+
+1. Telegram (スマホ or デスクトップ) を開く。
+2. `@BotFather` を検索 (公式には青いチェックマーク)。チャットを
+   開始する。
+3. `/newbot` を送信。
+4. 2 つ聞かれるので答える:
+   - **表示名 (Display name)**: チャット上部に出る名前。何でも可。
+     例: `"アリスの MulmoClaude"`
+   - **ユーザー名 (Username)**: 末尾が `bot` で終わる、Telegram
+     全体でユニークな文字列。例: `alice_mulmoclaude_bot`
+5. BotFather が **token** を返す — `1234567890:AAHdqTcv…` のような
+   長い文字列。**この token は bot のパスワードです。外に漏らさない。**
+   token を持っている人は誰でも bot になりすませます。
+
+後から設定できる便利項目 (任意):
+
+- `/setdescription` — チャット開いた時の説明文
+- `/setuserpic` — アイコン画像
+- `/setprivacy` → `Disable` — グループチャットでも全メッセージを
+  見たい場合 (デフォルトはグループでは `/` 始まりのコマンドしか
+  見えない)
+
+---
+
+## ステップ 2 — MulmoClaude とブリッジを起動
+
+ターミナル A で MulmoClaude サーバを起動:
+
+```bash
+yarn dev
+```
+
+`[server] listening port=3001` が出るまで待つ。
+
+ターミナル B で Telegram ブリッジを起動する。allowlist は **最初は
+わざと空** にしておく (次ステップで自分の chat ID を取得するため):
+
+```bash
+export TELEGRAM_BOT_TOKEN='1234567890:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw'
+export TELEGRAM_ALLOWED_CHAT_IDS=''
+yarn telegram
+```
+
+こう表示されれば OK:
+
+```
+MulmoClaude Telegram bridge
+Allowlist: (empty — all chats will be denied)
+Connected (<socket id>).
+```
+
+---
+
+## ステップ 3 — 自分の chat ID を取得して allowlist に入れる
+
+1. Telegram で自分の bot (Step 1 で付けたユーザー名で検索) を
+   開き、適当に `hi` などメッセージを送る。
+2. ターミナル B の `yarn telegram` のログに:
+   ```
+   [telegram] denied chat=987654321 user=@alice — not on allowlist
+   ```
+   のような行が出る。`987654321` が **あなたの Telegram chat ID**。
+3. ブリッジを `Ctrl+C` で止めて、allowlist にその ID を入れて
+   再起動:
+
+   ```bash
+   export TELEGRAM_ALLOWED_CHAT_IDS='987654321'
+   yarn telegram
+   ```
+
+4. もう一度 bot にメッセージを送る → 今度は MulmoClaude からの
+   返信が返ってくる。
+
+---
+
+## ステップ 4 — 友人を招待
+
+友人にこの bot を使わせたい場合:
+
+1. 友人に bot のユーザー名を教える。友人が bot を検索してメッセージ
+   を送る。
+2. `yarn telegram` のターミナルに友人の chat ID が `denied` ログで
+   表示される。
+3. その ID を allowlist に追加して再起動:
+
+   ```bash
+   export TELEGRAM_ALLOWED_CHAT_IDS='987654321,123456789'
+   yarn telegram
+   ```
+
+4. 友人がもう一度 bot に話しかけると通るようになる。
+
+環境変数は `.env` やシェルの rc ファイルに書いておくと毎回 export
+しなくて済みます。
+
+---
+
+## bot が理解するコマンド
+
+CLI と同じです。Telegram チャットにそのまま入力してください:
+
+- `/help` — ヘルプ表示
+- `/reset` — 新しい会話セッションを開始
+- `/roles` — 利用可能なロール一覧
+- `/role <id>` — ロール切替
+- `/status` — 現在のセッション情報
+
+それ以外のテキストはアシスタントへのメッセージとして扱われます。
+
+---
+
+## トラブルシューティング
+
+**ブリッジに `Connect error: bearer token rejected` が出る。**
+MulmoClaude サーバを再起動すると bearer token が変わります。
+`yarn telegram` を再起動すれば新しい token を読み込みます。
+毎回再起動したくないなら、サーバと bridge の両方で
+`MULMOCLAUDE_AUTH_TOKEN` を同じ値に固定してください
+([`../../developer.md`](../../developer.md) の Auth セクション参照)。
+
+**`TELEGRAM_ALLOWED_CHAT_IDS: "foo" is not an integer chat id` と出る。**
+allowlist に書き間違いがあります。chat ID は整数のみ — 空白・
+引用符・`#` プレフィックスは入れられません。
+
+**友人の ID を追加したのに `"Access denied"` と返る。**
+env を変えた後にブリッジを再起動しましたか？ allowlist は起動時に
+一度だけ読まれます。
+
+**エラーも出ないのに返事が返ってこない。**
+`yarn dev` が生きているか確認。サーバを閉じてもブリッジは起動
+したままですが、話しかける相手がいません。次のメッセージで
+`Connect error` か `Disconnected` が出るはずです。
+
+**1 ユーザーしか入れていないのに、グループチャットで bot が
+反応する。**
+グループの chat ID は **負の数** (Telegram の仕様)。特定のグループ
+を許可したい場合はその負の ID を allowlist に入れてください。
+デフォルトでは BotFather が作る bot は「グループプライバシーモード」
+が有効で、グループでは `/` 始まりのコマンドしか見えません。全
+メッセージを見せたい場合は BotFather の `/setprivacy` で切り替え
+てください。
+
+---
+
+## セキュリティに関する注意
+
+- bot token はパスワードと同じ扱い。漏れたら BotFather で
+  `/revoke` を実行して再生成してください。
+- allowlist だけが「友人」と「地球上の全 Telegram ユーザー」を
+  隔てる唯一の防御です。友人でなくなった人の chat ID は外して
+  ブリッジを再起動してください。
+- ブリッジは chat ID・ユーザー名・メッセージ長をログに残しますが、
+  **メッセージ本文や bot token は残しません**。完全な監査ログが
+  必要なら、別途 Telegram 側で何か記録する必要があります。
+- MulmoClaude の bearer token は外に出ません。Telegram bridge は
+  `localhost:3001` にしか繋がらず、あなたの友人は Telegram の
+  サーバとだけ通信します。

--- a/docs/message_apps/telegram/README.md
+++ b/docs/message_apps/telegram/README.md
@@ -1,0 +1,182 @@
+# MulmoClaude — Telegram bridge
+
+Talk to your MulmoClaude from the Telegram app. This guide is for
+**operators** — the person running MulmoClaude on their machine and
+sharing the bot with friends / family.
+
+日本語版は [`README.ja.md`](README.ja.md) にあります。
+
+---
+
+## What you'll have when you're done
+
+- A Telegram bot (your own — with a name and picture you pick) that
+  forwards messages to the MulmoClaude running on your computer.
+- A short allowlist of Telegram accounts that can talk to the bot.
+  Everyone else gets `"Access denied"`.
+- `yarn dev` running in one terminal, `yarn telegram` in another,
+  both on your machine.
+
+Your computer has to be on and connected to the internet for the
+bot to respond. Close the laptop → the bot goes silent.
+
+---
+
+## Step 1 — Create the bot with BotFather
+
+1. Open Telegram (mobile or desktop).
+2. Search for `@BotFather` (the official account has a blue check).
+   Start a chat.
+3. Send `/newbot`.
+4. Answer the two prompts:
+   - **Display name**: what shows in chat headers. Anything, e.g.
+     `"Alice's MulmoClaude"`.
+   - **Username**: must end in `bot`, must be unique on Telegram.
+     e.g. `alice_mulmoclaude_bot`.
+5. BotFather replies with a **token** — a long string like
+   `1234567890:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw`. **This is the
+   bot's password. Keep it secret.** Anyone with this token can
+   impersonate the bot.
+
+Optional niceties (can be done later):
+
+- `/setdescription` — what users see when opening the chat
+- `/setuserpic` — a picture
+- `/setprivacy` → `Disable` if you want the bot to respond in
+  group chats (not just 1-on-1 DMs)
+
+---
+
+## Step 2 — Run MulmoClaude and start the bridge
+
+In one terminal, start MulmoClaude as usual:
+
+```bash
+yarn dev
+```
+
+Wait until you see `[server] listening port=3001`.
+
+In a second terminal, run the Telegram bridge with your token. The
+allowlist is **empty on purpose** the first time — we'll fill it in
+Step 3.
+
+```bash
+export TELEGRAM_BOT_TOKEN='1234567890:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw'
+export TELEGRAM_ALLOWED_CHAT_IDS=''
+yarn telegram
+```
+
+You should see:
+
+```
+MulmoClaude Telegram bridge
+Allowlist: (empty — all chats will be denied)
+Connected (<socket id>).
+```
+
+---
+
+## Step 3 — Find your own chat ID, add it to the allowlist
+
+1. On Telegram, open your new bot (search the username you
+   picked). Send any message — `hi` is fine.
+2. On the terminal running `yarn telegram`, you'll see something
+   like:
+   ```
+   [telegram] denied chat=987654321 user=@alice — not on allowlist
+   ```
+   That number (`987654321`) is **your Telegram chat ID**.
+3. Stop the bridge (`Ctrl+C`), set it on the allowlist, restart:
+
+   ```bash
+   export TELEGRAM_ALLOWED_CHAT_IDS='987654321'
+   yarn telegram
+   ```
+
+4. Send the bot another message. This time you should get a reply
+   from MulmoClaude.
+
+---
+
+## Step 4 — Invite a friend
+
+When a friend wants to use your MulmoClaude:
+
+1. They find the bot on Telegram (share the username) and send it
+   a message.
+2. Check your `yarn telegram` terminal — the bridge prints the
+   friend's chat ID in the `denied` log line.
+3. Add their chat ID to `TELEGRAM_ALLOWED_CHAT_IDS`, restart:
+
+   ```bash
+   export TELEGRAM_ALLOWED_CHAT_IDS='987654321,123456789'
+   yarn telegram
+   ```
+
+4. The friend messages the bot again — it now works.
+
+You can also put the env vars in a `.env` file or a shell profile
+so you don't have to re-export on every restart.
+
+---
+
+## Commands the bot understands
+
+Same as the CLI — type these in the Telegram chat:
+
+- `/help` — show help
+- `/reset` — start a new conversation session
+- `/roles` — list available roles
+- `/role <id>` — switch to a role
+- `/status` — show the current session info
+
+Anything else is a message to the assistant.
+
+---
+
+## Troubleshooting
+
+**The bridge shows `Connect error: bearer token rejected`.**
+The MulmoClaude server was restarted, so the bearer token changed.
+Re-run `yarn telegram` to pick up the new one. If you want to
+avoid this, pin the token with `MULMOCLAUDE_AUTH_TOKEN` on both
+sides (see [`../../developer.md`](../../developer.md) §Auth).
+
+**`TELEGRAM_ALLOWED_CHAT_IDS: "foo" is not an integer chat id`.**
+A typo in the allowlist. Chat IDs are integers — no spaces, no
+quotes, no `#` prefixes.
+
+**Friend gets `"Access denied"` even though I added their ID.**
+Did you restart the bridge after changing the env? The allowlist
+is read once at startup.
+
+**Messages stop flowing with no error.**
+Check `yarn dev` is still running. If you closed the MulmoClaude
+server, the bridge stays up but has nothing to talk to. The next
+message will print `Connect error` or `Disconnected`.
+
+**The bot replies from a group chat even though I only added one
+user.**
+Group chat IDs are **negative** (Telegram convention). If you want
+to allow a specific group, add that negative ID. By default
+BotFather creates bots with "group privacy mode" on, which means
+the bot only sees messages starting with `/` in groups — change
+that via BotFather's `/setprivacy` if you want the group use case.
+
+---
+
+## Security notes
+
+- The bot token is like a password. If it leaks, regenerate it via
+  BotFather `/revoke`.
+- The allowlist is the one defense between "a friend" and "any
+  Telegram user on Earth". Keep it current; when a friend stops
+  being a friend, remove their chat ID and restart.
+- The bridge logs chat IDs, usernames, and message lengths — but
+  never message contents or the bot token. If you need a full
+  audit trail, keep a separate Telegram-side log (BotFather
+  doesn't provide one by default).
+- Your MulmoClaude's bearer token never leaves your machine. The
+  Telegram bridge connects to `localhost:3001` only; your friends
+  talk to Telegram's servers, not yours.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "server": "tsx server/index.ts",
     "server:debug": "tsx server/index.ts --debug",
     "cli": "tsx bridges/cli/index.ts",
+    "telegram": "tsx bridges/telegram/index.ts",
     "lint": "eslint src server test e2e bridges",
     "format": "prettier --write '{src,server,test,e2e,bridges}/**/*.{ts,json,yaml,vue}'",
     "typecheck": "vue-tsc --noEmit",

--- a/plans/feat-telegram-bridge.md
+++ b/plans/feat-telegram-bridge.md
@@ -1,0 +1,166 @@
+# feat(bridges): Telegram bridge
+
+Tracks issue #321.
+
+## Goal
+
+Second bridge after CLI. Users run `yarn telegram` next to
+`yarn dev`, chat with a Telegram bot they created via BotFather,
+and MulmoClaude responds as if the chat came from any other
+front-end. Target audience is non-dev friends / family the
+operator shares the bot with.
+
+Depends on the shared client lib from #320 (merged).
+
+## Wire-level plumbing
+
+Two Telegram Bot API calls, raw `fetch` — no `node-telegram-bot-api`
+or `grammy` dependency:
+
+- `getUpdates` with `timeout=25` (long polling). Returns inbound
+  messages and a monotonic `update_id` for offset tracking.
+- `sendMessage` to deliver a text reply.
+
+Two MulmoClaude client calls, via `createBridgeClient` from
+`bridges/_lib/client.ts`:
+
+- `client.send(externalChatId, text)` — Telegram `chat.id` →
+  `externalChatId`; Telegram `message.text` → `text`; wait for the
+  ack; call `sendMessage`.
+- `client.onPush((ev) => telegramSendMessage(ev.chatId, ev.message))` —
+  server-originated pushes (Phase B #318).
+
+The bridge stays stateless. All chat state lives in MulmoClaude.
+
+## Allowlist (mandatory — first world-facing surface)
+
+Telegram bots are reachable by any Telegram user who knows the
+bot's username. Unlike CLI / HTTP (both localhost-gated by bearer
+token), this is the first bridge that accepts input from the open
+internet. Without an allowlist, anyone could:
+
+- Invoke Claude on the operator's machine
+- Burn API credits
+- Touch the workspace via prompts
+
+**Rules:**
+
+- `TELEGRAM_ALLOWED_CHAT_IDS` env var, comma-separated integer chat
+  IDs (Telegram chat IDs are numeric — positive for user chats,
+  negative for groups).
+- Parse at startup. Empty / unset → empty allowlist → deny
+  everyone. (Don't default-allow; a blank env is almost always a
+  misconfiguration.)
+- On a message from a non-allowed chat:
+  - Reply once with
+    `"Access denied. Contact the operator to be added to the allowlist."`
+  - Log at `warn` with the rejected chat ID + username so the
+    operator can decide whether to add them.
+  - Do NOT forward to MulmoClaude.
+- On a message from an allowed chat:
+  - Log at `info` with chat ID + username (audit trail).
+  - Forward normally.
+
+Edge cases:
+- `TELEGRAM_ALLOWED_CHAT_IDS` with a non-integer entry → refuse to
+  start, exit with an error. Silent ignore would hide typos that
+  would otherwise allow nobody and confuse the operator.
+- Also gate `onPush` callbacks: only call `sendMessage` if the
+  destination `chatId` is in the allowlist. Defense in depth
+  against a buggy / malicious task-manager sending to arbitrary
+  chats.
+
+## Scope
+
+### In
+
+- `bridges/telegram/index.ts` — polling loop, glue between Telegram
+  and `createBridgeClient`. ~100 lines.
+- `bridges/telegram/api.ts` — raw fetch wrappers, just
+  `getUpdates` + `sendMessage` + the shared result types. ~60
+  lines.
+- `bridges/telegram/allowlist.ts` — parse + check
+  `TELEGRAM_ALLOWED_CHAT_IDS`, exported factory so tests can build
+  one without touching env.
+- `package.json` — `"telegram": "tsx bridges/telegram/index.ts"`
+  script.
+- Tests (`test/bridges/telegram/`):
+  - `test_allowlist.ts` — parse edge cases, contains checks.
+  - `test_api.ts` — fetch-mocked `getUpdates` / `sendMessage`.
+  - `test_index.ts` — integration with a stubbed Telegram API and
+    a stubbed bridge client: allowed messages forward, denied
+    messages reply with access-denied, push events deliver through
+    the allowlist.
+- End-user docs:
+  - `docs/message_apps/telegram/README.md` (English)
+  - `docs/message_apps/telegram/README.ja.md` (Japanese)
+  - Both cover: BotFather setup, env vars, `yarn telegram`,
+    finding your chat ID, allowlist management, troubleshooting.
+- `docs/developer.md` — one-line pointer to the Telegram docs /
+  env vars section.
+
+### Out
+
+- Inline keyboards / rich message formatting
+- Non-text content (photos, audio, files)
+- Webhook mode (long-polling only — no public URL needed)
+- Always-on VM setup (the operator runs it on their own machine;
+  docs mention "laptop has to be open" as the obvious limit)
+- Multi-bot support (one bot token per bridge process; run
+  multiple `yarn telegram` processes with different transportIds
+  if you need many bots)
+
+## Env surface
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | Yes | BotFather token. Kept secret, never logged. |
+| `TELEGRAM_ALLOWED_CHAT_IDS` | Yes (else denies all) | CSV of integer chat IDs |
+| `MULMOCLAUDE_API_URL` | No | Defaults `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Overrides the `~/mulmoclaude/.session-token` file read |
+| `TELEGRAM_POLL_TIMEOUT_SEC` | No | Defaults 25 (Telegram recommendation); env for testing |
+
+All read via a small `env.ts` inside `bridges/telegram/` to keep it
+self-contained. We don't route through `server/env.ts` because the
+bridge is a separate process family.
+
+## Operator story (docs outline)
+
+1. Open Telegram, find `@BotFather`, send `/newbot`, answer
+   prompts (display name + unique username ending in "bot"). You
+   receive a token like `1234567890:AA…`.
+2. Set `TELEGRAM_BOT_TOKEN` and (initially) empty
+   `TELEGRAM_ALLOWED_CHAT_IDS`. Run `yarn telegram`. Message the
+   bot from your own Telegram account. The bridge logs the
+   rejection: `chat 987654 denied (user @alice)`. Copy the number
+   into `TELEGRAM_ALLOWED_CHAT_IDS`. Restart.
+3. To add a friend: they message the bot, the bridge logs their
+   chat ID, operator adds it to the allowlist and restarts.
+
+## Security notes
+
+- Bot token leak surface: env var, process listing
+  (`ps` / `/proc`). Same posture as other secrets — document
+  "treat like a password".
+- Allowlist check happens in the bridge process, not the server.
+  The server sees `transportId=telegram` + an `externalChatId`
+  string; it has no concept of "this is allowed". Keeping the
+  check bridge-side is consistent with the platform-specifics
+  boundary and avoids pushing Telegram knowledge into
+  `chat-service`.
+- Logging user-provided text at `info` is avoided — message
+  contents stay out of logs; only the chat ID + username +
+  message-length are logged. Operators who need full audit can
+  raise the log level or add a platform-side Telegram log.
+
+## Risk / open items
+
+- Telegram's `getUpdates` long-polling loops indefinitely. Clean
+  shutdown on `SIGINT` — abort the in-flight fetch with
+  `AbortController`, close the socket cleanly. Docs mention this
+  as a nicety but it shouldn't block the first cut.
+- Message length: Telegram caps at 4096 chars. For now, split
+  naively on 4096 and send as multiple messages. Pretty format
+  (markdown, code-block preservation across splits) is a follow-up.
+- Rate limits: Telegram allows ~30 messages/sec per bot. Not a
+  concern for a personal bot but document the limit.

--- a/test/bridges/telegram/test_allowlist.ts
+++ b/test/bridges/telegram/test_allowlist.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createAllowlist,
+  parseAllowlist,
+} from "../../../bridges/telegram/allowlist.ts";
+
+describe("parseAllowlist", () => {
+  it("empty / undefined → deny-everyone allowlist", () => {
+    for (const input of [undefined, "", "   "]) {
+      const list = parseAllowlist(input);
+      assert.equal(list.size(), 0);
+      assert.equal(list.allows(123), false);
+      assert.equal(list.allows(0), false);
+    }
+  });
+
+  it("parses a single integer", () => {
+    const list = parseAllowlist("12345");
+    assert.equal(list.size(), 1);
+    assert.equal(list.allows(12345), true);
+    assert.equal(list.allows(6789), false);
+  });
+
+  it("parses a CSV with whitespace around entries", () => {
+    const list = parseAllowlist("1, 2 ,3");
+    assert.deepEqual(list.snapshot(), [1, 2, 3]);
+  });
+
+  it("accepts negative chat IDs (groups) and zero is valid", () => {
+    const list = parseAllowlist("-100123,0,42");
+    assert.equal(list.allows(-100123), true);
+    assert.equal(list.allows(0), true);
+    assert.equal(list.allows(42), true);
+  });
+
+  it("drops empty segments from trailing commas", () => {
+    const list = parseAllowlist("1,2,");
+    assert.deepEqual(list.snapshot(), [1, 2]);
+  });
+
+  it("deduplicates repeated entries", () => {
+    const list = parseAllowlist("7,7,7");
+    assert.equal(list.size(), 1);
+    assert.equal(list.allows(7), true);
+  });
+
+  it("throws on non-integer entries (typo detector)", () => {
+    assert.throws(() => parseAllowlist("abc"), /not an integer/);
+    assert.throws(() => parseAllowlist("1,two,3"), /"two"/);
+    assert.throws(() => parseAllowlist("1.5"), /not an integer/);
+  });
+});
+
+describe("createAllowlist", () => {
+  it("builds a list from any iterable", () => {
+    const list = createAllowlist([1, 2, 3]);
+    assert.equal(list.allows(2), true);
+    assert.equal(list.allows(4), false);
+  });
+
+  it("snapshot() returns a sorted copy, caller cannot mutate state", () => {
+    const list = createAllowlist([3, 1, 2]);
+    const snap = list.snapshot() as number[];
+    assert.deepEqual(snap, [1, 2, 3]);
+    snap.push(999);
+    assert.equal(list.allows(999), false);
+  });
+});

--- a/test/bridges/telegram/test_api.ts
+++ b/test/bridges/telegram/test_api.ts
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createTelegramApi } from "../../../bridges/telegram/api.ts";
+
+interface FakeCall {
+  url: string;
+  init?: Parameters<typeof fetch>[1];
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+describe("TelegramApi.getUpdates", () => {
+  let calls: FakeCall[];
+  beforeEach(() => {
+    calls = [];
+  });
+
+  const fetchStub = (
+    script: (call: FakeCall) => Response | Promise<Response>,
+  ): typeof fetch =>
+    (async (input, init) => {
+      const call: FakeCall = {
+        url: typeof input === "string" ? input : input.toString(),
+        init,
+      };
+      calls.push(call);
+      return script(call);
+    }) as typeof fetch;
+
+  it("hits /getUpdates with offset and timeout query params", async () => {
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: fetchStub(() => jsonResponse({ ok: true, result: [] })),
+    });
+    await api.getUpdates({ offset: 42, timeoutSec: 25 });
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].url.includes("/botTKN/getUpdates"));
+    assert.ok(calls[0].url.includes("offset=42"));
+    assert.ok(calls[0].url.includes("timeout=25"));
+  });
+
+  it("returns updates on success", async () => {
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: fetchStub(() =>
+        jsonResponse({
+          ok: true,
+          result: [
+            {
+              update_id: 1,
+              message: {
+                message_id: 1,
+                chat: { id: 999, type: "private" },
+                date: 0,
+                text: "hi",
+              },
+            },
+          ],
+        }),
+      ),
+    });
+    const updates = await api.getUpdates();
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].update_id, 1);
+    assert.equal(updates[0].message?.text, "hi");
+  });
+
+  it("throws on non-2xx HTTP status", async () => {
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: fetchStub(() => textResponse("rate limited", 429)),
+    });
+    await assert.rejects(api.getUpdates(), /429/);
+  });
+
+  it("throws when the API response has ok=false", async () => {
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: fetchStub(() =>
+        jsonResponse({ ok: false, description: "Unauthorized" }),
+      ),
+    });
+    await assert.rejects(api.getUpdates(), /Unauthorized/);
+  });
+});
+
+describe("TelegramApi.sendMessage", () => {
+  it("POSTs JSON with chat_id and text", async () => {
+    const captured: { url?: string; body?: string } = {};
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: (async (input, init) => {
+        captured.url = typeof input === "string" ? input : input.toString();
+        captured.body = init?.body as string;
+        return jsonResponse({ ok: true });
+      }) as typeof fetch,
+    });
+    await api.sendMessage(123, "hello");
+    assert.ok(captured.url?.endsWith("/sendMessage"));
+    const parsed = JSON.parse(captured.body ?? "{}");
+    assert.equal(parsed.chat_id, 123);
+    assert.equal(parsed.text, "hello");
+  });
+
+  it("throws on API error", async () => {
+    const api = createTelegramApi({
+      botToken: "TKN",
+      fetchImpl: (async () =>
+        jsonResponse({
+          ok: false,
+          description: "chat not found",
+        })) as typeof fetch,
+    });
+    await assert.rejects(api.sendMessage(1, "x"), /chat not found/);
+  });
+});

--- a/test/bridges/telegram/test_router.ts
+++ b/test/bridges/telegram/test_router.ts
@@ -1,0 +1,240 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createMessageRouter,
+  type SendToMulmoFn,
+} from "../../../bridges/telegram/router.ts";
+import type {
+  TelegramApi,
+  TelegramMessage,
+} from "../../../bridges/telegram/api.ts";
+import { createAllowlist } from "../../../bridges/telegram/allowlist.ts";
+import type { PushEvent } from "../../../bridges/_lib/client.ts";
+
+interface SentMessage {
+  chatId: number;
+  text: string;
+}
+
+function stubApi(): TelegramApi & { sent: SentMessage[] } {
+  const sent: SentMessage[] = [];
+  return {
+    sent,
+    async getUpdates() {
+      return [];
+    },
+    async sendMessage(chatId, text) {
+      sent.push({ chatId, text });
+    },
+  };
+}
+
+function msg(
+  chatId: number,
+  text: string,
+  username = "alice",
+): TelegramMessage {
+  return {
+    message_id: 1,
+    chat: { id: chatId, type: "private" },
+    from: { id: 1, is_bot: false, first_name: "A", username },
+    date: 0,
+    text,
+  };
+}
+
+const silentLog = { info: () => {}, warn: () => {}, error: () => {} };
+
+describe("router.handleMessage — allowed chat", () => {
+  let api: ReturnType<typeof stubApi>;
+  let mulmoCalls: { chatId: string; text: string }[];
+  const sendOK: SendToMulmoFn = async (chatId, text) => {
+    mulmoCalls.push({ chatId, text });
+    return { ok: true, reply: "hi back" };
+  };
+
+  beforeEach(() => {
+    api = stubApi();
+    mulmoCalls = [];
+  });
+
+  it("forwards an allowed message and sends the reply", async () => {
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendOK,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(42, "hello"));
+    assert.deepEqual(mulmoCalls, [{ chatId: "42", text: "hello" }]);
+    assert.deepEqual(api.sent, [{ chatId: 42, text: "hi back" }]);
+  });
+
+  it("ignores whitespace-only messages (doesn't call MulmoClaude)", async () => {
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendOK,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(42, "   "));
+    assert.equal(mulmoCalls.length, 0);
+    assert.equal(api.sent.length, 0);
+  });
+
+  it("relays error acks as an error message", async () => {
+    const sendErr: SendToMulmoFn = async () => ({
+      ok: false,
+      error: "boom",
+      status: 500,
+    });
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendErr,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(42, "hi"));
+    assert.equal(api.sent.length, 1);
+    assert.match(api.sent[0].text, /Error \(500\): boom/);
+  });
+
+  it("splits replies longer than 4096 chars into multiple sendMessage calls", async () => {
+    const longReply = "x".repeat(4096 * 2 + 100);
+    const sendLong: SendToMulmoFn = async () => ({
+      ok: true,
+      reply: longReply,
+    });
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendLong,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(42, "tell me"));
+    assert.equal(api.sent.length, 3);
+    assert.equal(api.sent[0].text.length, 4096);
+    assert.equal(api.sent[1].text.length, 4096);
+    assert.equal(api.sent[2].text.length, 100);
+  });
+
+  it("empty reply becomes '(empty reply)' so the user sees something", async () => {
+    const sendEmpty: SendToMulmoFn = async () => ({ ok: true, reply: "" });
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendEmpty,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(42, "ping"));
+    assert.deepEqual(api.sent, [{ chatId: 42, text: "(empty reply)" }]);
+  });
+});
+
+describe("router.handleMessage — denied chat", () => {
+  const mulmoNever: SendToMulmoFn = async () => {
+    throw new Error("should not be called for denied chats");
+  };
+
+  it("replies with access-denied once and skips the forward", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([]),
+      sendToMulmo: mulmoNever,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(999, "hi"));
+    assert.equal(api.sent.length, 1);
+    assert.match(api.sent[0].text, /Access denied/);
+    assert.equal(router.deniedAlreadyNotified().has(999), true);
+  });
+
+  it("does not re-notify the same denied chat on subsequent messages", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([]),
+      sendToMulmo: mulmoNever,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(999, "first"));
+    await router.handleMessage(msg(999, "second"));
+    await router.handleMessage(msg(999, "third"));
+    assert.equal(api.sent.length, 1);
+  });
+
+  it("notifies different denied chats separately", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([]),
+      sendToMulmo: mulmoNever,
+      log: silentLog,
+    });
+    await router.handleMessage(msg(111, "x"));
+    await router.handleMessage(msg(222, "y"));
+    assert.equal(api.sent.length, 2);
+    assert.deepEqual(
+      api.sent.map((s) => s.chatId).sort((a, b) => a - b),
+      [111, 222],
+    );
+  });
+});
+
+describe("router.handlePush", () => {
+  function push(chatId: string, message: string): PushEvent {
+    return { chatId, message };
+  }
+
+  it("delivers to an allowed chat", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: (async () => ({ ok: true })) as SendToMulmoFn,
+      log: silentLog,
+    });
+    await router.handlePush(push("42", "your daily brief"));
+    assert.deepEqual(api.sent, [{ chatId: 42, text: "your daily brief" }]);
+  });
+
+  it("silently drops a push to a non-allowed chat (defense in depth)", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: (async () => ({ ok: true })) as SendToMulmoFn,
+      log: silentLog,
+    });
+    await router.handlePush(push("999", "leaked"));
+    assert.equal(api.sent.length, 0);
+  });
+
+  it("drops a push with a non-integer chatId", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: (async () => ({ ok: true })) as SendToMulmoFn,
+      log: silentLog,
+    });
+    await router.handlePush(push("not-a-number", "x"));
+    assert.equal(api.sent.length, 0);
+  });
+
+  it("chunks long push messages over 4096 chars", async () => {
+    const api = stubApi();
+    const router = createMessageRouter({
+      api,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: (async () => ({ ok: true })) as SendToMulmoFn,
+      log: silentLog,
+    });
+    const long = "y".repeat(5000);
+    await router.handlePush(push("42", long));
+    assert.equal(api.sent.length, 2);
+    assert.equal(api.sent[0].text.length, 4096);
+    assert.equal(api.sent[1].text.length, 904);
+  });
+});


### PR DESCRIPTION
## Summary

- Second bridge after CLI. Operators create a bot via BotFather, set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOWED_CHAT_IDS`, run `yarn telegram` alongside `yarn dev`.
- First world-facing surface — mandatory chat-ID allowlist, deny-by-default.
- Raw `fetch` to the Bot API (no `node-telegram-bot-api` / `grammy` dep).
- Long-polling (`getUpdates`) so the bridge works from behind NAT with no public URL.
- End-user docs in **English and Japanese** under `docs/message_apps/telegram/` as requested.

## Items to Confirm / Review

- **Allowlist defaults to empty = deny-everyone**. A non-integer entry in `TELEGRAM_ALLOWED_CHAT_IDS` halts startup (typo detector). Alternative would be log-and-skip; chosen halt so misconfig is loud.
- **One access-denied reply per rejected chat, per bridge lifetime**. Restart clears the memory. Prevents an attacker spamming your Telegram rate limit by flooding the bot.
- **Push allowlist check (defense in depth)**. Even if a buggy task-manager tries to push to an arbitrary chat ID, the bridge silently drops it if not on the allowlist.
- **Raw fetch vs grammy / node-telegram-bot-api** — ~60 lines of `api.ts` vs a ~1 MB dep. Happy to switch if anyone feels strongly.
- **Message chunking on 4096 chars** is naive character split. Preserving markdown / sentence boundaries is a documented follow-up.
- **Directory naming**: put docs under `docs/message_apps/` (plural) rather than the literal `docs/message_app/` from the issue — matches other plural container dirs. Trivial to rename if you prefer the original.

## User Prompt

テレグラム実装。エンドユーザー向けに、日本語と英語で。`docs/message_app/telegram` みたいな、わかりやすい dir において。セキュリティ面も含めて安全に。

## Implementation

See `plans/feat-telegram-bridge.md`.

**New:**
- `bridges/telegram/api.ts` — raw fetch wrapper (`getUpdates`, `sendMessage`)
- `bridges/telegram/allowlist.ts` — strict CSV parser
- `bridges/telegram/router.ts` — DI-pure message routing + push routing
- `bridges/telegram/index.ts` — thin entrypoint (env read → poll → wire deps)
- `docs/message_apps/telegram/README.md` — English operator guide
- `docs/message_apps/telegram/README.ja.md` — Japanese operator guide
- `test/bridges/telegram/test_allowlist.ts` — parse edge cases (9 tests)
- `test/bridges/telegram/test_api.ts` — fetch-mocked API tests (6 tests)
- `test/bridges/telegram/test_router.ts` — allow/deny/push paths (12 tests)
- `plans/feat-telegram-bridge.md`

**Modified:**
- `package.json` — `"telegram": "tsx bridges/telegram/index.ts"`
- `docs/developer.md` — Telegram env var table + bridge script pointers

## Test plan

- [x] `npx tsx --test test/bridges/telegram/*.ts` — 27/27 pass
- [x] `yarn test` — 2008/2008 pass
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn build` — clean
- [ ] Manual (operator flow): BotFather setup → `yarn dev` + `yarn telegram` → add own chat ID → exchange messages (see `docs/message_apps/telegram/README.md` for step-by-step)

## Related

- #268 — messaging bridge overall
- #320 — shared bridge client lib (prerequisite, merged)
- #315 / #318 — socket transport + push (Phase A merged, B open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)