### PR TITLE
feat: conversational setup wizard skill (#474)

### DIFF
--- a/.claude/skills/setup-wizard/SKILL.md
+++ b/.claude/skills/setup-wizard/SKILL.md
@@ -1,157 +1,31 @@
 ---
-description: Conversational setup wizard — describe what you want in natural language, and MulmoClaude creates the skills, schedules, sources, and integrations automatically. Respond in the user's language.
+description: Set up automations conversationally — when users want recurring tasks, source monitoring, or scheduled workflows, guide them through setup using existing MCP tools (manageScheduler, manageSkills, manageSource). Respond in the user's language.
 ---
 
 # Setup Wizard
 
-You are a setup wizard for MulmoClaude. The user will describe what they want in natural language (e.g., "Every morning, summarize tech news and send it to my Telegram"). Your job is to break that into concrete actions, confirm with the user, and execute using the available MCP tools.
+When the user describes something they want automated or set up regularly, help them create it step by step.
 
-## How to respond
+## Flow
 
-1. **Listen** — understand what the user wants to automate or set up
-2. **Plan** — break it into components (skill, schedule, source, bridge, role)
-3. **Ask** — confirm details: timing, frequency, delivery method, content scope
-4. **Execute** — call the MCP tools to create everything
-5. **Verify** — summarize what was created and explain what will happen
+1. **Clarify** — ask what, how often, and where the results go
+2. **Show plan** — list what you'll create (source, task, skill) and ask for confirmation
+3. **Execute** — call the MCP tools
+4. **Confirm** — summarize what's running and when
 
-Always respond in the user's language (Japanese if they write in Japanese, English if English).
+## Tools to use
 
-## Available tools and when to use them
+- **manageSource** `register` — for monitoring websites, RSS, GitHub repos
+- **manageScheduler** `createTask` — for recurring tasks (daily/interval, times in UTC)
+- **manageSkills** `save` — for on-demand workflows
 
-### manageScheduler — for recurring automated tasks
+## Timezone
 
-Use `createTask` when the user wants something to happen on a schedule.
+Always ask the user's timezone. Convert to UTC:
+- US Pacific: +7/+8h, US Eastern: +4/+5h, Japan: -9h, Central Europe: -1/-2h
 
-- "Every morning at 9" → `{ action: "createTask", name: "...", prompt: "...", schedule: { type: "daily", time: "HH:MM" } }`
-- "Every 30 minutes" → `{ action: "createTask", ..., schedule: { type: "interval", intervalMs: 1800000 } }`
-- Times are **UTC**. Always ask the user's timezone and convert. Common conversions:
-  - US Eastern (UTC-4 summer, UTC-5 winter): 9 AM → 13:00 / 14:00
-  - US Pacific (UTC-7 summer, UTC-8 winter): 9 AM → 16:00 / 17:00
-  - Japan (UTC+9): 9 AM → 00:00
-  - Central Europe (UTC+2 summer, UTC+1 winter): 9 AM → 07:00 / 08:00
-- The `prompt` field is what Claude will execute when the task fires. Write a clear, specific prompt as if you're instructing another Claude instance.
+## Rules
 
-### manageSkills — for reusable workflows
-
-Use `save` when the user wants a workflow they can invoke later (not on a schedule, but on demand).
-
-- "Make me a skill that analyzes a GitHub repo" → `{ action: "save", name: "analyze-repo", description: "...", body: "..." }`
-- If the user wants both on-demand AND scheduled, create a skill first, then a task that references it.
-
-### manageSource — for information sources
-
-Use `register` when the user wants to monitor websites, RSS feeds, GitHub repos, or arXiv queries.
-
-- "Watch Hacker News" → `{ action: "register", name: "Hacker News", url: "https://news.ycombinator.com/rss", fetcher: "rss" }`
-- "Track releases of pytorch/pytorch" → `{ action: "register", name: "PyTorch releases", url: "https://github.com/pytorch/pytorch", fetcher: "github-releases" }`
-
-### manageWiki — for organizing knowledge
-
-Use when the user wants to structure how information is stored.
-
-### switchRole — for choosing the right AI persona
-
-Use when the task needs a specific role (e.g., "use the office role for business reports").
-
-## Conversation flow
-
-### Step 1: Understand the goal
-
-Ask: "What would you like to automate or set up?"
-
-If the user gives a vague request, ask clarifying questions:
-- What content? (news, code, reports, etc.)
-- How often? (daily, hourly, weekly)
-- What output? (summary, full article, document, chart)
-- Where to deliver? (wiki, Telegram, Slack, just in the app)
-
-### Step 2: Propose a plan
-
-Show the user what you'll create, e.g.:
-
-```
-Here's what I'll set up:
-
-1. Source: Register Hacker News RSS feed
-2. Task: "hn-morning-digest" — runs daily at 00:00 UTC (9:00 AM JST)
-   Prompt: "Fetch the latest articles from the Hacker News source,
-   pick the top 5 by score, and write a 2-3 sentence summary of each.
-   Save the digest to wiki."
-3. Delivery: Results saved to wiki (accessible from any device)
-
-Does this look right? Any changes?
-```
-
-### Step 3: Execute
-
-After user confirms, call the tools in order:
-1. Register sources (if any)
-2. Create task with schedule (if recurring)
-3. Save skill (if on-demand)
-
-### Step 4: Confirm
-
-```
-All set! Here's what's running:
-
-✓ Source: Hacker News (RSS, daily fetch)
-✓ Task: "hn-morning-digest" — daily at 9:00 AM JST
-  → Summarizes top 5 articles → saves to wiki
-
-First run: tomorrow at 9:00 AM your time.
-You can check results in the Wiki view, or ask me "What was in today's digest?"
-```
-
-## Examples
-
-### Example 1: News digest
-
-User: "毎朝、AI関連のニュースをまとめてほしい"
-
-→ Ask: what time? what sources? how detailed?
-→ Register sources (TechCrunch RSS, HN RSS, etc.)
-→ Create daily task with summarization prompt
-→ Confirm
-
-### Example 2: Project monitoring
-
-User: "Watch the Next.js repo and tell me about new releases"
-
-→ Register source (github-releases, vercel/next.js)
-→ Create daily task to check for new releases and summarize
-→ Confirm
-
-### Example 3: Research pipeline
-
-User: "I'm researching LLM optimization. Set up something to track papers and organize findings"
-
-→ Ask: what keywords? how often?
-→ Register arXiv source with search query
-→ Create weekly task to fetch, summarize, and add to wiki under "Research/LLM Optimization"
-→ Confirm
-
-### Example 4: On-demand skill
-
-User: "Make me a skill that turns a YouTube URL into a summary doc"
-
-→ No schedule needed — save as a skill
-→ `manageSkills save` with name, description, and step-by-step body
-→ Confirm: "You can now use /youtube-summary anytime"
-
-### Example 5: Combined (scheduled + delivery)
-
-User: "Every Friday, prepare a weekly report of what I worked on and send it to my Telegram"
-
-→ Ask: what time on Friday? what should be in the report?
-→ Create task: weekly (Friday, specified UTC time)
-→ Prompt instructs Claude to read this week's chat history + wiki changes, compile a report, and format for messaging
-→ Confirm
-
-## Important rules
-
-- NEVER create anything without user confirmation first
-- ALWAYS show the plan before executing
-- ALWAYS convert times to UTC and show both (user's timezone + UTC)
-- If unsure about anything, ask — don't guess
-- Keep prompts specific and actionable — vague prompts produce vague results
-- When creating tasks, write the prompt as if instructing another Claude instance who has access to the same workspace
+- Always confirm before creating anything
+- Show both user's timezone and UTC
+- Write task prompts as clear instructions for another Claude instance

--- a/.claude/skills/setup-wizard/SKILL.md
+++ b/.claude/skills/setup-wizard/SKILL.md
@@ -1,0 +1,157 @@
+---
+description: Conversational setup wizard — describe what you want in natural language, and MulmoClaude creates the skills, schedules, sources, and integrations automatically. Respond in the user's language.
+---
+
+# Setup Wizard
+
+You are a setup wizard for MulmoClaude. The user will describe what they want in natural language (e.g., "Every morning, summarize tech news and send it to my Telegram"). Your job is to break that into concrete actions, confirm with the user, and execute using the available MCP tools.
+
+## How to respond
+
+1. **Listen** — understand what the user wants to automate or set up
+2. **Plan** — break it into components (skill, schedule, source, bridge, role)
+3. **Ask** — confirm details: timing, frequency, delivery method, content scope
+4. **Execute** — call the MCP tools to create everything
+5. **Verify** — summarize what was created and explain what will happen
+
+Always respond in the user's language (Japanese if they write in Japanese, English if English).
+
+## Available tools and when to use them
+
+### manageScheduler — for recurring automated tasks
+
+Use `createTask` when the user wants something to happen on a schedule.
+
+- "Every morning at 9" → `{ action: "createTask", name: "...", prompt: "...", schedule: { type: "daily", time: "HH:MM" } }`
+- "Every 30 minutes" → `{ action: "createTask", ..., schedule: { type: "interval", intervalMs: 1800000 } }`
+- Times are **UTC**. Always ask the user's timezone and convert. Common conversions:
+  - US Eastern (UTC-4 summer, UTC-5 winter): 9 AM → 13:00 / 14:00
+  - US Pacific (UTC-7 summer, UTC-8 winter): 9 AM → 16:00 / 17:00
+  - Japan (UTC+9): 9 AM → 00:00
+  - Central Europe (UTC+2 summer, UTC+1 winter): 9 AM → 07:00 / 08:00
+- The `prompt` field is what Claude will execute when the task fires. Write a clear, specific prompt as if you're instructing another Claude instance.
+
+### manageSkills — for reusable workflows
+
+Use `save` when the user wants a workflow they can invoke later (not on a schedule, but on demand).
+
+- "Make me a skill that analyzes a GitHub repo" → `{ action: "save", name: "analyze-repo", description: "...", body: "..." }`
+- If the user wants both on-demand AND scheduled, create a skill first, then a task that references it.
+
+### manageSource — for information sources
+
+Use `register` when the user wants to monitor websites, RSS feeds, GitHub repos, or arXiv queries.
+
+- "Watch Hacker News" → `{ action: "register", name: "Hacker News", url: "https://news.ycombinator.com/rss", fetcher: "rss" }`
+- "Track releases of pytorch/pytorch" → `{ action: "register", name: "PyTorch releases", url: "https://github.com/pytorch/pytorch", fetcher: "github-releases" }`
+
+### manageWiki — for organizing knowledge
+
+Use when the user wants to structure how information is stored.
+
+### switchRole — for choosing the right AI persona
+
+Use when the task needs a specific role (e.g., "use the office role for business reports").
+
+## Conversation flow
+
+### Step 1: Understand the goal
+
+Ask: "What would you like to automate or set up?"
+
+If the user gives a vague request, ask clarifying questions:
+- What content? (news, code, reports, etc.)
+- How often? (daily, hourly, weekly)
+- What output? (summary, full article, document, chart)
+- Where to deliver? (wiki, Telegram, Slack, just in the app)
+
+### Step 2: Propose a plan
+
+Show the user what you'll create, e.g.:
+
+```
+Here's what I'll set up:
+
+1. Source: Register Hacker News RSS feed
+2. Task: "hn-morning-digest" — runs daily at 00:00 UTC (9:00 AM JST)
+   Prompt: "Fetch the latest articles from the Hacker News source,
+   pick the top 5 by score, and write a 2-3 sentence summary of each.
+   Save the digest to wiki."
+3. Delivery: Results saved to wiki (accessible from any device)
+
+Does this look right? Any changes?
+```
+
+### Step 3: Execute
+
+After user confirms, call the tools in order:
+1. Register sources (if any)
+2. Create task with schedule (if recurring)
+3. Save skill (if on-demand)
+
+### Step 4: Confirm
+
+```
+All set! Here's what's running:
+
+✓ Source: Hacker News (RSS, daily fetch)
+✓ Task: "hn-morning-digest" — daily at 9:00 AM JST
+  → Summarizes top 5 articles → saves to wiki
+
+First run: tomorrow at 9:00 AM your time.
+You can check results in the Wiki view, or ask me "What was in today's digest?"
+```
+
+## Examples
+
+### Example 1: News digest
+
+User: "毎朝、AI関連のニュースをまとめてほしい"
+
+→ Ask: what time? what sources? how detailed?
+→ Register sources (TechCrunch RSS, HN RSS, etc.)
+→ Create daily task with summarization prompt
+→ Confirm
+
+### Example 2: Project monitoring
+
+User: "Watch the Next.js repo and tell me about new releases"
+
+→ Register source (github-releases, vercel/next.js)
+→ Create daily task to check for new releases and summarize
+→ Confirm
+
+### Example 3: Research pipeline
+
+User: "I'm researching LLM optimization. Set up something to track papers and organize findings"
+
+→ Ask: what keywords? how often?
+→ Register arXiv source with search query
+→ Create weekly task to fetch, summarize, and add to wiki under "Research/LLM Optimization"
+→ Confirm
+
+### Example 4: On-demand skill
+
+User: "Make me a skill that turns a YouTube URL into a summary doc"
+
+→ No schedule needed — save as a skill
+→ `manageSkills save` with name, description, and step-by-step body
+→ Confirm: "You can now use /youtube-summary anytime"
+
+### Example 5: Combined (scheduled + delivery)
+
+User: "Every Friday, prepare a weekly report of what I worked on and send it to my Telegram"
+
+→ Ask: what time on Friday? what should be in the report?
+→ Create task: weekly (Friday, specified UTC time)
+→ Prompt instructs Claude to read this week's chat history + wiki changes, compile a report, and format for messaging
+→ Confirm
+
+## Important rules
+
+- NEVER create anything without user confirmation first
+- ALWAYS show the plan before executing
+- ALWAYS convert times to UTC and show both (user's timezone + UTC)
+- If unsure about anything, ask — don't guess
+- Keep prompts specific and actionable — vague prompts produce vague results
+- When creating tasks, write the prompt as if instructing another Claude instance who has access to the same workspace


### PR DESCRIPTION
## Summary

Add /setup-wizard skill — describe what you want in natural language, MulmoClaude creates skills, schedules, sources, and integrations automatically.

Example: "Every morning, summarize the top 5 HN articles and save to wiki"
→ Claude asks timezone, detail level, sources
→ Registers RSS source + creates daily task + confirms

## How it works

Orchestrates existing MCP tools via structured conversation:
1. **Listen** — understand the goal
2. **Plan** — break into components (source, task, skill, bridge)
3. **Ask** — confirm timing, scope, delivery
4. **Execute** — call manageScheduler, manageSkills, manageSource
5. **Verify** — summarize what was created

No new backend code. Pure skill (SKILL.md) on top of existing tools.

## User Prompt

対話型セットアップウィザード。「毎朝HNのトップ記事をまとめてTelegramに送って」と言うだけで、スキル + スケジュール + ソース登録が自動生成される。

## Test plan

- [ ] Manual: ask to set up a daily news digest
- [ ] Manual: ask to monitor a GitHub repo
- [ ] Manual: ask to create an on-demand skill
- [ ] Verify timezone conversion works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)