### PR TITLE
fix: align settings modal to top to prevent jump on tab switch

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="open" class="fixed inset-0 z-50 bg-black/40 flex items-center justify-center" data-testid="settings-modal-backdrop" @click="close">
+  <div v-if="open" class="fixed inset-0 z-50 bg-black/40 flex items-start justify-center pt-16" data-testid="settings-modal-backdrop" @click="close">
     <div
       class="bg-white rounded-lg shadow-xl w-[36rem] max-h-[85vh] flex flex-col"
       role="dialog"


### PR DESCRIPTION
## Summary
- 設定モーダルのタブ切り替え時に、コンテンツ量の違いでダイアログ上端が上下に動く問題を修正
- `items-center`（垂直中央揃え）→ `items-start pt-16`（上端固定）に変更

<img width="833" height="620" alt="image" src="https://github.com/user-attachments/assets/d1c31daf-5f20-4c56-9d02-57f9c05826ac" />

<img width="778" height="605" alt="image" src="https://github.com/user-attachments/assets/978aab4e-3e4b-4730-9abc-034786851813" />


## Items to Confirm / Review
- `pt-16`（4rem）の上端マージンが適切か

## User Prompt
設定ダイアログのタブ切り替え時に window の上端が移動して使いづらい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted modal positioning to display at the top of the screen with fixed padding instead of being vertically centered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->