### PR TITLE
feat: PDF attachment support in chat input (#369)

### DIFF
--- a/bridges/_lib/mime.ts
+++ b/bridges/_lib/mime.ts
@@ -42,6 +42,18 @@ export function isImageMime(mimeType: string): boolean {
   return mimeType.startsWith("image/");
 }
 
+/** True when the MIME type is a PDF document Claude can read natively
+ *  via `type: "document"` content blocks. */
+export function isPdfMime(mimeType: string): boolean {
+  return mimeType === "application/pdf";
+}
+
+/** True when the attachment can be sent to Claude as a content block
+ *  (image vision or PDF document). */
+export function isSupportedAttachmentMime(mimeType: string): boolean {
+  return isImageMime(mimeType) || isPdfMime(mimeType);
+}
+
 export interface ParsedDataUrl {
   mimeType: string;
   data: string; // base64

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -6,7 +6,11 @@ import { MCP_PLUGIN_NAMES } from "./plugin-names.js";
 import type { McpServerSpec } from "../system/config.js";
 import { getCurrentToken } from "../api/auth/token.js";
 import type { Attachment } from "../api/chat-service/types.js";
-import { isImageMime } from "../../bridges/_lib/mime.js";
+import {
+  isImageMime,
+  isPdfMime,
+  isSupportedAttachmentMime,
+} from "../../bridges/_lib/mime.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
@@ -286,36 +290,31 @@ export function buildCliArgs(params: CliArgsParams): string[] {
 /** JSON line to write to the Claude CLI's stdin when running in
  *  stream-json input mode. One line per user turn.
  *
- *  When `attachments` are provided, image/* entries become vision
- *  content blocks and `content` becomes an array. Without
- *  attachments, content is a plain string (smaller, backward-
- *  compatible). Non-image MIME types are currently skipped — a
- *  future phase can map PDF/docx to Claude Files API. */
+ *  Supported attachment types:
+ *  - `image/*` → vision content blocks (`type: "image"`)
+ *  - `application/pdf` → document content blocks (`type: "document"`)
+ *  - Other MIME types (docx, pptx, video, …) → skipped with a
+ *    console hint. A future phase can add conversion pipelines.
+ *
+ *  Without attachments, content is a plain string (smaller,
+ *  backward-compatible). */
 export function buildUserMessageLine(
   message: string,
   attachments?: Attachment[],
 ): string {
   const all = attachments ?? [];
-  const imageAttachments = all.filter((a) => isImageMime(a.mimeType));
-  const skipped = all.length - imageAttachments.length;
+  const supported = all.filter((a) => isSupportedAttachmentMime(a.mimeType));
+  const skipped = all.length - supported.length;
   if (skipped > 0) {
-    // Non-image attachments (PDF, docx, etc.) are not yet supported
-    // by the vision content-block path. Log so operators can see
-    // "I attached a PDF and nothing happened" in the file log.
     const skippedTypes = all
-      .filter((a) => !isImageMime(a.mimeType))
+      .filter((a) => !isSupportedAttachmentMime(a.mimeType))
       .map((a) => a.mimeType);
-    // Using console.error as a lightweight debug hint — the
-    // structured logger isn't imported here (config.ts is import-
-    // light by design). The relay layer logs the full summary.
     console.error(
-      `[agent] skipping ${skipped} non-image attachment(s): ${skippedTypes.join(", ")}`,
+      `[agent] skipping ${skipped} unsupported attachment(s): ${skippedTypes.join(", ")}`,
     );
   }
   const content =
-    imageAttachments.length > 0
-      ? buildContentBlocks(message, imageAttachments)
-      : message;
+    supported.length > 0 ? buildContentBlocks(message, supported) : message;
   return (
     JSON.stringify({
       type: "user",
@@ -326,18 +325,29 @@ export function buildUserMessageLine(
 
 function buildContentBlocks(
   message: string,
-  images: Attachment[],
+  attachments: Attachment[],
 ): Array<Record<string, unknown>> {
   const blocks: Array<Record<string, unknown>> = [];
-  for (const img of images) {
-    blocks.push({
-      type: "image",
-      source: {
-        type: "base64",
-        media_type: img.mimeType,
-        data: img.data,
-      },
-    });
+  for (const att of attachments) {
+    if (isImageMime(att.mimeType)) {
+      blocks.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: att.mimeType,
+          data: att.data,
+        },
+      });
+    } else if (isPdfMime(att.mimeType)) {
+      blocks.push({
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: att.mimeType,
+          data: att.data,
+        },
+      });
+    }
   }
   blocks.push({ type: "text", text: message });
   return blocks;

--- a/src/App.vue
+++ b/src/App.vue
@@ -223,21 +223,23 @@
       <div
         class="p-4 border-t border-gray-200"
         @dragover.prevent
-        @drop="onDropImage"
+        @drop="onDropFile"
       >
         <div
-          v-if="imageError"
+          v-if="fileError"
           class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5"
-          data-testid="image-error"
+          data-testid="file-error"
         >
-          {{ imageError }}
+          {{ fileError }}
         </div>
-        <ChatImagePreview
-          v-if="pastedImage"
-          :src="pastedImage"
-          @remove="pastedImage = null"
+        <ChatAttachmentPreview
+          v-if="pastedFile"
+          :data-url="pastedFile.dataUrl"
+          :filename="pastedFile.name"
+          :mime="pastedFile.mime"
+          @remove="pastedFile = null"
         />
-        <div class="flex gap-2" :class="{ 'mt-2': pastedImage }">
+        <div class="flex gap-2" :class="{ 'mt-2': pastedFile }">
           <textarea
             ref="textareaRef"
             v-model="userInput"
@@ -250,7 +252,7 @@
             @compositionend="imeEnter.onCompositionEnd"
             @keydown="imeEnter.onKeydown"
             @blur="imeEnter.onBlur"
-            @paste="onPasteImage"
+            @paste="onPasteFile"
           />
           <button
             data-testid="send-btn"
@@ -367,7 +369,7 @@ import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import NotificationToast from "./components/NotificationToast.vue";
-import ChatImagePreview from "./components/ChatImagePreview.vue";
+import ChatAttachmentPreview from "./components/ChatAttachmentPreview.vue";
 import type { SseEvent } from "./types/sse";
 import {
   type SessionSummary,
@@ -645,48 +647,61 @@ const unreadCount = computed(
 const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
 
 const userInput = ref("");
-const pastedImage = ref<string | null>(null);
-const imageError = ref<string | null>(null);
+const pastedFile = ref<{ dataUrl: string; name: string; mime: string } | null>(
+  null,
+);
+const fileError = ref<string | null>(null);
 const activePane = ref<"sidebar" | "main">("sidebar");
 
-const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB base64 limit
+const MAX_ATTACH_BYTES = 30 * 1024 * 1024; // 30 MB (PDF can be larger than images)
+const ACCEPTED_MIME_PREFIXES = ["image/", "application/pdf"];
 
-function readImageFile(file: File): void {
-  imageError.value = null;
-  if (!file.type.startsWith("image/")) return;
-  if (file.size > MAX_IMAGE_BYTES) {
+function isAcceptedType(mime: string): boolean {
+  return ACCEPTED_MIME_PREFIXES.some(
+    (p) => mime === p || mime.startsWith(p.endsWith("/") ? p : p + "/"),
+  );
+}
+
+function readAttachmentFile(file: File): void {
+  fileError.value = null;
+  if (!isAcceptedType(file.type)) return;
+  if (file.size > MAX_ATTACH_BYTES) {
     const sizeMB = (file.size / 1024 / 1024).toFixed(1);
-    imageError.value = `Image too large (${sizeMB} MB). Maximum is 10 MB.`;
+    fileError.value = `File too large (${sizeMB} MB). Maximum is 30 MB.`;
     return;
   }
   const reader = new FileReader();
   reader.onload = () => {
     if (typeof reader.result === "string") {
-      pastedImage.value = reader.result;
+      pastedFile.value = {
+        dataUrl: reader.result,
+        name: file.name,
+        mime: file.type,
+      };
     }
   };
   reader.readAsDataURL(file);
 }
 
-function onPasteImage(e: ClipboardEvent): void {
+function onPasteFile(e: ClipboardEvent): void {
   const items = e.clipboardData?.items;
   if (!items) return;
   for (const item of items) {
-    if (item.type.startsWith("image/")) {
+    if (isAcceptedType(item.type)) {
       const file = item.getAsFile();
       if (file) {
         e.preventDefault();
-        readImageFile(file);
+        readAttachmentFile(file);
         return;
       }
     }
   }
 }
 
-function onDropImage(e: DragEvent): void {
+function onDropFile(e: DragEvent): void {
   e.preventDefault();
   const file = e.dataTransfer?.files[0];
-  if (file) readImageFile(file);
+  if (file) readAttachmentFile(file);
 }
 
 const imeEnter = useImeAwareEnter(() => sendMessage());
@@ -1452,8 +1467,8 @@ async function sendMessage(text?: string) {
   const message = typeof text === "string" ? text : userInput.value.trim();
   if (!message || isRunning.value) return;
   userInput.value = "";
-  const imageSnapshot = pastedImage.value;
-  pastedImage.value = null;
+  const fileSnapshot = pastedFile.value;
+  pastedFile.value = null;
 
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
@@ -1478,7 +1493,8 @@ async function sendMessage(text?: string) {
           message,
           role: sessionRole,
           chatSessionId: session.id,
-          selectedImageData: imageSnapshot ?? extractImageData(selectedRes),
+          selectedImageData:
+            fileSnapshot?.dataUrl ?? extractImageData(selectedRes),
         }),
       ),
       headers: { "Content-Type": "application/json" },

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    data-testid="chat-attachment-preview"
+    class="relative inline-flex items-center gap-2 border border-gray-300 rounded overflow-hidden px-2 py-1"
+  >
+    <img
+      v-if="isImage"
+      :src="dataUrl"
+      alt="Attached image"
+      class="max-h-20 max-w-40 object-contain"
+    />
+    <div v-else class="flex items-center gap-1.5 text-xs text-gray-700">
+      <span class="material-icons text-red-500 text-base">picture_as_pdf</span>
+      <span class="max-w-40 truncate">{{ filename || "document.pdf" }}</span>
+    </div>
+    <button
+      data-testid="chat-attachment-remove"
+      class="absolute top-0 right-0 bg-black/60 text-white rounded-bl px-1 text-xs leading-tight hover:bg-black/80"
+      @click="emit('remove')"
+    >
+      ✕
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  dataUrl: string;
+  filename: string;
+  mime: string;
+}>();
+const emit = defineEmits<{ remove: [] }>();
+
+const isImage = computed(() => props.mime.startsWith("image/"));
+</script>

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -571,27 +571,35 @@ describe("buildUserMessageLine", () => {
     assert.equal(typeof parsed.message.content, "string");
   });
 
-  it("skips non-image attachments (PDF etc.) for now", () => {
+  it("sends PDF as a document content block", () => {
     const line = buildUserMessageLine("read this", [
       { mimeType: "application/pdf", data: "JVBERi0x" },
     ]);
     const parsed = JSON.parse(line.trimEnd());
-    // No image content blocks → plain string fallback
-    assert.equal(typeof parsed.message.content, "string");
-    assert.equal(parsed.message.content, "read this");
+    const blocks = parsed.message.content;
+    assert.equal(blocks.length, 2);
+    assert.equal(blocks[0].type, "document");
+    assert.equal(blocks[0].source.media_type, "application/pdf");
+    assert.equal(blocks[0].source.data, "JVBERi0x");
+    assert.equal(blocks[1].type, "text");
+    assert.equal(blocks[1].text, "read this");
   });
 
-  it("includes only image attachments when mixed types are present", () => {
+  it("includes image and PDF attachments, skips unsupported types", () => {
     const line = buildUserMessageLine("analyze", [
       { mimeType: "image/jpeg", data: "/9j/4AAQ" },
       { mimeType: "application/pdf", data: "JVBERi0x" },
+      { mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", data: "UEs=" },
     ]);
     const parsed = JSON.parse(line.trimEnd());
     const blocks = parsed.message.content;
-    // 1 image + 1 text (PDF skipped)
-    assert.equal(blocks.length, 2);
+    // image + document (PDF) + text; docx skipped
+    assert.equal(blocks.length, 3);
+    assert.equal(blocks[0].type, "image");
     assert.equal(blocks[0].source.media_type, "image/jpeg");
-    assert.equal(blocks[1].type, "text");
+    assert.equal(blocks[1].type, "document");
+    assert.equal(blocks[1].source.media_type, "application/pdf");
+    assert.equal(blocks[2].type, "text");
   });
 });
 

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -589,7 +589,11 @@ describe("buildUserMessageLine", () => {
     const line = buildUserMessageLine("analyze", [
       { mimeType: "image/jpeg", data: "/9j/4AAQ" },
       { mimeType: "application/pdf", data: "JVBERi0x" },
-      { mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", data: "UEs=" },
+      {
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        data: "UEs=",
+      },
     ]);
     const parsed = JSON.parse(line.trimEnd());
     const blocks = parsed.message.content;


### PR DESCRIPTION
## Summary

Extends the chat input to accept PDF files alongside images. PDFs are sent to Claude as native `type: "document"` content blocks — Claude reads the PDF directly without conversion.

### Changes

| Layer | Change |
|---|---|
| **Vue UI** | Paste/drop handler accepts `application/pdf`. Size limit raised 10→30 MB. `ChatImagePreview` → `ChatAttachmentPreview` (shows PDF icon + filename for non-image). |
| **Agent** (`config.ts`) | `buildUserMessageLine` maps PDF → `{ type: "document", source: { type: "base64", media_type: "application/pdf", data } }`. Unsupported types (docx, pptx, video) still skipped. |
| **MIME helpers** (`mime.ts`) | Added `isPdfMime()` + `isSupportedAttachmentMime()`. |
| **Tests** | Updated: PDF is now a document block, not skipped. Mixed-type test verifies image + PDF + text blocks with docx skipped. |

### What's NOT supported (separate issue)

- DOCX/PPTX — needs server-side conversion (no native Claude support)
- Video — needs frame extraction or transcription
- Multiple attachments per message — single file for v1

## Verification

- typecheck (all 4) / lint (0 errors) / 2380 tests / build — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)