### PR TITLE
refactor: extract 3 composables from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -296,6 +296,7 @@ import { useClickOutside } from "./composables/useClickOutside";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
 import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
+import { useViewLayout } from "./composables/useViewLayout";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -606,31 +607,13 @@ const {
 // plugin launcher button (Todos / Scheduler / Files / ...) swaps the
 // canvas content without collapsing the frame back to the sidebar
 // layout.
-const isStackLayout = computed(
-  () => canvasViewMode.value !== CANVAS_VIEW.single,
-);
-
-// Remember the last chat-oriented view (single or stack) so that
-// selecting a session from a plugin view (Todos / Files / ...) can
-// restore the user's preferred chat layout rather than leaving them
-// on the plugin view.
-const CHAT_VIEWS = [CANVAS_VIEW.single, CANVAS_VIEW.stack] as const;
-type ChatViewMode = (typeof CHAT_VIEWS)[number];
-const isChatView = (m: string): m is ChatViewMode =>
-  (CHAT_VIEWS as readonly string[]).includes(m);
-
-const lastChatViewMode = ref<ChatViewMode>(
-  isChatView(canvasViewMode.value) ? canvasViewMode.value : CANVAS_VIEW.stack,
-);
-watch(canvasViewMode, (mode) => {
-  if (isChatView(mode)) lastChatViewMode.value = mode;
-});
-
-function restoreChatViewForSession(): void {
-  if (!isChatView(canvasViewMode.value)) {
-    setCanvasViewMode(lastChatViewMode.value);
-  }
-}
+const { isStackLayout, restoreChatViewForSession, displayedCurrentSessionId } =
+  useViewLayout({
+    canvasViewMode,
+    setCanvasViewMode,
+    currentSessionId,
+    activePane,
+  });
 
 // User-initiated session switches: clicking a session tab, a history
 // row, or a chat link in FilesView. In plugin views (Todos / Files /
@@ -650,25 +633,6 @@ function handleNewSessionClick(): void {
 }
 
 // In plugin views (Todos / Files / ...) no chat is active, so the
-// session tabs should show no tab as "current". That way clicking
-// any tab — including the session the user was last on — counts as a
-// fresh selection and routes back to the chat view.
-const displayedCurrentSessionId = computed(() =>
-  isChatView(canvasViewMode.value) ? currentSessionId.value : "",
-);
-
-// Keep arrow-key navigation tied to the canvas when the sidebar list
-// doesn't exist (Stack layout has no ToolResultsPanel to navigate),
-// and restore sidebar focus when returning to Single. `immediate`
-// covers the case of an initial stack-style URL (?view=stack, …).
-watch(
-  isStackLayout,
-  (stack) => {
-    activePane.value = stack ? "main" : "sidebar";
-  },
-  { immediate: true },
-);
-
 // Measure the top bar's height whenever the history popup is about
 // to open. Defer to nextTick so the popup's v-if transition doesn't
 // race the measurement.

--- a/src/App.vue
+++ b/src/App.vue
@@ -295,6 +295,7 @@ import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
 import { useDebugBeat } from "./composables/useDebugBeat";
+import { useChatScroll } from "./composables/useChatScroll";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -581,21 +582,12 @@ const historyButtonRef = computed(
 // needs the actual popup DOM element (not the component instance).
 const historyPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const historyPopupRef = computed(() => historyPanelRef.value?.root ?? null);
-function scrollChatToBottom() {
-  nextTick(() => {
-    if (chatListRef.value) {
-      chatListRef.value.scrollTop = chatListRef.value.scrollHeight;
-    }
-  });
-}
-
-watch(() => toolResults.value.length, scrollChatToBottom);
-watch(isRunning, (running) => {
-  if (running) {
-    scrollChatToBottom();
-  } else {
-    nextTick(() => focusChatInput());
-  }
+const toolResultsLength = computed(() => toolResults.value.length);
+useChatScroll({
+  chatListRef,
+  toolResultsLength,
+  isRunning,
+  focusChatInput,
 });
 
 const { showRightSidebar, toggleRightSidebar } = useRightSidebar();

--- a/src/App.vue
+++ b/src/App.vue
@@ -294,6 +294,7 @@ import {
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
+import { useDebugBeat } from "./composables/useDebugBeat";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -328,20 +329,9 @@ const sessionSubscriptions = new Map<string, () => void>();
 const currentSessionId = ref("");
 
 // --- Debug beat (pub/sub) ---
-const debugBeatColor = ref<string | null>(null);
-const debugTitleStyle = computed(() =>
-  debugBeatColor.value ? { color: debugBeatColor.value } : {},
-);
+const { debugTitleStyle } = useDebugBeat();
 
 const { subscribe: pubsubSubscribe } = usePubSub();
-pubsubSubscribe(PUBSUB_CHANNELS.debugBeat, (data) => {
-  const msg = data as { count: number; last?: boolean };
-  if (msg.last) {
-    debugBeatColor.value = null;
-  } else {
-    debugBeatColor.value = msg.count % 2 === 0 ? "#3b82f6" : "#ef4444";
-  }
-});
 
 // --- Sessions channel (pub/sub) ---
 // Subscribe to the global `sessions` channel. The server publishes a

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -1,0 +1,33 @@
+// Auto-scroll the sidebar chat list to the bottom when new results
+// arrive or a run starts. Also re-focuses the chat input when a run
+// finishes.
+
+import { nextTick, watch, type ComputedRef } from "vue";
+
+export function useChatScroll(opts: {
+  chatListRef: ComputedRef<HTMLDivElement | null>;
+  toolResultsLength: ComputedRef<number>;
+  isRunning: ComputedRef<boolean>;
+  focusChatInput: () => void;
+}) {
+  const { chatListRef, toolResultsLength, isRunning, focusChatInput } = opts;
+
+  function scrollChatToBottom(): void {
+    nextTick(() => {
+      if (chatListRef.value) {
+        chatListRef.value.scrollTop = chatListRef.value.scrollHeight;
+      }
+    });
+  }
+
+  watch(toolResultsLength, scrollChatToBottom);
+  watch(isRunning, (running) => {
+    if (running) {
+      scrollChatToBottom();
+    } else {
+      nextTick(() => focusChatInput());
+    }
+  });
+
+  return { scrollChatToBottom };
+}

--- a/src/composables/useDebugBeat.ts
+++ b/src/composables/useDebugBeat.ts
@@ -1,0 +1,25 @@
+// Debug beat indicator — toggles the app title color when the server
+// emits debug-beat events via pub/sub. Only active in --debug mode.
+
+import { ref, computed, type CSSProperties } from "vue";
+import { usePubSub } from "./usePubSub";
+import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
+
+export function useDebugBeat() {
+  const debugBeatColor = ref<string | null>(null);
+  const debugTitleStyle = computed<CSSProperties>(() =>
+    debugBeatColor.value ? { color: debugBeatColor.value } : {},
+  );
+
+  const { subscribe } = usePubSub();
+  subscribe(PUBSUB_CHANNELS.debugBeat, (data) => {
+    const msg = data as { count: number; last?: boolean };
+    if (msg.last) {
+      debugBeatColor.value = null;
+    } else {
+      debugBeatColor.value = msg.count % 2 === 0 ? "#3b82f6" : "#ef4444";
+    }
+  });
+
+  return { debugTitleStyle };
+}

--- a/src/composables/useViewLayout.ts
+++ b/src/composables/useViewLayout.ts
@@ -1,0 +1,62 @@
+// View-layout state: tracks whether the app is in a "stack" layout
+// (full-width canvas) or "single" (sidebar + canvas), remembers the
+// last chat-oriented view mode, and derives displayedCurrentSessionId
+// (blank in plugin views so no tab appears "current").
+
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { CANVAS_VIEW, type CanvasViewMode } from "../utils/canvas/viewMode";
+
+const CHAT_VIEWS = [CANVAS_VIEW.single, CANVAS_VIEW.stack] as const;
+type ChatViewMode = (typeof CHAT_VIEWS)[number];
+
+function isChatView(m: string): m is ChatViewMode {
+  return (CHAT_VIEWS as readonly string[]).includes(m);
+}
+
+export function useViewLayout(opts: {
+  canvasViewMode: Ref<CanvasViewMode> | ComputedRef<CanvasViewMode>;
+  setCanvasViewMode: (mode: CanvasViewMode) => void;
+  currentSessionId: Ref<string>;
+  activePane: Ref<"sidebar" | "main">;
+}) {
+  const { canvasViewMode, setCanvasViewMode, currentSessionId, activePane } =
+    opts;
+
+  const isStackLayout = computed(
+    () => canvasViewMode.value !== CANVAS_VIEW.single,
+  );
+
+  const lastChatViewMode = ref<ChatViewMode>(
+    isChatView(canvasViewMode.value) ? canvasViewMode.value : CANVAS_VIEW.stack,
+  );
+
+  watch(canvasViewMode, (mode) => {
+    if (isChatView(mode)) lastChatViewMode.value = mode;
+  });
+
+  function restoreChatViewForSession(): void {
+    if (!isChatView(canvasViewMode.value)) {
+      setCanvasViewMode(lastChatViewMode.value);
+    }
+  }
+
+  const displayedCurrentSessionId = computed(() =>
+    isChatView(canvasViewMode.value) ? currentSessionId.value : "",
+  );
+
+  // Keep arrow-key navigation tied to the canvas when the sidebar
+  // list doesn't exist (Stack layout has no ToolResultsPanel).
+  watch(
+    isStackLayout,
+    (stack) => {
+      activePane.value = stack ? "main" : "sidebar";
+    },
+    { immediate: true },
+  );
+
+  return {
+    isStackLayout,
+    restoreChatViewForSession,
+    displayedCurrentSessionId,
+  };
+}


### PR DESCRIPTION
## Summary

App.vue から 3 つの composable を抽出 (1242 → 1188 行、-54)。

| Commit | Composable | 内容 |
|---|---|---|
| 1 | useDebugBeat | debugBeatColor + debugTitleStyle + pubsub subscribe |
| 2 | useChatScroll | scrollChatToBottom + watch(toolResults.length) + watch(isRunning) |
| 3 | useViewLayout | isStackLayout + lastChatViewMode + restoreChatViewForSession + displayedCurrentSessionId + activePane sync watch |

PR #513 + #516 からの累計: **1283 → 1188 行 (-95)**。

各 commit は独立して動作。動作変更なし。

## Test plan

- [x] yarn lint — 0 errors
- [x] yarn typecheck — clean
- [x] yarn build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract view layout, chat scroll handling, and debug beat pub/sub logic from App.vue into dedicated composable modules to simplify the root component and encapsulate related behavior.

Enhancements:
- Introduce a useViewLayout composable to manage canvas layout mode, last chat view state, displayed current session ID, and active pane focus behavior.
- Introduce a useChatScroll composable to handle auto-scrolling the chat list and refocusing the chat input around tool runs.
- Introduce a useDebugBeat composable to encapsulate debug beat pub/sub subscription and title style state in debug mode.