### PR TITLE
fix: retry transient rename errors on Windows in writeFileAtomic

### DIFF
--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -22,6 +22,72 @@ export interface WriteAtomicOptions {
   uniqueTmp?: boolean;
 }
 
+// ── Windows rename retry ────────────────────────────────────────
+//
+// On Windows, `rename` (MoveFileEx with MOVEFILE_REPLACE_EXISTING) can
+// transiently fail with EPERM or EBUSY when antivirus / Search
+// Indexer / Defender momentarily holds a handle on the tmp file or
+// destination file. The failure window is tiny (usually <100ms) and
+// the rename succeeds on a retry.
+//
+// On POSIX, `rename` is atomic and overwrites unconditionally. EPERM
+// there means a real permission problem (read-only filesystem, sticky
+// bit, cross-device link) — retrying wouldn't help and would only add
+// latency before the inevitable throw. So the retry loop is gated to
+// Windows.
+const IS_WINDOWS = process.platform === "win32";
+const RENAME_RETRY_DELAYS_MS = [30, 100, 300] as const;
+
+function hasErrnoCode(err: unknown): err is { code: string } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    typeof (err as { code: unknown }).code === "string"
+  );
+}
+
+function isTransientRenameError(err: unknown): boolean {
+  if (!IS_WINDOWS || !hasErrnoCode(err)) return false;
+  return err.code === "EPERM" || err.code === "EBUSY" || err.code === "EACCES";
+}
+
+async function renameWithWindowsRetry(from: string, to: string): Promise<void> {
+  for (const delayMs of RENAME_RETRY_DELAYS_MS) {
+    try {
+      await fs.promises.rename(from, to);
+      return;
+    } catch (err) {
+      if (!isTransientRenameError(err)) throw err;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  // Final attempt — let any error propagate.
+  await fs.promises.rename(from, to);
+}
+
+// Sync sleep that parks the thread instead of burning CPU. Only
+// invoked on the transient-Windows-rename path, so the total worst-
+// case block is the sum of RENAME_RETRY_DELAYS_MS (~430ms) and only
+// triggers under AV/indexer contention.
+const SYNC_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
+function sleepSync(ms: number): void {
+  Atomics.wait(SYNC_SLEEP_BUF, 0, 0, ms);
+}
+
+function renameSyncWithWindowsRetry(from: string, to: string): void {
+  for (const delayMs of RENAME_RETRY_DELAYS_MS) {
+    try {
+      fs.renameSync(from, to);
+      return;
+    } catch (err) {
+      if (!isTransientRenameError(err)) throw err;
+      sleepSync(delayMs);
+    }
+  }
+  fs.renameSync(from, to);
+}
+
 /**
  * Write `content` to `filePath` atomically. The parent directory is
  * created if missing. The tmp file is cleaned up on failure so a
@@ -41,7 +107,7 @@ export async function writeFileAtomic(
       encoding: "utf-8",
       mode: opts.mode,
     });
-    await fs.promises.rename(tmp, filePath);
+    await renameWithWindowsRetry(tmp, filePath);
   } catch (err) {
     await fs.promises.unlink(tmp).catch(() => {});
     throw err;
@@ -64,7 +130,7 @@ export function writeFileAtomicSync(
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   try {
     fs.writeFileSync(tmp, content, { encoding: "utf-8", mode: opts.mode });
-    fs.renameSync(tmp, filePath);
+    renameSyncWithWindowsRetry(tmp, filePath);
   } catch (err) {
     try {
       fs.unlinkSync(tmp);


### PR DESCRIPTION
## Summary

Windows CI の atomic rename テストが稀に `EPERM` で落ちる問題を、`writeFileAtomic` / `writeFileAtomicSync` に Windows 限定の短いリトライを追加することで根本修正します。

- EPERM/EBUSY/EACCES を検出した時のみ 30ms → 100ms → 300ms の backoff で計3回再試行
- リトライは `process.platform === "win32"` で完全にゲート — POSIX は 1 行も挙動が変わらない
- sync 版は `Atomics.wait` でスレッドをパーク（CPU spin しない）
- 最終試行はエラーを throw（無限ループにはならない）

## Items to Confirm / Review

- [ ] **POSIX 副作用なし**: `IS_WINDOWS` チェックで Linux/macOS は 1 行も新コードを実行しない — 要確認
- [ ] **sync の `Atomics.wait` 採用**: `fs.writeFileAtomicSync` 経路で最大 ~430ms ブロックしうるが、AV/indexer 干渉時のみ発火。CPU spin ではなくスレッドパーク。設計判断として妥当か確認
- [ ] **リトライ回数/遅延**: 30/100/300ms×3 は Windows rename 再試行のよくある値。これで十分か、あるいは多すぎるか
- [ ] **既存ブランチとの関係**: `fix/ci-windows-stability`（未マージ）は Defender 無効化 + テスト skip という CI ワークアラウンド。本 PR がマージされればそちらのテスト skip は不要になる

## User Prompt

Windows CI で atomic rename テストが稀に以下のエラーで落ちる:

```
Error: EPERM: operation not permitted, rename '...\unique.txt.xxx.tmp' -> '...\unique.txt'
    at async Object.rename (node:internal/fs/promises:785:10)
    at async writeFileAtomic (server/utils/files/atomic.ts:44:5)
```

直せないか、という要望。方針として (A) プラットフォームチェック付き Windows 限定リトライ、(B) 全環境でリトライ、の2案を提示し、ユーザーが (A) を選択。「コメントもしっかり書いておいて」とリクエスト。

## Implementation

`server/utils/files/atomic.ts` に以下を追加:

- `IS_WINDOWS = process.platform === "win32"` 定数
- `RENAME_RETRY_DELAYS_MS = [30, 100, 300] as const`
- `hasErrnoCode` 型ガード（CLAUDE.md の `as` cast 禁止ルール準拠）
- `isTransientRenameError` — Windows でのみ EPERM/EBUSY/EACCES を transient と判定
- `renameWithWindowsRetry` (async) — `setTimeout` Promise で待機
- `renameSyncWithWindowsRetry` (sync) — `Atomics.wait` でスレッドパーク

`writeFileAtomic` / `writeFileAtomicSync` の `fs.rename` / `fs.renameSync` 呼び出しをこのヘルパー経由に差し替え。

WHY を説明する block コメントを上部に追加（POSIX で EPERM が transient でない理由、Windows 特有の MoveFileEx 挙動など）。

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` 全て clean
- [x] `yarn test` 29 件 pass（`test/utils/files/test_atomic.ts` 含む 9/9 pass）
- [ ] Windows CI で flake が解消するか（複数回実行で確認したい）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Handle transient EPERM/EBUSY/EACCES errors during atomic file rename on Windows by retrying before failing.