### PR TITLE
chore: rename short identifiers in 4 files (todosItemsHandlers, scheduler, presentMulmoScript, test_filesTreeAsync)

### DIFF
--- a/server/api/routes/todosItemsHandlers.ts
+++ b/server/api/routes/todosItemsHandlers.ts
@@ -36,7 +36,7 @@ export type ItemsActionResult = { kind: "error"; status: number; error: string }
 export function migrateItems(rawItems: TodoItem[], columns: StatusColumn[]): TodoItem[] {
   const doneId = doneColumnId(columns);
   const openId = defaultStatusId(columns);
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
 
   // First pass: backfill status. Items pointing at a column that no
   // longer exists are reassigned to the default open or done column
@@ -50,55 +50,55 @@ export function migrateItems(rawItems: TodoItem[], columns: StatusColumn[]): Tod
   // fields as independent at the storage layer leaves both the REST
   // PATCH path (which keeps them in sync explicitly) and the legacy
   // MCP actions (which only touch `completed`) working correctly.
-  const withStatus = rawItems.map((it): TodoItem => {
-    const hasValidStatus = typeof it.status === "string" && validStatusIds.has(it.status);
-    if (hasValidStatus) return it;
-    const status = it.completed ? doneId : openId;
-    return { ...it, status };
+  const withStatus = rawItems.map((item): TodoItem => {
+    const hasValidStatus = typeof item.status === "string" && validStatusIds.has(item.status);
+    if (hasValidStatus) return item;
+    const status = item.completed ? doneId : openId;
+    return { ...item, status };
   });
 
   // Second pass: backfill order per column. Items that already have
-  // an order keep it untouched — only items missing order get one
+  // an order keep item untouched — only items missing order get one
   // assigned, and they go after the column's current max so they
   // sort to the bottom in createdAt order. This preserves any
   // hand-managed ordering even when a column is a mix of legacy
   // and kanban-aware items.
   const byStatus = new Map<string, TodoItem[]>();
-  for (const it of withStatus) {
-    const key = it.status ?? openId;
+  for (const item of withStatus) {
+    const key = item.status ?? openId;
     if (!byStatus.has(key)) byStatus.set(key, []);
-    byStatus.get(key)!.push(it);
+    byStatus.get(key)!.push(item);
   }
   const orderById = new Map<string, number>();
   for (const [, group] of byStatus) {
-    const missing = group.filter((it) => typeof it.order !== "number");
+    const missing = group.filter((item) => typeof item.order !== "number");
     if (missing.length === 0) continue;
-    const existingMax = group.filter((it) => typeof it.order === "number").reduce((acc, it) => Math.max(acc, it.order!), 0);
-    const sorted = [...missing].sort((a, b) => a.createdAt - b.createdAt);
-    sorted.forEach((it, i) => {
-      orderById.set(it.id, existingMax + (i + 1) * ORDER_STEP);
+    const existingMax = group.filter((item) => typeof item.order === "number").reduce((acc, item) => Math.max(acc, item.order!), 0);
+    const sorted = [...missing].sort((left, right) => left.createdAt - right.createdAt);
+    sorted.forEach((item, i) => {
+      orderById.set(item.id, existingMax + (i + 1) * ORDER_STEP);
     });
   }
-  return withStatus.map((it): TodoItem => {
-    const next = orderById.get(it.id);
-    if (next === undefined) return it;
-    return { ...it, order: next };
+  return withStatus.map((item): TodoItem => {
+    const next = orderById.get(item.id);
+    if (next === undefined) return item;
+    return { ...item, order: next };
   });
 }
 
 // ── Validators ────────────────────────────────────────────────────
 
-function isPriority(v: unknown): v is TodoPriority {
-  return typeof v === "string" && PRIORITIES.includes(v as TodoPriority);
+function isPriority(value: unknown): value is TodoPriority {
+  return typeof value === "string" && PRIORITIES.includes(value as TodoPriority);
 }
 
-// YYYY-MM-DD only — keep it boring so the column is sortable as text.
-function isDueDate(v: unknown): v is string {
-  return typeof v === "string" && /^\d{4}-\d{2}-\d{2}$/.test(v);
+// YYYY-MM-DD only — keep item boring so the column is sortable as text.
+function isDueDate(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
 function nextOrder(items: TodoItem[], statusId: string): number {
-  const inColumn = items.filter((i) => i.status === statusId).map((i) => i.order ?? 0);
+  const inColumn = items.filter((item) => item.status === statusId).map((item) => item.order ?? 0);
   if (inColumn.length === 0) return ORDER_STEP;
   return Math.max(...inColumn) + ORDER_STEP;
 }
@@ -122,7 +122,7 @@ function resolveStatus(input: CreateInput, columns: StatusColumn[]): ResolveStat
   if (input.status === undefined || input.status === "") {
     return { kind: "ok", status: defaultStatusId(columns) };
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   if (validStatusIds.has(input.status)) {
     return { kind: "ok", status: input.status };
   }
@@ -195,7 +195,7 @@ export interface PatchInput {
 
 // Each `applyXxx` helper mutates `updated` in place and returns either
 // `null` (success) or an error result. Splitting them out keeps the
-// top-level `handlePatch` linear so it stays under the cognitive
+// top-level `handlePatch` linear so item stays under the cognitive
 // complexity threshold and so each field's edit semantics live in one
 // obvious place.
 
@@ -253,7 +253,7 @@ function applyStatusPatch(updated: TodoItem, target: TodoItem, items: TodoItem[]
   if (typeof input.status !== "string" || input.status === target.status) {
     return null;
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   if (!validStatusIds.has(input.status)) {
     return {
       kind: "error",
@@ -268,7 +268,7 @@ function applyStatusPatch(updated: TodoItem, target: TodoItem, items: TodoItem[]
 }
 
 // Explicit `completed` toggle without changing status: lets the user
-// check / uncheck a card and have it move between the done column and
+// check / uncheck a card and have item move between the done column and
 // a default open column the obvious way.
 function applyCompletedPatch(updated: TodoItem, items: TodoItem[], columns: StatusColumn[], input: PatchInput): void {
   if (typeof input.completed !== "boolean") return;
@@ -305,7 +305,7 @@ export function handlePatch(items: TodoItem[], columns: StatusColumn[], id: stri
     if (err) return err;
   }
 
-  const next = items.map((it) => (it.id === id ? updated : it));
+  const next = items.map((item) => (item.id === id ? updated : item));
   return { kind: "success", items: next, item: updated };
 }
 
@@ -328,7 +328,7 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
   if (!target) {
     return { kind: "error", status: 404, error: `item not found: ${id}` };
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   const newStatus = input.status ?? target.status ?? defaultStatusId(columns);
   if (!validStatusIds.has(newStatus)) {
     return {
@@ -344,27 +344,27 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
     completed: isDone,
   };
   // Re-collect the items in the target column with the moving item
-  // pulled out, then splice it back in at `position`.
-  const others = items.filter((it) => it.id !== id && it.status === newStatus).sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  // pulled out, then splice item back in at `position`.
+  const others = items.filter((item) => item.id !== id && item.status === newStatus).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
   const insertAt = clampPosition(input.position, others.length);
   const reordered = [...others];
   reordered.splice(insertAt, 0, updatedSelf);
   // Reassign order values 1000 / 2000 / 3000 ...
   const reorderedById = new Map<string, number>();
-  reordered.forEach((it, i) => reorderedById.set(it.id, (i + 1) * ORDER_STEP));
-  const nextItems = items.map((it): TodoItem => {
-    const newOrder = reorderedById.get(it.id);
-    if (it.id === id) {
+  reordered.forEach((item, i) => reorderedById.set(item.id, (i + 1) * ORDER_STEP));
+  const nextItems = items.map((item): TodoItem => {
+    const newOrder = reorderedById.get(item.id);
+    if (item.id === id) {
       const out: TodoItem = {
         ...updatedSelf,
         order: newOrder ?? updatedSelf.order ?? ORDER_STEP,
       };
       return out;
     }
-    if (newOrder !== undefined) return { ...it, order: newOrder };
-    return it;
+    if (newOrder !== undefined) return { ...item, order: newOrder };
+    return item;
   });
-  const finalSelf = nextItems.find((it) => it.id === id)!;
+  const finalSelf = nextItems.find((item) => item.id === id)!;
   return { kind: "success", items: nextItems, item: finalSelf };
 }
 
@@ -382,5 +382,5 @@ export function handleDeleteItem(items: TodoItem[], id: string): ItemsActionResu
   if (!target) {
     return { kind: "error", status: 404, error: `item not found: ${id}` };
   }
-  return { kind: "success", items: items.filter((it) => it.id !== id) };
+  return { kind: "success", items: items.filter((item) => item.id !== id) };
 }

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -51,7 +51,7 @@
         <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Characters</span>
         <button
           class="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 disabled:opacity-50"
-          :disabled="movieGenerating || anyBeatRendering || characterKeys.every((k) => charRenderState[k] === 'rendering')"
+          :disabled="movieGenerating || anyBeatRendering || characterKeys.every((key) => charRenderState[key] === 'rendering')"
           @click="generateAllCharacters"
         >
           Generate All
@@ -435,7 +435,7 @@ const anyBeatRendering = computed(() => Object.values(renderState).some((s) => s
 
 const characterKeys = computed(() => {
   const imgs = script.value.imageParams?.images ?? {};
-  return Object.keys(imgs).filter((k) => imgs[k]?.type === "imagePrompt");
+  return Object.keys(imgs).filter((key) => imgs[key]?.type === "imagePrompt");
 });
 
 // Session-scoped pending generations — lets spinners survive view
@@ -862,7 +862,7 @@ async function loadExistingCharacterImage(key: string) {
 }
 
 function refreshMissingCharacterImages() {
-  getMissingCharacterKeys(characterKeys.value, charImages, charRenderState).forEach((k) => loadExistingCharacterImage(k));
+  getMissingCharacterKeys(characterKeys.value, charImages, charRenderState).forEach((key) => loadExistingCharacterImage(key));
 }
 
 async function renderCharacter(key: string, force: boolean) {
@@ -889,28 +889,28 @@ async function renderCharacter(key: string, force: boolean) {
 }
 
 async function generateAllCharacters() {
-  await Promise.all(characterKeys.value.filter((k) => charRenderState[k] !== "rendering").map((k) => renderCharacter(k, false)));
+  await Promise.all(characterKeys.value.filter((key) => charRenderState[key] !== "rendering").map((key) => renderCharacter(key, false)));
 }
 
 async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
-  Object.keys(renderState).forEach((k) => delete renderState[+k]);
-  Object.keys(renderedImages).forEach((k) => delete renderedImages[+k]);
-  Object.keys(renderErrors).forEach((k) => delete renderErrors[+k]);
-  Object.keys(sourceOpen).forEach((k) => delete sourceOpen[+k]);
-  Object.keys(sourceText).forEach((k) => delete sourceText[+k]);
-  Object.keys(beatSaveErrors).forEach((k) => delete beatSaveErrors[+k]);
-  Object.keys(beatSaving).forEach((k) => delete beatSaving[+k]);
-  Object.keys(localOverrides).forEach((k) => delete localOverrides[+k]);
-  Object.keys(beatAudios).forEach((k) => delete beatAudios[+k]);
-  Object.keys(audioState).forEach((k) => delete audioState[+k]);
-  Object.keys(audioErrors).forEach((k) => delete audioErrors[+k]);
-  Object.keys(charRenderState).forEach((k) => delete charRenderState[k]);
-  Object.keys(charImages).forEach((k) => delete charImages[k]);
-  Object.keys(charErrors).forEach((k) => delete charErrors[k]);
-  Object.keys(beatDragOver).forEach((k) => delete beatDragOver[+k]);
+  Object.keys(renderState).forEach((key) => delete renderState[+key]);
+  Object.keys(renderedImages).forEach((key) => delete renderedImages[+key]);
+  Object.keys(renderErrors).forEach((key) => delete renderErrors[+key]);
+  Object.keys(sourceOpen).forEach((key) => delete sourceOpen[+key]);
+  Object.keys(sourceText).forEach((key) => delete sourceText[+key]);
+  Object.keys(beatSaveErrors).forEach((key) => delete beatSaveErrors[+key]);
+  Object.keys(beatSaving).forEach((key) => delete beatSaving[+key]);
+  Object.keys(localOverrides).forEach((key) => delete localOverrides[+key]);
+  Object.keys(beatAudios).forEach((key) => delete beatAudios[+key]);
+  Object.keys(audioState).forEach((key) => delete audioState[+key]);
+  Object.keys(audioErrors).forEach((key) => delete audioErrors[+key]);
+  Object.keys(charRenderState).forEach((key) => delete charRenderState[key]);
+  Object.keys(charImages).forEach((key) => delete charImages[key]);
+  Object.keys(charErrors).forEach((key) => delete charErrors[key]);
+  Object.keys(beatDragOver).forEach((key) => delete beatDragOver[+key]);
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -276,8 +276,8 @@ const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
   endpoint: () => API_ROUTES.scheduler.base,
   extract: (json) => {
-    const v = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
-    return Array.isArray(v) ? v : null;
+    const payload = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
+    return Array.isArray(payload) ? payload : null;
   },
   apply: (data) => {
     items.value = data;
@@ -306,20 +306,20 @@ const currentDate = ref(new Date());
 // ── Calendar utilities ─────────────────────────────────────────────────────
 
 function startOfWeek(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
+  const result = new Date(date);
+  const day = result.getDay();
   const diff = day === 0 ? -6 : 1 - day; // Monday start
-  d.setDate(d.getDate() + diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
+  result.setDate(result.getDate() + diff);
+  result.setHours(0, 0, 0, 0);
+  return result;
 }
 
 function getWeekDays(date: Date): Date[] {
   const start = startOfWeek(date);
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    return d;
+  return Array.from({ length: 7 }, (__unused, i) => {
+    const next = new Date(start);
+    next.setDate(start.getDate() + i);
+    return next;
   });
 }
 
@@ -328,11 +328,11 @@ function getMonthGrid(year: number, month: number): Date[][] {
   const start = startOfWeek(firstDay);
   const weeks: Date[][] = [];
   const WEEK_COUNT = 6;
-  for (let w = 0; w < WEEK_COUNT; w++) {
+  for (let weekIdx = 0; weekIdx < WEEK_COUNT; weekIdx++) {
     const week: Date[] = [];
-    for (let d = 0; d < 7; d++) {
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
       const date = new Date(start);
-      date.setDate(start.getDate() + w * 7 + d);
+      date.setDate(start.getDate() + weekIdx * 7 + dayIdx);
       week.push(date);
     }
     weeks.push(week);
@@ -345,22 +345,22 @@ function isCurrentMonth(date: Date): boolean {
 }
 
 function toDateString(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function itemsForDay(day: Date): ScheduledItem[] {
-  const ds = toDateString(day);
-  return items.value.filter((item) => String(item.props.date) === ds);
+  const dateStr = toDateString(day);
+  return items.value.filter((item) => String(item.props.date) === dateStr);
 }
 
 const unscheduledItems = computed(() => items.value.filter((item) => !item.props.date));
 
 function itemTime(item: ScheduledItem): string {
-  const t = item.props.time;
-  return typeof t === "string" ? t : "";
+  const time = item.props.time;
+  return typeof time === "string" ? time : "";
 }
 
 function dayLabel(date: Date): string {
@@ -376,7 +376,7 @@ const monthGrid = computed(() => getMonthGrid(currentDate.value.getFullYear(), c
 const headerLabel = computed(() => {
   if (viewMode.value === "week") {
     const days = weekDays.value;
-    const fmt = (d: Date) => d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    const fmt = (date: Date) => date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
     return `${fmt(days[0])} – ${fmt(days[6])}, ${days[0].getFullYear()}`;
   }
   return currentDate.value.toLocaleDateString(undefined, {
@@ -390,43 +390,43 @@ function goToday() {
 }
 
 function goPrev() {
-  const d = new Date(currentDate.value);
+  const next = new Date(currentDate.value);
   if (viewMode.value === "week") {
-    d.setDate(d.getDate() - 7);
+    next.setDate(next.getDate() - 7);
   } else {
-    d.setMonth(d.getMonth() - 1);
+    next.setMonth(next.getMonth() - 1);
   }
-  currentDate.value = d;
+  currentDate.value = next;
 }
 
 function goNext() {
-  const d = new Date(currentDate.value);
+  const next = new Date(currentDate.value);
   if (viewMode.value === "week") {
-    d.setDate(d.getDate() + 7);
+    next.setDate(next.getDate() + 7);
   } else {
-    d.setMonth(d.getMonth() + 1);
+    next.setMonth(next.getMonth() + 1);
   }
-  currentDate.value = d;
+  currentDate.value = next;
 }
 
 // ── YAML helpers ────────────────────────────────────────────────────────────
 
-function yamlStringValue(v: string): string {
-  const needsQuotes = v === "" || /[:#[\]{},&*?|<>=!%@`]/.test(v) || /^\s|\s$/.test(v) || /^(true|false|null|~)$/i.test(v) || /^\d/.test(v);
+function yamlStringValue(raw: string): string {
+  const needsQuotes = raw === "" || /[:#[\]{},&*?|<>=!%@`]/.test(raw) || /^\s|\s$/.test(raw) || /^(true|false|null|~)$/i.test(raw) || /^\d/.test(raw);
   if (needsQuotes) {
-    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return `"${raw.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
-  return v;
+  return raw;
 }
 
 function serializeYaml(item: ScheduledItem): string {
   const lines: string[] = [`title: ${yamlStringValue(item.title)}`];
-  for (const [k, v] of Object.entries(item.props)) {
-    if (v === null) continue;
-    if (typeof v === "string") {
-      lines.push(`${k}: ${yamlStringValue(v)}`);
+  for (const [key, value] of Object.entries(item.props)) {
+    if (value === null) continue;
+    if (typeof value === "string") {
+      lines.push(`${key}: ${yamlStringValue(value)}`);
     } else {
-      lines.push(`${k}: ${v}`);
+      lines.push(`${key}: ${value}`);
     }
   }
   return lines.join("\n");
@@ -504,13 +504,13 @@ async function applyItemEdit() {
     yamlError.value = "Could not parse YAML — ensure 'title' is present";
     return;
   }
-  const ok = await callApi({
+  const success = await callApi({
     action: "update",
     id: selectedId.value,
     title: parsed.title,
     props: parsed.props,
   });
-  if (ok) selectedId.value = null;
+  if (success) selectedId.value = null;
 }
 
 // ── JSON source editor ───────────────────────────────────────────────────────
@@ -556,8 +556,8 @@ async function applyChanges() {
   try {
     parsed = JSON.parse(editorText.value);
     if (!Array.isArray(parsed)) throw new Error("Expected a JSON array");
-  } catch (e) {
-    parseError.value = e instanceof Error ? e.message : "Invalid JSON";
+  } catch (err) {
+    parseError.value = err instanceof Error ? err.message : "Invalid JSON";
     return;
   }
   callApi({ action: "replace", items: parsed });

--- a/test/routes/test_filesTreeAsync.ts
+++ b/test/routes/test_filesTreeAsync.ts
@@ -68,20 +68,20 @@ describe("buildTreeAsync", () => {
 
   it("orders dirs before files, alphabetically within type", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     // dir1 (dir) should come before a.md (file).
     assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
   });
 
   it("hides `.git/` hidden dir", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".git"));
   });
 
   it("hides `.env`, `id_rsa`, and `*.key` sensitive files", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".env"));
     assert.ok(!names.includes("id_rsa"));
     assert.ok(!names.includes("ok.key"));
@@ -89,13 +89,13 @@ describe("buildTreeAsync", () => {
 
   it("recurses into subdirs (sub/c.md reachable via dir1/sub)", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const dir1 = (tree.children ?? []).find((c) => c.name === "dir1");
+    const dir1 = (tree.children ?? []).find((child) => child.name === "dir1");
     assert.ok(dir1);
-    const sub = (dir1.children ?? []).find((c) => c.name === "sub");
+    const sub = (dir1.children ?? []).find((child) => child.name === "sub");
     assert.ok(sub);
-    const c = (sub.children ?? []).find((n) => n.name === "c.md");
-    assert.ok(c);
-    assert.equal(c.type, "file");
+    const leaf = (sub.children ?? []).find((node) => node.name === "c.md");
+    assert.ok(leaf);
+    assert.equal(leaf.type, "file");
   });
 
   it("skips symlinks (no workspace escape)", async () => {
@@ -106,7 +106,7 @@ describe("buildTreeAsync", () => {
     try {
       await symlink(linkTarget, linkPath);
       const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-      const names = (tree.children ?? []).map((c) => c.name);
+      const names = (tree.children ?? []).map((child) => child.name);
       assert.ok(!names.includes("escape"));
     } finally {
       await rm(linkPath, { force: true });
@@ -136,7 +136,7 @@ describe("listDirShallow", () => {
   it("returns only the immediate children, no nested `children` field on sub-dirs", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
     assert.equal(node.type, "dir");
-    const dir1 = (node.children ?? []).find((c) => c.name === "dir1");
+    const dir1 = (node.children ?? []).find((child) => child.name === "dir1");
     assert.ok(dir1);
     assert.equal(dir1.type, "dir");
     // Shallow → no grandchildren materialised.
@@ -145,7 +145,7 @@ describe("listDirShallow", () => {
 
   it("applies the same hidden/sensitive filters as the recursive walk", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".git"));
     assert.ok(!names.includes(".env"));
     assert.ok(!names.includes("id_rsa"));
@@ -154,19 +154,19 @@ describe("listDirShallow", () => {
 
   it("orders dirs before files, alphabetically", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
   });
 
   it("reads a sub-directory when given its path", async () => {
     const subAbs = path.join(root, "dir1");
     const node = (await listDirShallow(subAbs, "dir1")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     // dir1 contains `b.md` (file) and `sub/` (dir).
     assert.ok(names.includes("b.md"));
     assert.ok(names.includes("sub"));
     // sub/ reported as a dir, not expanded.
-    const sub = (node.children ?? []).find((c) => c.name === "sub");
+    const sub = (node.children ?? []).find((child) => child.name === "sub");
     assert.equal(sub?.type, "dir");
     assert.equal(sub?.children, undefined);
   });


### PR DESCRIPTION
## Summary

Incremental id-length cleanup on top of #540 (`prettierrc` branch). Mechanical renames only — no semantic changes.

**Repo-wide warnings: 2071 → 1997 (-74).**

## Per-file breakdown

| File | Before | After | Notes |
|---|--:|--:|---|
| `server/api/routes/todosItemsHandlers.ts` | 27 | 4 | `(c)` → `(column)` in `.map`, `(v)` → `(value)` in validators, `.sort((a, b))` → `((left, right))`, `(it)/(i)` → `(item)` |
| `src/plugins/scheduler/View.vue` | 21 | 2 | `d` → `result`/`next`, `y/m/d` in `toDateString` → `year/month/day`, `ds` → `dateStr`, `t` → `time`, `k/v` in Object.entries → `key/value`, `w` → `weekIdx`, `yamlStringValue(v)` → `(raw)`, `catch (e)` → `(err)`, `const ok` → `success` |
| `src/plugins/presentMulmoScript/View.vue` | 21 | 2 | Bulk `k` → `key` in ~20 `Object.keys().forEach/filter/map` callbacks |
| `test/routes/test_filesTreeAsync.ts` | 13 | 0 | `.find/.map((c))` → `((child))`, `.find((n))` → `((node))`, standalone `const c` → `const leaf` |

## Items to Confirm / Review

- **Remaining 2-4 per-file warnings** are all `{ id: ..., ok: ... }` object-literal keys and a couple of `catch (e)` parameters I skipped. These are domain idioms (id = item id, ok = Result-pattern discriminator) — deliberately not renamed.
- **`scheduler/View.vue goNext()` had a partial rename that broke the file mid-edit** — caught and re-fixed in the same session. Please double-check `goNext()` uses `next` consistently.
- **`presentMulmoScript/View.vue` used `perl -i` to bulk-replace `\bk\b` → `key`** across 20+ callbacks. I verified no existing top-level `key` declarations would shadow; typecheck + tests pass.
- **Base branch is `prettierrc` (#540)**, not `main`, because #540 is the `.prettierrc` + eslint exception tightening PR we want to land first. If that gets squashed/merged into main first, rebase this onto main.

## Test plan
- [x] `yarn format`, `yarn vue-tsc`, `yarn typecheck` all clean
- [x] `yarn test` — all passing (2576 + 34 + others)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename short variables to more descriptive identifiers across scheduler, todos items handlers, Mulmo script presenter, and related tests to improve readability without changing behavior.

Enhancements:
- Improve date, time, status, and YAML helper variable names in the scheduler view for clearer calendar and editing logic.
- Clarify migration, validation, and move/patch helper variable names in todos items handlers for easier reasoning about item status and ordering.
- Standardize key and state map iteration variable names in the Mulmo script presenter for clearer state management.
- Update test tree-walking code to use descriptive child/node variable names while preserving test behavior.