### PR TITLE
feat(history): make filter state URL-driven via path param

### DIFF
--- a/e2e/tests/history-filter.spec.ts
+++ b/e2e/tests/history-filter.spec.ts
@@ -1,0 +1,87 @@
+// E2E for the /history filter pill ↔ URL path param (#677).
+//
+// Clicking a pill pushes a new entry onto browser history, so back /
+// forward restore the prior filter state and deep links like
+// /history/unread open the panel with that pill already active.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { SESSION_A } from "../fixtures/sessions";
+
+test.describe("/history filter URL", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("landing on /history shows the All filter active", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+    // Class derived in the component: active pill gets bg-blue-500.
+    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-500/);
+  });
+
+  test("clicking the Unread pill updates the URL to /history/unread", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+
+    await page.getByTestId("session-filter-unread").click();
+
+    await expect(page).toHaveURL(/\/history\/unread$/);
+    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-500/);
+  });
+
+  test("clicking the Human pill updates the URL to /history/human", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+
+    await page.getByTestId("session-filter-human").click();
+
+    await expect(page).toHaveURL(/\/history\/human$/);
+    await expect(page.getByTestId("session-filter-human")).toHaveClass(/bg-blue-500/);
+    // Default-origin sessions (no `origin` field) render as `human`
+    // per `originOf`, so they remain visible under the Human filter.
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+  });
+
+  test("browser back restores the prior filter state", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+
+    await page.getByTestId("session-filter-unread").click();
+    await expect(page).toHaveURL(/\/history\/unread$/);
+
+    await page.getByTestId("session-filter-human").click();
+    await expect(page).toHaveURL(/\/history\/human$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/history\/unread$/);
+    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-500/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/history$/);
+    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-500/);
+  });
+
+  test("clicking the All pill from /history/unread returns to bare /history", async ({ page }) => {
+    await page.goto("/history/unread");
+    // Fixtures aren't flagged unread, so no session rows render here.
+    // Wait on the filter bar itself instead of a session item.
+    await expect(page.getByTestId("session-filter-bar")).toBeVisible();
+    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-500/);
+
+    await page.getByTestId("session-filter-all").click();
+
+    await expect(page).toHaveURL(/\/history$/);
+    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-500/);
+    await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
+  });
+
+  test("deep link to /history/scheduler opens with Scheduler pill active", async ({ page }) => {
+    await page.goto("/history/scheduler");
+    // Default fixtures are human-origin, so the Scheduler filter
+    // shows no matching sessions. We only assert the active-pill
+    // state + filter-bar rendering, not a specific session row.
+    await expect(page.getByTestId("session-filter-bar")).toBeVisible();
+    await expect(page.getByTestId("session-filter-scheduler")).toHaveClass(/bg-blue-500/);
+  });
+});

--- a/e2e/tests/history-filter.spec.ts
+++ b/e2e/tests/history-filter.spec.ts
@@ -84,4 +84,32 @@ test.describe("/history filter URL", () => {
     await expect(page.getByTestId("session-filter-bar")).toBeVisible();
     await expect(page.getByTestId("session-filter-scheduler")).toHaveClass(/bg-blue-500/);
   });
+
+  test("history close button from a deep filter pushes forward to the pre-history page", async ({ page }) => {
+    // "Close" is an explicit user intent — it pushes a new history
+    // entry rather than unwinding, so (a) one click closes the whole
+    // /history section regardless of how many filters were traversed,
+    // and (b) browser back from the closed state still reveals the
+    // last filter the user was viewing.
+    await page.goto("/chat");
+    await page.waitForURL(/\/chat\//);
+    const priorUrl = page.url();
+
+    await page.getByTestId("history-btn").click();
+    await expect(page).toHaveURL(/\/history$/);
+
+    await page.getByTestId("session-filter-unread").click();
+    await expect(page).toHaveURL(/\/history\/unread$/);
+
+    await page.getByTestId("session-filter-human").click();
+    await expect(page).toHaveURL(/\/history\/human$/);
+
+    // One click closes the whole /history section.
+    await page.getByTestId("history-btn").click();
+    await expect(page).toHaveURL(priorUrl);
+
+    // Browser back from the closed state still reveals the last filter.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/history\/human$/);
+  });
 });

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -70,12 +70,12 @@ test.describe("history panel (useSessionHistory)", () => {
     await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
   });
 
-  test("second click on history button (while on /history) goes back to prior page", async ({ page }) => {
+  test("second click on history button (while on /history) returns to prior page", async ({ page }) => {
     await page.goto("/chat");
     // Wait for the `/chat` → `/chat/<newSessionId>` redirect to
     // settle before capturing the "prior" URL — reading before the
-    // redirect gives the bare /chat which is not what the second
-    // click's router.back() lands on.
+    // redirect gives the bare /chat which isn't what the close push
+    // lands on.
     await page.waitForURL(/\/chat\//);
     const priorUrl = page.url();
 

--- a/plans/feat-history-filter-url.md
+++ b/plans/feat-history-filter-url.md
@@ -1,0 +1,131 @@
+# plan: history filter via URL path param
+
+Tracking: #677
+
+## Goal
+
+Make the `/history` filter pill (All / Unread / Human / Scheduler / Skill / Bridge) URL-driven via a path param so browser back / forward restore prior filter states and deep links like `/history/unread` work.
+
+## Non-goals
+
+- No new filters, no server-side filtering.
+- Unread count, mark-as-read, session list fetching — untouched.
+- No localStorage persistence (URL is the source of truth).
+
+## Design
+
+### Router
+
+Replace the current `{ path: "/history" }` with:
+
+```ts
+{ path: `/history/:filter(${HISTORY_FILTER_ROUTE_PATTERN})?`, name: PAGE_ROUTES.history, component: Stub }
+```
+
+`HISTORY_FILTER_ROUTE_PATTERN` is a pipe-joined list of non-default filter keys (every key except `all`), built once from `HISTORY_FILTERS`. Omitting the segment or hitting an unmatched value (vue-router refuses to match) just lands on the bare `/history` → `all` default. The value still gets re-validated in-component against the constants list, so a typo in a hand-rolled link stays safe.
+
+### Constants — `src/config/historyFilters.ts` (new)
+
+```ts
+import { SESSION_ORIGINS, type SessionOrigin } from "../types/session";
+
+export const HISTORY_FILTERS = {
+  all: "all",
+  unread: "unread",
+  human: SESSION_ORIGINS.human,
+  scheduler: SESSION_ORIGINS.scheduler,
+  skill: SESSION_ORIGINS.skill,
+  bridge: SESSION_ORIGINS.bridge,
+} as const;
+
+export type HistoryFilter = (typeof HISTORY_FILTERS)[keyof typeof HISTORY_FILTERS];
+
+// Ordered list used by the pill row renderer. `all` first.
+export const HISTORY_FILTER_ORDER: readonly HistoryFilter[] = [
+  HISTORY_FILTERS.all,
+  HISTORY_FILTERS.unread,
+  HISTORY_FILTERS.human,
+  HISTORY_FILTERS.scheduler,
+  HISTORY_FILTERS.skill,
+  HISTORY_FILTERS.bridge,
+] as const;
+
+// Pipe-joined pattern for the vue-router path param (excludes `all`,
+// which is represented by the bare `/history` URL).
+export const HISTORY_FILTER_ROUTE_PATTERN = HISTORY_FILTER_ORDER
+  .filter((value) => value !== HISTORY_FILTERS.all)
+  .join("|");
+
+export function isHistoryFilter(value: unknown): value is HistoryFilter {
+  return typeof value === "string" && HISTORY_FILTER_ORDER.includes(value as HistoryFilter);
+}
+```
+
+### SessionHistoryPanel.vue
+
+Replace the local `const activeFilter = ref<FilterKey>("all")` with a `computed<HistoryFilter>({ get, set })` bound to `route.params.filter`:
+
+```ts
+const activeFilter = computed<HistoryFilter>({
+  get: () => {
+    const raw = route.params.filter;
+    return typeof raw === "string" && isHistoryFilter(raw) ? raw : HISTORY_FILTERS.all;
+  },
+  set: (value) => {
+    const params = value === HISTORY_FILTERS.all ? {} : { filter: value };
+    router.push({ name: PAGE_ROUTES.history, params });
+  },
+});
+```
+
+`filteredSessions`, the pill renderer, and the per-filter count logic all keep reading `activeFilter.value` and stay unchanged. The local `FILTERS` array is replaced by `HISTORY_FILTER_ORDER` imported from the new config. The local `UNREAD_FILTER` constant is replaced by `HISTORY_FILTERS.unread`.
+
+### `router.push` vs `router.replace`
+
+User explicitly chose `push` — filter changes should populate browser history so back/forward restore prior filter states. Downside: clicking through all 6 filters stacks 6 history entries, which makes the back button traverse each before leaving `/history`. Acceptable cost for the feature.
+
+### i18n
+
+Filter labels already exist under `sessionHistoryPanel.filters.*` in all 8 locales (keyed by filter value). No translation work needed.
+
+## Testing
+
+### Unit
+
+`test/config/test_historyFilters.ts` — new. Covers:
+
+- `isHistoryFilter` happy / negative / edge cases (empty string, wrong type, unknown value).
+- `HISTORY_FILTER_ORDER` includes every value in `HISTORY_FILTERS` exactly once.
+- `HISTORY_FILTER_ROUTE_PATTERN` does not contain `all` and contains every non-default filter.
+- `HISTORY_FILTERS` values match `SESSION_ORIGINS` for the four origin keys.
+
+### E2E
+
+Extend `e2e/tests/router-navigation.spec.ts` (or add a sibling `history-filter.spec.ts`):
+
+- Land on `/history` → `All` pill is active, URL has no trailing segment.
+- Click `Unread` → URL becomes `/history/unread`, Unread pill becomes active.
+- Click `Human` → URL becomes `/history/human`.
+- Browser back → URL and active pill return to `/history/unread`.
+- Browser back again → URL and active pill return to `/history` with `All` active.
+- Deep link: `page.goto("/history/scheduler")` → Scheduler pill is active immediately.
+- Bogus deep link: `page.goto("/history/bogus")` → vue-router doesn't match, and the app's catch-all redirects to `/chat` (confirm this is desirable). If we want `/history/bogus` → `/history` (all) instead, add a fallback in the history-panel mount.
+
+## Files to touch
+
+- `src/config/historyFilters.ts` — new
+- `src/router/index.ts` — widen `/history` route
+- `src/components/SessionHistoryPanel.vue` — ref → computed, import from config, drop local constants
+- `test/config/test_historyFilters.ts` — new
+- `e2e/tests/router-navigation.spec.ts` (or new spec) — new cases
+
+## Done when
+
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
+- `yarn test` green on the new unit cases
+- Manual smoke: click each filter pill, back button restores prior state, deep links work
+- PR merged
+
+## Open questions (to decide during review)
+
+- **Catch-all behaviour for `/history/bogus`**: current router has `{ path: "/:pathMatch(.*)*", redirect: "/chat" }` as the catch-all. Plan above relies on the regex pattern in the param definition to restrict matches to known filter values, so `/history/bogus` falls through to the catch-all → `/chat`. Plan treats this as acceptable. If we want a softer fallback (redirect unknown filters to `/history`), add `{ path: "/history/:pathMatch(.*)", redirect: "/history" }` just before the catch-all. Will raise this in the PR for the reviewer.

--- a/src/App.vue
+++ b/src/App.vue
@@ -213,6 +213,7 @@ import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
 import { useMergedSessions } from "./composables/useMergedSessions";
 import { useLayoutMode } from "./composables/useLayoutMode";
+import { useHistoryEntrance } from "./composables/useHistoryEntrance";
 import { useSelectedResult } from "./composables/useSelectedResult";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
@@ -361,6 +362,7 @@ const { showRightSidebar, toggleRightSidebar } = useRightSidebar();
 const showSettings = ref(false);
 
 const { layoutMode, setLayoutMode, toggleLayoutMode } = useLayoutMode();
+const { preHistoryUrl } = useHistoryEntrance();
 
 // Current page derives from the route. The chat page has a layout
 // preference on top (single vs. stack); other pages are distinct
@@ -763,22 +765,19 @@ async function sendMessage(text?: string) {
 }
 
 // History is a page route (/history) now — no click-outside handling
-// needed. Clicking the history button toggles between /history and the
-// previous page via router.back / router.push.
+// needed. Clicking the history button from elsewhere opens /history;
+// clicking it while on /history "closes" by pushing forward to the
+// page the user came from (remembered by useHistoryEntrance). Close
+// is an explicit user intent — it should create a new history entry,
+// not rewind, so browser-back from the target still reveals the last
+// /history/<filter> the user was looking at.
 function handleHistoryClick(): void {
   if (currentPage.value !== PAGE_ROUTES.history) {
     router.push({ name: PAGE_ROUTES.history }).catch(() => {});
     return;
   }
-  // Direct-link to /history has no prior entry to go back to.
-  // vue-router exposes the previous entry on window.history.state.back;
-  // when null, fall back to /chat so the button still closes the panel.
-  const hasBack = typeof window !== "undefined" && window.history.state?.back != null;
-  if (hasBack) {
-    router.back();
-  } else {
-    router.push({ name: PAGE_ROUTES.chat }).catch(() => {});
-  }
+  const target = preHistoryUrl.value ?? { name: PAGE_ROUTES.chat };
+  router.push(target).catch(() => {});
 }
 
 // Fetch the session list when entering /history. Not `immediate` on

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -8,7 +8,7 @@
       <!-- Origin filter bar -->
       <div class="flex gap-1 mb-1 flex-wrap" data-testid="session-filter-bar">
         <button
-          v-for="f in FILTERS"
+          v-for="f in HISTORY_FILTER_ORDER"
           :key="f"
           class="px-2 py-0.5 text-[10px] rounded-full border transition-colors"
           :class="activeFilter === f ? 'bg-blue-500 text-white border-blue-500' : 'bg-white text-gray-500 border-gray-300 hover:bg-gray-50'"
@@ -16,7 +16,7 @@
           @click="activeFilter = f"
         >
           {{ t(`sessionHistoryPanel.filters.${f}`) }}
-          <span v-if="f !== 'all'" class="ml-0.5 opacity-70">{{ countByOrigin(f) }}</span>
+          <span v-if="f !== HISTORY_FILTERS.all" class="ml-0.5 opacity-70">{{ countByOrigin(f) }}</span>
         </button>
       </div>
 
@@ -30,7 +30,7 @@
         <span v-if="sessions.length > 0">{{ t("sessionHistoryPanel.showingLastKnown") }}</span>
       </div>
       <p v-if="filteredSessions.length === 0" class="text-xs text-gray-400 p-2">
-        {{ activeFilter === "all" ? t("sessionHistoryPanel.noSessions") : t("sessionHistoryPanel.noMatching") }}
+        {{ activeFilter === HISTORY_FILTERS.all ? t("sessionHistoryPanel.noSessions") : t("sessionHistoryPanel.noMatching") }}
       </p>
       <div
         v-for="session in filteredSessions"
@@ -75,21 +75,23 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
 import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
+import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, isHistoryFilter, type HistoryFilter } from "../config/historyFilters";
+import { PAGE_ROUTES } from "../router";
 import { formatDate } from "../utils/format/date";
 import { roleIcon, roleName } from "../utils/role/icon";
 
 const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
 
 // `unread` is mutually exclusive with origin pills — selecting it
 // shows every unread-flagged session regardless of origin, matching
 // the user expectation that "unread" is the primary question ("what
 // needs my attention?") rather than an origin sub-filter.
-const UNREAD_FILTER = "unread" as const;
-const FILTERS = ["all" as const, UNREAD_FILTER, SESSION_ORIGINS.human, SESSION_ORIGINS.scheduler, SESSION_ORIGINS.skill, SESSION_ORIGINS.bridge];
-type FilterKey = (typeof FILTERS)[number];
 
 const ORIGIN_ICONS: Record<string, string> = {
   human: "person",
@@ -122,21 +124,32 @@ defineExpose({ root });
 
 // ── Filter ──────────────────────────────────────────────────
 
-const activeFilter = ref<FilterKey>("all");
+// Backed by the /history/:filter? path param so browser back/forward
+// restores prior filter states and deep links like /history/unread work.
+const activeFilter = computed<HistoryFilter>({
+  get: () => {
+    const raw = route.params.filter;
+    return typeof raw === "string" && isHistoryFilter(raw) ? raw : HISTORY_FILTERS.all;
+  },
+  set: (value) => {
+    const params = value === HISTORY_FILTERS.all ? {} : { filter: value };
+    router.push({ name: PAGE_ROUTES.history, params });
+  },
+});
 
 function originOf(session: SessionSummary): SessionOrigin {
   return session.origin ?? SESSION_ORIGINS.human;
 }
 
 const filteredSessions = computed(() => {
-  if (activeFilter.value === "all") return props.sessions;
-  if (activeFilter.value === UNREAD_FILTER) return props.sessions.filter((session) => session.hasUnread === true);
+  if (activeFilter.value === HISTORY_FILTERS.all) return props.sessions;
+  if (activeFilter.value === HISTORY_FILTERS.unread) return props.sessions.filter((session) => session.hasUnread === true);
   return props.sessions.filter((session) => originOf(session) === activeFilter.value);
 });
 
-function countByOrigin(filterKey: FilterKey): number {
-  if (filterKey === "all") return props.sessions.length;
-  if (filterKey === UNREAD_FILTER) return props.sessions.filter((session) => session.hasUnread === true).length;
+function countByOrigin(filterKey: HistoryFilter): number {
+  if (filterKey === HISTORY_FILTERS.all) return props.sessions.length;
+  if (filterKey === HISTORY_FILTERS.unread) return props.sessions.filter((session) => session.hasUnread === true).length;
   return props.sessions.filter((session) => originOf(session) === filterKey).length;
 }
 

--- a/src/composables/useHistoryEntrance.ts
+++ b/src/composables/useHistoryEntrance.ts
@@ -1,0 +1,39 @@
+// Tracks the fullPath of the page the user was on just before they
+// navigated INTO the /history route. Used by the history-close button
+// so it can push-forward back to where the user came from, instead of
+// using router.back() — "close" is an explicit user intent and should
+// create a new history entry, not rewind. (See review thread on #681
+// for the full rationale.)
+//
+// Scope:
+//   - Records `from.fullPath` on every non-history → /history transition.
+//   - Value is NOT cleared when the user leaves /history. It gets
+//     overwritten on the NEXT entrance. This keeps the value meaningful
+//     across a session click (/history → /chat/<id>) without losing
+//     the original pre-history URL if the user immediately opens
+//     /history again from the same place.
+//   - When the user deep-links into /history directly (no prior entry),
+//     `preHistoryUrl` stays null — the caller falls back to /chat.
+
+import { ref, type Ref } from "vue";
+import { useRouter } from "vue-router";
+import { PAGE_ROUTES } from "../router";
+
+export function useHistoryEntrance(): { preHistoryUrl: Ref<string | null> } {
+  const router = useRouter();
+  const preHistoryUrl = ref<string | null>(null);
+
+  router.afterEach((nextRoute, prevRoute) => {
+    const enteringHistory = nextRoute.name === PAGE_ROUTES.history && prevRoute.name !== PAGE_ROUTES.history;
+    // Skip the synthetic START_LOCATION (prevRoute.name === undefined),
+    // which fires on initial navigation when the user deep-links
+    // straight to /history. No real "pre-history page" exists in that
+    // case — leaving preHistoryUrl null makes handleHistoryClick fall
+    // back to /chat instead of pushing to the bogus "/" root.
+    if (enteringHistory && prevRoute.name != null && typeof prevRoute.fullPath === "string" && prevRoute.fullPath.length > 0) {
+      preHistoryUrl.value = prevRoute.fullPath;
+    }
+  });
+
+  return { preHistoryUrl };
+}

--- a/src/config/historyFilters.ts
+++ b/src/config/historyFilters.ts
@@ -1,0 +1,42 @@
+// Filter keys for the `/history` page. Kept here (not in
+// `types/session.ts`) because `all` and `unread` are UI concepts — not
+// session-origin values — even though the four origin filters reuse
+// `SESSION_ORIGINS` verbatim so a single source of truth stays per
+// concept.
+//
+// The filter value is also a URL segment: `/history/unread`,
+// `/history/human`, etc. `all` is represented by the bare `/history`
+// URL, so it is excluded from `HISTORY_FILTER_ROUTE_PATTERN`.
+
+import { SESSION_ORIGINS } from "../types/session";
+
+export const HISTORY_FILTERS = {
+  all: "all",
+  unread: "unread",
+  human: SESSION_ORIGINS.human,
+  scheduler: SESSION_ORIGINS.scheduler,
+  skill: SESSION_ORIGINS.skill,
+  bridge: SESSION_ORIGINS.bridge,
+} as const;
+
+export type HistoryFilter = (typeof HISTORY_FILTERS)[keyof typeof HISTORY_FILTERS];
+
+// Display order for the pill row. `all` is always first; `unread` sits
+// between `all` and the origin filters to mirror the existing
+// hand-written order in SessionHistoryPanel.
+export const HISTORY_FILTER_ORDER: readonly HistoryFilter[] = [
+  HISTORY_FILTERS.all,
+  HISTORY_FILTERS.unread,
+  HISTORY_FILTERS.human,
+  HISTORY_FILTERS.scheduler,
+  HISTORY_FILTERS.skill,
+  HISTORY_FILTERS.bridge,
+] as const;
+
+// Pipe-joined pattern for the vue-router path param. Excludes `all`,
+// which is represented by the bare `/history` URL.
+export const HISTORY_FILTER_ROUTE_PATTERN: string = HISTORY_FILTER_ORDER.filter((value) => value !== HISTORY_FILTERS.all).join("|");
+
+export function isHistoryFilter(value: unknown): value is HistoryFilter {
+  return typeof value === "string" && HISTORY_FILTER_ORDER.includes(value as HistoryFilter);
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,6 +12,7 @@
 
 import { defineComponent, h } from "vue";
 import { createRouter, createWebHistory, type RouteRecordRaw } from "vue-router";
+import { HISTORY_FILTER_ROUTE_PATTERN } from "../config/historyFilters";
 
 // Stub component that renders nothing. Required by vue-router (every
 // route needs a component) but never actually mounted because App.vue
@@ -53,7 +54,11 @@ const routes: RouteRecordRaw[] = [
   { path: "/wiki/:section(pages|log|lint-report)?/:slug?", name: PAGE_ROUTES.wiki, component: Stub },
   { path: "/skills", name: PAGE_ROUTES.skills, component: Stub },
   { path: "/roles", name: PAGE_ROUTES.roles, component: Stub },
-  { path: "/history", name: PAGE_ROUTES.history, component: Stub },
+  // `filter` is a closed enum (see src/config/historyFilters.ts). The
+  // default `all` is represented by the bare `/history` URL, so it is
+  // not part of the pattern. Unknown values fall through to the
+  // catch-all redirect below.
+  { path: `/history/:filter(${HISTORY_FILTER_ROUTE_PATTERN})?`, name: PAGE_ROUTES.history, component: Stub },
   { path: "/:pathMatch(.*)*", redirect: "/chat" },
 ];
 

--- a/test/config/test_historyFilters.ts
+++ b/test/config/test_historyFilters.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, HISTORY_FILTER_ROUTE_PATTERN, isHistoryFilter } from "../../src/config/historyFilters.js";
+import { SESSION_ORIGINS } from "../../src/types/session.js";
+
+describe("HISTORY_FILTERS", () => {
+  it("reuses SESSION_ORIGINS for the four origin filter values", () => {
+    assert.equal(HISTORY_FILTERS.human, SESSION_ORIGINS.human);
+    assert.equal(HISTORY_FILTERS.scheduler, SESSION_ORIGINS.scheduler);
+    assert.equal(HISTORY_FILTERS.skill, SESSION_ORIGINS.skill);
+    assert.equal(HISTORY_FILTERS.bridge, SESSION_ORIGINS.bridge);
+  });
+
+  it("defines `all` and `unread` as UI-only filters", () => {
+    assert.equal(HISTORY_FILTERS.all, "all");
+    assert.equal(HISTORY_FILTERS.unread, "unread");
+  });
+});
+
+describe("HISTORY_FILTER_ORDER", () => {
+  it("contains every value in HISTORY_FILTERS exactly once", () => {
+    const expected = Object.values(HISTORY_FILTERS).sort();
+    const actual = [...HISTORY_FILTER_ORDER].sort();
+    assert.deepEqual(actual, expected);
+  });
+
+  it("starts with `all` so the pill row renders it first", () => {
+    assert.equal(HISTORY_FILTER_ORDER[0], HISTORY_FILTERS.all);
+  });
+});
+
+describe("HISTORY_FILTER_ROUTE_PATTERN", () => {
+  it("excludes `all` (represented by the bare /history URL)", () => {
+    const parts = HISTORY_FILTER_ROUTE_PATTERN.split("|");
+    assert.ok(!parts.includes(HISTORY_FILTERS.all));
+  });
+
+  it("includes every non-default filter value", () => {
+    const parts = HISTORY_FILTER_ROUTE_PATTERN.split("|");
+    const expected = Object.values(HISTORY_FILTERS).filter((value) => value !== HISTORY_FILTERS.all);
+    assert.deepEqual(parts.sort(), expected.sort());
+  });
+});
+
+describe("isHistoryFilter", () => {
+  it("accepts every known filter value", () => {
+    for (const value of HISTORY_FILTER_ORDER) {
+      assert.equal(isHistoryFilter(value), true, `expected ${value} to be accepted`);
+    }
+  });
+
+  it("rejects unknown strings", () => {
+    assert.equal(isHistoryFilter("bogus"), false);
+    assert.equal(isHistoryFilter(""), false);
+    assert.equal(isHistoryFilter("ALL"), false);
+    assert.equal(isHistoryFilter(" all"), false);
+  });
+
+  it("rejects non-string values", () => {
+    assert.equal(isHistoryFilter(undefined), false);
+    assert.equal(isHistoryFilter(null), false);
+    assert.equal(isHistoryFilter(42), false);
+    assert.equal(isHistoryFilter({}), false);
+    assert.equal(isHistoryFilter([]), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Moves the `/history` filter pill (All / Unread / Human / Scheduler / Skill / Bridge) into the URL as a path param so browser back/forward restore prior filter states and deep links like `/history/unread` work.
- Introduces `src/config/historyFilters.ts` as the single source of truth for filter keys, display order, the route pattern fragment, and a type guard.
- 6 new unit tests + 6 new e2e tests.

Closes #677.

## Items to Confirm / Review

1. **Constants location** — `src/config/historyFilters.ts` (new) alongside other config. Reuses `SESSION_ORIGINS` from `src/types/session.ts` for the four origin keys so the origin values stay single-sourced; `all` and `unread` are UI-only filters and live only in the new file. Open to alternative locations (e.g., folding into `src/types/session.ts` or `src/router/index.ts`) if preferred.
2. **Path-param vs query-param** — user explicitly asked for path param. Lines up with existing route conventions (`/chat/:sessionId?`, `/files/:pathMatch(.*)`, `/wiki/:section?/:slug?`). Router pattern is built from the constants (`HISTORY_FILTER_ROUTE_PATTERN`) so the router and component share one list — adding a new filter in the future only touches the config file.
3. **`router.push` vs `router.replace`** — user chose `push`. Each pill click adds a history entry. Tradeoff noted in `plans/feat-history-filter-url.md`: if you click through 6 filters, you need 6 back-presses to leave `/history`. Acceptable because the whole point is making filter transitions addressable.
4. **`/history/bogus` behaviour** — the regex-constrained path param means vue-router does NOT match unknown filter values, so `/history/bogus` falls through to the repo-wide catch-all (`{ path: "/:pathMatch(.*)*", redirect: "/chat" }`). If we'd rather land on `/history` (all) for unknown filters, add `{ path: "/history/:pathMatch(.*)", redirect: "/history" }` above the catch-all. Flagged in the plan; currently not implemented because I didn't want to hardcode a redirect the user didn't ask for.
5. **No i18n work needed** — filter labels already exist under `sessionHistoryPanel.filters.*` in all 8 locales (they are keyed by filter value string, which matches the new constants).

## User Prompt

> historyの未読とかの部分もurlにあててhistoryを。

Follow-up scoping confirmed by the user:

- issue + plan workflow please
- Option A: `router.push` so browser back/forward steps through filter history
- path param style: `/history/human` (not query param `?filter=human`)
- extract string literals to constants (no magic strings)

## Implementation approach

### New file `src/config/historyFilters.ts`

```ts
export const HISTORY_FILTERS = {
  all: "all",
  unread: "unread",
  human: SESSION_ORIGINS.human,
  scheduler: SESSION_ORIGINS.scheduler,
  skill: SESSION_ORIGINS.skill,
  bridge: SESSION_ORIGINS.bridge,
} as const;

export const HISTORY_FILTER_ORDER = [HISTORY_FILTERS.all, HISTORY_FILTERS.unread, ...];
export const HISTORY_FILTER_ROUTE_PATTERN = /* non-default values joined with `|` */;
export function isHistoryFilter(value: unknown): value is HistoryFilter { /* ... */ }
```

### Router (`src/router/index.ts`)

```diff
-{ path: "/history", name: PAGE_ROUTES.history, component: Stub },
+{ path: `/history/:filter(${HISTORY_FILTER_ROUTE_PATTERN})?`, name: PAGE_ROUTES.history, component: Stub },
```

### `SessionHistoryPanel.vue`

Replaces the local `ref<FilterKey>("all")` + locally-defined FILTERS / UNREAD_FILTER with a `computed<HistoryFilter>({ get, set })` bound to `route.params.filter`, plus imports from the new config. Template iterates `HISTORY_FILTER_ORDER` and compares to `HISTORY_FILTERS.all`.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
- [x] `yarn test` — 6 new unit cases pass (`HISTORY_FILTERS`, `HISTORY_FILTER_ORDER`, `HISTORY_FILTER_ROUTE_PATTERN`, `isHistoryFilter`)
- [x] `yarn test:e2e history-filter` — 6 new e2e cases pass (6.5s)
- [x] `yarn test:e2e history-panel` — 10 existing tests still pass (no regression on the `/history` route work from #659)
- [ ] Manual smoke (reviewer): click each filter pill, back button restores prior state, hit each deep link directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)