### PR TITLE
refactor: extract useSessionSync + useSessionDerived from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -297,19 +297,20 @@ import { useKeyNavigation } from "./composables/useKeyNavigation";
 import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
 import { useViewLayout } from "./composables/useViewLayout";
+import { useSessionSync } from "./composables/useSessionSync";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
-import { PUBSUB_CHANNELS, sessionChannel } from "./config/pubsubChannels";
+import { sessionChannel } from "./config/pubsubChannels";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
 import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
-import { apiGet, apiPost, apiFetchRaw } from "./utils/api";
+import { apiGet, apiFetchRaw } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
 
 // --- Per-session state ---
@@ -334,45 +335,6 @@ const currentSessionId = ref("");
 const { debugTitleStyle } = useDebugBeat();
 
 const { subscribe: pubsubSubscribe } = usePubSub();
-
-// --- Sessions channel (pub/sub) ---
-// Subscribe to the global `sessions` channel. The server publishes a
-// bare notification (no data) whenever any session's state changes.
-// The client refetches the session list via REST — the server is the
-// single source of truth for isRunning, hasUnread, etc.
-pubsubSubscribe(PUBSUB_CHANNELS.sessions, () => {
-  refreshSessionStates();
-});
-
-async function refreshSessionStates(): Promise<void> {
-  const summaries = await fetchSessions();
-  for (const s of summaries) {
-    const live = sessionMap.get(s.id);
-    if (!live) continue;
-    // Missing fields mean the server has no live entry — reset to defaults.
-    live.isRunning = s.isRunning ?? false;
-    live.statusMessage = s.statusMessage ?? "";
-    const unread = s.hasUnread ?? false;
-    // Don't mark the currently viewed session as unread
-    if (!(unread && s.id === currentSessionId.value)) {
-      live.hasUnread = unread;
-    }
-  }
-}
-
-async function markSessionRead(id: string): Promise<void> {
-  const result = await apiPost<{ ok: boolean }>(
-    API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(id)),
-  );
-  // The server returns `{ ok: boolean }` — a 200 with `ok: false`
-  // means the endpoint was reached but the flag wasn't actually
-  // cleared (e.g. session not found). Treat that the same as a
-  // transport failure and refetch so the sidebar doesn't go stale.
-  if (!result.ok || result.data.ok === false) {
-    // Server didn't clear the flag — refetch to restore truth.
-    await refreshSessionStates();
-  }
-}
 
 // --- Routing ---
 const route = useRoute();
@@ -541,6 +503,11 @@ const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, showHistory, historyError, fetchSessions, toggleHistory } =
   useSessionHistory();
+const { markSessionRead } = useSessionSync({
+  sessionMap,
+  currentSessionId,
+  fetchSessions,
+});
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
 
 // ── Dynamic favicon (#470) ──────────────────────────────────

--- a/src/App.vue
+++ b/src/App.vue
@@ -272,7 +272,6 @@ import {
 } from "./types/session";
 import { EVENT_TYPES } from "./types/events";
 import { extractImageData, makeTextResult } from "./utils/tools/result";
-import { deduplicateResults } from "./utils/tools/dedup";
 import { buildAgentRequestBody } from "./utils/agent/request";
 import {
   pushResult,
@@ -298,6 +297,7 @@ import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
 import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
+import { useSessionDerived } from "./composables/useSessionDerived";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -424,54 +424,7 @@ watch(
   },
 );
 
-const activeSession = computed(() => sessionMap.get(currentSessionId.value));
-
-const toolResults = computed(() => activeSession.value?.toolResults ?? []);
-
 // Deduplicate consecutive tool results with the same toolName for the
-// sidebar preview list. Tools like manageScheduler / manageTodoList
-// return the full item list on every call, so 4 consecutive scheduler
-// calls produce 4 identical "22 upcoming" previews. We keep only the
-// last one in each consecutive run. text-response is excluded because
-// each user/assistant message is unique content.
-// Deduplicate consecutive tool results that represent "full-state
-// refreshes" of the same collection. Tools like manageScheduler /
-// manageTodoList / manageWiki return the full list on every call
-// and set `updating: true` on the response — that flag is the
-// signal that the previous result is superseded, not a new artifact.
-//
-// Tools that create individual artifacts (generateImage,
-// presentDocument, editImage) DO NOT set `updating`, so consecutive
-// calls stay visible as separate preview cards. This matches the
-// "tennis vs golf docs" case raised in review: two different
-// documents produced in a row must both be shown.
-//
-// text-response is never collapsed because each user/assistant
-// message is unique content.
-const sidebarResults = computed(() => {
-  return deduplicateResults(toolResults.value);
-});
-
-// Read running/status from the server session list (single source of
-// truth). Falls back to sessionMap for the brief window before the
-// first fetchSessions completes.
-const currentSummary = computed(() =>
-  sessions.value.find((s) => s.id === currentSessionId.value),
-);
-const isRunning = computed(
-  () =>
-    currentSummary.value?.isRunning ?? activeSession.value?.isRunning ?? false,
-);
-const statusMessage = computed(
-  () =>
-    currentSummary.value?.statusMessage ??
-    activeSession.value?.statusMessage ??
-    "",
-);
-const toolCallHistory = computed(
-  () => activeSession.value?.toolCallHistory ?? [],
-);
-
 const selectedResultUuid = computed({
   get: () => activeSession.value?.selectedResultUuid ?? null,
   set: (val: string | null) => {
@@ -486,13 +439,6 @@ const selectedResultUuid = computed({
     });
   },
 });
-
-const activeSessionCount = computed(
-  () => sessions.value.filter((s) => s.isRunning).length,
-);
-const unreadCount = computed(
-  () => sessions.value.filter((s) => s.hasUnread).length,
-);
 
 // --- Global state ---
 const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
@@ -509,6 +455,18 @@ const { markSessionRead } = useSessionSync({
   fetchSessions,
 });
 const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
+
+const {
+  activeSession,
+  toolResults,
+  sidebarResults,
+  currentSummary,
+  isRunning,
+  statusMessage,
+  toolCallHistory,
+  activeSessionCount,
+  unreadCount,
+} = useSessionDerived({ sessionMap, currentSessionId, sessions });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
 const faviconState = computed<FaviconState>(() => {

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -1,0 +1,66 @@
+// Computed properties derived from sessionMap + sessions list.
+// Extracted from App.vue to reduce the component's reactive surface.
+
+import { computed, type Ref } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type { ActiveSession, SessionSummary } from "../types/session";
+import type { ToolCallHistoryItem } from "../types/toolCallHistory";
+import { deduplicateResults } from "../utils/tools/dedup";
+
+export function useSessionDerived(opts: {
+  sessionMap: Map<string, ActiveSession>;
+  currentSessionId: Ref<string>;
+  sessions: Ref<SessionSummary[]>;
+}) {
+  const { sessionMap, currentSessionId, sessions } = opts;
+
+  const activeSession = computed(() => sessionMap.get(currentSessionId.value));
+
+  const toolResults = computed<ToolResultComplete[]>(
+    () => activeSession.value?.toolResults ?? [],
+  );
+
+  const sidebarResults = computed(() => deduplicateResults(toolResults.value));
+
+  const currentSummary = computed(() =>
+    sessions.value.find((s) => s.id === currentSessionId.value),
+  );
+
+  const isRunning = computed(
+    () =>
+      currentSummary.value?.isRunning ??
+      activeSession.value?.isRunning ??
+      false,
+  );
+
+  const statusMessage = computed(
+    () =>
+      currentSummary.value?.statusMessage ??
+      activeSession.value?.statusMessage ??
+      "",
+  );
+
+  const toolCallHistory = computed<ToolCallHistoryItem[]>(
+    () => activeSession.value?.toolCallHistory ?? [],
+  );
+
+  const activeSessionCount = computed(
+    () => sessions.value.filter((s) => s.isRunning).length,
+  );
+
+  const unreadCount = computed(
+    () => sessions.value.filter((s) => s.hasUnread).length,
+  );
+
+  return {
+    activeSession,
+    toolResults,
+    sidebarResults,
+    currentSummary,
+    isRunning,
+    statusMessage,
+    toolCallHistory,
+    activeSessionCount,
+    unreadCount,
+  };
+}

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -3,9 +3,9 @@
 // whenever any session's state changes. Also provides markSessionRead
 // for clearing the unread flag on the server.
 
+import { onScopeDispose } from "vue";
 import type { Ref } from "vue";
-import type { ActiveSession } from "../types/session";
-import type { SessionSummary } from "../types/session";
+import type { ActiveSession, SessionSummary } from "../types/session";
 import { usePubSub } from "./usePubSub";
 import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
 import { apiPost } from "../utils/api";
@@ -20,7 +20,15 @@ export function useSessionSync(opts: {
   const { subscribe } = usePubSub();
 
   async function refreshSessionStates(): Promise<void> {
-    const summaries = await fetchSessions();
+    let summaries: SessionSummary[];
+    try {
+      summaries = await fetchSessions();
+    } catch (err) {
+      // Network / HTTP failure — log and bail so the pub/sub
+      // callback doesn't produce an unhandled rejection.
+      console.warn("[session-sync] failed to fetch sessions:", err);
+      return;
+    }
     for (const s of summaries) {
       const live = sessionMap.get(s.id);
       if (!live) continue;
@@ -42,9 +50,10 @@ export function useSessionSync(opts: {
     }
   }
 
-  subscribe(PUBSUB_CHANNELS.sessions, () => {
-    refreshSessionStates();
+  const unsub = subscribe(PUBSUB_CHANNELS.sessions, () => {
+    void refreshSessionStates();
   });
+  if (typeof unsub === "function") onScopeDispose(unsub);
 
   return { refreshSessionStates, markSessionRead };
 }

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -4,7 +4,8 @@
 // for clearing the unread flag on the server.
 
 import type { Ref } from "vue";
-import type { ActiveSession, SessionSummary } from "../types/session";
+import type { ActiveSession } from "../types/session";
+import type { SessionSummary } from "../types/session";
 import { usePubSub } from "./usePubSub";
 import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
 import { apiPost } from "../utils/api";

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -1,0 +1,49 @@
+// Keep in-memory session state in sync with the server via pub/sub.
+// Subscribes to the global `sessions` channel and refetches summaries
+// whenever any session's state changes. Also provides markSessionRead
+// for clearing the unread flag on the server.
+
+import type { Ref } from "vue";
+import type { ActiveSession, SessionSummary } from "../types/session";
+import { usePubSub } from "./usePubSub";
+import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
+import { apiPost } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+export function useSessionSync(opts: {
+  sessionMap: Map<string, ActiveSession>;
+  currentSessionId: Ref<string>;
+  fetchSessions: () => Promise<SessionSummary[]>;
+}) {
+  const { sessionMap, currentSessionId, fetchSessions } = opts;
+  const { subscribe } = usePubSub();
+
+  async function refreshSessionStates(): Promise<void> {
+    const summaries = await fetchSessions();
+    for (const s of summaries) {
+      const live = sessionMap.get(s.id);
+      if (!live) continue;
+      live.isRunning = s.isRunning ?? false;
+      live.statusMessage = s.statusMessage ?? "";
+      const unread = s.hasUnread ?? false;
+      if (!(unread && s.id === currentSessionId.value)) {
+        live.hasUnread = unread;
+      }
+    }
+  }
+
+  async function markSessionRead(id: string): Promise<void> {
+    const result = await apiPost<{ ok: boolean }>(
+      API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(id)),
+    );
+    if (!result.ok || result.data.ok === false) {
+      await refreshSessionStates();
+    }
+  }
+
+  subscribe(PUBSUB_CHANNELS.sessions, () => {
+    refreshSessionStates();
+  });
+
+  return { refreshSessionStates, markSessionRead };
+}


### PR DESCRIPTION
## Summary

App.vue から 2 つの composable を抽出 (1188 → 1113 行、-75)。

| Commit | Composable | 内容 |
|---|---|---|
| 1 | useSessionSync | refreshSessionStates + markSessionRead + sessions pubsub subscribe (~30 行) |
| 2 | useSessionDerived | 9 computed (activeSession, toolResults, sidebarResults, currentSummary, isRunning, statusMessage, toolCallHistory, activeSessionCount, unreadCount) (~55 行) |

累計: **1283 → 1113 行 (-170)**。

## Test plan

- [x] yarn lint — 0 errors
- [x] yarn typecheck — clean
- [x] yarn build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract session synchronization and derived state logic from App.vue into dedicated composables to simplify the root component and encapsulate session behavior.

Enhancements:
- Introduce useSessionSync composable to handle session pub/sub subscription, server state refresh, and read-status updates.
- Introduce useSessionDerived composable to centralize session-derived computed values such as active session data, sidebar results, and session counters.
- Clean up App.vue imports and wire it to use the new session composables instead of inline logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal session state management for improved code maintainability and separation of concerns. Session synchronization and state derivation logic have been modularized to enhance code reusability and reduce complexity in the main application component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->