### PR TITLE
feat(relay): add Microsoft Teams platform plugin (#615)

### DIFF
--- a/.claude/skills/setup-relay/SKILL.md
+++ b/.claude/skills/setup-relay/SKILL.md
@@ -46,7 +46,7 @@ cd packages/relay && wrangler secret put RELAY_TOKEN
 
 ### Platform secrets
 
-Ask the user **which platforms** they want to set up. Supported webhook platforms: **LINE, WhatsApp, Messenger, Google Chat, Telegram**. Only register secrets and webhook URLs for the ones they pick — `/health` reports `configured: true/false` per platform, so unused ones stay dormant with zero cost.
+Ask the user **which platforms** they want to set up. Supported webhook platforms: **LINE, WhatsApp, Messenger, Google Chat, Telegram, Microsoft Teams**. Only register secrets and webhook URLs for the ones they pick — `/health` reports `configured: true/false` per platform, so unused ones stay dormant with zero cost.
 
 For each selected platform, walk through the matching block below. All `wrangler secret put` invocations must run from `packages/relay`, use the `!` prefix (the user types the secret in their own terminal), and each registers exactly one secret.
 
@@ -128,6 +128,33 @@ For each selected platform, walk through the matching block below. All `wrangler
    curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<relay-url>/webhook/telegram&secret_token=<SECRET>"
    ```
 
+#### Microsoft Teams
+
+1. [Azure Portal](https://portal.azure.com/) → create **Azure Bot** resource (pricing tier F0 for free) → choose **Multi-tenant** (the simplest option) or **Single-tenant** if the bot is company-only.
+2. After creation, open the bot resource → **Configuration** → copy **Microsoft App ID**. Click **Manage** next to it → **Certificates & secrets** → **New client secret** → copy the **Value** (shows only once).
+3. (SingleTenant only) copy the **Tenant ID** from the same AAD app registration page.
+4. Register secrets:
+   ```
+   ! cd packages/relay && wrangler secret put MICROSOFT_APP_ID
+   ! cd packages/relay && wrangler secret put MICROSOFT_APP_PASSWORD
+   ```
+   For SingleTenant, also:
+   ```
+   ! cd packages/relay && wrangler secret put MICROSOFT_APP_TENANT_ID
+   ```
+   (Optional) AAD user object-ID allowlist:
+   ```
+   ! cd packages/relay && wrangler secret put TEAMS_ALLOWED_USERS
+   ```
+5. Edit `packages/relay/wrangler.toml` and add `MICROSOFT_APP_TYPE` under `[vars]` (non-secret) — values: `MultiTenant` (default) or `SingleTenant`. Re-run `wrangler deploy` after editing.
+6. Back in the Azure Bot resource → **Configuration** → **Messaging endpoint**:
+   ```
+   https://<relay-url>/webhook/teams
+   ```
+   Click **Apply** — Azure doesn't do a verify-token handshake, but your bot won't receive messages until the endpoint is saved here.
+7. Teams channel — on the same bot resource go to **Channels** → **Microsoft Teams** → accept T&C → **Apply**.
+8. Create a Teams app manifest (simplest path: [Developer Portal](https://dev.teams.microsoft.com/) → **Apps** → **New app** → set the `botId` to `MICROSOFT_APP_ID`) and install it into a team / personal scope.
+
 ## Step 4: Configure MulmoClaude
 
 Tell the user to add the Relay connection to `.env` themselves. Both the URL (from Step 2) and the token (generated in Step 3) are needed:
@@ -173,4 +200,7 @@ echo "RELAY_TOKEN=<token-from-step-3>" >> .env
 - **Google Chat uses the project number, not project ID** — project number is numeric (found on the Cloud Console home page), project ID is the human-readable slug
 - **Google Chat service-account JSON**: paste the _entire_ JSON blob (multi-line) at the wrangler prompt — do not base64-encode or try to escape it
 - Messenger webhooks require per-page subscription in addition to the app-level callback — setting only the callback URL is not enough; messages will arrive at Meta but never get forwarded to the app
+- **Teams SingleTenant**: must set both `MICROSOFT_APP_TENANT_ID` (secret) and `MICROSOFT_APP_TYPE=SingleTenant` (var in `wrangler.toml`) — missing either and `/health` reports `teams: false`
+- **Teams client secret shown once**: Azure's "New client secret" dialog displays the Value only on creation — if the user misses it, they have to generate a new one
+- **Teams endpoint is persistent once saved**: Azure doesn't verify the endpoint actively; you won't know it's wrong until a real message fails to arrive. Test with a personal-scope DM first
 - Durable Objects work on the free plan when using `new_sqlite_classes` in `wrangler.toml` (the default in this project)

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -1,6 +1,6 @@
 # @mulmobridge/relay
 
-Cloudflare Workers relay for MulmoBridge. Receives webhooks from messaging platforms (LINE, WhatsApp, Messenger, Google Chat, Telegram), queues messages when MulmoClaude is offline, and forwards them via WebSocket when connected.
+Cloudflare Workers relay for MulmoBridge. Receives webhooks from messaging platforms (LINE, WhatsApp, Messenger, Google Chat, Telegram, Microsoft Teams), queues messages when MulmoClaude is offline, and forwards them via WebSocket when connected.
 
 ## Why
 
@@ -18,9 +18,10 @@ With the relay:
 ```text
 LINE ─────────→ /webhook/line         ┐
 WhatsApp ─────→ /webhook/whatsapp     │
-Messenger ────→ /webhook/messenger    ├→ Durable Object → WS → MulmoClaude
-Google Chat ──→ /webhook/google-chat  │   (queue if offline)    (home PC)
-Telegram ─────→ /webhook/telegram     ┘
+Messenger ────→ /webhook/messenger    │
+Google Chat ──→ /webhook/google-chat  ├→ Durable Object → WS → MulmoClaude
+Telegram ─────→ /webhook/telegram     │   (queue if offline)    (home PC)
+Teams ────────→ /webhook/teams        ┘
 ```
 
 ## Setup
@@ -86,6 +87,19 @@ wrangler secret put TELEGRAM_BOT_TOKEN
 wrangler secret put TELEGRAM_WEBHOOK_SECRET
 ```
 
+#### Microsoft Teams
+
+```bash
+wrangler secret put MICROSOFT_APP_ID                # Azure Bot → Configuration → Microsoft App ID
+wrangler secret put MICROSOFT_APP_PASSWORD          # Client secret generated for that app
+# Only for SingleTenant apps:
+wrangler secret put MICROSOFT_APP_TENANT_ID
+# Optional: AAD user object ID allowlist (CSV)
+wrangler secret put TEAMS_ALLOWED_USERS
+```
+
+Also set `MICROSOFT_APP_TYPE` under `[vars]` in `wrangler.toml` (values: `MultiTenant` — default — or `SingleTenant`). It's non-sensitive, so it belongs in vars, not secrets.
+
 ### 3. Set webhook URLs in platform consoles
 
 | Platform    | Webhook URL                                      | Where to register                                                                                                                                 |
@@ -95,6 +109,7 @@ wrangler secret put TELEGRAM_WEBHOOK_SECRET
 | Messenger   | `https://<name>.workers.dev/webhook/messenger`   | [Meta for Developers](https://developers.facebook.com/apps/) → Messenger → **Settings** → **Webhooks** (use `MESSENGER_VERIFY_TOKEN` at prompt)   |
 | Google Chat | `https://<name>.workers.dev/webhook/google-chat` | [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Google Chat API → **Configuration** → **App URL**                   |
 | Telegram    | `https://<name>.workers.dev/webhook/telegram`    | Set via Bot API call (see below)                                                                                                                  |
+| Teams       | `https://<name>.workers.dev/webhook/teams`       | [Azure Portal](https://portal.azure.com/) → Azure Bot resource → **Configuration** → **Messaging endpoint**                                       |
 
 Telegram is the odd one out — no GUI, set via API:
 
@@ -115,15 +130,16 @@ RELAY_TOKEN=<same token as step 2>
 
 ## Endpoints
 
-| Method | Path                   | Description                                                                                              |
-| ------ | ---------------------- | -------------------------------------------------------------------------------------------------------- |
-| GET    | `/health`              | Health check + configured platforms                                                                      |
-| GET    | `/ws`                  | WebSocket (MulmoClaude connection, bearer auth)                                                          |
-| POST   | `/webhook/line`        | LINE webhook (HMAC-SHA256 verified)                                                                      |
-| POST   | `/webhook/whatsapp`    | WhatsApp Cloud API webhook (Meta signature + `hub.verify_token` echo for GET)                            |
-| POST   | `/webhook/messenger`   | Messenger webhook (Meta signature + `hub.verify_token` echo for GET)                                     |
-| POST   | `/webhook/google-chat` | Google Chat webhook (JWT `iss=chat@system.gserviceaccount.com`, audience = `GOOGLE_CHAT_PROJECT_NUMBER`) |
-| POST   | `/webhook/telegram`    | Telegram webhook (secret token verified)                                                                 |
+| Method | Path                   | Description                                                                                                                    |
+| ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| GET    | `/health`              | Health check + configured platforms                                                                                            |
+| GET    | `/ws`                  | WebSocket (MulmoClaude connection, bearer auth)                                                                                |
+| POST   | `/webhook/line`        | LINE webhook (HMAC-SHA256 verified)                                                                                            |
+| POST   | `/webhook/whatsapp`    | WhatsApp Cloud API webhook (Meta signature + `hub.verify_token` echo for GET)                                                  |
+| POST   | `/webhook/messenger`   | Messenger webhook (Meta signature + `hub.verify_token` echo for GET)                                                           |
+| POST   | `/webhook/google-chat` | Google Chat webhook (JWT `iss=chat@system.gserviceaccount.com`, audience = `GOOGLE_CHAT_PROJECT_NUMBER`)                       |
+| POST   | `/webhook/telegram`    | Telegram webhook (secret token verified)                                                                                       |
+| POST   | `/webhook/teams`       | Microsoft Teams webhook (Azure AD JWT verified, aud = `MICROSOFT_APP_ID`; non-message activities acked 200 without forwarding) |
 
 ## Security
 

--- a/packages/relay/src/durable-object.ts
+++ b/packages/relay/src/durable-object.ts
@@ -15,6 +15,7 @@ import "./webhooks/telegram.js";
 import "./webhooks/whatsapp.js";
 import "./webhooks/messenger.js";
 import "./webhooks/google-chat.js";
+import "./webhooks/teams.js";
 
 const MAX_QUEUE_SIZE = 1000;
 const QUEUE_KEY_PREFIX = "q:";

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -14,6 +14,7 @@ import "./webhooks/telegram.js";
 import "./webhooks/whatsapp.js";
 import "./webhooks/messenger.js";
 import "./webhooks/google-chat.js";
+import "./webhooks/teams.js";
 
 export { RelayDurableObject } from "./durable-object.js";
 

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -12,6 +12,7 @@ export const PLATFORMS = {
   matrix: "matrix",
   irc: "irc",
   googleChat: "google-chat",
+  teams: "teams",
 } as const;
 
 export type Platform = (typeof PLATFORMS)[keyof typeof PLATFORMS];

--- a/packages/relay/src/webhooks/teams-verify.ts
+++ b/packages/relay/src/webhooks/teams-verify.ts
@@ -1,0 +1,94 @@
+// Pure validators extracted from teams.ts so they can be unit-tested
+// without stubbing crypto.subtle or signing fake JWTs.
+//
+// Implements three security checks that protect against SSRF and
+// impersonation in the Teams webhook path:
+//
+//   1. `serviceurl` JWT claim MUST equal activity.serviceUrl
+//      (otherwise an attacker with a valid token could point replies —
+//       which carry our Bearer token — at an attacker-controlled URL).
+//   2. `activity.channelId` MUST be "msteams"
+//      (prevents impersonation from other Bot Framework channels).
+//   3. Key used to sign the JWT MUST be endorsed for `msteams`
+//      (MultiTenant only — the Bot Framework JWKS publishes
+//       per-channel endorsements; SingleTenant AAD JWKS does not).
+//
+// Items 1 and 2 come from Bot Framework security guidance:
+// https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication
+
+export const TEAMS_CHANNEL_ID = "msteams";
+
+export type AppType = "MultiTenant" | "SingleTenant";
+
+export interface TeamsActivityClaims {
+  serviceUrl: string;
+  channelId: string;
+}
+
+export interface JwkWithEndorsements {
+  endorsements?: string[];
+}
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/$/, "");
+}
+
+export interface ValidateTokenClaimsInput {
+  payload: Record<string, unknown>;
+  appId: string;
+  expectedIssuer: string;
+  nowSeconds: number;
+  activity: TeamsActivityClaims;
+}
+
+// Returns true only if every required claim lines up with the server's
+// expectations AND with the activity body. Leaves signature verification
+// and JWKS lookup to the caller.
+export function validateTokenClaims(input: ValidateTokenClaimsInput): boolean {
+  const { payload, appId, expectedIssuer, nowSeconds, activity } = input;
+
+  if (payload.iss !== expectedIssuer) return false;
+
+  const aud = payload.aud;
+  const audMatches = typeof aud === "string" ? aud === appId : Array.isArray(aud) && aud.includes(appId);
+  if (!audMatches) return false;
+
+  if (typeof payload.exp === "number" && payload.exp < nowSeconds) return false;
+
+  // Bot Framework tokens carry the activity's serviceUrl as the
+  // `serviceurl` claim (lowercase). Require it to be present AND match —
+  // a missing claim is suspicious, not a reason to pass.
+  if (typeof payload.serviceurl !== "string") return false;
+  if (normalizeUrl(payload.serviceurl) !== normalizeUrl(activity.serviceUrl)) return false;
+
+  if (activity.channelId !== TEAMS_CHANNEL_ID) return false;
+
+  return true;
+}
+
+// MultiTenant: the Bot Framework JWKS includes per-key `endorsements`
+// listing the channels the key is valid for. Teams keys have
+// "msteams". If the array is absent, reject.
+//
+// SingleTenant: the AAD JWKS does not publish endorsements; trust comes
+// from the tenant-pinned issuer, so skip this check.
+export function validateJwkEndorsement(jwk: JwkWithEndorsements, appType: AppType): boolean {
+  if (appType === "SingleTenant") return true;
+  if (!Array.isArray(jwk.endorsements)) return false;
+  return jwk.endorsements.includes(TEAMS_CHANNEL_ID);
+}
+
+export interface AllowlistCheckInput {
+  allowed: Set<string>;
+  senderAadObjectId: string;
+}
+
+// Fail-closed allowlist: if an allowlist is configured, the sender MUST
+// present an aadObjectId that is on the list. A missing aadObjectId is
+// not a free pass.
+export function isAllowedSender(input: AllowlistCheckInput): boolean {
+  const { allowed, senderAadObjectId } = input;
+  if (allowed.size === 0) return true;
+  if (!senderAadObjectId) return false;
+  return allowed.has(senderAadObjectId);
+}

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -1,0 +1,314 @@
+// Microsoft Teams platform plugin.
+//
+// Required secrets (wrangler secret put):
+//   MICROSOFT_APP_ID       — App ID from Azure Bot registration
+//   MICROSOFT_APP_PASSWORD — Client secret (App password)
+//
+// Optional:
+//   MICROSOFT_APP_TYPE      — "MultiTenant" (default) | "SingleTenant"
+//   MICROSOFT_APP_TENANT_ID — AAD tenant ID (required when SingleTenant)
+//   TEAMS_ALLOWED_USERS     — CSV of AAD user object IDs (empty = all)
+//
+// Verification: Teams posts activities with Authorization: Bearer <JWT>.
+// The JWT's issuer + audience + signature are checked against Azure AD JWKS
+// (per-tenant URL for SingleTenant, well-known Bot Framework URL for
+// MultiTenant). Audience = MICROSOFT_APP_ID.
+//
+// Replies: Teams needs an OAuth2 access token obtained from
+// login.microsoftonline.com with MICROSOFT_APP_ID + MICROSOFT_APP_PASSWORD
+// against scope https://api.botframework.com/.default. The reply itself
+// POSTs to <activity.serviceUrl>/v3/conversations/<conversation.id>/activities
+// — the serviceUrl varies per region and we carry it through via the
+// existing RelayMessage.replyToken channel (opaque to the relay core).
+
+import { chunkText } from "@mulmobridge/client/text";
+import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
+import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { ONE_HOUR_MS, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
+
+const MULTITENANT_ISSUER = "https://api.botframework.com";
+const MULTITENANT_JWKS_URL = "https://login.botframework.com/v1/.well-known/keys";
+const TOKEN_URL = "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const TOKEN_SCOPE = "https://api.botframework.com/.default";
+const MAX_TEAMS_TEXT = 28_000; // Teams soft limit is 40k; leave headroom
+const JWKS_CACHE_TTL_MS = ONE_HOUR_MS;
+const TOKEN_REFRESH_SKEW_SEC = 300; // refresh 5 min before expiry
+
+// ── Type guards ─────────────────────────────────────────────────
+
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+// ── Config helpers ──────────────────────────────────────────────
+
+function getAppType(env: Env): "MultiTenant" | "SingleTenant" {
+  const raw = typeof env.MICROSOFT_APP_TYPE === "string" ? env.MICROSOFT_APP_TYPE.trim() : "";
+  return raw === "SingleTenant" ? "SingleTenant" : "MultiTenant";
+}
+
+function getTenantId(env: Env): string {
+  return typeof env.MICROSOFT_APP_TENANT_ID === "string" ? env.MICROSOFT_APP_TENANT_ID.trim() : "";
+}
+
+function getJwksUrl(env: Env): string {
+  if (getAppType(env) === "SingleTenant") {
+    const tenantId = getTenantId(env);
+    return `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
+  }
+  return MULTITENANT_JWKS_URL;
+}
+
+function getExpectedIssuer(env: Env): string {
+  if (getAppType(env) === "SingleTenant") {
+    const tenantId = getTenantId(env);
+    return `https://sts.windows.net/${tenantId}/`;
+  }
+  return MULTITENANT_ISSUER;
+}
+
+function getAllowedUsers(env: Env): Set<string> {
+  const raw = typeof env.TEAMS_ALLOWED_USERS === "string" ? env.TEAMS_ALLOWED_USERS : "";
+  return new Set(
+    raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+// ── JWKS cache ──────────────────────────────────────────────────
+
+interface JwkKey {
+  kid: string;
+  kty: string;
+  n: string;
+  e: string;
+  alg?: string;
+}
+
+interface JwksCacheEntry {
+  keys: JwkKey[];
+  expiresAt: number;
+}
+
+// Cache is keyed by JWKS URL so MultiTenant and SingleTenant modes can
+// coexist (unusual, but cheap to support).
+const jwksCache = new Map<string, JwksCacheEntry>();
+
+async function fetchJwks(url: string): Promise<JwkKey[]> {
+  const cached = jwksCache.get(url);
+  if (cached && Date.now() < cached.expiresAt) return cached.keys;
+  const res = await fetch(url, { signal: AbortSignal.timeout(TEN_SECONDS_MS) });
+  if (!res.ok) return cached?.keys ?? [];
+  const data: { keys?: unknown[] } = await res.json();
+  if (!Array.isArray(data.keys)) return cached?.keys ?? [];
+  const keys = data.keys.filter((key): key is JwkKey => isObj(key) && typeof key.kid === "string" && typeof key.n === "string");
+  jwksCache.set(url, { keys, expiresAt: Date.now() + JWKS_CACHE_TTL_MS });
+  return keys;
+}
+
+// ── JWT parsing + verification ──────────────────────────────────
+
+function b64UrlDecode(str: string): Uint8Array {
+  const padded = str
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(str.length + ((4 - (str.length % 4)) % 4), "=");
+  return Uint8Array.from(atob(padded), (chr) => chr.charCodeAt(0));
+}
+
+interface ParsedJwt {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signInput: string;
+  sig: Uint8Array;
+}
+
+function parseJwt(token: string): ParsedJwt | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const header = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[0]))) as Record<string, unknown>;
+    const payload = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[1]))) as Record<string, unknown>;
+    return { header, payload, signInput: `${parts[0]}.${parts[1]}`, sig: b64UrlDecode(parts[2]) };
+  } catch {
+    return null;
+  }
+}
+
+async function verifyTeamsJwt(authHeader: string | undefined, env: Env): Promise<boolean> {
+  if (!authHeader?.startsWith("Bearer ")) return false;
+  const token = authHeader.slice(7).trim();
+  const jwt = parseJwt(token);
+  if (!jwt) return false;
+
+  const { header, payload } = jwt;
+  const appId = String(env.MICROSOFT_APP_ID);
+  const expectedIssuer = getExpectedIssuer(env);
+
+  if (payload.iss !== expectedIssuer) return false;
+  // `aud` can be a string or an array depending on the issuer.
+  const aud = payload.aud;
+  const audMatches = typeof aud === "string" ? aud === appId : Array.isArray(aud) && aud.includes(appId);
+  if (!audMatches) return false;
+  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) return false;
+
+  const keyId = typeof header.kid === "string" ? header.kid : "";
+  const alg = typeof header.alg === "string" ? header.alg : "RS256";
+  const hashAlg = alg === "RS256" ? "SHA-256" : alg === "RS384" ? "SHA-384" : "SHA-512";
+  const keys = await fetchJwks(getJwksUrl(env));
+  const jwk = keys.find((key) => key.kid === keyId);
+  if (!jwk) return false;
+  const pubKey = await crypto.subtle.importKey("jwk", jwk, { name: "RSASSA-PKCS1-v1_5", hash: hashAlg }, false, ["verify"]);
+  return crypto.subtle.verify("RSASSA-PKCS1-v1_5", pubKey, jwt.sig, new TextEncoder().encode(jwt.signInput));
+}
+
+// ── Activity parsing ────────────────────────────────────────────
+
+interface TeamsMessage {
+  conversationId: string;
+  senderId: string;
+  senderAadObjectId: string;
+  text: string;
+  serviceUrl: string;
+}
+
+function parseActivity(body: unknown): TeamsMessage | null {
+  if (!isObj(body)) return null;
+  // Non-message activities (conversationUpdate, invoke, typing, …) are
+  // legit but we don't forward them to MulmoClaude.
+  if (body.type !== "message") return null;
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!text) return null;
+  const conversation = body.conversation;
+  const from = body.from;
+  const serviceUrl = typeof body.serviceUrl === "string" ? body.serviceUrl.trim() : "";
+  if (!isObj(conversation) || typeof conversation.id !== "string") return null;
+  if (!isObj(from) || typeof from.id !== "string") return null;
+  if (!serviceUrl) return null;
+  return {
+    conversationId: conversation.id,
+    senderId: from.id,
+    senderAadObjectId: typeof from.aadObjectId === "string" ? from.aadObjectId : "",
+    text,
+    serviceUrl,
+  };
+}
+
+// ── OAuth2 token exchange ───────────────────────────────────────
+
+interface TokenCache {
+  token: string;
+  expiresAt: number; // epoch seconds
+}
+
+let tokenCache: TokenCache | null = null;
+
+async function getAccessToken(env: Env): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  if (tokenCache && tokenCache.expiresAt - TOKEN_REFRESH_SKEW_SEC > now) {
+    return tokenCache.token;
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: String(env.MICROSOFT_APP_ID),
+    client_secret: String(env.MICROSOFT_APP_PASSWORD),
+    scope: TOKEN_SCOPE,
+  });
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+    signal: AbortSignal.timeout(TEN_SECONDS_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Teams token exchange failed: ${res.status}`);
+  }
+  const data = (await res.json()) as { access_token?: string; expires_in?: number };
+  if (typeof data.access_token !== "string") {
+    throw new Error("Teams token response missing access_token");
+  }
+  const ttlSec = typeof data.expires_in === "number" ? data.expires_in : 3600;
+  tokenCache = { token: data.access_token, expiresAt: now + ttlSec };
+  return data.access_token;
+}
+
+// ── Plugin ──────────────────────────────────────────────────────
+
+const teamsPlugin: PlatformPlugin = {
+  name: PLATFORMS.teams,
+  mode: CONNECTION_MODES.webhook,
+  webhookPath: "/webhook/teams",
+
+  isConfigured(env: Env): boolean {
+    if (!env.MICROSOFT_APP_ID || !env.MICROSOFT_APP_PASSWORD) return false;
+    if (getAppType(env) === "SingleTenant" && !getTenantId(env)) return false;
+    return true;
+  },
+
+  async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {
+    const authHeader = request.headers.get("authorization") ?? undefined;
+    const valid = await verifyTeamsJwt(authHeader, env);
+    if (!valid) throw new Error("Teams JWT verification failed");
+
+    const activity = parseActivity(JSON.parse(body));
+    if (!activity) return []; // non-message or malformed — ack 200 OK
+
+    const allowed = getAllowedUsers(env);
+    if (allowed.size > 0 && activity.senderAadObjectId && !allowed.has(activity.senderAadObjectId)) {
+      // Drop messages from users not on the allowlist — still 200 OK
+      // so the Bot Framework doesn't mark the endpoint as flaky.
+      return [];
+    }
+
+    return [
+      {
+        id: crypto.randomUUID(),
+        platform: PLATFORMS.teams,
+        senderId: activity.senderAadObjectId || activity.senderId,
+        chatId: activity.conversationId,
+        text: activity.text,
+        receivedAt: new Date().toISOString(),
+        // Carry the activity's serviceUrl through the outbound path —
+        // the relay's response routing treats replyToken as opaque.
+        replyToken: activity.serviceUrl,
+      },
+    ];
+  },
+
+  async sendResponse(chatId: string, text: string, env: Env, replyToken?: string): Promise<void> {
+    const serviceUrl = typeof replyToken === "string" ? replyToken.trim() : "";
+    if (!serviceUrl) {
+      throw new Error("Teams sendResponse missing serviceUrl (no prior inbound message to reply to)");
+    }
+    const accessToken = await getAccessToken(env);
+    const base = serviceUrl.replace(/\/$/, "");
+    const endpoint = `${base}/v3/conversations/${encodeURIComponent(chatId)}/activities`;
+
+    for (const chunk of chunkText(text, MAX_TEAMS_TEXT)) {
+      let res: Response;
+      try {
+        res = await fetch(endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ type: "message", text: chunk }),
+          signal: AbortSignal.timeout(FIFTEEN_SECONDS_MS),
+        });
+      } catch (err) {
+        throw new Error(`Teams API network error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Teams API failed: ${res.status} ${detail.slice(0, 200)}`);
+      }
+    }
+  },
+};
+
+registerPlatform(teamsPlugin);

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -10,9 +10,12 @@
 //   TEAMS_ALLOWED_USERS     — CSV of AAD user object IDs (empty = all)
 //
 // Verification: Teams posts activities with Authorization: Bearer <JWT>.
-// The JWT's issuer + audience + signature are checked against Azure AD JWKS
-// (per-tenant URL for SingleTenant, well-known Bot Framework URL for
-// MultiTenant). Audience = MICROSOFT_APP_ID.
+// We check all of: issuer, audience (= MICROSOFT_APP_ID), exp, signature
+// against JWKS (per-tenant URL for SingleTenant, Bot Framework URL for
+// MultiTenant), `serviceurl` claim == activity.serviceUrl,
+// activity.channelId == "msteams", and — for MultiTenant — that the
+// signing key is endorsed for the `msteams` channel. See
+// teams-verify.ts for the pure validator functions.
 //
 // Replies: Teams needs an OAuth2 access token obtained from
 // login.microsoftonline.com with MICROSOFT_APP_ID + MICROSOFT_APP_PASSWORD
@@ -25,6 +28,7 @@ import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
+import { validateTokenClaims, validateJwkEndorsement, isAllowedSender, type AppType } from "./teams-verify.js";
 
 const MULTITENANT_ISSUER = "https://api.botframework.com";
 const MULTITENANT_JWKS_URL = "https://login.botframework.com/v1/.well-known/keys";
@@ -42,7 +46,7 @@ function isObj(value: unknown): value is Record<string, unknown> {
 
 // ── Config helpers ──────────────────────────────────────────────
 
-function getAppType(env: Env): "MultiTenant" | "SingleTenant" {
+function getAppType(env: Env): AppType {
   const raw = typeof env.MICROSOFT_APP_TYPE === "string" ? env.MICROSOFT_APP_TYPE.trim() : "";
   return raw === "SingleTenant" ? "SingleTenant" : "MultiTenant";
 }
@@ -85,6 +89,9 @@ interface JwkKey {
   n: string;
   e: string;
   alg?: string;
+  // Bot Framework JWKS publishes per-key channel endorsements; we
+  // require `msteams` to be present for MultiTenant auth.
+  endorsements?: string[];
 }
 
 interface JwksCacheEntry {
@@ -103,7 +110,19 @@ async function fetchJwks(url: string): Promise<JwkKey[]> {
   if (!res.ok) return cached?.keys ?? [];
   const data: { keys?: unknown[] } = await res.json();
   if (!Array.isArray(data.keys)) return cached?.keys ?? [];
-  const keys = data.keys.filter((key): key is JwkKey => isObj(key) && typeof key.kid === "string" && typeof key.n === "string");
+  const keys = data.keys
+    .filter((key): key is Record<string, unknown> => isObj(key) && typeof key.kid === "string" && typeof key.n === "string")
+    .map((key): JwkKey => {
+      const endorsements = Array.isArray(key.endorsements) ? key.endorsements.filter((entry): entry is string => typeof entry === "string") : undefined;
+      return {
+        kid: String(key.kid),
+        kty: typeof key.kty === "string" ? key.kty : "RSA",
+        n: String(key.n),
+        e: typeof key.e === "string" ? key.e : "AQAB",
+        alg: typeof key.alg === "string" ? key.alg : undefined,
+        endorsements,
+      };
+    });
   jwksCache.set(url, { keys, expiresAt: Date.now() + JWKS_CACHE_TTL_MS });
   return keys;
 }
@@ -137,22 +156,25 @@ function parseJwt(token: string): ParsedJwt | null {
   }
 }
 
-async function verifyTeamsJwt(authHeader: string | undefined, env: Env): Promise<boolean> {
+// Verifies the JWT against all of: expected issuer/audience/exp, the
+// activity body (serviceUrl + channelId cross-checks), the JWKS key's
+// channel endorsements, and the RSA signature. All four must pass —
+// signing key alone is not enough; see teams-verify.ts for rationale.
+async function verifyTeamsJwt(authHeader: string | undefined, env: Env, activity: TeamsMessage): Promise<boolean> {
   if (!authHeader?.startsWith("Bearer ")) return false;
   const token = authHeader.slice(7).trim();
   const jwt = parseJwt(token);
   if (!jwt) return false;
 
   const { header, payload } = jwt;
-  const appId = String(env.MICROSOFT_APP_ID);
-  const expectedIssuer = getExpectedIssuer(env);
-
-  if (payload.iss !== expectedIssuer) return false;
-  // `aud` can be a string or an array depending on the issuer.
-  const aud = payload.aud;
-  const audMatches = typeof aud === "string" ? aud === appId : Array.isArray(aud) && aud.includes(appId);
-  if (!audMatches) return false;
-  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) return false;
+  const claimsOk = validateTokenClaims({
+    payload,
+    appId: String(env.MICROSOFT_APP_ID),
+    expectedIssuer: getExpectedIssuer(env),
+    nowSeconds: Math.floor(Date.now() / 1000),
+    activity: { serviceUrl: activity.serviceUrl, channelId: activity.channelId },
+  });
+  if (!claimsOk) return false;
 
   const keyId = typeof header.kid === "string" ? header.kid : "";
   const alg = typeof header.alg === "string" ? header.alg : "RS256";
@@ -160,6 +182,8 @@ async function verifyTeamsJwt(authHeader: string | undefined, env: Env): Promise
   const keys = await fetchJwks(getJwksUrl(env));
   const jwk = keys.find((key) => key.kid === keyId);
   if (!jwk) return false;
+  if (!validateJwkEndorsement(jwk, getAppType(env))) return false;
+
   const pubKey = await crypto.subtle.importKey("jwk", jwk, { name: "RSASSA-PKCS1-v1_5", hash: hashAlg }, false, ["verify"]);
   return crypto.subtle.verify("RSASSA-PKCS1-v1_5", pubKey, jwt.sig, new TextEncoder().encode(jwt.signInput));
 }
@@ -172,6 +196,7 @@ interface TeamsMessage {
   senderAadObjectId: string;
   text: string;
   serviceUrl: string;
+  channelId: string;
 }
 
 function parseActivity(body: unknown): TeamsMessage | null {
@@ -184,6 +209,7 @@ function parseActivity(body: unknown): TeamsMessage | null {
   const conversation = body.conversation;
   const from = body.from;
   const serviceUrl = typeof body.serviceUrl === "string" ? body.serviceUrl.trim() : "";
+  const channelId = typeof body.channelId === "string" ? body.channelId.trim() : "";
   if (!isObj(conversation) || typeof conversation.id !== "string") return null;
   if (!isObj(from) || typeof from.id !== "string") return null;
   if (!serviceUrl) return null;
@@ -193,6 +219,7 @@ function parseActivity(body: unknown): TeamsMessage | null {
     senderAadObjectId: typeof from.aadObjectId === "string" ? from.aadObjectId : "",
     text,
     serviceUrl,
+    channelId,
   };
 }
 
@@ -250,15 +277,20 @@ const teamsPlugin: PlatformPlugin = {
   },
 
   async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {
-    const authHeader = request.headers.get("authorization") ?? undefined;
-    const valid = await verifyTeamsJwt(authHeader, env);
-    if (!valid) throw new Error("Teams JWT verification failed");
-
+    // Parse the activity first so the JWT verifier can cross-check the
+    // serviceUrl / channelId claims against the body. If parsing fails,
+    // the request is a non-message activity (typing, invoke, …) and
+    // still needs a 200 OK — but we skip signature checks since there's
+    // nothing to forward.
     const activity = parseActivity(JSON.parse(body));
     if (!activity) return []; // non-message or malformed — ack 200 OK
 
+    const authHeader = request.headers.get("authorization") ?? undefined;
+    const valid = await verifyTeamsJwt(authHeader, env, activity);
+    if (!valid) throw new Error("Teams JWT verification failed");
+
     const allowed = getAllowedUsers(env);
-    if (allowed.size > 0 && activity.senderAadObjectId && !allowed.has(activity.senderAadObjectId)) {
+    if (!isAllowedSender({ allowed, senderAadObjectId: activity.senderAadObjectId })) {
       // Drop messages from users not on the allowlist — still 200 OK
       // so the Bot Framework doesn't mark the endpoint as flaky.
       return [];

--- a/packages/relay/test/test_teams_webhook.ts
+++ b/packages/relay/test/test_teams_webhook.ts
@@ -1,0 +1,198 @@
+// Regression tests for the Teams webhook security checks that landed
+// alongside the plugin:
+//
+//   1. `serviceurl` JWT claim must equal the activity's serviceUrl
+//      (SSRF protection — the reply path carries a Bearer token).
+//   2. `activity.channelId` must be "msteams".
+//   3. Signing key must be endorsed for `msteams` (MultiTenant only).
+//   4. Allowlist must fail-closed when aadObjectId is missing.
+//
+// These tests cover the pure validators — the crypto.subtle signature
+// check is not in scope here (would require fake-signing JWTs).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { validateTokenClaims, validateJwkEndorsement, isAllowedSender, TEAMS_CHANNEL_ID } from "../src/webhooks/teams-verify.js";
+
+const APP_ID = "11111111-1111-1111-1111-111111111111";
+const ISSUER = "https://api.botframework.com";
+const NOW_SEC = 1_700_000_000;
+const VALID_SERVICE_URL = "https://smba.trafficmanager.net/amer/";
+
+function basePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iss: ISSUER,
+    aud: APP_ID,
+    exp: NOW_SEC + 300,
+    serviceurl: VALID_SERVICE_URL,
+    ...overrides,
+  };
+}
+
+function baseActivity(overrides: Partial<{ serviceUrl: string; channelId: string }> = {}) {
+  return {
+    serviceUrl: VALID_SERVICE_URL,
+    channelId: TEAMS_CHANNEL_ID,
+    ...overrides,
+  };
+}
+
+describe("validateTokenClaims", () => {
+  it("passes when every claim lines up", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload(),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, true);
+  });
+
+  it("accepts `aud` as an array", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload({ aud: ["other-id", APP_ID] }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, true);
+  });
+
+  it("rejects when issuer mismatches", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload({ iss: "https://evil.example.com" }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("rejects when audience mismatches", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload({ aud: "not-our-app" }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("rejects when token has expired", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload({ exp: NOW_SEC - 1 }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("rejects when serviceurl claim is absent (fail-closed against SSRF)", () => {
+    const payload = basePayload();
+    delete payload.serviceurl;
+    const ok = validateTokenClaims({
+      payload,
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity(),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("rejects when serviceurl claim does not match activity.serviceUrl", () => {
+    // Attacker reuses a valid token but swaps the body's serviceUrl to
+    // point the reply (carrying our Bearer token) at their endpoint.
+    const ok = validateTokenClaims({
+      payload: basePayload({ serviceurl: VALID_SERVICE_URL }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity({ serviceUrl: "https://attacker.example.com/" }),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("tolerates trailing-slash differences in serviceUrl", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload({ serviceurl: "https://smba.trafficmanager.net/amer" }),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity({ serviceUrl: "https://smba.trafficmanager.net/amer/" }),
+    });
+    assert.equal(ok, true);
+  });
+
+  it("rejects when channelId is not `msteams`", () => {
+    // Another Bot Framework channel's token must not be accepted here.
+    const ok = validateTokenClaims({
+      payload: basePayload(),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity({ channelId: "slack" }),
+    });
+    assert.equal(ok, false);
+  });
+
+  it("rejects when channelId is empty", () => {
+    const ok = validateTokenClaims({
+      payload: basePayload(),
+      appId: APP_ID,
+      expectedIssuer: ISSUER,
+      nowSeconds: NOW_SEC,
+      activity: baseActivity({ channelId: "" }),
+    });
+    assert.equal(ok, false);
+  });
+});
+
+describe("validateJwkEndorsement", () => {
+  it("passes when MultiTenant key lists msteams", () => {
+    assert.equal(validateJwkEndorsement({ endorsements: ["msteams", "webchat"] }, "MultiTenant"), true);
+  });
+
+  it("rejects MultiTenant key without endorsements", () => {
+    assert.equal(validateJwkEndorsement({}, "MultiTenant"), false);
+  });
+
+  it("rejects MultiTenant key whose endorsements omit msteams", () => {
+    assert.equal(validateJwkEndorsement({ endorsements: ["slack", "webchat"] }, "MultiTenant"), false);
+  });
+
+  it("skips the endorsement requirement for SingleTenant (AAD JWKS has no endorsements)", () => {
+    assert.equal(validateJwkEndorsement({}, "SingleTenant"), true);
+    assert.equal(validateJwkEndorsement({ endorsements: ["slack"] }, "SingleTenant"), true);
+  });
+});
+
+describe("isAllowedSender", () => {
+  it("allows anyone when the allowlist is empty", () => {
+    assert.equal(isAllowedSender({ allowed: new Set(), senderAadObjectId: "" }), true);
+    assert.equal(isAllowedSender({ allowed: new Set(), senderAadObjectId: "any-id" }), true);
+  });
+
+  it("allows senders whose aadObjectId is on the list", () => {
+    const allowed = new Set(["user-a", "user-b"]);
+    assert.equal(isAllowedSender({ allowed, senderAadObjectId: "user-a" }), true);
+  });
+
+  it("rejects senders whose aadObjectId is not on the list", () => {
+    const allowed = new Set(["user-a"]);
+    assert.equal(isAllowedSender({ allowed, senderAadObjectId: "user-b" }), false);
+  });
+
+  it("rejects senders with a missing aadObjectId when the list is configured (fail-closed)", () => {
+    // Previously: `allowed.size > 0 && activity.senderAadObjectId && !allowed.has(...)`
+    // let senders through when aadObjectId was absent — a fail-open bug.
+    const allowed = new Set(["user-a"]);
+    assert.equal(isAllowedSender({ allowed, senderAadObjectId: "" }), false);
+  });
+});


### PR DESCRIPTION
## Summary

Teams is the sixth webhook platform on the relay, following the exact pattern as the existing five. Closes #615.

### What's new
- \`packages/relay/src/webhooks/teams.ts\` — \`PlatformPlugin\` for Teams. JWT verify on inbound, OAuth2 client-credentials for outbound. ~260 lines, mirrors \`google-chat.ts\` structurally.
- \`PLATFORMS.teams\` added, plugin imported in \`index.ts\` + \`durable-object.ts\`.
- README: Teams section in secrets block, webhook-URL table, endpoint table.
- \`/setup-relay\` skill: Teams walkthrough (Azure Bot registration → client secret → \`MICROSOFT_APP_TYPE\` var → Messaging endpoint → Teams-channel enable → manifest install).

### Teams-specific wrinkles
1. **Per-activity \`serviceUrl\`** (\`smba.trafficmanager.net/amer/\` etc.) is carried through the existing \`RelayMessage.replyToken\` field — the relay treats it opaquely, the plugin reads it as the outbound base URL. Avoids extending the public \`RelayMessage\`/\`RelayResponse\` shape.
2. **MultiTenant / SingleTenant split**. MultiTenant (default) uses \`issuer=https://api.botframework.com\` and JWKS at \`login.botframework.com/v1/.well-known/keys\`. SingleTenant swaps to \`issuer=https://sts.windows.net/<tenantId>/\` + \`login.microsoftonline.com/<tenantId>/discovery/v2.0/keys\`. \`MICROSOFT_APP_TYPE\` picks between them; kept in \`wrangler.toml\` \`[vars]\` since it's not sensitive.

### Plugin behaviour details
- Audience check = \`MICROSOFT_APP_ID\` (handles both string and array \`aud\`).
- JWKS cached per URL, 1 h TTL (mirrors \`google-chat.ts\`).
- Access token cached in-memory, refreshed 5 min before expiry.
- Non-message activities (conversationUpdate, invoke, typing, …) are acked 200 without forwarding to MulmoClaude.
- \`TEAMS_ALLOWED_USERS\` — AAD object-ID allowlist; denied messages drop silently with 200 so Azure doesn't mark the endpoint flaky.

## User Prompt

> Teams だけ public URL が必須（Azure AD 仕様）。relay プラグイン化は follow-up で検討（LINE/WhatsApp/Messenger/Google Chat と同じ位置付けになる）。→ (#615 を立てた後) あら。つくって。

## Items to Confirm / Review

- **\`replyToken\` as serviceUrl carrier**. Semantic reuse of the field — LINE uses it as a real LINE reply token, Telegram doesn't use it at all, Teams now uses it as a URL. Opaque to the relay core, but worth noting the pattern. Alternative would be a dedicated \`serviceUrl\` field on \`RelayMessage\`, which widens the public shape.
- **No real-platform smoke test yet**. Typecheck + build both pass, but the Azure Bot registration + end-to-end flow hasn't been exercised. That's the "requires dev credentials" manual verification step acknowledged in the #615 acceptance criteria.
- **Invoke / tokenExchange activities**. Currently drop them silently with 200. If users hit sign-in cards they'll need this to handle \`type="invoke"\`, but that's additive.

## Test plan

- [x] \`yarn typecheck\` + \`yarn lint\` green across the relay package
- [x] \`yarn build\` green (full repo)
- [ ] Real Azure Bot registration + Teams message → relay → MulmoClaude round-trip (manual; blocked on having a test-tenant Azure subscription)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Microsoft Teams as a supported messaging platform for webhook integrations, enabling Teams Bot setup and message handling with Azure Bot authentication and optional allowlist controls.

* **Documentation**
  * Updated setup guides and architecture documentation with Teams platform integration instructions, including webhook endpoint configuration and credential requirements.

* **Tests**
  * Added test suite for Teams webhook security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->