### PR TITLE
fix: resolve id-length warnings across all src/ files

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -253,17 +253,17 @@ const router = useRouter();
 
 // Omit ?role= for the default role to keep URLs clean.
 function buildRoleQuery(): Record<string, string> {
-  const id = currentRoleId.value;
-  if (!id || roles.value.length === 0 || id === roles.value[0]?.id) return {};
-  return { role: id };
+  const roleId = currentRoleId.value;
+  if (!roleId || roles.value.length === 0 || roleId === roles.value[0]?.id) return {};
+  return { role: roleId };
 }
 
-function navigateToSession(id: string, replace = false): void {
-  currentSessionId.value = id;
+function navigateToSession(sessionId: string, replace = false): void {
+  currentSessionId.value = sessionId;
   const method = replace ? router.replace : router.push;
   method({
     name: "chat",
-    params: { sessionId: id },
+    params: { sessionId },
     query: { ...buildViewQuery(), ...buildRoleQuery() },
   }).catch((err) => {
     if (err?.type !== 16) {
@@ -382,9 +382,9 @@ const { isStackLayout, restoreChatViewForSession, displayedCurrentSessionId } = 
 // Not wired into the internal `loadSession` call path because that
 // also fires on initial mount with `?view=plugin` URLs, which must
 // be honoured as-is.
-function handleSessionSelect(id: string): void {
+function handleSessionSelect(sessionId: string): void {
   restoreChatViewForSession();
-  loadSession(id);
+  loadSession(sessionId);
 }
 
 function handleNewSessionClick(): void {
@@ -425,8 +425,8 @@ const { mergedSessions, tabSessions } = useMergedSessions({
 // when switching away (running sessions keep their subscription so they
 // continue receiving events — session_finished will clean them up).
 let previousSessionId: string | null = null;
-watch(currentSessionId, (id) => {
-  const session = sessionMap.get(id);
+watch(currentSessionId, (sessionId) => {
+  const session = sessionMap.get(sessionId);
   // Subscribe to the new session's channel
   if (session) {
     ensureSessionSubscription(session);
@@ -435,23 +435,23 @@ watch(currentSessionId, (id) => {
   // no in-flight background generations. Tearing down the subscription
   // while a generation is still running would orphan its completion
   // event, leaving the session's busy indicator stuck on.
-  if (previousSessionId && previousSessionId !== id) {
+  if (previousSessionId && previousSessionId !== sessionId) {
     const prevSession = sessionMap.get(previousSessionId);
     const prevBusy = !!prevSession && (prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
     if (prevSession && !prevBusy) {
       unsubscribeSession(previousSessionId);
     }
   }
-  previousSessionId = id;
+  previousSessionId = sessionId;
 
   // Clear unread in both sessionMap and sessions list (for badge count),
   // then tell the server so other tabs see it too.
-  const summary = sessions.value.find((entry) => entry.id === id);
+  const summary = sessions.value.find((entry) => entry.id === sessionId);
   const wasUnread = (session && session.hasUnread) || (summary && summary.hasUnread);
   if (wasUnread) {
     if (session) session.hasUnread = false;
     if (summary) summary.hasUnread = false;
-    markSessionRead(id);
+    markSessionRead(sessionId);
   }
 });
 
@@ -484,11 +484,11 @@ const needsGeminiForRole = (roleId: string) => needsGemini(roles.value, roleId);
 // router.replace instead of router.push to keep the empty session out
 // of browser navigation history.
 function removeCurrentIfEmpty(): boolean {
-  const id = currentSessionId.value;
-  if (!id) return false;
-  const session = sessionMap.get(id);
+  const sessionId = currentSessionId.value;
+  if (!sessionId) return false;
+  const session = sessionMap.get(sessionId);
   if (session && session.toolResults.length === 0) {
-    sessionMap.delete(id);
+    sessionMap.delete(sessionId);
     return true;
   }
   return false;
@@ -515,40 +515,40 @@ function onRoleChange() {
   maybeSeedRoleDefault(session);
 }
 
-function activateSession(id: string, roleId: string, replace: boolean): void {
-  const reactiveSession = sessionMap.get(id);
+function activateSession(sessionId: string, roleId: string, replace: boolean): void {
+  const reactiveSession = sessionMap.get(sessionId);
   if (reactiveSession) ensureSessionSubscription(reactiveSession);
   // Set role before navigating: buildRoleQuery() reads currentRoleId to
   // build ?role=, and the route.query.role watcher would otherwise fire
   // after navigation and revert currentRoleId to the previous session's role.
   currentRoleId.value = roleId;
-  navigateToSession(id, replace);
+  navigateToSession(sessionId, replace);
   showHistory.value = false;
 }
 
-async function loadSession(id: string) {
-  if (id === currentSessionId.value && sessionMap.has(id)) return;
+async function loadSession(sessionId: string) {
+  if (sessionId === currentSessionId.value && sessionMap.has(sessionId)) return;
   const replaced = removeCurrentIfEmpty();
 
-  const live = sessionMap.get(id);
+  const live = sessionMap.get(sessionId);
   if (live) {
-    activateSession(id, live.roleId, replaced);
+    activateSession(sessionId, live.roleId, replaced);
     return;
   }
 
-  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(id)));
+  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
   if (!response.ok) return;
 
   const newSession = buildLoadedSession({
-    id,
+    id: sessionId,
     entries: response.data,
     defaultRoleId: currentRoleId.value,
     urlResult: typeof route.query.result === "string" ? route.query.result : null,
-    serverSummary: sessions.value.find((s) => s.id === id),
+    serverSummary: sessions.value.find((summary) => summary.id === sessionId),
     nowIso: new Date().toISOString(),
   });
-  sessionMap.set(id, newSession);
-  activateSession(id, newSession.roleId, replaced);
+  sessionMap.set(sessionId, newSession);
+  activateSession(sessionId, newSession.roleId, replaced);
 }
 
 // Re-fetch the transcript from the server and patch any entries the

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -130,7 +130,7 @@ const ACCEPTED_MIME_EXACT = new Set([
 ]);
 
 function isAcceptedType(mime: string): boolean {
-  return ACCEPTED_MIME_PREFIXES.some((p) => mime.startsWith(p)) || ACCEPTED_MIME_EXACT.has(mime);
+  return ACCEPTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) || ACCEPTED_MIME_EXACT.has(mime);
 }
 
 function readAttachmentFile(file: File): void {
@@ -154,14 +154,14 @@ function readAttachmentFile(file: File): void {
   reader.readAsDataURL(file);
 }
 
-function onPasteFile(e: ClipboardEvent): void {
-  const items = e.clipboardData?.items;
+function onPasteFile(event: ClipboardEvent): void {
+  const items = event.clipboardData?.items;
   if (!items) return;
   for (const item of items) {
     if (isAcceptedType(item.type)) {
       const file = item.getAsFile();
       if (file) {
-        e.preventDefault();
+        event.preventDefault();
         readAttachmentFile(file);
         return;
       }
@@ -169,9 +169,9 @@ function onPasteFile(e: ClipboardEvent): void {
   }
 }
 
-function onDropFile(e: DragEvent): void {
-  e.preventDefault();
-  const file = e.dataTransfer?.files[0];
+function onDropFile(event: DragEvent): void {
+  event.preventDefault();
+  const file = event.dataTransfer?.files[0];
   if (file) readAttachmentFile(file);
 }
 

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -104,8 +104,8 @@ watch(
   },
 );
 
-function onTestQuery(q: string): void {
+function onTestQuery(query: string): void {
   emit("update:open", false);
-  emit("testQuery", q);
+  emit("testQuery", query);
 }
 </script>

--- a/src/components/NotificationToast.vue
+++ b/src/components/NotificationToast.vue
@@ -28,8 +28,8 @@ function dismiss(): void {
   visible.value = null;
 }
 
-function iconName(n: NotificationPayload): string {
-  return n.icon ?? NOTIFICATION_ICONS[n.kind] ?? "notifications";
+function iconName(notif: NotificationPayload): string {
+  return notif.icon ?? NOTIFICATION_ICONS[notif.kind] ?? "notifications";
 }
 </script>
 

--- a/src/components/RoleSelector.vue
+++ b/src/components/RoleSelector.vue
@@ -47,8 +47,8 @@ const dropdown = ref<HTMLDivElement | null>(null);
 
 const currentRoleName = computed(() => roleName(props.roles, props.currentRoleId));
 
-function selectRole(id: string): void {
-  emit("update:currentRoleId", id);
+function selectRole(roleId: string): void {
+  emit("update:currentRoleId", roleId);
   open.value = false;
   emit("change");
 }

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -128,12 +128,12 @@ function originOf(session: SessionSummary): SessionOrigin {
 
 const filteredSessions = computed(() => {
   if (activeFilter.value === "all") return props.sessions;
-  return props.sessions.filter((s) => originOf(s) === activeFilter.value);
+  return props.sessions.filter((session) => originOf(session) === activeFilter.value);
 });
 
 function countByOrigin(origin: string): number {
   if (origin === "all") return props.sessions.length;
-  return props.sessions.filter((s) => originOf(s) === origin).length;
+  return props.sessions.filter((session) => originOf(session) === origin).length;
 }
 
 function originIcon(origin: string): string {
@@ -146,11 +146,11 @@ function originColor(origin: string): string {
 
 // ── Role helpers ────────────────────────────────────────────
 
-function roleIconFor(id: string): string {
-  return roleIcon(props.roles, id);
+function roleIconFor(roleId: string): string {
+  return roleIcon(props.roles, roleId);
 }
-function roleNameFor(id: string): string {
-  return roleName(props.roles, id);
+function roleNameFor(roleId: string): string {
+  return roleName(props.roles, roleId);
 }
 
 function isSessionRunning(session: SessionSummary): boolean {

--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -265,21 +265,21 @@ function ensureUniqueId(base: string): string {
 }
 
 function commitAdd(): void {
-  let id = draft.value.id.trim();
-  if (!id) {
+  let mcpId = draft.value.id.trim();
+  if (!mcpId) {
     const suggested = ensureUniqueId(suggestIdFromDraft(draft.value));
     if (!suggested) {
       draftError.value = "Please provide a Name, or enter a URL / args we can derive one from.";
       return;
     }
-    id = suggested;
+    mcpId = suggested;
   }
-  if (!ID_RE.test(id)) {
+  if (!ID_RE.test(mcpId)) {
     draftError.value = "Name must start with a lowercase letter and contain only [a-z0-9_-].";
     return;
   }
-  if (props.servers.some((server) => server.id === id)) {
-    draftError.value = `Server id "${id}" already exists.`;
+  if (props.servers.some((server) => server.id === mcpId)) {
+    draftError.value = `Server id "${mcpId}" already exists.`;
     return;
   }
   let spec: ServerSpec;
@@ -302,7 +302,7 @@ function commitAdd(): void {
       enabled: true,
     };
   }
-  emit("add", { id, spec });
+  emit("add", { id: mcpId, spec });
   adding.value = false;
   draftError.value = "";
 }

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -177,11 +177,11 @@ let loadToken = 0;
 const parsedToolNames = computed(() =>
   toolsText.value
     .split("\n")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0),
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0),
 );
 
-const invalidToolNames = computed(() => parsedToolNames.value.filter((n) => !n.startsWith("mcp__") && !isBuiltIn(n)));
+const invalidToolNames = computed(() => parsedToolNames.value.filter((name) => !name.startsWith("mcp__") && !isBuiltIn(name)));
 
 function isBuiltIn(name: string): boolean {
   return ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"].includes(name);

--- a/src/components/SettingsReferenceDirsTab.vue
+++ b/src/components/SettingsReferenceDirsTab.vue
@@ -48,33 +48,33 @@ async function save(): Promise<void> {
 
 function addEntry(): void {
   draftError.value = "";
-  const p = draftPath.value.trim();
-  if (!p) {
+  const path = draftPath.value.trim();
+  if (!path) {
     draftError.value = "Path required";
     return;
   }
-  if (!p.startsWith("/") && !p.startsWith("~/")) {
+  if (!path.startsWith("/") && !path.startsWith("~/")) {
     draftError.value = "Must be an absolute path or start with ~/";
     return;
   }
   // Normalize: trim trailing slashes for consistent comparison
-  let normalized = p;
+  let normalized = path;
   while (normalized.length > 1 && normalized.endsWith("/")) {
     normalized = normalized.slice(0, -1);
   }
-  const stripSlash = (s: string): string => {
-    let r = s;
-    while (r.length > 1 && r.endsWith("/")) r = r.slice(0, -1);
-    return r;
+  const stripSlash = (str: string): string => {
+    let cleaned = str;
+    while (cleaned.length > 1 && cleaned.endsWith("/")) cleaned = cleaned.slice(0, -1);
+    return cleaned;
   };
-  if (dirs.value.some((d) => stripSlash(d.hostPath) === normalized)) {
+  if (dirs.value.some((dir) => stripSlash(dir.hostPath) === normalized)) {
     draftError.value = "Already exists";
     return;
   }
   const lastSeg = normalized.split("/").pop();
   const label = draftLabel.value.trim() || lastSeg || normalized;
   // Reject duplicate labels — @ref/<label> routing requires uniqueness
-  if (dirs.value.some((d) => d.label === label)) {
+  if (dirs.value.some((dir) => dir.label === label)) {
     draftError.value = `Label "${label}" already exists`;
     return;
   }

--- a/src/components/SettingsWorkspaceDirsTab.vue
+++ b/src/components/SettingsWorkspaceDirsTab.vue
@@ -51,21 +51,21 @@ async function save(): Promise<void> {
 
 function addEntry(): void {
   draftError.value = "";
-  const p = draftPath.value.trim();
-  if (!p) {
+  const path = draftPath.value.trim();
+  if (!path) {
     draftError.value = "Path required";
     return;
   }
-  if (!p.startsWith("data/") && !p.startsWith("artifacts/")) {
+  if (!path.startsWith("data/") && !path.startsWith("artifacts/")) {
     draftError.value = "Must start with data/ or artifacts/";
     return;
   }
-  if (dirs.value.some((d) => d.path === p)) {
+  if (dirs.value.some((dir) => dir.path === path)) {
     draftError.value = "Already exists";
     return;
   }
   dirs.value.push({
-    path: p,
+    path,
     description: draftDescription.value.trim(),
     structure: draftStructure.value,
   });

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -48,9 +48,9 @@ watch(expanded, (isExpanded) => {
   });
 });
 
-function onClick(e: MouseEvent, query: string): void {
+function onClick(event: MouseEvent, query: string): void {
   expanded.value = false;
-  if (e.shiftKey) {
+  if (event.shiftKey) {
     emit("edit", query);
     return;
   }

--- a/src/components/todo/TodoAddDialog.vue
+++ b/src/components/todo/TodoAddDialog.vue
@@ -123,8 +123,8 @@ function submit(): void {
   if (dueDate.value !== "") input.dueDate = dueDate.value;
   const labels = labelsText.value
     .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
   if (labels.length > 0) input.labels = labels;
   emit("create", input);
 }

--- a/src/components/todo/TodoEditPanel.vue
+++ b/src/components/todo/TodoEditPanel.vue
@@ -85,8 +85,8 @@ const labelsText = ref((props.item.labels ?? []).join(", "));
 function parseLabels(raw: string): string[] {
   return raw
     .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
 }
 
 function save(): void {

--- a/src/components/todo/TodoListView.vue
+++ b/src/components/todo/TodoListView.vue
@@ -58,22 +58,22 @@ const emit = defineEmits<{
 
 const expandedId = ref<string | null>(null);
 
-function toggleExpand(id: string): void {
-  expandedId.value = expandedId.value === id ? null : id;
+function toggleExpand(itemId: string): void {
+  expandedId.value = expandedId.value === itemId ? null : itemId;
 }
 
 function toggleComplete(item: TodoItem): void {
   emit("toggleComplete", item);
 }
 
-function onSave(id: string, input: PatchItemInput): void {
-  emit("patch", id, input);
+function onSave(itemId: string, input: PatchItemInput): void {
+  emit("patch", itemId, input);
   expandedId.value = null;
 }
 
 function statusLabel(item: TodoItem): string {
   if (!item.status) return "";
-  const col = props.columns.find((c) => c.id === item.status);
+  const col = props.columns.find((column) => column.id === item.status);
   return col?.label ?? "";
 }
 </script>

--- a/src/composables/useCanvasViewMode.ts
+++ b/src/composables/useCanvasViewMode.ts
@@ -94,13 +94,13 @@ export function useCanvasViewMode(opts: UseCanvasViewModeOptions): {
     }
   });
 
-  function handleViewModeShortcut(e: KeyboardEvent): void {
-    if (!(e.metaKey || e.ctrlKey)) return;
-    if (e.altKey || e.shiftKey) return;
-    const target = viewModeForShortcutKey(e.key);
+  function handleViewModeShortcut(event: KeyboardEvent): void {
+    if (!(event.metaKey || event.ctrlKey)) return;
+    if (event.altKey || event.shiftKey) return;
+    const target = viewModeForShortcutKey(event.key);
     if (target === null) return;
     setCanvasViewMode(target);
-    e.preventDefault();
+    event.preventDefault();
   }
 
   /** Plugin-launcher click: switch canvas to the matching view mode. */

--- a/src/composables/useClickOutside.ts
+++ b/src/composables/useClickOutside.ts
@@ -16,9 +16,9 @@ interface UseClickOutsideOptions {
 export function useClickOutside(opts: UseClickOutsideOptions): {
   handler: (e: MouseEvent) => void;
 } {
-  function handler(e: MouseEvent): void {
+  function handler(event: MouseEvent): void {
     if (!opts.isOpen.value) return;
-    if (isClickOutside(e.target as Node | null, opts.buttonRef.value, opts.popupRef.value)) {
+    if (isClickOutside(event.target as Node | null, opts.buttonRef.value, opts.popupRef.value)) {
       opts.isOpen.value = false;
     }
   }

--- a/src/composables/useFreshPluginData.ts
+++ b/src/composables/useFreshPluginData.ts
@@ -70,9 +70,9 @@ export function useFreshPluginData<T>(opts: UseFreshPluginDataOptions<T>): UseFr
 
   async function refresh(): Promise<boolean> {
     controller?.abort();
-    const c = new AbortController();
-    controller = c;
-    return refreshOnce(opts, c.signal);
+    const ctrl = new AbortController();
+    controller = ctrl;
+    return refreshOnce(opts, ctrl.signal);
   }
 
   function abort(): void {

--- a/src/composables/useKeyNavigation.ts
+++ b/src/composables/useKeyNavigation.ts
@@ -18,7 +18,7 @@ function isVerticalArrow(key: string): key is "ArrowUp" | "ArrowDown" {
 
 function resolveNextUuid(results: ToolResultComplete[], currentUuid: string | null, direction: "ArrowUp" | "ArrowDown"): string | null {
   if (results.length === 0) return null;
-  const idx = results.findIndex((r) => r.uuid === currentUuid);
+  const idx = results.findIndex((result) => result.uuid === currentUuid);
   if (idx === -1) {
     return direction === "ArrowDown" ? results[0].uuid : results[results.length - 1].uuid;
   }
@@ -36,23 +36,23 @@ export function useKeyNavigation(opts: {
 }) {
   const { canvasRef, activePane, sidebarResults, selectedResultUuid } = opts;
 
-  function handleCanvasKeydown(e: KeyboardEvent): void {
-    if (!isVerticalArrow(e.key)) return;
-    if (isEditableTarget(e.target)) return;
+  function handleCanvasKeydown(event: KeyboardEvent): void {
+    if (!isVerticalArrow(event.key)) return;
+    if (isEditableTarget(event.target)) return;
     if (!canvasRef.value) return;
     const scrollable = findScrollableChild(canvasRef.value);
     if (!scrollable) return;
-    e.preventDefault();
-    const delta = e.key === "ArrowDown" ? SCROLL_AMOUNT : -SCROLL_AMOUNT;
+    event.preventDefault();
+    const delta = event.key === "ArrowDown" ? SCROLL_AMOUNT : -SCROLL_AMOUNT;
     scrollable.scrollBy({ top: delta, behavior: "smooth" });
   }
 
-  function handleKeyNavigation(e: KeyboardEvent): void {
+  function handleKeyNavigation(event: KeyboardEvent): void {
     if (activePane.value !== "sidebar") return;
-    if (isEditableTarget(e.target)) return;
-    if (!isVerticalArrow(e.key)) return;
-    e.preventDefault();
-    const nextUuid = resolveNextUuid(sidebarResults.value, selectedResultUuid.value, e.key);
+    if (isEditableTarget(event.target)) return;
+    if (!isVerticalArrow(event.key)) return;
+    event.preventDefault();
+    const nextUuid = resolveNextUuid(sidebarResults.value, selectedResultUuid.value, event.key);
     if (nextUuid) selectedResultUuid.value = nextUuid;
   }
 

--- a/src/composables/useMcpTools.ts
+++ b/src/composables/useMcpTools.ts
@@ -56,8 +56,8 @@ export function useMcpTools(opts: UseMcpToolsOptions) {
     }
     mcpToolsError.value = null;
     const tools = result.data;
-    disabledMcpTools.value = new Set(tools.filter((t) => !t.enabled).map((t) => t.name));
-    mcpToolDescriptions.value = Object.fromEntries(tools.filter(hasPrompt).map((t) => [t.name, t.prompt]));
+    disabledMcpTools.value = new Set(tools.filter((tool) => !tool.enabled).map((tool) => tool.name));
+    mcpToolDescriptions.value = Object.fromEntries(tools.filter(hasPrompt).map((tool) => [tool.name, tool.prompt]));
   }
 
   return {

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -73,7 +73,7 @@ export function useNotifications(): {
 
   const unreadCount = computed(() => {
     if (!readAt.value) return notifications.value.length;
-    return notifications.value.filter((n) => n.firedAt > readAt.value!).length;
+    return notifications.value.filter((notif) => notif.firedAt > readAt.value!).length;
   });
 
   function markAllRead(): void {
@@ -82,8 +82,8 @@ export function useNotifications(): {
     }
   }
 
-  function dismiss(id: string): void {
-    notifications.value = notifications.value.filter((n) => n.id !== id);
+  function dismiss(notifId: string): void {
+    notifications.value = notifications.value.filter((notif) => notif.id !== notifId);
   }
 
   return { notifications, latest, unreadCount, markAllRead, dismiss };

--- a/src/composables/usePdfDownload.ts
+++ b/src/composables/usePdfDownload.ts
@@ -42,10 +42,10 @@ export function usePdfDownload(): UsePdfDownloadHandle {
       }
       const blob = await response.blob();
       url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      a.click();
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
     } catch (err) {
       pdfError.value = errorMessage(err);
     } finally {

--- a/src/composables/usePendingCalls.ts
+++ b/src/composables/usePendingCalls.ts
@@ -59,7 +59,7 @@ export function usePendingCalls(opts: UsePendingCallsOptions) {
     // unused.
     const __tickDep = displayTick.value;
     const now = Date.now();
-    return opts.toolCallHistory.value.filter((c) => __tickDep >= 0 && isCallStillPending(c, now));
+    return opts.toolCallHistory.value.filter((entry) => __tickDep >= 0 && isCallStillPending(entry, now));
   });
 
   function teardown(): void {

--- a/src/composables/usePubSub.ts
+++ b/src/composables/usePubSub.ts
@@ -21,16 +21,16 @@ let socket: Socket | null = null;
 
 const listeners = new Map<string, Set<Callback>>();
 
-function resendSubscriptions(s: Socket): void {
+function resendSubscriptions(sock: Socket): void {
   for (const channel of listeners.keys()) {
-    s.emit("subscribe", channel);
+    sock.emit("subscribe", channel);
   }
 }
 
 function connect(): Socket {
   if (socket) return socket;
 
-  const s = io({
+  const sock = io({
     path: "/ws/pubsub",
     // Match the server. Long-polling is fine as a fallback but
     // the server refuses it, so don't negotiate it here either —
@@ -38,17 +38,17 @@ function connect(): Socket {
     transports: ["websocket"],
   });
 
-  s.on("connect", () => resendSubscriptions(s));
+  sock.on("connect", () => resendSubscriptions(sock));
 
-  s.on("data", (msg: PubSubMessage) => {
+  sock.on("data", (msg: PubSubMessage) => {
     const cbs = listeners.get(msg.channel);
     if (cbs) {
-      for (const cb of cbs) cb(msg.data);
+      for (const handler of cbs) handler(msg.data);
     }
   });
 
-  socket = s;
-  return s;
+  socket = sock;
+  return sock;
 }
 
 function maybeDisconnect(): void {
@@ -63,8 +63,8 @@ export function usePubSub() {
     if (!listeners.has(channel)) listeners.set(channel, new Set());
     listeners.get(channel)!.add(callback);
 
-    const s = connect();
-    if (s.connected) s.emit("subscribe", channel);
+    const sock = connect();
+    if (sock.connected) sock.emit("subscribe", channel);
     // If not yet connected, the "connect" handler replays every
     // listener's subscription, so newly-added channels are
     // covered without extra bookkeeping.

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -17,7 +17,7 @@ export function useRoles(): {
 } {
   const roles = ref<Role[]>(ROLES);
   const currentRoleId = ref(ROLES[0].id);
-  const currentRole = computed(() => roles.value.find((r) => r.id === currentRoleId.value) ?? roles.value[0]);
+  const currentRole = computed(() => roles.value.find((role) => role.id === currentRoleId.value) ?? roles.value[0]);
 
   async function refreshRoles(): Promise<void> {
     const result = await apiGet<Role[]>(API_ROUTES.roles.list);

--- a/src/composables/useSandboxStatus.ts
+++ b/src/composables/useSandboxStatus.ts
@@ -29,7 +29,7 @@ function isSandboxStatus(raw: RawResponse): raw is {
 } {
   if (typeof raw.sshAgent !== "boolean") return false;
   if (!Array.isArray(raw.mounts)) return false;
-  return raw.mounts.every((m) => typeof m === "string");
+  return raw.mounts.every((mount) => typeof mount === "string");
 }
 
 export interface UseSandboxStatusHandle {

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -16,7 +16,7 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
 
   const sidebarResults = computed(() => deduplicateResults(toolResults.value));
 
-  const currentSummary = computed(() => sessions.value.find((s) => s.id === currentSessionId.value));
+  const currentSummary = computed(() => sessions.value.find((summary) => summary.id === currentSessionId.value));
 
   // The server-side summary already merges pendingGenerations into
   // `isRunning` (see server/api/routes/sessions.ts), but pub/sub events
@@ -33,9 +33,9 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
 
   const toolCallHistory = computed<ToolCallHistoryItem[]>(() => activeSession.value?.toolCallHistory ?? []);
 
-  const activeSessionCount = computed(() => sessions.value.filter((s) => s.isRunning).length);
+  const activeSessionCount = computed(() => sessions.value.filter((session) => session.isRunning).length);
 
-  const unreadCount = computed(() => sessions.value.filter((s) => s.hasUnread).length);
+  const unreadCount = computed(() => sessions.value.filter((session) => session.hasUnread).length);
 
   return {
     activeSession,

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -29,20 +29,20 @@ export function useSessionSync(opts: {
       console.warn("[session-sync] failed to fetch sessions:", err);
       return;
     }
-    for (const s of summaries) {
-      const live = sessionMap.get(s.id);
+    for (const summary of summaries) {
+      const live = sessionMap.get(summary.id);
       if (!live) continue;
-      live.isRunning = s.isRunning ?? false;
-      live.statusMessage = s.statusMessage ?? "";
-      const unread = s.hasUnread ?? false;
-      if (!(unread && s.id === currentSessionId.value)) {
+      live.isRunning = summary.isRunning ?? false;
+      live.statusMessage = summary.statusMessage ?? "";
+      const unread = summary.hasUnread ?? false;
+      if (!(unread && summary.id === currentSessionId.value)) {
         live.hasUnread = unread;
       }
     }
   }
 
-  async function markSessionRead(id: string): Promise<void> {
-    const result = await apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(id)));
+  async function markSessionRead(sessionId: string): Promise<void> {
+    const result = await apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(sessionId)));
     if (!result.ok || result.data.ok === false) {
       await refreshSessionStates();
     }

--- a/src/composables/useViewLayout.ts
+++ b/src/composables/useViewLayout.ts
@@ -9,8 +9,8 @@ import { CANVAS_VIEW, type CanvasViewMode } from "../utils/canvas/viewMode";
 const CHAT_VIEWS = [CANVAS_VIEW.single, CANVAS_VIEW.stack] as const;
 type ChatViewMode = (typeof CHAT_VIEWS)[number];
 
-function isChatView(m: string): m is ChatViewMode {
-  return (CHAT_VIEWS as readonly string[]).includes(m);
+function isChatView(mode: string): mode is ChatViewMode {
+  return (CHAT_VIEWS as readonly string[]).includes(mode);
 }
 
 export function useViewLayout(opts: {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -330,6 +330,6 @@ export type BuiltInRoleId = (typeof BUILTIN_ROLE_IDS)[keyof typeof BUILTIN_ROLE_
 
 export const DEFAULT_ROLE_ID: BuiltInRoleId = BUILTIN_ROLE_IDS.general;
 
-export function getRole(id: string): Role {
-  return ROLES.find((r) => r.id === id) ?? ROLES[0];
+export function getRole(roleId: string): Role {
+  return ROLES.find((role) => role.id === roleId) ?? ROLES[0];
 }

--- a/src/plugins/chart/Preview.vue
+++ b/src/plugins/chart/Preview.vue
@@ -25,8 +25,8 @@ const hint = computed(() => {
   const charts = data.value?.document?.charts ?? [];
   if (charts.length === 0) return "";
   const types = charts
-    .map((c) => c.type ?? inferTypeFromOption(c.option))
-    .filter((t): t is string => Boolean(t))
+    .map((chart) => chart.type ?? inferTypeFromOption(chart.option))
+    .filter((chartType): chartType is string => Boolean(chartType))
     .slice(0, 3);
   const suffix = charts.length > types.length ? ", …" : "";
   const typeList = types.join(", ");
@@ -41,8 +41,8 @@ function inferTypeFromOption(option: Record<string, unknown>): string | null {
     const first = series[0] as { type?: unknown };
     if (typeof first.type === "string") return first.type;
   } else if (series && typeof series === "object") {
-    const t = (series as { type?: unknown }).type;
-    if (typeof t === "string") return t;
+    const seriesType = (series as { type?: unknown }).type;
+    if (typeof seriesType === "string") return seriesType;
   }
   return null;
 }

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -173,7 +173,7 @@ const saving = ref(false);
 const editDescription = ref("");
 const editBody = ref("");
 
-const selected = computed(() => skills.value.find((s) => s.name === selectedName.value) ?? null);
+const selected = computed(() => skills.value.find((skill) => skill.name === selectedName.value) ?? null);
 
 const renderedBody = computed(() => {
   const body = detail.value?.body;
@@ -272,7 +272,7 @@ async function saveEdit(): Promise<void> {
     body: editBody.value,
   };
   // Update the sidebar summary too.
-  const idx = skills.value.findIndex((s) => s.name === name);
+  const idx = skills.value.findIndex((skill) => skill.name === name);
   if (idx >= 0) {
     skills.value[idx] = {
       ...skills.value[idx],
@@ -311,7 +311,7 @@ async function deleteSkill(): Promise<void> {
     return;
   }
   // Remove from the local list, advance selection, clear detail.
-  const idx = skills.value.findIndex((s) => s.name === name);
+  const idx = skills.value.findIndex((skill) => skill.name === name);
   if (idx >= 0) {
     skills.value.splice(idx, 1);
   }

--- a/src/plugins/manageSource/Preview.vue
+++ b/src/plugins/manageSource/Preview.vue
@@ -24,7 +24,7 @@ const hint = computed(() => {
   if (sources.length === 0) return "No sources registered yet.";
   const names = sources
     .slice(0, 3)
-    .map((s: Source) => s.slug)
+    .map((source: Source) => source.slug)
     .join(", ");
   const tail = sources.length > 3 ? ", …" : "";
   const plural = sources.length === 1 ? "" : "s";

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -156,8 +156,8 @@ const sourceDetails = ref<HTMLDetailsElement>();
 const editing = ref(false);
 const { copied, copy } = useClipboardCopy();
 
-function onDetailsToggle(e: Event) {
-  const open = (e.target as HTMLDetailsElement).open;
+function onDetailsToggle(event: Event) {
+  const open = (event.target as HTMLDetailsElement).open;
   editing.value = open;
   if (!open) {
     editableMarkdown.value = markdownContent.value;

--- a/src/plugins/presentHtml/helpers.ts
+++ b/src/plugins/presentHtml/helpers.ts
@@ -25,8 +25,8 @@ export function stripHtmlToPreview(html: string, maxLength: number): string {
   };
   let i = 0;
   while (i < html.length) {
-    const c = html[i];
-    if (c === "<") {
+    const char = html[i];
+    if (char === "<") {
       const close = html.indexOf(">", i + 1);
       if (close !== -1) {
         // Real tag span `<...>` — skip it, emit a separator.
@@ -36,7 +36,7 @@ export function stripHtmlToPreview(html: string, maxLength: number): string {
       }
       // No closing `>` anywhere after — treat as literal.
     }
-    emitChar(state, c);
+    emitChar(state, char);
     i++;
   }
   trimTrailingSpace(state.out);
@@ -48,12 +48,12 @@ interface WalkerState {
   lastWasSpace: boolean;
 }
 
-function emitChar(state: WalkerState, c: string): void {
-  if (isWhitespace(c)) {
+function emitChar(state: WalkerState, char: string): void {
+  if (isWhitespace(char)) {
     emitSeparator(state);
     return;
   }
-  state.out.push(c);
+  state.out.push(char);
   state.lastWasSpace = false;
 }
 
@@ -67,6 +67,6 @@ function trimTrailingSpace(out: string[]): void {
   if (out.length > 0 && out[out.length - 1] === " ") out.pop();
 }
 
-function isWhitespace(c: string): boolean {
-  return c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\v" || c === "\f";
+function isWhitespace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\v" || char === "\f";
 }

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -431,7 +431,7 @@ const charErrors = reactive<Record<string, string>>({});
 const charDragOver = reactive<Record<string, boolean>>({});
 const beatDragOver = reactive<Record<number, boolean>>({});
 
-const anyBeatRendering = computed(() => Object.values(renderState).some((s) => s === "rendering"));
+const anyBeatRendering = computed(() => Object.values(renderState).some((state) => state === "rendering"));
 
 const characterKeys = computed(() => {
   const imgs = script.value.imageParams?.images ?? {};
@@ -447,10 +447,10 @@ const chatSessionId = computed(() => activeSessionRef?.value?.id);
 const pendingForThisScript = computed(() => {
   const out: Record<string, PendingGeneration> = {};
   const pending = activeSessionRef?.value?.pendingGenerations ?? {};
-  const fp = filePath.value;
-  if (!fp) return out;
+  const currentPath = filePath.value;
+  if (!currentPath) return out;
   for (const [mapKey, entry] of Object.entries(pending)) {
-    if (entry.filePath === fp) out[mapKey] = entry;
+    if (entry.filePath === currentPath) out[mapKey] = entry;
   }
   return out;
 });

--- a/src/plugins/presentMulmoScript/helpers.ts
+++ b/src/plugins/presentMulmoScript/helpers.ts
@@ -63,7 +63,7 @@ export function shouldAutoRenderBeat(beat: { image?: { type?: string } | undefin
  * what's missing after a movie-generation event arrives.
  */
 export function getMissingCharacterKeys(keys: readonly string[], images: Record<string, unknown>, renderState: Record<string, string | undefined>): string[] {
-  return keys.filter((k) => !images[k] && renderState[k] !== "rendering");
+  return keys.filter((charKey) => !images[charKey] && renderState[charKey] !== "rendering");
 }
 
 /**

--- a/src/plugins/scheduler/Preview.vue
+++ b/src/plugins/scheduler/Preview.vue
@@ -26,8 +26,8 @@ const items = ref<ScheduledItem[]>(props.result.data?.items ?? []);
 const { refresh } = useFreshPluginData<ScheduledItem[]>({
   endpoint: () => API_ROUTES.scheduler.base,
   extract: (json) => {
-    const v = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
-    return Array.isArray(v) ? v : null;
+    const extracted = (json as { data?: { items?: ScheduledItem[] } }).data?.items;
+    return Array.isArray(extracted) ? extracted : null;
   },
   apply: (data) => {
     items.value = data;
@@ -49,15 +49,15 @@ const upcomingItems = computed(() => {
   const noDate: ScheduledItem[] = [];
 
   for (const item of items.value) {
-    const d = item.props.date;
-    if (typeof d === "string") {
-      if (d >= today) withDate.push(item);
+    const dateVal = item.props.date;
+    if (typeof dateVal === "string") {
+      if (dateVal >= today) withDate.push(item);
     } else {
       noDate.push(item);
     }
   }
 
-  withDate.sort((a, b) => (String(a.props.date) < String(b.props.date) ? -1 : 1));
+  withDate.sort((itemA, itemB) => (String(itemA.props.date) < String(itemB.props.date) ? -1 : 1));
 
   return [...withDate, ...noDate];
 });

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -168,9 +168,9 @@ function formatSchedule(schedule: TaskSchedule): string {
   return JSON.stringify(schedule);
 }
 
-async function runTask(id: string): Promise<void> {
+async function runTask(taskId: string): Promise<void> {
   mutationError.value = "";
-  const url = API_ROUTES.scheduler.taskRun.replace(":id", id);
+  const url = API_ROUTES.scheduler.taskRun.replace(":id", taskId);
   const result = await apiPost(url, {});
   if (!result.ok) {
     mutationError.value = `Run failed: ${result.error}`;
@@ -190,9 +190,9 @@ async function toggleEnabled(task: SchedulerTask): Promise<void> {
   await fetchTasks();
 }
 
-async function deleteTask(id: string): Promise<void> {
+async function deleteTask(taskId: string): Promise<void> {
   mutationError.value = "";
-  const url = API_ROUTES.scheduler.task.replace(":id", id);
+  const url = API_ROUTES.scheduler.task.replace(":id", taskId);
   const result = await apiDelete(url);
   if (!result.ok) {
     mutationError.value = `Delete failed: ${result.error}`;

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -168,8 +168,8 @@ const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload
 const detailsEl = ref<HTMLDetailsElement>();
 const editing = ref(false);
 
-function onDetailsToggle(e: Event) {
-  editing.value = (e.target as HTMLDetailsElement).open;
+function onDetailsToggle(event: Event) {
+  editing.value = (event.target as HTMLDetailsElement).open;
 }
 
 onMounted(() => {

--- a/src/plugins/todo/Preview.vue
+++ b/src/plugins/todo/Preview.vue
@@ -42,8 +42,8 @@ const items = ref<TodoItem[]>(props.result.data?.items ?? []);
 const { refresh } = useFreshPluginData<TodoItem[]>({
   endpoint: () => API_ROUTES.todos.list,
   extract: (json) => {
-    const v = (json as { data?: { items?: TodoItem[] } }).data?.items;
-    return Array.isArray(v) ? v : null;
+    const extracted = (json as { data?: { items?: TodoItem[] } }).data?.items;
+    return Array.isArray(extracted) ? extracted : null;
   },
   apply: (data) => {
     items.value = data;

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -111,8 +111,8 @@ const items = ref<TodoItem[]>(props.selectedResult.data?.items ?? []);
 const { refresh } = useFreshPluginData<TodoItem[]>({
   endpoint: () => API_ROUTES.todos.list,
   extract: (json) => {
-    const v = (json as { data?: { items?: TodoItem[] } }).data?.items;
-    return Array.isArray(v) ? v : null;
+    const extracted = (json as { data?: { items?: TodoItem[] } }).data?.items;
+    return Array.isArray(extracted) ? extracted : null;
   },
   apply: (data) => {
     items.value = data;
@@ -163,12 +163,12 @@ function clearFilters(): void {
 
 // ── YAML helpers ─────────────────────────────────────────────────────────────
 
-function yamlStringValue(v: string): string {
-  const needsQuotes = v === "" || /[:#[\]{},&*?|<>=!%@`]/.test(v) || /^\s|\s$/.test(v) || /^(true|false|null|~)$/i.test(v) || /^\d/.test(v);
+function yamlStringValue(str: string): string {
+  const needsQuotes = str === "" || /[:#[\]{},&*?|<>=!%@`]/.test(str) || /^\s|\s$/.test(str) || /^(true|false|null|~)$/i.test(str) || /^\d/.test(str);
   if (needsQuotes) {
-    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
-  return v;
+  return str;
 }
 
 function serializeYaml(item: TodoItem): string {
@@ -191,19 +191,19 @@ function parseFlowSequence(raw: string): string[] {
   let buffer = "";
   let inQuotes = false;
   for (let i = 0; i < inner.length; i++) {
-    const ch = inner[i];
-    if (ch === '"' && inner[i - 1] !== "\\") {
+    const char = inner[i];
+    if (char === '"' && inner[i - 1] !== "\\") {
       inQuotes = !inQuotes;
-      buffer += ch;
+      buffer += char;
       continue;
     }
-    if (ch === "," && !inQuotes) {
+    if (char === "," && !inQuotes) {
       const piece = parseYamlValue(buffer.trim());
       if (piece) result.push(piece);
       buffer = "";
       continue;
     }
-    buffer += ch;
+    buffer += char;
   }
   const last = parseYamlValue(buffer.trim());
   if (last) result.push(last);

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -166,12 +166,12 @@ export function useTodos(initialItems: TodoItem[] = [], initialColumns: StatusCo
     error,
     refresh,
     createItem: (input) => call(API_ROUTES.todos.items, "POST", input),
-    patchItem: (id, input) => call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)), "PATCH", input),
-    moveItem: (id, input) => call(API_ROUTES.todos.itemMove.replace(":id", encodeURIComponent(id)), "POST", input),
-    deleteItem: (id) => call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(id)), "DELETE"),
+    patchItem: (itemId, input) => call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(itemId)), "PATCH", input),
+    moveItem: (itemId, input) => call(API_ROUTES.todos.itemMove.replace(":id", encodeURIComponent(itemId)), "POST", input),
+    deleteItem: (itemId) => call(API_ROUTES.todos.item.replace(":id", encodeURIComponent(itemId)), "DELETE"),
     addColumn: (input) => call(API_ROUTES.todos.columns, "POST", input),
-    patchColumn: (id, input) => call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)), "PATCH", input),
-    deleteColumn: (id) => call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(id)), "DELETE"),
+    patchColumn: (colId, input) => call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(colId)), "PATCH", input),
+    deleteColumn: (colId) => call(API_ROUTES.todos.column.replace(":id", encodeURIComponent(colId)), "DELETE"),
     reorderColumns: (ids) => call(API_ROUTES.todos.columnsOrder, "PUT", { ids }),
   };
 }

--- a/src/plugins/wiki/Preview.vue
+++ b/src/plugins/wiki/Preview.vue
@@ -43,11 +43,11 @@ const { refresh } = useFreshPluginData<WikiData>({
 watch(
   () => props.result.uuid,
   () => {
-    const d = props.result.data;
-    if (d) {
-      action.value = d.action ?? "index";
-      title.value = d.title ?? "Wiki";
-      pageEntries.value = d.pageEntries ?? [];
+    const wikiData = props.result.data;
+    if (wikiData) {
+      action.value = wikiData.action ?? "index";
+      title.value = wikiData.title ?? "Wiki";
+      pageEntries.value = wikiData.pageEntries ?? [];
     }
     void refresh();
   },

--- a/src/plugins/wiki/helpers.ts
+++ b/src/plugins/wiki/helpers.ts
@@ -43,11 +43,11 @@ export function renderWikiLinks(content: string): string {
  * immediately after `from` (zero-length page name, which the old
  * regex rejected via the `+` quantifier).
  */
-function findNextCloseBrackets(s: string, from: number): number {
+function findNextCloseBrackets(str: string, from: number): number {
   let j = from;
-  while (j < s.length) {
-    if (s[j] === "]") {
-      if (s[j + 1] === "]" && j > from) return j;
+  while (j < str.length) {
+    if (str[j] === "]") {
+      if (str[j + 1] === "]" && j > from) return j;
       // Bare `]` inside the page-name span — old regex would not
       // match here, so we bail and let the caller emit the `[[`
       // as literal text.

--- a/src/router/guards.ts
+++ b/src/router/guards.ts
@@ -18,43 +18,43 @@ import { VALID_VIEW_MODES } from "../utils/canvas/viewMode";
 // doesn't exist on the server" gracefully.
 const SESSION_ID_RE = /^[\w-]{1,128}$/;
 
-function isValidSessionId(id: unknown): boolean {
-  return typeof id === "string" && SESSION_ID_RE.test(id);
+function isValidSessionId(value: unknown): boolean {
+  return typeof value === "string" && SESSION_ID_RE.test(value);
 }
 
 export function installGuards(router: Router): void {
-  router.beforeEach((to) => {
+  router.beforeEach((dest) => {
     // Only run guards on the chat route — other routes (redirect, etc.)
     // don't carry parameters that need sanitizing.
-    if (to.name !== "chat") return;
+    if (dest.name !== "chat") return;
 
     // ── sessionId format check ───────────────────────────────────
-    const sessionId = to.params.sessionId;
+    const sessionId = dest.params.sessionId;
     if (typeof sessionId === "string" && sessionId.length > 0 && !isValidSessionId(sessionId)) {
       // Garbage sessionId → strip it and go to /chat (new session).
       return { name: "chat", params: {}, query: {}, replace: true };
     }
 
     // ── view mode whitelist ──────────────────────────────────────
-    const view = to.query.view;
+    const view = dest.query.view;
     if (typeof view === "string" && !VALID_VIEW_MODES.has(view)) {
-      const cleaned = { ...to.query };
+      const cleaned = { ...dest.query };
       delete cleaned.view;
-      return { ...to, query: cleaned, replace: true };
+      return { ...dest, query: cleaned, replace: true };
     }
 
     // ── file path traversal check ────────────────────────────────
-    const filePath = to.query.path;
+    const filePath = dest.query.path;
     if (typeof filePath === "string") {
       if (filePath.includes("..") || filePath.startsWith("/")) {
-        const cleaned = { ...to.query };
+        const cleaned = { ...dest.query };
         delete cleaned.path;
-        return { ...to, query: cleaned, replace: true };
+        return { ...dest, query: cleaned, replace: true };
       }
 
       // ?path= without ?view=files → auto-add view=files so FilesView mounts.
       if (view !== "files") {
-        return { ...to, query: { ...to.query, view: "files" }, replace: true };
+        return { ...dest, query: { ...dest.query, view: "files" }, replace: true };
       }
     }
   });

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -70,10 +70,11 @@ export interface ToolResultEntry extends SessionEntry {
   result: ToolResultComplete;
 }
 
-export const isTextEntry = (e: SessionEntry): e is TextEntry =>
-  (e.source === "user" || e.source === "assistant") && e.type === EVENT_TYPES.text && typeof e.message === "string";
+export const isTextEntry = (entry: SessionEntry): entry is TextEntry =>
+  (entry.source === "user" || entry.source === "assistant") && entry.type === EVENT_TYPES.text && typeof entry.message === "string";
 
-export const isToolResultEntry = (e: SessionEntry): e is ToolResultEntry => e.source === "tool" && e.type === EVENT_TYPES.toolResult && e.result !== undefined;
+export const isToolResultEntry = (entry: SessionEntry): entry is ToolResultEntry =>
+  entry.source === "tool" && entry.type === EVENT_TYPES.toolResult && entry.result !== undefined;
 
 // In-memory session held in `sessionMap`. PR #88 introduced this so
 // multiple chats can run concurrently — `id` matches the `chatSessionId`

--- a/src/utils/agent/request.ts
+++ b/src/utils/agent/request.ts
@@ -45,11 +45,11 @@ export async function postAgentRun(body: AgentRequestBody): Promise<{ ok: true }
       };
     }
     return { ok: true };
-  } catch (e) {
-    console.error("[agent] fetch error:", e);
+  } catch (err) {
+    console.error("[agent] fetch error:", err);
     return {
       ok: false,
-      error: e instanceof Error ? e.message : "Connection error.",
+      error: err instanceof Error ? err.message : "Connection error.",
     };
   }
 }

--- a/src/utils/dom/scrollable.ts
+++ b/src/utils/dom/scrollable.ts
@@ -11,8 +11,8 @@
 // real DOM.
 export function findScrollableChild(container: HTMLElement): HTMLElement | null {
   const children = container.querySelectorAll("*");
-  for (const el of children) {
-    const html = el as HTMLElement;
+  for (const elem of children) {
+    const html = elem as HTMLElement;
     if (html.scrollHeight > html.clientHeight) {
       const style = getComputedStyle(html);
       if (style.overflowY === "auto" || style.overflowY === "scroll" || style.overflow === "auto" || style.overflow === "scroll") {

--- a/src/utils/files/expandedDirs.ts
+++ b/src/utils/files/expandedDirs.ts
@@ -13,7 +13,7 @@ export function parseStoredExpandedDirs(raw: string | null): Set<string> {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return new Set(DEFAULT_EXPANDED);
-    const strings = parsed.filter((v): v is string => typeof v === "string");
+    const strings = parsed.filter((val): val is string => typeof val === "string");
     return new Set(strings);
   } catch {
     return new Set(DEFAULT_EXPANDED);

--- a/src/utils/files/sortChildren.ts
+++ b/src/utils/files/sortChildren.ts
@@ -7,14 +7,14 @@ import type { FileSortMode } from "../../composables/useFileSortMode";
 // on name so the order is deterministic).
 export function sortChildren(children: readonly TreeNode[], mode: FileSortMode): TreeNode[] {
   const copy = children.slice();
-  copy.sort((a, b) => {
-    if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+  copy.sort((nodeA, nodeB) => {
+    if (nodeA.type !== nodeB.type) return nodeA.type === "dir" ? -1 : 1;
     if (mode === "recent") {
-      const am = a.modifiedMs ?? -Infinity;
-      const bm = b.modifiedMs ?? -Infinity;
-      if (am !== bm) return bm - am;
+      const modTimeA = nodeA.modifiedMs ?? -Infinity;
+      const modTimeB = nodeB.modifiedMs ?? -Infinity;
+      if (modTimeA !== modTimeB) return modTimeB - modTimeA;
     }
-    return a.name.localeCompare(b.name);
+    return nodeA.name.localeCompare(nodeB.name);
   });
   return copy;
 }

--- a/src/utils/format/frontmatter.ts
+++ b/src/utils/format/frontmatter.ts
@@ -66,15 +66,15 @@ function parseValue(raw: string): FrontmatterValue {
   if (arrayMatch) {
     return arrayMatch[1]
       .split(",")
-      .map((s) => unquote(s.trim()))
-      .filter((s) => s.length > 0);
+      .map((item) => unquote(item.trim()))
+      .filter((item) => item.length > 0);
   }
   return unquote(raw);
 }
 
-function unquote(s: string): string {
-  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
-    return s.slice(1, -1);
+function unquote(str: string): string {
+  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+    return str.slice(1, -1);
   }
-  return s;
+  return str;
 }

--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -51,7 +51,7 @@ function shouldSkip(url: string): boolean {
 function resolveWorkspacePath(basePath: string, url: string): string | null {
   // Absolute-within-workspace (e.g. "/images/foo.png") — reset base.
   const isAbsolute = url.startsWith("/");
-  const baseSegs = isAbsolute ? [] : basePath.split("/").filter((s) => s !== "" && s !== ".");
+  const baseSegs = isAbsolute ? [] : basePath.split("/").filter((seg) => seg !== "" && seg !== ".");
   const segs = [...baseSegs];
 
   const urlSegs = (isAbsolute ? url.slice(1) : url).split("/");
@@ -76,9 +76,9 @@ function extractBracketedAlt(raw: string): string | null {
   if (!raw.startsWith("![")) return null;
   let depth = 1;
   for (let i = 2; i < raw.length; i++) {
-    const c = raw[i];
-    if (c === "[") depth++;
-    else if (c === "]") {
+    const char = raw[i];
+    if (char === "[") depth++;
+    else if (char === "]") {
       depth--;
       if (depth === 0) return raw.slice(2, i);
     }
@@ -123,7 +123,7 @@ function getContainerChildren(token: Token): Token[] | null {
 // Returns true if the container was rendered via its children, false
 // if the caller should fall back to emitting the parent's raw.
 function renderContainerChildren(raw: string, children: Token[], basePath: string, out: string[]): boolean {
-  const joined = children.map((c) => (c as { raw?: string }).raw ?? "").join("");
+  const joined = children.map((token) => (token as { raw?: string }).raw ?? "").join("");
   if (joined === "") return false;
   const idx = raw.indexOf(joined);
   if (idx < 0) return false;

--- a/src/utils/markdown/extractFirstH1.ts
+++ b/src/utils/markdown/extractFirstH1.ts
@@ -30,8 +30,8 @@ export function extractFirstH1(markdown: string): string | null {
   return null;
 }
 
-function splitLines(s: string): string[] {
-  return s.split(/\r\n|\r|\n/);
+function splitLines(str: string): string[] {
+  return str.split(/\r\n|\r|\n/);
 }
 
 function isInlineSpace(code: number): boolean {

--- a/src/utils/path/relativeLink.ts
+++ b/src/utils/path/relativeLink.ts
@@ -73,13 +73,13 @@ export function resolveWorkspaceLink(currentFilePath: string, href: string): str
 
 // Drop any trailing #fragment or ?query from a path-like string.
 // Whichever marker comes first wins.
-function stripFragmentAndQuery(s: string): string {
-  const hashIdx = s.indexOf("#");
-  const queryIdx = s.indexOf("?");
-  let end = s.length;
+function stripFragmentAndQuery(str: string): string {
+  const hashIdx = str.indexOf("#");
+  const queryIdx = str.indexOf("?");
+  let end = str.length;
   if (hashIdx !== -1 && hashIdx < end) end = hashIdx;
   if (queryIdx !== -1 && queryIdx < end) end = queryIdx;
-  return s.slice(0, end);
+  return str.slice(0, end);
 }
 
 // If `resolvedPath` points at a chat session log (e.g.
@@ -95,26 +95,26 @@ export function extractSessionIdFromPath(resolvedPath: string): string | null {
   const JSONL_SUFFIX = ".jsonl";
   if (!resolvedPath.startsWith(CHAT_PREFIX)) return null;
   if (!resolvedPath.endsWith(JSONL_SUFFIX)) return null;
-  const id = resolvedPath.slice(CHAT_PREFIX.length, resolvedPath.length - JSONL_SUFFIX.length);
-  if (id.length === 0) return null;
-  if (id.includes("/")) return null;
-  return id;
+  const sessionId = resolvedPath.slice(CHAT_PREFIX.length, resolvedPath.length - JSONL_SUFFIX.length);
+  if (sessionId.length === 0) return null;
+  if (sessionId.includes("/")) return null;
+  return sessionId;
 }
 
 // POSIX-style dirname. The file viewer always uses "/" separators
 // so we don't need to worry about Windows paths.
-function posixDirname(p: string): string {
-  const i = p.lastIndexOf("/");
-  return i === -1 ? "" : p.slice(0, i);
+function posixDirname(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? "" : path.slice(0, i);
 }
 
 // Collapse "./" and "../" in a workspace path. Rejects paths that
 // escape above the workspace root. Returns null for the empty-path
 // case so the caller can bail out. Callers are expected to strip
 // #fragment / ?query before invoking this function.
-function normalizeWorkspacePath(p: string): string | null {
-  if (p.length === 0) return null;
-  const parts = p.split("/");
+function normalizeWorkspacePath(path: string): string | null {
+  if (path.length === 0) return null;
+  const parts = path.split("/");
   const stack: string[] = [];
   for (const part of parts) {
     if (part === "" || part === ".") continue;

--- a/src/utils/role/icon.ts
+++ b/src/utils/role/icon.ts
@@ -11,10 +11,10 @@ import type { Role } from "../../config/roles";
 const MATERIAL_ICON_RE = /^[a-z_]+$/;
 
 export function roleIcon(roles: Role[], roleId: string): string {
-  const icon = roles.find((r) => r.id === roleId)?.icon ?? "star";
+  const icon = roles.find((role) => role.id === roleId)?.icon ?? "star";
   return MATERIAL_ICON_RE.test(icon) ? icon : "smart_toy";
 }
 
 export function roleName(roles: Role[], roleId: string): string {
-  return roles.find((r) => r.id === roleId)?.name ?? roleId;
+  return roles.find((role) => role.id === roleId)?.name ?? roleId;
 }

--- a/src/utils/role/merge.ts
+++ b/src/utils/role/merge.ts
@@ -5,6 +5,6 @@
 import type { Role } from "../../config/roles";
 
 export function mergeRoles(builtin: Role[], custom: Role[]): Role[] {
-  const customIds = new Set(custom.map((r) => r.id));
-  return [...builtin.filter((r) => !customIds.has(r.id)), ...custom];
+  const customIds = new Set(custom.map((role) => role.id));
+  return [...builtin.filter((role) => !customIds.has(role.id)), ...custom];
 }

--- a/src/utils/role/plugins.ts
+++ b/src/utils/role/plugins.ts
@@ -8,5 +8,5 @@ const GEMINI_PLUGINS = new Set<ToolName>([TOOL_NAMES.generateImage, TOOL_NAMES.p
 
 /** Whether the given role uses any plugin that requires a Gemini API key. */
 export function needsGemini(roles: Role[], roleId: string): boolean {
-  return (roles.find((r) => r.id === roleId)?.availablePlugins ?? []).some((p) => GEMINI_PLUGINS.has(p));
+  return (roles.find((role) => role.id === roleId)?.availablePlugins ?? []).some((plugin) => GEMINI_PLUGINS.has(plugin));
 }

--- a/src/utils/session/sessionFactory.ts
+++ b/src/utils/session/sessionFactory.ts
@@ -2,10 +2,10 @@
 
 import type { ActiveSession } from "../../types/session";
 
-export function createEmptySession(id: string, roleId: string): ActiveSession {
+export function createEmptySession(sessionId: string, roleId: string): ActiveSession {
   const now = new Date().toISOString();
   return {
-    id,
+    id: sessionId,
     roleId,
     toolResults: [],
     resultTimestamps: new Map(),

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -79,7 +79,7 @@ export function applyTextEvent(session: ActiveSession, message: string, source: 
 /** In-place update a result that was re-emitted by a plugin view
  *  (e.g. after the user edits a chart config). */
 export function updateResult(session: ActiveSession, updatedResult: ToolResultComplete): void {
-  const index = session.toolResults.findIndex((r) => r.uuid === updatedResult.uuid);
+  const index = session.toolResults.findIndex((result) => result.uuid === updatedResult.uuid);
   if (index !== -1) {
     Object.assign(session.toolResults[index], updatedResult);
   }
@@ -89,7 +89,7 @@ export function updateResult(session: ActiveSession, updatedResult: ToolResultCo
  *  result list. Selects the result only on insert; in-place updates
  *  preserve the user's current selection. */
 export function applyToolResultToSession(session: ActiveSession, result: ToolResultComplete): void {
-  const idx = session.toolResults.findIndex((r) => r.uuid === result.uuid);
+  const idx = session.toolResults.findIndex((existing) => existing.uuid === result.uuid);
   if (idx >= 0) {
     session.toolResults[idx] = result;
   } else {

--- a/src/utils/tools/dedup.ts
+++ b/src/utils/tools/dedup.ts
@@ -7,11 +7,11 @@
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 export function deduplicateResults(all: ToolResultComplete[]): ToolResultComplete[] {
-  return all.filter((r, i) => {
-    if (r.toolName === "text-response") return true;
+  return all.filter((result, i) => {
+    if (result.toolName === "text-response") return true;
     const next = all[i + 1];
     if (!next) return true;
-    if (next.toolName !== r.toolName) return true;
-    return !(r.updating === true && next.updating === true);
+    if (next.toolName !== result.toolName) return true;
+    return !(result.updating === true && next.updating === true);
   });
 }

--- a/src/utils/tools/result.ts
+++ b/src/utils/tools/result.ts
@@ -9,9 +9,9 @@ import { isRecord } from "../types";
 // Type guard: a text-response entry whose `data.role` is `"user"`.
 // Used by App.vue to find the first user message in a live session
 // when building the merged history list.
-export function isUserTextResponse(r: ToolResultComplete): boolean {
-  if (r.toolName !== "text-response") return false;
-  const data = r.data;
+export function isUserTextResponse(res: ToolResultComplete): boolean {
+  if (res.toolName !== "text-response") return false;
+  const data = res.data;
   if (!isRecord(data)) return false;
   return data.role === "user";
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -20,12 +20,12 @@ export function isNonEmptyString(value: unknown): value is string {
 /** Record whose values are all strings. */
 export function isStringRecord(value: unknown): value is Record<string, string> {
   if (!isRecord(value)) return false;
-  return Object.values(value).every((v) => typeof v === "string");
+  return Object.values(value).every((val) => typeof val === "string");
 }
 
 /** String array (every element is a string). */
 export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((v) => typeof v === "string");
+  return Array.isArray(value) && value.every((val) => typeof val === "string");
 }
 
 /** Error-like object with a `code` property. */


### PR DESCRIPTION
## Summary

- `src/` 以下の全ファイルから `id-length` ESLint ワーニングを完全に除去（62ファイル、0件に）
- 短い識別子をコンテキストに合わせた説明的な名前にリネーム
- エラーゼロ、ビルド成功を確認済み

## Items to Confirm / Review

- 各リネームが元の意図を正確に伝えているか（特に `r` → `role`/`result`/`existing` など文脈依存のもの）
- `router/guards.ts` の `to` → `dest`（Vue Router 慣例から外れる）

## User Prompt

src以下のwarn(id-length)を続けて

## Implementation

主なリネームパターン:

| 旧 | 新 | 例 |
|---|---|---|
| `(r)` | `(role)` / `(result)` / `(existing)` | `.find((r) => ...)` |
| `(e)` | `(event)` / `(entry)` / `(err)` | `catch (e)`, イベントハンドラ |
| `(s)` | `(summary)` / `(session)` / `(skill)` / `(str)` | コンテキスト依存 |
| `id` 仮引数 | `sessionId` / `roleId` / `taskId` / `itemId` | 各関数の意味から命名 |
| `(c)` | `(chart)` / `(char)` / `(ctrl)` | コンテキスト依存 |
| `(a,b)` | `(nodeA,nodeB)` / `(itemA,itemB)` | ソート関数 |
| `am`/`bm` | `modTimeA`/`modTimeB` | `sortChildren.ts` |
| `fp` | `currentPath` | `presentMulmoScript/View.vue` |
| `ch` | `char` | `todo/View.vue` |
| `cb` | `handler` | `usePubSub.ts` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)