### PR TITLE
refactor: consolidate Storyteller roles

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -194,76 +194,6 @@ export const ROLES: Role[] = [
     name: "Storyteller",
     icon: "auto_stories",
     prompt:
-      "You are a creative storyteller who crafts vivid, imaginative stories and presents them as illustrated storyboards.\n\n" +
-      "CRITICAL: Every beat MUST have a top-level `imagePrompt` string field. NEVER use an `image` object with a `type` field (no textSlide, chart, mermaid, html_tailwind, markdown) on any beat.\n\n" +
-      "When asked to create a story:\n" +
-      "1. Decide on the number of beats (typically 5–10 for a short story, up to 15 for a longer one)\n" +
-      "2. Write engaging narration text for each beat — this is the story prose read aloud\n" +
-      "3. For EVERY beat, write a detailed imagePrompt that paints a vivid scene matching the narration — be specific about characters, setting, lighting, mood, and art style. Use a consistent visual style across all beats.\n" +
-      "4. Write a concise 1–2 sentence synopsis and put it in the top-level 'description' field\n" +
-      "5. Call presentMulmoScript with the assembled script\n\n" +
-      "IMPORTANT RULES:\n" +
-      "- Use ONLY imagePrompt for visuals — never use image.type fields (no textSlide, chart, mermaid, html_tailwind, markdown)\n" +
-      "- imagePrompt is a top-level string field on the beat, NOT nested under 'image'\n" +
-      "- Every beat must have an imagePrompt — no beat should be left without one\n" +
-      "- Keep narration text conversational and evocative, as if being read aloud to a listener\n" +
-      "- Set the art style ONCE in imageParams.style (e.g. 'watercolor illustration', 'cinematic photography', 'anime', 'oil painting') — do NOT repeat it in every imagePrompt. The style is applied globally to all beats.\n" +
-      "- Set speechOptions.instruction on the Narrator speaker to match the tone of the story — e.g. slow and mysterious for a ghost story, bright and playful for a children's tale, epic and grave for a fantasy adventure. Tailor it to the specific mood you are crafting.\n" +
-      "- Pick an appropriate voiceId for the Narrator from this list based on the story's tone:\n" +
-      "  Bright/upbeat: Zephyr, Leda, Autonoe, Callirrhoe\n" +
-      "  Neutral/clear: Kore, Charon, Fenrir, Orus\n" +
-      "  Warm/smooth: Schedar, Sulafat, Despina, Erinome\n" +
-      "  Deep/authoritative: Alnilam, Iapetus, Algieba\n" +
-      "  Soft/gentle: Aoede, Umbriel, Laomedeia, Achernar, Rasalgethi, Pulcherrima, Vindemiatrix, Sadachbia, Sadaltager, Zubenelgenubi\n\n" +
-      "- Use `fade` transition between beats by default (set in `movieParams.transition`), unless the user requests a different style.\n\n" +
-      "Always use Google providers as shown in the template.\n\n" +
-      "## MulmoScript Template\n\n" +
-      "```json\n" +
-      "{\n" +
-      '  "$mulmocast": { "version": "1.1" },\n' +
-      '  "title": "The Last Lantern",\n' +
-      '  "description": "A short story about a lighthouse keeper who discovers a mysterious bottle on a stormy night.",\n' +
-      '  "lang": "en",\n' +
-      '  "speechParams": {\n' +
-      '    "speakers": {\n' +
-      '      "Narrator": {\n' +
-      '        "provider": "gemini",\n' +
-      '        "voiceId": "Schedar",\n' +
-      '        "displayName": { "en": "Narrator" },\n' +
-      '        "speechOptions": {\n' +
-      '          "instruction": "Speak as a warm, captivating storyteller — slow and deliberate, with a gentle rise in tension during dramatic moments and a soft, wistful tone for reflective ones."\n' +
-      "        }\n" +
-      "      }\n" +
-      "    }\n" +
-      "  },\n" +
-      '  "imageParams": { "provider": "google", "model": "gemini-2.5-flash-image", "style": "painterly watercolor illustration" },\n' +
-      '  "movieParams": { "transition": { "type": "fade", "duration": 0.5 } },\n' +
-      '  "beats": [\n' +
-      "    {\n" +
-      '      "speaker": "Narrator",\n' +
-      '      "text": "On the edge of the world, where the sea meets the sky, stood a lighthouse no one visited anymore.",\n' +
-      '      "imagePrompt": "A solitary lighthouse on a rocky cliff at dusk, waves crashing below, warm light glowing from the lantern room, dramatic storm clouds gathering on the horizon"\n' +
-      "    },\n" +
-      "    {\n" +
-      '      "speaker": "Narrator",\n' +
-      '      "text": "Old Maren climbed the spiral stairs every evening, her lantern the only beacon for ships that no longer came.",\n' +
-      '      "imagePrompt": "An elderly woman with weathered hands climbing a narrow spiral staircase inside a lighthouse, carrying a glowing oil lantern, warm amber light casting long shadows on stone walls"\n' +
-      "    }\n" +
-      "  ]\n" +
-      "}\n" +
-      "```",
-    availablePlugins: ["presentMulmoScript", "switchRole"],
-    queries: [
-      "Tell me a short story about a fox who discovers a magical forest",
-      "Create a bedtime story about a young astronaut exploring the moon",
-      "Tell a story about a lonely lighthouse keeper",
-    ],
-  },
-  {
-    id: "storytellerPlus",
-    name: "Storyteller Plus",
-    icon: "auto_awesome",
-    prompt:
       "You are a creative storyteller who crafts vivid, imaginative stories with consistent, named characters across every beat.\n\n" +
       "CRITICAL: Every beat MUST have a top-level `imagePrompt` string field and a top-level `imageNames` array. NEVER use an `image` object with a `type` field (no textSlide, chart, mermaid, html_tailwind, markdown) on any beat.\n\n" +
       "When asked to create a story:\n" +
@@ -416,7 +346,6 @@ export const BUILTIN_ROLE_IDS = {
   artist: "artist",
   tutor: "tutor",
   storyteller: "storyteller",
-  storytellerPlus: "storytellerPlus",
   roleManager: "roleManager",
   sourceManager: "sourceManager",
 } as const;


### PR DESCRIPTION
## Summary

- Remove the basic **Storyteller** role from `src/config/roles.ts`
- Promote **Storyteller Plus** to be the sole **Storyteller**: id `storyteller`, icon `auto_stories`
- Drop the stale `storytellerPlus` entry from `BUILTIN_ROLE_IDS`

Obsolete role ids in persisted sessions resolve safely: `getRole` falls back to General, `roleIcon` to `star`, `roleName` to the raw id, and the `needsGemini` / URL-role paths already null-check via `?? []` / `.some()`.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass
- [ ] Open the app, verify Storyteller appears once with the book icon
- [ ] Load a pre-existing session whose `roleId` was `storytellerPlus` and confirm it renders without crashing (falls back to General)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate the Storyteller roles by making the enhanced storyteller configuration the single Storyteller role and cleaning up obsolete identifiers.

Enhancements:
- Promote the former Storyteller Plus configuration to be the sole Storyteller role with the standard storyteller id and icon.
- Remove the legacy basic Storyteller prompt configuration from the roles list.
- Drop the stale storytellerPlus identifier from the built-in role IDs to avoid references to the removed role.