### PR TITLE
fix: add attachment count + size limits to parseAttachments

### DIFF
--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -289,19 +289,30 @@ function parseMessagePayload(payload: MessagePayload): ParsedMessage {
   return { ok: true, externalChatId, text, attachments };
 }
 
+// Hard limits to prevent oversized payloads from bridges (DoS /
+// accidental misconfiguration). Express's JSON body limit (50 MB)
+// is the outer gate; these are tighter, attachment-specific caps.
+const MAX_ATTACHMENT_COUNT = 10;
+const MAX_ATTACHMENT_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB base64
+
 function parseAttachments(raw: unknown): Attachment[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined;
   const valid: Attachment[] = [];
+  let totalBytes = 0;
   for (const item of raw) {
+    if (valid.length >= MAX_ATTACHMENT_COUNT) break;
     if (
       item &&
       typeof item === "object" &&
       typeof (item as Record<string, unknown>).mimeType === "string" &&
       typeof (item as Record<string, unknown>).data === "string"
     ) {
+      const data = (item as Record<string, unknown>).data as string;
+      totalBytes += data.length;
+      if (totalBytes > MAX_ATTACHMENT_TOTAL_BYTES) break;
       const entry: Attachment = {
         mimeType: (item as Record<string, unknown>).mimeType as string,
-        data: (item as Record<string, unknown>).data as string,
+        data,
       };
       const fn = (item as Record<string, unknown>).filename;
       if (typeof fn === "string" && fn.length > 0) entry.filename = fn;


### PR DESCRIPTION
## Summary

PR #383 のレビューで指摘された attachment サイズ制限がモノレポ移行時に失われていた。`packages/chat-service/src/socket.ts` の `parseAttachments` に制限を追加。

- `MAX_ATTACHMENT_COUNT = 10` — 件数上限
- `MAX_ATTACHMENT_TOTAL_BYTES = 20 MB` — base64 合計バイト上限
- 上限超過時は静かに打ち切り（残りを無視）

Express の JSON body limit (50 MB) が外側のゲート。これはより細かい attachment 単位の防御。

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — pre-existing failures only (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)