### PR TITLE
fix: revert WORKSPACE_FILES cross-import that broke MCP server

### DIFF
--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -82,12 +82,21 @@ export const WORKSPACE_DIRS = {
   github: "github",
 } as const;
 
-// Well-known individual files — imported from the shared
-// src/config/workspacePaths.ts (single source of truth for both
-// server and frontend). Re-exported so server callers keep the
-// same `import { WORKSPACE_FILES } from "./paths.js"` they use.
-import { WORKSPACE_FILES } from "../../src/config/workspacePaths.js";
-export { WORKSPACE_FILES };
+// Well-known individual files. Values are workspace-relative paths.
+// The frontend mirror is `src/config/workspacePaths.ts` — keep them
+// in sync when adding or renaming entries.
+export const WORKSPACE_FILES = {
+  memory: "conversations/memory.md",
+  sessionToken: ".session-token",
+  wikiIndex: "data/wiki/index.md",
+  wikiLog: "data/wiki/log.md",
+  wikiSchema: "data/wiki/SCHEMA.md",
+  wikiSummary: "data/wiki/summary.md",
+  summariesIndex: "conversations/summaries/_index.md",
+  todosItems: "data/todos/todos.json",
+  todosColumns: "data/todos/columns.json",
+  schedulerItems: "data/scheduler/items.json",
+} as const;
 
 // Absolute paths, built once at module load from `workspacePath`.
 // The `workspacePath` const is itself fixed (reads `os.homedir()`


### PR DESCRIPTION
## Summary

- PR #415 で WORKSPACE_FILES を src/config/workspacePaths.ts に移動して server/workspace/paths.ts から re-export した
- MCP サーバーサブプロセス（tsx で起動）が `../../src/config/workspacePaths.js` を解決できず、全ツール登録が失敗していた
- presentMulmoScript, readXPost 等がアクセス不能になっていた

## Fix

server/workspace/paths.ts に WORKSPACE_FILES をインライン定義に戻す。src/config/workspacePaths.ts（フロントエンド用）はそのまま残し、手動同期。

## Test plan

- [x] yarn typecheck — pass
- [x] yarn test — pass
- [x] tsx で paths.ts のインポート確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)