### PR TITLE
Defer new session tab until first message is sent

### DIFF
--- a/src/composables/useMergedSessions.ts
+++ b/src/composables/useMergedSessions.ts
@@ -8,10 +8,18 @@ import { mergeSessionLists } from "../utils/session/mergeSessions";
 
 const MAX_TABS = 6;
 
+// A freshly-created live session (plus-button / role-change) has no
+// toolResults yet. Hide it from the tab bar + history until the user
+// sends the first message — otherwise the UI shows an empty shell row
+// that the user didn't ask for.
+function hasContent(session: ActiveSession): boolean {
+  return session.toolResults.length > 0;
+}
+
 export function useMergedSessions(opts: { sessionMap: Map<string, ActiveSession>; sessions: Ref<SessionSummary[]> }) {
   const { sessionMap, sessions } = opts;
 
-  const mergedSessions = computed((): SessionSummary[] => mergeSessionLists([...sessionMap.values()], sessions.value));
+  const mergedSessions = computed((): SessionSummary[] => mergeSessionLists([...sessionMap.values()].filter(hasContent), sessions.value));
 
   const tabSessions = computed(() => mergedSessions.value.slice(0, MAX_TABS));
 


### PR DESCRIPTION
## Summary
- Hide a freshly-created live session from the tab bar and history pane until its `toolResults` is non-empty
- Applies to both the plus-button path (`handleNewSessionClick`) and the role-change path (`onRoleChange`) — both funnel through `createNewSession`, which leaves `toolResults` empty until the first user message is pushed via `beginUserTurn`
- Once the user sends the first message, Vue reactivity re-evaluates `mergedSessions` and the tab appears immediately

## Why
Pressing the plus button or picking a role was immediately adding a tab for an empty session the user hadn't committed to yet. The existing `removeCurrentIfEmpty` logic already treats empty sessions as disposable; this makes the UI match that model.

## Test plan
- [ ] Click the plus button — chat input is focused, no new tab appears
- [ ] Type and send a message — tab appears for the new session
- [ ] Change role via the role selector — no new tab until the first message
- [ ] Load an existing session from history — its tab shows as expected
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Filter active sessions without tool results out of the merged sessions so only sessions with content are shown in the UI.