### PR TITLE
feat(files): add Name/Recent sort toggle to file tree

### DIFF
--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -33,6 +33,7 @@
         :selected-path="selectedPath"
         :recent-paths="recentPaths"
         :children-by-path="childrenByPath"
+        :sort-mode="sortMode"
         @select="(p) => emit('select', p)"
         @load-children="(p) => emit('loadChildren', p)"
       />
@@ -43,6 +44,8 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
+import { sortChildren } from "../utils/files/sortChildren";
+import type { FileSortMode } from "../composables/useFileSortMode";
 
 // TreeNode lives in src/types/fileTree.ts so .ts composables can
 // import it without depending on a .vue module. Re-export here so
@@ -59,6 +62,7 @@ const props = defineProps<{
   // so the parent kicks off the fetch. `null` = load in flight →
   // show spinner. Array = loaded.
   childrenByPath: Map<string, TreeNode[] | null>;
+  sortMode: FileSortMode;
 }>();
 
 const emit = defineEmits<{
@@ -77,7 +81,7 @@ const cached = computed(() => props.childrenByPath.get(props.node.path));
 // `cached === null` = load in flight. `undefined` = never requested.
 // Array = loaded.
 const loadingChildren = computed(() => cached.value === null);
-const loadedChildren = computed(() => (Array.isArray(cached.value) ? cached.value : []));
+const loadedChildren = computed(() => (Array.isArray(cached.value) ? sortChildren(cached.value, props.sortMode) : []));
 
 // Kick off a fetch if the dir is expanded but its children haven't
 // been requested yet. Covers two scenarios:

--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -1,5 +1,30 @@
 <template>
   <div class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50">
+    <div class="flex justify-end items-center gap-2 px-1 pb-1 text-xs">
+      <span class="text-gray-400">Sort:</span>
+      <button
+        type="button"
+        class="px-2 py-0.5 rounded transition-colors"
+        :class="sortMode === 'name' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
+        :aria-pressed="sortMode === 'name'"
+        title="Sort by name"
+        data-testid="file-sort-name"
+        @click="emit('update:sortMode', 'name')"
+      >
+        Name
+      </button>
+      <button
+        type="button"
+        class="px-2 py-0.5 rounded transition-colors"
+        :class="sortMode === 'recent' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
+        :aria-pressed="sortMode === 'recent'"
+        title="Sort by modified date (newest first)"
+        data-testid="file-sort-recent"
+        @click="emit('update:sortMode', 'recent')"
+      >
+        Recent
+      </button>
+    </div>
     <div v-if="treeError" class="p-2 text-xs text-red-600">
       {{ treeError }}
     </div>
@@ -10,6 +35,7 @@
       :selected-path="selectedPath"
       :recent-paths="recentPaths"
       :children-by-path="childrenByPath"
+      :sort-mode="sortMode"
       @select="emit('select', $event)"
       @load-children="emit('loadChildren', $event)"
     />
@@ -25,6 +51,7 @@
         :selected-path="selectedPath"
         :recent-paths="emptySet"
         :children-by-path="childrenByPath"
+        :sort-mode="sortMode"
         @select="emit('select', $event)"
         @load-children="emit('loadChildren', $event)"
       />
@@ -35,6 +62,7 @@
 <script setup lang="ts">
 import FileTree from "./FileTree.vue";
 import type { TreeNode } from "../types/fileTree";
+import type { FileSortMode } from "../composables/useFileSortMode";
 
 defineProps<{
   rootNode: TreeNode | null;
@@ -43,11 +71,13 @@ defineProps<{
   treeError: string | null;
   selectedPath: string | null;
   recentPaths: Set<string>;
+  sortMode: FileSortMode;
 }>();
 
 const emit = defineEmits<{
   select: [path: string];
   loadChildren: [path: string];
+  "update:sortMode": [mode: FileSortMode];
 }>();
 
 // Shared empty set for reference roots (they don't highlight recents).

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -7,8 +7,10 @@
       :tree-error="treeError"
       :selected-path="selectedPath"
       :recent-paths="recentPaths"
+      :sort-mode="sortMode"
       @select="selectFile"
       @load-children="loadDirChildren"
+      @update:sort-mode="setSortMode"
     />
     <!-- Content pane -->
     <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -54,6 +56,7 @@ import FileContentRenderer from "./FileContentRenderer.vue";
 import { useFileTree } from "../composables/useFileTree";
 import { useFileSelection, isValidFilePath } from "../composables/useFileSelection";
 import { useMarkdownMode } from "../composables/useMarkdownMode";
+import { useFileSortMode } from "../composables/useFileSortMode";
 import { useContentDisplay } from "../composables/useContentDisplay";
 import { useMarkdownLinkHandler } from "../composables/useMarkdownLinkHandler";
 import { apiPut } from "../utils/api";
@@ -81,6 +84,8 @@ const { rootNode, refRoots, childrenByPath, treeError, loadDirChildren, ensureAn
 const { selectedPath, content, contentLoading, contentError, loadContent, selectFile, deselectFile, abortContent } = useFileSelection();
 
 const { mdRawMode, toggleMdRaw } = useMarkdownMode();
+
+const { sortMode, setSortMode } = useFileSortMode();
 
 const { isMarkdown, isHtml, isJson, isJsonl, sandboxedHtml, jsonTokens, jsonlLines, mdFrontmatter } = useContentDisplay(selectedPath, content);
 

--- a/src/composables/useFileSortMode.ts
+++ b/src/composables/useFileSortMode.ts
@@ -1,0 +1,24 @@
+// Composable: file-tree sort mode ("name" | "recent") persisted to
+// localStorage. Applied globally across every directory in the Files
+// view; only affects within-group order (dirs-first grouping stays).
+
+import { ref } from "vue";
+
+const SORT_MODE_STORAGE_KEY = "files_sort_mode";
+
+export type FileSortMode = "name" | "recent";
+
+function readStoredMode(): FileSortMode {
+  return localStorage.getItem(SORT_MODE_STORAGE_KEY) === "recent" ? "recent" : "name";
+}
+
+export function useFileSortMode() {
+  const sortMode = ref<FileSortMode>(readStoredMode());
+
+  function setSortMode(mode: FileSortMode): void {
+    sortMode.value = mode;
+    localStorage.setItem(SORT_MODE_STORAGE_KEY, mode);
+  }
+
+  return { sortMode, setSortMode };
+}

--- a/src/utils/files/sortChildren.ts
+++ b/src/utils/files/sortChildren.ts
@@ -1,0 +1,20 @@
+import type { TreeNode } from "../../types/fileTree";
+import type { FileSortMode } from "../../composables/useFileSortMode";
+
+// Sort tree children: directories always come before files; within
+// each group, "name" is locale-aware alphabetical and "recent" is
+// newest-first by modifiedMs (missing mtimes sort last, then tie-break
+// on name so the order is deterministic).
+export function sortChildren(children: readonly TreeNode[], mode: FileSortMode): TreeNode[] {
+  const copy = children.slice();
+  copy.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+    if (mode === "recent") {
+      const am = a.modifiedMs ?? -Infinity;
+      const bm = b.modifiedMs ?? -Infinity;
+      if (am !== bm) return bm - am;
+    }
+    return a.name.localeCompare(b.name);
+  });
+  return copy;
+}


### PR DESCRIPTION
## Summary
- Add a pill-style "Name / Recent" toggle above the file tree so users can choose alphabetical vs. newest-modified-first ordering.
- Preference is persisted in `localStorage` via a new `useFileSortMode` composable and applied client-side to every directory (workspace tree + inside each reference root).
- Directory-before-file grouping is preserved. The order of the reference roots themselves (the top-level `@ref/<label>` entries) is intentionally **not** sorted — it stays in the configured order.

## Implementation notes
- New `src/utils/files/sortChildren.ts` — pure comparator: dirs-first, then `localeCompare` for name mode or `modifiedMs` desc for recent mode (missing mtimes sort last, name tie-break).
- `FilesView.vue` owns the sort state and forwards `update:sort-mode` to the composable.
- `FileTreePane.vue` renders the toggle; `FileTree.vue` sorts `loadedChildren` recursively using the mode prop.
- No server / API changes — tree data already lives in `childrenByPath`, so sorting is free on mode switch.

## Test plan
- [ ] Open the Files view; confirm "Name" is the default and the tree is alphabetical.
- [ ] Click "Recent" — files and folders re-order newest-first within each directory; dirs still come before files.
- [ ] Reload the page — the last-selected mode is restored.
- [ ] Expand a reference root; confirm its children sort by the active mode but the ref roots themselves keep their configured top-level order.
- [ ] After the workspace is modified by an agent run, the "Recent" view reflects the new mtimes on refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a user-selectable sort mode for the file tree and persist the preference across sessions.

New Features:
- Introduce a Name/Recent sort toggle in the file tree pane to switch between alphabetical and most-recently-modified ordering.
- Add a composable to manage and persist the global file sort mode in localStorage across browser sessions.

Enhancements:
- Apply a shared sort function to file tree children so directories stay grouped before files while respecting the active sort mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file sorting functionality with two modes: alphabetical (by name) and by recent modification date. Directories always appear first.
  * Added a toggle button in the file browser to switch between sorting modes.
  * Your preferred sorting mode is automatically saved and restored on your next visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->