### PR TITLE
docs(protocol): add README.md for npm page

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,0 +1,63 @@
+# @mulmobridge/protocol
+
+Shared types and constants for the [MulmoBridge](https://github.com/receptron/mulmoclaude) chat protocol — the wire-level contract between the chat-service (server) and external bridges (CLI, Telegram, etc.).
+
+## Install
+
+```bash
+npm install @mulmobridge/protocol
+```
+
+## What's included
+
+| Export | Description |
+|---|---|
+| `EVENT_TYPES` | Agent SSE event type discriminants (`"text"`, `"error"`, `"session_finished"`, …) |
+| `EventType` | Union type of all event type strings |
+| `CHAT_SOCKET_EVENTS` | Socket.io event names (`"message"`, `"push"`) |
+| `CHAT_SOCKET_PATH` | Socket.io endpoint path (`"/ws/chat"`) |
+| `ChatSocketEvent` | Union type of socket event names |
+| `CHAT_SERVICE_ROUTES` | REST endpoint patterns for the bridge API |
+| `Attachment` | File attachment interface (`mimeType` + base64 `data` + optional `filename`) |
+
+## Usage
+
+```typescript
+import {
+  EVENT_TYPES,
+  CHAT_SOCKET_EVENTS,
+  CHAT_SOCKET_PATH,
+  type Attachment,
+} from "@mulmobridge/protocol";
+
+// Discriminate agent events
+if (event.type === EVENT_TYPES.text) {
+  console.log(event.message);
+}
+
+// Connect via socket.io
+const socket = io(serverUrl, { path: CHAT_SOCKET_PATH });
+socket.on(CHAT_SOCKET_EVENTS.push, (event) => {
+  // handle server push
+});
+
+// Send with attachment
+const attachment: Attachment = {
+  mimeType: "image/png",
+  data: base64EncodedData,
+};
+```
+
+## Part of the MulmoBridge ecosystem
+
+| Package | Description |
+|---|---|
+| **@mulmobridge/protocol** | Wire protocol types and constants (this package) |
+| @mulmobridge/chat-service | Server-side chat service (coming soon) |
+| @mulmobridge/client | Bridge client library (coming soon) |
+| @mulmobridge/cli | CLI bridge (coming soon) |
+| @mulmobridge/telegram | Telegram bridge (coming soon) |
+
+## License
+
+MIT — [Receptron Team](https://github.com/receptron)

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -12,7 +12,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

@mulmobridge/protocol の npm ページに表示される README.md を追加。

- Install 手順
- Exports テーブル (全 7 export)
- Usage コード例 (event discrimination, socket.io connect, attachment)
- MulmoBridge エコシステムのロードマップ表

files[] に README.md 追加済み。次回 `npm publish` で npm ページに反映。

## Test plan

- [x] typecheck + lint + test green
- [ ] CI