### PR TITLE
fix(ui): hide right sidebar on non-chat views

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
         <SidebarHeader
           :sandbox-enabled="sandboxEnabled"
           :show-right-sidebar="showRightSidebar"
+          :is-chat-page="isChatPage"
           :title-style="debugTitleStyle"
           @test-query="(q) => sendMessage(q)"
           @notification-navigate="handleNotificationNavigate"
@@ -141,9 +142,11 @@
         </div>
       </div>
 
-      <!-- Right sidebar: tool call history -->
+      <!-- Right sidebar: tool call history. Only shown on the chat
+           page — system prompt / tools / tool-call history are all
+           agent-context and have no meaning on plugin views. -->
       <RightSidebar
-        v-if="showRightSidebar"
+        v-if="showRightSidebar && isChatPage"
         ref="rightSidebarRef"
         :tool-call-history="toolCallHistory"
         :available-tools="availableTools"

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -12,6 +12,7 @@
       />
       <NotificationBell :force-close="lockPopupOpen" @navigate="(action) => emit('notificationNavigate', action)" @update:open="onNotificationOpen" />
       <button
+        v-if="isChatPage"
         class="text-gray-400 hover:text-gray-700"
         :class="{ 'text-blue-500': showRightSidebar }"
         :title="t('sidebarHeader.toolCallHistory')"
@@ -46,6 +47,7 @@ const { t } = useI18n();
 defineProps<{
   sandboxEnabled: boolean;
   showRightSidebar: boolean;
+  isChatPage: boolean;
   titleStyle?: CSSProperties;
 }>();
 


### PR DESCRIPTION
## Summary

The right sidebar (system prompt / available tools / tool call history) is pure agent-context, but it was staying visible on wiki / todos / scheduler / skills / roles / files views — taking up screen width with information that has no meaning there. Gate both the panel and its header toggle on the existing `isChatPage` computed so they only appear during chat.

## Items to Confirm / Review

- Panel: `v-if="showRightSidebar && isChatPage"` on `App.vue:146`. The user's persisted toggle preference (localStorage key `right_sidebar_visible`) is **untouched** — it's honoured the moment you navigate back to chat.
- Toggle button: `v-if="isChatPage"` in `SidebarHeader.vue` so users don't see a dead control on plugin views.
- No other sidebar-related state change. If you had the panel open before entering a plugin view, it'll be back when you return to chat.

## Stacked PR

This PR targets `fix/i18n-html-detection-warning` (#647) because `main` currently fails `yarn typecheck:vue` due to a `pluginWiki` key drift that #647 repairs. GitHub should auto-retarget this to `main` once #647 merges.

## User Prompt

> レイアウトの話。チャットじゃなくてwikiとかのときに、右にtoolsなどの右メニューが残るのっておかしくない？
>
> 最良の方法で

## Test plan

- [x] `yarn typecheck:vue` — clean
- [x] `yarn format` / `yarn lint` — no new issues
- [ ] Open wiki / todos / scheduler / skills / roles / files → right sidebar hidden, 🔧 toggle hidden from the header
- [ ] Navigate back to chat → right sidebar returns at the user's saved preference
- [ ] Toggle the sidebar off while on chat, switch to wiki, back to chat → still off (preference preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)