### PR TITLE
refactor(bridges): replace imageDataUrl with attachments: Attachment[] (#382)

### DIFF
--- a/bridges/_lib/client.ts
+++ b/bridges/_lib/client.ts
@@ -35,13 +35,10 @@ export interface PushEvent {
   message: string;
 }
 
-/** Generic attachment — images, PDFs, documents, etc. The server
- *  decides what to do with each based on mimeType. */
-export interface Attachment {
-  mimeType: string;
-  data: string; // base64
-  filename?: string;
-}
+// Attachment type is defined in server/api/chat-service/types.ts.
+// Consumers import it directly from there — no re-export here
+// (CLAUDE.md rule). See also bridges/_lib/mime.ts for MIME helpers.
+import type { Attachment } from "../../server/api/chat-service/types.js";
 
 export interface BridgeClientOptions {
   /** Required. Identifier for this bridge in the handshake.

--- a/bridges/_lib/client.ts
+++ b/bridges/_lib/client.ts
@@ -35,6 +35,14 @@ export interface PushEvent {
   message: string;
 }
 
+/** Generic attachment — images, PDFs, documents, etc. The server
+ *  decides what to do with each based on mimeType. */
+export interface Attachment {
+  mimeType: string;
+  data: string; // base64
+  filename?: string;
+}
+
 export interface BridgeClientOptions {
   /** Required. Identifier for this bridge in the handshake.
    *  Matches `handshake.auth.transportId` server-side. */
@@ -45,7 +53,11 @@ export interface BridgeClientOptions {
 
 export interface BridgeClient {
   /** Send a user turn to MulmoClaude, wait for the assistant reply. */
-  send(externalChatId: string, text: string): Promise<MessageAck>;
+  send(
+    externalChatId: string,
+    text: string,
+    attachments?: Attachment[],
+  ): Promise<MessageAck>;
   /** Subscribe to server → bridge async pushes (Phase B of #268). */
   onPush(handler: (event: PushEvent) => void): void;
   /** Called each time the socket (re-)establishes a connection. */
@@ -91,7 +103,8 @@ export function createBridgeClient(opts: BridgeClientOptions): BridgeClient {
   installDefaultLogging(socket);
 
   return {
-    send: (externalChatId, text) => sendMessage(socket, externalChatId, text),
+    send: (externalChatId, text, attachments) =>
+      sendMessage(socket, externalChatId, text, attachments),
     onPush: (handler) => {
       socket.on(CHAT_SOCKET_EVENTS.push, handler);
     },
@@ -112,13 +125,16 @@ function sendMessage(
   socket: Socket,
   externalChatId: string,
   text: string,
+  attachments?: Attachment[],
 ): Promise<MessageAck> {
+  const payload: Record<string, unknown> = { externalChatId, text };
+  if (attachments && attachments.length > 0) payload.attachments = attachments;
   return new Promise((resolve) => {
     socket
       .timeout(REPLY_TIMEOUT_MS)
       .emit(
         CHAT_SOCKET_EVENTS.message,
-        { externalChatId, text },
+        payload,
         (err: Error | null, ack: MessageAck | undefined) => {
           if (err) {
             resolve({ ok: false, error: `timeout: ${err.message}` });

--- a/bridges/_lib/mime.ts
+++ b/bridges/_lib/mime.ts
@@ -1,0 +1,62 @@
+// Shared MIME type helpers used by both bridges and the server.
+// Pure functions — no I/O, no deps.
+
+const EXT_TO_MIME: Record<string, string> = {
+  // Images
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  heic: "image/heic",
+  heif: "image/heif",
+  bmp: "image/bmp",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+  avif: "image/avif",
+  // Documents
+  pdf: "application/pdf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  // Video / audio
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mp3: "audio/mpeg",
+  ogg: "audio/ogg",
+};
+
+/** Infer MIME type from a file extension (case-insensitive).
+ *  Returns the fallback if the extension is not recognised. */
+export function mimeFromExtension(
+  ext: string,
+  fallback = "application/octet-stream",
+): string {
+  return EXT_TO_MIME[ext.toLowerCase()] ?? fallback;
+}
+
+/** True when the MIME type is an image Claude can see via vision. */
+export function isImageMime(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+export interface ParsedDataUrl {
+  mimeType: string;
+  data: string; // base64
+}
+
+/** Parse a `data:<mime>;base64,<data>` string. Returns null if the
+ *  format doesn't match. Also handles parameterised data URLs like
+ *  `data:image/png;charset=binary;base64,…`. */
+export function parseDataUrl(dataUrl: string): ParsedDataUrl | null {
+  const match = dataUrl.match(/^data:([^;,]+)(?:;[^,]*)?;base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1], data: match[2] };
+}
+
+/** Build a `data:<mime>;base64,<data>` string from components. */
+export function buildDataUrl(mimeType: string, base64Data: string): string {
+  return `data:${mimeType};base64,${base64Data}`;
+}

--- a/bridges/telegram/api.ts
+++ b/bridges/telegram/api.ts
@@ -1,3 +1,5 @@
+import { mimeFromExtension, buildDataUrl } from "../_lib/mime.js";
+
 // Raw `fetch` wrapper for the Telegram Bot API. Only the two methods
 // the bridge actually uses (`getUpdates`, `sendMessage`) are exposed.
 //
@@ -151,16 +153,9 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       }
       const buffer = await fileRes.arrayBuffer();
       const b64 = Buffer.from(buffer).toString("base64");
-      const ext = getFileBody.result.file_path.split(".").pop()?.toLowerCase();
-      const mediaType =
-        ext === "jpg" || ext === "jpeg"
-          ? "image/jpeg"
-          : ext === "png"
-            ? "image/png"
-            : ext === "webp"
-              ? "image/webp"
-              : "image/jpeg";
-      return `data:${mediaType};base64,${b64}`;
+      const ext = getFileBody.result.file_path.split(".").pop() ?? "";
+      const mediaType = mimeFromExtension(ext, "image/jpeg");
+      return buildDataUrl(mediaType, b64);
     },
   };
 }

--- a/bridges/telegram/api.ts
+++ b/bridges/telegram/api.ts
@@ -16,11 +16,21 @@ export interface TelegramUpdate {
   message?: TelegramMessage;
 }
 
+export interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
 export interface TelegramMessage {
   message_id: number;
   chat: TelegramChat;
   from?: TelegramUser;
   text?: string;
+  photo?: TelegramPhotoSize[];
+  caption?: string;
   date: number;
 }
 
@@ -55,6 +65,7 @@ export interface GetUpdatesOptions {
 export interface TelegramApi {
   getUpdates(opts?: GetUpdatesOptions): Promise<TelegramUpdate[]>;
   sendMessage(chatId: number, text: string): Promise<void>;
+  downloadPhoto(fileId: string): Promise<string>;
 }
 
 const DEFAULT_BASE = "https://api.telegram.org";
@@ -112,6 +123,44 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
           `sendMessage API error: ${body.description ?? "unknown"}`,
         );
       }
+    },
+
+    async downloadPhoto(fileId) {
+      const getFileRes = await fetchImpl(
+        `${base}/getFile?file_id=${encodeURIComponent(fileId)}`,
+      );
+      if (!getFileRes.ok) {
+        throw new Error(
+          `getFile failed: ${getFileRes.status} ${await safeText(getFileRes)}`,
+        );
+      }
+      const getFileBody = (await getFileRes.json()) as {
+        ok: boolean;
+        description?: string;
+        result?: { file_path?: string };
+      };
+      if (!getFileBody.ok || !getFileBody.result?.file_path) {
+        throw new Error(
+          `getFile API error: ${getFileBody.description ?? "no file_path"}`,
+        );
+      }
+      const fileUrl = `${baseUrl}/file/bot${opts.botToken}/${getFileBody.result.file_path}`;
+      const fileRes = await fetchImpl(fileUrl);
+      if (!fileRes.ok) {
+        throw new Error(`file download failed: ${fileRes.status}`);
+      }
+      const buffer = await fileRes.arrayBuffer();
+      const b64 = Buffer.from(buffer).toString("base64");
+      const ext = getFileBody.result.file_path.split(".").pop()?.toLowerCase();
+      const mediaType =
+        ext === "jpg" || ext === "jpeg"
+          ? "image/jpeg"
+          : ext === "png"
+            ? "image/png"
+            : ext === "webp"
+              ? "image/webp"
+              : "image/jpeg";
+      return `data:${mediaType};base64,${b64}`;
     },
   };
 }

--- a/bridges/telegram/index.ts
+++ b/bridges/telegram/index.ts
@@ -99,7 +99,8 @@ async function main(): Promise<void> {
   const router = createMessageRouter({
     api,
     allowlist,
-    sendToMulmo: (chatId, text) => client.send(chatId, text),
+    sendToMulmo: (chatId, text, attachments) =>
+      client.send(chatId, text, attachments),
   });
 
   // Server → Telegram async push (Phase B of #268).

--- a/bridges/telegram/router.ts
+++ b/bridges/telegram/router.ts
@@ -6,7 +6,9 @@
 
 import type { TelegramApi, TelegramMessage } from "./api.js";
 import type { Allowlist } from "./allowlist.js";
-import type { Attachment, MessageAck, PushEvent } from "../_lib/client.js";
+import type { MessageAck, PushEvent } from "../_lib/client.js";
+import type { Attachment } from "../../server/api/chat-service/types.js";
+import { parseDataUrl } from "../_lib/mime.js";
 
 // Telegram caps a single message at 4096 chars. We split long
 // replies naively; pretty formatting (preserve markdown, break on
@@ -64,10 +66,10 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
     const largest = msg.photo![msg.photo!.length - 1];
     try {
       const dataUrl = await api.downloadPhoto(largest.file_id);
-      const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
-      if (match) {
+      const parsed = parseDataUrl(dataUrl);
+      if (parsed) {
         return {
-          attachments: [{ mimeType: match[1], data: match[2] }],
+          attachments: [{ mimeType: parsed.mimeType, data: parsed.data }],
           failed: false,
         };
       }
@@ -114,7 +116,13 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
       return;
     }
 
-    const messageText = text.trim().length > 0 ? text : "What is this image?";
+    // Surface the photo-drop so the user knows the image was lost.
+    const messageText =
+      failed && text.trim().length > 0
+        ? `${text}\n\n(note: attached photo could not be downloaded)`
+        : text.trim().length > 0
+          ? text
+          : "What is this image?";
     const ack = await sendToMulmo(
       String(chatId),
       messageText,

--- a/bridges/telegram/router.ts
+++ b/bridges/telegram/router.ts
@@ -46,45 +46,38 @@ const defaultLog = {
   error: (m: string) => console.error(m),
 };
 
+interface PhotoResult {
+  attachments: Attachment[];
+  failed: boolean;
+}
+
 export function createMessageRouter(deps: RouterDeps): MessageRouter {
   const { api, allowlist, sendToMulmo } = deps;
   const log = deps.log ?? defaultLog;
 
   // One denial reply per chat per bridge lifetime — restart clears.
-  // Prevents a sender from spamming the operator (and Telegram's
-  // rate limits) by repeatedly messaging a denied bot.
   const deniedAlreadyNotified = new Set<number>();
 
-  async function handleAllowed(msg: TelegramMessage): Promise<void> {
-    const chatId = msg.chat.id;
-    const text = msg.text ?? msg.caption ?? "";
+  async function tryDownloadPhoto(msg: TelegramMessage): Promise<PhotoResult> {
     const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
-    if (text.trim().length === 0 && !hasPhoto) return;
-    const user = userLabel(msg);
-    log.info(
-      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}${hasPhoto ? " +photo" : ""}`,
-    );
-
-    const attachments: Attachment[] = [];
-    if (hasPhoto) {
-      const largest = msg.photo![msg.photo!.length - 1];
-      try {
-        const dataUrl = await api.downloadPhoto(largest.file_id);
-        const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
-        if (match) {
-          attachments.push({ mimeType: match[1], data: match[2] });
-        }
-      } catch (err) {
-        log.error(`[telegram] photo download failed: ${String(err)}`);
+    if (!hasPhoto) return { attachments: [], failed: false };
+    const largest = msg.photo![msg.photo!.length - 1];
+    try {
+      const dataUrl = await api.downloadPhoto(largest.file_id);
+      const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+      if (match) {
+        return {
+          attachments: [{ mimeType: match[1], data: match[2] }],
+          failed: false,
+        };
       }
+    } catch (err) {
+      log.error(`[telegram] photo download failed: ${String(err)}`);
     }
+    return { attachments: [], failed: true };
+  }
 
-    const messageText = text.trim().length > 0 ? text : "What is this image?";
-    const ack = await sendToMulmo(
-      String(chatId),
-      messageText,
-      attachments.length > 0 ? attachments : undefined,
-    );
+  async function sendReply(chatId: number, ack: MessageAck): Promise<void> {
     if (ack.ok) {
       await sendChunked(api, chatId, ack.reply ?? "");
     } else {
@@ -97,11 +90,43 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
     }
   }
 
+  async function handleAllowed(msg: TelegramMessage): Promise<void> {
+    const chatId = msg.chat.id;
+    const text = msg.text ?? msg.caption ?? "";
+    const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
+    if (text.trim().length === 0 && !hasPhoto) return;
+
+    log.info(
+      `[telegram] accepted chat=${chatId} user=@${userLabel(msg)} len=${text.length}${hasPhoto ? " +photo" : ""}`,
+    );
+
+    const { attachments, failed } = await tryDownloadPhoto(msg);
+
+    // Photo-only message where download failed: bail out instead
+    // of sending "What is this image?" without the actual image.
+    if (failed && text.trim().length === 0) {
+      await api
+        .sendMessage(
+          chatId,
+          "Sorry, I could not download the photo. Please try again.",
+        )
+        .catch(() => {});
+      return;
+    }
+
+    const messageText = text.trim().length > 0 ? text : "What is this image?";
+    const ack = await sendToMulmo(
+      String(chatId),
+      messageText,
+      attachments.length > 0 ? attachments : undefined,
+    );
+    await sendReply(chatId, ack);
+  }
+
   async function handleDenied(msg: TelegramMessage): Promise<void> {
     const chatId = msg.chat.id;
-    const user = userLabel(msg);
     log.warn(
-      `[telegram] denied chat=${chatId} user=@${user} — not on allowlist`,
+      `[telegram] denied chat=${chatId} user=@${userLabel(msg)} — not on allowlist`,
     );
     if (deniedAlreadyNotified.has(chatId)) return;
     deniedAlreadyNotified.add(chatId);
@@ -130,10 +155,6 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
         log.warn(`[telegram] push chatId is not integer: ${ev.chatId}`);
         return;
       }
-      // Defense in depth: never sendMessage to a non-allowlisted
-      // chat, even when the push comes from our own server. A
-      // buggy task-manager or a compromised server shouldn't be
-      // able to reach arbitrary Telegram users.
       if (!allowlist.allows(chatId)) {
         log.warn(`[telegram] push denied: chat ${chatId} not on allowlist`);
         return;

--- a/bridges/telegram/router.ts
+++ b/bridges/telegram/router.ts
@@ -6,7 +6,7 @@
 
 import type { TelegramApi, TelegramMessage } from "./api.js";
 import type { Allowlist } from "./allowlist.js";
-import type { MessageAck, PushEvent } from "../_lib/client.js";
+import type { Attachment, MessageAck, PushEvent } from "../_lib/client.js";
 
 // Telegram caps a single message at 4096 chars. We split long
 // replies naively; pretty formatting (preserve markdown, break on
@@ -16,6 +16,7 @@ const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
 export type SendToMulmoFn = (
   externalChatId: string,
   text: string,
+  attachments?: Attachment[],
 ) => Promise<MessageAck>;
 
 export interface RouterDeps {
@@ -56,14 +57,34 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
 
   async function handleAllowed(msg: TelegramMessage): Promise<void> {
     const chatId = msg.chat.id;
-    const text = msg.text ?? "";
-    if (text.trim().length === 0) return;
+    const text = msg.text ?? msg.caption ?? "";
+    const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
+    if (text.trim().length === 0 && !hasPhoto) return;
     const user = userLabel(msg);
     log.info(
-      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}`,
+      `[telegram] accepted chat=${chatId} user=@${user} len=${text.length}${hasPhoto ? " +photo" : ""}`,
     );
 
-    const ack = await sendToMulmo(String(chatId), text);
+    const attachments: Attachment[] = [];
+    if (hasPhoto) {
+      const largest = msg.photo![msg.photo!.length - 1];
+      try {
+        const dataUrl = await api.downloadPhoto(largest.file_id);
+        const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+        if (match) {
+          attachments.push({ mimeType: match[1], data: match[2] });
+        }
+      } catch (err) {
+        log.error(`[telegram] photo download failed: ${String(err)}`);
+      }
+    }
+
+    const messageText = text.trim().length > 0 ? text : "What is this image?";
+    const ack = await sendToMulmo(
+      String(chatId),
+      messageText,
+      attachments.length > 0 ? attachments : undefined,
+    );
     if (ack.ok) {
       await sendChunked(api, chatId, ack.reply ?? "");
     } else {

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -124,6 +124,13 @@ Payload:
 - `text: string` — non-empty. The user's message, UTF-8. Trim
   leading / trailing whitespace yourself if you care; the server
   trims before dispatching.
+- `attachments?: Attachment[]` — optional array of file
+  attachments (#382). Each entry has `{ mimeType: string, data:
+  string, filename?: string }` where `data` is base64-encoded
+  content. The server filters by mimeType: `image/*` becomes
+  vision content blocks for Claude; other types are logged and
+  skipped for now. Multiple images are supported (one content
+  block per attachment).
 
 Ack shape:
 

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -6,6 +6,7 @@ import { MCP_PLUGIN_NAMES } from "./plugin-names.js";
 import type { McpServerSpec } from "../system/config.js";
 import { getCurrentToken } from "../api/auth/token.js";
 import type { Attachment } from "../api/chat-service/types.js";
+import { isImageMime } from "../../bridges/_lib/mime.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
@@ -294,9 +295,23 @@ export function buildUserMessageLine(
   message: string,
   attachments?: Attachment[],
 ): string {
-  const imageAttachments = (attachments ?? []).filter((a) =>
-    a.mimeType.startsWith("image/"),
-  );
+  const all = attachments ?? [];
+  const imageAttachments = all.filter((a) => isImageMime(a.mimeType));
+  const skipped = all.length - imageAttachments.length;
+  if (skipped > 0) {
+    // Non-image attachments (PDF, docx, etc.) are not yet supported
+    // by the vision content-block path. Log so operators can see
+    // "I attached a PDF and nothing happened" in the file log.
+    const skippedTypes = all
+      .filter((a) => !isImageMime(a.mimeType))
+      .map((a) => a.mimeType);
+    // Using console.error as a lightweight debug hint — the
+    // structured logger isn't imported here (config.ts is import-
+    // light by design). The relay layer logs the full summary.
+    console.error(
+      `[agent] skipping ${skipped} non-image attachment(s): ${skippedTypes.join(", ")}`,
+    );
+  }
   const content =
     imageAttachments.length > 0
       ? buildContentBlocks(message, imageAttachments)

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -5,6 +5,7 @@ import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { MCP_PLUGIN_NAMES } from "./plugin-names.js";
 import type { McpServerSpec } from "../system/config.js";
 import { getCurrentToken } from "../api/auth/token.js";
+import type { Attachment } from "../api/chat-service/types.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
@@ -284,17 +285,22 @@ export function buildCliArgs(params: CliArgsParams): string[] {
 /** JSON line to write to the Claude CLI's stdin when running in
  *  stream-json input mode. One line per user turn.
  *
- *  When `imageDataUrl` is provided (a `data:image/…;base64,…`
- *  string), the `content` becomes an array of content blocks so
- *  Claude can see the image via vision. Without it, content is a
- *  plain string (smaller payload, backward-compatible). */
+ *  When `attachments` are provided, image/* entries become vision
+ *  content blocks and `content` becomes an array. Without
+ *  attachments, content is a plain string (smaller, backward-
+ *  compatible). Non-image MIME types are currently skipped — a
+ *  future phase can map PDF/docx to Claude Files API. */
 export function buildUserMessageLine(
   message: string,
-  imageDataUrl?: string,
+  attachments?: Attachment[],
 ): string {
-  const content = imageDataUrl
-    ? buildContentWithImage(message, imageDataUrl)
-    : message;
+  const imageAttachments = (attachments ?? []).filter((a) =>
+    a.mimeType.startsWith("image/"),
+  );
+  const content =
+    imageAttachments.length > 0
+      ? buildContentBlocks(message, imageAttachments)
+      : message;
   return (
     JSON.stringify({
       type: "user",
@@ -303,25 +309,21 @@ export function buildUserMessageLine(
   );
 }
 
-function buildContentWithImage(
+function buildContentBlocks(
   message: string,
-  dataUrl: string,
+  images: Attachment[],
 ): Array<Record<string, unknown>> {
   const blocks: Array<Record<string, unknown>> = [];
-
-  // Parse data URL: data:image/png;base64,<data>
-  const match = dataUrl.match(/^data:(image\/[^;]+);base64,(.+)$/);
-  if (match) {
+  for (const img of images) {
     blocks.push({
       type: "image",
       source: {
         type: "base64",
-        media_type: match[1],
-        data: match[2],
+        media_type: img.mimeType,
+        data: img.data,
       },
     });
   }
-
   blocks.push({ type: "text", text: message });
   return blocks;
 }

--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -19,6 +19,7 @@ import {
   resolveMcpConfigPaths,
   userServerAllowedToolNames,
 } from "./config.js";
+import type { Attachment } from "../api/chat-service/types.js";
 import {
   parseStreamEvent,
   type AgentEvent,
@@ -128,7 +129,7 @@ export async function* runAgent(
   port: number,
   claudeSessionId?: string,
   abortSignal?: AbortSignal,
-  imageDataUrl?: string,
+  attachments?: Attachment[],
 ): AsyncGenerator<AgentEvent> {
   const activePlugins = getActivePlugins(role);
   const useDocker = await isDockerAvailable();
@@ -218,7 +219,7 @@ export async function* runAgent(
   // turns are coming. Writing before attaching the abort handler
   // is fine — if the write fails because the process already died
   // for other reasons, the `readAgentEvents` loop below surfaces it.
-  proc.stdin.write(buildUserMessageLine(message, imageDataUrl));
+  proc.stdin.write(buildUserMessageLine(message, attachments));
   proc.stdin.end();
 
   // If an abort signal is provided, kill the process when it fires.

--- a/server/api/chat-service/relay.ts
+++ b/server/api/chat-service/relay.ts
@@ -10,7 +10,13 @@
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import type { ChatStateStore } from "./chat-state.js";
 import type { CommandHandler } from "./commands.js";
-import type { Logger, OnSessionEventFn, Role, StartChatFn } from "./types.js";
+import type {
+  Attachment,
+  Logger,
+  OnSessionEventFn,
+  Role,
+  StartChatFn,
+} from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -18,6 +24,7 @@ export interface RelayParams {
   transportId: string;
   externalChatId: string;
   text: string;
+  attachments?: Attachment[];
 }
 
 export type RelayResult =
@@ -56,7 +63,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
   return async function relayMessage(
     params: RelayParams,
   ): Promise<RelayResult> {
-    const { transportId, externalChatId, text } = params;
+    const { transportId, externalChatId, text, attachments } = params;
 
     logger.info("chat-service", "message received", {
       transportId,
@@ -83,6 +90,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
       message: text,
       roleId: chatState.roleId,
       chatSessionId: chatState.sessionId,
+      attachments,
     });
 
     if (result.kind === "error") {

--- a/server/api/chat-service/relay.ts
+++ b/server/api/chat-service/relay.ts
@@ -65,10 +65,19 @@ export function createRelay(deps: RelayDeps): RelayFn {
   ): Promise<RelayResult> {
     const { transportId, externalChatId, text, attachments } = params;
 
+    // Log attachment summary (count + mimeTypes) — NEVER log raw
+    // base64 data (performance, log size, information leak risk).
+    const attachmentSummary = attachments
+      ? {
+          count: attachments.length,
+          mimeTypes: attachments.map((a) => a.mimeType),
+        }
+      : undefined;
     logger.info("chat-service", "message received", {
       transportId,
       externalChatId,
       textLength: text.length,
+      ...(attachmentSummary ? { attachments: attachmentSummary } : {}),
     });
 
     let chatState = await store.getChatState(transportId, externalChatId);

--- a/server/api/chat-service/socket.ts
+++ b/server/api/chat-service/socket.ts
@@ -31,7 +31,7 @@ import { Server as SocketServer } from "socket.io";
 import type { Socket } from "socket.io";
 import type { RelayFn } from "./relay.js";
 import type { PushQueue } from "./push-queue.js";
-import type { Logger } from "./types.js";
+import type { Attachment, Logger } from "./types.js";
 
 export const CHAT_SOCKET_PATH = "/ws/chat";
 
@@ -85,6 +85,8 @@ interface HandshakeAuth {
 interface MessagePayload {
   externalChatId?: unknown;
   text?: unknown;
+  /** Array of `{ mimeType, data, filename? }` attachments (#382). */
+  attachments?: unknown;
 }
 
 type MessageAck =
@@ -92,7 +94,12 @@ type MessageAck =
   | { ok: false; error: string; status?: number };
 
 type ParsedMessage =
-  | { ok: true; externalChatId: string; text: string }
+  | {
+      ok: true;
+      externalChatId: string;
+      text: string;
+      attachments?: Attachment[];
+    }
   | { ok: false; error: string };
 
 type HandshakeResult =
@@ -184,6 +191,7 @@ export function attachChatSocket(
           transportId,
           externalChatId: parsed.externalChatId,
           text: parsed.text,
+          attachments: parsed.attachments,
         });
 
         if (result.kind === "ok") {
@@ -269,5 +277,28 @@ function parseMessagePayload(payload: MessagePayload): ParsedMessage {
   if (!text) {
     return { ok: false, error: "text is required" };
   }
-  return { ok: true, externalChatId, text };
+  const attachments = parseAttachments(payload.attachments);
+  return { ok: true, externalChatId, text, attachments };
+}
+
+function parseAttachments(raw: unknown): Attachment[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const valid: Attachment[] = [];
+  for (const item of raw) {
+    if (
+      item &&
+      typeof item === "object" &&
+      typeof (item as Record<string, unknown>).mimeType === "string" &&
+      typeof (item as Record<string, unknown>).data === "string"
+    ) {
+      const entry: Attachment = {
+        mimeType: (item as Record<string, unknown>).mimeType as string,
+        data: (item as Record<string, unknown>).data as string,
+      };
+      const fn = (item as Record<string, unknown>).filename;
+      if (typeof fn === "string" && fn.length > 0) entry.filename = fn;
+      valid.push(entry);
+    }
+  }
+  return valid.length > 0 ? valid : undefined;
 }

--- a/server/api/chat-service/types.ts
+++ b/server/api/chat-service/types.ts
@@ -27,11 +27,22 @@ export interface Logger {
   debug(prefix: string, message: string, data?: Record<string, unknown>): void;
 }
 
+/** A file attached to a bridge message. Generic enough for images,
+ *  PDFs, documents, videos, etc. The server decides what to do with
+ *  each based on mimeType — images become vision content blocks,
+ *  unsupported types are ignored with a log. */
+export interface Attachment {
+  mimeType: string;
+  data: string; // base64-encoded
+  filename?: string;
+}
+
 export interface StartChatParams {
   message: string;
   roleId: string;
   chatSessionId: string;
   selectedImageData?: string;
+  attachments?: Attachment[];
 }
 
 export type StartChatResult =

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -33,6 +33,7 @@ import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
 import type { Attachment } from "../chat-service/types.js";
+import { parseDataUrl } from "../../../bridges/_lib/mime.js";
 
 const router = Router();
 const PORT = env.port;
@@ -270,9 +271,9 @@ function mergeAttachments(
 ): Attachment[] | undefined {
   const result: Attachment[] = [];
   if (selectedImageData) {
-    const match = selectedImageData.match(/^data:([^;]+);base64,(.+)$/);
-    if (match) {
-      result.push({ mimeType: match[1], data: match[2] });
+    const parsed = parseDataUrl(selectedImageData);
+    if (parsed) {
+      result.push({ mimeType: parsed.mimeType, data: parsed.data });
     }
   }
   if (explicit) {
@@ -283,6 +284,10 @@ function mergeAttachments(
 
 // ── HTTP route ──────────────────────────────────────────────────────
 
+// HTTP route body — used by the Vue UI only. `selectedImageData` is
+// the legacy data-URL path; new bridge clients send `attachments`
+// via the socket relay instead. mergeAttachments() unifies both
+// paths inside startChat(). See #382 for the rationale.
 interface AgentBody {
   message: string;
   roleId: string;

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -32,6 +32,7 @@ import {
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
+import type { Attachment } from "../chat-service/types.js";
 
 const router = Router();
 const PORT = env.port;
@@ -119,6 +120,7 @@ export interface StartChatParams {
   roleId: string;
   chatSessionId: string;
   selectedImageData?: string;
+  attachments?: Attachment[];
 }
 
 export type StartChatResult =
@@ -128,7 +130,8 @@ export type StartChatResult =
 export async function startChat(
   params: StartChatParams,
 ): Promise<StartChatResult> {
-  const { message, roleId, chatSessionId, selectedImageData } = params;
+  const { message, roleId, chatSessionId, selectedImageData, attachments } =
+    params;
 
   if (!message || !roleId || !chatSessionId) {
     return {
@@ -249,10 +252,33 @@ export async function startChat(
     metaFilePath,
     requestStartedAt,
     toolArgsCache: createArgsCache(),
-    imageDataUrl: selectedImageData,
+    attachments: mergeAttachments(selectedImageData, attachments),
   });
 
   return { kind: "started", chatSessionId };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Convert legacy `selectedImageData` (data URL from the Vue UI) into
+ *  the generic Attachment format, then merge with any explicitly-
+ *  provided attachments from the bridge protocol. Returns undefined
+ *  when there's nothing to attach. */
+function mergeAttachments(
+  selectedImageData: string | undefined,
+  explicit: Attachment[] | undefined,
+): Attachment[] | undefined {
+  const result: Attachment[] = [];
+  if (selectedImageData) {
+    const match = selectedImageData.match(/^data:([^;]+);base64,(.+)$/);
+    if (match) {
+      result.push({ mimeType: match[1], data: match[2] });
+    }
+  }
+  if (explicit) {
+    result.push(...explicit);
+  }
+  return result.length > 0 ? result : undefined;
 }
 
 // ── HTTP route ──────────────────────────────────────────────────────
@@ -300,7 +326,7 @@ interface BackgroundRunParams {
   metaFilePath: string;
   requestStartedAt: number;
   toolArgsCache: ReturnType<typeof createArgsCache>;
-  imageDataUrl: string | undefined;
+  attachments: Attachment[] | undefined;
 }
 
 // Per-event side-effect context passed to `handleAgentEvent`.
@@ -382,7 +408,7 @@ async function runAgentInBackground(
     metaFilePath,
     requestStartedAt,
     toolArgsCache,
-    imageDataUrl,
+    attachments,
   } = params;
 
   const eventCtx: EventContext = {
@@ -411,7 +437,7 @@ async function runAgentInBackground(
         PORT,
         currentClaudeSessionId,
         abortSignal,
-        imageDataUrl,
+        attachments,
       )) {
         if (
           failoverAttemptsRemaining > 0 &&

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -524,15 +524,16 @@ describe("buildUserMessageLine", () => {
     assert.equal(parsed.message.content, "/shiritori");
   });
 
-  it("sends plain string content when no image is provided", () => {
+  it("sends plain string content when no attachments", () => {
     const line = buildUserMessageLine("describe this");
     const parsed = JSON.parse(line.trimEnd());
     assert.equal(typeof parsed.message.content, "string");
   });
 
-  it("sends content blocks array when imageDataUrl is provided", () => {
-    const dataUrl = "data:image/png;base64,iVBORw0KGgo=";
-    const line = buildUserMessageLine("what is this?", dataUrl);
+  it("sends content blocks when image attachments are provided", () => {
+    const line = buildUserMessageLine("what is this?", [
+      { mimeType: "image/png", data: "iVBORw0KGgo=" },
+    ]);
     const parsed = JSON.parse(line.trimEnd());
     assert.ok(Array.isArray(parsed.message.content));
     const blocks = parsed.message.content;
@@ -545,26 +546,52 @@ describe("buildUserMessageLine", () => {
     assert.equal(blocks[1].text, "what is this?");
   });
 
-  it("falls back to plain string when imageDataUrl is empty", () => {
-    const line = buildUserMessageLine("hello", "");
+  it("supports multiple image attachments", () => {
+    const line = buildUserMessageLine("compare these", [
+      { mimeType: "image/png", data: "AAA" },
+      { mimeType: "image/jpeg", data: "BBB" },
+    ]);
     const parsed = JSON.parse(line.trimEnd());
-    assert.equal(typeof parsed.message.content, "string");
-    assert.equal(parsed.message.content, "hello");
+    const blocks = parsed.message.content;
+    assert.equal(blocks.length, 3);
+    assert.equal(blocks[0].source.media_type, "image/png");
+    assert.equal(blocks[1].source.media_type, "image/jpeg");
+    assert.equal(blocks[2].type, "text");
   });
 
-  it("falls back to plain string when imageDataUrl is undefined", () => {
+  it("falls back to plain string for empty attachments array", () => {
+    const line = buildUserMessageLine("hello", []);
+    const parsed = JSON.parse(line.trimEnd());
+    assert.equal(typeof parsed.message.content, "string");
+  });
+
+  it("falls back to plain string when attachments is undefined", () => {
     const line = buildUserMessageLine("hello", undefined);
     const parsed = JSON.parse(line.trimEnd());
     assert.equal(typeof parsed.message.content, "string");
   });
 
-  it("handles JPEG data URL correctly", () => {
-    const dataUrl = "data:image/jpeg;base64,/9j/4AAQ";
-    const line = buildUserMessageLine("analyze", dataUrl);
+  it("skips non-image attachments (PDF etc.) for now", () => {
+    const line = buildUserMessageLine("read this", [
+      { mimeType: "application/pdf", data: "JVBERi0x" },
+    ]);
+    const parsed = JSON.parse(line.trimEnd());
+    // No image content blocks → plain string fallback
+    assert.equal(typeof parsed.message.content, "string");
+    assert.equal(parsed.message.content, "read this");
+  });
+
+  it("includes only image attachments when mixed types are present", () => {
+    const line = buildUserMessageLine("analyze", [
+      { mimeType: "image/jpeg", data: "/9j/4AAQ" },
+      { mimeType: "application/pdf", data: "JVBERi0x" },
+    ]);
     const parsed = JSON.parse(line.trimEnd());
     const blocks = parsed.message.content;
+    // 1 image + 1 text (PDF skipped)
+    assert.equal(blocks.length, 2);
     assert.equal(blocks[0].source.media_type, "image/jpeg");
-    assert.equal(blocks[0].source.data, "/9j/4AAQ");
+    assert.equal(blocks[1].type, "text");
   });
 });
 

--- a/test/bridges/telegram/test_router.ts
+++ b/test/bridges/telegram/test_router.ts
@@ -26,6 +26,9 @@ function stubApi(): TelegramApi & { sent: SentMessage[] } {
     async sendMessage(chatId, text) {
       sent.push({ chatId, text });
     },
+    async downloadPhoto() {
+      return "data:image/jpeg;base64,AAAA";
+    },
   };
 }
 
@@ -128,6 +131,64 @@ describe("router.handleMessage — allowed chat", () => {
     });
     await router.handleMessage(msg(42, "ping"));
     assert.deepEqual(api.sent, [{ chatId: 42, text: "(empty reply)" }]);
+  });
+
+  it("downloads photo and passes attachments when message has photo", async () => {
+    let receivedAttachments: unknown;
+    const sendCapture: SendToMulmoFn = async (_chatId, _text, attachments) => {
+      receivedAttachments = attachments;
+      return { ok: true, reply: "nice pic" };
+    };
+    const photoApi = stubApi();
+    const router = createMessageRouter({
+      api: photoApi,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendCapture,
+      log: silentLog,
+    });
+    const photoMsg: TelegramMessage = {
+      message_id: 1,
+      chat: { id: 42, type: "private" },
+      from: { id: 1, is_bot: false, first_name: "A", username: "alice" },
+      date: 0,
+      photo: [
+        { file_id: "small", file_unique_id: "s", width: 90, height: 90 },
+        { file_id: "large", file_unique_id: "l", width: 800, height: 600 },
+      ],
+      caption: "look at this",
+    };
+    await router.handleMessage(photoMsg);
+    assert.ok(Array.isArray(receivedAttachments));
+    const atts = receivedAttachments as Array<{
+      mimeType: string;
+      data: string;
+    }>;
+    assert.equal(atts.length, 1);
+    assert.equal(atts[0].mimeType, "image/jpeg");
+    assert.equal(atts[0].data, "AAAA");
+  });
+
+  it("uses default text when photo has no caption", async () => {
+    let receivedText = "";
+    const sendCapture: SendToMulmoFn = async (_chatId, text) => {
+      receivedText = text;
+      return { ok: true, reply: "ok" };
+    };
+    const captionApi = stubApi();
+    const router = createMessageRouter({
+      api: captionApi,
+      allowlist: createAllowlist([42]),
+      sendToMulmo: sendCapture,
+      log: silentLog,
+    });
+    const photoMsg: TelegramMessage = {
+      message_id: 1,
+      chat: { id: 42, type: "private" },
+      date: 0,
+      photo: [{ file_id: "f", file_unique_id: "u", width: 100, height: 100 }],
+    };
+    await router.handleMessage(photoMsg);
+    assert.equal(receivedText, "What is this image?");
   });
 });
 

--- a/test/chat-service/test_socket.ts
+++ b/test/chat-service/test_socket.ts
@@ -128,11 +128,9 @@ describe("chat-service socket — no auth", () => {
 
     assert.deepEqual(ack, { ok: true, reply: "hello back" });
     assert.equal(harness.relayCalls.length, 1);
-    assert.deepEqual(harness.relayCalls[0], {
-      transportId: "cli",
-      externalChatId: "terminal",
-      text: "hi",
-    });
+    assert.equal(harness.relayCalls[0].transportId, "cli");
+    assert.equal(harness.relayCalls[0].externalChatId, "terminal");
+    assert.equal(harness.relayCalls[0].text, "hi");
 
     client.disconnect();
   });


### PR DESCRIPTION
## Summary (Draft)

bridge protocol の imageDataUrl: string を attachments: Attachment[] に置き換え。画像だけでなく PDF/docx/pptx/video も将来対応できる汎用形式。配列なので複数添付もサポート。

## Attachment 型

```ts
interface Attachment {
  mimeType: string;   // image/jpeg, application/pdf, ...
  data: string;       // base64
  filename?: string;
}
```

## 変更全レイヤー

- Socket protocol payload: `{ externalChatId, text, attachments? }`
- Relay: `RelayParams.attachments` → `startChat`
- Agent: `buildUserMessageLine(message, attachments?)` — image/* → vision blocks, others skip
- Bridge client: `send(chatId, text, attachments?)`
- Telegram: photo → `Attachment` via `downloadPhoto` + data URL parse
- Vue UI: 既存の selectedImageData (data URL) は server 側 `mergeAttachments()` が Attachment に変換

## Test plan

- [x] `yarn test` — 2356/2356 pass
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean

## Related

- #382 — this issue
- #369 / PR #379 — Vue paste/drop
- #380 — original bridge image issue (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending attachments (images and files) through the messaging bridge
  * Telegram photo messages are now supported with automatic download and conversion
  * Users can send multiple image attachments in a single message

<!-- end of auto-generated comment: release notes by coderabbit.ai -->