### PR TITLE
Add LINE bridge setup guide and skill

### DIFF
--- a/.claude/skills/setup-mulmobridge-line/NOTES.ja.md
+++ b/.claude/skills/setup-mulmobridge-line/NOTES.ja.md
@@ -4,7 +4,7 @@
 
 ## Step 1: 前提チェック
 
-1. MulmoClaude が起動しているか確認（`lsof -i :3001`）。未起動なら `/start-mulmoclaude` を案内
+1. MulmoClaude が起動しているか確認（`lsof -i :3001`）。未起動なら別ターミナルで `yarn dev` を実行するよう案内
 2. ngrok がインストールされているか確認（`which ngrok`）。未インストールなら `brew install ngrok` + authtoken 設定を案内
 
 ## Step 2: ドキュメントに従ってセットアップ

--- a/.claude/skills/setup-mulmobridge-line/NOTES.ja.md
+++ b/.claude/skills/setup-mulmobridge-line/NOTES.ja.md
@@ -1,0 +1,27 @@
+# Setup LINE Bridge — 開発者確認用メモ
+
+> このファイルは Claude に読まれません。SKILL.md の内容を日本語で確認するためのものです。
+
+## Step 1: 前提チェック
+
+1. MulmoClaude が起動しているか確認（`lsof -i :3001`）。未起動なら `/start-mulmoclaude` を案内
+2. ngrok がインストールされているか確認（`which ngrok`）。未インストールなら `brew install ngrok` + authtoken 設定を案内
+
+## Step 2: ドキュメントに従ってセットアップ
+
+`docs/message_apps/line/` のドキュメントを読み、ユーザーの言語に合わせて案内する（README.md / README.ja.md）。
+
+ハマりやすいポイント：
+
+- Webhook URL の末尾に `/webhook` を付ける（忘れると 404）
+- LINE 公式アカウント設定 → 応答メッセージ → OFF（二重返信防止）
+- `.env` に `LINE_CHANNEL_SECRET` と `LINE_CHANNEL_ACCESS_TOKEN` を追加
+
+## Step 3: ブリッジ起動
+
+```bash
+node packages/line/dist/index.js
+```
+
+- `npx @mulmobridge/line` はモノレポ内では動かない（yarn workspaces が bin のシンボリックリンクを作らないため）
+- 失敗時はドキュメントのトラブルシューティング表を参照

--- a/.claude/skills/setup-mulmobridge-line/SKILL.md
+++ b/.claude/skills/setup-mulmobridge-line/SKILL.md
@@ -10,7 +10,7 @@ Guide the user through LINE bridge setup following the docs at `docs/message_app
 
 ## Step 1: Prerequisites
 
-1. Check MulmoClaude is running (`lsof -i :3001 -sTCP:LISTEN`). If not, suggest `/start-mulmoclaude` first.
+1. Check MulmoClaude is running (`lsof -i :3001 -sTCP:LISTEN`). If not, ask the user to run `yarn dev` in a separate terminal first.
 2. Check ngrok is installed (`which ngrok`). If not, guide `brew install ngrok` + authtoken setup.
 
 ## Step 2: Follow the setup doc

--- a/.claude/skills/setup-mulmobridge-line/SKILL.md
+++ b/.claude/skills/setup-mulmobridge-line/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: setup-mulmobridge-line
+description: Interactively guide LINE bridge setup — ngrok install, LINE Developers Console config, and bridge startup. Respond in the user's language.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Setup LINE Bridge
+
+Guide the user through LINE bridge setup following the docs at `docs/message_apps/line/`. Use the language-appropriate version (README.md for English, README.ja.md for Japanese) based on the user's language.
+
+## Step 1: Prerequisites
+
+1. Check MulmoClaude is running (`lsof -i :3001 -sTCP:LISTEN`). If not, suggest `/start-mulmoclaude` first.
+2. Check ngrok is installed (`which ngrok`). If not, guide `brew install ngrok` + authtoken setup.
+
+## Step 2: Follow the setup doc
+
+Read the appropriate doc (`docs/message_apps/line/README.md` or `README.ja.md`) and walk the user through it. Key pitfalls to highlight:
+
+- Webhook URL must end with `/webhook` (without it, LINE POSTs to `/` and gets 404)
+- Disable auto-reply messages in LINE Official Account settings (prevents double replies)
+- Add `LINE_CHANNEL_SECRET` and `LINE_CHANNEL_ACCESS_TOKEN` to `.env`
+
+## Step 3: Start the bridge
+
+```bash
+node packages/line/dist/index.js
+```
+
+`npx @mulmobridge/line` does not work inside the monorepo. Use `node` directly.
+
+On failure, refer to the troubleshooting table in the setup doc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ Guides for using MulmoClaude. No programming knowledge required.
 | [Scheduler Guide](scheduler-guide.en.md) | English | Calendar and recurring tasks |
 | [Telegram Setup](message_apps/telegram/README.md) | English | Create and connect a Telegram Bot |
 | [Telegram セットアップ](message_apps/telegram/README.ja.md) | 日本語 | Telegram Bot の作成と接続手順 |
+| [LINE Setup](message_apps/line/README.md) | English | Create and connect a LINE bot (requires ngrok) |
+| [LINE セットアップ](message_apps/line/README.ja.md) | 日本語 | LINE bot の作成と接続手順 (ngrok 必要) |
 
 ## Developers
 

--- a/docs/message_apps/line/README.ja.md
+++ b/docs/message_apps/line/README.ja.md
@@ -93,7 +93,7 @@ LINE 公式アカウント設定画面 → **応答メッセージ** → OFF に
 
 プロジェクトルートの `.env` に以下を追加:
 
-```
+```dotenv
 LINE_CHANNEL_SECRET=xxxxxx
 LINE_CHANNEL_ACCESS_TOKEN=xxxxxx
 ```
@@ -118,7 +118,8 @@ yarn dev
 ngrok http 3002
 ```
 
-ターミナル C で LINE ブリッジを起動:
+ターミナル C で LINE ブリッジを起動（`yarn dev` が `predev` スクリプト経由で
+`packages/line/dist/` を自動ビルドするので、手動ビルドは不要）:
 
 ```bash
 node packages/line/dist/index.js

--- a/docs/message_apps/line/README.ja.md
+++ b/docs/message_apps/line/README.ja.md
@@ -1,0 +1,163 @@
+# MulmoClaude — LINE ブリッジ
+
+自分の PC で動かしている MulmoClaude と LINE アプリから会話
+できるようにします。このドキュメントは **運用者** 向け — MulmoClaude
+をホストしていて、bot を家族・友人と共有したい人を想定。
+
+English: [`README.md`](README.md)
+
+> **Experimental** — テストして [問題を報告](https://github.com/receptron/mulmoclaude/issues/new) してください。
+
+---
+
+## 完成した状態
+
+- 自作の LINE 公式アカウント (bot) が、自分の PC 上で動く
+  MulmoClaude にメッセージを中継する。
+- ngrok でローカル PC のポートをインターネットに公開し、LINE
+  の Webhook を受け取れる状態。
+- ターミナル A で `yarn dev`、ターミナル B で ngrok、ターミナル C
+  で LINE ブリッジを同時に動かしている状態。
+
+PC を閉じたりネットを切ったりすると bot は沈黙します。
+
+### Telegram との違い
+
+Telegram はポーリング方式（bot 側からサーバに聞きに行く）なので
+外部からのアクセスを受けず、ngrok も不要です。LINE は Webhook
+方式（LINE サーバからあなたの PC に HTTP リクエストが来る）なので
+ngrok が必要です。セキュリティ面では Telegram の方がシンプルです。
+
+---
+
+## ステップ 1 — ngrok のセットアップ
+
+ngrok はローカル PC のポートをインターネットに公開するトンネリング
+ツールです。LINE の Webhook を受け取るために必要です。
+
+### インストール
+
+```bash
+brew install ngrok
+```
+
+### アカウント登録と authtoken 設定
+
+1. [ngrok.com](https://ngrok.com) にサインアップ（GitHub アカウントで可）
+2. ダッシュボードに表示される authtoken をコピー
+3. ターミナルで設定:
+
+```bash
+ngrok config add-authtoken <あなたのトークン>
+```
+
+### 起動
+
+```bash
+ngrok http 3002
+```
+
+表示される `https://xxxx.ngrok-free.app` の URL をメモしてください。
+ステップ 3 で使います。
+
+---
+
+## ステップ 2 — LINE Messaging API チャンネルを作る
+
+1. [LINE Developers Console](https://developers.line.biz/console/) を開く
+2. **プロバイダ** を作成（未作成の場合）
+3. **Messaging API** チャンネルを作成
+4. **Basic settings** タブの **Channel secret** をメモ
+5. **Messaging API** タブで **Channel access token** を発行（long-lived）してメモ
+
+---
+
+## ステップ 3 — Webhook を設定する
+
+LINE Developers Console → **Messaging API** タブで:
+
+- **Webhook URL**: `https://xxxx.ngrok-free.app/webhook`
+  - **末尾の `/webhook` を忘れないこと。** 付け忘れると POST が `/` に行き 404 になる
+- **Use webhook**: 有効にする
+
+### 応答メッセージを OFF にする
+
+LINE 公式アカウントのデフォルト応答（あいさつメッセージ等）が有効
+だと、MulmoClaude の返信と二重に送られてしまいます。
+
+LINE 公式アカウント設定画面 → **応答メッセージ** → OFF にする。
+
+---
+
+## ステップ 4 — 環境変数を設定する
+
+プロジェクトルートの `.env` に以下を追加:
+
+```
+LINE_CHANNEL_SECRET=xxxxxx
+LINE_CHANNEL_ACCESS_TOKEN=xxxxxx
+```
+
+全環境変数の一覧は [packages/line/README.md](../../../packages/line/README.md) を参照。
+
+---
+
+## ステップ 5 — MulmoClaude とブリッジを起動
+
+ターミナル A で MulmoClaude サーバを起動:
+
+```bash
+yarn dev
+```
+
+`[server] listening port=3001` が出るまで待つ。
+
+ターミナル B で ngrok を起動（まだ起動していなければ）:
+
+```bash
+ngrok http 3002
+```
+
+ターミナル C で LINE ブリッジを起動:
+
+```bash
+node packages/line/dist/index.js
+```
+
+> **注意**: `npx @mulmobridge/line` はモノレポ内では動きません（yarn
+> workspaces が bin のシンボリックリンクを作らないため）。`node` で
+> 直接実行してください。
+
+---
+
+## ステップ 6 — bot を友だち追加して話しかける
+
+LINE Developers Console → **Messaging API** タブの QR コードを
+スキャンして bot を友だち追加。メッセージを送ると MulmoClaude から
+返信が来ます。
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| ngrok に `POST / 404 Not Found` | Webhook URL に `/webhook` が付いていない | LINE Console で URL 末尾に `/webhook` を追加 |
+| bot が二重に返信する | LINE の応答メッセージが ON | LINE 公式アカウント設定 → 応答メッセージ → OFF |
+| `LINE_CHANNEL_SECRET and LINE_CHANNEL_ACCESS_TOKEN are required` | 環境変数が読めていない | `.env` に設定するか、環境変数として export |
+| `sh: mulmobridge-line: command not found` | `npx` がモノレポ内で bin を見つけられない | `node packages/line/dist/index.js` を使う |
+| ブリッジに `Connect error: bearer token rejected` | MulmoClaude サーバを再起動して token が変わった | LINE ブリッジを再起動 |
+| 返信が来ない（エラーなし） | `yarn dev` が止まっている | MulmoClaude サーバの状態を確認 |
+
+---
+
+## セキュリティに関する注意
+
+- **ngrok は使うときだけ起動**し、終わったら止めること。起動中は
+  ポート 3002 がインターネットに公開されている。
+- LINE の Channel secret による署名検証があるので、不正なリクエスト
+  は弾かれる。ただし ngrok の URL 自体は誰でもアクセスできる。
+- Channel secret と Channel access token はパスワードと同じ扱い。
+  漏れたら LINE Developers Console で再発行してください。
+- MulmoClaude の bearer token は外に出ません。LINE bridge は
+  `localhost:3001` にしか繋がりません。

--- a/docs/message_apps/line/README.md
+++ b/docs/message_apps/line/README.md
@@ -92,7 +92,7 @@ Go to LINE Official Account settings, **Auto-reply messages**, turn it OFF.
 
 Add to `.env` in the project root:
 
-```
+```dotenv
 LINE_CHANNEL_SECRET=xxxxxx
 LINE_CHANNEL_ACCESS_TOKEN=xxxxxx
 ```
@@ -117,7 +117,8 @@ In terminal B, start ngrok (if not already running):
 ngrok http 3002
 ```
 
-In terminal C, start the LINE bridge:
+In terminal C, start the LINE bridge (`yarn dev` automatically builds
+`packages/line/dist/` via the `predev` script, so no manual build needed):
 
 ```bash
 node packages/line/dist/index.js

--- a/docs/message_apps/line/README.md
+++ b/docs/message_apps/line/README.md
@@ -1,0 +1,160 @@
+# MulmoClaude — LINE bridge
+
+Talk to your MulmoClaude from the LINE app. This guide is for
+**operators** — the person running MulmoClaude on their machine and
+sharing the bot with friends / family.
+
+Japanese: [`README.ja.md`](README.ja.md)
+
+> **Experimental** — please test and [report issues](https://github.com/receptron/mulmoclaude/issues/new).
+
+---
+
+## What you'll have when you're done
+
+- A LINE Official Account (bot) that forwards messages to the
+  MulmoClaude running on your computer.
+- ngrok exposing a local port so LINE's webhooks can reach your machine.
+- `yarn dev` in one terminal, ngrok in another, and the LINE bridge
+  in a third — all on your machine.
+
+Your computer has to be on and connected to the internet for the
+bot to respond. Close the laptop, the bot goes silent.
+
+### How it differs from Telegram
+
+Telegram uses polling (the bot asks the server for new messages),
+so no incoming port is opened and ngrok is not needed. LINE uses
+webhooks (LINE's server sends HTTP requests to your machine), so
+ngrok is required. Telegram is simpler from a security perspective.
+
+---
+
+## Step 1 — Set up ngrok
+
+ngrok is a tunneling tool that exposes a local port to the internet.
+LINE's webhooks need it to reach your machine.
+
+### Install
+
+```bash
+brew install ngrok
+```
+
+### Create an account and set your authtoken
+
+1. Sign up at [ngrok.com](https://ngrok.com) (GitHub login works)
+2. Copy the authtoken from the dashboard
+3. Run:
+
+```bash
+ngrok config add-authtoken <your-token>
+```
+
+### Start ngrok
+
+```bash
+ngrok http 3002
+```
+
+Note the `https://xxxx.ngrok-free.app` URL — you'll need it in Step 3.
+
+---
+
+## Step 2 — Create a LINE Messaging API Channel
+
+1. Go to [LINE Developers Console](https://developers.line.biz/console/)
+2. Create a **Provider** (if you don't have one)
+3. Create a **Messaging API** channel
+4. Note the **Channel secret** (Basic settings tab)
+5. Issue a **Channel access token** (Messaging API tab, long-lived) and note it
+
+---
+
+## Step 3 — Configure the webhook
+
+In the LINE Developers Console, Messaging API tab:
+
+- **Webhook URL**: `https://xxxx.ngrok-free.app/webhook`
+  - **The trailing `/webhook` is required.** Without it, POSTs go to `/` and return 404.
+- **Use webhook**: enabled
+
+### Disable auto-reply messages
+
+LINE Official Accounts send default greeting / auto-reply messages.
+These interfere with MulmoClaude's responses (you'll get double replies).
+
+Go to LINE Official Account settings, **Auto-reply messages**, turn it OFF.
+
+---
+
+## Step 4 — Set environment variables
+
+Add to `.env` in the project root:
+
+```
+LINE_CHANNEL_SECRET=xxxxxx
+LINE_CHANNEL_ACCESS_TOKEN=xxxxxx
+```
+
+Full variable reference: [packages/line/README.md](../../../packages/line/README.md).
+
+---
+
+## Step 5 — Start MulmoClaude and the bridge
+
+In terminal A, start MulmoClaude:
+
+```bash
+yarn dev
+```
+
+Wait for `[server] listening port=3001`.
+
+In terminal B, start ngrok (if not already running):
+
+```bash
+ngrok http 3002
+```
+
+In terminal C, start the LINE bridge:
+
+```bash
+node packages/line/dist/index.js
+```
+
+> **Note**: `npx @mulmobridge/line` does not work inside the monorepo
+> (yarn workspaces doesn't create the bin symlink). Use `node` directly.
+
+---
+
+## Step 6 — Add the bot as a friend and send a message
+
+Scan the QR code in the LINE Developers Console (Messaging API tab)
+to add the bot. Send a message — MulmoClaude replies.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| ngrok shows `POST / 404 Not Found` | Webhook URL missing `/webhook` | Add `/webhook` to the URL in LINE Console |
+| Bot sends double replies | LINE auto-reply is ON | LINE Official Account settings, Auto-reply messages, OFF |
+| `LINE_CHANNEL_SECRET and LINE_CHANNEL_ACCESS_TOKEN are required` | Env vars not loaded | Add to `.env` or export them |
+| `sh: mulmobridge-line: command not found` | `npx` can't find the bin in the monorepo | Use `node packages/line/dist/index.js` |
+| `Connect error: bearer token rejected` | MulmoClaude server restarted, token changed | Restart the LINE bridge |
+| No reply, no error | `yarn dev` is not running | Check the MulmoClaude server |
+
+---
+
+## Security notes
+
+- **Only run ngrok when you need it** — stop it when done. While
+  running, port 3002 is exposed to the internet.
+- LINE's Channel secret signature verification rejects forged
+  requests, but the ngrok URL itself is publicly accessible.
+- Treat Channel secret and Channel access token like passwords.
+  If leaked, reissue them in the LINE Developers Console.
+- MulmoClaude's bearer token never leaves your machine. The LINE
+  bridge connects to `localhost:3001` only.


### PR DESCRIPTION
## Summary

- LINE ブリッジを実際にセットアップし、躓くポイントを整理
- `setup-mulmobridge-line` スキルを追加（ドキュメント参照型の対話ガイド）
- LINE ブリッジのセットアップガイドを `docs/message_apps/line/` に追加（英語・日本語）
- `docs/README.md` のインデックスに LINE ドキュメントへのリンクを追加

## 背景

LINE ブリッジを実際にセットアップした際のハマりポイント（ngrok のインストール、Webhook URL 末尾の `/webhook` 忘れ、応答メッセージ OFF、`npx` がモノレポ内で動かない等）をドキュメント化した。

## Test plan

- [ ] `docs/message_apps/line/README.md` と `README.ja.md` のリンクが正しいか確認
- [ ] `/setup-mulmobridge-line` スキルが表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive LINE bridge setup guides in English and Japanese, covering ngrok configuration, LINE Messaging API channel creation, webhook setup, and environment variable configuration.
  * Included troubleshooting tables for common setup issues and security best practices for ngrok and credential handling.
  * Updated documentation index with new LINE setup resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->