### PR TITLE
fix: clamp text-response preview when content has tables or blocks

### DIFF
--- a/src/plugins/textResponse/Preview.vue
+++ b/src/plugins/textResponse/Preview.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="text-sm leading-snug" :class="textColorClass">
-    <div class="preview-markdown" v-html="renderedMarkdown" />
-  </div>
+  <div class="preview-text text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
 </template>
 
 <script setup lang="ts">
@@ -14,7 +12,6 @@ const props = defineProps<{
   result: ToolResultComplete<TextResponseData>;
 }>();
 
-const previewText = computed(() => props.result.data?.text ?? "");
 const messageRole = computed(() => props.result.data?.role ?? "assistant");
 
 const textColorClass = computed(() => {
@@ -28,67 +25,27 @@ const textColorClass = computed(() => {
   }
 });
 
-const renderedMarkdown = computed(() => marked(previewText.value, { breaks: true, gfm: true }));
+const previewText = computed(() => markdownToPlainText(props.result.data?.text ?? ""));
+
+function markdownToPlainText(markdown: string): string {
+  const html = marked(markdown, { breaks: true, gfm: true }) as string;
+  const spaced = html
+    .replace(/<\/(td|th)>/gi, " ")
+    .replace(/<\/(p|h[1-6]|li|tr|blockquote|pre|div)>/gi, "$&\n")
+    .replace(/<br\s*\/?>/gi, "\n");
+  const doc = new DOMParser().parseFromString(spaced, "text/html");
+  const text = doc.body.textContent ?? "";
+  return text.replace(/\n{3,}/g, "\n\n").trim();
+}
 </script>
 
 <style scoped>
-.preview-markdown {
+.preview-text {
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 5;
   -webkit-box-orient: vertical;
-  /* Links inside v-html would otherwise hijack the row-level
-     select click and navigate to the article URL. */
-  pointer-events: none;
-}
-
-.preview-markdown :deep(p) {
-  margin: 0;
-  display: inline;
-}
-
-.preview-markdown :deep(h1),
-.preview-markdown :deep(h2),
-.preview-markdown :deep(h3),
-.preview-markdown :deep(h4),
-.preview-markdown :deep(h5),
-.preview-markdown :deep(h6) {
-  font-size: inherit;
-  font-weight: bold;
-  display: inline;
-}
-
-.preview-markdown :deep(ul),
-.preview-markdown :deep(ol) {
-  display: inline;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.preview-markdown :deep(li) {
-  display: inline;
-}
-
-.preview-markdown :deep(li)::before {
-  content: "• ";
-}
-
-.preview-markdown :deep(strong) {
-  font-weight: bold;
-}
-
-.preview-markdown :deep(em) {
-  font-style: italic;
-}
-
-.preview-markdown :deep(code) {
-  font-family: monospace;
-  font-size: 0.9em;
-}
-
-.preview-markdown :deep(pre) {
-  display: inline;
   white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>


### PR DESCRIPTION
## Summary
- `-webkit-line-clamp: 5` on the text-response preview silently gave up whenever `marked` produced a block-level descendant (tables, `<blockquote>`, `<hr>`). Those elements open their own formatting context inside `display: -webkit-box`, so the line counter stopped applying and the full content rendered. Reproduced with a response containing a 10-row markdown table — all rows displayed.
- Switched the preview from `v-html` to plain text: `markdownToPlainText()` runs `marked`, injects newline hints at block boundaries (`</p>`, `</tr>`, `</li>`, `<br>`, …) plus spaces at `</td>/</th>`, then uses `DOMParser` to pull `textContent` (which also decodes HTML entities).
- Dropped the `display: inline` whack-a-mole for `<p>/<h1-6>/<ul>/<ol>/<li>/<pre>` and the `pointer-events: none` hack — no HTML is rendered anymore, so there are no links to hijack the row click. Added `word-break: break-word` so long URLs can't blow out the column.
- The 5-line clamp now holds for arbitrary markdown shapes. Inline formatting (bold/italic/links) is lost in the preview; the full markdown still renders in `View.vue`.

## Test plan
- [ ] `yarn format`, `yarn lint`, `yarn typecheck:vue`, `yarn build:client` (all green locally)
- [ ] Load a text-response whose body contains a markdown table and confirm the preview clamps to 5 lines
- [ ] Load responses with only prose, with bullet lists, with fenced code, and with a single short line — confirm each previews correctly
- [ ] Click the row to confirm row-level selection still works (no link hijack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)