### PR TITLE
fix(i18n): align pt-BR/fr/de with current en.ts schema

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -34,6 +34,7 @@ const deMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "Alle",
+      unread: "Ungelesen",
       human: "Mensch",
       scheduler: "Scheduler",
       skill: "Skill",
@@ -389,7 +390,7 @@ const deMessages = {
     heading: "Skills",
     previewCount: "{count} Skill | {count} Skills",
     previewMore: "+{count} weitere",
-    subheading: '{count} verfügbar · zum Anzeigen klicken · "Run" ruft sie als /<name> auf',
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} verfügbar · zum Anzeigen klicken · "Run" ruft sie als /<name> auf`,
     emptyWithPath: "Keine Skills gefunden. Fügen Sie Skill-Ordner unter {path} hinzu.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "Wählen Sie links eine Skill aus, um ihre SKILL.md anzuzeigen.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -34,6 +34,7 @@ const frMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "Toutes",
+      unread: "Non lues",
       human: "Humain",
       scheduler: "Planificateur",
       skill: "Skill",
@@ -389,7 +390,7 @@ const frMessages = {
     heading: "Skills",
     previewCount: "{count} skill | {count} skills",
     previewMore: "+{count} de plus",
-    subheading: '{count} disponibles · cliquez pour afficher · "Run" l\'invoque comme /<name>',
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} disponibles · cliquez pour afficher · "Run" l'invoque comme /<name>`,
     emptyWithPath: "Aucune skill trouvée. Ajoutez des dossiers de skills sous {path}.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "Sélectionnez une skill à gauche pour afficher son SKILL.md.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -34,6 +34,7 @@ const ptBRMessages = {
   sessionHistoryPanel: {
     filters: {
       all: "Todas",
+      unread: "Não lidas",
       human: "Pessoa",
       scheduler: "Agendador",
       skill: "Skill",
@@ -387,7 +388,7 @@ const ptBRMessages = {
     heading: "Skills",
     previewCount: "{count} skill | {count} skills",
     previewMore: "+{count} mais",
-    subheading: '{count} disponíveis · clique para visualizar · "Run" invoca como /<name>',
+    subheading: ({ named }: { named: (key: string) => unknown }) => `${named("count")} disponíveis · clique para visualizar · "Run" invoca como /<name>`,
     emptyWithPath: "Nenhuma skill encontrada. Adicione pastas de skills em {path}.",
     emptySkillPath: "~/.claude/skills/",
     selectHint: "Selecione uma skill à esquerda para ver seu SKILL.md.",


### PR DESCRIPTION
## Summary

`vue-tsc` on `main` currently fails with two `MessageSchema` mismatches — any PR merging into main today will fail CI. Root cause: two recent changes landed in `en.ts` without mirroring into `pt-BR.ts`, `fr.ts`, and `de.ts`.

- `sessionHistoryPanel.filters.unread` — added in #650 (unread-filter pill). Present in en/ja/zh/ko/es, missing from pt-BR/fr/de.
- `pluginManageSkills.subheading` — function-form message in en/ja/zh/ko/es (required because it contains `<name>`, which trips vue-i18n's HTML heuristic and logs a warning on every mount — see the rationale comment at the top of `en.ts`). The three missing locales had it as a plain string with `{count}` placeholder.

Both fixed here with translations that match the tone used in the other locales.

See the CLAUDE.md rule added in `f2b9b26`: *"all 8 locales must move in lockstep"*. This PR catches up pt-BR/fr/de for the two drifts that slipped through.

## Test plan

- [x] `yarn typecheck` passes (was failing on main before this PR)
- [x] `yarn format`, `yarn lint` (only pre-existing v-html warnings)
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)