### PR TITLE
refactor: eliminate magic time numbers across server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,8 +212,30 @@ String literals that form cross-module contracts (endpoint paths, event types, t
 | Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
 | Pub-sub channels | `src/config/pubsubChannels.ts` → `sessionChannel()` | `pubsub.publish(sessionChannel(id), event)` |
 | SSE event types | `src/types/events.ts` → `EVENT_TYPES` / `EventType` | `event.type === EVENT_TYPES.toolCall` |
+| Time constants | `server/utils/time.ts` → `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS` | `intervalMs: ONE_HOUR_MS`, `timeout: 5 * ONE_SECOND_MS` |
+| Timeout presets | `server/utils/time.ts` → `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `{ timeout: SUBPROCESS_PROBE_TIMEOUT_MS }` |
+| Scheduler types | `@receptron/task-scheduler` → `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES` | `schedule.type === SCHEDULE_TYPES.interval` |
 
 **Adding a new endpoint**: add the path to `src/config/apiRoutes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
+
+### Time literals — NEVER use raw numbers
+
+NEVER write raw millisecond literals (`1000`, `5000`, `60_000`, `3_600_000`, `86_400_000`) or raw arithmetic (`60 * 60 * 1000`). MUST import from `server/utils/time.ts`:
+
+```typescript
+// GOOD
+import { ONE_HOUR_MS, ONE_MINUTE_MS, SUBPROCESS_PROBE_TIMEOUT_MS } from "../utils/time.js";
+const INTERVAL_MS = 15 * ONE_MINUTE_MS;
+await execFileAsync("docker", ["ps"], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+
+// BAD
+const INTERVAL_MS = 15 * 60 * 1000;
+await execFileAsync("docker", ["ps"], { timeout: 5000 });
+```
+
+When a new timeout value is needed in 3+ places, add a named preset to `server/utils/time.ts` rather than repeating `N * ONE_SECOND_MS` inline.
+
+Scheduler-related string literals (`"interval"`, `"daily"`, `"success"`, `"error"`, `"scheduled"`, `"catch-up"`, `"run-once"`) MUST use constants from `@receptron/task-scheduler` (`SCHEDULE_TYPES`, `TASK_RESULTS`, `TASK_TRIGGERS`, `MISSED_RUN_POLICIES`). Typos in string literals are silent bugs; constants produce compile errors.
 
 ## Cross-platform considerations
 
@@ -310,6 +332,9 @@ Key shared helpers in this repo:
 | `loadJsonFile` / `saveJsonFile` | `server/utils/files/json.ts` |
 | `errorMessage(err)` | `server/utils/errors.ts` |
 | `dispatchResponse(res, result)` | `server/api/routes/dispatchResponse.ts` |
+| `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS` | `server/utils/time.ts` |
+| `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `server/utils/time.ts` |
+| `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES` | `@receptron/task-scheduler` |
 | `useFreshPluginData(opts)` | `src/composables/useFreshPluginData.ts` |
 | `useCanvasViewMode(opts)` | `src/composables/useCanvasViewMode.ts` |
 | `applyViewToQuery(query, mode)` | `src/composables/useCanvasViewMode.ts` |

--- a/server/agent/attachmentConverter.ts
+++ b/server/agent/attachmentConverter.ts
@@ -22,6 +22,10 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 import type { Attachment } from "@mulmobridge/protocol";
+import {
+  SUBPROCESS_PROBE_TIMEOUT_MS,
+  SUBPROCESS_WORK_TIMEOUT_MS,
+} from "../utils/time.js";
 
 export interface ContentBlock {
   type: string;
@@ -96,7 +100,9 @@ const PPTX_MIME =
 
 async function tryNativeLibreOffice(): Promise<boolean> {
   try {
-    await execFileAsync("libreoffice", ["--version"], { timeout: 5000 });
+    await execFileAsync("libreoffice", ["--version"], {
+      timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
+    });
     return true;
   } catch {
     return false;
@@ -106,7 +112,7 @@ async function tryNativeLibreOffice(): Promise<boolean> {
 async function tryDockerLibreOffice(): Promise<boolean> {
   try {
     await execFileAsync("docker", ["image", "inspect", "mulmoclaude-sandbox"], {
-      timeout: 5000,
+      timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
     });
     return true;
   } catch {
@@ -127,7 +133,7 @@ async function convertPptxToPdf(data: string): Promise<Buffer | null> {
       await execFileAsync(
         "libreoffice",
         ["--headless", "--convert-to", "pdf", "--outdir", tmpDir, inputPath],
-        { timeout: 60_000 },
+        { timeout: SUBPROCESS_WORK_TIMEOUT_MS },
       );
     } else if (await tryDockerLibreOffice()) {
       // Use the sandbox Docker image for conversion
@@ -147,7 +153,7 @@ async function convertPptxToPdf(data: string): Promise<Buffer | null> {
           "/data",
           "/data/input.pptx",
         ],
-        { timeout: 60_000 },
+        { timeout: SUBPROCESS_WORK_TIMEOUT_MS },
       );
     } else {
       return null;

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -19,6 +19,7 @@ import fs from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { log } from "../system/logger/index.js";
+import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../utils/time.js";
 
 // ── Config-mount allowlist ──────────────────────────────────────────
 
@@ -342,7 +343,7 @@ function resolveGhTokenFallback(
     try {
       const token = execFileSync("gh", ["auth", "token"], {
         encoding: "utf-8",
-        timeout: 5_000,
+        timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
       }).trim();
       if (token.length > 0) {
         log.info(

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -18,6 +18,7 @@ import { notFound } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
+import { ONE_DAY_MS } from "../../utils/time.js";
 import {
   encodeCursor,
   parseCursor,
@@ -99,7 +100,7 @@ const router = Router();
 
 // Sessions older than this are excluded from the listing. Set
 // SESSIONS_LIST_WINDOW_DAYS to override (0 = no cutoff).
-const WINDOW_MS = env.sessionsListWindowDays * 86_400_000;
+const WINDOW_MS = env.sessionsListWindowDays * ONE_DAY_MS;
 
 // Read the full session list off disk. Each row carries its
 // `changeMs` — the later of the jsonl mtime and the chat-index

--- a/server/events/notifications.ts
+++ b/server/events/notifications.ts
@@ -18,12 +18,13 @@
 // a PoC; #144's production scheduler will persist to disk.
 
 import { PUBSUB_CHANNELS } from "../../src/config/pubsubChannels.js";
+import { ONE_SECOND_MS, MAX_NOTIFICATION_DELAY_SEC } from "../utils/time.js";
 
 // Guard against a caller passing an accidentally-huge delay (typo,
 // ms-vs-seconds confusion, etc.). 1 hour ceiling is plenty for a
 // test ping and still leaves headroom for "fire in 30 minutes".
 const DEFAULT_DELAY_SECONDS = 60;
-const MAX_DELAY_SECONDS = 3_600;
+const MAX_DELAY_SECONDS = MAX_NOTIFICATION_DELAY_SEC;
 
 export const DEFAULT_NOTIFICATION_MESSAGE = "Test notification";
 export const DEFAULT_NOTIFICATION_TRANSPORT_ID = "cli";
@@ -69,7 +70,7 @@ export function scheduleTestNotification(
   const transportId = opts.transportId ?? DEFAULT_NOTIFICATION_TRANSPORT_ID;
   const chatId = opts.chatId ?? DEFAULT_NOTIFICATION_CHAT_ID;
   const delaySeconds = clampDelay(opts.delaySeconds);
-  const delayMs = delaySeconds * 1_000;
+  const delayMs = delaySeconds * ONE_SECOND_MS;
 
   const firesAt = new Date(Date.now() + delayMs).toISOString();
 

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -13,6 +13,7 @@ import {
 import { log } from "../../system/logger/index.js";
 import { updateHasUnread } from "../../utils/files/session-io.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
+import { ONE_HOUR_MS, ONE_MINUTE_MS } from "../../utils/time.js";
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -42,8 +43,8 @@ export interface ServerSession {
 
 // ── Constants ──────────────────────────────────────────────────
 
-const IDLE_EVICTION_MS = 60 * 60 * 1000; // 1 hour
-const EVICTION_CHECK_INTERVAL_MS = 5 * 60 * 1000; // check every 5 min
+const IDLE_EVICTION_MS = ONE_HOUR_MS;
+const EVICTION_CHECK_INTERVAL_MS = 5 * ONE_MINUTE_MS;
 
 // ── Store ──────────────────────────────────────────────────────
 

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { promisify } from "util";
 import { log } from "./logger/index.js";
+import { ONE_SECOND_MS, ONE_MINUTE_MS } from "../utils/time.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -11,11 +12,11 @@ const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
 
 /** Safety margin — treat tokens as expired 60s before actual expiry. */
-const EXPIRY_MARGIN_MS = 60_000;
+const EXPIRY_MARGIN_MS = ONE_MINUTE_MS;
 /** Maximum time to wait for the claude CLI to respond. */
-const PTY_TIMEOUT_MS = 30_000;
+const PTY_TIMEOUT_MS = 30 * ONE_SECOND_MS;
 /** Delay before sending input to the claude CLI. */
-const PTY_INPUT_DELAY_MS = 3_000;
+const PTY_INPUT_DELAY_MS = 3 * ONE_SECOND_MS;
 
 interface CredentialsJson {
   claudeAiOauth?: {
@@ -101,7 +102,7 @@ async function renewTokenViaPty(): Promise<boolean> {
     const timeout = setTimeout(() => {
       log.error(
         "credentials",
-        `Token renewal timed out after ${PTY_TIMEOUT_MS / 1000}s`,
+        `Token renewal timed out after ${PTY_TIMEOUT_MS / ONE_SECOND_MS}s`,
       );
       finish(false);
     }, PTY_TIMEOUT_MS);

--- a/server/system/docker.ts
+++ b/server/system/docker.ts
@@ -6,6 +6,7 @@ import { homedir } from "os";
 import { join, resolve as resolvePath } from "path";
 import { log } from "./logger/index.js";
 import { env } from "./env.js";
+import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../utils/time.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -51,7 +52,9 @@ export async function isDockerAvailable(): Promise<boolean> {
   if (_dockerEnabled !== null) return _dockerEnabled;
   assertClaudeFiles();
   try {
-    await execFileAsync("docker", ["ps", "-q"], { timeout: 5000 });
+    await execFileAsync("docker", ["ps", "-q"], {
+      timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
+    });
     _dockerEnabled = true;
   } catch {
     _dockerEnabled = false;

--- a/server/utils/time.ts
+++ b/server/utils/time.ts
@@ -1,5 +1,9 @@
 // Common time constants in milliseconds. Avoids magic numbers like
 // 3_600_000 scattered across the codebase.
+//
+// All server-side code should import from here instead of using raw
+// numeric literals. When a specific duration is needed (e.g. a
+// 5-second timeout), express it as `5 * ONE_SECOND_MS`.
 
 export const ONE_SECOND_MS = 1_000;
 export const ONE_MINUTE_MS = 60_000;
@@ -12,3 +16,19 @@ export const TIME_UNIT_MS: Record<string, number> = {
   m: ONE_MINUTE_MS,
   h: ONE_HOUR_MS,
 };
+
+// ── Common timeout presets ──────────────────────────────────────
+// Named timeouts for recurring patterns. Prefer these over inline
+// `5 * ONE_SECOND_MS` when the same value is used in 3+ places.
+
+/** Quick subprocess probe (docker ps, libreoffice --version, etc.) */
+export const SUBPROCESS_PROBE_TIMEOUT_MS = 5 * ONE_SECOND_MS;
+
+/** Heavy subprocess work (libreoffice conversion, etc.) */
+export const SUBPROCESS_WORK_TIMEOUT_MS = ONE_MINUTE_MS;
+
+/** CLI subprocess timeout (claude -p for summarization, etc.) */
+export const CLI_SUBPROCESS_TIMEOUT_MS = 5 * ONE_MINUTE_MS;
+
+/** Maximum one-shot notification delay */
+export const MAX_NOTIFICATION_DELAY_SEC = 3_600; // 1 hour in seconds

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -24,13 +24,14 @@ import {
 import type { ChatIndexEntry, ChatIndexManifest } from "./types.js";
 import { writeJsonAtomic } from "../../utils/files/index.js";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
+import { ONE_MINUTE_MS } from "../../utils/time.js";
 
 // Freshness throttle: a session whose existing index entry is
 // newer than this is skipped. The 15-minute window is a compromise
 // — long enough that a single conversation doesn't re-summarize
 // every turn, short enough that a user who leaves for lunch and
 // comes back sees the title refresh.
-export const MIN_INDEX_INTERVAL_MS = 15 * 60 * 1000;
+export const MIN_INDEX_INTERVAL_MS = 15 * ONE_MINUTE_MS;
 
 // Injection points for tests. Defaults are the production spawn +
 // wall-clock.

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
 import { errorMessage } from "../../utils/errors.js";
 import type { SummaryResult } from "./types.js";
+import { ONE_MINUTE_MS } from "../../utils/time.js";
 
 const SYSTEM_PROMPT =
   "You summarize a single chat session. Output strict JSON matching the provided schema. " +
@@ -43,7 +44,7 @@ const TAIL_CHARS = 5000;
 const PER_MESSAGE_MAX = 500;
 
 // Spawn / budget constants.
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
 // Budget cap per summarization call, forwarded to `claude
 // --max-budget-usd`. Previously 0.05 but that was tight enough
 // that a first-burst call — which pays a one-time cache creation

--- a/server/workspace/journal/archivist.ts
+++ b/server/workspace/journal/archivist.ts
@@ -8,6 +8,7 @@
 // production path supplies `runClaudeCli`.
 
 import { spawn } from "node:child_process";
+import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
 
 // (systemPrompt, userPrompt) → raw model output as a string.
 // The daily/optimization passes parse JSON out of the string
@@ -20,7 +21,7 @@ export type Summarize = (
 // Wall-clock cap per CLI invocation. 5 minutes is comfortably above
 // the worst-case summarization run we've seen and still short enough
 // that a wedged subprocess doesn't tie up resources forever.
-const CLI_TIMEOUT_MS = 5 * 60 * 1000;
+const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
 // Sentinel we throw on ENOENT so maybeRunJournal can disable the
 // feature for the rest of the server lifetime instead of retrying

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -12,6 +12,7 @@ import {
   writeJournalState as writeJournalStateRaw,
   journalStateExists as journalStateExistsRaw,
 } from "../../utils/files/journal-io.js";
+import { ONE_HOUR_MS, ONE_DAY_MS } from "../../utils/time.js";
 
 // Bump this when the schema changes in a backwards-incompatible way.
 // Older state files are treated as corrupted and replaced with a
@@ -109,7 +110,7 @@ export function isDailyDue(state: JournalState, nowMs: number): boolean {
   if (state.lastDailyRunAt === null) return true;
   const last = Date.parse(state.lastDailyRunAt);
   if (Number.isNaN(last)) return true;
-  const intervalMs = state.dailyIntervalHours * 60 * 60 * 1000;
+  const intervalMs = state.dailyIntervalHours * ONE_HOUR_MS;
   return nowMs - last >= intervalMs;
 }
 
@@ -117,7 +118,7 @@ export function isOptimizationDue(state: JournalState, nowMs: number): boolean {
   if (state.lastOptimizationRunAt === null) return true;
   const last = Date.parse(state.lastOptimizationRunAt);
   if (Number.isNaN(last)) return true;
-  const intervalMs = state.optimizationIntervalDays * 24 * 60 * 60 * 1000;
+  const intervalMs = state.optimizationIntervalDays * ONE_DAY_MS;
   return nowMs - last >= intervalMs;
 }
 

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -5,7 +5,7 @@
 // Minimal YAML: we only care about a few keys, so rather than
 // pulling in a YAML parser we do line-by-line extraction.
 
-import { TIME_UNIT_MS } from "../../utils/time.js";
+import { TIME_UNIT_MS, ONE_SECOND_MS } from "../../utils/time.js";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 
 export interface SkillSchedule {
@@ -54,7 +54,7 @@ function parseScalar(raw: string): string {
  *   "interval 300s"    → { type: "interval", intervalMs: 300000 }
  */
 // Minimum interval to prevent accidental runaway scheduling.
-const MIN_INTERVAL_MS = 10_000; // 10 seconds
+const MIN_INTERVAL_MS = 10 * ONE_SECOND_MS;
 
 function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   const trimmed = raw.trim();

--- a/server/workspace/sources/classifier.ts
+++ b/server/workspace/sources/classifier.ts
@@ -21,6 +21,7 @@ import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist.js";
 import { formatSpawnFailure } from "../../utils/spawn.js";
+import { ONE_MINUTE_MS } from "../../utils/time.js";
 import {
   CATEGORY_SLUGS,
   normalizeCategories,
@@ -66,7 +67,7 @@ export type ClassifyFn = (input: ClassifyInput) => Promise<ClassifyResult>;
 // Max time we let `claude` run during registration. Registration
 // is a foreground user action, so anything longer than 2 min is
 // effectively broken anyway.
-export const DEFAULT_TIMEOUT_MS = 120_000;
+export const DEFAULT_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
 
 // Budget cap. Classification is one small call per source (once
 // at registration, rarely re-classified) so $0.05 is fine — we

--- a/server/workspace/sources/httpFetcher.ts
+++ b/server/workspace/sources/httpFetcher.ts
@@ -30,6 +30,7 @@ import {
   type RateLimiterDeps,
 } from "./rateLimiter.js";
 import { isAllowedByRobots, parseRobots } from "./robots.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
 
 // The User-Agent value sent on every fetch. Identifies us clearly
 // enough for a site operator to find the project and contact us.
@@ -40,7 +41,7 @@ export const USER_AGENT =
 // Per-request wall-clock cap. Fetchers can still cancel earlier
 // via a passed-in AbortSignal; this is the outer safety net so a
 // hung server never holds a rate-limit slot forever.
-export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+export const DEFAULT_FETCH_TIMEOUT_MS = 30 * ONE_SECOND_MS;
 
 // Thrown when a URL would violate the target host's robots.txt
 // policy for our User-Agent. Caught by fetchers so a single

--- a/server/workspace/sources/pipeline/fetch.ts
+++ b/server/workspace/sources/pipeline/fetch.ts
@@ -19,6 +19,7 @@ import type {
 import type { FetcherKind, Source, SourceState } from "../types.js";
 import { defaultSourceState } from "../types.js";
 import { errorMessage } from "../../../utils/errors.js";
+import { ONE_MINUTE_MS, ONE_DAY_MS } from "../../../utils/time.js";
 
 // Outcome of one source's fetch attempt.
 export type FetchOutcome =
@@ -104,12 +105,12 @@ async function fetchOneSource(
 // Exponential backoff (in ms) for the Nth consecutive failure.
 // Bounded at BACKOFF_MAX so even a permanently-broken source
 // gets retried eventually.
-export const BACKOFF_MAX_MS = 24 * 60 * 60 * 1000; // 24h
+export const BACKOFF_MAX_MS = ONE_DAY_MS;
 
 export function backoffDelayMs(consecutiveFailures: number): number {
   if (consecutiveFailures <= 0) return 0;
   // 1m, 2m, 4m, 8m, 16m, ..., capped at 24h.
-  const base = 60_000;
+  const base = ONE_MINUTE_MS;
   const ms = base * 2 ** Math.min(consecutiveFailures - 1, 20);
   return Math.min(ms, BACKOFF_MAX_MS);
 }

--- a/server/workspace/sources/pipeline/summarize.ts
+++ b/server/workspace/sources/pipeline/summarize.ts
@@ -16,6 +16,7 @@ import { ClaudeCliNotFoundError } from "../../journal/archivist.js";
 import { formatSpawnFailure } from "../../../utils/spawn.js";
 import { errorMessage } from "../../../utils/errors.js";
 import type { SourceItem } from "../types.js";
+import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../../utils/time.js";
 
 // A function that takes items and returns markdown. The
 // production implementation spawns claude; tests pass a
@@ -25,7 +26,7 @@ export type SummarizeFn = (items: readonly SourceItem[]) => Promise<string>;
 // Wall-clock cap per summarize call. 5 minutes is plenty for a
 // daily brief across a few dozen items; beyond that the call is
 // almost certainly wedged.
-export const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+export const DEFAULT_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
 // Budget per summarize call. A daily brief is longer and more
 // expensive than a classify call, so the cap is higher than the

--- a/server/workspace/sources/rateLimiter.ts
+++ b/server/workspace/sources/rateLimiter.ts
@@ -22,10 +22,12 @@
 // instance — no module-level globals. Tests can spin up a fresh
 // limiter per case and fully observe the ordering.
 
+import { ONE_SECOND_MS } from "../../utils/time.js";
+
 // Seconds of quiet between requests to the same host when the
 // caller doesn't specify an explicit `minDelayMs` for the host.
 // One second is polite-default for public feeds.
-export const DEFAULT_MIN_DELAY_MS = 1000;
+export const DEFAULT_MIN_DELAY_MS = ONE_SECOND_MS;
 
 export interface RateLimiterDeps {
   // Returns current wall-clock milliseconds. `Date.now` in prod,

--- a/server/workspace/wiki-backlinks/index.ts
+++ b/server/workspace/wiki-backlinks/index.ts
@@ -21,11 +21,12 @@ import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 import { log } from "../../system/logger/index.js";
 import { updateSessionBacklinks } from "./sessionBacklinks.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
 
 // Small tolerance for filesystem mtime granularity (some filesystems
 // only record to 1-second precision). Without this, a page written
 // within the same millisecond as turnStartedAt could be skipped.
-const MTIME_TOLERANCE_MS = 1000;
+const MTIME_TOLERANCE_MS = ONE_SECOND_MS;
 
 export interface WikiBacklinksDeps {
   readdir: (dir: string) => Promise<string[]>;


### PR DESCRIPTION
## Summary

- サーバーコード全体のマジックナンバー（時間リテラル）を `server/utils/time.ts` の名前付き定数に統一
- 共通タイムアウトプリセットを追加: `SUBPROCESS_PROBE_TIMEOUT_MS` (5s), `SUBPROCESS_WORK_TIMEOUT_MS` (1min), `CLI_SUBPROCESS_TIMEOUT_MS` (5min), `MAX_NOTIFICATION_DELAY_SEC` (3600)
- 13ファイルを更新: agent, api, events, system, workspace の全レイヤー

## Items to Confirm / Review

- `SUBPROCESS_PROBE_TIMEOUT_MS` (5秒) は docker ps, libreoffice --version, gh auth token, docker image inspect で共通利用。値を変更したい場合は `server/utils/time.ts` の1箇所のみ
- `CLI_SUBPROCESS_TIMEOUT_MS` (5分) は journal archivist と sources summarizer で共通。長すぎ/短すぎの場合は同ファイルで調整可能

## User Prompt

サーバのコード全てで `@receptron/task-scheduler` の定数と `server/utils/time.ts` の時間定数を使うように統一。リテラル・マジックナンバーはできる限り廃止。utils/time を使うときに、時間のデータも1つのファイルに集約して、そこで変更できるようにする。

## Changes by file

| File | Change |
|---|---|
| `server/utils/time.ts` | 4 timeout presets added |
| `server/events/session-store/index.ts` | `60*60*1000` → `ONE_HOUR_MS`, `5*60*1000` → `5*ONE_MINUTE_MS` |
| `server/workspace/journal/state.ts` | `*60*60*1000` → `*ONE_HOUR_MS`, `*24*60*60*1000` → `*ONE_DAY_MS` |
| `server/workspace/chat-index/indexer.ts` | `15*60*1000` → `15*ONE_MINUTE_MS` |
| `server/workspace/journal/archivist.ts` | `5*60*1000` → `CLI_SUBPROCESS_TIMEOUT_MS` |
| `server/workspace/sources/pipeline/fetch.ts` | `24*60*60*1000` → `ONE_DAY_MS`, `60_000` → `ONE_MINUTE_MS` |
| `server/workspace/sources/pipeline/summarize.ts` | `5*60_000` → `CLI_SUBPROCESS_TIMEOUT_MS` |
| `server/api/routes/sessions.ts` | `86_400_000` → `ONE_DAY_MS` |
| `server/events/notifications.ts` | `3_600` → `MAX_NOTIFICATION_DELAY_SEC`, `1_000` → `ONE_SECOND_MS` |
| `server/system/docker.ts` | `5000` → `SUBPROCESS_PROBE_TIMEOUT_MS` |
| `server/system/credentials.ts` | `60_000`/`30_000`/`3_000`/`1000` → time constants |
| `server/agent/attachmentConverter.ts` | `5000` → `SUBPROCESS_PROBE_TIMEOUT_MS`, `60_000` → `SUBPROCESS_WORK_TIMEOUT_MS` |
| `server/agent/sandboxMounts.ts` | `5_000` → `SUBPROCESS_PROBE_TIMEOUT_MS` |

## Test plan

- [x] `yarn format` — no changes
- [x] `yarn lint` — 0 errors (pre-existing warnings only)
- [x] `yarn typecheck` — pass
- [x] `yarn build` — pass
- [x] `yarn test` — 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated internal timing configuration constants across server modules for improved code maintainability and consistency. This standardization reduces duplication and potential configuration errors without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->