### PR TITLE
chore(server): sweep missed server/utils helper usage

### DIFF
--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -9,6 +9,8 @@ import { saveUserTasks } from "../../utils/files/user-tasks-io.js";
 import { startChat } from "./agent.js";
 import { log } from "../../system/logger/index.js";
 import { SCHEDULER_ACTIONS, TASK_ACTIONS } from "../../../src/config/schedulerActions.js";
+import { badRequest, notFound, serverError } from "../../utils/httpError.js";
+import { errorMessage } from "../../utils/errors.js";
 
 const router = Router();
 
@@ -77,7 +79,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
     if (action === SCHEDULER_ACTIONS.createTask) {
       const result = validateAndCreate(input);
       if (result.kind === "error") {
-        res.status(400).json({ error: result.error });
+        badRequest(res, result.error);
         return;
       }
       const tasks = loadUserTasks();
@@ -97,7 +99,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       const tasks = loadUserTasks();
       const idx = tasks.findIndex((task) => task.id === taskId);
       if (idx === -1) {
-        res.status(404).json({ error: `task not found: ${taskId}` });
+        notFound(res, `task not found: ${taskId}`);
         return;
       }
       const name = tasks[idx].name;
@@ -117,7 +119,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       const tasks = loadUserTasks();
       const task = tasks.find((candidate) => candidate.id === taskId);
       if (!task) {
-        res.status(404).json({ error: `task not found: ${taskId}` });
+        notFound(res, `task not found: ${taskId}`);
         return;
       }
       const chatSessionId = crypto.randomUUID();
@@ -143,10 +145,10 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       return;
     }
 
-    res.status(400).json({ error: `unknown task action: ${action}` });
+    badRequest(res, `unknown task action: ${action}`);
   } catch (err) {
-    log.error("scheduler", "task action failed", { error: String(err) });
-    res.status(500).json({ error: "Internal server error" });
+    log.error("scheduler", "task action failed", { error: errorMessage(err) });
+    serverError(res, "Internal server error");
   }
 }
 

--- a/server/api/routes/sources.ts
+++ b/server/api/routes/sources.ts
@@ -312,7 +312,7 @@ async function handleRegister(body: ManageSourceBody, res: Response<ManageSource
 async function handleRemove(body: ManageSourceBody, res: Response<ManageSourceSuccess | ErrorResponse>): Promise<void> {
   const slug = typeof body.slug === "string" ? body.slug.trim() : "";
   if (!isValidSlug(slug)) {
-    res.status(400).json({ error: "slug is required and must be a valid slug" });
+    badRequest(res, "slug is required and must be a valid slug");
     return;
   }
   const removed = await deleteSource(workspacePath, slug);

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -12,6 +12,7 @@
 import WebSocket from "ws";
 import type { ChatService } from "@mulmobridge/chat-service";
 import { ONE_SECOND_MS } from "../utils/time.js";
+import { errorMessage } from "../utils/errors.js";
 
 type RelayFn = ChatService["relay"];
 
@@ -106,7 +107,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       socket = new WebSocket(buildUrl());
     } catch (err) {
       logger.error(LOG_PREFIX, "failed to create WebSocket", {
-        error: err instanceof Error ? err.message : String(err),
+        error: errorMessage(err),
       });
       scheduleReconnect();
       return;
@@ -204,7 +205,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
     } catch (err) {
       logger.error(LOG_PREFIX, "relay processing failed", {
         id: msg.id,
-        error: err instanceof Error ? err.message : String(err),
+        error: errorMessage(err),
       });
       sendResponse({
         platform: msg.platform,

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,6 +53,7 @@ import { requireSameOrigin } from "./api/csrfGuard.js";
 import { bearerAuth } from "./api/auth/bearerAuth.js";
 import { deleteTokenFile, generateAndWriteToken, getCurrentToken } from "./api/auth/token.js";
 import { log } from "./system/logger/index.js";
+import { logBackgroundError } from "./utils/logBackgroundError.js";
 import { startChat } from "./api/routes/agent.js";
 import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
 import { registerUserTasks } from "./workspace/skills/user-tasks.js";
@@ -329,9 +330,7 @@ function maybeForceJournalRun(): void {
   // propagate out of maybeRunJournal.
   if (!env.journalForceRunOnStartup) return;
   log.info("journal", "JOURNAL_FORCE_RUN_ON_STARTUP=1 — running now");
-  maybeRunJournal({ force: true }).catch((err) => {
-    log.warn("journal", "forced startup run failed", { error: String(err) });
-  });
+  maybeRunJournal({ force: true }).catch(logBackgroundError("journal", "forced startup run failed"));
 }
 
 function maybeForceChatIndexBackfill(): void {
@@ -349,11 +348,7 @@ function maybeForceChatIndexBackfill(): void {
         skipped: result.skipped,
       });
     })
-    .catch((err) => {
-      log.warn("chat-index", "forced startup backfill failed", {
-        error: String(err),
-      });
-    });
+    .catch(logBackgroundError("chat-index", "forced startup backfill failed"));
 }
 
 function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
@@ -464,11 +459,7 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
         log.info("skills", "scheduled skills registered", { count });
       }
     })
-    .catch((err) => {
-      log.warn("skills", "failed to register scheduled skills", {
-        error: String(err),
-      });
-    });
+    .catch(logBackgroundError("skills", "failed to register scheduled skills"));
 
   // Register user-created scheduled tasks from tasks.json.
   registerUserTasks({ taskManager, startChat })
@@ -477,11 +468,7 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
         log.info("user-tasks", "user tasks registered", { count });
       }
     })
-    .catch((err) => {
-      log.warn("user-tasks", "failed to register user tasks", {
-        error: String(err),
-      });
-    });
+    .catch(logBackgroundError("user-tasks", "failed to register user tasks"));
 
   taskManager.start();
 

--- a/server/utils/logBackgroundError.ts
+++ b/server/utils/logBackgroundError.ts
@@ -1,4 +1,5 @@
 import { log } from "../system/logger/index.js";
+import { errorMessage } from "./errors.js";
 
 /**
  * Build a `.catch` handler for a fire-and-forget background job that
@@ -8,15 +9,23 @@ import { log } from "../system/logger/index.js";
  *
  * Usage:
  *
+ *   // Default message — good for generic background scans.
  *   maybeRunJournal({ ... }).catch(logBackgroundError("journal"));
+ *
+ *   // Custom message — pass context when the failure mode is
+ *   // worth surfacing distinctly (e.g. "failed to register
+ *   // scheduled skills" vs other `skills` warnings).
+ *   registerScheduledSkills(...).catch(
+ *     logBackgroundError("skills", "failed to register scheduled skills"),
+ *   );
  *
  * The handler never rethrows — the caller's promise chain is
  * terminated cleanly so nothing propagates into the request path.
  */
-export function logBackgroundError(prefix: string): (err: unknown) => void {
+export function logBackgroundError(prefix: string, message = "unexpected error in background"): (err: unknown) => void {
   return (err) => {
-    log.warn(prefix, "unexpected error in background", {
-      error: String(err),
+    log.warn(prefix, message, {
+      error: errorMessage(err),
     });
   };
 }


### PR DESCRIPTION
## Summary

Audit of \`server/\` (excluding \`server/utils/\`) for places that reimplement logic already in a helper. Three patterns, small scope, no behaviour change.

### 1. \`res.status(N).json({ error: ... })\` → \`httpError\` helpers
\`scheduler.ts\` (5 sites) and \`sources.ts\` (1 site, file was already importing \`badRequest\` for other branches). Canonical \`{ error: string }\` shape on both sides — drop-in replacement.

### 2. \`err instanceof Error ? err.message : String(err)\` → \`errorMessage()\`
\`relay-client.ts\` × 2. \`server/utils/errors.ts\` exists specifically for this pattern.

### 3. \`.catch((err) => log.warn(..., error: String(err)))\` → \`logBackgroundError()\`
\`server/index.ts\` × 4 (fire-and-forget startup tasks). Each carries a specific failure message ("forced startup run failed", "failed to register user tasks", …) — the current helper hard-codes \`"unexpected error in background"\`, which would have swallowed that context.

**Enhanced \`logBackgroundError\`** to take an optional message (default preserves today's wording, so the ~8 existing single-arg callers in \`agent.ts\` / \`skills.ts\` stay untouched). Also made the helper use \`errorMessage()\` internally — meta-dogfood.

## Items to Confirm / Review

- **\`html.ts\` / \`image.ts\` left alone**: they return \`{ success: false, message: "…" }\`, not the canonical \`{ error }\`. Unifying them is a client-visible contract change, worth a separate PR with its own scope.
- **\`index.ts:448\` left alone**: uses \`log.error\` (not \`warn\`) for scheduler init failure. \`logBackgroundError\` is \`warn\`-only — forcing a level change would silently weaken the alert.
- **\`prompt.ts:55\` false positive**: a literal \`3600000\` flagged by the audit is inside a JSON code block in the system prompt (documentation of \`overrides.json\`), not a runtime duration.

## Test plan

- [x] \`yarn typecheck:server\` green
- [x] \`yarn lint\` on modified files clean
- [x] \`test/utils/test_logBackgroundError.ts\` passes unchanged (backward-compatible signature)
- [ ] Manual: send a POST to \`/api/scheduler\` with unknown task action → expect \`{ error: "unknown task action: …" }\` 400 (same shape as before, just routed through \`badRequest\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)