### PR TITLE
fix(files): make Apply Changes save markdown edits (#477)

### DIFF
--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 import { WORKSPACE_FILES } from "../../src/config/workspacePaths";
+import { API_ROUTES } from "../../src/config/apiRoutes";
 
 // Override the lazy-expand endpoint with a small fixture tree. Each
 // directory returns its immediate children only — recursion is
 // emulated by the client via subsequent fetches on expand.
 async function mockFileTree(page: Page) {
   await page.route(
-    (url) => url.pathname === "/api/files/dir",
+    (url) => url.pathname === API_ROUTES.files.dir,
     (route) => {
       const path =
         new URL(route.request().url()).searchParams.get("path") ?? "";
@@ -77,7 +78,7 @@ async function mockFileTree(page: Page) {
   // Mock file content for wiki/hello.md
   await page.route(
     (url) =>
-      url.pathname === "/api/files/content" &&
+      url.pathname === API_ROUTES.files.content &&
       url.searchParams.get("path") === "wiki/hello.md",
     (route) =>
       route.fulfill({
@@ -165,7 +166,7 @@ test.describe("file explorer path in URL", () => {
     // the editor sent to the server.
     const putRequests: Array<{ path: string; content: string }> = [];
     await page.route(
-      (url) => url.pathname === "/api/files/content",
+      (url) => url.pathname === API_ROUTES.files.content,
       async (route, req) => {
         if (req.method() === "PUT") {
           const body = req.postDataJSON() as {

--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -158,6 +158,62 @@ test.describe("file explorer path in URL", () => {
     }).toPass({ timeout: 5000 });
   });
 
+  test("editing a markdown file via the rendered-mode editor saves via PUT /api/files/content", async ({
+    page,
+  }) => {
+    // Capture the PUT request body so we can assert on exactly what
+    // the editor sent to the server.
+    const putRequests: Array<{ path: string; content: string }> = [];
+    await page.route(
+      (url) => url.pathname === "/api/files/content",
+      async (route, req) => {
+        if (req.method() === "PUT") {
+          const body = req.postDataJSON() as {
+            path: string;
+            content: string;
+          };
+          putRequests.push(body);
+          await route.fulfill({
+            json: {
+              path: body.path,
+              size: body.content.length,
+              modifiedMs: Date.now(),
+            },
+          });
+          return;
+        }
+        // Non-PUT → fall through to the earlier GET mock.
+        await route.fallback();
+      },
+    );
+
+    await page.goto("/chat?view=files&path=wiki/hello.md");
+
+    // Open the collapsible editor — it hangs off the bottom of the
+    // rendered markdown pane. The textarea is seeded with the raw
+    // on-disk source (not the rewritten display text), so edits
+    // round-trip through PUT /api/files/content unmodified.
+    const summary = page.getByTestId("text-response-edit-summary");
+    await expect(summary).toBeVisible({ timeout: 5000 });
+    await summary.click();
+
+    const textarea = page.getByTestId("text-response-edit-textarea");
+    await expect(textarea).toHaveValue("# Hello\n\nThis is a test.");
+
+    const apply = page.getByTestId("text-response-apply-btn");
+    await expect(apply).toBeDisabled();
+
+    await textarea.fill("# Hello\n\nEdited by the test.");
+    await expect(apply).toBeEnabled();
+    await apply.click();
+
+    await expect(() => {
+      expect(putRequests).toHaveLength(1);
+      expect(putRequests[0].path).toBe("wiki/hello.md");
+      expect(putRequests[0].content).toBe("# Hello\n\nEdited by the test.");
+    }).toPass({ timeout: 5000 });
+  });
+
   test("closing a file removes ?path= from URL", async ({ page }) => {
     await page.goto("/chat?view=files&path=wiki/hello.md");
     await expect(page.getByText("This is a test.")).toBeVisible({

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -7,6 +7,7 @@ import {
   statSafeAsync,
   readDirSafeAsync,
   resolveWithinRoot,
+  writeFileAtomic,
 } from "../../utils/files/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import {
@@ -167,6 +168,17 @@ interface FileContentText {
   kind: "text";
   path: string;
   content: string;
+  size: number;
+  modifiedMs: number;
+}
+
+interface WriteContentRequest {
+  path?: unknown;
+  content?: unknown;
+}
+
+interface WriteContentResponse {
+  path: string;
   size: number;
   modifiedMs: number;
 }
@@ -666,6 +678,75 @@ router.get(
       return;
     }
     res.json({ kind: "text", ...meta, content });
+  },
+);
+
+// Write the body of an existing text file. Only text-classified files
+// (per `classify`) are editable — binary, image, audio, etc. are
+// refused so the endpoint can't be used to ship arbitrary uploads.
+// The file must already exist; creating new files is out of scope.
+router.put(
+  API_ROUTES.files.content,
+  async (
+    req: Request<object, unknown, WriteContentRequest>,
+    res: Response<WriteContentResponse | ErrorResponse>,
+  ) => {
+    const { path: relPathRaw, content: contentRaw } = req.body ?? {};
+    if (typeof relPathRaw !== "string" || relPathRaw.length === 0) {
+      badRequest(res, "path required");
+      return;
+    }
+    if (typeof contentRaw !== "string") {
+      badRequest(res, "content required");
+      return;
+    }
+    if (Buffer.byteLength(contentRaw, "utf-8") > MAX_PREVIEW_BYTES) {
+      badRequest(res, `content exceeds ${MAX_PREVIEW_BYTES} byte limit`);
+      return;
+    }
+    // Two-step resolution to distinguish "path outside workspace" (400)
+    // from "file does not exist" (404): realpath throws on ENOENT, so
+    // resolveSafe conflates the two. Stat the syntactic candidate
+    // first; if it exists, THEN run the symlink-hardened resolveSafe.
+    const candidate = path.resolve(workspaceReal, path.normalize(relPathRaw));
+    const existing = await statSafeAsync(candidate);
+    if (!existing) {
+      const relativeFromWorkspace = path.relative(workspaceReal, candidate);
+      const escapesSyntactically =
+        relativeFromWorkspace === ".." ||
+        relativeFromWorkspace.startsWith(`..${path.sep}`);
+      if (escapesSyntactically) {
+        badRequest(res, "Path outside workspace");
+      } else {
+        notFound(res, "File not found");
+      }
+      return;
+    }
+    if (!existing.isFile()) {
+      badRequest(res, "Not a file");
+      return;
+    }
+    const absPath = resolveSafe(relPathRaw);
+    if (!absPath) {
+      badRequest(res, "Path outside workspace");
+      return;
+    }
+    if (classify(absPath) !== "text") {
+      badRequest(res, "File type not editable");
+      return;
+    }
+    try {
+      await writeFileAtomic(absPath, contentRaw);
+    } catch (err) {
+      serverError(res, `Failed to write file: ${errorMessage(err)}`);
+      return;
+    }
+    const fresh = await statSafeAsync(absPath);
+    res.json({
+      path: relPathRaw,
+      size: fresh?.size ?? Buffer.byteLength(contentRaw, "utf-8"),
+      modifiedMs: fresh?.mtimeMs ?? Date.now(),
+    });
   },
 );
 

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -736,7 +736,10 @@ router.put(
       return;
     }
     try {
-      await writeFileAtomic(absPath, contentRaw);
+      // `uniqueTmp: true` appends a randomUUID to the tmp filename so
+      // two simultaneous PUTs to the same path can't clobber each
+      // other's staging file and race through the rename.
+      await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
     } catch (err) {
       serverError(res, `Failed to write file: ${errorMessage(err)}`);
       return;

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -120,7 +120,16 @@
                       mdFrontmatter ? mdFrontmatter.body : content.content,
                     )
                   "
+                  :editable-source="content.content"
+                  @update-source="saveRawMarkdown"
                 />
+              </div>
+              <div
+                v-if="rawSaveError"
+                class="shrink-0 m-4 mt-0 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-700"
+                role="alert"
+              >
+                ⚠ {{ rawSaveError }}
               </div>
             </div>
             <!-- Markdown raw source (includes frontmatter) -->
@@ -248,7 +257,7 @@ import FileTree, { type TreeNode } from "./FileTree.vue";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
-import { apiGet } from "../utils/api";
+import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
 import { formatDateTime } from "../utils/format/date";
@@ -362,6 +371,44 @@ function toggleMdRaw(): void {
   mdRawMode.value = !mdRawMode.value;
   localStorage.setItem(MD_RAW_STORAGE_KEY, String(mdRawMode.value));
 }
+
+// Save-error banner shown above the Rendered-mode markdown editor.
+// Cleared on every new file load and on the next successful save.
+const rawSaveError = ref<string | null>(null);
+
+async function saveRawMarkdown(newSource: string): Promise<void> {
+  if (!selectedPath.value) return;
+  if (content.value?.kind !== "text") return;
+  if (newSource === content.value.content) return;
+  rawSaveError.value = null;
+  const result = await apiPut<{
+    path: string;
+    size: number;
+    modifiedMs: number;
+  }>(API_ROUTES.files.content, {
+    path: selectedPath.value,
+    content: newSource,
+  });
+  if (!result.ok) {
+    rawSaveError.value = result.error;
+    return;
+  }
+  // Reflect the saved state locally — size/modifiedMs come from the
+  // server's post-write stat, and `content` is what we just sent. Avoid
+  // a round-trip GET since the server has already confirmed the write.
+  content.value = {
+    kind: "text",
+    path: result.data.path,
+    content: newSource,
+    size: result.data.size,
+    modifiedMs: result.data.modifiedMs,
+  };
+}
+
+// Clear any stale save error whenever a new file is loaded.
+watch(content, () => {
+  rawSaveError.value = null;
+});
 const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
 
 // The HTML body handed to the iframe's `srcdoc`. We inject a CSP

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -380,15 +380,21 @@ async function saveRawMarkdown(newSource: string): Promise<void> {
   if (!selectedPath.value) return;
   if (content.value?.kind !== "text") return;
   if (newSource === content.value.content) return;
+  // Snapshot the target path so a late response from a PUT for file A
+  // can't overwrite `content.value` after the user has navigated to
+  // file B. Server-side the save still completes — we only suppress
+  // the stale UI update.
+  const pathAtSave = selectedPath.value;
   rawSaveError.value = null;
   const result = await apiPut<{
     path: string;
     size: number;
     modifiedMs: number;
   }>(API_ROUTES.files.content, {
-    path: selectedPath.value,
+    path: pathAtSave,
     content: newSource,
   });
+  if (selectedPath.value !== pathAtSave) return;
   if (!result.ok) {
     rawSaveError.value = result.error;
     return;

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -55,17 +55,26 @@
         </div>
 
         <!-- Collapsible Editor -->
-        <details ref="detailsEl" class="text-response-source">
-          <summary>Edit Text Content</summary>
+        <details
+          v-if="editable"
+          ref="detailsEl"
+          class="text-response-source"
+          data-testid="text-response-edit"
+        >
+          <summary data-testid="text-response-edit-summary">
+            Edit Text Content
+          </summary>
           <textarea
             v-model="editedText"
             class="text-response-editor"
             spellcheck="false"
+            data-testid="text-response-edit-textarea"
           ></textarea>
           <button
-            @click="applyChanges"
             class="apply-btn"
             :disabled="!hasChanges"
+            data-testid="text-response-apply-btn"
+            @click="applyChanges"
           >
             Apply Changes
           </button>
@@ -97,24 +106,39 @@ import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 
-const props = defineProps<{
-  selectedResult: ToolResultComplete<TextResponseData>;
+const props = withDefaults(
+  defineProps<{
+    selectedResult: ToolResultComplete<TextResponseData>;
+    editable?: boolean;
+    // When set, the editor textarea edits this string instead of the
+    // displayed `data.text`. FilesView uses it to feed the editor the
+    // raw on-disk source (with frontmatter intact, no image-URL
+    // rewriting) while the rendered pane keeps showing the cleaned-up
+    // display text. Callers listen for `updateSource` to receive the
+    // edited source and handle persistence themselves.
+    editableSource?: string;
+  }>(),
+  { editable: true, editableSource: undefined },
+);
+const emit = defineEmits<{
+  updateResult: [result: ToolResult];
+  updateSource: [source: string];
 }>();
-const emit = defineEmits<{ updateResult: [result: ToolResult] }>();
 
 // --- Data & computed from upstream View ---
 
 const messageText = computed(() => props.selectedResult.data?.text ?? "");
-const editedText = ref(messageText.value);
-
-watch(
-  () => props.selectedResult.data?.text,
-  (newText) => {
-    if (newText !== undefined) {
-      editedText.value = newText;
-    }
-  },
+// Source fed into the editor. When the parent passes `editableSource`
+// it wins; otherwise we edit the displayed text, matching the
+// component's original (chat-message) behaviour.
+const editorSource = computed(() =>
+  props.editableSource !== undefined ? props.editableSource : messageText.value,
 );
+const editedText = ref(editorSource.value);
+
+watch(editorSource, (next) => {
+  editedText.value = next;
+});
 
 const messageRole = computed(
   () => props.selectedResult.data?.role ?? "assistant",
@@ -176,20 +200,27 @@ const roleTheme = computed(() => {
   }
 });
 
-const hasChanges = computed(() => editedText.value !== messageText.value);
+const hasChanges = computed(() => editedText.value !== editorSource.value);
 
 function applyChanges() {
   if (!hasChanges.value) return;
 
-  const updatedResult: ToolResult = {
-    ...props.selectedResult,
-    data: {
-      ...props.selectedResult.data,
-      text: editedText.value,
-    },
-  };
-
-  emit("updateResult", updatedResult);
+  if (props.editableSource !== undefined) {
+    // Source-editing mode: hand the edited string to the parent and
+    // let it decide how to persist. The component's own `data.text`
+    // isn't touched — the parent will re-supply `editableSource` after
+    // the save round-trip.
+    emit("updateSource", editedText.value);
+  } else {
+    const updatedResult: ToolResult = {
+      ...props.selectedResult,
+      data: {
+        ...props.selectedResult.data,
+        text: editedText.value,
+      },
+    };
+    emit("updateResult", updatedResult);
+  }
   if (detailsEl.value) detailsEl.value.open = false;
 }
 
@@ -226,8 +257,10 @@ onBeforeUnmount(() => {
 
 function cancelEdit() {
   if (detailsEl.value) detailsEl.value.open = false;
-  // Reset edited text to original
-  editedText.value = messageText.value;
+  // Reset edited text to whatever the editor started with — in
+  // source-editing mode that's the raw source, otherwise the display
+  // text. Using the computed `editorSource` keeps both paths correct.
+  editedText.value = editorSource.value;
 }
 
 const { copied, copy } = useClipboardCopy();

--- a/test/routes/test_filesPutRoute.ts
+++ b/test/routes/test_filesPutRoute.ts
@@ -1,0 +1,257 @@
+// Route-level checks for PUT /api/files/content — the editor-save
+// endpoint added in #477 for the Files UI.
+//
+// We drive the handler with plain Request / Response mocks so we
+// don't pay for an Express + supertest harness, mirroring the pattern
+// established in test_sessionsRoute.ts. The workspace path is resolved
+// from os.homedir() at module load, so HOME is redirected to a tmp
+// dir BEFORE the route module is imported.
+
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import type { Request, Response } from "express";
+
+type RouteModule = typeof import("../../server/api/routes/files.js");
+
+type Handler = (req: Request, res: Response) => Promise<void> | void;
+
+interface StackFrame {
+  route?: {
+    path: string;
+    stack: Array<{ method: string; handle: Handler }>;
+  };
+}
+interface RouterInternals {
+  stack: StackFrame[];
+}
+
+function extractRouteHandler(
+  mod: RouteModule,
+  routePath: string,
+  method: string,
+): Handler {
+  const router = mod.default as unknown as RouterInternals;
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((s) => s.method === method);
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
+}
+
+interface ErrorBody {
+  error: string;
+}
+interface WriteBody {
+  path: string;
+  size: number;
+  modifiedMs: number;
+}
+type ResBody = ErrorBody | WriteBody;
+
+function mockRes() {
+  const state: { status: number; body: ResBody | undefined } = {
+    status: 200,
+    body: undefined,
+  };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(payload: ResBody) {
+      state.body = payload;
+      return res;
+    },
+  };
+  return { state, res: res as unknown as Response };
+}
+
+let tmpRoot: string;
+let workspaceDir: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let putHandler: Handler;
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-files-put-route-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+  const { workspacePath: wp } =
+    await import("../../server/workspace/workspace.js");
+  workspaceDir = wp;
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  const routeMod = await import("../../server/api/routes/files.js");
+  putHandler = extractRouteHandler(routeMod, "/api/files/content", "put");
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function resetWorkspace(): Promise<void> {
+  // Clean workspace contents but keep the directory — files.ts
+  // captured its realpath at module load, so rm'ing the whole thing
+  // would leave the handler with a dangling reference.
+  for (const entry of fs.readdirSync(workspaceDir)) {
+    await rm(path.join(workspaceDir, entry), { recursive: true, force: true });
+  }
+}
+
+beforeEach(async () => {
+  await resetWorkspace();
+});
+
+function req(body: unknown): Request {
+  return { body } as unknown as Request;
+}
+
+describe("PUT /api/files/content — happy path", () => {
+  it("overwrites an existing markdown file with the new content", async () => {
+    const rel = "notes.md";
+    await writeFile(path.join(workspaceDir, rel), "# old\n", "utf-8");
+
+    const { state, res } = mockRes();
+    await putHandler(req({ path: rel, content: "# new\nbody\n" }), res);
+
+    assert.equal(state.status, 200);
+    const body = state.body as WriteBody;
+    assert.equal(body.path, rel);
+    assert.equal(typeof body.size, "number");
+    assert.equal(typeof body.modifiedMs, "number");
+
+    const onDisk = await fs.promises.readFile(
+      path.join(workspaceDir, rel),
+      "utf-8",
+    );
+    assert.equal(onDisk, "# new\nbody\n");
+  });
+
+  it("writes UTF-8 content correctly (multi-byte characters)", async () => {
+    const rel = "unicode.md";
+    await writeFile(path.join(workspaceDir, rel), "old", "utf-8");
+
+    const { state, res } = mockRes();
+    await putHandler(
+      req({ path: rel, content: "日本語テスト — em–dash" }),
+      res,
+    );
+
+    assert.equal(state.status, 200);
+    const onDisk = await fs.promises.readFile(
+      path.join(workspaceDir, rel),
+      "utf-8",
+    );
+    assert.equal(onDisk, "日本語テスト — em–dash");
+  });
+});
+
+describe("PUT /api/files/content — validation", () => {
+  it("rejects a missing body entirely", async () => {
+    const { state, res } = mockRes();
+    await putHandler({ body: undefined } as unknown as Request, res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /path required/i);
+  });
+
+  it("rejects a missing path", async () => {
+    const { state, res } = mockRes();
+    await putHandler(req({ content: "x" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /path required/i);
+  });
+
+  it("rejects an empty path string", async () => {
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "", content: "x" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /path required/i);
+  });
+
+  it("rejects a missing content field", async () => {
+    await writeFile(path.join(workspaceDir, "a.md"), "x", "utf-8");
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "a.md" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /content required/i);
+  });
+
+  it("rejects a non-string content field", async () => {
+    await writeFile(path.join(workspaceDir, "a.md"), "x", "utf-8");
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "a.md", content: 42 }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /content required/i);
+  });
+
+  it("rejects content larger than the 1 MB preview limit", async () => {
+    const rel = "big.md";
+    await writeFile(path.join(workspaceDir, rel), "x", "utf-8");
+    // One byte over the 1 MiB preview cap enforced by the handler.
+    const oversized = "x".repeat(1024 * 1024 + 1);
+    const { state, res } = mockRes();
+    await putHandler(req({ path: rel, content: oversized }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /exceeds/i);
+  });
+});
+
+describe("PUT /api/files/content — security", () => {
+  it("rejects a path-traversal escape", async () => {
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "../escape.md", content: "pwn" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /outside workspace/i);
+  });
+
+  it("rejects a sensitive basename (.env)", async () => {
+    // Pre-create the file so we'd otherwise reach the write step. The
+    // rejection must fire on the name check, not the stat.
+    await writeFile(path.join(workspaceDir, ".env"), "SECRET=1", "utf-8");
+    const { state, res } = mockRes();
+    await putHandler(req({ path: ".env", content: "SECRET=2" }), res);
+    assert.equal(state.status, 400);
+    // Verify the original content is unchanged.
+    const onDisk = await fs.promises.readFile(
+      path.join(workspaceDir, ".env"),
+      "utf-8",
+    );
+    assert.equal(onDisk, "SECRET=1");
+  });
+
+  it("rejects a binary-classified extension even when the file exists", async () => {
+    const rel = "image.png";
+    await writeFile(path.join(workspaceDir, rel), "\x89PNG...", "utf-8");
+    const { state, res } = mockRes();
+    await putHandler(req({ path: rel, content: "overwritten" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /not editable/i);
+  });
+});
+
+describe("PUT /api/files/content — missing targets", () => {
+  it("returns 404 when the target file does not exist", async () => {
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "new.md", content: "hello" }), res);
+    assert.equal(state.status, 404);
+    assert.match((state.body as ErrorBody).error, /not found/i);
+  });
+
+  it("returns 400 when the target is a directory", async () => {
+    fs.mkdirSync(path.join(workspaceDir, "adir"));
+    const { state, res } = mockRes();
+    await putHandler(req({ path: "adir", content: "x" }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /not a file/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #477 — the "Edit Text Content" drawer under rendered markdown in the Files UI was a no-op. The save button now persists edits to disk.
- Adds `PUT /api/files/content` for atomic, size-capped, text-only workspace writes.
- Extends `TextResponseView` with `editableSource` / `updateSource` so the editor operates on the raw on-disk source instead of the display text (which had image refs rewritten to `/api/files/raw` URLs and frontmatter stripped — saving the display text would have corrupted the file).

## Why the editor was broken

1. `TextResponseView` emitted `updateResult` on Apply — `FilesView.vue` never listened.
2. Even if it had, there was no server endpoint for writing workspace files; `API_ROUTES.files` exposed `tree`/`dir`/`content`/`raw`, all GET.
3. The text handed to the editor was the *rewritten display* version: image refs rewritten to `/api/files/raw?path=…`, frontmatter stripped. Round-tripping that back to disk would corrupt the file on save.

## Fix

- **Backend**: new `PUT /api/files/content` in `server/api/routes/files.ts`. Uses the same two-step resolve (syntactic stat → realpath-hardened `resolveSafe`) as `GET /content` to distinguish 404 from 400, enforces the 1 MiB preview cap, refuses non-text extensions via `classify`, refuses sensitive paths via `isSensitivePath`, and writes via `writeFileAtomic`.
- **Editor prop**: `TextResponseView` gains `editableSource?: string` and a new `updateSource` event. When `editableSource` is passed, the textarea edits that string; Apply emits the edited string via `updateSource` and leaves `data.text` / `updateResult` alone.
- **FilesView**: passes the full raw `content.content` (frontmatter + body) as `editableSource`. On `updateSource`, it PUTs the edited string and refreshes local `content` so the header's size / modifiedMs update immediately.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green.
- [x] `yarn test` — 2413 unit tests pass, including the new `test/routes/test_filesPutRoute.ts` suite (happy path, validation, path traversal, sensitive files, binary extensions, missing file, directory target).
- [x] `yarn test:e2e -- tests/file-explorer.spec.ts` — 6 tests pass, including the new round-trip (open editor → edit → Apply → PUT assertion).
- [ ] Manual: open a markdown file in Files view, expand "Edit Text Content", edit, click Apply Changes, confirm the file changes on disk (and reloads in the UI with the new size/mtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit and save Markdown source while viewing rendered files, with inline save, validation, and user-facing error banner on failure.

* **Tests**
  * Added end-to-end and server-side tests covering save flows, validation errors, security checks (path/sensitive-file protection), and binary/text classification to ensure safe write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->