### PR TITLE
fix: remove pre-#284 migration startup check (#449)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -202,12 +202,14 @@ Three independent Node processes cooperate at runtime:
   .mulmoclaude/       internal: per-session MCP config files
 ```
 
-Existing workspaces from before #284 need to run the one-shot migration script once before the server will start:
+Existing workspaces from before #284 can optionally run the migration script to reorganize old directories:
 
 ```bash
 yarn tsx scripts/migrate-workspace-284.ts --dry-run   # preview
 yarn tsx scripts/migrate-workspace-284.ts --execute   # commit (backs up via rsync first)
 ```
+
+> The server no longer blocks startup on pre-#284 layouts. The script is kept for users who want to clean up old directory names.
 
 The `config/` dir is the home for the [web Settings UI](../README.md#configuring-additional-tools-web-settings) — `settings.json` carries `extraAllowedTools`, `mcp.json` follows Claude CLI's `--mcp-config` format so you can copy it between machines.
 

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -26,62 +26,7 @@ export { workspacePath };
 // Must exist before downstream modules call realpathSync(workspacePath) at their own module-load time.
 fs.mkdirSync(workspacePath, { recursive: true });
 
-// Legacy (pre-#284) top-level directory names. If any of these still
-// exist at the workspace root, the workspace hasn't been migrated to
-// the new layout yet and the server must refuse to start — running
-// against the pre-migration tree with the new constants would write
-// new sessions to empty dirs and leave the old data stranded.
-//
-// Full migration is a one-shot operation (`scripts/migrate-workspace-284.ts`).
-// The list must cover every DIR_MIGRATIONS.from entry in that script;
-// a workspace that has ANY of these present still needs migration.
-const LEGACY_TOP_LEVEL_DIRS_PRE_284 = [
-  "HTMLs",
-  "calendar",
-  "charts",
-  "chat",
-  "configs",
-  "contacts",
-  "helps",
-  "html",
-  "images",
-  "markdowns",
-  "news",
-  "roles",
-  "scheduler",
-  "scripts",
-  "searches",
-  "sources",
-  "spreadsheets",
-  "stories",
-  "summaries",
-  "todos",
-  "transports",
-  "wiki",
-] as const;
-
-function assertPost284Layout(): void {
-  const legacyPresent = LEGACY_TOP_LEVEL_DIRS_PRE_284.filter((name) =>
-    fs.existsSync(path.join(workspacePath, name)),
-  );
-  if (legacyPresent.length === 0) return;
-
-  const msg =
-    `Workspace at ${workspacePath} still has pre-#284 directories: ` +
-    legacyPresent.join(", ") +
-    `.\nRun the migration before starting the server:\n` +
-    `  yarn tsx scripts/migrate-workspace-284.ts --dry-run   # preview\n` +
-    `  yarn tsx scripts/migrate-workspace-284.ts --execute   # commit\n` +
-    `See issue #284 for details.`;
-  log.error("workspace", msg);
-  throw new Error(
-    "Workspace layout is pre-#284. Run scripts/migrate-workspace-284.ts first.",
-  );
-}
-
 export function initWorkspace(): string {
-  assertPost284Layout();
-
   // Create directory structure if needed
   for (const key of EAGER_WORKSPACE_DIRS) {
     fs.mkdirSync(WORKSPACE_PATHS[key], { recursive: true });


### PR DESCRIPTION
## Summary

- サーバー起動時の pre-#284 レイアウトチェックを削除
- `assertPost284Layout()` と `LEGACY_TOP_LEVEL_DIRS_PRE_284` を削除
- migration script (`scripts/migrate-workspace-284.ts`) は残す（オプショナルクリーンアップ用）
- docs/developer.md のマイグレーション説明を更新

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)