### PR TITLE
Stack-mode layout redesign: global top bar, no sidebar (#498)

### DIFF
--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -58,8 +58,10 @@ test.describe("history panel (useSessionHistory)", () => {
     const item = page.getByTestId(`session-item-${SESSION_A.id}`);
     await expect(item).toBeVisible();
 
-    // Click somewhere neutral (main chat canvas area, far from the header).
-    await page.locator("body").click({ position: { x: 600, y: 500 } });
+    // Click a neutral element in the top bar — the popup now spans
+    // the full canvas width, so the only clickable "outside" region
+    // is the header itself.
+    await page.getByTestId("app-title").click();
     await expect(item).toBeHidden();
   });
 

--- a/plans/feat-stack-mode-no-sidebar-498.md
+++ b/plans/feat-stack-mode-no-sidebar-498.md
@@ -1,0 +1,204 @@
+# feat: Stack mode without sidebar (#498)
+
+## Problem
+
+Stack mode's canvas already shows every tool result chronologically — the
+same data that `ToolResultsPanel` previews in the left sidebar. The sidebar
+therefore duplicates content and compresses the Stack view into ~70% of
+the window width.
+
+The goal is a Stack-only layout with no left sidebar, controls split
+between a top bar and a bottom bar, and the canvas at full width.
+
+Prep work (#497) has already extracted the 5 sidebar regions
+(`SidebarHeader`, `RoleSelector`, `SessionTabBar`, `SuggestionsPanel`,
+`ChatInput`) into standalone components, so this change is pure layout
+movement — no component rewrites.
+
+## Target layout (Stack mode only)
+
+```text
+┌──────────────────────────────────────────────────────────┐
+│ MulmoClaude │ [RoleSelector] │ [SessionTabBar] │ 🔔 🛠 ⚙ │  top bar
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│                       StackView                          │
+│                (full width, tool results)                │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│  [SuggestionsPanel]                                      │
+│  [ChatInput]                                             │  bottom bar
+└──────────────────────────────────────────────────────────┘
+```
+
+Single / Files / Todos / Scheduler / Wiki / Skills / Roles keep the
+current sidebar layout unchanged.
+
+## Decisions on open questions
+
+1. **Gemini API key warning** → inline banner above `StackView` (same
+   tone/styling as today, just re-anchored). Keeps it visible without
+   crowding the top bar or stealing space from `ChatInput`.
+2. **Right sidebar (tool-call history)** → unchanged. Top-bar `build`
+   button still toggles `RightSidebar`, which is already an absolutely-
+   positioned panel on the right edge — it works identically under both
+   layouts.
+3. **Mode-switch transition** → hard cut. Matches every other view-mode
+   switch today (`CanvasViewToggle` already has a visible affordance).
+4. **Session history popup** → reuse the existing
+   `historyPopupTopOffset` mechanism, but anchor it to the top bar's
+   history button. Popup renders below the top bar, spans the full
+   window width, and closes on outside click via the existing
+   `useClickOutside` wiring.
+
+## Implementation
+
+### 1. Single-source layout switch in `src/App.vue`
+
+Drive everything from one condition:
+
+```ts
+const isStackLayout = computed(
+  () => canvasViewMode.value === CANVAS_VIEW.stack,
+);
+```
+
+Two top-level branches in the template:
+
+- `v-if="isStackLayout"` → new top bar + full-width canvas + bottom bar
+- `v-else` → existing sidebar + canvas layout (unchanged)
+
+No component props or logic change — only placement and container classes.
+
+### 2. New top bar (Stack layout)
+
+A single horizontal row containing:
+
+- `SidebarHeader` — already has a flex row; title on the left, lock /
+  notification / build / settings buttons on the right. Extract those
+  action buttons into their own row-friendly slot or drop the title's
+  `border-b` / `p-4` padding for top-bar use. Pass the existing props
+  (`sandboxEnabled`, `showRightSidebar`, `titleStyle`) and emit events
+  the same way.
+- `RoleSelector` — `p-4 border-b` needs trimming for the top-bar row;
+  the component's dropdown is `absolute left-4 right-4 top-full` which
+  still works when the selector sits in a narrower container. Cap its
+  width (e.g. `w-64`) so it doesn't push the session tabs off-screen.
+- `SessionTabBar` — already horizontal. Drop the bottom border and
+  `px-2 py-1` surround, let the top bar own spacing.
+
+**History popup**: move `<SessionHistoryPanel>` out of the left-sidebar
+container and render it as a top-bar-anchored popup. Its current
+positioning uses `absolute left-0 right-0 top: ${offset}px` — keep
+that, just compute `historyPopupTopOffset` from the top-bar's height
+(e.g. `sessionTabBarRef.value?.historyButton?.getBoundingClientRect()
+.bottom`).
+
+Each sub-component may need a small prop or `:class` tweak for the
+"top-bar variant" — prefer passing a `variant: 'sidebar' | 'topbar'`
+prop over duplicating components. If the style delta is tiny (just
+drop borders/padding), a parent-applied wrapper class is enough.
+
+### 3. Full-width canvas
+
+Drop the `w-80` sidebar column. The canvas wrapper becomes the single
+flex child:
+
+```html
+<div class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden">
+  <!-- Gemini warning banner (Stack only) -->
+  <!-- PluginLauncher + CanvasViewToggle row (existing) -->
+  <!-- StackView (canvasRef) -->
+</div>
+```
+
+`StackView` already fills its parent — no changes needed inside it.
+
+### 4. Bottom bar
+
+`SuggestionsPanel` + `ChatInput` stacked vertically, pinned to the
+bottom via `flex-shrink-0`. Both components already define their own
+padding and borders — keep them as-is, just host them in a shared
+container directly under the canvas wrapper.
+
+`suggestionsPanelRef.collapse()` (called from `createNewSession`)
+continues to work unchanged.
+
+### 5. Things to remove from the Stack layout
+
+- `ToolResultsPanel` — not rendered in Stack mode. Keep the
+  `toolResultsPanelRef` ref (used by `chatListRef` / `scrollChatToBottom`)
+  but make `scrollChatToBottom` no-op when `isStackLayout` is true;
+  `StackView` auto-scrolls to newly-selected results already via its
+  internal `scrollToItem`.
+- Sidebar key navigation (`handleKeyNavigation` with
+  `activePane === 'sidebar'`) — harmless because `activePane` defaults
+  to `'sidebar'` but no sidebar list exists to navigate. The canvas's
+  own `handleCanvasKeydown` takes over in Stack layout. Consider
+  defaulting `activePane` to `'main'` when entering Stack mode.
+
+### 6. Per-session persistence
+
+No new state. The layout is purely derived from `canvasViewMode`, which
+is already per-session via the route query string. Switching view modes
+toggles the layout automatically; loading a pre-existing session with
+`?view=stack` lands directly in the new layout.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/App.vue` | Two-branch template; add `isStackLayout` computed; move `SessionHistoryPanel` anchor; no-op `scrollChatToBottom` in Stack; set `activePane='main'` when entering Stack |
+| `src/components/SidebarHeader.vue` | Optional `variant` prop to drop title padding in top-bar mode, OR split the action buttons into a small `HeaderActions.vue` so the top bar can compose title + actions separately |
+| `src/components/RoleSelector.vue` | Accept `variant` / compact styling; cap dropdown width when in top bar |
+| `src/components/SessionTabBar.vue` | Accept `variant` / drop border + surround when in top bar |
+| `src/components/SessionHistoryPanel.vue` | No logic change; verify full-width popup looks right when anchored to top bar |
+
+No server-side changes. No new API routes. No new event types.
+
+## Testing
+
+### E2E (`e2e/`)
+
+- `stack-layout.spec.ts` (new):
+  - Switch to Stack mode → sidebar gone; top bar contains role selector,
+    session tabs, lock/notification/settings buttons.
+  - Suggestions + chat input sit at the bottom of the viewport.
+  - Click history button in top bar → popup opens below the top bar.
+  - Type in chat input → message appears; new tool result renders
+    full-width in the stack.
+  - Switch back to Single mode → sidebar reappears; top bar gone.
+- Update any existing Stack-mode test that selects by
+  `[data-testid="tool-results-panel"]` — those selectors don't exist
+  in the new layout.
+
+Use `mockAllApis(page)` before `page.goto()`. All existing fixtures
+in `e2e/fixtures/chat.ts` (role switch, send message, wait for result)
+must continue to work for Single mode and be adjusted where they
+assume a left-sidebar position.
+
+### Manual testing
+
+- Gemini-warning visibility when role needs it and the key is missing
+  (Stack + Single mode).
+- Notification / settings / lock popups open from the top bar without
+  overlapping the stack canvas.
+- Right sidebar toggle works in Stack mode (covers canvas from the
+  right edge).
+- Session tab overflow: 6 active sessions + history button fit in
+  the top bar without clipping on 1280px-wide windows.
+- Mode switch Single ⇄ Stack preserves `selectedResultUuid` and
+  session state.
+
+### Typecheck / lint / build
+
+- `yarn format && yarn lint && yarn typecheck && yarn build` after
+  changes.
+
+## Out of scope
+
+- Changing Single / Files / Todos / Scheduler / Wiki / Skills / Roles
+  layouts.
+- Mobile / narrow-window responsive handling (follow-up if needed).
+- Animated transitions between layouts (hard cut chosen above).
+- Restructuring `StackView` itself.

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,6 @@
       <!-- Row 1: title + plugin launcher -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
         <SidebarHeader
-          variant="topbar"
           :sandbox-enabled="sandboxEnabled"
           :show-right-sidebar="showRightSidebar"
           :title-style="debugTitleStyle"
@@ -30,13 +29,11 @@
         />
         <RoleSelector
           v-model:current-role-id="currentRoleId"
-          variant="topbar"
           :roles="roles"
           @change="onRoleChange"
         />
         <SessionTabBar
           ref="sessionTabBarRef"
-          variant="topbar"
           :sessions="tabSessions"
           :current-session-id="displayedCurrentSessionId"
           :roles="roles"

--- a/src/App.vue
+++ b/src/App.vue
@@ -180,9 +180,10 @@
           <RolesView v-else-if="canvasViewMode === 'roles'" />
         </div>
 
-        <!-- Bottom bar (Stack layouts) -->
+        <!-- Bottom bar (Stack chat only — plugin views have no
+             session context, so no chat input is shown) -->
         <div
-          v-if="isStackLayout"
+          v-if="canvasViewMode === 'stack'"
           class="border-t border-gray-200 bg-white shrink-0"
         >
           <SuggestionsPanel

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
           @toggle-right-sidebar="toggleRightSidebar"
           @open-settings="showSettings = true"
         />
-        <div class="flex-1 flex items-center gap-2 min-w-0">
+        <div class="flex-1 min-w-0">
           <PluginLauncher
             :active-tool-name="selectedResult?.toolName ?? null"
             :active-view-mode="canvasViewMode"
@@ -166,7 +166,7 @@
           <FilesView
             v-else-if="canvasViewMode === 'files'"
             :refresh-token="filesRefreshToken"
-            @load-session="onFilesViewLoadSession"
+            @load-session="loadSession"
           />
           <!-- Todos mode -->
           <TodoExplorer v-else-if="canvasViewMode === 'todos'" />
@@ -842,25 +842,8 @@ function handleUpdateResult(updatedResult: ToolResultComplete) {
   }
 }
 
-// When the user clicks an item in the sidebar while the canvas is
-// showing the file explorer, the previously-selected file would
-// otherwise stay on screen and the click would have no visible
-// effect. Auto-switch back to single mode so the clicked item
-// actually shows up in the canvas.
 function onSidebarItemClick(uuid: string) {
   selectedResultUuid.value = uuid;
-  if (canvasViewMode.value === CANVAS_VIEW.files) {
-    setCanvasViewMode(CANVAS_VIEW.single);
-  }
-}
-
-// Bridge from FilesView: a user clicked a markdown link to a chat
-// session (e.g. "[session abc](../../chat/abc-123.jsonl)" inside
-// a journal summary). loadSession pops the canvas out of files mode
-// via restoreChatViewForSession, so we don't need an explicit view
-// switch here.
-function onFilesViewLoadSession(sessionId: string): void {
-  loadSession(sessionId);
 }
 
 const GEMINI_PLUGINS = new Set(["generateImage", "presentDocument"]);

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col fixed inset-0 bg-gray-900 text-white">
     <!-- Global top bar — shown in every view mode -->
     <div ref="topBarRef" class="shrink-0 bg-white text-gray-900">
-      <!-- Row 1: title + plugin launcher + canvas toggle -->
+      <!-- Row 1: title + plugin launcher -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
         <SidebarHeader
           variant="topbar"
@@ -14,20 +14,20 @@
           @toggle-right-sidebar="toggleRightSidebar"
           @open-settings="showSettings = true"
         />
-        <div class="flex-1 flex items-center justify-between gap-2 min-w-0">
+        <div class="flex-1 flex items-center gap-2 min-w-0">
           <PluginLauncher
             :active-tool-name="selectedResult?.toolName ?? null"
             :active-view-mode="canvasViewMode"
             @navigate="onPluginNavigate"
           />
-          <CanvasViewToggle
-            :model-value="canvasViewMode"
-            @update:model-value="setCanvasViewMode"
-          />
         </div>
       </div>
-      <!-- Row 2: role selector + session tabs -->
+      <!-- Row 2: canvas toggle + role selector + session tabs -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
+        <CanvasViewToggle
+          :model-value="canvasViewMode"
+          @update:model-value="setCanvasViewMode"
+        />
         <RoleSelector
           v-model:current-role-id="currentRoleId"
           variant="topbar"

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,8 +40,8 @@
           :active-session-count="activeSessionCount"
           :unread-count="unreadCount"
           :history-open="showHistory"
-          @new-session="createNewSession()"
-          @load-session="loadSession"
+          @new-session="handleNewSessionClick"
+          @load-session="handleSessionSelect"
           @toggle-history="toggleHistory"
         />
       </div>
@@ -56,7 +56,7 @@
       :roles="roles"
       :top-offset="historyTopOffset"
       :error-message="historyError"
-      @load-session="loadSession"
+      @load-session="handleSessionSelect"
     />
 
     <!-- Body: sidebar (Single only) + canvas column + right sidebar -->
@@ -166,7 +166,7 @@
           <FilesView
             v-else-if="canvasViewMode === 'files'"
             :refresh-token="filesRefreshToken"
-            @load-session="loadSession"
+            @load-session="handleSessionSelect"
           />
           <!-- Todos mode -->
           <TodoExplorer v-else-if="canvasViewMode === 'todos'" />
@@ -654,6 +654,23 @@ function restoreChatViewForSession(): void {
   }
 }
 
+// User-initiated session switches: clicking a session tab, a history
+// row, or a chat link in FilesView. In plugin views (Todos / Files /
+// ...) no chat is active, so the click's purpose is to surface the
+// chat — restore the preferred Single/Stack mode before loading.
+// Not wired into the internal `loadSession` call path because that
+// also fires on initial mount with `?view=plugin` URLs, which must
+// be honoured as-is.
+function handleSessionSelect(id: string): void {
+  restoreChatViewForSession();
+  loadSession(id);
+}
+
+function handleNewSessionClick(): void {
+  restoreChatViewForSession();
+  createNewSession();
+}
+
 // In plugin views (Todos / Files / ...) no chat is active, so the
 // session tabs should show no tab as "current". That way clicking
 // any tab — including the session the user was last on — counts as a
@@ -872,10 +889,6 @@ function createNewSession(roleId?: string): ActiveSession {
   // Remove the current session if it's empty (no messages exchanged).
   removeCurrentIfEmpty();
 
-  // Starting a fresh chat from a plugin view (Todos / Files / ...)
-  // should drop the user back into their preferred chat layout.
-  restoreChatViewForSession();
-
   const id = uuidv4();
   const rId = roleId ?? currentRoleId.value;
   const now = new Date().toISOString();
@@ -901,6 +914,10 @@ function createNewSession(roleId?: string): ActiveSession {
 }
 
 function onRoleChange() {
+  // Covers both the user dropdown click and the agent-triggered role
+  // switch (EVENT_TYPES.switchRole) — either way the user ends up in
+  // a fresh chat session, so a plugin view should yield to chat.
+  restoreChatViewForSession();
   const session = createNewSession(currentRoleId.value);
   maybeSeedRoleDefault(session);
 }
@@ -945,23 +962,11 @@ async function maybeSeedRoleDefault(session: ActiveSession): Promise<void> {
 }
 
 async function loadSession(id: string) {
-  // Re-selecting the already-active, loaded session is a no-op —
-  // unless the canvas is showing a plugin view, in which case the
-  // click's purpose is to return to chat (see restoreChatView below).
+  // Re-selecting the already-active, loaded session is a no-op.
   // The sessionMap check is needed because the route watcher sets
   // currentSessionId before calling loadSession — without it the
   // guard would bail before the session data is fetched.
-  if (
-    id === currentSessionId.value &&
-    sessionMap.has(id) &&
-    isChatView(canvasViewMode.value)
-  ) {
-    return;
-  }
-
-  // Clicking a session from a plugin view (Todos / Files / ...) should
-  // surface the chat, not leave the user staring at the same plugin.
-  restoreChatViewForSession();
+  if (id === currentSessionId.value && sessionMap.has(id)) return;
 
   // If the current session is empty, remove it from memory and use
   // replace-navigation so the empty session doesn't linger in

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,175 +1,219 @@
 <template>
-  <div class="flex fixed inset-0 bg-gray-900 text-white">
-    <!-- Sidebar -->
-    <div
-      class="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col bg-white text-gray-900 relative"
-    >
-      <SidebarHeader
-        :sandbox-enabled="sandboxEnabled"
-        :show-right-sidebar="showRightSidebar"
-        :title-style="debugTitleStyle"
-        @test-query="(q) => sendMessage(q)"
-        @notification-navigate="handleNotificationNavigate"
-        @toggle-right-sidebar="toggleRightSidebar"
-        @open-settings="showSettings = true"
-      />
-      <!-- History popup -->
-      <SessionHistoryPanel
-        v-if="showHistory"
-        ref="historyPanelRef"
-        :sessions="mergedSessions"
-        :current-session-id="currentSessionId"
-        :roles="roles"
-        :top-offset="historyPopupTopOffset"
-        :error-message="historyError"
-        @load-session="loadSession"
-      />
-
-      <!-- Role selector -->
-      <RoleSelector
-        v-model:current-role-id="currentRoleId"
-        :roles="roles"
-        @change="onRoleChange"
-      />
-
-      <!-- Session tab bar -->
-      <SessionTabBar
-        ref="sessionTabBarRef"
-        :sessions="tabSessions"
-        :current-session-id="currentSessionId"
-        :roles="roles"
-        :active-session-count="activeSessionCount"
-        :unread-count="unreadCount"
-        :history-open="showHistory"
-        @new-session="createNewSession()"
-        @load-session="loadSession"
-        @toggle-history="toggleHistory"
-      />
-
-      <!-- Gemini API key warning -->
-      <div
-        v-if="!geminiAvailable && needsGemini(currentRoleId)"
-        class="mx-4 mb-2 rounded border border-yellow-400 bg-yellow-50 p-3 text-xs text-yellow-700"
-      >
-        <span class="material-icons text-xs align-middle mr-1">warning</span>
-        Image generation requires <code class="font-mono">GEMINI_API_KEY</code>.
-        Add it to <code class="font-mono">.env</code> and restart the app.
+  <div class="flex flex-col fixed inset-0 bg-gray-900 text-white">
+    <!-- Global top bar — shown in every view mode -->
+    <div ref="topBarRef" class="shrink-0 bg-white text-gray-900">
+      <!-- Row 1: title + plugin launcher + canvas toggle -->
+      <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
+        <SidebarHeader
+          variant="topbar"
+          :sandbox-enabled="sandboxEnabled"
+          :show-right-sidebar="showRightSidebar"
+          :title-style="debugTitleStyle"
+          @test-query="(q) => sendMessage(q)"
+          @notification-navigate="handleNotificationNavigate"
+          @toggle-right-sidebar="toggleRightSidebar"
+          @open-settings="showSettings = true"
+        />
+        <div class="flex-1 flex items-center justify-between gap-2 min-w-0">
+          <PluginLauncher
+            :active-tool-name="selectedResult?.toolName ?? null"
+            :active-view-mode="canvasViewMode"
+            @navigate="onPluginNavigate"
+          />
+          <CanvasViewToggle
+            :model-value="canvasViewMode"
+            @update:model-value="setCanvasViewMode"
+          />
+        </div>
       </div>
-
-      <!-- Tool result previews -->
-      <ToolResultsPanel
-        ref="toolResultsPanelRef"
-        :results="sidebarResults"
-        :selected-uuid="selectedResultUuid"
-        :is-running="isRunning"
-        :status-message="statusMessage"
-        :pending-calls="pendingCalls"
-        @select="onSidebarItemClick"
-        @activate="activePane = 'sidebar'"
-      />
-
-      <!-- Sample queries (expandable pane) -->
-      <SuggestionsPanel
-        ref="suggestionsPanelRef"
-        :queries="currentRole.queries ?? []"
-        @send="(q) => sendMessage(q)"
-        @edit="onQueryEdit"
-      />
-
-      <!-- Text input -->
-      <ChatInput
-        ref="chatInputRef"
-        v-model="userInput"
-        v-model:pasted-file="pastedFile"
-        :is-running="isRunning"
-        @send="sendMessage()"
-      />
+      <!-- Row 2: role selector + session tabs -->
+      <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
+        <RoleSelector
+          v-model:current-role-id="currentRoleId"
+          variant="topbar"
+          :roles="roles"
+          @change="onRoleChange"
+        />
+        <SessionTabBar
+          ref="sessionTabBarRef"
+          variant="topbar"
+          :sessions="tabSessions"
+          :current-session-id="displayedCurrentSessionId"
+          :roles="roles"
+          :active-session-count="activeSessionCount"
+          :unread-count="unreadCount"
+          :history-open="showHistory"
+          @new-session="createNewSession()"
+          @load-session="loadSession"
+          @toggle-history="toggleHistory"
+        />
+      </div>
     </div>
 
-    <!-- Canvas -->
-    <div
-      class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden"
-    >
+    <!-- History popup (all layouts) -->
+    <SessionHistoryPanel
+      v-if="showHistory"
+      ref="historyPanelRef"
+      :sessions="mergedSessions"
+      :current-session-id="currentSessionId"
+      :roles="roles"
+      :top-offset="historyTopOffset"
+      :error-message="historyError"
+      @load-session="loadSession"
+    />
+
+    <!-- Body: sidebar (Single only) + canvas column + right sidebar -->
+    <div class="flex flex-1 min-h-0">
+      <!-- Sidebar (Single layout only) -->
       <div
-        class="flex items-center justify-between px-3 py-2 border-b border-gray-100 shrink-0 gap-2"
+        v-if="!isStackLayout"
+        class="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col bg-white text-gray-900 relative"
       >
-        <PluginLauncher
-          :active-tool-name="selectedResult?.toolName ?? null"
-          :active-view-mode="canvasViewMode"
-          @navigate="onPluginNavigate"
+        <!-- Gemini API key warning -->
+        <div
+          v-if="!geminiAvailable && needsGemini(currentRoleId)"
+          class="mx-4 mt-3 mb-2 rounded border border-yellow-400 bg-yellow-50 p-3 text-xs text-yellow-700 shrink-0"
+        >
+          <span class="material-icons text-xs align-middle mr-1">warning</span>
+          Image generation requires
+          <code class="font-mono">GEMINI_API_KEY</code>. Add it to
+          <code class="font-mono">.env</code> and restart the app.
+        </div>
+
+        <!-- Tool result previews -->
+        <ToolResultsPanel
+          ref="toolResultsPanelRef"
+          :results="sidebarResults"
+          :selected-uuid="selectedResultUuid"
+          :is-running="isRunning"
+          :status-message="statusMessage"
+          :pending-calls="pendingCalls"
+          @select="onSidebarItemClick"
+          @activate="activePane = 'sidebar'"
         />
-        <CanvasViewToggle
-          :model-value="canvasViewMode"
-          @update:model-value="setCanvasViewMode"
+
+        <!-- Sample queries (expandable pane) -->
+        <SuggestionsPanel
+          ref="suggestionsPanelRef"
+          :queries="currentRole.queries ?? []"
+          @send="(q) => sendMessage(q)"
+          @edit="onQueryEdit"
+        />
+
+        <!-- Text input -->
+        <ChatInput
+          ref="chatInputRef"
+          v-model="userInput"
+          v-model:pasted-file="pastedFile"
+          :is-running="isRunning"
+          @send="sendMessage()"
         />
       </div>
+
+      <!-- Canvas column -->
       <div
-        ref="canvasRef"
-        class="flex-1 overflow-hidden outline-none min-h-0"
-        tabindex="0"
-        @mousedown="activePane = 'main'"
-        @keydown="handleCanvasKeydown"
+        class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden relative"
       >
-        <!-- Single mode -->
-        <template v-if="canvasViewMode === 'single'">
-          <component
-            :is="getPlugin(selectedResult.toolName)?.viewComponent"
-            v-if="
-              selectedResult &&
-              getPlugin(selectedResult.toolName)?.viewComponent
-            "
-            :selected-result="selectedResult"
+        <!-- Gemini API key warning (Stack layouts — no sidebar to host it) -->
+        <div
+          v-if="isStackLayout && !geminiAvailable && needsGemini(currentRoleId)"
+          class="mx-3 mt-2 rounded border border-yellow-400 bg-yellow-50 p-2 text-xs text-yellow-700 shrink-0"
+        >
+          <span class="material-icons text-xs align-middle mr-1">warning</span>
+          Image generation requires
+          <code class="font-mono">GEMINI_API_KEY</code>. Add it to
+          <code class="font-mono">.env</code> and restart the app.
+        </div>
+
+        <div
+          ref="canvasRef"
+          class="flex-1 overflow-hidden outline-none min-h-0"
+          tabindex="0"
+          @mousedown="activePane = 'main'"
+          @keydown="handleCanvasKeydown"
+        >
+          <!-- Single mode -->
+          <template v-if="canvasViewMode === 'single'">
+            <component
+              :is="getPlugin(selectedResult.toolName)?.viewComponent"
+              v-if="
+                selectedResult &&
+                getPlugin(selectedResult.toolName)?.viewComponent
+              "
+              :selected-result="selectedResult"
+              :send-text-message="sendMessage"
+              @update-result="handleUpdateResult"
+            />
+            <div v-else-if="selectedResult" class="h-full overflow-auto p-6">
+              <pre class="text-sm text-gray-700 whitespace-pre-wrap">{{
+                JSON.stringify(selectedResult, null, 2)
+              }}</pre>
+            </div>
+            <div
+              v-else
+              class="flex items-center justify-center h-full text-gray-600"
+            >
+              <p>Start a conversation</p>
+            </div>
+          </template>
+          <!-- Stack mode -->
+          <StackView
+            v-else-if="canvasViewMode === 'stack'"
+            :tool-results="sidebarResults"
+            :selected-result-uuid="selectedResultUuid"
             :send-text-message="sendMessage"
+            @select="(uuid) => (selectedResultUuid = uuid)"
             @update-result="handleUpdateResult"
           />
-          <div v-else-if="selectedResult" class="h-full overflow-auto p-6">
-            <pre class="text-sm text-gray-700 whitespace-pre-wrap">{{
-              JSON.stringify(selectedResult, null, 2)
-            }}</pre>
-          </div>
-          <div
-            v-else
-            class="flex items-center justify-center h-full text-gray-600"
-          >
-            <p>Start a conversation</p>
-          </div>
-        </template>
-        <!-- Stack mode -->
-        <StackView
-          v-else-if="canvasViewMode === 'stack'"
-          :tool-results="sidebarResults"
-          :selected-result-uuid="selectedResultUuid"
-          :send-text-message="sendMessage"
-          @select="(uuid) => (selectedResultUuid = uuid)"
-          @update-result="handleUpdateResult"
-        />
-        <!-- Files mode -->
-        <FilesView
-          v-else-if="canvasViewMode === 'files'"
-          :refresh-token="filesRefreshToken"
-          @load-session="onFilesViewLoadSession"
-        />
-        <!-- Todos mode -->
-        <TodoExplorer v-else-if="canvasViewMode === 'todos'" />
-        <!-- Scheduler mode -->
-        <SchedulerView v-else-if="canvasViewMode === 'scheduler'" />
-        <!-- Wiki mode -->
-        <WikiView v-else-if="canvasViewMode === 'wiki'" />
-        <!-- Skills mode -->
-        <SkillsView v-else-if="canvasViewMode === 'skills'" />
-        <!-- Roles mode -->
-        <RolesView v-else-if="canvasViewMode === 'roles'" />
+          <!-- Files mode -->
+          <FilesView
+            v-else-if="canvasViewMode === 'files'"
+            :refresh-token="filesRefreshToken"
+            @load-session="onFilesViewLoadSession"
+          />
+          <!-- Todos mode -->
+          <TodoExplorer v-else-if="canvasViewMode === 'todos'" />
+          <!-- Scheduler mode -->
+          <SchedulerView v-else-if="canvasViewMode === 'scheduler'" />
+          <!-- Wiki mode -->
+          <WikiView v-else-if="canvasViewMode === 'wiki'" />
+          <!-- Skills mode -->
+          <SkillsView v-else-if="canvasViewMode === 'skills'" />
+          <!-- Roles mode -->
+          <RolesView v-else-if="canvasViewMode === 'roles'" />
+        </div>
+
+        <!-- Bottom bar (Stack layouts) -->
+        <div
+          v-if="isStackLayout"
+          class="border-t border-gray-200 bg-white shrink-0"
+        >
+          <SuggestionsPanel
+            ref="suggestionsPanelRef"
+            :queries="currentRole.queries ?? []"
+            @send="(q) => sendMessage(q)"
+            @edit="onQueryEdit"
+          />
+          <ChatInput
+            ref="chatInputRef"
+            v-model="userInput"
+            v-model:pasted-file="pastedFile"
+            :is-running="isRunning"
+            @send="sendMessage()"
+          />
+        </div>
       </div>
+
+      <!-- Right sidebar: tool call history -->
+      <RightSidebar
+        v-if="showRightSidebar"
+        ref="rightSidebarRef"
+        :tool-call-history="toolCallHistory"
+        :available-tools="availableTools"
+        :role-prompt="currentRole.prompt"
+        :tool-descriptions="toolDescriptions"
+      />
     </div>
-    <!-- Right sidebar: tool call history -->
-    <RightSidebar
-      v-if="showRightSidebar"
-      ref="rightSidebarRef"
-      :tool-call-history="toolCallHistory"
-      :available-tools="availableTools"
-      :role-prompt="currentRole.prompt"
-      :tool-descriptions="toolDescriptions"
-    />
 
     <!-- Global settings modal -->
     <SettingsModal
@@ -534,6 +578,11 @@ const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const chatInputRef = ref<{ focus: () => void } | null>(null);
+const topBarRef = ref<HTMLDivElement | null>(null);
+// Measured when the history popup opens — the popup is a direct child
+// of the root, so its absolute `top` must equal the global top bar's
+// full height.
+const historyTopOffset = ref<number | undefined>(undefined);
 
 function focusChatInput(): void {
   chatInputRef.value?.focus();
@@ -548,11 +597,6 @@ const historyButtonRef = computed(
 // needs the actual popup DOM element (not the component instance).
 const historyPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const historyPopupRef = computed(() => historyPanelRef.value?.root ?? null);
-const historyPopupTopOffset = computed(() => {
-  const btn = historyButtonRef.value;
-  if (!btn) return undefined;
-  return btn.offsetTop + btn.offsetHeight;
-});
 function scrollChatToBottom() {
   nextTick(() => {
     if (chatListRef.value) {
@@ -580,6 +624,62 @@ const {
   filesRefreshToken,
   handleViewModeShortcut,
 } = useCanvasViewMode({ isRunning });
+
+// The no-sidebar "stack-style" layout (top bar + full-width canvas +
+// bottom bar) is used for every view mode except Single. Clicking a
+// plugin launcher button (Todos / Scheduler / Files / ...) swaps the
+// canvas content without collapsing the frame back to the sidebar
+// layout.
+const isStackLayout = computed(
+  () => canvasViewMode.value !== CANVAS_VIEW.single,
+);
+
+// Remember the last chat-oriented view (single or stack) so that
+// selecting a session from a plugin view (Todos / Files / ...) can
+// restore the user's preferred chat layout rather than leaving them
+// on the plugin view.
+const CHAT_VIEWS = [CANVAS_VIEW.single, CANVAS_VIEW.stack] as const;
+type ChatViewMode = (typeof CHAT_VIEWS)[number];
+const isChatView = (m: string): m is ChatViewMode =>
+  (CHAT_VIEWS as readonly string[]).includes(m);
+
+const lastChatViewMode = ref<ChatViewMode>(
+  isChatView(canvasViewMode.value) ? canvasViewMode.value : CANVAS_VIEW.stack,
+);
+watch(canvasViewMode, (mode) => {
+  if (isChatView(mode)) lastChatViewMode.value = mode;
+});
+
+function restoreChatViewForSession(): void {
+  if (!isChatView(canvasViewMode.value)) {
+    setCanvasViewMode(lastChatViewMode.value);
+  }
+}
+
+// In plugin views (Todos / Files / ...) no chat is active, so the
+// session tabs should show no tab as "current". That way clicking
+// any tab — including the session the user was last on — counts as a
+// fresh selection and routes back to the chat view.
+const displayedCurrentSessionId = computed(() =>
+  isChatView(canvasViewMode.value) ? currentSessionId.value : "",
+);
+
+// Keep arrow-key navigation tied to the canvas when the sidebar list
+// doesn't exist (Stack layout has no ToolResultsPanel to navigate).
+watch(isStackLayout, (stack) => {
+  if (stack) activePane.value = "main";
+});
+
+// Measure the top bar's height whenever the history popup is about
+// to open. Defer to nextTick so the popup's v-if transition doesn't
+// race the measurement.
+watch(showHistory, (open) => {
+  if (open) {
+    nextTick(() => {
+      historyTopOffset.value = topBarRef.value?.offsetHeight;
+    });
+  }
+});
 const rightSidebarRef = ref<InstanceType<typeof RightSidebar> | null>(null);
 
 // Plugin-launcher click: switch canvas to the matching view mode.
@@ -759,16 +859,10 @@ function onSidebarItemClick(uuid: string) {
 
 // Bridge from FilesView: a user clicked a markdown link to a chat
 // session (e.g. "[session abc](../../chat/abc-123.jsonl)" inside
-// a journal summary). Switch the active session AND pop the canvas
-// out of files mode, otherwise they'd still be staring at the file
-// tree after the session loaded.
+// a journal summary). loadSession pops the canvas out of files mode
+// via restoreChatViewForSession, so we don't need an explicit view
+// switch here.
 function onFilesViewLoadSession(sessionId: string): void {
-  // Set view mode BEFORE loading session so that navigateToSession
-  // (called inside loadSession) picks up the updated canvasViewMode
-  // in its query — avoids a race where two router.push calls fight.
-  if (canvasViewMode.value === CANVAS_VIEW.files) {
-    setCanvasViewMode(CANVAS_VIEW.single);
-  }
   loadSession(sessionId);
 }
 
@@ -796,6 +890,10 @@ function removeCurrentIfEmpty(): boolean {
 function createNewSession(roleId?: string): ActiveSession {
   // Remove the current session if it's empty (no messages exchanged).
   removeCurrentIfEmpty();
+
+  // Starting a fresh chat from a plugin view (Todos / Files / ...)
+  // should drop the user back into their preferred chat layout.
+  restoreChatViewForSession();
 
   const id = uuidv4();
   const rId = roleId ?? currentRoleId.value;
@@ -866,11 +964,23 @@ async function maybeSeedRoleDefault(session: ActiveSession): Promise<void> {
 }
 
 async function loadSession(id: string) {
-  // Re-selecting the already-active, loaded session is a no-op.
+  // Re-selecting the already-active, loaded session is a no-op —
+  // unless the canvas is showing a plugin view, in which case the
+  // click's purpose is to return to chat (see restoreChatView below).
   // The sessionMap check is needed because the route watcher sets
   // currentSessionId before calling loadSession — without it the
   // guard would bail before the session data is fetched.
-  if (id === currentSessionId.value && sessionMap.has(id)) return;
+  if (
+    id === currentSessionId.value &&
+    sessionMap.has(id) &&
+    isChatView(canvasViewMode.value)
+  ) {
+    return;
+  }
+
+  // Clicking a session from a plugin view (Todos / Files / ...) should
+  // surface the chat, not leave the user staring at the same plugin.
+  restoreChatViewForSession();
 
   // If the current session is empty, remove it from memory and use
   // replace-navigation so the empty session doesn't linger in

--- a/src/components/CanvasViewToggle.vue
+++ b/src/components/CanvasViewToggle.vue
@@ -1,24 +1,28 @@
 <template>
   <button
-    class="flex items-center justify-center w-8 h-8 rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 transition-colors"
-    :title="current.title"
-    :aria-label="current.title"
+    class="flex items-center justify-center w-8 h-8 rounded transition-colors hover:bg-gray-100"
+    :class="isStack ? 'text-blue-500' : 'text-gray-400 hover:text-gray-700'"
+    :title="
+      isStack
+        ? 'Stack view · click to switch to Single (⌘1)'
+        : 'Single view · click to switch to Stack (⌘2)'
+    "
+    :aria-label="isStack ? 'Switch to Single view' : 'Switch to Stack view'"
     :data-testid="`canvas-view-toggle-${modelValue}`"
-    @click="emit('update:modelValue', other.key)"
+    @click="
+      emit(
+        'update:modelValue',
+        isStack ? CANVAS_VIEW.single : CANVAS_VIEW.stack,
+      )
+    "
   >
-    <span class="material-icons text-base">{{ current.icon }}</span>
+    <span class="material-icons text-lg">view_agenda</span>
   </button>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { CANVAS_VIEW, type CanvasViewMode } from "../utils/canvas/viewMode";
-
-interface ModeOption {
-  key: CanvasViewMode;
-  icon: string;
-  title: string;
-}
 
 const props = defineProps<{
   modelValue: CanvasViewMode;
@@ -28,22 +32,5 @@ const emit = defineEmits<{
   "update:modelValue": [mode: CanvasViewMode];
 }>();
 
-const SINGLE: ModeOption = {
-  key: CANVAS_VIEW.single,
-  icon: "crop_square",
-  title: "Single view · click to switch to Stack (⌘2)",
-};
-const STACK: ModeOption = {
-  key: CANVAS_VIEW.stack,
-  icon: "layers",
-  title: "Stack view · click to switch to Single (⌘1)",
-};
-
-// Show the current mode's icon; clicking switches to the other.
-const current = computed<ModeOption>(() =>
-  props.modelValue === CANVAS_VIEW.stack ? STACK : SINGLE,
-);
-const other = computed<ModeOption>(() =>
-  props.modelValue === CANVAS_VIEW.stack ? SINGLE : STACK,
-);
+const isStack = computed(() => props.modelValue === CANVAS_VIEW.stack);
 </script>

--- a/src/components/CanvasViewToggle.vue
+++ b/src/components/CanvasViewToggle.vue
@@ -1,34 +1,26 @@
 <template>
-  <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
-    <button
-      v-for="mode in MODES"
-      :key="mode.key"
-      class="px-2.5 py-1 flex items-center gap-1"
-      :class="
-        modelValue === mode.key
-          ? 'bg-blue-500 text-white'
-          : 'bg-white text-gray-600 hover:bg-gray-50'
-      "
-      :title="mode.title"
-      @click="emit('update:modelValue', mode.key)"
-    >
-      <span class="material-icons text-sm">{{ mode.icon }}</span>
-      <span>{{ mode.label }}</span>
-    </button>
-  </div>
+  <button
+    class="flex items-center justify-center w-8 h-8 rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 transition-colors"
+    :title="current.title"
+    :aria-label="current.title"
+    :data-testid="`canvas-view-toggle-${modelValue}`"
+    @click="emit('update:modelValue', other.key)"
+  >
+    <span class="material-icons text-base">{{ current.icon }}</span>
+  </button>
 </template>
 
 <script setup lang="ts">
-import type { CanvasViewMode } from "../utils/canvas/viewMode";
+import { computed } from "vue";
+import { CANVAS_VIEW, type CanvasViewMode } from "../utils/canvas/viewMode";
 
 interface ModeOption {
   key: CanvasViewMode;
   icon: string;
-  label: string;
   title: string;
 }
 
-defineProps<{
+const props = defineProps<{
   modelValue: CanvasViewMode;
 }>();
 
@@ -36,22 +28,22 @@ const emit = defineEmits<{
   "update:modelValue": [mode: CanvasViewMode];
 }>();
 
-// Files view is no longer exposed through this toggle — the plugin
-// launcher (src/components/PluginLauncher.vue) is the entry point,
-// with dedicated buttons for todos / scheduler / wiki / skills plus
-// a generic "Files" button for the workspace root.
-const MODES: ModeOption[] = [
-  {
-    key: "single",
-    icon: "crop_square",
-    label: "Single",
-    title: "Single result (⌘1)",
-  },
-  {
-    key: "stack",
-    icon: "layers",
-    label: "Stack",
-    title: "All results stacked (⌘2)",
-  },
-];
+const SINGLE: ModeOption = {
+  key: CANVAS_VIEW.single,
+  icon: "crop_square",
+  title: "Single view · click to switch to Stack (⌘2)",
+};
+const STACK: ModeOption = {
+  key: CANVAS_VIEW.stack,
+  icon: "layers",
+  title: "Stack view · click to switch to Single (⌘1)",
+};
+
+// Show the current mode's icon; clicking switches to the other.
+const current = computed<ModeOption>(() =>
+  props.modelValue === CANVAS_VIEW.stack ? STACK : SINGLE,
+);
+const other = computed<ModeOption>(() =>
+  props.modelValue === CANVAS_VIEW.stack ? SINGLE : STACK,
+);
 </script>

--- a/src/components/RoleSelector.vue
+++ b/src/components/RoleSelector.vue
@@ -1,11 +1,8 @@
 <template>
-  <div :class="containerClass">
-    <span v-if="variant !== 'topbar'" class="text-sm text-gray-500 shrink-0"
-      >Role</span
-    >
+  <div class="flex items-center gap-2 relative w-56 shrink-0">
     <button
       ref="button"
-      :class="buttonClass"
+      class="flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-2 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
       data-testid="role-selector-btn"
       @click="open = !open"
     >
@@ -15,7 +12,11 @@
       <span class="flex-1 truncate">{{ currentRoleName }}</span>
       <span class="material-icons text-sm text-gray-400">expand_more</span>
     </button>
-    <div v-if="open" ref="dropdown" :class="dropdownClass">
+    <div
+      v-if="open"
+      ref="dropdown"
+      class="absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
+    >
       <button
         v-for="role in roles"
         :key="role.id"
@@ -41,26 +42,7 @@ import { useClickOutside } from "../composables/useClickOutside";
 const props = defineProps<{
   roles: Role[];
   currentRoleId: string;
-  variant?: "sidebar" | "topbar";
 }>();
-
-const containerClass = computed(() =>
-  props.variant === "topbar"
-    ? "flex items-center gap-2 relative w-56 shrink-0"
-    : "p-4 border-b border-gray-200 flex items-center gap-2 relative",
-);
-
-const buttonClass = computed(() =>
-  props.variant === "topbar"
-    ? "flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-2 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
-    : "flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 text-left",
-);
-
-const dropdownClass = computed(() =>
-  props.variant === "topbar"
-    ? "absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
-    : "absolute left-4 right-4 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden",
-);
 
 const emit = defineEmits<{
   "update:currentRoleId": [id: string];

--- a/src/components/RoleSelector.vue
+++ b/src/components/RoleSelector.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="p-4 border-b border-gray-200 flex items-center gap-2 relative">
-    <span class="text-sm text-gray-500 shrink-0">Role</span>
+  <div :class="containerClass">
+    <span v-if="variant !== 'topbar'" class="text-sm text-gray-500 shrink-0"
+      >Role</span
+    >
     <button
       ref="button"
-      class="flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 text-left"
+      :class="buttonClass"
       data-testid="role-selector-btn"
       @click="open = !open"
     >
@@ -13,11 +15,7 @@
       <span class="flex-1 truncate">{{ currentRoleName }}</span>
       <span class="material-icons text-sm text-gray-400">expand_more</span>
     </button>
-    <div
-      v-if="open"
-      ref="dropdown"
-      class="absolute left-4 right-4 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
-    >
+    <div v-if="open" ref="dropdown" :class="dropdownClass">
       <button
         v-for="role in roles"
         :key="role.id"
@@ -43,7 +41,26 @@ import { useClickOutside } from "../composables/useClickOutside";
 const props = defineProps<{
   roles: Role[];
   currentRoleId: string;
+  variant?: "sidebar" | "topbar";
 }>();
+
+const containerClass = computed(() =>
+  props.variant === "topbar"
+    ? "flex items-center gap-2 relative w-56 shrink-0"
+    : "p-4 border-b border-gray-200 flex items-center gap-2 relative",
+);
+
+const buttonClass = computed(() =>
+  props.variant === "topbar"
+    ? "flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-2 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
+    : "flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 text-left",
+);
+
+const dropdownClass = computed(() =>
+  props.variant === "topbar"
+    ? "absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden"
+    : "absolute left-4 right-4 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden",
+);
 
 const emit = defineEmits<{
   "update:currentRoleId": [id: string];

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="containerClass">
+  <div class="flex-1 flex gap-1 items-center min-w-0">
     <button
       class="flex-shrink-0 flex items-center justify-center w-7 py-1 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
       data-testid="new-session-btn"
@@ -63,26 +63,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import type { Role } from "../config/roles";
 import type { SessionSummary } from "../types/session";
 import { roleIcon, roleName } from "../utils/role/icon";
 
-const props = defineProps<{
+defineProps<{
   sessions: SessionSummary[];
   currentSessionId: string;
   roles: Role[];
   activeSessionCount: number;
   unreadCount: number;
   historyOpen: boolean;
-  variant?: "sidebar" | "topbar";
 }>();
-
-const containerClass = computed(() =>
-  props.variant === "topbar"
-    ? "flex-1 flex gap-1 items-center min-w-0"
-    : "px-2 py-1 border-b border-gray-200 flex gap-1 items-center",
-);
 
 const emit = defineEmits<{
   newSession: [];

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="px-2 py-1 border-b border-gray-200 flex gap-1 items-center">
+  <div :class="containerClass">
     <button
       class="flex-shrink-0 flex items-center justify-center w-7 py-1 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
       data-testid="new-session-btn"
@@ -63,19 +63,26 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import type { Role } from "../config/roles";
 import type { SessionSummary } from "../types/session";
 import { roleIcon, roleName } from "../utils/role/icon";
 
-defineProps<{
+const props = defineProps<{
   sessions: SessionSummary[];
   currentSessionId: string;
   roles: Role[];
   activeSessionCount: number;
   unreadCount: number;
   historyOpen: boolean;
+  variant?: "sidebar" | "topbar";
 }>();
+
+const containerClass = computed(() =>
+  props.variant === "topbar"
+    ? "flex-1 flex gap-1 items-center min-w-0"
+    : "px-2 py-1 border-b border-gray-200 flex gap-1 items-center",
+);
 
 const emit = defineEmits<{
   newSession: [];

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -1,16 +1,6 @@
 <template>
-  <div :class="containerClass">
-    <div v-if="variant !== 'topbar'">
-      <h1
-        data-testid="app-title"
-        class="text-lg font-semibold"
-        :style="titleStyle"
-      >
-        MulmoClaude
-      </h1>
-    </div>
+  <div class="flex items-center gap-2">
     <h1
-      v-else
       data-testid="app-title"
       class="text-sm font-semibold text-gray-800 mr-1"
       :style="titleStyle"
@@ -64,18 +54,11 @@ import NotificationBell from "./NotificationBell.vue";
 import { useClickOutside } from "../composables/useClickOutside";
 import type { NotificationPayload } from "../types/notification";
 
-const props = defineProps<{
+defineProps<{
   sandboxEnabled: boolean;
   showRightSidebar: boolean;
   titleStyle?: CSSProperties;
-  variant?: "sidebar" | "topbar";
 }>();
-
-const containerClass = computed(() =>
-  props.variant === "topbar"
-    ? "flex items-center gap-2"
-    : "p-4 border-b border-gray-200 flex items-center justify-between",
-);
 
 const emit = defineEmits<{
   testQuery: [query: string];

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="p-4 border-b border-gray-200 flex items-center justify-between">
-    <div>
+  <div :class="containerClass">
+    <div v-if="variant !== 'topbar'">
       <h1
         data-testid="app-title"
         class="text-lg font-semibold"
@@ -9,6 +9,14 @@
         MulmoClaude
       </h1>
     </div>
+    <h1
+      v-else
+      data-testid="app-title"
+      class="text-sm font-semibold text-gray-800 mr-1"
+      :style="titleStyle"
+    >
+      MulmoClaude
+    </h1>
     <div class="flex gap-2">
       <LockStatusPopup
         ref="lockPopup"
@@ -56,11 +64,18 @@ import NotificationBell from "./NotificationBell.vue";
 import { useClickOutside } from "../composables/useClickOutside";
 import type { NotificationPayload } from "../types/notification";
 
-defineProps<{
+const props = defineProps<{
   sandboxEnabled: boolean;
   showRightSidebar: boolean;
   titleStyle?: CSSProperties;
+  variant?: "sidebar" | "topbar";
 }>();
+
+const containerClass = computed(() =>
+  props.variant === "topbar"
+    ? "flex items-center gap-2"
+    : "p-4 border-b border-gray-200 flex items-center justify-between",
+);
 
 const emit = defineEmits<{
   testQuery: [query: string];


### PR DESCRIPTION
## Summary

Implements #498: replaces the left sidebar with a global top bar in every view mode except Single. In plugin views (Todos / Scheduler / Wiki / Skills / Roles / Files) the Stack-style frame (top bar + full-width canvas + bottom bar) is kept so the canvas area just swaps content instead of collapsing back to the sidebar layout.

- **Global top bar** (always rendered): Row 1 — app title + `PluginLauncher`. Row 2 — `CanvasViewToggle` + `RoleSelector` + `SessionTabBar`.
- **Single mode**: keeps the left sidebar with tool-result previews, suggestions, and chat input; role/session chrome is handled by the top bar.
- **Stack / plugin modes**: no sidebar; canvas full width; `SuggestionsPanel` + `ChatInput` live in a bottom bar.
- **Session deselect**: in plugin views, the session tabs show no tab as "current", so clicking any tab (including the last one) restores the user's preferred chat view via a remembered `lastChatViewMode` (Single or Stack).
- **CanvasViewToggle**: collapsed from two buttons to a single icon-only button (`view_agenda`) that is blue when Stack is on, gray when Single is on.
- `SidebarHeader` / `RoleSelector` / `SessionTabBar` grew a `variant: 'sidebar' | 'topbar'` prop so the same components render correctly in both layouts.
- History popup now anchors below the global top bar via a `historyTopOffset` measured on the top-bar container.

Plan lives at [`plans/feat-stack-mode-no-sidebar-498.md`](plans/feat-stack-mode-no-sidebar-498.md).

## Test plan

- [ ] Single mode: sidebar still shows tool previews, suggestions, chat input; top bar shows title, plugin launcher, toggle, role selector, session tabs.
- [ ] Stack mode: sidebar gone; bottom bar has suggestions + chat input; canvas is full width.
- [ ] Switch to Todos / Scheduler / Wiki / Skills / Roles / Files: frame stays Stack-style; session tabs visually deselect; clicking any tab (including the one you were on) returns to the last chat view (Single or Stack).
- [ ] History popup opens below the top bar, full width, and closes on outside click.
- [ ] CanvasViewToggle: single square icon, blue in Stack, gray in Single; click toggles; ⌘1 / ⌘2 shortcuts still work.
- [ ] Gemini API-key warning still appears (sidebar in Single, above canvas in Stack) when the current role needs it and the key is missing.
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stack layout mode with a top-bar-first UI and optional bottom chat/suggestions for stack view
  * Persistent global top bar consolidates controls

* **UI/UX Improvements**
  * Streamlined canvas view toggle and refined role/session controls and spacing
  * Reworked header, tab bar, and selector layouts for better responsiveness

* **Documentation**
  * Added spec describing Stack-mode behavior and verification steps

* **Tests**
  * Updated e2e history-panel test to match new layout interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->