### PR TITLE
feat(i18n): extract SettingsMcpTab strings

### DIFF
--- a/src/components/FileContentHeader.vue
+++ b/src/components/FileContentHeader.vue
@@ -6,17 +6,17 @@
     <button
       v-if="isMarkdown"
       class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
-      :title="mdRawMode ? 'Show rendered Markdown' : 'Show raw source'"
+      :title="mdRawMode ? t('fileContentHeader.showRendered') : t('fileContentHeader.showRaw')"
       @click="emit('toggleMdRaw')"
     >
-      {{ mdRawMode ? "Rendered" : "Raw" }}
+      {{ mdRawMode ? t("fileContentHeader.rendered") : t("fileContentHeader.raw") }}
     </button>
     <button
       type="button"
       class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
       :class="{ 'ml-auto': !isMarkdown }"
-      title="Close file"
-      aria-label="Close file"
+      :title="t('fileContentHeader.closeFile')"
+      :aria-label="t('fileContentHeader.closeFile')"
       data-testid="close-file-btn"
       @click="emit('deselect')"
     >
@@ -26,7 +26,10 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import { formatDateTime } from "../utils/format/date";
+
+const { t } = useI18n();
 
 defineProps<{
   selectedPath: string | null;

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flex-1 overflow-auto min-h-0">
-    <div v-if="!selectedPath" class="h-full flex items-center justify-center text-gray-400 text-sm">Select a file</div>
+    <div v-if="!selectedPath" class="h-full flex items-center justify-center text-gray-400 text-sm">{{ t("fileContentRenderer.selectFile") }}</div>
     <div v-else-if="contentError" class="p-4 text-sm text-red-600">
       {{ contentError }}
     </div>
-    <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">Loading...</div>
+    <div v-else-if="contentLoading" class="p-4 text-sm text-gray-400">{{ t("common.loading") }}</div>
     <template v-else-if="content">
       <template v-if="content.kind === 'text'">
         <!-- Scheduler items.json: render with the scheduler plugin's
@@ -55,7 +55,13 @@
              to restrict script loads to a vetted CDN whitelist +
              inline; connect-src is `'none'` so the page can't
              phone home. See src/utils/html/previewCsp.ts. -->
-        <iframe v-else-if="isHtml" :srcdoc="sandboxedHtml" class="w-full h-full border-0" sandbox="allow-scripts" title="HTML preview" />
+        <iframe
+          v-else-if="isHtml"
+          :srcdoc="sandboxedHtml"
+          class="w-full h-full border-0"
+          sandbox="allow-scripts"
+          :title="t('fileContentRenderer.htmlPreview')"
+        />
         <!-- JSON: pretty-printed with simple syntax coloring. Fall
              back to raw content if the file is malformed. -->
         <pre v-else-if="isJson" class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"><span
@@ -66,7 +72,7 @@
         <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
         <div v-else-if="isJsonl" class="p-4 space-y-2">
           <div v-for="(line, i) in jsonlLines" :key="i" class="rounded border bg-gray-50 p-3" :class="line.parseError ? 'border-red-300' : 'border-gray-200'">
-            <div v-if="line.parseError" class="text-xs text-red-600 mb-1 font-sans">parse error</div>
+            <div v-if="line.parseError" class="text-xs text-red-600 mb-1 font-sans">{{ t("fileContentRenderer.parseError") }}</div>
             <pre class="text-xs font-mono text-gray-800 whitespace-pre-wrap"><span
               v-for="(tok, j) in line.tokens"
               :key="j"
@@ -82,7 +88,12 @@
         <img :src="rawUrl(selectedPath)" :alt="selectedPath" class="max-w-full max-h-full object-contain" />
       </div>
       <!-- PDF -->
-      <iframe v-else-if="content.kind === 'pdf' && selectedPath" :src="rawUrl(selectedPath)" class="w-full h-full border-0" title="PDF preview" />
+      <iframe
+        v-else-if="content.kind === 'pdf' && selectedPath"
+        :src="rawUrl(selectedPath)"
+        class="w-full h-full border-0"
+        :title="t('fileContentRenderer.pdfPreview')"
+      />
       <!-- Audio -->
       <div v-else-if="content.kind === 'audio' && selectedPath" class="h-full flex items-center justify-center p-4">
         <audio :key="selectedPath" :src="rawUrl(selectedPath)" controls preload="metadata" class="w-full max-w-2xl" />
@@ -100,6 +111,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SchedulerView from "../plugins/scheduler/View.vue";
 import TodoExplorer from "./TodoExplorer.vue";
@@ -113,6 +125,8 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import type { Frontmatter } from "../utils/format/frontmatter";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedPath: string | null;

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -8,12 +8,12 @@
           'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
           isActive(target) ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
         ]"
-        :title="target.title"
+        :title="t(`pluginLauncher.${target.key}.title`)"
         :data-testid="`plugin-launcher-${target.key}`"
         @click="emit('navigate', target)"
       >
         <span class="material-icons text-sm">{{ target.icon }}</span>
-        <span v-if="!compact">{{ target.label }}</span>
+        <span v-if="!compact">{{ t(`pluginLauncher.${target.key}.label`) }}</span>
       </button>
     </template>
   </div>
@@ -21,6 +21,9 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 // Quick-access toolbar sitting above the canvas. Each button
 // switches the canvas to a dedicated view mode via URL
@@ -38,63 +41,27 @@ const props = defineProps<{
 
 export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated view mode
 
+// The `key` is also the i18n lookup prefix (see pluginLauncher.*
+// in src/lang/en.ts). Templates resolve the label / tooltip via
+// `t(\`pluginLauncher.\${target.key}.label\`)` — keeping label/title
+// strings out of this file avoids duplication across locales.
 export interface PluginLauncherTarget {
   /** Stable key for testid + dispatch in App.vue. */
   key: "todos" | "scheduler" | "skills" | "wiki" | "roles" | "files";
   kind: PluginLauncherKind;
   /** Material-icons glyph. */
   icon: string;
-  /** Visible label next to the icon. */
-  label: string;
-  /** Tooltip on hover. */
-  title: string;
 }
 
 const TARGETS: PluginLauncherTarget[] = [
   // ─── Data plugins ───
-  {
-    key: "todos",
-    kind: "view",
-    icon: "checklist",
-    label: "Todos",
-    title: "Open todos (⌘4)",
-  },
-  {
-    key: "scheduler",
-    kind: "view",
-    icon: "event",
-    label: "Schedule",
-    title: "Open schedule (⌘5)",
-  },
-  {
-    key: "wiki",
-    kind: "view",
-    icon: "menu_book",
-    label: "Wiki",
-    title: "Open wiki (⌘6)",
-  },
+  { key: "todos", kind: "view", icon: "checklist" },
+  { key: "scheduler", kind: "view", icon: "event" },
+  { key: "wiki", kind: "view", icon: "menu_book" },
   // ─── Management / navigation ───
-  {
-    key: "skills",
-    kind: "view",
-    icon: "psychology",
-    label: "Skills",
-    title: "Open skills (⌘7)",
-  },
-  {
-    key: "roles",
-    kind: "view",
-    icon: "manage_accounts",
-    label: "Roles",
-    title: "Open roles (⌘8)",
-  },
-  {
-    key: "files",
-    kind: "view",
-    icon: "folder",
-    label: "Files",
-    title: "Open workspace files (⌘3)",
-  },
+  { key: "skills", kind: "view", icon: "psychology" },
+  { key: "roles", kind: "view", icon: "manage_accounts" },
+  { key: "files", kind: "view", icon: "folder" },
 ];
 
 // Index AFTER which the visual separator is inserted (between wiki

--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -6,7 +6,7 @@
       <code class="bg-gray-100 px-1 rounded">tsx</code>; paths must live under the workspace when Docker is enabled.
     </p>
 
-    <div v-if="servers.length === 0" class="text-xs text-gray-500 italic" data-testid="mcp-empty">No MCP servers configured yet.</div>
+    <div v-if="servers.length === 0" class="text-xs text-gray-500 italic" data-testid="mcp-empty">{{ t("settingsMcpTab.noServers") }}</div>
 
     <ul v-else class="space-y-2" data-testid="mcp-server-list">
       <li
@@ -25,14 +25,16 @@
             >
             <label class="flex items-center gap-1 text-xs text-gray-600 ml-2">
               <input type="checkbox" :checked="entry.spec.enabled !== false" :data-testid="'mcp-enabled-' + entry.id" @change="onToggleEnabled(idx, $event)" />
-              enabled
+              {{ t("settingsMcpTab.enabled") }}
             </label>
           </div>
-          <button class="text-xs text-red-600 hover:text-red-800" :data-testid="'mcp-remove-' + entry.id" @click="emit('remove', idx)">Remove</button>
+          <button class="text-xs text-red-600 hover:text-red-800" :data-testid="'mcp-remove-' + entry.id" @click="emit('remove', idx)">
+            {{ t("common.remove") }}
+          </button>
         </div>
         <div v-if="entry.spec.type === 'http'" class="text-xs space-y-1">
           <div>
-            <span class="text-gray-500">URL:</span>
+            <span class="text-gray-500">{{ t("settingsMcpTab.urlLabel") }}</span>
             <code class="ml-1">{{ entry.spec.url }}</code>
           </div>
           <div v-if="dockerMode && wouldRewriteLocalhost((entry.spec as HttpSpec).url)" class="text-amber-700">
@@ -41,7 +43,7 @@
         </div>
         <div v-else-if="entry.spec.type === 'stdio'" class="text-xs space-y-1">
           <div>
-            <span class="text-gray-500">Command:</span>
+            <span class="text-gray-500">{{ t("settingsMcpTab.commandLabel") }}</span>
             <code class="ml-1">{{ entry.spec.command }}</code>
             <code v-if="(entry.spec as StdioSpec).args?.length" class="ml-1">
               {{ ((entry.spec as StdioSpec).args ?? []).join(" ") }}
@@ -52,23 +54,23 @@
             class="text-red-600"
             :data-testid="'mcp-docker-warning-' + entry.id"
           >
-            ⚠ Contains paths outside the workspace — will not resolve inside Docker.
+            {{ t("settingsMcpTab.dockerNonWorkspaceWarning") }}
           </div>
         </div>
       </li>
     </ul>
 
     <button v-if="!adding" class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-700 hover:bg-gray-50" data-testid="mcp-add-btn" @click="startAdd">
-      + Add MCP Server
+      {{ t("settingsMcpTab.addServerButton") }}
     </button>
 
     <div v-else class="border border-blue-300 rounded p-3 space-y-2" data-testid="mcp-add-form">
       <label class="block text-xs font-semibold text-gray-700">
-        Name
+        {{ t("settingsMcpTab.nameLabel") }}
         <input
           v-model="draft.id"
           type="text"
-          placeholder="my-server"
+          :placeholder="t('settingsMcpTab.namePlaceholder')"
           class="mt-1 w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
           data-testid="mcp-draft-id"
           @keydown.stop
@@ -77,20 +79,20 @@
       <div class="flex gap-3 text-xs">
         <label class="flex items-center gap-1">
           <input v-model="draft.type" type="radio" value="http" data-testid="mcp-draft-type-http" />
-          HTTP
+          {{ t("settingsMcpTab.typeHttp") }}
         </label>
         <label class="flex items-center gap-1">
           <input v-model="draft.type" type="radio" value="stdio" data-testid="mcp-draft-type-stdio" />
-          Stdio (command)
+          {{ t("settingsMcpTab.typeStdio") }}
         </label>
       </div>
       <div v-if="draft.type === 'http'" class="space-y-2">
         <label class="block text-xs font-semibold text-gray-700">
-          URL
+          {{ t("settingsMcpTab.urlFieldLabel") }}
           <input
             v-model="draft.url"
             type="text"
-            placeholder="https://example.com/mcp"
+            :placeholder="t('settingsMcpTab.urlPlaceholder')"
             class="mt-1 w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
             data-testid="mcp-draft-url"
             @keydown.stop
@@ -99,7 +101,7 @@
       </div>
       <div v-else class="space-y-2">
         <label class="block text-xs font-semibold text-gray-700">
-          Command
+          {{ t("settingsMcpTab.commandFieldLabel") }}
           <select
             v-model="draft.command"
             class="mt-1 w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
@@ -111,11 +113,11 @@
           </select>
         </label>
         <label class="block text-xs font-semibold text-gray-700">
-          Arguments (one per line)
+          {{ t("settingsMcpTab.argsLabel") }}
           <textarea
             v-model="draft.argsText"
             class="mt-1 w-full h-20 px-2 py-1 text-sm font-mono border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-            placeholder="-y&#10;@modelcontextprotocol/server-filesystem&#10;/workspace/path"
+            :placeholder="t('settingsMcpTab.argsPlaceholder')"
             data-testid="mcp-draft-args"
             @keydown.stop
           ></textarea>
@@ -126,9 +128,11 @@
       </div>
       <div class="flex justify-end gap-2">
         <button class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50" data-testid="mcp-draft-cancel" @click="cancelAdd">
-          Cancel
+          {{ t("common.cancel") }}
         </button>
-        <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="mcp-draft-add" @click="commitAdd">Add</button>
+        <button class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" data-testid="mcp-draft-add" @click="commitAdd">
+          {{ t("common.add") }}
+        </button>
       </div>
     </div>
   </div>
@@ -136,6 +140,9 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 // UI-local representation of a configured server. Matches
 // server/config.ts#McpServerEntry. Re-declared here to avoid a
@@ -269,24 +276,24 @@ function commitAdd(): void {
   if (!mcpId) {
     const suggested = ensureUniqueId(suggestIdFromDraft(draft.value));
     if (!suggested) {
-      draftError.value = "Please provide a Name, or enter a URL / args we can derive one from.";
+      draftError.value = t("settingsMcpTab.errNoName");
       return;
     }
     mcpId = suggested;
   }
   if (!ID_RE.test(mcpId)) {
-    draftError.value = "Name must start with a lowercase letter and contain only [a-z0-9_-].";
+    draftError.value = t("settingsMcpTab.errBadName");
     return;
   }
   if (props.servers.some((server) => server.id === mcpId)) {
-    draftError.value = `Server id "${mcpId}" already exists.`;
+    draftError.value = t("settingsMcpTab.errIdExists", { id: mcpId });
     return;
   }
   let spec: ServerSpec;
   if (draft.value.type === "http") {
     const url = draft.value.url.trim();
     if (!/^https?:\/\//.test(url)) {
-      draftError.value = "HTTP URL must start with http:// or https://";
+      draftError.value = t("settingsMcpTab.errBadHttpUrl");
       return;
     }
     spec = { type: "http", url, enabled: true };

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -171,6 +171,27 @@ const enMessages = {
     pdfPreview: "PDF preview",
     parseError: "parse error",
   },
+  settingsMcpTab: {
+    noServers: "No MCP servers configured yet.",
+    enabled: "enabled",
+    urlLabel: "URL:",
+    commandLabel: "Command:",
+    dockerNonWorkspaceWarning: "⚠ Contains paths outside the workspace — will not resolve inside Docker.",
+    addServerButton: "+ Add MCP Server",
+    nameLabel: "Name",
+    namePlaceholder: "my-server",
+    typeHttp: "HTTP",
+    typeStdio: "Stdio (command)",
+    urlFieldLabel: "URL",
+    urlPlaceholder: "https://example.com/mcp",
+    commandFieldLabel: "Command",
+    argsLabel: "Arguments (one per line)",
+    argsPlaceholder: "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
+    errNoName: "Please provide a Name, or enter a URL / args we can derive one from.",
+    errBadName: "Name must start with a lowercase letter and contain only [a-z0-9_-].",
+    errIdExists: 'Server id "{id}" already exists.',
+    errBadHttpUrl: "HTTP URL must start with http:// or https://",
+  },
 };
 
 export default enMessages;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -150,6 +150,27 @@ const en = {
     errAlreadyExists: "Already exists",
     errLabelConflict: 'Label "{label}" already exists',
   },
+  pluginLauncher: {
+    todos: { label: "Todos", title: "Open todos (⌘4)" },
+    scheduler: { label: "Schedule", title: "Open schedule (⌘5)" },
+    wiki: { label: "Wiki", title: "Open wiki (⌘6)" },
+    skills: { label: "Skills", title: "Open skills (⌘7)" },
+    roles: { label: "Roles", title: "Open roles (⌘8)" },
+    files: { label: "Files", title: "Open workspace files (⌘3)" },
+  },
+  fileContentHeader: {
+    showRendered: "Show rendered Markdown",
+    showRaw: "Show raw source",
+    rendered: "Rendered",
+    raw: "Raw",
+    closeFile: "Close file",
+  },
+  fileContentRenderer: {
+    selectFile: "Select a file",
+    htmlPreview: "HTML preview",
+    pdfPreview: "PDF preview",
+    parseError: "parse error",
+  },
 };
 
 export default en;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -162,6 +162,27 @@ const jaMessages = {
     pdfPreview: "PDF プレビュー",
     parseError: "パースエラー",
   },
+  settingsMcpTab: {
+    noServers: "MCP サーバは未設定です。",
+    enabled: "有効",
+    urlLabel: "URL:",
+    commandLabel: "コマンド:",
+    dockerNonWorkspaceWarning: "⚠ ワークスペース外のパスが含まれています — Docker 内では解決されません。",
+    addServerButton: "+ MCP サーバを追加",
+    nameLabel: "名前",
+    namePlaceholder: "my-server",
+    typeHttp: "HTTP",
+    typeStdio: "Stdio (コマンド)",
+    urlFieldLabel: "URL",
+    urlPlaceholder: "https://example.com/mcp",
+    commandFieldLabel: "コマンド",
+    argsLabel: "引数（1行につき1つ）",
+    argsPlaceholder: "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
+    errNoName: "名前を入力するか、URL / 引数から推論できる値を入力してください。",
+    errBadName: "名前は小文字で始まり、[a-z0-9_-] のみ使用できます。",
+    errIdExists: "サーバ ID「{id}」は既に存在します。",
+    errBadHttpUrl: "HTTP URL は http:// または https:// で始める必要があります",
+  },
 };
 
 export default jaMessages;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -141,6 +141,27 @@ const ja = {
     errAlreadyExists: "既に登録されています",
     errLabelConflict: "ラベル「{label}」は既に使用されています",
   },
+  pluginLauncher: {
+    todos: { label: "Todo", title: "Todo を開く (⌘4)" },
+    scheduler: { label: "スケジュール", title: "スケジュールを開く (⌘5)" },
+    wiki: { label: "Wiki", title: "Wiki を開く (⌘6)" },
+    skills: { label: "スキル", title: "スキルを開く (⌘7)" },
+    roles: { label: "ロール", title: "ロールを開く (⌘8)" },
+    files: { label: "ファイル", title: "ワークスペースファイルを開く (⌘3)" },
+  },
+  fileContentHeader: {
+    showRendered: "レンダリング表示",
+    showRaw: "ソース表示",
+    rendered: "レンダリング",
+    raw: "ソース",
+    closeFile: "ファイルを閉じる",
+  },
+  fileContentRenderer: {
+    selectFile: "ファイルを選択してください",
+    htmlPreview: "HTML プレビュー",
+    pdfPreview: "PDF プレビュー",
+    parseError: "パースエラー",
+  },
 };
 
 export default ja;


### PR DESCRIPTION
## Summary

vue-i18n batch 8 (#559 follow-up)。MCP サーバ設定タブの文字列を辞書化。

> **依存**: #581 (batch 7) の上にスタック。#581 マージ後に自動リベース。

### 対象

- \`SettingsMcpTab.vue\` (350 行)
  - Empty state、\`enabled\` チェックボックス、Remove、\`URL:\`/\`Command:\` ラベル
  - Docker 非ワークスペースパス警告
  - \`+ Add MCP Server\` ボタン
  - Add フォーム: Name / HTTP / Stdio (command) / URL / Command / Arguments
  - Name/URL/args placeholder
  - 4種類の validation エラー (errNoName, errBadName, errIdExists with \`{id}\`, errBadHttpUrl)
  - Cancel/Add は \`common.cancel\` / \`common.add\` 再利用

### 辞書

- 新規 namespace: \`settingsMcpTab\`

### Non-goal（後続バッチ）

- MCP 説明文段落（inline \`<code>npx</code>\` 等）
- \"In Docker mode \`localhost\` is rewritten to \`host.docker.internal\`\" のインライン code を含むヒント

## Items to Confirm / Review

- [ ] **\`argsPlaceholder\`**: dictionary で \`\\n\` を使って複数行 placeholder を表現。vue-i18n は改行を保持
- [ ] **サーバ ID エラー**: \`errIdExists\` は \`{id}\` named interpolation で渡す。template literal の ` 記法から置換
- [ ] **既存の \`common.remove\` / \`common.add\` / \`common.cancel\` 再利用**: 設定モーダル/ディレクトリタブと一貫

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)