### PR TITLE
fix(ui): lock popup overflows left edge of viewport

### DIFF
--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -22,7 +22,7 @@
     <div
       v-if="open"
       ref="popup"
-      class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-3 text-xs"
+      class="absolute left-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-3 text-xs"
     >
       <p
         class="mb-2"


### PR DESCRIPTION
1-line CSS fix: `right-0` → `left-0` on the lock status popup. The lock icon sits in the middle of the header toolbar — extending rightward has room, extending leftward overflowed past the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix lock status popup positioning so it no longer overflows past the left edge of the viewport.