### PR TITLE
fix(textResponse): prevent preview link from hijacking row click

### DIFF
--- a/src/plugins/textResponse/Preview.vue
+++ b/src/plugins/textResponse/Preview.vue
@@ -37,6 +37,9 @@ const renderedMarkdown = computed(() => marked(previewText.value, { breaks: true
   display: -webkit-box;
   -webkit-line-clamp: 5;
   -webkit-box-orient: vertical;
+  /* Links inside v-html would otherwise hijack the row-level
+     select click and navigate to the article URL. */
+  pointer-events: none;
 }
 
 .preview-markdown :deep(p) {


### PR DESCRIPTION
## Summary

- A text-response in the sidebar renders markdown via `v-html`, so `[title](url)` becomes a live `<a href>`. Clicking the preview row triggered the anchor's default navigation and took the app to the article URL instead of selecting the result.
- Disabled `pointer-events` on `.preview-markdown` so clicks fall through to the row-level `@click="emit('select', ...)"` handler in `ToolResultsPanel.vue`.
- The detail view (`View.vue`) already guards against this via `@click.capture="openLinksInNewTab"`, so the full clickable link remains where it belongs.

## Test plan

- [ ] Ask the assistant for a response that embeds a markdown link (e.g. a news summary with a URL).
- [ ] Click the preview row in the sidebar — confirm it selects the result and does NOT navigate to the article URL.
- [ ] Open the selected result in the detail view — confirm clicking the link still opens the article in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure clicking a text response preview row selects the result instead of navigating via embedded markdown links in the preview content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where embedded links in the markdown preview were unintentionally capturing user interactions and triggering navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->