### PR TITLE
fix(notifications): stop firing bell on LLM session completion

### DIFF
--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -14,12 +14,6 @@ import { log } from "../../system/logger/index.js";
 import { updateHasUnread } from "../../utils/files/session-io.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { ONE_HOUR_MS, ONE_MINUTE_MS } from "../../utils/time.js";
-import { publishNotification } from "../notifications.js";
-import {
-  NOTIFICATION_KINDS,
-  NOTIFICATION_ACTION_TYPES,
-  NOTIFICATION_VIEWS,
-} from "../../../src/types/notification.js";
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -138,22 +132,6 @@ export function endRun(chatSessionId: string): void {
     type: EVENT_TYPES.sessionFinished,
   });
   notifySessionsChanged();
-
-  // P0 trigger: agent completed → notification.
-  // Fires for all sessions (web UI + bridge-initiated). Bridge users
-  // benefit from the bell notification when they later open the web UI
-  // to review agent output. publishNotification is try-catch wrapped,
-  // so failures here never break the session lifecycle.
-  publishNotification({
-    kind: NOTIFICATION_KINDS.agent,
-    title: `Session completed (${session.roleId})`,
-    action: {
-      type: NOTIFICATION_ACTION_TYPES.navigate,
-      view: NOTIFICATION_VIEWS.chat,
-      sessionId: chatSessionId,
-    },
-    sessionId: chatSessionId,
-  });
 }
 
 /** Cancel a running session by killing the child process. */


### PR DESCRIPTION
## Summary

- The session tab bar already indicates completed sessions via the red **unread replies** badge on the history button (driven by `session.hasUnread`).
- The bell notification fired from `endRun` in `server/events/session-store/index.ts` was a **duplicate indicator** for the same event — every LLM reply produced both a red badge on the history button *and* a bell notification, creating visual noise.
- This PR removes the `publishNotification` call (and the now-unused imports) from `endRun`.

## Why remove it

The two signals overlapped completely for the common case (web UI user sending a message and awaiting a reply): both the history-button badge and the bell fired on every session completion. Keeping only the history-button badge gives a single, unambiguous place to see unread replies.

## Scope

Only the agent-completion trigger is removed. Other notification sources remain untouched:

- Source-pipeline "interests" matches (`server/workspace/sources/pipeline/notify.ts`) — user-opted-in alerts for discovered articles.
- Legacy test-notification endpoint (`scheduleTestNotification`).

## Test plan

- [ ] Start a session; send a prompt; confirm no bell notification appears when the reply lands.
- [ ] Confirm the red "unread replies" badge on the history button still appears.
- [ ] Confirm source-pipeline "interests" notifications and the test-notification endpoint still work.
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn test` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)