### PR TITLE
refactor: extract useFaviconState + useMergedSessions from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -258,12 +258,6 @@ import {
   type NotificationAction,
 } from "./types/notification";
 import { CANVAS_VIEW } from "./utils/canvas/viewMode";
-import {
-  useDynamicFavicon,
-  FAVICON_STATES,
-  type FaviconState,
-} from "./composables/useDynamicFavicon";
-import { useNotifications } from "./composables/useNotifications";
 import type { SseEvent } from "./types/sse";
 import {
   type SessionSummary,
@@ -298,6 +292,7 @@ import { useChatScroll } from "./composables/useChatScroll";
 import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
 import { useSessionDerived } from "./composables/useSessionDerived";
+import { useFaviconState } from "./composables/useFaviconState";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -469,21 +464,7 @@ const {
 } = useSessionDerived({ sessionMap, currentSessionId, sessions });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
-const faviconState = computed<FaviconState>(() => {
-  if (isRunning.value) return FAVICON_STATES.running;
-  const hasUnread =
-    currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
-  if (hasUnread) return FAVICON_STATES.done;
-  return FAVICON_STATES.idle;
-});
-
-const { unreadCount: notificationUnreadCount } = useNotifications();
-const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0);
-
-useDynamicFavicon({
-  state: faviconState,
-  hasNotification: hasNotificationBadge,
-});
+useFaviconState({ isRunning, currentSummary, activeSession });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);

--- a/src/App.vue
+++ b/src/App.vue
@@ -259,11 +259,7 @@ import {
 } from "./types/notification";
 import { CANVAS_VIEW } from "./utils/canvas/viewMode";
 import type { SseEvent } from "./types/sse";
-import {
-  type SessionSummary,
-  type SessionEntry,
-  type ActiveSession,
-} from "./types/session";
+import { type SessionEntry, type ActiveSession } from "./types/session";
 import { EVENT_TYPES } from "./types/events";
 import { extractImageData, makeTextResult } from "./utils/tools/result";
 import { buildAgentRequestBody } from "./utils/agent/request";
@@ -278,7 +274,6 @@ import {
   findPendingToolCall,
   shouldSelectAssistantText,
 } from "./utils/agent/toolCalls";
-import { mergeSessionLists } from "./utils/session/mergeSessions";
 import {
   parseSessionEntries,
   resolveSelectedUuid,
@@ -293,6 +288,7 @@ import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
 import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
+import { useMergedSessions } from "./composables/useMergedSessions";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
 import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
@@ -579,22 +575,10 @@ const selectedResult = computed(
 // that haven't been persisted to disk yet.
 // Merged list for the history pane: live sessions in `sessionMap`
 // merged with server-only sessions, sorted newest-first by
-// `updatedAt` (most recently touched floats to the top). `updatedAt`
-// is bumped in `sendMessage` for live sessions and taken from the
-// jsonl file mtime for server-only sessions.
-//
-// When a session exists on the server side (the indexer has produced
-// a title / summary / keywords for it), we prefer those fields over
-// the live-session fallback: a live session that was loaded from a
-// pre-indexed jsonl should keep showing the AI-generated title in
-// the sidebar, not regress to the raw first user message. Without
-// this merge, opening an indexed session immediately clobbered its
-// sidebar row with the first-user-message preview.
-const mergedSessions = computed((): SessionSummary[] =>
-  mergeSessionLists([...sessionMap.values()], sessions.value),
-);
-
-const tabSessions = computed(() => mergedSessions.value.slice(0, 6));
+const { mergedSessions, tabSessions } = useMergedSessions({
+  sessionMap,
+  sessions,
+});
 
 // Centralised session-switch handler: subscribe to the current session's
 // pub/sub channel so we receive real-time events even if the session is

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,0 +1,39 @@
+// Dynamic favicon state: running → done (unread) → idle.
+// Also drives the notification badge dot on the favicon.
+
+import { computed, type ComputedRef } from "vue";
+import {
+  FAVICON_STATES,
+  type FaviconState,
+  useDynamicFavicon,
+} from "./useDynamicFavicon";
+import { useNotifications } from "./useNotifications";
+import type { ActiveSession, SessionSummary } from "../types/session";
+
+export function useFaviconState(opts: {
+  isRunning: ComputedRef<boolean>;
+  currentSummary: ComputedRef<SessionSummary | undefined>;
+  activeSession: ComputedRef<ActiveSession | undefined>;
+}) {
+  const { isRunning, currentSummary, activeSession } = opts;
+
+  const faviconState = computed<FaviconState>(() => {
+    if (isRunning.value) return FAVICON_STATES.running;
+    const hasUnread =
+      currentSummary.value?.hasUnread ??
+      activeSession.value?.hasUnread ??
+      false;
+    if (hasUnread) return FAVICON_STATES.done;
+    return FAVICON_STATES.idle;
+  });
+
+  const { unreadCount: notificationUnreadCount } = useNotifications();
+  const hasNotificationBadge = computed(
+    () => notificationUnreadCount.value > 0,
+  );
+
+  useDynamicFavicon({
+    state: faviconState,
+    hasNotification: hasNotificationBadge,
+  });
+}

--- a/src/composables/useMergedSessions.ts
+++ b/src/composables/useMergedSessions.ts
@@ -1,0 +1,24 @@
+// Merged session list for the history pane + tab bar.
+// Live sessions in sessionMap are merged with server-only sessions
+// (from the chat indexer), sorted newest-first by updatedAt.
+
+import { computed, type Ref } from "vue";
+import type { ActiveSession, SessionSummary } from "../types/session";
+import { mergeSessionLists } from "../utils/session/mergeSessions";
+
+const MAX_TABS = 6;
+
+export function useMergedSessions(opts: {
+  sessionMap: Map<string, ActiveSession>;
+  sessions: Ref<SessionSummary[]>;
+}) {
+  const { sessionMap, sessions } = opts;
+
+  const mergedSessions = computed((): SessionSummary[] =>
+    mergeSessionLists([...sessionMap.values()], sessions.value),
+  );
+
+  const tabSessions = computed(() => mergedSessions.value.slice(0, MAX_TABS));
+
+  return { mergedSessions, tabSessions };
+}


### PR DESCRIPTION
## Summary

App.vue から 2 composable を抽出 (1113 → 1078 行、-35)。

| Commit | Composable | 内容 |
|---|---|---|
| 1 | useFaviconState | faviconState computed + notification badge + useDynamicFavicon (~15 行) |
| 2 | useMergedSessions | mergedSessions + tabSessions computed (~15 行) |

累計: **1283 → 1078 行 (-205)**。

## テスト方法

### 自動テスト
```bash
yarn lint && yarn typecheck && yarn build && yarn test && yarn test:e2e
```

### 手動テスト (yarn dev)

**useFaviconState:**
- agent 実行中 → ファビコンが running 状態に変化
- 実行完了 + 別セッション → done (unread) 状態
- 全既読 → idle 状態
- 通知がある時 → ファビコンにドット表示

**useMergedSessions:**
- サイドバーの session history に全セッションが表示される (live + server-only)
- タブバーに最大 6 セッションが表示される
- 新しいセッションが先頭に来る (updatedAt 降順)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract favicon handling and merged session list logic from App.vue into dedicated composables to simplify the root component and improve reuse.

Enhancements:
- Introduce useFaviconState composable to encapsulate dynamic favicon state and notification badge behavior.
- Introduce useMergedSessions composable to encapsulate merged session history and tab session selection logic, including tab count limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized favicon and notification badge computation logic for improved code organization
  * Restructured session history and tab management implementation for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->