### PR TITLE
refactor(io): migrate medium-priority callers to workspace-io / writeFileAtomic (#366 Phase 4)

### DIFF
--- a/server/api/chat-service/chat-state.ts
+++ b/server/api/chat-service/chat-state.ts
@@ -6,7 +6,8 @@
 // package: the transports directory path and logger arrive via the
 // factory, never through a direct `../workspace-paths.js` import.
 
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile } from "fs/promises";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import path from "path";
 import type { Logger } from "./types.js";
 
@@ -93,7 +94,7 @@ export function createChatStateStore(opts: {
       throw new Error("Invalid transport or chat ID");
     }
     await mkdir(transportDir(transportId), { recursive: true });
-    await writeFile(
+    await writeFileAtomic(
       statePath(transportId, state.externalChatId),
       JSON.stringify(state, null, 2),
     );

--- a/server/api/routes/chart.ts
+++ b/server/api/routes/chart.ts
@@ -1,7 +1,9 @@
 import { Router, Request, Response } from "express";
-import { writeFile, mkdir } from "fs/promises";
-import path from "path";
-import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
+import { WORKSPACE_DIRS } from "../../workspace/paths.js";
+import {
+  writeWorkspaceText,
+  ensureWorkspaceDir,
+} from "../../utils/files/workspace-io.js";
 import { slugify } from "../../utils/slug.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
@@ -97,15 +99,12 @@ router.post(
       const baseLabel = title ?? document.title ?? "chart";
       const slug = slugify(baseLabel) || "chart";
       const fname = `${slug}-${Date.now()}.chart.json`;
-      const chartsDir = WORKSPACE_PATHS.charts;
-      await mkdir(chartsDir, { recursive: true });
-      await writeFile(
-        path.join(chartsDir, fname),
-        `${JSON.stringify(document, null, 2)}\n`,
-        "utf-8",
-      );
-
       const filePath = `${WORKSPACE_DIRS.charts}/${fname}`;
+      ensureWorkspaceDir(WORKSPACE_DIRS.charts);
+      await writeWorkspaceText(
+        filePath,
+        `${JSON.stringify(document, null, 2)}\n`,
+      );
       res.json({
         message: `Saved chart document to ${filePath}`,
         instructions:

--- a/server/api/routes/presentHtml.ts
+++ b/server/api/routes/presentHtml.ts
@@ -1,7 +1,9 @@
 import { Router, Request, Response } from "express";
-import { writeFile, mkdir } from "fs/promises";
-import path from "path";
-import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
+import { WORKSPACE_DIRS } from "../../workspace/paths.js";
+import {
+  writeWorkspaceText,
+  ensureWorkspaceDir,
+} from "../../utils/files/workspace-io.js";
 import { slugify } from "../../utils/slug.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
@@ -43,11 +45,9 @@ router.post(
     try {
       const slug = title ? slugify(title) : "page";
       const fname = `${slug}-${Date.now()}.html`;
-      const htmlDir = WORKSPACE_PATHS.htmls;
-      await mkdir(htmlDir, { recursive: true });
-      await writeFile(path.join(htmlDir, fname), html, "utf-8");
-
       const filePath = `${WORKSPACE_DIRS.htmls}/${fname}`;
+      ensureWorkspaceDir(WORKSPACE_DIRS.htmls);
+      await writeWorkspaceText(filePath, html);
       res.json({
         message: `Saved HTML to ${filePath}`,
         instructions:

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -12,6 +12,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import {
   type Summarize,
   type SessionExcerpt,
@@ -765,8 +766,7 @@ async function writeDailySummary(
   content: string,
 ): Promise<void> {
   const p = dailyPathFor(workspaceRoot, date);
-  await fsp.mkdir(path.dirname(p), { recursive: true });
-  await fsp.writeFile(p, content, "utf-8");
+  await writeFileAtomic(p, content);
 }
 
 // If the file doesn't exist, write `content` fresh; otherwise append
@@ -792,16 +792,12 @@ export async function appendOrCreate(
       "code" in err &&
       err.code === "ENOENT"
     ) {
-      await fsp.writeFile(filePath, content, "utf-8");
+      await writeFileAtomic(filePath, content);
       return "created";
     }
     throw err;
   }
-  await fsp.writeFile(
-    filePath,
-    `${existing.trimEnd()}\n\n${content}\n`,
-    "utf-8",
-  );
+  await writeFileAtomic(filePath, `${existing.trimEnd()}\n\n${content}\n`);
   return "updated";
 }
 
@@ -819,7 +815,7 @@ async function applyTopicUpdate(
   }
   if (update.action === "rewrite") {
     const existed = (await readTextOrNull(p)) !== null;
-    await fsp.writeFile(p, update.content, "utf-8");
+    await writeFileAtomic(p, update.content);
     return existed ? "updated" : "created";
   }
   // append

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -10,6 +10,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import {
   readState,
   writeState,
@@ -179,8 +180,7 @@ async function rebuildIndex(workspaceRoot: string): Promise<void> {
     builtAtIso: new Date().toISOString(),
   });
   const p = path.join(summariesRoot(workspaceRoot), INDEX_FILE);
-  await fsp.mkdir(path.dirname(p), { recursive: true });
-  await fsp.writeFile(p, md, "utf-8");
+  await writeFileAtomic(p, md);
 }
 
 async function walkTopics(workspaceRoot: string): Promise<IndexTopicEntry[]> {

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -6,6 +6,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import {
   type Summarize,
   type OptimizationTopicSnapshot,
@@ -87,13 +88,9 @@ async function executeMergePlans(
   mergedSlugs: string[],
 ): Promise<void> {
   for (const plan of plans) {
-    await fsp.mkdir(path.dirname(topicPathFor(workspaceRoot, plan.intoSlug)), {
-      recursive: true,
-    });
-    await fsp.writeFile(
+    await writeFileAtomic(
       topicPathFor(workspaceRoot, plan.intoSlug),
       plan.newContent,
-      "utf-8",
     );
     for (const src of plan.fromSlugs) {
       // Only record the merge as successful if the source file


### PR DESCRIPTION
## Summary

Phase 4 of #366. Migrates the remaining 6 medium-priority modules from raw `fsp.writeFile` to the consolidated helpers shipped in Phase 1 (#368).

Two patterns used, depending on whether the module takes a `workspaceRoot` param:

### Pattern A: `writeWorkspaceText` (path + I/O fully consolidated)
- **chart.ts** — chart artifact save
- **presentHtml.ts** — HTML artifact save

These now have zero `path.join` / `WORKSPACE_PATHS` / raw `fs` calls. The workspace root reference no longer leaks into these modules.

### Pattern B: `writeFileAtomic` (atomic safety, keeps testability)
- **journal/dailyPass.ts** — 4 write sites (daily summary, appendOrCreate ×2, topic rewrite)
- **journal/index.ts** — `_index.md` rebuild
- **journal/optimizationPass.ts** — merged topic write
- **chat-service/chat-state.ts** — transport state persistence

These use `workspaceRoot` parameter injection for testability, so raw `writeFileAtomic` is the right level — `writeWorkspaceText` would bypass the param and hardcode the workspace root.

### Result after Phase 1-4

| Metric | Before | After |
|---|---|---|
| Raw `writeFile`/`writeFileSync` to workspace | 15+ sites | 0 high/medium priority remaining |
| Duplicate `atomicWrite` implementations | 2 | 1 (shared) |
| Modules using `writeWorkspaceText` | 0 | 2 (chart, presentHtml) |

## Test plan

- [x] All tests pass, typecheck + lint + build green
- [ ] CI matrix

Ref: #366