### PR TITLE
fix: clean up ?path= URL param when file is closed or view changes

### DIFF
--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -157,4 +157,26 @@ test.describe("file explorer path in URL", () => {
       expect(url.searchParams.get("path")).toBeNull();
     }).toPass({ timeout: 5000 });
   });
+
+  test("closing a file removes ?path= from URL", async ({ page }) => {
+    await page.goto("/chat?view=files&path=wiki/hello.md");
+    await expect(page.getByText("This is a test.")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Click the close button
+    await expect(page.getByTestId("close-file-btn")).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByTestId("close-file-btn").click();
+
+    // ?path= should be removed
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("path")).toBeNull();
+    }).toPass({ timeout: 5000 });
+
+    // "Select a file" placeholder should be visible
+    await expect(page.getByText("Select a file")).toBeVisible();
+  });
 });

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -42,13 +42,15 @@
           {{ mdRawMode ? "Rendered" : "Raw" }}
         </button>
         <button
+          type="button"
           class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
           :class="{ 'ml-auto': !isMarkdown }"
           title="Close file"
+          aria-label="Close file"
           data-testid="close-file-btn"
           @click="deselectFile"
         >
-          <span class="material-icons text-base">close</span>
+          <span class="material-icons text-base" aria-hidden="true">close</span>
         </button>
       </div>
       <div class="flex-1 overflow-auto min-h-0">
@@ -634,8 +636,11 @@ function selectFile(filePath: string): void {
 }
 
 function deselectFile(): void {
+  contentAbort?.abort();
+  contentAbort = null;
   selectedPath.value = null;
   content.value = null;
+  contentLoading.value = false;
   contentError.value = null;
   // Remove ?path= from URL for a clean state on reload.
   const { path: __path, ...restQuery } = route.query;

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -41,6 +41,15 @@
         >
           {{ mdRawMode ? "Rendered" : "Raw" }}
         </button>
+        <button
+          class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+          :class="{ 'ml-auto': !isMarkdown }"
+          title="Close file"
+          data-testid="close-file-btn"
+          @click="deselectFile"
+        >
+          <span class="material-icons text-base">close</span>
+        </button>
       </div>
       <div class="flex-1 overflow-auto min-h-0">
         <div
@@ -622,6 +631,19 @@ function selectFile(filePath: string): void {
         console.error("[selectFile] navigation failed:", err);
       }
     });
+}
+
+function deselectFile(): void {
+  selectedPath.value = null;
+  content.value = null;
+  contentError.value = null;
+  // Remove ?path= from URL for a clean state on reload.
+  const { path: __path, ...restQuery } = route.query;
+  router.replace({ query: restQuery }).catch((err: unknown) => {
+    if (!isNavigationFailure(err)) {
+      console.error("[deselectFile] navigation failed:", err);
+    }
+  });
 }
 
 // When the user clicks an <a> inside a rendered markdown body, check

--- a/src/composables/useCanvasViewMode.ts
+++ b/src/composables/useCanvasViewMode.ts
@@ -33,6 +33,9 @@ function applyViewToQuery(
 ): LocationQuery {
   const rest: LocationQuery = { ...currentQuery };
   delete rest.view;
+  // Remove ?path= when leaving the files view — it's only meaningful
+  // in files mode and would cause a stale file selection on reload.
+  if (mode !== "files") delete rest.path;
   if (mode === "single") return rest;
   return { ...rest, view: mode };
 }


### PR DESCRIPTION
## Summary

- Add close button (x) to file header in FilesView
- `deselectFile()` removes `?path=` from URL via `router.replace`
- `applyViewToQuery()` strips `?path=` when leaving files view mode
- E2E test for close button behavior

## User Prompt

ファイルエクスプローラーでファイルを開くと `?path=data/sources/xxx.md` が URL につくが、ファイルを閉じても `path` が残り、reload すると必ずそのファイルに行く問題。

## Test plan

- [x] E2E: 5 file-explorer tests pass (including new close test)
- [x] Typecheck clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close file button in the file explorer interface. Clicking it deselects the current file, clears the displayed content, and removes the file path parameter from the URL.
  * Enhanced URL state management to ensure file selection does not persist when switching between different view modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->