### PR TITLE
refactor(agent): migrate agent.ts to session-io — zero raw fs/path (#366)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,47 @@ Key shared helpers in this repo:
 
 Periodically audit for duplication (`sonarjs/no-duplicate-string` warnings, `jscpd`). Batch low-risk extractions into a single refactor PR (as #145 did).
 
+### File I/O — domain I/O modules (#366)
+
+**NEVER use raw `fs.readFile` / `fs.writeFile` / `path.join` in route handlers or business logic.** All workspace file I/O MUST go through domain-specific I/O modules under `server/utils/files/`. This prevents path bugs when directories are renamed (like #284).
+
+**Where to put what:**
+
+| Layer | Location | Example |
+|---|---|---|
+| **Domain I/O** (highest) | `server/utils/files/<domain>-io.ts` | `readSessionMeta(id)`, `saveTodos(items)`, `writeDailySummary(date, content)` |
+| **Generic workspace I/O** | `server/utils/files/workspace-io.ts` | `readWorkspaceText(relPath)`, `writeWorkspaceJson(relPath, data)` |
+| **Atomic primitives** | `server/utils/files/atomic.ts` | `writeFileAtomic(absPath, content)` |
+| **Safe wrappers** | `server/utils/files/safe.ts` | `resolveWithinRoot(root, relPath)`, `readTextSafeSync(absPath)` |
+| **Path constants** | `server/workspace/paths.ts` | `WORKSPACE_DIRS.chat`, `WORKSPACE_FILES.todosItems` |
+
+**Adding a new domain I/O module:**
+
+1. Create `server/utils/files/<domain>-io.ts`
+2. Functions take **IDs and data** as arguments, never paths — e.g. `readSessionMeta(id)` not `readFile(path.join(WORKSPACE_PATHS.chat, id + ".json"))`
+3. All functions take optional `root?: string` parameter for test DI (defaults to `workspacePath`)
+4. Reads return `null` / fallback on ENOENT; log + return fallback on JSON corruption (never crash)
+5. Writes go through `writeFileAtomic` (atomic safety)
+6. Export from `server/utils/files/index.ts` barrel
+
+**Existing domain I/O modules:**
+
+| Module | Functions |
+|---|---|
+| `session-io.ts` | `readSessionMeta`, `createSessionMeta`, `backfillFirstUserMessage`, `setClaudeSessionId`, `clearClaudeSessionId`, `updateHasUnread`, `readSessionJsonl`, `appendSessionLine`, `ensureChatDir` |
+| `todos-io.ts` | `loadTodos`, `saveTodos`, `loadColumns`, `saveColumns` |
+| `scheduler-io.ts` | `loadSchedulerItems`, `saveSchedulerItems` |
+| `html-io.ts` | `readCurrentHtml`, `writeCurrentHtml` |
+| `journal-io.ts` | `readDailySummary`, `writeDailySummary`, `readTopicFile`, `writeTopicFile`, `appendOrCreateTopic`, `readJournalState`, `writeJournalState`, `writeJournalIndex`, `listTopicSlugs`, `archiveTopic`, `listDailyFiles`, `countArchivedTopics` |
+
+### Network I/O — centralized API helpers
+
+**Frontend → Server**: All HTTP calls from Vue MUST go through `src/utils/api.ts` (`apiGet`, `apiPost`, `apiPut`, `apiPatch`, `apiDelete`, `apiCall`). These attach the #272 bearer token automatically. NEVER use raw `fetch("/api/...")` in `.vue` or composable files.
+
+**MCP Server → Server**: The MCP subprocess uses `postJson()` in `server/agent/mcp-server.ts` which attaches `AUTH_HEADER`. NEVER add a raw `fetch` call in mcp-server.ts without the auth header.
+
+**Server → External APIs**: Use `AbortController` for timeouts. Handle both network errors (try/catch) and HTTP errors (`!response.ok`). Surface errors to the user in the UI where appropriate.
+
 ### Files: one concept per file
 
 - Name files for the concept they contain — **not** generic `utils.ts` / `helpers.ts` / `common.ts` (conflict magnets).

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -4,7 +4,6 @@
  * back to the active frontend SSE stream via the session registry.
  */
 
-import fs from "node:fs";
 import type { ToolDefinition } from "gui-chat-protocol";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { TOOL_ENDPOINTS, PLUGIN_DEFS } from "./plugin-names.js";
@@ -12,6 +11,7 @@ import { errorMessage } from "../utils/errors.js";
 import { API_ROUTES } from "../../src/config/apiRoutes.js";
 import { env } from "../system/env.js";
 import { extractFetchError } from "../utils/fetch.js";
+import { readTextSafeSync } from "../utils/files/safe.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 
 type JsonRpcId = string | number | null;
@@ -45,11 +45,7 @@ const BASE_URL = `http://${MCP_HOST}:${PORT}`;
 function readSessionToken(): string {
   const fromEnv = process.env.MULMOCLAUDE_AUTH_TOKEN;
   if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
-  try {
-    return fs.readFileSync(WORKSPACE_PATHS.sessionToken, "utf-8").trim();
-  } catch {
-    return "";
-  }
+  return readTextSafeSync(WORKSPACE_PATHS.sessionToken)?.trim() ?? "";
 }
 const SESSION_TOKEN = readSessionToken();
 const AUTH_HEADER: Record<string, string> = SESSION_TOKEN

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -1,7 +1,15 @@
-import { access, appendFile, mkdir, readFile } from "fs/promises";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
-import path from "path";
 import { Router, Request, Response } from "express";
+import {
+  createSessionMeta,
+  backfillFirstUserMessage as backfillMeta,
+  readSessionMeta,
+  setClaudeSessionId as setClaudeId,
+  clearClaudeSessionId as clearClaudeId,
+  appendSessionLine,
+  readSessionJsonl,
+  sessionJsonlAbsPath,
+  ensureChatDir,
+} from "../../utils/files/session-io.js";
 import { getRole } from "../../workspace/roles.js";
 import { runAgent } from "../../agent/index.js";
 import { prependJournalPointer } from "../../agent/prompt.js";
@@ -19,7 +27,6 @@ import {
   getActiveSessionIds,
 } from "../../events/session-store/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
-import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { maybeRunJournal } from "../../workspace/journal/index.js";
 import { maybeIndexSession } from "../../workspace/chat-index/index.js";
 import { maybeAppendWikiBacklinks } from "../../workspace/wiki-backlinks/index.js";
@@ -138,35 +145,16 @@ export async function startChat(
     };
   }
 
-  const chatDir = WORKSPACE_PATHS.chat;
-  await mkdir(chatDir, { recursive: true });
-  const resultsFilePath = path.join(chatDir, `${chatSessionId}.jsonl`);
-  const metaFilePath = path.join(chatDir, `${chatSessionId}.json`);
+  ensureChatDir();
+  const resultsFilePath = sessionJsonlAbsPath(chatSessionId);
 
-  // Check whether this is a brand-new session up front so we can both
-  // (a) decide whether to read persisted hasUnread (skipped for first
-  // turn — nothing on disk yet) and (b) pick meta-write vs backfill
-  // after beginRun succeeds.
-  let isFirstTurn = false;
-  try {
-    await access(metaFilePath);
-  } catch {
-    isFirstTurn = true;
-  }
-
-  // Read persisted hasUnread so the in-memory store starts with the
-  // correct value (survives server restarts). Must happen before
-  // getOrCreateSession; for the first turn the meta file doesn't
-  // exist yet so the value stays undefined.
-  let persistedHasUnread: boolean | undefined;
-  if (!isFirstTurn) {
-    try {
-      const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-      persistedHasUnread = meta.hasUnread === true;
-    } catch {
-      // ignore — meta file may be missing or malformed
-    }
-  }
+  // Check whether this is a brand-new session and read persisted
+  // hasUnread in one read. readSessionMeta returns null if the meta
+  // file doesn't exist yet (= first turn).
+  const existingMeta = await readSessionMeta(chatSessionId);
+  const isFirstTurn = existingMeta === null;
+  const persistedHasUnread =
+    existingMeta?.hasUnread === true ? true : undefined;
 
   const now = new Date().toISOString();
   getOrCreateSession(chatSessionId, {
@@ -194,22 +182,15 @@ export async function startChat(
   // title cache; the append follows so the jsonl is always a
   // superset of what metadata advertised.
   if (isFirstTurn) {
-    await writeFileAtomic(
-      metaFilePath,
-      JSON.stringify({
-        roleId,
-        startedAt: new Date().toISOString(),
-        firstUserMessage: message,
-      }),
-    );
+    await createSessionMeta(chatSessionId, roleId, message);
   } else {
-    await backfillFirstUserMessage(metaFilePath, message);
+    await backfillMeta(chatSessionId, message);
   }
 
   // Append user message for this turn
-  await appendFile(
-    resultsFilePath,
-    JSON.stringify({ source: "user", type: EVENT_TYPES.text, message }) + "\n",
+  await appendSessionLine(
+    chatSessionId,
+    JSON.stringify({ source: "user", type: EVENT_TYPES.text, message }),
   );
 
   // Broadcast the user message so other tabs viewing this session
@@ -222,10 +203,7 @@ export async function startChat(
   });
 
   const role = getRole(roleId);
-  const claudeSessionId = await readClaudeSessionId(
-    metaFilePath,
-    resultsFilePath,
-  );
+  const claudeSessionId = await readClaudeSessionIdFromSession(chatSessionId);
 
   const requestStartedAt = Date.now();
   log.info("agent", "request received", {
@@ -246,7 +224,6 @@ export async function startChat(
     claudeSessionId,
     abortSignal: abortController.signal,
     resultsFilePath,
-    metaFilePath,
     requestStartedAt,
     toolArgsCache: createArgsCache(),
     imageDataUrl: selectedImageData,
@@ -297,7 +274,6 @@ interface BackgroundRunParams {
   claudeSessionId: string | undefined;
   abortSignal: AbortSignal;
   resultsFilePath: string;
-  metaFilePath: string;
   requestStartedAt: number;
   toolArgsCache: ReturnType<typeof createArgsCache>;
   imageDataUrl: string | undefined;
@@ -307,7 +283,6 @@ interface BackgroundRunParams {
 interface EventContext {
   chatSessionId: string;
   resultsFilePath: string;
-  metaFilePath: string;
   toolArgsCache: ReturnType<typeof createArgsCache>;
 }
 
@@ -323,19 +298,19 @@ async function handleAgentEvent(
   ctx: EventContext,
 ): Promise<void> {
   if (event.type === EVENT_TYPES.claudeSessionId) {
-    await updateClaudeSessionId(ctx.metaFilePath, event.id);
+    await setClaudeId(ctx.chatSessionId, event.id);
     return;
   }
   pushSessionEvent(ctx.chatSessionId, event as Record<string, unknown>);
 
   if (event.type === EVENT_TYPES.text) {
-    await appendFile(
-      ctx.resultsFilePath,
+    await appendSessionLine(
+      ctx.chatSessionId,
       JSON.stringify({
         source: "assistant",
         type: EVENT_TYPES.text,
         message: event.message,
-      }) + "\n",
+      }),
     );
     return;
   }
@@ -379,7 +354,6 @@ async function runAgentInBackground(
     claudeSessionId,
     abortSignal,
     resultsFilePath,
-    metaFilePath,
     requestStartedAt,
     toolArgsCache,
     imageDataUrl,
@@ -388,7 +362,6 @@ async function runAgentInBackground(
   const eventCtx: EventContext = {
     chatSessionId,
     resultsFilePath,
-    metaFilePath,
     toolArgsCache,
   };
 
@@ -440,8 +413,8 @@ async function runAgentInBackground(
       log.warn("agent", "stale claude session id — retrying without --resume", {
         chatSessionId,
       });
-      await clearClaudeSessionId(metaFilePath);
-      const preamble = await readTranscriptPreamble(resultsFilePath);
+      await clearClaudeId(chatSessionId);
+      const preamble = await readTranscriptPreamble(chatSessionId);
       currentMessage = preamble
         ? `${preamble}${decoratedMessage}`
         : decoratedMessage;
@@ -486,96 +459,34 @@ async function runAgentInBackground(
   }
 }
 
-async function readClaudeSessionId(
-  metaFilePath: string,
-  jsonlFilePath: string,
+// Read claudeSessionId from meta (primary) or jsonl (legacy fallback).
+async function readClaudeSessionIdFromSession(
+  chatSessionId: string,
 ): Promise<string | undefined> {
-  try {
-    const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-    if (meta.claudeSessionId) return meta.claudeSessionId;
-  } catch {
-    // fall through to legacy scan
-  }
-  try {
-    const lines = (await readFile(jsonlFilePath, "utf-8"))
-      .split("\n")
-      .filter(Boolean);
-    for (let i = lines.length - 1; i >= 0; i--) {
-      try {
-        const entry = JSON.parse(lines[i]);
-        if (entry.type === EVENT_TYPES.claudeSessionId && entry.id)
-          return entry.id;
-      } catch {
-        // skip malformed lines
-      }
+  const meta = await readSessionMeta(chatSessionId);
+  if (meta?.claudeSessionId) return meta.claudeSessionId as string;
+  // Legacy scan: search jsonl lines backwards for a claudeSessionId event
+  const jsonl = await readSessionJsonl(chatSessionId);
+  if (!jsonl) return undefined;
+  const lines = jsonl.split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]);
+      if (entry.type === EVENT_TYPES.claudeSessionId && entry.id)
+        return entry.id;
+    } catch {
+      // skip malformed lines
     }
-  } catch {
-    // file doesn't exist yet
   }
   return undefined;
 }
 
-/** Add firstUserMessage to an existing meta file if it's missing (migration). */
-async function backfillFirstUserMessage(
-  metaFilePath: string,
-  message: string,
-): Promise<void> {
-  try {
-    const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-    if (!meta.firstUserMessage) {
-      await writeFileAtomic(
-        metaFilePath,
-        JSON.stringify({ ...meta, firstUserMessage: message }),
-      );
-    }
-  } catch {
-    // ignore — meta file may not exist
-  }
-}
-
-async function updateClaudeSessionId(
-  metaFilePath: string,
-  claudeSessionId: string,
-): Promise<void> {
-  try {
-    const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-    await writeFileAtomic(
-      metaFilePath,
-      JSON.stringify({ ...meta, claudeSessionId }),
-    );
-  } catch {
-    // ignore if meta file is missing
-  }
-}
-
-// Drop the (now-stale) `claudeSessionId` key from meta after a
-// `--resume` fail-over. Leaves every other field (roleId, startedAt,
-// firstUserMessage, hasUnread) intact. The new id gets written back
-// by `updateClaudeSessionId` on the retried run's first
-// `claudeSessionId` event.
-async function clearClaudeSessionId(metaFilePath: string): Promise<void> {
-  try {
-    const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
-    delete meta.claudeSessionId;
-    await writeFileAtomic(metaFilePath, JSON.stringify(meta));
-  } catch {
-    // ignore if meta file is missing or unreadable
-  }
-}
-
 // Read the session jsonl and render the transcript preamble used on
-// `--resume` fail-over. Returns "" on any read / parse failure —
-// the retry then runs without a preamble, which is still an
-// improvement over the user seeing the original error.
-async function readTranscriptPreamble(
-  resultsFilePath: string,
-): Promise<string> {
-  try {
-    const jsonl = await readFile(resultsFilePath, "utf-8");
-    return buildTranscriptPreamble(jsonl);
-  } catch {
-    return "";
-  }
+// `--resume` fail-over.
+async function readTranscriptPreamble(chatSessionId: string): Promise<string> {
+  const jsonl = await readSessionJsonl(chatSessionId);
+  if (!jsonl) return "";
+  return buildTranscriptPreamble(jsonl);
 }
 
 export default router;

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import { getSessionQuery } from "../../utils/request.js";
 import {
   createSessionMeta,
   backfillFirstUserMessage as backfillMeta,
@@ -75,7 +76,7 @@ router.post(
     req: Request<object, unknown, Record<string, unknown>>,
     res: Response<OkResponse>,
   ) => {
-    const chatSessionId = String(req.query.session ?? "");
+    const chatSessionId = getSessionQuery(req);
     const outcome = await pushToolResult(chatSessionId, req.body);
     res.json({ ok: outcome.kind === "processed" });
   },
@@ -92,7 +93,7 @@ router.post(
     req: Request<object, unknown, SwitchRoleBody>,
     res: Response<OkResponse>,
   ) => {
-    const chatSessionId = String(req.query.session ?? "");
+    const chatSessionId = getSessionQuery(req);
     pushSessionEvent(chatSessionId, {
       type: EVENT_TYPES.switchRole,
       roleId: req.body.roleId,

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import {
   createSessionMeta,
   backfillFirstUserMessage as backfillMeta,
+  readSessionMetaFull,
   readSessionMeta,
   setClaudeSessionId as setClaudeId,
   clearClaudeSessionId as clearClaudeId,
@@ -152,13 +153,18 @@ export async function startChat(
   ensureChatDir();
   const resultsFilePath = sessionJsonlAbsPath(chatSessionId);
 
-  // Check whether this is a brand-new session and read persisted
-  // hasUnread in one read. readSessionMeta returns null if the meta
-  // file doesn't exist yet (= first turn).
-  const existingMeta = await readSessionMeta(chatSessionId);
-  const isFirstTurn = existingMeta === null;
+  // Discriminate missing (first turn) from corrupt (warn, don't clobber).
+  const metaResult = await readSessionMetaFull(chatSessionId);
+  const isFirstTurn = metaResult.kind === "missing";
+  if (metaResult.kind === "corrupt") {
+    log.warn("agent", "session meta is corrupt — treating as existing", {
+      chatSessionId,
+    });
+  }
   const persistedHasUnread =
-    existingMeta?.hasUnread === true ? true : undefined;
+    metaResult.kind === "ok" && metaResult.meta.hasUnread === true
+      ? true
+      : undefined;
 
   const now = new Date().toISOString();
   getOrCreateSession(chatSessionId, {

--- a/server/api/routes/chart.ts
+++ b/server/api/routes/chart.ts
@@ -1,10 +1,7 @@
 import { Router, Request, Response } from "express";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
-import {
-  writeWorkspaceText,
-  ensureWorkspaceDir,
-} from "../../utils/files/workspace-io.js";
-import { slugify } from "../../utils/slug.js";
+import { writeWorkspaceText } from "../../utils/files/workspace-io.js";
+import { buildArtifactPath } from "../../utils/files/naming.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -97,10 +94,12 @@ router.post(
 
     try {
       const baseLabel = title ?? document.title ?? "chart";
-      const slug = slugify(baseLabel) || "chart";
-      const fname = `${slug}-${Date.now()}.chart.json`;
-      const filePath = `${WORKSPACE_DIRS.charts}/${fname}`;
-      ensureWorkspaceDir(WORKSPACE_DIRS.charts);
+      const filePath = buildArtifactPath(
+        WORKSPACE_DIRS.charts,
+        baseLabel,
+        ".chart.json",
+        "chart",
+      );
       await writeWorkspaceText(
         filePath,
         `${JSON.stringify(document, null, 2)}\n`,

--- a/server/api/routes/image.ts
+++ b/server/api/routes/image.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import { getOptionalStringQuery } from "../../utils/request.js";
 import { getSessionImageData } from "../../events/session-store/index.js";
 import {
   generateGeminiImageContent,
@@ -126,8 +127,7 @@ router.post(
     res: Response<ImageResponse>,
   ) => {
     const { prompt } = req.body;
-    const session =
-      typeof req.query.session === "string" ? req.query.session : undefined;
+    const session = getOptionalStringQuery(req, "session");
     if (!prompt) {
       res.status(400).json({ success: false, message: "prompt is required" });
       return;

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -5,9 +5,12 @@ import { marked } from "marked";
 import puppeteer from "puppeteer";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
-import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
-import { resolveWithinRoot } from "../../utils/files/safe.js";
+import {
+  resolveWithinRoot,
+  readBinarySafeSync,
+} from "../../utils/files/safe.js";
+import { resolveWorkspacePath } from "../../utils/files/workspace-io.js";
 import { log } from "../../system/logger/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 
@@ -56,7 +59,7 @@ const MIME_BY_EXT: Record<string, string> = {
 // Realpath of the workspace, resolved once at module load. Used to
 // validate that image paths resolved relative to markdowns/ stay
 // inside the workspace after symlink resolution.
-const workspaceReal = fs.realpathSync(workspacePath);
+const workspaceReal = fs.realpathSync(resolveWorkspacePath(""));
 
 /**
  * Inline local images as base64 data URIs so Puppeteer can render them.
@@ -92,15 +95,14 @@ function inlineImages(html: string): string {
         log.warn("pdf", "image path rejected by safe-resolve", { src });
         return _match;
       }
-      try {
-        const buf = fs.readFileSync(abs);
-        const ext = path.extname(abs).toLowerCase();
-        const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
-        return `${before}data:${mime};base64,${buf.toString("base64")}${after}`;
-      } catch {
+      const buf = readBinarySafeSync(abs);
+      if (!buf) {
         log.warn("pdf", "could not read image", { abs });
         return _match;
       }
+      const ext = path.extname(abs).toLowerCase();
+      const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+      return `${before}data:${mime};base64,${buf.toString("base64")}${after}`;
     },
   );
 }

--- a/server/api/routes/presentHtml.ts
+++ b/server/api/routes/presentHtml.ts
@@ -1,10 +1,7 @@
 import { Router, Request, Response } from "express";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
-import {
-  writeWorkspaceText,
-  ensureWorkspaceDir,
-} from "../../utils/files/workspace-io.js";
-import { slugify } from "../../utils/slug.js";
+import { writeWorkspaceText } from "../../utils/files/workspace-io.js";
+import { buildArtifactPath } from "../../utils/files/naming.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -43,10 +40,12 @@ router.post(
     }
 
     try {
-      const slug = title ? slugify(title) : "page";
-      const fname = `${slug}-${Date.now()}.html`;
-      const filePath = `${WORKSPACE_DIRS.htmls}/${fname}`;
-      ensureWorkspaceDir(WORKSPACE_DIRS.htmls);
+      const filePath = buildArtifactPath(
+        WORKSPACE_DIRS.htmls,
+        title,
+        ".html",
+        "page",
+      );
       await writeWorkspaceText(filePath, html);
       res.json({
         message: `Saved HTML to ${filePath}`,

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import { getSessionQuery } from "../../utils/request.js";
 import { loadCustomRoles } from "../../workspace/roles.js";
 import { BUILTIN_ROLES, type Role } from "../../../src/config/roles.js";
 import { pushSessionEvent } from "../../events/session-store/index.js";
@@ -21,7 +22,7 @@ router.get(API_ROUTES.roles.list, (_req: Request, res: Response<Role[]>) => {
 router.post(
   API_ROUTES.roles.manage,
   async (req: Request, res: Response<Record<string, unknown>>) => {
-    const session = String(req.query.session ?? "");
+    const session = getSessionQuery(req);
     const result = await executeManageRoles(req.body, session);
     res.json(result);
   },

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -1,15 +1,15 @@
 import { Router, Request, Response } from "express";
-import path from "path";
-import fs from "fs";
 import { loadCustomRoles } from "../../workspace/roles.js";
 import { BUILTIN_ROLES, type Role } from "../../../src/config/roles.js";
 import { pushSessionEvent } from "../../events/session-store/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
-import { WORKSPACE_PATHS } from "../../workspace/paths.js";
-import { writeFileAtomicSync } from "../../utils/files/atomic.js";
+import {
+  roleExists,
+  deleteRole,
+  saveRole,
+} from "../../utils/files/roles-io.js";
 
-const rolesDir = WORKSPACE_PATHS.roles;
 const BUILTIN_IDS = new Set(BUILTIN_ROLES.map((r) => r.id));
 
 const router = Router();
@@ -68,11 +68,10 @@ export async function executeManageRoles(
     if (BUILTIN_IDS.has(id)) {
       return { success: false, error: "Cannot delete built-in roles." };
     }
-    const filePath = path.join(rolesDir, `${id}.json`);
-    if (!fs.existsSync(filePath)) {
+    if (!roleExists(id)) {
       return { success: false, error: `Role '${id}' not found.` };
     }
-    fs.unlinkSync(filePath);
+    deleteRole(id);
     notifyRolesUpdated(sessionId);
     return {
       success: true,
@@ -104,11 +103,7 @@ export async function executeManageRoles(
     availablePlugins: pluginsToSave.filter((p) => p !== "switchRole"),
   };
 
-  fs.mkdirSync(rolesDir, { recursive: true });
-  writeFileAtomicSync(
-    path.join(rolesDir, `${roleId2}.json`),
-    JSON.stringify(roleToSave, null, 2),
-  );
+  saveRole(roleId2, roleToSave);
   notifyRolesUpdated(sessionId);
   return {
     success: true,

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -4,6 +4,11 @@ import { readdir, readFile, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
+import {
+  readSessionMeta as readSessionMetaIO,
+  readSessionJsonl,
+  sessionJsonlAbsPath,
+} from "../../utils/files/session-io.js";
 import { readManifest } from "../../workspace/chat-index/indexer.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
 import type { ChatIndexEntry } from "../../workspace/chat-index/types.js";
@@ -26,29 +31,26 @@ interface SessionMeta {
 }
 
 async function readSessionMeta(
-  chatDir: string,
+  __chatDir: string,
   id: string,
 ): Promise<SessionMeta | null> {
-  // Try new-style .json file first
-  try {
-    const meta = JSON.parse(
-      await readFile(path.join(chatDir, `${id}.json`), "utf-8"),
-    );
-    if (meta.roleId && meta.startedAt) return meta;
-  } catch {
-    // fall through
+  // Try new-style .json meta first
+  const meta = await readSessionMetaIO(id);
+  if (meta?.roleId && meta?.startedAt) {
+    return meta as SessionMeta;
   }
   // Legacy: read first line of .jsonl
-  try {
-    const first = (await readFile(path.join(chatDir, `${id}.jsonl`), "utf-8"))
-      .split("\n")
-      .find(Boolean);
+  const jsonl = await readSessionJsonl(id);
+  if (jsonl) {
+    const first = jsonl.split("\n").find(Boolean);
     if (first) {
-      const meta = JSON.parse(first);
-      if (meta.roleId && meta.startedAt) return meta;
+      try {
+        const parsed = JSON.parse(first);
+        if (parsed.roleId && parsed.startedAt) return parsed;
+      } catch {
+        // ignore
+      }
     }
-  } catch {
-    // ignore
   }
   return null;
 }
@@ -118,7 +120,7 @@ async function loadAllSessions(): Promise<
       const id = file.replace(".jsonl", "");
       try {
         // stat only — no readFile on .jsonl content
-        const fileStat = await stat(path.join(chatDir, file));
+        const fileStat = await stat(sessionJsonlAbsPath(id));
         if (cutoff > 0 && fileStat.mtimeMs < cutoff) return null;
 
         const meta = await readSessionMeta(chatDir, id);
@@ -222,10 +224,13 @@ router.get(
   ) => {
     const { id } = req.params;
     const chatDir = WORKSPACE_PATHS.chat;
-    const filePath = path.join(chatDir, `${id}.jsonl`);
     try {
       const meta = await readSessionMeta(chatDir, id);
-      const content = await readFile(filePath, "utf-8");
+      const content = await readSessionJsonl(id);
+      if (!content) {
+        notFound(res, `Session ${id} not found`);
+        return;
+      }
       const entries = (
         await Promise.all(
           content

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import fs from "fs";
-import { readdir, readFile, stat } from "fs/promises";
+import { readdir, stat } from "fs/promises";
+import { readTextSafe } from "../../utils/files/safe.js";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
@@ -277,7 +278,7 @@ router.get(
                       relFromStories,
                     );
                     if (!scriptPath) return entry;
-                    const scriptJson = await readFile(scriptPath, "utf-8");
+                    const scriptJson = (await readTextSafe(scriptPath)) ?? "";
                     return {
                       ...entry,
                       result: {

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -1,8 +1,7 @@
 import { Router, Request, Response } from "express";
-import fsp from "node:fs/promises";
 import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
-import { readTextSafeSync } from "../../utils/files/safe.js";
+import { readTextSafeSync, readTextSafe } from "../../utils/files/safe.js";
 import { getPageIndex } from "./wiki/pageIndex.js";
 import { badRequest } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -348,9 +347,10 @@ async function collectLintIssues(): Promise<string[]> {
   // Parallel read: N small markdown files, ~50 KB each. Bounded by
   // the number of wiki pages, not by CPU.
   const contents = await Promise.all(
-    pageFiles.map((f) =>
-      fsp.readFile(path.join(dir, f), "utf-8").catch(() => ""),
-    ),
+    pageFiles.map(async (f) => {
+      const content = await readTextSafe(path.join(dir, f));
+      return content ?? "";
+    }),
   );
   for (let i = 0; i < pageFiles.length; i++) {
     issues.push(...findBrokenLinksInPage(pageFiles[i], contents[i], fileSlugs));

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -4,16 +4,14 @@
 // clients can subscribe to the same session channel and receive
 // identical events.
 
+import { appendFile } from "fs/promises";
 import type { IPubSub } from "../pub-sub/index.js";
 import {
   PUBSUB_CHANNELS,
   sessionChannel,
 } from "../../../src/config/pubsubChannels.js";
 import { log } from "../../system/logger/index.js";
-import {
-  updateHasUnread,
-  appendSessionLine,
-} from "../../utils/files/session-io.js";
+import { updateHasUnread } from "../../utils/files/session-io.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 
 // ── Types ──────────────────────────────────────────────────────
@@ -206,13 +204,13 @@ export async function pushToolResult(
   const session = store.get(chatSessionId);
   if (!session) return { kind: "skipped", reason: "unknown session" };
 
-  await appendSessionLine(
-    chatSessionId,
+  await appendFile(
+    session.resultsFilePath,
     JSON.stringify({
       source: "tool",
       type: EVENT_TYPES.toolResult,
       result,
-    }),
+    }) + "\n",
   );
   publishToSessionChannel(chatSessionId, {
     type: EVENT_TYPES.toolResult,

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -4,14 +4,16 @@
 // clients can subscribe to the same session channel and receive
 // identical events.
 
-import { appendFile } from "fs/promises";
 import type { IPubSub } from "../pub-sub/index.js";
 import {
   PUBSUB_CHANNELS,
   sessionChannel,
 } from "../../../src/config/pubsubChannels.js";
 import { log } from "../../system/logger/index.js";
-import { updateHasUnread } from "../../utils/files/session-io.js";
+import {
+  updateHasUnread,
+  appendSessionLine,
+} from "../../utils/files/session-io.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 
 // ── Types ──────────────────────────────────────────────────────
@@ -204,13 +206,13 @@ export async function pushToolResult(
   const session = store.get(chatSessionId);
   if (!session) return { kind: "skipped", reason: "unknown session" };
 
-  await appendFile(
-    session.resultsFilePath,
+  await appendSessionLine(
+    chatSessionId,
     JSON.stringify({
       source: "tool",
       type: EVENT_TYPES.toolResult,
       result,
-    }) + "\n",
+    }),
   );
   publishToSessionChannel(chatSessionId, {
     type: EVENT_TYPES.toolResult,

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -14,6 +14,7 @@ import path from "path";
 import { log } from "./logger/index.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 import { writeFileAtomicSync } from "../utils/files/atomic.js";
+import { readTextSafeSync } from "../utils/files/safe.js";
 
 export interface AppSettings {
   // Extra tool names appended to BASE_ALLOWED_TOOLS in
@@ -59,12 +60,8 @@ export function isAppSettings(value: unknown): value is AppSettings {
 
 export function loadSettings(): AppSettings {
   const file = settingsPath();
-  let raw: string;
-  try {
-    raw = fs.readFileSync(file, "utf-8");
-  } catch {
-    return { ...DEFAULT_SETTINGS };
-  }
+  const raw = readTextSafeSync(file);
+  if (raw === null) return { ...DEFAULT_SETTINGS };
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -218,12 +215,8 @@ export function isMcpConfigFile(value: unknown): value is McpConfigFile {
 
 export function loadMcpConfig(): McpConfigFile {
   const file = mcpConfigPath();
-  let raw: string;
-  try {
-    raw = fs.readFileSync(file, "utf-8");
-  } catch {
-    return { mcpServers: { ...DEFAULT_MCP.mcpServers } };
-  }
+  const raw = readTextSafeSync(file);
+  if (raw === null) return { mcpServers: { ...DEFAULT_MCP.mcpServers } };
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -52,10 +52,13 @@ function isStringArray(value: unknown): value is string[] {
   );
 }
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
 export function isAppSettings(value: unknown): value is AppSettings {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  return isStringArray(candidate.extraAllowedTools);
+  if (!isRecord(value)) return false;
+  return isStringArray(value.extraAllowedTools);
 }
 
 export function loadSettings(): AppSettings {
@@ -164,27 +167,31 @@ function isHttpUrl(value: string): boolean {
 }
 
 export function isMcpHttpSpec(value: unknown): value is McpHttpSpec {
-  if (typeof value !== "object" || value === null) return false;
-  const c = value as Record<string, unknown>;
-  if (c.type !== "http") return false;
-  if (typeof c.url !== "string" || !isHttpUrl(c.url)) return false;
-  if (c.headers !== undefined && !isStringRecord(c.headers)) return false;
-  if (c.enabled !== undefined && typeof c.enabled !== "boolean") return false;
+  if (!isRecord(value)) return false;
+
+  if (value.type !== "http") return false;
+  if (typeof value.url !== "string" || !isHttpUrl(value.url)) return false;
+  if (value.headers !== undefined && !isStringRecord(value.headers))
+    return false;
+  if (value.enabled !== undefined && typeof value.enabled !== "boolean")
+    return false;
   return true;
 }
 
 export function isMcpStdioSpec(value: unknown): value is McpStdioSpec {
-  if (typeof value !== "object" || value === null) return false;
-  const c = value as Record<string, unknown>;
-  if (c.type !== "stdio") return false;
-  if (typeof c.command !== "string" || c.command.length === 0) return false;
-  if (!STDIO_COMMAND_ALLOWLIST.has(c.command)) return false;
-  if (c.args !== undefined) {
-    if (!Array.isArray(c.args)) return false;
-    if (!c.args.every((a) => typeof a === "string")) return false;
+  if (!isRecord(value)) return false;
+
+  if (value.type !== "stdio") return false;
+  if (typeof value.command !== "string" || value.command.length === 0)
+    return false;
+  if (!STDIO_COMMAND_ALLOWLIST.has(value.command)) return false;
+  if (value.args !== undefined) {
+    if (!Array.isArray(value.args)) return false;
+    if (!value.args.every((a) => typeof a === "string")) return false;
   }
-  if (c.env !== undefined && !isStringRecord(c.env)) return false;
-  if (c.enabled !== undefined && typeof c.enabled !== "boolean") return false;
+  if (value.env !== undefined && !isStringRecord(value.env)) return false;
+  if (value.enabled !== undefined && typeof value.enabled !== "boolean")
+    return false;
   return true;
 }
 
@@ -201,9 +208,9 @@ export function isMcpServerId(value: unknown): value is string {
 }
 
 export function isMcpConfigFile(value: unknown): value is McpConfigFile {
-  if (typeof value !== "object" || value === null) return false;
-  const c = value as Record<string, unknown>;
-  const servers = c.mcpServers;
+  if (!isRecord(value)) return false;
+
+  const servers = value.mcpServers;
   if (typeof servers !== "object" || servers === null) return false;
   if (Array.isArray(servers)) return false;
   for (const [id, spec] of Object.entries(servers)) {

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -42,7 +42,7 @@ export async function saveImage(base64Data: string): Promise<string> {
   const filename = `${id}.png`;
   const absPath = path.join(IMAGES_DIR, filename);
   await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
-  return `${WORKSPACE_DIRS.images}/${filename}`;
+  return path.posix.join(WORKSPACE_DIRS.images, filename);
 }
 
 /** Overwrite an existing image file. The relativePath must start with "images/". */

--- a/server/utils/files/index.ts
+++ b/server/utils/files/index.ts
@@ -18,6 +18,8 @@ export {
 } from "./atomic.js";
 
 export {
+  isEnoent,
+  readTextSafeSync,
   statSafe,
   statSafeAsync,
   readDirSafe,
@@ -34,7 +36,6 @@ export {
 } from "./json.js";
 
 export {
-  isEnoent,
   resolveWorkspacePath,
   resolvePath,
   readWorkspaceText,

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -1,0 +1,238 @@
+// Domain I/O: workspace journal (summaries)
+//   conversations/summaries/_state.json        — journal state
+//   conversations/summaries/_index.md           — browseable index
+//   conversations/summaries/daily/YYYY/MM/DD.md — daily summaries
+//   conversations/summaries/topics/<slug>.md    — topic files
+//   conversations/summaries/archive/topics/     — archived topics
+//
+// All functions take optional `root` for test DI.
+// Path helpers (summariesRoot, dailyPathFor, topicPathFor) live in
+// journal/paths.ts — this module wraps them with I/O.
+
+import path from "node:path";
+import fsp from "node:fs/promises";
+import { workspacePath } from "../../workspace/paths.js";
+import { writeFileAtomic } from "./atomic.js";
+import { isEnoent } from "./workspace-io.js";
+import { log } from "../../system/logger/index.js";
+import {
+  summariesRoot,
+  dailyPathFor,
+  topicPathFor,
+  TOPICS_DIR,
+  INDEX_FILE,
+  STATE_FILE,
+  DAILY_DIR,
+  ARCHIVE_DIR,
+} from "../../workspace/journal/paths.js";
+
+const root = (r?: string) => r ?? workspacePath;
+
+// ── State ───────────────────────────────────────────────────────
+
+export async function readJournalState<T>(fallback: T, r?: string): Promise<T> {
+  const p = path.join(summariesRoot(root(r)), STATE_FILE);
+  try {
+    return JSON.parse(await fsp.readFile(p, "utf-8")) as T;
+  } catch (err) {
+    if (isEnoent(err)) return fallback;
+    log.error("journal-io", "readJournalState failed", { error: String(err) });
+    return fallback;
+  }
+}
+
+export async function writeJournalState(
+  state: unknown,
+  r?: string,
+): Promise<void> {
+  const p = path.join(summariesRoot(root(r)), STATE_FILE);
+  await writeFileAtomic(p, JSON.stringify(state, null, 2));
+}
+
+// ── Index ───────────────────────────────────────────────────────
+
+export async function writeJournalIndex(md: string, r?: string): Promise<void> {
+  const p = path.join(summariesRoot(root(r)), INDEX_FILE);
+  await writeFileAtomic(p, md);
+}
+
+// ── Daily summaries ─────────────────────────────────────────────
+
+export async function readDailySummary(
+  date: string,
+  r?: string,
+): Promise<string | null> {
+  try {
+    return await fsp.readFile(dailyPathFor(root(r), date), "utf-8");
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    log.error("journal-io", `readDailySummary(${date}) failed`, {
+      error: String(err),
+    });
+    return null;
+  }
+}
+
+export async function writeDailySummary(
+  date: string,
+  content: string,
+  r?: string,
+): Promise<void> {
+  await writeFileAtomic(dailyPathFor(root(r), date), content);
+}
+
+// ── Topics ──────────────────────────────────────────────────────
+
+export async function readTopicFile(
+  slug: string,
+  r?: string,
+): Promise<string | null> {
+  try {
+    return await fsp.readFile(topicPathFor(root(r), slug), "utf-8");
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    log.error("journal-io", `readTopicFile(${slug}) failed`, {
+      error: String(err),
+    });
+    return null;
+  }
+}
+
+export async function writeTopicFile(
+  slug: string,
+  content: string,
+  r?: string,
+): Promise<void> {
+  await writeFileAtomic(topicPathFor(root(r), slug), content);
+}
+
+/** Append content to an existing topic, or create a new file. */
+export async function appendOrCreateTopic(
+  slug: string,
+  content: string,
+  r?: string,
+): Promise<"created" | "updated"> {
+  const existing = await readTopicFile(slug, r);
+  if (existing === null) {
+    await writeTopicFile(slug, content, r);
+    return "created";
+  }
+  await writeTopicFile(slug, `${existing.trimEnd()}\n\n${content}\n`, r);
+  return "updated";
+}
+
+/** List topic slugs (filenames without .md). */
+export async function listTopicSlugs(r?: string): Promise<string[]> {
+  const dir = path.join(summariesRoot(root(r)), TOPICS_DIR);
+  try {
+    const files = await fsp.readdir(dir);
+    return files
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, ""));
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    log.error("journal-io", "listTopicSlugs failed", { error: String(err) });
+    return [];
+  }
+}
+
+/** Read all topic files at once. Returns slug→content map. */
+export async function readAllTopicFiles(
+  r?: string,
+): Promise<Map<string, string>> {
+  const dir = path.join(summariesRoot(root(r)), TOPICS_DIR);
+  const out = new Map<string, string>();
+  let files: string[];
+  try {
+    files = await fsp.readdir(dir);
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    if (!f.endsWith(".md")) continue;
+    try {
+      const content = await fsp.readFile(path.join(dir, f), "utf-8");
+      out.set(f.replace(/\.md$/, ""), content);
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return out;
+}
+
+/** Move a topic to the archive directory. Returns false if the
+ *  source doesn't exist or the move fails. */
+export async function archiveTopic(slug: string, r?: string): Promise<boolean> {
+  const src = topicPathFor(root(r), slug);
+  const dst = path.join(
+    summariesRoot(root(r)),
+    ARCHIVE_DIR,
+    TOPICS_DIR,
+    `${slug}.md`,
+  );
+  try {
+    await fsp.mkdir(path.dirname(dst), { recursive: true });
+    await fsp.rename(src, dst);
+    return true;
+  } catch (err) {
+    log.warn("journal-io", `archiveTopic(${slug}) failed`, {
+      error: String(err),
+    });
+    return false;
+  }
+}
+
+// ── Daily file listing ──────────────────────────────────────────
+
+export interface DailyFileEntry {
+  year: string;
+  month: string;
+  day: string;
+}
+
+export async function listDailyFiles(r?: string): Promise<DailyFileEntry[]> {
+  const dailyRoot = path.join(summariesRoot(root(r)), DAILY_DIR);
+  const out: DailyFileEntry[] = [];
+  let years: string[];
+  try {
+    years = await fsp.readdir(dailyRoot);
+  } catch {
+    return out;
+  }
+  for (const y of years) {
+    if (!/^\d{4}$/.test(y)) continue;
+    let months: string[];
+    try {
+      months = await fsp.readdir(path.join(dailyRoot, y));
+    } catch {
+      continue;
+    }
+    for (const m of months) {
+      if (!/^\d{2}$/.test(m)) continue;
+      let dayFiles: string[];
+      try {
+        dayFiles = await fsp.readdir(path.join(dailyRoot, y, m));
+      } catch {
+        continue;
+      }
+      for (const d of dayFiles) {
+        if (d.endsWith(".md")) {
+          out.push({ year: y, month: m, day: d.replace(/\.md$/, "") });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ── Archived topic count ────────────────────────────────────────
+
+export async function countArchivedTopics(r?: string): Promise<number> {
+  const dir = path.join(summariesRoot(root(r)), ARCHIVE_DIR, TOPICS_DIR);
+  try {
+    const files = await fsp.readdir(dir);
+    return files.filter((f) => f.endsWith(".md")).length;
+  } catch {
+    return 0;
+  }
+}

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -203,37 +203,43 @@ export interface DailyFileEntry {
 
 export async function listDailyFiles(r?: string): Promise<DailyFileEntry[]> {
   const dailyRoot = path.join(summariesRoot(root(r)), DAILY_DIR);
+  const years = await safeReaddir(dailyRoot);
   const out: DailyFileEntry[] = [];
-  let years: string[];
-  try {
-    years = await fsp.readdir(dailyRoot);
-  } catch {
-    return out;
+  for (const y of years.filter(isYearDir)) {
+    const entries = await listDaysForYear(dailyRoot, y);
+    out.push(...entries);
   }
-  for (const y of years) {
-    if (!/^\d{4}$/.test(y)) continue;
-    let months: string[];
-    try {
-      months = await fsp.readdir(path.join(dailyRoot, y));
-    } catch {
-      continue;
-    }
-    for (const m of months) {
-      if (!/^\d{2}$/.test(m)) continue;
-      let dayFiles: string[];
-      try {
-        dayFiles = await fsp.readdir(path.join(dailyRoot, y, m));
-      } catch {
-        continue;
-      }
-      for (const d of dayFiles) {
-        if (d.endsWith(".md")) {
-          out.push({ year: y, month: m, day: d.replace(/\.md$/, "") });
-        }
+  return out;
+}
+
+const YEAR_RE = /^\d{4}$/;
+const MONTH_RE = /^\d{2}$/;
+const isYearDir = (name: string) => YEAR_RE.test(name);
+const isMonthDir = (name: string) => MONTH_RE.test(name);
+
+async function listDaysForYear(
+  dailyRoot: string,
+  year: string,
+): Promise<DailyFileEntry[]> {
+  const months = await safeReaddir(path.join(dailyRoot, year));
+  const out: DailyFileEntry[] = [];
+  for (const m of months.filter(isMonthDir)) {
+    const dayFiles = await safeReaddir(path.join(dailyRoot, year, m));
+    for (const d of dayFiles) {
+      if (d.endsWith(".md")) {
+        out.push({ year, month: m, day: d.replace(/\.md$/, "") });
       }
     }
   }
   return out;
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
 }
 
 // ── Archived topic count ────────────────────────────────────────

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -103,10 +103,9 @@ export async function readTopicFile(
     return await fsp.readFile(topicPathFor(root(r), slug), "utf-8");
   } catch (err) {
     if (isEnoent(err)) return null;
-    log.error("journal-io", `readTopicFile(${slug}) failed`, {
-      error: String(err),
-    });
-    return null;
+    // EACCES/EPERM must propagate — swallowing them would cause
+    // appendOrCreateTopic to clobber an unreadable file.
+    throw err;
   }
 }
 

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 import fsp from "node:fs/promises";
 import { workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
-import { isEnoent } from "./workspace-io.js";
+import { isEnoent } from "./safe.js";
 import { log } from "../../system/logger/index.js";
 import {
   summariesRoot,

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -26,9 +26,21 @@ import {
   ARCHIVE_DIR,
 } from "../../workspace/journal/paths.js";
 
+import fs from "node:fs";
+
 const root = (r?: string) => r ?? workspacePath;
 
 // ── State ───────────────────────────────────────────────────────
+
+export function journalStateExists(r?: string): boolean {
+  const p = path.join(summariesRoot(root(r)), STATE_FILE);
+  try {
+    fs.statSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function readJournalState<T>(fallback: T, r?: string): Promise<T> {
   const p = path.join(summariesRoot(root(r)), STATE_FILE);

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -6,15 +6,36 @@
 import fs from "fs";
 import path from "path";
 import { writeFileAtomic } from "./atomic.js";
+import { isEnoent } from "./workspace-io.js";
+import { log } from "../../system/logger/index.js";
 
-// ── Sync (legacy callers — todos, scheduler, columns) ───────────
+// ── Sync helpers ────────────────────────────────────────────────
 
+/**
+ * Read and parse a JSON file synchronously. Returns `defaultValue`
+ * on ENOENT (file not yet created) or JSON corruption (logs the
+ * error but doesn't crash — user data files must not take down the
+ * server). Rethrows unexpected errors (EACCES, EPERM).
+ */
 export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
+  let raw: string;
   try {
-    if (!fs.existsSync(filePath)) return defaultValue;
-    const parsed: T = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    return parsed;
-  } catch {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (err) {
+    if (isEnoent(err)) return defaultValue;
+    log.error("json", "loadJsonFile read failed", {
+      path: filePath,
+      error: String(err),
+    });
+    throw err;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    log.error("json", "loadJsonFile parse failed, using default", {
+      path: filePath,
+      error: String(err),
+    });
     return defaultValue;
   }
 }

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -6,7 +6,7 @@
 import fs from "fs";
 import path from "path";
 import { writeFileAtomic } from "./atomic.js";
-import { isEnoent } from "./workspace-io.js";
+import { isEnoent } from "./safe.js";
 import { log } from "../../system/logger/index.js";
 
 // ── Sync helpers ────────────────────────────────────────────────

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -13,7 +13,7 @@ export async function saveMarkdown(content: string): Promise<string> {
     content,
     "utf-8",
   );
-  return `${WORKSPACE_DIRS.markdowns}/${filename}`;
+  return path.posix.join(WORKSPACE_DIRS.markdowns, filename);
 }
 
 /** Read a markdown file and return its content. */

--- a/server/utils/files/naming.ts
+++ b/server/utils/files/naming.ts
@@ -1,0 +1,29 @@
+// Workspace file naming conventions.
+//
+// Centralizes the `slug-${Date.now()}.ext` pattern used across
+// multiple plugins (chart, presentHtml, markdown, spreadsheet, image).
+// Call sites pass a human title + extension; this module handles
+// slugification and timestamp suffixing.
+
+import path from "node:path";
+import { slugify } from "../slug.js";
+
+/**
+ * Build a workspace-relative path for a new artifact file.
+ *
+ * @param dir  Workspace-relative directory (e.g. WORKSPACE_DIRS.charts)
+ * @param title  Human-readable title (slugified for the filename)
+ * @param ext  File extension with leading dot (e.g. ".html", ".json")
+ * @param fallbackSlug  Slug to use when title is empty/undefined
+ * @returns  Workspace-relative path like "artifacts/charts/sales-1776135210389.chart.json"
+ */
+export function buildArtifactPath(
+  dir: string,
+  title: string | undefined,
+  ext: string,
+  fallbackSlug = "file",
+): string {
+  const slug = title ? slugify(title) || fallbackSlug : fallbackSlug;
+  const fname = `${slug}-${Date.now()}${ext}`;
+  return path.posix.join(dir, fname);
+}

--- a/server/utils/files/roles-io.ts
+++ b/server/utils/files/roles-io.ts
@@ -1,0 +1,45 @@
+// Domain I/O: custom roles
+//   config/roles/<id>.json
+//
+// Optional `root` for test DI.
+
+import path from "node:path";
+import fs from "node:fs";
+import { WORKSPACE_DIRS } from "../../workspace/paths.js";
+import { workspacePath } from "../../workspace/paths.js";
+import { writeFileAtomicSync } from "./atomic.js";
+import { isEnoent } from "./safe.js";
+
+const root = (r?: string) => r ?? workspacePath;
+
+function roleFilePath(id: string, r?: string): string {
+  return path.join(root(r), WORKSPACE_DIRS.roles, `${id}.json`);
+}
+
+/** Check if a custom role file exists. */
+export function roleExists(id: string, r?: string): boolean {
+  try {
+    fs.statSync(roleFilePath(id, r));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Delete a custom role file. Returns false if not found. */
+export function deleteRole(id: string, r?: string): boolean {
+  try {
+    fs.unlinkSync(roleFilePath(id, r));
+    return true;
+  } catch (err) {
+    if (isEnoent(err)) return false;
+    throw err;
+  }
+}
+
+/** Save (create or overwrite) a custom role file atomically. */
+export function saveRole(id: string, data: unknown, r?: string): void {
+  const dir = path.join(root(r), WORKSPACE_DIRS.roles);
+  fs.mkdirSync(dir, { recursive: true });
+  writeFileAtomicSync(roleFilePath(id, r), JSON.stringify(data, null, 2));
+}

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -10,6 +10,16 @@
 import fs from "fs";
 import path from "path";
 
+/** Check if an error is ENOENT (file/dir not found). */
+export function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "ENOENT"
+  );
+}
+
 /** Read a text file by absolute path. Null on ENOENT. */
 export function readTextSafeSync(absPath: string): string | null {
   try {

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -20,7 +20,25 @@ export function isEnoent(err: unknown): boolean {
   );
 }
 
-/** Read a text file by absolute path. Null on ENOENT. */
+/** Read a binary file by absolute path. Null on ENOENT. */
+export function readBinarySafeSync(absPath: string): Buffer | null {
+  try {
+    return fs.readFileSync(absPath);
+  } catch {
+    return null;
+  }
+}
+
+/** Read a text file by absolute path (async). Null on ENOENT. */
+export async function readTextSafe(absPath: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(absPath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/** Read a text file by absolute path (sync). Null on ENOENT. */
 export function readTextSafeSync(absPath: string): string | null {
   try {
     return fs.readFileSync(absPath, "utf-8");

--- a/server/utils/files/scheduler-io.ts
+++ b/server/utils/files/scheduler-io.ts
@@ -5,25 +5,17 @@
 
 import { WORKSPACE_FILES } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
-import { resolvePath, isEnoent } from "./workspace-io.js";
+import { resolvePath } from "./workspace-io.js";
+import { loadJsonFile } from "./json.js";
 import { writeFileAtomicSync } from "./atomic.js";
-import { log } from "../../system/logger/index.js";
-import fs from "fs";
 
 const root = (r?: string) => r ?? workspacePath;
 
 export function loadSchedulerItems<T>(fallback: T, r?: string): T {
-  const p = resolvePath(root(r), WORKSPACE_FILES.schedulerItems);
-  try {
-    return JSON.parse(fs.readFileSync(p, "utf-8")) as T;
-  } catch (err) {
-    if (isEnoent(err)) return fallback;
-    log.error("scheduler-io", "failed to read items, using fallback", {
-      path: p,
-      error: String(err),
-    });
-    return fallback;
-  }
+  return loadJsonFile(
+    resolvePath(root(r), WORKSPACE_FILES.schedulerItems),
+    fallback,
+  );
 }
 
 export function saveSchedulerItems(items: unknown, r?: string): void {

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -8,10 +8,20 @@ import { appendFile } from "fs/promises";
 import path from "node:path";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
-import { readTextUnder, writeTextUnder, resolvePath } from "./workspace-io.js";
+import {
+  readTextUnder,
+  writeTextUnder,
+  resolvePath,
+  ensureWorkspaceDir,
+} from "./workspace-io.js";
 
 const CHAT = WORKSPACE_DIRS.chat;
 const root = (r?: string) => r ?? workspacePath;
+
+/** Ensure the chat directory exists. Called once at session start. */
+export function ensureChatDir(): void {
+  ensureWorkspaceDir(CHAT);
+}
 
 function metaRel(id: string): string {
   return path.posix.join(CHAT, `${id}.json`);

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -42,17 +42,33 @@ export interface SessionMeta {
   [key: string]: unknown;
 }
 
+export type ReadMetaResult =
+  | { kind: "missing" }
+  | { kind: "ok"; meta: SessionMeta }
+  | { kind: "corrupt"; raw: string };
+
+/** Read session metadata with full outcome discrimination. */
+export async function readSessionMetaFull(
+  id: string,
+  r?: string,
+): Promise<ReadMetaResult> {
+  const raw = await readTextUnder(root(r), metaRel(id));
+  if (raw === null) return { kind: "missing" };
+  try {
+    return { kind: "ok", meta: JSON.parse(raw) as SessionMeta };
+  } catch {
+    return { kind: "corrupt", raw };
+  }
+}
+
+/** Convenience: returns the meta or null. Treats corrupt as null
+ *  (callers that need to distinguish use readSessionMetaFull). */
 export async function readSessionMeta(
   id: string,
   r?: string,
 ): Promise<SessionMeta | null> {
-  const raw = await readTextUnder(root(r), metaRel(id));
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as SessionMeta;
-  } catch {
-    return null;
-  }
+  const result = await readSessionMetaFull(id, r);
+  return result.kind === "ok" ? result.meta : null;
 }
 
 export async function writeSessionMeta(

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -46,7 +46,7 @@ export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
     JSON.stringify(sheets),
     "utf-8",
   );
-  return `${WORKSPACE_DIRS.spreadsheets}/${filename}`;
+  return path.posix.join(WORKSPACE_DIRS.spreadsheets, filename);
 }
 
 /** Overwrite an existing spreadsheet file. */

--- a/server/utils/files/todos-io.ts
+++ b/server/utils/files/todos-io.ts
@@ -6,28 +6,14 @@
 
 import { WORKSPACE_FILES } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
-import { resolvePath, isEnoent } from "./workspace-io.js";
+import { resolvePath } from "./workspace-io.js";
+import { loadJsonFile } from "./json.js";
 import { writeFileAtomicSync } from "./atomic.js";
-import { log } from "../../system/logger/index.js";
-import fs from "fs";
 
 const root = (r?: string) => r ?? workspacePath;
 
-function readJsonOrFallback<T>(absPath: string, fallback: T): T {
-  try {
-    return JSON.parse(fs.readFileSync(absPath, "utf-8")) as T;
-  } catch (err) {
-    if (isEnoent(err)) return fallback;
-    log.error("todos-io", "failed to read JSON, using fallback", {
-      path: absPath,
-      error: String(err),
-    });
-    return fallback;
-  }
-}
-
 export function loadTodos<T>(fallback: T, r?: string): T {
-  return readJsonOrFallback(
+  return loadJsonFile(
     resolvePath(root(r), WORKSPACE_FILES.todosItems),
     fallback,
   );
@@ -41,7 +27,7 @@ export function saveTodos(items: unknown, r?: string): void {
 }
 
 export function loadColumns<T>(fallback: T, r?: string): T {
-  return readJsonOrFallback(
+  return loadJsonFile(
     resolvePath(root(r), WORKSPACE_FILES.todosColumns),
     fallback,
   );

--- a/server/utils/files/workspace-io.ts
+++ b/server/utils/files/workspace-io.ts
@@ -16,18 +16,7 @@ import path from "path";
 import { workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic, writeFileAtomicSync } from "./atomic.js";
 import { log } from "../../system/logger/index.js";
-
-// Only ENOENT (file/dir doesn't exist) is silently swallowed.
-// EACCES, EPERM, EISDIR, and other unexpected errors are logged
-// and re-thrown so production failures are diagnosable.
-export function isEnoent(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code: string }).code === "ENOENT"
-  );
-}
+import { isEnoent } from "./safe.js";
 
 function rethrowUnexpected(err: unknown, context: string): null {
   if (isEnoent(err)) return null;

--- a/server/utils/request.ts
+++ b/server/utils/request.ts
@@ -1,0 +1,32 @@
+// Express request helpers — shared query/param extraction.
+//
+// Centralizes patterns that were duplicated across route handlers
+// (3+ different ways to read `req.query.session`).
+
+// Use a minimal interface so the helpers work with any Express
+// Request generic (Request<object, ...>, Request<Params, ...>, etc.)
+// without type incompatibility.
+interface HasQuery {
+  query: Record<string, unknown>;
+}
+
+/**
+ * Extract the session ID from `req.query.session`.
+ * Returns the string value, or "" if missing/non-string.
+ */
+export function getSessionQuery(req: HasQuery): string {
+  const raw = req.query.session;
+  return typeof raw === "string" ? raw : "";
+}
+
+/**
+ * Extract an optional string query parameter.
+ * Returns the string value, or undefined if missing/non-string.
+ */
+export function getOptionalStringQuery(
+  req: HasQuery,
+  key: string,
+): string | undefined {
+  const raw = req.query[key];
+  return typeof raw === "string" ? raw : undefined;
+}

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -12,7 +12,12 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
+import {
+  writeDailySummary,
+  readTopicFile,
+  writeTopicFile,
+  appendOrCreateTopic,
+} from "../../utils/files/journal-io.js";
 import {
   type Summarize,
   type SessionExcerpt,
@@ -273,7 +278,7 @@ async function writeDailySummaryForDate(
     `${dayPart}.md`,
   );
   const content = rewriteWorkspaceLinks(dailyFileWsPath, rawMarkdown);
-  await writeDailySummary(workspaceRoot, date, content);
+  await writeDailySummary(date, content, workspaceRoot);
 }
 
 // Apply every topic update the archivist asked for, keeping the
@@ -760,64 +765,15 @@ async function readAllTopics(
   return out;
 }
 
-async function writeDailySummary(
-  workspaceRoot: string,
-  date: string,
-  content: string,
-): Promise<void> {
-  const p = dailyPathFor(workspaceRoot, date);
-  await writeFileAtomic(p, content);
-}
-
-// If the file doesn't exist, write `content` fresh; otherwise append
-// it after a blank line. Returns "created" or "updated" so the caller
-// can report which action was taken.
-//
-// Distinguishes a true missing file (ENOENT) from other read errors
-// (permission denied, I/O failure) — without this, a transient EACCES
-// on an existing topic would silently overwrite it.
-//
-// Exported for unit testing in test/journal/test_appendOrCreate.ts.
-export async function appendOrCreate(
-  filePath: string,
-  content: string,
-): Promise<"created" | "updated"> {
-  let existing: string;
-  try {
-    existing = await fsp.readFile(filePath, "utf-8");
-  } catch (err) {
-    if (
-      typeof err === "object" &&
-      err !== null &&
-      "code" in err &&
-      err.code === "ENOENT"
-    ) {
-      await writeFileAtomic(filePath, content);
-      return "created";
-    }
-    throw err;
-  }
-  await writeFileAtomic(filePath, `${existing.trimEnd()}\n\n${content}\n`);
-  return "updated";
-}
-
 async function applyTopicUpdate(
   workspaceRoot: string,
   update: TopicUpdate,
 ): Promise<"created" | "updated"> {
-  const p = topicPathFor(workspaceRoot, update.slug);
-  await fsp.mkdir(path.dirname(p), { recursive: true });
-
-  if (update.action === "create") {
-    // If the file already exists (e.g. the LLM mis-classified), treat
-    // it as an append so we don't clobber prior content.
-    return appendOrCreate(p, update.content);
+  if (update.action === "create" || update.action === "append") {
+    return appendOrCreateTopic(update.slug, update.content, workspaceRoot);
   }
-  if (update.action === "rewrite") {
-    const existed = (await readTextOrNull(p)) !== null;
-    await writeFileAtomic(p, update.content);
-    return existed ? "updated" : "created";
-  }
-  // append
-  return appendOrCreate(p, update.content);
+  // rewrite
+  const existed = (await readTopicFile(update.slug, workspaceRoot)) !== null;
+  await writeTopicFile(update.slug, update.content, workspaceRoot);
+  return existed ? "updated" : "created";
 }

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -547,7 +547,7 @@ async function loadSessionExcerptsByDate(
 
   const stat = await statUnder(
     workspaceRoot,
-    `${WORKSPACE_DIRS.chat}/${sessionId}.jsonl`,
+    path.posix.join(WORKSPACE_DIRS.chat, `${sessionId}.jsonl`),
   );
   const fallbackDate = toIsoDate(stat?.mtimeMs ?? Date.now());
 

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -14,10 +14,17 @@ import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 import {
   writeDailySummary,
+  readDailySummary,
   readTopicFile,
   writeTopicFile,
   appendOrCreateTopic,
+  readAllTopicFiles,
 } from "../../utils/files/journal-io.js";
+import {
+  readSessionMeta as readSessionMetaIO,
+  readSessionJsonl as readSessionJsonlIO,
+} from "../../utils/files/session-io.js";
+import { statUnder } from "../../utils/files/workspace-io.js";
 import {
   type Summarize,
   type SessionExcerpt,
@@ -32,14 +39,7 @@ import {
   isDailyArchivistOutput,
   ClaudeCliNotFoundError,
 } from "./archivist.js";
-import {
-  summariesRoot,
-  dailyPathFor,
-  topicPathFor,
-  toIsoDate,
-  slugify,
-  TOPICS_DIR,
-} from "./paths.js";
+import { toIsoDate, slugify } from "./paths.js";
 import {
   findDirtySessions,
   applyProcessed,
@@ -47,7 +47,6 @@ import {
 } from "./diff.js";
 import { rewriteWorkspaceLinks } from "./linkRewrite.js";
 import { writeState, type JournalState } from "./state.js";
-import { readTextOrNull } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 
@@ -103,7 +102,11 @@ export async function runDailyPass(
   const { dirty } = findDirtySessions(eligible, state.processedSessions);
   if (dirty.length === 0) return { nextState: { ...state }, result };
 
-  const perSessionExcerpts = await loadDirtySessionExcerpts(chatDir, dirty);
+  const perSessionExcerpts = await loadDirtySessionExcerpts(
+    chatDir,
+    dirty,
+    workspaceRoot,
+  );
   const { dayBuckets, sessionToDays } = buildDayBuckets(perSessionExcerpts);
 
   // Note: we intentionally do NOT early-return when `dayBuckets` is
@@ -195,7 +198,7 @@ async function processOneDay(
   existingTopics: ExistingTopicSnapshot[],
   summarize: Summarize,
 ): Promise<DayOutcome> {
-  const existingDaily = await readTextOrNull(dailyPathFor(workspaceRoot, date));
+  const existingDaily = await readDailySummary(date, workspaceRoot);
   const input: DailyArchivistInput = {
     date,
     existingDailySummary: existingDaily,
@@ -324,7 +327,7 @@ async function refreshTopicSnapshot(
   slug: string,
   existingTopics: ExistingTopicSnapshot[],
 ): Promise<void> {
-  const newBody = await readTextOrNull(topicPathFor(workspaceRoot, slug));
+  const newBody = await readTopicFile(slug, workspaceRoot);
   if (newBody === null) return;
   const snapshot: ExistingTopicSnapshot = { slug, content: newBody };
   const idx = existingTopics.findIndex((t) => t.slug === slug);
@@ -488,11 +491,16 @@ export function advanceJournalState(
 async function loadDirtySessionExcerpts(
   chatDir: string,
   dirty: readonly string[],
+  workspaceRoot: string,
 ): Promise<Map<string, Map<string, SessionExcerpt>>> {
   const perSession = new Map<string, Map<string, SessionExcerpt>>();
   for (const sessionId of dirty) {
     try {
-      const excerpts = await loadSessionExcerptsByDate(chatDir, sessionId);
+      const excerpts = await loadSessionExcerptsByDate(
+        chatDir,
+        sessionId,
+        workspaceRoot,
+      );
       if (excerpts.size > 0) perSession.set(sessionId, excerpts);
     } catch (err) {
       log.warn("journal", "failed to load session", {
@@ -531,19 +539,17 @@ async function listSessionMetas(chatDir: string): Promise<SessionFileMeta[]> {
 async function loadSessionExcerptsByDate(
   chatDir: string,
   sessionId: string,
+  workspaceRoot: string,
 ): Promise<Map<string, SessionExcerpt>> {
-  const jsonlPath = path.join(chatDir, `${sessionId}.jsonl`);
-  const metaPath = path.join(chatDir, `${sessionId}.json`);
+  const roleId = await readRoleIdFromMeta(sessionId, workspaceRoot);
+  const raw = await readSessionJsonlIO(sessionId, workspaceRoot);
+  if (!raw) return new Map();
 
-  const roleId = await readRoleId(metaPath);
-  const raw = await fsp.readFile(jsonlPath, "utf-8");
-
-  // We don't have per-event timestamps in the legacy jsonl format,
-  // so fall back to the file's mtime for unscoped events. If the
-  // session spans midnight we still bucket everything into whichever
-  // date the mtime lands in — acceptable for a personal workspace
-  // where most sessions are short-lived.
-  const fallbackDate = toIsoDate((await fsp.stat(jsonlPath)).mtimeMs);
+  const stat = await statUnder(
+    workspaceRoot,
+    `${WORKSPACE_DIRS.chat}/${sessionId}.jsonl`,
+  );
+  const fallbackDate = toIsoDate(stat?.mtimeMs ?? Date.now());
 
   const parsedEvents = parseJsonlEvents(raw, MAX_EVENTS_PER_SESSION);
   return bucketParsedEvents(parsedEvents, sessionId, roleId, fallbackDate);
@@ -623,10 +629,13 @@ export function bucketParsedEvents(
   return buckets;
 }
 
-async function readRoleId(metaPath: string): Promise<string> {
+async function readRoleIdFromMeta(
+  sessionId: string,
+  workspaceRoot: string,
+): Promise<string> {
   try {
-    const meta = JSON.parse(await fsp.readFile(metaPath, "utf-8"));
-    if (typeof meta.roleId === "string") return meta.roleId;
+    const meta = await readSessionMetaIO(sessionId, workspaceRoot);
+    if (meta && typeof meta.roleId === "string") return meta.roleId;
   } catch {
     // ignore
   }
@@ -744,23 +753,10 @@ function truncate(s: string, max: number): string {
 async function readAllTopics(
   workspaceRoot: string,
 ): Promise<ExistingTopicSnapshot[]> {
-  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
-  let entries: string[];
-  try {
-    entries = await fsp.readdir(dir);
-  } catch {
-    return [];
-  }
+  const topicMap = await readAllTopicFiles(workspaceRoot);
   const out: ExistingTopicSnapshot[] = [];
-  for (const name of entries) {
-    if (!name.endsWith(".md")) continue;
-    const slug = name.replace(/\.md$/, "");
-    try {
-      const content = await fsp.readFile(path.join(dir, name), "utf-8");
-      out.push({ slug, content });
-    } catch {
-      // ignore
-    }
+  for (const [slug, content] of topicMap) {
+    out.push({ slug, content });
   }
   return out;
 }

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -7,10 +7,14 @@
 // All failures are caught and logged here; nothing ever bubbles
 // back to the request handler.
 
-import fsp from "node:fs/promises";
-import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
+import {
+  writeJournalIndex,
+  listTopicSlugs as listTopicSlugsIO,
+  readTopicFile,
+  listDailyFiles as listDailyFilesIO,
+  countArchivedTopics as countArchivedIO,
+} from "../../utils/files/journal-io.js";
 import {
   readState,
   writeState,
@@ -24,13 +28,6 @@ import {
   type IndexTopicEntry,
   type IndexDailyEntry,
 } from "./indexFile.js";
-import {
-  summariesRoot,
-  DAILY_DIR,
-  TOPICS_DIR,
-  ARCHIVE_DIR,
-  INDEX_FILE,
-} from "./paths.js";
 import {
   runClaudeCli,
   ClaudeCliNotFoundError,
@@ -171,96 +168,37 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
 
 async function rebuildIndex(workspaceRoot: string): Promise<void> {
   const topics = await walkTopics(workspaceRoot);
-  const days = await walkDailyFiles(workspaceRoot);
-  const archivedCount = await countArchivedTopics(workspaceRoot);
+  const dailyEntries = await listDailyFilesIO(workspaceRoot);
+  const days: IndexDailyEntry[] = dailyEntries.map((e) => ({
+    date: `${e.year}-${e.month}-${e.day}`,
+  }));
+  const archivedCount = await countArchivedIO(workspaceRoot);
   const md = buildIndexMarkdown({
     topics,
     days,
     archivedTopicCount: archivedCount,
     builtAtIso: new Date().toISOString(),
   });
-  const p = path.join(summariesRoot(workspaceRoot), INDEX_FILE);
-  await writeFileAtomic(p, md);
+  await writeJournalIndex(md, workspaceRoot);
 }
 
 async function walkTopics(workspaceRoot: string): Promise<IndexTopicEntry[]> {
-  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
-  let names: string[];
-  try {
-    names = await fsp.readdir(dir);
-  } catch {
-    return [];
-  }
+  const slugs = await listTopicSlugsIO(workspaceRoot);
   const out: IndexTopicEntry[] = [];
-  for (const name of names) {
-    if (!name.endsWith(".md")) continue;
-    const slug = name.replace(/\.md$/, "");
-    const full = path.join(dir, name);
-    try {
-      const [stat, content] = await Promise.all([
-        fsp.stat(full),
-        fsp.readFile(full, "utf-8"),
-      ]);
-      out.push({
-        slug,
-        title: extractFirstH1(content) ?? undefined,
-        lastUpdatedIso: new Date(stat.mtimeMs).toISOString(),
-      });
-    } catch {
-      out.push({ slug });
-    }
+  for (const slug of slugs) {
+    const content = await readTopicFile(slug, workspaceRoot);
+    out.push({
+      slug,
+      title: content ? (extractFirstH1(content) ?? undefined) : undefined,
+    });
   }
   return out;
 }
 
-// Returns the entries of `dir`, or [] if `dir` is missing / unreadable.
-// Centralizes the "missing parent directory is fine" idiom that the
-// daily-files walker leans on.
-async function safeReaddir(dir: string): Promise<string[]> {
-  try {
-    return await fsp.readdir(dir);
-  } catch {
-    return [];
-  }
-}
-
-const YEAR_PATTERN = /^\d{4}$/;
-const MONTH_PATTERN = /^\d{2}$/;
 const DAY_FILE_PATTERN = /^(\d{2})\.md$/;
 
 // Pure: returns the two-digit day if `name` matches `DD.md`, else null.
 export function parseDailyFilename(name: string): string | null {
   const match = DAY_FILE_PATTERN.exec(name);
   return match ? (match[1] ?? null) : null;
-}
-
-async function walkDailyFiles(
-  workspaceRoot: string,
-): Promise<IndexDailyEntry[]> {
-  const root = path.join(summariesRoot(workspaceRoot), DAILY_DIR);
-  const out: IndexDailyEntry[] = [];
-  const years = (await safeReaddir(root)).filter((y) => YEAR_PATTERN.test(y));
-  for (const y of years) {
-    const months = (await safeReaddir(path.join(root, y))).filter((m) =>
-      MONTH_PATTERN.test(m),
-    );
-    for (const m of months) {
-      const dayFiles = await safeReaddir(path.join(root, y, m));
-      for (const d of dayFiles) {
-        const day = parseDailyFilename(d);
-        if (day) out.push({ date: `${y}-${m}-${day}` });
-      }
-    }
-  }
-  return out;
-}
-
-async function countArchivedTopics(workspaceRoot: string): Promise<number> {
-  const dir = path.join(summariesRoot(workspaceRoot), ARCHIVE_DIR, TOPICS_DIR);
-  try {
-    const entries = await fsp.readdir(dir);
-    return entries.filter((e) => e.endsWith(".md")).length;
-  } catch {
-    return 0;
-  }
 }

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -3,10 +3,12 @@
 // two can evolve independently and so the optimizer stays opt-in
 // from the top-level runner.
 
-import fsp from "node:fs/promises";
-import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
+import {
+  writeTopicFile,
+  readAllTopicFiles,
+  archiveTopic,
+} from "../../utils/files/journal-io.js";
 import {
   type Summarize,
   type OptimizationTopicSnapshot,
@@ -16,13 +18,7 @@ import {
   isOptimizationOutput,
   ClaudeCliNotFoundError,
 } from "./archivist.js";
-import {
-  summariesRoot,
-  topicPathFor,
-  archivedTopicPathFor,
-  slugify,
-  TOPICS_DIR,
-} from "./paths.js";
+import { slugify } from "./paths.js";
 import type { JournalState } from "./state.js";
 import { log } from "../../system/logger/index.js";
 
@@ -88,10 +84,7 @@ async function executeMergePlans(
   mergedSlugs: string[],
 ): Promise<void> {
   for (const plan of plans) {
-    await writeFileAtomic(
-      topicPathFor(workspaceRoot, plan.intoSlug),
-      plan.newContent,
-    );
+    await writeTopicFile(plan.intoSlug, plan.newContent, workspaceRoot);
     for (const src of plan.fromSlugs) {
       // Only record the merge as successful if the source file
       // actually moved. If moveToArchive fails (missing file, IO
@@ -187,49 +180,20 @@ export async function runOptimizationPass(
 async function loadTopicHeads(
   workspaceRoot: string,
 ): Promise<OptimizationTopicSnapshot[]> {
-  const dir = path.join(summariesRoot(workspaceRoot), TOPICS_DIR);
-  let entries: string[];
-  try {
-    entries = await fsp.readdir(dir);
-  } catch {
-    return [];
-  }
+  const topicMap = await readAllTopicFiles(workspaceRoot);
   const out: OptimizationTopicSnapshot[] = [];
-  for (const name of entries) {
-    if (!name.endsWith(".md")) continue;
-    const slug = name.replace(/\.md$/, "");
-    try {
-      const full = await fsp.readFile(path.join(dir, name), "utf-8");
-      out.push({
-        slug,
-        headContent: full.slice(0, OPTIMIZER_HEAD_CHARS),
-      });
-    } catch {
-      // ignore
-    }
+  for (const [slug, content] of topicMap) {
+    out.push({
+      slug,
+      headContent: content.slice(0, OPTIMIZER_HEAD_CHARS),
+    });
   }
   return out;
 }
 
-// Move a topic file into archive/topics/. Returns true on success,
-// false if the source didn't exist or rename failed — the caller
-// uses the boolean to decide whether to update state for this slug.
 async function moveToArchive(
   workspaceRoot: string,
   slug: string,
 ): Promise<boolean> {
-  const src = topicPathFor(workspaceRoot, slug);
-  const dst = archivedTopicPathFor(workspaceRoot, slug);
-  try {
-    await fsp.mkdir(path.dirname(dst), { recursive: true });
-    await fsp.rename(src, dst);
-    return true;
-  } catch (err) {
-    // Source may not exist (e.g. the LLM named a slug that was
-    // never a real file) or the rename hit an unexpected IO error.
-    // Log and return false — the caller leaves state untouched for
-    // this slug so the in-memory knownTopics stays accurate.
-    log.warn("journal", "could not archive", { slug, error: String(err) });
-    return false;
-  }
+  return archiveTopic(slug, workspaceRoot);
 }

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -87,10 +87,10 @@ async function executeMergePlans(
     await writeTopicFile(plan.intoSlug, plan.newContent, workspaceRoot);
     for (const src of plan.fromSlugs) {
       // Only record the merge as successful if the source file
-      // actually moved. If moveToArchive fails (missing file, IO
+      // actually moved. If archiveTopic fails (missing file, IO
       // error) we leave the source out of the removed set so the
       // in-memory knownTopics state stays accurate.
-      if (!(await moveToArchive(workspaceRoot, src))) continue;
+      if (!(await archiveTopic(src, workspaceRoot))) continue;
       removed.add(src);
       mergedSlugs.push(src);
     }
@@ -106,7 +106,7 @@ async function executeArchives(
   for (const raw of rawSlugs) {
     const slug = slugify(raw);
     if (removed.has(slug)) continue;
-    if (!(await moveToArchive(workspaceRoot, slug))) continue;
+    if (!(await archiveTopic(slug, workspaceRoot))) continue;
     removed.add(slug);
     archivedSlugs.push(slug);
   }
@@ -189,11 +189,4 @@ async function loadTopicHeads(
     });
   }
   return out;
-}
-
-async function moveToArchive(
-  workspaceRoot: string,
-  slug: string,
-): Promise<boolean> {
-  return archiveTopic(slug, workspaceRoot);
 }

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -7,12 +7,11 @@
 // them without touching disk. Filesystem helpers at the bottom wrap
 // those pure functions with atomic read/write.
 
-import fs from "node:fs";
-import fsp from "node:fs/promises";
-import path from "node:path";
-import { summariesRoot, STATE_FILE } from "./paths.js";
-import { log } from "../../system/logger/index.js";
-import { writeJsonAtomic } from "../../utils/files/index.js";
+import {
+  readJournalState as readJournalStateRaw,
+  writeJournalState as writeJournalStateRaw,
+  journalStateExists as journalStateExistsRaw,
+} from "../../utils/files/journal-io.js";
 
 // Bump this when the schema changes in a backwards-incompatible way.
 // Older state files are treated as corrupted and replaced with a
@@ -122,51 +121,20 @@ export function isOptimizationDue(state: JournalState, nowMs: number): boolean {
   return nowMs - last >= intervalMs;
 }
 
-// --- Filesystem helpers --------------------------------------------
-
-export function statePathFor(workspaceRoot: string): string {
-  return path.join(summariesRoot(workspaceRoot), STATE_FILE);
-}
+// --- Filesystem helpers (delegated to journal-io) --------------------
 
 export async function readState(workspaceRoot: string): Promise<JournalState> {
-  const p = statePathFor(workspaceRoot);
-  try {
-    const raw = await fsp.readFile(p, "utf-8");
-    return parseState(JSON.parse(raw));
-  } catch (err) {
-    if (isFileNotFound(err)) {
-      return defaultState();
-    }
-    // Corrupted JSON or any other read error — fall back to defaults
-    // and log a warning. Better to rebuild from scratch than to
-    // crash the journal module.
-    log.warn("journal", "state file unreadable, using defaults", {
-      error: String(err),
-    });
-    return defaultState();
-  }
+  const raw = await readJournalStateRaw<unknown>(null, workspaceRoot);
+  return parseState(raw);
 }
 
-// Atomic write: write to a tmp file and rename, so a crash mid-write
-// can't leave a half-written state.json behind.
 export async function writeState(
   workspaceRoot: string,
   state: JournalState,
 ): Promise<void> {
-  await writeJsonAtomic(statePathFor(workspaceRoot), state);
+  await writeJournalStateRaw(state, workspaceRoot);
 }
 
-// Tiny helper so callers don't need to import `fs` directly just to
-// check if the state file exists yet.
 export function stateFileExists(workspaceRoot: string): boolean {
-  return fs.existsSync(statePathFor(workspaceRoot));
-}
-
-// Narrow an unknown error value into "is this an ENOENT?". Written
-// without the NodeJS.ErrnoException global so we don't depend on
-// @types/node globals from this file.
-function isFileNotFound(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  if (!("code" in err)) return false;
-  return (err as Error & { code?: unknown }).code === "ENOENT";
+  return journalStateExistsRaw(workspaceRoot);
 }

--- a/server/workspace/roles.ts
+++ b/server/workspace/roles.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   BUILTIN_ROLES,
   RoleSchema,
@@ -25,7 +26,7 @@ export function loadCustomRoles(): Role[] {
       try {
         const raw = readTextUnderSync(
           workspacePath,
-          `${WORKSPACE_DIRS.roles}/${f}`,
+          path.posix.join(WORKSPACE_DIRS.roles, f),
         );
         if (!raw) return [];
         return [withSwitchRole(RoleSchema.parse(JSON.parse(raw)))];

--- a/server/workspace/tool-trace/writeSearch.ts
+++ b/server/workspace/tool-trace/writeSearch.ts
@@ -44,7 +44,7 @@ export function computeSearchRelPath(inputs: SearchPathInputs): string {
   const slug = slugify(inputs.query, "search", MAX_QUERY_SLUG_CHARS);
   const hash = computeSearchHash(inputs.query, inputs.sessionId, inputs.ts);
   const dateDir = toUtcIsoDate(inputs.ts);
-  return `${SEARCHES_DIR}/${dateDir}/${slug}-${hash}.md`;
+  return path.posix.join(SEARCHES_DIR, dateDir, `${slug}-${hash}.md`);
 }
 
 export interface SearchContentInputs {

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -5,9 +5,14 @@ import { fileURLToPath } from "url";
 import { log } from "../system/logger/index.js";
 import {
   EAGER_WORKSPACE_DIRS,
+  WORKSPACE_FILES,
   WORKSPACE_PATHS,
   workspacePath,
 } from "./paths.js";
+import {
+  existsInWorkspace,
+  writeWorkspaceTextSync,
+} from "../utils/files/workspace-io.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, "helps");
@@ -82,9 +87,9 @@ export function initWorkspace(): string {
   }
 
   // Create memory.md if it doesn't exist
-  if (!fs.existsSync(WORKSPACE_PATHS.memory)) {
-    fs.writeFileSync(
-      WORKSPACE_PATHS.memory,
+  if (!existsInWorkspace(WORKSPACE_FILES.memory)) {
+    writeWorkspaceTextSync(
+      WORKSPACE_FILES.memory,
       "# Memory\n\nDistilled facts about you and your work.\n",
     );
   }

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -106,10 +106,9 @@ export function initWorkspace(): string {
   // Create .gitignore if missing. The workspace is a git repo for
   // version-tracking user data, but cloned dev repos under github/
   // have their own .git and shouldn't be committed (#256).
-  const gitignorePath = path.join(workspacePath, ".gitignore");
-  if (!fs.existsSync(gitignorePath)) {
-    fs.writeFileSync(
-      gitignorePath,
+  if (!existsInWorkspace(".gitignore")) {
+    writeWorkspaceTextSync(
+      ".gitignore",
       [
         "# Cloned repositories have their own .git — don't nest",
         "github/",

--- a/test/journal/test_appendOrCreate.ts
+++ b/test/journal/test_appendOrCreate.ts
@@ -3,10 +3,15 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { appendOrCreate } from "../../server/workspace/journal/dailyPass.js";
+import { WORKSPACE_DIRS } from "../../server/workspace/paths.js";
+import { appendOrCreateTopic } from "../../server/utils/files/journal-io.js";
 
-function makeScratch(): string {
+function makeWorkspace(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmoclaude-aoc-"));
+  // Create the summaries/topics/ dir inside the workspace root
+  fs.mkdirSync(path.join(dir, WORKSPACE_DIRS.summaries, "topics"), {
+    recursive: true,
+  });
   return fs.realpathSync(dir);
 }
 
@@ -14,82 +19,83 @@ function rm(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-describe("appendOrCreate — happy paths", () => {
-  let scratch: string;
+function topicPath(root: string, slug: string): string {
+  return path.join(root, WORKSPACE_DIRS.summaries, "topics", `${slug}.md`);
+}
+
+describe("appendOrCreateTopic — happy paths", () => {
+  let root: string;
   before(() => {
-    scratch = makeScratch();
+    root = makeWorkspace();
   });
-  after(() => rm(scratch));
+  after(() => rm(root));
 
   it("writes a fresh file when missing and reports 'created'", async () => {
-    const p = path.join(scratch, "topic-a.md");
-    const outcome = await appendOrCreate(p, "first line");
+    const outcome = await appendOrCreateTopic("topic-a", "first line", root);
     assert.equal(outcome, "created");
-    assert.equal(fs.readFileSync(p, "utf-8"), "first line");
+    assert.equal(
+      fs.readFileSync(topicPath(root, "topic-a"), "utf-8"),
+      "first line",
+    );
   });
 
   it("appends with a blank-line separator and reports 'updated'", async () => {
-    const p = path.join(scratch, "topic-b.md");
-    fs.writeFileSync(p, "existing line");
-    const outcome = await appendOrCreate(p, "new line");
+    fs.writeFileSync(topicPath(root, "topic-b"), "existing line");
+    const outcome = await appendOrCreateTopic("topic-b", "new line", root);
     assert.equal(outcome, "updated");
-    assert.equal(fs.readFileSync(p, "utf-8"), "existing line\n\nnew line\n");
+    assert.equal(
+      fs.readFileSync(topicPath(root, "topic-b"), "utf-8"),
+      "existing line\n\nnew line\n",
+    );
   });
 
   it("trims trailing whitespace from existing content before appending", async () => {
-    const p = path.join(scratch, "topic-c.md");
-    fs.writeFileSync(p, "existing\n\n\n");
-    await appendOrCreate(p, "added");
-    assert.equal(fs.readFileSync(p, "utf-8"), "existing\n\nadded\n");
+    fs.writeFileSync(topicPath(root, "topic-c"), "existing\n\n\n");
+    await appendOrCreateTopic("topic-c", "added", root);
+    assert.equal(
+      fs.readFileSync(topicPath(root, "topic-c"), "utf-8"),
+      "existing\n\nadded\n",
+    );
   });
 
-  it("appends correctly across multiple calls (trimEnd before each join)", async () => {
-    const p = path.join(scratch, "topic-d.md");
-    await appendOrCreate(p, "one");
-    await appendOrCreate(p, "two");
-    await appendOrCreate(p, "three");
-    // Each append trims the previous trailing newline before joining
-    // with "\n\n", so blank lines never multiply.
-    assert.equal(fs.readFileSync(p, "utf-8"), "one\n\ntwo\n\nthree\n");
+  it("appends correctly across multiple calls", async () => {
+    await appendOrCreateTopic("topic-d", "one", root);
+    await appendOrCreateTopic("topic-d", "two", root);
+    await appendOrCreateTopic("topic-d", "three", root);
+    assert.equal(
+      fs.readFileSync(topicPath(root, "topic-d"), "utf-8"),
+      "one\n\ntwo\n\nthree\n",
+    );
   });
 });
 
-// REGRESSION GUARD for the data-loss bug CodeRabbit caught:
-// readTextOrNull-based versions returned null on ANY read error, so
-// a transient EACCES on an existing topic file would cause
-// appendOrCreate to clobber it. The fixed version distinguishes
-// ENOENT and rethrows everything else.
-describe("appendOrCreate — non-ENOENT read errors", () => {
-  let scratch: string;
+describe("appendOrCreateTopic — non-ENOENT read errors", () => {
+  let root: string;
   before(() => {
-    scratch = makeScratch();
+    root = makeWorkspace();
   });
   after(() => {
-    // Restore mode in case the test failed mid-flight, otherwise rm
-    // can't traverse the dir.
     try {
-      fs.chmodSync(scratch, 0o755);
+      fs.chmodSync(root, 0o755);
     } catch {
       /* ignore */
     }
-    rm(scratch);
+    rm(root);
   });
 
   it("rethrows EACCES instead of clobbering an unreadable file", async (t) => {
     if (process.platform === "win32" || process.getuid?.() === 0) {
-      // Windows perms don't behave the same way; root bypasses chmod.
       t.skip("requires POSIX permissions and a non-root user");
       return;
     }
-    const p = path.join(scratch, "locked.md");
+    const p = topicPath(root, "locked");
     fs.writeFileSync(p, "important content");
     fs.chmodSync(p, 0o000);
     try {
       await assert.rejects(
-        () => appendOrCreate(p, "would clobber"),
+        () => appendOrCreateTopic("locked", "would clobber", root),
         /EACCES|EPERM/,
       );
-      // Restore perms and verify the file was NOT touched.
       fs.chmodSync(p, 0o644);
       assert.equal(fs.readFileSync(p, "utf-8"), "important content");
     } finally {


### PR DESCRIPTION
## Summary

agent.ts was the largest remaining consumer of raw `fs.*` / `path.join` for workspace files. 10 `path.join`, 6 `readFile`, 5 `writeFileAtomic`, 2 `appendFile`, 1 `mkdir`, 1 `access` — all replaced with session-io domain functions.

### Before → After

```typescript
// Before (scattered path + fs):
const chatDir = WORKSPACE_PATHS.chat;
await mkdir(chatDir, { recursive: true });
const metaFilePath = path.join(chatDir, `${id}.json`);
const meta = JSON.parse(await readFile(metaFilePath, "utf-8"));
await writeFileAtomic(metaFilePath, JSON.stringify({...meta, claudeSessionId}));

// After (domain function):
await setClaudeId(chatSessionId, claudeSessionId);
```

### Deleted 5 local functions (replaced by session-io)

- `backfillFirstUserMessage` → `session-io.backfillFirstUserMessage`
- `updateClaudeSessionId` → `session-io.setClaudeSessionId`
- `clearClaudeSessionId` → `session-io.clearClaudeSessionId`
- `readClaudeSessionId` → `readClaudeSessionIdFromSession` (kept locally, uses session-io reads)
- `readTranscriptPreamble` → simplified with `readSessionJsonl`

### Net: -79 lines, 0 raw fs/path imports

Dropped: `access`, `appendFile`, `mkdir`, `readFile` (fs/promises), `writeFileAtomic`, `path`, `WORKSPACE_PATHS`, `WORKSPACE_DIRS`, `resolveWorkspacePath`.

## Test plan

- [x] All tests pass, typecheck + lint + build green
- [ ] CI matrix

Ref: #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed guidelines for file I/O layering and centralized API helpers for frontend/backend network calls.

* **New Features**
  * Workspace journal: read/write/indexing of summaries, daily notes, topics, archiving, and topic discovery.
  * New helpers for artifact naming and role management.

* **Bug Fixes**
  * Safer handling of missing or corrupted files, atomic writes, and consistent POSIX-style workspace paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->