### PR TITLE
feat: dynamic favicon — state-aware color icon (#470)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     -->
     <meta name="mulmoclaude-auth" content="__MULMOCLAUDE_AUTH_TOKEN__" />
     <title>MulmoClaude</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='30' height='30' x='1' y='1' rx='6' fill='%236B7280'/><text x='16' y='17' text-anchor='middle' dominant-baseline='central' font-family='sans-serif' font-weight='bold' font-size='20' fill='white'>M</text></svg>" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -742,22 +742,6 @@ const toolCallHistory = computed(
   () => activeSession.value?.toolCallHistory ?? [],
 );
 
-// ── Dynamic favicon (#470) ──────────────────────────────────
-const faviconState = computed<FaviconState>(() => {
-  if (isRunning.value) return FAVICON_STATES.running;
-  const hasUnread =
-    currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
-  if (hasUnread) return FAVICON_STATES.done;
-  return FAVICON_STATES.idle;
-});
-
-const { unreadCount: notificationUnreadCount } = useNotifications();
-const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0);
-
-useDynamicFavicon({
-  state: faviconState,
-  hasNotification: hasNotificationBadge,
-});
 const selectedResultUuid = computed({
   get: () => activeSession.value?.selectedResultUuid ?? null,
   set: (val: string | null) => {
@@ -865,6 +849,23 @@ const { sessions, showHistory, historyError, fetchSessions, toggleHistory } =
   useSessionHistory();
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 const showLockPopup = ref(false);
+
+// ── Dynamic favicon (#470) ──────────────────────────────────
+const faviconState = computed<FaviconState>(() => {
+  if (isRunning.value) return FAVICON_STATES.running;
+  const hasUnread =
+    currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
+  if (hasUnread) return FAVICON_STATES.done;
+  return FAVICON_STATES.idle;
+});
+
+const { unreadCount: notificationUnreadCount } = useNotifications();
+const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0);
+
+useDynamicFavicon({
+  state: faviconState,
+  hasNotification: hasNotificationBadge,
+});
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);

--- a/src/App.vue
+++ b/src/App.vue
@@ -466,6 +466,12 @@ import {
 } from "./types/notification";
 import { CANVAS_VIEW } from "./utils/canvas/viewMode";
 import ChatAttachmentPreview from "./components/ChatAttachmentPreview.vue";
+import {
+  useDynamicFavicon,
+  FAVICON_STATES,
+  type FaviconState,
+} from "./composables/useDynamicFavicon";
+import { useNotifications } from "./composables/useNotifications";
 import type { SseEvent } from "./types/sse";
 import {
   type SessionSummary,
@@ -735,6 +741,23 @@ const statusMessage = computed(
 const toolCallHistory = computed(
   () => activeSession.value?.toolCallHistory ?? [],
 );
+
+// ── Dynamic favicon (#470) ──────────────────────────────────
+const faviconState = computed<FaviconState>(() => {
+  if (isRunning.value) return FAVICON_STATES.running;
+  const hasUnread =
+    currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
+  if (hasUnread) return FAVICON_STATES.done;
+  return FAVICON_STATES.idle;
+});
+
+const { unreadCount: notificationUnreadCount } = useNotifications();
+const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0);
+
+useDynamicFavicon({
+  state: faviconState,
+  hasNotification: hasNotificationBadge,
+});
 const selectedResultUuid = computed({
   get: () => activeSession.value?.selectedResultUuid ?? null,
   set: (val: string | null) => {

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -110,6 +110,7 @@ function applyFavicon(dataUrl: string): void {
     link.type = "image/png";
     document.head.appendChild(link);
   }
+  link.type = "image/png";
   link.href = dataUrl;
 }
 

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,0 +1,126 @@
+// Dynamic favicon that changes color based on agent state (#470).
+//
+// Uses Canvas API to draw a rounded-square icon with the letter "M"
+// in the center. Color reflects the current state:
+//   idle (gray) → running (blue, pulse) → done (green) → error (red)
+//   notification badge (orange dot) overlaid when unread count > 0.
+
+import { watch, type Ref, type ComputedRef } from "vue";
+
+export const FAVICON_STATES = {
+  idle: "idle",
+  running: "running",
+  done: "done",
+  error: "error",
+} as const;
+
+export type FaviconState = (typeof FAVICON_STATES)[keyof typeof FAVICON_STATES];
+
+const STATE_COLORS: Record<FaviconState, string> = {
+  idle: "#6B7280", // gray-500
+  running: "#3B82F6", // blue-500
+  done: "#22C55E", // green-500
+  error: "#EF4444", // red-500
+};
+
+const NOTIFICATION_DOT_COLOR = "#F97316"; // orange-500
+const SIZE = 32;
+const RADIUS = 6;
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function renderFavicon(state: FaviconState, hasNotification: boolean): string {
+  const canvas = document.createElement("canvas");
+  canvas.width = SIZE;
+  canvas.height = SIZE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+
+  // Background: rounded square
+  const color = STATE_COLORS[state];
+  drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
+  ctx.fillStyle = color;
+  ctx.fill();
+
+  // Subtle shadow/depth
+  ctx.strokeStyle = "rgba(0,0,0,0.15)";
+  ctx.lineWidth = 1;
+  drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
+  ctx.stroke();
+
+  // "M" letter
+  ctx.fillStyle = "white";
+  ctx.font = "bold 20px -apple-system, BlinkMacSystemFont, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("M", SIZE / 2, SIZE / 2 + 1);
+
+  // Running state: subtle glow ring
+  if (state === FAVICON_STATES.running) {
+    ctx.strokeStyle = "rgba(255,255,255,0.4)";
+    ctx.lineWidth = 2;
+    drawRoundedRect(ctx, 3, 3, SIZE - 6, SIZE - 6, RADIUS - 1);
+    ctx.stroke();
+  }
+
+  // Notification badge (orange dot, top-right)
+  if (hasNotification) {
+    const dotR = 5;
+    const dotX = SIZE - dotR - 1;
+    const dotY = dotR + 1;
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, dotR, 0, Math.PI * 2);
+    ctx.fillStyle = NOTIFICATION_DOT_COLOR;
+    ctx.fill();
+    ctx.strokeStyle = "white";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+
+  return canvas.toDataURL("image/png");
+}
+
+function applyFavicon(dataUrl: string): void {
+  if (!dataUrl) return;
+  let link = document.querySelector(
+    "link[rel='icon']",
+  ) as HTMLLinkElement | null;
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "icon";
+    link.type = "image/png";
+    document.head.appendChild(link);
+  }
+  link.href = dataUrl;
+}
+
+export function useDynamicFavicon(opts: {
+  state: Ref<FaviconState> | ComputedRef<FaviconState>;
+  hasNotification: Ref<boolean> | ComputedRef<boolean>;
+}): void {
+  function update(): void {
+    const dataUrl = renderFavicon(opts.state.value, opts.hasNotification.value);
+    applyFavicon(dataUrl);
+  }
+
+  watch([opts.state, opts.hasNotification], update, { immediate: true });
+}


### PR DESCRIPTION
## Summary

ブラウザタブに動的 favicon を表示。エージェントの状態で色が変わる。

## Design

Canvas API で 32x32 の角丸四角アイコンに白い "M" を描画。状態に応じて背景色を変更:

| 状態 | 色 | いつ |
|---|---|---|
| アイドル | グレー | 入力待ち |
| 実行中 | 青 (内側グロー) | Claude 処理中 |
| 完了 (未読) | 緑 | セッション完了、まだ見ていない |
| 通知あり | オレンジドット (右上) | 未読通知がある |

## Files

| File | Purpose |
|---|---|
| src/composables/useDynamicFavicon.ts | Canvas 描画 + 状態監視 composable |
| src/App.vue | composable 呼び出し + 状態計算 |
| index.html | 静的 SVG fallback (初期表示 / JS 無効時) |

## Test plan

- [ ] `yarn dev` → タブにグレーの M アイコンが表示
- [ ] チャット送信 → 青に変化
- [ ] 完了 → 緑に変化
- [ ] 別セッションで完了 → 通知バッジ → オレンジドット付き
- [ ] bell を開いて既読 → ドット消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic favicon that changes based on app status (idle, running, done, or error states)
  * Notification badge indicator appears on favicon when unread messages exist
  * Visual glow effect displays during active processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->