### PR TITLE
refactor: migrate remaining inline type checks (#504)

### DIFF
--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -11,6 +11,7 @@ import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
 import { loadJsonFile } from "./json.js";
 import { writeFileAtomicSync } from "./atomic.js";
 import { log } from "../../system/logger/index.js";
+import { isRecord } from "../types.js";
 
 export interface ScheduleOverride {
   /** Override interval in milliseconds (for interval-type schedules). */
@@ -25,8 +26,8 @@ export type ScheduleOverrides = Record<string, ScheduleOverride>;
 export const UTC_HH_MM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 function isScheduleOverride(value: unknown): value is ScheduleOverride {
-  if (typeof value !== "object" || value === null) return false;
-  const obj = value as Record<string, unknown>;
+  if (!isRecord(value)) return false;
+  const obj = value;
   const hasInterval =
     "intervalMs" in obj &&
     typeof obj.intervalMs === "number" &&
@@ -46,12 +47,12 @@ function overridesPath(root?: string): string {
 /** Load schedule overrides. Filters out invalid entries with a warning. */
 export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
   const raw = loadJsonFile<unknown>(overridesPath(root), {});
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+  if (!isRecord(raw)) {
     log.warn("scheduler-overrides", "overrides.json is not an object");
     return {};
   }
   const result: ScheduleOverrides = {};
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(raw)) {
     if (isScheduleOverride(value)) {
       result[key] = value;
     } else {

--- a/server/workspace/sources/fetchers/github.ts
+++ b/server/workspace/sources/fetchers/github.ts
@@ -11,6 +11,7 @@
 
 import type { HttpFetcherDeps } from "../httpFetcher.js";
 import { fetchPolite } from "../httpFetcher.js";
+import { hasStringProp } from "../../../utils/types.js";
 
 // GitHub REST API base. Factored out so tests / local dev can
 // point at a stub server by patching this module — rare enough
@@ -90,13 +91,8 @@ export async function githubFetchJson(
     let apiMessage: string | null = null;
     try {
       const bodyJson: unknown = await res.json();
-      if (
-        typeof bodyJson === "object" &&
-        bodyJson !== null &&
-        "message" in bodyJson &&
-        typeof (bodyJson as { message: unknown }).message === "string"
-      ) {
-        apiMessage = (bodyJson as { message: string }).message;
+      if (hasStringProp(bodyJson, "message")) {
+        apiMessage = bodyJson.message;
       }
     } catch {
       // Ignore — just means the body wasn't JSON.


### PR DESCRIPTION
## Summary

Final cleanup — 3 remaining inline type checks that were missed or added after PR #506.

- `github.ts`: 5-line typeof + as cast ��� `hasStringProp(bodyJson, "message")`
- `scheduler-overrides-io.ts`: 2 inline checks → `isRecord()`

After this PR, **zero** `typeof x === "object"` runtime checks remain in `server/` code (only comments).

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor remaining inline runtime type checks in scheduler overrides and GitHub fetcher code to use shared type guard utilities for object and string property validation.

Enhancements:
- Replace manual object shape checks in scheduler overrides I/O with the shared isRecord type guard.
- Use the hasStringProp helper to simplify extracting error messages from GitHub API JSON responses.