### PR TITLE
feat(markdown): require sanitized filenamePrefix for presentDocument

### DIFF
--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -122,25 +122,36 @@ async function fillImagePlaceholders(markdown: string): Promise<string> {
 interface PresentDocumentBody {
   title: string;
   markdown: string;
-  filenameHint?: string;
+  filenamePrefix: string;
 }
 
-interface PresentDocumentResponse {
+interface PresentDocumentSuccess {
   message: string;
   title: string;
-  data: { markdown: string; filenameHint?: string };
+  data: { markdown: string; filenamePrefix: string };
 }
 
-router.post(API_ROUTES.plugins.presentDocument, async (req: Request<object, unknown, PresentDocumentBody>, res: Response<PresentDocumentResponse>) => {
-  const { title, markdown, filenameHint } = req.body;
-  const filledMarkdown = await fillImagePlaceholders(markdown);
-  const markdownPath = await saveMarkdown(filledMarkdown);
-  res.json({
-    message: `Document "${title}" is ready.`,
-    title,
-    data: { markdown: markdownPath, filenameHint },
-  });
-});
+interface PresentDocumentError {
+  error: string;
+}
+
+router.post(
+  API_ROUTES.plugins.presentDocument,
+  async (req: Request<object, unknown, PresentDocumentBody>, res: Response<PresentDocumentSuccess | PresentDocumentError>) => {
+    const { title, markdown, filenamePrefix } = req.body;
+    if (typeof filenamePrefix !== "string" || filenamePrefix.trim().length === 0) {
+      badRequest(res, "filenamePrefix is required");
+      return;
+    }
+    const filledMarkdown = await fillImagePlaceholders(markdown);
+    const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
+    res.json({
+      message: `Document "${title}" is ready.`,
+      title,
+      data: { markdown: markdownPath, filenamePrefix },
+    });
+  },
+);
 
 // Update markdown file on disk (user edits in View)
 interface UpdateMarkdownBody {

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,15 +1,18 @@
 import fs from "fs/promises";
 import path from "path";
-import crypto from "crypto";
 import { workspacePath } from "../../workspace/workspace.js";
-import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
+import { WORKSPACE_DIRS } from "../../workspace/paths.js";
+import { buildArtifactPathRandom } from "./naming.js";
 
-/** Save markdown content as a file. Returns the workspace-relative path. */
-export async function saveMarkdown(content: string): Promise<string> {
-  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-  const filename = `${id}.md`;
-  await fs.writeFile(path.join(WORKSPACE_PATHS.markdowns, filename), content, "utf-8");
-  return path.posix.join(WORKSPACE_DIRS.markdowns, filename);
+/**
+ * Save markdown content as a file. Returns the workspace-relative path.
+ * `prefix` is slugified; a random id is always appended to prevent
+ * collisions between concurrent writers sharing the same prefix.
+ */
+export async function saveMarkdown(content: string, prefix: string): Promise<string> {
+  const relPath = buildArtifactPathRandom(WORKSPACE_DIRS.markdowns, prefix, ".md", "document");
+  await fs.writeFile(path.join(workspacePath, relPath), content, "utf-8");
+  return relPath;
 }
 
 /** Read a markdown file and return its content. */

--- a/server/utils/files/naming.ts
+++ b/server/utils/files/naming.ts
@@ -6,7 +6,13 @@
 // slugification and timestamp suffixing.
 
 import path from "node:path";
+import crypto from "node:crypto";
 import { slugify } from "../slug.js";
+
+// Length of the random hex suffix appended by `buildArtifactPathRandom`.
+// 16 chars = 64 bits ≈ birthday-collision at 2^32 entries — effectively
+// impossible for any realistic per-workspace artifact volume.
+const RANDOM_SUFFIX_LEN = 16;
 
 /**
  * Build a workspace-relative path for a new artifact file.
@@ -20,5 +26,25 @@ import { slugify } from "../slug.js";
 export function buildArtifactPath(dir: string, title: string | undefined, ext: string, fallbackSlug = "file"): string {
   const slug = title ? slugify(title) || fallbackSlug : fallbackSlug;
   const fname = `${slug}-${Date.now()}${ext}`;
+  return path.posix.join(dir, fname);
+}
+
+/**
+ * Like `buildArtifactPath`, but appends a random hex id instead of a
+ * timestamp. Use when multiple concurrent writers may share the same
+ * prefix within the same millisecond (e.g. LLM-supplied `filenamePrefix`
+ * on the `presentDocument` route).
+ *
+ * @param dir  Workspace-relative directory
+ * @param prefix  Human-readable prefix (slugified via `slugify`)
+ * @param ext  File extension with leading dot
+ * @param fallbackSlug  Slug to use when the sanitized prefix is empty
+ */
+export function buildArtifactPathRandom(dir: string, prefix: string, ext: string, fallbackSlug = "file"): string {
+  // Pass fallbackSlug as slugify's default so it overrides slugify's
+  // built-in "page" default when `prefix` sanitizes to empty.
+  const slug = slugify(prefix, fallbackSlug);
+  const id = crypto.randomUUID().replace(/-/g, "").slice(0, RANDOM_SUFFIX_LEN);
+  const fname = `${slug}-${id}${ext}`;
   return path.posix.join(dir, fname);
 }

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -61,6 +61,7 @@ import { usePdfDownload } from "../../composables/usePdfDownload";
 import { apiGet, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
+import { toSafeFilename } from "../../utils/files/filename";
 
 const props = defineProps<{
   selectedResult: ToolResult<MarkdownToolData>;
@@ -176,8 +177,9 @@ const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload
 
 async function downloadPdf() {
   if (!markdownContent.value) return;
-  const hint = props.selectedResult.data?.filenameHint;
-  const title = hint ? hint.replace(/[/\\:*?"<>|]/g, "_") : props.selectedResult.title ? props.selectedResult.title.replace(/[/\\:*?"<>|]/g, "_") : "document";
+  const prefix = props.selectedResult.data?.filenamePrefix;
+  const rawName = prefix || props.selectedResult.title || "document";
+  const title = toSafeFilename(rawName, "document");
   await rawDownloadPdf(markdownContent.value, `${title}.pdf`);
 }
 

--- a/src/plugins/markdown/definition.ts
+++ b/src/plugins/markdown/definition.ts
@@ -5,7 +5,7 @@ export const TOOL_NAME = "presentDocument";
 export interface MarkdownToolData {
   markdown: string;
   pdfPath?: string;
-  filenameHint?: string;
+  filenamePrefix?: string;
 }
 
 /** True when the `markdown` field is a workspace-relative file path
@@ -37,13 +37,13 @@ const toolDefinition: ToolDefinition = {
         description:
           "The markdown content to display. Describe embedded images in the following format: ![Detailed image prompt](__too_be_replaced_image_path__). IMPORTANT: For embedded images, you MUST use the EXACT placeholder path '__too_be_replaced_image_path__'.",
       },
-      filenameHint: {
+      filenamePrefix: {
         type: "string",
         description:
-          "Short English filename for download (without extension). Use lowercase with hyphens, e.g. 'project-summary'. Required when the title is not in ASCII.",
+          "Short English filename prefix (without extension). Use lowercase with hyphens, e.g. 'project-summary'. The server sanitizes the value and appends a random id to prevent collisions.",
       },
     },
-    required: ["title", "markdown"],
+    required: ["title", "markdown", "filenamePrefix"],
   },
 };
 

--- a/src/utils/files/filename.ts
+++ b/src/utils/files/filename.ts
@@ -1,0 +1,12 @@
+// Strip filesystem-hostile chars from a string so it can safely be used
+// as a browser download filename across Windows / macOS / Linux. Not a
+// full slugifier — server-side slugification lives in
+// `server/utils/slug.ts` and is applied before data hits the client.
+// This helper is the last-line defensive escape for plugin views that
+// build a download filename from arbitrary title text.
+const UNSAFE_FILENAME_CHARS = /[/\\:*?"<>|]/g;
+
+export function toSafeFilename(name: string, fallback = "download"): string {
+  const cleaned = name.replace(UNSAFE_FILENAME_CHARS, "_").trim();
+  return cleaned || fallback;
+}

--- a/test/utils/files/test_filename.ts
+++ b/test/utils/files/test_filename.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toSafeFilename } from "../../../src/utils/files/filename.js";
+
+describe("toSafeFilename", () => {
+  it("leaves a clean filename untouched", () => {
+    assert.equal(toSafeFilename("project-summary"), "project-summary");
+  });
+
+  it("replaces filesystem-hostile chars with underscores", () => {
+    assert.equal(toSafeFilename('a/b\\c:d*e?f"g<h>i|j'), "a_b_c_d_e_f_g_h_i_j");
+  });
+
+  it("preserves spaces and unicode (safe on modern filesystems)", () => {
+    assert.equal(toSafeFilename("プロジェクト 概要"), "プロジェクト 概要");
+  });
+
+  it("trims whitespace and falls back when result is empty", () => {
+    assert.equal(toSafeFilename("   ", "document"), "document");
+  });
+
+  it("uses the default fallback when none is provided", () => {
+    assert.equal(toSafeFilename(""), "download");
+  });
+});

--- a/test/utils/files/test_naming.ts
+++ b/test/utils/files/test_naming.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildArtifactPath, buildArtifactPathRandom } from "../../../server/utils/files/naming.js";
+
+describe("buildArtifactPath", () => {
+  it("uses slugified title + timestamp suffix", () => {
+    const p = buildArtifactPath("artifacts/charts", "Sales Q1", ".chart.json", "chart");
+    assert.match(p, /^artifacts\/charts\/sales-q1-\d+\.chart\.json$/);
+  });
+
+  it("falls back when title is undefined", () => {
+    const p = buildArtifactPath("artifacts/charts", undefined, ".json", "chart");
+    assert.match(p, /^artifacts\/charts\/chart-\d+\.json$/);
+  });
+});
+
+describe("buildArtifactPathRandom", () => {
+  it("uses slugified prefix + 16-char hex suffix", () => {
+    const p = buildArtifactPathRandom("artifacts/documents", "project-summary", ".md", "document");
+    assert.match(p, /^artifacts\/documents\/project-summary-[0-9a-f]{16}\.md$/);
+  });
+
+  it("slugifies mixed-case / spaces / punctuation", () => {
+    const p = buildArtifactPathRandom("artifacts/documents", "My Report: Draft #2!", ".md", "document");
+    assert.match(p, /^artifacts\/documents\/my-report-draft-2-[0-9a-f]{16}\.md$/);
+  });
+
+  it("falls back when prefix sanitizes to empty", () => {
+    const p = buildArtifactPathRandom("artifacts/documents", "***", ".md", "document");
+    assert.match(p, /^artifacts\/documents\/document-[0-9a-f]{16}\.md$/);
+  });
+
+  it("handles non-ASCII prefixes via slugify's hash fallback", () => {
+    const p = buildArtifactPathRandom("artifacts/documents", "進行中", ".md", "document");
+    // slugify returns a base64url hash for fully non-ASCII input.
+    assert.match(p, /^artifacts\/documents\/[A-Za-z0-9_-]+-[0-9a-f]{16}\.md$/);
+  });
+
+  it("produces distinct suffixes across calls with the same prefix", () => {
+    const a = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
+    const b = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
+    assert.notEqual(a, b);
+  });
+});


### PR DESCRIPTION
## Summary

- Rename `presentDocument`'s `filenameHint` → `filenamePrefix`, make it **required**, and use it as the actual filename on disk. Saved documents are now `artifacts/documents/<slug>-<16-hex>.md` instead of `<16-hex>.md`, making workspace contents browsable while still collision-safe (the random id is always appended).
- Centralize sanitization so it can be reused by other plugins:
  - **Server**: `server/utils/files/naming.ts` gains `buildArtifactPathRandom()` alongside the existing timestamp-suffix `buildArtifactPath()`. Delegates slugification to the shared `server/utils/slug.ts` → `slugify()`.
  - **Frontend**: `src/utils/files/filename.ts` adds `toSafeFilename()` for download-filename escaping. Removes the inlined `/[/\\:*?"<>|]/g` regex from `src/plugins/markdown/View.vue` — the plugin holds no sanitization logic of its own anymore.
- Server validates `filenamePrefix` is a non-empty string at the route boundary (returns 400 otherwise).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` — 0 errors (pre-existing warnings unchanged)
- [x] `yarn typecheck` clean across all workspaces
- [x] `yarn test` — 2596 tests pass (+5 new unit tests for `buildArtifactPathRandom` and `toSafeFilename`)
- [x] `yarn build` succeeds
- [ ] Manual: invoke `presentDocument` from the UI and confirm the saved file under `~/mulmoclaude/artifacts/documents/` uses the LLM-supplied prefix
- [ ] Manual: verify PDF download filename uses the prefix (and falls back to title for legacy chat sessions whose `data.filenameHint` no longer matches)

## Breaking notes

- LLM tool schema gains a required parameter (`filenamePrefix`). Any custom system prompt / role that still references `filenameHint` needs updating.
- Legacy chat-history records with `data.filenameHint` will have that field ignored; PDF downloads in those views fall back to the document `title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require a sanitized filename prefix when presenting markdown documents so saved artifacts and downloads use human-readable, collision-safe filenames.

New Features:
- Add a required filenamePrefix parameter to the markdown presentDocument tool and API so generated documents are named with a human-readable prefix plus a random suffix.
- Introduce shared helpers for building random-suffixed artifact paths and for sanitizing download filenames across the app.

Enhancements:
- Validate filenamePrefix on the server and centralize slugification and filename sanitization to avoid per-plugin ad hoc logic.

Tests:
- Add unit tests for the new filename sanitization and random artifact path helpers.