### PR TITLE
fix: recognize post-#284 workspace paths in markdown + spreadsheet plugins

### DIFF
--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -27,6 +27,7 @@ import {
   isSpreadsheetPath,
 } from "../../utils/spreadsheet-store.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 
 const router = Router();
 
@@ -182,7 +183,7 @@ router.put(
     req: Request<{ filename: string }, unknown, UpdateMarkdownBody>,
     res: Response<UpdateMarkdownResponse | UpdateMarkdownError>,
   ) => {
-    const relativePath = `markdowns/${req.params.filename}`;
+    const relativePath = `${WORKSPACE_DIRS.markdowns}/${req.params.filename}`;
     const { markdown } = req.body;
     if (!markdown) {
       badRequest(res, "markdown is required");
@@ -240,7 +241,7 @@ router.put(
     req: Request<{ filename: string }, unknown, UpdateSpreadsheetBody>,
     res: Response<UpdateSpreadsheetResponse | UpdateSpreadsheetError>,
   ) => {
-    const relativePath = `spreadsheets/${req.params.filename}`;
+    const relativePath = `${WORKSPACE_DIRS.spreadsheets}/${req.params.filename}`;
     const { sheets } = req.body;
     if (!Array.isArray(sheets)) {
       badRequest(res, "sheets must be an array");

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -248,7 +248,7 @@ async function applyMarkdown() {
   // If file-based, save to server
   if (isFilePath(raw)) {
     saving.value = true;
-    const filename = raw.replace(/^markdowns\//, "");
+    const filename = raw.replace(/^(artifacts\/documents|markdowns)\//, "");
     const result = await apiPut<unknown>(
       API_ROUTES.plugins.updateMarkdown.replace(":filename", filename),
       {

--- a/src/plugins/markdown/definition.ts
+++ b/src/plugins/markdown/definition.ts
@@ -9,9 +9,14 @@ export interface MarkdownToolData {
 }
 
 /** True when the `markdown` field is a workspace-relative file path
- *  (stored under markdowns/*.md) rather than inline content. */
+ *  rather than inline content. Covers both the post-#284 canonical
+ *  path (`artifacts/documents/*.md`) and the legacy `markdowns/*.md`
+ *  prefix for sessions whose jsonl hasn't been migrated yet. */
 export function isFilePath(value: string): boolean {
-  return value.startsWith("markdowns/") && value.endsWith(".md");
+  if (!value.endsWith(".md")) return false;
+  return (
+    value.startsWith("artifacts/documents/") || value.startsWith("markdowns/")
+  );
 }
 
 const toolDefinition: ToolDefinition = {

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -214,7 +214,8 @@ const resolvedSheets = ref<SpreadsheetSheet[]>([]);
 function isFilePath(value: unknown): value is string {
   return (
     typeof value === "string" &&
-    value.startsWith("spreadsheets/") &&
+    (value.startsWith("artifacts/spreadsheets/") ||
+      value.startsWith("spreadsheets/")) &&
     value.endsWith(".json")
   );
 }
@@ -267,7 +268,10 @@ fetchSheets().then(() => {
 async function persistSheets(sheets: SpreadsheetSheet[]): Promise<void> {
   const raw = props.selectedResult.data?.sheets;
   if (isFilePath(raw)) {
-    const filename = raw.replace(/^spreadsheets\//, "");
+    const filename = raw.replace(
+      /^(artifacts\/spreadsheets|spreadsheets)\//,
+      "",
+    );
     const result = await apiPut<unknown>(
       API_ROUTES.plugins.updateSpreadsheet.replace(":filename", filename),
       {


### PR DESCRIPTION
## Summary

After the #284 workspace migration (\`markdowns/\` → \`artifacts/documents/\`, \`spreadsheets/\` → \`artifacts/spreadsheets/\`), four client-side code sites and one server-side route still hardcoded the old directory prefixes. This caused:

- **Markdown documents showing raw path strings** instead of rendered content (e.g. "artifacts/documents/bacacc5c53664ecf.md" displayed as text)
- **Spreadsheet files failing to load** from post-migration paths
- **Edit/save returning 400** for all markdown and spreadsheet updates

## Changes (4 files)

| File | Issue | Fix |
|---|---|---|
| \`src/plugins/markdown/definition.ts\` | \`isFilePath()\` only matched \`"markdowns/"\` | Added \`"artifacts/documents/"\` |
| \`src/plugins/markdown/View.vue\` | Filename extraction stripped \`"markdowns/"\` only | Regex now strips either prefix |
| \`src/plugins/spreadsheet/View.vue\` | \`isFilePath()\` + filename extraction same issue | Same fix for \`"artifacts/spreadsheets/"\` |
| \`server/api/routes/plugins.ts\` | Update endpoints hardcoded \`"markdowns/"\` and \`"spreadsheets/"\` prefixes | Changed to \`WORKSPACE_DIRS.markdowns\` / \`WORKSPACE_DIRS.spreadsheets\` |

Server-side stores (\`markdown-store.ts\`, \`spreadsheet-store.ts\`, \`image-store.ts\`) were already correct — they've used \`WORKSPACE_DIRS\` since #284.

## Verification

- typecheck (all 4) / lint (0 errors) / test — all green
- Manual: confirmed \`artifacts/documents/bacacc5c53664ecf.md\` now renders correctly in the markdown View after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)