### PR TITLE
ui(tool-results): overlay timestamp on card's top border

### DIFF
--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -9,22 +9,18 @@
     <div
       v-for="result in results"
       :key="result.uuid"
-      class="cursor-pointer rounded border border-gray-300 p-2 text-sm text-gray-900 hover:opacity-75 transition-opacity"
+      class="relative cursor-pointer rounded border border-gray-300 p-2 text-sm text-gray-900 hover:opacity-75 transition-opacity"
       :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
       @click="emit('select', result.uuid)"
     >
-      <div class="flex items-center gap-1">
-        <component
-          :is="getPlugin(result.toolName)?.previewComponent"
-          v-if="getPlugin(result.toolName)?.previewComponent"
-          :result="result"
-          class="flex-1 min-w-0"
-        />
-        <span v-else class="flex-1 min-w-0 truncate">{{ result.title || result.toolName }}</span>
-        <span v-if="resultTimestamps.get(result.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
-          formatSmartTime(resultTimestamps.get(result.uuid)!)
-        }}</span>
-      </div>
+      <span
+        v-if="resultTimestamps.get(result.uuid)"
+        class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
+      >
+        {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
+      </span>
+      <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
+      <span v-else class="block truncate">{{ result.title || result.toolName }}</span>
     </div>
 
     <!-- Thinking indicator -->


### PR DESCRIPTION
## Summary
- Moved the per-result timestamp out of the flex row and onto the card's top border so the preview component can use the full card width.
- The timestamp uses `bg-gray-100` (matching the panel background) to mask the border line behind it, giving a clean notch-on-border look.
- No padding/margin changes — positioning is purely absolute with `-translate-y-1/2`.

## Test plan
- [ ] Open the right-hand tool results panel with a mix of plugin previews (markdown, chart, spreadsheet, etc.) and confirm previews now use the full card width.
- [ ] Confirm each timestamp sits centered on the top border and the border line behind it is hidden.
- [ ] Confirm selected/unselected ring and hover opacity still render correctly.
- [ ] Confirm cards without a timestamp (none in `resultTimestamps`) render with an unbroken border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)