### PR TITLE
@mulmobridge/slack@0.2.0

### DIFF
--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/slack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Slack bridge for MulmoBridge — connect a Slack bot to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Version bump to **0.2.0** (minor, backward-compatible)
- npm published: [\`@mulmobridge/slack@0.2.0\`](https://www.npmjs.com/package/@mulmobridge/slack/v/0.2.0)
- Ship the per-thread session feature merged in #599

## Highlights

- **Per-thread session option** via `SLACK_SESSION_GRANULARITY` env var
  - `channel` *(default, unchanged)* — one session per channel
  - `thread` — each Slack thread becomes its own session (matches Zulip's per-topic behavior)
  - `auto` — reserved for future auto-detection; today == `thread`
- Reply routing preserves `thread_ts` so bot replies land in the correct thread
- English + Japanese README with ASCII diagrams, "How to choose" table, and "switching modes safely" guidance for non-engineers

## Verified

- ✅ 16/16 unit tests pass (`test/test_sessionId.ts`)
- ✅ Production tested — reporter confirms it works on a real Slack workspace

## User prompt
> マージした。リリースして。

🤖 Generated with [Claude Code](https://claude.com/claude-code)