### PR TITLE
feat(ui): make MulmoClaude logo/title click resume latest chat

### DIFF
--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -27,6 +27,38 @@ test.describe("session navigation via URL", () => {
     expect(page.url()).toMatch(/\/chat\/[\w-]+/);
   });
 
+  test("clicking the app home button keeps the current empty session when there is no history", async ({ page }) => {
+    await page.route(
+      (url) => url.pathname === "/api/sessions",
+      (route) => {
+        if (route.request().method() === "GET") {
+          return route.fulfill({
+            json: { sessions: [], cursor: "v1:0", deletedIds: [] },
+          });
+        }
+        return route.fallback();
+      },
+    );
+
+    await page.route(
+      (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+      (route) => {
+        if (route.request().method() === "POST") {
+          return route.fulfill({ json: { ok: true } });
+        }
+        return route.fulfill({ status: 404, json: { error: "not found" } });
+      },
+    );
+
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+    const initialUrl = page.url();
+
+    await page.getByTestId("app-home-btn").click();
+
+    await expect(page).toHaveURL(initialUrl);
+  });
+
   test("clicking a session in history changes the URL", async ({ page }) => {
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);

--- a/src/App.vue
+++ b/src/App.vue
@@ -574,6 +574,11 @@ function onRoleChange() {
 async function resumeOrCreateChatSession(): Promise<void> {
   const topId = mergedSessions.value[0]?.id;
   if (!topId) {
+    const currentSession = sessionMap.get(currentSessionId.value);
+    if (currentSession && currentSession.toolResults.length === 0) {
+      navigateToSession(currentSession.id);
+      return;
+    }
     createNewSession();
     return;
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
           @notification-navigate="handleNotificationNavigate"
           @toggle-right-sidebar="toggleRightSidebar"
           @open-settings="showSettings = true"
+          @home="handleHomeClick"
         />
         <div class="flex-1 min-w-0">
           <PluginLauncher :active-tool-name="selectedResult?.toolName ?? null" :active-view-mode="currentPage" @navigate="onPluginNavigate" />
@@ -434,6 +435,10 @@ function handleSessionSelect(sessionId: string): void {
 
 function handleNewSessionClick(): void {
   createNewSession();
+}
+
+function handleHomeClick(): void {
+  resumeOrCreateChatSession().catch((err) => console.error("[home] resume failed:", err));
 }
 
 const rightSidebarRef = ref<InstanceType<typeof RightSidebar> | null>(null);

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="flex items-center gap-2">
-    <img :src="logoUrl" alt="" class="h-[50px] w-auto -my-3.5 -ml-3 rounded object-contain shrink-0" />
-    <h1 data-testid="app-title" class="text-sm font-semibold text-gray-800 mr-1" :style="titleStyle">MulmoClaude</h1>
+    <button
+      type="button"
+      class="flex items-center gap-2 -my-1 -ml-1 py-1 pl-1 pr-2 rounded hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+      data-testid="app-home-btn"
+      :title="t('sidebarHeader.home')"
+      :aria-label="t('sidebarHeader.home')"
+      @click="emit('home')"
+    >
+      <img :src="logoUrl" alt="" class="h-[50px] w-auto -my-3.5 -ml-3 rounded object-contain shrink-0" />
+      <h1 data-testid="app-title" class="text-sm font-semibold text-gray-800 mr-1" :style="titleStyle">MulmoClaude</h1>
+    </button>
     <div class="flex gap-2">
       <LockStatusPopup
         ref="lockPopup"
@@ -56,6 +65,7 @@ const emit = defineEmits<{
   notificationNavigate: [action: NotificationPayload["action"]];
   toggleRightSidebar: [];
   openSettings: [];
+  home: [];
 }>();
 
 const lockPopupOpen = ref(false);

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -55,6 +55,7 @@ const deMessages = {
     dismiss: "Verwerfen",
   },
   sidebarHeader: {
+    home: "Zum neuesten Chat",
     toolCallHistory: "Tool-Aufrufverlauf",
     settings: "Einstellungen",
   },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -77,6 +77,7 @@ const enMessages = {
     dismiss: "Dismiss",
   },
   sidebarHeader: {
+    home: "Go to latest chat",
     toolCallHistory: "Tool call history",
     settings: "Settings",
   },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -60,6 +60,7 @@ const esMessages = {
     dismiss: "Descartar",
   },
   sidebarHeader: {
+    home: "Ir al chat más reciente",
     toolCallHistory: "Historial de llamadas a herramientas",
     settings: "Ajustes",
   },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -55,6 +55,7 @@ const frMessages = {
     dismiss: "Ignorer",
   },
   sidebarHeader: {
+    home: "Aller à la dernière conversation",
     toolCallHistory: "Historique des appels d'outils",
     settings: "Paramètres",
   },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -62,6 +62,7 @@ const jaMessages = {
     dismiss: "閉じる",
   },
   sidebarHeader: {
+    home: "最新のチャットに移動",
     toolCallHistory: "ツール呼び出し履歴",
     settings: "設定",
   },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -62,6 +62,7 @@ const koMessages = {
     dismiss: "닫기",
   },
   sidebarHeader: {
+    home: "최신 채팅으로 이동",
     toolCallHistory: "도구 호출 기록",
     settings: "설정",
   },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -55,6 +55,7 @@ const ptBRMessages = {
     dismiss: "Dispensar",
   },
   sidebarHeader: {
+    home: "Ir para o chat mais recente",
     toolCallHistory: "Histórico de chamadas de ferramentas",
     settings: "Configurações",
   },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -60,6 +60,7 @@ const zhMessages = {
     dismiss: "关闭",
   },
   sidebarHeader: {
+    home: "前往最新对话",
     toolCallHistory: "工具调用历史",
     settings: "设置",
   },


### PR DESCRIPTION
## Summary

- Clicking the MulmoClaude logo + wordmark in the top bar now calls `resumeOrCreateChatSession()` — the same "land on latest chat" behaviour that `Cmd+1` provides from non-chat pages. Navigation goes through `router.push()`, so browser back/forward keeps working from any page (files, todos, wiki, …) back to the previous view.
- Adds a new `sidebarHeader.home` i18n key across all 8 locales.

## Items to Confirm / Review

1. **Rescue from PR #645** — this commit (cherry-picked from `4cbb1a9a`) was originally written on the `feat/i18n-readme-translations` branch but got pushed after #645 was already merged, so it never made it onto main. Re-landing here as its own PR.
2. **Conflict resolution** — cherry-pick conflicted on `src/App.vue` because a composable refactor on main removed the `watch(showHistory, …)` block that the original commit had sat next to. Kept only the `handleHomeClick` function; dropped the watch re-add.
3. **i18n key added across all 8 locales** in the same PR, per the CLAUDE.md i18n lockstep rule introduced earlier. Translations: `Go to latest chat` / 最新のチャットに移動 / 前往最新对话 / 최신 채팅으로 이동 / Ir al chat más reciente / Ir para o chat mais recente / Aller à la dernière conversation / Zum neuesten Chat.

## User Prompt

> ページ上部の MulmoClaude とアイコンを押すと、最新のchatに移動してほしい。/にいどうすればよいかな
>
> historyでいどうできるように気を使ってね

User confirmed the approach (call `resumeOrCreateChatSession()` via router.push, not a hard redirect to `/`), and later noticed the feature was missing from main and asked for status.

## Implementation

- `src/components/SidebarHeader.vue` — wraps the logo `<img>` + title `<h1>` in a `<button type="button" @click="emit('home')">` with `title` / `aria-label` bound to `t("sidebarHeader.home")`, focus-visible ring for keyboard nav.
- `src/App.vue` — listens for `@home` and dispatches to a new `handleHomeClick()` wrapping `resumeOrCreateChatSession()`. Same behaviour as the existing Cmd+1 path from non-chat pages — reuses the exact function, so session resumption logic stays single-sourced.
- All 8 locale files — new `sidebarHeader.home` key.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (0 errors, 4 pre-existing `vue/no-v-html` warnings)
- [x] `yarn typecheck` clean across all workspaces
- [x] `yarn build` succeeds
- [ ] Manual smoke (reviewer): from /files or /wiki, click the MulmoClaude logo → lands on most recent /chat session; browser back returns to /files
- [ ] Manual smoke (reviewer): with no chat history, clicking the logo creates a new session
- [ ] Manual smoke (reviewer): while viewing an older session on /chat, clicking logo jumps to the most recent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a home button to the sidebar header that navigates to the latest chat session, with full localization support across eight languages (English, German, Spanish, French, Japanese, Korean, Portuguese, and Simplified Chinese).

* **Tests**
  * Added end-to-end test validating home button navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->