### PR TITLE
fix(e2e): deflake Safari IME Enter test (collapse into single evaluate)

### DIFF
--- a/e2e/tests/ime-enter.spec.ts
+++ b/e2e/tests/ime-enter.spec.ts
@@ -13,41 +13,34 @@ import { test, expect } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 import { chatInput, fillChatInput } from "../fixtures/chat";
 
-// Dispatch a composition event on the textarea.
-async function dispatchComposition(textarea: ReturnType<typeof chatInput>, type: "compositionstart" | "compositionend") {
-  await textarea.evaluate((elem, eventType) => elem.dispatchEvent(new CompositionEvent(eventType, { bubbles: true })), type);
-}
+// The events in a real IME confirmation arrive within microseconds of
+// each other (same JS microtask in Safari). Every `await
+// page.evaluate(...)` hop crosses the test-runner ↔ browser boundary,
+// which in CI can exceed the composable's 30 ms race window. So we
+// dispatch whole sequences inside a single `evaluate` — one hop, one
+// JS turn, deterministic timing regardless of CI load.
 
-// Dispatch a keydown Enter on the textarea.
-async function dispatchEnterKeydown(textarea: ReturnType<typeof chatInput>, opts: { isComposing?: boolean } = {}) {
-  await textarea.evaluate(
-    (elem, options) =>
-      elem.dispatchEvent(
-        new KeyboardEvent("keydown", {
-          key: "Enter",
-          code: "Enter",
-          isComposing: options.isComposing ?? false,
-          bubbles: true,
-          cancelable: true,
-        }),
-      ),
-    opts,
-  );
-}
+type ImeStep = { kind: "composition"; type: "compositionstart" | "compositionend" } | { kind: "keydown"; isComposing: boolean; shiftKey?: boolean };
 
-// Dispatch a Shift+Enter keydown on the textarea.
-async function dispatchShiftEnterKeydown(textarea: ReturnType<typeof chatInput>) {
-  await textarea.evaluate((elem) =>
-    elem.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        key: "Enter",
-        code: "Enter",
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    ),
-  );
+async function dispatchImeSequence(textarea: ReturnType<typeof chatInput>, steps: readonly ImeStep[]) {
+  await textarea.evaluate((elem, stepList) => {
+    for (const step of stepList) {
+      if (step.kind === "composition") {
+        elem.dispatchEvent(new CompositionEvent(step.type, { bubbles: true }));
+      } else {
+        elem.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            code: "Enter",
+            isComposing: step.isComposing,
+            shiftKey: step.shiftKey ?? false,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      }
+    }
+  }, steps);
 }
 
 test.describe("IME Enter handling", () => {
@@ -80,12 +73,15 @@ test.describe("IME Enter handling", () => {
     const input = chatInput(page);
     await fillChatInput(page, "テスト");
 
-    // Chrome order: compositionstart → keydown(Enter, isComposing=true) → compositionend
-    await dispatchComposition(input, "compositionstart");
-    await dispatchEnterKeydown(input, { isComposing: true });
-    await dispatchComposition(input, "compositionend");
+    // Chrome order: compositionstart → keydown(Enter, isComposing=true) → compositionend.
+    // The `isComposing: true` flag alone blocks the send; no timing
+    // dependency here, but we still batch for consistency.
+    await dispatchImeSequence(input, [
+      { kind: "composition", type: "compositionstart" },
+      { kind: "keydown", isComposing: true },
+      { kind: "composition", type: "compositionend" },
+    ]);
 
-    // Wait a tick to ensure no async send was queued.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
   });
@@ -94,11 +90,17 @@ test.describe("IME Enter handling", () => {
     const input = chatInput(page);
     await fillChatInput(page, "テスト");
 
-    // Safari order: compositionstart → compositionend → keydown(Enter, isComposing=false)
-    // The keydown follows compositionend synchronously (within the 30ms race window).
-    await dispatchComposition(input, "compositionstart");
-    await dispatchComposition(input, "compositionend");
-    await dispatchEnterKeydown(input, { isComposing: false });
+    // Safari order: compositionstart → compositionend → keydown(Enter, isComposing=false).
+    // The composable's 30 ms post-compositionend race window is what
+    // suppresses the send. We batch inside one evaluate() so the gap
+    // between compositionend and keydown is microseconds (same JS
+    // turn) rather than a full round-trip, which in slow CI webkit
+    // can exceed 30 ms and flake this test.
+    await dispatchImeSequence(input, [
+      { kind: "composition", type: "compositionstart" },
+      { kind: "composition", type: "compositionend" },
+      { kind: "keydown", isComposing: false },
+    ]);
 
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
@@ -108,16 +110,18 @@ test.describe("IME Enter handling", () => {
     const input = chatInput(page);
     await fillChatInput(page, "テスト");
 
-    // Complete an IME sequence first (Safari order).
-    await dispatchComposition(input, "compositionstart");
-    await dispatchComposition(input, "compositionend");
-    await dispatchEnterKeydown(input, { isComposing: false });
+    // Complete an IME sequence first (Safari order), atomically.
+    await dispatchImeSequence(input, [
+      { kind: "composition", type: "compositionstart" },
+      { kind: "composition", type: "compositionend" },
+      { kind: "keydown", isComposing: false },
+    ]);
 
-    // Wait past the 30ms race window, then send a real Enter.
+    // Wait past the 30 ms race window, then send a real Enter.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
 
-    await dispatchEnterKeydown(input, { isComposing: false });
+    await dispatchImeSequence(input, [{ kind: "keydown", isComposing: false }]);
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(1);
   });
@@ -126,7 +130,7 @@ test.describe("IME Enter handling", () => {
     const input = chatInput(page);
     await fillChatInput(page, "改行テスト");
 
-    await dispatchShiftEnterKeydown(input);
+    await dispatchImeSequence(input, [{ kind: "keydown", isComposing: false, shiftKey: true }]);
 
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);


### PR DESCRIPTION
## Summary

CI で定期的に落ちていた \`Safari IME: compositionstart → compositionend → keydown\` テストの flaky を恒久修正。

## Root cause

テストは「\`compositionend\` 後 30ms 以内に来る Enter keydown を useImeAwareEnter が抑制すること」を検証している。だが元のテストは:

\`\`\`ts
await dispatchComposition(input, "compositionstart");  // hop 1
await dispatchComposition(input, "compositionend");    // hop 2
await dispatchEnterKeydown(input, { isComposing: false }); // hop 3
\`\`\`

と **3 回独立した \`page.evaluate()\`** を await していた。1 hop あたり CI (特に webkit) では 20-100ms かかることがあり、\`compositionend\` と \`keydown\` の間が 30ms を超えると composable が正しく抑制しない → send が飛ぶ → テスト失敗。

実際の Safari は IME 確定時に 3 イベントを**同じ microtask 内 (microseconds)** で発火する。テストもそれに合わせて**単一 \`page.evaluate()\` 内で連続 dispatch** する形に変更。

## Changes

\`e2e/tests/ime-enter.spec.ts\` だけ。3 つの \`dispatch*\` ヘルパを 1 つの \`dispatchImeSequence(textarea, steps)\` に統合し、各テストが \`composition → composition → keydown\` のような step 配列を渡す形に書き換え。ヘルパ内部は単一 \`evaluate()\` の中で同期的に全イベントを発火するので、hop 間隔による flaky が発生しない。

composable 側 (\`useImeAwareEnter.ts\`) の 30 ms 定数は実機の Safari 挙動と一致しているので触らない。

## Items to Confirm / Review

- Chrome-order テストは \`isComposing: true\` flag だけで抑制されるので元々 timing 依存ではないが、一貫性のため同じヘルパに乗せた。挙動は変わらない。
- Shift+Enter / normal-Enter-after-IME 系もヘルパ化のみで、assertion は変更なし。

## User Prompt

> #657 (scheduler UI local tz): ... e2e のみ fail — ただし中身は既知 flaky の webkit Safari IME タイミングテスト (30ms race window) で … って、ちょくちょくもんだいになるけど、なんか修正できない？テストが失敗しないように。

## Verification

- \`yarn test:e2e e2e/tests/ime-enter.spec.ts\` — 全 project × 4 テスト pass
- \`yarn test:e2e e2e/tests/ime-enter.spec.ts --repeat-each=5\` で stress test → **40/40 green** (webkit の Safari-order 含む)
- \`yarn typecheck\` / \`yarn lint\` (0 errors) / \`yarn build\` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)