### PR TITLE
feat: background generation for MulmoScript

### DIFF
--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -52,13 +52,33 @@ export interface GenerationEvent {
 }
 
 /**
+ * Decomposed view of a pending generation, stored as the *value* of
+ * `pendingGenerations[mapKey]`. Consumers read these fields directly
+ * rather than splitting the composite map key — filePath and user-
+ * defined character keys can contain arbitrary characters, so
+ * positional string parsing is unsafe.
+ */
+export interface PendingGeneration {
+  kind: GenerationKind;
+  filePath: string;
+  key: string;
+}
+
+/**
  * Stable map-key for a generation: the triple (kind, filePath, key).
- * Both server and client use this to update `pendingGenerations`.
+ * Separator is U+001F (UNIT SEPARATOR), a non-printable ASCII control
+ * character that cannot appear in filePaths or user-entered keys —
+ * this guarantees `generationKey(a) === generationKey(b)` iff a≡b,
+ * unlike a human-visible delimiter that could collide.
+ *
+ * The returned string is used only as a map identity. Do NOT split it
+ * to recover the fields — store the decomposed `PendingGeneration`
+ * object as the map value instead.
  */
 export function generationKey(
   kind: GenerationKind,
   filePath: string,
   key: string,
 ): string {
-  return `${kind}:${filePath}:${key}`;
+  return `${kind}\u001f${filePath}\u001f${key}`;
 }

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -16,6 +16,49 @@ export const EVENT_TYPES = {
   sessionFinished: "session_finished",
   sessionMeta: "session_meta",
   rolesUpdated: "roles_updated",
+  generationStarted: "generation_started",
+  generationFinished: "generation_finished",
 } as const;
 
 export type EventType = (typeof EVENT_TYPES)[keyof typeof EVENT_TYPES];
+
+/**
+ * Long-running async work originated by a plugin (MulmoScript etc.)
+ * that continues past the initial HTTP response. The server publishes
+ * a `generationStarted` event when the work begins and a
+ * `generationFinished` event when it completes (or fails). Clients
+ * track the in-flight set in `Session.pendingGenerations` so the UI
+ * can keep a "busy" indicator lit across view navigation.
+ */
+export const GENERATION_KINDS = {
+  beatImage: "beatImage",
+  characterImage: "characterImage",
+  beatAudio: "beatAudio",
+  movie: "movie",
+} as const;
+
+export type GenerationKind =
+  (typeof GENERATION_KINDS)[keyof typeof GENERATION_KINDS];
+
+export interface GenerationEvent {
+  type: "generation_started" | "generation_finished";
+  kind: GenerationKind;
+  /** MulmoScript file path — identifies the script the generation belongs to. */
+  filePath: string;
+  /** beatIndex (as string) for beat*, character key for characterImage, "" for movie. */
+  key: string;
+  /** Only set on generation_finished when the work failed. */
+  error?: string;
+}
+
+/**
+ * Stable map-key for a generation: the triple (kind, filePath, key).
+ * Both server and client use this to update `pendingGenerations`.
+ */
+export function generationKey(
+  kind: GenerationKind,
+  filePath: string,
+  key: string,
+): string {
+  return `${kind}:${filePath}:${key}`;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -13,6 +13,7 @@ export {
   GENERATION_KINDS,
   type GenerationKind,
   type GenerationEvent,
+  type PendingGeneration,
   generationKey,
 } from "./events.js";
 export {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -7,7 +7,14 @@
 //
 // No runtime dependencies. Types + const-only.
 
-export { EVENT_TYPES, type EventType } from "./events.js";
+export {
+  EVENT_TYPES,
+  type EventType,
+  GENERATION_KINDS,
+  type GenerationKind,
+  type GenerationEvent,
+  generationKey,
+} from "./events.js";
 export {
   CHAT_SOCKET_PATH,
   CHAT_SOCKET_EVENTS,

--- a/packages/protocol/test/test_exports.ts
+++ b/packages/protocol/test/test_exports.ts
@@ -22,6 +22,8 @@ describe("@mulmobridge/protocol exports", () => {
       "sessionFinished",
       "sessionMeta",
       "rolesUpdated",
+      "generationStarted",
+      "generationFinished",
     ];
     assert.deepEqual(Object.keys(EVENT_TYPES).sort(), expected.sort());
   });

--- a/plans/feat-background-generation.md
+++ b/plans/feat-background-generation.md
@@ -1,0 +1,324 @@
+# Background Generation for MulmoScript
+
+## Problem
+
+The MulmoScript view (`src/plugins/presentMulmoScript/View.vue`) runs four
+long-running "generate" flows:
+
+| Flow                | Function                          | Route                       |
+| ------------------- | --------------------------------- | --------------------------- |
+| Beat image          | `renderBeat` / `regenerateBeat`   | `mulmoScript.renderBeat`    |
+| Character image     | `renderCharacter`                 | `mulmoScript.renderCharacter` |
+| Beat audio          | `generateAudio`                   | `mulmoScript.generateBeatAudio` |
+| Whole movie         | `generateMovie`                   | `mulmoScript.generateMovie` (SSE) |
+
+All four store their "in progress" state in component-local `reactive` refs
+(`renderState`, `charRenderState`, `audioState`, `movieGenerating`). When the
+user navigates away from the view (switches session, opens a different tool
+result, etc.), the component unmounts and that state is lost. Spinners
+disappear, the movie SSE stream is torn down, and the user has no cross-view
+indication that anything is still happening.
+
+The generation itself continues — the fetch has no `AbortController`, the
+server finishes the job, and files land on disk — so the *result* is not
+lost. Only the *visibility* is.
+
+## Goal
+
+Let the user start a generation, leave the view, and
+
+- see a "busy" indicator in the same place chat completion shows one
+  (`ChatInput`), so they know work is still in flight,
+- return to the MulmoScript view and see completed results without a manual
+  refresh.
+
+Explicitly *in* scope:
+
+- **Switching sessions mid-generation must stay unblocked.** User starts a
+  render in session A, switches to session B, chats freely in B. B's
+  `ChatInput` is not disabled by A's work.
+- **Cross-session visibility.** While on B, the sidebar entry for A shows a
+  "busy" indicator so the user knows A still has work running.
+
+Non-goals:
+
+- Surviving a full app close / reload. If the app closes mid-generation, the
+  "in progress" signal is lost; completed files simply reappear via the
+  existing `loadExistingBeatImage` / `loadExistingBeatAudio` path on next
+  mount.
+- Cancel / abort. Out of scope; follow-up if needed.
+
+## Design
+
+The filesystem is the ledger. Pub/sub is just a nudge — "look again."
+
+### Wire format
+
+Two new event types, flowing through the existing per-session channel
+(`session.${chatSessionId}`, `src/config/pubsubChannels.ts:21`):
+
+```ts
+// packages/protocol/src/events.ts — extend EVENT_TYPES
+generationStarted:  "generation_started",
+generationFinished: "generation_finished",
+
+// payload shape
+interface GenerationEvent {
+  type: "generation_started" | "generation_finished";
+  kind: "beatImage" | "characterImage" | "beatAudio" | "movie";
+  filePath: string;   // MulmoScript file path — scopes the generation
+  key: string;        // beatIndex for beat*, character key for characterImage, "" for movie
+  error?: string;     // only on generation_finished if it failed
+}
+```
+
+The `{kind, filePath, key}` triple is the generation's identity. The client
+uses it both as a map key (for per-beat spinners) and to decide which
+`loadExisting*` to call on completion.
+
+### Server changes
+
+1. **Extend `EVENT_TYPES`** (`packages/protocol/src/events.ts`) with the two
+   new strings.
+
+2. **Plumb `chatSessionId` through generate routes.** The four routes in
+   `server/api/routes/mulmo-script.ts` currently take `{ filePath, … }`.
+   Extend the request body with an optional `chatSessionId`. When present,
+   publish generation events on `sessionChannel(chatSessionId)`.
+
+   > *Optional* because the same routes can be called from contexts
+   > without a session (scripts, tests); absent ID = no events published,
+   > existing behavior preserved.
+
+3. **Add a publish helper** in `server/api/routes/mulmo-script.ts` (or a
+   small `server/events/generation.ts` if it gets reused):
+
+   ```ts
+   function publishGeneration(
+     chatSessionId: string | undefined,
+     kind: GenerationKind,
+     filePath: string,
+     key: string,
+     finished: false,
+   ): void;
+   function publishGeneration(
+     chatSessionId: string | undefined,
+     kind: GenerationKind,
+     filePath: string,
+     key: string,
+     finished: true,
+     error?: string,
+   ): void;
+   ```
+
+   Reaches `publishToSessionChannel` via `pushSessionEvent`
+   (`server/events/session-store/index.ts:166`) so the existing plumbing
+   handles delivery.
+
+4. **Wrap each handler.** In `mulmo-script.ts`, wrap the four handlers
+   (`renderBeat` at L436?/L495? — verify, `renderCharacter`, `generateBeatAudio`,
+   `generateMovie`) so that:
+
+   ```ts
+   publishGeneration(chatSessionId, kind, filePath, key, /*finished*/ false);
+   try {
+     // existing work
+     publishGeneration(chatSessionId, kind, filePath, key, true);
+   } catch (err) {
+     publishGeneration(chatSessionId, kind, filePath, key, true, errorMessage(err));
+     throw;
+   }
+   ```
+
+   `generateMovie` already streams SSE — publish `generation_finished` at
+   the same point it emits its final `done` SSE frame, and
+   `generation_started` at the top of the handler.
+
+5. **Mutate session state in `pushSessionEvent`**
+   (`server/events/session-store/index.ts:166`) so the session summary
+   returned by the sessions REST endpoint carries the in-flight set.
+
+   ```ts
+   interface Session {
+     // existing fields…
+     pendingGenerations: Record<string, GenerationKind>; // key = `${kind}:${filePath}:${key}`
+   }
+   ```
+
+   On `generation_started`: set the entry. On `generation_finished`: delete.
+   Call `notifySessionsChanged()` on both (debounced — see Risk section)
+   so the sidebar refetches `/api/sessions` and shows the indicator on
+   session A while the user is on B.
+
+6. **Merge pending generations into the summary's `isRunning`.** The
+   sessions REST handler (and whatever serializes a `Session` to a
+   `SessionSummary`) should compute:
+
+   ```ts
+   isRunning: session.isRunning || Object.keys(session.pendingGenerations).length > 0
+   ```
+
+   This is what makes cross-session visibility "fall out for free": the
+   sidebar already reads `summary.isRunning` per session, so session A's
+   entry lights up even while the user is on B. No sidebar changes
+   needed.
+
+### Client changes
+
+1. **Extend the client session type** (`src/types/session.ts` or wherever
+   the active-session interface lives) with `pendingGenerations:
+   Record<string, GenerationKind>`. Initialize to `{}`.
+
+2. **Handle the two new events in `applyAgentEvent`**
+   (`src/App.vue` ~L1184). Switch on `event.type`, mutate
+   `activeSession.pendingGenerations`:
+
+   ```ts
+   case EVENT_TYPES.generationStarted:
+     session.pendingGenerations[keyOf(event)] = event.kind;
+     break;
+   case EVENT_TYPES.generationFinished:
+     delete session.pendingGenerations[keyOf(event)];
+     // forward to any listening MulmoScript view — see step 4
+     break;
+   ```
+
+3. **`isRunning` computed stays almost as-is** (`src/App.vue:513`) —
+   `currentSummary.value?.isRunning` already reflects pending
+   generations once the server merges them into the summary (step 6 on
+   the server side). The only change needed is the in-memory fallback
+   for the brief window before the first `/api/sessions` fetch lands:
+
+   ```ts
+   const isRunning = computed(() => {
+     const summary = currentSummary.value;
+     if (summary) return summary.isRunning;
+     const a = activeSession.value;
+     if (!a) return false;
+     return a.isRunning ||
+       Object.keys(a.pendingGenerations ?? {}).length > 0;
+   });
+   ```
+
+   Key semantic: this reads the **active** session's state. Switching to
+   a non-busy session B ⇒ `isRunning` is false ⇒ `ChatInput` in B is
+   unblocked. Session A's busy-ness is visible only via its sidebar
+   entry (driven by `summaries[a].isRunning`, step 6 server-side).
+
+4. **Bridge events into the MulmoScript view.** The view needs to know
+   when *its* generations finish so it can call `loadExistingBeatImage` /
+   `loadExistingBeatAudio` / movie-status refresh. Two options:
+
+   - **Option A (preferred, simpler):** View reads
+     `activeSession.pendingGenerations` via a prop or a shared composable
+     and `watch`es it. When an entry for *its* `filePath` disappears, it
+     calls the matching `loadExisting*`.
+   - **Option B:** App.vue emits a dedicated "generationFinished" signal
+     on a small event bus the view subscribes to. More ceremony; same
+     outcome.
+
+   Go with A.
+
+5. **Drop (or thin out) the local state in `View.vue`.** The view still
+   needs its own state for per-beat error messages and for the
+   drop-to-upload path (which isn't a server-initiated generation), but
+   the "is rendering" booleans should derive from `pendingGenerations`:
+
+   ```ts
+   const renderState = computed<Record<number, RenderState>>(() => {
+     const out: Record<number, RenderState> = {};
+     const pending = session.pendingGenerations ?? {};
+     for (const k of Object.keys(pending)) {
+       const [kind, fp, key] = k.split(":");
+       if (kind === "beatImage" && fp === filePath.value) {
+         out[Number(key)] = "rendering";
+       }
+     }
+     // merge in any local error/done states
+     return out;
+   });
+   ```
+
+   Same pattern for `charRenderState`, `audioState`, `movieGenerating`.
+   Local `renderErrors` / `charErrors` / `audioErrors` stay component-local
+   — errors for completed generations are one-shot and don't need to
+   survive unmount.
+
+6. **Pass `chatSessionId` in request bodies.** View.vue's `renderBeat`,
+   `renderCharacter`, `generateAudio`, `generateMovie` POST bodies get
+   `chatSessionId: activeSessionId.value` (new prop or injection).
+
+### UI
+
+Nothing new to build. Three existing consumers of `SessionSummary.isRunning`
+pick up the new behavior automatically once the server merges
+`pendingGenerations` into the summary:
+
+- `ChatInput` (`src/components/ChatInput.vue:30,48,113`) — disables the
+  input when the *active* session is busy. Switching to a non-busy session
+  unblocks it.
+- `SessionTabBar` (`src/components/SessionTabBar.vue:31,90`) — spins the
+  role icon and tints it yellow on any session with `isRunning === true`.
+  This is the cross-session indicator: session A's tab keeps spinning
+  while the user is on session B.
+- `SessionHistoryPanel` (`src/components/SessionHistoryPanel.vue:177`) —
+  same signal, used in the dropdown list + the `activeSessionCount`
+  yellow badge at `SessionTabBar.vue:50`.
+
+The MulmoScript view still shows per-beat / per-character spinners when
+open; they're now derived from the same `pendingGenerations` map instead
+of component locals, so they survive remount.
+
+## Edge cases
+
+- **Duplicate start events.** If a user hammers "Regenerate," the server
+  publishes `generation_started` twice for the same key. Map-set is
+  idempotent — fine.
+- **Finish event for a generation we never saw start.** Mount-after-start
+  race: view mounts after the start event already fired, or a non-session
+  caller triggered the work. The delete is a no-op; the view still picks
+  up the result via `loadExisting*`. Fine.
+- **App closes mid-generation.** `pendingGenerations` is rebuilt from
+  scratch on next session load (empty). File appears on disk; next visit
+  to the view shows it. Signal lost, result preserved. Matches the
+  "simple" constraint.
+- **Movie SSE stream aborted on unmount.** Today `streamMovieEvents`
+  drives beat reloads as frames arrive. After this change, the SSE stream
+  still runs while the view is open (nice-to-have: faster updates) but
+  the pub/sub events are the load-bearing path. If the user leaves
+  mid-movie, the SSE closes, the server keeps working, and
+  `generation_finished` fires when the movie completes.
+
+## Risk / complexity
+
+- Cognitive complexity on `pushSessionEvent` and `applyAgentEvent` grows;
+  may need to extract per-event-type helpers to stay under the
+  `sonarjs/cognitive-complexity` threshold (15).
+- Need to verify `notifySessionsChanged()` on every generation event
+  isn't too chatty for the sidebar. If it is, gate it behind a debounce
+  or only fire on the set transitioning empty↔non-empty.
+
+## Implementation order
+
+1. Add `EVENT_TYPES.generationStarted` / `generationFinished` +
+   `GenerationEvent` type to `packages/protocol`.
+2. Server: `publishGeneration` helper + wrap the four handlers. Manual
+   smoke-test: watch websocket frames in devtools while rendering a beat.
+3. Server: extend session store with `pendingGenerations`, wire
+   `pushSessionEvent`, expose on the session summary.
+4. Client: extend session type, handle the two events in
+   `applyAgentEvent`, extend `isRunning`.
+5. Client: pass `chatSessionId` in View.vue generate requests.
+6. Client: derive View.vue render/audio/movie state from
+   `pendingGenerations`; drop the matching local refs.
+7. Unit tests for the `pushSessionEvent` branch + client reducer branch.
+8. Manual pass: start a beat render, switch session, confirm ChatInput is
+   busy; switch back, confirm thumbnail appears.
+
+## Out of scope / follow-ups
+
+- Abort / cancel a running generation.
+- Cross-session visibility (e.g., notification badge on session A's
+  sidebar entry while the user is on session B).
+- Persisting `pendingGenerations` across app reloads (would require a
+  server-side job registry keyed by `{filePath, kind, key}`).

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -32,6 +32,8 @@ import {
   validateUpdateScriptBody,
 } from "./mulmoScriptValidate.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { publishGeneration } from "../../events/session-store/index.js";
+import { GENERATION_KINDS } from "../../../src/types/events.js";
 
 const router = Router();
 const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
@@ -72,6 +74,7 @@ interface RenderBeatBody {
   filePath: string;
   beatIndex: number;
   force?: boolean;
+  chatSessionId?: string;
 }
 
 interface UploadBeatImageBody {
@@ -439,90 +442,155 @@ router.post(
     req: Request<
       object,
       object,
-      { filePath: string; beatIndex: number; force?: boolean }
+      {
+        filePath: string;
+        beatIndex: number;
+        force?: boolean;
+        chatSessionId?: string;
+      }
     >,
     res: Response<GenerateBeatAudioResponse>,
   ) => {
-    const { filePath, beatIndex, force } = req.body;
+    const { filePath, beatIndex, force, chatSessionId } = req.body;
 
     if (!filePath || beatIndex === undefined) {
       badRequest(res, "filePath and beatIndex are required");
       return;
     }
 
-    await withStoryContext(
-      res,
+    const key = String(beatIndex);
+    publishGeneration(
+      chatSessionId,
+      GENERATION_KINDS.beatAudio,
       filePath,
-      { force, operation: "generate-beat-audio" },
-      async ({ context }) => {
-        // Thrown errors bubble up to withStoryContext which logs +
-        // returns 500. No inner try/catch needed.
-        await generateBeatAudio(beatIndex, context, {
-          settings: process.env as Record<string, string>,
-        } as Parameters<typeof generateBeatAudio>[2]);
-
-        const beat = context.studio.script.beats[beatIndex];
-        const audioPath =
-          context.studio.beats[beatIndex]?.audioFile ??
-          getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
-
-        if (!audioPath || !fs.existsSync(audioPath)) {
-          // Logic-flow failure (not an exception) — emit a targeted log
-          // with the diagnostic payload before responding. The helper's
-          // catch-all log.warn wouldn't fire for this non-throw path.
-          // Don't write raw `beat.text` into persistent logs — it's
-          // free-form user content and can contain sensitive data.
-          log.error("generate-beat-audio", "audio was not generated", {
-            beatIndex,
-            audioPath,
-            exists: audioPath ? fs.existsSync(audioPath) : false,
-            beatTextLength:
-              typeof beat?.text === "string" ? beat.text.length : 0,
-            audioFilePresent: Boolean(
-              context.studio.beats[beatIndex]?.audioFile,
-            ),
-          });
-          serverError(res, "Audio was not generated");
-          return;
-        }
-
-        res.json({ audio: fileToDataUri(audioPath, "audio/mpeg") });
-      },
+      key,
+      false,
     );
+    let genError: string | undefined;
+    try {
+      await withStoryContext(
+        res,
+        filePath,
+        { force, operation: "generate-beat-audio" },
+        async ({ context }) => {
+          try {
+            await generateBeatAudio(beatIndex, context, {
+              settings: process.env as Record<string, string>,
+            } as Parameters<typeof generateBeatAudio>[2]);
+
+            const beat = context.studio.script.beats[beatIndex];
+            const audioPath =
+              context.studio.beats[beatIndex]?.audioFile ??
+              getBeatAudioPathOrUrl(
+                beat.text ?? "",
+                context,
+                beat,
+                context.lang,
+              );
+
+            if (!audioPath || !fs.existsSync(audioPath)) {
+              // Logic-flow failure (not an exception) — emit a targeted
+              // log. Don't write raw `beat.text` into persistent logs —
+              // it's free-form user content and can contain sensitive
+              // data.
+              log.error("generate-beat-audio", "audio was not generated", {
+                beatIndex,
+                audioPath,
+                exists: audioPath ? fs.existsSync(audioPath) : false,
+                beatTextLength:
+                  typeof beat?.text === "string" ? beat.text.length : 0,
+                audioFilePresent: Boolean(
+                  context.studio.beats[beatIndex]?.audioFile,
+                ),
+              });
+              genError = "Audio was not generated";
+              serverError(res, genError);
+              return;
+            }
+
+            res.json({ audio: fileToDataUri(audioPath, "audio/mpeg") });
+          } catch (err) {
+            genError = errorMessage(err);
+            throw err;
+          }
+        },
+      );
+    } finally {
+      publishGeneration(
+        chatSessionId,
+        GENERATION_KINDS.beatAudio,
+        filePath,
+        key,
+        true,
+        genError,
+      );
+    }
   },
 );
 
 router.post(
   API_ROUTES.mulmoScript.renderBeat,
   async (req: Request<object, object, RenderBeatBody>, res: Response) => {
-    const { filePath, beatIndex, force } = req.body;
+    const { filePath, beatIndex, force, chatSessionId } = req.body;
 
     if (!filePath || beatIndex === undefined) {
       badRequest(res, "filePath and beatIndex are required");
       return;
     }
 
-    await withStoryContext(res, filePath, { force }, async ({ context }) => {
-      await generateBeatImage({
-        index: beatIndex,
-        context,
-        args: force ? { forceImage: true } : undefined,
-      });
+    const key = String(beatIndex);
+    publishGeneration(
+      chatSessionId,
+      GENERATION_KINDS.beatImage,
+      filePath,
+      key,
+      false,
+    );
+    // withStoryContext swallows errors and responds with 500, so we
+    // track failure via a local flag / message rather than try/catch
+    // around the outer call.
+    let genError: string | undefined;
+    try {
+      await withStoryContext(res, filePath, { force }, async ({ context }) => {
+        try {
+          await generateBeatImage({
+            index: beatIndex,
+            context,
+            args: force ? { forceImage: true } : undefined,
+          });
 
-      const { imagePath } = getBeatPngImagePath(context, beatIndex);
-      if (!fs.existsSync(imagePath)) {
-        serverError(res, "Image was not generated");
-        return;
-      }
-      res.json({ image: fileToDataUri(imagePath, "image/png") });
-    });
+          const { imagePath } = getBeatPngImagePath(context, beatIndex);
+          if (!fs.existsSync(imagePath)) {
+            genError = "Image was not generated";
+            serverError(res, genError);
+            return;
+          }
+          res.json({ image: fileToDataUri(imagePath, "image/png") });
+        } catch (err) {
+          genError = errorMessage(err);
+          throw err;
+        }
+      });
+    } finally {
+      publishGeneration(
+        chatSessionId,
+        GENERATION_KINDS.beatImage,
+        filePath,
+        key,
+        true,
+        genError,
+      );
+    }
   },
 );
 
 router.post(
   API_ROUTES.mulmoScript.generateMovie,
-  async (req: Request<object, object, { filePath: string }>, res: Response) => {
-    const { filePath } = req.body;
+  async (
+    req: Request<object, object, { filePath: string; chatSessionId?: string }>,
+    res: Response,
+  ) => {
+    const { filePath, chatSessionId } = req.body;
 
     if (!filePath) {
       badRequest(res, "filePath is required");
@@ -539,10 +607,19 @@ router.post(
     const send = (data: unknown) =>
       res.write(`data: ${JSON.stringify(data)}\n\n`);
 
+    publishGeneration(
+      chatSessionId,
+      GENERATION_KINDS.movie,
+      filePath,
+      "",
+      false,
+    );
+    let genError: string | undefined;
     try {
       const context = await buildContext(absoluteFilePath);
       if (!context) {
-        send({ type: "error", message: "Failed to initialize mulmo context" });
+        genError = "Failed to initialize mulmo context";
+        send({ type: "error", message: genError });
         res.end();
         return;
       }
@@ -580,7 +657,8 @@ router.post(
 
         const outputPath = movieFilePath(audioContext);
         if (!fs.existsSync(outputPath)) {
-          send({ type: "error", message: "Movie was not generated" });
+          genError = "Movie was not generated";
+          send({ type: "error", message: genError });
           res.end();
           return;
         }
@@ -590,8 +668,17 @@ router.post(
         removeSessionProgressCallback(onProgress);
       }
     } catch (err) {
-      send({ type: "error", message: errorMessage(err) });
+      genError = errorMessage(err);
+      send({ type: "error", message: genError });
     } finally {
+      publishGeneration(
+        chatSessionId,
+        GENERATION_KINDS.movie,
+        filePath,
+        "",
+        true,
+        genError,
+      );
       res.end();
     }
   },
@@ -606,6 +693,7 @@ interface RenderCharacterBody {
   filePath: string;
   key: string;
   force?: boolean;
+  chatSessionId?: string;
 }
 
 interface UploadCharacterImageBody {
@@ -671,38 +759,64 @@ router.post(
     req: Request<object, CharacterImageResponse, RenderCharacterBody>,
     res: Response<CharacterImageResponse>,
   ) => {
-    const { filePath, key, force } = req.body;
+    const { filePath, key, force, chatSessionId } = req.body;
 
     if (!filePath || !key) {
       badRequest(res, "filePath and key are required");
       return;
     }
 
-    await withStoryContext(res, filePath, { force }, async ({ context }) => {
-      const images = context.studio.script.imageParams?.images ?? {};
-      const imageEntry = images[key];
-      if (!imageEntry || imageEntry.type !== "imagePrompt") {
-        badRequest(res, `No imagePrompt entry for key: ${key}`);
-        return;
-      }
+    publishGeneration(
+      chatSessionId,
+      GENERATION_KINDS.characterImage,
+      filePath,
+      key,
+      false,
+    );
+    let genError: string | undefined;
+    try {
+      await withStoryContext(res, filePath, { force }, async ({ context }) => {
+        try {
+          const images = context.studio.script.imageParams?.images ?? {};
+          const imageEntry = images[key];
+          if (!imageEntry || imageEntry.type !== "imagePrompt") {
+            genError = `No imagePrompt entry for key: ${key}`;
+            badRequest(res, genError);
+            return;
+          }
 
-      const index = Object.keys(images).indexOf(key);
-      const imagePath = getReferenceImagePath(context, key, "png");
-      fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+          const index = Object.keys(images).indexOf(key);
+          const imagePath = getReferenceImagePath(context, key, "png");
+          fs.mkdirSync(path.dirname(imagePath), { recursive: true });
 
-      await generateReferenceImage({
-        context,
-        key,
-        index,
-        image: imageEntry as MulmoImagePromptMedia,
-        force,
+          await generateReferenceImage({
+            context,
+            key,
+            index,
+            image: imageEntry as MulmoImagePromptMedia,
+            force,
+          });
+          if (!fs.existsSync(imagePath)) {
+            genError = "Character image was not generated";
+            serverError(res, genError);
+            return;
+          }
+          res.json({ image: fileToDataUri(imagePath, "image/png") });
+        } catch (err) {
+          genError = errorMessage(err);
+          throw err;
+        }
       });
-      if (!fs.existsSync(imagePath)) {
-        serverError(res, "Character image was not generated");
-        return;
-      }
-      res.json({ image: fileToDataUri(imagePath, "image/png") });
-    });
+    } finally {
+      publishGeneration(
+        chatSessionId,
+        GENERATION_KINDS.characterImage,
+        filePath,
+        key,
+        true,
+        genError,
+      );
+    }
   },
 );
 

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -154,7 +154,11 @@ export async function loadAllSessions(): Promise<
         if (indexEntry?.keywords !== undefined)
           summary.keywords = indexEntry.keywords;
         if (live) {
-          summary.isRunning = live.isRunning;
+          // Background generations (image/audio/movie) keep the session
+          // "busy" even when the agent turn has ended, so the sidebar
+          // indicator stays lit across view navigation.
+          summary.isRunning =
+            live.isRunning || Object.keys(live.pendingGenerations).length > 0;
           summary.statusMessage = live.statusMessage;
         }
         return {

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -9,6 +9,7 @@ import {
   readSessionMeta as readSessionMetaIO,
   readSessionJsonl,
   sessionJsonlAbsPath,
+  sessionMetaAbsPath,
 } from "../../utils/files/session-io.js";
 import { readManifest } from "../../workspace/chat-index/indexer.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
@@ -132,6 +133,15 @@ export async function loadAllSessions(): Promise<
         const meta = await readSessionMeta(chatDir, id);
         if (!meta) return null;
 
+        // The meta sidecar bumps its mtime on hasUnread / origin
+        // writes — feed it into changeMs so cursor-based refetches
+        // pick up drains of background generations (which only touch
+        // meta, not the jsonl). Missing stat (brand-new session
+        // before its first meta write) contributes 0.
+        const metaMtimeMs = await stat(sessionMetaAbsPath(id))
+          .then((s) => s.mtimeMs)
+          .catch(() => 0);
+
         const indexEntry = indexById.get(id);
         // Prefer AI title → meta.firstUserMessage → empty.
         // `summary` and `keywords` are spread conditionally
@@ -163,7 +173,11 @@ export async function loadAllSessions(): Promise<
         }
         return {
           summary,
-          changeMs: sessionChangeMs(fileStat.mtimeMs, indexEntry?.indexedAt),
+          changeMs: sessionChangeMs(
+            fileStat.mtimeMs,
+            indexEntry?.indexedAt,
+            metaMtimeMs,
+          ),
         };
       } catch {
         return null;

--- a/server/api/routes/sessionsCursor.ts
+++ b/server/api/routes/sessionsCursor.ts
@@ -42,18 +42,27 @@ export function parseCursor(raw: unknown): number {
 }
 
 /**
- * Compute the per-session "change timestamp" in ms — the later of
- * the jsonl mtime (new user/assistant turn) and the chat-index
- * `indexedAt` (AI-generated title / summary updated in the
- * background and doesn't touch the jsonl). Missing / malformed
- * `indexedAt` falls back to the mtime alone.
+ * Compute the per-session "change timestamp" in ms — the latest of:
+ *   - jsonl mtime (new user/assistant turn)
+ *   - chat-index `indexedAt` (AI-generated title / summary, updated in
+ *     the background and doesn't touch the jsonl)
+ *   - meta json mtime (hasUnread flip, origin update — also sidecar
+ *     to the jsonl)
+ *
+ * Missing / malformed `indexedAt` or `metaMtimeMs` contributes 0 so
+ * they don't pull the timestamp backward.
  */
 export function sessionChangeMs(
   jsonlMtimeMs: number,
   indexedAtIso: string | undefined,
+  metaMtimeMs: number | undefined = undefined,
 ): number {
   const indexedAtMs =
     indexedAtIso !== undefined ? new Date(indexedAtIso).getTime() : NaN;
   const safeIndexed = Number.isFinite(indexedAtMs) ? indexedAtMs : 0;
-  return Math.max(jsonlMtimeMs, safeIndexed);
+  const safeMeta =
+    typeof metaMtimeMs === "number" && Number.isFinite(metaMtimeMs)
+      ? metaMtimeMs
+      : 0;
+  return Math.max(jsonlMtimeMs, safeIndexed, safeMeta);
 }

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -15,6 +15,7 @@ import { updateHasUnread } from "../../utils/files/session-io.js";
 import {
   EVENT_TYPES,
   type GenerationKind,
+  type PendingGeneration,
   generationKey,
 } from "../../../src/types/events.js";
 import { ONE_HOUR_MS, ONE_MINUTE_MS } from "../../utils/time.js";
@@ -45,10 +46,12 @@ export interface ServerSession {
   abortRun?: () => void;
   /**
    * In-flight background generations keyed by `generationKey(kind, filePath, key)`.
-   * Non-empty means the session has ongoing work even when `isRunning` (agent turn)
-   * is false — used to keep the busy indicator lit across view navigation.
+   * The value carries the decomposed (kind, filePath, key) so consumers never
+   * have to parse the opaque composite key back out. Non-empty means the
+   * session has ongoing work even when `isRunning` (agent turn) is false —
+   * used to keep the busy indicator lit across view navigation.
    */
-  pendingGenerations: Record<string, GenerationKind>;
+  pendingGenerations: Record<string, PendingGeneration>;
 }
 
 // ── Constants ──────────────────────────────────────────────────
@@ -316,7 +319,7 @@ function updatePendingGenerations(
   const wasEmpty = Object.keys(session.pendingGenerations).length === 0;
 
   if (type === EVENT_TYPES.generationStarted) {
-    session.pendingGenerations[mapKey] = kind;
+    session.pendingGenerations[mapKey] = { kind, filePath, key };
   } else {
     delete session.pendingGenerations[mapKey];
   }

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -191,12 +191,24 @@ export function pushSessionEvent(
   event: Record<string, unknown>,
 ): void {
   const type = event.type as string;
+  const isGenerationEvent =
+    type === EVENT_TYPES.generationStarted ||
+    type === EVENT_TYPES.generationFinished;
 
-  // Delivery to subscribers is always attempted — plugin-initiated
-  // generation events can fire for sessions that aren't in the
-  // in-memory store (loaded from disk, evicted after idle timeout,
-  // etc.). The client's subscription is on the channel, not on any
-  // server-side session object, so the UI still updates.
+  // Non-generation events keep the pre-existing "store or drop"
+  // behavior: toolCall / toolCallResult / status fire only during a
+  // live agent turn (which always has a store entry), and
+  // rolesUpdated / sessionFinished are equally tied to in-store
+  // sessions. Publishing them for evicted sessions would broaden the
+  // wire contract without a concrete need.
+  //
+  // Generation events are the exception — a plugin view (e.g.
+  // MulmoScript) can kick off work on a session whose store entry
+  // never existed or was evicted after idle timeout, and the client
+  // subscription lives on the channel, not on any server-side
+  // session object. We always deliver those so the UI can update.
+  const session = store.get(chatSessionId);
+  if (!session && !isGenerationEvent) return;
   publishToSessionChannel(chatSessionId, event);
 
   const generationDelta = resolveGenerationDelta(chatSessionId, type, event);
@@ -208,7 +220,6 @@ export function pushSessionEvent(
 
   // Drained: flag hasUnread, same semantics as endRun(). Clients
   // viewing the session clear it via markRead.
-  const session = store.get(chatSessionId);
   if (session) {
     session.hasUnread = true;
     // Store is the source of truth, so the refetch already sees the

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -14,6 +14,7 @@ import { log } from "../../system/logger/index.js";
 import { updateHasUnread } from "../../utils/files/session-io.js";
 import {
   EVENT_TYPES,
+  GENERATION_KINDS,
   type GenerationKind,
   type PendingGeneration,
   generationKey,
@@ -243,10 +244,15 @@ function updateStorelessPending(
   type: string,
   event: Record<string, unknown>,
 ): GenerationDelta {
-  const kind = event.kind as GenerationKind;
-  const filePath = event.filePath as string;
-  const key = event.key as string;
-  const mapKey = generationKey(kind, filePath, key);
+  const payload = parseGenerationPayload(event);
+  if (!payload) {
+    log.warn("session-store", "malformed generation event", {
+      chatSessionId,
+      type,
+    });
+    return "same";
+  }
+  const mapKey = generationKey(payload.kind, payload.filePath, payload.key);
   const existing = storelessPending.get(chatSessionId);
   const wasEmpty = !existing || existing.size === 0;
 
@@ -276,6 +282,36 @@ function updateStorelessPending(
  * and whether to flip hasUnread on drain.
  */
 type GenerationDelta = "started" | "drained" | "same";
+
+/** Fields pulled off a validated generation event. */
+interface GenerationPayload {
+  kind: GenerationKind;
+  filePath: string;
+  key: string;
+}
+
+const GENERATION_KIND_VALUES: ReadonlySet<string> = new Set(
+  Object.values(GENERATION_KINDS),
+);
+
+function isGenerationKind(v: unknown): v is GenerationKind {
+  return typeof v === "string" && GENERATION_KIND_VALUES.has(v);
+}
+
+/**
+ * Narrow an event's generation fields at runtime. The event arrives
+ * as `Record<string, unknown>` so we can't trust its shape — validate
+ * every field before handing back a typed struct. Unknown kinds or
+ * missing fields return null; the caller should log + no-op.
+ */
+function parseGenerationPayload(
+  event: Record<string, unknown>,
+): GenerationPayload | null {
+  const { kind, filePath, key } = event;
+  if (!isGenerationKind(kind)) return null;
+  if (typeof filePath !== "string" || typeof key !== "string") return null;
+  return { kind, filePath, key };
+}
 
 function applyEventToSession(
   session: ServerSession,
@@ -312,14 +348,19 @@ function updatePendingGenerations(
   type: string,
   event: Record<string, unknown>,
 ): GenerationDelta {
-  const kind = event.kind as GenerationKind;
-  const filePath = event.filePath as string;
-  const key = event.key as string;
-  const mapKey = generationKey(kind, filePath, key);
+  const payload = parseGenerationPayload(event);
+  if (!payload) {
+    log.warn("session-store", "malformed generation event", {
+      chatSessionId: session.chatSessionId,
+      type,
+    });
+    return "same";
+  }
+  const mapKey = generationKey(payload.kind, payload.filePath, payload.key);
   const wasEmpty = Object.keys(session.pendingGenerations).length === 0;
 
   if (type === EVENT_TYPES.generationStarted) {
-    session.pendingGenerations[mapKey] = { kind, filePath, key };
+    session.pendingGenerations[mapKey] = payload;
   } else {
     delete session.pendingGenerations[mapKey];
   }

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -201,21 +201,29 @@ export function pushSessionEvent(
 
   const generationDelta = resolveGenerationDelta(chatSessionId, type, event);
   if (generationDelta === "same") return;
-
-  // When the last pending generation completes, flag the session as
-  // unread — same semantics as endRun(): "something for the user to
-  // notice". Clients viewing the session clear it via markRead.
-  if (generationDelta === "drained") {
-    const session = store.get(chatSessionId);
-    if (session) session.hasUnread = true;
-    persistHasUnread(chatSessionId, true);
+  if (generationDelta === "started") {
+    notifySessionsChanged();
+    return;
   }
 
-  // A generation starting or finishing changes the session summary's
-  // isRunning flag, so the sidebar needs to refetch. We fire on both
-  // transitions (started and drained) so the sidebar indicator and
-  // hasUnread both propagate without waiting for a later refetch.
-  notifySessionsChanged();
+  // Drained: flag hasUnread, same semantics as endRun(). Clients
+  // viewing the session clear it via markRead.
+  const session = store.get(chatSessionId);
+  if (session) {
+    session.hasUnread = true;
+    // Store is the source of truth, so the refetch already sees the
+    // flag via `live.hasUnread` — the disk write is just a backstop
+    // across server restarts and can stay fire-and-forget.
+    void persistHasUnread(chatSessionId, true);
+    notifySessionsChanged();
+    return;
+  }
+
+  // Storeless: meta.hasUnread on disk is the ONLY place the flag lives.
+  // If we notified before the write completed, the client's refetch
+  // would read the stale pre-drain value. Sequence: persist, then
+  // notify.
+  void persistHasUnread(chatSessionId, true).then(notifySessionsChanged);
 }
 
 /**

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -12,7 +12,11 @@ import {
 } from "../../../src/config/pubsubChannels.js";
 import { log } from "../../system/logger/index.js";
 import { updateHasUnread } from "../../utils/files/session-io.js";
-import { EVENT_TYPES } from "../../../src/types/events.js";
+import {
+  EVENT_TYPES,
+  type GenerationKind,
+  generationKey,
+} from "../../../src/types/events.js";
 import { ONE_HOUR_MS, ONE_MINUTE_MS } from "../../utils/time.js";
 
 // ── Types ──────────────────────────────────────────────────────
@@ -39,6 +43,12 @@ export interface ServerSession {
   updatedAt: string;
   /** Kills the spawned Claude CLI process for this session. */
   abortRun?: () => void;
+  /**
+   * In-flight background generations keyed by `generationKey(kind, filePath, key)`.
+   * Non-empty means the session has ongoing work even when `isRunning` (agent turn)
+   * is false — used to keep the busy indicator lit across view navigation.
+   */
+  pendingGenerations: Record<string, GenerationKind>;
 }
 
 // ── Constants ──────────────────────────────────────────────────
@@ -49,6 +59,14 @@ const EVICTION_CHECK_INTERVAL_MS = 5 * ONE_MINUTE_MS;
 // ── Store ──────────────────────────────────────────────────────
 
 const store = new Map<string, ServerSession>();
+/**
+ * Parallel pending-generation tracking for sessions that aren't in the
+ * in-memory store. The MulmoScript view can be opened on a session
+ * whose full ServerSession entry never existed or was evicted after
+ * idle timeout — we still want to mark unread and fire
+ * notifySessionsChanged when the work drains. Cleared on drain.
+ */
+const storelessPending = new Map<string, Set<string>>();
 let pubsub: IPubSub | null = null;
 let evictionTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -92,6 +110,7 @@ export function getOrCreateSession(
     selectedImageData: opts.selectedImageData,
     startedAt: opts.startedAt,
     updatedAt: opts.updatedAt,
+    pendingGenerations: {},
   };
   store.set(chatSessionId, session);
   return session;
@@ -167,11 +186,99 @@ export function pushSessionEvent(
   chatSessionId: string,
   event: Record<string, unknown>,
 ): void {
-  const session = store.get(chatSessionId);
-  if (!session) return;
-
   const type = event.type as string;
 
+  // Delivery to subscribers is always attempted — plugin-initiated
+  // generation events can fire for sessions that aren't in the
+  // in-memory store (loaded from disk, evicted after idle timeout,
+  // etc.). The client's subscription is on the channel, not on any
+  // server-side session object, so the UI still updates.
+  publishToSessionChannel(chatSessionId, event);
+
+  const generationDelta = resolveGenerationDelta(chatSessionId, type, event);
+  if (generationDelta === "same") return;
+
+  // When the last pending generation completes, flag the session as
+  // unread — same semantics as endRun(): "something for the user to
+  // notice". Clients viewing the session clear it via markRead.
+  if (generationDelta === "drained") {
+    const session = store.get(chatSessionId);
+    if (session) session.hasUnread = true;
+    persistHasUnread(chatSessionId, true);
+  }
+
+  // A generation starting or finishing changes the session summary's
+  // isRunning flag, so the sidebar needs to refetch. We fire on both
+  // transitions (started and drained) so the sidebar indicator and
+  // hasUnread both propagate without waiting for a later refetch.
+  notifySessionsChanged();
+}
+
+/**
+ * Dispatch the event to whichever pending tracker the session has.
+ * Returns the empty↔non-empty transition so the caller can decide
+ * whether to flip hasUnread and notify.
+ */
+function resolveGenerationDelta(
+  chatSessionId: string,
+  type: string,
+  event: Record<string, unknown>,
+): GenerationDelta {
+  const session = store.get(chatSessionId);
+  if (session) return applyEventToSession(session, type, event);
+  if (
+    type === EVENT_TYPES.generationStarted ||
+    type === EVENT_TYPES.generationFinished
+  ) {
+    return updateStorelessPending(chatSessionId, type, event);
+  }
+  return "same";
+}
+
+function updateStorelessPending(
+  chatSessionId: string,
+  type: string,
+  event: Record<string, unknown>,
+): GenerationDelta {
+  const kind = event.kind as GenerationKind;
+  const filePath = event.filePath as string;
+  const key = event.key as string;
+  const mapKey = generationKey(kind, filePath, key);
+  const existing = storelessPending.get(chatSessionId);
+  const wasEmpty = !existing || existing.size === 0;
+
+  if (type === EVENT_TYPES.generationStarted) {
+    const set = existing ?? new Set<string>();
+    set.add(mapKey);
+    if (!existing) storelessPending.set(chatSessionId, set);
+  } else if (existing) {
+    existing.delete(mapKey);
+    if (existing.size === 0) storelessPending.delete(chatSessionId);
+  }
+
+  const isEmpty = (storelessPending.get(chatSessionId)?.size ?? 0) === 0;
+  if (wasEmpty === isEmpty) return "same";
+  return isEmpty ? "drained" : "started";
+}
+
+/**
+ * How a generation event affected the session's pendingGenerations set:
+ *
+ * - `started`: empty → non-empty (first generation in a quiet session)
+ * - `drained`: non-empty → empty (last pending generation finished)
+ * - `same`: no transition (parallel starts/finishes within a burst,
+ *   or a non-generation event type)
+ *
+ * Callers use this to decide whether to fire `notifySessionsChanged()`
+ * and whether to flip hasUnread on drain.
+ */
+type GenerationDelta = "started" | "drained" | "same";
+
+function applyEventToSession(
+  session: ServerSession,
+  type: string,
+  event: Record<string, unknown>,
+): GenerationDelta {
   if (type === EVENT_TYPES.toolCall) {
     session.toolCallHistory.push({
       toolUseId: event.toolUseId as string,
@@ -188,9 +295,62 @@ export function pushSessionEvent(
     session.statusMessage = event.message as string;
     // No notifySessionsChanged() here — status updates are high-frequency
     // and flow to subscribed clients via the session.<id> channel directly.
+  } else if (
+    type === EVENT_TYPES.generationStarted ||
+    type === EVENT_TYPES.generationFinished
+  ) {
+    return updatePendingGenerations(session, type, event);
+  }
+  return "same";
+}
+
+function updatePendingGenerations(
+  session: ServerSession,
+  type: string,
+  event: Record<string, unknown>,
+): GenerationDelta {
+  const kind = event.kind as GenerationKind;
+  const filePath = event.filePath as string;
+  const key = event.key as string;
+  const mapKey = generationKey(kind, filePath, key);
+  const wasEmpty = Object.keys(session.pendingGenerations).length === 0;
+
+  if (type === EVENT_TYPES.generationStarted) {
+    session.pendingGenerations[mapKey] = kind;
+  } else {
+    delete session.pendingGenerations[mapKey];
   }
 
-  publishToSessionChannel(chatSessionId, event);
+  const isEmpty = Object.keys(session.pendingGenerations).length === 0;
+  if (wasEmpty === isEmpty) return "same";
+  return isEmpty ? "drained" : "started";
+}
+
+/**
+ * Convenience wrapper for plugin routes that run long async jobs.
+ * Publishes a generationStarted or generationFinished event on the
+ * session channel. Safely no-ops when chatSessionId is missing — lets
+ * callers that aren't inside a session context use the same routes.
+ */
+export function publishGeneration(
+  chatSessionId: string | undefined,
+  kind: GenerationKind,
+  filePath: string,
+  key: string,
+  finished: boolean,
+  error?: string,
+): void {
+  if (!chatSessionId) return;
+  const event: Record<string, unknown> = {
+    type: finished
+      ? EVENT_TYPES.generationFinished
+      : EVENT_TYPES.generationStarted,
+    kind,
+    filePath,
+    key,
+  };
+  if (error) event.error = error;
+  pushSessionEvent(chatSessionId, event);
 }
 
 export type PushToolResultOutcome =
@@ -313,6 +473,7 @@ function evictIdleSessions(): void {
  */
 export function __resetForTests(): void {
   store.clear();
+  storelessPending.clear();
   pubsub = null;
   if (evictionTimer) {
     clearInterval(evictionTimer);

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -214,7 +214,7 @@ export function pushSessionEvent(
     // Store is the source of truth, so the refetch already sees the
     // flag via `live.hasUnread` — the disk write is just a backstop
     // across server restarts and can stay fire-and-forget.
-    void persistHasUnread(chatSessionId, true);
+    persistHasUnread(chatSessionId, true).catch(() => {});
     notifySessionsChanged();
     return;
   }
@@ -223,7 +223,9 @@ export function pushSessionEvent(
   // If we notified before the write completed, the client's refetch
   // would read the stale pre-drain value. Sequence: persist, then
   // notify.
-  void persistHasUnread(chatSessionId, true).then(notifySessionsChanged);
+  persistHasUnread(chatSessionId, true)
+    .catch(() => {})
+    .then(() => notifySessionsChanged());
 }
 
 /**

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -152,6 +152,16 @@ export function sessionJsonlAbsPath(id: string, r?: string): string {
   return resolvePath(root(r), jsonlRel(id));
 }
 
+/**
+ * Resolve the absolute path of a session's metadata JSON file. The
+ * jsonl variant is the event log; this one is the sidecar that holds
+ * `hasUnread`, `roleId`, `startedAt`, `origin`, etc. Its mtime bumps
+ * whenever any of those fields change via `writeSessionMeta`.
+ */
+export function sessionMetaAbsPath(id: string, r?: string): string {
+  return resolvePath(root(r), metaRel(id));
+}
+
 export async function readSessionJsonl(
   id: string,
   r?: string,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1302,7 +1302,11 @@ async function applyAgentEvent(
       return;
     case EVENT_TYPES.generationStarted: {
       const mapKey = generationKey(event.kind, event.filePath, event.key);
-      session.pendingGenerations[mapKey] = event.kind;
+      session.pendingGenerations[mapKey] = {
+        kind: event.kind,
+        filePath: event.filePath,
+        key: event.key,
+      };
       return;
     }
     case EVENT_TYPES.generationFinished: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -270,7 +270,7 @@ import {
   type SessionEntry,
   type ActiveSession,
 } from "./types/session";
-import { EVENT_TYPES } from "./types/events";
+import { EVENT_TYPES, generationKey } from "./types/events";
 import { extractImageData, makeTextResult } from "./utils/tools/result";
 import { findScrollableChild } from "./utils/dom/scrollable";
 import { buildAgentRequestBody } from "./utils/agent/request";
@@ -298,6 +298,7 @@ import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
 import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
+import { provideActiveSession } from "./composables/useActiveSession";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import { apiGet, apiPost, apiFetchRaw } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
@@ -510,10 +511,20 @@ const sidebarResults = computed(() => {
 const currentSummary = computed(() =>
   sessions.value.find((s) => s.id === currentSessionId.value),
 );
-const isRunning = computed(
-  () =>
-    currentSummary.value?.isRunning ?? activeSession.value?.isRunning ?? false,
-);
+// The server-side summary already merges pendingGenerations into
+// `isRunning` (see server/api/routes/sessions.ts), but pub/sub events
+// for background generations arrive faster than the next sessions
+// refetch — fold the in-memory map in so ChatInput reflects the new
+// state immediately.
+const isRunning = computed(() => {
+  const active = activeSession.value;
+  const pending = active
+    ? Object.keys(active.pendingGenerations).length > 0
+    : false;
+  return (
+    currentSummary.value?.isRunning || active?.isRunning || pending || false
+  );
+});
 const statusMessage = computed(
   () =>
     currentSummary.value?.statusMessage ??
@@ -762,10 +773,17 @@ watch(currentSessionId, (id) => {
   if (session) {
     ensureSessionSubscription(session);
   }
-  // Unsubscribe from the previous session if it's not running
+  // Unsubscribe from the previous session if it's not running and has
+  // no in-flight background generations. Tearing down the subscription
+  // while a generation is still running would orphan its completion
+  // event, leaving the session's busy indicator stuck on.
   if (previousSessionId && previousSessionId !== id) {
     const prevSession = sessionMap.get(previousSessionId);
-    if (prevSession && !prevSession.isRunning) {
+    const prevBusy =
+      !!prevSession &&
+      (prevSession.isRunning ||
+        Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
+    if (prevSession && !prevBusy) {
       unsubscribeSession(previousSessionId);
     }
   }
@@ -919,6 +937,7 @@ function createNewSession(roleId?: string): ActiveSession {
     startedAt: now,
     updatedAt: now,
     runStartIndex: 0,
+    pendingGenerations: {},
   };
   sessionMap.set(id, session);
   navigateToSession(id, true);
@@ -1043,6 +1062,7 @@ async function loadSession(id: string) {
     startedAt,
     updatedAt,
     runStartIndex: toolResultsList.length,
+    pendingGenerations: {},
   };
   sessionMap.set(id, newSession);
   // Subscribe immediately — the watch(currentSessionId) may have
@@ -1135,7 +1155,13 @@ function ensureSessionSubscription(session: ActiveSession): void {
       if (currentSessionId.value === session.id) {
         markSessionRead(session.id);
       } else {
-        unsubscribeSession(session.id);
+        // Keep the subscription alive if background generations are
+        // still in flight — otherwise their completion events would
+        // be lost and the busy indicator would stay stuck.
+        const live = sessionMap.get(session.id);
+        const hasPending =
+          !!live && Object.keys(live.pendingGenerations ?? {}).length > 0;
+        if (!hasPending) unsubscribeSession(session.id);
       }
       return;
     }
@@ -1274,6 +1300,23 @@ async function applyAgentEvent(
     case EVENT_TYPES.sessionFinished:
       // Handled in the subscription callback — no-op here.
       return;
+    case EVENT_TYPES.generationStarted: {
+      const mapKey = generationKey(event.kind, event.filePath, event.key);
+      session.pendingGenerations[mapKey] = event.kind;
+      return;
+    }
+    case EVENT_TYPES.generationFinished: {
+      const mapKey = generationKey(event.kind, event.filePath, event.key);
+      delete session.pendingGenerations[mapKey];
+      // When the last pending generation drains and the user is
+      // actively viewing this session, clear the unread flag server
+      // set on drain. Mirrors the sessionFinished handler.
+      const drained = Object.keys(session.pendingGenerations).length === 0;
+      if (drained && currentSessionId.value === session.id) {
+        markSessionRead(session.id);
+      }
+      return;
+    }
   }
 }
 
@@ -1343,6 +1386,9 @@ provideAppApi({
   refreshRoles,
   sendMessage: (message: string) => sendMessage(message),
 });
+// Plugin Views that need to tag background work with the current
+// session (e.g. MulmoScript generations) inject this.
+provideActiveSession(activeSession);
 
 useEventListeners({
   onKeyNavigation: handleKeyNavigation,

--- a/src/composables/useActiveSession.ts
+++ b/src/composables/useActiveSession.ts
@@ -1,0 +1,40 @@
+// Provide/inject contract for the currently-active chat session.
+//
+// Plugin Views (e.g. MulmoScript) need two things from the app-level
+// session state:
+//
+//   1. The `chatSessionId` so they can tag long-running work (image /
+//      audio / movie generation) on the right session channel.
+//   2. A reactive view of `pendingGenerations` so they can derive
+//      per-beat / per-character "rendering" spinners from the same
+//      map the sidebar busy-indicator reads. This lets the spinner
+//      survive View unmount/remount across session switches.
+//
+// Rather than thread two new props through every plugin's
+// `<component :is="...">` mount point, we expose the active session
+// via provide/inject — same pattern as useAppApi.
+
+import { inject, provide, type Ref } from "vue";
+import type { ActiveSession } from "../types/session";
+
+/**
+ * Ref to the currently-active session. May be `undefined` during the
+ * brief window before the first session loads.
+ */
+export type ActiveSessionRef = Ref<ActiveSession | undefined>;
+
+const ACTIVE_SESSION_KEY = Symbol("activeSession");
+
+/** Called once in App.vue setup to expose the ref to descendants. */
+export function provideActiveSession(ref: ActiveSessionRef): void {
+  provide(ACTIVE_SESSION_KEY, ref);
+}
+
+/**
+ * Plugin Views call this to observe the active session. Returns
+ * `undefined` when used outside an App.vue subtree (e.g. in a unit
+ * test) so plugins can render standalone without the provider.
+ */
+export function useActiveSession(): ActiveSessionRef | undefined {
+  return inject<ActiveSessionRef>(ACTIVE_SESSION_KEY);
+}

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -579,7 +579,7 @@ import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 import { useActiveSession } from "../../composables/useActiveSession";
-import { GENERATION_KINDS } from "../../types/events";
+import { GENERATION_KINDS, type PendingGeneration } from "../../types/events";
 
 interface Beat {
   speaker?: string;
@@ -673,16 +673,13 @@ const characterKeys = computed(() => {
 const activeSessionRef = useActiveSession();
 const chatSessionId = computed(() => activeSessionRef?.value?.id);
 
-const pendingForThisScript = computed<Record<string, true>>(() => {
-  const out: Record<string, true> = {};
+const pendingForThisScript = computed(() => {
+  const out: Record<string, PendingGeneration> = {};
   const pending = activeSessionRef?.value?.pendingGenerations ?? {};
   const fp = filePath.value;
   if (!fp) return out;
-  for (const key of Object.keys(pending)) {
-    const parts = key.split(":");
-    if (parts.length >= 3 && parts[1] === fp) {
-      out[key] = true;
-    }
+  for (const [mapKey, entry] of Object.entries(pending)) {
+    if (entry.filePath === fp) out[mapKey] = entry;
   }
   return out;
 });
@@ -1220,8 +1217,8 @@ async function initializeScript() {
 
   // Reflect any generations that were already in flight when we
   // mounted (user switched away mid-generation and came back).
-  for (const key of Object.keys(pendingForThisScript.value)) {
-    reflectGenerationStart(key);
+  for (const entry of Object.values(pendingForThisScript.value)) {
+    reflectGenerationStart(entry);
   }
 }
 
@@ -1229,48 +1226,50 @@ onMounted(initializeScript);
 watch(() => props.selectedResult, initializeScript);
 
 // Keep the view in sync with generations that started from a different
-// view mount or a parallel tab. When a generation key for this script
+// view mount or a parallel tab. When a generation for this script
 // disappears from session.pendingGenerations we reload the relevant
 // artifact off disk; when one appears we mirror it into the local
 // "rendering" state so spinners show even after a remount.
 watch(pendingForThisScript, (now, prev = {}) => {
-  for (const key of Object.keys(now)) {
-    if (!(key in prev)) reflectGenerationStart(key);
+  for (const [mapKey, entry] of Object.entries(now)) {
+    if (!(mapKey in prev)) reflectGenerationStart(entry);
   }
-  for (const key of Object.keys(prev)) {
-    if (!(key in now)) reflectGenerationFinish(key);
+  for (const [mapKey, entry] of Object.entries(prev)) {
+    if (!(mapKey in now)) reflectGenerationFinish(entry);
   }
 });
 
-function reflectGenerationStart(key: string): void {
-  const [kind, , tail] = key.split(":");
-  if (kind === GENERATION_KINDS.beatImage) {
-    const idx = Number(tail);
+function reflectGenerationStart(entry: PendingGeneration): void {
+  if (entry.kind === GENERATION_KINDS.beatImage) {
+    const idx = Number(entry.key);
     if (!renderedImages[idx]) renderState[idx] = "rendering";
-  } else if (kind === GENERATION_KINDS.beatAudio) {
-    const idx = Number(tail);
+  } else if (entry.kind === GENERATION_KINDS.beatAudio) {
+    const idx = Number(entry.key);
     if (!beatAudios[idx]) audioState[idx] = "generating";
-  } else if (kind === GENERATION_KINDS.characterImage) {
-    if (!charImages[tail]) charRenderState[tail] = "rendering";
-  } else if (kind === GENERATION_KINDS.movie) {
+  } else if (entry.kind === GENERATION_KINDS.characterImage) {
+    if (!charImages[entry.key]) charRenderState[entry.key] = "rendering";
+  } else if (entry.kind === GENERATION_KINDS.movie) {
     movieGenerating.value = true;
   }
 }
 
-async function reflectGenerationFinish(key: string): Promise<void> {
-  const [kind, , tail] = key.split(":");
-  if (kind === GENERATION_KINDS.beatImage) {
-    const idx = Number(tail);
+async function reflectGenerationFinish(
+  entry: PendingGeneration,
+): Promise<void> {
+  if (entry.kind === GENERATION_KINDS.beatImage) {
+    const idx = Number(entry.key);
     await loadExistingBeatImage(idx);
     if (renderState[idx] === "rendering") delete renderState[idx];
-  } else if (kind === GENERATION_KINDS.beatAudio) {
-    const idx = Number(tail);
+  } else if (entry.kind === GENERATION_KINDS.beatAudio) {
+    const idx = Number(entry.key);
     await loadExistingBeatAudio(idx);
     if (audioState[idx] === "generating") delete audioState[idx];
-  } else if (kind === GENERATION_KINDS.characterImage) {
-    await loadExistingCharacterImage(tail);
-    if (charRenderState[tail] === "rendering") delete charRenderState[tail];
-  } else if (kind === GENERATION_KINDS.movie) {
+  } else if (entry.kind === GENERATION_KINDS.characterImage) {
+    await loadExistingCharacterImage(entry.key);
+    if (charRenderState[entry.key] === "rendering") {
+      delete charRenderState[entry.key];
+    }
+  } else if (entry.kind === GENERATION_KINDS.movie) {
     movieGenerating.value = false;
     await refreshMoviePath();
   }

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -1235,7 +1235,14 @@ watch(pendingForThisScript, (now, prev = {}) => {
     if (!(mapKey in prev)) reflectGenerationStart(entry);
   }
   for (const [mapKey, entry] of Object.entries(prev)) {
-    if (!(mapKey in now)) reflectGenerationFinish(entry);
+    if (!(mapKey in now)) {
+      // Fire-and-forget: the watcher callback must stay sync so Vue
+      // can batch multiple pendingGenerations updates. Swallow + log
+      // so a failed reload doesn't surface as an unhandled rejection.
+      reflectGenerationFinish(entry).catch((err) => {
+        console.error("[presentMulmoScript] reload on finish failed:", err);
+      });
+    }
   }
 });
 

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -578,6 +578,8 @@ import { apiGet, apiPost, apiFetchRaw } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
+import { useActiveSession } from "../../composables/useActiveSession";
+import { GENERATION_KINDS } from "../../types/events";
 
 interface Beat {
   speaker?: string;
@@ -664,6 +666,31 @@ const characterKeys = computed(() => {
   const imgs = script.value.imageParams?.images ?? {};
   return Object.keys(imgs).filter((k) => imgs[k]?.type === "imagePrompt");
 });
+
+// Session-scoped pending generations — lets spinners survive view
+// unmount/remount and tags new generations on the correct session
+// channel so the cross-session sidebar indicator stays lit.
+const activeSessionRef = useActiveSession();
+const chatSessionId = computed(() => activeSessionRef?.value?.id);
+
+const pendingForThisScript = computed<Record<string, true>>(() => {
+  const out: Record<string, true> = {};
+  const pending = activeSessionRef?.value?.pendingGenerations ?? {};
+  const fp = filePath.value;
+  if (!fp) return out;
+  for (const key of Object.keys(pending)) {
+    const parts = key.split(":");
+    if (parts.length >= 3 && parts[1] === fp) {
+      out[key] = true;
+    }
+  }
+  return out;
+});
+
+// Local renderState / charRenderState / audioState / movieGenerating
+// are kept in sync with `pendingForThisScript` by the watcher below
+// and by `initializeScript`, so the template continues to read them
+// without needing per-kind predicates here.
 
 function characterPrompt(key: string): string {
   return (script.value.imageParams?.images?.[key]?.prompt as string) ?? "";
@@ -849,7 +876,11 @@ async function renderBeat(index: number) {
   renderState[index] = "rendering";
   const response = await apiPost<{ image?: string; error?: string }>(
     API_ROUTES.mulmoScript.renderBeat,
-    { filePath: filePath.value, beatIndex: index },
+    {
+      filePath: filePath.value,
+      beatIndex: index,
+      chatSessionId: chatSessionId.value,
+    },
   );
   if (!response.ok) {
     renderErrors[index] = response.error || "Render failed";
@@ -871,7 +902,12 @@ async function regenerateBeat(index: number) {
   renderState[index] = "rendering";
   const response = await apiPost<{ image?: string; error?: string }>(
     API_ROUTES.mulmoScript.renderBeat,
-    { filePath: filePath.value, beatIndex: index, force: true },
+    {
+      filePath: filePath.value,
+      beatIndex: index,
+      force: true,
+      chatSessionId: chatSessionId.value,
+    },
   );
   if (!response.ok) {
     renderErrors[index] = response.error || "Render failed";
@@ -916,7 +952,11 @@ async function generateAudio(index: number) {
   delete audioErrors[index];
   const response = await apiPost<{ audio?: string; error?: string }>(
     API_ROUTES.mulmoScript.generateBeatAudio,
-    { filePath: filePath.value, beatIndex: index },
+    {
+      filePath: filePath.value,
+      beatIndex: index,
+      chatSessionId: chatSessionId.value,
+    },
   );
   if (!response.ok) {
     audioErrors[index] = response.error || "Audio generation failed";
@@ -1097,7 +1137,12 @@ async function renderCharacter(key: string, force: boolean) {
   delete charErrors[key];
   const response = await apiPost<{ image?: string; error?: string }>(
     API_ROUTES.mulmoScript.renderCharacter,
-    { filePath: filePath.value, key, force },
+    {
+      filePath: filePath.value,
+      key,
+      force,
+      chatSessionId: chatSessionId.value,
+    },
   );
   if (!response.ok) {
     charErrors[key] = response.error || "Render failed";
@@ -1172,17 +1217,85 @@ async function initializeScript() {
     }
     // ignore errors
   }
+
+  // Reflect any generations that were already in flight when we
+  // mounted (user switched away mid-generation and came back).
+  for (const key of Object.keys(pendingForThisScript.value)) {
+    reflectGenerationStart(key);
+  }
 }
 
 onMounted(initializeScript);
 watch(() => props.selectedResult, initializeScript);
+
+// Keep the view in sync with generations that started from a different
+// view mount or a parallel tab. When a generation key for this script
+// disappears from session.pendingGenerations we reload the relevant
+// artifact off disk; when one appears we mirror it into the local
+// "rendering" state so spinners show even after a remount.
+watch(pendingForThisScript, (now, prev = {}) => {
+  for (const key of Object.keys(now)) {
+    if (!(key in prev)) reflectGenerationStart(key);
+  }
+  for (const key of Object.keys(prev)) {
+    if (!(key in now)) reflectGenerationFinish(key);
+  }
+});
+
+function reflectGenerationStart(key: string): void {
+  const [kind, , tail] = key.split(":");
+  if (kind === GENERATION_KINDS.beatImage) {
+    const idx = Number(tail);
+    if (!renderedImages[idx]) renderState[idx] = "rendering";
+  } else if (kind === GENERATION_KINDS.beatAudio) {
+    const idx = Number(tail);
+    if (!beatAudios[idx]) audioState[idx] = "generating";
+  } else if (kind === GENERATION_KINDS.characterImage) {
+    if (!charImages[tail]) charRenderState[tail] = "rendering";
+  } else if (kind === GENERATION_KINDS.movie) {
+    movieGenerating.value = true;
+  }
+}
+
+async function reflectGenerationFinish(key: string): Promise<void> {
+  const [kind, , tail] = key.split(":");
+  if (kind === GENERATION_KINDS.beatImage) {
+    const idx = Number(tail);
+    await loadExistingBeatImage(idx);
+    if (renderState[idx] === "rendering") delete renderState[idx];
+  } else if (kind === GENERATION_KINDS.beatAudio) {
+    const idx = Number(tail);
+    await loadExistingBeatAudio(idx);
+    if (audioState[idx] === "generating") delete audioState[idx];
+  } else if (kind === GENERATION_KINDS.characterImage) {
+    await loadExistingCharacterImage(tail);
+    if (charRenderState[tail] === "rendering") delete charRenderState[tail];
+  } else if (kind === GENERATION_KINDS.movie) {
+    movieGenerating.value = false;
+    await refreshMoviePath();
+  }
+}
+
+async function refreshMoviePath(): Promise<void> {
+  if (!filePath.value) return;
+  const response = await apiGet<{ moviePath?: string }>(
+    API_ROUTES.mulmoScript.movieStatus,
+    { filePath: filePath.value },
+  );
+  if (response.ok && response.data.moviePath) {
+    moviePath.value = response.data.moviePath;
+  }
+}
 
 async function generateMovie() {
   movieGenerating.value = true;
   try {
     const res = await apiFetchRaw(API_ROUTES.mulmoScript.generateMovie, {
       method: "POST",
-      body: JSON.stringify({ filePath: filePath.value }),
+      body: JSON.stringify({
+        filePath: filePath.value,
+        chatSessionId: chatSessionId.value,
+      }),
       headers: { "Content-Type": "application/json" },
     });
     if (!res.ok || !res.body) throw new Error("Generation failed");

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -11,5 +11,6 @@ export {
   GENERATION_KINDS,
   type GenerationKind,
   type GenerationEvent,
+  type PendingGeneration,
   generationKey,
 } from "@mulmobridge/protocol";

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -5,4 +5,11 @@
 // New code should import directly from "@mulmobridge/protocol" when
 // it's in a package-eligible module (chat-service, bridges).
 
-export { EVENT_TYPES, type EventType } from "@mulmobridge/protocol";
+export {
+  EVENT_TYPES,
+  type EventType,
+  GENERATION_KINDS,
+  type GenerationKind,
+  type GenerationEvent,
+  generationKey,
+} from "@mulmobridge/protocol";

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -2,7 +2,7 @@
 // returned by the server's session routes.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
-import { EVENT_TYPES, type GenerationKind } from "./events";
+import { EVENT_TYPES, type PendingGeneration } from "./events";
 import type { ToolCallHistoryItem } from "./toolCallHistory";
 
 // ── Session origin (#486) ───────────────────────────────────
@@ -116,10 +116,9 @@ export interface ActiveSession {
   /**
    * In-flight background generations triggered by a plugin view (e.g.
    * MulmoScript image/audio/movie renders). Keyed by
-   * `generationKey(kind, filePath, key)` so views can derive their
-   * per-beat / per-character spinner state from this map instead of
-   * component-local refs that vanish on unmount. Empty map = no
-   * background work.
+   * `generationKey(kind, filePath, key)` (opaque identity, not parsed
+   * back); the value carries the decomposed (kind, filePath, key) so
+   * views read those fields directly. Empty map = no background work.
    */
-  pendingGenerations: Record<string, GenerationKind>;
+  pendingGenerations: Record<string, PendingGeneration>;
 }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -2,7 +2,7 @@
 // returned by the server's session routes.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
-import { EVENT_TYPES } from "./events";
+import { EVENT_TYPES, type GenerationKind } from "./events";
 import type { ToolCallHistoryItem } from "./toolCallHistory";
 
 // ── Session origin (#486) ───────────────────────────────────
@@ -113,4 +113,13 @@ export interface ActiveSession {
   // session (not on the subscription closure) so updates on turn N+1
   // are visible to the reused subscription callback.
   runStartIndex: number;
+  /**
+   * In-flight background generations triggered by a plugin view (e.g.
+   * MulmoScript image/audio/movie renders). Keyed by
+   * `generationKey(kind, filePath, key)` so views can derive their
+   * per-beat / per-character spinner state from this map instead of
+   * component-local refs that vanish on unmount. Empty map = no
+   * background work.
+   */
+  pendingGenerations: Record<string, GenerationKind>;
 }

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -3,7 +3,7 @@
 // session's state.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
-import { EVENT_TYPES } from "./events";
+import { EVENT_TYPES, type GenerationKind } from "./events";
 
 export interface SseToolCall {
   type: typeof EVENT_TYPES.toolCall;
@@ -53,6 +53,29 @@ export interface SseSessionFinished {
   type: typeof EVENT_TYPES.sessionFinished;
 }
 
+/**
+ * Plugin-initiated background work (e.g. MulmoScript image / audio /
+ * movie render) started. The client records this in
+ * `session.pendingGenerations` so the sidebar busy indicator stays
+ * lit even when the originating view isn't mounted.
+ */
+export interface SseGenerationStarted {
+  type: typeof EVENT_TYPES.generationStarted;
+  kind: GenerationKind;
+  filePath: string;
+  key: string;
+}
+
+/** Companion event to `SseGenerationStarted` — the work completed
+ *  (or failed; `error` populated). */
+export interface SseGenerationFinished {
+  type: typeof EVENT_TYPES.generationFinished;
+  kind: GenerationKind;
+  filePath: string;
+  key: string;
+  error?: string;
+}
+
 export type SseEvent =
   | SseToolCall
   | SseToolCallResult
@@ -62,4 +85,6 @@ export type SseEvent =
   | SseToolResult
   | SseRolesUpdated
   | SseError
-  | SseSessionFinished;
+  | SseSessionFinished
+  | SseGenerationStarted
+  | SseGenerationFinished;

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -29,16 +29,22 @@ function buildLiveSummary(
     updatedAt: live.updatedAt,
     preview,
   };
-  // Fold in-memory pending generations into isRunning. The server
-  // summary also carries this (via /api/sessions) but arrives on a
-  // REST refetch — using the live map too makes the session-tab
-  // spinner react within one socket round-trip of the click.
+  // Fold every in-memory signal into isRunning so the sidebar spinner
+  // reacts as fast as the fastest source:
+  //   - serverEntry.isRunning: authoritative but arrives on a /api/sessions
+  //     refetch
+  //   - live.isRunning: mirrored from the server via refreshSessionStates;
+  //     may be ahead during the refetch window, and covers live-only
+  //     sessions with no serverEntry yet
+  //   - live.pendingGenerations: updates on the socket round-trip of a
+  //     generationStarted event, before any REST refetch
+  // OR them so any one is enough. `live.isRunning` is always defined on
+  // an ActiveSession, so the summary always carries a boolean here.
   const pending = live.pendingGenerations ?? {};
-  const livePending = Object.keys(pending).length > 0;
   const isRunning =
-    serverEntry?.isRunning !== undefined
-      ? serverEntry.isRunning || livePending
-      : livePending || undefined;
+    !!serverEntry?.isRunning ||
+    live.isRunning ||
+    Object.keys(pending).length > 0;
   // Carry summary / keywords ONLY if the server already has them.
   // Object-spread with a conditional object keeps us from adding
   // `undefined` values that would otherwise show up as explicit
@@ -49,7 +55,7 @@ function buildLiveSummary(
     ...(serverEntry?.keywords !== undefined && {
       keywords: serverEntry.keywords,
     }),
-    ...(isRunning !== undefined && { isRunning }),
+    isRunning,
     ...(serverEntry?.hasUnread !== undefined && {
       hasUnread: serverEntry.hasUnread,
     }),

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -29,6 +29,16 @@ function buildLiveSummary(
     updatedAt: live.updatedAt,
     preview,
   };
+  // Fold in-memory pending generations into isRunning. The server
+  // summary also carries this (via /api/sessions) but arrives on a
+  // REST refetch — using the live map too makes the session-tab
+  // spinner react within one socket round-trip of the click.
+  const pending = live.pendingGenerations ?? {};
+  const livePending = Object.keys(pending).length > 0;
+  const isRunning =
+    serverEntry?.isRunning !== undefined
+      ? serverEntry.isRunning || livePending
+      : livePending || undefined;
   // Carry summary / keywords ONLY if the server already has them.
   // Object-spread with a conditional object keeps us from adding
   // `undefined` values that would otherwise show up as explicit
@@ -39,10 +49,7 @@ function buildLiveSummary(
     ...(serverEntry?.keywords !== undefined && {
       keywords: serverEntry.keywords,
     }),
-    // Carry live state from the server entry (authoritative source).
-    ...(serverEntry?.isRunning !== undefined && {
-      isRunning: serverEntry.isRunning,
-    }),
+    ...(isRunning !== undefined && { isRunning }),
     ...(serverEntry?.hasUnread !== undefined && {
       hasUnread: serverEntry.hasUnread,
     }),

--- a/test/routes/test_sessionsCursor.ts
+++ b/test/routes/test_sessionsCursor.ts
@@ -69,4 +69,16 @@ describe("sessionChangeMs", () => {
   it("falls back to mtime alone when indexedAt is malformed", () => {
     assert.equal(sessionChangeMs(100, "not a date"), 100);
   });
+  it("folds meta mtime into the max", () => {
+    const mtime = 1_700_000_000_000;
+    assert.equal(
+      sessionChangeMs(mtime, undefined, mtime + 9_000),
+      mtime + 9_000,
+    );
+    assert.equal(sessionChangeMs(mtime, undefined, mtime - 9_000), mtime);
+  });
+  it("ignores an undefined or non-finite meta mtime", () => {
+    assert.equal(sessionChangeMs(100, undefined, undefined), 100);
+    assert.equal(sessionChangeMs(100, undefined, Number.NaN), 100);
+  });
 });

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -111,9 +111,13 @@ async function writeSession(
   await writeFile(path.join(chatDir, `${id}.json`), JSON.stringify(meta));
   await writeFile(path.join(chatDir, `${id}.jsonl`), "");
   // Set both atime and mtime so the handler's stat.mtimeMs reads
-  // what the test intends.
+  // what the test intends. Back-date the .json meta too — the cursor
+  // derivation reads it alongside the .jsonl mtime (hasUnread writes
+  // bump meta but not jsonl), so a freshly-written meta at "now"
+  // would otherwise dominate the computed changeMs.
   const secs = opts.mtimeMs / 1000;
   await utimes(path.join(chatDir, `${id}.jsonl`), secs, secs);
+  await utimes(path.join(chatDir, `${id}.json`), secs, secs);
 
   if (opts.indexedAtMs !== undefined) {
     const manifestPath = path.join(manifestDir, "manifest.json");

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -29,6 +29,7 @@ function makeActive(overrides: Partial<ActiveSession> = {}): ActiveSession {
     startedAt: "2026-04-10T10:00:00.000Z",
     updatedAt: "2026-04-10T10:05:00.000Z",
     runStartIndex: 0,
+    pendingGenerations: {},
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Let users start long-running MulmoScript generations (beat image, character image, beat audio, movie) and then switch to another session while the work runs. The originating session's tab icon keeps spinning; when the work finishes it flips to the unread state. Closing the app mid-work is still safe — files land on disk and reappear on next visit via the existing `loadExisting*` path.

Plan doc: [`plans/feat-background-generation.md`](plans/feat-background-generation.md)

## What changed

**Protocol** — new `generation_started` / `generation_finished` event types + `GENERATION_KINDS` + `generationKey(kind, filePath, key)` helper for the triple that identifies a generation.

**Server**
- `publishGeneration(chatSessionId, kind, filePath, key, finished, error?)` wraps the four mulmo-script handlers. Because `withStoryContext` swallows errors, each handler captures failure via a local `genError` and publishes in a `finally`.
- `pushSessionEvent` always delivers to the Socket.IO channel — the client subscription is on the channel, not the store, so events must flow even when the server's `ServerSession` has been evicted.
- A new `storelessPending: Map<string, Set<string>>` tracks pending generations for sessions not in the store. Drain transitions still fire `persistHasUnread(true)` + `notifySessionsChanged()` — this is what makes the unread dot appear when an evicted session's work finishes.
- `SessionSummary.isRunning` merges `pendingGenerations.size > 0` so cross-session visibility falls out automatically via `SessionTabBar` / `SessionHistoryPanel`.

**Client**
- New `useActiveSession` provide/inject — same pattern as `useAppApi`. View plugins read the active session to tag POSTs with `chatSessionId` and observe pending work.
- `applyAgentEvent` handles the two new event types; on drain while viewing the session it calls `markSessionRead` to clear the unread flag.
- `isRunning` computed and `mergeSessionLists` fold `live.pendingGenerations` into the busy signal so the tab reacts within one socket round-trip of the click, no REST refetch required.
- Subscription teardown (the two spots in `App.vue` that unsubscribe on navigation / session-finished) now keeps the subscription alive while generations are in flight — otherwise the completion event is orphaned and the spinner stays stuck.

**View.vue** — injects the active session, tags all four generate POST bodies with `chatSessionId`, adds a watcher that syncs local render/audio/movie state against `pendingGenerations` (on started: mark rendering; on finished: reload via existing `loadExisting*`). `initializeScript` reflects in-flight generations on mount so spinners survive remount.

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
- [x] `yarn test` — 29 pass
- [x] Manual: click Generate on a character, switch to another session, confirm the originating session's tab icon keeps spinning
- [x] Manual: wait for generation to finish while viewing a different session, confirm the tab icon flips from spinning to the unread state
- [x] Manual: return to the session, confirm the character image appears and the unread flag clears
- [ ] Manual: repeat for beat image, beat audio, and full movie generation
- [ ] Manual: kill mid-generation and verify finished artifacts still appear on next visit (no regression in `loadExisting*` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-session/background generation progress tracking for images, audio, and video.
  * Sessions now show pending-generation status across views in real time; sidebar/activity indicators reflect background work.
  * UI loading and per-item indicators synchronize with actual generation lifecycle so progress and completion/errors are reflected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->