### PR TITLE
feat(skills): render SKILL.md body as formatted markdown (#335)

### DIFF
--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -151,11 +151,29 @@ test.describe("manageSkills plugin", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     // The first skill is auto-selected; its body should be visible.
-    await expect(page.locator("pre")).toContainText("## CI Enable");
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "CI Enable",
+    );
 
     // Click the second skill → body swaps.
     await page.getByTestId("skill-item-publish").click();
-    await expect(page.locator("pre")).toContainText("## Publish");
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "Publish",
+    );
+  });
+
+  test("skill body is rendered as formatted HTML, not raw markdown", async ({
+    page,
+  }) => {
+    await page.goto("/chat/skills-session?result=skills-result-1");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const rendered = page.getByTestId("skill-body-rendered");
+    await expect(rendered).toBeVisible();
+    // The `## CI Enable` heading should render as an <h2>, and the
+    // ordered list items as <li>. Raw `##` or `1.` shouldn't appear.
+    await expect(rendered.locator("h2")).toContainText("CI Enable");
+    await expect(rendered.locator("li").first()).toContainText("Add workflow");
   });
 
   test("Run button sends the skill invocation as a slash command", async ({
@@ -180,7 +198,9 @@ test.describe("manageSkills plugin", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     // Wait for the detail endpoint to resolve before clicking Run.
-    await expect(page.locator("pre")).toContainText("## CI Enable");
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "CI Enable",
+    );
     await page.getByTestId("skill-run-btn").click();
 
     // Run button routes through App.vue's sendMessage via the
@@ -305,7 +325,9 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
     // First skill (user-only) is auto-selected on mount; Delete
     // button should not appear.
     await page.getByTestId("skill-item-user-only").click();
-    await expect(page.locator("pre")).toContainText("## user-only");
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "user-only",
+    );
     await expect(page.getByTestId("skill-delete-btn")).toHaveCount(0);
   });
 
@@ -315,7 +337,9 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
     await page.goto("/chat/skills-session?result=skills-result-1");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
     await page.getByTestId("skill-item-my-project-skill").click();
-    await expect(page.locator("pre")).toContainText("## my-project-skill");
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "my-project-skill",
+    );
     await expect(page.getByTestId("skill-delete-btn")).toBeVisible();
   });
 

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -88,11 +88,16 @@
           <div v-else-if="detailError" class="text-sm text-red-600">
             {{ detailError }}
           </div>
-          <pre
-            v-else-if="detail"
-            class="text-xs text-gray-700 whitespace-pre-wrap font-mono bg-gray-50 p-4 rounded border border-gray-200"
-            >{{ detail.body || "(empty body)" }}</pre
-          >
+          <!-- eslint-disable-next-line vue/no-v-html -- sanitized via DOMPurify -->
+          <div
+            v-else-if="detail && renderedBody"
+            class="markdown-content text-gray-700"
+            data-testid="skill-body-rendered"
+            v-html="renderedBody"
+          ></div>
+          <p v-else-if="detail" class="text-sm text-gray-400 italic">
+            (empty body)
+          </p>
         </div>
       </div>
     </div>
@@ -101,6 +106,8 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
@@ -132,6 +139,12 @@ const deleting = ref(false);
 const selected = computed(
   () => skills.value.find((s) => s.name === selectedName.value) ?? null,
 );
+
+const renderedBody = computed(() => {
+  const body = detail.value?.body;
+  if (!body) return "";
+  return DOMPurify.sanitize(marked(body) as string);
+});
 
 // Reset the selection when the tool result is replaced (e.g. the
 // user opens a newer `manageSkills` invocation from the sidebar).


### PR DESCRIPTION
## Summary
Skill detail pane now renders markdown as formatted HTML instead of raw text in a \`<pre>\` block. Headings, lists, code blocks, etc. display correctly using the existing \`.markdown-content\` CSS classes.

## Items to Confirm / Review
- Uses \`marked\` + \`DOMPurify.sanitize()\` — same pattern as \`manageSource/View.vue:784\`.
- \`v-html\` is unavoidable for rendered markdown; the \`eslint-disable-next-line vue/no-v-html\` comment documents the DOMPurify sanitization.
- Empty body shows "(empty body)" in italic instead of a blank rendered div.
- All existing E2E assertions updated from \`page.locator(\"pre\")\` to \`page.getByTestId(\"skill-body-rendered\")\` — content checks use \`toContainText\` which strips HTML tags naturally.

## User Prompt
> skillのviewerのmd部分は、整形したい

## Verification
- \`yarn typecheck\` / \`yarn lint\` clean
- \`yarn build\` succeeds
- \`yarn test:e2e -- tests/skills.spec.ts\` — 8/8 pass (+1 new: \"skill body is rendered as formatted HTML, not raw markdown\")

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)