### PR TITLE
ui(chat-input): drop focus expansion, tighten padding, equalize buttons

### DIFF
--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-4 border-t border-gray-200" @dragover.prevent @drop="onDropFile">
+  <div class="p-2 border-t border-gray-200" @dragover.prevent @drop="onDropFile">
     <div v-if="fileError" class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="file-error">
       {{ fileError }}
     </div>
@@ -16,34 +16,32 @@
         :value="modelValue"
         data-testid="user-input"
         placeholder="Type a task..."
-        :rows="inputFocused ? 8 : 2"
-        class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none transition-all duration-200"
-        :class="inputFocused ? 'ring-2 ring-blue-300' : ''"
+        rows="2"
+        class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
         :disabled="isRunning"
         @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
-        @focus="inputFocused = true"
         @compositionstart="imeEnter.onCompositionStart"
         @compositionend="imeEnter.onCompositionEnd"
         @keydown="imeEnter.onKeydown"
-        @blur="onInputBlur"
+        @blur="imeEnter.onBlur"
         @paste="onPasteFile"
       />
       <div class="flex flex-col gap-1">
         <button
           data-testid="send-btn"
-          class="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          class="bg-blue-600 hover:bg-blue-700 text-white rounded w-8 h-8 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="isRunning"
           @click="emit('send')"
         >
-          <span class="material-icons text-base">send</span>
+          <span class="material-icons text-base leading-none">send</span>
         </button>
         <button
           data-testid="expand-input-btn"
-          class="text-gray-400 hover:text-gray-600 rounded px-3 py-1 text-sm"
+          class="text-gray-400 hover:text-gray-600 rounded w-8 h-8 flex items-center justify-center"
           title="Expand editor"
           @click="openExpandedEditor"
         >
-          <span class="material-icons text-base">open_in_full</span>
+          <span class="material-icons text-base leading-none">open_in_full</span>
         </button>
       </div>
     </div>
@@ -111,7 +109,6 @@ const emit = defineEmits<{
 
 const textarea = ref<HTMLTextAreaElement | null>(null);
 const expandedTextarea = ref<HTMLTextAreaElement | null>(null);
-const inputFocused = ref(false);
 const expandedEditorOpen = ref(false);
 const fileError = ref<string | null>(null);
 
@@ -176,13 +173,6 @@ function onDropFile(event: DragEvent): void {
 }
 
 const imeEnter = useImeAwareEnter(() => emit("send"));
-
-function onInputBlur(): void {
-  imeEnter.onBlur();
-  setTimeout(() => {
-    inputFocused.value = false;
-  }, 150);
-}
 
 function openExpandedEditor(): void {
   expandedEditorOpen.value = true;


### PR DESCRIPTION
## Summary
- Remove the focus-expand mechanism on the chat textarea (rows toggling 2↔8, focus ring, blur timeout). The modal expand editor already handles long composition.
- Match the wrapper padding (`p-4` → `p-2`) to the surrounding message-preview panel so the input aligns horizontally with the previews above.
- Make the send and expand buttons both `w-8 h-8` with centered icons. The previously wider expand button was stretching the button column and leaving a visible gap to the right of the small send button.

## Test plan
- [ ] Open a session — textarea stays compact at 2 rows on focus, no ring/animation.
- [ ] Send and expand buttons are the same compact size, icons centered, flush with the right edge.
- [ ] Click expand button — modal editor opens and Cmd/Ctrl+Enter still sends.
- [ ] IME composition (Japanese/Chinese/Korean) — Enter still confirms without sending.
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced padding around the chat input area for a more compact layout.
  * Simplified textarea interaction by removing dynamic auto-expansion behavior and focus-based styling.
  * Updated send and expand button styling with consistent sizing and improved icon alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->