### PR TITLE
feat(skills): update skills via chat conversation (#337)

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -175,6 +175,7 @@ async function handleManageSkills(
 ): Promise<string> {
   const action = typeof args.action === "string" ? args.action : "list";
   if (action === "save") return handleManageSkillsSave(args);
+  if (action === "update") return handleManageSkillsUpdate(args);
   if (action === "delete") return handleManageSkillsDelete(args);
   return handleManageSkillsList();
 }
@@ -241,6 +242,35 @@ async function handleManageSkillsSave(
   }
   await pushSkillsListResult(`Saved skill "${name}".`);
   return `Saved skill ${name}. Run with /${name}.`;
+}
+
+async function handleManageSkillsUpdate(
+  args: Record<string, unknown>,
+): Promise<string> {
+  const name = String(args.name ?? "");
+  const url = `${BASE_URL}/api/skills/${encodeURIComponent(name)}?session=${encodeURIComponent(SESSION_ID)}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "PUT",
+      headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        description: args.description,
+        body: args.body,
+      }),
+    });
+  } catch (err) {
+    throw new Error(
+      `Network error calling PUT /api/skills/${name}: ${errorMessage(err)}`,
+    );
+  }
+  if (!res.ok) {
+    const errBody = (await res.json().catch(() => ({}))) as { error?: string };
+    const detail = errBody.error ?? "HTTP " + res.status;
+    return "Error: " + detail;
+  }
+  await pushSkillsListResult(`Updated skill "${name}".`);
+  return `Updated skill ${name}. The changes take effect in new sessions.`;
 }
 
 async function handleManageSkillsDelete(

--- a/src/plugins/manageSkills/definition.ts
+++ b/src/plugins/manageSkills/definition.ts
@@ -18,7 +18,8 @@ const toolDefinition: ToolDefinition = {
     `  5. Call ${TOOL_NAME} with \`{action: "save", name, description, body}\`. Saves go to <workspace>/.claude/skills/<slug>/SKILL.md.\n` +
     `  6. If the response says the name already exists, ask the user for a different one.\n` +
     `- **update**: when the user asks to modify an existing skill (e.g. "〇〇のスキルを更新して" / "change the description of X"), call \`{action: "update", name, description, body}\`. Only project-scope skills can be updated; user-scope skills are read-only. You must provide both description and body (read the current skill first via list or the Read tool if you only need to change part of it).\n` +
-    `- **delete**: when the user asks to remove a named skill, call \`{action: "delete", name}\`. Only project-scope skills can be deleted; user-scope skills are protected.`,
+    `- **delete**: when the user asks to remove a named skill, call \`{action: "delete", name}\`. Only project-scope skills can be deleted; user-scope skills are protected.\n\n` +
+    `**IMPORTANT**: NEVER edit SKILL.md files directly with the Edit or Write tools. Always use this ${TOOL_NAME} tool with the appropriate action. Direct file edits bypass validation and won't refresh the skills UI.`,
   parameters: {
     type: "object",
     properties: {

--- a/src/plugins/manageSkills/definition.ts
+++ b/src/plugins/manageSkills/definition.ts
@@ -6,7 +6,7 @@ const toolDefinition: ToolDefinition = {
   type: "function",
   name: TOOL_NAME,
   description:
-    "List, save, or delete Claude Code skills. Discovery merges ~/.claude/skills/ (user, read-only) and <workspace>/.claude/skills/ (project, writable). Save and delete only affect the project scope.",
+    "List, save, update, or delete Claude Code skills. Discovery merges ~/.claude/skills/ (user, read-only) and <workspace>/.claude/skills/ (project, writable). Save, update, and delete only affect the project scope.",
   prompt:
     `Use the ${TOOL_NAME} tool for the user's skill library:\n\n` +
     `- **list** (default, no args): show every available skill in the canvas.\n` +
@@ -17,13 +17,14 @@ const toolDefinition: ToolDefinition = {
     `  4. Write a one-line description for the YAML frontmatter.\n` +
     `  5. Call ${TOOL_NAME} with \`{action: "save", name, description, body}\`. Saves go to <workspace>/.claude/skills/<slug>/SKILL.md.\n` +
     `  6. If the response says the name already exists, ask the user for a different one.\n` +
+    `- **update**: when the user asks to modify an existing skill (e.g. "〇〇のスキルを更新して" / "change the description of X"), call \`{action: "update", name, description, body}\`. Only project-scope skills can be updated; user-scope skills are read-only. You must provide both description and body (read the current skill first via list or the Read tool if you only need to change part of it).\n` +
     `- **delete**: when the user asks to remove a named skill, call \`{action: "delete", name}\`. Only project-scope skills can be deleted; user-scope skills are protected.`,
   parameters: {
     type: "object",
     properties: {
       action: {
         type: "string",
-        enum: ["list", "save", "delete"],
+        enum: ["list", "save", "update", "delete"],
         description:
           "The operation to perform. Default: list (show all skills).",
       },


### PR DESCRIPTION
## Summary
Extends the \`manageSkills\` tool with an \`update\` action so Claude can modify existing project-scope skills through the chat conversation. Completes the 3-ticket skill improvement series (#335 → #336 → #337).

## Items to Confirm / Review
- **Auto-approve is the default** — Claude updates the SKILL.md immediately on the user's instruction. The confirm-before-apply mode (diff preview + approve/reject UI) is designed in the issue comments and deferred to a follow-up PR.
- **Return message says \"changes take effect in new sessions\"** — Claude CLI caches skills at session start; a running session won't see the update until the user starts a new one.
- **Must provide both description and body** — the prompt instructs Claude to read the current skill first (via list or the Read tool) when only part needs changing, then call update with the full content. Partial update is intentionally not supported to keep the API simple.
- **MCP handler uses the same PUT /api/skills/:name endpoint** from #336 — no new server code beyond the handler.

## User Prompt
> skillをチャットで更新できるようにしたい。

## Verification
- \`yarn typecheck\` / \`yarn typecheck:server\` / \`yarn lint\` clean
- \`yarn build\` succeeds
- \`yarn test\` all pass (no new unit tests — the MCP handler is a thin HTTP call; the PUT endpoint is already tested via #336's E2E + writer unit tests)

## Testing (manual)
1. \`yarn dev\` → open a chat session
2. Ask Claude: \"shiritori スキルの説明を『日本語しりとりゲーム』に変更して\"
3. Claude reads the current skill, calls \`{action: \"update\", name: \"shiritori\", description: \"日本語しりとりゲーム\", body: \"...\"}\`
4. Skills list refreshes in the canvas with the new description
5. New session → \`/shiritori\` → updated content

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)