### PR TITLE
feat(skills): schedule skills via SKILL.md frontmatter (#357 Phase 2)

### DIFF
--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -23,6 +23,8 @@ import type { Skill, SkillSummary } from "../../workspace/skills/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
+import { refreshScheduledSkills } from "../../workspace/skills/scheduler.js";
+import { logBackgroundError } from "../../utils/logBackgroundError.js";
 import {
   badRequest,
   conflict,
@@ -117,6 +119,7 @@ router.post(
     });
     if (result.kind === "saved") {
       log.info("skills", "saved", { name });
+      refreshScheduledSkills().catch(logBackgroundError("skills"));
       res.json({ saved: true, path: result.path });
       return;
     }
@@ -174,6 +177,7 @@ router.put(
     });
     if (result.kind === "updated") {
       log.info("skills", "updated", { name });
+      refreshScheduledSkills().catch(logBackgroundError("skills"));
       res.json({ updated: true, path: result.path });
       return;
     }
@@ -210,6 +214,7 @@ router.delete(
     });
     if (result.kind === "deleted") {
       log.info("skills", "deleted", { name: result.name });
+      refreshScheduledSkills().catch(logBackgroundError("skills"));
       res.json({ deleted: true, name: result.name });
       return;
     }

--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -11,12 +11,14 @@ import path from "path";
 import { workspacePath } from "../workspace/workspace.js";
 import { writeFileAtomic } from "../utils/files/atomic.js";
 import { log } from "../system/logger/index.js";
+import { ONE_SECOND_MS } from "../utils/time.js";
 import type { ITaskManager, TaskDefinition } from "./task-manager/index.js";
 import {
   type TaskSchedule,
   type TaskExecutionState,
   type TaskLogEntry,
   type CatchUpTask,
+  type TaskTrigger,
   emptyState,
   computeCatchUpPlan,
   nextWindowAfter,
@@ -24,6 +26,10 @@ import {
   updateAndSave,
   appendLogEntry,
   queryLog,
+  SCHEDULE_TYPES,
+  TASK_RESULTS,
+  TASK_TRIGGERS,
+  MISSED_RUN_POLICIES,
   type StateMap,
   type StateDeps,
   type LogDeps,
@@ -64,7 +70,10 @@ export interface SystemTaskDef {
   name: string;
   description: string;
   schedule: TaskDefinition["schedule"];
-  missedRunPolicy: "skip" | "run-once" | "run-all";
+  missedRunPolicy:
+    | typeof MISSED_RUN_POLICIES.skip
+    | typeof MISSED_RUN_POLICIES.runOnce
+    | typeof MISSED_RUN_POLICIES.runAll;
   run: () => Promise<void>;
 }
 
@@ -113,7 +122,11 @@ export async function initScheduler(
     for (const run of plan.runs) {
       const task = tasks.find((t) => t.id === run.taskId);
       if (!task) continue;
-      await executeAndLog(task, run.context.scheduledFor, "catch-up");
+      await executeAndLog(
+        task,
+        run.context.scheduledFor,
+        TASK_TRIGGERS.catchUp,
+      );
     }
   }
 
@@ -125,7 +138,7 @@ export async function initScheduler(
       schedule: task.schedule,
       run: async () => {
         const windowIso = computeCurrentWindow(task);
-        await executeAndLog(task, windowIso, "scheduled");
+        await executeAndLog(task, windowIso, TASK_TRIGGERS.scheduled);
       },
     });
   }
@@ -169,7 +182,7 @@ export function getSchedulerTasks(): Array<{
 async function executeAndLog(
   task: SystemTaskDef,
   scheduledFor: string,
-  trigger: "scheduled" | "catch-up" | "manual",
+  trigger: TaskTrigger,
 ): Promise<void> {
   const startedAt = new Date().toISOString();
   const startMs = Date.now();
@@ -203,7 +216,7 @@ async function safePersist(
   scheduledFor: string,
   startedAt: string,
   durationMs: number,
-  trigger: "scheduled" | "catch-up" | "manual",
+  trigger: TaskTrigger,
   errorMessage: string | null,
 ): Promise<void> {
   const isSuccess = errorMessage === null;
@@ -215,7 +228,7 @@ async function safePersist(
       task.id,
       {
         lastRunAt: scheduledFor,
-        lastRunResult: isSuccess ? "success" : "error",
+        lastRunResult: isSuccess ? TASK_RESULTS.success : TASK_RESULTS.error,
         lastRunDurationMs: durationMs,
         lastErrorMessage: errorMessage,
         consecutiveFailures: isSuccess
@@ -241,7 +254,7 @@ async function safePersist(
         scheduledFor,
         startedAt,
         completedAt: new Date().toISOString(),
-        result: isSuccess ? "success" : "error",
+        result: isSuccess ? TASK_RESULTS.success : TASK_RESULTS.error,
         durationMs,
         trigger,
         ...(errorMessage !== null && { errorMessage }),
@@ -282,7 +295,9 @@ function computeCurrentWindow(task: SystemTaskDef): string {
   const windowMs = nextWindowAfter(
     coreSchedule,
     nowMs -
-      (coreSchedule.type === "interval" ? coreSchedule.intervalSec * 1000 : 0),
+      (coreSchedule.type === "interval"
+        ? coreSchedule.intervalSec * ONE_SECOND_MS
+        : 0),
   );
   return windowMs !== null && windowMs <= nowMs
     ? new Date(windowMs).toISOString()
@@ -296,10 +311,10 @@ function computeNextScheduled(task: SystemTaskDef): string | null {
 }
 
 function toCoreSchedule(schedule: TaskDefinition["schedule"]): TaskSchedule {
-  if (schedule.type === "interval") {
+  if (schedule.type === SCHEDULE_TYPES.interval) {
     return {
       type: "interval",
-      intervalSec: Math.round(schedule.intervalMs / 1000),
+      intervalSec: Math.round(schedule.intervalMs / ONE_SECOND_MS),
     };
   }
   return schedule;

--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -45,16 +45,16 @@ function logsDir(root = workspacePath): string {
 // ── I/O deps (real filesystem) ───────────────────────────────────
 
 const stateDeps: StateDeps = {
-  readFile: (p) => readFile(p, "utf-8"),
-  writeFileAtomic: (p, content) => writeFileAtomic(p, content),
+  readFile: (p: string) => readFile(p, "utf-8"),
+  writeFileAtomic: (p: string, content: string) => writeFileAtomic(p, content),
   exists: existsSync,
 };
 
 const logDeps: LogDeps = {
-  appendFile: (p, content) => appendFile(p, content),
-  readFile: (p) => readFile(p, "utf-8"),
+  appendFile: (p: string, content: string) => appendFile(p, content),
+  readFile: (p: string) => readFile(p, "utf-8"),
   exists: existsSync,
-  ensureDir: (p) => mkdir(p, { recursive: true }).then(() => {}),
+  ensureDir: (p: string) => mkdir(p, { recursive: true }).then(() => {}),
 };
 
 // ── System task registry ─────────────────────────────────────────

--- a/server/events/task-manager/index.ts
+++ b/server/events/task-manager/index.ts
@@ -1,8 +1,10 @@
 import { log } from "../../system/logger/index.js";
+import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "../../utils/time.js";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 
 export type TaskSchedule =
-  | { type: "interval"; intervalMs: number }
-  | { type: "daily"; time: string }; // time: "HH:MM" in UTC
+  | { type: typeof SCHEDULE_TYPES.interval; intervalMs: number }
+  | { type: typeof SCHEDULE_TYPES.daily; time: string }; // time: "HH:MM" in UTC
 
 export interface TaskRunContext {
   taskId: string;
@@ -30,28 +32,28 @@ export interface ITaskManager {
 }
 
 export interface TaskManagerOptions {
-  tickMs?: number; // default: 60_000
+  tickMs?: number; // default: ONE_MINUTE_MS
   now?: () => Date; // default: () => new Date()
 }
 
 function isDue(now: Date, schedule: TaskSchedule, tickMs: number): boolean {
-  if (schedule.type === "interval") {
+  if (schedule.type === SCHEDULE_TYPES.interval) {
     const msSinceMidnight =
-      now.getUTCHours() * 3600000 +
-      now.getUTCMinutes() * 60000 +
-      now.getUTCSeconds() * 1000;
+      now.getUTCHours() * ONE_HOUR_MS +
+      now.getUTCMinutes() * ONE_MINUTE_MS +
+      now.getUTCSeconds() * ONE_SECOND_MS;
     // Round down to tick boundary, then check if it aligns with the interval
     const rounded = Math.floor(msSinceMidnight / tickMs) * tickMs;
     return rounded % schedule.intervalMs === 0;
   }
 
-  if (schedule.type === "daily") {
+  if (schedule.type === SCHEDULE_TYPES.daily) {
     const [hh, mm] = schedule.time.split(":").map(Number);
-    const targetMs = hh * 3600000 + mm * 60000;
+    const targetMs = hh * ONE_HOUR_MS + mm * ONE_MINUTE_MS;
     const msSinceMidnight =
-      now.getUTCHours() * 3600000 +
-      now.getUTCMinutes() * 60000 +
-      now.getUTCSeconds() * 1000;
+      now.getUTCHours() * ONE_HOUR_MS +
+      now.getUTCMinutes() * ONE_MINUTE_MS +
+      now.getUTCSeconds() * ONE_SECOND_MS;
     const rounded = Math.floor(msSinceMidnight / tickMs) * tickMs;
     return rounded === targetMs;
   }
@@ -60,7 +62,7 @@ function isDue(now: Date, schedule: TaskSchedule, tickMs: number): boolean {
 }
 
 export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
-  const tickMs = options?.tickMs ?? 60_000;
+  const tickMs = options?.tickMs ?? ONE_MINUTE_MS;
   const now = options?.now ?? (() => new Date());
   const registry = new Map<string, TaskDefinition>();
   let timer: ReturnType<typeof setInterval> | null = null;

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,7 @@ import {
   mcpTools,
   isMcpToolEnabled,
 } from "./agent/mcp-tools/index.js";
-import { initWorkspace } from "./workspace/workspace.js";
+import { initWorkspace, workspacePath } from "./workspace/workspace.js";
 import { env, isGeminiAvailable } from "./system/env.js";
 import { buildSandboxStatus } from "./api/sandboxStatus.js";
 import fs from "fs";
@@ -61,6 +61,7 @@ import {
 } from "./api/auth/token.js";
 import { log } from "./system/logger/index.js";
 import { startChat } from "./api/routes/agent.js";
+import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
 
 const HTML_TOKEN_PLACEHOLDER = "__MULMOCLAUDE_AUTH_TOKEN__";
@@ -390,6 +391,25 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
       error: String(err),
     });
   });
+
+  // Register skills with schedule: frontmatter as scheduled tasks.
+  // Fire-and-forget — skill scan errors are logged but don't block
+  // server startup.
+  registerScheduledSkills({
+    taskManager,
+    workspaceRoot: workspacePath,
+    startChat,
+  })
+    .then((count) => {
+      if (count > 0) {
+        log.info("skills", "scheduled skills registered", { count });
+      }
+    })
+    .catch((err) => {
+      log.warn("skills", "failed to register scheduled skills", {
+        error: String(err),
+      });
+    });
 
   taskManager.start();
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,6 +63,8 @@ import { log } from "./system/logger/index.js";
 import { startChat } from "./api/routes/agent.js";
 import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
+import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
+import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 
 const HTML_TOKEN_PLACEHOLDER = "__MULMOCLAUDE_AUTH_TOKEN__";
 
@@ -357,7 +359,7 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
 
   // --- Task Manager ---
   const taskManager = createTaskManager({
-    tickMs: debugMode ? 1_000 : 60_000,
+    tickMs: debugMode ? ONE_SECOND_MS : ONE_MINUTE_MS,
   });
 
   if (debugMode) {
@@ -373,16 +375,16 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
       id: "system:journal",
       name: "Journal daily pass",
       description: "Summarize recent chat sessions into daily + topic files",
-      schedule: { type: "interval", intervalMs: 3_600_000 }, // 1h
-      missedRunPolicy: "run-once",
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_HOUR_MS },
+      missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
       run: () => maybeRunJournal({}),
     },
     {
       id: "system:chat-index",
       name: "Chat index backfill",
       description: "Generate AI titles + summaries for un-indexed sessions",
-      schedule: { type: "interval", intervalMs: 3_600_000 },
-      missedRunPolicy: "run-once",
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_HOUR_MS },
+      missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
       run: () => backfillAllSessions().then(() => {}),
     },
   ];
@@ -478,7 +480,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
     id: "debug.auto-chat",
     description:
       "Debug — toggles title color 10 times then starts a General-mode chat, then self-removes",
-    schedule: { type: "interval", intervalMs: 1_000 },
+    schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_SECOND_MS },
     run: async () => {
       tick++;
       const last = tick === 10;

--- a/server/utils/time.ts
+++ b/server/utils/time.ts
@@ -1,0 +1,14 @@
+// Common time constants in milliseconds. Avoids magic numbers like
+// 3_600_000 scattered across the codebase.
+
+export const ONE_SECOND_MS = 1_000;
+export const ONE_MINUTE_MS = 60_000;
+export const ONE_HOUR_MS = 3_600_000;
+export const ONE_DAY_MS = 86_400_000;
+
+/** Map time-unit suffixes (s/m/h) to milliseconds. */
+export const TIME_UNIT_MS: Record<string, number> = {
+  s: ONE_SECOND_MS,
+  m: ONE_MINUTE_MS,
+  h: ONE_HOUR_MS,
+};

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -1,11 +1,11 @@
 // Pure SKILL.md parser. Given the raw file content, return the
-// `description` (from YAML frontmatter) + body. Kept dependency-free
-// so tests don't need a filesystem.
+// `description` (from YAML frontmatter) + body, plus optional
+// `schedule` and `roleId` for auto-scheduling (#357 Phase 2).
 //
-// Minimal YAML: we only care about one `description` key, so rather
-// than pulling in a YAML parser we do line-by-line extraction. This
-// mirrors the approach used by server/sources/registry.ts for source
-// frontmatter — no js-yaml, no ambiguity with multi-line scalars.
+// Minimal YAML: we only care about a few keys, so rather than
+// pulling in a YAML parser we do line-by-line extraction.
+
+import { TIME_UNIT_MS } from "../../utils/time.js";
 
 export interface SkillSchedule {
   /** "daily HH:MM" or "interval Ns/Nm/Nh" or "once YYYY-MM-DDTHH:MM" */
@@ -66,12 +66,9 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   if (intervalMatch) {
     const value = Number(intervalMatch[1]);
     const unit = intervalMatch[2];
-    const multipliers: Record<string, number> = {
-      s: 1_000,
-      m: 60_000,
-      h: 3_600_000,
-    };
-    return { type: "interval", intervalMs: value * multipliers[unit] };
+    const ms = TIME_UNIT_MS[unit];
+    if (!ms) return null;
+    return { type: "interval", intervalMs: value * ms };
   }
 
   return null;

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -52,23 +52,31 @@ function parseScalar(raw: string): string {
  *   "interval 2h"      → { type: "interval", intervalMs: 7200000 }
  *   "interval 300s"    → { type: "interval", intervalMs: 300000 }
  */
+// Minimum interval to prevent accidental runaway scheduling.
+const MIN_INTERVAL_MS = 10_000; // 10 seconds
+
 function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   const trimmed = raw.trim();
 
-  // daily HH:MM
-  const dailyMatch = trimmed.match(/^daily\s+(\d{2}:\d{2})$/);
+  // daily HH:MM — validate range: HH 00-23, MM 00-59
+  const dailyMatch = trimmed.match(/^daily\s+(\d{2}):(\d{2})$/);
   if (dailyMatch) {
-    return { type: "daily", time: dailyMatch[1] };
+    const hh = Number(dailyMatch[1]);
+    const mm = Number(dailyMatch[2]);
+    if (hh > 23 || mm > 59) return null;
+    return { type: "daily", time: `${dailyMatch[1]}:${dailyMatch[2]}` };
   }
 
-  // interval Ns / Nm / Nh
+  // interval Ns / Nm / Nh — must be >= MIN_INTERVAL_MS
   const intervalMatch = trimmed.match(/^interval\s+(\d+)([smh])$/);
   if (intervalMatch) {
     const value = Number(intervalMatch[1]);
     const unit = intervalMatch[2];
     const ms = TIME_UNIT_MS[unit];
     if (!ms) return null;
-    return { type: "interval", intervalMs: value * ms };
+    const intervalMs = value * ms;
+    if (intervalMs < MIN_INTERVAL_MS) return null;
+    return { type: "interval", intervalMs };
   }
 
   return null;

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -6,14 +6,15 @@
 // pulling in a YAML parser we do line-by-line extraction.
 
 import { TIME_UNIT_MS } from "../../utils/time.js";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 
 export interface SkillSchedule {
-  /** "daily HH:MM" or "interval Ns/Nm/Nh" or "once YYYY-MM-DDTHH:MM" */
+  /** "daily HH:MM" or "interval Ns/Nm/Nh" */
   raw: string;
   /** Parsed into task-manager-compatible shape */
   parsed:
-    | { type: "daily"; time: string }
-    | { type: "interval"; intervalMs: number }
+    | { type: typeof SCHEDULE_TYPES.daily; time: string }
+    | { type: typeof SCHEDULE_TYPES.interval; intervalMs: number }
     | null;
 }
 
@@ -64,7 +65,10 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
     const hh = Number(dailyMatch[1]);
     const mm = Number(dailyMatch[2]);
     if (hh > 23 || mm > 59) return null;
-    return { type: "daily", time: `${dailyMatch[1]}:${dailyMatch[2]}` };
+    return {
+      type: SCHEDULE_TYPES.daily,
+      time: `${dailyMatch[1]}:${dailyMatch[2]}`,
+    };
   }
 
   // interval Ns / Nm / Nh — must be >= MIN_INTERVAL_MS
@@ -76,7 +80,7 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
     if (!ms) return null;
     const intervalMs = value * ms;
     if (intervalMs < MIN_INTERVAL_MS) return null;
-    return { type: "interval", intervalMs };
+    return { type: SCHEDULE_TYPES.interval, intervalMs };
   }
 
   return null;

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -7,9 +7,23 @@
 // mirrors the approach used by server/sources/registry.ts for source
 // frontmatter — no js-yaml, no ambiguity with multi-line scalars.
 
+export interface SkillSchedule {
+  /** "daily HH:MM" or "interval Ns/Nm/Nh" or "once YYYY-MM-DDTHH:MM" */
+  raw: string;
+  /** Parsed into task-manager-compatible shape */
+  parsed:
+    | { type: "daily"; time: string }
+    | { type: "interval"; intervalMs: number }
+    | null;
+}
+
 export interface ParsedSkill {
   description: string;
   body: string;
+  /** If present, this skill should be auto-scheduled */
+  schedule?: SkillSchedule;
+  /** Role to use when running the scheduled skill (default: "general") */
+  roleId?: string;
 }
 
 // Match a YAML scalar value on a single line:
@@ -31,6 +45,39 @@ function parseScalar(raw: string): string {
 }
 
 /**
+ * Parse schedule value from frontmatter.
+ * Supported formats:
+ *   "daily HH:MM"      → { type: "daily", time: "HH:MM" }
+ *   "interval 30m"     → { type: "interval", intervalMs: 1800000 }
+ *   "interval 2h"      → { type: "interval", intervalMs: 7200000 }
+ *   "interval 300s"    → { type: "interval", intervalMs: 300000 }
+ */
+function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
+  const trimmed = raw.trim();
+
+  // daily HH:MM
+  const dailyMatch = trimmed.match(/^daily\s+(\d{2}:\d{2})$/);
+  if (dailyMatch) {
+    return { type: "daily", time: dailyMatch[1] };
+  }
+
+  // interval Ns / Nm / Nh
+  const intervalMatch = trimmed.match(/^interval\s+(\d+)([smh])$/);
+  if (intervalMatch) {
+    const value = Number(intervalMatch[1]);
+    const unit = intervalMatch[2];
+    const multipliers: Record<string, number> = {
+      s: 1_000,
+      m: 60_000,
+      h: 3_600_000,
+    };
+    return { type: "interval", intervalMs: value * multipliers[unit] };
+  }
+
+  return null;
+}
+
+/**
  * Parse a SKILL.md file. Returns null when:
  *  - the file has no frontmatter (no leading `---` fence)
  *  - the frontmatter is unterminated
@@ -38,11 +85,30 @@ function parseScalar(raw: string): string {
  *
  * An empty body is allowed (the skill may be just metadata for now).
  */
+// Extract key-value pairs from YAML frontmatter lines. Returns a
+// map of key → scalar value. Keeps parseSkillFrontmatter under the
+// cognitive-complexity threshold.
+function extractFrontmatterFields(
+  lines: string[],
+  startIdx: number,
+  endIdx: number,
+): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (let i = startIdx; i < endIdx; i++) {
+    const line = lines[i];
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = parseScalar(line.slice(colonIdx + 1));
+    fields.set(key, value);
+  }
+  return fields;
+}
+
 export function parseSkillFrontmatter(raw: string): ParsedSkill | null {
   const lines = raw.split(/\r?\n/);
   if (lines.length === 0 || lines[0].trim() !== "---") return null;
 
-  // Find the closing `---` fence. Skip index 0 (the opener).
   let closeIdx = -1;
   for (let i = 1; i < lines.length; i++) {
     if (lines[i].trim() === "---") {
@@ -52,20 +118,12 @@ export function parseSkillFrontmatter(raw: string): ParsedSkill | null {
   }
   if (closeIdx === -1) return null;
 
-  let description: string | null = null;
-  for (let i = 1; i < closeIdx; i++) {
-    const line = lines[i];
-    // Only the `description:` key matters in phase 0. Split on the
-    // FIRST colon so values containing ":" are preserved.
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) continue;
-    const key = line.slice(0, colonIdx).trim();
-    if (key !== "description") continue;
-    description = parseScalar(line.slice(colonIdx + 1));
-    break;
-  }
-
+  const fields = extractFrontmatterFields(lines, 1, closeIdx);
+  const description = fields.get("description") ?? null;
   if (description === null) return null;
+
+  const scheduleRaw = fields.get("schedule") ?? null;
+  const roleId = fields.get("roleId") ?? null;
 
   // Body starts after the closing fence. Trim leading blank lines so
   // the UI doesn't render an awkward gap above the first heading.
@@ -75,5 +133,13 @@ export function parseSkillFrontmatter(raw: string): ParsedSkill | null {
     .replace(/^(?:\s*\n)+/, "")
     .trimEnd();
 
-  return { description, body };
+  const result: ParsedSkill = { description, body };
+  if (scheduleRaw) {
+    result.schedule = {
+      raw: scheduleRaw,
+      parsed: parseScheduleValue(scheduleRaw),
+    };
+  }
+  if (roleId) result.roleId = roleId;
+  return result;
 }

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -3,9 +3,9 @@
 // task-manager. Each scheduled skill fires `startChat()` with the
 // skill body as the message and the skill's `roleId` (or "general").
 //
-// Called once at server startup after the task-manager is created.
-// Re-scanning on skill file changes is deferred — restart is the
-// simplest refresh for now.
+// `refreshScheduledSkills()` can be called at any time to re-scan
+// and update registrations (e.g. after a skill is saved/deleted
+// via the API). It unregisters stale tasks and registers new ones.
 
 import { discoverSkills } from "./discovery.js";
 import type { Skill } from "./types.js";
@@ -17,6 +17,11 @@ import { parseSkillFrontmatter } from "./parser.js";
 import { log } from "../../system/logger/index.js";
 import { readFileSync } from "fs";
 
+interface SkillScheduleInfo {
+  schedule: TaskSchedule;
+  roleId: string;
+}
+
 export interface SkillSchedulerDeps {
   taskManager: ITaskManager;
   workspaceRoot: string;
@@ -27,19 +32,51 @@ export interface SkillSchedulerDeps {
   }) => Promise<{ kind: string }>;
 }
 
+const SKILL_TASK_PREFIX = "skill.";
+
+// Track registered skill task IDs so refresh can unregister stale ones.
+let registeredTaskIds = new Set<string>();
+let cachedDeps: SkillSchedulerDeps | null = null;
+
 export async function registerScheduledSkills(
   deps: SkillSchedulerDeps,
 ): Promise<number> {
+  cachedDeps = deps;
+  return doRegister(deps);
+}
+
+/**
+ * Re-scan skills and update task-manager registrations. Safe to call
+ * after a skill is saved, updated, or deleted — removes stale tasks
+ * and adds new ones without a server restart.
+ */
+export async function refreshScheduledSkills(): Promise<number> {
+  if (!cachedDeps) {
+    log.warn("skills", "refreshScheduledSkills called before initial register");
+    return 0;
+  }
+  return doRegister(cachedDeps);
+}
+
+async function doRegister(deps: SkillSchedulerDeps): Promise<number> {
   const { taskManager, workspaceRoot, startChat } = deps;
+
+  // Unregister all previously registered skill tasks
+  for (const taskId of registeredTaskIds) {
+    taskManager.removeTask(taskId);
+  }
+  const previousCount = registeredTaskIds.size;
+  registeredTaskIds = new Set<string>();
+
   const skills = await discoverSkills({ workspaceRoot });
   let registered = 0;
 
   for (const skill of skills) {
-    const schedule = readSkillSchedule(skill);
-    if (!schedule) continue;
+    const info = readSkillScheduleInfo(skill);
+    if (!info) continue;
 
-    const roleId = readSkillRoleId(skill) ?? "general";
-    const taskId = `skill.${skill.name}`;
+    const { schedule, roleId } = info;
+    const taskId = `${SKILL_TASK_PREFIX}${skill.name}`;
 
     taskManager.registerTask({
       id: taskId,
@@ -64,42 +101,32 @@ export async function registerScheduledSkills(
       },
     });
 
-    log.info("skills", "registered scheduled skill", {
-      name: skill.name,
-      taskId,
-      schedule: schedule.type,
-      roleId,
-    });
+    registeredTaskIds.add(taskId);
     registered++;
+  }
+
+  if (previousCount > 0 || registered > 0) {
+    log.info("skills", "skill schedules refreshed", {
+      previous: previousCount,
+      current: registered,
+    });
   }
 
   return registered;
 }
 
-function readSkillSchedule(skill: Skill): TaskSchedule | null {
+// Read schedule + roleId in one file read (avoid reading the same
+// SKILL.md twice). Returns null if no schedule is configured.
+function readSkillScheduleInfo(skill: Skill): SkillScheduleInfo | null {
   try {
     const raw = readFileSync(skill.path, "utf-8");
     const parsed = parseSkillFrontmatter(raw);
-    if (!parsed?.schedule?.parsed) return null;
-
-    const s = parsed.schedule.parsed;
-    if (s.type === "daily") {
-      return { type: "daily", time: s.time };
-    }
-    if (s.type === "interval") {
-      return { type: "interval", intervalMs: s.intervalMs };
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function readSkillRoleId(skill: Skill): string | null {
-  try {
-    const raw = readFileSync(skill.path, "utf-8");
-    const parsed = parseSkillFrontmatter(raw);
-    return parsed?.roleId ?? null;
+    const s = parsed?.schedule?.parsed;
+    if (!s) return null;
+    return {
+      schedule: s,
+      roleId: parsed?.roleId ?? "general",
+    };
   } catch {
     return null;
   }

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -38,24 +38,37 @@ const SKILL_TASK_PREFIX = "skill.";
 let registeredTaskIds = new Set<string>();
 let cachedDeps: SkillSchedulerDeps | null = null;
 
+// Mutex: serialize refresh calls so concurrent save/update/delete
+// API calls don't interleave register/unregister and corrupt state.
+let refreshMutex: Promise<number> = Promise.resolve(0);
+
 export async function registerScheduledSkills(
   deps: SkillSchedulerDeps,
 ): Promise<number> {
   cachedDeps = deps;
-  return doRegister(deps);
+  return serializedRefresh(deps);
 }
 
 /**
  * Re-scan skills and update task-manager registrations. Safe to call
  * after a skill is saved, updated, or deleted — removes stale tasks
- * and adds new ones without a server restart.
+ * and adds new ones without a server restart. Serialized: concurrent
+ * calls queue behind the in-flight one.
  */
 export async function refreshScheduledSkills(): Promise<number> {
   if (!cachedDeps) {
     log.warn("skills", "refreshScheduledSkills called before initial register");
     return 0;
   }
-  return doRegister(cachedDeps);
+  return serializedRefresh(cachedDeps);
+}
+
+function serializedRefresh(deps: SkillSchedulerDeps): Promise<number> {
+  refreshMutex = refreshMutex.then(
+    () => doRegister(deps),
+    () => doRegister(deps),
+  );
+  return refreshMutex;
 }
 
 async function doRegister(deps: SkillSchedulerDeps): Promise<number> {

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -16,10 +16,17 @@ import type {
 import { parseSkillFrontmatter } from "./parser.js";
 import { log } from "../../system/logger/index.js";
 import { readFileSync } from "fs";
+import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
 
 interface SkillScheduleInfo {
   schedule: TaskSchedule;
   roleId: string;
+}
+
+interface StartChatResult {
+  kind: string;
+  error?: string;
+  status?: number;
 }
 
 export interface SkillSchedulerDeps {
@@ -29,7 +36,7 @@ export interface SkillSchedulerDeps {
     message: string;
     roleId: string;
     chatSessionId: string;
-  }) => Promise<{ kind: string }>;
+  }) => Promise<StartChatResult>;
 }
 
 const SKILL_TASK_PREFIX = "skill.";
@@ -107,6 +114,11 @@ async function doRegister(deps: SkillSchedulerDeps): Promise<number> {
           roleId,
           chatSessionId,
         });
+        if (result.kind === "error") {
+          throw new Error(
+            `scheduled skill failed: ${result.error ?? "unknown"}`,
+          );
+        }
         log.info("skills", "scheduled skill completed", {
           name: skill.name,
           kind: result.kind,
@@ -138,7 +150,7 @@ function readSkillScheduleInfo(skill: Skill): SkillScheduleInfo | null {
     if (!s) return null;
     return {
       schedule: s,
-      roleId: parsed?.roleId ?? "general",
+      roleId: parsed?.roleId ?? DEFAULT_ROLE_ID,
     };
   } catch {
     return null;

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -1,0 +1,106 @@
+// Skill scheduling (#357 Phase 2). Scans all discovered skills for
+// `schedule:` frontmatter and registers matching ones with the
+// task-manager. Each scheduled skill fires `startChat()` with the
+// skill body as the message and the skill's `roleId` (or "general").
+//
+// Called once at server startup after the task-manager is created.
+// Re-scanning on skill file changes is deferred — restart is the
+// simplest refresh for now.
+
+import { discoverSkills } from "./discovery.js";
+import type { Skill } from "./types.js";
+import type {
+  ITaskManager,
+  TaskSchedule,
+} from "../../events/task-manager/index.js";
+import { parseSkillFrontmatter } from "./parser.js";
+import { log } from "../../system/logger/index.js";
+import { readFileSync } from "fs";
+
+export interface SkillSchedulerDeps {
+  taskManager: ITaskManager;
+  workspaceRoot: string;
+  startChat: (params: {
+    message: string;
+    roleId: string;
+    chatSessionId: string;
+  }) => Promise<{ kind: string }>;
+}
+
+export async function registerScheduledSkills(
+  deps: SkillSchedulerDeps,
+): Promise<number> {
+  const { taskManager, workspaceRoot, startChat } = deps;
+  const skills = await discoverSkills({ workspaceRoot });
+  let registered = 0;
+
+  for (const skill of skills) {
+    const schedule = readSkillSchedule(skill);
+    if (!schedule) continue;
+
+    const roleId = readSkillRoleId(skill) ?? "general";
+    const taskId = `skill.${skill.name}`;
+
+    taskManager.registerTask({
+      id: taskId,
+      description: `Scheduled skill: ${skill.name} — ${skill.description}`,
+      schedule,
+      run: async () => {
+        const chatSessionId = crypto.randomUUID();
+        log.info("skills", "running scheduled skill", {
+          name: skill.name,
+          roleId,
+          chatSessionId,
+        });
+        const result = await startChat({
+          message: `/${skill.name}`,
+          roleId,
+          chatSessionId,
+        });
+        log.info("skills", "scheduled skill completed", {
+          name: skill.name,
+          kind: result.kind,
+        });
+      },
+    });
+
+    log.info("skills", "registered scheduled skill", {
+      name: skill.name,
+      taskId,
+      schedule: schedule.type,
+      roleId,
+    });
+    registered++;
+  }
+
+  return registered;
+}
+
+function readSkillSchedule(skill: Skill): TaskSchedule | null {
+  try {
+    const raw = readFileSync(skill.path, "utf-8");
+    const parsed = parseSkillFrontmatter(raw);
+    if (!parsed?.schedule?.parsed) return null;
+
+    const s = parsed.schedule.parsed;
+    if (s.type === "daily") {
+      return { type: "daily", time: s.time };
+    }
+    if (s.type === "interval") {
+      return { type: "interval", intervalMs: s.intervalMs };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function readSkillRoleId(skill: Skill): string | null {
+  try {
+    const raw = readFileSync(skill.path, "utf-8");
+    const parsed = parseSkillFrontmatter(raw);
+    return parsed?.roleId ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/test/skills/test_schedule_parser.ts
+++ b/test/skills/test_schedule_parser.ts
@@ -79,4 +79,58 @@ describe("parseSkillFrontmatter — schedule", () => {
     assert.ok(result);
     assert.equal(result.roleId, undefined);
   });
+
+  it("rejects interval 0m (zero interval)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Zero\nschedule: interval 0m\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule?.parsed, null);
+  });
+
+  it("rejects interval 5s (below 10s minimum)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: TooFast\nschedule: interval 5s\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule?.parsed, null);
+  });
+
+  it("accepts interval 10s (minimum allowed)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Min\nschedule: interval 10s\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule?.parsed, {
+      type: "interval",
+      intervalMs: 10_000,
+    });
+  });
+
+  it("rejects daily 25:00 (invalid hour)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Bad\nschedule: daily 25:00\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule?.parsed, null);
+  });
+
+  it("rejects daily 12:60 (invalid minute)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Bad\nschedule: daily 12:60\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule?.parsed, null);
+  });
+
+  it("accepts daily 23:59 (max valid)", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Late\nschedule: daily 23:59\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule?.parsed, {
+      type: "daily",
+      time: "23:59",
+    });
+  });
 });

--- a/test/skills/test_schedule_parser.ts
+++ b/test/skills/test_schedule_parser.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { parseSkillFrontmatter } from "../../server/workspace/skills/parser.ts";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 
 describe("parseSkillFrontmatter — schedule", () => {
   it("parses daily HH:MM schedule", () => {
@@ -10,7 +11,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     assert.ok(result);
     assert.deepEqual(result.schedule, {
       raw: "daily 08:00",
-      parsed: { type: "daily", time: "08:00" },
+      parsed: { type: SCHEDULE_TYPES.daily, time: "08:00" },
     });
   });
 
@@ -20,7 +21,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.schedule?.parsed, {
-      type: "interval",
+      type: SCHEDULE_TYPES.interval,
       intervalMs: 1_800_000,
     });
   });
@@ -31,7 +32,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.schedule?.parsed, {
-      type: "interval",
+      type: SCHEDULE_TYPES.interval,
       intervalMs: 7_200_000,
     });
   });
@@ -42,7 +43,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.schedule?.parsed, {
-      type: "interval",
+      type: SCHEDULE_TYPES.interval,
       intervalMs: 300_000,
     });
   });
@@ -102,7 +103,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.schedule?.parsed, {
-      type: "interval",
+      type: SCHEDULE_TYPES.interval,
       intervalMs: 10_000,
     });
   });
@@ -129,7 +130,7 @@ describe("parseSkillFrontmatter — schedule", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.schedule?.parsed, {
-      type: "daily",
+      type: SCHEDULE_TYPES.daily,
       time: "23:59",
     });
   });

--- a/test/skills/test_schedule_parser.ts
+++ b/test/skills/test_schedule_parser.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseSkillFrontmatter } from "../../server/workspace/skills/parser.ts";
+
+describe("parseSkillFrontmatter — schedule", () => {
+  it("parses daily HH:MM schedule", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Daily news\nschedule: daily 08:00\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule, {
+      raw: "daily 08:00",
+      parsed: { type: "daily", time: "08:00" },
+    });
+  });
+
+  it("parses interval with minutes", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Check\nschedule: interval 30m\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule?.parsed, {
+      type: "interval",
+      intervalMs: 1_800_000,
+    });
+  });
+
+  it("parses interval with hours", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Hourly\nschedule: interval 2h\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule?.parsed, {
+      type: "interval",
+      intervalMs: 7_200_000,
+    });
+  });
+
+  it("parses interval with seconds", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Fast\nschedule: interval 300s\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.deepEqual(result.schedule?.parsed, {
+      type: "interval",
+      intervalMs: 300_000,
+    });
+  });
+
+  it("returns null parsed for unrecognized schedule format", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Unknown\nschedule: weekly Mon 09:00\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule?.raw, "weekly Mon 09:00");
+    assert.equal(result.schedule?.parsed, null);
+  });
+
+  it("omits schedule when not in frontmatter", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: No schedule\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.schedule, undefined);
+  });
+
+  it("parses roleId from frontmatter", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: News\nschedule: daily 08:00\nroleId: office\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.roleId, "office");
+  });
+
+  it("omits roleId when not present", () => {
+    const result = parseSkillFrontmatter(
+      "---\ndescription: Simple\n---\n\nBody",
+    );
+    assert.ok(result);
+    assert.equal(result.roleId, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
SKILL.md の frontmatter に \`schedule:\` を書くだけでスキルが自動定期実行される。

\`\`\`yaml
---
description: 毎朝のニュースまとめ
schedule: daily 08:00
roleId: general
---
\`\`\`

サーバー起動時に全 skill を scan → \`schedule:\` 付きを task-manager に登録 → 指定時刻/間隔で \`startChat()\` が発火。

## Supported formats
- \`daily HH:MM\` — 毎日 UTC の指定時刻
- \`interval 30m\` / \`interval 2h\` / \`interval 300s\` — 一定間隔

## Changes
| File | Change |
|---|---|
| \`parser.ts\` | \`schedule\` / \`roleId\` frontmatter 抽出 + \`parseScheduleValue\` |
| \`scheduler.ts\` | 新規 — skill scan → task-manager 登録 |
| \`index.ts\` | \`registerScheduledSkills\` を startup に配線 |
| \`scheduler-adapter.ts\` | pre-existing implicit-any 修正 |
| \`test_schedule_parser.ts\` | 8 unit tests |

## User-facing
ユーザーは SKILL.md に 1 行 (\`schedule: daily 08:00\`) 追加 → サーバー再起動 → 自動実行開始。Phase 3 (chat UI から登録) は別 PR。

Refs #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now be scheduled to run automatically at specified times (daily at a specific time, or at regular intervals).
  * Scheduled skills are automatically registered and refreshed at runtime without blocking server operations.

* **Tests**
  * Added comprehensive test coverage for skill schedule parsing, including daily schedules, intervals, and validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->