### PR TITLE
fix(history): browser back from /chat/:id returns to /history (revert replace-on-select)

### DIFF
--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -50,23 +50,21 @@ test.describe("history panel (useSessionHistory)", () => {
     await expect(page.getByTestId(`session-item-${SESSION_B.id}`)).toBeVisible();
   });
 
-  test("clicking a session from /history replaces /history in browser history", async ({ page }) => {
-    // Selecting a session while on /history should replace the
-    // /history entry, so browser back goes to whatever was before
-    // /history — not back to the panel. This preserves intuitive
-    // session-to-session back/forward when the user jumps between
-    // sessions via history.
+  test("browser back from /chat/:id after selecting returns to /history", async ({ page }) => {
+    // /history is a real page in browser history. After selecting a
+    // session from the panel, back should return to /history (not
+    // skip over it) — that matches the mental model of "I visited
+    // the history page, clicked a session, now go back".
     await page.goto("/chat");
-    await page.waitForURL(/\/chat\//);
-    const priorUrl = page.url();
-
     await page.getByTestId("history-btn").click();
     await expect(page).toHaveURL(/\/history$/);
     await page.getByTestId(`session-item-${SESSION_A.id}`).click();
     await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
 
     await page.goBack();
-    await expect(page).toHaveURL(priorUrl);
+    await expect(page).toHaveURL(/\/history$/);
+    // Panel re-renders with the session list.
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
   });
 
   test("second click on history button (while on /history) goes back to prior page", async ({ page }) => {

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -56,6 +56,9 @@ test.describe("history panel (useSessionHistory)", () => {
     // skip over it) — that matches the mental model of "I visited
     // the history page, clicked a session, now go back".
     await page.goto("/chat");
+    // Wait for the /chat → /chat/<newId> redirect before opening
+    // history — clicking mid-bootstrap makes the stack timing-dependent.
+    await page.waitForURL(/\/chat\//);
     await page.getByTestId("history-btn").click();
     await expect(page).toHaveURL(/\/history$/);
     await page.getByTestId(`session-item-${SESSION_A.id}`).click();

--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -38,7 +38,11 @@ test.describe("session navigation via URL", () => {
     expect(page.url()).toContain(SESSION_A.id);
   });
 
-  test("browser back returns to the previous session", async ({ page }) => {
+  test("browser back returns to the previous session (via /history)", async ({ page }) => {
+    // /history is a real page route, so navigating between sessions
+    // via the history panel leaves /history entries in browser
+    // history. Stack after two selects: [..., /history, /chat/A,
+    // /history, /chat/B]. One back → /history; another back → /chat/A.
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
 
@@ -52,15 +56,20 @@ test.describe("session navigation via URL", () => {
     await page.locator(`[data-testid="session-item-${SESSION_B.id}"]`).click();
     await page.waitForURL(new RegExp(SESSION_B.id));
 
-    // Back → session A
+    // Back → /history (the panel we opened to pick B)
+    await page.goBack();
+    await page.waitForURL(/\/history$/);
+
+    // Back → /chat/A
     await page.goBack();
     await page.waitForURL(new RegExp(SESSION_A.id));
   });
 
   test("browser forward works after going back", async ({ page }) => {
-    // Navigate through two real (non-empty) sessions so both are in
-    // browser history — the initial empty session is intentionally
-    // replaced out of history by removeCurrentIfEmpty.
+    // With /history as a real page route, the stack after two
+    // session selects is [..., /history, /chat/A, /history, /chat/B].
+    // Going back twice lands on /chat/A via /history; going forward
+    // twice returns through /history to /chat/B.
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
 
@@ -72,11 +81,15 @@ test.describe("session navigation via URL", () => {
     await page.locator(`[data-testid="session-item-${SESSION_B.id}"]`).click();
     await page.waitForURL(new RegExp(SESSION_B.id));
 
-    // Back → session A
+    // Back twice → session A (via /history)
+    await page.goBack();
+    await page.waitForURL(/\/history$/);
     await page.goBack();
     await page.waitForURL(new RegExp(SESSION_A.id));
 
-    // Forward → session B
+    // Forward twice → session B (via /history)
+    await page.goForward();
+    await page.waitForURL(/\/history$/);
     await page.goForward();
     await page.waitForURL(new RegExp(SESSION_B.id));
   });

--- a/plans/feat-history-url-route.md
+++ b/plans/feat-history-url-route.md
@@ -96,16 +96,15 @@ watch(currentPage, (page) => {
 
 ### Browser-history semantics
 
-Clicking a session while on `/history` uses `router.replace` (not `push`), swapping the `/history` entry for `/chat/:id`. This keeps session-to-session back/forward working intuitively — `back` from a session you picked via history goes to whatever you were doing before opening history, not back to the panel. If users want the panel again, they click the history button (one click, one push).
-
-Direct-link `/history` still works (it's a real bookmarkable URL); only the replace-on-select changes the stack behavior.
+`/history` is a real page route. Clicking a session pushes `/chat/:id` on top of `/history`, so browser back from the chat returns to `/history` (re-renders the panel). This matches the mental model of "I visited the history page, clicked a session, now go back". Session-to-session navigation via the panel leaves `/history` entries in the stack between sessions — going back through them is a deliberate trace of how the user got there.
 
 ## Test plan
 
 - Manual
   - Click history button on `/chat/<id>` → URL flips to `/history`, panel renders inline
-  - Click a session card → URL flips to `/chat/<id>` (replaces `/history` in the stack)
-  - Browser back → returns to the chat you were on before opening history
+  - Click a session card → URL flips to `/chat/<id>`
+  - Browser back → returns to `/history` (panel re-renders)
+  - Browser back again → returns to the prior chat
   - Direct-link `/history` → panel opens with fetched sessions
   - On `/history`, click history button again → `router.back()` goes to prior page
 - Existing e2e for session history still green (modal-style interactions updated for the route-based flow)

--- a/src/App.vue
+++ b/src/App.vue
@@ -609,10 +609,7 @@ async function loadSession(sessionId: string) {
   // instead of silently no-opping.
   const alreadyOnThatChat = sessionId === currentSessionId.value && sessionMap.has(sessionId) && route.params.sessionId === sessionId;
   if (alreadyOnThatChat) return;
-  // Clicking a session from /history should replace the /history
-  // entry — otherwise browser back lands on /history instead of the
-  // previous session, breaking session-to-session back/forward.
-  const replaced = removeCurrentIfEmpty() || route.name === PAGE_ROUTES.history;
+  const replaced = removeCurrentIfEmpty();
 
   const live = sessionMap.get(sessionId);
   if (live) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -609,7 +609,13 @@ async function loadSession(sessionId: string) {
   // instead of silently no-opping.
   const alreadyOnThatChat = sessionId === currentSessionId.value && sessionMap.has(sessionId) && route.params.sessionId === sessionId;
   if (alreadyOnThatChat) return;
-  const replaced = removeCurrentIfEmpty();
+  // Mirror createNewSession: only replace when we just discarded an
+  // empty session AND we're on that /chat/:emptyId URL. On /history
+  // (or any non-chat page) selecting a session must push, otherwise
+  // the /history entry would be skipped when the last chat happened
+  // to be empty.
+  const removedEmpty = removeCurrentIfEmpty();
+  const replaced = removedEmpty && isChatPage.value;
 
   const live = sessionMap.get(sessionId);
   if (live) {


### PR DESCRIPTION
## Summary
Fixes a UX regression reported on #659: navigating `chat → /history → click session → /chat/:id → browser back` was skipping `/history` and landing on the chat *before* `/history`. Now back correctly returns to `/history` (panel re-renders).

## Items to Confirm / Review
- **This reverts the `replace`-on-session-select logic I added in #659.** That was a deliberate choice to keep session-to-session back/forward clean when bouncing between sessions via the panel. But it sacrificed the "I visited a page, now go back to it" mental model for `/history`, which is the more important one (and the one you noticed).
- **Session-to-session back/forward via the panel now takes two backs** (one to `/history`, one to the prior session). Router-navigation tests are updated to reflect this — see `e2e/tests/router-navigation.spec.ts`. Worth confirming this is the right tradeoff vs. trying to be smart about which pushes get swallowed.
- No changes to direct-link `/history`, history-button second-click, or the `handleHistoryClick` direct-link fallback added in the earlier review fix — all still work as before.

## User Prompt
> とりこんだんだけど、chat -> history -> chatと移動してブラウザバックしてもhistoryにならないよ

## Implementation
- `src/App.vue` `loadSession`: drop the `|| route.name === PAGE_ROUTES.history` clause so session selects use `router.push` uniformly (not `replace` when coming from `/history`).
- `e2e/tests/history-panel.spec.ts`: restore the "browser back from /chat/:id after selecting returns to /history" test (was previously rewritten to assert the opposite).
- `e2e/tests/router-navigation.spec.ts`: update "browser back returns to the previous session" and "browser forward works after going back" to account for `/history` sitting between sessions in the stack — one more `goBack()` / `goForward()` to traverse `/history`.
- `plans/feat-history-url-route.md`: update the browser-history-semantics section.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (pre-existing v-html warnings only)
- [x] `yarn format` clean
- [x] `yarn test:e2e` — all 303 tests pass
- [ ] Manual: `/chat` → history → click session → browser back → returns to `/history` with panel rendered
- [ ] Manual: `/chat` → history → click session A → history → click session B → back → `/history` → back again → `/chat/A`
- [ ] Manual: direct-link `/history` → panel opens; history button closes to `/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser back/forward navigation behavior when switching between the history panel and chat sessions.

* **Tests**
  * Updated navigation tests to validate proper browser history handling with the history panel route integration.

* **Documentation**
  * Clarified browser navigation semantics for the history panel feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->