### PR TITLE
fix: notification panel overflow — fixed positioning

### DIFF
--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -104,7 +104,7 @@ function handleDismiss(e: Event, id: string): void {
     <!-- Dropdown panel -->
     <div
       v-if="open"
-      class="absolute right-0 top-full mt-1 w-72 max-h-80 overflow-y-auto rounded-lg shadow-xl border border-gray-200 bg-white z-50"
+      class="fixed top-12 right-4 w-72 max-h-80 overflow-y-auto rounded-lg shadow-xl border border-gray-200 bg-white z-50"
       data-testid="notification-panel"
     >
       <!-- Header -->


### PR DESCRIPTION
## Summary

通知パネルが左にはみ出す問題を修正。absolute (ベルアイコン相対) → fixed (ビューポート相対) に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)