### PR TITLE
feat: system task schedule overrides via config file

### DIFF
--- a/plans/feat-system-task-override-493.md
+++ b/plans/feat-system-task-override-493.md
@@ -1,0 +1,38 @@
+# feat: System task schedule overrides (#493)
+
+## Problem
+
+System tasks (journal, chat-index) have schedules hardcoded in server/index.ts.
+Users cannot change their frequency without editing code.
+
+## Design
+
+### Config file: `config/scheduler-overrides.json`
+
+```json
+{
+  "system:journal": { "intervalMs": 7200000 },
+  "system:chat-index": { "intervalMs": 3600000 }
+}
+```
+
+- Only `intervalMs` and `time` (for daily) are overridable
+- Missing entries → use code default
+- Invalid entries → log warning, use code default
+
+### Implementation
+
+1. Add `WORKSPACE_FILES.schedulerOverrides` constant
+2. Create `server/utils/files/scheduler-overrides-io.ts` — load/save
+3. Modify `server/index.ts` — apply overrides before `initScheduler`
+4. Add API endpoints for reading/writing overrides
+5. UI: Scheduler TasksTab shows editable schedule for system tasks
+
+### Files
+
+| File | Change |
+|---|---|
+| `src/config/workspacePaths.ts` | Add `schedulerOverrides` |
+| `server/utils/files/scheduler-overrides-io.ts` | New: load/save |
+| `server/index.ts` | Apply overrides to systemTasks |
+| `test/events/test_scheduler_overrides.ts` | New: unit tests |

--- a/plans/feat-system-task-override-493.md
+++ b/plans/feat-system-task-override-493.md
@@ -7,7 +7,7 @@ Users cannot change their frequency without editing code.
 
 ## Design
 
-### Config file: `config/scheduler-overrides.json`
+### Config file: `config/scheduler/overrides.json`
 
 ```json
 {

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -50,6 +50,19 @@ Skills and tasks can be scheduled via SKILL.md frontmatter (\`schedule: "daily H
 
 Suggest a schedule at registration time; let the user confirm or adjust. Prefer \`daily HH:MM\` for tasks that should run once per day, and \`interval Nh\` for polling tasks.
 
+### Changing system task frequency
+
+System tasks (journal, chat-index) have default schedules. Users can override them by editing \`config/scheduler/overrides.json\`:
+
+\`\`\`json
+{
+  "system:journal": { "intervalMs": 7200000 },
+  "system:chat-index": { "intervalMs": 3600000 }
+}
+\`\`\`
+
+When the user asks to change a system task's frequency, use the WebFetch tool to PUT to \`/api/config/scheduler-overrides\` with \`{ "overrides": { "system:journal": { "intervalMs": <ms> } } }\`. This saves the config and applies the change immediately without a server restart.
+
 ## Memory Management
 
 When you learn something from the conversation that would be useful to remember in future sessions, silently append it to \`conversations/memory.md\` using the Edit tool. Do not ask permission — just write it.

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -283,7 +283,7 @@ router.get(
 
 router.put(
   API_ROUTES.config.schedulerOverrides,
-  (
+  async (
     req: Request<unknown, unknown, { overrides: unknown }>,
     res: Response<{ overrides: ScheduleOverrides } | ConfigErrorResponse>,
   ) => {
@@ -304,7 +304,7 @@ router.put(
       // Apply to running task-manager immediately
       for (const [taskId, ovr] of Object.entries(overrides)) {
         if (typeof ovr.intervalMs === "number" && ovr.intervalMs > 0) {
-          applyScheduleOverride(taskId, {
+          await applyScheduleOverride(taskId, {
             type: SCHEDULE_TYPES.interval,
             intervalMs: ovr.intervalMs,
           });
@@ -312,7 +312,7 @@ router.put(
           typeof ovr.time === "string" &&
           /^\d{2}:\d{2}$/.test(ovr.time)
         ) {
-          applyScheduleOverride(taskId, {
+          await applyScheduleOverride(taskId, {
             type: SCHEDULE_TYPES.daily,
             time: ovr.time,
           });

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -264,4 +264,66 @@ router.put(
   },
 );
 
+// ── Scheduler overrides (#493) ──────────────────────────────────
+
+import {
+  loadSchedulerOverrides,
+  saveSchedulerOverrides,
+  type ScheduleOverrides,
+} from "../../utils/files/scheduler-overrides-io.js";
+import { applyScheduleOverride } from "../../events/scheduler-adapter.js";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
+
+router.get(
+  API_ROUTES.config.schedulerOverrides,
+  (_req: Request, res: Response<{ overrides: ScheduleOverrides }>) => {
+    res.json({ overrides: loadSchedulerOverrides() });
+  },
+);
+
+router.put(
+  API_ROUTES.config.schedulerOverrides,
+  (
+    req: Request<unknown, unknown, { overrides: unknown }>,
+    res: Response<{ overrides: ScheduleOverrides } | ConfigErrorResponse>,
+  ) => {
+    const body = req.body;
+    if (typeof body !== "object" || body === null || !("overrides" in body)) {
+      badRequest(res, "expected { overrides: { ... } }");
+      return;
+    }
+    const raw = (body as Record<string, unknown>).overrides;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      badRequest(res, "overrides must be an object");
+      return;
+    }
+    const overrides = raw as ScheduleOverrides;
+    try {
+      saveSchedulerOverrides(overrides);
+
+      // Apply to running task-manager immediately
+      for (const [taskId, ovr] of Object.entries(overrides)) {
+        if (typeof ovr.intervalMs === "number" && ovr.intervalMs > 0) {
+          applyScheduleOverride(taskId, {
+            type: SCHEDULE_TYPES.interval,
+            intervalMs: ovr.intervalMs,
+          });
+        } else if (
+          typeof ovr.time === "string" &&
+          /^\d{2}:\d{2}$/.test(ovr.time)
+        ) {
+          applyScheduleOverride(taskId, {
+            type: SCHEDULE_TYPES.daily,
+            time: ovr.time,
+          });
+        }
+      }
+
+      res.json({ overrides: loadSchedulerOverrides() });
+    } catch (err) {
+      serverError(res, err instanceof Error ? err.message : "save failed");
+    }
+  },
+);
+
 export default router;

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -269,6 +269,7 @@ router.put(
 import {
   loadSchedulerOverrides,
   saveSchedulerOverrides,
+  UTC_HH_MM_RE,
   type ScheduleOverrides,
 } from "../../utils/files/scheduler-overrides-io.js";
 import { applyScheduleOverride } from "../../events/scheduler-adapter.js";
@@ -310,7 +311,7 @@ router.put(
           });
         } else if (
           typeof ovr.time === "string" &&
-          /^\d{2}:\d{2}$/.test(ovr.time)
+          UTC_HH_MM_RE.test(ovr.time)
         ) {
           await applyScheduleOverride(taskId, {
             type: SCHEDULE_TYPES.daily,

--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -152,15 +152,22 @@ export async function initScheduler(
 }
 
 /** Apply a schedule override to a running system task.
- *  Updates both the in-memory task definition and the task-manager. */
-export function applyScheduleOverride(
+ *  Updates the in-memory task definition, the task-manager, and
+ *  recalculates nextScheduledAt in persisted state. */
+export async function applyScheduleOverride(
   taskId: string,
   schedule: SystemTaskDef["schedule"],
-): boolean {
+): Promise<boolean> {
   const task = systemTasks.find((t) => t.id === taskId);
   if (!task || !taskManagerRef) return false;
   task.schedule = schedule;
-  return taskManagerRef.updateSchedule(taskId, schedule);
+  taskManagerRef.updateSchedule(taskId, schedule);
+
+  // Recalculate next window so the UI reflects the new schedule
+  const nextScheduledAt = computeNextScheduled(task);
+  await safeUpdateState(taskId, { nextScheduledAt });
+
+  return true;
 }
 
 /** Query execution logs — used by API routes. */

--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -81,6 +81,7 @@ export interface SystemTaskDef {
 
 let stateMap: StateMap = new Map();
 const systemTasks: SystemTaskDef[] = [];
+let taskManagerRef: ITaskManager | null = null;
 
 /**
  * Initialize the scheduler adapter. Call once at server startup
@@ -96,6 +97,7 @@ export async function initScheduler(
   stateMap = await loadState(stateFilePath(), stateDeps);
   systemTasks.length = 0;
   systemTasks.push(...tasks);
+  taskManagerRef = taskManager;
 
   // Run catch-up
   const catchUpTasks: CatchUpTask[] = tasks.map((t) => ({
@@ -147,6 +149,18 @@ export async function initScheduler(
     tasks: tasks.map((t) => t.id),
     stateEntries: stateMap.size,
   });
+}
+
+/** Apply a schedule override to a running system task.
+ *  Updates both the in-memory task definition and the task-manager. */
+export function applyScheduleOverride(
+  taskId: string,
+  schedule: SystemTaskDef["schedule"],
+): boolean {
+  const task = systemTasks.find((t) => t.id === taskId);
+  if (!task || !taskManagerRef) return false;
+  task.schedule = schedule;
+  return taskManagerRef.updateSchedule(taskId, schedule);
 }
 
 /** Query execution logs — used by API routes. */

--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -160,8 +160,8 @@ export async function applyScheduleOverride(
 ): Promise<boolean> {
   const task = systemTasks.find((t) => t.id === taskId);
   if (!task || !taskManagerRef) return false;
+  if (!taskManagerRef.updateSchedule(taskId, schedule)) return false;
   task.schedule = schedule;
-  taskManagerRef.updateSchedule(taskId, schedule);
 
   // Recalculate next window so the UI reflects the new schedule
   const nextScheduledAt = computeNextScheduled(task);

--- a/server/events/task-manager/index.ts
+++ b/server/events/task-manager/index.ts
@@ -26,6 +26,8 @@ export interface TaskDefinition {
 export interface ITaskManager {
   registerTask(def: TaskDefinition): void;
   removeTask(taskId: string): void;
+  /** Update the schedule of an existing task. Returns false if not found. */
+  updateSchedule(taskId: string, schedule: TaskSchedule): boolean;
   start(): void;
   stop(): void;
   /** Run one tick manually (for testing). */
@@ -157,6 +159,14 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
       }
       registry.set(def.id, def);
       log.info("task-manager", "registered", { id: def.id });
+    },
+
+    updateSchedule(taskId: string, schedule: TaskSchedule): boolean {
+      const def = registry.get(taskId);
+      if (!def) return false;
+      def.schedule = schedule;
+      log.info("task-manager", "schedule updated", { id: taskId });
+      return true;
     },
 
     removeTask(taskId: string) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,6 +53,7 @@ import {
   type SystemTaskDef,
 } from "./events/scheduler-adapter.js";
 import schedulerTasksRoutes from "./api/routes/schedulerTasks.js";
+import { loadSchedulerOverrides } from "./utils/files/scheduler-overrides-io.js";
 import type { IPubSub } from "./events/pub-sub/index.js";
 import { initSessionStore } from "./events/session-store/index.js";
 import { requireSameOrigin } from "./api/csrfGuard.js";
@@ -399,6 +400,41 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
       run: () => backfillAllSessions().then(() => {}),
     },
   ];
+
+  // Apply user-configurable schedule overrides from
+  // config/scheduler/overrides.json. Missing file or unknown keys
+  // are silently ignored — the hardcoded defaults above remain.
+  const overrides = loadSchedulerOverrides();
+  for (const task of systemTasks) {
+    const ovr = overrides[task.id];
+    if (!ovr) continue;
+    if (
+      task.schedule.type === SCHEDULE_TYPES.interval &&
+      typeof ovr.intervalMs === "number" &&
+      ovr.intervalMs > 0
+    ) {
+      log.info("scheduler", "applying override", {
+        id: task.id,
+        intervalMs: ovr.intervalMs,
+      });
+      task.schedule = {
+        type: SCHEDULE_TYPES.interval,
+        intervalMs: ovr.intervalMs,
+      };
+    }
+    if (
+      task.schedule.type === SCHEDULE_TYPES.daily &&
+      typeof ovr.time === "string" &&
+      /^\d{2}:\d{2}$/.test(ovr.time)
+    ) {
+      log.info("scheduler", "applying override", {
+        id: task.id,
+        time: ovr.time,
+      });
+      task.schedule = { type: SCHEDULE_TYPES.daily, time: ovr.time };
+    }
+  }
+
   initScheduler(taskManager, systemTasks).catch((err) => {
     log.error("scheduler", "init failed (non-fatal)", {
       error: String(err),

--- a/server/index.ts
+++ b/server/index.ts
@@ -55,7 +55,10 @@ import {
   type SystemTaskDef,
 } from "./events/scheduler-adapter.js";
 import schedulerTasksRoutes from "./api/routes/schedulerTasks.js";
-import { loadSchedulerOverrides } from "./utils/files/scheduler-overrides-io.js";
+import {
+  loadSchedulerOverrides,
+  UTC_HH_MM_RE,
+} from "./utils/files/scheduler-overrides-io.js";
 import type { IPubSub } from "./events/pub-sub/index.js";
 import { initSessionStore } from "./events/session-store/index.js";
 import { requireSameOrigin } from "./api/csrfGuard.js";
@@ -473,7 +476,7 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
     if (
       task.schedule.type === SCHEDULE_TYPES.daily &&
       typeof ovr.time === "string" &&
-      /^\d{2}:\d{2}$/.test(ovr.time)
+      UTC_HH_MM_RE.test(ovr.time)
     ) {
       log.info("scheduler", "applying override", {
         id: task.id,

--- a/server/utils/files/index.ts
+++ b/server/utils/files/index.ts
@@ -60,3 +60,4 @@ export * from "./todos-io.js";
 export * from "./scheduler-io.js";
 export * from "./html-io.js";
 export * from "./reference-dirs-io.js";
+export * from "./scheduler-overrides-io.js";

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -4,10 +4,12 @@
 // system task ID (e.g. "system:journal"), value overrides the
 // default schedule.
 
+import fs from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/paths.js";
 import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
 import { loadJsonFile } from "./json.js";
+import { writeFileAtomicSync } from "./atomic.js";
 import { log } from "../../system/logger/index.js";
 
 export interface ScheduleOverride {
@@ -31,4 +33,14 @@ export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
     return {};
   }
   return raw as ScheduleOverrides;
+}
+
+/** Save schedule overrides atomically. Creates directory if needed. */
+export function saveSchedulerOverrides(
+  overrides: ScheduleOverrides,
+  root?: string,
+): void {
+  const filePath = overridesPath(root);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileAtomicSync(filePath, JSON.stringify(overrides, null, 2));
 }

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -1,0 +1,34 @@
+// Domain I/O for scheduler override config.
+//
+// Reads/writes config/scheduler/overrides.json. Each key is a
+// system task ID (e.g. "system:journal"), value overrides the
+// default schedule.
+
+import path from "path";
+import { workspacePath } from "../../workspace/paths.js";
+import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
+import { loadJsonFile } from "./json.js";
+import { log } from "../../system/logger/index.js";
+
+export interface ScheduleOverride {
+  /** Override interval in milliseconds (for interval-type schedules). */
+  intervalMs?: number;
+  /** Override time "HH:MM" in UTC (for daily-type schedules). */
+  time?: string;
+}
+
+export type ScheduleOverrides = Record<string, ScheduleOverride>;
+
+function overridesPath(root?: string): string {
+  return path.join(root ?? workspacePath, WORKSPACE_FILES.schedulerOverrides);
+}
+
+/** Load schedule overrides. Returns empty object on missing/corrupt file. */
+export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
+  const raw = loadJsonFile<unknown>(overridesPath(root), {});
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    log.warn("scheduler-overrides", "overrides.json is not an object");
+    return {};
+  }
+  return raw as ScheduleOverrides;
+}

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -21,18 +21,44 @@ export interface ScheduleOverride {
 
 export type ScheduleOverrides = Record<string, ScheduleOverride>;
 
+/** Strict HH:MM validation — rejects 99:99 etc. */
+export const UTC_HH_MM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function isScheduleOverride(value: unknown): value is ScheduleOverride {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  const hasInterval =
+    "intervalMs" in obj &&
+    typeof obj.intervalMs === "number" &&
+    obj.intervalMs > 0;
+  const hasTime =
+    "time" in obj &&
+    typeof obj.time === "string" &&
+    UTC_HH_MM_RE.test(obj.time);
+  // At least one valid field required
+  return hasInterval || hasTime;
+}
+
 function overridesPath(root?: string): string {
   return path.join(root ?? workspacePath, WORKSPACE_FILES.schedulerOverrides);
 }
 
-/** Load schedule overrides. Returns empty object on missing/corrupt file. */
+/** Load schedule overrides. Filters out invalid entries with a warning. */
 export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
   const raw = loadJsonFile<unknown>(overridesPath(root), {});
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     log.warn("scheduler-overrides", "overrides.json is not an object");
     return {};
   }
-  return raw as ScheduleOverrides;
+  const result: ScheduleOverrides = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (isScheduleOverride(value)) {
+      result[key] = value;
+    } else {
+      log.warn("scheduler-overrides", "invalid entry, skipping", { key });
+    }
+  }
+  return result;
 }
 
 /** Save schedule overrides atomically. Creates directory if needed. */

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -134,6 +134,10 @@ export const WORKSPACE_PATHS = {
     workspacePath,
     WORKSPACE_FILES.schedulerUserTasks,
   ),
+  schedulerOverrides: path.join(
+    workspacePath,
+    WORKSPACE_FILES.schedulerOverrides,
+  ),
 } as const;
 
 export type WorkspaceDirKey = keyof typeof WORKSPACE_DIRS;

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -50,6 +50,7 @@ export const API_ROUTES = {
     mcp: "/api/config/mcp",
     workspaceDirs: "/api/config/workspace-dirs",
     referenceDirs: "/api/config/reference-dirs",
+    schedulerOverrides: "/api/config/scheduler-overrides",
   },
 
   files: {

--- a/src/config/workspacePaths.ts
+++ b/src/config/workspacePaths.ts
@@ -20,4 +20,5 @@ export const WORKSPACE_FILES = {
   todosColumns: "data/todos/columns.json",
   schedulerItems: "data/scheduler/items.json",
   schedulerUserTasks: "config/scheduler/tasks.json",
+  schedulerOverrides: "config/scheduler/overrides.json",
 } as const;

--- a/test/events/test_scheduler_overrides.ts
+++ b/test/events/test_scheduler_overrides.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import path from "path";
+import os from "os";
+import { loadSchedulerOverrides } from "../../server/utils/files/scheduler-overrides-io.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "sched-override-test-"));
+}
+
+describe("loadSchedulerOverrides", () => {
+  it("returns empty object when file does not exist", () => {
+    const root = makeTmpDir();
+    const result = loadSchedulerOverrides(root);
+    assert.deepEqual(result, {});
+  });
+
+  it("loads valid overrides", () => {
+    const root = makeTmpDir();
+    const dir = path.join(root, "config", "scheduler");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "overrides.json"),
+      JSON.stringify({
+        "system:journal": { intervalMs: 7200000 },
+        "system:chat-index": { time: "03:00" },
+      }),
+    );
+    const result = loadSchedulerOverrides(root);
+    assert.equal(result["system:journal"]?.intervalMs, 7200000);
+    assert.equal(result["system:chat-index"]?.time, "03:00");
+  });
+
+  it("returns empty object for corrupt JSON", () => {
+    const root = makeTmpDir();
+    const dir = path.join(root, "config", "scheduler");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "overrides.json"), "NOT JSON");
+    const result = loadSchedulerOverrides(root);
+    assert.deepEqual(result, {});
+  });
+
+  it("returns empty object when file is an array", () => {
+    const root = makeTmpDir();
+    const dir = path.join(root, "config", "scheduler");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "overrides.json"), "[]");
+    const result = loadSchedulerOverrides(root);
+    assert.deepEqual(result, {});
+  });
+});


### PR DESCRIPTION
## Summary

System タスク（journal daily pass, chat-index backfill）のスケジュールを `config/scheduler/overrides.json` で変更可能に。

### 使い方

```json
{
  "system:journal": { "intervalMs": 7200000 },
  "system:chat-index": { "intervalMs": 3600000 }
}
```

- ファイルがなければコードのデフォルト値を使用
- 不正なキーや値はログ warning + デフォルトにフォールバック
- サーバー起動時に1回読み込み

### 実装

- `WORKSPACE_FILES.schedulerOverrides` 定数追加
- `server/utils/files/scheduler-overrides-io.ts` — domain I/O モジュール
- `server/index.ts` — `initScheduler` 前に override 適用

## テスト方法

```bash
npx tsx --test test/events/test_scheduler_overrides.ts
```

| テスト | 検証内容 |
|---|---|
| ファイルなし → 空オブジェクト | フォールバック |
| 有効な overrides を読み込む | 正常系 |
| 壊れた JSON → 空オブジェクト | エラー耐性 |
| 配列 → 空オブジェクト | 型チェック |

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable scheduling overrides for system tasks via a configuration file
  * New API endpoints to read and modify scheduler overrides
  * System task schedules can now be adjusted at runtime without server restart

* **Documentation**
  * Updated system guidance with instructions for overriding system task frequency

* **Tests**
  * Added test coverage for scheduler override load functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->