### PR TITLE
feat(ui): highlight unread sessions in history panel

### DIFF
--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -104,7 +104,7 @@ function rowClasses(session: SessionSummary): string {
   if (isSessionRunning(session))
     return "border-yellow-400 bg-yellow-50 hover:bg-yellow-100";
   if (isSessionUnread(session))
-    return "border-gray-400 bg-white hover:bg-gray-50";
+    return "border-sky-300 bg-sky-50 hover:bg-sky-100";
   if (session.id === props.currentSessionId)
     return "border-blue-400 bg-blue-50 hover:bg-blue-100";
   return "border-gray-200 hover:bg-gray-50";


### PR DESCRIPTION
## Summary

Unread sessions in the session history dropdown now have a light sky-blue background, making them visually distinct from read sessions at a glance.

1-line change in \`SessionHistoryPanel.vue\`'s \`rowClasses()\`:
\`border-gray-400 bg-white\` → \`border-sky-300 bg-sky-50 hover:bg-sky-100\`

### Color scheme (all four states)

| State | Border | Background | Hover |
|---|---|---|---|
| Running | yellow-400 | yellow-50 | yellow-100 |
| **Unread** | **sky-300** | **sky-50** | **sky-100** |
| Current session | blue-400 | blue-50 | blue-100 |
| Normal | gray-200 | none | gray-50 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)