### PR TITLE
fix(scheduler): display daily triggers in the viewer's local timezone

### DIFF
--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -30,7 +30,7 @@
           <tbody>
             <tr v-for="hint in FREQUENCY_HINTS" :key="hint.label" class="border-b border-gray-50 last:border-0">
               <td class="px-3 py-1">{{ hint.label }}</td>
-              <td class="px-3 py-1 font-mono text-gray-700">{{ hint.schedule }}</td>
+              <td class="px-3 py-1 font-mono text-gray-700">{{ formatSchedule(hint.schedule) }}</td>
             </tr>
           </tbody>
         </table>
@@ -120,6 +120,7 @@ import { useI18n } from "vue-i18n";
 import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { formatShortTime } from "../../utils/format/date";
+import { formatSchedule as formatTaskSchedule, type TaskSchedule as FormatterTaskSchedule } from "./formatSchedule";
 
 const { t } = useI18n();
 
@@ -145,13 +146,17 @@ interface SchedulerTask {
   state?: TaskState;
 }
 
-const FREQUENCY_HINTS = [
-  { label: "News / RSS fetch", schedule: "Every 1h" },
-  { label: "Journal daily pass", schedule: "Daily 23:00 UTC" },
-  { label: "Wiki maintenance", schedule: "Daily 02:00 UTC" },
-  { label: "Memory extraction", schedule: "Daily 00:00 UTC" },
-  { label: "Calendar / contact sync", schedule: "Every 4h" },
-] as const;
+// Hints showing common task cadences. Stored as structured schedules
+// (not pre-rendered strings) so the display routes through
+// formatTaskSchedule() and picks up the viewer's local timezone for
+// daily rows — the same conversion applied to real tasks below.
+const FREQUENCY_HINTS: Array<{ label: string; schedule: FormatterTaskSchedule }> = [
+  { label: "News / RSS fetch", schedule: { type: "interval", intervalMs: 3_600_000 } },
+  { label: "Journal daily pass", schedule: { type: "daily", time: "23:00" } },
+  { label: "Wiki maintenance", schedule: { type: "daily", time: "02:00" } },
+  { label: "Memory extraction", schedule: { type: "daily", time: "00:00" } },
+  { label: "Calendar / contact sync", schedule: { type: "interval", intervalMs: 14_400_000 } },
+];
 
 const tasks = ref<SchedulerTask[]>([]);
 const loading = ref(true);
@@ -189,15 +194,7 @@ function resultDotClass(result: string): string {
 }
 
 function formatSchedule(schedule: TaskSchedule): string {
-  if (schedule.type === "interval" && schedule.intervalMs) {
-    const mins = Math.round(schedule.intervalMs / 60000);
-    if (mins >= 60) return `Every ${Math.round(mins / 60)}h`;
-    return `Every ${mins}m`;
-  }
-  if (schedule.type === "daily" && schedule.time) {
-    return `Daily ${schedule.time} UTC`;
-  }
-  return JSON.stringify(schedule);
+  return formatTaskSchedule(schedule as FormatterTaskSchedule);
 }
 
 async function runTask(taskId: string): Promise<void> {

--- a/src/plugins/scheduler/formatSchedule.ts
+++ b/src/plugins/scheduler/formatSchedule.ts
@@ -1,0 +1,93 @@
+// Pure formatters for scheduler-task display. Extracted from
+// TasksTab.vue so the UTC → local conversion can be unit-tested
+// without spinning up Vue.
+//
+// Internally every task stores its daily trigger as `HH:MM` in UTC
+// (that's what the scheduler engine fires on). The UI should show the
+// same moment in the viewer's local timezone so a user in Tokyo sees
+// "Daily 05:00 JST" instead of "Daily 20:00 UTC".
+
+export interface DailySchedule {
+  type: "daily";
+  time: string; // "HH:MM" in UTC
+}
+
+export interface IntervalSchedule {
+  type: "interval";
+  intervalMs: number;
+}
+
+export type TaskSchedule = DailySchedule | IntervalSchedule | { type: string; [k: string]: unknown };
+
+const DAILY_TIME_RE = /^(\d{1,2}):(\d{2})$/;
+
+// Build a Date anchored to `now`'s local calendar day but at the
+// requested UTC wall-clock hour/minute. Using today's date (rather
+// than epoch 1970) makes the DST/TZ conversion accurate for the
+// viewer's current moment — "20:00 UTC every day" in Europe/London
+// can differ by an hour between summer and winter.
+function buildUtcInstant(utcHour: number, utcMinute: number, now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), utcHour, utcMinute));
+}
+
+// Intl formatter configured to surface HH:MM + the short timezone
+// name (e.g. "JST", "PDT"). When the browser can't resolve a zone
+// abbreviation it falls back to the offset string ("GMT+9"), which
+// is fine — the point is that the user doesn't have to mentally
+// convert from UTC.
+const LOCAL_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  timeZoneName: "short",
+});
+
+function extractHourMinuteTz(date: Date): { hourMinute: string; tzLabel: string } | null {
+  try {
+    const parts = LOCAL_TIME_FORMATTER.formatToParts(date);
+    const hour = parts.find((part) => part.type === "hour")?.value ?? "";
+    const minute = parts.find((part) => part.type === "minute")?.value ?? "";
+    const tzLabel = parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+    if (!hour || !minute) return null;
+    // Intl returns "24" for midnight hour under `hour: "2-digit"` on
+    // some runtimes — normalize so "Daily 24:00 JST" never appears.
+    const normalizedHour = hour === "24" ? "00" : hour;
+    return { hourMinute: `${normalizedHour}:${minute}`, tzLabel };
+  } catch {
+    return null;
+  }
+}
+
+// Convert a UTC "HH:MM" into "Daily HH:MM <tz>" in the viewer's
+// local zone. Returns the original "Daily HH:MM UTC" string if the
+// input is malformed or the Intl machinery is unavailable — callers
+// never see `null`/throw for a scheduler entry.
+export function formatDailyLocal(utcHHMM: string, now: Date = new Date()): string {
+  const match = DAILY_TIME_RE.exec(utcHHMM);
+  if (!match) return `Daily ${utcHHMM} UTC`;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute) || hour > 23 || minute > 59) {
+    return `Daily ${utcHHMM} UTC`;
+  }
+  const extracted = extractHourMinuteTz(buildUtcInstant(hour, minute, now));
+  if (!extracted) return `Daily ${utcHHMM} UTC`;
+  return `Daily ${extracted.hourMinute} ${extracted.tzLabel}`;
+}
+
+export function formatInterval(intervalMs: number): string {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) return "Every ?";
+  const mins = Math.round(intervalMs / 60_000);
+  if (mins >= 60) return `Every ${Math.round(mins / 60)}h`;
+  return `Every ${mins}m`;
+}
+
+export function formatSchedule(schedule: TaskSchedule, now: Date = new Date()): string {
+  if (schedule.type === "interval" && typeof (schedule as IntervalSchedule).intervalMs === "number") {
+    return formatInterval((schedule as IntervalSchedule).intervalMs);
+  }
+  if (schedule.type === "daily" && typeof (schedule as DailySchedule).time === "string") {
+    return formatDailyLocal((schedule as DailySchedule).time, now);
+  }
+  return JSON.stringify(schedule);
+}

--- a/test/plugins/scheduler/test_formatSchedule.ts
+++ b/test/plugins/scheduler/test_formatSchedule.ts
@@ -1,0 +1,89 @@
+// Tests for the UTC → local-timezone formatter used by TasksTab.vue.
+//
+// The scheduler engine stores daily triggers as "HH:MM" UTC, but a
+// user in Tokyo expects to see the same moment rendered in JST. These
+// tests pin the formatter's behaviour for both the conversion and
+// the graceful-degradation paths (malformed input, bad runtime).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatSchedule, formatDailyLocal, formatInterval } from "../../../src/plugins/scheduler/formatSchedule.js";
+
+// A fixed moment anchors the date portion of the UTC instant so DST
+// transitions don't make the assertions flap.
+const FIXED_NOW = new Date("2026-04-23T00:30:00Z");
+
+// `Intl.DateTimeFormat` picks up the host's timezone when the first
+// argument is `undefined`. Many CI runners use UTC; tests that assert
+// a non-UTC conversion override that by wrapping the formatter call.
+// Rather than spoofing process.env.TZ (unreliable on macOS workers),
+// we verify the conversion indirectly: any valid host TZ must at a
+// minimum produce a HH:MM pair and a non-empty TZ label.
+
+describe("formatDailyLocal", () => {
+  it("produces Daily HH:MM <tz> for a valid UTC input", () => {
+    const out = formatDailyLocal("20:00", FIXED_NOW);
+    assert.match(out, /^Daily \d{2}:\d{2} \S.+$/);
+  });
+
+  it("keeps the Daily ... UTC fallback for a malformed time", () => {
+    assert.equal(formatDailyLocal("not-a-time", FIXED_NOW), "Daily not-a-time UTC");
+    assert.equal(formatDailyLocal("99:99", FIXED_NOW), "Daily 99:99 UTC");
+    assert.equal(formatDailyLocal("", FIXED_NOW), "Daily  UTC");
+  });
+
+  it("normalizes hour 24 to 00 (some runtimes return '24' for midnight)", () => {
+    const out = formatDailyLocal("00:00", FIXED_NOW);
+    assert.ok(!out.startsWith("Daily 24:"), `got '${out}' — expected 00 not 24`);
+  });
+
+  it("uses the viewer's current date so DST transitions are respected", () => {
+    // The formatter anchors to `now` rather than a fixed epoch.
+    // Passing two different dates around a DST boundary can produce
+    // different outputs — we assert only that both calls succeed and
+    // format-check passes. (A full DST assertion would require
+    // forcing a specific host TZ, which is outside this test's scope.)
+    const march = new Date("2026-03-15T12:00:00Z");
+    const july = new Date("2026-07-15T12:00:00Z");
+    const outMar = formatDailyLocal("12:00", march);
+    const outJul = formatDailyLocal("12:00", july);
+    assert.match(outMar, /^Daily \d{2}:\d{2} \S.+$/);
+    assert.match(outJul, /^Daily \d{2}:\d{2} \S.+$/);
+  });
+});
+
+describe("formatInterval", () => {
+  it("rounds to hours once the interval crosses 60 minutes", () => {
+    assert.equal(formatInterval(60 * 60 * 1000), "Every 1h");
+    assert.equal(formatInterval(4 * 60 * 60 * 1000), "Every 4h");
+  });
+
+  it("keeps sub-hour intervals in minutes", () => {
+    assert.equal(formatInterval(5 * 60 * 1000), "Every 5m");
+    assert.equal(formatInterval(30 * 60 * 1000), "Every 30m");
+  });
+
+  it("handles invalid input gracefully", () => {
+    assert.equal(formatInterval(0), "Every ?");
+    assert.equal(formatInterval(-1000), "Every ?");
+    assert.equal(formatInterval(Number.NaN), "Every ?");
+  });
+});
+
+describe("formatSchedule", () => {
+  it("dispatches to the daily formatter for daily schedules", () => {
+    const out = formatSchedule({ type: "daily", time: "23:00" }, FIXED_NOW);
+    assert.match(out, /^Daily \d{2}:\d{2} \S.+$/);
+  });
+
+  it("dispatches to the interval formatter for interval schedules", () => {
+    assert.equal(formatSchedule({ type: "interval", intervalMs: 3_600_000 }, FIXED_NOW), "Every 1h");
+  });
+
+  it("stringifies unknown shapes as-is so the user can still see what came down the wire", () => {
+    // JSON.stringify returns identical output, just asserting the
+    // fallback exists so a future refactor can't silently drop it.
+    const out = formatSchedule({ type: "cron", cron: "0 * * * *" }, FIXED_NOW);
+    assert.ok(out.includes("cron"));
+  });
+});


### PR DESCRIPTION
## Summary

スケジューラ UI で \`Daily 20:00 UTC\` と表示されていた行を、**ブラウザのローカル TZ** に変換して表示するよう修正。

例 (東京からの閲覧):

| Task | Before | After |
|---|---|---|
| 毎日のニュースまとめ | \`Daily 20:00 UTC\` | \`Daily 05:00 GMT+9\` |
| Journal daily pass | \`Daily 23:00 UTC\` | \`Daily 08:00 GMT+9\` |

スケジューラエンジン側は引き続き \`HH:MM\` UTC で発火するので動作変更はゼロ、表示だけ。

## Items to Confirm / Review

- **TZ 略称の揺れ**: \`Intl.DateTimeFormat\` の default locale だと Node/Chrome によって \`JST\` か \`GMT+9\` を返す。見やすさは \`ja-JP\` locale 固定の方が良い (\`JST\` 表示) が、他の言語話者には読みづらくなるので default に任せています。必要なら locale を固定してください。
- **Frequency Hints テーブル**: これも文字列ハードコードで UTC 固定だったので、構造化スケジュール (\`{ type: "daily", time: "23:00" }\`) に直して実タスクと同じ formatter を通すようにしました。
- **ユーザー目線の実装方針**: 今回は表示のみの変換。もし「ユーザが JST で 05:00 と指定したら裏で 20:00 UTC に変換して保存」まで行いたいなら別 PR でフォローアップ (agent の tool parameter 仕様変更が絡むので大きめの作業)。

## User Prompt

> Daily 20:00 UTC タスクのtimezoneがutcになっていた。日本にいるからJST.ブラウザ見える？

## Verification

- \`yarn typecheck\` 全ワークスペース通過
- \`yarn lint\` 0 errors
- \`yarn build\` 通過
- 新規ユニットテスト 10 件 pass (\`test/plugins/scheduler/test_formatSchedule.ts\`)
- Smoke test:
  \`\`\`
  TZ=Asia/Tokyo tsx -e '...formatDailyLocal("20:00")...' → "Daily 05:00 GMT+9"
  TZ=Asia/Tokyo tsx -e '...formatDailyLocal("00:00")...' → "Daily 09:00 GMT+9"
  \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)