### PR TITLE
fix(app): role selector revert on session tab switch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -499,8 +499,8 @@ function createNewSession(roleId?: string): ActiveSession {
   const rId = roleId ?? currentRoleId.value;
   const session = createEmptySession(uuidv4(), rId);
   sessionMap.set(session.id, session);
-  navigateToSession(session.id, true);
   currentRoleId.value = rId;
+  navigateToSession(session.id, true);
   suggestionsPanelRef.value?.collapse();
   nextTick(() => focusChatInput());
   return sessionMap.get(session.id)!;
@@ -518,8 +518,11 @@ function onRoleChange() {
 function activateSession(id: string, roleId: string, replace: boolean): void {
   const reactiveSession = sessionMap.get(id);
   if (reactiveSession) ensureSessionSubscription(reactiveSession);
-  navigateToSession(id, replace);
+  // Set role before navigating: buildRoleQuery() reads currentRoleId to
+  // build ?role=, and the route.query.role watcher would otherwise fire
+  // after navigation and revert currentRoleId to the previous session's role.
   currentRoleId.value = roleId;
+  navigateToSession(id, replace);
   showHistory.value = false;
 }
 


### PR DESCRIPTION
## Summary
- Tapping a session tab sometimes left the role selector showing the *previous* session's role.
- Root cause: `activateSession` / `createNewSession` called `navigateToSession` **before** updating `currentRoleId`. `buildRoleQuery()` read the stale `currentRoleId` and wrote `?role=<old>` into the URL; the `route.query.role` watcher then fired after navigation and reverted `currentRoleId` back to the previous session's role.
- Fix: set `currentRoleId` before navigating, so the URL is written with the correct role and the watcher is a no-op.

## Test plan
- [ ] Create session A with role X, session B with role Y (both non-default).
- [ ] Tap A → tap B → tap A → tap B repeatedly; role selector always matches the active tab.
- [ ] Back/forward browser navigation across sessions with different roles still syncs the selector.
- [ ] Agent-triggered role switch (`EVENT_TYPES.switchRole`) still creates a new session with the new role.
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix session tab switches sometimes showing the previous session's role in the role selector by updating the current role before navigation.