### PR TITLE
fix(ui): launcher active highlight + group separator + badge tooltips

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,16 +27,18 @@
             @click="toggleHistory"
           >
             <span class="material-icons">history</span>
-            <!-- Active sessions badge -->
+            <!-- Active sessions badge (yellow, left) -->
             <span
               v-if="activeSessionCount > 0"
-              class="absolute -top-1.5 -left-1.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none"
+              class="absolute -top-1.5 -left-1.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+              :title="`${activeSessionCount} active session${activeSessionCount > 1 ? 's' : ''} (agent running)`"
               >{{ activeSessionCount }}</span
             >
-            <!-- Unread replies badge -->
+            <!-- Unread replies badge (red, right) -->
             <span
               v-if="unreadCount > 0"
-              class="absolute -top-1.5 -right-1.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none"
+              class="absolute -top-1.5 -right-1.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+              :title="`${unreadCount} unread repl${unreadCount > 1 ? 'ies' : 'y'}`"
               >{{ unreadCount }}</span
             >
           </button>
@@ -252,7 +254,11 @@
       <div
         class="flex items-center justify-between px-3 py-2 border-b border-gray-100 shrink-0 gap-2"
       >
-        <PluginLauncher @navigate="onPluginNavigate" />
+        <PluginLauncher
+          :active-tool-name="selectedResult?.toolName ?? null"
+          :active-view-mode="canvasViewMode"
+          @navigate="onPluginNavigate"
+        />
         <CanvasViewToggle
           :model-value="canvasViewMode"
           @update:model-value="setCanvasViewMode"

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -4,17 +4,27 @@
     class="flex border border-gray-300 rounded overflow-hidden text-xs"
     data-testid="plugin-launcher"
   >
-    <button
-      v-for="target in TARGETS"
-      :key="target.key"
-      class="px-2.5 py-1 flex items-center gap-1 bg-white text-gray-600 hover:bg-gray-50 border-r border-gray-200 last:border-r-0"
-      :title="target.title"
-      :data-testid="`plugin-launcher-${target.key}`"
-      @click="emit('navigate', target)"
-    >
-      <span class="material-icons text-sm">{{ target.icon }}</span>
-      <span v-if="!compact">{{ target.label }}</span>
-    </button>
+    <template v-for="(target, idx) in TARGETS" :key="target.key">
+      <!-- Visual separator between data plugins and management plugins -->
+      <div
+        v-if="idx === SEPARATOR_AFTER_INDEX"
+        class="w-px bg-gray-300 my-0.5"
+      />
+      <button
+        :class="[
+          'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+          isActive(target)
+            ? 'bg-blue-50 text-blue-600 font-medium'
+            : 'bg-white text-gray-600 hover:bg-gray-50',
+        ]"
+        :title="target.title"
+        :data-testid="`plugin-launcher-${target.key}`"
+        @click="emit('navigate', target)"
+      >
+        <span class="material-icons text-sm">{{ target.icon }}</span>
+        <span v-if="!compact">{{ target.label }}</span>
+      </button>
+    </template>
   </div>
 </template>
 
@@ -29,6 +39,15 @@ import { onBeforeUnmount, onMounted, ref } from "vue";
 // First slice of issue #253. The list of targets is declared here so
 // the launcher can be swapped for a customisable per-role palette
 // later without touching the App.vue wiring.
+
+const props = defineProps<{
+  /** toolName of the currently selected ToolResult (e.g. "manageTodoList").
+   *  Null when nothing is selected or the result is from a non-launcher
+   *  plugin — the active indicator simply stays off. */
+  activeToolName?: string | null;
+  /** Current canvas view mode. When "files", the Files button lights up. */
+  activeViewMode?: string | null;
+}>();
 
 export type PluginLauncherKind =
   | "invoke" // Call the matching plugin's client endpoint and push the ToolResult into the current session
@@ -47,6 +66,7 @@ export interface PluginLauncherTarget {
 }
 
 const TARGETS: PluginLauncherTarget[] = [
+  // ─── Data plugins ───
   {
     key: "todos",
     kind: "invoke",
@@ -62,18 +82,19 @@ const TARGETS: PluginLauncherTarget[] = [
     title: "Open schedule",
   },
   {
-    key: "skills",
-    kind: "invoke",
-    icon: "psychology",
-    label: "Skills",
-    title: "Open skills",
-  },
-  {
     key: "wiki",
     kind: "invoke",
     icon: "menu_book",
     label: "Wiki",
     title: "Open wiki",
+  },
+  // ─── Management / navigation ───
+  {
+    key: "skills",
+    kind: "invoke",
+    icon: "psychology",
+    label: "Skills",
+    title: "Open skills",
   },
   {
     key: "roles",
@@ -90,6 +111,29 @@ const TARGETS: PluginLauncherTarget[] = [
     title: "Open workspace files",
   },
 ];
+
+// Index AFTER which the visual separator is inserted (between wiki
+// and skills — data plugins on the left, management on the right).
+const SEPARATOR_AFTER_INDEX = 3;
+
+// Map launcher key → the toolName the corresponding plugin
+// uses in its ToolResult. Used to match the active (selected)
+// result against the launcher buttons.
+const KEY_TO_TOOL_NAME: Record<string, string> = {
+  todos: "manageTodoList",
+  scheduler: "manageScheduler",
+  skills: "manageSkills",
+  wiki: "manageWiki",
+  roles: "manageRoles",
+};
+
+function isActive(target: PluginLauncherTarget): boolean {
+  if (target.kind === "files") {
+    return props.activeViewMode === "files";
+  }
+  const toolName = KEY_TO_TOOL_NAME[target.key];
+  return !!toolName && toolName === props.activeToolName;
+}
 
 const emit = defineEmits<{
   navigate: [target: PluginLauncherTarget];


### PR DESCRIPTION
## Summary

Three quick UX polish items for the plugin launcher bar, all CSS + props — no behaviour change.

1. **Active state highlight** — the selected launcher button gets a blue highlight (`bg-blue-50 text-blue-600`) so "what am I looking at" is instantly visible. Derived from the selected `ToolResult.toolName` for invoke targets and `canvasViewMode === "files"` for the Files button.

2. **Visual group separator** — a 1px vertical line between data plugins (Todos / Schedule / Wiki) and management plugins (Skills / Roles / Files). The flat row of 6 now reads as 3+3. Also reordered Skills after Wiki to keep the data cluster contiguous.

3. **Notification badge tooltips** — the yellow badge (active sessions) and red badge (unread replies) on the history button now have dynamic `title` attributes (e.g. "2 active sessions (agent running)", "1 unread reply") + `cursor-help` so users know what the numbers mean.

## User Prompt

> role含めたメニュー、これで良いかな？改善案ある？
> 1,2,4をささっとPR化

## Test plan

- [x] Typecheck green
- [x] Unit tests pass
- [x] E2E: lock-status-popup + smoke + chat-flow pass (16 tests)
- [ ] Manual: click Todos → button highlights blue; click Files → Files highlights, Todos unhighlights
- [ ] Manual: hover the yellow/red badges → tooltip shows count + context
- [ ] Manual: visual separator visible between Wiki and Skills

No new lint errors (3 pre-existing on main from session-store are unchanged).