### PR TITLE
perf(ci): Windows speed — node_modules cache + pin windows-2022

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,20 +19,31 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
     steps:
     - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
+        # Skip setup-node's built-in yarn cache on Windows — tar
+        # extraction on NTFS is slower than a fresh install.
+        # We use actions/cache for node_modules instead.
+        cache: ${{ runner.os == 'Windows' && '' || 'yarn' }}
     # Windows: disable Defender realtime monitoring to prevent
-    # EPERM on atomic rename and yarn install hangs (#CI)
+    # EPERM on atomic rename (#CI)
     - name: Disable Windows Defender realtime monitoring
       if: runner.os == 'Windows'
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
+    # Windows: cache node_modules directly (faster than yarn cache
+    # because it skips the tar extract → yarn install file-write cycle)
+    - name: Cache node_modules (Windows)
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
     - run: yarn install --frozen-lockfile --network-timeout 120000
     - name: Build internal packages (required before typecheck)
       run: yarn build:packages


### PR DESCRIPTION
## 問題

Windows CI が Ubuntu の 2倍以上遅い（454秒 vs 216秒）。最大のボトルネックは setup-node の yarn cache restore（NTFS での tar 展開が 145秒 vs Ubuntu 15秒）。

## 変更

| 変更 | 理由 |
|---|---|
| `windows-latest` → `windows-2022` | 2025 イメージの不安定さ回避 |
| Windows で setup-node の `cache: 'yarn'` を無効化 | NTFS での tar 展開が遅すぎて逆効果 |
| Windows で `actions/cache` で node_modules 直接キャッシュ | yarn install のファイル書き込みをスキップ |
| Ubuntu/macOS は変更なし | yarn cache が高速に機能 |

## 期待効果

初回: 変化なし（キャッシュ構築）
2回目以降: node_modules 復元でyarn install がほぼスキップ → setup-node の 145秒ボトルネック解消

## 参考

- [actions/setup-node#975](https://github.com/actions/setup-node/issues/975) — NTFS での cache restore が遅い
- [actions/runner-images#7320](https://github.com/actions/runner-images/issues/7320) — Windows CI 速度問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize Windows CI job performance by adjusting runner image, Node.js caching strategy, and Windows-specific settings.

CI:
- Pin Windows runners to windows-2022 instead of windows-latest in the pull_request workflow matrix.
- Disable setup-node's built-in yarn cache on Windows and rely on actions/cache for direct node_modules caching instead.
- Add a Windows-only node_modules cache keyed by Node.js version and yarn.lock to reduce repeated install time.
- Clarify the Windows Defender realtime monitoring step comment to focus on preventing EPERM on atomic rename.