### PR TITLE
feat(ui): favicon uses the MulmoClaude mascot logo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -338,7 +338,10 @@ const { selectedResultUuid } = useSelectedResult({
 });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
-useFaviconState({ isRunning, currentSummary, activeSession });
+// `unreadCount` covers every session (not just the active tab), so
+// the favicon badge lights up when a background session gets a new
+// reply even though the user is looking at a different session.
+useFaviconState({ isRunning, currentSummary, activeSession, sessionsUnreadCount: unreadCount });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,15 +1,18 @@
 // Dynamic favicon that changes color based on agent state (#470).
 //
-// Uses Canvas API to draw a rounded-square icon containing the
-// MulmoClaude mascot logo. Agent state appears as a 2 px colored ring
-// around the frame (so the mascot stays visible):
+// Renders the MulmoClaude mascot on a colored rounded square. The
+// background color reflects state, and the mascot floats on top:
 //   idle (gray) → running (blue, pulse) → done (green) → error (red)
 //   notification badge (orange dot) overlaid when unread count > 0.
 //
-// The logo PNG is loaded once on first render via Vite's asset-URL
-// import and cached as an HTMLImageElement. If it fails to decode we
-// fall back to the earlier "M"-letter variant so the tab icon never
-// disappears entirely.
+// The logo PNG has an opaque white background, which would otherwise
+// hide the state color. On first load we pre-process the pixels,
+// punching out near-white pixels to transparency so the colored
+// backing shows through. The processed image is cached as an
+// offscreen canvas for the lifetime of the page.
+//
+// If the logo fails to load we fall back to the earlier "M"-letter
+// variant so the tab icon never disappears entirely.
 
 import { watch, type Ref, type ComputedRef } from "vue";
 import logoUrl from "../assets/mulmo_bw.png";
@@ -30,28 +33,48 @@ const STATE_COLORS: Record<FaviconState, string> = {
   error: "#EF4444", // red-500
 };
 
-const NOTIFICATION_DOT_COLOR = "#F97316"; // orange-500
+const NOTIFICATION_DOT_COLOR = "#DC2626"; // red-600 — stands out against the gray/blue/green state backgrounds
 const SIZE = 32;
 const RADIUS = 6;
-const RING_WIDTH = 2;
+// How much of the inner rounded square the mascot fills. 2 px of
+// padding on each side keeps it off the rounded corners and leaves
+// room for the colored backing to peek around the outline.
+const MASCOT_INSET = 2;
 
-// Load the logo PNG once and memoize the decoded <img>. Multiple
-// concurrent calls before the first resolve share the same promise so
-// we don't kick off N redundant decodes during a burst of state
-// changes. A failed load falls through to the "M" fallback for the
-// rest of the session.
-let logoImage: HTMLImageElement | null = null;
+// Pixels whose RGB channels are all above this are treated as the
+// PNG's white backing and punched to transparent. The PNG uses a soft
+// pastel palette so the mascot itself never hits all three channels
+// this high.
+const WHITE_TO_ALPHA_THRESHOLD = 235;
+// Pixels in the [FEATHER_LOW, WHITE_TO_ALPHA_THRESHOLD] band get a
+// partial-alpha ramp so the mascot's anti-aliased outline blends with
+// the colored background instead of showing a hard seam.
+const FEATHER_LOW = 205;
+
+// ── Asset loading ──────────────────────────────────────────────
+
+let logoCanvas: HTMLCanvasElement | null = null;
 let logoLoadFailed = false;
-let logoLoadPromise: Promise<HTMLImageElement> | null = null;
+let logoLoadPromise: Promise<HTMLCanvasElement> | null = null;
 
-function loadLogo(): Promise<HTMLImageElement> {
-  if (logoImage) return Promise.resolve(logoImage);
+function loadLogo(): Promise<HTMLCanvasElement> {
+  if (logoCanvas) return Promise.resolve(logoCanvas);
   if (logoLoadPromise) return logoLoadPromise;
-  logoLoadPromise = new Promise((resolve, reject) => {
+  logoLoadPromise = decodeAndPunchOutWhite();
+  return logoLoadPromise;
+}
+
+function decodeAndPunchOutWhite(): Promise<HTMLCanvasElement> {
+  return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => {
-      logoImage = img;
-      resolve(img);
+      try {
+        logoCanvas = buildTransparentLogoCanvas(img);
+        resolve(logoCanvas);
+      } catch (err) {
+        logoLoadFailed = true;
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     };
     img.onerror = (err) => {
       logoLoadFailed = true;
@@ -59,8 +82,39 @@ function loadLogo(): Promise<HTMLImageElement> {
     };
     img.src = logoUrl;
   });
-  return logoLoadPromise;
 }
+
+// Copy the decoded <img> into an offscreen canvas and scan every
+// pixel, replacing near-white with transparency. The PNG is opaque so
+// the background would otherwise cover the state color backing.
+function buildTransparentLogoCanvas(img: HTMLImageElement): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2d context unavailable");
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const pixels = imageData.data;
+  for (let i = 0; i < pixels.length; i += 4) {
+    const red = pixels[i];
+    const green = pixels[i + 1];
+    const blue = pixels[i + 2];
+    const minChannel = Math.min(red, green, blue);
+    if (minChannel >= WHITE_TO_ALPHA_THRESHOLD) {
+      pixels[i + 3] = 0; // fully transparent
+    } else if (minChannel >= FEATHER_LOW) {
+      // Linear ramp across the feather band. At minChannel = FEATHER_LOW
+      // alpha stays 255; at threshold it drops to 0.
+      const ratio = (minChannel - FEATHER_LOW) / (WHITE_TO_ALPHA_THRESHOLD - FEATHER_LOW);
+      pixels[i + 3] = Math.round(255 * (1 - ratio));
+    }
+  }
+  ctx.putImageData(imageData, 0, 0);
+  return canvas;
+}
+
+// ── Drawing primitives ─────────────────────────────────────────
 
 function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: number, width: number, height: number, radius: number): void {
   ctx.beginPath();
@@ -76,39 +130,16 @@ function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: numb
   ctx.closePath();
 }
 
-// Aspect-preserving letterbox: scale the logo to fit the inner frame
-// without distorting the mascot, then center the leftover space. With
-// a transparent PNG the leftover is transparent (white fill below);
-// with the current opaque PNG the leftover matches the PNG's white
-// background so the two blend seamlessly.
-function drawLogoCentered(ctx: CanvasRenderingContext2D, img: HTMLImageElement, inset: number): void {
+// Aspect-preserving letterbox: scale the logo to fit the inner area
+// without distorting the mascot, then center the leftover space.
+function drawLogoCentered(ctx: CanvasRenderingContext2D, source: HTMLCanvasElement, inset: number): void {
   const available = SIZE - inset * 2;
-  const aspect = img.width / img.height;
+  const aspect = source.width / source.height;
   const drawW = aspect >= 1 ? available : available * aspect;
   const drawH = aspect >= 1 ? available / aspect : available;
   const drawX = inset + (available - drawW) / 2;
   const drawY = inset + (available - drawH) / 2;
-  ctx.drawImage(img, drawX, drawY, drawW, drawH);
-}
-
-function drawStateRing(ctx: CanvasRenderingContext2D, state: FaviconState): void {
-  // Ring sits ON the edge of the rounded square rather than inside, so
-  // the full 32×32 is used for the mascot. `lineWidth = RING_WIDTH`
-  // with a half-inset keeps strokes on-pixel.
-  const half = RING_WIDTH / 2;
-  ctx.strokeStyle = STATE_COLORS[state];
-  ctx.lineWidth = RING_WIDTH;
-  drawRoundedRect(ctx, half, half, SIZE - RING_WIDTH, SIZE - RING_WIDTH, RADIUS);
-  ctx.stroke();
-
-  // Running: a second inner ring at lower alpha reads as a subtle
-  // glow / pulse cue at 32 px.
-  if (state === FAVICON_STATES.running) {
-    ctx.strokeStyle = "rgba(59, 130, 246, 0.35)"; // matches blue-500 state
-    ctx.lineWidth = 2;
-    drawRoundedRect(ctx, 4, 4, SIZE - 8, SIZE - 8, Math.max(RADIUS - 2, 2));
-    ctx.stroke();
-  }
+  ctx.drawImage(source, drawX, drawY, drawW, drawH);
 }
 
 function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
@@ -124,9 +155,11 @@ function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
   ctx.stroke();
 }
 
+// ── Composition ────────────────────────────────────────────────
+
 // Fallback for when the logo PNG fails to decode (or before the first
-// decode completes). Same geometry as the previous implementation so
-// the favicon never looks broken during the first paint.
+// decode completes). Mirrors the earlier "M"-on-colored-square design
+// so the favicon always has a valid first paint.
 function renderFallbackFavicon(ctx: CanvasRenderingContext2D, state: FaviconState, hasNotification: boolean): void {
   drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
   ctx.fillStyle = STATE_COLORS[state];
@@ -141,20 +174,29 @@ function renderFallbackFavicon(ctx: CanvasRenderingContext2D, state: FaviconStat
   if (hasNotification) drawNotificationDot(ctx);
 }
 
-function renderLogoFavicon(ctx: CanvasRenderingContext2D, img: HTMLImageElement, state: FaviconState, hasNotification: boolean): void {
-  // Clip to the rounded square so the PNG's corners don't bleed
-  // outside the frame.
+function renderLogoFavicon(ctx: CanvasRenderingContext2D, logo: HTMLCanvasElement, state: FaviconState, hasNotification: boolean): void {
+  // Colored rounded-square backing — the dynamic cue.
+  drawRoundedRect(ctx, 0, 0, SIZE, SIZE, RADIUS);
+  ctx.fillStyle = STATE_COLORS[state];
+  ctx.fill();
+
+  // Clip subsequent draws to the rounded square so the mascot's
+  // anti-aliased edges don't spill past the corners.
   ctx.save();
   drawRoundedRect(ctx, 0, 0, SIZE, SIZE, RADIUS);
   ctx.clip();
-  // White backing so transparent regions of the PNG (none today, but
-  // future-proof) don't render with the browser's tab-bar color.
-  ctx.fillStyle = "white";
-  ctx.fillRect(0, 0, SIZE, SIZE);
-  drawLogoCentered(ctx, img, RING_WIDTH);
+  drawLogoCentered(ctx, logo, MASCOT_INSET);
   ctx.restore();
 
-  drawStateRing(ctx, state);
+  // Running state: subtle inner glow ring reinforces the pulse cue
+  // without overpowering the colored backing.
+  if (state === FAVICON_STATES.running) {
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.55)";
+    ctx.lineWidth = 1.5;
+    drawRoundedRect(ctx, 2.25, 2.25, SIZE - 4.5, SIZE - 4.5, Math.max(RADIUS - 1, 2));
+    ctx.stroke();
+  }
+
   if (hasNotification) drawNotificationDot(ctx);
 }
 
@@ -167,8 +209,8 @@ async function renderFavicon(state: FaviconState, hasNotification: boolean): Pro
 
   if (!logoLoadFailed) {
     try {
-      const img = await loadLogo();
-      renderLogoFavicon(ctx, img, state, hasNotification);
+      const logo = await loadLogo();
+      renderLogoFavicon(ctx, logo, state, hasNotification);
       return canvas.toDataURL("image/png");
     } catch {
       // fall through — renderFallbackFavicon below handles it.

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,11 +1,18 @@
 // Dynamic favicon that changes color based on agent state (#470).
 //
-// Uses Canvas API to draw a rounded-square icon with the letter "M"
-// in the center. Color reflects the current state:
+// Uses Canvas API to draw a rounded-square icon containing the
+// MulmoClaude mascot logo. Agent state appears as a 2 px colored ring
+// around the frame (so the mascot stays visible):
 //   idle (gray) → running (blue, pulse) → done (green) → error (red)
 //   notification badge (orange dot) overlaid when unread count > 0.
+//
+// The logo PNG is loaded once on first render via Vite's asset-URL
+// import and cached as an HTMLImageElement. If it fails to decode we
+// fall back to the earlier "M"-letter variant so the tab icon never
+// disappears entirely.
 
 import { watch, type Ref, type ComputedRef } from "vue";
+import logoUrl from "../assets/mulmo_bw.png";
 
 export const FAVICON_STATES = {
   idle: "idle",
@@ -26,6 +33,34 @@ const STATE_COLORS: Record<FaviconState, string> = {
 const NOTIFICATION_DOT_COLOR = "#F97316"; // orange-500
 const SIZE = 32;
 const RADIUS = 6;
+const RING_WIDTH = 2;
+
+// Load the logo PNG once and memoize the decoded <img>. Multiple
+// concurrent calls before the first resolve share the same promise so
+// we don't kick off N redundant decodes during a burst of state
+// changes. A failed load falls through to the "M" fallback for the
+// rest of the session.
+let logoImage: HTMLImageElement | null = null;
+let logoLoadFailed = false;
+let logoLoadPromise: Promise<HTMLImageElement> | null = null;
+
+function loadLogo(): Promise<HTMLImageElement> {
+  if (logoImage) return Promise.resolve(logoImage);
+  if (logoLoadPromise) return logoLoadPromise;
+  logoLoadPromise = new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      logoImage = img;
+      resolve(img);
+    };
+    img.onerror = (err) => {
+      logoLoadFailed = true;
+      reject(err instanceof Error ? err : new Error("favicon logo failed to load"));
+    };
+    img.src = logoUrl;
+  });
+  return logoLoadPromise;
+}
 
 function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: number, width: number, height: number, radius: number): void {
   ctx.beginPath();
@@ -41,54 +76,106 @@ function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: numb
   ctx.closePath();
 }
 
-function renderFavicon(state: FaviconState, hasNotification: boolean): string {
-  const canvas = document.createElement("canvas");
-  canvas.width = SIZE;
-  canvas.height = SIZE;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return "";
+// Aspect-preserving letterbox: scale the logo to fit the inner frame
+// without distorting the mascot, then center the leftover space. With
+// a transparent PNG the leftover is transparent (white fill below);
+// with the current opaque PNG the leftover matches the PNG's white
+// background so the two blend seamlessly.
+function drawLogoCentered(ctx: CanvasRenderingContext2D, img: HTMLImageElement, inset: number): void {
+  const available = SIZE - inset * 2;
+  const aspect = img.width / img.height;
+  const drawW = aspect >= 1 ? available : available * aspect;
+  const drawH = aspect >= 1 ? available / aspect : available;
+  const drawX = inset + (available - drawW) / 2;
+  const drawY = inset + (available - drawH) / 2;
+  ctx.drawImage(img, drawX, drawY, drawW, drawH);
+}
 
-  // Background: rounded square
-  const color = STATE_COLORS[state];
-  drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
-  ctx.fillStyle = color;
-  ctx.fill();
-
-  // Subtle shadow/depth
-  ctx.strokeStyle = "rgba(0,0,0,0.15)";
-  ctx.lineWidth = 1;
-  drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
+function drawStateRing(ctx: CanvasRenderingContext2D, state: FaviconState): void {
+  // Ring sits ON the edge of the rounded square rather than inside, so
+  // the full 32×32 is used for the mascot. `lineWidth = RING_WIDTH`
+  // with a half-inset keeps strokes on-pixel.
+  const half = RING_WIDTH / 2;
+  ctx.strokeStyle = STATE_COLORS[state];
+  ctx.lineWidth = RING_WIDTH;
+  drawRoundedRect(ctx, half, half, SIZE - RING_WIDTH, SIZE - RING_WIDTH, RADIUS);
   ctx.stroke();
 
-  // "M" letter
+  // Running: a second inner ring at lower alpha reads as a subtle
+  // glow / pulse cue at 32 px.
+  if (state === FAVICON_STATES.running) {
+    ctx.strokeStyle = "rgba(59, 130, 246, 0.35)"; // matches blue-500 state
+    ctx.lineWidth = 2;
+    drawRoundedRect(ctx, 4, 4, SIZE - 8, SIZE - 8, Math.max(RADIUS - 2, 2));
+    ctx.stroke();
+  }
+}
+
+function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
+  const dotR = 5;
+  const dotX = SIZE - dotR - 1;
+  const dotY = dotR + 1;
+  ctx.beginPath();
+  ctx.arc(dotX, dotY, dotR, 0, Math.PI * 2);
+  ctx.fillStyle = NOTIFICATION_DOT_COLOR;
+  ctx.fill();
+  ctx.strokeStyle = "white";
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+// Fallback for when the logo PNG fails to decode (or before the first
+// decode completes). Same geometry as the previous implementation so
+// the favicon never looks broken during the first paint.
+function renderFallbackFavicon(ctx: CanvasRenderingContext2D, state: FaviconState, hasNotification: boolean): void {
+  drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
+  ctx.fillStyle = STATE_COLORS[state];
+  ctx.fill();
+
   ctx.fillStyle = "white";
   ctx.font = "bold 20px -apple-system, BlinkMacSystemFont, sans-serif";
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.fillText("M", SIZE / 2, SIZE / 2 + 1);
 
-  // Running state: subtle glow ring
-  if (state === FAVICON_STATES.running) {
-    ctx.strokeStyle = "rgba(255,255,255,0.4)";
-    ctx.lineWidth = 2;
-    drawRoundedRect(ctx, 3, 3, SIZE - 6, SIZE - 6, RADIUS - 1);
-    ctx.stroke();
+  if (hasNotification) drawNotificationDot(ctx);
+}
+
+function renderLogoFavicon(ctx: CanvasRenderingContext2D, img: HTMLImageElement, state: FaviconState, hasNotification: boolean): void {
+  // Clip to the rounded square so the PNG's corners don't bleed
+  // outside the frame.
+  ctx.save();
+  drawRoundedRect(ctx, 0, 0, SIZE, SIZE, RADIUS);
+  ctx.clip();
+  // White backing so transparent regions of the PNG (none today, but
+  // future-proof) don't render with the browser's tab-bar color.
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, SIZE, SIZE);
+  drawLogoCentered(ctx, img, RING_WIDTH);
+  ctx.restore();
+
+  drawStateRing(ctx, state);
+  if (hasNotification) drawNotificationDot(ctx);
+}
+
+async function renderFavicon(state: FaviconState, hasNotification: boolean): Promise<string> {
+  const canvas = document.createElement("canvas");
+  canvas.width = SIZE;
+  canvas.height = SIZE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+
+  if (!logoLoadFailed) {
+    try {
+      const img = await loadLogo();
+      renderLogoFavicon(ctx, img, state, hasNotification);
+      return canvas.toDataURL("image/png");
+    } catch {
+      // fall through — renderFallbackFavicon below handles it.
+    }
   }
 
-  // Notification badge (orange dot, top-right)
-  if (hasNotification) {
-    const dotR = 5;
-    const dotX = SIZE - dotR - 1;
-    const dotY = dotR + 1;
-    ctx.beginPath();
-    ctx.arc(dotX, dotY, dotR, 0, Math.PI * 2);
-    ctx.fillStyle = NOTIFICATION_DOT_COLOR;
-    ctx.fill();
-    ctx.strokeStyle = "white";
-    ctx.lineWidth = 1.5;
-    ctx.stroke();
-  }
-
+  renderFallbackFavicon(ctx, state, hasNotification);
   return canvas.toDataURL("image/png");
 }
 
@@ -106,10 +193,16 @@ function applyFavicon(dataUrl: string): void {
 }
 
 export function useDynamicFavicon(opts: { state: Ref<FaviconState> | ComputedRef<FaviconState>; hasNotification: Ref<boolean> | ComputedRef<boolean> }): void {
-  function update(): void {
-    const dataUrl = renderFavicon(opts.state.value, opts.hasNotification.value);
+  async function update(): Promise<void> {
+    const dataUrl = await renderFavicon(opts.state.value, opts.hasNotification.value);
     applyFavicon(dataUrl);
   }
 
-  watch([opts.state, opts.hasNotification], update, { immediate: true });
+  watch(
+    [opts.state, opts.hasNotification],
+    () => {
+      update().catch((err) => console.warn("[favicon] render failed", err));
+    },
+    { immediate: true },
+  );
 }

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -10,8 +10,13 @@ export function useFaviconState(opts: {
   isRunning: ComputedRef<boolean>;
   currentSummary: ComputedRef<SessionSummary | undefined>;
   activeSession: ComputedRef<ActiveSession | undefined>;
+  // Number of sessions (across all tabs) with unread messages. We
+  // light the badge dot when any session is unread, even if it's not
+  // the currently-focused one, so background replies still surface in
+  // the tab bar.
+  sessionsUnreadCount: ComputedRef<number>;
 }) {
-  const { isRunning, currentSummary, activeSession } = opts;
+  const { isRunning, currentSummary, activeSession, sessionsUnreadCount } = opts;
 
   const faviconState = computed<FaviconState>(() => {
     if (isRunning.value) return FAVICON_STATES.running;
@@ -21,7 +26,13 @@ export function useFaviconState(opts: {
   });
 
   const { unreadCount: notificationUnreadCount } = useNotifications();
-  const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0);
+  // Badge dot covers two independent signals:
+  //   1. Pub-sub notifications (scheduled tasks, etc.)
+  //   2. Any session with unread chat messages (including background
+  //      tabs the user isn't currently viewing).
+  // Either one flips the dot on — the dot doesn't distinguish source,
+  // just tells the user "there's something to look at".
+  const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0 || sessionsUnreadCount.value > 0);
 
   useDynamicFavicon({
     state: faviconState,


### PR DESCRIPTION
## Summary

Favicon が動的に状態変化するのは維持したまま、中身を **"M" 文字 → MulmoClaude のマスコットロゴ** に差し替え。

| | Before | After |
|---|---|---|
| 中央 | 白の "M" 文字 | \`src/assets/mulmo_bw.png\` のマスコット (角丸フレーム内に aspect 保存でセンタリング) |
| 状態色 | 背景全面 | 2 px の外側リング (マスコットを潰さない) |
| Running 時 | 内側の薄いリング | 同じく維持 (blue-500 @ 35% alpha) |
| 通知バッジ | 右上の orange dot | 変更なし |
| 状態種別 | idle / running / done / error | 変更なし |

## Items to Confirm / Review

- **見た目の確認**: 32 px での視認性は実機で見ないと判断できません。ロゴの細部は潰れますが、全体のシルエット (ふくよかな丸い子猫) は残るはず。ブラウザのタブ + bookmark bar の両方で違和感無いかご確認ください。
- **ロゴ PNG の大きさ (1,013 KB)**: Vite のアセット URL インポートなので JS bundle には入らず、静的配信される単独ファイル。初回タブ表示時のみロード。
- **ロード失敗時のフォールバック**: 何らかの理由で PNG がデコードできないとき旧 "M" デザインに戻る挙動を残してあります (offline キャッシュ + 初回レンダーのレースケース対策)。

## User Prompt

> favicon、動的に変わるけどロゴの画像を参考にした favicon で、それをできる？

## Verification

- \`yarn typecheck\` 全ワークスペース通過
- \`yarn lint\` 0 errors
- \`yarn build\` 通過
- \`yarn test\` — 2,660 tests pass, 0 fail
- \`useFaviconState\` + \`App.vue\` の呼び出し箇所は未変更、状態遷移ロジックは既存のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)