### PR TITLE
feat(manageRoles): create + rename custom roles from the view

### DIFF
--- a/plans/feat-manage-roles-view-crud.md
+++ b/plans/feat-manage-roles-view-crud.md
@@ -1,0 +1,213 @@
+# Custom Roles View — Create / Edit / Rename from UI
+
+## Overview
+
+The `manageRoles` plugin view (`src/plugins/manageRoles/View.vue`) previously let
+the user inline-edit a limited set of fields on existing custom roles — but
+creating a new role or changing a role's id was only possible by asking Claude
+in chat. This change makes both operations available directly from the view.
+
+The key user-facing additions:
+
+1. **`+ Add` button** in the header to open a creation panel.
+2. **Editable `ID` field** in the existing inline editor (ids are the filename
+   of `~/mulmoclaude/config/roles/<id>.json`, so renaming must also delete the
+   old file — a server change was required).
+3. **Disabled-by-default submit buttons** tied to live validation (required
+   id / charset / duplicate / required name).
+4. **Responsive plugin-checkbox grid** using CSS `auto-fit` so the column
+   count adapts to the panel width instead of being stuck at 2 columns.
+5. **Scrollable body area** so the tall creation/edit panels are always
+   fully reachable.
+6. **Button style consistency** — the `+ Add` button matches the ToDo
+   view's `+ Add` styling (`bg-blue-500 ... px-2 py-1 text-xs`, defined
+   in `src/components/TodoExplorer.vue`) and sits on the right side of
+   the header.
+
+---
+
+## Baseline drift since plan was drafted
+
+`main` has moved forward from the branch point (`683520c`) with changes
+that touch the files listed below. None of them alter logic — they
+change formatting and lint posture — but they do shift what a rebase /
+merge of this work will look like.
+
+* **`.prettierrc` added** with `printWidth: 160` (`58054fb`, `579e8b7`).
+  Every role-plugin file (`server/api/routes/roles.ts`,
+  `server/workspace/roles.ts`, `src/config/roles.ts`,
+  `src/plugins/manageRoles/{View,Preview}.vue`,
+  `src/plugins/manageRoles/{definition,index}.ts`) has been reflowed —
+  multi-line imports, wrapped JSX-like Vue attributes, and wrapped
+  function signatures now collapse to one line where they fit. Rebasing
+  the work for this plan will cascade prettier through the diff; no
+  functional conflicts, just whitespace.
+* **`eslint.config.mjs` — `id-length` added as `warn`** (`4c788a1`),
+  `min: 3`, exceptions `i / j / fs / os`. The plan's
+  `deleteRoleResult(id, sessionId)` helper uses `id` (2 chars) — that
+  will surface as a lint warning. Either rename the parameter
+  (e.g. `roleId`) or accept the warn; it does not block CI.
+* **`eslint.config.mjs` — `sonarjs/no-nested-conditional` flipped
+  `off → warn`** (`d5ddf09`). The proposed code does not use nested
+  ternaries, so this should not fire.
+
+No logic changes in any role-plugin file on `main` since plan was
+drafted. All pre-change assumptions (monolithic `executeManageRoles`,
+no `id` field in `EditForm`, `grid-cols-2` on the plugin checkbox grid,
+no `+ Add` button) still hold on current `main`.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/plugins/manageRoles/View.vue` | Template + script: new-role panel, editable id, computed validation, scrollable body, responsive plugin grid, ToDo-style `+ Add` button |
+| `server/api/routes/roles.ts` | New `oldRoleId` field on the manage payload; rename handling; refactor into `listRolesResult` / `deleteRoleResult` / `saveRoleResult` helpers to satisfy the cognitive-complexity lint threshold |
+| `test/routes/test_rolesManage.ts` | New unit tests for the rename path (happy path + builtin-id guard + duplicate-id guard + plain update) |
+
+No package changes, no schema changes to the persisted JSON files.
+
+---
+
+## Server change — `server/api/routes/roles.ts`
+
+### New input field
+
+```ts
+interface ManageRolesInput {
+  action: string;
+  role?: { id, name, icon, prompt, availablePlugins, queries? };
+  roleId?: string;
+  oldRoleId?: string;   // ← new
+}
+```
+
+### Rename semantics
+
+When `action === "update"` and `oldRoleId` is present and differs from
+`role.id`, the request is treated as a **rename**:
+
+1. Reject if the new id collides with a built-in role id
+   (`BUILTIN_IDS.has(role.id)`).
+2. Reject if the new id is already used by another custom role
+   (`roleExists(role.id)`) — this guards against silently overwriting a
+   neighbour.
+3. `saveRole(role.id, roleToSave)` — writes the new file.
+4. `deleteRole(oldRoleId)` — removes the old file (guarded against
+   deleting a built-in id or a missing file).
+
+Old `update` requests without `oldRoleId` keep their previous behaviour
+(overwrite in place), so existing LLM tool-calls are unaffected.
+
+### Refactor
+
+The original `executeManageRoles` was a single function containing the
+list, delete, and create/update branches. Adding the rename check pushed
+it over the `sonarjs/cognitive-complexity` threshold (15), so it was
+split:
+
+```
+executeManageRoles(input, sessionId)  // tiny dispatcher
+  ├── listRolesResult()
+  ├── deleteRoleResult(id, sessionId)
+  └── saveRoleResult(input, sessionId)
+        └── validateSaveInput(input)  // returns {role, isRename} | errorString
+```
+
+---
+
+## Client change — `src/plugins/manageRoles/View.vue`
+
+### Template additions
+
+```
+┌─ Header ──────────────────────────────────────────┐
+│ Custom Roles              N roles  [+ Add]        │   ← ToDo-style button
+└───────────────────────────────────────────────────┘
+┌─ flex-1 overflow-y-auto ──────────────────────────┐
+│ ┌─ creating === true ─ Create new role ─────────┐ │
+│ │ [ID] [Name] [Icon]                            │ │
+│ │ [Prompt textarea]                             │ │
+│ │ [Plugins — auto-fit grid]                     │ │
+│ │ [Starter queries]                             │ │
+│ │ [Create (disabled if invalid)] [Cancel]       │ │
+│ │ validation hint (gray) / server error (red)   │ │
+│ └───────────────────────────────────────────────┘ │
+│ <role list>                                       │
+│   └─ inline editor now has an editable [ID] too   │
+└───────────────────────────────────────────────────┘
+```
+
+Both the creation panel and the inline editor now share a single
+`flex-1 overflow-y-auto` scroll container; previously the creation
+panel was a direct flex child with no overflow handling, so tall
+content clipped the Create/Cancel buttons.
+
+The plugin checkbox grid in both panels uses:
+
+```
+grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]
+```
+
+so column count adapts to the actual panel width instead of a fixed
+`grid-cols-2`.
+
+### Script additions
+
+* `EditForm` now has an `id` field. `NewRoleForm` was removed because
+  it became identical to `EditForm`.
+* `creating` / `newForm` / `createError` state for the creation panel;
+  `startCreate` / `cancelCreate` toggle it and reset the form.
+* `validateRoleForm(form, excludeId)` — shared validator. `newFormError`
+  calls it with `excludeId = null`; `editFormError` passes
+  `selectedId.value` so the currently-edited role does not count as a
+  duplicate of itself.
+* Both submit buttons bind `:disabled="saving || !!formError"` with
+  `:title="formError ?? ''"` so hover reveals *why* it is disabled, and
+  a gray hint line below the buttons shows the active validation error.
+* `saveEdit(originalId)` sends `{ action: "update", role, oldRoleId:
+  originalId }` — `originalId` is the template `role.id` from the v-for,
+  which always reflects the id that existed before the edit session.
+* `saveNew()` sends `{ action: "create", role }` and then calls the
+  existing `refreshList()` helper, which emits the `updateResult`
+  event and calls `appApi.refreshRoles()` so the top-bar role dropdown
+  reflects the new role immediately.
+
+### Validation rules (client-side, mirrored on server)
+
+1. id required
+2. id matches `/^[a-zA-Z0-9_-]+$/`
+3. name required
+4. id not already used by another custom role (excluding self on edit)
+
+Server adds: id not a built-in id, and on rename, id not already used
+(in case the client is out of sync).
+
+---
+
+## Tests — `test/routes/test_rolesManage.ts`
+
+Four unit tests exercise `executeManageRoles` against a temp workspace
+(HOME override + dynamic import, matching `test_html_io.ts`):
+
+1. **rename happy path** — new file exists, old file is gone.
+2. **rename into built-in id** — rejected, no file written.
+3. **rename into an id already used** — rejected, both original roles
+   intact.
+4. **plain update (no `oldRoleId`)** — still works, nothing deleted.
+
+---
+
+## Out of scope / follow-ups
+
+* No refactor of the creation panel and inline editor into a shared
+  component. The markup duplication is ~80 lines; extracting a
+  `<RoleEditor>` component is a plausible next step but was kept out of
+  this change to keep the diff reviewable.
+* No auto-slug from Name → ID. The user types the id explicitly; the
+  validator gives fast feedback if they pick a bad one.
+* Dev-server ergonomics: `yarn dev` runs `tsx server/index.ts` without
+  `--watch`, so server-side changes in `roles.ts` require a manual
+  restart of the server process. This surfaced during testing of the
+  rename path. Not changed here — it is a repo-wide concern.

--- a/plans/feat-manage-roles-view-crud.md
+++ b/plans/feat-manage-roles-view-crud.md
@@ -94,8 +94,12 @@ When `action === "update"` and `oldRoleId` is present and differs from
    (`roleExists(role.id)`) — this guards against silently overwriting a
    neighbour.
 3. `saveRole(role.id, roleToSave)` — writes the new file.
-4. `deleteRole(oldRoleId)` — removes the old file (guarded against
-   deleting a built-in id or a missing file).
+4. `deleteRole(oldRoleId)` — removes the old file (guarded only
+   against a missing file). A file at `config/roles/<builtin>.json`
+   is a user-created override, not the built-in itself (which lives in
+   `BUILTIN_ROLES`); leaving it behind on rename would continue to
+   shadow the built-in and couldn't be cleaned up via `delete`, which
+   also rejects built-in ids.
 
 Old `update` requests without `oldRoleId` keep their previous behaviour
 (overwrite in place), so existing LLM tool-calls are unaffected.

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -98,7 +98,12 @@ function saveRoleResult(input: ManageRolesInput, sessionId: string): Record<stri
   };
 
   saveRole(role.id, roleToSave);
-  if (isRename && oldRoleId && !BUILTIN_IDS.has(oldRoleId) && roleExists(oldRoleId)) {
+  // On rename, remove the old file even if its id matches a built-in —
+  // a file at `config/roles/<builtin>.json` is a user-created override,
+  // not the built-in itself (which lives in BUILTIN_ROLES). Leaving it
+  // behind would shadow the built-in and couldn't be cleaned up via
+  // `delete`, which also rejects built-in ids.
+  if (isRename && oldRoleId && roleExists(oldRoleId)) {
     deleteRole(oldRoleId);
   }
   notifyRolesUpdated(sessionId);

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -38,53 +38,57 @@ interface ManageRolesInput {
     queries?: string[];
   };
   roleId?: string;
+  oldRoleId?: string;
 }
 
-export async function executeManageRoles(input: ManageRolesInput, sessionId: string): Promise<Record<string, unknown>> {
-  const { action, role, roleId } = input;
+function listRolesResult(): Record<string, unknown> {
+  const customRoles = loadCustomRoles();
+  return {
+    success: true,
+    message: `${customRoles.length} custom role${customRoles.length !== 1 ? "s" : ""}.`,
+    data: { customRoles },
+  };
+}
 
-  if (action === "list") {
-    const customRoles = loadCustomRoles();
-    return {
-      success: true,
-      message: `${customRoles.length} custom role${customRoles.length !== 1 ? "s" : ""}.`,
-      data: { customRoles },
-    };
+function deleteRoleResult(roleId: string | undefined, sessionId: string): Record<string, unknown> {
+  if (!roleId) return { success: false, error: "roleId is required for delete action" };
+  if (BUILTIN_IDS.has(roleId)) {
+    return { success: false, error: "Cannot delete built-in roles." };
   }
-
-  if (action === "delete") {
-    const id = roleId;
-    if (!id) return { success: false, error: "roleId is required for delete action" };
-    if (BUILTIN_IDS.has(id)) {
-      return { success: false, error: "Cannot delete built-in roles." };
-    }
-    if (!roleExists(id)) {
-      return { success: false, error: `Role '${id}' not found.` };
-    }
-    deleteRole(id);
-    notifyRolesUpdated(sessionId);
-    return {
-      success: true,
-      message: `Role '${id}' deleted.`,
-      roles: loadCustomRoles(),
-    };
+  if (!roleExists(roleId)) {
+    return { success: false, error: `Role '${roleId}' not found.` };
   }
+  deleteRole(roleId);
+  notifyRolesUpdated(sessionId);
+  return {
+    success: true,
+    message: `Role '${roleId}' deleted.`,
+    roles: loadCustomRoles(),
+  };
+}
 
-  // create or update
-  if (!role)
-    return {
-      success: false,
-      error: "role definition required for create/update",
-    };
-  if (!role.id) return { success: false, error: "role.id is required" };
-  const roleId2 = role.id;
+function validateSaveInput(input: ManageRolesInput): { role: NonNullable<ManageRolesInput["role"]>; isRename: boolean } | string {
+  const { action, role, oldRoleId } = input;
+  if (!role) return "role definition required for create/update";
+  if (!role.id) return "role.id is required";
 
-  if (BUILTIN_IDS.has(roleId2) && action === "create") {
-    return {
-      success: false,
-      error: `ID '${roleId2}' is reserved for a built-in role.`,
-    };
+  const isRename = Boolean(oldRoleId && oldRoleId !== role.id);
+  if (BUILTIN_IDS.has(role.id) && (action === "create" || isRename)) {
+    return `ID '${role.id}' is reserved for a built-in role.`;
   }
+  if (isRename && roleExists(role.id)) {
+    return `A role with ID '${role.id}' already exists.`;
+  }
+  return { role, isRename };
+}
+
+function saveRoleResult(input: ManageRolesInput, sessionId: string): Record<string, unknown> {
+  const validated = validateSaveInput(input);
+  if (typeof validated === "string") {
+    return { success: false, error: validated };
+  }
+  const { role, isRename } = validated;
+  const { action, oldRoleId } = input;
 
   // Strip switchRole before saving — it is injected at load time by server/roles.ts
   const pluginsToSave = role.availablePlugins ?? [];
@@ -93,11 +97,20 @@ export async function executeManageRoles(input: ManageRolesInput, sessionId: str
     availablePlugins: pluginsToSave.filter((p) => p !== "switchRole"),
   };
 
-  saveRole(roleId2, roleToSave);
+  saveRole(role.id, roleToSave);
+  if (isRename && oldRoleId && !BUILTIN_IDS.has(oldRoleId) && roleExists(oldRoleId)) {
+    deleteRole(oldRoleId);
+  }
   notifyRolesUpdated(sessionId);
   return {
     success: true,
     message: `Role '${role.name}' ${action}d successfully.`,
     roles: loadCustomRoles(),
   };
+}
+
+export async function executeManageRoles(input: ManageRolesInput, sessionId: string): Promise<Record<string, unknown>> {
+  if (input.action === "list") return listRolesResult();
+  if (input.action === "delete") return deleteRoleResult(input.roleId, sessionId);
+  return saveRoleResult(input, sessionId);
 }

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -72,11 +72,15 @@ function validateSaveInput(input: ManageRolesInput): { role: NonNullable<ManageR
   if (!role) return "role definition required for create/update";
   if (!role.id) return "role.id is required";
 
-  const isRename = Boolean(oldRoleId && oldRoleId !== role.id);
+  // Rename is strictly an update-with-different-id. Gating on
+  // action === "update" means a malformed create payload that
+  // happens to include `oldRoleId` cannot silently delete an
+  // unrelated file via the rename cleanup below.
+  const isRename = Boolean(action === "update" && oldRoleId && oldRoleId !== role.id);
   if (BUILTIN_IDS.has(role.id) && (action === "create" || isRename)) {
     return `ID '${role.id}' is reserved for a built-in role.`;
   }
-  if (isRename && roleExists(role.id)) {
+  if ((action === "create" || isRename) && roleExists(role.id)) {
     return `A role with ID '${role.id}' already exists.`;
   }
   return { role, isRename };

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -2,144 +2,267 @@
   <div class="h-full bg-white flex flex-col">
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <h2 class="text-lg font-semibold text-gray-800">Custom Roles</h2>
-      <span class="text-sm text-gray-500">
-        {{ customRoles.length }}
-        role{{ customRoles.length !== 1 ? "s" : "" }}
-      </span>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-gray-500">
+          {{ customRoles.length }}
+          role{{ customRoles.length !== 1 ? "s" : "" }}
+        </span>
+        <button v-if="!creating" data-testid="role-add-btn" class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" @click="startCreate">
+          + Add
+        </button>
+      </div>
     </div>
 
-    <div v-if="customRoles.length === 0" class="flex-1 flex items-center justify-center text-gray-400 text-sm">
-      No custom roles yet. Ask Claude to create one.
-    </div>
+    <div class="flex-1 overflow-y-auto">
+      <!-- New role creation panel -->
+      <div v-if="creating" class="m-4 border border-blue-300 bg-blue-50 rounded-lg p-4 space-y-3">
+        <div class="text-sm font-semibold text-gray-700">Create new role</div>
 
-    <ul v-else class="flex-1 overflow-y-auto p-4 space-y-2">
-      <li v-for="role in customRoles" :key="role.id" class="rounded-lg border" :class="selectedId === role.id ? 'border-blue-400' : 'border-gray-200'">
-        <!-- Role header row -->
-        <div
-          class="flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 rounded-lg"
-          :class="selectedId === role.id ? 'rounded-b-none' : ''"
-          @click="selectRole(role)"
-        >
-          <span class="material-icons text-gray-500">{{ role.icon }}</span>
-          <div class="flex-1 min-w-0">
-            <div class="font-medium text-sm text-gray-800">
-              {{ role.name }}
-              <span class="ml-1 text-xs font-mono text-gray-400">({{ role.id }})</span>
-            </div>
-            <div class="text-xs text-gray-400 truncate">
-              {{ role.availablePlugins.join(", ") }}
-            </div>
-          </div>
-          <span class="material-icons text-gray-400 text-sm" :title="selectedId === role.id ? 'Collapse' : 'Expand'">
-            {{ selectedId === role.id ? "expand_less" : "expand_more" }}
-          </span>
-        </div>
-
-        <!-- Inline editor -->
-        <div v-if="selectedId === role.id" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
-          <!-- Name + Icon row -->
-          <div class="flex gap-3">
-            <div class="flex-1">
-              <label class="block text-xs font-medium text-gray-600 mb-1">Name</label>
-              <input
-                v-model="editForm.name"
-                type="text"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-                @keydown.enter="saveEdit(role.id)"
-              />
-            </div>
-            <div class="w-32">
-              <label class="block text-xs font-medium text-gray-600 mb-1">
-                Icon
-                <a class="text-blue-400 font-normal ml-1" href="https://fonts.google.com/icons" target="_blank" rel="noopener">?</a>
-              </label>
-              <input
-                v-model="editForm.icon"
-                type="text"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
-              />
-            </div>
-          </div>
-
-          <!-- Prompt -->
-          <div>
-            <label class="block text-xs font-medium text-gray-600 mb-1">Prompt</label>
-            <textarea
-              v-model="editForm.prompt"
-              rows="6"
-              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono resize-y focus:outline-none focus:border-blue-400"
-              spellcheck="false"
+        <!-- ID + Name + Icon row -->
+        <div class="flex gap-3">
+          <div class="w-40">
+            <label class="block text-xs font-medium text-gray-600 mb-1">ID</label>
+            <input
+              v-model="newForm.id"
+              type="text"
+              placeholder="unique-id"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
             />
           </div>
-
-          <!-- Plugins -->
-          <div>
-            <label class="block text-xs font-medium text-gray-600 mb-2">Plugins</label>
-            <div class="grid grid-cols-2 gap-x-4 gap-y-1">
-              <label
-                v-for="plugin in availablePlugins"
-                :key="plugin.name"
-                class="flex items-center gap-2 text-sm cursor-pointer"
-                :class="plugin.enabled ? 'text-gray-700' : 'text-gray-400 cursor-not-allowed'"
-                :title="plugin.enabled ? '' : `Requires ${plugin.requiredEnv.join(', ')} in .env`"
-              >
-                <input
-                  v-model="editForm.selectedPlugins"
-                  type="checkbox"
-                  :value="plugin.name"
-                  :disabled="!plugin.enabled"
-                  class="cursor-pointer disabled:cursor-not-allowed"
-                />
-                {{ plugin.name }}
-                <span v-if="!plugin.enabled" class="text-xs text-gray-400">(missing {{ plugin.requiredEnv.join(", ") }})</span>
-              </label>
-            </div>
+          <div class="flex-1">
+            <label class="block text-xs font-medium text-gray-600 mb-1">Name</label>
+            <input
+              v-model="newForm.name"
+              type="text"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+            />
           </div>
-
-          <!-- Starter queries -->
-          <div>
+          <div class="w-32">
             <label class="block text-xs font-medium text-gray-600 mb-1">
-              Starter queries
-              <span class="text-gray-400 font-normal">(one per line)</span>
+              Icon
+              <a class="text-blue-400 font-normal ml-1" href="https://fonts.google.com/icons" target="_blank" rel="noopener">?</a>
             </label>
-            <textarea
-              v-model="editForm.queriesText"
-              rows="3"
-              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+            <input
+              v-model="newForm.icon"
+              type="text"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
             />
           </div>
+        </div>
 
-          <!-- Buttons -->
-          <div class="flex items-center justify-between pt-1">
-            <div class="flex gap-2">
-              <button
-                class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50"
-                :disabled="saving"
-                @click="saveEdit(role.id)"
-              >
-                {{ saving ? "Updating…" : "Update" }}
-              </button>
-              <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="selectedId = null">Cancel</button>
-            </div>
-            <button
-              class="px-3 py-1.5 text-sm rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-50"
-              :disabled="saving"
-              @click="deleteRole(role.id)"
+        <!-- Prompt -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">Prompt</label>
+          <textarea
+            v-model="newForm.prompt"
+            rows="6"
+            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono resize-y focus:outline-none focus:border-blue-400"
+            spellcheck="false"
+          />
+        </div>
+
+        <!-- Plugins -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-2">Plugins</label>
+          <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+            <label
+              v-for="plugin in availablePlugins"
+              :key="plugin.name"
+              class="flex items-center gap-2 text-sm cursor-pointer"
+              :class="plugin.enabled ? 'text-gray-700' : 'text-gray-400 cursor-not-allowed'"
+              :title="plugin.enabled ? '' : `Requires ${plugin.requiredEnv.join(', ')} in .env`"
             >
-              Delete
-            </button>
-          </div>
-          <div v-if="saveError" class="text-xs text-red-500">
-            {{ saveError }}
+              <input
+                v-model="newForm.selectedPlugins"
+                type="checkbox"
+                :value="plugin.name"
+                :disabled="!plugin.enabled"
+                class="cursor-pointer disabled:cursor-not-allowed"
+              />
+              {{ plugin.name }}
+              <span v-if="!plugin.enabled" class="text-xs text-gray-400">(missing {{ plugin.requiredEnv.join(", ") }})</span>
+            </label>
           </div>
         </div>
-      </li>
-    </ul>
+
+        <!-- Starter queries -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">
+            Starter queries
+            <span class="text-gray-400 font-normal">(one per line)</span>
+          </label>
+          <textarea
+            v-model="newForm.queriesText"
+            rows="3"
+            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+          />
+        </div>
+
+        <!-- Buttons -->
+        <div class="flex gap-2 pt-1">
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            :disabled="saving || !!newFormError"
+            :title="newFormError ?? ''"
+            @click="saveNew"
+          >
+            {{ saving ? "Creating…" : "Create" }}
+          </button>
+          <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="cancelCreate">Cancel</button>
+        </div>
+        <div v-if="newFormError" class="text-xs text-gray-500" data-testid="role-form-hint">
+          {{ newFormError }}
+        </div>
+        <div v-if="createError" class="text-xs text-red-500">
+          {{ createError }}
+        </div>
+      </div>
+
+      <div v-if="!creating && customRoles.length === 0" class="h-full flex items-center justify-center text-gray-400 text-sm">
+        No custom roles yet. Click "+ Add" or ask Claude to create one.
+      </div>
+
+      <ul v-if="customRoles.length > 0" class="p-4 space-y-2">
+        <li v-for="role in customRoles" :key="role.id" class="rounded-lg border" :class="selectedId === role.id ? 'border-blue-400' : 'border-gray-200'">
+          <!-- Role header row -->
+          <div
+            class="flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 rounded-lg"
+            :class="selectedId === role.id ? 'rounded-b-none' : ''"
+            @click="selectRole(role)"
+          >
+            <span class="material-icons text-gray-500">{{ role.icon }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-sm text-gray-800">
+                {{ role.name }}
+                <span class="ml-1 text-xs font-mono text-gray-400">({{ role.id }})</span>
+              </div>
+              <div class="text-xs text-gray-400 truncate">
+                {{ role.availablePlugins.join(", ") }}
+              </div>
+            </div>
+            <span class="material-icons text-gray-400 text-sm" :title="selectedId === role.id ? 'Collapse' : 'Expand'">
+              {{ selectedId === role.id ? "expand_less" : "expand_more" }}
+            </span>
+          </div>
+
+          <!-- Inline editor -->
+          <div v-if="selectedId === role.id" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+            <!-- ID + Name + Icon row -->
+            <div class="flex gap-3">
+              <div class="w-40">
+                <label class="block text-xs font-medium text-gray-600 mb-1">ID</label>
+                <input
+                  v-model="editForm.id"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+                />
+              </div>
+              <div class="flex-1">
+                <label class="block text-xs font-medium text-gray-600 mb-1">Name</label>
+                <input
+                  v-model="editForm.name"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+                  @keydown.enter="saveEdit(role.id)"
+                />
+              </div>
+              <div class="w-32">
+                <label class="block text-xs font-medium text-gray-600 mb-1">
+                  Icon
+                  <a class="text-blue-400 font-normal ml-1" href="https://fonts.google.com/icons" target="_blank" rel="noopener">?</a>
+                </label>
+                <input
+                  v-model="editForm.icon"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+                />
+              </div>
+            </div>
+
+            <!-- Prompt -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Prompt</label>
+              <textarea
+                v-model="editForm.prompt"
+                rows="6"
+                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono resize-y focus:outline-none focus:border-blue-400"
+                spellcheck="false"
+              />
+            </div>
+
+            <!-- Plugins -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-2">Plugins</label>
+              <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+                <label
+                  v-for="plugin in availablePlugins"
+                  :key="plugin.name"
+                  class="flex items-center gap-2 text-sm cursor-pointer"
+                  :class="plugin.enabled ? 'text-gray-700' : 'text-gray-400 cursor-not-allowed'"
+                  :title="plugin.enabled ? '' : `Requires ${plugin.requiredEnv.join(', ')} in .env`"
+                >
+                  <input
+                    v-model="editForm.selectedPlugins"
+                    type="checkbox"
+                    :value="plugin.name"
+                    :disabled="!plugin.enabled"
+                    class="cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  {{ plugin.name }}
+                  <span v-if="!plugin.enabled" class="text-xs text-gray-400">(missing {{ plugin.requiredEnv.join(", ") }})</span>
+                </label>
+              </div>
+            </div>
+
+            <!-- Starter queries -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">
+                Starter queries
+                <span class="text-gray-400 font-normal">(one per line)</span>
+              </label>
+              <textarea
+                v-model="editForm.queriesText"
+                rows="3"
+                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+              />
+            </div>
+
+            <!-- Buttons -->
+            <div class="flex items-center justify-between pt-1">
+              <div class="flex gap-2">
+                <button
+                  class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  :disabled="saving || !!editFormError"
+                  :title="editFormError ?? ''"
+                  @click="saveEdit(role.id)"
+                >
+                  {{ saving ? "Updating…" : "Update" }}
+                </button>
+                <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="selectedId = null">Cancel</button>
+              </div>
+              <button
+                class="px-3 py-1.5 text-sm rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-50"
+                :disabled="saving"
+                @click="deleteRole(role.id)"
+              >
+                Delete
+              </button>
+            </div>
+            <div v-if="editFormError" class="text-xs text-gray-500">
+              {{ editFormError }}
+            </div>
+            <div v-if="saveError" class="text-xs text-red-500">
+              {{ saveError }}
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { useAppApi } from "../../composables/useAppApi";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -203,6 +326,7 @@ const saving = ref(false);
 const saveError = ref("");
 
 interface EditForm {
+  id: string;
   name: string;
   icon: string;
   prompt: string;
@@ -211,12 +335,43 @@ interface EditForm {
 }
 
 const editForm = ref<EditForm>({
+  id: "",
   name: "",
   icon: "",
   prompt: "",
   selectedPlugins: [],
   queriesText: "",
 });
+
+const creating = ref(false);
+const createError = ref("");
+const newForm = ref<EditForm>({
+  id: "",
+  name: "",
+  icon: "person",
+  prompt: "",
+  selectedPlugins: [],
+  queriesText: "",
+});
+
+function startCreate() {
+  selectedId.value = null;
+  createError.value = "";
+  newForm.value = {
+    id: "",
+    name: "",
+    icon: "person",
+    prompt: "",
+    selectedPlugins: [],
+    queriesText: "",
+  };
+  creating.value = true;
+}
+
+function cancelCreate() {
+  creating.value = false;
+  createError.value = "";
+}
 
 function selectRole(role: CustomRole) {
   if (selectedId.value === role.id) {
@@ -226,6 +381,7 @@ function selectRole(role: CustomRole) {
   selectedId.value = role.id;
   saveError.value = "";
   editForm.value = {
+    id: role.id,
     name: role.name,
     icon: role.icon,
     prompt: role.prompt,
@@ -273,11 +429,64 @@ async function refreshList() {
   }
 }
 
-async function saveEdit(id: string) {
+function validateRoleForm(form: EditForm, excludeId: string | null): string | null {
+  const trimmedId = form.id.trim();
+  const trimmedName = form.name.trim();
+  if (!trimmedId) return "ID is required.";
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmedId)) {
+    return "ID may only contain letters, numbers, '-' and '_'.";
+  }
+  if (!trimmedName) return "Name is required.";
+  if (customRoles.value.some((r) => r.id === trimmedId && r.id !== excludeId)) {
+    return `A role with ID '${trimmedId}' already exists.`;
+  }
+  return null;
+}
+
+const newFormError = computed<string | null>(() => validateRoleForm(newForm.value, null));
+
+const editFormError = computed<string | null>(() => validateRoleForm(editForm.value, selectedId.value));
+
+function buildNewRole(): CustomRole {
+  return {
+    id: newForm.value.id.trim(),
+    name: newForm.value.name.trim(),
+    icon: newForm.value.icon.trim() || "person",
+    prompt: newForm.value.prompt,
+    availablePlugins: newForm.value.selectedPlugins,
+    queries: newForm.value.queriesText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+async function saveNew() {
+  if (newFormError.value) {
+    createError.value = newFormError.value;
+    return;
+  }
+  saving.value = true;
+  createError.value = "";
+  const result = await callManage({ action: "create", role: buildNewRole() });
+  if (result.success) {
+    creating.value = false;
+    await refreshList();
+  } else {
+    createError.value = result.error ?? "Create failed";
+  }
+  saving.value = false;
+}
+
+async function saveEdit(originalId: string) {
+  if (editFormError.value) {
+    saveError.value = editFormError.value;
+    return;
+  }
   saving.value = true;
   saveError.value = "";
   const role: CustomRole = {
-    id,
+    id: editForm.value.id.trim(),
     name: editForm.value.name.trim(),
     icon: editForm.value.icon.trim(),
     prompt: editForm.value.prompt,
@@ -287,7 +496,11 @@ async function saveEdit(id: string) {
       .map((s) => s.trim())
       .filter(Boolean),
   };
-  const result = await callManage({ action: "update", role });
+  const result = await callManage({
+    action: "update",
+    role,
+    oldRoleId: originalId,
+  });
   if (result.success) {
     selectedId.value = null;
     await refreshList();
@@ -297,10 +510,10 @@ async function saveEdit(id: string) {
   saving.value = false;
 }
 
-async function deleteRole(id: string) {
+async function deleteRole(roleId: string) {
   saving.value = true;
   saveError.value = "";
-  const result = await callManage({ action: "delete", roleId: id });
+  const result = await callManage({ action: "delete", roleId });
   if (result.success) {
     selectedId.value = null;
     await refreshList();

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -1,0 +1,120 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// The roles route imports workspacePath at module load. Override HOME
+// so os.homedir() → temp root, then dynamic-import the modules.
+let tmpRoot: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+
+type RolesRoute = typeof import("../../server/api/routes/roles.js");
+type RolesIo = typeof import("../../server/utils/files/roles-io.js");
+let rolesRoute: RolesRoute;
+let rolesIo: RolesIo;
+let rolesDir: string;
+
+before(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "roles-manage-test-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  rolesRoute = await import("../../server/api/routes/roles.js");
+  rolesIo = await import("../../server/utils/files/roles-io.js");
+  rolesDir = path.join(tmpRoot, "mulmoclaude", "config", "roles");
+});
+
+after(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function sampleRole(roleId: string) {
+  return {
+    id: roleId,
+    name: `Role ${roleId}`,
+    icon: "person",
+    prompt: "You are a test role.",
+    availablePlugins: ["wiki"],
+    queries: [],
+  };
+}
+
+describe("executeManageRoles — rename (oldRoleId)", () => {
+  it("writes the new-id file and removes the old-id file", async () => {
+    rolesIo.saveRole("original", sampleRole("original"));
+    assert.equal(rolesIo.roleExists("original"), true);
+
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "update",
+        role: sampleRole("renamed"),
+        oldRoleId: "original",
+      },
+      "test-session",
+    );
+
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    assert.equal(rolesIo.roleExists("renamed"), true, "new role file should exist");
+    assert.equal(rolesIo.roleExists("original"), false, "old role file should have been deleted");
+  });
+
+  it("rejects a rename into a built-in id", async () => {
+    rolesIo.saveRole("tmp", sampleRole("tmp"));
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "update",
+        role: sampleRole("general"), // "general" is a built-in id
+        oldRoleId: "tmp",
+      },
+      "test-session",
+    );
+    assert.equal(result.success, false);
+    assert.match(String(result.error), /reserved/i);
+    // Clean up
+    rolesIo.deleteRole("tmp");
+    // Ensure we didn't accidentally create the built-in id file
+    const generalPath = path.join(rolesDir, "general.json");
+    assert.equal(fs.existsSync(generalPath), false);
+  });
+
+  it("rejects a rename into an id already in use", async () => {
+    rolesIo.saveRole("alpha", sampleRole("alpha"));
+    rolesIo.saveRole("beta", sampleRole("beta"));
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "update",
+        role: sampleRole("beta"),
+        oldRoleId: "alpha",
+      },
+      "test-session",
+    );
+    assert.equal(result.success, false);
+    assert.match(String(result.error), /already exists/i);
+    assert.equal(rolesIo.roleExists("alpha"), true, "'alpha' should still exist");
+    assert.equal(rolesIo.roleExists("beta"), true, "'beta' should still exist");
+    rolesIo.deleteRole("alpha");
+    rolesIo.deleteRole("beta");
+  });
+
+  it("plain update (no oldRoleId) still works and does not delete anything", async () => {
+    rolesIo.saveRole("plain", sampleRole("plain"));
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "update",
+        role: { ...sampleRole("plain"), name: "Renamed Display" },
+      },
+      "test-session",
+    );
+    assert.equal(result.success, true);
+    assert.equal(rolesIo.roleExists("plain"), true);
+    rolesIo.deleteRole("plain");
+  });
+});

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -104,6 +104,29 @@ describe("executeManageRoles — rename (oldRoleId)", () => {
     rolesIo.deleteRole("beta");
   });
 
+  it("removes a built-in-id override file when renaming away from it", async () => {
+    // A file at config/roles/general.json is a user override of the
+    // built-in "general" role. Renaming it to a non-builtin id must
+    // remove the override file — otherwise it would continue to shadow
+    // the built-in and couldn't be deleted through the manage API.
+    rolesIo.saveRole("general", sampleRole("general"));
+    assert.equal(rolesIo.roleExists("general"), true);
+
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "update",
+        role: sampleRole("general_custom"),
+        oldRoleId: "general",
+      },
+      "test-session",
+    );
+
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    assert.equal(rolesIo.roleExists("general_custom"), true, "new role file should exist");
+    assert.equal(rolesIo.roleExists("general"), false, "built-in override file should have been deleted");
+    rolesIo.deleteRole("general_custom");
+  });
+
   it("plain update (no oldRoleId) still works and does not delete anything", async () => {
     rolesIo.saveRole("plain", sampleRole("plain"));
     const result = await rolesRoute.executeManageRoles(

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -127,6 +127,47 @@ describe("executeManageRoles — rename (oldRoleId)", () => {
     rolesIo.deleteRole("general_custom");
   });
 
+  it("ignores oldRoleId on a create payload (never runs rename cleanup)", async () => {
+    // Defensive: a malformed create payload that includes oldRoleId
+    // must not trigger the rename-delete path. Rename detection is
+    // gated on action === "update".
+    rolesIo.saveRole("victim", sampleRole("victim"));
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "create",
+        role: sampleRole("fresh"),
+        oldRoleId: "victim",
+      },
+      "test-session",
+    );
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    assert.equal(rolesIo.roleExists("fresh"), true, "'fresh' should have been created");
+    assert.equal(rolesIo.roleExists("victim"), true, "'victim' must not be deleted by a create payload");
+    rolesIo.deleteRole("fresh");
+    rolesIo.deleteRole("victim");
+  });
+
+  it("rejects a create whose id collides with an existing custom role", async () => {
+    // Defensive: a direct-API or stale-client `create` must not
+    // silently overwrite an existing custom role. The client-side
+    // validator catches this for the UI path, but the server is the
+    // last line of defence.
+    rolesIo.saveRole("target", { ...sampleRole("target"), name: "Original" });
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "create",
+        role: { ...sampleRole("target"), name: "Overwriter" },
+      },
+      "test-session",
+    );
+    assert.equal(result.success, false);
+    assert.match(String(result.error), /already exists/i);
+    // Original content must be intact
+    const onDisk = JSON.parse(fs.readFileSync(path.join(rolesDir, "target.json"), "utf-8")) as { name: string };
+    assert.equal(onDisk.name, "Original", "existing role must not be overwritten");
+    rolesIo.deleteRole("target");
+  });
+
   it("plain update (no oldRoleId) still works and does not delete anything", async () => {
     rolesIo.saveRole("plain", sampleRole("plain"));
     const result = await rolesRoute.executeManageRoles(


### PR DESCRIPTION
## Summary
- Adds a **`+ Add`** button to `manageRoles/View.vue` that opens a creation panel — users can now create custom roles without going through chat.
- Makes the inline editor's **ID field editable**; saving with a changed id renames the backing `~/mulmoclaude/config/roles/<id>.json` file via a new server `oldRoleId` path (write new, delete old), guarded against built-in-id and duplicate-id collisions.
- Shared **live validator** disables the submit buttons on invalid input (required id / charset / duplicate / required name); gray hint line + native `title` tooltip explain *why* the button is disabled.
- **Responsive plugin-checkbox grid** (`auto-fit, minmax(180px, 1fr)`) replaces the fixed 2-column grid so narrow panels don't truncate.
- Server: `executeManageRoles` split into `listRolesResult` / `deleteRoleResult` / `saveRoleResult` helpers to stay under `sonarjs/cognitive-complexity`.
- 4 new unit tests cover the rename flow (happy path, built-in collision, duplicate collision, plain update).

Plan doc: [`plans/feat-manage-roles-view-crud.md`](../blob/feat/manage-roles-view-crud/plans/feat-manage-roles-view-crud.md).

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean, 0 errors.
- [x] `yarn test` — 2581 / 2581 pass; new `executeManageRoles — rename (oldRoleId)` suite: 4 / 4.
- [ ] **Manual UI verification not done** — please exercise in `yarn dev`:
  - [ ] Click `+ Add`, fill required fields, verify `Create` enables only when valid; hover disabled button to see validation tooltip.
  - [ ] Create a role, then rename it (change ID field); verify old-id file gone, new-id file exists (`~/mulmoclaude/config/roles/`), top-bar role dropdown refreshes.
  - [ ] Try renaming into a built-in id (e.g. `general`) and into an existing custom id — both should be rejected with clear errors.
  - [ ] Resize the view — plugin-checkbox grid should reflow columns (not stay stuck at 2).
  - [ ] Tall panel scrolls correctly; Create/Cancel buttons always reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable creating and renaming custom roles directly from the manageRoles UI and update the server roles API to support role ID renames with validation and tests.

New Features:
- Add a UI flow to create new custom roles from the manageRoles view, including form fields for ID, name, icon, prompt, plugins, and starter queries.
- Allow editing a role's ID from the inline editor so users can rename existing custom roles.

Enhancements:
- Add shared client-side validation for role forms and disable submit actions when input is invalid, with user-facing hints.
- Make the plugins selection grid responsive so it adapts to panel width and ensure the roles view body scrolls to keep tall panels usable.
- Refactor the roles management server handler into smaller helpers for list, delete, and save operations, and extend it to handle safe renames including built-in and duplicate ID checks.

Documentation:
- Add a planning document describing the custom roles create/edit/rename UX and server behavior.

Tests:
- Introduce server-side tests for the manage roles API covering role rename success, built-in ID protection, duplicate ID protection, and plain update behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Create" flow with a + Add button, editable role ID in create/edit, and client-side validation that disables submit until inputs are valid (including duplicate-id checks).
  * Plugin checkbox grid made responsive with an auto-fit layout; panel bodies are scrollable.

* **Bug Fixes**
  * Improved rename behavior to prevent reserved/duplicate IDs and to clean up old role overrides when renaming.

* **Tests**
  * Added tests covering create, update, rename success/failure, and overwrite/cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->