### PR TITLE
fix(ui): hide right sidebar on non-chat views (re-land #648)

### DIFF
--- a/e2e/tests/right-sidebar-toggle.spec.ts
+++ b/e2e/tests/right-sidebar-toggle.spec.ts
@@ -44,4 +44,30 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     const stored2 = await page.evaluate(() => localStorage.getItem("right_sidebar_visible"));
     expect(stored2).toBe("false");
   });
+
+  test("is hidden on plugin views even when the preference is on", async ({ page }) => {
+    // User has the panel toggled on — should still hide on wiki / todos /
+    // scheduler etc. because those views have no agent context.
+    await page.addInitScript(() => localStorage.setItem("right_sidebar_visible", "true"));
+
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    // Panel and toggle button both visible on chat.
+    await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
+    await expect(page.getByTitle("Tool call history")).toBeVisible();
+
+    for (const route of ["/wiki", "/todos", "/scheduler", "/skills", "/roles", "/files"] as const) {
+      await page.goto(route);
+      await expect(page.getByText("MulmoClaude")).toBeVisible();
+      // Panel content gone.
+      await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeHidden();
+      // Toggle button gone (dead control suppression).
+      await expect(page.getByTitle("Tool call history")).toBeHidden();
+    }
+
+    // Returning to chat restores the panel at the user's saved preference.
+    await page.goto("/chat");
+    await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
+    await expect(page.getByTitle("Tool call history")).toBeVisible();
+  });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
         <SidebarHeader
           :sandbox-enabled="sandboxEnabled"
           :show-right-sidebar="showRightSidebar"
+          :is-chat-page="isChatPage"
           :title-style="debugTitleStyle"
           @test-query="(q) => sendMessage(q)"
           @notification-navigate="handleNotificationNavigate"
@@ -141,9 +142,11 @@
         </div>
       </div>
 
-      <!-- Right sidebar: tool call history -->
+      <!-- Right sidebar: tool call history. Only shown on the chat
+           page — system prompt / tools / tool-call history are all
+           agent-context and have no meaning on plugin views. -->
       <RightSidebar
-        v-if="showRightSidebar"
+        v-if="showRightSidebar && isChatPage"
         ref="rightSidebarRef"
         :tool-call-history="toolCallHistory"
         :available-tools="availableTools"

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -12,6 +12,7 @@
       />
       <NotificationBell :force-close="lockPopupOpen" @navigate="(action) => emit('notificationNavigate', action)" @update:open="onNotificationOpen" />
       <button
+        v-if="isChatPage"
         class="text-gray-400 hover:text-gray-700"
         :class="{ 'text-blue-500': showRightSidebar }"
         :title="t('sidebarHeader.toolCallHistory')"
@@ -46,6 +47,7 @@ const { t } = useI18n();
 defineProps<{
   sandboxEnabled: boolean;
   showRightSidebar: boolean;
+  isChatPage: boolean;
   titleStyle?: CSSProperties;
 }>();
 


### PR DESCRIPTION
## Summary

Re-land the fix from #648, which was merged into its base branch (`fix/i18n-html-detection-warning`) instead of reaching `main` — #647 landed first and only carried the i18n commit, so the layout commit never made it to `main`. This PR brings it in directly, plus a new E2E test to prevent regressing it again.

## Items to Confirm / Review

- `App.vue:146` — `RightSidebar` now gated on `showRightSidebar && isChatPage`.
- `SidebarHeader.vue` — `isChatPage` prop, `🔧` toggle button hidden off chat.
- `e2e/tests/right-sidebar-toggle.spec.ts` — new test `is hidden on plugin views even when the preference is on` exercises all six plugin routes with `right_sidebar_visible=true` and asserts both the panel and toggle are hidden, then returns to `/chat` and asserts both are visible again.
- User's persisted preference is untouched — it's honoured the moment you navigate back to chat.

## Test plan

- [x] `yarn test:e2e e2e/tests/right-sidebar-toggle.spec.ts` — 3/3 passing (the new plugin-views test exercises wiki / todos / scheduler / skills / roles / files)
- [x] `yarn typecheck:vue` clean
- [ ] Open wiki / todos / scheduler / skills / roles / files in the dev server → right sidebar and its 🔧 toggle hidden
- [ ] Navigate back to `/chat` → panel + toggle return at the saved preference

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/648 なおってないかった
>
> e2eでテストしてたしかめてね

🤖 Generated with [Claude Code](https://claude.com/claude-code)