### PR TITLE
refactor: extract useFileTree + useFileSelection composables (#507)

### DIFF
--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -60,14 +60,11 @@
 import { computed, watch } from "vue";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 
-export interface TreeNode {
-  name: string;
-  path: string;
-  type: "file" | "dir";
-  size?: number;
-  modifiedMs?: number;
-  children?: TreeNode[];
-}
+// TreeNode lives in src/types/fileTree.ts so .ts composables can
+// import it without depending on a .vue module. Re-export here so
+// existing `import { TreeNode } from "./FileTree.vue"` keeps working.
+export type { TreeNode } from "../types/fileTree";
+import type { TreeNode } from "../types/fileTree";
 
 const props = defineProps<{
   node: TreeNode;

--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -24,11 +24,12 @@ interface MetaContent {
 
 export type FileContent = TextContent | MetaContent;
 
+/** Segment-wise traversal check: rejects `../` path components
+ *  but allows legitimate filenames like `my..notes.txt`. */
 export function isValidFilePath(p: unknown): p is string {
   if (typeof p !== "string" || p.length === 0) return false;
-  if (p.includes("..")) return false;
   if (p.startsWith("/")) return false;
-  return true;
+  return !p.split("/").some((seg) => seg === "..");
 }
 
 export function useFileSelection() {
@@ -53,20 +54,23 @@ export function useFileSelection() {
     contentLoading.value = true;
     contentError.value = null;
     content.value = null;
-    const result = await apiGet<FileContent>(
-      API_ROUTES.files.content,
-      { path: filePath },
-      { signal: controller.signal },
-    );
-    if (controller.signal.aborted) return;
-    if (!result.ok) {
-      contentError.value = result.error;
-    } else {
-      content.value = result.data;
-    }
-    if (contentAbort === controller) {
-      contentLoading.value = false;
-      contentAbort = null;
+    try {
+      const result = await apiGet<FileContent>(
+        API_ROUTES.files.content,
+        { path: filePath },
+        { signal: controller.signal },
+      );
+      if (controller.signal.aborted) return;
+      if (!result.ok) {
+        contentError.value = result.error;
+      } else {
+        content.value = result.data;
+      }
+    } finally {
+      if (contentAbort === controller) {
+        contentLoading.value = false;
+        contentAbort = null;
+      }
     }
   }
 
@@ -78,6 +82,8 @@ export function useFileSelection() {
       .push({ query: { ...restQuery, path: filePath } })
       .catch((err: unknown) => {
         if (!isNavigationFailure(err)) {
+          // Frontend composable — server logger not available.
+          // console.error is the standard pattern in Vue composables.
           console.error("[selectFile] navigation failed:", err);
         }
       });
@@ -100,6 +106,8 @@ export function useFileSelection() {
 
   function abortContent(): void {
     contentAbort?.abort();
+    contentAbort = null;
+    contentLoading.value = false;
   }
 
   return {

--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -1,0 +1,115 @@
+// Composable: file selection, content loading with abort, URL sync.
+// Extracted from FilesView.vue (#507 step 2).
+
+import { ref } from "vue";
+import { useRoute, useRouter, isNavigationFailure } from "vue-router";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+interface TextContent {
+  kind: "text";
+  path: string;
+  content: string;
+  size: number;
+  modifiedMs: number;
+}
+
+interface MetaContent {
+  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  message?: string;
+}
+
+export type FileContent = TextContent | MetaContent;
+
+export function isValidFilePath(p: unknown): p is string {
+  if (typeof p !== "string" || p.length === 0) return false;
+  if (p.includes("..")) return false;
+  if (p.startsWith("/")) return false;
+  return true;
+}
+
+export function useFileSelection() {
+  const route = useRoute();
+  const router = useRouter();
+
+  const urlPath = route.query.path;
+  const selectedPath = ref<string | null>(
+    isValidFilePath(urlPath) ? urlPath : null,
+  );
+  const content = ref<FileContent | null>(null);
+  const contentLoading = ref(false);
+  const contentError = ref<string | null>(null);
+
+  let contentAbort: AbortController | null = null;
+
+  async function loadContent(filePath: string): Promise<void> {
+    contentAbort?.abort();
+    const controller = new AbortController();
+    contentAbort = controller;
+
+    contentLoading.value = true;
+    contentError.value = null;
+    content.value = null;
+    const result = await apiGet<FileContent>(
+      API_ROUTES.files.content,
+      { path: filePath },
+      { signal: controller.signal },
+    );
+    if (controller.signal.aborted) return;
+    if (!result.ok) {
+      contentError.value = result.error;
+    } else {
+      content.value = result.data;
+    }
+    if (contentAbort === controller) {
+      contentLoading.value = false;
+      contentAbort = null;
+    }
+  }
+
+  function selectFile(filePath: string): void {
+    selectedPath.value = filePath;
+    loadContent(filePath);
+    const { path: __path, ...restQuery } = route.query;
+    router
+      .push({ query: { ...restQuery, path: filePath } })
+      .catch((err: unknown) => {
+        if (!isNavigationFailure(err)) {
+          console.error("[selectFile] navigation failed:", err);
+        }
+      });
+  }
+
+  function deselectFile(): void {
+    contentAbort?.abort();
+    contentAbort = null;
+    selectedPath.value = null;
+    content.value = null;
+    contentLoading.value = false;
+    contentError.value = null;
+    const { path: __path, ...restQuery } = route.query;
+    router.replace({ query: restQuery }).catch((err: unknown) => {
+      if (!isNavigationFailure(err)) {
+        console.error("[deselectFile] navigation failed:", err);
+      }
+    });
+  }
+
+  function abortContent(): void {
+    contentAbort?.abort();
+  }
+
+  return {
+    selectedPath,
+    content,
+    contentLoading,
+    contentError,
+    loadContent,
+    selectFile,
+    deselectFile,
+    abortContent,
+  };
+}

--- a/src/composables/useFileTree.ts
+++ b/src/composables/useFileTree.ts
@@ -15,14 +15,21 @@ export function useFileTree() {
   const childrenByPath = ref<Map<string, TreeNode[] | null>>(new Map());
   const treeError = ref<string | null>(null);
 
+  // Generation counter — incremented on reloadRoot so in-flight
+  // requests from a prior generation don't write stale data.
+  let generation = 0;
+
   async function loadDirChildren(path: string): Promise<void> {
     if (childrenByPath.value.has(path)) return;
 
+    const gen = generation;
     const next = new Map(childrenByPath.value);
     next.set(path, null);
     childrenByPath.value = next;
 
     const result = await apiGet<TreeNode>(API_ROUTES.files.dir, { path });
+    // Bail if reloadRoot was called while we were awaiting.
+    if (gen !== generation) return;
     if (!result.ok) {
       const rollback = new Map(childrenByPath.value);
       rollback.delete(path);
@@ -51,6 +58,8 @@ export function useFileTree() {
   }
 
   async function reloadRoot(): Promise<void> {
+    generation++;
+    rootNode.value = null;
     childrenByPath.value = new Map();
     treeError.value = null;
     await loadDirChildren("");

--- a/src/composables/useFileTree.ts
+++ b/src/composables/useFileTree.ts
@@ -1,0 +1,76 @@
+// Composable: workspace file tree state + lazy loading.
+// Extracted from FilesView.vue (#507 step 1).
+
+import { ref } from "vue";
+import type { TreeNode } from "../components/FileTree.vue";
+import { useExpandedDirs } from "./useExpandedDirs";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+export function useFileTree() {
+  const { expand } = useExpandedDirs();
+
+  const rootNode = ref<TreeNode | null>(null);
+  const refRoots = ref<TreeNode[]>([]);
+  const childrenByPath = ref<Map<string, TreeNode[] | null>>(new Map());
+  const treeError = ref<string | null>(null);
+
+  async function loadDirChildren(path: string): Promise<void> {
+    if (childrenByPath.value.has(path)) return;
+
+    const next = new Map(childrenByPath.value);
+    next.set(path, null);
+    childrenByPath.value = next;
+
+    const result = await apiGet<TreeNode>(API_ROUTES.files.dir, { path });
+    if (!result.ok) {
+      const rollback = new Map(childrenByPath.value);
+      rollback.delete(path);
+      childrenByPath.value = rollback;
+      treeError.value = result.error || `dir: ${result.status}`;
+      return;
+    }
+    const node = result.data;
+    const updated = new Map(childrenByPath.value);
+    updated.set(path, node.children ?? []);
+    childrenByPath.value = updated;
+    if (path === "") rootNode.value = { ...node, children: [] };
+  }
+
+  async function ensureAncestorsLoaded(filePath: string): Promise<void> {
+    const parts = filePath.split("/").filter(Boolean);
+    if (parts.length <= 1) return;
+    const ancestors: string[] = [];
+    for (let i = 1; i < parts.length; i++) {
+      ancestors.push(parts.slice(0, i).join("/"));
+    }
+    for (const dir of ancestors) {
+      expand(dir);
+      await loadDirChildren(dir);
+    }
+  }
+
+  async function reloadRoot(): Promise<void> {
+    childrenByPath.value = new Map();
+    treeError.value = null;
+    await loadDirChildren("");
+  }
+
+  async function loadRefRoots(): Promise<void> {
+    const result = await apiGet<TreeNode[]>(API_ROUTES.files.refRoots);
+    if (result.ok && Array.isArray(result.data)) {
+      refRoots.value = result.data;
+    }
+  }
+
+  return {
+    rootNode,
+    refRoots,
+    childrenByPath,
+    treeError,
+    loadDirChildren,
+    ensureAncestorsLoaded,
+    reloadRoot,
+    loadRefRoots,
+  };
+}

--- a/src/composables/useFileTree.ts
+++ b/src/composables/useFileTree.ts
@@ -2,7 +2,7 @@
 // Extracted from FilesView.vue (#507 step 1).
 
 import { ref } from "vue";
-import type { TreeNode } from "../components/FileTree.vue";
+import type { TreeNode } from "../types/fileTree";
 import { useExpandedDirs } from "./useExpandedDirs";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";

--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -1,0 +1,13 @@
+// TreeNode type — shared between FileTree.vue, FilesView.vue,
+// and composables (useFileTree, useFileSelection).
+// Extracted from FileTree.vue so .ts files can import it without
+// depending on a .vue module (which tsc can't resolve).
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+  size?: number;
+  modifiedMs?: number;
+  children?: TreeNode[];
+}


### PR DESCRIPTION
## Summary

Step 1-2 of #507: extract two composables from FilesView.vue (809 lines).

- **useFileTree** — tree state, lazy directory loading, cache, reload, reference roots
- **useFileSelection** — file selection, content fetch with abort, URL bidirectional sync

Composables are standalone and typecheck-clean. FilesView.vue not modified yet — wiring is next step.

## Test plan

- [x] vue-tsc typecheck clean
- [ ] CI

Part of #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract file tree and file selection logic from the files view into standalone Vue composables.

New Features:
- Add a useFileSelection composable to manage file selection state, content loading with abort support, and URL query sync.
- Add a useFileTree composable to manage workspace file tree state, lazy directory loading, and reference roots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file browsing and selection functionality with support for lazy-loading directory contents
  * Enabled viewing file content with automatic URL synchronization
  * Implemented path validation and error handling for file operations
  * Added reference roots support for workspace navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->