### PR TITLE
refactor: consolidate date/time formatting helpers

### DIFF
--- a/server/workspace/sources/pipeline/index.ts
+++ b/server/workspace/sources/pipeline/index.ts
@@ -50,6 +50,7 @@ import { runFetchPhase, computeNextState, type FetchOutcome } from "./fetch.js";
 import { dedupAcrossSources, type DedupStats } from "./dedup.js";
 import { makeDefaultSummarize, type SummarizeFn } from "./summarize.js";
 import { writeDailyFile, appendItemsToArchives } from "./write.js";
+import { toLocalIsoDate } from "../../../utils/date.js";
 
 export interface RunPipelineInput {
   workspaceRoot: string;
@@ -92,15 +93,8 @@ export interface RunPipelineResult {
 // Convert a wall-clock millis value to YYYY-MM-DD in LOCAL
 // time, matching the #188 Q6 decision ("Local time, like the
 // journal"). The journal's `toIsoDate` in paths.ts uses the
-// same algorithm — duplicated here to avoid a cross-module
-// import that would pull journal code into the sources module.
-export function toLocalIsoDate(ms: number): string {
-  const d = new Date(ms);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
+// Re-export for callers that imported from this module.
+export { toLocalIsoDate } from "../../../utils/date.js";
 
 // Convert a wall-clock millis value to the LOCAL year-month
 // key (YYYY-MM) used as the archive fallback for items without

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -31,7 +31,7 @@
           >· {{ formatBytes(content.size) }}</span
         >
         <span v-if="content?.modifiedMs" class="text-gray-400 shrink-0"
-          >· {{ formatTime(content.modifiedMs) }}</span
+          >· {{ formatDateTime(content.modifiedMs) }}</span
         >
         <button
           v-if="isMarkdown"
@@ -251,6 +251,7 @@ import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRef
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
+import { formatDateTime } from "../utils/format/date";
 import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
@@ -517,15 +518,6 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-}
-
-function formatTime(ms: number): string {
-  return new Date(ms).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 // Fetch the immediate children of one directory via the lazy-expand

--- a/src/components/RightSidebar.vue
+++ b/src/components/RightSidebar.vue
@@ -113,6 +113,7 @@
 <script setup lang="ts">
 import { ref, nextTick } from "vue";
 import type { ToolCallHistoryItem } from "../types/toolCallHistory";
+import { formatTime } from "../utils/format/date";
 
 defineProps<{
   toolCallHistory: ToolCallHistoryItem[];
@@ -132,10 +133,6 @@ function toggleTool(tool: string): void {
     expandedTools.value.add(tool);
   }
   expandedTools.value = new Set(expandedTools.value);
-}
-
-function formatTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString();
 }
 
 function formatJson(obj: unknown): string {

--- a/src/components/todo/TodoTableView.vue
+++ b/src/components/todo/TodoTableView.vue
@@ -86,7 +86,7 @@
               >
             </td>
             <td class="px-3 py-2 text-xs text-gray-400">
-              {{ formatCreated(item.createdAt) }}
+              {{ formatShortDate(item.createdAt) }}
             </td>
             <td class="px-3 py-2 text-right">
               <button
@@ -127,6 +127,7 @@ import {
 } from "../../plugins/todo/priority";
 import type { PatchItemInput } from "../../plugins/todo/composables/useTodos";
 import TodoEditPanel from "./TodoEditPanel.vue";
+import { formatShortDate } from "../../utils/format/date";
 
 type SortKey =
   | "completed"
@@ -236,11 +237,4 @@ const sortedItems = computed(() => {
   });
   return list;
 });
-
-function formatCreated(ms: number): string {
-  return new Date(ms).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
 </script>

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -111,7 +111,7 @@
               {{ task.state.lastRunResult }}
             </span>
             <span v-if="task.state?.nextScheduledAt">
-              Next: {{ formatTime(task.state.nextScheduledAt) }}
+              Next: {{ formatShortTime(task.state.nextScheduledAt) }}
             </span>
           </div>
 
@@ -132,6 +132,7 @@
 import { ref, onMounted } from "vue";
 import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { formatShortTime } from "../../utils/format/date";
 
 interface TaskSchedule {
   type: string;
@@ -202,17 +203,6 @@ function formatSchedule(schedule: TaskSchedule): string {
     return `Daily ${schedule.time} UTC`;
   }
   return JSON.stringify(schedule);
-}
-
-function formatTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
 }
 
 async function runTask(id: string): Promise<void> {

--- a/src/utils/format/date.ts
+++ b/src/utils/format/date.ts
@@ -1,9 +1,8 @@
-// Pure formatting helpers used by the sidebar / history pane.
+// Pure date/time formatting helpers for the Vue frontend.
+// All functions are locale-aware on purpose; tests assert
+// structural properties only, not exact strings.
 
-// "Apr 11 06:32" — short month, numeric day, 24h hour:minute. The
-// implementation is locale-aware on purpose; tests assert structural
-// properties only, not exact strings, since the locale of the test
-// environment is not pinned.
+/** "Apr 11 06:32" — short month + day + 24h time. */
 export function formatDate(iso: string): string {
   const d = new Date(iso);
   return (
@@ -11,4 +10,39 @@ export function formatDate(iso: string): string {
     " " +
     d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
   );
+}
+
+/** "Apr 11 06:32" — same format as formatDate but from epoch ms. */
+export function formatDateTime(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** "06:32:15" — locale time string from epoch ms. */
+export function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString();
+}
+
+/** "06:32" — short HH:MM from ISO string. Falls back to raw string on parse error. */
+export function formatShortTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** "Apr 11" — short month + day from epoch ms. */
+export function formatShortDate(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { formatDate } from "../../../src/utils/format/date.js";
+import {
+  formatDate,
+  formatDateTime,
+  formatTime,
+  formatShortTime,
+  formatShortDate,
+} from "../../../src/utils/format/date.js";
 
 describe("formatDate", () => {
   it("returns a non-empty string for a valid ISO date", () => {
@@ -32,5 +38,44 @@ describe("formatDate", () => {
     const a = formatDate("2026-01-01T12:00:00Z");
     const b = formatDate("2026-12-31T12:00:00Z");
     assert.notEqual(a, b);
+  });
+});
+
+describe("formatDateTime", () => {
+  it("returns a non-empty string from epoch ms", () => {
+    const out = formatDateTime(Date.now());
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+    assert.match(out, /\d/);
+  });
+});
+
+describe("formatTime", () => {
+  it("returns a non-empty string from epoch ms", () => {
+    const out = formatTime(Date.now());
+    assert.equal(typeof out, "string");
+    assert.match(out, /\d/);
+  });
+});
+
+describe("formatShortTime", () => {
+  it("returns a short time from ISO string", () => {
+    const out = formatShortTime("2026-04-10T07:21:39.125Z");
+    assert.equal(typeof out, "string");
+    assert.match(out, /\d/);
+  });
+
+  it("falls back to raw string on parse error", () => {
+    const out = formatShortTime("not a date");
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+  });
+});
+
+describe("formatShortDate", () => {
+  it("returns a short date from epoch ms", () => {
+    const out = formatShortDate(Date.now());
+    assert.equal(typeof out, "string");
+    assert.match(out, /\d/);
   });
 });


### PR DESCRIPTION
## Summary

4コンポーネントに散在していた日時フォーマット関数を `src/utils/format/date.ts` に集約。

### 統合した関数

| 関数 | 元の場所 | 入力 | 出力例 |
|---|---|---|---|
| `formatDateTime(ms)` | FilesView.vue | epoch ms | "Apr 11 06:32" |
| `formatTime(ms)` | RightSidebar.vue | epoch ms | "06:32:15" |
| `formatShortTime(iso)` | TasksTab.vue | ISO string | "06:32" |
| `formatShortDate(ms)` | TodoTableView.vue | epoch ms | "Apr 11" |

### サーバー側

`server/workspace/sources/pipeline/index.ts` の `toLocalIsoDate` を `server/utils/date.ts` からの re-export に置換（コピペ解消）。

## Test plan

- [x] yarn typecheck — pass
- [x] yarn lint — 0 errors
- [x] yarn test — pass（新規テスト4件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)