### PR TITLE
fix: session origin — backfill, validation, tests (#486)

### DIFF
--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -41,6 +41,7 @@ import {
 } from "../../workspace/tool-trace/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
+import { isSessionOrigin } from "../../../src/types/session.js";
 import { env } from "../../system/env.js";
 import type { Attachment } from "@mulmobridge/protocol";
 import { parseDataUrl } from "@mulmobridge/client";
@@ -196,18 +197,21 @@ export async function startChat(
   // other tabs) see the turn. Metadata first — it powers the sidebar
   // title cache; the append follows so the jsonl is always a
   // superset of what metadata advertised.
+  const validOrigin = isSessionOrigin(params.origin)
+    ? params.origin
+    : undefined;
   if (isFirstTurn) {
     await createSessionMeta(
       chatSessionId,
       roleId,
       message,
       undefined,
-      params.origin,
+      validOrigin,
     );
   } else {
     await backfillMeta(chatSessionId, message);
-    if (params.origin) {
-      await backfillOrigin(chatSessionId, params.origin);
+    if (validOrigin) {
+      await backfillOrigin(chatSessionId, validOrigin);
     }
   }
 

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -98,14 +98,12 @@ export async function createSessionMeta(
 
 export async function backfillOrigin(
   id: string,
-  origin: string,
+  origin: SessionMeta["origin"],
   r?: string,
 ): Promise<void> {
   const meta = await readSessionMeta(id, r);
   if (!meta || meta.origin) return; // already set
-  const updated = { ...meta };
-  updated.origin = origin as SessionMeta["origin"];
-  await writeSessionMeta(id, updated, r);
+  await writeSessionMeta(id, { ...meta, origin }, r);
 }
 
 export async function backfillFirstUserMessage(

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -17,6 +17,14 @@ export const SESSION_ORIGINS = {
 export type SessionOrigin =
   (typeof SESSION_ORIGINS)[keyof typeof SESSION_ORIGINS];
 
+const VALID_ORIGINS: ReadonlySet<string> = new Set(
+  Object.values(SESSION_ORIGINS),
+);
+
+export function isSessionOrigin(value: unknown): value is SessionOrigin {
+  return typeof value === "string" && VALID_ORIGINS.has(value);
+}
+
 // Server `/api/sessions` summary. Optional `summary` and `keywords`
 // are populated by the chat indexer (#123) when present.
 //


### PR DESCRIPTION
## Summary

PR #494 (フィルタUI) のフォローアップ。

- bridge がセッション再利用時に origin が設定されないバグ修正
- origin の値検証（不正値は保存しない）
- unit test 7件 + E2E 2件追加

## Changes

### backfillOrigin (bridge reuse fix)
bridge が既存セッションを再利用すると isFirstTurn=false → createSessionMeta がスキップされ origin が書き込まれなかった。backfillOrigin() で既存セッションにも origin を追記。

### origin validation
isSessionOrigin() type guard を追加。startChat で params.origin を検証し、不正値（typo 等）は silently drop して human 扱い。unsafe な as キャストを削除。

### Tests
- Unit (7件): createSessionMeta origin 設定 / backfillOrigin 上書き防止・missing 安全性
- E2E (2件): フィルタバー表示 / Bridge フィルタで絞り込み→All リセット

🤖 Generated with [Claude Code](https://claude.com/claude-code)