### PR TITLE
feat: scheduler frequency hints + adaptive empty-fetch backoff (#465)

### DIFF
--- a/server/workspace/sources/pipeline/fetch.ts
+++ b/server/workspace/sources/pipeline/fetch.ts
@@ -15,7 +15,7 @@ import type { FetcherDeps, FetchResult, SourceFetcher } from "../fetchers/index.
 import type { FetcherKind, Source, SourceState } from "../types.js";
 import { defaultSourceState } from "../types.js";
 import { errorMessage } from "../../../utils/errors.js";
-import { ONE_MINUTE_MS, ONE_DAY_MS } from "../../../utils/time.js";
+import { ONE_MINUTE_MS, ONE_HOUR_MS, ONE_DAY_MS } from "../../../utils/time.js";
 
 // Outcome of one source's fetch attempt.
 export type FetchOutcome =
@@ -97,32 +97,52 @@ export const BACKOFF_MAX_MS = ONE_DAY_MS;
 export function backoffDelayMs(consecutiveFailures: number): number {
   if (consecutiveFailures <= 0) return 0;
   // 1m, 2m, 4m, 8m, 16m, ..., capped at 24h.
-  const base = ONE_MINUTE_MS;
-  const ms = base * 2 ** Math.min(consecutiveFailures - 1, 20);
+  const ms = ONE_MINUTE_MS * 2 ** Math.min(consecutiveFailures - 1, 20);
   return Math.min(ms, BACKOFF_MAX_MS);
+}
+
+// Number of consecutive empty fetches before adaptive backoff kicks in.
+export const EMPTY_FETCH_THRESHOLD = 3;
+export const EMPTY_BACKOFF_MAX_MS = ONE_DAY_MS;
+
+// Exponential backoff (in ms) for Nth consecutive empty-success fetch.
+// Returns 0 when below the threshold so callers can use it as a guard.
+// Starts at 1h after threshold, doubling each time up to 24h.
+export function emptyBackoffDelayMs(consecutiveEmptyFetches: number): number {
+  if (consecutiveEmptyFetches < EMPTY_FETCH_THRESHOLD) return 0;
+  const steps = consecutiveEmptyFetches - EMPTY_FETCH_THRESHOLD;
+  const ms = ONE_HOUR_MS * 2 ** Math.min(steps, 10);
+  return Math.min(ms, EMPTY_BACKOFF_MAX_MS);
 }
 
 // Compute the next per-source state given the outcome. Pure.
 //
-// On success:
-//   - lastFetchedAt = now
-//   - cursor = outcome.cursor (replace wholesale — fetchers
-//     return the merged cursor map)
-//   - consecutiveFailures = 0
-//   - nextAttemptAt = null
+// On success with items:
+//   - lastFetchedAt = now, cursor updated
+//   - consecutiveFailures = 0, nextAttemptAt = null
+//   - consecutiveEmptyFetches = 0, emptyBackoffUntil = null
+// On success with 0 items:
+//   - lastFetchedAt = now, cursor updated
+//   - consecutiveFailures = 0, nextAttemptAt = null
+//   - consecutiveEmptyFetches += 1
+//   - emptyBackoffUntil = now + emptyBackoffDelayMs(newCount) if above threshold
 // On any non-success:
-//   - lastFetchedAt unchanged (we didn't successfully fetch)
-//   - cursor unchanged
-//   - consecutiveFailures += 1
-//   - nextAttemptAt = now + backoffDelayMs(newCount)
+//   - lastFetchedAt/cursor unchanged
+//   - consecutiveFailures += 1, nextAttemptAt = now + backoffDelayMs(newCount)
+//   - consecutiveEmptyFetches/emptyBackoffUntil unchanged
 export function computeNextState(prev: SourceState, outcome: FetchOutcome, nowMs: number): SourceState {
   if (outcome.kind === "success") {
+    const hasItems = outcome.items.length > 0;
+    const emptyCount = hasItems ? 0 : prev.consecutiveEmptyFetches + 1;
+    const emptyDelayMs = emptyBackoffDelayMs(emptyCount);
     return {
       slug: prev.slug,
       lastFetchedAt: new Date(nowMs).toISOString(),
       cursor: outcome.cursor,
       consecutiveFailures: 0,
       nextAttemptAt: null,
+      consecutiveEmptyFetches: emptyCount,
+      emptyBackoffUntil: emptyDelayMs > 0 ? new Date(nowMs + emptyDelayMs).toISOString() : null,
     };
   }
   const failures = prev.consecutiveFailures + 1;
@@ -132,5 +152,7 @@ export function computeNextState(prev: SourceState, outcome: FetchOutcome, nowMs
     cursor: prev.cursor,
     consecutiveFailures: failures,
     nextAttemptAt: new Date(nowMs + backoffDelayMs(failures)).toISOString(),
+    consecutiveEmptyFetches: prev.consecutiveEmptyFetches,
+    emptyBackoffUntil: prev.emptyBackoffUntil,
   };
 }

--- a/server/workspace/sources/pipeline/index.ts
+++ b/server/workspace/sources/pipeline/index.ts
@@ -34,6 +34,7 @@ import { listSources } from "../registry.js";
 import { readManyStates, writeManyStates } from "../sourceState.js";
 import { dailyNewsPath } from "../paths.js";
 import { getFetcher as registryGetFetcher, type FetcherDeps, type SourceFetcher } from "../fetchers/index.js";
+import { defaultSourceState } from "../types.js";
 import type { FetcherKind, Source, SourceItem, SourceState, SourceSchedule } from "../types.js";
 import { planEligibleSources } from "./plan.js";
 import { runFetchPhase, computeNextState, type FetchOutcome } from "./fetch.js";
@@ -234,13 +235,7 @@ function buildNextStates(
   }
   const nextStates: SourceState[] = [];
   for (const source of eligible) {
-    const prev = statesBySlug.get(source.slug) ?? {
-      slug: source.slug,
-      lastFetchedAt: null,
-      cursor: {},
-      consecutiveFailures: 0,
-      nextAttemptAt: null,
-    };
+    const prev = statesBySlug.get(source.slug) ?? defaultSourceState(source.slug);
     const outcome = outcomeBySlug.get(source.slug);
     if (!outcome) continue; // unreachable in practice; defensive
     nextStates.push(computeNextState(prev, outcome, nowMs));

--- a/server/workspace/sources/pipeline/plan.ts
+++ b/server/workspace/sources/pipeline/plan.ts
@@ -49,18 +49,20 @@ export function planEligibleSources(input: PlanInput): Source[] {
 }
 
 // True when the state indicates the source is STILL in backoff
-// (so we should SKIP it). False means eligible to run now.
+// (so we should SKIP it). Checks both error backoff (nextAttemptAt)
+// and empty-fetch adaptive backoff (emptyBackoffUntil). Either one
+// being in the future is enough to skip this cycle.
 //
-// - No state at all → run.
-// - No nextAttemptAt → run.
-// - nextAttemptAt unparseable → run (don't let a corrupt state
-//   file permanently lock out a source).
-// - nextAttemptAt in the future → skip.
-// - nextAttemptAt at or before now → run.
+// Corrupt / unparseable timestamps are ignored so a bad state file
+// never permanently locks out a source.
 function isWithinBackoff(state: SourceState | undefined, nowMs: number): boolean {
   if (!state) return false;
-  if (!state.nextAttemptAt) return false;
-  const ts = Date.parse(state.nextAttemptAt);
-  if (!Number.isFinite(ts)) return false;
-  return ts > nowMs;
+  return isFutureTimestamp(state.nextAttemptAt, nowMs) || isFutureTimestamp(state.emptyBackoffUntil, nowMs);
+}
+
+function isFutureTimestamp(ts: string | null | undefined, nowMs: number): boolean {
+  if (!ts) return false;
+  const parsed = Date.parse(ts);
+  if (!Number.isFinite(parsed)) return false;
+  return parsed > nowMs;
 }

--- a/server/workspace/sources/sourceState.ts
+++ b/server/workspace/sources/sourceState.ts
@@ -50,8 +50,9 @@ export function validateSourceState(raw: unknown, slug: string): SourceState {
   const o = raw as Record<string, unknown>;
   const lastFetchedAt = typeof o.lastFetchedAt === "string" ? o.lastFetchedAt : null;
   const nextAttemptAt = typeof o.nextAttemptAt === "string" ? o.nextAttemptAt : null;
-  const consecutiveFailures =
-    typeof o.consecutiveFailures === "number" && Number.isFinite(o.consecutiveFailures) && o.consecutiveFailures >= 0 ? Math.floor(o.consecutiveFailures) : 0;
+  const emptyBackoffUntil = typeof o.emptyBackoffUntil === "string" ? o.emptyBackoffUntil : null;
+  const consecutiveFailures = toNonNegativeInt(o.consecutiveFailures);
+  const consecutiveEmptyFetches = toNonNegativeInt(o.consecutiveEmptyFetches);
   const cursor = validateCursor(o.cursor);
   return {
     slug,
@@ -59,7 +60,13 @@ export function validateSourceState(raw: unknown, slug: string): SourceState {
     cursor,
     consecutiveFailures,
     nextAttemptAt,
+    consecutiveEmptyFetches,
+    emptyBackoffUntil,
   };
+}
+
+function toNonNegativeInt(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
 }
 
 function validateCursor(raw: unknown): Record<string, string> {

--- a/server/workspace/sources/types.ts
+++ b/server/workspace/sources/types.ts
@@ -131,6 +131,13 @@ export interface SourceState {
   // Timestamp after which the next attempt is allowed, so backoff
   // survives server restarts.
   nextAttemptAt: string | null;
+  // Consecutive empty-success count (fetcher returned 0 items).
+  // Reset to 0 when items are found. Drives adaptive empty backoff.
+  consecutiveEmptyFetches: number;
+  // Timestamp after which the next attempt is allowed following
+  // repeated empty fetches. Separate from nextAttemptAt (error
+  // backoff) so the two policies don't interfere.
+  emptyBackoffUntil: string | null;
 }
 
 export function defaultSourceState(slug: string): SourceState {
@@ -140,5 +147,7 @@ export function defaultSourceState(slug: string): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
   };
 }

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -13,8 +13,27 @@
       {{ error }}
     </div>
 
-    <!-- Task list -->
+    <!-- Task list + frequency hints -->
     <div v-else>
+      <!-- Frequency hints reference -->
+      <details class="mb-4 border border-gray-200 rounded-lg text-sm" data-testid="scheduler-frequency-hints">
+        <summary class="px-3 py-2 cursor-pointer text-gray-600 font-medium select-none hover:bg-gray-50 rounded-lg">Recommended Frequencies</summary>
+        <table class="w-full mt-1 mb-2 text-xs text-gray-500">
+          <thead>
+            <tr class="border-b border-gray-100">
+              <th class="px-3 py-1 text-left font-medium text-gray-600">Task type</th>
+              <th class="px-3 py-1 text-left font-medium text-gray-600">Suggested schedule</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="hint in FREQUENCY_HINTS" :key="hint.label" class="border-b border-gray-50 last:border-0">
+              <td class="px-3 py-1">{{ hint.label }}</td>
+              <td class="px-3 py-1 font-mono text-gray-700">{{ hint.schedule }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
+
       <div v-if="tasks.length === 0" class="flex items-center justify-center h-32 text-gray-400">No scheduled tasks</div>
 
       <div v-else class="space-y-2">
@@ -120,6 +139,14 @@ interface SchedulerTask {
   enabled?: boolean;
   state?: TaskState;
 }
+
+const FREQUENCY_HINTS = [
+  { label: "News / RSS fetch", schedule: "Every 1h" },
+  { label: "Journal daily pass", schedule: "Daily 23:00 UTC" },
+  { label: "Wiki maintenance", schedule: "Daily 02:00 UTC" },
+  { label: "Memory extraction", schedule: "Daily 00:00 UTC" },
+  { label: "Calendar / contact sync", schedule: "Every 4h" },
+] as const;
 
 const tasks = ref<SchedulerTask[]>([]);
 const loading = ref(true);

--- a/test/sources/test_arxiv.ts
+++ b/test/sources/test_arxiv.ts
@@ -39,6 +39,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }

--- a/test/sources/test_githubIssues.ts
+++ b/test/sources/test_githubIssues.ts
@@ -41,6 +41,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }

--- a/test/sources/test_githubReleases.ts
+++ b/test/sources/test_githubReleases.ts
@@ -40,6 +40,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }

--- a/test/sources/test_pipelineEntry.ts
+++ b/test/sources/test_pipelineEntry.ts
@@ -294,6 +294,8 @@ describe("runSourcesPipeline — failure isolation (Q8)", () => {
       // local timezone, so the plan phase doesn't filter this
       // source out for still being in backoff.
       nextAttemptAt: "2026-04-12T00:00:00Z",
+      consecutiveEmptyFetches: 0,
+      emptyBackoffUntil: null,
     });
     const fetcher = fakeFetcher("rss", {
       hn: [makeItem({ id: "recovered" })],

--- a/test/sources/test_pipelineFetch.ts
+++ b/test/sources/test_pipelineFetch.ts
@@ -1,6 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { runFetchPhase, computeNextState, backoffDelayMs, BACKOFF_MAX_MS } from "../../server/workspace/sources/pipeline/fetch.js";
+import {
+  runFetchPhase,
+  computeNextState,
+  backoffDelayMs,
+  emptyBackoffDelayMs,
+  BACKOFF_MAX_MS,
+  EMPTY_FETCH_THRESHOLD,
+  EMPTY_BACKOFF_MAX_MS,
+} from "../../server/workspace/sources/pipeline/fetch.js";
 import type { FetcherDeps, FetchResult, SourceFetcher } from "../../server/workspace/sources/fetchers/index.js";
 import type { FetcherKind, Source, SourceState } from "../../server/workspace/sources/types.js";
 import { HostRateLimiter, type RateLimiterDeps } from "../../server/workspace/sources/rateLimiter.js";
@@ -31,6 +39,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }
@@ -286,5 +296,70 @@ describe("computeNextState — on failure", () => {
     const next = computeNextState(prev, outcome, now);
     const gap = Date.parse(next.nextAttemptAt!) - now;
     assert.equal(gap, BACKOFF_MAX_MS);
+  });
+
+  it("preserves consecutiveEmptyFetches on failure", () => {
+    const prev = makeState({ slug: "s", consecutiveEmptyFetches: 2 });
+    const outcome = { kind: "error" as const, sourceSlug: "s", error: "boom" };
+    const next = computeNextState(prev, outcome, now);
+    assert.equal(next.consecutiveEmptyFetches, 2);
+  });
+});
+
+describe("emptyBackoffDelayMs — adaptive empty-fetch backoff", () => {
+  it("returns 0 below the threshold", () => {
+    assert.equal(emptyBackoffDelayMs(0), 0);
+    assert.equal(emptyBackoffDelayMs(EMPTY_FETCH_THRESHOLD - 1), 0);
+  });
+
+  it("returns 1h at the threshold", () => {
+    assert.equal(emptyBackoffDelayMs(EMPTY_FETCH_THRESHOLD), 3_600_000);
+  });
+
+  it("doubles each step beyond the threshold", () => {
+    assert.equal(emptyBackoffDelayMs(EMPTY_FETCH_THRESHOLD + 1), 7_200_000);
+    assert.equal(emptyBackoffDelayMs(EMPTY_FETCH_THRESHOLD + 2), 14_400_000);
+  });
+
+  it("caps at EMPTY_BACKOFF_MAX_MS", () => {
+    assert.equal(emptyBackoffDelayMs(EMPTY_FETCH_THRESHOLD + 100), EMPTY_BACKOFF_MAX_MS);
+  });
+});
+
+describe("computeNextState — empty-success adaptive backoff", () => {
+  const now = Date.parse("2026-04-13T10:00:00Z");
+
+  it("increments consecutiveEmptyFetches when items array is empty", () => {
+    const prev = makeState({ slug: "s", consecutiveEmptyFetches: 0 });
+    const outcome = { kind: "success" as const, sourceSlug: "s", items: [], cursor: {} };
+    const next = computeNextState(prev, outcome, now);
+    assert.equal(next.consecutiveEmptyFetches, 1);
+    assert.equal(next.emptyBackoffUntil, null); // below threshold
+  });
+
+  it("sets emptyBackoffUntil once threshold is reached", () => {
+    const prev = makeState({ slug: "s", consecutiveEmptyFetches: EMPTY_FETCH_THRESHOLD - 1 });
+    const outcome = { kind: "success" as const, sourceSlug: "s", items: [], cursor: {} };
+    const next = computeNextState(prev, outcome, now);
+    assert.equal(next.consecutiveEmptyFetches, EMPTY_FETCH_THRESHOLD);
+    assert.ok(next.emptyBackoffUntil, "emptyBackoffUntil should be set at threshold");
+    const gap = Date.parse(next.emptyBackoffUntil!) - now;
+    assert.equal(gap, 3_600_000); // 1h
+  });
+
+  it("resets empty counters when items are found", () => {
+    const fakeItem = {
+      id: "x",
+      title: "t",
+      url: "https://x.com",
+      publishedAt: new Date(now).toISOString(),
+      categories: [] as import("../../server/workspace/sources/taxonomy.js").CategorySlug[],
+      sourceSlug: "s",
+    };
+    const prev = makeState({ slug: "s", consecutiveEmptyFetches: 5, emptyBackoffUntil: "2026-04-14T10:00:00Z" });
+    const outcome = { kind: "success" as const, sourceSlug: "s", items: [fakeItem], cursor: {} };
+    const next = computeNextState(prev, outcome, now);
+    assert.equal(next.consecutiveEmptyFetches, 0);
+    assert.equal(next.emptyBackoffUntil, null);
   });
 });

--- a/test/sources/test_pipelinePlan.ts
+++ b/test/sources/test_pipelinePlan.ts
@@ -26,6 +26,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }
@@ -188,6 +190,46 @@ describe("planEligibleSources — backoff respect", () => {
     // Defensive: a corrupt state file shouldn't permanently lock
     // out a source. Run it, and the next run's writeState will
     // overwrite with a valid timestamp.
+    assert.equal(eligible.length, 1);
+  });
+
+  it("skips sources with a future emptyBackoffUntil (empty-fetch adaptive backoff)", () => {
+    const sources = [makeSource({ slug: "quiet-feed" })];
+    const states = new Map([
+      [
+        "quiet-feed",
+        makeState({
+          slug: "quiet-feed",
+          emptyBackoffUntil: "2026-04-13T12:00:00Z", // 2 hours after now
+        }),
+      ],
+    ]);
+    const eligible = planEligibleSources({
+      sources,
+      statesBySlug: states,
+      scheduleType: "daily",
+      nowMs: now,
+    });
+    assert.equal(eligible.length, 0);
+  });
+
+  it("includes sources whose emptyBackoffUntil has already passed", () => {
+    const sources = [makeSource({ slug: "quiet-feed-ready" })];
+    const states = new Map([
+      [
+        "quiet-feed-ready",
+        makeState({
+          slug: "quiet-feed-ready",
+          emptyBackoffUntil: "2026-04-13T08:00:00Z", // 2 hours before now
+        }),
+      ],
+    ]);
+    const eligible = planEligibleSources({
+      sources,
+      statesBySlug: states,
+      scheduleType: "daily",
+      nowMs: now,
+    });
     assert.equal(eligible.length, 1);
   });
 });

--- a/test/sources/test_rss.ts
+++ b/test/sources/test_rss.ts
@@ -32,6 +32,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: {},
     consecutiveFailures: 0,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }

--- a/test/sources/test_sourceState.ts
+++ b/test/sources/test_sourceState.ts
@@ -98,6 +98,8 @@ function makeState(over: Partial<SourceState> = {}): SourceState {
     cursor: { k: "v" },
     consecutiveFailures: 1,
     nextAttemptAt: null,
+    consecutiveEmptyFetches: 0,
+    emptyBackoffUntil: null,
     ...over,
   };
 }


### PR DESCRIPTION
## Summary

- **Part A**: Added a collapsible "Recommended Frequencies" reference table to the Scheduler tab (`TasksTab.vue`) showing suggested schedules for common task types (news/RSS, journal, wiki, memory, calendar sync).
- **Part B**: Implemented adaptive backoff for source fetches that return 0 items — after 3 consecutive empty successes, the source is skipped with exponential delay starting at 1h, doubling up to 24h. Resets immediately when items are found.

## Items to Confirm / Review

- **Threshold of 3** for empty-fetch backoff — is this the right value, or should it be configurable?
- **Part A UI placement** — frequency hints are in a `<details>` accordion above the task list; collapsed by default. Acceptable UX?
- **emptyBackoffUntil vs nextAttemptAt** — kept them separate so error backoff and empty-backoff don't interfere. Correct?

---

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/465 — implement A (UI frequency recommendation hints in scheduler) then B (adaptive backoff for source tasks when no new items found)

---

## Implementation

### Part A — `src/plugins/scheduler/TasksTab.vue`

Added `FREQUENCY_HINTS` constant and a `<details>/<table>` UI block inside the `v-else` (loaded-state) section. Collapsed by default so it doesn't clutter the task list.

### Part B — server-side source pipeline

| File | Change |
|---|---|
| `server/workspace/sources/types.ts` | Added `consecutiveEmptyFetches: number` and `emptyBackoffUntil: string \| null` to `SourceState`; updated `defaultSourceState()` |
| `server/workspace/sources/sourceState.ts` | `validateSourceState()` parses new fields; extracted `toNonNegativeInt()` helper to deduplicate validation |
| `server/workspace/sources/pipeline/fetch.ts` | Added `EMPTY_FETCH_THRESHOLD`, `EMPTY_BACKOFF_MAX_MS`, `emptyBackoffDelayMs()`; updated `computeNextState()` to handle empty/item success cases |
| `server/workspace/sources/pipeline/plan.ts` | `isWithinBackoff()` now checks both `nextAttemptAt` and `emptyBackoffUntil` via shared `isFutureTimestamp()` helper |
| `server/workspace/sources/pipeline/index.ts` | Replaced stale inline `SourceState` literal with `defaultSourceState()` |

### Tests added

- `emptyBackoffDelayMs` curve (0 below threshold, 1h at threshold, doubles, capped at 24h)
- `computeNextState` empty-success increment, threshold trigger, item-found reset
- `planEligibleSources` skips future `emptyBackoffUntil`, includes past one
- All existing test `makeState()` helpers updated with new required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)