### PR TITLE
feat(i18n): extract PluginLauncher, FileContentHeader, FileContentRenderer

### DIFF
--- a/src/components/FileContentHeader.vue
+++ b/src/components/FileContentHeader.vue
@@ -6,17 +6,17 @@
     <button
       v-if="isMarkdown"
       class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
-      :title="mdRawMode ? 'Show rendered Markdown' : 'Show raw source'"
+      :title="mdRawMode ? t('fileContentHeader.showRendered') : t('fileContentHeader.showRaw')"
       @click="emit('toggleMdRaw')"
     >
-      {{ mdRawMode ? "Rendered" : "Raw" }}
+      {{ mdRawMode ? t("fileContentHeader.rendered") : t("fileContentHeader.raw") }}
     </button>
     <button
       type="button"
       class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
       :class="{ 'ml-auto': !isMarkdown }"
-      title="Close file"
-      aria-label="Close file"
+      :title="t('fileContentHeader.closeFile')"
+      :aria-label="t('fileContentHeader.closeFile')"
       data-testid="close-file-btn"
       @click="emit('deselect')"
     >
@@ -26,7 +26,10 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import { formatDateTime } from "../utils/format/date";
+
+const { t } = useI18n();
 
 defineProps<{
   selectedPath: string | null;

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flex-1 overflow-auto min-h-0">
-    <div v-if="!selectedPath" class="h-full flex items-center justify-center text-gray-400 text-sm">Select a file</div>
+    <div v-if="!selectedPath" class="h-full flex items-center justify-center text-gray-400 text-sm">{{ t("fileContentRenderer.selectFile") }}</div>
     <div v-else-if="contentError" class="p-4 text-sm text-red-600">
       {{ contentError }}
     </div>
-    <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">Loading...</div>
+    <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">{{ t("common.loading") }}</div>
     <template v-else-if="content">
       <template v-if="content.kind === 'text'">
         <!-- Scheduler items.json: render with the scheduler plugin's
@@ -55,7 +55,13 @@
              to restrict script loads to a vetted CDN whitelist +
              inline; connect-src is `'none'` so the page can't
              phone home. See src/utils/html/previewCsp.ts. -->
-        <iframe v-else-if="isHtml" :srcdoc="sandboxedHtml" class="w-full h-full border-0" sandbox="allow-scripts" title="HTML preview" />
+        <iframe
+          v-else-if="isHtml"
+          :srcdoc="sandboxedHtml"
+          class="w-full h-full border-0"
+          sandbox="allow-scripts"
+          :title="t('fileContentRenderer.htmlPreview')"
+        />
         <!-- JSON: pretty-printed with simple syntax coloring. Fall
              back to raw content if the file is malformed. -->
         <pre v-else-if="isJson" class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"><span
@@ -66,7 +72,7 @@
         <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
         <div v-else-if="isJsonl" class="p-4 space-y-2">
           <div v-for="(line, i) in jsonlLines" :key="i" class="rounded border bg-gray-50 p-3" :class="line.parseError ? 'border-red-300' : 'border-gray-200'">
-            <div v-if="line.parseError" class="text-xs text-red-600 mb-1 font-sans">parse error</div>
+            <div v-if="line.parseError" class="text-xs text-red-600 mb-1 font-sans">{{ t("fileContentRenderer.parseError") }}</div>
             <pre class="text-xs font-mono text-gray-800 whitespace-pre-wrap"><span
               v-for="(tok, j) in line.tokens"
               :key="j"
@@ -82,7 +88,12 @@
         <img :src="rawUrl(selectedPath)" :alt="selectedPath" class="max-w-full max-h-full object-contain" />
       </div>
       <!-- PDF -->
-      <iframe v-else-if="content.kind === 'pdf' && selectedPath" :src="rawUrl(selectedPath)" class="w-full h-full border-0" title="PDF preview" />
+      <iframe
+        v-else-if="content.kind === 'pdf' && selectedPath"
+        :src="rawUrl(selectedPath)"
+        class="w-full h-full border-0"
+        :title="t('fileContentRenderer.pdfPreview')"
+      />
       <!-- Audio -->
       <div v-else-if="content.kind === 'audio' && selectedPath" class="h-full flex items-center justify-center p-4">
         <audio :key="selectedPath" :src="rawUrl(selectedPath)" controls preload="metadata" class="w-full max-w-2xl" />
@@ -100,6 +111,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
@@ -113,6 +125,8 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import type { Frontmatter } from "../utils/format/frontmatter";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedPath: string | null;

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -8,12 +8,12 @@
           'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
           isActive(target) ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
         ]"
-        :title="target.title"
+        :title="t(`pluginLauncher.${target.key}.title`)"
         :data-testid="`plugin-launcher-${target.key}`"
         @click="emit('navigate', target)"
       >
         <span class="material-icons text-sm">{{ target.icon }}</span>
-        <span v-if="!compact">{{ target.label }}</span>
+        <span v-if="!compact">{{ t(`pluginLauncher.${target.key}.label`) }}</span>
       </button>
     </template>
   </div>
@@ -21,6 +21,9 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 // Quick-access toolbar sitting above the canvas. Each button
 // switches the canvas to a dedicated view mode via URL
@@ -38,63 +41,27 @@ const props = defineProps<{
 
 export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated view mode
 
+// The `key` is also the i18n lookup prefix (see pluginLauncher.*
+// in src/lang/en.ts). Templates resolve the label / tooltip via
+// `t(\`pluginLauncher.\${target.key}.label\`)` — keeping label/title
+// strings out of this file avoids duplication across locales.
 export interface PluginLauncherTarget {
   /** Stable key for testid + dispatch in App.vue. */
   key: "todos" | "scheduler" | "skills" | "wiki" | "roles" | "files";
   kind: PluginLauncherKind;
   /** Material-icons glyph. */
   icon: string;
-  /** Visible label next to the icon. */
-  label: string;
-  /** Tooltip on hover. */
-  title: string;
 }
 
 const TARGETS: PluginLauncherTarget[] = [
   // ─── Data plugins ───
-  {
-    key: "todos",
-    kind: "view",
-    icon: "checklist",
-    label: "Todos",
-    title: "Open todos (⌘4)",
-  },
-  {
-    key: "scheduler",
-    kind: "view",
-    icon: "event",
-    label: "Schedule",
-    title: "Open schedule (⌘5)",
-  },
-  {
-    key: "wiki",
-    kind: "view",
-    icon: "menu_book",
-    label: "Wiki",
-    title: "Open wiki (⌘6)",
-  },
+  { key: "todos", kind: "view", icon: "checklist" },
+  { key: "scheduler", kind: "view", icon: "event" },
+  { key: "wiki", kind: "view", icon: "menu_book" },
   // ─── Management / navigation ───
-  {
-    key: "skills",
-    kind: "view",
-    icon: "psychology",
-    label: "Skills",
-    title: "Open skills (⌘7)",
-  },
-  {
-    key: "roles",
-    kind: "view",
-    icon: "manage_accounts",
-    label: "Roles",
-    title: "Open roles (⌘8)",
-  },
-  {
-    key: "files",
-    kind: "view",
-    icon: "folder",
-    label: "Files",
-    title: "Open workspace files (⌘3)",
-  },
+  { key: "skills", kind: "view", icon: "psychology" },
+  { key: "roles", kind: "view", icon: "manage_accounts" },
+  { key: "files", kind: "view", icon: "folder" },
 ];
 
 // Index AFTER which the visual separator is inserted (between wiki

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -150,6 +150,27 @@ const en = {
     errAlreadyExists: "Already exists",
     errLabelConflict: 'Label "{label}" already exists',
   },
+  pluginLauncher: {
+    todos: { label: "Todos", title: "Open todos (⌘4)" },
+    scheduler: { label: "Schedule", title: "Open schedule (⌘5)" },
+    wiki: { label: "Wiki", title: "Open wiki (⌘6)" },
+    skills: { label: "Skills", title: "Open skills (⌘7)" },
+    roles: { label: "Roles", title: "Open roles (⌘8)" },
+    files: { label: "Files", title: "Open workspace files (⌘3)" },
+  },
+  fileContentHeader: {
+    showRendered: "Show rendered Markdown",
+    showRaw: "Show raw source",
+    rendered: "Rendered",
+    raw: "Raw",
+    closeFile: "Close file",
+  },
+  fileContentRenderer: {
+    selectFile: "Select a file",
+    htmlPreview: "HTML preview",
+    pdfPreview: "PDF preview",
+    parseError: "parse error",
+  },
 };
 
 export default en;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -141,6 +141,27 @@ const ja = {
     errAlreadyExists: "既に登録されています",
     errLabelConflict: "ラベル「{label}」は既に使用されています",
   },
+  pluginLauncher: {
+    todos: { label: "Todo", title: "Todo を開く (⌘4)" },
+    scheduler: { label: "スケジュール", title: "スケジュールを開く (⌘5)" },
+    wiki: { label: "Wiki", title: "Wiki を開く (⌘6)" },
+    skills: { label: "スキル", title: "スキルを開く (⌘7)" },
+    roles: { label: "ロール", title: "ロールを開く (⌘8)" },
+    files: { label: "ファイル", title: "ワークスペースファイルを開く (⌘3)" },
+  },
+  fileContentHeader: {
+    showRendered: "レンダリング表示",
+    showRaw: "ソース表示",
+    rendered: "レンダリング",
+    raw: "ソース",
+    closeFile: "ファイルを閉じる",
+  },
+  fileContentRenderer: {
+    selectFile: "ファイルを選択してください",
+    htmlPreview: "HTML プレビュー",
+    pdfPreview: "PDF プレビュー",
+    parseError: "パースエラー",
+  },
 };
 
 export default ja;


### PR DESCRIPTION
## Summary

vue-i18n batch 7 (#559 follow-up)。

### 対象

- \`PluginLauncher.vue\` — 6つの launcher ボタン (Todos / Schedule / Wiki / Skills / Roles / Files)。TARGETS から \`label\`/\`title\` カラムを削除し、テンプレで \`t(\`pluginLauncher.\${target.key}.label\`)\` 形式の動的ルックアップに変更（新規 locale 追加時に本ファイルを触らずに済む）
- \`FileContentHeader.vue\` — Rendered/Raw トグル (text + tooltip)、Close file (title + aria-label)
- \`FileContentRenderer.vue\` — \"Select a file\" empty state、Loading (\`common.loading\` 再利用)、HTML/PDF プレビュー iframe title、JSONL ビューの \"parse error\"

### 辞書

- 新規 namespace: \`pluginLauncher\`, \`fileContentHeader\`, \`fileContentRenderer\`
- ja 完全ミラー

## Items to Confirm / Review

- [ ] **PluginLauncher のキー整合性**: \`pluginLauncher.*\` の子キーは TARGETS の \`key\` と完全一致 (\`scheduler\` など) — リネーム時は両方同時に更新する必要
- [ ] **日本語訳**: \"Schedule\" → 「スケジュール」、\"Skills\" → 「スキル」、\"Roles\" → 「ロール」等、ロール名称との一貫性
- [ ] **\`<iframe title>\`**: HTML/PDF プレビューの iframe に title 属性を当てる i18n は a11y 的にも有効

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)