### PR TITLE
chore: disable id-length in test/e2e + rename identifiers in 15 src/ files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,6 +136,10 @@ export default [
       // `no-explicit-any` at `error` in production code; demote to
       // warn inside tests.
       "@typescript-eslint/no-explicit-any": "warn",
+      // Tests use lots of throwaway names (`a`, `b` in sort compare,
+      // `{ id: "a" }` in fixtures, `s` in session tests, etc.) that
+      // are fine in test context and would be noise to rename.
+      "id-length": "off",
     },
   },
   {

--- a/server/api/routes/todosItemsHandlers.ts
+++ b/server/api/routes/todosItemsHandlers.ts
@@ -36,7 +36,7 @@ export type ItemsActionResult = { kind: "error"; status: number; error: string }
 export function migrateItems(rawItems: TodoItem[], columns: StatusColumn[]): TodoItem[] {
   const doneId = doneColumnId(columns);
   const openId = defaultStatusId(columns);
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
 
   // First pass: backfill status. Items pointing at a column that no
   // longer exists are reassigned to the default open or done column
@@ -50,55 +50,55 @@ export function migrateItems(rawItems: TodoItem[], columns: StatusColumn[]): Tod
   // fields as independent at the storage layer leaves both the REST
   // PATCH path (which keeps them in sync explicitly) and the legacy
   // MCP actions (which only touch `completed`) working correctly.
-  const withStatus = rawItems.map((it): TodoItem => {
-    const hasValidStatus = typeof it.status === "string" && validStatusIds.has(it.status);
-    if (hasValidStatus) return it;
-    const status = it.completed ? doneId : openId;
-    return { ...it, status };
+  const withStatus = rawItems.map((item): TodoItem => {
+    const hasValidStatus = typeof item.status === "string" && validStatusIds.has(item.status);
+    if (hasValidStatus) return item;
+    const status = item.completed ? doneId : openId;
+    return { ...item, status };
   });
 
   // Second pass: backfill order per column. Items that already have
-  // an order keep it untouched — only items missing order get one
+  // an order keep item untouched — only items missing order get one
   // assigned, and they go after the column's current max so they
   // sort to the bottom in createdAt order. This preserves any
   // hand-managed ordering even when a column is a mix of legacy
   // and kanban-aware items.
   const byStatus = new Map<string, TodoItem[]>();
-  for (const it of withStatus) {
-    const key = it.status ?? openId;
+  for (const item of withStatus) {
+    const key = item.status ?? openId;
     if (!byStatus.has(key)) byStatus.set(key, []);
-    byStatus.get(key)!.push(it);
+    byStatus.get(key)!.push(item);
   }
   const orderById = new Map<string, number>();
   for (const [, group] of byStatus) {
-    const missing = group.filter((it) => typeof it.order !== "number");
+    const missing = group.filter((item) => typeof item.order !== "number");
     if (missing.length === 0) continue;
-    const existingMax = group.filter((it) => typeof it.order === "number").reduce((acc, it) => Math.max(acc, it.order!), 0);
-    const sorted = [...missing].sort((a, b) => a.createdAt - b.createdAt);
-    sorted.forEach((it, i) => {
-      orderById.set(it.id, existingMax + (i + 1) * ORDER_STEP);
+    const existingMax = group.filter((item) => typeof item.order === "number").reduce((acc, item) => Math.max(acc, item.order!), 0);
+    const sorted = [...missing].sort((left, right) => left.createdAt - right.createdAt);
+    sorted.forEach((item, i) => {
+      orderById.set(item.id, existingMax + (i + 1) * ORDER_STEP);
     });
   }
-  return withStatus.map((it): TodoItem => {
-    const next = orderById.get(it.id);
-    if (next === undefined) return it;
-    return { ...it, order: next };
+  return withStatus.map((item): TodoItem => {
+    const next = orderById.get(item.id);
+    if (next === undefined) return item;
+    return { ...item, order: next };
   });
 }
 
 // ── Validators ────────────────────────────────────────────────────
 
-function isPriority(v: unknown): v is TodoPriority {
-  return typeof v === "string" && PRIORITIES.includes(v as TodoPriority);
+function isPriority(value: unknown): value is TodoPriority {
+  return typeof value === "string" && PRIORITIES.includes(value as TodoPriority);
 }
 
-// YYYY-MM-DD only — keep it boring so the column is sortable as text.
-function isDueDate(v: unknown): v is string {
-  return typeof v === "string" && /^\d{4}-\d{2}-\d{2}$/.test(v);
+// YYYY-MM-DD only — keep item boring so the column is sortable as text.
+function isDueDate(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
 function nextOrder(items: TodoItem[], statusId: string): number {
-  const inColumn = items.filter((i) => i.status === statusId).map((i) => i.order ?? 0);
+  const inColumn = items.filter((item) => item.status === statusId).map((item) => item.order ?? 0);
   if (inColumn.length === 0) return ORDER_STEP;
   return Math.max(...inColumn) + ORDER_STEP;
 }
@@ -122,7 +122,7 @@ function resolveStatus(input: CreateInput, columns: StatusColumn[]): ResolveStat
   if (input.status === undefined || input.status === "") {
     return { kind: "ok", status: defaultStatusId(columns) };
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   if (validStatusIds.has(input.status)) {
     return { kind: "ok", status: input.status };
   }
@@ -195,7 +195,7 @@ export interface PatchInput {
 
 // Each `applyXxx` helper mutates `updated` in place and returns either
 // `null` (success) or an error result. Splitting them out keeps the
-// top-level `handlePatch` linear so it stays under the cognitive
+// top-level `handlePatch` linear so item stays under the cognitive
 // complexity threshold and so each field's edit semantics live in one
 // obvious place.
 
@@ -253,7 +253,7 @@ function applyStatusPatch(updated: TodoItem, target: TodoItem, items: TodoItem[]
   if (typeof input.status !== "string" || input.status === target.status) {
     return null;
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   if (!validStatusIds.has(input.status)) {
     return {
       kind: "error",
@@ -268,7 +268,7 @@ function applyStatusPatch(updated: TodoItem, target: TodoItem, items: TodoItem[]
 }
 
 // Explicit `completed` toggle without changing status: lets the user
-// check / uncheck a card and have it move between the done column and
+// check / uncheck a card and have item move between the done column and
 // a default open column the obvious way.
 function applyCompletedPatch(updated: TodoItem, items: TodoItem[], columns: StatusColumn[], input: PatchInput): void {
   if (typeof input.completed !== "boolean") return;
@@ -305,7 +305,7 @@ export function handlePatch(items: TodoItem[], columns: StatusColumn[], id: stri
     if (err) return err;
   }
 
-  const next = items.map((it) => (it.id === id ? updated : it));
+  const next = items.map((item) => (item.id === id ? updated : item));
   return { kind: "success", items: next, item: updated };
 }
 
@@ -328,7 +328,7 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
   if (!target) {
     return { kind: "error", status: 404, error: `item not found: ${id}` };
   }
-  const validStatusIds = new Set(columns.map((c) => c.id));
+  const validStatusIds = new Set(columns.map((column) => column.id));
   const newStatus = input.status ?? target.status ?? defaultStatusId(columns);
   if (!validStatusIds.has(newStatus)) {
     return {
@@ -344,27 +344,27 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
     completed: isDone,
   };
   // Re-collect the items in the target column with the moving item
-  // pulled out, then splice it back in at `position`.
-  const others = items.filter((it) => it.id !== id && it.status === newStatus).sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  // pulled out, then splice item back in at `position`.
+  const others = items.filter((item) => item.id !== id && item.status === newStatus).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
   const insertAt = clampPosition(input.position, others.length);
   const reordered = [...others];
   reordered.splice(insertAt, 0, updatedSelf);
   // Reassign order values 1000 / 2000 / 3000 ...
   const reorderedById = new Map<string, number>();
-  reordered.forEach((it, i) => reorderedById.set(it.id, (i + 1) * ORDER_STEP));
-  const nextItems = items.map((it): TodoItem => {
-    const newOrder = reorderedById.get(it.id);
-    if (it.id === id) {
+  reordered.forEach((item, i) => reorderedById.set(item.id, (i + 1) * ORDER_STEP));
+  const nextItems = items.map((item): TodoItem => {
+    const newOrder = reorderedById.get(item.id);
+    if (item.id === id) {
       const out: TodoItem = {
         ...updatedSelf,
         order: newOrder ?? updatedSelf.order ?? ORDER_STEP,
       };
       return out;
     }
-    if (newOrder !== undefined) return { ...it, order: newOrder };
-    return it;
+    if (newOrder !== undefined) return { ...item, order: newOrder };
+    return item;
   });
-  const finalSelf = nextItems.find((it) => it.id === id)!;
+  const finalSelf = nextItems.find((item) => item.id === id)!;
   return { kind: "success", items: nextItems, item: finalSelf };
 }
 
@@ -382,5 +382,5 @@ export function handleDeleteItem(items: TodoItem[], id: string): ItemsActionResu
   if (!target) {
     return { kind: "error", status: 404, error: `item not found: ${id}` };
   }
-  return { kind: "success", items: items.filter((it) => it.id !== id) };
+  return { kind: "success", items: items.filter((item) => item.id !== id) };
 }

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -9,9 +9,9 @@ const { notifications, unreadCount, markAllRead, dismiss } = useNotifications();
 const open = ref(false);
 const rootRef = ref<HTMLElement | null>(null);
 
-function onDocumentClick(e: MouseEvent): void {
+function onDocumentClick(event: MouseEvent): void {
   if (!open.value || !rootRef.value) return;
-  if (!rootRef.value.contains(e.target as Node)) {
+  if (!rootRef.value.contains(event.target as Node)) {
     close();
   }
 }
@@ -30,8 +30,8 @@ const emit = defineEmits<{
 
 watch(
   () => props.forceClose,
-  (v) => {
-    if (v && open.value) close();
+  (shouldClose) => {
+    if (shouldClose && open.value) close();
   },
 );
 
@@ -46,24 +46,24 @@ function close(): void {
   emit("update:open", false);
 }
 
-function iconName(n: NotificationPayload): string {
-  return n.icon ?? NOTIFICATION_ICONS[n.kind] ?? "notifications";
+function iconName(notification: NotificationPayload): string {
+  return notification.icon ?? NOTIFICATION_ICONS[notification.kind] ?? "notifications";
 }
 
 function formatTime(iso: string): string {
   return formatRelativeTime(iso);
 }
 
-function handleClick(n: NotificationPayload): void {
-  if (n.action.type === NOTIFICATION_ACTION_TYPES.navigate) {
-    emit("navigate", n.action);
+function handleClick(notification: NotificationPayload): void {
+  if (notification.action.type === NOTIFICATION_ACTION_TYPES.navigate) {
+    emit("navigate", notification.action);
     close();
   }
 }
 
-function handleDismiss(e: Event, id: string): void {
-  e.stopPropagation();
-  dismiss(id);
+function handleDismiss(event: Event, notificationId: string): void {
+  event.stopPropagation();
+  dismiss(notificationId);
 }
 </script>
 

--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -204,23 +204,25 @@ const ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 // Covers the common shapes: a scoped npm package in stdio args
 // (`@modelcontextprotocol/server-everything` → `everything`), or a
 // hostname for an HTTP url (`mcp.deepwiki.com` → `deepwiki`).
-function suggestIdFromDraft(d: DraftState): string {
-  if (d.type === "http") {
-    return suggestIdFromUrl(d.url.trim());
+function suggestIdFromDraft(state: DraftState): string {
+  if (state.type === "http") {
+    return suggestIdFromUrl(state.url.trim());
   }
-  const args = d.argsText
+  const args = state.argsText
     .split("\n")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
   return suggestIdFromStdioArgs(args);
 }
 
 function suggestIdFromUrl(rawUrl: string): string {
   try {
     const host = new URL(rawUrl).hostname;
-    const parts = host.split(".").filter((p) => p.length > 0);
+    const parts = host.split(".").filter((part) => part.length > 0);
     // Drop generic subdomain / TLD noise so `mcp.deepwiki.com` → `deepwiki`.
-    const filtered = parts.filter((p, i) => !(i === 0 && (p === "mcp" || p === "www" || p === "api")) && !(i === parts.length - 1 && /^[a-z]{2,4}$/.test(p)));
+    const filtered = parts.filter(
+      (part, i) => !(i === 0 && (part === "mcp" || part === "www" || part === "api")) && !(i === parts.length - 1 && /^[a-z]{2,4}$/.test(part)),
+    );
     const candidate = filtered[0] ?? parts[0] ?? "";
     return slugifyToId(candidate);
   } catch {
@@ -230,7 +232,7 @@ function suggestIdFromUrl(rawUrl: string): string {
 
 function suggestIdFromStdioArgs(args: string[]): string {
   // First arg that isn't a flag is typically the package/script name.
-  const payload = args.find((a) => !a.startsWith("-"));
+  const payload = args.find((arg) => !arg.startsWith("-"));
   if (!payload) return "";
   // For scoped packages / paths, keep only the last segment.
   const lastSegment = payload.split("/").pop() ?? payload;
@@ -254,10 +256,10 @@ function slugifyToId(raw: string): string {
 
 function ensureUniqueId(base: string): string {
   if (!base) return "";
-  if (!props.servers.some((s) => s.id === base)) return base;
+  if (!props.servers.some((server) => server.id === base)) return base;
   for (let i = 2; i < 1000; i += 1) {
     const candidate = `${base}-${i}`;
-    if (!props.servers.some((s) => s.id === candidate)) return candidate;
+    if (!props.servers.some((server) => server.id === candidate)) return candidate;
   }
   return "";
 }
@@ -276,7 +278,7 @@ function commitAdd(): void {
     draftError.value = "Name must start with a lowercase letter and contain only [a-z0-9_-].";
     return;
   }
-  if (props.servers.some((s) => s.id === id)) {
+  if (props.servers.some((server) => server.id === id)) {
     draftError.value = `Server id "${id}" already exists.`;
     return;
   }
@@ -291,8 +293,8 @@ function commitAdd(): void {
   } else {
     const args = draft.value.argsText
       .split("\n")
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
     spec = {
       type: "stdio",
       command: draft.value.command,

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -4,7 +4,7 @@
     <div
       v-for="result in toolResults"
       :key="result.uuid"
-      :ref="(el) => setItemRef(result.uuid, el as HTMLElement | null)"
+      :ref="(element) => setItemRef(result.uuid, element as HTMLElement | null)"
       class="bg-white rounded-lg border transition-colors"
       :class="result.uuid === selectedResultUuid ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
     >
@@ -39,7 +39,11 @@
            / flex-1 via the .stack-natural scoped styles below. For
            plugins that embed iframes (e.g. presentHtml) we also size
            each iframe to its content after load. -->
-      <div v-else-if="isStackNatural(result.toolName)" :ref="(el) => setNaturalWrapperRef(result.uuid, el as HTMLElement | null)" class="stack-natural">
+      <div
+        v-else-if="isStackNatural(result.toolName)"
+        :ref="(element) => setNaturalWrapperRef(result.uuid, element as HTMLElement | null)"
+        class="stack-natural"
+      >
         <component
           :is="getPlugin(result.toolName)?.viewComponent"
           v-if="getPlugin(result.toolName)?.viewComponent"
@@ -117,15 +121,15 @@ const containerRef = ref<HTMLDivElement | null>(null);
 const itemRefs = new Map<string, HTMLElement>();
 const naturalWrapperRefs = new Map<string, HTMLElement>();
 
-function setItemRef(uuid: string, el: HTMLElement | null): void {
-  if (el) itemRefs.set(uuid, el);
+function setItemRef(uuid: string, element: HTMLElement | null): void {
+  if (element) itemRefs.set(uuid, element);
   else itemRefs.delete(uuid);
 }
 
-function setNaturalWrapperRef(uuid: string, el: HTMLElement | null): void {
-  if (el) {
-    naturalWrapperRefs.set(uuid, el);
-    nextTick(() => sizeIframesIn(el));
+function setNaturalWrapperRef(uuid: string, element: HTMLElement | null): void {
+  if (element) {
+    naturalWrapperRefs.set(uuid, element);
+    nextTick(() => sizeIframesIn(element));
   } else {
     naturalWrapperRefs.delete(uuid);
   }
@@ -203,8 +207,8 @@ function beginSuppressScrollSync(): void {
   }, SCROLL_SPY_SUPPRESS_MS);
 }
 
-function readPaddingTop(el: HTMLElement): number {
-  const value = parseFloat(getComputedStyle(el).paddingTop);
+function readPaddingTop(element: HTMLElement): number {
+  const value = parseFloat(getComputedStyle(element).paddingTop);
   return Number.isFinite(value) ? value : 0;
 }
 
@@ -220,9 +224,9 @@ function computeActiveUuidFromScroll(): string | null {
   const paddedTop = container.getBoundingClientRect().top + readPaddingTop(container);
   let activeUuid: string | null = null;
   for (const result of props.toolResults) {
-    const el = itemRefs.get(result.uuid);
-    if (!el) continue;
-    if (el.getBoundingClientRect().top <= paddedTop) {
+    const element = itemRefs.get(result.uuid);
+    if (!element) continue;
+    if (element.getBoundingClientRect().top <= paddedTop) {
       activeUuid = result.uuid;
     } else {
       break;
@@ -260,10 +264,10 @@ watch(
     }
     scrollSpyEmittedUuid = null;
     nextTick(() => {
-      const el = itemRefs.get(uuid);
-      if (!el) return;
+      const element = itemRefs.get(uuid);
+      if (!element) return;
       beginSuppressScrollSync();
-      el.scrollIntoView({ block: "start", behavior: "auto" });
+      element.scrollIntoView({ block: "start", behavior: "auto" });
     });
   },
 );
@@ -297,10 +301,10 @@ onMounted(() => {
   // item so the sidebar and stack start in sync on mount.
   nextTick(() => {
     if (!props.selectedResultUuid) return;
-    const el = itemRefs.get(props.selectedResultUuid);
-    if (!el) return;
+    const element = itemRefs.get(props.selectedResultUuid);
+    if (!element) return;
     beginSuppressScrollSync();
-    el.scrollIntoView({ block: "start", behavior: "auto" });
+    element.scrollIntoView({ block: "start", behavior: "auto" });
   });
 });
 

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -219,11 +219,11 @@ function clearFilters(): void {
 
 const filteredItems = computed(() => {
   const byLabels = filterByLabels(items.value, [...activeFilters.value]);
-  const q = search.value.trim().toLowerCase();
-  if (q.length === 0) return byLabels;
+  const query = search.value.trim().toLowerCase();
+  if (query.length === 0) return byLabels;
   return byLabels.filter((item) => {
-    if (item.text.toLowerCase().includes(q)) return true;
-    if (item.note?.toLowerCase().includes(q)) return true;
+    if (item.text.toLowerCase().includes(query)) return true;
+    if (item.note?.toLowerCase().includes(query)) return true;
     return false;
   });
 });
@@ -241,8 +241,8 @@ function quickAddInColumn(statusId: string): void {
 }
 
 async function onCreateItem(input: CreateItemInput): Promise<void> {
-  const ok = await createItem(input);
-  if (ok) {
+  const created = await createItem(input);
+  if (created) {
     addOpen.value = false;
     addDefaultStatus.value = undefined;
   }
@@ -256,8 +256,8 @@ const newColumnLabel = ref("");
 async function commitNewColumn(): Promise<void> {
   const label = newColumnLabel.value.trim();
   if (label.length === 0) return;
-  const ok = await addColumn({ label });
-  if (ok) {
+  const added = await addColumn({ label });
+  if (added) {
     addColumnOpen.value = false;
     newColumnLabel.value = "";
   }
@@ -277,33 +277,33 @@ onUnmounted(() => document.removeEventListener("keydown", onExplorerKeydown));
 
 // ── Item handlers ──────────────────────────────────────────────
 
-function onPatchItem(id: string, input: PatchItemInput): void {
-  void patchItem(id, input);
+function onPatchItem(itemId: string, input: PatchItemInput): void {
+  void patchItem(itemId, input);
 }
 
 // Single confirm gate for every item deletion path: row "✕" buttons
 // in list/table, the kanban edit dialog's delete button, anything
 // else that wants to remove an item. Centralised so we never
 // accidentally bypass the confirm in a future caller.
-function confirmAndDelete(id: string): boolean {
-  const item = items.value.find((i) => i.id === id);
+function confirmAndDelete(itemId: string): boolean {
+  const item = items.value.find((i) => i.id === itemId);
   if (!item) return false;
-  const ok = window.confirm(`Delete "${item.text}"?`);
-  if (!ok) return false;
-  void deleteItem(id);
+  const confirmed = window.confirm(`Delete "${item.text}"?`);
+  if (!confirmed) return false;
+  void deleteItem(itemId);
   return true;
 }
 
-function onDeleteItem(id: string): void {
-  confirmAndDelete(id);
+function onDeleteItem(itemId: string): void {
+  confirmAndDelete(itemId);
 }
 
 function onToggleComplete(item: TodoItem): void {
   void patchItem(item.id, { completed: !item.completed });
 }
 
-function onMove(id: string, statusId: string, position: number): void {
-  void moveItem(id, { status: statusId, position });
+function onMove(itemId: string, statusId: string, position: number): void {
+  void moveItem(itemId, { status: statusId, position });
 }
 
 // ── Edit dialog (kanban click) ─────────────────────────────────
@@ -319,37 +319,37 @@ function onOpenItem(item: TodoItem): void {
 async function onEditDialogSave(input: PatchItemInput): Promise<void> {
   const target = editingItem.value;
   if (!target) return;
-  const ok = await patchItem(target.id, input);
-  if (ok) editingItem.value = null;
+  const saved = await patchItem(target.id, input);
+  if (saved) editingItem.value = null;
 }
 
-function onEditDialogDelete(id: string): void {
+function onEditDialogDelete(itemId: string): void {
   // Funnel through the same confirm gate as the inline ✕ buttons.
   // The dialog only closes if the user confirmed; if they cancelled
   // the confirm, the dialog stays open so they can keep editing.
-  if (confirmAndDelete(id)) editingItem.value = null;
+  if (confirmAndDelete(itemId)) editingItem.value = null;
 }
 
 // ── Column handlers ────────────────────────────────────────────
 
-function onRenameColumn(id: string, label: string): void {
-  void patchColumn(id, { label });
+function onRenameColumn(columnId: string, label: string): void {
+  void patchColumn(columnId, { label });
 }
 
-function onDeleteColumn(id: string): void {
+function onDeleteColumn(columnId: string): void {
   // Use a native confirm dialog: deleting a column reassigns its
   // items, which is reversible but worth a beat. The other column
   // operations (rename, mark-done) are inexpensive enough not to need
   // confirmation.
-  const col = columns.value.find((c) => c.id === id);
+  const col = columns.value.find((column) => column.id === columnId);
   if (!col) return;
-  const ok = window.confirm(`Delete column "${col.label}"? Items in this column will be moved to another column.`);
-  if (!ok) return;
-  void deleteColumn(id);
+  const confirmed = window.confirm(`Delete column "${col.label}"? Items in this column will be moved to another column.`);
+  if (!confirmed) return;
+  void deleteColumn(columnId);
 }
 
-function onMarkDone(id: string): void {
-  void patchColumn(id, { isDone: true });
+function onMarkDone(columnId: string): void {
+  void patchColumn(columnId, { isDone: true });
 }
 
 function onReorderColumns(ids: string[]): void {

--- a/src/components/todo/TodoKanbanView.vue
+++ b/src/components/todo/TodoKanbanView.vue
@@ -163,11 +163,11 @@ watch(
 );
 
 function onColumnDragEnd(): void {
-  const before = props.columns.map((c) => c.id);
-  const after = columnsLocal.value.map((c) => c.id);
+  const before = props.columns.map((column) => column.id);
+  const after = columnsLocal.value.map((column) => column.id);
   // No-op drops: avoid an unnecessary network round-trip when the
   // drop position equals the original.
-  if (before.length === after.length && before.every((id, i) => id === after[i])) {
+  if (before.length === after.length && before.every((columnId, i) => columnId === after[i])) {
     return;
   }
   emit("reorderColumns", after);
@@ -179,19 +179,19 @@ const itemsByStatus = computed(() => {
   const map = new Map<string, TodoItem[]>();
   for (const col of props.columns) map.set(col.id, []);
   for (const item of props.filteredItems) {
-    const id = item.status ?? props.columns[0]?.id;
-    if (!id) continue;
-    if (!map.has(id)) map.set(id, []);
-    map.get(id)!.push(item);
+    const columnId = item.status ?? props.columns[0]?.id;
+    if (!columnId) continue;
+    if (!map.has(columnId)) map.set(columnId, []);
+    map.get(columnId)!.push(item);
   }
   for (const list of map.values()) {
-    list.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    list.sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
   }
   return map;
 });
 
-function itemsByColumn(id: string): TodoItem[] {
-  return itemsByStatus.value.get(id) ?? [];
+function itemsByColumn(columnId: string): TodoItem[] {
+  return itemsByStatus.value.get(columnId) ?? [];
 }
 
 function onDragChange(columnId: string, event: DragChangeEvent): void {
@@ -211,8 +211,8 @@ const renamingId = ref<string | null>(null);
 const renameDraft = ref("");
 const renameInput = ref<HTMLInputElement[] | HTMLInputElement | null>(null);
 
-function toggleMenu(id: string): void {
-  menuOpenId.value = menuOpenId.value === id ? null : id;
+function toggleMenu(columnId: string): void {
+  menuOpenId.value = menuOpenId.value === columnId ? null : columnId;
 }
 
 function startRename(col: StatusColumn): void {
@@ -221,29 +221,29 @@ function startRename(col: StatusColumn): void {
   renameDraft.value = col.label;
   void nextTick(() => {
     const inputRef = renameInput.value;
-    const el = Array.isArray(inputRef) ? inputRef[0] : inputRef;
-    el?.focus();
-    el?.select();
+    const input = Array.isArray(inputRef) ? inputRef[0] : inputRef;
+    input?.focus();
+    input?.select();
   });
 }
 
-function commitRename(id: string): void {
-  if (renamingId.value !== id) return;
+function commitRename(columnId: string): void {
+  if (renamingId.value !== columnId) return;
   const next = renameDraft.value.trim();
   renamingId.value = null;
   if (next.length === 0) return;
-  const current = props.columns.find((c) => c.id === id);
+  const current = props.columns.find((column) => column.id === columnId);
   if (!current || current.label === next) return;
-  emit("renameColumn", id, next);
+  emit("renameColumn", columnId, next);
 }
 
-function deleteColumn(id: string): void {
+function deleteColumn(columnId: string): void {
   menuOpenId.value = null;
-  emit("deleteColumn", id);
+  emit("deleteColumn", columnId);
 }
 
-function markAsDone(id: string): void {
+function markAsDone(columnId: string): void {
   menuOpenId.value = null;
-  emit("markDone", id);
+  emit("markDone", columnId);
 }
 </script>

--- a/src/components/todo/TodoTableView.vue
+++ b/src/components/todo/TodoTableView.vue
@@ -118,33 +118,33 @@ function setSort(key: SortKey): void {
   }
 }
 
-function toggleExpand(id: string): void {
-  expandedId.value = expandedId.value === id ? null : id;
+function toggleExpand(itemId: string): void {
+  expandedId.value = expandedId.value === itemId ? null : itemId;
 }
 
-function onSave(id: string, input: PatchItemInput): void {
-  emit("patch", id, input);
+function onSave(itemId: string, input: PatchItemInput): void {
+  emit("patch", itemId, input);
   expandedId.value = null;
 }
 
 function statusLabel(item: TodoItem): string {
   if (!item.status) return "";
-  return props.columns.find((c) => c.id === item.status)?.label ?? "";
+  return props.columns.find((col) => col.id === item.status)?.label ?? "";
 }
 
-function compareValues(a: unknown, b: unknown): number {
+function compareValues(left: unknown, right: unknown): number {
   // Undefined sorts last regardless of direction so empty cells stay
   // at the bottom of the list (ascending) or top (descending — flipped
   // by the caller). This matches GitHub's "issues with no due date"
   // ordering, which I find the least surprising.
-  if (a === undefined && b === undefined) return 0;
-  if (a === undefined) return 1;
-  if (b === undefined) return -1;
-  if (typeof a === "number" && typeof b === "number") return a - b;
-  if (typeof a === "boolean" && typeof b === "boolean") {
-    return a === b ? 0 : a ? 1 : -1;
+  if (left === undefined && right === undefined) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  if (typeof left === "boolean" && typeof right === "boolean") {
+    return left === right ? 0 : left ? 1 : -1;
   }
-  return String(a).localeCompare(String(b));
+  return String(left).localeCompare(String(right));
 }
 
 function sortValueOf(item: TodoItem, key: SortKey): unknown {
@@ -168,8 +168,8 @@ function sortValueOf(item: TodoItem, key: SortKey): unknown {
 
 const sortedItems = computed(() => {
   const list = [...props.filteredItems];
-  list.sort((x, y) => {
-    const result = compareValues(sortValueOf(x, sortKey.value), sortValueOf(y, sortKey.value));
+  list.sort((left, right) => {
+    const result = compareValues(sortValueOf(left, sortKey.value), sortValueOf(right, sortKey.value));
     return sortDir.value === "asc" ? result : -result;
   });
   return list;

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -27,17 +27,17 @@ const NOTIFICATION_DOT_COLOR = "#F97316"; // orange-500
 const SIZE = 32;
 const RADIUS = 6;
 
-function drawRoundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: number, width: number, height: number, radius: number): void {
   ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  ctx.lineTo(x + r, y + h);
-  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.moveTo(posX + radius, posY);
+  ctx.lineTo(posX + width - radius, posY);
+  ctx.quadraticCurveTo(posX + width, posY, posX + width, posY + radius);
+  ctx.lineTo(posX + width, posY + height - radius);
+  ctx.quadraticCurveTo(posX + width, posY + height, posX + width - radius, posY + height);
+  ctx.lineTo(posX + radius, posY + height);
+  ctx.quadraticCurveTo(posX, posY + height, posX, posY + height - radius);
+  ctx.lineTo(posX, posY + radius);
+  ctx.quadraticCurveTo(posX, posY, posX + radius, posY);
   ctx.closePath();
 }
 

--- a/src/plugins/chart/View.vue
+++ b/src/plugins/chart/View.vue
@@ -52,8 +52,8 @@ const containers = ref<Array<HTMLDivElement | null>>([]);
 // imperatively and should not trigger Vue re-renders on mutation.
 const instances: echarts.ECharts[] = [];
 
-function setChartRef(idx: number, el: HTMLDivElement | null): void {
-  containers.value[idx] = el;
+function setChartRef(idx: number, element: HTMLDivElement | null): void {
+  containers.value[idx] = element;
 }
 
 function disposeAll(): void {
@@ -69,8 +69,8 @@ function disposeAll(): void {
 // (zoomOnMouseWheel=true), which traps the scroll over the canvas.
 // Toolbox/slider/drag zoom still work — only the wheel is disabled.
 function disableWheelZoom(option: Record<string, unknown>): Record<string, unknown> {
-  const dz = option.dataZoom;
-  if (dz === undefined || dz === null) return option;
+  const dataZoom = option.dataZoom;
+  if (dataZoom === undefined || dataZoom === null) return option;
   const normalise = (entry: unknown): unknown => {
     if (!isRecord(entry)) return entry;
     return {
@@ -79,17 +79,17 @@ function disableWheelZoom(option: Record<string, unknown>): Record<string, unkno
       moveOnMouseWheel: false,
     };
   };
-  const next = Array.isArray(dz) ? dz.map(normalise) : normalise(dz);
+  const next = Array.isArray(dataZoom) ? dataZoom.map(normalise) : normalise(dataZoom);
   return { ...option, dataZoom: next };
 }
 
 function renderAll(): void {
   disposeAll();
   for (let i = 0; i < charts.value.length; i += 1) {
-    const el = containers.value[i];
+    const element = containers.value[i];
     const chart = charts.value[i];
-    if (!el || !chart) continue;
-    const instance = echarts.init(el);
+    if (!element || !chart) continue;
+    const instance = echarts.init(element);
     try {
       instance.setOption(disableWheelZoom(chart.option));
     } catch (err) {
@@ -133,11 +133,11 @@ function exportPng(idx: number, chartTitle?: string): void {
   while (filenameSlug.startsWith("-")) filenameSlug = filenameSlug.slice(1);
   while (filenameSlug.endsWith("-")) filenameSlug = filenameSlug.slice(0, -1);
   if (!filenameSlug) filenameSlug = "chart";
-  const a = document.createElement("a");
-  a.href = dataUrl;
-  a.download = `${filenameSlug}-${idx + 1}.png`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
+  const anchor = document.createElement("a");
+  anchor.href = dataUrl;
+  anchor.download = `${filenameSlug}-${idx + 1}.png`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
 }
 </script>

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -157,7 +157,7 @@ interface PluginEntry {
 // Plugins the user can assign — exclude internal/auto-managed ones
 const EXCLUDED = new Set(["text-response", "switchRole"]);
 const guiPlugins: PluginEntry[] = getAllPluginNames()
-  .filter((p) => !EXCLUDED.has(p))
+  .filter((name) => !EXCLUDED.has(name))
   .map((name) => ({ name, enabled: true, requiredEnv: [] }));
 
 const availablePlugins = ref<PluginEntry[]>(guiPlugins);
@@ -229,7 +229,7 @@ function selectRole(role: CustomRole) {
     name: role.name,
     icon: role.icon,
     prompt: role.prompt,
-    selectedPlugins: role.availablePlugins.filter((p) => p !== "switchRole"),
+    selectedPlugins: role.availablePlugins.filter((plugin) => plugin !== "switchRole"),
     queriesText: (role.queries ?? []).join("\n"),
   };
 }
@@ -273,18 +273,18 @@ async function refreshList() {
   }
 }
 
-async function saveEdit(id: string) {
+async function saveEdit(roleId: string) {
   saving.value = true;
   saveError.value = "";
   const role: CustomRole = {
-    id,
+    id: roleId,
     name: editForm.value.name.trim(),
     icon: editForm.value.icon.trim(),
     prompt: editForm.value.prompt,
     availablePlugins: editForm.value.selectedPlugins,
     queries: editForm.value.queriesText
       .split("\n")
-      .map((s) => s.trim())
+      .map((line) => line.trim())
       .filter(Boolean),
   };
   const result = await callManage({ action: "update", role });
@@ -297,10 +297,10 @@ async function saveEdit(id: string) {
   saving.value = false;
 }
 
-async function deleteRole(id: string) {
+async function deleteRole(roleId: string) {
   saving.value = true;
   saveError.value = "";
-  const result = await callManage({ action: "delete", roleId: id });
+  const result = await callManage({ action: "delete", roleId });
   if (result.success) {
     selectedId.value = null;
     await refreshList();

--- a/src/plugins/manageSource/View.vue
+++ b/src/plugins/manageSource/View.vue
@@ -290,11 +290,11 @@ interface RegisterPayload {
   fetcherParams: Record<string, string>;
 }
 
-function buildRegisterPayload(d: DraftState): RegisterPayload | string {
-  const primary = d.primary.trim();
-  const title = d.title.trim();
+function buildRegisterPayload(input: DraftState): RegisterPayload | string {
+  const primary = input.primary.trim();
+  const title = input.title.trim();
   if (!primary) return "Please fill in the URL / query field.";
-  switch (d.kind) {
+  switch (input.kind) {
     case "rss": {
       if (!/^https?:\/\//i.test(primary)) {
         return "RSS feed URL must start with http:// or https://";
@@ -324,7 +324,7 @@ function buildRegisterPayload(d: DraftState): RegisterPayload | string {
       return {
         title: title || slug,
         url: `https://github.com/${slug}`,
-        fetcherKind: d.kind,
+        fetcherKind: input.kind,
         fetcherParams: { github_repo: slug },
       };
     }
@@ -440,8 +440,8 @@ const PRESETS: Preset[] = [
 
 async function installPreset(preset: Preset): Promise<void> {
   busy.value = `preset-${preset.id}`;
-  const alreadyHave = new Set(sources.value.map((s) => s.slug));
-  const toRegister = preset.entries.filter((e) => !alreadyHave.has(e.slug));
+  const alreadyHave = new Set(sources.value.map((source) => source.slug));
+  const toRegister = preset.entries.filter((entry) => !alreadyHave.has(entry.slug));
   if (toRegister.length === 0) {
     flash(`All sources in "${preset.label}" are already registered.`);
     busy.value = null;
@@ -607,16 +607,16 @@ const briefFilePath = ref("");
 // Build `news/daily/YYYY/MM/DD.md` from an ISO date. Local-time
 // matches how the pipeline writes the file (see toLocalIsoDate).
 function dailyPathFor(isoDate: string): string {
-  const [y, m, d] = isoDate.split("-");
-  return `news/daily/${y}/${m}/${d}.md`;
+  const [year, month, day] = isoDate.split("-");
+  return `news/daily/${year}/${month}/${day}.md`;
 }
 
 function todayIsoDate(): string {
   const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, "0");
-  const d = String(now.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 // Monotonically-increasing token so concurrent loadBrief() calls

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -46,10 +46,10 @@ const displayTitle = computed(() => {
   if (props.result.title) {
     return props.result.title;
   }
-  const md = resolvedMarkdown.value;
-  if (md) {
-    const h1 = extractFirstH1(md);
-    if (h1) return h1;
+  const markdown = resolvedMarkdown.value;
+  if (markdown) {
+    const heading = extractFirstH1(markdown);
+    if (heading) return heading;
   }
   return "Markdown Document";
 });
@@ -60,18 +60,18 @@ const resolvedMarkdown = computed(() => {
   return isFilePath(raw) ? fetchedContent.value : raw;
 });
 
-function extractPreview(md: string): string {
-  const lines = md
+function extractPreview(markdown: string): string {
+  const lines = markdown
     .split("\n")
-    .filter((l) => !/^#{1,6}\s/.test(l) && l.trim() !== "")
-    .map((l) => l.replace(/[*_`~[\]]/g, "").trim())
+    .filter((line) => !/^#{1,6}\s/.test(line) && line.trim() !== "")
+    .map((line) => line.replace(/[*_`~[\]]/g, "").trim())
     .filter(Boolean);
   return lines.slice(0, 6).join("\n");
 }
 
 const contentPreview = computed(() => {
-  const md = resolvedMarkdown.value;
-  if (!md) return "";
-  return extractPreview(md);
+  const markdown = resolvedMarkdown.value;
+  if (!markdown) return "";
+  return extractPreview(markdown);
 });
 </script>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -51,7 +51,7 @@
         <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Characters</span>
         <button
           class="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 disabled:opacity-50"
-          :disabled="movieGenerating || anyBeatRendering || characterKeys.every((k) => charRenderState[k] === 'rendering')"
+          :disabled="movieGenerating || anyBeatRendering || characterKeys.every((key) => charRenderState[key] === 'rendering')"
           @click="generateAllCharacters"
         >
           Generate All
@@ -435,7 +435,7 @@ const anyBeatRendering = computed(() => Object.values(renderState).some((s) => s
 
 const characterKeys = computed(() => {
   const imgs = script.value.imageParams?.images ?? {};
-  return Object.keys(imgs).filter((k) => imgs[k]?.type === "imagePrompt");
+  return Object.keys(imgs).filter((key) => imgs[key]?.type === "imagePrompt");
 });
 
 // Session-scoped pending generations — lets spinners survive view
@@ -862,7 +862,7 @@ async function loadExistingCharacterImage(key: string) {
 }
 
 function refreshMissingCharacterImages() {
-  getMissingCharacterKeys(characterKeys.value, charImages, charRenderState).forEach((k) => loadExistingCharacterImage(k));
+  getMissingCharacterKeys(characterKeys.value, charImages, charRenderState).forEach((key) => loadExistingCharacterImage(key));
 }
 
 async function renderCharacter(key: string, force: boolean) {
@@ -889,28 +889,28 @@ async function renderCharacter(key: string, force: boolean) {
 }
 
 async function generateAllCharacters() {
-  await Promise.all(characterKeys.value.filter((k) => charRenderState[k] !== "rendering").map((k) => renderCharacter(k, false)));
+  await Promise.all(characterKeys.value.filter((key) => charRenderState[key] !== "rendering").map((key) => renderCharacter(key, false)));
 }
 
 async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
-  Object.keys(renderState).forEach((k) => delete renderState[+k]);
-  Object.keys(renderedImages).forEach((k) => delete renderedImages[+k]);
-  Object.keys(renderErrors).forEach((k) => delete renderErrors[+k]);
-  Object.keys(sourceOpen).forEach((k) => delete sourceOpen[+k]);
-  Object.keys(sourceText).forEach((k) => delete sourceText[+k]);
-  Object.keys(beatSaveErrors).forEach((k) => delete beatSaveErrors[+k]);
-  Object.keys(beatSaving).forEach((k) => delete beatSaving[+k]);
-  Object.keys(localOverrides).forEach((k) => delete localOverrides[+k]);
-  Object.keys(beatAudios).forEach((k) => delete beatAudios[+k]);
-  Object.keys(audioState).forEach((k) => delete audioState[+k]);
-  Object.keys(audioErrors).forEach((k) => delete audioErrors[+k]);
-  Object.keys(charRenderState).forEach((k) => delete charRenderState[k]);
-  Object.keys(charImages).forEach((k) => delete charImages[k]);
-  Object.keys(charErrors).forEach((k) => delete charErrors[k]);
-  Object.keys(beatDragOver).forEach((k) => delete beatDragOver[+k]);
+  Object.keys(renderState).forEach((key) => delete renderState[+key]);
+  Object.keys(renderedImages).forEach((key) => delete renderedImages[+key]);
+  Object.keys(renderErrors).forEach((key) => delete renderErrors[+key]);
+  Object.keys(sourceOpen).forEach((key) => delete sourceOpen[+key]);
+  Object.keys(sourceText).forEach((key) => delete sourceText[+key]);
+  Object.keys(beatSaveErrors).forEach((key) => delete beatSaveErrors[+key]);
+  Object.keys(beatSaving).forEach((key) => delete beatSaving[+key]);
+  Object.keys(localOverrides).forEach((key) => delete localOverrides[+key]);
+  Object.keys(beatAudios).forEach((key) => delete beatAudios[+key]);
+  Object.keys(audioState).forEach((key) => delete audioState[+key]);
+  Object.keys(audioErrors).forEach((key) => delete audioErrors[+key]);
+  Object.keys(charRenderState).forEach((key) => delete charRenderState[key]);
+  Object.keys(charImages).forEach((key) => delete charImages[key]);
+  Object.keys(charErrors).forEach((key) => delete charErrors[key]);
+  Object.keys(beatDragOver).forEach((key) => delete beatDragOver[+key]);
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -276,8 +276,8 @@ const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
   endpoint: () => API_ROUTES.scheduler.base,
   extract: (json) => {
-    const v = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
-    return Array.isArray(v) ? v : null;
+    const payload = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
+    return Array.isArray(payload) ? payload : null;
   },
   apply: (data) => {
     items.value = data;
@@ -306,20 +306,20 @@ const currentDate = ref(new Date());
 // ── Calendar utilities ─────────────────────────────────────────────────────
 
 function startOfWeek(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
+  const result = new Date(date);
+  const day = result.getDay();
   const diff = day === 0 ? -6 : 1 - day; // Monday start
-  d.setDate(d.getDate() + diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
+  result.setDate(result.getDate() + diff);
+  result.setHours(0, 0, 0, 0);
+  return result;
 }
 
 function getWeekDays(date: Date): Date[] {
   const start = startOfWeek(date);
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    return d;
+  return Array.from({ length: 7 }, (__unused, i) => {
+    const next = new Date(start);
+    next.setDate(start.getDate() + i);
+    return next;
   });
 }
 
@@ -328,11 +328,11 @@ function getMonthGrid(year: number, month: number): Date[][] {
   const start = startOfWeek(firstDay);
   const weeks: Date[][] = [];
   const WEEK_COUNT = 6;
-  for (let w = 0; w < WEEK_COUNT; w++) {
+  for (let weekIdx = 0; weekIdx < WEEK_COUNT; weekIdx++) {
     const week: Date[] = [];
-    for (let d = 0; d < 7; d++) {
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
       const date = new Date(start);
-      date.setDate(start.getDate() + w * 7 + d);
+      date.setDate(start.getDate() + weekIdx * 7 + dayIdx);
       week.push(date);
     }
     weeks.push(week);
@@ -345,22 +345,22 @@ function isCurrentMonth(date: Date): boolean {
 }
 
 function toDateString(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function itemsForDay(day: Date): ScheduledItem[] {
-  const ds = toDateString(day);
-  return items.value.filter((item) => String(item.props.date) === ds);
+  const dateStr = toDateString(day);
+  return items.value.filter((item) => String(item.props.date) === dateStr);
 }
 
 const unscheduledItems = computed(() => items.value.filter((item) => !item.props.date));
 
 function itemTime(item: ScheduledItem): string {
-  const t = item.props.time;
-  return typeof t === "string" ? t : "";
+  const time = item.props.time;
+  return typeof time === "string" ? time : "";
 }
 
 function dayLabel(date: Date): string {
@@ -376,7 +376,7 @@ const monthGrid = computed(() => getMonthGrid(currentDate.value.getFullYear(), c
 const headerLabel = computed(() => {
   if (viewMode.value === "week") {
     const days = weekDays.value;
-    const fmt = (d: Date) => d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    const fmt = (date: Date) => date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
     return `${fmt(days[0])} – ${fmt(days[6])}, ${days[0].getFullYear()}`;
   }
   return currentDate.value.toLocaleDateString(undefined, {
@@ -390,43 +390,43 @@ function goToday() {
 }
 
 function goPrev() {
-  const d = new Date(currentDate.value);
+  const next = new Date(currentDate.value);
   if (viewMode.value === "week") {
-    d.setDate(d.getDate() - 7);
+    next.setDate(next.getDate() - 7);
   } else {
-    d.setMonth(d.getMonth() - 1);
+    next.setMonth(next.getMonth() - 1);
   }
-  currentDate.value = d;
+  currentDate.value = next;
 }
 
 function goNext() {
-  const d = new Date(currentDate.value);
+  const next = new Date(currentDate.value);
   if (viewMode.value === "week") {
-    d.setDate(d.getDate() + 7);
+    next.setDate(next.getDate() + 7);
   } else {
-    d.setMonth(d.getMonth() + 1);
+    next.setMonth(next.getMonth() + 1);
   }
-  currentDate.value = d;
+  currentDate.value = next;
 }
 
 // ── YAML helpers ────────────────────────────────────────────────────────────
 
-function yamlStringValue(v: string): string {
-  const needsQuotes = v === "" || /[:#[\]{},&*?|<>=!%@`]/.test(v) || /^\s|\s$/.test(v) || /^(true|false|null|~)$/i.test(v) || /^\d/.test(v);
+function yamlStringValue(raw: string): string {
+  const needsQuotes = raw === "" || /[:#[\]{},&*?|<>=!%@`]/.test(raw) || /^\s|\s$/.test(raw) || /^(true|false|null|~)$/i.test(raw) || /^\d/.test(raw);
   if (needsQuotes) {
-    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return `"${raw.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
-  return v;
+  return raw;
 }
 
 function serializeYaml(item: ScheduledItem): string {
   const lines: string[] = [`title: ${yamlStringValue(item.title)}`];
-  for (const [k, v] of Object.entries(item.props)) {
-    if (v === null) continue;
-    if (typeof v === "string") {
-      lines.push(`${k}: ${yamlStringValue(v)}`);
+  for (const [key, value] of Object.entries(item.props)) {
+    if (value === null) continue;
+    if (typeof value === "string") {
+      lines.push(`${key}: ${yamlStringValue(value)}`);
     } else {
-      lines.push(`${k}: ${v}`);
+      lines.push(`${key}: ${value}`);
     }
   }
   return lines.join("\n");
@@ -504,13 +504,13 @@ async function applyItemEdit() {
     yamlError.value = "Could not parse YAML — ensure 'title' is present";
     return;
   }
-  const ok = await callApi({
+  const success = await callApi({
     action: "update",
     id: selectedId.value,
     title: parsed.title,
     props: parsed.props,
   });
-  if (ok) selectedId.value = null;
+  if (success) selectedId.value = null;
 }
 
 // ── JSON source editor ───────────────────────────────────────────────────────
@@ -556,8 +556,8 @@ async function applyChanges() {
   try {
     parsed = JSON.parse(editorText.value);
     if (!Array.isArray(parsed)) throw new Error("Expected a JSON array");
-  } catch (e) {
-    parseError.value = e instanceof Error ? e.message : "Invalid JSON";
+  } catch (err) {
+    parseError.value = err instanceof Error ? err.message : "Invalid JSON";
     return;
   }
   callApi({ action: "replace", items: parsed });

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -19,12 +19,12 @@ interface TodosResponse {
   data?: { items?: TodoItem[]; columns?: StatusColumn[] };
 }
 
-function isTodoItemArray(x: unknown): x is TodoItem[] {
-  return Array.isArray(x);
+function isTodoItemArray(value: unknown): value is TodoItem[] {
+  return Array.isArray(value);
 }
 
-function isStatusColumnArray(x: unknown): x is StatusColumn[] {
-  return Array.isArray(x);
+function isStatusColumnArray(value: unknown): value is StatusColumn[] {
+  return Array.isArray(value);
 }
 
 function extractItems(json: unknown): TodoItem[] | null {
@@ -114,10 +114,10 @@ export function useTodos(initialItems: TodoItem[] = [], initialColumns: StatusCo
   }>({
     endpoint: () => API_ROUTES.todos.list,
     extract: (json) => {
-      const i = extractItems(json);
-      const c = extractColumns(json);
-      if (!i) return null;
-      return { items: i, columns: c ?? [] };
+      const extractedItems = extractItems(json);
+      const extractedColumns = extractColumns(json);
+      if (!extractedItems) return null;
+      return { items: extractedItems, columns: extractedColumns ?? [] };
     },
     apply: ({ items: nextItems, columns: nextColumns }) => {
       items.value = nextItems;
@@ -131,9 +131,9 @@ export function useTodos(initialItems: TodoItem[] = [], initialColumns: StatusCo
   // through the same `error` ref the rest of the composable uses.
   async function refresh(): Promise<boolean> {
     error.value = null;
-    const ok = await rawRefresh();
-    if (!ok) error.value = "Failed to load todos";
-    return ok;
+    const success = await rawRefresh();
+    if (!success) error.value = "Failed to load todos";
+    return success;
   }
 
   // Thin wrapper around apiCall that applies the response payload

--- a/src/plugins/todo/priority.ts
+++ b/src/plugins/todo/priority.ts
@@ -43,13 +43,13 @@ export const PRIORITY_BORDER: Record<TodoPriority, string> = {
 
 export const PRIORITIES: readonly TodoPriority[] = ["low", "medium", "high", "urgent"];
 
-export function isPriority(v: unknown): v is TodoPriority {
+export function isPriority(value: unknown): value is TodoPriority {
   // Use hasOwnProperty rather than the `in` operator: `in` walks the
   // prototype chain, so `"toString" in PRIORITY_ORDER` would return
   // true and incorrectly narrow `"toString"` to TodoPriority. We use
   // the .call form (rather than Object.hasOwn) because the project's
   // client tsconfig targets ES2021, and Object.hasOwn is ES2022.
-  return typeof v === "string" && Object.prototype.hasOwnProperty.call(PRIORITY_ORDER, v);
+  return typeof value === "string" && Object.prototype.hasOwnProperty.call(PRIORITY_ORDER, value);
 }
 
 // ── due date helpers ─────────────────────────────────────────────
@@ -63,9 +63,9 @@ export function dueDateClasses(dueDate: string | undefined): string {
   if (dueDate < today) return "bg-red-100 text-red-700";
   if (dueDate === today) return "bg-orange-100 text-orange-700";
   // Within 3 days?
-  const t = new Date(today);
-  const d = new Date(dueDate);
-  const diffDays = Math.round((d.getTime() - t.getTime()) / (1000 * 60 * 60 * 24));
+  const todayDate = new Date(today);
+  const dueDateObj = new Date(dueDate);
+  const diffDays = Math.round((dueDateObj.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24));
   if (diffDays <= 3) return "bg-yellow-100 text-yellow-700";
   return "bg-gray-100 text-gray-600";
 }
@@ -77,20 +77,20 @@ export function dueDateClasses(dueDate: string | undefined): string {
 export function todayISO(): string {
   const now = new Date();
   const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${month}-${day}`;
 }
 
 // Pretty short label for the kanban card badges. "2026-04-12" →
 // "Apr 12". Year is omitted unless it differs from the current one.
 export function formatDueLabel(dueDate: string | undefined): string {
   if (!dueDate) return "";
-  const d = new Date(`${dueDate}T00:00:00`);
-  if (Number.isNaN(d.getTime())) return dueDate;
+  const date = new Date(`${dueDate}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return dueDate;
   const today = new Date();
-  const sameYear = d.getFullYear() === today.getFullYear();
-  return d.toLocaleDateString(undefined, {
+  const sameYear = date.getFullYear() === today.getFullYear();
+  return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     ...(sameYear ? {} : { year: "numeric" }),

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -124,12 +124,12 @@ const { refresh } = useFreshPluginData<WikiData>({
 watch(
   () => props.selectedResult?.uuid,
   () => {
-    const d = props.selectedResult?.data;
-    if (d) {
-      action.value = d.action ?? "index";
-      title.value = d.title ?? "Wiki";
-      content.value = d.content ?? "";
-      pageEntries.value = d.pageEntries ?? [];
+    const data = props.selectedResult?.data;
+    if (data) {
+      action.value = data.action ?? "index";
+      title.value = data.title ?? "Wiki";
+      content.value = data.content ?? "";
+      pageEntries.value = data.pageEntries ?? [];
     }
     void refresh();
   },
@@ -214,19 +214,19 @@ async function downloadPdf() {
   }
   const blob = await response.blob();
   const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${title.value}.pdf`;
-  a.click();
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${title.value}.pdf`;
+  anchor.click();
   URL.revokeObjectURL(url);
   pdfDownloading.value = false;
 }
 
-function handleContentClick(e: MouseEvent) {
+function handleContentClick(event: MouseEvent) {
   // 1. Internal wiki links: `[[Page Name]]` was rewritten to a
   //    `<span class="wiki-link">` during markdown pre-processing,
   //    so it doesn't overlap with regular `<a>` handling.
-  const target = e.target as HTMLElement;
+  const target = event.target as HTMLElement;
   const link = target.closest(".wiki-link") as HTMLElement | null;
   if (link?.dataset.page) {
     navigatePage(link.dataset.page);
@@ -236,7 +236,7 @@ function handleContentClick(e: MouseEvent) {
   //    in a new tab so clicking them doesn't navigate the whole
   //    SPA away from MulmoClaude. Same-origin and non-http links
   //    (mailto:, tel:, anchors) fall through to the browser default.
-  handleExternalLinkClick(e);
+  handleExternalLinkClick(event);
 }
 </script>
 

--- a/src/utils/format/date.ts
+++ b/src/utils/format/date.ts
@@ -4,13 +4,15 @@
 
 /** "Apr 11 06:32" — short month + day + 24h time. */
 export function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" }) + " " + d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  const date = new Date(iso);
+  return (
+    date.toLocaleDateString(undefined, { month: "short", day: "numeric" }) + " " + date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
+  );
 }
 
 /** "Apr 11 06:32" — same format as formatDate but from epoch ms. */
-export function formatDateTime(ms: number): string {
-  return new Date(ms).toLocaleString(undefined, {
+export function formatDateTime(epochMs: number): string {
+  return new Date(epochMs).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -19,15 +21,15 @@ export function formatDateTime(ms: number): string {
 }
 
 /** "06:32:15" — locale time string from epoch ms. */
-export function formatTime(ms: number): string {
-  return new Date(ms).toLocaleTimeString();
+export function formatTime(epochMs: number): string {
+  return new Date(epochMs).toLocaleTimeString();
 }
 
 /** "06:32" — short HH:MM. Accepts Date, epoch ms, or ISO string. */
 export function formatShortTime(value: Date | number | string): string {
   try {
-    const d = value instanceof Date ? value : new Date(value);
-    return d.toLocaleTimeString([], {
+    const date = value instanceof Date ? value : new Date(value);
+    return date.toLocaleTimeString([], {
       hour: "2-digit",
       minute: "2-digit",
     });
@@ -38,16 +40,16 @@ export function formatShortTime(value: Date | number | string): string {
 
 /** "Apr 11" — short month + day. Accepts Date, epoch ms, or ISO string. */
 export function formatShortDate(value: Date | number | string): string {
-  const d = value instanceof Date ? value : new Date(value);
-  return d.toLocaleDateString(undefined, {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
   });
 }
 
 /** True when two Dates fall on the same calendar day. */
-export function isSameDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+export function isSameDay(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth() && left.getDate() === right.getDate();
 }
 
 /** True when the given Date is today. */
@@ -58,10 +60,10 @@ export function isToday(date: Date): boolean {
 /** "14:32" for today, "Apr 16 14:32" for past dates. Works with
  *  both epoch ms (number) and ISO strings. */
 export function formatSmartTime(value: number | string): string {
-  const d = new Date(value);
-  const time = formatShortTime(d);
-  if (isToday(d)) return time;
-  return `${formatShortDate(d)} ${time}`;
+  const date = new Date(value);
+  const time = formatShortTime(date);
+  if (isToday(date)) return time;
+  return `${formatShortDate(date)} ${time}`;
 }
 
 const ONE_MINUTE = 60_000;
@@ -71,12 +73,12 @@ const ONE_DAY = 86_400_000;
 /** "just now", "5m ago", "2h ago", "Apr 11" — relative time from ISO string. */
 export function formatRelativeTime(iso: string): string {
   try {
-    const d = new Date(iso);
-    const diffMs = Date.now() - d.getTime();
+    const date = new Date(iso);
+    const diffMs = Date.now() - date.getTime();
     if (diffMs < ONE_MINUTE) return "just now";
     if (diffMs < ONE_HOUR) return `${Math.floor(diffMs / ONE_MINUTE)}m ago`;
     if (diffMs < ONE_DAY) return `${Math.floor(diffMs / ONE_HOUR)}h ago`;
-    return formatShortDate(d);
+    return formatShortDate(date);
   } catch {
     return iso;
   }

--- a/src/utils/format/jsonSyntax.ts
+++ b/src/utils/format/jsonSyntax.ts
@@ -29,18 +29,18 @@ const NUMBER_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/;
 const WS_RE = /^\s+/;
 const PUNCT_RE = /^[{}[\]:,]/;
 
-const MATCHERS: { type: JsonTokenType; re: RegExp }[] = [
-  { type: "string", re: STRING_RE },
-  { type: "keyword", re: KEYWORD_RE },
-  { type: "number", re: NUMBER_RE },
-  { type: "whitespace", re: WS_RE },
-  { type: "punct", re: PUNCT_RE },
+const MATCHERS: { type: JsonTokenType; pattern: RegExp }[] = [
+  { type: "string", pattern: STRING_RE },
+  { type: "keyword", pattern: KEYWORD_RE },
+  { type: "number", pattern: NUMBER_RE },
+  { type: "whitespace", pattern: WS_RE },
+  { type: "punct", pattern: PUNCT_RE },
 ];
 
 function nextToken(slice: string): JsonToken | null {
-  for (const { type, re } of MATCHERS) {
-    const m = re.exec(slice);
-    if (m) return { type, value: m[0] };
+  for (const { type, pattern } of MATCHERS) {
+    const match = pattern.exec(slice);
+    if (match) return { type, value: match[0] };
   }
   return null;
 }

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -63,10 +63,10 @@ function buildLiveSummary(live: ActiveSession, serverEntry: SessionSummary | und
 // if updatedAt ties (same second-granularity mtime on two
 // server-only rows, say), fall back to `startedAt`. Exported so
 // tests can exercise the tie-break directly.
-export function compareSessionsByRecency(a: SessionSummary, b: SessionSummary): number {
-  const byUpdated = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+export function compareSessionsByRecency(left: SessionSummary, right: SessionSummary): number {
+  const byUpdated = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
   if (byUpdated !== 0) return byUpdated;
-  return Date.parse(b.startedAt) - Date.parse(a.startedAt);
+  return Date.parse(right.startedAt) - Date.parse(left.startedAt);
 }
 
 // Merge live sessions (in-memory, still editable) with server
@@ -75,10 +75,10 @@ export function compareSessionsByRecency(a: SessionSummary, b: SessionSummary): 
 // but pull over the server's AI title / summary / keywords when
 // present. Pure, returns a new array; does not mutate inputs.
 export function mergeSessionLists(liveSessions: readonly ActiveSession[], serverSessions: readonly SessionSummary[]): SessionSummary[] {
-  const liveIds = new Set(liveSessions.map((s) => s.id));
-  const serverById = new Map<string, SessionSummary>(serverSessions.map((s) => [s.id, s]));
+  const liveIds = new Set(liveSessions.map((session) => session.id));
+  const serverById = new Map<string, SessionSummary>(serverSessions.map((session) => [session.id, session]));
   const liveSummaries = liveSessions.map((live) => buildLiveSummary(live, serverById.get(live.id)));
-  const serverOnly = serverSessions.filter((s) => !liveIds.has(s.id));
+  const serverOnly = serverSessions.filter((session) => !liveIds.has(session.id));
   return [...liveSummaries, ...serverOnly].sort(compareSessionsByRecency);
 }
 
@@ -95,9 +95,9 @@ export function mergeSessionLists(liveSessions: readonly ActiveSession[], server
 // sites that don't care which they got.
 export function applySessionDiff(cache: readonly SessionSummary[], diff: readonly SessionSummary[], deletedIds: readonly string[]): SessionSummary[] {
   const deleted = new Set(deletedIds);
-  const diffById = new Map<string, SessionSummary>(diff.map((s) => [s.id, s]));
-  const kept = cache.filter((s) => !deleted.has(s.id)).map((s) => diffById.get(s.id) ?? s);
-  const existingIds = new Set(kept.map((s) => s.id));
-  const added = diff.filter((s) => !existingIds.has(s.id));
+  const diffById = new Map<string, SessionSummary>(diff.map((session) => [session.id, session]));
+  const kept = cache.filter((session) => !deleted.has(session.id)).map((session) => diffById.get(session.id) ?? session);
+  const existingIds = new Set(kept.map((session) => session.id));
+  const added = diff.filter((session) => !existingIds.has(session.id));
   return [...kept, ...added].sort(compareSessionsByRecency);
 }

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -40,7 +40,7 @@ export function parseSessionEntries(entries: readonly SessionEntry[]): ToolResul
 //      any kind.
 //   4. If the list is empty, return null.
 export function resolveSelectedUuid(toolResults: readonly ToolResultComplete[], urlResult: string | null): string | null {
-  if (urlResult && toolResults.some((r) => r.uuid === urlResult)) {
+  if (urlResult && toolResults.some((result) => result.uuid === urlResult)) {
     return urlResult;
   }
   // Iterate backwards for the "last non-text" lookup so callers
@@ -75,11 +75,11 @@ export function resolveSessionTimestamps(serverSummary: SessionSummary | undefin
 // Real-time results will overwrite with Date.now() via pushResult.
 export function interpolateTimestamps(toolResults: readonly ToolResultComplete[], startedAt: string, updatedAt: string): Map<string, number> {
   const timestamps = new Map<string, number>();
-  const t0 = new Date(startedAt).getTime();
-  const t1 = new Date(updatedAt).getTime();
-  toolResults.forEach((r, i) => {
+  const startMs = new Date(startedAt).getTime();
+  const endMs = new Date(updatedAt).getTime();
+  toolResults.forEach((result, i) => {
     const frac = toolResults.length > 1 ? i / (toolResults.length - 1) : 0;
-    timestamps.set(r.uuid, t0 + (t1 - t0) * frac);
+    timestamps.set(result.uuid, startMs + (endMs - startMs) * frac);
   });
   return timestamps;
 }
@@ -96,7 +96,7 @@ export function buildLoadedSession(opts: {
   nowIso: string;
 }): ActiveSession {
   const { id, entries, defaultRoleId, urlResult, serverSummary, nowIso } = opts;
-  const meta = entries.find((e) => e.type === EVENT_TYPES.sessionMeta);
+  const meta = entries.find((entry) => entry.type === EVENT_TYPES.sessionMeta);
   const roleId = meta?.roleId ?? defaultRoleId;
   const toolResults = parseSessionEntries(entries);
   const selectedResultUuid = resolveSelectedUuid(toolResults, urlResult);

--- a/test/routes/test_filesTreeAsync.ts
+++ b/test/routes/test_filesTreeAsync.ts
@@ -68,20 +68,20 @@ describe("buildTreeAsync", () => {
 
   it("orders dirs before files, alphabetically within type", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     // dir1 (dir) should come before a.md (file).
     assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
   });
 
   it("hides `.git/` hidden dir", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".git"));
   });
 
   it("hides `.env`, `id_rsa`, and `*.key` sensitive files", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const names = (tree.children ?? []).map((c) => c.name);
+    const names = (tree.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".env"));
     assert.ok(!names.includes("id_rsa"));
     assert.ok(!names.includes("ok.key"));
@@ -89,13 +89,13 @@ describe("buildTreeAsync", () => {
 
   it("recurses into subdirs (sub/c.md reachable via dir1/sub)", async () => {
     const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-    const dir1 = (tree.children ?? []).find((c) => c.name === "dir1");
+    const dir1 = (tree.children ?? []).find((child) => child.name === "dir1");
     assert.ok(dir1);
-    const sub = (dir1.children ?? []).find((c) => c.name === "sub");
+    const sub = (dir1.children ?? []).find((child) => child.name === "sub");
     assert.ok(sub);
-    const c = (sub.children ?? []).find((n) => n.name === "c.md");
-    assert.ok(c);
-    assert.equal(c.type, "file");
+    const leaf = (sub.children ?? []).find((node) => node.name === "c.md");
+    assert.ok(leaf);
+    assert.equal(leaf.type, "file");
   });
 
   it("skips symlinks (no workspace escape)", async () => {
@@ -106,7 +106,7 @@ describe("buildTreeAsync", () => {
     try {
       await symlink(linkTarget, linkPath);
       const tree = (await buildTreeAsync(root, "")) as TreeNodeShape;
-      const names = (tree.children ?? []).map((c) => c.name);
+      const names = (tree.children ?? []).map((child) => child.name);
       assert.ok(!names.includes("escape"));
     } finally {
       await rm(linkPath, { force: true });
@@ -136,7 +136,7 @@ describe("listDirShallow", () => {
   it("returns only the immediate children, no nested `children` field on sub-dirs", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
     assert.equal(node.type, "dir");
-    const dir1 = (node.children ?? []).find((c) => c.name === "dir1");
+    const dir1 = (node.children ?? []).find((child) => child.name === "dir1");
     assert.ok(dir1);
     assert.equal(dir1.type, "dir");
     // Shallow → no grandchildren materialised.
@@ -145,7 +145,7 @@ describe("listDirShallow", () => {
 
   it("applies the same hidden/sensitive filters as the recursive walk", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     assert.ok(!names.includes(".git"));
     assert.ok(!names.includes(".env"));
     assert.ok(!names.includes("id_rsa"));
@@ -154,19 +154,19 @@ describe("listDirShallow", () => {
 
   it("orders dirs before files, alphabetically", async () => {
     const node = (await listDirShallow(root, "")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     assert.ok(names.indexOf("dir1") < names.indexOf("a.md"));
   });
 
   it("reads a sub-directory when given its path", async () => {
     const subAbs = path.join(root, "dir1");
     const node = (await listDirShallow(subAbs, "dir1")) as TreeNodeShape;
-    const names = (node.children ?? []).map((c) => c.name);
+    const names = (node.children ?? []).map((child) => child.name);
     // dir1 contains `b.md` (file) and `sub/` (dir).
     assert.ok(names.includes("b.md"));
     assert.ok(names.includes("sub"));
     // sub/ reported as a dir, not expanded.
-    const sub = (node.children ?? []).find((c) => c.name === "sub");
+    const sub = (node.children ?? []).find((child) => child.name === "sub");
     assert.equal(sub?.type, "dir");
     assert.equal(sub?.children, undefined);
   });


### PR DESCRIPTION
## Summary

Continues id-length cleanup on top of `prettierrc` branch (#540). Two parts:

1. **Scope rule to production code** — add `id-length: off` to the existing test/e2e override in `eslint.config.mjs`. Tests use throwaway names (`a`/`b` in sort, `{ id: "a" }` fixtures, `s` in session tests) where renaming is pure noise.
2. **Rename short identifiers in 15 src/ files** — mechanical, no semantic changes.

**Repo-wide warnings: 2071 → 758.**

## Per-file renames

| File | Before | After | Key renames |
|---|--:|--:|---|
| `TodoExplorer.vue` | 15 | 8 | `q→query`, `ok→created/added/saved/confirmed`, `id`-params → `itemId`/`columnId` |
| `SettingsMcpTab.vue` | 14 | 3 | `(d)→(state)/(input)`, `(s)→(server)`, `(p)→(part)`, `(a)→(arg)` |
| `TodoKanbanView.vue` | 13 | 7 | `(c)→(column)`, id-params → `columnId`, sort `(a,b)→(left,right)` |
| `manageSource/View.vue` | 12 | 3 | `(d)→(input)`, `(s)→(source)`, `(e)→(entry)`, `y/m/d→year/month/day` |
| `mergeSessions.ts` | 11 | 1 | sort `(a,b)→(left,right)`, callback `(s)→(session)` |
| `date.ts` | 9 | 0 | `(d)→(date)`, `(ms)→(epochMs)`, `(a,b)→(left,right)` |
| `useTodos.ts` | 9 | 5 | `(x)→(value)`, `(i,c)→(extractedItems,extractedColumns)`, `ok→success` |
| `priority.ts` | 6 | 0 | `(v)→(value)`, `t/d→todayDate/dueDateObj`, `yyyy/mm/dd` unpacked |
| `manageRoles/View.vue` | 6 | 3 | `(p)→(plugin)/(name)`, `id→roleId`, `(s)→(line)` |
| `markdown/Preview.vue` | 6 | 0 | `(md)→(markdown)`, `(h1)→(heading)`, `(l)→(line)` |
| `chart/View.vue` | 6 | 1 | `(el)→(element)`, `(dz)→(dataZoom)`, `(a)→(anchor)` |
| `StackView.vue` | 6 | 0 | bulk `(el)→(element)` via perl |
| `NotificationBell.vue` | 6 | 1 | `(e)→(event)`, `(v)→(shouldClose)`, `(n)→(notification)` |
| `jsonSyntax.ts` | 7 | 1 | `(re,m)→(pattern,match)` |
| `sessionEntries.ts` | 7 | 2 | `(r)→(result)`, `t0/t1→startMs/endMs`, `(e)→(entry)` |
| `wiki/View.vue` | 5 | 1 | `(d)→(data)`, `(a)→(anchor)`, `(e)→(event)` |
| `useDynamicFavicon.ts` | 5 | 0 | `drawRoundedRect(x,y,w,h,r)` → `(posX,posY,width,height,radius)` |
| `TodoTableView.vue` | 7 | 2 | id-params → `itemId`, `(c)→(col)`, `(a,b)/(x,y)→(left,right)` |

## Items to Confirm / Review

- **`id-length: off` in test/e2e override** — deliberate scope narrowing. Call out if you'd rather keep it on.
- **`id` property keys in data literals (e.g. `{ id: "tech-news" }`) left alone** — these are semantic domain values, not variable names worth renaming.
- **no-shadow errors caught mid-edit** — `buildRegisterPayload(draft)` and `suggestIdFromDraft(draft)` each shadowed an outer `draft` ref; renamed to `(input)` / `(state)` respectively.
- **`StackView.vue` uses `perl -i` bulk rename** of `\bel\b → element` (6 sites). Verified typecheck passes.
- **chart/View.vue `(el)→(element)` rename** collided with `element` already existing at outer scope? No — verified no outer `element` binding.

## Test plan
- [x] `yarn format`, `yarn lint` (0 errors, 758 warnings), `yarn vue-tsc`, `yarn typecheck` all clean
- [x] `yarn test` — 2576 + 34 passing
- [ ] CI
- [ ] Manual smoke check (todo kanban drag, scheduler calendar, wiki navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope ESLint id-length rule away from tests and rename short identifiers across multiple source files for clearer, more consistent naming.

Enhancements:
- Rename short and ambiguous variables, parameters, and locals to more descriptive names across todo components, markdown/wiki views, notifications, charts, sessions, JSON formatting, and various utilities to improve readability and maintainability.
- Adjust comparison and helper function signatures (e.g., date/time, session merging, sorting utilities) to use clearer parameter names while preserving behavior.
- Update test/e2e ESLint override to disable id-length in test contexts where short throwaway identifiers are acceptable noise.