### PR TITLE
feat(history): add unread filter pill

### DIFF
--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -83,7 +83,13 @@ import { roleIcon, roleName } from "../utils/role/icon";
 
 const { t } = useI18n();
 
-const FILTERS = ["all" as const, SESSION_ORIGINS.human, SESSION_ORIGINS.scheduler, SESSION_ORIGINS.skill, SESSION_ORIGINS.bridge];
+// `unread` is mutually exclusive with origin pills — selecting it
+// shows every unread-flagged session regardless of origin, matching
+// the user expectation that "unread" is the primary question ("what
+// needs my attention?") rather than an origin sub-filter.
+const UNREAD_FILTER = "unread" as const;
+const FILTERS = ["all" as const, UNREAD_FILTER, SESSION_ORIGINS.human, SESSION_ORIGINS.scheduler, SESSION_ORIGINS.skill, SESSION_ORIGINS.bridge];
+type FilterKey = (typeof FILTERS)[number];
 
 const ORIGIN_ICONS: Record<string, string> = {
   human: "person",
@@ -117,7 +123,7 @@ defineExpose({ root });
 
 // ── Filter ──────────────────────────────────────────────────
 
-const activeFilter = ref<SessionOrigin | "all">("all");
+const activeFilter = ref<FilterKey>("all");
 
 function originOf(session: SessionSummary): SessionOrigin {
   return session.origin ?? SESSION_ORIGINS.human;
@@ -125,12 +131,14 @@ function originOf(session: SessionSummary): SessionOrigin {
 
 const filteredSessions = computed(() => {
   if (activeFilter.value === "all") return props.sessions;
+  if (activeFilter.value === UNREAD_FILTER) return props.sessions.filter((session) => session.hasUnread === true);
   return props.sessions.filter((session) => originOf(session) === activeFilter.value);
 });
 
-function countByOrigin(origin: string): number {
-  if (origin === "all") return props.sessions.length;
-  return props.sessions.filter((session) => originOf(session) === origin).length;
+function countByOrigin(filterKey: FilterKey): number {
+  if (filterKey === "all") return props.sessions.length;
+  if (filterKey === UNREAD_FILTER) return props.sessions.filter((session) => session.hasUnread === true).length;
+  return props.sessions.filter((session) => originOf(session) === filterKey).length;
 }
 
 function originIcon(origin: string): string {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -43,6 +43,7 @@ const enMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "All",
+      unread: "Unread",
       human: "Human",
       scheduler: "Scheduler",
       skill: "Skill",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -34,6 +34,7 @@ const esMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "Todas",
+      unread: "No leídas",
       human: "Persona",
       scheduler: "Programador",
       skill: "Skill",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -36,6 +36,7 @@ const jaMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "すべて",
+      unread: "未読",
       human: "手動",
       scheduler: "スケジューラ",
       skill: "スキル",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -36,6 +36,7 @@ const koMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "전체",
+      unread: "읽지 않음",
       human: "사람",
       scheduler: "스케줄러",
       skill: "스킬",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -35,6 +35,7 @@ const zhMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "全部",
+      unread: "未读",
       human: "人工",
       scheduler: "调度器",
       skill: "技能",


### PR DESCRIPTION
## Summary
- Adds an **Unread** pill to the session history filter bar. Clicking it lists every session with `hasUnread === true` regardless of origin.
- Count on the pill matches the bell badge exactly (same `hasUnread` signal).
- Translations for en / ja / ko / es / zh.

## Design note
Modelled as mutually exclusive with the origin pills (`all / human / scheduler / skill / bridge`), not as a combinable toggle. The user's primary question is typically "what needs my attention?" rather than "which scheduler tasks are unread?", so flat pills stay the simplest UX and match the existing pattern. If a combined axis is wanted later (e.g. "unread scheduler tasks only") we can promote unread to a separate toggle without breaking the current shape.

## User Prompt
> チャット履歴のfilter、未読のみも追加してほしい
>
> あと履歴で選択されているものをクリックしても、チャットに遷移しない

The second issue (history click on already-selected session) is already fixed on main (alreadyOnThatChat check with `route.params.sessionId === sessionId`), so this PR only contains the filter addition.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — 0 errors
- [ ] Manual: open history popup, click "Unread" pill, confirm only unread sessions show and count matches the bell badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)