### PR TITLE
feat(bridges): image support — relay + socket protocol + Telegram photo (#380)

### DIFF
--- a/bridges/_lib/client.ts
+++ b/bridges/_lib/client.ts
@@ -45,7 +45,11 @@ export interface BridgeClientOptions {
 
 export interface BridgeClient {
   /** Send a user turn to MulmoClaude, wait for the assistant reply. */
-  send(externalChatId: string, text: string): Promise<MessageAck>;
+  send(
+    externalChatId: string,
+    text: string,
+    imageDataUrl?: string,
+  ): Promise<MessageAck>;
   /** Subscribe to server → bridge async pushes (Phase B of #268). */
   onPush(handler: (event: PushEvent) => void): void;
   /** Called each time the socket (re-)establishes a connection. */
@@ -91,7 +95,8 @@ export function createBridgeClient(opts: BridgeClientOptions): BridgeClient {
   installDefaultLogging(socket);
 
   return {
-    send: (externalChatId, text) => sendMessage(socket, externalChatId, text),
+    send: (externalChatId, text, imageDataUrl) =>
+      sendMessage(socket, externalChatId, text, imageDataUrl),
     onPush: (handler) => {
       socket.on(CHAT_SOCKET_EVENTS.push, handler);
     },
@@ -112,13 +117,16 @@ function sendMessage(
   socket: Socket,
   externalChatId: string,
   text: string,
+  imageDataUrl?: string,
 ): Promise<MessageAck> {
+  const payload: Record<string, string> = { externalChatId, text };
+  if (imageDataUrl) payload.imageDataUrl = imageDataUrl;
   return new Promise((resolve) => {
     socket
       .timeout(REPLY_TIMEOUT_MS)
       .emit(
         CHAT_SOCKET_EVENTS.message,
-        { externalChatId, text },
+        payload,
         (err: Error | null, ack: MessageAck | undefined) => {
           if (err) {
             resolve({ ok: false, error: `timeout: ${err.message}` });

--- a/bridges/telegram/api.ts
+++ b/bridges/telegram/api.ts
@@ -16,11 +16,22 @@ export interface TelegramUpdate {
   message?: TelegramMessage;
 }
 
+export interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
 export interface TelegramMessage {
   message_id: number;
   chat: TelegramChat;
   from?: TelegramUser;
   text?: string;
+  /** Array of photo sizes, largest last. Present when user sends a photo. */
+  photo?: TelegramPhotoSize[];
+  caption?: string;
   date: number;
 }
 
@@ -55,6 +66,8 @@ export interface GetUpdatesOptions {
 export interface TelegramApi {
   getUpdates(opts?: GetUpdatesOptions): Promise<TelegramUpdate[]>;
   sendMessage(chatId: number, text: string): Promise<void>;
+  /** Download a photo by file_id, return as base64 data URL. */
+  downloadPhoto(fileId: string): Promise<string>;
 }
 
 const DEFAULT_BASE = "https://api.telegram.org";
@@ -112,6 +125,49 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
           `sendMessage API error: ${body.description ?? "unknown"}`,
         );
       }
+    },
+
+    async downloadPhoto(fileId) {
+      // Step 1: getFile to get the file_path
+      const getFileRes = await fetchImpl(
+        `${base}/getFile?file_id=${encodeURIComponent(fileId)}`,
+      );
+      if (!getFileRes.ok) {
+        throw new Error(
+          `getFile failed: ${getFileRes.status} ${await safeText(getFileRes)}`,
+        );
+      }
+      const getFileBody = (await getFileRes.json()) as {
+        ok: boolean;
+        description?: string;
+        result?: { file_path?: string };
+      };
+      if (!getFileBody.ok || !getFileBody.result?.file_path) {
+        throw new Error(
+          `getFile API error: ${getFileBody.description ?? "no file_path"}`,
+        );
+      }
+
+      // Step 2: download the file bytes
+      const fileUrl = `${baseUrl}/file/bot${opts.botToken}/${getFileBody.result.file_path}`;
+      const fileRes = await fetchImpl(fileUrl);
+      if (!fileRes.ok) {
+        throw new Error(`file download failed: ${fileRes.status}`);
+      }
+      const buffer = await fileRes.arrayBuffer();
+      const base64 = Buffer.from(buffer).toString("base64");
+
+      // Infer media type from file path extension
+      const ext = getFileBody.result.file_path.split(".").pop()?.toLowerCase();
+      const mediaType =
+        ext === "jpg" || ext === "jpeg"
+          ? "image/jpeg"
+          : ext === "png"
+            ? "image/png"
+            : ext === "webp"
+              ? "image/webp"
+              : "image/jpeg"; // Telegram defaults to JPEG for photos
+      return `data:${mediaType};base64,${base64}`;
     },
   };
 }

--- a/bridges/telegram/index.ts
+++ b/bridges/telegram/index.ts
@@ -99,7 +99,8 @@ async function main(): Promise<void> {
   const router = createMessageRouter({
     api,
     allowlist,
-    sendToMulmo: (chatId, text) => client.send(chatId, text),
+    sendToMulmo: (chatId, text, imageDataUrl) =>
+      client.send(chatId, text, imageDataUrl),
   });
 
   // Server → Telegram async push (Phase B of #268).

--- a/bridges/telegram/router.ts
+++ b/bridges/telegram/router.ts
@@ -16,6 +16,7 @@ const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
 export type SendToMulmoFn = (
   externalChatId: string,
   text: string,
+  imageDataUrl?: string,
 ) => Promise<MessageAck>;
 
 export interface RouterDeps {
@@ -56,14 +57,27 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
 
   async function handleAllowed(msg: TelegramMessage): Promise<void> {
     const chatId = msg.chat.id;
-    const text = msg.text ?? "";
-    if (text.trim().length === 0) return;
+    const text = msg.text ?? msg.caption ?? "";
+    const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
+    if (text.trim().length === 0 && !hasPhoto) return;
     const user = userLabel(msg);
     log.info(
-      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}`,
+      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}${hasPhoto ? " +photo" : ""}`,
     );
 
-    const ack = await sendToMulmo(String(chatId), text);
+    // Download the largest photo size if present
+    let imageDataUrl: string | undefined;
+    if (hasPhoto) {
+      const largest = msg.photo![msg.photo!.length - 1];
+      try {
+        imageDataUrl = await api.downloadPhoto(largest.file_id);
+      } catch (err) {
+        log.error(`[telegram] photo download failed: ${String(err)}`);
+      }
+    }
+
+    const messageText = text.trim().length > 0 ? text : "What is this image?";
+    const ack = await sendToMulmo(String(chatId), messageText, imageDataUrl);
     if (ack.ok) {
       await sendChunked(api, chatId, ack.reply ?? "");
     } else {

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -124,6 +124,11 @@ Payload:
 - `text: string` — non-empty. The user's message, UTF-8. Trim
   leading / trailing whitespace yourself if you care; the server
   trims before dispatching.
+- `imageDataUrl?: string` — optional. Base64 data URL
+  (`data:image/png;base64,…`) for vision input (#380). When
+  present, Claude receives the image as a content block alongside
+  the text. The Telegram bridge populates this by downloading the
+  photo via `getFile` + base64-encoding it.
 
 Ack shape:
 

--- a/server/api/chat-service/relay.ts
+++ b/server/api/chat-service/relay.ts
@@ -18,6 +18,10 @@ export interface RelayParams {
   transportId: string;
   externalChatId: string;
   text: string;
+  /** Base64 data URL (e.g. data:image/png;base64,...). Optional —
+   *  when present the image is passed to Claude CLI as a vision
+   *  content block alongside the text message. */
+  imageDataUrl?: string;
 }
 
 export type RelayResult =
@@ -56,7 +60,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
   return async function relayMessage(
     params: RelayParams,
   ): Promise<RelayResult> {
-    const { transportId, externalChatId, text } = params;
+    const { transportId, externalChatId, text, imageDataUrl } = params;
 
     logger.info("chat-service", "message received", {
       transportId,
@@ -83,6 +87,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
       message: text,
       roleId: chatState.roleId,
       chatSessionId: chatState.sessionId,
+      selectedImageData: imageDataUrl,
     });
 
     if (result.kind === "error") {

--- a/server/api/chat-service/socket.ts
+++ b/server/api/chat-service/socket.ts
@@ -85,6 +85,8 @@ interface HandshakeAuth {
 interface MessagePayload {
   externalChatId?: unknown;
   text?: unknown;
+  /** Base64 data URL for vision (optional, #380). */
+  imageDataUrl?: unknown;
 }
 
 type MessageAck =
@@ -92,7 +94,7 @@ type MessageAck =
   | { ok: false; error: string; status?: number };
 
 type ParsedMessage =
-  | { ok: true; externalChatId: string; text: string }
+  | { ok: true; externalChatId: string; text: string; imageDataUrl?: string }
   | { ok: false; error: string };
 
 type HandshakeResult =
@@ -184,6 +186,7 @@ export function attachChatSocket(
           transportId,
           externalChatId: parsed.externalChatId,
           text: parsed.text,
+          imageDataUrl: parsed.imageDataUrl,
         });
 
         if (result.kind === "ok") {
@@ -269,5 +272,9 @@ function parseMessagePayload(payload: MessagePayload): ParsedMessage {
   if (!text) {
     return { ok: false, error: "text is required" };
   }
-  return { ok: true, externalChatId, text };
+  const imageDataUrl =
+    typeof payload.imageDataUrl === "string" && payload.imageDataUrl.length > 0
+      ? payload.imageDataUrl
+      : undefined;
+  return { ok: true, externalChatId, text, imageDataUrl };
 }

--- a/test/bridges/telegram/test_router.ts
+++ b/test/bridges/telegram/test_router.ts
@@ -26,6 +26,9 @@ function stubApi(): TelegramApi & { sent: SentMessage[] } {
     async sendMessage(chatId, text) {
       sent.push({ chatId, text });
     },
+    async downloadPhoto() {
+      return "data:image/jpeg;base64,AAAA";
+    },
   };
 }
 
@@ -128,6 +131,61 @@ describe("router.handleMessage — allowed chat", () => {
     });
     await router.handleMessage(msg(42, "ping"));
     assert.deepEqual(api.sent, [{ chatId: 42, text: "(empty reply)" }]);
+  });
+  it("downloads photo and passes imageDataUrl when message has photo", async () => {
+    let receivedImage: string | undefined;
+    const sendWithImage: SendToMulmoFn = async (
+      _chatId,
+      _text,
+      imageDataUrl,
+    ) => {
+      receivedImage = imageDataUrl;
+      return { ok: true, reply: "nice pic" };
+    };
+    const photoApi = stubApi();
+    const router = createMessageRouter({
+      api: photoApi,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendWithImage,
+      log: silentLog,
+    });
+    const photoMsg: TelegramMessage = {
+      message_id: 1,
+      chat: { id: 42, type: "private" },
+      from: { id: 1, is_bot: false, first_name: "A", username: "alice" },
+      date: 0,
+      photo: [
+        { file_id: "small", file_unique_id: "s", width: 90, height: 90 },
+        { file_id: "large", file_unique_id: "l", width: 800, height: 600 },
+      ],
+      caption: "look at this",
+    };
+    await router.handleMessage(photoMsg);
+    assert.equal(receivedImage, "data:image/jpeg;base64,AAAA");
+    assert.deepEqual(photoApi.sent, [{ chatId: 42, text: "nice pic" }]);
+  });
+
+  it("uses default text when photo has no caption", async () => {
+    let receivedText = "";
+    const sendCapture: SendToMulmoFn = async (_chatId, text) => {
+      receivedText = text;
+      return { ok: true, reply: "ok" };
+    };
+    const captionApi = stubApi();
+    const router = createMessageRouter({
+      api: captionApi,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendCapture,
+      log: silentLog,
+    });
+    const photoMsg: TelegramMessage = {
+      message_id: 1,
+      chat: { id: 42, type: "private" },
+      date: 0,
+      photo: [{ file_id: "f", file_unique_id: "u", width: 100, height: 100 }],
+    };
+    await router.handleMessage(photoMsg);
+    assert.equal(receivedText, "What is this image?");
   });
 });
 

--- a/test/chat-service/test_socket.ts
+++ b/test/chat-service/test_socket.ts
@@ -128,11 +128,9 @@ describe("chat-service socket — no auth", () => {
 
     assert.deepEqual(ack, { ok: true, reply: "hello back" });
     assert.equal(harness.relayCalls.length, 1);
-    assert.deepEqual(harness.relayCalls[0], {
-      transportId: "cli",
-      externalChatId: "terminal",
-      text: "hi",
-    });
+    assert.equal(harness.relayCalls[0].transportId, "cli");
+    assert.equal(harness.relayCalls[0].externalChatId, "terminal");
+    assert.equal(harness.relayCalls[0].text, "hi");
 
     client.disconnect();
   });


### PR DESCRIPTION
## Summary

Bridge path で画像を送れるようにした。Telegram ユーザーが bot に写真を送ると Claude が vision で見られる。

- Socket protocol に optional `imageDataUrl` フィールド追加 (後方互換)
- relay が `selectedImageData` を `startChat` に passthrough
- Telegram bridge が `message.photo` を検出 → `getFile` → download → base64 → `imageDataUrl` として送信
- キャプション無し写真は `"What is this image?"` がデフォルトテキスト

## User Prompt

bridge で画像が送られてくることは想定されている？ → issue 立てて実装。

## Implementation

| 層 | 変更 |
|---|---|
| Socket protocol | `MessagePayload` に `imageDataUrl?: string` 追加、`parseMessagePayload` で passthrough |
| Relay | `RelayParams` に `imageDataUrl?` 追加、`startChat` に `selectedImageData` として渡す |
| Bridge client | `send()` に `imageDataUrl?` 引数追加、payload に含める |
| Telegram API | `TelegramPhotoSize` 型、`downloadPhoto(fileId)` — getFile → download → base64 data URL |
| Telegram router | `handleAllowed` で最大サイズ photo を download、`sendToMulmo` に渡す |
| bridge-protocol.md | `imageDataUrl` フィールド追記 |

## Test plan

- [x] `yarn test` — 2354/2354 pass
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean
- [ ] Manual: Telegram bot に写真を送る → Claude が画像の内容を答える

## Related

- #369 / PR #379 — Vue UI paste/drop (frontend + server content blocks)
- #268 — socket.io transport
- #321 — Telegram bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)