### PR TITLE
docs: correct 0.3.0 CHANGELOG to reflect aligned mulmoclaude npm version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,7 +62,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Packages published during this cycle
 
-- `mulmoclaude@0.1.2` (new, initial npm publish — port fallback, ready banner, tsx runtime)
+- `mulmoclaude@0.3.0` (aligned to app version — initial npm publish with port fallback, ready banner, tsx runtime)
 - `@mulmobridge/protocol@0.1.3` (adds `GENERATION_KINDS` export chain)
 - `@mulmobridge/chat-service@0.1.1` (catches up with protocol 0.1.3)
 - `@mulmobridge/relay@0.1.0` (new)


### PR DESCRIPTION
## Summary

The v0.3.0 CHANGELOG on main still refers to \`mulmoclaude@0.1.2\` (the test version used during dev). The shipped npm package is \`mulmoclaude@0.3.0\` (aligned to the app tag). One-line fix.

This was commit \`252bfa0\` on PR #564 but got pushed after the merge. Re-applying on a fresh branch.

## Test plan
- [x] Diff touches only one line

## Summary by Sourcery

Documentation:
- Update the v0.3.0 CHANGELOG entry to list mulmoclaude@0.3.0 with an accurate description of the initial npm publish.