### PR TITLE
feat(i18n): extract SettingsWorkspaceDirsTab and SettingsReferenceDirsTab

### DIFF
--- a/src/components/SettingsReferenceDirsTab.vue
+++ b/src/components/SettingsReferenceDirsTab.vue
@@ -1,18 +1,24 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
 
 interface RefDirEntry {
   hostPath: string;
   label: string;
 }
 
+// See note in SettingsWorkspaceDirsTab — mirrored here.
+type SaveStatus = { kind: "ok" } | { kind: "error"; message: string };
+
 const dirs = ref<RefDirEntry[]>([]);
 const loading = ref(true);
 const error = ref("");
 const saving = ref(false);
-const saveStatus = ref("");
+const saveStatus = ref<SaveStatus | null>(null);
 
 const draftPath = ref("");
 const draftLabel = ref("");
@@ -32,17 +38,17 @@ async function load(): Promise<void> {
 
 async function save(): Promise<void> {
   saving.value = true;
-  saveStatus.value = "";
+  saveStatus.value = null;
   const result = await apiPut<{ dirs: RefDirEntry[] }>(API_ROUTES.config.referenceDirs, { dirs: dirs.value });
   saving.value = false;
   if (!result.ok) {
-    saveStatus.value = result.error;
+    saveStatus.value = { kind: "error", message: result.error };
     return;
   }
   dirs.value = result.data.dirs;
-  saveStatus.value = "Saved";
+  saveStatus.value = { kind: "ok" };
   setTimeout(() => {
-    saveStatus.value = "";
+    saveStatus.value = null;
   }, 2000);
 }
 
@@ -50,11 +56,11 @@ function addEntry(): void {
   draftError.value = "";
   const path = draftPath.value.trim();
   if (!path) {
-    draftError.value = "Path required";
+    draftError.value = t("settingsReferenceDirs.errPathRequired");
     return;
   }
   if (!path.startsWith("/") && !path.startsWith("~/")) {
-    draftError.value = "Must be an absolute path or start with ~/";
+    draftError.value = t("settingsReferenceDirs.errMustBeAbsolute");
     return;
   }
   // Normalize: trim trailing slashes for consistent comparison
@@ -68,14 +74,14 @@ function addEntry(): void {
     return cleaned;
   };
   if (dirs.value.some((dir) => stripSlash(dir.hostPath) === normalized)) {
-    draftError.value = "Already exists";
+    draftError.value = t("settingsReferenceDirs.errAlreadyExists");
     return;
   }
   const lastSeg = normalized.split("/").pop();
   const label = draftLabel.value.trim() || lastSeg || normalized;
   // Reject duplicate labels — @ref/<label> routing requires uniqueness
   if (dirs.value.some((dir) => dir.label === label)) {
-    draftError.value = `Label "${label}" already exists`;
+    draftError.value = t("settingsReferenceDirs.errLabelConflict", { label });
     return;
   }
   dirs.value.push({ hostPath: normalized, label });
@@ -98,14 +104,14 @@ onMounted(load);
     </p>
 
     <!-- Loading -->
-    <div v-if="loading" class="text-sm text-gray-400">Loading...</div>
+    <div v-if="loading" class="text-sm text-gray-400">{{ t("common.loading") }}</div>
     <div v-else-if="error" class="text-sm text-red-600 bg-red-50 rounded px-3 py-2">
       {{ error }}
     </div>
 
     <template v-else>
       <!-- Existing entries -->
-      <div v-if="dirs.length === 0" class="text-sm text-gray-400">No reference directories configured.</div>
+      <div v-if="dirs.length === 0" class="text-sm text-gray-400">{{ t("settingsReferenceDirs.noEntries") }}</div>
       <div v-else class="space-y-1.5">
         <div
           v-for="(dir, i) in dirs"
@@ -122,8 +128,8 @@ onMounted(load);
               {{ dir.label }}
             </div>
           </div>
-          <span class="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-600 shrink-0"> read-only </span>
-          <button class="text-gray-300 hover:text-red-500 shrink-0" title="Remove" data-testid="reference-dir-remove-btn" @click="removeEntry(i)">
+          <span class="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-600 shrink-0">{{ t("settingsReferenceDirs.readOnlyBadge") }}</span>
+          <button class="text-gray-300 hover:text-red-500 shrink-0" :title="t('common.remove')" data-testid="reference-dir-remove-btn" @click="removeEntry(i)">
             <span class="material-icons text-sm">close</span>
           </button>
         </div>
@@ -131,11 +137,11 @@ onMounted(load);
 
       <!-- Add new -->
       <div class="border border-gray-200 rounded p-2 space-y-2">
-        <div class="text-xs font-semibold text-gray-600">Add reference directory</div>
+        <div class="text-xs font-semibold text-gray-600">{{ t("settingsReferenceDirs.addDirTitle") }}</div>
         <input
           v-model="draftPath"
           class="w-full px-2 py-1 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-          placeholder="/Users/me/ObsidianVault or ~/Documents/notes"
+          :placeholder="t('settingsReferenceDirs.pathPlaceholder')"
           data-testid="reference-dir-path-input"
           @keydown.enter="addEntry"
           @keydown.stop
@@ -143,13 +149,15 @@ onMounted(load);
         <input
           v-model="draftLabel"
           class="w-full px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-          placeholder="Label (optional — defaults to folder name)"
+          :placeholder="t('settingsReferenceDirs.labelPlaceholder')"
           data-testid="reference-dir-label-input"
           @keydown.enter="addEntry"
           @keydown.stop
         />
         <div class="flex items-center gap-2">
-          <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="reference-dir-add-btn" @click="addEntry">Add</button>
+          <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="reference-dir-add-btn" @click="addEntry">
+            {{ t("common.add") }}
+          </button>
           <span v-if="draftError" class="text-xs text-red-500">{{ draftError }}</span>
         </div>
       </div>
@@ -162,10 +170,10 @@ onMounted(load);
           data-testid="reference-dirs-save-btn"
           @click="save"
         >
-          {{ saving ? "Saving..." : "Save" }}
+          {{ saving ? t("common.saving") : t("common.save") }}
         </button>
-        <span v-if="saveStatus" class="text-xs" :class="saveStatus === 'Saved' ? 'text-green-600' : 'text-red-600'">
-          {{ saveStatus }}
+        <span v-if="saveStatus" class="text-xs" :class="saveStatus.kind === 'ok' ? 'text-green-600' : 'text-red-600'">
+          {{ saveStatus.kind === "ok" ? t("common.saved") : saveStatus.message }}
         </span>
       </div>
     </template>

--- a/src/components/SettingsWorkspaceDirsTab.vue
+++ b/src/components/SettingsWorkspaceDirsTab.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
 
 interface DirEntry {
   path: string;
@@ -9,11 +12,16 @@ interface DirEntry {
   structure: "flat" | "by-name" | "by-date";
 }
 
+// Typed save status so the template can drive colour off `kind`
+// instead of string-comparing a localised "Saved" — previously the
+// green-on-success styling was coupled to the English literal.
+type SaveStatus = { kind: "ok" } | { kind: "error"; message: string };
+
 const dirs = ref<DirEntry[]>([]);
 const loading = ref(true);
 const error = ref("");
 const saving = ref(false);
-const saveStatus = ref("");
+const saveStatus = ref<SaveStatus | null>(null);
 
 // Draft for new entry
 const draftPath = ref("");
@@ -35,17 +43,17 @@ async function load(): Promise<void> {
 
 async function save(): Promise<void> {
   saving.value = true;
-  saveStatus.value = "";
+  saveStatus.value = null;
   const result = await apiPut<{ dirs: DirEntry[] }>(API_ROUTES.config.workspaceDirs, { dirs: dirs.value });
   saving.value = false;
   if (!result.ok) {
-    saveStatus.value = result.error;
+    saveStatus.value = { kind: "error", message: result.error };
     return;
   }
   dirs.value = result.data.dirs;
-  saveStatus.value = "Saved";
+  saveStatus.value = { kind: "ok" };
   setTimeout(() => {
-    saveStatus.value = "";
+    saveStatus.value = null;
   }, 2000);
 }
 
@@ -53,15 +61,15 @@ function addEntry(): void {
   draftError.value = "";
   const path = draftPath.value.trim();
   if (!path) {
-    draftError.value = "Path required";
+    draftError.value = t("settingsWorkspaceDirs.errPathRequired");
     return;
   }
   if (!path.startsWith("data/") && !path.startsWith("artifacts/")) {
-    draftError.value = "Must start with data/ or artifacts/";
+    draftError.value = t("settingsWorkspaceDirs.errMustStartWith");
     return;
   }
   if (dirs.value.some((dir) => dir.path === path)) {
-    draftError.value = "Already exists";
+    draftError.value = t("settingsWorkspaceDirs.errAlreadyExists");
     return;
   }
   dirs.value.push({
@@ -89,14 +97,14 @@ onMounted(load);
     </p>
 
     <!-- Loading -->
-    <div v-if="loading" class="text-sm text-gray-400">Loading...</div>
+    <div v-if="loading" class="text-sm text-gray-400">{{ t("common.loading") }}</div>
     <div v-else-if="error" class="text-sm text-red-600 bg-red-50 rounded px-3 py-2">
       {{ error }}
     </div>
 
     <template v-else>
       <!-- Existing entries -->
-      <div v-if="dirs.length === 0" class="text-sm text-gray-400">No custom directories configured.</div>
+      <div v-if="dirs.length === 0" class="text-sm text-gray-400">{{ t("settingsWorkspaceDirs.noEntries") }}</div>
       <div v-else class="space-y-1.5">
         <div
           v-for="(dir, i) in dirs"
@@ -113,7 +121,7 @@ onMounted(load);
           <span class="text-[10px] px-1.5 py-0.5 rounded bg-gray-200 text-gray-600 shrink-0">
             {{ dir.structure }}
           </span>
-          <button class="text-gray-300 hover:text-red-500 shrink-0" title="Remove" @click="removeEntry(i)">
+          <button class="text-gray-300 hover:text-red-500 shrink-0" :title="t('common.remove')" @click="removeEntry(i)">
             <span class="material-icons text-sm">close</span>
           </button>
         </div>
@@ -121,12 +129,12 @@ onMounted(load);
 
       <!-- Add new -->
       <div class="border border-gray-200 rounded p-2 space-y-2">
-        <div class="text-xs font-semibold text-gray-600">Add directory</div>
+        <div class="text-xs font-semibold text-gray-600">{{ t("settingsWorkspaceDirs.addDirTitle") }}</div>
         <div class="flex gap-2">
           <input
             v-model="draftPath"
             class="flex-1 px-2 py-1 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-            placeholder="data/clients or artifacts/reports"
+            :placeholder="t('settingsWorkspaceDirs.pathPlaceholder')"
             data-testid="workspace-dir-path-input"
             @keydown.enter="addEntry"
             @keydown.stop
@@ -144,13 +152,15 @@ onMounted(load);
         <input
           v-model="draftDescription"
           class="w-full px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-          placeholder="Description (what goes in this folder)"
+          :placeholder="t('settingsWorkspaceDirs.descPlaceholder')"
           data-testid="workspace-dir-desc-input"
           @keydown.enter="addEntry"
           @keydown.stop
         />
         <div class="flex items-center gap-2">
-          <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="workspace-dir-add-btn" @click="addEntry">Add</button>
+          <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="workspace-dir-add-btn" @click="addEntry">
+            {{ t("common.add") }}
+          </button>
           <span v-if="draftError" class="text-xs text-red-500">{{ draftError }}</span>
         </div>
       </div>
@@ -163,10 +173,10 @@ onMounted(load);
           data-testid="workspace-dirs-save-btn"
           @click="save"
         >
-          {{ saving ? "Saving..." : "Save" }}
+          {{ saving ? t("common.saving") : t("common.save") }}
         </button>
-        <span v-if="saveStatus" class="text-xs" :class="saveStatus === 'Saved' ? 'text-green-600' : 'text-red-600'">
-          {{ saveStatus }}
+        <span v-if="saveStatus" class="text-xs" :class="saveStatus.kind === 'ok' ? 'text-green-600' : 'text-red-600'">
+          {{ saveStatus.kind === "ok" ? t("common.saved") : saveStatus.message }}
         </span>
       </div>
     </template>

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -15,6 +15,10 @@ const en = {
     loading: "Loading...",
     close: "Close",
     dismiss: "Dismiss",
+    add: "Add",
+    remove: "Remove",
+    saving: "Saving...",
+    saved: "Saved",
   },
   sessionTabBar: {
     newSession: "New session",
@@ -125,6 +129,26 @@ const en = {
     singleViewTooltip: "Single view · click to switch to Stack (⌘2)",
     switchToSingle: "Switch to Single view",
     switchToStack: "Switch to Stack view",
+  },
+  settingsWorkspaceDirs: {
+    noEntries: "No custom directories configured.",
+    addDirTitle: "Add directory",
+    pathPlaceholder: "data/clients or artifacts/reports",
+    descPlaceholder: "Description (what goes in this folder)",
+    errPathRequired: "Path required",
+    errMustStartWith: "Must start with data/ or artifacts/",
+    errAlreadyExists: "Already exists",
+  },
+  settingsReferenceDirs: {
+    noEntries: "No reference directories configured.",
+    addDirTitle: "Add reference directory",
+    pathPlaceholder: "/Users/me/ObsidianVault or ~/Documents/notes",
+    labelPlaceholder: "Label (optional — defaults to folder name)",
+    readOnlyBadge: "read-only",
+    errPathRequired: "Path required",
+    errMustBeAbsolute: "Must be an absolute path or start with ~/",
+    errAlreadyExists: "Already exists",
+    errLabelConflict: 'Label "{label}" already exists',
   },
 };
 

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -8,6 +8,10 @@ const ja = {
     loading: "読み込み中...",
     close: "閉じる",
     dismiss: "閉じる",
+    add: "追加",
+    remove: "削除",
+    saving: "保存中...",
+    saved: "保存しました",
   },
   sessionTabBar: {
     newSession: "新しいセッション",
@@ -116,6 +120,26 @@ const ja = {
     singleViewTooltip: "Single 表示・クリックで Stack に切替 (⌘2)",
     switchToSingle: "Single 表示に切替",
     switchToStack: "Stack 表示に切替",
+  },
+  settingsWorkspaceDirs: {
+    noEntries: "カスタムディレクトリは未設定です。",
+    addDirTitle: "ディレクトリを追加",
+    pathPlaceholder: "data/clients または artifacts/reports",
+    descPlaceholder: "説明（このフォルダに入れるもの）",
+    errPathRequired: "パスを入力してください",
+    errMustStartWith: "data/ または artifacts/ で始める必要があります",
+    errAlreadyExists: "既に登録されています",
+  },
+  settingsReferenceDirs: {
+    noEntries: "参照ディレクトリは未設定です。",
+    addDirTitle: "参照ディレクトリを追加",
+    pathPlaceholder: "/Users/me/ObsidianVault または ~/Documents/notes",
+    labelPlaceholder: "ラベル（省略時はフォルダ名）",
+    readOnlyBadge: "読み取り専用",
+    errPathRequired: "パスを入力してください",
+    errMustBeAbsolute: "絶対パスまたは ~/ で始まる必要があります",
+    errAlreadyExists: "既に登録されています",
+    errLabelConflict: "ラベル「{label}」は既に使用されています",
   },
 };
 


### PR DESCRIPTION
## Summary

vue-i18n batch 6 (#559 follow-up)。設定の Workspace / Reference ディレクトリタブの文字列を辞書化 + 小規模 refactor。

> **依存**: #576 (batch 5) の上にスタック。#576 マージ後にリベースされ、本 PR の diff は batch 6 分のみに。

### 対象

- \`SettingsWorkspaceDirsTab.vue\` — loading、no-entries、Remove、Add directory、path/description placeholder、Add/Save/Saving…、3つの validation error
- \`SettingsReferenceDirsTab.vue\` — 同上 + read-only バッジ、label-conflict エラー ({label} 補間付き)

### Refactor — \`saveStatus\` を typed enum に

両タブとも \`saveStatus\` が free-form string で、\"Saved\" という英語リテラルとの比較で成功色をつけていた。i18n 化すると比較が壊れるため:

\`\`\`ts
type SaveStatus = { kind: \"ok\" } | { kind: \"error\"; message: string };
\`\`\`

テンプレート側は \`saveStatus.kind\` で色分け、表示は \`common.saved\` or API error を返す。

### 辞書

- 新規 namespace: \`settingsWorkspaceDirs\`, \`settingsReferenceDirs\`
- 共通キー 4 個追加: \`common.add\`, \`common.remove\`, \`common.saving\`, \`common.saved\`

### Non-goal（後続バッチ）

- 両タブの説明文段落（inline \`<code>\` 含む）は \`<i18n-t>\` slot 処理が必要

## Items to Confirm / Review

- [ ] **\`saveStatus\` refactor の影響**: 比較ロジックを文字列から \`kind\` に変更。挙動は同じ（2秒後にクリア、エラー時赤・成功時緑）
- [ ] **validation error の t() 評価タイミング**: ユーザーが add を押した瞬間の locale で表示される。現状 locale は env var 固定なので runtime 変更を想定していなく問題なし
- [ ] **日本語の「読み取り専用」バッジ**: 英語の \"read-only\" より長いが許容範囲

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)