### PR TITLE
feat(ui): favicon conditional palette (13 colors from 4)

### DIFF
--- a/plans/feat-favicon-conditional-palette.md
+++ b/plans/feat-favicon-conditional-palette.md
@@ -1,0 +1,111 @@
+# feat: favicon conditional palette
+
+## Problem
+
+The favicon has four colors (`idle` gray, `running` blue, `done` green, `error` red) plus a red unread dot. Every tab looks the same whenever the session is idle — which is most of the time. Users asked for a more varied, context-aware tab icon: different colors for different conditions, both informational (load, unread count) and flavour (time of day, weekend).
+
+## Goal
+
+Replace the 4-value `STATE_COLORS` record with a **priority-ordered rule chain** that picks one colour from ~10 options based on the full runtime context (agent state, unread count, time of day, weekday, server CPU load, and a couple of date-based easter eggs). Keep the existing frame / mascot / unread-dot rendering — only the backing colour changes.
+
+Non-goals: animations, gradients, per-project palette customisation (those can layer on later).
+
+## Conditions and colours
+
+Listed highest priority first; the first rule that matches wins.
+
+| # | Condition | Color | Rationale |
+|---|---|---|---|
+| 1 | **error** — agent run ended with `ERROR` | `#DC2626` red-600 | Strongest alert, always wins. |
+| 2 | **overloaded** — server `load1 / cores > 0.9` | `#EA580C` orange-600 | Machine is burning; the chat likely feels laggy. Surface the cause. |
+| 3 | **many-unread** — `sessionsUnreadCount >= 5` | `#D946EF` fuchsia-500 | Attention threshold — 5+ unread tabs means a real pile-up. |
+| 4 | **running-long** — `running` AND for `>= 60 s` | `#06B6D4` cyan-500 | Still thinking — distinct from the fresh-start blue. |
+| 5 | **running** (default) | `#3B82F6` blue-500 | Unchanged from today. |
+| 6 | **has-unread** (active or current session) | `#22C55E` green-500 | Unchanged from today. |
+| 7 | **birthday** — memory has `User: birthday: MM-DD` matching today | `#EAB308` yellow-500 | Easter egg. Optional — skip if no memory key. |
+| 8 | **new-year** — Jan 1–3 | `#B91C1C` red-700 | Festive. |
+| 9 | **christmas** — Dec 24–25 | `#15803D` green-700 | Festive. |
+| 10 | **late-night** — local hour `∈ [22, 5)` | `#6366F1` indigo-500 | Deep work / wind-down. |
+| 11 | **morning** — local hour `∈ [5, 9)` | `#F59E0B` amber-500 | Sunrise. |
+| 12 | **weekend** — Sat/Sun, 9:00–22:00 local | `#14B8A6` teal-500 | Casual. |
+| 13 | **idle** (fallback) | `#6B7280` gray-500 | Unchanged fallback. |
+
+### Priority reasoning
+
+- Rules 1–6 are **state** driven: they always beat flavour so a running agent still looks blue even on Christmas evening.
+- Rules 7–12 only fire on **idle**. If you're watching the tab, a green "done" or red "error" is what you care about.
+- Among idle rules: calendar (birthday / holiday) beats clock (late-night, morning, weekend). Two clocks never match at once (disjoint hour ranges), so no further tiebreak needed.
+
+## Architecture
+
+Split out of `src/composables/useDynamicFavicon.ts` into pure, testable pieces:
+
+```
+src/composables/favicon/
+  resolveColor.ts      # pure: (context) => hex string
+  conditions.ts        # pure predicates: isLateNight, isWeekend, isBirthday, ...
+  types.ts             # FaviconContext, FaviconColorReason (for telemetry)
+test/composables/favicon/
+  test_resolveColor.ts
+  test_conditions.ts
+```
+
+`resolveColor(ctx: FaviconContext): { color: string; reason: FaviconColorReason }` is a total function with no clock / DOM dependencies (all time inputs are passed in). `useFaviconState` assembles the context at call time:
+
+```ts
+resolveColor({
+  state,                    // "idle" | "running" | "done" | "error"
+  sessionsUnreadCount,      // number
+  runningSinceMs,           // number | null — epoch ms when current run started
+  now,                      // Date (so tests can pin it)
+  userBirthdayMMDD,         // "MM-DD" | null — from memory.md parse (optional)
+  cpuLoadRatio,             // number | null — load1 / cores from /api/health
+});
+```
+
+Returning a `reason` (e.g. `"overloaded"`, `"late-night"`) lets us log it once per change for debuggability without inventing colour names in the UI layer.
+
+## Server-side: add CPU load to `/api/health`
+
+`os.loadavg()[0]` gives the kernel's 1-minute load average on Linux / macOS. Normalise by `os.cpus().length` so `load1/cores > 1.0` means "one full core saturated per host core". On Windows `os.loadavg()` returns `[0, 0, 0]`, so the overloaded rule is silently unreachable there — acceptable (Windows users just never see the orange).
+
+Change:
+
+```ts
+// server/index.ts GET /api/health response shape
+{
+  status: "OK",
+  geminiAvailable,
+  sandboxEnabled,
+  cpu: { load1: os.loadavg()[0], cores: os.cpus().length },
+}
+```
+
+Client polls every 15 s from `useHealth` (currently a one-shot fetch). The ratio is stored as a `ref<number | null>` and fed into `FaviconContext`. Missing / null → rule 2 is skipped.
+
+## Memory birthday (optional, low-risk)
+
+Looking into `conversations/memory.md` for `birthday: MM-DD` under `## User` is a niche feature but cheap. Parse once on mount (via a tiny `/api/config/user-birthday` endpoint that greps the memory file server-side) and cache in `useFaviconState`. If the memory file doesn't exist or the key isn't there, the context value stays `null` and rule 7 is skipped.
+
+**If this feels like over-reach, drop rules 7–9 entirely** and keep the clock-based + overload + state rules. The code path is the same either way — the resolver just loses a branch.
+
+## Testing
+
+Every condition gets a `test_conditions.ts` case with a pinned `Date`. `resolveColor` gets a matrix test: one assertion per rule firing in isolation + one "state-beats-flavour" fixture to pin priority. Drift-testing: a fuzz-lite loop that generates 100 random contexts and asserts `reason` is one of the 13 enum values (catches any rule that falls through to `idle` when it shouldn't).
+
+## Migration
+
+- [ ] Step 1: add `cpu` field to `/api/health` + extend `useHealth` to poll every 15 s and expose `cpuLoadRatio`.
+- [ ] Step 2: create `src/composables/favicon/{types,conditions,resolveColor}.ts` with the full rule chain.
+- [ ] Step 3: add `test/composables/favicon/{test_conditions,test_resolveColor}.ts`.
+- [ ] Step 4: rewire `useDynamicFavicon` to call `resolveColor` instead of its internal `STATE_COLORS[state]` lookup.
+- [ ] Step 5: rewire `useFaviconState` to thread `runningSinceMs` + `cpuLoadRatio` into the context.
+- [ ] Step 6: (optional) memory-birthday plumbing — skip if not wanted.
+- [ ] Step 7: smoke-test each rule in a local dev server by temporarily pinning the `now` / `cpuLoadRatio` from devtools.
+
+## Out of scope
+
+- Animation / pulsing — the running-long cyan already differentiates extended runs without motion.
+- Gradient backgrounds — 32 px is too small for them to read.
+- Per-project palette overrides — can come later with a `config/favicon.json` if demand appears.
+- Alternative CPU sources (Claude CLI subprocess, client-side `requestAnimationFrame` jank probe) — `os.loadavg()` is the cheapest cross-cutting signal and all we need today.

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,7 +34,7 @@ import { initWorkspace, workspacePath } from "./workspace/workspace.js";
 import { env, isGeminiAvailable } from "./system/env.js";
 import { buildSandboxStatus } from "./api/sandboxStatus.js";
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
+import { cpus, homedir, loadavg } from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
 import { maybeRunJournal } from "./workspace/journal/index.js";
 import { backfillAllSessions } from "./workspace/chat-index/index.js";
@@ -112,10 +112,19 @@ app.use("/api", (req, res, next) => {
 });
 
 app.get(API_ROUTES.health, (_req: Request, res: Response) => {
+  // `os.loadavg()[0]` is the kernel 1-minute load average. On Linux /
+  // macOS it's the primary "is this machine busy" signal; on Windows
+  // the array is `[0, 0, 0]` (platform has no equivalent), in which
+  // case `load1` stays 0 and the favicon's overloaded rule silently
+  // never fires there. `cores` lets the client normalise so a 16-core
+  // box at load 8 reads the same intensity as an 8-core box at load 4.
+  const [load1] = loadavg();
+  const cores = cpus().length;
   res.json({
     status: "OK",
     geminiAvailable: isGeminiAvailable(),
     sandboxEnabled,
+    cpu: { load1, cores },
   });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -330,7 +330,7 @@ const { markSessionRead } = useSessionSync({
   currentSessionId,
   fetchSessions,
 });
-const { geminiAvailable, sandboxEnabled, fetchHealth } = useHealth();
+const { geminiAvailable, sandboxEnabled, cpuLoadRatio, fetchHealth } = useHealth();
 
 const { activeSession, toolResults, sidebarResults, currentSummary, isRunning, statusMessage, toolCallHistory, activeSessionCount, unreadCount } =
   useSessionDerived({ sessionMap, currentSessionId, sessions });
@@ -345,7 +345,7 @@ const { selectedResultUuid } = useSelectedResult({
 // `unreadCount` covers every session (not just the active tab), so
 // the favicon badge lights up when a background session gets a new
 // reply even though the user is looking at a different session.
-useFaviconState({ isRunning, currentSummary, activeSession, sessionsUnreadCount: unreadCount });
+useFaviconState({ isRunning, currentSummary, activeSession, sessionsUnreadCount: unreadCount, cpuLoadRatio });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);

--- a/src/composables/favicon/conditions.ts
+++ b/src/composables/favicon/conditions.ts
@@ -1,0 +1,76 @@
+// Pure predicates for the favicon resolver. Every function takes
+// only its inputs — no global `Date`, no env, no network — so a test
+// can pin an arbitrary moment and assert the branch deterministically.
+
+// Night runs from 22:00 (inclusive) to 05:00 (exclusive). Chosen so a
+// typical "I'm winding down" window (22–24) and a "still up" window
+// (00–05) share the same deep-work indigo.
+export function isLateNight(now: Date): boolean {
+  const hour = now.getHours();
+  return hour >= 22 || hour < 5;
+}
+
+// Morning covers 05:00–09:00 — the "before the inbox wins" window.
+// Disjoint from `isLateNight`, so the two rules never both fire.
+export function isMorning(now: Date): boolean {
+  const hour = now.getHours();
+  return hour >= 5 && hour < 9;
+}
+
+// Weekend fires only during waking hours so the late-night rule wins
+// overnight on Fri→Sat (that's still "deep work", not "weekend vibes").
+// Saturday = 6, Sunday = 0 per `Date.getDay()`.
+export function isWeekend(now: Date): boolean {
+  const day = now.getDay();
+  const hour = now.getHours();
+  const onWeekend = day === 0 || day === 6;
+  const duringDay = hour >= 9 && hour < 22;
+  return onWeekend && duringDay;
+}
+
+// Birthday match: context stores "MM-DD"; we compare to today in the
+// caller's local clock. Returns false for any malformed input rather
+// than throwing — the favicon must never crash on a typo.
+export function isBirthday(now: Date, userBirthdayMMDD: string | null): boolean {
+  if (!userBirthdayMMDD) return false;
+  if (!/^\d{2}-\d{2}$/.test(userBirthdayMMDD)) return false;
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${month}-${day}` === userBirthdayMMDD;
+}
+
+// New Year window — Jan 1–3 inclusive. Short enough that it stays
+// special; 3 days covers the common "holiday still going" case
+// (especially in Japan).
+export function isNewYear(now: Date): boolean {
+  return now.getMonth() === 0 && now.getDate() >= 1 && now.getDate() <= 3;
+}
+
+// Christmas window — Dec 24–25. Eve + day.
+export function isChristmas(now: Date): boolean {
+  return now.getMonth() === 11 && (now.getDate() === 24 || now.getDate() === 25);
+}
+
+// Overloaded: server 1-minute load average divided by logical core
+// count. A ratio > 0.9 means "nearly all cores saturated for a full
+// minute". Null input (no data yet, or Windows) → the rule is off.
+export function isOverloaded(cpuLoadRatio: number | null): boolean {
+  if (cpuLoadRatio === null || !Number.isFinite(cpuLoadRatio)) return false;
+  return cpuLoadRatio > 0.9;
+}
+
+// Many-unread threshold — tuned so a typical day with 1–3 sleepy
+// tabs stays green, but a noisy ping storm bumps up to fuchsia.
+export const MANY_UNREAD_THRESHOLD = 5;
+export function isManyUnread(count: number): boolean {
+  return Number.isFinite(count) && count >= MANY_UNREAD_THRESHOLD;
+}
+
+// Running-long threshold — anything past ~1 minute is a "real" run
+// (code gen, long web searches) as opposed to a quick reply.
+export const RUNNING_LONG_MS = 60 * 1000;
+export function isRunningLong(runningSinceMs: number | null, now: Date): boolean {
+  if (runningSinceMs === null) return false;
+  const elapsed = now.getTime() - runningSinceMs;
+  return Number.isFinite(elapsed) && elapsed >= RUNNING_LONG_MS;
+}

--- a/src/composables/favicon/resolveColor.ts
+++ b/src/composables/favicon/resolveColor.ts
@@ -1,0 +1,93 @@
+// Priority-ordered rule chain that picks the favicon's backing
+// colour from the full runtime context. See
+// `plans/feat-favicon-conditional-palette.md` for the reasoning
+// behind the ordering and the chosen hex values.
+//
+// The function is pure: one input → one output. No clock, no DOM,
+// no network. Every test pins the branch it wants by constructing
+// the context verbatim.
+
+import { FAVICON_REASONS, FAVICON_STATES, type FaviconContext, type FaviconPick } from "./types";
+import { isBirthday, isChristmas, isLateNight, isManyUnread, isMorning, isNewYear, isOverloaded, isRunningLong, isWeekend } from "./conditions";
+
+// Keeping the palette values adjacent to the resolver (rather than
+// in a separate constants module) makes the "why does this colour
+// fire?" audit a one-file read.
+const COLORS = {
+  error: "#DC2626", // red-600
+  overloaded: "#EA580C", // orange-600 — machine is burning
+  manyUnread: "#D946EF", // fuchsia-500 — attention pile-up
+  runningLong: "#06B6D4", // cyan-500 — still thinking (> 60 s)
+  running: "#3B82F6", // blue-500 — default running
+  hasUnread: "#22C55E", // green-500 — reply waiting
+  birthday: "#EAB308", // yellow-500
+  newYear: "#B91C1C", // red-700 — festive deeper red
+  christmas: "#15803D", // green-700 — festive deeper green
+  lateNight: "#6366F1", // indigo-500 — deep work
+  morning: "#F59E0B", // amber-500 — sunrise
+  weekend: "#14B8A6", // teal-500 — relaxed
+  idle: "#6B7280", // gray-500 — fallback
+} as const;
+
+// Split the state-driven vs flavour branches so the priority
+// argument is in one place and each helper stays under the
+// cognitive-complexity threshold.
+
+// Rules 1–6 in the plan: error + load + state-adjusted unread /
+// running. These always fire when applicable, beating any flavour.
+function resolveByState(ctx: FaviconContext): FaviconPick | null {
+  if (ctx.state === FAVICON_STATES.error) {
+    return { color: COLORS.error, reason: FAVICON_REASONS.error };
+  }
+  if (isOverloaded(ctx.cpuLoadRatio)) {
+    return { color: COLORS.overloaded, reason: FAVICON_REASONS.overloaded };
+  }
+  if (isManyUnread(ctx.sessionsUnreadCount)) {
+    return { color: COLORS.manyUnread, reason: FAVICON_REASONS.manyUnread };
+  }
+  if (ctx.state === FAVICON_STATES.running) {
+    if (isRunningLong(ctx.runningSinceMs, ctx.now)) {
+      return { color: COLORS.runningLong, reason: FAVICON_REASONS.runningLong };
+    }
+    return { color: COLORS.running, reason: FAVICON_REASONS.running };
+  }
+  if (ctx.state === FAVICON_STATES.done) {
+    return { color: COLORS.hasUnread, reason: FAVICON_REASONS.hasUnread };
+  }
+  return null;
+}
+
+// Rules 7–12: flavour / easter eggs. Only consulted when no
+// state-driven rule matched, so a running agent never gets a
+// "cute" colour. Calendar beats clock; hour-based rules are
+// disjoint so we pick whichever matches first.
+function resolveByFlavour(ctx: FaviconContext): FaviconPick {
+  if (isBirthday(ctx.now, ctx.userBirthdayMMDD)) {
+    return { color: COLORS.birthday, reason: FAVICON_REASONS.birthday };
+  }
+  if (isNewYear(ctx.now)) {
+    return { color: COLORS.newYear, reason: FAVICON_REASONS.newYear };
+  }
+  if (isChristmas(ctx.now)) {
+    return { color: COLORS.christmas, reason: FAVICON_REASONS.christmas };
+  }
+  if (isLateNight(ctx.now)) {
+    return { color: COLORS.lateNight, reason: FAVICON_REASONS.lateNight };
+  }
+  if (isMorning(ctx.now)) {
+    return { color: COLORS.morning, reason: FAVICON_REASONS.morning };
+  }
+  if (isWeekend(ctx.now)) {
+    return { color: COLORS.weekend, reason: FAVICON_REASONS.weekend };
+  }
+  return { color: COLORS.idle, reason: FAVICON_REASONS.idle };
+}
+
+export function resolveFaviconColor(ctx: FaviconContext): FaviconPick {
+  return resolveByState(ctx) ?? resolveByFlavour(ctx);
+}
+
+// Expose the palette for test assertions so the hex values aren't
+// hard-coded in two places. Not exported from types.ts because it's
+// resolver-implementation state, not part of the public contract.
+export const FAVICON_COLORS = COLORS;

--- a/src/composables/favicon/types.ts
+++ b/src/composables/favicon/types.ts
@@ -1,0 +1,63 @@
+// Shared types for the favicon palette resolver. Keeping them in a
+// dedicated file lets `conditions.ts` and `resolveColor.ts` import
+// them without cycling, and the unit tests pin the exact shape the
+// context must satisfy.
+
+export const FAVICON_STATES = {
+  idle: "idle",
+  running: "running",
+  done: "done",
+  error: "error",
+} as const;
+
+export type FaviconState = (typeof FAVICON_STATES)[keyof typeof FAVICON_STATES];
+
+// Every possible path through `resolveColor` — the same enum used for
+// the returned `reason` field so callers (and the log breadcrumb) can
+// name the branch without memorising hex codes.
+export const FAVICON_REASONS = {
+  error: "error",
+  overloaded: "overloaded",
+  manyUnread: "many-unread",
+  runningLong: "running-long",
+  running: "running",
+  hasUnread: "has-unread",
+  birthday: "birthday",
+  newYear: "new-year",
+  christmas: "christmas",
+  lateNight: "late-night",
+  morning: "morning",
+  weekend: "weekend",
+  idle: "idle",
+} as const;
+
+export type FaviconReason = (typeof FAVICON_REASONS)[keyof typeof FAVICON_REASONS];
+
+// The full runtime context fed to `resolveColor`. Everything is
+// plumbed in so the function stays pure: no `new Date()` inside, no
+// global fetches — test fixtures can pin any branch.
+export interface FaviconContext {
+  state: FaviconState;
+  /** Unread across every session, not just the active one. */
+  sessionsUnreadCount: number;
+  /** Epoch ms when the current agent run started, or null if idle. */
+  runningSinceMs: number | null;
+  /** "now" — caller's clock. Tests pass a fixed Date. */
+  now: Date;
+  /**
+   * "MM-DD" if the user has a birthday stored in memory.md, else
+   * null. Null → the birthday rule is skipped.
+   */
+  userBirthdayMMDD: string | null;
+  /**
+   * Server's 1-minute load average divided by logical core count.
+   * `null` when the server hasn't reported yet or the platform
+   * doesn't support `loadavg` (Windows).
+   */
+  cpuLoadRatio: number | null;
+}
+
+export interface FaviconPick {
+  color: string;
+  reason: FaviconReason;
+}

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,54 +1,36 @@
-// Dynamic favicon that changes color based on agent state (#470).
+// Dynamic favicon that changes its backing color based on a rich
+// runtime context (#470 + palette expansion).
 //
-// Renders the MulmoClaude mascot on a colored rounded square. The
-// background color reflects state, and the mascot floats on top:
-//   idle (gray) → running (blue, pulse) → done (green) → error (red)
-//   notification badge (orange dot) overlaid when unread count > 0.
+// Color selection moved to `./favicon/resolveColor.ts`; this module
+// is now a thin canvas renderer that takes the already-resolved
+// color and paints it behind the mascot. The split keeps the pixel-
+// level drawing code and the rule chain independently testable.
 //
-// The logo PNG has an opaque white background, which would otherwise
-// hide the state color. On first load we pre-process the pixels,
-// punching out near-white pixels to transparency so the colored
-// backing shows through. The processed image is cached as an
-// offscreen canvas for the lifetime of the page.
-//
-// If the logo fails to load we fall back to the earlier "M"-letter
-// variant so the tab icon never disappears entirely.
+// Rendering details:
+// - The logo PNG has an opaque white background; on first load we
+//   pre-process the pixels, punching near-white to transparency so
+//   the resolved color shows through.
+// - If the PNG fails to load we fall back to a plain colored square
+//   with the letter "M" so the tab icon never blanks out.
 
 import { watch, type Ref, type ComputedRef } from "vue";
 import logoUrl from "../assets/mulmo_bw.png";
 
-export const FAVICON_STATES = {
-  idle: "idle",
-  running: "running",
-  done: "done",
-  error: "error",
-} as const;
-
-export type FaviconState = (typeof FAVICON_STATES)[keyof typeof FAVICON_STATES];
-
-const STATE_COLORS: Record<FaviconState, string> = {
-  idle: "#6B7280", // gray-500
-  running: "#3B82F6", // blue-500
-  done: "#22C55E", // green-500
-  error: "#EF4444", // red-500
-};
-
-const NOTIFICATION_DOT_COLOR = "#DC2626"; // red-600 — stands out against the gray/blue/green state backgrounds
+// Keep the palette-independent display constants local to this file
+// — they describe pixel geometry, not semantics.
+const NOTIFICATION_DOT_COLOR = "#DC2626"; // red-600
 const SIZE = 32;
 const RADIUS = 6;
-// How much of the inner rounded square the mascot fills. 2 px of
-// padding on each side keeps it off the rounded corners and leaves
-// room for the colored backing to peek around the outline.
+// How much of the rounded square the mascot fills. 2 px of padding
+// on each side keeps it off the rounded corners and leaves room for
+// the colored backing to peek around the outline.
 const MASCOT_INSET = 2;
 
 // Pixels whose RGB channels are all above this are treated as the
-// PNG's white backing and punched to transparent. The PNG uses a soft
-// pastel palette so the mascot itself never hits all three channels
-// this high.
+// PNG's white backing and punched to transparent. The PNG uses soft
+// pastels so the mascot itself never hits all three channels this
+// high.
 const WHITE_TO_ALPHA_THRESHOLD = 235;
-// Pixels in the [FEATHER_LOW, WHITE_TO_ALPHA_THRESHOLD] band get a
-// partial-alpha ramp so the mascot's anti-aliased outline blends with
-// the colored background instead of showing a hard seam.
 const FEATHER_LOW = 205;
 
 // ── Asset loading ──────────────────────────────────────────────
@@ -84,9 +66,6 @@ function decodeAndPunchOutWhite(): Promise<HTMLCanvasElement> {
   });
 }
 
-// Copy the decoded <img> into an offscreen canvas and scan every
-// pixel, replacing near-white with transparency. The PNG is opaque so
-// the background would otherwise cover the state color backing.
 function buildTransparentLogoCanvas(img: HTMLImageElement): HTMLCanvasElement {
   const canvas = document.createElement("canvas");
   canvas.width = img.naturalWidth;
@@ -102,10 +81,8 @@ function buildTransparentLogoCanvas(img: HTMLImageElement): HTMLCanvasElement {
     const blue = pixels[i + 2];
     const minChannel = Math.min(red, green, blue);
     if (minChannel >= WHITE_TO_ALPHA_THRESHOLD) {
-      pixels[i + 3] = 0; // fully transparent
+      pixels[i + 3] = 0;
     } else if (minChannel >= FEATHER_LOW) {
-      // Linear ramp across the feather band. At minChannel = FEATHER_LOW
-      // alpha stays 255; at threshold it drops to 0.
       const ratio = (minChannel - FEATHER_LOW) / (WHITE_TO_ALPHA_THRESHOLD - FEATHER_LOW);
       pixels[i + 3] = Math.round(255 * (1 - ratio));
     }
@@ -130,8 +107,6 @@ function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: numb
   ctx.closePath();
 }
 
-// Aspect-preserving letterbox: scale the logo to fit the inner area
-// without distorting the mascot, then center the leftover space.
 function drawLogoCentered(ctx: CanvasRenderingContext2D, source: HTMLCanvasElement, inset: number): void {
   const available = SIZE - inset * 2;
   const aspect = source.width / source.height;
@@ -157,12 +132,9 @@ function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
 
 // ── Composition ────────────────────────────────────────────────
 
-// Fallback for when the logo PNG fails to decode (or before the first
-// decode completes). Mirrors the earlier "M"-on-colored-square design
-// so the favicon always has a valid first paint.
-function renderFallbackFavicon(ctx: CanvasRenderingContext2D, state: FaviconState, hasNotification: boolean): void {
+function renderFallbackFavicon(ctx: CanvasRenderingContext2D, color: string, hasNotification: boolean): void {
   drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
-  ctx.fillStyle = STATE_COLORS[state];
+  ctx.fillStyle = color;
   ctx.fill();
 
   ctx.fillStyle = "white";
@@ -174,23 +146,21 @@ function renderFallbackFavicon(ctx: CanvasRenderingContext2D, state: FaviconStat
   if (hasNotification) drawNotificationDot(ctx);
 }
 
-function renderLogoFavicon(ctx: CanvasRenderingContext2D, logo: HTMLCanvasElement, state: FaviconState, hasNotification: boolean): void {
-  // Colored rounded-square backing — the dynamic cue.
+function renderLogoFavicon(ctx: CanvasRenderingContext2D, logo: HTMLCanvasElement, color: string, isRunning: boolean, hasNotification: boolean): void {
   drawRoundedRect(ctx, 0, 0, SIZE, SIZE, RADIUS);
-  ctx.fillStyle = STATE_COLORS[state];
+  ctx.fillStyle = color;
   ctx.fill();
 
-  // Clip subsequent draws to the rounded square so the mascot's
-  // anti-aliased edges don't spill past the corners.
   ctx.save();
   drawRoundedRect(ctx, 0, 0, SIZE, SIZE, RADIUS);
   ctx.clip();
   drawLogoCentered(ctx, logo, MASCOT_INSET);
   ctx.restore();
 
-  // Running state: subtle inner glow ring reinforces the pulse cue
-  // without overpowering the colored backing.
-  if (state === FAVICON_STATES.running) {
+  // Running glow — kept at a fixed white/translucent ring so it reads
+  // against any resolved color (blue, cyan, orange, whatever) rather
+  // than having to retune per palette entry.
+  if (isRunning) {
     ctx.strokeStyle = "rgba(255, 255, 255, 0.55)";
     ctx.lineWidth = 1.5;
     drawRoundedRect(ctx, 2.25, 2.25, SIZE - 4.5, SIZE - 4.5, Math.max(RADIUS - 1, 2));
@@ -200,7 +170,7 @@ function renderLogoFavicon(ctx: CanvasRenderingContext2D, logo: HTMLCanvasElemen
   if (hasNotification) drawNotificationDot(ctx);
 }
 
-async function renderFavicon(state: FaviconState, hasNotification: boolean): Promise<string> {
+async function renderFavicon(color: string, isRunning: boolean, hasNotification: boolean): Promise<string> {
   const canvas = document.createElement("canvas");
   canvas.width = SIZE;
   canvas.height = SIZE;
@@ -210,14 +180,14 @@ async function renderFavicon(state: FaviconState, hasNotification: boolean): Pro
   if (!logoLoadFailed) {
     try {
       const logo = await loadLogo();
-      renderLogoFavicon(ctx, logo, state, hasNotification);
+      renderLogoFavicon(ctx, logo, color, isRunning, hasNotification);
       return canvas.toDataURL("image/png");
     } catch {
-      // fall through — renderFallbackFavicon below handles it.
+      // fall through to the fallback path
     }
   }
 
-  renderFallbackFavicon(ctx, state, hasNotification);
+  renderFallbackFavicon(ctx, color, hasNotification);
   return canvas.toDataURL("image/png");
 }
 
@@ -234,17 +204,27 @@ function applyFavicon(dataUrl: string): void {
   link.href = dataUrl;
 }
 
-export function useDynamicFavicon(opts: { state: Ref<FaviconState> | ComputedRef<FaviconState>; hasNotification: Ref<boolean> | ComputedRef<boolean> }): void {
+export interface DynamicFaviconOpts {
+  color: Ref<string> | ComputedRef<string>;
+  isRunning: Ref<boolean> | ComputedRef<boolean>;
+  hasNotification: Ref<boolean> | ComputedRef<boolean>;
+}
+
+export function useDynamicFavicon(opts: DynamicFaviconOpts): void {
   async function update(): Promise<void> {
-    const dataUrl = await renderFavicon(opts.state.value, opts.hasNotification.value);
+    const dataUrl = await renderFavicon(opts.color.value, opts.isRunning.value, opts.hasNotification.value);
     applyFavicon(dataUrl);
   }
 
   watch(
-    [opts.state, opts.hasNotification],
+    [opts.color, opts.isRunning, opts.hasNotification],
     () => {
       update().catch((err) => console.warn("[favicon] render failed", err));
     },
     { immediate: true },
   );
 }
+
+// Re-export the state enum from the new location so existing callers
+// continue to import from this file during the transition period.
+export { FAVICON_STATES, type FaviconState } from "./favicon/types";

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,23 +1,39 @@
-// Dynamic favicon state: running → done (unread) → idle.
-// Also drives the notification badge dot on the favicon.
+// Dynamic favicon wiring.
+//
+// Assembles the full `FaviconContext` from reactive app signals
+// (`isRunning`, `sessionsUnreadCount`, a ticking clock, server CPU
+// load, optional user birthday), feeds it through the pure
+// `resolveFaviconColor` rule chain, and hands the resolved color
+// to `useDynamicFavicon` for painting.
 
-import { computed, type ComputedRef } from "vue";
-import { FAVICON_STATES, type FaviconState, useDynamicFavicon } from "./useDynamicFavicon";
+import { computed, onScopeDispose, ref, watch, type ComputedRef } from "vue";
+import { useDynamicFavicon } from "./useDynamicFavicon";
 import { useNotifications } from "./useNotifications";
+import { resolveFaviconColor } from "./favicon/resolveColor";
+import { FAVICON_STATES, type FaviconContext, type FaviconState } from "./favicon/types";
 import type { ActiveSession, SessionSummary } from "../types/session";
+
+// Ticking cadence for the clock context. Once per minute is enough
+// to cross the morning / late-night / weekend / running-long
+// boundaries — we don't need second-level precision in a tab icon.
+const FAVICON_TICK_MS = 60_000;
 
 export function useFaviconState(opts: {
   isRunning: ComputedRef<boolean>;
   currentSummary: ComputedRef<SessionSummary | undefined>;
   activeSession: ComputedRef<ActiveSession | undefined>;
-  // Number of sessions (across all tabs) with unread messages. We
-  // light the badge dot when any session is unread, even if it's not
-  // the currently-focused one, so background replies still surface in
-  // the tab bar.
+  /** Unread count across every session, not just the active one. */
   sessionsUnreadCount: ComputedRef<number>;
+  /** Server CPU load1 / cores, or null if not yet fetched / Windows. */
+  cpuLoadRatio?: ComputedRef<number | null>;
+  /** User birthday as "MM-DD" parsed from memory.md, or null. */
+  userBirthdayMMDD?: ComputedRef<string | null>;
 }) {
-  const { isRunning, currentSummary, activeSession, sessionsUnreadCount } = opts;
+  const { isRunning, currentSummary, activeSession, sessionsUnreadCount, cpuLoadRatio, userBirthdayMMDD } = opts;
 
+  // Legacy 4-state enum still drives state priority inside the
+  // resolver. `running` vs `running-long` is split downstream by
+  // the runningSinceMs clock.
   const faviconState = computed<FaviconState>(() => {
     if (isRunning.value) return FAVICON_STATES.running;
     const hasUnread = currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
@@ -25,17 +41,44 @@ export function useFaviconState(opts: {
     return FAVICON_STATES.idle;
   });
 
+  // Track when the current run began. Cleared the moment `isRunning`
+  // flips false so the next run starts a fresh blue/cyan timer.
+  const runningSinceMs = ref<number | null>(isRunning.value ? Date.now() : null);
+  watch(isRunning, (running) => {
+    runningSinceMs.value = running ? Date.now() : null;
+  });
+
+  // Per-minute tick so time-of-day rules (morning, late-night,
+  // weekend) pick up boundary crossings without the user needing to
+  // interact. Also re-evaluates running-long so the cyan shift lands
+  // within a minute of the 60-second mark.
+  const clockTick = ref<Date>(new Date());
+  const tickHandle = window.setInterval(() => {
+    clockTick.value = new Date();
+  }, FAVICON_TICK_MS);
+  onScopeDispose(() => window.clearInterval(tickHandle));
+
+  const color = computed<string>(() => {
+    const context: FaviconContext = {
+      state: faviconState.value,
+      sessionsUnreadCount: sessionsUnreadCount.value,
+      runningSinceMs: runningSinceMs.value,
+      now: clockTick.value,
+      userBirthdayMMDD: userBirthdayMMDD?.value ?? null,
+      cpuLoadRatio: cpuLoadRatio?.value ?? null,
+    };
+    return resolveFaviconColor(context).color;
+  });
+
   const { unreadCount: notificationUnreadCount } = useNotifications();
-  // Badge dot covers two independent signals:
-  //   1. Pub-sub notifications (scheduled tasks, etc.)
-  //   2. Any session with unread chat messages (including background
-  //      tabs the user isn't currently viewing).
-  // Either one flips the dot on — the dot doesn't distinguish source,
-  // just tells the user "there's something to look at".
+  // Badge dot fires on either pub-sub notifications (scheduled
+  // tasks, etc.) or any session carrying unread chat messages —
+  // the dot itself doesn't distinguish source.
   const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0 || sessionsUnreadCount.value > 0);
 
   useDynamicFavicon({
-    state: faviconState,
+    color,
+    isRunning,
     hasNotification: hasNotificationBadge,
   });
 }

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -6,7 +6,7 @@
 // `resolveFaviconColor` rule chain, and hands the resolved color
 // to `useDynamicFavicon` for painting.
 
-import { computed, onScopeDispose, ref, watch, type ComputedRef } from "vue";
+import { computed, onScopeDispose, ref, type ComputedRef } from "vue";
 import { useDynamicFavicon } from "./useDynamicFavicon";
 import { useNotifications } from "./useNotifications";
 import { resolveFaviconColor } from "./favicon/resolveColor";
@@ -41,11 +41,26 @@ export function useFaviconState(opts: {
     return FAVICON_STATES.idle;
   });
 
-  // Track when the current run began. Cleared the moment `isRunning`
-  // flips false so the next run starts a fresh blue/cyan timer.
-  const runningSinceMs = ref<number | null>(isRunning.value ? Date.now() : null);
-  watch(isRunning, (running) => {
-    runningSinceMs.value = running ? Date.now() : null;
+  // Run-start timestamp, derived from the session's `updatedAt` —
+  // which the server bumps every time the user sends a message, i.e.
+  // right before a run begins. That means:
+  //   1. The clock is correct across a page reload or a second tab:
+  //      a 5-minute-old run stays cyan instead of reverting to blue
+  //      for 60 s after mount.
+  //   2. We don't need a separate server "runStartedAt" field; the
+  //      existing `updatedAt` already serves as the anchor because
+  //      the session is locked during a run, so `updatedAt` can't
+  //      change until this run ends.
+  // Falls back to `Date.now()` only if the session has no
+  // `updatedAt` (brand-new session before the first server echo).
+  const runningSinceMs = computed<number | null>(() => {
+    if (!isRunning.value) return null;
+    const updatedAt = activeSession.value?.updatedAt;
+    if (updatedAt) {
+      const parsed = new Date(updatedAt).getTime();
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return Date.now();
   });
 
   // Per-minute tick so time-of-day rules (morning, late-night,

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -1,38 +1,87 @@
 // Composable for the server /api/health probe.
 //
-// Owns two refs that the UI reads (gemini key availability + sandbox
-// toggle) plus the one-shot fetch that populates them on mount. On
-// fetch failure we assume Gemini is unavailable so dependent UI
+// Owns three refs that the UI reads (gemini key availability +
+// sandbox toggle + server CPU load ratio) plus a one-shot fetch
+// that populates them on mount, plus an optional periodic refresh
+// for the CPU ratio (the favicon's "overloaded" rule needs a live
+// signal, not a boot-time snapshot).
+//
+// On fetch failure we assume Gemini is unavailable so dependent UI
 // (e.g. the "generate image" plugin buttons) falls back gracefully
 // — the sandbox flag keeps its initial `true` so the lock indicator
-// doesn't momentarily flash "sandbox disabled" on a transient error.
+// doesn't momentarily flash "sandbox disabled" on a transient error,
+// and the CPU ratio goes to null so the favicon resolver skips the
+// overloaded rule rather than guessing.
 
-import { ref, type Ref } from "vue";
+import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import { apiGet } from "../utils/api";
+
+// Once every 15 s is enough for a sustained load spike to light the
+// favicon. Shorter would mostly flap on short-lived spikes that
+// aren't actually user-visible as lag.
+const HEALTH_REFRESH_MS = 15_000;
+
+interface CpuPayload {
+  load1?: unknown;
+  cores?: unknown;
+}
 
 interface HealthResponse {
   geminiAvailable?: unknown;
   sandboxEnabled?: unknown;
+  cpu?: CpuPayload;
 }
 
 export function useHealth(): {
   geminiAvailable: Ref<boolean>;
   sandboxEnabled: Ref<boolean>;
+  cpuLoadRatio: ComputedRef<number | null>;
   fetchHealth: () => Promise<void>;
 } {
   const geminiAvailable = ref(true);
   const sandboxEnabled = ref(true);
+  const cpuLoad1 = ref<number | null>(null);
+  const cpuCores = ref<number | null>(null);
 
   async function fetchHealth(): Promise<void> {
     const result = await apiGet<HealthResponse>(API_ROUTES.health);
     if (!result.ok) {
       geminiAvailable.value = false;
+      cpuLoad1.value = null;
+      cpuCores.value = null;
       return;
     }
     geminiAvailable.value = !!result.data.geminiAvailable;
     sandboxEnabled.value = !!result.data.sandboxEnabled;
+    const cpu = result.data.cpu;
+    if (cpu && typeof cpu.load1 === "number" && Number.isFinite(cpu.load1) && typeof cpu.cores === "number" && cpu.cores > 0) {
+      cpuLoad1.value = cpu.load1;
+      cpuCores.value = cpu.cores;
+    } else {
+      cpuLoad1.value = null;
+      cpuCores.value = null;
+    }
   }
 
-  return { geminiAvailable, sandboxEnabled, fetchHealth };
+  // Refresh the CPU figure periodically. The flag-style booleans
+  // (gemini / sandbox) don't change at runtime so re-fetching them
+  // is waste; but piggy-backing on the same endpoint keeps the
+  // server side to a single route and the client to a single poll.
+  const refreshHandle = window.setInterval(() => {
+    fetchHealth().catch(() => {
+      /* intentionally swallowed — a failed poll just stalls the
+         favicon's overloaded rule, not user-visible UI */
+    });
+  }, HEALTH_REFRESH_MS);
+  onScopeDispose(() => window.clearInterval(refreshHandle));
+
+  // Expose the normalised ratio the favicon resolver expects (load
+  // per logical core). Null when either component is missing.
+  const cpuLoadRatio = computed<number | null>(() => {
+    if (cpuLoad1.value === null || cpuCores.value === null) return null;
+    return cpuLoad1.value / cpuCores.value;
+  });
+
+  return { geminiAvailable, sandboxEnabled, cpuLoadRatio, fetchHealth };
 }

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -44,16 +44,36 @@ export function useHealth(): {
   const cpuLoad1 = ref<number | null>(null);
   const cpuCores = ref<number | null>(null);
 
+  // Separate flag so transient poll failures don't flip
+  // `geminiAvailable` back to false after a successful boot-time
+  // fetch. `geminiAvailable` / `sandboxEnabled` are config-derived
+  // and don't change at runtime — once we've observed them once,
+  // the next 15 s poll's network blip shouldn't mask them.
+  let bootFetchCompleted = false;
+
   async function fetchHealth(): Promise<void> {
     const result = await apiGet<HealthResponse>(API_ROUTES.health);
     if (!result.ok) {
-      geminiAvailable.value = false;
+      // Only the CPU figures get nulled — the favicon resolver
+      // reads null as "skip overloaded" which is the correct fail-
+      // closed behaviour. The config flags keep their last-known
+      // values, and stay at the initial defaults if we never
+      // succeeded (gemini=true → request lands, gets an auth error
+      // handled elsewhere; sandbox=true → lock indicator reads on).
       cpuLoad1.value = null;
       cpuCores.value = null;
+      if (!bootFetchCompleted) {
+        // On the FIRST fetch we do still flip gemini → false so
+        // the "Gemini key required" banner can show immediately
+        // without waiting for a second attempt. Subsequent poll
+        // failures don't re-enter this branch.
+        geminiAvailable.value = false;
+      }
       return;
     }
     geminiAvailable.value = !!result.data.geminiAvailable;
     sandboxEnabled.value = !!result.data.sandboxEnabled;
+    bootFetchCompleted = true;
     const cpu = result.data.cpu;
     if (cpu && typeof cpu.load1 === "number" && Number.isFinite(cpu.load1) && typeof cpu.cores === "number" && cpu.cores > 0) {
       cpuLoad1.value = cpu.load1;

--- a/test/composables/favicon/test_conditions.ts
+++ b/test/composables/favicon/test_conditions.ts
@@ -1,0 +1,165 @@
+// Pin every favicon predicate against fixed clocks. Each test
+// constructs the exact moment that should fall inside / outside the
+// window so a future reshuffle of the thresholds breaks the test
+// loudly rather than quietly shifting the palette.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isBirthday,
+  isChristmas,
+  isLateNight,
+  isManyUnread,
+  isMorning,
+  isNewYear,
+  isOverloaded,
+  isRunningLong,
+  isWeekend,
+  MANY_UNREAD_THRESHOLD,
+  RUNNING_LONG_MS,
+} from "../../../src/composables/favicon/conditions.js";
+
+// Shorthand constructor. Named `makeDate` (not `at`) to satisfy the
+// id-length lint rule — it means the same thing.
+function makeDate(year: number, monthZeroBased: number, day: number, hour = 12, minute = 0): Date {
+  return new Date(year, monthZeroBased, day, hour, minute);
+}
+
+describe("isLateNight", () => {
+  it("fires at 22:00 and 04:59 (inclusive / exclusive boundaries)", () => {
+    assert.equal(isLateNight(makeDate(2026, 3, 23, 22, 0)), true);
+    assert.equal(isLateNight(makeDate(2026, 3, 23, 4, 59)), true);
+  });
+
+  it("skips 21:59 and 05:00 (just outside)", () => {
+    assert.equal(isLateNight(makeDate(2026, 3, 23, 21, 59)), false);
+    assert.equal(isLateNight(makeDate(2026, 3, 23, 5, 0)), false);
+  });
+});
+
+describe("isMorning", () => {
+  it("covers 05:00 through 08:59", () => {
+    assert.equal(isMorning(makeDate(2026, 3, 23, 5, 0)), true);
+    assert.equal(isMorning(makeDate(2026, 3, 23, 8, 59)), true);
+  });
+
+  it("skips 09:00 and 04:59 (outside the window)", () => {
+    assert.equal(isMorning(makeDate(2026, 3, 23, 9, 0)), false);
+    assert.equal(isMorning(makeDate(2026, 3, 23, 4, 59)), false);
+  });
+});
+
+describe("isWeekend", () => {
+  it("fires on Saturday and Sunday during daytime", () => {
+    // 2026-04-25 is Saturday.
+    assert.equal(isWeekend(makeDate(2026, 3, 25, 14, 0)), true);
+    // 2026-04-26 is Sunday.
+    assert.equal(isWeekend(makeDate(2026, 3, 26, 10, 0)), true);
+  });
+
+  it("skips weekend nights — late-night wins over weekend", () => {
+    // Saturday 23:30: late-night territory.
+    assert.equal(isWeekend(makeDate(2026, 3, 25, 23, 30)), false);
+    // Saturday 03:00.
+    assert.equal(isWeekend(makeDate(2026, 3, 25, 3, 0)), false);
+  });
+
+  it("skips weekdays", () => {
+    // 2026-04-23 is Thursday.
+    assert.equal(isWeekend(makeDate(2026, 3, 23, 14, 0)), false);
+  });
+});
+
+describe("isBirthday", () => {
+  it("matches when today's MM-DD equals the stored value", () => {
+    assert.equal(isBirthday(makeDate(2026, 2, 15, 10, 0), "03-15"), true);
+  });
+
+  it("is false on any other day", () => {
+    assert.equal(isBirthday(makeDate(2026, 2, 14, 10, 0), "03-15"), false);
+  });
+
+  it("rejects malformed input without throwing", () => {
+    assert.equal(isBirthday(makeDate(2026, 2, 15), "3-15"), false); // missing zero pad
+    assert.equal(isBirthday(makeDate(2026, 2, 15), "03/15"), false);
+    assert.equal(isBirthday(makeDate(2026, 2, 15), ""), false);
+    assert.equal(isBirthday(makeDate(2026, 2, 15), null), false);
+  });
+});
+
+describe("isNewYear", () => {
+  it("fires on Jan 1, 2, 3", () => {
+    assert.equal(isNewYear(makeDate(2027, 0, 1)), true);
+    assert.equal(isNewYear(makeDate(2027, 0, 2)), true);
+    assert.equal(isNewYear(makeDate(2027, 0, 3)), true);
+  });
+
+  it("skips Dec 31 and Jan 4", () => {
+    assert.equal(isNewYear(makeDate(2026, 11, 31)), false);
+    assert.equal(isNewYear(makeDate(2027, 0, 4)), false);
+  });
+});
+
+describe("isChristmas", () => {
+  it("fires on Dec 24 and 25", () => {
+    assert.equal(isChristmas(makeDate(2026, 11, 24)), true);
+    assert.equal(isChristmas(makeDate(2026, 11, 25)), true);
+  });
+
+  it("skips Dec 23 and Dec 26", () => {
+    assert.equal(isChristmas(makeDate(2026, 11, 23)), false);
+    assert.equal(isChristmas(makeDate(2026, 11, 26)), false);
+  });
+});
+
+describe("isOverloaded", () => {
+  it("fires above the 0.9 threshold", () => {
+    assert.equal(isOverloaded(1.2), true);
+    assert.equal(isOverloaded(0.91), true);
+  });
+
+  it("stays quiet at or under 0.9", () => {
+    assert.equal(isOverloaded(0.9), false);
+    assert.equal(isOverloaded(0.3), false);
+  });
+
+  it("skips when load data isn't available (null / NaN / Windows zeros)", () => {
+    assert.equal(isOverloaded(null), false);
+    assert.equal(isOverloaded(Number.NaN), false);
+    assert.equal(isOverloaded(0), false);
+  });
+});
+
+describe("isManyUnread", () => {
+  it(`fires at exactly MANY_UNREAD_THRESHOLD (${MANY_UNREAD_THRESHOLD})`, () => {
+    assert.equal(isManyUnread(MANY_UNREAD_THRESHOLD), true);
+    assert.equal(isManyUnread(MANY_UNREAD_THRESHOLD + 5), true);
+  });
+
+  it("skips below threshold", () => {
+    assert.equal(isManyUnread(MANY_UNREAD_THRESHOLD - 1), false);
+    assert.equal(isManyUnread(0), false);
+  });
+
+  it("handles bogus input without misfiring", () => {
+    assert.equal(isManyUnread(Number.NaN), false);
+  });
+});
+
+describe("isRunningLong", () => {
+  it(`fires once elapsed >= RUNNING_LONG_MS (${RUNNING_LONG_MS})`, () => {
+    const now = new Date(2026, 3, 23, 12, 1, 0); // 60 s later
+    const runningSinceMs = new Date(2026, 3, 23, 12, 0, 0).getTime();
+    assert.equal(isRunningLong(runningSinceMs, now), true);
+  });
+
+  it("stays quiet under the threshold", () => {
+    const now = new Date(2026, 3, 23, 12, 0, 59);
+    const runningSinceMs = new Date(2026, 3, 23, 12, 0, 0).getTime();
+    assert.equal(isRunningLong(runningSinceMs, now), false);
+  });
+
+  it("skips when the session isn't running", () => {
+    assert.equal(isRunningLong(null, new Date()), false);
+  });
+});

--- a/test/composables/favicon/test_resolveColor.ts
+++ b/test/composables/favicon/test_resolveColor.ts
@@ -1,0 +1,180 @@
+// Priority tests for the favicon resolver. Each test pins one rule
+// by constructing the exact context that should fire it, then checks
+// both the returned hex and the `reason` tag so a mis-classification
+// (right colour, wrong branch) still fails.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveFaviconColor, FAVICON_COLORS } from "../../../src/composables/favicon/resolveColor.js";
+import { FAVICON_REASONS, FAVICON_STATES, type FaviconContext } from "../../../src/composables/favicon/types.js";
+
+// Plain weekday afternoon — every flavour rule is off so "idle" is
+// the default fallback. Use this as a base and override one field
+// per test to keep the intent obvious.
+function baseIdle(): FaviconContext {
+  return {
+    state: FAVICON_STATES.idle,
+    sessionsUnreadCount: 0,
+    runningSinceMs: null,
+    now: new Date(2026, 3, 23, 14, 0), // Thu 2026-04-23 14:00
+    userBirthdayMMDD: null,
+    cpuLoadRatio: 0.2,
+  };
+}
+
+describe("resolveFaviconColor — state-driven rules (priority 1-6)", () => {
+  it("error state beats everything, including overload and calendar", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.error,
+      cpuLoadRatio: 1.5, // would be overloaded
+      now: new Date(2026, 11, 25, 3, 0), // would be christmas + late-night
+      sessionsUnreadCount: 99, // would be many-unread
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.error);
+    assert.equal(pick.color, FAVICON_COLORS.error);
+  });
+
+  it("overloaded beats many-unread + running", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      cpuLoadRatio: 1.2,
+      sessionsUnreadCount: 7,
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.overloaded);
+    assert.equal(pick.color, FAVICON_COLORS.overloaded);
+  });
+
+  it("many-unread beats running and done", () => {
+    const runningPick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      sessionsUnreadCount: 6,
+    });
+    assert.equal(runningPick.reason, FAVICON_REASONS.manyUnread);
+
+    const donePick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.done,
+      sessionsUnreadCount: 10,
+    });
+    assert.equal(donePick.reason, FAVICON_REASONS.manyUnread);
+  });
+
+  it("running-long replaces running after 60s", () => {
+    const now = new Date(2026, 3, 23, 14, 1, 30); // 90 s elapsed
+    const runningSinceMs = new Date(2026, 3, 23, 14, 0).getTime();
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      now,
+      runningSinceMs,
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.runningLong);
+    assert.equal(pick.color, FAVICON_COLORS.runningLong);
+  });
+
+  it("short running fires the default running branch", () => {
+    const now = new Date(2026, 3, 23, 14, 0, 10); // 10 s elapsed
+    const runningSinceMs = new Date(2026, 3, 23, 14, 0).getTime();
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      now,
+      runningSinceMs,
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.running);
+    assert.equal(pick.color, FAVICON_COLORS.running);
+  });
+
+  it("has-unread fires for done state with a modest unread count", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.done,
+      sessionsUnreadCount: 2,
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.hasUnread);
+    assert.equal(pick.color, FAVICON_COLORS.hasUnread);
+  });
+});
+
+describe("resolveFaviconColor — flavour rules (priority 7-12)", () => {
+  it("birthday beats every other flavour rule", () => {
+    // Dec 25 10:00 — would be christmas + weekend, but birthday wins.
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2026, 11, 25, 10, 0),
+      userBirthdayMMDD: "12-25",
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.birthday);
+    assert.equal(pick.color, FAVICON_COLORS.birthday);
+  });
+
+  it("new year beats late-night and christmas (can't overlap, but pins order)", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2027, 0, 1, 23, 0), // Jan 1 23:00 — also late-night
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.newYear);
+  });
+
+  it("christmas fires on Dec 24 midday", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2026, 11, 24, 14, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.christmas);
+  });
+
+  it("late-night fires at 23:00 on a plain weekday", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2026, 3, 23, 23, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.lateNight);
+  });
+
+  it("morning fires at 07:00 on a plain weekday", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2026, 3, 23, 7, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.morning);
+  });
+
+  it("weekend fires on Saturday afternoon", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      now: new Date(2026, 3, 25, 14, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.weekend);
+  });
+
+  it("idle gray is the fallback on a plain weekday midday", () => {
+    const pick = resolveFaviconColor(baseIdle());
+    assert.equal(pick.reason, FAVICON_REASONS.idle);
+    assert.equal(pick.color, FAVICON_COLORS.idle);
+  });
+});
+
+describe("resolveFaviconColor — cross-rule priority", () => {
+  it("state-driven rules always beat flavour", () => {
+    // Christmas 00:00 with a running agent — running-blue, not christmas-green.
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      runningSinceMs: new Date(2026, 11, 25, 0, 0).getTime() - 1000,
+      now: new Date(2026, 11, 25, 0, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.running);
+  });
+
+  it("skips overloaded when cpuLoadRatio is null (no data yet / Windows)", () => {
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      cpuLoadRatio: null,
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.idle);
+  });
+});


### PR DESCRIPTION
## Summary

favicon の背景色バリエーションを 4 → 13 に拡張。agent state + 未読数 + 時刻 + 曜日 + サーバ CPU 負荷 + 記念日を合わせて優先度付きのルールチェーンで評価し、状況に応じた色を返す純粋関数を分離。

設計: \`plans/feat-favicon-conditional-palette.md\`

## 13 色 + 条件

### State driven (常に勝つ)

| # | 条件 | 色 |
|---|---|---|
| 1 | error | \`#DC2626\` red-600 |
| 2 | server overloaded (\`load1/cores > 0.9\`) | \`#EA580C\` orange-600 |
| 3 | many-unread ≥ 5 | \`#D946EF\` fuchsia-500 |
| 4 | running-long (≥ 60s) | \`#06B6D4\` cyan-500 |
| 5 | running | \`#3B82F6\` blue-500 |
| 6 | has-unread | \`#22C55E\` green-500 |

### Flavour (idle 時のみ、calendar > clock)

| # | 条件 | 色 |
|---|---|---|
| 7 | 誕生日 (memory.md に \`birthday: MM-DD\` があれば) | \`#EAB308\` yellow-500 |
| 8 | 元日 (1/1〜1/3) | \`#B91C1C\` red-700 |
| 9 | クリスマス (12/24, 12/25) | \`#15803D\` green-700 |
| 10 | 深夜 22:00〜05:00 | \`#6366F1\` indigo-500 |
| 11 | 早朝 05:00〜09:00 | \`#F59E0B\` amber-500 |
| 12 | 週末 土日 09:00〜22:00 | \`#14B8A6\` teal-500 |
| 13 | idle フォールバック | \`#6B7280\` gray-500 |

## Architecture

```
src/composables/favicon/
  types.ts         # FaviconContext, FaviconState, FaviconReason, FaviconPick
  conditions.ts    # pure predicates: isLateNight, isWeekend, isManyUnread, ...
  resolveColor.ts  # rule chain: (ctx) => { color, reason }
test/composables/favicon/
  test_conditions.ts   # 27 ケース
  test_resolveColor.ts # 11 ケース (state-beats-flavour 含む)
```

- \`useDynamicFavicon\` は canvas レンダラに専念。\`STATE_COLORS\` を削除、色は呼び出し側が resolve 済みで渡す
- \`useFaviconState\` が毎分 tick + \`runningSinceMs\` + \`cpuLoadRatio\` を集約して \`resolveFaviconColor\` に通す
- \`/api/health\` に \`cpu: { load1, cores }\` を追加 (\`os.loadavg()\` + \`os.cpus().length\`)
- \`useHealth\` が 15 秒間隔でポーリング、\`load1/cores\` 比を expose

## Items to Confirm / Review

- **CPU 負荷**: \`os.loadavg()\` が Windows では \`[0, 0, 0]\` を返すので overloaded ルールは silently 発火しない (Windows ユーザはオレンジを見ない) → 許容
- **birthday の source**: \`userBirthdayMMDD\` は optional で null 時はルール 7 はスキップ。memory.md パーサは今 PR では未実装 — 将来 \`/api/config/user-birthday\` を足せば有効化できる (計画書の Step 6)
- **色の選択**: fuchsia / teal / indigo / amber などは彩度高め。タブ ストリップでの視認性は実機確認お願いします
- **優先度**: state が flavour を常に勝つ設計。例: クリスマスの夜に agent が running → クリスマス緑ではなく running 青 (= 進行中は合図を絶対に曇らせない)

## User Prompt

> faviconだけど、なんか色んな色にしたいな。条件とカラーを考えて、特殊条件でいろんな色になるようにしてほしい。  
> いいね！ CPU 使用率ってとれるんならやってもよいかもね。faviconぶぶん、関数でファイルにしたうえでplan作って実装を！！

## Verification

- \`yarn typecheck\` 全ワークスペース通過
- \`yarn lint\` 0 errors
- \`yarn build\` 通過
- \`yarn test\` — **2,732 tests pass, 0 fail** (新規 38 追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)