### PR TITLE
refactor: rename short identifiers in server (batch 3) — zeroes server/

### DIFF
--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -202,7 +202,7 @@ export async function* runAgent(
       chatSessionId: sessionId,
       port,
       activePlugins,
-      roleIds: loadAllRoles().map((r) => r.id),
+      roleIds: loadAllRoles().map((loadedRole) => loadedRole.id),
       useDocker,
       userServers,
     });

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -17,7 +17,7 @@ export interface McpTool {
 
 export const mcpTools: McpTool[] = [readXPost, searchX];
 
-const toolMap = new Map(mcpTools.map((t) => [t.definition.name, t]));
+const toolMap = new Map(mcpTools.map((tool) => [tool.definition.name, tool]));
 
 export function isMcpToolEnabled(tool: McpTool): boolean {
   return (tool.requiredEnv ?? []).every((key) => !!process.env[key]);
@@ -34,11 +34,11 @@ interface McpToolParams {
 // GET /api/mcp-tools — returns { name, enabled, requiredEnv } for each tool (used by the role builder UI)
 mcpToolsRouter.get(API_ROUTES.mcpTools.list, (_req: Request, res: Response) => {
   res.json(
-    mcpTools.map((t) => ({
-      name: t.definition.name,
-      enabled: isMcpToolEnabled(t),
-      requiredEnv: t.requiredEnv ?? [],
-      prompt: t.prompt,
+    mcpTools.map((tool) => ({
+      name: tool.definition.name,
+      enabled: isMcpToolEnabled(tool),
+      requiredEnv: tool.requiredEnv ?? [],
+      prompt: tool.prompt,
     })),
   );
 });

--- a/server/agent/resumeFailover.ts
+++ b/server/agent/resumeFailover.ts
@@ -77,12 +77,12 @@ function parseTranscriptEntries(jsonlContent: string): TranscriptEntry[] {
       continue;
     }
     if (!isRecord(entry)) continue;
-    const o = entry;
-    if (o.type !== EVENT_TYPES.text) continue;
-    if (o.source !== "user" && o.source !== "assistant") continue;
-    const message = o.message;
+    const record = entry;
+    if (record.type !== EVENT_TYPES.text) continue;
+    if (record.source !== "user" && record.source !== "assistant") continue;
+    const message = record.message;
     if (typeof message !== "string" || message.length === 0) continue;
-    out.push({ source: o.source, text: message });
+    out.push({ source: record.source, text: message });
   }
   return out;
 }

--- a/server/api/auth/bearerAuth.ts
+++ b/server/api/auth/bearerAuth.ts
@@ -1,8 +1,8 @@
 import { timingSafeEqual } from "crypto";
 
-function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+function safeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(Buffer.from(left), Buffer.from(right));
 }
 
 // Bearer token middleware (#272). Reject any `/api/*` request whose

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -43,7 +43,7 @@ function isMcpPutBody(value: unknown): value is { servers: McpServerEntry[] } {
   if (!Array.isArray(value.servers)) return false;
   // Full shape validation happens inside fromMcpEntries (throws on
   // anything malformed). Here we just confirm the envelope.
-  return value.servers.every((e) => isRecord(e) && "id" in e && "spec" in e);
+  return value.servers.every((entry) => isRecord(entry) && "id" in entry && "spec" in entry);
 }
 
 // Parse an MCP payload through `fromMcpEntries` (which does the full

--- a/server/api/routes/html.ts
+++ b/server/api/routes/html.ts
@@ -7,8 +7,8 @@ import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 const router = Router();
 
 async function callGemini(prompt: string): Promise<string> {
-  const ai = getGeminiClient();
-  const response = await ai.models.generateContent({
+  const client = getGeminiClient();
+  const response = await client.models.generateContent({
     model: "gemini-2.0-flash",
     contents: [{ text: prompt }],
   });

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -373,7 +373,7 @@ router.get(API_ROUTES.mulmoScript.beatAudio, async (req: Request<object, BeatAud
     filePath,
     {
       operation: "beat-audio",
-      onContextMissing: (r) => r.json({ audio: null }),
+      onContextMissing: (response) => response.json({ audio: null }),
     },
     async ({ context }) => {
       const beat = context.studio.script.beats[beatIndex];

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -80,10 +80,10 @@ async function fillImagePlaceholders(markdown: string): Promise<string> {
   }
 
   const results = await Promise.all(
-    matches.map(async (m) => ({
-      full: m[0],
-      prompt: m[1],
-      url: geminiOk ? await generateImageFile(m[1]) : null,
+    matches.map(async (match) => ({
+      full: match[0],
+      prompt: match[1],
+      url: geminiOk ? await generateImageFile(match[1]) : null,
     })),
   );
 
@@ -91,7 +91,7 @@ async function fillImagePlaceholders(markdown: string): Promise<string> {
   // success rate even when most calls go through. The per-call
   // error already lands at warn from generateImageFile's catch.
   if (geminiOk) {
-    const failed = results.filter((r) => !r.url).length;
+    const failed = results.filter((result) => !result.url).length;
     if (failed > 0) {
       log.warn("present-document", "image generation had failures", {
         failed,

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -7,7 +7,7 @@ import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { roleExists, deleteRole, saveRole } from "../../utils/files/roles-io.js";
 
-const BUILTIN_IDS = new Set(BUILTIN_ROLES.map((r) => r.id));
+const BUILTIN_IDS = new Set(BUILTIN_ROLES.map((role) => role.id));
 
 const router = Router();
 
@@ -98,7 +98,7 @@ function saveRoleResult(input: ManageRolesInput, sessionId: string): Record<stri
   const pluginsToSave = role.availablePlugins ?? [];
   const roleToSave = {
     ...role,
-    availablePlugins: pluginsToSave.filter((p) => p !== "switchRole"),
+    availablePlugins: pluginsToSave.filter((plugin) => plugin !== "switchRole"),
   };
 
   saveRole(role.id, roleToSave);

--- a/server/api/routes/sessionsCursor.ts
+++ b/server/api/routes/sessionsCursor.ts
@@ -21,8 +21,8 @@ const CURSOR_PREFIX = "v1:";
  * fall back to when an incoming cursor is malformed.
  */
 export function encodeCursor(changeMs: number): string {
-  const ms = Number.isFinite(changeMs) && changeMs > 0 ? Math.floor(changeMs) : 0;
-  return `${CURSOR_PREFIX}${ms}`;
+  const floored = Number.isFinite(changeMs) && changeMs > 0 ? Math.floor(changeMs) : 0;
+  return `${CURSOR_PREFIX}${floored}`;
 }
 
 /**
@@ -36,8 +36,8 @@ export function encodeCursor(changeMs: number): string {
 export function parseCursor(raw: unknown): number {
   if (typeof raw !== "string") return 0;
   if (!raw.startsWith(CURSOR_PREFIX)) return 0;
-  const n = Number(raw.slice(CURSOR_PREFIX.length));
-  return Number.isFinite(n) && n > 0 ? n : 0;
+  const parsed = Number(raw.slice(CURSOR_PREFIX.length));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
 /**

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -55,17 +55,17 @@ interface DeleteSkillResponse {
 router.get(API_ROUTES.skills.list, async (_req: Request, res: Response<SkillsListResponse>) => {
   const skills = await discoverSkills({ workspaceRoot: workspacePath });
   res.json({
-    skills: skills.map((s) => ({
-      name: s.name,
-      description: s.description,
-      source: s.source,
+    skills: skills.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      source: skill.source,
     })),
   });
 });
 
 router.get(API_ROUTES.skills.detail, async (req: Request<{ name: string }>, res: Response<SkillDetailResponse | ErrorResponse>) => {
   const skills = await discoverSkills({ workspaceRoot: workspacePath });
-  const skill = skills.find((s) => s.name === req.params.name);
+  const skill = skills.find((candidate) => candidate.name === req.params.name);
   if (!skill) {
     notFound(res, `skill not found: ${req.params.name}`);
     return;

--- a/server/api/routes/sources.ts
+++ b/server/api/routes/sources.ts
@@ -525,8 +525,8 @@ async function resolveCategories(parsed: ParsedRegisterBody): Promise<{ categori
 
 function isHttpUrl(raw: string): boolean {
   try {
-    const u = new URL(raw);
-    return u.protocol === "http:" || u.protocol === "https:";
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:";
   } catch {
     return false;
   }

--- a/server/api/routes/todosHandlers.ts
+++ b/server/api/routes/todosHandlers.ts
@@ -242,7 +242,7 @@ export function handleRemoveLabel(items: TodoItem[], input: TodosActionInput): T
 
 export function handleListLabels(items: TodoItem[]): TodosActionResult {
   const inventory = listLabelsWithCount(items);
-  const summary = inventory.map((l) => `${l.label} (${l.count})`).join(", ");
+  const summary = inventory.map((entry) => `${entry.label} (${entry.count})`).join(", ");
   const message = inventory.length === 0 ? "No labels in use" : `${inventory.length} label(s) in use: ${summary}`;
   return {
     kind: "success",

--- a/server/api/routes/todosItemsHandlers.ts
+++ b/server/api/routes/todosItemsHandlers.ts
@@ -281,10 +281,10 @@ function applyCompletedPatch(updated: TodoItem, items: TodoItem[], columns: Stat
   }
 }
 
-export function handlePatch(items: TodoItem[], columns: StatusColumn[], id: string, input: PatchInput): ItemsActionResult {
-  const target = items.find((i) => i.id === id);
+export function handlePatch(items: TodoItem[], columns: StatusColumn[], itemId: string, input: PatchInput): ItemsActionResult {
+  const target = items.find((item) => item.id === itemId);
   if (!target) {
-    return { kind: "error", status: 404, error: `item not found: ${id}` };
+    return { kind: "error", status: 404, error: `item not found: ${itemId}` };
   }
   const updated: TodoItem = { ...target };
 
@@ -305,7 +305,7 @@ export function handlePatch(items: TodoItem[], columns: StatusColumn[], id: stri
     if (err) return err;
   }
 
-  const next = items.map((item) => (item.id === id ? updated : item));
+  const next = items.map((item) => (item.id === itemId ? updated : item));
   return { kind: "success", items: next, item: updated };
 }
 
@@ -323,10 +323,10 @@ export interface MoveInput {
   position?: number;
 }
 
-export function handleMove(items: TodoItem[], columns: StatusColumn[], id: string, input: MoveInput): ItemsActionResult {
-  const target = items.find((i) => i.id === id);
+export function handleMove(items: TodoItem[], columns: StatusColumn[], itemId: string, input: MoveInput): ItemsActionResult {
+  const target = items.find((item) => item.id === itemId);
   if (!target) {
-    return { kind: "error", status: 404, error: `item not found: ${id}` };
+    return { kind: "error", status: 404, error: `item not found: ${itemId}` };
   }
   const validStatusIds = new Set(columns.map((column) => column.id));
   const newStatus = input.status ?? target.status ?? defaultStatusId(columns);
@@ -345,7 +345,7 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
   };
   // Re-collect the items in the target column with the moving item
   // pulled out, then splice item back in at `position`.
-  const others = items.filter((item) => item.id !== id && item.status === newStatus).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
+  const others = items.filter((item) => item.id !== itemId && item.status === newStatus).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
   const insertAt = clampPosition(input.position, others.length);
   const reordered = [...others];
   reordered.splice(insertAt, 0, updatedSelf);
@@ -354,7 +354,7 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
   reordered.forEach((item, i) => reorderedById.set(item.id, (i + 1) * ORDER_STEP));
   const nextItems = items.map((item): TodoItem => {
     const newOrder = reorderedById.get(item.id);
-    if (item.id === id) {
+    if (item.id === itemId) {
       const out: TodoItem = {
         ...updatedSelf,
         order: newOrder ?? updatedSelf.order ?? ORDER_STEP,
@@ -364,7 +364,7 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], id: strin
     if (newOrder !== undefined) return { ...item, order: newOrder };
     return item;
   });
-  const finalSelf = nextItems.find((item) => item.id === id)!;
+  const finalSelf = nextItems.find((item) => item.id === itemId)!;
   return { kind: "success", items: nextItems, item: finalSelf };
 }
 
@@ -377,10 +377,10 @@ function clampPosition(raw: number | undefined, max: number): number {
 
 // ── Delete ────────────────────────────────────────────────────────
 
-export function handleDeleteItem(items: TodoItem[], id: string): ItemsActionResult {
-  const target = items.find((i) => i.id === id);
+export function handleDeleteItem(items: TodoItem[], itemId: string): ItemsActionResult {
+  const target = items.find((item) => item.id === itemId);
   if (!target) {
-    return { kind: "error", status: 404, error: `item not found: ${id}` };
+    return { kind: "error", status: 404, error: `item not found: ${itemId}` };
   }
-  return { kind: "success", items: items.filter((item) => item.id !== id) };
+  return { kind: "success", items: items.filter((item) => item.id !== itemId) };
 }

--- a/server/api/sandboxStatus.ts
+++ b/server/api/sandboxStatus.ts
@@ -59,6 +59,6 @@ export function buildSandboxStatus(params: BuildSandboxStatusParams): SandboxSta
 
   return {
     sshAgent,
-    mounts: parsed.resolved.map((m) => m.name),
+    mounts: parsed.resolved.map((mount) => mount.name),
   };
 }

--- a/server/events/notifications.ts
+++ b/server/events/notifications.ts
@@ -32,8 +32,8 @@ export interface NotificationDeps {
 
 let deps: NotificationDeps | null = null;
 
-export function initNotifications(d: NotificationDeps): void {
-  deps = d;
+export function initNotifications(injected: NotificationDeps): void {
+  deps = injected;
 }
 
 // ── In-memory store ─────────────────────────────────────────────
@@ -97,10 +97,10 @@ export function publishNotification(opts: PublishNotificationOpts): void {
   }
 }
 
-function formatBridgeMessage(p: NotificationPayload): string {
-  const icon = p.kind === NOTIFICATION_KINDS.agent ? "\u2705" : "\u{1F514}";
-  const parts = [icon, p.title];
-  if (p.body) parts.push(p.body);
+function formatBridgeMessage(payload: NotificationPayload): string {
+  const icon = payload.kind === NOTIFICATION_KINDS.agent ? "\u2705" : "\u{1F514}";
+  const parts = [icon, payload.title];
+  if (payload.body) parts.push(payload.body);
   return parts.join(" ");
 }
 

--- a/server/events/pub-sub/index.ts
+++ b/server/events/pub-sub/index.ts
@@ -13,7 +13,7 @@ export interface IPubSub {
 // itself, which is why we switched off raw ws.
 
 export function createPubSub(server: http.Server): IPubSub {
-  const io = new IOServer(server, {
+  const ioServer = new IOServer(server, {
     path: "/ws/pubsub",
     // Server binds to 127.0.0.1 only, so CORS is moot — but
     // socket.io defaults to rejecting cross-origin upgrade
@@ -28,7 +28,7 @@ export function createPubSub(server: http.Server): IPubSub {
     transports: ["websocket"],
   });
 
-  io.on("connection", (socket) => {
+  ioServer.on("connection", (socket) => {
     socket.on("subscribe", (channel: unknown) => {
       if (typeof channel === "string") socket.join(channel);
     });
@@ -39,7 +39,7 @@ export function createPubSub(server: http.Server): IPubSub {
 
   return {
     publish(channel: string, data: unknown): void {
-      io.to(channel).emit("data", { channel, data });
+      ioServer.to(channel).emit("data", { channel, data });
     },
   };
 }

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -6,7 +6,7 @@
 //
 // NOTE: packages/relay/src/client.ts is a parallel implementation
 // for browser/edge environments using the global WebSocket API.
-// This module uses the `ws` npm package for Node.js. If you change
+// This module uses the `socket` npm package for Node.js. If you change
 // reconnection logic or URL handling here, check the other file too.
 
 import WebSocket from "ws";
@@ -87,7 +87,7 @@ function isRelayMessage(value: unknown): value is RelayMessage {
 export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
   const { relayUrl, relayToken, relay, logger } = deps;
 
-  let ws: WebSocket | null = null;
+  let socket: WebSocket | null = null;
   let reconnectMs = MIN_RECONNECT_MS;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
@@ -103,7 +103,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
     if (stopped) return;
 
     try {
-      ws = new WebSocket(buildUrl());
+      socket = new WebSocket(buildUrl());
     } catch (err) {
       logger.error(LOG_PREFIX, "failed to create WebSocket", {
         error: err instanceof Error ? err.message : String(err),
@@ -112,18 +112,18 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       return;
     }
 
-    ws.on("open", () => {
+    socket.on("open", () => {
       logger.info(LOG_PREFIX, "connected", { url: relayUrl });
       reconnectMs = MIN_RECONNECT_MS;
       flushResponseQueue();
     });
 
-    ws.on("message", (data) => {
+    socket.on("message", (data) => {
       handleMessage(String(data));
     });
 
-    ws.on("close", (code, reason) => {
-      ws = null;
+    socket.on("close", (code, reason) => {
+      socket = null;
       if (TERMINAL_CLOSE_CODES.has(code)) {
         logger.error(LOG_PREFIX, "terminal close, not reconnecting", {
           code,
@@ -138,7 +138,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       scheduleReconnect();
     });
 
-    ws.on("error", (err) => {
+    socket.on("error", (err) => {
       logger.warn(LOG_PREFIX, "connection error", {
         error: err.message,
       });
@@ -227,9 +227,9 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
   }
 
   function trySend(response: RelayResponse): boolean {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
     try {
-      ws.send(JSON.stringify(response), (err) => {
+      socket.send(JSON.stringify(response), (err) => {
         if (err && !stopped) {
           logger.warn(LOG_PREFIX, "send failed, requeueing", {
             platform: response.platform,
@@ -261,7 +261,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       count: responseQueue.length,
     });
     while (responseQueue.length > 0) {
-      if (!ws || ws.readyState !== WebSocket.OPEN) break;
+      if (!socket || socket.readyState !== WebSocket.OPEN) break;
       const response = responseQueue[0]!;
       if (!trySend(response)) break;
       responseQueue.shift();
@@ -274,9 +274,9 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-    if (ws) {
-      ws.close(1000, "shutdown");
-      ws = null;
+    if (socket) {
+      socket.close(1000, "shutdown");
+      socket = null;
     }
     logger.info(LOG_PREFIX, "stopped");
   }

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -181,8 +181,8 @@ export function isMcpConfigFile(value: unknown): value is McpConfigFile {
 
   const servers = value.mcpServers;
   if (!isRecord(servers)) return false;
-  for (const [id, spec] of Object.entries(servers)) {
-    if (!isMcpServerId(id)) return false;
+  for (const [serverId, spec] of Object.entries(servers)) {
+    if (!isMcpServerId(serverId)) return false;
     if (!isMcpServerSpec(spec)) return false;
   }
   return true;
@@ -220,7 +220,7 @@ export function saveMcpConfig(cfg: McpConfigFile): void {
 
 // Flatten storage form to UI-friendly array.
 export function toMcpEntries(cfg: McpConfigFile): McpServerEntry[] {
-  return Object.entries(cfg.mcpServers).map(([id, spec]) => ({ id, spec }));
+  return Object.entries(cfg.mcpServers).map(([serverId, spec]) => ({ id: serverId, spec }));
 }
 
 // Re-inflate UI-friendly array to storage form. Duplicate ids are

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -121,13 +121,13 @@ async function renewTokenViaPty(): Promise<boolean> {
       buffer += data;
 
       if (!responded) {
-        const m = ECHO_RE.exec(buffer);
-        if (m) {
+        const match = ECHO_RE.exec(buffer);
+        if (match) {
           // Claude echoed our "hi" — remember where the response
           // window starts so the success check looks only at bytes
           // that arrived AFTER the echo.
           responded = true;
-          echoEndIdx = m.index + m[0].length;
+          echoEndIdx = match.index + match[0].length;
         }
         return;
       }

--- a/server/system/env.ts
+++ b/server/system/env.ts
@@ -19,11 +19,11 @@
 
 function asInt(value: string | undefined, fallback: number, opts: { min?: number; max?: number } = {}): number {
   if (value === undefined || value === "") return fallback;
-  const n = Number(value);
-  if (!Number.isInteger(n)) return fallback;
-  if (opts.min !== undefined && n < opts.min) return fallback;
-  if (opts.max !== undefined && n > opts.max) return fallback;
-  return n;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return fallback;
+  if (opts.min !== undefined && parsed < opts.min) return fallback;
+  if (opts.max !== undefined && parsed > opts.max) return fallback;
+  return parsed;
 }
 
 function asFlag(value: string | undefined): boolean {

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -37,8 +37,8 @@ export async function generateGeminiImageContent(
   config?: GenerateContentParameters["config"],
   model: string = DEFAULT_IMAGE_MODEL,
 ): Promise<GeminiImageResult> {
-  const ai = getGeminiClient();
-  const response = await ai.models.generateContent({
+  const client = getGeminiClient();
+  const response = await client.models.generateContent({
     model,
     contents,
     ...(config && { config }),

--- a/server/utils/gitignore.ts
+++ b/server/utils/gitignore.ts
@@ -20,19 +20,19 @@ import path from "path";
 import ignore, { type Ignore } from "ignore";
 
 export class GitignoreFilter {
-  private ig: Ignore;
+  private rules: Ignore;
 
   constructor(rules?: string) {
-    this.ig = ignore();
+    this.rules = ignore();
     if (rules) {
-      this.ig.add(rules);
+      this.rules.add(rules);
     }
   }
 
   /** Test whether a workspace-relative path should be hidden. */
   ignores(relPath: string): boolean {
     if (!relPath) return false;
-    return this.ig.ignores(relPath);
+    return this.rules.ignores(relPath);
   }
 
   /** Create a child filter that inherits this filter's rules and
@@ -40,12 +40,12 @@ export class GitignoreFilter {
   childForDir(dirAbsPath: string): GitignoreFilter {
     const child = new GitignoreFilter();
     // Inherit parent rules
-    child.ig = ignore().add(this.ig);
+    child.rules = ignore().add(this.rules);
     // Add local .gitignore if present
     const gitignorePath = path.join(dirAbsPath, ".gitignore");
     try {
       const content = fs.readFileSync(gitignorePath, "utf-8");
-      child.ig.add(content);
+      child.rules.add(content);
     } catch {
       // No .gitignore in this directory — just inherit parent
     }

--- a/server/utils/json.ts
+++ b/server/utils/json.ts
@@ -44,22 +44,22 @@ export function findBalancedBraceBlock(raw: string): string | null {
   let inString = false;
   let escape = false;
   for (let i = start; i < raw.length; i++) {
-    const ch = raw[i];
+    const char = raw[i];
     if (escape) {
       escape = false;
       continue;
     }
-    if (ch === "\\") {
+    if (char === "\\") {
       escape = true;
       continue;
     }
-    if (ch === '"') {
+    if (char === '"') {
       inString = !inString;
       continue;
     }
     if (inString) continue;
-    if (ch === "{") depth++;
-    if (ch === "}" && --depth === 0) return raw.slice(start, i + 1);
+    if (char === "{") depth++;
+    if (char === "}" && --depth === 0) return raw.slice(start, i + 1);
   }
   return null;
 }

--- a/server/utils/markdown.ts
+++ b/server/utils/markdown.ts
@@ -68,15 +68,15 @@ export function rewriteMarkdownLinks(input: string, rewrite: (href: string) => s
  * Split a trailing `#fragment` or `?query` off a path so the caller
  * can rewrite the path portion and concatenate the suffix back.
  */
-export function splitFragmentAndQuery(s: string): {
+export function splitFragmentAndQuery(href: string): {
   pathPart: string;
   suffix: string;
 } {
-  const hashIdx = s.indexOf("#");
-  const queryIdx = s.indexOf("?");
+  const hashIdx = href.indexOf("#");
+  const queryIdx = href.indexOf("?");
   let cut = -1;
   if (hashIdx !== -1) cut = hashIdx;
   if (queryIdx !== -1 && (cut === -1 || queryIdx < cut)) cut = queryIdx;
-  if (cut === -1) return { pathPart: s, suffix: "" };
-  return { pathPart: s.slice(0, cut), suffix: s.slice(cut) };
+  if (cut === -1) return { pathPart: href, suffix: "" };
+  return { pathPart: href.slice(0, cut), suffix: href.slice(cut) };
 }

--- a/server/utils/spawn.ts
+++ b/server/utils/spawn.ts
@@ -28,7 +28,7 @@ export function extractClaudeErrorMessage(stdout: string): string | null {
   if (!isRecord(parsed)) return null;
   if (parsed.is_error !== true) return null;
   if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
-    const joined = parsed.errors.filter((e): e is string => typeof e === "string").join("; ");
+    const joined = parsed.errors.filter((err): err is string => typeof err === "string").join("; ");
     if (joined.length > 0) return joined;
   }
   const subtype = typeof parsed.subtype === "string" ? parsed.subtype : "";

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -23,12 +23,12 @@ export function isNonEmptyString(value: unknown): value is string {
 /** Record whose values are all strings. */
 export function isStringRecord(value: unknown): value is Record<string, string> {
   if (!isRecord(value)) return false;
-  return Object.values(value).every((v) => typeof v === "string");
+  return Object.values(value).every((val) => typeof val === "string");
 }
 
 /** String array (every element is a string). */
 export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((v) => typeof v === "string");
+  return Array.isArray(value) && value.every((val) => typeof val === "string");
 }
 
 /** Error-like object with a `code` property (e.g. Node.js fs errors). */

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -152,10 +152,10 @@ export function validateSummaryResult(obj: unknown): SummaryResult {
   if (!isRecord(obj)) {
     throw new Error("[chat-index] summary result is not an object");
   }
-  const o = obj as Record<string, unknown>;
-  const title = typeof o.title === "string" ? o.title : "";
-  const summary = typeof o.summary === "string" ? o.summary : "";
-  const keywords = Array.isArray(o.keywords) ? o.keywords.filter((k): k is string => typeof k === "string") : [];
+  const record = obj as Record<string, unknown>;
+  const title = typeof record.title === "string" ? record.title : "";
+  const summary = typeof record.summary === "string" ? record.summary : "";
+  const keywords = Array.isArray(record.keywords) ? record.keywords.filter((keyword): keyword is string => typeof keyword === "string") : [];
   return { title, summary, keywords };
 }
 

--- a/server/workspace/journal/diff.ts
+++ b/server/workspace/journal/diff.ts
@@ -52,8 +52,8 @@ export function findDirtySessions(current: readonly SessionFileMeta[], processed
   }
 
   const missing: string[] = [];
-  for (const id of Object.keys(processed)) {
-    if (!seenNow.has(id)) missing.push(id);
+  for (const sessionId of Object.keys(processed)) {
+    if (!seenNow.has(sessionId)) missing.push(sessionId);
   }
 
   return { dirty, missing };

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -150,17 +150,17 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
 async function rebuildIndex(workspaceRoot: string): Promise<void> {
   const topics = await walkTopics(workspaceRoot);
   const dailyEntries = await listDailyFilesIO(workspaceRoot);
-  const days: IndexDailyEntry[] = dailyEntries.map((e) => ({
-    date: `${e.year}-${e.month}-${e.day}`,
+  const days: IndexDailyEntry[] = dailyEntries.map((entry) => ({
+    date: `${entry.year}-${entry.month}-${entry.day}`,
   }));
   const archivedCount = await countArchivedIO(workspaceRoot);
-  const md = buildIndexMarkdown({
+  const markdown = buildIndexMarkdown({
     topics,
     days,
     archivedTopicCount: archivedCount,
     builtAtIso: new Date().toISOString(),
   });
-  await writeJournalIndex(md, workspaceRoot);
+  await writeJournalIndex(markdown, workspaceRoot);
 }
 
 async function walkTopics(workspaceRoot: string): Promise<IndexTopicEntry[]> {

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -54,7 +54,7 @@ export function planMerges(merges: readonly RawMerge[]): MergePlanItem[] {
   const plans: MergePlanItem[] = [];
   for (const merge of merges) {
     const intoSlug = slugify(merge.into);
-    const fromSlugs = merge.from.map(slugify).filter((s) => s !== intoSlug);
+    const fromSlugs = merge.from.map(slugify).filter((slug) => slug !== intoSlug);
     if (fromSlugs.length === 0) continue;
     plans.push({ intoSlug, fromSlugs, newContent: merge.newContent });
   }
@@ -66,7 +66,7 @@ export function planMerges(merges: readonly RawMerge[]): MergePlanItem[] {
 export function applyRemovedTopics(state: JournalState, removed: ReadonlySet<string>): JournalState {
   return {
     ...state,
-    knownTopics: state.knownTopics.filter((t) => !removed.has(t)),
+    knownTopics: state.knownTopics.filter((topic) => !removed.has(topic)),
   };
 }
 

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -65,27 +65,27 @@ export function parseState(raw: unknown): JournalState {
   // Version mismatch → throw it all out. Cheap to rebuild.
   if (obj.version !== JOURNAL_STATE_VERSION) return defaultState();
 
-  const d = defaultState();
+  const fallback = defaultState();
   return {
     version: JOURNAL_STATE_VERSION,
     lastDailyRunAt: typeof obj.lastDailyRunAt === "string" ? obj.lastDailyRunAt : null,
     lastOptimizationRunAt: typeof obj.lastOptimizationRunAt === "string" ? obj.lastOptimizationRunAt : null,
-    dailyIntervalHours: typeof obj.dailyIntervalHours === "number" && obj.dailyIntervalHours > 0 ? obj.dailyIntervalHours : d.dailyIntervalHours,
+    dailyIntervalHours: typeof obj.dailyIntervalHours === "number" && obj.dailyIntervalHours > 0 ? obj.dailyIntervalHours : fallback.dailyIntervalHours,
     optimizationIntervalDays:
-      typeof obj.optimizationIntervalDays === "number" && obj.optimizationIntervalDays > 0 ? obj.optimizationIntervalDays : d.optimizationIntervalDays,
+      typeof obj.optimizationIntervalDays === "number" && obj.optimizationIntervalDays > 0 ? obj.optimizationIntervalDays : fallback.optimizationIntervalDays,
     processedSessions: parseProcessedSessions(obj.processedSessions),
-    knownTopics: Array.isArray(obj.knownTopics) ? obj.knownTopics.filter((t): t is string => typeof t === "string") : [],
+    knownTopics: Array.isArray(obj.knownTopics) ? obj.knownTopics.filter((topic): topic is string => typeof topic === "string") : [],
   };
 }
 
 function parseProcessedSessions(raw: unknown): Record<string, ProcessedSessionRecord> {
   if (!isRecord(raw)) return {};
   const out: Record<string, ProcessedSessionRecord> = {};
-  for (const [id, rec] of Object.entries(raw as Record<string, unknown>)) {
+  for (const [sessionId, rec] of Object.entries(raw as Record<string, unknown>)) {
     if (!isRecord(rec)) continue;
     const mtime = (rec as Record<string, unknown>).lastMtimeMs;
     if (typeof mtime === "number" && mtime >= 0) {
-      out[id] = { lastMtimeMs: mtime };
+      out[sessionId] = { lastMtimeMs: mtime };
     }
   }
   return out;

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -56,9 +56,9 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   // daily HH:MM — validate range: HH 00-23, MM 00-59
   const dailyMatch = trimmed.match(/^daily\s+(\d{2}):(\d{2})$/);
   if (dailyMatch) {
-    const hh = Number(dailyMatch[1]);
-    const mm = Number(dailyMatch[2]);
-    if (hh > 23 || mm > 59) return null;
+    const hours = Number(dailyMatch[1]);
+    const minutes = Number(dailyMatch[2]);
+    if (hours > 23 || minutes > 59) return null;
     return {
       type: SCHEDULE_TYPES.daily,
       time: `${dailyMatch[1]}:${dailyMatch[2]}`,
@@ -70,9 +70,9 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   if (intervalMatch) {
     const value = Number(intervalMatch[1]);
     const unit = intervalMatch[2];
-    const ms = TIME_UNIT_MS[unit];
-    if (!ms) return null;
-    const intervalMs = value * ms;
+    const unitMs = TIME_UNIT_MS[unit];
+    if (!unitMs) return null;
+    const intervalMs = value * unitMs;
     if (intervalMs < MIN_INTERVAL_MS) return null;
     return { type: SCHEDULE_TYPES.interval, intervalMs };
   }

--- a/server/workspace/skills/scheduler.ts
+++ b/server/workspace/skills/scheduler.ts
@@ -137,10 +137,10 @@ function readSkillScheduleInfo(skill: Skill): SkillScheduleInfo | null {
   try {
     const raw = readFileSync(skill.path, "utf-8");
     const parsed = parseSkillFrontmatter(raw);
-    const s = parsed?.schedule?.parsed;
-    if (!s) return null;
+    const schedule = parsed?.schedule?.parsed;
+    if (!schedule) return null;
     return {
-      schedule: s,
+      schedule,
       roleId: parsed?.roleId ?? DEFAULT_ROLE_ID,
     };
   } catch {

--- a/server/workspace/skills/writer.ts
+++ b/server/workspace/skills/writer.ts
@@ -54,7 +54,7 @@ export async function saveProjectSkill(input: SaveSkillInput): Promise<SaveResul
   // user-scope skill with the same name (project would silently
   // override it via the precedence rule).
   const existing = await discoverSkills({ workspaceRoot });
-  if (existing.some((s) => s.name === name)) {
+  if (existing.some((skill) => skill.name === name)) {
     return { kind: "exists", name };
   }
 
@@ -98,7 +98,7 @@ export async function updateProjectSkill(input: SaveSkillInput): Promise<UpdateR
   }
 
   const existing = await discoverSkills({ workspaceRoot });
-  const skill = existing.find((s) => s.name === name);
+  const skill = existing.find((candidate) => candidate.name === name);
   if (!skill) return { kind: "not-found", name };
   if (skill.source === "user") return { kind: "user-scope", name };
 
@@ -139,7 +139,7 @@ export async function deleteProjectSkill(input: DeleteSkillInput): Promise<Delet
   // Look up the skill's effective source via discovery — if the
   // matching name is user-scope, we refuse.
   const all = await discoverSkills({ workspaceRoot });
-  const skill = all.find((s) => s.name === name);
+  const skill = all.find((candidate) => candidate.name === name);
   if (!skill) return { kind: "not-found", name };
   if (skill.source === "user") return { kind: "user-scope", name };
 

--- a/server/workspace/sources/fetchers/rss.ts
+++ b/server/workspace/sources/fetchers/rss.ts
@@ -74,7 +74,7 @@ function entryToSourceItem(entry: ParsedFeedItem, source: Source, lastSeenTs: nu
   // Use the feed's own id as a hint, but always derive the
   // SourceItem.id from the normalized URL so cross-source dedup
   // (see #188 Q3) lines up regardless of feed conventions.
-  const id = stableItemId(normalizedUrl);
+  const itemId = stableItemId(normalizedUrl);
   const publishedAt =
     entry.publishedAt ??
     // Synthesize a fetch-time timestamp when the feed didn't
@@ -85,7 +85,7 @@ function entryToSourceItem(entry: ParsedFeedItem, source: Source, lastSeenTs: nu
   // carry `undefined` fields that break exactOptionalPropertyTypes
   // on the server tsconfig.
   return {
-    id,
+    id: itemId,
     title: entry.title,
     url: normalizedUrl,
     publishedAt,
@@ -107,9 +107,9 @@ export function updateCursor(current: Record<string, string>, feed: ParsedFeed):
   let newest: number | null = null;
   for (const entry of feed.items) {
     if (!entry.publishedAt) continue;
-    const ts = Date.parse(entry.publishedAt);
-    if (!Number.isFinite(ts)) continue;
-    if (newest === null || ts > newest) newest = ts;
+    const publishedMs = Date.parse(entry.publishedAt);
+    if (!Number.isFinite(publishedMs)) continue;
+    if (newest === null || publishedMs > newest) newest = publishedMs;
   }
   if (newest === null) return current;
   // Only advance forwards. A feed whose newest item is older

--- a/server/workspace/sources/fetchers/rssParser.ts
+++ b/server/workspace/sources/fetchers/rssParser.ts
@@ -178,7 +178,7 @@ function parseAtom(feed: Record<string, unknown>): ParsedFeed | null {
 
 function parseAtomEntry(raw: Record<string, unknown>): ParsedFeedItem | null {
   const title = readString(raw.title);
-  const id = readString(raw.id);
+  const entryId = readString(raw.id);
   const link = resolveAtomLink(raw.link);
   const published = readString(raw.published) ?? readString(raw.updated) ?? null;
   const publishedAt = published ? normalizeDate(published) : null;
@@ -189,7 +189,7 @@ function parseAtomEntry(raw: Record<string, unknown>): ParsedFeedItem | null {
   const summary = readString(raw.summary) ?? content;
   if (!title) return null;
   return {
-    feedId: id ?? link ?? null,
+    feedId: entryId ?? link ?? null,
     title,
     link,
     publishedAt,
@@ -289,7 +289,7 @@ function stripBom(text: string): string {
 // date is more useful to the pipeline than a null.
 function normalizeDate(raw: string | null): string | null {
   if (!raw) return null;
-  const ts = Date.parse(raw);
-  if (Number.isFinite(ts)) return new Date(ts).toISOString();
+  const parsed = Date.parse(raw);
+  if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
   return raw;
 }

--- a/server/workspace/sources/paths.ts
+++ b/server/workspace/sources/paths.ts
@@ -71,11 +71,11 @@ export function newsRoot(workspaceRoot: string): string {
 export function dailyNewsPath(workspaceRoot: string, isoDate: string): string {
   // Validate shape at the boundary so an empty / bogus date can't
   // produce "undefined/undefined/undefined.md" downstream.
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
-  if (!m) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) {
     throw new Error(`[sources] dailyNewsPath: expected YYYY-MM-DD, got "${isoDate}"`);
   }
-  const [, year, month, day] = m;
+  const [, year, month, day] = match;
   return path.join(newsRoot(workspaceRoot), DAILY_DIR, year, month, `${day}.md`);
 }
 
@@ -94,11 +94,11 @@ export function archiveDir(workspaceRoot: string, slug: string): string {
 // to split; we do the split here.
 export function archivePath(workspaceRoot: string, slug: string, yearMonth: string): string {
   assertValidSlug(slug);
-  const m = /^(\d{4})-(\d{2})$/.exec(yearMonth);
-  if (!m) {
+  const match = /^(\d{4})-(\d{2})$/.exec(yearMonth);
+  if (!match) {
     throw new Error(`[sources] archivePath: expected YYYY-MM, got "${yearMonth}"`);
   }
-  const [, year, month] = m;
+  const [, year, month] = match;
   return path.join(archiveDir(workspaceRoot, slug), year, `${month}.md`);
 }
 

--- a/server/workspace/sources/pipeline/fetch.ts
+++ b/server/workspace/sources/pipeline/fetch.ts
@@ -98,8 +98,8 @@ export function backoffDelayMs(consecutiveFailures: number): number {
   if (consecutiveFailures <= 0) return 0;
   // 1m, 2m, 4m, 8m, 16m, ..., capped at 24h.
   const base = ONE_MINUTE_MS;
-  const ms = base * 2 ** Math.min(consecutiveFailures - 1, 20);
-  return Math.min(ms, BACKOFF_MAX_MS);
+  const delayMs = base * 2 ** Math.min(consecutiveFailures - 1, 20);
+  return Math.min(delayMs, BACKOFF_MAX_MS);
 }
 
 // Compute the next per-source state given the outcome. Pure.

--- a/server/workspace/sources/pipeline/notify.ts
+++ b/server/workspace/sources/pipeline/notify.ts
@@ -30,7 +30,7 @@ export function runNotifyPhase(items: readonly SourceItem[], workspaceRoot?: str
 }
 
 function formatSingleBody(item: SourceItem): string {
-  const suffix = item.summary ? " \u2014 " + item.summary : "";
+  const suffix = item.summary ? " — " + item.summary : "";
   return "From " + item.sourceSlug + suffix;
 }
 
@@ -52,12 +52,12 @@ function publishBatchNotification(scored: readonly ScoredItem[]): void {
 
   const bullets = scored
     .slice(0, 5)
-    .map((s) => `\u2022 ${s.item.title} (${s.item.sourceSlug})`)
+    .map((row) => `• ${row.item.title} (${row.item.sourceSlug})`)
     .join("\n");
   const extra = scored.length > 5 ? `\n+${scored.length - 5} more` : "";
 
   // Preserve high priority if any item in the batch is critical
-  const hasCritical = scored.some((s) => s.item.severity === "critical");
+  const hasCritical = scored.some((row) => row.item.severity === "critical");
 
   publishNotification({
     kind: NOTIFICATION_KINDS.push,

--- a/server/workspace/sources/pipeline/write.ts
+++ b/server/workspace/sources/pipeline/write.ts
@@ -130,11 +130,11 @@ export function renderItemForArchive(item: SourceItem): string {
 // Malformed dates fall back to the caller-supplied default
 // (typically the current YYYY-MM) so we don't drop items.
 export function archiveMonthFor(isoPublishedAt: string, fallbackMonth: string): string {
-  const ts = Date.parse(isoPublishedAt);
-  if (!Number.isFinite(ts)) return fallbackMonth;
-  const d = new Date(ts);
-  const year = d.getUTCFullYear();
-  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const parsed = Date.parse(isoPublishedAt);
+  if (!Number.isFinite(parsed)) return fallbackMonth;
+  const date = new Date(parsed);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   return `${year}-${String(month).padStart(2, "0")}`;
 }
 

--- a/server/workspace/sources/rateLimiter.ts
+++ b/server/workspace/sources/rateLimiter.ts
@@ -41,7 +41,7 @@ export interface RateLimiterDeps {
 export function defaultRateLimiterDeps(): RateLimiterDeps {
   return {
     now: () => Date.now(),
-    sleep: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+    sleep: (millis: number) => new Promise<void>((resolve) => setTimeout(resolve, millis)),
   };
 }
 

--- a/server/workspace/sources/urls.ts
+++ b/server/workspace/sources/urls.ts
@@ -80,7 +80,7 @@ export function normalizeUrl(raw: string): string | null {
   // Sort remaining params for deterministic ordering. Preserve
   // multi-value params by iterating all entries.
   const entries = Array.from(url.searchParams.entries());
-  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  entries.sort(([leftKey], [rightKey]) => (leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0));
   // Clear and reinsert.
   for (const name of Array.from(url.searchParams.keys())) {
     url.searchParams.delete(name);

--- a/server/workspace/tool-trace/classify.ts
+++ b/server/workspace/tool-trace/classify.ts
@@ -96,10 +96,10 @@ function imagePointerFromContent(content: string): string | null {
 // regardless of how the tool happened to quote it. Leave "../"
 // prefixes alone — a relative escape is a bug and we want it visible
 // rather than silently fixed up.
-function normalizeWorkspacePath(p: string): string {
-  if (p.startsWith("./")) return p.slice(2);
-  if (p.startsWith("/")) return p.slice(1);
-  return p;
+function normalizeWorkspacePath(candidatePath: string): string {
+  if (candidatePath.startsWith("./")) return candidatePath.slice(2);
+  if (candidatePath.startsWith("/")) return candidatePath.slice(1);
+  return candidatePath;
 }
 
 function inlineWithTruncation(content: string): Classification {


### PR DESCRIPTION
## Summary
- **server/ の id-length warnings を 70 → 0 にした** (batch 2 の続き、server 完走)
- 純粋 refactor、挙動変更なし
- 44 ファイル / +169 −169 行
- Base branch: \`fix/id-length-server-batch2\` (#556) — あちらのマージ後に main へ rebase して単独マージ可

## Items to Confirm / Review
- `relay-client.ts` の \`ws\` → \`socket\` (WebSocket local ref) の広域置換
- \`loadAllRoles().map((loadedRole) => ...)\` を使った shadow 回避 (\`role\` は外側引数名)
- Vue-side の id-length はスコープ外

## Test plan
- [x] \`yarn format\` — clean
- [x] \`yarn lint\` — 0 errors, **0 id-length warnings in server/**
- [x] \`yarn typecheck\` — pass
- [x] \`yarn build\` — pass
- [x] \`yarn test\` — pass

## 合計
| Branch | Warnings before | after |
|---|---|---|
| batch1 (#551) | main baseline | baseline |
| batch2 (#556) | 144 | 70 |
| **batch3 (この PR)** | 70 | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)