### PR TITLE
feat(i18n): extract LockStatusPopup and FileTree strings

### DIFF
--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -7,7 +7,7 @@
       @click="onToggle"
     >
       <span class="material-icons text-sm text-gray-400 shrink-0">{{ expanded ? "folder_open" : "folder" }}</span>
-      <span class="text-gray-700 truncate">{{ node.name || "(workspace)" }}</span>
+      <span class="text-gray-700 truncate">{{ node.name || t("fileTree.workspace") }}</span>
     </button>
     <button
       v-else
@@ -19,13 +19,13 @@
     >
       <span class="material-icons text-sm text-gray-400 shrink-0">description</span>
       <span class="truncate">{{ node.name }}</span>
-      <span v-if="isRecent" class="ml-auto w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" title="Recently changed" />
+      <span v-if="isRecent" class="ml-auto w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" :title="t('fileTree.recentlyChanged')" />
     </button>
     <div v-if="node.type === 'dir' && expanded" class="pl-4">
       <!-- Loading state: children not in the cache yet. Rendered
            once per dir so a slow network shows where the wait is,
            not as a global overlay. -->
-      <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">Loading...</div>
+      <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">{{ t("common.loading") }}</div>
       <FileTree
         v-for="child in loadedChildren"
         :key="child.path"
@@ -43,9 +43,12 @@
 
 <script setup lang="ts">
 import { computed, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import { sortChildren } from "../utils/files/sortChildren";
 import type { FileSortMode } from "../composables/useFileSortMode";
+
+const { t } = useI18n();
 
 // TreeNode lives in src/types/fileTree.ts so .ts composables can
 // import it without depending on a .vue module. Re-export here so

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -4,7 +4,7 @@
       ref="button"
       data-testid="sandbox-lock-button"
       :class="sandboxEnabled ? 'text-gray-400 hover:text-gray-700' : 'text-amber-400 hover:text-amber-500'"
-      :title="sandboxEnabled ? 'Sandbox enabled (Docker)' : 'No sandbox (Docker not found)'"
+      :title="sandboxEnabled ? t('lockStatusPopup.sandboxEnabledTooltip') : t('lockStatusPopup.noSandboxTooltip')"
       @click="emit('update:open', !open)"
     >
       <span class="material-icons">{{ sandboxEnabled ? "lock" : "lock_open" }}</span>
@@ -13,36 +13,36 @@
       <p class="mb-2" :class="sandboxEnabled ? 'text-green-800' : 'text-amber-500'">
         <template v-if="sandboxEnabled">
           <span class="material-icons text-xs align-middle mr-1">lock</span>
-          <strong>Sandbox enabled:</strong> Docker is running. Filesystem access is isolated.
+          <strong>{{ t("lockStatusPopup.sandboxEnabledLabel") }}</strong> {{ t("lockStatusPopup.sandboxEnabledBody") }}
         </template>
         <template v-else>
           <span class="material-icons text-xs align-middle mr-1">warning</span>
-          <strong>No sandbox:</strong> Claude can access all files on your machine. Install
-          <a href="https://www.docker.com/products/docker-desktop/" target="_blank" class="underline">Docker Desktop</a>
-          to enable filesystem isolation.
+          <strong>{{ t("lockStatusPopup.noSandboxLabel") }}</strong> {{ t("lockStatusPopup.noSandboxBodyPrefix") }}
+          <a href="https://www.docker.com/products/docker-desktop/" target="_blank" class="underline">{{ t("lockStatusPopup.dockerDesktop") }}</a>
+          {{ t("lockStatusPopup.noSandboxBodySuffix") }}
         </template>
       </p>
       <div v-if="sandboxEnabled" data-testid="sandbox-credentials-block" class="mb-2 border-t border-gray-100 pt-2">
-        <p class="text-gray-400 mb-1">Host credentials attached:</p>
-        <p v-if="sandboxStatus === null" class="text-gray-400 italic" data-testid="sandbox-credentials-loading">loading…</p>
+        <p class="text-gray-400 mb-1">{{ t("lockStatusPopup.hostCredentials") }}</p>
+        <p v-if="sandboxStatus === null" class="text-gray-400 italic" data-testid="sandbox-credentials-loading">{{ t("lockStatusPopup.credsLoading") }}</p>
         <template v-else>
           <p data-testid="sandbox-credentials-ssh">
             <span class="mr-1">🔑</span>
-            <span class="text-gray-500">SSH agent:</span>
+            <span class="text-gray-500">{{ t("lockStatusPopup.sshAgent") }}</span>
             <span :class="sandboxStatus.sshAgent ? 'text-green-700' : 'text-gray-400'" class="ml-1">
-              {{ sandboxStatus.sshAgent ? "forwarded" : "not forwarded" }}
+              {{ sandboxStatus.sshAgent ? t("lockStatusPopup.forwarded") : t("lockStatusPopup.notForwarded") }}
             </span>
           </p>
           <p data-testid="sandbox-credentials-mounts">
             <span class="mr-1">📁</span>
-            <span class="text-gray-500">Mounted configs:</span>
+            <span class="text-gray-500">{{ t("lockStatusPopup.mountedConfigs") }}</span>
             <span :class="sandboxStatus.mounts.length > 0 ? 'text-green-700' : 'text-gray-400'" class="ml-1">
-              {{ sandboxStatus.mounts.length > 0 ? sandboxStatus.mounts.join(", ") : "none" }}
+              {{ sandboxStatus.mounts.length > 0 ? sandboxStatus.mounts.join(", ") : t("lockStatusPopup.none") }}
             </span>
           </p>
         </template>
       </div>
-      <p class="text-gray-400 mb-1">Test sandbox isolation:</p>
+      <p class="text-gray-400 mb-1">{{ t("lockStatusPopup.testIsolation") }}</p>
       <div class="flex flex-col gap-1">
         <button
           v-for="q in SANDBOX_TEST_QUERIES"
@@ -60,7 +60,10 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useSandboxStatus } from "../composables/useSandboxStatus";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   sandboxEnabled: boolean;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -79,6 +79,28 @@ const en = {
     // badge next to the Reference label.
     readOnlyBadge: "RO",
   },
+  fileTree: {
+    workspace: "(workspace)",
+    recentlyChanged: "Recently changed",
+  },
+  lockStatusPopup: {
+    sandboxEnabledTooltip: "Sandbox enabled (Docker)",
+    noSandboxTooltip: "No sandbox (Docker not found)",
+    sandboxEnabledLabel: "Sandbox enabled:",
+    sandboxEnabledBody: "Docker is running. Filesystem access is isolated.",
+    noSandboxLabel: "No sandbox:",
+    noSandboxBodyPrefix: "Claude can access all files on your machine. Install",
+    noSandboxBodySuffix: "to enable filesystem isolation.",
+    dockerDesktop: "Docker Desktop",
+    hostCredentials: "Host credentials attached:",
+    credsLoading: "loading…",
+    sshAgent: "SSH agent:",
+    forwarded: "forwarded",
+    notForwarded: "not forwarded",
+    mountedConfigs: "Mounted configs:",
+    none: "none",
+    testIsolation: "Test sandbox isolation:",
+  },
 };
 
 export default en;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -70,6 +70,28 @@ const ja = {
     reference: "参照",
     readOnlyBadge: "RO",
   },
+  fileTree: {
+    workspace: "（ワークスペース）",
+    recentlyChanged: "最近変更されました",
+  },
+  lockStatusPopup: {
+    sandboxEnabledTooltip: "サンドボックス有効 (Docker)",
+    noSandboxTooltip: "サンドボックスなし (Docker 未検出)",
+    sandboxEnabledLabel: "サンドボックス有効:",
+    sandboxEnabledBody: "Docker が動作中です。ファイルシステムアクセスは隔離されています。",
+    noSandboxLabel: "サンドボックスなし:",
+    noSandboxBodyPrefix: "Claude はこのマシンの全ファイルにアクセスできます。",
+    noSandboxBodySuffix: "をインストールしてファイルシステムを隔離してください。",
+    dockerDesktop: "Docker Desktop",
+    hostCredentials: "ホスト認証情報の接続状況:",
+    credsLoading: "読み込み中…",
+    sshAgent: "SSH エージェント:",
+    forwarded: "転送中",
+    notForwarded: "転送なし",
+    mountedConfigs: "マウント設定:",
+    none: "なし",
+    testIsolation: "サンドボックス隔離をテスト:",
+  },
 };
 
 export default ja;


### PR DESCRIPTION
## Summary

vue-i18n string-extraction batch 4 (#559 follow-up)。サンドボックス状態ポップアップと FileTree の文字列を辞書化。

> **依存**: #572 (batch 3) にスタック。#572 マージ後に自動リベースされ、本 PR の diff は batch 4 のみになります。

### 対象

- \`LockStatusPopup.vue\` — lock ボタン tooltip、Sandbox/No-sandbox 説明文 + Docker Desktop リンク、ホスト認証情報ブロック (loading / SSH agent / Mounted configs)、Test sandbox isolation ヘッダ
- \`FileTree.vue\` — \"(workspace)\" ルート名、\"Recently changed\" dot tooltip、Loading... (\`common.loading\` 再利用)

### 辞書

- 新規 namespace: \`lockStatusPopup\`, \`fileTree\`
- ja 完全ミラー

## Items to Confirm / Review

- [ ] **翻訳の自然さ**: SSH agent の「転送中/転送なし」、Mounted configs の「なし」表記など、運用上の英語用語 → 日本語のバランス
- [ ] **インライン HTML 構成**: \"Sandbox enabled:\" の太字ラベル + 本文を別キーに分割。本文ノード分解が必要ならコメント頂きたい
- [ ] **\`Docker Desktop\` のリンクテキスト**: 固有名詞のため ja.ts でも \"Docker Desktop\" のまま

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)