### PR TITLE
feat(telegram): document/file attachment support (PDF, DOCX, XLSX, PPTX)

### DIFF
--- a/packages/telegram/src/api.ts
+++ b/packages/telegram/src/api.ts
@@ -191,8 +191,14 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       }
       const buffer = await fileRes.arrayBuffer();
       const b64 = Buffer.from(buffer).toString("base64");
+      // Prefer the caller-supplied MIME (Telegram's doc.mime_type is
+      // authoritative). Fall back to extension-based inference only
+      // when the caller passed the generic default.
       const ext = getFileBody.result.file_path.split(".").pop() ?? "";
-      const mediaType = mimeFromExtension(ext, fallbackMime);
+      const mediaType =
+        fallbackMime !== "application/octet-stream"
+          ? fallbackMime
+          : mimeFromExtension(ext, fallbackMime);
       return buildDataUrl(mediaType, b64);
     },
   };

--- a/packages/telegram/src/api.ts
+++ b/packages/telegram/src/api.ts
@@ -26,12 +26,21 @@ export interface TelegramPhotoSize {
   file_size?: number;
 }
 
+export interface TelegramDocument {
+  file_id: string;
+  file_unique_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
 export interface TelegramMessage {
   message_id: number;
   chat: TelegramChat;
   from?: TelegramUser;
   text?: string;
   photo?: TelegramPhotoSize[];
+  document?: TelegramDocument;
   caption?: string;
   date: number;
 }
@@ -74,7 +83,10 @@ export interface TelegramApi {
     messageId: number,
     text: string,
   ): Promise<void>;
-  downloadPhoto(fileId: string): Promise<string>;
+  /** Download any file by file_id via the Telegram getFile API.
+   *  Returns a data URL (`data:<mime>;base64,...`).
+   *  Works for photos, documents, audio, etc. */
+  downloadFile(fileId: string, fallbackMime?: string): Promise<string>;
 }
 
 const DEFAULT_BASE = "https://api.telegram.org";
@@ -153,7 +165,7 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       }
     },
 
-    async downloadPhoto(fileId) {
+    async downloadFile(fileId, fallbackMime = "application/octet-stream") {
       const getFileRes = await fetchImpl(
         `${base}/getFile?file_id=${encodeURIComponent(fileId)}`,
       );
@@ -180,7 +192,7 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       const buffer = await fileRes.arrayBuffer();
       const b64 = Buffer.from(buffer).toString("base64");
       const ext = getFileBody.result.file_path.split(".").pop() ?? "";
-      const mediaType = mimeFromExtension(ext, "image/jpeg");
+      const mediaType = mimeFromExtension(ext, fallbackMime);
       return buildDataUrl(mediaType, b64);
     },
   };

--- a/packages/telegram/src/router.ts
+++ b/packages/telegram/src/router.ts
@@ -120,48 +120,53 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
     }
   }
 
+  // Download all media from a message. Telegram messages are usually
+  // exclusive (photo OR document), but forwarded messages or future
+  // API changes could carry both. We collect all available attachments
+  // rather than picking one.
   async function tryDownloadAttachments(
     msg: TelegramMessage,
   ): Promise<AttachmentResult> {
-    const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
-    const hasDocument = msg.document !== undefined;
-    if (!hasPhoto && !hasDocument) return { attachments: [], failed: false };
+    const attachments: Attachment[] = [];
+    let anyFailed = false;
 
-    try {
-      if (hasPhoto) {
-        // Photos: Telegram sends multiple sizes; pick the largest.
-        const largest = msg.photo![msg.photo!.length - 1];
+    if (Array.isArray(msg.photo) && msg.photo.length > 0) {
+      const largest = msg.photo[msg.photo.length - 1];
+      try {
         const dataUrl = await api.downloadFile(largest.file_id, "image/jpeg");
         const parsed = parseDataUrl(dataUrl);
         if (parsed) {
-          return {
-            attachments: [{ mimeType: parsed.mimeType, data: parsed.data }],
-            failed: false,
-          };
+          attachments.push({ mimeType: parsed.mimeType, data: parsed.data });
         }
-      } else if (hasDocument) {
-        // Documents: PDF, DOCX, XLSX, PPTX, text files, etc.
-        const doc = msg.document!;
-        const fallbackMime = doc.mime_type ?? "application/octet-stream";
+      } catch (err) {
+        log.error(`[telegram] photo download failed: ${String(err)}`);
+        anyFailed = true;
+      }
+    }
+
+    if (msg.document) {
+      const doc = msg.document;
+      const fallbackMime = doc.mime_type ?? "application/octet-stream";
+      try {
         const dataUrl = await api.downloadFile(doc.file_id, fallbackMime);
         const parsed = parseDataUrl(dataUrl);
         if (parsed) {
-          return {
-            attachments: [
-              {
-                mimeType: parsed.mimeType,
-                data: parsed.data,
-                filename: doc.file_name,
-              },
-            ],
-            failed: false,
-          };
+          attachments.push({
+            mimeType: parsed.mimeType,
+            data: parsed.data,
+            filename: doc.file_name,
+          });
         }
+      } catch (err) {
+        log.error(`[telegram] document download failed: ${String(err)}`);
+        anyFailed = true;
       }
-    } catch (err) {
-      log.error(`[telegram] attachment download failed: ${String(err)}`);
     }
-    return { attachments: [], failed: true };
+
+    if (attachments.length === 0 && anyFailed) {
+      return { attachments: [], failed: true };
+    }
+    return { attachments, failed: false };
   }
 
   async function sendReply(chatId: number, ack: MessageAck): Promise<void> {

--- a/packages/telegram/src/router.ts
+++ b/packages/telegram/src/router.ts
@@ -53,7 +53,7 @@ const defaultLog = {
   error: (m: string) => console.error(m),
 };
 
-interface PhotoResult {
+interface AttachmentResult {
   attachments: Attachment[];
   failed: boolean;
 }
@@ -120,21 +120,46 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
     }
   }
 
-  async function tryDownloadPhoto(msg: TelegramMessage): Promise<PhotoResult> {
+  async function tryDownloadAttachments(
+    msg: TelegramMessage,
+  ): Promise<AttachmentResult> {
     const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
-    if (!hasPhoto) return { attachments: [], failed: false };
-    const largest = msg.photo![msg.photo!.length - 1];
+    const hasDocument = msg.document !== undefined;
+    if (!hasPhoto && !hasDocument) return { attachments: [], failed: false };
+
     try {
-      const dataUrl = await api.downloadPhoto(largest.file_id);
-      const parsed = parseDataUrl(dataUrl);
-      if (parsed) {
-        return {
-          attachments: [{ mimeType: parsed.mimeType, data: parsed.data }],
-          failed: false,
-        };
+      if (hasPhoto) {
+        // Photos: Telegram sends multiple sizes; pick the largest.
+        const largest = msg.photo![msg.photo!.length - 1];
+        const dataUrl = await api.downloadFile(largest.file_id, "image/jpeg");
+        const parsed = parseDataUrl(dataUrl);
+        if (parsed) {
+          return {
+            attachments: [{ mimeType: parsed.mimeType, data: parsed.data }],
+            failed: false,
+          };
+        }
+      } else if (hasDocument) {
+        // Documents: PDF, DOCX, XLSX, PPTX, text files, etc.
+        const doc = msg.document!;
+        const fallbackMime = doc.mime_type ?? "application/octet-stream";
+        const dataUrl = await api.downloadFile(doc.file_id, fallbackMime);
+        const parsed = parseDataUrl(dataUrl);
+        if (parsed) {
+          return {
+            attachments: [
+              {
+                mimeType: parsed.mimeType,
+                data: parsed.data,
+                filename: doc.file_name,
+              },
+            ],
+            failed: false,
+          };
+        }
       }
     } catch (err) {
-      log.error(`[telegram] photo download failed: ${String(err)}`);
+      log.error(`[telegram] attachment download failed: ${String(err)}`);
     }
     return { attachments: [], failed: true };
   }
@@ -155,28 +180,31 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
   async function handleAllowed(msg: TelegramMessage): Promise<void> {
     const chatId = msg.chat.id;
     const text = msg.text ?? msg.caption ?? "";
-    const hasPhoto = Array.isArray(msg.photo) && msg.photo.length > 0;
-    if (text.trim().length === 0 && !hasPhoto) return;
+    const hasMedia =
+      (Array.isArray(msg.photo) && msg.photo.length > 0) ||
+      msg.document !== undefined;
+    if (text.trim().length === 0 && !hasMedia) return;
 
+    const mediaLabel = buildMediaLabel(msg);
     log.info(
-      `[telegram] accepted chat=${chatId} user=@${userLabel(msg)} len=${text.length}${hasPhoto ? " +photo" : ""}`,
+      `[telegram] accepted chat=${chatId} user=@${userLabel(msg)} len=${text.length}${mediaLabel}`,
     );
 
-    const { attachments, failed } = await tryDownloadPhoto(msg);
+    const { attachments, failed } = await tryDownloadAttachments(msg);
 
-    // Photo-only message where download failed: bail out instead
-    // of sending "What is this image?" without the actual image.
+    // Attachment-only message where download failed: bail out instead
+    // of sending a query without the actual file.
     if (failed && text.trim().length === 0) {
       await api
         .sendMessage(
           chatId,
-          "Sorry, I could not download the photo. Please try again.",
+          "Sorry, I could not download the attachment. Please try again.",
         )
         .catch(() => {});
       return;
     }
 
-    // Surface the photo-drop so the user knows the image was lost.
+    // Surface the attachment failure so the user knows the file was lost.
     const messageText = resolveMessageText(text, failed);
 
     // Start streaming: chunks will arrive via handleTextChunk and
@@ -276,13 +304,22 @@ async function sendChunked(
   }
 }
 
-function resolveMessageText(text: string, photoFailed: boolean): string {
+function resolveMessageText(text: string, attachmentFailed: boolean): string {
   const hasText = text.trim().length > 0;
-  if (photoFailed && hasText) {
-    return `${text}\n\n(note: attached photo could not be downloaded)`;
+  if (attachmentFailed && hasText) {
+    return `${text}\n\n(note: attached file could not be downloaded)`;
   }
   if (hasText) return text;
-  return "What is this image?";
+  return "Describe / analyze this file.";
+}
+
+function buildMediaLabel(msg: TelegramMessage): string {
+  if (msg.document) {
+    const hint = msg.document.file_name ?? msg.document.mime_type ?? "unknown";
+    return ` +file(${hint})`;
+  }
+  if (Array.isArray(msg.photo) && msg.photo.length > 0) return " +photo";
+  return "";
 }
 
 function userLabel(msg: TelegramMessage): string {

--- a/packages/telegram/test/test_router.ts
+++ b/packages/telegram/test/test_router.ts
@@ -20,7 +20,7 @@ function stubApi(): TelegramApi & { sent: SentMessage[] } {
     async sendMessage(chatId, text) {
       sent.push({ chatId, text });
     },
-    async downloadPhoto() {
+    async downloadFile() {
       return "data:image/jpeg;base64,AAAA";
     },
   };
@@ -182,7 +182,7 @@ describe("router.handleMessage — allowed chat", () => {
       photo: [{ file_id: "f", file_unique_id: "u", width: 100, height: 100 }],
     };
     await router.handleMessage(photoMsg);
-    assert.equal(receivedText, "What is this image?");
+    assert.equal(receivedText, "Describe / analyze this file.");
   });
 });
 


### PR DESCRIPTION
## Summary

Telegram users can now send files (PDF, DOCX, XLSX, PPTX, text files, etc.) to the bot — not just photos. The bridge downloads them via the same Telegram getFile API and forwards as Attachment objects to the server, where attachmentConverter.ts handles conversion.

### End-to-end flow

```
Telegram user sends PPTX → bridge downloads via getFile API
  → Attachment { mimeType: "application/...presentationml...", data, filename }
  → server attachmentConverter: libreoffice --headless → PDF
  → Claude reads the PDF as a document content block
```

### Changes

| File | What |
|---|---|
| `packages/telegram/src/api.ts` | Added `TelegramDocument` interface; renamed `downloadPhoto` → `downloadFile` (generic, accepts `fallbackMime` param) |
| `packages/telegram/src/router.ts` | `tryDownloadPhoto` → `tryDownloadAttachments` handles both `msg.photo` and `msg.document`; includes `filename` for documents; log shows `+file(name.pptx)` |
| `packages/telegram/test/test_router.ts` | Updated default-text assertion |

### Supported types (via server-side conversion)

| Type | What happens |
|---|---|
| Image (photo) | Vision block (existing) |
| PDF | Document block (native) |
| Text files | UTF-8 decode → text block |
| DOCX | mammoth → text block |
| XLSX | xlsx → CSV text block |
| PPTX | libreoffice → PDF document block (Docker sandbox) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram document and file attachments in addition to existing photo support
  * Implemented generalized file download mechanism with automatic MIME type detection and proper fallback handling for unrecognized formats

* **Improvements**
  * Updated user-facing prompts to reference file attachments generically, improving clarity when processing non-image content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->