### PR TITLE
fix(server): walk forward when PORT is busy in dev, unify with npm launcher

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -9,9 +9,13 @@ import { execSync, spawn } from "child_process";
 import { existsSync } from "fs";
 import { get as httpGet } from "http";
 import { createRequire } from "module";
-import net from "net";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+
+// Shared with `server/index.ts` — the launcher and the dev server use
+// the same probe + fallback logic. See server/utils/port.mjs for why
+// it's plain JS rather than TypeScript.
+import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "../server/utils/port.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -43,27 +47,6 @@ function pickOpenCommand() {
   if (process.platform === "darwin") return "open";
   if (process.platform === "win32") return "start";
   return "xdg-open";
-}
-
-function isPortFree(portNum) {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close(() => resolve(true));
-    });
-    server.listen(portNum, "127.0.0.1");
-  });
-}
-
-// Walk forward from `start` to find a free port. `MAX_PORT_PROBES` caps
-// the scan so an accidentally-saturated system doesn't spin forever.
-const MAX_PORT_PROBES = 20;
-async function findFreePort(start) {
-  for (let candidate = start; candidate < start + MAX_PORT_PROBES; candidate++) {
-    if (await isPortFree(candidate)) return candidate;
-  }
-  return null;
 }
 
 // Poll the server until it answers an HTTP request, then call `onReady`.
@@ -178,7 +161,7 @@ async function chooseAvailablePort(requested, explicit) {
     error(`Port ${requested} is already in use. Stop the other process or pick a different --port.`);
     process.exit(1);
   }
-  const fallback = await findFreePort(requested + 1);
+  const fallback = await findAvailablePort(requested + 1);
   if (fallback === null) {
     error(`Port ${requested} is in use and no free port found in ${requested}..${requested + MAX_PORT_PROBES - 1}.`);
     process.exit(1);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import express, { Request, Response, NextFunction } from "express";
-import net from "net";
 import path from "path";
 import { fileURLToPath } from "url";
 import agentRoutes from "./api/routes/agent.js";
@@ -60,6 +59,7 @@ import { API_ROUTES } from "../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../src/types/events.js";
 import { SESSION_ORIGINS } from "../src/types/session.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
+import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "./utils/port.mjs";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 
 const HTML_TOKEN_PLACEHOLDER = "__MULMOCLAUDE_AUTH_TOKEN__";
@@ -74,7 +74,6 @@ initWorkspace();
 let sandboxEnabled = false;
 
 const app = express();
-const PORT = env.port;
 
 app.disable("x-powered-by");
 // No `cors()` middleware. The Vite dev proxy forwards `/api/*`
@@ -255,18 +254,30 @@ app.use((err: Error, _req: Request, res: Response, __next: NextFunction) => {
   serverError(res, "Internal Server Error");
 });
 
-function isPortFree(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close(() => resolve(true));
-    });
-    // Probe the same interface we'll actually bind to so a port
-    // held by a different process on a different interface doesn't
-    // give us a false "free" reading.
-    server.listen(port, "127.0.0.1");
-  });
+// True iff the user set `PORT` explicitly; empty string counts as "not
+// set". We use this to decide between "walk forward when busy" (friendly
+// dev behaviour) and "fail loudly" (respect the user's choice).
+const portExplicit = typeof process.env.PORT === "string" && process.env.PORT.trim() !== "";
+
+// Resolve the port we'll actually bind to. Default PORT (3001) + busy
+// walks forward so a stale `yarn dev` or a parallel test run doesn't
+// crash the launch. Explicit PORT + busy exits — matches the launcher's
+// `--port` semantics so `PORT=3099 yarn dev` behaves the same as
+// `npx mulmoclaude --port 3099`.
+async function resolvePort(): Promise<number> {
+  const requested = env.port;
+  if (await isPortFree(requested)) return requested;
+  if (portExplicit) {
+    log.error("server", `Port ${requested} is already in use. Stop the other process or pick a different PORT.`);
+    process.exit(1);
+  }
+  const fallback = await findAvailablePort(requested + 1);
+  if (fallback === null) {
+    log.error("server", `Port ${requested} is in use and no free port found in ${requested}..${requested + MAX_PORT_PROBES - 1}.`);
+    process.exit(1);
+  }
+  log.info("server", `Port ${requested} busy → using ${fallback} instead`);
+  return fallback;
 }
 
 async function ensureCredentialsAvailable(): Promise<void> {
@@ -356,8 +367,8 @@ function maybeForceChatIndexBackfill(): void {
     });
 }
 
-function startRuntimeServices(httpServer: ReturnType<typeof app.listen>): void {
-  log.info("server", "listening", { port: PORT });
+function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: number): void {
+  log.info("server", "listening", { port });
 
   // --- Pub/Sub ---
   const pubsub = createPubSub(httpServer);
@@ -510,11 +521,7 @@ process.on("SIGTERM", () => {
 });
 
 (async () => {
-  const portFree = await isPortFree(PORT);
-  if (!portFree) {
-    log.error("server", `Port ${PORT} is already in use. Stop the other process and try again.`);
-    process.exit(1);
-  }
+  const port = await resolvePort();
 
   // Generate the bearer token before `app.listen` so the first
   // request cannot race an uninitialised `getCurrentToken()`. The
@@ -535,8 +542,8 @@ process.on("SIGTERM", () => {
   // `http://<laptop-ip>:3001/api/*`), which combined with the
   // workspace file API is a credential-theft risk. Personal dev
   // tool — localhost is the right default.
-  const httpServer = app.listen(PORT, "127.0.0.1", () => {
-    startRuntimeServices(httpServer);
+  const httpServer = app.listen(port, "127.0.0.1", () => {
+    startRuntimeServices(httpServer, port);
   });
 })();
 

--- a/server/utils/port.d.mts
+++ b/server/utils/port.d.mts
@@ -1,0 +1,6 @@
+// Type declarations for port.mjs. See port.mjs for rationale on why
+// the shared helper lives in plain JS.
+
+export const MAX_PORT_PROBES: number;
+export function isPortFree(port: number): Promise<boolean>;
+export function findAvailablePort(start: number): Promise<number | null>;

--- a/server/utils/port.mjs
+++ b/server/utils/port.mjs
@@ -1,0 +1,49 @@
+// Shared port-resolution helpers for the dev server and the npm
+// launcher (`packages/mulmoclaude/bin/mulmoclaude.js`).
+//
+// Kept as plain `.mjs` (no TypeScript) because the launcher runs
+// directly under Node — it boots BEFORE tsx is wired up, so it can't
+// import from a `.ts` file. The server-side TypeScript imports this
+// through Node's ESM resolution; `moduleResolution: "bundler"` + the
+// sibling `port.d.mts` declarations give us the type coverage without
+// turning the whole `server/` tree into mixed JS/TS.
+
+import net from "node:net";
+
+// Scan cap: 20 slots is enough to step around the occasional stale
+// server on `localhost` without spinning forever on a pathologically
+// saturated machine.
+export const MAX_PORT_PROBES = 20;
+
+/**
+ * Returns true iff binding `127.0.0.1:port` would succeed right now.
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+export function isPortFree(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    // Probe the same interface we'll actually bind to so a port
+    // held by a different process on a different interface doesn't
+    // give us a false "free" reading.
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/**
+ * Walk forward from `start` until we find a free port. Returns `null`
+ * if every slot in `[start, start + MAX_PORT_PROBES)` is busy.
+ * @param {number} start
+ * @returns {Promise<number | null>}
+ */
+export async function findAvailablePort(start) {
+  for (let candidate = start; candidate < start + MAX_PORT_PROBES; candidate++) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await isPortFree(candidate)) return candidate;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Dev (`yarn dev`) の Express が既に 3001 で動いていると即死する問題を修正。npm 版 (`npx mulmoclaude`) と同じフォールバック挙動に揃える。
- 同じ `isPortFree` が launcher (JS) と server (TS) に重複していたのを単一の `.mjs` モジュールに統合。

## Items to Confirm / Review

- **Shared module の置き場所 (`server/utils/port.mjs`)**: launcher は tsx 起動前の pre-bootstrap なので TypeScript を import できず、`.mjs` (plain JS ESM) にしました。TypeScript 側は sibling `port.d.mts` で型を受け取る形。他の server util は `.ts` ですが、JS/TS 境界を跨ぐ要件があるのはこれだけなので例外扱いしています。
- **Explicit vs default PORT の分岐**: `process.env.PORT` が set されていれば「ユーザーの明示的な選択」と見なして busy 時にエラー終了、default なら walk forward。`PORT=3099 yarn dev` が `npx mulmoclaude --port 3099` と同じ semantics になります。`.env` から PORT を読んで起動するケースは明示扱いになる点、違和感が無いかご確認ください。

## User Prompt

> npm配布版では解決したけど、dev版では express の port が重複すると起動しない。コード共通化して直せる？

## Implementation

### 新規 (2 ファイル)
- `server/utils/port.mjs` — plain JS ESM。`isPortFree`, `findAvailablePort`, `MAX_PORT_PROBES` を export。
- `server/utils/port.d.mts` — TypeScript 側への型宣言。

### 変更 (2 ファイル)
- `server/index.ts`:
  - ローカルの `isPortFree` を削除、共通モジュールから import
  - `const PORT = env.port` を削除、起動時に `resolvePort()` で動的解決
  - `startRuntimeServices(httpServer, port)` に port 引数を追加
  - Default PORT + busy → `findAvailablePort(PORT+1)` で walk forward
  - Explicit PORT + busy → 従来通り exit
- `packages/mulmoclaude/bin/mulmoclaude.js`:
  - 重複していた `isPortFree` / `findFreePort` / `MAX_PORT_PROBES` を削除
  - `../server/utils/port.mjs` から import (publish 時は `prepare-dist.js` が server/ を複製するのでパスが通る)

## Verification

- ` yarn typecheck` / `yarn lint` (0 errors) / `yarn build` 通過
- `yarn test` — 2,655 tests pass, 0 fail
- `node packages/mulmoclaude/bin/prepare-dist.js` 後、`packages/mulmoclaude/server/utils/port.{mjs,d.mts}` が複製されているのを確認
- dynamic import で shared module を両方のパスから実行して挙動確認:
  - `isPortFree(3001)` → `false` (既存 dev 走ってる)
  - `findAvailablePort(3001)` → `3002`

🤖 Generated with [Claude Code](https://claude.com/claude-code)