### PR TITLE
verify(step6): drift trap — DO NOT MERGE

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -11,3 +11,9 @@ export { EVENT_TYPES, type EventType, GENERATION_KINDS, type GenerationKind, typ
 export { CHAT_SOCKET_PATH, CHAT_SOCKET_EVENTS, type ChatSocketEvent } from "./socket.js";
 export { type Attachment } from "./attachment.js";
 export { CHAT_SERVICE_ROUTES } from "./routes.js";
+
+// step 6 verification marker — intentionally added value export
+// without a version bump to test whether `scripts/mulmoclaude/drift.mjs`
+// flags the drift in CI. This export will be removed when the
+// verify/step6-drift-trap PR is closed.
+export const STEP6_DRIFT_MARKER = "verify/step6-drift-trap";


### PR DESCRIPTION
Dev-only PR to exercise the drift trap for plan step 6. Expected to either (a) flag drift and fail the smoke job [trap works as intended], or (b) pass because workspace symlinks make src==dist after build:packages [reveals an implementation gap to fix in a follow-up].

Will be closed without merging either way.