### PR TITLE
docs: add connection method + public URL columns to bridge table

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -36,20 +36,22 @@ A **bridge** is a tiny process (~100 lines) that translates between a messaging 
 
 ### Bridges
 
-| Package | Description | npm |
-|---|---|---|
-| [@mulmobridge/cli](./cli/) | Terminal bridge | [![npm](https://img.shields.io/npm/v/@mulmobridge/cli)](https://www.npmjs.com/package/@mulmobridge/cli) |
-| [@mulmobridge/telegram](./telegram/) | Telegram bot (photo support, allowlist) | [![npm](https://img.shields.io/npm/v/@mulmobridge/telegram)](https://www.npmjs.com/package/@mulmobridge/telegram) |
-| [@mulmobridge/slack](./slack/) | Slack bot (Socket Mode) | [![npm](https://img.shields.io/npm/v/@mulmobridge/slack)](https://www.npmjs.com/package/@mulmobridge/slack) |
-| [@mulmobridge/discord](./discord/) | Discord bot | [![npm](https://img.shields.io/npm/v/@mulmobridge/discord)](https://www.npmjs.com/package/@mulmobridge/discord) |
-| [@mulmobridge/line](./line/) | LINE bot (webhook) | [![npm](https://img.shields.io/npm/v/@mulmobridge/line)](https://www.npmjs.com/package/@mulmobridge/line) |
-| [@mulmobridge/whatsapp](./whatsapp/) | WhatsApp Cloud API (webhook + HMAC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/whatsapp)](https://www.npmjs.com/package/@mulmobridge/whatsapp) |
-| [@mulmobridge/matrix](./matrix/) | Matrix (matrix-js-sdk) | [![npm](https://img.shields.io/npm/v/@mulmobridge/matrix)](https://www.npmjs.com/package/@mulmobridge/matrix) |
-| [@mulmobridge/irc](./irc/) | IRC (irc-framework) | [![npm](https://img.shields.io/npm/v/@mulmobridge/irc)](https://www.npmjs.com/package/@mulmobridge/irc) |
-| [@mulmobridge/mattermost](./mattermost/) | Mattermost (WebSocket + REST) | [![npm](https://img.shields.io/npm/v/@mulmobridge/mattermost)](https://www.npmjs.com/package/@mulmobridge/mattermost) |
-| [@mulmobridge/zulip](./zulip/) | Zulip (long-polling events API) | [![npm](https://img.shields.io/npm/v/@mulmobridge/zulip)](https://www.npmjs.com/package/@mulmobridge/zulip) |
-| [@mulmobridge/messenger](./messenger/) | Facebook Messenger (webhook + HMAC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/messenger)](https://www.npmjs.com/package/@mulmobridge/messenger) |
-| [@mulmobridge/google-chat](./google-chat/) | Google Chat (webhook + JWT/OIDC) | [![npm](https://img.shields.io/npm/v/@mulmobridge/google-chat)](https://www.npmjs.com/package/@mulmobridge/google-chat) |
+| Package | Description | How it receives messages | Public URL needed? | npm |
+|---|---|---|---|---|
+| [@mulmobridge/cli](./cli/) | Terminal bridge | stdin | No | [![npm](https://img.shields.io/npm/v/@mulmobridge/cli)](https://www.npmjs.com/package/@mulmobridge/cli) |
+| [@mulmobridge/telegram](./telegram/) | Telegram bot (photo support, allowlist) | Long polling (outbound HTTP) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/telegram)](https://www.npmjs.com/package/@mulmobridge/telegram) |
+| [@mulmobridge/slack](./slack/) | Slack bot (Socket Mode) | WebSocket to Slack (outbound) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/slack)](https://www.npmjs.com/package/@mulmobridge/slack) |
+| [@mulmobridge/discord](./discord/) | Discord bot | WebSocket Gateway (outbound) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/discord)](https://www.npmjs.com/package/@mulmobridge/discord) |
+| [@mulmobridge/line](./line/) | LINE bot (webhook) | Inbound HTTP webhook | **Yes** | [![npm](https://img.shields.io/npm/v/@mulmobridge/line)](https://www.npmjs.com/package/@mulmobridge/line) |
+| [@mulmobridge/whatsapp](./whatsapp/) | WhatsApp Cloud API (webhook + HMAC) | Inbound HTTP webhook | **Yes** | [![npm](https://img.shields.io/npm/v/@mulmobridge/whatsapp)](https://www.npmjs.com/package/@mulmobridge/whatsapp) |
+| [@mulmobridge/matrix](./matrix/) | Matrix (matrix-js-sdk) | Sync polling to homeserver (outbound) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/matrix)](https://www.npmjs.com/package/@mulmobridge/matrix) |
+| [@mulmobridge/irc](./irc/) | IRC (irc-framework) | TCP to IRC server (outbound) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/irc)](https://www.npmjs.com/package/@mulmobridge/irc) |
+| [@mulmobridge/mattermost](./mattermost/) | Mattermost (WebSocket + REST) | WebSocket to Mattermost (outbound) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/mattermost)](https://www.npmjs.com/package/@mulmobridge/mattermost) |
+| [@mulmobridge/zulip](./zulip/) | Zulip (long-polling events API) | Long polling (outbound HTTP) | **No** | [![npm](https://img.shields.io/npm/v/@mulmobridge/zulip)](https://www.npmjs.com/package/@mulmobridge/zulip) |
+| [@mulmobridge/messenger](./messenger/) | Facebook Messenger (webhook + HMAC) | Inbound HTTP webhook | **Yes** | [![npm](https://img.shields.io/npm/v/@mulmobridge/messenger)](https://www.npmjs.com/package/@mulmobridge/messenger) |
+| [@mulmobridge/google-chat](./google-chat/) | Google Chat (webhook + JWT/OIDC) | Inbound HTTP webhook | **Yes** | [![npm](https://img.shields.io/npm/v/@mulmobridge/google-chat)](https://www.npmjs.com/package/@mulmobridge/google-chat) |
+
+> **"Public URL needed?"** — Bridges that use inbound webhooks require the bridge process to be reachable from the internet (public IP, ngrok, Cloudflare Tunnel, etc.). Outbound-only bridges (polling / WebSocket) work from behind any NAT or firewall with no extra setup.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Added **"How it receives messages"** column to the Bridges table in `packages/README.md`
- Added **"Public URL needed?"** column — clarifies which bridges require a publicly reachable endpoint

## User Prompt

> packagesのREADMEに、どうやってつないでいるか（とくに中間サーバが必要か）という観点でまとめてほしい。既存の表に追加かな

## Details

Outbound-only bridges (Telegram, Slack, Discord, Matrix, IRC, Mattermost, Zulip) work behind any NAT/firewall — no relay or public URL needed.

Webhook-based bridges (LINE, WhatsApp, Messenger, Google Chat) require a publicly reachable endpoint (ngrok, Cloudflare Tunnel, public server, etc.).

Added a brief explanatory note below the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)