### PR TITLE
fix(chat): sync role on Cmd+1 resume + fix invalid h1 inside button

### DIFF
--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -106,4 +106,34 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     const stored = await page.evaluate(() => localStorage.getItem("canvas_layout_mode"));
     expect(stored).toBe("single");
   });
+
+  test("Cmd/Ctrl+1 re-syncs the role selector to the resumed session's role (#665 follow-up)", async ({ page }) => {
+    // Regression: resumeOrCreateChatSession() used to call
+    // navigateToSession() directly on the cached-session branch,
+    // bypassing currentRoleId sync. The selector would stay on
+    // whichever role the user picked on /files / /wiki / etc.
+    //
+    // Fixture sessions are created with roleId "general". Change
+    // the selector to "artist" on /files (which is a no-op for
+    // the session since !isChatPage), then Cmd+1 back to /chat
+    // and confirm the selector reverted to "general".
+    await page.goto("/chat");
+    // Wait for /chat → /chat/<id> redirect to settle — resumeOrCreate
+    // reads the top-of-list session on Cmd+1, so we need the initial
+    // session list loaded.
+    await page.waitForURL(/\/chat\//);
+
+    await page.goto("/files");
+    await expect(page).toHaveURL(/\/files/);
+
+    // Flip role to Artist via the selector.
+    await page.getByTestId("role-selector-btn").click();
+    await page.getByTestId("role-option-artist").click();
+    await expect(page.getByTestId("role-selector-btn")).toContainText("Artist");
+
+    // Cmd+1 → back to /chat; resumed session's role is "general".
+    await pressShortcut(page, "1");
+    await expect(page).toHaveURL(/\/chat\//);
+    await expect(page.getByTestId("role-selector-btn")).toContainText("General");
+  });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -588,10 +588,13 @@ async function resumeOrCreateChatSession(): Promise<void> {
     return;
   }
   if (sessionMap.has(topId)) {
-    // Already in memory — navigate explicitly. loadSession would
-    // early-return here if topId === currentSessionId, skipping the
-    // URL push we need when arriving from a non-chat page.
-    navigateToSession(topId);
+    // Already in memory — activate so the role selector re-syncs to
+    // the session's role. Going through navigateToSession alone would
+    // push `/chat/:topId` without touching `currentRoleId`, leaving
+    // the selector stuck on whatever role the user picked on the
+    // page they're coming from.
+    const live = sessionMap.get(topId)!;
+    activateSession(topId, live.roleId, false);
     return;
   }
   await loadSession(topId);

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -9,7 +9,9 @@
       @click="emit('home')"
     >
       <img :src="logoUrl" alt="" class="h-[50px] w-auto -my-3.5 -ml-3 rounded object-contain shrink-0" />
-      <h1 data-testid="app-title" class="text-sm font-semibold text-gray-800 mr-1" :style="titleStyle">MulmoClaude</h1>
+      <!-- span, not h1: `<h1>` inside `<button>` is invalid HTML, and
+           the brand label here is a clickable logo, not a page heading. -->
+      <span data-testid="app-title" class="text-sm font-semibold text-gray-800 mr-1" :style="titleStyle">MulmoClaude</span>
     </button>
     <div class="flex gap-2">
       <LockStatusPopup


### PR DESCRIPTION
Follow-up to unaddressed self-review on merged PR #665.

## Summary
- **Cmd+1 role desync**: `resumeOrCreateChatSession()`'s cached-session branch called `navigateToSession()` directly, bypassing `activateSession()`. The role selector stayed stuck on whatever role the user picked on the page they were coming from instead of re-syncing to the resumed session's role.
- **Invalid HTML**: `SidebarHeader` had `<button>` wrapping `<h1>`, which HTML forbids (button can only contain phrasing content). The brand label is a clickable logo, not a page heading — swapped to `<span>` with the same testid / styling.

## Items to Confirm / Review
- **Cmd+1 role sync**: routes through `activateSession(topId, live.roleId, false)` to flip `currentRoleId` before navigating. The existing comment about 'navigate explicitly' still holds — activateSession also calls navigateToSession internally, so no URL push behavior changed.
- **h1 → span**: removed the semantic heading. If someone relied on "MulmoClaude" being an `<h1>` for SEO / a11y outline, that's intentional — the sidebar header isn't meant to be the document outline's h1 anyway (most pages are unstyled / plugin views).
- `data-testid=\"app-title\"` kept — used by `smoke.spec.ts` and `bearer-auth.spec.ts`, no test changes needed.

## User Prompt
> 24時間以内のPRを全部見て、closeしているのにコメント対応してないののを対応
> […調査結果を提示 → 4 本の独立 PR に分割提案 → ユーザー承認…]
> はい、１つ１つPRで全部

This is PR 1 of 4. Follow-ups planned for #655 (wiki route params), #679 (session-tab-bar e2e assertions), #645 (README anchor links).

## Implementation
- `src/App.vue:590-598` — `sessionMap.has(topId)` branch now calls `activateSession(topId, live.roleId, false)` instead of `navigateToSession(topId)`.
- `src/components/SidebarHeader.vue:12` — `<h1 data-testid=\"app-title\">` → `<span data-testid=\"app-title\">` + explanatory comment.
- `e2e/tests/keyboard-shortcuts.spec.ts:110` — new regression test: `/chat` → `/files` → change role to Artist → Cmd+1 → asserts selector back on General.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (pre-existing v-html warnings only)
- [x] `yarn format` clean
- [x] `yarn test:e2e --grep keyboard-shortcuts` — all 9 tests pass (+1 new)
- [ ] Manual: open /chat, switch to /wiki, change role, Cmd+1 → selector reverts to session role

🤖 Generated with [Claude Code](https://claude.com/claude-code)