### PR TITLE
feat(i18n): extract RightSidebar, SidebarHeader, FileTreePane strings

### DIFF
--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -1,34 +1,34 @@
 <template>
   <div class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50">
     <div class="flex justify-end items-center gap-2 px-1 pb-1 text-xs">
-      <span class="text-gray-400">Sort:</span>
+      <span class="text-gray-400">{{ t("fileTreePane.sort") }}</span>
       <button
         type="button"
         class="px-2 py-0.5 rounded transition-colors"
         :class="sortMode === 'name' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
         :aria-pressed="sortMode === 'name'"
-        title="Sort by name"
+        :title="t('fileTreePane.sortByName')"
         data-testid="file-sort-name"
         @click="emit('update:sortMode', 'name')"
       >
-        Name
+        {{ t("fileTreePane.name") }}
       </button>
       <button
         type="button"
         class="px-2 py-0.5 rounded transition-colors"
         :class="sortMode === 'recent' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
         :aria-pressed="sortMode === 'recent'"
-        title="Sort by modified date (newest first)"
+        :title="t('fileTreePane.sortByRecent')"
         data-testid="file-sort-recent"
         @click="emit('update:sortMode', 'recent')"
       >
-        Recent
+        {{ t("fileTreePane.recent") }}
       </button>
     </div>
     <div v-if="treeError" class="p-2 text-xs text-red-600">
       {{ treeError }}
     </div>
-    <div v-else-if="!rootNode" class="p-2 text-xs text-gray-400">Loading...</div>
+    <div v-else-if="!rootNode" class="p-2 text-xs text-gray-400">{{ t("common.loading") }}</div>
     <FileTree
       v-else
       :node="rootNode"
@@ -41,8 +41,8 @@
     />
     <template v-if="refRoots.length > 0">
       <div class="mt-2 pt-2 border-t border-gray-200 px-1 mb-1 flex items-center gap-1">
-        <span class="text-[10px] font-semibold text-gray-400 uppercase">Reference</span>
-        <span class="text-[9px] px-1 py-0.5 rounded bg-blue-100 text-blue-600">RO</span>
+        <span class="text-[10px] font-semibold text-gray-400 uppercase">{{ t("fileTreePane.reference") }}</span>
+        <span class="text-[9px] px-1 py-0.5 rounded bg-blue-100 text-blue-600">{{ t("fileTreePane.readOnlyBadge") }}</span>
       </div>
       <FileTree
         v-for="refNode in refRoots"
@@ -60,9 +60,12 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import FileTree from "./FileTree.vue";
 import type { TreeNode } from "../types/fileTree";
 import type { FileSortMode } from "../composables/useFileSortMode";
+
+const { t } = useI18n();
 
 defineProps<{
   rootNode: TreeNode | null;

--- a/src/components/RightSidebar.vue
+++ b/src/components/RightSidebar.vue
@@ -4,10 +4,10 @@
       <div class="bg-white border-b border-gray-200">
         <button
           class="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50"
-          title="Toggle system prompt"
+          :title="t('rightSidebar.toggleSystemPrompt')"
           @click="showSystemPrompt = !showSystemPrompt"
         >
-          <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">System Prompt</span>
+          <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">{{ t("rightSidebar.systemPrompt") }}</span>
           <span class="text-gray-400 text-xs">{{ showSystemPrompt ? "▲" : "▼" }}</span>
         </button>
         <div v-if="showSystemPrompt" class="px-4 pb-4">
@@ -19,11 +19,11 @@
 
       <div class="bg-white border-b border-gray-200">
         <div class="p-4 pb-0">
-          <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Available Tools</span>
+          <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">{{ t("rightSidebar.availableTools") }}</span>
         </div>
         <div class="px-4 py-3 space-y-1">
           <div v-for="tool in availableTools" :key="tool" class="text-xs">
-            <button class="flex items-center gap-1 w-full text-left" title="Toggle tool description" @click="toggleTool(tool)">
+            <button class="flex items-center gap-1 w-full text-left" :title="t('rightSidebar.toggleToolDescription')" @click="toggleTool(tool)">
               <span class="bg-gray-100 text-gray-700 rounded px-2 py-0.5 border border-gray-200 font-mono">{{ tool }}</span>
               <span v-if="toolDescriptions[tool]" class="text-gray-400">{{ expandedTools.has(tool) ? "▲" : "▼" }}</span>
             </button>
@@ -35,32 +35,32 @@
       </div>
 
       <div class="p-4 border-b border-gray-200 bg-white">
-        <h2 class="text-lg font-semibold">Tool Call History</h2>
+        <h2 class="text-lg font-semibold">{{ t("rightSidebar.toolCallHistory") }}</h2>
       </div>
 
       <div class="p-2 space-y-2 bg-gray-100">
-        <div v-if="toolCallHistory.length === 0" class="text-gray-400 text-sm text-center py-4">No tool calls yet</div>
+        <div v-if="toolCallHistory.length === 0" class="text-gray-400 text-sm text-center py-4">{{ t("rightSidebar.noToolCalls") }}</div>
         <div v-for="(call, index) in toolCallHistory" :key="index" class="border border-gray-300 rounded p-3 bg-white text-xs space-y-1">
           <div class="flex justify-between items-start gap-2">
             <span class="font-semibold text-blue-600 break-all">{{ call.toolName }}</span>
             <span class="text-gray-400 flex-shrink-0">{{ formatTime(call.timestamp) }}</span>
           </div>
           <div>
-            <div class="font-medium text-gray-500 mb-1">Arguments</div>
+            <div class="font-medium text-gray-500 mb-1">{{ t("rightSidebar.arguments") }}</div>
             <pre class="bg-gray-50 p-2 rounded overflow-x-auto text-gray-700">{{ formatJson(call.args) }}</pre>
           </div>
           <div v-if="call.error">
-            <div class="font-medium text-gray-500 mb-1">Error</div>
+            <div class="font-medium text-gray-500 mb-1">{{ t("rightSidebar.error") }}</div>
             <div class="bg-red-50 p-2 rounded text-red-700">
               {{ call.error }}
             </div>
           </div>
           <div v-else-if="call.result !== undefined">
-            <div class="font-medium text-gray-500 mb-1">Result</div>
+            <div class="font-medium text-gray-500 mb-1">{{ t("rightSidebar.result") }}</div>
             <pre class="bg-green-50 p-2 rounded overflow-x-auto text-gray-700">{{ call.result }}</pre>
           </div>
           <div v-else>
-            <div class="text-gray-400 italic">Running...</div>
+            <div class="text-gray-400 italic">{{ t("rightSidebar.running") }}</div>
           </div>
         </div>
       </div>
@@ -70,8 +70,11 @@
 
 <script setup lang="ts">
 import { ref, nextTick } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolCallHistoryItem } from "../types/toolCallHistory";
 import { formatTime } from "../utils/format/date";
+
+const { t } = useI18n();
 
 defineProps<{
   toolCallHistory: ToolCallHistoryItem[];

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -14,12 +14,18 @@
       <button
         class="text-gray-400 hover:text-gray-700"
         :class="{ 'text-blue-500': showRightSidebar }"
-        title="Tool call history"
+        :title="t('sidebarHeader.toolCallHistory')"
         @click="emit('toggleRightSidebar')"
       >
         <span class="material-icons">build</span>
       </button>
-      <button class="text-gray-400 hover:text-gray-700" data-testid="settings-btn" title="Settings" aria-label="Settings" @click="emit('openSettings')">
+      <button
+        class="text-gray-400 hover:text-gray-700"
+        data-testid="settings-btn"
+        :title="t('sidebarHeader.settings')"
+        :aria-label="t('sidebarHeader.settings')"
+        @click="emit('openSettings')"
+      >
         <span class="material-icons">settings</span>
       </button>
     </div>
@@ -28,11 +34,14 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, type CSSProperties } from "vue";
+import { useI18n } from "vue-i18n";
 import LockStatusPopup from "./LockStatusPopup.vue";
 import NotificationBell from "./NotificationBell.vue";
 import { useClickOutside } from "../composables/useClickOutside";
 import type { NotificationPayload } from "../types/notification";
 import logoUrl from "../assets/mulmo_bw.png";
+
+const { t } = useI18n();
 
 defineProps<{
   sandboxEnabled: boolean;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -12,6 +12,7 @@ const en = {
   common: {
     save: "Save",
     cancel: "Cancel",
+    loading: "Loading...",
   },
   sessionTabBar: {
     newSession: "New session",
@@ -50,6 +51,33 @@ const en = {
     markAllRead: "Mark all read",
     noNotifications: "No notifications",
     dismiss: "Dismiss",
+  },
+  sidebarHeader: {
+    toolCallHistory: "Tool call history",
+    settings: "Settings",
+  },
+  rightSidebar: {
+    toggleSystemPrompt: "Toggle system prompt",
+    systemPrompt: "System Prompt",
+    availableTools: "Available Tools",
+    toggleToolDescription: "Toggle tool description",
+    toolCallHistory: "Tool Call History",
+    noToolCalls: "No tool calls yet",
+    arguments: "Arguments",
+    error: "Error",
+    result: "Result",
+    running: "Running...",
+  },
+  fileTreePane: {
+    sort: "Sort:",
+    sortByName: "Sort by name",
+    name: "Name",
+    sortByRecent: "Sort by modified date (newest first)",
+    recent: "Recent",
+    reference: "Reference",
+    // "RO" = Read-Only. Kept short on purpose — rendered as a compact
+    // badge next to the Reference label.
+    readOnlyBadge: "RO",
   },
 };
 

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -5,6 +5,7 @@ const ja = {
   common: {
     save: "保存",
     cancel: "キャンセル",
+    loading: "読み込み中...",
   },
   sessionTabBar: {
     newSession: "新しいセッション",
@@ -43,6 +44,31 @@ const ja = {
     markAllRead: "すべて既読にする",
     noNotifications: "通知はありません",
     dismiss: "閉じる",
+  },
+  sidebarHeader: {
+    toolCallHistory: "ツール呼び出し履歴",
+    settings: "設定",
+  },
+  rightSidebar: {
+    toggleSystemPrompt: "システムプロンプトの表示切替",
+    systemPrompt: "システムプロンプト",
+    availableTools: "利用可能ツール",
+    toggleToolDescription: "ツール説明の表示切替",
+    toolCallHistory: "ツール呼び出し履歴",
+    noToolCalls: "ツール呼び出しはまだありません",
+    arguments: "引数",
+    error: "エラー",
+    result: "結果",
+    running: "実行中...",
+  },
+  fileTreePane: {
+    sort: "並び順:",
+    sortByName: "名前順",
+    name: "名前",
+    sortByRecent: "更新日順（新しい順）",
+    recent: "最近",
+    reference: "参照",
+    readOnlyBadge: "RO",
   },
 };
 


### PR DESCRIPTION
## Summary

vue-i18n string-extraction batch 3 (#559 follow-up)。右サイドバー + ヘッダー + ファイルツリーのペインの UI 文字列を辞書化。

### 対象

- \`RightSidebar.vue\` — System Prompt セクション、Available Tools、Tool Call History、Arguments/Error/Result/Running… ラベル
- \`SidebarHeader.vue\` — Tool call history ボタン、Settings ボタン (title + aria-label)
- \`FileTreePane.vue\` — Sort: / Name / Recent / Reference / RO バッジ、Loading...

### 辞書

- 3 新規 namespace: \`rightSidebar\`, \`sidebarHeader\`, \`fileTreePane\`
- \`common.loading\` を追加（汎用ローディング）

## Items to Confirm / Review

- [ ] **\"RO\" バッジ**: Read-Only の略。ja.ts でも \"RO\" のまま残すか日本語化するか要議論（現状「RO」のまま）
- [ ] **\`Tool call history\` と \`Tool Call History\`**: SidebarHeader は tooltip、RightSidebar は h2 見出しで両方同じ意味。キーを分けた (\`sidebarHeader.toolCallHistory\` と \`rightSidebar.toolCallHistory\`)
- [ ] **E2E 非影響**: \`data-testid\` ベース

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)