### PR TITLE
feat(ui): show source label on preview cards, move padding into plugins

### DIFF
--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -9,10 +9,13 @@
     <div
       v-for="result in results"
       :key="result.uuid"
-      class="relative cursor-pointer rounded border border-gray-300 p-2 text-sm text-gray-900 hover:opacity-75 transition-opacity"
+      class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
       :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
       @click="emit('select', result.uuid)"
     >
+      <span class="absolute top-0 left-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none">
+        {{ sourceLabel(result) }}
+      </span>
       <span
         v-if="resultTimestamps.get(result.uuid)"
         class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
@@ -20,7 +23,7 @@
         {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
       </span>
       <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
-      <span v-else class="block truncate">{{ result.title || result.toolName }}</span>
+      <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
     </div>
 
     <!-- Thinking indicator -->
@@ -48,6 +51,11 @@ import { ref } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
+
+function sourceLabel(result: ToolResultComplete): string {
+  if (result.toolName === "text-response") return result.title ?? "Assistant";
+  return result.toolName;
+}
 
 interface PendingCall {
   toolUseId: string;

--- a/src/plugins/chart/Preview.vue
+++ b/src/plugins/chart/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="font-medium text-gray-700 truncate mb-1">
       {{ title }}
     </div>

--- a/src/plugins/manageSkills/Preview.vue
+++ b/src/plugins/manageSkills/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="flex items-center gap-1 font-medium text-gray-700 mb-1">
       <span class="material-icons" style="font-size: 14px">auto_awesome</span>
       <span>{{ skills.length }} skill{{ skills.length !== 1 ? "s" : "" }}</span>

--- a/src/plugins/manageSource/Preview.vue
+++ b/src/plugins/manageSource/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="font-medium text-gray-700 truncate mb-1">
       {{ title }}
     </div>

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-3 bg-purple-100 rounded overflow-hidden">
+  <div class="p-2 bg-purple-100 rounded overflow-hidden">
     <div class="text-sm text-gray-800 font-medium truncate">
       {{ displayTitle }}
     </div>

--- a/src/plugins/presentHtml/Preview.vue
+++ b/src/plugins/presentHtml/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="font-medium text-gray-700 truncate mb-1">
       {{ title }}
     </div>

--- a/src/plugins/presentMulmoScript/Preview.vue
+++ b/src/plugins/presentMulmoScript/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="font-medium text-gray-700 truncate mb-1">
       {{ title }}
     </div>

--- a/src/plugins/scheduler/Preview.vue
+++ b/src/plugins/scheduler/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="flex items-center gap-1 font-medium text-gray-700 mb-1">
       <span>📅</span>
       <span>{{ upcomingItems.length }} upcoming</span>

--- a/src/plugins/textResponse/Preview.vue
+++ b/src/plugins/textResponse/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="preview-text text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
+  <div class="preview-text p-2 text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
 </template>
 
 <script setup lang="ts">

--- a/src/plugins/todo/Preview.vue
+++ b/src/plugins/todo/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="flex items-center gap-1 font-medium text-gray-700 mb-1">
       <span>☑</span>
       <span>{{ completedCount }}/{{ items.length }} completed</span>

--- a/src/plugins/wiki/Preview.vue
+++ b/src/plugins/wiki/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-sm">
+  <div class="p-2 text-sm">
     <div class="flex items-center gap-1 font-medium text-gray-700 mb-1">
       <span class="material-icons" style="font-size: 14px">menu_book</span>
       <span>{{ label }}</span>


### PR DESCRIPTION
## Summary

- Add a source label (e.g. `You`, `Assistant`, `presentDocument`) to the top-left of each tool-result preview card, mirroring the existing timestamp on the top-right. Both labels use `bg-gray-100` so they visually cut through the card border.
- Move the preview card's inner padding out of `ToolResultsPanel.vue` and into each plugin's `Preview.vue`. This lets "filled" previews (e.g. `markdown/Preview.vue` with `bg-purple-100`) extend their background edge-to-edge inside the rounded border — removing the previous `-m-2` hack.

### Files touched

- `src/components/ToolResultsPanel.vue` — drop outer `p-2`, add source-label span + `sourceLabel()` helper, pad the fallback span.
- `src/plugins/markdown/Preview.vue` — drop `-m-2` hack; purple fills the card naturally.
- `src/plugins/textResponse/Preview.vue` — add `p-2`.
- Added `p-2` to: `chart`, `manageSkills`, `manageSource`, `presentHtml`, `presentMulmoScript`, `scheduler`, `todo`, `wiki`.

## Test plan

- [ ] Load a session with a mix of text-response, markdown, and other tool results.
- [ ] Confirm the top-left source label reads `You` for user messages, `Assistant` for assistant text, and the tool name (e.g. `presentDocument`) for other results.
- [ ] Confirm the markdown preview's purple background reaches the rounded border with no gap.
- [ ] Confirm non-filled previews (text-response, chart, todo, scheduler, wiki, manageSkills, manageSource, presentHtml, presentMulmoScript) have consistent `p-2` inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source labels to result items for better clarity on tool origins.

* **Style**
  * Adjusted padding and spacing across preview components for improved visual consistency.
  * Optimized layout spacing in the results panel for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->