### PR TITLE
feat(i18n): extract SessionHistoryPanel and NotificationBell strings

### DIFF
--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted } from "vue";
+import { useI18n } from "vue-i18n";
 import { useNotifications } from "../composables/useNotifications";
 import { formatRelativeTime } from "../utils/format/date";
 import { NOTIFICATION_ICONS, NOTIFICATION_ACTION_TYPES, NOTIFICATION_PRIORITIES } from "../types/notification";
 import type { NotificationPayload } from "../types/notification";
 
+const { t } = useI18n();
 const { notifications, unreadCount, markAllRead, dismiss } = useNotifications();
 const open = ref(false);
 const rootRef = ref<HTMLElement | null>(null);
@@ -70,7 +72,12 @@ function handleDismiss(event: Event, notificationId: string): void {
 <template>
   <div ref="rootRef" class="relative">
     <!-- Bell button -->
-    <button class="relative text-gray-400 hover:text-gray-700" data-testid="notification-bell" aria-label="Notifications" @click="toggle">
+    <button
+      class="relative text-gray-400 hover:text-gray-700"
+      data-testid="notification-bell"
+      :aria-label="t('notificationBell.notifications')"
+      @click="toggle"
+    >
       <span class="material-icons">notifications</span>
       <span
         v-if="unreadCount > 0"
@@ -89,12 +96,14 @@ function handleDismiss(event: Event, notificationId: string): void {
     >
       <!-- Header -->
       <div class="flex items-center justify-between px-4 py-2 border-b border-gray-100">
-        <span class="text-sm font-semibold text-gray-700">Notifications</span>
-        <button class="text-xs text-blue-500 hover:text-blue-700" data-testid="notification-mark-all-read" @click="markAllRead">Mark all read</button>
+        <span class="text-sm font-semibold text-gray-700">{{ t("notificationBell.notifications") }}</span>
+        <button class="text-xs text-blue-500 hover:text-blue-700" data-testid="notification-mark-all-read" @click="markAllRead">
+          {{ t("notificationBell.markAllRead") }}
+        </button>
       </div>
 
       <!-- Empty state -->
-      <div v-if="notifications.length === 0" class="py-8 text-center text-sm text-gray-400">No notifications</div>
+      <div v-if="notifications.length === 0" class="py-8 text-center text-sm text-gray-400">{{ t("notificationBell.noNotifications") }}</div>
 
       <!-- Items -->
       <div v-else>
@@ -121,7 +130,7 @@ function handleDismiss(event: Event, notificationId: string): void {
               {{ formatTime(n.firedAt) }}
             </p>
           </div>
-          <button class="text-gray-300 hover:text-gray-500 shrink-0 mt-0.5" aria-label="Dismiss" @click="handleDismiss($event, n.id)">
+          <button class="text-gray-300 hover:text-gray-500 shrink-0 mt-0.5" :aria-label="t('notificationBell.dismiss')" @click="handleDismiss($event, n.id)">
             <span class="material-icons text-sm">close</span>
           </button>
         </div>

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -9,14 +9,14 @@
       <div class="flex gap-1 mb-1 flex-wrap" data-testid="session-filter-bar">
         <button
           v-for="f in FILTERS"
-          :key="f.value"
+          :key="f"
           class="px-2 py-0.5 text-[10px] rounded-full border transition-colors"
-          :class="activeFilter === f.value ? 'bg-blue-500 text-white border-blue-500' : 'bg-white text-gray-500 border-gray-300 hover:bg-gray-50'"
-          :data-testid="`session-filter-${f.value}`"
-          @click="activeFilter = f.value"
+          :class="activeFilter === f ? 'bg-blue-500 text-white border-blue-500' : 'bg-white text-gray-500 border-gray-300 hover:bg-gray-50'"
+          :data-testid="`session-filter-${f}`"
+          @click="activeFilter = f"
         >
-          {{ f.label }}
-          <span v-if="f.value !== 'all'" class="ml-0.5 opacity-70">{{ countByOrigin(f.value) }}</span>
+          {{ t(`sessionHistoryPanel.filters.${f}`) }}
+          <span v-if="f !== 'all'" class="ml-0.5 opacity-70">{{ countByOrigin(f) }}</span>
         </button>
       </div>
 
@@ -26,11 +26,11 @@
         role="alert"
         data-testid="session-history-error"
       >
-        ⚠ Failed to refresh: {{ errorMessage }}
-        <span v-if="sessions.length > 0"> — showing last known list.</span>
+        {{ t("sessionHistoryPanel.failedToRefresh", { error: errorMessage }) }}
+        <span v-if="sessions.length > 0">{{ t("sessionHistoryPanel.showingLastKnown") }}</span>
       </div>
       <p v-if="filteredSessions.length === 0" class="text-xs text-gray-400 p-2">
-        {{ activeFilter === "all" ? "No sessions yet." : "No matching sessions." }}
+        {{ activeFilter === "all" ? t("sessionHistoryPanel.noSessions") : t("sessionHistoryPanel.noMatching") }}
       </p>
       <div
         v-for="session in filteredSessions"
@@ -53,14 +53,14 @@
           <span class="ml-auto flex items-center gap-1.5">
             <span v-if="isSessionRunning(session)" class="flex items-center gap-0.5 text-yellow-600 font-medium">
               <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
-              Running
+              {{ t("sessionHistoryPanel.running") }}
             </span>
-            <span v-else-if="isSessionUnread(session)" class="flex items-center gap-0.5 text-gray-900 font-bold"> Unread </span>
+            <span v-else-if="isSessionUnread(session)" class="flex items-center gap-0.5 text-gray-900 font-bold">{{ t("sessionHistoryPanel.unread") }}</span>
             <span v-else>{{ formatDate(session.updatedAt) }}</span>
           </span>
         </div>
         <p class="truncate" :class="previewClasses(session)">
-          {{ session.preview || "(no messages)" }}
+          {{ session.preview || t("sessionHistoryPanel.noMessages") }}
         </p>
         <!-- Optional second line: AI-generated summary of the
              session, populated by the chat indexer (#123). -->
@@ -74,19 +74,16 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
+import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
 import { formatDate } from "../utils/format/date";
 import { roleIcon, roleName } from "../utils/role/icon";
 
-const FILTERS = [
-  { value: "all" as const, label: "All" },
-  { value: SESSION_ORIGINS.human, label: "Human" },
-  { value: SESSION_ORIGINS.scheduler, label: "Scheduler" },
-  { value: SESSION_ORIGINS.skill, label: "Skill" },
-  { value: SESSION_ORIGINS.bridge, label: "Bridge" },
-];
+const { t } = useI18n();
+
+const FILTERS = ["all" as const, SESSION_ORIGINS.human, SESSION_ORIGINS.scheduler, SESSION_ORIGINS.skill, SESSION_ORIGINS.bridge];
 
 const ORIGIN_ICONS: Record<string, string> = {
   human: "person",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -29,6 +29,28 @@ const en = {
     send: "Send",
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",
   },
+  sessionHistoryPanel: {
+    filters: {
+      all: "All",
+      human: "Human",
+      scheduler: "Scheduler",
+      skill: "Skill",
+      bridge: "Bridge",
+    },
+    failedToRefresh: "⚠ Failed to refresh: {error}",
+    showingLastKnown: " — showing last known list.",
+    noSessions: "No sessions yet.",
+    noMatching: "No matching sessions.",
+    running: "Running",
+    unread: "Unread",
+    noMessages: "(no messages)",
+  },
+  notificationBell: {
+    notifications: "Notifications",
+    markAllRead: "Mark all read",
+    noNotifications: "No notifications",
+    dismiss: "Dismiss",
+  },
 };
 
 export default en;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -22,6 +22,28 @@ const ja = {
     send: "送信",
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",
   },
+  sessionHistoryPanel: {
+    filters: {
+      all: "すべて",
+      human: "手動",
+      scheduler: "スケジューラ",
+      skill: "スキル",
+      bridge: "ブリッジ",
+    },
+    failedToRefresh: "⚠ 更新に失敗: {error}",
+    showingLastKnown: " — 前回取得の一覧を表示しています。",
+    noSessions: "セッションはまだありません。",
+    noMatching: "該当するセッションはありません。",
+    running: "実行中",
+    unread: "未読",
+    noMessages: "（メッセージなし）",
+  },
+  notificationBell: {
+    notifications: "通知",
+    markAllRead: "すべて既読にする",
+    noNotifications: "通知はありません",
+    dismiss: "閉じる",
+  },
 };
 
 export default ja;


### PR DESCRIPTION
## Summary

vue-i18n string-extraction batch 2 (#559 follow-up)。Session 履歴パネル + 通知ベルの UI 文字列を辞書化。

### 扱ったパターン

- **Dynamic key lookup**: SessionHistoryPanel のフィルタラベルは \`t(\`sessionHistoryPanel.filters.\${value}\`)\` 形式で origin 値をそのまま key に使い、\`FILTERS\` 配列から \`label\` カラムを削除
- **Named interpolation**: エラーバナーの \`{error}\` 置換
- **Conditional t() in template**: 空状態の 3項演算子
- **aria-label i18n**: 両コンポーネントでスクリーンリーダー向けラベルも対象に

## Items to Confirm / Review

- [ ] **FILTERS リファクタ**: \`label\` カラム削除により配列がただの string union になった。\`v-for\` の \`:key="f"\` + \`activeFilter = f\` で問題なく動作
- [ ] **日本語訳**: \`Human\` → 「手動」、\`Skill\` → 「スキル」等、origin 意味と齟齬ないか要確認
- [ ] **E2E 非影響**: \`data-testid\` ベースなので影響なし（\`grep\` 済）

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` 39 + 29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added internationalization (i18n) support with English and Japanese translations for the notification bell and session history panel components, enabling localized interface text for buttons, labels, messages, and filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->