### PR TITLE
fix(scripts): drift check compares against registry-published dist

### DIFF
--- a/scripts/mulmoclaude/drift.d.mts
+++ b/scripts/mulmoclaude/drift.d.mts
@@ -6,6 +6,9 @@
 export interface PackageDriftResult {
   packageBaseName: string;
   localVersion: string | null;
+  /** The version the `latest` dist-tag resolved to on the registry. Null when
+   * the fetch failed and we fell back to the local installed dist. */
+  publishedVersion?: string | null;
   status: "ok" | "drifted" | "skipped";
   /** Present when `status` is "ok" or "drifted". */
   localCount?: number;
@@ -13,7 +16,20 @@ export interface PackageDriftResult {
   distCount?: number;
   /** Present when `status` is "skipped" — human-readable explanation. */
   reason?: string;
+  /** Present when the registry was unreachable and we compared against
+   * the local installed dist instead. */
+  fallbackReason?: string;
 }
+
+/** Outcome of the registry fetch — raw source plus the resolved version. */
+export interface PublishedSource {
+  version: string | null;
+  source: string | null;
+  reason: string | null;
+}
+
+/** Injectable fetcher — tests supply a stub, real runs use the registry. */
+export type FetchPublishedSource = (args: { packageBaseName: string; timeoutMs?: number }) => Promise<PublishedSource>;
 
 export function countValueExportLines(source: string): number;
 
@@ -27,6 +43,9 @@ export interface CheckPackageDriftOptions {
   /** Override the `node_modules` path (used by fixtures that
    * can't ship a real node_modules/ — globally gitignored). */
   installedRoot?: string;
+  /** Injectable published-source fetcher. Defaults to the real
+   * registry+unpkg implementation; tests pass a stub. */
+  fetchPublishedSource?: FetchPublishedSource;
 }
 
 export function checkPackageDrift(options: CheckPackageDriftOptions): Promise<PackageDriftResult>;
@@ -46,6 +65,7 @@ export interface CheckWorkspaceDriftOptions {
   installedRoot?: string;
   srcRelative?: string;
   distRelative?: string;
+  fetchPublishedSource?: FetchPublishedSource;
 }
 
 export function checkWorkspaceDrift(options?: CheckWorkspaceDriftOptions): Promise<PackageDriftResult[]>;

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -1,21 +1,29 @@
 // @mulmobridge/* drift check (§2 of publish-mulmoclaude skill).
 //
 // Problem: a local `packages/<name>/src/` file adds a new runtime
-// export without a version bump. `yarn install` keeps using the
-// older dist/ already in node_modules, so consumers crash with:
+// export without a version bump. The tarball a real user installs
+// from the registry ships the OLD dist/, so consumers crash with:
 //   does not provide an export named X
 // at runtime — invisible to lint, typecheck, or local dev.
 //
-// Detection strategy (from the skill, unchanged):
-//   count value-export LINES in src/index.ts
-//   count value-export LINES in <installed dist>/index.js
-//   if src > dist, the package has drifted and must be bumped.
+// Detection strategy: count value-export LINES in src/index.ts and
+// in the currently-published dist (fetched from the npm registry),
+// flag when src > published.
+//
+// Why the registry and not `node_modules/.../dist`: in a yarn-
+// workspace repo, `node_modules/@mulmobridge/<name>` is a symlink
+// into `packages/<name>/`. `yarn build:packages` then rebuilds that
+// symlinked dist from the current src, making `src == dist` in CI
+// regardless of whether the published version lags behind — the
+// whole point of the check. Compare against the registry payload
+// instead so the drift picks up exactly what a fresh
+// `npm install mulmoclaude` would see at runtime.
 //
 // "Value export LINES" = every `^export …` line except ones that
 // are entirely type-only (`export type …`, `export interface …`,
 // `export { type … }`). Counting lines (not individual specifiers)
-// is intentional — the skill has been using this heuristic across
-// real releases and it's picked up every regression we've seen.
+// matches the original skill heuristic and has caught every real
+// drift we've seen.
 
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -23,6 +31,9 @@ import { fileURLToPath } from "node:url";
 
 const MULMOBRIDGE_SCOPE = "@mulmobridge/";
 const DEFAULT_INSTALLED_ROOT = "node_modules";
+const REGISTRY_BASE = "https://registry.npmjs.org";
+const UNPKG_BASE = "https://unpkg.com";
+const REGISTRY_TIMEOUT_MS = 15_000;
 
 // Returns how many `^export …` lines in `source` declare at least
 // one runtime (value) export. Type-only lines are filtered.
@@ -60,26 +71,82 @@ async function readLocalVersion(root, packageBaseName) {
   }
 }
 
+// Default published-source fetcher: queries the npm registry for
+// the package's `latest` dist-tag version, then pulls the `main` /
+// `module` entry from unpkg. Returns `null` on any network / 404
+// failure so the caller can skip rather than crash.
+async function defaultFetchPublishedSource({ packageBaseName, timeoutMs = REGISTRY_TIMEOUT_MS } = {}) {
+  const fullName = MULMOBRIDGE_SCOPE + packageBaseName;
+  const controller = new AbortController();
+  const killer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const metaRes = await fetch(`${REGISTRY_BASE}/${encodeURIComponent(fullName)}/latest`, {
+      signal: controller.signal,
+    });
+    if (!metaRes.ok) return { version: null, source: null, reason: `registry ${metaRes.status}` };
+    const meta = await metaRes.json();
+    const version = typeof meta.version === "string" ? meta.version : null;
+    if (!version) return { version: null, source: null, reason: "registry meta missing version" };
+    // Prefer the package's declared `main` / `module` entry rather
+    // than assuming `dist/index.js` — a future refactor of the
+    // @mulmobridge/* packages could move the entry file.
+    const entry =
+      typeof meta.module === "string"
+        ? meta.module
+        : typeof meta.main === "string"
+          ? meta.main
+          : "dist/index.js";
+    const distRes = await fetch(`${UNPKG_BASE}/${fullName}@${version}/${entry.replace(/^\.?\/+/, "")}`, {
+      signal: controller.signal,
+    });
+    if (!distRes.ok) return { version, source: null, reason: `unpkg ${distRes.status}` };
+    const source = await distRes.text();
+    return { version, source, reason: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { version: null, source: null, reason: `network: ${message}` };
+  } finally {
+    clearTimeout(killer);
+  }
+}
+
+// Read installed-dist source (the pre-registry behaviour). Kept as
+// a fallback so offline / registry-unreachable callers still get a
+// signal, and the existing fixture-based tests keep working.
+async function readInstalledDistSource({ root, packageBaseName, installedRoot, distRelative }) {
+  const distPath = path.join(root, installedRoot, MULMOBRIDGE_SCOPE + packageBaseName, distRelative);
+  try {
+    return await readFile(distPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
 // Inspect one package: compare local src value-export count with
-// installed dist value-export count. If either file is missing,
-// the package is reported as `skipped` with a reason so the CLI
-// caller can decide whether to treat it as a failure or warning.
+// the currently-published dist (fetched from the registry). Returns
+// `{ status: "ok"|"drifted"|"skipped", ... }`.
 //
-// `installedRoot` is overridable so fixture trees (which can't use
-// a real `node_modules/` path — it's globally gitignored) can point
-// the lookup at an alternate directory.
+// Options:
+//   fetchPublishedSource: override for the registry fetcher; must
+//     resolve to `{ version, source, reason }` shape. Tests pass a
+//     fake; real runs use defaultFetchPublishedSource.
+//   installedRoot / distRelative: legacy local-dist fallback, used
+//     when `fetchPublishedSource` returns no source (offline CI,
+//     package not on registry, etc.). Also kept so the existing
+//     fixture tests can exercise the local-dist path without hitting
+//     the network.
 export async function checkPackageDrift({
   root = process.cwd(),
   packageBaseName,
   srcRelative = "src/index.ts",
   distRelative = "dist/index.js",
   installedRoot = DEFAULT_INSTALLED_ROOT,
+  fetchPublishedSource = defaultFetchPublishedSource,
 } = {}) {
   if (!packageBaseName) {
     throw new Error("checkPackageDrift: packageBaseName is required");
   }
   const srcPath = path.join(root, "packages", packageBaseName, srcRelative);
-  const distPath = path.join(root, installedRoot, MULMOBRIDGE_SCOPE + packageBaseName, distRelative);
   const localVersion = await readLocalVersion(root, packageBaseName);
 
   let srcSource;
@@ -89,14 +156,24 @@ export async function checkPackageDrift({
     return { packageBaseName, localVersion, status: "skipped", reason: `local src not found at ${srcRelative}` };
   }
 
-  let distSource;
-  try {
-    distSource = await readFile(distPath, "utf8");
-  } catch {
-    // Common when `yarn install` hasn't run yet, or when the dep
-    // isn't in node_modules at this workspace level. Not an error —
-    // the caller (CLI or smoke driver) decides.
-    return { packageBaseName, localVersion, status: "skipped", reason: "installed dist not found (run yarn install first)" };
+  const published = await fetchPublishedSource({ packageBaseName });
+  let distSource = published.source;
+  let publishedVersion = published.version;
+  let fallbackReason = null;
+  if (distSource === null) {
+    distSource = await readInstalledDistSource({ root, packageBaseName, installedRoot, distRelative });
+    if (distSource !== null) {
+      fallbackReason = `registry unreachable (${published.reason ?? "unknown"}) — compared against local ${installedRoot}/.../${distRelative}`;
+    }
+  }
+
+  if (distSource === null) {
+    return {
+      packageBaseName,
+      localVersion,
+      status: "skipped",
+      reason: `no dist to compare — registry: ${published.reason ?? "unknown"}, local dist not found either`,
+    };
   }
 
   const localCount = countValueExportLines(srcSource);
@@ -105,9 +182,11 @@ export async function checkPackageDrift({
   return {
     packageBaseName,
     localVersion,
+    publishedVersion,
     status: drifted ? "drifted" : "ok",
     localCount,
     distCount,
+    ...(fallbackReason ? { fallbackReason } : {}),
   };
 }
 
@@ -136,25 +215,37 @@ export async function checkWorkspaceDrift({
   installedRoot = DEFAULT_INSTALLED_ROOT,
   srcRelative,
   distRelative,
+  fetchPublishedSource,
 } = {}) {
   const names = packageBaseNames ?? (await detectMulmobridgeDeps({ root }));
   const results = [];
   for (const name of names) {
-    results.push(await checkPackageDrift({ root, packageBaseName: name, installedRoot, srcRelative, distRelative }));
+    results.push(
+      await checkPackageDrift({
+        root,
+        packageBaseName: name,
+        installedRoot,
+        srcRelative,
+        distRelative,
+        ...(fetchPublishedSource ? { fetchPublishedSource } : {}),
+      }),
+    );
   }
   return results;
 }
 
 function formatLine(result) {
-  const { packageBaseName, localVersion, status } = result;
-  const ver = localVersion ? `v${localVersion}` : "(no local version)";
+  const { packageBaseName, localVersion, publishedVersion, status, fallbackReason } = result;
+  const local = localVersion ? `v${localVersion}` : "(no local version)";
+  const published = publishedVersion ? `→ published v${publishedVersion}` : "";
+  const fallback = fallbackReason ? ` [${fallbackReason}]` : "";
   if (status === "drifted") {
-    return `  ⚠ @mulmobridge/${packageBaseName} ${ver}: local has ${result.localCount} value-export lines, installed dist has ${result.distCount}`;
+    return `  ⚠ @mulmobridge/${packageBaseName} ${local} ${published}: src has ${result.localCount} value-export lines, published dist has ${result.distCount}${fallback}`;
   }
   if (status === "skipped") {
-    return `  · @mulmobridge/${packageBaseName} ${ver}: skipped — ${result.reason}`;
+    return `  · @mulmobridge/${packageBaseName} ${local}: skipped — ${result.reason}`;
   }
-  return `  ✓ @mulmobridge/${packageBaseName} ${ver}: ${result.localCount} value-export lines (src == dist)`;
+  return `  ✓ @mulmobridge/${packageBaseName} ${local} ${published}: ${result.localCount} value-export lines (src == published)${fallback}`;
 }
 
 // CLI: exits 1 if any package drifted, 0 otherwise. "skipped"

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -12,6 +12,18 @@ import * as drift from "../../../scripts/mulmoclaude/drift.mjs";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(HERE, "fixtures");
 
+// Most tests want to exercise the local-fixture fallback rather
+// than the real registry. Pass this stub to force the fallback
+// branch (registry "unreachable") and let the existing fixtures
+// under installed_packages/.../\_dist/ drive the comparison.
+const offlineRegistry = async () => ({ version: null, source: null, reason: "test stub — skip registry" });
+
+// Stub returning a specific source, used by the new drifted-from-
+// published tests below.
+function registryReturning(source: string, version = "0.0.0-stub") {
+  return async () => ({ version, source, reason: null });
+}
+
 describe("countValueExportLines", () => {
   it("counts plain re-export lines", () => {
     const source = `export { foo } from "./foo";\nexport { bar } from "./bar";\n`;
@@ -74,6 +86,7 @@ describe("checkPackageDrift", () => {
       packageBaseName: "protocol",
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(result.status, "ok");
     assert.equal(result.localCount, 3);
@@ -87,6 +100,7 @@ describe("checkPackageDrift", () => {
       packageBaseName: "protocol",
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(result.status, "drifted");
     assert.equal(result.localCount, 3);
@@ -99,6 +113,7 @@ describe("checkPackageDrift", () => {
       packageBaseName: "client",
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(result.status, "ok");
     assert.equal(result.localCount, 1);
@@ -114,6 +129,7 @@ describe("checkPackageDrift", () => {
       packageBaseName: "chat-service",
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(result.status, "skipped");
     assert.match(result.reason ?? "", /src not found|dist not found/);
@@ -121,6 +137,37 @@ describe("checkPackageDrift", () => {
 
   it("throws when packageBaseName is missing", async () => {
     await assert.rejects(drift.checkPackageDrift({ root: FIXTURES }), /packageBaseName is required/);
+  });
+
+  it("flags drift against the registry-published source (workspace-symlink aware)", async () => {
+    // drift-clean's protocol src has 3 value-export lines. The
+    // stub registry returns a dist with only 2 lines — what
+    // would ship to users after an install-from-registry. Drift
+    // must flag this even though the local workspace dist would
+    // otherwise match src.
+    const publishedOldDist = `export { a } from "./a.js";\nexport { b } from "./b.js";\n`;
+    const result = await drift.checkPackageDrift({
+      root: path.join(FIXTURES, "drift-clean"),
+      packageBaseName: "protocol",
+      fetchPublishedSource: registryReturning(publishedOldDist, "0.1.3"),
+    });
+    assert.equal(result.status, "drifted");
+    assert.equal(result.localCount, 3);
+    assert.equal(result.distCount, 2);
+    assert.equal(result.publishedVersion, "0.1.3");
+    assert.equal(result.fallbackReason, undefined, "must not use local fallback when registry succeeded");
+  });
+
+  it("falls back to local installed dist when the registry fetch returns no source", async () => {
+    const result = await drift.checkPackageDrift({
+      root: path.join(FIXTURES, "drift-clean"),
+      packageBaseName: "protocol",
+      installedRoot: "installed_packages",
+      distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
+    });
+    assert.equal(result.status, "ok");
+    assert.match(result.fallbackReason ?? "", /registry unreachable/);
   });
 });
 
@@ -150,6 +197,7 @@ describe("checkWorkspaceDrift (auto-detection)", () => {
       root: path.join(FIXTURES, "drift-drifted"),
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(results.length, 2);
     const protocolResult = results.find((row) => row.packageBaseName === "protocol");
@@ -164,6 +212,7 @@ describe("checkWorkspaceDrift (auto-detection)", () => {
       packageBaseNames: ["protocol"],
       installedRoot: "installed_packages",
       distRelative: "_dist/index.js",
+      fetchPublishedSource: offlineRegistry,
     });
     assert.equal(results.length, 1);
     assert.equal(results[0].status, "ok");


### PR DESCRIPTION
## Summary

Closes the gap exposed by #686 (step-6 verification PR). The drift check didn't fire in CI because \`node_modules/@mulmobridge/<name>\` is a yarn workspace symlink — \`yarn build:packages\` rebuilds the symlinked dist from the modified src before smoke runs, so \`src == dist\` regardless of what the registry actually holds.

This PR changes drift to fetch the real **published** dist from \`registry.npmjs.org\` + \`unpkg\`, which is the exact payload a fresh \`npm install mulmoclaude\` would install for a user. That's the scenario the check was meant to guard.

## Items to Confirm / Review

- **Fetch strategy**: \`/<pkg>/latest\` on registry → read \`module\`/\`main\` field → download that file from unpkg. Falls back to \`dist/index.js\` if the manifest doesn't declare \`module\` or \`main\`. If EITHER fetch fails (offline CI, 404, timeout), returns source=null and the caller falls back to the installed local dist with an explicit \`fallbackReason\` field so the log tells you why.
- **Injectable fetcher**: \`fetchPublishedSource\` option on \`checkPackageDrift\` / \`checkWorkspaceDrift\`. Tests stub it (deterministic, no network). Real runs use the default. Keeps the public API clean and testable.
- **Output format gained \"→ published v<X.Y.Z>\"** so the log names both sides of the comparison clearly.
- **Timeout**: 15s total for the registry fetch (registry + unpkg combined). AbortController-based. Tight but not so tight that a CI cold-start trips it.
- **No regression**: all existing 18 drift tests still pass with a stub that returns \`{ source: null }\` to force the local-fixture fallback path.

## User Prompt

> [C] drift trap だけ形式検証（実績ゼロなので）、残りは skip

Step 6 follow-up. The verification PR (#686) showed that the check as originally implemented wouldn't fire in this workspace repo; this PR is the fix.

## Test plan

- [x] \`yarn format\` / \`yarn lint\` — 0 errors
- [x] \`yarn typecheck\` — passes (d.mts updated)
- [x] \`npx tsx --test test/scripts/mulmoclaude/test_drift.ts\` — 20 pass (18 existing + 2 new)
- [x] Real repo, no marker: \`node scripts/mulmoclaude/drift.mjs\` → all 3 packages ok with \`→ published v<ver>\` annotation
- [x] Real repo, temporary \`STEP6_DRIFT_MARKER\` added to protocol src: drift flags protocol (\`src has 4 value-export lines, published dist has 3\`), exit 1 (marker reverted before commit)
- [ ] CI — expected green on main; the marker isn't on this branch

## Follow-ups

- Step 7: update \`.claude/skills/publish-mulmoclaude/SKILL.md\` to point §2 at the new registry-based check (the Bash snippet in the skill has the same workspace-symlink blind spot that the old drift.mjs had).

🤖 Generated with [Claude Code](https://claude.com/claude-code)