### PR TITLE
fix(mcp): pass tool prompt field to Claude CLI via MCP description

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -62,10 +62,21 @@ interface ToolDef {
   endpoint?: string; // absent for tools handled specially (e.g. switchRole)
 }
 
+// Combine `description` (one-liner) and `prompt` (detailed usage
+// instructions) into the MCP tool description so Claude CLI sees
+// both. The MCP protocol only has `description` — there's no
+// `prompt` field — so the prompt content must ride along in the
+// description string. The gui-chat-protocol ToolDefinition carries
+// `prompt` separately because the Vue client uses it for different
+// purposes, but the CLI needs it in-band.
 function fromPackage(def: ToolDefinition, endpoint: string): ToolDef {
+  const parts = [def.description];
+  if (typeof def.prompt === "string" && def.prompt.length > 0) {
+    parts.push(def.prompt);
+  }
   return {
     name: def.name,
-    description: def.description,
+    description: parts.join("\n\n"),
     inputSchema: def.parameters ?? {},
     endpoint,
   };


### PR DESCRIPTION
## Summary
**Root cause fix**: gui-chat-protocol の \`ToolDefinition\` は \`description\` (1行) と \`prompt\` (詳細指示) を持つが、MCP \`tools/list\` レスポンスには \`description\` しか含めていなかった。Claude CLI は \`prompt\` の内容を一切見ておらず、skill update の使い方も「直接ファイル編集するな」の指示も届いていなかった。

\`fromPackage()\` で \`description\` + \`prompt\` を結合して MCP tool description に渡すよう修正。

## Items to Confirm / Review
- **全 tool に影響**: manageSkills だけでなく、todo / scheduler / spreadsheet / markdown / canvas / editImage / generateImage など prompt フィールドを持つ全 tool の指示が Claude CLI に届くようになる。これは **改善** — 今まで invisible だったプロンプトが全部有効になる
- **description が長くなる**: MCP protocol 的には description の長さ制限はない。Claude は長い description を普通に読む
- **Vue client 側への影響なし**: client は \`prompt\` を別途読む (gui-chat-protocol の仕組み)。MCP 側で結合しても client のロジックは変わらない

## User Prompt
> で、全然この更新機能がうまく動かないから直して。全面的に見直し。

## Verification
- \`yarn typecheck:server\` / \`yarn lint\` clean
- \`yarn test\` all pass
- \`yarn build\` succeeds

## Testing
1. \`yarn dev\` → new session
2. 「shiritori スキルを更新して。開始の言葉をメロンにして」
3. Claude should now use \`manageSkills\` with \`{action: \"update\", ...}\` instead of trying to Edit the file directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool descriptions now include comprehensive usage instructions in addition to basic descriptions, providing users with more detailed guidance when selecting and using tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->