### PR TITLE
docs: update all documentation for 12 messaging bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn dev
 
 This starts both the frontend (Vite) and the backend (Express + Claude Code agent) concurrently. Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-### Messaging bridges (Telegram, CLI)
+### Messaging bridges
 
 MulmoClaude can be accessed from messaging apps via **bridge processes**. Bridges run as separate child processes and connect to the server over socket.io.
 
@@ -44,11 +44,21 @@ yarn telegram
 Bridges are also available as standalone npm packages:
 
 ```bash
-npx @mulmobridge/cli@latest      # CLI bridge
-npx @mulmobridge/telegram@latest # Telegram bridge
+npx @mulmobridge/cli@latest          # CLI bridge
+npx @mulmobridge/telegram@latest     # Telegram bridge
+npx @mulmobridge/slack@latest        # Slack bridge
+npx @mulmobridge/discord@latest      # Discord bridge
+npx @mulmobridge/line@latest         # LINE bridge
+npx @mulmobridge/whatsapp@latest     # WhatsApp bridge
+npx @mulmobridge/matrix@latest       # Matrix bridge
+npx @mulmobridge/irc@latest          # IRC bridge
+npx @mulmobridge/mattermost@latest   # Mattermost bridge
+npx @mulmobridge/zulip@latest        # Zulip bridge
+npx @mulmobridge/messenger@latest    # Facebook Messenger bridge
+npx @mulmobridge/google-chat@latest  # Google Chat bridge
 ```
 
-Both bridges support **real-time text streaming** (typing updates as the agent writes) and **file attachments** (images, PDFs, DOCX, XLSX, PPTX). See [`docs/message_apps/telegram/README.md`](docs/message_apps/telegram/README.md) for Telegram bot setup (BotFather, chat ID allowlist, etc.).
+All bridges support **real-time text streaming** (typing updates as the agent writes). CLI and Telegram also support **file attachments** (images, PDFs, DOCX, XLSX, PPTX). See [`docs/mulmobridge-guide.md`](docs/mulmobridge-guide.md) for the full platform list and setup instructions.
 
 ### Why do you need a Gemini API key?
 
@@ -511,14 +521,24 @@ Claude automatically extracts durable user facts from chat conversations and app
 
 Shared code is extracted into publishable npm packages under `packages/`:
 
-| Package                     | Description                                                                 | Links                                                                                     |
-| --------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `@mulmobridge/protocol`     | Shared types and constants (EVENT_TYPES, Attachment, socket events)         | [source](packages/protocol/)                                                              |
-| `@mulmobridge/client`       | Socket.io client library + bearer token reader + MIME utilities             | [source](packages/client/)                                                                |
-| `@mulmobridge/chat-service` | Server-side chat service (socket.io + REST bridge, DI factory)              | [source](packages/chat-service/)                                                          |
-| `@mulmobridge/cli`          | Interactive terminal bridge (`yarn cli` or `npx @mulmobridge/cli`)          | [npm](https://www.npmjs.com/package/@mulmobridge/cli) / [source](packages/cli/)           |
-| `@mulmobridge/telegram`     | Telegram bot bridge (`yarn telegram` or `npx @mulmobridge/telegram`)        | [npm](https://www.npmjs.com/package/@mulmobridge/telegram) / [source](packages/telegram/) |
-| `@receptron/task-scheduler` | Persistent task scheduler with catch-up — recurring tasks, restart recovery | [source](packages/scheduler/)                                                             |
-| `@mulmobridge/mock-server`  | Lightweight mock server for bridge integration testing                      | [source](packages/mock-server/)                                                           |
+| Package | Description | Links |
+|---|---|---|
+| `@mulmobridge/protocol` | Shared types and constants (EVENT_TYPES, Attachment, socket events) | [source](packages/protocol/) |
+| `@mulmobridge/client` | Socket.io client library + bearer token reader + MIME utilities | [source](packages/client/) |
+| `@mulmobridge/chat-service` | Server-side chat service (socket.io + REST bridge, DI factory) | [source](packages/chat-service/) |
+| `@mulmobridge/cli` | Interactive terminal bridge | [npm](https://www.npmjs.com/package/@mulmobridge/cli) / [source](packages/cli/) |
+| `@mulmobridge/telegram` | Telegram bot bridge (photo support, allowlist) | [npm](https://www.npmjs.com/package/@mulmobridge/telegram) / [source](packages/telegram/) |
+| `@mulmobridge/slack` | Slack bot bridge (Socket Mode) | [source](packages/slack/) |
+| `@mulmobridge/discord` | Discord bot bridge | [source](packages/discord/) |
+| `@mulmobridge/line` | LINE bot bridge (webhook) | [source](packages/line/) |
+| `@mulmobridge/whatsapp` | WhatsApp Cloud API bridge (webhook) | [source](packages/whatsapp/) |
+| `@mulmobridge/matrix` | Matrix bridge (matrix-js-sdk) | [source](packages/matrix/) |
+| `@mulmobridge/irc` | IRC bridge (irc-framework) | [source](packages/irc/) |
+| `@mulmobridge/mattermost` | Mattermost bridge (WebSocket + REST) | [source](packages/mattermost/) |
+| `@mulmobridge/zulip` | Zulip bridge (long-polling events API) | [source](packages/zulip/) |
+| `@mulmobridge/messenger` | Facebook Messenger bridge (webhook + HMAC) | [source](packages/messenger/) |
+| `@mulmobridge/google-chat` | Google Chat bridge (webhook + JWT verification) | [source](packages/google-chat/) |
+| `@mulmobridge/mock-server` | Lightweight mock server for bridge testing | [source](packages/mock-server/) |
+| `@receptron/task-scheduler` | Persistent task scheduler with catch-up | [source](packages/scheduler/) |
 
 Anyone can write a bridge in any language — just speak the socket.io protocol documented in [`docs/bridge-protocol.md`](docs/bridge-protocol.md).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [0.1.2] - 2026-04-19
+
+### Highlights
+
+- **12 messaging bridges** — MulmoBridge now supports Slack, Discord, LINE, WhatsApp, Matrix, IRC, Mattermost, Zulip, Facebook Messenger, and Google Chat in addition to CLI and Telegram
+- **Security hardening** — Google Chat JWT/OIDC verification, rate limiting + body size limits on webhook bridges, PII redaction in logs
+
+### Added
+
+- `@mulmobridge/slack` (v0.1.0) — Slack bot bridge (Socket Mode, no public URL needed)
+- `@mulmobridge/discord` (v0.1.0) — Discord bot bridge (Partials.Channel for DMs)
+- `@mulmobridge/line` (v0.1.0) — LINE bot bridge (webhook + HMAC signature)
+- `@mulmobridge/whatsapp` (v0.1.0) — WhatsApp Cloud API bridge (webhook + HMAC)
+- `@mulmobridge/matrix` (v0.1.0) — Matrix bridge (matrix-js-sdk, end-to-end encryption ready)
+- `@mulmobridge/irc` (v0.1.0) — IRC bridge (irc-framework, TLS, channel + DM)
+- `@mulmobridge/mattermost` (v0.1.0) — Mattermost bridge (WebSocket + REST, auto-reconnect)
+- `@mulmobridge/zulip` (v0.1.0) — Zulip bridge (long-polling events API)
+- `@mulmobridge/messenger` (v0.1.0) — Facebook Messenger bridge (webhook + x-hub-signature-256 HMAC)
+- `@mulmobridge/google-chat` (v0.1.0) — Google Chat bridge (webhook + JWT/OIDC verification)
+- `@mulmobridge/mock-server` (v0.1.0) — Lightweight mock server for bridge integration testing
+
+### Fixed
+
+- Google Chat webhook now verifies JWT tokens against Google's JWKS endpoint (iss/aud/exp claims)
+- Webhook bridges (Messenger, Google Chat) enforce 1MB body size limit and per-IP rate limiting
+- PII redaction in bridge logs — sender IDs are partially masked
+
+---
+
 ## [0.1.1] - 2026-04-18
 
 ### Highlights
@@ -106,5 +135,6 @@ First tagged release. GUI-chat with Claude Code — chat with Claude and get bac
 
 ---
 
+[0.1.2]: https://github.com/receptron/mulmoclaude/releases/tag/v0.1.2
 [0.1.1]: https://github.com/receptron/mulmoclaude/releases/tag/v0.1.1
 [0.1.0]: https://github.com/receptron/mulmoclaude/releases/tag/v0.1.0

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -398,8 +398,19 @@ MulmoClaude uses a yarn-workspaces monorepo. Shared code lives in `packages/`, p
 | `@mulmobridge/protocol`     | messaging | Wire protocol types and constants                |
 | `@mulmobridge/chat-service` | messaging | Server-side Express + socket.io chat service     |
 | `@mulmobridge/client`       | messaging | Bridge-side socket.io client library             |
+| `@mulmobridge/mock-server`  | messaging | Lightweight mock server for testing              |
 | `@mulmobridge/cli`          | messaging | Interactive terminal bridge                      |
 | `@mulmobridge/telegram`     | messaging | Telegram bot bridge                              |
+| `@mulmobridge/slack`        | messaging | Slack bot bridge (Socket Mode)                   |
+| `@mulmobridge/discord`      | messaging | Discord bot bridge                               |
+| `@mulmobridge/line`         | messaging | LINE bot bridge (webhook)                        |
+| `@mulmobridge/whatsapp`     | messaging | WhatsApp Cloud API bridge (webhook)              |
+| `@mulmobridge/matrix`       | messaging | Matrix bridge (matrix-js-sdk)                    |
+| `@mulmobridge/irc`          | messaging | IRC bridge (irc-framework)                       |
+| `@mulmobridge/mattermost`   | messaging | Mattermost bridge (WebSocket + REST)             |
+| `@mulmobridge/zulip`        | messaging | Zulip bridge (long-polling events API)           |
+| `@mulmobridge/messenger`    | messaging | Facebook Messenger bridge (webhook + HMAC)       |
+| `@mulmobridge/google-chat`  | messaging | Google Chat bridge (webhook + JWT)               |
 | `@receptron/task-scheduler` | general   | Persistent task scheduler with catch-up recovery |
 
 **Build order matters** — `build:packages` in root `package.json` runs them in dependency order. When adding a new package, insert it at the correct position in the chain.

--- a/docs/mulmobridge-guide.md
+++ b/docs/mulmobridge-guide.md
@@ -90,6 +90,10 @@ TELEGRAM_ALLOWED_CHAT_IDS=your-chat-id \
 | **WhatsApp** | [@mulmobridge/whatsapp](https://www.npmjs.com/package/@mulmobridge/whatsapp) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/whatsapp/README.md) |
 | **Matrix** | [@mulmobridge/matrix](https://www.npmjs.com/package/@mulmobridge/matrix) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/matrix/README.md) |
 | **IRC** | [@mulmobridge/irc](https://www.npmjs.com/package/@mulmobridge/irc) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/irc/README.md) |
+| **Mattermost** | [@mulmobridge/mattermost](https://www.npmjs.com/package/@mulmobridge/mattermost) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/mattermost/README.md) |
+| **Zulip** | [@mulmobridge/zulip](https://www.npmjs.com/package/@mulmobridge/zulip) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/zulip/README.md) |
+| **Facebook Messenger** | [@mulmobridge/messenger](https://www.npmjs.com/package/@mulmobridge/messenger) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/messenger/README.md) |
+| **Google Chat** | [@mulmobridge/google-chat](https://www.npmjs.com/package/@mulmobridge/google-chat) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/google-chat/README.md) |
 
 > **「実験的」とは？** テストが十分でなく、バグがある可能性があります。フィードバックをお待ちしています！
 
@@ -215,6 +219,10 @@ if (ack.ok) {
 | [@mulmobridge/whatsapp](https://www.npmjs.com/package/@mulmobridge/whatsapp) | WhatsApp ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/whatsapp) |
 | [@mulmobridge/matrix](https://www.npmjs.com/package/@mulmobridge/matrix) | Matrix ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/matrix) |
 | [@mulmobridge/irc](https://www.npmjs.com/package/@mulmobridge/irc) | IRC ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/irc) |
+| [@mulmobridge/mattermost](https://www.npmjs.com/package/@mulmobridge/mattermost) | Mattermost ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/mattermost) |
+| [@mulmobridge/zulip](https://www.npmjs.com/package/@mulmobridge/zulip) | Zulip ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/zulip) |
+| [@mulmobridge/messenger](https://www.npmjs.com/package/@mulmobridge/messenger) | Facebook Messenger ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/messenger) |
+| [@mulmobridge/google-chat](https://www.npmjs.com/package/@mulmobridge/google-chat) | Google Chat ブリッジ | [source](https://github.com/receptron/mulmoclaude/tree/main/packages/google-chat) |
 
 ### 汎用ツール（@receptron スコープ）
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -25,13 +25,31 @@ A **bridge** is a tiny process (~100 lines) that translates between a messaging 
 
 ## Packages
 
+### Core
+
 | Package | Description | npm |
 |---|---|---|
 | [@mulmobridge/protocol](./protocol/) | Wire protocol types and constants | [![npm](https://img.shields.io/npm/v/@mulmobridge/protocol)](https://www.npmjs.com/package/@mulmobridge/protocol) |
 | [@mulmobridge/chat-service](./chat-service/) | Server-side chat service (Express + socket.io, DI-pure) | [![npm](https://img.shields.io/npm/v/@mulmobridge/chat-service)](https://www.npmjs.com/package/@mulmobridge/chat-service) |
 | [@mulmobridge/client](./client/) | Bridge-side socket.io client library | [![npm](https://img.shields.io/npm/v/@mulmobridge/client)](https://www.npmjs.com/package/@mulmobridge/client) |
-| [@mulmobridge/cli](./cli/) | Terminal bridge — talk to your agent from the command line | [![npm](https://img.shields.io/npm/v/@mulmobridge/cli)](https://www.npmjs.com/package/@mulmobridge/cli) |
-| [@mulmobridge/telegram](./telegram/) | Telegram bot bridge — photo support, chat-ID allowlist | [![npm](https://img.shields.io/npm/v/@mulmobridge/telegram)](https://www.npmjs.com/package/@mulmobridge/telegram) |
+| [@mulmobridge/mock-server](./mock-server/) | Lightweight mock server for testing | [![npm](https://img.shields.io/npm/v/@mulmobridge/mock-server)](https://www.npmjs.com/package/@mulmobridge/mock-server) |
+
+### Bridges
+
+| Package | Description | npm |
+|---|---|---|
+| [@mulmobridge/cli](./cli/) | Terminal bridge | [![npm](https://img.shields.io/npm/v/@mulmobridge/cli)](https://www.npmjs.com/package/@mulmobridge/cli) |
+| [@mulmobridge/telegram](./telegram/) | Telegram bot (photo support, allowlist) | [![npm](https://img.shields.io/npm/v/@mulmobridge/telegram)](https://www.npmjs.com/package/@mulmobridge/telegram) |
+| [@mulmobridge/slack](./slack/) | Slack bot (Socket Mode) | [![npm](https://img.shields.io/npm/v/@mulmobridge/slack)](https://www.npmjs.com/package/@mulmobridge/slack) |
+| [@mulmobridge/discord](./discord/) | Discord bot | [![npm](https://img.shields.io/npm/v/@mulmobridge/discord)](https://www.npmjs.com/package/@mulmobridge/discord) |
+| [@mulmobridge/line](./line/) | LINE bot (webhook) | [![npm](https://img.shields.io/npm/v/@mulmobridge/line)](https://www.npmjs.com/package/@mulmobridge/line) |
+| [@mulmobridge/whatsapp](./whatsapp/) | WhatsApp Cloud API (webhook + HMAC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/whatsapp)](https://www.npmjs.com/package/@mulmobridge/whatsapp) |
+| [@mulmobridge/matrix](./matrix/) | Matrix (matrix-js-sdk) | [![npm](https://img.shields.io/npm/v/@mulmobridge/matrix)](https://www.npmjs.com/package/@mulmobridge/matrix) |
+| [@mulmobridge/irc](./irc/) | IRC (irc-framework) | [![npm](https://img.shields.io/npm/v/@mulmobridge/irc)](https://www.npmjs.com/package/@mulmobridge/irc) |
+| [@mulmobridge/mattermost](./mattermost/) | Mattermost (WebSocket + REST) | [![npm](https://img.shields.io/npm/v/@mulmobridge/mattermost)](https://www.npmjs.com/package/@mulmobridge/mattermost) |
+| [@mulmobridge/zulip](./zulip/) | Zulip (long-polling events API) | [![npm](https://img.shields.io/npm/v/@mulmobridge/zulip)](https://www.npmjs.com/package/@mulmobridge/zulip) |
+| [@mulmobridge/messenger](./messenger/) | Facebook Messenger (webhook + HMAC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/messenger)](https://www.npmjs.com/package/@mulmobridge/messenger) |
+| [@mulmobridge/google-chat](./google-chat/) | Google Chat (webhook + JWT/OIDC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/google-chat)](https://www.npmjs.com/package/@mulmobridge/google-chat) |
 
 ## Quick Start
 
@@ -118,8 +136,19 @@ packages/
   protocol/       ← wire types + constants (zero deps)
   chat-service/   ← server-side Express + socket.io service
   client/         ← bridge-side socket.io client + MIME utils
+  mock-server/    ← test mock server (echo mode)
   cli/            ← reference bridge: interactive terminal
-  telegram/       ← production bridge: Telegram bot
+  telegram/       ← Telegram bot bridge
+  slack/          ← Slack bot bridge (Socket Mode)
+  discord/        ← Discord bot bridge
+  line/           ← LINE bot bridge (webhook)
+  whatsapp/       ← WhatsApp Cloud API bridge (webhook)
+  matrix/         ← Matrix bridge (matrix-js-sdk)
+  irc/            ← IRC bridge (irc-framework)
+  mattermost/     ← Mattermost bridge (WebSocket)
+  zulip/          ← Zulip bridge (long-polling)
+  messenger/      ← Facebook Messenger bridge (webhook)
+  google-chat/    ← Google Chat bridge (webhook + JWT)
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Update README.md: expand messaging bridges section with all 12 platforms, update Monorepo Packages table
- Update packages/README.md: restructure into Core + Bridges sections, add all bridge packages with npm badges
- Update docs/mulmobridge-guide.md: add Mattermost, Zulip, Messenger, Google Chat to platform tables
- Update docs/developer.md: add all bridge packages to monorepo packages table
- Update docs/CHANGELOG.md: add v0.1.2 entry with all new bridges and security fixes

## npm publish

The following packages were published to npm as v0.1.0:
- `@mulmobridge/mattermost`
- `@mulmobridge/zulip`
- `@mulmobridge/messenger`
- `@mulmobridge/google-chat`

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] npm links resolve to published packages
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)