### PR TITLE
feat: 6 new messaging bridges — Slack, Discord, LINE, WhatsApp, Matrix, IRC

### DIFF
--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -1,0 +1,53 @@
+# @mulmobridge/discord
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+Discord bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). The bot responds to messages in channels it has access to.
+
+## Setup
+
+### 1. Create a Discord Application
+
+1. Go to [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**
+2. Name it (e.g. "MulmoClaude")
+
+### 2. Create the Bot
+
+1. **Bot** tab → **Add Bot**
+2. Copy the **Token** (this is your `DISCORD_BOT_TOKEN`)
+3. Enable **Message Content Intent** under Privileged Gateway Intents
+
+### 3. Invite the bot to your server
+
+**OAuth2** → **URL Generator**:
+- Scopes: `bot`
+- Permissions: `Send Messages`, `Read Message History`
+
+Copy the generated URL and open it in your browser to invite the bot.
+
+### 4. Run the bridge
+
+```bash
+# With mock server (testing)
+npx @mulmobridge/mock-server &
+DISCORD_BOT_TOKEN=... \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/discord
+
+# With real MulmoClaude
+DISCORD_BOT_TOKEN=... \
+npx @mulmobridge/discord
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | Yes | Bot token from Developer Portal |
+| `DISCORD_ALLOWED_CHANNELS` | No | CSV of channel IDs to restrict (empty = all) |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token (auto-read from workspace) |
+
+## License
+
+MIT

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@mulmobridge/discord",
+  "version": "0.1.0",
+  "description": "Discord bridge for MulmoBridge — connect a Discord bot to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-discord": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "discord.js": "^14.18.0",
+    "dotenv": "^17.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// @mulmobridge/discord — Discord bridge for MulmoClaude.
+//
+// Required env vars:
+//   DISCORD_BOT_TOKEN      — Bot token from Discord Developer Portal
+//
+// Optional:
+//   DISCORD_ALLOWED_CHANNELS — CSV of channel IDs (empty = allow all)
+//   MULMOCLAUDE_API_URL      — default http://localhost:3001
+//   MULMOCLAUDE_AUTH_TOKEN   — bearer token (or read from workspace)
+
+import "dotenv/config";
+import { Client, GatewayIntentBits, type Message } from "discord.js";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "discord";
+const MAX_DISCORD_LENGTH = 2000;
+
+const token = process.env.DISCORD_BOT_TOKEN;
+if (!token) {
+  console.error(
+    "DISCORD_BOT_TOKEN is required.\nSee README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const allowedChannels = new Set(
+  (process.env.DISCORD_ALLOWED_CHANNELS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+const allowAll = allowedChannels.size === 0;
+
+const discord = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
+
+mulmo.onPush((ev) => {
+  const channel = discord.channels.cache.get(ev.chatId);
+  if (channel?.isTextBased() && "send" in channel) {
+    (channel as { send: (text: string) => Promise<unknown> })
+      .send(ev.message)
+      .catch((err: unknown) =>
+        console.error(`[discord] push send failed: ${err}`),
+      );
+  }
+});
+
+discord.on("messageCreate", async (msg: Message) => {
+  // Ignore bots (including ourselves)
+  if (msg.author.bot) return;
+
+  const channelId = msg.channelId;
+  const text = msg.content.trim();
+  if (!text) return;
+
+  if (!allowAll && !allowedChannels.has(channelId)) return;
+
+  console.log(
+    `[discord] message channel=${channelId} user=${msg.author.tag} len=${text.length}`,
+  );
+
+  const ack = await mulmo.send(channelId, text);
+  if (ack.ok) {
+    await sendChunked(msg, ack.reply ?? "");
+  } else {
+    const status = ack.status ? ` (${ack.status})` : "";
+    await msg.reply(`Error${status}: ${ack.error ?? "unknown"}`);
+  }
+});
+
+async function sendChunked(msg: Message, text: string): Promise<void> {
+  if (text.length === 0) {
+    await msg.reply("(empty reply)");
+    return;
+  }
+  for (let i = 0; i < text.length; i += MAX_DISCORD_LENGTH) {
+    const chunk = text.slice(i, i + MAX_DISCORD_LENGTH);
+    if (i === 0) {
+      await msg.reply(chunk);
+    } else {
+      if ("send" in msg.channel) {
+        await msg.channel.send(chunk);
+      }
+    }
+  }
+}
+
+discord.once("ready", () => {
+  console.log("MulmoClaude Discord bridge");
+  console.log(`Logged in as ${discord.user?.tag}`);
+  console.log(
+    `Channels: ${allowAll ? "(all)" : [...allowedChannels].join(", ")}`,
+  );
+});
+
+discord.login(token).catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -43,14 +43,22 @@ const discord = new Client({
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
-mulmo.onPush((ev) => {
-  const channel = discord.channels.cache.get(ev.chatId);
-  if (channel?.isTextBased() && "send" in channel) {
-    (channel as { send: (text: string) => Promise<unknown> })
-      .send(ev.message)
-      .catch((err: unknown) =>
-        console.error(`[discord] push send failed: ${err}`),
+mulmo.onPush(async (ev) => {
+  try {
+    const channel =
+      discord.channels.cache.get(ev.chatId) ??
+      (await discord.channels.fetch(ev.chatId).catch(() => null));
+    if (channel?.isTextBased() && "send" in channel) {
+      await (channel as { send: (text: string) => Promise<unknown> }).send(
+        ev.message,
       );
+    } else {
+      console.warn(
+        `[discord] push: channel ${ev.chatId} not found or not text-based`,
+      );
+    }
+  } catch (err) {
+    console.error(`[discord] push send failed: ${err}`);
   }
 });
 

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -10,7 +10,7 @@
 //   MULMOCLAUDE_AUTH_TOKEN   — bearer token (or read from workspace)
 
 import "dotenv/config";
-import { Client, GatewayIntentBits, type Message } from "discord.js";
+import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "discord";
@@ -39,6 +39,9 @@ const discord = new Client({
     GatewayIntentBits.DirectMessages,
     GatewayIntentBits.MessageContent,
   ],
+  // Partials.Channel is required to receive DM messageCreate events —
+  // DM channels are not cached by default in discord.js v14.
+  partials: [Partials.Channel],
 });
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
@@ -49,9 +52,8 @@ mulmo.onPush(async (ev) => {
       discord.channels.cache.get(ev.chatId) ??
       (await discord.channels.fetch(ev.chatId).catch(() => null));
     if (channel?.isTextBased() && "send" in channel) {
-      await (channel as { send: (text: string) => Promise<unknown> }).send(
-        ev.message,
-      );
+      const sendable = channel as { send: (t: string) => Promise<unknown> };
+      await sendChunkedToSendable(sendable, ev.message);
     } else {
       console.warn(
         `[discord] push: channel ${ev.chatId} not found or not text-based`,
@@ -63,25 +65,26 @@ mulmo.onPush(async (ev) => {
 });
 
 discord.on("messageCreate", async (msg: Message) => {
-  // Ignore bots (including ourselves)
   if (msg.author.bot) return;
-
   const channelId = msg.channelId;
   const text = msg.content.trim();
   if (!text) return;
-
   if (!allowAll && !allowedChannels.has(channelId)) return;
 
   console.log(
     `[discord] message channel=${channelId} user=${msg.author.tag} len=${text.length}`,
   );
 
-  const ack = await mulmo.send(channelId, text);
-  if (ack.ok) {
-    await sendChunked(msg, ack.reply ?? "");
-  } else {
-    const status = ack.status ? ` (${ack.status})` : "";
-    await msg.reply(`Error${status}: ${ack.error ?? "unknown"}`);
+  try {
+    const ack = await mulmo.send(channelId, text);
+    if (ack.ok) {
+      await sendChunked(msg, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await msg.reply(`Error${status}: ${ack.error ?? "unknown"}`);
+    }
+  } catch (err) {
+    console.error(`[discord] message handling failed: ${err}`);
   }
 });
 
@@ -94,11 +97,21 @@ async function sendChunked(msg: Message, text: string): Promise<void> {
     const chunk = text.slice(i, i + MAX_DISCORD_LENGTH);
     if (i === 0) {
       await msg.reply(chunk);
-    } else {
-      if ("send" in msg.channel) {
-        await msg.channel.send(chunk);
-      }
+    } else if ("send" in msg.channel) {
+      await (msg.channel as { send: (t: string) => Promise<unknown> }).send(
+        chunk,
+      );
     }
+  }
+}
+
+async function sendChunkedToSendable(
+  channel: { send: (t: string) => Promise<unknown> },
+  text: string,
+): Promise<void> {
+  const content = text.length === 0 ? "(empty reply)" : text;
+  for (let i = 0; i < content.length; i += MAX_DISCORD_LENGTH) {
+    await channel.send(content.slice(i, i + MAX_DISCORD_LENGTH));
   }
 }
 

--- a/packages/discord/tsconfig.json
+++ b/packages/discord/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/irc/README.md
+++ b/packages/irc/README.md
@@ -1,0 +1,47 @@
+# @mulmobridge/irc
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+IRC bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Connects to any IRC server (Libera.Chat, OFTC, self-hosted, etc.).
+
+## Setup
+
+No API keys or bot registration needed — just pick a nickname and connect.
+
+```bash
+# Testing with mock server
+npx @mulmobridge/mock-server &
+IRC_SERVER=irc.libera.chat \
+IRC_NICK=mulmo-bot \
+IRC_CHANNELS=#your-channel \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/irc
+
+# With real MulmoClaude
+IRC_SERVER=irc.libera.chat \
+IRC_NICK=mulmo-bot \
+IRC_CHANNELS=#your-channel \
+npx @mulmobridge/irc
+```
+
+## How it works
+
+- **In channels**: the bot responds only when mentioned (`mulmo-bot: what is 2+2?`)
+- **In private messages**: the bot responds to everything
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `IRC_SERVER` | Yes | e.g. `irc.libera.chat` |
+| `IRC_NICK` | Yes | Bot nickname |
+| `IRC_CHANNELS` | Yes | CSV of channels (e.g. `#mulmo,#test`) |
+| `IRC_PORT` | No | Default: 6697 (TLS) or 6667 (plain) |
+| `IRC_TLS` | No | `true` (default) or `false` |
+| `IRC_PASSWORD` | No | NickServ or server password |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
+
+## License
+
+MIT

--- a/packages/irc/package.json
+++ b/packages/irc/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@mulmobridge/irc",
+  "version": "0.1.0",
+  "description": "IRC bridge for MulmoBridge — connect IRC channels to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-irc": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "irc-framework": "^4.14.0",
+    "dotenv": "^17.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/irc/package.json
+++ b/packages/irc/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/irc/src/index.ts
+++ b/packages/irc/src/index.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// @mulmobridge/irc — IRC bridge for MulmoClaude.
+//
+// Required env vars:
+//   IRC_SERVER     — e.g. irc.libera.chat
+//   IRC_NICK       — bot nickname
+//   IRC_CHANNELS   — CSV of channels to join (e.g. #mulmo,#test)
+//
+// Optional:
+//   IRC_PORT       — default 6697 (TLS) or 6667 (plain)
+//   IRC_TLS        — true/false (default: true)
+//   IRC_PASSWORD   — NickServ or server password
+
+import "dotenv/config";
+// @ts-expect-error — irc-framework has no type declarations
+import { Client as IrcClient } from "irc-framework";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "irc";
+
+const server = process.env.IRC_SERVER;
+const nick = process.env.IRC_NICK;
+const channelsStr = process.env.IRC_CHANNELS;
+if (!server || !nick || !channelsStr) {
+  console.error(
+    "IRC_SERVER, IRC_NICK, and IRC_CHANNELS are required.\n" +
+      "See README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const channels = channelsStr
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const useTls = (process.env.IRC_TLS ?? "true") !== "false";
+const port = Number(process.env.IRC_PORT) || (useTls ? 6697 : 6667);
+const password = process.env.IRC_PASSWORD;
+
+const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
+
+mulmo.onPush((ev) => {
+  // ev.chatId is the channel name
+  irc.say(ev.chatId, ev.message);
+});
+
+const irc = new IrcClient();
+
+irc.connect({
+  host: server,
+  port,
+  nick,
+  tls: useTls,
+  password: password ?? undefined,
+});
+
+irc.on("registered", () => {
+  console.log("MulmoClaude IRC bridge");
+  console.log(`Connected to ${server}:${port} as ${nick}`);
+  for (const ch of channels) {
+    irc.join(ch);
+    console.log(`Joined ${ch}`);
+  }
+});
+
+irc.on(
+  "message",
+  async (event: { target: string; nick: string; message: string }) => {
+    // Ignore our own messages
+    if (event.nick === nick) return;
+
+    const isChannel = event.target.startsWith("#");
+    const chatId = isChannel ? event.target : event.nick;
+    const text = event.message.trim();
+    if (!text) return;
+
+    // In channels, only respond when mentioned or prefixed with bot nick
+    if (isChannel) {
+      const mentionPrefix = `${nick}:`;
+      const mentionPrefix2 = `${nick},`;
+      if (!text.startsWith(mentionPrefix) && !text.startsWith(mentionPrefix2)) {
+        return;
+      }
+      // Strip the mention prefix
+      const stripped = text
+        .slice(
+          text.startsWith(mentionPrefix)
+            ? mentionPrefix.length
+            : mentionPrefix2.length,
+        )
+        .trim();
+      if (!stripped) return;
+
+      console.log(
+        `[irc] message channel=${chatId} nick=${event.nick} len=${stripped.length}`,
+      );
+      const ack = await mulmo.send(chatId, stripped);
+      sendReply(chatId, ack);
+      return;
+    }
+
+    // Private messages — respond directly
+    console.log(`[irc] pm from=${event.nick} len=${text.length}`);
+    const ack = await mulmo.send(chatId, text);
+    sendReply(chatId, ack);
+  },
+);
+
+function sendReply(
+  target: string,
+  ack: { ok: boolean; reply?: string; error?: string; status?: number },
+): void {
+  if (ack.ok) {
+    const text = ack.reply ?? "(empty reply)";
+    // IRC messages are max ~512 bytes per line. Chunk at 400 chars.
+    const lines = text.split("\n");
+    for (const line of lines) {
+      for (let i = 0; i < line.length; i += 400) {
+        irc.say(target, line.slice(i, i + 400));
+      }
+    }
+  } else {
+    const status = ack.status ? ` (${ack.status})` : "";
+    irc.say(target, `Error${status}: ${ack.error ?? "unknown"}`);
+  }
+}
+
+irc.on("close", () => {
+  console.log("[irc] disconnected, exiting");
+  process.exit(0);
+});

--- a/packages/irc/src/index.ts
+++ b/packages/irc/src/index.ts
@@ -69,7 +69,8 @@ irc.on(
     // Ignore our own messages
     if (event.nick === nick) return;
 
-    const isChannel = event.target.startsWith("#");
+    // IRC channel prefixes: #, &, +, ! (RFC 2812 §1.3)
+    const isChannel = /^[#&+!]/.test(event.target);
     const chatId = isChannel ? event.target : event.nick;
     const text = event.message.trim();
     if (!text) return;

--- a/packages/irc/tsconfig.json
+++ b/packages/irc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/line/README.md
+++ b/packages/line/README.md
@@ -1,0 +1,66 @@
+# @mulmobridge/line
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+LINE bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Uses webhook events — requires a public URL (ngrok for development).
+
+## Setup
+
+### 1. Create a LINE Messaging API Channel
+
+1. Go to [LINE Developers Console](https://developers.line.biz/console/) → create a Provider → create a **Messaging API** channel
+2. Note the **Channel secret** (Basic settings tab)
+3. Issue a **Channel access token** (Messaging API tab → long-lived)
+
+### 2. Set up ngrok (for development)
+
+```bash
+ngrok http 3002
+# Copy the https://xxxx.ngrok-free.app URL
+```
+
+### 3. Configure the webhook
+
+In the LINE Developers Console → Messaging API tab:
+- **Webhook URL**: `https://xxxx.ngrok-free.app/webhook`
+- **Use webhook**: enabled
+- **Auto-reply messages**: disabled (so LINE's default replies don't interfere)
+
+### 4. Run the bridge
+
+```bash
+# With mock server (testing)
+npx @mulmobridge/mock-server &
+LINE_CHANNEL_SECRET=... \
+LINE_CHANNEL_ACCESS_TOKEN=... \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/line
+
+# With real MulmoClaude
+LINE_CHANNEL_SECRET=... \
+LINE_CHANNEL_ACCESS_TOKEN=... \
+npx @mulmobridge/line
+```
+
+### 5. Add the bot as a friend
+
+Scan the QR code in the LINE Developers Console → Messaging API tab. Send a message — MulmoClaude replies.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `LINE_CHANNEL_SECRET` | Yes | Channel secret for signature verification |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Long-lived channel access token |
+| `LINE_BRIDGE_PORT` | No | Webhook port (default: 3002) |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
+
+## Notes
+
+- LINE reply tokens expire in **1 minute**. Since Claude responses can take longer, the bridge uses **push messages** instead of reply messages. This requires your bot to be a verified/certified account for push to work with all users, OR the user must have added the bot as a friend first.
+- LINE limits messages to 5 per push call and ~5000 chars per message. Long replies are automatically chunked.
+
+## License
+
+MIT

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mulmobridge/line",
+  "version": "0.1.0",
+  "description": "LINE bridge for MulmoBridge — connect a LINE bot to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-line": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "dotenv": "^17.0.0",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/line/src/index.ts
+++ b/packages/line/src/index.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// @mulmobridge/line — LINE bridge for MulmoClaude.
+//
+// Runs a small HTTP server to receive LINE webhook events.
+// Requires a public URL (use ngrok for development).
+//
+// Required env vars:
+//   LINE_CHANNEL_SECRET      — Channel secret from LINE Developers Console
+//   LINE_CHANNEL_ACCESS_TOKEN — Channel access token (long-lived)
+//
+// Optional:
+//   LINE_BRIDGE_PORT          — Webhook listener port (default: 3002)
+//   MULMOCLAUDE_API_URL       — default http://localhost:3001
+//   MULMOCLAUDE_AUTH_TOKEN    — bearer token
+
+import "dotenv/config";
+import crypto from "crypto";
+import express, { type Request, type Response } from "express";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "line";
+const PORT = Number(process.env.LINE_BRIDGE_PORT) || 3002;
+
+const channelSecret = process.env.LINE_CHANNEL_SECRET;
+const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+if (!channelSecret || !channelAccessToken) {
+  console.error(
+    "LINE_CHANNEL_SECRET and LINE_CHANNEL_ACCESS_TOKEN are required.\n" +
+      "See README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const client = createBridgeClient({ transportId: TRANSPORT_ID });
+
+client.onPush((ev) => {
+  pushMessage(ev.chatId, ev.message).catch((err) =>
+    console.error(`[line] push send failed: ${err}`),
+  );
+});
+
+// ── LINE API helpers ────────────────────────────────────────────
+
+async function pushMessage(userId: string, text: string): Promise<void> {
+  const messages = chunkText(text).map((t) => ({ type: "text", text: t }));
+  // LINE allows max 5 messages per push
+  for (let i = 0; i < messages.length; i += 5) {
+    await fetch("https://api.line.me/v2/bot/message/push", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${channelAccessToken}`,
+      },
+      body: JSON.stringify({
+        to: userId,
+        messages: messages.slice(i, i + 5),
+      }),
+    });
+  }
+}
+
+function chunkText(text: string, max = 5000): string[] {
+  if (text.length === 0) return ["(empty reply)"];
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += max) {
+    chunks.push(text.slice(i, i + max));
+  }
+  return chunks;
+}
+
+// ── Signature verification ──────────────────────────────────────
+
+function verifySignature(body: string, signature: string): boolean {
+  const hash = crypto
+    .createHmac("SHA256", channelSecret!)
+    .update(body)
+    .digest("base64");
+  return hash === signature;
+}
+
+// ── Webhook server ──────────────────────────────────────────────
+
+const app = express();
+app.disable("x-powered-by");
+app.use(express.text({ type: "application/json" }));
+
+app.post("/webhook", async (req: Request, res: Response) => {
+  const signature = req.headers["x-line-signature"] as string;
+  const bodyStr = req.body as string;
+
+  if (!signature || !verifySignature(bodyStr, signature)) {
+    res.status(401).send("Invalid signature");
+    return;
+  }
+
+  res.status(200).send("OK");
+
+  const body = JSON.parse(bodyStr) as {
+    events: Array<{
+      type: string;
+      replyToken?: string;
+      source?: { userId?: string; type?: string };
+      message?: { type: string; text?: string };
+    }>;
+  };
+
+  for (const event of body.events) {
+    if (event.type !== "message" || event.message?.type !== "text") continue;
+    const userId = event.source?.userId;
+    const text = event.message?.text ?? "";
+    if (!userId || !text.trim()) continue;
+
+    console.log(`[line] message user=${userId} len=${text.length}`);
+
+    // Reply token expires in 1 minute. Since agent can take longer,
+    // use push messages for the actual reply. The reply token is
+    // used only for a quick "thinking..." indicator if desired.
+    const ack = await client.send(userId, text);
+    if (ack.ok) {
+      await pushMessage(userId, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await pushMessage(userId, `Error${status}: ${ack.error ?? "unknown"}`);
+    }
+  }
+});
+
+app.listen(PORT, () => {
+  console.log("MulmoClaude LINE bridge");
+  console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
+  console.log("Set your LINE webhook URL to: <public-url>/webhook");
+});

--- a/packages/line/src/index.ts
+++ b/packages/line/src/index.ts
@@ -45,17 +45,27 @@ async function pushMessage(userId: string, text: string): Promise<void> {
   const messages = chunkText(text).map((t) => ({ type: "text", text: t }));
   // LINE allows max 5 messages per push
   for (let i = 0; i < messages.length; i += 5) {
-    await fetch("https://api.line.me/v2/bot/message/push", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${channelAccessToken}`,
-      },
-      body: JSON.stringify({
-        to: userId,
-        messages: messages.slice(i, i + 5),
-      }),
-    });
+    try {
+      const res = await fetch("https://api.line.me/v2/bot/message/push", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${channelAccessToken}`,
+        },
+        body: JSON.stringify({
+          to: userId,
+          messages: messages.slice(i, i + 5),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        console.error(
+          `[line] pushMessage failed: ${res.status} ${body.slice(0, 200)}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[line] pushMessage network error: ${err}`);
+    }
   }
 }
 
@@ -95,7 +105,7 @@ app.post("/webhook", async (req: Request, res: Response) => {
 
   res.status(200).send("OK");
 
-  const body = JSON.parse(bodyStr) as {
+  let body: {
     events: Array<{
       type: string;
       replyToken?: string;
@@ -103,6 +113,12 @@ app.post("/webhook", async (req: Request, res: Response) => {
       message?: { type: string; text?: string };
     }>;
   };
+  try {
+    body = JSON.parse(bodyStr);
+  } catch {
+    console.error("[line] malformed JSON in webhook body");
+    return;
+  }
 
   for (const event of body.events) {
     if (event.type !== "message" || event.message?.type !== "text") continue;

--- a/packages/line/src/index.ts
+++ b/packages/line/src/index.ts
@@ -56,6 +56,7 @@ async function pushMessage(userId: string, text: string): Promise<void> {
           to: userId,
           messages: messages.slice(i, i + 5),
         }),
+        signal: AbortSignal.timeout(30_000),
       });
       if (!res.ok) {
         const body = await res.text().catch(() => "");
@@ -81,11 +82,12 @@ function chunkText(text: string, max = 5000): string[] {
 // ── Signature verification ──────────────────────────────────────
 
 function verifySignature(body: string, signature: string): boolean {
-  const hash = crypto
+  const expected = crypto
     .createHmac("SHA256", channelSecret!)
     .update(body)
     .digest("base64");
-  return hash === signature;
+  if (expected.length !== signature.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
 }
 
 // ── Webhook server ──────────────────────────────────────────────
@@ -128,15 +130,16 @@ app.post("/webhook", async (req: Request, res: Response) => {
 
     console.log(`[line] message user=${userId} len=${text.length}`);
 
-    // Reply token expires in 1 minute. Since agent can take longer,
-    // use push messages for the actual reply. The reply token is
-    // used only for a quick "thinking..." indicator if desired.
-    const ack = await client.send(userId, text);
-    if (ack.ok) {
-      await pushMessage(userId, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await pushMessage(userId, `Error${status}: ${ack.error ?? "unknown"}`);
+    try {
+      const ack = await client.send(userId, text);
+      if (ack.ok) {
+        await pushMessage(userId, ack.reply ?? "");
+      } else {
+        const status = ack.status ? ` (${ack.status})` : "";
+        await pushMessage(userId, `Error${status}: ${ack.error ?? "unknown"}`);
+      }
+    } catch (err) {
+      console.error(`[line] message handling failed: ${err}`);
     }
   }
 });

--- a/packages/line/tsconfig.json
+++ b/packages/line/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/matrix/README.md
+++ b/packages/matrix/README.md
@@ -1,0 +1,68 @@
+# @mulmobridge/matrix
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+Matrix bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Works with any Matrix homeserver (matrix.org, Element, Synapse, Dendrite, Conduit).
+
+## Setup
+
+### 1. Create a bot account
+
+Register a new user on your Matrix homeserver for the bot. On matrix.org:
+
+```bash
+# Using Element: create a new account manually
+# Or use the admin API on your self-hosted server
+```
+
+### 2. Get an access token
+
+```bash
+curl -X POST "https://matrix.org/_matrix/client/v3/login" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"m.login.password","user":"@mulmo-bot:matrix.org","password":"..."}'
+# → { "access_token": "syt_..." }
+```
+
+### 3. Invite the bot to a room
+
+In Element or your Matrix client, invite `@mulmo-bot:matrix.org` to the room where you want to use MulmoClaude.
+
+### 4. Run the bridge
+
+```bash
+# Testing with mock server
+npx @mulmobridge/mock-server &
+MATRIX_HOMESERVER_URL=https://matrix.org \
+MATRIX_ACCESS_TOKEN=syt_... \
+MATRIX_USER_ID=@mulmo-bot:matrix.org \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/matrix
+
+# With real MulmoClaude
+MATRIX_HOMESERVER_URL=https://matrix.org \
+MATRIX_ACCESS_TOKEN=syt_... \
+MATRIX_USER_ID=@mulmo-bot:matrix.org \
+npx @mulmobridge/matrix
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MATRIX_HOMESERVER_URL` | Yes | e.g. `https://matrix.org` |
+| `MATRIX_ACCESS_TOKEN` | Yes | Bot user's access token |
+| `MATRIX_USER_ID` | Yes | e.g. `@mulmo-bot:matrix.org` |
+| `MATRIX_ALLOWED_ROOMS` | No | CSV of room IDs (empty = all joined rooms) |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
+
+## Notes
+
+- Matrix is an **open, federated protocol**. Your bot can join rooms on any server, not just the one it's registered on.
+- No webhook or public URL needed — the bridge connects to the homeserver directly via long-polling sync.
+- End-to-end encrypted rooms are **not supported** in this version (the SDK supports it, but key management adds complexity).
+
+## License
+
+MIT

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@mulmobridge/matrix",
+  "version": "0.1.0",
+  "description": "Matrix bridge for MulmoBridge — connect Matrix/Element to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-matrix": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "matrix-js-sdk": "^41.3.0",
+    "dotenv": "^17.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/matrix/src/index.ts
+++ b/packages/matrix/src/index.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// @mulmobridge/matrix — Matrix bridge for MulmoClaude.
+//
+// Uses the Matrix Client-Server API (works with any Matrix server
+// including matrix.org, Element, Synapse, Dendrite, Conduit).
+//
+// Required env vars:
+//   MATRIX_HOMESERVER_URL  — e.g. https://matrix.org
+//   MATRIX_ACCESS_TOKEN    — access token for the bot user
+//   MATRIX_USER_ID         — e.g. @mulmo-bot:matrix.org
+//
+// Optional:
+//   MATRIX_ALLOWED_ROOMS   — CSV of room IDs (empty = all joined rooms)
+
+import "dotenv/config";
+import {
+  createClient,
+  type MatrixClient,
+  type MatrixEvent,
+  type Room,
+} from "matrix-js-sdk";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "matrix";
+
+const homeserverUrl = process.env.MATRIX_HOMESERVER_URL;
+const accessToken = process.env.MATRIX_ACCESS_TOKEN;
+const userId = process.env.MATRIX_USER_ID;
+if (!homeserverUrl || !accessToken || !userId) {
+  console.error(
+    "MATRIX_HOMESERVER_URL, MATRIX_ACCESS_TOKEN, and MATRIX_USER_ID are required.\n" +
+      "See README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const allowedRooms = new Set(
+  (process.env.MATRIX_ALLOWED_ROOMS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+const allowAll = allowedRooms.size === 0;
+
+const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
+
+mulmo.onPush((ev) => {
+  matrixClient
+    .sendTextMessage(ev.chatId, ev.message)
+    .catch((err: unknown) =>
+      console.error(`[matrix] push send failed: ${err}`),
+    );
+});
+
+const matrixClient: MatrixClient = createClient({
+  baseUrl: homeserverUrl,
+  accessToken,
+  userId,
+});
+
+// The matrix-js-sdk event emitter types are narrowly typed; the
+// Room.timeline event name requires a cast.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(matrixClient as any).on(
+  "Room.timeline",
+  async (event: MatrixEvent, room: Room | null) => {
+    if (!room) return;
+    if (event.getType() !== "m.room.message") return;
+    if (event.getSender() === userId) return;
+
+    const content = event.getContent();
+    if (content.msgtype !== "m.text") return;
+
+    const roomId = room.roomId;
+    const text = (content.body as string) ?? "";
+    if (!text.trim()) return;
+
+    if (!allowAll && !allowedRooms.has(roomId)) return;
+
+    console.log(
+      `[matrix] message room=${roomId} sender=${event.getSender()} len=${text.length}`,
+    );
+
+    const ack = await mulmo.send(roomId, text);
+    if (ack.ok) {
+      await sendChunked(roomId, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await matrixClient.sendTextMessage(
+        roomId,
+        `Error${status}: ${ack.error ?? "unknown"}`,
+      );
+    }
+  },
+);
+
+async function sendChunked(roomId: string, text: string): Promise<void> {
+  // Matrix has no strict char limit but we chunk at 4000 for readability
+  const MAX = 4000;
+  if (text.length === 0) {
+    await matrixClient.sendTextMessage(roomId, "(empty reply)");
+    return;
+  }
+  for (let i = 0; i < text.length; i += MAX) {
+    await matrixClient.sendTextMessage(roomId, text.slice(i, i + MAX));
+  }
+}
+
+async function main(): Promise<void> {
+  console.log("MulmoClaude Matrix bridge");
+  console.log(`Homeserver: ${homeserverUrl}`);
+  console.log(`User: ${userId}`);
+  console.log(
+    `Rooms: ${allowAll ? "(all joined)" : [...allowedRooms].join(", ")}`,
+  );
+
+  await matrixClient.startClient({ initialSyncLimit: 0 });
+  console.log("Connected to Matrix.");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/matrix/src/index.ts
+++ b/packages/matrix/src/index.ts
@@ -70,9 +70,10 @@ const matrixClient: MatrixClient = createClient({
 
     const content = event.getContent();
     if (content.msgtype !== "m.text") return;
+    if (typeof content.body !== "string") return;
 
     const roomId = room.roomId;
-    const text = (content.body as string) ?? "";
+    const text = content.body;
     if (!text.trim()) return;
 
     if (!allowAll && !allowedRooms.has(roomId)) return;
@@ -81,15 +82,19 @@ const matrixClient: MatrixClient = createClient({
       `[matrix] message room=${roomId} sender=${event.getSender()} len=${text.length}`,
     );
 
-    const ack = await mulmo.send(roomId, text);
-    if (ack.ok) {
-      await sendChunked(roomId, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await matrixClient.sendTextMessage(
-        roomId,
-        `Error${status}: ${ack.error ?? "unknown"}`,
-      );
+    try {
+      const ack = await mulmo.send(roomId, text);
+      if (ack.ok) {
+        await sendChunked(roomId, ack.reply ?? "");
+      } else {
+        const status = ack.status ? ` (${ack.status})` : "";
+        await matrixClient.sendTextMessage(
+          roomId,
+          `Error${status}: ${ack.error ?? "unknown"}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[matrix] message handling failed: ${err}`);
     }
   },
 );

--- a/packages/matrix/tsconfig.json
+++ b/packages/matrix/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -1,0 +1,71 @@
+# @mulmobridge/slack
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new). Your feedback helps us improve.
+
+Slack bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Uses **Socket Mode** — no public URL or ngrok needed.
+
+## Setup
+
+### 1. Create a Slack App
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+2. Name it (e.g. "MulmoClaude") and pick your workspace
+
+### 2. Configure permissions
+
+**OAuth & Permissions** → add these Bot Token Scopes:
+- `chat:write` — send messages
+- `channels:history` — read messages in public channels
+- `groups:history` — read messages in private channels
+- `im:history` — read direct messages
+- `mpim:history` — read group DMs
+
+### 3. Enable Socket Mode
+
+**Socket Mode** → toggle **Enable Socket Mode** → create an App-Level Token with `connections:write` scope. Copy the `xapp-...` token.
+
+### 4. Enable Events
+
+**Event Subscriptions** → toggle **Enable Events** → subscribe to:
+- `message.channels`
+- `message.groups`
+- `message.im`
+- `message.mpim`
+
+### 5. Install to workspace
+
+**Install App** → **Install to Workspace** → copy the `xoxb-...` Bot User OAuth Token.
+
+### 6. Run the bridge
+
+```bash
+# With mock server (for testing)
+npx @mulmobridge/mock-server &
+SLACK_BOT_TOKEN=xoxb-... \
+SLACK_APP_TOKEN=xapp-... \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/slack
+
+# With real MulmoClaude
+SLACK_BOT_TOKEN=xoxb-... \
+SLACK_APP_TOKEN=xapp-... \
+npx @mulmobridge/slack
+```
+
+### 7. Invite the bot
+
+In Slack, invite the bot to a channel: `/invite @MulmoClaude`
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SLACK_BOT_TOKEN` | Yes | `xoxb-...` Bot User OAuth Token |
+| `SLACK_APP_TOKEN` | Yes | `xapp-...` App-Level Token (connections:write) |
+| `SLACK_ALLOWED_CHANNELS` | No | CSV of channel IDs to restrict access (empty = all) |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token (auto-read from workspace if not set) |
+
+## License
+
+MIT

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mulmobridge/slack",
+  "version": "0.1.0",
+  "description": "Slack bridge for MulmoBridge — connect a Slack bot to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-slack": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "@slack/socket-mode": "^2.0.3",
+    "@slack/web-api": "^7.8.0",
+    "dotenv": "^17.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// @mulmobridge/slack — Slack bridge for MulmoClaude.
+//
+// Uses Slack Socket Mode (no public URL needed).
+//
+// Required env vars:
+//   SLACK_BOT_TOKEN     — xoxb-... (Bot User OAuth Token)
+//   SLACK_APP_TOKEN     — xapp-... (App-Level Token with connections:write)
+//
+// Optional:
+//   SLACK_ALLOWED_CHANNELS — CSV of channel IDs (empty = allow all)
+//   MULMOCLAUDE_API_URL    — default http://localhost:3001
+//   MULMOCLAUDE_AUTH_TOKEN — bearer token (or read from workspace)
+
+import "dotenv/config";
+import { SocketModeClient } from "@slack/socket-mode";
+import { WebClient } from "@slack/web-api";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "slack";
+
+const botToken = process.env.SLACK_BOT_TOKEN;
+const appToken = process.env.SLACK_APP_TOKEN;
+if (!botToken || !appToken) {
+  console.error(
+    "SLACK_BOT_TOKEN and SLACK_APP_TOKEN are required.\n" +
+      "See README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const allowedChannels = new Set(
+  (process.env.SLACK_ALLOWED_CHANNELS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+const allowAll = allowedChannels.size === 0;
+
+const web = new WebClient(botToken);
+const socketMode = new SocketModeClient({ appToken });
+
+const client = createBridgeClient({ transportId: TRANSPORT_ID });
+
+// Resolve the bot's own user ID so we can ignore our own messages
+let botUserId: string | null = null;
+
+client.onPush((ev) => {
+  web.chat
+    .postMessage({ channel: ev.chatId, text: ev.message })
+    .catch((err) => console.error(`[slack] push send failed: ${err}`));
+});
+
+socketMode.on("message", async ({ event, ack }) => {
+  await ack();
+
+  // Ignore bot's own messages, message_changed, etc.
+  if (event.subtype) return;
+  if (event.bot_id) return;
+  if (botUserId && event.user === botUserId) return;
+
+  const channelId: string = event.channel;
+  const text: string = event.text ?? "";
+  if (!text.trim()) return;
+
+  if (!allowAll && !allowedChannels.has(channelId)) {
+    console.log(`[slack] denied channel=${channelId}`);
+    return;
+  }
+
+  console.log(
+    `[slack] message channel=${channelId} user=${event.user} len=${text.length}`,
+  );
+
+  const ackResult = await client.send(channelId, text);
+  if (ackResult.ok) {
+    await sendChunked(channelId, ackResult.reply ?? "");
+  } else {
+    const status = ackResult.status ? ` (${ackResult.status})` : "";
+    await web.chat.postMessage({
+      channel: channelId,
+      text: `Error${status}: ${ackResult.error ?? "unknown"}`,
+    });
+  }
+});
+
+async function sendChunked(channel: string, text: string): Promise<void> {
+  // Slack's max message length is ~40,000 chars but we chunk at 4000
+  // for readability (matching Telegram's approach).
+  const MAX = 4000;
+  if (text.length === 0) {
+    await web.chat.postMessage({ channel, text: "(empty reply)" });
+    return;
+  }
+  for (let i = 0; i < text.length; i += MAX) {
+    await web.chat.postMessage({
+      channel,
+      text: text.slice(i, i + MAX),
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  // Get bot user ID
+  const authResult = await web.auth.test();
+  botUserId = (authResult.user_id as string) ?? null;
+
+  console.log("MulmoClaude Slack bridge");
+  console.log(
+    `Channels: ${allowAll ? "(all)" : [...allowedChannels].join(", ")}`,
+  );
+
+  await socketMode.start();
+  console.log("Connected to Slack (Socket Mode).");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -72,15 +72,23 @@ socketMode.on("message", async ({ event, ack }) => {
     `[slack] message channel=${channelId} user=${event.user} len=${text.length}`,
   );
 
-  const ackResult = await client.send(channelId, text);
-  if (ackResult.ok) {
-    await sendChunked(channelId, ackResult.reply ?? "");
-  } else {
-    const status = ackResult.status ? ` (${ackResult.status})` : "";
-    await web.chat.postMessage({
-      channel: channelId,
-      text: `Error${status}: ${ackResult.error ?? "unknown"}`,
-    });
+  try {
+    const ackResult = await client.send(channelId, text);
+    if (ackResult.ok) {
+      await sendChunked(channelId, ackResult.reply ?? "");
+    } else {
+      const status = ackResult.status ? ` (${ackResult.status})` : "";
+      await web.chat
+        .postMessage({
+          channel: channelId,
+          text: `Error${status}: ${ackResult.error ?? "unknown"}`,
+        })
+        .catch((err) =>
+          console.error(`[slack] error notification failed: ${err}`),
+        );
+    }
+  } catch (err) {
+    console.error(`[slack] message handling failed: ${err}`);
   }
 });
 
@@ -103,7 +111,8 @@ async function sendChunked(channel: string, text: string): Promise<void> {
 async function main(): Promise<void> {
   // Get bot user ID
   const authResult = await web.auth.test();
-  botUserId = (authResult.user_id as string) ?? null;
+  const rawUserId = authResult.user_id;
+  botUserId = typeof rawUserId === "string" ? rawUserId : null;
 
   console.log("MulmoClaude Slack bridge");
   console.log(

--- a/packages/slack/tsconfig.json
+++ b/packages/slack/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/whatsapp/README.md
+++ b/packages/whatsapp/README.md
@@ -1,0 +1,65 @@
+# @mulmobridge/whatsapp
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+WhatsApp bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude) via Meta's Cloud API. Requires a Meta Business account.
+
+## Setup
+
+### 1. Create a Meta App
+
+1. Go to [developers.facebook.com](https://developers.facebook.com/apps/) → **Create App** → **Business** type
+2. Add the **WhatsApp** product
+3. In WhatsApp → Getting Started, note your **Phone Number ID** and generate a **permanent access token**
+
+### 2. Set up ngrok
+
+```bash
+ngrok http 3003
+```
+
+### 3. Configure webhook
+
+In Meta Dashboard → WhatsApp → Configuration:
+- **Callback URL**: `https://xxxx.ngrok-free.app/webhook`
+- **Verify token**: any string you choose (set as `WHATSAPP_VERIFY_TOKEN`)
+- Subscribe to: `messages`
+
+### 4. Run the bridge
+
+```bash
+# Testing with mock server
+npx @mulmobridge/mock-server &
+WHATSAPP_ACCESS_TOKEN=... \
+WHATSAPP_PHONE_NUMBER_ID=... \
+WHATSAPP_VERIFY_TOKEN=my-verify-token \
+MULMOCLAUDE_AUTH_TOKEN=mock-test-token \
+npx @mulmobridge/whatsapp
+
+# With real MulmoClaude
+WHATSAPP_ACCESS_TOKEN=... \
+WHATSAPP_PHONE_NUMBER_ID=... \
+WHATSAPP_VERIFY_TOKEN=my-verify-token \
+npx @mulmobridge/whatsapp
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | Yes | Permanent access token from Meta dashboard |
+| `WHATSAPP_PHONE_NUMBER_ID` | Yes | Phone number ID |
+| `WHATSAPP_VERIFY_TOKEN` | Yes | Arbitrary string for webhook verification |
+| `WHATSAPP_BRIDGE_PORT` | No | Webhook port (default: 3003) |
+| `WHATSAPP_ALLOWED_NUMBERS` | No | CSV of phone numbers (empty = all) |
+| `MULMOCLAUDE_API_URL` | No | Default `http://localhost:3001` |
+| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
+
+## Notes
+
+- WhatsApp has a **24-hour messaging window**: you can only reply to a user within 24 hours of their last message. After that, you need a pre-approved template message to initiate contact.
+- The Meta Cloud API requires a **verified Business account** for production use. The test number works for development.
+
+## License
+
+MIT

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mulmobridge/whatsapp",
+  "version": "0.1.0",
+  "description": "WhatsApp bridge for MulmoBridge — connect WhatsApp Business to MulmoClaude",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mulmobridge-whatsapp": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "yarn build",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "author": "Receptron Team",
+  "dependencies": {
+    "@mulmobridge/client": "^0.1.0",
+    "@mulmobridge/protocol": "^0.1.0",
+    "dotenv": "^17.0.0",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "yarn build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo no tests yet"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/whatsapp/src/index.ts
+++ b/packages/whatsapp/src/index.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// @mulmobridge/whatsapp — WhatsApp bridge for MulmoClaude.
+//
+// Uses Meta's WhatsApp Cloud API (webhook mode).
+// Requires a Meta Business account + WhatsApp Business API setup.
+//
+// Required env vars:
+//   WHATSAPP_ACCESS_TOKEN    — permanent access token
+//   WHATSAPP_PHONE_NUMBER_ID — phone number ID from Meta dashboard
+//   WHATSAPP_VERIFY_TOKEN    — any string for webhook verification
+//
+// Optional:
+//   WHATSAPP_BRIDGE_PORT      — webhook port (default: 3003)
+//   WHATSAPP_ALLOWED_NUMBERS  — CSV of phone numbers (empty = all)
+
+import "dotenv/config";
+import express, { type Request, type Response } from "express";
+import { createBridgeClient } from "@mulmobridge/client";
+
+const TRANSPORT_ID = "whatsapp";
+const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
+
+const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
+const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
+if (!accessToken || !phoneNumberId || !verifyToken) {
+  console.error(
+    "WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, and WHATSAPP_VERIFY_TOKEN are required.\n" +
+      "See README for setup instructions.",
+  );
+  process.exit(1);
+}
+
+const allowedNumbers = new Set(
+  (process.env.WHATSAPP_ALLOWED_NUMBERS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+const allowAll = allowedNumbers.size === 0;
+
+const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
+
+mulmo.onPush((ev) => {
+  sendWhatsAppMessage(ev.chatId, ev.message).catch((err) =>
+    console.error(`[whatsapp] push send failed: ${err}`),
+  );
+});
+
+// ── WhatsApp Cloud API ──────────────────────────────────────────
+
+const API_BASE = `https://graph.facebook.com/v21.0/${phoneNumberId}`;
+
+async function sendWhatsAppMessage(to: string, text: string): Promise<void> {
+  // WhatsApp max message length is ~65536 but we chunk for readability
+  const MAX = 4096;
+  const chunks =
+    text.length === 0
+      ? ["(empty reply)"]
+      : Array.from({ length: Math.ceil(text.length / MAX) }, (_, i) =>
+          text.slice(i * MAX, (i + 1) * MAX),
+        );
+
+  for (const chunk of chunks) {
+    const res = await fetch(`${API_BASE}/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        to,
+        type: "text",
+        text: { body: chunk },
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(
+        `[whatsapp] sendMessage failed: ${res.status} ${body.slice(0, 200)}`,
+      );
+    }
+  }
+}
+
+// ── Webhook server ──────────────────────────────────────────────
+
+const app = express();
+app.disable("x-powered-by");
+app.use(express.json());
+
+// Webhook verification (GET)
+app.get("/webhook", (req: Request, res: Response) => {
+  const mode = req.query["hub.mode"];
+  const token = req.query["hub.verify_token"];
+  const challenge = req.query["hub.challenge"];
+
+  if (mode === "subscribe" && token === verifyToken) {
+    console.log("[whatsapp] webhook verified");
+    res.status(200).send(challenge);
+  } else {
+    res.status(403).send("Forbidden");
+  }
+});
+
+interface WhatsAppTextMessage {
+  from: string;
+  type: string;
+  text?: { body: string };
+}
+
+function extractMessages(body: Record<string, unknown>): WhatsAppTextMessage[] {
+  const entries = (body.entry ?? []) as Array<{
+    changes?: Array<{ value?: { messages?: WhatsAppTextMessage[] } }>;
+  }>;
+  const out: WhatsAppTextMessage[] = [];
+  for (const entry of entries) {
+    for (const change of entry.changes ?? []) {
+      for (const msg of change.value?.messages ?? []) {
+        if (msg.type === "text" && msg.text?.body) out.push(msg);
+      }
+    }
+  }
+  return out;
+}
+
+// Webhook events (POST)
+app.post("/webhook", async (req: Request, res: Response) => {
+  res.status(200).send("OK");
+
+  for (const msg of extractMessages(req.body as Record<string, unknown>)) {
+    const from = msg.from;
+    const text = msg.text!.body;
+
+    if (!allowAll && !allowedNumbers.has(from)) {
+      console.log(`[whatsapp] denied from=${from}`);
+      continue;
+    }
+
+    console.log(`[whatsapp] message from=${from} len=${text.length}`);
+
+    const ack = await mulmo.send(from, text);
+    if (ack.ok) {
+      await sendWhatsAppMessage(from, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await sendWhatsAppMessage(
+        from,
+        `Error${status}: ${ack.error ?? "unknown"}`,
+      );
+    }
+  }
+});
+
+app.listen(PORT, () => {
+  console.log("MulmoClaude WhatsApp bridge");
+  console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
+  console.log("Set your Meta webhook URL to: <public-url>/webhook");
+});

--- a/packages/whatsapp/src/index.ts
+++ b/packages/whatsapp/src/index.ts
@@ -2,30 +2,33 @@
 // @mulmobridge/whatsapp — WhatsApp bridge for MulmoClaude.
 //
 // Uses Meta's WhatsApp Cloud API (webhook mode).
-// Requires a Meta Business account + WhatsApp Business API setup.
 //
 // Required env vars:
 //   WHATSAPP_ACCESS_TOKEN    — permanent access token
 //   WHATSAPP_PHONE_NUMBER_ID — phone number ID from Meta dashboard
 //   WHATSAPP_VERIFY_TOKEN    — any string for webhook verification
+//   WHATSAPP_APP_SECRET      — App secret for x-hub-signature-256 HMAC
 //
 // Optional:
 //   WHATSAPP_BRIDGE_PORT      — webhook port (default: 3003)
 //   WHATSAPP_ALLOWED_NUMBERS  — CSV of phone numbers (empty = all)
 
 import "dotenv/config";
+import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "whatsapp";
 const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
+const FETCH_TIMEOUT_MS = 30_000;
 
 const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
 const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
 const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
-if (!accessToken || !phoneNumberId || !verifyToken) {
+const appSecret = process.env.WHATSAPP_APP_SECRET;
+if (!accessToken || !phoneNumberId || !verifyToken || !appSecret) {
   console.error(
-    "WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, and WHATSAPP_VERIFY_TOKEN are required.\n" +
+    "WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_VERIFY_TOKEN, and WHATSAPP_APP_SECRET are required.\n" +
       "See README for setup instructions.",
   );
   process.exit(1);
@@ -52,7 +55,6 @@ mulmo.onPush((ev) => {
 const API_BASE = `https://graph.facebook.com/v21.0/${phoneNumberId}`;
 
 async function sendWhatsAppMessage(to: string, text: string): Promise<void> {
-  // WhatsApp max message length is ~65536 but we chunk for readability
   const MAX = 4096;
   const chunks =
     text.length === 0
@@ -62,33 +64,91 @@ async function sendWhatsAppMessage(to: string, text: string): Promise<void> {
         );
 
   for (const chunk of chunks) {
-    const res = await fetch(`${API_BASE}/messages`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({
-        messaging_product: "whatsapp",
-        to,
-        type: "text",
-        text: { body: chunk },
-      }),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      console.error(
-        `[whatsapp] sendMessage failed: ${res.status} ${body.slice(0, 200)}`,
-      );
+    try {
+      const res = await fetch(`${API_BASE}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          to,
+          type: "text",
+          text: { body: chunk },
+        }),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        console.error(
+          `[whatsapp] sendMessage failed: ${res.status} ${body.slice(0, 200)}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[whatsapp] sendMessage error: ${err}`);
     }
   }
+}
+
+// ── Signature verification (x-hub-signature-256) ────────────────
+
+function verifyWebhookSignature(rawBody: string, signature: string): boolean {
+  const expected = crypto
+    .createHmac("sha256", appSecret!)
+    .update(rawBody)
+    .digest("hex");
+  const provided = signature.replace("sha256=", "");
+  if (expected.length !== provided.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(provided));
+}
+
+// ── Payload extraction ──────────────────────────────────────────
+
+interface WhatsAppTextMessage {
+  from: string;
+  text: { body: string };
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function parseOneMessage(msg: unknown): WhatsAppTextMessage | null {
+  if (!isObj(msg)) return null;
+  if (msg.type !== "text" || typeof msg.from !== "string") return null;
+  if (!isObj(msg.text)) return null;
+  const body = msg.text.body;
+  if (typeof body !== "string" || !body.trim()) return null;
+  return { from: msg.from, text: { body } };
+}
+
+function collectRawMessages(body: unknown): unknown[] {
+  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  const raw: unknown[] = [];
+  for (const entry of body.entry) {
+    if (!isObj(entry) || !Array.isArray(entry.changes)) continue;
+    for (const change of entry.changes) {
+      if (!isObj(change) || !isObj(change.value)) continue;
+      const messages = change.value.messages;
+      if (Array.isArray(messages)) raw.push(...messages);
+    }
+  }
+  return raw;
+}
+
+function extractTextMessages(body: unknown): WhatsAppTextMessage[] {
+  return collectRawMessages(body)
+    .map(parseOneMessage)
+    .filter((m): m is WhatsAppTextMessage => m !== null);
 }
 
 // ── Webhook server ──────────────────────────────────────────────
 
 const app = express();
 app.disable("x-powered-by");
-app.use(express.json());
+// Parse as raw text so we can verify the HMAC before JSON parsing
+app.use(express.text({ type: "application/json" }));
 
 // Webhook verification (GET)
 app.get("/webhook", (req: Request, res: Response) => {
@@ -104,51 +164,50 @@ app.get("/webhook", (req: Request, res: Response) => {
   }
 });
 
-interface WhatsAppTextMessage {
-  from: string;
-  type: string;
-  text?: { body: string };
-}
-
-function extractMessages(body: Record<string, unknown>): WhatsAppTextMessage[] {
-  const entries = (body.entry ?? []) as Array<{
-    changes?: Array<{ value?: { messages?: WhatsAppTextMessage[] } }>;
-  }>;
-  const out: WhatsAppTextMessage[] = [];
-  for (const entry of entries) {
-    for (const change of entry.changes ?? []) {
-      for (const msg of change.value?.messages ?? []) {
-        if (msg.type === "text" && msg.text?.body) out.push(msg);
-      }
-    }
-  }
-  return out;
-}
-
-// Webhook events (POST)
+// Webhook events (POST) — signature-verified
 app.post("/webhook", async (req: Request, res: Response) => {
+  const signature = req.headers["x-hub-signature-256"] as string;
+  const rawBody = req.body as string;
+
+  if (!signature || !verifyWebhookSignature(rawBody, signature)) {
+    console.warn("[whatsapp] webhook signature verification failed");
+    res.status(401).send("Invalid signature");
+    return;
+  }
+
   res.status(200).send("OK");
 
-  for (const msg of extractMessages(req.body as Record<string, unknown>)) {
-    const from = msg.from;
-    const text = msg.text!.body;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    console.error("[whatsapp] malformed JSON in webhook body");
+    return;
+  }
 
-    if (!allowAll && !allowedNumbers.has(from)) {
-      console.log(`[whatsapp] denied from=${from}`);
+  for (const msg of extractTextMessages(parsed)) {
+    if (!allowAll && !allowedNumbers.has(msg.from)) {
+      console.log(`[whatsapp] denied from=${msg.from}`);
       continue;
     }
 
-    console.log(`[whatsapp] message from=${from} len=${text.length}`);
+    console.log(
+      `[whatsapp] message from=${msg.from} len=${msg.text.body.length}`,
+    );
 
-    const ack = await mulmo.send(from, text);
-    if (ack.ok) {
-      await sendWhatsAppMessage(from, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await sendWhatsAppMessage(
-        from,
-        `Error${status}: ${ack.error ?? "unknown"}`,
-      );
+    try {
+      const ack = await mulmo.send(msg.from, msg.text.body);
+      if (ack.ok) {
+        await sendWhatsAppMessage(msg.from, ack.reply ?? "");
+      } else {
+        const status = ack.status ? ` (${ack.status})` : "";
+        await sendWhatsAppMessage(
+          msg.from,
+          `Error${status}: ${ack.error ?? "unknown"}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[whatsapp] message handling failed: ${err}`);
     }
   }
 });
@@ -156,5 +215,4 @@ app.post("/webhook", async (req: Request, res: Response) => {
 app.listen(PORT, () => {
   console.log("MulmoClaude WhatsApp bridge");
   console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
-  console.log("Set your Meta webhook URL to: <public-url>/webhook");
 });

--- a/packages/whatsapp/tsconfig.json
+++ b/packages/whatsapp/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig.packages.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,6 +124,73 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
+"@discordjs/builders@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.14.1.tgz#c0ec04f3ae7a584296bfd1dccdda59bf580a0c89"
+  integrity sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==
+  dependencies:
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.40"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-1.5.3.tgz#5a1250159ebfff9efa4f963cfa7e97f1b291be18"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/collection@^2.1.0", "@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-2.1.1.tgz#901917bc538c12b9c3613036d317847baee08cae"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/formatters@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@discordjs/formatters/-/formatters-0.6.2.tgz#93c4a213ceb49c9a28e8adb65d50a027579b8c30"
+  integrity sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-2.6.1.tgz#53f88b5b150392e325c85d32a3ad894e9d839380"
+  integrity sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==
+  dependencies:
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.5"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.40"
+    magic-bytes.js "^1.13.0"
+    tslib "^2.6.3"
+    undici "6.24.1"
+
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/util/-/util-1.2.0.tgz#a45a2b643423094eb6378060c623f4d3e6d593d4"
+  integrity sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@discordjs/ws/-/ws-1.2.3.tgz#7cf80d8528366c6810c02b43ca49958ef154c3d4"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
+
 "@emnapi/core@1.9.2", "@emnapi/core@^1.8.1":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
@@ -656,6 +723,11 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
+"@matrix-org/matrix-sdk-crypto-wasm@^18.0.0":
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.1.0.tgz#86bba0dcecbacc84e0b480287c948c9aef36242d"
+  integrity sha512-GxXK2U39+2qWNvR3fXJY7nxdikvpiT17RaS0/Dktk6R8FMKDk3vm79Hq65yrCWLBmT7pJZoerfILNZqhrcUHrg==
+
 "@modelcontextprotocol/sdk@^1.27.1", "@modelcontextprotocol/sdk@^1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
@@ -904,6 +976,29 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.5.5.tgz#2b18d402bb920b65b13ad4ed8dfb6c386300dd84"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
+
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz#86c1b41002ff5d0b2ad21cbc3418b06834b89040"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash "^4.17.21"
+
+"@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.5.3.tgz#0c102aa2ec5b34f806e9bc8625fc6a5e1d0a0c6a"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
+
+"@sapphire/snowflake@^3.5.5":
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.5.5.tgz#33a60ab4231e3cab29e8a0077f342125f2c8d1bd"
+  integrity sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==
+
 "@sec-ant/readable-stream@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
@@ -913,6 +1008,48 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
   integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
+
+"@slack/logger@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-4.0.1.tgz#d8eed47117b6b106c976f5f76c9e5845f6de721b"
+  integrity sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==
+  dependencies:
+    "@types/node" ">=18"
+
+"@slack/socket-mode@^2.0.3":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@slack/socket-mode/-/socket-mode-2.0.6.tgz#9fff31f180d9bab1f7051f4bf49b1889d9542e18"
+  integrity sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==
+  dependencies:
+    "@slack/logger" "^4.0.1"
+    "@slack/web-api" "^7.15.0"
+    "@types/node" ">=18"
+    "@types/ws" "^8"
+    eventemitter3 "^5"
+    ws "^8"
+
+"@slack/types@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.20.1.tgz#2528592813eb088691a8665d55e21ec47ddc8217"
+  integrity sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==
+
+"@slack/web-api@^7.15.0", "@slack/web-api@^7.8.0":
+  version "7.15.1"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-7.15.1.tgz#164b95ba3a9b4f1f0d5f30793e3d42e02afe8bb3"
+  integrity sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==
+  dependencies:
+    "@slack/logger" "^4.0.1"
+    "@slack/types" "^2.20.1"
+    "@types/node" ">=18"
+    "@types/retry" "0.12.0"
+    axios "^1.15.0"
+    eventemitter3 "^5.0.1"
+    form-data "^4.0.4"
+    is-electron "2.2.2"
+    is-stream "^2"
+    p-queue "^6"
+    p-retry "^4"
+    retry "^0.13.1"
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.2"
@@ -1093,6 +1230,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/events@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.3.tgz#a8ef894305af28d1fc6d2dfdfc98e899591ea529"
+  integrity sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==
+
 "@types/express-serve-static-core@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
@@ -1142,7 +1284,7 @@
   dependencies:
     undici-types "~7.18.0"
 
-"@types/node@>=10.0.0", "@types/node@^25.6.0":
+"@types/node@>=10.0.0", "@types/node@>=18", "@types/node@^25.6.0":
   version "25.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
   integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
@@ -1208,7 +1350,7 @@
   dependencies:
     uuid "*"
 
-"@types/ws@^8.18.1", "@types/ws@^8.5.12":
+"@types/ws@^8", "@types/ws@^8.18.1", "@types/ws@^8.5.10", "@types/ws@^8.5.12":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -1324,6 +1466,11 @@
   integrity sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==
   dependencies:
     "@rolldown/pluginutils" "1.0.0-rc.13"
+
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz#5d6db8b20e2a3d729834e7cda429d1b6723ff91b"
+  integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
 "@volar/language-core@2.4.28":
   version "2.4.28"
@@ -1559,6 +1706,11 @@ alien-signals@^3.0.0:
   resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-3.1.2.tgz#26e623e3ed81e401df1a7c503f726e2288a4fa02"
   integrity sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==
 
+another-json@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz#b5f4019c973b6dd5c6506a2d93469cb6d32aeedc"
+  integrity sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1742,7 +1894,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.7.7:
+axios@^1.15.0, axios@^1.7.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
   integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
@@ -1808,6 +1960,11 @@ bare-url@^2.2.2:
   integrity sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==
   dependencies:
     bare-path "^3.0.0"
+
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
 base64-arraybuffer@^1.0.2:
   version "1.0.2"
@@ -1904,6 +2061,13 @@ brotli@^1.3.2:
   integrity sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==
   dependencies:
     base64-js "^1.1.2"
+
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
 
 buffer-crc32@^1.0.0:
   version "1.0.0"
@@ -2142,7 +2306,7 @@ content-disposition@^1.0.0:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.1.tgz#a8b7bbeb2904befdfb6787e5c0c086959f605f9b"
   integrity sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==
 
-content-type@^1.0.5:
+content-type@^1.0.4, content-type@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -2157,7 +2321,7 @@ cookie@^0.7.1, cookie@~0.7.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-core-js@^3.6.0, core-js@^3.8.3:
+core-js@^3.38.1, core-js@^3.6.0, core-js@^3.8.3:
   version "3.49.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
   integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
@@ -2369,6 +2533,30 @@ dingbat-to-unicode@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz#5091dd673241453e6b5865e26e5a4452cdef5c83"
   integrity sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==
+
+discord-api-types@^0.38.1, discord-api-types@^0.38.33, discord-api-types@^0.38.40:
+  version "0.38.47"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.38.47.tgz#34f2dde6ff65d31fc8950b298426d61b46836901"
+  integrity sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==
+
+discord.js@^14.18.0:
+  version "14.26.3"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-14.26.3.tgz#51d0b781780058cce4a2d71caa5653bfcc152559"
+  integrity sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==
+  dependencies:
+    "@discordjs/builders" "^1.14.1"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/rest" "^2.6.1"
+    "@discordjs/util" "^1.2.0"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.40"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.13.0"
+    tslib "^2.6.3"
+    undici "6.24.1"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -2888,6 +3076,16 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventemitter3@^5, eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
 events-universal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
@@ -2895,7 +3093,7 @@ events-universal@^1.0.0:
   dependencies:
     bare-events "^2.7.0"
 
-events@^3.3.0:
+events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -2952,7 +3150,7 @@ express-rate-limit@^8.2.1:
   dependencies:
     ip-address "10.1.0"
 
-express@^5.2.1:
+express@^5.1.0, express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -3007,7 +3205,7 @@ extract-zip@^2.0.1:
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -3052,6 +3250,11 @@ fast-string-width@^3.0.2:
   integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
   dependencies:
     fast-string-truncated-width "^3.0.2"
+
+fast-text-encoding@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
 fast-uri@^3.0.1:
   version "3.1.0"
@@ -3463,6 +3666,11 @@ graphai@^2.0.16:
   resolved "https://registry.yarnpkg.com/graphai/-/graphai-2.0.16.tgz#c0665473f15656dc7b78fc66248553b0431a8603"
   integrity sha512-fjA7dNelP32Lz+AXO1hMAcUdy/CJlAaDNW5nsrfxZ1s6vc8O1plzBiBf94EmBq7XgAUV3UxOz9w+SRszJbjRVA==
 
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
 groq-sdk@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/groq-sdk/-/groq-sdk-0.30.0.tgz#02a4fbf2cc4617093a228d61b36fabb6efb02a52"
@@ -3598,6 +3806,13 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
@@ -3666,6 +3881,32 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+irc-framework@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/irc-framework/-/irc-framework-4.14.0.tgz#1854229c61e71bc3ca44c504afa4f31ace2c10de"
+  integrity sha512-lNujDAxy9kcu89WbU5H7IDWly64aD1B9nN9AV5M6btfx88qyQuyH16j1tjS40nmkQH6ld6vvaihKRn9cjk1JrA==
+  dependencies:
+    buffer "^6.0.3"
+    core-js "^3.38.1"
+    eventemitter3 "^5.0.1"
+    grapheme-splitter "^1.0.4"
+    iconv-lite "^0.6.3"
+    isomorphic-textencoder "^1.0.1"
+    lodash "^4.17.21"
+    middleware-handler "^0.2.0"
+    regenerator-runtime "^0.14.1"
+    socks "^2.8.3"
+    stream-browserify "^3.0.0"
+    util "^0.12.5"
+
+is-arguments@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
@@ -3741,6 +3982,11 @@ is-docker@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
   integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
 
+is-electron@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3758,7 +4004,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-generator-function@^1.0.10:
+is-generator-function@^1.0.10, is-generator-function@^1.0.7:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
   integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
@@ -3797,6 +4043,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-network-error@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/is-network-error/-/is-network-error-1.3.1.tgz#a2a86b80ffd6b05b774755c73c8aaab16597e58d"
+  integrity sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==
 
 is-number-object@^1.1.1:
   version "1.1.1"
@@ -3843,7 +4094,7 @@ is-shared-array-buffer@^1.0.4:
   dependencies:
     call-bound "^1.0.3"
 
-is-stream@^2.0.0, is-stream@^2.0.1:
+is-stream@^2, is-stream@^2.0.0, is-stream@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
@@ -3870,7 +4121,7 @@ is-symbol@^1.0.4, is-symbol@^1.1.1:
     has-symbols "^1.1.0"
     safe-regex-test "^1.1.0"
 
-is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15, is-typed-array@^1.1.3:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
@@ -3935,6 +4186,13 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isomorphic-textencoder@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-textencoder/-/isomorphic-textencoder-1.0.1.tgz#38dcd3b4416d29cd33e274f64b99ae567cd15e83"
+  integrity sha512-676hESgHullDdHDsj469hr+7t3i/neBKU9J7q1T4RHaWwLAsaQnywC0D1dIUId0YZ+JtVrShzuBk1soo0+GVcQ==
+  dependencies:
+    fast-text-encoding "^1.0.0"
 
 jackspeak@^3.1.2:
   version "3.4.3"
@@ -4114,6 +4372,11 @@ jws@^4.0.0:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -4256,7 +4519,12 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15:
+lodash.snakecase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -4268,6 +4536,11 @@ log-symbols@^7.0.1:
   dependencies:
     is-unicode-supported "^2.0.0"
     yoctocolors "^2.1.1"
+
+loglevel@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 long@^5.0.0:
   version "5.3.2"
@@ -4304,6 +4577,11 @@ macos-version@^6.0.0:
   integrity sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==
   dependencies:
     semver "^7.3.5"
+
+magic-bytes.js@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz#b86cc065639368599034ec67941da39d88d7795e"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
 
 magic-string-ast@^1.0.2:
   version "1.0.3"
@@ -4355,6 +4633,39 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+matrix-events-sdk@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
+  integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
+
+matrix-js-sdk@^41.3.0:
+  version "41.3.0"
+  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-41.3.0.tgz#7003a7a862232d06e015db90c5174d61ad673b2c"
+  integrity sha512-QTNHpBQEKPH3WS4O92CBfFj6GxeyijT8osI/QxNvOrM3rE6CySXRtRRKnzR0ntFSdrk1CxrDGV6h2wmk7B3peQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@matrix-org/matrix-sdk-crypto-wasm" "^18.0.0"
+    another-json "^0.2.0"
+    bs58 "^6.0.0"
+    content-type "^1.0.4"
+    jwt-decode "^4.0.0"
+    loglevel "^1.9.2"
+    matrix-events-sdk "0.0.1"
+    matrix-widget-api "^1.16.1"
+    oidc-client-ts "^3.0.1"
+    p-retry "7"
+    sdp-transform "^3.0.0"
+    unhomoglyph "^1.0.6"
+    uuid "13"
+
+matrix-widget-api@^1.16.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.17.0.tgz#2336de2186fe70d8bd741c1603c162f60b2099c2"
+  integrity sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==
+  dependencies:
+    "@types/events" "^3.0.0"
+    events "^3.2.0"
+
 mdn-data@2.27.1:
   version "2.27.1"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
@@ -4374,6 +4685,11 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+middleware-handler@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/middleware-handler/-/middleware-handler-0.2.0.tgz#bf02af7e6b577c0230609b2ae58df0e446f3fd02"
+  integrity sha512-Qz4B0yWndSokapr3Kl7fpMRysS0DaBlOuATrExFuZbr+oXZ3rsAPufdLe8mUJXiG5A4aJGW6GfKS4PDfQwu7Mg==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -4697,6 +5013,13 @@ object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+oidc-client-ts@^3.0.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz#222c145d35e8d654ea4e1dee71cc5dde5e1c91a2"
+  integrity sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==
+  dependencies:
+    jwt-decode "^4.0.0"
+
 on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -4770,6 +5093,11 @@ own-keys@^1.0.1:
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
@@ -4784,13 +5112,35 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-retry@^4.6.2:
+p-queue@^6:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@7:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-7.1.1.tgz#7470fdecb1152ba50f1334e48378c9e401330e24"
+  integrity sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==
+  dependencies:
+    is-network-error "^1.1.0"
+
+p-retry@^4, p-retry@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
   dependencies:
     "@types/retry" "0.12.0"
     retry "^0.13.1"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 pac-proxy-agent@^7.1.0:
   version "7.2.0"
@@ -5218,7 +5568,7 @@ readable-stream@^2.0.5, readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1:
+readable-stream@^3.1.1, readable-stream@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -5264,6 +5614,11 @@ regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp-ast-analysis@^0.7.0:
   version "0.7.1"
@@ -5474,6 +5829,11 @@ scule@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/scule/-/scule-1.3.0.tgz#6efbd22fd0bb801bdcc585c89266a7d2daa8fbd3"
   integrity sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==
+
+sdp-transform@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sdp-transform/-/sdp-transform-3.0.0.tgz#863dd2d781c468d7d6a2f9c70fedcf0538f3e76c"
+  integrity sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==
 
 semver@^6.3.1:
   version "6.3.1"
@@ -5723,6 +6083,14 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
+
+stream-browserify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
 
 stream-events@^1.0.5:
   version "1.0.5"
@@ -6082,6 +6450,11 @@ ts-api-utils@^2.5.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -6097,7 +6470,7 @@ tslib@2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
+tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -6243,10 +6616,20 @@ undici-types@~7.19.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.19.2.tgz#1b67fc26d0f157a0cba3a58a5b5c1e2276b8ba2a"
   integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
+undici@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
+  integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
+
 undici@^7.24.5:
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.6.tgz#b7e977e1bab53d0aab3fa5722fc1efff093aa5e9"
   integrity sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==
+
+unhomoglyph@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/unhomoglyph/-/unhomoglyph-1.0.6.tgz#ea41f926d0fcf598e3b8bb2980c2ddac66b081d3"
+  integrity sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==
 
 unicode-properties@^1.4.0:
   version "1.4.1"
@@ -6310,6 +6693,17 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+util@^0.12.5:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 utrie@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
@@ -6317,7 +6711,7 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, uuid@^13.0.0:
+uuid@*, uuid@13, uuid@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
   integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
@@ -6517,7 +6911,7 @@ which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.16, which-typed-array@^1.1.19:
+which-typed-array@^1.1.16, which-typed-array@^1.1.19, which-typed-array@^1.1.2:
   version "1.1.20"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.20.tgz#3fdb7adfafe0ea69157b1509f3a1cd892bd1d122"
   integrity sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==
@@ -6599,7 +6993,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.18.0, ws@^8.19.0:
+ws@^8, ws@^8.17.0, ws@^8.18.0, ws@^8.19.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==


### PR DESCRIPTION
## Summary

6 new bridge packages, bringing the total from 2 (CLI + Telegram) to 8. All experimental, seeking user testing.

| Package | Platform | Transport | Key dependency | Public URL needed? |
|---|---|---|---|---|
| \`@mulmobridge/slack\` | Slack | Socket Mode | \`@slack/socket-mode\` | No |
| \`@mulmobridge/discord\` | Discord | Gateway | \`discord.js\` v14 | No |
| \`@mulmobridge/line\` | LINE | Webhook | raw fetch | Yes (ngrok) |
| \`@mulmobridge/whatsapp\` | WhatsApp | Cloud API webhook | raw fetch | Yes (ngrok) |
| \`@mulmobridge/matrix\` | Matrix/Element | Client-Server API | \`matrix-js-sdk\` | No |
| \`@mulmobridge/irc\` | IRC | TCP/TLS | \`irc-framework\` | No |

### Common pattern

All bridges follow the same architecture:
1. Platform SDK/API for message ingress
2. \`createBridgeClient()\` from \`@mulmobridge/client\` for MulmoClaude connection
3. Channel/user allowlist (CSV env var, empty = allow all)
4. Long-message chunking (platform-appropriate limits)
5. Push delivery (server → bridge → platform)

### Testing

All 6 build successfully. Each README has step-by-step setup instructions, env var tables, and platform-specific notes. All marked as **experimental** with a link to report issues.

Test with the mock server (no MulmoClaude needed):
\`\`\`bash
npx @mulmobridge/mock-server &
MULMOCLAUDE_AUTH_TOKEN=mock-test-token npx @mulmobridge/slack
\`\`\`

### Platform-specific notes

- **Slack**: Socket Mode = no ngrok. Needs bot + app-level tokens.
- **Discord**: Message Content Intent must be enabled. Responds in channels + DMs.
- **LINE**: Reply tokens expire in 1 min — uses push messages instead (needs the user to add the bot as a friend).
- **WhatsApp**: 24-hour messaging window. Needs a Meta Business account for production.
- **Matrix**: Open protocol, no registration API needed. Federated — works across servers.
- **IRC**: Zero API keys. Responds to \`nick: message\` in channels, all DMs. TLS by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bridges for Discord, IRC, LINE, Matrix, Slack, and WhatsApp, enabling two-way integration between these messaging platforms and MulmoClaude.

* **Documentation**
  * Added comprehensive setup and configuration documentation for all new bridges, including environment variable requirements and operational guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->