### PR TITLE
feat: support `npx mulmoclaude` startup for Vue + Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Chat with Claude Code and get back not just text but **interactive visual output
 
 ## Quick Start
 
+### Option A: Run directly with npx
+
+```bash
+npx mulmoclaude
+```
+
+This starts both services for local use:
+
+- Vue client: `http://localhost:5173`
+- Express server: `http://localhost:3001`
+
+### Option B: Clone and run from source
+
 ```bash
 # 1. Clone and install
 git clone git@github.com:receptron/mulmoclaude.git

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "private": true,
+  "private": false,
   "version": "0.2.0",
   "type": "module",
   "author": "snakajima",
@@ -107,5 +107,8 @@
     "vite": "^8.0.8",
     "vue-eslint-parser": "^10.4.0",
     "vue-tsc": "^3.2.7"
+  },
+  "bin": {
+    "mulmoclaude": "scripts/mulmoclaude.mjs"
   }
 }

--- a/scripts/mulmoclaude.mjs
+++ b/scripts/mulmoclaude.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const SERVER_START_DELAY_MS = 2000;
+
+const spawnProcess = (name, command, args) => {
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      console.log(`[${name}] exited via signal ${signal}`);
+      return;
+    }
+
+    if (code && code !== 0) {
+      console.error(`[${name}] exited with code ${code}`);
+    }
+  });
+
+  return child;
+};
+
+const server = spawnProcess("server", "npx", ["tsx", "server/index.ts"]);
+let client;
+
+const startClient = () => {
+  client = spawnProcess("client", "npx", ["vite"]);
+};
+
+const shutdown = () => {
+  server?.kill("SIGTERM");
+  client?.kill("SIGTERM");
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+server.on("exit", () => {
+  client?.kill("SIGTERM");
+  process.exit();
+});
+
+setTimeout(startClient, SERVER_START_DELAY_MS);


### PR DESCRIPTION
### Motivation
- Make it easy to run the app without cloning by providing an `npx mulmoclaude` entrypoint that launches both the Vue client and Express server for local use.

### Description
- Add `scripts/mulmoclaude.mjs`, a small Node launcher that spawns the server (`tsx server/index.ts`) and then the Vite client (`vite`), handles `SIGINT`/`SIGTERM`, and kills the child processes on exit.
- Expose the launcher via the root `package.json` `bin` field as `mulmoclaude` and set the root package `private` to `false` so it can be executed with `npx`.
- Update `README.md` Quick Start to add `Option A: npx mulmoclaude` and document the client/server URLs.

### Testing
- Ran `yarn format` (succeeded).
- Ran `yarn lint` (succeeded; existing `vue/no-v-html` warnings remain but no new errors).
- Ran `yarn typecheck` (failed due to pre-existing unrelated type errors in `src/App.vue` and unresolved `@mulmobridge/protocol` types; not introduced by this change).
- Ran `yarn build` (succeeded) and executed the launcher (`node scripts/mulmoclaude.mjs` with a short timeout) to verify the server and Vite client start behavior (Vite reported ready within the test window).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e718a931088333ae65c5f77d8c9d47)

## Summary by Sourcery

Add an npx-executable launcher script that starts both the Vue client and Express server for local development and document this new startup option.

New Features:
- Provide a mulmoclaude CLI entrypoint via the package bin field so the app can be started with npx without cloning.
- Introduce a Node launcher script that spins up the Express server and Vite-based Vue client and coordinates their lifecycle.

Documentation:
- Update the Quick Start guide to describe running the app via npx and document the local client and server URLs.