### PR TITLE
fix(i18n): silence vue-i18n HTML warning + reconcile pluginWiki keys

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -8,6 +8,19 @@
 // reads `typeof en` to feed `DefineLocaleMessage`, and readonly literal
 // types would conflict with vue-i18n's writable message interface.
 
+// ⚠️ Angle-bracket text (e.g. `<name>`, `</tag>`) in a plain string
+// message trips vue-i18n's XSS heuristic and logs
+// `[intlify] Detected HTML in '…' message` on every mount. If the
+// copy must contain `<...>`, use the **function form** so the
+// message compiler is skipped entirely:
+//
+//   subheading: ({ named }: { named: (key: string) => unknown }) =>
+//     `${named("count")} available · invokes as /<name>`,
+//
+// See `argsPlaceholder` and `pluginManageSkills.subheading` for
+// worked examples. Mirror the same form in every other lang file
+// when the English side uses a function.
+
 const enMessages = {
   common: {
     save: "Save",
@@ -393,7 +406,10 @@ const enMessages = {
     heading: "Skills",
     previewCount: "{count} skill | {count} skills",
     previewMore: "+{count} more",
-    subheading: '{count} available · click one to view · "Run" invokes it as /<name>',
+    // Function form skips vue-i18n's message compiler, which
+    // otherwise flags the literal `<name>` as a suspected HTML
+    // fragment and warns about XSS on every mount.
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} available · click one to view · "Run" invokes it as /<name>`,
     emptyWithPath: "No skills found. Add skill folders under {path}.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "Select a skill on the left to view its SKILL.md.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1,5 +1,10 @@
 // Spanish dictionary. Mirror the shape of src/lang/en.ts —
 // missing keys fall back to English per createI18n's fallbackLocale.
+//
+// ⚠️ Las cadenas que contienen ángulos (p.ej. `<name>`) activan la
+// heurística XSS de vue-i18n y generan el aviso
+// "Detected HTML in '…' message". Usa siempre la **forma función**
+// en esos casos. Ver la cabecera de en.ts para más detalle.
 
 const esMessages = {
   common: {
@@ -316,8 +321,7 @@ const esMessages = {
   },
   pluginWiki: {
     backToIndex: "Volver al índice",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ Error de PDF",
     tabIndex: "Índice",
     tabLog: "Registro",
@@ -387,7 +391,10 @@ const esMessages = {
     heading: "Skills",
     previewCount: "{count} skill | {count} skills",
     previewMore: "+{count} más",
-    subheading: '{count} disponibles · haz clic para ver · "Run" la invoca como /<name>',
+    // La forma función evita el compilador de mensajes de vue-i18n,
+    // que de lo contrario marca el literal `<name>` como fragmento
+    // HTML y avisa "Detected HTML in '…' message" en cada montaje.
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} disponibles · haz clic para ver · "Run" la invoca como /<name>`,
     emptyWithPath: "No se encontraron skills. Añade carpetas de skills en {path}.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "Selecciona una skill a la izquierda para ver su SKILL.md.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1,5 +1,10 @@
 // Japanese dictionary. Mirror the shape of src/lang/en.ts —
 // missing keys fall back to English per createI18n's fallbackLocale.
+//
+// ⚠️ `<name>` のような山括弧を含む文字列は vue-i18n の XSS
+// ヒューリスティックに引っかかり「Detected HTML in '…' message」
+// 警告が出るため、**関数形式** で書くこと。詳細は en.ts の
+// ヘッダーコメントを参照。
 
 const jaMessages = {
   common: {
@@ -385,7 +390,10 @@ const jaMessages = {
     heading: "スキル",
     previewCount: "{count} スキル",
     previewMore: "他 {count} 件",
-    subheading: "{count} 件利用可能 · クリックで表示 · 「Run」で /<name> として呼び出し",
+    // 関数形式で vue-i18n のメッセージコンパイラをバイパスする。
+    // 通常形式だと `<name>` が HTML フラグメント扱いされ、毎回
+    // 「Detected HTML in '…' message」警告が出る。
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} 件利用可能 · クリックで表示 · 「Run」で /<name> として呼び出し`,
     emptyWithPath: "スキルが見つかりません。{path} にスキルフォルダを追加してください。",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "左側のスキルを選択して SKILL.md を表示します。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1,5 +1,10 @@
 // Korean dictionary. Mirror the shape of src/lang/en.ts —
 // missing keys fall back to English per createI18n's fallbackLocale.
+//
+// ⚠️ `<name>` 같은 꺾쇠 괄호가 들어간 문자열은 vue-i18n 의 XSS
+// 탐지에 걸려 "Detected HTML in '…' message" 경고가 발생하므로
+// 반드시 **함수 형식** 으로 작성한다. 자세한 내용은 en.ts 의
+// 헤더 주석 참고.
 
 const koMessages = {
   common: {
@@ -315,8 +320,7 @@ const koMessages = {
   },
   pluginWiki: {
     backToIndex: "목차로 돌아가기",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF 실패",
     tabIndex: "목차",
     tabLog: "로그",
@@ -386,7 +390,10 @@ const koMessages = {
     heading: "스킬",
     previewCount: "{count}개 스킬",
     previewMore: "+{count}개 더",
-    subheading: '{count}개 사용 가능 · 클릭해서 보기 · "Run" 은 /<name> 형식으로 호출합니다',
+    // 함수 형식으로 vue-i18n 의 메시지 컴파일러를 우회한다. 일반
+    // 문자열이면 `<name>` 이 HTML 조각으로 간주되어 매번 "Detected
+    // HTML in '…' message" 경고가 발생한다.
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")}개 사용 가능 · 클릭해서 보기 · "Run" 은 /<name> 형식으로 호출합니다`,
     emptyWithPath: "스킬을 찾을 수 없습니다. {path} 아래에 스킬 폴더를 추가하세요.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "왼쪽에서 스킬을 선택해 SKILL.md 를 확인하세요.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1,5 +1,9 @@
 // Simplified Chinese dictionary. Mirror the shape of src/lang/en.ts —
 // missing keys fall back to English per createI18n's fallbackLocale.
+//
+// ⚠️ 包含 `<name>` 等尖括号的字符串会触发 vue-i18n 的 XSS
+// 检测,输出 "Detected HTML in '…' message" 警告。此类文案必须
+// 改用 **函数形式**。详见 en.ts 的头部注释。
 
 const zhMessages = {
   common: {
@@ -313,8 +317,7 @@ const zhMessages = {
   },
   pluginWiki: {
     backToIndex: "返回目录",
-    downloadPdf: "↓ PDF",
-    pdfLoadingLabel: "PDF",
+    pdf: "PDF",
     pdfFailed: "⚠ PDF 失败",
     tabIndex: "目录",
     tabLog: "日志",
@@ -384,7 +387,10 @@ const zhMessages = {
     heading: "技能",
     previewCount: "{count} 个技能",
     previewMore: "+还有 {count} 个",
-    subheading: '{count} 个可用 · 点击查看 · "Run" 会以 /<name> 的形式调用',
+    // 使用函数形式绕过 vue-i18n 的消息编译器,否则 `<name>`
+    // 会被当作 HTML 片段,每次挂载都会触发
+    // "Detected HTML in '…' message" 警告。
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} 个可用 · 点击查看 · "Run" 会以 /<name> 的形式调用`,
     emptyWithPath: "未找到技能。请在 {path} 下添加技能文件夹。",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "在左侧选择一个技能以查看其 SKILL.md。",


### PR DESCRIPTION
## Summary

- Silence the repeating `[intlify] Detected HTML in '…' message` console warning that appears on every mount of the **Skills** plugin panel.
- Fix pre-existing `pluginWiki` key drift between en/ja and zh/ko/es that was breaking `yarn typecheck:vue` on `main`.
- Add header comments to every lang file so this class of mistake doesn't recur.

## Items to Confirm / Review

- **Root cause of the HTML warning**: `pluginManageSkills.subheading` ends with the literal `/<name>`. vue-i18n's message compiler flags `<name>` as a suspected HTML fragment and logs the XSS warning. Switching to the **function form** (`() => \`…\``) skips the compiler — same trick already used for `argsPlaceholder`.
- **pluginWiki drift**: zh/ko/es were renamed to `downloadPdf` + `pdfLoadingLabel` when those locales were added (PR #637), but en/ja kept `pdf`. `DefineLocaleMessage` derives the schema from `typeof enMessages`, so the mismatch produced a TS2719 on `main`. `src/plugins/wiki/View.vue:16` calls `t("pluginWiki.pdf")`, confirming the en/ja shape is the intended one — I reverted the three locales back to `pdf`.
- **Header comments**: every lang file now opens with a warning about angle-bracket literals needing the function form. en.ts is authoritative; the others point back to it.

## User Prompt

> `[intlify] Detected HTML in '{count} 件利用可能 · クリックで表示 · 「Run」で /<name> として呼び出し' message. Recommend not using HTML messages to avoid XSS.`
>
> pullして、他にもこういう問題がないか全部調べて。再発しないようにソースのheaderにコメントするなど対策してね

## Test plan

- [x] `yarn typecheck:vue` — clean
- [x] `yarn format` — clean
- [x] `yarn lint` — no new warnings from this change
- [ ] Open Skills plugin in the dev server → no HTML warning in console
- [ ] Open Wiki plugin → `pluginWiki.pdf` renders correctly in zh / ko / es

🤖 Generated with [Claude Code](https://claude.com/claude-code)