### PR TITLE
Fix result selection bug

### DIFF
--- a/plans/fix-stale-run-start-index.md
+++ b/plans/fix-stale-run-start-index.md
@@ -1,0 +1,137 @@
+# Fix: Stale `runStartIndex` Breaks Auto-Select of LLM Text Replies
+
+## Problem
+
+After the first turn in a session that used any plugin (GUI-chat-protocol tool),
+subsequent LLM text replies fail to become the selected canvas result. The
+user keeps seeing the old plugin output (or, in some edge cases, a blank
+"Start a conversation" panel) even though the sidebar shows a fresh text
+reply from the assistant.
+
+## Expected Behavior
+
+When an assistant text reply arrives from the LLM during a run:
+
+- **Select it** (make it the active canvas result) if no plugin result
+  has landed during the **current** run.
+- **Do NOT select it** if a plugin result has already landed during the
+  current run — the plugin output is visually richer and should remain
+  selected.
+
+This rule MUST hold **on every turn**, not just the first turn after the
+session is subscribed. Run N+1 must not be influenced by plugin results
+emitted during run N.
+
+## Root Cause
+
+`ensureSessionSubscription` in `src/App.vue` (around line 1431) is
+idempotent — if a subscription already exists for the session, it returns
+early:
+
+```ts
+function ensureSessionSubscription(session, runStartIndex): void {
+  if (sessionSubscriptions.has(session.id)) return;   // ← early return
+  const ctx: AgentEventContext = {
+    session,
+    runStartIndex,   // ← captured once in closure
+    ...
+  };
+  const unsub = pubsubSubscribe(channel, (data) => {
+    ...
+    applyAgentEvent(event, ctx);   // ← stale ctx reused forever
+  });
+  sessionSubscriptions.set(session.id, unsub);
+}
+```
+
+`beginUserTurn` (around line 1416) computes a fresh `runStartIndex`
+(= `session.toolResults.length` after the user message is pushed) on
+every turn, and `sendMessage` passes it to `ensureSessionSubscription`
+— but on turn 2+ the early return discards it. The `ctx` object created
+on turn 1 remains the one that every future `applyAgentEvent` call sees.
+
+Consequence: `shouldSelectAssistantText(toolResults, ctx.runStartIndex)`
+(in `src/utils/agent/toolCalls.ts`) scans results starting from turn 1's
+start index. Once any plugin result exists anywhere at or after that
+stale index, the function returns `false` forever — so new assistant
+text cards on turn 2, 3, 4, … are never selected automatically.
+
+## Fix (Option 2: move `runStartIndex` onto the session)
+
+Store `runStartIndex` on the `ActiveSession` object itself instead of
+closure-capturing it inside the subscription. The event handler already
+has a reference to `session`, so reading a fresh value from there is
+trivial and avoids rebuilding the subscription on every turn.
+
+### Changes
+
+1. **`ActiveSession` type** — add a field:
+
+   ```ts
+   interface ActiveSession {
+     ...
+     runStartIndex: number;
+   }
+   ```
+
+   Initialize to `0` (or `toolResults.length`) wherever an `ActiveSession`
+   is constructed:
+   - `createNewSession` (around line 1249)
+   - `loadSession` (around line 1362)
+
+2. **`beginUserTurn`** (`src/App.vue` around line 1416) — write the index
+   onto the session and return it for the caller that still expects it:
+
+   ```ts
+   function beginUserTurn(session: ActiveSession, message: string): number {
+     session.updatedAt = new Date().toISOString();
+     session.toolResults.push(makeTextResult(message, "user"));
+     session.runStartIndex = session.toolResults.length;
+     return session.runStartIndex;
+   }
+   ```
+
+3. **Text event handler in `applyAgentEvent`** (around line 1585) — read
+   from the session, not from `ctx`:
+
+   ```ts
+   if (shouldSelectAssistantText(session.toolResults, session.runStartIndex)) {
+     session.selectedResultUuid = textResult.uuid;
+   }
+   ```
+
+4. **Drop `runStartIndex` from `AgentEventContext`** (around line 1497)
+   and from `ensureSessionSubscription`'s signature. Update both call
+   sites (`sendMessage` around line 1633 and `loadSession` around line
+   1381) to pass only the session.
+
+5. **Tests** — add a case to the existing `toolCalls` unit tests that
+   asserts `shouldSelectAssistantText` is called with the per-turn
+   index. Add an E2E or integration test for the two-turn scenario:
+
+   - Turn 1: user asks something that triggers a plugin, LLM also sends
+     text. Assert plugin is selected.
+   - Turn 2: user asks a text-only follow-up, LLM replies with text.
+     Assert the new text card is selected (this is the regression
+     this fix addresses).
+
+## Why Option 2 over Option 1
+
+Option 1 would be to drop the idempotent guard and rebuild `ctx` on
+every turn — but the subscription callback has already closed over the
+old `ctx`, so that doesn't help without further restructuring (mutable
+ref boxes, manager objects, etc.). Option 2 is a ~10-line diff that
+keeps the subscription lifecycle untouched and puts the per-turn state
+where it belongs: on the session object the event handler already
+reads from.
+
+## Out of Scope
+
+- The separate "Start a conversation" symptom where `selectedResultUuid`
+  points to a uuid not in the current session's `toolResults` (e.g.
+  URL `?result=` carrying a stale uuid across session switches). That
+  is a different dangling-reference bug and should be tracked in its
+  own plan.
+- Any change to `shouldSelectAssistantText`'s algorithm. The current
+  "any plugin in run → don't select" rule is correct; the bug is that
+  it's being called with the wrong `runStartIndex`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1074,7 +1074,7 @@ watch(currentSessionId, (id) => {
   const session = sessionMap.get(id);
   // Subscribe to the new session's channel
   if (session) {
-    ensureSessionSubscription(session, session.toolResults.length);
+    ensureSessionSubscription(session);
   }
   // Unsubscribe from the previous session if it's not running
   if (previousSessionId && previousSessionId !== id) {
@@ -1264,6 +1264,7 @@ function createNewSession(roleId?: string): ActiveSession {
     hasUnread: false,
     startedAt: now,
     updatedAt: now,
+    runStartIndex: 0,
   };
   sessionMap.set(id, session);
   navigateToSession(id, true);
@@ -1370,6 +1371,7 @@ async function loadSession(id: string) {
     hasUnread: false,
     startedAt,
     updatedAt,
+    runStartIndex: toolResultsList.length,
   };
   sessionMap.set(id, newSession);
   // Subscribe immediately — the watch(currentSessionId) may have
@@ -1378,10 +1380,7 @@ async function loadSession(id: string) {
   // Use sessionMap.get() to obtain the reactive proxy — passing the
   // raw object would bypass Vue's reactivity tracking.
   const reactiveSession = sessionMap.get(id)!;
-  ensureSessionSubscription(
-    reactiveSession,
-    reactiveSession.toolResults.length,
-  );
+  ensureSessionSubscription(reactiveSession);
   navigateToSession(id, replaced);
   currentRoleId.value = roleId;
   showHistory.value = false;
@@ -1409,18 +1408,18 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
 
 // Seed the session state for a fresh user turn. Not pure (mutates
 // session), but isolated so sendMessage doesn't have the init
-// pattern inline. Returns `runStartIndex` — the index into
-// toolResults at which this run's outputs start, used later to
-// decide whether a trailing text response becomes the selected
-// canvas result.
-function beginUserTurn(session: ActiveSession, message: string): number {
+// pattern inline. Writes `runStartIndex` onto the session — the
+// index into toolResults at which this run's outputs start, used
+// later to decide whether a trailing text response becomes the
+// selected canvas result.
+function beginUserTurn(session: ActiveSession, message: string): void {
   // Append the user's message so it renders immediately. State like
   // isRunning / statusMessage is NOT set here — it comes from the
   // server via the `sessions` channel notification → refetch cycle,
   // keeping all clients (including the initiator) in sync.
   session.updatedAt = new Date().toISOString();
   session.toolResults.push(makeTextResult(message, "user"));
-  return session.toolResults.length;
+  session.runStartIndex = session.toolResults.length;
 }
 
 // Subscribe to a session's pub/sub channel so events from the server
@@ -1428,10 +1427,7 @@ function beginUserTurn(session: ActiveSession, message: string): number {
 // WebSocket and are dispatched into the session's reactive state.
 // Returns the unsubscribe function. Idempotent — if a subscription
 // already exists for this session, it's reused.
-function ensureSessionSubscription(
-  session: ActiveSession,
-  runStartIndex: number,
-): void {
+function ensureSessionSubscription(session: ActiveSession): void {
   if (sessionSubscriptions.has(session.id)) return;
 
   const sessionId = session.id;
@@ -1441,7 +1437,6 @@ function ensureSessionSubscription(
       // reactive proxy — loadSession may replace the object.
       return sessionMap.get(sessionId) ?? session;
     },
-    runStartIndex,
     setCurrentRoleId: (roleId) => {
       currentRoleId.value = roleId;
     },
@@ -1496,7 +1491,6 @@ function unsubscribeSession(chatSessionId: string): void {
 // with a clear signature.
 interface AgentEventContext {
   session: ActiveSession;
-  runStartIndex: number;
   setCurrentRoleId: (roleId: string) => void;
   onRoleChange: () => void;
   refreshRoles: () => Promise<void>;
@@ -1526,7 +1520,7 @@ async function applyAgentEvent(
   event: SseEvent,
   ctx: AgentEventContext,
 ): Promise<void> {
-  const { session, runStartIndex } = ctx;
+  const { session } = ctx;
   switch (event.type) {
     case EVENT_TYPES.toolCall:
       session.toolCallHistory.push({
@@ -1582,7 +1576,9 @@ async function applyAgentEvent(
       if (appendToLastAssistantText(session, event.message)) return;
       const textResult = makeTextResult(event.message, "assistant");
       session.toolResults.push(textResult);
-      if (shouldSelectAssistantText(session.toolResults, runStartIndex)) {
+      if (
+        shouldSelectAssistantText(session.toolResults, session.runStartIndex)
+      ) {
         session.selectedResultUuid = textResult.uuid;
       }
       return;
@@ -1620,7 +1616,7 @@ async function sendMessage(text?: string) {
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
 
-  const runStartIndex = beginUserTurn(session, message);
+  beginUserTurn(session, message);
   const sessionRole =
     roles.value.find((r) => r.id === session.roleId) ?? roles.value[0];
   const selectedRes =
@@ -1630,7 +1626,7 @@ async function sendMessage(text?: string) {
   // Subscribe to the session's pub/sub channel BEFORE posting so we
   // don't miss events. The subscription callback dispatches each
   // event into the session's reactive state via applyAgentEvent.
-  ensureSessionSubscription(session, runStartIndex);
+  ensureSessionSubscription(session);
 
   try {
     const response = await apiFetchRaw(API_ROUTES.agent.run, {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -78,4 +78,11 @@ export interface ActiveSession {
   // Used by `mergedSessions` to sort the sidebar history list by
   // "most recently touched" rather than "created first".
   updatedAt: string;
+  // Index into `toolResults` at which the current run's outputs begin.
+  // Rewritten on every user turn by `beginUserTurn`; consumed by
+  // `shouldSelectAssistantText` to decide whether a trailing text
+  // reply should become the selected canvas result. Lives on the
+  // session (not on the subscription closure) so updates on turn N+1
+  // are visible to the reused subscription callback.
+  runStartIndex: number;
 }

--- a/test/utils/agent/test_toolCalls.ts
+++ b/test/utils/agent/test_toolCalls.ts
@@ -153,3 +153,30 @@ describe("shouldSelectAssistantText — boundary conditions", () => {
     assert.equal(shouldSelectAssistantText(results, 99), true);
   });
 });
+
+describe("shouldSelectAssistantText — multi-turn regression (#stale-runStartIndex)", () => {
+  it("turn 2 with a plugin result in turn 1 → true for text-only turn 2", () => {
+    // Simulates the two-turn bug:
+    //   Turn 1 (runStart=1): user asks a question that triggers a
+    //   plugin; LLM also emits text. Plugin result lands.
+    //   Turn 2 (runStart=4): user sends a text-only follow-up; LLM
+    //   replies with text only.
+    // Before the fix, the subscription closed over turn 1's
+    // runStartIndex (=1) forever — so on turn 2 the scan still saw
+    // the turn-1 plugin result and returned false. With the fix,
+    // runStartIndex lives on the session and is refreshed per turn;
+    // the turn-2 scan starts at index 4 and sees only the two
+    // text-responses, returning true.
+    const results = [
+      makeToolResult("u1-user", "text-response"),
+      makeToolResult("u1-plugin", "generateImage"),
+      makeToolResult("u1-text", "text-response"),
+      makeToolResult("u2-user", "text-response"),
+      makeToolResult("u2-text", "text-response"),
+    ];
+    // Stale index (turn 1's) — demonstrates the bug.
+    assert.equal(shouldSelectAssistantText(results, 1), false);
+    // Fresh per-turn index — the fix.
+    assert.equal(shouldSelectAssistantText(results, 4), true);
+  });
+});

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -27,6 +27,7 @@ function makeActive(overrides: Partial<ActiveSession> = {}): ActiveSession {
     hasUnread: false,
     startedAt: "2026-04-10T10:00:00.000Z",
     updatedAt: "2026-04-10T10:05:00.000Z",
+    runStartIndex: 0,
     ...overrides,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-turn conversation behavior where stale state data caused incorrect assistant text selection when plugin results and text responses were used together across different turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->