### PR TITLE
docs: Obsidian integration tips

### DIFF
--- a/docs/tips/obsidian.en.md
+++ b/docs/tips/obsidian.en.md
@@ -1,0 +1,106 @@
+# MulmoClaude + Obsidian Integration Guide
+
+MulmoClaude's workspace is entirely plain Markdown files. [Obsidian](https://obsidian.md/) is a knowledge management tool that works directly with local Markdown files, so they integrate **with zero code changes and no plugins required**.
+
+---
+
+## Pattern A: Browse MulmoClaude's files in Obsidian
+
+Explore documents, wiki pages, memory, and TODOs created by Claude using Obsidian's graph view and search.
+
+### Setup
+
+1. Open Obsidian
+2. Choose "Open folder as vault"
+3. Select `~/mulmoclaude/`
+
+That's it. Obsidian creates a `.obsidian/` directory, which has no effect on MulmoClaude.
+
+### What you'll see
+
+```
+~/mulmoclaude/
+  data/wiki/pages/*.md        ← Wiki pages (Claude's accumulated knowledge base)
+  data/wiki/index.md          ← Wiki index
+  conversations/memory.md     ← Claude's long-term memory
+  conversations/summaries/    ← Daily summaries
+  artifacts/documents/*.md    ← Documents created by Claude
+```
+
+### How to use it
+
+- **Graph view**: `[[wiki link]]` syntax in wiki pages is natively recognized by Obsidian, visualizing how knowledge connects
+- **Full-text search**: Find anything across past conversation results and documents using Obsidian's fast search
+- **Tags & folders**: Adding tags or stars in Obsidian won't affect Claude's behavior
+- **Mobile sync**: Sync `~/mulmoclaude/` via Obsidian Sync or iCloud/Dropbox to browse Claude's output from your phone
+
+### Notes
+
+- Editing files in Obsidian means Claude will read the modified content. Unless intentional, we recommend using Obsidian as read-only for MulmoClaude files
+- Add `.obsidian/` to your `.gitignore` to keep the repo clean
+
+---
+
+## Pattern B: Let Claude reference your existing Obsidian Vault
+
+If you already manage notes and documents in Obsidian and want Claude to read them.
+
+### Option 1: Non-Docker mode (simplest)
+
+Start MulmoClaude with `DISABLE_SANDBOX=1` and Claude has full filesystem access. Just tell it the vault path in chat:
+
+```
+Read the notes in ~/ObsidianVault/projects/ and summarize them
+```
+
+Claude uses its built-in file tools (`read`, `glob`, `grep`) to read files directly from the vault.
+
+### Option 2: Docker mode — add reference directories via workspace settings
+
+Open Settings (gear icon) → Workspace Dirs tab and add your Obsidian Vault path. In the Docker sandbox, it's mounted read-only, so Claude physically cannot modify your files.
+
+### Option 3: Import via wiki ingest
+
+Import Obsidian notes into MulmoClaude's wiki:
+
+```
+Ingest the notes from ~/ObsidianVault/research/ into the wiki
+```
+
+Claude reads the notes, organizes the knowledge, and saves them as wiki pages. The original Obsidian files remain unchanged.
+
+### Which option to choose?
+
+| Option | Docker compatible | Write protection | Setup |
+|--------|------------------|-----------------|-------|
+| Non-Docker + path instruction | No | No (prompt only) | None |
+| Workspace settings | Yes | Yes (read-only mount) | Settings UI |
+| Wiki ingest | Yes | Yes (copy) | None |
+
+---
+
+## Using both directions
+
+Combine Pattern A + B:
+
+1. Manage your everyday notes in Obsidian
+2. Have Claude reference your Obsidian notes for questions, analysis, and summaries
+3. Browse Claude's output (wiki, documents) in Obsidian's graph view and search
+
+The `[[wiki link]]` syntax is shared, so Claude's wiki pages and your Obsidian notes connect seamlessly.
+
+---
+
+## FAQ
+
+**Q: Will Obsidian's `.obsidian/` folder cause problems?**
+
+A: No. MulmoClaude ignores this directory. Add it to `.gitignore` to keep git history clean.
+
+**Q: Is the `[[wiki link]]` format compatible?**
+
+A: Yes. Both MulmoClaude's wiki and Obsidian use `[[page name]]` syntax. Obsidian's graph view displays the link structure as-is.
+
+**Q: Can Claude accidentally overwrite my Obsidian notes?**
+
+A: With Docker mode + workspace settings, files are mounted read-only — physically impossible to overwrite. In non-Docker mode, protection is prompt-based only, so Docker mode is recommended if you have important files.

--- a/docs/tips/obsidian.md
+++ b/docs/tips/obsidian.md
@@ -1,0 +1,106 @@
+# MulmoClaude + Obsidian 連携ガイド
+
+MulmoClaude のワークスペースは全てプレーンな Markdown ファイルで構成されています。[Obsidian](https://obsidian.md/) はローカルの Markdown ファイルをそのまま扱うナレッジ管理ツールなので、**コード変更なし・プラグイン不要**で連携できます。
+
+---
+
+## パターン A: MulmoClaude のファイルを Obsidian で閲覧する
+
+Claude が作成したドキュメント、Wiki ページ、メモリ、TODO などを Obsidian のグラフビューや検索で探索できます。
+
+### セットアップ
+
+1. Obsidian を開く
+2. 「Open folder as vault」(フォルダを Vault として開く) を選択
+3. `~/mulmoclaude/` を指定
+
+以上です。Obsidian が `.obsidian/` ディレクトリを作成しますが、MulmoClaude 側には影響しません。
+
+### 見えるファイル
+
+```
+~/mulmoclaude/
+  data/wiki/pages/*.md        ← Wiki ページ（Claude が蓄積した知識ベース）
+  data/wiki/index.md          ← Wiki インデックス
+  conversations/memory.md     ← Claude の長期記憶
+  conversations/summaries/    ← 日次サマリー
+  artifacts/documents/*.md    ← Claude が作成したドキュメント
+```
+
+### 活用例
+
+- **グラフビュー**: Wiki ページ間の `[[wiki link]]` がそのまま Obsidian のリンクとして認識され、知識のつながりを視覚化できる
+- **全文検索**: Obsidian の高速検索で、Claude との過去の会話結果やドキュメントを横断的に探せる
+- **タグ・フォルダ管理**: Obsidian 側でタグやスター付けしても、Claude の動作に影響しない
+- **モバイル同期**: Obsidian Sync や iCloud/Dropbox で `~/mulmoclaude/` を同期すれば、スマホから Claude の出力を閲覧できる
+
+### 注意点
+
+- Obsidian でファイルを編集すると、Claude も変更後の内容を読みます。意図的でない限り、Obsidian 側では閲覧のみにすることを推奨します
+- `.obsidian/` ディレクトリは `.gitignore` に追加しておくと良いでしょう
+
+---
+
+## パターン B: 既存の Obsidian Vault を Claude に参照させる
+
+既に Obsidian で管理しているノートやドキュメントを Claude に読ませたい場合。
+
+### 方法 1: 非 Docker モード（最も簡単）
+
+`DISABLE_SANDBOX=1` で MulmoClaude を起動すると、Claude はファイルシステム全体にアクセスできます。チャットで Vault のパスを伝えるだけです。
+
+```
+~/ObsidianVault/projects/ にあるノートを読んで、要約して
+```
+
+Claude は内蔵のファイルツール (`read`, `glob`, `grep`) で Vault 内のファイルを直接読み取ります。
+
+### 方法 2: Docker モード — ワークスペース設定で参照ディレクトリを追加
+
+Settings (歯車アイコン) → Workspace Dirs タブで Obsidian Vault のパスを追加できます。Docker sandbox 内では read-only でマウントされるため、Claude がファイルを書き換える心配はありません。
+
+### 方法 3: Wiki の ingest 機能でインポート
+
+Obsidian のノートを MulmoClaude の Wiki に取り込むこともできます。
+
+```
+~/ObsidianVault/research/ にあるノートを wiki にインポートして
+```
+
+Claude がノートを読み、知識を整理して Wiki ページとして保存します。元の Obsidian ファイルは変更されません。
+
+### どの方法を選ぶ？
+
+| 方法 | Docker 対応 | 書き込み保護 | セットアップ |
+|------|------------|------------|-------------|
+| 非 Docker + パス指示 | ❌ | ❌ (プロンプトのみ) | なし |
+| ワークスペース設定 | ✅ | ✅ (read-only mount) | Settings UI |
+| Wiki ingest | ✅ | ✅ (コピー) | なし |
+
+---
+
+## 双方向で使う
+
+パターン A + B を組み合わせると:
+
+1. Obsidian で普段のノート管理をする
+2. Claude に Obsidian のノートを参照させて質問・分析・要約する
+3. Claude の出力（Wiki、ドキュメント）を Obsidian で閲覧・検索する
+
+`[[wiki link]]` 記法が共通なので、Claude が作った Wiki ページと Obsidian のノートがシームレスにつながります。
+
+---
+
+## FAQ
+
+**Q: Obsidian の `.obsidian/` フォルダが邪魔にならない？**
+
+A: なりません。MulmoClaude はこのディレクトリを無視します。`.gitignore` に追加しておくと git 管理上もクリーンです。
+
+**Q: `[[wiki link]]` の形式は互換性がある？**
+
+A: はい。MulmoClaude の Wiki も Obsidian も `[[ページ名]]` 形式を使います。Obsidian のグラフビューでリンク構造がそのまま表示されます。
+
+**Q: Claude が Obsidian のノートを書き換えてしまわない？**
+
+A: Docker モード + ワークスペース設定を使えば、read-only mount により物理的に書き換え不可能です。非 Docker モードではプロンプトによる制限のみなので、重要なファイルがある場合は Docker モードを推奨します。


### PR DESCRIPTION
## Summary

- Add `docs/tips/obsidian.md` (Japanese) and `docs/tips/obsidian.en.md` (English)
- Two integration patterns documented:
  - **Pattern A**: Open `~/mulmoclaude/` as Obsidian vault to browse wiki, documents, memory in graph view
  - **Pattern B**: Let Claude reference an existing Obsidian vault (non-Docker path, workspace settings, wiki ingest)
- FAQ covering `.obsidian/` directory, `[[wiki link]]` compatibility, write protection

## Test plan

- [ ] Documentation renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)