### PR TITLE
feat(prompt): summarize large help files instead of inlining full content (#487)

### DIFF
--- a/plans/feat-help-pointer-threshold.md
+++ b/plans/feat-help-pointer-threshold.md
@@ -1,0 +1,45 @@
+# Help file pointer-or-inline threshold (#487)
+
+## Problem
+
+`buildInlinedHelpFiles()` inlines the full content of every `config/helps/*.md` referenced from a role prompt. Typical sizes today:
+
+| file             | chars |
+| ---------------- | ----- |
+| `github.md`      | 1,200 |
+| `spreadsheet.md` | 1,359 |
+| `index.md`       | 3,782 |
+| `business.md`    | 4,041 |
+| `sandbox.md`     | 4,313 |
+| `mulmoscript.md` | 6,261 |
+| `wiki.md`        | 6,670 |
+| `telegram.md`    | 6,755 |
+
+All of these land in the system prompt regardless of whether the LLM actually needs them this turn. Issue #487 tracks the prompt-bloat risk — help files already account for up to 6,670 chars in a single turn, and the list keeps growing.
+
+## Approach
+
+Branch per help file on size:
+
+- **< 2,000 chars** → inline as today. The round-trip cost of a `Read` tool call would exceed the prompt savings, and the LLM gets the content without indirection.
+- **≥ 2,000 chars** → emit a summary (first H1 + first paragraph, capped at ~200 chars) plus an explicit pointer: `"Detailed reference: use Read on config/helps/<name>.md"`.
+
+Threshold is a constant so it's easy to tune later based on observed behaviour.
+
+Summary extraction:
+
+- First H1 heading line (if present) — identifies the file
+- First non-heading paragraph (up to 200 chars, ellipsed) — gives the LLM enough to decide whether a Read is worth it
+- No frontmatter / manual summary fields required — keeps help-file authoring zero-ceremony
+
+## Out of scope
+
+- Memory context (`conversations/memory.md`) pointer-ization — separate discussion in #487, deferred pending results from this change
+- Dynamic size adjustment (e.g. threshold-per-role) — keep one global constant for now
+
+## Acceptance
+
+- Small help files (`github.md`, `spreadsheet.md`) stay inline byte-for-byte
+- Large help files emit the summary + pointer block
+- Unit tests cover: under threshold, at threshold, over threshold, file missing, no first paragraph present
+- A role prompt that currently references `wiki.md` still causes the LLM to use `manageWiki` / `Read` on the canonical path — manual smoke test required after merge

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -295,7 +295,47 @@ The bash tool runs inside a Docker sandbox. The following tools are guaranteed p
 
 Runtime \`pip install\` / \`apt install\` are not available (no network-installed deps by design). Work within the list above; if something is missing, say so rather than attempting to install it.`;
 
-function buildInlinedHelpFiles(rolePrompt: string, workspacePath: string): string[] {
+// Files ≤ this threshold stay inlined verbatim; above it, only a short
+// summary + pointer reaches the system prompt and the full content is
+// fetched on demand via the Read tool. 2000 chars keeps today's small
+// helps (github.md ~1.2K, spreadsheet.md ~1.4K) inline, while wiki.md /
+// mulmoscript.md / telegram.md (4–7K each) switch to summary mode. See
+// plans/feat-help-pointer-threshold.md and issue #487.
+const HELP_INLINE_THRESHOLD_CHARS = 2000;
+const HELP_SUMMARY_PARAGRAPH_CAP = 200;
+
+// Pull a short, prompt-friendly summary from a help file:
+// - first H1 heading (identifies the file)
+// - first non-empty, non-heading paragraph, truncated to ~200 chars
+// No frontmatter required — the goal is zero ceremony for help authors.
+export function summarizeHelpContent(content: string): string {
+  const lines = content.split("\n");
+  const heading = lines
+    .find((line) => /^#\s+\S/.test(line))
+    ?.replace(/^#\s+/, "")
+    .trim();
+
+  let paragraph = "";
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      if (paragraph) break;
+      continue;
+    }
+    paragraph = paragraph ? `${paragraph} ${trimmed}` : trimmed;
+    if (paragraph.length >= HELP_SUMMARY_PARAGRAPH_CAP) break;
+  }
+  if (paragraph.length > HELP_SUMMARY_PARAGRAPH_CAP) {
+    paragraph = paragraph.slice(0, HELP_SUMMARY_PARAGRAPH_CAP).trimEnd() + "…";
+  }
+
+  const parts: string[] = [];
+  if (heading) parts.push(heading);
+  if (paragraph) parts.push(paragraph);
+  return parts.join(" — ");
+}
+
+export function buildInlinedHelpFiles(rolePrompt: string, workspacePath: string): string[] {
   // Match either legacy `helps/<name>.md` or post-#284
   // `config/helps/<name>.md` references in role prompts. Both
   // resolve to the same on-disk file under `config/helps/`.
@@ -310,10 +350,17 @@ function buildInlinedHelpFiles(rolePrompt: string, workspacePath: string): strin
       const fullPath = join(workspacePath, WORKSPACE_DIRS.helps, name);
       if (!existsSync(fullPath)) return null;
       const content = readFileSync(fullPath, "utf-8").trim();
-      // Keep the heading anchored to the canonical post-#284 path
-      // so the LLM reading the inlined block can't accidentally
-      // Read() the stale legacy location.
-      return content ? `### ${WORKSPACE_DIRS.helps}/${name}\n\n${content}` : null;
+      if (!content) return null;
+      // Keep the heading anchored to the canonical post-#284 path so
+      // the LLM can't accidentally Read() the stale legacy location.
+      const canonicalPath = `${WORKSPACE_DIRS.helps}/${name}`;
+      const header = `### ${canonicalPath}`;
+      if (content.length <= HELP_INLINE_THRESHOLD_CHARS) {
+        return `${header}\n\n${content}`;
+      }
+      const summary = summarizeHelpContent(content);
+      const pointer = `Detailed reference: use Read on \`${canonicalPath}\` when you need the full content.`;
+      return summary ? `${header}\n\n${summary}\n\n${pointer}` : `${header}\n\n${pointer}`;
     })
     .filter((section): section is string => section !== null);
 }

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -3,7 +3,15 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { buildMemoryContext, buildWikiContext, buildSystemPrompt, headingSection, prependJournalPointer } from "../../server/agent/prompt.js";
+import {
+  buildMemoryContext,
+  buildWikiContext,
+  buildSystemPrompt,
+  headingSection,
+  prependJournalPointer,
+  buildInlinedHelpFiles,
+  summarizeHelpContent,
+} from "../../server/agent/prompt.js";
 import { WORKSPACE_FILES } from "../../server/workspace/paths.js";
 import { dirname } from "path";
 import type { Role } from "../../src/config/roles.js";
@@ -307,5 +315,91 @@ describe("prependJournalPointer", () => {
     writeJournalIndex();
     const result = prependJournalPointer("hi", workspace);
     assert.ok(result.toLowerCase().includes("skip"), "pointer should tell the model it can skip when not needed");
+  });
+});
+
+describe("summarizeHelpContent", () => {
+  it("extracts H1 and first paragraph joined by em-dash", () => {
+    const content = "# Wiki Help\n\nWrite wiki pages under data/wiki/pages/.\n\nMore details here.";
+    const result = summarizeHelpContent(content);
+    assert.equal(result, "Wiki Help — Write wiki pages under data/wiki/pages/.");
+  });
+
+  it("handles file with no H1", () => {
+    const content = "Quick tip: prefix branches with feat/.";
+    assert.equal(summarizeHelpContent(content), "Quick tip: prefix branches with feat/.");
+  });
+
+  it("handles file with only a heading", () => {
+    const content = "# Sandbox";
+    assert.equal(summarizeHelpContent("# Sandbox"), "Sandbox");
+    assert.equal(summarizeHelpContent(content), "Sandbox");
+  });
+
+  it("truncates long first paragraphs to 200 chars with ellipsis", () => {
+    const long = "x".repeat(500);
+    const content = `# Header\n\n${long}`;
+    const result = summarizeHelpContent(content);
+    assert.ok(result.startsWith("Header — "));
+    assert.ok(result.endsWith("…"));
+    // 200 for the paragraph cap + "Header — " prefix + trailing ellipsis
+    assert.ok(result.length <= "Header — ".length + 201);
+  });
+
+  it("skips headings between paragraphs when looking for a first paragraph", () => {
+    const content = "# Top\n\n## Sub\n\nFirst real paragraph after sub-heading.";
+    assert.equal(summarizeHelpContent(content), "Top — First real paragraph after sub-heading.");
+  });
+
+  it("returns empty string for content with nothing quotable", () => {
+    assert.equal(summarizeHelpContent(""), "");
+    assert.equal(summarizeHelpContent("\n\n\n"), "");
+  });
+});
+
+describe("buildInlinedHelpFiles", () => {
+  // Reuses the outer-scope `workspace` set by the top-level
+  // beforeEach/afterEach at the top of this file.
+  function writeHelp(name: string, content: string): void {
+    writeFileAt(workspace, `config/helps/${name}`, content);
+  }
+
+  it("inlines small help files verbatim", () => {
+    writeHelp("small.md", "# Small\n\nOne short line.");
+    const result = buildInlinedHelpFiles("Read helps/small.md for details.", workspace);
+    assert.equal(result.length, 1);
+    assert.ok(result[0].includes("### config/helps/small.md"));
+    assert.ok(result[0].includes("# Small\n\nOne short line."));
+    assert.ok(!result[0].includes("Detailed reference"));
+  });
+
+  it("summarizes + points to large help files", () => {
+    const bigBody = "\n\n" + "filler paragraph. ".repeat(200);
+    writeHelp("big.md", "# Big Help\n\nFirst real content paragraph explaining the feature." + bigBody);
+    const result = buildInlinedHelpFiles("See config/helps/big.md", workspace);
+    assert.equal(result.length, 1);
+    const section = result[0];
+    assert.ok(section.includes("### config/helps/big.md"));
+    assert.ok(section.includes("Big Help"));
+    assert.ok(section.includes("First real content paragraph"));
+    assert.ok(section.includes("Detailed reference: use Read on `config/helps/big.md`"));
+    assert.ok(!section.includes("filler paragraph. filler paragraph."));
+  });
+
+  it("deduplicates when the exact same ref appears twice", () => {
+    writeHelp("dup.md", "# Dup\n\nShort.");
+    const result = buildInlinedHelpFiles("Read helps/dup.md first, then helps/dup.md again.", workspace);
+    assert.equal(result.length, 1);
+  });
+
+  it("skips missing files without throwing", () => {
+    const result = buildInlinedHelpFiles("Read helps/ghost.md", workspace);
+    assert.deepEqual(result, []);
+  });
+
+  it("skips empty-content files", () => {
+    writeHelp("empty.md", "   \n\n   ");
+    const result = buildInlinedHelpFiles("Read helps/empty.md", workspace);
+    assert.deepEqual(result, []);
   });
 });


### PR DESCRIPTION
## Summary
- \`buildInlinedHelpFiles()\` now branches on file size: ≤ 2000 chars inline verbatim, > 2000 chars emit \`<first H1> — <first paragraph, ≤200 chars>\` + \`Detailed reference: use Read on \`config/helps/<name>.md\`\`.
- Summary extraction requires nothing from help authors (no frontmatter / \`summary:\` field) — first H1 + first non-heading paragraph.
- Net effect on a General-role turn referencing the three largest helps: drops system-prompt bytes by ~18K chars (~4.5K tokens).
- Small helps (\`github.md\`, \`spreadsheet.md\`) stay inline because they fall under the threshold.

## Items to Confirm / Review
- **Threshold choice (2000)** — picked so today's small helps (\`github.md\` 1.2K, \`spreadsheet.md\` 1.4K) stay inline and the 4–7K ones switch to summary mode. Happy to raise/lower based on feedback.
- **Summary shape** — H1 + 200-char first paragraph joined by \` — \`. Is that informative enough to keep the LLM from guessing when to Read?
- **Pointer wording** — \`Detailed reference: use Read on \`…\` when you need the full content.\` — explicit about when and how, but behaviour depends on the LLM taking the hint.
- **No memory.md change yet** — #487 also floats pointer-izing memory context. Deferred on purpose; see plan doc.

## User Prompt

> issue #487 について「ヘルプはファイルの場所と概要だけにして、必要なら開いてもらう」方式が良いか? → はい、コメントして PR。

## Test plan

- [x] \`summarizeHelpContent\` unit tests (H1 + paragraph, no H1, only heading, 500-char truncation, heading-between-paragraphs, empty input)
- [x] \`buildInlinedHelpFiles\` unit tests (small stays inline, large summarizes, dedup, missing file, empty file)
- [x] \`yarn typecheck\` + \`yarn lint\` green
- [ ] Manual smoke: load a role that references \`wiki.md\`, confirm the LLM still uses \`manageWiki\` on user request (i.e. the summary isn't so terse the LLM forgets the feature exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)