### PR TITLE
docs: rewrite docs/README.md in English

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,45 +1,45 @@
-# MulmoClaude ドキュメント
+# MulmoClaude Documentation
 
-## ユーザー向け / End Users
+## End Users
 
-使い方や機能の説明。プログラミングの知識がなくても読めるように書いています。
+Guides for using MulmoClaude. No programming knowledge required.
 
-| ドキュメント | 言語 | 説明 |
+| Document | Language | Description |
 |---|---|---|
-| [MulmoBridge ガイド](mulmobridge-guide.md) | 日本語 | メッセージアプリから自宅PCのAIと話す方法。仕組み、設定方法、ダミーサーバーの使い方 |
-| [MulmoBridge Guide](mulmobridge-guide.en.md) | English | Same as above in English |
-| [スケジューラー ガイド](scheduler-guide.md) | 日本語 | カレンダーと定期タスク。AIに自動で仕事をさせる方法 |
-| [Scheduler Guide](scheduler-guide.en.md) | English | Same as above in English |
-| [Telegram セットアップ](message_apps/telegram/README.md) | English | Telegram Bot の作成と接続手順 |
-| [Telegram セットアップ](message_apps/telegram/README.ja.md) | 日本語 | 同上の日本語版 |
+| [MulmoBridge ガイド](mulmobridge-guide.md) | 日本語 | メッセージアプリから自宅PCのAIと話す方法 |
+| [MulmoBridge Guide](mulmobridge-guide.en.md) | English | Connect messaging apps to your home PC's AI agent |
+| [スケジューラー ガイド](scheduler-guide.md) | 日本語 | カレンダーと定期タスクの使い方 |
+| [Scheduler Guide](scheduler-guide.en.md) | English | Calendar and recurring tasks |
+| [Telegram Setup](message_apps/telegram/README.md) | English | Create and connect a Telegram Bot |
+| [Telegram セットアップ](message_apps/telegram/README.ja.md) | 日本語 | Telegram Bot の作成と接続手順 |
 
-## 開発者向け / Developers
+## Developers
 
-コードの構造、API、ビルド方法。
+Code structure, APIs, and build instructions.
 
-| ドキュメント | 言語 | 説明 |
+| Document | Language | Description |
 |---|---|---|
-| [Developer Guide](developer.md) | English | 環境変数、スクリプト、ワークスペース構造、CI、内部パッケージ一覧 |
-| [Bridge Protocol](bridge-protocol.md) | English | MulmoBridge のワイヤープロトコル仕様（socket.io イベント、認証） |
-| [Task Manager](task-manager.md) | English | サーバー内部の tick ループ + @receptron/task-scheduler との関係 |
-| [Logging](logging.md) | English | ログレベル、フォーマット、ローテーション設定 |
-| [Sandbox Credentials](sandbox-credentials.md) | English | Docker サンドボックスへの資格情報転送 |
-| [Manual Testing](manual-testing.md) | English | E2E でカバーできない手動テスト項目 |
+| [Developer Guide](developer.md) | English | Environment variables, scripts, workspace structure, CI, internal packages |
+| [Bridge Protocol](bridge-protocol.md) | English | MulmoBridge wire protocol spec (socket.io events, auth) |
+| [Task Manager](task-manager.md) | English | Server tick loop + @receptron/task-scheduler integration |
+| [Logging](logging.md) | English | Log levels, formats, rotation |
+| [Sandbox Credentials](sandbox-credentials.md) | English | Docker sandbox credential forwarding |
+| [Manual Testing](manual-testing.md) | English | Manual test items not covered by E2E |
 
-## プロジェクト情報 / Project
+## Project
 
-| ドキュメント | 言語 | 説明 |
+| Document | Language | Description |
 |---|---|---|
-| [CHANGELOG](CHANGELOG.md) | English | リリース履歴（Keep a Changelog 形式） |
+| [CHANGELOG](CHANGELOG.md) | English | Release history (Keep a Changelog format) |
 | [PR紹介](PR-ja.md) | 日本語 | MulmoClaude の紹介・PR用テキスト |
-| [v0.1.0 リリースノート](releases/v0.1.0.md) | English | 初回リリース |
-| [v0.1.1 リ���ースノート](releases/v0.1.1.md) | English | モノレポ + ストリーミング + ブリッジ |
+| [v0.1.0 Release Notes](releases/v0.1.0.md) | English | First tagged release |
+| [v0.1.1 Release Notes](releases/v0.1.1.md) | English | Monorepo + streaming + bridges |
 
-## パッケージ / Packages
+## Packages
 
-各パッケージの README は `packages/` ディレクトリ内にあります。
+Each package has its own README inside `packages/`.
 
-| ドキュメント | 説明 |
+| Document | Description |
 |---|---|
-| [packages/README.md](../packages/README.md) | MulmoBridge パッケージ全体像（English） |
-| 各パッケージの README | npm ページに表示される個別ドキュメント |
+| [packages/README.md](../packages/README.md) | MulmoBridge package overview |
+| Individual package READMEs | Published to npm package pages |


### PR DESCRIPTION
Docs only. Japanese document titles kept as-is.