### PR TITLE
docs: fix broken plan links + LINE bridge verified

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -13,7 +13,7 @@ Non-Node implementations (Python, Go, anything with a socket.io
 
 For the architectural context (why bridges are separate processes,
 how they fit into the five layers), see
-[`plans/messaging_layers_guide.md`](../plans/messaging_layers_guide.md).
+[`plans/done/messaging_layers_guide.md`](../plans/done/messaging_layers_guide.md).
 
 ---
 
@@ -246,8 +246,8 @@ For the production-grade TS version with error paths baked in, use
 
 ## Related reading
 
-- [`plans/messaging_layers_guide.md`](../plans/messaging_layers_guide.md) — architecture, why out-of-process
-- [`plans/messaging_transports.md`](../plans/messaging_transports.md) — design decisions log
-- [`plans/feat-chat-socketio.md`](../plans/feat-chat-socketio.md) — Phase A (socket transport)
-- [`plans/feat-chat-socketio-phase-b.md`](../plans/feat-chat-socketio-phase-b.md) — Phase B (server→bridge push)
+- [`plans/done/messaging_layers_guide.md`](../plans/done/messaging_layers_guide.md) — architecture, why out-of-process
+- [`plans/done/messaging_transports.md`](../plans/done/messaging_transports.md) — design decisions log
+- [`plans/done/feat-chat-socketio.md`](../plans/done/feat-chat-socketio.md) — Phase A (socket transport)
+- [`plans/done/feat-chat-socketio-phase-b.md`](../plans/done/feat-chat-socketio-phase-b.md) — Phase B (server→bridge push)
 - [`docs/developer.md` § Auth](developer.md) — bearer token details

--- a/docs/mulmobridge-guide.en.md
+++ b/docs/mulmobridge-guide.en.md
@@ -86,7 +86,7 @@ Detailed setup: [Telegram README](https://github.com/receptron/mulmoclaude/blob/
 | **Telegram** | [@mulmobridge/telegram](https://www.npmjs.com/package/@mulmobridge/telegram) | Stable | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/telegram/README.md) |
 | **Discord** | [@mulmobridge/discord](https://www.npmjs.com/package/@mulmobridge/discord) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/discord/README.md) |
 | **Slack** | [@mulmobridge/slack](https://www.npmjs.com/package/@mulmobridge/slack) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/slack/README.md) |
-| **LINE** | [@mulmobridge/line](https://www.npmjs.com/package/@mulmobridge/line) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/line/README.md) |
+| **LINE** | [@mulmobridge/line](https://www.npmjs.com/package/@mulmobridge/line) | Verified | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/line/README.md) |
 | **WhatsApp** | [@mulmobridge/whatsapp](https://www.npmjs.com/package/@mulmobridge/whatsapp) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/whatsapp/README.md) |
 | **Matrix** | [@mulmobridge/matrix](https://www.npmjs.com/package/@mulmobridge/matrix) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/matrix/README.md) |
 | **IRC** | [@mulmobridge/irc](https://www.npmjs.com/package/@mulmobridge/irc) | Experimental | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/irc/README.md) |

--- a/docs/mulmobridge-guide.md
+++ b/docs/mulmobridge-guide.md
@@ -86,7 +86,7 @@ TELEGRAM_ALLOWED_CHAT_IDS=your-chat-id \
 | **Telegram** | [@mulmobridge/telegram](https://www.npmjs.com/package/@mulmobridge/telegram) | 安定 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/telegram/README.md) |
 | **Discord** | [@mulmobridge/discord](https://www.npmjs.com/package/@mulmobridge/discord) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/discord/README.md) |
 | **Slack** | [@mulmobridge/slack](https://www.npmjs.com/package/@mulmobridge/slack) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/slack/README.md) |
-| **LINE** | [@mulmobridge/line](https://www.npmjs.com/package/@mulmobridge/line) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/line/README.md) |
+| **LINE** | [@mulmobridge/line](https://www.npmjs.com/package/@mulmobridge/line) | 動作確認済み | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/line/README.md) |
 | **WhatsApp** | [@mulmobridge/whatsapp](https://www.npmjs.com/package/@mulmobridge/whatsapp) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/whatsapp/README.md) |
 | **Matrix** | [@mulmobridge/matrix](https://www.npmjs.com/package/@mulmobridge/matrix) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/matrix/README.md) |
 | **IRC** | [@mulmobridge/irc](https://www.npmjs.com/package/@mulmobridge/irc) | 実験的 | [README](https://github.com/receptron/mulmoclaude/blob/main/packages/irc/README.md) |


### PR DESCRIPTION
## Summary

- bridge-protocol.md の plan リンク4箇所を plans/done/ に修正（done に移動されたため）
- LINE ブリッジのステータスを「実験的/Experimental」→「動作確認済み/Verified」に更新

## Changes

| File | Change |
|---|---|
| docs/bridge-protocol.md | 4 links: plans/ → plans/done/ |
| docs/mulmobridge-guide.md | LINE: 実験的 → 動作確認済み |
| docs/mulmobridge-guide.en.md | LINE: Experimental → Verified |

🤖 Generated with [Claude Code](https://claude.com/claude-code)