### PR TITLE
feat: bridge text streaming — real-time typing in CLI (#268 Phase C)

### DIFF
--- a/packages/chat-service/src/relay.ts
+++ b/packages/chat-service/src/relay.ts
@@ -25,6 +25,10 @@ export interface RelayParams {
   externalChatId: string;
   text: string;
   attachments?: Attachment[];
+  /** Called for each text chunk as the agent generates it. Used by
+   *  the socket transport to stream text to the bridge in real time
+   *  (Phase C of #268). */
+  onChunk?: (text: string) => void;
 }
 
 export type RelayResult =
@@ -130,6 +134,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
       const reply = await collectAgentReply(
         onSessionEvent,
         chatState.sessionId,
+        params.onChunk,
       );
       await store.setChatState(transportId, {
         ...chatState,
@@ -158,6 +163,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
 function collectAgentReply(
   onSessionEvent: OnSessionEventFn,
   chatSessionId: string,
+  onChunk?: (text: string) => void,
 ): Promise<string> {
   return new Promise((resolve) => {
     const textChunks: string[] = [];
@@ -174,7 +180,9 @@ function collectAgentReply(
       const type = event.type as string;
 
       if (type === EVENT_TYPES.text) {
-        textChunks.push(event.message as string);
+        const chunk = event.message as string;
+        textChunks.push(chunk);
+        onChunk?.(chunk);
       }
 
       if (type === EVENT_TYPES.error) {

--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -50,6 +50,8 @@ export const CHAT_SOCKET_EVENTS = {
   /** server → bridge async push (Phase B of #268); body:
    *  `{ chatId, message }`. */
   push: "push",
+  /** server → bridge streaming text chunk (Phase C of #268). */
+  textChunk: "textChunk",
 } as const;
 export type ChatSocketEvent =
   (typeof CHAT_SOCKET_EVENTS)[keyof typeof CHAT_SOCKET_EVENTS];
@@ -192,6 +194,12 @@ export function attachChatSocket(
           externalChatId: parsed.externalChatId,
           text: parsed.text,
           attachments: parsed.attachments,
+          // Stream text chunks to this bridge socket in real time
+          // (Phase C of #268). The ack still returns the full text
+          // for backward compatibility.
+          onChunk: (text) => {
+            socket.emit(CHAT_SOCKET_EVENTS.textChunk, { text });
+          },
         });
 
         if (result.kind === "ok") {

--- a/packages/chat-service/test/test_streaming.ts
+++ b/packages/chat-service/test/test_streaming.ts
@@ -1,0 +1,250 @@
+// Integration test for text streaming (Phase C of #268).
+//
+// Spins up a real chat-service socket.io server with a mock relay
+// that emits text chunks via the onChunk callback, then connects a
+// bridge client and verifies:
+//   1. textChunk events arrive in real time (before the ack)
+//   2. Chunks arrive in order
+//   3. The ack carries the full accumulated text
+//   4. When no chunks are emitted, the ack still works (fallback)
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "http";
+import express from "express";
+import { io as ioClient, Socket as ClientSocket } from "socket.io-client";
+import {
+  attachChatSocket,
+  CHAT_SOCKET_EVENTS,
+  CHAT_SOCKET_PATH,
+  type ChatSocketHandle,
+} from "../src/socket.js";
+import { createPushQueue } from "../src/push-queue.js";
+import type { RelayParams, RelayResult } from "../src/relay.js";
+import type { Logger } from "../src/types.js";
+
+const silentLogger: Logger = {
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+};
+
+interface Harness {
+  httpServer: http.Server;
+  handle: ChatSocketHandle;
+  url: string;
+}
+
+type RelayFn = (params: RelayParams) => Promise<RelayResult>;
+
+async function startHarness(relay: RelayFn): Promise<Harness> {
+  const app = express();
+  const httpServer = http.createServer(app);
+  const handle = attachChatSocket(httpServer, {
+    relay,
+    queue: createPushQueue(),
+    logger: silentLogger,
+  });
+
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to get server address");
+  }
+
+  return {
+    httpServer,
+    handle,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function stopHarness(h: Harness): Promise<void> {
+  await h.handle.io.close();
+  await new Promise<void>((resolve) => h.httpServer.close(() => resolve()));
+}
+
+function connectClient(url: string, transportId = "test"): ClientSocket {
+  return ioClient(url, {
+    path: CHAT_SOCKET_PATH,
+    auth: { transportId },
+    transports: ["websocket"],
+    reconnection: false,
+    timeout: 2000,
+  });
+}
+
+function waitConnect(socket: ClientSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.on("connect", () => resolve());
+    socket.on("connect_error", (err) => reject(err));
+  });
+}
+
+describe("text streaming (Phase C)", () => {
+  let harness: Harness;
+  let client: ClientSocket;
+
+  afterEach(async () => {
+    client?.disconnect();
+    if (harness) await stopHarness(harness);
+  });
+
+  it("emits textChunk events for each chunk before the ack", async () => {
+    // Relay that sends 3 chunks via onChunk, then returns full text
+    harness = await startHarness(async (params) => {
+      params.onChunk?.("Hello ");
+      params.onChunk?.("beautiful ");
+      params.onChunk?.("world!");
+      return { kind: "ok", reply: "Hello beautiful world!" };
+    });
+
+    client = connectClient(harness.url);
+    await waitConnect(client);
+
+    const chunks: string[] = [];
+    client.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+      chunks.push(event.text);
+    });
+
+    // Send message and wait for ack
+    const ack = await new Promise<{
+      ok: boolean;
+      reply?: string;
+    }>((resolve) => {
+      client
+        .timeout(5000)
+        .emit(
+          CHAT_SOCKET_EVENTS.message,
+          { externalChatId: "test-chat", text: "hello" },
+          (_err: Error | null, response: { ok: boolean; reply?: string }) => {
+            resolve(response);
+          },
+        );
+    });
+
+    // Verify chunks arrived
+    assert.deepEqual(chunks, ["Hello ", "beautiful ", "world!"]);
+    // Verify ack has full text
+    assert.equal(ack.ok, true);
+    assert.equal(ack.reply, "Hello beautiful world!");
+  });
+
+  it("works without chunks (backward compatibility)", async () => {
+    // Relay that does NOT call onChunk — simulates no streaming
+    harness = await startHarness(async () => {
+      return { kind: "ok", reply: "no streaming reply" };
+    });
+
+    client = connectClient(harness.url);
+    await waitConnect(client);
+
+    const chunks: string[] = [];
+    client.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+      chunks.push(event.text);
+    });
+
+    const ack = await new Promise<{
+      ok: boolean;
+      reply?: string;
+    }>((resolve) => {
+      client
+        .timeout(5000)
+        .emit(
+          CHAT_SOCKET_EVENTS.message,
+          { externalChatId: "test-chat", text: "hi" },
+          (_err: Error | null, response: { ok: boolean; reply?: string }) => {
+            resolve(response);
+          },
+        );
+    });
+
+    // No chunks emitted
+    assert.equal(chunks.length, 0);
+    // Ack still works
+    assert.equal(ack.ok, true);
+    assert.equal(ack.reply, "no streaming reply");
+  });
+
+  it("handles error relay without chunks", async () => {
+    harness = await startHarness(async () => {
+      return { kind: "error", status: 500, message: "internal error" };
+    });
+
+    client = connectClient(harness.url);
+    await waitConnect(client);
+
+    const chunks: string[] = [];
+    client.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+      chunks.push(event.text);
+    });
+
+    const ack = await new Promise<{
+      ok: boolean;
+      error?: string;
+      status?: number;
+    }>((resolve) => {
+      client
+        .timeout(5000)
+        .emit(
+          CHAT_SOCKET_EVENTS.message,
+          { externalChatId: "test-chat", text: "fail" },
+          (
+            _err: Error | null,
+            response: { ok: boolean; error?: string; status?: number },
+          ) => {
+            resolve(response);
+          },
+        );
+    });
+
+    assert.equal(chunks.length, 0);
+    assert.equal(ack.ok, false);
+    assert.equal(ack.error, "internal error");
+    assert.equal(ack.status, 500);
+  });
+
+  it("streams chunks to the correct socket only (not broadcast)", async () => {
+    harness = await startHarness(async (params) => {
+      params.onChunk?.("for you only");
+      return { kind: "ok", reply: "for you only" };
+    });
+
+    // Two clients connect
+    const clientA = connectClient(harness.url, "bridge-a");
+    const clientB = connectClient(harness.url, "bridge-b");
+    await Promise.all([waitConnect(clientA), waitConnect(clientB)]);
+
+    const chunksA: string[] = [];
+    const chunksB: string[] = [];
+    clientA.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+      chunksA.push(event.text);
+    });
+    clientB.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+      chunksB.push(event.text);
+    });
+
+    // Only clientA sends a message
+    await new Promise<void>((resolve) => {
+      clientA
+        .timeout(5000)
+        .emit(
+          CHAT_SOCKET_EVENTS.message,
+          { externalChatId: "chat", text: "test" },
+          () => resolve(),
+        );
+    });
+
+    // Only clientA should get chunks
+    assert.deepEqual(chunksA, ["for you only"]);
+    // clientB should get nothing (different transport, didn't send)
+    assert.equal(chunksB.length, 0);
+
+    clientA.disconnect();
+    clientB.disconnect();
+    client = null as unknown as ClientSocket; // skip afterEach disconnect
+  });
+});

--- a/packages/chat-service/test/test_streaming.ts
+++ b/packages/chat-service/test/test_streaming.ts
@@ -8,7 +8,7 @@
 //   3. The ack carries the full accumulated text
 //   4. When no chunks are emitted, the ack still works (fallback)
 
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import http from "http";
 import express from "express";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,19 @@ async function main(): Promise<void> {
     console.log(`\n[push] ${ev.chatId}: ${ev.message}\n`);
   });
 
+  // Streaming text chunks (Phase C of #268). Each chunk is a
+  // fragment of the assistant's response, printed in real time
+  // so the user sees a typing effect instead of waiting for the
+  // full response.
+  let streamingActive = false;
+  client.onTextChunk((chunk) => {
+    if (!streamingActive) {
+      process.stdout.write("\nAssistant: ");
+      streamingActive = true;
+    }
+    process.stdout.write(chunk);
+  });
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -32,8 +45,13 @@ async function main(): Promise<void> {
     const line = (await askOnce()).trim();
     if (!line) continue;
 
+    streamingActive = false;
     const ack = await client.send(CHAT_ID, line);
-    if (ack.ok) {
+    if (streamingActive) {
+      // Text was streamed chunk-by-chunk; just add a trailing newline.
+      process.stdout.write("\n\n");
+    } else if (ack.ok) {
+      // No chunks arrived (e.g. short response) — print the full ack.
       console.log(`\nAssistant: ${ack.reply ?? ""}\n`);
     } else {
       const statusSuffix = ack.status ? ` (${ack.status})` : "";

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -55,6 +55,11 @@ export interface BridgeClient {
   ): Promise<MessageAck>;
   /** Subscribe to server → bridge async pushes (Phase B of #268). */
   onPush(handler: (event: PushEvent) => void): void;
+  /** Subscribe to streaming text chunks during a relay (Phase C of
+   *  #268). Each chunk is a fragment of the assistant's response,
+   *  emitted in real time as the agent generates text. The final
+   *  ack from `send()` still carries the full response. */
+  onTextChunk(handler: (chunk: string) => void): void;
   /** Called each time the socket (re-)establishes a connection. */
   onConnect(handler: () => void): void;
   /** Called when the socket disconnects. */
@@ -102,6 +107,11 @@ export function createBridgeClient(opts: BridgeClientOptions): BridgeClient {
       sendMessage(socket, externalChatId, text, attachments),
     onPush: (handler) => {
       socket.on(CHAT_SOCKET_EVENTS.push, handler);
+    },
+    onTextChunk: (handler) => {
+      socket.on(CHAT_SOCKET_EVENTS.textChunk, (event: { text: string }) => {
+        handler(event.text);
+      });
     },
     onConnect: (handler) => {
       socket.on("connect", handler);

--- a/packages/protocol/src/socket.ts
+++ b/packages/protocol/src/socket.ts
@@ -5,6 +5,11 @@ export const CHAT_SOCKET_PATH = "/ws/chat";
 export const CHAT_SOCKET_EVENTS = {
   message: "message",
   push: "push",
+  /** Server → bridge streaming text chunk (Phase C of #268).
+   *  Emitted during a relay while the agent is generating text.
+   *  Bridge accumulates chunks for display; the final ack still
+   *  carries the full response for backward compatibility. */
+  textChunk: "textChunk",
 } as const;
 
 export type ChatSocketEvent =


### PR DESCRIPTION
## Summary
Bridge (CLI/Telegram) にテキスト streaming を追加。CLI bridge でリアルタイムのタイピング表示が可能に。

Web UI の streaming (#393) では server → pub-sub → browser の経路。Bridge では server → socket.io \`textChunk\` event → bridge client の経路を追加。

## Changes

| Package | Change |
|---|---|
| \`@mulmobridge/protocol\` | \`CHAT_SOCKET_EVENTS.textChunk\` 追加 |
| \`@mulmobridge/chat-service\` | relay に \`onChunk\` callback 追加。socket handler が \`textChunk\` を bridge に emit |
| \`@mulmobridge/client\` | \`onTextChunk(handler)\` を \`BridgeClient\` に追加 |
| \`@mulmobridge/cli\` | \`onTextChunk\` で逐次 stdout 表示。ack は streaming 済みなら skip |

## Design

- **後方互換**: ack は引き続き全文を返す。\`textChunk\` は追加の streaming チャネル
- **Fallback**: chunk が 0 件の場合 (短い応答等) は ack の全文を表示
- **Telegram**: 未対応 (この PR は CLI のみ)。Telegram は \`editMessageText\` で chunk ごとにメッセージ更新する形が自然 — 別 PR

## Verification
- \`yarn build:packages\` / \`yarn typecheck\` / \`yarn lint\` clean
- \`yarn test\` all pass

## Manual test
\`\`\`bash
yarn dev    # terminal 1
yarn cli    # terminal 2
> 日本の四季について説明して
# → "Assistant: " の後にテキストがリアルタイムで流れる
\`\`\`

Refs #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)