### PR TITLE
feat(wiki): sync navigation with URL and polish tabs/PDF button

### DIFF
--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -1,0 +1,183 @@
+// URL-driven navigation for the wiki plugin.
+//
+// Covers the routing contract established by plans/feat-wiki-url-sync.md:
+//
+// - /wiki              → index
+// - /wiki?page=<slug>  → page view
+// - /wiki?view=log     → activity log
+// - /wiki?view=lint_report → lint report
+//
+// Also regressions:
+//
+// - TDZ in the immediate route watcher (navError declared after callApi
+//   meant direct /wiki loads silently did nothing and rendered
+//   "Wiki is empty").
+// - Mount-vs-watcher race on ?view= / ?page= direct loads
+//   (useFreshPluginData's GET returned the index payload, clobbering
+//   the POST-driven log / page state when it resolved last).
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const INDEX_PAYLOAD = {
+  action: "index",
+  title: "Wiki Index",
+  content: "# Wiki Index\n\nRoot page.",
+  pageEntries: [
+    { title: "Onboarding", slug: "onboarding", description: "Getting started" },
+    { title: "Architecture", slug: "architecture", description: "How things fit" },
+  ],
+};
+
+const PAGE_ONBOARDING = {
+  action: "page",
+  title: "Onboarding",
+  pageName: "onboarding",
+  content: "# Onboarding\n\nWelcome to the project.",
+};
+
+const LOG_PAYLOAD = {
+  action: "log",
+  title: "Activity Log",
+  content: "## 2026-04-22\n- Did stuff",
+};
+
+async function mockWikiApi(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/wiki",
+    async (route) => {
+      const req = route.request();
+      if (req.method() === "GET") {
+        const slug = new URL(req.url()).searchParams.get("slug");
+        if (slug === "onboarding") return route.fulfill({ json: { data: PAGE_ONBOARDING } });
+        return route.fulfill({ json: { data: INDEX_PAYLOAD } });
+      }
+      if (req.method() === "POST") {
+        const body = (req.postDataJSON() ?? {}) as { action?: string; pageName?: string };
+        if (body.action === "page" && body.pageName === "onboarding") {
+          return route.fulfill({ json: { data: PAGE_ONBOARDING } });
+        }
+        if (body.action === "log") return route.fulfill({ json: { data: LOG_PAYLOAD } });
+        return route.fulfill({ json: { data: INDEX_PAYLOAD } });
+      }
+      return route.fallback();
+    },
+  );
+}
+
+test.describe("wiki navigation — URL sync", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockWikiApi(page);
+  });
+
+  test("direct /wiki load renders the index page list", async ({ page }) => {
+    // Regression guard: a TDZ inside the immediate URL watcher used to
+    // swallow the POST silently and leave the view stuck on the empty
+    // state.
+    await page.goto("/wiki");
+    await expect(page.getByTestId("wiki-page-entry-onboarding")).toBeVisible();
+    await expect(page.getByTestId("wiki-page-entry-architecture")).toBeVisible();
+    // Empty-state copy must NOT show when the index has entries.
+    await expect(page.getByText("Wiki is empty", { exact: false })).toHaveCount(0);
+  });
+
+  test("clicking a page card updates the URL and renders the page", async ({ page }) => {
+    await page.goto("/wiki");
+    await expect(page.getByTestId("wiki-page-entry-onboarding")).toBeVisible();
+
+    await page.getByTestId("wiki-page-entry-onboarding").click();
+
+    await page.waitForURL(/\/wiki\?page=onboarding/);
+    // h1 comes from the rendered page markdown; h2 is the view header.
+    await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
+    await expect(page.getByText("Welcome to the project.")).toBeVisible();
+  });
+
+  test("clicking the Log tab switches to ?view=log", async ({ page }) => {
+    await page.goto("/wiki");
+    await expect(page.getByText("Onboarding")).toBeVisible();
+
+    await page.getByRole("button", { name: /Log/ }).click();
+
+    await page.waitForURL(/\/wiki\?view=log/);
+    await expect(page.getByText("Did stuff")).toBeVisible();
+  });
+
+  test("direct /wiki?view=log load renders log content, not index", async ({ page }) => {
+    // Regression guard: useFreshPluginData's mount GET returns the
+    // index payload; if it resolves after the POST-driven log fetch
+    // on a direct load, the log content was clobbered.
+    await page.goto("/wiki?view=log");
+
+    await expect(page.getByText("Did stuff")).toBeVisible();
+    // Page-card rows from the index must not appear here.
+    await expect(page.getByTestId("wiki-page-entry-onboarding")).toHaveCount(0);
+    await expect(page.getByTestId("wiki-page-entry-architecture")).toHaveCount(0);
+  });
+
+  test("direct /wiki?page=onboarding load renders the page", async ({ page }) => {
+    await page.goto("/wiki?page=onboarding");
+
+    await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
+    await expect(page.getByText("Welcome to the project.")).toBeVisible();
+  });
+});
+
+test.describe("wiki navigation — from manageWiki tool result", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page, {
+      sessions: [
+        {
+          id: "wiki-session",
+          title: "Wiki Session",
+          roleId: "general",
+          startedAt: "2026-04-12T10:00:00Z",
+          updatedAt: "2026-04-12T10:05:00Z",
+        },
+      ],
+    });
+    await mockWikiApi(page);
+
+    // Session transcript with a manageWiki INDEX tool result.
+    await page.route(
+      (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+      (route) =>
+        route.fulfill({
+          json: [
+            { type: "session_meta", roleId: "general", sessionId: "wiki-session" },
+            { type: "text", source: "user", message: "Show the wiki" },
+            {
+              type: "tool_result",
+              source: "tool",
+              result: {
+                uuid: "wiki-index-result",
+                toolName: "manageWiki",
+                title: INDEX_PAYLOAD.title,
+                message: "Index loaded",
+                data: INDEX_PAYLOAD,
+              },
+            },
+          ],
+        }),
+    );
+  });
+
+  test("clicking a page card in a tool-result index navigates to /wiki", async ({ page }) => {
+    await page.goto("/chat/wiki-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Select the wiki index tool result in the right sidebar.
+    await page.getByText(`Wiki Index`, { exact: false }).first().click();
+    await expect(page.getByTestId("wiki-page-entry-onboarding")).toBeVisible();
+
+    await page.getByTestId("wiki-page-entry-onboarding").click();
+
+    // From /chat, clicking a page card should land on /wiki with the
+    // shareable query. Chat-specific params like ?result= must NOT
+    // bleed through — the URL should be exactly /wiki?page=<slug>.
+    await page.waitForURL(/\/wiki\?page=onboarding/);
+    expect(new URL(page.url()).search).toBe("?page=onboarding");
+    await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
+  });
+});

--- a/plans/feat-wiki-url-sync.md
+++ b/plans/feat-wiki-url-sync.md
@@ -1,0 +1,164 @@
+# feat: Sync Wiki navigation with the URL
+
+## Problem
+
+The Wiki already *reads* `?page=<slug>` from the URL (`src/plugins/wiki/View.vue:146-154`) and external wiki-link clicks already push it (`src/App.vue:757`), but **in-view** navigation does not update the URL:
+
+| Interaction | Location | Current behavior |
+|---|---|---|
+| Click a page card in the index list | `View.vue:70` → `navigatePage()` | Calls `callApi()` only; URL stays `/wiki` |
+| Click a `[[wiki-link]]` inside rendered markdown | `View.vue:250` → `navigatePage()` | Same — URL unchanged |
+| Click the **Index** / **Log** / **Lint** tab buttons | `View.vue:30/37/44` → `navigate()` | Same — URL unchanged |
+| Click **← back to Index** | `View.vue:6` → `navigate('index')` | Same — `?page=` stays in URL |
+
+Consequences:
+
+1. Reloading the page or copying the URL loses the current selection.
+2. Browser back/forward doesn't traverse wiki history.
+3. Most importantly: when the Wiki index is displayed **as the result of a `manageWiki` tool call** (i.e. `WikiView` mounted at `App.vue:105-110` inside the chat-page single layout), clicking a page card silently mutates local state without any URL change — there is no breadcrumb that the user navigated anywhere, and no way to deep-link back to what they saw.
+
+## Goal
+
+Make the URL the single source of truth for wiki navigation, following the same pattern `useFileSelection` uses for `/files?path=...`. Every in-view navigation — tab switch, index card click, wiki-link click, back button — should go through `router.push(...)` and let a single watcher drive the API call that refreshes state.
+
+Must work in **both** mount contexts of `WikiView`:
+
+- `App.vue:131` — standalone `/wiki` page.
+- `App.vue:105-110` — as the `manageWiki` tool-result viewer on `/chat/:sessionId`.
+
+## Non-goals
+
+- Redesigning the wiki API or tool definition.
+- Persisting the last-seen wiki page across sessions (URL sharing already gives that).
+- Changing how `[[wiki-link]]` rewriting works in markdown pre-processing.
+
+## Design
+
+### URL schema
+
+Extend what is already read today. One query param per dimension:
+
+| Param | Values | Meaning |
+|---|---|---|
+| `page` | any wiki slug | Show that page. Takes precedence over `view`. |
+| `view` | `log` \| `lint_report` | Show the corresponding action view. Absent = index. |
+
+Examples:
+
+- `/wiki` → index
+- `/wiki?page=anthropic` → page view for slug `anthropic`
+- `/wiki?view=log` → activity log
+- `/wiki?view=lint_report` → lint report
+
+No param = index. `page` wins over `view` if both are set (defensive; shouldn't happen in practice).
+
+### Single source of truth
+
+Today `navigate()` and `navigatePage()` both call `callApi()` directly. After this change, they push to the router and a single watcher drives `callApi()`:
+
+```ts
+// Replaces the existing route.query.page watcher.
+watch(
+  () => [route.query.page, route.query.view] as const,
+  ([page, view]) => {
+    if (typeof page === "string" && page.length > 0) {
+      callApi({ action: "page", pageName: page });
+    } else if (view === "log" || view === "lint_report") {
+      callApi({ action: view });
+    } else {
+      callApi({ action: "index" });
+    }
+  },
+  { immediate: true },
+);
+```
+
+`navigate()` / `navigatePage()` become pure URL-pushers:
+
+```ts
+function navigate(newAction: "index" | "log" | "lint_report") {
+  const query =
+    newAction === "index" ? dropKeys(route.query, ["page", "view"])
+    : { ...dropKeys(route.query, ["page"]), view: newAction };
+  pushWiki(query);
+}
+
+function navigatePage(pageName: string) {
+  pushWiki({ ...dropKeys(route.query, ["view"]), page: pageName });
+}
+```
+
+`pushWiki(query)` is the cross-context helper described next.
+
+### Cross-context navigation
+
+`WikiView` is mounted in two places, so `router.push` must behave differently:
+
+- On `/wiki` → update query params, stay on `/wiki`.
+- On `/chat/:sessionId` (tool-result viewer) → navigate to `/wiki` with the requested query. This moves the user from the chat single-layout into the dedicated wiki page, matching the existing behavior in `App.vue:749-758` for wiki-link clicks inside text responses.
+
+```ts
+function pushWiki(query: LocationQuery) {
+  const target = route.name === PAGE_ROUTES.wiki
+    ? { query }
+    : { name: PAGE_ROUTES.wiki, query };
+  router.push(target).catch(() => {});
+}
+```
+
+This keeps the tool-result variant's behavior consistent with App.vue's existing wiki-link handler and means: **clicking a page card in an index rendered as a tool result takes the user to `/wiki?page=<slug>`**, with a proper history entry and shareable URL.
+
+### Relationship to `props.selectedResult` and `useFreshPluginData`
+
+Currently three sources mutate the local `action`/`content` state:
+
+1. `callApi()` — from button clicks.
+2. The `props.selectedResult.uuid` watcher — when a new tool result is selected.
+3. `useFreshPluginData` — periodic refresh keyed off the current slug.
+
+After this change:
+
+- `callApi()` is only ever invoked by the route watcher. Button handlers push the URL and do nothing else.
+- The `props.selectedResult.uuid` watcher is **kept as-is** (it seeds initial state from the tool result payload when the view first mounts inside a chat page — we don't want to immediately refetch when the tool already returned the data).
+- `useFreshPluginData` is kept. Its endpoint function already keys off the current `action`/`pageName`, which are still updated by `callApi()`, so the behavior is unchanged.
+
+Edge case: when the tool result arrives (`selectedResult.uuid` changes) while the URL also has `?page=` set, both watchers will try to set state. Order the logic so the route watcher runs second and wins (trivial — Vue runs watchers in the order they're declared; keep the route watcher last). In practice they'll produce the same state, so this is belt-and-suspenders.
+
+## Implementation steps
+
+All changes are in `src/plugins/wiki/View.vue` unless noted.
+
+1. **Add router imports and helper.** Import `useRouter`, `PAGE_ROUTES`, and a small `dropKeys(obj, keys)` helper (inline — not worth a utility file for one call site).
+2. **Replace the two handlers.** Rewrite `navigate()` (line 201) and `navigatePage()` (line 205) to push router state via `pushWiki()` instead of calling `callApi()`.
+3. **Introduce a single route-driven watcher.** Replace the existing `route.query.page` watcher (line 146-154) with the combined `[page, view]` watcher shown in the Design section. Use `immediate: true` so mounting with `?page=foo` or `?view=log` already in the URL triggers the right fetch.
+4. **Keep `callApi()` private to the watcher.** No signature change, but no other code path should call it.
+5. **Audit `handleContentClick()`** (line 243). It already calls `navigatePage(link.dataset.page)` for `[[wiki-link]]` clicks — no change needed once `navigatePage()` switches to pushing the URL.
+6. **Remove the now-redundant `App.vue:756-758` handler?** No. Keep it — that path handles wiki links rendered in *text responses* (outside `WikiView`), which need to navigate into `/wiki` regardless. The logic is identical to `pushWiki()`, but consolidating would require moving it into a shared composable for marginal benefit; out of scope.
+
+## Test plan
+
+### E2E (Playwright — add to `e2e/tests/wiki-plugin.spec.ts`)
+
+- Click a page card in the index → URL becomes `/wiki?page=<slug>` and the page content renders.
+- Click the **Log** tab → URL becomes `/wiki?view=log`.
+- Click **Index** tab from a page → URL becomes `/wiki` (no query).
+- Click an in-content `[[wiki-link]]` → URL updates to `/wiki?page=<target>`.
+- Browser back button from a page view returns to the index with URL `/wiki`.
+- Direct visit to `/wiki?page=<slug>` loads that page without a visible "index → page" flicker.
+- **Tool-result context**: mount the wiki index as a `manageWiki` tool result on `/chat/:sessionId`, click a page card, assert the URL is now `/wiki?page=<slug>` and the full `/wiki` view is rendered.
+
+### Unit
+
+No new unit tests — the logic lives entirely in the Vue component and is covered by E2E.
+
+### Manual
+
+- Reload the page while on `/wiki?page=foo` — selection persists.
+- Copy URL, open in new tab — same page loads.
+- Use back/forward to traverse `index → page A → page B → log` — each step restores the expected state.
+
+## Out of scope / future work
+
+- Lifting the `pushWiki` logic into a shared composable when a third mount context appears. Two call sites (View + App.vue:756) isn't enough to justify it yet.
+- Encoding position within a page (scroll offset, section anchor) in the URL.
+- Browser title updates as the slug changes.

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -323,8 +323,7 @@ const enMessages = {
   },
   pluginWiki: {
     backToIndex: "Back to index",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF failed",
     tabIndex: "Index",
     tabLog: "Log",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -315,8 +315,7 @@ const jaMessages = {
   },
   pluginWiki: {
     backToIndex: "インデックスに戻る",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF 失敗",
     tabIndex: "インデックス",
     tabLog: "ログ",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
       <div class="flex items-center gap-3">
-        <button v-if="action !== 'index'" class="text-gray-400 hover:text-gray-700" :title="t('pluginWiki.backToIndex')" @click="navigate('index')">
+        <button v-if="action !== 'index'" class="text-gray-400 hover:text-gray-700" :title="t('pluginWiki.backToIndex')" @click="router.back()">
           <span class="material-icons text-base">arrow_back</span>
         </button>
         <h2 class="text-lg font-semibold text-gray-800">{{ title }}</h2>

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -72,6 +72,7 @@
         v-for="entry in pageEntries"
         :key="entry.slug"
         class="flex items-baseline gap-2 px-4 py-1 cursor-pointer hover:bg-blue-50 transition-colors"
+        :data-testid="`wiki-page-entry-${entry.slug || entry.title}`"
         @click="navigatePage(entry.slug || entry.title)"
       >
         <span class="font-medium text-sm text-gray-800 shrink-0">{{ entry.title }}</span>
@@ -249,13 +250,21 @@ function pushWiki(query: LocationQuery) {
   });
 }
 
+// Preserve siblings only when already on /wiki. Cross-route jumps
+// (e.g. from /chat, where the URL may carry `?result=<uuid>`) start
+// from a clean query so chat-specific params don't bleed into /wiki.
+function currentWikiQuery(): LocationQuery {
+  return route.name === PAGE_ROUTES.wiki ? route.query : {};
+}
+
 function navigate(newAction: "index" | WikiTabView) {
-  const query = newAction === "index" ? dropKeys(route.query, ["page", "view"]) : { ...dropKeys(route.query, ["page"]), view: newAction };
+  const base = currentWikiQuery();
+  const query = newAction === "index" ? dropKeys(base, ["page", "view"]) : { ...dropKeys(base, ["page"]), view: newAction };
   pushWiki(query);
 }
 
 function navigatePage(pageName: string) {
-  pushWiki({ ...dropKeys(route.query, ["view"]), page: pageName });
+  pushWiki({ ...dropKeys(currentWikiQuery(), ["view"]), page: pageName });
 }
 
 function handleContentClick(event: MouseEvent) {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -10,19 +10,13 @@
       </div>
       <div class="flex gap-1 items-center">
         <template v-if="action === 'page' && content">
-          <button
-            class="px-3 py-1 text-xs rounded-full border transition-colors border-gray-200 text-gray-500 hover:bg-gray-50 disabled:opacity-40 w-16 flex items-center justify-center gap-1"
-            :disabled="pdfDownloading"
-            @click="downloadPdf"
-          >
-            <svg v-if="pdfDownloading" class="animate-spin w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="none">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-            </svg>
-            <span v-else>{{ t("pluginWiki.downloadPdf") }}</span>
-            <span v-if="pdfDownloading">{{ t("pluginWiki.pdfLoadingLabel") }}</span>
-          </button>
-          <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
+          <div class="button-group">
+            <button class="download-btn download-btn-green" :disabled="pdfDownloading" @click="downloadPdf">
+              <span class="material-icons">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+              {{ t("pluginWiki.pdf") }}
+            </button>
+          </div>
+          <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
         </template>
         <button
           class="px-3 py-1 text-xs rounded-full border transition-colors"
@@ -90,12 +84,12 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
+import { usePdfDownload } from "../../composables/usePdfDownload";
 import { renderWikiLinks } from "./helpers";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
-import { apiPost, apiFetchRaw } from "../../utils/api";
+import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { PAGE_ROUTES } from "../../router";
-import { errorMessage } from "../../utils/errors";
 
 type WikiTabView = "log" | "lint_report";
 
@@ -178,8 +172,11 @@ const renderedContent = computed(() => {
 });
 
 const navError = ref<string | null>(null);
-const pdfDownloading = ref(false);
-const pdfError = ref<string | null>(null);
+const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
+
+async function downloadPdf() {
+  await rawDownloadPdf(content.value, `${title.value}.pdf`);
+}
 
 async function callApi(body: Record<string, unknown>) {
   navError.value = null;
@@ -236,40 +233,6 @@ function navigatePage(pageName: string) {
   pushWiki({ ...dropKeys(route.query, ["view"]), page: pageName });
 }
 
-async function downloadPdf() {
-  pdfError.value = null;
-  pdfDownloading.value = true;
-  let response: Response;
-  try {
-    response = await apiFetchRaw(API_ROUTES.pdf.markdown, {
-      method: "POST",
-      body: JSON.stringify({
-        markdown: content.value,
-        filename: `${title.value}.pdf`,
-      }),
-      headers: { "Content-Type": "application/json" },
-    });
-  } catch (err) {
-    pdfError.value = errorMessage(err);
-    pdfDownloading.value = false;
-    return;
-  }
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    pdfError.value = `PDF error ${response.status}: ${text}`;
-    pdfDownloading.value = false;
-    return;
-  }
-  const blob = await response.blob();
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = `${title.value}.pdf`;
-  anchor.click();
-  URL.revokeObjectURL(url);
-  pdfDownloading.value = false;
-}
-
 function handleContentClick(event: MouseEvent) {
   // 1. Internal wiki links: `[[Page Name]]` was rewritten to a
   //    `<span class="wiki-link">` during markdown pre-processing,
@@ -289,6 +252,31 @@ function handleContentClick(event: MouseEvent) {
 </script>
 
 <style scoped>
+.button-group {
+  display: flex;
+  gap: 0.5em;
+}
+.download-btn {
+  padding: 0.5em 1em;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.download-btn-green {
+  background-color: #4caf50;
+}
+.download-btn .material-icons {
+  font-size: 1.2em;
+}
+.download-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 .wiki-content :deep(.wiki-link) {
   color: #2563eb;
   cursor: pointer;

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -83,7 +83,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter, isNavigationFailure, type LocationQuery } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -94,9 +94,13 @@ import { renderWikiLinks } from "./helpers";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { apiPost, apiFetchRaw } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { PAGE_ROUTES } from "../../router";
 import { errorMessage } from "../../utils/errors";
 
+type WikiTabView = "log" | "lint_report";
+
 const route = useRoute();
+const router = useRouter();
 const { t } = useI18n();
 
 const props = defineProps<{
@@ -140,14 +144,22 @@ watch(
   },
 );
 
-// Deep-link support: when navigated via ?page=slug (e.g. clicking a
-// wiki link in a text-response), load the page. immediate: true
-// handles mount with ?page= already set in the URL.
+// URL is the single source of truth for wiki navigation. Button
+// handlers push to the router; this watcher drives callApi(). Only
+// runs when WikiView is mounted as the /wiki page — when mounted as
+// a manageWiki tool-result inside /chat, the tool-result watcher
+// above seeds state and this watcher does nothing.
 watch(
-  () => route.query.page,
-  (newPage: string | null | (string | null)[]) => {
-    if (typeof newPage === "string" && newPage.length > 0) {
-      navigatePage(newPage);
+  () => (route.name === PAGE_ROUTES.wiki ? [route.query.page, route.query.view] : null),
+  (params) => {
+    if (!params) return;
+    const [page, view] = params;
+    if (typeof page === "string" && page.length > 0) {
+      callApi({ action: "page", pageName: page });
+    } else if (view === "log" || view === "lint_report") {
+      callApi({ action: view });
+    } else {
+      callApi({ action: "index" });
     }
   },
   { immediate: true },
@@ -198,12 +210,30 @@ async function callApi(body: Record<string, unknown>) {
   }
 }
 
-function navigate(newAction: string) {
-  callApi({ action: newAction });
+function dropKeys(query: LocationQuery, keys: string[]): LocationQuery {
+  const next: LocationQuery = {};
+  for (const [key, value] of Object.entries(query)) {
+    if (!keys.includes(key)) next[key] = value;
+  }
+  return next;
+}
+
+function pushWiki(query: LocationQuery) {
+  const target = route.name === PAGE_ROUTES.wiki ? { query } : { name: PAGE_ROUTES.wiki, query };
+  router.push(target).catch((err: unknown) => {
+    if (!isNavigationFailure(err)) {
+      console.error("[wiki] navigation failed:", err);
+    }
+  });
+}
+
+function navigate(newAction: "index" | WikiTabView) {
+  const query = newAction === "index" ? dropKeys(route.query, ["page", "view"]) : { ...dropKeys(route.query, ["page"]), view: newAction };
+  pushWiki(query);
 }
 
 function navigatePage(pageName: string) {
-  callApi({ action: "page", pageName });
+  pushWiki({ ...dropKeys(route.query, ["view"]), page: pageName });
 }
 
 async function downloadPdf() {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter, isNavigationFailure, type LocationQuery } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { marked } from "marked";
@@ -119,7 +119,7 @@ const title = ref(props.selectedResult?.data?.title ?? "Wiki");
 const content = ref(props.selectedResult?.data?.content ?? "");
 const pageEntries = ref<WikiPageEntry[]>(props.selectedResult?.data?.pageEntries ?? []);
 
-const { refresh } = useFreshPluginData<WikiData>({
+const { refresh, abort: abortFreshFetch } = useFreshPluginData<WikiData>({
   // Slug-aware: when the view is currently showing a specific page,
   // fetch that page by slug; otherwise fetch the index.
   endpoint: () => {
@@ -133,6 +133,15 @@ const { refresh } = useFreshPluginData<WikiData>({
     content.value = data.content ?? "";
     pageEntries.value = data.pageEntries ?? [];
   },
+});
+
+onMounted(() => {
+  // On /wiki, the route watcher below fires with `immediate: true` and
+  // is the source of truth for the initial fetch (via POST callApi).
+  // useFreshPluginData's mount fetch is GET-only and always returns
+  // the index payload — if it resolves last, it clobbers log / lint /
+  // page state. Cancel it here so the two can't race.
+  if (route.name === PAGE_ROUTES.wiki) abortFreshFetch();
 });
 
 watch(

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -18,27 +18,38 @@
           </div>
           <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
         </template>
-        <button
-          class="px-3 py-1 text-xs rounded-full border transition-colors"
-          :class="action === 'index' ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-500 hover:bg-gray-50'"
-          @click="navigate('index')"
-        >
-          {{ t("pluginWiki.tabIndex") }}
-        </button>
-        <button
-          class="px-3 py-1 text-xs rounded-full border transition-colors"
-          :class="action === 'log' ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-500 hover:bg-gray-50'"
-          @click="navigate('log')"
-        >
-          {{ t("pluginWiki.tabLog") }}
-        </button>
-        <button
-          class="px-3 py-1 text-xs rounded-full border transition-colors"
-          :class="action === 'lint_report' ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-500 hover:bg-gray-50'"
-          @click="navigate('lint_report')"
-        >
-          {{ t("pluginWiki.tabLint") }}
-        </button>
+        <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
+          <button
+            :class="[
+              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              action === 'index' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+            ]"
+            @click="navigate('index')"
+          >
+            <span class="material-icons text-sm">list</span>
+            <span>{{ t("pluginWiki.tabIndex") }}</span>
+          </button>
+          <button
+            :class="[
+              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              action === 'log' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+            ]"
+            @click="navigate('log')"
+          >
+            <span class="material-icons text-sm">history</span>
+            <span>{{ t("pluginWiki.tabLog") }}</span>
+          </button>
+          <button
+            :class="[
+              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              action === 'lint_report' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+            ]"
+            @click="navigate('lint_report')"
+          >
+            <span class="material-icons text-sm">rule</span>
+            <span>{{ t("pluginWiki.tabLint") }}</span>
+          </button>
+        </div>
       </div>
     </div>
 

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -118,6 +118,12 @@ const action = ref(props.selectedResult?.data?.action ?? "index");
 const title = ref(props.selectedResult?.data?.title ?? "Wiki");
 const content = ref(props.selectedResult?.data?.content ?? "");
 const pageEntries = ref<WikiPageEntry[]>(props.selectedResult?.data?.pageEntries ?? []);
+// Declared up here — not next to callApi — because the URL watcher
+// below fires with `immediate: true`, which invokes callApi
+// synchronously during setup. If this ref were declared after the
+// watcher, callApi's `navError.value = null` would hit the TDZ on
+// direct loads of /wiki and the fetch would never run.
+const navError = ref<string | null>(null);
 
 const { refresh, abort: abortFreshFetch } = useFreshPluginData<WikiData>({
   // Slug-aware: when the view is currently showing a specific page,
@@ -191,7 +197,6 @@ const renderedContent = computed(() => {
   return marked.parse(renderWikiLinks(withImages)) as string;
 });
 
-const navError = ref<string | null>(null);
 const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
 
 async function downloadPdf() {


### PR DESCRIPTION
## Summary

- Make the URL the single source of truth for wiki navigation so page cards, `[[wiki-link]]` clicks, and Index/Log/Lint tabs all produce shareable, bookmarkable URLs (`/wiki?page=<slug>` / `/wiki?view=log|lint_report`). Works whether WikiView is rendered as the `/wiki` page or as a `manageWiki` tool-result on `/chat`.
- Replace the in-view `← back to Index` arrow with `router.back()` so it matches the icon semantic and gracefully returns to either the index or the previous `/chat` session.
- Reuse the shared `usePdfDownload` composable and the `download-btn / download-btn-green` markup so the wiki PDF button matches the textResponse/markdown views pixel-for-pixel.
- Re-style Index / Log / Lint as a segmented selector matching the top-bar `PluginLauncher` (single bordered container, material-icons, `bg-blue-50` active state).

## Plan

`plans/feat-wiki-url-sync.md` — design notes covering the URL schema, the single route-driven watcher, cross-context navigation, and test plan.

## Test plan

- [ ] On `/wiki`: click a page card → URL becomes `/wiki?page=<slug>`; click Log/Lint tabs → URL becomes `/wiki?view=log|lint_report`; arrow_back returns to `/wiki`.
- [ ] Direct visit to `/wiki?page=<slug>` loads the page without flicker.
- [ ] Browser back/forward traverses wiki history correctly.
- [ ] From `/chat/:sessionId` with a `manageWiki` tool-result showing the index, clicking a page card navigates to `/wiki?page=<slug>` (shareable URL); browser back returns to `/chat/:sessionId`.
- [ ] Click `[[wiki-link]]` inside rendered markdown → updates URL and loads page.
- [ ] PDF download button shows green pill with `download` → `hourglass_empty` icon swap while downloading; errors surface as red `⚠ PDF failed` span.
- [ ] Index/Log/Lint selector visually matches `PluginLauncher` at the top of the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wiki navigation UI redesigned with segmented controls for improved usability.
  * Added dedicated PDF download button in wiki page views.

* **Improvements**
  * Enhanced browser history and back-button navigation behavior.
  * Wiki pages now support shareable deep links for easier collaboration.
  * Consolidated PDF-related UI messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->