### PR TITLE
fix(security): harden token handling and file API blocklist

### DIFF
--- a/server/api/auth/bearerAuth.ts
+++ b/server/api/auth/bearerAuth.ts
@@ -1,3 +1,10 @@
+import { timingSafeEqual } from "crypto";
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
 // Bearer token middleware (#272). Reject any `/api/*` request whose
 // `Authorization: Bearer <token>` header doesn't match the current
 // server token.
@@ -50,7 +57,7 @@ export function bearerAuth(
     return;
   }
   const provided = header.slice(BEARER_PREFIX.length);
-  if (provided !== expected) {
+  if (!safeEqual(provided, expected)) {
     unauthorized(res, "unauthorized");
     return;
   }

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -31,6 +31,9 @@ const HIDDEN_DIRS = new Set([".git"]);
 const SENSITIVE_BASENAMES = new Set([
   "credentials.json",
   // Claude Code credentials file written by server/credentials.ts.
+  ".session-token",
+  // Bearer auth token file — readable without auth via /api/files/*
+  // exemption, so it must be blocked here (defense in depth).
   ".npmrc",
   ".htpasswd",
   "id_rsa",

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -234,7 +234,7 @@ export async function refreshCredentials(): Promise<boolean> {
       }
     }
 
-    await writeFile(CREDENTIALS_PATH, credentials + "\n");
+    await writeFile(CREDENTIALS_PATH, credentials + "\n", { mode: 0o600 });
     log.info(
       "credentials",
       "Fresh credentials written to ~/.claude/.credentials.json",


### PR DESCRIPTION
## Summary

副作用のないセキュリティ強化3件。

- `.session-token` を `SENSITIVE_BASENAMES` ブロックリストに追加（`/api/files/*` はbearer認証免除のため、防御の深さとして）
- bearer トークン比較を `crypto.timingSafeEqual` に変更
- `~/.claude/.credentials.json` の書き込みモードを `0o600` に制限

## Test plan

- [x] yarn typecheck — pass
- [x] yarn lint — 0 errors
- [x] yarn test — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)