### PR TITLE
feat(skills): direct editing of project-scope skills in the UI (#336)

### DIFF
--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -134,21 +134,24 @@ test.describe("manageSkills plugin", () => {
   });
 
   test("View renders the full skill list when selected", async ({ page }) => {
-    // Select the tool result via URL so we don't depend on the
-    // sidebar preview being clickable at a specific node.
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    // Both skills appear in the list pane (data-testid per item).
+    // Click the tool-result preview in the sidebar to open the View.
+    await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
+
+    // Both skills appear in the list pane (data-testid per item).
     await expect(page.getByTestId("skill-item-publish")).toBeVisible();
   });
 
   test("selecting a skill loads its detail body from the API", async ({
     page,
   }) => {
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
 
     // The first skill is auto-selected; its body should be visible.
     await expect(page.getByTestId("skill-body-rendered")).toContainText(
@@ -165,8 +168,10 @@ test.describe("manageSkills plugin", () => {
   test("skill body is rendered as formatted HTML, not raw markdown", async ({
     page,
   }) => {
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
 
     const rendered = page.getByTestId("skill-body-rendered");
     await expect(rendered).toBeVisible();
@@ -194,8 +199,10 @@ test.describe("manageSkills plugin", () => {
       return route.fallback();
     });
 
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
 
     // Wait for the detail endpoint to resolve before clicking Run.
     await expect(page.getByTestId("skill-body-rendered")).toContainText(
@@ -320,8 +327,11 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
   });
 
   test("Delete button is hidden for user-scope skills", async ({ page }) => {
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
+
     // First skill (user-only) is auto-selected on mount; Delete
     // button should not appear.
     await page.getByTestId("skill-item-user-only").click();
@@ -334,8 +344,11 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
   test("Delete button is visible for project-scope skills", async ({
     page,
   }) => {
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
+
     await page.getByTestId("skill-item-my-project-skill").click();
     await expect(page.getByTestId("skill-body-rendered")).toContainText(
       "my-project-skill",
@@ -367,7 +380,11 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
       },
     );
 
-    await page.goto("/chat/skills-session?result=skills-result-1");
+    await page.goto("/chat/skills-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
+
     await page.getByTestId("skill-item-my-project-skill").click();
     await expect(page.getByTestId("skill-delete-btn")).toBeVisible();
 
@@ -381,5 +398,49 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
       0,
     );
     await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
+  });
+
+  test("Edit button opens edit mode, saves changes, and returns to view mode", async ({
+    page,
+  }) => {
+    // Mock PUT /api/skills/my-project-skill to return success.
+    await page.route(
+      (url) => url.pathname === "/api/skills/my-project-skill",
+      (route: Route) => {
+        if (route.request().method() === "PUT") {
+          return route.fulfill({
+            json: { updated: true, path: "/fake/path" },
+          });
+        }
+        return route.fallback();
+      },
+    );
+
+    await page.goto("/chat/skills-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+    await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
+
+    // Select the project-scope skill — Edit button should be visible.
+    await page.getByTestId("skill-item-my-project-skill").click();
+    await expect(page.getByTestId("skill-body-rendered")).toContainText(
+      "my-project-skill",
+    );
+    await expect(page.getByTestId("skill-edit-btn")).toBeVisible();
+
+    // Click Edit → description input + body textarea should appear.
+    await page.getByTestId("skill-edit-btn").click();
+    await expect(page.getByTestId("skill-edit-description")).toBeVisible();
+    await expect(page.getByTestId("skill-edit-body")).toBeVisible();
+
+    // Edit the description.
+    await page.getByTestId("skill-edit-description").fill("Updated desc");
+
+    // Click Save.
+    await page.getByTestId("skill-save-btn").click();
+
+    // After save: edit mode should close, rendered body should show.
+    await expect(page.getByTestId("skill-body-rendered")).toBeVisible();
+    await expect(page.getByTestId("skill-edit-description")).toHaveCount(0);
   });
 });

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -3,18 +3,21 @@
 //   GET    /api/skills        → { skills: SkillSummary[] }                phase 0
 //   GET    /api/skills/:name  → { skill: Skill } | 404                    phase 0
 //   POST   /api/skills        → { saved: true, path } | 400/409          phase 1
+//   PUT    /api/skills/:name  → { updated: true, path } | 400/403/404    phase 2
 //   DELETE /api/skills/:name  → { deleted: true } | 400/403/404          phase 1
 //
 // Discovery reads both ~/.claude/skills/ (user) and
 // <workspace>/.claude/skills/ (project); project wins on name
 // collision. Writes are confined to the project scope —
-// `saveProjectSkill` / `deleteProjectSkill` enforce that.
+// `saveProjectSkill` / `updateProjectSkill` / `deleteProjectSkill`
+// enforce that.
 
 import { Router, Request, Response } from "express";
 import {
   deleteProjectSkill,
   discoverSkills,
   saveProjectSkill,
+  updateProjectSkill,
 } from "../../workspace/skills/index.js";
 import type { Skill, SkillSummary } from "../../workspace/skills/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
@@ -133,6 +136,64 @@ router.post(
         res,
         `skill already exists: ${result.name}. Choose a different name or delete the existing one first.`,
       );
+    }
+  },
+);
+
+interface UpdateSkillBody {
+  description?: unknown;
+  body?: unknown;
+}
+
+interface UpdateSkillResponse {
+  updated: true;
+  path: string;
+}
+
+router.put(
+  API_ROUTES.skills.update,
+  async (
+    req: Request<{ name: string }, unknown, UpdateSkillBody>,
+    res: Response<UpdateSkillResponse | ErrorResponse>,
+  ) => {
+    const { name } = req.params;
+    const { description, body } = req.body ?? {};
+    if (typeof description !== "string") {
+      badRequest(res, "description must be a string");
+      return;
+    }
+    if (typeof body !== "string") {
+      badRequest(res, "body must be a string");
+      return;
+    }
+    const result = await updateProjectSkill({
+      workspaceRoot: workspacePath,
+      name,
+      description,
+      body,
+    });
+    if (result.kind === "updated") {
+      log.info("skills", "updated", { name });
+      res.json({ updated: true, path: result.path });
+      return;
+    }
+    if (result.kind === "invalid-slug") {
+      badRequest(res, `invalid slug: "${result.slug}"`);
+      return;
+    }
+    if (result.kind === "missing-field") {
+      badRequest(res, `${result.field} must be a non-empty string`);
+      return;
+    }
+    if (result.kind === "user-scope") {
+      forbidden(
+        res,
+        `cannot update user-scope skill "${result.name}" — only project-scope skills are writable.`,
+      );
+      return;
+    }
+    if (result.kind === "not-found") {
+      notFound(res, `skill not found: ${result.name}`);
     }
   },
 );

--- a/server/workspace/skills/index.ts
+++ b/server/workspace/skills/index.ts
@@ -3,8 +3,12 @@
 
 export { discoverSkills, collectSkillsFromDir } from "./discovery.js";
 export { parseSkillFrontmatter } from "./parser.js";
-export { saveProjectSkill, deleteProjectSkill } from "./writer.js";
-export type { SaveResult, DeleteResult } from "./writer.js";
+export {
+  saveProjectSkill,
+  updateProjectSkill,
+  deleteProjectSkill,
+} from "./writer.js";
+export type { SaveResult, UpdateResult, DeleteResult } from "./writer.js";
 export {
   isValidSlug,
   projectSkillsDir,

--- a/server/workspace/skills/writer.ts
+++ b/server/workspace/skills/writer.ts
@@ -76,6 +76,48 @@ export async function saveProjectSkill(
   return { kind: "saved", path: finalPath };
 }
 
+export type UpdateResult =
+  | { kind: "updated"; path: string }
+  | { kind: "invalid-slug"; slug: string }
+  | { kind: "missing-field"; field: "description" | "body" }
+  | { kind: "not-found"; name: string }
+  | { kind: "user-scope"; name: string };
+
+/**
+ * Overwrite an existing project-scope SKILL.md. Refuses to touch
+ * user-scope skills and rejects names that don't exist.
+ */
+export async function updateProjectSkill(
+  input: SaveSkillInput,
+): Promise<UpdateResult> {
+  const { workspaceRoot, name, description, body } = input;
+
+  if (!isValidSlug(name)) return { kind: "invalid-slug", slug: name };
+  if (typeof description !== "string" || description.trim().length === 0) {
+    return { kind: "missing-field", field: "description" };
+  }
+  if (typeof body !== "string") {
+    return { kind: "missing-field", field: "body" };
+  }
+
+  const existing = await discoverSkills({ workspaceRoot });
+  const skill = existing.find((s) => s.name === name);
+  if (!skill) return { kind: "not-found", name };
+  if (skill.source === "user") return { kind: "user-scope", name };
+
+  const finalPath = projectSkillPath(workspaceRoot, name);
+  const contents = formatSkillFile(description, body);
+
+  try {
+    await writeFileAtomic(finalPath, contents, { uniqueTmp: true });
+  } catch (err) {
+    log.error("skills", "update failed", { name, error: String(err) });
+    throw err;
+  }
+
+  return { kind: "updated", path: finalPath };
+}
+
 export interface DeleteSkillInput {
   workspaceRoot: string;
   name: string;

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -142,6 +142,7 @@ export const API_ROUTES = {
     list: "/api/skills",
     detail: "/api/skills/:name",
     create: "/api/skills",
+    update: "/api/skills/:name",
     remove: "/api/skills/:name",
   },
 

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -60,26 +60,56 @@
               </p>
             </div>
             <div class="flex items-center gap-2 shrink-0">
-              <button
-                v-if="detail && detail.source === 'project'"
-                class="px-3 py-1.5 text-sm rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-40 flex items-center gap-1"
-                :disabled="detailLoading || deleting"
-                data-testid="skill-delete-btn"
-                @click="deleteSkill"
-                title="Delete this project-scope skill"
-              >
-                <span class="material-icons text-base">delete</span>
-                Delete
-              </button>
-              <button
-                class="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40 flex items-center gap-1"
-                :disabled="detailLoading || !detail"
-                data-testid="skill-run-btn"
-                @click="runSkill"
-              >
-                <span class="material-icons text-base">play_arrow</span>
-                Run
-              </button>
+              <template v-if="editing">
+                <button
+                  class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 flex items-center gap-1"
+                  data-testid="skill-cancel-btn"
+                  @click="cancelEdit"
+                >
+                  Cancel
+                </button>
+                <button
+                  class="px-3 py-1.5 text-sm rounded bg-green-600 hover:bg-green-700 text-white disabled:opacity-40 flex items-center gap-1"
+                  :disabled="saving"
+                  data-testid="skill-save-btn"
+                  @click="saveEdit"
+                >
+                  <span class="material-icons text-base">save</span>
+                  Save
+                </button>
+              </template>
+              <template v-else>
+                <button
+                  v-if="detail && detail.source === 'project'"
+                  class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40 flex items-center gap-1"
+                  :disabled="detailLoading"
+                  data-testid="skill-edit-btn"
+                  @click="startEdit"
+                >
+                  <span class="material-icons text-base">edit</span>
+                  Edit
+                </button>
+                <button
+                  v-if="detail && detail.source === 'project'"
+                  class="px-3 py-1.5 text-sm rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-40 flex items-center gap-1"
+                  :disabled="detailLoading || deleting"
+                  data-testid="skill-delete-btn"
+                  @click="deleteSkill"
+                  title="Delete this project-scope skill"
+                >
+                  <span class="material-icons text-base">delete</span>
+                  Delete
+                </button>
+                <button
+                  class="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40 flex items-center gap-1"
+                  :disabled="detailLoading || !detail"
+                  data-testid="skill-run-btn"
+                  @click="runSkill"
+                >
+                  <span class="material-icons text-base">play_arrow</span>
+                  Run
+                </button>
+              </template>
             </div>
           </div>
           <div v-if="detailLoading" class="text-sm text-gray-400 italic">
@@ -88,6 +118,30 @@
           <div v-else-if="detailError" class="text-sm text-red-600">
             {{ detailError }}
           </div>
+          <!-- Edit mode -->
+          <div v-else-if="editing && detail" class="space-y-4">
+            <div>
+              <label class="block text-xs font-medium text-gray-500 mb-1">
+                Description
+              </label>
+              <input
+                v-model="editDescription"
+                data-testid="skill-edit-description"
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800"
+              />
+            </div>
+            <div class="flex-1">
+              <label class="block text-xs font-medium text-gray-500 mb-1">
+                Body (Markdown)
+              </label>
+              <textarea
+                v-model="editBody"
+                data-testid="skill-edit-body"
+                class="w-full h-96 px-3 py-2 text-sm font-mono border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800 resize-y"
+              ></textarea>
+            </div>
+          </div>
+          <!-- View mode -->
           <!-- eslint-disable-next-line vue/no-v-html -- sanitized via DOMPurify -->
           <div
             v-else-if="detail && renderedBody"
@@ -111,7 +165,7 @@ import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
-import { apiGet, apiDelete } from "../../utils/api";
+import { apiGet, apiPut, apiDelete } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 
 interface SkillDetail {
@@ -135,6 +189,10 @@ const detail = ref<SkillDetail | null>(null);
 const detailLoading = ref(false);
 const detailError = ref<string | null>(null);
 const deleting = ref(false);
+const editing = ref(false);
+const saving = ref(false);
+const editDescription = ref("");
+const editBody = ref("");
 
 const selected = computed(
   () => skills.value.find((s) => s.name === selectedName.value) ?? null,
@@ -167,8 +225,10 @@ watch(
   async (name) => {
     if (!name) {
       detail.value = null;
+      editing.value = false;
       return;
     }
+    editing.value = false;
     detailLoading.value = true;
     detailError.value = null;
     const response = await apiGet<{ skill: SkillDetail }>(
@@ -188,6 +248,47 @@ watch(
   },
   { immediate: true },
 );
+
+function startEdit(): void {
+  if (!detail.value) return;
+  editDescription.value = detail.value.description;
+  editBody.value = detail.value.body;
+  editing.value = true;
+}
+
+function cancelEdit(): void {
+  editing.value = false;
+}
+
+async function saveEdit(): Promise<void> {
+  if (!detail.value) return;
+  const name = detail.value.name;
+  saving.value = true;
+  detailError.value = null;
+  const result = await apiPut<{ updated: boolean; path: string }>(
+    API_ROUTES.skills.update.replace(":name", encodeURIComponent(name)),
+    { description: editDescription.value, body: editBody.value },
+  );
+  saving.value = false;
+  if (!result.ok) {
+    detailError.value = `Save failed: ${result.error}`;
+    return;
+  }
+  detail.value = {
+    ...detail.value,
+    description: editDescription.value,
+    body: editBody.value,
+  };
+  // Update the sidebar summary too.
+  const idx = skills.value.findIndex((s) => s.name === name);
+  if (idx >= 0) {
+    skills.value[idx] = {
+      ...skills.value[idx],
+      description: editDescription.value,
+    };
+  }
+  editing.value = false;
+}
 
 // Run = send the skill invocation as a Claude Code slash command.
 // Claude CLI already knows about every ~/.claude/skills/<name>/SKILL.md


### PR DESCRIPTION
## Summary
- Project-scope skills can now be edited directly in the UI — \"Edit\" button toggles description input + markdown body textarea + Save/Cancel.
- New \`PUT /api/skills/:name\` server endpoint (\`updateProjectSkill\` in \`writer.ts\`) overwrites the existing SKILL.md; user-scope skills and non-existent names return appropriate error kinds.
- E2E tests migrated from broken \`?result=\` URL param to sidebar-click approach (pre-existing regression), +1 new edit round-trip test.

## Items to Confirm / Review
- **Edit is project-scope only** — same guard as Delete (\`detail.source === 'project'\`). User-scope skills show no Edit button.
- **PUT semantics**: name in URL param (not body), description + body in body. Returning \`{ kind: \"not-found\" }\` / \`{ kind: \"user-scope\" }\` / \`{ kind: \"invalid-slug\" }\` mirrors the Delete handler's shape.
- **No plan file** — scope is small + well-specified in #336's issue body; plan deferred to the issue tracker per CLAUDE.md \"When you can skip the plan\" (single-feature, obvious approach).
- **E2E sidebar-click migration**: all 8 existing tests now open the View by clicking the sidebar preview (\"2 skills\" text) instead of relying on \`?result=skills-result-1\` URL param. This works around a pre-existing regression from #338 where \`?result=\` stopped opening the tool result in canvas.

## User Prompt
> skillを直接編集できるようにしたい

## Verification
- \`yarn typecheck\` / \`yarn typecheck:server\` / \`yarn lint\` clean
- \`yarn build\` succeeds
- \`yarn test\` all unit tests pass
- \`yarn test:e2e -- tests/skills.spec.ts\` — 9/9 pass (+1 new edit flow)

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit skill descriptions and body content. An Edit button now appears in the Skills View for project-scoped skills, allowing users to modify and save changes.

* **Tests**
  * Added new E2E test coverage for the skill editing workflow, verifying the edit mode transitions, form inputs, and save functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->