### PR TITLE
feat(i18n): extract SettingsModal, NotificationToast, CanvasViewToggle

### DIFF
--- a/src/components/CanvasViewToggle.vue
+++ b/src/components/CanvasViewToggle.vue
@@ -2,8 +2,8 @@
   <button
     class="flex items-center justify-center w-8 h-8 rounded transition-colors hover:bg-gray-100"
     :class="isStack ? 'text-blue-500' : 'text-gray-400 hover:text-gray-700'"
-    :title="isStack ? 'Stack view · click to switch to Single (⌘1)' : 'Single view · click to switch to Stack (⌘2)'"
-    :aria-label="isStack ? 'Switch to Single view' : 'Switch to Stack view'"
+    :title="isStack ? t('canvasViewToggle.stackViewTooltip') : t('canvasViewToggle.singleViewTooltip')"
+    :aria-label="isStack ? t('canvasViewToggle.switchToSingle') : t('canvasViewToggle.switchToStack')"
     :data-testid="`canvas-view-toggle-${modelValue}`"
     @click="emit('update:modelValue', isStack ? CANVAS_VIEW.single : CANVAS_VIEW.stack)"
   >
@@ -13,7 +13,10 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { CANVAS_VIEW, type CanvasViewMode } from "../utils/canvas/viewMode";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   modelValue: CanvasViewMode;

--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -7,7 +7,7 @@
       @click="onToggle"
     >
       <span class="material-icons text-sm text-gray-400 shrink-0">{{ expanded ? "folder_open" : "folder" }}</span>
-      <span class="text-gray-700 truncate">{{ node.name || "(workspace)" }}</span>
+      <span class="text-gray-700 truncate">{{ node.name || t("fileTree.workspace") }}</span>
     </button>
     <button
       v-else
@@ -19,13 +19,13 @@
     >
       <span class="material-icons text-sm text-gray-400 shrink-0">description</span>
       <span class="truncate">{{ node.name }}</span>
-      <span v-if="isRecent" class="ml-auto w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" title="Recently changed" />
+      <span v-if="isRecent" class="ml-auto w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" :title="t('fileTree.recentlyChanged')" />
     </button>
     <div v-if="node.type === 'dir' && expanded" class="pl-4">
       <!-- Loading state: children not in the cache yet. Rendered
            once per dir so a slow network shows where the wait is,
            not as a global overlay. -->
-      <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">Loading...</div>
+      <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">{{ t("common.loading") }}</div>
       <FileTree
         v-for="child in loadedChildren"
         :key="child.path"
@@ -43,9 +43,12 @@
 
 <script setup lang="ts">
 import { computed, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import { sortChildren } from "../utils/files/sortChildren";
 import type { FileSortMode } from "../composables/useFileSortMode";
+
+const { t } = useI18n();
 
 // TreeNode lives in src/types/fileTree.ts so .ts composables can
 // import it without depending on a .vue module. Re-export here so

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -4,7 +4,7 @@
       ref="button"
       data-testid="sandbox-lock-button"
       :class="sandboxEnabled ? 'text-gray-400 hover:text-gray-700' : 'text-amber-400 hover:text-amber-500'"
-      :title="sandboxEnabled ? 'Sandbox enabled (Docker)' : 'No sandbox (Docker not found)'"
+      :title="sandboxEnabled ? t('lockStatusPopup.sandboxEnabledTooltip') : t('lockStatusPopup.noSandboxTooltip')"
       @click="emit('update:open', !open)"
     >
       <span class="material-icons">{{ sandboxEnabled ? "lock" : "lock_open" }}</span>
@@ -13,36 +13,36 @@
       <p class="mb-2" :class="sandboxEnabled ? 'text-green-800' : 'text-amber-500'">
         <template v-if="sandboxEnabled">
           <span class="material-icons text-xs align-middle mr-1">lock</span>
-          <strong>Sandbox enabled:</strong> Docker is running. Filesystem access is isolated.
+          <strong>{{ t("lockStatusPopup.sandboxEnabledLabel") }}</strong> {{ t("lockStatusPopup.sandboxEnabledBody") }}
         </template>
         <template v-else>
           <span class="material-icons text-xs align-middle mr-1">warning</span>
-          <strong>No sandbox:</strong> Claude can access all files on your machine. Install
-          <a href="https://www.docker.com/products/docker-desktop/" target="_blank" class="underline">Docker Desktop</a>
-          to enable filesystem isolation.
+          <strong>{{ t("lockStatusPopup.noSandboxLabel") }}</strong> {{ t("lockStatusPopup.noSandboxBodyPrefix") }}
+          <a href="https://www.docker.com/products/docker-desktop/" target="_blank" class="underline">{{ t("lockStatusPopup.dockerDesktop") }}</a>
+          {{ t("lockStatusPopup.noSandboxBodySuffix") }}
         </template>
       </p>
       <div v-if="sandboxEnabled" data-testid="sandbox-credentials-block" class="mb-2 border-t border-gray-100 pt-2">
-        <p class="text-gray-400 mb-1">Host credentials attached:</p>
-        <p v-if="sandboxStatus === null" class="text-gray-400 italic" data-testid="sandbox-credentials-loading">loading…</p>
+        <p class="text-gray-400 mb-1">{{ t("lockStatusPopup.hostCredentials") }}</p>
+        <p v-if="sandboxStatus === null" class="text-gray-400 italic" data-testid="sandbox-credentials-loading">{{ t("lockStatusPopup.credsLoading") }}</p>
         <template v-else>
           <p data-testid="sandbox-credentials-ssh">
             <span class="mr-1">🔑</span>
-            <span class="text-gray-500">SSH agent:</span>
+            <span class="text-gray-500">{{ t("lockStatusPopup.sshAgent") }}</span>
             <span :class="sandboxStatus.sshAgent ? 'text-green-700' : 'text-gray-400'" class="ml-1">
-              {{ sandboxStatus.sshAgent ? "forwarded" : "not forwarded" }}
+              {{ sandboxStatus.sshAgent ? t("lockStatusPopup.forwarded") : t("lockStatusPopup.notForwarded") }}
             </span>
           </p>
           <p data-testid="sandbox-credentials-mounts">
             <span class="mr-1">📁</span>
-            <span class="text-gray-500">Mounted configs:</span>
+            <span class="text-gray-500">{{ t("lockStatusPopup.mountedConfigs") }}</span>
             <span :class="sandboxStatus.mounts.length > 0 ? 'text-green-700' : 'text-gray-400'" class="ml-1">
-              {{ sandboxStatus.mounts.length > 0 ? sandboxStatus.mounts.join(", ") : "none" }}
+              {{ sandboxStatus.mounts.length > 0 ? sandboxStatus.mounts.join(", ") : t("lockStatusPopup.none") }}
             </span>
           </p>
         </template>
       </div>
-      <p class="text-gray-400 mb-1">Test sandbox isolation:</p>
+      <p class="text-gray-400 mb-1">{{ t("lockStatusPopup.testIsolation") }}</p>
       <div class="flex flex-col gap-1">
         <button
           v-for="q in SANDBOX_TEST_QUERIES"
@@ -60,7 +60,10 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useSandboxStatus } from "../composables/useSandboxStatus";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   sandboxEnabled: boolean;

--- a/src/components/NotificationToast.vue
+++ b/src/components/NotificationToast.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { useNotifications } from "../composables/useNotifications";
+
+const { t } = useI18n();
 import { NOTIFICATION_ICONS } from "../types/notification";
 import type { NotificationPayload } from "../types/notification";
 import { ONE_SECOND_MS } from "../../server/utils/time";
@@ -52,7 +55,7 @@ function iconName(notif: NotificationPayload): string {
           {{ formatSmartTime(visible.firedAt) }}
         </p>
       </div>
-      <button type="button" class="text-slate-400 hover:text-white" aria-label="Dismiss" @click="dismiss">
+      <button type="button" class="text-slate-400 hover:text-white" :aria-label="t('common.dismiss')" @click="dismiss">
         <span class="material-icons text-base">close</span>
       </button>
     </div>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -9,8 +9,8 @@
       @click.stop
     >
       <div class="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
-        <h2 id="settings-modal-title" class="text-base font-semibold text-gray-900">Settings</h2>
-        <button class="text-gray-400 hover:text-gray-700" title="Close" data-testid="settings-close-btn" @click="close">
+        <h2 id="settings-modal-title" class="text-base font-semibold text-gray-900">{{ t("settingsModal.title") }}</h2>
+        <button class="text-gray-400 hover:text-gray-700" :title="t('common.close')" data-testid="settings-close-btn" @click="close">
           <span class="material-icons">close</span>
         </button>
       </div>
@@ -22,7 +22,7 @@
           data-testid="settings-tab-tools"
           @click="activeTab = 'tools'"
         >
-          Allowed Tools
+          {{ t("settingsModal.tabs.tools") }}
         </button>
         <button
           class="px-3 py-2 text-sm border-b-2"
@@ -30,7 +30,7 @@
           data-testid="settings-tab-mcp"
           @click="activeTab = 'mcp'"
         >
-          MCP Servers
+          {{ t("settingsModal.tabs.mcp") }}
         </button>
         <button
           class="px-3 py-2 text-sm border-b-2"
@@ -38,7 +38,7 @@
           data-testid="settings-tab-dirs"
           @click="activeTab = 'dirs'"
         >
-          Directories
+          {{ t("settingsModal.tabs.dirs") }}
         </button>
         <button
           class="px-3 py-2 text-sm border-b-2"
@@ -46,7 +46,7 @@
           data-testid="settings-tab-refs"
           @click="activeTab = 'refs'"
         >
-          Reference Dirs
+          {{ t("settingsModal.tabs.refs") }}
         </button>
       </div>
 
@@ -62,7 +62,7 @@
             after you have authenticated via <code class="bg-gray-100 px-1 rounded">claude mcp</code>.
           </p>
           <label class="block">
-            <span class="text-xs font-semibold text-gray-700">Tool names</span>
+            <span class="text-xs font-semibold text-gray-700">{{ t("settingsModal.toolNamesLabel") }}</span>
             <textarea
               v-model="toolsText"
               class="mt-1 w-full h-48 px-2 py-1.5 text-sm font-mono border border-gray-300 rounded focus:outline-none focus:border-blue-400"
@@ -72,8 +72,8 @@
             ></textarea>
           </label>
           <p v-if="invalidToolNames.length > 0" class="text-xs text-amber-700">
-            These look non-standard (expected prefix
-            <code class="bg-gray-100 px-1 rounded">mcp__</code>):
+            {{ t("settingsModal.invalidToolNamesPrefix") }}
+            <code class="bg-gray-100 px-1 rounded">mcp__</code>{{ t("settingsModal.invalidToolNamesSuffix") }}
             {{ invalidToolNames.join(", ") }}
           </p>
         </div>
@@ -85,7 +85,7 @@
             role="alert"
             data-testid="mcp-tools-error"
           >
-            ⚠ Could not fetch MCP tool status: {{ mcpToolsError }}. Showing all tools regardless of enablement.
+            {{ t("settingsModal.mcpToolsError", { error: mcpToolsError }) }}
           </div>
           <SettingsMcpTab
             ref="mcpTabRef"
@@ -106,19 +106,19 @@
         <span v-if="statusMessage" class="text-xs" :class="statusError ? 'text-red-600' : 'text-green-600'" data-testid="settings-status">
           {{ statusMessage }}
         </span>
-        <span v-else class="text-xs text-gray-500"> Changes apply on the next message. No restart needed. </span>
+        <span v-else class="text-xs text-gray-500"> {{ t("settingsModal.changesHint") }} </span>
         <div class="flex gap-2">
           <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" data-testid="settings-cancel-btn" @click="close">
-            Cancel
+            {{ t("common.cancel") }}
           </button>
           <button
             class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
             :disabled="saving || loading || !!loadError"
-            :title="loadError ? 'Cannot save until settings load successfully' : undefined"
+            :title="loadError ? t('settingsModal.cannotSaveTooltip') : undefined"
             data-testid="settings-save-btn"
             @click="save"
           >
-            {{ saving ? "Saving…" : loading ? "Loading…" : "Save" }}
+            {{ saving ? t("settingsModal.saving") : loading ? t("settingsModal.loadingLabel") : t("common.save") }}
           </button>
         </div>
       </div>
@@ -128,12 +128,15 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import SettingsMcpTab from "./SettingsMcpTab.vue";
 import SettingsWorkspaceDirsTab from "./SettingsWorkspaceDirsTab.vue";
 import SettingsReferenceDirsTab from "./SettingsReferenceDirsTab.vue";
 import type { McpServerEntry } from "./SettingsMcpTab.vue";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
 
 interface Props {
   open: boolean;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -79,6 +79,28 @@ const en = {
     // badge next to the Reference label.
     readOnlyBadge: "RO",
   },
+  fileTree: {
+    workspace: "(workspace)",
+    recentlyChanged: "Recently changed",
+  },
+  lockStatusPopup: {
+    sandboxEnabledTooltip: "Sandbox enabled (Docker)",
+    noSandboxTooltip: "No sandbox (Docker not found)",
+    sandboxEnabledLabel: "Sandbox enabled:",
+    sandboxEnabledBody: "Docker is running. Filesystem access is isolated.",
+    noSandboxLabel: "No sandbox:",
+    noSandboxBodyPrefix: "Claude can access all files on your machine. Install",
+    noSandboxBodySuffix: "to enable filesystem isolation.",
+    dockerDesktop: "Docker Desktop",
+    hostCredentials: "Host credentials attached:",
+    credsLoading: "loading…",
+    sshAgent: "SSH agent:",
+    forwarded: "forwarded",
+    notForwarded: "not forwarded",
+    mountedConfigs: "Mounted configs:",
+    none: "none",
+    testIsolation: "Test sandbox isolation:",
+  },
 };
 
 export default en;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -13,6 +13,8 @@ const en = {
     save: "Save",
     cancel: "Cancel",
     loading: "Loading...",
+    close: "Close",
+    dismiss: "Dismiss",
   },
   sessionTabBar: {
     newSession: "New session",
@@ -100,6 +102,29 @@ const en = {
     mountedConfigs: "Mounted configs:",
     none: "none",
     testIsolation: "Test sandbox isolation:",
+  },
+  settingsModal: {
+    title: "Settings",
+    tabs: {
+      tools: "Allowed Tools",
+      mcp: "MCP Servers",
+      dirs: "Directories",
+      refs: "Reference Dirs",
+    },
+    toolNamesLabel: "Tool names",
+    invalidToolNamesPrefix: "These look non-standard (expected prefix",
+    invalidToolNamesSuffix: "):",
+    mcpToolsError: "⚠ Could not fetch MCP tool status: {error}. Showing all tools regardless of enablement.",
+    changesHint: "Changes apply on the next message. No restart needed.",
+    cannotSaveTooltip: "Cannot save until settings load successfully",
+    saving: "Saving…",
+    loadingLabel: "Loading…",
+  },
+  canvasViewToggle: {
+    stackViewTooltip: "Stack view · click to switch to Single (⌘1)",
+    singleViewTooltip: "Single view · click to switch to Stack (⌘2)",
+    switchToSingle: "Switch to Single view",
+    switchToStack: "Switch to Stack view",
   },
 };
 

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -70,6 +70,28 @@ const ja = {
     reference: "参照",
     readOnlyBadge: "RO",
   },
+  fileTree: {
+    workspace: "（ワークスペース）",
+    recentlyChanged: "最近変更されました",
+  },
+  lockStatusPopup: {
+    sandboxEnabledTooltip: "サンドボックス有効 (Docker)",
+    noSandboxTooltip: "サンドボックスなし (Docker 未検出)",
+    sandboxEnabledLabel: "サンドボックス有効:",
+    sandboxEnabledBody: "Docker が動作中です。ファイルシステムアクセスは隔離されています。",
+    noSandboxLabel: "サンドボックスなし:",
+    noSandboxBodyPrefix: "Claude はこのマシンの全ファイルにアクセスできます。",
+    noSandboxBodySuffix: "をインストールしてファイルシステムを隔離してください。",
+    dockerDesktop: "Docker Desktop",
+    hostCredentials: "ホスト認証情報の接続状況:",
+    credsLoading: "読み込み中…",
+    sshAgent: "SSH エージェント:",
+    forwarded: "転送中",
+    notForwarded: "転送なし",
+    mountedConfigs: "マウント設定:",
+    none: "なし",
+    testIsolation: "サンドボックス隔離をテスト:",
+  },
 };
 
 export default ja;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -6,6 +6,8 @@ const ja = {
     save: "保存",
     cancel: "キャンセル",
     loading: "読み込み中...",
+    close: "閉じる",
+    dismiss: "閉じる",
   },
   sessionTabBar: {
     newSession: "新しいセッション",
@@ -91,6 +93,29 @@ const ja = {
     mountedConfigs: "マウント設定:",
     none: "なし",
     testIsolation: "サンドボックス隔離をテスト:",
+  },
+  settingsModal: {
+    title: "設定",
+    tabs: {
+      tools: "許可ツール",
+      mcp: "MCP サーバ",
+      dirs: "ディレクトリ",
+      refs: "参照ディレクトリ",
+    },
+    toolNamesLabel: "ツール名",
+    invalidToolNamesPrefix: "次の項目は標準的ではないようです（期待される接頭辞",
+    invalidToolNamesSuffix: "）:",
+    mcpToolsError: "⚠ MCP ツール状態の取得に失敗しました: {error}。有効/無効にかかわらず全ツールを表示しています。",
+    changesHint: "次回のメッセージから反映されます。再起動は不要です。",
+    cannotSaveTooltip: "設定の読み込みに成功するまで保存できません",
+    saving: "保存中…",
+    loadingLabel: "読み込み中…",
+  },
+  canvasViewToggle: {
+    stackViewTooltip: "スタック表示・クリックで Single に切替 (⌘1)",
+    singleViewTooltip: "Single 表示・クリックで Stack に切替 (⌘2)",
+    switchToSingle: "Single 表示に切替",
+    switchToStack: "Stack 表示に切替",
   },
 };
 


### PR DESCRIPTION
## Summary

vue-i18n string-extraction batch 5 (#559 follow-up)。設定モーダル、通知トースト、キャンバス表示トグルの文字列を辞書化。

> **依存**: #575 (batch 4) にスタック。#575 マージ後にリベースされ batch 5 の diff のみになります。

### 対象

- \`SettingsModal.vue\` — title、close tooltip、タブラベル×4、toolNames label、invalid-tool-names hint (inline \`<code>\` のため prefix/suffix 分割)、MCP tools エラーバナー、フッター hint、Cancel/Save/Saving…/Loading…、cannotSave tooltip
- \`NotificationToast.vue\` — dismiss aria-label
- \`CanvasViewToggle.vue\` — Stack/Single tooltips + switch aria-labels

### 辞書

- 新規 namespace: \`settingsModal\`, \`canvasViewToggle\`
- 共通キー 2 個追加: \`common.close\`, \`common.dismiss\`

### Non-goal（後続バッチ）

- SettingsModal の \"Extra tool names to pass to Claude via --allowedTools...\" という説明文段落。複数の inline \`<code>\` タグを含むため \`<i18n-t>\` slot 構成が必要

## Items to Confirm / Review

- [ ] **タブラベル日本語**: \"許可ツール\" / \"MCP サーバ\" / \"ディレクトリ\" / \"参照ディレクトリ\" の用語統一
- [ ] **invalid-tool-names 分割**: inline \`<code>mcp__</code>\` の位置を崩さないために prefix \"These look non-standard (expected prefix\" + suffix \"):\" に分けた。語順が逆になる言語だとこの分割は破綻するが、ja ではそのまま機能
- [ ] **\`common.dismiss\` 統合**: NotificationBell は \`notificationBell.dismiss\` のまま、NotificationToast は \`common.dismiss\` を新設して使用。将来 NotificationBell も統合するかは別途検討

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)