### PR TITLE
feat: /api/sessions incremental fetch with server cursor (#205)

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -73,7 +73,13 @@ export async function mockAllApis(
 
   await page.route(urlEndsWith("/api/sessions"), (route) => {
     if (route.request().method() === "GET") {
-      return route.fulfill({ json: sessions });
+      // Envelope shape from #205. Any test that wants to simulate
+      // a diff can override this route with its own handler — the
+      // catch-all always returns the full list and an empty
+      // deletedIds, which is the first-call / cold-start answer.
+      return route.fulfill({
+        json: { sessions, cursor: "v1:0", deletedIds: [] },
+      });
     }
     return route.fallback();
   });

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -73,7 +73,13 @@ test.describe("history panel (useSessionHistory)", () => {
       if (route.request().method() === "GET") {
         sessionFetchCount++;
       }
-      return route.fulfill({ json: [SESSION_A, SESSION_B] });
+      return route.fulfill({
+        json: {
+          sessions: [SESSION_A, SESSION_B],
+          cursor: "v1:0",
+          deletedIds: [],
+        },
+      });
     });
 
     await page.goto("/chat");

--- a/plans/feat-sessions-incremental.md
+++ b/plans/feat-sessions-incremental.md
@@ -1,0 +1,101 @@
+# feat: /api/sessions incremental fetch with server cursor (#205)
+
+## Context
+
+Issue [#205](https://github.com/receptron/mulmoclaude/issues/205). PR #203 made the initial `/api/sessions` response cheap (stat-only, no `.jsonl` body reads). The next bottleneck is **bandwidth + client-side JSON parse on every sidebar refresh** — the full 90-day window (~tens of KB for 100 sessions) is re-downloaded for every invalidation event.
+
+Goal: **2 回目以降は差分だけ**. Server returns an opaque cursor; client echoes it back on the next call; server answers with only sessions that changed since then.
+
+The user explicitly picked **approach A** (tombstone-shaped response) for this PR. Deletion doesn't exist in the product yet — I verified there's no `unlink` on any `chat/*.jsonl` path — so `deletedIds` is always `[]` today, but the surface is ready when deletion lands.
+
+## Wire shape
+
+**Before (still supported until clients migrate, but this PR flips everyone):**
+
+```ts
+GET /api/sessions → SessionSummary[]
+```
+
+**After:**
+
+```ts
+GET /api/sessions                  → { sessions: SessionSummary[], cursor: string, deletedIds: string[] }
+GET /api/sessions?since=<cursor>   → same shape, `sessions` is a diff
+```
+
+`cursor` is opaque — the spec says so and the product can change the encoding without touching clients. Today it's `"v1:<maxChangeMs>"` where `maxChangeMs` is the most recent of every visible session's (`mtimeMs`, `indexedAt`). Parsing is defensive: anything that doesn't start with `v1:` or doesn't parse to a number is treated as "since 0" (= full resend).
+
+## "Changed" = which timestamps?
+
+A session is in the diff when either:
+
+- its `.jsonl` mtime is newer than the cursor (new / resumed turn), OR
+- its chat-index entry's `indexedAt` is newer than the cursor (AI title / summary refreshed in the background, doesn't touch mtime).
+
+The `indexedAt` field already exists on `ChatIndexEntry` (see `server/workspace/chat-index/types.ts:27`). No schema migration needed.
+
+## Server changes
+
+1. `server/api/routes/sessions.ts` — accept `?since=`, compute `maxChangeMs`, filter by it, return the envelope.
+2. Add a small pure helper `computeSessionsCursor(...)` / `filterChangedSessions(...)` in a sibling file or inline (prefer sibling — see Code Organization in CLAUDE.md) so tests don't need supertest.
+
+### Edge cases
+
+- **No `?since=`**: full list, cursor built from max change. Same code path — `since = 0`.
+- **Invalid cursor**: treat as 0. Client gets a full resend, no 400. This is intentional — the one thing worse than a slow sidebar is a broken sidebar after a cursor-format rename.
+- **Empty diff**: `sessions: []`, `cursor` echoed back (same value is fine), `deletedIds: []`. Client no-ops.
+- **Server restart**: in-memory `sessionMap` is empty, so `isRunning` / `statusMessage` will flip to absent on the next diff. Acceptable — that's how the pre-diff world worked too.
+- **exactOptionalPropertyTypes**: the `summary` / `keywords` / `isRunning` / `statusMessage` fields are still spread conditionally (matches existing code, line 119-126).
+
+## Client changes
+
+`src/composables/useSessionHistory.ts`:
+
+- Keep `sessions: Ref<SessionSummary[]>` as the canonical cache.
+- Add `cursor: Ref<string | null>`, persisted in memory only for now (tab-scoped; cross-tab sharing is noted as out of scope in the issue).
+- First call: no `since` param. Cache the returned list + cursor.
+- Subsequent calls: pass `?since=<cursor>`. Merge diff into cache.
+- On error: preserve cache, set `historyError` (existing behaviour from #280 untouched).
+
+### Diff merge
+
+Add `applySessionDiff(cache, diff, deletedIds)` in `src/utils/session/mergeSessions.ts` next to `mergeSessionLists`:
+
+- Upsert each diff entry by `id` (new = prepend, existing = replace).
+- Remove any id in `deletedIds`.
+- Re-sort by `updatedAt` desc (same comparator as server).
+- Pure; returns a new array.
+
+Unit-testable with no Vue harness.
+
+## Backwards compatibility
+
+The **response shape changes** (array → object). Every server build ships with every client build, so there's no split deploy to worry about — but we still guard:
+
+- The e2e fixture's `GET /api/sessions` mock (`e2e/fixtures/api.ts`) returns the old array shape. Update it to the envelope. Tests that don't touch this endpoint aren't affected.
+- Any code reading `response.data.sessions` via `apiGet<SessionsResponse>(...)` will now see the envelope.
+
+## Out of scope for this PR
+
+- Push-based real-time session updates (mentioned in issue as "別 issue").
+- Cross-tab cursor sharing via `localStorage`.
+- Deletion tombstones actually being populated (nothing deletes today).
+
+## Tests
+
+- **Unit**: new `test/routes/test_sessionsRoute.ts` covering: no `since` → full list; valid `since` → only newer; invalid cursor → full list; cursor roundtrips (pass the returned cursor back in, expect empty diff).
+- **Unit**: extend `test/utils/session/test_mergeSessions.ts` with `applySessionDiff` cases: upsert, remove via `deletedIds`, stable sort.
+- **Unit**: extend `test/composables/test_useSessionHistory.ts` with cursor send/receive + diff merge case.
+- **E2E**: fixture update only — no behavioural e2e because the visible UI doesn't change.
+
+## Checklist
+
+- [ ] Server route accepts `?since=`, returns envelope with cursor + deletedIds
+- [ ] Pure helpers extracted for test
+- [ ] Client sends cursor on re-fetch; merges via `applySessionDiff`
+- [ ] `applySessionDiff` added next to `mergeSessionLists`
+- [ ] E2E fixture updated to envelope shape
+- [ ] `yarn format && yarn lint && yarn typecheck && yarn build`
+- [ ] `yarn test` (new cases added)
+- [ ] `yarn test:e2e`
+- [ ] PR referencing #205

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -12,6 +12,11 @@ import { notFound } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
+import {
+  encodeCursor,
+  parseCursor,
+  sessionChangeMs,
+} from "./sessionsCursor.js";
 
 interface SessionMeta {
   roleId: string;
@@ -69,69 +74,114 @@ interface SessionSummary {
   statusMessage?: string;
 }
 
+// Public response envelope for GET /api/sessions (issue #205).
+//
+// `cursor`     — opaque string clients echo back as `?since=` on the
+//                next call to receive only sessions that have changed.
+// `deletedIds` — always `[]` for now (no session-delete code path
+//                exists yet). Kept in the shape so the client already
+//                merges it; when deletion lands, populating this will
+//                be a server-only change.
+interface SessionsResponse {
+  sessions: SessionSummary[];
+  cursor: string;
+  deletedIds: string[];
+}
+
+interface SessionsQuery {
+  since?: string;
+}
+
 const router = Router();
 
 // Sessions older than this are excluded from the listing. Set
 // SESSIONS_LIST_WINDOW_DAYS to override (0 = no cutoff).
 const WINDOW_MS = env.sessionsListWindowDays * 86_400_000;
 
+// Read the full session list off disk. Each row carries its
+// `changeMs` — the later of the jsonl mtime and the chat-index
+// `indexedAt` — so the handler can filter against `?since=` and
+// compute the new cursor without re-statting anything.
+async function loadAllSessions(): Promise<
+  { summary: SessionSummary; changeMs: number }[]
+> {
+  const chatDir = WORKSPACE_PATHS.chat;
+  const manifest = await readManifest(workspacePath);
+  const indexById = new Map<string, ChatIndexEntry>(
+    manifest.entries.map((e) => [e.id, e]),
+  );
+  const cutoff = WINDOW_MS > 0 ? Date.now() - WINDOW_MS : 0;
+
+  const files = (await readdir(chatDir)).filter((f) => f.endsWith(".jsonl"));
+  const rows = await Promise.all(
+    files.map(async (file) => {
+      const id = file.replace(".jsonl", "");
+      try {
+        // stat only — no readFile on .jsonl content
+        const fileStat = await stat(path.join(chatDir, file));
+        if (cutoff > 0 && fileStat.mtimeMs < cutoff) return null;
+
+        const meta = await readSessionMeta(chatDir, id);
+        if (!meta) return null;
+
+        const indexEntry = indexById.get(id);
+        // Prefer AI title → meta.firstUserMessage → empty.
+        // `summary` and `keywords` are spread conditionally
+        // to respect the server tsconfig's
+        // exactOptionalPropertyTypes.
+        const preview = indexEntry?.title ?? meta.firstUserMessage ?? "";
+
+        const live = getSession(id);
+        const summary: SessionSummary = {
+          id,
+          roleId: meta.roleId,
+          startedAt: meta.startedAt,
+          updatedAt: new Date(fileStat.mtimeMs).toISOString(),
+          preview,
+          hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
+        };
+        if (indexEntry?.summary !== undefined)
+          summary.summary = indexEntry.summary;
+        if (indexEntry?.keywords !== undefined)
+          summary.keywords = indexEntry.keywords;
+        if (live) {
+          summary.isRunning = live.isRunning;
+          summary.statusMessage = live.statusMessage;
+        }
+        return {
+          summary,
+          changeMs: sessionChangeMs(fileStat.mtimeMs, indexEntry?.indexedAt),
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return rows.filter(
+    (r): r is { summary: SessionSummary; changeMs: number } => r !== null,
+  );
+}
+
 router.get(
   API_ROUTES.sessions.list,
-  async (_req: Request, res: Response<SessionSummary[]>) => {
-    const chatDir = WORKSPACE_PATHS.chat;
-    const manifest = await readManifest(workspacePath);
-    const indexById = new Map<string, ChatIndexEntry>(
-      manifest.entries.map((e) => [e.id, e]),
-    );
-    const cutoff = WINDOW_MS > 0 ? Date.now() - WINDOW_MS : 0;
+  async (
+    req: Request<object, SessionsResponse, object, SessionsQuery>,
+    res: Response<SessionsResponse>,
+  ) => {
     try {
-      const files = (await readdir(chatDir)).filter((f) =>
-        f.endsWith(".jsonl"),
-      );
-      const sessions = (
-        await Promise.all(
-          files.map(async (file) => {
-            const id = file.replace(".jsonl", "");
-            try {
-              // stat only — no readFile on .jsonl content
-              const fileStat = await stat(path.join(chatDir, file));
-              if (cutoff > 0 && fileStat.mtimeMs < cutoff) return null;
+      const sinceMs = parseCursor(req.query.since);
+      const rows = await loadAllSessions();
 
-              const meta = await readSessionMeta(chatDir, id);
-              if (!meta) return null;
+      // Cursor = max(changeMs) across every visible session, regardless
+      // of whether it's in the diff. Echoing the same cursor back on an
+      // empty diff (nothing changed since `?since=`) is fine; the
+      // client no-ops.
+      const maxChangeMs = rows.reduce((acc, r) => Math.max(acc, r.changeMs), 0);
 
-              const indexEntry = indexById.get(id);
-              // Prefer AI title → meta.firstUserMessage → empty.
-              // `summary` and `keywords` are spread conditionally
-              // to respect the server tsconfig's
-              // exactOptionalPropertyTypes.
-              const preview = indexEntry?.title ?? meta.firstUserMessage ?? "";
+      const filtered =
+        sinceMs > 0 ? rows.filter((r) => r.changeMs > sinceMs) : rows;
 
-              const live = getSession(id);
-              const summary: SessionSummary = {
-                id,
-                roleId: meta.roleId,
-                startedAt: meta.startedAt,
-                updatedAt: new Date(fileStat.mtimeMs).toISOString(),
-                preview,
-                hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
-              };
-              if (indexEntry?.summary !== undefined)
-                summary.summary = indexEntry.summary;
-              if (indexEntry?.keywords !== undefined)
-                summary.keywords = indexEntry.keywords;
-              if (live) {
-                summary.isRunning = live.isRunning;
-                summary.statusMessage = live.statusMessage;
-              }
-              return summary;
-            } catch {
-              return null;
-            }
-          }),
-        )
-      ).filter((s): s is SessionSummary => s !== null);
-
+      const sessions = filtered.map((r) => r.summary);
       sessions.sort((a, b) => {
         const byUpdated =
           new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
@@ -140,9 +190,18 @@ router.get(
           new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
         );
       });
-      res.json(sessions);
+
+      res.json({
+        sessions,
+        cursor: encodeCursor(maxChangeMs),
+        // No session-delete code path exists today — issue #205 picked
+        // approach A (tombstones) so the client already merges this
+        // field; populating it becomes a server-only change when
+        // deletion lands.
+        deletedIds: [],
+      });
     } catch {
-      res.json([]);
+      res.json({ sessions: [], cursor: encodeCursor(0), deletedIds: [] });
     }
   },
 );

--- a/server/api/routes/sessionsCursor.ts
+++ b/server/api/routes/sessionsCursor.ts
@@ -1,0 +1,59 @@
+// Cursor logic for `GET /api/sessions?since=<cursor>` (issue #205).
+//
+// Kept separate from `sessions.ts` so the pure logic can be unit
+// tested without an Express harness.
+//
+// The cursor is deliberately opaque to the client: today it encodes
+// the max "change timestamp" (ms since epoch) as `"v1:<ms>"`, where a
+// session's change timestamp is `max(jsonlMtimeMs, indexedAtMs)`. We
+// prefix with `v1:` so a future encoding change (e.g. adding a
+// deletion generation counter for approach A when deletion lands)
+// can bump the prefix without clients caring — they always echo back
+// whatever the server handed them.
+
+const CURSOR_PREFIX = "v1:";
+
+/**
+ * Encode a change timestamp (ms) as an opaque cursor string.
+ *
+ * `changeMs <= 0` is allowed and yields `"v1:0"` — that's the
+ * "beginning of time" cursor a client will never hold but which we
+ * fall back to when an incoming cursor is malformed.
+ */
+export function encodeCursor(changeMs: number): string {
+  const ms =
+    Number.isFinite(changeMs) && changeMs > 0 ? Math.floor(changeMs) : 0;
+  return `${CURSOR_PREFIX}${ms}`;
+}
+
+/**
+ * Parse an incoming `?since=` cursor back to the ms timestamp it
+ * encodes. Anything the client sends that we don't recognise — old
+ * format, truncated, typo, empty — returns 0 so the client gets a
+ * full resend instead of a broken sidebar. This is intentionally
+ * forgiving; the failure mode is "downloads slightly more than
+ * needed once" which is the behaviour clients had pre-#205 anyway.
+ */
+export function parseCursor(raw: unknown): number {
+  if (typeof raw !== "string") return 0;
+  if (!raw.startsWith(CURSOR_PREFIX)) return 0;
+  const n = Number(raw.slice(CURSOR_PREFIX.length));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * Compute the per-session "change timestamp" in ms — the later of
+ * the jsonl mtime (new user/assistant turn) and the chat-index
+ * `indexedAt` (AI-generated title / summary updated in the
+ * background and doesn't touch the jsonl). Missing / malformed
+ * `indexedAt` falls back to the mtime alone.
+ */
+export function sessionChangeMs(
+  jsonlMtimeMs: number,
+  indexedAtIso: string | undefined,
+): number {
+  const indexedAtMs =
+    indexedAtIso !== undefined ? new Date(indexedAtIso).getTime() : NaN;
+  const safeIndexed = Number.isFinite(indexedAtMs) ? indexedAtMs : 0;
+  return Math.max(jsonlMtimeMs, safeIndexed);
+}

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -5,11 +5,24 @@
 // The dropdown lazy-loads the list only when opened, and callers
 // can invoke `fetchSessions()` directly after an end-of-run so the
 // sidebar title cache stays fresh.
+//
+// Since #205, `fetchSessions()` sends the server's last-issued
+// cursor back as `?since=<cursor>` so the server can reply with
+// only the rows that changed. The first call has no cursor (full
+// fetch); subsequent calls receive a diff that we merge into the
+// existing cache via `applySessionDiff`.
 
 import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import type { SessionSummary } from "../types/session";
 import { apiGet } from "../utils/api";
+import { applySessionDiff } from "../utils/session/mergeSessions";
+
+interface SessionsResponse {
+  sessions: SessionSummary[];
+  cursor: string;
+  deletedIds: string[];
+}
 
 export function useSessionHistory(): {
   sessions: Ref<SessionSummary[]>;
@@ -25,9 +38,18 @@ export function useSessionHistory(): {
   // the moment the network hiccups is worse UX than one that shows
   // "⚠ using cached list" with the last-known good entries.
   const historyError = ref<string | null>(null);
+  // Opaque cursor the server hands back on every successful call.
+  // Tab-scoped — issue #205 calls out cross-tab sharing via
+  // localStorage as out of scope.
+  let cursor: string | null = null;
 
   async function fetchSessions(): Promise<SessionSummary[]> {
-    const result = await apiGet<SessionSummary[]>(API_ROUTES.sessions.list);
+    const query: Record<string, string> = {};
+    if (cursor !== null) query.since = cursor;
+    const result = await apiGet<SessionsResponse>(
+      API_ROUTES.sessions.list,
+      query,
+    );
     if (!result.ok) {
       historyError.value = result.error;
       // Intentionally preserve `sessions.value` — callers keep showing
@@ -35,8 +57,20 @@ export function useSessionHistory(): {
       return sessions.value;
     }
     historyError.value = null;
-    sessions.value = result.data;
-    return result.data;
+    const body = result.data;
+    if (cursor === null) {
+      // First call in this composable instance — server returned the
+      // full list; seed the cache directly.
+      sessions.value = body.sessions;
+    } else {
+      sessions.value = applySessionDiff(
+        sessions.value,
+        body.sessions,
+        body.deletedIds,
+      );
+    }
+    cursor = body.cursor;
+    return sessions.value;
   }
 
   async function toggleHistory(): Promise<void> {

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -84,3 +84,29 @@ export function mergeSessionLists(
   const serverOnly = serverSessions.filter((s) => !liveIds.has(s.id));
   return [...liveSummaries, ...serverOnly].sort(compareSessionsByRecency);
 }
+
+// Apply a server-sent diff to the client's cached session list
+// (see issue #205). `diff` holds rows the server says have changed
+// since the client's last cursor — each replaces any existing row
+// with the same id, or is prepended if new. `deletedIds` removes
+// rows the server has forgotten; always empty today (no
+// session-delete code path exists) but the shape is plumbed through
+// so populating it becomes a server-only change later.
+//
+// Pure; returns a new array sorted by the same recency rule
+// `mergeSessionLists` uses, so the two are interchangeable at call
+// sites that don't care which they got.
+export function applySessionDiff(
+  cache: readonly SessionSummary[],
+  diff: readonly SessionSummary[],
+  deletedIds: readonly string[],
+): SessionSummary[] {
+  const deleted = new Set(deletedIds);
+  const diffById = new Map<string, SessionSummary>(diff.map((s) => [s.id, s]));
+  const kept = cache
+    .filter((s) => !deleted.has(s.id))
+    .map((s) => diffById.get(s.id) ?? s);
+  const existingIds = new Set(kept.map((s) => s.id));
+  const added = diff.filter((s) => !existingIds.has(s.id));
+  return [...kept, ...added].sort(compareSessionsByRecency);
+}

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -2,9 +2,12 @@ import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { useSessionHistory } from "../../src/composables/useSessionHistory.js";
 
-// These tests exercise the error-surfacing added for issue #280:
-// a fetch failure must set `historyError` but leave `sessions`
-// untouched so the sidebar keeps showing its last known list.
+// These tests exercise the error-surfacing added for issue #280
+// and the cursor-aware incremental fetch added for issue #205:
+//   - a fetch failure must set `historyError` but leave `sessions`
+//     untouched so the sidebar keeps showing its last known list
+//   - the first call seeds from the full response; subsequent calls
+//     send the server's cursor back as `?since=` and merge the diff
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const originalFetch: any = (globalThis as any).fetch;
@@ -31,22 +34,32 @@ function mockJsonResponse(status: number, body: unknown): Response {
   } as any;
 }
 
+interface SummaryRow {
+  id: string;
+  roleId: string;
+  startedAt: string;
+  updatedAt: string;
+  preview: string;
+}
+
+function row(id: string, updatedAt = ""): SummaryRow {
+  return { id, roleId: "general", startedAt: "", updatedAt, preview: "" };
+}
+
+function envelope(
+  sessions: SummaryRow[],
+  cursor: string,
+  deletedIds: string[] = [],
+) {
+  return { sessions, cursor, deletedIds };
+}
+
 describe("useSessionHistory — error surfacing (#280)", () => {
   it("sets historyError and keeps existing sessions on failure", async () => {
     const { sessions, historyError, fetchSessions } = useSessionHistory();
 
     // Prime the list with a successful fetch.
-    stubFetch(async () =>
-      mockJsonResponse(200, [
-        {
-          id: "s1",
-          roleId: "general",
-          startedAt: "",
-          updatedAt: "",
-          preview: "",
-        },
-      ]),
-    );
+    stubFetch(async () => mockJsonResponse(200, envelope([row("s1")], "v1:1")));
     await fetchSessions();
     assert.equal(sessions.value.length, 1);
     assert.equal(historyError.value, null);
@@ -70,7 +83,7 @@ describe("useSessionHistory — error surfacing (#280)", () => {
     await fetchSessions();
     assert.ok(historyError.value);
 
-    stubFetch(async () => mockJsonResponse(200, []));
+    stubFetch(async () => mockJsonResponse(200, envelope([], "v1:1")));
     await fetchSessions();
     assert.equal(historyError.value, null);
   });
@@ -79,22 +92,7 @@ describe("useSessionHistory — error surfacing (#280)", () => {
     const { fetchSessions } = useSessionHistory();
 
     stubFetch(async () =>
-      mockJsonResponse(200, [
-        {
-          id: "a",
-          roleId: "general",
-          startedAt: "",
-          updatedAt: "",
-          preview: "",
-        },
-        {
-          id: "b",
-          roleId: "general",
-          startedAt: "",
-          updatedAt: "",
-          preview: "",
-        },
-      ]),
+      mockJsonResponse(200, envelope([row("a"), row("b")], "v1:1")),
     );
     const first = await fetchSessions();
     assert.equal(first.length, 2);
@@ -104,5 +102,105 @@ describe("useSessionHistory — error surfacing (#280)", () => {
     // Previous behaviour returned []; new behaviour returns the stale
     // list so the caller doesn't have to re-read `.sessions` separately.
     assert.equal(second.length, 2);
+  });
+});
+
+describe("useSessionHistory — cursor-aware incremental fetch (#205)", () => {
+  it("sends no `since` param on the first call, full response seeds the cache", async () => {
+    const { sessions, fetchSessions } = useSessionHistory();
+    let capturedUrl = "";
+    stubFetch(async (url) => {
+      capturedUrl = String(url);
+      return mockJsonResponse(
+        200,
+        envelope([row("a", "2026-04-17T01:00:00.000Z")], "v1:100"),
+      );
+    });
+    await fetchSessions();
+    assert.ok(
+      !capturedUrl.includes("since="),
+      `first call should omit ?since=, got: ${capturedUrl}`,
+    );
+    assert.equal(sessions.value.length, 1);
+  });
+
+  it("echoes the server cursor back on the second call", async () => {
+    const { fetchSessions } = useSessionHistory();
+    stubFetch(async () =>
+      mockJsonResponse(200, envelope([row("a")], "v1:1234")),
+    );
+    await fetchSessions();
+
+    let capturedUrl = "";
+    stubFetch(async (url) => {
+      capturedUrl = String(url);
+      return mockJsonResponse(200, envelope([], "v1:1234"));
+    });
+    await fetchSessions();
+
+    // URLs are built by apiGet via URLSearchParams — `v1:1234`
+    // encodes to `v1%3A1234`. Check both forms to stay robust.
+    assert.ok(
+      capturedUrl.includes("since=v1%3A1234") ||
+        capturedUrl.includes("since=v1:1234"),
+      `second call must carry the cursor, got: ${capturedUrl}`,
+    );
+  });
+
+  it("merges diffs into the cache (upsert + preserved rows)", async () => {
+    const { sessions, fetchSessions } = useSessionHistory();
+    // Seed with two sessions.
+    stubFetch(async () =>
+      mockJsonResponse(
+        200,
+        envelope(
+          [
+            row("a", "2026-04-17T01:00:00.000Z"),
+            row("b", "2026-04-17T02:00:00.000Z"),
+          ],
+          "v1:1",
+        ),
+      ),
+    );
+    await fetchSessions();
+
+    // Diff: `a` gets a newer updatedAt, `c` is new, `b` is unchanged
+    // and NOT returned in the diff. Cache must still contain b.
+    stubFetch(async () =>
+      mockJsonResponse(
+        200,
+        envelope(
+          [
+            { ...row("a", "2026-04-17T03:00:00.000Z"), preview: "updated" },
+            row("c", "2026-04-17T00:30:00.000Z"),
+          ],
+          "v1:2",
+        ),
+      ),
+    );
+    await fetchSessions();
+
+    const ids = sessions.value.map((s) => s.id);
+    assert.deepEqual(
+      ids.sort(),
+      ["a", "b", "c"].sort(),
+      "diff should upsert a/c while preserving untouched b",
+    );
+    const a = sessions.value.find((s) => s.id === "a");
+    assert.equal(a?.preview, "updated", "a must have the diff's fields");
+  });
+
+  it("removes cached rows whose id appears in deletedIds", async () => {
+    const { sessions, fetchSessions } = useSessionHistory();
+    stubFetch(async () =>
+      mockJsonResponse(200, envelope([row("a"), row("b"), row("c")], "v1:1")),
+    );
+    await fetchSessions();
+    assert.equal(sessions.value.length, 3);
+
+    stubFetch(async () => mockJsonResponse(200, envelope([], "v1:2", ["b"])));
+    await fetchSessions();
+    const ids = sessions.value.map((s) => s.id).sort();
+    assert.deepEqual(ids, ["a", "c"]);
   });
 });

--- a/test/routes/test_sessionsCursor.ts
+++ b/test/routes/test_sessionsCursor.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  encodeCursor,
+  parseCursor,
+  sessionChangeMs,
+} from "../../server/api/routes/sessionsCursor.js";
+
+// Pure helpers backing the /api/sessions?since= implementation
+// (issue #205). Exercised in isolation so the route handler's
+// tests can focus on end-to-end behaviour without re-litigating
+// cursor format edge cases.
+
+describe("encodeCursor", () => {
+  it("stamps the v1: prefix and a numeric ms", () => {
+    assert.equal(encodeCursor(1234), "v1:1234");
+  });
+  it("floors fractional inputs", () => {
+    assert.equal(encodeCursor(1234.9), "v1:1234");
+  });
+  it("maps 0 / negative / non-finite to v1:0", () => {
+    assert.equal(encodeCursor(0), "v1:0");
+    assert.equal(encodeCursor(-5), "v1:0");
+    assert.equal(encodeCursor(Number.NaN), "v1:0");
+    assert.equal(encodeCursor(Number.POSITIVE_INFINITY), "v1:0");
+  });
+});
+
+describe("parseCursor", () => {
+  it("roundtrips encodeCursor", () => {
+    assert.equal(
+      parseCursor(encodeCursor(1_700_000_000_000)),
+      1_700_000_000_000,
+    );
+  });
+  it("returns 0 for non-strings", () => {
+    assert.equal(parseCursor(undefined), 0);
+    assert.equal(parseCursor(null), 0);
+    assert.equal(parseCursor(42), 0);
+    assert.equal(parseCursor({}), 0);
+  });
+  it("returns 0 for unknown prefixes — forces a full resend instead of a 400", () => {
+    // Intentional: we would rather download one extra list than
+    // break the sidebar after a cursor-format rename.
+    assert.equal(parseCursor("v0:1234"), 0);
+    assert.equal(parseCursor("1234"), 0);
+    assert.equal(parseCursor(""), 0);
+    assert.equal(parseCursor("v1:"), 0);
+    assert.equal(parseCursor("v1:abc"), 0);
+  });
+  it("rejects zero / negative encoded values", () => {
+    assert.equal(parseCursor("v1:0"), 0);
+    assert.equal(parseCursor("v1:-5"), 0);
+  });
+});
+
+describe("sessionChangeMs", () => {
+  it("picks the jsonl mtime when there is no index entry", () => {
+    assert.equal(sessionChangeMs(100, undefined), 100);
+  });
+  it("picks the later of mtime and indexedAt", () => {
+    const mtime = 1_700_000_000_000;
+    const later = new Date(mtime + 5_000).toISOString();
+    assert.equal(sessionChangeMs(mtime, later), mtime + 5_000);
+
+    const earlier = new Date(mtime - 5_000).toISOString();
+    assert.equal(sessionChangeMs(mtime, earlier), mtime);
+  });
+  it("falls back to mtime alone when indexedAt is malformed", () => {
+    assert.equal(sessionChangeMs(100, "not a date"), 100);
+  });
+});

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -78,7 +78,9 @@ function mockRes() {
 // Base timestamps comfortably within the 90-day window so the
 // SESSIONS_LIST_WINDOW_DAYS cutoff never hides them during tests.
 // All per-test timestamps are offsets from this base.
-const BASE_MS = Date.now() - 10 * 86_400_000; // 10 days ago
+// Rounded to whole seconds so the utimes(secs) → stat(mtimeMs)
+// roundtrip doesn't lose sub-ms precision on CI filesystems.
+const BASE_MS = Math.floor((Date.now() - 10 * 86_400_000) / 1000) * 1000;
 
 let tmpRoot: string;
 let chatDir: string;
@@ -182,7 +184,7 @@ beforeEach(async () => {
 describe("GET /api/sessions — full fetch (no ?since=)", () => {
   it("returns every visible session plus an envelope with cursor + empty deletedIds", async () => {
     await writeSession("s1", { mtimeMs: BASE_MS });
-    await writeSession("s2", { mtimeMs: BASE_MS + 100_000 });
+    await writeSession("s2", { mtimeMs: BASE_MS + 100_000_000 });
 
     const { state, res } = mockRes();
     await getHandler({ query: {} } as unknown as Request, res);
@@ -195,12 +197,12 @@ describe("GET /api/sessions — full fetch (no ?since=)", () => {
       body.cursor.startsWith("v1:"),
       `opaque cursor, got: ${body.cursor}`,
     );
-    assert.equal(body.cursor, encodeCursor(BASE_MS + 100_000));
+    assert.equal(body.cursor, encodeCursor(BASE_MS + 100_000_000));
   });
 
   it("sorts newest updatedAt first", async () => {
     await writeSession("older", { mtimeMs: BASE_MS });
-    await writeSession("newer", { mtimeMs: BASE_MS + 500_000 });
+    await writeSession("newer", { mtimeMs: BASE_MS + 500_000_000 });
 
     const { state, res } = mockRes();
     await getHandler({ query: {} } as unknown as Request, res);
@@ -212,12 +214,12 @@ describe("GET /api/sessions — full fetch (no ?since=)", () => {
 describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
   it("omits sessions whose changeMs <= cursor", async () => {
     await writeSession("old", { mtimeMs: BASE_MS });
-    await writeSession("new", { mtimeMs: BASE_MS + 200_000 });
+    await writeSession("new", { mtimeMs: BASE_MS + 200_000_000 });
 
     const { state, res } = mockRes();
     await getHandler(
       {
-        query: { since: encodeCursor(BASE_MS + 100_000) },
+        query: { since: encodeCursor(BASE_MS + 100_000_000) },
       } as unknown as Request,
       res,
     );
@@ -228,13 +230,13 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
   it("includes a session whose chat-index indexedAt bumped past cursor (mtime alone would miss it)", async () => {
     await writeSession("summarised", {
       mtimeMs: BASE_MS,
-      indexedAtMs: BASE_MS + 500_000,
+      indexedAtMs: BASE_MS + 500_000_000,
     });
 
     const { state, res } = mockRes();
     await getHandler(
       {
-        query: { since: encodeCursor(BASE_MS + 100_000) },
+        query: { since: encodeCursor(BASE_MS + 100_000_000) },
       } as unknown as Request,
       res,
     );
@@ -242,7 +244,7 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
     assert.deepEqual(ids, ["summarised"]);
     // The returned cursor must advance to the indexedAt time, not
     // just the mtime, so the next call won't re-fetch this row.
-    assert.equal(state.body!.cursor, encodeCursor(BASE_MS + 500_000));
+    assert.equal(state.body!.cursor, encodeCursor(BASE_MS + 500_000_000));
   });
 
   it("returns an empty diff when nothing has changed since cursor", async () => {
@@ -251,7 +253,7 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
     const { state, res } = mockRes();
     await getHandler(
       {
-        query: { since: encodeCursor(BASE_MS + 100_000) },
+        query: { since: encodeCursor(BASE_MS + 100_000_000) },
       } as unknown as Request,
       res,
     );
@@ -264,7 +266,7 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
 
   it("falls back to a full resend when the cursor is malformed", async () => {
     await writeSession("a", { mtimeMs: BASE_MS });
-    await writeSession("b", { mtimeMs: BASE_MS + 100_000 });
+    await writeSession("b", { mtimeMs: BASE_MS + 100_000_000 });
 
     const { state, res } = mockRes();
     await getHandler(

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -1,0 +1,291 @@
+// Route-level checks for GET /api/sessions — end-to-end behaviour
+// of the cursor-aware incremental fetch added for issue #205.
+//
+// We drive the handler with plain Request / Response mocks so we
+// don't pay for an Express + supertest harness. The handler itself
+// stats real files in a temp workspace, so these tests double as a
+// regression check on the mtime-based `updatedAt` wiring.
+
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import { mkdtemp, rm, writeFile, utimes } from "fs/promises";
+import os from "os";
+import path from "path";
+import type { Request, Response } from "express";
+import { encodeCursor } from "../../server/api/routes/sessionsCursor.js";
+
+type RouteModule = typeof import("../../server/api/routes/sessions.js");
+
+interface SessionSummary {
+  id: string;
+  roleId: string;
+  startedAt: string;
+  updatedAt: string;
+  preview: string;
+}
+
+interface SessionsResponse {
+  sessions: SessionSummary[];
+  cursor: string;
+  deletedIds: string[];
+}
+
+type Handler = (req: Request, res: Response) => Promise<void> | void;
+
+interface StackFrame {
+  route?: {
+    path: string;
+    stack: Array<{ method: string; handle: Handler }>;
+  };
+}
+interface RouterInternals {
+  stack: StackFrame[];
+}
+
+function extractRouteHandler(
+  mod: RouteModule,
+  routePath: string,
+  method: "get",
+): Handler {
+  const router = mod.default as unknown as RouterInternals;
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((s) => s.method === method);
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
+}
+
+function mockRes() {
+  const state: { status: number; body: SessionsResponse | undefined } = {
+    status: 200,
+    body: undefined,
+  };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(payload: SessionsResponse) {
+      state.body = payload;
+      return res;
+    },
+  };
+  return { state, res: res as unknown as Response };
+}
+
+// Base timestamps comfortably within the 90-day window so the
+// SESSIONS_LIST_WINDOW_DAYS cutoff never hides them during tests.
+// All per-test timestamps are offsets from this base.
+const BASE_MS = Date.now() - 10 * 86_400_000; // 10 days ago
+
+let tmpRoot: string;
+let chatDir: string;
+// The manifest lives under a DIFFERENT tree from the session files —
+// `chatDirFor(workspaceRoot)` = `<workspace>/chat/index/manifest.json`
+// while WORKSPACE_PATHS.chat may be `<workspace>/conversations/chat/`.
+let manifestDir: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let getHandler: Handler;
+
+async function writeSession(
+  id: string,
+  opts: {
+    roleId?: string;
+    mtimeMs: number;
+    indexedAtMs?: number;
+    firstUserMessage?: string;
+  },
+): Promise<void> {
+  // Minimal session files: a .json meta + an empty-ish .jsonl.
+  const meta = {
+    roleId: opts.roleId ?? "general",
+    startedAt: new Date(opts.mtimeMs).toISOString(),
+    firstUserMessage: opts.firstUserMessage ?? `msg for ${id}`,
+  };
+  await writeFile(path.join(chatDir, `${id}.json`), JSON.stringify(meta));
+  await writeFile(path.join(chatDir, `${id}.jsonl`), "");
+  // Set both atime and mtime so the handler's stat.mtimeMs reads
+  // what the test intends.
+  const secs = opts.mtimeMs / 1000;
+  await utimes(path.join(chatDir, `${id}.jsonl`), secs, secs);
+
+  if (opts.indexedAtMs !== undefined) {
+    const manifestPath = path.join(manifestDir, "manifest.json");
+    let entries: unknown[] = [];
+    try {
+      entries =
+        JSON.parse(fs.readFileSync(manifestPath, "utf-8")).entries ?? [];
+    } catch {
+      /* first write */
+    }
+    entries.push({
+      id,
+      roleId: meta.roleId,
+      startedAt: meta.startedAt,
+      indexedAt: new Date(opts.indexedAtMs).toISOString(),
+      title: `AI title ${id}`,
+      summary: `AI summary ${id}`,
+      keywords: ["k1"],
+    });
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    await writeFile(manifestPath, JSON.stringify({ version: 1, entries }));
+  }
+}
+
+async function resetChatDir(): Promise<void> {
+  await rm(chatDir, { recursive: true, force: true });
+  await rm(manifestDir, { recursive: true, force: true });
+  fs.mkdirSync(chatDir, { recursive: true });
+  fs.mkdirSync(manifestDir, { recursive: true });
+}
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-sessions-route-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  // The workspace path resolves once at module load from os.homedir(),
+  // so we have to steer it BEFORE importing the route module. This
+  // mirrors the setup in test_configRoute.ts.
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+  // Use the real dir names from the workspace/paths and chat-index
+  // modules — they may differ (e.g. `conversations/chat` for session
+  // files, `chat/index` for the manifest after #284).
+  const { WORKSPACE_PATHS } = await import("../../server/workspace/paths.js");
+  const { indexDirFor } =
+    await import("../../server/workspace/chat-index/paths.js");
+  const { workspacePath: wp } =
+    await import("../../server/workspace/workspace.js");
+  chatDir = WORKSPACE_PATHS.chat;
+  manifestDir = indexDirFor(wp);
+  fs.mkdirSync(chatDir, { recursive: true });
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const routeMod = await import("../../server/api/routes/sessions.js");
+  getHandler = extractRouteHandler(routeMod, "/api/sessions", "get");
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await resetChatDir();
+});
+
+describe("GET /api/sessions — full fetch (no ?since=)", () => {
+  it("returns every visible session plus an envelope with cursor + empty deletedIds", async () => {
+    await writeSession("s1", { mtimeMs: BASE_MS });
+    await writeSession("s2", { mtimeMs: BASE_MS + 100_000 });
+
+    const { state, res } = mockRes();
+    await getHandler({ query: {} } as unknown as Request, res);
+
+    assert.equal(state.status, 200);
+    const body = state.body!;
+    assert.equal(body.sessions.length, 2);
+    assert.deepEqual(body.deletedIds, [], "deletedIds is always [] today");
+    assert.ok(
+      body.cursor.startsWith("v1:"),
+      `opaque cursor, got: ${body.cursor}`,
+    );
+    assert.equal(body.cursor, encodeCursor(BASE_MS + 100_000));
+  });
+
+  it("sorts newest updatedAt first", async () => {
+    await writeSession("older", { mtimeMs: BASE_MS });
+    await writeSession("newer", { mtimeMs: BASE_MS + 500_000 });
+
+    const { state, res } = mockRes();
+    await getHandler({ query: {} } as unknown as Request, res);
+    const ids = state.body!.sessions.map((s) => s.id);
+    assert.deepEqual(ids, ["newer", "older"]);
+  });
+});
+
+describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
+  it("omits sessions whose changeMs <= cursor", async () => {
+    await writeSession("old", { mtimeMs: BASE_MS });
+    await writeSession("new", { mtimeMs: BASE_MS + 200_000 });
+
+    const { state, res } = mockRes();
+    await getHandler(
+      {
+        query: { since: encodeCursor(BASE_MS + 100_000) },
+      } as unknown as Request,
+      res,
+    );
+    const ids = state.body!.sessions.map((s) => s.id);
+    assert.deepEqual(ids, ["new"]);
+  });
+
+  it("includes a session whose chat-index indexedAt bumped past cursor (mtime alone would miss it)", async () => {
+    await writeSession("summarised", {
+      mtimeMs: BASE_MS,
+      indexedAtMs: BASE_MS + 500_000,
+    });
+
+    const { state, res } = mockRes();
+    await getHandler(
+      {
+        query: { since: encodeCursor(BASE_MS + 100_000) },
+      } as unknown as Request,
+      res,
+    );
+    const ids = state.body!.sessions.map((s) => s.id);
+    assert.deepEqual(ids, ["summarised"]);
+    // The returned cursor must advance to the indexedAt time, not
+    // just the mtime, so the next call won't re-fetch this row.
+    assert.equal(state.body!.cursor, encodeCursor(BASE_MS + 500_000));
+  });
+
+  it("returns an empty diff when nothing has changed since cursor", async () => {
+    await writeSession("s", { mtimeMs: BASE_MS });
+
+    const { state, res } = mockRes();
+    await getHandler(
+      {
+        query: { since: encodeCursor(BASE_MS + 100_000) },
+      } as unknown as Request,
+      res,
+    );
+    assert.deepEqual(state.body!.sessions, []);
+    // Cursor is echoed to the server's view of the max change —
+    // same or higher than the client's — so subsequent idempotent
+    // calls keep getting empty diffs.
+    assert.equal(state.body!.cursor, encodeCursor(BASE_MS));
+  });
+
+  it("falls back to a full resend when the cursor is malformed", async () => {
+    await writeSession("a", { mtimeMs: BASE_MS });
+    await writeSession("b", { mtimeMs: BASE_MS + 100_000 });
+
+    const { state, res } = mockRes();
+    await getHandler(
+      { query: { since: "not-a-cursor" } } as unknown as Request,
+      res,
+    );
+    assert.equal(state.body!.sessions.length, 2);
+  });
+
+  it("round-trips: feed the returned cursor back in → empty diff", async () => {
+    await writeSession("a", { mtimeMs: BASE_MS });
+
+    const first = mockRes();
+    await getHandler({ query: {} } as unknown as Request, first.res);
+    const cursor = first.state.body!.cursor;
+
+    const second = mockRes();
+    await getHandler(
+      { query: { since: cursor } } as unknown as Request,
+      second.res,
+    );
+    assert.deepEqual(second.state.body!.sessions, []);
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -25,6 +25,11 @@
     // compiler.
     "jsx": "preserve"
   },
-  "include": ["**/*.ts", "../src/**/*.ts", "../server/**/*.ts", "../bridges/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "../src/**/*.ts",
+    "../server/**/*.ts",
+    "../bridges/**/*.ts"
+  ],
   "exclude": ["../node_modules", "../dist"]
 }

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   mergeSessionLists,
+  applySessionDiff,
   compareSessionsByRecency,
 } from "../../../src/utils/session/mergeSessions.js";
 import type {
@@ -249,5 +250,88 @@ describe("mergeSessionLists — does not mutate inputs", () => {
     const snapshot = server.slice();
     mergeSessionLists([], server);
     assert.deepEqual(server, snapshot);
+  });
+});
+
+// applySessionDiff powers the cursor-aware incremental fetch in
+// useSessionHistory (issue #205). Each diff row replaces the cached
+// row with the same id, new ids prepend, and deletedIds remove.
+describe("applySessionDiff — upsert", () => {
+  it("replaces the cached row when a diff row shares its id", () => {
+    const cache = [
+      makeSummary({ id: "a", preview: "old" }),
+      makeSummary({ id: "b" }),
+    ];
+    const diff = [makeSummary({ id: "a", preview: "new" })];
+    const out = applySessionDiff(cache, diff, []);
+    const a = out.find((s) => s.id === "a");
+    assert.equal(a?.preview, "new");
+    const b = out.find((s) => s.id === "b");
+    assert.ok(b, "untouched cache rows survive");
+  });
+
+  it("adds rows whose ids are new to the cache", () => {
+    const cache = [makeSummary({ id: "a" })];
+    const diff = [makeSummary({ id: "b" })];
+    const out = applySessionDiff(cache, diff, []);
+    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "b"]);
+  });
+
+  it("is a no-op when diff and deletedIds are both empty", () => {
+    const cache = [makeSummary({ id: "a" }), makeSummary({ id: "b" })];
+    const out = applySessionDiff(cache, [], []);
+    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "b"]);
+  });
+});
+
+describe("applySessionDiff — deletedIds", () => {
+  it("removes cached rows whose id is in deletedIds", () => {
+    const cache = [
+      makeSummary({ id: "a" }),
+      makeSummary({ id: "b" }),
+      makeSummary({ id: "c" }),
+    ];
+    const out = applySessionDiff(cache, [], ["b"]);
+    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "c"]);
+  });
+
+  it("removes before applying the diff (id in both → removed)", () => {
+    // Shape-wise impossible in the real product (server wouldn't
+    // both update and delete the same id), but the rule keeps the
+    // helper's behaviour unambiguous.
+    const cache = [makeSummary({ id: "a" })];
+    const diff = [makeSummary({ id: "a", preview: "updated" })];
+    const out = applySessionDiff(cache, diff, ["a"]);
+    // The diff re-adds `a` because deletedIds only scopes the
+    // *cache* pass; that matches the server's contract ("these
+    // rows changed, these rows are gone") where every diff row
+    // is authoritative.
+    const a = out.find((s) => s.id === "a");
+    assert.equal(a?.preview, "updated");
+    assert.equal(out.length, 1);
+  });
+});
+
+describe("applySessionDiff — sort + immutability", () => {
+  it("returns the merged list sorted by updatedAt desc", () => {
+    const cache = [
+      makeSummary({ id: "old", updatedAt: "2026-04-10T00:00:00.000Z" }),
+    ];
+    const diff = [
+      makeSummary({ id: "new", updatedAt: "2026-04-17T00:00:00.000Z" }),
+    ];
+    const out = applySessionDiff(cache, diff, []);
+    assert.equal(out[0].id, "new");
+    assert.equal(out[1].id, "old");
+  });
+
+  it("does not mutate cache or diff inputs", () => {
+    const cache = [makeSummary({ id: "a" })];
+    const diff = [makeSummary({ id: "b" })];
+    const cacheSnap = cache.slice();
+    const diffSnap = diff.slice();
+    applySessionDiff(cache, diff, ["a"]);
+    assert.deepEqual(cache, cacheSnap);
+    assert.deepEqual(diff, diffSnap);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `?since=<cursor>` to `GET /api/sessions`. 1st call returns full list + opaque cursor; subsequent calls echo the cursor and receive only changed sessions — eliminates re-downloading the entire 90-day window on every sidebar refresh.
- Response shape changes from bare `SessionSummary[]` to `{ sessions, cursor, deletedIds }`. `deletedIds` is always `[]` today (no deletion code path); the shape is plumbed end-to-end so populating it later is a server-only change.
- Client (`useSessionHistory`) caches cursor in-memory, sends `?since=` on re-fetch, merges diff via new `applySessionDiff` helper.

## Items to Confirm / Review

1. **Cursor format**: `"v1:<maxChangeMs>"`. Intentionally opaque. Malformed cursors fall back to 0 (full resend, no 400). Is this forgiving enough or should we log server-side when we silently reset?
2. **changeMs = max(mtimeMs, indexedAtMs)**: A session appears in the diff when either its `.jsonl` mtime or its chat-index `indexedAt` exceeds the cursor. `indexedAt` already exists on `ChatIndexEntry`. No schema migration needed.
3. **Response shape break**: Server and client ship together (same deploy), so there's no split-deploy window. All e2e fixtures updated atomically. Existing tests that had their own `/api/sessions` mock (e.g. `history-panel.spec.ts:76`) also updated.
4. **Cross-tab cursor sharing**: Out of scope per the issue. Each tab starts with cursor=null (full fetch). Future optimisation via `localStorage` or `BroadcastChannel` is possible.
5. **`applySessionDiff`** is alongside `mergeSessionLists` — same sort comparator, same pure/immutable contract. Both are interchangeable at call sites that don't care which shape they got.

## User Prompt

> \`https://github.com/receptron/mulmoclaude/issues/205\` これを進める。削除については今は削除がないので、一先ずAですすめよう

## Verification

- `yarn typecheck` — clean
- `yarn lint` — 5 pre-existing warnings, 0 errors
- `yarn build` — clean
- `yarn test` — **2113 / 2113** pass (+33 new)
- `yarn test:e2e` — **161 / 161** pass

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)