### PR TITLE
chore(relay): bump TypeScript devDependency to ^6.0.3

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260421.1",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "wrangler": "^4.84.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8578,11 +8578,6 @@ typescript@>=5, typescript@^6.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
-typescript@^5.8.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
-
 uc.micro@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"


### PR DESCRIPTION
## Summary

Align `packages/relay`'s TypeScript devDependency with every other workspace (all on `^6.0.3`). Relay was the only holdout at `^5.8.3`, resolving to 5.9.3 — flagged by `yarn outdated typescript`.

## Items to Confirm / Review

- One-line version bump in `packages/relay/package.json` + refreshed `yarn.lock`.
- `cd packages/relay && yarn typecheck` (i.e. `tsc --noEmit`) passes clean on TS 6.0.3.
- No source changes.

## Stacked PR

Targets `fix/i18n-html-detection-warning` (#647) because `main` currently fails `yarn typecheck:vue` due to a pre-existing `pluginWiki` key drift that #647 repairs. GitHub should auto-retarget this to `main` once #647 merges.

## User Prompt

> typescript latest 5.9.3 ❯ 6.0.3 あげられる？

## Test plan

- [x] `yarn install` — lockfile resolves cleanly
- [x] `yarn outdated typescript` — empty
- [x] `cd packages/relay && yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update packages/relay TypeScript devDependency to ^6.0.3 and regenerate yarn.lock to reflect the new version.