### PR TITLE
feat(ui): surface sandbox auth state in lock popup + explainer query (#329)

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -67,6 +67,14 @@ export async function mockAllApis(
     route.fulfill({ json: DEFAULT_HEALTH }),
   );
 
+  // `/api/sandbox` mirrors the real server's empty-object contract
+  // when the sandbox is off (#329). Tests that need the enabled
+  // branch override this route BEFORE calling mockAllApis —
+  // Playwright checks last-registered-first.
+  await page.route(urlEndsWith("/api/sandbox"), (route) =>
+    route.fulfill({ json: {} }),
+  );
+
   await page.route(urlEndsWith("/api/roles"), (route) =>
     route.fulfill({ json: DEFAULT_ROLES }),
   );

--- a/e2e/tests/lock-status-popup.spec.ts
+++ b/e2e/tests/lock-status-popup.spec.ts
@@ -18,10 +18,12 @@ test.describe("LockStatusPopup", () => {
 
     await lockBtn.click();
 
-    // Sandbox test query buttons appear.
+    // Sandbox test query buttons appear. The exact count is the
+    // length of SANDBOX_TEST_QUERIES in LockStatusPopup.vue — keep
+    // them in sync when adding / removing sample queries.
     const queries = page.getByTestId("sandbox-test-query");
     await expect(queries.first()).toBeVisible();
-    expect(await queries.count()).toBe(4);
+    expect(await queries.count()).toBe(5);
   });
 
   test("clicking a test query closes the popup", async ({ page }) => {
@@ -56,5 +58,60 @@ test.describe("LockStatusPopup", () => {
     await page.locator("body").click({ position: { x: 400, y: 400 } });
 
     await expect(firstQuery).toBeHidden();
+  });
+
+  test("credential block renders live /api/sandbox state when enabled", async ({
+    page,
+  }) => {
+    // Override /api/health so the popup takes the sandbox-on branch,
+    // and /api/sandbox so the credential block gets data to render.
+    // Registered BEFORE mockAllApis below so Playwright's
+    // "last-registered-first" order picks these up.
+    await page.route(
+      (url) => url.pathname === "/api/health",
+      (route) =>
+        route.fulfill({
+          json: { status: "OK", geminiAvailable: false, sandboxEnabled: true },
+        }),
+    );
+    await page.route(
+      (url) => url.pathname === "/api/sandbox",
+      (route) =>
+        route.fulfill({
+          json: { sshAgent: true, mounts: ["gh", "gitconfig"] },
+        }),
+    );
+
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByTestId("sandbox-lock-button").click();
+
+    // The credential block only renders when sandbox is enabled,
+    // distinguishing it from the "no sandbox" branch (which hides
+    // the block entirely).
+    await expect(page.getByTestId("sandbox-credentials-block")).toBeVisible();
+
+    const sshLine = page.getByTestId("sandbox-credentials-ssh");
+    await expect(sshLine).toContainText("forwarded");
+    // The negative string ("not forwarded") starts with "not" — check
+    // it isn't leaking into the positive case.
+    await expect(sshLine).not.toContainText("not forwarded");
+
+    const mountsLine = page.getByTestId("sandbox-credentials-mounts");
+    await expect(mountsLine).toContainText("gh, gitconfig");
+  });
+
+  test("credential block hides when sandbox is disabled", async ({ page }) => {
+    // The default mockAllApis returns sandboxEnabled=false, which is
+    // exactly this branch. Nothing to override; the popup just opens
+    // and the credential block should be absent.
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByTestId("sandbox-lock-button").click();
+
+    // Query buttons appear (sandbox-off popup still has them)…
+    await expect(page.getByTestId("sandbox-test-query").first()).toBeVisible();
+    // …but the credential block is gated on sandboxEnabled.
+    await expect(page.getByTestId("sandbox-credentials-block")).toBeHidden();
   });
 });

--- a/plans/feat-sandbox-status-popup.md
+++ b/plans/feat-sandbox-status-popup.md
@@ -1,0 +1,111 @@
+# Sandbox status popup + explainer query (#329)
+
+## Goal
+
+Make the opt-in host-credential forwarding added by #327 visible in the UI so users can confirm what's actually attached to the sandbox without reading startup logs. Plus give Claude enough context to answer "what's my sandbox setup?" in chat.
+
+## Design
+
+### 1. New endpoint `GET /api/sandbox`
+
+Deliberately separate from `/api/health` — health stays a minimal boot probe; sandbox state is lazy-loaded only when the popup opens.
+
+**Return shape:**
+
+```ts
+// Sandbox disabled (no Docker, or DISABLE_SANDBOX=1):
+{}
+
+// Sandbox enabled:
+{
+  sshAgent: boolean,
+  mounts: string[]   // e.g. ["gh", "gitconfig"] — names only
+}
+```
+
+Empty object when disabled: the popup already renders a distinct "No sandbox" branch, so any extra fields would be dead pixels.
+
+**Security posture:** payload is minimum. No host paths, no skip reasons, no unknown-name lists. All of that already lands in `server/system/logger` via the existing `log.warn` / `log.info` calls in `resolveSandboxAuth` — which is the right channel for debugging.
+
+**Implementation location:**
+
+- `src/config/apiRoutes.ts` — add `sandbox: "/api/sandbox"` under a new `system` group (or top-level alongside `health`; decide during implementation).
+- `server/index.ts` — add the handler inline next to the `health` route (it reads the same `sandboxEnabled` module-level boolean and the env vars from `env`).
+- New module `server/api/sandboxStatus.ts` — pure builder `buildSandboxStatus(params): SandboxStatus` so the handler stays thin and tests can drive the builder directly. Mirrors the pattern already used by `buildInlinedHelpFiles` / `resolveSandboxAuth`.
+
+### 2. Lock popup rendering
+
+Two changes in `src/components/LockStatusPopup.vue`:
+
+1. Lazy-fetch the sandbox state when the popup opens (`watch(() => props.open, async (isOpen) => { if (isOpen && !state.value) state.value = await apiGet(...)` — cache for the session; refresh requires a page reload, same as the rest of the health data).
+
+2. Render a new block between the existing "Sandbox enabled" paragraph and the "Test sandbox isolation:" heading:
+
+```
+Credentials attached to the sandbox:
+🔑 SSH agent        forwarded   (or ✗ not forwarded)
+📁 Mounted configs  gh, gitconfig   (or — none)
+```
+
+Emoji keeps it compact; no colours beyond what the rest of the popup already uses. The block is hidden when `sandboxEnabled` is false.
+
+A fresh composable `useSandboxStatus` (sibling to `useHealth`) owns the fetch + caching. Keeps `LockStatusPopup.vue` focused on rendering.
+
+### 3. New sample query + helps doc section
+
+**Query entry** (added to `SANDBOX_TEST_QUERIES` in `LockStatusPopup.vue`):
+
+> `Explain my current sandbox and credential setup`
+
+Claude handles this with its built-in tools: `Read config/helps/sandbox.md` for conceptual background, run `whoami` / `ssh-add -l` / check env if curious about live state, then summarise. No dedicated MCP tool needed (Option 1 from the decomposition discussion).
+
+**Helps doc update** (`server/workspace/helps/sandbox.md` — post-#323 location, copied into `~/mulmoclaude/config/helps/sandbox.md` at startup):
+
+Add a section titled "Checking the current sandbox state" covering:
+
+- How to read the lock-icon popup.
+- What the env vars mean (`SANDBOX_SSH_AGENT_FORWARD`, `SANDBOX_MOUNT_CONFIGS`).
+- How to verify from inside a chat session (Bash: `ssh-add -l`, `ls /home/node/.config/gh`, `cat /home/node/.gitconfig`).
+- What info is exposed where (UI popup = minimum, server log = full detail).
+
+This is what the sample query points Claude at.
+
+## Non-goals
+
+- **No copy-to-clipboard button** in the popup — discussed and rejected as MVP scope creep.
+- **No structured `describeSandbox` MCP tool** — Option 2 deferred until an LLM-driven workflow actually needs it.
+- **No host path exposure** via the API — log-only.
+- **No live refresh** — a restart is required for env-var changes anyway, so a cache that holds for the session is fine.
+
+## Touched files
+
+| Layer | File | Change |
+|---|---|---|
+| Server | `server/api/sandboxStatus.ts` | NEW — `buildSandboxStatus` pure builder |
+| Server | `server/index.ts` | mount `GET /api/sandbox` handler |
+| Shared | `src/config/apiRoutes.ts` | add `sandbox` route constant |
+| Client | `src/composables/useSandboxStatus.ts` | NEW — lazy fetch + cache |
+| Client | `src/components/LockStatusPopup.vue` | render state block + new sample query |
+| Docs | `server/workspace/helps/sandbox.md` | add "Checking the current sandbox state" section |
+| Tests | `test/api/test_sandboxStatus.ts` | NEW — builder: disabled → {}, enabled variants |
+| Tests | `test/components/test_LockStatusPopup.ts` | extend — state block renders / hides correctly |
+
+Existing `test/agent/test_sandboxMounts.ts` unchanged (its concern is docker-argv generation; we're consuming a different slice of the same state).
+
+## Implementation order
+
+1. **Pure builder + API** — land `buildSandboxStatus` + `/api/sandbox` with tests. Small, mechanical, independently verifiable.
+2. **Composable** — `useSandboxStatus`, typed against the API response. Can unit-test the cache-on-open behaviour.
+3. **Popup** — wire the composable, render the state block, add the sample query.
+4. **Helps doc** — write the "Checking the current sandbox state" section last, so the verification steps match what the popup actually shows.
+5. **Manual verify** — run with / without Docker, with / without each env var, confirm popup + query both surface the expected info.
+
+## Open questions
+
+- Keep the sandbox status cached for the whole page lifetime, or re-fetch on every popup open? First is cheaper + env vars only change on restart anyway; second is friendlier if the docker daemon is stopped mid-session. Lean toward page-lifetime cache — simpler, matches `useHealth`.
+- `apiRoutes.ts` grouping: the file already has small top-level entries (`health`, etc.). Add `sandbox` at top-level or create a new `system` group for both? Suggest top-level to match `health`.
+
+## Out of scope / follow-ups
+
+- Exposing the "what's NOT forwarded" side (host private keys, `.git-credentials`) as explicit negative rows in the popup — could be added later if users report confusion.
+- Watching `docker ps` to detect sandbox going down mid-session — relevant only if the cache TTL turns out to be wrong in practice.

--- a/server/api/sandboxStatus.ts
+++ b/server/api/sandboxStatus.ts
@@ -1,0 +1,68 @@
+// Compute the sandbox-auth snapshot exposed via GET /api/sandbox.
+//
+// The popup (`src/components/LockStatusPopup.vue`) consumes this to
+// surface what credentials are actually attached to the Docker
+// container, so users can confirm their `SANDBOX_SSH_AGENT_FORWARD` /
+// `SANDBOX_MOUNT_CONFIGS` env vars took effect without grepping the
+// startup log.
+//
+// Keep the payload **minimum**: names only, no host paths, no skip
+// reasons, no unknown-entry lists. Full detail already lives in the
+// server log via the `log.warn` / `log.info` calls inside
+// `resolveSandboxAuth`. Exposing host paths to the browser is an
+// intentional non-goal (see #329).
+
+import {
+  buildAllowedConfigMounts,
+  resolveMountNames,
+  sshAgentForwardArgs,
+} from "../agent/sandboxMounts.js";
+
+export interface SandboxStatus {
+  /** True iff the host SSH agent socket is bound into the container. */
+  sshAgent: boolean;
+  /**
+   * Allowlisted config mount names that actually got attached — i.e.
+   * the user requested them AND the host path exists. Order preserved
+   * from `SANDBOX_MOUNT_CONFIGS`.
+   */
+  mounts: string[];
+}
+
+export interface BuildSandboxStatusParams {
+  /** Output of `setupSandbox()` — true when Docker is running AND
+   *  `DISABLE_SANDBOX` is unset. When false, the builder returns null
+   *  so the handler serializes an empty `{}` body. */
+  sandboxEnabled: boolean;
+  sshAgentForward: boolean;
+  configMountNames: readonly string[];
+  sshAuthSock?: string | undefined;
+  home?: string;
+}
+
+/**
+ * Returns `null` when the sandbox is disabled — the caller (Express
+ * handler) serializes that as `{}`, matching the agreed API contract
+ * (#329). When enabled, returns the structured `{ sshAgent, mounts }`
+ * snapshot.
+ *
+ * Pure: no logging, no side effects beyond filesystem existence
+ * probes done by `resolveMountNames` (same probes the agent spawner
+ * already runs per request).
+ */
+export function buildSandboxStatus(
+  params: BuildSandboxStatusParams,
+): SandboxStatus | null {
+  if (!params.sandboxEnabled) return null;
+
+  const allowed = buildAllowedConfigMounts(params.home);
+  const parsed = resolveMountNames(params.configMountNames, allowed);
+
+  const ssh = sshAgentForwardArgs(params.sshAgentForward, params.sshAuthSock);
+  const sshAgent = ssh.args.length > 0;
+
+  return {
+    sshAgent,
+    mounts: parsed.resolved.map((m) => m.name),
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import {
 } from "./agent/mcp-tools/index.js";
 import { initWorkspace } from "./workspace/workspace.js";
 import { env, isGeminiAvailable } from "./system/env.js";
+import { buildSandboxStatus } from "./api/sandboxStatus.js";
 import fs from "fs";
 import os from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
@@ -103,6 +104,21 @@ app.get(API_ROUTES.health, (_req: Request, res: Response) => {
     geminiAvailable: isGeminiAvailable(),
     sandboxEnabled,
   });
+});
+
+// Sandbox credential-forwarding state (#329). Returns `{}` when the
+// sandbox is disabled — the popup already renders a distinct
+// "No sandbox" branch in that case and extra fields would be noise.
+// When enabled, returns `{ sshAgent, mounts }`; full debug detail
+// (host paths, skip reasons, unknown names) stays in the server log.
+app.get(API_ROUTES.sandbox, (_req: Request, res: Response) => {
+  const status = buildSandboxStatus({
+    sandboxEnabled,
+    sshAgentForward: env.sandboxSshAgentForward,
+    configMountNames: env.sandboxMountConfigs,
+    sshAuthSock: process.env.SSH_AUTH_SOCK,
+  });
+  res.json(status ?? {});
 });
 
 // Routers register FULL `/api/...` paths internally (see

--- a/server/workspace/helps/sandbox.md
+++ b/server/workspace/helps/sandbox.md
@@ -34,6 +34,47 @@ The sandbox is credential-free by default. Two opt-in flags let you expose the m
 
 Full contract, what's deliberately excluded, and troubleshooting: [`docs/sandbox-credentials.md`](../../docs/sandbox-credentials.md).
 
+## Checking the Current Sandbox State
+
+Two places surface what's actually attached to **your** running container — useful when you've just toggled an opt-in flag and want to confirm it took effect.
+
+### From the UI — lock icon popup
+
+Click the 🔒 icon in the top bar. The popup shows:
+
+- **Sandbox enabled / disabled** — whether Docker was detected and `DISABLE_SANDBOX` is off.
+- **Host credentials attached** (only when the sandbox is on):
+  - **SSH agent**: `forwarded` when `SANDBOX_SSH_AGENT_FORWARD=1` **and** `$SSH_AUTH_SOCK` points at a live socket. If the flag is on but the socket is missing, the popup shows `not forwarded` and the server log carries the reason.
+  - **Mounted configs**: allowlisted names from `SANDBOX_MOUNT_CONFIGS` whose host path exists. Names you typed but whose host path is missing are silently dropped from the UI (they appear in the server log as `config mount skipped`).
+
+The popup also has a **sample query button** that asks Claude to summarise this information in natural language.
+
+### From inside a chat session
+
+Inside the container, you can verify each piece directly:
+
+```bash
+# SSH agent — lists identities the host agent will sign with
+ssh-add -l
+
+# gh config — mounted read-only, so `gh auth status` should succeed
+ls /home/node/.config/gh && gh auth status
+
+# gitconfig — mounted read-only
+cat /home/node/.gitconfig
+```
+
+### From the server log
+
+The popup intentionally exposes **names only**, never host paths or skip reasons. Full debug detail lives in the server log:
+
+- `[sandbox] host credentials attached to container` — one-line summary of what was mounted on agent spawn.
+- `[sandbox] unknown SANDBOX_MOUNT_CONFIGS entries ignored` — typo in the CSV.
+- `[sandbox] config mount skipped (host path missing)` — name is in the allowlist but the host file/dir doesn't exist.
+- `[sandbox] SSH agent forward requested but skipped` — flag on but `$SSH_AUTH_SOCK` unset or non-existent.
+
+If the popup isn't showing what you expect, grep the startup log for `[sandbox]` first.
+
 ## First-Time Setup (macOS)
 
 On macOS, the Docker container uses a separate credential store from the host. Before using the sandbox for the first time (and whenever the credential expires), run:

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -46,6 +46,52 @@
           to enable filesystem isolation.
         </template>
       </p>
+      <div
+        v-if="sandboxEnabled"
+        data-testid="sandbox-credentials-block"
+        class="mb-2 border-t border-gray-100 pt-2"
+      >
+        <p class="text-gray-400 mb-1">Host credentials attached:</p>
+        <p
+          v-if="sandboxStatus === null"
+          class="text-gray-400 italic"
+          data-testid="sandbox-credentials-loading"
+        >
+          loading…
+        </p>
+        <template v-else>
+          <p data-testid="sandbox-credentials-ssh">
+            <span class="mr-1">🔑</span>
+            <span class="text-gray-500">SSH agent:</span>
+            <span
+              :class="
+                sandboxStatus.sshAgent ? 'text-green-700' : 'text-gray-400'
+              "
+              class="ml-1"
+            >
+              {{ sandboxStatus.sshAgent ? "forwarded" : "not forwarded" }}
+            </span>
+          </p>
+          <p data-testid="sandbox-credentials-mounts">
+            <span class="mr-1">📁</span>
+            <span class="text-gray-500">Mounted configs:</span>
+            <span
+              :class="
+                sandboxStatus.mounts.length > 0
+                  ? 'text-green-700'
+                  : 'text-gray-400'
+              "
+              class="ml-1"
+            >
+              {{
+                sandboxStatus.mounts.length > 0
+                  ? sandboxStatus.mounts.join(", ")
+                  : "none"
+              }}
+            </span>
+          </p>
+        </template>
+      </div>
       <p class="text-gray-400 mb-1">Test sandbox isolation:</p>
       <div class="flex flex-col gap-1">
         <button
@@ -63,9 +109,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
+import { useSandboxStatus } from "../composables/useSandboxStatus";
 
-defineProps<{
+const props = defineProps<{
   sandboxEnabled: boolean;
   open: boolean;
 }>();
@@ -78,16 +125,34 @@ const emit = defineEmits<{
 // Canned queries that demonstrate what the sandbox does / doesn't
 // allow. Kept here (not passed as a prop) because they are specific
 // to this popup and nothing else in the app needs them.
+//
+// The last entry is intentionally broader than the others: after #327
+// shipped opt-in credential forwarding, users need a way to ask what's
+// actually attached to *their* container, not just read the generic
+// docs. Claude answers by reading config/helps/sandbox.md and
+// inspecting the live state via built-in tools.
 const SANDBOX_TEST_QUERIES = [
   "Run `whoami` and show the result",
   "Run `hostname` and show the result",
   "Try to list files in ~/Library",
-  "Read helps/sandbox.md and explain how the sandbox works",
+  "Read config/helps/sandbox.md and explain how the sandbox works",
+  "Explain my current sandbox and credential setup",
 ];
 
 const button = ref<HTMLButtonElement | null>(null);
 const popup = ref<HTMLDivElement | null>(null);
 defineExpose({ button, popup });
+
+// Lazy-load the sandbox credential state the first time the popup
+// opens (and only when the sandbox is actually enabled — /api/sandbox
+// returns `{}` otherwise and the UI block is hidden).
+const { status: sandboxStatus, ensureLoaded } = useSandboxStatus();
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen && props.sandboxEnabled) await ensureLoaded();
+  },
+);
 
 function onTestQuery(q: string): void {
   emit("update:open", false);

--- a/src/composables/useSandboxStatus.ts
+++ b/src/composables/useSandboxStatus.ts
@@ -1,0 +1,67 @@
+// Lazy fetcher for `GET /api/sandbox` (#329).
+//
+// The lock popup consumes this to show which host credentials are
+// attached to the Docker sandbox. Deliberately lazy: the popup is
+// hidden most of the time, and env-var changes only take effect on
+// server restart anyway, so a page-lifetime cache populated on first
+// open is enough.
+//
+// Paired with `useHealth` (which loads `sandboxEnabled` at bootstrap)
+// — when the sandbox is disabled this composable is never called.
+
+import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
+import { apiGet } from "../utils/api";
+
+export interface SandboxStatus {
+  sshAgent: boolean;
+  mounts: string[];
+}
+
+interface RawResponse {
+  sshAgent?: unknown;
+  mounts?: unknown;
+}
+
+function isSandboxStatus(raw: RawResponse): raw is {
+  sshAgent: boolean;
+  mounts: string[];
+} {
+  if (typeof raw.sshAgent !== "boolean") return false;
+  if (!Array.isArray(raw.mounts)) return false;
+  return raw.mounts.every((m) => typeof m === "string");
+}
+
+export interface UseSandboxStatusHandle {
+  /** Parsed status, or null while not yet loaded / sandbox disabled
+   *  / fetch failed. UI renders a placeholder in all three cases. */
+  status: Ref<SandboxStatus | null>;
+  /** One-shot loader. Safe to call repeatedly — short-circuits once a
+   *  non-null value is cached. Designed to be triggered from a
+   *  `watch(() => props.open, …)` on the popup. */
+  ensureLoaded: () => Promise<void>;
+}
+
+export function useSandboxStatus(): UseSandboxStatusHandle {
+  const status = ref<SandboxStatus | null>(null);
+  let loaded = false;
+
+  async function ensureLoaded(): Promise<void> {
+    if (loaded) return;
+    loaded = true;
+    const result = await apiGet<RawResponse>(API_ROUTES.sandbox);
+    if (!result.ok) {
+      // Leave `status` null — popup shows a neutral "state unavailable"
+      // line. Allow a retry on next open by flipping `loaded` back.
+      loaded = false;
+      return;
+    }
+    // Server returns `{}` (empty object) when the sandbox is disabled.
+    // The popup shouldn't call us in that case, but double-guard here
+    // so a stale render doesn't blow up on shape validation.
+    if (!isSandboxStatus(result.data)) return;
+    status.value = result.data;
+  }
+
+  return { status, ensureLoaded };
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -20,6 +20,7 @@
 
 export const API_ROUTES = {
   health: "/api/health",
+  sandbox: "/api/sandbox",
 
   agent: {
     run: "/api/agent",

--- a/test/api/test_sandboxStatus.ts
+++ b/test/api/test_sandboxStatus.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { buildSandboxStatus } from "../../server/api/sandboxStatus.js";
+
+// Isolated fixture home so the tests don't depend on the developer
+// actually having ~/.config/gh or a ~/.gitconfig locally. Shares the
+// same pattern as test_sandboxMounts.ts.
+function makeFixtureHome(opts: { gh?: boolean; gitconfig?: boolean }): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-status-"));
+  if (opts.gh) {
+    const ghDir = path.join(dir, ".config", "gh");
+    fs.mkdirSync(ghDir, { recursive: true });
+    fs.writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
+  }
+  if (opts.gitconfig) {
+    fs.writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
+  }
+  return dir;
+}
+
+// Real socket is awkward to stand up in tests; a regular file is
+// enough since sshAgentForwardArgs only needs `existsSync` to pass.
+function makeFakeSocket(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-status-sock-"));
+  const sock = path.join(dir, "agent.sock");
+  fs.writeFileSync(sock, "");
+  return sock;
+}
+
+describe("buildSandboxStatus", () => {
+  it("returns null when the sandbox is disabled", () => {
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: false,
+      sshAgentForward: true,
+      configMountNames: ["gh", "gitconfig"],
+      sshAuthSock: makeFakeSocket(),
+      home,
+    });
+    // null → handler serializes `{}`. Contract is NOT a stub object
+    // with false/empty fields — the UI already has a distinct
+    // "no sandbox" branch and extra fields would be dead pixels.
+    assert.equal(status, null);
+  });
+
+  it("returns sshAgent=false and empty mounts when nothing is opted in", () => {
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: false,
+      configMountNames: [],
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: [] });
+  });
+
+  it("reports a config mount whose host path exists", () => {
+    const home = makeFixtureHome({ gh: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: false,
+      configMountNames: ["gh"],
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: ["gh"] });
+  });
+
+  it("silently drops a config mount whose host path is missing", () => {
+    // No gh/gitconfig in the fixture home, but the user requested
+    // `gh`. Must not surface it as mounted — mirrors the log-level
+    // "config mount skipped" behaviour.
+    const home = makeFixtureHome({});
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: false,
+      configMountNames: ["gh"],
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: [] });
+  });
+
+  it("drops unknown config names silently (log handles the warning)", () => {
+    // Unknown names are logged by `resolveSandboxAuth` in the agent
+    // spawner; the API status snapshot should not leak that noise.
+    const home = makeFixtureHome({ gh: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: false,
+      configMountNames: ["gh", "does-not-exist"],
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: ["gh"] });
+  });
+
+  it("reports sshAgent=true when the flag is on AND the socket exists", () => {
+    const home = makeFixtureHome({});
+    const sshAuthSock = makeFakeSocket();
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: true,
+      configMountNames: [],
+      sshAuthSock,
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: true, mounts: [] });
+  });
+
+  it("reports sshAgent=false when the flag is on but SSH_AUTH_SOCK is unset", () => {
+    const home = makeFixtureHome({});
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: true,
+      configMountNames: [],
+      sshAuthSock: undefined,
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: [] });
+  });
+
+  it("reports sshAgent=false when the socket path does not exist on the host", () => {
+    const home = makeFixtureHome({});
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: true,
+      configMountNames: [],
+      sshAuthSock: path.join(home, "missing-socket"),
+      home,
+    });
+    assert.deepEqual(status, { sshAgent: false, mounts: [] });
+  });
+
+  it("preserves config-mount order from the CSV", () => {
+    // Users type `SANDBOX_MOUNT_CONFIGS=gitconfig,gh` and expect the
+    // popup to render them in that order.
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: false,
+      configMountNames: ["gitconfig", "gh"],
+      home,
+    });
+    assert.deepEqual(status, {
+      sshAgent: false,
+      mounts: ["gitconfig", "gh"],
+    });
+  });
+
+  it("combines ssh agent + config mounts when both are opted in", () => {
+    const home = makeFixtureHome({ gh: true, gitconfig: true });
+    const status = buildSandboxStatus({
+      sandboxEnabled: true,
+      sshAgentForward: true,
+      configMountNames: ["gh", "gitconfig"],
+      sshAuthSock: makeFakeSocket(),
+      home,
+    });
+    assert.deepEqual(status, {
+      sshAgent: true,
+      mounts: ["gh", "gitconfig"],
+    });
+  });
+});

--- a/test/composables/test_useSandboxStatus.ts
+++ b/test/composables/test_useSandboxStatus.ts
@@ -1,0 +1,100 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { useSandboxStatus } from "../../src/composables/useSandboxStatus.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const originalFetch: any = (globalThis as any).fetch;
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = originalFetch;
+});
+
+function stubFetch(
+  impl: (input: unknown, init?: unknown) => Promise<Response>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = impl;
+}
+
+function mockJsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("useSandboxStatus", () => {
+  it("status is null until ensureLoaded resolves", () => {
+    const { status } = useSandboxStatus();
+    assert.equal(status.value, null);
+  });
+
+  it("populates status from a successful /api/sandbox response", async () => {
+    stubFetch(async () =>
+      mockJsonResponse(200, { sshAgent: true, mounts: ["gh", "gitconfig"] }),
+    );
+    const { status, ensureLoaded } = useSandboxStatus();
+    await ensureLoaded();
+    assert.deepEqual(status.value, {
+      sshAgent: true,
+      mounts: ["gh", "gitconfig"],
+    });
+  });
+
+  it("leaves status null when the server responds with `{}` (sandbox disabled)", async () => {
+    // Shouldn't happen in practice — the popup only calls us when
+    // sandboxEnabled is true — but the validator must still keep
+    // status null rather than crashing on the empty-object shape.
+    stubFetch(async () => mockJsonResponse(200, {}));
+    const { status, ensureLoaded } = useSandboxStatus();
+    await ensureLoaded();
+    assert.equal(status.value, null);
+  });
+
+  it("caches successful loads — only calls the network once", async () => {
+    let calls = 0;
+    stubFetch(async () => {
+      calls++;
+      return mockJsonResponse(200, { sshAgent: false, mounts: [] });
+    });
+    const { ensureLoaded } = useSandboxStatus();
+    await ensureLoaded();
+    await ensureLoaded();
+    await ensureLoaded();
+    assert.equal(calls, 1);
+  });
+
+  it("retries after a failed fetch (cache flip on error)", async () => {
+    // First attempt fails → status stays null, `loaded` internal flag
+    // is reset so the next ensureLoaded tries again. This matters
+    // because the popup reopens on every click and the user expects
+    // a flaky network to recover without a page reload.
+    let attempts = 0;
+    stubFetch(async () => {
+      attempts++;
+      if (attempts === 1) return mockJsonResponse(500, { error: "boom" });
+      return mockJsonResponse(200, { sshAgent: true, mounts: [] });
+    });
+    const { status, ensureLoaded } = useSandboxStatus();
+    await ensureLoaded();
+    assert.equal(status.value, null);
+    await ensureLoaded();
+    assert.deepEqual(status.value, { sshAgent: true, mounts: [] });
+    assert.equal(attempts, 2);
+  });
+
+  it("rejects malformed payloads (missing fields, wrong types)", async () => {
+    stubFetch(async () =>
+      mockJsonResponse(200, { sshAgent: "yes", mounts: [1, 2, 3] }),
+    );
+    const { status, ensureLoaded } = useSandboxStatus();
+    await ensureLoaded();
+    // Validator should drop the payload rather than letting bad types
+    // leak into the UI render.
+    assert.equal(status.value, null);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #327: users toggling `SANDBOX_SSH_AGENT_FORWARD` / `SANDBOX_MOUNT_CONFIGS` had no UI signal that their env var took effect. This PR lands three things together (single PR per the plan discussion):

- **`GET /api/sandbox`** — new endpoint, separate from `/api/health` so the health probe stays a lightweight boot check. Returns `{}` when the sandbox is disabled; `{ sshAgent, mounts }` when enabled.
- **LockStatusPopup credential block** — lazy-fetches the status on first open via the new `useSandboxStatus` composable (page-lifetime cache; retries on failure). Renders one line per credential category.
- **Explainer query + helps doc** — a new canned sample query `"Explain my current sandbox and credential setup"` pointing at a new `"Checking the Current Sandbox State"` section in `config/helps/sandbox.md`. Claude answers with built-in Read + Bash tools.

## Items to Confirm / Review

1. **API minimum-info principle**: payload is names only, no host paths or skip reasons. Full detail lives in the server log via `resolveSandboxAuth`'s existing `log.warn`/`log.info` calls. Flag if you want the popup to surface any of those signals (e.g. a grey "gh: host path missing" line).
2. **Lazy load strategy**: page-lifetime cache — the popup's first open does a fetch, subsequent opens reuse. Retries on failure so a transient blip recovers without a page reload. Env var changes only take effect on server restart anyway, so refreshing mid-session has no additional value.
3. **No dedicated `describeSandbox` MCP tool** (Option 1 from the plan). Claude uses built-in Read + Bash against the new helps doc section. Worth revisiting only if LLM-driven workflows start needing structured state.
4. **Doc lives under `server/workspace/helps/sandbox.md`** (post-#323 reorg), synced into `~/mulmoclaude/config/helps/sandbox.md` by `initWorkspace()` on every start.

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/327 のフィードバック
> git/gh を sandbox の中から使えるようにする変更ですね。取り込みましたが、lock アイコンで表示されるポップアップの中に、どんな状況にあるのかを表示し、sample queries の一つで説明を受けられるようにする必要があると思います。これを分解して丁寧に issue にしたい。

## Implementation

Plan: [`plans/feat-sandbox-status-popup.md`](plans/feat-sandbox-status-popup.md) (committed).

- **new** `server/api/sandboxStatus.ts` — pure `buildSandboxStatus` builder.
- **edit** `server/index.ts` — mount the new route.
- **edit** `src/config/apiRoutes.ts` — `sandbox: "/api/sandbox"`.
- **new** `src/composables/useSandboxStatus.ts` — lazy fetch + cache + retry-on-failure.
- **edit** `src/components/LockStatusPopup.vue` — credential block + new sample query, existing query path updated for post-#284 helps location.
- **edit** `server/workspace/helps/sandbox.md` — "Checking the Current Sandbox State" section.
- **new tests** (+16, total 2091): `test/api/test_sandboxStatus.ts`, `test/composables/test_useSandboxStatus.ts`.

## Test plan

- [x] 2091 unit tests pass
- [x] Typecheck / lint / build green
- [x] Manual: `curl /api/sandbox` against live server with sandbox disabled → `{}`
- [ ] Manual: click lock icon with sandbox **off** → popup shows "No sandbox", no credential block
- [ ] Manual: click lock icon with sandbox **on** but no opt-ins → "SSH agent: not forwarded" + "Mounted configs: none"
- [ ] Manual: set `SANDBOX_SSH_AGENT_FORWARD=1` + `SANDBOX_MOUNT_CONFIGS=gh,gitconfig`, restart, reopen popup → both forwarded + listed
- [ ] Manual: click the new "Explain my current sandbox and credential setup" query → Claude reads `config/helps/sandbox.md` and explains the current state
- [ ] CI: Windows / Linux / macOS × Node 22/24 + E2E

Closes #329.