### PR TITLE
chore: enable id-length rule as warn (min 3) + seed cleanups

### DIFF
--- a/e2e/tests/files-scheduler-preview.spec.ts
+++ b/e2e/tests/files-scheduler-preview.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { WORKSPACE_FILES } from "../../src/config/workspacePaths";
+
+// Opening data/scheduler/items.json in the Files view should render
+// the scheduler plugin's calendar/tasks view instead of a raw JSON
+// blob. This covers `toSchedulerResult` + the FileContentRenderer
+// dispatch in the composables/components extracted by #517.
+const SCHEDULER_URL = `/chat?view=files&path=${WORKSPACE_FILES.schedulerItems}`;
+
+const SAMPLE_ITEMS = [
+  {
+    id: "s1",
+    title: "Daily standup",
+    createdAt: Date.now(),
+    props: { schedule: "daily" },
+  },
+  {
+    id: "s2",
+    title: "Weekly review",
+    createdAt: Date.now(),
+    props: { schedule: "weekly" },
+  },
+];
+
+test.describe("Files view — scheduler preview", () => {
+  test("renders SchedulerView (Calendar + Tasks tabs) when opening the items file", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+
+    // Serve the raw JSON body via /api/files/content so the renderer
+    // can parse it into SchedulerData.
+    await page.route("**/api/files/content?**", (route) => {
+      return route.fulfill({
+        json: {
+          kind: "text",
+          path: WORKSPACE_FILES.schedulerItems,
+          content: JSON.stringify(SAMPLE_ITEMS),
+          size: JSON.stringify(SAMPLE_ITEMS).length,
+          modifiedMs: Date.now(),
+        },
+      });
+    });
+
+    await page.goto(SCHEDULER_URL);
+
+    // Tabs from SchedulerView (not present in a raw-JSON code view)
+    await expect(
+      page.locator('[data-testid="scheduler-tab-calendar"]'),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.locator('[data-testid="scheduler-tab-tasks"]'),
+    ).toBeVisible();
+  });
+
+  test("falls back to raw JSON rendering when the body is malformed", async ({
+    page,
+  }) => {
+    await mockAllApis(page);
+    await page.route("**/api/files/content?**", (route) =>
+      route.fulfill({
+        json: {
+          kind: "text",
+          path: WORKSPACE_FILES.schedulerItems,
+          content: "{not: json",
+          size: 10,
+          modifiedMs: Date.now(),
+        },
+      }),
+    );
+
+    await page.goto(SCHEDULER_URL);
+
+    // Scheduler-specific tabs must NOT appear (toSchedulerResult rejects
+    // malformed JSON and the renderer falls through to the .json branch).
+    await expect(page.getByTestId("scheduler-tab-calendar")).toHaveCount(0);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,33 @@ export default [
     },
     rules: {
       indent: ["error", 2],
+      // Loop iterators (i/j), throwaway (_), and domain-standard
+      // 2-char idioms exempted. `id` covers every record-with-id
+      // in the codebase. `fs`/`os`/`path` are Node-module imports.
+      // `ok` is the Result-pattern discriminator. `ms`/`ts` are
+      // unit-suffixed time values. `md` is markdown. `it` is
+      // node:test's `it()`.
+      // Enabled as `warn` so existing short names across the repo
+      // don't block CI — we migrate incrementally.
+      "id-length": [
+        "warn",
+        {
+          min: 3,
+          exceptions: [
+            "i",
+            "j",
+            "_",
+            "id",
+            "ok",
+            "fs",
+            "os",
+            "ts",
+            "ms",
+            "md",
+            "it",
+          ],
+        },
+      ],
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/src/App.vue
+++ b/src/App.vue
@@ -613,7 +613,7 @@ watch(currentSessionId, (id) => {
 
   // Clear unread in both sessionMap and sessions list (for badge count),
   // then tell the server so other tabs see it too.
-  const summary = sessions.value.find((session) => session.id === id);
+  const summary = sessions.value.find((entry) => entry.id === id);
   const wasUnread =
     (session && session.hasUnread) || (summary && summary.hasUnread);
   if (wasUnread) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -396,7 +396,7 @@ watch(
   () => route.query.role,
   (newRole) => {
     if (typeof newRole !== "string" || newRole === currentRoleId.value) return;
-    const roleExists = roles.value.some((r) => r.id === newRole);
+    const roleExists = roles.value.some((role) => role.id === newRole);
     if (roleExists) currentRoleId.value = newRole;
   },
 );
@@ -568,7 +568,9 @@ const { pendingCalls, teardown: teardownPendingCalls } = usePendingCalls({
 
 const selectedResult = computed(
   () =>
-    toolResults.value.find((r) => r.uuid === selectedResultUuid.value) ?? null,
+    toolResults.value.find(
+      (result) => result.uuid === selectedResultUuid.value,
+    ) ?? null,
 );
 
 // Type-guard for the user-side branch of a text-response result. Used
@@ -611,7 +613,7 @@ watch(currentSessionId, (id) => {
 
   // Clear unread in both sessionMap and sessions list (for badge count),
   // then tell the server so other tabs see it too.
-  const summary = sessions.value.find((s) => s.id === id);
+  const summary = sessions.value.find((session) => session.id === id);
   const wasUnread =
     (session && session.hasUnread) || (summary && summary.hasUnread);
   if (wasUnread) {
@@ -638,7 +640,9 @@ function onQueryEdit(query: string): void {
 function handleUpdateResult(updatedResult: ToolResultComplete) {
   const results = activeSession.value?.toolResults;
   if (!results) return;
-  const index = results.findIndex((r) => r.uuid === updatedResult.uuid);
+  const index = results.findIndex(
+    (result) => result.uuid === updatedResult.uuid,
+  );
   if (index !== -1) {
     Object.assign(results[index], updatedResult);
   }
@@ -650,8 +654,8 @@ function onSidebarItemClick(uuid: string) {
 
 const GEMINI_PLUGINS = new Set(["generateImage", "presentDocument"]);
 const needsGemini = (roleId: string) =>
-  (roles.value.find((r) => r.id === roleId)?.availablePlugins ?? []).some((p) =>
-    GEMINI_PLUGINS.has(p),
+  (roles.value.find((role) => role.id === roleId)?.availablePlugins ?? []).some(
+    (plugin) => GEMINI_PLUGINS.has(plugin),
   );
 
 // Remove the current session from sessionMap if it's empty (no messages).
@@ -737,14 +741,14 @@ async function loadSession(id: string) {
   if (!response.ok) return;
   const entries = response.data;
 
-  const meta = entries.find((e) => e.type === EVENT_TYPES.sessionMeta);
+  const meta = entries.find((entry) => entry.type === EVENT_TYPES.sessionMeta);
   const roleId = meta?.roleId ?? currentRoleId.value;
   const toolResultsList = parseSessionEntries(entries);
   const urlResult =
     typeof route.query.result === "string" ? route.query.result : null;
   const resolvedSelectedUuid = resolveSelectedUuid(toolResultsList, urlResult);
   // Use server summary for live state (isRunning, etc.) and timestamps
-  const serverSummary = sessions.value.find((s) => s.id === id);
+  const serverSummary = sessions.value.find((session) => session.id === id);
   const { startedAt, updatedAt } = resolveSessionTimestamps(
     serverSummary,
     new Date().toISOString(),
@@ -754,12 +758,12 @@ async function loadSession(id: string) {
   // startedAt and updatedAt. New results pushed in this session via
   // pushResult() will overwrite with the real Date.now().
   const loadedTimestamps = new Map<string, number>();
-  const t0 = new Date(startedAt).getTime();
-  const t1 = new Date(updatedAt).getTime();
-  toolResultsList.forEach((r, i) => {
+  const startMs = new Date(startedAt).getTime();
+  const endMs = new Date(updatedAt).getTime();
+  toolResultsList.forEach((result, i) => {
     const frac =
       toolResultsList.length > 1 ? i / (toolResultsList.length - 1) : 0;
-    loadedTimestamps.set(r.uuid, t0 + (t1 - t0) * frac);
+    loadedTimestamps.set(result.uuid, startMs + (endMs - startMs) * frac);
   });
 
   const newSession: ActiveSession = {
@@ -966,7 +970,7 @@ async function applyAgentEvent(
     case EVENT_TYPES.toolResult: {
       const { result } = event;
       const existing = session.toolResults.findIndex(
-        (r) => r.uuid === result.uuid,
+        (existingResult) => existingResult.uuid === result.uuid,
       );
       if (existing >= 0) {
         session.toolResults[existing] = result;
@@ -1019,10 +1023,11 @@ async function sendMessage(text?: string) {
 
   beginUserTurn(session, message);
   const sessionRole =
-    roles.value.find((r) => r.id === session.roleId) ?? roles.value[0];
+    roles.value.find((role) => role.id === session.roleId) ?? roles.value[0];
   const selectedRes =
-    session.toolResults.find((r) => r.uuid === session.selectedResultUuid) ??
-    undefined;
+    session.toolResults.find(
+      (result) => result.uuid === session.selectedResultUuid,
+    ) ?? undefined;
 
   // Subscribe to the session's pub/sub channel BEFORE posting so we
   // don't miss events. The subscription callback dispatches each
@@ -1052,11 +1057,11 @@ async function sendMessage(text?: string) {
       );
       unsubscribeSession(session.id);
     }
-  } catch (e) {
-    console.error("[agent] fetch error:", e);
+  } catch (err) {
+    console.error("[agent] fetch error:", err);
     pushErrorMessage(
       session,
-      e instanceof Error ? e.message : "Connection error.",
+      err instanceof Error ? err.message : "Connection error.",
     );
     unsubscribeSession(session.id);
   }
@@ -1097,7 +1102,7 @@ onMounted(async () => {
   // If the URL specifies a role, apply it before session creation.
   const urlRole =
     typeof route.query.role === "string" ? route.query.role : null;
-  if (urlRole && roles.value.some((r) => r.id === urlRole)) {
+  if (urlRole && roles.value.some((role) => role.id === urlRole)) {
     currentRoleId.value = urlRole;
   }
 

--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -26,10 +26,10 @@ export type FileContent = TextContent | MetaContent;
 
 /** Segment-wise traversal check: rejects `../` path components
  *  but allows legitimate filenames like `my..notes.txt`. */
-export function isValidFilePath(p: unknown): p is string {
-  if (typeof p !== "string" || p.length === 0) return false;
-  if (p.startsWith("/")) return false;
-  return !p.split("/").some((seg) => seg === "..");
+export function isValidFilePath(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  if (value.startsWith("/")) return false;
+  return !value.split("/").some((seg) => seg === "..");
 }
 
 export function useFileSelection() {

--- a/src/plugins/todo/labels.ts
+++ b/src/plugins/todo/labels.ts
@@ -20,11 +20,11 @@ export function normalizeLabel(raw: string): string | null {
 
 // Case-insensitive label equality. Both inputs are normalised first
 // so `" Work "` and `"work"` compare equal.
-export function labelsEqual(a: string, b: string): boolean {
-  const na = normalizeLabel(a);
-  const nb = normalizeLabel(b);
-  if (na === null || nb === null) return false;
-  return na.toLowerCase() === nb.toLowerCase();
+export function labelsEqual(left: string, right: string): boolean {
+  const normLeft = normalizeLabel(left);
+  const normRight = normalizeLabel(right);
+  if (normLeft === null || normRight === null) return false;
+  return normLeft.toLowerCase() === normRight.toLowerCase();
 }
 
 // ── Colour assignment ─────────────────────────────────────────────
@@ -75,15 +75,15 @@ export function filterByLabels<T extends { labels?: string[] }>(
   const wanted = new Set(
     filterLabels
       .map(normalizeLabel)
-      .filter((l): l is string => l !== null)
-      .map((l) => l.toLowerCase()),
+      .filter((label): label is string => label !== null)
+      .map((label) => label.toLowerCase()),
   );
   if (wanted.size === 0) return [...items];
   return items.filter((item) => {
     const itemLabels = item.labels ?? [];
-    return itemLabels.some((l) => {
-      const n = normalizeLabel(l);
-      return n !== null && wanted.has(n.toLowerCase());
+    return itemLabels.some((label) => {
+      const normalized = normalizeLabel(label);
+      return normalized !== null && wanted.has(normalized.toLowerCase());
     });
   });
 }
@@ -120,11 +120,11 @@ export function listLabelsWithCount(
       }
     }
   }
-  return [...groups.values()].sort((a, b) => {
-    if (b.count !== a.count) return b.count - a.count;
-    return a.label.toLowerCase() < b.label.toLowerCase()
+  return [...groups.values()].sort((left, right) => {
+    if (right.count !== left.count) return right.count - left.count;
+    return left.label.toLowerCase() < right.label.toLowerCase()
       ? -1
-      : a.label.toLowerCase() > b.label.toLowerCase()
+      : left.label.toLowerCase() > right.label.toLowerCase()
         ? 1
         : 0;
   });
@@ -165,14 +165,16 @@ export function subtractLabels(
   const toRemove = new Set(
     removing
       .map(normalizeLabel)
-      .filter((l): l is string => l !== null)
-      .map((l) => l.toLowerCase()),
+      .filter((label): label is string => label !== null)
+      .map((label) => label.toLowerCase()),
   );
   if (toRemove.size === 0) {
-    return existing.map(normalizeLabel).filter((l): l is string => l !== null);
+    return existing
+      .map(normalizeLabel)
+      .filter((label): label is string => label !== null);
   }
   return existing
     .map(normalizeLabel)
-    .filter((l): l is string => l !== null)
-    .filter((l) => !toRemove.has(l.toLowerCase()));
+    .filter((label): label is string => label !== null)
+    .filter((label) => !toRemove.has(label.toLowerCase()));
 }

--- a/src/utils/filesPreview/schedulerPreview.ts
+++ b/src/utils/filesPreview/schedulerPreview.ts
@@ -9,15 +9,15 @@ import type {
 } from "../../plugins/scheduler/index";
 import { WORKSPACE_FILES } from "../../config/workspacePaths";
 
-function isScheduledItem(x: unknown): x is ScheduledItem {
-  if (typeof x !== "object" || x === null) return false;
-  if (!("id" in x) || typeof x.id !== "string") return false;
-  if (!("title" in x) || typeof x.title !== "string") return false;
+function isScheduledItem(value: unknown): value is ScheduledItem {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("id" in value) || typeof value.id !== "string") return false;
+  if (!("title" in value) || typeof value.title !== "string") return false;
   return true;
 }
 
-function isScheduledItemArray(x: unknown): x is ScheduledItem[] {
-  return Array.isArray(x) && x.every(isScheduledItem);
+function isScheduledItemArray(value: unknown): value is ScheduledItem[] {
+  return Array.isArray(value) && value.every(isScheduledItem);
 }
 
 export function toSchedulerResult(

--- a/src/utils/filesPreview/todoPreview.ts
+++ b/src/utils/filesPreview/todoPreview.ts
@@ -10,18 +10,18 @@ import type {
 } from "../../plugins/todo/index";
 import { WORKSPACE_FILES } from "../../config/workspacePaths";
 
-function isTodoItem(x: unknown): x is TodoItem {
-  if (typeof x !== "object" || x === null) return false;
-  const o = x as Record<string, unknown>;
-  if (typeof o["id"] !== "string" || typeof o["text"] !== "string")
+function isTodoItem(value: unknown): value is TodoItem {
+  if (typeof value !== "object" || value === null) return false;
+  const rec = value as Record<string, unknown>;
+  if (typeof rec["id"] !== "string" || typeof rec["text"] !== "string")
     return false;
-  if (typeof o["completed"] !== "boolean") return false;
-  if (typeof o["createdAt"] !== "number") return false;
+  if (typeof rec["completed"] !== "boolean") return false;
+  if (typeof rec["createdAt"] !== "number") return false;
   return true;
 }
 
-function isTodoItemArray(x: unknown): x is TodoItem[] {
-  return Array.isArray(x) && x.every(isTodoItem);
+function isTodoItemArray(value: unknown): value is TodoItem[] {
+  return Array.isArray(value) && value.every(isTodoItem);
 }
 
 export function toTodoExplorerResult(

--- a/test/composables/test_useContentDisplay.ts
+++ b/test/composables/test_useContentDisplay.ts
@@ -1,0 +1,157 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ref } from "vue";
+import { useContentDisplay } from "../../src/composables/useContentDisplay.ts";
+import type { FileContent } from "../../src/composables/useFileSelection.ts";
+
+function textContent(path: string, body: string): FileContent {
+  return {
+    kind: "text",
+    path,
+    content: body,
+    size: body.length,
+    modifiedMs: 0,
+  };
+}
+
+describe("useContentDisplay — type flags", () => {
+  it("isMarkdown is true for .md and .markdown (case-insensitive)", () => {
+    for (const p of ["a.md", "a.MD", "a.Markdown", "deep/path/README.md"]) {
+      const selectedPath = ref<string | null>(p);
+      const content = ref<FileContent | null>(null);
+      const { isMarkdown } = useContentDisplay(selectedPath, content);
+      assert.equal(isMarkdown.value, true, `path=${p}`);
+    }
+  });
+
+  it("isMarkdown is false for null, unrelated extensions", () => {
+    for (const p of [null, "a.mdx", "a.txt", "a"]) {
+      const selectedPath = ref<string | null>(p);
+      const content = ref<FileContent | null>(null);
+      const { isMarkdown } = useContentDisplay(selectedPath, content);
+      assert.equal(isMarkdown.value, false, `path=${JSON.stringify(p)}`);
+    }
+  });
+
+  it("isHtml covers .html and .htm", () => {
+    const selected = ref<string | null>("x.html");
+    const content = ref<FileContent | null>(null);
+    assert.equal(useContentDisplay(selected, content).isHtml.value, true);
+    selected.value = "x.htm";
+    assert.equal(useContentDisplay(selected, content).isHtml.value, true);
+    selected.value = "x.xhtml";
+    assert.equal(useContentDisplay(selected, content).isHtml.value, false);
+  });
+
+  it("isJson only matches .json (not .jsonl)", () => {
+    const selected = ref<string | null>("x.json");
+    const content = ref<FileContent | null>(null);
+    assert.equal(useContentDisplay(selected, content).isJson.value, true);
+    selected.value = "x.jsonl";
+    assert.equal(useContentDisplay(selected, content).isJson.value, false);
+  });
+
+  it("isJsonl covers .jsonl and .ndjson", () => {
+    const selected = ref<string | null>("x.jsonl");
+    const content = ref<FileContent | null>(null);
+    assert.equal(useContentDisplay(selected, content).isJsonl.value, true);
+    selected.value = "x.ndjson";
+    assert.equal(useContentDisplay(selected, content).isJsonl.value, true);
+    selected.value = "x.json";
+    assert.equal(useContentDisplay(selected, content).isJsonl.value, false);
+  });
+});
+
+describe("useContentDisplay — sandboxedHtml", () => {
+  it("wraps HTML content with CSP meta when selection is .html + text kind", () => {
+    const selectedPath = ref<string | null>("a.html");
+    const content = ref<FileContent | null>(textContent("a.html", "<p>hi</p>"));
+    const { sandboxedHtml } = useContentDisplay(selectedPath, content);
+    assert.ok(sandboxedHtml.value.length > 0);
+    assert.ok(sandboxedHtml.value.includes("<p>hi</p>"));
+    assert.match(sandboxedHtml.value, /Content-Security-Policy/i);
+  });
+
+  it("is empty string when selection isn't HTML", () => {
+    const selectedPath = ref<string | null>("a.md");
+    const content = ref<FileContent | null>(textContent("a.md", "# hi"));
+    const { sandboxedHtml } = useContentDisplay(selectedPath, content);
+    assert.equal(sandboxedHtml.value, "");
+  });
+
+  it("is empty string when content is null", () => {
+    const selectedPath = ref<string | null>("a.html");
+    const content = ref<FileContent | null>(null);
+    const { sandboxedHtml } = useContentDisplay(selectedPath, content);
+    assert.equal(sandboxedHtml.value, "");
+  });
+});
+
+describe("useContentDisplay — JSON guards (regression: #517 review)", () => {
+  it("jsonTokens is [] for non-JSON text files (no eager parsing)", () => {
+    const selectedPath = ref<string | null>("a.md");
+    const content = ref<FileContent | null>(
+      textContent("a.md", "not json at all ["),
+    );
+    const { jsonTokens } = useContentDisplay(selectedPath, content);
+    // Without the isJson guard, prettyJson/tokenizeJson would run
+    // on arbitrary markdown. Guard must short-circuit first.
+    assert.deepEqual(jsonTokens.value, []);
+  });
+
+  it("jsonlLines is [] for non-JSONL text files", () => {
+    const selectedPath = ref<string | null>("a.md");
+    const content = ref<FileContent | null>(textContent("a.md", "body"));
+    const { jsonlLines } = useContentDisplay(selectedPath, content);
+    assert.deepEqual(jsonlLines.value, []);
+  });
+
+  it("jsonTokens has content for actual .json files", () => {
+    const selectedPath = ref<string | null>("a.json");
+    const content = ref<FileContent | null>(textContent("a.json", '{"k":1}'));
+    const { jsonTokens } = useContentDisplay(selectedPath, content);
+    assert.ok(jsonTokens.value.length > 0);
+  });
+
+  it("jsonlLines has lines for actual .jsonl files", () => {
+    const selectedPath = ref<string | null>("a.jsonl");
+    const content = ref<FileContent | null>(
+      textContent("a.jsonl", '{"k":1}\n{"k":2}'),
+    );
+    const { jsonlLines } = useContentDisplay(selectedPath, content);
+    assert.equal(jsonlLines.value.length, 2);
+  });
+});
+
+describe("useContentDisplay — mdFrontmatter", () => {
+  it("returns parsed frontmatter for markdown with `---` header", () => {
+    const selectedPath = ref<string | null>("a.md");
+    const content = ref<FileContent | null>(
+      textContent("a.md", "---\ntitle: Hello\n---\nbody"),
+    );
+    const { mdFrontmatter } = useContentDisplay(selectedPath, content);
+    assert.ok(mdFrontmatter.value);
+    assert.equal(mdFrontmatter.value.body, "body");
+    const titleField = mdFrontmatter.value.fields.find(
+      (f) => f.key === "title",
+    );
+    assert.ok(titleField);
+    assert.equal(titleField.value, "Hello");
+  });
+
+  it("is null for non-markdown files even if the text starts with ---", () => {
+    const selectedPath = ref<string | null>("a.txt");
+    const content = ref<FileContent | null>(
+      textContent("a.txt", "---\ntitle: x\n---\nbody"),
+    );
+    const { mdFrontmatter } = useContentDisplay(selectedPath, content);
+    assert.equal(mdFrontmatter.value, null);
+  });
+
+  it("is null when content is null", () => {
+    const selectedPath = ref<string | null>("a.md");
+    const content = ref<FileContent | null>(null);
+    const { mdFrontmatter } = useContentDisplay(selectedPath, content);
+    assert.equal(mdFrontmatter.value, null);
+  });
+});

--- a/test/composables/test_useContentDisplay.ts
+++ b/test/composables/test_useContentDisplay.ts
@@ -16,20 +16,20 @@ function textContent(path: string, body: string): FileContent {
 
 describe("useContentDisplay — type flags", () => {
   it("isMarkdown is true for .md and .markdown (case-insensitive)", () => {
-    for (const p of ["a.md", "a.MD", "a.Markdown", "deep/path/README.md"]) {
-      const selectedPath = ref<string | null>(p);
+    for (const path of ["a.md", "a.MD", "a.Markdown", "deep/path/README.md"]) {
+      const selectedPath = ref<string | null>(path);
       const content = ref<FileContent | null>(null);
       const { isMarkdown } = useContentDisplay(selectedPath, content);
-      assert.equal(isMarkdown.value, true, `path=${p}`);
+      assert.equal(isMarkdown.value, true, `path=${path}`);
     }
   });
 
   it("isMarkdown is false for null, unrelated extensions", () => {
-    for (const p of [null, "a.mdx", "a.txt", "a"]) {
-      const selectedPath = ref<string | null>(p);
+    for (const path of [null, "a.mdx", "a.txt", "a"]) {
+      const selectedPath = ref<string | null>(path);
       const content = ref<FileContent | null>(null);
       const { isMarkdown } = useContentDisplay(selectedPath, content);
-      assert.equal(isMarkdown.value, false, `path=${JSON.stringify(p)}`);
+      assert.equal(isMarkdown.value, false, `path=${JSON.stringify(path)}`);
     }
   });
 
@@ -133,7 +133,7 @@ describe("useContentDisplay — mdFrontmatter", () => {
     assert.ok(mdFrontmatter.value);
     assert.equal(mdFrontmatter.value.body, "body");
     const titleField = mdFrontmatter.value.fields.find(
-      (f) => f.key === "title",
+      (field) => field.key === "title",
     );
     assert.ok(titleField);
     assert.equal(titleField.value, "Hello");

--- a/test/composables/test_useFileSelection.ts
+++ b/test/composables/test_useFileSelection.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isValidFilePath } from "../../src/composables/useFileSelection.ts";
+
+// Full useFileSelection needs vue-router context; covered by e2e.
+// Here we lock down the URL-path validator, which is the entry point
+// for every externally-supplied `?path=` value.
+
+describe("isValidFilePath", () => {
+  it("accepts ordinary workspace-relative paths", () => {
+    for (const p of [
+      "a",
+      "a.md",
+      "notes/a.md",
+      "deep/nested/path/file.json",
+      "with-dashes_and.dots/file.txt",
+      "spaces are fine.md",
+      "unicode/日本語.md",
+    ]) {
+      assert.equal(isValidFilePath(p), true, `path=${p}`);
+    }
+  });
+
+  it("accepts filenames that contain '..' but aren't a traversal segment", () => {
+    // Segment-wise check (#504-style): `my..notes.txt` is a legitimate
+    // filename; `../secret` is not.
+    assert.equal(isValidFilePath("my..notes.txt"), true);
+    assert.equal(isValidFilePath("a/my..notes.txt"), true);
+    assert.equal(isValidFilePath("file..tar.gz"), true);
+  });
+
+  it("rejects parent-directory segments", () => {
+    for (const p of ["..", "../secret", "a/../b", "a/b/.."]) {
+      assert.equal(isValidFilePath(p), false, `path=${p}`);
+    }
+  });
+
+  it("rejects absolute paths (leading /)", () => {
+    assert.equal(isValidFilePath("/etc/passwd"), false);
+    assert.equal(isValidFilePath("/a.md"), false);
+  });
+
+  it("rejects empty string and non-string values", () => {
+    for (const v of ["", null, undefined, 42, [], ["a"], {}, true, false]) {
+      assert.equal(isValidFilePath(v), false, `value=${JSON.stringify(v)}`);
+    }
+  });
+});

--- a/test/composables/test_useFileSelection.ts
+++ b/test/composables/test_useFileSelection.ts
@@ -8,7 +8,7 @@ import { isValidFilePath } from "../../src/composables/useFileSelection.ts";
 
 describe("isValidFilePath", () => {
   it("accepts ordinary workspace-relative paths", () => {
-    for (const p of [
+    for (const path of [
       "a",
       "a.md",
       "notes/a.md",
@@ -17,7 +17,7 @@ describe("isValidFilePath", () => {
       "spaces are fine.md",
       "unicode/日本語.md",
     ]) {
-      assert.equal(isValidFilePath(p), true, `path=${p}`);
+      assert.equal(isValidFilePath(path), true, `path=${path}`);
     }
   });
 
@@ -30,8 +30,8 @@ describe("isValidFilePath", () => {
   });
 
   it("rejects parent-directory segments", () => {
-    for (const p of ["..", "../secret", "a/../b", "a/b/.."]) {
-      assert.equal(isValidFilePath(p), false, `path=${p}`);
+    for (const path of ["..", "../secret", "a/../b", "a/b/.."]) {
+      assert.equal(isValidFilePath(path), false, `path=${path}`);
     }
   });
 
@@ -41,8 +41,8 @@ describe("isValidFilePath", () => {
   });
 
   it("rejects empty string and non-string values", () => {
-    for (const v of ["", null, undefined, 42, [], ["a"], {}, true, false]) {
-      assert.equal(isValidFilePath(v), false, `value=${JSON.stringify(v)}`);
+    for (const val of ["", null, undefined, 42, [], ["a"], {}, true, false]) {
+      assert.equal(isValidFilePath(val), false, `value=${JSON.stringify(val)}`);
     }
   });
 });

--- a/test/composables/test_useMarkdownLinkHandler.ts
+++ b/test/composables/test_useMarkdownLinkHandler.ts
@@ -1,0 +1,232 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ref } from "vue";
+import { useMarkdownLinkHandler } from "../../src/composables/useMarkdownLinkHandler.ts";
+
+// Minimal Element stub: `closest(selector)` walks a parent chain we
+// pre-build in each test; `getAttribute` reads a map. useMarkdownLinkHandler
+// only touches these two methods plus the `instanceof Element` check
+// which we satisfy by stubbing `globalThis.Element`.
+
+interface FakeAnchor {
+  getAttribute(name: string): string | null;
+}
+
+interface FakeElement {
+  tag: string;
+  parent: FakeElement | null;
+  href?: string;
+  closest(selector: string): FakeAnchor | null;
+}
+
+function makeAnchor(href: string | null): FakeElement {
+  const el: FakeElement = {
+    tag: "a",
+    parent: null,
+    href: href ?? undefined,
+    closest(selector) {
+      if (selector !== "a") return null;
+      return {
+        getAttribute: (name: string) =>
+          name === "href" ? (href ?? null) : null,
+      };
+    },
+  };
+  return el;
+}
+
+function makeSpanInsideAnchor(href: string | null): FakeElement {
+  // Span whose `closest("a")` walks up to the anchor.
+  const anchorAttrs = href;
+  return {
+    tag: "span",
+    parent: null,
+    closest(selector) {
+      if (selector !== "a") return null;
+      return {
+        getAttribute: (name: string) =>
+          name === "href" ? (anchorAttrs ?? null) : null,
+      };
+    },
+  };
+}
+
+interface FakeMouseEvent {
+  button: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  target: FakeElement | null | Record<string, unknown>;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}
+
+function makeEvent(opts: Partial<FakeMouseEvent> = {}): FakeMouseEvent {
+  const ev: FakeMouseEvent = {
+    button: 0,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    target: null,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() {
+      ev.defaultPrevented = true;
+    },
+    stopPropagation() {
+      ev.propagationStopped = true;
+    },
+    ...opts,
+  };
+  return ev;
+}
+
+// Install a minimal Element constructor so `instanceof Element` passes
+// for anything whose prototype chain includes our base.
+class FakeElementBase {}
+const originalElement = (globalThis as { Element?: unknown }).Element;
+
+function installFakeElement(): void {
+  (globalThis as { Element: unknown }).Element = FakeElementBase;
+}
+function restoreElement(): void {
+  if (originalElement === undefined) {
+    delete (globalThis as { Element?: unknown }).Element;
+  } else {
+    (globalThis as { Element: unknown }).Element = originalElement;
+  }
+}
+
+function makeReal(fake: FakeElement): FakeElement {
+  Object.setPrototypeOf(fake, FakeElementBase.prototype);
+  return fake;
+}
+
+interface CapturedCalls {
+  navigate: string[];
+  session: string[];
+}
+
+function setup(selectedPath: string | null = "notes/a.md") {
+  const captured: CapturedCalls = { navigate: [], session: [] };
+  const path = ref<string | null>(selectedPath);
+  const { handleMarkdownLinkClick } = useMarkdownLinkHandler(path, {
+    onNavigate: (p) => captured.navigate.push(p),
+    onLoadSession: (s) => captured.session.push(s),
+  });
+  return { path, handleMarkdownLinkClick, captured };
+}
+
+describe("useMarkdownLinkHandler", () => {
+  beforeEach(installFakeElement);
+  afterEach(restoreElement);
+
+  it("navigates to a resolved workspace path for relative links", () => {
+    const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
+    const ev = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.deepEqual(captured.navigate, ["notes/b.md"]);
+    assert.equal(captured.session.length, 0);
+    assert.equal(ev.defaultPrevented, true);
+    assert.equal(ev.propagationStopped, true);
+  });
+
+  it("walks up via closest('a') when the click target is a nested element", () => {
+    const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
+    const ev = makeEvent({
+      target: makeReal(makeSpanInsideAnchor("./b.md")),
+    });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.deepEqual(captured.navigate, ["notes/b.md"]);
+  });
+
+  it("emits loadSession (not navigate) for chat/<id>.jsonl links", () => {
+    // resolveWorkspaceLink joins "notes/a.md" + "../chat/abc-123.jsonl"
+    // → "chat/abc-123.jsonl", which extractSessionIdFromPath recognises.
+    const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
+    const ev = makeEvent({
+      target: makeReal(makeAnchor("../chat/abc-123.jsonl")),
+    });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.deepEqual(captured.session, ["abc-123"]);
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("ignores external http(s) links (lets browser handle)", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    const ev = makeEvent({
+      target: makeReal(makeAnchor("https://example.com")),
+    });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+    assert.equal(ev.defaultPrevented, false);
+  });
+
+  it("ignores anchor-only (#section) links", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    const ev = makeEvent({ target: makeReal(makeAnchor("#heading")) });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+    assert.equal(ev.defaultPrevented, false);
+  });
+
+  it("ignores right/middle button clicks", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    for (const button of [1, 2]) {
+      const ev = makeEvent({
+        button,
+        target: makeReal(makeAnchor("./b.md")),
+      });
+      handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    }
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("ignores modifier-key clicks (ctrl/meta/shift open in new tab)", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    for (const mod of ["ctrlKey", "metaKey", "shiftKey"] as const) {
+      const ev = makeEvent({
+        [mod]: true,
+        target: makeReal(makeAnchor("./b.md")),
+      });
+      handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    }
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("does nothing when event.target isn't an Element (regression: instanceof guard)", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    // A plain object that does NOT inherit from FakeElementBase.
+    const ev = makeEvent({ target: { closest: () => makeAnchor("./b.md") } });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("does nothing when the target has no surrounding anchor", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    const targetWithNoAnchor: FakeElement = {
+      tag: "p",
+      parent: null,
+      closest: () => null,
+    };
+    const ev = makeEvent({ target: makeReal(targetWithNoAnchor) });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("does nothing when href is missing", () => {
+    const { handleMarkdownLinkClick, captured } = setup();
+    const ev = makeEvent({ target: makeReal(makeAnchor(null)) });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+  });
+
+  it("does nothing when no file is selected (selectedPath is null)", () => {
+    const { handleMarkdownLinkClick, captured } = setup(null);
+    const ev = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
+    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    assert.equal(captured.navigate.length, 0);
+  });
+});

--- a/test/composables/test_useMarkdownLinkHandler.ts
+++ b/test/composables/test_useMarkdownLinkHandler.ts
@@ -20,7 +20,7 @@ interface FakeElement {
 }
 
 function makeAnchor(href: string | null): FakeElement {
-  const el: FakeElement = {
+  const anchor: FakeElement = {
     tag: "a",
     parent: null,
     href: href ?? undefined,
@@ -32,7 +32,7 @@ function makeAnchor(href: string | null): FakeElement {
       };
     },
   };
-  return el;
+  return anchor;
 }
 
 function makeSpanInsideAnchor(href: string | null): FakeElement {
@@ -64,7 +64,7 @@ interface FakeMouseEvent {
 }
 
 function makeEvent(opts: Partial<FakeMouseEvent> = {}): FakeMouseEvent {
-  const ev: FakeMouseEvent = {
+  const event: FakeMouseEvent = {
     button: 0,
     ctrlKey: false,
     metaKey: false,
@@ -73,14 +73,14 @@ function makeEvent(opts: Partial<FakeMouseEvent> = {}): FakeMouseEvent {
     defaultPrevented: false,
     propagationStopped: false,
     preventDefault() {
-      ev.defaultPrevented = true;
+      event.defaultPrevented = true;
     },
     stopPropagation() {
-      ev.propagationStopped = true;
+      event.propagationStopped = true;
     },
     ...opts,
   };
-  return ev;
+  return event;
 }
 
 // Install a minimal Element constructor so `instanceof Element` passes
@@ -113,8 +113,8 @@ function setup(selectedPath: string | null = "notes/a.md") {
   const captured: CapturedCalls = { navigate: [], session: [] };
   const path = ref<string | null>(selectedPath);
   const { handleMarkdownLinkClick } = useMarkdownLinkHandler(path, {
-    onNavigate: (p) => captured.navigate.push(p),
-    onLoadSession: (s) => captured.session.push(s),
+    onNavigate: (target) => captured.navigate.push(target),
+    onLoadSession: (sessionId) => captured.session.push(sessionId),
   });
   return { path, handleMarkdownLinkClick, captured };
 }
@@ -125,20 +125,20 @@ describe("useMarkdownLinkHandler", () => {
 
   it("navigates to a resolved workspace path for relative links", () => {
     const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
-    const ev = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.deepEqual(captured.navigate, ["notes/b.md"]);
     assert.equal(captured.session.length, 0);
-    assert.equal(ev.defaultPrevented, true);
-    assert.equal(ev.propagationStopped, true);
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(event.propagationStopped, true);
   });
 
   it("walks up via closest('a') when the click target is a nested element", () => {
     const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
-    const ev = makeEvent({
+    const event = makeEvent({
       target: makeReal(makeSpanInsideAnchor("./b.md")),
     });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.deepEqual(captured.navigate, ["notes/b.md"]);
   });
 
@@ -146,40 +146,40 @@ describe("useMarkdownLinkHandler", () => {
     // resolveWorkspaceLink joins "notes/a.md" + "../chat/abc-123.jsonl"
     // → "chat/abc-123.jsonl", which extractSessionIdFromPath recognises.
     const { handleMarkdownLinkClick, captured } = setup("notes/a.md");
-    const ev = makeEvent({
+    const event = makeEvent({
       target: makeReal(makeAnchor("../chat/abc-123.jsonl")),
     });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.deepEqual(captured.session, ["abc-123"]);
     assert.equal(captured.navigate.length, 0);
   });
 
   it("ignores external http(s) links (lets browser handle)", () => {
     const { handleMarkdownLinkClick, captured } = setup();
-    const ev = makeEvent({
+    const event = makeEvent({
       target: makeReal(makeAnchor("https://example.com")),
     });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
-    assert.equal(ev.defaultPrevented, false);
+    assert.equal(event.defaultPrevented, false);
   });
 
   it("ignores anchor-only (#section) links", () => {
     const { handleMarkdownLinkClick, captured } = setup();
-    const ev = makeEvent({ target: makeReal(makeAnchor("#heading")) });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({ target: makeReal(makeAnchor("#heading")) });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
-    assert.equal(ev.defaultPrevented, false);
+    assert.equal(event.defaultPrevented, false);
   });
 
   it("ignores right/middle button clicks", () => {
     const { handleMarkdownLinkClick, captured } = setup();
     for (const button of [1, 2]) {
-      const ev = makeEvent({
+      const event = makeEvent({
         button,
         target: makeReal(makeAnchor("./b.md")),
       });
-      handleMarkdownLinkClick(ev as unknown as MouseEvent);
+      handleMarkdownLinkClick(event as unknown as MouseEvent);
     }
     assert.equal(captured.navigate.length, 0);
   });
@@ -187,11 +187,11 @@ describe("useMarkdownLinkHandler", () => {
   it("ignores modifier-key clicks (ctrl/meta/shift open in new tab)", () => {
     const { handleMarkdownLinkClick, captured } = setup();
     for (const mod of ["ctrlKey", "metaKey", "shiftKey"] as const) {
-      const ev = makeEvent({
+      const event = makeEvent({
         [mod]: true,
         target: makeReal(makeAnchor("./b.md")),
       });
-      handleMarkdownLinkClick(ev as unknown as MouseEvent);
+      handleMarkdownLinkClick(event as unknown as MouseEvent);
     }
     assert.equal(captured.navigate.length, 0);
   });
@@ -199,8 +199,10 @@ describe("useMarkdownLinkHandler", () => {
   it("does nothing when event.target isn't an Element (regression: instanceof guard)", () => {
     const { handleMarkdownLinkClick, captured } = setup();
     // A plain object that does NOT inherit from FakeElementBase.
-    const ev = makeEvent({ target: { closest: () => makeAnchor("./b.md") } });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({
+      target: { closest: () => makeAnchor("./b.md") },
+    });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
   });
 
@@ -211,22 +213,22 @@ describe("useMarkdownLinkHandler", () => {
       parent: null,
       closest: () => null,
     };
-    const ev = makeEvent({ target: makeReal(targetWithNoAnchor) });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({ target: makeReal(targetWithNoAnchor) });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
   });
 
   it("does nothing when href is missing", () => {
     const { handleMarkdownLinkClick, captured } = setup();
-    const ev = makeEvent({ target: makeReal(makeAnchor(null)) });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({ target: makeReal(makeAnchor(null)) });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
   });
 
   it("does nothing when no file is selected (selectedPath is null)", () => {
     const { handleMarkdownLinkClick, captured } = setup(null);
-    const ev = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
-    handleMarkdownLinkClick(ev as unknown as MouseEvent);
+    const event = makeEvent({ target: makeReal(makeAnchor("./b.md")) });
+    handleMarkdownLinkClick(event as unknown as MouseEvent);
     assert.equal(captured.navigate.length, 0);
   });
 });

--- a/test/composables/test_useMarkdownMode.ts
+++ b/test/composables/test_useMarkdownMode.ts
@@ -1,0 +1,89 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { useMarkdownMode } from "../../src/composables/useMarkdownMode.ts";
+
+const STORAGE_KEY = "files_md_raw_mode";
+
+// Minimal localStorage stub — useMarkdownMode only calls getItem/setItem.
+const storage = new Map<string, string>();
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage",
+);
+
+function installStubStorage(): void {
+  storage.clear();
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => storage.clear(),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreStorage(): void {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      "localStorage",
+      originalLocalStorageDescriptor,
+    );
+  } else {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+}
+
+describe("useMarkdownMode", () => {
+  beforeEach(installStubStorage);
+  afterEach(restoreStorage);
+
+  it("defaults to rendered mode (mdRawMode === false) on first load", () => {
+    const { mdRawMode } = useMarkdownMode();
+    assert.equal(mdRawMode.value, false);
+  });
+
+  it("reads the persisted 'true' state from localStorage", () => {
+    storage.set(STORAGE_KEY, "true");
+    const { mdRawMode } = useMarkdownMode();
+    assert.equal(mdRawMode.value, true);
+  });
+
+  it("treats any non-'true' value as false (incl. 'false', '1', garbage)", () => {
+    for (const bad of ["false", "1", "", "TRUE", "yes"]) {
+      storage.set(STORAGE_KEY, bad);
+      const { mdRawMode } = useMarkdownMode();
+      assert.equal(mdRawMode.value, false, `value=${JSON.stringify(bad)}`);
+    }
+  });
+
+  it("toggleMdRaw flips the ref and persists the new value", () => {
+    const { mdRawMode, toggleMdRaw } = useMarkdownMode();
+    toggleMdRaw();
+    assert.equal(mdRawMode.value, true);
+    assert.equal(storage.get(STORAGE_KEY), "true");
+    toggleMdRaw();
+    assert.equal(mdRawMode.value, false);
+    assert.equal(storage.get(STORAGE_KEY), "false");
+  });
+
+  it("multiple instances do not share state (each reads current storage)", () => {
+    const a = useMarkdownMode();
+    a.toggleMdRaw();
+    const b = useMarkdownMode();
+    assert.equal(b.mdRawMode.value, true);
+    // b.toggleMdRaw only flips b; a.mdRawMode is its own ref.
+    b.toggleMdRaw();
+    assert.equal(b.mdRawMode.value, false);
+    assert.equal(a.mdRawMode.value, true);
+    assert.equal(storage.get(STORAGE_KEY), "false");
+  });
+});

--- a/test/composables/test_useMarkdownMode.ts
+++ b/test/composables/test_useMarkdownMode.ts
@@ -76,14 +76,15 @@ describe("useMarkdownMode", () => {
   });
 
   it("multiple instances do not share state (each reads current storage)", () => {
-    const a = useMarkdownMode();
-    a.toggleMdRaw();
-    const b = useMarkdownMode();
-    assert.equal(b.mdRawMode.value, true);
-    // b.toggleMdRaw only flips b; a.mdRawMode is its own ref.
-    b.toggleMdRaw();
-    assert.equal(b.mdRawMode.value, false);
-    assert.equal(a.mdRawMode.value, true);
+    const first = useMarkdownMode();
+    first.toggleMdRaw();
+    const second = useMarkdownMode();
+    assert.equal(second.mdRawMode.value, true);
+    // `second.toggleMdRaw` only flips `second`; `first.mdRawMode`
+    // is its own ref.
+    second.toggleMdRaw();
+    assert.equal(second.mdRawMode.value, false);
+    assert.equal(first.mdRawMode.value, true);
     assert.equal(storage.get(STORAGE_KEY), "false");
   });
 });

--- a/test/utils/test_file.ts
+++ b/test/utils/test_file.ts
@@ -23,30 +23,37 @@ afterEach(() => {
 
 describe("loadJsonFile (existing)", () => {
   it("returns the parsed JSON when the file exists", () => {
-    const p = path.join(tmpDir, "x.json");
-    fs.writeFileSync(p, JSON.stringify({ hello: "world" }));
-    assert.deepEqual(loadJsonFile<{ hello: string }>(p, { hello: "default" }), {
-      hello: "world",
-    });
+    const filePath = path.join(tmpDir, "x.json");
+    fs.writeFileSync(filePath, JSON.stringify({ hello: "world" }));
+    assert.deepEqual(
+      loadJsonFile<{ hello: string }>(filePath, { hello: "default" }),
+      {
+        hello: "world",
+      },
+    );
   });
 
   it("returns the default when the file is missing", () => {
-    const p = path.join(tmpDir, "missing.json");
-    assert.deepEqual(loadJsonFile<{ x: number }>(p, { x: 42 }), { x: 42 });
+    const filePath = path.join(tmpDir, "missing.json");
+    assert.deepEqual(loadJsonFile<{ x: number }>(filePath, { x: 42 }), {
+      x: 42,
+    });
   });
 
   it("returns the default on malformed JSON", () => {
-    const p = path.join(tmpDir, "bad.json");
-    fs.writeFileSync(p, "{ not valid");
-    assert.deepEqual(loadJsonFile<{ x: number }>(p, { x: 42 }), { x: 42 });
+    const filePath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(filePath, "{ not valid");
+    assert.deepEqual(loadJsonFile<{ x: number }>(filePath, { x: 42 }), {
+      x: 42,
+    });
   });
 });
 
 describe("saveJsonFile (existing)", () => {
   it("creates the parent directory and writes pretty JSON", () => {
-    const p = path.join(tmpDir, "nested", "deep", "x.json");
-    saveJsonFile(p, { a: 1, b: [2, 3] });
-    const raw = fs.readFileSync(p, "utf-8");
+    const filePath = path.join(tmpDir, "nested", "deep", "x.json");
+    saveJsonFile(filePath, { a: 1, b: [2, 3] });
+    const raw = fs.readFileSync(filePath, "utf-8");
     assert.ok(raw.includes("\n"), "JSON should be pretty-printed");
     assert.deepEqual(JSON.parse(raw), { a: 1, b: [2, 3] });
   });
@@ -54,36 +61,36 @@ describe("saveJsonFile (existing)", () => {
 
 describe("writeFileAtomic", () => {
   it("writes plain text to the target path", async () => {
-    const p = path.join(tmpDir, "out.txt");
-    await writeFileAtomic(p, "hello\n");
-    assert.equal(fs.readFileSync(p, "utf-8"), "hello\n");
+    const filePath = path.join(tmpDir, "out.txt");
+    await writeFileAtomic(filePath, "hello\n");
+    assert.equal(fs.readFileSync(filePath, "utf-8"), "hello\n");
   });
 
   it("creates parent directories", async () => {
-    const p = path.join(tmpDir, "a", "b", "c.txt");
-    await writeFileAtomic(p, "x");
-    assert.ok(fs.existsSync(p));
+    const filePath = path.join(tmpDir, "a", "b", "c.txt");
+    await writeFileAtomic(filePath, "x");
+    assert.ok(fs.existsSync(filePath));
   });
 
   it("uses a .tmp suffix by default and cleans it up on success", async () => {
-    const p = path.join(tmpDir, "out.txt");
-    await writeFileAtomic(p, "hello");
-    assert.ok(!fs.existsSync(`${p}.tmp`), "tmp file should not remain");
+    const filePath = path.join(tmpDir, "out.txt");
+    await writeFileAtomic(filePath, "hello");
+    assert.ok(!fs.existsSync(`${filePath}.tmp`), "tmp file should not remain");
   });
 
   it("uses a UUID-suffixed tmp name when uniqueTmp is true", async () => {
-    const p = path.join(tmpDir, "out.txt");
-    await writeFileAtomic(p, "hello", { uniqueTmp: true });
+    const filePath = path.join(tmpDir, "out.txt");
+    await writeFileAtomic(filePath, "hello", { uniqueTmp: true });
     // Final file exists, and no `.tmp` siblings survive.
-    assert.equal(fs.readFileSync(p, "utf-8"), "hello");
+    assert.equal(fs.readFileSync(filePath, "utf-8"), "hello");
     const siblings = fs.readdirSync(tmpDir);
     assert.deepEqual(siblings, ["out.txt"]);
   });
 
   it("honours the `mode` option on the final file", async () => {
-    const p = path.join(tmpDir, "secret.txt");
-    await writeFileAtomic(p, "shhh", { mode: 0o600 });
-    const stat = fs.statSync(p);
+    const filePath = path.join(tmpDir, "secret.txt");
+    await writeFileAtomic(filePath, "shhh", { mode: 0o600 });
+    const stat = fs.statSync(filePath);
     // On POSIX the file-mode bits should reflect 0o600. On Windows
     // node's mode bits are best-effort; skip the assertion there.
     if (process.platform !== "win32") {
@@ -92,34 +99,34 @@ describe("writeFileAtomic", () => {
   });
 
   it("leaves the existing target untouched if the tmp write fails", async () => {
-    const p = path.join(tmpDir, "out.txt");
-    fs.writeFileSync(p, "ORIGINAL");
-    fs.mkdirSync(`${p}.tmp`);
-    await assert.rejects(writeFileAtomic(p, "NEW"));
-    assert.equal(fs.readFileSync(p, "utf-8"), "ORIGINAL");
+    const filePath = path.join(tmpDir, "out.txt");
+    fs.writeFileSync(filePath, "ORIGINAL");
+    fs.mkdirSync(`${filePath}.tmp`);
+    await assert.rejects(writeFileAtomic(filePath, "NEW"));
+    assert.equal(fs.readFileSync(filePath, "utf-8"), "ORIGINAL");
   });
 
   it("overwrites an existing file atomically", async () => {
-    const p = path.join(tmpDir, "data.txt");
-    fs.writeFileSync(p, "old");
-    await writeFileAtomic(p, "new");
-    assert.equal(fs.readFileSync(p, "utf-8"), "new");
+    const filePath = path.join(tmpDir, "data.txt");
+    fs.writeFileSync(filePath, "old");
+    await writeFileAtomic(filePath, "new");
+    assert.equal(fs.readFileSync(filePath, "utf-8"), "new");
   });
 });
 
 describe("writeJsonAtomic", () => {
   it("serialises as pretty JSON and writes atomically", async () => {
-    const p = path.join(tmpDir, "data.json");
-    await writeJsonAtomic(p, { hello: "world", n: 1 });
-    const raw = fs.readFileSync(p, "utf-8");
+    const filePath = path.join(tmpDir, "data.json");
+    await writeJsonAtomic(filePath, { hello: "world", n: 1 });
+    const raw = fs.readFileSync(filePath, "utf-8");
     assert.ok(raw.includes("\n  "), "pretty-printed with 2-space indent");
     assert.deepEqual(JSON.parse(raw), { hello: "world", n: 1 });
   });
 
   it("supports arrays, numbers, and nested structures", async () => {
-    const p = path.join(tmpDir, "nested.json");
-    await writeJsonAtomic(p, [1, 2, { a: [3, 4] }]);
-    assert.deepEqual(JSON.parse(fs.readFileSync(p, "utf-8")), [
+    const filePath = path.join(tmpDir, "nested.json");
+    await writeJsonAtomic(filePath, [1, 2, { a: [3, 4] }]);
+    assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf-8")), [
       1,
       2,
       { a: [3, 4] },
@@ -129,20 +136,20 @@ describe("writeJsonAtomic", () => {
 
 describe("readJsonOrNull", () => {
   it("returns the parsed JSON when the file exists", async () => {
-    const p = path.join(tmpDir, "x.json");
-    fs.writeFileSync(p, JSON.stringify({ n: 7 }));
-    const got = await readJsonOrNull<{ n: number }>(p);
+    const filePath = path.join(tmpDir, "x.json");
+    fs.writeFileSync(filePath, JSON.stringify({ n: 7 }));
+    const got = await readJsonOrNull<{ n: number }>(filePath);
     assert.deepEqual(got, { n: 7 });
   });
 
   it("returns null when the file is missing", async () => {
-    const p = path.join(tmpDir, "nope.json");
-    assert.equal(await readJsonOrNull(p), null);
+    const filePath = path.join(tmpDir, "nope.json");
+    assert.equal(await readJsonOrNull(filePath), null);
   });
 
   it("returns null on malformed JSON", async () => {
-    const p = path.join(tmpDir, "bad.json");
-    fs.writeFileSync(p, "not json");
-    assert.equal(await readJsonOrNull(p), null);
+    const filePath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(filePath, "not json");
+    assert.equal(await readJsonOrNull(filePath), null);
   });
 });

--- a/test/utils/test_schedulerPreview.ts
+++ b/test/utils/test_schedulerPreview.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toSchedulerResult } from "../../src/utils/filesPreview/schedulerPreview.ts";
+import { WORKSPACE_FILES } from "../../src/config/workspacePaths.ts";
+
+describe("toSchedulerResult", () => {
+  it("happy path: returns synthesized ToolResult for valid items", () => {
+    const items = [
+      { id: "a", title: "Alpha", createdAt: 1, props: {} },
+      { id: "b", title: "Beta", createdAt: 2, props: {} },
+    ];
+    const result = toSchedulerResult(
+      WORKSPACE_FILES.schedulerItems,
+      JSON.stringify(items),
+    );
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.equal(result.toolName, "manageScheduler");
+    assert.equal(result.message, WORKSPACE_FILES.schedulerItems);
+    assert.equal(result.title, "Scheduler");
+    assert.deepEqual(result.data.items, items);
+  });
+
+  it("returns null for unrelated path even if body is a valid item array", () => {
+    const items = [{ id: "a", title: "Alpha", createdAt: 1, props: {} }];
+    assert.equal(
+      toSchedulerResult("data/other/items.json", JSON.stringify(items)),
+      null,
+    );
+  });
+
+  it("returns null for null raw text (e.g. non-text file)", () => {
+    assert.equal(toSchedulerResult(WORKSPACE_FILES.schedulerItems, null), null);
+  });
+
+  it("returns null for null path", () => {
+    assert.equal(toSchedulerResult(null, "[]"), null);
+  });
+
+  it("returns null when JSON is malformed", () => {
+    assert.equal(
+      toSchedulerResult(WORKSPACE_FILES.schedulerItems, "{not json"),
+      null,
+    );
+  });
+
+  it("returns null when parsed value isn't an array", () => {
+    assert.equal(
+      toSchedulerResult(WORKSPACE_FILES.schedulerItems, '{"foo":1}'),
+      null,
+    );
+  });
+
+  it("returns null when array contains an element missing required fields", () => {
+    // Missing `title`
+    const bad = [{ id: "a", createdAt: 1, props: {} }];
+    assert.equal(
+      toSchedulerResult(WORKSPACE_FILES.schedulerItems, JSON.stringify(bad)),
+      null,
+    );
+  });
+
+  it("returns null when id is not a string", () => {
+    const bad = [{ id: 42, title: "x", createdAt: 1, props: {} }];
+    assert.equal(
+      toSchedulerResult(WORKSPACE_FILES.schedulerItems, JSON.stringify(bad)),
+      null,
+    );
+  });
+
+  it("empty array → empty items list (still valid)", () => {
+    const result = toSchedulerResult(WORKSPACE_FILES.schedulerItems, "[]");
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.deepEqual(result.data.items, []);
+  });
+
+  it("array containing null → rejected", () => {
+    assert.equal(
+      toSchedulerResult(WORKSPACE_FILES.schedulerItems, "[null]"),
+      null,
+    );
+  });
+});

--- a/test/utils/test_todoPreview.ts
+++ b/test/utils/test_todoPreview.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toTodoExplorerResult } from "../../src/utils/filesPreview/todoPreview.ts";
+import { WORKSPACE_FILES } from "../../src/config/workspacePaths.ts";
+
+describe("toTodoExplorerResult", () => {
+  it("happy path: returns ToolResult with parsed items", () => {
+    const items = [
+      { id: "1", text: "Buy milk", completed: false, createdAt: 100 },
+      { id: "2", text: "Walk dog", completed: true, createdAt: 200 },
+    ];
+    const result = toTodoExplorerResult(
+      WORKSPACE_FILES.todosItems,
+      JSON.stringify(items),
+    );
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.equal(result.toolName, "manageTodoList");
+    assert.equal(result.title, "Todo");
+    assert.deepEqual(result.data.items, items);
+    assert.deepEqual(result.data.columns, []);
+  });
+
+  it("returns null for unrelated path", () => {
+    const items = [{ id: "1", text: "x", completed: false, createdAt: 1 }];
+    assert.equal(
+      toTodoExplorerResult("data/other/todos.json", JSON.stringify(items)),
+      null,
+    );
+  });
+
+  it("returns null for null raw text", () => {
+    assert.equal(toTodoExplorerResult(WORKSPACE_FILES.todosItems, null), null);
+  });
+
+  it("returns null for null path", () => {
+    assert.equal(toTodoExplorerResult(null, "[]"), null);
+  });
+
+  it("malformed JSON → still returns a result with empty items", () => {
+    // Mirrors the original behaviour: the explorer renders with empty
+    // items rather than hiding entirely.
+    const result = toTodoExplorerResult(
+      WORKSPACE_FILES.todosItems,
+      "{not json",
+    );
+    // toTodoExplorerResult returns null specifically when JSON.parse throws
+    assert.equal(result, null);
+  });
+
+  it("non-array JSON → returns result with empty items (explorer fetches own state)", () => {
+    const result = toTodoExplorerResult(
+      WORKSPACE_FILES.todosItems,
+      '{"foo":1}',
+    );
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.deepEqual(result.data.items, []);
+  });
+
+  it("array with invalid items → empty items", () => {
+    const bad = [{ id: "1", text: "ok" }]; // missing completed, createdAt
+    const result = toTodoExplorerResult(
+      WORKSPACE_FILES.todosItems,
+      JSON.stringify(bad),
+    );
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.deepEqual(result.data.items, []);
+  });
+
+  it("empty array → empty items list", () => {
+    const result = toTodoExplorerResult(WORKSPACE_FILES.todosItems, "[]");
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.deepEqual(result.data.items, []);
+  });
+
+  it("completed must be boolean (not truthy value)", () => {
+    const bad = [{ id: "1", text: "x", completed: 1, createdAt: 1 }];
+    const result = toTodoExplorerResult(
+      WORKSPACE_FILES.todosItems,
+      JSON.stringify(bad),
+    );
+    assert.ok(result);
+    assert.ok(result.data);
+    assert.deepEqual(result.data.items, []);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `id-length` ESLint rule at `warn` (min: 3) so CI stays green while we migrate incrementally. Exempts loop iterators (`i`/`j`), throwaway (`_`), and Node / domain-standard 2-char idioms: `id`, `ok`, `fs`, `os`, `ts`, `ms`, `md`, `it`.
- Seeds the migration by cleaning up my #517 files + a few high-count files.
- Pulls in PR #517 tests (the test commit landed after that PR was merged, so it was never in main).

**Repo-wide warning count: initial (post-rule) 2189 → after idiom exemptions 1345 → after seed cleanups 1298.**

## Items to Confirm / Review
- **Rule level is `warn`, not `error`** — deliberate so CI doesn't block. If the team prefers `error` later, migrate the remaining 1298 first.
- **Exemption list** (`id`, `ok`, `fs`, `os`, `ts`, `ms`, `md`, `it`) — each has a comment explaining why. `id` alone accounts for 592 warnings; gating those would make the rule unusable.
- **Scope**: intentionally narrow. Only files I already touched in #517 + three high-density targets (`App.vue`, `todo/labels.ts`, `test/utils/test_file.ts`) were renamed. ~1298 warnings remain in 100+ other files — deferred to future PRs per-owner / per-area.
- **`test_file.ts` stopped at 14/30** because the remaining warnings are object-literal keys in test payloads (`{ a: 1, b: 2 }`, `{ n: 7 }`) — renaming those adds noise without clarity.
- **Cherry-pick from #517**: commit `220eb54` (unit + e2e tests) was pushed to the #517 branch after the maintainer manually merged. Cleanest way to land them was to bring them into this PR.

## Test plan
- [x] `yarn format`, `yarn lint` (0 errors, 1298 id-length warnings + 6 pre-existing v-html warnings), `yarn vue-tsc`, `yarn build`, `yarn test` all pass locally
- [x] New tests cherry-picked from #517: `test_schedulerPreview` (10), `test_todoPreview` (9), `test_useMarkdownMode` (5), `test_useContentDisplay` (15), `test_useMarkdownLinkHandler` (11), `test_useFileSelection.isValidFilePath` (5)
- [x] New e2e: `files-scheduler-preview` (2)
- [ ] CI

## User Prompt

> sonarjsで短い変数名って禁止してなかった？
> ... warnにして、直せるところは直す、、、がよいかな。それを別ブランで。
> min3で。
> mainとりこんで
> B (fix a few more easy wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable repository-wide short-identifier linting and seed the migration with variable name cleanups and stronger file preview behaviors covered by new tests.

Bug Fixes:
- Tighten type guards and file path validation helpers to more accurately detect todo, scheduler, and file selection inputs.

Enhancements:
- Improve naming clarity for variables, parameters, and collection callbacks to comply with the new identifier-length guidance.

Build:
- Configure ESLint id-length rule as a warning with a minimum identifier length of three characters and documented exceptions for common short idioms.

Tests:
- Add unit tests for markdown content display, markdown mode persistence, markdown link handling, todo and scheduler preview utilities, and file selection path validation.
- Add end-to-end coverage ensuring the Files view renders scheduler previews for valid data and falls back to raw JSON on malformed scheduler items.

Chores:
- Refactor various Vue components and utilities to reduce existing id-length lint violations as an initial migration step.