### PR TITLE
feat(ui): auto-expand chat input on focus + expand-to-modal button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -243,23 +243,92 @@
             v-model="userInput"
             data-testid="user-input"
             placeholder="Type a task..."
-            rows="2"
-            class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+            :rows="inputFocused ? 8 : 2"
+            class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none transition-all duration-200"
+            :class="inputFocused ? 'ring-2 ring-blue-300' : ''"
             :disabled="isRunning"
+            @focus="inputFocused = true"
             @compositionstart="imeEnter.onCompositionStart"
             @compositionend="imeEnter.onCompositionEnd"
             @keydown="imeEnter.onKeydown"
-            @blur="imeEnter.onBlur"
+            @blur="onInputBlur"
             @paste="onPasteImage"
           />
-          <button
-            data-testid="send-btn"
-            class="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-            :disabled="isRunning"
-            @click="sendMessage()"
+          <div class="flex flex-col gap-1">
+            <button
+              data-testid="send-btn"
+              class="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              :disabled="isRunning"
+              @click="sendMessage()"
+            >
+              <span class="material-icons text-base">send</span>
+            </button>
+            <button
+              data-testid="expand-input-btn"
+              class="text-gray-400 hover:text-gray-600 rounded px-3 py-1 text-sm"
+              title="Expand editor"
+              @click="openExpandedEditor"
+            >
+              <span class="material-icons text-base">open_in_full</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Expanded editor modal -->
+        <div
+          v-if="expandedEditorOpen"
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          @click.self="closeExpandedEditor"
+        >
+          <div
+            class="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4 flex flex-col"
+            style="max-height: 80vh"
           >
-            <span class="material-icons text-base">send</span>
-          </button>
+            <div
+              class="flex items-center justify-between px-4 py-3 border-b border-gray-200"
+            >
+              <h3 class="text-sm font-semibold text-gray-700">
+                Compose message
+              </h3>
+              <button
+                class="text-gray-400 hover:text-gray-600"
+                @click="closeExpandedEditor"
+              >
+                <span class="material-icons text-base">close</span>
+              </button>
+            </div>
+            <textarea
+              ref="expandedTextareaRef"
+              v-model="userInput"
+              data-testid="expanded-input"
+              placeholder="Type a task..."
+              class="flex-1 px-4 py-3 text-sm text-gray-900 placeholder-gray-400 resize-none focus:outline-none"
+              style="min-height: 300px"
+              @keydown.meta.enter="sendFromExpanded"
+              @keydown.ctrl.enter="sendFromExpanded"
+            ></textarea>
+            <div
+              class="flex items-center justify-between px-4 py-3 border-t border-gray-200"
+            >
+              <p class="text-xs text-gray-400">Cmd+Enter to send</p>
+              <div class="flex gap-2">
+                <button
+                  class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                  @click="closeExpandedEditor"
+                >
+                  Cancel
+                </button>
+                <button
+                  class="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40"
+                  :disabled="isRunning"
+                  data-testid="expanded-send-btn"
+                  @click="sendFromExpanded"
+                >
+                  Send
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -700,6 +769,32 @@ const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
+const expandedTextareaRef = ref<HTMLTextAreaElement | null>(null);
+const inputFocused = ref(false);
+const expandedEditorOpen = ref(false);
+
+function onInputBlur(): void {
+  imeEnter.onBlur();
+  // Delay collapsing so a click on send/expand buttons registers first
+  setTimeout(() => {
+    inputFocused.value = false;
+  }, 150);
+}
+
+function openExpandedEditor(): void {
+  expandedEditorOpen.value = true;
+  nextTick(() => expandedTextareaRef.value?.focus());
+}
+
+function closeExpandedEditor(): void {
+  expandedEditorOpen.value = false;
+  nextTick(() => textareaRef.value?.focus());
+}
+
+function sendFromExpanded(): void {
+  closeExpandedEditor();
+  sendMessage();
+}
 const historyButtonRef = ref<HTMLButtonElement | null>(null);
 // Exposed `root` from SessionHistoryPanel — the click-outside guard
 // needs the actual popup DOM element (not the component instance).


### PR DESCRIPTION
## Summary
チャット入力エリアの 2 つの改善:

1. **Auto-expand on focus**: フォーカスで 2 行 → 8 行に拡大、青リングハイライト。blur で戻る (150ms delay で send/expand ボタンクリックが先に処理される)
2. **Expand ボタン**: \`open_in_full\` アイコン → モーダルオーバーレイ (min 300px, max 80vh)。Cmd+Enter / Ctrl+Enter で送信。Cancel or backdrop click で閉じる

同じ \`v-model(userInput)\` を共有するので、テキストがシームレスに行き来する。

## Items to Confirm / Review
- blur 時の 150ms delay: send/expand ボタンの click イベントが blur より先に発火する必要がある。短すぎるとクリック前に collapse する
- モーダルの Cmd+Enter / Ctrl+Enter: macOS + Windows 両対応
- モーダル外クリック (\`@click.self\`) で閉じる — テキストは保持

## Verification
- \`yarn typecheck\` / \`yarn lint\` / \`yarn build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)