### PR TITLE
fix(App.vue): move sessionMap/currentSessionId before pubsub callbacks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -309,6 +309,24 @@ import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import { apiGet, apiPost, apiFetchRaw } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
 
+// --- Per-session state ---
+// Declared early so that pub/sub callbacks and function declarations
+// below can reference them without forward-reference ambiguity.
+const sessionMap = reactive(new Map<string, ActiveSession>());
+
+// Tracks active pub/sub subscriptions per session. The unsubscribe
+// function is stored so we can clean up when the session is removed
+// from memory. Sessions that are running always have an active
+// subscription so events arrive via WebSocket.
+const sessionSubscriptions = new Map<string, () => void>();
+
+// currentSessionId is a plain ref so that synchronous writes (e.g.
+// inside createNewSession, which is called right before sendMessage
+// might run) take effect immediately. The URL is kept in sync via
+// navigateToSession, and external URL changes (back button, typed
+// URL) feed back into the ref via the route watcher below.
+const currentSessionId = ref("");
+
 // --- Debug beat (pub/sub) ---
 const debugBeatColor = ref<string | null>(null);
 const debugTitleStyle = computed(() =>
@@ -367,27 +385,6 @@ async function markSessionRead(id: string): Promise<void> {
 // --- Routing ---
 const route = useRoute();
 const router = useRouter();
-
-// --- Per-session state ---
-const sessionMap = reactive(new Map<string, ActiveSession>());
-
-// Tracks active pub/sub subscriptions per session. The unsubscribe
-// function is stored so we can clean up when the session is removed
-// from memory. Sessions that are running always have an active
-// subscription so events arrive via WebSocket.
-const sessionSubscriptions = new Map<string, () => void>();
-
-// currentSessionId is a plain ref so that synchronous writes (e.g.
-// inside createNewSession, which is called right before sendMessage
-// might run) take effect immediately. The URL is kept in sync via
-// navigateToSession, and external URL changes (back button, typed
-// URL) feed back into the ref via the route watcher below.
-//
-// Earlier attempt used a computed derived from route.params, but
-// router.push is async — the route param doesn't update until the
-// next tick, so any code reading currentSessionId between the push
-// and the tick sees the stale value ("") and drops messages silently.
-const currentSessionId = ref("");
 
 function navigateToSession(id: string, replace = false): void {
   currentSessionId.value = id;
@@ -866,12 +863,6 @@ function onRoleChange() {
   maybeSeedRoleDefault(session);
 }
 
-// Some roles ship with a "default view" that's useful before any
-// chat exchange. Seed a synthetic tool_result so the canvas renders
-// the plugin immediately on role switch, without requiring the user
-// to first ask Claude to list anything. The result is client-only
-// (never persisted server-side) — any subsequent LLM tool call will
-// replace / augment it in the normal way.
 async function loadSession(id: string) {
   // Re-selecting the already-active, loaded session is a no-op.
   // The sessionMap check is needed because the route watcher sets
@@ -972,13 +963,6 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
     session.toolResults = serverResults;
   }
 }
-
-// Seed the session state for a fresh user turn. Not pure (mutates
-// session), but isolated so sendMessage doesn't have the init
-// pattern inline. Writes `runStartIndex` onto the session — the
-// index into toolResults at which this run's outputs start, used
-// later to decide whether a trailing text response becomes the
-// selected canvas result.
 
 // Subscribe to a session's pub/sub channel so events from the server
 // (tool_call, text, tool_result, session_finished, etc.) arrive via


### PR DESCRIPTION
## Summary

App.vue レビュー指摘 4 件を修正。

1. **sessionMap / currentSessionId 宣言順**: pubsub callback (line 340, 347) より前に移動。実行時は安全だったが前方参照は可読性・保守性が悪い
2. **sessionSubscriptions**: 同上
3. **孤立コメント削除**: maybeSeedRoleDefault 抽出後に残っていた説明コメント (5 行)
4. **孤立コメント削除**: beginUserTurn 抽出後に残っていた説明コメント (6 行)

1242 行 (← 1252)。動作変更なし。

## Test plan

- [x] yarn lint / yarn build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reorder per-session state declarations in App.vue to appear before pub/sub callbacks and clean up obsolete explanatory comments without changing runtime behavior.

Enhancements:
- Move session-related reactive state and subscription maps earlier in the file to avoid forward references and improve readability.
- Remove outdated explanatory comments that are now redundant with extracted helper functions.

Tests:
- Rely on existing linting and build checks, which pass without additional test changes.