### PR TITLE
fix: rename short identifiers to satisfy id-length lint rule

### DIFF
--- a/server/workspace/sources/pipeline/fetch.ts
+++ b/server/workspace/sources/pipeline/fetch.ts
@@ -112,8 +112,8 @@ export const EMPTY_BACKOFF_MAX_MS = ONE_DAY_MS;
 export function emptyBackoffDelayMs(consecutiveEmptyFetches: number): number {
   if (consecutiveEmptyFetches < EMPTY_FETCH_THRESHOLD) return 0;
   const steps = consecutiveEmptyFetches - EMPTY_FETCH_THRESHOLD;
-  const ms = ONE_HOUR_MS * 2 ** Math.min(steps, 10);
-  return Math.min(ms, EMPTY_BACKOFF_MAX_MS);
+  const delayMs = ONE_HOUR_MS * 2 ** Math.min(steps, 10);
+  return Math.min(delayMs, EMPTY_BACKOFF_MAX_MS);
 }
 
 // Compute the next per-source state given the outcome. Pure.

--- a/server/workspace/sources/pipeline/plan.ts
+++ b/server/workspace/sources/pipeline/plan.ts
@@ -60,9 +60,9 @@ function isWithinBackoff(state: SourceState | undefined, nowMs: number): boolean
   return isFutureTimestamp(state.nextAttemptAt, nowMs) || isFutureTimestamp(state.emptyBackoffUntil, nowMs);
 }
 
-function isFutureTimestamp(ts: string | null | undefined, nowMs: number): boolean {
-  if (!ts) return false;
-  const parsed = Date.parse(ts);
+function isFutureTimestamp(timestamp: string | null | undefined, nowMs: number): boolean {
+  if (!timestamp) return false;
+  const parsed = Date.parse(timestamp);
   if (!Number.isFinite(parsed)) return false;
   return parsed > nowMs;
 }


### PR DESCRIPTION
## Summary
- `yarn lint` の id-length エラー 2 件を解消
- `server/workspace/sources/pipeline/fetch.ts`: `ms` → `delayMs`
- `server/workspace/sources/pipeline/plan.ts`: `ts` → `timestamp`

## Items to Confirm / Review
- 変数名のリネームのみ、ロジックは変更していません
- 残る 4 件の `v-html` warning は既存のもので本 PR のスコープ外

## User Prompt
「lint失敗直して」→「PR、マージ」

## Test plan
- [x] `yarn lint` がエラー 0 件で通る（v-html warning 4件は既存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)