### PR TITLE
feat: @mulmobridge/mock-server — mock MulmoClaude for bridge testing

### DIFF
--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -85,6 +85,8 @@ The verbose log includes everything we need to diagnose the issue:
 - Latency per message
 - Disconnect reasons
 
+**Before pasting:** the mock token is a placeholder (`mock-test-token`), but review the log for any real tokens, chat IDs, or message text you don't want public. Redact them with `[REDACTED]`. If the log contains sensitive content, use a [private security report](https://github.com/receptron/mulmoclaude/security/advisories/new) instead of a public issue.
+
 Paste the log into your [GitHub issue](https://github.com/receptron/mulmoclaude/issues/new).
 
 ## Switching to real MulmoClaude
@@ -92,15 +94,16 @@ Paste the log into your [GitHub issue](https://github.com/receptron/mulmoclaude/
 Once your bridge works with the mock, switch to the real server:
 
 ```bash
-# 1. Install and start MulmoClaude
+# 1. Stop the mock server first (Ctrl+C) — both use port 3001
+# 2. Install and start MulmoClaude
 git clone https://github.com/receptron/mulmoclaude.git
 cd mulmoclaude && yarn install && yarn dev
 
-# 2. Connect your bridge (token is auto-read from the workspace)
+# 3. Connect your bridge (token is auto-read from the workspace)
 npx @mulmobridge/telegram
 ```
 
-The bridge connects to `http://localhost:3001` by default — same port as the mock. Override with `MULMOCLAUDE_API_URL` if needed.
+> **Important:** Stop the mock server before starting MulmoClaude — both default to `http://localhost:3001`. If the mock is still running, the real server will fail to bind or your bridge will keep talking to the mock. Override with `MULMOCLAUDE_API_URL` if you need both running simultaneously.
 
 ## Supported bridge platforms
 

--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -1,0 +1,121 @@
+# @mulmobridge/mock-server
+
+> **Experimental** — this package is under active development. We'd love your help testing it! If something doesn't work, please [open an issue](https://github.com/receptron/mulmoclaude/issues/new) and paste the `--verbose` terminal output. Your reports help us ship better bridges faster.
+
+A mock [MulmoClaude](https://github.com/receptron/mulmoclaude) server for testing messaging bridges. It speaks the full MulmoBridge protocol (socket.io + bearer auth) and echoes your messages back — **no Claude API key needed, no MulmoClaude installation required**.
+
+## What is MulmoClaude?
+
+[MulmoClaude](https://github.com/receptron/mulmoclaude) is a GUI-chat agent app powered by Claude Code. It produces rich visual output — documents, spreadsheets, charts, images — and maintains a personal wiki as long-term memory. MulmoClaude runs as a local server and can be accessed from messaging apps like Telegram, Slack, LINE, Discord, and more through **bridge** processes.
+
+This mock server lets you test your bridge without running the full MulmoClaude stack.
+
+## Quick Start
+
+```bash
+# Terminal 1: start the mock server
+npx @mulmobridge/mock-server
+
+# Terminal 2: connect the CLI bridge
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token npx @mulmobridge/cli
+```
+
+Type a message in the CLI — the mock echoes it back with `[echo]` prefix.
+
+## Testing with Telegram
+
+```bash
+# Terminal 1: mock server
+npx @mulmobridge/mock-server --verbose
+
+# Terminal 2: Telegram bridge
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+TELEGRAM_BOT_TOKEN=<your-bot-token> \
+TELEGRAM_ALLOWED_CHAT_IDS=<your-chat-id> \
+npx @mulmobridge/telegram
+```
+
+Send a message from your phone → the bot echoes it back. Send a photo or document — the echo shows the attachment type and size, confirming the file was received.
+
+For Telegram bot setup (BotFather, getting your chat ID), see the [Telegram bridge docs](https://github.com/receptron/mulmoclaude/blob/main/docs/message_apps/telegram/README.md).
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port <n>` | `3001` | Listen port |
+| `--token <s>` | `mock-test-token` | Bearer token for auth |
+| `--slow <ms>` | `0` | Delay before replies (simulates agent thinking time) |
+| `--error` | off | Always return error acks (test error handling) |
+| `--reject-auth` | off | Reject all connections (test auth error paths) |
+| `--verbose`, `-v` | off | Full protocol trace (recommended for bug reports) |
+| `--log-file <path>` | — | Write verbose log to a file |
+
+## What the mock supports
+
+- **Socket.io handshake** — same `auth: { transportId, token }` as production
+- **`message` event with ack** — echoes text + lists attachments
+- **`push` event** — trigger via `POST /mock/push` (see below)
+- **Slash commands** — `/help`, `/reset`, `/roles`, `/role <id>`, `/status`
+- **Bearer token auth** — rejects wrong tokens with the same error messages as production
+
+## Simulating server→bridge push
+
+```bash
+curl -X POST http://localhost:3001/mock/push \
+  -H "Content-Type: application/json" \
+  -d '{"transportId":"cli","chatId":"terminal","message":"Scheduled reminder!"}'
+```
+
+The mock delivers the push to all connected bridges with matching `transportId`.
+
+## Reporting bugs
+
+Run with `--verbose` and copy the terminal output:
+
+```bash
+npx @mulmobridge/mock-server --verbose 2>&1 | tee debug.log
+```
+
+The verbose log includes everything we need to diagnose the issue:
+- Server + Node + OS versions
+- Auth handshake details
+- Full message payloads (attachment data shown as size, not content)
+- Ack payloads
+- Latency per message
+- Disconnect reasons
+
+Paste the log into your [GitHub issue](https://github.com/receptron/mulmoclaude/issues/new).
+
+## Switching to real MulmoClaude
+
+Once your bridge works with the mock, switch to the real server:
+
+```bash
+# 1. Install and start MulmoClaude
+git clone https://github.com/receptron/mulmoclaude.git
+cd mulmoclaude && yarn install && yarn dev
+
+# 2. Connect your bridge (token is auto-read from the workspace)
+npx @mulmobridge/telegram
+```
+
+The bridge connects to `http://localhost:3001` by default — same port as the mock. Override with `MULMOCLAUDE_API_URL` if needed.
+
+## Supported bridge platforms
+
+| Platform | Package | Status |
+|---|---|---|
+| CLI | `@mulmobridge/cli` | ✅ Available |
+| Telegram | `@mulmobridge/telegram` | ✅ Available |
+| LINE | — | 🔲 Planned |
+| Slack | — | 🔲 Planned |
+| Discord | — | 🔲 Planned |
+| WhatsApp | — | 🔲 Planned |
+| Matrix | — | 🔲 Planned |
+
+Want to build a bridge for your platform? The [bridge protocol docs](https://github.com/receptron/mulmoclaude/blob/main/docs/bridge-protocol.md) cover the full wire-level contract. Any language with a socket.io 4.x client works.
+
+## License
+
+MIT

--- a/packages/mock-server/eslint.config.mjs
+++ b/packages/mock-server/eslint.config.mjs
@@ -1,0 +1,11 @@
+import eslintBase from "../../config/eslint.packages.mjs";
+
+const packageTsFiles = ["{src,test}/**/*.ts"];
+
+export default [
+  { ignores: ["dist/**/*"] },
+  ...eslintBase.map((config) => ({
+    ...config,
+    files: packageTsFiles,
+  })),
+];

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mulmobridge/mock-server",
+  "version": "0.1.0",
+  "description": "Mock MulmoClaude server for testing MulmoBridge bridges — no Claude API key needed",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-mock-server": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit",
+    "start": "tsx src/index.ts"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/protocol": "^0.1.1",
+    "express": "^5.1.0",
+    "socket.io": "^4.8.3"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -16,6 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test",
     "start": "tsx src/index.ts"
   },
   "license": "MIT",

--- a/packages/mock-server/src/handlers.ts
+++ b/packages/mock-server/src/handlers.ts
@@ -1,0 +1,108 @@
+import type { MockServerOptions } from "./server.js";
+
+export interface AttachmentPayload {
+  mimeType: string;
+  data: string;
+  filename?: string;
+}
+
+export interface MessagePayload {
+  externalChatId: string;
+  text: string;
+  attachments?: AttachmentPayload[];
+}
+
+export interface MessageAck {
+  ok: boolean;
+  reply?: string;
+  error?: string;
+  status?: number;
+}
+
+// ── Slash commands ────────────────────────────────────────────────
+
+const HELP_TEXT = `Available commands:
+  /reset  — Start a new session
+  /help   — Show this help
+  /roles  — List available roles
+  /role <id> — Switch role
+  /status — Show current session info
+
+Send any other text to chat with the assistant.`;
+
+const ROLES_TEXT = `Available roles:
+  general — General Assistant
+  office — Office Guide & Tutor
+  artist — Artist`;
+
+function handleSlashCommand(
+  text: string,
+  payload: MessagePayload,
+): MessageAck | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  const [command, ...args] = trimmed.split(/\s+/);
+
+  switch (command) {
+    case "/help":
+      return { ok: true, reply: HELP_TEXT };
+    case "/reset":
+      return { ok: true, reply: "Session reset. Role: general" };
+    case "/roles":
+      return { ok: true, reply: ROLES_TEXT };
+    case "/role": {
+      const roleId = args[0] ?? "general";
+      return {
+        ok: true,
+        reply: `Switched to ${roleId}. New session started.`,
+      };
+    }
+    case "/status":
+      return {
+        ok: true,
+        reply: `Role: general\nSession: mock-${payload.externalChatId}\nLast activity: ${new Date().toISOString()}`,
+      };
+    default:
+      return {
+        ok: true,
+        reply: `Unknown command: ${command}\n\n${HELP_TEXT}`,
+      };
+  }
+}
+
+// ── Echo reply ────────────────────────────────────────────────────
+
+function buildEchoReply(payload: MessagePayload): string {
+  const parts: string[] = [`[echo] ${payload.text}`];
+
+  if (payload.attachments && payload.attachments.length > 0) {
+    for (const att of payload.attachments) {
+      const sizeBytes = Math.ceil((att.data.length * 3) / 4);
+      const name = att.filename ? ` ${att.filename}` : "";
+      parts.push(`[attachment: ${att.mimeType} ${sizeBytes}B${name}]`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+// ── Public ────────────────────────────────────────────────────────
+
+export function handleMessage(
+  payload: MessagePayload,
+  opts: MockServerOptions,
+): MessageAck {
+  if (opts.alwaysError) {
+    return { ok: false, error: "simulated error", status: 500 };
+  }
+
+  const text = payload.text ?? "";
+
+  // Slash commands first
+  const cmdResult = handleSlashCommand(text, payload);
+  if (cmdResult) return cmdResult;
+
+  // Echo mode
+  return { ok: true, reply: buildEchoReply(payload) };
+}

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -15,6 +15,28 @@
 
 import { createMockServer, type MockServerOptions } from "./server.js";
 
+function failUsage(message: string): never {
+  console.error(`Error: ${message}`);
+  printHelp();
+  process.exit(1);
+}
+
+function parsePort(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+    failUsage(`--port must be an integer between 1 and 65535, got "${raw}"`);
+  }
+  return n;
+}
+
+function parseSlowMs(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    failUsage(`--slow must be a non-negative number, got "${raw}"`);
+  }
+  return n;
+}
+
 function parseArgs(argv: string[]): MockServerOptions {
   const opts: MockServerOptions = {
     port: 3001,
@@ -28,11 +50,11 @@ function parseArgs(argv: string[]): MockServerOptions {
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--port" && argv[i + 1]) {
-      opts.port = Number(argv[++i]);
+      opts.port = parsePort(argv[++i]);
     } else if (arg === "--token" && argv[i + 1]) {
       opts.token = argv[++i];
     } else if (arg === "--slow" && argv[i + 1]) {
-      opts.slowMs = Number(argv[++i]);
+      opts.slowMs = parseSlowMs(argv[++i]);
     } else if (arg === "--error") {
       opts.alwaysError = true;
     } else if (arg === "--reject-auth") {
@@ -44,6 +66,8 @@ function parseArgs(argv: string[]): MockServerOptions {
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
+    } else if (arg.startsWith("-")) {
+      failUsage(`unknown option: ${arg}`);
     }
   }
   return opts;

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// @mulmobridge/mock-server — mock MulmoClaude server for bridge testing.
+//
+// Usage:
+//   npx @mulmobridge/mock-server [options]
+//
+// Options:
+//   --port <n>        Listen port (default: 3001)
+//   --token <s>       Bearer token (default: mock-test-token)
+//   --slow <ms>       Add delay before replies (default: 0)
+//   --error           Always return error acks
+//   --reject-auth     Reject all connections (test error handling)
+//   --verbose, -v     Full protocol trace logging
+//   --log-file <path> Write verbose log to file (always verbose)
+
+import { createMockServer, type MockServerOptions } from "./server.js";
+
+function parseArgs(argv: string[]): MockServerOptions {
+  const opts: MockServerOptions = {
+    port: 3001,
+    token: "mock-test-token",
+    slowMs: 0,
+    alwaysError: false,
+    rejectAuth: false,
+    verbose: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--port" && argv[i + 1]) {
+      opts.port = Number(argv[++i]);
+    } else if (arg === "--token" && argv[i + 1]) {
+      opts.token = argv[++i];
+    } else if (arg === "--slow" && argv[i + 1]) {
+      opts.slowMs = Number(argv[++i]);
+    } else if (arg === "--error") {
+      opts.alwaysError = true;
+    } else if (arg === "--reject-auth") {
+      opts.rejectAuth = true;
+    } else if (arg === "--verbose" || arg === "-v") {
+      opts.verbose = true;
+    } else if (arg === "--log-file" && argv[i + 1]) {
+      opts.logFile = argv[++i];
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function printHelp(): void {
+  console.log(`
+@mulmobridge/mock-server — mock MulmoClaude server for bridge testing
+
+Usage:
+  npx @mulmobridge/mock-server [options]
+
+Options:
+  --port <n>         Listen port (default: 3001)
+  --token <s>        Bearer token (default: mock-test-token)
+  --slow <ms>        Add delay before replies (default: 0)
+  --error            Always return error acks
+  --reject-auth      Reject all connections (test error handling)
+  --verbose, -v      Full protocol trace logging
+  --log-file <path>  Write verbose log to file
+  --help, -h         Show this help
+
+Examples:
+  # Basic echo mode
+  npx @mulmobridge/mock-server
+
+  # Test with the CLI bridge
+  MULMOCLAUDE_AUTH_TOKEN=mock-test-token npx @mulmobridge/cli
+
+  # Slow responses (simulate agent thinking)
+  npx @mulmobridge/mock-server --slow 2000
+
+  # Test error handling
+  npx @mulmobridge/mock-server --error
+
+  # Debug mode with full protocol trace
+  npx @mulmobridge/mock-server --verbose
+`);
+}
+
+const opts = parseArgs(process.argv);
+createMockServer(opts);

--- a/packages/mock-server/src/logger.ts
+++ b/packages/mock-server/src/logger.ts
@@ -7,6 +7,8 @@ export interface MockLogger {
 }
 
 export function createLogger(verbose: boolean, logFile?: string): MockLogger {
+  let warnedLogFileFailure = false;
+
   function timestamp(): string {
     return new Date().toISOString().slice(11, 23);
   }
@@ -15,8 +17,13 @@ export function createLogger(verbose: boolean, logFile?: string): MockLogger {
     if (!logFile) return;
     try {
       appendFileSync(logFile, line + "\n");
-    } catch {
-      // Best-effort — don't crash on log write failure
+    } catch (err) {
+      if (!warnedLogFileFailure) {
+        warnedLogFileFailure = true;
+        console.error(
+          `[mock] warning: cannot write to log file ${logFile}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 

--- a/packages/mock-server/src/logger.ts
+++ b/packages/mock-server/src/logger.ts
@@ -1,0 +1,41 @@
+import { appendFileSync } from "fs";
+
+export interface MockLogger {
+  info(msg: string): void;
+  verbose(msg: string): void;
+  raw(msg: string): void;
+}
+
+export function createLogger(verbose: boolean, logFile?: string): MockLogger {
+  function timestamp(): string {
+    return new Date().toISOString().slice(11, 23);
+  }
+
+  function writeToFile(line: string): void {
+    if (!logFile) return;
+    try {
+      appendFileSync(logFile, line + "\n");
+    } catch {
+      // Best-effort — don't crash on log write failure
+    }
+  }
+
+  return {
+    info(msg: string): void {
+      const line = `[mock] ${timestamp()} ${msg}`;
+      console.log(line);
+      writeToFile(line);
+    },
+    verbose(msg: string): void {
+      const line = `[mock] ${msg}`;
+      if (verbose) console.log(line);
+      // Always write to log file regardless of --verbose flag
+      writeToFile(line);
+    },
+    raw(msg: string): void {
+      const line = `[mock] ${msg}`;
+      console.log(line);
+      writeToFile(line);
+    },
+  };
+}

--- a/packages/mock-server/src/server.ts
+++ b/packages/mock-server/src/server.ts
@@ -134,8 +134,11 @@ export function createMockServer(opts: MockServerOptions): void {
   process.on("SIGINT", () => {
     log.info("shutting down...");
     printReportHint(log);
-    server.close();
-    process.exit(0);
+    io.close();
+    server.close(() => process.exit(0));
+    // Safety net — if server.close() hangs (stuck connections),
+    // force exit after 3 seconds.
+    setTimeout(() => process.exit(0), 3000).unref();
   });
 }
 

--- a/packages/mock-server/src/server.ts
+++ b/packages/mock-server/src/server.ts
@@ -1,0 +1,200 @@
+import http from "http";
+import express from "express";
+import { Server as IOServer } from "socket.io";
+import { CHAT_SOCKET_PATH, CHAT_SOCKET_EVENTS } from "@mulmobridge/protocol";
+import { handleMessage, type MessagePayload } from "./handlers.js";
+import { createLogger, type MockLogger } from "./logger.js";
+
+export interface MockServerOptions {
+  port: number;
+  token: string;
+  slowMs: number;
+  alwaysError: boolean;
+  rejectAuth: boolean;
+  verbose: boolean;
+  logFile?: string;
+}
+
+export function createMockServer(opts: MockServerOptions): void {
+  const log = createLogger(opts.verbose, opts.logFile);
+  const app = express();
+  app.use(express.json());
+  const server = http.createServer(app);
+
+  const io = new IOServer(server, {
+    path: CHAT_SOCKET_PATH,
+    cors: { origin: true, credentials: true },
+    transports: ["websocket"],
+  });
+
+  printBanner(opts, log);
+
+  // ── Auth middleware ────────────────────────────────────────────
+
+  io.use((socket, next) => {
+    if (opts.rejectAuth) {
+      log.verbose(`  auth: REJECTED (--reject-auth mode)`);
+      return next(new Error("server auth not ready"));
+    }
+    const auth = socket.handshake.auth as Record<string, unknown>;
+    const transportId = auth?.transportId;
+    const token = auth?.token;
+
+    if (!transportId || typeof transportId !== "string") {
+      log.verbose(`  auth: REJECTED (transportId missing)`);
+      return next(new Error("transportId is required"));
+    }
+    if (!token || typeof token !== "string") {
+      log.verbose(`  auth: REJECTED (token missing)`);
+      return next(new Error("token is required"));
+    }
+    if (token !== opts.token) {
+      log.verbose(
+        `  auth: REJECTED (token mismatch: got "${token.slice(0, 8)}…")`,
+      );
+      return next(new Error("invalid token"));
+    }
+    log.verbose(`  auth: { transportId: "${transportId}", token: valid }`);
+    next();
+  });
+
+  // ── Connection handling ───────────────────────────────────────
+
+  io.on("connection", (socket) => {
+    const auth = socket.handshake.auth as { transportId: string };
+    const transportId = auth.transportId;
+    socket.join(`bridge:${transportId}`);
+
+    log.info(`CONNECT  sid=${socket.id} transportId=${transportId}`);
+
+    socket.on(
+      CHAT_SOCKET_EVENTS.message,
+      async (payload: MessagePayload, ack: (response: unknown) => void) => {
+        log.info(
+          `← MESSAGE  sid=${socket.id} chat=${payload.externalChatId} len=${(payload.text ?? "").length}${formatAttachmentSummary(payload)}`,
+        );
+        log.verbose(`  payload: ${JSON.stringify(sanitizePayload(payload))}`);
+
+        if (opts.slowMs > 0) {
+          await new Promise((r) => setTimeout(r, opts.slowMs));
+        }
+
+        const response = handleMessage(payload, opts);
+        const ackDetail = response.ok
+          ? `reply="${truncate(response.reply ?? "", 60)}"`
+          : `error="${response.error}"`;
+        log.info(`→ ACK  sid=${socket.id} ok=${response.ok} ${ackDetail}`);
+        log.verbose(`  ack: ${JSON.stringify(response)}`);
+
+        ack(response);
+      },
+    );
+
+    socket.on("disconnect", (reason) => {
+      log.info(`DISCONNECT  sid=${socket.id} reason=${reason}`);
+    });
+  });
+
+  // ── Push endpoint ─────────────────────────────────────────────
+
+  app.post("/mock/push", (req, res) => {
+    const { transportId, chatId, message } = req.body as {
+      transportId?: string;
+      chatId?: string;
+      message?: string;
+    };
+    if (!transportId || !chatId || !message) {
+      res
+        .status(400)
+        .json({ error: "transportId, chatId, and message are required" });
+      return;
+    }
+    io.to(`bridge:${transportId}`).emit(CHAT_SOCKET_EVENTS.push, {
+      chatId,
+      message,
+    });
+    log.info(
+      `→ PUSH  transportId=${transportId} chatId=${chatId} message="${truncate(message, 60)}"`,
+    );
+    res.json({ ok: true });
+  });
+
+  // ── Health endpoint ───────────────────────────────────────────
+
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "OK", mock: true });
+  });
+
+  // ── Start ─────────────────────────────────────────────────────
+
+  server.listen(opts.port, "127.0.0.1", () => {
+    log.info(`listening on http://localhost:${opts.port}`);
+  });
+
+  process.on("SIGINT", () => {
+    log.info("shutting down...");
+    printReportHint(log);
+    server.close();
+    process.exit(0);
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+function formatAttachmentSummary(payload: MessagePayload): string {
+  if (!payload.attachments || payload.attachments.length === 0) return "";
+  const parts = payload.attachments.map((a) => {
+    const size = Math.ceil((a.data.length * 3) / 4);
+    const name = a.filename ? ` ${a.filename}` : "";
+    return `${a.mimeType} ${formatBytes(size)}${name}`;
+  });
+  return ` +${parts.length}attachment(s): [${parts.join(", ")}]`;
+}
+
+function sanitizePayload(payload: MessagePayload): Record<string, unknown> {
+  const clean: Record<string, unknown> = {
+    externalChatId: payload.externalChatId,
+    text: payload.text,
+  };
+  if (payload.attachments && payload.attachments.length > 0) {
+    clean.attachments = payload.attachments.map((a) => ({
+      mimeType: a.mimeType,
+      data: `<base64 ${formatBytes(Math.ceil((a.data.length * 3) / 4))}>`,
+      ...(a.filename && { filename: a.filename }),
+    }));
+  }
+  return clean;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function printBanner(opts: MockServerOptions, log: MockLogger): void {
+  log.raw("══════════════════════════════════════════════════════");
+  log.raw("@mulmobridge/mock-server v0.1.0");
+  log.raw(
+    `node: ${process.version} | os: ${process.platform} ${process.arch} | socket.io: 4.x`,
+  );
+  log.raw(`token: ${opts.token}`);
+  const modeParts = ["echo"];
+  if (opts.alwaysError) modeParts.push("error");
+  if (opts.slowMs > 0) modeParts.push(`slow: ${opts.slowMs}ms`);
+  if (opts.rejectAuth) modeParts.push("reject-auth");
+  log.raw(`mode: ${modeParts.join(" | ")}`);
+  log.raw("══════════════════════════════════════════════════════");
+}
+
+function printReportHint(log: MockLogger): void {
+  log.raw("──────────────────────────────────────────────────────");
+  log.raw("To report a bug, paste the output above into:");
+  log.raw("  https://github.com/receptron/mulmoclaude/issues/new");
+  log.raw("Include: what you expected vs. what happened.");
+  log.raw("──────────────────────────────────────────────────────");
+}

--- a/packages/mock-server/test/test_handlers.ts
+++ b/packages/mock-server/test/test_handlers.ts
@@ -1,0 +1,126 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { handleMessage, type MessagePayload } from "../src/handlers.ts";
+import type { MockServerOptions } from "../src/server.ts";
+
+const defaultOpts: MockServerOptions = {
+  port: 3001,
+  token: "test-token",
+  slowMs: 0,
+  alwaysError: false,
+  rejectAuth: false,
+  verbose: false,
+};
+
+function payload(text: string, chatId = "test-chat"): MessagePayload {
+  return { externalChatId: chatId, text };
+}
+
+describe("handleMessage — echo mode", () => {
+  it("echoes the user text", () => {
+    const ack = handleMessage(payload("hello world"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.equal(ack.reply, "[echo] hello world");
+  });
+
+  it("includes attachment summary in echo", () => {
+    const msg: MessagePayload = {
+      externalChatId: "c1",
+      text: "look at this",
+      attachments: [{ mimeType: "image/png", data: "AAAA" }],
+    };
+    const ack = handleMessage(msg, defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("[echo] look at this"));
+    assert.ok(ack.reply?.includes("[attachment: image/png"));
+  });
+
+  it("includes filename when present", () => {
+    const msg: MessagePayload = {
+      externalChatId: "c1",
+      text: "file",
+      attachments: [
+        { mimeType: "application/pdf", data: "AAAA", filename: "doc.pdf" },
+      ],
+    };
+    const ack = handleMessage(msg, defaultOpts);
+    assert.ok(ack.reply?.includes("doc.pdf"));
+  });
+
+  it("handles empty text", () => {
+    const ack = handleMessage(payload(""), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.equal(ack.reply, "[echo] ");
+  });
+});
+
+describe("handleMessage — slash commands", () => {
+  it("/help returns help text", () => {
+    const ack = handleMessage(payload("/help"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("Available commands"));
+    assert.ok(ack.reply?.includes("/reset"));
+  });
+
+  it("/reset returns confirmation", () => {
+    const ack = handleMessage(payload("/reset"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("Session reset"));
+  });
+
+  it("/roles lists available roles", () => {
+    const ack = handleMessage(payload("/roles"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("general"));
+    assert.ok(ack.reply?.includes("artist"));
+  });
+
+  it("/role <id> switches role", () => {
+    const ack = handleMessage(payload("/role artist"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("artist"));
+    assert.ok(ack.reply?.includes("Switched"));
+  });
+
+  it("/role without arg defaults to general", () => {
+    const ack = handleMessage(payload("/role"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("general"));
+  });
+
+  it("/status returns session info", () => {
+    const ack = handleMessage(payload("/status", "my-chat"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("Role: general"));
+    assert.ok(ack.reply?.includes("my-chat"));
+  });
+
+  it("unknown command returns help with error", () => {
+    const ack = handleMessage(payload("/foo"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.ok(ack.reply?.includes("Unknown command: /foo"));
+    assert.ok(ack.reply?.includes("Available commands"));
+  });
+
+  it("non-slash text is not treated as command", () => {
+    const ack = handleMessage(payload("just text"), defaultOpts);
+    assert.equal(ack.ok, true);
+    assert.equal(ack.reply, "[echo] just text");
+  });
+});
+
+describe("handleMessage — alwaysError mode", () => {
+  const errorOpts: MockServerOptions = { ...defaultOpts, alwaysError: true };
+
+  it("returns error ack for any message", () => {
+    const ack = handleMessage(payload("hello"), errorOpts);
+    assert.equal(ack.ok, false);
+    assert.equal(ack.status, 500);
+    assert.ok(ack.error?.includes("simulated"));
+  });
+
+  it("returns error even for slash commands", () => {
+    const ack = handleMessage(payload("/help"), errorOpts);
+    assert.equal(ack.ok, false);
+  });
+});

--- a/packages/mock-server/test/test_logger.ts
+++ b/packages/mock-server/test/test_logger.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { createLogger } from "../src/logger.ts";
 
 describe("createLogger", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mock-log-test-"));
   let tmpFile: string | undefined;
 
   afterEach(() => {
@@ -15,8 +16,13 @@ describe("createLogger", () => {
     tmpFile = undefined;
   });
 
+  // Clean up the temp directory after all tests
+  process.on("exit", () => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it("info() writes to log file when logFile is set", () => {
-    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    tmpFile = path.join(tmpDir, `info-${Date.now()}.log`);
     const log = createLogger(false, tmpFile);
     log.info("test message");
     const content = fs.readFileSync(tmpFile, "utf-8");
@@ -25,7 +31,7 @@ describe("createLogger", () => {
   });
 
   it("verbose() writes to log file even when verbose is false", () => {
-    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    tmpFile = path.join(tmpDir, `verbose-${Date.now()}.log`);
     const log = createLogger(false, tmpFile);
     log.verbose("detail info");
     const content = fs.readFileSync(tmpFile, "utf-8");
@@ -33,7 +39,7 @@ describe("createLogger", () => {
   });
 
   it("raw() writes to log file", () => {
-    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    tmpFile = path.join(tmpDir, `raw-${Date.now()}.log`);
     const log = createLogger(false, tmpFile);
     log.raw("banner line");
     const content = fs.readFileSync(tmpFile, "utf-8");

--- a/packages/mock-server/test/test_logger.ts
+++ b/packages/mock-server/test/test_logger.ts
@@ -1,0 +1,50 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createLogger } from "../src/logger.ts";
+
+describe("createLogger", () => {
+  let tmpFile: string | undefined;
+
+  afterEach(() => {
+    if (tmpFile && fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+    tmpFile = undefined;
+  });
+
+  it("info() writes to log file when logFile is set", () => {
+    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    const log = createLogger(false, tmpFile);
+    log.info("test message");
+    const content = fs.readFileSync(tmpFile, "utf-8");
+    assert.ok(content.includes("test message"));
+    assert.ok(content.includes("[mock]"));
+  });
+
+  it("verbose() writes to log file even when verbose is false", () => {
+    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    const log = createLogger(false, tmpFile);
+    log.verbose("detail info");
+    const content = fs.readFileSync(tmpFile, "utf-8");
+    assert.ok(content.includes("detail info"));
+  });
+
+  it("raw() writes to log file", () => {
+    tmpFile = path.join(os.tmpdir(), `mock-log-test-${Date.now()}.log`);
+    const log = createLogger(false, tmpFile);
+    log.raw("banner line");
+    const content = fs.readFileSync(tmpFile, "utf-8");
+    assert.ok(content.includes("banner line"));
+  });
+
+  it("works without logFile (no crash)", () => {
+    const log = createLogger(false);
+    log.info("no file");
+    log.verbose("no file verbose");
+    log.raw("no file raw");
+    // No assertion needed — just verify it doesn't throw
+  });
+});

--- a/packages/mock-server/tsconfig.json
+++ b/packages/mock-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,7 +2952,7 @@ express-rate-limit@^8.2.1:
   dependencies:
     ip-address "10.1.0"
 
-express@^5.2.1:
+express@^5.1.0, express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==


### PR DESCRIPTION
## Summary

New npm package: \`npx @mulmobridge/mock-server\` starts a local mock MulmoClaude server that speaks the full bridge protocol. Bridge developers and end users can test their bridges **without running MulmoClaude or needing a Claude API key**.

### Why

MulmoClaude aims to support bridges for 16+ messaging platforms (Telegram, LINE, Slack, Discord, WhatsApp, etc.). Each bridge needs to be developed and tested independently. The mock removes the barrier: zero setup, zero Claude costs, fast iteration.

### What it does

```
npx @mulmobridge/mock-server           # start mock (port 3001)
MULMOCLAUDE_AUTH_TOKEN=mock-test-token npx @mulmobridge/cli  # connect bridge
```

- **Echo mode** — replies with \`[echo] <text>\` + attachment summary
- **Slash commands** — \`/help\`, \`/reset\`, \`/roles\`, \`/role\`, \`/status\` (hardcoded responses)
- **Bearer auth** — same handshake as production; rejects wrong tokens with production error messages
- **Push simulation** — \`POST /mock/push\` triggers server→bridge pushes
- **Test modes** — \`--slow <ms>\`, \`--error\`, \`--reject-auth\`
- **Diagnostic logging** — \`--verbose\` shows full protocol trace (auth, payloads, latency, disconnect reason). Designed so users paste terminal output into GitHub issues and we can diagnose without follow-up questions.

### Smoke test results

```
[mock] CONNECT  sid=abc123 transportId=test
[mock] ← MESSAGE  sid=abc123 chat=demo len=11
[mock] → ACK  sid=abc123 ok=true reply="[echo] hello world"
[mock] DISCONNECT  sid=abc123 reason=client namespace disconnect
```

Auth rejection, slash commands, and health endpoint all verified.

### README (goes to npm)

Marks the package as **experimental**, asks users to test and report bugs, explains how to set up Telegram/CLI bridges with the mock, and guides users from mock → real MulmoClaude. Includes the full platform support roadmap table.

### Files

| File | Purpose |
|---|---|
| \`packages/mock-server/src/index.ts\` | CLI entry (arg parsing) |
| \`packages/mock-server/src/server.ts\` | Express + socket.io setup, auth, push endpoint |
| \`packages/mock-server/src/handlers.ts\` | Message handler (echo, slash commands) |
| \`packages/mock-server/src/logger.ts\` | Logger with verbose + file output |
| \`packages/mock-server/README.md\` | npm-facing docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `@mulmobridge/mock-server` package with a new `mulmobridge-mock-server` CLI tool for testing MulmoBridge messaging integration, supporting socket.io protocol with authentication, message echo functionality, slash command handling, and HTTP push delivery endpoint.

* **Documentation**
  * Added comprehensive README with quick-start instructions, configuration options, and testing guidance.

* **Tests**
  * Added test coverage for message handling and logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->