### PR TITLE
chore: release v0.4.0 (CHANGELOG + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,36 +8,93 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-04-23
+
+### Highlights
+
+- **13 new messaging bridges** bring the total bridge count to 20+ — bots can now talk to Mastodon, Bluesky, Chatwork, XMPP / Jabber, Rocket.Chat, Signal, Microsoft Teams, Viber, LINE Works, Nostr, plus three generic connectors (Webhook / Twilio SMS / IMAP-SMTP Email).
+- **Path-based URLs** for Wiki (`/wiki/index`, `/wiki/pages/<slug>`), Files (`/files/<path>`), History (`/history`), and Chat (`/chat/:id`, lands on the latest session when naked). Back/forward/bookmark work everywhere; the browser history IS the navigation source of truth.
+- **Internationalization goes live** — vue-i18n skeleton (#559), auto-detect locale from the browser, and **8 locales** ship out of the box (en, ja, zh, ko, es, pt-BR, fr, de). Dozens of components had hard-coded strings extracted into the locale files across 17 extraction batches.
+- **Agent respects the user's timezone** — requests now carry the browser's IANA zone, and the system prompt tells the model to interpret bare times ("15:00") in that zone without re-asking every turn. Scheduler UI mirrors the change — daily triggers render in the viewer's local zone (`Daily 05:00 GMT+9`) instead of UTC.
+- **Favicon rebuilt around the mascot** (#470 follow-up): mascot logo in the rounded frame, background color carries state (idle / running / done / error), red dot surfaces **any** unread session, not just the active one.
+- **Dev-server port fallback** — `yarn dev` no longer crashes when 3001 is already in use; the walk-forward logic from `npx mulmoclaude` now lives in a shared `server/utils/port.mjs` and drives both entry points.
+
 ### Added
 
-- `@mulmobridge/mastodon` (v0.1.0) — Mastodon bridge. Subscribes to the user notification stream (WebSocket), handles DMs and optionally public mentions, inherits visibility on reply, forwards image attachments.
-- `@mulmobridge/bluesky` (v0.1.0) — Bluesky bridge. Polls `chat.bsky.convo.getLog` via the atproto-proxy header, forwards DMs, auto-refreshes the session JWT on 401.
-- `@mulmobridge/chatwork` (v0.1.0) — Chatwork bridge (Japanese business chat). Polls unread messages per room via REST, sends replies back, strips Chatwork markup before forwarding.
-- `@mulmobridge/xmpp` (v0.1.0) — XMPP / Jabber bridge. Connects with JID + password to any XMPP server over TLS, handles `type=chat` message stanzas.
-- `@mulmobridge/rocketchat` (v0.1.0) — Rocket.Chat bridge. Polls the bot's DM rooms via REST with personal access token auth; chunked replies.
-- `@mulmobridge/signal` (v0.1.0) — Signal bridge. Talks to a locally running [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) daemon over WebSocket (receive) + REST (send); number-based allowlist.
-- `@mulmobridge/teams` (v0.1.0) — Microsoft Teams bridge via Bot Framework (`botbuilder` SDK). Webhook receiver + Azure AD JWT validation; conversation-reference cache for push delivery; AAD object-id allowlist. **Requires a public URL** — Teams endpoint validation is strict.
-- `@mulmobridge/webhook` (v0.1.0) — Generic HTTP webhook bridge. POST JSON to `/webhook`, get the AI reply in the response body. Optional `x-webhook-secret` header for auth. Developer glue for cron jobs, Zapier / n8n, Home Assistant, etc.
-- `@mulmobridge/twilio-sms` (v0.1.0) — SMS bridge via Twilio Programmable Messaging. Inbound webhook with `X-Twilio-Signature` HMAC-SHA1 verification; outbound via Twilio REST API. Number-based allowlist.
-- `@mulmobridge/email` (v0.1.0) — Email bridge. IMAP poll for unread mail, SMTP reply with threading preserved (`In-Reply-To` + `References`). Uses `imapflow` + `mailparser` + `nodemailer`. Sender allowlist.
-- `@mulmobridge/line-works` (v0.1.0) — LINE Works (enterprise LINE) bridge. Service-account JWT → OAuth access token (auto-refresh); webhook signature verification via bot secret; sends via Bot Message API. Separate from consumer LINE.
-- `@mulmobridge/nostr` (v0.1.0) — Nostr encrypted DM bridge. Subscribes to kind=4 events tagged to the bot pubkey on multiple relays; NIP-04 decrypt + sign-and-broadcast replies. Hex / nsec key input; pubkey allowlist.
-- `@mulmobridge/viber` (v0.1.0) — Viber Public Account bot bridge. Inbound webhook with `X-Viber-Content-Signature` HMAC-SHA256; outbound via Viber REST. Swapped in for KakaoTalk (deferred due to 5 s sync webhook timeout).
+- **Bridges** (13 new; all new packages, `v0.1.0` each):
+  - `@mulmobridge/mastodon` — subscribes to the user notification stream (WebSocket), handles DMs and optionally public mentions, inherits visibility on reply, forwards image attachments, chained thread replies for long output, proactive direct-visibility push mentions the recipient.
+  - `@mulmobridge/bluesky` — polls `chat.bsky.convo.getLog` via the atproto-proxy header, forwards DMs, auto-refreshes the session JWT on 401, cursor-at-startup for missed DMs.
+  - `@mulmobridge/chatwork` — Japanese business chat, polls unread messages per room via REST, strips Chatwork markup.
+  - `@mulmobridge/xmpp` — XMPP / Jabber over TLS with JID + password.
+  - `@mulmobridge/rocketchat` — personal-access-token auth, paginated `im.list` + `im.history`, seeds cursor to `now - pollInterval` on first discovery so the message that created the DM room isn't lost.
+  - `@mulmobridge/signal` — talks to a local [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) daemon, groups routed to `group.<id>` chatIds (not mixed with DMs), E.164 source validation, module-scoped exponential backoff on reconnect.
+  - `@mulmobridge/teams` — Microsoft Teams via Bot Framework (`botbuilder` SDK). Conversation-reference cache for push, AAD object-id allowlist. Requires a public URL.
+  - `@mulmobridge/webhook` — generic HTTP bridge; POST JSON, get the AI reply in the response body. Optional `x-webhook-secret`.
+  - `@mulmobridge/twilio-sms` — Twilio Programmable Messaging, `X-Twilio-Signature` HMAC-SHA1 verification, number-based allowlist.
+  - `@mulmobridge/email` — IMAP poll / SMTP reply with threading preserved (`In-Reply-To` + `References`).
+  - `@mulmobridge/line-works` — enterprise LINE via service-account JWT → OAuth, separate from consumer LINE.
+  - `@mulmobridge/nostr` — NIP-04 encrypted DMs across multiple relays, periodic resubscribe after relay drops, last-seen cursor persisted to `~/.mulmoclaude/nostr-cursor.json` so restarts don't lose messages, hex / nsec key input with pubkey allowlist.
+  - `@mulmobridge/viber` — Viber Public Account bot, `X-Viber-Content-Signature` HMAC-SHA256.
+- **Wiki**: per-page chat composer (`pages/<slug>` leaf view) that spawns a new session scoped to the page; back-arrow now walks browser history instead of forcing index; slug path-traversal rejection; empty-slug guard; exact-title lookup for non-ASCII pages.
+- **Files view**: path-based URL (`/files/<path>`) with query-form back-compat, internal workspace link router routes markdown-embedded links to the right view.
+- **History view**: promoted to `/history`, "unread only" filter pill, session-origin filter (human / scheduler / skill / bridge).
+- **Chat**: naked `/chat` lands on the most recent session; MulmoClaude logo/title click resumes the latest session; `/chat/:id` push via `router.push` (no replace).
+- **i18n**: vue-i18n skeleton, auto-detect locale from `navigator.language` when `VITE_LOCALE` unset, 7 new locale files (ja, zh, ko, es, pt-BR, fr, de — en remains the source of truth), vue-i18n lint wiring via `batch/i18n-dump.ts`.
+- **UI**: MulmoClaude mascot-based favicon with state-colored background + red unread dot, scheduler frequency hints, ChatInput attach-file discoverability, source labels on preview cards.
+- **Server**: session-origin tag on every session, chat-index + journal force-run env flags, reference directory mounts into Docker sandbox.
+- **Canvas**: PNG file as source of truth so drawings survive reload; POST `/api/canvas` + PUT `/api/images/:filename` endpoints with unit tests.
+- **Prompt**: compact plugin bullets, per-section size monitoring with threshold warning, summary-only inlining for large help files.
+- **Tests**: E2E right-sidebar hidden on plugin views, `/files/<path>` character coverage, workspace link routing unit + E2E, ChatInput attach discoverability, internal-link-navigation assertion for path-based Files, regression tests for session behavior fixes.
 
 ### Changed
 
-- `@mulmobridge/slack` (v0.2.0 → **v0.3.0**) — `SLACK_SESSION_GRANULARITY=thread` now auto-creates a Slack thread on the first bot reply to a top-level channel post. Users firing off multiple unrelated top-level messages get one thread per topic — replies no longer interleave at channel level. `channel` (default) and `auto` modes are unchanged. DMs are intentionally unaffected. Operators already on `thread` mode will see more threading on upgrade (#661, closes #658).
-- `@mulmobridge/client` (v0.1.1 → **v0.1.2**) — Patch release that exports the shared `chunkText` helper from `./text`. Required by every new bridge (mastodon, bluesky, chatwork, xmpp, rocketchat, signal, teams, webhook, twilio-sms, email, line-works, nostr, viber); without it, their `npx` invocations fail at runtime because they depend on `^0.1.0`.
-- `@mulmobridge/mock-server` (v0.1.0 → **v0.1.1**) — Patch release. Internal refactor of `handlers.ts` / `server.ts` + README catch-up listing all supported platforms.
-- `@mulmobridge/relay` (v0.1.0 → **v0.2.0**) — Minor release adding four new platform plugins:
-  - **WhatsApp** (HMAC-SHA256 webhook, Cloud API send)
-  - **Messenger** (Meta HMAC-SHA256 webhook, Messenger Send API)
-  - **Google Chat** (JWT/OIDC inbound, optional service-account async reply)
-  - **Microsoft Teams** (Bot Framework inbound with SSRF-hardened auth verification, `adapter.continueConversationAsync` for push)
-  Plus Durable Object hibernation recovery, subpath exports, CoderRabbit / Sourcery review fixes, extracted time constants.
+- **`@mulmobridge/slack`** (v0.2.0 → **v0.3.0**): `SLACK_SESSION_GRANULARITY=thread` auto-creates a Slack thread on the first bot reply to a top-level channel post; unrelated top-level messages now get one thread per topic. `channel` (default) and `auto` unchanged; DMs unaffected (#661 / closes #658).
+- **`@mulmobridge/client`** (v0.1.1 → **v0.1.2**): exports `chunkText` from `./text`; required by every new bridge.
+- **`@mulmobridge/mock-server`** (v0.1.0 → **v0.1.1**): internal refactor + README catch-up.
+- **`@mulmobridge/relay`** (v0.1.0 → **v0.2.0**): four new platform plugins — WhatsApp, Messenger, Google Chat, Microsoft Teams — plus Durable Object hibernation recovery and subpath exports.
+- Dev server port resolution: shared `server/utils/port.mjs` drives both `yarn dev` and the `npx mulmoclaude` launcher; explicit `PORT=3099` exits on conflict, default walks forward through 20 slots.
+- Scheduler UI: daily triggers render in viewer's local timezone (e.g. Tokyo sees `Daily 05:00 GMT+9` instead of `Daily 20:00 UTC`).
+- Agent prompt: new `## Time & Timezone` section instructs the model to default bare time expressions to the user's browser timezone and only clarify for explicit cross-zone mentions. "Today's date" is now computed in that zone.
+- Wiki tabs (Index / Log / Lint) styled to match PluginLauncher; PDF download button aligned with TextResponse view; index rows condensed to single line.
+- Bridges moved from `packages/<name>/` into `packages/bridges/<name>/` subdirectory.
+- CLAUDE.md: i18n rule — all 8 locales must move in lockstep; `id-length` lint promoted to `error`.
+- ChatInput: focus expansion dropped, padding tightened, buttons equalized.
+- Tool-results card timestamps overlaid on top border instead of inline.
+- Express request-id header normalization (CRLF stripped before multi-paragraph plugin check).
+
+### Fixed
+
+- **Wiki**: back arrow walks browser history instead of resetting to index (#wiki-nav); same-origin markdown links no longer trigger full page reloads; relative links in text-response don't navigate the SPA; cross-route query bleed; redundant mount fetch on `/wiki` cancelled; `navError` hoisted above the immediate URL watcher; originating page retained in history when starting a chat.
+- **Session**: role switch from a non-chat page no longer creates a phantom chat session; sidebar preview links don't spawn new sessions; re-selecting the active session from a non-chat page navigates correctly; fall back to a new session when top-session resume fails; URL session id read directly to avoid watcher timing race.
+- **Right sidebar**: hidden along with its toggle on non-chat views (#652).
+- **Mastodon**: image-only DMs no longer dropped; chunked replies chain into one readable thread; fail loudly on a create-status response missing `id` (previously left stale `prevId` chaining onto the wrong parent).
+- **Rocket.Chat**: `im.history` / `im.list` pagination (previously silently trimmed past 50 / 100 entries); cursor rewind on first DM discovery.
+- **Signal**: E.164 source check (UUID-only senders would 400 on reply); `backoffMs` hoisted to module scope so reconnect actually backs off; `dataMessage.groupV2.id` / `groupInfo.groupId` routing so group chats don't collapse into the sender's DM.
+- **Nostr**: auto-resubscribe every 5 min to survive relay WebSocket drops; last-seen cursor persisted so a >60 s restart doesn't lose DMs.
+- **Bluesky**: cursor-at-startup so DMs delivered while the bridge was down still flow in on first poll.
+- **Teams (relay)**: webhook auth hardened against SSRF and impersonation — `serviceurl` claim cross-check, `channelId === "msteams"` check, JWK endorsement check for MultiTenant, fail-closed allowlist when `aadObjectId` missing.
+- **Scheduler / prompt**: plugin-prompt paragraph detection normalizes CRLF.
+- **i18n**: pluginWiki schema drift across pt-BR / fr / de / es / ko / zh fixed in multiple rounds; literal `@` in stdio argsPlaceholder escaped (the Intl linked-message compiler was turning `@modelcontextprotocol/...` into a runtime error); silence vue-i18n HTML warning; missing chatPlaceholder / chatSend / pdf keys aligned across all locales.
+- **E2E**: IME Enter test deflaked by collapsing the `compositionstart → compositionend → keydown` dispatches into a single `page.evaluate()` (per-hop latency was blowing past the 30 ms race window on CI webkit).
+- **Slack**: session-granularity env invalidation now rejects invalid values up front; id-length lint clean-up across the package.
+- **Settings / MCP**: stdio form rendering regression (vue-i18n link-compile error).
+- **Roles**: role switch on non-chat pages no longer creates a session.
+- **Build**: i18n cache location and `dumpi18n` wired into lint so the rule can see every locale.
+
+### Security
+
+- **`@mulmobridge/relay`**: Teams webhook auth — reject bodies whose `serviceUrl` doesn't match the JWT's `serviceurl` claim (SSRF prevention), enforce `channelId === "msteams"`, require `msteams` in JWK `endorsements` for MultiTenant keys, fail-closed allowlist.
+- **`@mulmobridge/nostr`**: Tight IANA regex + `Intl.DateTimeFormat` round-trip validation on any timezone string before it lands in the system prompt, so a hostile client can't inject newlines or instructions via a crafted payload.
+- **`@mulmobridge/signal`**: E.164 source validation — the `/v2/send` API requires a phone number, and a UUID-only sender would quietly 400; now we drop instead.
+- **Agent prompt**: IANA timezone string sanitisation before it reaches the system prompt.
 
 ### Packages published during this cycle
 
+- `mulmoclaude@0.4.0` (this release)
+- `@mulmobridge/slack@0.3.0`
+- `@mulmobridge/slack@0.2.0`
 - `@mulmobridge/client@0.1.2`
 - `@mulmobridge/mock-server@0.1.1`
 - `@mulmobridge/relay@0.2.0`
@@ -54,7 +111,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 - `@mulmobridge/line-works@0.1.0`
 - `@mulmobridge/nostr@0.1.0`
 - `@mulmobridge/viber@0.1.0`
-- `@mulmobridge/slack@0.3.0`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",


### PR DESCRIPTION
## Summary

App release **v0.4.0** の準備 PR: \`docs/CHANGELOG.md\` に 0.4.0 エントリ追加 + ルート \`package.json\` の version bump (0.3.0 → 0.4.0)。

npm package (\`mulmoclaude@0.4.0\`) は #666 で既に publish 済み (registry 反映済み)。本 PR がマージされたら git tag \`v0.4.0\` + GitHub release を作成します。

## CHANGELOG の要約 (Highlights)

- **13 新規 bridge** (Mastodon / Bluesky / Chatwork / XMPP / Rocket.Chat / Signal / Teams / Webhook / Twilio SMS / Email / LINE Works / Nostr / Viber) で総 bridge 数 20+ へ
- **Path-based URL** を Wiki (\`/wiki/index\`, \`/wiki/pages/<slug>\`), Files (\`/files/<path>\`), History (\`/history\`), Chat (\`/chat/:id\`) に導入 — back/forward/bookmark すべて想定どおり
- **i18n 本番化** — vue-i18n + \`navigator.language\` 自動検出、**8 locale** (en/ja/zh/ko/es/pt-BR/fr/de) が同梱、17 batch 分のキー抽出
- **Agent の timezone ハンドリング** — ブラウザの IANA timezone をリクエストに載せて、裸の時刻は確認なしでそのまま解釈。スケジューラ UI も同方針で daily トリガーをローカル TZ 表示
- **Favicon 再設計** — マスコット + state 色背景 + 赤い未読ドット (他セッション含む)
- **Dev server の port fallback** — \`yarn dev\` が 3001 使用中でも walk forward。npm launcher と共通の \`server/utils/port.mjs\` に統合

Full changelog は \`docs/CHANGELOG.md\` の \`[0.4.0]\` セクションで、Added / Changed / Fixed / Security / Packages 各 sub-section にかなり網羅的に記録しています。

## Items to Confirm / Review

- CHANGELOG のカバレッジ: 170 コミット分を圧縮して書いているので、重要な feat/fix を入れ忘れていないか
- 0.4.0 セクションの [Unreleased] との境界: 前サイクルで \`[Unreleased]\` 下に積まれていた bridge リストを 0.4.0 に畳んだ
- 公開済みパッケージの行: 今サイクルで登録した 0.4.0 本体 + slack 0.3.0 / 0.2.0 + 13 bridge 各 0.1.0 のリストが正しいか

## Next steps (マージ後)

1. \`git pull origin main\`
2. \`git tag v0.4.0\`
3. \`git push origin main --tags\` (tag push のみ; main は既に最新)
4. \`gh release create v0.4.0\` (\`--latest\` / 網羅的な highlight notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)