### PR TITLE
chore: enable eslint --cache for ~20x faster incremental lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "server:debug": "tsx server/index.ts --debug",
     "cli": "tsx packages/cli/src/index.ts",
     "telegram": "tsx packages/telegram/src/index.ts",
-    "lint": "eslint src server test e2e packages",
+    "lint": "eslint src server test e2e packages --cache --cache-location node_modules/.cache/eslint/",
     "format": "prettier --write '{src,server,test,e2e,packages}/**/*.{ts,json,yaml,vue}'",
     "typecheck": "yarn typecheck:vue && yarn typecheck:server && yarn typecheck:test && yarn typecheck:e2e && yarn typecheck:packages",
     "typecheck:packages": "yarn workspaces run typecheck",


### PR DESCRIPTION
## Summary

`yarn lint` が 30s 弱かかっていたのを、eslint の \`--cache\` フラグ追加で2回目以降を劇的に高速化。

| シナリオ | Before | After | 高速化 |
|---|---|---|---|
| Cold run (cache なし or 初回) | 29.57s | 28.92s | ほぼ同じ |
| Warm cache (無変更で再実行) | 29.57s | **1.36s** | 21.7x |
| 1ファイル変更後 | 29.57s | **1.57s** | 18.8x |

## Items to Confirm / Review

- [ ] **CI は影響なし**: CI runner は毎回クリーン環境なので cache は効かない。ローカル開発のフィードバックループだけが速くなる
- [ ] **Cache 場所**: \`node_modules/.cache/eslint/\` — \`.gitignore\` で \`node_modules\` が既に無視されているので新規設定不要
- [ ] **lint 結果の正確性**: 292 warnings (変更前と同数) を両方で確認済み

## User Prompt

「lint が遅いけどこんなもん？」という指摘を受け、原因調査の結果 eslint 実行が 30s 弱、内訳は \`import/no-cycle\` が52%、\`prettier/prettier\` が18% の順で重かった。対策3案 (A: \`--cache\`、B: prettier ルール分離、C: no-cycle 削除) を提示し、ユーザーが **A (cache)** を選択。測定付きで実装を依頼された。

## Implementation

\`package.json\` の \`lint\` スクリプトに \`--cache --cache-location node_modules/.cache/eslint/\` を追加。

## Test plan

- [x] Cold run 測定: 28.92s
- [x] Warm cache run 測定: 1.36s
- [x] 1ファイル変更後 run 測定: 1.57s
- [x] Warning 数が変更前後で一致 (292件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)