### PR TITLE
feat: user-configurable read-only reference directories (#455)

### DIFF
--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -29,6 +29,10 @@ import { log } from "../system/logger/index.js";
 import { EVENT_TYPES } from "../../src/types/events.js";
 import { env } from "../system/env.js";
 import { resolveSandboxAuth } from "./sandboxMounts.js";
+import {
+  getCachedReferenceDirs,
+  referenceDirMountArgs,
+} from "../workspace/reference-dirs.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
 
@@ -49,13 +53,14 @@ function spawnClaude(
     configMountNames: env.sandboxMountConfigs,
     sshAuthSock: process.env.SSH_AUTH_SOCK,
   });
+  const refDirArgs = referenceDirMountArgs(getCachedReferenceDirs());
   const dockerArgs = buildDockerSpawnArgs({
     workspacePath,
     cliArgs,
     uid: process.getuid?.() ?? 1000,
     gid: process.getgid?.() ?? 1000,
     platform: process.platform,
-    sandboxAuthArgs: sandboxAuth.args,
+    sandboxAuthArgs: [...sandboxAuth.args, ...refDirArgs],
     sshAgentForward: env.sandboxSshAgentForward,
   });
   return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -8,6 +8,10 @@ import {
   getCachedCustomDirs,
   buildCustomDirsPrompt,
 } from "../workspace/custom-dirs.js";
+import {
+  getCachedReferenceDirs,
+  buildReferenceDirsPrompt,
+} from "../workspace/reference-dirs.js";
 
 export const SYSTEM_PROMPT = `You are MulmoClaude, a versatile assistant app with rich visual output.
 
@@ -306,6 +310,7 @@ export function buildSystemPrompt(params: SystemPromptParams): string {
     buildWikiContext(workspacePath),
     buildSourcesContext(workspacePath),
     buildCustomDirsPrompt(getCachedCustomDirs()),
+    buildReferenceDirsPrompt(getCachedReferenceDirs(), useDocker),
     headingSection(
       "Reference Files",
       buildInlinedHelpFiles(role.prompt, workspacePath),

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -20,6 +20,12 @@ import {
   validateCustomDirs,
   type CustomDirEntry,
 } from "../../workspace/custom-dirs.js";
+import {
+  loadReferenceDirs,
+  saveReferenceDirs,
+  validateReferenceDirs,
+  type ReferenceDirEntry,
+} from "../../workspace/reference-dirs.js";
 
 // Public surface of /api/config. GET returns the full config tree so
 // the client can render every section in one request. PUT surfaces are
@@ -215,6 +221,42 @@ router.put(
     try {
       saveCustomDirs(result.entries);
       ensureCustomDirs(result.entries);
+      res.json({ dirs: result.entries });
+    } catch (err) {
+      serverError(res, err instanceof Error ? err.message : "save failed");
+    }
+  },
+);
+
+// ── Reference directories (#455) ────────────────────────────────
+
+router.get(
+  API_ROUTES.config.referenceDirs,
+  (_req: Request, res: Response<{ dirs: ReferenceDirEntry[] }>) => {
+    res.json({ dirs: loadReferenceDirs() });
+  },
+);
+
+router.put(
+  API_ROUTES.config.referenceDirs,
+  (
+    req: Request<unknown, unknown, { dirs: unknown }>,
+    res: Response<{ dirs: ReferenceDirEntry[] } | ConfigErrorResponse>,
+  ) => {
+    const body = req.body;
+    if (typeof body !== "object" || body === null || !("dirs" in body)) {
+      badRequest(res, "expected { dirs: [...] }");
+      return;
+    }
+    const result = validateReferenceDirs(
+      (body as Record<string, unknown>).dirs,
+    );
+    if ("error" in result) {
+      badRequest(res, result.error);
+      return;
+    }
+    try {
+      saveReferenceDirs(result.entries);
       res.json({ dirs: result.entries });
     } catch (err) {
       serverError(res, err instanceof Error ? err.message : "save failed");

--- a/server/utils/files/index.ts
+++ b/server/utils/files/index.ts
@@ -59,3 +59,4 @@ export * from "./session-io.js";
 export * from "./todos-io.js";
 export * from "./scheduler-io.js";
 export * from "./html-io.js";
+export * from "./reference-dirs-io.js";

--- a/server/utils/files/reference-dirs-io.ts
+++ b/server/utils/files/reference-dirs-io.ts
@@ -1,0 +1,48 @@
+// Domain I/O for reference directories.
+//
+// Reads/writes config/reference-dirs.json and checks host paths.
+// All fs access is funneled through shared helpers so path changes
+// propagate from a single constant.
+
+import fs from "fs";
+import path from "path";
+import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
+import { loadJsonFile } from "./json.js";
+import { writeFileAtomicSync } from "./atomic.js";
+import { log } from "../../system/logger/index.js";
+
+const CONFIG_FILE_NAME = "reference-dirs.json";
+
+function configPath(root: string): string {
+  return path.join(root, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
+}
+
+/** Read reference-dirs.json. Returns [] on missing/corrupt file. */
+export function readReferenceDirsJson(root?: string): unknown[] {
+  const filePath = configPath(root ?? workspacePath);
+  const parsed = loadJsonFile<unknown>(filePath, []);
+  if (!Array.isArray(parsed)) {
+    log.warn("reference-dirs-io", "reference-dirs.json is not an array");
+    return [];
+  }
+  return parsed;
+}
+
+/** Write reference-dirs.json atomically. Creates config/ if needed. */
+export function writeReferenceDirsJson(
+  entries: readonly unknown[],
+  root?: string,
+): void {
+  const filePath = configPath(root ?? workspacePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
+}
+
+/** Check whether a host path exists and is a directory. */
+export function isExistingDirectory(hostPath: string): boolean {
+  try {
+    return fs.statSync(hostPath).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -1,0 +1,248 @@
+// User-defined reference directories (#455).
+//
+// Loaded from `config/reference-dirs.json`. Users can specify external
+// directories that the agent can read (but not write to).
+//
+// Docker mode: mounted as `:ro` — filesystem-enforced read-only.
+// Non-Docker mode: prompt-based restriction only.
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { workspacePath } from "./paths.js";
+import { log } from "../system/logger/index.js";
+import { writeFileAtomicSync } from "../utils/files/atomic.js";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface ReferenceDirEntry {
+  /** Absolute host path to the directory. */
+  hostPath: string;
+  /** Short label shown in prompt and UI. */
+  label: string;
+}
+
+// ── Constants ───────────────────────────────────────────────────
+
+const CONFIG_FILE = "config/reference-dirs.json";
+const MAX_ENTRIES = 20;
+const MAX_LABEL_LENGTH = 100;
+const CONTAINER_MOUNT_ROOT = "/mnt/readonly";
+
+/** Directories that must never be mounted — credential/key stores. */
+const BLOCKED_PATHS = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".config/gh",
+  ".kube",
+  ".docker",
+];
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE_G = /[\x00-\x1f]/g;
+
+// ── Validation ──────────────────────────────────────────────────
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+function isSensitivePath(absPath: string): boolean {
+  const home = os.homedir();
+  return BLOCKED_PATHS.some((bp) => {
+    const full = path.join(home, bp);
+    return absPath === full || absPath.startsWith(full + path.sep);
+  });
+}
+
+function sanitizeLabel(raw: string): string {
+  if (typeof raw !== "string") return "";
+  return raw.replace(CONTROL_CHAR_RE_G, " ").trim().slice(0, MAX_LABEL_LENGTH);
+}
+
+function validateEntry(raw: unknown): ReferenceDirEntry | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+
+  const rawPath = typeof obj.hostPath === "string" ? obj.hostPath : "";
+  if (!rawPath) return null;
+
+  const absPath = expandHome(rawPath);
+
+  // Must be absolute
+  if (!path.isAbsolute(absPath)) return null;
+
+  // No path traversal
+  if (absPath.includes("..")) return null;
+
+  // Block sensitive directories
+  if (isSensitivePath(absPath)) {
+    log.warn("reference-dirs", "blocked sensitive path", { path: absPath });
+    return null;
+  }
+
+  const label = sanitizeLabel(String(obj.label ?? path.basename(absPath)));
+
+  return { hostPath: absPath, label };
+}
+
+// ── Load ────────────────────────────────────────────────────────
+
+export function loadReferenceDirs(root?: string): ReferenceDirEntry[] {
+  const base = root ?? workspacePath;
+  const filePath = path.join(base, CONFIG_FILE);
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      log.warn("reference-dirs", "reference-dirs.json is not an array");
+      return [];
+    }
+    const entries = parsed
+      .slice(0, MAX_ENTRIES)
+      .map(validateEntry)
+      .filter((e): e is ReferenceDirEntry => e !== null);
+
+    const skipped = parsed.length - entries.length;
+    if (skipped > 0) {
+      log.warn("reference-dirs", "skipped invalid entries", { skipped });
+    }
+    return entries;
+  } catch (err) {
+    log.warn("reference-dirs", "failed to load reference-dirs.json", {
+      error: String(err),
+    });
+    return [];
+  }
+}
+
+// ── Save ────────────────────────────────────────────────────────
+
+export function saveReferenceDirs(
+  entries: readonly ReferenceDirEntry[],
+  root?: string,
+): void {
+  const base = root ?? workspacePath;
+  const filePath = path.join(base, CONFIG_FILE);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
+  invalidateCache();
+}
+
+// ── Validate input array (for API) ─────────────────────────────
+
+export function validateReferenceDirs(
+  raw: unknown,
+): { entries: ReferenceDirEntry[] } | { error: string } {
+  if (!Array.isArray(raw)) {
+    return { error: "expected an array" };
+  }
+  if (raw.length > MAX_ENTRIES) {
+    return { error: `too many entries (max ${MAX_ENTRIES})` };
+  }
+  const entries: ReferenceDirEntry[] = [];
+  const errors: string[] = [];
+  raw.forEach((item, i) => {
+    const entry = validateEntry(item);
+    if (entry) {
+      entries.push(entry);
+    } else {
+      const p =
+        typeof item === "object" && item !== null
+          ? String((item as Record<string, unknown>).hostPath ?? "")
+          : "";
+      errors.push(`entry ${i}: invalid or blocked path "${p}"`);
+    }
+  });
+  if (errors.length > 0) {
+    return { error: errors.join("; ") };
+  }
+  return { entries };
+}
+
+// ── Cached loader (for system prompt + Docker mounts) ───────────
+
+let cachedEntries: ReferenceDirEntry[] | null = null;
+
+export function getCachedReferenceDirs(): readonly ReferenceDirEntry[] {
+  if (cachedEntries === null) {
+    cachedEntries = loadReferenceDirs();
+  }
+  return cachedEntries;
+}
+
+function invalidateCache(): void {
+  cachedEntries = null;
+}
+
+// ── Docker mount args ───────────────────────────────────────────
+
+/** Container path for a reference directory. */
+export function containerPath(entry: ReferenceDirEntry): string {
+  const basename = path.basename(entry.hostPath);
+  return path.posix.join(CONTAINER_MOUNT_ROOT, basename);
+}
+
+/**
+ * Return Docker `-v` args for read-only reference directory mounts.
+ * Skips entries whose host path doesn't exist.
+ */
+export function referenceDirMountArgs(
+  entries: readonly ReferenceDirEntry[],
+): string[] {
+  const args: string[] = [];
+  for (const entry of entries) {
+    try {
+      const stat = fs.statSync(entry.hostPath);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      log.info("reference-dirs", "skipped (not found)", {
+        path: entry.hostPath,
+      });
+      continue;
+    }
+    const host = entry.hostPath.replace(/\\/g, "/");
+    args.push("-v", `${host}:${containerPath(entry)}:ro`);
+  }
+  return args;
+}
+
+// ── System prompt snippet ───────────────────────────────────────
+
+export function buildReferenceDirsPrompt(
+  entries: readonly ReferenceDirEntry[],
+  useDocker: boolean,
+): string {
+  if (entries.length === 0) return "";
+
+  const lines = [
+    "",
+    "## Reference Directories (Read-Only)",
+    "",
+    "The user has configured external directories for reference.",
+    "You may READ files in these directories but MUST NOT write, modify, or delete anything in them.",
+    "",
+  ];
+
+  for (const e of entries) {
+    const mountPath = useDocker ? containerPath(e) : e.hostPath;
+    lines.push(`- \`${mountPath}\` — ${e.label}`);
+  }
+
+  if (!useDocker) {
+    lines.push("");
+    lines.push(
+      "**Important**: These directories are outside the workspace. " +
+        "Do not create, edit, or delete files in them. " +
+        "Only use read operations (read, glob, grep).",
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -7,12 +7,14 @@
 // Non-Docker mode: prompt-based restriction only.
 
 import { createHash } from "crypto";
-import fs from "fs";
 import path from "path";
 import os from "os";
-import { workspacePath, WORKSPACE_DIRS } from "./paths.js";
 import { log } from "../system/logger/index.js";
-import { writeFileAtomicSync } from "../utils/files/atomic.js";
+import {
+  readReferenceDirsJson,
+  writeReferenceDirsJson,
+  isExistingDirectory,
+} from "../utils/files/reference-dirs-io.js";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -25,7 +27,6 @@ export interface ReferenceDirEntry {
 
 // ── Constants ───────────────────────────────────────────────────
 
-const CONFIG_FILE_NAME = "reference-dirs.json";
 const MAX_ENTRIES = 20;
 const MAX_LABEL_LENGTH = 100;
 const CONTAINER_MOUNT_ROOT = "/mnt/readonly";
@@ -134,32 +135,17 @@ function validateEntry(raw: unknown): ReferenceDirEntry | null {
 // ── Load ────────────────────────────────────────────────────────
 
 export function loadReferenceDirs(root?: string): ReferenceDirEntry[] {
-  const base = root ?? workspacePath;
-  const filePath = path.join(base, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
-  try {
-    if (!fs.existsSync(filePath)) return [];
-    const raw = fs.readFileSync(filePath, "utf-8");
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      log.warn("reference-dirs", "reference-dirs.json is not an array");
-      return [];
-    }
-    const entries = parsed
-      .slice(0, MAX_ENTRIES)
-      .map(validateEntry)
-      .filter((e): e is ReferenceDirEntry => e !== null);
+  const parsed = readReferenceDirsJson(root);
+  const entries = parsed
+    .slice(0, MAX_ENTRIES)
+    .map(validateEntry)
+    .filter((e): e is ReferenceDirEntry => e !== null);
 
-    const skipped = parsed.length - entries.length;
-    if (skipped > 0) {
-      log.warn("reference-dirs", "skipped invalid entries", { skipped });
-    }
-    return entries;
-  } catch (err) {
-    log.warn("reference-dirs", "failed to load reference-dirs.json", {
-      error: String(err),
-    });
-    return [];
+  const skipped = parsed.length - entries.length;
+  if (skipped > 0) {
+    log.warn("reference-dirs", "skipped invalid entries", { skipped });
   }
+  return entries;
 }
 
 // ── Save ────────────────────────────────────────────────────────
@@ -168,10 +154,7 @@ export function saveReferenceDirs(
   entries: readonly ReferenceDirEntry[],
   root?: string,
 ): void {
-  const base = root ?? workspacePath;
-  const filePath = path.join(base, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
+  writeReferenceDirsJson(entries, root);
   invalidateCache();
 }
 
@@ -244,11 +227,8 @@ export function referenceDirMountArgs(
 ): string[] {
   const args: string[] = [];
   for (const entry of entries) {
-    try {
-      const stat = fs.statSync(entry.hostPath);
-      if (!stat.isDirectory()) continue;
-    } catch {
-      log.info("reference-dirs", "skipped (not found)", {
+    if (!isExistingDirectory(entry.hostPath)) {
+      log.info("reference-dirs", "skipped (not found or not a directory)", {
         path: entry.hostPath,
       });
       continue;

--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -6,10 +6,11 @@
 // Docker mode: mounted as `:ro` — filesystem-enforced read-only.
 // Non-Docker mode: prompt-based restriction only.
 
+import { createHash } from "crypto";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { workspacePath } from "./paths.js";
+import { workspacePath, WORKSPACE_DIRS } from "./paths.js";
 import { log } from "../system/logger/index.js";
 import { writeFileAtomicSync } from "../utils/files/atomic.js";
 
@@ -24,19 +25,33 @@ export interface ReferenceDirEntry {
 
 // ── Constants ───────────────────────────────────────────────────
 
-const CONFIG_FILE = "config/reference-dirs.json";
+const CONFIG_FILE_NAME = "reference-dirs.json";
 const MAX_ENTRIES = 20;
 const MAX_LABEL_LENGTH = 100;
 const CONTAINER_MOUNT_ROOT = "/mnt/readonly";
 
-/** Directories that must never be mounted — credential/key stores. */
-const BLOCKED_PATHS = [
+/** Home-relative directories that must never be mounted. */
+const HOME_RELATIVE_BLOCKED = [
   ".ssh",
   ".aws",
   ".gnupg",
   ".config/gh",
   ".kube",
   ".docker",
+];
+
+/** Absolute system paths that must never be mounted. */
+const SYSTEM_BLOCKED_PREFIXES = [
+  "/etc",
+  "/root",
+  "/var",
+  "/proc",
+  "/sys",
+  "/boot",
+  "/private/etc",
+  "/private/var",
+  "/System",
+  "/Library",
 ];
 
 // eslint-disable-next-line no-control-regex
@@ -52,16 +67,39 @@ function expandHome(p: string): string {
 }
 
 function isSensitivePath(absPath: string): boolean {
+  const normalized = path.resolve(absPath);
+
+  // Reject filesystem root
+  if (normalized === path.parse(normalized).root) return true;
+
   const home = os.homedir();
-  return BLOCKED_PATHS.some((bp) => {
-    const full = path.join(home, bp);
-    return absPath === full || absPath.startsWith(full + path.sep);
-  });
+
+  // Block $HOME itself (transitively exposes .ssh etc.)
+  if (normalized === home) return true;
+
+  // Block home-relative sensitive dirs
+  if (
+    HOME_RELATIVE_BLOCKED.some((bp) => {
+      const full = path.join(home, bp);
+      return normalized === full || normalized.startsWith(full + path.sep);
+    })
+  ) {
+    return true;
+  }
+
+  // Block system directories
+  return SYSTEM_BLOCKED_PREFIXES.some(
+    (p) => normalized === p || normalized.startsWith(p + path.sep),
+  );
 }
 
 function sanitizeLabel(raw: string): string {
   if (typeof raw !== "string") return "";
   return raw.replace(CONTROL_CHAR_RE_G, " ").trim().slice(0, MAX_LABEL_LENGTH);
+}
+
+function hasTraversalSegment(p: string): boolean {
+  return p.split(path.sep).some((seg) => seg === "..");
 }
 
 function validateEntry(raw: unknown): ReferenceDirEntry | null {
@@ -71,13 +109,16 @@ function validateEntry(raw: unknown): ReferenceDirEntry | null {
   const rawPath = typeof obj.hostPath === "string" ? obj.hostPath : "";
   if (!rawPath) return null;
 
-  const absPath = expandHome(rawPath);
+  const expanded = expandHome(rawPath);
 
   // Must be absolute
-  if (!path.isAbsolute(absPath)) return null;
+  if (!path.isAbsolute(expanded)) return null;
 
-  // No path traversal
-  if (absPath.includes("..")) return null;
+  // Normalize to collapse . and // segments
+  const absPath = path.resolve(expanded);
+
+  // Reject actual ".." traversal segments (not substrings in filenames)
+  if (hasTraversalSegment(expanded)) return null;
 
   // Block sensitive directories
   if (isSensitivePath(absPath)) {
@@ -94,7 +135,7 @@ function validateEntry(raw: unknown): ReferenceDirEntry | null {
 
 export function loadReferenceDirs(root?: string): ReferenceDirEntry[] {
   const base = root ?? workspacePath;
-  const filePath = path.join(base, CONFIG_FILE);
+  const filePath = path.join(base, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
   try {
     if (!fs.existsSync(filePath)) return [];
     const raw = fs.readFileSync(filePath, "utf-8");
@@ -128,7 +169,7 @@ export function saveReferenceDirs(
   root?: string,
 ): void {
   const base = root ?? workspacePath;
-  const filePath = path.join(base, CONFIG_FILE);
+  const filePath = path.join(base, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
   invalidateCache();
@@ -182,10 +223,16 @@ function invalidateCache(): void {
 
 // ── Docker mount args ───────────────────────────────────────────
 
-/** Container path for a reference directory. */
+/** Container path for a reference directory.
+ *  Disambiguates with a short hash suffix to prevent collisions
+ *  when different host paths share the same basename. */
 export function containerPath(entry: ReferenceDirEntry): string {
   const basename = path.basename(entry.hostPath);
-  return path.posix.join(CONTAINER_MOUNT_ROOT, basename);
+  const hash = createHash("sha256")
+    .update(entry.hostPath)
+    .digest("hex")
+    .slice(0, 8);
+  return path.posix.join(CONTAINER_MOUNT_ROOT, `${basename}-${hash}`);
 }
 
 /**

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -69,6 +69,18 @@
         >
           Directories
         </button>
+        <button
+          class="px-3 py-2 text-sm border-b-2"
+          :class="
+            activeTab === 'refs'
+              ? 'border-blue-500 text-blue-600'
+              : 'border-transparent text-gray-500 hover:text-gray-800'
+          "
+          data-testid="settings-tab-refs"
+          @click="activeTab = 'refs'"
+        >
+          Reference Dirs
+        </button>
       </div>
 
       <div class="px-5 py-4 overflow-y-auto flex-1 space-y-4 text-gray-900">
@@ -127,6 +139,8 @@
         </div>
 
         <SettingsWorkspaceDirsTab v-else-if="activeTab === 'dirs'" />
+
+        <SettingsReferenceDirsTab v-else-if="activeTab === 'refs'" />
       </div>
 
       <div
@@ -174,6 +188,7 @@
 import { computed, ref, watch } from "vue";
 import SettingsMcpTab from "./SettingsMcpTab.vue";
 import SettingsWorkspaceDirsTab from "./SettingsWorkspaceDirsTab.vue";
+import SettingsReferenceDirsTab from "./SettingsReferenceDirsTab.vue";
 import type { McpServerEntry } from "./SettingsMcpTab.vue";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -201,7 +216,7 @@ const emit = defineEmits<{
 // button" footgun). Null when the MCP tab isn't the active one.
 const mcpTabRef = ref<{ flushDraft: () => boolean } | null>(null);
 
-const activeTab = ref<"tools" | "mcp" | "dirs">("tools");
+const activeTab = ref<"tools" | "mcp" | "dirs" | "refs">("tools");
 const toolsText = ref("");
 const mcpServers = ref<McpServerEntry[]>([]);
 const loadError = ref("");

--- a/src/components/SettingsReferenceDirsTab.vue
+++ b/src/components/SettingsReferenceDirsTab.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+interface RefDirEntry {
+  hostPath: string;
+  label: string;
+}
+
+const dirs = ref<RefDirEntry[]>([]);
+const loading = ref(true);
+const error = ref("");
+const saving = ref(false);
+const saveStatus = ref("");
+
+const draftPath = ref("");
+const draftLabel = ref("");
+const draftError = ref("");
+
+async function load(): Promise<void> {
+  loading.value = true;
+  error.value = "";
+  const result = await apiGet<{ dirs: RefDirEntry[] }>(
+    API_ROUTES.config.referenceDirs,
+  );
+  loading.value = false;
+  if (!result.ok) {
+    error.value = result.error;
+    return;
+  }
+  dirs.value = result.data.dirs;
+}
+
+async function save(): Promise<void> {
+  saving.value = true;
+  saveStatus.value = "";
+  const result = await apiPut<{ dirs: RefDirEntry[] }>(
+    API_ROUTES.config.referenceDirs,
+    { dirs: dirs.value },
+  );
+  saving.value = false;
+  if (!result.ok) {
+    saveStatus.value = result.error;
+    return;
+  }
+  dirs.value = result.data.dirs;
+  saveStatus.value = "Saved";
+  setTimeout(() => {
+    saveStatus.value = "";
+  }, 2000);
+}
+
+function addEntry(): void {
+  draftError.value = "";
+  const p = draftPath.value.trim();
+  if (!p) {
+    draftError.value = "Path required";
+    return;
+  }
+  if (!p.startsWith("/") && !p.startsWith("~/")) {
+    draftError.value = "Must be an absolute path or start with ~/";
+    return;
+  }
+  if (dirs.value.some((d) => d.hostPath === p)) {
+    draftError.value = "Already exists";
+    return;
+  }
+  dirs.value.push({
+    hostPath: p,
+    label: draftLabel.value.trim() || p.split("/").pop() || p,
+  });
+  draftPath.value = "";
+  draftLabel.value = "";
+}
+
+function removeEntry(index: number): void {
+  dirs.value.splice(index, 1);
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="space-y-3">
+    <p class="text-xs text-gray-600 leading-relaxed">
+      External directories Claude can read but not modify. In Docker mode, these
+      are mounted read-only. Useful for referencing Obsidian vaults, project
+      code, or document folders.
+    </p>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-sm text-gray-400">Loading...</div>
+    <div
+      v-else-if="error"
+      class="text-sm text-red-600 bg-red-50 rounded px-3 py-2"
+    >
+      {{ error }}
+    </div>
+
+    <template v-else>
+      <!-- Existing entries -->
+      <div v-if="dirs.length === 0" class="text-sm text-gray-400">
+        No reference directories configured.
+      </div>
+      <div v-else class="space-y-1.5">
+        <div
+          v-for="(dir, i) in dirs"
+          :key="dir.hostPath"
+          class="flex items-center gap-2 px-2 py-1.5 bg-gray-50 rounded text-sm"
+          :data-testid="`reference-dir-${i}`"
+        >
+          <span class="material-icons text-sm text-gray-400 shrink-0"
+            >folder_open</span
+          >
+          <div class="flex-1 min-w-0">
+            <div class="font-mono text-xs text-gray-800 truncate">
+              {{ dir.hostPath }}
+            </div>
+            <div v-if="dir.label" class="text-xs text-gray-500 truncate">
+              {{ dir.label }}
+            </div>
+          </div>
+          <span
+            class="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-600 shrink-0"
+          >
+            read-only
+          </span>
+          <button
+            class="text-gray-300 hover:text-red-500 shrink-0"
+            title="Remove"
+            @click="removeEntry(i)"
+          >
+            <span class="material-icons text-sm">close</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Add new -->
+      <div class="border border-gray-200 rounded p-2 space-y-2">
+        <div class="text-xs font-semibold text-gray-600">
+          Add reference directory
+        </div>
+        <input
+          v-model="draftPath"
+          class="w-full px-2 py-1 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          placeholder="/Users/me/ObsidianVault or ~/Documents/notes"
+          data-testid="reference-dir-path-input"
+          @keydown.enter="addEntry"
+          @keydown.stop
+        />
+        <input
+          v-model="draftLabel"
+          class="w-full px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+          placeholder="Label (optional — defaults to folder name)"
+          data-testid="reference-dir-label-input"
+          @keydown.enter="addEntry"
+          @keydown.stop
+        />
+        <div class="flex items-center gap-2">
+          <button
+            class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600"
+            data-testid="reference-dir-add-btn"
+            @click="addEntry"
+          >
+            Add
+          </button>
+          <span v-if="draftError" class="text-xs text-red-500">{{
+            draftError
+          }}</span>
+        </div>
+      </div>
+
+      <!-- Save -->
+      <div class="flex items-center gap-2">
+        <button
+          class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300"
+          :disabled="saving"
+          data-testid="reference-dirs-save-btn"
+          @click="save"
+        >
+          {{ saving ? "Saving..." : "Save" }}
+        </button>
+        <span
+          v-if="saveStatus"
+          class="text-xs"
+          :class="saveStatus === 'Saved' ? 'text-green-600' : 'text-red-600'"
+        >
+          {{ saveStatus }}
+        </span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/components/SettingsReferenceDirsTab.vue
+++ b/src/components/SettingsReferenceDirsTab.vue
@@ -62,13 +62,24 @@ function addEntry(): void {
     draftError.value = "Must be an absolute path or start with ~/";
     return;
   }
-  if (dirs.value.some((d) => d.hostPath === p)) {
+  // Normalize: trim trailing slashes for consistent comparison
+  let normalized = p;
+  while (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  const stripSlash = (s: string): string => {
+    let r = s;
+    while (r.length > 1 && r.endsWith("/")) r = r.slice(0, -1);
+    return r;
+  };
+  if (dirs.value.some((d) => stripSlash(d.hostPath) === normalized)) {
     draftError.value = "Already exists";
     return;
   }
+  const lastSeg = normalized.split("/").pop();
   dirs.value.push({
-    hostPath: p,
-    label: draftLabel.value.trim() || p.split("/").pop() || p,
+    hostPath: normalized,
+    label: draftLabel.value.trim() || lastSeg || normalized,
   });
   draftPath.value = "";
   draftLabel.value = "";
@@ -129,6 +140,7 @@ onMounted(load);
           <button
             class="text-gray-300 hover:text-red-500 shrink-0"
             title="Remove"
+            data-testid="reference-dir-remove-btn"
             @click="removeEntry(i)"
           >
             <span class="material-icons text-sm">close</span>

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -49,6 +49,7 @@ export const API_ROUTES = {
     settings: "/api/config/settings",
     mcp: "/api/config/mcp",
     workspaceDirs: "/api/config/workspace-dirs",
+    referenceDirs: "/api/config/reference-dirs",
   },
 
   files: {


### PR DESCRIPTION
## Summary

- Users can specify external directories (e.g. Obsidian vault, project code) that Claude can read but not modify
- Docker mode: directories are mounted with `:ro` flag — filesystem-enforced read-only
- Non-Docker mode: system prompt instructs read-only access (best-effort)
- New "Reference Dirs" tab in Settings modal for easy configuration

## Items to Confirm / Review

- Sensitive path blocking: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gh`, `~/.kube`, `~/.docker` — should more paths be blocked?
- Container mount path: `/mnt/readonly/<basename>` — basename collisions are possible if two dirs have the same folder name
- Max 20 reference directories — is this enough?

## Implementation

| File | Change |
|------|--------|
| `server/workspace/reference-dirs.ts` | Core: load/save/validate/cache, Docker mount args, prompt builder |
| `server/agent/index.ts` | Inject reference dir mounts into Docker spawn args |
| `server/agent/prompt.ts` | Add reference dirs to system prompt |
| `server/api/routes/config.ts` | GET/PUT `/api/config/reference-dirs` |
| `src/config/apiRoutes.ts` | Route constant |
| `src/components/SettingsReferenceDirsTab.vue` | Settings UI tab |
| `src/components/SettingsModal.vue` | Add "Reference Dirs" tab |

## User Prompt

> #455: user-configurable read-only directory mounts for Docker sandbox
> Obsidian vault との連携に便利

## Test plan

- [ ] `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` pass
- [ ] Manual: Settings → Reference Dirs → add path → Save → verify config file created
- [ ] Manual: Docker mode → verify directory is mounted read-only
- [ ] Manual: blocked paths (e.g. ~/.ssh) are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Reference Dirs" settings tab for configuring external read-only directories accessible to the AI agent
  * Users can add directories with custom labels using absolute or home-directory paths
  * Configured directories are automatically mounted in Docker environments and included in AI agent prompts
  * Added validation to prevent sensitive directories from being added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->