### PR TITLE
fix(i18n): align pluginWiki.pdf across locales to unbreak typecheck CI

### DIFF
--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -316,8 +316,7 @@ const esMessages = {
   },
   pluginWiki: {
     backToIndex: "Volver al índice",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ Error de PDF",
     tabIndex: "Índice",
     tabLog: "Registro",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -315,8 +315,7 @@ const koMessages = {
   },
   pluginWiki: {
     backToIndex: "목차로 돌아가기",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF 실패",
     tabIndex: "목차",
     tabLog: "로그",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -313,8 +313,7 @@ const zhMessages = {
   },
   pluginWiki: {
     backToIndex: "返回目录",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF 失败",
     tabIndex: "目录",
     tabLog: "日志",


### PR DESCRIPTION
## Summary

main が typecheck CI で壊れていたのを修正 ([failed run](https://github.com/receptron/mulmoclaude/actions/runs/24798449563/job/72574375098)).

## Root cause

マージ順の事故:
- **914279b** (\`refactor(wiki): match PDF download button with TextResponse view\`): en.ts / ja.ts の \`pluginWiki.downloadPdf\` + \`pluginWiki.pdfLoadingLabel\` を 1 つの \`pluginWiki.pdf\` にリファクタ。
- **6cdc42e** (\`feat(i18n): add Simplified Chinese, Korean, and Spanish translations\`): 旧 schema (\`downloadPdf\` / \`pdfLoadingLabel\`) で es.ts / ko.ts / zh.ts を追加。

main に両方がマージされた結果、locale union の型が合わず vue-tsc が TS2719 (\`Property 'pdf' is missing...\`) を投げて落ちていました。

## Fix

es.ts / ko.ts / zh.ts の \`pluginWiki\` を en.ts / ja.ts と同じ shape に揃え:
- \`downloadPdf\` / \`pdfLoadingLabel\` の 2 キーを削除
- \`pdf\` キー 1 つに統合 (\`src/plugins/wiki/View.vue\` はこの 1 キーしか参照していない)

## Verification

- \`yarn typecheck\` 通過
- \`yarn lint\` 0 errors
- \`yarn build\` 通過
- \`yarn format\` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)