### PR TITLE
docs: MulmoBridge Relay setup guide (EN + JA)

### DIFF
--- a/.claude/skills/setup-relay/SKILL.md
+++ b/.claude/skills/setup-relay/SKILL.md
@@ -1,0 +1,113 @@
+---
+description: Interactively guide MulmoBridge Relay setup — Cloudflare Workers deploy, platform secrets, and MulmoClaude connection. Respond in the user's language.
+---
+
+# Setup MulmoBridge Relay
+
+Guide the user through Relay setup following `docs/message_apps/relay/`. Use the language-appropriate version (README.md for English, README.ja.md for Japanese) based on the user's language.
+
+## Step 1: Prerequisites
+
+1. Check MulmoClaude is running (`lsof -i :3001 -sTCP:LISTEN`). If not, ask the user to run `yarn dev` first.
+2. Check wrangler is installed (`which wrangler`). If not:
+   ```bash
+   npm install -g wrangler
+   ```
+3. Check wrangler is authenticated (`wrangler whoami`). If not, tell the user to run:
+   ```
+   ! wrangler login
+   ```
+   (The `!` prefix runs it in the user's terminal since it requires browser interaction.)
+
+## Step 2: Deploy the Relay
+
+Tell the user to run:
+```
+! cd packages/relay && wrangler deploy
+```
+
+Wait for the user to confirm. Ask them to paste the output URL (e.g., `https://mulmobridge-relay.xxx.workers.dev`).
+
+Save the URL — you'll need it for Step 4.
+
+## Step 3: Set secrets
+
+### RELAY_TOKEN
+
+Generate a random token:
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Tell the user to run:
+```
+! wrangler secret put RELAY_TOKEN
+```
+And paste the generated token. **Save this token** for Step 4.
+
+### Platform secrets
+
+Ask the user which platforms they want to use. For each selected platform:
+
+#### LINE
+Tell the user to run:
+```
+! wrangler secret put LINE_CHANNEL_SECRET
+! wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+```
+And enter their LINE Developers Console values.
+
+Then tell them to update their LINE webhook URL to:
+```
+https://<relay-url>/webhook/line
+```
+
+#### Telegram
+Tell the user to run:
+```
+! wrangler secret put TELEGRAM_BOT_TOKEN
+! wrangler secret put TELEGRAM_WEBHOOK_SECRET
+```
+
+Then set the webhook:
+```bash
+curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<relay-url>/webhook/telegram&secret_token=<SECRET>"
+```
+
+## Step 4: Configure MulmoClaude
+
+Add the Relay connection to `.env`:
+
+```bash
+echo "" >> .env
+echo "# MulmoBridge Relay" >> .env
+echo "RELAY_URL=wss://<relay-url>/ws" >> .env
+echo "RELAY_TOKEN=<token-from-step-3>" >> .env
+```
+
+Replace `<relay-url>` with the URL from Step 2, and `<token-from-step-3>` with the token generated in Step 3.
+
+## Step 5: Verify
+
+1. Check the health endpoint:
+   ```bash
+   curl https://<relay-url>/health
+   ```
+   Confirm the configured platforms show `true`.
+
+2. Restart MulmoClaude:
+   ```bash
+   # Tell user to restart yarn dev
+   ```
+
+3. Send a test message from the configured platform.
+
+4. Check server logs for relay connection and message delivery.
+
+## Key pitfalls to highlight
+
+- `wrangler secret put` is interactive — the user must run it themselves (use `!` prefix)
+- `wrangler deploy` and `wrangler login` require browser interaction
+- The RELAY_TOKEN must be identical in both the Cloudflare secret and the `.env` file
+- LINE webhook URL must be the Relay URL, not the old ngrok URL
+- If using Durable Objects, the user needs Workers Paid plan ($5/month) — the free tier works for testing but has limitations

--- a/docs/message_apps/line/README.ja.md
+++ b/docs/message_apps/line/README.ja.md
@@ -21,6 +21,11 @@ English: [`README.md`](README.md)
 
 PC を閉じたりネットを切ったりすると bot は沈黙します。
 
+> **ヒント**: ngrok の設定が面倒ですか？代わりに
+> [MulmoBridge Relay](../relay/README.ja.md) を使えば、固定 URL で
+> オフライン時のメッセージキューも可能です。ngrok 不要。
+> セットアップ: Claude Code で `/setup-relay` を実行。
+
 ### Telegram との違い
 
 Telegram はポーリング方式（bot 側からサーバに聞きに行く）なので

--- a/docs/message_apps/line/README.md
+++ b/docs/message_apps/line/README.md
@@ -21,6 +21,11 @@ Japanese: [`README.ja.md`](README.ja.md)
 Your computer has to be on and connected to the internet for the
 bot to respond. Close the laptop, the bot goes silent.
 
+> **Tip**: Don't want to deal with ngrok? Use the
+> [MulmoBridge Relay](../relay/README.md) instead — a permanent
+> cloud URL with offline message queuing. No ngrok needed.
+> Setup: `/setup-relay` in Claude Code.
+
 ### How it differs from Telegram
 
 Telegram uses polling (the bot asks the server for new messages),

--- a/docs/message_apps/relay/README.ja.md
+++ b/docs/message_apps/relay/README.ja.md
@@ -1,0 +1,215 @@
+# MulmoBridge Relay — ngrok なしでスマホから使う
+
+English: [`README.md`](README.md)
+
+---
+
+## Relay って何？
+
+LINE や Slack、Messenger で MulmoClaude を使うとき、これらのサービスはあなたのパソコンにメッセージを送る必要があります。通常は **ngrok** という、パソコンに一時的な公開 URL を作るツールが必要です。問題は、ngrok を再起動するたびに URL が変わり、LINE の開発者コンソールで毎回書き換えなければならないこと。
+
+**Relay** はこの問題を解決します。クラウド（Cloudflare Workers）上に小さなサーバーを置き、**固定 URL** を持ちます。LINE がメッセージを Relay に送り、Relay がそれを安全な WebSocket 接続であなたのパソコンに転送します。パソコンがオフのときはメッセージをキューに入れ、オンラインに戻ったら届けます。
+
+```text
+あなたのスマホ (LINE/Telegram)
+     ↓ メッセージ
+Relay (クラウド、固定URL)
+     ↓ WebSocket (暗号化)
+あなたのパソコン (MulmoClaude)
+     ↓
+Claude が応答
+     ↓
+Relay → LINE/Telegram → あなたのスマホ
+```
+
+### ビフォー・アフター
+
+| | 従来（ngrok） | Relay 導入後 |
+|---|---|---|
+| 公開 URL | 再起動のたびに変わる | 固定（一度設定すれば変わらない） |
+| 再起動時の作業 | URL をコピーして LINE コンソールに貼り直し | 不要 |
+| パソコンがオフ | メッセージ消失 | メッセージをキューに保持 |
+| ngrok | 必要 | 不要 |
+| 複数プラットフォーム | それぞれ別プロセスで起動 | 1つの Relay で全部受信 |
+
+---
+
+## 必要なもの
+
+1. **Cloudflare アカウント**（無料）— [こちらから登録](https://dash.cloudflare.com/sign-up)
+2. **Node.js 20 以上**がパソコンにインストール済み
+3. **MulmoClaude** が動いている状態（`yarn dev`）
+4. **メッセージアプリの Bot**が作成済み（LINE Bot、Telegram Bot など）
+
+> **料金**: Cloudflare Workers の無料枠は 1日 10万リクエスト — 個人利用には十分です。Relay が使う Durable Objects は本番運用では Workers Paid プラン（月$5）が必要ですが、無料枠でテストできます。
+
+---
+
+## セットアップ手順
+
+### ステップ 1: Cloudflare CLI をインストール
+
+```bash
+npm install -g wrangler
+```
+
+### ステップ 2: Cloudflare にログイン
+
+```bash
+wrangler login
+```
+
+ブラウザが開きます。Cloudflare アカウントでログインして、Wrangler を承認してください。
+
+### ステップ 3: Relay をデプロイ
+
+```bash
+cd packages/relay
+wrangler deploy
+```
+
+以下のような出力が表示されます：
+
+```
+Published mulmobridge-relay
+  https://mulmobridge-relay.あなたの名前.workers.dev
+```
+
+**この URL を保存してください** — これがあなたの固定 Relay アドレスです。
+
+### ステップ 4: 認証トークンを設定
+
+このトークンは Relay と MulmoClaude の間の認証に使います。あなたのパソコンだけが接続できるようにするためです。
+
+```bash
+wrangler secret put RELAY_TOKEN
+```
+
+強いランダムなパスワードを入力してください。**忘れないでください** — ステップ 6 でも使います。
+
+### ステップ 5: メッセージアプリを設定
+
+#### LINE の場合
+
+```bash
+wrangler secret put LINE_CHANNEL_SECRET
+wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+```
+
+LINE Developers Console の値を入力します。
+
+次に、LINE の Webhook URL を以下に変更：
+
+```
+https://mulmobridge-relay.あなたの名前.workers.dev/webhook/line
+```
+
+#### Telegram の場合
+
+```bash
+wrangler secret put TELEGRAM_BOT_TOKEN
+wrangler secret put TELEGRAM_WEBHOOK_SECRET
+```
+
+次に、Telegram の Bot API で Webhook を設定：
+
+```bash
+curl "https://api.telegram.org/bot<ボットトークン>/setWebhook?url=https://mulmobridge-relay.あなたの名前.workers.dev/webhook/telegram&secret_token=<Webhookシークレット>"
+```
+
+### ステップ 6: MulmoClaude を Relay に接続
+
+MulmoClaude の `.env` ファイルに追加：
+
+```dotenv
+RELAY_URL=wss://mulmobridge-relay.あなたの名前.workers.dev/ws
+RELAY_TOKEN=ステップ4で設定したのと同じトークン
+```
+
+MulmoClaude を起動：
+
+```bash
+yarn dev
+```
+
+### ステップ 7: テスト！
+
+LINE や Telegram からメッセージを送ってみてください。MulmoClaude のサーバーログにメッセージが表示され、Claude の応答がチャットアプリに届くはずです。
+
+---
+
+## 複数のプラットフォームを同時に使う
+
+Relay は LINE と Telegram を同時に扱えます。ステップ 5 で両方のシークレットを設定し、両方の Webhook URL を登録するだけです。すべてのプラットフォームからのメッセージが 1本の WebSocket で届きます。
+
+設定済みのプラットフォームを確認：
+
+```bash
+curl https://mulmobridge-relay.あなたの名前.workers.dev/health
+```
+
+応答：
+
+```json
+{ "status": "ok", "platforms": { "line": true, "telegram": true } }
+```
+
+---
+
+## パソコンがオフのとき
+
+メッセージは Relay に保存されます（最大 1,000 件）。パソコンが再接続すると、キューに溜まったメッセージが自動的に届きます。何もする必要はありません。
+
+---
+
+## セキュリティ
+
+| レイヤー | 保護 |
+|---|---|
+| スマホ → Relay | LINE: HMAC-SHA256 署名検証。Telegram: シークレットトークンヘッダー |
+| Relay → パソコン | 暗号化された WebSocket (wss://) + bearer トークン |
+| Cloudflare | DDoS 保護、TLS 証明書（自動） |
+| アクセス制御 | あなたのパソコンだけが接続可能（同時接続1台まで） |
+
+メッセージは Cloudflare のネットワークを経由します。通信中は暗号化（TLS）され、パソコンがオフラインの間は Durable Object に一時保存されます。保存されたメッセージは配信後に削除されます。長期保存はしません。
+
+---
+
+## トラブルシューティング
+
+### "LINE not configured"（404）と表示される
+
+LINE のシークレットがまだ設定されていません：
+
+```bash
+wrangler secret put LINE_CHANNEL_SECRET
+wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+```
+
+### メッセージが届かない
+
+1. health エンドポイントを確認 — あなたのプラットフォームが `true` になっていますか？
+2. MulmoClaude のサーバーログを確認 — relay 接続のメッセージが出ていますか？
+3. `.env` の `RELAY_URL` と `RELAY_TOKEN` が正しいか確認
+
+### Webhook で "Unauthorized"（401）
+
+Webhook の署名検証に失敗しています。`LINE_CHANNEL_SECRET`（または `TELEGRAM_WEBHOOK_SECRET`）が、プラットフォームの開発者コンソールの値と一致しているか確認してください。
+
+### パソコンが再接続してもキューのメッセージが届かない
+
+キューは最大 1,000 件です。オフライン中に 1,000 件を超えるメッセージが届いた場合、古いものから削除されます。
+
+---
+
+## Relay のアップデート
+
+新しいバージョンがリリースされたら：
+
+```bash
+cd packages/relay
+git pull origin main
+wrangler deploy
+```
+
+シークレットは保持されます — 再入力の必要はありません。

--- a/docs/message_apps/relay/README.ja.md
+++ b/docs/message_apps/relay/README.ja.md
@@ -213,3 +213,15 @@ wrangler deploy
 ```
 
 シークレットは保持されます — 再入力の必要はありません。
+
+---
+
+## Claude Code でガイド付きセットアップ
+
+MulmoClaude 内で Claude Code を使っている場合、対話的にセットアップを実行できます：
+
+```
+/setup-relay
+```
+
+Claude が各ステップを案内します — 前提条件の確認、Relay のデプロイ、シークレットの設定、MulmoClaude との接続まで。ブラウザ操作が必要なコマンド（`wrangler login` など）は `!` プレフィックスでユーザーのターミナルで実行します。

--- a/docs/message_apps/relay/README.md
+++ b/docs/message_apps/relay/README.md
@@ -1,0 +1,244 @@
+# MulmoBridge Relay — No more ngrok
+
+Japanese: [`README.ja.md`](README.ja.md)
+
+---
+
+## What is the Relay?
+
+When you use LINE, Slack, or Messenger with MulmoClaude, those
+services need to send messages to your computer. Normally that
+requires **ngrok** — a tool that creates a temporary public URL
+pointing to your machine. The problem? Every time you restart
+ngrok, the URL changes and you have to update it in the LINE
+console.
+
+The **Relay** solves this. It's a tiny server that runs in the
+cloud (Cloudflare Workers) with a **permanent URL**. LINE sends
+messages to the Relay, and the Relay forwards them to your
+computer over a secure WebSocket connection. When your computer
+is off, messages are queued and delivered when you come back
+online.
+
+```text
+Your phone (LINE/Telegram)
+     ↓ message
+Relay (cloud, permanent URL)
+     ↓ WebSocket (encrypted)
+Your computer (MulmoClaude)
+     ↓
+Claude responds
+     ↓
+Relay → LINE/Telegram → Your phone
+```
+
+### Before vs After
+
+| | Before (ngrok) | After (Relay) |
+|---|---|---|
+| Public URL | Changes every restart | Permanent |
+| Setup per restart | Copy URL → LINE console | Nothing |
+| Computer off | Messages lost | Messages queued |
+| ngrok needed | Yes | No |
+| Multiple platforms | Separate process each | One Relay handles all |
+
+---
+
+## What you need
+
+1. **A Cloudflare account** (free) — [sign up here](https://dash.cloudflare.com/sign-up)
+2. **Node.js 20+** installed on your computer
+3. **MulmoClaude** already running (`yarn dev`)
+4. **A messaging bot** already created (LINE bot, Telegram bot, etc.)
+
+> **Cost**: Cloudflare Workers free tier includes 100,000 requests
+> per day — more than enough for personal use. The Relay uses
+> Durable Objects which require the Workers Paid plan ($5/month)
+> for production, but you can test with the free tier.
+
+---
+
+## Step-by-step setup
+
+### Step 1: Install the Cloudflare CLI
+
+```bash
+npm install -g wrangler
+```
+
+### Step 2: Log in to Cloudflare
+
+```bash
+wrangler login
+```
+
+A browser window opens. Log in to your Cloudflare account and
+authorize Wrangler.
+
+### Step 3: Deploy the Relay
+
+```bash
+cd packages/relay
+wrangler deploy
+```
+
+You'll see output like:
+
+```
+Published mulmobridge-relay
+  https://mulmobridge-relay.YOUR-NAME.workers.dev
+```
+
+**Save this URL** — this is your permanent Relay address.
+
+### Step 4: Set the authentication token
+
+This token is shared between the Relay and MulmoClaude so only
+your computer can connect.
+
+```bash
+wrangler secret put RELAY_TOKEN
+```
+
+Type a strong random password when prompted. **Remember it** —
+you'll need it in Step 6.
+
+### Step 5: Configure your messaging platform
+
+#### For LINE
+
+```bash
+wrangler secret put LINE_CHANNEL_SECRET
+wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+```
+
+Enter the values from your LINE Developers Console.
+
+Then update your LINE webhook URL to:
+
+```
+https://mulmobridge-relay.YOUR-NAME.workers.dev/webhook/line
+```
+
+#### For Telegram
+
+```bash
+wrangler secret put TELEGRAM_BOT_TOKEN
+wrangler secret put TELEGRAM_WEBHOOK_SECRET
+```
+
+Then set the webhook via Telegram's Bot API:
+
+```bash
+curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://mulmobridge-relay.YOUR-NAME.workers.dev/webhook/telegram&secret_token=<YOUR_WEBHOOK_SECRET>"
+```
+
+### Step 6: Connect MulmoClaude to the Relay
+
+Add to your MulmoClaude `.env` file:
+
+```dotenv
+RELAY_URL=wss://mulmobridge-relay.YOUR-NAME.workers.dev/ws
+RELAY_TOKEN=the-same-token-from-step-4
+```
+
+Then start MulmoClaude:
+
+```bash
+yarn dev
+```
+
+### Step 7: Test it!
+
+Send a message from your LINE or Telegram app. You should see
+the message appear in MulmoClaude's server log, and Claude's
+response should appear in your chat app.
+
+---
+
+## Using multiple platforms at once
+
+The Relay can handle LINE and Telegram simultaneously. Just
+configure both sets of secrets (Step 5) and both webhook URLs.
+Messages from all platforms arrive through a single WebSocket
+connection.
+
+Check which platforms are configured:
+
+```bash
+curl https://mulmobridge-relay.YOUR-NAME.workers.dev/health
+```
+
+Response:
+
+```json
+{ "status": "ok", "platforms": { "line": true, "telegram": true } }
+```
+
+---
+
+## When your computer is off
+
+Messages are stored in the Relay (up to 1,000 messages). When
+your computer reconnects, all queued messages are delivered
+automatically. You don't need to do anything.
+
+---
+
+## Security
+
+| Layer | Protection |
+|---|---|
+| Phone → Relay | LINE: HMAC-SHA256 signature verification. Telegram: secret token header |
+| Relay → Computer | Encrypted WebSocket (wss://) + bearer token |
+| Cloudflare | DDoS protection, TLS certificates (automatic) |
+| Access control | Only your computer can connect (1 connection limit) |
+
+Your messages pass through Cloudflare's network. They are
+encrypted in transit (TLS) and temporarily stored in the
+Durable Object when your computer is offline. Stored messages
+are deleted after delivery. No long-term storage.
+
+---
+
+## Troubleshooting
+
+### "LINE not configured" (404)
+
+You haven't set the LINE secrets yet. Run:
+
+```bash
+wrangler secret put LINE_CHANNEL_SECRET
+wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+```
+
+### Messages not arriving
+
+1. Check the health endpoint — is your platform listed as `true`?
+2. Check MulmoClaude server logs — do you see relay connection messages?
+3. Verify your `.env` has the correct `RELAY_URL` and `RELAY_TOKEN`
+
+### "Unauthorized" (401) on webhook
+
+The webhook signature verification failed. Double-check that
+`LINE_CHANNEL_SECRET` (or `TELEGRAM_WEBHOOK_SECRET`) matches
+what's in your platform's developer console.
+
+### Computer reconnects but no queued messages
+
+The queue holds up to 1,000 messages. If more than 1,000
+messages arrived while offline, the oldest ones are dropped.
+
+---
+
+## Updating the Relay
+
+When a new version is released:
+
+```bash
+cd packages/relay
+git pull origin main
+wrangler deploy
+```
+
+Your secrets are preserved — no need to re-enter them.

--- a/docs/message_apps/relay/README.md
+++ b/docs/message_apps/relay/README.md
@@ -242,3 +242,19 @@ wrangler deploy
 ```
 
 Your secrets are preserved — no need to re-enter them.
+
+---
+
+## Guided setup with Claude Code
+
+If you're using Claude Code inside MulmoClaude, you can run the
+setup interactively:
+
+```
+/setup-relay
+```
+
+Claude will walk you through each step — checking prerequisites,
+deploying the Relay, configuring secrets, and connecting MulmoClaude.
+Commands that require browser interaction (like `wrangler login`)
+are run in your terminal via the `!` prefix.

--- a/docs/message_apps/telegram/README.ja.md
+++ b/docs/message_apps/telegram/README.ja.md
@@ -20,6 +20,11 @@ English: [`README.md`](README.md)
 
 PC を閉じたりネットを切ったりすると bot は沈黙します。
 
+> **ヒント**: オフライン時のメッセージキューが欲しいですか？
+> [MulmoBridge Relay](../relay/README.ja.md) を使えば、メッセージが
+> クラウドに保存され、PC がオンラインに戻ったときに届きます。
+> セットアップ: Claude Code で `/setup-relay` を実行。
+
 ---
 
 ## ステップ 1 — BotFather で bot を作る

--- a/docs/message_apps/telegram/README.md
+++ b/docs/message_apps/telegram/README.md
@@ -20,6 +20,11 @@ sharing the bot with friends / family.
 Your computer has to be on and connected to the internet for the
 bot to respond. Close the laptop → the bot goes silent.
 
+> **Tip**: Want offline message queuing? Use the
+> [MulmoBridge Relay](../relay/README.md) — messages are stored
+> in the cloud and delivered when your computer comes back online.
+> Setup: `/setup-relay` in Claude Code.
+
 ---
 
 ## Step 1 — Create the bot with BotFather


### PR DESCRIPTION
## Summary

- Relay のセットアップガイドを日英で作成（非エンジニア向け）
- docs/message_apps/relay/ に配置（LINE, Telegram と同じ構造）

## Content

- Relay とは何か（ngrok が不要になる仕組み）
- ビフォー・アフター比較表
- 7ステップのセットアップ手順（コマンド付き）
- 複数プラットフォーム同時利用
- オフラインキューの説明
- セキュリティ概要
- トラブルシューティング

🤖 Generated with [Claude Code](https://claude.com/claude-code)