### PR TITLE
chore: bump client 0.1.2 + mock-server 0.1.1 + relay 0.2.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 - `@mulmobridge/nostr` (v0.1.0) — Nostr encrypted DM bridge. Subscribes to kind=4 events tagged to the bot pubkey on multiple relays; NIP-04 decrypt + sign-and-broadcast replies. Hex / nsec key input; pubkey allowlist.
 - `@mulmobridge/viber` (v0.1.0) — Viber Public Account bot bridge. Inbound webhook with `X-Viber-Content-Signature` HMAC-SHA256; outbound via Viber REST. Swapped in for KakaoTalk (deferred due to 5 s sync webhook timeout).
 
+### Changed
+
+- `@mulmobridge/client` (v0.1.1 → **v0.1.2**) — Patch release that exports the shared `chunkText` helper from `./text`. Required by every new bridge (mastodon, bluesky, chatwork, xmpp, rocketchat, signal, teams, webhook, twilio-sms, email, line-works, nostr, viber); without it, their `npx` invocations fail at runtime because they depend on `^0.1.0`.
+- `@mulmobridge/mock-server` (v0.1.0 → **v0.1.1**) — Patch release. Internal refactor of `handlers.ts` / `server.ts` + README catch-up listing all supported platforms.
+- `@mulmobridge/relay` (v0.1.0 → **v0.2.0**) — Minor release adding four new platform plugins:
+  - **WhatsApp** (HMAC-SHA256 webhook, Cloud API send)
+  - **Messenger** (Meta HMAC-SHA256 webhook, Messenger Send API)
+  - **Google Chat** (JWT/OIDC inbound, optional service-account async reply)
+  - **Microsoft Teams** (Bot Framework inbound with SSRF-hardened auth verification, `adapter.continueConversationAsync` for push)
+  Plus Durable Object hibernation recovery, subpath exports, CoderRabbit / Sourcery review fixes, extracted time constants.
+
+### Packages published during this cycle
+
+- `@mulmobridge/client@0.1.2`
+- `@mulmobridge/mock-server@0.1.1`
+- `@mulmobridge/relay@0.2.0`
+- `@mulmobridge/mastodon@0.1.0`
+- `@mulmobridge/bluesky@0.1.0`
+- `@mulmobridge/chatwork@0.1.0`
+- `@mulmobridge/xmpp@0.1.0`
+- `@mulmobridge/rocketchat@0.1.0`
+- `@mulmobridge/signal@0.1.0`
+- `@mulmobridge/teams@0.1.0`
+- `@mulmobridge/webhook@0.1.0`
+- `@mulmobridge/twilio-sms@0.1.0`
+- `@mulmobridge/email@0.1.0`
+- `@mulmobridge/line-works@0.1.0`
+- `@mulmobridge/nostr@0.1.0`
+- `@mulmobridge/viber@0.1.0`
+
 ---
 
 ## [0.3.0] - 2026-04-22

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Socket.io client library for MulmoBridge — shared by all bridge implementations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/mock-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mock MulmoClaude server for testing MulmoBridge bridges — no Claude API key needed",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/relay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cloudflare Workers relay for MulmoBridge — receives webhooks, queues messages, forwards via WebSocket to MulmoClaude",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Three core packages drifted from npm during the bridge expansion cycle. Bump + CHANGELOG + re-publish.

| Package | npm now | → bump to | Rationale |
|---|---|---|---|
| `@mulmobridge/client` | 0.1.1 | **0.1.2** (patch) | Adds `chunkText` export via `./text` subpath. **Required** — the 13 new bridges published yesterday all import `chunkText` from `@mulmobridge/client` via `^0.1.0`, which currently resolves to 0.1.1 → runtime error. Patch bump so the \`^0.1.0\` caret picks it up automatically without needing to re-publish the bridges. |
| `@mulmobridge/mock-server` | 0.1.0 | **0.1.1** (patch) | Internal refactor of `handlers.ts` / `server.ts` + README catch-up listing every supported platform. No public API changes. |
| `@mulmobridge/relay` | 0.1.0 | **0.2.0** (minor) | Four new platform plugins: WhatsApp (HMAC-SHA256 + Cloud API), Messenger (Meta HMAC + Send API), Google Chat (JWT/OIDC + optional async reply), Microsoft Teams (SSRF-hardened auth). Plus Durable Object hibernation recovery, subpath exports, review fixes. Nothing in the repo consumes `@mulmobridge/relay` as a dependency, so the minor bump has no cross-package impact. |

## Items to Confirm / Review

- **Patch vs minor for client**: technically adding a new export is a minor bump under strict semver, but for 0.x with a caret range, patch is the pragmatic choice so downstream bridges resolve it without their own re-publish. OK with this call?
- **Relay dep on client**: `@mulmobridge/relay` depends on `@mulmobridge/client ^0.1.1`. After this PR merges, relay still works against client 0.1.2 (caret compatible).

## Publish plan

After merge:
1. \`npm publish\` each of the three packages
2. Tag \`@mulmobridge/client@0.1.2\`, \`@mulmobridge/mock-server@0.1.1\`, \`@mulmobridge/relay@0.2.0\`
3. Create GitHub releases with \`--latest=false\`

## User Prompt

> relayとかってupdateしたあとpublishしている？

Verified: no, they had drifted. This PR + re-publish closes the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform support for WhatsApp, Messenger, Google Chat, and Microsoft Teams in relay service.

* **Chores**
  * Version updates: relay to v0.2.0, client to v0.1.2, mock-server to v0.1.1.
  * Updated documentation with supported platform details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->