### PR TITLE
docs(relay): document all four webhook platforms + update setup-relay skill

### DIFF
--- a/.claude/skills/setup-relay/SKILL.md
+++ b/.claude/skills/setup-relay/SKILL.md
@@ -23,6 +23,7 @@ Guide the user through Relay setup following `docs/message_apps/relay/`. Use the
 ## Step 2: Deploy the Relay
 
 Tell the user to run:
+
 ```
 ! cd packages/relay && wrangler deploy
 ```
@@ -45,32 +46,87 @@ cd packages/relay && wrangler secret put RELAY_TOKEN
 
 ### Platform secrets
 
-Ask the user which platforms they want to use. For each selected platform:
+Ask the user **which platforms** they want to set up. Supported webhook platforms: **LINE, WhatsApp, Messenger, Google Chat, Telegram**. Only register secrets and webhook URLs for the ones they pick — `/health` reports `configured: true/false` per platform, so unused ones stay dormant with zero cost.
+
+For each selected platform, walk through the matching block below. All `wrangler secret put` invocations must run from `packages/relay`, use the `!` prefix (the user types the secret in their own terminal), and each registers exactly one secret.
 
 #### LINE
-Tell the user to run (must be in `packages/relay` directory):
-```
-! cd packages/relay && wrangler secret put LINE_CHANNEL_SECRET
-! cd packages/relay && wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
-```
-And enter their LINE Developers Console values.
 
-Then tell them to update their LINE webhook URL to:
-```
-https://<relay-url>/webhook/line
-```
+1. [LINE Developers Console](https://developers.line.biz/console/) → channel → **Messaging API** tab → copy **Channel secret** and **Channel access token (long-lived)**.
+2. Register:
+   ```
+   ! cd packages/relay && wrangler secret put LINE_CHANNEL_SECRET
+   ! cd packages/relay && wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+   ```
+3. In the same console screen, set **Webhook URL** to:
+   ```
+   https://<relay-url>/webhook/line
+   ```
+4. Toggle **Use webhook** ON and verify with the console's "Verify" button.
+
+#### WhatsApp (Meta Cloud API)
+
+1. [Meta for Developers](https://developers.facebook.com/apps/) → your app → **Settings** → **Basic** → copy **App Secret**.
+2. In the same app → **WhatsApp** → **API Setup** → copy **Access Token** and **Phone Number ID** (the "From" field). Keep a browser tab open — you'll come back for webhook registration.
+3. Pick any string to use as your own verify token (e.g. `openssl rand -hex 16`). The user will paste this same string into Meta's console in a moment.
+4. Register the four secrets:
+   ```
+   ! cd packages/relay && wrangler secret put WHATSAPP_APP_SECRET
+   ! cd packages/relay && wrangler secret put WHATSAPP_VERIFY_TOKEN
+   ! cd packages/relay && wrangler secret put WHATSAPP_ACCESS_TOKEN
+   ! cd packages/relay && wrangler secret put WHATSAPP_PHONE_NUMBER_ID
+   ```
+5. Back in Meta console → WhatsApp → **Configuration** → **Webhook** → **Edit** → enter:
+   - Callback URL: `https://<relay-url>/webhook/whatsapp`
+   - Verify Token: the same string used for `WHATSAPP_VERIFY_TOKEN` above
+   - Click **Verify and save** — Meta will hit the relay's GET handler and expect the verify-token echo.
+6. Under **Webhook fields**, subscribe to at least `messages`.
+
+#### Messenger
+
+1. [Meta for Developers](https://developers.facebook.com/apps/) → your app → **Settings** → **Basic** → copy **App Secret** (can share with WhatsApp if same app).
+2. Add **Messenger** product (if not already) → **Settings** → **Access Tokens** → generate a **Page Access Token** for the Facebook Page you want to bridge.
+3. Pick a verify-token string (same pattern as WhatsApp above).
+4. Register the three secrets:
+   ```
+   ! cd packages/relay && wrangler secret put MESSENGER_APP_SECRET
+   ! cd packages/relay && wrangler secret put MESSENGER_VERIFY_TOKEN
+   ! cd packages/relay && wrangler secret put MESSENGER_PAGE_ACCESS_TOKEN
+   ```
+5. In Messenger settings → **Webhooks** → **Add Callback URL** → enter:
+   - Callback URL: `https://<relay-url>/webhook/messenger`
+   - Verify Token: same string used for `MESSENGER_VERIFY_TOKEN` above
+6. Subscribe the callback to the target Page under **Webhooks** → **Add or Remove Pages**. Required fields: `messages`, `messaging_postbacks` (at minimum).
+
+#### Google Chat
+
+1. [Google Cloud Console](https://console.cloud.google.com/) → pick/create a project → **APIs & Services** → enable **Google Chat API**.
+2. **IAM & Admin** → **Service Accounts** → create a service account (or reuse) → **Keys** → **Add Key** → **Create new key** → JSON → downloads a file. **Keep the full JSON handy**.
+3. Copy the **project number** (not project ID) from the console's home / Dashboard. The relay uses it as the audience claim when verifying Google's inbound JWT.
+4. Register:
+   ```
+   ! cd packages/relay && wrangler secret put GOOGLE_CHAT_PROJECT_NUMBER
+   ! cd packages/relay && wrangler secret put GOOGLE_CHAT_SERVICE_ACCOUNT_KEY
+   ```
+   For `GOOGLE_CHAT_SERVICE_ACCOUNT_KEY`, paste the **entire JSON contents** at the prompt (wrangler accepts multi-line).
+5. In the Cloud Console → **APIs & Services** → **Google Chat API** → **Configuration** → fill:
+   - App URL: `https://<relay-url>/webhook/google-chat`
+   - Connection settings: **App URL** (HTTP)
+   - Functionality: match what you want (1:1 DMs, spaces, etc.)
 
 #### Telegram
-Tell the user to run:
-```
-! wrangler secret put TELEGRAM_BOT_TOKEN
-! wrangler secret put TELEGRAM_WEBHOOK_SECRET
-```
 
-Then set the webhook:
-```bash
-curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<relay-url>/webhook/telegram&secret_token=<SECRET>"
-```
+1. Create a bot via [@BotFather](https://t.me/BotFather) — `/newbot` — copy the token.
+2. Pick a webhook secret (`openssl rand -hex 16`).
+3. Register:
+   ```
+   ! cd packages/relay && wrangler secret put TELEGRAM_BOT_TOKEN
+   ! cd packages/relay && wrangler secret put TELEGRAM_WEBHOOK_SECRET
+   ```
+4. Register the webhook via API (no GUI):
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<relay-url>/webhook/telegram&secret_token=<SECRET>"
+   ```
 
 ## Step 4: Configure MulmoClaude
 
@@ -88,12 +144,15 @@ echo "RELAY_TOKEN=<token-from-step-3>" >> .env
 ## Step 5: Verify
 
 1. Check the health endpoint:
+
    ```bash
    curl https://<relay-url>/health
    ```
+
    Confirm the configured platforms show `true`.
 
 2. Restart MulmoClaude:
+
    ```bash
    # Tell user to restart yarn dev
    ```
@@ -110,4 +169,8 @@ echo "RELAY_TOKEN=<token-from-step-3>" >> .env
 - The RELAY_TOKEN must be identical in both the Cloudflare secret and the `.env` file
 - **Token management**: Let the user generate and manage the token in their own terminal. Do NOT generate it in Claude's shell — this avoids the user having to copy a value back from the conversation
 - LINE webhook URL must be the Relay URL, not the old ngrok URL
+- **Meta verify tokens (WhatsApp / Messenger)**: the same string must be in `wrangler secret` AND the Meta console "Verify Token" field — Meta's "Verify and save" button calls the relay's GET handler expecting that exact echo, and silently fails on mismatch with no obvious error
+- **Google Chat uses the project number, not project ID** — project number is numeric (found on the Cloud Console home page), project ID is the human-readable slug
+- **Google Chat service-account JSON**: paste the _entire_ JSON blob (multi-line) at the wrangler prompt — do not base64-encode or try to escape it
+- Messenger webhooks require per-page subscription in addition to the app-level callback — setting only the callback URL is not enough; messages will arrive at Meta but never get forwarded to the app
 - Durable Objects work on the free plan when using `new_sqlite_classes` in `wrangler.toml` (the default in this project)

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -1,12 +1,13 @@
 # @mulmobridge/relay
 
-Cloudflare Workers relay for MulmoBridge. Receives webhooks from messaging platforms (LINE, Telegram, etc.), queues messages when MulmoClaude is offline, and forwards them via WebSocket when connected.
+Cloudflare Workers relay for MulmoBridge. Receives webhooks from messaging platforms (LINE, WhatsApp, Messenger, Google Chat, Telegram), queues messages when MulmoClaude is offline, and forwards them via WebSocket when connected.
 
 ## Why
 
 Without the relay, webhook-based bridges (LINE, Slack, etc.) need a public URL — typically via ngrok, which requires manual URL updates on every restart.
 
 With the relay:
+
 - **Fixed URL** — `<your-name>.workers.dev` never changes
 - **Offline queue** — messages are stored and delivered when MulmoClaude reconnects
 - **Multi-platform** — one relay handles all platforms simultaneously
@@ -15,9 +16,11 @@ With the relay:
 ## Architecture
 
 ```text
-LINE ─────→ /webhook/line ─────┐
-Telegram ─→ /webhook/telegram ─┼→ Durable Object → WS → MulmoClaude
-(future) ─→ /webhook/...  ────┘   (queue if offline)    (home PC)
+LINE ─────────→ /webhook/line         ┐
+WhatsApp ─────→ /webhook/whatsapp     │
+Messenger ────→ /webhook/messenger    ├→ Durable Object → WS → MulmoClaude
+Google Chat ──→ /webhook/google-chat  │   (queue if offline)    (home PC)
+Telegram ─────→ /webhook/telegram     ┘
 ```
 
 ## Setup
@@ -38,34 +41,73 @@ wrangler deploy
 
 ### 2. Configure secrets
 
+Only register secrets for platforms you actually use — the relay's `/health` endpoint reports `configured: true/false` per platform based on whether its secrets are present.
+
 ```bash
-# Relay authentication token (shared with MulmoClaude)
+# Relay authentication token (shared with MulmoClaude) — always required
 wrangler secret put RELAY_TOKEN
+```
 
-# LINE (if using)
-wrangler secret put LINE_CHANNEL_SECRET
-wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+#### LINE
 
-# Telegram (if using)
+```bash
+wrangler secret put LINE_CHANNEL_SECRET        # "Channel secret" in LINE console
+wrangler secret put LINE_CHANNEL_ACCESS_TOKEN  # "Channel access token (long-lived)"
+```
+
+#### WhatsApp (Meta Cloud API)
+
+```bash
+wrangler secret put WHATSAPP_APP_SECRET        # Meta app → Settings → Basic → App Secret
+wrangler secret put WHATSAPP_VERIFY_TOKEN      # arbitrary string, repeated in the console verification step
+wrangler secret put WHATSAPP_ACCESS_TOKEN      # WhatsApp → API Setup → Access Token
+wrangler secret put WHATSAPP_PHONE_NUMBER_ID   # WhatsApp → API Setup → From (Phone Number ID)
+```
+
+#### Messenger
+
+```bash
+wrangler secret put MESSENGER_APP_SECRET        # Meta app → Settings → Basic → App Secret
+wrangler secret put MESSENGER_VERIFY_TOKEN      # arbitrary string, repeated in the console verification step
+wrangler secret put MESSENGER_PAGE_ACCESS_TOKEN # Meta app → Messenger → Settings → Page token
+```
+
+#### Google Chat
+
+```bash
+wrangler secret put GOOGLE_CHAT_PROJECT_NUMBER       # GCP project number (verifies inbound JWT audience)
+wrangler secret put GOOGLE_CHAT_SERVICE_ACCOUNT_KEY  # Service-account JSON — paste the full JSON at the prompt
+```
+
+#### Telegram
+
+```bash
 wrangler secret put TELEGRAM_BOT_TOKEN
 wrangler secret put TELEGRAM_WEBHOOK_SECRET
 ```
 
 ### 3. Set webhook URLs in platform consoles
 
-| Platform | Webhook URL |
-|----------|-------------|
-| LINE | `https://<name>.workers.dev/webhook/line` |
-| Telegram | `https://<name>.workers.dev/webhook/telegram` |
+| Platform    | Webhook URL                                      | Where to register                                                                                                                                 |
+| ----------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LINE        | `https://<name>.workers.dev/webhook/line`        | [LINE Developers Console](https://developers.line.biz/console/) → channel → **Messaging API** → **Webhook URL**                                   |
+| WhatsApp    | `https://<name>.workers.dev/webhook/whatsapp`    | [Meta for Developers](https://developers.facebook.com/apps/) → WhatsApp → **Configuration** → **Webhook** (use `WHATSAPP_VERIFY_TOKEN` at prompt) |
+| Messenger   | `https://<name>.workers.dev/webhook/messenger`   | [Meta for Developers](https://developers.facebook.com/apps/) → Messenger → **Settings** → **Webhooks** (use `MESSENGER_VERIFY_TOKEN` at prompt)   |
+| Google Chat | `https://<name>.workers.dev/webhook/google-chat` | [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Google Chat API → **Configuration** → **App URL**                   |
+| Telegram    | `https://<name>.workers.dev/webhook/telegram`    | Set via Bot API call (see below)                                                                                                                  |
 
-For Telegram, set the webhook via Bot API:
+Telegram is the odd one out — no GUI, set via API:
+
 ```bash
 curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<name>.workers.dev/webhook/telegram&secret_token=<SECRET>"
 ```
 
+**Meta-family verify token note**: Both WhatsApp and Messenger use the Graph webhook verification handshake. When you paste the webhook URL in the Meta console, it prompts for a "Verify Token" — enter the same string you stored in `WHATSAPP_VERIFY_TOKEN` / `MESSENGER_VERIFY_TOKEN` respectively. The relay's GET handler returns the `hub.challenge` echo only when the token matches.
+
 ### 4. Connect MulmoClaude
 
 Add to `.env`:
+
 ```dotenv
 RELAY_URL=wss://<name>.workers.dev/ws
 RELAY_TOKEN=<same token as step 2>
@@ -73,12 +115,15 @@ RELAY_TOKEN=<same token as step 2>
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/health` | Health check + configured platforms |
-| GET | `/ws` | WebSocket (MulmoClaude connection, bearer auth) |
-| POST | `/webhook/line` | LINE webhook (HMAC-SHA256 verified) |
-| POST | `/webhook/telegram` | Telegram webhook (secret token verified) |
+| Method | Path                   | Description                                                                                              |
+| ------ | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| GET    | `/health`              | Health check + configured platforms                                                                      |
+| GET    | `/ws`                  | WebSocket (MulmoClaude connection, bearer auth)                                                          |
+| POST   | `/webhook/line`        | LINE webhook (HMAC-SHA256 verified)                                                                      |
+| POST   | `/webhook/whatsapp`    | WhatsApp Cloud API webhook (Meta signature + `hub.verify_token` echo for GET)                            |
+| POST   | `/webhook/messenger`   | Messenger webhook (Meta signature + `hub.verify_token` echo for GET)                                     |
+| POST   | `/webhook/google-chat` | Google Chat webhook (JWT `iss=chat@system.gserviceaccount.com`, audience = `GOOGLE_CHAT_PROJECT_NUMBER`) |
+| POST   | `/webhook/telegram`    | Telegram webhook (secret token verified)                                                                 |
 
 ## Security
 
@@ -98,31 +143,35 @@ file in `src/webhooks/` that implements `PlatformPlugin`:
 // src/webhooks/slack.ts
 const slackPlugin: PlatformPlugin = {
   name: PLATFORMS.slack,
-  mode: CONNECTION_MODES.webhook,  // or "polling" or "persistent"
+  mode: CONNECTION_MODES.webhook, // or "polling" or "persistent"
   webhookPath: "/webhook/slack",
   isConfigured: (env) => !!env.SLACK_SIGNING_SECRET,
-  handleWebhook: async (request, body, env) => { /* ... */ },
-  sendResponse: async (chatId, text, env) => { /* ... */ },
+  handleWebhook: async (request, body, env) => {
+    /* ... */
+  },
+  sendResponse: async (chatId, text, env) => {
+    /* ... */
+  },
 };
 registerPlatform(slackPlugin);
 ```
 
 Three connection modes are supported:
 
-| Mode | Examples | Method |
-|------|----------|--------|
-| `webhook` | LINE, Messenger, Google Chat | Platform POSTs to relay URL |
-| `polling` | Telegram (alt) | Relay fetches from platform API |
-| `persistent` | Slack Socket Mode, Discord Gateway | Relay maintains WS to platform |
+| Mode         | Examples                           | Method                          |
+| ------------ | ---------------------------------- | ------------------------------- |
+| `webhook`    | LINE, Messenger, Google Chat       | Platform POSTs to relay URL     |
+| `polling`    | Telegram (alt)                     | Relay fetches from platform API |
+| `persistent` | Slack Socket Mode, Discord Gateway | Relay maintains WS to platform  |
 
 ### Relay vs Bridge packages
 
-| | Relay | Bridge (`@mulmobridge/*`) |
-|---|---|---|
-| Runs on | Cloud (CF Workers) | User's computer |
-| Public URL | Permanent | Requires ngrok |
-| Offline queue | Yes | No |
-| Multi-platform | One relay | One process each |
+|                | Relay              | Bridge (`@mulmobridge/*`) |
+| -------------- | ------------------ | ------------------------- |
+| Runs on        | Cloud (CF Workers) | User's computer           |
+| Public URL     | Permanent          | Requires ngrok            |
+| Offline queue  | Yes                | No                        |
+| Multi-platform | One relay          | One process each          |
 
 Both can coexist. Some platforms via Relay, others via local Bridge.
 


### PR DESCRIPTION
## Summary

Relay code already registers LINE, WhatsApp, Messenger, Google Chat, and Telegram (each wired via \`registerPlatform(...)\` in \`packages/relay/src/webhooks/*.ts\`). Docs only covered LINE + Telegram, so the three Meta / Google platforms appeared unsupported despite shipping.

### packages/relay/README.md

- Architecture diagram expanded to show all five webhook paths
- Per-platform secret blocks enumerate the exact env-var names the code reads (\`WHATSAPP_{APP_SECRET,VERIFY_TOKEN,ACCESS_TOKEN,PHONE_NUMBER_ID}\`; \`MESSENGER_{APP_SECRET,VERIFY_TOKEN,PAGE_ACCESS_TOKEN}\`; \`GOOGLE_CHAT_{PROJECT_NUMBER,SERVICE_ACCOUNT_KEY}\`)
- Webhook URL table with the console path for each (LINE Developers, Meta for Developers, GCP Console)
- Meta-family verify-token handshake note — "Verify and save" silently fails on mismatch, easy footgun
- \`/webhook/*\` endpoint table now lists all five paths

### .claude/skills/setup-relay/SKILL.md

- "Platform secrets" expanded into five per-platform branches. Each branch takes the user all the way through console copy → \`wrangler secret put\` → console webhook URL registration before moving on.
- New pitfalls:
  - Meta verify-token must match between wrangler secret and the Meta console dialog
  - Google Chat uses project number (numeric), not project ID (slug)
  - \`GOOGLE_CHAT_SERVICE_ACCOUNT_KEY\` wants the entire JSON pasted multi-line at the prompt
  - Messenger webhooks need per-page subscription, not just app-level callback

No code changes. Relay implementations were already present and registered — this closes the gap where the docs underrepresented what ships.

## User Prompt

> relay について、Four platforms deliver messages via inbound HTTP webhooks — LINE, WhatsApp, Messenger, Google Chat. They need the receiver to be reachable from the public internet. とあるからこれらには対応したほうが良い? → 1 (README 拡張) と 2 (/setup-relay skill を 4 プラットフォームの対話フロー化) を一気に！

## Items to Confirm / Review

- **Console step wording**: I haven't re-verified every "→ Settings → Basic" click-path against the current Meta/GCP UIs. If any have moved, the skill is easiest to patch (point at the new path in the platform's block).
- **GOOGLE_CHAT_SERVICE_ACCOUNT_KEY** is documented as "paste the full JSON" — \`wrangler secret put\` accepts multi-line stdin, but worth a smoke test once someone sets up Google Chat for real.
- **pitfalls** section is growing — fine for now since each item catches a real footgun, but could move into a dedicated troubleshooting doc if it grows further.

## Test plan

- [x] No code changes; typecheck/lint not applicable
- [x] Prettier format both files
- [ ] Manual verification by setting up one of WhatsApp / Messenger / Google Chat end-to-end (tracked separately — requires developer credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded relay setup guide with platform-specific instructions for LINE, WhatsApp, Messenger, Google Chat, and Telegram, including credential requirements, webhook URLs, and verification token alignment.
* Updated relay README with comprehensive coverage of additional messaging platforms, detailed endpoint configurations, and setup examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->