### PR TITLE
chore: enable id-length warn in test/e2e; rename short identifiers

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -89,7 +89,7 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
       // GET /api/sessions/:id
       if (method !== "GET") return route.fallback();
       const id = route.request().url().split("/api/sessions/").pop() ?? "";
-      const match = sessions.find((s) => s.id === id);
+      const match = sessions.find((session) => session.id === id);
       if (match) {
         return route.fulfill({ json: makeSessionEntries(match.id) });
       }

--- a/e2e/fixtures/todos-mutable.ts
+++ b/e2e/fixtures/todos-mutable.ts
@@ -85,7 +85,7 @@ export function mockSlugifyColumnId(label: string): string {
 export async function setupMutableTodoMocks(page: Page, options: MutableTodoOptions = {}): Promise<MutableTodoState> {
   const state: MutableTodoState = {
     items: (options.items ?? TODO_ITEMS).map((i) => ({ ...i })),
-    columns: (options.columns ?? TODO_COLUMNS).map((c) => ({ ...c })),
+    columns: (options.columns ?? TODO_COLUMNS).map((col) => ({ ...col })),
   };
 
   const buildResponse = (extra?: Record<string, unknown>) => ({

--- a/e2e/tests/chat-flow.spec.ts
+++ b/e2e/tests/chat-flow.spec.ts
@@ -31,12 +31,12 @@ function urlEndsWith(suffix: string): (url: URL) => boolean {
 async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Promise<void> {
   await page.routeWebSocket(
     (url) => url.pathname.startsWith("/ws/pubsub"),
-    (ws) => {
+    (webSocket) => {
       // Send the engine.io OPEN packet immediately so the socket.io
       // client can transition from "connecting" to "connected" and
       // start emitting `subscribe` events. Values are placeholders —
       // the client only inspects `sid` and the timing fields.
-      ws.send(
+      webSocket.send(
         "0" +
           JSON.stringify({
             sid: "mock-sid",
@@ -47,15 +47,15 @@ async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Prom
           }),
       );
 
-      ws.onMessage((msg) => {
+      webSocket.onMessage((msg) => {
         const text = String(msg);
         if (text === "2") {
-          ws.send("3");
+          webSocket.send("3");
           return;
         }
         // Client CONNECT to default namespace.
         if (text === "40") {
-          ws.send("40" + JSON.stringify({ sid: "mock-socket-sid" }));
+          webSocket.send("40" + JSON.stringify({ sid: "mock-socket-sid" }));
           return;
         }
         // Event: `42["subscribe", "session.…"]`.
@@ -74,9 +74,9 @@ async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Prom
         const channel = arg;
         setTimeout(() => {
           for (const event of events) {
-            ws.send("42" + JSON.stringify(["data", { channel, data: event }]));
+            webSocket.send("42" + JSON.stringify(["data", { channel, data: event }]));
           }
-          ws.send("42" + JSON.stringify(["data", { channel, data: { type: "session_finished" } }]));
+          webSocket.send("42" + JSON.stringify(["data", { channel, data: { type: "session_finished" } }]));
         }, 50);
       });
     },

--- a/e2e/tests/fetch-error-surfaces.spec.ts
+++ b/e2e/tests/fetch-error-surfaces.spec.ts
@@ -33,7 +33,9 @@ test.describe("fetch failure → inline error banner (#280)", () => {
 
     await page.goto("/chat");
     // Arrange: wait for the failing GET to land before asserting on UI.
-    const failedGet = page.waitForResponse((r) => r.url().includes("/api/config") && r.request().method() === "GET" && r.status() === 500);
+    const failedGet = page.waitForResponse(
+      (response) => response.url().includes("/api/config") && response.request().method() === "GET" && response.status() === 500,
+    );
     await page.locator('[data-testid="settings-btn"]').click();
     await failedGet;
 
@@ -68,7 +70,7 @@ test.describe("fetch failure → inline error banner (#280)", () => {
     await page.goto("/chat");
 
     // Open the history popup — this is what calls fetchSessions().
-    const failedGet = page.waitForResponse((r) => r.url().includes("/api/sessions") && r.request().method() === "GET" && r.status() === 500);
+    const failedGet = page.waitForResponse((resp) => resp.url().includes("/api/sessions") && resp.request().method() === "GET" && resp.status() === 500);
     await page.locator('[data-testid="history-btn"]').click();
     await failedGet;
 

--- a/e2e/tests/ime-enter.spec.ts
+++ b/e2e/tests/ime-enter.spec.ts
@@ -15,18 +15,18 @@ import { chatInput, fillChatInput } from "../fixtures/chat";
 
 // Dispatch a composition event on the textarea.
 async function dispatchComposition(textarea: ReturnType<typeof chatInput>, type: "compositionstart" | "compositionend") {
-  await textarea.evaluate((el, t) => el.dispatchEvent(new CompositionEvent(t, { bubbles: true })), type);
+  await textarea.evaluate((elem, eventType) => elem.dispatchEvent(new CompositionEvent(eventType, { bubbles: true })), type);
 }
 
 // Dispatch a keydown Enter on the textarea.
 async function dispatchEnterKeydown(textarea: ReturnType<typeof chatInput>, opts: { isComposing?: boolean } = {}) {
   await textarea.evaluate(
-    (el, o) =>
-      el.dispatchEvent(
+    (elem, options) =>
+      elem.dispatchEvent(
         new KeyboardEvent("keydown", {
           key: "Enter",
           code: "Enter",
-          isComposing: o.isComposing ?? false,
+          isComposing: options.isComposing ?? false,
           bubbles: true,
           cancelable: true,
         }),
@@ -37,8 +37,8 @@ async function dispatchEnterKeydown(textarea: ReturnType<typeof chatInput>, opts
 
 // Dispatch a Shift+Enter keydown on the textarea.
 async function dispatchShiftEnterKeydown(textarea: ReturnType<typeof chatInput>) {
-  await textarea.evaluate((el) =>
-    el.dispatchEvent(
+  await textarea.evaluate((elem) =>
+    elem.dispatchEvent(
       new KeyboardEvent("keydown", {
         key: "Enter",
         code: "Enter",

--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -326,7 +326,7 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
 
   test("clicking Delete fires DELETE /api/skills/:name and removes the row", async ({ page }) => {
     // Auto-accept the native confirm() dialog the View shows.
-    page.on("dialog", (d) => d.accept());
+    page.on("dialog", (dialog) => dialog.accept());
 
     let deletedName: string | null = null;
     await page.route(

--- a/e2e/tests/streaming-autoscroll.spec.ts
+++ b/e2e/tests/streaming-autoscroll.spec.ts
@@ -35,17 +35,17 @@ function buildStreamingEvents(chunkCount: number, chunkBody: string) {
 
 // Relay a sequence of pub/sub events to the mocked WebSocket with a
 // small gap between each send so Vue re-renders between chunks.
-async function streamEventsToSocket(ws: { send: (data: string) => void }, channel: string, events: readonly unknown[]): Promise<void> {
+async function streamEventsToSocket(webSocket: { send: (data: string) => void }, channel: string, events: readonly unknown[]): Promise<void> {
   for (const event of events) {
-    ws.send("42" + JSON.stringify(["data", { channel, data: event }]));
-    await new Promise((r) => setTimeout(r, 20));
+    webSocket.send("42" + JSON.stringify(["data", { channel, data: event }]));
+    await new Promise((resolve) => setTimeout(resolve, 20));
   }
-  ws.send("42" + JSON.stringify(["data", { channel, data: { type: "session_finished" } }]));
+  webSocket.send("42" + JSON.stringify(["data", { channel, data: { type: "session_finished" } }]));
 }
 
-function handleSocketFrame(text: string, ws: { send: (data: string) => void }, events: readonly unknown[]): void {
-  if (text === "2") return ws.send("3");
-  if (text === "40") return ws.send("40" + JSON.stringify({ sid: "mock-socket-sid" }));
+function handleSocketFrame(text: string, webSocket: { send: (data: string) => void }, events: readonly unknown[]): void {
+  if (text === "2") return webSocket.send("3");
+  if (text === "40") return webSocket.send("40" + JSON.stringify({ sid: "mock-socket-sid" }));
   if (!text.startsWith("42")) return;
   let parsed: unknown;
   try {
@@ -56,14 +56,14 @@ function handleSocketFrame(text: string, ws: { send: (data: string) => void }, e
   if (!Array.isArray(parsed)) return;
   const [name, arg] = parsed as [string, unknown];
   if (name !== "subscribe" || typeof arg !== "string" || !arg.startsWith("session.")) return;
-  void streamEventsToSocket(ws, arg, events);
+  void streamEventsToSocket(webSocket, arg, events);
 }
 
 async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Promise<void> {
   await page.routeWebSocket(
     (url) => url.pathname.startsWith("/ws/pubsub"),
-    (ws) => {
-      ws.send(
+    (webSocket) => {
+      webSocket.send(
         "0" +
           JSON.stringify({
             sid: "mock-sid",
@@ -73,7 +73,7 @@ async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Prom
             maxPayload: 1_000_000,
           }),
       );
-      ws.onMessage((msg) => handleSocketFrame(String(msg), ws, events));
+      webSocket.onMessage((msg) => handleSocketFrame(String(msg), webSocket, events));
     },
   );
 
@@ -95,7 +95,7 @@ async function waitForScrollHeightStable(page: Page, testId: string, opts: { sam
   let last = -1;
   let stable = 0;
   while (Date.now() < deadline) {
-    const current = await page.getByTestId(testId).evaluate((el) => el.scrollHeight);
+    const current = await page.getByTestId(testId).evaluate((elem) => elem.scrollHeight);
     if (current === last && current > 0) {
       stable++;
       if (stable >= 2) return;
@@ -109,10 +109,10 @@ async function waitForScrollHeightStable(page: Page, testId: string, opts: { sam
 
 /** Read scrollTop + scrollHeight + clientHeight from a scroll container. */
 async function scrollMetrics(page: Page, testId: string): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
-  return page.getByTestId(testId).evaluate((el) => ({
-    scrollTop: el.scrollTop,
-    scrollHeight: el.scrollHeight,
-    clientHeight: el.clientHeight,
+  return page.getByTestId(testId).evaluate((elem) => ({
+    scrollTop: elem.scrollTop,
+    scrollHeight: elem.scrollHeight,
+    clientHeight: elem.clientHeight,
   }));
 }
 

--- a/e2e/tests/todo-columns.spec.ts
+++ b/e2e/tests/todo-columns.spec.ts
@@ -12,20 +12,20 @@ async function setupTodoMocks(page: Page): Promise<void> {
       if (method === "POST") {
         const label = typeof body.label === "string" && body.label.length > 0 ? body.label : "New Column";
         const baseId = mockSlugifyColumnId(label);
-        const existing = new Set(state.columns.map((c) => c.id));
+        const existing = new Set(state.columns.map((col) => col.id));
         let newId = baseId;
-        let n = 2;
-        while (existing.has(newId)) newId = `${baseId}_${n++}`;
+        let num = 2;
+        while (existing.has(newId)) newId = `${baseId}_${num++}`;
         return {
           columns: [...state.columns, { id: newId, label }],
         };
       }
       if (method === "DELETE" && id) {
-        return { columns: state.columns.filter((c) => c.id !== id) };
+        return { columns: state.columns.filter((col) => col.id !== id) };
       }
       if (method === "PATCH" && id) {
         return {
-          columns: state.columns.map((c) => (c.id === id ? { ...c, label: "Renamed" } : c)),
+          columns: state.columns.map((col) => (col.id === id ? { ...col, label: "Renamed" } : col)),
         };
       }
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,7 +73,11 @@ export default [
             "_",
             "i",
             "j",
+            "id",
             "ok",
+            "md",
+            "ms",
+            "it",
             "fs",
             "os"
           ],
@@ -150,10 +154,6 @@ export default [
       // `no-explicit-any` at `error` in production code; demote to
       // warn inside tests.
       "@typescript-eslint/no-explicit-any": "warn",
-      // Tests use lots of throwaway names (`a`, `b` in sort compare,
-      // `{ id: "a" }` in fixtures, `s` in session tests, etc.) that
-      // are fine in test context and would be noise to rename.
-      "id-length": "off",
     },
   },
   {

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -68,7 +68,7 @@ describe("buildCliArgs", () => {
     assert.ok(args.includes("--output-format"));
     assert.ok(args.includes("--input-format"));
     // stream-json is used for both input and output formats.
-    assert.equal(args.filter((a) => a === "stream-json").length, 2, "stream-json should appear twice (input + output format)");
+    assert.equal(args.filter((arg) => arg === "stream-json").length, 2, "stream-json should appear twice (input + output format)");
     assert.ok(args.includes("--verbose"));
     assert.ok(args.includes("--system-prompt"));
     assert.ok(args.includes("You are helpful"));
@@ -274,7 +274,7 @@ describe("buildDockerSpawnArgs", () => {
       workspacePath: "C:\\Users\\me\\ws",
     });
     assert.ok(
-      args.some((a) => a.startsWith("C:/Users/me/ws:")),
+      args.some((arg) => arg.startsWith("C:/Users/me/ws:")),
       "expected forward-slash conversion",
     );
   });
@@ -297,8 +297,8 @@ describe("buildDockerSpawnArgs", () => {
 
   it("defaults to no sandbox auth args when omitted", async () => {
     const args = buildDockerSpawnArgs(baseParams());
-    assert.ok(!args.some((a) => a.includes(".config/gh")));
-    assert.ok(!args.some((a) => a.includes("SSH_AUTH_SOCK")));
+    assert.ok(!args.some((arg) => arg.includes(".config/gh")));
+    assert.ok(!args.some((arg) => arg.includes("SSH_AUTH_SOCK")));
   });
 });
 

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -8,8 +8,8 @@ import { WORKSPACE_FILES } from "../../server/workspace/paths.js";
 import { dirname } from "path";
 import type { Role } from "../../src/config/roles.js";
 
-function ensureDir(p: string): void {
-  mkdirSync(p, { recursive: true });
+function ensureDir(dirPath: string): void {
+  mkdirSync(dirPath, { recursive: true });
 }
 function writeFileAt(workspace: string, rel: string, content: string): void {
   const abs = join(workspace, rel);

--- a/test/agent/test_mcp_docker_smoke.ts
+++ b/test/agent/test_mcp_docker_smoke.ts
@@ -54,7 +54,7 @@ const canRunDocker = isDockerAvailable() && isSandboxImageAvailable();
 
 describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
   it("responds to initialize + tools/list inside Docker container", async () => {
-    const toDockerPath = (p: string): string => p.replace(/\\/g, "/");
+    const toDockerPath = (filePath: string): string => filePath.replace(/\\/g, "/");
 
     const dockerArgs = [
       "run",
@@ -132,15 +132,15 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
         clearTimeout(timer);
         const parsed: JsonRpcResponse[] = stdout
           .split("\n")
-          .filter((l) => l.trim())
-          .map((l) => {
+          .filter((line) => line.trim())
+          .map((line) => {
             try {
-              return JSON.parse(l) as JsonRpcResponse;
+              return JSON.parse(line) as JsonRpcResponse;
             } catch {
               return null;
             }
           })
-          .filter((r): r is JsonRpcResponse => r !== null);
+          .filter((resp): resp is JsonRpcResponse => resp !== null);
 
         if (parsed.length === 0 && code !== 0) {
           reject(new Error(`Docker MCP server exited ${code}. stderr:\n${stderr.slice(0, 1000)}`));
@@ -150,14 +150,14 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
       });
     });
 
-    const initResp = responses.find((r) => r.id === 1);
+    const initResp = responses.find((resp) => resp.id === 1);
     assert.ok(initResp?.result, "Missing initialize response");
     assert.equal(initResp.result.serverInfo?.name, "mulmoclaude");
 
-    const toolsResp = responses.find((r) => r.id === 2);
+    const toolsResp = responses.find((resp) => resp.id === 2);
     assert.ok(toolsResp?.result?.tools, "Missing tools/list response");
 
-    const toolNames = toolsResp.result.tools.map((t) => t.name);
+    const toolNames = toolsResp.result.tools.map((tool) => tool.name);
     assert.ok(toolNames.includes("presentMulmoScript"), `presentMulmoScript not in tools: ${toolNames.join(", ")}`);
     assert.ok(toolNames.includes("manageTodoList"), `manageTodoList not in tools: ${toolNames.join(", ")}`);
   });

--- a/test/agent/test_mcp_smoke.ts
+++ b/test/agent/test_mcp_smoke.ts
@@ -66,15 +66,15 @@ function sendAndReceive(lines: string[], env: Record<string, string>): Promise<J
       clearTimeout(timer);
       const responses: JsonRpcResponse[] = stdout
         .split("\n")
-        .filter((l) => l.trim())
-        .map((l) => {
+        .filter((line) => line.trim())
+        .map((line) => {
           try {
-            return JSON.parse(l) as JsonRpcResponse;
+            return JSON.parse(line) as JsonRpcResponse;
           } catch {
             return null;
           }
         })
-        .filter((r): r is JsonRpcResponse => r !== null);
+        .filter((resp): resp is JsonRpcResponse => resp !== null);
 
       if (code !== 0) {
         reject(new Error(`MCP server exited with code ${code}. stderr: ${stderr.slice(0, 500)}`));
@@ -124,19 +124,19 @@ describe("MCP server subprocess smoke test", () => {
     assert.ok(responses.length >= 2, `Expected >= 2 responses, got ${responses.length}: ${JSON.stringify(responses)}`);
 
     // Initialize response
-    const initResp = responses.find((r) => r.id === 1);
+    const initResp = responses.find((resp) => resp.id === 1);
     assert.ok(initResp, "Missing initialize response");
     assert.ok(initResp.result, "Initialize response has no result");
     assert.equal(initResp.result.serverInfo?.name, "mulmoclaude");
 
     // tools/list response
-    const toolsResp = responses.find((r) => r.id === 2);
+    const toolsResp = responses.find((resp) => resp.id === 2);
     assert.ok(toolsResp, "Missing tools/list response");
     assert.ok(toolsResp.result?.tools, "tools/list has no tools array");
     assert.ok(Array.isArray(toolsResp.result.tools), "tools is not an array");
 
     // The tools we requested via PLUGIN_NAMES should be present.
-    const toolNames = toolsResp.result.tools.map((t: { name: string }) => t.name);
+    const toolNames = toolsResp.result.tools.map((tool: { name: string }) => tool.name);
     assert.ok(toolNames.includes("manageTodoList"), `manageTodoList not in tools: ${toolNames.join(", ")}`);
     assert.ok(toolNames.includes("presentMulmoScript"), `presentMulmoScript not in tools: ${toolNames.join(", ")}`);
     assert.ok(toolNames.includes("manageWiki"), `manageWiki not in tools: ${toolNames.join(", ")}`);

--- a/test/agent/test_resumeFailover.ts
+++ b/test/agent/test_resumeFailover.ts
@@ -11,7 +11,7 @@ function jsonlLine(source: "user" | "assistant", message: string): string {
 }
 
 function jsonlFrom(entries: { source: "user" | "assistant"; message: string }[]): string {
-  return entries.map((e) => jsonlLine(e.source, e.message)).join("\n") + "\n";
+  return entries.map((entry) => jsonlLine(entry.source, entry.message)).join("\n") + "\n";
 }
 
 describe("isStaleSessionError", () => {

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -92,7 +92,7 @@ describe("resolveMountNames", () => {
     const home = makeFixtureHome({ gh: true, gitconfig: true });
     const out = resolveMountNames(["gitconfig", "", "gh"], buildAllowedConfigMounts(home));
     assert.deepEqual(
-      out.resolved.map((r) => r.name),
+      out.resolved.map((mount) => mount.name),
       ["gitconfig", "gh"],
     );
   });
@@ -117,40 +117,40 @@ describe("configMountArgs", () => {
 
 describe("sshAgentForwardArgs", () => {
   it("no-op when disabled", () => {
-    const r = sshAgentForwardArgs(false, "/tmp/anything");
-    assert.deepEqual(r, { args: [], skippedReason: null });
+    const result = sshAgentForwardArgs(false, "/tmp/anything");
+    assert.deepEqual(result, { args: [], skippedReason: null });
   });
 
   it("uses Docker Desktop magic socket on macOS", () => {
-    const r = sshAgentForwardArgs(true, "/tmp/irrelevant", "darwin");
-    assert.equal(r.skippedReason, null);
-    assert.deepEqual(r.args, ["-v", `/run/host-services/ssh-auth.sock:${SSH_AGENT_CONTAINER_SOCK}`, "-e", `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`]);
+    const result = sshAgentForwardArgs(true, "/tmp/irrelevant", "darwin");
+    assert.equal(result.skippedReason, null);
+    assert.deepEqual(result.args, ["-v", `/run/host-services/ssh-auth.sock:${SSH_AGENT_CONTAINER_SOCK}`, "-e", `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`]);
   });
 
   it("macOS path ignores SSH_AUTH_SOCK value entirely", () => {
-    const r = sshAgentForwardArgs(true, undefined, "darwin");
-    assert.equal(r.skippedReason, null);
-    assert.equal(r.args.length, 4);
+    const result = sshAgentForwardArgs(true, undefined, "darwin");
+    assert.equal(result.skippedReason, null);
+    assert.equal(result.args.length, 4);
   });
 
   it("reports SSH_AUTH_SOCK missing on Linux", () => {
-    const r = sshAgentForwardArgs(true, undefined, "linux");
-    assert.deepEqual(r.args, []);
-    assert.match(r.skippedReason ?? "", /not set/);
+    const result = sshAgentForwardArgs(true, undefined, "linux");
+    assert.deepEqual(result.args, []);
+    assert.match(result.skippedReason ?? "", /not set/);
   });
 
   it("reports socket path missing on disk (Linux)", () => {
-    const r = sshAgentForwardArgs(true, "/tmp/definitely-not-a-real-sock", "linux");
-    assert.deepEqual(r.args, []);
-    assert.match(r.skippedReason ?? "", /not found/);
+    const result = sshAgentForwardArgs(true, "/tmp/definitely-not-a-real-sock", "linux");
+    assert.deepEqual(result.args, []);
+    assert.match(result.skippedReason ?? "", /not found/);
   });
 
   it("binds socket and sets SSH_AUTH_SOCK when sock exists (Linux)", () => {
     const fake = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "sock-")), "agent.sock");
     fs.writeFileSync(fake, "");
-    const r = sshAgentForwardArgs(true, fake, "linux");
-    assert.equal(r.skippedReason, null);
+    const result = sshAgentForwardArgs(true, fake, "linux");
+    assert.equal(result.skippedReason, null);
     const expectedHostPath = fake.replace(/\\/g, "/");
-    assert.deepEqual(r.args, ["-v", `${expectedHostPath}:${SSH_AGENT_CONTAINER_SOCK}`, "-e", `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`]);
+    assert.deepEqual(result.args, ["-v", `${expectedHostPath}:${SSH_AGENT_CONTAINER_SOCK}`, "-e", `SSH_AUTH_SOCK=${SSH_AGENT_CONTAINER_SOCK}`]);
   });
 });

--- a/test/agent/test_streamParser.ts
+++ b/test/agent/test_streamParser.ts
@@ -56,9 +56,9 @@ describe("createStreamParser — delta streaming", () => {
       message: { content: [{ type: "text", text: "streamed" }] },
     });
     // Should have status but NO text (filtered as duplicate)
-    const textEvents = events.filter((e) => e.type === EVENT_TYPES.text);
+    const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 0);
-    assert.ok(events.some((e) => e.type === EVENT_TYPES.status));
+    assert.ok(events.some((evt) => evt.type === EVENT_TYPES.status));
   });
 
   it("suppresses result text after deltas were streamed", () => {
@@ -89,7 +89,7 @@ describe("createStreamParser — no deltas (fallback)", () => {
       type: "assistant",
       message: { content: [{ type: "text", text: "direct reply" }] },
     });
-    const textEvents = events.filter((e) => e.type === EVENT_TYPES.text);
+    const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 1);
     assert.equal(textEvents[0].message, "direct reply");
   });
@@ -105,7 +105,7 @@ describe("createStreamParser — no deltas (fallback)", () => {
       result: "from block",
     });
     // No text event from result (already emitted via assistant)
-    const textEvents = events.filter((e) => e.type === EVENT_TYPES.text);
+    const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 0);
   });
 
@@ -144,7 +144,7 @@ describe("createStreamParser — multi-turn reset", () => {
       type: "assistant",
       message: { content: [{ type: "text", text: "turn2" }] },
     });
-    const textEvents = events.filter((e) => e.type === EVENT_TYPES.text);
+    const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 1);
     assert.equal(textEvents[0].message, "turn2");
   });

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -297,7 +297,7 @@ describe("indexSession — manifest upsert and ordering", () => {
 
     const manifest = await readManifest(workspace);
     assert.deepEqual(
-      manifest.entries.map((e) => e.id),
+      manifest.entries.map((entry) => entry.id),
       ["newest", "middle", "oldest"],
     );
   });

--- a/test/chat-index/test_summarizer.ts
+++ b/test/chat-index/test_summarizer.ts
@@ -68,8 +68,8 @@ describe("extractText", () => {
 
 describe("truncate", () => {
   it("passes short input through unchanged", () => {
-    const s = "hello world";
-    assert.equal(truncate(s), s);
+    const str = "hello world";
+    assert.equal(truncate(str), str);
   });
 
   it("keeps head + tail for long input", () => {

--- a/test/composables/test_useChatScroll.ts
+++ b/test/composables/test_useChatScroll.ts
@@ -21,7 +21,7 @@ import { makeTextResult } from "../../src/utils/tools/result.js";
 function makeFakeScrollEl() {
   const writes: number[] = [];
   let scrollTop = 0;
-  const el = {
+  const element = {
     get scrollTop() {
       return scrollTop;
     },
@@ -33,7 +33,7 @@ function makeFakeScrollEl() {
   };
   // The composable expects an HTMLDivElement; the fake only needs
   // scrollTop/scrollHeight, so the cast is safe in test scope.
-  return { el: el as unknown as HTMLDivElement, writes };
+  return { el: element as unknown as HTMLDivElement, writes };
 }
 
 describe("useChatScroll — streaming auto-scroll", () => {

--- a/test/composables/test_useFreshPluginData.ts
+++ b/test/composables/test_useFreshPluginData.ts
@@ -51,8 +51,8 @@ describe("refreshOnce (core of useFreshPluginData)", () => {
     const opts: UseFreshPluginDataOptions<number[]> = {
       endpoint: () => "/api/todos",
       extract: (json) => {
-        const v = (json as { data?: { items?: number[] } }).data?.items;
-        return Array.isArray(v) ? v : null;
+        const val = (json as { data?: { items?: number[] } }).data?.items;
+        return Array.isArray(val) ? val : null;
       },
       apply: (data) => {
         appliedWith.push(data);
@@ -154,8 +154,8 @@ describe("refreshOnce (core of useFreshPluginData)", () => {
       {
         endpoint: () => "/api/todos",
         extract: (json) => {
-          const v = (json as { data?: { items?: number[] } }).data?.items;
-          return Array.isArray(v) ? v : null;
+          const val = (json as { data?: { items?: number[] } }).data?.items;
+          return Array.isArray(val) ? val : null;
         },
         apply: (data) => appliedWith.push(data),
       },
@@ -172,8 +172,8 @@ describe("refreshOnce (core of useFreshPluginData)", () => {
       {
         endpoint: () => "/api/todos",
         extract: (json) => {
-          const v = (json as { data?: { items?: Array<{ id: string }> } }).data?.items;
-          return Array.isArray(v) ? v : null;
+          const val = (json as { data?: { items?: Array<{ id: string }> } }).data?.items;
+          return Array.isArray(val) ? val : null;
         },
         apply: (data) => appliedWith.push(data),
       },

--- a/test/composables/test_useImeAwareEnter.ts
+++ b/test/composables/test_useImeAwareEnter.ts
@@ -13,16 +13,16 @@ interface TestKeyboardEvent {
 }
 
 function fakeKeydown(opts: { key: string; shiftKey?: boolean; isComposing?: boolean }): TestKeyboardEvent {
-  const ev: TestKeyboardEvent = {
+  const evt: TestKeyboardEvent = {
     key: opts.key,
     shiftKey: opts.shiftKey ?? false,
     isComposing: opts.isComposing ?? false,
     defaultPrevented: false,
     preventDefault() {
-      ev.defaultPrevented = true;
+      evt.defaultPrevented = true;
     },
   };
-  return ev;
+  return evt;
 }
 
 function setup() {
@@ -49,26 +49,26 @@ function setup() {
 describe("useImeAwareEnter", () => {
   it("plain Enter sends and prevents default newline", () => {
     const { handlers, sends } = setup();
-    const ev = fakeKeydown({ key: "Enter" });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "Enter" });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 1);
-    assert.equal(ev.defaultPrevented, true);
+    assert.equal(keyEvent.defaultPrevented, true);
   });
 
   it("Shift+Enter does not send and allows default newline", () => {
     const { handlers, sends } = setup();
-    const ev = fakeKeydown({ key: "Enter", shiftKey: true });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "Enter", shiftKey: true });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 0);
-    assert.equal(ev.defaultPrevented, false);
+    assert.equal(keyEvent.defaultPrevented, false);
   });
 
   it("non-Enter keys are ignored", () => {
     const { handlers, sends } = setup();
-    const ev = fakeKeydown({ key: "a" });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "a" });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 0);
-    assert.equal(ev.defaultPrevented, false);
+    assert.equal(keyEvent.defaultPrevented, false);
   });
 
   it("Chrome-order: keydown with isComposing=true does not send", () => {
@@ -126,18 +126,18 @@ describe("useImeAwareEnter", () => {
     // composition without isComposing=true, our internal flag catches it.
     const { handlers, sends } = setup();
     handlers.onCompositionStart();
-    const ev = fakeKeydown({ key: "Enter", isComposing: false });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "Enter", isComposing: false });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 0);
-    assert.equal(ev.defaultPrevented, true);
+    assert.equal(keyEvent.defaultPrevented, true);
   });
 
   it("onBlur clears state so a stale composition doesn't wedge the textarea", () => {
     const { handlers, sends } = setup();
     handlers.onCompositionStart();
     handlers.onBlur();
-    const ev = fakeKeydown({ key: "Enter" });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "Enter" });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 1);
   });
 
@@ -148,8 +148,8 @@ describe("useImeAwareEnter", () => {
     handlers.onBlur();
     // If the timestamp weren't cleared, this Enter would still be
     // within the race window and get suppressed.
-    const ev = fakeKeydown({ key: "Enter" });
-    handlers.onKeydown(ev as unknown as KeyboardEvent);
+    const keyEvent = fakeKeydown({ key: "Enter" });
+    handlers.onKeydown(keyEvent as unknown as KeyboardEvent);
     assert.equal(sends.length, 1);
   });
 });

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -138,10 +138,10 @@ describe("useSessionHistory — cursor-aware incremental fetch (#205)", () => {
     );
     await fetchSessions();
 
-    const ids = sessions.value.map((s) => s.id);
+    const ids = sessions.value.map((session) => session.id);
     assert.deepEqual(ids.sort(), ["a", "b", "c"].sort(), "diff should upsert a/c while preserving untouched b");
-    const a = sessions.value.find((s) => s.id === "a");
-    assert.equal(a?.preview, "updated", "a must have the diff's fields");
+    const sessionA = sessions.value.find((session) => session.id === "a");
+    assert.equal(sessionA?.preview, "updated", "a must have the diff's fields");
   });
 
   it("removes cached rows whose id appears in deletedIds", async () => {
@@ -152,7 +152,7 @@ describe("useSessionHistory — cursor-aware incremental fetch (#205)", () => {
 
     stubFetch(async () => mockJsonResponse(200, envelope([], "v1:2", ["b"])));
     await fetchSessions();
-    const ids = sessions.value.map((s) => s.id).sort();
+    const ids = sessions.value.map((session) => session.id).sort();
     assert.deepEqual(ids, ["a", "c"]);
   });
 });

--- a/test/config/test_toolNames.ts
+++ b/test/config/test_toolNames.ts
@@ -8,9 +8,9 @@ describe("TOOL_NAMES", () => {
     // set of values has no duplicates.
     const values = Object.values(TOOL_NAMES);
     assert.equal(new Set(values).size, values.length);
-    for (const v of values) {
-      assert.equal(typeof v, "string");
-      assert.ok(v.length > 0);
+    for (const val of values) {
+      assert.equal(typeof val, "string");
+      assert.ok(val.length > 0);
     }
   });
 
@@ -55,8 +55,8 @@ describe("isToolName", () => {
     const input: unknown = "manageWiki";
     if (isToolName(input)) {
       // If this compiles, the narrowing works.
-      const t: ToolName = input;
-      assert.equal(t, "manageWiki");
+      const toolName: ToolName = input;
+      assert.equal(toolName, "manageWiki");
     } else {
       assert.fail("expected narrow to succeed for a valid tool name");
     }

--- a/test/events/test_session_store.ts
+++ b/test/events/test_session_store.ts
@@ -50,33 +50,33 @@ describe("getSession / getOrCreateSession", () => {
   });
 
   it("creates a session on first call and returns it on subsequent calls", () => {
-    const a = getOrCreateSession("s1", sessionOpts());
-    assert.equal(a.chatSessionId, "s1");
-    assert.equal(a.roleId, "general");
-    assert.equal(a.isRunning, false);
-    assert.equal(a.hasUnread, false);
+    const session = getOrCreateSession("s1", sessionOpts());
+    assert.equal(session.chatSessionId, "s1");
+    assert.equal(session.roleId, "general");
+    assert.equal(session.isRunning, false);
+    assert.equal(session.hasUnread, false);
 
-    const b = getOrCreateSession("s1", sessionOpts({ roleId: "coder" }));
-    assert.strictEqual(a, b); // same object
-    assert.equal(b.roleId, "general"); // not overwritten
+    const sessionB = getOrCreateSession("s1", sessionOpts({ roleId: "coder" }));
+    assert.strictEqual(session, sessionB); // same object
+    assert.equal(sessionB.roleId, "general"); // not overwritten
   });
 
   it("updates selectedImageData and updatedAt on re-access", () => {
     getOrCreateSession("s1", sessionOpts());
-    const b = getOrCreateSession(
+    const updated = getOrCreateSession(
       "s1",
       sessionOpts({
         selectedImageData: "base64...",
         updatedAt: "2026-04-17T01:00:00Z",
       }),
     );
-    assert.equal(b.selectedImageData, "base64...");
-    assert.equal(b.updatedAt, "2026-04-17T01:00:00Z");
+    assert.equal(updated.selectedImageData, "base64...");
+    assert.equal(updated.updatedAt, "2026-04-17T01:00:00Z");
   });
 
   it("honours hasUnread option on creation", () => {
-    const s = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
-    assert.equal(s.hasUnread, true);
+    const sess = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
+    assert.equal(sess.hasUnread, true);
   });
 });
 
@@ -110,9 +110,9 @@ describe("beginRun / endRun / cancelRun", () => {
     // initSessionStore is needed for endRun to publish
     initSessionStore(stubPubSub());
     endRun("s1");
-    const s = getSession("s1")!;
-    assert.equal(s.isRunning, false);
-    assert.equal(s.hasUnread, true);
+    const sess = getSession("s1")!;
+    assert.equal(sess.isRunning, false);
+    assert.equal(sess.hasUnread, true);
   });
 
   it("cancelRun invokes the abort callback and returns true", () => {
@@ -138,28 +138,28 @@ describe("beginRun / endRun / cancelRun", () => {
 describe("markRead", () => {
   it("clears hasUnread on an in-memory session", async () => {
     initSessionStore(stubPubSub());
-    const s = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
-    assert.equal(s.hasUnread, true);
+    const sess = getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
+    assert.equal(sess.hasUnread, true);
     await markRead("s1");
-    assert.equal(s.hasUnread, false);
+    assert.equal(sess.hasUnread, false);
   });
 
   it("is a no-op when hasUnread is already false (no redundant work)", async () => {
-    const ps = stubPubSub();
-    initSessionStore(ps);
+    const pubSub = stubPubSub();
+    initSessionStore(pubSub);
     getOrCreateSession("s1", sessionOpts({ hasUnread: false }));
     await markRead("s1");
     // No sessions-changed notification should fire for a no-op
-    const sessionChanges = ps.published.filter((p) => p.channel === "sessions");
+    const sessionChanges = pubSub.published.filter((pub) => pub.channel === "sessions");
     assert.equal(sessionChanges.length, 0);
   });
 
   it("publishes a sessions-changed notification when clearing the flag", async () => {
-    const ps = stubPubSub();
-    initSessionStore(ps);
+    const pubSub = stubPubSub();
+    initSessionStore(pubSub);
     getOrCreateSession("s1", sessionOpts({ hasUnread: true }));
     await markRead("s1");
-    const sessionChanges = ps.published.filter((p) => p.channel === "sessions");
+    const sessionChanges = pubSub.published.filter((pub) => pub.channel === "sessions");
     assert.ok(sessionChanges.length > 0);
   });
 

--- a/test/events/test_task_dependencies.ts
+++ b/test/events/test_task_dependencies.ts
@@ -5,19 +5,19 @@ import { createTaskManager } from "../../server/events/task-manager/index.js";
 describe("task-manager dependsOn", () => {
   it("runs dependent task after its dependency succeeds", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
         order.push("parent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -26,18 +26,18 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     assert.deepEqual(order, ["parent", "child"]);
   });
 
   it("skips dependent task when dependency fails", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
@@ -45,7 +45,7 @@ describe("task-manager dependsOn", () => {
         throw new Error("boom");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -54,26 +54,26 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     assert.deepEqual(order, ["parent-fail"]);
   });
 
   it("skips dependent task when dependency is not due", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       // 00:01:00 — parent (every 120s) NOT due, child (every 60s) IS due
       now: () => new Date("2026-01-01T00:01:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 120_000 },
       run: async () => {
         order.push("parent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -82,7 +82,7 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     // Parent not due at 00:01:00 (120s boundary = 00:00, 00:02, ...),
     // so child is skipped even though it's due
     assert.deepEqual(order, []);
@@ -90,19 +90,19 @@ describe("task-manager dependsOn", () => {
 
   it("chains multiple dependencies in order", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "fetch",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
         order.push("fetch");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "journal",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "fetch",
@@ -110,7 +110,7 @@ describe("task-manager dependsOn", () => {
         order.push("journal");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "memory",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "journal",
@@ -119,18 +119,18 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     assert.deepEqual(order, ["fetch", "journal", "memory"]);
   });
 
   it("skips dependent when dependsOn references a nonexistent task", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "orphan",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "nonexistent",
@@ -139,18 +139,18 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     assert.deepEqual(order, []);
   });
 
   it("skips dependent when parent is disabled", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       enabled: false,
@@ -158,7 +158,7 @@ describe("task-manager dependsOn", () => {
         order.push("parent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -167,25 +167,25 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     assert.deepEqual(order, []);
   });
 
   it("independent tasks run regardless of dependent task failures", async () => {
     const order: string[] = [];
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "independent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
         order.push("independent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
@@ -193,7 +193,7 @@ describe("task-manager dependsOn", () => {
         throw new Error("boom");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -202,7 +202,7 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick();
+    await taskMgr.tick();
     // independent and parent both run (parallel), child skipped
     assert.ok(order.includes("independent"));
     assert.ok(order.includes("parent"));
@@ -214,12 +214,12 @@ describe("task-manager dependsOn", () => {
     let tickCount = 0;
     // Advance time between ticks so tickId changes
     let fakeTime = new Date("2026-01-01T00:00:00Z");
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => fakeTime,
     });
 
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
@@ -228,7 +228,7 @@ describe("task-manager dependsOn", () => {
         order.push("parent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -237,25 +237,25 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick(); // tick 1: parent succeeds → child runs
+    await taskMgr.tick(); // tick 1: parent succeeds → child runs
     assert.deepEqual(order, ["parent", "child"]);
 
     order.length = 0;
     fakeTime = new Date("2026-01-01T00:01:00Z"); // advance 1 tick
-    await tm.tick(); // tick 2: parent fails → child skipped
+    await taskMgr.tick(); // tick 2: parent fails → child skipped
     assert.deepEqual(order, []);
   });
 
   it("stale success does not leak across tick() calls in same bucket", async () => {
     const order: string[] = [];
     // Fixed time — both tick() calls resolve to the same tickId
-    const tm = createTaskManager({
+    const taskMgr = createTaskManager({
       tickMs: 60_000,
       now: () => new Date("2026-01-01T00:00:00Z"),
     });
 
     let parentEnabled = true;
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "parent",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {
@@ -263,7 +263,7 @@ describe("task-manager dependsOn", () => {
         order.push("parent");
       },
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "child",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "parent",
@@ -272,31 +272,31 @@ describe("task-manager dependsOn", () => {
       },
     });
 
-    await tm.tick(); // parent succeeds → child runs
+    await taskMgr.tick(); // parent succeeds → child runs
     assert.deepEqual(order, ["parent", "child"]);
 
     order.length = 0;
     parentEnabled = false;
-    await tm.tick(); // same tickId, but parent fails → child must NOT run
+    await taskMgr.tick(); // same tickId, but parent fails → child must NOT run
     assert.deepEqual(order, []);
   });
 
   it("includes dependsOn in listTasks output", () => {
-    const tm = createTaskManager();
-    tm.registerTask({
+    const taskMgr = createTaskManager();
+    taskMgr.registerTask({
       id: "a",
       schedule: { type: "interval", intervalMs: 60_000 },
       run: async () => {},
     });
-    tm.registerTask({
+    taskMgr.registerTask({
       id: "b",
       schedule: { type: "interval", intervalMs: 60_000 },
       dependsOn: "a",
       run: async () => {},
     });
 
-    const tasks = tm.listTasks();
-    const b = tasks.find((t) => t.id === "b");
-    assert.equal(b?.dependsOn, "a");
+    const tasks = taskMgr.listTasks();
+    const taskB = tasks.find((task) => task.id === "b");
+    assert.equal(taskB?.dependsOn, "a");
   });
 });

--- a/test/journal/test_appendOrCreate.ts
+++ b/test/journal/test_appendOrCreate.ts
@@ -15,7 +15,7 @@ function makeWorkspace(): string {
   return fs.realpathSync(dir);
 }
 
-function rm(dir: string): void {
+function rmDir(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
@@ -28,7 +28,7 @@ describe("appendOrCreateTopic — happy paths", () => {
   before(() => {
     root = makeWorkspace();
   });
-  after(() => rm(root));
+  after(() => rmDir(root));
 
   it("writes a fresh file when missing and reports 'created'", async () => {
     const outcome = await appendOrCreateTopic("topic-a", "first line", root);
@@ -68,24 +68,24 @@ describe("appendOrCreateTopic — non-ENOENT read errors", () => {
     } catch {
       /* ignore */
     }
-    rm(root);
+    rmDir(root);
   });
 
-  it("rethrows EACCES instead of clobbering an unreadable file", async (t) => {
+  it("rethrows EACCES instead of clobbering an unreadable file", async (testCtx) => {
     if (process.platform === "win32" || process.getuid?.() === 0) {
-      t.skip("requires POSIX permissions and a non-root user");
+      testCtx.skip("requires POSIX permissions and a non-root user");
       return;
     }
-    const p = topicPath(root, "locked");
-    fs.writeFileSync(p, "important content");
-    fs.chmodSync(p, 0o000);
+    const lockPath = topicPath(root, "locked");
+    fs.writeFileSync(lockPath, "important content");
+    fs.chmodSync(lockPath, 0o000);
     try {
       await assert.rejects(() => appendOrCreateTopic("locked", "would clobber", root), /EACCES|EPERM/);
-      fs.chmodSync(p, 0o644);
-      assert.equal(fs.readFileSync(p, "utf-8"), "important content");
+      fs.chmodSync(lockPath, 0o644);
+      assert.equal(fs.readFileSync(lockPath, "utf-8"), "important content");
     } finally {
       try {
-        fs.chmodSync(p, 0o644);
+        fs.chmodSync(lockPath, 0o644);
       } catch {
         /* ignore */
       }

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -274,8 +274,8 @@ describe("buildDayBuckets", () => {
 
   it("tracks the full day-set for a session that spans many dates", () => {
     const byDate = new Map<string, SessionExcerpt>();
-    for (const d of ["2026-04-10", "2026-04-11", "2026-04-12"]) {
-      byDate.set(d, mkExcerpt("s1", d));
+    for (const dateKey of ["2026-04-10", "2026-04-11", "2026-04-12"]) {
+      byDate.set(dateKey, mkExcerpt("s1", dateKey));
     }
     const plan = buildDayBuckets(new Map([["s1", byDate]]));
     assert.equal(plan.sessionToDays.get("s1")!.size, 3);
@@ -376,7 +376,7 @@ describe("computeJustCompletedSessions", () => {
     const excerpts = [mkExcerpt("s1", "hi")];
     const completed = computeJustCompletedSessions("2026-04-10", excerpts, sessionToDays, dirtyMetaById);
     assert.deepEqual(
-      completed.map((m) => m.id),
+      completed.map((meta) => meta.id),
       ["s1"],
     );
     // sessionToDays should be empty after the mutation.
@@ -408,7 +408,7 @@ describe("computeJustCompletedSessions", () => {
     const completed = computeJustCompletedSessions("2026-04-10", excerpts, sessionToDays, dirtyMetaById);
     // Only s1 completes; s2 still has 2026-04-11 pending.
     assert.deepEqual(
-      completed.map((m) => m.id),
+      completed.map((meta) => meta.id),
       ["s1"],
     );
     assert.equal(sessionToDays.has("s1"), false);

--- a/test/journal/test_indexFile.ts
+++ b/test/journal/test_indexFile.ts
@@ -147,9 +147,9 @@ describe("renderRecentDaysSection", () => {
       date: `2026-01-0${i + 1}`,
     }));
     const lines = renderRecentDaysSection(days, 3);
-    const rows = lines.filter((l) => l.startsWith("- ["));
+    const rows = lines.filter((line) => line.startsWith("- ["));
     assert.equal(rows.length, 3);
-    assert.ok(lines.some((l) => /…and 2 earlier days\./.test(l)));
+    assert.ok(lines.some((line) => /…and 2 earlier days\./.test(line)));
   });
 
   it("uses singular 'day' when exactly one is collapsed", () => {
@@ -157,13 +157,13 @@ describe("renderRecentDaysSection", () => {
       date: `2026-01-0${i + 1}`,
     }));
     const lines = renderRecentDaysSection(days, 3);
-    assert.ok(lines.some((l) => /…and 1 earlier day\./.test(l)));
+    assert.ok(lines.some((line) => /…and 1 earlier day\./.test(line)));
   });
 
   it("omits the collapsed-count footer when nothing is collapsed", () => {
     const days = [{ date: "2026-04-11" }];
     const lines = renderRecentDaysSection(days, 14);
-    assert.ok(!lines.some((l) => /earlier day/.test(l)));
+    assert.ok(!lines.some((line) => /earlier day/.test(line)));
   });
 });
 

--- a/test/journal/test_linkRewrite.ts
+++ b/test/journal/test_linkRewrite.ts
@@ -107,19 +107,19 @@ describe("rewriteMarkdownLinks", () => {
   });
 
   it("passes through plain bracketed text that is not a link", () => {
-    const out = rewriteMarkdownLinks("[not a link] followed by text", (h) => h);
+    const out = rewriteMarkdownLinks("[not a link] followed by text", (href) => href);
     assert.equal(out, "[not a link] followed by text");
   });
 
   it("handles an empty input", () => {
     assert.equal(
-      rewriteMarkdownLinks("", (h) => h),
+      rewriteMarkdownLinks("", (href) => href),
       "",
     );
   });
 
   it("handles input with no links at all", () => {
-    const out = rewriteMarkdownLinks("plain prose without links", (h) => h);
+    const out = rewriteMarkdownLinks("plain prose without links", (href) => href);
     assert.equal(out, "plain prose without links");
   });
 

--- a/test/journal/test_paths.ts
+++ b/test/journal/test_paths.ts
@@ -3,33 +3,33 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { summariesRoot, dailyPathFor, topicPathFor, archivedTopicPathFor, toIsoDate, slugify } from "../../server/workspace/journal/paths.js";
 
-const WS = "/fake/workspace";
+const WORKSPACE = "/fake/workspace";
 
 describe("summariesRoot", () => {
   it("joins workspace root with the summaries dir", () => {
-    assert.equal(summariesRoot(WS), path.join(WS, "conversations", "summaries"));
+    assert.equal(summariesRoot(WORKSPACE), path.join(WORKSPACE, "conversations", "summaries"));
   });
 });
 
 describe("dailyPathFor", () => {
   it("builds summaries/daily/YYYY/MM/DD.md", () => {
-    assert.equal(dailyPathFor(WS, "2026-04-11"), path.join(WS, "conversations", "summaries", "daily", "2026", "04", "11.md"));
+    assert.equal(dailyPathFor(WORKSPACE, "2026-04-11"), path.join(WORKSPACE, "conversations", "summaries", "daily", "2026", "04", "11.md"));
   });
 
   it("preserves leading zeros", () => {
-    assert.equal(dailyPathFor(WS, "2026-01-03"), path.join(WS, "conversations", "summaries", "daily", "2026", "01", "03.md"));
+    assert.equal(dailyPathFor(WORKSPACE, "2026-01-03"), path.join(WORKSPACE, "conversations", "summaries", "daily", "2026", "01", "03.md"));
   });
 });
 
 describe("topicPathFor", () => {
   it("builds summaries/topics/<slug>.md", () => {
-    assert.equal(topicPathFor(WS, "refactoring"), path.join(WS, "conversations", "summaries", "topics", "refactoring.md"));
+    assert.equal(topicPathFor(WORKSPACE, "refactoring"), path.join(WORKSPACE, "conversations", "summaries", "topics", "refactoring.md"));
   });
 });
 
 describe("archivedTopicPathFor", () => {
   it("builds summaries/archive/topics/<slug>.md", () => {
-    assert.equal(archivedTopicPathFor(WS, "old-topic"), path.join(WS, "conversations", "summaries", "archive", "topics", "old-topic.md"));
+    assert.equal(archivedTopicPathFor(WORKSPACE, "old-topic"), path.join(WORKSPACE, "conversations", "summaries", "archive", "topics", "old-topic.md"));
   });
 });
 
@@ -38,18 +38,18 @@ describe("toIsoDate", () => {
     // Pick a date in the middle of a month to avoid timezone edge
     // cases flipping the result. April 15 at noon local is April 15
     // in every timezone on Earth.
-    const d = new Date(2026, 3, 15, 12, 0, 0); // month is 0-indexed
-    assert.equal(toIsoDate(d), "2026-04-15");
+    const date = new Date(2026, 3, 15, 12, 0, 0); // month is 0-indexed
+    assert.equal(toIsoDate(date), "2026-04-15");
   });
 
   it("pads single-digit months and days", () => {
-    const d = new Date(2026, 0, 3, 12, 0, 0);
-    assert.equal(toIsoDate(d), "2026-01-03");
+    const date = new Date(2026, 0, 3, 12, 0, 0);
+    assert.equal(toIsoDate(date), "2026-01-03");
   });
 
   it("accepts a ms timestamp", () => {
-    const d = new Date(2026, 5, 20, 12, 0, 0);
-    assert.equal(toIsoDate(d.getTime()), "2026-06-20");
+    const date = new Date(2026, 5, 20, 12, 0, 0);
+    assert.equal(toIsoDate(date.getTime()), "2026-06-20");
   });
 });
 

--- a/test/journal/test_state.ts
+++ b/test/journal/test_state.ts
@@ -13,14 +13,14 @@ import {
 
 describe("defaultState", () => {
   it("produces a valid fresh state with the current schema version", () => {
-    const s = defaultState();
-    assert.equal(s.version, JOURNAL_STATE_VERSION);
-    assert.equal(s.lastDailyRunAt, null);
-    assert.equal(s.lastOptimizationRunAt, null);
-    assert.equal(s.dailyIntervalHours, DEFAULT_DAILY_INTERVAL_HOURS);
-    assert.equal(s.optimizationIntervalDays, DEFAULT_OPTIMIZATION_INTERVAL_DAYS);
-    assert.deepEqual(s.processedSessions, {});
-    assert.deepEqual(s.knownTopics, []);
+    const state = defaultState();
+    assert.equal(state.version, JOURNAL_STATE_VERSION);
+    assert.equal(state.lastDailyRunAt, null);
+    assert.equal(state.lastOptimizationRunAt, null);
+    assert.equal(state.dailyIntervalHours, DEFAULT_DAILY_INTERVAL_HOURS);
+    assert.equal(state.optimizationIntervalDays, DEFAULT_OPTIMIZATION_INTERVAL_DAYS);
+    assert.deepEqual(state.processedSessions, {});
+    assert.deepEqual(state.knownTopics, []);
   });
 });
 
@@ -37,7 +37,7 @@ describe("parseState", () => {
   });
 
   it("round-trips a well-formed state", () => {
-    const s: JournalState = {
+    const state: JournalState = {
       version: JOURNAL_STATE_VERSION,
       lastDailyRunAt: "2026-04-11T09:00:00.000Z",
       lastOptimizationRunAt: "2026-04-05T09:00:00.000Z",
@@ -46,7 +46,7 @@ describe("parseState", () => {
       processedSessions: { "abc-123": { lastMtimeMs: 1710000000000 } },
       knownTopics: ["refactoring", "video-generation"],
     };
-    assert.deepEqual(parseState(s), s);
+    assert.deepEqual(parseState(state), state);
   });
 
   it("restores default intervals when stored values are non-positive", () => {
@@ -93,39 +93,39 @@ describe("isDailyDue", () => {
   });
 
   it("is true when an unparseable string is stored", () => {
-    const s = { ...base, lastDailyRunAt: "not a date" };
-    assert.equal(isDailyDue(s, Date.now()), true);
+    const state = { ...base, lastDailyRunAt: "not a date" };
+    assert.equal(isDailyDue(state, Date.now()), true);
   });
 
   it("is false when less than one interval has elapsed", () => {
     const anchor = new Date("2026-04-11T09:00:00Z");
-    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
-    assert.equal(isDailyDue(s, anchor.getTime() + 30 * 60 * 1000), false);
+    const state = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(state, anchor.getTime() + 30 * 60 * 1000), false);
   });
 
   it("is true at exactly one interval elapsed", () => {
     const anchor = new Date("2026-04-11T09:00:00Z");
-    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
-    assert.equal(isDailyDue(s, anchor.getTime() + HOUR), true);
+    const state = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(state, anchor.getTime() + HOUR), true);
   });
 
   it("is true after more than one interval", () => {
     const anchor = new Date("2026-04-11T09:00:00Z");
-    const s = { ...base, lastDailyRunAt: anchor.toISOString() };
-    assert.equal(isDailyDue(s, anchor.getTime() + 2 * HOUR), true);
+    const state = { ...base, lastDailyRunAt: anchor.toISOString() };
+    assert.equal(isDailyDue(state, anchor.getTime() + 2 * HOUR), true);
   });
 
   it("respects a custom interval stored in state", () => {
     const anchor = new Date("2026-04-11T09:00:00Z");
-    const s = {
+    const state = {
       ...base,
       dailyIntervalHours: 6,
       lastDailyRunAt: anchor.toISOString(),
     };
     // 3 hours later — not due with a 6h interval
-    assert.equal(isDailyDue(s, anchor.getTime() + 3 * HOUR), false);
+    assert.equal(isDailyDue(state, anchor.getTime() + 3 * HOUR), false);
     // 6 hours later — exactly due
-    assert.equal(isDailyDue(s, anchor.getTime() + 6 * HOUR), true);
+    assert.equal(isDailyDue(state, anchor.getTime() + 6 * HOUR), true);
   });
 });
 
@@ -139,13 +139,13 @@ describe("isOptimizationDue", () => {
 
   it("is false until the full interval has passed", () => {
     const anchor = new Date("2026-04-01T00:00:00Z");
-    const s = { ...base, lastOptimizationRunAt: anchor.toISOString() };
-    assert.equal(isOptimizationDue(s, anchor.getTime() + 6 * DAY), false);
+    const state = { ...base, lastOptimizationRunAt: anchor.toISOString() };
+    assert.equal(isOptimizationDue(state, anchor.getTime() + 6 * DAY), false);
   });
 
   it("is true exactly at the interval boundary", () => {
     const anchor = new Date("2026-04-01T00:00:00Z");
-    const s = { ...base, lastOptimizationRunAt: anchor.toISOString() };
-    assert.equal(isOptimizationDue(s, anchor.getTime() + 7 * DAY), true);
+    const state = { ...base, lastOptimizationRunAt: anchor.toISOString() };
+    assert.equal(isOptimizationDue(state, anchor.getTime() + 7 * DAY), true);
   });
 });

--- a/test/logger/test_sinks.ts
+++ b/test/logger/test_sinks.ts
@@ -101,7 +101,7 @@ describe("createFileSink", () => {
     // the fresh one). Asserting just "includes newest" and "not
     // oldest" previously could pass even when retention left an
     // extra middle log behind — tighten to count + exact set.
-    const logFiles = files.filter((f) => f.startsWith("server-"));
+    const logFiles = files.filter((file) => file.startsWith("server-"));
     assert.equal(logFiles.length, 2);
     assert.ok(files.includes("server-2026-01-04.log"));
     assert.ok(files.includes("server-2026-01-03.log"));

--- a/test/notifications/test_route.ts
+++ b/test/notifications/test_route.ts
@@ -41,8 +41,8 @@ afterEach(() => {
 describe("notification route — body validation via scheduleTestNotification", () => {
   it("uses defaults when body is empty", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({}, deps);
-    assert.equal(s.delaySeconds, 60);
+    const scheduled = scheduleTestNotification({}, deps);
+    assert.equal(scheduled.delaySeconds, 60);
     mock.timers.tick(60_000);
     assert.deepEqual(deps.pushCalls, [
       {
@@ -70,26 +70,26 @@ describe("notification route — body validation via scheduleTestNotification", 
 
   it("accepts a valid numeric delaySeconds", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({ delaySeconds: 10 }, deps);
-    assert.equal(s.delaySeconds, 10);
+    const scheduled = scheduleTestNotification({ delaySeconds: 10 }, deps);
+    assert.equal(scheduled.delaySeconds, 10);
   });
 
   it("clamps invalid delay (Infinity) to default", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({ delaySeconds: Infinity }, deps);
-    assert.equal(s.delaySeconds, 60);
+    const scheduled = scheduleTestNotification({ delaySeconds: Infinity }, deps);
+    assert.equal(scheduled.delaySeconds, 60);
   });
 
   it("caps delay at 3600 seconds", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({ delaySeconds: 10_000 }, deps);
-    assert.equal(s.delaySeconds, 3_600);
+    const scheduled = scheduleTestNotification({ delaySeconds: 10_000 }, deps);
+    assert.equal(scheduled.delaySeconds, 3_600);
   });
 
   it("clamps negative delay to 0", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({ delaySeconds: -5 }, deps);
-    assert.equal(s.delaySeconds, 0);
+    const scheduled = scheduleTestNotification({ delaySeconds: -5 }, deps);
+    assert.equal(scheduled.delaySeconds, 0);
   });
 
   it("accepts custom transportId and chatId", () => {
@@ -102,7 +102,7 @@ describe("notification route — body validation via scheduleTestNotification", 
 
   it("returns a valid ISO8601 firesAt timestamp", () => {
     const deps = createSpyDeps();
-    const s = scheduleTestNotification({ delaySeconds: 5 }, deps);
-    assert.match(s.firesAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    const scheduled = scheduleTestNotification({ delaySeconds: 5 }, deps);
+    assert.match(scheduled.firesAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 });

--- a/test/notifications/test_scheduler.ts
+++ b/test/notifications/test_scheduler.ts
@@ -13,8 +13,8 @@ import { PUBSUB_CHANNELS } from "../../src/config/pubsubChannels.ts";
 
 function isNotificationPayload(value: unknown): value is NotificationPayload {
   if (value === null || typeof value !== "object") return false;
-  const v = value as Record<string, unknown>;
-  return typeof v.id === "string" && typeof v.title === "string";
+  const rec = value as Record<string, unknown>;
+  return typeof rec.id === "string" && typeof rec.title === "string";
 }
 
 interface SpyDeps extends NotificationDeps {
@@ -122,15 +122,15 @@ describe("scheduleTestNotification — delay clamping", () => {
   it("caps delays above the 1-hour ceiling at 3600s", () => {
     const deps = createSpyDeps();
     initNotifications(deps);
-    const s = scheduleTestNotification({ delaySeconds: 99999 }, deps);
-    assert.equal(s.delaySeconds, 3600);
+    const scheduled = scheduleTestNotification({ delaySeconds: 99999 }, deps);
+    assert.equal(scheduled.delaySeconds, 3600);
   });
 
   it("clamps negative delays to 0 and fires on the next tick", () => {
     const deps = createSpyDeps();
     initNotifications(deps);
-    const s = scheduleTestNotification({ delaySeconds: -10 }, deps);
-    assert.equal(s.delaySeconds, 0);
+    const scheduled = scheduleTestNotification({ delaySeconds: -10 }, deps);
+    assert.equal(scheduled.delaySeconds, 0);
     mock.timers.tick(0);
     assert.equal(deps.publishCalls.length, 1);
   });
@@ -138,15 +138,15 @@ describe("scheduleTestNotification — delay clamping", () => {
   it("floors fractional delays (1.9 → 1)", () => {
     const deps = createSpyDeps();
     initNotifications(deps);
-    const s = scheduleTestNotification({ delaySeconds: 1.9 }, deps);
-    assert.equal(s.delaySeconds, 1);
+    const scheduled = scheduleTestNotification({ delaySeconds: 1.9 }, deps);
+    assert.equal(scheduled.delaySeconds, 1);
   });
 
   it("cancel() prevents the push from firing", () => {
     const deps = createSpyDeps();
     initNotifications(deps);
-    const s = scheduleTestNotification({ delaySeconds: 10 }, deps);
-    s.cancel();
+    const scheduled = scheduleTestNotification({ delaySeconds: 10 }, deps);
+    scheduled.cancel();
     mock.timers.tick(20_000);
     assert.equal(deps.publishCalls.length, 0);
     assert.equal(deps.pushCalls.length, 0);

--- a/test/plugins/spreadsheet/engine/test_formulaRefs.ts
+++ b/test/plugins/spreadsheet/engine/test_formulaRefs.ts
@@ -331,7 +331,7 @@ describe("extractCellReferences — boundary / precision", () => {
 
 // --- helpers ---
 
-function cmpCoord(a: { row: number; col: number }, b: { row: number; col: number }): number {
-  if (a.row !== b.row) return a.row - b.row;
-  return a.col - b.col;
+function cmpCoord(coordA: { row: number; col: number }, coordB: { row: number; col: number }): number {
+  if (coordA.row !== coordB.row) return coordA.row - coordB.row;
+  return coordA.col - coordB.col;
 }

--- a/test/plugins/spreadsheet/test_cellHighlights.ts
+++ b/test/plugins/spreadsheet/test_cellHighlights.ts
@@ -17,11 +17,11 @@ function makeCell(): HighlightableElement & { classes: Set<string> } {
   return {
     classes,
     classList: {
-      add: (c: string) => {
-        classes.add(c);
+      add: (cls: string) => {
+        classes.add(cls);
       },
-      remove: (c: string) => {
-        classes.delete(c);
+      remove: (cls: string) => {
+        classes.delete(cls);
       },
     },
   };
@@ -45,7 +45,7 @@ function makeTable(rowsAndCols: number[][]): {
   const rows = rowsAndCols.map((cols) => makeRow(cols.length));
   return {
     rows,
-    table: { querySelectorAll: () => rows.map((r) => r.row) },
+    table: { querySelectorAll: () => rows.map((rowItem) => rowItem.row) },
   };
 }
 
@@ -59,9 +59,9 @@ function makeContainer(opts: {
   // The `querySelector` overloaded signature can't be satisfied by
   // a single closure, so we cast the callable to the interface
   // slot — the test itself validates runtime behaviour.
-  const qs = opts.onQuerySelector ?? (() => null);
+  const queryFn = opts.onQuerySelector ?? (() => null);
   return {
-    querySelector: qs as HighlightableContainer["querySelector"],
+    querySelector: queryFn as HighlightableContainer["querySelector"],
     querySelectorAll: (sel) => opts.onQueryAll?.(sel) ?? [],
   };
 }

--- a/test/plugins/todo/test_labels.ts
+++ b/test/plugins/todo/test_labels.ts
@@ -72,9 +72,9 @@ describe("colorForLabel", () => {
   });
 
   it("is deterministic for the same input", () => {
-    const a = colorForLabel("Urgent");
-    const b = colorForLabel("Urgent");
-    assert.equal(a, b);
+    const colorA = colorForLabel("Urgent");
+    const colorB = colorForLabel("Urgent");
+    assert.equal(colorA, colorB);
   });
 
   it("is case-insensitive", () => {
@@ -194,7 +194,7 @@ describe("listLabelsWithCount", () => {
     const items = [{ labels: ["Zebra"] }, { labels: ["apple"] }, { labels: ["Mango"] }];
     const result = listLabelsWithCount(items);
     assert.deepEqual(
-      result.map((r) => r.label),
+      result.map((item) => item.label),
       ["apple", "Mango", "Zebra"],
     );
   });

--- a/test/plugins/todo/test_priority.ts
+++ b/test/plugins/todo/test_priority.ts
@@ -4,8 +4,8 @@ import { PRIORITIES, PRIORITY_LABELS, isPriority } from "../../../src/plugins/to
 
 describe("isPriority", () => {
   it("accepts every value in PRIORITIES", () => {
-    for (const p of PRIORITIES) {
-      assert.equal(isPriority(p), true);
+    for (const priority of PRIORITIES) {
+      assert.equal(isPriority(priority), true);
     }
   });
 
@@ -38,9 +38,9 @@ describe("isPriority", () => {
 
 describe("PRIORITY_LABELS", () => {
   it("has a label for every priority", () => {
-    for (const p of PRIORITIES) {
-      assert.equal(typeof PRIORITY_LABELS[p], "string");
-      assert.ok(PRIORITY_LABELS[p].length > 0);
+    for (const priority of PRIORITIES) {
+      assert.equal(typeof PRIORITY_LABELS[priority], "string");
+      assert.ok(PRIORITY_LABELS[priority].length > 0);
     }
   });
 });

--- a/test/pub-sub/test_index.ts
+++ b/test/pub-sub/test_index.ts
@@ -29,35 +29,35 @@ describe("pub-sub (socket.io round trip)", () => {
   });
 
   async function connected(): Promise<Socket> {
-    const s = connect(url, { path: "/ws/pubsub", transports: ["websocket"] });
+    const socket = connect(url, { path: "/ws/pubsub", transports: ["websocket"] });
     await new Promise<void>((resolve, reject) => {
-      s.once("connect", () => resolve());
-      s.once("connect_error", reject);
+      socket.once("connect", () => resolve());
+      socket.once("connect_error", reject);
     });
-    return s;
+    return socket;
   }
 
   it("delivers publish() to a subscribed client", async () => {
-    const s = await connected();
-    const received = new Promise<unknown>((resolve) => s.once("data", (msg) => resolve(msg)));
-    s.emit("subscribe", "alpha");
+    const socket = await connected();
+    const received = new Promise<unknown>((resolve) => socket.once("data", (msg) => resolve(msg)));
+    socket.emit("subscribe", "alpha");
     // Wait for the subscribe to register as a room join before
     // publishing — socket.io rooms join synchronously on the
     // server once the event handler runs, but the handler runs
     // on the next tick after the emit. One microtask yield is
     // plenty.
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((resolve) => setTimeout(resolve, 20));
     pubsub.publish("alpha", { hello: "world" });
     const msg = await received;
     assert.deepEqual(msg, { channel: "alpha", data: { hello: "world" } });
-    s.disconnect();
+    socket.disconnect();
   });
 
   it("does not deliver to non-subscribers", async () => {
     const sub = await connected();
     const other = await connected();
     sub.emit("subscribe", "beta");
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     let otherGotData = false;
     other.on("data", () => {
@@ -68,7 +68,7 @@ describe("pub-sub (socket.io round trip)", () => {
     pubsub.publish("beta", { n: 1 });
     await received;
     // Give the "other" client a tick to receive (and thus fail).
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(otherGotData, false);
 
     sub.disconnect();
@@ -76,26 +76,26 @@ describe("pub-sub (socket.io round trip)", () => {
   });
 
   it("stops delivering after unsubscribe", async () => {
-    const s = await connected();
-    s.emit("subscribe", "gamma");
-    await new Promise((r) => setTimeout(r, 20));
+    const socket = await connected();
+    socket.emit("subscribe", "gamma");
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     // First publish — should arrive.
-    const first = new Promise<unknown>((resolve) => s.once("data", (msg) => resolve(msg)));
+    const first = new Promise<unknown>((resolve) => socket.once("data", (msg) => resolve(msg)));
     pubsub.publish("gamma", { seq: 1 });
     await first;
 
     // Now unsubscribe.
-    s.emit("unsubscribe", "gamma");
-    await new Promise((r) => setTimeout(r, 20));
+    socket.emit("unsubscribe", "gamma");
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     let got = false;
-    s.on("data", () => {
+    socket.on("data", () => {
       got = true;
     });
     pubsub.publish("gamma", { seq: 2 });
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(got, false);
-    s.disconnect();
+    socket.disconnect();
   });
 });

--- a/test/roles/test_builtin_role_ids.ts
+++ b/test/roles/test_builtin_role_ids.ts
@@ -9,7 +9,7 @@ import { ROLES, BUILTIN_ROLE_IDS, DEFAULT_ROLE_ID } from "../../src/config/roles
 describe("BUILTIN_ROLE_IDS", () => {
   it("has one entry per ROLES element", () => {
     const idsFromMap = Object.values(BUILTIN_ROLE_IDS).sort();
-    const idsFromArray = ROLES.map((r) => r.id).sort();
+    const idsFromArray = ROLES.map((role) => role.id).sort();
     assert.deepEqual(idsFromMap, idsFromArray);
   });
 
@@ -21,7 +21,7 @@ describe("BUILTIN_ROLE_IDS", () => {
 
   it("every BUILTIN_ROLE_IDS value resolves to an actual role via ROLES.find", () => {
     for (const id of Object.values(BUILTIN_ROLE_IDS)) {
-      const role = ROLES.find((r) => r.id === id);
+      const role = ROLES.find((roleItem) => roleItem.id === id);
       assert.ok(role, `no role found for id "${id}"`);
     }
   });
@@ -34,7 +34,7 @@ describe("DEFAULT_ROLE_ID", () => {
   });
 
   it("resolves to an actual role", () => {
-    const role = ROLES.find((r) => r.id === DEFAULT_ROLE_ID);
+    const role = ROLES.find((roleItem) => roleItem.id === DEFAULT_ROLE_ID);
     assert.ok(role, "DEFAULT_ROLE_ID does not match any role in ROLES");
   });
 });

--- a/test/roles/test_role_schema.ts
+++ b/test/roles/test_role_schema.ts
@@ -137,7 +137,7 @@ describe("BUILTIN_ROLES", () => {
   });
 
   it("all built-in roles have unique ids", () => {
-    const ids = BUILTIN_ROLES.map((r) => r.id);
+    const ids = BUILTIN_ROLES.map((role) => role.id);
     const uniqueIds = new Set(ids);
     assert.strictEqual(ids.length, uniqueIds.size, "Role ids must be unique");
   });

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -52,7 +52,7 @@ function extractRouteHandler(mod: RouteModule, routePath: string, method: "get" 
   // frame matching BOTH path and method rather than the first path hit.
   for (const frame of router.stack) {
     if (frame.route?.path !== routePath) continue;
-    const layer = frame.route.stack.find((s) => s.method === method);
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === method);
     if (layer) return layer.handle;
   }
   throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);

--- a/test/routes/test_filesPutRoute.ts
+++ b/test/routes/test_filesPutRoute.ts
@@ -33,7 +33,7 @@ function extractRouteHandler(mod: RouteModule, routePath: string, method: string
   const router = mod.default as unknown as RouterInternals;
   for (const frame of router.stack) {
     if (frame.route?.path !== routePath) continue;
-    const layer = frame.route.stack.find((s) => s.method === method);
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === method);
     if (layer) return layer.handle;
   }
   throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
@@ -79,8 +79,8 @@ before(async () => {
   originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
-  const { workspacePath: wp } = await import("../../server/workspace/workspace.js");
-  workspaceDir = wp;
+  const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
+  workspaceDir = workspacePth;
   fs.mkdirSync(workspaceDir, { recursive: true });
   const routeMod = await import("../../server/api/routes/files.js");
   putHandler = extractRouteHandler(routeMod, "/api/files/content", "put");

--- a/test/routes/test_mulmoScriptHelpers.ts
+++ b/test/routes/test_mulmoScriptHelpers.ts
@@ -50,8 +50,8 @@ describe("withStoryContext — resolver rejects filePath", () => {
         handlerCalled = true;
       },
       {
-        resolveStoryPath: (_fp, r) => {
-          (r as unknown as RecordedResponse).status(400).json({ error: "bad" });
+        resolveStoryPath: (_fp, resp) => {
+          (resp as unknown as RecordedResponse).status(400).json({ error: "bad" });
           return null;
         },
         buildContext: async () => {
@@ -101,7 +101,7 @@ describe("withStoryContext — buildContext returns null", () => {
       res as unknown as Response,
       "stories/x.json",
       {
-        onContextMissing: (r) => (r as unknown as RecordedResponse).json({ audio: null }),
+        onContextMissing: (resp) => (resp as unknown as RecordedResponse).json({ audio: null }),
       },
       async () => {
         handlerCalled = true;

--- a/test/routes/test_schedulerHandlers.ts
+++ b/test/routes/test_schedulerHandlers.ts
@@ -136,9 +136,9 @@ describe("handleDelete", () => {
   });
 
   it("removes the matching item", () => {
-    const a = makeItem({ id: "a" });
-    const b = makeItem({ id: "b" });
-    const result = handleDelete([a, b], { id: "a" });
+    const itemA = makeItem({ id: "a" });
+    const itemB = makeItem({ id: "b" });
+    const result = handleDelete([itemA, itemB], { id: "a" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items.length, 1);
@@ -169,8 +169,8 @@ describe("handleUpdate", () => {
   });
 
   it("reports not found without mutating when id doesn't match", () => {
-    const a = makeItem({ id: "a", title: "Original" });
-    const result = handleUpdate([a], { id: "missing", title: "x" });
+    const itemA = makeItem({ id: "a", title: "Original" });
+    const result = handleUpdate([itemA], { id: "missing", title: "x" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.match(result.message, /Item not found/);
@@ -178,8 +178,8 @@ describe("handleUpdate", () => {
   });
 
   it("updates the title when provided", () => {
-    const a = makeItem({ id: "a", title: "Old" });
-    const result = handleUpdate([a], { id: "a", title: "New" });
+    const itemA = makeItem({ id: "a", title: "Old" });
+    const result = handleUpdate([itemA], { id: "a", title: "New" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     const updated = result.items.find((i) => i.id === "a");
@@ -187,11 +187,11 @@ describe("handleUpdate", () => {
   });
 
   it("merges props patches by key", () => {
-    const a = makeItem({
+    const itemA = makeItem({
       id: "a",
       props: { date: "2026-01-01", note: "old" },
     });
-    const result = handleUpdate([a], {
+    const result = handleUpdate([itemA], {
       id: "a",
       props: { note: "new" },
     });
@@ -203,11 +203,11 @@ describe("handleUpdate", () => {
   });
 
   it("removes a prop when its patch value is null", () => {
-    const a = makeItem({
+    const itemA = makeItem({
       id: "a",
       props: { date: "2026-01-01", note: "x" },
     });
-    const result = handleUpdate([a], { id: "a", props: { note: null } });
+    const result = handleUpdate([itemA], { id: "a", props: { note: null } });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     const updated = result.items.find((i) => i.id === "a");
@@ -216,10 +216,10 @@ describe("handleUpdate", () => {
   });
 
   it("does not mutate the input items array", () => {
-    const a = makeItem({ id: "a", title: "Old", props: { x: 1 } });
-    const items = [a];
+    const itemA = makeItem({ id: "a", title: "Old", props: { x: 1 } });
+    const items = [itemA];
     handleUpdate(items, { id: "a", title: "New" });
-    assert.equal(a.title, "Old");
+    assert.equal(itemA.title, "Old");
     assert.equal(items[0]?.title, "Old");
   });
 });

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -47,7 +47,7 @@ function extractRouteHandler(mod: RouteModule, routePath: string, method: string
   const router = mod.default as unknown as RouterInternals;
   for (const frame of router.stack) {
     if (frame.route?.path !== routePath) continue;
-    const layer = frame.route.stack.find((s) => s.method === method);
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === method);
     if (layer) return layer.handle;
   }
   throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
@@ -158,9 +158,9 @@ before(async () => {
   // files, `chat/index` for the manifest after #284).
   const { WORKSPACE_PATHS } = await import("../../server/workspace/paths.js");
   const { indexDirFor } = await import("../../server/workspace/chat-index/paths.js");
-  const { workspacePath: wp } = await import("../../server/workspace/workspace.js");
+  const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
   chatDir = WORKSPACE_PATHS.chat;
-  manifestDir = indexDirFor(wp);
+  manifestDir = indexDirFor(workspacePth);
   fs.mkdirSync(chatDir, { recursive: true });
   fs.mkdirSync(manifestDir, { recursive: true });
   const routeMod = await import("../../server/api/routes/sessions.js");
@@ -202,7 +202,7 @@ describe("GET /api/sessions — full fetch (no ?since=)", () => {
 
     const { state, res } = mockRes();
     await getHandler({ query: {} } as unknown as Request, res);
-    const ids = state.body!.sessions.map((s) => s.id);
+    const ids = state.body!.sessions.map((sess) => sess.id);
     assert.deepEqual(ids, ["newer", "older"]);
   });
 });
@@ -219,7 +219,7 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
       } as unknown as Request,
       res,
     );
-    const ids = state.body!.sessions.map((s) => s.id);
+    const ids = state.body!.sessions.map((sess) => sess.id);
     assert.deepEqual(ids, ["new"]);
   });
 
@@ -236,7 +236,7 @@ describe("GET /api/sessions?since=<cursor> — incremental fetch", () => {
       } as unknown as Request,
       res,
     );
-    const ids = state.body!.sessions.map((s) => s.id);
+    const ids = state.body!.sessions.map((sess) => sess.id);
     assert.deepEqual(ids, ["summarised"]);
     // The returned cursor must advance to the indexedAt time, not
     // just the mtime, so the next call won't re-fetch this row.

--- a/test/routes/test_todosColumnsHandlers.ts
+++ b/test/routes/test_todosColumnsHandlers.ts
@@ -15,7 +15,7 @@ import type { TodoItem } from "../../server/api/routes/todos.js";
 
 function cols(): StatusColumn[] {
   // Fresh copy each call so mutations in one test don't bleed.
-  return DEFAULT_COLUMNS.map((c) => ({ ...c }));
+  return DEFAULT_COLUMNS.map((col) => ({ ...col }));
 }
 
 function makeItem(overrides: Partial<TodoItem> = {}): TodoItem {
@@ -44,7 +44,7 @@ describe("normalizeColumns", () => {
   it("strips entries missing id or label", () => {
     const result = normalizeColumns([{ id: "a", label: "A" }, { id: 5, label: "B" }, { id: "c" }, { label: "D" }, { id: "e", label: "E" }]);
     assert.deepEqual(
-      result.map((c) => c.id),
+      result.map((col) => col.id),
       ["a", "e"],
     );
   });
@@ -135,12 +135,12 @@ describe("handleAddColumn", () => {
   });
 
   it("is deterministic — same label always yields the same id", () => {
-    const a = handleAddColumn(cols(), [], { label: "完了" });
-    const b = handleAddColumn(cols(), [], { label: "完了" });
-    if (a.kind !== "success" || b.kind !== "success") {
+    const resultA = handleAddColumn(cols(), [], { label: "完了" });
+    const resultB = handleAddColumn(cols(), [], { label: "完了" });
+    if (resultA.kind !== "success" || resultB.kind !== "success") {
       assert.fail("both should succeed");
     }
-    assert.equal(a.columns[a.columns.length - 1]?.id, b.columns[b.columns.length - 1]?.id);
+    assert.equal(resultA.columns[resultA.columns.length - 1]?.id, resultB.columns[resultB.columns.length - 1]?.id);
   });
 
   it("demotes existing done columns when isDone is true", () => {
@@ -150,7 +150,7 @@ describe("handleAddColumn", () => {
     });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const doneIds = result.columns.filter((c) => c.isDone).map((c) => c.id);
+    const doneIds = result.columns.filter((col) => col.isDone).map((col) => col.id);
     assert.deepEqual(doneIds, ["archived"]);
   });
 
@@ -166,10 +166,10 @@ describe("handleAddColumn", () => {
     });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const a = result.items?.find((i) => i.id === "a");
-    const b = result.items?.find((i) => i.id === "b");
-    assert.equal(a?.completed, false);
-    assert.equal(b?.completed, false);
+    const itemA = result.items?.find((i) => i.id === "a");
+    const itemB = result.items?.find((i) => i.id === "b");
+    assert.equal(itemA?.completed, false);
+    assert.equal(itemB?.completed, false);
   });
 
   it("does not resync items when adding a non-done column", () => {
@@ -188,7 +188,7 @@ describe("handlePatchColumn", () => {
     const result = handlePatchColumn(cols(), "todo", { label: "Up Next" }, items);
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    assert.equal(result.columns.find((c) => c.id === "todo")?.label, "Up Next");
+    assert.equal(result.columns.find((col) => col.id === "todo")?.label, "Up Next");
     assert.equal(result.items, undefined);
   });
 
@@ -204,8 +204,8 @@ describe("handlePatchColumn", () => {
     const result = handlePatchColumn(cols(), "in_progress", { isDone: true }, items);
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const inProgress = result.columns.find((c) => c.id === "in_progress");
-    const done = result.columns.find((c) => c.id === "done");
+    const inProgress = result.columns.find((col) => col.id === "in_progress");
+    const done = result.columns.find((col) => col.id === "done");
     assert.equal(inProgress?.isDone, true);
     assert.equal(done?.isDone, undefined);
     // "a" is now in the new done column → completed should be true.
@@ -244,7 +244,7 @@ describe("handleDeleteColumn", () => {
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(
-      result.columns.find((c) => c.id === "backlog"),
+      result.columns.find((col) => col.id === "backlog"),
       undefined,
     );
     // "a" was in backlog → moves to first non-done column (now "todo")
@@ -267,7 +267,7 @@ describe("handleDeleteColumn", () => {
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     // All four items now live in "todo" with unique, contiguous orders.
-    const todoItems = result.items!.filter((i) => i.status === "todo").sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    const todoItems = result.items!.filter((i) => i.status === "todo").sort((itemX, itemY) => (itemX.order ?? 0) - (itemY.order ?? 0));
     const orders = todoItems.map((i) => i.order);
     // No duplicates.
     assert.equal(new Set(orders).size, 4);
@@ -281,15 +281,15 @@ describe("handleDeleteColumn", () => {
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(
-      result.columns.find((c) => c.id === "done"),
+      result.columns.find((col) => col.id === "done"),
       undefined,
     );
     const last = result.columns[result.columns.length - 1];
     assert.equal(last?.isDone, true);
     // Orphan from old done column moved to new done column.
-    const a = result.items?.find((i) => i.id === "a");
-    assert.equal(a?.status, last?.id);
-    assert.equal(a?.completed, true);
+    const itemA = result.items?.find((i) => i.id === "a");
+    assert.equal(itemA?.status, last?.id);
+    assert.equal(itemA?.completed, true);
   });
 });
 
@@ -314,7 +314,7 @@ describe("handleReorderColumns", () => {
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.deepEqual(
-      result.columns.map((c) => c.id),
+      result.columns.map((col) => col.id),
       ["done", "in_progress", "todo", "backlog"],
     );
   });

--- a/test/routes/test_todosHandlers.ts
+++ b/test/routes/test_todosHandlers.ts
@@ -28,10 +28,10 @@ function makeTodo(overrides: Partial<TodoItem> = {}): TodoItem {
 
 describe("findTodoByText", () => {
   it("returns the first item containing the substring (case-insensitive)", () => {
-    const a = makeTodo({ id: "a", text: "Buy milk" });
-    const b = makeTodo({ id: "b", text: "Walk the dog" });
-    assert.equal(findTodoByText([a, b], "MILK")?.id, "a");
-    assert.equal(findTodoByText([a, b], "dog")?.id, "b");
+    const todoA = makeTodo({ id: "a", text: "Buy milk" });
+    const todoB = makeTodo({ id: "b", text: "Walk the dog" });
+    assert.equal(findTodoByText([todoA, todoB], "MILK")?.id, "a");
+    assert.equal(findTodoByText([todoA, todoB], "dog")?.id, "b");
   });
 
   it("returns undefined when no item matches", () => {
@@ -188,8 +188,8 @@ describe("handleUpdate", () => {
   });
 
   it("reports not found without mutating when no match", () => {
-    const a = makeTodo({ id: "a", text: "Original" });
-    const result = handleUpdate([a], { text: "missing", newText: "x" });
+    const todoA = makeTodo({ id: "a", text: "Original" });
+    const result = handleUpdate([todoA], { text: "missing", newText: "x" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.match(result.message, /not found/);
@@ -197,16 +197,16 @@ describe("handleUpdate", () => {
   });
 
   it("updates the matched item's text", () => {
-    const a = makeTodo({ id: "a", text: "Old" });
-    const result = handleUpdate([a], { text: "old", newText: "New" });
+    const todoA = makeTodo({ id: "a", text: "Old" });
+    const result = handleUpdate([todoA], { text: "old", newText: "New" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.text, "New");
   });
 
   it("updates note when provided", () => {
-    const a = makeTodo({ id: "a", text: "x", note: "old" });
-    const result = handleUpdate([a], {
+    const todoA = makeTodo({ id: "a", text: "x", note: "old" });
+    const result = handleUpdate([todoA], {
       text: "x",
       newText: "y",
       note: "new",
@@ -217,17 +217,17 @@ describe("handleUpdate", () => {
   });
 
   it("clears note when an empty string is passed", () => {
-    const a = makeTodo({ id: "a", text: "x", note: "old" });
-    const result = handleUpdate([a], { text: "x", newText: "y", note: "" });
+    const todoA = makeTodo({ id: "a", text: "x", note: "old" });
+    const result = handleUpdate([todoA], { text: "x", newText: "y", note: "" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.note, undefined);
   });
 
   it("does not mutate the original item", () => {
-    const a = makeTodo({ id: "a", text: "Old" });
-    handleUpdate([a], { text: "old", newText: "New" });
-    assert.equal(a.text, "Old");
+    const todoA = makeTodo({ id: "a", text: "Old" });
+    handleUpdate([todoA], { text: "old", newText: "New" });
+    assert.equal(todoA.text, "Old");
   });
 });
 
@@ -237,8 +237,8 @@ describe("handleCheck", () => {
   });
 
   it("marks the matched item completed=true", () => {
-    const a = makeTodo({ id: "a", text: "x", completed: false });
-    const result = handleCheck([a], { text: "x" });
+    const todoA = makeTodo({ id: "a", text: "x", completed: false });
+    const result = handleCheck([todoA], { text: "x" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.completed, true);
@@ -246,17 +246,17 @@ describe("handleCheck", () => {
   });
 
   it("reports not found without mutating when no match", () => {
-    const a = makeTodo({ id: "a", text: "x", completed: false });
-    const result = handleCheck([a], { text: "missing" });
+    const todoA = makeTodo({ id: "a", text: "x", completed: false });
+    const result = handleCheck([todoA], { text: "missing" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.completed, false);
   });
 
   it("does not mutate the original item", () => {
-    const a = makeTodo({ id: "a", text: "x", completed: false });
-    handleCheck([a], { text: "x" });
-    assert.equal(a.completed, false);
+    const todoA = makeTodo({ id: "a", text: "x", completed: false });
+    handleCheck([todoA], { text: "x" });
+    assert.equal(todoA.completed, false);
   });
 });
 
@@ -266,8 +266,8 @@ describe("handleUncheck", () => {
   });
 
   it("marks the matched item completed=false", () => {
-    const a = makeTodo({ id: "a", text: "x", completed: true });
-    const result = handleUncheck([a], { text: "x" });
+    const todoA = makeTodo({ id: "a", text: "x", completed: true });
+    const result = handleUncheck([todoA], { text: "x" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.completed, false);
@@ -338,8 +338,8 @@ describe("handleAddLabel", () => {
   });
 
   it("merges new labels into the matched item", () => {
-    const a = makeTodo({ id: "a", text: "thing", labels: ["work"] });
-    const result = handleAddLabel([a], {
+    const todoA = makeTodo({ id: "a", text: "thing", labels: ["work"] });
+    const result = handleAddLabel([todoA], {
       text: "thing",
       labels: ["urgent"],
     });
@@ -349,16 +349,16 @@ describe("handleAddLabel", () => {
   });
 
   it("dedupes when adding an existing label", () => {
-    const a = makeTodo({ id: "a", text: "x", labels: ["work"] });
-    const result = handleAddLabel([a], { text: "x", labels: ["WORK"] });
+    const todoA = makeTodo({ id: "a", text: "x", labels: ["work"] });
+    const result = handleAddLabel([todoA], { text: "x", labels: ["WORK"] });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
     assert.equal(result.items[0]?.labels?.length, 1);
   });
 
   it("reports not found without mutating", () => {
-    const a = makeTodo({ id: "a", text: "thing", labels: ["work"] });
-    const result = handleAddLabel([a], {
+    const todoA = makeTodo({ id: "a", text: "thing", labels: ["work"] });
+    const result = handleAddLabel([todoA], {
       text: "missing",
       labels: ["urgent"],
     });
@@ -369,9 +369,9 @@ describe("handleAddLabel", () => {
   });
 
   it("does not mutate the input item", () => {
-    const a = makeTodo({ id: "a", text: "thing", labels: ["work"] });
-    handleAddLabel([a], { text: "thing", labels: ["urgent"] });
-    assert.deepEqual(a.labels, ["work"]);
+    const todoA = makeTodo({ id: "a", text: "thing", labels: ["work"] });
+    handleAddLabel([todoA], { text: "thing", labels: ["urgent"] });
+    assert.deepEqual(todoA.labels, ["work"]);
   });
 });
 
@@ -382,12 +382,12 @@ describe("handleRemoveLabel", () => {
   });
 
   it("removes the matching labels case-insensitively", () => {
-    const a = makeTodo({
+    const todoA = makeTodo({
       id: "a",
       text: "thing",
       labels: ["Work", "Urgent"],
     });
-    const result = handleRemoveLabel([a], {
+    const result = handleRemoveLabel([todoA], {
       text: "thing",
       labels: ["work"],
     });
@@ -397,8 +397,8 @@ describe("handleRemoveLabel", () => {
   });
 
   it("deletes the labels field when removing the last one", () => {
-    const a = makeTodo({ id: "a", text: "x", labels: ["work"] });
-    const result = handleRemoveLabel([a], {
+    const todoA = makeTodo({ id: "a", text: "x", labels: ["work"] });
+    const result = handleRemoveLabel([todoA], {
       text: "x",
       labels: ["work"],
     });
@@ -409,8 +409,8 @@ describe("handleRemoveLabel", () => {
   });
 
   it("is a no-op when removing a label that isn't present", () => {
-    const a = makeTodo({ id: "a", text: "x", labels: ["work"] });
-    const result = handleRemoveLabel([a], {
+    const todoA = makeTodo({ id: "a", text: "x", labels: ["work"] });
+    const result = handleRemoveLabel([todoA], {
       text: "x",
       labels: ["personal"],
     });
@@ -437,7 +437,7 @@ describe("handleListLabels", () => {
       label: string;
       count: number;
     }>;
-    const work = inventory.find((l) => l.label.toLowerCase() === "work");
+    const work = inventory.find((labelItem) => labelItem.label.toLowerCase() === "work");
     assert.equal(work?.count, 2);
   });
 });

--- a/test/routes/test_todosItemsHandlers.ts
+++ b/test/routes/test_todosItemsHandlers.ts
@@ -5,7 +5,7 @@ import { DEFAULT_COLUMNS } from "../../server/api/routes/todosColumnsHandlers.js
 import type { TodoItem } from "../../server/api/routes/todos.js";
 
 function cols() {
-  return DEFAULT_COLUMNS.map((c) => ({ ...c }));
+  return DEFAULT_COLUMNS.map((col) => ({ ...col }));
 }
 
 function makeItem(overrides: Partial<TodoItem> = {}): TodoItem {
@@ -37,14 +37,14 @@ describe("migrateItems", () => {
       },
     ];
     const result = migrateItems(legacy, cols());
-    const a = result.find((i) => i.id === "a");
-    const b = result.find((i) => i.id === "b");
-    assert.equal(a?.status, "done");
-    assert.equal(a?.completed, true);
-    assert.equal(b?.status, "backlog");
-    assert.equal(b?.completed, false);
-    assert.equal(typeof a?.order, "number");
-    assert.equal(typeof b?.order, "number");
+    const itemA = result.find((i) => i.id === "a");
+    const itemB = result.find((i) => i.id === "b");
+    assert.equal(itemA?.status, "done");
+    assert.equal(itemA?.completed, true);
+    assert.equal(itemB?.status, "backlog");
+    assert.equal(itemB?.completed, false);
+    assert.equal(typeof itemA?.order, "number");
+    assert.equal(typeof itemB?.order, "number");
   });
 
   it("reassigns items pointing at unknown columns", () => {
@@ -330,7 +330,7 @@ describe("handleMove", () => {
     });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const todoItems = result.items.filter((i) => i.status === "todo").sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    const todoItems = result.items.filter((i) => i.status === "todo").sort((itemX, itemY) => (itemX.order ?? 0) - (itemY.order ?? 0));
     assert.deepEqual(
       todoItems.map((i) => i.id),
       ["b", "c", "a"],
@@ -345,7 +345,7 @@ describe("handleMove", () => {
     });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const todoItems = result.items.filter((i) => i.status === "todo").sort((x, y) => (x.order ?? 0) - (y.order ?? 0));
+    const todoItems = result.items.filter((i) => i.status === "todo").sort((itemX, itemY) => (itemX.order ?? 0) - (itemY.order ?? 0));
     assert.deepEqual(
       todoItems.map((i) => i.id),
       ["b", "a"],

--- a/test/scripts/test_migrate_workspace_284.ts
+++ b/test/scripts/test_migrate_workspace_284.ts
@@ -171,16 +171,16 @@ describe("invariants", () => {
   it("all target paths are under one of the 4 grouping dirs", () => {
     const groupings = ["config/", "conversations/", "data/", "artifacts/"];
     for (const { to } of DIR_MIGRATIONS) {
-      const under = groupings.some((g) => to === g.slice(0, -1) || to.startsWith(g));
+      const under = groupings.some((grouping) => to === grouping.slice(0, -1) || to.startsWith(grouping));
       assert.ok(under, `target "${to}" does not fit any grouping`);
     }
   });
 
   it("no `from` is a prefix of another `from` (would cause ordering issues)", () => {
-    for (const a of DIR_MIGRATIONS) {
-      for (const b of DIR_MIGRATIONS) {
-        if (a === b) continue;
-        assert.ok(!b.from.startsWith(`${a.from}/`), `"${b.from}" is nested under "${a.from}" — migration order matters`);
+    for (const migA of DIR_MIGRATIONS) {
+      for (const migB of DIR_MIGRATIONS) {
+        if (migA === migB) continue;
+        assert.ok(!migB.from.startsWith(`${migA.from}/`), `"${migB.from}" is nested under "${migA.from}" — migration order matters`);
       }
     }
   });

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -288,7 +288,7 @@ describe("saveSettings", () => {
     mod.saveSettings({ extraAllowedTools: ["first"] });
     mod.saveSettings({ extraAllowedTools: ["second"] });
     const entries = fs.readdirSync(mod.configsDir());
-    const leftover = entries.filter((e) => e.endsWith(".tmp"));
+    const leftover = entries.filter((entry) => entry.endsWith(".tmp"));
     assert.deepEqual(leftover, []);
     assert.deepEqual(mod.loadSettings(), { extraAllowedTools: ["second"] });
   });

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -108,16 +108,16 @@ describe("env coercion", () => {
 
   it("treats DISABLE_SANDBOX=1 as true; anything else as false", async () => {
     process.env.DISABLE_SANDBOX = "1";
-    const a = await loadEnvFresh();
-    assert.equal(a.env.disableSandbox, true);
+    const envA = await loadEnvFresh();
+    assert.equal(envA.env.disableSandbox, true);
 
     process.env.DISABLE_SANDBOX = "true";
-    const b = await loadEnvFresh();
-    assert.equal(b.env.disableSandbox, false, "string 'true' should not flip");
+    const envB = await loadEnvFresh();
+    assert.equal(envB.env.disableSandbox, false, "string 'true' should not flip");
 
     process.env.DISABLE_SANDBOX = "0";
-    const c = await loadEnvFresh();
-    assert.equal(c.env.disableSandbox, false);
+    const envC = await loadEnvFresh();
+    assert.equal(envC.env.disableSandbox, false);
   });
 
   it("isProduction reflects NODE_ENV=production", async () => {

--- a/test/skills/test_discovery.ts
+++ b/test/skills/test_discovery.ts
@@ -97,7 +97,7 @@ describe("collectSkillsFromDir", () => {
     await writeSkill(root, "mango", "M");
     const skills = await collectSkillsFromDir(root, "user");
     assert.deepEqual(
-      skills.map((s) => s.name),
+      skills.map((skill) => skill.name),
       ["apple", "mango", "zebra"],
     );
   });
@@ -146,7 +146,7 @@ describe("discoverSkills", () => {
     const skills = await discoverSkills({ userDir: root });
     assert.equal(skills.length, 2);
     assert.deepEqual(
-      skills.map((s) => [s.name, s.source]),
+      skills.map((skill) => [skill.name, skill.source]),
       [
         ["u1", "user"],
         ["u2", "user"],
@@ -171,7 +171,7 @@ describe("discoverSkills", () => {
       });
       // Alphabetical: only_project, only_user, shared
       assert.deepEqual(
-        skills.map((s) => [s.name, s.source, s.description]),
+        skills.map((skill) => [skill.name, skill.source, skill.description]),
         [
           ["only_project", "project", "Project only"],
           ["only_user", "user", "User only"],

--- a/test/skills/test_writer.ts
+++ b/test/skills/test_writer.ts
@@ -163,13 +163,13 @@ describe("deleteProjectSkill", () => {
     assert.deepEqual(result, { kind: "deleted", name: "removable" });
 
     // Re-saving the same slug should now succeed.
-    const re = await saveProjectSkill({
+    const reSave = await saveProjectSkill({
       workspaceRoot: workspace,
       name: "removable",
       description: "fresh",
       body: "fresh body",
     });
-    assert.equal(re.kind, "saved");
+    assert.equal(reSave.kind, "saved");
   });
 
   it("returns not-found when the skill does not exist", async () => {

--- a/test/sources/test_arxivDiscovery.ts
+++ b/test/sources/test_arxivDiscovery.ts
@@ -7,18 +7,18 @@ import { buildArxivQuery, keywordsToSlug, discoverAndRegister } from "../../serv
 
 describe("buildArxivQuery", () => {
   it("builds query for single keyword", () => {
-    const q = buildArxivQuery(["transformer"]);
-    assert.equal(q, 'ti:"transformer" OR abs:"transformer"');
+    const query = buildArxivQuery(["transformer"]);
+    assert.equal(query, 'ti:"transformer" OR abs:"transformer"');
   });
 
   it("builds query for multiple keywords", () => {
-    const q = buildArxivQuery(["transformer", "attention"]);
-    assert.equal(q, 'ti:"transformer" OR abs:"transformer" OR ti:"attention" OR abs:"attention"');
+    const query = buildArxivQuery(["transformer", "attention"]);
+    assert.equal(query, 'ti:"transformer" OR abs:"transformer" OR ti:"attention" OR abs:"attention"');
   });
 
   it("escapes quotes in keywords", () => {
-    const q = buildArxivQuery(['large "language" model']);
-    assert.equal(q, 'ti:"large language model" OR abs:"large language model"');
+    const query = buildArxivQuery(['large "language" model']);
+    assert.equal(query, 'ti:"large language model" OR abs:"large language model"');
   });
 
   it("handles empty array", () => {

--- a/test/sources/test_githubIssues.ts
+++ b/test/sources/test_githubIssues.ts
@@ -101,9 +101,9 @@ function makePr(over: Partial<Record<string, unknown>> = {}) {
 
 describe("resolveIssuesParams", () => {
   it("defaults to state=open, includePrs=true", () => {
-    const p = resolveIssuesParams({});
-    assert.equal(p.state, "open");
-    assert.equal(p.includePrs, true);
+    const params = resolveIssuesParams({});
+    assert.equal(params.state, "open");
+    assert.equal(params.includePrs, true);
   });
 
   it("accepts state=closed and state=all", () => {
@@ -166,37 +166,37 @@ describe("issuesUrl", () => {
 
 describe("parseGithubIssue", () => {
   it("extracts the fields we consume", () => {
-    const p = parseGithubIssue(makeIssue());
-    assert.ok(p);
-    assert.equal(p!.id, 42);
-    assert.equal(p!.number, 7);
-    assert.equal(p!.title, "Bug: thing broken");
-    assert.equal(p!.htmlUrl, "https://github.com/receptron/mulmoclaude/issues/7");
-    assert.equal(p!.updatedAt, "2026-04-10T10:00:00Z");
-    assert.equal(p!.state, "open");
-    assert.equal(p!.isPr, false);
+    const parsed = parseGithubIssue(makeIssue());
+    assert.ok(parsed);
+    assert.equal(parsed!.id, 42);
+    assert.equal(parsed!.number, 7);
+    assert.equal(parsed!.title, "Bug: thing broken");
+    assert.equal(parsed!.htmlUrl, "https://github.com/receptron/mulmoclaude/issues/7");
+    assert.equal(parsed!.updatedAt, "2026-04-10T10:00:00Z");
+    assert.equal(parsed!.state, "open");
+    assert.equal(parsed!.isPr, false);
   });
 
   it("marks PRs via the pull_request field", () => {
-    const p = parseGithubIssue(makePr());
-    assert.ok(p);
-    assert.equal(p!.isPr, true);
+    const parsed = parseGithubIssue(makePr());
+    assert.ok(parsed);
+    assert.equal(parsed!.isPr, true);
   });
 
   it("treats a pull_request field with an empty object as PR", () => {
-    const p = parseGithubIssue({ ...makeIssue(), pull_request: {} });
-    assert.ok(p);
-    assert.equal(p!.isPr, true);
+    const parsed = parseGithubIssue({ ...makeIssue(), pull_request: {} });
+    assert.ok(parsed);
+    assert.equal(parsed!.isPr, true);
   });
 
   it("coerces missing fields to null, doesn't crash", () => {
-    const p = parseGithubIssue({});
-    assert.ok(p);
-    assert.equal(p!.id, null);
-    assert.equal(p!.number, null);
-    assert.equal(p!.title, null);
-    assert.equal(p!.htmlUrl, null);
-    assert.equal(p!.isPr, false);
+    const parsed = parseGithubIssue({});
+    assert.ok(parsed);
+    assert.equal(parsed!.id, null);
+    assert.equal(parsed!.number, null);
+    assert.equal(parsed!.title, null);
+    assert.equal(parsed!.htmlUrl, null);
+    assert.equal(parsed!.isPr, false);
   });
 
   it("returns null for non-objects", () => {
@@ -244,8 +244,8 @@ describe("issueToSourceItem — filtering", () => {
   const params = { state: "open" as const, includePrs: true };
 
   it("drops PRs when includePrs is false", () => {
-    const pr = parseGithubIssue(makePr())!;
-    const item = issueToSourceItem(pr, makeSource(), { state: "open", includePrs: false }, null);
+    const prIssue = parseGithubIssue(makePr())!;
+    const item = issueToSourceItem(prIssue, makeSource(), { state: "open", includePrs: false }, null);
     assert.equal(item, null);
   });
 

--- a/test/sources/test_githubReleases.ts
+++ b/test/sources/test_githubReleases.ts
@@ -91,15 +91,15 @@ function makeRelease(over: Partial<Record<string, unknown>> = {}) {
 
 describe("parseGithubRelease", () => {
   it("extracts the fields we actually consume", () => {
-    const r = parseGithubRelease(makeRelease());
-    assert.ok(r);
-    assert.equal(r!.id, 12345);
-    assert.equal(r!.tagName, "v1.2.3");
-    assert.equal(r!.name, "1.2.3 — Spring release");
-    assert.equal(r!.htmlUrl, "https://github.com/anthropics/claude-code/releases/tag/v1.2.3");
-    assert.equal(r!.publishedAt, "2026-04-10T10:00:00Z");
-    assert.equal(r!.draft, false);
-    assert.equal(r!.prerelease, false);
+    const release = parseGithubRelease(makeRelease());
+    assert.ok(release);
+    assert.equal(release!.id, 12345);
+    assert.equal(release!.tagName, "v1.2.3");
+    assert.equal(release!.name, "1.2.3 — Spring release");
+    assert.equal(release!.htmlUrl, "https://github.com/anthropics/claude-code/releases/tag/v1.2.3");
+    assert.equal(release!.publishedAt, "2026-04-10T10:00:00Z");
+    assert.equal(release!.draft, false);
+    assert.equal(release!.prerelease, false);
   });
 
   it("returns null for non-objects", () => {
@@ -109,20 +109,20 @@ describe("parseGithubRelease", () => {
   });
 
   it("coerces missing fields to null without failing the whole parse", () => {
-    const r = parseGithubRelease({});
-    assert.ok(r);
-    assert.equal(r!.id, null);
-    assert.equal(r!.name, null);
-    assert.equal(r!.htmlUrl, null);
-    assert.equal(r!.publishedAt, null);
-    assert.equal(r!.draft, false);
-    assert.equal(r!.prerelease, false);
+    const release = parseGithubRelease({});
+    assert.ok(release);
+    assert.equal(release!.id, null);
+    assert.equal(release!.name, null);
+    assert.equal(release!.htmlUrl, null);
+    assert.equal(release!.publishedAt, null);
+    assert.equal(release!.draft, false);
+    assert.equal(release!.prerelease, false);
   });
 
   it("treats missing `draft` / `prerelease` as false (default)", () => {
-    const r = parseGithubRelease({ id: 1 });
-    assert.equal(r!.draft, false);
-    assert.equal(r!.prerelease, false);
+    const release = parseGithubRelease({ id: 1 });
+    assert.equal(release!.draft, false);
+    assert.equal(release!.prerelease, false);
   });
 });
 

--- a/test/sources/test_httpFetcher.ts
+++ b/test/sources/test_httpFetcher.ts
@@ -52,8 +52,8 @@ function makeStubFetch(responses: Record<string, Response | Error>): {
     const headers: Record<string, string> = {};
     const rawHeaders = init?.headers as Record<string, string> | undefined;
     if (rawHeaders) {
-      for (const [k, v] of Object.entries(rawHeaders)) {
-        headers[k] = v;
+      for (const [key, val] of Object.entries(rawHeaders)) {
+        headers[key] = val;
       }
     }
     calls.push({ url, headers, signal: init?.signal ?? null });
@@ -158,8 +158,8 @@ describe("fetchPolite — rate limiting", () => {
       const url = String(input);
       order.push(`start:${url}`);
       if (url.endsWith("a")) {
-        await new Promise<void>((r) => {
-          releaseA = r;
+        await new Promise<void>((resolve) => {
+          releaseA = resolve;
         });
       }
       order.push(`end:${url}`);
@@ -171,14 +171,14 @@ describe("fetchPolite — rate limiting", () => {
       rateLimiterDeps: clock.deps,
       crawlDelayMs: () => 0,
     });
-    const a = fetchPolite("https://example.com/a", deps);
-    const b = fetchPolite("https://example.com/b", deps);
+    const fetchA = fetchPolite("https://example.com/a", deps);
+    const fetchB = fetchPolite("https://example.com/b", deps);
     await Promise.resolve();
     await Promise.resolve();
     // Only a has started; b is queued.
     assert.deepEqual(order, ["start:https://example.com/a"]);
     releaseA();
-    await Promise.all([a, b]);
+    await Promise.all([fetchA, fetchB]);
     // b starts only after a ends.
     assert.deepEqual(order, ["start:https://example.com/a", "end:https://example.com/a", "start:https://example.com/b", "end:https://example.com/b"]);
   });
@@ -241,7 +241,7 @@ describe("fetchPolite — timeout + abort", () => {
     const calls: string[] = [];
     const deps = makeDeps({
       fetchImpl: stub.fetchImpl,
-      onWillFetch: (u) => calls.push(u),
+      onWillFetch: (fetchUrl) => calls.push(fetchUrl),
     });
     await fetchPolite(url, deps);
     assert.deepEqual(calls, [url]);

--- a/test/sources/test_paths.ts
+++ b/test/sources/test_paths.ts
@@ -21,8 +21,8 @@ describe("path helpers", () => {
   it("robotsCachePath sanitizes colons in host:port", () => {
     // Hosts with explicit ports have colons that break on some
     // filesystems. Colon → underscore.
-    const p = robotsCachePath(root, "example.com:8080");
-    assert.equal(p, path.join(root, "sources", "_state", "robots", "example.com_8080.txt"));
+    const cachePath = robotsCachePath(root, "example.com:8080");
+    assert.equal(cachePath, path.join(root, "sources", "_state", "robots", "example.com_8080.txt"));
   });
 
   it("dailyNewsPath splits YYYY-MM-DD into year / month / day.md", () => {

--- a/test/sources/test_pipelineFetch.ts
+++ b/test/sources/test_pipelineFetch.ts
@@ -79,7 +79,7 @@ function fakeFetcher(kind: FetcherKind, impl: (source: Source, state: SourceStat
 // Build a `getFetcher` lookup for a set of fakes.
 function makeGetFetcher(fetchers: SourceFetcher[]): (kind: FetcherKind) => SourceFetcher | null {
   const byKind = new Map<FetcherKind, SourceFetcher>();
-  for (const f of fetchers) byKind.set(f.kind, f);
+  for (const fetcher of fetchers) byKind.set(fetcher.kind, fetcher);
   return (kind) => byKind.get(kind) ?? null;
 }
 
@@ -154,7 +154,7 @@ describe("runFetchPhase — failure isolation (Q8)", () => {
       deps: makeDeps(),
       getFetcher: makeGetFetcher([fetcher]),
     });
-    const kinds = new Map(result.outcomes.map((o) => [o.sourceSlug, o.kind]));
+    const kinds = new Map(result.outcomes.map((outcome) => [outcome.sourceSlug, outcome.kind]));
     assert.equal(kinds.get("ok-a"), "success");
     assert.equal(kinds.get("broken"), "error");
     assert.equal(kinds.get("ok-b"), "success");

--- a/test/sources/test_pipelineFetchersIntegration.ts
+++ b/test/sources/test_pipelineFetchersIntegration.ts
@@ -82,7 +82,7 @@ function makeHttpDeps(routes: Array<{ url: RegExp | string; body: string; conten
   const clock = controllableClock();
   const fetchImpl: typeof fetch = async (input) => {
     const url = String(input);
-    const match = routes.find((r) => (typeof r.url === "string" ? url === r.url : r.url.test(url)));
+    const match = routes.find((route) => (typeof route.url === "string" ? url === route.url : route.url.test(url)));
     if (!match) {
       throw new Error(`test: unexpected fetch ${url}`);
     }
@@ -258,23 +258,23 @@ const CASES: FixtureCase[] = [
 ];
 
 describe("pipeline integration with real fetchers", () => {
-  for (const c of CASES) {
-    it(`${c.kind} source produces items end-to-end`, async () => {
+  for (const testCase of CASES) {
+    it(`${testCase.kind} source produces items end-to-end`, async () => {
       await writeSource(
         workspace,
         makeSource({
-          slug: c.slug,
-          title: c.slug,
-          url: c.url,
-          fetcherKind: c.kind,
-          fetcherParams: c.fetcherParams,
+          slug: testCase.slug,
+          title: testCase.slug,
+          url: testCase.url,
+          fetcherKind: testCase.kind,
+          fetcherParams: testCase.fetcherParams,
         }),
       );
       const result = await runSourcesPipeline({
         workspaceRoot: workspace,
         scheduleType: "daily",
         fetcherDeps: {
-          http: makeHttpDeps([c.httpRoute]),
+          http: makeHttpDeps([testCase.httpRoute]),
           now: () => Date.now(),
         },
         // Skip the real claude CLI call — the pipeline doesn't need
@@ -283,32 +283,35 @@ describe("pipeline integration with real fetchers", () => {
         nowMs: () => Date.now(),
       });
       assert.equal(result.plannedCount, 1);
-      assert.ok(result.items.length >= c.expectedMinItems, `expected at least ${c.expectedMinItems} items for ${c.kind}, got ${result.items.length}`);
       assert.ok(
-        result.items.some((i) => i.title?.includes(c.expectedTitleFragment)),
-        `expected an item titled ~"${c.expectedTitleFragment}" for ${c.kind}; got titles: ${result.items.map((i) => i.title).join(", ")}`,
+        result.items.length >= testCase.expectedMinItems,
+        `expected at least ${testCase.expectedMinItems} items for ${testCase.kind}, got ${result.items.length}`,
+      );
+      assert.ok(
+        result.items.some((i) => i.title?.includes(testCase.expectedTitleFragment)),
+        `expected an item titled ~"${testCase.expectedTitleFragment}" for ${testCase.kind}; got titles: ${result.items.map((i) => i.title).join(", ")}`,
       );
       // Daily file actually contains the items we fetched.
       const daily = await readFile(result.dailyPath, "utf-8");
-      assert.ok(daily.includes(c.expectedTitleFragment), `daily file should mention "${c.expectedTitleFragment}"`);
+      assert.ok(daily.includes(testCase.expectedTitleFragment), `daily file should mention "${testCase.expectedTitleFragment}"`);
     });
   }
 
   it("runs all four kinds together in one pass (cross-source)", async () => {
     // Write one source per kind so the pipeline plans them all.
-    for (const c of CASES) {
+    for (const testCase of CASES) {
       await writeSource(
         workspace,
         makeSource({
-          slug: c.slug,
-          title: c.slug,
-          url: c.url,
-          fetcherKind: c.kind,
-          fetcherParams: c.fetcherParams,
+          slug: testCase.slug,
+          title: testCase.slug,
+          url: testCase.url,
+          fetcherKind: testCase.kind,
+          fetcherParams: testCase.fetcherParams,
         }),
       );
     }
-    const http = makeHttpDeps(CASES.map((c) => c.httpRoute));
+    const http = makeHttpDeps(CASES.map((testCase) => testCase.httpRoute));
     const result = await runSourcesPipeline({
       workspaceRoot: workspace,
       scheduleType: "daily",
@@ -318,10 +321,10 @@ describe("pipeline integration with real fetchers", () => {
     });
     assert.equal(result.plannedCount, CASES.length);
     // Every kind contributes at least one item.
-    for (const c of CASES) {
+    for (const testCase of CASES) {
       assert.ok(
-        result.items.some((i) => i.sourceSlug === c.slug),
-        `expected at least one item from ${c.kind} (slug="${c.slug}")`,
+        result.items.some((i) => i.sourceSlug === testCase.slug),
+        `expected at least one item from ${testCase.kind} (slug="${testCase.slug}")`,
       );
     }
     // Per-source archive file written for each kind.

--- a/test/sources/test_pipelinePlan.ts
+++ b/test/sources/test_pipelinePlan.ts
@@ -46,7 +46,7 @@ describe("planEligibleSources — schedule matching", () => {
       nowMs: 0,
     });
     assert.deepEqual(
-      eligible.map((s) => s.slug),
+      eligible.map((src) => src.slug),
       ["daily-1", "daily-2"],
     );
   });
@@ -96,7 +96,7 @@ describe("planEligibleSources — sort ordering", () => {
       nowMs: 0,
     });
     assert.deepEqual(
-      eligible.map((s) => s.slug),
+      eligible.map((src) => src.slug),
       ["alpha", "bravo", "charlie"],
     );
   });

--- a/test/sources/test_rateLimiter.ts
+++ b/test/sources/test_rateLimiter.ts
@@ -73,8 +73,8 @@ describe("HostRateLimiter — serialization per host", () => {
       "example.com",
       async () => {
         events.push("first:start");
-        await new Promise<void>((r) => {
-          releaseFirst = r;
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
         });
         events.push("first:end");
         return 1;
@@ -95,9 +95,9 @@ describe("HostRateLimiter — serialization per host", () => {
     // Second hasn't started yet.
     assert.deepEqual(events, ["first:start"]);
     releaseFirst();
-    const [a, b] = await Promise.all([first, second]);
-    assert.equal(a, 1);
-    assert.equal(b, 2);
+    const [resA, resB] = await Promise.all([first, second]);
+    assert.equal(resA, 1);
+    assert.equal(resB, 2);
     assert.deepEqual(events, ["first:start", "first:end", "second:start"]);
   });
 
@@ -106,19 +106,19 @@ describe("HostRateLimiter — serialization per host", () => {
     const lim = new HostRateLimiter(deps);
     const events: string[] = [];
     let releaseA: () => void = () => {};
-    const a = lim.run(
+    const runA = lim.run(
       "a.com",
       async () => {
         events.push("a:start");
-        await new Promise<void>((r) => {
-          releaseA = r;
+        await new Promise<void>((resolve) => {
+          releaseA = resolve;
         });
         events.push("a:end");
         return "a";
       },
       0,
     );
-    const b = lim.run(
+    const runB = lim.run(
       "b.com",
       async () => {
         events.push("b:start");
@@ -128,13 +128,13 @@ describe("HostRateLimiter — serialization per host", () => {
     );
     // Let both tasks schedule. a is still awaiting; b should
     // have completed.
-    const bResult = await b;
+    const bResult = await runB;
     assert.equal(bResult, "b");
     // b:start must have happened BEFORE a finishes — distinct
     // hosts don't serialize.
     assert.deepEqual(events, ["a:start", "b:start"]);
     releaseA();
-    await a;
+    await runA;
   });
 });
 

--- a/test/sources/test_registry.ts
+++ b/test/sources/test_registry.ts
@@ -127,76 +127,76 @@ describe("buildSource — validation", () => {
   });
 
   it("returns null for missing slug", () => {
-    const f = base();
-    f.delete("slug");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.delete("slug");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for invalid slug (uppercase)", () => {
-    const f = base();
-    f.set("slug", "HN");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.set("slug", "HN");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for invalid slug (path traversal)", () => {
-    const f = base();
-    f.set("slug", "../etc/passwd");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.set("slug", "../etc/passwd");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for missing title", () => {
-    const f = base();
-    f.delete("title");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.delete("title");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for missing url", () => {
-    const f = base();
-    f.delete("url");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.delete("url");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for unknown fetcher kind", () => {
-    const f = base();
-    f.set("fetcher_kind", "bogus");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.set("fetcher_kind", "bogus");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("returns null for unknown schedule", () => {
-    const f = base();
-    f.set("schedule", "quarterly");
-    assert.equal(buildSource(f, ""), null);
+    const front = base();
+    front.set("schedule", "quarterly");
+    assert.equal(buildSource(front, ""), null);
   });
 
   it("drops invalid categories silently", () => {
-    const f = base();
-    f.set("categories", ["ai", "bogus", "security"]);
-    const source = buildSource(f, "");
+    const front = base();
+    front.set("categories", ["ai", "bogus", "security"]);
+    const source = buildSource(front, "");
     assert.ok(source);
     assert.deepEqual(source!.categories, ["ai", "security"]);
   });
 
   it("falls back to the default max_items_per_fetch for invalid values", () => {
-    const f = base();
-    f.set("max_items_per_fetch", "not-a-number");
-    const source = buildSource(f, "");
+    const front = base();
+    front.set("max_items_per_fetch", "not-a-number");
+    const source = buildSource(front, "");
     assert.ok(source);
     assert.equal(source!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
   });
 
   it("falls back to the default for a zero / negative max", () => {
-    const f = base();
-    f.set("max_items_per_fetch", "0");
-    assert.equal(buildSource(f, "")!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
-    f.set("max_items_per_fetch", "-10");
-    assert.equal(buildSource(f, "")!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
+    const front = base();
+    front.set("max_items_per_fetch", "0");
+    assert.equal(buildSource(front, "")!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
+    front.set("max_items_per_fetch", "-10");
+    assert.equal(buildSource(front, "")!.maxItemsPerFetch, DEFAULT_MAX_ITEMS_PER_FETCH);
   });
 
   it("collects unrecognized keys into fetcherParams", () => {
-    const f = base();
-    f.set("github_repo", "anthropics/claude-code");
-    f.set("arxiv_query", "cs.CL");
-    const source = buildSource(f, "");
+    const front = base();
+    front.set("github_repo", "anthropics/claude-code");
+    front.set("arxiv_query", "cs.CL");
+    const source = buildSource(front, "");
     assert.ok(source);
     assert.deepEqual(source!.fetcherParams, {
       github_repo: "anthropics/claude-code",
@@ -205,9 +205,9 @@ describe("buildSource — validation", () => {
   });
 
   it("ignores array values in fetcherParams (schema mismatch)", () => {
-    const f = base();
-    f.set("weird_array", ["a", "b"]);
-    const source = buildSource(f, "");
+    const front = base();
+    front.set("weird_array", ["a", "b"]);
+    const source = buildSource(front, "");
     assert.ok(source);
     assert.equal(source!.fetcherParams["weird_array"], undefined);
   });
@@ -414,10 +414,10 @@ describe("listSources", () => {
       { ...makeSource(), slug: "alpha", title: "A" },
       { ...makeSource(), slug: "bravo", title: "B" },
     ];
-    for (const s of sources) await writeSource(workspace, s);
+    for (const src of sources) await writeSource(workspace, src);
     const listed = await listSources(workspace);
     assert.deepEqual(
-      listed.map((s) => s.slug),
+      listed.map((src) => src.slug),
       ["alpha", "bravo", "charlie"],
     );
   });

--- a/test/sources/test_robots.ts
+++ b/test/sources/test_robots.ts
@@ -163,9 +163,9 @@ Disallow: /private
 `);
     const merged = selectGroup(duplicateGroupsRobots, "Googlebot");
     assert.ok(merged);
-    const kinds = merged!.rules.map((r) => ({
-      kind: r.kind,
-      pattern: r.pattern,
+    const kinds = merged!.rules.map((rule) => ({
+      kind: rule.kind,
+      pattern: rule.pattern,
     }));
     assert.deepEqual(kinds, [
       { kind: "allow", pattern: "/public" },

--- a/test/sources/test_sourcesRoute.ts
+++ b/test/sources/test_sourcesRoute.ts
@@ -127,12 +127,12 @@ describe("deriveSourceSlug", () => {
   });
 
   it("is deterministic for the same input", () => {
-    const a = deriveSourceSlug("Cool feed");
-    const b = deriveSourceSlug("Cool feed");
-    assert.equal(a, b);
-    const h1 = deriveSourceSlug("日本語");
-    const h2 = deriveSourceSlug("日本語");
-    assert.equal(h1, h2);
+    const slugA = deriveSourceSlug("Cool feed");
+    const slugB = deriveSourceSlug("Cool feed");
+    assert.equal(slugA, slugB);
+    const hashA = deriveSourceSlug("日本語");
+    const hashB = deriveSourceSlug("日本語");
+    assert.equal(hashA, hashB);
   });
 });
 

--- a/test/tool-trace/test_classify.ts
+++ b/test/tool-trace/test_classify.ts
@@ -4,37 +4,37 @@ import { MAX_INLINE_CONTENT_CHARS, classifyToolResult } from "../../server/works
 
 describe("classifyToolResult — WebSearch", () => {
   it("returns a pointer when searchContentRef is provided", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "WebSearch",
       args: { query: "foo" },
       content: "irrelevant",
       searchContentRef: "conversations/searches/2026-04-13/foo-abc.md",
     });
-    assert.deepEqual(c, {
+    assert.deepEqual(result, {
       kind: "pointer",
       contentRef: "conversations/searches/2026-04-13/foo-abc.md",
     });
   });
 
   it("falls back to inline when no searchContentRef is provided", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "WebSearch",
       args: { query: "foo" },
       content: "raw body",
     });
-    assert.equal(c.kind, "inline");
+    assert.equal(result.kind, "inline");
   });
 });
 
 describe("classifyToolResult — file-pointer tools", () => {
   for (const toolName of ["Read", "Write", "Edit"]) {
     it(`${toolName} with file_path → pointer`, () => {
-      const c = classifyToolResult({
+      const result = classifyToolResult({
         toolName,
         args: { file_path: "wiki/pages/foo.md" },
         content: "content should be ignored",
       });
-      assert.deepEqual(c, {
+      assert.deepEqual(result, {
         kind: "pointer",
         contentRef: "wiki/pages/foo.md",
       });
@@ -42,76 +42,76 @@ describe("classifyToolResult — file-pointer tools", () => {
   }
 
   it("normalises leading ./ in file_path", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Read",
       args: { file_path: "./chat/foo.jsonl" },
       content: "",
     });
-    assert.deepEqual(c, { kind: "pointer", contentRef: "chat/foo.jsonl" });
+    assert.deepEqual(result, { kind: "pointer", contentRef: "chat/foo.jsonl" });
   });
 
   it("normalises leading / in file_path", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Read",
       args: { file_path: "/wiki/index.md" },
       content: "",
     });
-    assert.deepEqual(c, { kind: "pointer", contentRef: "wiki/index.md" });
+    assert.deepEqual(result, { kind: "pointer", contentRef: "wiki/index.md" });
   });
 
   it("falls back to inline when file_path is absent/non-string", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Read",
       args: {},
       content: "some content",
     });
-    assert.equal(c.kind, "inline");
+    assert.equal(result.kind, "inline");
   });
 });
 
 describe("classifyToolResult — image tools", () => {
   it("generateImage with filePath in content → pointer", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "generateImage",
       args: { prompt: "cat" },
       content: '{"filePath": "images/cat-123.png", "size": 1024}',
     });
-    assert.deepEqual(c, {
+    assert.deepEqual(result, {
       kind: "pointer",
       contentRef: "images/cat-123.png",
     });
   });
 
   it("editImage with path key in content → pointer", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "editImage",
       args: {},
       content: '{"path": "images/edit-abc.png"}',
     });
-    assert.deepEqual(c, {
+    assert.deepEqual(result, {
       kind: "pointer",
       contentRef: "images/edit-abc.png",
     });
   });
 
   it("falls back to inline when image content has no path key", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "generateImage",
       args: {},
       content: "no path here",
     });
-    assert.equal(c.kind, "inline");
+    assert.equal(result.kind, "inline");
   });
 });
 
 describe("classifyToolResult — inline truncation", () => {
   it("short content is inlined verbatim, not truncated", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Bash",
       args: { command: "ls" },
       content: "foo.md\nbar.md",
     });
-    assert.deepEqual(c, {
+    assert.deepEqual(result, {
       kind: "inline",
       content: "foo.md\nbar.md",
       truncated: false,
@@ -120,58 +120,58 @@ describe("classifyToolResult — inline truncation", () => {
 
   it("content exactly at MAX is inlined, not truncated", () => {
     const content = "a".repeat(MAX_INLINE_CONTENT_CHARS);
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Bash",
       args: {},
       content,
     });
-    assert.equal(c.kind, "inline");
-    if (c.kind === "inline") {
-      assert.equal(c.content.length, MAX_INLINE_CONTENT_CHARS);
-      assert.equal(c.truncated, false);
+    assert.equal(result.kind, "inline");
+    if (result.kind === "inline") {
+      assert.equal(result.content.length, MAX_INLINE_CONTENT_CHARS);
+      assert.equal(result.truncated, false);
     }
   });
 
   it("one char over MAX → truncated to MAX", () => {
     const content = "a".repeat(MAX_INLINE_CONTENT_CHARS + 1);
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Bash",
       args: {},
       content,
     });
-    assert.equal(c.kind, "inline");
-    if (c.kind === "inline") {
-      assert.equal(c.content.length, MAX_INLINE_CONTENT_CHARS);
-      assert.equal(c.truncated, true);
+    assert.equal(result.kind, "inline");
+    if (result.kind === "inline") {
+      assert.equal(result.content.length, MAX_INLINE_CONTENT_CHARS);
+      assert.equal(result.truncated, true);
     }
   });
 
   it("WebFetch huge body → truncated", () => {
     const content = "x".repeat(MAX_INLINE_CONTENT_CHARS * 3);
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "WebFetch",
       args: { url: "https://example.com" },
       content,
     });
-    assert.equal(c.kind, "inline");
-    if (c.kind === "inline") assert.equal(c.truncated, true);
+    assert.equal(result.kind, "inline");
+    if (result.kind === "inline") assert.equal(result.truncated, true);
   });
 
   it("empty content is inlined as empty string, not truncated", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "Bash",
       args: {},
       content: "",
     });
-    assert.deepEqual(c, { kind: "inline", content: "", truncated: false });
+    assert.deepEqual(result, { kind: "inline", content: "", truncated: false });
   });
 
   it("unknown tool name defaults to inline behaviour", () => {
-    const c = classifyToolResult({
+    const result = classifyToolResult({
       toolName: "SomeRandomTool",
       args: {},
       content: "hello",
     });
-    assert.deepEqual(c, { kind: "inline", content: "hello", truncated: false });
+    assert.deepEqual(result, { kind: "inline", content: "hello", truncated: false });
   });
 });

--- a/test/tool-trace/test_index.ts
+++ b/test/tool-trace/test_index.ts
@@ -65,12 +65,12 @@ describe("recordToolEvent", () => {
 
   // Isolate each test with its own harness so argsCache / jsonl don't
   // leak between cases.
-  let h: Harness;
+  let harness: Harness;
   beforeEach(async () => {
     // Crypto-grade random keeps sonarjs/pseudo-random happy;
     // uniqueness only matters so each case gets its own jsonl dir.
     const subdir = path.join(workspaceRoot, `case-${randomBytes(4).toString("hex")}`);
-    h = await makeHarness(subdir);
+    harness = await makeHarness(subdir);
   });
 
   it("writes a tool_call record and caches args", async () => {
@@ -81,14 +81,14 @@ describe("recordToolEvent", () => {
         toolName: "Bash",
         args: { command: "ls" },
       },
-      h.deps,
+      harness.deps,
     );
-    const lines = readJsonlLines(await h.readJsonl());
+    const lines = readJsonlLines(await harness.readJsonl());
     assert.equal(lines.length, 1);
     assert.equal(lines[0].type, "tool_call");
     assert.equal(lines[0].toolName, "Bash");
     assert.deepEqual(lines[0].args, { command: "ls" });
-    assert.equal(h.deps.argsCache.size, 1);
+    assert.equal(harness.deps.argsCache.size, 1);
   });
 
   it("matching tool_call_result for WebSearch writes a pointer record", async () => {
@@ -99,7 +99,7 @@ describe("recordToolEvent", () => {
         toolName: "WebSearch",
         args: { query: "foo bar" },
       },
-      h.deps,
+      harness.deps,
     );
     await recordToolEvent(
       {
@@ -107,15 +107,15 @@ describe("recordToolEvent", () => {
         toolUseId: "u-ws",
         content: "top result body",
       },
-      h.deps,
+      harness.deps,
     );
-    const lines = readJsonlLines(await h.readJsonl());
-    const resultLine = lines.find((l) => l.type === "tool_call_result");
+    const lines = readJsonlLines(await harness.readJsonl());
+    const resultLine = lines.find((line) => line.type === "tool_call_result");
     assert.ok(resultLine);
     assert.ok(String(resultLine?.contentRef).startsWith("conversations/searches/2026-04-13/"));
     assert.equal(resultLine?.content, undefined);
-    assert.equal(h.savedSearches.length, 1);
-    assert.equal(h.savedSearches[0].query, "foo bar");
+    assert.equal(harness.savedSearches.length, 1);
+    assert.equal(harness.savedSearches[0].query, "foo bar");
   });
 
   it("Read tool_call_result records a pointer to args.file_path", async () => {
@@ -126,7 +126,7 @@ describe("recordToolEvent", () => {
         toolName: "Read",
         args: { file_path: "wiki/pages/foo.md" },
       },
-      h.deps,
+      harness.deps,
     );
     await recordToolEvent(
       {
@@ -134,10 +134,10 @@ describe("recordToolEvent", () => {
         toolUseId: "u-read",
         content: "file content bytes",
       },
-      h.deps,
+      harness.deps,
     );
-    const lines = readJsonlLines(await h.readJsonl());
-    const resultLine = lines.find((l) => l.type === "tool_call_result");
+    const lines = readJsonlLines(await harness.readJsonl());
+    const resultLine = lines.find((line) => line.type === "tool_call_result");
     assert.equal(resultLine?.contentRef, "wiki/pages/foo.md");
     assert.equal(resultLine?.content, undefined);
   });
@@ -150,11 +150,11 @@ describe("recordToolEvent", () => {
         toolName: "Bash",
         args: { command: "echo hi" },
       },
-      h.deps,
+      harness.deps,
     );
-    await recordToolEvent({ type: "tool_call_result", toolUseId: "u-bash", content: "hi" }, h.deps);
-    const lines = readJsonlLines(await h.readJsonl());
-    const resultLine = lines.find((l) => l.type === "tool_call_result");
+    await recordToolEvent({ type: "tool_call_result", toolUseId: "u-bash", content: "hi" }, harness.deps);
+    const lines = readJsonlLines(await harness.readJsonl());
+    const resultLine = lines.find((line) => line.type === "tool_call_result");
     assert.equal(resultLine?.content, "hi");
     assert.equal(resultLine?.truncated, false);
   });
@@ -167,10 +167,10 @@ describe("recordToolEvent", () => {
         toolName: "Bash",
         args: { command: "ls" },
       },
-      h.deps,
+      harness.deps,
     );
-    await recordToolEvent({ type: "tool_call_result", toolUseId: "u-x", content: "ok" }, h.deps);
-    assert.equal(h.deps.argsCache.size, 0);
+    await recordToolEvent({ type: "tool_call_result", toolUseId: "u-x", content: "ok" }, harness.deps);
+    assert.equal(harness.deps.argsCache.size, 0);
   });
 
   it("orphan tool_call_result (no prior call) still writes a best-effort inline record", async () => {
@@ -180,9 +180,9 @@ describe("recordToolEvent", () => {
         toolUseId: "u-orphan",
         content: "mystery output",
       },
-      h.deps,
+      harness.deps,
     );
-    const lines = readJsonlLines(await h.readJsonl());
+    const lines = readJsonlLines(await harness.readJsonl());
     assert.equal(lines.length, 1);
     assert.equal(lines[0].type, "tool_call_result");
     assert.equal(lines[0].content, "mystery output");
@@ -191,7 +191,7 @@ describe("recordToolEvent", () => {
 
   it("saveSearch throwing falls back to inline content (never kills the turn)", async () => {
     const failingDeps: RecordToolEventDeps = {
-      ...h.deps,
+      ...harness.deps,
       saveSearch: async () => {
         throw new Error("disk full");
       },
@@ -213,8 +213,8 @@ describe("recordToolEvent", () => {
       },
       failingDeps,
     );
-    const lines = readJsonlLines(await h.readJsonl());
-    const resultLine = lines.find((l) => l.type === "tool_call_result");
+    const lines = readJsonlLines(await harness.readJsonl());
+    const resultLine = lines.find((line) => line.type === "tool_call_result");
     assert.equal(resultLine?.content, "raw result");
     assert.equal(resultLine?.contentRef, undefined);
   });

--- a/test/tool-trace/test_writeSearch.ts
+++ b/test/tool-trace/test_writeSearch.ts
@@ -26,67 +26,67 @@ describe("formatSearchDateDir", () => {
 
 describe("computeSearchHash", () => {
   it("is deterministic for the same inputs", () => {
-    const a = computeSearchHash("foo", SID, FIXED_TS);
-    const b = computeSearchHash("foo", SID, FIXED_TS);
-    assert.equal(a, b);
+    const hash1 = computeSearchHash("foo", SID, FIXED_TS);
+    const hash2 = computeSearchHash("foo", SID, FIXED_TS);
+    assert.equal(hash1, hash2);
   });
 
   it("differs when query changes", () => {
-    const a = computeSearchHash("foo", SID, FIXED_TS);
-    const b = computeSearchHash("bar", SID, FIXED_TS);
-    assert.notEqual(a, b);
+    const hash1 = computeSearchHash("foo", SID, FIXED_TS);
+    const hash2 = computeSearchHash("bar", SID, FIXED_TS);
+    assert.notEqual(hash1, hash2);
   });
 
   it("differs when sessionId changes", () => {
-    const a = computeSearchHash("foo", "session-A", FIXED_TS);
-    const b = computeSearchHash("foo", "session-B", FIXED_TS);
-    assert.notEqual(a, b);
+    const hash1 = computeSearchHash("foo", "session-A", FIXED_TS);
+    const hash2 = computeSearchHash("foo", "session-B", FIXED_TS);
+    assert.notEqual(hash1, hash2);
   });
 
   it("returns an 8-char base64url-ish string", () => {
-    const h = computeSearchHash("foo", SID, FIXED_TS);
-    assert.equal(h.length, 8);
-    assert.match(h, /^[A-Za-z0-9_-]+$/);
+    const hash = computeSearchHash("foo", SID, FIXED_TS);
+    assert.equal(hash.length, 8);
+    assert.match(hash, /^[A-Za-z0-9_-]+$/);
   });
 });
 
 describe("computeSearchRelPath", () => {
   it("builds conversations/searches/YYYY-MM-DD/<slug>-<hash>.md", () => {
-    const p = computeSearchRelPath({
+    const relPath = computeSearchRelPath({
       query: "熊本地震 2016",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
-    assert.ok(p.startsWith("conversations/searches/2026-04-13/"));
-    assert.ok(p.endsWith(".md"));
+    assert.ok(relPath.startsWith("conversations/searches/2026-04-13/"));
+    assert.ok(relPath.endsWith(".md"));
   });
 
   it("produces stable path for identical inputs", () => {
-    const a = computeSearchRelPath({
+    const path1 = computeSearchRelPath({
       query: "claude code",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
-    const b = computeSearchRelPath({
+    const path2 = computeSearchRelPath({
       query: "claude code",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
-    assert.equal(a, b);
+    assert.equal(path1, path2);
   });
 
   it("produces different paths for different queries", () => {
-    const a = computeSearchRelPath({
+    const path1 = computeSearchRelPath({
       query: "foo",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
-    const b = computeSearchRelPath({
+    const path2 = computeSearchRelPath({
       query: "bar",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
-    assert.notEqual(a, b);
+    assert.notEqual(path1, path2);
   });
 });
 
@@ -169,7 +169,7 @@ describe("writeSearchResult (I/O)", () => {
       resultBody: "b",
     });
     const dir = path.join(workspaceRoot, "conversations", "searches", "2026-04-13");
-    const files = (await readdir(dir)).filter((n) => n.endsWith(".md"));
+    const files = (await readdir(dir)).filter((name) => name.endsWith(".md"));
     // At least two files (prior test in this block wrote one too).
     assert.ok(files.length >= 2);
   });

--- a/test/utils/dom/test_clickOutside.ts
+++ b/test/utils/dom/test_clickOutside.ts
@@ -4,16 +4,16 @@ import { isClickOutside } from "../../../src/utils/dom/clickOutside.js";
 
 // Minimal Element-shaped fakes. The function only needs `contains`.
 function fakeEl(name: string, descendants: Node[] = []): HTMLElement {
-  const el = {
+  const element = {
     __name: name,
-    contains: (n: Node | null) => {
-      if (!n) return false;
-      if (n === (el as unknown as Node)) return true;
-      return descendants.includes(n);
+    contains: (node: Node | null) => {
+      if (!node) return false;
+      if (node === (element as unknown as Node)) return true;
+      return descendants.includes(node);
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
-  return el as HTMLElement;
+  return element as HTMLElement;
 }
 
 function fakeNode(name: string): Node {

--- a/test/utils/dom/test_scrollable.ts
+++ b/test/utils/dom/test_scrollable.ts
@@ -28,10 +28,10 @@ afterEach(() => {
 
 function fakeContainer(children: MockElement[]) {
   const elements = children.map(
-    (c) =>
+    (child) =>
       ({
-        scrollHeight: c.scrollHeight,
-        clientHeight: c.clientHeight,
+        scrollHeight: child.scrollHeight,
+        clientHeight: child.clientHeight,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any,
   );
@@ -40,15 +40,15 @@ function fakeContainer(children: MockElement[]) {
   // sees the overflow we configured per fake child. The afterEach
   // hook above restores the original implementation.
   const styles = new Map<unknown, { overflow: string; overflowY: string }>();
-  children.forEach((c, i) => {
+  children.forEach((child, i) => {
     styles.set(elements[i], {
-      overflowY: c.overflowY ?? "visible",
-      overflow: c.overflow ?? "visible",
+      overflowY: child.overflowY ?? "visible",
+      overflow: child.overflow ?? "visible",
     });
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).getComputedStyle = (el: unknown): { overflow: string; overflowY: string } =>
-    styles.get(el) ?? { overflow: "visible", overflowY: "visible" };
+  (globalThis as any).getComputedStyle = (element: unknown): { overflow: string; overflowY: string } =>
+    styles.get(element) ?? { overflow: "visible", overflowY: "visible" };
 
   return {
     querySelectorAll: () => elements,
@@ -58,38 +58,38 @@ function fakeContainer(children: MockElement[]) {
 
 describe("findScrollableChild", () => {
   it("returns null when no descendant overflows", () => {
-    const c = fakeContainer([
+    const container = fakeContainer([
       { scrollHeight: 100, clientHeight: 100 },
       { scrollHeight: 50, clientHeight: 200 },
     ]);
-    assert.equal(findScrollableChild(c), null);
+    assert.equal(findScrollableChild(container), null);
   });
 
   it("returns null when a descendant overflows but has visible overflow", () => {
-    const c = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflow: "visible" }]);
-    assert.equal(findScrollableChild(c), null);
+    const container = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflow: "visible" }]);
+    assert.equal(findScrollableChild(container), null);
   });
 
   it("returns the first descendant that overflows AND is overflow-y: auto", () => {
-    const c = fakeContainer([
+    const container = fakeContainer([
       { scrollHeight: 100, clientHeight: 100 }, // not scrollable
       { scrollHeight: 500, clientHeight: 100, overflowY: "auto" }, // ✓
       { scrollHeight: 500, clientHeight: 100, overflowY: "scroll" }, // also ✓ but later
     ]);
-    const found = findScrollableChild(c);
+    const found = findScrollableChild(container);
     assert.ok(found);
     assert.equal(found?.scrollHeight, 500);
   });
 
   it("recognizes overflow: scroll on the shorthand property", () => {
-    const c = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflow: "scroll" }]);
-    const found = findScrollableChild(c);
+    const container = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflow: "scroll" }]);
+    const found = findScrollableChild(container);
     assert.ok(found);
   });
 
   it("recognizes overflow-y: scroll", () => {
-    const c = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflowY: "scroll" }]);
-    const found = findScrollableChild(c);
+    const container = fakeContainer([{ scrollHeight: 500, clientHeight: 100, overflowY: "scroll" }]);
+    const found = findScrollableChild(container);
     assert.ok(found);
   });
 });

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -42,7 +42,7 @@ describe("writeFileAtomic", () => {
     await assert.rejects(() => writeFileAtomic(dir, "content"));
     // No .tmp file should be left behind
     const siblings = fs.readdirSync(path.dirname(dir));
-    const tmps = siblings.filter((f) => f.endsWith(".tmp"));
+    const tmps = siblings.filter((file) => file.endsWith(".tmp"));
     assert.equal(tmps.length, 0);
   });
 
@@ -81,6 +81,6 @@ describe("writeFileAtomicSync", () => {
     fs.mkdirSync(dir, { recursive: true });
     assert.throws(() => writeFileAtomicSync(dir, "content"));
     const siblings = fs.readdirSync(path.dirname(dir));
-    assert.equal(siblings.filter((f) => f.endsWith(".tmp")).length, 0);
+    assert.equal(siblings.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 });

--- a/test/utils/files/test_naming.ts
+++ b/test/utils/files/test_naming.ts
@@ -4,41 +4,41 @@ import { buildArtifactPath, buildArtifactPathRandom } from "../../../server/util
 
 describe("buildArtifactPath", () => {
   it("uses slugified title + timestamp suffix", () => {
-    const p = buildArtifactPath("artifacts/charts", "Sales Q1", ".chart.json", "chart");
-    assert.match(p, /^artifacts\/charts\/sales-q1-\d+\.chart\.json$/);
+    const artifactPath = buildArtifactPath("artifacts/charts", "Sales Q1", ".chart.json", "chart");
+    assert.match(artifactPath, /^artifacts\/charts\/sales-q1-\d+\.chart\.json$/);
   });
 
   it("falls back when title is undefined", () => {
-    const p = buildArtifactPath("artifacts/charts", undefined, ".json", "chart");
-    assert.match(p, /^artifacts\/charts\/chart-\d+\.json$/);
+    const artifactPath = buildArtifactPath("artifacts/charts", undefined, ".json", "chart");
+    assert.match(artifactPath, /^artifacts\/charts\/chart-\d+\.json$/);
   });
 });
 
 describe("buildArtifactPathRandom", () => {
   it("uses slugified prefix + 16-char hex suffix", () => {
-    const p = buildArtifactPathRandom("artifacts/documents", "project-summary", ".md", "document");
-    assert.match(p, /^artifacts\/documents\/project-summary-[0-9a-f]{16}\.md$/);
+    const artifactPath = buildArtifactPathRandom("artifacts/documents", "project-summary", ".md", "document");
+    assert.match(artifactPath, /^artifacts\/documents\/project-summary-[0-9a-f]{16}\.md$/);
   });
 
   it("slugifies mixed-case / spaces / punctuation", () => {
-    const p = buildArtifactPathRandom("artifacts/documents", "My Report: Draft #2!", ".md", "document");
-    assert.match(p, /^artifacts\/documents\/my-report-draft-2-[0-9a-f]{16}\.md$/);
+    const artifactPath = buildArtifactPathRandom("artifacts/documents", "My Report: Draft #2!", ".md", "document");
+    assert.match(artifactPath, /^artifacts\/documents\/my-report-draft-2-[0-9a-f]{16}\.md$/);
   });
 
   it("falls back when prefix sanitizes to empty", () => {
-    const p = buildArtifactPathRandom("artifacts/documents", "***", ".md", "document");
-    assert.match(p, /^artifacts\/documents\/document-[0-9a-f]{16}\.md$/);
+    const artifactPath = buildArtifactPathRandom("artifacts/documents", "***", ".md", "document");
+    assert.match(artifactPath, /^artifacts\/documents\/document-[0-9a-f]{16}\.md$/);
   });
 
   it("handles non-ASCII prefixes via slugify's hash fallback", () => {
-    const p = buildArtifactPathRandom("artifacts/documents", "進行中", ".md", "document");
+    const artifactPath = buildArtifactPathRandom("artifacts/documents", "進行中", ".md", "document");
     // slugify returns a base64url hash for fully non-ASCII input.
-    assert.match(p, /^artifacts\/documents\/[A-Za-z0-9_-]+-[0-9a-f]{16}\.md$/);
+    assert.match(artifactPath, /^artifacts\/documents\/[A-Za-z0-9_-]+-[0-9a-f]{16}\.md$/);
   });
 
   it("produces distinct suffixes across calls with the same prefix", () => {
-    const a = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
-    const b = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
-    assert.notEqual(a, b);
+    const path1 = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
+    const path2 = buildArtifactPathRandom("artifacts/documents", "note", ".md", "document");
+    assert.notEqual(path1, path2);
   });
 });

--- a/test/utils/files/test_workspace_io.ts
+++ b/test/utils/files/test_workspace_io.ts
@@ -62,7 +62,7 @@ describe("readWorkspaceText / writeWorkspaceText", () => {
   it("write is atomic — no .tmp leftover on success", async () => {
     await mod.writeWorkspaceText("test-atomic/clean.txt", "ok");
     const entries = fs.readdirSync(path.join(wsRoot(), "test-atomic"));
-    assert.equal(entries.filter((f) => f.endsWith(".tmp")).length, 0);
+    assert.equal(entries.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 
   it("creates parent directories on write", async () => {

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -29,9 +29,9 @@ describe("formatDate", () => {
   });
 
   it("differs across days at the same time", () => {
-    const a = formatDate("2026-01-01T12:00:00Z");
-    const b = formatDate("2026-12-31T12:00:00Z");
-    assert.notEqual(a, b);
+    const dateJan = formatDate("2026-01-01T12:00:00Z");
+    const dateDec = formatDate("2026-12-31T12:00:00Z");
+    assert.notEqual(dateJan, dateDec);
   });
 });
 

--- a/test/utils/role/test_icon.ts
+++ b/test/utils/role/test_icon.ts
@@ -42,7 +42,7 @@ describe("roleIcon", () => {
   });
 
   it("accepts only lowercase letters and underscores as valid icons", () => {
-    const r: Role[] = [
+    const testRoles: Role[] = [
       {
         id: "a",
         name: "",
@@ -72,10 +72,10 @@ describe("roleIcon", () => {
         availablePlugins: [],
       },
     ];
-    assert.equal(roleIcon(r, "a"), "valid_name");
-    assert.equal(roleIcon(r, "b"), "smart_toy");
-    assert.equal(roleIcon(r, "c"), "smart_toy");
-    assert.equal(roleIcon(r, "d"), "smart_toy");
+    assert.equal(roleIcon(testRoles, "a"), "valid_name");
+    assert.equal(roleIcon(testRoles, "b"), "smart_toy");
+    assert.equal(roleIcon(testRoles, "c"), "smart_toy");
+    assert.equal(roleIcon(testRoles, "d"), "smart_toy");
   });
 });
 

--- a/test/utils/role/test_merge.ts
+++ b/test/utils/role/test_merge.ts
@@ -17,7 +17,7 @@ describe("mergeRoles", () => {
   it("returns built-in roles unchanged when there are no custom roles", () => {
     const out = mergeRoles([role("a"), role("b")], []);
     assert.deepEqual(
-      out.map((r) => r.id),
+      out.map((entry) => entry.id),
       ["a", "b"],
     );
   });
@@ -25,7 +25,7 @@ describe("mergeRoles", () => {
   it("appends custom roles after the built-ins", () => {
     const out = mergeRoles([role("a"), role("b")], [role("c"), role("d")]);
     assert.deepEqual(
-      out.map((r) => r.id),
+      out.map((entry) => entry.id),
       ["a", "b", "c", "d"],
     );
   });
@@ -43,7 +43,7 @@ describe("mergeRoles", () => {
   it("returns custom only when built-ins are empty", () => {
     const out = mergeRoles([], [role("only")]);
     assert.deepEqual(
-      out.map((r) => r.id),
+      out.map((entry) => entry.id),
       ["only"],
     );
   });
@@ -55,7 +55,7 @@ describe("mergeRoles", () => {
   it("preserves the order of built-in roles that are not overridden", () => {
     const out = mergeRoles([role("a"), role("b"), role("c"), role("d")], [role("c", "Custom C")]);
     assert.deepEqual(
-      out.map((r) => r.id),
+      out.map((entry) => entry.id),
       ["a", "b", "d", "c"],
     );
   });

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -53,34 +53,34 @@ function makeUserTextResult(message: string): ToolResultComplete {
 
 describe("compareSessionsByRecency", () => {
   it("returns negative when a is more recently updated", () => {
-    const a = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
-    const b = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
-    assert.ok(compareSessionsByRecency(a, b) < 0);
+    const sessA = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    const sessB = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(sessA, sessB) < 0);
   });
 
   it("returns positive when b is more recently updated", () => {
-    const a = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
-    const b = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
-    assert.ok(compareSessionsByRecency(a, b) > 0);
+    const sessA = makeSummary({ updatedAt: "2026-04-10T10:00:00.000Z" });
+    const sessB = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
+    assert.ok(compareSessionsByRecency(sessA, sessB) > 0);
   });
 
   it("falls back to startedAt on updatedAt tie", () => {
-    const a = makeSummary({
+    const sessA = makeSummary({
       updatedAt: "2026-04-10T10:00:00.000Z",
       startedAt: "2026-04-08T10:00:00.000Z",
     });
-    const b = makeSummary({
+    const sessB = makeSummary({
       updatedAt: "2026-04-10T10:00:00.000Z",
       startedAt: "2026-04-09T10:00:00.000Z",
     });
-    // b has newer startedAt, so b should come first
-    assert.ok(compareSessionsByRecency(a, b) > 0);
+    // sessB has newer startedAt, so sessB should come first
+    assert.ok(compareSessionsByRecency(sessA, sessB) > 0);
   });
 
   it("returns 0 when both updatedAt and startedAt match", () => {
-    const a = makeSummary({ id: "a" });
-    const b = makeSummary({ id: "b" });
-    assert.equal(compareSessionsByRecency(a, b), 0);
+    const sessA = makeSummary({ id: "a" });
+    const sessB = makeSummary({ id: "b" });
+    assert.equal(compareSessionsByRecency(sessA, sessB), 0);
   });
 });
 
@@ -167,7 +167,7 @@ describe("mergeSessionLists — server-only entries", () => {
     const live = makeActive({ id: "live-only" });
     const server = makeSummary({ id: "srv-only" });
     const result = mergeSessionLists([live], [server]);
-    const serverEntry = result.find((s) => s.id === "srv-only");
+    const serverEntry = result.find((sess) => sess.id === "srv-only");
     assert.equal(serverEntry, server);
   });
 
@@ -191,7 +191,7 @@ describe("mergeSessionLists — sort order", () => {
     });
     const result = mergeSessionLists([], [older, recent]);
     assert.deepEqual(
-      result.map((s) => s.id),
+      result.map((sess) => sess.id),
       ["recent", "older"],
     );
   });
@@ -208,26 +208,26 @@ describe("mergeSessionLists — sort order", () => {
     const result = mergeSessionLists([live], [server]);
     // srv is newer → comes first
     assert.deepEqual(
-      result.map((s) => s.id),
+      result.map((sess) => sess.id),
       ["srv", "live"],
     );
   });
 
   it("breaks updatedAt ties with startedAt", () => {
-    const a = makeSummary({
+    const sessA = makeSummary({
       id: "a",
       updatedAt: "2026-04-10T10:00:00.000Z",
       startedAt: "2026-04-08T10:00:00.000Z",
     });
-    const b = makeSummary({
+    const sessB = makeSummary({
       id: "b",
       updatedAt: "2026-04-10T10:00:00.000Z",
       startedAt: "2026-04-09T10:00:00.000Z",
     });
-    const result = mergeSessionLists([], [a, b]);
-    // b has newer startedAt → b first
+    const result = mergeSessionLists([], [sessA, sessB]);
+    // sessB has newer startedAt → sessB first
     assert.deepEqual(
-      result.map((s) => s.id),
+      result.map((sess) => sess.id),
       ["b", "a"],
     );
   });
@@ -257,23 +257,23 @@ describe("applySessionDiff — upsert", () => {
     const cache = [makeSummary({ id: "a", preview: "old" }), makeSummary({ id: "b" })];
     const diff = [makeSummary({ id: "a", preview: "new" })];
     const out = applySessionDiff(cache, diff, []);
-    const a = out.find((s) => s.id === "a");
-    assert.equal(a?.preview, "new");
-    const b = out.find((s) => s.id === "b");
-    assert.ok(b, "untouched cache rows survive");
+    const sessA = out.find((sess) => sess.id === "a");
+    assert.equal(sessA?.preview, "new");
+    const sessB = out.find((sess) => sess.id === "b");
+    assert.ok(sessB, "untouched cache rows survive");
   });
 
   it("adds rows whose ids are new to the cache", () => {
     const cache = [makeSummary({ id: "a" })];
     const diff = [makeSummary({ id: "b" })];
     const out = applySessionDiff(cache, diff, []);
-    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "b"]);
+    assert.deepEqual(out.map((sess) => sess.id).sort(), ["a", "b"]);
   });
 
   it("is a no-op when diff and deletedIds are both empty", () => {
     const cache = [makeSummary({ id: "a" }), makeSummary({ id: "b" })];
     const out = applySessionDiff(cache, [], []);
-    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "b"]);
+    assert.deepEqual(out.map((sess) => sess.id).sort(), ["a", "b"]);
   });
 });
 
@@ -281,7 +281,7 @@ describe("applySessionDiff — deletedIds", () => {
   it("removes cached rows whose id is in deletedIds", () => {
     const cache = [makeSummary({ id: "a" }), makeSummary({ id: "b" }), makeSummary({ id: "c" })];
     const out = applySessionDiff(cache, [], ["b"]);
-    assert.deepEqual(out.map((s) => s.id).sort(), ["a", "c"]);
+    assert.deepEqual(out.map((sess) => sess.id).sort(), ["a", "c"]);
   });
 
   it("removes before applying the diff (id in both → removed)", () => {
@@ -295,8 +295,8 @@ describe("applySessionDiff — deletedIds", () => {
     // *cache* pass; that matches the server's contract ("these
     // rows changed, these rows are gone") where every diff row
     // is authoritative.
-    const a = out.find((s) => s.id === "a");
-    assert.equal(a?.preview, "updated");
+    const sessA = out.find((sess) => sess.id === "a");
+    assert.equal(sessA?.preview, "updated");
     assert.equal(out.length, 1);
   });
 });

--- a/test/utils/test_date.ts
+++ b/test/utils/test_date.ts
@@ -5,30 +5,30 @@ import { toLocalIsoDate, toUtcIsoDate, isoDateOnly, isValidIsoDate } from "../..
 describe("toLocalIsoDate", () => {
   it("formats a Date to YYYY-MM-DD in local time", () => {
     // Use a date where local and UTC differ to verify local is used.
-    const d = new Date(2026, 3, 17); // April 17, 2026 in local tz
-    assert.equal(toLocalIsoDate(d), "2026-04-17");
+    const date = new Date(2026, 3, 17); // April 17, 2026 in local tz
+    assert.equal(toLocalIsoDate(date), "2026-04-17");
   });
 
   it("accepts a ms timestamp", () => {
-    const d = new Date(2026, 0, 1);
-    assert.equal(toLocalIsoDate(d.getTime()), "2026-01-01");
+    const date = new Date(2026, 0, 1);
+    assert.equal(toLocalIsoDate(date.getTime()), "2026-01-01");
   });
 
   it("zero-pads single-digit months and days", () => {
-    const d = new Date(2026, 0, 5); // Jan 5
-    assert.equal(toLocalIsoDate(d), "2026-01-05");
+    const date = new Date(2026, 0, 5); // Jan 5
+    assert.equal(toLocalIsoDate(date), "2026-01-05");
   });
 });
 
 describe("toUtcIsoDate", () => {
   it("formats a Date to YYYY-MM-DD in UTC", () => {
-    const d = new Date("2026-04-17T23:30:00Z");
-    assert.equal(toUtcIsoDate(d), "2026-04-17");
+    const date = new Date("2026-04-17T23:30:00Z");
+    assert.equal(toUtcIsoDate(date), "2026-04-17");
   });
 
   it("zero-pads single-digit months and days", () => {
-    const d = new Date("2026-01-05T00:00:00Z");
-    assert.equal(toUtcIsoDate(d), "2026-01-05");
+    const date = new Date("2026-01-05T00:00:00Z");
+    assert.equal(toUtcIsoDate(date), "2026-01-05");
   });
 });
 

--- a/test/utils/test_fs.ts
+++ b/test/utils/test_fs.ts
@@ -15,7 +15,7 @@ function makeScratch(prefix: string): string {
   return fs.realpathSync(dir);
 }
 
-function rm(dir: string): void {
+function removeScratch(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
@@ -26,18 +26,18 @@ describe("statSafe", () => {
     fs.writeFileSync(path.join(scratch, "file.txt"), "hi");
     fs.mkdirSync(path.join(scratch, "subdir"));
   });
-  after(() => rm(scratch));
+  after(() => removeScratch(scratch));
 
   it("returns Stats for an existing file", () => {
-    const s = statSafe(path.join(scratch, "file.txt"));
-    assert.ok(s);
-    assert.ok(s!.isFile());
+    const stats = statSafe(path.join(scratch, "file.txt"));
+    assert.ok(stats);
+    assert.ok(stats!.isFile());
   });
 
   it("returns Stats for an existing directory", () => {
-    const s = statSafe(path.join(scratch, "subdir"));
-    assert.ok(s);
-    assert.ok(s!.isDirectory());
+    const stats = statSafe(path.join(scratch, "subdir"));
+    assert.ok(stats);
+    assert.ok(stats!.isDirectory());
   });
 
   it("returns null for a missing path (ENOENT)", () => {
@@ -57,11 +57,11 @@ describe("readDirSafe", () => {
     fs.writeFileSync(path.join(scratch, "b.txt"), "");
     fs.mkdirSync(path.join(scratch, "sub"));
   });
-  after(() => rm(scratch));
+  after(() => removeScratch(scratch));
 
   it("returns the directory entries with file types", () => {
     const entries = readDirSafe(scratch)
-      .map((e) => e.name)
+      .map((entry) => entry.name)
       .sort();
     assert.deepEqual(entries, ["a.txt", "b.txt", "sub"]);
   });
@@ -87,7 +87,7 @@ describe("readTextOrNull", () => {
     scratch = makeScratch("readTextOrNull");
     fs.writeFileSync(path.join(scratch, "hi.txt"), "hello world");
   });
-  after(() => rm(scratch));
+  after(() => removeScratch(scratch));
 
   it("returns the file contents as a string", async () => {
     assert.equal(await readTextOrNull(path.join(scratch, "hi.txt")), "hello world");
@@ -110,7 +110,7 @@ describe("resolveWithinRoot — happy path", () => {
     fs.mkdirSync(path.join(scratch, "sub"));
     fs.writeFileSync(path.join(scratch, "sub", "nested.txt"), "");
   });
-  after(() => rm(scratch));
+  after(() => removeScratch(scratch));
 
   it("resolves a top-level file under the root", () => {
     const out = resolveWithinRoot(scratch, "file.txt");
@@ -148,7 +148,7 @@ describe("resolveWithinRoot — security: traversal", () => {
   });
   after(() => {
     fs.rmSync(outsideFile, { force: true });
-    rm(scratch);
+    removeScratch(scratch);
   });
 
   it("rejects ../ traversal that lands outside the root", () => {
@@ -202,7 +202,7 @@ describe("resolveWithinRoot — security: symlinks", () => {
   });
   after(() => {
     fs.rmSync(outsideFile, { force: true });
-    rm(scratch);
+    removeScratch(scratch);
   });
 
   it("rejects a symlink that resolves outside the root", () => {
@@ -250,7 +250,7 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
         /* ignore */
       }
     }
-    rm(realRoot);
+    removeScratch(realRoot);
   });
 
   it("resolves child paths against the realpath of a symlinked root", () => {
@@ -282,7 +282,7 @@ describe("resolveWithinRoot — missing files and edge cases", () => {
   before(() => {
     scratch = makeScratch("resolveWithinRoot-missing");
   });
-  after(() => rm(scratch));
+  after(() => removeScratch(scratch));
 
   it("returns null for a non-existent leaf path", () => {
     assert.equal(resolveWithinRoot(scratch, "nope.txt"), null);

--- a/test/utils/test_gitignore.ts
+++ b/test/utils/test_gitignore.ts
@@ -17,22 +17,22 @@ afterEach(() => {
 
 describe("GitignoreFilter", () => {
   it("ignores nothing when constructed with no rules", () => {
-    const f = new GitignoreFilter();
-    assert.equal(f.ignores("anything.txt"), false);
-    assert.equal(f.ignores("node_modules/"), false);
+    const filter = new GitignoreFilter();
+    assert.equal(filter.ignores("anything.txt"), false);
+    assert.equal(filter.ignores("node_modules/"), false);
   });
 
   it("matches patterns from the constructor", () => {
-    const f = new GitignoreFilter("node_modules/\ndist/\n");
-    assert.equal(f.ignores("node_modules/foo.js"), true);
-    assert.equal(f.ignores("dist/index.js"), true);
-    assert.equal(f.ignores("src/index.ts"), false);
+    const filter = new GitignoreFilter("node_modules/\ndist/\n");
+    assert.equal(filter.ignores("node_modules/foo.js"), true);
+    assert.equal(filter.ignores("dist/index.js"), true);
+    assert.equal(filter.ignores("src/index.ts"), false);
   });
 
   it("supports negation patterns", () => {
-    const f = new GitignoreFilter("*.log\n!important.log\n");
-    assert.equal(f.ignores("debug.log"), true);
-    assert.equal(f.ignores("important.log"), false);
+    const filter = new GitignoreFilter("*.log\n!important.log\n");
+    assert.equal(filter.ignores("debug.log"), true);
+    assert.equal(filter.ignores("important.log"), false);
   });
 });
 
@@ -64,16 +64,16 @@ describe("GitignoreFilter.childForDir", () => {
 
 describe("createRootFilter", () => {
   it("returns an empty filter when no .gitignore exists", () => {
-    const f = createRootFilter(tmpDir);
-    assert.equal(f.ignores("anything"), false);
+    const filter = createRootFilter(tmpDir);
+    assert.equal(filter.ignores("anything"), false);
   });
 
   it("reads the root .gitignore", () => {
     fs.writeFileSync(path.join(tmpDir, ".gitignore"), "github/\n.session-token\n");
-    const f = createRootFilter(tmpDir);
-    assert.equal(f.ignores("github/"), true);
-    assert.equal(f.ignores("github/repo/file.ts"), true);
-    assert.equal(f.ignores(".session-token"), true);
-    assert.equal(f.ignores("data/todos/todos.json"), false);
+    const filter = createRootFilter(tmpDir);
+    assert.equal(filter.ignores("github/"), true);
+    assert.equal(filter.ignores("github/repo/file.ts"), true);
+    assert.equal(filter.ignores(".session-token"), true);
+    assert.equal(filter.ignores("data/todos/todos.json"), false);
   });
 });

--- a/test/utils/test_id.ts
+++ b/test/utils/test_id.ts
@@ -14,9 +14,9 @@ describe("makeId", () => {
     const parts = id.split("_");
     // Format: prefix_timestamp_hex
     assert.equal(parts.length, 3);
-    const ts = Number(parts[1]);
-    assert.ok(Number.isFinite(ts));
-    assert.ok(ts > 1_700_000_000_000, "timestamp should be recent epoch ms");
+    const timestamp = Number(parts[1]);
+    assert.ok(Number.isFinite(timestamp));
+    assert.ok(timestamp > 1_700_000_000_000, "timestamp should be recent epoch ms");
   });
 
   it("ends with 6 hex characters", () => {

--- a/test/utils/test_logBackgroundError.ts
+++ b/test/utils/test_logBackgroundError.ts
@@ -5,15 +5,15 @@ import { logBackgroundError } from "../../server/utils/logBackgroundError.js";
 // The helper returns a callback. We capture stderr (the logger's
 // warn level target) so we can assert what lands without wiring
 // dependency injection into the logger itself.
-function captureStderr<T>(fn: () => T): { result: T; out: string } {
+function captureStderr<T>(func: () => T): { result: T; out: string } {
   const chunks: string[] = [];
   const originalWrite = process.stderr.write.bind(process.stderr);
-  process.stderr.write = ((c: string | Uint8Array) => {
-    chunks.push(typeof c === "string" ? c : c.toString());
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
     return true;
   }) as typeof process.stderr.write;
   try {
-    const result = fn();
+    const result = func();
     return { result, out: chunks.join("") };
   } finally {
     process.stderr.write = originalWrite;

--- a/test/utils/test_markdown.ts
+++ b/test/utils/test_markdown.ts
@@ -35,7 +35,7 @@ describe("splitFragmentAndQuery", () => {
 describe("rewriteMarkdownLinks", () => {
   it("rewrites the href of every markdown link", () => {
     const input = "See [foo](old) and [bar](old2).";
-    const result = rewriteMarkdownLinks(input, (h) => h.toUpperCase());
+    const result = rewriteMarkdownLinks(input, (href) => href.toUpperCase());
     assert.equal(result, "See [foo](OLD) and [bar](OLD2).");
   });
 
@@ -47,7 +47,7 @@ describe("rewriteMarkdownLinks", () => {
 
   it("handles adjacent links", () => {
     const input = "[a](1)[b](2)";
-    const result = rewriteMarkdownLinks(input, (h) => `_${h}_`);
+    const result = rewriteMarkdownLinks(input, (href) => `_${href}_`);
     assert.equal(result, "[a](_1_)[b](_2_)");
   });
 });

--- a/test/utils/test_slug.ts
+++ b/test/utils/test_slug.ts
@@ -72,11 +72,11 @@ describe("slugify (non-ASCII fallback)", () => {
   });
 
   it("gives different ids to labels differing only in suffix", () => {
-    const a = slugify("プロジェクトA");
-    const b = slugify("プロジェクトB");
-    assert.notEqual(a, b);
-    assert.equal(a.length, HASH_LEN);
-    assert.equal(b.length, HASH_LEN);
+    const slugA = slugify("プロジェクトA");
+    const slugB = slugify("プロジェクトB");
+    assert.notEqual(slugA, slugB);
+    assert.equal(slugA.length, HASH_LEN);
+    assert.equal(slugB.length, HASH_LEN);
   });
 
   it("keeps an ASCII prefix when ≥3 chars survive", () => {

--- a/test/utils/tools/test_pendingCalls.ts
+++ b/test/utils/tools/test_pendingCalls.ts
@@ -15,38 +15,38 @@ function call(over: Partial<ToolCallHistoryItem>): ToolCallHistoryItem {
 
 describe("isCallStillPending", () => {
   it("is true when neither result nor error is set", () => {
-    const c = call({ timestamp: 1000 });
-    assert.equal(isCallStillPending(c, 9999999), true);
+    const toolCall = call({ timestamp: 1000 });
+    assert.equal(isCallStillPending(toolCall, 9999999), true);
   });
 
   it("is true when result has just landed (within the min window)", () => {
-    const c = call({ timestamp: 1000, result: "done" });
-    assert.equal(isCallStillPending(c, 1000 + PENDING_MIN_MS - 1), true);
+    const toolCall = call({ timestamp: 1000, result: "done" });
+    assert.equal(isCallStillPending(toolCall, 1000 + PENDING_MIN_MS - 1), true);
   });
 
   it("is false when result landed and the min window has elapsed", () => {
-    const c = call({ timestamp: 1000, result: "done" });
-    assert.equal(isCallStillPending(c, 1000 + PENDING_MIN_MS + 1), false);
+    const toolCall = call({ timestamp: 1000, result: "done" });
+    assert.equal(isCallStillPending(toolCall, 1000 + PENDING_MIN_MS + 1), false);
   });
 
   it("is false at the exact PENDING_MIN_MS boundary", () => {
-    const c = call({ timestamp: 1000, result: "done" });
-    assert.equal(isCallStillPending(c, 1000 + PENDING_MIN_MS), false);
+    const toolCall = call({ timestamp: 1000, result: "done" });
+    assert.equal(isCallStillPending(toolCall, 1000 + PENDING_MIN_MS), false);
   });
 
   it("is true when error landed within the min window", () => {
-    const c = call({ timestamp: 1000, error: "boom" });
-    assert.equal(isCallStillPending(c, 1100), true);
+    const toolCall = call({ timestamp: 1000, error: "boom" });
+    assert.equal(isCallStillPending(toolCall, 1100), true);
   });
 
   it("is false when error landed and the min window has elapsed", () => {
-    const c = call({ timestamp: 1000, error: "boom" });
-    assert.equal(isCallStillPending(c, 1000 + PENDING_MIN_MS + 100), false);
+    const toolCall = call({ timestamp: 1000, error: "boom" });
+    assert.equal(isCallStillPending(toolCall, 1000 + PENDING_MIN_MS + 100), false);
   });
 
   it("treats a result of empty string as resolved (not still pending)", () => {
-    const c = call({ timestamp: 1000, result: "" });
-    assert.equal(isCallStillPending(c, 1000 + PENDING_MIN_MS + 1), false);
+    const toolCall = call({ timestamp: 1000, result: "" });
+    assert.equal(isCallStillPending(toolCall, 1000 + PENDING_MIN_MS + 1), false);
   });
 
   it("PENDING_MIN_MS is exposed as a positive constant", () => {

--- a/test/utils/tools/test_result.ts
+++ b/test/utils/tools/test_result.ts
@@ -16,52 +16,52 @@ function makeResult(over: Partial<ToolResultComplete>): ToolResultComplete {
 
 describe("isUserTextResponse", () => {
   it("returns true for a user text-response", () => {
-    const r = makeResult({
+    const toolResult = makeResult({
       toolName: "text-response",
       data: { text: "hi", role: "user", transportKind: "text-rest" },
     });
-    assert.equal(isUserTextResponse(r), true);
+    assert.equal(isUserTextResponse(toolResult), true);
   });
 
   it("returns false for an assistant text-response", () => {
-    const r = makeResult({
+    const toolResult = makeResult({
       toolName: "text-response",
       data: { text: "hi", role: "assistant", transportKind: "text-rest" },
     });
-    assert.equal(isUserTextResponse(r), false);
+    assert.equal(isUserTextResponse(toolResult), false);
   });
 
   it("returns false for non text-response tool names", () => {
-    const r = makeResult({
+    const toolResult = makeResult({
       toolName: "manageScheduler",
       data: { role: "user" },
     });
-    assert.equal(isUserTextResponse(r), false);
+    assert.equal(isUserTextResponse(toolResult), false);
   });
 
   it("returns false when data is missing", () => {
-    const r = makeResult({ toolName: "text-response", data: undefined });
-    assert.equal(isUserTextResponse(r), false);
+    const toolResult = makeResult({ toolName: "text-response", data: undefined });
+    assert.equal(isUserTextResponse(toolResult), false);
   });
 
   it("returns false when data is null", () => {
-    const r = makeResult({ toolName: "text-response", data: null });
-    assert.equal(isUserTextResponse(r), false);
+    const toolResult = makeResult({ toolName: "text-response", data: null });
+    assert.equal(isUserTextResponse(toolResult), false);
   });
 
   it("returns false when data has no role property", () => {
-    const r = makeResult({
+    const toolResult = makeResult({
       toolName: "text-response",
       data: { text: "hi" },
     });
-    assert.equal(isUserTextResponse(r), false);
+    assert.equal(isUserTextResponse(toolResult), false);
   });
 });
 
 describe("extractImageData", () => {
   it("returns the imageData string when present", () => {
-    const r = makeResult({ data: { imageData: "BASE64..." } });
-    assert.equal(extractImageData(r), "BASE64...");
+    const toolResult = makeResult({ data: { imageData: "BASE64..." } });
+    assert.equal(extractImageData(toolResult), "BASE64...");
   });
 
   it("returns undefined when imageData is missing", () => {
@@ -69,8 +69,8 @@ describe("extractImageData", () => {
   });
 
   it("returns undefined when imageData is not a string", () => {
-    const r = makeResult({ data: { imageData: 42 } });
-    assert.equal(extractImageData(r), undefined);
+    const toolResult = makeResult({ data: { imageData: 42 } });
+    assert.equal(extractImageData(toolResult), undefined);
   });
 
   it("returns undefined when result is undefined", () => {
@@ -84,29 +84,29 @@ describe("extractImageData", () => {
 
 describe("makeTextResult", () => {
   it("creates a user text-response", () => {
-    const r = makeTextResult("hello", "user");
-    assert.equal(r.toolName, "text-response");
-    assert.equal(r.message, "hello");
-    assert.equal(r.title, "You");
-    assert.deepEqual(r.data, {
+    const result = makeTextResult("hello", "user");
+    assert.equal(result.toolName, "text-response");
+    assert.equal(result.message, "hello");
+    assert.equal(result.title, "You");
+    assert.deepEqual(result.data, {
       text: "hello",
       role: "user",
       transportKind: "text-rest",
     });
     // uuidv4 strings are 36 chars with dashes
-    assert.match(r.uuid, /^[0-9a-f-]{36}$/);
+    assert.match(result.uuid, /^[0-9a-f-]{36}$/);
   });
 
   it("creates an assistant text-response", () => {
-    const r = makeTextResult("hi back", "assistant");
-    assert.equal(r.title, "Assistant");
-    const data = r.data as { role: string };
+    const result = makeTextResult("hi back", "assistant");
+    assert.equal(result.title, "Assistant");
+    const data = result.data as { role: string };
     assert.equal(data.role, "assistant");
   });
 
   it("generates a fresh uuid each call", () => {
-    const a = makeTextResult("x", "user");
-    const b = makeTextResult("x", "user");
-    assert.notEqual(a.uuid, b.uuid);
+    const result1 = makeTextResult("x", "user");
+    const result2 = makeTextResult("x", "user");
+    assert.notEqual(result1.uuid, result2.uuid);
   });
 });

--- a/test/wiki-backlinks/test_index.ts
+++ b/test/wiki-backlinks/test_index.ts
@@ -118,9 +118,9 @@ describe("maybeAppendWikiBacklinks (driver)", () => {
     await writeFile(brokenPath, "# Broken\n", "utf-8");
 
     const deps: Partial<WikiBacklinksDeps> = {
-      readFile: async (p: string) => {
-        if (p.endsWith("broken.md")) throw new Error("simulated read failure");
-        return readFile(p, "utf-8");
+      readFile: async (filePath: string) => {
+        if (filePath.endsWith("broken.md")) throw new Error("simulated read failure");
+        return readFile(filePath, "utf-8");
       },
     };
 


### PR DESCRIPTION
## Summary
- `eslint.config.mjs` の test/e2e override から `"id-length": "off"` を削除し、src/server と同じ warn ルールを適用
- exceptions に `id`, `md`, `ms`, `it` を追加（config コメントに記載済みだったが未追加だったもの）
- test/ と e2e/ 以下の約80ファイルで短い識別子をリネーム（474件 → 0件）

## Items to Confirm / Review
- テスト内の `a`/`b` は sort 比較・fixture 等で `left`/`right`, `itemA`/`itemB` 等に置換 — 意味的に適切か確認
- Playwright の `page` パラメータ衝突を避けるため `testPage` 等を使用した箇所あり

## User Prompt
test/ と e2e/ 以下にも id-length の warn を適用し、対応できる短い識別子を修正してほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code readability across test files and fixtures by renaming parameters and variables from single-letter names to descriptive identifiers (e.g., `s` → `session`, `ws` → `webSocket`, `el` → `element`).

* **Chores**
  * Updated ESLint configuration to expand allowed short identifier exceptions and enforce improved naming conventions across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->