### PR TITLE
fix: Tool Call History not updating after page reload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1434,8 +1434,13 @@ function ensureSessionSubscription(
 ): void {
   if (sessionSubscriptions.has(session.id)) return;
 
+  const sessionId = session.id;
   const ctx: AgentEventContext = {
-    session,
+    get session() {
+      // Always resolve from sessionMap so we track the latest
+      // reactive proxy — loadSession may replace the object.
+      return sessionMap.get(sessionId) ?? session;
+    },
     runStartIndex,
     setCurrentRoleId: (roleId) => {
       currentRoleId.value = roleId;


### PR DESCRIPTION
## Summary

リロード後に Tool Call History に新しいツール呼び出しが表示されないバグを修正。

## 原因

`ensureSessionSubscription` のクロージャが `session` オブジェクトの参照をキャプチャ。`loadSession` でセッションが `sessionMap` に再作成されると新しい reactive proxy が生成されるが、クロージャは古い参照に push し続けていた。`activeSession` (= `sessionMap.get()`) は新しいオブジェクトを指すため、UI に反映されなかった。

## 修正

`ctx.session` をゲッターにし、毎回 `sessionMap.get(sessionId)` から最新の reactive proxy を取得。`applyAgentEvent` は各イベントごとに `ctx.session` を読むので、常に正しいオブジェクトに書き込む。

## Test plan

- [x] yarn typecheck — pass
- [x] yarn lint — 0 errors
- [x] yarn test — pass
- [x] 手動: リロード後にエージェント実行 → Tool Call History に表示される

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)