### PR TITLE
chore: add dependency/plan-lifecycle rules to /precommit + CLAUDE.md

### DIFF
--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -113,3 +113,11 @@ Run `git diff --stat` and `git diff` first, then check every item below against 
 
 - [ ] **No `eslint-disable-line` or `eslint-disable-next-line`.** If the lint rule fires, fix the code — don't suppress. The only exception is `@typescript-eslint/no-explicit-any` in test mocks where the mock intentionally returns `as any` to satisfy a type constraint that doesn't matter for the test.
 - [ ] No `@ts-ignore` or `@ts-expect-error`.
+
+## 14. Dependencies
+
+- [ ] **No unnecessary npm packages.** If the functionality can be implemented in <50 lines of pure code, do that instead of adding a dependency.
+- [ ] Prefer **mature, mainstream packages** with large user bases, stable APIs, and infrequent breaking changes (e.g., `express`, `marked`, `zod`, `uuid`).
+- [ ] Avoid trendy / fast-moving / hype-cycle packages that are likely to become obsolete, change APIs frequently, or introduce supply-chain risk.
+- [ ] Before adding a package, check: last publish date, weekly downloads, open issues count, bus factor (single maintainer?), and whether a simpler alternative already exists in the repo.
+- [ ] No duplicate-purpose packages — if the repo already has a library that covers the use case (even partially), extend it rather than adding a second one.

--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -94,6 +94,7 @@ Run `git diff --stat` and `git diff` first, then check every item below against 
 - [ ] `docs/manual-testing.md` updated if a scenario is deliberately left uncovered by E2E.
 - [ ] New plugins update all required places (see Plugin Development in CLAUDE.md — 4 places for package, 8 for local).
 - [ ] New endpoints added to `src/config/apiRoutes.ts` FIRST, then referenced.
+- [ ] If this PR completes work tracked by a plan file under `plans/`, move that file to `plans/done/` in the same PR.
 
 ## 11. Git Hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,8 +350,10 @@ src/
 test/             ← mirrors source layout 1:1
 e2e/              ← Playwright E2E tests + fixtures
 plans/            ← one file per feature/refactor/fix
+plans/done/       ← completed plans (moved here when the PR lands)
 ```
 
+- **Plan files lifecycle**: create under `plans/` before implementation; move to `plans/done/` in the PR that completes the work. Never delete — `plans/done/` is the archive.
 - Group by *what files are about*, not file kind. `src/plugins/wiki/` keeps def/index/View/Preview together.
 - Mirror source layout in `test/`. `server/workspace/journal/dailyPass.ts` → `test/journal/test_dailyPass.ts`.
 - Prefer a new named directory over dropping files into the closest pre-existing bucket.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #389. Adds 3 more rules:

1. **Dependency hygiene** (precommit skill) — no unnecessary npm packages, prefer mature/mainstream, avoid trendy/fast-moving, check stats before adding, no duplicate-purpose packages.
2. **Plan file lifecycle** (precommit skill) — move completed plan files from `plans/` to `plans/done/` in the same PR.
3. **Plan file lifecycle** (CLAUDE.md) — documents `plans/done/` in the directory layout and adds a lifecycle rule: create before implementation, move to done/ when PR lands, never delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)