### PR TITLE
fix(wiki): clear optional route params on index/log/lint navigation

### DIFF
--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -179,6 +179,40 @@ test.describe("wiki navigation — URL sync", () => {
     await expect(page.getByText("Welcome to the project.")).toBeVisible();
   });
 
+  test("navigating from a page back to the index strips the slug from the URL (#655 follow-up)", async ({ page }) => {
+    // Regression: buildWikiRouteParams({ kind: "index" }) used to
+    // return `{}`, but Vue Router's named-route navigation does NOT
+    // clear previously-set optional params. The old URL `section` /
+    // `slug` would leak into the push, leaving the user on
+    // `/wiki/pages/foo` after clicking the Index tab, while the View
+    // rendered the index. Empty-string params now force a clean URL.
+    await page.goto("/wiki/pages/onboarding");
+    await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
+
+    // Click the Index tab (first button in the tab bar).
+    await page.getByRole("button", { name: /Index/ }).click();
+
+    await expect(async () => {
+      const parsed = new URL(page.url());
+      expect(parsed.pathname).toMatch(/^\/wiki\/?$/);
+    }).toPass({ timeout: 5000 });
+    await expect(page.getByTestId("wiki-page-entry-onboarding")).toBeVisible();
+  });
+
+  test("navigating from a page to the log clears the slug (#655 follow-up)", async ({ page }) => {
+    // Same stale-param concern as the index case, but the log
+    // destination still has a section — only the slug needs
+    // clearing. `/wiki/pages/foo` → log click must land on
+    // `/wiki/log`, not `/wiki/log/foo`.
+    await page.goto("/wiki/pages/onboarding");
+    await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
+
+    await page.getByRole("button", { name: /Log/ }).click();
+
+    await page.waitForURL(/\/wiki\/log$/);
+    await expect(page.getByText("Did stuff")).toBeVisible();
+  });
+
   // Table-driven round-trip for reserved / non-ASCII characters:
   // navigate straight to /wiki/pages/<encoded>, assert the API saw
   // the decoded slug verbatim (sentinel body renders in the DOM).

--- a/src/plugins/wiki/route.ts
+++ b/src/plugins/wiki/route.ts
@@ -80,18 +80,26 @@ export function readWikiRouteTarget(params: unknown): WikiTarget | null {
 
 // Inverse of `readWikiRouteTarget`: given a target, produce the
 // `{ section, slug }` params object that `router.push({ name: "wiki",
-// params })` needs. Index returns `{}` so the router strips the
-// optional segments and lands on `/wiki`.
+// params })` needs.
+//
+// Optional route params are NOT cleared by named-route navigation
+// unless explicitly set — returning `{}` for `kind: "index"` would
+// leak the previous `section`/`slug` into the URL when navigating
+// from `/wiki/pages/foo` back to the index, leaving the user on
+// `/wiki/pages/foo` with the View believing it's the index. Pass
+// empty strings so the router writes out `/wiki` cleanly. The
+// readWikiRouteTarget() branch for `section === ""` already
+// normalises those back to `{ kind: "index" }`.
 export function buildWikiRouteParams(target: WikiTarget): Record<string, string> {
   switch (target.kind) {
     case "index":
-      return {};
+      return { section: "", slug: "" };
     case "page":
       return { section: WIKI_ROUTE_SECTION.pages, slug: target.slug };
     case "log":
-      return { section: WIKI_ROUTE_SECTION.log };
+      return { section: WIKI_ROUTE_SECTION.log, slug: "" };
     case "lint_report":
-      return { section: WIKI_ROUTE_SECTION.lintReport };
+      return { section: WIKI_ROUTE_SECTION.lintReport, slug: "" };
   }
 }
 

--- a/test/plugins/wiki/test_route.ts
+++ b/test/plugins/wiki/test_route.ts
@@ -85,17 +85,25 @@ describe("readWikiRouteTarget", () => {
 });
 
 describe("buildWikiRouteParams", () => {
-  it("returns {} for index (so the router strips optional segments)", () => {
-    assert.deepEqual(buildWikiRouteParams({ kind: "index" }), {});
+  it("returns empty strings for index so vue-router clears stale optional params", () => {
+    // Named-route navigation does NOT clear optional params unless
+    // they're explicitly set. Returning `{}` would leak the previous
+    // `section`/`slug` when navigating from `/wiki/pages/foo` back
+    // to the index, leaving the URL stuck on the page route. Empty
+    // strings tell the router to write out the bare `/wiki` path.
+    assert.deepEqual(buildWikiRouteParams({ kind: "index" }), { section: "", slug: "" });
   });
 
   it("builds page params", () => {
     assert.deepEqual(buildWikiRouteParams({ kind: "page", slug: "onboarding" }), { section: "pages", slug: "onboarding" });
   });
 
-  it("builds log / lint_report params (kebab-case URL)", () => {
-    assert.deepEqual(buildWikiRouteParams({ kind: "log" }), { section: "log" });
-    assert.deepEqual(buildWikiRouteParams({ kind: "lint_report" }), { section: "lint-report" });
+  it("builds log / lint_report params with slug explicitly cleared (kebab-case URL)", () => {
+    // Same optional-param leak concern as the index case: slug needs
+    // to be explicitly "" so `/wiki/pages/foo` → log navigation
+    // doesn't produce `/wiki/log/foo`.
+    assert.deepEqual(buildWikiRouteParams({ kind: "log" }), { section: "log", slug: "" });
+    assert.deepEqual(buildWikiRouteParams({ kind: "lint_report" }), { section: "lint-report", slug: "" });
   });
 
   it("round-trips through readWikiRouteTarget", () => {


### PR DESCRIPTION
Follow-up to unaddressed P1 from chatgpt-codex-connector on merged PR #655.

## Summary
- `buildWikiRouteParams({ kind: \"index\" })` returned `{}`, but Vue Router's named-route navigation does NOT clear previously-set optional params. Pushing that from `/wiki/pages/foo` leaked `section`/`slug` into the URL — the user saw `/wiki/pages/foo` in the address bar while the View rendered the index.
- Same leak for `log` and `lint_report`: they set `section` but not `slug`, so `/wiki/pages/foo` → Log tab landed on `/wiki/log/foo` instead of `/wiki/log`.
- Fix: return empty strings for every optional param we don't need. `readWikiRouteTarget` already normalises `section === \"\"` back to `{ kind: \"index\" }`.

## Items to Confirm / Review
- **Breaking change for callers that rely on the `{}` shape**: none exist — `buildWikiRouteParams` is only consumed by `pushWiki()` in `src/plugins/wiki/View.vue`. The Vue Router `push()` call doesn't care about extra empty-string fields.
- **Unit test expectation flipped**: the old test asserted `assert.deepEqual(buildWikiRouteParams({ kind: \"index\" }), {})` — updated to `{ section: \"\", slug: \"\" }` since that's the whole point of this fix. Round-trip test still holds.
- **No functional change to reads** (`readWikiRouteTarget`) — only writes (`buildWikiRouteParams`).

## User Prompt
> 24時間以内のPRを全部見て、closeしているのにコメント対応してないののを対応
> […調査 → 4 本の独立 PR 分割提案 → 承認…]
> はい、１つ１つPRで全部

This is PR 2 of 4. Companion: #687 (role sync + invalid HTML). Remaining: session-tab-bar e2e, README anchor links.

## Implementation
- `src/plugins/wiki/route.ts:85` — `buildWikiRouteParams` now returns `{ section: \"\", slug: \"\" }` for index and `{ section: \"log\"|\"lint-report\", slug: \"\" }` for log/lint.
- `test/plugins/wiki/test_route.ts` — update unit expectations + explanatory comment.
- `e2e/tests/wiki-navigation.spec.ts` — two new regression tests: page → Index (URL strips to `/wiki`) and page → Log (URL strips to `/wiki/log`).

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (pre-existing v-html warnings only)
- [x] `yarn format` clean
- [x] `yarn build` succeeds
- [x] `yarn test` — 3015 pass (+ updated assertions)
- [x] `yarn test:e2e --grep wiki-navigation` — all 25 pass (+2 new)
- [ ] Manual: open `/wiki/pages/onboarding`, click Index tab, URL becomes `/wiki`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed wiki navigation to properly clear route parameters when switching between sections, preventing stale page slugs from appearing in the URL.

* **Tests**
  * Added regression tests to verify wiki navigation correctly clears route parameters when navigating to the Index and Log sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->