### PR TITLE
fix: notification panel position v2 — match LockStatusPopup

### DIFF
--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -104,7 +104,7 @@ function handleDismiss(e: Event, id: string): void {
     <!-- Dropdown panel -->
     <div
       v-if="open"
-      class="fixed top-12 right-4 w-72 max-h-80 overflow-y-auto rounded-lg shadow-xl border border-gray-200 bg-white z-50"
+      class="absolute left-0 top-full mt-1 w-72 max-h-80 overflow-y-auto rounded-lg shadow-xl border border-gray-200 bg-white z-50"
       data-testid="notification-panel"
     >
       <!-- Header -->


### PR DESCRIPTION
LockStatusPopup と同じ absolute left-0 top-full パターンに修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the notification dropdown panel positioning to display relative to the bell icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->