### PR TITLE
ui(wiki): condense index view to single-line rows

### DIFF
--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -62,17 +62,17 @@
     </div>
 
     <!-- Index: page card list -->
-    <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 overflow-y-auto p-4 space-y-2">
+    <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 overflow-y-auto">
       <div
         v-for="entry in pageEntries"
         :key="entry.slug"
-        class="rounded-lg border border-gray-200 p-3 cursor-pointer hover:border-blue-300 hover:bg-blue-50 transition-colors"
+        class="flex items-baseline gap-2 px-4 py-1 cursor-pointer hover:bg-blue-50 transition-colors"
         @click="navigatePage(entry.slug || entry.title)"
       >
-        <div class="font-medium text-sm text-gray-800">{{ entry.title }}</div>
-        <div v-if="entry.description" class="text-xs text-gray-500 mt-0.5">
+        <span class="font-medium text-sm text-gray-800 shrink-0">{{ entry.title }}</span>
+        <span v-if="entry.description" class="text-xs text-gray-500 truncate">
           {{ entry.description }}
-        </div>
+        </span>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Removed card styling (borders, rounded corners, per-row padding, inter-row gap) from the wiki index view in `src/plugins/wiki/View.vue`.
- Each entry now renders as a single flex row: title on the left, description inline to the right (truncated when long).
- Hover state swapped from an outline change to a light blue background tint.

## Test plan
- [ ] Open the wiki plugin and verify the index list is denser, with rows flush to each other.
- [ ] Confirm entries with long descriptions truncate instead of wrapping.
- [ ] Confirm hover highlights the row and clicking still navigates to the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)