### PR TITLE
fix(auth): wire bearer token to MCP subprocess (closes #272 gap)

### DIFF
--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -4,6 +4,7 @@ import type { Role } from "../../src/config/roles.js";
 import { mcpTools, isMcpToolEnabled } from "../mcp-tools/index.js";
 import { MCP_PLUGIN_NAMES } from "../plugin-names.js";
 import type { McpServerSpec } from "../config.js";
+import { getCurrentToken } from "../auth/token.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
@@ -146,6 +147,13 @@ function buildMulmoclaudeServer(params: {
       }
     : {};
 
+  // Bearer token for MCP subprocess to call /api/* back to this server
+  // (#272). The MCP bridge also has a file-read fallback from
+  // <workspace>/.session-token, but env is faster and works in Docker
+  // where the token file may not be bind-mounted.
+  const token = getCurrentToken();
+  const authEnv = token ? { MULMOCLAUDE_AUTH_TOKEN: token } : {};
+
   return {
     command,
     args: [mcpServerPath],
@@ -154,6 +162,7 @@ function buildMulmoclaudeServer(params: {
       PORT: String(port),
       PLUGIN_NAMES: activePlugins.join(","),
       ROLE_IDS: roleIds.join(","),
+      ...authEnv,
       ...dockerEnv,
     },
   };

--- a/server/mcp-server.ts
+++ b/server/mcp-server.ts
@@ -4,12 +4,14 @@
  * back to the active frontend SSE stream via the session registry.
  */
 
+import fs from "node:fs";
 import type { ToolDefinition } from "gui-chat-protocol";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { TOOL_ENDPOINTS, PLUGIN_DEFS } from "./plugin-names.js";
 import { errorMessage } from "./utils/errors.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
 import { env } from "./env.js";
+import { WORKSPACE_PATHS } from "./workspace-paths.js";
 
 type JsonRpcId = string | number | null;
 
@@ -34,6 +36,24 @@ const PLUGIN_NAMES = env.mcpPluginNames;
 const ROLE_IDS = env.mcpRoleIds;
 const MCP_HOST = env.mcpHost;
 const BASE_URL = `http://${MCP_HOST}:${PORT}`;
+
+// Bearer token for /api/* calls back to the parent server (#272).
+// The parent writes it to <workspace>/.session-token at startup; we
+// read once at module load — the token is immutable for the server's
+// lifetime. Same resolution order as bridges/cli/token.ts.
+function readSessionToken(): string {
+  const fromEnv = process.env.MULMOCLAUDE_AUTH_TOKEN;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  try {
+    return fs.readFileSync(WORKSPACE_PATHS.sessionToken, "utf-8").trim();
+  } catch {
+    return "";
+  }
+}
+const SESSION_TOKEN = readSessionToken();
+const AUTH_HEADER: Record<string, string> = SESSION_TOKEN
+  ? { Authorization: `Bearer ${SESSION_TOKEN}` }
+  : {};
 
 interface ToolDef {
   name: string;
@@ -129,7 +149,7 @@ async function postJson(
       `${BASE_URL}${path}?session=${encodeURIComponent(SESSION_ID)}`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...AUTH_HEADER },
         body: JSON.stringify(body),
       },
     );
@@ -163,7 +183,7 @@ async function fetchSkillsList(): Promise<{ name: string }[]> {
   const url = `${BASE_URL}/api/skills?session=${encodeURIComponent(SESSION_ID)}`;
   let res: Response;
   try {
-    res = await fetch(url);
+    res = await fetch(url, { headers: AUTH_HEADER });
   } catch (err) {
     throw new Error(`Network error calling /api/skills: ${errorMessage(err)}`);
   }
@@ -230,7 +250,10 @@ async function handleManageSkillsDelete(
   const url = `/api/skills/${encodeURIComponent(name)}?session=${encodeURIComponent(SESSION_ID)}`;
   let res: Response;
   try {
-    res = await fetch(`${BASE_URL}${url}`, { method: "DELETE" });
+    res = await fetch(`${BASE_URL}${url}`, {
+      method: "DELETE",
+      headers: AUTH_HEADER,
+    });
   } catch (err) {
     throw new Error(
       `Network error calling DELETE ${url}: ${errorMessage(err)}`,


### PR DESCRIPTION
## Summary

- #272 added bearer-auth to every `/api/*` route but never wired the token into the MCP subprocess that `server/agent/config.ts` spawns.
- Every MCP-bridged tool call (manageSkills, wiki, scheduler, todos, roles, etc.) hit `/api/*` without an `Authorization` header and got 401'd, surfacing as `\"<toolName> failed: unauthorized\"` in the UI.
- The frontend path (meta-tag → `apiFetch`) has always worked, so this went unnoticed until someone tried an LLM-initiated tool call.

## Items to confirm / review

- **Token transport**: env var (`MULMOCLAUDE_AUTH_TOKEN`) is the primary path; file-read fallback (`<workspace>/.session-token`, same as `bridges/cli/token.ts`) covers Docker bind-mount scenarios where env might not be forwarded. Want a second opinion on whether the file fallback is worth keeping vs env-only.
- **Security scope**: the MCP subprocess is a sibling local process spawned by the parent server with the same trust level. Passing the token via env is the same intent level as how `SESSION_ID` / `PORT` are passed today. Env vars are owner-readable only on modern Linux (`/proc/<pid>/environ` mode 600) and on macOS (`ps e` requires root); acceptable local-attacker model for #272.
- **Three fetch sites updated**: `postJson` (main path — all POST tool calls), `fetchSkillsList` (GET), and `handleManageSkillsDelete` (DELETE). Searched mcp-server.ts for any remaining `fetch(` — none left unauth'd.

## User Prompt

> [Error] manageSkills failed: unauthorized  skillこわれている？
> wiki, スケジュールもダメかも。
> mainで、ブランチつくってコミット。CI　okでマージして、ここにとりこんで。

Investigation traced this to the MCP bridge being spawned with no Authorization header, since #272 only wired the frontend.

## Test plan

- [x] Unit tests pass (1986/1986)
- [x] Typecheck + lint + build clean
- [ ] CI: Windows / Linux / macOS × Node 22/24 matrix
- [ ] Manual: start `yarn dev`, invoke `manageSkills` / wiki / scheduler via chat — confirm no `unauthorized` error