### PR TITLE
docs: update README, CLAUDE.md, developer.md for 2-day PR batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,15 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 /chat/:sessionId                           → existing session, single view
 /chat/:sessionId?view=stack                → stack view
 /chat/:sessionId?view=files                → files view
-/chat/:sessionId?view=files&path=wiki/foo  → files view + file selected (future)
+/chat/:sessionId?view=files&path=data/wiki/pages/foo.md → files view + file selected
+/chat/:sessionId?view=todos                → todos view (kanban/table/list)
+/chat/:sessionId?view=scheduler            → scheduler view (calendar/list)
+/chat/:sessionId?view=wiki                 → wiki index view
+/chat/:sessionId?view=skills               → skills list view
+/chat/:sessionId?view=roles                → roles management view
 ```
+
+**Keyboard shortcuts**: `Cmd/Ctrl + 1–8` switch between views (single, stack, files, todos, scheduler, wiki, skills, roles). The mapping is derived from the `VIEW_MODES` array in `src/utils/canvas/viewMode.ts` — adding a new mode is a single array append.
 
 **Key pattern — ref + bidirectional sync**: `router.push` is async, so state that must be readable synchronously (e.g. `currentSessionId`, `canvasViewMode`) is kept as a plain `ref`. The ref is the source of truth for reads; `router.push`/`router.replace` keeps the URL in sync. A `watch` on route params/query handles external URL changes (back/forward button, typed URL).
 
@@ -143,32 +150,32 @@ URL-based navigation via `vue-router` (history mode — clean paths, no `#`). Th
 
 `server/` is grouped by concern (#323). Top-level directories: `agent/`, `api/`, `workspace/`, `events/`, `system/`, `utils/`.
 
-| File | Purpose |
-|---|---|
-| `server/agent/index.ts` | Agent loop, MCP server creation per role |
-| `server/agent/mcp-server.ts` | stdio JSON-RPC MCP bridge spawned by the Claude CLI |
-| `server/agent/attachmentConverter.ts` | Converts non-native attachments (DOCX/XLSX/PPTX/text) to Claude content blocks |
-| `server/api/routes/agent.ts` | `POST /api/agent` → SSE stream |
-| `server/api/chat-service/` | External-bridge HTTP + socket.io surface (DI factory, `@mulmobridge/chat-service`) |
-| `server/api/auth/` | Bearer token + CSRF gate (`/api/files/*` exempt for `<img>` tags) |
-| `server/workspace/journal/` | Workspace journal (daily + optimization passes) |
-| `server/workspace/chat-index/` | Per-session summarizer + sidebar title cache |
-| `server/workspace/roles.ts` | Custom-role loader over `<workspace>/roles/` |
-| `server/events/pub-sub/` | In-process publish/subscribe (socket.io-backed) |
-| `server/events/session-store/` | In-memory session state + event fan-out |
-| `server/events/task-manager/` | Cron-ish scheduled task runner (tick loop) |
-| `server/events/scheduler-adapter.ts` | Wires `@receptron/task-scheduler` to MulmoClaude (catch-up + persistence) |
-| `packages/scheduler/` | `@receptron/task-scheduler` — pure scheduler library (independent npm package) |
-| `server/system/env.ts` | Single source of truth for `process.env.*` |
-| `server/system/logger/` | Structured logger (console + rotating file + telemetry stub) |
-| `server/utils/` | Shared helpers: `fs.ts`, `errors.ts` |
-| `src/config/apiRoutes.ts` | Central `/api/*` endpoint path constants (shared by server + frontend) |
-| `src/config/roles.ts` | Role definitions |
-| `src/tools/index.ts` | Plugin registry |
-| `src/router/index.ts` | Vue-router setup (history mode, route definitions) |
-| `src/router/guards.ts` | Navigation guards (param validation + sanitize) |
-| `src/composables/useCanvasViewMode.ts` | View mode state — URL sync via router, localStorage fallback |
-| `src/App.vue` | Main UI — sidebar + canvas + role switcher |
+| File                                   | Purpose                                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| `server/agent/index.ts`                | Agent loop, MCP server creation per role                                           |
+| `server/agent/mcp-server.ts`           | stdio JSON-RPC MCP bridge spawned by the Claude CLI                                |
+| `server/agent/attachmentConverter.ts`  | Converts non-native attachments (DOCX/XLSX/PPTX/text) to Claude content blocks     |
+| `server/api/routes/agent.ts`           | `POST /api/agent` → SSE stream                                                     |
+| `server/api/chat-service/`             | External-bridge HTTP + socket.io surface (DI factory, `@mulmobridge/chat-service`) |
+| `server/api/auth/`                     | Bearer token + CSRF gate (`/api/files/*` exempt for `<img>` tags)                  |
+| `server/workspace/journal/`            | Workspace journal (daily + optimization passes)                                    |
+| `server/workspace/chat-index/`         | Per-session summarizer + sidebar title cache                                       |
+| `server/workspace/roles.ts`            | Custom-role loader over `<workspace>/roles/`                                       |
+| `server/events/pub-sub/`               | In-process publish/subscribe (socket.io-backed)                                    |
+| `server/events/session-store/`         | In-memory session state + event fan-out                                            |
+| `server/events/task-manager/`          | Cron-ish scheduled task runner (tick loop)                                         |
+| `server/events/scheduler-adapter.ts`   | Wires `@receptron/task-scheduler` to MulmoClaude (catch-up + persistence)          |
+| `packages/scheduler/`                  | `@receptron/task-scheduler` — pure scheduler library (independent npm package)     |
+| `server/system/env.ts`                 | Single source of truth for `process.env.*`                                         |
+| `server/system/logger/`                | Structured logger (console + rotating file + telemetry stub)                       |
+| `server/utils/`                        | Shared helpers: `fs.ts`, `errors.ts`                                               |
+| `src/config/apiRoutes.ts`              | Central `/api/*` endpoint path constants (shared by server + frontend)             |
+| `src/config/roles.ts`                  | Role definitions                                                                   |
+| `src/tools/index.ts`                   | Plugin registry                                                                    |
+| `src/router/index.ts`                  | Vue-router setup (history mode, route definitions)                                 |
+| `src/router/guards.ts`                 | Navigation guards (param validation + sanitize)                                    |
+| `src/composables/useCanvasViewMode.ts` | View mode state — URL sync via router, localStorage fallback                       |
+| `src/App.vue`                          | Main UI — sidebar + canvas + role switcher                                         |
 
 ## Plugin Development
 
@@ -212,18 +219,20 @@ router.post("/items/:id", (req: Request, res: Response) => { const x = req.body 
 
 String literals that form cross-module contracts (endpoint paths, event types, tool names, role IDs, pub-sub channels, workspace directory names) MUST be defined once in a shared `as const` module and referenced everywhere else. NEVER introduce a new raw string literal for something that already has a constant.
 
-| What | Source of truth | Pattern |
-|---|---|---|
-| API endpoint paths | `src/config/apiRoutes.ts` → `API_ROUTES` | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
-| SSE / event types | `src/types/events.ts` → `EVENT_TYPES` / `EventType` | `{ type: EVENT_TYPES.toolResult, ... }` — also used in `AgentEvent` union |
-| Workspace directories | `server/workspace/paths.ts` → `WORKSPACE_PATHS` | `path.join(WORKSPACE_PATHS.wiki, "pages")` |
-| Tool names | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName` | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]` |
-| Built-in role IDs | `src/config/roles.ts` → `BUILTIN_ROLE_IDS` | `if (roleId === BUILTIN_ROLE_IDS.general)` |
-| Pub-sub channels | `src/config/pubsubChannels.ts` → `sessionChannel()` | `pubsub.publish(sessionChannel(id), event)` |
-| SSE event types | `src/types/events.ts` → `EVENT_TYPES` / `EventType` | `event.type === EVENT_TYPES.toolCall` |
-| Time constants | `server/utils/time.ts` → `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS` | `intervalMs: ONE_HOUR_MS`, `timeout: 5 * ONE_SECOND_MS` |
-| Timeout presets | `server/utils/time.ts` → `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `{ timeout: SUBPROCESS_PROBE_TIMEOUT_MS }` |
-| Scheduler types | `@receptron/task-scheduler` → `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES` | `schedule.type === SCHEDULE_TYPES.interval` |
+| What                  | Source of truth                                                                                                     | Pattern                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| API endpoint paths    | `src/config/apiRoutes.ts` → `API_ROUTES`                                                                            | `router.post(API_ROUTES.todos.items, ...)` / `fetch(API_ROUTES.todos.items)` |
+| SSE / event types     | `src/types/events.ts` → `EVENT_TYPES` / `EventType`                                                                 | `{ type: EVENT_TYPES.toolResult, ... }` — also used in `AgentEvent` union    |
+| Workspace directories | `server/workspace/paths.ts` → `WORKSPACE_PATHS`                                                                     | `path.join(WORKSPACE_PATHS.wiki, "pages")`                                   |
+| Workspace files       | `src/config/workspacePaths.ts` → `WORKSPACE_FILES`                                                                  | `WORKSPACE_FILES.todosItems` — shared by server (re-export) and frontend     |
+| Canvas view modes     | `src/utils/canvas/viewMode.ts` → `VIEW_MODES` / `CanvasViewMode`                                                    | `isCanvasViewMode(value)` — add mode by appending to array                   |
+| Tool names            | `src/config/toolNames.ts` → `TOOL_NAMES` / `ToolName`                                                               | `availablePlugins: [TOOL_NAMES.manageTodoList, ...]`                         |
+| Built-in role IDs     | `src/config/roles.ts` → `BUILTIN_ROLE_IDS`                                                                          | `if (roleId === BUILTIN_ROLE_IDS.general)`                                   |
+| Pub-sub channels      | `src/config/pubsubChannels.ts` → `sessionChannel()`                                                                 | `pubsub.publish(sessionChannel(id), event)`                                  |
+| SSE event types       | `src/types/events.ts` → `EVENT_TYPES` / `EventType`                                                                 | `event.type === EVENT_TYPES.toolCall`                                        |
+| Time constants        | `server/utils/time.ts` → `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS`                           | `intervalMs: ONE_HOUR_MS`, `timeout: 5 * ONE_SECOND_MS`                      |
+| Timeout presets       | `server/utils/time.ts` → `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `{ timeout: SUBPROCESS_PROBE_TIMEOUT_MS }`                                   |
+| Scheduler types       | `@receptron/task-scheduler` → `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES`           | `schedule.type === SCHEDULE_TYPES.interval`                                  |
 
 **Adding a new endpoint**: add the path to `src/config/apiRoutes.ts` first, then reference `API_ROUTES.<group>.<name>` from both the router file and the frontend `fetch()` call. Routers register the full `/api/...` path directly (no mount prefix in `server/index.ts`).
 
@@ -233,7 +242,11 @@ NEVER write raw millisecond literals (`1000`, `5000`, `60_000`, `3_600_000`, `86
 
 ```typescript
 // GOOD
-import { ONE_HOUR_MS, ONE_MINUTE_MS, SUBPROCESS_PROBE_TIMEOUT_MS } from "../utils/time.js";
+import {
+  ONE_HOUR_MS,
+  ONE_MINUTE_MS,
+  SUBPROCESS_PROBE_TIMEOUT_MS,
+} from "../utils/time.js";
 const INTERVAL_MS = 15 * ONE_MINUTE_MS;
 await execFileAsync("docker", ["ps"], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
 
@@ -341,29 +354,29 @@ When the same 3+ line pattern appears in two or more files, extract a shared hel
 
 Key shared helpers in this repo:
 
-| Helper | Location |
-|---|---|
-| `API_ROUTES` | `src/config/apiRoutes.ts` |
-| `EVENT_TYPES` / `EventType` | `src/types/events.ts` |
-| `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace/paths.ts` |
-| `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` |
-| `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` |
-| `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` |
-| `EVENT_TYPES` / `EventType` | `src/types/events.ts` |
-| `writeFileAtomic` / `writeFileAtomicSync` | `server/utils/files/atomic.ts` |
-| `readWorkspaceText` / `writeWorkspaceText` | `server/utils/files/workspace-io.ts` |
-| `readWorkspaceJson` / `writeWorkspaceJson` | `server/utils/files/workspace-io.ts` |
-| `resolveWithinRoot(root, relPath)` | `server/utils/files/safe.ts` |
-| `statSafe` / `readDirSafe` | `server/utils/files/safe.ts` |
-| `loadJsonFile` / `saveJsonFile` | `server/utils/files/json.ts` |
-| `errorMessage(err)` | `server/utils/errors.ts` |
-| `dispatchResponse(res, result)` | `server/api/routes/dispatchResponse.ts` |
-| `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS` | `server/utils/time.ts` |
-| `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `server/utils/time.ts` |
-| `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES` | `@receptron/task-scheduler` |
-| `useFreshPluginData(opts)` | `src/composables/useFreshPluginData.ts` |
-| `useCanvasViewMode(opts)` | `src/composables/useCanvasViewMode.ts` |
-| `applyViewToQuery(query, mode)` | `src/composables/useCanvasViewMode.ts` |
+| Helper                                                                                     | Location                                |
+| ------------------------------------------------------------------------------------------ | --------------------------------------- |
+| `API_ROUTES`                                                                               | `src/config/apiRoutes.ts`               |
+| `EVENT_TYPES` / `EventType`                                                                | `src/types/events.ts`                   |
+| `WORKSPACE_PATHS` / `WORKSPACE_DIRS`                                                       | `server/workspace/paths.ts`             |
+| `TOOL_NAMES` / `ToolName`                                                                  | `src/config/toolNames.ts`               |
+| `BUILTIN_ROLE_IDS` / `BuiltInRoleId`                                                       | `src/config/roles.ts`                   |
+| `PUBSUB_CHANNELS` / `sessionChannel()`                                                     | `src/config/pubsubChannels.ts`          |
+| `EVENT_TYPES` / `EventType`                                                                | `src/types/events.ts`                   |
+| `writeFileAtomic` / `writeFileAtomicSync`                                                  | `server/utils/files/atomic.ts`          |
+| `readWorkspaceText` / `writeWorkspaceText`                                                 | `server/utils/files/workspace-io.ts`    |
+| `readWorkspaceJson` / `writeWorkspaceJson`                                                 | `server/utils/files/workspace-io.ts`    |
+| `resolveWithinRoot(root, relPath)`                                                         | `server/utils/files/safe.ts`            |
+| `statSafe` / `readDirSafe`                                                                 | `server/utils/files/safe.ts`            |
+| `loadJsonFile` / `saveJsonFile`                                                            | `server/utils/files/json.ts`            |
+| `errorMessage(err)`                                                                        | `server/utils/errors.ts`                |
+| `dispatchResponse(res, result)`                                                            | `server/api/routes/dispatchResponse.ts` |
+| `ONE_SECOND_MS` / `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS`                           | `server/utils/time.ts`                  |
+| `SUBPROCESS_PROBE_TIMEOUT_MS` / `SUBPROCESS_WORK_TIMEOUT_MS` / `CLI_SUBPROCESS_TIMEOUT_MS` | `server/utils/time.ts`                  |
+| `SCHEDULE_TYPES` / `TASK_RESULTS` / `TASK_TRIGGERS` / `MISSED_RUN_POLICIES`                | `@receptron/task-scheduler`             |
+| `useFreshPluginData(opts)`                                                                 | `src/composables/useFreshPluginData.ts` |
+| `useCanvasViewMode(opts)`                                                                  | `src/composables/useCanvasViewMode.ts`  |
+| `applyViewToQuery(query, mode)`                                                            | `src/composables/useCanvasViewMode.ts`  |
 
 Periodically audit for duplication (`sonarjs/no-duplicate-string` warnings, `jscpd`). Batch low-risk extractions into a single refactor PR (as #145 did).
 
@@ -373,13 +386,13 @@ Periodically audit for duplication (`sonarjs/no-duplicate-string` warnings, `jsc
 
 **Where to put what:**
 
-| Layer | Location | Example |
-|---|---|---|
-| **Domain I/O** (highest) | `server/utils/files/<domain>-io.ts` | `readSessionMeta(id)`, `saveTodos(items)`, `writeDailySummary(date, content)` |
-| **Generic workspace I/O** | `server/utils/files/workspace-io.ts` | `readWorkspaceText(relPath)`, `writeWorkspaceJson(relPath, data)` |
-| **Atomic primitives** | `server/utils/files/atomic.ts` | `writeFileAtomic(absPath, content)` |
-| **Safe wrappers** | `server/utils/files/safe.ts` | `resolveWithinRoot(root, relPath)`, `readTextSafeSync(absPath)` |
-| **Path constants** | `server/workspace/paths.ts` | `WORKSPACE_DIRS.chat`, `WORKSPACE_FILES.todosItems` |
+| Layer                     | Location                             | Example                                                                       |
+| ------------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| **Domain I/O** (highest)  | `server/utils/files/<domain>-io.ts`  | `readSessionMeta(id)`, `saveTodos(items)`, `writeDailySummary(date, content)` |
+| **Generic workspace I/O** | `server/utils/files/workspace-io.ts` | `readWorkspaceText(relPath)`, `writeWorkspaceJson(relPath, data)`             |
+| **Atomic primitives**     | `server/utils/files/atomic.ts`       | `writeFileAtomic(absPath, content)`                                           |
+| **Safe wrappers**         | `server/utils/files/safe.ts`         | `resolveWithinRoot(root, relPath)`, `readTextSafeSync(absPath)`               |
+| **Path constants**        | `server/workspace/paths.ts`          | `WORKSPACE_DIRS.chat`, `WORKSPACE_FILES.todosItems`                           |
 
 **Adding a new domain I/O module:**
 
@@ -392,13 +405,13 @@ Periodically audit for duplication (`sonarjs/no-duplicate-string` warnings, `jsc
 
 **Existing domain I/O modules:**
 
-| Module | Functions |
-|---|---|
-| `session-io.ts` | `readSessionMeta`, `createSessionMeta`, `backfillFirstUserMessage`, `setClaudeSessionId`, `clearClaudeSessionId`, `updateHasUnread`, `readSessionJsonl`, `appendSessionLine`, `ensureChatDir` |
-| `todos-io.ts` | `loadTodos`, `saveTodos`, `loadColumns`, `saveColumns` |
-| `scheduler-io.ts` | `loadSchedulerItems`, `saveSchedulerItems` |
-| `html-io.ts` | `readCurrentHtml`, `writeCurrentHtml` |
-| `journal-io.ts` | `readDailySummary`, `writeDailySummary`, `readTopicFile`, `writeTopicFile`, `appendOrCreateTopic`, `readJournalState`, `writeJournalState`, `writeJournalIndex`, `listTopicSlugs`, `archiveTopic`, `listDailyFiles`, `countArchivedTopics` |
+| Module            | Functions                                                                                                                                                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `session-io.ts`   | `readSessionMeta`, `createSessionMeta`, `backfillFirstUserMessage`, `setClaudeSessionId`, `clearClaudeSessionId`, `updateHasUnread`, `readSessionJsonl`, `appendSessionLine`, `ensureChatDir`                                              |
+| `todos-io.ts`     | `loadTodos`, `saveTodos`, `loadColumns`, `saveColumns`                                                                                                                                                                                     |
+| `scheduler-io.ts` | `loadSchedulerItems`, `saveSchedulerItems`                                                                                                                                                                                                 |
+| `html-io.ts`      | `readCurrentHtml`, `writeCurrentHtml`                                                                                                                                                                                                      |
+| `journal-io.ts`   | `readDailySummary`, `writeDailySummary`, `readTopicFile`, `writeTopicFile`, `appendOrCreateTopic`, `readJournalState`, `writeJournalState`, `writeJournalIndex`, `listTopicSlugs`, `archiveTopic`, `listDailyFiles`, `countArchivedTopics` |
 
 ### Network I/O — centralized API helpers
 
@@ -466,7 +479,7 @@ plans/done/       ← completed plans (moved here when the PR lands)
 ```
 
 - **Plan files lifecycle**: create under `plans/` before implementation; move to `plans/done/` in the PR that completes the work. Never delete — `plans/done/` is the archive.
-- Group by *what files are about*, not file kind. `src/plugins/wiki/` keeps def/index/View/Preview together.
+- Group by _what files are about_, not file kind. `src/plugins/wiki/` keeps def/index/View/Preview together.
 - Mirror source layout in `test/`. `server/workspace/journal/dailyPass.ts` → `test/journal/test_dailyPass.ts`.
 - Prefer a new named directory over dropping files into the closest pre-existing bucket.
 
@@ -532,7 +545,7 @@ Some behaviours can't be covered by E2E — drag-and-drop via `vuedraggable` / S
 
 - MUST update [`docs/manual-testing.md`](docs/manual-testing.md) whenever a change deliberately leaves a scenario uncovered by E2E — add an entry with the flow, the reason it can't be automated, and how to smoke-check it.
 - MUST remove / strike-through an entry when a change brings a previously-manual scenario under E2E coverage.
-- Per-PR smoke-test notes go in the PR description, NOT in this doc. The doc is for *persistent* manual-test obligations only.
+- Per-PR smoke-test notes go in the PR description, NOT in this doc. The doc is for _persistent_ manual-test obligations only.
 
 See `plans/` entries and past PR descriptions (#193 wiki-backlinks, #195 tool-trace, #209 todo-items-crud) for examples of cleanly separating "E2E covers this" from "manual check after each release covers this".
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx @mulmobridge/cli@latest      # CLI bridge
 npx @mulmobridge/telegram@latest # Telegram bridge
 ```
 
-See [`docs/message_apps/telegram/README.md`](docs/message_apps/telegram/README.md) for Telegram bot setup (BotFather, chat ID allowlist, etc.).
+Both bridges support **real-time text streaming** (typing updates as the agent writes) and **file attachments** (images, PDFs, DOCX, XLSX, PPTX). See [`docs/message_apps/telegram/README.md`](docs/message_apps/telegram/README.md) for Telegram bot setup (BotFather, chat ID allowlist, etc.).
 
 ### Why do you need a Gemini API key?
 
@@ -133,7 +133,7 @@ MulmoClaude can list and launch the **Claude Code skills** you already have. A s
 ### How to use
 
 1. Open MulmoClaude and stay in one of the skill-enabled roles: **General**, **Office**, or **Tutor**.
-2. Ask Claude to show your skills — e.g. *"show my skills"* or *"list skills"*.
+2. Ask Claude to show your skills — e.g. _"show my skills"_ or _"list skills"_.
 3. Claude invokes the `manageSkills` tool, and a split-pane **Skills** view opens in the canvas:
    - **Left**: every skill discovered on your machine, with its description and scope badge (`USER` / `PROJECT`).
    - **Right**: the full `SKILL.md` content of the selected skill.
@@ -143,10 +143,10 @@ No extra typing, no copy-pasting SKILL.md bodies — the Run button is a one-cli
 
 ### Skill discovery — two scopes
 
-| Scope       | Location                                | Semantics                                                                                 |
-| ----------- | --------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **User**    | `~/.claude/skills/<name>/SKILL.md`      | Personal skills, shared across every project you open with the Claude CLI.                |
-| **Project** | `~/mulmoclaude/.claude/skills/<name>/`  | MulmoClaude-workspace-scoped skills. Project scope **wins** if a name collides with user. |
+| Scope       | Location                               | Semantics                                                                                 |
+| ----------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **User**    | `~/.claude/skills/<name>/SKILL.md`     | Personal skills, shared across every project you open with the Claude CLI.                |
+| **Project** | `~/mulmoclaude/.claude/skills/<name>/` | MulmoClaude-workspace-scoped skills. Project scope **wins** if a name collides with user. |
 
 Both scopes are read-only in phase 0 — edits happen on the file system. A future release will let MulmoClaude itself create / edit project-scope skills.
 
@@ -423,16 +423,33 @@ You don't need to list `mcp__<id>` entries for servers defined in `mcp.json` —
 
 Paste (Ctrl+V / Cmd+V) or drag-and-drop files into the chat input to send them to Claude alongside your message.
 
-| File type | What Claude sees | Dependency |
-|---|---|---|
-| Image (PNG, JPEG, GIF, WebP, …) | Vision content block (native) | None |
-| PDF | Document content block (native) | None |
-| Text (.txt, .csv, .json, .md, .xml, .html, .yaml) | Decoded UTF-8 text | None |
-| DOCX | Extracted plain text | `mammoth` (npm) |
-| XLSX | CSV per sheet | `xlsx` (npm) |
-| PPTX | Converted to PDF | LibreOffice (Docker sandbox) |
+| File type                                         | What Claude sees                | Dependency                   |
+| ------------------------------------------------- | ------------------------------- | ---------------------------- |
+| Image (PNG, JPEG, GIF, WebP, …)                   | Vision content block (native)   | None                         |
+| PDF                                               | Document content block (native) | None                         |
+| Text (.txt, .csv, .json, .md, .xml, .html, .yaml) | Decoded UTF-8 text              | None                         |
+| DOCX                                              | Extracted plain text            | `mammoth` (npm)              |
+| XLSX                                              | CSV per sheet                   | `xlsx` (npm)                 |
+| PPTX                                              | Converted to PDF                | LibreOffice (Docker sandbox) |
 
 PPTX conversion runs inside the Docker sandbox image (`libreoffice --headless`). Without Docker, a message suggests exporting to PDF or images instead. Maximum attachment size is 30 MB.
+
+## Canvas view modes
+
+The canvas (right panel) supports 8 view modes, switchable via the launcher toolbar, URL query param, or keyboard shortcut:
+
+| Shortcut     | View      | URL param         | Description                      |
+| ------------ | --------- | ----------------- | -------------------------------- |
+| `Cmd/Ctrl+1` | Single    | (default)         | Show the selected tool result    |
+| `Cmd/Ctrl+2` | Stack     | `?view=stack`     | All results stacked vertically   |
+| `Cmd/Ctrl+3` | Files     | `?view=files`     | Workspace file explorer          |
+| `Cmd/Ctrl+4` | Todos     | `?view=todos`     | Kanban / table / list todo board |
+| `Cmd/Ctrl+5` | Scheduler | `?view=scheduler` | Scheduled tasks calendar         |
+| `Cmd/Ctrl+6` | Wiki      | `?view=wiki`      | Wiki page index                  |
+| `Cmd/Ctrl+7` | Skills    | `?view=skills`    | Skills list and editor           |
+| `Cmd/Ctrl+8` | Roles     | `?view=roles`     | Role management                  |
+
+Every view mode is URL-driven: clicking a launcher button updates `?view=`, and landing on a URL with `?view=todos` (for example) restores the corresponding view. The view mode list is defined once in `src/utils/canvas/viewMode.ts` — adding a new mode is a single array append.
 
 ## Workspace
 
@@ -452,8 +469,7 @@ See [`docs/developer.md`](docs/developer.md#workspace-layout-mulmoclaude) for th
 
 ### Todo explorer
 
-Selecting `data/todos/todos.json` in the file explorer opens a full **Todo
-Explorer** with three view modes:
+The Todo Explorer is accessible via `Cmd/Ctrl+4`, the Todos launcher button, or by selecting `data/todos/todos.json` in the file explorer. It provides three sub-view modes:
 
 - **Kanban** — GitHub Projects-style columns. Drag cards between
   columns to change status. Each column has a menu to rename, mark as
@@ -472,16 +488,37 @@ The chat-side `manageTodoList` MCP tool keeps its existing behaviour
 unchanged — it can read and edit text / note / labels / completed
 todos, and the explorer's extra fields are preserved across MCP edits.
 
+### Scheduler and skill scheduling
+
+The scheduler (`Cmd/Ctrl+5` or `?view=scheduler`) manages recurring tasks stored in `data/scheduler/items.json`. The scheduler core (`@receptron/task-scheduler`) handles catch-up logic for missed runs and supports `interval`, `daily`, and `cron` schedules.
+
+Skills can be scheduled to run automatically by adding a `schedule` field to the SKILL.md frontmatter:
+
+```yaml
+---
+description: Morning news digest
+schedule: daily 08:00
+---
+```
+
+Claude will register the skill with the scheduler, and it runs automatically on the specified schedule.
+
+### Memory extraction
+
+Claude automatically extracts durable user facts from chat conversations and appends them to `conversations/memory.md`. This runs as part of the journal daily pass — facts like food preferences, work habits, and tool preferences are distilled from recent chats without user intervention. The memory file is always loaded into the agent context so Claude can personalize responses.
+
 ## Monorepo Packages
 
 Shared code is extracted into publishable npm packages under `packages/`:
 
-| Package | Description |
-|---|---|
-| `@mulmobridge/protocol` | Shared types and constants (EVENT_TYPES, Attachment, socket events) |
-| `@mulmobridge/client` | Socket.io client library + bearer token reader + MIME utilities |
-| `@mulmobridge/chat-service` | Server-side chat service (socket.io + REST bridge, DI factory) |
-| `@mulmobridge/cli` | Interactive terminal bridge (`yarn cli` or `npx @mulmobridge/cli`) |
-| `@mulmobridge/telegram` | Telegram bot bridge (`yarn telegram` or `npx @mulmobridge/telegram`) |
+| Package                     | Description                                                                 | Links                                                                                     |
+| --------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `@mulmobridge/protocol`     | Shared types and constants (EVENT_TYPES, Attachment, socket events)         | [source](packages/protocol/)                                                              |
+| `@mulmobridge/client`       | Socket.io client library + bearer token reader + MIME utilities             | [source](packages/client/)                                                                |
+| `@mulmobridge/chat-service` | Server-side chat service (socket.io + REST bridge, DI factory)              | [source](packages/chat-service/)                                                          |
+| `@mulmobridge/cli`          | Interactive terminal bridge (`yarn cli` or `npx @mulmobridge/cli`)          | [npm](https://www.npmjs.com/package/@mulmobridge/cli) / [source](packages/cli/)           |
+| `@mulmobridge/telegram`     | Telegram bot bridge (`yarn telegram` or `npx @mulmobridge/telegram`)        | [npm](https://www.npmjs.com/package/@mulmobridge/telegram) / [source](packages/telegram/) |
+| `@receptron/task-scheduler` | Persistent task scheduler with catch-up — recurring tasks, restart recovery | [source](packages/scheduler/)                                                             |
+| `@mulmobridge/mock-server`  | Lightweight mock server for bridge integration testing                      | [source](packages/mock-server/)                                                           |
 
 Anyone can write a bridge in any language — just speak the socket.io protocol documented in [`docs/bridge-protocol.md`](docs/bridge-protocol.md).

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -46,61 +46,61 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 
 ### API keys
 
-| Variable | Used by | Notes |
-|---|---|---|
-| `GEMINI_API_KEY` | `server/utils/gemini.ts` | Enables Gemini image generation / editing. Without it, image plugins surface a UI warning. The `geminiAvailable` flag in `GET /api/health` mirrors this. |
-| `X_BEARER_TOKEN` | `server/agent/mcp-tools/x.ts` | **Required** to enable `readXPost` / `searchX` MCP tools. Tools are silently disabled if absent. |
-| `TELEGRAM_BOT_TOKEN` | `@mulmobridge/telegram` | **Required** for the Telegram bridge. BotFather token. Treat like a password. See [`message_apps/telegram/`](message_apps/telegram/). |
-| `TELEGRAM_ALLOWED_CHAT_IDS` | `@mulmobridge/telegram` | CSV of integer Telegram chat IDs allowed to message the bot. Empty / unset → deny everyone. A non-integer entry halts startup. |
-| `TELEGRAM_POLL_TIMEOUT_SEC` | `@mulmobridge/telegram` | Long-polling timeout in seconds. Defaults `25` (Telegram's recommended max). |
+| Variable                    | Used by                       | Notes                                                                                                                                                    |
+| --------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`            | `server/utils/gemini.ts`      | Enables Gemini image generation / editing. Without it, image plugins surface a UI warning. The `geminiAvailable` flag in `GET /api/health` mirrors this. |
+| `X_BEARER_TOKEN`            | `server/agent/mcp-tools/x.ts` | **Required** to enable `readXPost` / `searchX` MCP tools. Tools are silently disabled if absent.                                                         |
+| `TELEGRAM_BOT_TOKEN`        | `@mulmobridge/telegram`       | **Required** for the Telegram bridge. BotFather token. Treat like a password. See [`message_apps/telegram/`](message_apps/telegram/).                    |
+| `TELEGRAM_ALLOWED_CHAT_IDS` | `@mulmobridge/telegram`       | CSV of integer Telegram chat IDs allowed to message the bot. Empty / unset → deny everyone. A non-integer entry halts startup.                           |
+| `TELEGRAM_POLL_TIMEOUT_SEC` | `@mulmobridge/telegram`       | Long-polling timeout in seconds. Defaults `25` (Telegram's recommended max).                                                                             |
 
 ### Runtime
 
-| Variable | Default | Effect |
-|---|---|---|
-| `PORT` | `3001` | Express listen port (`server/index.ts:47`). |
-| `NODE_ENV` | unset / `production` | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually. |
-| `DISABLE_SANDBOX` | unset | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/system/docker.ts:49`, `server/index.ts:147`). |
-| `SANDBOX_SSH_AGENT_FORWARD` | unset | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md). |
-| `SANDBOX_MOUNT_CONFIGS` | unset | CSV of allowlisted config mounts (currently `gh`, `gitconfig`). Each entry resolves to a fixed host→container path pair defined in `server/agent/sandboxMounts.ts`; unknown names are logged and ignored. |
-| `SESSIONS_LIST_WINDOW_DAYS` | `90` | Caps how far back the sidebar looks when listing chat sessions (`server/api/routes/sessions.ts`). Set to `0` to disable the cutoff entirely. Introduced in PR #203 to keep `GET /api/sessions` cheap on long-lived workspaces; anything older is still on disk, just hidden from the list. |
+| Variable                    | Default              | Effect                                                                                                                                                                                                                                                                                     |
+| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PORT`                      | `3001`               | Express listen port (`server/index.ts:47`).                                                                                                                                                                                                                                                |
+| `NODE_ENV`                  | unset / `production` | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually.                                                                                                     |
+| `DISABLE_SANDBOX`           | unset                | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/system/docker.ts:49`, `server/index.ts:147`).                                                        |
+| `SANDBOX_SSH_AGENT_FORWARD` | unset                | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md).                                                                        |
+| `SANDBOX_MOUNT_CONFIGS`     | unset                | CSV of allowlisted config mounts (currently `gh`, `gitconfig`). Each entry resolves to a fixed host→container path pair defined in `server/agent/sandboxMounts.ts`; unknown names are logged and ignored.                                                                                  |
+| `SESSIONS_LIST_WINDOW_DAYS` | `90`                 | Caps how far back the sidebar looks when listing chat sessions (`server/api/routes/sessions.ts`). Set to `0` to disable the cutoff entirely. Introduced in PR #203 to keep `GET /api/sessions` cheap on long-lived workspaces; anything older is still on disk, just hidden from the list. |
 
 ### Debug startup hooks
 
 Both gate idempotent backfills that normally run on a schedule. Set to `1` to force-run once at server start (`server/index.ts:197`, `:209`):
 
-| Variable | Forces |
-|---|---|
-| `JOURNAL_FORCE_RUN_ON_STARTUP` | A full daily journal pass over the workspace at boot. |
+| Variable                          | Forces                                                            |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `JOURNAL_FORCE_RUN_ON_STARTUP`    | A full daily journal pass over the workspace at boot.             |
 | `CHAT_INDEX_FORCE_RUN_ON_STARTUP` | A backfill of session titles / summaries for every existing chat. |
 
 ### Logger (`LOG_*`)
 
 The structured logger (`server/system/logger/`) reads its config fresh at process start. Full reference in [`docs/logging.md`](logging.md). Quick map:
 
-| Variable | Default | Values |
-|---|---|---|
-| `LOG_LEVEL` | `info` | Coarse knob — applies to both sinks unless overridden below. `error` \| `warn` \| `info` \| `debug` |
-| `LOG_CONSOLE_LEVEL` / `LOG_FILE_LEVEL` | `info` / `debug` | Per-sink override. |
-| `LOG_CONSOLE_FORMAT` / `LOG_FILE_FORMAT` | `text` / `json` | `text` (human) or `json` (JSONL). |
-| `LOG_CONSOLE_ENABLED` / `LOG_FILE_ENABLED` | `true` / `true` | Boolean. |
-| `LOG_FILE_DIR` | `server/system/logs` | Where rotating daily files land. |
-| `LOG_FILE_MAX_FILES` | `14` | Retention count. |
-| `LOG_TELEMETRY_*` | — | Telemetry sink stub for a future remote shipper. No-op today. |
+| Variable                                   | Default              | Values                                                                                              |
+| ------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL`                                | `info`               | Coarse knob — applies to both sinks unless overridden below. `error` \| `warn` \| `info` \| `debug` |
+| `LOG_CONSOLE_LEVEL` / `LOG_FILE_LEVEL`     | `info` / `debug`     | Per-sink override.                                                                                  |
+| `LOG_CONSOLE_FORMAT` / `LOG_FILE_FORMAT`   | `text` / `json`      | `text` (human) or `json` (JSONL).                                                                   |
+| `LOG_CONSOLE_ENABLED` / `LOG_FILE_ENABLED` | `true` / `true`      | Boolean.                                                                                            |
+| `LOG_FILE_DIR`                             | `server/system/logs` | Where rotating daily files land.                                                                    |
+| `LOG_FILE_MAX_FILES`                       | `14`                 | Retention count.                                                                                    |
+| `LOG_TELEMETRY_*`                          | —                    | Telemetry sink stub for a future remote shipper. No-op today.                                       |
 
 ### Container-only env (auto-set)
 
 You never set these by hand; the server constructs them when spawning Claude inside the Docker sandbox (`server/agent/config.ts` and `server/agent/mcp-server.ts`). They're listed here so log lines / failures involving them are decodable.
 
-| Variable | Set by | Purpose |
-|---|---|---|
-| `SESSION_ID` | per agent run | Session id passed to the MCP stdio bridge. |
-| `PORT` | per agent run | Host server port the bridge connects back to. |
-| `PLUGIN_NAMES` | per agent run | Comma-separated list of plugins active for this session's role. |
-| `ROLE_IDS` | per agent run | Comma-separated list of all role ids. |
-| `MCP_HOST` | container only | `host.docker.internal` so the bridge inside the container can reach the host's Express server. |
-| `NODE_PATH` | container only | `/app/node_modules` — points the container's tsx runtime at the bind-mounted modules. |
-| `HOME` | container only | `/home/node` so Claude CLI finds its credentials at `~/.claude`. |
+| Variable                         | Set by         | Purpose                                                                                                                                      |
+| -------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SESSION_ID`                     | per agent run  | Session id passed to the MCP stdio bridge.                                                                                                   |
+| `PORT`                           | per agent run  | Host server port the bridge connects back to.                                                                                                |
+| `PLUGIN_NAMES`                   | per agent run  | Comma-separated list of plugins active for this session's role.                                                                              |
+| `ROLE_IDS`                       | per agent run  | Comma-separated list of all role ids.                                                                                                        |
+| `MCP_HOST`                       | container only | `host.docker.internal` so the bridge inside the container can reach the host's Express server.                                               |
+| `NODE_PATH`                      | container only | `/app/node_modules` — points the container's tsx runtime at the bind-mounted modules.                                                        |
+| `HOME`                           | container only | `/home/node` so Claude CLI finds its credentials at `~/.claude`.                                                                             |
 | Sentinel `X_BEARER_TOKEN=1` etc. | container only | `isMcpToolEnabled()` re-evaluates inside the container; the actual API call still happens on the host, so we only signal "enabled" with `1`. |
 
 > **There is no `WORKSPACE_PATH` env var.** The workspace path is hard-coded to `~/mulmoclaude` in `server/workspace/workspace.ts:11`. To experiment with multiple workspaces you currently need a code change or a symlink swap.
@@ -111,44 +111,46 @@ You never set these by hand; the server constructs them when spawning Claude ins
 
 ### Development
 
-| Script | What it does |
-|---|---|
-| `yarn dev` | Server (`:3001`) + Vite client (`:5173`) concurrently. The default. |
-| `yarn dev:debug` | Same as `dev` but spawns the server with `--debug` (Node inspector ready). |
-| `yarn dev:client` | Vite client only — useful when you've already started the server elsewhere. |
-| `yarn dev:server` / `yarn server` | Express server only. |
-| `yarn server:debug` | Server with `--debug` flag. |
-| `yarn cli` | CLI bridge — REPL in your terminal that talks to the running server (see [`bridge-protocol.md`](bridge-protocol.md)). |
-| `yarn telegram` | Telegram bridge — operator guide at [`message_apps/telegram/`](message_apps/telegram/) (JP: [`README.ja.md`](message_apps/telegram/README.ja.md) / EN: [`README.md`](message_apps/telegram/README.md)). |
+| Script                            | What it does                                                                                                                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `yarn dev`                        | Server (`:3001`) + Vite client (`:5173`) concurrently. The default.                                                                                                                                     |
+| `yarn dev:debug`                  | Same as `dev` but spawns the server with `--debug` (Node inspector ready).                                                                                                                              |
+| `yarn dev:client`                 | Vite client only — useful when you've already started the server elsewhere.                                                                                                                             |
+| `yarn dev:server` / `yarn server` | Express server only.                                                                                                                                                                                    |
+| `yarn server:debug`               | Server with `--debug` flag.                                                                                                                                                                             |
+| `yarn cli`                        | CLI bridge — REPL in your terminal that talks to the running server (see [`bridge-protocol.md`](bridge-protocol.md)).                                                                                   |
+| `yarn telegram`                   | Telegram bridge — operator guide at [`message_apps/telegram/`](message_apps/telegram/) (JP: [`README.ja.md`](message_apps/telegram/README.ja.md) / EN: [`README.md`](message_apps/telegram/README.md)). |
 
 ### Static checks
 
-| Script | Notes |
-|---|---|
-| `yarn lint` | ESLint on `src/` and `server/`. CI-blocking. |
-| `yarn format` | Prettier auto-fix on `{src,server,test}/**/*.{ts,json,yaml,vue}`. |
-| `yarn typecheck` | `vue-tsc --noEmit` for the client. |
+| Script                  | Notes                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| `yarn lint`             | ESLint on `src/` and `server/`. CI-blocking.                                       |
+| `yarn format`           | Prettier auto-fix on `{src,server,test}/**/*.{ts,json,yaml,vue}`.                  |
+| `yarn typecheck`        | `vue-tsc --noEmit` for the client.                                                 |
 | `yarn typecheck:server` | `tsc -p server/tsconfig.json --noEmit` for the server (separate, stricter config). |
-| `yarn build` | Vite client build → `dist/client`, then server typecheck. |
-| `yarn build:client` | Client build only. |
+| `yarn build`            | Vite client build → `dist/client`, then server typecheck.                          |
+| `yarn build:client`     | Client build only.                                                                 |
 
 ### Tests
 
-| Script | Notes |
-|---|---|
-| `yarn test` | Node `node:test` unit suite. Globs across `test/*/test_*.ts` and 1–3 levels deep. |
-| `yarn test:coverage` | Same but with `--experimental-test-coverage`. CI uses this. |
-| `yarn test:e2e` | Playwright (Chromium headless). Auto-starts Vite dev client. |
-| `yarn test:e2e -- tests/smoke.spec.ts` | Single file. |
-| `yarn test:e2e -- --headed` | Visible browser, useful for debugging. |
+| Script                                               | Notes                                                                                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `yarn test`                                          | Node `node:test` unit suite. Globs across `test/*/test_*.ts` and 1–3 levels deep.                                                     |
+| `yarn test:coverage`                                 | Same but with `--experimental-test-coverage`. CI uses this.                                                                           |
+| `yarn test:e2e`                                      | Playwright (Chromium headless). Auto-starts Vite dev client.                                                                          |
+| `yarn test:e2e -- tests/smoke.spec.ts`               | Single file.                                                                                                                          |
+| `yarn test:e2e -- --headed`                          | Visible browser, useful for debugging.                                                                                                |
+| `npx tsx --test test/agent/test_mcp_smoke.ts`        | MCP server subprocess smoke test (CI).                                                                                                |
+| `npx tsx --test test/agent/test_mcp_docker_smoke.ts` | MCP server Docker smoke test (local only, requires `mulmoclaude-sandbox` image). Run after changing package exports or Docker mounts. |
 
 ### Docker sandbox
 
-| Script | Notes |
-|---|---|
-| `yarn sandbox:remove` | `docker rmi mulmoclaude-sandbox` — force a rebuild on next run. |
-| `yarn sandbox:login` | macOS only. Exports the Claude CLI keychain entry to `~/.claude/.credentials.json` so the sandbox container can reuse it. |
-| `yarn sandbox:logout` | Removes that file. |
+| Script                | Notes                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `yarn sandbox:remove` | `docker rmi mulmoclaude-sandbox` — force a rebuild on next run.                                                           |
+| `yarn sandbox:login`  | macOS only. Exports the Claude CLI keychain entry to `~/.claude/.credentials.json` so the sandbox container can reuse it. |
+| `yarn sandbox:logout` | Removes that file.                                                                                                        |
 
 ---
 
@@ -219,14 +221,14 @@ Every HTTP call to `/api/*` requires `Authorization: Bearer <token>`. Layered on
 
 **Token lifecycle**
 
-| Event | What happens |
-|---|---|
-| Server start | `generateAndWriteToken()` writes a fresh 32-byte hex token to `<workspace>/.session-token` (mode 0600) |
+| Event                            | What happens                                                                                                                           |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Server start                     | `generateAndWriteToken()` writes a fresh 32-byte hex token to `<workspace>/.session-token` (mode 0600)                                 |
 | Vue page load / reload / new tab | Vite plugin (dev) / Express handler (prod) reads the file and substitutes `<meta name="mulmoclaude-auth" content="…">` into index.html |
-| Vue bootstrap (`src/main.ts`) | Reads the meta tag, calls `setAuthToken()` so every `apiFetch` attaches the header |
-| HMR | No file I/O — token stays in Vue memory, SPA never reloads |
-| `SIGINT` / `SIGTERM` | Best-effort `unlink` of `.session-token` |
-| Crash / `kill -9` | File may linger — harmless, next startup generates a new token and the stale value no longer matches |
+| Vue bootstrap (`src/main.ts`)    | Reads the meta tag, calls `setAuthToken()` so every `apiFetch` attaches the header                                                     |
+| HMR                              | No file I/O — token stays in Vue memory, SPA never reloads                                                                             |
+| `SIGINT` / `SIGTERM`             | Best-effort `unlink` of `.session-token`                                                                                               |
+| Crash / `kill -9`                | File may linger — harmless, next startup generates a new token and the stale value no longer matches                                   |
 
 **Dev-mode escape hatch**: setting `MULMOCLAUDE_AUTH_TOKEN=…` before `yarn dev:client` makes the Vite plugin use that value instead of reading the file. Used by `e2e/playwright.config.ts` to inject a predictable token in E2E; also handy for debugging without a running server. Production (Express serving built HTML) never reads env — the in-memory token from `generateAndWriteToken()` is the sole source.
 
@@ -235,6 +237,7 @@ Every HTTP call to `/api/*` requires `Authorization: Bearer <token>`. Layered on
 **Current scope** (#272 Phase 1+2): Vue client, Express middleware, and the CLI bridge (`yarn cli`). The bridge reads the same `.session-token` file (or `MULMOCLAUDE_AUTH_TOKEN` env var) on startup and attaches the header to its `fetch` calls.
 
 **Files**
+
 - `server/api/auth/token.ts` — generate / write / unlink
 - `server/api/auth/bearerAuth.ts` — Express middleware
 - `src/utils/api.ts` — `setAuthToken()` + header injection (no call site changes needed; `apiFetch` auto-attaches)
@@ -246,7 +249,7 @@ Every HTTP call to `/api/*` requires `Authorization: Bearer <token>`. Layered on
 
 ## Notifications (PoC scaffold)
 
-A one-shot, delayed **push fan-out** that lands on every open Web tab *and* every connected bridge simultaneously. Scaffolding for the in-app notification center (#144) and external-channel notifications (#142) — the endpoint and fan-out are stable, the UI / persistence layers land in those issues.
+A one-shot, delayed **push fan-out** that lands on every open Web tab _and_ every connected bridge simultaneously. Scaffolding for the in-app notification center (#144) and external-channel notifications (#142) — the endpoint and fan-out are stable, the UI / persistence layers land in those issues.
 
 ### Trigger
 
@@ -260,12 +263,12 @@ curl -X POST http://localhost:3001/api/notifications/test \
 
 Body fields (all optional):
 
-| Field | Default | Effect |
-|---|---|---|
-| `message` | `"Test notification"` | Text delivered to both targets. |
+| Field          | Default                | Effect                                                                                                |
+| -------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| `message`      | `"Test notification"`  | Text delivered to both targets.                                                                       |
 | `delaySeconds` | `60`, capped at `3600` | Timer length. Non-numeric / NaN falls back to the default; negative clamps to `0`; fractional floors. |
-| `transportId` | `"cli"` | Bridge target for `chatService.pushToBridge`. |
-| `chatId` | `"notifications"` | Bridge chat slot. |
+| `transportId`  | `"cli"`                | Bridge target for `chatService.pushToBridge`.                                                         |
+| `chatId`       | `"notifications"`      | Bridge chat slot.                                                                                     |
 
 ### Fan-out at fire time
 
@@ -299,15 +302,15 @@ Full motivation + file plan: `plans/feat-notification-push-scaffold.md`. Impleme
 
 Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are defined once and imported everywhere. A typo in an import key fails typecheck; a typo in a raw string literal silently produces a runtime 404 or broken channel.
 
-| Constant | Module | Consumers |
-|---|---|---|
-| `API_ROUTES` | `src/config/apiRoutes.ts` | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
-| `EVENT_TYPES` / `EventType` | `src/types/events.ts` | SSE stream emitters, pub-sub session events, chat jsonl parsers, `AgentEvent` union discriminators |
-| `WORKSPACE_PATHS` / `WORKSPACE_DIRS` | `server/workspace/paths.ts` | Every server module that reads or writes workspace files |
-| `TOOL_NAMES` / `ToolName` | `src/config/toolNames.ts` | Role definitions (`availablePlugins`), plugin registry, session-store tool matching |
-| `BUILTIN_ROLE_IDS` / `BuiltInRoleId` | `src/config/roles.ts` | Anywhere a built-in role ID appears outside the role definition itself |
-| `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` | Pub-sub publish/subscribe sites in session-store and task-manager |
-| `EVENT_TYPES` / `EventType` | `src/types/events.ts` | SSE event type discriminants in agent loop, session store, and frontend dispatch |
+| Constant                               | Module                         | Consumers                                                                                                                                            |
+| -------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `API_ROUTES`                           | `src/config/apiRoutes.ts`      | Server route files (`router.post(API_ROUTES.todos.items, ...)`), frontend fetch calls (`fetch(API_ROUTES.todos.items)`), MCP bridge `postJson` calls |
+| `EVENT_TYPES` / `EventType`            | `src/types/events.ts`          | SSE stream emitters, pub-sub session events, chat jsonl parsers, `AgentEvent` union discriminators                                                   |
+| `WORKSPACE_PATHS` / `WORKSPACE_DIRS`   | `server/workspace/paths.ts`    | Every server module that reads or writes workspace files                                                                                             |
+| `TOOL_NAMES` / `ToolName`              | `src/config/toolNames.ts`      | Role definitions (`availablePlugins`), plugin registry, session-store tool matching                                                                  |
+| `BUILTIN_ROLE_IDS` / `BuiltInRoleId`   | `src/config/roles.ts`          | Anywhere a built-in role ID appears outside the role definition itself                                                                               |
+| `PUBSUB_CHANNELS` / `sessionChannel()` | `src/config/pubsubChannels.ts` | Pub-sub publish/subscribe sites in session-store and task-manager                                                                                    |
+| `EVENT_TYPES` / `EventType`            | `src/types/events.ts`          | SSE event type discriminants in agent loop, session store, and frontend dispatch                                                                     |
 
 **Convention**: add new entries to the appropriate module before writing the first consumer. Keep the `as const` assertion so TypeScript infers literal types, not `string`.
 
@@ -319,14 +322,15 @@ Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazil
 
 **Bind mounts** (constructed by `buildDockerSpawnArgs` in `server/agent/config.ts`):
 
-| Host | Container | Mode |
-|---|---|---|
-| `./node_modules` | `/app/node_modules` | ro |
-| `./server` | `/app/server` | ro |
-| `./src` | `/app/src` | ro |
-| `<workspace>` | `/home/node/mulmoclaude` | rw |
-| `~/.claude` | `/home/node/.claude` | rw (credentials) |
-| `~/.claude.json` | `/home/node/.claude.json` | ro |
+| Host             | Container                 | Mode             |
+| ---------------- | ------------------------- | ---------------- |
+| `./node_modules` | `/app/node_modules`       | ro               |
+| `./packages`     | `/app/packages`           | ro               |
+| `./server`       | `/app/server`             | ro               |
+| `./src`          | `/app/src`                | ro               |
+| `<workspace>`    | `/home/node/mulmoclaude`  | rw               |
+| `~/.claude`      | `/home/node/.claude`      | rw (credentials) |
+| `~/.claude.json` | `/home/node/.claude.json` | ro               |
 
 **Path translation**: `resolveMcpConfigPaths()` writes the per-session MCP config to `<workspace>/.mulmoclaude/mcp-<id>.json` on the host and passes the container path to `--mcp-config`.
 
@@ -338,14 +342,14 @@ Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazil
 
 Users can paste or drop files into the chat input. The server converts non-native types before forwarding to Claude.
 
-| Type | Conversion | Claude block | Dependency | Environment |
-|---|---|---|---|---|
-| image/* | None (native) | `type: "image"` | — | All |
-| PDF | None (native) | `type: "document"` | — | All |
-| text/* (.txt, .csv, .json, .md, .xml, .html, .yaml) | base64 → UTF-8 | `type: "text"` | — | All |
-| DOCX | mammoth → plain text | `type: "text"` | `mammoth` (npm) | All |
-| XLSX | xlsx → CSV per sheet | `type: "text"` | `xlsx` (npm) | All |
-| PPTX | libreoffice → PDF | `type: "document"` | LibreOffice | Docker sandbox or native install |
+| Type                                                 | Conversion           | Claude block       | Dependency      | Environment                      |
+| ---------------------------------------------------- | -------------------- | ------------------ | --------------- | -------------------------------- |
+| image/\*                                             | None (native)        | `type: "image"`    | —               | All                              |
+| PDF                                                  | None (native)        | `type: "document"` | —               | All                              |
+| text/\* (.txt, .csv, .json, .md, .xml, .html, .yaml) | base64 → UTF-8       | `type: "text"`     | —               | All                              |
+| DOCX                                                 | mammoth → plain text | `type: "text"`     | `mammoth` (npm) | All                              |
+| XLSX                                                 | xlsx → CSV per sheet | `type: "text"`     | `xlsx` (npm)    | All                              |
+| PPTX                                                 | libreoffice → PDF    | `type: "document"` | LibreOffice     | Docker sandbox or native install |
 
 **PPTX conversion path**: the server process runs on the host (macOS/Linux), but LibreOffice lives inside the Docker sandbox image. `convertPptxToPdf()` in `server/agent/attachmentConverter.ts` tries native `libreoffice` first; if not found, falls back to `docker run --rm -v tmpdir:/data mulmoclaude-sandbox libreoffice --headless --convert-to pdf`. Without either, the user sees a text hint suggesting PDF or image export.
 
@@ -389,14 +393,14 @@ Cross-platform compatibility is a hard requirement — use `node:path` joins, `n
 
 MulmoClaude uses a yarn-workspaces monorepo. Shared code lives in `packages/`, published to npm as independent MIT-licensed packages.
 
-| Package | Scope | Description |
-|---|---|---|
-| `@mulmobridge/protocol` | messaging | Wire protocol types and constants |
-| `@mulmobridge/chat-service` | messaging | Server-side Express + socket.io chat service |
-| `@mulmobridge/client` | messaging | Bridge-side socket.io client library |
-| `@mulmobridge/cli` | messaging | Interactive terminal bridge |
-| `@mulmobridge/telegram` | messaging | Telegram bot bridge |
-| `@receptron/task-scheduler` | general | Persistent task scheduler with catch-up recovery |
+| Package                     | Scope     | Description                                      |
+| --------------------------- | --------- | ------------------------------------------------ |
+| `@mulmobridge/protocol`     | messaging | Wire protocol types and constants                |
+| `@mulmobridge/chat-service` | messaging | Server-side Express + socket.io chat service     |
+| `@mulmobridge/client`       | messaging | Bridge-side socket.io client library             |
+| `@mulmobridge/cli`          | messaging | Interactive terminal bridge                      |
+| `@mulmobridge/telegram`     | messaging | Telegram bot bridge                              |
+| `@receptron/task-scheduler` | general   | Persistent task scheduler with catch-up recovery |
 
 **Build order matters** — `build:packages` in root `package.json` runs them in dependency order. When adding a new package, insert it at the correct position in the chain.
 
@@ -408,7 +412,7 @@ See [`packages/README.md`](../packages/README.md) for the MulmoBridge architectu
 
 ## Common gotchas
 
-- **Vite `reuseExistingServer: true`** in `e2e/playwright.config.ts` — if a stale `vite` process is already serving `:5173` (e.g. from a different working tree), Playwright happily talks to *that* one. Symptom: tests fail because UI changes "haven't landed". Kill the stray process: `lsof -i :5173 | grep LISTEN`.
+- **Vite `reuseExistingServer: true`** in `e2e/playwright.config.ts` — if a stale `vite` process is already serving `:5173` (e.g. from a different working tree), Playwright happily talks to _that_ one. Symptom: tests fail because UI changes "haven't landed". Kill the stray process: `lsof -i :5173 | grep LISTEN`.
 - **CSRF guard is strict.** `requireSameOrigin` (`server/api/csrfGuard.ts`) rejects state-changing requests from non-localhost origins. Requests with no `Origin` header (CLI tools, server-to-server) are allowed because the listener is bound to `127.0.0.1`. If you ever expose the listener publicly, tighten this middleware first.
 - **Workspace is git-init'd.** The first server start creates `~/mulmoclaude/.git`. Don't be surprised when journal / wiki edits show up in `git log`.
 - **`.vue` cognitive-complexity is warn-only.** A few legacy components exceed 15. The override demotes the rule to warn so CI isn't blocked. Each fix should re-raise to error in `eslint.config.mjs`.
@@ -419,11 +423,11 @@ See [`packages/README.md`](../packages/README.md) for the MulmoBridge architectu
 
 ## Where to file what
 
-| Problem area | File / dir |
-|---|---|
-| Adding a new `/api/*` route | `server/api/routes/<name>.ts`, wire in `server/index.ts` |
-| Adding a shared server helper | `server/utils/<concept>.ts` (one concept per file) |
-| Adding a Vue composable | `src/composables/use<Name>.ts` |
-| Adding a plugin | `src/plugins/<name>/{definition,index,View,Preview}.ts/vue` — see CLAUDE.md |
-| Adding a test | `test/<mirrored-source-path>/test_<module>.ts` |
-| New developer-facing doc | `docs/<name>.md` and link from the table at the top of the README |
+| Problem area                  | File / dir                                                                  |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| Adding a new `/api/*` route   | `server/api/routes/<name>.ts`, wire in `server/index.ts`                    |
+| Adding a shared server helper | `server/utils/<concept>.ts` (one concept per file)                          |
+| Adding a Vue composable       | `src/composables/use<Name>.ts`                                              |
+| Adding a plugin               | `src/plugins/<name>/{definition,index,View,Preview}.ts/vue` — see CLAUDE.md |
+| Adding a test                 | `test/<mirrored-source-path>/test_<module>.ts`                              |
+| New developer-facing doc      | `docs/<name>.md` and link from the table at the top of the README           |


### PR DESCRIPTION
## Summary

直近2日間のPRバッチ（#415〜#433）を反映したドキュメント更新。

### README.md
- Canvas view modes テーブル（8モード + Cmd+1-8 キーボードショートカット）
- Scheduler / skill scheduling セクション追加
- Memory extraction（自動ユーザーファクト抽出）セクション追加
- Bridge のテキストストリーミング・添付ファイル対応の記述
- Monorepo packages テーブルに scheduler, mock-server 追加 + npm/source リンク

### CLAUDE.md
- URL scheme を全8ビューモードに拡張（?view=todos/scheduler/wiki/skills/roles）
- キーボードショートカットの説明追加
- Centralized Constants テーブルに WORKSPACE_FILES, VIEW_MODES 追加

### docs/developer.md
- Docker bind mounts テーブルに packages/ 追加
- Tests テーブルに MCP smoke test (CI) + Docker smoke test (local) 追加

## Test plan

- [x] yarn format — clean
- [x] yarn lint — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)