### PR TITLE
feat: session origin tracking — Phase 1 data layer (#486)

### DIFF
--- a/packages/chat-service/src/relay.ts
+++ b/packages/chat-service/src/relay.ts
@@ -104,6 +104,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
       roleId: chatState.roleId,
       chatSessionId: chatState.sessionId,
       attachments,
+      origin: "bridge",
     });
 
     if (result.kind === "error") {

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -43,7 +43,7 @@ export interface StartChatParams {
   chatSessionId: string;
   selectedImageData?: string;
   attachments?: Attachment[];
-  /** Session origin: "human", "scheduler", "skill", "bridge" */
+  /** Session origin — application-defined (e.g. "human", "bridge") */
   origin?: string;
 }
 

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -43,6 +43,8 @@ export interface StartChatParams {
   chatSessionId: string;
   selectedImageData?: string;
   attachments?: Attachment[];
+  /** Session origin: "human", "scheduler", "skill", "bridge" */
+  origin?: string;
 }
 
 export type StartChatResult =

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -131,7 +131,8 @@ export interface StartChatParams {
   chatSessionId: string;
   selectedImageData?: string;
   attachments?: Attachment[];
-  /** Where this session originates: human, scheduler, skill, bridge */
+  /** Where this session originates (#486). Accepts string for
+   *  cross-package compatibility (chat-service passes string). */
   origin?: string;
 }
 

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -131,6 +131,8 @@ export interface StartChatParams {
   chatSessionId: string;
   selectedImageData?: string;
   attachments?: Attachment[];
+  /** Where this session originates: human, scheduler, skill, bridge */
+  origin?: string;
 }
 
 export type StartChatResult =
@@ -193,7 +195,13 @@ export async function startChat(
   // title cache; the append follows so the jsonl is always a
   // superset of what metadata advertised.
   if (isFirstTurn) {
-    await createSessionMeta(chatSessionId, roleId, message);
+    await createSessionMeta(
+      chatSessionId,
+      roleId,
+      message,
+      undefined,
+      params.origin,
+    );
   } else {
     await backfillMeta(chatSessionId, message);
   }

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -13,6 +13,7 @@ import {
   type DispatchErrorResponse,
 } from "./dispatchResponse.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { SESSION_ORIGINS } from "../../../src/types/session.js";
 import {
   loadUserTasks,
   validateAndCreate,
@@ -157,7 +158,7 @@ async function handleTaskAction(
         message: task.prompt,
         roleId: task.roleId,
         chatSessionId,
-        origin: "scheduler",
+        origin: SESSION_ORIGINS.scheduler,
       }).catch((err) => {
         log.error("scheduler", "manual run failed", {
           error: String(err),

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -157,6 +157,7 @@ async function handleTaskAction(
         message: task.prompt,
         roleId: task.roleId,
         chatSessionId,
+        origin: "scheduler",
       }).catch((err) => {
         log.error("scheduler", "manual run failed", {
           error: String(err),

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -14,6 +14,7 @@ import {
 } from "../../events/scheduler-adapter.js";
 import type { TaskLogEntry } from "@receptron/task-scheduler";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { SESSION_ORIGINS } from "../../../src/types/session.js";
 import {
   loadUserTasks,
   validateAndCreate,
@@ -137,7 +138,7 @@ router.post(
         message: userTask.prompt,
         roleId: userTask.roleId,
         chatSessionId,
-        origin: "scheduler",
+        origin: SESSION_ORIGINS.scheduler,
       }).catch((err) => {
         log.error("scheduler-tasks", "manual run failed", {
           error: String(err),

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -137,6 +137,7 @@ router.post(
         message: userTask.prompt,
         roleId: userTask.roleId,
         chatSessionId,
+        origin: "scheduler",
       }).catch((err) => {
         log.error("scheduler-tasks", "manual run failed", {
           error: String(err),

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -30,6 +30,7 @@ interface SessionMeta {
   startedAt: string;
   firstUserMessage?: string;
   hasUnread?: boolean;
+  origin?: string;
 }
 
 async function readSessionMeta(
@@ -71,6 +72,8 @@ interface SessionSummary {
   // under the preview in the history popup. See #123.
   summary?: string;
   keywords?: string[];
+  // Where this session originated (#486). Missing = "human".
+  origin?: string;
   // Live state from the in-memory session store. Absent when the
   // session has no active entry in the store (i.e. idle / historical).
   isRunning?: boolean;
@@ -144,6 +147,7 @@ async function loadAllSessions(): Promise<
           preview,
           hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
         };
+        if (meta.origin) summary.origin = meta.origin;
         if (indexEntry?.summary !== undefined)
           summary.summary = indexEntry.summary;
         if (indexEntry?.keywords !== undefined)

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -17,6 +17,7 @@ import { markRead, getSession } from "../../events/session-store/index.js";
 import { notFound } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
+import type { SessionOrigin } from "../../../src/types/session.js";
 import { env } from "../../system/env.js";
 import { ONE_DAY_MS } from "../../utils/time.js";
 import {
@@ -30,7 +31,7 @@ interface SessionMeta {
   startedAt: string;
   firstUserMessage?: string;
   hasUnread?: boolean;
-  origin?: string;
+  origin?: SessionOrigin;
 }
 
 async function readSessionMeta(
@@ -73,7 +74,7 @@ interface SessionSummary {
   summary?: string;
   keywords?: string[];
   // Where this session originated (#486). Missing = "human".
-  origin?: string;
+  origin?: SessionOrigin;
   // Live state from the in-memory session store. Absent when the
   // session has no active entry in the store (i.e. idle / historical).
   isRunning?: boolean;

--- a/server/index.ts
+++ b/server/index.ts
@@ -519,6 +519,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
         message: "Tell me about this app, MulmoClaude.",
         roleId: DEFAULT_ROLE_ID,
         chatSessionId,
+        origin: "scheduler",
       });
       log.info("debug", "auto-chat result", { kind: result.kind });
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -67,6 +67,7 @@ import { startChat } from "./api/routes/agent.js";
 import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
 import { registerUserTasks } from "./workspace/skills/user-tasks.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
+import { SESSION_ORIGINS } from "../src/types/session.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 
@@ -519,7 +520,7 @@ function registerDebugTasks(taskManager: ITaskManager, pubsub: IPubSub) {
         message: "Tell me about this app, MulmoClaude.",
         roleId: DEFAULT_ROLE_ID,
         chatSessionId,
-        origin: "scheduler",
+        origin: SESSION_ORIGINS.scheduler,
       });
       log.info("debug", "auto-chat result", { kind: result.kind });
     },

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -39,6 +39,7 @@ export interface SessionMeta {
   firstUserMessage?: string;
   claudeSessionId?: string;
   hasUnread?: boolean;
+  origin?: string;
   [key: string]: unknown;
 }
 
@@ -84,12 +85,15 @@ export async function createSessionMeta(
   roleId: string,
   firstUserMessage: string,
   r?: string,
+  origin?: string,
 ): Promise<void> {
-  await writeSessionMeta(
-    id,
-    { roleId, startedAt: new Date().toISOString(), firstUserMessage },
-    r,
-  );
+  const meta: Record<string, unknown> = {
+    roleId,
+    startedAt: new Date().toISOString(),
+    firstUserMessage,
+  };
+  if (origin) meta.origin = origin;
+  await writeSessionMeta(id, meta, r);
 }
 
 export async function backfillFirstUserMessage(

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -39,7 +39,7 @@ export interface SessionMeta {
   firstUserMessage?: string;
   claudeSessionId?: string;
   hasUnread?: boolean;
-  origin?: string;
+  origin?: "human" | "scheduler" | "skill" | "bridge";
   [key: string]: unknown;
 }
 

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -36,6 +36,7 @@ export interface SkillSchedulerDeps {
     message: string;
     roleId: string;
     chatSessionId: string;
+    origin?: string;
   }) => Promise<StartChatResult>;
 }
 
@@ -113,6 +114,7 @@ async function doRegister(deps: SkillSchedulerDeps): Promise<number> {
           message: `/${skill.name}`,
           roleId,
           chatSessionId,
+          origin: "skill",
         });
         if (result.kind === "error") {
           throw new Error(

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -17,6 +17,10 @@ import { parseSkillFrontmatter } from "./parser.js";
 import { log } from "../../system/logger/index.js";
 import { readFileSync } from "fs";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
+import {
+  SESSION_ORIGINS,
+  type SessionOrigin,
+} from "../../../src/types/session.js";
 
 interface SkillScheduleInfo {
   schedule: TaskSchedule;
@@ -36,7 +40,7 @@ export interface SkillSchedulerDeps {
     message: string;
     roleId: string;
     chatSessionId: string;
-    origin?: string;
+    origin?: SessionOrigin;
   }) => Promise<StartChatResult>;
 }
 
@@ -114,7 +118,7 @@ async function doRegister(deps: SkillSchedulerDeps): Promise<number> {
           message: `/${skill.name}`,
           roleId,
           chatSessionId,
-          origin: "skill",
+          origin: SESSION_ORIGINS.skill,
         });
         if (result.kind === "error") {
           throw new Error(

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -195,6 +195,7 @@ export interface UserTaskDeps {
     message: string;
     roleId: string;
     chatSessionId: string;
+    origin?: string;
   }) => Promise<{ kind: string; error?: string }>;
 }
 
@@ -250,6 +251,7 @@ async function doRegisterUserTasks(deps: UserTaskDeps): Promise<number> {
           message: task.prompt,
           roleId: task.roleId,
           chatSessionId,
+          origin: "scheduler",
         });
         if (result.kind === "error") {
           throw new Error(`user task failed: ${result.error ?? "unknown"}`);

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -15,6 +15,10 @@ import type { MissedRunPolicy } from "@receptron/task-scheduler";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 import type { TaskSchedule as LocalTaskSchedule } from "../../events/task-manager/index.js";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
+import {
+  SESSION_ORIGINS,
+  type SessionOrigin,
+} from "../../../src/types/session.js";
 import { log } from "../../system/logger/index.js";
 import type { ITaskManager } from "../../events/task-manager/index.js";
 
@@ -195,7 +199,7 @@ export interface UserTaskDeps {
     message: string;
     roleId: string;
     chatSessionId: string;
-    origin?: string;
+    origin?: SessionOrigin;
   }) => Promise<{ kind: string; error?: string }>;
 }
 
@@ -251,7 +255,7 @@ async function doRegisterUserTasks(deps: UserTaskDeps): Promise<number> {
           message: task.prompt,
           roleId: task.roleId,
           chatSessionId,
-          origin: "scheduler",
+          origin: SESSION_ORIGINS.scheduler,
         });
         if (result.kind === "error") {
           throw new Error(`user task failed: ${result.error ?? "unknown"}`);

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -5,6 +5,18 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { EVENT_TYPES } from "./events";
 import type { ToolCallHistoryItem } from "./toolCallHistory";
 
+// ── Session origin (#486) ───────────────────────────────────
+
+export const SESSION_ORIGINS = {
+  human: "human",
+  scheduler: "scheduler",
+  skill: "skill",
+  bridge: "bridge",
+} as const;
+
+export type SessionOrigin =
+  (typeof SESSION_ORIGINS)[keyof typeof SESSION_ORIGINS];
+
 // Server `/api/sessions` summary. Optional `summary` and `keywords`
 // are populated by the chat indexer (#123) when present.
 //
@@ -22,6 +34,8 @@ export interface SessionSummary {
   preview: string;
   summary?: string;
   keywords?: string[];
+  /** Where this session originated. Missing = "human" (backward compat). */
+  origin?: SessionOrigin;
   // Live state from the server session store (present when the
   // session has an active in-memory entry on the server).
   isRunning?: boolean;


### PR DESCRIPTION
## Summary

全セッションに origin (human / scheduler / skill / bridge) を記録。Phase 2 (UI フィルター) の前提。

## Changes

| Call site | origin |
|---|---|
| Web UI (agent route) | `"human"` (default, omitted) |
| Skill scheduler | `"skill"` |
| User tasks | `"scheduler"` |
| Manual task run | `"scheduler"` |
| Bridge (chat-service) | `"bridge"` |

## Files changed

- `src/types/session.ts` — SESSION_ORIGINS 定数 + SessionOrigin 型
- `server/utils/files/session-io.ts` — SessionMeta + createSessionMeta に origin 追加
- `server/api/routes/agent.ts` — StartChatParams に origin 追加
- `server/api/routes/sessions.ts` — API レスポンスに origin 含む
- `server/workspace/skills/scheduler.ts` — `origin: "skill"`
- `server/workspace/skills/user-tasks.ts` — `origin: "scheduler"`
- `packages/chat-service/src/types.ts` — StartChatParams に origin
- `packages/chat-service/src/relay.ts` — `origin: "bridge"`

## Backward compatibility

既存セッション（origin フィールドなし）は `"human"` として扱われる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)