### PR TITLE
fix(i18n): unbreak settings MCP stdio form — escape literal `@` in argsPlaceholder

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -186,7 +186,9 @@ const enMessages = {
     urlPlaceholder: "https://example.com/mcp",
     commandFieldLabel: "Command",
     argsLabel: "Arguments (one per line)",
-    argsPlaceholder: "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
+    // Message function form — skips vue-i18n's message compiler so
+    // the literal `@` isn't parsed as a linked-message reference.
+    argsPlaceholder: () => "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
     errNoName: "Please provide a Name, or enter a URL / args we can derive one from.",
     errBadName: "Name must start with a lowercase letter and contain only [a-z0-9_-].",
     errIdExists: 'Server id "{id}" already exists.',

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -177,7 +177,9 @@ const jaMessages = {
     urlPlaceholder: "https://example.com/mcp",
     commandFieldLabel: "コマンド",
     argsLabel: "引数（1行につき1つ）",
-    argsPlaceholder: "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
+    // Message function form — skips vue-i18n's message compiler so
+    // the literal `@` isn't parsed as a linked-message reference.
+    argsPlaceholder: () => "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
     errNoName: "名前を入力するか、URL / 引数から推論できる値を入力してください。",
     errBadName: "名前は小文字で始まり、[a-z0-9_-] のみ使用できます。",
     errIdExists: "サーバ ID「{id}」は既に存在します。",


### PR DESCRIPTION
## Summary
- **Fixes the broken `adds a stdio server with npx + args` e2e test** that has been red on main since #583 merged
- Blocks PR #587 and any other PR that picks up main into its branch

## Root cause

PR #583 extracted the MCP args placeholder string into en.ts / ja.ts:

```ts
argsPlaceholder: "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path"
```

vue-i18n parses every `@` in a message as the start of a linked-message reference (`@:key`, `@.modifier:key`). The compiler throws:

```
SyntaxError: Message compilation error: Invalid linked format
  -y
  @modelcontextprotocol/server-filesystem
   ^
```

…when the stdio branch of `SettingsMcpTab` mounts. The Vue render function aborts, which silently rolls back the `draft.type = "stdio"` state update, so the command dropdown + args textarea never render — making the stdio form look unresponsive.

## Fix

Pass `argsPlaceholder` as a message function instead of a raw string:

```ts
argsPlaceholder: () => "-y\n@modelcontextprotocol/server-filesystem\n/workspace/path",
```

vue-i18n treats message functions as pre-compiled, so the literal `@` is preserved verbatim.

## Escapes that did NOT work (documented in the commit)

- `{'@'}` interpolation (docs imply it works, but vue-i18n v11 still errored)
- Backticks around `@` (`` `@` ``) — same compile error

## Test plan
- [x] Run `tests/settings.spec.ts -g "adds a stdio server with npx"` → **passes**
- [x] `yarn typecheck` / `yarn lint` / `yarn build` → pass
- [ ] Full e2e (verify in CI)

## Notes for future string extraction

Any i18n value that contains `@`, `$`, `|`, `{`, or `}` as a literal character should use the message function form to avoid the same class of regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)