### PR TITLE
feat(relay): add WhatsApp, Messenger, Google Chat webhook plugins

### DIFF
--- a/packages/relay/src/durable-object.ts
+++ b/packages/relay/src/durable-object.ts
@@ -12,6 +12,9 @@ import { getPlatformByName } from "./platform.js";
 // Import plugins so they register themselves
 import "./webhooks/line.js";
 import "./webhooks/telegram.js";
+import "./webhooks/whatsapp.js";
+import "./webhooks/messenger.js";
+import "./webhooks/google-chat.js";
 
 const MAX_QUEUE_SIZE = 1000;
 const QUEUE_KEY_PREFIX = "q:";

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -11,6 +11,9 @@ import { getPlatformByPath, getConfiguredPlatforms, CONNECTION_MODES } from "./p
 // Each import registers itself via registerPlatform().
 import "./webhooks/line.js";
 import "./webhooks/telegram.js";
+import "./webhooks/whatsapp.js";
+import "./webhooks/messenger.js";
+import "./webhooks/google-chat.js";
 
 export { RelayDurableObject } from "./durable-object.js";
 
@@ -19,59 +22,40 @@ const MAX_BODY_SIZE = 1024 * 1024; // 1MB
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
-
-    // Health check — shows all registered + configured platforms
-    if (url.pathname === "/health") {
-      return Response.json({
-        status: "ok",
-        platforms: getConfiguredPlatforms(env),
-      });
-    }
-
-    // WebSocket — proxy to Durable Object
-    if (url.pathname === "/ws") {
-      return forwardToDurableObject(request, env, "/ws");
-    }
-
-    // Webhooks — only POST
-    if (request.method !== "POST") {
-      return new Response("Method not allowed", { status: 405 });
-    }
-
-    // Body size check (Content-Length header)
-    const contentLength = request.headers.get("content-length");
-    if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
-      return new Response("Payload too large", { status: 413 });
-    }
-
-    // Route to platform plugin by path
-    const plugin = getPlatformByPath(url.pathname);
-    if (!plugin) {
-      return new Response("Not found", { status: 404 });
-    }
-
-    if (plugin.mode !== CONNECTION_MODES.webhook || !plugin.handleWebhook) {
-      return new Response("Not a webhook platform", { status: 400 });
-    }
-
-    if (!plugin.isConfigured(env)) {
-      return new Response(`${plugin.name} not configured`, { status: 404 });
-    }
-
-    try {
-      const body = await readBodyWithLimit(request);
-      const messages = await plugin.handleWebhook(request, body, env);
-      await enqueueMessages(messages, env);
-      return new Response("ok", { status: 200 });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("verification failed") || msg.includes("not configured")) {
-        return new Response("Unauthorized", { status: 401 });
-      }
-      return new Response("Internal error", { status: 500 });
-    }
+    if (url.pathname === "/health") return Response.json({ status: "ok", platforms: getConfiguredPlatforms(env) });
+    if (url.pathname === "/ws") return forwardToDurableObject(request, env, "/ws");
+    if (request.method === "GET") return handleVerificationRequest(request, env, url);
+    if (request.method !== "POST") return new Response("Method not allowed", { status: 405 });
+    return handleWebhookPost(request, env, url);
   },
 };
+
+function handleVerificationRequest(request: Request, env: Env, url: URL): Response {
+  const plugin = getPlatformByPath(url.pathname);
+  if (plugin?.handleVerification) return plugin.handleVerification(request, env);
+  return new Response("Not found", { status: 404 });
+}
+
+async function handleWebhookPost(request: Request, env: Env, url: URL): Promise<Response> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
+    return new Response("Payload too large", { status: 413 });
+  }
+  const plugin = getPlatformByPath(url.pathname);
+  if (!plugin) return new Response("Not found", { status: 404 });
+  if (plugin.mode !== CONNECTION_MODES.webhook || !plugin.handleWebhook) return new Response("Not a webhook platform", { status: 400 });
+  if (!plugin.isConfigured(env)) return new Response(`${plugin.name} not configured`, { status: 404 });
+  try {
+    const body = await readBodyWithLimit(request);
+    const messages = await plugin.handleWebhook(request, body, env);
+    await enqueueMessages(messages, env);
+    return new Response("ok", { status: 200 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("verification failed") || msg.includes("not configured")) return new Response("Unauthorized", { status: 401 });
+    return new Response("Internal error", { status: 500 });
+  }
+}
 
 // ── Helpers ──────────────────────────────────────────────────
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -32,7 +32,7 @@ export default {
 
 function handleVerificationRequest(request: Request, env: Env, url: URL): Response {
   const plugin = getPlatformByPath(url.pathname);
-  if (plugin?.handleVerification) return plugin.handleVerification(request, env);
+  if (plugin?.handleVerification && plugin.isConfigured(env)) return plugin.handleVerification(request, env);
   return new Response("Not found", { status: 404 });
 }
 

--- a/packages/relay/src/platform.ts
+++ b/packages/relay/src/platform.ts
@@ -43,6 +43,12 @@ export interface PlatformPlugin {
   isConfigured(env: Env): boolean;
 
   /**
+   * Respond to a platform's GET webhook verification challenge (e.g. Meta hub.challenge).
+   * Only needed for webhook platforms that require a GET verification step before POSTs.
+   */
+  handleVerification?(request: Request, env: Env): Response;
+
+  /**
    * Handle an incoming webhook request.
    * Only called when mode=webhook. Parse + verify → RelayMessage[].
    */

--- a/packages/relay/src/time.ts
+++ b/packages/relay/src/time.ts
@@ -1,0 +1,11 @@
+// Time constants for the relay Worker.
+//
+// The relay runs as a Cloudflare Worker and is a separate package from the
+// MulmoClaude server, so it cannot import from `server/utils/time.ts`.
+// Duplicating only the constants the Worker actually uses.
+
+export const ONE_SECOND_MS = 1_000;
+export const ONE_HOUR_MS = 60 * 60 * ONE_SECOND_MS;
+export const FIFTEEN_SECONDS_MS = 15 * ONE_SECOND_MS;
+export const TEN_SECONDS_MS = 10 * ONE_SECOND_MS;
+export const ONE_HOUR_S = 60 * 60;

--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -1,0 +1,218 @@
+// Google Chat platform plugin.
+//
+// Required secrets (wrangler secret put):
+//   GOOGLE_CHAT_PROJECT_NUMBER      — Cloud project number (for JWT aud claim)
+//
+// Optional (enables async replies):
+//   GOOGLE_CHAT_SERVICE_ACCOUNT_KEY — Service account JSON (stringified)
+//
+// Google Chat sends events via HTTP POST with an Authorization: Bearer JWT.
+// Replies are delivered asynchronously via the Chat REST API when a
+// service account key is configured; otherwise the relay acknowledges
+// the message but cannot send replies back.
+
+import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
+import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+
+const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
+const JWKS_URL = "https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com";
+const JWKS_CACHE_TTL_MS = 3_600_000;
+const CHAT_API_BASE = "https://chat.googleapis.com/v1";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot";
+const MAX_CHAT_TEXT = 4000;
+
+// ── JWKS cache ──────────────────────────────────────────────────
+
+interface JwkKey {
+  kid: string;
+  kty: string;
+  n: string;
+  e: string;
+  alg?: string;
+}
+let cachedKeys: JwkKey[] = [];
+let cacheExpiresAt = 0;
+
+async function getJwks(): Promise<JwkKey[]> {
+  if (Date.now() < cacheExpiresAt && cachedKeys.length > 0) return cachedKeys;
+  const res = await fetch(JWKS_URL, { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) return cachedKeys;
+  const data: { keys?: unknown[] } = await res.json();
+  if (!Array.isArray(data.keys)) return cachedKeys;
+  const isJwk = (key: unknown): key is JwkKey =>
+    typeof key === "object" && key !== null && typeof (key as JwkKey).kid === "string" && typeof (key as JwkKey).n === "string";
+  cachedKeys = data.keys.filter(isJwk);
+  cacheExpiresAt = Date.now() + JWKS_CACHE_TTL_MS;
+  return cachedKeys;
+}
+
+// ── JWT verification ────────────────────────────────────────────
+
+function b64UrlDecode(str: string): Uint8Array {
+  const padded = str
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(str.length + ((4 - (str.length % 4)) % 4), "=");
+  return Uint8Array.from(atob(padded), (chr) => chr.charCodeAt(0));
+}
+
+function parseJwt(token: string): { header: Record<string, unknown>; payload: Record<string, unknown>; signInput: string; sig: Uint8Array } | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const header = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[0]))) as Record<string, unknown>;
+    const payload = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[1]))) as Record<string, unknown>;
+    return { header, payload, signInput: `${parts[0]}.${parts[1]}`, sig: b64UrlDecode(parts[2]) };
+  } catch {
+    return null;
+  }
+}
+
+async function verifyGoogleJwt(authHeader: string | undefined, projectNumber: string): Promise<boolean> {
+  if (!authHeader?.startsWith("Bearer ")) return false;
+  const token = authHeader.slice(7).trim();
+  const jwt = parseJwt(token);
+  if (!jwt) return false;
+  const { payload, header } = jwt;
+  if (payload.iss !== GOOGLE_CHAT_ISSUER) return false;
+  if (String(payload.aud) !== projectNumber) return false;
+  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) return false;
+  const keyId = typeof header.kid === "string" ? header.kid : "";
+  const alg = typeof header.alg === "string" ? header.alg : "RS256";
+  const hashAlg = alg === "RS256" ? "SHA-256" : alg === "RS384" ? "SHA-384" : "SHA-512";
+  const keys = await getJwks();
+  const jwk = keys.find((key) => key.kid === keyId);
+  if (!jwk) return false;
+  const pubKey = await crypto.subtle.importKey("jwk", jwk, { name: "RSASSA-PKCS1-v1_5", hash: hashAlg }, false, ["verify"]);
+  return crypto.subtle.verify("RSASSA-PKCS1-v1_5", pubKey, jwt.sig, new TextEncoder().encode(jwt.signInput));
+}
+
+// ── Payload parsing ─────────────────────────────────────────────
+
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+interface ChatMessage {
+  spaceName: string;
+  text: string;
+}
+
+function parseMessage(body: unknown): ChatMessage | null {
+  if (!isObj(body) || body.type !== "MESSAGE") return null;
+  const msg = body.message;
+  if (!isObj(msg) || typeof msg.text !== "string") return null;
+  const space = msg.space;
+  if (!isObj(space) || typeof space.name !== "string") return null;
+  return { spaceName: space.name, text: msg.text.trim() };
+}
+
+// ── Service account → access token ─────────────────────────────
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+}
+
+function parseServiceAccount(raw: string): ServiceAccount | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isObj(parsed) || typeof parsed.client_email !== "string" || typeof parsed.private_key !== "string") return null;
+    return { client_email: parsed.client_email, private_key: parsed.private_key };
+  } catch {
+    return null;
+  }
+}
+
+function b64UrlEncode(data: Uint8Array): string {
+  return btoa(String.fromCharCode(...data))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+async function makeServiceAccountJwt(account: ServiceAccount): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64UrlEncode(new TextEncoder().encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
+  const claims = b64UrlEncode(
+    new TextEncoder().encode(JSON.stringify({ iss: account.client_email, scope: CHAT_SCOPE, aud: GOOGLE_TOKEN_URL, exp: now + 3600, iat: now })),
+  );
+  const pemContents = account.private_key.replace(/-----[^-]+-----/g, "").replace(/\s/g, "");
+  const keyBuffer = Uint8Array.from(atob(pemContents), (chr) => chr.charCodeAt(0));
+  const privateKey = await crypto.subtle.importKey("pkcs8", keyBuffer, { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }, false, ["sign"]);
+  const sig = b64UrlEncode(new Uint8Array(await crypto.subtle.sign("RSASSA-PKCS1-v1_5", privateKey, new TextEncoder().encode(`${header}.${claims}`))));
+  return `${header}.${claims}.${sig}`;
+}
+
+async function getGoogleAccessToken(account: ServiceAccount): Promise<string> {
+  const jwt = await makeServiceAccountJwt(account);
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: `grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}`,
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`Google token exchange failed: ${res.status}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+// ── Plugin ──────────────────────────────────────────────────────
+
+const googleChatPlugin: PlatformPlugin = {
+  name: PLATFORMS.googleChat,
+  mode: CONNECTION_MODES.webhook,
+  webhookPath: "/webhook/google-chat",
+
+  isConfigured(env: Env): boolean {
+    return !!env.GOOGLE_CHAT_PROJECT_NUMBER;
+  },
+
+  async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {
+    const authHeader = request.headers.get("authorization") ?? undefined;
+    const valid = await verifyGoogleJwt(authHeader, String(env.GOOGLE_CHAT_PROJECT_NUMBER));
+    if (!valid) throw new Error("Google Chat JWT verification failed");
+
+    const parsed = parseMessage(JSON.parse(body));
+    if (!parsed || !parsed.text) return [];
+
+    return [
+      {
+        id: crypto.randomUUID(),
+        platform: PLATFORMS.googleChat,
+        senderId: parsed.spaceName,
+        chatId: parsed.spaceName,
+        text: parsed.text,
+        receivedAt: new Date().toISOString(),
+      },
+    ];
+  },
+
+  async sendResponse(chatId: string, text: string, env: Env): Promise<void> {
+    const saKeyRaw = typeof env.GOOGLE_CHAT_SERVICE_ACCOUNT_KEY === "string" ? env.GOOGLE_CHAT_SERVICE_ACCOUNT_KEY : "";
+    if (!saKeyRaw) {
+      console.warn(`[google-chat] reply not delivered (no service account): ${chatId}`);
+      return;
+    }
+    const account = parseServiceAccount(saKeyRaw);
+    if (!account) throw new Error("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY is not valid JSON");
+
+    const accessToken = await getGoogleAccessToken(account);
+    const chunks =
+      text.length <= MAX_CHAT_TEXT
+        ? [text]
+        : Array.from({ length: Math.ceil(text.length / MAX_CHAT_TEXT) }, (_, i) => text.slice(i * MAX_CHAT_TEXT, (i + 1) * MAX_CHAT_TEXT));
+    for (const chunk of chunks) {
+      const res = await fetch(`${CHAT_API_BASE}/${chatId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ text: chunk }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) throw new Error(`Google Chat API failed: ${res.status}`);
+    }
+  },
+};
+
+registerPlatform(googleChatPlugin);

--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -11,12 +11,14 @@
 // service account key is configured; otherwise the relay acknowledges
 // the message but cannot send replies back.
 
+import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
 
 const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
 const JWKS_URL = "https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com";
-const JWKS_CACHE_TTL_MS = 3_600_000;
+const JWKS_CACHE_TTL_MS = ONE_HOUR_MS;
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot";
@@ -36,7 +38,7 @@ let cacheExpiresAt = 0;
 
 async function getJwks(): Promise<JwkKey[]> {
   if (Date.now() < cacheExpiresAt && cachedKeys.length > 0) return cachedKeys;
-  const res = await fetch(JWKS_URL, { signal: AbortSignal.timeout(10_000) });
+  const res = await fetch(JWKS_URL, { signal: AbortSignal.timeout(TEN_SECONDS_MS) });
   if (!res.ok) return cachedKeys;
   const data: { keys?: unknown[] } = await res.json();
   if (!Array.isArray(data.keys)) return cachedKeys;
@@ -136,7 +138,7 @@ async function makeServiceAccountJwt(account: ServiceAccount): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const header = b64UrlEncode(new TextEncoder().encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
   const claims = b64UrlEncode(
-    new TextEncoder().encode(JSON.stringify({ iss: account.client_email, scope: CHAT_SCOPE, aud: GOOGLE_TOKEN_URL, exp: now + 3600, iat: now })),
+    new TextEncoder().encode(JSON.stringify({ iss: account.client_email, scope: CHAT_SCOPE, aud: GOOGLE_TOKEN_URL, exp: now + ONE_HOUR_S, iat: now })),
   );
   const pemContents = account.private_key.replace(/-----[^-]+-----/g, "").replace(/\s/g, "");
   const keyBuffer = Uint8Array.from(atob(pemContents), (chr) => chr.charCodeAt(0));
@@ -151,7 +153,7 @@ async function getGoogleAccessToken(account: ServiceAccount): Promise<string> {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: `grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}`,
-    signal: AbortSignal.timeout(10_000),
+    signal: AbortSignal.timeout(TEN_SECONDS_MS),
   });
   if (!res.ok) throw new Error(`Google token exchange failed: ${res.status}`);
   const data = (await res.json()) as { access_token: string };
@@ -199,17 +201,21 @@ const googleChatPlugin: PlatformPlugin = {
     if (!account) throw new Error("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY is not valid JSON");
 
     const accessToken = await getGoogleAccessToken(account);
-    const chunks =
-      text.length <= MAX_CHAT_TEXT
-        ? [text]
-        : Array.from({ length: Math.ceil(text.length / MAX_CHAT_TEXT) }, (_, i) => text.slice(i * MAX_CHAT_TEXT, (i + 1) * MAX_CHAT_TEXT));
+    // chunkText respects code-point boundaries (avoids splitting emoji
+    // surrogate pairs) and keeps parity with WhatsApp / Messenger.
+    const chunks = chunkText(text, MAX_CHAT_TEXT);
     for (const chunk of chunks) {
-      const res = await fetch(`${CHAT_API_BASE}/${chatId}/messages`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
-        body: JSON.stringify({ text: chunk }),
-        signal: AbortSignal.timeout(15_000),
-      });
+      let res: Response;
+      try {
+        res = await fetch(`${CHAT_API_BASE}/${chatId}/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({ text: chunk }),
+          signal: AbortSignal.timeout(FIFTEEN_SECONDS_MS),
+        });
+      } catch (err) {
+        throw new Error(`Google Chat API network error: ${err instanceof Error ? err.message : String(err)}`);
+      }
       if (!res.ok) throw new Error(`Google Chat API failed: ${res.status}`);
     }
   },

--- a/packages/relay/src/webhooks/messenger.ts
+++ b/packages/relay/src/webhooks/messenger.ts
@@ -9,6 +9,7 @@ import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
+import { FIFTEEN_SECONDS_MS } from "../time.js";
 
 const MAX_MESSENGER_TEXT = 2000;
 
@@ -74,14 +75,21 @@ const messengerPlugin: PlatformPlugin = {
     const accessToken = String(env.MESSENGER_PAGE_ACCESS_TOKEN ?? "");
     if (!accessToken) throw new Error("MESSENGER_PAGE_ACCESS_TOKEN not configured");
 
+    // Authorization header (not query string) — Graph API supports it, and
+    // avoids leaking the token into CDN / proxy access logs and error reports.
     const chunks = chunkText(text, MAX_MESSENGER_TEXT);
     for (const chunk of chunks) {
-      const res = await fetch(`https://graph.facebook.com/v21.0/me/messages?access_token=${accessToken}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recipient: { id: chatId }, message: { text: chunk } }),
-        signal: AbortSignal.timeout(15_000),
-      });
+      let res: Response;
+      try {
+        res = await fetch("https://graph.facebook.com/v21.0/me/messages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({ recipient: { id: chatId }, message: { text: chunk } }),
+          signal: AbortSignal.timeout(FIFTEEN_SECONDS_MS),
+        });
+      } catch (err) {
+        throw new Error(`Messenger API network error: ${err instanceof Error ? err.message : String(err)}`);
+      }
       if (!res.ok) {
         const detail = await res.text().catch(() => "");
         throw new Error(`Messenger API failed: ${res.status} ${detail.slice(0, 200)}`);

--- a/packages/relay/src/webhooks/messenger.ts
+++ b/packages/relay/src/webhooks/messenger.ts
@@ -1,0 +1,93 @@
+// Facebook Messenger platform plugin.
+//
+// Required secrets (wrangler secret put):
+//   MESSENGER_APP_SECRET        — App secret for x-hub-signature-256 HMAC
+//   MESSENGER_PAGE_ACCESS_TOKEN — Page access token
+//   MESSENGER_VERIFY_TOKEN      — Arbitrary string for webhook verification
+
+import { chunkText } from "@mulmobridge/client/text";
+import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
+import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
+
+const MAX_MESSENGER_TEXT = 2000;
+
+interface ExtractedMessage {
+  senderId: string;
+  text: string;
+}
+
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseOneEvent(event: unknown): ExtractedMessage | null {
+  if (!isObj(event) || !isObj(event.sender) || typeof event.sender.id !== "string") return null;
+  if (!isObj(event.message) || typeof event.message.text !== "string") return null;
+  const text = event.message.text.trim();
+  if (!text) return null;
+  return { senderId: event.sender.id, text };
+}
+
+function extractMessages(body: unknown): ExtractedMessage[] {
+  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  const out: ExtractedMessage[] = [];
+  for (const entry of body.entry) {
+    if (!isObj(entry) || !Array.isArray(entry.messaging)) continue;
+    for (const event of entry.messaging) {
+      const msg = parseOneEvent(event);
+      if (msg) out.push(msg);
+    }
+  }
+  return out;
+}
+
+const messengerPlugin: PlatformPlugin = {
+  name: PLATFORMS.messenger,
+  mode: CONNECTION_MODES.webhook,
+  webhookPath: "/webhook/messenger",
+
+  isConfigured(env: Env): boolean {
+    return !!env.MESSENGER_APP_SECRET && !!env.MESSENGER_PAGE_ACCESS_TOKEN;
+  },
+
+  handleVerification(request: Request, env: Env): Response {
+    return handleMetaVerification(request, String(env.MESSENGER_VERIFY_TOKEN ?? ""));
+  },
+
+  async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {
+    const signature = request.headers.get("x-hub-signature-256") ?? "";
+    const valid = await verifyMetaSignature(String(env.MESSENGER_APP_SECRET), body, signature);
+    if (!valid) throw new Error("Messenger signature verification failed");
+
+    return extractMessages(JSON.parse(body)).map((msg) => ({
+      id: crypto.randomUUID(),
+      platform: PLATFORMS.messenger,
+      senderId: msg.senderId,
+      chatId: msg.senderId,
+      text: msg.text,
+      receivedAt: new Date().toISOString(),
+    }));
+  },
+
+  async sendResponse(chatId: string, text: string, env: Env): Promise<void> {
+    const accessToken = String(env.MESSENGER_PAGE_ACCESS_TOKEN ?? "");
+    if (!accessToken) throw new Error("MESSENGER_PAGE_ACCESS_TOKEN not configured");
+
+    const chunks = chunkText(text, MAX_MESSENGER_TEXT);
+    for (const chunk of chunks) {
+      const res = await fetch(`https://graph.facebook.com/v21.0/me/messages?access_token=${accessToken}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recipient: { id: chatId }, message: { text: chunk } }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Messenger API failed: ${res.status} ${detail.slice(0, 200)}`);
+      }
+    }
+  },
+};
+
+registerPlatform(messengerPlugin);

--- a/packages/relay/src/webhooks/meta.ts
+++ b/packages/relay/src/webhooks/meta.ts
@@ -1,0 +1,29 @@
+// Shared helpers for Meta platform webhooks (WhatsApp, Messenger).
+// Both use the same x-hub-signature-256 HMAC and hub.challenge verification.
+
+export async function verifyMetaSignature(secret: string, body: string, signature: string): Promise<boolean> {
+  const provided = signature.replace("sha256=", "");
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const sigBytes = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  const expected = Array.from(new Uint8Array(sigBytes))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  if (expected.length !== provided.length) return false;
+  let diff = 0;
+  for (let idx = 0; idx < expected.length; idx++) {
+    diff |= expected.charCodeAt(idx) ^ provided.charCodeAt(idx);
+  }
+  return diff === 0;
+}
+
+export function handleMetaVerification(request: Request, verifyToken: string): Response {
+  const url = new URL(request.url);
+  const mode = url.searchParams.get("hub.mode");
+  const token = url.searchParams.get("hub.verify_token");
+  const challenge = url.searchParams.get("hub.challenge");
+  if (mode === "subscribe" && token === verifyToken) {
+    return new Response(challenge ?? "", { status: 200 });
+  }
+  return new Response("Forbidden", { status: 403 });
+}

--- a/packages/relay/src/webhooks/meta.ts
+++ b/packages/relay/src/webhooks/meta.ts
@@ -2,7 +2,9 @@
 // Both use the same x-hub-signature-256 HMAC and hub.challenge verification.
 
 export async function verifyMetaSignature(secret: string, body: string, signature: string): Promise<boolean> {
-  const provided = signature.replace("sha256=", "");
+  if (!signature.startsWith("sha256=")) return false;
+  const provided = signature.slice("sha256=".length);
+  if (!provided) return false;
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
   const sigBytes = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
@@ -18,6 +20,9 @@ export async function verifyMetaSignature(secret: string, body: string, signatur
 }
 
 export function handleMetaVerification(request: Request, verifyToken: string): Response {
+  // Reject unconfigured deployments — an empty verify token would otherwise
+  // match an empty `hub.verify_token` query param and leak the challenge echo.
+  if (!verifyToken) return new Response("Forbidden", { status: 403 });
   const url = new URL(request.url);
   const mode = url.searchParams.get("hub.mode");
   const token = url.searchParams.get("hub.verify_token");

--- a/packages/relay/src/webhooks/whatsapp.ts
+++ b/packages/relay/src/webhooks/whatsapp.ts
@@ -10,6 +10,7 @@ import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
+import { FIFTEEN_SECONDS_MS } from "../time.js";
 
 const WHATSAPP_API_VERSION = "v21.0";
 const MAX_WA_TEXT = 4096;
@@ -77,12 +78,17 @@ const whatsappPlugin: PlatformPlugin = {
 
     const chunks = chunkText(text, MAX_WA_TEXT);
     for (const chunk of chunks) {
-      const res = await fetch(`https://graph.facebook.com/${WHATSAPP_API_VERSION}/${phoneNumberId}/messages`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
-        body: JSON.stringify({ messaging_product: "whatsapp", to: chatId, type: "text", text: { body: chunk } }),
-        signal: AbortSignal.timeout(15_000),
-      });
+      let res: Response;
+      try {
+        res = await fetch(`https://graph.facebook.com/${WHATSAPP_API_VERSION}/${phoneNumberId}/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({ messaging_product: "whatsapp", to: chatId, type: "text", text: { body: chunk } }),
+          signal: AbortSignal.timeout(FIFTEEN_SECONDS_MS),
+        });
+      } catch (err) {
+        throw new Error(`WhatsApp API network error: ${err instanceof Error ? err.message : String(err)}`);
+      }
       if (!res.ok) {
         const detail = await res.text().catch(() => "");
         throw new Error(`WhatsApp API failed: ${res.status} ${detail.slice(0, 200)}`);

--- a/packages/relay/src/webhooks/whatsapp.ts
+++ b/packages/relay/src/webhooks/whatsapp.ts
@@ -1,0 +1,94 @@
+// WhatsApp Cloud API platform plugin.
+//
+// Required secrets (wrangler secret put):
+//   WHATSAPP_APP_SECRET        — App secret for x-hub-signature-256 HMAC
+//   WHATSAPP_ACCESS_TOKEN      — Permanent access token
+//   WHATSAPP_PHONE_NUMBER_ID   — Phone number ID from Meta dashboard
+//   WHATSAPP_VERIFY_TOKEN      — Arbitrary string for webhook verification
+
+import { chunkText } from "@mulmobridge/client/text";
+import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
+import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
+
+const WHATSAPP_API_VERSION = "v21.0";
+const MAX_WA_TEXT = 4096;
+
+interface WaTextMessage {
+  from: string;
+  text: { body: string };
+}
+
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseOneWaMessage(msg: unknown): WaTextMessage | null {
+  if (!isObj(msg) || msg.type !== "text" || typeof msg.from !== "string") return null;
+  if (!isObj(msg.text) || typeof msg.text.body !== "string" || !msg.text.body.trim()) return null;
+  return { from: msg.from, text: { body: msg.text.body } };
+}
+
+function extractWaMessages(body: unknown): WaTextMessage[] {
+  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  const raw: unknown[] = [];
+  for (const entry of body.entry) {
+    if (!isObj(entry) || !Array.isArray(entry.changes)) continue;
+    for (const change of entry.changes) {
+      if (!isObj(change) || !isObj(change.value) || !Array.isArray(change.value.messages)) continue;
+      raw.push(...change.value.messages);
+    }
+  }
+  return raw.map(parseOneWaMessage).filter((msg): msg is WaTextMessage => msg !== null);
+}
+
+const whatsappPlugin: PlatformPlugin = {
+  name: PLATFORMS.whatsapp,
+  mode: CONNECTION_MODES.webhook,
+  webhookPath: "/webhook/whatsapp",
+
+  isConfigured(env: Env): boolean {
+    return !!env.WHATSAPP_APP_SECRET && !!env.WHATSAPP_ACCESS_TOKEN;
+  },
+
+  handleVerification(request: Request, env: Env): Response {
+    return handleMetaVerification(request, String(env.WHATSAPP_VERIFY_TOKEN ?? ""));
+  },
+
+  async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {
+    const signature = request.headers.get("x-hub-signature-256") ?? "";
+    const valid = await verifyMetaSignature(String(env.WHATSAPP_APP_SECRET), body, signature);
+    if (!valid) throw new Error("WhatsApp signature verification failed");
+
+    return extractWaMessages(JSON.parse(body)).map((msg) => ({
+      id: crypto.randomUUID(),
+      platform: PLATFORMS.whatsapp,
+      senderId: msg.from,
+      chatId: msg.from,
+      text: msg.text.body,
+      receivedAt: new Date().toISOString(),
+    }));
+  },
+
+  async sendResponse(chatId: string, text: string, env: Env): Promise<void> {
+    const accessToken = String(env.WHATSAPP_ACCESS_TOKEN ?? "");
+    const phoneNumberId = String(env.WHATSAPP_PHONE_NUMBER_ID ?? "");
+    if (!accessToken || !phoneNumberId) throw new Error("WhatsApp access token / phone number ID not configured");
+
+    const chunks = chunkText(text, MAX_WA_TEXT);
+    for (const chunk of chunks) {
+      const res = await fetch(`https://graph.facebook.com/${WHATSAPP_API_VERSION}/${phoneNumberId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ messaging_product: "whatsapp", to: chatId, type: "text", text: { body: chunk } }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`WhatsApp API failed: ${res.status} ${detail.slice(0, 200)}`);
+      }
+    }
+  },
+};
+
+registerPlatform(whatsappPlugin);


### PR DESCRIPTION
## Summary

- Added 3 new webhook platform plugins to `@mulmobridge/relay`:
  - **WhatsApp** (`/webhook/whatsapp`) — HMAC-SHA256 signature + GET verification challenge + Cloud API replies
  - **Facebook Messenger** (`/webhook/messenger`) — same Meta format, Messenger Send API replies
  - **Google Chat** (`/webhook/google-chat`) — JWT/OIDC verification + async replies via Chat REST API (service account)
- Added `handleVerification` to `PlatformPlugin` interface for GET challenge requests (Meta's `hub.challenge` flow)
- Extracted shared Meta HMAC + GET challenge helpers into `webhooks/meta.ts`
- Refactored `fetch()` in `index.ts` into `handleVerificationRequest` + `handleWebhookPost` to stay under cognitive complexity limit

## Items to Confirm / Review

- **Google Chat `sendResponse`**: requires `GOOGLE_CHAT_SERVICE_ACCOUNT_KEY` (service account JSON as a string secret). If not set, replies are silently dropped with a console warning — is this the right behavior vs. throwing?
- **Google Chat webhook response**: the relay responds `"ok"` to Google Chat's POST (not `{"text": "..."}` JSON). Google will silently discard this, but the message is queued. The actual reply arrives async via the Chat API. This is a deliberate trade-off — confirm this is acceptable.
- **Meta verification GET**: routes through the same path registry as POST. Tested via the `handleVerification` interface — but no end-to-end test since Workers env is needed.

## User Prompt

> relayのはなしね。mainからで。webhookみたいに外部サーバが必要なのはできる限り追加したい

## Implementation

New files:
- `src/webhooks/meta.ts` — `verifyMetaSignature()` (HMAC-SHA256 hex) + `handleMetaVerification()` (hub.challenge)
- `src/webhooks/whatsapp.ts` — WhatsApp Cloud API plugin
- `src/webhooks/messenger.ts` — Messenger plugin
- `src/webhooks/google-chat.ts` — JWKS cache, JWT parse/verify, service account JWT → token exchange, Chat REST API

Secrets to configure via `wrangler secret put`:

| Platform | Required | Optional |
|---|---|---|
| WhatsApp | `WHATSAPP_APP_SECRET`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN` | — |
| Messenger | `MESSENGER_APP_SECRET`, `MESSENGER_PAGE_ACCESS_TOKEN`, `MESSENGER_VERIFY_TOKEN` | — |
| Google Chat | `GOOGLE_CHAT_PROJECT_NUMBER` | `GOOGLE_CHAT_SERVICE_ACCOUNT_KEY` (for replies) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WhatsApp webhook integration with Cloud API support for sending and receiving messages
  * Added Facebook Messenger webhook integration with verification endpoints
  * Added Google Chat webhook integration with service account authentication support
  * Enhanced webhook request handling with platform verification capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->