### PR TITLE
refactor: add shared type guard functions + 35 tests (#504)

### DIFF
--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -1,7 +1,57 @@
-// Shared runtime type guards. Previously duplicated in
-// sources/fetchers/github.ts and sources/fetchers/rssParser.ts.
+// Shared runtime type guards (#504).
+//
+// Centralised here to eliminate 40+ hand-written inline checks
+// scattered across server/ and src/. Import from this module
+// instead of writing `typeof x !== "object" || x === null`.
 
 /** Narrow `unknown` to a plain object (not null, not array). */
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Narrow `unknown` to any object (not null, arrays allowed).
+ *  Use `isRecord` when you need to access string keys. */
+export function isObj(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+/** Non-empty string after trimming whitespace. */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Record whose values are all strings. */
+export function isStringRecord(
+  value: unknown,
+): value is Record<string, string> {
+  if (!isRecord(value)) return false;
+  return Object.values(value).every((v) => typeof v === "string");
+}
+
+/** String array (every element is a string). */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/** Error-like object with a `code` property (e.g. Node.js fs errors). */
+export function isErrorWithCode(
+  value: unknown,
+): value is { code: string; message?: string } {
+  return isRecord(value) && typeof value.code === "string";
+}
+
+/** Check that a record has a specific key with a string value. */
+export function hasStringProp<K extends string>(
+  value: unknown,
+  key: K,
+): value is Record<K, string> & Record<string, unknown> {
+  return isRecord(value) && typeof value[key] === "string";
+}
+
+/** Check that a record has a specific key with a number value. */
+export function hasNumberProp<K extends string>(
+  value: unknown,
+  key: K,
+): value is Record<K, number> & Record<string, unknown> {
+  return isRecord(value) && typeof value[key] === "number";
 }

--- a/test/utils/test_types.ts
+++ b/test/utils/test_types.ts
@@ -1,6 +1,17 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isRecord } from "../../server/utils/types.js";
+import {
+  isRecord,
+  isObj,
+  isNonEmptyString,
+  isStringRecord,
+  isStringArray,
+  isErrorWithCode,
+  hasStringProp,
+  hasNumberProp,
+} from "../../server/utils/types.js";
+
+// ── isRecord ────────────────────────────────────────────────────
 
 describe("isRecord", () => {
   it("returns true for plain objects", () => {
@@ -23,5 +34,188 @@ describe("isRecord", () => {
     assert.equal(isRecord(42), false);
     assert.equal(isRecord("string"), false);
     assert.equal(isRecord(true), false);
+  });
+});
+
+// ── isObj ───────────────────────────────────────────────────────
+
+describe("isObj", () => {
+  it("accepts plain objects", () => {
+    assert.equal(isObj({}), true);
+    assert.equal(isObj({ a: 1 }), true);
+  });
+
+  it("accepts arrays (unlike isRecord)", () => {
+    assert.equal(isObj([]), true);
+    assert.equal(isObj([1, 2]), true);
+  });
+
+  it("rejects null", () => {
+    assert.equal(isObj(null), false);
+  });
+
+  it("rejects undefined", () => {
+    assert.equal(isObj(undefined), false);
+  });
+
+  it("rejects primitives", () => {
+    assert.equal(isObj("string"), false);
+    assert.equal(isObj(42), false);
+    assert.equal(isObj(true), false);
+  });
+});
+
+// ── isNonEmptyString ────────────────────────────────────────────
+
+describe("isNonEmptyString", () => {
+  it("accepts non-empty strings", () => {
+    assert.equal(isNonEmptyString("hello"), true);
+    assert.equal(isNonEmptyString("a"), true);
+  });
+
+  it("rejects empty string", () => {
+    assert.equal(isNonEmptyString(""), false);
+  });
+
+  it("rejects whitespace-only string", () => {
+    assert.equal(isNonEmptyString("   "), false);
+    assert.equal(isNonEmptyString("\t\n"), false);
+  });
+
+  it("rejects non-strings", () => {
+    assert.equal(isNonEmptyString(null), false);
+    assert.equal(isNonEmptyString(undefined), false);
+    assert.equal(isNonEmptyString(42), false);
+    assert.equal(isNonEmptyString({}), false);
+  });
+});
+
+// ── isStringRecord ──────────────────────────────────────────────
+
+describe("isStringRecord", () => {
+  it("accepts record with all string values", () => {
+    assert.equal(isStringRecord({ a: "x", b: "y" }), true);
+  });
+
+  it("accepts empty object", () => {
+    assert.equal(isStringRecord({}), true);
+  });
+
+  it("rejects mixed values", () => {
+    assert.equal(isStringRecord({ a: "x", b: 42 }), false);
+  });
+
+  it("rejects non-objects", () => {
+    assert.equal(isStringRecord(null), false);
+    assert.equal(isStringRecord("string"), false);
+    assert.equal(isStringRecord([]), false);
+  });
+});
+
+// ── isStringArray ───────────────────────────────────────────────
+
+describe("isStringArray", () => {
+  it("accepts string arrays", () => {
+    assert.equal(isStringArray(["a", "b"]), true);
+    assert.equal(isStringArray([]), true);
+  });
+
+  it("rejects mixed arrays", () => {
+    assert.equal(isStringArray(["a", 1]), false);
+    assert.equal(isStringArray([null]), false);
+  });
+
+  it("rejects non-arrays", () => {
+    assert.equal(isStringArray("string"), false);
+    assert.equal(isStringArray({}), false);
+    assert.equal(isStringArray(null), false);
+  });
+});
+
+// ── isErrorWithCode ─────────────────────────────────────────────
+
+describe("isErrorWithCode", () => {
+  it("accepts object with string code", () => {
+    assert.equal(isErrorWithCode({ code: "ENOENT" }), true);
+    assert.equal(isErrorWithCode({ code: "EACCES", message: "denied" }), true);
+  });
+
+  it("rejects without code", () => {
+    assert.equal(isErrorWithCode({}), false);
+    assert.equal(isErrorWithCode({ message: "error" }), false);
+  });
+
+  it("rejects non-string code", () => {
+    assert.equal(isErrorWithCode({ code: 42 }), false);
+  });
+
+  it("rejects non-objects", () => {
+    assert.equal(isErrorWithCode(null), false);
+    assert.equal(isErrorWithCode("ENOENT"), false);
+  });
+
+  it("accepts real Error with code (Node.js style)", () => {
+    const err = Object.assign(new Error("fail"), { code: "ENOENT" });
+    assert.equal(isErrorWithCode(err), true);
+  });
+});
+
+// ── hasStringProp ───────────────────────────────────────────────
+
+describe("hasStringProp", () => {
+  it("returns true when key exists with string value", () => {
+    assert.equal(hasStringProp({ name: "alice" }, "name"), true);
+  });
+
+  it("returns false when key missing", () => {
+    assert.equal(hasStringProp({}, "name"), false);
+  });
+
+  it("returns false when value is not string", () => {
+    assert.equal(hasStringProp({ name: 42 }, "name"), false);
+    assert.equal(hasStringProp({ name: null }, "name"), false);
+  });
+
+  it("returns false for non-objects", () => {
+    assert.equal(hasStringProp(null, "name"), false);
+    assert.equal(hasStringProp("str", "name"), false);
+  });
+
+  it("narrows type correctly", () => {
+    const val: unknown = { id: "abc", count: 5 };
+    if (hasStringProp(val, "id")) {
+      const id: string = val.id;
+      assert.equal(id, "abc");
+    }
+  });
+});
+
+// ── hasNumberProp ───────────────────────────────────────────────
+
+describe("hasNumberProp", () => {
+  it("returns true when key exists with number value", () => {
+    assert.equal(hasNumberProp({ count: 42 }, "count"), true);
+    assert.equal(hasNumberProp({ count: 0 }, "count"), true);
+  });
+
+  it("returns false when key missing", () => {
+    assert.equal(hasNumberProp({}, "count"), false);
+  });
+
+  it("returns false when value is not number", () => {
+    assert.equal(hasNumberProp({ count: "42" }, "count"), false);
+    assert.equal(hasNumberProp({ count: null }, "count"), false);
+  });
+
+  it("returns false for non-objects", () => {
+    assert.equal(hasNumberProp(null, "count"), false);
+  });
+
+  it("narrows type correctly", () => {
+    const val: unknown = { score: 99 };
+    if (hasNumberProp(val, "score")) {
+      const score: number = val.score;
+      assert.equal(score, 99);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Add 7 new type guard functions to `server/utils/types.ts` with 35 unit tests. These will replace 40+ hand-written inline type checks across the codebase (migration is a follow-up).

## New guards

| Function | Replaces |
|----------|----------|
| `isObj(v)` | `typeof v === "object" && v !== null` |
| `isNonEmptyString(v)` | `typeof v === "string" && v.trim().length > 0` |
| `isStringRecord(v)` | `isRecord(v) && Object.values(v).every(...)` |
| `isStringArray(v)` | `Array.isArray(v) && v.every(...)` |
| `isErrorWithCode(v)` | `typeof err === "object" && "code" in err` |
| `hasStringProp(v, key)` | `isRecord(v) && typeof v[key] === "string"` |
| `hasNumberProp(v, key)` | `isRecord(v) && typeof v[key] === "number"` |

## Test plan

- [x] 35/35 tests pass
- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)