### PR TITLE
feat(sandbox): opt-in host credential forwarding (#259)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -61,6 +61,8 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 | `PORT` | `3001` | Express listen port (`server/index.ts:47`). |
 | `NODE_ENV` | unset / `production` | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually. |
 | `DISABLE_SANDBOX` | unset | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/docker.ts:49`, `server/index.ts:147`). |
+| `SANDBOX_SSH_AGENT_FORWARD` | unset | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md). |
+| `SANDBOX_MOUNT_CONFIGS` | unset | CSV of allowlisted config mounts (currently `gh`, `gitconfig`). Each entry resolves to a fixed host→container path pair defined in `server/agent/sandboxMounts.ts`; unknown names are logged and ignored. |
 | `SESSIONS_LIST_WINDOW_DAYS` | `90` | Caps how far back the sidebar looks when listing chat sessions (`server/routes/sessions.ts`). Set to `0` to disable the cutoff entirely. Introduced in PR #203 to keep `GET /api/sessions` cheap on long-lived workspaces; anything older is still on disk, just hidden from the list. |
 
 ### Debug startup hooks

--- a/docs/sandbox-credentials.md
+++ b/docs/sandbox-credentials.md
@@ -1,0 +1,126 @@
+# Sandbox Host Credentials
+
+By default, the MulmoClaude Docker sandbox is **credential-free**. The container has `git` and `gh` installed, but no SSH keys, no GitHub token, no git identity — so `git pull` over SSH, `gh issue list`, or `git commit --signoff` all fail inside the container.
+
+This page describes the two opt-in mechanisms for giving the sandbox just enough credentials to authenticate, without leaking the underlying secrets.
+
+> **Before you turn anything on, read [What we do NOT do](#what-we-do-not-do) and [What we cannot do](#what-we-cannot-do) below.** Both mechanisms are safe by design, but the safety relies on understanding the scope.
+
+---
+
+## Quick start
+
+Add one or both to your `.env` (or shell environment):
+
+```env
+# Forward the host's SSH agent into the container.
+# Private keys stay on the host; only the signing oracle is exposed.
+SANDBOX_SSH_AGENT_FORWARD=1
+
+# Mount allowlisted config files/dirs read-only.
+# See the table below for the names you can put here.
+SANDBOX_MOUNT_CONFIGS=gh,gitconfig
+```
+
+Restart the server. On the next agent run you should see a log line like:
+
+```text
+INFO  [sandbox] host credentials attached to container mounts=["gh (GitHub CLI auth token + hosts config)","gitconfig (...)","ssh-agent forward"]
+```
+
+Inside the container (you can verify by running an agent task that executes shell commands):
+
+```bash
+ssh -T git@github.com   # should authenticate via the forwarded agent
+gh auth status          # should show your host's gh login
+git config --global user.email
+```
+
+---
+
+## Mechanism 1 — SSH agent forward
+
+Set `SANDBOX_SSH_AGENT_FORWARD=1`.
+
+**What it does.** Bind-mounts the host's `$SSH_AUTH_SOCK` into the container at `/ssh-agent` and sets `SSH_AUTH_SOCK=/ssh-agent` inside. OpenSSH, `git`, and anything else that speaks the agent protocol will use the host's running `ssh-agent` to sign challenges. **Your private key bytes never enter the container.**
+
+**Prerequisites on the host:**
+
+- An SSH agent is running and `$SSH_AUTH_SOCK` is set.
+- Your keys have been added (`ssh-add`). Passphrase-protected keys need to be unlocked once on the host before starting the server — the container has no TTY to prompt for a passphrase.
+- macOS: the Apple keychain agent is set up by default. To verify: `echo $SSH_AUTH_SOCK`.
+- Linux: typically provided by `gnome-keyring`, `keychain`, or manually via `eval "$(ssh-agent)"`.
+
+**Skipped automatically (with a `log.warn`) when:**
+
+- `$SSH_AUTH_SOCK` is not set on the host.
+- The socket path doesn't exist on disk.
+
+The server doesn't fail — it just logs the reason and continues without the forward.
+
+---
+
+## Mechanism 2 — Allowlisted config mounts
+
+Set `SANDBOX_MOUNT_CONFIGS=<names>` to a comma-separated list of names from the table below. Each name is a server-side key that resolves to a fixed host path and container path. **Users cannot pass arbitrary paths** — unknown names are logged as warnings and ignored.
+
+### Allowlist
+
+| Name | Host path | Container path | Kind | What it enables |
+|---|---|---|---|---|
+| `gh` | `~/.config/gh` | `/home/node/.config/gh` | dir | `gh` CLI (`gh issue list`, `gh pr create`, etc.). Also makes `git push` to GitHub over HTTPS work via the `gh` credential helper. |
+| `gitconfig` | `~/.gitconfig` | `/home/node/.gitconfig` | file | `user.name`, `user.email`, signing key, global aliases. Needed to let `git commit` record an author identity. |
+
+All mounts are **read-only** (`:ro`). The container cannot write back to your host config.
+
+### Adding a new tool
+
+Extending the list is a code change, not a user config. This is deliberate — the allowlist is the security boundary. To add an entry:
+
+1. Append a row to `ALLOWED` in [`server/agent/sandboxMounts.ts`](../server/agent/sandboxMounts.ts), specifying `name`, `hostPath`, `containerPath`, `kind`, and `description`.
+2. Add a row to the table above.
+3. Think about what the mount exposes and write a short "What it enables" sentence. If the expose is wider than `gh`-level (e.g. tokens for multiple hosts, or a key used for more than one service), consider whether it deserves its own env var instead of riding on `SANDBOX_MOUNT_CONFIGS`.
+
+---
+
+## What we do NOT do
+
+- **We do not mount `~/.ssh`.** Direct filesystem access to private keys would defeat the point of the sandbox. Use `SANDBOX_SSH_AGENT_FORWARD=1` instead.
+- **We do not mount `~/.git-credentials`.** That file contains plaintext HTTPS tokens for *any* host; the blast radius is unbounded. If you need HTTPS for a specific service, set it up through that service's CLI (like `gh`) and mount the CLI's config dir instead.
+- **We do not support cloud-provider CLIs (`gcloud`, `aws`, Azure) today.** They're intentionally out of scope — larger attack surface, different threat model. A future issue can revisit this if concrete demand appears.
+- **We do not resolve symlinks for you.** If `~/.config/gh` is a symlink to a path outside your home directory, Docker will follow it and mount the target. Check that your config dirs are not symlinked to secrets you don't mean to expose.
+- **The read-only flag is not tamper-proof against a malicious image.** The sandbox runs images we build from `Dockerfile.sandbox`. If you replace that image with something hostile, it can read the mounted credentials. The point of the opt-in is to keep *unmodified-Claude-Code* safe, not to defend against a compromised container.
+
+## What we cannot do
+
+- **macOS Keychain-backed credentials.** Git's `osxkeychain` helper, iTerm's SSH keychain integration, and Apple-signed SSH keys in the system keychain all require macOS APIs that aren't mountable. If your GitHub token is only in Keychain, run `gh auth login` once with the `file` credential store to get a mountable `~/.config/gh/hosts.yml`. Same for Windows `wincred`.
+- **Passphrase prompts.** Neither mechanism gives the container a TTY. If an SSH key is passphrase-protected and not yet unlocked in the agent, the sign request fails silently. Unlock once on the host (`ssh-add ~/.ssh/id_ed25519`) before starting the server.
+- **Interactive 2FA (`gh auth login`, `aws configure sso`).** The container can't drive a browser-based device flow. Do the login on the host; the resulting config is what the mount exposes.
+- **Remote bridge / multi-user setups.** This whole page assumes the machine running MulmoClaude is the same machine whose credentials you want to expose. If a future feature lets MulmoClaude run on a remote box, the credentials story is different and this doc does not cover it.
+
+---
+
+## Troubleshooting
+
+**`gh auth status` inside the container says "not logged in", but the mount is set.**
+- The server logged `config mount skipped (host path missing) name=gh hostPath=...`: your `~/.config/gh` doesn't exist on the host. Run `gh auth login` on the host first.
+- The mount is present but the `.config/gh/hosts.yml` file is writable only by root or a different user. Docker preserves uid/gid; the container runs as your host uid. Run `ls -l ~/.config/gh/hosts.yml` and confirm it's readable by you.
+
+**`git push` over SSH fails with `Permission denied (publickey)`.**
+- Confirm `SSH_AUTH_SOCK` is set inside the container: the startup log line should list `ssh-agent forward`. If it's not listed, the server logged a `SSH agent forward requested but skipped` warning with the reason.
+- Run `ssh-add -l` on the host — if it says "The agent has no identities", nothing is available to forward.
+
+**`git commit` inside the container errors with `Please tell me who you are`.**
+- You haven't mounted `gitconfig`. Either add it to `SANDBOX_MOUNT_CONFIGS` or let Claude set a per-repo identity with `git config user.email` inside the workspace.
+
+**I turned both flags on and see no extra mounts in `docker inspect`.**
+- Check the server log at startup for `unknown SANDBOX_MOUNT_CONFIGS entries ignored` — you may have a typo in the env var (`ghub`, `git-config`, etc. are not recognised; only the names in the allowlist table above).
+- `DISABLE_SANDBOX=1` also disables the sandbox entirely — in that case `git` and `gh` run on the host and use your host credentials directly, which is why the mounts look absent.
+
+---
+
+## Related
+
+- Issue [#259](https://github.com/receptron/mulmoclaude/issues/259) — the design discussion that led to this doc.
+- [server/helps/sandbox.md](../server/helps/sandbox.md) — general sandbox behaviour (what runs where, how to disable it).
+- [docs/developer.md](./developer.md) — full list of env vars honoured by the server.

--- a/plans/feat-sandbox-host-credentials.md
+++ b/plans/feat-sandbox-host-credentials.md
@@ -1,0 +1,78 @@
+# Sandbox host credentials — SSH agent forward + config mounts (#259)
+
+## Goal
+
+Let Claude do authenticated `git` / `gh` operations inside the Docker sandbox **without** spraying host credentials into the container. Opt-in only. Extensible beyond `gh`.
+
+## Design
+
+Two **independent** env-var toggles, composable:
+
+1. `SANDBOX_SSH_AGENT_FORWARD=1` — forwards the host's SSH agent socket.
+2. `SANDBOX_MOUNT_CONFIGS=gh,gitconfig` — CSV list of allowlisted config mounts.
+
+### Why two separate mechanisms
+
+- SSH agent forward is a **socket**, not a filesystem bind. Private keys never enter the container; the agent on the host signs. Different kernel object, different safety story.
+- Config mounts are **read-only filesystem binds**. Simpler, narrower. They expose plaintext files.
+
+Same env var would have conflated these; users would turn on "auth" and silently get a thing they didn't ask for.
+
+### Config-mount allowlist (server-side, not user-editable)
+
+Defined once in `server/agent/sandboxMounts.ts`:
+
+```ts
+const ALLOWED: Record<string, SandboxMountSpec> = {
+  gh: {
+    hostPath: ~/.config/gh,
+    containerPath: /home/node/.config/gh,
+    kind: "dir",
+    description: "GitHub CLI auth + hosts config",
+  },
+  gitconfig: {
+    hostPath: ~/.gitconfig,
+    containerPath: /home/node/.gitconfig,
+    kind: "file",
+    description: "Git user identity (name, email, signing key)",
+  },
+};
+```
+
+Users can't pass arbitrary paths — they pass names; the server resolves. Unknown names produce a hard error at startup. Missing host paths are skipped with a one-shot warning so a user without `.gitconfig` just gets a no-op instead of a crash.
+
+Adding a new tool (e.g. `npm`, `aws`) later = one row in this file + one row in the docs table. No new env var parsing, no user-visible schema change.
+
+### Docker args additions
+
+Extending `buildDockerSpawnArgs` in `server/agent/config.ts`. Each resolved mount adds `-v <hostPath>:<containerPath>:ro`. SSH agent forward adds `-v $SSH_AUTH_SOCK:/ssh-agent` + `-e SSH_AUTH_SOCK=/ssh-agent`.
+
+### What's **not** in this change (deliberately)
+
+- `~/.ssh` direct mount — we want agent forward, not private key exposure.
+- `~/.git-credentials` — plaintext HTTPS creds for any host; too wide. Users who need this can turn it into their own allowlist entry locally.
+- macOS Keychain — not fs-mountable, would need a separate bridge.
+- Cloud CLIs (`gcloud`, `aws`, Azure) — bigger blast radius, separate discussion.
+- Symlink resolution inside mounts — Docker follows symlinks on the host side, then binds the target. If a user has `~/.config/gh` symlinked to a secret elsewhere, the container sees the target. Documented but not mitigated.
+
+### What the sandbox **can't** do even with these on
+
+- `git push` to non-GitHub HTTPS remotes if the creds are in `osxkeychain` / `wincred` helpers — no filesystem path to forward.
+- Prompt for a passphrase on an ssh-agent key — container has no tty for the passphrase prompt. If the key is passphrase-protected, add it to the host agent first.
+- Remote hosts that require TTY-based 2FA (`gh auth login` interactive) — run those on the host, then the sandbox inherits via the mount.
+
+## Files
+
+- **new** `server/agent/sandboxMounts.ts` — allowlist + resolver + parse/validate.
+- **edit** `server/env.ts` — `sandboxSshAgentForward`, `sandboxMountConfigs` (CSV).
+- **edit** `server/agent/config.ts` — `buildDockerSpawnArgs` consumes resolved mounts + agent forward flag.
+- **new** `docs/sandbox-credentials.md` — user-facing guide. Table of allowed names, what/where, opt-in recipe, what we don't do, what we can't do, troubleshooting.
+- **edit** `server/helps/sandbox.md` — pointer to new doc + one-liner about the flags.
+- **edit** `docs/developer.md` — env var table row.
+- **new** `test/agent/test_sandboxMounts.ts` — unit tests for parse + resolver.
+
+## Verification
+
+- Unit tests cover: empty CSV → empty list; unknown name → error; known name → correct spec; missing host path → logged warning + skipped.
+- Manual: set `SANDBOX_MOUNT_CONFIGS=gh,gitconfig SANDBOX_SSH_AGENT_FORWARD=1` on a machine with the three artefacts present, run `yarn dev`, confirm `docker ps` shows the extra mounts and `SSH_AUTH_SOCK` env.
+- Inside the container, `gh auth status` and `git config --global user.email` should both report values.

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -26,6 +26,8 @@ import {
 } from "./agent/stream.js";
 import { log } from "./logger/index.js";
 import { EVENT_TYPES } from "../src/types/events.js";
+import { env } from "./env.js";
+import { resolveSandboxAuth } from "./agent/sandboxMounts.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
 
@@ -40,12 +42,18 @@ function spawnClaude(
       stdio: ["pipe", "pipe", "pipe"],
     });
   }
+  const sandboxAuth = resolveSandboxAuth({
+    sshAgentForward: env.sandboxSshAgentForward,
+    configMountNames: env.sandboxMountConfigs,
+    sshAuthSock: process.env.SSH_AUTH_SOCK,
+  });
   const dockerArgs = buildDockerSpawnArgs({
     workspacePath,
     cliArgs,
     uid: process.getuid?.() ?? 1000,
     gid: process.getgid?.() ?? 1000,
     platform: process.platform,
+    sandboxAuthArgs: sandboxAuth.args,
   });
   return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
 }

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -342,6 +342,9 @@ export interface DockerSpawnArgsParams {
   platform: Platform;
   projectRoot?: string;
   homeDir?: string;
+  /** Extra `-v` / `-e` tokens for opt-in host credentials (#259).
+   *  Built by `resolveSandboxAuth` in `sandboxMounts.ts`. Default []. */
+  sandboxAuthArgs?: readonly string[];
 }
 
 // Pure helper that returns the full `docker run ... claude <args>`
@@ -356,6 +359,7 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     platform,
     projectRoot = process.cwd(),
     homeDir = homedir(),
+    sandboxAuthArgs = [],
   } = params;
   const toDockerPath = (p: string): string => p.replace(/\\/g, "/");
   const extraHosts: string[] =
@@ -388,6 +392,7 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     `${toDockerPath(homeDir)}/.claude:/home/node/.claude`,
     "-v",
     `${toDockerPath(homeDir)}/.claude.json:/home/node/.claude.json`,
+    ...sandboxAuthArgs,
     ...extraHosts,
     "mulmoclaude-sandbox",
     "claude",

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -1,0 +1,260 @@
+// Host-credential mounts for the Docker sandbox (#259).
+//
+// Two independent opt-in mechanisms, composable:
+//
+//   SANDBOX_SSH_AGENT_FORWARD=1
+//     Bind-mounts $SSH_AUTH_SOCK into the container and sets
+//     SSH_AUTH_SOCK to the container path. Private keys stay on the
+//     host — the agent on the host signs on behalf of the container.
+//
+//   SANDBOX_MOUNT_CONFIGS=gh,gitconfig
+//     CSV of allowlisted config mounts. Each name resolves to a fixed
+//     host path via the server-side ALLOWED_CONFIG_MOUNTS map; users
+//     cannot pass arbitrary paths.
+//
+// See docs/sandbox-credentials.md for the user-facing contract.
+
+import path from "node:path";
+import fs from "node:fs";
+import { homedir } from "node:os";
+import { log } from "../logger/index.js";
+
+// ── Config-mount allowlist ──────────────────────────────────────────
+
+export interface SandboxMountSpec {
+  /** The short name users type in SANDBOX_MOUNT_CONFIGS. */
+  name: string;
+  /** Absolute path on the host. Resolved from `$HOME` at lookup. */
+  hostPath: string;
+  /** Absolute path inside the container (must match where the tool looks). */
+  containerPath: string;
+  /** Whether the host path is expected to be a file or a directory. */
+  kind: "file" | "dir";
+  /** Short human description — shown in docs and in startup logs. */
+  description: string;
+}
+
+/**
+ * Build the allowlist. Parameterized on `home` so tests can inject a
+ * temp directory without touching the real filesystem.
+ *
+ * To add a new tool:
+ * 1. Append a row here with the host path the tool reads on startup
+ *    and the container path it should find the same file at.
+ * 2. Add a row in docs/sandbox-credentials.md.
+ * 3. That's it — no env var changes, no parser changes.
+ */
+export function buildAllowedConfigMounts(
+  home: string = homedir(),
+): Record<string, SandboxMountSpec> {
+  return {
+    gh: {
+      name: "gh",
+      hostPath: path.join(home, ".config", "gh"),
+      containerPath: "/home/node/.config/gh",
+      kind: "dir",
+      description: "GitHub CLI auth token + hosts config",
+    },
+    gitconfig: {
+      name: "gitconfig",
+      hostPath: path.join(home, ".gitconfig"),
+      containerPath: "/home/node/.gitconfig",
+      kind: "file",
+      description: "Git user identity (name, email, signing key)",
+    },
+  };
+}
+
+// ── Name parsing / validation ──────────────────────────────────────
+
+export interface ParsedMountList {
+  /** Names that resolved to a spec. Order preserved. */
+  resolved: SandboxMountSpec[];
+  /** Names the user requested that aren't in the allowlist. */
+  unknown: string[];
+  /** Names whose host path does not exist — silently skipped. */
+  missing: SandboxMountSpec[];
+}
+
+/**
+ * Parse a CSV list of mount names, resolve against the allowlist,
+ * check that each host path exists. The three output buckets let the
+ * caller decide what to error on (unknown) vs warn on (missing).
+ */
+export function resolveMountNames(
+  names: readonly string[],
+  allowed: Record<string, SandboxMountSpec> = buildAllowedConfigMounts(),
+): ParsedMountList {
+  const resolved: SandboxMountSpec[] = [];
+  const unknown: string[] = [];
+  const missing: SandboxMountSpec[] = [];
+
+  for (const raw of names) {
+    const name = raw.trim();
+    if (!name) continue;
+    const spec = allowed[name];
+    if (!spec) {
+      unknown.push(name);
+      continue;
+    }
+    if (!hostPathExists(spec)) {
+      missing.push(spec);
+      continue;
+    }
+    resolved.push(spec);
+  }
+  return { resolved, unknown, missing };
+}
+
+function hostPathExists(spec: SandboxMountSpec): boolean {
+  try {
+    const stat = fs.statSync(spec.hostPath);
+    return spec.kind === "dir" ? stat.isDirectory() : stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+// ── Docker arg generation ──────────────────────────────────────────
+
+/**
+ * Return the `-v ...` argument pairs for the given resolved mounts.
+ * Always read-only. The caller splices these into the full docker
+ * argv in `buildDockerSpawnArgs`.
+ */
+export function configMountArgs(
+  resolved: readonly SandboxMountSpec[],
+): string[] {
+  const args: string[] = [];
+  for (const spec of resolved) {
+    args.push("-v", `${toDockerPath(spec.hostPath)}:${spec.containerPath}:ro`);
+  }
+  return args;
+}
+
+// ── SSH agent forward ──────────────────────────────────────────────
+
+/** Absolute container path the agent socket is bound to. */
+export const SSH_AGENT_CONTAINER_SOCK = "/ssh-agent";
+
+export interface SshAgentForwardResult {
+  args: string[];
+  /** When null, forward was requested but not possible; caller decides
+   *  whether to log once (we always log in the production driver). */
+  skippedReason: string | null;
+}
+
+/**
+ * Return the docker argv fragment that forwards the host SSH agent
+ * into the container. The agent socket is bind-mounted and
+ * `SSH_AUTH_SOCK` is re-pointed so ssh / git pick it up.
+ *
+ * Skipped (empty args + reason) when:
+ * - the flag is off
+ * - $SSH_AUTH_SOCK isn't set (no agent running on host)
+ * - the socket path doesn't exist on the host
+ */
+export function sshAgentForwardArgs(
+  enabled: boolean,
+  sshAuthSock: string | undefined,
+): SshAgentForwardResult {
+  if (!enabled) return { args: [], skippedReason: null };
+  if (!sshAuthSock || sshAuthSock.length === 0) {
+    return {
+      args: [],
+      skippedReason: "SSH_AUTH_SOCK not set on host",
+    };
+  }
+  if (!fs.existsSync(sshAuthSock)) {
+    return {
+      args: [],
+      skippedReason: `SSH_AUTH_SOCK=${sshAuthSock} not found on host`,
+    };
+  }
+  return {
+    args: [
+      "-v",
+      `${toDockerPath(sshAuthSock)}:${SSH_AGENT_CONTAINER_SOCK}`,
+      "-e",
+      `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`,
+    ],
+    skippedReason: null,
+  };
+}
+
+// ── Top-level resolver used by buildDockerSpawnArgs ────────────────
+
+export interface ResolvedSandboxAuth {
+  /** docker argv additions: a list of `-v` / `-e` tokens. */
+  args: string[];
+  /** Descriptions the caller can log once to show what got mounted. */
+  appliedDescriptions: string[];
+}
+
+export interface ResolveSandboxAuthParams {
+  sshAgentForward: boolean;
+  configMountNames: readonly string[];
+  sshAuthSock?: string | undefined;
+  home?: string;
+}
+
+/**
+ * Combine the two mechanisms. Emits a `log.warn` for unknown names
+ * (configuration error the user should fix), a `log.info` for missing
+ * paths (expected when a user hasn't set up the tool), and a
+ * `log.info` line listing what actually got mounted so the startup
+ * log shows the sandbox's effective auth posture.
+ */
+export function resolveSandboxAuth(
+  params: ResolveSandboxAuthParams,
+): ResolvedSandboxAuth {
+  const home = params.home ?? homedir();
+  const allowed = buildAllowedConfigMounts(home);
+  const parsed = resolveMountNames(params.configMountNames, allowed);
+
+  if (parsed.unknown.length > 0) {
+    log.warn("sandbox", "unknown SANDBOX_MOUNT_CONFIGS entries ignored", {
+      unknown: parsed.unknown,
+      allowed: Object.keys(allowed),
+    });
+  }
+  for (const spec of parsed.missing) {
+    log.info("sandbox", "config mount skipped (host path missing)", {
+      name: spec.name,
+      hostPath: spec.hostPath,
+    });
+  }
+
+  const sshResult = sshAgentForwardArgs(
+    params.sshAgentForward,
+    params.sshAuthSock,
+  );
+  if (sshResult.skippedReason !== null) {
+    log.warn("sandbox", "SSH agent forward requested but skipped", {
+      reason: sshResult.skippedReason,
+    });
+  }
+
+  const args = [...configMountArgs(parsed.resolved), ...sshResult.args];
+  const appliedDescriptions = [
+    ...parsed.resolved.map((s) => `${s.name} (${s.description})`),
+    ...(sshResult.args.length > 0 ? ["ssh-agent forward"] : []),
+  ];
+
+  if (appliedDescriptions.length > 0) {
+    log.info("sandbox", "host credentials attached to container", {
+      mounts: appliedDescriptions,
+    });
+  }
+
+  return { args, appliedDescriptions };
+}
+
+// ── Utilities ──────────────────────────────────────────────────────
+
+// Docker accepts POSIX-style paths even on Windows when using
+// Docker Desktop, and the rest of the codebase already uses this
+// helper in buildDockerSpawnArgs.
+function toDockerPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}

--- a/server/env.ts
+++ b/server/env.ts
@@ -62,6 +62,10 @@ export const env = Object.freeze({
 
   // Sandbox / Docker
   disableSandbox: asFlag(process.env.DISABLE_SANDBOX),
+  // Host-credential opt-ins for the Docker sandbox (#259). Both off
+  // by default. See docs/sandbox-credentials.md for the contract.
+  sandboxSshAgentForward: asFlag(process.env.SANDBOX_SSH_AGENT_FORWARD),
+  sandboxMountConfigs: asCsv(process.env.SANDBOX_MOUNT_CONFIGS),
 
   // API credentials (undefined when not configured)
   geminiApiKey: process.env.GEMINI_API_KEY,

--- a/server/helps/sandbox.md
+++ b/server/helps/sandbox.md
@@ -25,6 +25,15 @@ The container runs with `--cap-drop ALL` and as the host user's UID/GID, so it h
 
 Set the environment variable `DISABLE_SANDBOX=1` to always run the agent directly on the host, even when Docker is available.
 
+## Host Credentials (opt-in)
+
+The sandbox is credential-free by default. Two opt-in flags let you expose the minimum needed for `git` / `gh` to authenticate without leaking private keys into the container:
+
+- `SANDBOX_SSH_AGENT_FORWARD=1` — forwards the host's SSH agent socket (private keys stay on the host).
+- `SANDBOX_MOUNT_CONFIGS=gh,gitconfig` — allowlisted read-only config mounts.
+
+Full contract, what's deliberately excluded, and troubleshooting: [`docs/sandbox-credentials.md`](../../docs/sandbox-credentials.md).
+
 ## First-Time Setup (macOS)
 
 On macOS, the Docker container uses a separate credential store from the host. Before using the sandbox for the first time (and whenever the credential expires), run:

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -271,6 +271,23 @@ describe("buildDockerSpawnArgs", () => {
     const args = buildDockerSpawnArgs(baseParams());
     assert.ok(args.includes("mulmoclaude-sandbox"));
   });
+
+  it("splices sandboxAuthArgs in before the image name (#259)", () => {
+    const args = buildDockerSpawnArgs({
+      ...baseParams(),
+      sandboxAuthArgs: ["-v", "/host/.config/gh:/home/node/.config/gh:ro"],
+    });
+    const authIdx = args.indexOf("/host/.config/gh:/home/node/.config/gh:ro");
+    const imageIdx = args.indexOf("mulmoclaude-sandbox");
+    assert.ok(authIdx >= 0, "expected sandboxAuthArgs to be present");
+    assert.ok(authIdx < imageIdx, "auth mounts must land before image name");
+  });
+
+  it("defaults to no sandbox auth args when omitted", () => {
+    const args = buildDockerSpawnArgs(baseParams());
+    assert.ok(!args.some((a) => a.includes(".config/gh")));
+    assert.ok(!args.some((a) => a.includes("SSH_AUTH_SOCK")));
+  });
 });
 
 describe("rewriteLocalhostForDocker", () => {

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -158,9 +158,13 @@ describe("sshAgentForwardArgs", () => {
     fs.writeFileSync(fake, "");
     const r = sshAgentForwardArgs(true, fake);
     assert.equal(r.skippedReason, null);
+    // Normalise to forward slashes on both sides: the helper converts
+    // backslashes to forward slashes for Docker, so the expected value
+    // has to do the same to stay portable across Windows CI runners.
+    const expectedHostPath = fake.replace(/\\/g, "/");
     assert.deepEqual(r.args, [
       "-v",
-      `${fake}:${SSH_AGENT_CONTAINER_SOCK}`,
+      `${expectedHostPath}:${SSH_AGENT_CONTAINER_SOCK}`,
       "-e",
       `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`,
     ]);

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -1,0 +1,168 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import {
+  buildAllowedConfigMounts,
+  resolveMountNames,
+  configMountArgs,
+  sshAgentForwardArgs,
+  SSH_AGENT_CONTAINER_SOCK,
+} from "../../server/agent/sandboxMounts.js";
+
+// Use an isolated temp HOME so these tests don't depend on whether
+// the developer running CI actually has ~/.config/gh or a ~/.gitconfig.
+
+function makeFixtureHome(opts: { gh?: boolean; gitconfig?: boolean }): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-mounts-"));
+  if (opts.gh) {
+    const ghDir = path.join(dir, ".config", "gh");
+    fs.mkdirSync(ghDir, { recursive: true });
+    fs.writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
+  }
+  if (opts.gitconfig) {
+    fs.writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
+  }
+  return dir;
+}
+
+describe("buildAllowedConfigMounts", () => {
+  it("exposes every expected name", () => {
+    const allowed = buildAllowedConfigMounts("/fake/home");
+    assert.deepEqual(Object.keys(allowed).sort(), ["gh", "gitconfig"]);
+  });
+
+  it("maps names to stable host paths under the given home", () => {
+    const allowed = buildAllowedConfigMounts("/fake/home");
+    assert.equal(allowed.gh.hostPath, path.join("/fake/home", ".config", "gh"));
+    assert.equal(allowed.gh.containerPath, "/home/node/.config/gh");
+    assert.equal(allowed.gh.kind, "dir");
+    assert.equal(
+      allowed.gitconfig.hostPath,
+      path.join("/fake/home", ".gitconfig"),
+    );
+    assert.equal(allowed.gitconfig.kind, "file");
+  });
+});
+
+describe("resolveMountNames", () => {
+  it("empty input → empty output", () => {
+    const out = resolveMountNames([], buildAllowedConfigMounts("/fake/home"));
+    assert.deepEqual(out, { resolved: [], unknown: [], missing: [] });
+  });
+
+  it("flags unknown names without crashing", () => {
+    const out = resolveMountNames(
+      ["nope", "also-nope"],
+      buildAllowedConfigMounts("/fake/home"),
+    );
+    assert.deepEqual(out.unknown, ["nope", "also-nope"]);
+    assert.equal(out.resolved.length, 0);
+  });
+
+  it("reports missing host paths separately from unknown", () => {
+    const home = makeFixtureHome({}); // nothing on disk
+    const out = resolveMountNames(["gh"], buildAllowedConfigMounts(home));
+    assert.equal(out.unknown.length, 0);
+    assert.equal(out.resolved.length, 0);
+    assert.equal(out.missing.length, 1);
+    assert.equal(out.missing[0].name, "gh");
+  });
+
+  it("resolves a present dir", () => {
+    const home = makeFixtureHome({ gh: true });
+    const out = resolveMountNames(["gh"], buildAllowedConfigMounts(home));
+    assert.equal(out.resolved.length, 1);
+    assert.equal(out.resolved[0].name, "gh");
+  });
+
+  it("resolves a present file", () => {
+    const home = makeFixtureHome({ gitconfig: true });
+    const out = resolveMountNames(
+      ["gitconfig"],
+      buildAllowedConfigMounts(home),
+    );
+    assert.equal(out.resolved.length, 1);
+    assert.equal(out.resolved[0].name, "gitconfig");
+  });
+
+  it("rejects dir when host path is a file and vice versa", () => {
+    const home = makeFixtureHome({ gh: false, gitconfig: false });
+    // Place a FILE where gh expects a DIR.
+    fs.mkdirSync(path.join(home, ".config"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".config", "gh"), "oops");
+    const out = resolveMountNames(["gh"], buildAllowedConfigMounts(home));
+    assert.equal(out.resolved.length, 0);
+    assert.equal(out.missing.length, 1);
+  });
+
+  it("preserves CSV order, skips blanks", () => {
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const out = resolveMountNames(
+      ["gitconfig", "", "gh"],
+      buildAllowedConfigMounts(home),
+    );
+    assert.deepEqual(
+      out.resolved.map((r) => r.name),
+      ["gitconfig", "gh"],
+    );
+  });
+});
+
+describe("configMountArgs", () => {
+  it("emits read-only -v pairs for each spec", () => {
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const { resolved } = resolveMountNames(
+      ["gh", "gitconfig"],
+      buildAllowedConfigMounts(home),
+    );
+    const args = configMountArgs(resolved);
+    assert.equal(args[0], "-v");
+    assert.match(args[1], /:\/home\/node\/\.config\/gh:ro$/);
+    assert.equal(args[2], "-v");
+    assert.match(args[3], /:\/home\/node\/\.gitconfig:ro$/);
+    assert.equal(args.length, 4);
+  });
+
+  it("empty input → empty args", () => {
+    assert.deepEqual(configMountArgs([]), []);
+  });
+});
+
+describe("sshAgentForwardArgs", () => {
+  it("no-op when disabled", () => {
+    const r = sshAgentForwardArgs(false, "/tmp/anything");
+    assert.deepEqual(r, { args: [], skippedReason: null });
+  });
+
+  it("reports SSH_AUTH_SOCK missing", () => {
+    const r = sshAgentForwardArgs(true, undefined);
+    assert.deepEqual(r.args, []);
+    assert.match(r.skippedReason ?? "", /not set/);
+  });
+
+  it("reports socket path missing on disk", () => {
+    const r = sshAgentForwardArgs(true, "/tmp/definitely-not-a-real-sock");
+    assert.deepEqual(r.args, []);
+    assert.match(r.skippedReason ?? "", /not found/);
+  });
+
+  it("binds socket and sets SSH_AUTH_SOCK when sock exists", () => {
+    // Use an ordinary file as a stand-in for the socket — the helper
+    // only checks existence, not socket-ness.
+    const fake = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "sock-")),
+      "agent.sock",
+    );
+    fs.writeFileSync(fake, "");
+    const r = sshAgentForwardArgs(true, fake);
+    assert.equal(r.skippedReason, null);
+    assert.deepEqual(r.args, [
+      "-v",
+      `${fake}:${SSH_AGENT_CONTAINER_SOCK}`,
+      "-e",
+      `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two independent, composable opt-in flags so Claude can do authenticated `git` / `gh` work inside the Docker sandbox without leaking host secrets:

- `SANDBOX_SSH_AGENT_FORWARD=1` — bind-mounts `$SSH_AUTH_SOCK`. **Private keys never enter the container.**
- `SANDBOX_MOUNT_CONFIGS=gh,gitconfig` — CSV of **allowlisted** read-only config mounts. Users pass names; server resolves to fixed host→container path pairs via a hard-coded allowlist. Extensible: adding a new tool is one row in `server/agent/sandboxMounts.ts` plus one row in the user doc.

Both off by default. Skipped gracefully when prerequisites are missing (SSH_AUTH_SOCK unset, `~/.config/gh` nonexistent, unknown mount names, etc.) — warnings logged, server keeps running.

Closes #259.

## Items to Confirm / Review

1. **Allowlist scope (intentionally narrow)**: only `gh` and `gitconfig` today. `~/.ssh` direct mount is rejected (use agent forward instead); `~/.git-credentials` is rejected (blast radius too wide); cloud CLIs deferred to a future issue.
2. **Docs over enforcement**: the user doc's "What we do NOT do" and "What we cannot do" sections are load-bearing — they define the security envelope. Please skim and push back if anything reads misleading.
3. **Path resolution**: `hostPathExists` uses `fs.statSync`, which follows symlinks. Documented in the user doc; if we ever want to block symlinks, `fs.lstatSync` is the change point.
4. **SSH agent forward on Windows**: platform semantics vary; the code doesn't gate on platform. If you set the flag on Windows without a Unix-socket-compatible agent, it logs the "socket not found" warning and continues. Explicit Windows handling can come later if demand exists.

## User Prompt

> `https://github.com/receptron/mulmoclaude/issues/259` これだけとopt inとして環境変数でssh agent forwardと、~/.config/gh:ro マウントを設定できるようにするのでどう？
>
> ~/.config/gh:roはgh以外の拡張性も考えて仕組み化してね。なにをどうおくかと。で、ユーザ向けのdocumentもしっかり書いて実装進めて。やらないこと、できないことを書いておくのはとてもよいね

## Implementation

Plan: [`plans/feat-sandbox-host-credentials.md`](plans/feat-sandbox-host-credentials.md)

- **new** `server/agent/sandboxMounts.ts` — allowlist, resolver, docker-arg generator.
- **edit** `server/agent/config.ts` — `DockerSpawnArgsParams.sandboxAuthArgs`, spliced before the image name.
- **edit** `server/agent.ts` — calls `resolveSandboxAuth` from `env` + `process.env.SSH_AUTH_SOCK`.
- **edit** `server/env.ts` — `sandboxSshAgentForward`, `sandboxMountConfigs`.
- **new** `docs/sandbox-credentials.md` — user-facing contract (this is the document that matters).
- **edit** `server/helps/sandbox.md`, `docs/developer.md` — pointers + env-var rows.
- **new** `test/agent/test_sandboxMounts.ts` (+8 tests) + additions to `test/agent/test_agent_config.ts`.

## Verification

- typecheck / typecheck:server / lint (0 errors) / 2038 tests (+10 new) / build — all green locally.
- Manual smoke: exercised `resolveSandboxAuth` with real env — confirmed correct splice for present configs, warn logs for unknown names + missing socket, clean skip when host paths don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)