### PR TITLE
refactor: extract @receptron/task-scheduler + review fixes (#357)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "packages/*"
   ],
   "scripts": {
+    "predev": "yarn build:packages",
     "dev": "concurrently -n server,client -k \"npm run server\" \"sleep 2 && vite\"",
+    "predev:debug": "yarn build:packages",
     "dev:debug": "concurrently -n server,client -k \"npm run server:debug\" \"sleep 2 && vite\"",
     "dev:client": "vite",
     "dev:server": "tsx server/index.ts",


### PR DESCRIPTION
## Summary

- Extract scheduler core from `server/utils/scheduler/` into `@receptron/task-scheduler` (independent npm package, zero MulmoClaude deps)
- Fix critical review feedback on persistence safety and window-time accuracy
- Add `predev` script so `yarn dev` works on clean checkouts

## Items to Confirm / Review

- Package name: `@receptron/task-scheduler` (not `@mulmobridge/*` — generic scheduler isn't messaging-specific)
- `safePersist` isolates persistence failures from task execution flow
- `computeCurrentWindow` uses epoch-aligned window boundary, not wall-clock time
- `as TaskExecutionState` cast replaced with `isPartialState` type guard
- All string literals replaced with `as const` constants

## User Prompt

scheduler core (`server/utils/scheduler/`) is an independent library — extract to `packages/scheduler/` as `@receptron/task-scheduler`. Fix review issues: persistence failure isolation, window-time accuracy, magic numbers, `as` casts. Add `predev` for clean-checkout dev experience.

## Changes

### Package extraction
- `server/utils/scheduler/{types,windows,catchup,state,log,index}.ts` moved to `packages/scheduler/src/`
- Tests moved to `packages/scheduler/test/`
- `server/events/scheduler-adapter.ts` imports directly from `@receptron/task-scheduler` (no re-export)
- `toUtcIsoDate` copied into package as `src/date.ts` (only external dep was this 5-line function)

### Review fixes
- **Critical**: `persistResult` renamed to `safePersist` — state and log writes are independent try/catch blocks, neither propagates
- **Medium**: Scheduled runs use `computeCurrentWindow()` for epoch-aligned window boundary instead of `new Date().toISOString()`
- **Minor**: `/api/scheduler/logs` limit validated (positive integer, capped at 500)
- **Code quality**: All string literals → `as const` constants (`SCHEDULE_TYPES`, `MISSED_RUN_POLICIES`, `TASK_RESULTS`, `TASK_TRIGGERS`, `TASK_ORIGINS`), magic numbers → named constants, `as` cast → type guard

### Dev experience
- `predev` / `predev:debug` scripts run `build:packages` before server start

### Docs
- `docs/task-manager.md`: relationship between task-manager and @receptron/task-scheduler
- `docs/developer.md`: new "Internal packages" section listing all 6 packages
- `CLAUDE.md`: scheduler-adapter and packages/scheduler in key files table

## Test plan

- [x] 39 scheduler tests pass in package
- [x] 2455 total tests pass, 0 failures
- [x] Typecheck, lint, build all clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)