### PR TITLE
fix(App): sync activePane on initial mount and when leaving Stack

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -682,10 +682,16 @@ const displayedCurrentSessionId = computed(() =>
 );
 
 // Keep arrow-key navigation tied to the canvas when the sidebar list
-// doesn't exist (Stack layout has no ToolResultsPanel to navigate).
-watch(isStackLayout, (stack) => {
-  if (stack) activePane.value = "main";
-});
+// doesn't exist (Stack layout has no ToolResultsPanel to navigate),
+// and restore sidebar focus when returning to Single. `immediate`
+// covers the case of an initial stack-style URL (?view=stack, …).
+watch(
+  isStackLayout,
+  (stack) => {
+    activePane.value = stack ? "main" : "sidebar";
+  },
+  { immediate: true },
+);
 
 // Measure the top bar's height whenever the history popup is about
 // to open. Defer to nextTick so the popup's v-if transition doesn't


### PR DESCRIPTION
## Summary

Addresses [CodeRabbit feedback](https://github.com/receptron/mulmoclaude/pull/502) on PR #502 (issue #498, Stack-mode layout redesign).

The `isStackLayout` watcher had two small issues:

- It was not `{ immediate: true }`, so loading the app with a stack-style URL (`?view=stack`, `?view=todos`, …) left `activePane` at its default `"sidebar"` even though no `ToolResultsPanel` was rendered. `handleKeyNavigation` then took its sidebar branch and mutated `selectedResultUuid` via arrow keys with no visible list to guide the user.
- When `isStackLayout` flipped back to `false` (stack/plugin → Single), `activePane` remained `"main"`, so arrow-key navigation in `ToolResultsPanel` was dead until the user clicked the panel.

Fix: make the watcher `immediate` and set `activePane` in both directions (`stack ? "main" : "sidebar"`).

## Test plan

- [ ] Load app with `?view=stack` — arrow keys should scroll the canvas (not silently mutate selection).
- [ ] Switch from Single → Stack — canvas takes arrow-key focus.
- [ ] Switch from Stack → Single — arrow keys navigate the sidebar `ToolResultsPanel` without clicking first.
- [ ] Switch from plugin view (Todos/Files/…) → Single — same as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Synchronize the active pane with the current layout mode on mount and when toggling between stack and single layouts to keep keyboard navigation focus consistent.

Bug Fixes:
- Ensure activePane is initialized correctly for stack-style URLs so arrow-key navigation does not target an invisible sidebar list.
- Restore sidebar focus for arrow-key navigation when switching from stack or plugin layouts back to the single layout.