### PR TITLE
test: session-store unit tests + mark-read route tests

### DIFF
--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -50,10 +50,12 @@ const EVICTION_CHECK_INTERVAL_MS = 5 * 60 * 1000; // check every 5 min
 
 const store = new Map<string, ServerSession>();
 let pubsub: IPubSub | null = null;
+let evictionTimer: ReturnType<typeof setInterval> | null = null;
 
 export function initSessionStore(ps: IPubSub): void {
   pubsub = ps;
-  setInterval(evictIdleSessions, EVICTION_CHECK_INTERVAL_MS);
+  if (evictionTimer) clearInterval(evictionTimer);
+  evictionTimer = setInterval(evictIdleSessions, EVICTION_CHECK_INTERVAL_MS);
 }
 
 // ── Session lifecycle ──────────────────────────────────────────
@@ -299,5 +301,18 @@ function evictIdleSessions(): void {
       });
       removeSession(id);
     }
+  }
+}
+
+/**
+ * Test-only: clear all in-memory state so a test suite can start
+ * fresh without reloading the module.
+ */
+export function __resetForTests(): void {
+  store.clear();
+  pubsub = null;
+  if (evictionTimer) {
+    clearInterval(evictionTimer);
+    evictionTimer = null;
   }
 }

--- a/test/events/test_session_store.ts
+++ b/test/events/test_session_store.ts
@@ -1,0 +1,201 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  __resetForTests,
+  getSession,
+  getOrCreateSession,
+  beginRun,
+  endRun,
+  cancelRun,
+  markRead,
+  getActiveSessionIds,
+  getSessionImageData,
+  initSessionStore,
+} from "../../server/events/session-store/index.ts";
+
+const NOW = "2026-04-17T00:00:00.000Z";
+
+function sessionOpts(
+  overrides: Partial<Parameters<typeof getOrCreateSession>[1]> = {},
+) {
+  return {
+    roleId: "general",
+    resultsFilePath: "/tmp/fake.jsonl",
+    startedAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+// Stub pubsub — just tracks published channels.
+function stubPubSub() {
+  const published: { channel: string; data: unknown }[] = [];
+  return {
+    published,
+    publish(channel: string, data: unknown) {
+      published.push({ channel, data });
+    },
+  };
+}
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+afterEach(() => {
+  __resetForTests();
+});
+
+describe("getSession / getOrCreateSession", () => {
+  it("returns undefined for a non-existent session", () => {
+    assert.equal(getSession("nope"), undefined);
+  });
+
+  it("creates a session on first call and returns it on subsequent calls", () => {
+    const a = getOrCreateSession("s1", sessionOpts());
+    assert.equal(a.chatSessionId, "s1");
+    assert.equal(a.roleId, "general");
+    assert.equal(a.isRunning, false);
+    assert.equal(a.hasUnread, false);
+
+    const b = getOrCreateSession("s1", sessionOpts({ roleId: "coder" }));
+    assert.strictEqual(a, b); // same object
+    assert.equal(b.roleId, "general"); // not overwritten
+  });
+
+  it("updates selectedImageData and updatedAt on re-access", () => {
+    getOrCreateSession("s1", sessionOpts());
+    const b = getOrCreateSession(
+      "s1",
+      sessionOpts({
+        selectedImageData: "base64...",
+        updatedAt: "2026-04-17T01:00:00Z",
+      }),
+    );
+    assert.equal(b.selectedImageData, "base64...");
+    assert.equal(b.updatedAt, "2026-04-17T01:00:00Z");
+  });
+
+  it("honours hasUnread option on creation", () => {
+    const s = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
+    assert.equal(s.hasUnread, true);
+  });
+});
+
+describe("beginRun / endRun / cancelRun", () => {
+  it("beginRun sets isRunning=true and returns true", () => {
+    getOrCreateSession("s1", sessionOpts());
+    const abort = () => {};
+    assert.equal(beginRun("s1", abort), true);
+    assert.equal(getSession("s1")!.isRunning, true);
+  });
+
+  it("beginRun rejects when session is already running (409 guard)", () => {
+    getOrCreateSession("s1", sessionOpts());
+    beginRun("s1", () => {});
+    assert.equal(
+      beginRun("s1", () => {}),
+      false,
+    );
+  });
+
+  it("beginRun returns false for unknown session", () => {
+    assert.equal(
+      beginRun("nope", () => {}),
+      false,
+    );
+  });
+
+  it("endRun sets isRunning=false and hasUnread=true", () => {
+    getOrCreateSession("s1", sessionOpts());
+    beginRun("s1", () => {});
+    // initSessionStore is needed for endRun to publish
+    initSessionStore(stubPubSub());
+    endRun("s1");
+    const s = getSession("s1")!;
+    assert.equal(s.isRunning, false);
+    assert.equal(s.hasUnread, true);
+  });
+
+  it("cancelRun invokes the abort callback and returns true", () => {
+    getOrCreateSession("s1", sessionOpts());
+    let aborted = false;
+    beginRun("s1", () => {
+      aborted = true;
+    });
+    assert.equal(cancelRun("s1"), true);
+    assert.equal(aborted, true);
+  });
+
+  it("cancelRun returns false when not running", () => {
+    getOrCreateSession("s1", sessionOpts());
+    assert.equal(cancelRun("s1"), false);
+  });
+
+  it("cancelRun returns false for unknown session", () => {
+    assert.equal(cancelRun("nope"), false);
+  });
+});
+
+describe("markRead", () => {
+  it("clears hasUnread on an in-memory session", async () => {
+    initSessionStore(stubPubSub());
+    const s = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
+    assert.equal(s.hasUnread, true);
+    await markRead("s1");
+    assert.equal(s.hasUnread, false);
+  });
+
+  it("is a no-op when hasUnread is already false (no redundant work)", async () => {
+    const ps = stubPubSub();
+    initSessionStore(ps);
+    getOrCreateSession("s1", sessionOpts({ hasUnread: false }));
+    await markRead("s1");
+    // No sessions-changed notification should fire for a no-op
+    const sessionChanges = ps.published.filter((p) => p.channel === "sessions");
+    assert.equal(sessionChanges.length, 0);
+  });
+
+  it("publishes a sessions-changed notification when clearing the flag", async () => {
+    const ps = stubPubSub();
+    initSessionStore(ps);
+    getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
+    await markRead("s1");
+    const sessionChanges = ps.published.filter((p) => p.channel === "sessions");
+    assert.ok(sessionChanges.length > 0);
+  });
+
+  it("does not throw for an unknown session (disk-only fallback)", async () => {
+    initSessionStore(stubPubSub());
+    // No session created — should not throw
+    await markRead("nonexistent");
+  });
+});
+
+describe("getActiveSessionIds", () => {
+  it("returns only running sessions", () => {
+    getOrCreateSession("s1", sessionOpts());
+    getOrCreateSession("s2", sessionOpts());
+    beginRun("s1", () => {});
+    const active = getActiveSessionIds();
+    assert.equal(active.size, 1);
+    assert.ok(active.has("s1"));
+    assert.ok(!active.has("s2"));
+  });
+
+  it("returns empty set when nothing is running", () => {
+    getOrCreateSession("s1", sessionOpts());
+    assert.equal(getActiveSessionIds().size, 0);
+  });
+});
+
+describe("getSessionImageData", () => {
+  it("returns the selectedImageData for an existing session", () => {
+    getOrCreateSession("s1", sessionOpts({ selectedImageData: "img" }));
+    assert.equal(getSessionImageData("s1"), "img");
+  });
+
+  it("returns undefined for unknown session", () => {
+    assert.equal(getSessionImageData("nope"), undefined);
+  });
+});

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -46,7 +46,7 @@ interface RouterInternals {
 function extractRouteHandler(
   mod: RouteModule,
   routePath: string,
-  method: "get",
+  method: string,
 ): Handler {
   const router = mod.default as unknown as RouterInternals;
   for (const frame of router.stack) {
@@ -91,6 +91,7 @@ let manifestDir: string;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
 let getHandler: Handler;
+let markReadHandler: Handler;
 
 async function writeSession(
   id: string,
@@ -167,6 +168,11 @@ before(async () => {
   fs.mkdirSync(manifestDir, { recursive: true });
   const routeMod = await import("../../server/api/routes/sessions.js");
   getHandler = extractRouteHandler(routeMod, "/api/sessions", "get");
+  markReadHandler = extractRouteHandler(
+    routeMod,
+    "/api/sessions/:id/mark-read",
+    "post",
+  );
 });
 
 after(async () => {
@@ -289,5 +295,61 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
       second.res,
     );
     assert.deepEqual(second.state.body!.sessions, []);
+  });
+});
+
+// ── POST /api/sessions/:id/mark-read ──────────────────────────
+
+function mockMarkReadRes() {
+  const state: { status: number; body: { ok: boolean } | undefined } = {
+    status: 200,
+    body: undefined,
+  };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(payload: { ok: boolean }) {
+      state.body = payload;
+      return res;
+    },
+  };
+  return { state, res: res as unknown as Response };
+}
+
+describe("POST /api/sessions/:id/mark-read", () => {
+  it("returns { ok: true } for a session that exists on disk", async () => {
+    await writeSession("s1", { mtimeMs: BASE_MS });
+    const { state, res } = mockMarkReadRes();
+    await markReadHandler({ params: { id: "s1" } } as unknown as Request, res);
+    assert.equal(state.status, 200);
+    assert.deepEqual(state.body, { ok: true });
+  });
+
+  it("succeeds even when no session file exists (graceful no-op)", async () => {
+    const { state, res } = mockMarkReadRes();
+    await markReadHandler(
+      { params: { id: "nonexistent" } } as unknown as Request,
+      res,
+    );
+    assert.equal(state.status, 200);
+    assert.deepEqual(state.body, { ok: true });
+  });
+
+  it("persists hasUnread=false to the meta .json file", async () => {
+    // Write a meta with hasUnread=true
+    const metaPath = path.join(chatDir, "s1.json");
+    await writeFile(
+      metaPath,
+      JSON.stringify({ roleId: "general", hasUnread: true }),
+    );
+    await writeFile(path.join(chatDir, "s1.jsonl"), "");
+
+    const { res } = mockMarkReadRes();
+    await markReadHandler({ params: { id: "s1" } } as unknown as Request, res);
+
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    assert.equal(meta.hasUnread, false);
   });
 });


### PR DESCRIPTION
## Summary

直近 PR の中で最もテストが薄かった **hasUnread / markRead / persistHasUnread** フローに 22 テストを追加。unread バッジのリグレッションを CI で検出できるようにする。

## 追加したテスト

### test/events/test_session_store.ts (19 tests, **新規**)
- `getSession` / `getOrCreateSession` — 作成、再取得、update、hasUnread option
- `beginRun` / `endRun` / `cancelRun` — 409 guard、abort callback、state 遷移、endRun で hasUnread=true
- `markRead` — flag クリア、already-false no-op、sessions-changed 通知、unknown session でも throw しない
- `getActiveSessionIds` / `getSessionImageData` — query helpers

### test/routes/test_sessionsRoute.ts (3 tests追加)
- `POST /api/sessions/:id/mark-read` — happy path / missing session / hasUnread=false の disk 永続化

## 修正

- `server/events/session-store/index.ts`:
  - `__resetForTests()` 追加 — store + pubsub + eviction interval をクリア
  - `evictionTimer` をトラックして `clearInterval` できるようにした (テストのハング防止)

## Test plan

- [x] `yarn test` — 2155/2155 pass
- [x] `yarn lint` / `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session eviction reliability by preventing multiple concurrent eviction loops when initialization is called repeatedly.

* **Tests**
  * Added comprehensive test coverage for session management operations including session creation, lifecycle management, and read/unread tracking.
  * Expanded tests for the mark-read endpoint to ensure proper session state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->