### PR TITLE
chore(lint): promote id-length to error

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -88,8 +88,8 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
       }
       // GET /api/sessions/:id
       if (method !== "GET") return route.fallback();
-      const id = route.request().url().split("/api/sessions/").pop() ?? "";
-      const match = sessions.find((session) => session.id === id);
+      const sessionId = route.request().url().split("/api/sessions/").pop() ?? "";
+      const match = sessions.find((session) => session.id === sessionId);
       if (match) {
         return route.fulfill({ json: makeSessionEntries(match.id) });
       }

--- a/e2e/fixtures/todos-mutable.ts
+++ b/e2e/fixtures/todos-mutable.ts
@@ -122,9 +122,9 @@ export async function setupMutableTodoMocks(page: Page, options: MutableTodoOpti
     (route: Route) => {
       const method = route.request().method();
       const url = new URL(route.request().url());
-      const id = url.pathname.replace(/^\/api\/todos\/columns\/?/, "") || null;
+      const columnId = url.pathname.replace(/^\/api\/todos\/columns\/?/, "") || null;
       const body = (route.request().postDataJSON() ?? {}) as Record<string, unknown>;
-      const outcome = options.dispatchColumn?.(method, id, body, state) ?? undefined;
+      const outcome = options.dispatchColumn?.(method, columnId, body, state) ?? undefined;
       if (outcome?.items) state.items = outcome.items;
       if (outcome?.columns) state.columns = outcome.columns;
       return route.fulfill({ json: buildResponse(outcome?.extra) });

--- a/e2e/tests/chat-flow.spec.ts
+++ b/e2e/tests/chat-flow.spec.ts
@@ -225,8 +225,8 @@ test.describe("sending a chat message", () => {
       (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
       (route) => {
         if (route.request().method() !== "GET") return route.fallback();
-        const id = route.request().url().split("/api/sessions/").pop() ?? "";
-        capturedSessionId = id.split("?")[0]; // strip query
+        const sessionId = route.request().url().split("/api/sessions/").pop() ?? "";
+        capturedSessionId = sessionId.split("?")[0]; // strip query
         return route.fulfill({
           json: [
             {

--- a/e2e/tests/files-html-preview.spec.ts
+++ b/e2e/tests/files-html-preview.spec.ts
@@ -88,12 +88,12 @@ test.describe("Files view — markdown image path rewrite", () => {
 
   test("`![](images/foo.png)` renders as an `<img src=/api/files/raw?...>`", async ({ page }) => {
     const markdown = `# Page\n\n![chart](images/foo.png)\n`;
-    await mockFileContent(page, "markdowns/sample.markdown", {
+    await mockFileContent(page, "markdowns/sample.md", {
       kind: "text",
       content: markdown,
     });
 
-    await page.goto("/chat?view=files&path=markdowns/sample.markdown");
+    await page.goto("/chat?view=files&path=markdowns/sample.md");
     // Wait for the rendered markdown to surface a real <img>.
     await expect(page.locator("img[alt='chart']")).toBeVisible();
     const src = await page.locator("img[alt='chart']").getAttribute("src");
@@ -105,12 +105,12 @@ test.describe("Files view — markdown image path rewrite", () => {
 
   test("`![](../../images/foo.png)` with relative-up prefix also resolves", async ({ page }) => {
     const markdown = `![two](../../images/two.png)`;
-    await mockFileContent(page, "wiki/pages/a.markdown", {
+    await mockFileContent(page, "wiki/pages/a.md", {
       kind: "text",
       content: markdown,
     });
 
-    await page.goto("/chat?view=files&path=wiki/pages/a.markdown");
+    await page.goto("/chat?view=files&path=wiki/pages/a.md");
     await expect(page.locator("img[alt='two']")).toBeVisible();
     const src = await page.locator("img[alt='two']").getAttribute("src");
     expect(src).toContain("/api/files/raw");
@@ -124,11 +124,11 @@ test.describe("Files view — markdown image path rewrite", () => {
 ![data](data:image/png;base64,AAA=)
 ![cdn](https://cdn.example.com/x.png)
 `;
-    await mockFileContent(page, "markdowns/pass.markdown", {
+    await mockFileContent(page, "markdowns/pass.md", {
       kind: "text",
       content: markdown,
     });
-    await page.goto("/chat?view=files&path=markdowns/pass.markdown");
+    await page.goto("/chat?view=files&path=markdowns/pass.md");
     const dataSrc = await page.locator("img[alt='data']").getAttribute("src");
     expect(dataSrc).toBe("data:image/png;base64,AAA=");
     const cdnSrc = await page.locator("img[alt='cdn']").getAttribute("src");

--- a/e2e/tests/files-html-preview.spec.ts
+++ b/e2e/tests/files-html-preview.spec.ts
@@ -87,13 +87,13 @@ test.describe("Files view — markdown image path rewrite", () => {
   });
 
   test("`![](images/foo.png)` renders as an `<img src=/api/files/raw?...>`", async ({ page }) => {
-    const md = `# Page\n\n![chart](images/foo.png)\n`;
-    await mockFileContent(page, "markdowns/sample.md", {
+    const markdown = `# Page\n\n![chart](images/foo.png)\n`;
+    await mockFileContent(page, "markdowns/sample.markdown", {
       kind: "text",
-      content: md,
+      content: markdown,
     });
 
-    await page.goto("/chat?view=files&path=markdowns/sample.md");
+    await page.goto("/chat?view=files&path=markdowns/sample.markdown");
     // Wait for the rendered markdown to surface a real <img>.
     await expect(page.locator("img[alt='chart']")).toBeVisible();
     const src = await page.locator("img[alt='chart']").getAttribute("src");
@@ -104,13 +104,13 @@ test.describe("Files view — markdown image path rewrite", () => {
   });
 
   test("`![](../../images/foo.png)` with relative-up prefix also resolves", async ({ page }) => {
-    const md = `![two](../../images/two.png)`;
-    await mockFileContent(page, "wiki/pages/a.md", {
+    const markdown = `![two](../../images/two.png)`;
+    await mockFileContent(page, "wiki/pages/a.markdown", {
       kind: "text",
-      content: md,
+      content: markdown,
     });
 
-    await page.goto("/chat?view=files&path=wiki/pages/a.md");
+    await page.goto("/chat?view=files&path=wiki/pages/a.markdown");
     await expect(page.locator("img[alt='two']")).toBeVisible();
     const src = await page.locator("img[alt='two']").getAttribute("src");
     expect(src).toContain("/api/files/raw");
@@ -120,15 +120,15 @@ test.describe("Files view — markdown image path rewrite", () => {
   });
 
   test("data: URIs and http URLs pass through untouched", async ({ page }) => {
-    const md = `
+    const markdown = `
 ![data](data:image/png;base64,AAA=)
 ![cdn](https://cdn.example.com/x.png)
 `;
-    await mockFileContent(page, "markdowns/pass.md", {
+    await mockFileContent(page, "markdowns/pass.markdown", {
       kind: "text",
-      content: md,
+      content: markdown,
     });
-    await page.goto("/chat?view=files&path=markdowns/pass.md");
+    await page.goto("/chat?view=files&path=markdowns/pass.markdown");
     const dataSrc = await page.locator("img[alt='data']").getAttribute("src");
     expect(dataSrc).toBe("data:image/png;base64,AAA=");
     const cdnSrc = await page.locator("img[alt='cdn']").getAttribute("src");

--- a/e2e/tests/todo-columns.spec.ts
+++ b/e2e/tests/todo-columns.spec.ts
@@ -9,7 +9,7 @@ const TODOS_URL = `/chat?view=files&path=${WORKSPACE_FILES.todosItems}`;
 async function setupTodoMocks(page: Page): Promise<void> {
   await mockAllApis(page);
   await setupMutableTodoMocks(page, {
-    dispatchColumn(method, id, body, state) {
+    dispatchColumn(method, columnId, body, state) {
       if (method === "POST") {
         const label = typeof body.label === "string" && body.label.length > 0 ? body.label : "New Column";
         const baseId = mockSlugifyColumnId(label);
@@ -21,12 +21,12 @@ async function setupTodoMocks(page: Page): Promise<void> {
           columns: [...state.columns, { id: newId, label }],
         };
       }
-      if (method === "DELETE" && id) {
-        return { columns: state.columns.filter((col) => col.id !== id) };
+      if (method === "DELETE" && columnId) {
+        return { columns: state.columns.filter((col) => col.id !== columnId) };
       }
-      if (method === "PATCH" && id) {
+      if (method === "PATCH" && columnId) {
         return {
-          columns: state.columns.map((col) => (col.id === id ? { ...col, label: "Renamed" } : col)),
+          columns: state.columns.map((col) => (col.id === columnId ? { ...col, label: "Renamed" } : col)),
         };
       }
     },

--- a/e2e/tests/todo-items-crud.spec.ts
+++ b/e2e/tests/todo-items-crud.spec.ts
@@ -55,28 +55,28 @@ function applyCreate(items: TodoFixture[], body: Record<string, unknown>): { ite
   return { items: [...items, item], item };
 }
 
-function applyPatch(items: TodoFixture[], id: string, body: Record<string, unknown>): { items: TodoFixture[]; item: TodoFixture | null } {
+function applyPatch(items: TodoFixture[], itemId: string, body: Record<string, unknown>): { items: TodoFixture[]; item: TodoFixture | null } {
   let item: TodoFixture | null = null;
-  const next = items.map((it) => {
-    if (it.id !== id) return it;
-    item = { ...it, ...body };
+  const next = items.map((todoItem) => {
+    if (todoItem.id !== itemId) return todoItem;
+    item = { ...todoItem, ...body };
     return item;
   });
   return { items: next, item };
 }
 
-function applyMove(items: TodoFixture[], id: string, body: Record<string, unknown>): TodoFixture[] {
-  return items.map((it) =>
-    it.id === id
+function applyMove(items: TodoFixture[], itemId: string, body: Record<string, unknown>): TodoFixture[] {
+  return items.map((todoItem) =>
+    todoItem.id === itemId
       ? {
-          ...it,
+          ...todoItem,
           ...(typeof body.status === "string" && { status: body.status }),
           ...(typeof body.order === "number" && { order: body.order }),
           ...(typeof body.completed === "boolean" && {
             completed: body.completed,
           }),
         }
-      : it,
+      : todoItem,
   );
 }
 
@@ -97,7 +97,7 @@ async function setupItemsCrudMocks(page: Page): Promise<void> {
         return { items: applyMove(state.items, idSegment, body) };
       }
       if (method === "DELETE" && idSegment) {
-        return { items: state.items.filter((it) => it.id !== idSegment) };
+        return { items: state.items.filter((todoItem) => todoItem.id !== idSegment) };
       }
     },
   });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,16 +54,14 @@ export default [
     },
     rules: {
       indent: ["error", 2],
-      // Loop iterators (i/j), throwaway (_), and domain-standard
-      // 2-char idioms exempted. `id` covers every record-with-id
-      // in the codebase. `fs`/`os`/`path` are Node-module imports.
-      // `ok` is the Result-pattern discriminator. `ms`/`ts` are
-      // unit-suffixed time values. `md` is markdown. `it` is
-      // node:test's `it()`.
-      // Enabled as `warn` so existing short names across the repo
-      // don't block CI — we migrate incrementally.
+      // Loop iterators (i/j), throwaway (_), and the Result-pattern
+      // discriminator (ok) are the only exempted short names. Everything
+      // else — fs/os namespace imports, id/md/ms abbreviations, etc. —
+      // must be ≥3 chars. Use named imports (e.g. `{ readFileSync }`
+      // from "fs") and descriptive locals (`markdown`, `delayMs`,
+      // `itemId`) instead.
       "id-length": [
-        "warn",
+        "error",
         {
           min: 3,
           // Don't flag object property keys — external API payloads
@@ -73,13 +71,7 @@ export default [
             "_",
             "i",
             "j",
-            "id",
-            "ok",
-            "md",
-            "ms",
-            "it",
-            "fs",
-            "os"
+            "ok"
           ],
         },
       ],
@@ -109,7 +101,10 @@ export default [
       "sonarjs/no-ignored-exceptions": "error",
       "sonarjs/todo-tag": "off",
       "sonarjs/no-commented-code": "off",
-      "sonarjs/no-nested-conditional": "warn",
+      // The rule has no depth option — it flags any nested ternary.
+      // In practice most of our `a ? b : c ? d : e` chains are clean
+      // option tables, not obfuscation. Disable rather than warn.
+      "sonarjs/no-nested-conditional": "off",
       "sonarjs/cognitive-complexity": "error",
       // `@typescript-eslint/no-unused-vars` already covers this and
       // honours the `^__` ignore pattern (see its options above); the

--- a/server/agent/attachmentConverter.ts
+++ b/server/agent/attachmentConverter.ts
@@ -17,7 +17,7 @@ import * as XLSX from "xlsx";
 import { execFile } from "child_process";
 import { mkdtemp, readFile, writeFile, rm } from "fs/promises";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
@@ -116,7 +116,7 @@ async function tryDockerLibreOffice(): Promise<boolean> {
 }
 
 async function convertPptxToPdf(data: string): Promise<Buffer | null> {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pptx-"));
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "pptx-"));
   const inputPath = path.join(tmpDir, "input.pptx");
   const outputPath = path.join(tmpDir, "input.pdf");
 

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -15,7 +15,7 @@
 // See docs/sandbox-credentials.md for the user-facing contract.
 
 import path from "node:path";
-import fs from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { log } from "../system/logger/index.js";
@@ -105,7 +105,7 @@ export function resolveMountNames(names: readonly string[], allowed: Record<stri
 
 function hostPathExists(spec: SandboxMountSpec): boolean {
   try {
-    const stat = fs.statSync(spec.hostPath);
+    const stat = statSync(spec.hostPath);
     return spec.kind === "dir" ? stat.isDirectory() : stat.isFile();
   } catch {
     return false;
@@ -181,7 +181,7 @@ export function sshAgentForwardArgs(
       skippedReason: "SSH_AUTH_SOCK not set on host",
     };
   }
-  if (!fs.existsSync(sshAuthSock)) {
+  if (!existsSync(sshAuthSock)) {
     return {
       args: [],
       skippedReason: `SSH_AUTH_SOCK=${sshAuthSock} not found on host`,

--- a/server/api/auth/token.ts
+++ b/server/api/auth/token.ts
@@ -21,7 +21,7 @@
 // setting it once on both sides survives restarts.
 
 import { randomBytes } from "crypto";
-import fs from "fs";
+import { promises } from "fs";
 import { writeFileAtomic } from "../../utils/files/index.js";
 import { log } from "../../system/logger/index.js";
 import { isNonEmptyString } from "../../utils/types.js";
@@ -83,7 +83,7 @@ function resolveToken(override: string | undefined): string {
  */
 export async function deleteTokenFile(tokenPath: string = WORKSPACE_PATHS.sessionToken): Promise<void> {
   try {
-    await fs.promises.unlink(tokenPath);
+    await promises.unlink(tokenPath);
   } catch {
     /* already gone — nothing to do */
   }

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { ReadStream, Stats, createReadStream, promises, readFileSync, realpathSync } from "fs";
+import { ReadStream, Stats, createReadStream, readFileSync, realpathSync } from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { statSafe, statSafeAsync, readDirSafeAsync, resolveWithinRoot, writeFileAtomic } from "../../utils/files/index.js";

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import fs from "fs";
+import { ReadStream, Stats, createReadStream, promises, readFileSync, realpathSync } from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { statSafe, statSafeAsync, readDirSafeAsync, resolveWithinRoot, writeFileAtomic } from "../../utils/files/index.js";
@@ -187,7 +187,7 @@ export function classify(filename: string): ContentKind {
 // Cached realpath of the workspace. Computed once at module load so
 // every request avoids the syscall. resolveWithinRoot needs an
 // already-realpath'd root.
-const workspaceReal = fs.realpathSync(workspacePath);
+const workspaceReal = realpathSync(workspacePath);
 
 // Wraps the shared resolveWithinRoot helper with the additional
 // hidden-dir traversal check (e.g. `.git/config`). `buildTreeAsync`
@@ -235,7 +235,7 @@ function resolveRefPath(prefixedPath: string): string | null {
 
   let rootReal: string;
   try {
-    rootReal = fs.realpathSync(entry.hostPath);
+    rootReal = realpathSync(entry.hostPath);
   } catch {
     return null;
   }
@@ -276,7 +276,7 @@ export function parseRange(header: string, size: number): ByteRange | null {
   // RFC 7233 §2.1: "A Range request on a representation whose current
   // length is 0 cannot be satisfied". We also need this guard at the
   // top because the naive suffix-range math below produces `end = -1`
-  // for zero-byte files, which then crashes `fs.createReadStream`
+  // for zero-byte files, which then crashes `createReadStream`
   // with `ERR_OUT_OF_RANGE`.
   if (size <= 0) return null;
   const match = /^bytes=(\d*)-(\d*)$/i.exec(header.trim());
@@ -325,7 +325,7 @@ function applyRawSecurityHeaders(res: Response): void {
 // If the read stream errors mid-flight (file deleted, disk error,
 // permissions changed), surface a clean failure to the client instead
 // of leaving the connection hanging.
-function pipeWithErrorHandling(stream: fs.ReadStream, res: Response<ErrorResponse>): void {
+function pipeWithErrorHandling(stream: ReadStream, res: Response<ErrorResponse>): void {
   stream.on("error", (err) => {
     if (res.headersSent) {
       res.destroy(err);
@@ -340,7 +340,7 @@ function pipeWithErrorHandling(stream: fs.ReadStream, res: Response<ErrorRespons
 // the same security filters as the original sync implementation
 // (hidden dirs, sensitive files, symlinks all rejected) and the same
 // ordering (dirs before files, alphabetical within type). Uses
-// `fs.promises` throughout so the walk never blocks the event loop,
+// `promises` throughout so the walk never blocks the event loop,
 // and fans out each directory's children in parallel via
 // `Promise.all`.
 //
@@ -567,7 +567,7 @@ interface PathQuery {
 function resolveAndStatFile<T>(
   req: Request<object, unknown, unknown, PathQuery>,
   res: Response<T | ErrorResponse>,
-): { relPath: string; absPath: string; stat: fs.Stats } | null {
+): { relPath: string; absPath: string; stat: Stats } | null {
   const relPath = typeof req.query.path === "string" ? req.query.path : "";
   if (!relPath) {
     badRequest(res, "path required");
@@ -668,7 +668,7 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
   }
   let content: string;
   try {
-    content = fs.readFileSync(absPath, "utf-8");
+    content = readFileSync(absPath, "utf-8");
   } catch (err) {
     res.status(500).json({ error: `Failed to read file: ${errorMessage(err)}` });
     return;
@@ -779,12 +779,12 @@ router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQue
     res.status(206);
     res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
     res.setHeader("Content-Length", String(range.end - range.start + 1));
-    pipeWithErrorHandling(fs.createReadStream(absPath, { start: range.start, end: range.end }), res);
+    pipeWithErrorHandling(createReadStream(absPath, { start: range.start, end: range.end }), res);
     return;
   }
 
   res.setHeader("Content-Length", String(stat.size));
-  pipeWithErrorHandling(fs.createReadStream(absPath), res);
+  pipeWithErrorHandling(createReadStream(absPath), res);
 });
 
 // ── Reference directory roots ───────────────────────────────────

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import fs from "fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
 import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { stripDataUri } from "../../utils/files/image-store.js";
@@ -54,8 +54,8 @@ let storiesRealCache: string | null = null;
 function ensureStoriesReal(): string | null {
   if (storiesRealCache) return storiesRealCache;
   try {
-    fs.mkdirSync(storiesDir, { recursive: true });
-    storiesRealCache = fs.realpathSync(storiesDir);
+    mkdirSync(storiesDir, { recursive: true });
+    storiesRealCache = realpathSync(storiesDir);
     return storiesRealCache;
   } catch {
     return null;
@@ -104,14 +104,14 @@ router.post(API_ROUTES.mulmoScript.save, (req: Request<object, object, SaveMulmo
     return;
   }
 
-  fs.mkdirSync(storiesDir, { recursive: true });
+  mkdirSync(storiesDir, { recursive: true });
 
   const title = script.title || "untitled";
   const slug = filename ? filename.replace(/\.json$/, "") : slugify(title);
   const fname = `${slug}-${Date.now()}.json`;
   const filePath = path.join(storiesDir, fname);
 
-  fs.writeFileSync(filePath, JSON.stringify(script, null, 2));
+  writeFileSync(filePath, JSON.stringify(script, null, 2));
 
   res.json({
     data: { script, filePath: `stories/${fname}` },
@@ -131,7 +131,7 @@ router.post(API_ROUTES.mulmoScript.updateBeat, (req: Request<object, object, unk
   const absoluteFilePath = resolveStoryPath(filePath, res);
   if (!absoluteFilePath) return;
 
-  const script: MulmoScript = JSON.parse(fs.readFileSync(absoluteFilePath, "utf-8"));
+  const script: MulmoScript = JSON.parse(readFileSync(absoluteFilePath, "utf-8"));
 
   if (!Array.isArray(script.beats) || beatIndex >= script.beats.length) {
     badRequest(res, "Invalid beatIndex");
@@ -139,7 +139,7 @@ router.post(API_ROUTES.mulmoScript.updateBeat, (req: Request<object, object, unk
   }
 
   script.beats[beatIndex] = beat as MulmoBeat;
-  fs.writeFileSync(absoluteFilePath, JSON.stringify(script, null, 2));
+  writeFileSync(absoluteFilePath, JSON.stringify(script, null, 2));
 
   res.json({ ok: true });
 });
@@ -155,7 +155,7 @@ router.post(API_ROUTES.mulmoScript.updateScript, (req: Request<object, object, u
   const absoluteFilePath = resolveStoryPath(filePath, res);
   if (!absoluteFilePath) return;
 
-  fs.writeFileSync(absoluteFilePath, JSON.stringify(updatedScript, null, 2));
+  writeFileSync(absoluteFilePath, JSON.stringify(updatedScript, null, 2));
   res.json({ ok: true });
 });
 
@@ -170,7 +170,7 @@ router.get(API_ROUTES.mulmoScript.beatImage, async (req: Request<object, BeatIma
 
   await withStoryContext(res, filePath, {}, async ({ context }) => {
     const { imagePath } = getBeatPngImagePath(context, beatIndex);
-    if (!fs.existsSync(imagePath)) {
+    if (!existsSync(imagePath)) {
       res.json({ image: null });
       return;
     }
@@ -197,13 +197,13 @@ router.get(API_ROUTES.mulmoScript.movieStatus, async (req: Request<object, Movie
     }
 
     const outputPath = movieFilePath(context);
-    if (!fs.existsSync(outputPath)) {
+    if (!existsSync(outputPath)) {
       res.json({ moviePath: null });
       return;
     }
 
-    const movieMtime = fs.statSync(outputPath).mtimeMs;
-    const sourceMtime = fs.statSync(absoluteFilePath).mtimeMs;
+    const movieMtime = statSync(outputPath).mtimeMs;
+    const sourceMtime = statSync(absoluteFilePath).mtimeMs;
     if (movieMtime < sourceMtime) {
       res.json({ moviePath: null });
       return;
@@ -216,7 +216,7 @@ router.get(API_ROUTES.mulmoScript.movieStatus, async (req: Request<object, Movie
 });
 
 function fileToDataUri(filePath: string, mimeType: string): string {
-  const data = fs.readFileSync(filePath);
+  const data = readFileSync(filePath);
   return `data:${mimeType};base64,${data.toString("base64")}`;
 }
 
@@ -257,7 +257,7 @@ function resolveStoryPath(filePath: string, res: Response): string | null {
   const resolved = resolveWithinRoot(storiesReal, relFromStories);
   if (!resolved) {
     const candidate = path.resolve(storiesReal, relFromStories);
-    if (!fs.existsSync(candidate)) {
+    if (!existsSync(candidate)) {
       notFound(res, `File not found: ${filePath}`);
     } else {
       badRequest(res, "Invalid filePath");
@@ -378,7 +378,7 @@ router.get(API_ROUTES.mulmoScript.beatAudio, async (req: Request<object, BeatAud
     async ({ context }) => {
       const beat = context.studio.script.beats[beatIndex];
       const audioPath = getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
-      if (!audioPath || !fs.existsSync(audioPath)) {
+      if (!audioPath || !existsSync(audioPath)) {
         res.json({ audio: null });
         return;
       }
@@ -422,7 +422,7 @@ router.post(
           const beat = context.studio.script.beats[beatIndex];
           const audioPath = context.studio.beats[beatIndex]?.audioFile ?? getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
 
-          if (!audioPath || !fs.existsSync(audioPath)) {
+          if (!audioPath || !existsSync(audioPath)) {
             // Logic-flow failure (not an exception) — emit a targeted
             // log. Don't write raw `beat.text` into persistent logs —
             // it's free-form user content and can contain sensitive
@@ -430,7 +430,7 @@ router.post(
             log.error("generate-beat-audio", "audio was not generated", {
               beatIndex,
               audioPath,
-              exists: audioPath ? fs.existsSync(audioPath) : false,
+              exists: audioPath ? existsSync(audioPath) : false,
               beatTextLength: typeof beat?.text === "string" ? beat.text.length : 0,
               audioFilePresent: Boolean(context.studio.beats[beatIndex]?.audioFile),
             });
@@ -475,7 +475,7 @@ router.post(API_ROUTES.mulmoScript.renderBeat, async (req: Request<object, objec
         });
 
         const { imagePath } = getBeatPngImagePath(context, beatIndex);
-        if (!fs.existsSync(imagePath)) {
+        if (!existsSync(imagePath)) {
           genError = "Image was not generated";
           serverError(res, genError);
           return;
@@ -542,7 +542,7 @@ router.post(API_ROUTES.mulmoScript.generateMovie, async (req: Request<object, ob
       await movie(audioContext);
 
       const outputPath = movieFilePath(audioContext);
-      if (!fs.existsSync(outputPath)) {
+      if (!existsSync(outputPath)) {
         genError = "Movie was not generated";
         send({ type: "error", message: genError });
         res.end();
@@ -594,7 +594,7 @@ router.get(
 
     await withStoryContext(res, filePath, {}, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
-      if (!fs.existsSync(imagePath)) {
+      if (!existsSync(imagePath)) {
         res.json({ image: null });
         return;
       }
@@ -613,10 +613,10 @@ router.post(API_ROUTES.mulmoScript.uploadBeatImage, async (req: Request<object, 
 
   await withStoryContext(res, filePath, {}, async ({ context }) => {
     const { imagePath } = getBeatPngImagePath(context, beatIndex);
-    fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+    mkdirSync(path.dirname(imagePath), { recursive: true });
 
     const base64 = stripDataUri(imageData);
-    fs.writeFileSync(imagePath, Buffer.from(base64, "base64"));
+    writeFileSync(imagePath, Buffer.from(base64, "base64"));
 
     res.json({ image: fileToDataUri(imagePath, "image/png") });
   });
@@ -647,7 +647,7 @@ router.post(
 
           const index = Object.keys(images).indexOf(key);
           const imagePath = getReferenceImagePath(context, key, "png");
-          fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+          mkdirSync(path.dirname(imagePath), { recursive: true });
 
           await generateReferenceImage({
             context,
@@ -656,7 +656,7 @@ router.post(
             image: imageEntry as MulmoImagePromptMedia,
             force,
           });
-          if (!fs.existsSync(imagePath)) {
+          if (!existsSync(imagePath)) {
             genError = "Character image was not generated";
             serverError(res, genError);
             return;
@@ -685,10 +685,10 @@ router.post(
 
     await withStoryContext(res, filePath, {}, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
-      fs.mkdirSync(path.dirname(imagePath), { recursive: true });
+      mkdirSync(path.dirname(imagePath), { recursive: true });
 
       const base64 = stripDataUri(imageData);
-      fs.writeFileSync(imagePath, Buffer.from(base64, "base64"));
+      writeFileSync(imagePath, Buffer.from(base64, "base64"));
 
       res.json({ image: fileToDataUri(imagePath, "image/png") });
     });

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import { realpathSync } from "fs";
 import path from "path";
 import { Router, Request, Response } from "express";
 import { marked } from "marked";
@@ -56,7 +56,7 @@ const MIME_BY_EXT: Record<string, string> = {
 // Realpath of the workspace, resolved once at module load. Used to
 // validate that image paths resolved relative to markdowns/ stay
 // inside the workspace after symlink resolution.
-const workspaceReal = fs.realpathSync(resolveWorkspacePath(""));
+const workspaceReal = realpathSync(resolveWorkspacePath(""));
 
 /**
  * Inline local images as base64 data URIs so Puppeteer can render them.

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import fs from "fs";
+import { realpathSync } from "fs";
 import { readdir, stat } from "fs/promises";
 import { readTextSafe } from "../../utils/files/safe.js";
 import path from "path";
@@ -242,7 +242,7 @@ router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res
                   const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
                   let storiesReal: string;
                   try {
-                    storiesReal = fs.realpathSync(storiesDir);
+                    storiesReal = realpathSync(storiesDir);
                   } catch {
                     return entry;
                   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,8 +34,8 @@ import { mcpToolsRouter, mcpTools, isMcpToolEnabled } from "./agent/mcp-tools/in
 import { initWorkspace, workspacePath } from "./workspace/workspace.js";
 import { env, isGeminiAvailable } from "./system/env.js";
 import { buildSandboxStatus } from "./api/sandboxStatus.js";
-import fs from "fs";
-import os from "os";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
 import { maybeRunJournal } from "./workspace/journal/index.js";
 import { backfillAllSessions } from "./workspace/chat-index/index.js";
@@ -234,7 +234,7 @@ if (env.isProduction) {
   app.get("/{*splat}", (_req: Request, res: Response) => {
     let html: string;
     try {
-      html = fs.readFileSync(indexHtmlPath, "utf-8");
+      html = readFileSync(indexHtmlPath, "utf-8");
     } catch (err) {
       log.error("server", "failed to read index.html", { error: String(err) });
       serverError(res, "Internal Server Error");
@@ -270,8 +270,8 @@ function isPortFree(port: number): Promise<boolean> {
 }
 
 async function ensureCredentialsAvailable(): Promise<void> {
-  const credentialsPath = path.join(os.homedir(), ".claude", ".credentials.json");
-  if (fs.existsSync(credentialsPath)) return;
+  const credentialsPath = path.join(homedir(), ".claude", ".credentials.json");
+  if (existsSync(credentialsPath)) return;
 
   if (process.platform === "darwin") {
     const { refreshCredentials } = await import("./system/credentials.js");

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -9,7 +9,7 @@
 // defaults. Writers perform an atomic replace (tmp + rename) so a
 // reader never observes a half-written file.
 
-import fs from "fs";
+import { mkdirSync } from "fs";
 import path from "path";
 import { log } from "./logger/index.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
@@ -44,7 +44,7 @@ export function mcpConfigPath(): string {
 }
 
 export function ensureConfigsDir(): void {
-  fs.mkdirSync(configsDir(), { recursive: true });
+  mkdirSync(configsDir(), { recursive: true });
 }
 
 export function isAppSettings(value: unknown): value is AppSettings {

--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -6,7 +6,7 @@
 // Moved from server/utils/file.ts (issue #366 Phase 1). The old
 // file re-exports these for backwards compat.
 
-import fs from "fs";
+import { mkdirSync, promises, renameSync, unlinkSync, writeFileSync } from "fs";
 import path from "path";
 import { randomUUID } from "crypto";
 
@@ -50,7 +50,7 @@ function isTransientRenameError(err: unknown): boolean {
 async function renameWithWindowsRetry(fromPath: string, toPath: string): Promise<void> {
   for (const delayMs of RENAME_RETRY_DELAYS_MS) {
     try {
-      await fs.promises.rename(fromPath, toPath);
+      await promises.rename(fromPath, toPath);
       return;
     } catch (err) {
       if (!isTransientRenameError(err)) throw err;
@@ -58,7 +58,7 @@ async function renameWithWindowsRetry(fromPath: string, toPath: string): Promise
     }
   }
   // Final attempt — let any error propagate.
-  await fs.promises.rename(fromPath, toPath);
+  await promises.rename(fromPath, toPath);
 }
 
 // Sync sleep that parks the thread instead of burning CPU. Only
@@ -73,14 +73,14 @@ function sleepSync(millis: number): void {
 function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
   for (const delayMs of RENAME_RETRY_DELAYS_MS) {
     try {
-      fs.renameSync(fromPath, toPath);
+      renameSync(fromPath, toPath);
       return;
     } catch (err) {
       if (!isTransientRenameError(err)) throw err;
       sleepSync(delayMs);
     }
   }
-  fs.renameSync(fromPath, toPath);
+  renameSync(fromPath, toPath);
 }
 
 /**
@@ -90,15 +90,15 @@ function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
  */
 export async function writeFileAtomic(filePath: string, content: string, opts: WriteAtomicOptions = {}): Promise<void> {
   const tmp = opts.uniqueTmp ? `${filePath}.${randomUUID()}.tmp` : `${filePath}.tmp`;
-  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await promises.mkdir(path.dirname(filePath), { recursive: true });
   try {
-    await fs.promises.writeFile(tmp, content, {
+    await promises.writeFile(tmp, content, {
       encoding: "utf-8",
       mode: opts.mode,
     });
     await renameWithWindowsRetry(tmp, filePath);
   } catch (err) {
-    await fs.promises.unlink(tmp).catch(() => {});
+    await promises.unlink(tmp).catch(() => {});
     throw err;
   }
 }
@@ -110,13 +110,13 @@ export async function writeFileAtomic(filePath: string, content: string, opts: W
  */
 export function writeFileAtomicSync(filePath: string, content: string, opts: WriteAtomicOptions = {}): void {
   const tmp = opts.uniqueTmp ? `${filePath}.${randomUUID()}.tmp` : `${filePath}.tmp`;
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  mkdirSync(path.dirname(filePath), { recursive: true });
   try {
-    fs.writeFileSync(tmp, content, { encoding: "utf-8", mode: opts.mode });
+    writeFileSync(tmp, content, { encoding: "utf-8", mode: opts.mode });
     renameSyncWithWindowsRetry(tmp, filePath);
   } catch (err) {
     try {
-      fs.unlinkSync(tmp);
+      unlinkSync(tmp);
     } catch {
       // best-effort cleanup
     }

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
@@ -12,8 +12,8 @@ let imagesDirReal: string | null = null;
 
 async function ensureImagesDir(): Promise<string> {
   if (imagesDirReal) return imagesDirReal;
-  await fs.mkdir(IMAGES_DIR, { recursive: true });
-  imagesDirReal = await fs.realpath(IMAGES_DIR);
+  await mkdir(IMAGES_DIR, { recursive: true });
+  imagesDirReal = await realpath(IMAGES_DIR);
   return imagesDirReal;
 }
 
@@ -38,20 +38,20 @@ export async function saveImage(base64Data: string): Promise<string> {
   const imageId = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
   const filename = `${imageId}.png`;
   const absPath = path.join(IMAGES_DIR, filename);
-  await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
+  await writeFile(absPath, Buffer.from(base64Data, "base64"));
   return path.posix.join(WORKSPACE_DIRS.images, filename);
 }
 
 /** Overwrite an existing image file. The relativePath must start with "images/". */
 export async function overwriteImage(relativePath: string, base64Data: string): Promise<void> {
   const absPath = await safeResolve(relativePath);
-  await fs.writeFile(absPath, Buffer.from(base64Data, "base64"));
+  await writeFile(absPath, Buffer.from(base64Data, "base64"));
 }
 
 /** Read an image file and return raw base64 (no data URI prefix). */
 export async function loadImageBase64(relativePath: string): Promise<string> {
   const absPath = await safeResolve(relativePath);
-  const buf = await fs.readFile(absPath);
+  const buf = await readFile(absPath);
   return buf.toString("base64");
 }
 

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -17,7 +17,7 @@ import { isEnoent } from "./safe.js";
 import { log } from "../../system/logger/index.js";
 import { summariesRoot, dailyPathFor, topicPathFor, TOPICS_DIR, INDEX_FILE, STATE_FILE, DAILY_DIR, ARCHIVE_DIR } from "../../workspace/journal/paths.js";
 
-import fs from "node:fs";
+import { statSync } from "node:fs";
 
 const root = (rootOverride?: string) => rootOverride ?? workspacePath;
 
@@ -26,7 +26,7 @@ const root = (rootOverride?: string) => rootOverride ?? workspacePath;
 export function journalStateExists(rootOverride?: string): boolean {
   const filePath = path.join(summariesRoot(root(rootOverride)), STATE_FILE);
   try {
-    fs.statSync(filePath);
+    statSync(filePath);
     return true;
   } catch {
     return false;

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -3,7 +3,7 @@
 // Moved from server/utils/file.ts (issue #366 Phase 1). The old
 // file re-exports these for backwards compat.
 
-import fs from "fs";
+import { mkdirSync, promises, readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { writeFileAtomic } from "./atomic.js";
 import { isEnoent } from "./safe.js";
@@ -20,7 +20,7 @@ import { log } from "../../system/logger/index.js";
 export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
   let raw: string;
   try {
-    raw = fs.readFileSync(filePath, "utf-8");
+    raw = readFileSync(filePath, "utf-8");
   } catch (err) {
     if (isEnoent(err)) return defaultValue;
     log.error("json", "loadJsonFile read failed", {
@@ -41,8 +41,8 @@ export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
 }
 
 export function saveJsonFile(filePath: string, data: unknown): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
 // ── Async ───────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ export async function writeJsonAtomic(filePath: string, data: unknown, opts: Par
  */
 export async function readJsonOrNull<T>(filePath: string): Promise<T | null> {
   try {
-    const content = await fs.promises.readFile(filePath, "utf-8");
+    const content = await promises.readFile(filePath, "utf-8");
     const parsed: T = JSON.parse(content);
     return parsed;
   } catch {

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -11,20 +11,20 @@ import { buildArtifactPathRandom } from "./naming.js";
  */
 export async function saveMarkdown(content: string, prefix: string): Promise<string> {
   const relPath = buildArtifactPathRandom(WORKSPACE_DIRS.markdowns, prefix, ".md", "document");
-  await fs.writeFile(path.join(workspacePath, relPath), content, "utf-8");
+  await writeFile(path.join(workspacePath, relPath), content, "utf-8");
   return relPath;
 }
 
 /** Read a markdown file and return its content. */
 export async function loadMarkdown(relativePath: string): Promise<string> {
   const absPath = path.join(workspacePath, relativePath);
-  return fs.readFile(absPath, "utf-8");
+  return readFile(absPath, "utf-8");
 }
 
 /** Overwrite an existing markdown file. */
 export async function overwriteMarkdown(relativePath: string, content: string): Promise<void> {
   const absPath = path.join(workspacePath, relativePath);
-  await fs.writeFile(absPath, content, "utf-8");
+  await writeFile(absPath, content, "utf-8");
 }
 
 /** Check if a string is a markdown file path (not inline content). */

--- a/server/utils/files/reference-dirs-io.ts
+++ b/server/utils/files/reference-dirs-io.ts
@@ -4,7 +4,7 @@
 // All fs access is funneled through shared helpers so path changes
 // propagate from a single constant.
 
-import fs from "fs";
+import { mkdirSync, statSync } from "fs";
 import path from "path";
 import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
 import { loadJsonFile } from "./json.js";
@@ -31,14 +31,14 @@ export function readReferenceDirsJson(root?: string): unknown[] {
 /** Write reference-dirs.json atomically. Creates config/ if needed. */
 export function writeReferenceDirsJson(entries: readonly unknown[], root?: string): void {
   const filePath = configPath(root ?? workspacePath);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
 }
 
 /** Check whether a host path exists and is a directory. */
 export function isExistingDirectory(hostPath: string): boolean {
   try {
-    return fs.statSync(hostPath).isDirectory();
+    return statSync(hostPath).isDirectory();
   } catch {
     return false;
   }

--- a/server/utils/files/roles-io.ts
+++ b/server/utils/files/roles-io.ts
@@ -4,7 +4,7 @@
 // Optional `root` for test DI.
 
 import path from "node:path";
-import fs from "node:fs";
+import { mkdirSync, statSync, unlinkSync } from "node:fs";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomicSync } from "./atomic.js";
@@ -19,7 +19,7 @@ function roleFilePath(roleId: string, workspaceRoot?: string): string {
 /** Check if a custom role file exists. */
 export function roleExists(roleId: string, workspaceRoot?: string): boolean {
   try {
-    fs.statSync(roleFilePath(roleId, workspaceRoot));
+    statSync(roleFilePath(roleId, workspaceRoot));
     return true;
   } catch {
     return false;
@@ -29,7 +29,7 @@ export function roleExists(roleId: string, workspaceRoot?: string): boolean {
 /** Delete a custom role file. Returns false if not found. */
 export function deleteRole(roleId: string, workspaceRoot?: string): boolean {
   try {
-    fs.unlinkSync(roleFilePath(roleId, workspaceRoot));
+    unlinkSync(roleFilePath(roleId, workspaceRoot));
     return true;
   } catch (err) {
     if (isEnoent(err)) return false;
@@ -40,6 +40,6 @@ export function deleteRole(roleId: string, workspaceRoot?: string): boolean {
 /** Save (create or overwrite) a custom role file atomically. */
 export function saveRole(roleId: string, data: unknown, workspaceRoot?: string): void {
   const dir = path.join(root(workspaceRoot), WORKSPACE_DIRS.roles);
-  fs.mkdirSync(dir, { recursive: true });
+  mkdirSync(dir, { recursive: true });
   writeFileAtomicSync(roleFilePath(roleId, workspaceRoot), JSON.stringify(data, null, 2));
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -7,7 +7,7 @@
 // Moved from server/utils/fs.ts (issue #366 Phase 1). The old
 // file re-exports these for backwards compat.
 
-import fs from "fs";
+import { Dirent, Stats, promises, readFileSync, readdirSync, realpathSync, statSync } from "fs";
 import path from "path";
 import { isErrorWithCode } from "../types.js";
 
@@ -19,7 +19,7 @@ export function isEnoent(err: unknown): boolean {
 /** Read a binary file by absolute path. Null on ENOENT. */
 export function readBinarySafeSync(absPath: string): Buffer | null {
   try {
-    return fs.readFileSync(absPath);
+    return readFileSync(absPath);
   } catch {
     return null;
   }
@@ -28,7 +28,7 @@ export function readBinarySafeSync(absPath: string): Buffer | null {
 /** Read a text file by absolute path (async). Null on ENOENT. */
 export async function readTextSafe(absPath: string): Promise<string | null> {
   try {
-    return await fs.promises.readFile(absPath, "utf-8");
+    return await promises.readFile(absPath, "utf-8");
   } catch {
     return null;
   }
@@ -37,39 +37,39 @@ export async function readTextSafe(absPath: string): Promise<string | null> {
 /** Read a text file by absolute path (sync). Null on ENOENT. */
 export function readTextSafeSync(absPath: string): string | null {
   try {
-    return fs.readFileSync(absPath, "utf-8");
+    return readFileSync(absPath, "utf-8");
   } catch {
     return null;
   }
 }
 
-export function statSafe(absPath: string): fs.Stats | null {
+export function statSafe(absPath: string): Stats | null {
   try {
-    return fs.statSync(absPath);
+    return statSync(absPath);
   } catch {
     return null;
   }
 }
 
-export async function statSafeAsync(absPath: string): Promise<fs.Stats | null> {
+export async function statSafeAsync(absPath: string): Promise<Stats | null> {
   try {
-    return await fs.promises.stat(absPath);
+    return await promises.stat(absPath);
   } catch {
     return null;
   }
 }
 
-export function readDirSafe(absPath: string): fs.Dirent[] {
+export function readDirSafe(absPath: string): Dirent[] {
   try {
-    return fs.readdirSync(absPath, { withFileTypes: true });
+    return readdirSync(absPath, { withFileTypes: true });
   } catch {
     return [];
   }
 }
 
-export async function readDirSafeAsync(absPath: string): Promise<fs.Dirent[]> {
+export async function readDirSafeAsync(absPath: string): Promise<Dirent[]> {
   try {
-    return await fs.promises.readdir(absPath, { withFileTypes: true });
+    return await promises.readdir(absPath, { withFileTypes: true });
   } catch {
     return [];
   }
@@ -77,7 +77,7 @@ export async function readDirSafeAsync(absPath: string): Promise<fs.Dirent[]> {
 
 export async function readTextOrNull(file: string): Promise<string | null> {
   try {
-    return await fs.promises.readFile(file, "utf-8");
+    return await promises.readFile(file, "utf-8");
   } catch {
     return null;
   }
@@ -95,7 +95,7 @@ export function resolveWithinRoot(rootReal: string, relPath: string): string | n
   const resolved = path.resolve(rootReal, normalized);
   let resolvedReal: string;
   try {
-    resolvedReal = fs.realpathSync(resolved);
+    resolvedReal = realpathSync(resolved);
   } catch {
     return null;
   }

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -4,7 +4,7 @@
 // system task ID (e.g. "system:journal"), value overrides the
 // default schedule.
 
-import fs from "fs";
+import { mkdirSync } from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/paths.js";
 import { WORKSPACE_FILES } from "../../../src/config/workspacePaths.js";
@@ -59,6 +59,6 @@ export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
 /** Save schedule overrides atomically. Creates directory if needed. */
 export function saveSchedulerOverrides(overrides: ScheduleOverrides, root?: string): void {
   const filePath = overridesPath(root);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicSync(filePath, JSON.stringify(overrides, null, 2));
 }

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises";
+import { mkdir, realpath, writeFile } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
@@ -13,8 +13,8 @@ let spreadsheetsDirReal: string | null = null;
 
 async function ensureSpreadsheetsDir(): Promise<string> {
   if (spreadsheetsDirReal) return spreadsheetsDirReal;
-  await fs.mkdir(SPREADSHEETS_DIR, { recursive: true });
-  spreadsheetsDirReal = await fs.realpath(SPREADSHEETS_DIR);
+  await mkdir(SPREADSHEETS_DIR, { recursive: true });
+  spreadsheetsDirReal = await realpath(SPREADSHEETS_DIR);
   return spreadsheetsDirReal;
 }
 
@@ -38,14 +38,14 @@ export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   await ensureSpreadsheetsDir();
   const sheetId = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
   const filename = `${sheetId}.json`;
-  await fs.writeFile(path.join(SPREADSHEETS_DIR, filename), JSON.stringify(sheets), "utf-8");
+  await writeFile(path.join(SPREADSHEETS_DIR, filename), JSON.stringify(sheets), "utf-8");
   return path.posix.join(WORKSPACE_DIRS.spreadsheets, filename);
 }
 
 /** Overwrite an existing spreadsheet file. */
 export async function overwriteSpreadsheet(relativePath: string, sheets: unknown[]): Promise<void> {
   const absPath = await safeResolve(relativePath);
-  await fs.writeFile(absPath, JSON.stringify(sheets), "utf-8");
+  await writeFile(absPath, JSON.stringify(sheets), "utf-8");
 }
 
 /** Check if a string is a spreadsheet file path (not inline data).

--- a/server/utils/files/workspace-io.ts
+++ b/server/utils/files/workspace-io.ts
@@ -11,7 +11,7 @@
 // All reads swallow ENOENT and return null / fallback so callers can
 // do `if (!content)` instead of try/catch.
 
-import fs from "fs";
+import { Stats, mkdirSync, promises, readFileSync, readdirSync, statSync } from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic, writeFileAtomicSync } from "./atomic.js";
@@ -44,7 +44,7 @@ export function resolveWorkspacePath(relPath: string): string {
  */
 export async function readWorkspaceText(relPath: string): Promise<string | null> {
   try {
-    return await fs.promises.readFile(resolveWorkspacePath(relPath), "utf-8");
+    return await promises.readFile(resolveWorkspacePath(relPath), "utf-8");
   } catch (err) {
     return rethrowUnexpected(err, `readWorkspaceText(${relPath})`);
   }
@@ -53,7 +53,7 @@ export async function readWorkspaceText(relPath: string): Promise<string | null>
 /** Sync variant. Same ENOENT-only swallow contract. */
 export function readWorkspaceTextSync(relPath: string): string | null {
   try {
-    return fs.readFileSync(resolveWorkspacePath(relPath), "utf-8");
+    return readFileSync(resolveWorkspacePath(relPath), "utf-8");
   } catch (err) {
     return rethrowUnexpected(err, `readWorkspaceTextSync(${relPath})`);
   }
@@ -133,7 +133,7 @@ export function resolvePath(root: string, relPath: string): string {
  *  unexpected errors. */
 export async function readTextUnder(root: string, relPath: string): Promise<string | null> {
   try {
-    return await fs.promises.readFile(path.join(root, relPath), "utf-8");
+    return await promises.readFile(path.join(root, relPath), "utf-8");
   } catch (err) {
     return rethrowUnexpected(err, `readTextUnder(${relPath})`);
   }
@@ -147,7 +147,7 @@ export async function writeTextUnder(root: string, relPath: string, content: str
 /** Sync read text under a root. Null on ENOENT. */
 export function readTextUnderSync(root: string, relPath: string): string | null {
   try {
-    return fs.readFileSync(path.join(root, relPath), "utf-8");
+    return readFileSync(path.join(root, relPath), "utf-8");
   } catch (err) {
     return rethrowUnexpected(err, `readTextUnderSync(${relPath})`);
   }
@@ -156,7 +156,7 @@ export function readTextUnderSync(root: string, relPath: string): string | null 
 /** Sync readdir under a root. Empty on ENOENT. */
 export function readdirUnderSync(root: string, relPath: string): string[] {
   try {
-    return fs.readdirSync(path.join(root, relPath));
+    return readdirSync(path.join(root, relPath));
   } catch (err) {
     if (isEnoent(err)) return [];
     log.error("workspace-io", `readdirUnderSync(${relPath})`, {
@@ -169,7 +169,7 @@ export function readdirUnderSync(root: string, relPath: string): string[] {
 /** Readdir under a root. Empty on ENOENT; rethrows unexpected. */
 export async function readdirUnder(root: string, relPath: string): Promise<string[]> {
   try {
-    return await fs.promises.readdir(path.join(root, relPath));
+    return await promises.readdir(path.join(root, relPath));
   } catch (err) {
     if (isEnoent(err)) return [];
     log.error("workspace-io", `readdirUnder(${relPath})`, {
@@ -180,9 +180,9 @@ export async function readdirUnder(root: string, relPath: string): Promise<strin
 }
 
 /** Stat under a root. Null on ENOENT; rethrows unexpected. */
-export async function statUnder(root: string, relPath: string): Promise<fs.Stats | null> {
+export async function statUnder(root: string, relPath: string): Promise<Stats | null> {
   try {
-    return await fs.promises.stat(path.join(root, relPath));
+    return await promises.stat(path.join(root, relPath));
   } catch (err) {
     return rethrowUnexpected(err, `statUnder(${relPath})`);
   }
@@ -190,7 +190,7 @@ export async function statUnder(root: string, relPath: string): Promise<fs.Stats
 
 /** Ensure a directory exists under a root. */
 export async function ensureDirUnder(root: string, relPath: string): Promise<void> {
-  await fs.promises.mkdir(path.join(root, relPath), { recursive: true });
+  await promises.mkdir(path.join(root, relPath), { recursive: true });
 }
 
 // ── Existence ───────────────────────────────────────────────────
@@ -201,7 +201,7 @@ export async function ensureDirUnder(root: string, relPath: string): Promise<voi
  */
 export function existsInWorkspace(relPath: string): boolean {
   try {
-    fs.statSync(resolveWorkspacePath(relPath));
+    statSync(resolveWorkspacePath(relPath));
     return true;
   } catch (err) {
     if (isEnoent(err)) return false;
@@ -217,5 +217,5 @@ export function existsInWorkspace(relPath: string): boolean {
  * (including parents) if missing. Idempotent.
  */
 export function ensureWorkspaceDir(relPath: string): void {
-  fs.mkdirSync(resolveWorkspacePath(relPath), { recursive: true });
+  mkdirSync(resolveWorkspacePath(relPath), { recursive: true });
 }

--- a/server/utils/gitignore.ts
+++ b/server/utils/gitignore.ts
@@ -15,7 +15,7 @@
 // the workspace scale (~hundreds of dirs) this is negligible. If
 // profiling shows otherwise, cache the parsed ignore instances.
 
-import fs from "fs";
+import { readFileSync } from "fs";
 import path from "path";
 import ignore, { type Ignore } from "ignore";
 
@@ -44,7 +44,7 @@ export class GitignoreFilter {
     // Add local .gitignore if present
     const gitignorePath = path.join(dirAbsPath, ".gitignore");
     try {
-      const content = fs.readFileSync(gitignorePath, "utf-8");
+      const content = readFileSync(gitignorePath, "utf-8");
       child.rules.add(content);
     } catch {
       // No .gitignore in this directory — just inherit parent
@@ -61,7 +61,7 @@ export class GitignoreFilter {
 export function createRootFilter(workspaceRoot: string): GitignoreFilter {
   const gitignorePath = path.join(workspaceRoot, ".gitignore");
   try {
-    const content = fs.readFileSync(gitignorePath, "utf-8");
+    const content = readFileSync(gitignorePath, "utf-8");
     return new GitignoreFilter(content);
   } catch {
     return new GitignoreFilter();

--- a/server/workspace/custom-dirs.ts
+++ b/server/workspace/custom-dirs.ts
@@ -4,7 +4,7 @@
 // directories under `data/` and `artifacts/` for organizing files.
 // Claude sees these in the system prompt and routes saves accordingly.
 
-import fs from "fs";
+import { existsSync, mkdirSync, readFileSync } from "fs";
 import path from "path";
 import { workspacePath, WORKSPACE_DIRS } from "./paths.js";
 import { log } from "../system/logger/index.js";
@@ -102,8 +102,8 @@ export function loadCustomDirs(root?: string): CustomDirEntry[] {
   const base = root ?? workspacePath;
   const filePath = path.join(base, CONFIG_FILE);
   try {
-    if (!fs.existsSync(filePath)) return [];
-    const raw = fs.readFileSync(filePath, "utf-8");
+    if (!existsSync(filePath)) return [];
+    const raw = readFileSync(filePath, "utf-8");
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) {
       log.warn("custom-dirs", "workspace-dirs.json is not an array");
@@ -132,7 +132,7 @@ export function loadCustomDirs(root?: string): CustomDirEntry[] {
 export function saveCustomDirs(entries: readonly CustomDirEntry[], root?: string): void {
   const base = root ?? workspacePath;
   const filePath = path.join(base, CONFIG_FILE);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
   invalidateCache();
 }
@@ -186,7 +186,7 @@ export function ensureCustomDirs(entries: readonly CustomDirEntry[], root?: stri
   const base = root ?? workspacePath;
   for (const entry of entries) {
     const dirPath = path.join(base, entry.path);
-    fs.mkdirSync(dirPath, { recursive: true });
+    mkdirSync(dirPath, { recursive: true });
   }
 }
 

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -21,7 +21,7 @@
 // `WORKSPACE_DIRS` record below. The absolute path is derived
 // automatically via `WORKSPACE_PATHS`.
 
-import os from "os";
+import { homedir } from "os";
 import path from "path";
 
 // Workspace root. Hard-coded to `~/mulmoclaude` — there is no
@@ -29,7 +29,7 @@ import path from "path";
 // requires a code edit or a symlink. Re-exported by
 // `server/workspace.ts` for backwards compatibility of existing
 // callers that `import { workspacePath } from "./workspace.js"`.
-export const workspacePath = path.join(os.homedir(), "mulmoclaude");
+export const workspacePath = path.join(homedir(), "mulmoclaude");
 
 // Workspace-relative paths. Keys are the stable code-side identifiers
 // (e.g. `markdowns` — unchanged for call-site compatibility); values
@@ -90,7 +90,7 @@ import { WORKSPACE_FILES } from "../../src/config/workspacePaths.js";
 export { WORKSPACE_FILES };
 
 // Absolute paths, built once at module load from `workspacePath`.
-// The `workspacePath` const is itself fixed (reads `os.homedir()`
+// The `workspacePath` const is itself fixed (reads `homedir()`
 // at process start — no env override, see `server/workspace.ts`),
 // so freezing these paths is safe.
 export const WORKSPACE_PATHS = {

--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -8,7 +8,7 @@
 
 import { createHash } from "crypto";
 import path from "path";
-import os from "os";
+import { homedir } from "os";
 import { log } from "../system/logger/index.js";
 import { readReferenceDirsJson, writeReferenceDirsJson, isExistingDirectory } from "../utils/files/reference-dirs-io.js";
 import { isRecord } from "../utils/types.js";
@@ -41,7 +41,7 @@ const CONTROL_CHAR_RE_G = /[\x00-\x1f]/g;
 
 function expandHome(inputPath: string): string {
   if (inputPath.startsWith("~/")) {
-    return path.join(os.homedir(), inputPath.slice(2));
+    return path.join(homedir(), inputPath.slice(2));
   }
   return inputPath;
 }
@@ -52,7 +52,7 @@ function isSensitivePath(absPath: string): boolean {
   // Reject filesystem root
   if (normalized === path.parse(normalized).root) return true;
 
-  const home = os.homedir();
+  const home = homedir();
 
   // Block $HOME itself (transitively exposes .ssh etc.)
   if (normalized === home) return true;

--- a/server/workspace/sources/arxivDiscovery.ts
+++ b/server/workspace/sources/arxivDiscovery.ts
@@ -16,7 +16,7 @@ import { workspacePath } from "../paths.js";
 import { log } from "../../system/logger/index.js";
 import { slugify } from "../../utils/slug.js";
 import type { Source } from "./types.js";
-import fs from "fs";
+import { mkdirSync } from "fs";
 
 // ── Constants ───────────────────────────────────────────────────
 
@@ -88,7 +88,7 @@ export async function discoverAndRegister(root?: string): Promise<DiscoveryResul
 
   // Ensure sources directory exists
   const dir = sourcesRoot(base);
-  fs.mkdirSync(dir, { recursive: true });
+  mkdirSync(dir, { recursive: true });
 
   const existing = await listSources(base);
   const existingSlugs = new Set(existing.map((source) => source.slug));

--- a/server/workspace/sources/interests.ts
+++ b/server/workspace/sources/interests.ts
@@ -4,7 +4,7 @@
 // during conversation when it detects user interest in a topic.
 // The pipeline's notify phase uses it to score and filter articles.
 
-import fs from "fs";
+import { existsSync, readFileSync } from "fs";
 import path from "path";
 import { workspacePath } from "../paths.js";
 import { log } from "../../system/logger/index.js";
@@ -41,8 +41,8 @@ export function loadInterests(root?: string): InterestsProfile | null {
   const base = root ?? workspacePath;
   const filePath = path.join(base, CONFIG_FILE);
   try {
-    if (!fs.existsSync(filePath)) return null;
-    const raw = fs.readFileSync(filePath, "utf-8");
+    if (!existsSync(filePath)) return null;
+    const raw = readFileSync(filePath, "utf-8");
     const parsed: unknown = JSON.parse(raw);
     return validateInterests(parsed);
   } catch (err) {

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import fs from "fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { log } from "../system/logger/index.js";
@@ -16,12 +16,12 @@ const TEMPLATES_DIR = path.join(__dirname, "helps");
 export { workspacePath };
 
 // Must exist before downstream modules call realpathSync(workspacePath) at their own module-load time.
-fs.mkdirSync(workspacePath, { recursive: true });
+mkdirSync(workspacePath, { recursive: true });
 
 export function initWorkspace(): string {
   // Create directory structure if needed
   for (const key of EAGER_WORKSPACE_DIRS) {
-    fs.mkdirSync(WORKSPACE_PATHS[key], { recursive: true });
+    mkdirSync(WORKSPACE_PATHS[key], { recursive: true });
   }
 
   // Create memory.md if it doesn't exist
@@ -30,9 +30,9 @@ export function initWorkspace(): string {
   }
 
   // Always sync all files from server/helps/ into workspace/helps/
-  fs.mkdirSync(WORKSPACE_PATHS.helps, { recursive: true });
-  for (const file of fs.readdirSync(TEMPLATES_DIR)) {
-    fs.copyFileSync(path.join(TEMPLATES_DIR, file), path.join(WORKSPACE_PATHS.helps, file));
+  mkdirSync(WORKSPACE_PATHS.helps, { recursive: true });
+  for (const file of readdirSync(TEMPLATES_DIR)) {
+    copyFileSync(path.join(TEMPLATES_DIR, file), path.join(WORKSPACE_PATHS.helps, file));
   }
 
   // Create .gitignore if missing. The workspace is a git repo for
@@ -56,7 +56,7 @@ export function initWorkspace(): string {
 
   // Git init if not already a repo
   const gitDir = path.join(workspacePath, ".git");
-  if (!fs.existsSync(gitDir)) {
+  if (!existsSync(gitDir)) {
     execSync("git init", { cwd: workspacePath });
     log.info("workspace", "initialized git repository", { workspacePath });
   }

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -8,7 +8,7 @@
 // reads `typeof en` to feed `DefineLocaleMessage`, and readonly literal
 // types would conflict with vue-i18n's writable message interface.
 
-const en = {
+const enMessages = {
   common: {
     save: "Save",
     cancel: "Cancel",
@@ -53,4 +53,4 @@ const en = {
   },
 };
 
-export default en;
+export default enMessages;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1,7 +1,7 @@
 // Japanese dictionary. Mirror the shape of src/lang/en.ts —
 // missing keys fall back to English per createI18n's fallbackLocale.
 
-const ja = {
+const jaMessages = {
   common: {
     save: "保存",
     cancel: "キャンセル",
@@ -46,4 +46,4 @@ const ja = {
   },
 };
 
-export default ja;
+export default jaMessages;

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -10,15 +10,15 @@
 // the Options API `this.$t`. CLAUDE.md mandates Composition API.
 
 import { createI18n } from "vue-i18n";
-import en from "../lang/en";
-import ja from "../lang/ja";
+import enMessages from "../lang/en";
+import jaMessages from "../lang/ja";
 
 // Schema generic on createI18n — this is what makes `t("common.save")`
 // calls across the whole app compile-time checked (the module
 // augmentation in src/types/vue-i18n.d.ts alone is not enough; vue-i18n
 // v11's `t` overloads still fall back to `string` unless the schema is
 // threaded through here).
-type MessageSchema = typeof en;
+type MessageSchema = typeof enMessages;
 type Locale = "en" | "ja";
 
 const locale = (import.meta.env.VITE_LOCALE ?? "en") as Locale;
@@ -27,7 +27,7 @@ const i18n = createI18n<[MessageSchema], Locale>({
   legacy: false,
   locale,
   fallbackLocale: "en",
-  messages: { en, ja },
+  messages: { en: enMessages, ja: jaMessages },
 });
 
 export default i18n;

--- a/src/types/vue-i18n.d.ts
+++ b/src/types/vue-i18n.d.ts
@@ -8,11 +8,11 @@
 // site may still compile. Autocomplete is the main value; strict
 // rejection of unknown keys would require a bespoke wrapper.
 
-import en from "../lang/en";
+import enMessages from "../lang/en";
 
 // Alias so `extends` has an interface-shaped base (typeof in extends
 // position is a syntax error).
-type EnMessages = typeof en;
+type EnMessages = typeof enMessages;
 
 declare module "vue-i18n" {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -358,9 +358,9 @@ describe("prepareUserServers", () => {
       },
     };
     const out = prepareUserServers(servers, true, hostWs);
-    const fs = out.fs;
-    assert.ok(fs && fs.type === "stdio");
-    assert.deepEqual(fs.args, ["-y", "@modelcontextprotocol/server-filesystem", `${CONTAINER_WORKSPACE_PATH}/docs`]);
+    const fsSpec = out.fs;
+    assert.ok(fsSpec && fsSpec.type === "stdio");
+    assert.deepEqual(fsSpec.args, ["-y", "@modelcontextprotocol/server-filesystem", `${CONTAINER_WORKSPACE_PATH}/docs`]);
   });
 
   it("leaves non-workspace stdio args untouched (caller warns in UI)", async () => {

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import fs from "node:fs";
-import os from "node:os";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import {
   buildAllowedConfigMounts,
   resolveMountNames,
@@ -15,14 +15,14 @@ import {
 // the developer running CI actually has ~/.config/gh or a ~/.gitconfig.
 
 function makeFixtureHome(opts: { gh?: boolean; gitconfig?: boolean }): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-mounts-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "sandbox-mounts-"));
   if (opts.gh) {
     const ghDir = path.join(dir, ".config", "gh");
-    fs.mkdirSync(ghDir, { recursive: true });
-    fs.writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
+    mkdirSync(ghDir, { recursive: true });
+    writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
   }
   if (opts.gitconfig) {
-    fs.writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
+    writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
   }
   return dir;
 }
@@ -81,8 +81,8 @@ describe("resolveMountNames", () => {
   it("rejects dir when host path is a file and vice versa", () => {
     const home = makeFixtureHome({ gh: false, gitconfig: false });
     // Place a FILE where gh expects a DIR.
-    fs.mkdirSync(path.join(home, ".config"), { recursive: true });
-    fs.writeFileSync(path.join(home, ".config", "gh"), "oops");
+    mkdirSync(path.join(home, ".config"), { recursive: true });
+    writeFileSync(path.join(home, ".config", "gh"), "oops");
     const out = resolveMountNames(["gh"], buildAllowedConfigMounts(home));
     assert.equal(out.resolved.length, 0);
     assert.equal(out.missing.length, 1);
@@ -146,8 +146,8 @@ describe("sshAgentForwardArgs", () => {
   });
 
   it("binds socket and sets SSH_AUTH_SOCK when sock exists (Linux)", () => {
-    const fake = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "sock-")), "agent.sock");
-    fs.writeFileSync(fake, "");
+    const fake = path.join(mkdtempSync(path.join(tmpdir(), "sock-")), "agent.sock");
+    writeFileSync(fake, "");
     const result = sshAgentForwardArgs(true, fake, "linux");
     assert.equal(result.skippedReason, null);
     const expectedHostPath = fake.replace(/\\/g, "/");

--- a/test/api/test_sandboxStatus.ts
+++ b/test/api/test_sandboxStatus.ts
@@ -1,22 +1,22 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import fs from "node:fs";
-import os from "node:os";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { buildSandboxStatus } from "../../server/api/sandboxStatus.js";
 
 // Isolated fixture home so the tests don't depend on the developer
 // actually having ~/.config/gh or a ~/.gitconfig locally. Shares the
 // same pattern as test_sandboxMounts.ts.
 function makeFixtureHome(opts: { gh?: boolean; gitconfig?: boolean }): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-status-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "sandbox-status-"));
   if (opts.gh) {
     const ghDir = path.join(dir, ".config", "gh");
-    fs.mkdirSync(ghDir, { recursive: true });
-    fs.writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
+    mkdirSync(ghDir, { recursive: true });
+    writeFileSync(path.join(ghDir, "hosts.yml"), "github.com:\n");
   }
   if (opts.gitconfig) {
-    fs.writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
+    writeFileSync(path.join(dir, ".gitconfig"), "[user]\n  name = t\n");
   }
   return dir;
 }
@@ -24,9 +24,9 @@ function makeFixtureHome(opts: { gh?: boolean; gitconfig?: boolean }): string {
 // Real socket is awkward to stand up in tests; a regular file is
 // enough since sshAgentForwardArgs only needs `existsSync` to pass.
 function makeFakeSocket(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-status-sock-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "sandbox-status-sock-"));
   const sock = path.join(dir, "agent.sock");
-  fs.writeFileSync(sock, "");
+  writeFileSync(sock, "");
   return sock;
 }
 

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 // Helper: seed a session jsonl + matching meta file so the indexer
 // has something real to read. Returns the session id.
 function seedSession(
-  id: string,
+  sessionId: string,
   opts: {
     roleId?: string;
     startedAt?: string;
@@ -37,7 +37,7 @@ function seedSession(
     assistantMessages = ["Sure — tell me what it's about."],
   } = opts;
   const chatDir = join(workspace, "chat");
-  writeFileSync(join(chatDir, `${id}.json`), JSON.stringify({ roleId, startedAt }));
+  writeFileSync(join(chatDir, `${sessionId}.json`), JSON.stringify({ roleId, startedAt }));
   const lines: string[] = [];
   for (let i = 0; i < Math.max(userMessages.length, assistantMessages.length); i++) {
     if (userMessages[i] !== undefined) {
@@ -59,8 +59,8 @@ function seedSession(
       );
     }
   }
-  writeFileSync(join(chatDir, `${id}.jsonl`), lines.join("\n") + "\n");
-  return id;
+  writeFileSync(join(chatDir, `${sessionId}.jsonl`), lines.join("\n") + "\n");
+  return sessionId;
 }
 
 // Helper: build a stub summarize function that records calls and

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -21,16 +21,16 @@ afterEach(() => {
   rmSync(workspace, { recursive: true, force: true });
 });
 
-function seedSession(id: string): void {
+function seedSession(sessionId: string): void {
   const chatDir = join(workspace, "chat");
   writeFileSync(
-    join(chatDir, `${id}.json`),
+    join(chatDir, `${sessionId}.json`),
     JSON.stringify({
       roleId: "general",
       startedAt: "2026-04-12T10:00:00.000Z",
     }),
   );
-  writeFileSync(join(chatDir, `${id}.jsonl`), JSON.stringify({ source: "user", type: "text", message: "hello" }) + "\n");
+  writeFileSync(join(chatDir, `${sessionId}.jsonl`), JSON.stringify({ source: "user", type: "text", message: "hello" }) + "\n");
 }
 
 function stubSummarize(

--- a/test/chat-index/test_paths.ts
+++ b/test/chat-index/test_paths.ts
@@ -47,8 +47,8 @@ describe("sessionJsonlPathFor", () => {
   });
 
   it("handles UUID-style session IDs", () => {
-    const id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
-    assert.equal(sessionJsonlPathFor(workspace, id), path.join(workspace, "chat", `${id}.jsonl`));
+    const sessionId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    assert.equal(sessionJsonlPathFor(workspace, sessionId), path.join(workspace, "chat", `${sessionId}.jsonl`));
   });
 });
 

--- a/test/composables/test_useImeAwareEnter.ts
+++ b/test/composables/test_useImeAwareEnter.ts
@@ -37,8 +37,8 @@ function setup() {
   return {
     handlers,
     sends,
-    advance(ms: number) {
-      nowValue += ms;
+    advance(delayMs: number) {
+      nowValue += delayMs;
     },
     now() {
       return nowValue;

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -40,8 +40,8 @@ interface SummaryRow {
   preview: string;
 }
 
-function row(id: string, updatedAt = ""): SummaryRow {
-  return { id, roleId: "general", startedAt: "", updatedAt, preview: "" };
+function row(sessionId: string, updatedAt = ""): SummaryRow {
+  return { id: sessionId, roleId: "general", startedAt: "", updatedAt, preview: "" };
 }
 
 function envelope(sessions: SummaryRow[], cursor: string, deletedIds: string[] = []) {

--- a/test/events/test_scheduler_overrides.ts
+++ b/test/events/test_scheduler_overrides.ts
@@ -2,11 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { loadSchedulerOverrides } from "../../server/utils/files/scheduler-overrides-io.js";
 
 function makeTmpDir(): string {
-  return mkdtempSync(path.join(os.tmpdir(), "sched-override-test-"));
+  return mkdtempSync(path.join(tmpdir(), "sched-override-test-"));
 }
 
 describe("loadSchedulerOverrides", () => {

--- a/test/journal/test_appendOrCreate.ts
+++ b/test/journal/test_appendOrCreate.ts
@@ -1,22 +1,22 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import { WORKSPACE_DIRS } from "../../server/workspace/paths.js";
 import { appendOrCreateTopic } from "../../server/utils/files/journal-io.js";
 
 function makeWorkspace(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmoclaude-aoc-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "mulmoclaude-aoc-"));
   // Create the summaries/topics/ dir inside the workspace root
-  fs.mkdirSync(path.join(dir, WORKSPACE_DIRS.summaries, "topics"), {
+  mkdirSync(path.join(dir, WORKSPACE_DIRS.summaries, "topics"), {
     recursive: true,
   });
-  return fs.realpathSync(dir);
+  return realpathSync(dir);
 }
 
 function rmDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  rmSync(dir, { recursive: true, force: true });
 }
 
 function topicPath(root: string, slug: string): string {
@@ -33,27 +33,27 @@ describe("appendOrCreateTopic — happy paths", () => {
   it("writes a fresh file when missing and reports 'created'", async () => {
     const outcome = await appendOrCreateTopic("topic-a", "first line", root);
     assert.equal(outcome, "created");
-    assert.equal(fs.readFileSync(topicPath(root, "topic-a"), "utf-8"), "first line");
+    assert.equal(readFileSync(topicPath(root, "topic-a"), "utf-8"), "first line");
   });
 
   it("appends with a blank-line separator and reports 'updated'", async () => {
-    fs.writeFileSync(topicPath(root, "topic-b"), "existing line");
+    writeFileSync(topicPath(root, "topic-b"), "existing line");
     const outcome = await appendOrCreateTopic("topic-b", "new line", root);
     assert.equal(outcome, "updated");
-    assert.equal(fs.readFileSync(topicPath(root, "topic-b"), "utf-8"), "existing line\n\nnew line\n");
+    assert.equal(readFileSync(topicPath(root, "topic-b"), "utf-8"), "existing line\n\nnew line\n");
   });
 
   it("trims trailing whitespace from existing content before appending", async () => {
-    fs.writeFileSync(topicPath(root, "topic-c"), "existing\n\n\n");
+    writeFileSync(topicPath(root, "topic-c"), "existing\n\n\n");
     await appendOrCreateTopic("topic-c", "added", root);
-    assert.equal(fs.readFileSync(topicPath(root, "topic-c"), "utf-8"), "existing\n\nadded\n");
+    assert.equal(readFileSync(topicPath(root, "topic-c"), "utf-8"), "existing\n\nadded\n");
   });
 
   it("appends correctly across multiple calls", async () => {
     await appendOrCreateTopic("topic-d", "one", root);
     await appendOrCreateTopic("topic-d", "two", root);
     await appendOrCreateTopic("topic-d", "three", root);
-    assert.equal(fs.readFileSync(topicPath(root, "topic-d"), "utf-8"), "one\n\ntwo\n\nthree\n");
+    assert.equal(readFileSync(topicPath(root, "topic-d"), "utf-8"), "one\n\ntwo\n\nthree\n");
   });
 });
 
@@ -64,7 +64,7 @@ describe("appendOrCreateTopic — non-ENOENT read errors", () => {
   });
   after(() => {
     try {
-      fs.chmodSync(root, 0o755);
+      chmodSync(root, 0o755);
     } catch {
       /* ignore */
     }
@@ -77,15 +77,15 @@ describe("appendOrCreateTopic — non-ENOENT read errors", () => {
       return;
     }
     const lockPath = topicPath(root, "locked");
-    fs.writeFileSync(lockPath, "important content");
-    fs.chmodSync(lockPath, 0o000);
+    writeFileSync(lockPath, "important content");
+    chmodSync(lockPath, 0o000);
     try {
       await assert.rejects(() => appendOrCreateTopic("locked", "would clobber", root), /EACCES|EPERM/);
-      fs.chmodSync(lockPath, 0o644);
-      assert.equal(fs.readFileSync(lockPath, "utf-8"), "important content");
+      chmodSync(lockPath, 0o644);
+      assert.equal(readFileSync(lockPath, "utf-8"), "important content");
     } finally {
       try {
-        fs.chmodSync(lockPath, 0o644);
+        chmodSync(lockPath, 0o644);
       } catch {
         /* ignore */
       }

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -366,8 +366,8 @@ describe("parseArchivistOutput", () => {
 });
 
 describe("computeJustCompletedSessions", () => {
-  function makeMeta(id: string, mtimeMs = 100): SessionFileMeta {
-    return { id, mtimeMs };
+  function makeMeta(sessionId: string, mtimeMs = 100): SessionFileMeta {
+    return { id: sessionId, mtimeMs };
   }
 
   it("marks a session complete when this day is its only remaining one", () => {

--- a/test/journal/test_indexFile.ts
+++ b/test/journal/test_indexFile.ts
@@ -64,8 +64,8 @@ describe("buildIndexMarkdown", () => {
         topics: [{ slug: "video-generation", title: "Video Generation" }, { slug: "bare-slug" }],
       }),
     );
-    assert.match(out, /\[Video Generation\]\(topics\/video-generation\.md\)/);
-    assert.match(out, /\[bare-slug\]\(topics\/bare-slug\.md\)/);
+    assert.match(out, /\[Video Generation\]\(topics\/video-generation\.markdown\)/);
+    assert.match(out, /\[bare-slug\]\(topics\/bare-slug\.markdown\)/);
   });
 
   it("sorts daily entries newest-first", () => {
@@ -110,7 +110,7 @@ describe("buildIndexMarkdown", () => {
 
   it("renders daily row with nested YYYY/MM/DD path", () => {
     const out = buildIndexMarkdown(baseInput({ days: [{ date: "2026-04-11" }] }));
-    assert.match(out, /\[2026-04-11\]\(daily\/2026\/04\/11\.md\)/);
+    assert.match(out, /\[2026-04-11\]\(daily\/2026\/04\/11\.markdown\)/);
   });
 });
 
@@ -193,20 +193,20 @@ describe("topic sort order (compareTopicsNewestFirst)", () => {
   };
 
   it("sorts topics newest first", () => {
-    const md = buildIndexMarkdown({
+    const markdown = buildIndexMarkdown({
       ...BASE,
       topics: [
         { slug: "old", title: "Old", lastUpdatedIso: "2026-01-01T00:00:00Z" },
         { slug: "new", title: "New", lastUpdatedIso: "2026-04-12T00:00:00Z" },
       ],
     });
-    const newIdx = md.indexOf("New");
-    const oldIdx = md.indexOf("Old");
+    const newIdx = markdown.indexOf("New");
+    const oldIdx = markdown.indexOf("Old");
     assert.ok(newIdx < oldIdx, "New should come before Old");
   });
 
   it("topics without timestamps sort after those with timestamps", () => {
-    const md = buildIndexMarkdown({
+    const markdown = buildIndexMarkdown({
       ...BASE,
       topics: [
         { slug: "no-time", title: "No Time" },
@@ -217,13 +217,13 @@ describe("topic sort order (compareTopicsNewestFirst)", () => {
         },
       ],
     });
-    const hasIdx = md.indexOf("Has Time");
-    const noIdx = md.indexOf("No Time");
+    const hasIdx = markdown.indexOf("Has Time");
+    const noIdx = markdown.indexOf("No Time");
     assert.ok(hasIdx < noIdx, "Has Time should come before No Time");
   });
 
   it("same timestamp → sorted by slug for determinism", () => {
-    const md = buildIndexMarkdown({
+    const markdown = buildIndexMarkdown({
       ...BASE,
       topics: [
         {
@@ -238,8 +238,8 @@ describe("topic sort order (compareTopicsNewestFirst)", () => {
         },
       ],
     });
-    const alphaIdx = md.indexOf("Alpha");
-    const zebraIdx = md.indexOf("Zebra");
+    const alphaIdx = markdown.indexOf("Alpha");
+    const zebraIdx = markdown.indexOf("Zebra");
     assert.ok(alphaIdx < zebraIdx, "Alpha should come before Zebra");
   });
 });

--- a/test/journal/test_indexFile.ts
+++ b/test/journal/test_indexFile.ts
@@ -64,8 +64,8 @@ describe("buildIndexMarkdown", () => {
         topics: [{ slug: "video-generation", title: "Video Generation" }, { slug: "bare-slug" }],
       }),
     );
-    assert.match(out, /\[Video Generation\]\(topics\/video-generation\.markdown\)/);
-    assert.match(out, /\[bare-slug\]\(topics\/bare-slug\.markdown\)/);
+    assert.match(out, /\[Video Generation\]\(topics\/video-generation\.md\)/);
+    assert.match(out, /\[bare-slug\]\(topics\/bare-slug\.md\)/);
   });
 
   it("sorts daily entries newest-first", () => {
@@ -110,7 +110,7 @@ describe("buildIndexMarkdown", () => {
 
   it("renders daily row with nested YYYY/MM/DD path", () => {
     const out = buildIndexMarkdown(baseInput({ days: [{ date: "2026-04-11" }] }));
-    assert.match(out, /\[2026-04-11\]\(daily\/2026\/04\/11\.markdown\)/);
+    assert.match(out, /\[2026-04-11\]\(daily\/2026\/04\/11\.md\)/);
   });
 });
 

--- a/test/journal/test_linkRewrite.ts
+++ b/test/journal/test_linkRewrite.ts
@@ -4,79 +4,90 @@ import { rewriteWorkspaceLinks, rewriteMarkdownLinks } from "../../server/worksp
 
 describe("rewriteWorkspaceLinks", () => {
   it("rewrites a workspace-absolute link from a topic file", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/refactoring.md", "See [wiki](/wiki/pages/foo.md) for details.");
-    assert.equal(out, "See [wiki](../../wiki/pages/foo.md) for details.");
+    const out = rewriteWorkspaceLinks("summaries/topics/refactoring.markdown", "See [wiki](/wiki/pages/foo.markdown) for details.");
+    assert.equal(out, "See [wiki](../../wiki/pages/foo.markdown) for details.");
   });
 
   it("rewrites from a nested daily file", () => {
-    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.md", "Today: [html](/HTMLs/report.html)");
+    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.markdown", "Today: [html](/HTMLs/report.html)");
     assert.equal(out, "Today: [html](../../../../HTMLs/report.html)");
   });
 
   it("leaves true-relative links alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [other](../daily/2026/04/11.md)");
-    assert.equal(out, "See [other](../daily/2026/04/11.md)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [other](../daily/2026/04/11.markdown)");
+    assert.equal(out, "See [other](../daily/2026/04/11.markdown)");
   });
 
   it("leaves external URLs alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [docs](https://example.com/foo)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [docs](https://example.com/foo)");
     assert.equal(out, "See [docs](https://example.com/foo)");
   });
 
   it("leaves protocol-relative URLs alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [cdn](//cdn.example.com/foo)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [cdn](//cdn.example.com/foo)");
     assert.equal(out, "See [cdn](//cdn.example.com/foo)");
   });
 
   it("leaves anchor-only links alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "Jump to [section](#details)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "Jump to [section](#details)");
     assert.equal(out, "Jump to [section](#details)");
   });
 
   it("preserves #fragment on rewritten links", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [wiki heading](/wiki/pages/foo.md#section-2)");
-    assert.equal(out, "See [wiki heading](../../wiki/pages/foo.md#section-2)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [wiki heading](/wiki/pages/foo.markdown#section-2)");
+    assert.equal(out, "See [wiki heading](../../wiki/pages/foo.markdown#section-2)");
   });
 
   it("handles multiple links in one document", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[a](/wiki/a.md) and [b](/wiki/b.md) and [c](https://x.com) and [d](../bar.md)");
-    assert.equal(out, "[a](../../wiki/a.md) and [b](../../wiki/b.md) and [c](https://x.com) and [d](../bar.md)");
+    const out = rewriteWorkspaceLinks(
+      "summaries/topics/foo.markdown",
+      "[a](/wiki/a.markdown) and [b](/wiki/b.markdown) and [c](https://x.com) and [d](../bar.markdown)",
+    );
+    assert.equal(out, "[a](../../wiki/a.markdown) and [b](../../wiki/b.markdown) and [c](https://x.com) and [d](../bar.markdown)");
   });
 
   it("handles a link at the start of a line", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "- [wiki](/wiki/foo.md) — updated today");
-    assert.equal(out, "- [wiki](../../wiki/foo.md) — updated today");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "- [wiki](/wiki/foo.markdown) — updated today");
+    assert.equal(out, "- [wiki](../../wiki/foo.markdown) — updated today");
   });
 
   it("handles markdown headings and prose around links", () => {
-    const md = ["# Title", "", "Some [link](/wiki/pages/topic.md) in prose.", "", "## Subheading", "", "- bullet [two](/HTMLs/report.html) here"].join("\n");
-    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.md", md);
-    assert.match(out, /\[link\]\(\.\.\/\.\.\/\.\.\/\.\.\/wiki\/pages\/topic\.md\)/);
+    const markdown = [
+      "# Title",
+      "",
+      "Some [link](/wiki/pages/topic.markdown) in prose.",
+      "",
+      "## Subheading",
+      "",
+      "- bullet [two](/HTMLs/report.html) here",
+    ].join("\n");
+    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.markdown", markdown);
+    assert.match(out, /\[link\]\(\.\.\/\.\.\/\.\.\/\.\.\/wiki\/pages\/topic\.markdown\)/);
     assert.match(out, /\[two\]\(\.\.\/\.\.\/\.\.\/\.\.\/HTMLs\/report\.html\)/);
   });
 
   it("does not touch square brackets that are not links", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "TODO item: [x] done, [ ] pending");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "TODO item: [x] done, [ ] pending");
     assert.equal(out, "TODO item: [x] done, [ ] pending");
   });
 
   it("handles '/' (root) href by returning '.' relative", () => {
     // Edge case: link to the workspace root itself. Not useful in
     // practice but must not crash.
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[root](/)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[root](/)");
     assert.equal(out, "[root](/)");
   });
 
   it("emits '.' for a self-reference", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[self](/summaries/topics/foo.md)");
-    // relative from "summaries/topics" to "summaries/topics/foo.md"
-    // is "foo.md" — not a self-reference; let me rewrite the test.
-    assert.equal(out, "[self](foo.md)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[self](/summaries/topics/foo.markdown)");
+    // relative from "summaries/topics" to "summaries/topics/foo.markdown"
+    // is "foo.markdown" — not a self-reference; let me rewrite the test.
+    assert.equal(out, "[self](foo.markdown)");
   });
 
   it("emits '.' when target equals current directory", () => {
-    // current = "summaries/topics/foo.md", link to "/summaries/topics"
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[dir](/summaries/topics)");
+    // current = "summaries/topics/foo.markdown", link to "/summaries/topics"
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[dir](/summaries/topics)");
     assert.equal(out, "[dir](.)");
   });
 });

--- a/test/journal/test_linkRewrite.ts
+++ b/test/journal/test_linkRewrite.ts
@@ -4,90 +4,81 @@ import { rewriteWorkspaceLinks, rewriteMarkdownLinks } from "../../server/worksp
 
 describe("rewriteWorkspaceLinks", () => {
   it("rewrites a workspace-absolute link from a topic file", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/refactoring.markdown", "See [wiki](/wiki/pages/foo.markdown) for details.");
-    assert.equal(out, "See [wiki](../../wiki/pages/foo.markdown) for details.");
+    const out = rewriteWorkspaceLinks("summaries/topics/refactoring.md", "See [wiki](/wiki/pages/foo.md) for details.");
+    assert.equal(out, "See [wiki](../../wiki/pages/foo.md) for details.");
   });
 
   it("rewrites from a nested daily file", () => {
-    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.markdown", "Today: [html](/HTMLs/report.html)");
+    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.md", "Today: [html](/HTMLs/report.html)");
     assert.equal(out, "Today: [html](../../../../HTMLs/report.html)");
   });
 
   it("leaves true-relative links alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [other](../daily/2026/04/11.markdown)");
-    assert.equal(out, "See [other](../daily/2026/04/11.markdown)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [other](../daily/2026/04/11.md)");
+    assert.equal(out, "See [other](../daily/2026/04/11.md)");
   });
 
   it("leaves external URLs alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [docs](https://example.com/foo)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [docs](https://example.com/foo)");
     assert.equal(out, "See [docs](https://example.com/foo)");
   });
 
   it("leaves protocol-relative URLs alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [cdn](//cdn.example.com/foo)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [cdn](//cdn.example.com/foo)");
     assert.equal(out, "See [cdn](//cdn.example.com/foo)");
   });
 
   it("leaves anchor-only links alone", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "Jump to [section](#details)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "Jump to [section](#details)");
     assert.equal(out, "Jump to [section](#details)");
   });
 
   it("preserves #fragment on rewritten links", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "See [wiki heading](/wiki/pages/foo.markdown#section-2)");
-    assert.equal(out, "See [wiki heading](../../wiki/pages/foo.markdown#section-2)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "See [wiki heading](/wiki/pages/foo.md#section-2)");
+    assert.equal(out, "See [wiki heading](../../wiki/pages/foo.md#section-2)");
   });
 
   it("handles multiple links in one document", () => {
-    const out = rewriteWorkspaceLinks(
-      "summaries/topics/foo.markdown",
-      "[a](/wiki/a.markdown) and [b](/wiki/b.markdown) and [c](https://x.com) and [d](../bar.markdown)",
-    );
-    assert.equal(out, "[a](../../wiki/a.markdown) and [b](../../wiki/b.markdown) and [c](https://x.com) and [d](../bar.markdown)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[a](/wiki/a.md) and [b](/wiki/b.md) and [c](https://x.com) and [d](../bar.md)");
+    assert.equal(out, "[a](../../wiki/a.md) and [b](../../wiki/b.md) and [c](https://x.com) and [d](../bar.md)");
   });
 
   it("handles a link at the start of a line", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "- [wiki](/wiki/foo.markdown) — updated today");
-    assert.equal(out, "- [wiki](../../wiki/foo.markdown) — updated today");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "- [wiki](/wiki/foo.md) — updated today");
+    assert.equal(out, "- [wiki](../../wiki/foo.md) — updated today");
   });
 
   it("handles markdown headings and prose around links", () => {
-    const markdown = [
-      "# Title",
-      "",
-      "Some [link](/wiki/pages/topic.markdown) in prose.",
-      "",
-      "## Subheading",
-      "",
-      "- bullet [two](/HTMLs/report.html) here",
-    ].join("\n");
-    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.markdown", markdown);
-    assert.match(out, /\[link\]\(\.\.\/\.\.\/\.\.\/\.\.\/wiki\/pages\/topic\.markdown\)/);
+    const markdown = ["# Title", "", "Some [link](/wiki/pages/topic.md) in prose.", "", "## Subheading", "", "- bullet [two](/HTMLs/report.html) here"].join(
+      "\n",
+    );
+    const out = rewriteWorkspaceLinks("summaries/daily/2026/04/11.md", markdown);
+    assert.match(out, /\[link\]\(\.\.\/\.\.\/\.\.\/\.\.\/wiki\/pages\/topic\.md\)/);
     assert.match(out, /\[two\]\(\.\.\/\.\.\/\.\.\/\.\.\/HTMLs\/report\.html\)/);
   });
 
   it("does not touch square brackets that are not links", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "TODO item: [x] done, [ ] pending");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "TODO item: [x] done, [ ] pending");
     assert.equal(out, "TODO item: [x] done, [ ] pending");
   });
 
   it("handles '/' (root) href by returning '.' relative", () => {
     // Edge case: link to the workspace root itself. Not useful in
     // practice but must not crash.
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[root](/)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[root](/)");
     assert.equal(out, "[root](/)");
   });
 
   it("emits '.' for a self-reference", () => {
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[self](/summaries/topics/foo.markdown)");
-    // relative from "summaries/topics" to "summaries/topics/foo.markdown"
-    // is "foo.markdown" — not a self-reference; let me rewrite the test.
-    assert.equal(out, "[self](foo.markdown)");
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[self](/summaries/topics/foo.md)");
+    // relative from "summaries/topics" to "summaries/topics/foo.md"
+    // is "foo.md" — not a self-reference; let me rewrite the test.
+    assert.equal(out, "[self](foo.md)");
   });
 
   it("emits '.' when target equals current directory", () => {
-    // current = "summaries/topics/foo.markdown", link to "/summaries/topics"
-    const out = rewriteWorkspaceLinks("summaries/topics/foo.markdown", "[dir](/summaries/topics)");
+    // current = "summaries/topics/foo.md", link to "/summaries/topics"
+    const out = rewriteWorkspaceLinks("summaries/topics/foo.md", "[dir](/summaries/topics)");
     assert.equal(out, "[dir](.)");
   });
 });

--- a/test/logger/test_rotation.ts
+++ b/test/logger/test_rotation.ts
@@ -1,7 +1,7 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readdir, rm, writeFile } from "fs/promises";
-import os from "os";
+import { tmpdir } from "os";
 import path from "path";
 import { dailyFileName, enforceMaxFiles, listLogFiles } from "../../server/system/logger/rotation.js";
 
@@ -19,7 +19,7 @@ describe("listLogFiles / enforceMaxFiles", () => {
   let dir: string;
 
   before(async () => {
-    dir = await mkdtemp(path.join(os.tmpdir(), "log-rot-"));
+    dir = await mkdtemp(path.join(tmpdir(), "log-rot-"));
   });
 
   after(async () => {

--- a/test/logger/test_sinks.ts
+++ b/test/logger/test_sinks.ts
@@ -1,7 +1,7 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, readdir, rm, writeFile } from "fs/promises";
-import os from "os";
+import { tmpdir } from "os";
 import path from "path";
 import { createFileSink } from "../../server/system/logger/sinks.js";
 import type { LogRecord } from "../../server/system/logger/types.js";
@@ -20,7 +20,7 @@ describe("createFileSink", () => {
   let dir: string;
 
   before(async () => {
-    dir = await mkdtemp(path.join(os.tmpdir(), "log-sink-"));
+    dir = await mkdtemp(path.join(tmpdir(), "log-sink-"));
   });
 
   after(async () => {
@@ -51,7 +51,7 @@ describe("createFileSink", () => {
   });
 
   it("rotates to a new file when the UTC day changes", async () => {
-    const rotDir = await mkdtemp(path.join(os.tmpdir(), "log-rot-"));
+    const rotDir = await mkdtemp(path.join(tmpdir(), "log-rot-"));
     let fake = new Date("2026-05-01T10:00:00Z");
     const sink = createFileSink(
       {
@@ -79,7 +79,7 @@ describe("createFileSink", () => {
   });
 
   it("enforces maxFiles retention on rotation", async () => {
-    const retDir = await mkdtemp(path.join(os.tmpdir(), "log-ret-"));
+    const retDir = await mkdtemp(path.join(tmpdir(), "log-ret-"));
     // Pre-create 3 old files
     await writeFile(path.join(retDir, "server-2026-01-01.log"), "a");
     await writeFile(path.join(retDir, "server-2026-01-02.log"), "b");

--- a/test/roles/test_builtin_role_ids.ts
+++ b/test/roles/test_builtin_role_ids.ts
@@ -20,9 +20,9 @@ describe("BUILTIN_ROLE_IDS", () => {
   });
 
   it("every BUILTIN_ROLE_IDS value resolves to an actual role via ROLES.find", () => {
-    for (const id of Object.values(BUILTIN_ROLE_IDS)) {
-      const role = ROLES.find((roleItem) => roleItem.id === id);
-      assert.ok(role, `no role found for id "${id}"`);
+    for (const roleId of Object.values(BUILTIN_ROLE_IDS)) {
+      const role = ROLES.find((roleItem) => roleItem.id === roleId);
+      assert.ok(role, `no role found for id "${roleId}"`);
     }
   });
 });

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -15,7 +15,7 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, rmSync } from "fs";
 import { mkdtemp, rm } from "fs/promises";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -13,9 +13,9 @@
 
 import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdirSync, rmSync } from "fs";
 import { mkdtemp, rm } from "fs/promises";
-import os from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 
@@ -79,13 +79,13 @@ function mockRes() {
 }
 
 before(async () => {
-  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-config-route-"));
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-config-route-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
-  // os.homedir() uses HOME on POSIX and USERPROFILE on Windows.
+  // homedir() uses HOME on POSIX and USERPROFILE on Windows.
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
-  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   configMod = await import("../../server/system/config.js");
   routeMod = await import("../../server/api/routes/config.js");
   getHandler = extractRouteHandler(routeMod, "/api/config", "get");
@@ -103,7 +103,7 @@ after(async () => {
 
 describe("GET /config", () => {
   beforeEach(() => {
-    fs.rmSync(configMod.configsDir(), { recursive: true, force: true });
+    rmSync(configMod.configsDir(), { recursive: true, force: true });
   });
 
   it("returns defaults when nothing is on disk", () => {
@@ -131,7 +131,7 @@ describe("GET /config", () => {
 
 describe("PUT /config/settings", () => {
   beforeEach(() => {
-    fs.rmSync(configMod.configsDir(), { recursive: true, force: true });
+    rmSync(configMod.configsDir(), { recursive: true, force: true });
   });
 
   it("persists a well-formed payload and echoes the re-read state", () => {
@@ -174,7 +174,7 @@ describe("PUT /config/settings", () => {
 
 describe("PUT /config (atomic)", () => {
   beforeEach(() => {
-    fs.rmSync(configMod.configsDir(), { recursive: true, force: true });
+    rmSync(configMod.configsDir(), { recursive: true, force: true });
   });
 
   it("persists settings and mcp together in a single call", () => {

--- a/test/routes/test_filesPutRoute.ts
+++ b/test/routes/test_filesPutRoute.ts
@@ -11,7 +11,7 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, promises, readdirSync } from "fs";
 import { mkdtemp, rm, writeFile } from "fs/promises";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 

--- a/test/routes/test_filesPutRoute.ts
+++ b/test/routes/test_filesPutRoute.ts
@@ -4,14 +4,14 @@
 // We drive the handler with plain Request / Response mocks so we
 // don't pay for an Express + supertest harness, mirroring the pattern
 // established in test_sessionsRoute.ts. The workspace path is resolved
-// from os.homedir() at module load, so HOME is redirected to a tmp
+// from homedir() at module load, so HOME is redirected to a tmp
 // dir BEFORE the route module is imported.
 
 import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdirSync, promises, readdirSync } from "fs";
 import { mkdtemp, rm, writeFile } from "fs/promises";
-import os from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 
@@ -74,14 +74,14 @@ let originalUserProfile: string | undefined;
 let putHandler: Handler;
 
 before(async () => {
-  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-files-put-route-"));
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-files-put-route-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
   const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
   workspaceDir = workspacePth;
-  fs.mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(workspaceDir, { recursive: true });
   const routeMod = await import("../../server/api/routes/files.js");
   putHandler = extractRouteHandler(routeMod, "/api/files/content", "put");
 });
@@ -98,7 +98,7 @@ async function resetWorkspace(): Promise<void> {
   // Clean workspace contents but keep the directory — files.ts
   // captured its realpath at module load, so rm'ing the whole thing
   // would leave the handler with a dangling reference.
-  for (const entry of fs.readdirSync(workspaceDir)) {
+  for (const entry of readdirSync(workspaceDir)) {
     await rm(path.join(workspaceDir, entry), { recursive: true, force: true });
   }
 }
@@ -125,7 +125,7 @@ describe("PUT /api/files/content — happy path", () => {
     assert.equal(typeof body.size, "number");
     assert.equal(typeof body.modifiedMs, "number");
 
-    const onDisk = await fs.promises.readFile(path.join(workspaceDir, rel), "utf-8");
+    const onDisk = await promises.readFile(path.join(workspaceDir, rel), "utf-8");
     assert.equal(onDisk, "# new\nbody\n");
   });
 
@@ -137,7 +137,7 @@ describe("PUT /api/files/content — happy path", () => {
     await putHandler(req({ path: rel, content: "日本語テスト — em–dash" }), res);
 
     assert.equal(state.status, 200);
-    const onDisk = await fs.promises.readFile(path.join(workspaceDir, rel), "utf-8");
+    const onDisk = await promises.readFile(path.join(workspaceDir, rel), "utf-8");
     assert.equal(onDisk, "日本語テスト — em–dash");
   });
 });
@@ -208,7 +208,7 @@ describe("PUT /api/files/content — security", () => {
     await putHandler(req({ path: ".env", content: "SECRET=2" }), res);
     assert.equal(state.status, 400);
     // Verify the original content is unchanged.
-    const onDisk = await fs.promises.readFile(path.join(workspaceDir, ".env"), "utf-8");
+    const onDisk = await promises.readFile(path.join(workspaceDir, ".env"), "utf-8");
     assert.equal(onDisk, "SECRET=1");
   });
 
@@ -231,7 +231,7 @@ describe("PUT /api/files/content — missing targets", () => {
   });
 
   it("returns 400 when the target is a directory", async () => {
-    fs.mkdirSync(path.join(workspaceDir, "adir"));
+    mkdirSync(path.join(workspaceDir, "adir"));
     const { state, res } = mockRes();
     await putHandler(req({ path: "adir", content: "x" }), res);
     assert.equal(state.status, 400);

--- a/test/routes/test_filesTreeAsync.ts
+++ b/test/routes/test_filesTreeAsync.ts
@@ -9,7 +9,7 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, rm, writeFile, symlink } from "node:fs/promises";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { buildTreeAsync, listDirShallow } from "../../server/api/routes/files.js";
 
@@ -24,7 +24,7 @@ interface TreeNodeShape {
 }
 
 async function setupFixture(): Promise<string> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "files-tree-"));
+  const root = await mkdtemp(path.join(tmpdir(), "files-tree-"));
   // root/
   //   a.md
   //   dir1/
@@ -101,7 +101,7 @@ describe("buildTreeAsync", () => {
   it("skips symlinks (no workspace escape)", async () => {
     // Create a symlink AFTER the fixture so it lives alongside the
     // other children; buildTreeAsync should ignore it.
-    const linkTarget = await mkdtemp(path.join(os.tmpdir(), "files-link-"));
+    const linkTarget = await mkdtemp(path.join(tmpdir(), "files-link-"));
     const linkPath = path.join(root, "escape");
     try {
       await symlink(linkTarget, linkPath);

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -1,11 +1,11 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 // The roles route imports workspacePath at module load. Override HOME
-// so os.homedir() → temp root, then dynamic-import the modules.
+// so homedir() → temp root, then dynamic-import the modules.
 let tmpRoot: string;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
@@ -17,12 +17,12 @@ let rolesIo: RolesIo;
 let rolesDir: string;
 
 before(async () => {
-  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "roles-manage-test-"));
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "roles-manage-test-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
-  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   rolesRoute = await import("../../server/api/routes/roles.js");
   rolesIo = await import("../../server/utils/files/roles-io.js");
   rolesDir = path.join(tmpRoot, "mulmoclaude", "config", "roles");
@@ -33,7 +33,7 @@ after(() => {
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
-  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 function sampleRole(roleId: string) {
@@ -82,7 +82,7 @@ describe("executeManageRoles — rename (oldRoleId)", () => {
     rolesIo.deleteRole("tmp");
     // Ensure we didn't accidentally create the built-in id file
     const generalPath = path.join(rolesDir, "general.json");
-    assert.equal(fs.existsSync(generalPath), false);
+    assert.equal(existsSync(generalPath), false);
   });
 
   it("rejects a rename into an id already in use", async () => {
@@ -163,7 +163,7 @@ describe("executeManageRoles — rename (oldRoleId)", () => {
     assert.equal(result.success, false);
     assert.match(String(result.error), /already exists/i);
     // Original content must be intact
-    const onDisk = JSON.parse(fs.readFileSync(path.join(rolesDir, "target.json"), "utf-8")) as { name: string };
+    const onDisk = JSON.parse(readFileSync(path.join(rolesDir, "target.json"), "utf-8")) as { name: string };
     assert.equal(onDisk.name, "Original", "existing role must not be overwritten");
     rolesIo.deleteRole("target");
   });

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -2,7 +2,7 @@ import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 
 // The roles route imports workspacePath at module load. Override HOME
 // so homedir() → temp root, then dynamic-import the modules.

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -10,7 +10,7 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync } from "fs";
 import { mkdtemp, rm, writeFile, utimes } from "fs/promises";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 import { encodeCursor } from "../../server/api/routes/sessionsCursor.js";
@@ -90,7 +90,7 @@ let getHandler: Handler;
 let markReadHandler: Handler;
 
 async function writeSession(
-  id: string,
+  sessionId: string,
   opts: {
     roleId?: string;
     mtimeMs: number;
@@ -102,18 +102,18 @@ async function writeSession(
   const meta = {
     roleId: opts.roleId ?? "general",
     startedAt: new Date(opts.mtimeMs).toISOString(),
-    firstUserMessage: opts.firstUserMessage ?? `msg for ${id}`,
+    firstUserMessage: opts.firstUserMessage ?? `msg for ${sessionId}`,
   };
-  await writeFile(path.join(chatDir, `${id}.json`), JSON.stringify(meta));
-  await writeFile(path.join(chatDir, `${id}.jsonl`), "");
+  await writeFile(path.join(chatDir, `${sessionId}.json`), JSON.stringify(meta));
+  await writeFile(path.join(chatDir, `${sessionId}.jsonl`), "");
   // Set both atime and mtime so the handler's stat.mtimeMs reads
   // what the test intends. Back-date the .json meta too — the cursor
   // derivation reads it alongside the .jsonl mtime (hasUnread writes
   // bump meta but not jsonl), so a freshly-written meta at "now"
   // would otherwise dominate the computed changeMs.
   const secs = opts.mtimeMs / 1000;
-  await utimes(path.join(chatDir, `${id}.jsonl`), secs, secs);
-  await utimes(path.join(chatDir, `${id}.json`), secs, secs);
+  await utimes(path.join(chatDir, `${sessionId}.jsonl`), secs, secs);
+  await utimes(path.join(chatDir, `${sessionId}.json`), secs, secs);
 
   if (opts.indexedAtMs !== undefined) {
     const manifestPath = path.join(manifestDir, "manifest.json");
@@ -124,12 +124,12 @@ async function writeSession(
       /* first write */
     }
     entries.push({
-      id,
+      id: sessionId,
       roleId: meta.roleId,
       startedAt: meta.startedAt,
       indexedAt: new Date(opts.indexedAtMs).toISOString(),
-      title: `AI title ${id}`,
-      summary: `AI summary ${id}`,
+      title: `AI title ${sessionId}`,
+      summary: `AI summary ${sessionId}`,
       keywords: ["k1"],
     });
     mkdirSync(path.dirname(manifestPath), { recursive: true });

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -8,9 +8,9 @@
 
 import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import { mkdtemp, rm, writeFile, utimes } from "fs/promises";
-import os from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import type { Request, Response } from "express";
 import { encodeCursor } from "../../server/api/routes/sessionsCursor.js";
@@ -119,7 +119,7 @@ async function writeSession(
     const manifestPath = path.join(manifestDir, "manifest.json");
     let entries: unknown[] = [];
     try {
-      entries = JSON.parse(fs.readFileSync(manifestPath, "utf-8")).entries ?? [];
+      entries = JSON.parse(readFileSync(manifestPath, "utf-8")).entries ?? [];
     } catch {
       /* first write */
     }
@@ -132,7 +132,7 @@ async function writeSession(
       summary: `AI summary ${id}`,
       keywords: ["k1"],
     });
-    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    mkdirSync(path.dirname(manifestPath), { recursive: true });
     await writeFile(manifestPath, JSON.stringify({ version: 1, entries }));
   }
 }
@@ -140,15 +140,15 @@ async function writeSession(
 async function resetChatDir(): Promise<void> {
   await rm(chatDir, { recursive: true, force: true });
   await rm(manifestDir, { recursive: true, force: true });
-  fs.mkdirSync(chatDir, { recursive: true });
-  fs.mkdirSync(manifestDir, { recursive: true });
+  mkdirSync(chatDir, { recursive: true });
+  mkdirSync(manifestDir, { recursive: true });
 }
 
 before(async () => {
-  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-sessions-route-"));
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-sessions-route-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
-  // The workspace path resolves once at module load from os.homedir(),
+  // The workspace path resolves once at module load from homedir(),
   // so we have to steer it BEFORE importing the route module. This
   // mirrors the setup in test_configRoute.ts.
   process.env.HOME = tmpRoot;
@@ -161,8 +161,8 @@ before(async () => {
   const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
   chatDir = WORKSPACE_PATHS.chat;
   manifestDir = indexDirFor(workspacePth);
-  fs.mkdirSync(chatDir, { recursive: true });
-  fs.mkdirSync(manifestDir, { recursive: true });
+  mkdirSync(chatDir, { recursive: true });
+  mkdirSync(manifestDir, { recursive: true });
   const routeMod = await import("../../server/api/routes/sessions.js");
   getHandler = extractRouteHandler(routeMod, "/api/sessions", "get");
   markReadHandler = extractRouteHandler(routeMod, "/api/sessions/:id/mark-read", "post");
@@ -327,7 +327,7 @@ describe("POST /api/sessions/:id/mark-read", () => {
     const { res } = mockMarkReadRes();
     await markReadHandler({ params: { id: "s1" } } as unknown as Request, res);
 
-    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
     assert.equal(meta.hasUnread, false);
   });
 });

--- a/test/routes/test_todosColumnsHandlers.ts
+++ b/test/routes/test_todosColumnsHandlers.ts
@@ -130,8 +130,8 @@ describe("handleAddColumn", () => {
     const result = handleAddColumn(cols(), [], { label: "Doing (進行中)" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const id = result.columns[result.columns.length - 1]?.id;
-    assert.ok(id?.startsWith("doing_"));
+    const columnId = result.columns[result.columns.length - 1]?.id;
+    assert.ok(columnId?.startsWith("doing_"));
   });
 
   it("is deterministic — same label always yields the same id", () => {

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -39,30 +39,30 @@ describe("wikiSlugify", () => {
 });
 
 describe("extractSlugFromBulletHref", () => {
-  it("extracts slug from pages/<slug>.markdown", () => {
-    assert.equal(extractSlugFromBulletHref("pages/sakura-internet.markdown"), "sakura-internet");
+  it("extracts slug from pages/<slug>.md", () => {
+    assert.equal(extractSlugFromBulletHref("pages/sakura-internet.md"), "sakura-internet");
   });
 
   it("handles leading ./ and deeper prefixes", () => {
-    assert.equal(extractSlugFromBulletHref("./pages/foo.markdown"), "foo");
-    assert.equal(extractSlugFromBulletHref("wiki/pages/foo.markdown"), "foo");
+    assert.equal(extractSlugFromBulletHref("./pages/foo.md"), "foo");
+    assert.equal(extractSlugFromBulletHref("wiki/pages/foo.md"), "foo");
   });
 
-  it("accepts a bare <slug>.markdown without the pages prefix", () => {
-    assert.equal(extractSlugFromBulletHref("foo.markdown"), "foo");
+  it("accepts a bare <slug>.md without the pages prefix", () => {
+    assert.equal(extractSlugFromBulletHref("foo.md"), "foo");
   });
 
-  it("accepts just <slug> with no .markdown extension", () => {
+  it("accepts just <slug> with no .md extension", () => {
     assert.equal(extractSlugFromBulletHref("foo"), "foo");
   });
 
   it("strips surrounding whitespace", () => {
-    assert.equal(extractSlugFromBulletHref("  pages/foo.markdown  "), "foo");
+    assert.equal(extractSlugFromBulletHref("  pages/foo.md  "), "foo");
   });
 
   it("returns empty for absolute URLs (caller should fall back)", () => {
     assert.equal(extractSlugFromBulletHref("https://example.com/foo"), "");
-    assert.equal(extractSlugFromBulletHref("http://x/foo.markdown"), "");
+    assert.equal(extractSlugFromBulletHref("http://x/foo.md"), "");
   });
 
   it("returns empty for an empty input", () => {
@@ -99,7 +99,7 @@ describe("parseIndexEntries", () => {
   });
 
   it("parses bullet markdown links", () => {
-    const markdown = "- [Video Generation](pages/video-generation.markdown) — about video";
+    const markdown = "- [Video Generation](pages/video-generation.md) — about video";
     const entries = parseIndexEntries(markdown);
     assert.deepEqual(entries[0], {
       title: "Video Generation",
@@ -113,7 +113,7 @@ describe("parseIndexEntries", () => {
     // `wikiSlugify(title)` which stripped every non-ASCII character
     // and returned "", breaking in-canvas navigation. The slug must
     // now come from the href segment.
-    const markdown = "- [さくらインターネット](pages/sakura-internet.markdown) — クラウド事業者";
+    const markdown = "- [さくらインターネット](pages/sakura-internet.md) — クラウド事業者";
     const entries = parseIndexEntries(markdown);
     assert.deepEqual(entries[0], {
       title: "さくらインターネット",
@@ -123,9 +123,9 @@ describe("parseIndexEntries", () => {
   });
 
   it("derives slug from a bare filename href", () => {
-    // Some historical index.markdown files used `[Title](slug.markdown)` without
+    // Some historical index.md files used `[Title](slug.md)` without
     // the `pages/` prefix. Still valid — use the filename as slug.
-    const markdown = "- [Video Generation](video-generation.markdown) — about video";
+    const markdown = "- [Video Generation](video-generation.md) — about video";
     const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.slug, "video-generation");
   });
@@ -166,7 +166,7 @@ describe("parseIndexEntries", () => {
   });
 
   it("handles a missing description on bullet links", () => {
-    const markdown = "- [Topic](pages/topic.markdown)";
+    const markdown = "- [Topic](pages/topic.md)";
     const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.description, "");
   });
@@ -197,7 +197,7 @@ describe("findOrphanPages", () => {
     const indexed = new Set(["a", "b"]);
     const issues = findOrphanPages(files, indexed);
     assert.equal(issues.length, 1);
-    assert.match(issues[0] ?? "", /Orphan page.*orphan\.markdown/);
+    assert.match(issues[0] ?? "", /Orphan page.*orphan\.md/);
   });
 
   it("flags multiple orphans", () => {
@@ -231,28 +231,28 @@ describe("findBrokenLinksInPage", () => {
   it("returns no issues when every wiki link resolves", () => {
     const content = "See [[Topic A]] and [[Topic B]] for details.";
     const fileSlugs = new Set(["topic-a", "topic-b"]);
-    assert.deepEqual(findBrokenLinksInPage("source.markdown", content, fileSlugs), []);
+    assert.deepEqual(findBrokenLinksInPage("source.md", content, fileSlugs), []);
   });
 
   it("flags a broken link", () => {
     const content = "See [[Missing Topic]] for details.";
     const fileSlugs = new Set(["other"]);
-    const issues = findBrokenLinksInPage("source.markdown", content, fileSlugs);
+    const issues = findBrokenLinksInPage("source.md", content, fileSlugs);
     assert.equal(issues.length, 1);
-    assert.match(issues[0] ?? "", /Broken link\*\* in `source\.markdown`/);
-    assert.match(issues[0] ?? "", /missing-topic\.markdown/);
+    assert.match(issues[0] ?? "", /Broken link\*\* in `source\.md`/);
+    assert.match(issues[0] ?? "", /missing-topic\.md/);
   });
 
   it("ignores non-wiki-link bracket sequences", () => {
     const content = "Plain text with [normal](link) references.";
     const fileSlugs = new Set<string>();
-    assert.deepEqual(findBrokenLinksInPage("source.markdown", content, fileSlugs), []);
+    assert.deepEqual(findBrokenLinksInPage("source.md", content, fileSlugs), []);
   });
 
   it("flags multiple broken links in the same page", () => {
     const content = "[[A]] and [[B]] and [[C]]";
     const fileSlugs = new Set<string>();
-    assert.equal(findBrokenLinksInPage("source.markdown", content, fileSlugs).length, 3);
+    assert.equal(findBrokenLinksInPage("source.md", content, fileSlugs).length, 3);
   });
 });
 

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -39,30 +39,30 @@ describe("wikiSlugify", () => {
 });
 
 describe("extractSlugFromBulletHref", () => {
-  it("extracts slug from pages/<slug>.md", () => {
-    assert.equal(extractSlugFromBulletHref("pages/sakura-internet.md"), "sakura-internet");
+  it("extracts slug from pages/<slug>.markdown", () => {
+    assert.equal(extractSlugFromBulletHref("pages/sakura-internet.markdown"), "sakura-internet");
   });
 
   it("handles leading ./ and deeper prefixes", () => {
-    assert.equal(extractSlugFromBulletHref("./pages/foo.md"), "foo");
-    assert.equal(extractSlugFromBulletHref("wiki/pages/foo.md"), "foo");
+    assert.equal(extractSlugFromBulletHref("./pages/foo.markdown"), "foo");
+    assert.equal(extractSlugFromBulletHref("wiki/pages/foo.markdown"), "foo");
   });
 
-  it("accepts a bare <slug>.md without the pages prefix", () => {
-    assert.equal(extractSlugFromBulletHref("foo.md"), "foo");
+  it("accepts a bare <slug>.markdown without the pages prefix", () => {
+    assert.equal(extractSlugFromBulletHref("foo.markdown"), "foo");
   });
 
-  it("accepts just <slug> with no .md extension", () => {
+  it("accepts just <slug> with no .markdown extension", () => {
     assert.equal(extractSlugFromBulletHref("foo"), "foo");
   });
 
   it("strips surrounding whitespace", () => {
-    assert.equal(extractSlugFromBulletHref("  pages/foo.md  "), "foo");
+    assert.equal(extractSlugFromBulletHref("  pages/foo.markdown  "), "foo");
   });
 
   it("returns empty for absolute URLs (caller should fall back)", () => {
     assert.equal(extractSlugFromBulletHref("https://example.com/foo"), "");
-    assert.equal(extractSlugFromBulletHref("http://x/foo.md"), "");
+    assert.equal(extractSlugFromBulletHref("http://x/foo.markdown"), "");
   });
 
   it("returns empty for an empty input", () => {
@@ -77,13 +77,13 @@ describe("parseIndexEntries", () => {
   });
 
   it("parses a markdown table with header + separator + rows", () => {
-    const md = [
+    const markdown = [
       "| slug | title | description |",
       "|------|-------|-------------|",
       "| `video-gen` | Video Gen | Notes about video |",
       "| `audio-gen` | Audio Gen | Notes about audio |",
     ].join("\n");
-    const entries = parseIndexEntries(md);
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries.length, 2);
     assert.deepEqual(entries[0], {
       slug: "video-gen",
@@ -93,14 +93,14 @@ describe("parseIndexEntries", () => {
   });
 
   it("falls back to slug as title when title is empty", () => {
-    const md = ["| slug | title |", "|------|-------|", "| `bare` |  |"].join("\n");
-    const entries = parseIndexEntries(md);
+    const markdown = ["| slug | title |", "|------|-------|", "| `bare` |  |"].join("\n");
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.title, "bare");
   });
 
   it("parses bullet markdown links", () => {
-    const md = "- [Video Generation](pages/video-generation.md) — about video";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [Video Generation](pages/video-generation.markdown) — about video";
+    const entries = parseIndexEntries(markdown);
     assert.deepEqual(entries[0], {
       title: "Video Generation",
       slug: "video-generation",
@@ -113,8 +113,8 @@ describe("parseIndexEntries", () => {
     // `wikiSlugify(title)` which stripped every non-ASCII character
     // and returned "", breaking in-canvas navigation. The slug must
     // now come from the href segment.
-    const md = "- [さくらインターネット](pages/sakura-internet.md) — クラウド事業者";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [さくらインターネット](pages/sakura-internet.markdown) — クラウド事業者";
+    const entries = parseIndexEntries(markdown);
     assert.deepEqual(entries[0], {
       title: "さくらインターネット",
       slug: "sakura-internet",
@@ -123,16 +123,16 @@ describe("parseIndexEntries", () => {
   });
 
   it("derives slug from a bare filename href", () => {
-    // Some historical index.md files used `[Title](slug.md)` without
+    // Some historical index.markdown files used `[Title](slug.markdown)` without
     // the `pages/` prefix. Still valid — use the filename as slug.
-    const md = "- [Video Generation](video-generation.md) — about video";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [Video Generation](video-generation.markdown) — about video";
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.slug, "video-generation");
   });
 
   it("derives slug from a plain filename with no extension", () => {
-    const md = "- [Video Generation](video-generation) — about video";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [Video Generation](video-generation) — about video";
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.slug, "video-generation");
   });
 
@@ -141,14 +141,14 @@ describe("parseIndexEntries", () => {
     // slug is the only reasonable choice. For non-ASCII titles this
     // still produces "" — but that's fine: such a row isn't a
     // real wiki page entry in the first place.
-    const md = "- [Video Generation](https://example.com/xyz) — about video";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [Video Generation](https://example.com/xyz) — about video";
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.slug, "video-generation");
   });
 
   it("parses bullet wiki links", () => {
-    const md = "- [[Video Generation]] — about video";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [[Video Generation]] — about video";
+    const entries = parseIndexEntries(markdown);
     assert.deepEqual(entries[0], {
       title: "Video Generation",
       slug: "video-generation",
@@ -166,19 +166,19 @@ describe("parseIndexEntries", () => {
   });
 
   it("handles a missing description on bullet links", () => {
-    const md = "- [Topic](pages/topic.md)";
-    const entries = parseIndexEntries(md);
+    const markdown = "- [Topic](pages/topic.markdown)";
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries[0]?.description, "");
   });
 
   it("ignores lines that don't match any format", () => {
-    const md = "Just some text\n# A heading\n";
-    assert.deepEqual(parseIndexEntries(md), []);
+    const markdown = "Just some text\n# A heading\n";
+    assert.deepEqual(parseIndexEntries(markdown), []);
   });
 
   it("handles a mix of table and bullet entries", () => {
-    const md = ["| slug | title |", "|------|-------|", "| `t1` | Topic 1 |", "", "- [[Topic 2]]"].join("\n");
-    const entries = parseIndexEntries(md);
+    const markdown = ["| slug | title |", "|------|-------|", "| `t1` | Topic 1 |", "", "- [[Topic 2]]"].join("\n");
+    const entries = parseIndexEntries(markdown);
     assert.equal(entries.length, 2);
     assert.equal(entries[0]?.slug, "t1");
     assert.equal(entries[1]?.slug, "topic-2");
@@ -197,7 +197,7 @@ describe("findOrphanPages", () => {
     const indexed = new Set(["a", "b"]);
     const issues = findOrphanPages(files, indexed);
     assert.equal(issues.length, 1);
-    assert.match(issues[0] ?? "", /Orphan page.*orphan\.md/);
+    assert.match(issues[0] ?? "", /Orphan page.*orphan\.markdown/);
   });
 
   it("flags multiple orphans", () => {
@@ -231,28 +231,28 @@ describe("findBrokenLinksInPage", () => {
   it("returns no issues when every wiki link resolves", () => {
     const content = "See [[Topic A]] and [[Topic B]] for details.";
     const fileSlugs = new Set(["topic-a", "topic-b"]);
-    assert.deepEqual(findBrokenLinksInPage("source.md", content, fileSlugs), []);
+    assert.deepEqual(findBrokenLinksInPage("source.markdown", content, fileSlugs), []);
   });
 
   it("flags a broken link", () => {
     const content = "See [[Missing Topic]] for details.";
     const fileSlugs = new Set(["other"]);
-    const issues = findBrokenLinksInPage("source.md", content, fileSlugs);
+    const issues = findBrokenLinksInPage("source.markdown", content, fileSlugs);
     assert.equal(issues.length, 1);
-    assert.match(issues[0] ?? "", /Broken link\*\* in `source\.md`/);
-    assert.match(issues[0] ?? "", /missing-topic\.md/);
+    assert.match(issues[0] ?? "", /Broken link\*\* in `source\.markdown`/);
+    assert.match(issues[0] ?? "", /missing-topic\.markdown/);
   });
 
   it("ignores non-wiki-link bracket sequences", () => {
     const content = "Plain text with [normal](link) references.";
     const fileSlugs = new Set<string>();
-    assert.deepEqual(findBrokenLinksInPage("source.md", content, fileSlugs), []);
+    assert.deepEqual(findBrokenLinksInPage("source.markdown", content, fileSlugs), []);
   });
 
   it("flags multiple broken links in the same page", () => {
     const content = "[[A]] and [[B]] and [[C]]";
     const fileSlugs = new Set<string>();
-    assert.equal(findBrokenLinksInPage("source.md", content, fileSlugs).length, 3);
+    assert.equal(findBrokenLinksInPage("source.markdown", content, fileSlugs).length, 3);
   });
 });
 

--- a/test/routes/test_wikiPageIndex.ts
+++ b/test/routes/test_wikiPageIndex.ts
@@ -1,7 +1,7 @@
 import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { __resetPageIndexCache, getPageIndex } from "../../server/api/routes/wiki/pageIndex.js";
 
@@ -17,7 +17,7 @@ describe("getPageIndex", () => {
   let dir: string;
 
   before(async () => {
-    dir = await mkdtemp(path.join(os.tmpdir(), "wiki-pages-"));
+    dir = await mkdtemp(path.join(tmpdir(), "wiki-pages-"));
   });
 
   after(async () => {

--- a/test/server/test_auth_token.ts
+++ b/test/server/test_auth_token.ts
@@ -1,21 +1,21 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { __resetForTests, deleteTokenFile, generateAndWriteToken, getCurrentToken } from "../../server/api/auth/token.js";
 
 let tmpDir = "";
 let tokenPath = "";
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-token-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-token-test-"));
   tokenPath = path.join(tmpDir, ".session-token");
   __resetForTests();
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("generateAndWriteToken", () => {
@@ -27,7 +27,7 @@ describe("generateAndWriteToken", () => {
 
   it("writes the token to the given path", async () => {
     const token = await generateAndWriteToken(tokenPath);
-    const onDisk = fs.readFileSync(tokenPath, "utf-8");
+    const onDisk = readFileSync(tokenPath, "utf-8");
     assert.equal(onDisk, token);
   });
 
@@ -42,20 +42,20 @@ describe("generateAndWriteToken", () => {
     const second = await generateAndWriteToken(tokenPath);
     assert.notEqual(first, second);
     assert.equal(getCurrentToken(), second);
-    assert.equal(fs.readFileSync(tokenPath, "utf-8"), second);
+    assert.equal(readFileSync(tokenPath, "utf-8"), second);
   });
 
   it("writes with mode 0600 on POSIX", async () => {
     if (process.platform === "win32") return; // chmod 0600 is a no-op on Windows
     await generateAndWriteToken(tokenPath);
-    const mode = fs.statSync(tokenPath).mode & 0o777;
+    const mode = statSync(tokenPath).mode & 0o777;
     assert.equal(mode, 0o600);
   });
 
   it("creates the parent directory if it doesn't exist", async () => {
     const nested = path.join(tmpDir, "nested", "deep", ".session-token");
     await generateAndWriteToken(nested);
-    assert.ok(fs.existsSync(nested));
+    assert.ok(existsSync(nested));
   });
 });
 
@@ -65,7 +65,7 @@ describe("generateAndWriteToken — env override (#316)", () => {
     const token = await generateAndWriteToken(tokenPath, override);
     assert.equal(token, override);
     assert.equal(getCurrentToken(), override);
-    assert.equal(fs.readFileSync(tokenPath, "utf-8"), override);
+    assert.equal(readFileSync(tokenPath, "utf-8"), override);
   });
 
   it("does not rotate — repeated calls with the same override return it each time", async () => {
@@ -97,15 +97,15 @@ describe("generateAndWriteToken — env override (#316)", () => {
 describe("deleteTokenFile", () => {
   it("removes the token file", async () => {
     await generateAndWriteToken(tokenPath);
-    assert.ok(fs.existsSync(tokenPath));
+    assert.ok(existsSync(tokenPath));
     await deleteTokenFile(tokenPath);
-    assert.ok(!fs.existsSync(tokenPath));
+    assert.ok(!existsSync(tokenPath));
   });
 
   it("is a no-op when the file is already missing", async () => {
-    assert.ok(!fs.existsSync(tokenPath));
+    assert.ok(!existsSync(tokenPath));
     await deleteTokenFile(tokenPath); // must not throw
-    assert.ok(!fs.existsSync(tokenPath));
+    assert.ok(!existsSync(tokenPath));
   });
 
   it("does not touch the in-memory token (caller's responsibility)", async () => {

--- a/test/server/test_bearerAuth.ts
+++ b/test/server/test_bearerAuth.ts
@@ -13,9 +13,9 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdtempSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import type { Request, Response, NextFunction } from "express";
 import { bearerAuth } from "../../server/api/auth/bearerAuth.js";
 import { __resetForTests, generateAndWriteToken } from "../../server/api/auth/token.js";
@@ -74,7 +74,7 @@ let tokenPath = "";
 let validToken = "";
 
 beforeEach(async () => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-auth-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-auth-test-"));
   tokenPath = path.join(tmpDir, ".session-token");
   __resetForTests();
   validToken = await generateAndWriteToken(tokenPath);

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -2,7 +2,7 @@ import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import { mkdtemp, rm } from "fs/promises";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import path from "path";
 
 // The config module reads workspacePath at the time of each call,

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -1,8 +1,8 @@
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import { mkdtemp, rm } from "fs/promises";
-import os from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 
 // The config module reads workspacePath at the time of each call,
@@ -16,15 +16,15 @@ type ConfigModule = typeof import("../../server/system/config.js");
 let mod: ConfigModule;
 
 before(async () => {
-  tmpRoot = await mkdtemp(path.join(os.tmpdir(), "mulmo-config-test-"));
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-config-test-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
-  // os.homedir() uses HOME on POSIX and USERPROFILE on Windows; set both
+  // homedir() uses HOME on POSIX and USERPROFILE on Windows; set both
   // so the test's temp workspace is picked up regardless of platform.
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
   // Pre-create the workspace root that workspace.ts expects.
-  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   mod = await import("../../server/system/config.js");
 });
 
@@ -69,7 +69,7 @@ describe("isAppSettings", () => {
 describe("loadSettings", () => {
   afterEach(() => {
     // Always start each test with a clean configs dir.
-    fs.rmSync(mod.configsDir(), { recursive: true, force: true });
+    rmSync(mod.configsDir(), { recursive: true, force: true });
   });
 
   it("returns defaults when the file is missing", () => {
@@ -84,14 +84,14 @@ describe("loadSettings", () => {
 
   it("returns defaults and warns on malformed JSON", () => {
     mod.ensureConfigsDir();
-    fs.writeFileSync(mod.settingsPath(), "not json");
+    writeFileSync(mod.settingsPath(), "not json");
     const cfg = mod.loadSettings();
     assert.deepEqual(cfg, { extraAllowedTools: [] });
   });
 
   it("returns defaults when shape does not match", () => {
     mod.ensureConfigsDir();
-    fs.writeFileSync(mod.settingsPath(), JSON.stringify({ extraAllowedTools: [1, 2, 3] }));
+    writeFileSync(mod.settingsPath(), JSON.stringify({ extraAllowedTools: [1, 2, 3] }));
     assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [] });
   });
 
@@ -176,7 +176,7 @@ describe("isMcpServerId", () => {
 
 describe("loadMcpConfig / saveMcpConfig", () => {
   beforeEach(() => {
-    fs.rmSync(mod.configsDir(), { recursive: true, force: true });
+    rmSync(mod.configsDir(), { recursive: true, force: true });
   });
 
   it("returns empty mcpServers when missing", () => {
@@ -204,13 +204,13 @@ describe("loadMcpConfig / saveMcpConfig", () => {
 
   it("returns defaults on malformed JSON", () => {
     mod.ensureConfigsDir();
-    fs.writeFileSync(mod.mcpConfigPath(), "{broken");
+    writeFileSync(mod.mcpConfigPath(), "{broken");
     assert.deepEqual(mod.loadMcpConfig(), { mcpServers: {} });
   });
 
   it("returns defaults when schema does not match", () => {
     mod.ensureConfigsDir();
-    fs.writeFileSync(mod.mcpConfigPath(), JSON.stringify({ mcpServers: { BAD: { type: "http", url: "x" } } }));
+    writeFileSync(mod.mcpConfigPath(), JSON.stringify({ mcpServers: { BAD: { type: "http", url: "x" } } }));
     assert.deepEqual(mod.loadMcpConfig(), { mcpServers: {} });
   });
 
@@ -221,7 +221,7 @@ describe("loadMcpConfig / saveMcpConfig", () => {
         mcpServers: { ok: { type: "nope" } as any },
       }),
     );
-    assert.equal(fs.existsSync(mod.mcpConfigPath()), false);
+    assert.equal(existsSync(mod.mcpConfigPath()), false);
   });
 });
 
@@ -255,12 +255,12 @@ describe("toMcpEntries / fromMcpEntries", () => {
 
 describe("saveSettings", () => {
   beforeEach(() => {
-    fs.rmSync(mod.configsDir(), { recursive: true, force: true });
+    rmSync(mod.configsDir(), { recursive: true, force: true });
   });
 
   it("creates config/ if missing and writes JSON", () => {
     mod.saveSettings({ extraAllowedTools: ["mcp__claude_ai_Gmail"] });
-    const raw = fs.readFileSync(mod.settingsPath(), "utf-8");
+    const raw = readFileSync(mod.settingsPath(), "utf-8");
     assert.deepEqual(JSON.parse(raw), {
       extraAllowedTools: ["mcp__claude_ai_Gmail"],
     });
@@ -268,10 +268,10 @@ describe("saveSettings", () => {
 
   it("writes trailing newline and restrictive permissions", () => {
     mod.saveSettings({ extraAllowedTools: [] });
-    const raw = fs.readFileSync(mod.settingsPath(), "utf-8");
+    const raw = readFileSync(mod.settingsPath(), "utf-8");
     assert.ok(raw.endsWith("\n"));
     if (process.platform !== "win32") {
-      const stat = fs.statSync(mod.settingsPath());
+      const stat = statSync(mod.settingsPath());
       // Low 9 bits = owner/group/other perms; expect 0o600.
       assert.equal(stat.mode & 0o777, 0o600);
     }
@@ -287,7 +287,7 @@ describe("saveSettings", () => {
   it("replaces existing file atomically (no .tmp leftover)", () => {
     mod.saveSettings({ extraAllowedTools: ["first"] });
     mod.saveSettings({ extraAllowedTools: ["second"] });
-    const entries = fs.readdirSync(mod.configsDir());
+    const entries = readdirSync(mod.configsDir());
     const leftover = entries.filter((entry) => entry.endsWith(".tmp"));
     assert.deepEqual(leftover, []);
     assert.deepEqual(mod.loadSettings(), { extraAllowedTools: ["second"] });

--- a/test/skills/test_updateSkill.ts
+++ b/test/skills/test_updateSkill.ts
@@ -3,25 +3,25 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { updateProjectSkill } from "../../server/workspace/skills/writer.ts";
 
 let tmpDir = "";
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-skill-update-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-skill-update-"));
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 function createSkill(name: string, desc: string, body: string): void {
   const skillDir = path.join(tmpDir, ".claude", "skills", name);
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.writeFileSync(path.join(skillDir, "SKILL.md"), `---\ndescription: ${desc}\n---\n\n${body}`);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), `---\ndescription: ${desc}\n---\n\n${body}`);
 }
 
 describe("updateProjectSkill", () => {
@@ -35,7 +35,7 @@ describe("updateProjectSkill", () => {
     });
     assert.equal(result.kind, "updated");
     if (result.kind === "updated") {
-      const content = fs.readFileSync(result.path, "utf-8");
+      const content = readFileSync(result.path, "utf-8");
       assert.ok(content.includes("new desc"));
       assert.ok(content.includes("new body"));
     }
@@ -83,7 +83,7 @@ describe("updateProjectSkill", () => {
       description: "v2",
       body: "body v2",
     });
-    const content = fs.readFileSync(path.join(tmpDir, ".claude", "skills", "my-skill", "SKILL.md"), "utf-8");
+    const content = readFileSync(path.join(tmpDir, ".claude", "skills", "my-skill", "SKILL.md"), "utf-8");
     assert.ok(!content.includes("v1"));
     assert.ok(content.includes("v2"));
     assert.ok(content.includes("body v2"));

--- a/test/skills/test_user_tasks.ts
+++ b/test/skills/test_user_tasks.ts
@@ -2,14 +2,14 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { loadUserTasks, validateAndCreate, applyUpdate } from "../../server/workspace/skills/user-tasks.ts";
 import { saveUserTasks } from "../../server/utils/files/user-tasks-io.ts";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 import { ONE_MINUTE_MS, ONE_HOUR_MS } from "../../server/utils/time.ts";
 
 function tmpRoot(): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "user-tasks-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "user-tasks-"));
   mkdirSync(path.join(dir, "config", "scheduler"), { recursive: true });
   return dir;
 }

--- a/test/sources/test_arxiv.ts
+++ b/test/sources/test_arxiv.ts
@@ -47,8 +47,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };

--- a/test/sources/test_arxivDiscovery.ts
+++ b/test/sources/test_arxivDiscovery.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { buildArxivQuery, keywordsToSlug, discoverAndRegister } from "../../server/workspace/sources/arxivDiscovery.js";
 
 describe("buildArxivQuery", () => {
@@ -68,14 +68,14 @@ describe("keywordsToSlug", () => {
 
 describe("discoverAndRegister", () => {
   function makeTmpWorkspace(interests: Record<string, unknown> | null): string {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "arxiv-disc-"));
+    const tmp = mkdtempSync(path.join(tmpdir(), "arxiv-disc-"));
     const configDir = path.join(tmp, "config");
-    fs.mkdirSync(configDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
     if (interests) {
-      fs.writeFileSync(path.join(configDir, "interests.json"), JSON.stringify(interests));
+      writeFileSync(path.join(configDir, "interests.json"), JSON.stringify(interests));
     }
     // Create sources directory
-    fs.mkdirSync(path.join(tmp, "sources"), { recursive: true });
+    mkdirSync(path.join(tmp, "sources"), { recursive: true });
     return tmp;
   }
 
@@ -84,14 +84,14 @@ describe("discoverAndRegister", () => {
     const result = await discoverAndRegister(tmp);
     assert.equal(result.reason, "no keywords in interests");
     assert.equal(result.registered.length, 0);
-    fs.rmSync(tmp, { recursive: true });
+    rmSync(tmp, { recursive: true });
   });
 
   it("skips when no keywords", async () => {
     const tmp = makeTmpWorkspace({ keywords: [], categories: ["ai"] });
     const result = await discoverAndRegister(tmp);
     assert.equal(result.reason, "no keywords in interests");
-    fs.rmSync(tmp, { recursive: true });
+    rmSync(tmp, { recursive: true });
   });
 
   it("registers arXiv source for keywords", async () => {
@@ -105,12 +105,12 @@ describe("discoverAndRegister", () => {
 
     // Verify source file was created
     const sourceFile = path.join(tmp, "sources", result.registered[0] + ".md");
-    assert.ok(fs.existsSync(sourceFile));
-    const content = fs.readFileSync(sourceFile, "utf-8");
+    assert.ok(existsSync(sourceFile));
+    const content = readFileSync(sourceFile, "utf-8");
     assert.ok(content.includes("arxiv_query"));
     assert.ok(content.includes("transformer"));
 
-    fs.rmSync(tmp, { recursive: true });
+    rmSync(tmp, { recursive: true });
   });
 
   it("skips existing sources", async () => {
@@ -124,7 +124,7 @@ describe("discoverAndRegister", () => {
     const result = await discoverAndRegister(tmp);
     assert.equal(result.registered.length, 0);
     assert.equal(result.skipped.length, 1);
-    fs.rmSync(tmp, { recursive: true });
+    rmSync(tmp, { recursive: true });
   });
 
   it("chunks keywords into groups of 5", async () => {
@@ -135,7 +135,7 @@ describe("discoverAndRegister", () => {
     // categories empty but keywords present — needs at least one to pass
     // Actually with empty categories, loadInterests returns null...
     // Let's add a category
-    fs.writeFileSync(
+    writeFileSync(
       path.join(tmp, "config", "interests.json"),
       JSON.stringify({
         keywords: ["a", "b", "c", "d", "e", "f", "g"],
@@ -144,6 +144,6 @@ describe("discoverAndRegister", () => {
     );
     const result = await discoverAndRegister(tmp);
     assert.equal(result.registered.length, 2); // [a,b,c,d,e] + [f,g]
-    fs.rmSync(tmp, { recursive: true });
+    rmSync(tmp, { recursive: true });
   });
 });

--- a/test/sources/test_github.ts
+++ b/test/sources/test_github.ts
@@ -108,19 +108,19 @@ describe("parseRepoSlug — rejects malformed / unsafe input", () => {
 
 function controllableClock(start = 0): {
   deps: RateLimiterDeps;
-  tick: (ms: number) => void;
+  tick: (delayMs: number) => void;
 } {
   const state = { t: start };
   return {
     deps: {
       now: () => state.t,
-      sleep: (ms) => {
-        state.t += ms;
+      sleep: (delayMs) => {
+        state.t += delayMs;
         return Promise.resolve();
       },
     },
-    tick: (ms) => {
-      state.t += ms;
+    tick: (delayMs) => {
+      state.t += delayMs;
     },
   };
 }

--- a/test/sources/test_githubIssues.ts
+++ b/test/sources/test_githubIssues.ts
@@ -49,8 +49,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };

--- a/test/sources/test_githubReleases.ts
+++ b/test/sources/test_githubReleases.ts
@@ -48,8 +48,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };

--- a/test/sources/test_httpFetcher.ts
+++ b/test/sources/test_httpFetcher.ts
@@ -15,20 +15,20 @@ import { HostRateLimiter, type RateLimiterDeps } from "../../server/workspace/so
 // Controllable clock for the rate limiter.
 function controllableClock(start = 0): {
   deps: RateLimiterDeps;
-  tick: (ms: number) => void;
+  tick: (delayMs: number) => void;
   read: () => number;
 } {
   const state = { t: start };
   return {
     deps: {
       now: () => state.t,
-      sleep: (ms) => {
-        state.t += ms;
+      sleep: (delayMs) => {
+        state.t += delayMs;
         return Promise.resolve();
       },
     },
-    tick: (ms) => {
-      state.t += ms;
+    tick: (delayMs) => {
+      state.t += delayMs;
     },
     read: () => state.t,
   };

--- a/test/sources/test_interests.ts
+++ b/test/sources/test_interests.ts
@@ -2,9 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { scoreItem, scoreAndFilter, loadInterests, type InterestsProfile } from "../../server/workspace/sources/interests.js";
 import type { SourceItem } from "../../server/workspace/sources/types.js";
-import fs from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 
 function makeItem(overrides: Partial<SourceItem> = {}): SourceItem {
   return {
@@ -163,17 +163,17 @@ describe("scoreAndFilter", () => {
 
 describe("loadInterests", () => {
   it("returns null when file doesn't exist", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const result = loadInterests(tmpDir);
     assert.equal(result, null);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 
   it("loads valid interests file", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const configDir = path.join(tmpDir, "config");
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
       path.join(configDir, "interests.json"),
       JSON.stringify({
         keywords: ["AI", "ML"],
@@ -188,46 +188,46 @@ describe("loadInterests", () => {
     assert.deepEqual(result!.categories, ["ai"]);
     assert.equal(result!.minRelevance, 0.3);
     assert.equal(result!.maxNotificationsPerRun, 10);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 
   it("returns null for empty keywords and categories", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const configDir = path.join(tmpDir, "config");
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, "interests.json"), JSON.stringify({ keywords: [], categories: [] }));
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, "interests.json"), JSON.stringify({ keywords: [], categories: [] }));
     const result = loadInterests(tmpDir);
     assert.equal(result, null);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 
   it("returns null for invalid JSON", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const configDir = path.join(tmpDir, "config");
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, "interests.json"), "not json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, "interests.json"), "not json");
     const result = loadInterests(tmpDir);
     assert.equal(result, null);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 
   it("uses defaults for missing optional fields", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const configDir = path.join(tmpDir, "config");
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, "interests.json"), JSON.stringify({ keywords: ["test"] }));
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, "interests.json"), JSON.stringify({ keywords: ["test"] }));
     const result = loadInterests(tmpDir);
     assert.notEqual(result, null);
     assert.equal(result!.minRelevance, 0.5);
     assert.equal(result!.maxNotificationsPerRun, 5);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 
   it("filters invalid category slugs", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "interests-"));
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "interests-"));
     const configDir = path.join(tmpDir, "config");
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
       path.join(configDir, "interests.json"),
       JSON.stringify({
         keywords: ["test"],
@@ -237,6 +237,6 @@ describe("loadInterests", () => {
     const result = loadInterests(tmpDir);
     assert.notEqual(result, null);
     assert.deepEqual(result!.categories, ["ai", "security"]);
-    fs.rmSync(tmpDir, { recursive: true });
+    rmSync(tmpDir, { recursive: true });
   });
 });

--- a/test/sources/test_pipelineDedup.ts
+++ b/test/sources/test_pipelineDedup.ts
@@ -3,11 +3,11 @@ import assert from "node:assert/strict";
 import { dedupAcrossSources } from "../../server/workspace/sources/pipeline/dedup.js";
 import type { SourceItem } from "../../server/workspace/sources/types.js";
 
-function makeItem(id: string, sourceSlug: string): SourceItem {
+function makeItem(itemId: string, sourceSlug: string): SourceItem {
   return {
-    id,
-    title: `Item ${id}`,
-    url: `https://example.com/${id}`,
+    id: itemId,
+    title: `Item ${itemId}`,
+    url: `https://example.com/${itemId}`,
     publishedAt: "2026-04-13T00:00:00Z",
     categories: ["tech-news"],
     sourceSlug,

--- a/test/sources/test_pipelineEntry.ts
+++ b/test/sources/test_pipelineEntry.ts
@@ -49,8 +49,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };
@@ -350,14 +350,14 @@ describe("toLocalIsoDate", () => {
   it("formats local YYYY-MM-DD with zero-padded components", () => {
     // January 1st local midnight — ensures zero-padding on both
     // month and day.
-    const ms = new Date(2026, 0, 1, 0, 0, 0).getTime();
-    assert.equal(toLocalIsoDate(ms), "2026-01-01");
+    const delayMs = new Date(2026, 0, 1, 0, 0, 0).getTime();
+    assert.equal(toLocalIsoDate(delayMs), "2026-01-01");
   });
 
   it("keeps local time even when UTC would roll over", () => {
     // 23:00 local on 2026-04-13 is still 2026-04-13 regardless
     // of which way the UTC offset slides.
-    const ms = new Date(2026, 3, 13, 23, 0, 0).getTime();
-    assert.equal(toLocalIsoDate(ms), "2026-04-13");
+    const delayMs = new Date(2026, 3, 13, 23, 0, 0).getTime();
+    assert.equal(toLocalIsoDate(delayMs), "2026-04-13");
   });
 });

--- a/test/sources/test_pipelineFetch.ts
+++ b/test/sources/test_pipelineFetch.ts
@@ -39,8 +39,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };

--- a/test/sources/test_pipelineFetchersIntegration.ts
+++ b/test/sources/test_pipelineFetchersIntegration.ts
@@ -53,8 +53,8 @@ function controllableClock(): RateLimiterDeps {
   const state = { t: 0 };
   return {
     now: () => state.t,
-    sleep: (ms) => {
-      state.t += ms;
+    sleep: (delayMs) => {
+      state.t += delayMs;
       return Promise.resolve();
     },
   };

--- a/test/sources/test_pipelineSummarize.ts
+++ b/test/sources/test_pipelineSummarize.ts
@@ -63,9 +63,9 @@ describe("buildSummarizePromptBody", () => {
 
 describe("buildEmptyDayMarkdown", () => {
   it("produces a minimal 'nothing new' markdown for empty days", () => {
-    const md = buildEmptyDayMarkdown("2026-04-13");
-    assert.match(md, /^# Daily brief — 2026-04-13/);
-    assert.match(md, /No new items today/);
+    const markdown = buildEmptyDayMarkdown("2026-04-13");
+    assert.match(markdown, /^# Daily brief — 2026-04-13/);
+    assert.match(markdown, /No new items today/);
   });
 });
 

--- a/test/sources/test_pipelineWrite.ts
+++ b/test/sources/test_pipelineWrite.ts
@@ -70,8 +70,8 @@ describe("buildDailyJsonIndex", () => {
 
 describe("assembleDailyFile", () => {
   it("appends a ```json fenced block with the structured index", () => {
-    const md = "# Daily brief\n\n## AI\n- foo\n";
-    const file = assembleDailyFile(md, [makeItem()]);
+    const markdown = "# Daily brief\n\n## AI\n- foo\n";
+    const file = assembleDailyFile(markdown, [makeItem()]);
     assert.match(file, /# Daily brief/);
     assert.match(file, /```json/);
     // JSON block must parse.
@@ -152,32 +152,32 @@ describe("groupItemsForArchive", () => {
 
 describe("renderItemForArchive", () => {
   it("renders title, metadata, summary and the trailing separator", () => {
-    const md = renderItemForArchive(makeItem({ title: "Cool thing", summary: "It's cool" }));
-    assert.match(md, /^## Cool thing/);
-    assert.match(md, /\*\*Published:\*\* 2026-04-13T10:00:00Z/);
-    assert.match(md, /\*\*Source:\*\* hn/);
-    assert.match(md, /\*\*URL:\*\* https:\/\/example\.com\/a/);
-    assert.match(md, /\*\*Categories:\*\* tech-news, ai/);
-    assert.match(md, /It's cool/);
+    const markdown = renderItemForArchive(makeItem({ title: "Cool thing", summary: "It's cool" }));
+    assert.match(markdown, /^## Cool thing/);
+    assert.match(markdown, /\*\*Published:\*\* 2026-04-13T10:00:00Z/);
+    assert.match(markdown, /\*\*Source:\*\* hn/);
+    assert.match(markdown, /\*\*URL:\*\* https:\/\/example\.com\/a/);
+    assert.match(markdown, /\*\*Categories:\*\* tech-news, ai/);
+    assert.match(markdown, /It's cool/);
     // Ends with the separator line (blank + --- + final newline).
-    assert.match(md, /---\n$/);
+    assert.match(markdown, /---\n$/);
   });
 
   it("omits content when identical to summary (no repetition)", () => {
-    const md = renderItemForArchive(makeItem({ summary: "same text", content: "same text" }));
+    const markdown = renderItemForArchive(makeItem({ summary: "same text", content: "same text" }));
     // summary appears once, not twice.
-    const matches = md.match(/same text/g) ?? [];
+    const matches = markdown.match(/same text/g) ?? [];
     assert.equal(matches.length, 1);
   });
 
   it("includes severity line when set", () => {
-    const md = renderItemForArchive(makeItem({ severity: "critical" }));
-    assert.match(md, /\*\*Severity:\*\* critical/);
+    const markdown = renderItemForArchive(makeItem({ severity: "critical" }));
+    assert.match(markdown, /\*\*Severity:\*\* critical/);
   });
 
   it("omits Categories line when categories is empty", () => {
-    const md = renderItemForArchive(makeItem({ categories: [] }));
-    assert.doesNotMatch(md, /\*\*Categories:\*\*/);
+    const markdown = renderItemForArchive(makeItem({ categories: [] }));
+    assert.doesNotMatch(markdown, /\*\*Categories:\*\*/);
   });
 });
 

--- a/test/sources/test_rateLimiter.ts
+++ b/test/sources/test_rateLimiter.ts
@@ -7,20 +7,20 @@ import { HostRateLimiter, DEFAULT_MIN_DELAY_MS, type RateLimiterDeps } from "../
 // without real timers.
 function controllableClock(start = 0): {
   deps: RateLimiterDeps;
-  tick: (ms: number) => void;
+  tick: (delayMs: number) => void;
   read: () => number;
 } {
   const state = { t: start };
   return {
     deps: {
       now: () => state.t,
-      sleep: (ms) => {
-        state.t += ms;
+      sleep: (delayMs) => {
+        state.t += delayMs;
         return Promise.resolve();
       },
     },
-    tick: (ms) => {
-      state.t += ms;
+    tick: (delayMs) => {
+      state.t += delayMs;
     },
     read: () => state.t,
   };
@@ -170,7 +170,7 @@ describe("HostRateLimiter — minimum delay enforcement", () => {
     await lim.run("a.com", async () => "first");
     const before = clock.read();
     await lim.run("a.com", async () => "second");
-    assert.ok(clock.read() - before >= DEFAULT_MIN_DELAY_MS, `expected default ${DEFAULT_MIN_DELAY_MS}ms delay, got ${clock.read() - before}`);
+    assert.ok(clock.read() - before >= DEFAULT_MIN_DELAY_MS, `expected default ${DEFAULT_MIN_DELAY_MS}delayMs delay, got ${clock.read() - before}`);
   });
 
   it("marks finishedAt even on error so the next retry waits", async () => {

--- a/test/sources/test_rss.ts
+++ b/test/sources/test_rss.ts
@@ -271,19 +271,19 @@ describe("updateCursor", () => {
 
 function controllableClock(start = 0): {
   deps: RateLimiterDeps;
-  tick: (ms: number) => void;
+  tick: (delayMs: number) => void;
 } {
   const state = { t: start };
   return {
     deps: {
       now: () => state.t,
-      sleep: (ms) => {
-        state.t += ms;
+      sleep: (delayMs) => {
+        state.t += delayMs;
         return Promise.resolve();
       },
     },
-    tick: (ms) => {
-      state.t += ms;
+    tick: (delayMs) => {
+      state.t += delayMs;
     },
   };
 }

--- a/test/sources/test_urls.ts
+++ b/test/sources/test_urls.ts
@@ -117,9 +117,9 @@ describe("stableItemId", () => {
 
   it("is always 16 hex chars (SHA-256 truncated to 64 bits)", () => {
     for (const input of ["", "x", "https://example.com/a", "https://example.com/" + "x".repeat(1000)]) {
-      const id = stableItemId(input);
-      assert.equal(id.length, 16);
-      assert.match(id, /^[0-9a-f]{16}$/);
+      const itemId = stableItemId(input);
+      assert.equal(itemId.length, 16);
+      assert.match(itemId, /^[0-9a-f]{16}$/);
     }
   });
 

--- a/test/tool-trace/test_index.ts
+++ b/test/tool-trace/test_index.ts
@@ -2,7 +2,7 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm } from "fs/promises";
 import { randomBytes } from "crypto";
-import os from "os";
+import { tmpdir } from "os";
 import path from "path";
 import { createArgsCache, recordToolEvent, type RecordToolEventDeps } from "../../server/workspace/tool-trace/index.js";
 
@@ -19,8 +19,8 @@ async function makeHarness(workspaceRoot: string): Promise<Harness> {
   const resultsFilePath = path.join(workspaceRoot, "chat", `${SID}.jsonl`);
   // `appendFile` will create the dir's parent only if it exists; make
   // it explicit here so the first append doesn't ENOENT.
-  const fs = await import("node:fs/promises");
-  await fs.mkdir(path.dirname(resultsFilePath), { recursive: true });
+  const fsp = await import("node:fs/promises");
+  await fsp.mkdir(path.dirname(resultsFilePath), { recursive: true });
 
   const savedSearches: { workspaceRoot: string; query: string }[] = [];
   const deps: RecordToolEventDeps = {
@@ -56,7 +56,7 @@ describe("recordToolEvent", () => {
   let workspaceRoot: string;
 
   before(async () => {
-    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "tool-trace-drv-"));
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "tool-trace-drv-"));
   });
 
   after(async () => {

--- a/test/tool-trace/test_writeSearch.ts
+++ b/test/tool-trace/test_writeSearch.ts
@@ -51,14 +51,14 @@ describe("computeSearchHash", () => {
 });
 
 describe("computeSearchRelPath", () => {
-  it("builds conversations/searches/YYYY-MM-DD/<slug>-<hash>.markdown", () => {
+  it("builds conversations/searches/YYYY-MM-DD/<slug>-<hash>.md", () => {
     const relPath = computeSearchRelPath({
       query: "熊本地震 2016",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
     assert.ok(relPath.startsWith("conversations/searches/2026-04-13/"));
-    assert.ok(relPath.endsWith(".markdown"));
+    assert.ok(relPath.endsWith(".md"));
   });
 
   it("produces stable path for identical inputs", () => {
@@ -169,7 +169,7 @@ describe("writeSearchResult (I/O)", () => {
       resultBody: "b",
     });
     const dir = path.join(workspaceRoot, "conversations", "searches", "2026-04-13");
-    const files = (await readdir(dir)).filter((name) => name.endsWith(".markdown"));
+    const files = (await readdir(dir)).filter((name) => name.endsWith(".md"));
     // At least two files (prior test in this block wrote one too).
     assert.ok(files.length >= 2);
   });

--- a/test/tool-trace/test_writeSearch.ts
+++ b/test/tool-trace/test_writeSearch.ts
@@ -1,7 +1,7 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, readdir, rm } from "fs/promises";
-import os from "os";
+import { tmpdir } from "os";
 import path from "path";
 import {
   buildSearchMarkdown,
@@ -51,14 +51,14 @@ describe("computeSearchHash", () => {
 });
 
 describe("computeSearchRelPath", () => {
-  it("builds conversations/searches/YYYY-MM-DD/<slug>-<hash>.md", () => {
+  it("builds conversations/searches/YYYY-MM-DD/<slug>-<hash>.markdown", () => {
     const relPath = computeSearchRelPath({
       query: "熊本地震 2016",
       sessionId: SID,
       timestamp: FIXED_TS,
     });
     assert.ok(relPath.startsWith("conversations/searches/2026-04-13/"));
-    assert.ok(relPath.endsWith(".md"));
+    assert.ok(relPath.endsWith(".markdown"));
   });
 
   it("produces stable path for identical inputs", () => {
@@ -92,39 +92,39 @@ describe("computeSearchRelPath", () => {
 
 describe("buildSearchMarkdown", () => {
   it("includes YAML frontmatter + heading + body", () => {
-    const md = buildSearchMarkdown({
+    const markdown = buildSearchMarkdown({
       query: "foo",
       sessionId: SID,
       timestamp: FIXED_TS,
       resultBody: "- result 1\n- result 2",
     });
-    assert.ok(md.startsWith("---\n"));
-    assert.ok(md.includes(`query: foo`));
-    assert.ok(md.includes(`sessionId: ${SID}`));
-    assert.ok(md.includes(`ts: 2026-04-13T05:18:47.123Z`));
-    assert.ok(md.includes("# Search: foo"));
-    assert.ok(md.includes("- result 1"));
-    assert.ok(md.endsWith("\n"), "should end with a trailing newline");
+    assert.ok(markdown.startsWith("---\n"));
+    assert.ok(markdown.includes(`query: foo`));
+    assert.ok(markdown.includes(`sessionId: ${SID}`));
+    assert.ok(markdown.includes(`ts: 2026-04-13T05:18:47.123Z`));
+    assert.ok(markdown.includes("# Search: foo"));
+    assert.ok(markdown.includes("- result 1"));
+    assert.ok(markdown.endsWith("\n"), "should end with a trailing newline");
   });
 
   it("quotes query when it contains a colon", () => {
-    const md = buildSearchMarkdown({
+    const markdown = buildSearchMarkdown({
       query: "a:b",
       sessionId: SID,
       timestamp: FIXED_TS,
       resultBody: "body",
     });
-    assert.ok(md.includes('query: "a:b"'));
+    assert.ok(markdown.includes('query: "a:b"'));
   });
 
   it("passes through unicode queries unchanged in the heading", () => {
-    const md = buildSearchMarkdown({
+    const markdown = buildSearchMarkdown({
       query: "熊本地震",
       sessionId: SID,
       timestamp: FIXED_TS,
       resultBody: "body",
     });
-    assert.ok(md.includes("# Search: 熊本地震"));
+    assert.ok(markdown.includes("# Search: 熊本地震"));
   });
 });
 
@@ -132,7 +132,7 @@ describe("writeSearchResult (I/O)", () => {
   let workspaceRoot: string;
 
   before(async () => {
-    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "tool-trace-"));
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "tool-trace-"));
   });
 
   after(async () => {
@@ -169,7 +169,7 @@ describe("writeSearchResult (I/O)", () => {
       resultBody: "b",
     });
     const dir = path.join(workspaceRoot, "conversations", "searches", "2026-04-13");
-    const files = (await readdir(dir)).filter((name) => name.endsWith(".md"));
+    const files = (await readdir(dir)).filter((name) => name.endsWith(".markdown"));
     // At least two files (prior test in this block wrote one too).
     assert.ok(files.length >= 2);
   });

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -1,47 +1,47 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import { writeFileAtomic, writeFileAtomicSync } from "../../../server/utils/files/atomic.js";
 
 let tmpDir: string;
 
 before(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "atomic-test-"));
 });
 
 after(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("writeFileAtomic", () => {
   it("creates a new file with the expected content", async () => {
     const file = path.join(tmpDir, "new.txt");
     await writeFileAtomic(file, "hello");
-    assert.equal(fs.readFileSync(file, "utf-8"), "hello");
+    assert.equal(readFileSync(file, "utf-8"), "hello");
   });
 
   it("overwrites an existing file atomically", async () => {
     const file = path.join(tmpDir, "overwrite.txt");
     await writeFileAtomic(file, "first");
     await writeFileAtomic(file, "second");
-    assert.equal(fs.readFileSync(file, "utf-8"), "second");
+    assert.equal(readFileSync(file, "utf-8"), "second");
   });
 
   it("creates parent directories if missing", async () => {
     const file = path.join(tmpDir, "deep", "nested", "dir", "file.txt");
     await writeFileAtomic(file, "deep");
-    assert.equal(fs.readFileSync(file, "utf-8"), "deep");
+    assert.equal(readFileSync(file, "utf-8"), "deep");
   });
 
   it("cleans up tmp file on write failure", async () => {
     // Use a directory as the target path — writeFile will fail
     const dir = path.join(tmpDir, "is-a-dir");
-    fs.mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true });
     await assert.rejects(() => writeFileAtomic(dir, "content"));
     // No .tmp file should be left behind
-    const siblings = fs.readdirSync(path.dirname(dir));
+    const siblings = readdirSync(path.dirname(dir));
     const tmps = siblings.filter((file) => file.endsWith(".tmp"));
     assert.equal(tmps.length, 0);
   });
@@ -50,7 +50,7 @@ describe("writeFileAtomic", () => {
     if (process.platform === "win32") return; // chmod no-op on Windows
     const file = path.join(tmpDir, "secret.txt");
     await writeFileAtomic(file, "secret", { mode: 0o600 });
-    const stat = fs.statSync(file);
+    const stat = statSync(file);
     assert.equal(stat.mode & 0o777, 0o600);
   });
 
@@ -58,7 +58,7 @@ describe("writeFileAtomic", () => {
     const file = path.join(tmpDir, "unique.txt");
     // Two concurrent writes should both succeed without collision
     await Promise.all([writeFileAtomic(file, "a", { uniqueTmp: true }), writeFileAtomic(file, "b", { uniqueTmp: true })]);
-    const content = fs.readFileSync(file, "utf-8");
+    const content = readFileSync(file, "utf-8");
     assert.ok(content === "a" || content === "b");
   });
 });
@@ -67,20 +67,20 @@ describe("writeFileAtomicSync", () => {
   it("writes content synchronously", () => {
     const file = path.join(tmpDir, "sync.txt");
     writeFileAtomicSync(file, "sync-content");
-    assert.equal(fs.readFileSync(file, "utf-8"), "sync-content");
+    assert.equal(readFileSync(file, "utf-8"), "sync-content");
   });
 
   it("creates parent directories", () => {
     const file = path.join(tmpDir, "sync-deep", "nested", "file.txt");
     writeFileAtomicSync(file, "deep-sync");
-    assert.equal(fs.readFileSync(file, "utf-8"), "deep-sync");
+    assert.equal(readFileSync(file, "utf-8"), "deep-sync");
   });
 
   it("cleans up tmp on failure", () => {
     const dir = path.join(tmpDir, "sync-is-dir");
-    fs.mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true });
     assert.throws(() => writeFileAtomicSync(dir, "content"));
-    const siblings = fs.readdirSync(path.dirname(dir));
+    const siblings = readdirSync(path.dirname(dir));
     assert.equal(siblings.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 });

--- a/test/utils/files/test_html_io.ts
+++ b/test/utils/files/test_html_io.ts
@@ -1,11 +1,11 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 // html-io imports workspacePath at module load. Override HOME so
-// os.homedir() → temp root, then dynamic-import.
+// homedir() → temp root, then dynamic-import.
 let tmpRoot: string;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
@@ -14,12 +14,12 @@ type HtmlIo = typeof import("../../../server/utils/files/html-io.js");
 let mod: HtmlIo;
 
 before(async () => {
-  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "html-io-test-"));
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "html-io-test-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
-  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   mod = await import("../../../server/utils/files/html-io.js");
 });
 
@@ -28,7 +28,7 @@ after(() => {
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
-  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 describe("readCurrentHtml / writeCurrentHtml", () => {

--- a/test/utils/files/test_html_io.ts
+++ b/test/utils/files/test_html_io.ts
@@ -2,7 +2,7 @@ import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 
 // html-io imports workspacePath at module load. Override HOME so
 // homedir() → temp root, then dynamic-import.

--- a/test/utils/files/test_json.ts
+++ b/test/utils/files/test_json.ts
@@ -1,18 +1,18 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import { loadJsonFile, saveJsonFile, writeJsonAtomic, readJsonOrNull } from "../../../server/utils/files/json.js";
 
 let tmpDir: string;
 
 before(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "json-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "json-test-"));
 });
 
 after(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("loadJsonFile (sync)", () => {
@@ -23,13 +23,13 @@ describe("loadJsonFile (sync)", () => {
 
   it("parses a well-formed JSON file", () => {
     const file = path.join(tmpDir, "good.json");
-    fs.writeFileSync(file, JSON.stringify({ a: "hello" }));
+    writeFileSync(file, JSON.stringify({ a: "hello" }));
     assert.deepEqual(loadJsonFile(file, {}), { a: "hello" });
   });
 
   it("returns default on malformed JSON", () => {
     const file = path.join(tmpDir, "bad.json");
-    fs.writeFileSync(file, "not json");
+    writeFileSync(file, "not json");
     assert.deepEqual(loadJsonFile(file, []), []);
   });
 });
@@ -38,13 +38,13 @@ describe("saveJsonFile (sync)", () => {
   it("writes pretty-printed JSON", () => {
     const file = path.join(tmpDir, "save.json");
     saveJsonFile(file, { b: 2 });
-    assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf-8")), { b: 2 });
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf-8")), { b: 2 });
   });
 
   it("creates parent directories", () => {
     const file = path.join(tmpDir, "save-deep", "nested.json");
     saveJsonFile(file, [1, 2, 3]);
-    assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf-8")), [1, 2, 3]);
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf-8")), [1, 2, 3]);
   });
 });
 
@@ -52,7 +52,7 @@ describe("writeJsonAtomic (async)", () => {
   it("writes atomically and pretty-prints", async () => {
     const file = path.join(tmpDir, "atomic.json");
     await writeJsonAtomic(file, { c: true });
-    const raw = fs.readFileSync(file, "utf-8");
+    const raw = readFileSync(file, "utf-8");
     assert.deepEqual(JSON.parse(raw), { c: true });
     // Pretty-printed: contains newlines
     assert.ok(raw.includes("\n"));
@@ -62,7 +62,7 @@ describe("writeJsonAtomic (async)", () => {
 describe("readJsonOrNull (async)", () => {
   it("returns parsed JSON from a valid file", async () => {
     const file = path.join(tmpDir, "read.json");
-    fs.writeFileSync(file, JSON.stringify({ d: 4 }));
+    writeFileSync(file, JSON.stringify({ d: 4 }));
     assert.deepEqual(await readJsonOrNull(file), { d: 4 });
   });
 
@@ -72,7 +72,7 @@ describe("readJsonOrNull (async)", () => {
 
   it("returns null for malformed JSON", async () => {
     const file = path.join(tmpDir, "corrupt.json");
-    fs.writeFileSync(file, "{broken");
+    writeFileSync(file, "{broken");
     assert.equal(await readJsonOrNull(file), null);
   });
 });

--- a/test/utils/files/test_session_io.ts
+++ b/test/utils/files/test_session_io.ts
@@ -1,8 +1,8 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import {
   createSessionMeta,
   readSessionMeta,
@@ -19,13 +19,13 @@ import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
 let root: string;
 
 before(() => {
-  root = fs.mkdtempSync(path.join(os.tmpdir(), "session-io-test-"));
+  root = mkdtempSync(path.join(tmpdir(), "session-io-test-"));
   // Create the chat dir
-  fs.mkdirSync(path.join(root, WORKSPACE_DIRS.chat), { recursive: true });
+  mkdirSync(path.join(root, WORKSPACE_DIRS.chat), { recursive: true });
 });
 
 after(() => {
-  fs.rmSync(root, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
 });
 
 describe("readSessionMeta", () => {
@@ -35,7 +35,7 @@ describe("readSessionMeta", () => {
 
   it("returns null for corrupt JSON (not crash)", async () => {
     const chatDir = path.join(root, WORKSPACE_DIRS.chat);
-    fs.writeFileSync(path.join(chatDir, "corrupt.json"), "{broken");
+    writeFileSync(path.join(chatDir, "corrupt.json"), "{broken");
     assert.equal(await readSessionMeta("corrupt", root), null);
   });
 
@@ -56,12 +56,12 @@ describe("createSessionMeta", () => {
   });
 
   it("creates parent dir if missing", async () => {
-    const freshRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-io-nodir-"));
+    const freshRoot = mkdtempSync(path.join(tmpdir(), "session-io-nodir-"));
     // Don't pre-create chat dir
     await createSessionMeta("nodir-test", "general", "hi", freshRoot);
     const meta = await readSessionMeta("nodir-test", freshRoot);
     assert.equal(meta?.roleId, "general");
-    fs.rmSync(freshRoot, { recursive: true, force: true });
+    rmSync(freshRoot, { recursive: true, force: true });
   });
 });
 

--- a/test/utils/files/test_session_origin.ts
+++ b/test/utils/files/test_session_origin.ts
@@ -2,11 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { createSessionMeta, backfillOrigin, readSessionMeta } from "../../../server/utils/files/session-io.ts";
 
 function tmpRoot(): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "session-origin-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "session-origin-"));
   mkdirSync(path.join(dir, "conversations", "chat"), { recursive: true });
   return dir;
 }

--- a/test/utils/files/test_todos_io.ts
+++ b/test/utils/files/test_todos_io.ts
@@ -1,18 +1,18 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import { loadTodos, saveTodos, loadColumns, saveColumns } from "../../../server/utils/files/todos-io.js";
 
 let root: string;
 
 before(() => {
-  root = fs.mkdtempSync(path.join(os.tmpdir(), "todos-io-test-"));
+  root = mkdtempSync(path.join(tmpdir(), "todos-io-test-"));
 });
 
 after(() => {
-  fs.rmSync(root, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
 });
 
 describe("loadTodos / saveTodos", () => {
@@ -27,28 +27,28 @@ describe("loadTodos / saveTodos", () => {
   });
 
   it("creates parent dir on save", () => {
-    const freshRoot = fs.mkdtempSync(path.join(os.tmpdir(), "todos-io-nodir-"));
+    const freshRoot = mkdtempSync(path.join(tmpdir(), "todos-io-nodir-"));
     saveTodos([{ id: "2", text: "test" }], freshRoot);
     assert.deepEqual(loadTodos([], freshRoot), [{ id: "2", text: "test" }]);
-    fs.rmSync(freshRoot, { recursive: true, force: true });
+    rmSync(freshRoot, { recursive: true, force: true });
   });
 
   it("returns fallback on corrupt JSON (not crash)", () => {
-    const corruptRoot = fs.mkdtempSync(path.join(os.tmpdir(), "todos-corrupt-"));
+    const corruptRoot = mkdtempSync(path.join(tmpdir(), "todos-corrupt-"));
     const dir = path.join(corruptRoot, "data", "todos");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, "todos.json"), "{broken json");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "todos.json"), "{broken json");
     // Should NOT throw — returns fallback and logs
     assert.deepEqual(loadTodos([], corruptRoot), []);
-    fs.rmSync(corruptRoot, { recursive: true, force: true });
+    rmSync(corruptRoot, { recursive: true, force: true });
   });
 });
 
 describe("loadColumns / saveColumns", () => {
   it("returns fallback when file is missing", () => {
-    const freshRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cols-io-test-"));
+    const freshRoot = mkdtempSync(path.join(tmpdir(), "cols-io-test-"));
     assert.deepEqual(loadColumns(["default"], freshRoot), ["default"]);
-    fs.rmSync(freshRoot, { recursive: true, force: true });
+    rmSync(freshRoot, { recursive: true, force: true });
   });
 
   it("round-trips columns", () => {

--- a/test/utils/files/test_workspace_io.ts
+++ b/test/utils/files/test_workspace_io.ts
@@ -1,11 +1,11 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 // workspace-io imports workspacePath at module load. We override
-// HOME/USERPROFILE so os.homedir() → our temp root, then dynamic-
+// HOME/USERPROFILE so homedir() → our temp root, then dynamic-
 // import so the module picks up the overridden HOME.
 let tmpRoot: string;
 let originalHome: string | undefined;
@@ -15,13 +15,13 @@ type WsIo = typeof import("../../../server/utils/files/workspace-io.js");
 let mod: WsIo;
 
 before(async () => {
-  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ws-io-test-"));
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "ws-io-test-"));
   originalHome = process.env.HOME;
   originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
   // Pre-create the workspace root that paths.ts expects.
-  fs.mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
+  mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   mod = await import("../../../server/utils/files/workspace-io.js");
 });
 
@@ -30,7 +30,7 @@ after(() => {
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
-  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 function wsRoot(): string {
@@ -61,13 +61,13 @@ describe("readWorkspaceText / writeWorkspaceText", () => {
 
   it("write is atomic — no .tmp leftover on success", async () => {
     await mod.writeWorkspaceText("test-atomic/clean.txt", "ok");
-    const entries = fs.readdirSync(path.join(wsRoot(), "test-atomic"));
+    const entries = readdirSync(path.join(wsRoot(), "test-atomic"));
     assert.equal(entries.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 
   it("creates parent directories on write", async () => {
     await mod.writeWorkspaceText("deep/nested/dir/file.md", "content");
-    assert.equal(fs.readFileSync(path.join(wsRoot(), "deep", "nested", "dir", "file.md"), "utf-8"), "content");
+    assert.equal(readFileSync(path.join(wsRoot(), "deep", "nested", "dir", "file.md"), "utf-8"), "content");
   });
 });
 
@@ -131,13 +131,13 @@ describe("ensureWorkspaceDir", () => {
   it("creates a nested directory", () => {
     mod.ensureWorkspaceDir("test-ensure/a/b/c");
     const abs = path.join(wsRoot(), "test-ensure", "a", "b", "c");
-    assert.ok(fs.statSync(abs).isDirectory());
+    assert.ok(statSync(abs).isDirectory());
   });
 
   it("is idempotent", () => {
     mod.ensureWorkspaceDir("test-ensure/idem");
     mod.ensureWorkspaceDir("test-ensure/idem");
     const abs = path.join(wsRoot(), "test-ensure", "idem");
-    assert.ok(fs.statSync(abs).isDirectory());
+    assert.ok(statSync(abs).isDirectory());
   });
 });

--- a/test/utils/files/test_workspace_io.ts
+++ b/test/utils/files/test_workspace_io.ts
@@ -2,7 +2,7 @@ import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 
 // workspace-io imports workspacePath at module load. We override
 // HOME/USERPROFILE so homedir() → our temp root, then dynamic-

--- a/test/utils/role/test_merge.ts
+++ b/test/utils/role/test_merge.ts
@@ -3,9 +3,9 @@ import assert from "node:assert/strict";
 import { mergeRoles } from "../../../src/utils/role/merge.js";
 import type { Role } from "../../../src/config/roles";
 
-function role(id: string, name = id): Role {
+function role(roleId: string, name = roleId): Role {
   return {
-    id,
+    id: roleId,
     name,
     icon: "star",
     prompt: "",

--- a/test/utils/test_file.ts
+++ b/test/utils/test_file.ts
@@ -1,24 +1,24 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { loadJsonFile, saveJsonFile, writeFileAtomic, writeJsonAtomic, readJsonOrNull } from "../../server/utils/files/index.js";
 
 let tmpDir = "";
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-file-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-file-test-"));
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("loadJsonFile (existing)", () => {
   it("returns the parsed JSON when the file exists", () => {
     const filePath = path.join(tmpDir, "x.json");
-    fs.writeFileSync(filePath, JSON.stringify({ hello: "world" }));
+    writeFileSync(filePath, JSON.stringify({ hello: "world" }));
     assert.deepEqual(loadJsonFile<{ hello: string }>(filePath, { hello: "default" }), {
       hello: "world",
     });
@@ -33,7 +33,7 @@ describe("loadJsonFile (existing)", () => {
 
   it("returns the default on malformed JSON", () => {
     const filePath = path.join(tmpDir, "bad.json");
-    fs.writeFileSync(filePath, "{ not valid");
+    writeFileSync(filePath, "{ not valid");
     assert.deepEqual(loadJsonFile<{ x: number }>(filePath, { x: 42 }), {
       x: 42,
     });
@@ -44,7 +44,7 @@ describe("saveJsonFile (existing)", () => {
   it("creates the parent directory and writes pretty JSON", () => {
     const filePath = path.join(tmpDir, "nested", "deep", "x.json");
     saveJsonFile(filePath, { a: 1, b: [2, 3] });
-    const raw = fs.readFileSync(filePath, "utf-8");
+    const raw = readFileSync(filePath, "utf-8");
     assert.ok(raw.includes("\n"), "JSON should be pretty-printed");
     assert.deepEqual(JSON.parse(raw), { a: 1, b: [2, 3] });
   });
@@ -54,34 +54,34 @@ describe("writeFileAtomic", () => {
   it("writes plain text to the target path", async () => {
     const filePath = path.join(tmpDir, "out.txt");
     await writeFileAtomic(filePath, "hello\n");
-    assert.equal(fs.readFileSync(filePath, "utf-8"), "hello\n");
+    assert.equal(readFileSync(filePath, "utf-8"), "hello\n");
   });
 
   it("creates parent directories", async () => {
     const filePath = path.join(tmpDir, "a", "b", "c.txt");
     await writeFileAtomic(filePath, "x");
-    assert.ok(fs.existsSync(filePath));
+    assert.ok(existsSync(filePath));
   });
 
   it("uses a .tmp suffix by default and cleans it up on success", async () => {
     const filePath = path.join(tmpDir, "out.txt");
     await writeFileAtomic(filePath, "hello");
-    assert.ok(!fs.existsSync(`${filePath}.tmp`), "tmp file should not remain");
+    assert.ok(!existsSync(`${filePath}.tmp`), "tmp file should not remain");
   });
 
   it("uses a UUID-suffixed tmp name when uniqueTmp is true", async () => {
     const filePath = path.join(tmpDir, "out.txt");
     await writeFileAtomic(filePath, "hello", { uniqueTmp: true });
     // Final file exists, and no `.tmp` siblings survive.
-    assert.equal(fs.readFileSync(filePath, "utf-8"), "hello");
-    const siblings = fs.readdirSync(tmpDir);
+    assert.equal(readFileSync(filePath, "utf-8"), "hello");
+    const siblings = readdirSync(tmpDir);
     assert.deepEqual(siblings, ["out.txt"]);
   });
 
   it("honours the `mode` option on the final file", async () => {
     const filePath = path.join(tmpDir, "secret.txt");
     await writeFileAtomic(filePath, "shhh", { mode: 0o600 });
-    const stat = fs.statSync(filePath);
+    const stat = statSync(filePath);
     // On POSIX the file-mode bits should reflect 0o600. On Windows
     // node's mode bits are best-effort; skip the assertion there.
     if (process.platform !== "win32") {
@@ -91,17 +91,17 @@ describe("writeFileAtomic", () => {
 
   it("leaves the existing target untouched if the tmp write fails", async () => {
     const filePath = path.join(tmpDir, "out.txt");
-    fs.writeFileSync(filePath, "ORIGINAL");
-    fs.mkdirSync(`${filePath}.tmp`);
+    writeFileSync(filePath, "ORIGINAL");
+    mkdirSync(`${filePath}.tmp`);
     await assert.rejects(writeFileAtomic(filePath, "NEW"));
-    assert.equal(fs.readFileSync(filePath, "utf-8"), "ORIGINAL");
+    assert.equal(readFileSync(filePath, "utf-8"), "ORIGINAL");
   });
 
   it("overwrites an existing file atomically", async () => {
     const filePath = path.join(tmpDir, "data.txt");
-    fs.writeFileSync(filePath, "old");
+    writeFileSync(filePath, "old");
     await writeFileAtomic(filePath, "new");
-    assert.equal(fs.readFileSync(filePath, "utf-8"), "new");
+    assert.equal(readFileSync(filePath, "utf-8"), "new");
   });
 });
 
@@ -109,7 +109,7 @@ describe("writeJsonAtomic", () => {
   it("serialises as pretty JSON and writes atomically", async () => {
     const filePath = path.join(tmpDir, "data.json");
     await writeJsonAtomic(filePath, { hello: "world", n: 1 });
-    const raw = fs.readFileSync(filePath, "utf-8");
+    const raw = readFileSync(filePath, "utf-8");
     assert.ok(raw.includes("\n  "), "pretty-printed with 2-space indent");
     assert.deepEqual(JSON.parse(raw), { hello: "world", n: 1 });
   });
@@ -117,14 +117,14 @@ describe("writeJsonAtomic", () => {
   it("supports arrays, numbers, and nested structures", async () => {
     const filePath = path.join(tmpDir, "nested.json");
     await writeJsonAtomic(filePath, [1, 2, { a: [3, 4] }]);
-    assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf-8")), [1, 2, { a: [3, 4] }]);
+    assert.deepEqual(JSON.parse(readFileSync(filePath, "utf-8")), [1, 2, { a: [3, 4] }]);
   });
 });
 
 describe("readJsonOrNull", () => {
   it("returns the parsed JSON when the file exists", async () => {
     const filePath = path.join(tmpDir, "x.json");
-    fs.writeFileSync(filePath, JSON.stringify({ n: 7 }));
+    writeFileSync(filePath, JSON.stringify({ n: 7 }));
     const got = await readJsonOrNull<{ n: number }>(filePath);
     assert.deepEqual(got, { n: 7 });
   });
@@ -136,7 +136,7 @@ describe("readJsonOrNull", () => {
 
   it("returns null on malformed JSON", async () => {
     const filePath = path.join(tmpDir, "bad.json");
-    fs.writeFileSync(filePath, "not json");
+    writeFileSync(filePath, "not json");
     assert.equal(await readJsonOrNull(filePath), null);
   });
 });

--- a/test/utils/test_fs.ts
+++ b/test/utils/test_fs.ts
@@ -1,8 +1,8 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { tmpdir } from "node:os";
 import { statSafe, readDirSafe, readTextOrNull, resolveWithinRoot } from "../../server/utils/files/safe.js";
 
 // Each test gets its own scratch dir so they can run in parallel and
@@ -11,20 +11,20 @@ import { statSafe, readDirSafe, readTextOrNull, resolveWithinRoot } from "../../
 // (a symlink target of /tmp on some configs) and resolveWithinRoot
 // requires its `rootReal` arg to already be a realpath.
 function makeScratch(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `mulmoclaude-${prefix}-`));
-  return fs.realpathSync(dir);
+  const dir = mkdtempSync(path.join(tmpdir(), `mulmoclaude-${prefix}-`));
+  return realpathSync(dir);
 }
 
 function removeScratch(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  rmSync(dir, { recursive: true, force: true });
 }
 
 describe("statSafe", () => {
   let scratch: string;
   before(() => {
     scratch = makeScratch("statSafe");
-    fs.writeFileSync(path.join(scratch, "file.txt"), "hi");
-    fs.mkdirSync(path.join(scratch, "subdir"));
+    writeFileSync(path.join(scratch, "file.txt"), "hi");
+    mkdirSync(path.join(scratch, "subdir"));
   });
   after(() => removeScratch(scratch));
 
@@ -53,9 +53,9 @@ describe("readDirSafe", () => {
   let scratch: string;
   before(() => {
     scratch = makeScratch("readDirSafe");
-    fs.writeFileSync(path.join(scratch, "a.txt"), "");
-    fs.writeFileSync(path.join(scratch, "b.txt"), "");
-    fs.mkdirSync(path.join(scratch, "sub"));
+    writeFileSync(path.join(scratch, "a.txt"), "");
+    writeFileSync(path.join(scratch, "b.txt"), "");
+    mkdirSync(path.join(scratch, "sub"));
   });
   after(() => removeScratch(scratch));
 
@@ -76,7 +76,7 @@ describe("readDirSafe", () => {
 
   it("returns [] for an empty directory", () => {
     const empty = path.join(scratch, "empty-dir");
-    fs.mkdirSync(empty);
+    mkdirSync(empty);
     assert.deepEqual(readDirSafe(empty), []);
   });
 });
@@ -85,7 +85,7 @@ describe("readTextOrNull", () => {
   let scratch: string;
   before(() => {
     scratch = makeScratch("readTextOrNull");
-    fs.writeFileSync(path.join(scratch, "hi.txt"), "hello world");
+    writeFileSync(path.join(scratch, "hi.txt"), "hello world");
   });
   after(() => removeScratch(scratch));
 
@@ -106,9 +106,9 @@ describe("resolveWithinRoot — happy path", () => {
   let scratch: string;
   before(() => {
     scratch = makeScratch("resolveWithinRoot-happy");
-    fs.writeFileSync(path.join(scratch, "file.txt"), "");
-    fs.mkdirSync(path.join(scratch, "sub"));
-    fs.writeFileSync(path.join(scratch, "sub", "nested.txt"), "");
+    writeFileSync(path.join(scratch, "file.txt"), "");
+    mkdirSync(path.join(scratch, "sub"));
+    writeFileSync(path.join(scratch, "sub", "nested.txt"), "");
   });
   after(() => removeScratch(scratch));
 
@@ -140,14 +140,14 @@ describe("resolveWithinRoot — security: traversal", () => {
   let outsideFile: string;
   before(() => {
     scratch = makeScratch("resolveWithinRoot-traversal");
-    fs.writeFileSync(path.join(scratch, "ok.txt"), "");
+    writeFileSync(path.join(scratch, "ok.txt"), "");
     // Create a file OUTSIDE the root that traversal attacks would
     // try to reach. Put it next to scratch so realpath can find it.
     outsideFile = path.join(path.dirname(scratch), "outside.txt");
-    fs.writeFileSync(outsideFile, "secret");
+    writeFileSync(outsideFile, "secret");
   });
   after(() => {
-    fs.rmSync(outsideFile, { force: true });
+    rmSync(outsideFile, { force: true });
     removeScratch(scratch);
   });
 
@@ -181,13 +181,13 @@ describe("resolveWithinRoot — security: symlinks", () => {
   let outsideFile: string;
   before(() => {
     scratch = makeScratch("resolveWithinRoot-symlinks");
-    fs.writeFileSync(path.join(scratch, "real.txt"), "");
+    writeFileSync(path.join(scratch, "real.txt"), "");
     outsideFile = path.join(path.dirname(scratch), "outside-target.txt");
-    fs.writeFileSync(outsideFile, "secret");
+    writeFileSync(outsideFile, "secret");
     // Symlink inside scratch pointing OUTSIDE — the attack we
     // designed resolveWithinRoot to defeat.
     try {
-      fs.symlinkSync(outsideFile, path.join(scratch, "escape"));
+      symlinkSync(outsideFile, path.join(scratch, "escape"));
     } catch {
       // Some CI environments (e.g. Windows without dev mode) can't
       // create symlinks. Tests below will be skipped via the marker.
@@ -195,25 +195,25 @@ describe("resolveWithinRoot — security: symlinks", () => {
     // Symlink inside scratch pointing to another file inside scratch
     // — a legitimate symlink that should resolve normally.
     try {
-      fs.symlinkSync(path.join(scratch, "real.txt"), path.join(scratch, "alias.txt"));
+      symlinkSync(path.join(scratch, "real.txt"), path.join(scratch, "alias.txt"));
     } catch {
       /* ignore */
     }
   });
   after(() => {
-    fs.rmSync(outsideFile, { force: true });
+    rmSync(outsideFile, { force: true });
     removeScratch(scratch);
   });
 
   it("rejects a symlink that resolves outside the root", () => {
     const escapeLink = path.join(scratch, "escape");
-    if (!fs.existsSync(escapeLink)) return; // platform skip
+    if (!existsSync(escapeLink)) return; // platform skip
     assert.equal(resolveWithinRoot(scratch, "escape"), null);
   });
 
   it("accepts a symlink that resolves inside the root", () => {
     const aliasLink = path.join(scratch, "alias.txt");
-    if (!fs.existsSync(aliasLink)) return; // platform skip
+    if (!existsSync(aliasLink)) return; // platform skip
     // The alias is followed to its target — both are inside scratch.
     assert.equal(resolveWithinRoot(scratch, "alias.txt"), path.join(scratch, "real.txt"));
   });
@@ -230,14 +230,14 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
   let symlinkRoot: string;
   before(() => {
     realRoot = makeScratch("symlinkRoot-real");
-    fs.writeFileSync(path.join(realRoot, "story.json"), "{}");
-    fs.mkdirSync(path.join(realRoot, "sub"));
-    fs.writeFileSync(path.join(realRoot, "sub", "nested.mp4"), "");
+    writeFileSync(path.join(realRoot, "story.json"), "{}");
+    mkdirSync(path.join(realRoot, "sub"));
+    writeFileSync(path.join(realRoot, "sub", "nested.mp4"), "");
     // Create a symlink elsewhere that points at realRoot
     const linkParent = makeScratch("symlinkRoot-link");
     symlinkRoot = path.join(linkParent, "stories-link");
     try {
-      fs.symlinkSync(realRoot, symlinkRoot);
+      symlinkSync(realRoot, symlinkRoot);
     } catch {
       // Platform without symlink support — tests will skip via marker.
     }
@@ -245,7 +245,7 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
   after(() => {
     if (symlinkRoot) {
       try {
-        fs.rmSync(path.dirname(symlinkRoot), { recursive: true, force: true });
+        rmSync(path.dirname(symlinkRoot), { recursive: true, force: true });
       } catch {
         /* ignore */
       }
@@ -254,25 +254,25 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
   });
 
   it("resolves child paths against the realpath of a symlinked root", () => {
-    if (!fs.existsSync(symlinkRoot)) return; // platform skip
+    if (!existsSync(symlinkRoot)) return; // platform skip
     // Caller realpaths the root once at module load — this is the
     // pattern routes/mulmo-script.ts uses for ensureStoriesReal().
-    const rootReal = fs.realpathSync(symlinkRoot);
+    const rootReal = realpathSync(symlinkRoot);
     assert.equal(rootReal, realRoot, "sanity: realpath should follow symlink");
     const out = resolveWithinRoot(rootReal, "story.json");
     assert.equal(out, path.join(realRoot, "story.json"));
   });
 
   it("resolves nested paths under a symlinked root", () => {
-    if (!fs.existsSync(symlinkRoot)) return;
-    const rootReal = fs.realpathSync(symlinkRoot);
+    if (!existsSync(symlinkRoot)) return;
+    const rootReal = realpathSync(symlinkRoot);
     const out = resolveWithinRoot(rootReal, "sub/nested.mp4");
     assert.equal(out, path.join(realRoot, "sub", "nested.mp4"));
   });
 
   it("rejects traversal even when the root is the realpath of a symlink", () => {
-    if (!fs.existsSync(symlinkRoot)) return;
-    const rootReal = fs.realpathSync(symlinkRoot);
+    if (!existsSync(symlinkRoot)) return;
+    const rootReal = realpathSync(symlinkRoot);
     assert.equal(resolveWithinRoot(rootReal, "../../etc/passwd"), null);
   });
 });
@@ -298,7 +298,7 @@ describe("resolveWithinRoot — missing files and edge cases", () => {
   });
 
   it("rejects a path containing a null byte", () => {
-    // Node's fs.realpathSync throws on null bytes, which our catch
+    // Node's realpathSync throws on null bytes, which our catch
     // converts to null. This protects against C-string truncation
     // tricks even though Node itself isn't vulnerable.
     assert.equal(resolveWithinRoot(scratch, "foo\0.txt"), null);

--- a/test/utils/test_gitignore.ts
+++ b/test/utils/test_gitignore.ts
@@ -1,18 +1,18 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { GitignoreFilter, createRootFilter } from "../../server/utils/gitignore.ts";
 
 let tmpDir = "";
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-gitignore-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-gitignore-"));
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("GitignoreFilter", () => {
@@ -40,7 +40,7 @@ describe("GitignoreFilter.childForDir", () => {
   it("inherits parent rules", () => {
     const parent = new GitignoreFilter("*.tmp\n");
     const childDir = path.join(tmpDir, "sub");
-    fs.mkdirSync(childDir);
+    mkdirSync(childDir);
     // No .gitignore in childDir
     const child = parent.childForDir(childDir);
     assert.equal(child.ignores("foo.tmp"), true);
@@ -50,8 +50,8 @@ describe("GitignoreFilter.childForDir", () => {
   it("adds local .gitignore rules on top of parent", () => {
     const parent = new GitignoreFilter("*.tmp\n");
     const childDir = path.join(tmpDir, "sub");
-    fs.mkdirSync(childDir);
-    fs.writeFileSync(path.join(childDir, ".gitignore"), "node_modules/\n");
+    mkdirSync(childDir);
+    writeFileSync(path.join(childDir, ".gitignore"), "node_modules/\n");
     const child = parent.childForDir(childDir);
     // Parent rule
     assert.equal(child.ignores("foo.tmp"), true);
@@ -69,7 +69,7 @@ describe("createRootFilter", () => {
   });
 
   it("reads the root .gitignore", () => {
-    fs.writeFileSync(path.join(tmpDir, ".gitignore"), "github/\n.session-token\n");
+    writeFileSync(path.join(tmpDir, ".gitignore"), "github/\n.session-token\n");
     const filter = createRootFilter(tmpDir);
     assert.equal(filter.ignores("github/"), true);
     assert.equal(filter.ignores("github/repo/file.ts"), true);

--- a/test/utils/test_id.ts
+++ b/test/utils/test_id.ts
@@ -10,8 +10,8 @@ describe("makeId", () => {
   });
 
   it("contains a timestamp segment", () => {
-    const id = makeId("x");
-    const parts = id.split("_");
+    const generatedId = makeId("x");
+    const parts = generatedId.split("_");
     // Format: prefix_timestamp_hex
     assert.equal(parts.length, 3);
     const timestamp = Number(parts[1]);
@@ -20,8 +20,8 @@ describe("makeId", () => {
   });
 
   it("ends with 6 hex characters", () => {
-    const id = makeId("test");
-    const hex = id.split("_")[2];
+    const generatedId = makeId("test");
+    const hex = generatedId.split("_")[2];
     assert.equal(hex.length, 6);
     assert.match(hex, /^[0-9a-f]{6}$/);
   });

--- a/test/utils/test_types.ts
+++ b/test/utils/test_types.ts
@@ -175,8 +175,8 @@ describe("hasStringProp", () => {
   it("narrows type correctly", () => {
     const val: unknown = { id: "abc", count: 5 };
     if (hasStringProp(val, "id")) {
-      const id: string = val.id;
-      assert.equal(id, "abc");
+      const fieldId: string = val.id;
+      assert.equal(fieldId, "abc");
     }
   });
 });

--- a/test/wiki-backlinks/test_index.ts
+++ b/test/wiki-backlinks/test_index.ts
@@ -1,7 +1,7 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from "fs/promises";
-import os from "os";
+import { tmpdir } from "os";
 import path from "path";
 import { maybeAppendWikiBacklinks, type WikiBacklinksDeps } from "../../server/workspace/wiki-backlinks/index.js";
 import { BACKLINKS_MARKER } from "../../server/workspace/wiki-backlinks/sessionBacklinks.js";
@@ -24,7 +24,7 @@ describe("maybeAppendWikiBacklinks (driver)", () => {
   let workspaceRoot: string;
 
   before(async () => {
-    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "wiki-backlinks-"));
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "wiki-backlinks-"));
   });
 
   after(async () => {

--- a/test/workspace/test_custom_dirs.ts
+++ b/test/workspace/test_custom_dirs.ts
@@ -2,11 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import path from "path";
-import os from "os";
+import { tmpdir } from "os";
 import { loadCustomDirs, ensureCustomDirs, buildCustomDirsPrompt, DIR_STRUCTURES } from "../../server/workspace/custom-dirs.ts";
 
 function tmpRoot(): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "custom-dirs-"));
+  const dir = mkdtempSync(path.join(tmpdir(), "custom-dirs-"));
   mkdirSync(path.join(dir, "config"), { recursive: true });
   return dir;
 }

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -1,10 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import os from "node:os";
+import { homedir } from "node:os";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS, WORKSPACE_FILES, EAGER_WORKSPACE_DIRS, workspacePath } from "../../server/workspace/paths.js";
 
-const expectedWorkspacePath = path.join(os.homedir(), "mulmoclaude");
+const expectedWorkspacePath = path.join(homedir(), "mulmoclaude");
 
 describe("workspacePath", () => {
   it("points to ~/mulmoclaude", () => {


### PR DESCRIPTION
## Summary
- Tighten `id-length` exceptions from 10 entries to just `["_", "i", "j", "ok"]` and promote the rule from `warn` to `error`.
- Disable `sonarjs/no-nested-conditional` — the rule has no depth option and our chained ternaries are option tables, not obfuscation.
- Convert the ~60 files that still used `import fs from "fs"` / `import os from "os"` namespace imports to named imports.
- Rename local `md` → `markdown`, `ms` → `delayMs`, `id` → contextual (`sessionId`, `itemId`, `columnId`, `roleId`, `generatedId`, `fieldId`), `en`/`ja` locale constants → `enMessages` / `jaMessages`.

## Items to Confirm / Review
- **i18n rename**: `src/lib/vue-i18n.ts` now declares `messages: { en: enMessages, ja: jaMessages }` — the runtime locale keys (`en`, `ja`) are unchanged so nothing on the message-resolution side should move. Please double-check.
- **`.md` vs `markdown`**: the batch rename accidentally rewrote `.md` file-extension strings in test fixtures in commit 1; commit 2 reverts those. A regex grep confirms no remaining `.markdown` substrings exist outside of identifier names. Flagging this in case there's a legit `"foo.markdown"` somewhere I missed.
- **`no-nested-conditional` → off** is a policy choice, not a batched find-and-fix. If you'd prefer `warn` or a refactor of the 11 sites that would've been flagged, happy to take that approach instead.
- **The two bridge `sort()` comparator renames** (`schedulerHandlers.ts` had been left `a`/`b` in an older state) ended up as `left`/`right` here. Purely cosmetic.

## User Prompt
> ok　ではid-lengthをエラーにできるね。
> no-nested-conditionalって深さ指定できないよね？
> → [user confirmed disabling it rather than refactoring]
> あと、深さ指定については本家で議論がないかgitでみて、なければお願いしておいて。
> あ、で、こっちはPR

## Implementation notes
- Commit 1 (`chore(lint): tighten id-length exceptions …`): 80 files, mechanical namespace-import → named-import conversion across server/, test/, e2e/ plus `md`/`ms` variable rename.
- Commit 2 (`chore(lint): rename remaining id/it/en/ja locals …`): 34 files, the leftover `id`/`it`/`en`/`ja` cases plus the `id-length` warn→error bump.

## Test plan
- [x] `yarn lint` — 0 errors, 5 warnings (all pre-existing `v-html`)
- [x] `yarn typecheck` — clean
- [x] `yarn test` — all suites green
- [ ] CI matrix (Linux/macOS/Windows) — relying on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)