### PR TITLE
feat(wiki): tag-based filtering + AI lint on the Wiki index

### DIFF
--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -25,8 +25,8 @@ const INDEX_PAYLOAD = {
   title: "Wiki Index",
   content: "# Wiki Index\n\nRoot page.",
   pageEntries: [
-    { title: "Onboarding", slug: "onboarding", description: "Getting started" },
-    { title: "Architecture", slug: "architecture", description: "How things fit" },
+    { title: "Onboarding", slug: "onboarding", description: "Getting started", tags: [] },
+    { title: "Architecture", slug: "architecture", description: "How things fit", tags: [] },
   ],
 };
 

--- a/e2e/tests/wiki-page-chat.spec.ts
+++ b/e2e/tests/wiki-page-chat.spec.ts
@@ -11,7 +11,7 @@ const INDEX_PAYLOAD = {
   action: "index",
   title: "Wiki Index",
   content: "# Wiki Index\n\nRoot page.",
-  pageEntries: [{ title: "Onboarding", slug: "onboarding", description: "Getting started" }],
+  pageEntries: [{ title: "Onboarding", slug: "onboarding", description: "Getting started", tags: [] }],
 };
 
 const PAGE_ONBOARDING = {

--- a/plans/feat-wiki-tags.md
+++ b/plans/feat-wiki-tags.md
@@ -142,6 +142,7 @@ Add under `pluginWiki` in `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`:
 |---|---|
 | `tagFilterAll` | `All` |
 | `noMatches` | `No pages tagged {tag}` |
+| `lintChat` | `Lint My Wiki` |
 
 Translate each into the target locale — don't copy English. Placeholders (`{tag}`) stay verbatim. `en.ts` is the schema source of truth, so add there first, then the 7 siblings in the same PR.
 
@@ -160,7 +161,7 @@ Update `server/workspace/helps/wiki.md`:
 4. **Lint rule**: add `findTagDrift` + direct unit tests alongside existing ones. Wire into `collectLintIssues` using the already-read `contents` array.
 5. **Frontend type mirror** in `src/plugins/wiki/index.ts`.
 6. **`View.vue` UI**: tag filter bar, per-entry chips, `visibleEntries` computed, empty-filter state. Scoped styles match existing Tailwind chip vibe (gray border, blue active).
-7. **i18n**: `tagFilterAll`, `noMatches` across all 8 locales.
+7. **i18n**: `tagFilterAll`, `noMatches`, `lintChat` across all 8 locales.
 8. **Schema doc** update in `server/workspace/helps/wiki.md`.
 9. **Run** `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`.
 

--- a/plans/feat-wiki-tags.md
+++ b/plans/feat-wiki-tags.md
@@ -1,0 +1,220 @@
+# feat: Tag-based filtering on the Wiki index
+
+## Problem
+
+Wiki pages already carry `tags: [...]` in YAML frontmatter (e.g. `ai-security, research-paper`), but the index view in `src/plugins/wiki/View.vue` has no way to show or filter by them. As the wiki grows past ~30 pages, the flat alphabetical list becomes hard to navigate. Users want to narrow the index to a single topic (e.g. show only `#ai-agents` pages).
+
+The API response (`WikiPageEntry`) exposes `title`, `slug`, `description` — no `tags` field — so the frontend can't filter even if it wanted to. Reading each page file on every index request to pull tags from frontmatter would work but adds per-request fs cost. Cheaper: put tags directly in `index.md` alongside each entry so the existing `parseIndexEntries` pass picks them up.
+
+## Goal
+
+1. Extend `index.md` formats to carry tags per entry.
+2. Parse them into `WikiPageEntry.tags` and return via `/api/wiki`.
+3. In `View.vue`'s index view: show a tag filter chip row at the top, tag chips next to each entry, and filter the list to entries matching the selected tag.
+4. Lint: flag drift between a page's frontmatter `tags` and the tags recorded for that slug in `index.md`.
+
+## Non-goals
+
+- Multi-tag (intersection / union) filtering. Single selected tag in v1; "all" resets.
+- Tag editing UI — tags are still authored by Claude via `index.md` and page frontmatter.
+- Migrating existing workspace `index.md` files. Entries without tags just render zero chips and don't contribute to the filter bar.
+- A standalone `/wiki/tag/:tag` route. Filter is view-local state only.
+- Singleton-tag / typo detection or any fuzzy tag similarity checks.
+- Touching the workspace `data/wiki/SCHEMA.md` from code — that file is Claude-maintained. The code-owned `server/workspace/helps/wiki.md` is the only schema doc we update.
+
+## Design
+
+### Index format additions
+
+**Table format** (what the current workspace `index.md` uses) — add a `Tags` column. Detection is header-based, case-insensitive, so existing 4-column tables (`Slug | Title | Summary | Updated`) keep working with empty tags:
+
+```markdown
+| Slug | Title | Summary | Tags | Updated |
+|------|-------|---------|------|---------|
+| `satoshi-nakajima` | Satoshi Nakajima | Engineer… | biography, japan, tech | 2026-04-10 |
+```
+
+- Tags cell is comma- or space-separated. Empty cell → `tags: []`.
+- Parser reads header row once per `index.md` parse, maps column names → indices, extracts `tags` from the mapped column. Falls back to the current positional `[slug, title, description]` for the first three when header is absent or non-standard.
+
+**Bullet format** (canonical per SCHEMA.md) — append `#tag` tokens anywhere in the description:
+
+```markdown
+- [Transformer Architecture](pages/transformer-architecture.md) — foundational seq2seq model #ml #attention (2026-04-05)
+```
+
+- `#tag` tokens are matched with `/(?:^|\s)#([a-z0-9][a-z0-9-]*)/gi`, extracted into `tags`, and stripped from the resulting `description`.
+- Keeps back-compat: descriptions without `#` tokens yield `tags: []` and an unchanged description.
+
+Both formats land in the same `WikiPageEntry` shape — the UI doesn't care which authoring style the user picked.
+
+### Type changes
+
+`server/api/routes/wiki.ts`:
+
+```ts
+export interface WikiPageEntry {
+  title: string;
+  slug: string;
+  description: string;
+  tags: string[]; // always present, empty array when none
+}
+```
+
+Mirror the same change in `src/plugins/wiki/index.ts` (the frontend-side `WikiPageEntry`). Keep `tags` required (non-optional) so every code path has to reason about it — avoids the optional-undefined-empty trilemma in filter logic.
+
+### Server parser changes
+
+Three places in `server/api/routes/wiki.ts`:
+
+1. **`parseTableRow`** — change from the current positional-only parser to a header-aware one. Add a `parseIndexEntries` outer pass that:
+   - Detects the header row (first `|…|` line where cells are non-code-fenced identifiers).
+   - Builds a column index map: `{ slug: 0, title: 1, summary: 2, tags: 3, updated: 4 }` (case-insensitive, whitespace-trimmed).
+   - Uses the map when reading data rows; unmapped columns are ignored.
+   - Falls back to the current positional read when the header is missing or doesn't contain a `slug`/`title` column.
+2. **`parseBulletLinkRow` / `parseBulletWikiLinkRow`** — run a small `extractHashTags(description)` helper on the captured description before returning:
+   ```ts
+   function extractHashTags(desc: string): { description: string; tags: string[] } { … }
+   ```
+   Returns the stripped description and the sorted, deduped tag list.
+3. **API response** — no shape change (tags live on each `WikiPageEntry`); just make sure the `tags: []` default is applied uniformly.
+
+Keep the three parser functions under the 20-line style limit — extract `extractHashTags` and `buildTableColumnMap` as named pure helpers in the same file and export them for direct unit tests.
+
+### Frontend (`src/plugins/wiki/View.vue`)
+
+Current index render (lines 70–83) is a flat list keyed by `entry.slug`. Changes:
+
+1. **Tag filter bar** — render above the list when `action === 'index'` and there's at least one tag across all entries. Horizontal scrollable flex row of chips:
+   - First chip: "All" (`t('pluginWiki.tagFilterAll')`). Active when no filter is selected.
+   - One chip per unique tag, label = `tag (count)`. Active when `selectedTag === tag`.
+   - Click behaviour: click an inactive chip to set filter; click the active one (or "All") to clear.
+   - Data-testids: `wiki-tag-filter-all`, `wiki-tag-filter-<tag>`.
+2. **Per-entry tag chips** — small gray pills between title and description (or wrapping to a new line on narrow widths). Each chip is clickable and sets the filter to that tag. `data-testid="wiki-entry-tag-<slug>-<tag>"`.
+3. **Filtering logic** — computed `visibleEntries`: if `selectedTag === null` return `pageEntries`, else return `pageEntries.filter(e => e.tags.includes(selectedTag))`.
+4. **Empty filtered state** — when `selectedTag` is set and `visibleEntries.length === 0`, show `t('pluginWiki.noMatches', { tag })` instead of the list (the top-level "Wiki is empty" branch is unchanged).
+5. **State is local** — `const selectedTag = ref<string | null>(null)`. Not persisted to URL, not synced to props. Switching away from the index view and back resets the filter.
+
+Tag list computation:
+```ts
+const allTags = computed(() => {
+  const counts = new Map<string, number>();
+  for (const entry of pageEntries.value) {
+    for (const tag of entry.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])); // by count desc, then name asc
+});
+```
+
+Small helpers (`allTags`, `visibleEntries`) stay in the `<script setup>` — no new composable unless a second caller appears.
+
+### Lint: tag drift
+
+Add one new pure helper to `server/api/routes/wiki.ts`:
+
+```ts
+export function findTagDrift(
+  pageEntries: readonly WikiPageEntry[],
+  frontmatterTagsBySlug: ReadonlyMap<string, readonly string[]>,
+): string[] { … }
+```
+
+Rules:
+- For each `entry` in `pageEntries` where the slug exists in `frontmatterTagsBySlug`:
+  - Compare as sorted sets. If they differ, emit `- **Tag drift**: \`<slug>.md\` frontmatter has [a, b, c] but index.md has [a, b]`.
+- Slugs with no frontmatter file are already caught by `findMissingFiles`; don't double-report.
+- Slugs whose frontmatter has no `tags:` field at all → treat as `[]` and compare.
+
+Frontmatter reader:
+- Add `server/api/routes/wiki/frontmatter.ts` (new file; the existing `wiki/` subdir already holds `pageIndex.ts`).
+- Exports `parseFrontmatterTags(content: string): string[]` — reads only the first `---`-fenced YAML block, matches a `tags:` line in either flow (`tags: [a, b, c]`) or block (`tags:\n  - a\n  - b`) style, returns the list. Anything unparseable → `[]`. No third-party YAML dep — a ~20-line regex extractor is enough for this narrow field.
+
+Wire into `collectLintIssues` (lines 311–338):
+- After the existing orphan / missing / broken-link passes, read frontmatter in parallel over the already-loaded `contents` array (no extra fs pass — `contents` is already produced by the broken-link pass at line 328).
+- Build the `frontmatterTagsBySlug` map, call `findTagDrift`, push issues.
+
+### i18n — all 8 locales in lockstep
+
+Add under `pluginWiki` in `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`:
+
+| Key | English |
+|---|---|
+| `tagFilterAll` | `All` |
+| `noMatches` | `No pages tagged {tag}` |
+
+Translate each into the target locale — don't copy English. Placeholders (`{tag}`) stay verbatim. `en.ts` is the schema source of truth, so add there first, then the 7 siblings in the same PR.
+
+### Schema doc
+
+Update `server/workspace/helps/wiki.md`:
+
+- Under **`index.md` Format**: document the new `Tags` column (table) and `#tag` tokens (bullet), with a worked example of each.
+- Add a short "Tags" subsection explaining: tags in frontmatter are the source of truth; tags in `index.md` must match; lint flags drift.
+
+## Implementation steps
+
+1. **Server types + parser.** Extend `WikiPageEntry`, add `extractHashTags` + `buildTableColumnMap` helpers, update `parseTableRow` / `parseBulletLinkRow` / `parseBulletWikiLinkRow`. Default `tags: []` everywhere. Export the new helpers.
+2. **Server tests** (`test/routes/test_wikiHelpers.ts`): table with Tags column, table without (back-compat), bullet with `#tag` tokens, bullet without, tag dedup + sort, non-ASCII-safe.
+3. **Frontmatter reader** (`server/api/routes/wiki/frontmatter.ts`) + unit tests: flow-style `tags: [a, b]`, block-style list, missing frontmatter, missing `tags:` field, malformed YAML (returns `[]`).
+4. **Lint rule**: add `findTagDrift` + direct unit tests alongside existing ones. Wire into `collectLintIssues` using the already-read `contents` array.
+5. **Frontend type mirror** in `src/plugins/wiki/index.ts`.
+6. **`View.vue` UI**: tag filter bar, per-entry chips, `visibleEntries` computed, empty-filter state. Scoped styles match existing Tailwind chip vibe (gray border, blue active).
+7. **i18n**: `tagFilterAll`, `noMatches` across all 8 locales.
+8. **Schema doc** update in `server/workspace/helps/wiki.md`.
+9. **Run** `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`.
+
+## Test plan
+
+### Unit (server, `node:test`)
+
+- `extractHashTags`:
+  - `"notes #ml #attention"` → `{ description: "notes", tags: ["attention", "ml"] }` (sorted, deduped).
+  - `"plain text"` → `{ description: "plain text", tags: [] }`.
+  - `"#a #a #b"` → `tags: ["a", "b"]`.
+  - `"#ml-arch"` / `"#AI"` — hyphens allowed, lowercased.
+- `buildTableColumnMap`:
+  - Header `| Slug | Title | Summary | Tags | Updated |` → map includes `tags: 3`.
+  - Header without `Tags` → map omits it; parser returns `tags: []`.
+  - Case + whitespace tolerance.
+- `parseIndexEntries`:
+  - Table with Tags column populates tags.
+  - Back-compat: legacy 3-col table (no Tags) → `tags: []` on every entry (regression guard for the existing test at line 87).
+  - Bullet with `#tag` populates tags and strips them from description.
+  - Bullet with em-dash + tags: `- [[X]] — desc #a #b` → `description: "desc"`, `tags: ["a", "b"]`.
+  - Mixed table + bullet entries both carry tags correctly.
+- `parseFrontmatterTags`:
+  - Flow `tags: [a, b, c]` → `["a", "b", "c"]`.
+  - Block list `tags:\n  - a\n  - b` → `["a", "b"]`.
+  - Missing frontmatter → `[]`. Missing `tags:` → `[]`. Malformed YAML → `[]`.
+- `findTagDrift`:
+  - Matching sets → no issues.
+  - Different sets → one issue per mismatched slug, message includes both lists.
+  - Slug in `pageEntries` but not in frontmatter map → no issue (handled by `findMissingFiles`).
+  - Empty frontmatter tags vs non-empty index tags → flagged.
+
+### E2E (Playwright, extend `e2e/tests/wiki-plugin.spec.ts`)
+
+- Mock `/api/wiki` to return entries with varied tags. Navigate to `/wiki`:
+  - Tag filter bar renders; "All" chip is active by default.
+  - Per-entry chips render with correct labels.
+  - Click `#ai-agents` chip in the filter bar → only entries with that tag visible; chip becomes active; "All" deactivates.
+  - Click the active chip → filter clears, full list returns.
+  - Click a tag chip on an entry row → filter switches to that tag.
+  - Mock an empty-result scenario: select a tag, then navigate to a mocked payload with zero matching entries → empty-state message shown.
+- Filter state is view-local: navigate to `/wiki/log` and back → filter is reset (expected, per design).
+
+### Manual
+
+- In a real workspace: ask Claude to regenerate `data/wiki/index.md` with tags following the updated `helps/wiki.md` schema. Verify chips + filter behave against real data.
+- Deliberately edit a page's frontmatter `tags` to diverge from `index.md`, run Lint → expect a `Tag drift` entry pointing at that slug. Re-sync → lint clears.
+- Non-ASCII entry with tags: `- [さくらインターネット](pages/sakura-internet.md) — クラウド #日本企業 #infra` — confirm the non-ASCII tag `#日本企業` is accepted (or, if we restrict to `[a-z0-9-]`, confirm the restriction is intentional and documented in `helps/wiki.md`). Decision for v1: **ASCII-only tag tokens** in bullet form, to keep the regex simple. Non-ASCII tag names can still be used via the table format's `Tags` column, which accepts any comma-separated string.
+
+## Out of scope / future work
+
+- Multi-tag filtering (AND / OR chips).
+- Tag pages / `/wiki/tag/:tag` routes.
+- Tag renaming or merging utilities.
+- Singleton-tag / typo warnings in lint.
+- Automatic back-fill of tags from page frontmatter into `index.md` (a "regenerate index" command).
+- Tag coloring / iconography.

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -78,7 +78,12 @@ export function buildTableColumnMap(headerRow: string): Map<string, number> {
   const cells = headerRow
     .split("|")
     .slice(1, -1)
-    .map((cell) => cell.trim().toLowerCase());
+    // Mirror `parseTableRow`'s cell-normalising: strip the surrounding
+    // backticks that commonly wrap cell values in wiki tables. Without
+    // this, a `| \`tags\` |` header maps to the key "`tags`" and the
+    // subsequent `columnMap.get("tags")` lookup silently misses the
+    // column, falling back to `tags: []`.
+    .map((cell) => cell.trim().replace(/^`|`$/g, "").toLowerCase());
   const map = new Map<string, number>();
   cells.forEach((cell, i) => {
     if (cell) map.set(cell, i);

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -42,7 +42,11 @@ const TABLE_SEPARATOR_PATTERN = /^\|[\s|:-]+\|$/;
 // where `wikiSlugify` returns "" and the slug would otherwise be lost.
 const BULLET_LINK_PATTERN = /^[-*]\s+\[([^\]]+)\]\(([^)]*)\)(?:\s*[—–-]\s*(.*))?/;
 const BULLET_WIKI_LINK_PATTERN = /^[-*]\s+\[\[([^\]]+)\]\](?:\s*[—–-]\s*(.*))?/;
-const HASHTAG_PATTERN = /(?:^|\s)#([a-z0-9][a-z0-9-]*)/gi;
+// Unicode-aware tag body: any letter or number in any script
+// (so Japanese / Chinese / Korean tags like `#クラウド` or `#可視化`
+// work), plus `-` and `_` as internal joiners. First char is a
+// letter or number only — no leading punctuation.
+const HASHTAG_PATTERN = /(?:^|\s)#([\p{L}\p{N}][\p{L}\p{N}_-]*)/gu;
 
 // Extract `#tag` tokens from a bullet description, returning the
 // stripped description and a sorted, deduped, lowercased tag list.
@@ -381,7 +385,11 @@ function formatTagList(tags: readonly string[]): string {
 export function findTagDrift(pageEntries: readonly WikiPageEntry[], frontmatterTagsBySlug: ReadonlyMap<string, readonly string[]>): string[] {
   const issues: string[] = [];
   for (const entry of pageEntries) {
-    const pageTags = frontmatterTagsBySlug.get(entry.slug);
+    // Lowercase on lookup — `collectLintIssues` keys the map with
+    // lowercased slugs, so a `MyPage.md` filename still matches an
+    // `entry.slug` of `mypage` produced by `wikiSlugify` on the
+    // wiki-link parser path.
+    const pageTags = frontmatterTagsBySlug.get(entry.slug.toLowerCase());
     if (pageTags === undefined) continue;
     const pageSet = new Set(pageTags);
     const indexSet = new Set(entry.tags);
@@ -426,7 +434,11 @@ async function collectLintIssues(): Promise<string[]> {
   const frontmatterTagsBySlug = new Map<string, string[]>();
   for (let i = 0; i < pageFiles.length; i++) {
     issues.push(...findBrokenLinksInPage(pageFiles[i], contents[i], fileSlugs));
-    const slug = pageFiles[i].replace(/\.md$/i, "");
+    // Lowercase the map key so a `MyPage.md` filename still matches
+    // an `entry.slug` of `mypage` produced by `wikiSlugify` on the
+    // wiki-link parser path. `findTagDrift` lowercases the lookup
+    // side to match.
+    const slug = pageFiles[i].replace(/\.md$/i, "").toLowerCase();
     frontmatterTagsBySlug.set(slug, parseFrontmatterTags(contents[i]));
   }
   issues.push(...findTagDrift(pageEntries, frontmatterTagsBySlug));

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { readTextSafeSync, readTextSafe } from "../../utils/files/safe.js";
 import { getPageIndex } from "./wiki/pageIndex.js";
+import { parseFrontmatterTags } from "./wiki/frontmatter.js";
 import { badRequest } from "../../utils/httpError.js";
 import { getOptionalStringQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -21,6 +22,7 @@ export interface WikiPageEntry {
   title: string;
   slug: string;
   description: string;
+  tags: string[];
 }
 
 // Slug rules: lowercase, spaces to hyphens, strip everything that
@@ -40,20 +42,72 @@ const TABLE_SEPARATOR_PATTERN = /^\|[\s|:-]+\|$/;
 // where `wikiSlugify` returns "" and the slug would otherwise be lost.
 const BULLET_LINK_PATTERN = /^[-*]\s+\[([^\]]+)\]\(([^)]*)\)(?:\s*[—–-]\s*(.*))?/;
 const BULLET_WIKI_LINK_PATTERN = /^[-*]\s+\[\[([^\]]+)\]\](?:\s*[—–-]\s*(.*))?/;
+const HASHTAG_PATTERN = /(?:^|\s)#([a-z0-9][a-z0-9-]*)/gi;
+
+// Extract `#tag` tokens from a bullet description, returning the
+// stripped description and a sorted, deduped, lowercased tag list.
+// Only matches at word boundaries so mid-word `#` (e.g. anchor URLs)
+// is left alone.
+export function extractHashTags(text: string): { description: string; tags: string[] } {
+  const tags: string[] = [];
+  HASHTAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HASHTAG_PATTERN.exec(text)) !== null) {
+    tags.push(match[1].toLowerCase());
+  }
+  const description = text.replace(HASHTAG_PATTERN, "").replace(/\s+/g, " ").trim();
+  const deduped = [...new Set(tags)].sort();
+  return { description, tags: deduped };
+}
+
+// Split a table Tags cell — tolerates comma, whitespace, or `#`
+// prefixes. Empty cell yields an empty list.
+export function parseTagsCell(cell: string): string[] {
+  const tokens = cell
+    .split(/[,\s]+/)
+    .map((token) => token.trim().replace(/^#/, "").toLowerCase())
+    .filter((token) => token.length > 0);
+  return [...new Set(tokens)].sort();
+}
+
+// Map header cell names → column indices, case- and whitespace-
+// tolerant. Used by `parseTableRow` to locate the Tags column (and
+// any other named column) without assuming a fixed position, so
+// older 3- and 4-column tables keep working.
+export function buildTableColumnMap(headerRow: string): Map<string, number> {
+  const cells = headerRow
+    .split("|")
+    .slice(1, -1)
+    .map((cell) => cell.trim().toLowerCase());
+  const map = new Map<string, number>();
+  cells.forEach((cell, i) => {
+    if (cell) map.set(cell, i);
+  });
+  return map;
+}
 
 // Each parser returns the entry it produced (if any). The parent
 // loop tries them in order; the first non-null result wins.
-function parseTableRow(trimmed: string): WikiPageEntry | null {
+function parseTableRow(trimmed: string, columnMap: Map<string, number> | null): WikiPageEntry | null {
   const cols = trimmed
     .split("|")
     .slice(1, -1)
     .map((column) => column.trim().replace(/^`|`$/g, ""));
   if (cols.length < 2) return null;
-  const slug = cols[0];
-  const title = cols[1] || slug;
-  const desc = cols[2] ?? "";
+  const slugIdx = columnMap?.get("slug") ?? 0;
+  const titleIdx = columnMap?.get("title") ?? 1;
+  // Accept either "summary" (the canonical column name in
+  // server/workspace/helps/wiki.md) or "description" (used by the
+  // existing unit test fixture). Fall back to column 2 when the
+  // table has no header map.
+  const summaryIdx = columnMap?.get("summary") ?? columnMap?.get("description") ?? 2;
+  const tagsIdx = columnMap?.get("tags");
+  const slug = cols[slugIdx] ?? "";
+  const title = cols[titleIdx] || slug;
+  const description = cols[summaryIdx] ?? "";
+  const tags = tagsIdx !== undefined ? parseTagsCell(cols[tagsIdx] ?? "") : [];
   if (!slug || !title) return null;
-  return { title, slug, description: desc };
+  return { title, slug, description, tags };
 }
 
 // Extract the slug segment from a bullet link's href. Accepts the
@@ -75,21 +129,23 @@ function parseBulletLinkRow(trimmed: string): WikiPageEntry | null {
   if (!match) return null;
   const title = match[1].trim();
   const href = match[2] ?? "";
-  const desc = match[3]?.trim() ?? "";
+  const raw = match[3]?.trim() ?? "";
+  const { description, tags } = extractHashTags(raw);
   // Prefer the slug embedded in the href so non-ASCII titles keep
   // a navigable slug. Fall back to slugifying the title only when
   // the href has no recognisable slug (rare — usually means the
   // author put an external URL here).
   const slug = extractSlugFromBulletHref(href) || wikiSlugify(title);
-  return { title, slug, description: desc };
+  return { title, slug, description, tags };
 }
 
 function parseBulletWikiLinkRow(trimmed: string): WikiPageEntry | null {
   const match = BULLET_WIKI_LINK_PATTERN.exec(trimmed);
   if (!match) return null;
   const title = match[1].trim();
-  const desc = match[2]?.trim() ?? "";
-  return { title, slug: wikiSlugify(title), description: desc };
+  const raw = match[2]?.trim() ?? "";
+  const { description, tags } = extractHashTags(raw);
+  return { title, slug: wikiSlugify(title), description, tags };
 }
 
 // Parse entries from index.md — supports three formats:
@@ -99,23 +155,31 @@ function parseBulletWikiLinkRow(trimmed: string): WikiPageEntry | null {
 export function parseIndexEntries(content: string): WikiPageEntry[] {
   const entries: WikiPageEntry[] = [];
   let inTable = false;
+  let columnMap: Map<string, number> | null = null;
 
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
 
     if (trimmed.startsWith("|")) {
-      // Header / separator rows just toggle the in-table flag and
-      // produce no entry.
-      if (TABLE_SEPARATOR_PATTERN.test(trimmed) || !inTable) {
+      if (TABLE_SEPARATOR_PATTERN.test(trimmed)) {
         inTable = true;
         continue;
       }
-      const entry = parseTableRow(trimmed);
+      if (!inTable) {
+        // First `|`-line before the separator is the header. Capture
+        // the column map so parseTableRow can locate the Tags
+        // column (if any) by name rather than position.
+        columnMap = buildTableColumnMap(trimmed);
+        inTable = true;
+        continue;
+      }
+      const entry = parseTableRow(trimmed, columnMap);
       if (entry) entries.push(entry);
       continue;
     }
 
     inTable = false;
+    columnMap = null;
 
     const bullet = parseBulletLinkRow(trimmed) ?? parseBulletWikiLinkRow(trimmed);
     if (bullet) entries.push(bullet);
@@ -300,6 +364,29 @@ export function findBrokenLinksInPage(fileName: string, content: string, fileSlu
   return issues;
 }
 
+function formatTagList(tags: readonly string[]): string {
+  return `[${[...tags].sort().join(", ")}]`;
+}
+
+// Flag any slug whose index.md tags differ from the page's own
+// frontmatter `tags:` field. Comparison is set-based and order-
+// insensitive; both sides are lowercased at parse time. Slugs
+// missing from `frontmatterTagsBySlug` are ignored here — the
+// missing file itself is already reported by `findMissingFiles`.
+export function findTagDrift(pageEntries: readonly WikiPageEntry[], frontmatterTagsBySlug: ReadonlyMap<string, readonly string[]>): string[] {
+  const issues: string[] = [];
+  for (const entry of pageEntries) {
+    const pageTags = frontmatterTagsBySlug.get(entry.slug);
+    if (pageTags === undefined) continue;
+    const pageSet = new Set(pageTags);
+    const indexSet = new Set(entry.tags);
+    if (pageSet.size !== indexSet.size || [...pageSet].some((tag) => !indexSet.has(tag))) {
+      issues.push(`- **Tag drift**: \`${entry.slug}.md\` frontmatter has ${formatTagList(pageTags)} but index.md has ${formatTagList(entry.tags)}`);
+    }
+  }
+  return issues;
+}
+
 export function formatLintReport(issues: readonly string[]): string {
   if (issues.length === 0) {
     return "# Wiki Lint Report\n\n✓ No issues found. Wiki is healthy.";
@@ -331,9 +418,13 @@ async function collectLintIssues(): Promise<string[]> {
       return content ?? "";
     }),
   );
+  const frontmatterTagsBySlug = new Map<string, string[]>();
   for (let i = 0; i < pageFiles.length; i++) {
     issues.push(...findBrokenLinksInPage(pageFiles[i], contents[i], fileSlugs));
+    const slug = pageFiles[i].replace(/\.md$/i, "");
+    frontmatterTagsBySlug.set(slug, parseFrontmatterTags(contents[i]));
   }
+  issues.push(...findTagDrift(pageEntries, frontmatterTagsBySlug));
   return issues;
 }
 

--- a/server/api/routes/wiki/frontmatter.ts
+++ b/server/api/routes/wiki/frontmatter.ts
@@ -1,0 +1,86 @@
+// Narrow YAML frontmatter reader for wiki page files. We only need
+// the `tags:` field, so a tiny regex-based parser beats pulling in a
+// full YAML dependency. Supports both flow style (`tags: [a, b, c]`)
+// and block-list style:
+//
+//   tags:
+//     - a
+//     - b
+//
+// Anything unparseable returns `[]` — callers use this for a
+// best-effort comparison against index.md, so a noisy file should
+// degrade silently, not throw.
+
+// Match `- value` with any leading indentation. Keeps to linear
+// matching (no lazy quantifier) so sonarjs/slow-regex stays happy.
+const BLOCK_LIST_ITEM_PATTERN = /^\s*-\s+(\S.*)$/;
+
+// Pull the inner list from a line that starts with `tags:` and
+// contains a `[...]` flow list. Returns null when the line isn't a
+// flow-style tags line. Bracket matching is done with `indexOf` so
+// we don't need a lazy-quantified regex.
+function extractFlowTagsCell(line: string): string | null {
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith("tags:")) return null;
+  const open = trimmed.indexOf("[");
+  if (open === -1) return null;
+  const close = trimmed.indexOf("]", open + 1);
+  if (close === -1) return null;
+  return trimmed.slice(open + 1, close);
+}
+
+// Extract the YAML frontmatter body with plain string scanning so
+// we don't rely on a lazy-quantified regex (which ESLint's slow-regex
+// rule flags for super-linear backtracking when the closing fence is
+// missing). Returns null when no well-formed `---\n…\n---` block is
+// present at the top of the file.
+function extractFrontmatterBody(content: string): string | null {
+  if (!content.startsWith("---")) return null;
+  const after = content.indexOf("\n");
+  if (after === -1) return null;
+  const close = content.indexOf("\n---", after);
+  if (close === -1) return null;
+  return content.slice(after + 1, close);
+}
+
+function cleanTagToken(token: string): string {
+  return token
+    .trim()
+    .replace(/^['"]|['"]$/g, "")
+    .replace(/^#/, "")
+    .toLowerCase();
+}
+
+function parseFlowList(cell: string): string[] {
+  return cell
+    .split(",")
+    .map(cleanTagToken)
+    .filter((token) => token.length > 0);
+}
+
+function parseBlockList(lines: string[], startIndex: number): string[] {
+  const tags: string[] = [];
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // Block list ends at the first line that isn't a list item —
+    // blank line, next key, or unindented text.
+    if (/^\S/.test(line) || line.trim() === "") break;
+    const match = BLOCK_LIST_ITEM_PATTERN.exec(line);
+    if (!match) break;
+    const token = cleanTagToken(match[1].trimEnd());
+    if (token.length > 0) tags.push(token);
+  }
+  return tags;
+}
+
+export function parseFrontmatterTags(content: string): string[] {
+  const body = extractFrontmatterBody(content);
+  if (body === null) return [];
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const flow = extractFlowTagsCell(lines[i]);
+    if (flow !== null) return parseFlowList(flow);
+    if (/^tags:\s*$/.test(lines[i])) return parseBlockList(lines, i);
+  }
+  return [];
+}

--- a/server/workspace/helps/wiki.md
+++ b/server/workspace/helps/wiki.md
@@ -109,7 +109,7 @@ Key rules:
 
 - Always write bullet items as `[Title](pages/<slug>.md) — description #tag1 #tag2 (YYYY-MM-DD)` — **no** `[[slug]]` wiki-link form, and **no** markdown tables. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug.
 - Slugs are lowercase ASCII, hyphen-separated. They match the page filename one-to-one (`pages/sakura-internet.md` → slug `sakura-internet`).
-- `#tag` tokens appear inline in the description (word-boundary match). Tokens are extracted and indexed for the Wiki tag-filter UI. Use `[a-z0-9][a-z0-9-]*` for ASCII tags; the "タグ一覧" section can still list non-ASCII group labels.
+- `#tag` tokens appear inline in the description (whitespace-bounded on the left). Tokens are extracted and indexed for the Wiki tag-filter UI. Tags accept any Unicode letter or digit (so `#クラウド`, `#可視化`, `#ai-agents` all work); `-` and `_` are allowed as internal joiners but not as the first character. Separate adjacent tags with a space — there is no right-hand boundary char, so `#クラウドデータ` parses as one tag.
 - Group by category if useful, then include a "タグ一覧" / "Tags" section with the same `[Title](pages/<slug>.md)` link form so every mention is clickable.
 - Keep the index in sync with `pages/` — when you add a page, add a row; when you rename a file, update every link that points at it.
 

--- a/server/workspace/helps/wiki.md
+++ b/server/workspace/helps/wiki.md
@@ -107,7 +107,7 @@ Cross-references use `[[Page Name]]` wiki-link syntax. Slugs are lowercase, hyph
 
 Key rules:
 
-- Always write bullet items as `[Title](pages/<slug>.md) — description #tag1 #tag2 (YYYY-MM-DD)` — **no** `[[slug]]` wiki-link form, and **no** markdown tables. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug.
+- Prefer bullet items as `[Title](pages/<slug>.md) — description #tag1 #tag2 (YYYY-MM-DD)` — avoid the `[[slug]]` wiki-link form. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug. Markdown tables are also supported via the alternative format below, but the bullet form is easier to read in plain text and plays nicer with non-ASCII titles.
 - Slugs are lowercase ASCII, hyphen-separated. They match the page filename one-to-one (`pages/sakura-internet.md` → slug `sakura-internet`).
 - `#tag` tokens appear inline in the description (whitespace-bounded on the left). Tokens are extracted and indexed for the Wiki tag-filter UI. Tags accept any Unicode letter or digit (so `#クラウド`, `#可視化`, `#ai-agents` all work); `-` and `_` are allowed as internal joiners but not as the first character. Separate adjacent tags with a space — there is no right-hand boundary char, so `#クラウドデータ` parses as one tag.
 - Group by category if useful, then include a "タグ一覧" / "Tags" section with the same `[Title](pages/<slug>.md)` link form so every mention is clickable.

--- a/server/workspace/helps/wiki.md
+++ b/server/workspace/helps/wiki.md
@@ -95,9 +95,9 @@ Cross-references use `[[Page Name]]` wiki-link syntax. Slugs are lowercase, hyph
 
 ## ページ一覧
 
-- [Transformer Architecture](pages/transformer-architecture.md) — machine-learning, architecture, attention (2026-04-05)
-- [さくらインターネット](pages/sakura-internet.md) — クラウド, 日本企業, データセンター (2026-04-06)
-- [ECharts DataZoom](pages/echarts-datazoom.md) — ECharts, データ可視化 (2026-04-13)
+- [Transformer Architecture](pages/transformer-architecture.md) — foundational seq2seq model #ml #attention #architecture (2026-04-05)
+- [さくらインターネット](pages/sakura-internet.md) — 日本のクラウド事業者 #クラウド #日本企業 #データセンター (2026-04-06)
+- [ECharts DataZoom](pages/echarts-datazoom.md) — ズーム操作の仕組み #echarts #可視化 (2026-04-13)
 
 ## タグ一覧
 
@@ -107,10 +107,29 @@ Cross-references use `[[Page Name]]` wiki-link syntax. Slugs are lowercase, hyph
 
 Key rules:
 
-- Always write bullet items as `[Title](pages/<slug>.md) — description (YYYY-MM-DD)` — **no** `[[slug]]` wiki-link form, and **no** markdown tables. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug.
+- Always write bullet items as `[Title](pages/<slug>.md) — description #tag1 #tag2 (YYYY-MM-DD)` — **no** `[[slug]]` wiki-link form, and **no** markdown tables. The canvas parser extracts the slug from the href so non-ASCII titles (日本語, etc.) keep a navigable slug.
 - Slugs are lowercase ASCII, hyphen-separated. They match the page filename one-to-one (`pages/sakura-internet.md` → slug `sakura-internet`).
+- `#tag` tokens appear inline in the description (word-boundary match). Tokens are extracted and indexed for the Wiki tag-filter UI. Use `[a-z0-9][a-z0-9-]*` for ASCII tags; the "タグ一覧" section can still list non-ASCII group labels.
 - Group by category if useful, then include a "タグ一覧" / "Tags" section with the same `[Title](pages/<slug>.md)` link form so every mention is clickable.
 - Keep the index in sync with `pages/` — when you add a page, add a row; when you rename a file, update every link that points at it.
+
+### Alternative table format
+
+If you prefer a table layout, the canvas also accepts a `Tags` column. Column names are matched by header (case-insensitive), so the order is flexible:
+
+```markdown
+| Slug | Title | Summary | Tags | Updated |
+|------|-------|---------|------|---------|
+| `transformer-architecture` | Transformer Architecture | foundational seq2seq model | ml, attention, architecture | 2026-04-05 |
+```
+
+Pre-existing 3- or 4-column tables (without a Tags header) keep parsing; their entries just have no tags.
+
+## Tag rules
+
+- A page's YAML frontmatter `tags:` field is the source of truth for that page's tags.
+- The tags recorded for that slug in `index.md` must match the frontmatter set exactly (order and case don't matter; we compare as a lowercased set).
+- `manageWiki` `action: "lint_report"` flags any mismatch as **Tag drift**. Fix by updating whichever side is stale.
 
 ## Canvas Tool
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -819,13 +819,13 @@ function navigateToWorkspacePath(href: string): void {
   }
 }
 
-function startNewChat(message: string): void {
+function startNewChat(message: string, roleId?: string): void {
   // createNewSession sets currentSessionId synchronously (see the
   // comment on its declaration), so the follow-up sendMessage lands
   // in the new session rather than whatever was previously active.
   // Cross-route push behaviour (so browser Back returns to /wiki)
   // is now handled inside createNewSession via the isChatPage check.
-  createNewSession(currentRoleId.value);
+  createNewSession(roleId ?? currentRoleId.value);
   void sendMessage(message);
 }
 
@@ -833,7 +833,7 @@ function startNewChat(message: string): void {
 provideAppApi({
   refreshRoles,
   sendMessage: (message: string) => sendMessage(message),
-  startNewChat: (message: string) => startNewChat(message),
+  startNewChat: (message: string, roleId?: string) => startNewChat(message, roleId),
   navigateToWorkspacePath: (href: string) => navigateToWorkspacePath(href),
 });
 // Plugin Views that need to tag background work with the current

--- a/src/App.vue
+++ b/src/App.vue
@@ -825,7 +825,18 @@ function startNewChat(message: string, roleId?: string): void {
   // in the new session rather than whatever was previously active.
   // Cross-route push behaviour (so browser Back returns to /wiki)
   // is now handled inside createNewSession via the isChatPage check.
-  createNewSession(roleId ?? currentRoleId.value);
+  const previousRoleId = currentRoleId.value;
+  createNewSession(roleId ?? previousRoleId);
+  // `createNewSession` mutates `currentRoleId.value` to the role it
+  // just used. When the caller passed an explicit `roleId` override
+  // (e.g. wiki Lint spawns a General-role chat regardless of the
+  // role the user is currently viewing the wiki under), restore the
+  // previously-selected role afterwards so future `+` clicks and
+  // role-aware UI don't inherit this one-shot override. The newly-
+  // created session keeps the overridden role on its own record.
+  if (roleId && roleId !== previousRoleId) {
+    currentRoleId.value = previousRoleId;
+  }
   void sendMessage(message);
 }
 

--- a/src/composables/useAppApi.ts
+++ b/src/composables/useAppApi.ts
@@ -21,12 +21,15 @@ export interface AppApi {
   /** Send a chat message through App.vue's normal sendMessage pipeline. */
   sendMessage: (message: string) => void;
   /**
-   * Open a fresh chat session (using the currently selected role) and
-   * send `message` as its first turn. Used by plugin views that want
-   * to kick off a new conversation instead of threading into whatever
-   * session happens to be active.
+   * Open a fresh chat session and send `message` as its first turn.
+   * Used by plugin views that want to kick off a new conversation
+   * instead of threading into whatever session happens to be active.
+   * Pass `roleId` to override the role for this one session (e.g. a
+   * wiki lint needs the General role even if the user is currently
+   * viewing the wiki under a different role); omit it to inherit the
+   * currently selected role.
    */
-  startNewChat: (message: string) => void;
+  startNewChat: (message: string, roleId?: string) => void;
   /** Navigate to a workspace-internal link (wiki page, file, session). */
   navigateToWorkspacePath: (href: string) => void;
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -329,6 +329,7 @@ const deMessages = {
     chatSend: "Neuen Chat zu dieser Seite starten",
     tagFilterAll: "Alle",
     noMatches: "Keine Seiten mit dem Tag #{tag}",
+    lintChat: "Wiki prüfen",
   },
   pluginPresentHtml: {
     saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -327,6 +327,8 @@ const deMessages = {
     previewMore: "+ {count} weitere…",
     chatPlaceholder: "Fragen Sie zu dieser Seite…",
     chatSend: "Neuen Chat zu dieser Seite starten",
+    tagFilterAll: "Alle",
+    noMatches: "Keine Seiten mit dem Tag #{tag}",
   },
   pluginPresentHtml: {
     saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -349,6 +349,7 @@ const enMessages = {
     chatSend: "Start a new chat about this page",
     tagFilterAll: "All",
     noMatches: "No pages tagged #{tag}",
+    lintChat: "Lint My Wiki",
   },
   pluginPresentHtml: {
     saveAsPdf: "Save as PDF (opens print dialog)",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -347,6 +347,8 @@ const enMessages = {
     previewMore: "+ {count} more…",
     chatPlaceholder: "Ask about this page…",
     chatSend: "Start a new chat about this page",
+    tagFilterAll: "All",
+    noMatches: "No pages tagged #{tag}",
   },
   pluginPresentHtml: {
     saveAsPdf: "Save as PDF (opens print dialog)",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -334,6 +334,7 @@ const esMessages = {
     chatSend: "Iniciar un chat nuevo sobre esta página",
     tagFilterAll: "Todas",
     noMatches: "No hay páginas con la etiqueta #{tag}",
+    lintChat: "Revisar mi wiki",
   },
   pluginPresentHtml: {
     saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -332,6 +332,8 @@ const esMessages = {
     previewMore: "+ {count} más…",
     chatPlaceholder: "Pregunta sobre esta página…",
     chatSend: "Iniciar un chat nuevo sobre esta página",
+    tagFilterAll: "Todas",
+    noMatches: "No hay páginas con la etiqueta #{tag}",
   },
   pluginPresentHtml: {
     saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -329,6 +329,7 @@ const frMessages = {
     chatSend: "Démarrer une nouvelle conversation sur cette page",
     tagFilterAll: "Toutes",
     noMatches: "Aucune page avec le tag #{tag}",
+    lintChat: "Vérifier mon wiki",
   },
   pluginPresentHtml: {
     saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -327,6 +327,8 @@ const frMessages = {
     previewMore: "+ {count} de plus…",
     chatPlaceholder: "Posez une question sur cette page…",
     chatSend: "Démarrer une nouvelle conversation sur cette page",
+    tagFilterAll: "Toutes",
+    noMatches: "Aucune page avec le tag #{tag}",
   },
   pluginPresentHtml: {
     saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -333,6 +333,7 @@ const jaMessages = {
     chatSend: "このページについて新しいチャットを開始",
     tagFilterAll: "すべて",
     noMatches: "#{tag} タグのページがありません",
+    lintChat: "Wiki を Lint",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -331,6 +331,8 @@ const jaMessages = {
     previewMore: "+ {count} 件…",
     chatPlaceholder: "このページについて質問…",
     chatSend: "このページについて新しいチャットを開始",
+    tagFilterAll: "すべて",
+    noMatches: "#{tag} タグのページがありません",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -333,6 +333,7 @@ const koMessages = {
     chatSend: "이 페이지에 대한 새 채팅 시작",
     tagFilterAll: "전체",
     noMatches: "#{tag} 태그가 달린 페이지가 없습니다",
+    lintChat: "Wiki 점검",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -331,6 +331,8 @@ const koMessages = {
     previewMore: "+ {count}개 더…",
     chatPlaceholder: "이 페이지에 대해 질문…",
     chatSend: "이 페이지에 대한 새 채팅 시작",
+    tagFilterAll: "전체",
+    noMatches: "#{tag} 태그가 달린 페이지가 없습니다",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -328,6 +328,7 @@ const ptBRMessages = {
     chatSend: "Iniciar um novo chat sobre esta página",
     tagFilterAll: "Todas",
     noMatches: "Nenhuma página com a tag #{tag}",
+    lintChat: "Revisar meu wiki",
   },
   pluginPresentHtml: {
     saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -326,6 +326,8 @@ const ptBRMessages = {
     previewMore: "+ {count} mais…",
     chatPlaceholder: "Pergunte sobre esta página…",
     chatSend: "Iniciar um novo chat sobre esta página",
+    tagFilterAll: "Todas",
+    noMatches: "Nenhuma página com a tag #{tag}",
   },
   pluginPresentHtml: {
     saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -330,6 +330,7 @@ const zhMessages = {
     chatSend: "就本页开启新对话",
     tagFilterAll: "全部",
     noMatches: "没有带 #{tag} 标签的页面",
+    lintChat: "检查 Wiki",
   },
   pluginPresentHtml: {
     saveAsPdf: "另存为 PDF(打开打印对话框)",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -328,6 +328,8 @@ const zhMessages = {
     previewMore: "+ 还有 {count} 项…",
     chatPlaceholder: "就本页提问…",
     chatSend: "就本页开启新对话",
+    tagFilterAll: "全部",
+    noMatches: "没有带 #{tag} 标签的页面",
   },
   pluginPresentHtml: {
     saveAsPdf: "另存为 PDF(打开打印对话框)",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -18,6 +18,12 @@
           </div>
           <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
         </template>
+        <div v-if="action === 'index'" class="button-group">
+          <button class="download-btn download-btn-green" data-testid="wiki-lint-chat-button" @click="startLintChat">
+            <span class="material-icons">rule</span>
+            {{ t("pluginWiki.lintChat") }}
+          </button>
+        </div>
         <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
           <button
             :class="[
@@ -165,6 +171,7 @@ import { useImeAwareEnter } from "../../composables/useImeAwareEnter";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { useAppApi } from "../../composables/useAppApi";
 import { renderWikiLinks } from "./helpers";
+import { BUILTIN_ROLE_IDS } from "../../config/roles";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
@@ -281,6 +288,15 @@ const visibleEntries = computed(() =>
 
 function toggleTagFilter(tag: string) {
   selectedTag.value = selectedTag.value === tag ? null : tag;
+}
+
+// Spawn a new chat under the General role (which owns the wiki
+// tooling) regardless of the role the user is currently viewing the
+// wiki under. "lint my wiki" is a direct instruction to the agent,
+// not a tool call — the agent decides how to run the lint and
+// report back.
+function startLintChat() {
+  appApi.startNewChat("lint my wiki", BUILTIN_ROLE_IDS.general);
 }
 
 // Clear the filter whenever we leave the index view — otherwise

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -107,7 +107,7 @@
           <span v-if="entry.description" class="text-xs text-gray-500 truncate">
             {{ entry.description }}
           </span>
-          <span v-if="entry.tags.length > 0" class="flex gap-1 flex-wrap shrink-0">
+          <span v-if="entry.tags && entry.tags.length > 0" class="flex gap-1 flex-wrap shrink-0">
             <button
               v-for="tag in entry.tags"
               :key="tag"
@@ -277,13 +277,13 @@ watch(
 const allTags = computed<[string, number][]>(() => {
   const counts = new Map<string, number>();
   for (const entry of pageEntries.value) {
-    for (const tag of entry.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    for (const tag of entry.tags ?? []) counts.set(tag, (counts.get(tag) ?? 0) + 1);
   }
   return [...counts.entries()].filter(([, count]) => count > 1).sort(([tagA, countA], [tagB, countB]) => countB - countA || tagA.localeCompare(tagB));
 });
 
 const visibleEntries = computed(() =>
-  selectedTag.value === null ? pageEntries.value : pageEntries.value.filter((entry) => entry.tags.includes(selectedTag.value as string)),
+  selectedTag.value === null ? pageEntries.value : pageEntries.value.filter((entry) => (entry.tags ?? []).includes(selectedTag.value as string)),
 );
 
 function toggleTagFilter(tag: string) {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -66,19 +66,53 @@
       </div>
     </div>
 
-    <!-- Index: page card list -->
-    <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 overflow-y-auto">
-      <div
-        v-for="entry in pageEntries"
-        :key="entry.slug"
-        class="flex items-baseline gap-2 px-4 py-1 cursor-pointer hover:bg-blue-50 transition-colors"
-        :data-testid="`wiki-page-entry-${entry.slug || entry.title}`"
-        @click="navigatePage(entry.slug || entry.title)"
-      >
-        <span class="font-medium text-sm text-gray-800 shrink-0">{{ entry.title }}</span>
-        <span v-if="entry.description" class="text-xs text-gray-500 truncate">
-          {{ entry.description }}
-        </span>
+    <!-- Index: tag filter + page card list -->
+    <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 flex flex-col overflow-hidden">
+      <div v-if="allTags.length > 0" class="shrink-0 border-b border-gray-100 px-4 py-2 flex flex-wrap gap-1">
+        <button
+          :class="['tag-chip', selectedTag === null ? 'tag-chip-active' : 'tag-chip-inactive']"
+          data-testid="wiki-tag-filter-all"
+          @click="selectedTag = null"
+        >
+          {{ t("pluginWiki.tagFilterAll") }}
+        </button>
+        <button
+          v-for="[tag, count] in allTags"
+          :key="tag"
+          :class="['tag-chip', selectedTag === tag ? 'tag-chip-active' : 'tag-chip-inactive']"
+          :data-testid="`wiki-tag-filter-${tag}`"
+          @click="toggleTagFilter(tag)"
+        >
+          {{ tag }} ({{ count }})
+        </button>
+      </div>
+      <div v-if="visibleEntries.length === 0 && selectedTag" class="flex-1 flex items-center justify-center text-gray-400 text-sm px-4 text-center">
+        {{ t("pluginWiki.noMatches", { tag: selectedTag }) }}
+      </div>
+      <div v-else class="flex-1 overflow-y-auto">
+        <div
+          v-for="entry in visibleEntries"
+          :key="entry.slug"
+          class="flex items-baseline gap-2 px-4 py-1 cursor-pointer hover:bg-blue-50 transition-colors"
+          :data-testid="`wiki-page-entry-${entry.slug || entry.title}`"
+          @click="navigatePage(entry.slug || entry.title)"
+        >
+          <span class="font-medium text-sm text-gray-800 shrink-0">{{ entry.title }}</span>
+          <span v-if="entry.description" class="text-xs text-gray-500 truncate">
+            {{ entry.description }}
+          </span>
+          <span v-if="entry.tags.length > 0" class="flex gap-1 flex-wrap shrink-0">
+            <button
+              v-for="tag in entry.tags"
+              :key="tag"
+              class="entry-tag-chip"
+              :data-testid="`wiki-entry-tag-${entry.slug}-${tag}`"
+              @click.stop="selectedTag = tag"
+            >
+              {{ `#${tag}` }}
+            </button>
+          </span>
+        </div>
       </div>
     </div>
 
@@ -153,6 +187,10 @@ const action = ref(props.selectedResult?.data?.action ?? "index");
 const title = ref(props.selectedResult?.data?.title ?? "Wiki");
 const content = ref(props.selectedResult?.data?.content ?? "");
 const pageEntries = ref<WikiPageEntry[]>(props.selectedResult?.data?.pageEntries ?? []);
+// View-local tag filter. Null = no filter. Not persisted to URL —
+// kept intentionally ephemeral so it doesn't leak into bookmarks
+// or the per-session stack history.
+const selectedTag = ref<string | null>(null);
 // Declared up here — not next to callApi — because the URL watcher
 // below fires with `immediate: true`, which invokes callApi
 // synchronously during setup. If this ref were declared after the
@@ -222,6 +260,35 @@ watch(
   },
   { immediate: true },
 );
+
+// Tag frequencies for the filter bar — sorted by count desc, then
+// name asc so the most common tags appear first and equally-common
+// tags stay in deterministic order. Singletons are dropped: a tag
+// used on a single page adds no filtering value, just visual noise.
+// Per-entry `#tag` chips still render every tag, so singletons stay
+// clickable from the row itself.
+const allTags = computed<[string, number][]>(() => {
+  const counts = new Map<string, number>();
+  for (const entry of pageEntries.value) {
+    for (const tag of entry.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).sort(([tagA, countA], [tagB, countB]) => countB - countA || tagA.localeCompare(tagB));
+});
+
+const visibleEntries = computed(() =>
+  selectedTag.value === null ? pageEntries.value : pageEntries.value.filter((entry) => entry.tags.includes(selectedTag.value as string)),
+);
+
+function toggleTagFilter(tag: string) {
+  selectedTag.value = selectedTag.value === tag ? null : tag;
+}
+
+// Clear the filter whenever we leave the index view — otherwise
+// switching to Log / Lint and back leaves a stale filter active,
+// which feels like a bug.
+watch(action, (next) => {
+  if (next !== "index") selectedTag.value = null;
+});
 
 const renderedContent = computed(() => {
   if (!content.value) return "";
@@ -337,6 +404,46 @@ function handleContentClick(event: MouseEvent) {
 </script>
 
 <style scoped>
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+.tag-chip-active {
+  background-color: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+.tag-chip-inactive {
+  background-color: #f3f4f6;
+  color: #374151;
+  border-color: #e5e7eb;
+}
+.tag-chip-inactive:hover {
+  background-color: #e5e7eb;
+}
+.entry-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.375rem;
+  font-size: 0.7rem;
+  line-height: 1rem;
+  border-radius: 9999px;
+  background-color: #f3f4f6;
+  color: #4b5563;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.entry-tag-chip:hover {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
 .button-group {
   display: flex;
   gap: 0.5em;

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -74,7 +74,7 @@
 
     <!-- Index: tag filter + page card list -->
     <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 flex flex-col overflow-hidden">
-      <div v-if="allTags.length > 0" class="shrink-0 border-b border-gray-100 px-4 py-2 flex flex-wrap gap-1">
+      <div v-if="allTags.length > 0 || selectedTag !== null" class="shrink-0 border-b border-gray-100 px-4 py-2 flex flex-wrap gap-1">
         <button
           :class="['tag-chip', selectedTag === null ? 'tag-chip-active' : 'tag-chip-inactive']"
           data-testid="wiki-tag-filter-all"
@@ -90,6 +90,14 @@
           @click="toggleTagFilter(tag)"
         >
           {{ tag }} ({{ count }})
+        </button>
+        <button
+          v-if="selectedTag !== null && !allTags.some(([tag]) => tag === selectedTag)"
+          class="tag-chip tag-chip-active"
+          :data-testid="`wiki-tag-filter-${selectedTag}`"
+          @click="toggleTagFilter(selectedTag)"
+        >
+          {{ `${selectedTag} (1)` }}
         </button>
       </div>
       <div v-if="visibleEntries.length === 0 && selectedTag" class="flex-1 flex items-center justify-center text-gray-400 text-sm px-4 text-center">
@@ -113,7 +121,7 @@
               :key="tag"
               class="entry-tag-chip"
               :data-testid="`wiki-entry-tag-${entry.slug}-${tag}`"
-              @click.stop="selectedTag = tag"
+              @click.stop="toggleTagFilter(tag)"
             >
               {{ `#${tag}` }}
             </button>

--- a/src/plugins/wiki/index.ts
+++ b/src/plugins/wiki/index.ts
@@ -10,6 +10,7 @@ export interface WikiPageEntry {
   title: string;
   slug: string;
   description: string;
+  tags: string[];
 }
 
 export interface WikiData {

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -371,6 +371,17 @@ describe("extractHashTags", () => {
     assert.deepEqual(out.tags, ["a", "b"]);
     assert.equal(out.description, "foo bar");
   });
+
+  it("accepts non-ASCII tag names (Japanese, CJK, etc.)", () => {
+    const out = extractHashTags("日本のクラウド事業者 #クラウド #日本企業 #データセンター");
+    assert.deepEqual(out.tags, ["クラウド", "データセンター", "日本企業"]);
+    assert.equal(out.description, "日本のクラウド事業者");
+  });
+
+  it("accepts mixed ASCII + non-ASCII tags", () => {
+    const out = extractHashTags("notes #ai-エージェント #foo");
+    assert.deepEqual(out.tags, ["ai-エージェント", "foo"]);
+  });
 });
 
 describe("parseTagsCell", () => {
@@ -490,5 +501,15 @@ describe("findTagDrift", () => {
     const entries = [entry("foo", ["a"])];
     const frontmatter = new Map<string, string[]>();
     assert.deepEqual(findTagDrift(entries, frontmatter), []);
+  });
+
+  it("lowercases the lookup so mixed-case filenames still match", () => {
+    // collectLintIssues lowercases the map keys. Here the index.md
+    // slug is lowercased (via wikiSlugify on a wiki-link), and the
+    // map was keyed from a `MyPage.md` filename — we still expect
+    // the two to be compared.
+    const entries = [entry("mypage", ["a"])];
+    const frontmatter = new Map<string, string[]>([["mypage", ["a", "b"]]]);
+    assert.equal(findTagDrift(entries, frontmatter).length, 1);
   });
 });

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -414,6 +414,14 @@ describe("buildTableColumnMap", () => {
     assert.equal(map.get("tags"), 2);
     assert.equal(map.size, 2);
   });
+
+  it("strips surrounding backticks from header cells", () => {
+    // Mirror parseTableRow's data-cell normaliser so a backticked
+    // header like `| `tags` |` still resolves via columnMap.get("tags").
+    const map = buildTableColumnMap("| `slug` | `tags` |");
+    assert.equal(map.get("slug"), 0);
+    assert.equal(map.get("tags"), 1);
+  });
 });
 
 describe("parseFrontmatterTags", () => {

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -504,11 +504,13 @@ describe("findTagDrift", () => {
   });
 
   it("lowercases the lookup so mixed-case filenames still match", () => {
-    // collectLintIssues lowercases the map keys. Here the index.md
-    // slug is lowercased (via wikiSlugify on a wiki-link), and the
-    // map was keyed from a `MyPage.md` filename — we still expect
-    // the two to be compared.
-    const entries = [entry("mypage", ["a"])];
+    // collectLintIssues lowercases the map keys. Here the entry's
+    // slug is kept mixed-case (as a parser could produce from a
+    // `MyPage.md` filename before normalization), while the
+    // frontmatter map uses the canonical lowercase key. The test
+    // fails if findTagDrift stops calling `.toLowerCase()` on
+    // `entry.slug` before the lookup.
+    const entries = [entry("MyPage", ["a"])];
     const frontmatter = new Map<string, string[]>([["mypage", ["a", "b"]]]);
     assert.equal(findTagDrift(entries, frontmatter).length, 1);
   });

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -1,15 +1,20 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildTableColumnMap,
+  extractHashTags,
   extractSlugFromBulletHref,
   findBrokenLinksInPage,
   findMissingFiles,
   findOrphanPages,
+  findTagDrift,
   formatLintReport,
   parseIndexEntries,
+  parseTagsCell,
   wikiSlugify,
   type WikiPageEntry,
 } from "../../server/api/routes/wiki.js";
+import { parseFrontmatterTags } from "../../server/api/routes/wiki/frontmatter.js";
 
 describe("wikiSlugify", () => {
   it("lowercases input", () => {
@@ -97,6 +102,7 @@ describe("parseIndexEntries", () => {
       slug: "video-gen",
       title: "Video Gen",
       description: "Notes about video",
+      tags: [],
     });
   });
 
@@ -113,6 +119,7 @@ describe("parseIndexEntries", () => {
       title: "Video Generation",
       slug: "video-generation",
       description: "about video",
+      tags: [],
     });
   });
 
@@ -127,6 +134,7 @@ describe("parseIndexEntries", () => {
       title: "さくらインターネット",
       slug: "sakura-internet",
       description: "クラウド事業者",
+      tags: [],
     });
   });
 
@@ -161,7 +169,48 @@ describe("parseIndexEntries", () => {
       title: "Video Generation",
       slug: "video-generation",
       description: "about video",
+      tags: [],
     });
+  });
+
+  it("parses a Tags column in the table header", () => {
+    const markdown = [
+      "| Slug | Title | Summary | Tags | Updated |",
+      "|------|-------|---------|------|---------|",
+      "| `foo` | Foo | summary text | ai, research, paper | 2026-04-05 |",
+    ].join("\n");
+    const entries = parseIndexEntries(markdown);
+    assert.deepEqual(entries[0]?.tags, ["ai", "paper", "research"]);
+    assert.equal(entries[0]?.description, "summary text");
+  });
+
+  it("keeps legacy 4-column tables working when Tags header is absent", () => {
+    // Regression: the pre-tags workspace index.md uses
+    // | Slug | Title | Summary | Updated | — tags must default to [].
+    const markdown = ["| Slug | Title | Summary | Updated |", "|------|-------|---------|---------|", "| `foo` | Foo | summary | 2026-04-05 |"].join("\n");
+    const entries = parseIndexEntries(markdown);
+    assert.deepEqual(entries[0]?.tags, []);
+    assert.equal(entries[0]?.description, "summary");
+  });
+
+  it("is case- and whitespace-tolerant for the Tags header name", () => {
+    const markdown = ["| slug |  TAGS  | title |", "|------|--------|-------|", "| foo | a, b | Foo |"].join("\n");
+    const entries = parseIndexEntries(markdown);
+    assert.deepEqual(entries[0]?.tags, ["a", "b"]);
+  });
+
+  it("extracts #tag tokens from bullet descriptions", () => {
+    const markdown = "- [Transformer](pages/transformer.md) — foundational #ml #attention (2026-04-05)";
+    const entries = parseIndexEntries(markdown);
+    assert.deepEqual(entries[0]?.tags, ["attention", "ml"]);
+    assert.match(entries[0]?.description ?? "", /foundational/);
+    assert.doesNotMatch(entries[0]?.description ?? "", /#ml|#attention/);
+  });
+
+  it("extracts #tag tokens from bullet wiki links", () => {
+    const entries = parseIndexEntries("- [[Topic A]] — short #foo #bar");
+    assert.deepEqual(entries[0]?.tags, ["bar", "foo"]);
+    assert.equal(entries[0]?.description, "short");
   });
 
   it("treats em-dash, en-dash, and hyphen as the same description separator", () => {
@@ -217,7 +266,7 @@ describe("findOrphanPages", () => {
 
 describe("findMissingFiles", () => {
   function entry(slug: string): WikiPageEntry {
-    return { slug, title: slug, description: "" };
+    return { slug, title: slug, description: "", tags: [] };
   }
 
   it("returns no issues when every indexed entry has a file", () => {
@@ -285,5 +334,153 @@ describe("formatLintReport", () => {
     assert.match(out, /- one/);
     assert.match(out, /- two/);
     assert.match(out, /- three/);
+  });
+});
+
+describe("extractHashTags", () => {
+  it("extracts sorted, deduped, lowercased tags and strips them from the description", () => {
+    const out = extractHashTags("notes #ML #attention");
+    assert.deepEqual(out.tags, ["attention", "ml"]);
+    assert.equal(out.description, "notes");
+  });
+
+  it("returns an empty tag list when no # tokens are present", () => {
+    const out = extractHashTags("just a plain description");
+    assert.deepEqual(out.tags, []);
+    assert.equal(out.description, "just a plain description");
+  });
+
+  it("dedupes repeated tags", () => {
+    assert.deepEqual(extractHashTags("#a #a #b").tags, ["a", "b"]);
+  });
+
+  it("accepts hyphens inside tag names", () => {
+    assert.deepEqual(extractHashTags("#ai-agents #ml-arch").tags, ["ai-agents", "ml-arch"]);
+  });
+
+  it("does not match hashes that aren't at a word boundary", () => {
+    // `foo#bar` is a URL fragment / anchor, not a tag — leave it
+    // alone so we don't corrupt descriptions that link out.
+    const out = extractHashTags("see page#frag for details");
+    assert.deepEqual(out.tags, []);
+    assert.equal(out.description, "see page#frag for details");
+  });
+
+  it("collapses internal whitespace left over after stripping tags", () => {
+    const out = extractHashTags("foo  #a   bar  #b");
+    assert.deepEqual(out.tags, ["a", "b"]);
+    assert.equal(out.description, "foo bar");
+  });
+});
+
+describe("parseTagsCell", () => {
+  it("splits on commas and whitespace", () => {
+    assert.deepEqual(parseTagsCell("a, b  c"), ["a", "b", "c"]);
+  });
+
+  it("strips leading # and lowercases", () => {
+    assert.deepEqual(parseTagsCell("#A,#b"), ["a", "b"]);
+  });
+
+  it("dedupes and sorts", () => {
+    assert.deepEqual(parseTagsCell("z, a, a, m"), ["a", "m", "z"]);
+  });
+
+  it("returns an empty list for an empty cell", () => {
+    assert.deepEqual(parseTagsCell(""), []);
+    assert.deepEqual(parseTagsCell("   "), []);
+  });
+});
+
+describe("buildTableColumnMap", () => {
+  it("builds a lowercase-keyed map from a header row", () => {
+    const map = buildTableColumnMap("| Slug | Title | Summary | Tags | Updated |");
+    assert.equal(map.get("slug"), 0);
+    assert.equal(map.get("title"), 1);
+    assert.equal(map.get("summary"), 2);
+    assert.equal(map.get("tags"), 3);
+    assert.equal(map.get("updated"), 4);
+  });
+
+  it("is whitespace-tolerant", () => {
+    const map = buildTableColumnMap("|  slug  |   tags   |");
+    assert.equal(map.get("slug"), 0);
+    assert.equal(map.get("tags"), 1);
+  });
+
+  it("omits empty columns from the map", () => {
+    const map = buildTableColumnMap("| slug | | tags |");
+    assert.equal(map.get("slug"), 0);
+    assert.equal(map.get("tags"), 2);
+    assert.equal(map.size, 2);
+  });
+});
+
+describe("parseFrontmatterTags", () => {
+  it("parses flow-style tags", () => {
+    const content = "---\ntitle: X\ntags: [a, b, c]\n---\n\n# body";
+    assert.deepEqual(parseFrontmatterTags(content), ["a", "b", "c"]);
+  });
+
+  it("parses block-style tags", () => {
+    const content = "---\ntitle: X\ntags:\n  - foo\n  - bar\n---\n\n# body";
+    assert.deepEqual(parseFrontmatterTags(content), ["foo", "bar"]);
+  });
+
+  it("lowercases and strips quotes + leading #", () => {
+    const content = '---\ntags: ["#AI", "Research-Paper"]\n---';
+    assert.deepEqual(parseFrontmatterTags(content), ["ai", "research-paper"]);
+  });
+
+  it("returns [] when frontmatter is missing", () => {
+    assert.deepEqual(parseFrontmatterTags("# just markdown"), []);
+  });
+
+  it("returns [] when the tags field is absent", () => {
+    assert.deepEqual(parseFrontmatterTags("---\ntitle: X\n---"), []);
+  });
+
+  it("returns [] for malformed frontmatter", () => {
+    // Frontmatter block never closes — treated as no frontmatter.
+    assert.deepEqual(parseFrontmatterTags("---\ntitle: X\n"), []);
+  });
+
+  it("stops at the next top-level key when reading a block list", () => {
+    const content = "---\ntags:\n  - a\n  - b\nother: value\n---";
+    assert.deepEqual(parseFrontmatterTags(content), ["a", "b"]);
+  });
+});
+
+describe("findTagDrift", () => {
+  function entry(slug: string, tags: string[]): WikiPageEntry {
+    return { slug, title: slug, description: "", tags };
+  }
+
+  it("returns no issues when index and frontmatter tags match as sets", () => {
+    const entries = [entry("foo", ["a", "b"])];
+    const frontmatter = new Map<string, string[]>([["foo", ["b", "a"]]]);
+    assert.deepEqual(findTagDrift(entries, frontmatter), []);
+  });
+
+  it("flags slugs whose tag sets differ", () => {
+    const entries = [entry("foo", ["a", "b"])];
+    const frontmatter = new Map<string, string[]>([["foo", ["a", "b", "c"]]]);
+    const issues = findTagDrift(entries, frontmatter);
+    assert.equal(issues.length, 1);
+    assert.match(issues[0], /Tag drift.*foo\.md/);
+    assert.match(issues[0], /\[a, b, c\]/);
+    assert.match(issues[0], /\[a, b\]/);
+  });
+
+  it("flags empty index tags against non-empty frontmatter", () => {
+    const entries = [entry("foo", [])];
+    const frontmatter = new Map<string, string[]>([["foo", ["a"]]]);
+    assert.equal(findTagDrift(entries, frontmatter).length, 1);
+  });
+
+  it("ignores slugs missing from the frontmatter map (covered by findMissingFiles)", () => {
+    const entries = [entry("foo", ["a"])];
+    const frontmatter = new Map<string, string[]>();
+    assert.deepEqual(findTagDrift(entries, frontmatter), []);
   });
 });


### PR DESCRIPTION
## Summary

- Surface the `tags: [...]` YAML frontmatter that wiki pages already carry on the Wiki Index, so the index is navigable once you pass ~30 pages.
- Add a "Lint My Wiki" button that spawns a fresh chat under the General role with `lint my wiki` as the first turn — no role-switching or prompt-crafting required.
- Add a `Tag drift` rule to the existing (static) Wiki Lint report so the tags in `index.md` and the tags in each page's frontmatter can't silently diverge.

## Changes

- **Server** (`server/api/routes/wiki.ts`, new `wiki/frontmatter.ts`):
  - `WikiPageEntry.tags: string[]`.
  - `parseIndexEntries` is header-aware: a `Tags` column in table-format `index.md` (case-insensitive column name, position-agnostic) or `#tag` tokens inline in the bullet format both populate `tags`. Legacy 3/4-col tables keep working → `tags: []`.
  - New `parseFrontmatterTags` reader (flow + block YAML lists, no third-party dep).
  - New `findTagDrift` lint rule wired into `collectLintIssues` using the same per-page read that the broken-link check already does (no extra fs pass).
- **Frontend** (`src/plugins/wiki/View.vue`, `index.ts`):
  - Filter chip bar above the index, with counts. Singleton tags hidden from the bar (noise); per-entry chips still render every tag so singletons stay clickable.
  - `visibleEntries` computed; empty-filter state; filter auto-clears on leaving the index.
  - "Lint My Wiki" button in the header, next to the Index/Log/Lint selector (styled like the page-level PDF download).
- **AppApi**: `startNewChat(message, roleId?)` — `roleId` overrides the current role for that one new session. Existing per-page chat composer is unchanged.
- **i18n**: `pluginWiki.tagFilterAll`, `pluginWiki.noMatches`, `pluginWiki.lintChat` translated across all 8 locales.
- **Docs**: `server/workspace/helps/wiki.md` documents the two index formats (table with `Tags` column, bullet with `#tag` tokens) and the drift invariant.
- **Plan**: `plans/feat-wiki-tags.md` captures the design.

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` — all green (only pre-existing `v-html` warnings remain).
- [x] New unit tests for `extractHashTags`, `parseTagsCell`, `buildTableColumnMap`, `parseFrontmatterTags`, `findTagDrift`, plus back-compat regression for legacy 4-column tables.
- [ ] Manual: ask Claude to regenerate `data/wiki/index.md` with tags, verify chips + filter.
- [ ] Manual: edit a page's frontmatter to diverge from index.md, run the Lint tab → expect `Tag drift` entry.
- [ ] Manual: click "Lint My Wiki" → new chat opens under General role with `lint my wiki` as the first message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki entries support per-page tags, tag chips, and an index tag-filter bar with "All" and counts
  * "Lint My Wiki" action added to trigger a wiki validation/chat

* **Documentation**
  * Updated wiki indexing rules and tag conventions; frontmatter/tag alignment (tag‑drift) documented
  * i18n messages added for tag UI and empty-state text

* **Tests**
  * Unit and E2E tests added/updated to cover tag parsing, filtering, and drift detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->