### PR TITLE
refactor: extract view mode string literals to constants

### DIFF
--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -269,8 +269,6 @@ watch(
 
 // ── View mode (persisted in localStorage) ───────────────────────
 
-const viewMode = ref<ViewMode>(loadViewMode());
-
 const VALID_VIEW_MODES: ReadonlySet<string> = new Set(Object.values(TODO_VIEW));
 
 function loadViewMode(): ViewMode {
@@ -280,6 +278,8 @@ function loadViewMode(): ViewMode {
   }
   return TODO_VIEW.kanban;
 }
+
+const viewMode = ref<ViewMode>(loadViewMode());
 
 function setViewMode(next: ViewMode): void {
   viewMode.value = next;

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -28,7 +28,7 @@
         </button>
         <!-- Add column button (kanban only) -->
         <button
-          v-if="viewMode === 'kanban'"
+          v-if="viewMode === TODO_VIEW.kanban"
           data-testid="todo-column-add-btn"
           class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
           @click="addColumnOpen = true"
@@ -106,7 +106,7 @@
       </div>
       <template v-else>
         <TodoKanbanView
-          v-if="viewMode === 'kanban'"
+          v-if="viewMode === TODO_VIEW.kanban"
           :filtered-items="filteredItems"
           :columns="columns"
           @move="onMove"
@@ -119,7 +119,7 @@
           @reorder-columns="onReorderColumns"
         />
         <TodoTableView
-          v-else-if="viewMode === 'table'"
+          v-else-if="viewMode === TODO_VIEW.table"
           :filtered-items="filteredItems"
           :columns="columns"
           @patch="onPatchItem"
@@ -225,19 +225,11 @@ import TodoListView from "./todo/TodoListView.vue";
 import TodoAddDialog from "./todo/TodoAddDialog.vue";
 import TodoEditDialog from "./todo/TodoEditDialog.vue";
 
-type ViewMode = "kanban" | "table" | "list";
-
-interface ViewModeOption {
-  key: ViewMode;
-  label: string;
-  icon: string;
-}
-
-const VIEW_MODES: ViewModeOption[] = [
-  { key: "kanban", label: "Kanban", icon: "view_kanban" },
-  { key: "table", label: "Table", icon: "table_rows" },
-  { key: "list", label: "List", icon: "view_list" },
-];
+import {
+  TODO_VIEW,
+  TODO_VIEW_MODES as VIEW_MODES,
+  type TodoViewMode as ViewMode,
+} from "../plugins/todo/viewModes";
 
 const VIEW_MODE_KEY = "todo_explorer_view_mode";
 
@@ -279,12 +271,14 @@ watch(
 
 const viewMode = ref<ViewMode>(loadViewMode());
 
+const VALID_VIEW_MODES: ReadonlySet<string> = new Set(Object.values(TODO_VIEW));
+
 function loadViewMode(): ViewMode {
   const stored = localStorage.getItem(VIEW_MODE_KEY);
-  if (stored === "kanban" || stored === "table" || stored === "list") {
-    return stored;
+  if (stored && VALID_VIEW_MODES.has(stored)) {
+    return stored as ViewMode;
   }
-  return "kanban";
+  return TODO_VIEW.kanban;
 }
 
 function setViewMode(next: ViewMode): void {

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -15,34 +15,34 @@
       <button
         class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
         :class="
-          activeTab === 'calendar'
+          activeTab === SCHEDULER_TAB.calendar
             ? 'border-blue-500 text-blue-600'
             : 'border-transparent text-gray-500 hover:text-gray-700'
         "
         data-testid="scheduler-tab-calendar"
-        @click="activeTab = 'calendar'"
+        @click="activeTab = SCHEDULER_TAB.calendar"
       >
         Calendar
       </button>
       <button
         class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
         :class="
-          activeTab === 'tasks'
+          activeTab === SCHEDULER_TAB.tasks
             ? 'border-blue-500 text-blue-600'
             : 'border-transparent text-gray-500 hover:text-gray-700'
         "
         data-testid="scheduler-tab-tasks"
-        @click="activeTab = 'tasks'"
+        @click="activeTab = SCHEDULER_TAB.tasks"
       >
         Tasks
       </button>
     </div>
 
     <!-- Tasks tab -->
-    <TasksTab v-if="activeTab === 'tasks'" />
+    <TasksTab v-if="activeTab === SCHEDULER_TAB.tasks" />
 
     <!-- Calendar tab (existing content) -->
-    <template v-if="activeTab === 'calendar'">
+    <template v-if="activeTab === SCHEDULER_TAB.calendar">
       <!-- Header -->
       <div
         class="flex items-center justify-between px-6 py-3 border-b border-gray-100"
@@ -55,7 +55,7 @@
         </div>
         <div class="flex items-center gap-2">
           <!-- Navigation (calendar modes only) -->
-          <template v-if="viewMode !== 'list'">
+          <template v-if="viewMode !== SCHEDULER_VIEW.list">
             <button
               class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded"
               title="Previous"
@@ -104,7 +104,10 @@
       </div>
 
       <!-- List view -->
-      <div v-if="viewMode === 'list'" class="flex-1 overflow-y-auto min-h-0">
+      <div
+        v-if="viewMode === SCHEDULER_VIEW.list"
+        class="flex-1 overflow-y-auto min-h-0"
+      >
         <div
           v-if="items.length === 0"
           class="flex items-center justify-center h-full text-gray-400"
@@ -155,7 +158,7 @@
 
       <!-- Week view -->
       <div
-        v-else-if="viewMode === 'week'"
+        v-else-if="viewMode === SCHEDULER_VIEW.week"
         class="flex-1 overflow-y-auto min-h-0"
       >
         <div class="grid grid-cols-7 border-b border-gray-200">
@@ -399,7 +402,7 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
 function detectInitialTab(
   result?: ToolResultComplete<SchedulerData>,
-): "calendar" | "tasks" {
+): SchedulerTab {
   const data = result?.data as Record<string, unknown> | undefined;
   if (
     data &&
@@ -408,14 +411,12 @@ function detectInitialTab(
       "triggered" in data ||
       "deleted" in data)
   ) {
-    return "tasks";
+    return SCHEDULER_TAB.tasks;
   }
-  return "calendar";
+  return SCHEDULER_TAB.calendar;
 }
 
-const activeTab = ref<"calendar" | "tasks">(
-  detectInitialTab(props.selectedResult),
-);
+const activeTab = ref<SchedulerTab>(detectInitialTab(props.selectedResult));
 const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
@@ -440,18 +441,18 @@ watch(
 
 // ── View mode ──────────────────────────────────────────────────────────────
 
-type ViewMode = "list" | "week" | "month";
-
-const VIEW_MODES: { key: ViewMode; label: string; icon: string }[] = [
-  { key: "month", label: "Month", icon: "calendar_month" },
-  { key: "week", label: "Week", icon: "view_week" },
-  { key: "list", label: "List", icon: "view_list" },
-];
+import {
+  SCHEDULER_VIEW,
+  SCHEDULER_VIEW_MODES as VIEW_MODES,
+  SCHEDULER_TAB,
+  type SchedulerViewMode as ViewMode,
+  type SchedulerTab,
+} from "./viewModes";
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const MAX_MONTH_ITEMS = 3;
 
-const viewMode = ref<ViewMode>("month");
+const viewMode = ref<ViewMode>(SCHEDULER_VIEW.month);
 const currentDate = ref(new Date());
 
 // ── Calendar utilities ─────────────────────────────────────────────────────

--- a/src/plugins/scheduler/viewModes.ts
+++ b/src/plugins/scheduler/viewModes.ts
@@ -1,0 +1,27 @@
+// View mode and tab constants for the Scheduler plugin.
+
+export const SCHEDULER_VIEW = {
+  list: "list",
+  week: "week",
+  month: "month",
+} as const;
+
+export type SchedulerViewMode =
+  (typeof SCHEDULER_VIEW)[keyof typeof SCHEDULER_VIEW];
+
+export const SCHEDULER_VIEW_MODES: {
+  key: SchedulerViewMode;
+  label: string;
+  icon: string;
+}[] = [
+  { key: SCHEDULER_VIEW.month, label: "Month", icon: "calendar_month" },
+  { key: SCHEDULER_VIEW.week, label: "Week", icon: "view_week" },
+  { key: SCHEDULER_VIEW.list, label: "List", icon: "view_list" },
+];
+
+export const SCHEDULER_TAB = {
+  calendar: "calendar",
+  tasks: "tasks",
+} as const;
+
+export type SchedulerTab = (typeof SCHEDULER_TAB)[keyof typeof SCHEDULER_TAB];

--- a/src/plugins/todo/viewModes.ts
+++ b/src/plugins/todo/viewModes.ts
@@ -1,0 +1,19 @@
+// View mode constants for the Todo Explorer.
+
+export const TODO_VIEW = {
+  kanban: "kanban",
+  table: "table",
+  list: "list",
+} as const;
+
+export type TodoViewMode = (typeof TODO_VIEW)[keyof typeof TODO_VIEW];
+
+export const TODO_VIEW_MODES: {
+  key: TodoViewMode;
+  label: string;
+  icon: string;
+}[] = [
+  { key: TODO_VIEW.kanban, label: "Kanban", icon: "view_kanban" },
+  { key: TODO_VIEW.table, label: "Table", icon: "table_rows" },
+  { key: TODO_VIEW.list, label: "List", icon: "view_list" },
+];


### PR DESCRIPTION
## Summary

TodoExplorer と Scheduler の view mode / tab 切替リテラルを定数化し、別ファイルに外出し。

| コンポーネント | 定数ファイル | 内容 |
|---|---|---|
| TodoExplorer.vue | src/plugins/todo/viewModes.ts | TODO_VIEW, TODO_VIEW_MODES, TodoViewMode |
| scheduler/View.vue | src/plugins/scheduler/viewModes.ts | SCHEDULER_VIEW, SCHEDULER_VIEW_MODES, SCHEDULER_TAB, SchedulerTab |

- template の全 `'kanban'` / `'table'` / `'list'` / `'week'` / `'month'` / `'calendar'` / `'tasks'` を定数参照に
- loadViewMode の validation を Set ベースに統一

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract scheduler and todo view mode/tab string literals into shared constants and update components to use them.

Enhancements:
- Introduce centralized view mode and tab constants for the scheduler and todo plugins, including corresponding TypeScript types and option lists.
- Refine TodoExplorer view mode persistence logic to validate stored values against the defined constant set before applying them.