### PR TITLE
refactor: App.vue composable extraction round 4

### DIFF
--- a/e2e/tests/streaming-autoscroll.spec.ts
+++ b/e2e/tests/streaming-autoscroll.spec.ts
@@ -1,0 +1,187 @@
+// E2E regression for the streaming auto-scroll bug (PR #529).
+//
+// Background: the sidebar's useChatScroll composable and StackView's
+// own scroll watcher BOTH keyed only on `toolResults.length`. During
+// assistant text streaming, `appendToLastAssistantText` appends to
+// the last card in place — length does not change — so auto-scroll
+// silently stopped after the first chunk, leaving the newest text
+// below the fold.
+//
+// The fix watches a key that includes the last result's message
+// length so every streaming chunk triggers a scroll. This test
+// guards both scroll paths (sidebar in Single mode, StackView in
+// Stack mode) because a future refactor that introduces a new view
+// mode with its own scroll container must extend the same pattern.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+// Build a streaming transcript: the first text event creates the
+// assistant card (length 0 → 1), every subsequent event appends to
+// the same card via appendToLastAssistantText (length stays at 1).
+// Generates enough total bytes to overflow the visible viewport so
+// the scroll container actually has room to scroll.
+function buildStreamingEvents(chunkCount: number, chunkBody: string) {
+  return Array.from({ length: chunkCount }, () => ({
+    type: "text",
+    source: "assistant",
+    message: chunkBody,
+  }));
+}
+
+// Relay a sequence of pub/sub events to the mocked WebSocket with a
+// small gap between each send so Vue re-renders between chunks.
+async function streamEventsToSocket(
+  ws: { send: (data: string) => void },
+  channel: string,
+  events: readonly unknown[],
+): Promise<void> {
+  for (const event of events) {
+    ws.send("42" + JSON.stringify(["data", { channel, data: event }]));
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  ws.send(
+    "42" +
+      JSON.stringify(["data", { channel, data: { type: "session_finished" } }]),
+  );
+}
+
+function handleSocketFrame(
+  text: string,
+  ws: { send: (data: string) => void },
+  events: readonly unknown[],
+): void {
+  if (text === "2") return ws.send("3");
+  if (text === "40")
+    return ws.send("40" + JSON.stringify({ sid: "mock-socket-sid" }));
+  if (!text.startsWith("42")) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(2));
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  const [name, arg] = parsed as [string, unknown];
+  if (
+    name !== "subscribe" ||
+    typeof arg !== "string" ||
+    !arg.startsWith("session.")
+  )
+    return;
+  void streamEventsToSocket(ws, arg, events);
+}
+
+async function mockAgentWithPubSub(
+  page: Page,
+  events: readonly unknown[],
+): Promise<void> {
+  await page.routeWebSocket(
+    (url) => url.pathname.startsWith("/ws/pubsub"),
+    (ws) => {
+      ws.send(
+        "0" +
+          JSON.stringify({
+            sid: "mock-sid",
+            upgrades: [],
+            pingInterval: 25000,
+            pingTimeout: 20000,
+            maxPayload: 1_000_000,
+          }),
+      );
+      ws.onMessage((msg) => handleSocketFrame(String(msg), ws, events));
+    },
+  );
+
+  await page.route(urlEndsWith("/api/agent"), (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 202,
+      json: { chatSessionId: "mock-session" },
+    });
+  });
+}
+
+/** Wait until scrollHeight stops growing for two consecutive samples,
+ *  meaning the streaming has finished and the DOM has settled. */
+async function waitForScrollHeightStable(
+  page: Page,
+  testId: string,
+  opts: { sampleGapMs?: number; maxWaitMs?: number } = {},
+): Promise<void> {
+  const gap = opts.sampleGapMs ?? 300;
+  const maxWait = opts.maxWaitMs ?? 10_000;
+  const deadline = Date.now() + maxWait;
+  let last = -1;
+  let stable = 0;
+  while (Date.now() < deadline) {
+    const current = await page
+      .getByTestId(testId)
+      .evaluate((el) => el.scrollHeight);
+    if (current === last && current > 0) {
+      stable++;
+      if (stable >= 2) return;
+    } else {
+      stable = 0;
+      last = current;
+    }
+    await page.waitForTimeout(gap);
+  }
+}
+
+/** Read scrollTop + scrollHeight + clientHeight from a scroll container. */
+async function scrollMetrics(
+  page: Page,
+  testId: string,
+): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
+  return page.getByTestId(testId).evaluate((el) => ({
+    scrollTop: el.scrollTop,
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+  }));
+}
+
+// We accept "near-bottom" rather than exact equality — browser
+// rounding and late iframe sizing can leave a handful of pixels.
+const BOTTOM_TOLERANCE_PX = 50;
+
+// The sidebar ToolResultsPanel only renders preview titles for each
+// result, so long streamed text never makes it overflow — the
+// streaming bug wasn't observable there in practice. StackView on
+// the other hand renders the full message body, where the stalled
+// scroll was visible to users. That's the case this test guards.
+test.describe("assistant text streaming — auto-scroll follows the stream", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("StackView (Stack mode) stays pinned to the bottom during streaming", async ({
+    page,
+  }) => {
+    const chunk = "Streaming chunk with enough text to matter. ".repeat(5);
+    await mockAgentWithPubSub(page, buildStreamingEvents(40, chunk));
+
+    await page.goto("/?view=stack");
+    await page.getByTestId("user-input").fill("stream me in stack");
+    await page.getByTestId("send-btn").click();
+
+    await expect(page.locator("text=Streaming chunk").first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await waitForScrollHeightStable(page, "stack-scroll");
+
+    const { scrollTop, scrollHeight, clientHeight } = await scrollMetrics(
+      page,
+      "stack-scroll",
+    );
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+    expect(scrollHeight - scrollTop - clientHeight).toBeLessThan(
+      BOTTOM_TOLERANCE_PX,
+    );
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -452,34 +452,25 @@ const {
 useFaviconState({ isRunning, currentSummary, activeSession });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
-const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
 const canvasRef = ref<HTMLDivElement | null>(null);
 const chatInputRef = ref<{ focus: () => void } | null>(null);
 const topBarRef = ref<HTMLDivElement | null>(null);
-// Measured when the history popup opens — the popup is a direct child
-// of the root, so its absolute `top` must equal the global top bar's
-// full height.
 const historyTopOffset = ref<number | undefined>(undefined);
 
-function focusChatInput(): void {
-  chatInputRef.value?.focus();
-}
 const sessionTabBarRef = ref<{
   historyButton: HTMLButtonElement | null;
 } | null>(null);
 const historyButtonRef = computed(
   () => sessionTabBarRef.value?.historyButton ?? null,
 );
-// Exposed `root` from SessionHistoryPanel — the click-outside guard
-// needs the actual popup DOM element (not the component instance).
 const historyPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const historyPopupRef = computed(() => historyPanelRef.value?.root ?? null);
-const toolResultsLength = computed(() => toolResults.value.length);
-useChatScroll({
-  chatListRef,
-  toolResultsLength,
+
+const { focusChatInput } = useChatScroll({
+  toolResultsPanelRef,
+  toolResults,
   isRunning,
-  focusChatInput,
+  chatInputRef,
 });
 
 const { showRightSidebar, toggleRightSidebar } = useRightSidebar();

--- a/src/App.vue
+++ b/src/App.vue
@@ -681,29 +681,24 @@ function onRoleChange() {
   maybeSeedRoleDefault(session);
 }
 
-async function loadSession(id: string) {
-  // Re-selecting the already-active, loaded session is a no-op.
-  // The sessionMap check is needed because the route watcher sets
-  // currentSessionId before calling loadSession — without it the
-  // guard would bail before the session data is fetched.
-  if (id === currentSessionId.value && sessionMap.has(id)) return;
+function activateSession(id: string, roleId: string, replace: boolean): void {
+  const reactiveSession = sessionMap.get(id);
+  if (reactiveSession) ensureSessionSubscription(reactiveSession);
+  navigateToSession(id, replace);
+  currentRoleId.value = roleId;
+  showHistory.value = false;
+}
 
-  // If the current session is empty, remove it from memory and use
-  // replace-navigation so the empty session doesn't linger in
-  // browser history (back button won't revisit it).
+async function loadSession(id: string) {
+  if (id === currentSessionId.value && sessionMap.has(id)) return;
   const replaced = removeCurrentIfEmpty();
 
-  // Already live in memory — just switch to it. The watch on
-  // currentSessionId clears the unread flag automatically.
   const live = sessionMap.get(id);
   if (live) {
-    navigateToSession(id, replaced);
-    currentRoleId.value = live.roleId;
-    showHistory.value = false;
+    activateSession(id, live.roleId, replaced);
     return;
   }
 
-  // Load from server
   const response = await apiGet<SessionEntry[]>(
     API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(id)),
   );
@@ -719,16 +714,7 @@ async function loadSession(id: string) {
     nowIso: new Date().toISOString(),
   });
   sessionMap.set(id, newSession);
-  // Subscribe immediately — the watch(currentSessionId) may have
-  // already fired before the session was in sessionMap (e.g. when
-  // opened via URL), so it couldn't subscribe at that point.
-  // Use sessionMap.get() to obtain the reactive proxy — passing the
-  // raw object would bypass Vue's reactivity tracking.
-  const reactiveSession = sessionMap.get(id)!;
-  ensureSessionSubscription(reactiveSession);
-  navigateToSession(id, replaced);
-  currentRoleId.value = newSession.roleId;
-  showHistory.value = false;
+  activateSession(id, newSession.roleId, replaced);
 }
 
 // Re-fetch the transcript from the server and patch any entries the
@@ -754,16 +740,10 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
 // Subscribe to a session's pub/sub channel so events from the server
 // (tool_call, text, tool_result, session_finished, etc.) arrive via
 // WebSocket and are dispatched into the session's reactive state.
-// Returns the unsubscribe function. Idempotent — if a subscription
-// already exists for this session, it's reused.
-function ensureSessionSubscription(session: ActiveSession): void {
-  if (sessionSubscriptions.has(session.id)) return;
-
+function buildAgentEventContext(session: ActiveSession): AgentEventContext {
   const sessionId = session.id;
-  const ctx: AgentEventContext = {
+  return {
     get session() {
-      // Always resolve from sessionMap so we track the latest
-      // reactive proxy — loadSession may replace the object.
       return sessionMap.get(sessionId) ?? session;
     },
     setCurrentRoleId: (roleId) => {
@@ -773,34 +753,30 @@ function ensureSessionSubscription(session: ActiveSession): void {
     refreshRoles,
     scrollSidebarToBottom: () => rightSidebarRef.value?.scrollToBottom(),
   };
+}
 
+function handleSessionFinished(sessionId: string): void {
+  refreshSessionTranscript(sessionId);
+  if (currentSessionId.value === sessionId) {
+    markSessionRead(sessionId);
+  } else {
+    unsubscribeSession(sessionId);
+  }
+}
+
+function ensureSessionSubscription(session: ActiveSession): void {
+  if (sessionSubscriptions.has(session.id)) return;
+  const ctx = buildAgentEventContext(session);
   const channel = sessionChannel(session.id);
   const unsub = pubsubSubscribe(channel, (data) => {
     const event = data as SseEvent;
     if (!event || typeof event !== "object") return;
-
-    // session_finished signals end-of-run. If the user is viewing
-    // this session, clear unread and keep the subscription alive so
-    // we receive events if another tab starts a new run. Only
-    // unsubscribe sessions the user is NOT currently viewing — the
-    // watch(currentSessionId) handler cleans up when switching away.
     if (event.type === EVENT_TYPES.sessionFinished) {
-      // Recover any events lost due to pub-sub disconnects during
-      // long runs (e.g. Docker builds). Fire-and-forget; if the
-      // re-fetch fails the user still has whatever events arrived
-      // via the live stream + can reload manually. See #350.
-      refreshSessionTranscript(session.id);
-      if (currentSessionId.value === session.id) {
-        markSessionRead(session.id);
-      } else {
-        unsubscribeSession(session.id);
-      }
+      handleSessionFinished(session.id);
       return;
     }
-
     applyAgentEvent(event, ctx);
   });
-
   sessionSubscriptions.set(session.id, unsub);
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -268,6 +268,7 @@ import {
 import {
   pushErrorMessage,
   beginUserTurn,
+  updateResult,
 } from "./utils/session/sessionHelpers";
 import { maybeSeedRoleDefault } from "./utils/session/seedRoleDefault";
 import { createEmptySession } from "./utils/session/sessionFactory";
@@ -287,6 +288,7 @@ import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
 import { useMergedSessions } from "./composables/useMergedSessions";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
+import { useSelectedResult } from "./composables/useSelectedResult";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
@@ -297,7 +299,7 @@ import { useRightSidebar } from "./composables/useRightSidebar";
 import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
 import { provideActiveSession } from "./composables/useActiveSession";
-import { useRoute, useRouter, isNavigationFailure } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { apiGet } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
 import { needsGemini } from "./utils/role/plugins";
@@ -389,37 +391,6 @@ watch(
   },
 );
 
-// External URL changes for ?result= → sync into the session's
-// selectedResultUuid. This handles back/forward and direct URL
-// access with a specific result pre-selected.
-watch(
-  () => route.query.result,
-  (newResult) => {
-    const session = sessionMap.get(currentSessionId.value);
-    if (!session) return;
-    const resultId = typeof newResult === "string" ? newResult : null;
-    if (resultId !== session.selectedResultUuid) {
-      session.selectedResultUuid = resultId;
-    }
-  },
-);
-
-// Deduplicate consecutive tool results with the same toolName for the
-const selectedResultUuid = computed({
-  get: () => activeSession.value?.selectedResultUuid ?? null,
-  set: (val: string | null) => {
-    if (activeSession.value) activeSession.value.selectedResultUuid = val;
-    // Sync to URL. Null/empty → remove ?result= for clean URLs.
-    const { result: __result, ...restQuery } = route.query;
-    const nextQuery = val ? { ...restQuery, result: val } : restQuery;
-    router.replace({ query: nextQuery }).catch((err: unknown) => {
-      if (!isNavigationFailure(err)) {
-        console.error("[selectedResultUuid] navigation failed:", err);
-      }
-    });
-  },
-});
-
 // --- Global state ---
 const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
 
@@ -447,6 +418,12 @@ const {
   activeSessionCount,
   unreadCount,
 } = useSessionDerived({ sessionMap, currentSessionId, sessions });
+
+const { selectedResultUuid } = useSelectedResult({
+  activeSession,
+  sessionMap,
+  currentSessionId,
+});
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
 useFaviconState({ isRunning, currentSummary, activeSession });
@@ -515,10 +492,7 @@ function handleNewSessionClick(): void {
   createNewSession();
 }
 
-// In plugin views (Todos / Files / ...) no chat is active, so the
-// Measure the top bar's height whenever the history popup is about
-// to open. Defer to nextTick so the popup's v-if transition doesn't
-// race the measurement.
+// Measure the top bar's height when the history popup opens.
 watch(showHistory, (open) => {
   if (open) {
     nextTick(() => {
@@ -544,11 +518,6 @@ const selectedResult = computed(
     toolResults.value.find((r) => r.uuid === selectedResultUuid.value) ?? null,
 );
 
-// Type-guard for the user-side branch of a text-response result. Used
-// to surface the first user message as a preview for live sessions
-// that haven't been persisted to disk yet.
-// Merged list for the history pane: live sessions in `sessionMap`
-// merged with server-only sessions, sorted newest-first by
 const { mergedSessions, tabSessions } = useMergedSessions({
   sessionMap,
   sessions,
@@ -609,12 +578,7 @@ function onQueryEdit(query: string): void {
 }
 
 function handleUpdateResult(updatedResult: ToolResultComplete) {
-  const results = activeSession.value?.toolResults;
-  if (!results) return;
-  const index = results.findIndex((r) => r.uuid === updatedResult.uuid);
-  if (index !== -1) {
-    Object.assign(results[index], updatedResult);
-  }
+  if (activeSession.value) updateResult(activeSession.value, updatedResult);
 }
 
 function onSidebarItemClick(uuid: string) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -728,7 +728,9 @@ function createSessionEventHandler(
       handleSessionFinished(session.id);
       return;
     }
-    applyAgentEvent(event, ctx);
+    applyAgentEvent(event, ctx).catch((err) => {
+      console.error("[applyAgentEvent] unhandled:", err);
+    });
   };
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -254,11 +254,7 @@ import SkillsView from "./plugins/manageSkills/View.vue";
 import RolesView from "./plugins/manageRoles/View.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import NotificationToast from "./components/NotificationToast.vue";
-import {
-  NOTIFICATION_ACTION_TYPES,
-  NOTIFICATION_VIEWS,
-  type NotificationAction,
-} from "./types/notification";
+import type { NotificationAction } from "./types/notification";
 import { CANVAS_VIEW } from "./utils/canvas/viewMode";
 import type { SseEvent } from "./types/sse";
 import { type SessionEntry, type ActiveSession } from "./types/session";
@@ -266,17 +262,20 @@ import { EVENT_TYPES } from "./types/events";
 import { extractImageData } from "./utils/tools/result";
 import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import {
+  applyAgentEvent,
+  type AgentEventContext,
+} from "./utils/agent/eventDispatch";
+import {
   pushErrorMessage,
   beginUserTurn,
-  applyTextEvent,
-  applyToolResultToSession,
 } from "./utils/session/sessionHelpers";
 import { maybeSeedRoleDefault } from "./utils/session/seedRoleDefault";
-import { findPendingToolCall, toToolCallEntry } from "./utils/agent/toolCalls";
+import { createEmptySession } from "./utils/session/sessionFactory";
 import {
   buildLoadedSession,
   parseSessionEntries,
 } from "./utils/session/sessionEntries";
+import { resolveNotificationTarget } from "./utils/notification/dispatch";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
@@ -351,15 +350,12 @@ function navigateToSession(id: string, replace = false): void {
 }
 
 function handleNotificationNavigate(action: NotificationAction): void {
-  if (action.type !== NOTIFICATION_ACTION_TYPES.navigate) return;
-  if (action.view === NOTIFICATION_VIEWS.chat) {
-    if (action.sessionId) navigateToSession(action.sessionId);
-  } else if (action.view === NOTIFICATION_VIEWS.todos) {
-    setCanvasViewMode(CANVAS_VIEW.todos);
-  } else if (action.view === NOTIFICATION_VIEWS.scheduler) {
-    setCanvasViewMode(CANVAS_VIEW.scheduler);
-  } else if (action.view === NOTIFICATION_VIEWS.files) {
-    setCanvasViewMode(CANVAS_VIEW.files);
+  const target = resolveNotificationTarget(action);
+  if (!target) return;
+  if (target.kind === "session") {
+    navigateToSession(target.sessionId);
+  } else {
+    setCanvasViewMode(CANVAS_VIEW[target.view]);
   }
 }
 
@@ -644,32 +640,15 @@ function removeCurrentIfEmpty(): boolean {
 }
 
 function createNewSession(roleId?: string): ActiveSession {
-  // Remove the current session if it's empty (no messages exchanged).
   removeCurrentIfEmpty();
-
-  const id = uuidv4();
   const rId = roleId ?? currentRoleId.value;
-  const now = new Date().toISOString();
-  const session: ActiveSession = {
-    id,
-    roleId: rId,
-    toolResults: [],
-    resultTimestamps: new Map(),
-    isRunning: false,
-    statusMessage: "",
-    toolCallHistory: [],
-    selectedResultUuid: null,
-    hasUnread: false,
-    startedAt: now,
-    updatedAt: now,
-    runStartIndex: 0,
-  };
-  sessionMap.set(id, session);
-  navigateToSession(id, true);
+  const session = createEmptySession(uuidv4(), rId);
+  sessionMap.set(session.id, session);
+  navigateToSession(session.id, true);
   currentRoleId.value = rId;
   suggestionsPanelRef.value?.collapse();
   nextTick(() => focusChatInput());
-  return sessionMap.get(id)!;
+  return sessionMap.get(session.id)!;
 }
 
 function onRoleChange() {
@@ -792,67 +771,6 @@ function unsubscribeSession(chatSessionId: string): void {
   if (unsub) {
     unsub();
     sessionSubscriptions.delete(chatSessionId);
-  }
-}
-
-// Dispatch a single event from the agent pub/sub channel against an
-// active session. Hoisted so its switch counts toward its own
-// cognitive-complexity budget rather than ballooning the caller's
-// score. Reactive refs / callbacks that live in the setup scope are
-// passed via `ctx` — this keeps the handler a regular named function
-// with a clear signature.
-interface AgentEventContext {
-  session: ActiveSession;
-  setCurrentRoleId: (roleId: string) => void;
-  onRoleChange: () => void;
-  refreshRoles: () => Promise<void>;
-  scrollSidebarToBottom: () => void;
-}
-
-async function applyAgentEvent(
-  event: SseEvent,
-  ctx: AgentEventContext,
-): Promise<void> {
-  const { session } = ctx;
-  switch (event.type) {
-    case EVENT_TYPES.toolCall:
-      session.toolCallHistory.push(toToolCallEntry(event));
-      ctx.scrollSidebarToBottom();
-      return;
-    case EVENT_TYPES.toolCallResult: {
-      const entry = findPendingToolCall(
-        session.toolCallHistory,
-        event.toolUseId,
-      );
-      if (entry) entry.result = event.content;
-      ctx.scrollSidebarToBottom();
-      return;
-    }
-    case EVENT_TYPES.status:
-      session.statusMessage = event.message;
-      return;
-    case EVENT_TYPES.switchRole:
-      setTimeout(() => {
-        ctx.setCurrentRoleId(event.roleId);
-        ctx.onRoleChange();
-      }, 0);
-      return;
-    case EVENT_TYPES.rolesUpdated:
-      await ctx.refreshRoles();
-      return;
-    case EVENT_TYPES.text:
-      applyTextEvent(session, event.message, event.source ?? "assistant");
-      return;
-    case EVENT_TYPES.toolResult:
-      applyToolResultToSession(session, event.result);
-      return;
-    case EVENT_TYPES.error:
-      console.error("[agent] error event:", event.message);
-      pushErrorMessage(session, event.message);
-      return;
-    case EVENT_TYPES.sessionFinished:
-      // Handled in the subscription callback — no-op here.
-      return;
   }
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -764,11 +764,11 @@ function handleSessionFinished(sessionId: string): void {
   }
 }
 
-function ensureSessionSubscription(session: ActiveSession): void {
-  if (sessionSubscriptions.has(session.id)) return;
-  const ctx = buildAgentEventContext(session);
-  const channel = sessionChannel(session.id);
-  const unsub = pubsubSubscribe(channel, (data) => {
+function createSessionEventHandler(
+  session: ActiveSession,
+  ctx: AgentEventContext,
+): (data: unknown) => void {
+  return (data: unknown) => {
     const event = data as SseEvent;
     if (!event || typeof event !== "object") return;
     if (event.type === EVENT_TYPES.sessionFinished) {
@@ -776,7 +776,14 @@ function ensureSessionSubscription(session: ActiveSession): void {
       return;
     }
     applyAgentEvent(event, ctx);
-  });
+  };
+}
+
+function ensureSessionSubscription(session: ActiveSession): void {
+  if (sessionSubscriptions.has(session.id)) return;
+  const ctx = buildAgentEventContext(session);
+  const handler = createSessionEventHandler(session, ctx);
+  const unsub = pubsubSubscribe(sessionChannel(session.id), handler);
   sessionSubscriptions.set(session.id, unsub);
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -332,7 +332,7 @@ const router = useRouter();
 // Omit ?role= for the default role to keep URLs clean.
 function buildRoleQuery(): Record<string, string> {
   const id = currentRoleId.value;
-  if (!id || id === roles.value[0]?.id) return {};
+  if (!id || roles.value.length === 0 || id === roles.value[0]?.id) return {};
   return { role: id };
 }
 
@@ -724,9 +724,6 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
   }
 }
 
-// Subscribe to a session's pub/sub channel so events from the server
-// (tool_call, text, tool_result, session_finished, etc.) arrive via
-// WebSocket and are dispatched into the session's reactive state.
 function buildAgentEventContext(session: ActiveSession): AgentEventContext {
   const sessionId = session.id;
   return {
@@ -753,7 +750,9 @@ function hasPendingGenerations(sessionId: string): boolean {
 }
 
 function handleSessionFinished(sessionId: string): void {
-  refreshSessionTranscript(sessionId);
+  refreshSessionTranscript(sessionId).catch((err) => {
+    console.error("[handleSessionFinished] refresh failed:", err);
+  });
   if (currentSessionId.value === sessionId) {
     markSessionRead(sessionId);
   } else if (!hasPendingGenerations(sessionId)) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,7 @@
       >
         <!-- Gemini API key warning -->
         <div
-          v-if="!geminiAvailable && needsGemini(currentRoleId)"
+          v-if="!geminiAvailable && needsGeminiForRole(currentRoleId)"
           class="mx-4 mt-3 mb-2 rounded border border-yellow-400 bg-yellow-50 p-3 text-xs text-yellow-700 shrink-0"
         >
           <span class="material-icons text-xs align-middle mr-1">warning</span>
@@ -114,7 +114,11 @@
       >
         <!-- Gemini API key warning (Stack layouts — no sidebar to host it) -->
         <div
-          v-if="isStackLayout && !geminiAvailable && needsGemini(currentRoleId)"
+          v-if="
+            isStackLayout &&
+            !geminiAvailable &&
+            needsGeminiForRole(currentRoleId)
+          "
           class="mx-3 mt-2 rounded border border-yellow-400 bg-yellow-50 p-2 text-xs text-yellow-700 shrink-0"
         >
           <span class="material-icons text-xs align-middle mr-1">warning</span>
@@ -240,9 +244,7 @@ import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";
 import CanvasViewToggle from "./components/CanvasViewToggle.vue";
-import PluginLauncher, {
-  type PluginLauncherTarget,
-} from "./components/PluginLauncher.vue";
+import PluginLauncher from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
 import TodoExplorer from "./components/TodoExplorer.vue";
@@ -261,23 +263,19 @@ import { CANVAS_VIEW } from "./utils/canvas/viewMode";
 import type { SseEvent } from "./types/sse";
 import { type SessionEntry, type ActiveSession } from "./types/session";
 import { EVENT_TYPES } from "./types/events";
-import { extractImageData, makeTextResult } from "./utils/tools/result";
-import { buildAgentRequestBody } from "./utils/agent/request";
+import { extractImageData } from "./utils/tools/result";
+import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import {
-  pushResult,
   pushErrorMessage,
   beginUserTurn,
-  appendToLastAssistantText,
+  applyTextEvent,
+  applyToolResultToSession,
 } from "./utils/session/sessionHelpers";
 import { maybeSeedRoleDefault } from "./utils/session/seedRoleDefault";
+import { findPendingToolCall, toToolCallEntry } from "./utils/agent/toolCalls";
 import {
-  findPendingToolCall,
-  shouldSelectAssistantText,
-} from "./utils/agent/toolCalls";
-import {
+  buildLoadedSession,
   parseSessionEntries,
-  resolveSelectedUuid,
-  resolveSessionTimestamps,
 } from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useClickOutside } from "./composables/useClickOutside";
@@ -290,7 +288,6 @@ import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
 import { useMergedSessions } from "./composables/useMergedSessions";
 import { useCanvasViewMode } from "./composables/useCanvasViewMode";
-import { isCanvasViewMode } from "./utils/canvas/viewMode";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { usePubSub } from "./composables/usePubSub";
@@ -301,8 +298,9 @@ import { useRightSidebar } from "./composables/useRightSidebar";
 import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
-import { apiGet, apiFetchRaw } from "./utils/api";
+import { apiGet } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
+import { needsGemini } from "./utils/role/plugins";
 
 // --- Per-session state ---
 // Declared early so that pub/sub callbacks and function declarations
@@ -331,27 +329,21 @@ const { subscribe: pubsubSubscribe } = usePubSub();
 const route = useRoute();
 const router = useRouter();
 
+// Omit ?role= for the default role to keep URLs clean.
+function buildRoleQuery(): Record<string, string> {
+  const id = currentRoleId.value;
+  if (!id || id === roles.value[0]?.id) return {};
+  return { role: id };
+}
+
 function navigateToSession(id: string, replace = false): void {
   currentSessionId.value = id;
   const method = replace ? router.replace : router.push;
-  // Use buildViewQuery() (reads canvasViewMode ref) instead of raw
-  // route.query — the ref may have been updated synchronously by
-  // setCanvasViewMode before this navigation runs, while
-  // route.query.view is still stale (router.push is async).
-  // Build query: view mode + role (omit role if it's the default
-  // to keep URLs clean for the common case).
-  const viewQuery = buildViewQuery();
-  const roleQuery =
-    currentRoleId.value && currentRoleId.value !== roles.value[0]?.id
-      ? { role: currentRoleId.value }
-      : {};
   method({
     name: "chat",
     params: { sessionId: id },
-    query: { ...viewQuery, ...roleQuery },
+    query: { ...buildViewQuery(), ...buildRoleQuery() },
   }).catch((err) => {
-    // NavigationDuplicated is harmless (user clicked the same session
-    // they're already on). Anything else is a real bug.
     if (err?.type !== 16) {
       console.error("[navigateToSession] push failed:", err);
     }
@@ -502,6 +494,7 @@ const {
   buildViewQuery,
   filesRefreshToken,
   handleViewModeShortcut,
+  onPluginNavigate,
 } = useCanvasViewMode({ isRunning });
 
 // The no-sidebar "stack-style" layout (top bar + full-width canvas +
@@ -546,13 +539,6 @@ watch(showHistory, (open) => {
   }
 });
 const rightSidebarRef = ref<InstanceType<typeof RightSidebar> | null>(null);
-
-// Plugin-launcher click: switch canvas to the matching view mode.
-function onPluginNavigate(target: PluginLauncherTarget): void {
-  if (isCanvasViewMode(target.key)) {
-    setCanvasViewMode(target.key);
-  }
-}
 
 const { availableTools, toolDescriptions, mcpToolsError, fetchMcpToolsStatus } =
   useMcpTools({
@@ -640,11 +626,7 @@ function onSidebarItemClick(uuid: string) {
   selectedResultUuid.value = uuid;
 }
 
-const GEMINI_PLUGINS = new Set(["generateImage", "presentDocument"]);
-const needsGemini = (roleId: string) =>
-  (roles.value.find((r) => r.id === roleId)?.availablePlugins ?? []).some((p) =>
-    GEMINI_PLUGINS.has(p),
-  );
+const needsGeminiForRole = (roleId: string) => needsGemini(roles.value, roleId);
 
 // Remove the current session from sessionMap if it's empty (no messages).
 // Returns true if a session was removed, so the caller can use
@@ -726,47 +708,16 @@ async function loadSession(id: string) {
     API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(id)),
   );
   if (!response.ok) return;
-  const entries = response.data;
 
-  const meta = entries.find((e) => e.type === EVENT_TYPES.sessionMeta);
-  const roleId = meta?.roleId ?? currentRoleId.value;
-  const toolResultsList = parseSessionEntries(entries);
-  const urlResult =
-    typeof route.query.result === "string" ? route.query.result : null;
-  const resolvedSelectedUuid = resolveSelectedUuid(toolResultsList, urlResult);
-  // Use server summary for live state (isRunning, etc.) and timestamps
-  const serverSummary = sessions.value.find((s) => s.id === id);
-  const { startedAt, updatedAt } = resolveSessionTimestamps(
-    serverSummary,
-    new Date().toISOString(),
-  );
-  // Approximate per-entry timestamps for a loaded session: the JSONL
-  // format doesn't persist them yet, so spread entries evenly between
-  // startedAt and updatedAt. New results pushed in this session via
-  // pushResult() will overwrite with the real Date.now().
-  const loadedTimestamps = new Map<string, number>();
-  const t0 = new Date(startedAt).getTime();
-  const t1 = new Date(updatedAt).getTime();
-  toolResultsList.forEach((r, i) => {
-    const frac =
-      toolResultsList.length > 1 ? i / (toolResultsList.length - 1) : 0;
-    loadedTimestamps.set(r.uuid, t0 + (t1 - t0) * frac);
-  });
-
-  const newSession: ActiveSession = {
+  const newSession = buildLoadedSession({
     id,
-    roleId,
-    toolResults: toolResultsList,
-    resultTimestamps: loadedTimestamps,
-    isRunning: serverSummary?.isRunning ?? false,
-    statusMessage: serverSummary?.statusMessage ?? "",
-    toolCallHistory: [],
-    selectedResultUuid: resolvedSelectedUuid,
-    hasUnread: false,
-    startedAt,
-    updatedAt,
-    runStartIndex: toolResultsList.length,
-  };
+    entries: response.data,
+    defaultRoleId: currentRoleId.value,
+    urlResult:
+      typeof route.query.result === "string" ? route.query.result : null,
+    serverSummary: sessions.value.find((s) => s.id === id),
+    nowIso: new Date().toISOString(),
+  });
   sessionMap.set(id, newSession);
   // Subscribe immediately — the watch(currentSessionId) may have
   // already fired before the session was in sessionMap (e.g. when
@@ -776,7 +727,7 @@ async function loadSession(id: string) {
   const reactiveSession = sessionMap.get(id)!;
   ensureSessionSubscription(reactiveSession);
   navigateToSession(id, replaced);
-  currentRoleId.value = roleId;
+  currentRoleId.value = newSession.roleId;
   showHistory.value = false;
 }
 
@@ -875,11 +826,6 @@ interface AgentEventContext {
   scrollSidebarToBottom: () => void;
 }
 
-// Try to append a text chunk to the last assistant text-response
-// result in the session. Returns true if appended, false if a new
-// result should be created instead. Extracted to keep
-// applyAgentEvent under the cognitive-complexity threshold.
-// eslint-disable-next-line sonarjs/cognitive-complexity -- pre-existing 15; streaming append adds 1
 async function applyAgentEvent(
   event: SseEvent,
   ctx: AgentEventContext,
@@ -887,12 +833,7 @@ async function applyAgentEvent(
   const { session } = ctx;
   switch (event.type) {
     case EVENT_TYPES.toolCall:
-      session.toolCallHistory.push({
-        toolUseId: event.toolUseId,
-        toolName: event.toolName,
-        args: event.args,
-        timestamp: Date.now(),
-      });
+      session.toolCallHistory.push(toToolCallEntry(event));
       ctx.scrollSidebarToBottom();
       return;
     case EVENT_TYPES.toolCallResult: {
@@ -916,50 +857,12 @@ async function applyAgentEvent(
     case EVENT_TYPES.rolesUpdated:
       await ctx.refreshRoles();
       return;
-    case EVENT_TYPES.text: {
-      const source = event.source ?? "assistant";
-      if (source === "user") {
-        // The tab that sent the message already added it locally via
-        // beginUserTurn. Deduplicate: skip if the last text-response
-        // is a user message with identical text.
-        const last = session.toolResults[session.toolResults.length - 1];
-        const lastData = last?.data as
-          | { role?: string; text?: string }
-          | undefined;
-        if (
-          last?.toolName === "text-response" &&
-          lastData?.role === "user" &&
-          lastData?.text === event.message
-        )
-          return;
-        pushResult(session, makeTextResult(event.message, "user"));
-        return;
-      }
-      // Streaming: append to the last assistant text-response if one
-      // exists, rather than creating a new card per chunk.
-      if (appendToLastAssistantText(session, event.message)) return;
-      const textResult = makeTextResult(event.message, "assistant");
-      pushResult(session, textResult);
-      if (
-        shouldSelectAssistantText(session.toolResults, session.runStartIndex)
-      ) {
-        session.selectedResultUuid = textResult.uuid;
-      }
+    case EVENT_TYPES.text:
+      applyTextEvent(session, event.message, event.source ?? "assistant");
       return;
-    }
-    case EVENT_TYPES.toolResult: {
-      const { result } = event;
-      const existing = session.toolResults.findIndex(
-        (r) => r.uuid === result.uuid,
-      );
-      if (existing >= 0) {
-        session.toolResults[existing] = result;
-      } else {
-        pushResult(session, result);
-        session.selectedResultUuid = result.uuid;
-      }
+    case EVENT_TYPES.toolResult:
+      applyToolResultToSession(session, event.result);
       return;
-    }
     case EVENT_TYPES.error:
       console.error("[agent] error event:", event.message);
       pushErrorMessage(session, event.message);
@@ -987,40 +890,18 @@ async function sendMessage(text?: string) {
     session.toolResults.find((r) => r.uuid === session.selectedResultUuid) ??
     undefined;
 
-  // Subscribe to the session's pub/sub channel BEFORE posting so we
-  // don't miss events. The subscription callback dispatches each
-  // event into the session's reactive state via applyAgentEvent.
   ensureSessionSubscription(session);
 
-  try {
-    const response = await apiFetchRaw(API_ROUTES.agent.run, {
-      method: "POST",
-      body: JSON.stringify(
-        buildAgentRequestBody({
-          message,
-          role: sessionRole,
-          chatSessionId: session.id,
-          selectedImageData:
-            fileSnapshot?.dataUrl ?? extractImageData(selectedRes),
-        }),
-      ),
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (!response.ok) {
-      const errBody = await response.text().catch(() => "");
-      pushErrorMessage(
-        session,
-        `Server error ${response.status}: ${errBody.slice(0, 200)}`,
-      );
-      unsubscribeSession(session.id);
-    }
-  } catch (e) {
-    console.error("[agent] fetch error:", e);
-    pushErrorMessage(
-      session,
-      e instanceof Error ? e.message : "Connection error.",
-    );
+  const result = await postAgentRun(
+    buildAgentRequestBody({
+      message,
+      role: sessionRole,
+      chatSessionId: session.id,
+      selectedImageData: fileSnapshot?.dataUrl ?? extractImageData(selectedRes),
+    }),
+  );
+  if (!result.ok) {
+    pushErrorMessage(session, result.error);
     unsubscribeSession(session.id);
   }
 }

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { getPlugin } from "../tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { View as TextResponseOriginalView } from "../plugins/textResponse/index";
@@ -308,21 +308,26 @@ watch(
   },
 );
 
-watch(
-  () => props.toolResults.length,
-  () => {
-    nextTick(() => {
-      if (containerRef.value) {
-        beginSuppressScrollSync();
-        containerRef.value.scrollTop = containerRef.value.scrollHeight;
-      }
-      // New items may have brought in more iframes to size.
-      for (const wrapper of naturalWrapperRefs.values()) {
-        sizeIframesIn(wrapper);
-      }
-    });
-  },
-);
+// Key that changes both on new results AND on streaming updates to
+// the last text card (which appends in place, leaving length stable).
+const latestResultScrollKey = computed(() => {
+  const list = props.toolResults;
+  const last = list[list.length - 1];
+  return `${list.length}:${last?.uuid ?? ""}:${last?.message?.length ?? 0}`;
+});
+
+watch(latestResultScrollKey, () => {
+  nextTick(() => {
+    if (containerRef.value) {
+      beginSuppressScrollSync();
+      containerRef.value.scrollTop = containerRef.value.scrollHeight;
+    }
+    // New items may have brought in more iframes to size.
+    for (const wrapper of naturalWrapperRefs.values()) {
+      sizeIframesIn(wrapper);
+    }
+  });
+});
 
 onMounted(() => {
   containerRef.value?.addEventListener("scroll", onContainerScroll, {

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -2,6 +2,7 @@
   <div
     ref="containerRef"
     class="h-full overflow-y-auto bg-gray-50 p-4 space-y-3"
+    data-testid="stack-scroll"
   >
     <div
       v-if="toolResults.length === 0"

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -3,6 +3,7 @@
     ref="root"
     class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 bg-gray-100 outline-none"
     tabindex="0"
+    data-testid="tool-results-scroll"
     @mousedown="emit('activate')"
   >
     <div

--- a/src/composables/useCanvasViewMode.ts
+++ b/src/composables/useCanvasViewMode.ts
@@ -14,6 +14,7 @@ import {
   VIEW_MODE_STORAGE_KEY,
   parseStoredViewMode,
   viewModeForShortcutKey,
+  isCanvasViewMode,
 } from "../utils/canvas/viewMode";
 import type { LocationQuery } from "vue-router";
 
@@ -47,6 +48,7 @@ export function useCanvasViewMode(opts: UseCanvasViewModeOptions): {
   buildViewQuery: () => LocationQuery;
   filesRefreshToken: Ref<number>;
   handleViewModeShortcut: (e: KeyboardEvent) => void;
+  onPluginNavigate: (target: { key: string }) => void;
 } {
   const route = useRoute();
   const router = useRouter();
@@ -111,11 +113,19 @@ export function useCanvasViewMode(opts: UseCanvasViewModeOptions): {
     e.preventDefault();
   }
 
+  /** Plugin-launcher click: switch canvas to the matching view mode. */
+  function onPluginNavigate(target: { key: string }): void {
+    if (isCanvasViewMode(target.key)) {
+      setCanvasViewMode(target.key);
+    }
+  }
+
   return {
     canvasViewMode,
     setCanvasViewMode,
     buildViewQuery,
     filesRefreshToken,
     handleViewModeShortcut,
+    onPluginNavigate,
   };
 }

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -2,15 +2,19 @@
 // arrive or a run starts. Also re-focuses the chat input when a run
 // finishes.
 
-import { nextTick, watch, type ComputedRef } from "vue";
+import { computed, nextTick, watch, type ComputedRef, type Ref } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 export function useChatScroll(opts: {
-  chatListRef: ComputedRef<HTMLDivElement | null>;
-  toolResultsLength: ComputedRef<number>;
+  toolResultsPanelRef: Ref<{ root: HTMLDivElement | null } | null>;
+  toolResults: ComputedRef<ToolResultComplete[]>;
   isRunning: ComputedRef<boolean>;
-  focusChatInput: () => void;
+  chatInputRef: Ref<{ focus: () => void } | null>;
 }) {
-  const { chatListRef, toolResultsLength, isRunning, focusChatInput } = opts;
+  const { toolResultsPanelRef, toolResults, isRunning, chatInputRef } = opts;
+
+  const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
+  const toolResultsLength = computed(() => toolResults.value.length);
 
   function scrollChatToBottom(): void {
     nextTick(() => {
@@ -18,6 +22,10 @@ export function useChatScroll(opts: {
         chatListRef.value.scrollTop = chatListRef.value.scrollHeight;
       }
     });
+  }
+
+  function focusChatInput(): void {
+    chatInputRef.value?.focus();
   }
 
   watch(toolResultsLength, scrollChatToBottom);
@@ -29,5 +37,5 @@ export function useChatScroll(opts: {
     }
   });
 
-  return { scrollChatToBottom };
+  return { scrollChatToBottom, focusChatInput };
 }

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -19,7 +19,7 @@ export function useChatScroll(opts: {
   const latestResultScrollKey = computed(() => {
     const list = toolResults.value;
     const last = list[list.length - 1];
-    return `${list.length}:${last?.uuid ?? ""}:${last?.message ?? ""}`;
+    return `${list.length}:${last?.uuid ?? ""}:${last?.message?.length ?? 0}`;
   });
 
   function scrollChatToBottom(): void {

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -14,7 +14,13 @@ export function useChatScroll(opts: {
   const { toolResultsPanelRef, toolResults, isRunning, chatInputRef } = opts;
 
   const chatListRef = computed(() => toolResultsPanelRef.value?.root ?? null);
-  const toolResultsLength = computed(() => toolResults.value.length);
+  // Key that changes both on new results AND on streaming updates to
+  // the last text card (which appends in place, leaving length stable).
+  const latestResultScrollKey = computed(() => {
+    const list = toolResults.value;
+    const last = list[list.length - 1];
+    return `${list.length}:${last?.uuid ?? ""}:${last?.message ?? ""}`;
+  });
 
   function scrollChatToBottom(): void {
     nextTick(() => {
@@ -28,7 +34,7 @@ export function useChatScroll(opts: {
     chatInputRef.value?.focus();
   }
 
-  watch(toolResultsLength, scrollChatToBottom);
+  watch(latestResultScrollKey, scrollChatToBottom);
   watch(isRunning, (running) => {
     if (running) {
       scrollChatToBottom();

--- a/src/composables/useSelectedResult.ts
+++ b/src/composables/useSelectedResult.ts
@@ -1,0 +1,52 @@
+// Writable computed that bridges activeSession.selectedResultUuid
+// with the URL's ?result= query parameter.
+
+import {
+  computed,
+  watch,
+  type ComputedRef,
+  type WritableComputedRef,
+} from "vue";
+import { useRoute, useRouter, isNavigationFailure } from "vue-router";
+import type { ActiveSession } from "../types/session";
+
+export function useSelectedResult(opts: {
+  activeSession: ComputedRef<ActiveSession | undefined>;
+  sessionMap: Map<string, ActiveSession>;
+  currentSessionId: { readonly value: string };
+}): {
+  selectedResultUuid: WritableComputedRef<string | null>;
+} {
+  const { activeSession } = opts;
+  const route = useRoute();
+  const router = useRouter();
+
+  const selectedResultUuid = computed({
+    get: () => activeSession.value?.selectedResultUuid ?? null,
+    set: (val: string | null) => {
+      if (activeSession.value) activeSession.value.selectedResultUuid = val;
+      const { result: __result, ...restQuery } = route.query;
+      const nextQuery = val ? { ...restQuery, result: val } : restQuery;
+      router.replace({ query: nextQuery }).catch((err: unknown) => {
+        if (!isNavigationFailure(err)) {
+          console.error("[selectedResultUuid] navigation failed:", err);
+        }
+      });
+    },
+  });
+
+  // External URL changes for ?result= → sync into the session.
+  watch(
+    () => route.query.result,
+    (newResult) => {
+      const session = opts.sessionMap.get(opts.currentSessionId.value);
+      if (!session) return;
+      const resultId = typeof newResult === "string" ? newResult : null;
+      if (resultId !== session.selectedResultUuid) {
+        session.selectedResultUuid = resultId;
+      }
+    },
+  );
+
+  return { selectedResultUuid };
+}

--- a/src/composables/useSelectedResult.ts
+++ b/src/composables/useSelectedResult.ts
@@ -41,6 +41,8 @@ export function useSelectedResult(opts: {
     (newResult) => {
       const session = opts.sessionMap.get(opts.currentSessionId.value);
       if (!session) return;
+      // Ignore malformed (array) values rather than clobbering state.
+      if (Array.isArray(newResult)) return;
       const resultId = typeof newResult === "string" ? newResult : null;
       if (resultId !== session.selectedResultUuid) {
         session.selectedResultUuid = resultId;

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -1,0 +1,66 @@
+// Pure dispatcher: maps an SseEvent into mutations on an ActiveSession
+// via the AgentEventContext adapter. No Vue refs, no component scope.
+
+import type { ActiveSession } from "../../types/session";
+import type { SseEvent } from "../../types/sse";
+import { EVENT_TYPES } from "../../types/events";
+import { findPendingToolCall, toToolCallEntry } from "./toolCalls";
+import {
+  pushErrorMessage,
+  applyTextEvent,
+  applyToolResultToSession,
+} from "../session/sessionHelpers";
+
+export interface AgentEventContext {
+  session: ActiveSession;
+  setCurrentRoleId: (roleId: string) => void;
+  onRoleChange: () => void;
+  refreshRoles: () => Promise<void>;
+  scrollSidebarToBottom: () => void;
+}
+
+export async function applyAgentEvent(
+  event: SseEvent,
+  ctx: AgentEventContext,
+): Promise<void> {
+  const { session } = ctx;
+  switch (event.type) {
+    case EVENT_TYPES.toolCall:
+      session.toolCallHistory.push(toToolCallEntry(event));
+      ctx.scrollSidebarToBottom();
+      return;
+    case EVENT_TYPES.toolCallResult: {
+      const entry = findPendingToolCall(
+        session.toolCallHistory,
+        event.toolUseId,
+      );
+      if (entry) entry.result = event.content;
+      ctx.scrollSidebarToBottom();
+      return;
+    }
+    case EVENT_TYPES.status:
+      session.statusMessage = event.message;
+      return;
+    case EVENT_TYPES.switchRole:
+      setTimeout(() => {
+        ctx.setCurrentRoleId(event.roleId);
+        ctx.onRoleChange();
+      }, 0);
+      return;
+    case EVENT_TYPES.rolesUpdated:
+      await ctx.refreshRoles();
+      return;
+    case EVENT_TYPES.text:
+      applyTextEvent(session, event.message, event.source ?? "assistant");
+      return;
+    case EVENT_TYPES.toolResult:
+      applyToolResultToSession(session, event.result);
+      return;
+    case EVENT_TYPES.error:
+      console.error("[agent] error event:", event.message);
+      pushErrorMessage(session, event.message);
+      return;
+    case EVENT_TYPES.sessionFinished:
+      return;
+  }
+}

--- a/src/utils/agent/request.ts
+++ b/src/utils/agent/request.ts
@@ -1,6 +1,8 @@
-// Request-body construction for `POST /api/agent`.
+// Request-body construction and dispatch for `POST /api/agent`.
 
 import type { Role } from "../../config/roles";
+import { API_ROUTES } from "../../config/apiRoutes";
+import { apiFetchRaw } from "../api";
 
 export interface AgentRequestBodyParams {
   message: string;
@@ -25,4 +27,33 @@ export function buildAgentRequestBody(
     chatSessionId: params.chatSessionId,
     selectedImageData: params.selectedImageData,
   };
+}
+
+/** POST the agent request body and return the response.
+ *  On network or HTTP error, returns a descriptive error string
+ *  instead. The caller decides how to surface it. */
+export async function postAgentRun(
+  body: AgentRequestBody,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const response = await apiFetchRaw(API_ROUTES.agent.run, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      return {
+        ok: false,
+        error: `Server error ${response.status}: ${errBody.slice(0, 200)}`,
+      };
+    }
+    return { ok: true };
+  } catch (e) {
+    console.error("[agent] fetch error:", e);
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Connection error.",
+    };
+  }
 }

--- a/src/utils/agent/toolCalls.ts
+++ b/src/utils/agent/toolCalls.ts
@@ -6,7 +6,19 @@
 // in #175.
 
 import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
+import type { SseToolCall } from "../../types/sse";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+// Convert an SSE tool_call event into a ToolCallHistoryItem ready
+// to push onto a session's toolCallHistory. Pure.
+export function toToolCallEntry(event: SseToolCall): ToolCallHistoryItem {
+  return {
+    toolUseId: event.toolUseId,
+    toolName: event.toolName,
+    args: event.args,
+    timestamp: Date.now(),
+  };
+}
 
 // When an SSE `tool_call_result` event arrives, the server tells
 // us which tool call it belongs to via `toolUseId`. Find the most

--- a/src/utils/notification/dispatch.ts
+++ b/src/utils/notification/dispatch.ts
@@ -1,0 +1,35 @@
+// Pure mapping from NotificationAction → target view/session to navigate to.
+
+import {
+  NOTIFICATION_ACTION_TYPES,
+  NOTIFICATION_VIEWS,
+  type NotificationAction,
+} from "../../types/notification";
+
+// Views that map directly to a canvas view mode (excludes "chat"
+// which is handled as a session navigation).
+type CanvasNotificationView = "todos" | "scheduler" | "files";
+
+export type NotificationTarget =
+  | { kind: "session"; sessionId: string }
+  | { kind: "view"; view: CanvasNotificationView }
+  | null;
+
+/** Determine what the user should see after clicking a notification.
+ *  Pure — the caller performs the actual navigation. */
+export function resolveNotificationTarget(
+  action: NotificationAction,
+): NotificationTarget {
+  if (action.type !== NOTIFICATION_ACTION_TYPES.navigate) return null;
+  if (action.view === NOTIFICATION_VIEWS.chat && action.sessionId) {
+    return { kind: "session", sessionId: action.sessionId };
+  }
+  if (
+    action.view === NOTIFICATION_VIEWS.todos ||
+    action.view === NOTIFICATION_VIEWS.scheduler ||
+    action.view === NOTIFICATION_VIEWS.files
+  ) {
+    return { kind: "view", view: action.view };
+  }
+  return null;
+}

--- a/src/utils/role/plugins.ts
+++ b/src/utils/role/plugins.ts
@@ -1,0 +1,13 @@
+// Pure helpers for role → plugin queries.
+// Takes the role list as a parameter for testability.
+
+import type { Role } from "../../config/roles";
+
+const GEMINI_PLUGINS = new Set(["generateImage", "presentDocument"]);
+
+/** Whether the given role uses any plugin that requires a Gemini API key. */
+export function needsGemini(roles: Role[], roleId: string): boolean {
+  return (roles.find((r) => r.id === roleId)?.availablePlugins ?? []).some(
+    (p) => GEMINI_PLUGINS.has(p),
+  );
+}

--- a/src/utils/role/plugins.ts
+++ b/src/utils/role/plugins.ts
@@ -2,8 +2,12 @@
 // Takes the role list as a parameter for testability.
 
 import type { Role } from "../../config/roles";
+import { TOOL_NAMES, type ToolName } from "../../config/toolNames";
 
-const GEMINI_PLUGINS = new Set(["generateImage", "presentDocument"]);
+const GEMINI_PLUGINS = new Set<ToolName>([
+  TOOL_NAMES.generateImage,
+  TOOL_NAMES.presentDocument,
+]);
 
 /** Whether the given role uses any plugin that requires a Gemini API key. */
 export function needsGemini(roles: Role[], roleId: string): boolean {

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -9,6 +9,7 @@ import { makeTextResult } from "../tools/result";
 import {
   isTextEntry,
   isToolResultEntry,
+  type ActiveSession,
   type SessionEntry,
   type SessionSummary,
 } from "../../types/session";
@@ -81,4 +82,64 @@ export function resolveSessionTimestamps(
   const startedAt = serverSummary?.startedAt ?? nowIso;
   const updatedAt = serverSummary?.updatedAt ?? startedAt;
   return { startedAt, updatedAt };
+}
+
+// Spread toolResults evenly between startedAt and updatedAt to
+// approximate per-entry timestamps for sessions loaded from disk.
+// Real-time results will overwrite with Date.now() via pushResult.
+export function interpolateTimestamps(
+  toolResults: readonly ToolResultComplete[],
+  startedAt: string,
+  updatedAt: string,
+): Map<string, number> {
+  const timestamps = new Map<string, number>();
+  const t0 = new Date(startedAt).getTime();
+  const t1 = new Date(updatedAt).getTime();
+  toolResults.forEach((r, i) => {
+    const frac = toolResults.length > 1 ? i / (toolResults.length - 1) : 0;
+    timestamps.set(r.uuid, t0 + (t1 - t0) * frac);
+  });
+  return timestamps;
+}
+
+// Build an ActiveSession from server-fetched entries + metadata.
+// Pure — the caller is responsible for inserting into sessionMap
+// and subscribing.
+export function buildLoadedSession(opts: {
+  id: string;
+  entries: readonly SessionEntry[];
+  defaultRoleId: string;
+  urlResult: string | null;
+  serverSummary: SessionSummary | undefined;
+  nowIso: string;
+}): ActiveSession {
+  const { id, entries, defaultRoleId, urlResult, serverSummary, nowIso } = opts;
+  const meta = entries.find((e) => e.type === EVENT_TYPES.sessionMeta);
+  const roleId = meta?.roleId ?? defaultRoleId;
+  const toolResults = parseSessionEntries(entries);
+  const selectedResultUuid = resolveSelectedUuid(toolResults, urlResult);
+  const { startedAt, updatedAt } = resolveSessionTimestamps(
+    serverSummary,
+    nowIso,
+  );
+  const resultTimestamps = interpolateTimestamps(
+    toolResults,
+    startedAt,
+    updatedAt,
+  );
+
+  return {
+    id,
+    roleId,
+    toolResults,
+    resultTimestamps,
+    isRunning: serverSummary?.isRunning ?? false,
+    statusMessage: serverSummary?.statusMessage ?? "",
+    toolCallHistory: [],
+    selectedResultUuid,
+    hasUnread: false,
+    startedAt,
+    updatedAt,
+    runStartIndex: toolResults.length,
+  };
 }

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -137,7 +137,7 @@ export function buildLoadedSession(opts: {
     statusMessage: serverSummary?.statusMessage ?? "",
     toolCallHistory: [],
     selectedResultUuid,
-    hasUnread: false,
+    hasUnread: serverSummary?.hasUnread ?? false,
     startedAt,
     updatedAt,
     runStartIndex: toolResults.length,

--- a/src/utils/session/sessionFactory.ts
+++ b/src/utils/session/sessionFactory.ts
@@ -1,0 +1,21 @@
+// Pure factory for creating a blank ActiveSession.
+
+import type { ActiveSession } from "../../types/session";
+
+export function createEmptySession(id: string, roleId: string): ActiveSession {
+  const now = new Date().toISOString();
+  return {
+    id,
+    roleId,
+    toolResults: [],
+    resultTimestamps: new Map(),
+    isRunning: false,
+    statusMessage: "",
+    toolCallHistory: [],
+    selectedResultUuid: null,
+    hasUnread: false,
+    startedAt: now,
+    updatedAt: now,
+    runStartIndex: 0,
+  };
+}

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -92,6 +92,20 @@ export function applyTextEvent(
   }
 }
 
+/** In-place update a result that was re-emitted by a plugin view
+ *  (e.g. after the user edits a chart config). */
+export function updateResult(
+  session: ActiveSession,
+  updatedResult: ToolResultComplete,
+): void {
+  const index = session.toolResults.findIndex(
+    (r) => r.uuid === updatedResult.uuid,
+  );
+  if (index !== -1) {
+    Object.assign(session.toolResults[index], updatedResult);
+  }
+}
+
 /** Handle an incoming tool_result event: upsert into the session's
  *  result list. Selects the result only on insert; in-place updates
  *  preserve the user's current selection. */

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -93,7 +93,8 @@ export function applyTextEvent(
 }
 
 /** Handle an incoming tool_result event: upsert into the session's
- *  result list and select it. */
+ *  result list. Selects the result only on insert; in-place updates
+ *  preserve the user's current selection. */
 export function applyToolResultToSession(
   session: ActiveSession,
   result: ToolResultComplete,

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ActiveSession } from "../../types/session";
 import { makeTextResult } from "../tools/result";
+import { shouldSelectAssistantText } from "../agent/toolCalls";
 
 /** Push a result and record its timestamp in one place. */
 export function pushResult(
@@ -54,4 +55,54 @@ export function appendToLastAssistantText(
   lastData.text = (lastData.text ?? "") + text;
   last.message = (last.message ?? "") + text;
   return true;
+}
+
+/** Check if an incoming user text event is a duplicate of the last
+ *  user message (sent by this tab via beginUserTurn). */
+function isDuplicateUserText(session: ActiveSession, message: string): boolean {
+  const last = session.toolResults[session.toolResults.length - 1];
+  const lastData = last?.data as { role?: string; text?: string } | undefined;
+  return (
+    last?.toolName === "text-response" &&
+    lastData?.role === "user" &&
+    lastData?.text === message
+  );
+}
+
+/** Handle an incoming text event (user or assistant) from the
+ *  agent's SSE/pubsub stream. Deduplicates user messages,
+ *  streams assistant text into the last card, and selects the
+ *  result when appropriate. */
+export function applyTextEvent(
+  session: ActiveSession,
+  message: string,
+  source: "user" | "assistant",
+): void {
+  if (source === "user") {
+    if (!isDuplicateUserText(session, message)) {
+      pushResult(session, makeTextResult(message, "user"));
+    }
+    return;
+  }
+  if (appendToLastAssistantText(session, message)) return;
+  const textResult = makeTextResult(message, "assistant");
+  pushResult(session, textResult);
+  if (shouldSelectAssistantText(session.toolResults, session.runStartIndex)) {
+    session.selectedResultUuid = textResult.uuid;
+  }
+}
+
+/** Handle an incoming tool_result event: upsert into the session's
+ *  result list and select it. */
+export function applyToolResultToSession(
+  session: ActiveSession,
+  result: ToolResultComplete,
+): void {
+  const idx = session.toolResults.findIndex((r) => r.uuid === result.uuid);
+  if (idx >= 0) {
+    session.toolResults[idx] = result;
+  } else {
+    pushResult(session, result);
+    session.selectedResultUuid = result.uuid;
+  }
 }

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -81,6 +81,7 @@ export function applyTextEvent(
   if (source === "user") {
     if (!isDuplicateUserText(session, message)) {
       pushResult(session, makeTextResult(message, "user"));
+      session.runStartIndex = session.toolResults.length;
     }
     return;
   }

--- a/test/composables/test_useChatScroll.ts
+++ b/test/composables/test_useChatScroll.ts
@@ -1,0 +1,143 @@
+// Regression test for the streaming auto-scroll bug: when the
+// assistant streams text into an existing text-response card via
+// appendToLastAssistantText, the card's `.message` grows in place
+// and `toolResults.length` does not change. Watching only `length`
+// (the pre-fix behaviour) stopped auto-scroll mid-stream.
+//
+// The fix is to watch a key that includes the last result's message
+// length, so the scroll fires on every streaming chunk.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computed, nextTick, reactive, ref } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { useChatScroll } from "../../src/composables/useChatScroll.js";
+import {
+  applyTextEvent,
+  pushResult,
+} from "../../src/utils/session/sessionHelpers.js";
+import { createEmptySession } from "../../src/utils/session/sessionFactory.js";
+import { makeTextResult } from "../../src/utils/tools/result.js";
+
+// Build a fake scroll-container element that records every write
+// to scrollTop so the test can count auto-scroll invocations.
+function makeFakeScrollEl() {
+  const writes: number[] = [];
+  let scrollTop = 0;
+  const el = {
+    get scrollTop() {
+      return scrollTop;
+    },
+    set scrollTop(val: number) {
+      scrollTop = val;
+      writes.push(val);
+    },
+    scrollHeight: 1000,
+  };
+  // The composable expects an HTMLDivElement; the fake only needs
+  // scrollTop/scrollHeight, so the cast is safe in test scope.
+  return { el: el as unknown as HTMLDivElement, writes };
+}
+
+describe("useChatScroll — streaming auto-scroll", () => {
+  it("scrolls when a new text-response is appended (length changes)", async () => {
+    const session = reactive(createEmptySession("s1", "general"));
+    const { el, writes } = makeFakeScrollEl();
+
+    const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>({
+      root: el,
+    });
+    const toolResults = computed<ToolResultComplete[]>(
+      () => session.toolResults,
+    );
+    const isRunning = computed(() => false);
+    const chatInputRef = ref<{ focus: () => void } | null>(null);
+
+    useChatScroll({
+      toolResultsPanelRef,
+      toolResults,
+      isRunning,
+      chatInputRef,
+    });
+
+    // Simulate: first assistant chunk pushes a new text-response card.
+    pushResult(session, makeTextResult("Hello", "assistant"));
+    await nextTick();
+    await nextTick(); // watcher → scrollChatToBottom → nextTick → write
+
+    assert.ok(writes.length >= 1, "scroll should fire on new result");
+  });
+
+  it("scrolls on in-place streaming updates (length unchanged)", async () => {
+    // This is the regression the fix targets: `appendToLastAssistantText`
+    // mutates `last.message` in place — if the watch key only tracked
+    // `toolResults.length`, no further scrolls would fire after the
+    // first chunk.
+    const session = reactive(createEmptySession("s2", "general"));
+    const { el, writes } = makeFakeScrollEl();
+
+    const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>({
+      root: el,
+    });
+    const toolResults = computed<ToolResultComplete[]>(
+      () => session.toolResults,
+    );
+    const isRunning = computed(() => false);
+    const chatInputRef = ref<{ focus: () => void } | null>(null);
+
+    useChatScroll({
+      toolResultsPanelRef,
+      toolResults,
+      isRunning,
+      chatInputRef,
+    });
+
+    // First chunk: new text-response card (length 0 → 1, uuid changes).
+    applyTextEvent(session, "Hello", "assistant");
+    await nextTick();
+    await nextTick();
+    const writesAfterFirst = writes.length;
+    assert.ok(writesAfterFirst >= 1, "first chunk should scroll");
+
+    // Subsequent chunks append in place — length stays 1, but message
+    // grows. The fix must trigger additional scrolls here.
+    applyTextEvent(session, " world", "assistant");
+    await nextTick();
+    await nextTick();
+    applyTextEvent(session, "!", "assistant");
+    await nextTick();
+    await nextTick();
+
+    assert.ok(
+      writes.length > writesAfterFirst,
+      `streaming chunks should trigger further scrolls — pre-fix this stayed at ${writesAfterFirst} (writes=${writes.length})`,
+    );
+
+    // Sanity: the session accumulated the full message in place.
+    assert.equal(session.toolResults.length, 1);
+    assert.equal(session.toolResults[0].message, "Hello world!");
+  });
+
+  it("does not scroll when isRunning is the only change and no results", async () => {
+    // isRunning flipping true also schedules a scroll (run-start focus),
+    // but nothing to scroll when there are no results. Just confirm
+    // the watcher is wired and doesn't throw.
+    const session = reactive(createEmptySession("s3", "general"));
+    const running = ref(false);
+    const { el } = makeFakeScrollEl();
+
+    useChatScroll({
+      toolResultsPanelRef: ref({ root: el }),
+      toolResults: computed(() => session.toolResults),
+      isRunning: computed(() => running.value),
+      chatInputRef: ref(null),
+    });
+
+    running.value = true;
+    await nextTick();
+    running.value = false;
+    await nextTick();
+    // No assertion on scrolls — this test just ensures the watchers
+    // don't crash when flipping isRunning with an empty list.
+  });
+});


### PR DESCRIPTION
## Summary
- Extract pure helpers and composable functions from App.vue (1078 → 935 lines)
- All long functions (>30 lines) split into focused helpers
- Pure functions moved out of Vue into utility modules

## Items to Confirm / Review
- `applyTextEvent` / `applyToolResultToSession` in sessionHelpers.ts handle all edge cases from the original inline code
- `postAgentRun` discriminated-union return type is clean
- `buildLoadedSession` in sessionEntries.ts consolidates ~40 lines of session reconstruction logic

## User Prompt
- onPluginNavigate を useCanvasViewMode の中に配置
- 残りの独立抽出候補: needsGemini helper, selectedResultUuid computed
- eventからpayloadを作る関数にして session.toolCallHistory.push(toToolCallEntry(event)) にする
- roleQuery を関数化して navigateToSession をきれいに
- 30行以上の関数はできる限り分割
- pure関数はVueに置かないで外に移動

## Extractions

| What | Where |
|---|---|
| `onPluginNavigate` | `useCanvasViewMode` composable |
| `needsGemini` | `src/utils/role/plugins.ts` |
| `toToolCallEntry` | `src/utils/agent/toolCalls.ts` |
| `buildRoleQuery` | App.vue (local, cleans up navigateToSession) |
| `buildLoadedSession` + `interpolateTimestamps` | `src/utils/session/sessionEntries.ts` |
| `applyTextEvent` + `applyToolResultToSession` | `src/utils/session/sessionHelpers.ts` |
| `postAgentRun` | `src/utils/agent/request.ts` |
| `buildAgentEventContext` | App.vue (local, splits ensureSessionSubscription) |
| `handleSessionFinished` | App.vue (local, splits subscription callback) |
| `activateSession` | App.vue (local, shared by loadSession live/server paths) |

## Test plan
- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors (6 pre-existing warnings)
- [x] `yarn typecheck` — pass
- [x] `yarn build` — pass
- [x] `yarn test` — 29/29 pass
- [ ] E2E tests (run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor App.vue by extracting session, agent, view-mode, and role/plugin helpers into dedicated utility modules and composables, simplifying session loading, event handling, and agent request flow.

Enhancements:
- Move Gemini plugin requirement logic into a reusable role plugins helper and wire it into App.vue.
- Extract canvas plugin navigation into the useCanvasViewMode composable to centralize view-mode switching behavior.
- Introduce pure helpers for converting SSE tool_call events and applying text/tool_result events to session state, reducing App.vue complexity.
- Add utilities to build loaded sessions and interpolate timestamps from server-fetched entries, consolidating session reconstruction logic.
- Encapsulate agent POST request/response handling in a dedicated postAgentRun helper, separating network concerns from UI logic.
- Factor out agent event context construction and session-finished handling into focused helpers to streamline subscription setup and callbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin navigation now supports canvas view-mode targets and notification actions map to sessions or canvas views.
  * Added selection sync between session results and URL, and chat focus helper when new results arrive.

* **Refactor**
  * Modularized agent event dispatch and subscription flow; centralized session activation and construction with interpolated timestamps and tool-call history.
  * Simplified notification-to-navigation resolution.

* **Bug Fixes**
  * Improved agent request error handling and more accurate Gemini-related UI warning rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->