### PR TITLE
feat(i18n): auto-detect locale from browser language

### DIFF
--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -1,9 +1,17 @@
 // vue-i18n setup.
 //
-// Locale is picked at build-time from the `VITE_LOCALE` env var
-// (falls back to "en"). Use `VITE_LOCALE=ja yarn dev` to switch.
-// There's no runtime locale selector yet — follow-up work will add
-// one if needed.
+// Locale resolution priority (highest → lowest):
+//   1. `VITE_LOCALE` env var — explicit build-time / dev override
+//      (e.g. `VITE_LOCALE=ja yarn dev`)
+//   2. Browser language list (`navigator.languages` falling back to
+//      `navigator.language`) — the browser inherits this from the OS,
+//      so Japanese-machine users get Japanese automatically without
+//      extra config. First entry that matches a supported locale wins.
+//   3. Hard default `"en"`
+//
+// Language tags like `"ja-JP"` are matched by primary subtag, so
+// `ja-JP`, `ja-Hira-JP`, etc. all collapse to `"ja"`. Unknown tags
+// (`"fr-FR"`) skip to the next candidate.
 //
 // `legacy: false` switches vue-i18n to the Composition API mode, so
 // components call `const { t } = useI18n()` instead of relying on
@@ -21,7 +29,42 @@ import jaMessages from "../lang/ja";
 type MessageSchema = typeof enMessages;
 type Locale = "en" | "ja";
 
-const locale = (import.meta.env.VITE_LOCALE ?? "en") as Locale;
+const SUPPORTED_LOCALES: readonly Locale[] = ["en", "ja"] as const;
+const DEFAULT_LOCALE: Locale = "en";
+
+function isSupported(tag: string): tag is Locale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(tag);
+}
+
+// Collapse `ja-JP`, `ja-Hira-JP`, etc. to `ja`. Returns null when the
+// primary subtag isn't one we support.
+function primarySubtagIfSupported(tag: string): Locale | null {
+  const primary = tag.toLowerCase().split("-")[0];
+  return isSupported(primary) ? primary : null;
+}
+
+function detectLocale(): Locale {
+  // 1. explicit env override
+  const envLocale = import.meta.env.VITE_LOCALE;
+  if (typeof envLocale === "string" && isSupported(envLocale)) {
+    return envLocale;
+  }
+
+  // 2. browser / OS preference list
+  if (typeof navigator !== "undefined") {
+    const preferred = navigator.languages && navigator.languages.length > 0 ? navigator.languages : [navigator.language];
+    for (const tag of preferred) {
+      if (typeof tag !== "string") continue;
+      const match = primarySubtagIfSupported(tag);
+      if (match) return match;
+    }
+  }
+
+  // 3. hard default
+  return DEFAULT_LOCALE;
+}
+
+const locale = detectLocale();
 
 const i18n = createI18n<[MessageSchema], Locale>({
   legacy: false,


### PR DESCRIPTION
## Summary
- Add automatic locale detection from `navigator.languages` / `navigator.language` when `VITE_LOCALE` is unset.
- Priority is **VITE_LOCALE → browser language → hard default \"en\"**.
- Japanese-machine users now get the Japanese UI without any extra setup.

## Why not env → browser → OS (3 tiers)?
In a web app, the OS language is only visible to JavaScript via `navigator.language` — the browser inherits it from the OS by default, so the two collapse into one signal. If MulmoClaude ever ships an Electron/Tauri shell, we can expose an OS-native API that takes priority over `navigator.*`, but for the browser path there's no separate signal to consult.

## Behavior
| Scenario | Resolved locale |
|---|---|
| `VITE_LOCALE=ja yarn dev` | `ja` |
| `VITE_LOCALE=en yarn dev` | `en` |
| `VITE_LOCALE` unset, browser in Japanese (`ja-JP`) | `ja` |
| `VITE_LOCALE` unset, browser in English (`en-US`) | `en` |
| `VITE_LOCALE` unset, browser in French (`fr-FR`) | `en` (hard default — unsupported tags fall through) |
| `VITE_LOCALE=fr` (unsupported) | `en` (validated against SUPPORTED_LOCALES) |

Tag matching collapses by primary subtag, so `ja-JP` / `ja-Hira-JP` / `ja` all map to `ja`.

## User Prompt
> いま VITE_LOCALE で言語切り替えしているけどコンピュータやブラウザの言語みて切り替えすることもできる？VITE_LOCALE 指定、ブラウザの言語、コンピュータの言語の順で。

## Test plan
- [x] `yarn typecheck:vue` — clean
- [x] `yarn lint` — 0 errors
- [ ] Manual:
  - [ ] Browser in Japanese, unset VITE_LOCALE → Japanese UI
  - [ ] Browser in English, unset VITE_LOCALE → English UI
  - [ ] `VITE_LOCALE=ja` + English browser → Japanese UI (env wins)
  - [ ] `VITE_LOCALE=en` + Japanese browser → English UI (env wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language detection: The app now automatically detects and applies your browser's language preference at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->