### PR TITLE
docs: comprehensive v0.1.1 documentation update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with the MulmoClaude rep
 
 ## Project Overview
 
-MulmoClaude is a text/task-driven agent app with rich visual output. It uses **Claude Code Agent SDK** as the LLM core and **gui-chat-protocol** as the plugin layer.
+MulmoClaude is a text/task-driven agent app with rich visual output. It uses **Claude Code Agent SDK** as the LLM core and **gui-chat-protocol** as the plugin layer. Shared code is published as `@mulmobridge/*` npm packages under `packages/`.
 
 **Core philosophy**: The workspace is the database. Files are the source of truth. Claude is the intelligent interface.
 
@@ -128,9 +128,10 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 |---|---|
 | `server/agent/index.ts` | Agent loop, MCP server creation per role |
 | `server/agent/mcp-server.ts` | stdio JSON-RPC MCP bridge spawned by the Claude CLI |
+| `server/agent/attachmentConverter.ts` | Converts non-native attachments (DOCX/XLSX/PPTX/text) to Claude content blocks |
 | `server/api/routes/agent.ts` | `POST /api/agent` → SSE stream |
-| `server/api/chat-service/` | External-bridge HTTP + socket.io surface |
-| `server/api/auth/` | Bearer token + CSRF gate |
+| `server/api/chat-service/` | External-bridge HTTP + socket.io surface (DI factory, `@mulmobridge/chat-service`) |
+| `server/api/auth/` | Bearer token + CSRF gate (`/api/files/*` exempt for `<img>` tags) |
 | `server/workspace/journal/` | Workspace journal (daily + optimization passes) |
 | `server/workspace/chat-index/` | Per-session summarizer + sidebar title cache |
 | `server/workspace/roles.ts` | Custom-role loader over `<workspace>/roles/` |
@@ -361,7 +362,7 @@ server/                     ← 6 topical dirs + index.ts + tsconfig.json (#323)
     index.ts                ← runAgent, the agent orchestrator
     mcp-server.ts           ← stdio MCP bridge spawned by Claude CLI
     mcp-tools/              ← auto-registered non-GUI MCP tools
-    config.ts, prompt.ts, stream.ts, resumeFailover.ts, sandboxMounts.ts
+    config.ts, prompt.ts, stream.ts, resumeFailover.ts, sandboxMounts.ts, attachmentConverter.ts
   api/                      ← everything external clients touch
     routes/                 ← one file per /api/* surface
     chat-service/           ← bridge HTTP + socket.io
@@ -377,6 +378,13 @@ server/                     ← 6 topical dirs + index.ts + tsconfig.json (#323)
     env.ts, config.ts, docker.ts, credentials.ts
     logger/, logs/          (logs/ is gitignored runtime output)
   utils/                    ← shared helpers, one file per concept
+
+packages/                   ← @mulmobridge/* npm packages (yarn workspaces)
+  protocol/                 ← shared types + constants (EVENT_TYPES, Attachment)
+  client/                   ← socket.io client + token reader + MIME utils
+  chat-service/             ← server-side chat service (DI factory)
+  cli/                      ← interactive terminal bridge
+  telegram/                 ← Telegram bot bridge
 
 src/
   components/     ← shared Vue components

--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ yarn dev
 
 This starts both the frontend (Vite) and the backend (Express + Claude Code agent) concurrently. Open [http://localhost:5173](http://localhost:5173) in your browser.
 
+### Messaging bridges (Telegram, CLI)
+
+MulmoClaude can be accessed from messaging apps via **bridge processes**. Bridges run as separate child processes and connect to the server over socket.io.
+
+```bash
+# Interactive CLI bridge (same machine)
+yarn cli
+
+# Telegram bot bridge (requires TELEGRAM_BOT_TOKEN in .env)
+yarn telegram
+```
+
+Bridges are also available as standalone npm packages:
+
+```bash
+npx @mulmobridge/cli@latest      # CLI bridge
+npx @mulmobridge/telegram@latest # Telegram bridge
+```
+
+See [`docs/message_apps/telegram/README.md`](docs/message_apps/telegram/README.md) for Telegram bot setup (BotFather, chat ID allowlist, etc.).
+
 ### Why do you need a Gemini API key?
 
 MulmoClaude uses Google's **Gemini 3.1 Flash Image (nano banana 2)** model for image generation and editing. This powers:
@@ -55,6 +76,15 @@ MulmoClaude uses Claude Code as its AI backend, which has access to tools includ
 **Without Docker**, Claude can access any file your user account can reach, including SSH keys and credentials stored outside your workspace. This is acceptable for personal local use, but worth understanding.
 
 **With Docker Desktop installed**, MulmoClaude automatically runs Claude inside a sandboxed container. Only your workspace and Claude's own config (`~/.claude`) are mounted — the rest of your filesystem is invisible to Claude. No configuration is required: the app detects Docker on startup and enables the sandbox automatically.
+
+**Bearer token auth**: every `/api/*` endpoint requires an `Authorization: Bearer <token>` header. The token is auto-generated on server startup and injected into the browser via a `<meta>` tag — no manual setup. The only exception is `/api/files/*` (exempt because `<img>` tags in rendered documents can't attach headers). See [`docs/developer.md`](docs/developer.md#auth-bearer-token-on-api) for details.
+
+**Sandbox credential forwarding** (opt-in): by default the sandbox has no access to host credentials. Two environment variables let you selectively expose what `git` / `gh` need:
+
+- `SANDBOX_SSH_AGENT_FORWARD=1` — forwards the host's SSH agent socket. Private keys stay on the host.
+- `SANDBOX_MOUNT_CONFIGS=gh,gitconfig` — mounts `~/.config/gh` and `~/.gitconfig` read-only.
+
+Full contract and security notes: [`docs/sandbox-credentials.md`](docs/sandbox-credentials.md).
 
 ### Installing Docker Desktop
 
@@ -389,6 +419,21 @@ Constraints the server enforces when loading the file:
 
 You don't need to list `mcp__<id>` entries for servers defined in `mcp.json` — those are allowed automatically on every agent run. `extraAllowedTools` is only for tools that aren't reachable through your own `mcpServers`, typically Claude Code's built-in `mcp__claude_ai_*` bridges after you've run `claude mcp` and completed OAuth.
 
+## Chat Attachments
+
+Paste (Ctrl+V / Cmd+V) or drag-and-drop files into the chat input to send them to Claude alongside your message.
+
+| File type | What Claude sees | Dependency |
+|---|---|---|
+| Image (PNG, JPEG, GIF, WebP, …) | Vision content block (native) | None |
+| PDF | Document content block (native) | None |
+| Text (.txt, .csv, .json, .md, .xml, .html, .yaml) | Decoded UTF-8 text | None |
+| DOCX | Extracted plain text | `mammoth` (npm) |
+| XLSX | CSV per sheet | `xlsx` (npm) |
+| PPTX | Converted to PDF | LibreOffice (Docker sandbox) |
+
+PPTX conversion runs inside the Docker sandbox image (`libreoffice --headless`). Without Docker, a message suggests exporting to PDF or images instead. Maximum attachment size is 30 MB.
+
 ## Workspace
 
 All data is stored as plain files in the workspace directory, grouped into four semantic buckets (#284):
@@ -426,3 +471,17 @@ fields.
 The chat-side `manageTodoList` MCP tool keeps its existing behaviour
 unchanged — it can read and edit text / note / labels / completed
 todos, and the explorer's extra fields are preserved across MCP edits.
+
+## Monorepo Packages
+
+Shared code is extracted into publishable npm packages under `packages/`:
+
+| Package | Description |
+|---|---|
+| `@mulmobridge/protocol` | Shared types and constants (EVENT_TYPES, Attachment, socket events) |
+| `@mulmobridge/client` | Socket.io client library + bearer token reader + MIME utilities |
+| `@mulmobridge/chat-service` | Server-side chat service (socket.io + REST bridge, DI factory) |
+| `@mulmobridge/cli` | Interactive terminal bridge (`yarn cli` or `npx @mulmobridge/cli`) |
+| `@mulmobridge/telegram` | Telegram bot bridge (`yarn telegram` or `npx @mulmobridge/telegram`) |
+
+Anyone can write a bridge in any language — just speak the socket.io protocol documented in [`docs/bridge-protocol.md`](docs/bridge-protocol.md).

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,67 @@
+# MulmoClaude v0.1.1
+
+## Highlights
+
+### Monorepo & npm Packages (#360)
+Extracted shared code into publishable `@mulmobridge/*` packages under yarn workspaces:
+- **@mulmobridge/protocol** (v0.1.1) — shared types and constants (EVENT_TYPES, Attachment, CHAT_SOCKET_EVENTS)
+- **@mulmobridge/client** (v0.1.0) — socket.io client library, bearer token reader, MIME utilities
+- **@mulmobridge/chat-service** (v0.1.0) — server-side chat service (socket.io + REST bridge)
+- **@mulmobridge/cli** (v0.1.1) — interactive terminal bridge (`npx @mulmobridge/cli@latest`)
+- **@mulmobridge/telegram** (v0.1.1) — Telegram bot bridge (`npx @mulmobridge/telegram@latest`)
+
+### Real-time Text Streaming (#392, #393)
+Claude responses now stream token-by-token in the Web UI instead of appearing all at once.
+
+### Workspace Restructure (#284, #314)
+Workspace layout reorganized into 4 semantic buckets: `config/`, `conversations/`, `data/`, `artifacts/`. Migration script included for existing workspaces.
+
+### File I/O Consolidation (#366, #368, #371, #374, #376, #384)
+All workspace file operations centralized into domain-specific I/O modules under `server/utils/files/` with atomic writes, discriminated-union returns, and DI-ready signatures. Eliminates raw `fs.*` / `path.join` in route handlers.
+
+### Telegram Bridge (#321, #322, #355)
+Full Telegram bot bridge with long-polling, photo/image attachment support, chat-ID allowlist, long-message chunking, and server push delivery.
+
+## Features
+
+- **Sandbox enhancements**: opt-in host credential forwarding (#327), macOS SSH agent support (#347), gh CLI with auth (#353)
+- **Image & PDF in chat**: paste/drag-and-drop image (#379), PDF attachment support (#385)
+- **UI improvements**: auto-expand chat input (#387), unread session highlights (#343), launcher active highlight + badge tooltips (#362), lock popup improvements (#332, #356)
+- **Skills system**: render SKILL.md as formatted markdown (#339), direct editing in UI (#342), update via chat (#344)
+- **Incremental session fetch**: server cursor for efficient session loading (#338)
+- **Notification scaffold**: time-delayed push fan-out (#331)
+- **GitHub workspace**: standardize github/ directory + .gitignore filter (#358, #365)
+
+## Refactoring & Infrastructure
+
+- Server reorganized into 6 topical dirs (#328)
+- Extracted `useImeAwareEnter` composable (#378)
+- Attachment protocol: `imageDataUrl` replaced with `Attachment[]` (#383)
+- Pre-commit hook + `/precommit` review skill (#388, #389, #391, #398)
+- Test coverage expanded: session-store, image-store, plugin paths, workspace shape, chat-index, markdown-store (#367, #370, #373, #375)
+- ESLint flat config scoped correctly for all packages
+
+## Bug Fixes
+
+- Bearer token wired to MCP subprocess (#325) and frontend plugin launcher (#326)
+- Agent resume failover on stored session ID rejection (#324)
+- Wiki path references updated for post-#284 layout (#354, #359)
+- PresentDocument images broken by bearer auth + path migration (#372)
+- Re-fetch transcript on session_finished to recover missed events (#351)
+- Post-#284 workspace paths in markdown + spreadsheet plugins (#348)
+
+## Breaking Changes
+
+- Workspace layout changed (#284) — run migration script before upgrading
+- `bridges/` directory removed — use `@mulmobridge/*` packages or `yarn cli` / `yarn telegram`
+- `imageDataUrl` field removed from bridge protocol — use `attachments: Attachment[]` instead
+
+## npm Packages
+
+| Package | Version | npm |
+|---|---|---|
+| @mulmobridge/protocol | 0.1.1 | https://www.npmjs.com/package/@mulmobridge/protocol |
+| @mulmobridge/client | 0.1.0 | https://www.npmjs.com/package/@mulmobridge/client |
+| @mulmobridge/chat-service | 0.1.0 | https://www.npmjs.com/package/@mulmobridge/chat-service |
+| @mulmobridge/cli | 0.1.1 | https://www.npmjs.com/package/@mulmobridge/cli |
+| @mulmobridge/telegram | 0.1.1 | https://www.npmjs.com/package/@mulmobridge/telegram |


### PR DESCRIPTION
## Summary

Brings README.md, CLAUDE.md, and release docs up to date with all v0.1.1 changes. The audit found 6 major features documented nowhere in the main docs.

### README.md additions

| Section | What was added |
|---|---|
| **Messaging bridges** | Telegram + CLI bridge intro, \`yarn cli\` / \`yarn telegram\`, npx standalone usage, link to Telegram setup guide |
| **Security (expanded)** | Bearer token auth explanation, \`/api/files/*\` exemption rationale, sandbox credential forwarding (\`SANDBOX_SSH_AGENT_FORWARD\`, \`SANDBOX_MOUNT_CONFIGS\`), link to sandbox-credentials.md |
| **Chat Attachments** (new) | Support table (image/PDF/text/DOCX/XLSX/PPTX) with conversion methods, dependencies, and PPTX Docker requirement. 30 MB limit noted. |
| **Monorepo Packages** (new) | \`@mulmobridge/*\` package table (protocol, client, chat-service, cli, telegram) with descriptions |

### CLAUDE.md additions

- \`server/agent/attachmentConverter.ts\` added to Key Files table
- \`chat-service\` description updated (DI factory, \`@mulmobridge/chat-service\`)
- \`auth\` description updated (\`/api/files/*\` exemption note)
- \`packages/\` directory added to layout section (all 5 workspace packages)
- \`attachmentConverter.ts\` added to agent/ dir listing

### Release notes

\`docs/releases/v0.1.1.md\` — archived from GitHub release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)