### PR TITLE
feat(i18n): extract App shell, SettingsModal explanation, SuggestionsPanel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,8 +58,10 @@
           class="mx-4 mt-3 mb-2 rounded border border-yellow-400 bg-yellow-50 p-3 text-xs text-yellow-700 shrink-0"
         >
           <span class="material-icons text-xs align-middle mr-1">warning</span>
-          Image generation requires
-          <code class="font-mono">GEMINI_API_KEY</code>. Add it to <code class="font-mono">.env</code> and restart the app.
+          <i18n-t keypath="app.geminiRequired" tag="span">
+            <template #envKey><code class="font-mono">GEMINI_API_KEY</code></template>
+            <template #envFile><code class="font-mono">.env</code></template>
+          </i18n-t>
         </div>
 
         <!-- Tool result previews -->
@@ -90,8 +92,10 @@
           class="mx-3 mt-2 rounded border border-yellow-400 bg-yellow-50 p-2 text-xs text-yellow-700 shrink-0"
         >
           <span class="material-icons text-xs align-middle mr-1">warning</span>
-          Image generation requires
-          <code class="font-mono">GEMINI_API_KEY</code>. Add it to <code class="font-mono">.env</code> and restart the app.
+          <i18n-t keypath="app.geminiRequired" tag="span">
+            <template #envKey><code class="font-mono">GEMINI_API_KEY</code></template>
+            <template #envFile><code class="font-mono">.env</code></template>
+          </i18n-t>
         </div>
 
         <div ref="canvasRef" class="flex-1 overflow-hidden outline-none min-h-0" tabindex="0" @mousedown="activePane = 'main'" @keydown="handleCanvasKeydown">
@@ -108,7 +112,7 @@
               <pre class="text-sm text-gray-700 whitespace-pre-wrap">{{ JSON.stringify(selectedResult, null, 2) }}</pre>
             </div>
             <div v-else class="flex items-center justify-center h-full text-gray-600">
-              <p>Start a conversation</p>
+              <p>{{ t("app.startConversation") }}</p>
             </div>
           </template>
           <!-- Stack mode -->
@@ -162,7 +166,10 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, reactive } from "vue";
+import { useI18n } from "vue-i18n";
 import { v4 as uuidv4 } from "uuid";
+
+const { t } = useI18n();
 import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import RightSidebar from "./components/RightSidebar.vue";

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -56,11 +56,10 @@
         </div>
 
         <div v-if="activeTab === 'tools'" class="space-y-3">
-          <p class="text-xs text-gray-600 leading-relaxed">
-            Extra tool names to pass to Claude via
-            <code class="bg-gray-100 px-1 rounded">--allowedTools</code>. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar
-            after you have authenticated via <code class="bg-gray-100 px-1 rounded">claude mcp</code>.
-          </p>
+          <i18n-t keypath="settingsToolsTab.explanation" tag="p" class="text-xs text-gray-600 leading-relaxed">
+            <template #allowedTools><code class="bg-gray-100 px-1 rounded">--allowedTools</code></template>
+            <template #claudeMcp><code class="bg-gray-100 px-1 rounded">claude mcp</code></template>
+          </i18n-t>
           <label class="block">
             <span class="text-xs font-semibold text-gray-700">{{ t("settingsModal.toolNamesLabel") }}</span>
             <textarea

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -9,7 +9,7 @@
       >
         {{ query }}
       </button>
-      <p class="text-center text-[10px] text-gray-400 py-0.5">click to send · shift+click to edit</p>
+      <p class="text-center text-[10px] text-gray-400 py-0.5">{{ t("suggestionsPanel.sendEditHint") }}</p>
     </div>
     <button
       class="w-full flex items-center justify-between px-4 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-50 transition-colors"
@@ -17,7 +17,7 @@
     >
       <span class="flex items-center gap-1">
         <span class="material-icons text-sm">lightbulb</span>
-        Suggestions
+        {{ t("suggestionsPanel.suggestions") }}
       </span>
       <span class="material-icons text-sm transition-transform" :class="{ 'rotate-180': !expanded }">expand_less</span>
     </button>
@@ -26,6 +26,9 @@
 
 <script setup lang="ts">
 import { nextTick, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 defineProps<{
   queries: string[];

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -230,6 +230,24 @@ const enMessages = {
     valueOrFormulaPlaceholder: "Value or Formula (e.g., 100 or SUM(B2:B11))",
     formatPlaceholder: "Format (e.g., $#,##0.00)",
   },
+  app: {
+    // `<i18n-t>` slots — named `envKey` / `envFile` render as inline
+    // `<code>` in App.vue, so the literal variable and file names
+    // stay untranslated while the surrounding copy is localised.
+    geminiRequired: "Image generation requires {envKey}. Add it to {envFile} and restart the app.",
+    startConversation: "Start a conversation",
+  },
+  suggestionsPanel: {
+    suggestions: "Suggestions",
+    sendEditHint: "click to send · shift+click to edit",
+  },
+  settingsToolsTab: {
+    // Rendered via <i18n-t> with named slots `allowedTools` and `claudeMcp`
+    // so the inline `<code>` tags keep their styling while the copy
+    // is translatable.
+    explanation:
+      "Extra tool names to pass to Claude via {allowedTools}. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar after you have authenticated via {claudeMcp}.",
+  },
 };
 
 export default enMessages;

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -221,6 +221,18 @@ const jaMessages = {
     valueOrFormulaPlaceholder: "値または数式（例: 100, SUM(B2:B11)）",
     formatPlaceholder: "書式（例: $#,##0.00）",
   },
+  app: {
+    geminiRequired: "画像生成には {envKey} が必要です。{envFile} に追加してアプリを再起動してください。",
+    startConversation: "会話を開始してください",
+  },
+  suggestionsPanel: {
+    suggestions: "候補",
+    sendEditHint: "クリックで送信 · Shift+クリックで編集",
+  },
+  settingsToolsTab: {
+    explanation:
+      "{allowedTools} を介して Claude に渡す追加ツール名。1行につき1つ。Gmail / Google Calendar などの Claude Code 組み込み MCP サーバを、{claudeMcp} で認証した後に利用する場合に便利です。",
+  },
 };
 
 export default jaMessages;


### PR DESCRIPTION
## Summary

vue-i18n batch 10 (#559 follow-up)。アプリシェルの頻出ユーザー可視文言を辞書化。

> **依存**: #608 (localeDir 設定 + dumpi18n) の上にスタック

### 対象

- **App.vue** — Gemini API key 警告バナー ×2（通常レイアウト + Stack レイアウト）、"Start a conversation" 空状態
- **SettingsModal.vue** — Allowed Tools の説明文段落
- **SuggestionsPanel.vue** — "Suggestions" ヘッダ + "click to send · shift+click to edit" ヒント

### \`<i18n-t>\` スロット活用

\`GEMINI_API_KEY\` や \`--allowedTools\` のような inline \`<code>\` を保ったまま翻訳可能にするため、\`<i18n-t>\` component + named slots を使用:

\`\`\`vue
<i18n-t keypath="app.geminiRequired" tag="span">
  <template #envKey><code class="font-mono">GEMINI_API_KEY</code></template>
  <template #envFile><code class="font-mono">.env</code></template>
</i18n-t>
\`\`\`

辞書側は普通の \`{envKey}\` / \`{envFile}\` interpolation 記法で書ける。

### 辞書

新規 namespace 3 つ: \`app\`, \`suggestionsPanel\`, \`settingsToolsTab\`

### 効果

- Before: 394 warnings
- After: 382 warnings (12 件解消)

## Items to Confirm / Review

- [ ] **\`<i18n-t>\` パターン**: 今後の同種ケース（SettingsWorkspaceDirsTab / SettingsReferenceDirsTab / SettingsMcpTab / LockStatusPopup の説明文）も同じパターンで順次対応予定
- [ ] **日本語訳の技術用語**: \"GEMINI_API_KEY\" / \".env\" / \"--allowedTools\" / \"claude mcp\" は untranslated（変数名・ファイル名・コマンド）
- [ ] **\"Start a conversation\" → 「会話を開始してください」**: 他アプリの定番訳に合わせたが代替案あれば議論

## Test plan

- [x] \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` / \`yarn build\` clean
- [x] \`yarn test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)