### PR TITLE
feat(scheduler): Phase 3 — user task CRUD, MCP tool, Tasks UI (#357)

### DIFF
--- a/plans/feat-scheduler-phase3.md
+++ b/plans/feat-scheduler-phase3.md
@@ -1,0 +1,117 @@
+# Phase 3: User Tasks + Scheduler UI (#357)
+
+## Goal
+
+Enable users to create, manage, and monitor scheduled tasks through:
+1. **API** — CRUD endpoints for user-created tasks in `config/scheduler/tasks.json`
+2. **MCP tool** — Chat-driven task creation ("毎朝8時にニュースまとめて")
+3. **UI** — Task list + execution log in the existing Scheduler plugin
+
+## Current State (Phase 1 + 2 done)
+
+- `@receptron/task-scheduler` — pure library with catch-up, persistence, state management
+- `server/events/scheduler-adapter.ts` — wires library to MulmoClaude, registers system tasks
+- `server/workspace/skills/scheduler.ts` — scans SKILL.md frontmatter, registers skill tasks
+- `GET /api/scheduler/tasks` — read-only, returns system + skill tasks with state
+- `GET /api/scheduler/logs` — execution log query
+- Scheduler plugin (`src/plugins/scheduler/`) — calendar-style event/item manager (unrelated to task scheduler)
+
+## Design Decisions
+
+### User task persistence
+
+- File: `config/scheduler/tasks.json` (array of `PersistedUserTask`)
+- Loaded at server startup, registered with task-manager alongside system + skill tasks
+- CRUD via API → file rewrite → task-manager re-registration (same pattern as skill refresh)
+
+### Scheduler plugin: two modes
+
+The existing Scheduler plugin is a calendar/event tool. Phase 3 adds a **"Tasks" tab** to the same plugin that shows the unified task registry (system + skill + user) with execution state and logs. The calendar view stays as-is.
+
+### User task execution
+
+User tasks fire `startChat()` like skill tasks — a chat session appears in the sidebar. The task's `prompt` field is the message sent to the agent.
+
+## Data Model
+
+```ts
+interface PersistedUserTask {
+  id: string;           // UUID
+  name: string;
+  description: string;
+  schedule: TaskSchedule;
+  missedRunPolicy: MissedRunPolicy;
+  enabled: boolean;
+  roleId: string;       // default: DEFAULT_ROLE_ID
+  prompt: string;       // message sent to startChat
+  createdAt: string;    // ISO UTC
+  updatedAt: string;
+}
+```
+
+## API Endpoints
+
+```
+POST   /api/scheduler/tasks           — create user task
+PUT    /api/scheduler/tasks/:id       — update user task
+DELETE /api/scheduler/tasks/:id       — delete user task (user-origin only)
+POST   /api/scheduler/tasks/:id/run   — manual trigger (any origin)
+```
+
+Existing read endpoints stay unchanged:
+```
+GET    /api/scheduler/tasks           — all tasks + state (add origin field)
+GET    /api/scheduler/logs            — execution log
+```
+
+## Implementation Steps
+
+### Step 1: Backend — User task I/O + registration
+
+1. Create `server/utils/files/user-tasks-io.ts`
+   - `loadUserTasks(root?)` → `PersistedUserTask[]`
+   - `saveUserTasks(tasks, root?)` → atomic write
+2. Update `server/events/scheduler-adapter.ts`
+   - Add `registerUserTasks(deps)` — load tasks.json, register each with task-manager
+   - Each user task fires `startChat({ message: task.prompt, roleId, chatSessionId })`
+   - Add `refreshUserTasks()` — re-scan after CRUD (same mutex pattern as skill refresh)
+3. Update `server/index.ts` — call `registerUserTasks()` at startup after skill registration
+4. Enhance `getSchedulerTasks()` — add `origin` field to response
+
+### Step 2: Backend — CRUD API routes
+
+1. Update `src/config/apiRoutes.ts` — add nested scheduler routes
+2. Expand `server/api/routes/schedulerTasks.ts`:
+   - `POST /api/scheduler/tasks` — validate, save to tasks.json, refresh
+   - `PUT /api/scheduler/tasks/:id` — validate, update, refresh
+   - `DELETE /api/scheduler/tasks/:id` — check origin=user, remove, refresh
+   - `POST /api/scheduler/tasks/:id/run` — manual trigger via task-manager
+
+### Step 3: MCP tool update
+
+1. Update `src/plugins/scheduler/definition.ts` — add `createTask` / `deleteTask` / `listTasks` actions
+2. Update `server/agent/mcp-server.ts` — wire new actions to the CRUD API
+3. Server handler: parse schedule from natural language ("毎朝8時" → `{ type: "daily", time: "23:00" }` UTC)
+
+### Step 4: UI — Tasks tab
+
+1. Add "Tasks" tab to `src/plugins/scheduler/View.vue`
+   - Task list with origin badges, schedule display, state indicators
+   - Enable/disable toggle per task
+   - "Run Now" button
+   - Create/Edit/Delete for user tasks
+2. Execution log panel (expandable per task)
+   - Recent runs with result icons, duration, session links
+3. Fetch data from `GET /api/scheduler/tasks` + `GET /api/scheduler/logs`
+
+### Step 5: Tests
+
+1. Unit tests for user-tasks-io (load/save/validation)
+2. Unit tests for CRUD handlers (create/update/delete/run)
+3. E2E test for task list display + create flow
+
+## Out of Scope
+
+- Timezone-aware datetime picker (Phase 3 stores UTC; user enters UTC times for now)
+- Template variables `{{scheduledFor}}` / `{{scheduledDate}}` (documented in routines.md, deferred)
+- Notification wiring (Phase 4, #144)

--- a/plans/feat-scheduler-phase3.md
+++ b/plans/feat-scheduler-phase3.md
@@ -55,7 +55,7 @@ interface PersistedUserTask {
 POST   /api/scheduler/tasks           — create user task
 PUT    /api/scheduler/tasks/:id       — update user task
 DELETE /api/scheduler/tasks/:id       — delete user task (user-origin only)
-POST   /api/scheduler/tasks/:id/run   — manual trigger (any origin)
+POST   /api/scheduler/tasks/:id/run   — manual trigger (user tasks only)
 ```
 
 Existing read endpoints stay unchanged:

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -13,6 +13,14 @@ import {
   type DispatchErrorResponse,
 } from "./dispatchResponse.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import {
+  loadUserTasks,
+  saveUserTasks,
+  validateAndCreate,
+  refreshUserTasks,
+} from "../../workspace/skills/user-tasks.js";
+import { startChat } from "./agent.js";
+import { log } from "../../system/logger/index.js";
 
 const router = Router();
 
@@ -38,22 +46,42 @@ router.get(
   },
 );
 
+// Task-related actions dispatched via MCP tool
+const TASK_ACTIONS = new Set([
+  "createTask",
+  "listTasks",
+  "deleteTask",
+  "runTask",
+]);
+
 interface SchedulerBody extends SchedulerActionInput {
   action: string;
+  // Task-related fields
+  name?: string;
+  prompt?: string;
+  schedule?: unknown;
+  roleId?: string;
 }
 
 router.post(
   API_ROUTES.scheduler.base,
-  (
+  async (
     req: Request<object, unknown, SchedulerBody>,
     res: Response<
-      DispatchSuccessResponse<ScheduledItem> | DispatchErrorResponse
+      DispatchSuccessResponse<ScheduledItem> | DispatchErrorResponse | unknown
     >,
   ) => {
     const { action, ...input } = req.body;
+
+    // Route task actions to the user-task subsystem
+    if (TASK_ACTIONS.has(action)) {
+      await handleTaskAction(action, input, res);
+      return;
+    }
+
+    // Calendar item actions (existing behavior)
     const items = loadItems();
     const result = dispatchScheduler(action, items, input);
-    // "show" is the only read-only action; everything else mutates.
     respondWithDispatchResult(res, result, {
       shouldPersist: action !== "show",
       instructions: "Display the updated scheduler to the user.",
@@ -61,5 +89,96 @@ router.post(
     });
   },
 );
+
+async function handleTaskAction(
+  action: string,
+  input: Record<string, unknown>,
+  res: Response,
+): Promise<void> {
+  try {
+    if (action === "listTasks") {
+      const tasks = loadUserTasks();
+      res.json({
+        uuid: crypto.randomUUID(),
+        message: `${tasks.length} scheduled task(s) found.`,
+        data: { tasks },
+      });
+      return;
+    }
+
+    if (action === "createTask") {
+      const result = validateAndCreate(input);
+      if (result.kind === "error") {
+        res.status(400).json({ error: result.error });
+        return;
+      }
+      const tasks = loadUserTasks();
+      tasks.push(result.task);
+      await saveUserTasks(tasks);
+      await refreshUserTasks();
+      res.json({
+        uuid: crypto.randomUUID(),
+        message: `Task "${result.task.name}" created and scheduled.`,
+        data: { task: result.task },
+      });
+      return;
+    }
+
+    if (action === "deleteTask") {
+      const id = typeof input.id === "string" ? input.id : "";
+      const tasks = loadUserTasks();
+      const idx = tasks.findIndex((t) => t.id === id);
+      if (idx === -1) {
+        res.status(404).json({ error: `task not found: ${id}` });
+        return;
+      }
+      const name = tasks[idx].name;
+      tasks.splice(idx, 1);
+      await saveUserTasks(tasks);
+      await refreshUserTasks();
+      res.json({
+        uuid: crypto.randomUUID(),
+        message: `Task "${name}" deleted.`,
+        data: { deleted: id },
+      });
+      return;
+    }
+
+    if (action === "runTask") {
+      const id = typeof input.id === "string" ? input.id : "";
+      const tasks = loadUserTasks();
+      const task = tasks.find((t) => t.id === id);
+      if (!task) {
+        res.status(404).json({ error: `task not found: ${id}` });
+        return;
+      }
+      const chatSessionId = crypto.randomUUID();
+      log.info("scheduler", "manual run via MCP", {
+        name: task.name,
+        chatSessionId,
+      });
+      startChat({
+        message: task.prompt,
+        roleId: task.roleId,
+        chatSessionId,
+      }).catch((err) => {
+        log.error("scheduler", "manual run failed", {
+          error: String(err),
+        });
+      });
+      res.json({
+        uuid: crypto.randomUUID(),
+        message: `Task "${task.name}" triggered.`,
+        data: { triggered: id, chatSessionId },
+      });
+      return;
+    }
+
+    res.status(400).json({ error: `unknown task action: ${action}` });
+  } catch (err) {
+    log.error("scheduler", "task action failed", { error: String(err) });
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
 
 export default router;

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -21,6 +21,10 @@ import {
 } from "../../workspace/skills/user-tasks.js";
 import { startChat } from "./agent.js";
 import { log } from "../../system/logger/index.js";
+import {
+  SCHEDULER_ACTIONS,
+  TASK_ACTIONS,
+} from "../../../src/config/schedulerActions.js";
 
 const router = Router();
 
@@ -45,14 +49,6 @@ router.get(
     res.json({ data: { items: loadItems() } });
   },
 );
-
-// Task-related actions dispatched via MCP tool
-const TASK_ACTIONS = new Set([
-  "createTask",
-  "listTasks",
-  "deleteTask",
-  "runTask",
-]);
 
 interface SchedulerBody extends SchedulerActionInput {
   action: string;
@@ -83,7 +79,7 @@ router.post(
     const items = loadItems();
     const result = dispatchScheduler(action, items, input);
     respondWithDispatchResult(res, result, {
-      shouldPersist: action !== "show",
+      shouldPersist: action !== SCHEDULER_ACTIONS.show,
       instructions: "Display the updated scheduler to the user.",
       persist: saveItems,
     });
@@ -96,7 +92,7 @@ async function handleTaskAction(
   res: Response,
 ): Promise<void> {
   try {
-    if (action === "listTasks") {
+    if (action === SCHEDULER_ACTIONS.listTasks) {
       const tasks = loadUserTasks();
       res.json({
         uuid: crypto.randomUUID(),
@@ -106,7 +102,7 @@ async function handleTaskAction(
       return;
     }
 
-    if (action === "createTask") {
+    if (action === SCHEDULER_ACTIONS.createTask) {
       const result = validateAndCreate(input);
       if (result.kind === "error") {
         res.status(400).json({ error: result.error });
@@ -124,7 +120,7 @@ async function handleTaskAction(
       return;
     }
 
-    if (action === "deleteTask") {
+    if (action === SCHEDULER_ACTIONS.deleteTask) {
       const id = typeof input.id === "string" ? input.id : "";
       const tasks = loadUserTasks();
       const idx = tasks.findIndex((t) => t.id === id);
@@ -144,7 +140,7 @@ async function handleTaskAction(
       return;
     }
 
-    if (action === "runTask") {
+    if (action === SCHEDULER_ACTIONS.runTask) {
       const id = typeof input.id === "string" ? input.id : "";
       const tasks = loadUserTasks();
       const task = tasks.find((t) => t.id === id);

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -15,10 +15,10 @@ import {
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import {
   loadUserTasks,
-  saveUserTasks,
   validateAndCreate,
   refreshUserTasks,
 } from "../../workspace/skills/user-tasks.js";
+import { saveUserTasks } from "../../utils/files/user-tasks-io.js";
 import { startChat } from "./agent.js";
 import { log } from "../../system/logger/index.js";
 import {

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -30,9 +30,12 @@ const router = Router();
 // ── List all tasks ──────────────────────────────────────────────
 
 router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
+  // getSchedulerTasks() returns system-only tasks (registered via
+  // initScheduler at startup — journal, chat-index, sources, etc.).
+  // origin: "system" is correct, not an overwrite — these tasks
+  // have no origin field of their own.
   const systemTasks = getSchedulerTasks();
   const userTasks = loadUserTasks();
-  // Merge: system/skill tasks from adapter + user tasks from file
   const all = [
     ...systemTasks.map((t) => ({ ...t, origin: "system" as const })),
     ...userTasks.map((t) => ({ ...t, origin: "user" as const })),
@@ -149,7 +152,7 @@ router.post(
       return;
     }
     // System tasks don't have a prompt to startChat with — return 400
-    badRequest(res, "manual run is only supported for user and skill tasks");
+    badRequest(res, "manual run is only supported for user tasks");
   },
 );
 

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -16,10 +16,9 @@ import type { TaskLogEntry } from "@receptron/task-scheduler";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import {
   loadUserTasks,
-  saveUserTasks,
   validateAndCreate,
   applyUpdate,
-  refreshUserTasks,
+  withUserTaskLock,
 } from "../../workspace/skills/user-tasks.js";
 import { badRequest, notFound, serverError } from "../../utils/httpError.js";
 import { log } from "../../system/logger/index.js";
@@ -46,17 +45,17 @@ router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
 // ── Create user task ────────────────────────────────────────────
 
 router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
-  const result = validateAndCreate(req.body);
-  if (result.kind === "error") {
-    badRequest(res, result.error);
+  const validated = validateAndCreate(req.body);
+  if (validated.kind === "error") {
+    badRequest(res, validated.error);
     return;
   }
   try {
-    const tasks = loadUserTasks();
-    tasks.push(result.task);
-    await saveUserTasks(tasks);
-    await refreshUserTasks();
-    res.status(201).json({ task: result.task });
+    const task = await withUserTaskLock(async (tasks) => ({
+      tasks: [...tasks, validated.task],
+      result: validated.task,
+    }));
+    res.status(201).json({ task });
   } catch (err) {
     log.error("scheduler-tasks", "create failed", {
       error: String(err),
@@ -72,20 +71,22 @@ router.put(
   async (req: Request<{ id: string }>, res: Response) => {
     const { id } = req.params;
     try {
-      const tasks = loadUserTasks();
-      const result = applyUpdate(tasks, id, req.body);
-      if (result.kind === "error") {
-        notFound(res, result.error);
-        return;
-      }
-      await saveUserTasks(result.tasks);
-      await refreshUserTasks();
-      const updated = result.tasks.find((t) => t.id === id);
+      const updated = await withUserTaskLock(async (tasks) => {
+        const result = applyUpdate(tasks, id, req.body);
+        if (result.kind === "error") {
+          throw new Error(result.error);
+        }
+        const task = result.tasks.find((t) => t.id === id);
+        return { tasks: result.tasks, result: task };
+      });
       res.json({ task: updated });
     } catch (err) {
-      log.error("scheduler-tasks", "update failed", {
-        error: String(err),
-      });
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.startsWith("task not found") || msg.startsWith("request body")) {
+        notFound(res, msg);
+        return;
+      }
+      log.error("scheduler-tasks", "update failed", { error: msg });
       serverError(res, "Failed to update task");
     }
   },
@@ -98,20 +99,20 @@ router.delete(
   async (req: Request<{ id: string }>, res: Response) => {
     const { id } = req.params;
     try {
-      const tasks = loadUserTasks();
-      const idx = tasks.findIndex((t) => t.id === id);
-      if (idx === -1) {
-        notFound(res, `task not found: ${id}`);
-        return;
-      }
-      tasks.splice(idx, 1);
-      await saveUserTasks(tasks);
-      await refreshUserTasks();
+      await withUserTaskLock(async (tasks) => {
+        const idx = tasks.findIndex((t) => t.id === id);
+        if (idx === -1) throw new Error(`task not found: ${id}`);
+        const next = tasks.filter((t) => t.id !== id);
+        return { tasks: next, result: undefined };
+      });
       res.json({ deleted: id });
     } catch (err) {
-      log.error("scheduler-tasks", "delete failed", {
-        error: String(err),
-      });
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.startsWith("task not found")) {
+        notFound(res, msg);
+        return;
+      }
+      log.error("scheduler-tasks", "delete failed", { error: msg });
       serverError(res, "Failed to delete task");
     }
   },

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -1,9 +1,11 @@
 // API routes for the unified scheduler (#357).
 //
-//   GET /api/scheduler/tasks   — all registered tasks + state
-//   GET /api/scheduler/logs    — execution log (newest first)
-//
-// Read-only for Phase 1. Phase 3 adds CRUD for user tasks.
+//   GET    /api/scheduler/tasks        — all registered tasks + state
+//   POST   /api/scheduler/tasks        — create user task
+//   PUT    /api/scheduler/tasks/:id    — update user task
+//   DELETE /api/scheduler/tasks/:id    — delete user task
+//   POST   /api/scheduler/tasks/:id/run — manual trigger
+//   GET    /api/scheduler/logs         — execution log (newest first)
 
 import { Router, type Request, type Response } from "express";
 import {
@@ -11,12 +13,147 @@ import {
   getSchedulerLogs,
 } from "../../events/scheduler-adapter.js";
 import type { TaskLogEntry } from "@receptron/task-scheduler";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import {
+  loadUserTasks,
+  saveUserTasks,
+  validateAndCreate,
+  applyUpdate,
+  refreshUserTasks,
+} from "../../workspace/skills/user-tasks.js";
+import { badRequest, notFound, serverError } from "../../utils/httpError.js";
+import { log } from "../../system/logger/index.js";
+import { startChat } from "./agent.js";
 
 const router = Router();
 
-router.get("/api/scheduler/tasks", (_req: Request, res: Response) => {
-  res.json({ tasks: getSchedulerTasks() });
+// ── List all tasks ──────────────────────────────────────────────
+
+router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
+  const systemTasks = getSchedulerTasks();
+  const userTasks = loadUserTasks();
+  // Merge: system/skill tasks from adapter + user tasks from file
+  const all = [
+    ...systemTasks.map((t) => ({ ...t, origin: "system" as const })),
+    ...userTasks.map((t) => ({ ...t, origin: "user" as const })),
+  ];
+  res.json({ tasks: all });
 });
+
+// ── Create user task ────────────────────────────────────────────
+
+router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
+  const result = validateAndCreate(req.body);
+  if (result.kind === "error") {
+    badRequest(res, result.error);
+    return;
+  }
+  try {
+    const tasks = loadUserTasks();
+    tasks.push(result.task);
+    await saveUserTasks(tasks);
+    await refreshUserTasks();
+    res.status(201).json({ task: result.task });
+  } catch (err) {
+    log.error("scheduler-tasks", "create failed", {
+      error: String(err),
+    });
+    serverError(res, "Failed to create task");
+  }
+});
+
+// ── Update user task ────────────────────────────────────────────
+
+router.put(
+  API_ROUTES.scheduler.task,
+  async (req: Request<{ id: string }>, res: Response) => {
+    const { id } = req.params;
+    try {
+      const tasks = loadUserTasks();
+      const result = applyUpdate(tasks, id, req.body);
+      if (result.kind === "error") {
+        notFound(res, result.error);
+        return;
+      }
+      await saveUserTasks(result.tasks);
+      await refreshUserTasks();
+      const updated = result.tasks.find((t) => t.id === id);
+      res.json({ task: updated });
+    } catch (err) {
+      log.error("scheduler-tasks", "update failed", {
+        error: String(err),
+      });
+      serverError(res, "Failed to update task");
+    }
+  },
+);
+
+// ── Delete user task ────────────────────────────────────────────
+
+router.delete(
+  API_ROUTES.scheduler.task,
+  async (req: Request<{ id: string }>, res: Response) => {
+    const { id } = req.params;
+    try {
+      const tasks = loadUserTasks();
+      const idx = tasks.findIndex((t) => t.id === id);
+      if (idx === -1) {
+        notFound(res, `task not found: ${id}`);
+        return;
+      }
+      tasks.splice(idx, 1);
+      await saveUserTasks(tasks);
+      await refreshUserTasks();
+      res.json({ deleted: id });
+    } catch (err) {
+      log.error("scheduler-tasks", "delete failed", {
+        error: String(err),
+      });
+      serverError(res, "Failed to delete task");
+    }
+  },
+);
+
+// ── Manual trigger ──────────────────────────────────────────────
+
+router.post(
+  API_ROUTES.scheduler.taskRun,
+  async (req: Request<{ id: string }>, res: Response) => {
+    const { id } = req.params;
+    // Check user tasks first
+    const userTasks = loadUserTasks();
+    const userTask = userTasks.find((t) => t.id === id);
+    if (userTask) {
+      const chatSessionId = crypto.randomUUID();
+      log.info("scheduler-tasks", "manual run (user task)", {
+        name: userTask.name,
+        chatSessionId,
+      });
+      startChat({
+        message: userTask.prompt,
+        roleId: userTask.roleId,
+        chatSessionId,
+      }).catch((err) => {
+        log.error("scheduler-tasks", "manual run failed", {
+          error: String(err),
+        });
+      });
+      res.json({ triggered: id, chatSessionId });
+      return;
+    }
+    // Not a user task — check system/skill tasks
+    const systemTasks = getSchedulerTasks();
+    const found = systemTasks.find((t) => t.id === id);
+    if (!found) {
+      notFound(res, `task not found: ${id}`);
+      return;
+    }
+    // System tasks don't have a prompt to startChat with — return 400
+    badRequest(res, "manual run is only supported for user and skill tasks");
+  },
+);
+
+// ── Execution logs ──────────────────────────────────────────────
 
 interface LogQuery {
   since?: string;
@@ -25,7 +162,7 @@ interface LogQuery {
 }
 
 router.get(
-  "/api/scheduler/logs",
+  API_ROUTES.scheduler.logs,
   async (
     req: Request<object, unknown, object, LogQuery>,
     res: Response<{ logs: TaskLogEntry[] }>,

--- a/server/index.ts
+++ b/server/index.ts
@@ -62,6 +62,7 @@ import {
 import { log } from "./system/logger/index.js";
 import { startChat } from "./api/routes/agent.js";
 import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
+import { registerUserTasks } from "./workspace/skills/user-tasks.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
@@ -409,6 +410,19 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
     })
     .catch((err) => {
       log.warn("skills", "failed to register scheduled skills", {
+        error: String(err),
+      });
+    });
+
+  // Register user-created scheduled tasks from tasks.json.
+  registerUserTasks({ taskManager, startChat })
+    .then((count) => {
+      if (count > 0) {
+        log.info("user-tasks", "user tasks registered", { count });
+      }
+    })
+    .catch((err) => {
+      log.warn("user-tasks", "failed to register user tasks", {
         error: String(err),
       });
     });

--- a/server/utils/files/user-tasks-io.ts
+++ b/server/utils/files/user-tasks-io.ts
@@ -1,0 +1,28 @@
+// Domain I/O: user-created scheduled tasks
+//   config/scheduler/tasks.json
+//
+// Optional `root` parameter for test DI (defaults to workspacePath).
+
+import path from "path";
+import { mkdir } from "fs/promises";
+import { WORKSPACE_FILES } from "../../workspace/paths.js";
+import { workspacePath } from "../../workspace/paths.js";
+import { resolvePath } from "./workspace-io.js";
+import { loadJsonFile } from "./json.js";
+import { writeFileAtomic } from "./atomic.js";
+
+const root = (r?: string) => r ?? workspacePath;
+
+export function loadUserTasks<T>(r?: string): T[] {
+  const tasks = loadJsonFile<T[]>(
+    resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks),
+    [],
+  );
+  return Array.isArray(tasks) ? tasks : [];
+}
+
+export async function saveUserTasks<T>(tasks: T[], r?: string): Promise<void> {
+  const filePath = resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFileAtomic(filePath, JSON.stringify(tasks, null, 2));
+}

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -130,6 +130,10 @@ export const WORKSPACE_PATHS = {
   todosItems: path.join(workspacePath, WORKSPACE_FILES.todosItems),
   todosColumns: path.join(workspacePath, WORKSPACE_FILES.todosColumns),
   schedulerItems: path.join(workspacePath, WORKSPACE_FILES.schedulerItems),
+  schedulerUserTasks: path.join(
+    workspacePath,
+    WORKSPACE_FILES.schedulerUserTasks,
+  ),
 } as const;
 
 export type WorkspaceDirKey = keyof typeof WORKSPACE_DIRS;

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -96,6 +96,7 @@ export const WORKSPACE_FILES = {
   todosItems: "data/todos/todos.json",
   todosColumns: "data/todos/columns.json",
   schedulerItems: "data/scheduler/items.json",
+  schedulerUserTasks: "config/scheduler/tasks.json",
 } as const;
 
 // Absolute paths, built once at module load from `workspacePath`.

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -1,0 +1,267 @@
+// User-created scheduled tasks (#357 Phase 3).
+//
+// Users can create tasks via the API or MCP tool. Each task fires
+// `startChat()` with its prompt when the schedule triggers.
+//
+// Tasks are persisted in `config/scheduler/tasks.json` and
+// registered with the task-manager at startup. CRUD operations
+// trigger a refresh that unregisters old tasks and registers new ones.
+
+import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
+import { workspacePath } from "../paths.js";
+import { loadJsonFile } from "../../utils/files/json.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { resolvePath } from "../../utils/files/workspace-io.js";
+import path from "path";
+import { mkdir } from "fs/promises";
+import type { MissedRunPolicy } from "@receptron/task-scheduler";
+import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
+import type { TaskSchedule as LocalTaskSchedule } from "../../events/task-manager/index.js";
+import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
+import { log } from "../../system/logger/index.js";
+import type { ITaskManager } from "../../events/task-manager/index.js";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface PersistedUserTask {
+  id: string;
+  name: string;
+  description: string;
+  schedule: LocalTaskSchedule;
+  missedRunPolicy: MissedRunPolicy;
+  enabled: boolean;
+  roleId: string;
+  prompt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserTaskInput {
+  name: string;
+  description?: string;
+  schedule: LocalTaskSchedule;
+  missedRunPolicy?: MissedRunPolicy;
+  roleId?: string;
+  prompt: string;
+}
+
+// ── I/O ─────────────────────────────────────────────────────────
+
+const root = (r?: string) => r ?? workspacePath;
+
+export function loadUserTasks(r?: string): PersistedUserTask[] {
+  const tasks = loadJsonFile<PersistedUserTask[]>(
+    resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks),
+    [],
+  );
+  return Array.isArray(tasks) ? tasks : [];
+}
+
+export async function saveUserTasks(
+  tasks: PersistedUserTask[],
+  r?: string,
+): Promise<void> {
+  const filePath = resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFileAtomic(filePath, JSON.stringify(tasks, null, 2));
+}
+
+// ── Validation ──────────────────────────────────────────────────
+
+function isValidSchedule(s: unknown): s is LocalTaskSchedule {
+  if (typeof s !== "object" || s === null) return false;
+  const obj = s as Record<string, unknown>;
+  if (obj.type === SCHEDULE_TYPES.interval) {
+    return typeof obj.intervalMs === "number" && obj.intervalMs > 0;
+  }
+  if (obj.type === SCHEDULE_TYPES.daily) {
+    return typeof obj.time === "string" && /^\d{2}:\d{2}$/.test(obj.time);
+  }
+  return false;
+}
+
+function isValidMissedRunPolicy(p: unknown): p is MissedRunPolicy {
+  return (
+    p === MISSED_RUN_POLICIES.skip ||
+    p === MISSED_RUN_POLICIES.runOnce ||
+    p === MISSED_RUN_POLICIES.runAll
+  );
+}
+
+export type ValidateResult =
+  | { kind: "ok"; task: PersistedUserTask }
+  | { kind: "error"; error: string };
+
+export function validateAndCreate(input: unknown): ValidateResult {
+  if (typeof input !== "object" || input === null) {
+    return { kind: "error", error: "request body required" };
+  }
+  const obj = input as Record<string, unknown>;
+
+  if (typeof obj.name !== "string" || obj.name.trim().length === 0) {
+    return { kind: "error", error: "name required" };
+  }
+  if (typeof obj.prompt !== "string" || obj.prompt.trim().length === 0) {
+    return { kind: "error", error: "prompt required" };
+  }
+  if (!isValidSchedule(obj.schedule)) {
+    return { kind: "error", error: "valid schedule required" };
+  }
+  const missedRunPolicy = isValidMissedRunPolicy(obj.missedRunPolicy)
+    ? obj.missedRunPolicy
+    : MISSED_RUN_POLICIES.runOnce;
+  const roleId = typeof obj.roleId === "string" ? obj.roleId : DEFAULT_ROLE_ID;
+
+  const now = new Date().toISOString();
+  const task: PersistedUserTask = {
+    id: crypto.randomUUID(),
+    name: obj.name.trim(),
+    description:
+      typeof obj.description === "string" ? obj.description.trim() : "",
+    schedule: obj.schedule,
+    missedRunPolicy,
+    enabled: true,
+    roleId,
+    prompt: obj.prompt.trim(),
+    createdAt: now,
+    updatedAt: now,
+  };
+  return { kind: "ok", task };
+}
+
+export type UpdateResult =
+  | { kind: "ok"; tasks: PersistedUserTask[] }
+  | { kind: "error"; error: string };
+
+export function applyUpdate(
+  tasks: PersistedUserTask[],
+  id: string,
+  patch: Record<string, unknown>,
+): UpdateResult {
+  const idx = tasks.findIndex((t) => t.id === id);
+  if (idx === -1) {
+    return { kind: "error", error: `task not found: ${id}` };
+  }
+  const existing = tasks[idx];
+  const updated: PersistedUserTask = { ...existing };
+
+  if (typeof patch.name === "string" && patch.name.trim().length > 0) {
+    updated.name = patch.name.trim();
+  }
+  if (typeof patch.description === "string") {
+    updated.description = patch.description.trim();
+  }
+  if (isValidSchedule(patch.schedule)) {
+    updated.schedule = patch.schedule;
+  }
+  if (isValidMissedRunPolicy(patch.missedRunPolicy)) {
+    updated.missedRunPolicy = patch.missedRunPolicy;
+  }
+  if (typeof patch.enabled === "boolean") {
+    updated.enabled = patch.enabled;
+  }
+  if (typeof patch.roleId === "string") {
+    updated.roleId = patch.roleId;
+  }
+  if (typeof patch.prompt === "string" && patch.prompt.trim().length > 0) {
+    updated.prompt = patch.prompt.trim();
+  }
+  updated.updatedAt = new Date().toISOString();
+
+  const next = [...tasks];
+  next[idx] = updated;
+  return { kind: "ok", tasks: next };
+}
+
+// ── Task registration ───────────────────────────────────────────
+
+const USER_TASK_PREFIX = "user.";
+let registeredUserTaskIds = new Set<string>();
+let cachedUserTaskDeps: UserTaskDeps | null = null;
+let userTaskMutex: Promise<number> = Promise.resolve(0);
+
+export interface UserTaskDeps {
+  taskManager: ITaskManager;
+  startChat: (params: {
+    message: string;
+    roleId: string;
+    chatSessionId: string;
+  }) => Promise<{ kind: string; error?: string }>;
+}
+
+export async function registerUserTasks(deps: UserTaskDeps): Promise<number> {
+  cachedUserTaskDeps = deps;
+  return serializedRefreshUserTasks(deps);
+}
+
+export async function refreshUserTasks(): Promise<number> {
+  if (!cachedUserTaskDeps) {
+    log.warn("user-tasks", "refreshUserTasks called before initial register");
+    return 0;
+  }
+  return serializedRefreshUserTasks(cachedUserTaskDeps);
+}
+
+function serializedRefreshUserTasks(deps: UserTaskDeps): Promise<number> {
+  userTaskMutex = userTaskMutex.then(
+    () => doRegisterUserTasks(deps),
+    () => doRegisterUserTasks(deps),
+  );
+  return userTaskMutex;
+}
+
+async function doRegisterUserTasks(deps: UserTaskDeps): Promise<number> {
+  const { taskManager, startChat } = deps;
+
+  for (const taskId of registeredUserTaskIds) {
+    taskManager.removeTask(taskId);
+  }
+  const previousCount = registeredUserTaskIds.size;
+  registeredUserTaskIds = new Set<string>();
+
+  const tasks = loadUserTasks();
+  let registered = 0;
+
+  for (const task of tasks) {
+    if (!task.enabled) continue;
+
+    const taskId = `${USER_TASK_PREFIX}${task.id}`;
+    taskManager.registerTask({
+      id: taskId,
+      description: `User task: ${task.name}`,
+      schedule: task.schedule,
+      run: async () => {
+        const chatSessionId = crypto.randomUUID();
+        log.info("user-tasks", "running user task", {
+          name: task.name,
+          roleId: task.roleId,
+          chatSessionId,
+        });
+        const result = await startChat({
+          message: task.prompt,
+          roleId: task.roleId,
+          chatSessionId,
+        });
+        if (result.kind === "error") {
+          throw new Error(`user task failed: ${result.error ?? "unknown"}`);
+        }
+        log.info("user-tasks", "user task completed", {
+          name: task.name,
+          kind: result.kind,
+        });
+      },
+    });
+
+    registeredUserTaskIds.add(taskId);
+    registered++;
+  }
+
+  if (previousCount > 0 || registered > 0) {
+    log.info("user-tasks", "user tasks refreshed", {
+      previous: previousCount,
+      current: registered,
+    });
+  }
+
+  return registered;
+}

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -56,6 +56,10 @@ export async function saveUserTasks(
 
 // ── Validation ──────────────────────────────────────────────────
 
+function isValidDailyTime(value: string): boolean {
+  return /^([01]\d|2[0-3]):([0-5]\d)$/.test(value);
+}
+
 function isValidSchedule(s: unknown): s is LocalTaskSchedule {
   if (typeof s !== "object" || s === null) return false;
   const obj = s as Record<string, unknown>;
@@ -63,7 +67,7 @@ function isValidSchedule(s: unknown): s is LocalTaskSchedule {
     return typeof obj.intervalMs === "number" && obj.intervalMs > 0;
   }
   if (obj.type === SCHEDULE_TYPES.daily) {
-    return typeof obj.time === "string" && /^\d{2}:\d{2}$/.test(obj.time);
+    return typeof obj.time === "string" && isValidDailyTime(obj.time);
   }
   return false;
 }
@@ -124,41 +128,75 @@ export type UpdateResult =
 export function applyUpdate(
   tasks: PersistedUserTask[],
   id: string,
-  patch: Record<string, unknown>,
+  patch: unknown,
 ): UpdateResult {
+  if (typeof patch !== "object" || patch === null) {
+    return { kind: "error", error: "request body required" };
+  }
   const idx = tasks.findIndex((t) => t.id === id);
   if (idx === -1) {
     return { kind: "error", error: `task not found: ${id}` };
   }
   const existing = tasks[idx];
   const updated: PersistedUserTask = { ...existing };
+  // patch is validated as non-null object above; spread into Record
+  const p: Record<string, unknown> = { ...patch };
 
-  if (typeof patch.name === "string" && patch.name.trim().length > 0) {
-    updated.name = patch.name.trim();
+  if (typeof p.name === "string" && p.name.trim().length > 0) {
+    updated.name = p.name.trim();
   }
-  if (typeof patch.description === "string") {
-    updated.description = patch.description.trim();
+  if (typeof p.description === "string") {
+    updated.description = p.description.trim();
   }
-  if (isValidSchedule(patch.schedule)) {
-    updated.schedule = patch.schedule;
+  if (isValidSchedule(p.schedule)) {
+    updated.schedule = p.schedule;
   }
-  if (isValidMissedRunPolicy(patch.missedRunPolicy)) {
-    updated.missedRunPolicy = patch.missedRunPolicy;
+  if (isValidMissedRunPolicy(p.missedRunPolicy)) {
+    updated.missedRunPolicy = p.missedRunPolicy;
   }
-  if (typeof patch.enabled === "boolean") {
-    updated.enabled = patch.enabled;
+  if (typeof p.enabled === "boolean") {
+    updated.enabled = p.enabled;
   }
-  if (typeof patch.roleId === "string") {
-    updated.roleId = patch.roleId;
+  if (typeof p.roleId === "string") {
+    updated.roleId = p.roleId;
   }
-  if (typeof patch.prompt === "string" && patch.prompt.trim().length > 0) {
-    updated.prompt = patch.prompt.trim();
+  if (typeof p.prompt === "string" && p.prompt.trim().length > 0) {
+    updated.prompt = p.prompt.trim();
   }
   updated.updatedAt = new Date().toISOString();
 
   const next = [...tasks];
   next[idx] = updated;
   return { kind: "ok", tasks: next };
+}
+
+// ── Mutexed CRUD ────────────────────────────────────────────────
+// Serialize read-modify-write sequences so concurrent API calls
+// don't clobber each other's changes.
+
+let crudMutex: Promise<void> = Promise.resolve();
+
+export async function withUserTaskLock<T>(
+  fn: (tasks: PersistedUserTask[]) => Promise<{
+    tasks: PersistedUserTask[];
+    result: T;
+  }>,
+): Promise<T> {
+  const prev = crudMutex;
+  let release: () => void = () => {};
+  crudMutex = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    const current = loadUserTasks();
+    const { tasks: next, result } = await fn(current);
+    await saveUserTasks(next);
+    await refreshUserTasks();
+    return result;
+  } finally {
+    release();
+  }
 }
 
 // ── Task registration ───────────────────────────────────────────

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -7,13 +7,10 @@
 // registered with the task-manager at startup. CRUD operations
 // trigger a refresh that unregisters old tasks and registers new ones.
 
-import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
-import { workspacePath } from "../paths.js";
-import { loadJsonFile } from "../../utils/files/json.js";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
-import { resolvePath } from "../../utils/files/workspace-io.js";
-import path from "path";
-import { mkdir } from "fs/promises";
+import {
+  loadUserTasks as loadUserTasksRaw,
+  saveUserTasks as saveUserTasksRaw,
+} from "../../utils/files/user-tasks-io.js";
 import type { MissedRunPolicy } from "@receptron/task-scheduler";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 import type { TaskSchedule as LocalTaskSchedule } from "../../events/task-manager/index.js";
@@ -45,25 +42,16 @@ export interface UserTaskInput {
   prompt: string;
 }
 
-// ── I/O ─────────────────────────────────────────────────────────
-
-const root = (r?: string) => r ?? workspacePath;
-
+// Typed wrappers around the generic I/O module.
 export function loadUserTasks(r?: string): PersistedUserTask[] {
-  const tasks = loadJsonFile<PersistedUserTask[]>(
-    resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks),
-    [],
-  );
-  return Array.isArray(tasks) ? tasks : [];
+  return loadUserTasksRaw<PersistedUserTask>(r);
 }
 
 export async function saveUserTasks(
   tasks: PersistedUserTask[],
   r?: string,
 ): Promise<void> {
-  const filePath = resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks);
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFileAtomic(filePath, JSON.stringify(tasks, null, 2));
+  return saveUserTasksRaw(tasks, r);
 }
 
 // ── Validation ──────────────────────────────────────────────────

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -8,8 +8,8 @@
 // trigger a refresh that unregisters old tasks and registers new ones.
 
 import {
-  loadUserTasks as loadUserTasksRaw,
-  saveUserTasks as saveUserTasksRaw,
+  loadUserTasks as loadRaw,
+  saveUserTasks,
 } from "../../utils/files/user-tasks-io.js";
 import type { MissedRunPolicy } from "@receptron/task-scheduler";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
@@ -33,25 +33,8 @@ export interface PersistedUserTask {
   updatedAt: string;
 }
 
-export interface UserTaskInput {
-  name: string;
-  description?: string;
-  schedule: LocalTaskSchedule;
-  missedRunPolicy?: MissedRunPolicy;
-  roleId?: string;
-  prompt: string;
-}
-
-// Typed wrappers around the generic I/O module.
 export function loadUserTasks(r?: string): PersistedUserTask[] {
-  return loadUserTasksRaw<PersistedUserTask>(r);
-}
-
-export async function saveUserTasks(
-  tasks: PersistedUserTask[],
-  r?: string,
-): Promise<void> {
-  return saveUserTasksRaw(tasks, r);
+  return loadRaw<PersistedUserTask>(r);
 }
 
 // ── Validation ──────────────────────────────────────────────────

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -123,6 +123,10 @@ export const API_ROUTES = {
 
   scheduler: {
     base: "/api/scheduler",
+    tasks: "/api/scheduler/tasks",
+    task: "/api/scheduler/tasks/:id",
+    taskRun: "/api/scheduler/tasks/:id/run",
+    logs: "/api/scheduler/logs",
   },
 
   sessions: {

--- a/src/config/schedulerActions.ts
+++ b/src/config/schedulerActions.ts
@@ -1,0 +1,26 @@
+// Scheduler MCP tool action constants.
+// Used by both the tool definition (frontend) and the route handler (server).
+
+export const SCHEDULER_ACTIONS = {
+  // Calendar item actions (existing)
+  show: "show",
+  add: "add",
+  delete: "delete",
+  update: "update",
+  // Scheduled task actions (Phase 3)
+  createTask: "createTask",
+  listTasks: "listTasks",
+  deleteTask: "deleteTask",
+  runTask: "runTask",
+} as const;
+
+export type SchedulerAction =
+  (typeof SCHEDULER_ACTIONS)[keyof typeof SCHEDULER_ACTIONS];
+
+/** Task-specific actions that route to user-task subsystem. */
+export const TASK_ACTIONS: ReadonlySet<string> = new Set([
+  SCHEDULER_ACTIONS.createTask,
+  SCHEDULER_ACTIONS.listTasks,
+  SCHEDULER_ACTIONS.deleteTask,
+  SCHEDULER_ACTIONS.runTask,
+]);

--- a/src/config/workspacePaths.ts
+++ b/src/config/workspacePaths.ts
@@ -19,4 +19,5 @@ export const WORKSPACE_FILES = {
   todosItems: "data/todos/todos.json",
   todosColumns: "data/todos/columns.json",
   schedulerItems: "data/scheduler/items.json",
+  schedulerUserTasks: "config/scheduler/tasks.json",
 } as const;

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="flex-1 overflow-y-auto min-h-0 p-4">
+    <!-- Mutation error banner -->
+    <div
+      v-if="mutationError"
+      class="mb-3 px-4 py-2 bg-red-50 text-red-700 rounded text-sm"
+      data-testid="scheduler-task-error"
+    >
+      {{ mutationError }}
+    </div>
+
     <!-- Loading -->
     <div
       v-if="loading"
@@ -29,6 +38,7 @@
         <div
           v-for="task in tasks"
           :key="task.id"
+          :data-testid="`scheduler-task-${task.id}`"
           class="border border-gray-200 rounded-lg p-3 hover:bg-gray-50"
           :class="{ 'opacity-50': task.enabled === false }"
         >
@@ -51,6 +61,8 @@
                 v-if="task.origin === 'user'"
                 class="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded"
                 title="Run now"
+                aria-label="Run now"
+                data-testid="scheduler-task-run"
                 @click="runTask(task.id)"
               >
                 <span class="material-icons text-sm">play_arrow</span>
@@ -76,6 +88,8 @@
                 v-if="task.origin === 'user'"
                 class="px-2 py-1 text-xs text-red-500 hover:bg-red-50 rounded"
                 title="Delete"
+                aria-label="Delete"
+                data-testid="scheduler-task-delete"
                 @click="deleteTask(task.id)"
               >
                 <span class="material-icons text-sm">delete</span>
@@ -144,6 +158,7 @@ interface SchedulerTask {
 const tasks = ref<SchedulerTask[]>([]);
 const loading = ref(true);
 const error = ref("");
+const mutationError = ref("");
 
 async function fetchTasks(): Promise<void> {
   loading.value = true;
@@ -201,24 +216,36 @@ function formatTime(iso: string): string {
 }
 
 async function runTask(id: string): Promise<void> {
+  mutationError.value = "";
   const url = API_ROUTES.scheduler.taskRun.replace(":id", id);
-  await apiPost(url, {});
+  const result = await apiPost(url, {});
+  if (!result.ok) {
+    mutationError.value = `Run failed: ${result.error}`;
+    return;
+  }
+  await fetchTasks();
 }
 
 async function toggleEnabled(task: SchedulerTask): Promise<void> {
+  mutationError.value = "";
   const url = API_ROUTES.scheduler.task.replace(":id", task.id);
   const result = await apiPut(url, { enabled: task.enabled === false });
-  if (result.ok) {
-    await fetchTasks();
+  if (!result.ok) {
+    mutationError.value = `Toggle failed: ${result.error}`;
+    return;
   }
+  await fetchTasks();
 }
 
 async function deleteTask(id: string): Promise<void> {
+  mutationError.value = "";
   const url = API_ROUTES.scheduler.task.replace(":id", id);
   const result = await apiDelete(url);
-  if (result.ok) {
-    await fetchTasks();
+  if (!result.ok) {
+    mutationError.value = `Delete failed: ${result.error}`;
+    return;
   }
+  await fetchTasks();
 }
 
 onMounted(fetchTasks);

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -1,0 +1,225 @@
+<template>
+  <div class="flex-1 overflow-y-auto min-h-0 p-4">
+    <!-- Loading -->
+    <div
+      v-if="loading"
+      class="flex items-center justify-center h-32 text-gray-400"
+    >
+      Loading...
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="error"
+      class="px-4 py-2 bg-red-50 text-red-700 rounded text-sm"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Task list -->
+    <div v-else>
+      <div
+        v-if="tasks.length === 0"
+        class="flex items-center justify-center h-32 text-gray-400"
+      >
+        No scheduled tasks
+      </div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="task in tasks"
+          :key="task.id"
+          class="border border-gray-200 rounded-lg p-3 hover:bg-gray-50"
+          :class="{ 'opacity-50': task.enabled === false }"
+        >
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2 min-w-0">
+              <!-- Origin badge -->
+              <span
+                class="text-xs px-1.5 py-0.5 rounded font-medium shrink-0"
+                :class="originClass(task.origin)"
+              >
+                {{ originLabel(task.origin) }}
+              </span>
+              <span class="font-medium text-gray-800 truncate">
+                {{ task.name }}
+              </span>
+            </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <!-- Run now -->
+              <button
+                v-if="task.origin === 'user'"
+                class="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded"
+                title="Run now"
+                @click="runTask(task.id)"
+              >
+                <span class="material-icons text-sm">play_arrow</span>
+              </button>
+              <!-- Enable/disable toggle -->
+              <button
+                v-if="task.origin === 'user'"
+                class="px-2 py-1 text-xs rounded"
+                :class="
+                  task.enabled !== false
+                    ? 'text-green-600 hover:bg-green-50'
+                    : 'text-gray-400 hover:bg-gray-100'
+                "
+                :title="task.enabled !== false ? 'Disable' : 'Enable'"
+                @click="toggleEnabled(task)"
+              >
+                <span class="material-icons text-sm">
+                  {{ task.enabled !== false ? "toggle_on" : "toggle_off" }}
+                </span>
+              </button>
+              <!-- Delete -->
+              <button
+                v-if="task.origin === 'user'"
+                class="px-2 py-1 text-xs text-red-500 hover:bg-red-50 rounded"
+                title="Delete"
+                @click="deleteTask(task.id)"
+              >
+                <span class="material-icons text-sm">delete</span>
+              </button>
+            </div>
+          </div>
+
+          <!-- Details row -->
+          <div class="mt-1 flex items-center gap-3 text-xs text-gray-500">
+            <span>{{ formatSchedule(task.schedule) }}</span>
+            <span
+              v-if="task.state?.lastRunResult"
+              class="flex items-center gap-1"
+            >
+              <span
+                class="inline-block w-2 h-2 rounded-full"
+                :class="resultDotClass(task.state.lastRunResult)"
+              ></span>
+              {{ task.state.lastRunResult }}
+            </span>
+            <span v-if="task.state?.nextScheduledAt">
+              Next: {{ formatTime(task.state.nextScheduledAt) }}
+            </span>
+          </div>
+
+          <!-- Description -->
+          <div
+            v-if="task.description"
+            class="mt-1 text-xs text-gray-400 truncate"
+          >
+            {{ task.description }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
+import { API_ROUTES } from "../../config/apiRoutes";
+
+interface TaskSchedule {
+  type: string;
+  intervalMs?: number;
+  time?: string;
+}
+
+interface TaskState {
+  lastRunAt?: string | null;
+  lastRunResult?: string | null;
+  nextScheduledAt?: string | null;
+}
+
+interface SchedulerTask {
+  id: string;
+  name: string;
+  description?: string;
+  schedule: TaskSchedule;
+  origin: string;
+  enabled?: boolean;
+  state?: TaskState;
+}
+
+const tasks = ref<SchedulerTask[]>([]);
+const loading = ref(true);
+const error = ref("");
+
+async function fetchTasks(): Promise<void> {
+  loading.value = true;
+  error.value = "";
+  const result = await apiGet<{ tasks: SchedulerTask[] }>(
+    API_ROUTES.scheduler.tasks,
+  );
+  loading.value = false;
+  if (!result.ok) {
+    error.value = result.error;
+    return;
+  }
+  tasks.value = result.data.tasks;
+}
+
+function originLabel(origin: string): string {
+  if (origin === "system") return "System";
+  if (origin === "user") return "User";
+  return "Skill";
+}
+
+function originClass(origin: string): string {
+  if (origin === "system") return "bg-gray-100 text-gray-600";
+  if (origin === "user") return "bg-blue-100 text-blue-700";
+  return "bg-purple-100 text-purple-700";
+}
+
+function resultDotClass(result: string): string {
+  if (result === "success") return "bg-green-500";
+  if (result === "error") return "bg-red-500";
+  return "bg-gray-400";
+}
+
+function formatSchedule(schedule: TaskSchedule): string {
+  if (schedule.type === "interval" && schedule.intervalMs) {
+    const mins = Math.round(schedule.intervalMs / 60000);
+    if (mins >= 60) return `Every ${Math.round(mins / 60)}h`;
+    return `Every ${mins}m`;
+  }
+  if (schedule.type === "daily" && schedule.time) {
+    return `Daily ${schedule.time} UTC`;
+  }
+  return JSON.stringify(schedule);
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+async function runTask(id: string): Promise<void> {
+  const url = API_ROUTES.scheduler.taskRun.replace(":id", id);
+  await apiPost(url, {});
+}
+
+async function toggleEnabled(task: SchedulerTask): Promise<void> {
+  const url = API_ROUTES.scheduler.task.replace(":id", task.id);
+  const result = await apiPut(url, { enabled: task.enabled === false });
+  if (result.ok) {
+    await fetchTasks();
+  }
+}
+
+async function deleteTask(id: string): Promise<void> {
+  const url = API_ROUTES.scheduler.task.replace(":id", id);
+  const result = await apiDelete(url);
+  if (result.ok) {
+    await fetchTasks();
+  }
+}
+
+onMounted(fetchTasks);
+</script>

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -10,333 +10,373 @@
     >
       ⚠ Failed to update scheduler: {{ apiError }}
     </div>
-    <!-- Header -->
-    <div
-      class="flex items-center justify-between px-6 py-3 border-b border-gray-100"
-    >
-      <div class="flex items-center gap-3">
-        <h2 class="text-lg font-semibold text-gray-800">Scheduler</h2>
-        <span class="text-sm text-gray-500"
-          >{{ items.length }} item{{ items.length !== 1 ? "s" : "" }}</span
-        >
-      </div>
-      <div class="flex items-center gap-2">
-        <!-- Navigation (calendar modes only) -->
-        <template v-if="viewMode !== 'list'">
-          <button
-            class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded"
-            title="Previous"
-            @click="goPrev"
+    <!-- Top-level tab bar: Calendar / Tasks -->
+    <div class="flex border-b border-gray-200 px-6">
+      <button
+        class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
+        :class="
+          activeTab === 'calendar'
+            ? 'border-blue-500 text-blue-600'
+            : 'border-transparent text-gray-500 hover:text-gray-700'
+        "
+        data-testid="scheduler-tab-calendar"
+        @click="activeTab = 'calendar'"
+      >
+        Calendar
+      </button>
+      <button
+        class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
+        :class="
+          activeTab === 'tasks'
+            ? 'border-blue-500 text-blue-600'
+            : 'border-transparent text-gray-500 hover:text-gray-700'
+        "
+        data-testid="scheduler-tab-tasks"
+        @click="activeTab = 'tasks'"
+      >
+        Tasks
+      </button>
+    </div>
+
+    <!-- Tasks tab -->
+    <TasksTab v-if="activeTab === 'tasks'" />
+
+    <!-- Calendar tab (existing content) -->
+    <template v-if="activeTab === 'calendar'">
+      <!-- Header -->
+      <div
+        class="flex items-center justify-between px-6 py-3 border-b border-gray-100"
+      >
+        <div class="flex items-center gap-3">
+          <h2 class="text-lg font-semibold text-gray-800">Scheduler</h2>
+          <span class="text-sm text-gray-500"
+            >{{ items.length }} item{{ items.length !== 1 ? "s" : "" }}</span
           >
-            <span class="material-icons text-sm">chevron_left</span>
-          </button>
-          <button
-            class="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded"
-            title="Go to today"
-            @click="goToday"
+        </div>
+        <div class="flex items-center gap-2">
+          <!-- Navigation (calendar modes only) -->
+          <template v-if="viewMode !== 'list'">
+            <button
+              class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded"
+              title="Previous"
+              @click="goPrev"
+            >
+              <span class="material-icons text-sm">chevron_left</span>
+            </button>
+            <button
+              class="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded"
+              title="Go to today"
+              @click="goToday"
+            >
+              Today
+            </button>
+            <button
+              class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded"
+              title="Next"
+              @click="goNext"
+            >
+              <span class="material-icons text-sm">chevron_right</span>
+            </button>
+            <span class="text-sm text-gray-600 min-w-[140px] text-center">{{
+              headerLabel
+            }}</span>
+          </template>
+          <!-- View mode toggle -->
+          <div
+            class="flex border border-gray-300 rounded overflow-hidden text-xs"
           >
-            Today
-          </button>
-          <button
-            class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded"
-            title="Next"
-            @click="goNext"
-          >
-            <span class="material-icons text-sm">chevron_right</span>
-          </button>
-          <span class="text-sm text-gray-600 min-w-[140px] text-center">{{
-            headerLabel
-          }}</span>
-        </template>
-        <!-- View mode toggle -->
-        <div
-          class="flex border border-gray-300 rounded overflow-hidden text-xs"
-        >
-          <button
-            v-for="mode in VIEW_MODES"
-            :key="mode.key"
-            class="px-2.5 py-1"
-            :class="
-              viewMode === mode.key
-                ? 'bg-blue-500 text-white'
-                : 'bg-white text-gray-600 hover:bg-gray-50'
-            "
-            :title="mode.label"
-            @click="viewMode = mode.key"
-          >
-            <span class="material-icons text-sm">{{ mode.icon }}</span>
-          </button>
+            <button
+              v-for="mode in VIEW_MODES"
+              :key="mode.key"
+              class="px-2.5 py-1"
+              :class="
+                viewMode === mode.key
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-white text-gray-600 hover:bg-gray-50'
+              "
+              :title="mode.label"
+              @click="viewMode = mode.key"
+            >
+              <span class="material-icons text-sm">{{ mode.icon }}</span>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- List view -->
-    <div v-if="viewMode === 'list'" class="flex-1 overflow-y-auto min-h-0">
-      <div
-        v-if="items.length === 0"
-        class="flex items-center justify-center h-full text-gray-400"
-      >
-        No scheduled items
+      <!-- List view -->
+      <div v-if="viewMode === 'list'" class="flex-1 overflow-y-auto min-h-0">
+        <div
+          v-if="items.length === 0"
+          class="flex items-center justify-center h-full text-gray-400"
+        >
+          No scheduled items
+        </div>
+
+        <ul v-else class="p-4 space-y-2">
+          <li
+            v-for="item in items"
+            :key="item.id"
+            class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer group"
+            :class="
+              selectedId === item.id
+                ? 'border-blue-400 bg-blue-50'
+                : 'border-gray-200 hover:bg-gray-50'
+            "
+            @click="selectItem(item)"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-gray-800 text-sm">
+                {{ item.title }}
+              </div>
+              <div
+                v-if="Object.keys(item.props).length > 0"
+                class="flex flex-wrap gap-1 mt-1"
+              >
+                <span
+                  v-for="(val, key) in item.props"
+                  :key="key"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 text-xs text-gray-600"
+                >
+                  <span class="text-gray-400">{{ key }}:</span>
+                  <span>{{ val }}</span>
+                </span>
+              </div>
+            </div>
+            <button
+              class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 mt-0.5 shrink-0"
+              title="Delete item"
+              @click.stop="remove(item)"
+            >
+              ✕
+            </button>
+          </li>
+        </ul>
       </div>
 
-      <ul v-else class="p-4 space-y-2">
-        <li
-          v-for="item in items"
-          :key="item.id"
-          class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer group"
-          :class="
-            selectedId === item.id
-              ? 'border-blue-400 bg-blue-50'
-              : 'border-gray-200 hover:bg-gray-50'
-          "
-          @click="selectItem(item)"
-        >
-          <div class="flex-1 min-w-0">
-            <div class="font-medium text-gray-800 text-sm">
-              {{ item.title }}
-            </div>
+      <!-- Week view -->
+      <div
+        v-else-if="viewMode === 'week'"
+        class="flex-1 overflow-y-auto min-h-0"
+      >
+        <div class="grid grid-cols-7 border-b border-gray-200">
+          <div
+            v-for="day in weekDays"
+            :key="day.toISOString()"
+            class="border-r last:border-r-0 border-gray-200 min-h-[200px] flex flex-col"
+          >
+            <!-- Day header -->
             <div
-              v-if="Object.keys(item.props).length > 0"
-              class="flex flex-wrap gap-1 mt-1"
+              class="px-2 py-1.5 text-center border-b border-gray-100 sticky top-0 bg-white"
+              :class="isToday(day) ? 'bg-blue-50' : ''"
             >
-              <span
-                v-for="(val, key) in item.props"
-                :key="key"
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 text-xs text-gray-600"
+              <div class="text-xs text-gray-400">{{ dayLabel(day) }}</div>
+              <div
+                class="text-sm font-medium"
+                :class="
+                  isToday(day)
+                    ? 'text-blue-600 bg-blue-500 text-white w-6 h-6 rounded-full flex items-center justify-center mx-auto'
+                    : 'text-gray-700'
+                "
               >
-                <span class="text-gray-400">{{ key }}:</span>
-                <span>{{ val }}</span>
-              </span>
+                {{ day.getDate() }}
+              </div>
+            </div>
+            <!-- Day items -->
+            <div class="flex-1 p-1 space-y-0.5">
+              <div
+                v-for="item in itemsForDay(day)"
+                :key="item.id"
+                class="text-xs px-1.5 py-0.5 rounded cursor-pointer truncate"
+                :class="
+                  selectedId === item.id
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                "
+                :title="item.title"
+                @click="selectItem(item)"
+              >
+                <span v-if="itemTime(item)" class="font-medium"
+                  >{{ itemTime(item) }} </span
+                >{{ item.title }}
+              </div>
             </div>
           </div>
-          <button
-            class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 mt-0.5 shrink-0"
-            title="Delete item"
-            @click.stop="remove(item)"
-          >
-            ✕
-          </button>
-        </li>
-      </ul>
-    </div>
-
-    <!-- Week view -->
-    <div v-else-if="viewMode === 'week'" class="flex-1 overflow-y-auto min-h-0">
-      <div class="grid grid-cols-7 border-b border-gray-200">
+        </div>
+        <!-- Unscheduled -->
         <div
-          v-for="day in weekDays"
-          :key="day.toISOString()"
-          class="border-r last:border-r-0 border-gray-200 min-h-[200px] flex flex-col"
+          v-if="unscheduledItems.length > 0"
+          class="p-3 border-t border-gray-200"
         >
-          <!-- Day header -->
-          <div
-            class="px-2 py-1.5 text-center border-b border-gray-100 sticky top-0 bg-white"
-            :class="isToday(day) ? 'bg-blue-50' : ''"
-          >
-            <div class="text-xs text-gray-400">{{ dayLabel(day) }}</div>
+          <div class="text-xs text-gray-400 mb-1.5">Unscheduled</div>
+          <div class="flex flex-wrap gap-1">
             <div
-              class="text-sm font-medium"
+              v-for="item in unscheduledItems"
+              :key="item.id"
+              class="text-xs px-2 py-1 rounded cursor-pointer"
               :class="
-                isToday(day)
-                  ? 'text-blue-600 bg-blue-500 text-white w-6 h-6 rounded-full flex items-center justify-center mx-auto'
-                  : 'text-gray-700'
+                selectedId === item.id
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              "
+              @click="selectItem(item)"
+            >
+              {{ item.title }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Month view -->
+      <div v-else class="flex-1 overflow-y-auto min-h-0">
+        <!-- Weekday headers -->
+        <div
+          class="grid grid-cols-7 border-b border-gray-200 sticky top-0 bg-white z-10"
+        >
+          <div
+            v-for="label in WEEKDAY_LABELS"
+            :key="label"
+            class="text-xs text-center text-gray-400 py-1.5 border-r last:border-r-0 border-gray-100"
+          >
+            {{ label }}
+          </div>
+        </div>
+        <!-- Month grid -->
+        <div
+          v-for="(week, wi) in monthGrid"
+          :key="wi"
+          class="grid grid-cols-7 border-b border-gray-100"
+        >
+          <div
+            v-for="day in week"
+            :key="day.toISOString()"
+            class="border-r last:border-r-0 border-gray-100 min-h-[80px] p-1 flex flex-col"
+            :class="isToday(day) ? 'bg-blue-50/50' : ''"
+          >
+            <div
+              class="text-xs mb-0.5"
+              :class="
+                isCurrentMonth(day)
+                  ? isToday(day)
+                    ? 'text-blue-600 font-bold'
+                    : 'text-gray-700'
+                  : 'text-gray-300'
               "
             >
               {{ day.getDate() }}
             </div>
-          </div>
-          <!-- Day items -->
-          <div class="flex-1 p-1 space-y-0.5">
-            <div
-              v-for="item in itemsForDay(day)"
-              :key="item.id"
-              class="text-xs px-1.5 py-0.5 rounded cursor-pointer truncate"
-              :class="
-                selectedId === item.id
-                  ? 'bg-blue-500 text-white'
-                  : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
-              "
-              :title="item.title"
-              @click="selectItem(item)"
-            >
-              <span v-if="itemTime(item)" class="font-medium"
-                >{{ itemTime(item) }} </span
-              >{{ item.title }}
+            <div class="space-y-0.5 flex-1">
+              <div
+                v-for="item in itemsForDay(day).slice(0, MAX_MONTH_ITEMS)"
+                :key="item.id"
+                class="text-[10px] leading-tight px-1 py-0.5 rounded cursor-pointer truncate"
+                :class="
+                  selectedId === item.id
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                "
+                :title="item.title"
+                @click="selectItem(item)"
+              >
+                {{ item.title }}
+              </div>
+              <div
+                v-if="itemsForDay(day).length > MAX_MONTH_ITEMS"
+                class="text-[10px] text-gray-400 px-1"
+              >
+                +{{ itemsForDay(day).length - MAX_MONTH_ITEMS }} more
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <!-- Unscheduled -->
-      <div
-        v-if="unscheduledItems.length > 0"
-        class="p-3 border-t border-gray-200"
-      >
-        <div class="text-xs text-gray-400 mb-1.5">Unscheduled</div>
-        <div class="flex flex-wrap gap-1">
-          <div
-            v-for="item in unscheduledItems"
-            :key="item.id"
-            class="text-xs px-2 py-1 rounded cursor-pointer"
-            :class="
-              selectedId === item.id
-                ? 'bg-blue-500 text-white'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            "
-            @click="selectItem(item)"
-          >
-            {{ item.title }}
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Month view -->
-    <div v-else class="flex-1 overflow-y-auto min-h-0">
-      <!-- Weekday headers -->
-      <div
-        class="grid grid-cols-7 border-b border-gray-200 sticky top-0 bg-white z-10"
-      >
+        <!-- Unscheduled -->
         <div
-          v-for="label in WEEKDAY_LABELS"
-          :key="label"
-          class="text-xs text-center text-gray-400 py-1.5 border-r last:border-r-0 border-gray-100"
+          v-if="unscheduledItems.length > 0"
+          class="p-3 border-t border-gray-200"
         >
-          {{ label }}
-        </div>
-      </div>
-      <!-- Month grid -->
-      <div
-        v-for="(week, wi) in monthGrid"
-        :key="wi"
-        class="grid grid-cols-7 border-b border-gray-100"
-      >
-        <div
-          v-for="day in week"
-          :key="day.toISOString()"
-          class="border-r last:border-r-0 border-gray-100 min-h-[80px] p-1 flex flex-col"
-          :class="isToday(day) ? 'bg-blue-50/50' : ''"
-        >
-          <div
-            class="text-xs mb-0.5"
-            :class="
-              isCurrentMonth(day)
-                ? isToday(day)
-                  ? 'text-blue-600 font-bold'
-                  : 'text-gray-700'
-                : 'text-gray-300'
-            "
-          >
-            {{ day.getDate() }}
-          </div>
-          <div class="space-y-0.5 flex-1">
+          <div class="text-xs text-gray-400 mb-1.5">Unscheduled</div>
+          <div class="flex flex-wrap gap-1">
             <div
-              v-for="item in itemsForDay(day).slice(0, MAX_MONTH_ITEMS)"
+              v-for="item in unscheduledItems"
               :key="item.id"
-              class="text-[10px] leading-tight px-1 py-0.5 rounded cursor-pointer truncate"
+              class="text-xs px-2 py-1 rounded cursor-pointer"
               :class="
                 selectedId === item.id
                   ? 'bg-blue-500 text-white'
-                  : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               "
-              :title="item.title"
               @click="selectItem(item)"
             >
               {{ item.title }}
             </div>
-            <div
-              v-if="itemsForDay(day).length > MAX_MONTH_ITEMS"
-              class="text-[10px] text-gray-400 px-1"
-            >
-              +{{ itemsForDay(day).length - MAX_MONTH_ITEMS }} more
-            </div>
           </div>
         </div>
       </div>
-      <!-- Unscheduled -->
-      <div
-        v-if="unscheduledItems.length > 0"
-        class="p-3 border-t border-gray-200"
-      >
-        <div class="text-xs text-gray-400 mb-1.5">Unscheduled</div>
-        <div class="flex flex-wrap gap-1">
-          <div
-            v-for="item in unscheduledItems"
-            :key="item.id"
-            class="text-xs px-2 py-1 rounded cursor-pointer"
-            :class="
-              selectedId === item.id
-                ? 'bg-blue-500 text-white'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            "
-            @click="selectItem(item)"
-          >
-            {{ item.title }}
-          </div>
-        </div>
-      </div>
-    </div>
 
-    <!-- Item YAML editor -->
-    <div v-if="selectedId" class="border-t border-blue-200 bg-blue-50 shrink-0">
+      <!-- Item YAML editor -->
       <div
-        class="flex items-center justify-between px-4 py-2 text-sm font-medium text-blue-700"
+        v-if="selectedId"
+        class="border-t border-blue-200 bg-blue-50 shrink-0"
       >
-        <span>Edit item</span>
-        <button
-          class="text-blue-400 hover:text-blue-600 text-xs"
-          title="Close editor"
-          @click="selectedId = null"
+        <div
+          class="flex items-center justify-between px-4 py-2 text-sm font-medium text-blue-700"
         >
-          ✕
-        </button>
-      </div>
-      <div class="px-3 pb-3">
-        <textarea
-          v-model="yamlText"
-          class="w-full h-32 p-3 font-mono text-xs bg-white border border-blue-300 rounded resize-y focus:outline-none focus:border-blue-500"
-          spellcheck="false"
-        />
-        <div class="flex items-center gap-2 mt-2">
+          <span>Edit item</span>
           <button
-            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
-            @click="applyItemEdit"
+            class="text-blue-400 hover:text-blue-600 text-xs"
+            title="Close editor"
+            @click="selectedId = null"
           >
-            Update
+            ✕
           </button>
-          <span v-if="yamlError" class="text-xs text-red-500">{{
-            yamlError
-          }}</span>
+        </div>
+        <div class="px-3 pb-3">
+          <textarea
+            v-model="yamlText"
+            class="w-full h-32 p-3 font-mono text-xs bg-white border border-blue-300 rounded resize-y focus:outline-none focus:border-blue-500"
+            spellcheck="false"
+          />
+          <div class="flex items-center gap-2 mt-2">
+            <button
+              class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+              @click="applyItemEdit"
+            >
+              Update
+            </button>
+            <span v-if="yamlError" class="text-xs text-red-500">{{
+              yamlError
+            }}</span>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- JSON source editor -->
-    <details class="border-t border-gray-200 bg-gray-50 shrink-0">
-      <summary
-        class="cursor-pointer select-none px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
-      >
-        Edit Source
-      </summary>
-      <div class="p-3">
-        <textarea
-          v-model="editorText"
-          class="w-full h-[40vh] p-3 font-mono text-xs bg-white border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
-          spellcheck="false"
-        />
-        <div class="flex items-center gap-2 mt-2">
-          <button
-            :disabled="!isModified"
-            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
-            @click="applyChanges"
-          >
-            Apply Changes
-          </button>
-          <span v-if="parseError" class="text-xs text-red-500">{{
-            parseError
-          }}</span>
+      <!-- JSON source editor -->
+      <details class="border-t border-gray-200 bg-gray-50 shrink-0">
+        <summary
+          class="cursor-pointer select-none px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+        >
+          Edit Source
+        </summary>
+        <div class="p-3">
+          <textarea
+            v-model="editorText"
+            class="w-full h-[40vh] p-3 font-mono text-xs bg-white border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+            spellcheck="false"
+          />
+          <div class="flex items-center gap-2 mt-2">
+            <button
+              :disabled="!isModified"
+              class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+              @click="applyChanges"
+            >
+              Apply Changes
+            </button>
+            <span v-if="parseError" class="text-xs text-red-500">{{
+              parseError
+            }}</span>
+          </div>
         </div>
-      </div>
-    </details>
+      </details>
+    </template>
   </div>
 </template>
 
@@ -347,6 +387,7 @@ import type { SchedulerData, ScheduledItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import TasksTab from "./TasksTab.vue";
 
 type YamlScalar = string | number | boolean | null;
 
@@ -355,6 +396,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
+const activeTab = ref<"calendar" | "tasks">("calendar");
 const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -396,7 +396,25 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
-const activeTab = ref<"calendar" | "tasks">("calendar");
+function detectInitialTab(
+  result?: ToolResultComplete<SchedulerData>,
+): "calendar" | "tasks" {
+  const data = result?.data as Record<string, unknown> | undefined;
+  if (
+    data &&
+    ("task" in data ||
+      "tasks" in data ||
+      "triggered" in data ||
+      "deleted" in data)
+  ) {
+    return "tasks";
+  }
+  return "calendar";
+}
+
+const activeTab = ref<"calendar" | "tasks">(
+  detectInitialTab(props.selectedResult),
+);
 const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
@@ -413,6 +431,7 @@ const { refresh } = useFreshPluginData<ScheduledItem[]>({
 watch(
   () => props.selectedResult?.uuid,
   () => {
+    activeTab.value = detectInitialTab(props.selectedResult);
     items.value = props.selectedResult?.data?.items ?? [];
     void refresh();
   },

--- a/src/plugins/scheduler/definition.ts
+++ b/src/plugins/scheduler/definition.ts
@@ -4,16 +4,30 @@ const toolDefinition: ToolDefinition = {
   type: "function",
   name: "manageScheduler",
   prompt:
-    "When users mention events, appointments, meetings, or things to schedule, use manageScheduler to help them track them. Store relevant details (date, time, location, etc.) as props.",
+    "When users mention events, appointments, meetings, reminders, or recurring tasks to schedule, use manageScheduler. " +
+    "For calendar events use show/add/update/delete. " +
+    "For automated recurring tasks (e.g. '毎朝8時にニュースまとめて', 'remind me every day') use createTask/listTasks/deleteTask/runTask. " +
+    "Schedule format: { type: 'interval', intervalMs: 3600000 } for hourly, { type: 'daily', time: 'HH:MM' } for daily (UTC).",
   description:
-    "Manage a scheduler — show, add, update, or delete scheduled items. Each item has a title and dynamic properties (e.g. date, time, location, description). Use this whenever the user mentions events, appointments, reminders, or things to schedule.",
+    "Manage a scheduler — calendar events (show/add/update/delete) and automated tasks (createTask/listTasks/deleteTask/runTask). " +
+    "Calendar items have a title and properties. Automated tasks have a name, prompt, schedule, and run via the agent on a recurring basis.",
   parameters: {
     type: "object",
     properties: {
       action: {
         type: "string",
-        enum: ["show", "add", "delete", "update"],
-        description: "Action to perform on the scheduler.",
+        enum: [
+          "show",
+          "add",
+          "delete",
+          "update",
+          "createTask",
+          "listTasks",
+          "deleteTask",
+          "runTask",
+        ],
+        description:
+          "Action to perform. show/add/delete/update for calendar items. createTask/listTasks/deleteTask/runTask for automated tasks.",
       },
       title: {
         type: "string",
@@ -22,13 +36,32 @@ const toolDefinition: ToolDefinition = {
       },
       id: {
         type: "string",
-        description: "For 'delete' and 'update': the item id.",
+        description:
+          "For 'delete', 'update', 'deleteTask', 'runTask': the item/task id.",
       },
       props: {
         type: "object",
         description:
           "For 'add': initial properties (e.g. { date, time, location }). For 'update': properties to merge in; set a key to null to remove it.",
         additionalProperties: true,
+      },
+      name: {
+        type: "string",
+        description: "For 'createTask': the task name.",
+      },
+      prompt: {
+        type: "string",
+        description:
+          "For 'createTask': the prompt message sent to the agent when the task fires.",
+      },
+      schedule: {
+        type: "object",
+        description:
+          "For 'createTask': { type: 'daily', time: 'HH:MM' } or { type: 'interval', intervalMs: number }. Times are UTC.",
+      },
+      roleId: {
+        type: "string",
+        description: "For 'createTask': role to use (default: general).",
       },
     },
     required: ["action"],

--- a/src/plugins/scheduler/definition.ts
+++ b/src/plugins/scheduler/definition.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from "gui-chat-protocol";
+import { SCHEDULER_ACTIONS } from "../../config/schedulerActions";
 
 const toolDefinition: ToolDefinition = {
   type: "function",
@@ -16,16 +17,7 @@ const toolDefinition: ToolDefinition = {
     properties: {
       action: {
         type: "string",
-        enum: [
-          "show",
-          "add",
-          "delete",
-          "update",
-          "createTask",
-          "listTasks",
-          "deleteTask",
-          "runTask",
-        ],
+        enum: Object.values(SCHEDULER_ACTIONS),
         description:
           "Action to perform. show/add/delete/update for calendar items. createTask/listTasks/deleteTask/runTask for automated tasks.",
       },

--- a/test/skills/test_user_tasks.ts
+++ b/test/skills/test_user_tasks.ts
@@ -5,10 +5,10 @@ import path from "path";
 import os from "os";
 import {
   loadUserTasks,
-  saveUserTasks,
   validateAndCreate,
   applyUpdate,
 } from "../../server/workspace/skills/user-tasks.ts";
+import { saveUserTasks } from "../../server/utils/files/user-tasks-io.ts";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 
 function tmpRoot(): string {

--- a/test/skills/test_user_tasks.ts
+++ b/test/skills/test_user_tasks.ts
@@ -1,0 +1,207 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "fs";
+import path from "path";
+import os from "os";
+import {
+  loadUserTasks,
+  saveUserTasks,
+  validateAndCreate,
+  applyUpdate,
+} from "../../server/workspace/skills/user-tasks.ts";
+import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
+
+function tmpRoot(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "user-tasks-"));
+  mkdirSync(path.join(dir, "config", "scheduler"), { recursive: true });
+  return dir;
+}
+
+describe("loadUserTasks", () => {
+  it("returns empty array when file does not exist", () => {
+    const root = tmpRoot();
+    const tasks = loadUserTasks(root);
+    assert.deepEqual(tasks, []);
+  });
+
+  it("loads tasks from file", () => {
+    const root = tmpRoot();
+    const data = [
+      {
+        id: "abc",
+        name: "Test",
+        description: "",
+        schedule: { type: "daily", time: "08:00" },
+        missedRunPolicy: "run-once",
+        enabled: true,
+        roleId: "general",
+        prompt: "hello",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ];
+    writeFileSync(
+      path.join(root, "config", "scheduler", "tasks.json"),
+      JSON.stringify(data),
+    );
+    const tasks = loadUserTasks(root);
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0].name, "Test");
+  });
+
+  it("returns empty array for corrupted JSON", () => {
+    const root = tmpRoot();
+    writeFileSync(
+      path.join(root, "config", "scheduler", "tasks.json"),
+      "not json",
+    );
+    const tasks = loadUserTasks(root);
+    assert.deepEqual(tasks, []);
+  });
+});
+
+describe("saveUserTasks", () => {
+  it("writes tasks to file", async () => {
+    const root = tmpRoot();
+    const schedule = {
+      type: SCHEDULE_TYPES.interval,
+      intervalMs: 60000,
+    };
+    const tasks = [
+      {
+        id: "xyz",
+        name: "Saved",
+        description: "",
+        schedule,
+        missedRunPolicy: MISSED_RUN_POLICIES.skip,
+        enabled: true,
+        roleId: "general",
+        prompt: "test",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    ];
+    await saveUserTasks(tasks, root);
+    const raw = readFileSync(
+      path.join(root, "config", "scheduler", "tasks.json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(raw);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].name, "Saved");
+  });
+});
+
+describe("validateAndCreate", () => {
+  it("creates a valid task", () => {
+    const result = validateAndCreate({
+      name: "Daily news",
+      prompt: "Summarize the news",
+      schedule: { type: "daily", time: "08:00" },
+    });
+    assert.equal(result.kind, "ok");
+    if (result.kind === "ok") {
+      assert.equal(result.task.name, "Daily news");
+      assert.equal(result.task.prompt, "Summarize the news");
+      assert.equal(result.task.enabled, true);
+      assert.equal(result.task.missedRunPolicy, MISSED_RUN_POLICIES.runOnce);
+      assert.ok(result.task.id.length > 0);
+    }
+  });
+
+  it("rejects missing name", () => {
+    const result = validateAndCreate({
+      prompt: "hello",
+      schedule: { type: "daily", time: "08:00" },
+    });
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects missing prompt", () => {
+    const result = validateAndCreate({
+      name: "Test",
+      schedule: { type: "daily", time: "08:00" },
+    });
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects invalid schedule", () => {
+    const result = validateAndCreate({
+      name: "Test",
+      prompt: "hello",
+      schedule: { type: "weekly", days: [1] },
+    });
+    assert.equal(result.kind, "error");
+  });
+
+  it("rejects null body", () => {
+    const result = validateAndCreate(null);
+    assert.equal(result.kind, "error");
+  });
+
+  it("accepts custom missedRunPolicy", () => {
+    const result = validateAndCreate({
+      name: "Metrics",
+      prompt: "Ping metrics",
+      schedule: { type: "interval", intervalMs: 3600000 },
+      missedRunPolicy: "run-all",
+    });
+    assert.equal(result.kind, "ok");
+    if (result.kind === "ok") {
+      assert.equal(result.task.missedRunPolicy, "run-all");
+    }
+  });
+});
+
+describe("applyUpdate", () => {
+  const dailySchedule = {
+    type: SCHEDULE_TYPES.daily,
+    time: "08:00",
+  };
+  const baseTasks = [
+    {
+      id: "t1",
+      name: "Original",
+      description: "desc",
+      schedule: dailySchedule,
+      missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
+      enabled: true,
+      roleId: "general",
+      prompt: "do stuff",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ];
+
+  it("updates name", () => {
+    const result = applyUpdate([...baseTasks], "t1", { name: "Updated" });
+    assert.equal(result.kind, "ok");
+    if (result.kind === "ok") {
+      assert.equal(result.tasks[0].name, "Updated");
+    }
+  });
+
+  it("updates enabled", () => {
+    const result = applyUpdate([...baseTasks], "t1", { enabled: false });
+    assert.equal(result.kind, "ok");
+    if (result.kind === "ok") {
+      assert.equal(result.tasks[0].enabled, false);
+    }
+  });
+
+  it("returns error for unknown id", () => {
+    const result = applyUpdate([...baseTasks], "unknown", { name: "X" });
+    assert.equal(result.kind, "error");
+  });
+
+  it("ignores invalid schedule", () => {
+    const result = applyUpdate([...baseTasks], "t1", {
+      schedule: { type: "nope" },
+    });
+    assert.equal(result.kind, "ok");
+    if (result.kind === "ok") {
+      // Schedule unchanged
+      assert.equal(result.tasks[0].schedule.type, SCHEDULE_TYPES.daily);
+    }
+  });
+});

--- a/test/skills/test_user_tasks.ts
+++ b/test/skills/test_user_tasks.ts
@@ -10,6 +10,7 @@ import {
 } from "../../server/workspace/skills/user-tasks.ts";
 import { saveUserTasks } from "../../server/utils/files/user-tasks-io.ts";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
+import { ONE_MINUTE_MS, ONE_HOUR_MS } from "../../server/utils/time.ts";
 
 function tmpRoot(): string {
   const dir = mkdtempSync(path.join(os.tmpdir(), "user-tasks-"));
@@ -31,8 +32,8 @@ describe("loadUserTasks", () => {
         id: "abc",
         name: "Test",
         description: "",
-        schedule: { type: "daily", time: "08:00" },
-        missedRunPolicy: "run-once",
+        schedule: { type: SCHEDULE_TYPES.daily, time: "08:00" },
+        missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
         enabled: true,
         roleId: "general",
         prompt: "hello",
@@ -65,7 +66,7 @@ describe("saveUserTasks", () => {
     const root = tmpRoot();
     const schedule = {
       type: SCHEDULE_TYPES.interval,
-      intervalMs: 60000,
+      intervalMs: ONE_MINUTE_MS,
     };
     const tasks = [
       {
@@ -97,7 +98,7 @@ describe("validateAndCreate", () => {
     const result = validateAndCreate({
       name: "Daily news",
       prompt: "Summarize the news",
-      schedule: { type: "daily", time: "08:00" },
+      schedule: { type: SCHEDULE_TYPES.daily, time: "08:00" },
     });
     assert.equal(result.kind, "ok");
     if (result.kind === "ok") {
@@ -112,7 +113,7 @@ describe("validateAndCreate", () => {
   it("rejects missing name", () => {
     const result = validateAndCreate({
       prompt: "hello",
-      schedule: { type: "daily", time: "08:00" },
+      schedule: { type: SCHEDULE_TYPES.daily, time: "08:00" },
     });
     assert.equal(result.kind, "error");
   });
@@ -120,7 +121,7 @@ describe("validateAndCreate", () => {
   it("rejects missing prompt", () => {
     const result = validateAndCreate({
       name: "Test",
-      schedule: { type: "daily", time: "08:00" },
+      schedule: { type: SCHEDULE_TYPES.daily, time: "08:00" },
     });
     assert.equal(result.kind, "error");
   });
@@ -143,12 +144,12 @@ describe("validateAndCreate", () => {
     const result = validateAndCreate({
       name: "Metrics",
       prompt: "Ping metrics",
-      schedule: { type: "interval", intervalMs: 3600000 },
-      missedRunPolicy: "run-all",
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_HOUR_MS },
+      missedRunPolicy: MISSED_RUN_POLICIES.runAll,
     });
     assert.equal(result.kind, "ok");
     if (result.kind === "ok") {
-      assert.equal(result.task.missedRunPolicy, "run-all");
+      assert.equal(result.task.missedRunPolicy, MISSED_RUN_POLICIES.runAll);
     }
   });
 });


### PR DESCRIPTION
## Summary

- ユーザーがスケジュールタスクを作成・管理・監視できるように Phase 3 を実装
- API (CRUD) + MCP tool (チャット連携) + UI (Tasks タブ) の3レイヤー
- 14件のユニットテスト追加

## Items to Confirm / Review

- user-tasks.ts の配置が `server/workspace/skills/` 以下 — skill と同じディレクトリ。`server/workspace/scheduler/` に分けるべきか？
- MCP tool に `createTask` 等を追加したが、既存の `show/add/delete/update` (カレンダーイベント用) との共存が適切か
- Tasks タブのUI — 最小限の表示で、Phase 4 (通知連携) に向けた拡張余地あり

## User Prompt

#357 の Phase 3 を実装。ユーザータスク CRUD + MCP tool + UI を1PRで。

## Implementation

### Backend (Step 1 + 2)
- `server/workspace/skills/user-tasks.ts` — PersistedUserTask 型、I/O (tasks.json)、バリデーション、タスク登録 (mutex付き)
- `server/api/routes/schedulerTasks.ts` — CRUD API: POST/PUT/DELETE /api/scheduler/tasks, POST .../run
- `src/config/workspacePaths.ts` + `server/workspace/paths.ts` — schedulerUserTasks パス追加
- `src/config/apiRoutes.ts` — scheduler.tasks / task / taskRun / logs
- `server/index.ts` — startup で registerUserTasks() 呼び出し

### MCP Tool (Step 3)
- `src/plugins/scheduler/definition.ts` — createTask / listTasks / deleteTask / runTask アクション追加
- `server/api/routes/scheduler.ts` — タスクアクションのハンドリング追加

### UI (Step 4)
- `src/plugins/scheduler/TasksTab.vue` — タスク一覧コンポーネント (origin バッジ、スケジュール表示、Run Now / Enable / Delete)
- `src/plugins/scheduler/View.vue` — Calendar / Tasks タブ切り替え

### Tests (Step 5)
- `test/skills/test_user_tasks.ts` — 14テスト (load/save/validate/update)

## Test plan

- [x] yarn format / lint / typecheck / build / test — all pass
- [x] 14 unit tests for user-tasks I/O and validation
- [ ] Manual: create task via MCP tool, verify it appears in Tasks tab
- [ ] Manual: toggle enable/disable, verify task stops/starts firing
- [ ] Manual: delete task, verify removed from Tasks tab and task-manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-managed scheduled tasks: create, edit, delete, enable/disable, and manual "Run Now"
  * Unified Tasks tab in Scheduler showing system/user tasks, state, next run, and logs
  * Natural-language schedule parsing for task creation

* **Tests**
  * Added end-to-end and unit tests for task persistence, validation, and CRUD flows

* **Documentation**
  * Added Phase 3 specification for the Scheduler plugin
<!-- end of auto-generated comment: release notes by coderabbit.ai -->