### PR TITLE
fix(lint): session-store unused import + invariant-returns

### DIFF
--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -311,8 +311,8 @@ router.get(
 router.post(
   API_ROUTES.sessions.markRead,
   async (req: Request<SessionIdParams>, res: Response<{ ok: boolean }>) => {
-    const ok = await markRead(req.params.id);
-    res.json({ ok });
+    await markRead(req.params.id);
+    res.json({ ok: true });
   },
 );
 

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -12,7 +12,6 @@ import {
   sessionChannel,
 } from "../../../src/config/pubsubChannels.js";
 import { log } from "../../system/logger/index.js";
-import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 
@@ -145,19 +144,18 @@ export function cancelRun(chatSessionId: string): boolean {
  *  Awaits the disk write so the caller can respond only after the
  *  flag is actually persisted — avoids the race where the client
  *  refetches before the write lands and sees the stale value. */
-export async function markRead(chatSessionId: string): Promise<boolean> {
+export async function markRead(chatSessionId: string): Promise<void> {
   const session = store.get(chatSessionId);
   if (!session) {
     // No in-memory session — still persist to disk so the flag is
     // cleared for the next server restart / session listing.
     await persistHasUnread(chatSessionId, false);
-    return true;
+    return;
   }
-  if (!session.hasUnread) return true;
+  if (!session.hasUnread) return;
   session.hasUnread = false;
   await persistHasUnread(chatSessionId, false);
   notifySessionsChanged();
-  return true;
 }
 
 // ── Event publishing ───────────────────────────────────────────
@@ -265,10 +263,7 @@ async function persistHasUnread(
   chatSessionId: string,
   hasUnread: boolean,
 ): Promise<void> {
-  const metaFilePath = path.join(
-    WORKSPACE_PATHS.chat,
-    `${chatSessionId}.json`,
-  );
+  const metaFilePath = path.join(WORKSPACE_PATHS.chat, `${chatSessionId}.json`);
   try {
     const raw = await readFile(metaFilePath, "utf-8");
     const meta = JSON.parse(raw);


### PR DESCRIPTION
## Summary

PR #361 (dependabot protobufjs bump) の CI 失敗原因となっていた lint エラー 4 件を修正。

- `server/events/session-store/index.ts`:
  - 未使用 import `workspacePath` を削除 (sonarjs/unused-import)
  - `markRead()` の戻り値を `Promise<boolean>` (常に true) → `Promise<void>` に変更 (sonarjs/no-invariant-returns)
  - Prettier のフォーマット修正 (path.join の改行)
- `server/api/routes/sessions.ts`:
  - `markRead` の呼び出しを `await markRead(); res.json({ ok: true })` に合わせた

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — clean
- [x] `yarn test` — 2133/2133 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)