### PR TITLE
refactor: rename short identifiers in server (batch 2)

### DIFF
--- a/server/agent/mcp-tools/x.ts
+++ b/server/agent/mcp-tools/x.ts
@@ -64,7 +64,7 @@ function formatTweet(tweet: XTweet, author?: XUser, url?: string): string {
     : "";
   const link = url ?? "";
   return [byline, "", tweet.text, "", metrics, link]
-    .filter((l) => l !== undefined)
+    .filter((line) => line !== undefined)
     .join("\n")
     .trimEnd();
 }
@@ -104,12 +104,12 @@ export const readXPost = {
       return errorMessage(err);
     }
 
-    if (data.errors?.length) return `X API error: ${data.errors.map((e) => e.detail).join("; ")}`;
+    if (data.errors?.length) return `X API error: ${data.errors.map((err) => err.detail).join("; ")}`;
 
     const tweet = data.data as XTweet | undefined;
     if (!tweet) return "Tweet not found.";
 
-    const author = data.includes?.users?.find((u) => u.id === tweet.author_id);
+    const author = data.includes?.users?.find((user) => user.id === tweet.author_id);
     const canonicalUrl = author ? `https://x.com/${author.username}/status/${tweet.id}` : undefined;
     return formatTweet(tweet, author, canonicalUrl);
   },
@@ -168,13 +168,13 @@ export const searchX = {
       return errorMessage(err);
     }
 
-    if (data.errors?.length) return `X API error: ${data.errors.map((e) => e.detail).join("; ")}`;
+    if (data.errors?.length) return `X API error: ${data.errors.map((err) => err.detail).join("; ")}`;
 
     const tweets = Array.isArray(data.data) ? data.data : [];
     if (tweets.length === 0) return `No recent posts found for: "${query}"`;
 
     const users = data.includes?.users ?? [];
-    const userMap = new Map(users.map((u) => [u.id, u]));
+    const userMap = new Map(users.map((user) => [user.id, user]));
 
     const lines: string[] = [`Search: "${query}" — ${tweets.length} result${tweets.length !== 1 ? "s" : ""}`, ""];
     tweets.forEach((tweet, i) => {

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -93,11 +93,11 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
     }
 
     if (action === SCHEDULER_ACTIONS.deleteTask) {
-      const id = typeof input.id === "string" ? input.id : "";
+      const taskId = typeof input.id === "string" ? input.id : "";
       const tasks = loadUserTasks();
-      const idx = tasks.findIndex((t) => t.id === id);
+      const idx = tasks.findIndex((task) => task.id === taskId);
       if (idx === -1) {
-        res.status(404).json({ error: `task not found: ${id}` });
+        res.status(404).json({ error: `task not found: ${taskId}` });
         return;
       }
       const name = tasks[idx].name;
@@ -107,17 +107,17 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       res.json({
         uuid: crypto.randomUUID(),
         message: `Task "${name}" deleted.`,
-        data: { deleted: id },
+        data: { deleted: taskId },
       });
       return;
     }
 
     if (action === SCHEDULER_ACTIONS.runTask) {
-      const id = typeof input.id === "string" ? input.id : "";
+      const taskId = typeof input.id === "string" ? input.id : "";
       const tasks = loadUserTasks();
-      const task = tasks.find((t) => t.id === id);
+      const task = tasks.find((candidate) => candidate.id === taskId);
       if (!task) {
-        res.status(404).json({ error: `task not found: ${id}` });
+        res.status(404).json({ error: `task not found: ${taskId}` });
         return;
       }
       const chatSessionId = crypto.randomUUID();
@@ -138,7 +138,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       res.json({
         uuid: crypto.randomUUID(),
         message: `Task "${task.name}" triggered.`,
-        data: { triggered: id, chatSessionId },
+        data: { triggered: taskId, chatSessionId },
       });
       return;
     }

--- a/server/api/routes/schedulerHandlers.ts
+++ b/server/api/routes/schedulerHandlers.ts
@@ -29,14 +29,14 @@ export type SchedulerActionResult =
     };
 
 export function sortItems(items: ScheduledItem[]): ScheduledItem[] {
-  return [...items].sort((a, b) => {
-    const aDate = typeof a.props.date === "string" ? a.props.date : null;
-    const bDate = typeof b.props.date === "string" ? b.props.date : null;
-    const aTime = typeof a.props.time === "string" ? a.props.time : "00:00";
-    const bTime = typeof b.props.time === "string" ? b.props.time : "00:00";
-    const aKey = aDate ? `0_${aDate}_${aTime}` : `1_${a.createdAt}`;
-    const bKey = bDate ? `0_${bDate}_${bTime}` : `1_${b.createdAt}`;
-    return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
+  return [...items].sort((left, right) => {
+    const leftDate = typeof left.props.date === "string" ? left.props.date : null;
+    const rightDate = typeof right.props.date === "string" ? right.props.date : null;
+    const leftTime = typeof left.props.time === "string" ? left.props.time : "00:00";
+    const rightTime = typeof right.props.time === "string" ? right.props.time : "00:00";
+    const leftKey = leftDate ? `0_${leftDate}_${leftTime}` : `1_${left.createdAt}`;
+    const rightKey = rightDate ? `0_${rightDate}_${rightTime}` : `1_${right.createdAt}`;
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
   });
 }
 
@@ -84,11 +84,11 @@ export function handleDelete(items: ScheduledItem[], input: SchedulerActionInput
 
 function applyPropPatch(current: ScheduledItem["props"], patch: Record<string, string | number | boolean | null>): ScheduledItem["props"] {
   const next: ScheduledItem["props"] = { ...current };
-  for (const [k, v] of Object.entries(patch)) {
-    if (v === null) {
-      delete next[k];
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete next[key];
     } else {
-      next[k] = v;
+      next[key] = value;
     }
   }
   return next;

--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -47,18 +47,18 @@ function isTransientRenameError(err: unknown): boolean {
   return err.code === "EPERM" || err.code === "EBUSY" || err.code === "EACCES";
 }
 
-async function renameWithWindowsRetry(from: string, to: string): Promise<void> {
+async function renameWithWindowsRetry(fromPath: string, toPath: string): Promise<void> {
   for (const delayMs of RENAME_RETRY_DELAYS_MS) {
     try {
-      await fs.promises.rename(from, to);
+      await fs.promises.rename(fromPath, toPath);
       return;
     } catch (err) {
       if (!isTransientRenameError(err)) throw err;
-      await new Promise((r) => setTimeout(r, delayMs));
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
   // Final attempt — let any error propagate.
-  await fs.promises.rename(from, to);
+  await fs.promises.rename(fromPath, toPath);
 }
 
 // Sync sleep that parks the thread instead of burning CPU. Only
@@ -66,21 +66,21 @@ async function renameWithWindowsRetry(from: string, to: string): Promise<void> {
 // case block is the sum of RENAME_RETRY_DELAYS_MS (~430ms) and only
 // triggers under AV/indexer contention.
 const SYNC_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
-function sleepSync(ms: number): void {
-  Atomics.wait(SYNC_SLEEP_BUF, 0, 0, ms);
+function sleepSync(millis: number): void {
+  Atomics.wait(SYNC_SLEEP_BUF, 0, 0, millis);
 }
 
-function renameSyncWithWindowsRetry(from: string, to: string): void {
+function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
   for (const delayMs of RENAME_RETRY_DELAYS_MS) {
     try {
-      fs.renameSync(from, to);
+      fs.renameSync(fromPath, toPath);
       return;
     } catch (err) {
       if (!isTransientRenameError(err)) throw err;
       sleepSync(delayMs);
     }
   }
-  fs.renameSync(from, to);
+  fs.renameSync(fromPath, toPath);
 }
 
 /**

--- a/server/utils/files/html-io.ts
+++ b/server/utils/files/html-io.ts
@@ -9,12 +9,12 @@ import { workspacePath } from "../../workspace/paths.js";
 import { readTextUnder, writeTextUnder } from "./workspace-io.js";
 
 const HTML_REL = path.posix.join(WORKSPACE_DIRS.html, "current.html");
-const root = (r?: string) => r ?? workspacePath;
+const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
 
-export async function readCurrentHtml(r?: string): Promise<string | null> {
-  return readTextUnder(root(r), HTML_REL);
+export async function readCurrentHtml(workspaceRoot?: string): Promise<string | null> {
+  return readTextUnder(root(workspaceRoot), HTML_REL);
 }
 
-export async function writeCurrentHtml(html: string, r?: string): Promise<void> {
-  await writeTextUnder(root(r), HTML_REL, html);
+export async function writeCurrentHtml(html: string, workspaceRoot?: string): Promise<void> {
+  await writeTextUnder(root(workspaceRoot), HTML_REL, html);
 }

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -35,8 +35,8 @@ async function safeResolve(relativePath: string): Promise<string> {
 /** Save raw base64 (no data URI prefix) as a PNG file. Returns the workspace-relative path. */
 export async function saveImage(base64Data: string): Promise<string> {
   await ensureImagesDir();
-  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-  const filename = `${id}.png`;
+  const imageId = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const filename = `${imageId}.png`;
   const absPath = path.join(IMAGES_DIR, filename);
   await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
   return path.posix.join(WORKSPACE_DIRS.images, filename);

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -51,9 +51,9 @@ export async function writeJournalState(state: unknown, rootOverride?: string): 
 
 // ── Index ───────────────────────────────────────────────────────
 
-export async function writeJournalIndex(md: string, rootOverride?: string): Promise<void> {
+export async function writeJournalIndex(markdown: string, rootOverride?: string): Promise<void> {
   const filePath = path.join(summariesRoot(root(rootOverride)), INDEX_FILE);
-  await writeFileAtomic(filePath, md);
+  await writeFileAtomic(filePath, markdown);
 }
 
 // ── Daily summaries ─────────────────────────────────────────────

--- a/server/utils/files/naming.ts
+++ b/server/utils/files/naming.ts
@@ -44,7 +44,7 @@ export function buildArtifactPathRandom(dir: string, prefix: string, ext: string
   // Pass fallbackSlug as slugify's default so it overrides slugify's
   // built-in "page" default when `prefix` sanitizes to empty.
   const slug = slugify(prefix, fallbackSlug);
-  const id = crypto.randomUUID().replace(/-/g, "").slice(0, RANDOM_SUFFIX_LEN);
-  const fname = `${slug}-${id}${ext}`;
+  const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, RANDOM_SUFFIX_LEN);
+  const fname = `${slug}-${suffix}${ext}`;
   return path.posix.join(dir, fname);
 }

--- a/server/utils/files/scheduler-io.ts
+++ b/server/utils/files/scheduler-io.ts
@@ -9,12 +9,12 @@ import { resolvePath } from "./workspace-io.js";
 import { loadJsonFile } from "./json.js";
 import { writeFileAtomicSync } from "./atomic.js";
 
-const root = (r?: string) => r ?? workspacePath;
+const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
 
-export function loadSchedulerItems<T>(fallback: T, r?: string): T {
-  return loadJsonFile(resolvePath(root(r), WORKSPACE_FILES.schedulerItems), fallback);
+export function loadSchedulerItems<T>(fallback: T, workspaceRoot?: string): T {
+  return loadJsonFile(resolvePath(root(workspaceRoot), WORKSPACE_FILES.schedulerItems), fallback);
 }
 
-export function saveSchedulerItems(items: unknown, r?: string): void {
-  writeFileAtomicSync(resolvePath(root(r), WORKSPACE_FILES.schedulerItems), JSON.stringify(items, null, 2));
+export function saveSchedulerItems(items: unknown, workspaceRoot?: string): void {
+  writeFileAtomicSync(resolvePath(root(workspaceRoot), WORKSPACE_FILES.schedulerItems), JSON.stringify(items, null, 2));
 }

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -36,8 +36,8 @@ async function safeResolve(relativePath: string): Promise<string> {
 /** Save sheets array as a JSON file. Returns the workspace-relative path. */
 export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   await ensureSpreadsheetsDir();
-  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-  const filename = `${id}.json`;
+  const sheetId = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const filename = `${sheetId}.json`;
   await fs.writeFile(path.join(SPREADSHEETS_DIR, filename), JSON.stringify(sheets), "utf-8");
   return path.posix.join(WORKSPACE_DIRS.spreadsheets, filename);
 }

--- a/server/utils/files/todos-io.ts
+++ b/server/utils/files/todos-io.ts
@@ -10,20 +10,20 @@ import { resolvePath } from "./workspace-io.js";
 import { loadJsonFile } from "./json.js";
 import { writeFileAtomicSync } from "./atomic.js";
 
-const root = (r?: string) => r ?? workspacePath;
+const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
 
-export function loadTodos<T>(fallback: T, r?: string): T {
-  return loadJsonFile(resolvePath(root(r), WORKSPACE_FILES.todosItems), fallback);
+export function loadTodos<T>(fallback: T, workspaceRoot?: string): T {
+  return loadJsonFile(resolvePath(root(workspaceRoot), WORKSPACE_FILES.todosItems), fallback);
 }
 
-export function saveTodos(items: unknown, r?: string): void {
-  writeFileAtomicSync(resolvePath(root(r), WORKSPACE_FILES.todosItems), JSON.stringify(items, null, 2));
+export function saveTodos(items: unknown, workspaceRoot?: string): void {
+  writeFileAtomicSync(resolvePath(root(workspaceRoot), WORKSPACE_FILES.todosItems), JSON.stringify(items, null, 2));
 }
 
-export function loadColumns<T>(fallback: T, r?: string): T {
-  return loadJsonFile(resolvePath(root(r), WORKSPACE_FILES.todosColumns), fallback);
+export function loadColumns<T>(fallback: T, workspaceRoot?: string): T {
+  return loadJsonFile(resolvePath(root(workspaceRoot), WORKSPACE_FILES.todosColumns), fallback);
 }
 
-export function saveColumns(columns: unknown, r?: string): void {
-  writeFileAtomicSync(resolvePath(root(r), WORKSPACE_FILES.todosColumns), JSON.stringify(columns, null, 2));
+export function saveColumns(columns: unknown, workspaceRoot?: string): void {
+  writeFileAtomicSync(resolvePath(root(workspaceRoot), WORKSPACE_FILES.todosColumns), JSON.stringify(columns, null, 2));
 }

--- a/server/utils/files/user-tasks-io.ts
+++ b/server/utils/files/user-tasks-io.ts
@@ -11,15 +11,15 @@ import { resolvePath } from "./workspace-io.js";
 import { loadJsonFile } from "./json.js";
 import { writeFileAtomic } from "./atomic.js";
 
-const root = (r?: string) => r ?? workspacePath;
+const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
 
-export function loadUserTasks<T>(r?: string): T[] {
-  const tasks = loadJsonFile<T[]>(resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks), []);
+export function loadUserTasks<T>(workspaceRoot?: string): T[] {
+  const tasks = loadJsonFile<T[]>(resolvePath(root(workspaceRoot), WORKSPACE_FILES.schedulerUserTasks), []);
   return Array.isArray(tasks) ? tasks : [];
 }
 
-export async function saveUserTasks<T>(tasks: T[], r?: string): Promise<void> {
-  const filePath = resolvePath(root(r), WORKSPACE_FILES.schedulerUserTasks);
+export async function saveUserTasks<T>(tasks: T[], workspaceRoot?: string): Promise<void> {
+  const filePath = resolvePath(root(workspaceRoot), WORKSPACE_FILES.schedulerUserTasks);
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFileAtomic(filePath, JSON.stringify(tasks, null, 2));
 }

--- a/server/workspace/sources/classifier.ts
+++ b/server/workspace/sources/classifier.ts
@@ -115,18 +115,18 @@ export function buildClassifyPrompt(input: ClassifyInput): string {
   if (titles.length > 0) {
     lines.push("");
     lines.push("RECENT ITEM TITLES:");
-    for (const t of titles.slice(0, 5)) {
-      lines.push(`- ${t}`);
+    for (const title of titles.slice(0, 5)) {
+      lines.push(`- ${title}`);
     }
   }
   const summaries = input.sampleSummaries ?? [];
   if (summaries.length > 0) {
     lines.push("");
     lines.push("RECENT ITEM SUMMARIES:");
-    for (const s of summaries.slice(0, 3)) {
+    for (const summary of summaries.slice(0, 3)) {
       // One-line truncation so a single long abstract doesn't
       // dominate the prompt budget.
-      lines.push(`- ${s.replace(/\s+/g, " ").slice(0, 200)}`);
+      lines.push(`- ${summary.replace(/\s+/g, " ").slice(0, 200)}`);
     }
   }
   return lines.join("\n");
@@ -167,8 +167,8 @@ export function validateClassifyResult(obj: unknown): ClassifyResult {
   if (!isRecord(obj)) {
     throw new Error("[sources/classifier] output is not an object");
   }
-  const o = obj as Record<string, unknown>;
-  const categories = normalizeCategories(o.categories);
+  const record = obj as Record<string, unknown>;
+  const categories = normalizeCategories(record.categories);
   if (categories.length === 0) {
     // The model is required to pick at least one (min_items=1 in
     // the schema). If we end up here, something went wrong upstream
@@ -178,7 +178,7 @@ export function validateClassifyResult(obj: unknown): ClassifyResult {
     // with no categories.
     throw new Error("[sources/classifier] output has no valid categories from the taxonomy");
   }
-  const rationale = typeof o.rationale === "string" ? o.rationale.slice(0, 400) : "";
+  const rationale = typeof record.rationale === "string" ? record.rationale.slice(0, 400) : "";
   return { categories, rationale };
 }
 

--- a/server/workspace/sources/fetchers/arxiv.ts
+++ b/server/workspace/sources/fetchers/arxiv.ts
@@ -90,8 +90,8 @@ export function normalizeArxivFeed(feed: ParsedFeed, source: Source, cursor: Rec
 function parseCursorTs(cursor: Record<string, string>): number | null {
   const raw = cursor[ARXIV_CURSOR_KEY];
   if (!raw) return null;
-  const ts = Date.parse(raw);
-  return Number.isFinite(ts) ? ts : null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 // Decide whether one ParsedFeedItem produces a SourceItem given
@@ -104,8 +104,8 @@ function feedItemToSourceItem(entry: ParsedFeed["items"][number], source: Source
   const normalizedUrl = normalizeUrl(entry.link);
   if (!normalizedUrl) return null;
   if (entry.publishedAt && lastSeenTs !== null) {
-    const ts = Date.parse(entry.publishedAt);
-    if (Number.isFinite(ts) && ts <= lastSeenTs) return null;
+    const publishedMs = Date.parse(entry.publishedAt);
+    if (Number.isFinite(publishedMs) && publishedMs <= lastSeenTs) return null;
   }
   const publishedAt = entry.publishedAt ?? new Date().toISOString();
   return {
@@ -128,9 +128,9 @@ export function updateArxivCursor(current: Record<string, string>, feed: ParsedF
   let newest: number | null = null;
   for (const entry of feed.items) {
     if (!entry.publishedAt) continue;
-    const ts = Date.parse(entry.publishedAt);
-    if (!Number.isFinite(ts)) continue;
-    if (newest === null || ts > newest) newest = ts;
+    const publishedMs = Date.parse(entry.publishedAt);
+    if (!Number.isFinite(publishedMs)) continue;
+    if (newest === null || publishedMs > newest) newest = publishedMs;
   }
   if (newest === null) return current;
   const currentTs = current[ARXIV_CURSOR_KEY] ? Date.parse(current[ARXIV_CURSOR_KEY]) : -Infinity;

--- a/server/workspace/sources/fetchers/githubIssues.ts
+++ b/server/workspace/sources/fetchers/githubIssues.ts
@@ -69,7 +69,7 @@ interface ParsedIssue {
 // signal.
 export function parseGithubIssue(raw: unknown): ParsedIssue | null {
   if (!isRecord(raw)) return null;
-  const id = typeof raw.id === "number" && Number.isFinite(raw.id) ? raw.id : null;
+  const issueId = typeof raw.id === "number" && Number.isFinite(raw.id) ? raw.id : null;
   const issueNumber = typeof raw.number === "number" && Number.isFinite(raw.number) ? raw.number : null;
   const title = typeof raw.title === "string" ? raw.title : null;
   const htmlUrl = typeof raw.html_url === "string" ? raw.html_url : null;
@@ -81,7 +81,7 @@ export function parseGithubIssue(raw: unknown): ParsedIssue | null {
   // object) means this is a PR. Absence means it's an issue.
   const isPr = "pull_request" in raw && raw.pull_request !== undefined && raw.pull_request !== null;
   return {
-    id,
+    id: issueId,
     number: issueNumber,
     title,
     htmlUrl,
@@ -110,7 +110,7 @@ export function issueToSourceItem(issue: ParsedIssue, source: Source, params: Is
 
   const normalizedUrl = normalizeUrl(issue.htmlUrl);
   if (!normalizedUrl) return null;
-  const id = stableItemId(normalizedUrl);
+  const itemId = stableItemId(normalizedUrl);
 
   // Title annotations: `[PR]` for pulls, `[closed]` for closed
   // state so the daily summary makes state visible at a glance.
@@ -123,7 +123,7 @@ export function issueToSourceItem(issue: ParsedIssue, source: Source, params: Is
   const summary = issue.body ? firstParagraph(issue.body) : null;
 
   return {
-    id,
+    id: itemId,
     title,
     url: normalizedUrl,
     publishedAt: new Date(updatedTs).toISOString(),
@@ -139,9 +139,9 @@ export function updateIssuesCursor(current: Record<string, string>, issues: read
   for (const issue of issues) {
     if (issue.isPr && !params.includePrs) continue;
     if (!issue.updatedAt) continue;
-    const ts = Date.parse(issue.updatedAt);
-    if (!Number.isFinite(ts)) continue;
-    if (newest === null || ts > newest) newest = ts;
+    const updatedMs = Date.parse(issue.updatedAt);
+    if (!Number.isFinite(updatedMs)) continue;
+    if (newest === null || updatedMs > newest) newest = updatedMs;
   }
   if (newest === null) return current;
   const currentTs = current[ISSUES_CURSOR_KEY] ? Date.parse(current[ISSUES_CURSOR_KEY]) : -Infinity;

--- a/server/workspace/sources/fetchers/githubReleases.ts
+++ b/server/workspace/sources/fetchers/githubReleases.ts
@@ -52,7 +52,7 @@ interface ParsedRelease {
 // hitting the network.
 export function parseGithubRelease(raw: unknown): ParsedRelease | null {
   if (!isRecord(raw)) return null;
-  const id = typeof raw.id === "number" && Number.isFinite(raw.id) ? raw.id : null;
+  const releaseId = typeof raw.id === "number" && Number.isFinite(raw.id) ? raw.id : null;
   const name = typeof raw.name === "string" ? raw.name : null;
   const tagName = typeof raw.tag_name === "string" ? raw.tag_name : null;
   const htmlUrl = typeof raw.html_url === "string" ? raw.html_url : null;
@@ -60,7 +60,7 @@ export function parseGithubRelease(raw: unknown): ParsedRelease | null {
   const publishedAt = typeof raw.published_at === "string" ? raw.published_at : null;
   const draft = raw.draft === true;
   const prerelease = raw.prerelease === true;
-  return { id, name, tagName, htmlUrl, body, publishedAt, draft, prerelease };
+  return { id: releaseId, name, tagName, htmlUrl, body, publishedAt, draft, prerelease };
 }
 
 // Build a SourceItem from a parsed release + the parent Source.
@@ -82,7 +82,7 @@ export function releaseToSourceItem(release: ParsedRelease, source: Source, last
 
   const normalizedUrl = normalizeUrl(release.htmlUrl);
   if (!normalizedUrl) return null;
-  const id = stableItemId(normalizedUrl);
+  const itemId = stableItemId(normalizedUrl);
 
   // Title resolution: prefer <name> (release display name), fall
   // back to <tag_name> (e.g. "v1.2.3"). Annotate pre-releases so
@@ -92,7 +92,7 @@ export function releaseToSourceItem(release: ParsedRelease, source: Source, last
   const summary = release.body ? firstParagraph(release.body) : null;
 
   return {
-    id,
+    id: itemId,
     title,
     url: normalizedUrl,
     publishedAt: new Date(publishedTs).toISOString(),
@@ -128,9 +128,9 @@ export function updateReleasesCursor(current: Record<string, string>, releases: 
   for (const release of releases) {
     if (release.draft) continue;
     if (!release.publishedAt) continue;
-    const ts = Date.parse(release.publishedAt);
-    if (!Number.isFinite(ts)) continue;
-    if (newest === null || ts > newest) newest = ts;
+    const publishedMs = Date.parse(release.publishedAt);
+    if (!Number.isFinite(publishedMs)) continue;
+    if (newest === null || publishedMs > newest) newest = publishedMs;
   }
   if (newest === null) return current;
   const currentTs = current[RELEASES_CURSOR_KEY] ? Date.parse(current[RELEASES_CURSOR_KEY]) : -Infinity;

--- a/server/workspace/sources/pipeline/index.ts
+++ b/server/workspace/sources/pipeline/index.ts
@@ -92,11 +92,11 @@ export { toLocalIsoDate } from "../../../utils/date.js";
 // Convert a wall-clock millis value to the LOCAL year-month
 // key (YYYY-MM) used as the archive fallback for items without
 // a parseable publishedAt.
-export function toLocalYearMonth(ms: number): string {
-  const d = new Date(ms);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  return `${y}-${m}`;
+export function toLocalYearMonth(millis: number): string {
+  const date = new Date(millis);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
 }
 
 export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPipelineResult> {
@@ -125,7 +125,7 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
   const allSources = await listSources(workspaceRoot);
   const statesBySlug = await readManyStates(
     workspaceRoot,
-    allSources.map((s) => s.slug),
+    allSources.map((source) => source.slug),
   );
 
   // --- 2. Plan ------------------------------------------------------

--- a/server/workspace/sources/pipeline/plan.ts
+++ b/server/workspace/sources/pipeline/plan.ts
@@ -31,8 +31,8 @@ export interface PlanInput {
 // Sort key: slug, ascending. Deterministic ordering keeps the
 // daily summary's item sequence stable across runs for the same
 // input, which makes markdown diffs readable.
-function bySlug(a: Source, b: Source): number {
-  return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+function bySlug(left: Source, right: Source): number {
+  return left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0;
 }
 
 // Returns the subset of sources eligible for this cycle. Pure.
@@ -60,7 +60,7 @@ export function planEligibleSources(input: PlanInput): Source[] {
 function isWithinBackoff(state: SourceState | undefined, nowMs: number): boolean {
   if (!state) return false;
   if (!state.nextAttemptAt) return false;
-  const ts = Date.parse(state.nextAttemptAt);
-  if (!Number.isFinite(ts)) return false;
-  return ts > nowMs;
+  const parsed = Date.parse(state.nextAttemptAt);
+  if (!Number.isFinite(parsed)) return false;
+  return parsed > nowMs;
 }

--- a/server/workspace/sources/robots.ts
+++ b/server/workspace/sources/robots.ts
@@ -105,8 +105,8 @@ function applyRule(group: RobotsGroup, name: string, value: string): void {
   } else if (name === "allow") {
     group.rules.push({ kind: "allow", pattern: value });
   } else if (name === "crawl-delay") {
-    const n = Number(value);
-    if (Number.isFinite(n) && n >= 0) group.crawlDelaySec = n;
+    const seconds = Number(value);
+    if (Number.isFinite(seconds) && seconds >= 0) group.crawlDelaySec = seconds;
   }
   // Any other directive: ignored.
 }
@@ -138,13 +138,13 @@ function parseDirective(line: string): { name: string; value: string } | null {
 // duplicate group get ignored, which could silently let a fetcher
 // hit a path the site explicitly blocked.
 export function selectGroup(robots: ParsedRobots, userAgent: string): RobotsGroup | null {
-  const ua = userAgent.toLowerCase();
+  const agent = userAgent.toLowerCase();
   const exacts: RobotsGroup[] = [];
   const stars: RobotsGroup[] = [];
   let bestPrefixScore = -1;
   let prefixMatches: RobotsGroup[] = [];
   for (const group of robots.groups) {
-    const outcome = scoreGroupAgainstAgent(group, ua);
+    const outcome = scoreGroupAgainstAgent(group, agent);
     if (outcome.kind === "exact") exacts.push(outcome.group);
     else if (outcome.kind === "star") stars.push(outcome.group);
     else if (outcome.kind === "prefix") {
@@ -170,11 +170,11 @@ function mergeGroups(groups: readonly RobotsGroup[]): RobotsGroup {
   const rules: RobotsRule[] = [];
   const userAgents: string[] = [];
   let crawlDelaySec: number | null = null;
-  for (const g of groups) {
-    rules.push(...g.rules);
-    userAgents.push(...g.userAgents);
-    if (g.crawlDelaySec !== null) {
-      crawlDelaySec = crawlDelaySec === null ? g.crawlDelaySec : Math.min(crawlDelaySec, g.crawlDelaySec);
+  for (const group of groups) {
+    rules.push(...group.rules);
+    userAgents.push(...group.userAgents);
+    if (group.crawlDelaySec !== null) {
+      crawlDelaySec = crawlDelaySec === null ? group.crawlDelaySec : Math.min(crawlDelaySec, group.crawlDelaySec);
     }
   }
   return { userAgents, rules, crawlDelaySec };
@@ -186,7 +186,7 @@ type AgentMatch =
   | { kind: "star"; group: RobotsGroup }
   | { kind: "none" };
 
-function scoreGroupAgainstAgent(group: RobotsGroup, ua: string): AgentMatch {
+function scoreGroupAgainstAgent(group: RobotsGroup, agent: string): AgentMatch {
   let bestPrefix = -1;
   let hasStar = false;
   for (const listed of group.userAgents) {
@@ -194,8 +194,8 @@ function scoreGroupAgainstAgent(group: RobotsGroup, ua: string): AgentMatch {
       hasStar = true;
       continue;
     }
-    if (listed === ua) return { kind: "exact", group };
-    if (ua.startsWith(listed) && listed.length > bestPrefix) {
+    if (listed === agent) return { kind: "exact", group };
+    if (agent.startsWith(listed) && listed.length > bestPrefix) {
       bestPrefix = listed.length;
     }
   }
@@ -266,6 +266,6 @@ export function matchesPattern(pattern: string, path: string): number {
     .split("*")
     .map((chunk) => chunk.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join(".*");
-  const re = new RegExp("^" + regexBody + (endAnchored ? "$" : ""));
-  return re.test(path) ? pattern.length : -1;
+  const regex = new RegExp("^" + regexBody + (endAnchored ? "$" : ""));
+  return regex.test(path) ? pattern.length : -1;
 }

--- a/server/workspace/sources/sourceState.ts
+++ b/server/workspace/sources/sourceState.ts
@@ -47,12 +47,14 @@ export function validateSourceState(raw: unknown, slug: string): SourceState {
   if (!isRecord(raw)) {
     return defaultSourceState(slug);
   }
-  const o = raw as Record<string, unknown>;
-  const lastFetchedAt = typeof o.lastFetchedAt === "string" ? o.lastFetchedAt : null;
-  const nextAttemptAt = typeof o.nextAttemptAt === "string" ? o.nextAttemptAt : null;
+  const record = raw as Record<string, unknown>;
+  const lastFetchedAt = typeof record.lastFetchedAt === "string" ? record.lastFetchedAt : null;
+  const nextAttemptAt = typeof record.nextAttemptAt === "string" ? record.nextAttemptAt : null;
   const consecutiveFailures =
-    typeof o.consecutiveFailures === "number" && Number.isFinite(o.consecutiveFailures) && o.consecutiveFailures >= 0 ? Math.floor(o.consecutiveFailures) : 0;
-  const cursor = validateCursor(o.cursor);
+    typeof record.consecutiveFailures === "number" && Number.isFinite(record.consecutiveFailures) && record.consecutiveFailures >= 0
+      ? Math.floor(record.consecutiveFailures)
+      : 0;
+  const cursor = validateCursor(record.cursor);
   return {
     slug,
     lastFetchedAt,
@@ -127,9 +129,9 @@ export async function deleteSourceState(workspaceRoot: string, slug: string): Pr
 // deterministic regardless of which fetcher finished first.
 // Used by reporting / logging code.
 export function sortBySlug<T extends { sourceSlug?: string; slug?: string }>(items: readonly T[]): T[] {
-  return [...items].sort((a, b) => {
-    const ak = a.sourceSlug ?? a.slug ?? "";
-    const bk = b.sourceSlug ?? b.slug ?? "";
-    return ak < bk ? -1 : ak > bk ? 1 : 0;
+  return [...items].sort((left, right) => {
+    const leftKey = left.sourceSlug ?? left.slug ?? "";
+    const rightKey = right.sourceSlug ?? right.slug ?? "";
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
   });
 }

--- a/server/workspace/wiki-backlinks/index.ts
+++ b/server/workspace/wiki-backlinks/index.ts
@@ -30,16 +30,16 @@ const MTIME_TOLERANCE_MS = ONE_SECOND_MS;
 
 export interface WikiBacklinksDeps {
   readdir: (dir: string) => Promise<string[]>;
-  stat: (p: string) => Promise<{ mtimeMs: number }>;
-  readFile: (p: string) => Promise<string>;
-  writeFile: (p: string, content: string) => Promise<void>;
+  stat: (filePath: string) => Promise<{ mtimeMs: number }>;
+  readFile: (filePath: string) => Promise<string>;
+  writeFile: (filePath: string, content: string) => Promise<void>;
 }
 
 const defaultDeps: WikiBacklinksDeps = {
   readdir: (dir) => fsp.readdir(dir),
-  stat: (p) => fsp.stat(p),
-  readFile: (p) => fsp.readFile(p, "utf-8"),
-  writeFile: (p, content) => fsp.writeFile(p, content, "utf-8"),
+  stat: (filePath) => fsp.stat(filePath),
+  readFile: (filePath) => fsp.readFile(filePath, "utf-8"),
+  writeFile: (filePath, content) => fsp.writeFile(filePath, content, "utf-8"),
 };
 
 export interface MaybeAppendWikiBacklinksOptions {
@@ -78,8 +78,8 @@ async function listPageFiles(pagesDir: string, deps: WikiBacklinksDeps): Promise
 async function processOneFile(pagesDir: string, fileName: string, sessionId: string, mtimeThreshold: number, deps: WikiBacklinksDeps): Promise<void> {
   const fullPath = path.join(pagesDir, fileName);
   try {
-    const st = await deps.stat(fullPath);
-    if (st.mtimeMs < mtimeThreshold) return;
+    const stats = await deps.stat(fullPath);
+    if (stats.mtimeMs < mtimeThreshold) return;
 
     const content = await deps.readFile(fullPath);
     // Compute the relative path from the wiki page's directory to

--- a/server/workspace/wiki-backlinks/sessionBacklinks.ts
+++ b/server/workspace/wiki-backlinks/sessionBacklinks.ts
@@ -73,8 +73,8 @@ function extractSessionIdsFromAppendix(appendix: string): Set<string> {
     if (!line.startsWith("- ") && !line.startsWith("* ")) continue;
     const href = extractHrefFromBullet(line);
     if (!href) continue;
-    const id = extractSessionIdFromHref(href);
-    if (id) ids.add(id);
+    const sessionId = extractSessionIdFromHref(href);
+    if (sessionId) ids.add(sessionId);
   }
   return ids;
 }
@@ -105,25 +105,25 @@ function extractSessionIdFromHref(href: string): string | null {
   if (lastSlash === -1) return null;
   const parentSegment = findPrecedingSegment(cleanHref, lastSlash);
   if (parentSegment !== "chat") return null;
-  const id = cleanHref.slice(lastSlash + 1, cleanHref.length - JSONL_SUFFIX.length);
-  if (id.length === 0 || id.includes("/")) return null;
-  return id;
+  const sessionId = cleanHref.slice(lastSlash + 1, cleanHref.length - JSONL_SUFFIX.length);
+  if (sessionId.length === 0 || sessionId.includes("/")) return null;
+  return sessionId;
 }
 
-function stripFragmentAndQuery(s: string): string {
-  let end = s.length;
-  const hash = s.indexOf("#");
+function stripFragmentAndQuery(href: string): string {
+  let end = href.length;
+  const hash = href.indexOf("#");
   if (hash !== -1) end = hash;
-  const query = s.indexOf("?");
+  const query = href.indexOf("?");
   if (query !== -1 && query < end) end = query;
-  return s.slice(0, end);
+  return href.slice(0, end);
 }
 
 // Given `.../chat/abc.jsonl` and the index of the last `/`, return
 // the segment immediately before the filename (here: `"chat"`).
-function findPrecedingSegment(s: string, lastSlash: number): string {
-  const prevSlash = s.lastIndexOf("/", lastSlash - 1);
-  return s.slice(prevSlash + 1, lastSlash);
+function findPrecedingSegment(href: string, lastSlash: number): string {
+  const prevSlash = href.lastIndexOf("/", lastSlash - 1);
+  return href.slice(prevSlash + 1, lastSlash);
 }
 
 // Insert `newBullet` at the end of the History list inside the
@@ -135,9 +135,9 @@ function appendBulletToAppendix(appendix: string, newBullet: string): string {
   // Hand-rolled rtrim so sonarjs/slow-regex stays quiet.
   let end = appendix.length;
   while (end > 0) {
-    const ch = appendix.charCodeAt(end - 1);
+    const charCode = appendix.charCodeAt(end - 1);
     // Whitespace codepoints we expect here: \n, \r, \t, space.
-    if (ch !== 10 && ch !== 13 && ch !== 9 && ch !== 32) break;
+    if (charCode !== 10 && charCode !== 13 && charCode !== 9 && charCode !== 32) break;
     end--;
   }
   return `${appendix.slice(0, end)}\n${newBullet}\n`;


### PR DESCRIPTION
## Summary
- 144 → 70 の id-length warnings を削減 (server/ 配下の single/double-letter locals を descriptive 名に)
- 純粋 refactor、挙動変更なし
- 外部 API / JSONL / JSON ファイル shape は保持 (key のみの rename で済む箇所は computed-property ではなく \`{ id: value }\` のまま)

## Items to Confirm / Review
- `workspaceRoot` / `filePath` / `itemId` などの命名が各 domain で一貫しているか
- fetcher 系 (arxiv/githubIssues/githubReleases) で \`ts\` → 文脈別名 (\`publishedMs\`/\`updatedMs\`/\`parsed\`) への置き換えが適切か
- `robots.ts` の `ua` → `agent` リネーム (RFC 仕様のパラメータ名と少し違うが、コード内の変数としては agent の方が読める)

## 変更ファイル (22)

### I/O helpers
- `todos-io.ts`, `html-io.ts`, `scheduler-io.ts`, `user-tasks-io.ts`: `r` → `workspaceRoot`
- `image-store.ts`: `id` → `imageId`
- `naming.ts`: `id` → `suffix`
- `spreadsheet-store.ts`: `id` → `sheetId`
- `journal-io.ts`: `md` → `markdown`
- `atomic.ts`: `from`/`to` → `fromPath`/`toPath`, `ms` → `millis`, `r` → `resolve`

### Sources
- `robots.ts`: `ua` → `agent`, `n` → `seconds`, `g` → `group`, `re` → `regex`
- `sourceState.ts`: `o` → `record`; sort compare `a`/`b`/`ak`/`bk` → `left`/`right`/`leftKey`/`rightKey`
- `pipeline/index.ts`: `ms`/`d`/`y`/`m` → `millis`/`date`/`year`/`month`
- `pipeline/plan.ts`: `a`/`b` → `left`/`right`, `ts` → `parsed`
- `classifier.ts`: `o` → `record`, `t` → `title`, `s` → `summary`
- `fetchers/arxiv.ts`, `githubIssues.ts`, `githubReleases.ts`: `id` → `itemId`/`issueId`/`releaseId`, `ts` → `publishedMs`/`updatedMs`

### API routes
- `scheduler.ts`: `id` → `taskId`, `t` → `task`/`candidate`
- `schedulerHandlers.ts`: sort compare `a`/`b` → `left`/`right`, `k`/`v` → `key`/`value`

### Wiki backlinks
- `index.ts`: `p` → `filePath`, `st` → `stats`
- `sessionBacklinks.ts`: `id` → `sessionId`, `s` → `href`, `ch` → `charCode`

### MCP tools
- `mcp-tools/x.ts`: `e` → `err`, `u` → `user`, `l` → `line`

## Test plan
- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors (70 id-length warnings 残存、別 batch で対応)
- [x] `yarn typecheck` — pass
- [x] `yarn build` — pass
- [x] `yarn test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine server-side code readability by renaming short or ambiguous local identifiers to more descriptive names across workspace, sources, API routes, file utilities, and MCP tools, without changing behavior or external data shapes.

Enhancements:
- Improve clarity of wiki backlinks processing, scheduler handlers, robots.txt parsing, and source state utilities by replacing single-letter or ambiguous locals with descriptive names.
- Standardize identifier naming for IDs and timestamps in source fetchers (arXiv, GitHub issues, GitHub releases) and pipeline planning helpers for more self-documenting code.
- Make file I/O helpers and storage utilities (todos, HTML, scheduler items, user tasks, images, spreadsheets, journal index, atomic rename) use clearer parameter names like workspaceRoot, filePath, and specific ID suffixes.
- Tighten naming and iteration variable semantics in classifier and MCP X tools to better reflect their roles while preserving existing logic and APIs.