### PR TITLE
refactor: complete FilesView split (#507 steps 3-8)

### DIFF
--- a/src/components/FileContentHeader.vue
+++ b/src/components/FileContentHeader.vue
@@ -1,0 +1,56 @@
+<template>
+  <div
+    v-if="selectedPath"
+    class="px-4 py-2 border-b border-gray-200 text-xs text-gray-500 font-mono shrink-0 flex items-center gap-2"
+  >
+    <span class="truncate min-w-0">{{ selectedPath }}</span>
+    <span v-if="size !== null" class="text-gray-400 shrink-0"
+      >· {{ formatBytes(size) }}</span
+    >
+    <span v-if="modifiedMs" class="text-gray-400 shrink-0"
+      >· {{ formatDateTime(modifiedMs) }}</span
+    >
+    <button
+      v-if="isMarkdown"
+      class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
+      :title="mdRawMode ? 'Show rendered Markdown' : 'Show raw source'"
+      @click="emit('toggleMdRaw')"
+    >
+      {{ mdRawMode ? "Rendered" : "Raw" }}
+    </button>
+    <button
+      type="button"
+      class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+      :class="{ 'ml-auto': !isMarkdown }"
+      title="Close file"
+      aria-label="Close file"
+      data-testid="close-file-btn"
+      @click="emit('deselect')"
+    >
+      <span class="material-icons text-base" aria-hidden="true">close</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatDateTime } from "../utils/format/date";
+
+defineProps<{
+  selectedPath: string | null;
+  size: number | null;
+  modifiedMs: number | null;
+  isMarkdown: boolean;
+  mdRawMode: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggleMdRaw: [];
+  deselect: [];
+}>();
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+</script>

--- a/src/components/FileContentHeader.vue
+++ b/src/components/FileContentHeader.vue
@@ -7,7 +7,7 @@
     <span v-if="size !== null" class="text-gray-400 shrink-0"
       >· {{ formatBytes(size) }}</span
     >
-    <span v-if="modifiedMs" class="text-gray-400 shrink-0"
+    <span v-if="modifiedMs !== null" class="text-gray-400 shrink-0"
       >· {{ formatDateTime(modifiedMs) }}</span
     >
     <button

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="flex-1 overflow-auto min-h-0">
+    <div
+      v-if="!selectedPath"
+      class="h-full flex items-center justify-center text-gray-400 text-sm"
+    >
+      Select a file
+    </div>
+    <div v-else-if="contentError" class="p-4 text-sm text-red-600">
+      {{ contentError }}
+    </div>
+    <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">
+      Loading...
+    </div>
+    <template v-else-if="content">
+      <template v-if="content.kind === 'text'">
+        <!-- Scheduler items.json: render with the scheduler plugin's
+             calendar/list view by synthesizing a fake tool result. -->
+        <div v-if="schedulerResult" class="h-full">
+          <SchedulerView :selected-result="schedulerResult" />
+        </div>
+        <!-- Todos todos.json: full kanban / table / list explorer. -->
+        <div v-else-if="todoExplorerResult" class="h-full">
+          <TodoExplorer :selected-result="todoExplorerResult" />
+        </div>
+        <!-- Markdown rendered: frontmatter panel + body -->
+        <div
+          v-else-if="isMarkdown && !mdRawMode"
+          class="h-full flex flex-col overflow-auto"
+        >
+          <div
+            v-if="mdFrontmatter && mdFrontmatter.fields.length > 0"
+            class="shrink-0 m-4 mb-0 rounded border border-gray-200 bg-gray-50 p-3 text-xs"
+          >
+            <div
+              v-for="field in mdFrontmatter.fields"
+              :key="field.key"
+              class="flex items-baseline gap-2 py-0.5"
+            >
+              <span class="font-semibold text-gray-600 shrink-0"
+                >{{ field.key }}:</span
+              >
+              <template v-if="Array.isArray(field.value)">
+                <span class="flex flex-wrap gap-1">
+                  <span
+                    v-for="item in field.value"
+                    :key="item"
+                    class="rounded-full bg-white border border-gray-300 px-2 py-0.5 text-gray-700"
+                  >
+                    {{ item }}
+                  </span>
+                </span>
+              </template>
+              <span v-else class="text-gray-800 break-words">{{
+                field.value
+              }}</span>
+            </div>
+          </div>
+          <div
+            class="flex-1 min-h-0"
+            @click.capture="(e: MouseEvent) => emit('markdownLinkClick', e)"
+          >
+            <TextResponseView
+              :selected-result="
+                markdownResult(
+                  mdFrontmatter ? mdFrontmatter.body : content.content,
+                )
+              "
+              :editable-source="content.content"
+              @update-source="(src: string) => emit('updateSource', src)"
+            />
+          </div>
+          <div
+            v-if="rawSaveError"
+            class="shrink-0 m-4 mt-0 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-700"
+            role="alert"
+          >
+            ⚠ {{ rawSaveError }}
+          </div>
+        </div>
+        <!-- Markdown raw source (includes frontmatter) -->
+        <pre
+          v-else-if="isMarkdown && mdRawMode"
+          class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
+          >{{ content.content }}</pre
+        >
+        <!-- HTML: sandboxed iframe preview.
+             `allow-scripts` lets Chart.js / canvas drawing / other
+             JS-driven HTML (the common case for LLM-generated
+             results) run. We deliberately DO NOT grant
+             `allow-same-origin`, so the iframe keeps a null
+             origin — it can't read MulmoClaude's cookies,
+             localStorage, or the parent window's DOM.
+             A CSP meta tag is injected via wrapHtmlWithPreviewCsp
+             to restrict script loads to a vetted CDN whitelist +
+             inline; connect-src is `'none'` so the page can't
+             phone home. See src/utils/html/previewCsp.ts. -->
+        <iframe
+          v-else-if="isHtml"
+          :srcdoc="sandboxedHtml"
+          class="w-full h-full border-0"
+          sandbox="allow-scripts"
+          title="HTML preview"
+        />
+        <!-- JSON: pretty-printed with simple syntax coloring. Fall
+             back to raw content if the file is malformed. -->
+        <pre
+          v-else-if="isJson"
+          class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
+        ><span
+          v-for="(tok, i) in jsonTokens"
+          :key="i"
+          :class="JSON_TOKEN_CLASS[tok.type]"
+        >{{ tok.value }}</span></pre>
+        <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
+        <div v-else-if="isJsonl" class="p-4 space-y-2">
+          <div
+            v-for="(line, i) in jsonlLines"
+            :key="i"
+            class="rounded border bg-gray-50 p-3"
+            :class="line.parseError ? 'border-red-300' : 'border-gray-200'"
+          >
+            <div
+              v-if="line.parseError"
+              class="text-xs text-red-600 mb-1 font-sans"
+            >
+              parse error
+            </div>
+            <pre
+              class="text-xs font-mono text-gray-800 whitespace-pre-wrap"
+            ><span
+              v-for="(tok, j) in line.tokens"
+              :key="j"
+              :class="JSON_TOKEN_CLASS[tok.type]"
+            >{{ tok.value }}</span></pre>
+          </div>
+        </div>
+        <!-- Plain text fallback -->
+        <pre
+          v-else
+          class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
+          >{{ content.content }}</pre
+        >
+      </template>
+      <!-- Image -->
+      <div
+        v-else-if="content.kind === 'image' && selectedPath"
+        class="h-full flex items-center justify-center p-4"
+      >
+        <img
+          :src="rawUrl(selectedPath)"
+          :alt="selectedPath"
+          class="max-w-full max-h-full object-contain"
+        />
+      </div>
+      <!-- PDF -->
+      <iframe
+        v-else-if="content.kind === 'pdf' && selectedPath"
+        :src="rawUrl(selectedPath)"
+        class="w-full h-full border-0"
+        title="PDF preview"
+      />
+      <!-- Audio -->
+      <div
+        v-else-if="content.kind === 'audio' && selectedPath"
+        class="h-full flex items-center justify-center p-4"
+      >
+        <audio
+          :key="selectedPath"
+          :src="rawUrl(selectedPath)"
+          controls
+          preload="metadata"
+          class="w-full max-w-2xl"
+        />
+      </div>
+      <!-- Video -->
+      <div
+        v-else-if="content.kind === 'video' && selectedPath"
+        class="h-full flex items-center justify-center p-4 bg-black"
+      >
+        <video
+          :key="selectedPath"
+          :src="rawUrl(selectedPath)"
+          controls
+          preload="metadata"
+          class="max-w-full max-h-full"
+        />
+      </div>
+      <!-- Binary or too-large -->
+      <div v-else class="p-4 text-sm text-gray-500">
+        {{ "message" in content ? content.message : "" }}
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import TextResponseView from "../plugins/textResponse/View.vue";
+import SchedulerView from "../plugins/scheduler/View.vue";
+import TodoExplorer from "./TodoExplorer.vue";
+import type { FileContent } from "../composables/useFileSelection";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type { TextResponseData } from "../plugins/textResponse/types";
+import type { SchedulerData } from "../plugins/scheduler/index";
+import type { TodoData } from "../plugins/todo/index";
+import { JSON_TOKEN_CLASS } from "../utils/format/jsonSyntax";
+import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
+import type { Frontmatter } from "../utils/format/frontmatter";
+import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
+import { API_ROUTES } from "../config/apiRoutes";
+
+const props = defineProps<{
+  selectedPath: string | null;
+  content: FileContent | null;
+  contentError: string | null;
+  contentLoading: boolean;
+  schedulerResult: ToolResultComplete<SchedulerData> | null;
+  todoExplorerResult: ToolResultComplete<TodoData> | null;
+  isMarkdown: boolean;
+  isHtml: boolean;
+  isJson: boolean;
+  isJsonl: boolean;
+  mdRawMode: boolean;
+  sandboxedHtml: string;
+  jsonTokens: JsonToken[];
+  jsonlLines: JsonlLine[];
+  mdFrontmatter: Frontmatter | null;
+  rawSaveError: string | null;
+}>();
+
+const emit = defineEmits<{
+  markdownLinkClick: [event: MouseEvent];
+  updateSource: [newSource: string];
+}>();
+
+function rawUrl(filePath: string): string {
+  return `${API_ROUTES.files.raw}?path=${encodeURIComponent(filePath)}`;
+}
+
+function markdownResult(text: string): ToolResultComplete<TextResponseData> {
+  // Rewrite `![alt](path)` refs BEFORE handing the markdown to
+  // TextResponseView so workspace-relative image paths resolve via
+  // /api/files/raw instead of 404-ing against the SPA page URL.
+  const current = props.selectedPath ?? "";
+  const slash = current.lastIndexOf("/");
+  const basePath = slash >= 0 ? current.slice(0, slash) : "";
+  const rewritten = rewriteMarkdownImageRefs(text, basePath);
+  return {
+    uuid: "files-preview",
+    toolName: "text-response",
+    message: rewritten,
+    title: props.selectedPath ?? "",
+    // role: "user" hides the PDF download button in TextResponseView
+    data: { text: rewritten, role: "user", transportKind: "text-rest" },
+  };
+}
+</script>

--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50"
+  >
+    <div v-if="treeError" class="p-2 text-xs text-red-600">
+      {{ treeError }}
+    </div>
+    <div v-else-if="!rootNode" class="p-2 text-xs text-gray-400">
+      Loading...
+    </div>
+    <FileTree
+      v-else
+      :node="rootNode"
+      :selected-path="selectedPath"
+      :recent-paths="recentPaths"
+      :children-by-path="childrenByPath"
+      @select="emit('select', $event)"
+      @load-children="emit('loadChildren', $event)"
+    />
+    <template v-if="refRoots.length > 0">
+      <div
+        class="mt-2 pt-2 border-t border-gray-200 px-1 mb-1 flex items-center gap-1"
+      >
+        <span class="text-[10px] font-semibold text-gray-400 uppercase"
+          >Reference</span
+        >
+        <span class="text-[9px] px-1 py-0.5 rounded bg-blue-100 text-blue-600"
+          >RO</span
+        >
+      </div>
+      <FileTree
+        v-for="refNode in refRoots"
+        :key="refNode.path"
+        :node="refNode"
+        :selected-path="selectedPath"
+        :recent-paths="emptySet"
+        :children-by-path="childrenByPath"
+        @select="emit('select', $event)"
+        @load-children="emit('loadChildren', $event)"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import FileTree from "./FileTree.vue";
+import type { TreeNode } from "../types/fileTree";
+
+defineProps<{
+  rootNode: TreeNode | null;
+  refRoots: TreeNode[];
+  childrenByPath: Map<string, TreeNode[] | null>;
+  treeError: string | null;
+  selectedPath: string | null;
+  recentPaths: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  select: [path: string];
+  loadChildren: [path: string];
+}>();
+
+// Shared empty set for reference roots (they don't highlight recents).
+const emptySet = new Set<string>();
+</script>

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -58,17 +58,11 @@ import {
 } from "../composables/useFileSelection";
 import { useMarkdownMode } from "../composables/useMarkdownMode";
 import { useContentDisplay } from "../composables/useContentDisplay";
+import { useMarkdownLinkHandler } from "../composables/useMarkdownLinkHandler";
 import { apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
-import { WORKSPACE_FILES } from "../config/workspacePaths";
-import type { ToolResultComplete } from "gui-chat-protocol/vue";
-import type { SchedulerData, ScheduledItem } from "../plugins/scheduler/index";
-import type { StatusColumn, TodoData, TodoItem } from "../plugins/todo/index";
-import {
-  isExternalHref,
-  resolveWorkspaceLink,
-  extractSessionIdFromPath,
-} from "../utils/path/relativeLink";
+import { toSchedulerResult } from "../utils/filesPreview/schedulerPreview";
+import { toTodoExplorerResult } from "../utils/filesPreview/todoPreview";
 
 const RECENT_THRESHOLD_MS = 60 * 1000;
 
@@ -164,80 +158,19 @@ watch(content, () => {
   rawSaveError.value = null;
 });
 
-function isScheduledItem(x: unknown): x is ScheduledItem {
-  if (typeof x !== "object" || x === null) return false;
-  if (!("id" in x) || typeof x.id !== "string") return false;
-  if (!("title" in x) || typeof x.title !== "string") return false;
-  return true;
-}
-
-function isScheduledItemArray(x: unknown): x is ScheduledItem[] {
-  return Array.isArray(x) && x.every(isScheduledItem);
-}
-
-// When the user opens the scheduler items file, render it with the
-// scheduler plugin's calendar view instead of as a JSON blob. We
-// synthesize a fake ToolResultComplete<SchedulerData> so the View
-// component receives the same shape it normally gets in chat mode.
-const schedulerResult = computed(
-  (): ToolResultComplete<SchedulerData> | null => {
-    if (selectedPath.value !== WORKSPACE_FILES.schedulerItems) return null;
-    if (!content.value || content.value.kind !== "text") return null;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(content.value.content);
-    } catch {
-      return null;
-    }
-    if (!isScheduledItemArray(parsed)) return null;
-    return {
-      uuid: "files-scheduler-preview",
-      toolName: "manageScheduler",
-      message: WORKSPACE_FILES.schedulerItems,
-      title: "Scheduler",
-      data: { items: parsed },
-    };
-  },
+const schedulerResult = computed(() =>
+  toSchedulerResult(
+    selectedPath.value,
+    content.value?.kind === "text" ? content.value.content : null,
+  ),
 );
 
-// Same idea as schedulerResult: when the user opens the todos file
-// we render it as a full TodoExplorer (kanban / table / list) instead
-// of a raw JSON blob. The TodoExplorer fetches its own state from
-// /api/todos so the data we synthesize here is just a starter — the
-// columns array might be empty until the first refresh lands.
-function isTodoItem(x: unknown): x is TodoItem {
-  if (typeof x !== "object" || x === null) return false;
-  const o = x as Record<string, unknown>;
-  if (typeof o["id"] !== "string" || typeof o["text"] !== "string")
-    return false;
-  if (typeof o["completed"] !== "boolean") return false;
-  if (typeof o["createdAt"] !== "number") return false;
-  return true;
-}
-
-function isTodoItemArray(x: unknown): x is TodoItem[] {
-  return Array.isArray(x) && x.every(isTodoItem);
-}
-
-const todoExplorerResult = computed((): ToolResultComplete<TodoData> | null => {
-  if (selectedPath.value !== WORKSPACE_FILES.todosItems) return null;
-  if (!content.value || content.value.kind !== "text") return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content.value.content);
-  } catch {
-    return null;
-  }
-  const items: TodoItem[] = isTodoItemArray(parsed) ? parsed : [];
-  const columns: StatusColumn[] = [];
-  return {
-    uuid: "files-todo-preview",
-    toolName: "manageTodoList",
-    message: WORKSPACE_FILES.todosItems,
-    title: "Todo",
-    data: { items, columns },
-  };
-});
+const todoExplorerResult = computed(() =>
+  toTodoExplorerResult(
+    selectedPath.value,
+    content.value?.kind === "text" ? content.value.content : null,
+  ),
+);
 
 const recentPaths = computed(() => {
   const set = new Set<string>();
@@ -260,43 +193,12 @@ const recentPaths = computed(() => {
   return set;
 });
 
-// When the user clicks an <a> inside a rendered markdown body, check
-// if it's a workspace-internal relative/absolute link. If so, resolve
-// it against the current file and navigate inside FilesView instead
-// of letting the browser follow the (meaningless) relative href.
-//
 // Uses click.capture so we intercept before TextResponseView's own
 // handler (which only knows about absolute URLs) sees the event.
-function handleMarkdownLinkClick(event: MouseEvent): void {
-  if (event.button !== 0) return;
-  if (event.ctrlKey || event.metaKey || event.shiftKey) return;
-  const target = event.target as HTMLElement | null;
-  if (!target) return;
-  const anchor = target.closest("a");
-  if (!anchor) return;
-  const href = anchor.getAttribute("href");
-  if (!href) return;
-  // External URLs and mailto/tel: let TextResponseView's existing
-  // handler open them in a new tab.
-  if (isExternalHref(href)) return;
-  // Anchor-only (#section): let the browser handle in-page scroll.
-  if (href.startsWith("#")) return;
-  if (!selectedPath.value) return;
-  const resolved = resolveWorkspaceLink(selectedPath.value, href);
-  if (!resolved) return;
-  event.preventDefault();
-  event.stopPropagation();
-  // Chat session link: hand off to App.vue so the sidebar chat
-  // switches to that session instead of opening the raw jsonl
-  // as a file. Direct clicks in the file tree still open the
-  // jsonl in raw view — only markdown link clicks route here.
-  const sessionId = extractSessionIdFromPath(resolved);
-  if (sessionId !== null) {
-    emit("loadSession", sessionId);
-    return;
-  }
-  selectFile(resolved);
-}
+const { handleMarkdownLinkClick } = useMarkdownLinkHandler(selectedPath, {
+  onNavigate: selectFile,
+  onLoadSession: (sessionId) => emit("loadSession", sessionId),
+});
 
 // External URL changes (back/forward) → update selectedPath.
 watch(

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -249,33 +249,27 @@ import {
   useFileSelection,
   isValidFilePath,
 } from "../composables/useFileSelection";
+import { useMarkdownMode } from "../composables/useMarkdownMode";
+import { useContentDisplay } from "../composables/useContentDisplay";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
 import { formatDateTime } from "../utils/format/date";
-import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "../plugins/textResponse/types";
 import type { SchedulerData, ScheduledItem } from "../plugins/scheduler/index";
 import type { StatusColumn, TodoData, TodoItem } from "../plugins/todo/index";
-import {
-  tokenizeJson,
-  tokenizeJsonl,
-  prettyJson,
-  JSON_TOKEN_CLASS,
-} from "../utils/format/jsonSyntax";
-import { extractFrontmatter } from "../utils/format/frontmatter";
+import { JSON_TOKEN_CLASS } from "../utils/format/jsonSyntax";
 import {
   isExternalHref,
   resolveWorkspaceLink,
   extractSessionIdFromPath,
 } from "../utils/path/relativeLink";
 
-const MD_RAW_STORAGE_KEY = "files_md_raw_mode";
 const RECENT_THRESHOLD_MS = 60 * 1000;
 
 const route = useRoute();
@@ -313,22 +307,18 @@ const {
   abortContent,
 } = useFileSelection();
 
-function hasExt(filePath: string | null, exts: string[]): boolean {
-  if (!filePath) return false;
-  const lower = filePath.toLowerCase();
-  return exts.some((ext) => lower.endsWith(ext));
-}
+const { mdRawMode, toggleMdRaw } = useMarkdownMode();
 
-const isMarkdown = computed(() =>
-  hasExt(selectedPath.value, [".md", ".markdown"]),
-);
-
-const mdRawMode = ref(localStorage.getItem(MD_RAW_STORAGE_KEY) === "true");
-
-function toggleMdRaw(): void {
-  mdRawMode.value = !mdRawMode.value;
-  localStorage.setItem(MD_RAW_STORAGE_KEY, String(mdRawMode.value));
-}
+const {
+  isMarkdown,
+  isHtml,
+  isJson,
+  isJsonl,
+  sandboxedHtml,
+  jsonTokens,
+  jsonlLines,
+  mdFrontmatter,
+} = useContentDisplay(selectedPath, content);
 
 // Save-error banner shown above the Rendered-mode markdown editor.
 // Cleared on every new file load and on the next successful save.
@@ -372,31 +362,6 @@ async function saveRawMarkdown(newSource: string): Promise<void> {
 // Clear any stale save error whenever a new file is loaded.
 watch(content, () => {
   rawSaveError.value = null;
-});
-const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
-
-// The HTML body handed to the iframe's `srcdoc`. We inject a CSP
-// meta tag that narrows what the LLM's output can load — see
-// src/utils/html/previewCsp.ts. Computed so the injection happens
-// once per content change, not on every render.
-const sandboxedHtml = computed(() =>
-  content.value?.kind === "text" && isHtml.value
-    ? wrapHtmlWithPreviewCsp(content.value.content)
-    : "",
-);
-const isJson = computed(() => hasExt(selectedPath.value, [".json"]));
-const isJsonl = computed(() =>
-  hasExt(selectedPath.value, [".jsonl", ".ndjson"]),
-);
-
-const jsonTokens = computed(() => {
-  if (!content.value || content.value.kind !== "text") return [];
-  return tokenizeJson(prettyJson(content.value.content));
-});
-
-const jsonlLines = computed(() => {
-  if (!content.value || content.value.kind !== "text") return [];
-  return tokenizeJsonl(content.value.content);
 });
 
 function isScheduledItem(x: unknown): x is ScheduledItem {
@@ -472,12 +437,6 @@ const todoExplorerResult = computed((): ToolResultComplete<TodoData> | null => {
     title: "Todo",
     data: { items, columns },
   };
-});
-
-const mdFrontmatter = computed(() => {
-  if (!content.value || content.value.kind !== "text") return null;
-  if (!isMarkdown.value) return null;
-  return extractFrontmatter(content.value.content);
 });
 
 function markdownResult(text: string): ToolResultComplete<TextResponseData> {

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -12,37 +12,15 @@
     />
     <!-- Content pane -->
     <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
-      <div
-        v-if="selectedPath"
-        class="px-4 py-2 border-b border-gray-200 text-xs text-gray-500 font-mono shrink-0 flex items-center gap-2"
-      >
-        <span class="truncate min-w-0">{{ selectedPath }}</span>
-        <span v-if="content" class="text-gray-400 shrink-0"
-          >· {{ formatBytes(content.size) }}</span
-        >
-        <span v-if="content?.modifiedMs" class="text-gray-400 shrink-0"
-          >· {{ formatDateTime(content.modifiedMs) }}</span
-        >
-        <button
-          v-if="isMarkdown"
-          class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
-          :title="mdRawMode ? 'Show rendered Markdown' : 'Show raw source'"
-          @click="toggleMdRaw"
-        >
-          {{ mdRawMode ? "Rendered" : "Raw" }}
-        </button>
-        <button
-          type="button"
-          class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
-          :class="{ 'ml-auto': !isMarkdown }"
-          title="Close file"
-          aria-label="Close file"
-          data-testid="close-file-btn"
-          @click="deselectFile"
-        >
-          <span class="material-icons text-base" aria-hidden="true">close</span>
-        </button>
-      </div>
+      <FileContentHeader
+        :selected-path="selectedPath"
+        :size="content?.size ?? null"
+        :modified-ms="content?.modifiedMs ?? null"
+        :is-markdown="isMarkdown"
+        :md-raw-mode="mdRawMode"
+        @toggle-md-raw="toggleMdRaw"
+        @deselect="deselectFile"
+      />
       <div class="flex-1 overflow-auto min-h-0">
         <div
           v-if="!selectedPath"
@@ -244,6 +222,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import FileTreePane from "./FileTreePane.vue";
+import FileContentHeader from "./FileContentHeader.vue";
 import { useFileTree } from "../composables/useFileTree";
 import {
   useFileSelection,
@@ -256,7 +235,6 @@ import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRef
 import { apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
-import { formatDateTime } from "../utils/format/date";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -482,12 +460,6 @@ const recentPaths = computed(() => {
 
 function rawUrl(filePath: string): string {
   return `${API_ROUTES.files.raw}?path=${encodeURIComponent(filePath)}`;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 // When the user clicks an <a> inside a rendered markdown body, check

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -275,12 +275,16 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
-import { useRoute, useRouter, isNavigationFailure } from "vue-router";
-import FileTree, { type TreeNode } from "./FileTree.vue";
-import { useExpandedDirs } from "../composables/useExpandedDirs";
+import { useRoute } from "vue-router";
+import FileTree from "./FileTree.vue";
+import { useFileTree } from "../composables/useFileTree";
+import {
+  useFileSelection,
+  isValidFilePath,
+} from "../composables/useFileSelection";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
-import { apiGet, apiPut } from "../utils/api";
+import { apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
 import { formatDateTime } from "../utils/format/date";
@@ -308,35 +312,6 @@ const MD_RAW_STORAGE_KEY = "files_md_raw_mode";
 const RECENT_THRESHOLD_MS = 60 * 1000;
 
 const route = useRoute();
-const router = useRouter();
-
-// Validate a file path from the URL: reject traversal attempts and
-// obviously invalid values. We don't check existence here — a 404 is
-// handled gracefully by the content loader.
-function isValidFilePath(p: unknown): p is string {
-  if (typeof p !== "string" || p.length === 0) return false;
-  if (p.includes("..")) return false;
-  if (p.startsWith("/")) return false;
-  return true;
-}
-
-interface TextContent {
-  kind: "text";
-  path: string;
-  content: string;
-  size: number;
-  modifiedMs: number;
-}
-
-interface MetaContent {
-  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
-  path: string;
-  size: number;
-  modifiedMs: number;
-  message?: string;
-}
-
-type FileContent = TextContent | MetaContent;
 
 const props = defineProps<{
   refreshToken?: number;
@@ -349,36 +324,29 @@ const emit = defineEmits<{
   loadSession: [sessionId: string];
 }>();
 
-// Share the expand-state composable with FileTree so deep-link
-// auto-expand (`?path=wiki/pages/foo.md`) can mark ancestors as
-// expanded before the children arrive.
-const { expand } = useExpandedDirs();
+const {
+  rootNode,
+  refRoots,
+  childrenByPath,
+  treeError,
+  loadDirChildren,
+  ensureAncestorsLoaded,
+  reloadRoot,
+  loadRefRoots,
+} = useFileTree();
 
-// Root dir metadata (name/path/modifiedMs). Children live in
-// `childrenByPath` below so the lazy-expand cache has a single
-// home — see Phase-2 notes for #200.
-const rootNode = ref<TreeNode | null>(null);
-const refRoots = ref<TreeNode[]>([]);
 const emptySet = new Set<string>();
-// Lazy-expand cache: one entry per directory we've fetched via
-// `/api/files/dir`. `undefined` (= not in the map) means "not
-// loaded yet". `null` means "load in flight — show spinner".
-const childrenByPath = ref<Map<string, TreeNode[] | null>>(new Map());
-const treeError = ref<string | null>(null);
 
-// Seed selectedPath from URL query ?path=, falling back to
-// localStorage. Same bidirectional-sync pattern as sessionId
-// and canvasViewMode: ref is the source of truth for reads,
-// router.push keeps the URL in sync, watcher handles external
-// URL changes (back/forward).
-const urlPath = route.query.path;
-const selectedPath = ref<string | null>(
-  isValidFilePath(urlPath) ? urlPath : null,
-);
-
-const content = ref<FileContent | null>(null);
-const contentLoading = ref(false);
-const contentError = ref<string | null>(null);
+const {
+  selectedPath,
+  content,
+  contentLoading,
+  contentError,
+  loadContent,
+  selectFile,
+  deselectFile,
+  abortContent,
+} = useFileSelection();
 
 function hasExt(filePath: string | null, exts: string[]): boolean {
   if (!filePath) return false;
@@ -598,129 +566,6 @@ function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
-// Fetch the immediate children of one directory via the lazy-expand
-// endpoint added in #207. Stores them in `childrenByPath` under the
-// same `path` the server returned. Idempotent — if already loaded,
-// no-ops. Setting the map value to `null` briefly lets the UI show
-// a spinner while the request is in flight.
-async function loadDirChildren(path: string): Promise<void> {
-  // Already loaded or in flight — skip. `undefined` (not present)
-  // is the only case that kicks off a fetch.
-  if (childrenByPath.value.has(path)) return;
-
-  const next = new Map(childrenByPath.value);
-  next.set(path, null);
-  childrenByPath.value = next;
-
-  const result = await apiGet<TreeNode>(API_ROUTES.files.dir, { path });
-  if (!result.ok) {
-    // Drop the `null` marker so the user can retry (e.g. via the
-    // refresh-token watcher). Keep the error visible too.
-    const rollback = new Map(childrenByPath.value);
-    rollback.delete(path);
-    childrenByPath.value = rollback;
-    treeError.value = result.error || `dir: ${result.status}`;
-    return;
-  }
-  const node = result.data;
-  const updated = new Map(childrenByPath.value);
-  updated.set(path, node.children ?? []);
-  childrenByPath.value = updated;
-  // Also expose the root dir's own metadata (name / path /
-  // modifiedMs) for the FileTree header — only relevant for the
-  // workspace root, which the tree renders as "(workspace)".
-  if (path === "") rootNode.value = { ...node, children: [] };
-}
-
-// Walk each ancestor of a file path and expand + load it. Used on
-// mount for deep links like `?path=wiki/pages/foo.md` so the tree
-// reveals the selection rather than keeping every directory
-// collapsed.
-async function ensureAncestorsLoaded(filePath: string): Promise<void> {
-  const parts = filePath.split("/").filter(Boolean);
-  if (parts.length <= 1) return; // file sits at root, nothing to expand
-  const ancestors: string[] = [];
-  for (let i = 1; i < parts.length; i++) {
-    ancestors.push(parts.slice(0, i).join("/"));
-  }
-  for (const dir of ancestors) {
-    expand(dir);
-    await loadDirChildren(dir);
-  }
-}
-
-async function reloadRoot(): Promise<void> {
-  // Wipe the whole lazy cache, then re-seed the root. Any
-  // currently-expanded descendants will be re-fetched lazily when
-  // the FileTree re-emits `load-children` from their expanded
-  // state.
-  childrenByPath.value = new Map();
-  treeError.value = null;
-  await loadDirChildren("");
-}
-
-// Tracks the currently in-flight content fetch so a stale response from
-// a previously-clicked file can't overwrite the latest selection.
-let contentAbort: AbortController | null = null;
-
-async function loadContent(filePath: string): Promise<void> {
-  contentAbort?.abort();
-  const controller = new AbortController();
-  contentAbort = controller;
-
-  contentLoading.value = true;
-  contentError.value = null;
-  content.value = null;
-  const result = await apiGet<FileContent>(
-    API_ROUTES.files.content,
-    { path: filePath },
-    { signal: controller.signal },
-  );
-  // Early-return covers abort (network error with status 0) and
-  // exits before any state mutation, so the error branch below only
-  // fires for real failures.
-  if (controller.signal.aborted) return;
-  if (!result.ok) {
-    contentError.value = result.error;
-  } else {
-    content.value = result.data;
-  }
-  if (contentAbort === controller) {
-    contentLoading.value = false;
-    contentAbort = null;
-  }
-}
-
-function selectFile(filePath: string): void {
-  selectedPath.value = filePath;
-  loadContent(filePath);
-  // Push file path into the URL so it's bookmarkable / back-navigable.
-  const { path: __path, ...restQuery } = route.query;
-  router
-    .push({ query: { ...restQuery, path: filePath } })
-    .catch((err: unknown) => {
-      if (!isNavigationFailure(err)) {
-        console.error("[selectFile] navigation failed:", err);
-      }
-    });
-}
-
-function deselectFile(): void {
-  contentAbort?.abort();
-  contentAbort = null;
-  selectedPath.value = null;
-  content.value = null;
-  contentLoading.value = false;
-  contentError.value = null;
-  // Remove ?path= from URL for a clean state on reload.
-  const { path: __path, ...restQuery } = route.query;
-  router.replace({ query: restQuery }).catch((err: unknown) => {
-    if (!isNavigationFailure(err)) {
-      console.error("[deselectFile] navigation failed:", err);
-    }
-  });
-}
-
 // When the user clicks an <a> inside a rendered markdown body, check
 // if it's a workspace-internal relative/absolute link. If so, resolve
 // it against the current file and navigate inside FilesView instead
@@ -787,12 +632,7 @@ watch(
 
 onMounted(async () => {
   await loadDirChildren("");
-
-  // Fetch reference directory roots (read-only external dirs)
-  const refResult = await apiGet<TreeNode[]>(API_ROUTES.files.refRoots);
-  if (refResult.ok && Array.isArray(refResult.data)) {
-    refRoots.value = refResult.data;
-  }
+  await loadRefRoots();
 
   // Deep-link: if the URL has a selected path, reveal its ancestors
   // by fetching each dir in sequence so the tree auto-expands to
@@ -804,6 +644,6 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  contentAbort?.abort();
+  abortContent();
 });
 </script>

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -1,48 +1,15 @@
 <template>
   <div class="h-full flex bg-white">
-    <!-- Tree pane -->
-    <div
-      class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50"
-    >
-      <div v-if="treeError" class="p-2 text-xs text-red-600">
-        {{ treeError }}
-      </div>
-      <div v-else-if="!rootNode" class="p-2 text-xs text-gray-400">
-        Loading...
-      </div>
-      <FileTree
-        v-else
-        :node="rootNode"
-        :selected-path="selectedPath"
-        :recent-paths="recentPaths"
-        :children-by-path="childrenByPath"
-        @select="selectFile"
-        @load-children="loadDirChildren"
-      />
-      <!-- Reference directories -->
-      <template v-if="refRoots.length > 0">
-        <div
-          class="mt-2 pt-2 border-t border-gray-200 px-1 mb-1 flex items-center gap-1"
-        >
-          <span class="text-[10px] font-semibold text-gray-400 uppercase"
-            >Reference</span
-          >
-          <span class="text-[9px] px-1 py-0.5 rounded bg-blue-100 text-blue-600"
-            >RO</span
-          >
-        </div>
-        <FileTree
-          v-for="refNode in refRoots"
-          :key="refNode.path"
-          :node="refNode"
-          :selected-path="selectedPath"
-          :recent-paths="emptySet"
-          :children-by-path="childrenByPath"
-          @select="selectFile"
-          @load-children="loadDirChildren"
-        />
-      </template>
-    </div>
+    <FileTreePane
+      :root-node="rootNode"
+      :ref-roots="refRoots"
+      :children-by-path="childrenByPath"
+      :tree-error="treeError"
+      :selected-path="selectedPath"
+      :recent-paths="recentPaths"
+      @select="selectFile"
+      @load-children="loadDirChildren"
+    />
     <!-- Content pane -->
     <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
       <div
@@ -276,7 +243,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
-import FileTree from "./FileTree.vue";
+import FileTreePane from "./FileTreePane.vue";
 import { useFileTree } from "../composables/useFileTree";
 import {
   useFileSelection,
@@ -334,8 +301,6 @@ const {
   reloadRoot,
   loadRefRoots,
 } = useFileTree();
-
-const emptySet = new Set<string>();
 
 const {
   selectedPath,

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -21,199 +21,26 @@
         @toggle-md-raw="toggleMdRaw"
         @deselect="deselectFile"
       />
-      <div class="flex-1 overflow-auto min-h-0">
-        <div
-          v-if="!selectedPath"
-          class="h-full flex items-center justify-center text-gray-400 text-sm"
-        >
-          Select a file
-        </div>
-        <div v-else-if="contentError" class="p-4 text-sm text-red-600">
-          {{ contentError }}
-        </div>
-        <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">
-          Loading...
-        </div>
-        <template v-else-if="content">
-          <template v-if="content.kind === 'text'">
-            <!-- Scheduler items.json: render with the scheduler plugin's
-                 calendar/list view by synthesizing a fake tool result. -->
-            <div v-if="schedulerResult" class="h-full">
-              <SchedulerView :selected-result="schedulerResult" />
-            </div>
-            <!-- Todos todos.json: full kanban / table / list explorer. -->
-            <div v-else-if="todoExplorerResult" class="h-full">
-              <TodoExplorer :selected-result="todoExplorerResult" />
-            </div>
-            <!-- Markdown rendered: frontmatter panel + body -->
-            <div
-              v-else-if="isMarkdown && !mdRawMode"
-              class="h-full flex flex-col overflow-auto"
-            >
-              <div
-                v-if="mdFrontmatter && mdFrontmatter.fields.length > 0"
-                class="shrink-0 m-4 mb-0 rounded border border-gray-200 bg-gray-50 p-3 text-xs"
-              >
-                <div
-                  v-for="field in mdFrontmatter.fields"
-                  :key="field.key"
-                  class="flex items-baseline gap-2 py-0.5"
-                >
-                  <span class="font-semibold text-gray-600 shrink-0"
-                    >{{ field.key }}:</span
-                  >
-                  <template v-if="Array.isArray(field.value)">
-                    <span class="flex flex-wrap gap-1">
-                      <span
-                        v-for="item in field.value"
-                        :key="item"
-                        class="rounded-full bg-white border border-gray-300 px-2 py-0.5 text-gray-700"
-                      >
-                        {{ item }}
-                      </span>
-                    </span>
-                  </template>
-                  <span v-else class="text-gray-800 break-words">{{
-                    field.value
-                  }}</span>
-                </div>
-              </div>
-              <div
-                class="flex-1 min-h-0"
-                @click.capture="handleMarkdownLinkClick"
-              >
-                <TextResponseView
-                  :selected-result="
-                    markdownResult(
-                      mdFrontmatter ? mdFrontmatter.body : content.content,
-                    )
-                  "
-                  :editable-source="content.content"
-                  @update-source="saveRawMarkdown"
-                />
-              </div>
-              <div
-                v-if="rawSaveError"
-                class="shrink-0 m-4 mt-0 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-700"
-                role="alert"
-              >
-                ⚠ {{ rawSaveError }}
-              </div>
-            </div>
-            <!-- Markdown raw source (includes frontmatter) -->
-            <pre
-              v-else-if="isMarkdown && mdRawMode"
-              class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
-              >{{ content.content }}</pre
-            >
-            <!-- HTML: sandboxed iframe preview.
-                 `allow-scripts` lets Chart.js / canvas drawing / other
-                 JS-driven HTML (the common case for LLM-generated
-                 results) run. We deliberately DO NOT grant
-                 `allow-same-origin`, so the iframe keeps a null
-                 origin — it can't read MulmoClaude's cookies,
-                 localStorage, or the parent window's DOM.
-                 A CSP meta tag is injected via wrapHtmlWithPreviewCsp
-                 to restrict script loads to a vetted CDN whitelist +
-                 inline; connect-src is `'none'` so the page can't
-                 phone home. See src/utils/html/previewCsp.ts. -->
-            <iframe
-              v-else-if="isHtml"
-              :srcdoc="sandboxedHtml"
-              class="w-full h-full border-0"
-              sandbox="allow-scripts"
-              title="HTML preview"
-            />
-            <!-- JSON: pretty-printed with simple syntax coloring. Fall
-                 back to raw content if the file is malformed. -->
-            <pre
-              v-else-if="isJson"
-              class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
-            ><span
-              v-for="(tok, i) in jsonTokens"
-              :key="i"
-              :class="JSON_TOKEN_CLASS[tok.type]"
-            >{{ tok.value }}</span></pre>
-            <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
-            <div v-else-if="isJsonl" class="p-4 space-y-2">
-              <div
-                v-for="(line, i) in jsonlLines"
-                :key="i"
-                class="rounded border bg-gray-50 p-3"
-                :class="line.parseError ? 'border-red-300' : 'border-gray-200'"
-              >
-                <div
-                  v-if="line.parseError"
-                  class="text-xs text-red-600 mb-1 font-sans"
-                >
-                  parse error
-                </div>
-                <pre
-                  class="text-xs font-mono text-gray-800 whitespace-pre-wrap"
-                ><span
-                  v-for="(tok, j) in line.tokens"
-                  :key="j"
-                  :class="JSON_TOKEN_CLASS[tok.type]"
-                >{{ tok.value }}</span></pre>
-              </div>
-            </div>
-            <!-- Plain text fallback -->
-            <pre
-              v-else
-              class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"
-              >{{ content.content }}</pre
-            >
-          </template>
-          <!-- Image -->
-          <div
-            v-else-if="content.kind === 'image'"
-            class="h-full flex items-center justify-center p-4"
-          >
-            <img
-              :src="rawUrl(selectedPath)"
-              :alt="selectedPath"
-              class="max-w-full max-h-full object-contain"
-            />
-          </div>
-          <!-- PDF -->
-          <iframe
-            v-else-if="content.kind === 'pdf'"
-            :src="rawUrl(selectedPath)"
-            class="w-full h-full border-0"
-            title="PDF preview"
-          />
-          <!-- Audio -->
-          <div
-            v-else-if="content.kind === 'audio'"
-            class="h-full flex items-center justify-center p-4"
-          >
-            <audio
-              :key="selectedPath"
-              :src="rawUrl(selectedPath)"
-              controls
-              preload="metadata"
-              class="w-full max-w-2xl"
-            />
-          </div>
-          <!-- Video -->
-          <div
-            v-else-if="content.kind === 'video'"
-            class="h-full flex items-center justify-center p-4 bg-black"
-          >
-            <video
-              :key="selectedPath"
-              :src="rawUrl(selectedPath)"
-              controls
-              preload="metadata"
-              class="max-w-full max-h-full"
-            />
-          </div>
-          <!-- Binary or too-large -->
-          <div v-else class="p-4 text-sm text-gray-500">
-            {{ content.message }}
-          </div>
-        </template>
-      </div>
+      <FileContentRenderer
+        :selected-path="selectedPath"
+        :content="content"
+        :content-error="contentError"
+        :content-loading="contentLoading"
+        :scheduler-result="schedulerResult"
+        :todo-explorer-result="todoExplorerResult"
+        :is-markdown="isMarkdown"
+        :is-html="isHtml"
+        :is-json="isJson"
+        :is-jsonl="isJsonl"
+        :md-raw-mode="mdRawMode"
+        :sandboxed-html="sandboxedHtml"
+        :json-tokens="jsonTokens"
+        :jsonl-lines="jsonlLines"
+        :md-frontmatter="mdFrontmatter"
+        :raw-save-error="rawSaveError"
+        @markdown-link-click="handleMarkdownLinkClick"
+        @update-source="saveRawMarkdown"
+      />
     </div>
   </div>
 </template>
@@ -223,6 +50,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import FileTreePane from "./FileTreePane.vue";
 import FileContentHeader from "./FileContentHeader.vue";
+import FileContentRenderer from "./FileContentRenderer.vue";
 import { useFileTree } from "../composables/useFileTree";
 import {
   useFileSelection,
@@ -230,18 +58,12 @@ import {
 } from "../composables/useFileSelection";
 import { useMarkdownMode } from "../composables/useMarkdownMode";
 import { useContentDisplay } from "../composables/useContentDisplay";
-import TextResponseView from "../plugins/textResponse/View.vue";
-import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { WORKSPACE_FILES } from "../config/workspacePaths";
-import SchedulerView from "../plugins/scheduler/View.vue";
-import TodoExplorer from "./TodoExplorer.vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
-import type { TextResponseData } from "../plugins/textResponse/types";
 import type { SchedulerData, ScheduledItem } from "../plugins/scheduler/index";
 import type { StatusColumn, TodoData, TodoItem } from "../plugins/todo/index";
-import { JSON_TOKEN_CLASS } from "../utils/format/jsonSyntax";
 import {
   isExternalHref,
   resolveWorkspaceLink,
@@ -417,26 +239,6 @@ const todoExplorerResult = computed((): ToolResultComplete<TodoData> | null => {
   };
 });
 
-function markdownResult(text: string): ToolResultComplete<TextResponseData> {
-  // Rewrite `![alt](path)` refs BEFORE handing the markdown to
-  // TextResponseView (which we don't own — it's a package component)
-  // so workspace-relative image paths resolve via /api/files/raw
-  // instead of 404-ing against the SPA page URL. basePath is the
-  // directory of the current file so `../` refs resolve correctly.
-  const current = selectedPath.value ?? "";
-  const slash = current.lastIndexOf("/");
-  const basePath = slash >= 0 ? current.slice(0, slash) : "";
-  const rewritten = rewriteMarkdownImageRefs(text, basePath);
-  return {
-    uuid: "files-preview",
-    toolName: "text-response",
-    message: rewritten,
-    title: selectedPath.value ?? "",
-    // role: "user" hides the PDF download button in TextResponseView
-    data: { text: rewritten, role: "user", transportKind: "text-rest" },
-  };
-}
-
 const recentPaths = computed(() => {
   const set = new Set<string>();
   const now = Date.now();
@@ -457,10 +259,6 @@ const recentPaths = computed(() => {
   }
   return set;
 });
-
-function rawUrl(filePath: string): string {
-  return `${API_ROUTES.files.raw}?path=${encodeURIComponent(filePath)}`;
-}
 
 // When the user clicks an <a> inside a rendered markdown body, check
 // if it's a workspace-internal relative/absolute link. If so, resolve

--- a/src/composables/useContentDisplay.ts
+++ b/src/composables/useContentDisplay.ts
@@ -1,0 +1,65 @@
+// Composable: derive content-type flags and formatted views from the
+// current selection. Extracted from FilesView.vue (#507 step 5).
+
+import { computed, type Ref } from "vue";
+import type { FileContent } from "./useFileSelection";
+import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
+import {
+  tokenizeJson,
+  tokenizeJsonl,
+  prettyJson,
+} from "../utils/format/jsonSyntax";
+import { extractFrontmatter } from "../utils/format/frontmatter";
+
+function hasExt(filePath: string | null, exts: string[]): boolean {
+  if (!filePath) return false;
+  const lower = filePath.toLowerCase();
+  return exts.some((ext) => lower.endsWith(ext));
+}
+
+export function useContentDisplay(
+  selectedPath: Ref<string | null>,
+  content: Ref<FileContent | null>,
+) {
+  const isMarkdown = computed(() =>
+    hasExt(selectedPath.value, [".md", ".markdown"]),
+  );
+  const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
+  const isJson = computed(() => hasExt(selectedPath.value, [".json"]));
+  const isJsonl = computed(() =>
+    hasExt(selectedPath.value, [".jsonl", ".ndjson"]),
+  );
+
+  const sandboxedHtml = computed(() =>
+    content.value?.kind === "text" && isHtml.value
+      ? wrapHtmlWithPreviewCsp(content.value.content)
+      : "",
+  );
+
+  const jsonTokens = computed(() => {
+    if (!content.value || content.value.kind !== "text") return [];
+    return tokenizeJson(prettyJson(content.value.content));
+  });
+
+  const jsonlLines = computed(() => {
+    if (!content.value || content.value.kind !== "text") return [];
+    return tokenizeJsonl(content.value.content);
+  });
+
+  const mdFrontmatter = computed(() => {
+    if (!content.value || content.value.kind !== "text") return null;
+    if (!isMarkdown.value) return null;
+    return extractFrontmatter(content.value.content);
+  });
+
+  return {
+    isMarkdown,
+    isHtml,
+    isJson,
+    isJsonl,
+    sandboxedHtml,
+    jsonTokens,
+    jsonlLines,
+    mdFrontmatter,
+  };
+}

--- a/src/composables/useContentDisplay.ts
+++ b/src/composables/useContentDisplay.ts
@@ -38,11 +38,13 @@ export function useContentDisplay(
 
   const jsonTokens = computed(() => {
     if (!content.value || content.value.kind !== "text") return [];
+    if (!isJson.value) return [];
     return tokenizeJson(prettyJson(content.value.content));
   });
 
   const jsonlLines = computed(() => {
     if (!content.value || content.value.kind !== "text") return [];
+    if (!isJsonl.value) return [];
     return tokenizeJsonl(content.value.content);
   });
 

--- a/src/composables/useMarkdownLinkHandler.ts
+++ b/src/composables/useMarkdownLinkHandler.ts
@@ -1,0 +1,53 @@
+// Composable: intercept clicks on <a> links inside rendered markdown
+// bodies and route workspace-internal refs back into FilesView / the
+// chat session loader. Extracted from FilesView.vue (#507 step 8).
+
+import type { Ref } from "vue";
+import {
+  isExternalHref,
+  resolveWorkspaceLink,
+  extractSessionIdFromPath,
+} from "../utils/path/relativeLink";
+
+interface MarkdownLinkHandlers {
+  /** Invoked when a link resolves to a workspace file path. */
+  onNavigate: (path: string) => void;
+  /** Invoked when a link resolves to a chat session jsonl. */
+  onLoadSession: (sessionId: string) => void;
+}
+
+export function useMarkdownLinkHandler(
+  selectedPath: Ref<string | null>,
+  handlers: MarkdownLinkHandlers,
+) {
+  function handleMarkdownLinkClick(event: MouseEvent): void {
+    if (event.button !== 0) return;
+    if (event.ctrlKey || event.metaKey || event.shiftKey) return;
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const anchor = target.closest("a");
+    if (!anchor) return;
+    const href = anchor.getAttribute("href");
+    if (!href) return;
+    // External URLs and mailto/tel: let TextResponseView's existing
+    // handler open them in a new tab.
+    if (isExternalHref(href)) return;
+    // Anchor-only (#section): let the browser handle in-page scroll.
+    if (href.startsWith("#")) return;
+    if (!selectedPath.value) return;
+    const resolved = resolveWorkspaceLink(selectedPath.value, href);
+    if (!resolved) return;
+    event.preventDefault();
+    event.stopPropagation();
+    // Chat session link: hand off so the sidebar chat switches to that
+    // session instead of opening the raw jsonl as a file.
+    const sessionId = extractSessionIdFromPath(resolved);
+    if (sessionId !== null) {
+      handlers.onLoadSession(sessionId);
+      return;
+    }
+    handlers.onNavigate(resolved);
+  }
+
+  return { handleMarkdownLinkClick };
+}

--- a/src/composables/useMarkdownLinkHandler.ts
+++ b/src/composables/useMarkdownLinkHandler.ts
@@ -23,8 +23,8 @@ export function useMarkdownLinkHandler(
   function handleMarkdownLinkClick(event: MouseEvent): void {
     if (event.button !== 0) return;
     if (event.ctrlKey || event.metaKey || event.shiftKey) return;
-    const target = event.target as HTMLElement | null;
-    if (!target) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
     const anchor = target.closest("a");
     if (!anchor) return;
     const href = anchor.getAttribute("href");

--- a/src/composables/useMarkdownMode.ts
+++ b/src/composables/useMarkdownMode.ts
@@ -1,0 +1,17 @@
+// Composable: markdown raw/rendered toggle persisted to localStorage.
+// Extracted from FilesView.vue (#507 step 5).
+
+import { ref } from "vue";
+
+const MD_RAW_STORAGE_KEY = "files_md_raw_mode";
+
+export function useMarkdownMode() {
+  const mdRawMode = ref(localStorage.getItem(MD_RAW_STORAGE_KEY) === "true");
+
+  function toggleMdRaw(): void {
+    mdRawMode.value = !mdRawMode.value;
+    localStorage.setItem(MD_RAW_STORAGE_KEY, String(mdRawMode.value));
+  }
+
+  return { mdRawMode, toggleMdRaw };
+}

--- a/src/utils/filesPreview/schedulerPreview.ts
+++ b/src/utils/filesPreview/schedulerPreview.ts
@@ -1,0 +1,43 @@
+// Synthesize a ToolResultComplete<SchedulerData> from raw scheduler
+// items.json content so FilesView can render it with the scheduler
+// plugin's calendar view. Extracted from FilesView.vue (#507 step 8).
+
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type {
+  SchedulerData,
+  ScheduledItem,
+} from "../../plugins/scheduler/index";
+import { WORKSPACE_FILES } from "../../config/workspacePaths";
+
+function isScheduledItem(x: unknown): x is ScheduledItem {
+  if (typeof x !== "object" || x === null) return false;
+  if (!("id" in x) || typeof x.id !== "string") return false;
+  if (!("title" in x) || typeof x.title !== "string") return false;
+  return true;
+}
+
+function isScheduledItemArray(x: unknown): x is ScheduledItem[] {
+  return Array.isArray(x) && x.every(isScheduledItem);
+}
+
+export function toSchedulerResult(
+  selectedPath: string | null,
+  rawText: string | null,
+): ToolResultComplete<SchedulerData> | null {
+  if (selectedPath !== WORKSPACE_FILES.schedulerItems) return null;
+  if (rawText === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return null;
+  }
+  if (!isScheduledItemArray(parsed)) return null;
+  return {
+    uuid: "files-scheduler-preview",
+    toolName: "manageScheduler",
+    message: WORKSPACE_FILES.schedulerItems,
+    title: "Scheduler",
+    data: { items: parsed },
+  };
+}

--- a/src/utils/filesPreview/todoPreview.ts
+++ b/src/utils/filesPreview/todoPreview.ts
@@ -1,0 +1,48 @@
+// Synthesize a ToolResultComplete<TodoData> from raw todos.json
+// content so FilesView can render it with the TodoExplorer.
+// Extracted from FilesView.vue (#507 step 8).
+
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type {
+  StatusColumn,
+  TodoData,
+  TodoItem,
+} from "../../plugins/todo/index";
+import { WORKSPACE_FILES } from "../../config/workspacePaths";
+
+function isTodoItem(x: unknown): x is TodoItem {
+  if (typeof x !== "object" || x === null) return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o["id"] !== "string" || typeof o["text"] !== "string")
+    return false;
+  if (typeof o["completed"] !== "boolean") return false;
+  if (typeof o["createdAt"] !== "number") return false;
+  return true;
+}
+
+function isTodoItemArray(x: unknown): x is TodoItem[] {
+  return Array.isArray(x) && x.every(isTodoItem);
+}
+
+export function toTodoExplorerResult(
+  selectedPath: string | null,
+  rawText: string | null,
+): ToolResultComplete<TodoData> | null {
+  if (selectedPath !== WORKSPACE_FILES.todosItems) return null;
+  if (rawText === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return null;
+  }
+  const items: TodoItem[] = isTodoItemArray(parsed) ? parsed : [];
+  const columns: StatusColumn[] = [];
+  return {
+    uuid: "files-todo-preview",
+    toolName: "manageTodoList",
+    message: WORKSPACE_FILES.todosItems,
+    title: "Todo",
+    data: { items, columns },
+  };
+}


### PR DESCRIPTION
## Summary

Completes #507 by finishing steps 3-8 on top of merged step 1-2 (PR #508).

**Result:** `FilesView.vue` shrinks from **809 → 245 lines** — now a thin composition-root wiring six composables together with three template sub-components.

## Items to Confirm / Review

- **Renderer prop count is large (16 props)** — kept as plain props rather than passing the whole content-display composable object, since the parent already destructures those refs. If you'd prefer a single `display` prop binding, easy to do.
- **`saveRawMarkdown` still lives in FilesView** — it owns `rawSaveError` local state tied to the parent, so I didn't pull it into a composable. Could become `useRawMarkdownSave(selectedPath, content)` later if needed.
- **Scheduler/todo preview builders are pure functions** (not composables) because they take raw text in and return a result — `computed()` wrapping stays in the parent. Simpler to test this way.
- **`useMarkdownLinkHandler`** takes a `handlers` callback object rather than emitting its own events, because it's a composable not a component. Callback names mirror the old behavior (`onNavigate`, `onLoadSession`).
- **`emptySet` moved into `FileTreePane`** since reference roots are its only user.

## User Prompt

> 次にやること（Step 3-8）:
> 3. FilesView.vue を composable で書き換え — useFileTree + useFileSelection を import して既存のインライン状態・関数を削除
> 4. FileTreePane コンポーネント抽出 — テンプレートの tree pane 部分
> 5. useMarkdownMode + useContentDisplay composable
> 6. FileContentHeader コンポーネント抽出
> 7. FileContentRenderer コンポーネント抽出
> 8. useMarkdownLinkHandler + ユーティリティ移動
>
> Issue: https://github.com/receptron/mulmoclaude/issues/507

「最後まで進めて」

## Implementation

Six commits, one per step:

| Step | Commit | Change |
|---|---|---|
| 3 | `53981cb` | Wire `useFileTree` + `useFileSelection` (drop 160 inline lines) |
| 4 | `03711ae` | Extract `FileTreePane.vue` (tree + ref roots) |
| 5 | `cf6ca07` | Extract `useMarkdownMode` + `useContentDisplay` |
| 6 | `cdc8862` | Extract `FileContentHeader.vue` |
| 7 | `ac6e5b9` | Extract `FileContentRenderer.vue` (markdown/html/json/media/...) |
| 8 | `60820e0` | Extract `useMarkdownLinkHandler` + `schedulerPreview` / `todoPreview` utilities |

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn vue-tsc` / `yarn build` / `yarn test` all clean
- [x] Playwright e2e files-related suite: 14/14 pass (file explorer, HTML preview, markdown image rewrite, todo explorer, keyboard shortcuts, localStorage restore)
- [ ] CI
- [ ] Manual smoke: open/close files, markdown raw/rendered toggle, workspace-link click to chat session, scheduler/todo preview from JSON

Closes #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown toggle to switch between raw and rendered views for markdown files
  * Introduced enhanced file preview support for multiple formats including JSON, JSONL, HTML, images, PDFs, audio, and video
  * Added scheduler and todo list rendering for workspace files
  * Added file metadata display showing file size and last modified timestamp

* **Improvements**
  * Refactored file viewing interface with improved layout and organization
  * Enhanced markdown link handling for better in-app navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->