### PR TITLE
fix(auth): route frontend plugin-launcher and Todo CRUD through apiCall

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -777,22 +777,22 @@ function isLauncherInvokeKey(key: string): key is LauncherInvokeKey {
 // a ToolResultComplete so the canvas renders it through the plugin's
 // own View component. Throws on HTTP / network failure; caller is
 // responsible for surfacing the error to the user.
+//
+// Uses apiGet/apiPost so the module-level bearer token (#272) is
+// attached automatically — a raw `fetch()` here would skip the auth
+// header and 401 on every launcher click.
 async function invokePluginForLauncher(
   key: LauncherInvokeKey,
 ): Promise<ToolResultComplete> {
   const spec = LAUNCHER_INVOKE_SPECS[key];
-  const res = await fetch(spec.endpoint, {
-    method: spec.method,
-    headers:
-      spec.method === "POST" ? { "Content-Type": "application/json" } : {},
-    body: spec.method === "POST" ? JSON.stringify(spec.body ?? {}) : undefined,
-  });
-  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!res.ok) {
-    const detail =
-      typeof json.error === "string" ? json.error : `HTTP ${res.status}`;
-    throw new Error(`${spec.toolName} failed: ${detail}`);
+  const result =
+    spec.method === "POST"
+      ? await apiPost<unknown>(spec.endpoint, spec.body ?? {})
+      : await apiGet<unknown>(spec.endpoint);
+  if (!result.ok) {
+    throw new Error(`${spec.toolName} failed: ${result.error}`);
   }
+  const json = (result.data ?? {}) as Record<string, unknown>;
   const data = spec.wrapData ? spec.wrapData(json) : json.data;
   return {
     ...json,

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -12,6 +12,7 @@ import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../../../config/apiRoutes";
 import { useFreshPluginData } from "../../../composables/useFreshPluginData";
 import { errorMessage } from "../../../utils/errors";
+import { apiCall } from "../../../utils/api";
 import type { StatusColumn, TodoItem } from "../index";
 
 interface TodosResponse {
@@ -36,26 +37,20 @@ function extractColumns(json: unknown): StatusColumn[] | null {
   return isStatusColumnArray(cols) ? cols : null;
 }
 
-// Apply server response (always { data: { items, columns } } for the
-// new REST routes) into the local refs. Centralised so every helper
-// uses the same parser and error guard. Returns false on a non-OK
-// status, malformed JSON, or a payload missing the items array.
-async function applyResponse(
-  response: Awaited<ReturnType<typeof fetch>>,
+// Apply parsed JSON payload (always { data: { items, columns } } for
+// the new REST routes) into the local refs. Centralised so every
+// helper uses the same parser and error guard. Returns false on a
+// payload missing the items array.
+function applyPayload(
+  json: unknown,
   items: Ref<TodoItem[]>,
   columns: Ref<StatusColumn[]>,
-): Promise<boolean> {
-  if (!response.ok) return false;
-  try {
-    const json: unknown = await response.json();
-    const nextItems = extractItems(json);
-    const nextColumns = extractColumns(json);
-    if (nextItems) items.value = nextItems;
-    if (nextColumns) columns.value = nextColumns;
-    return nextItems !== null;
-  } catch {
-    return false;
-  }
+): boolean {
+  const nextItems = extractItems(json);
+  const nextColumns = extractColumns(json);
+  if (nextItems) items.value = nextItems;
+  if (nextColumns) columns.value = nextColumns;
+  return nextItems !== null;
 }
 
 export interface UseTodosHandle {
@@ -148,47 +143,32 @@ export function useTodos(
     return ok;
   }
 
-  // Use Parameters<typeof fetch> rather than the global RequestInit
-  // type so this file doesn't depend on the DOM lib being in the
-  // ESLint globals (which it isn't outside src/composables/).
-  type FetchInit = Parameters<typeof fetch>[1];
-
-  async function call(url: string, init: FetchInit): Promise<boolean> {
+  // Thin wrapper around apiCall that applies the response payload
+  // into the local refs and surfaces errors through `error.value`.
+  // Using apiCall (not raw fetch) ensures the #272 bearer token is
+  // attached to every request.
+  async function call(
+    url: string,
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+    body?: unknown,
+  ): Promise<boolean> {
     error.value = null;
     try {
-      const res = await fetch(url, init);
-      const ok = await applyResponse(res, items, columns);
-      if (!ok) {
-        // Try to surface a server error message if the body looks
-        // like one. Falls back to a generic message.
-        let message = `Request failed (${res.status})`;
-        try {
-          const body: unknown = await res.clone().json();
-          if (
-            typeof body === "object" &&
-            body !== null &&
-            typeof (body as { error?: unknown }).error === "string"
-          ) {
-            message = (body as { error: string }).error;
-          }
-        } catch {
-          // ignore — keep the generic message
-        }
-        error.value = message;
+      const result = await apiCall<unknown>(url, { method, body });
+      if (!result.ok) {
+        error.value = result.error;
+        return false;
       }
-      return ok;
+      const applied = applyPayload(result.data, items, columns);
+      if (!applied) {
+        error.value = `Request failed: unexpected payload shape`;
+        return false;
+      }
+      return true;
     } catch (err) {
       error.value = errorMessage(err);
       return false;
     }
-  }
-
-  function jsonInit(method: string, body: unknown): FetchInit {
-    return {
-      method,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    };
   }
 
   return {
@@ -196,34 +176,37 @@ export function useTodos(
     columns,
     error,
     refresh,
-    createItem: (input) =>
-      call(API_ROUTES.todos.items, jsonInit("POST", input)),
+    createItem: (input) => call(API_ROUTES.todos.items, "POST", input),
     patchItem: (id, input) =>
       call(
         API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)),
-        jsonInit("PATCH", input),
+        "PATCH",
+        input,
       ),
     moveItem: (id, input) =>
       call(
         API_ROUTES.todos.itemMove.replace(":id", encodeURIComponent(id)),
-        jsonInit("POST", input),
+        "POST",
+        input,
       ),
     deleteItem: (id) =>
-      call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)), {
-        method: "DELETE",
-      }),
-    addColumn: (input) =>
-      call(API_ROUTES.todos.columns, jsonInit("POST", input)),
+      call(
+        API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)),
+        "DELETE",
+      ),
+    addColumn: (input) => call(API_ROUTES.todos.columns, "POST", input),
     patchColumn: (id, input) =>
       call(
         API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)),
-        jsonInit("PATCH", input),
+        "PATCH",
+        input,
       ),
     deleteColumn: (id) =>
-      call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)), {
-        method: "DELETE",
-      }),
+      call(
+        API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)),
+        "DELETE",
+      ),
     reorderColumns: (ids) =>
-      call(API_ROUTES.todos.columnsOrder, jsonInit("PUT", { ids })),
+      call(API_ROUTES.todos.columnsOrder, "PUT", { ids }),
   };
 }


### PR DESCRIPTION
## Summary

Two frontend call sites still used raw `fetch()` against `/api/*` endpoints, which skipped the module-level bearer token wired by #272. After `bearerAuth` middleware started rejecting unauth requests with 401, plugin-launcher clicks (Schedule / Todos / Wiki / Skills buttons in the top menu) and all Todo kanban/table CRUD operations surfaced to the user as `"<toolName> failed: unauthorized"`.

Companion fix to #325 (which fixed the MCP-subprocess side).

## Items to confirm / review

- **Exhaustive sweep**: grepped the whole repo for `fetch(`, `await fetch(`, `= fetch(`, `fetch(\"/api`, etc. The only remaining raw-fetch callers were these two files. `useFreshPluginData` already uses `apiGet`, and all other plugin code routes through the typed `apiGet`/`apiPost`/`apiCall` helpers. Please double-check I didn't miss a dynamic-URL path.
- **Todo error surfacing**: the old code tried `res.clone().json()` to extract a server `error` field; `apiCall`'s `ApiResult` already exposes that via `result.error`, so the error message ergonomics should match or improve (simpler failure → `result.error` carries the server's `error` string or a generic `HTTP N`).
- **Launcher payload shape**: `apiPost<unknown>` returns the parsed JSON body directly as `data`, which matches what the old code assigned to `json`. The `wrapData` / spread into `ToolResultComplete` logic is unchanged.

## User Prompt

> [Error] manageScheduler failed: unauthorized
> そういう部分探して全部直してね
> mainブランチで。

Investigation traced this to the two remaining raw-fetch sites in `src/App.vue` (plugin launcher) and `src/plugins/todo/composables/useTodos.ts` (Todo CRUD).

## Test plan

- [x] Unit tests pass (2021/2021)
- [x] Typecheck + lint + build clean
- [ ] CI: Windows / Linux / macOS × Node 22/24 matrix + E2E
- [ ] Manual: click Schedule / Todos / Wiki / Skills buttons in top menu — no unauthorized error
- [ ] Manual: Todo kanban D&D / add / edit / delete / column ops all work