### PR TITLE
feat(telegram): text streaming via editMessageText (#268 Phase C)

### DIFF
--- a/packages/telegram/src/api.ts
+++ b/packages/telegram/src/api.ts
@@ -66,7 +66,14 @@ export interface GetUpdatesOptions {
 
 export interface TelegramApi {
   getUpdates(opts?: GetUpdatesOptions): Promise<TelegramUpdate[]>;
-  sendMessage(chatId: number, text: string): Promise<void>;
+  /** Send a message and return its message_id (needed for editMessageText). */
+  sendMessage(chatId: number, text: string): Promise<number>;
+  /** Edit an existing message in place. Used for streaming text updates. */
+  editMessageText(
+    chatId: number,
+    messageId: number,
+    text: string,
+  ): Promise<void>;
   downloadPhoto(fileId: string): Promise<string>;
 }
 
@@ -119,11 +126,30 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       const body = (await res.json()) as {
         ok: boolean;
         description?: string;
+        result?: { message_id: number };
       };
       if (!body.ok) {
         throw new Error(
           `sendMessage API error: ${body.description ?? "unknown"}`,
         );
+      }
+      return body.result?.message_id ?? 0;
+    },
+
+    async editMessageText(chatId, messageId, text) {
+      const res = await fetchImpl(`${base}/editMessageText`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: chatId,
+          message_id: messageId,
+          text,
+        }),
+      });
+      if (!res.ok) {
+        // editMessageText fails if the text is unchanged (Telegram
+        // returns 400 "message is not modified"). Swallow silently.
+        return;
       }
     },
 

--- a/packages/telegram/src/index.ts
+++ b/packages/telegram/src/index.ts
@@ -104,6 +104,11 @@ async function main(): Promise<void> {
       client.send(chatId, text, attachments),
   });
 
+  // Server → Telegram streaming text chunks (Phase C of #268).
+  client.onTextChunk((chunk) => {
+    router.handleTextChunk(chunk);
+  });
+
   // Server → Telegram async push (Phase B of #268).
   client.onPush((ev) => {
     router

--- a/packages/telegram/src/router.ts
+++ b/packages/telegram/src/router.ts
@@ -40,6 +40,8 @@ export interface RouterDeps {
 export interface MessageRouter {
   handleMessage(msg: TelegramMessage): Promise<void>;
   handlePush(ev: PushEvent): Promise<void>;
+  /** Called for each streaming text chunk from the server. */
+  handleTextChunk(chunk: string): void;
   /** For tests / debugging: chat IDs we've already sent the
    *  access-denied notice to. */
   deniedAlreadyNotified(): ReadonlySet<number>;
@@ -56,12 +58,67 @@ interface PhotoResult {
   failed: boolean;
 }
 
+// Minimum interval between editMessageText calls to avoid Telegram
+// rate limits. 1 second is conservative; Telegram allows ~30 edits
+// per minute per chat.
+const STREAM_EDIT_INTERVAL_MS = 1000;
+
 export function createMessageRouter(deps: RouterDeps): MessageRouter {
   const { api, allowlist, sendToMulmo } = deps;
   const log = deps.log ?? defaultLog;
 
   // One denial reply per chat per bridge lifetime — restart clears.
   const deniedAlreadyNotified = new Set<number>();
+
+  // Streaming state: while a relay is in flight, chunks accumulate
+  // here. A timer periodically flushes them via editMessageText.
+  let streamChatId: number | null = null;
+  let streamMessageId: number | null = null;
+  let streamAccumulated = "";
+  let streamDirty = false;
+  let streamTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startStream(chatId: number): void {
+    streamChatId = chatId;
+    streamMessageId = null;
+    streamAccumulated = "";
+    streamDirty = false;
+    streamTimer = setInterval(flushStream, STREAM_EDIT_INTERVAL_MS);
+  }
+
+  function stopStream(): void {
+    if (streamTimer !== null) {
+      clearInterval(streamTimer);
+      streamTimer = null;
+    }
+    streamChatId = null;
+    streamMessageId = null;
+    streamAccumulated = "";
+    streamDirty = false;
+  }
+
+  function flushStream(): void {
+    if (!streamDirty || streamChatId === null) return;
+    streamDirty = false;
+    const chatId = streamChatId;
+    const text = streamAccumulated || "…";
+    if (streamMessageId === null) {
+      // First flush: send a new message
+      api
+        .sendMessage(chatId, text)
+        .then((msgId) => {
+          streamMessageId = msgId;
+        })
+        .catch((err) => {
+          log.error(`[telegram] stream sendMessage failed: ${String(err)}`);
+        });
+    } else {
+      // Subsequent flushes: edit existing message
+      api.editMessageText(chatId, streamMessageId, text).catch((err) => {
+        log.error(`[telegram] stream editMessage failed: ${String(err)}`);
+      });
+    }
+  }
 
   async function tryDownloadPhoto(msg: TelegramMessage): Promise<PhotoResult> {
     const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
@@ -121,12 +178,30 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
 
     // Surface the photo-drop so the user knows the image was lost.
     const messageText = resolveMessageText(text, failed);
+
+    // Start streaming: chunks will arrive via handleTextChunk and
+    // be sent/edited in the Telegram chat in real time.
+    startStream(chatId);
     const ack = await sendToMulmo(
       String(chatId),
       messageText,
       attachments.length > 0 ? attachments : undefined,
     );
-    await sendReply(chatId, ack);
+    // Final flush + capture the message id before stopStream clears it.
+    flushStream();
+    const sentMsgId = streamMessageId;
+    stopStream();
+
+    // If streaming sent the text, do a final edit with the full ack
+    // to catch any trailing chunks. If no streaming happened,
+    // send the full reply as a new message.
+    if (sentMsgId !== null && ack.ok) {
+      await api
+        .editMessageText(chatId, sentMsgId, ack.reply ?? "")
+        .catch(() => {});
+    } else if (sentMsgId === null) {
+      await sendReply(chatId, ack);
+    }
   }
 
   async function handleDenied(msg: TelegramMessage): Promise<void> {
@@ -170,6 +245,12 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
       } catch (err) {
         log.error(`[telegram] push sendMessage failed: ${String(err)}`);
       }
+    },
+
+    handleTextChunk(chunk: string) {
+      if (streamChatId === null) return;
+      streamAccumulated += chunk;
+      streamDirty = true;
     },
 
     deniedAlreadyNotified() {


### PR DESCRIPTION
## Summary
Telegram bridge でテキスト streaming。最初の chunk で新メッセージ送信、以降は \`editMessageText\` で同じメッセージを更新。Telegram 上で ChatGPT のようなリアルタイム表示。

## Design
- **Rate limit 対策**: 1 秒間隔の \`setInterval\` で batch flush (Telegram は ~30 edits/min/chat)
- **State machine**: \`startStream(chatId)\` → chunks accumulate → periodic \`flushStream()\` → \`stopStream()\`
- **Fallback**: chunk が 0 件なら従来通り ack の全文を新規メッセージで送信
- **Final edit**: relay 完了時に ack の全文で最終 edit (trailing chunks のキャッチ)

## Changes

| File | Change |
|---|---|
| \`api.ts\` | \`sendMessage\` が \`message_id\` を返す + \`editMessageText\` 追加 |
| \`router.ts\` | Streaming state machine + \`handleTextChunk\` |
| \`index.ts\` | \`client.onTextChunk → router.handleTextChunk\` 配線 |

## Verification
- \`yarn build:packages\` / \`yarn typecheck\` / \`yarn lint\` clean
- \`yarn test\` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)