### PR TITLE
feat: set up vue-i18n skeleton (#559)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Client locale for vue-i18n. Supported: "en" (default), "ja".
+# Picked up at build/dev time via import.meta.env.VITE_LOCALE.
+# VITE_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Open [http://localhost:5173](http://localhost:5173). That's it — start chattin
 
 > **Prerequisites**: Node.js 20+, [Claude Code CLI](https://claude.ai/code) installed and authenticated.
 
+> **UI language**: Defaults to English. Set `VITE_LOCALE=ja` in `.env` to use the Japanese dictionary (`src/lang/ja.ts`). Locale is picked at build/dev time; restart `yarn dev` after changing it. See [`docs/developer.md`](docs/developer.md#i18n-vue-i18n) for how to add strings.
+
 ## What can you do?
 
 | Ask Claude to... | What you get |

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -88,6 +88,14 @@ The structured logger (`server/system/logger/`) reads its config fresh at proces
 | `LOG_FILE_MAX_FILES`                       | `14`                 | Retention count.                                                                                    |
 | `LOG_TELEMETRY_*`                          | —                    | Telemetry sink stub for a future remote shipper. No-op today.                                       |
 
+### Client (Vite)
+
+Client-side env vars use the `VITE_` prefix so Vite exposes them to the bundled frontend via `import.meta.env`. They're baked at build/dev time — restart `yarn dev` or rerun `yarn build` after changing.
+
+| Variable      | Default | Effect                                                                                                                                   |
+| ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_LOCALE` | `en`    | Locale passed to vue-i18n (`src/lib/vue-i18n.ts`). Currently supports `en` / `ja`. Missing keys fall back to English. See [i18n](#i18n-vue-i18n). |
+
 ### Container-only env (auto-set)
 
 You never set these by hand; the server constructs them when spawning Claude inside the Docker sandbox (`server/agent/config.ts` and `server/agent/mcp-server.ts`). They're listed here so log lines / failures involving them are decodable.
@@ -343,6 +351,44 @@ Cross-module string literals (endpoint paths, tool names, role IDs, etc.) are de
 | `EVENT_TYPES` / `EventType`            | `src/types/events.ts`          | SSE event type discriminants in agent loop, session store, and frontend dispatch                                                                     |
 
 **Convention**: add new entries to the appropriate module before writing the first consumer. Keep the `as const` assertion so TypeScript infers literal types, not `string`.
+
+---
+
+## i18n (vue-i18n)
+
+CLAUDE.md mandates `$t()` / `useI18n()` for all template strings — never hardcode. The infrastructure lives in three places:
+
+| File                   | Purpose                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `src/lib/vue-i18n.ts`  | `createI18n({ legacy: false, locale, fallbackLocale: "en", messages })`. Locale comes from `VITE_LOCALE`.     |
+| `src/lang/en.ts`       | English dictionary — the **source of truth** for key shape. Missing keys in other locales fall back here.    |
+| `src/lang/ja.ts`       | Japanese dictionary. Mirror the tree shape of `en.ts`; any missing key silently falls back.                  |
+
+### Adding a string
+
+1. Add the key to `src/lang/en.ts` first, grouped by feature area (e.g. `common.*`, `chat.*`, `session.*`). Keep nested objects over flat `dot.keys` strings so related entries stay together.
+2. Mirror in `src/lang/ja.ts` — if you don't have a translation yet, either leave the key out (falls back to English) or add a TODO-style placeholder; don't duplicate the English string.
+3. In a component:
+
+   ```vue
+   <script setup lang="ts">
+   import { useI18n } from "vue-i18n";
+   const { t } = useI18n();
+   </script>
+
+   <template>
+     <button>{{ t("common.save") }}</button>
+     <!-- or in a template without setup:  {{ $t("common.save") }} -->
+   </template>
+   ```
+
+### Changing the running locale
+
+Set `VITE_LOCALE=ja` (or `en`) in `.env` and restart `yarn dev`. Vite inlines env vars at build time, so the app must be re-bundled for a new locale — there's no runtime selector.
+
+### Scope today vs. plans
+
+`src/lang/*.ts` currently holds only a seed (`common.save` / `common.cancel`). Existing hard-coded strings across `src/**/*.vue` will be extracted incrementally in follow-up PRs. See `plans/feat-vue-i18n-setup.md` for the rationale and [issue #559](https://github.com/receptron/mulmoclaude/issues/559).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "uuid": "^13.0.0",
     "vue": "^3.5.32",
     "vue-drawing-canvas": "^1.0.14",
+    "vue-i18n": "^11.3.2",
     "vue-router": "^5.0.3",
     "vuedraggable": "^4.1.0",
     "ws": "^8.20.0",

--- a/plans/feat-vue-i18n-setup.md
+++ b/plans/feat-vue-i18n-setup.md
@@ -1,0 +1,83 @@
+# vue-i18n スケルトン導入 (#559)
+
+## Problem
+
+CLAUDE.md に「MUST use vue-i18n for text; NEVER hardcode strings in templates (use `$t()`)」と記載があるが、実際には vue-i18n が導入されておらず、既存コンポーネントは日本語/英語の文字列をテンプレートに直書きしている。後から全文字列を `$t()` 化するのは大きな作業なので、まず **基盤だけ整える** ステップを切り出す。
+
+## Goal
+
+- `vue-i18n` を利用可能な状態にする
+- Locale は環境変数 (`import.meta.env.VITE_LOCALE`) で切り替え（UI は作らない）
+- 辞書データは **TypeScript** で持つ（JSON ではなく `*.ts` の default export）
+- 既存文字列の置き換えは **別 PR** で順次対応
+
+## Design
+
+参考: `~/ss/ownplate/src/lib/vue-i18n.ts` の構成をミラー。
+
+### ファイル追加
+
+```
+src/
+  lang/
+    en.ts        ← default export オブジェクト、スケルトン
+    ja.ts        ← 同上
+  lib/
+    vue-i18n.ts  ← createI18n 呼び出し、default export
+```
+
+### src/lib/vue-i18n.ts (骨子)
+
+```ts
+import { createI18n } from "vue-i18n";
+import en from "../lang/en";
+import ja from "../lang/ja";
+
+const locale = import.meta.env.VITE_LOCALE ?? "en";
+
+export default createI18n({
+  legacy: false,              // Composition API (CLAUDE.md 準拠)
+  locale,
+  fallbackLocale: "en",
+  messages: { en, ja },
+});
+```
+
+### src/lang/en.ts スケルトン
+
+```ts
+const en = {
+  common: {
+    save: "Save",
+    cancel: "Cancel",
+  },
+} as const;
+
+export default en;
+```
+
+### src/main.ts
+
+既存の `createApp(App)` の後に `app.use(i18n)` を追加。
+
+### .env.example
+
+`VITE_LOCALE=en` の行（コメント付き）を追加。
+
+## Non-goals
+
+- 既存コンポーネントの文字列抽出・置き換え（別 PR で段階的に）
+- Locale 切替 UI（`<select>` 等）
+- 複数言語の辞書充実（en + ja の骨組みだけ）
+- `<i18n-t>` タグの使用例（追加作業時に各 PR で）
+
+## Risk
+
+- 既存コンポーネントで `$t()` を使っていなければ破壊的変更はゼロ
+- `legacy: false` を選ぶのは CLAUDE.md の Composition API 指定に合わせるため
+
+## Test plan
+
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
+- `yarn test` 29/29 pass
+- 手動: `VITE_LOCALE=ja yarn dev` で起動できること（実際に `$t()` を使う場所がまだ無いので視覚確認は次 PR 以降）

--- a/plans/feat-vue-i18n-setup.md
+++ b/plans/feat-vue-i18n-setup.md
@@ -17,7 +17,7 @@ CLAUDE.md に「MUST use vue-i18n for text; NEVER hardcode strings in templates 
 
 ### ファイル追加
 
-```
+```text
 src/
   lang/
     en.ts        ← default export オブジェクト、スケルトン

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1,0 +1,14 @@
+// English dictionary for vue-i18n.
+//
+// Structure is grouped by feature area (common, chat, session, ...).
+// Prefer nested objects over flat keys so related strings stay
+// together and the namespace serves as self-documentation.
+
+const en = {
+  common: {
+    save: "Save",
+    cancel: "Cancel",
+  },
+} as const;
+
+export default en;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -4,11 +4,15 @@
 // Prefer nested objects over flat keys so related strings stay
 // together and the namespace serves as self-documentation.
 
+// No `as const` — the module augmentation in src/types/vue-i18n.d.ts
+// reads `typeof en` to feed `DefineLocaleMessage`, and readonly literal
+// types would conflict with vue-i18n's writable message interface.
+
 const en = {
   common: {
     save: "Save",
     cancel: "Cancel",
   },
-} as const;
+};
 
 export default en;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1,0 +1,11 @@
+// Japanese dictionary. Mirror the shape of src/lang/en.ts —
+// missing keys fall back to English per createI18n's fallbackLocale.
+
+const ja = {
+  common: {
+    save: "保存",
+    cancel: "キャンセル",
+  },
+} as const;
+
+export default ja;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -6,6 +6,6 @@ const ja = {
     save: "保存",
     cancel: "キャンセル",
   },
-} as const;
+};
 
 export default ja;

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -1,0 +1,25 @@
+// vue-i18n setup.
+//
+// Locale is picked at build-time from the `VITE_LOCALE` env var
+// (falls back to "en"). Use `VITE_LOCALE=ja yarn dev` to switch.
+// There's no runtime locale selector yet — follow-up work will add
+// one if needed.
+//
+// `legacy: false` switches vue-i18n to the Composition API mode, so
+// components call `const { t } = useI18n()` instead of relying on
+// the Options API `this.$t`. CLAUDE.md mandates Composition API.
+
+import { createI18n } from "vue-i18n";
+import en from "../lang/en";
+import ja from "../lang/ja";
+
+const locale = import.meta.env.VITE_LOCALE ?? "en";
+
+const i18n = createI18n({
+  legacy: false,
+  locale,
+  fallbackLocale: "en",
+  messages: { en, ja },
+});
+
+export default i18n;

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -13,9 +13,17 @@ import { createI18n } from "vue-i18n";
 import en from "../lang/en";
 import ja from "../lang/ja";
 
-const locale = import.meta.env.VITE_LOCALE ?? "en";
+// Schema generic on createI18n — this is what makes `t("common.save")`
+// calls across the whole app compile-time checked (the module
+// augmentation in src/types/vue-i18n.d.ts alone is not enough; vue-i18n
+// v11's `t` overloads still fall back to `string` unless the schema is
+// threaded through here).
+type MessageSchema = typeof en;
+type Locale = "en" | "ja";
 
-const i18n = createI18n({
+const locale = (import.meta.env.VITE_LOCALE ?? "en") as Locale;
+
+const i18n = createI18n<[MessageSchema], Locale>({
   legacy: false,
   locale,
   fallbackLocale: "en",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router/index";
 import { installGuards } from "./router/guards";
+import i18n from "./lib/vue-i18n";
 import { setAuthToken } from "./utils/api";
 import { readAuthTokenFromMeta } from "./utils/dom/authTokenMeta";
 import "./index.css";
@@ -22,4 +23,5 @@ installGuards(router);
 
 const app = createApp(App);
 app.use(router);
+app.use(i18n);
 app.mount("#app");

--- a/src/types/vue-i18n.d.ts
+++ b/src/types/vue-i18n.d.ts
@@ -1,0 +1,20 @@
+// Module augmentation for vue-i18n. Surfaces the English dictionary
+// shape as `DefineLocaleMessage` so IDEs autocomplete key paths on
+// `$t("…")` and `i18n.global.t("…")`. The schema generic on
+// createI18n (src/lib/vue-i18n.ts) handles the `useI18n()` side.
+//
+// Caveat: vue-i18n v11's `t()` overload has a `Key extends string`
+// fallback, so a typo in `useI18n().t("…")` at a deeply-typed call
+// site may still compile. Autocomplete is the main value; strict
+// rejection of unknown keys would require a bespoke wrapper.
+
+import en from "../lang/en";
+
+// Alias so `extends` has an interface-shaped base (typeof in extends
+// position is a syntax error).
+type EnMessages = typeof en;
+
+declare module "vue-i18n" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface DefineLocaleMessage extends EnMessages {}
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_LOCALE?: "en" | "ja";
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,36 @@
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.5.tgz#a02d90e5da8a36dce27ac8e7237a50c99a9003a3"
   integrity sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==
 
+"@intlify/core-base@11.3.2":
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.3.2.tgz#185d0e3259be5afc1888c2d2e1a636be09ad2dae"
+  integrity sha512-cgsUaV/dyD6aS49UPgerIblrWeXAZHNaDWqm4LujOGC7IafSyhghGXEiSVvuDYaDPiQTP+tSFSTM1HIu7Yp1nA==
+  dependencies:
+    "@intlify/devtools-types" "11.3.2"
+    "@intlify/message-compiler" "11.3.2"
+    "@intlify/shared" "11.3.2"
+
+"@intlify/devtools-types@11.3.2":
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.3.2.tgz#983e3c12340b36a41648fda451aeebc4f3ade812"
+  integrity sha512-q96G2ZZw0FNoXzejbjIf9dbfgz1xyYBZu6ZT4b5TE/55j8d1O9X5jv0k+U+L3fVe7uebPcqRQFD0ffm30i5mJA==
+  dependencies:
+    "@intlify/core-base" "11.3.2"
+    "@intlify/shared" "11.3.2"
+
+"@intlify/message-compiler@11.3.2":
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.3.2.tgz#3e53e5f71995a2ef7d385554185852f5139d4eb3"
+  integrity sha512-d/awyHUkNSaGPxBxT/qlUpfRizxHX9dt55CnW03xx5p1KmMyfYHKupCnvzINX+Na8JR8LAR7y32lPKjoeQGmzA==
+  dependencies:
+    "@intlify/shared" "11.3.2"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.3.2":
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.3.2.tgz#589d0a7d5448fb042b9553be28aca4467898368d"
+  integrity sha512-x66fjdH6i+lNYPae5URSQGTjBL68Av6hi09jvC5Ci96iTkwfqrPhCj46aylQZmgMaG89rOZCIKqS7ApC8ZDVjg==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1905,6 +1935,11 @@
   dependencies:
     "@vue/compiler-dom" "3.5.32"
     "@vue/shared" "3.5.32"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/devtools-api@^8.0.6":
   version "8.1.1"
@@ -6492,7 +6527,7 @@ sortablejs@1.14.0:
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
   integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
 
-source-map-js@^1.2.1:
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -7220,6 +7255,16 @@ vue-eslint-parser@^10.4.0:
     espree "^10.3.0 || ^11.0.0"
     esquery "^1.6.0"
     semver "^7.6.3"
+
+vue-i18n@^11.3.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.3.2.tgz#8f774a4e680be7e0c7a939ff04663cf26886fb85"
+  integrity sha512-gmFrvM+iuf2AH4ygligw/pC7PRJ63AdRNE68E0GPlQ83Mzfyck6g6cRQC3KzkYXr+ZidR91wq+5YBmAMpkgE1A==
+  dependencies:
+    "@intlify/core-base" "11.3.2"
+    "@intlify/devtools-types" "11.3.2"
+    "@intlify/shared" "11.3.2"
+    "@vue/devtools-api" "^6.5.0"
 
 vue-router@^5.0.3:
   version "5.0.4"


### PR DESCRIPTION
## Summary

CLAUDE.md に「MUST use vue-i18n for text; NEVER hardcode strings in templates」のルールがあるが、vue-i18n 未導入。まずは**スケルトン**だけ用意し、既存文字列の抽出は後続 PR で段階的に行う。

- \`vue-i18n@^11\` 追加
- \`src/lang/en.ts\`, \`src/lang/ja.ts\` — TS ネスト辞書（seed: \`common.save\` / \`common.cancel\`）
- \`src/lib/vue-i18n.ts\` — \`createI18n({ legacy: false })\`、locale は \`VITE_LOCALE\` env var（default \`en\`）
- \`src/vite-env.d.ts\` — \`ImportMetaEnv\` 型定義（\`typecheck:test\` が \`src/\` を含むため必要）
- \`src/main.ts\` に \`app.use(i18n)\`
- \`.env.example\` に \`VITE_LOCALE\` コメント追加
- README / \`docs/developer.md\` 更新

## Items to Confirm / Review

- [ ] **Non-goal 範囲**: 既存コンポーネントのハードコード文字列を \`\$t()\` 化する作業は**含まない**。follow-up PR で段階的に対応
- [ ] **Locale 切替**: UI ではなく \`VITE_LOCALE\` env var のみ。Vite はビルド時に env を inline するので、切り替え後は dev サーバの再起動が必要
- [ ] **\`legacy: false\`**: Composition API モード（CLAUDE.md 準拠）。今後 \`useI18n()\` を使う想定
- [ ] **\`src/vite-env.d.ts\`**: \`test/tsconfig.json\` が \`../src/\` を include しているため、\`import.meta.env\` の型定義を \`src/\` 配下に置かないと \`yarn typecheck:test\` が落ちる
- [ ] **ownplate の構成をミラー**: \`~/ss/ownplate/src/lib/vue-i18n.ts\` と同じパターン

## User Prompt

「~/ss/ownplate 以下を参考に vue-i18n を入れたい。データは TS にしてね。」「READMEやdevガイドもね。」という要望。要件クラリファイでは:
- 言語: en + ja のみ
- 初期内容: スケルトンのみ、既存文字列抽出は別 PR
- Locale 切替: 環境変数で

## Implementation

Plan: [\`plans/feat-vue-i18n-setup.md\`](plans/feat-vue-i18n-setup.md)

参考: \`~/ss/ownplate/src/lib/vue-i18n.ts\`

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` 39/39 + 29/29 pass
- [ ] 手動: \`VITE_LOCALE=ja yarn dev\` で起動し、\`\$t()\` を使うダミー箇所を確認（フォローアップ PR で実際のコンポーネント置換時に再確認）

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization (i18n) support with English and Japanese language options configurable at startup.

* **Documentation**
  * Added comprehensive developer documentation for i18n setup and configuration.
  * Updated README with locale switching instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->