### PR TITLE
chore: enable sonarjs/no-nested-conditional as warn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,7 +71,7 @@ export default [
       "sonarjs/no-ignored-exceptions": "error",
       "sonarjs/todo-tag": "off",
       "sonarjs/no-commented-code": "off",
-      "sonarjs/no-nested-conditional": "off",
+      "sonarjs/no-nested-conditional": "warn",
       "sonarjs/cognitive-complexity": "error",
       // `@typescript-eslint/no-unused-vars` already covers this and
       // honours the `^__` ignore pattern (see its options above); the


### PR DESCRIPTION
## Summary

`sonarjs/no-nested-conditional` は現在 off ですが、理由コメント無しで無効化されていました。他リポジトリ (mulmocast-cli) では recommended デフォルトのまま有効なため、本 repo でも `warn` として有効化します。

- Before: `"sonarjs/no-nested-conditional": "off"`
- After: `"sonarjs/no-nested-conditional": "warn"`

## Items to Confirm / Review

- [ ] **現状13箇所が warning**: CI は通る（error ではない）が、順次リファクタしたい場合の可視化として機能
- [ ] **error に昇格させない判断**: 既存コードのリファクタ負担を避けるため warn 止まり。時期を見て error 化は別途検討

## User Prompt

他リポジトリ (graphai, mulmocast-cli) の eslint 設定、主に sonarjs 部分を見て、本 repo に無いルールを warn で追加したい、という要望。比較した結果、sonarjs の差分としては以下3つが本 repo でのみ off になっており、そのうちユーザーは **`sonarjs/no-nested-conditional` のみ有効化** を選択:

- `sonarjs/no-nested-conditional: off` → warn に変更（本 PR）
- `sonarjs/no-os-command-from-path: off` → 据え置き（local desktop app の意図コメントあり）
- `sonarjs/cors: off` → 据え置き

## Test plan

- [x] `yarn lint` — 0 errors / 19 warnings (うち13件が今回有効化した `no-nested-conditional`、残り6件は既存の `v-html` warning)
- [x] `yarn build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Adjust ESLint configuration to turn sonarjs/no-nested-conditional from off to warn.