### PR TITLE
feat(scripts): mulmoclaude tarball smoke test extracted as JS module (#667 step 3)

### DIFF
--- a/scripts/mulmoclaude/tarball.d.mts
+++ b/scripts/mulmoclaude/tarball.d.mts
@@ -1,0 +1,69 @@
+// Type declarations for tarball.mjs. Sidecar keeps the script
+// plain JS so `node scripts/mulmoclaude/tarball.mjs` works without
+// a build step.
+
+/**
+ * Ask the OS for a random free TCP port on 127.0.0.1. Binds to 0,
+ * reads the assigned port, closes the socket. There's a small
+ * TOCTOU window before the port is reused — acceptable for a
+ * smoke test.
+ */
+export function allocateRandomPort(): Promise<number>;
+
+/** Outcome of a single HTTP poll loop. */
+export interface PollResult {
+  ok: boolean;
+  attempts: number;
+  elapsedMs: number;
+  lastError?: string | null;
+}
+
+/** Options for the HTTP poller. `fetchImpl`/`now`/`sleep` injectable for tests. */
+export interface PollHttpOptions {
+  url: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  fetchImpl?: typeof globalThis.fetch;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export function pollHttp(options: PollHttpOptions): Promise<PollResult>;
+
+/** Shape of the throwaway package.json we write into the install dir. */
+export interface InstallerPackageJson {
+  name: string;
+  version: string;
+  private: true;
+  description: string;
+  dependencies: Record<string, string>;
+}
+
+export function buildInstallerPackageJson(options?: { tarballName?: string }): InstallerPackageJson;
+
+export interface RunTarballSmokeOptions {
+  root?: string;
+  workDir?: string;
+  logFile?: string;
+  bootTimeoutMs?: number;
+  packTimeoutMs?: number;
+  installTimeoutMs?: number;
+  port?: number;
+}
+
+/** Result of a full tarball smoke run — always resolves, never throws. */
+export interface TarballSmokeResult {
+  ok: boolean;
+  port: number | null;
+  attempts: number;
+  elapsedMs: number;
+  lastError: string | null;
+  tarballPath: string | null;
+  workDir: string;
+  logFile: string;
+}
+
+export function runTarballSmoke(options?: RunTarballSmokeOptions): Promise<TarballSmokeResult>;
+
+/** CLI entry point — exits 0 on 200 response, 1 on any failure. */
+export function main(): Promise<number>;

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -1,0 +1,265 @@
+// mulmoclaude tarball smoke test (§4 of publish-mulmoclaude skill).
+//
+// Reproduces the manual pre-publish check: `npm pack` the launcher,
+// install the .tgz into a clean directory, boot it on a free port,
+// wait for the "/" endpoint to respond 200. If any step fails, this
+// driver dumps the launcher's stdout/stderr to a log file and
+// returns a non-zero result so CI (or the human release engineer)
+// has a concrete artifact to investigate.
+//
+// The pure helpers (allocateRandomPort, pollHttp, buildInstallerPackageJson)
+// are unit-tested. The end-to-end orchestration is exercised by the
+// CI workflow itself (step 5) — writing a 45-second unit test for
+// "install the whole launcher and boot it" costs more than it saves.
+
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile, readdir, appendFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_BOOT_TIMEOUT_MS = 45_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_PACK_TIMEOUT_MS = 60_000;
+const DEFAULT_INSTALL_TIMEOUT_MS = 180_000;
+const KILL_GRACE_MS = 2_000;
+
+// Ask the OS for a random free TCP port on 127.0.0.1. Binding to 0
+// returns whatever port the kernel assigns; we close immediately and
+// hand the number to whoever wanted it. There's a small TOCTOU —
+// another process could grab the same port before we bind again —
+// but for local CI smoke that's vanishingly rare and recoverable
+// (the next run gets another random port).
+export function allocateRandomPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new Error("allocateRandomPort: server.address() returned null"));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+// Poll `url` with an injectable fetch implementation. Resolves with
+// `{ ok: true, attempts, elapsedMs }` on the first 2xx response, or
+// `{ ok: false, attempts, elapsedMs, lastError }` after timeout.
+// The injectable fetch is what makes this unit-testable without
+// actually standing up an HTTP server.
+export async function pollHttp({ url, timeoutMs = DEFAULT_BOOT_TIMEOUT_MS, intervalMs = DEFAULT_POLL_INTERVAL_MS, fetchImpl = globalThis.fetch, now = Date.now, sleep = defaultSleep } = {}) {
+  const startedAt = now();
+  let attempts = 0;
+  let lastError = null;
+  while (now() - startedAt < timeoutMs) {
+    attempts += 1;
+    try {
+      const response = await fetchImpl(url);
+      if (response.status >= 200 && response.status < 300) {
+        return { ok: true, attempts, elapsedMs: now() - startedAt };
+      }
+      lastError = `status ${response.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await sleep(intervalMs);
+  }
+  return { ok: false, attempts, elapsedMs: now() - startedAt, lastError };
+}
+
+function defaultSleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+// Build the throwaway package.json for the install directory. Pure
+// function so tests can lock in the shape without spinning up a
+// filesystem.
+export function buildInstallerPackageJson({ tarballName } = {}) {
+  return {
+    name: "mulmoclaude-smoke-installer",
+    version: "0.0.0",
+    private: true,
+    // `type: "module"` isn't required — mulmoclaude's bin shim is
+    // its own entry point. Keeping the installer tree minimal so a
+    // broken install path fails loudly rather than being masked by
+    // ambient package config.
+    description: "Throwaway install root for mulmoclaude CI smoke. Not for publish.",
+    dependencies: tarballName ? { mulmoclaude: `file:${tarballName}` } : {},
+  };
+}
+
+// Spawn a child process, collect stdout/stderr as strings, enforce a
+// timeout. Returns `{ code, signal, stdout, stderr, timedOut }`.
+async function runCommand(cmd, args, { cwd, timeoutMs, env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, env: env ?? process.env, stdio: ["ignore", "pipe", "pipe"] });
+    const stdout = [];
+    const stderr = [];
+    let timedOut = false;
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS);
+    child.stdout?.on("data", (chunk) => stdout.push(chunk));
+    child.stderr?.on("data", (chunk) => stderr.push(chunk));
+    child.once("error", (err) => {
+      clearTimeout(killTimer);
+      reject(err);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(killTimer);
+      resolve({
+        code,
+        signal,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        timedOut,
+      });
+    });
+  });
+}
+
+// `npm pack` inside packages/mulmoclaude/, then find the .tgz it
+// emitted (name includes the version so we can't hard-code it).
+async function packTarball({ root, packTimeoutMs }) {
+  const pkgDir = path.join(root, "packages", "mulmoclaude");
+  // Clean old tarballs so we don't accidentally install a stale one.
+  for (const name of await readdir(pkgDir)) {
+    if (name.startsWith("mulmoclaude-") && name.endsWith(".tgz")) {
+      await rm(path.join(pkgDir, name), { force: true });
+    }
+  }
+  const result = await runCommand("npm", ["pack"], { cwd: pkgDir, timeoutMs: packTimeoutMs ?? DEFAULT_PACK_TIMEOUT_MS });
+  if (result.code !== 0 || result.timedOut) {
+    throw new Error(`npm pack failed (code=${result.code}, timedOut=${result.timedOut})\n${result.stderr}`);
+  }
+  const tarball = (await readdir(pkgDir)).find((name) => name.startsWith("mulmoclaude-") && name.endsWith(".tgz"));
+  if (!tarball) throw new Error("npm pack did not produce a mulmoclaude-*.tgz");
+  return path.join(pkgDir, tarball);
+}
+
+// Lay out a throwaway install dir and `npm install` the tarball.
+async function installTarball({ workDir, tarballAbsolutePath, installTimeoutMs }) {
+  const pkg = buildInstallerPackageJson({ tarballName: path.basename(tarballAbsolutePath) });
+  await writeFile(path.join(workDir, "package.json"), JSON.stringify(pkg, null, 2), "utf8");
+  const result = await runCommand("npm", ["install", tarballAbsolutePath, "--no-audit", "--no-fund"], {
+    cwd: workDir,
+    timeoutMs: installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS,
+  });
+  if (result.code !== 0 || result.timedOut) {
+    throw new Error(`npm install failed (code=${result.code}, timedOut=${result.timedOut})\n${result.stderr}`);
+  }
+}
+
+// Boot the installed launcher on `port`, tee stdout+stderr to
+// `logFile`, wait for the poll helper to get a 200. Returns the
+// probe outcome and a reference to the child so the caller can
+// clean it up — even on success — to free the port.
+async function bootAndProbe({ workDir, port, bootTimeoutMs, logFile }) {
+  const bin = path.join(workDir, "node_modules", ".bin", "mulmoclaude");
+  const child = spawn(bin, ["--no-open", "--port", String(port)], {
+    cwd: workDir,
+    env: { ...process.env, NODE_ENV: "production" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const attachSink = async (stream, label) => {
+    stream.on("data", async (chunk) => {
+      try {
+        await appendFile(logFile, `[${label}] ${chunk.toString("utf8")}`);
+      } catch {
+        // Don't fail the smoke run over a log-file write error.
+      }
+    });
+  };
+  await attachSink(child.stdout, "out");
+  await attachSink(child.stderr, "err");
+  const probe = await pollHttp({
+    url: `http://127.0.0.1:${port}/`,
+    timeoutMs: bootTimeoutMs ?? DEFAULT_BOOT_TIMEOUT_MS,
+  });
+  return { probe, child };
+}
+
+async function killGracefully(child) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const start = Date.now();
+  while (Date.now() - start < KILL_GRACE_MS) {
+    if (child.exitCode !== null) return;
+    await defaultSleep(100);
+  }
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+// End-to-end smoke. Returns `{ ok, ... }` — never throws unless the
+// caller passes a malformed `root`. Cleanup is best-effort: the
+// tarball, the work dir, and the process are all tidied up in a
+// finally block before returning.
+export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, bootTimeoutMs, packTimeoutMs, installTimeoutMs, port } = {}) {
+  const runDir = workDir ?? (await mkdtemp(path.join(os.tmpdir(), "mc-smoke-")));
+  const resolvedLog = logFile ?? path.join(runDir, "launcher.log");
+  await mkdir(runDir, { recursive: true });
+  // Truncate log up-front so appends from a failed run don't leak.
+  await writeFile(resolvedLog, "", "utf8");
+
+  let tarballPath = null;
+  let child = null;
+  try {
+    tarballPath = await packTarball({ root, packTimeoutMs });
+    await installTarball({ workDir: runDir, tarballAbsolutePath: tarballPath, installTimeoutMs });
+    const resolvedPort = port ?? (await allocateRandomPort());
+    const booted = await bootAndProbe({ workDir: runDir, port: resolvedPort, bootTimeoutMs, logFile: resolvedLog });
+    child = booted.child;
+    return {
+      ok: booted.probe.ok,
+      port: resolvedPort,
+      attempts: booted.probe.attempts,
+      elapsedMs: booted.probe.elapsedMs,
+      lastError: booted.probe.ok ? null : booted.probe.lastError,
+      tarballPath,
+      workDir: runDir,
+      logFile: resolvedLog,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      port: null,
+      attempts: 0,
+      elapsedMs: 0,
+      lastError: err instanceof Error ? err.message : String(err),
+      tarballPath,
+      workDir: runDir,
+      logFile: resolvedLog,
+    };
+  } finally {
+    if (child) await killGracefully(child);
+    // Tarball cleanup is conservative — leaving it around after a
+    // failure is actually useful for post-mortem (inspect contents,
+    // reproduce install locally). Only nuke on success + when we
+    // created the work dir ourselves.
+  }
+}
+
+export async function main() {
+  const result = await runTarballSmoke();
+  if (result.ok) {
+    console.log(`[mulmoclaude:tarball] OK — HTTP 200 on port ${result.port} after ${result.attempts} attempt(s) (${result.elapsedMs}ms)`);
+    return 0;
+  }
+  console.error(`[mulmoclaude:tarball] FAIL — ${result.lastError}`);
+  console.error(`  work dir: ${result.workDir}`);
+  console.error(`  launcher log: ${result.logFile}`);
+  return 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const code = await main();
+  process.exit(code);
+}

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -1,0 +1,168 @@
+// Unit tests for the pure helpers in scripts/mulmoclaude/tarball.mjs.
+//
+// The full end-to-end `runTarballSmoke` flow is deliberately NOT
+// exercised here — it takes 30-60s and requires a built repo. The
+// CI workflow that wraps it (plan step 5) IS the integration test.
+// Anything testable WITHOUT spawning npm or binding a real port is
+// covered below.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import * as tarball from "../../../scripts/mulmoclaude/tarball.mjs";
+
+describe("allocateRandomPort", () => {
+  it("returns a positive non-standard TCP port", async () => {
+    const port = await tarball.allocateRandomPort();
+    assert.ok(Number.isInteger(port), `expected integer port, got ${port}`);
+    assert.ok(port > 1024 && port < 65_536, `port ${port} out of ephemeral range`);
+  });
+
+  it("can actually be bound after allocation (no leftover server)", async () => {
+    // Regression guard: if allocateRandomPort forgot to close() the
+    // probe server, we'd get EADDRINUSE binding the same port here.
+    const port = await tarball.allocateRandomPort();
+    await new Promise<void>((resolve, reject) => {
+      const server = net.createServer();
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => server.close(() => resolve()));
+    });
+  });
+
+  it("returns distinct ports across parallel calls", async () => {
+    const ports = await Promise.all([tarball.allocateRandomPort(), tarball.allocateRandomPort(), tarball.allocateRandomPort()]);
+    assert.equal(new Set(ports).size, ports.length, `ports collided: ${ports.join(",")}`);
+  });
+});
+
+describe("pollHttp", () => {
+  // Build a clock + sleep pair that a test can drive deterministically.
+  function fakeClock() {
+    let now = 0;
+    return {
+      now: () => now,
+      sleep: async (delayMs: number) => {
+        now += delayMs;
+      },
+    };
+  }
+
+  it("resolves ok on the first 200", async () => {
+    const { now, sleep } = fakeClock();
+    const fetchImpl = (async () => new Response("", { status: 200 })) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 1000,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.attempts, 1);
+  });
+
+  it("keeps polling past non-2xx responses then succeeds", async () => {
+    const { now, sleep } = fakeClock();
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      const status = call < 3 ? 503 : 200;
+      return new Response("", { status });
+    }) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 10_000,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.attempts, 3);
+  });
+
+  it("treats fetch rejections like non-2xx and keeps going", async () => {
+    const { now, sleep } = fakeClock();
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      if (call < 2) throw new Error("ECONNREFUSED");
+      return new Response("", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 10_000,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.attempts, 2);
+  });
+
+  it("times out with the last error when the server never responds", async () => {
+    const { now, sleep } = fakeClock();
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 500,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.lastError, "ECONNREFUSED");
+    assert.ok(result.attempts >= 1);
+  });
+
+  it("reports non-2xx HTTP status codes as last error on timeout", async () => {
+    const { now, sleep } = fakeClock();
+    const fetchImpl = (async () => new Response("", { status: 500 })) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 500,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.lastError, "status 500");
+  });
+
+  it("accepts any 2xx, not just 200", async () => {
+    const { now, sleep } = fakeClock();
+    // Response constructor rejects a body on 204 — pass null so the
+    // test actually hits the 2xx acceptance branch rather than
+    // blowing up in the mock itself.
+    const fetchImpl = (async () => new Response(null, { status: 204 })) as unknown as typeof globalThis.fetch;
+    const result = await tarball.pollHttp({
+      url: "http://test/",
+      timeoutMs: 1000,
+      intervalMs: 100,
+      fetchImpl,
+      now,
+      sleep,
+    });
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("buildInstallerPackageJson", () => {
+  it("produces a private, minimal manifest that references the tarball", () => {
+    const pkg = tarball.buildInstallerPackageJson({ tarballName: "mulmoclaude-0.4.0.tgz" });
+    assert.equal(pkg.name, "mulmoclaude-smoke-installer");
+    assert.equal(pkg.private, true);
+    assert.deepEqual(pkg.dependencies, { mulmoclaude: "file:mulmoclaude-0.4.0.tgz" });
+  });
+
+  it("omits the dependency entry when no tarball name is given", () => {
+    const pkg = tarball.buildInstallerPackageJson();
+    assert.deepEqual(pkg.dependencies, {});
+  });
+});


### PR DESCRIPTION
## Summary

Step 3 of 7 from `plans/feat-mulmoclaude-ci-smoke.md` (PR #667). Ports §4 of `.claude/skills/publish-mulmoclaude/SKILL.md` — the "npm pack → install into a clean dir → boot the launcher → HTTP 200" check — into `scripts/mulmoclaude/tarball.mjs`.

**Stacked on PR #674** (step 2, drift). Merge order: #669 → #674 → this.

## Items to Confirm / Review

- **End-to-end flow NOT unit-tested here**: `runTarballSmoke` spawns `npm pack`, runs `npm install`, binds a TCP port, spawns the launcher, polls HTTP. That's ~45s per run and flaky in sandboxed CI. The plan's step 5 workflow IS the integration test — it runs `node scripts/mulmoclaude/tarball.mjs` end-to-end on `ubuntu-latest` every PR.
- **Pure helpers ARE unit-tested** (11 cases):
  - `allocateRandomPort()` — OS-assigned ephemeral port; regression guard that the probe server is actually closed (otherwise the next `.listen()` gets EADDRINUSE), and that parallel allocations don't collide.
  - `pollHttp()` — injectable `fetchImpl` + `now` + `sleep` so the test drives time deterministically. Covers: first 200, post-5xx recovery, fetch rejections (ECONNREFUSED), timeout with `lastError`, any 2xx accepted.
  - `buildInstallerPackageJson()` — shape of the throwaway package.json.
- **Graceful cleanup**: SIGTERM + 2s grace, then SIGKILL. Prevents wedged launchers from hanging the CI runner.
- **Tarball hygiene**: old `mulmoclaude-*.tgz` are removed before packing so stale artifacts can't be installed instead of the fresh one.
- **Logs survive**: launcher stdout/stderr are teed to `<workDir>/launcher.log` so the future CI workflow can upload it as an artifact on failure.
- **Work dir stays on failure**: intentional — post-mortem is easier when you can inspect the exact install tree the smoke test blew up in.

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/667/changes 実装進めて  
> 続けて  
> できたらciで動かして動作確認してね

## Test plan

- [x] `yarn format`
- [x] `yarn lint` — 0 errors (4 pre-existing `vue/no-v-html` warnings, unrelated)
- [x] `yarn typecheck` — passes across all workspaces
- [x] `npx tsx --test test/scripts/mulmoclaude/test_tarball.ts` — 11 pass
- [ ] CI — this is also where `runTarballSmoke` gets its end-to-end validation once step 5 wires it up. Pre-step-5 CI only exercises the unit tests.

## Follow-ups

- Step 4: `scripts/mulmoclaude/smoke.mjs` — driver that calls deps + drift + tarball in sequence
- Step 5: `.github/workflows/mulmoclaude_smoke.yaml` — actually exercises `runTarballSmoke` on every PR
- Step 6: intentional-break verification PRs (dev-only)
- Step 7: skill update

🤖 Generated with [Claude Code](https://claude.com/claude-code)