### PR TITLE
fix: MCP server crash in Docker — missing require export + packages mount

### DIFF
--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -117,7 +117,12 @@ Run `git diff --stat` and `git diff` first, then check every item below against 
 - [ ] **No `eslint-disable-line` or `eslint-disable-next-line`.** If the lint rule fires, fix the code — don't suppress. The only exception is `@typescript-eslint/no-explicit-any` in test mocks where the mock intentionally returns `as any` to satisfy a type constraint that doesn't matter for the test.
 - [ ] No `@ts-ignore` or `@ts-expect-error`.
 
-## 14. Dependencies
+## 14. Workspace Package Exports (Docker)
+
+- [ ] Every `packages/*/package.json` with an `"exports"` field includes `"require"` and `"default"` conditions (not just `"import"`). Missing `"require"` silently breaks the MCP server in the Docker sandbox.
+- [ ] If Docker volume mounts in `server/agent/config.ts` changed, or package exports changed, run `npx tsx --test test/agent/test_mcp_docker_smoke.ts` locally to verify.
+
+## 15. Dependencies
 
 - [ ] **No unnecessary npm packages.** If the functionality can be implemented in <50 lines of pure code, do that instead of adding a dependency.
 - [ ] Prefer **mature, mainstream packages** with large user bases, stable APIs, and infrequent breaking changes (e.g., `express`, `marked`, `zod`, `uuid`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,23 @@ CI runs the matrix `{ubuntu, windows, macOS} × {Node 22, Node 24}` (see `docs/d
 - **Line endings**: writes that round-trip through git on a Windows checkout may pick up CRLF — use `"\n"` explicitly when comparing string output, and parse with `replace(/\r\n/g, "\n")` if reading user-edited files.
 - **Shell scripts in npm scripts**: NEVER use shell-specific syntax (`rm -rf`, `cp`, glob expansions in single quotes). Use `rimraf`, `shx`, or a Node script. Globs in package.json scripts should be unquoted (`prettier --write src/**/*.ts`, not `'src/**/*.ts'`).
 
+### Workspace package exports (Docker sandbox)
+
+The MCP server subprocess runs inside a Docker container where `tsx` resolves modules in CJS mode. Every `packages/*/package.json` that has an `"exports"` field MUST include `"require"` and `"default"` conditions alongside `"import"` — otherwise `ERR_PACKAGE_PATH_NOT_EXPORTED` crashes the MCP server silently and all tools become inaccessible (see PR #427).
+
+```json
+"exports": {
+  ".": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js",
+    "require": "./dist/index.js",
+    "default": "./dist/index.js"
+  }
+}
+```
+
+After changing package exports or Docker volume mounts, run the local Docker smoke test: `npx tsx --test test/agent/test_mcp_docker_smoke.ts`
+
 ### Why this section keeps mattering
 
 Cross-platform path bugs land disproportionately often (multiple PRs in the last few weeks: `#224`, `#234`). The pattern is always the same: code works locally on macOS, ships, then Windows CI explodes on `\` vs `/`. Read this section once before writing any new fs / path code and the regressions go away.

--- a/packages/chat-service/package.json
+++ b/packages/chat-service/package.json
@@ -8,7 +8,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,14 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "mulmobridge-cli": "dist/index.js"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,7 +8,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -8,7 +8,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -8,7 +8,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -5,6 +5,14 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "mulmobridge-telegram": "./dist/index.js"
   },

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -486,6 +486,8 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     "-v",
     `${toDockerPath(projectRoot)}/src:/app/src:ro`,
     "-v",
+    `${toDockerPath(projectRoot)}/packages:/app/packages:ro`,
+    "-v",
     `${toDockerPath(workspacePath)}:${CONTAINER_WORKSPACE_PATH}`,
     "-v",
     `${toDockerPath(homeDir)}/.claude:/home/node/.claude`,

--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -61,6 +61,32 @@ function spawnClaude(
   return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
 }
 
+// Track MCP tool usage to detect silent MCP server failures.
+// If ToolSearch was called but no mcp__* tool was ever invoked,
+// the MCP server likely crashed on startup (e.g. module resolution
+// failure inside Docker). See #430.
+function createMcpTracker() {
+  let toolSearchCalled = false;
+  let mcpToolCalled = false;
+  return {
+    track(event: AgentEvent) {
+      if (event.type !== EVENT_TYPES.toolCall) return;
+      if (event.toolName === "ToolSearch") toolSearchCalled = true;
+      if (event.toolName.startsWith("mcp__")) mcpToolCalled = true;
+    },
+    logIfSuspicious() {
+      if (toolSearchCalled && !mcpToolCalled) {
+        log.warn(
+          "agent",
+          "ToolSearch was used but no MCP tool was called — the MCP server may have crashed. " +
+            "Check Docker volume mounts and package.json exports. " +
+            "Run: npx tsx --test test/agent/test_mcp_docker_smoke.ts",
+        );
+      }
+    },
+  };
+}
+
 async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
@@ -80,6 +106,8 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   // text is suppressed. See createStreamParser() in stream.ts.
   const parser = createStreamParser();
 
+  const mcpTracker = createMcpTracker();
+
   let buffer = "";
   for await (const chunk of proc.stdout) {
     buffer += (chunk as Buffer).toString();
@@ -95,6 +123,7 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
         continue;
       }
       for (const agentEvent of parser.parse(event)) {
+        mcpTracker.track(agentEvent);
         yield agentEvent;
       }
     }
@@ -106,6 +135,7 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
 
   if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
   log.info("agent", "claude exited", { exitCode });
+  mcpTracker.logIfSuspicious();
 
   if (exitCode !== 0) {
     yield {

--- a/test/agent/test_mcp_docker_smoke.ts
+++ b/test/agent/test_mcp_docker_smoke.ts
@@ -1,0 +1,185 @@
+// Docker smoke test for the MCP server subprocess.
+//
+// Verifies that the MCP server can start inside the Docker sandbox
+// container and respond to initialize + tools/list. This catches:
+//   - Missing Docker volume mounts (e.g. packages/ not mounted)
+//   - package.json exports issues (e.g. missing "require" condition)
+//   - Module resolution failures in the container's Node.js version
+//
+// NOT run in CI (Docker unavailable). Run locally after:
+//   - Adding/changing workspace package exports
+//   - Modifying Docker volume mounts in server/agent/config.ts
+//   - Upgrading Node.js version in the sandbox Dockerfile
+//
+// Usage: npx tsx --test test/agent/test_mcp_docker_smoke.ts
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { execSync, spawn } from "node:child_process";
+import path from "node:path";
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "../..");
+
+function isDockerAvailable(): boolean {
+  try {
+    execSync("docker info", { stdio: "ignore", timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSandboxImageAvailable(): boolean {
+  try {
+    const out = execSync("docker images -q mulmoclaude-sandbox", {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: number;
+  result?: {
+    serverInfo?: { name: string };
+    tools?: Array<{ name: string }>;
+  };
+}
+
+describe("MCP server Docker smoke test", () => {
+  before(() => {
+    if (!isDockerAvailable()) {
+      console.log("  SKIP: Docker not available");
+      process.exit(0);
+    }
+    if (!isSandboxImageAvailable()) {
+      console.log("  SKIP: mulmoclaude-sandbox image not built");
+      process.exit(0);
+    }
+  });
+
+  it("responds to initialize + tools/list inside Docker container", async () => {
+    const toDockerPath = (p: string): string => p.replace(/\\/g, "/");
+
+    const dockerArgs = [
+      "run",
+      "--rm",
+      "-i",
+      "-v",
+      `${toDockerPath(PROJECT_ROOT)}/node_modules:/app/node_modules:ro`,
+      "-v",
+      `${toDockerPath(PROJECT_ROOT)}/packages:/app/packages:ro`,
+      "-v",
+      `${toDockerPath(PROJECT_ROOT)}/server:/app/server:ro`,
+      "-v",
+      `${toDockerPath(PROJECT_ROOT)}/src:/app/src:ro`,
+      "-e",
+      "NODE_PATH=/app/node_modules",
+      "-e",
+      "SESSION_ID=docker-smoke-test",
+      "-e",
+      "PORT=9999",
+      "-e",
+      "PLUGIN_NAMES=manageTodoList,presentMulmoScript,manageWiki,switchRole",
+      "-e",
+      "ROLE_IDS=general",
+      "mulmoclaude-sandbox",
+      "tsx",
+      "/app/server/agent/mcp-server.ts",
+    ];
+
+    const responses = await new Promise<JsonRpcResponse[]>(
+      (resolve, reject) => {
+        const child = spawn("docker", dockerArgs, {
+          cwd: PROJECT_ROOT,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        child.stdout.on("data", (chunk: Buffer) => {
+          stdout += chunk.toString();
+        });
+        child.stderr.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString();
+        });
+
+        const lines = [
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2024-11-05",
+              capabilities: {},
+              clientInfo: { name: "docker-test", version: "0.0.0" },
+            },
+          }),
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list",
+            params: {},
+          }),
+        ];
+
+        for (const line of lines) {
+          child.stdin.write(line + "\n");
+        }
+        child.stdin.end();
+
+        const timer = setTimeout(() => {
+          child.kill("SIGTERM");
+          reject(new Error(`Docker MCP server timed out. stderr: ${stderr}`));
+        }, 30_000);
+
+        child.on("close", (code) => {
+          clearTimeout(timer);
+          const parsed: JsonRpcResponse[] = stdout
+            .split("\n")
+            .filter((l) => l.trim())
+            .map((l) => {
+              try {
+                return JSON.parse(l) as JsonRpcResponse;
+              } catch {
+                return null;
+              }
+            })
+            .filter((r): r is JsonRpcResponse => r !== null);
+
+          if (parsed.length === 0 && code !== 0) {
+            reject(
+              new Error(
+                `Docker MCP server exited ${code}. stderr:\n${stderr.slice(0, 1000)}`,
+              ),
+            );
+            return;
+          }
+          resolve(parsed);
+        });
+      },
+    );
+
+    const initResp = responses.find((r) => r.id === 1);
+    assert.ok(initResp?.result, "Missing initialize response");
+    assert.equal(initResp.result.serverInfo?.name, "mulmoclaude");
+
+    const toolsResp = responses.find((r) => r.id === 2);
+    assert.ok(toolsResp?.result?.tools, "Missing tools/list response");
+
+    const toolNames = toolsResp.result.tools.map((t) => t.name);
+    assert.ok(
+      toolNames.includes("presentMulmoScript"),
+      `presentMulmoScript not in tools: ${toolNames.join(", ")}`,
+    );
+    assert.ok(
+      toolNames.includes("manageTodoList"),
+      `manageTodoList not in tools: ${toolNames.join(", ")}`,
+    );
+  });
+});

--- a/test/agent/test_mcp_docker_smoke.ts
+++ b/test/agent/test_mcp_docker_smoke.ts
@@ -13,7 +13,7 @@
 //
 // Usage: npx tsx --test test/agent/test_mcp_docker_smoke.ts
 
-import { describe, it, before } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execSync, spawn } from "node:child_process";
 import path from "node:path";
@@ -50,18 +50,9 @@ interface JsonRpcResponse {
   };
 }
 
-describe("MCP server Docker smoke test", () => {
-  before(() => {
-    if (!isDockerAvailable()) {
-      console.log("  SKIP: Docker not available");
-      process.exit(0);
-    }
-    if (!isSandboxImageAvailable()) {
-      console.log("  SKIP: mulmoclaude-sandbox image not built");
-      process.exit(0);
-    }
-  });
+const canRunDocker = isDockerAvailable() && isSandboxImageAvailable();
 
+describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
   it("responds to initialize + tools/list inside Docker container", async () => {
     const toDockerPath = (p: string): string => p.replace(/\\/g, "/");
 


### PR DESCRIPTION
## Summary

全ての MCP ツール（presentMulmoScript, manageTodoList 等）が Docker sandbox 内で使用不能になっていた問題を修正。

## 原因

PR #390 で `src/config/apiRoutes.ts` が `@mulmobridge/protocol` からインポートするようになった。MCP サーバーは Docker コンテナ内で tsx サブプロセスとして起動され、apiRoutes.ts を間接的にインポートする。2つの問題で解決に失敗:

1. **`packages/protocol/package.json` の exports に "require" 条件がなかった** — コンテナ内の tsx (Node 22) は CJS モードで解決しようとするが、"import" しかないため ERR_PACKAGE_PATH_NOT_EXPORTED でクラッシュ
2. **`packages/` ディレクトリが Docker にマウントされていなかった** — yarn workspace の symlink (node_modules/@mulmobridge/protocol → ../../packages/protocol) がダングリング

結果: MCP サーバーが無言でクラッシュ → Claude CLI の ToolSearch が "No matching deferred tools found" を返す

## 修正内容

- 全6パッケージの package.json exports に `"require"` + `"default"` 条件を追加
- Docker コンテナに `packages/` ディレクトリをマウント
- Docker スモークテスト追加（ローカル専用、CI では Docker 不可）
- CLAUDE.md にパッケージ exports ガイドライン追加
- precommit チェックリストに項目 #14 追加

## 二分探索の経緯

```
6231702 (4/16 "Use .env")        → OK
5d880ec (precommit-skill)        → OK
40e05c0 (rename types→protocol)  → OK
f1d98ee (CodeRabbit review #390) → NG ← apiRoutes.ts に import 追加
```

## 再発防止

- CLAUDE.md: workspace パッケージの exports には必ず require/default を含める規則
- precommit スキル: パッケージ exports 変更時にローカル Docker テスト実行を促す
- Docker スモークテスト: `npx tsx --test test/agent/test_mcp_docker_smoke.ts`

## Test plan

- [x] yarn test — pass
- [x] yarn typecheck — pass
- [x] yarn lint — 0 errors
- [x] Docker 内 MCP サーバー起動テスト — initialize + tools/list 成功
- [x] 実際のブラウザで storyteller ロールの sample query → presentMulmoScript 呼び出し成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)