### PR TITLE
chore(slack): bump @mulmobridge/slack to 0.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Changed
 
+- `@mulmobridge/slack` (v0.2.0 → **v0.3.0**) — `SLACK_SESSION_GRANULARITY=thread` now auto-creates a Slack thread on the first bot reply to a top-level channel post. Users firing off multiple unrelated top-level messages get one thread per topic — replies no longer interleave at channel level. `channel` (default) and `auto` modes are unchanged. DMs are intentionally unaffected. Operators already on `thread` mode will see more threading on upgrade (#661, closes #658).
 - `@mulmobridge/client` (v0.1.1 → **v0.1.2**) — Patch release that exports the shared `chunkText` helper from `./text`. Required by every new bridge (mastodon, bluesky, chatwork, xmpp, rocketchat, signal, teams, webhook, twilio-sms, email, line-works, nostr, viber); without it, their `npx` invocations fail at runtime because they depend on `^0.1.0`.
 - `@mulmobridge/mock-server` (v0.1.0 → **v0.1.1**) — Patch release. Internal refactor of `handlers.ts` / `server.ts` + README catch-up listing all supported platforms.
 - `@mulmobridge/relay` (v0.1.0 → **v0.2.0**) — Minor release adding four new platform plugins:
@@ -53,6 +54,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 - `@mulmobridge/line-works@0.1.0`
 - `@mulmobridge/nostr@0.1.0`
 - `@mulmobridge/viber@0.1.0`
+- `@mulmobridge/slack@0.3.0`
 
 ---
 

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/slack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Slack bridge for MulmoBridge — connect a Slack bot to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `@mulmobridge/slack` from 0.2.0 to **0.3.0** (minor — behaviour change in \`thread\` mode).
- Adds the release entry to \`docs/CHANGELOG.md\` under the current \`[Unreleased]\` cycle.

## Items to Confirm / Review

1. **Version bump level** — 0.2.0 → 0.3.0 (minor). Reasoning: \`SLACK_SESSION_GRANULARITY=thread\` now changes behaviour for existing operators (bot replies always land in a thread). Default \`channel\` mode is unchanged, so end users on the default get a silent upgrade. Minor, not patch, because of the visible behaviour change on thread mode; not major because pre-1.0 + opt-in env var.
2. **CHANGELOG entry placement** — added under the existing \`[Unreleased]\` cycle's \`### Changed\` list and appended the package to \`### Packages published during this cycle\`. If we'd rather split this into its own Unreleased block separate from the bridge-expansion batch, happy to restructure.

## User Prompt

> マージした。publish & release

(Following merge of #661.)

## Implementation approach

Single-commit PR: \`packages/bridges/slack/package.json\` version bump + \`docs/CHANGELOG.md\` entry. After merge I'll:

1. \`npm publish --access public\` from \`packages/bridges/slack/\`
2. Tag \`@mulmobridge/slack@0.3.0\` (no \`v\` prefix)
3. \`gh release create --latest=false\` with highlights prepended to auto-generated notes

## Test plan

- [x] \`yarn install\` — clean
- [x] \`yarn format\` — clean
- [x] \`yarn typecheck\` — clean across all workspaces
- [x] \`yarn build\` — clean
- [x] \`yarn workspace @mulmobridge/slack test\` — 31 tests pass (done pre-merge in #661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)