### PR TITLE
feat(sandbox): add gh CLI + auto-inject GH_TOKEN (#164)

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -24,8 +24,8 @@ FROM node:22-slim
 # - `texlive-*` — ~150MB+ for marginal PDF quality gains over pandoc's
 #   default LaTeX-free path; add when a user actually needs math/
 #   journal-style typesetting.
-# - `gh` CLI + auth mount — tracked in #162 Phase 4, needs a code
-#   change in `server/agent/config.ts` to mount `~/.config/gh:ro`.
+# - `gh` CLI — now installed (Layer 1b). Auth via SANDBOX_MOUNT_CONFIGS=gh
+#   which mounts ~/.config/gh:ro into the container (#259).
 #
 # Runtime `pip install` is intentionally NOT wired up. Everything the
 # agent might need for data work is preinstalled at build time so
@@ -43,6 +43,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       zip \
       unzip \
       ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 1b: GitHub CLI (#164). Installed from the official apt repo
+# so we get a stable release. Auth is provided at runtime via
+# SANDBOX_MOUNT_CONFIGS=gh which bind-mounts ~/.config/gh:ro (#259).
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 2: data analysis + plotting

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -231,7 +231,7 @@ const SANDBOX_TOOLS_HINT = `## Sandbox Tools
 
 The bash tool runs inside a Docker sandbox. The following tools are guaranteed preinstalled — prefer them over reinventing or searching the filesystem:
 
-- **Core CLI**: \`git\`, \`curl\`, \`jq\`, \`make\`, \`sqlite3\`, \`zip\`, \`unzip\`, \`ripgrep\` (\`rg\`)
+- **Core CLI**: \`git\`, \`gh\` (GitHub CLI), \`curl\`, \`jq\`, \`make\`, \`sqlite3\`, \`zip\`, \`unzip\`, \`ripgrep\` (\`rg\`)
 - **Data / plotting**: \`python3\` with \`pandas\`, \`numpy\`, \`matplotlib\`, \`requests\` preinstalled; \`graphviz\` (\`dot\`); \`imagemagick\` (\`convert\`)
 - **Docs / media**: \`pandoc\`, \`ffmpeg\`, \`poppler-utils\` (\`pdftotext\`, \`pdftoppm\`)
 - **Misc**: \`tree\`, \`bc\`, \`less\`

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -16,6 +16,7 @@
 
 import path from "node:path";
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { log } from "../system/logger/index.js";
 
@@ -274,10 +275,17 @@ export function resolveSandboxAuth(
       ? ["-e", `SANDBOX_SSH_ALLOWED_HOSTS=${params.sshAllowedHosts}`]
       : [];
 
+  // Inject GH_TOKEN so `gh` CLI inside the container can authenticate.
+  // On macOS the host stores the token in the system keyring, which
+  // isn't accessible from inside Docker. Running `gh auth token` on the
+  // host extracts it; we pass it as an env var so no file mount needed.
+  const ghTokenArgs = resolveGhToken();
+
   const args = [
     ...configMountArgs(parsed.resolved),
     ...sshResult.args,
     ...sshAllowedHostsArgs,
+    ...ghTokenArgs.args,
   ];
   const allowedHostsSuffix =
     sshResult.args.length > 0 && params.sshAllowedHosts
@@ -288,6 +296,7 @@ export function resolveSandboxAuth(
     ...(sshResult.args.length > 0
       ? [`ssh-agent forward${allowedHostsSuffix}`]
       : []),
+    ...(ghTokenArgs.args.length > 0 ? ["gh CLI (GH_TOKEN)"] : []),
   ];
 
   if (appliedDescriptions.length > 0) {
@@ -297,6 +306,31 @@ export function resolveSandboxAuth(
   }
 
   return { args, appliedDescriptions };
+}
+
+// ── GitHub CLI token ──────────────────────────────────────────────
+
+// Extract the GH_TOKEN from the host's `gh auth token` command.
+// Falls back gracefully: if `gh` isn't installed on the host, or
+// the user isn't logged in, the container simply won't have GH_TOKEN
+// and `gh` commands inside will fail with a clear auth error.
+function resolveGhToken(): { args: string[] } {
+  // Prefer explicit env var (user override)
+  if (process.env.GH_TOKEN) {
+    return { args: ["-e", `GH_TOKEN=${process.env.GH_TOKEN}`] };
+  }
+  try {
+    const token = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+    if (token.length > 0) {
+      return { args: ["-e", `GH_TOKEN=${token}`] };
+    }
+  } catch {
+    // gh not installed or not authenticated — skip silently
+  }
+  return { args: [] };
 }
 
 // ── Utilities ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Docker sandbox に \`gh\` CLI を追加し、ホストの GitHub 認証を自動注入。

- Dockerfile: gh CLI を公式 apt repo からインストール
- \`resolveGhToken()\`: ホストの \`gh auth token\` からトークン取得 → \`GH_TOKEN\` env var でコンテナに渡す (macOS keyring 対応)
- System prompt: sandbox tools hint に \`gh\` 追加

\`git clone git@...\` (SSH agent, #347) + \`gh issue list\` (GH_TOKEN) で git/GitHub 操作が一通り sandbox 内で可能に。

## Verification
- Docker build 成功、\`gh --version\` 動作確認
- \`GH_TOKEN\` 経由で \`gh auth status\` / \`gh issue list\` 成功
- \`yarn typecheck:server\` / \`yarn lint\` / \`yarn test\` all pass

## Manual test
\`\`\`bash
docker build --load -f Dockerfile.sandbox -t mulmoclaude-sandbox .
SANDBOX_SSH_AGENT_FORWARD=1 yarn dev
# Chat: "receptron/mulmoclaude の open issue を 3 件表示して"
# → gh issue list --repo receptron/mulmoclaude --limit 3
\`\`\`

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub CLI is now preinstalled as a core tool in the sandbox environment, providing developers with direct, out-of-the-box access to GitHub repositories, workflows, and API services during sandbox operations
  * GitHub authentication is automatically configured and made available in sandboxes, streamlining authenticated interactions with GitHub resources and eliminating the need for manual credential configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->