### PR TITLE
refactor: replace remaining scheduler string literals with constants

### DIFF
--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -295,7 +295,7 @@ function computeCurrentWindow(task: SystemTaskDef): string {
   const windowMs = nextWindowAfter(
     coreSchedule,
     nowMs -
-      (coreSchedule.type === "interval"
+      (coreSchedule.type === SCHEDULE_TYPES.interval
         ? coreSchedule.intervalSec * ONE_SECOND_MS
         : 0),
   );
@@ -313,7 +313,7 @@ function computeNextScheduled(task: SystemTaskDef): string | null {
 function toCoreSchedule(schedule: TaskDefinition["schedule"]): TaskSchedule {
   if (schedule.type === SCHEDULE_TYPES.interval) {
     return {
-      type: "interval",
+      type: SCHEDULE_TYPES.interval,
       intervalSec: Math.round(schedule.intervalMs / ONE_SECOND_MS),
     };
   }


### PR DESCRIPTION
## Summary

- `server/events/scheduler-adapter.ts` の `computeCurrentWindow` と `toCoreSchedule` で残っていた `"interval"` 文字列リテラルを `SCHEDULE_TYPES.interval` に置換
- #421 で大部分を対応済みだが、この2箇所が漏れていた

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)