### PR TITLE
feat(i18n): extract plugin View strings (batch 9)

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -192,6 +192,40 @@ const enMessages = {
     errIdExists: 'Server id "{id}" already exists.',
     errBadHttpUrl: "HTTP URL must start with http:// or https://",
   },
+  pluginScheduler: {
+    prev: "Previous",
+    today: "Today",
+    goToday: "Go to today",
+    next: "Next",
+    deleteItem: "Delete item",
+    closeEditor: "Close editor",
+  },
+  pluginCanvas: {
+    undo: "Undo",
+    redo: "Redo",
+    clear: "Clear",
+  },
+  pluginTodo: {
+    clearFilters: "Clear all filters",
+    deleteItem: "Delete item",
+  },
+  pluginWiki: {
+    backToIndex: "Back to index",
+  },
+  pluginPresentHtml: {
+    saveAsPdf: "Save as PDF (opens print dialog)",
+  },
+  pluginManageSource: {
+    titlePlaceholder: "Title (optional)",
+  },
+  pluginManageSkills: {
+    deleteProjectSkill: "Delete this project-scope skill",
+  },
+  pluginSpreadsheet: {
+    valuePlaceholder: "Value",
+    valueOrFormulaPlaceholder: "Value or Formula (e.g., 100 or SUM(B2:B11))",
+    formatPlaceholder: "Format (e.g., $#,##0.00)",
+  },
 };
 
 export default enMessages;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -183,6 +183,40 @@ const jaMessages = {
     errIdExists: "サーバ ID「{id}」は既に存在します。",
     errBadHttpUrl: "HTTP URL は http:// または https:// で始める必要があります",
   },
+  pluginScheduler: {
+    prev: "前へ",
+    today: "今日",
+    goToday: "今日へ移動",
+    next: "次へ",
+    deleteItem: "項目を削除",
+    closeEditor: "エディタを閉じる",
+  },
+  pluginCanvas: {
+    undo: "元に戻す",
+    redo: "やり直し",
+    clear: "クリア",
+  },
+  pluginTodo: {
+    clearFilters: "すべてのフィルタをクリア",
+    deleteItem: "項目を削除",
+  },
+  pluginWiki: {
+    backToIndex: "インデックスに戻る",
+  },
+  pluginPresentHtml: {
+    saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",
+  },
+  pluginManageSource: {
+    titlePlaceholder: "タイトル（省略可）",
+  },
+  pluginManageSkills: {
+    deleteProjectSkill: "このプロジェクト限定スキルを削除",
+  },
+  pluginSpreadsheet: {
+    valuePlaceholder: "値",
+    valueOrFormulaPlaceholder: "値または数式（例: 100, SUM(B2:B11)）",
+    formatPlaceholder: "書式（例: $#,##0.00）",
+  },
 };
 
 export default jaMessages;

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -31,13 +31,25 @@
         </div>
 
         <div class="flex items-center gap-1">
-          <button class="w-8 h-8 flex items-center justify-center rounded border-2 border-gray-300 bg-white hover:bg-gray-50" title="Undo" @click="undo">
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded border-2 border-gray-300 bg-white hover:bg-gray-50"
+            :title="t('pluginCanvas.undo')"
+            @click="undo"
+          >
             <span class="material-icons text-sm">undo</span>
           </button>
-          <button class="w-8 h-8 flex items-center justify-center rounded border-2 border-gray-300 bg-white hover:bg-gray-50" title="Redo" @click="redo">
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded border-2 border-gray-300 bg-white hover:bg-gray-50"
+            :title="t('pluginCanvas.redo')"
+            @click="redo"
+          >
             <span class="material-icons text-sm">redo</span>
           </button>
-          <button class="w-8 h-8 flex items-center justify-center rounded border-2 border-red-300 bg-white hover:bg-red-50" title="Clear" @click="clear">
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded border-2 border-red-300 bg-white hover:bg-red-50"
+            :title="t('pluginCanvas.clear')"
+            @click="clear"
+          >
             <span class="material-icons text-sm">delete</span>
           </button>
         </div>
@@ -88,11 +100,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, nextTick, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import VueDrawingCanvas from "vue-drawing-canvas";
 import type { ToolResult } from "gui-chat-protocol/vue";
 import type { ImageToolData, CanvasDrawingState } from "./definition";
 import { apiPost, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedResult: ToolResult<ImageToolData> | null;

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -86,7 +86,7 @@
                   class="px-3 py-1.5 text-sm rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-40 flex items-center gap-1"
                   :disabled="detailLoading || deleting"
                   data-testid="skill-delete-btn"
-                  title="Delete this project-scope skill"
+                  :title="t('pluginManageSkills.deleteProjectSkill')"
                   @click="deleteSkill"
                 >
                   <span class="material-icons text-base">delete</span>
@@ -139,6 +139,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -146,6 +147,8 @@ import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
 import { apiGet, apiPut, apiDelete } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+
+const { t } = useI18n();
 
 interface SkillDetail {
   name: string;

--- a/src/plugins/manageSource/View.vue
+++ b/src/plugins/manageSource/View.vue
@@ -46,7 +46,7 @@
         <input
           v-model="draft.title"
           class="w-40 text-xs border border-gray-300 rounded px-2 py-1"
-          placeholder="Title (optional)"
+          :placeholder="t('pluginManageSource.titlePlaceholder')"
           data-testid="sources-draft-title"
           @keydown.enter="commitAdd"
         />
@@ -188,12 +188,15 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSourceData, RebuildSummary, Source } from "./index";
 import { apiGet, apiPost, apiDelete } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<ManageSourceData>;

--- a/src/plugins/presentHtml/View.vue
+++ b/src/plugins/presentHtml/View.vue
@@ -5,7 +5,7 @@
       <div class="flex items-center gap-2">
         <button
           class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 shrink-0"
-          title="Save as PDF (opens print dialog)"
+          :title="t('pluginPresentHtml.saveAsPdf')"
           @click="printToPdf"
         >
           <span class="material-icons text-sm align-middle">picture_as_pdf</span>
@@ -25,8 +25,11 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { PresentHtmlData } from "./index";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<PresentHtmlData>;

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -39,11 +39,13 @@
         <div class="flex items-center gap-2">
           <!-- Navigation (calendar modes only) -->
           <template v-if="viewMode !== SCHEDULER_VIEW.list">
-            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" title="Previous" @click="goPrev">
+            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" :title="t('pluginScheduler.prev')" @click="goPrev">
               <span class="material-icons text-sm">chevron_left</span>
             </button>
-            <button class="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded" title="Go to today" @click="goToday">Today</button>
-            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" title="Next" @click="goNext">
+            <button class="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded" :title="t('pluginScheduler.goToday')" @click="goToday">
+              {{ t("pluginScheduler.today") }}
+            </button>
+            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" :title="t('pluginScheduler.next')" @click="goNext">
               <span class="material-icons text-sm">chevron_right</span>
             </button>
             <span class="text-sm text-gray-600 min-w-[140px] text-center">{{ headerLabel }}</span>
@@ -93,7 +95,7 @@
             </div>
             <button
               class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 mt-0.5 shrink-0"
-              title="Delete item"
+              :title="t('pluginScheduler.deleteItem')"
               @click.stop="remove(item)"
             >
               ✕
@@ -205,7 +207,7 @@
       <div v-if="selectedId" class="border-t border-blue-200 bg-blue-50 shrink-0">
         <div class="flex items-center justify-between px-4 py-2 text-sm font-medium text-blue-700">
           <span>Edit item</span>
-          <button class="text-blue-400 hover:text-blue-600 text-xs" title="Close editor" @click="selectedId = null">✕</button>
+          <button class="text-blue-400 hover:text-blue-600 text-xs" :title="t('pluginScheduler.closeEditor')" @click="selectedId = null">✕</button>
         </div>
         <div class="px-3 pb-3">
           <textarea
@@ -247,6 +249,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SchedulerData, ScheduledItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
@@ -254,6 +257,8 @@ import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import TasksTab from "./TasksTab.vue";
 import { isToday } from "../../utils/format/date";
+
+const { t } = useI18n();
 
 type YamlScalar = string | number | boolean | null;
 

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -71,7 +71,7 @@
             v-model="miniEditorValue"
             type="text"
             class="form-input"
-            placeholder="Value"
+            :placeholder="t('pluginSpreadsheet.valuePlaceholder')"
             @keyup.enter="saveMiniEditor"
           />
 
@@ -81,10 +81,16 @@
               v-model="miniEditorFormula"
               type="text"
               class="form-input"
-              placeholder="Value or Formula (e.g., 100 or SUM(B2:B11))"
+              :placeholder="t('pluginSpreadsheet.valueOrFormulaPlaceholder')"
               @keyup.enter="saveMiniEditor"
             />
-            <input v-model="miniEditorFormat" type="text" class="form-input" placeholder="Format (e.g., $#,##0.00)" @keyup.enter="saveMiniEditor" />
+            <input
+              v-model="miniEditorFormat"
+              type="text"
+              class="form-input"
+              :placeholder="t('pluginSpreadsheet.formatPlaceholder')"
+              @keyup.enter="saveMiniEditor"
+            />
           </template>
 
           <button class="save-btn" @click="saveMiniEditor">Update</button>
@@ -97,6 +103,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, onMounted, onUnmounted } from "vue";
+import { useI18n } from "vue-i18n";
 import * as XLSX from "xlsx";
 import type { ToolResult } from "gui-chat-protocol";
 import type { SpreadsheetToolData, SpreadsheetSheet } from "./definition";
@@ -118,6 +125,8 @@ import { apiGet, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import type { FilesContentResponseLike } from "./engine/responseDecoder";
 import { isObj, isRecord } from "../../utils/types";
+
+const { t } = useI18n();
 
 /**
  * Normalize malformed data structures

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -27,7 +27,12 @@
         {{ entry.label }}
         <span class="opacity-60">{{ entry.count }}</span>
       </button>
-      <button v-if="activeFilters.size > 0" class="ml-auto text-xs text-gray-500 hover:text-gray-700" title="Clear all filters" @click="clearFilters">
+      <button
+        v-if="activeFilters.size > 0"
+        class="ml-auto text-xs text-gray-500 hover:text-gray-700"
+        :title="t('pluginTodo.clearFilters')"
+        @click="clearFilters"
+      >
         Clear ✕
       </button>
     </div>
@@ -62,7 +67,7 @@
           </div>
           <button
             class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 shrink-0"
-            title="Delete item"
+            :title="t('pluginTodo.deleteItem')"
             @click.stop="remove(item)"
           >
             ✕
@@ -94,12 +99,15 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { colorForLabel, filterByLabels, listLabelsWithCount, subtractLabels } from "./labels";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedResult: ToolResultComplete<TodoData>;

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
       <div class="flex items-center gap-3">
-        <button v-if="action !== 'index'" class="text-gray-400 hover:text-gray-700" title="Back to index" @click="navigate('index')">
+        <button v-if="action !== 'index'" class="text-gray-400 hover:text-gray-700" :title="t('pluginWiki.backToIndex')" @click="navigate('index')">
           <span class="material-icons text-base">arrow_back</span>
         </button>
         <h2 class="text-lg font-semibold text-gray-800">{{ title }}</h2>
@@ -83,6 +83,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
@@ -93,6 +94,8 @@ import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImage
 import { apiPost, apiFetchRaw } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   selectedResult?: ToolResultComplete<WikiData>;


### PR DESCRIPTION
## Summary

vue-i18n batch 9 (#559 follow-up)。8 プラグイン View のシンプル属性を辞書化。

### 対象

| File | 内容 |
|------|------|
| scheduler/View.vue | 前/今日/次 ナビ、delete-item、close-editor |
| canvas/View.vue | Undo / Redo / Clear ボタン tooltip |
| todo/View.vue | clear-filters + delete-item |
| wiki/View.vue | Back to index |
| presentHtml/View.vue | Save as PDF tooltip |
| manageSource/View.vue | Title placeholder |
| manageSkills/View.vue | project-skill delete tooltip |
| spreadsheet/View.vue | mini-editor placeholders ×3 |

### 辞書

新規 namespace 8個 (plugin プレフィックス): pluginScheduler / pluginCanvas / pluginTodo / pluginWiki / pluginPresentHtml / pluginManageSource / pluginManageSkills / pluginSpreadsheet

### Non-goal（後続バッチ）

main に追加された \`@intlify/vue-i18n/no-raw-text\` lint が、template 内のインラインテキスト（\"Calendar\", \"Tasks\", \"Apply Changes\" 等）を 490 件 warning として検出中。これらは後続バッチで順次対応予定。本 PR は \`title=\"\" placeholder=\"\" aria-label=\"\"\` の属性値に限定。

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean (warnings 残存は主に no-raw-text、0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)