### PR TITLE
fix(e2e): session-tab-bar assertions actually distinguish tabs

### DIFF
--- a/e2e/tests/session-tab-bar.spec.ts
+++ b/e2e/tests/session-tab-bar.spec.ts
@@ -17,10 +17,12 @@ test.describe("session tab bar — visible per-tab info", () => {
     const tabA = page.getByTestId(`session-tab-${SESSION_A.id}`);
     const tabB = page.getByTestId(`session-tab-${SESSION_B.id}`);
 
-    // Label is derived from the preview (first 10 chars). SESSION_A's
-    // preview is "Hello from session A" → "Hello from".
-    await expect(tabA).toContainText("Hello from");
-    await expect(tabB).toContainText("Hello from");
+    // Assert on the distinguishing suffix ("session A" / "session B")
+    // rather than the shared "Hello from" prefix — otherwise the test
+    // would pass even if the tabs got swapped and each rendered the
+    // wrong session's label.
+    await expect(tabA).toContainText("session A");
+    await expect(tabB).toContainText("session B");
 
     // Tab tooltip keeps the full preview for users who want more.
     await expect(tabA).toHaveAttribute("title", SESSION_A.preview ?? "");
@@ -80,10 +82,12 @@ test.describe("session tab bar — visible per-tab info", () => {
     // literally looking at that conversation).
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    const tabB = page.getByTestId(`session-tab-${SESSION_B.id}`);
-    await expect(tabB).toBeVisible();
-    const activeTabId = await tabB.evaluate((node) => node.getAttribute("data-testid"));
-    // SESSION_B is newer → it's the displayed chat session.
+    await expect(page.getByTestId(`session-tab-${SESSION_B.id}`)).toBeVisible();
+    // Query by `aria-current="page"` to identify the active tab —
+    // reading data-testid from a tab we selected by id (the previous
+    // approach) was tautological and would pass even if the tabs
+    // were swapped. SESSION_B is newer → it's the displayed chat.
+    const activeTabId = await page.locator("button[aria-current='page'][data-testid^='session-tab-']").getAttribute("data-testid");
     expect(activeTabId).toBe(`session-tab-${SESSION_B.id}`);
 
     // Navigate off chat. The dot on tab B must now appear, because

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -16,6 +16,7 @@
         :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
         :title="tabTooltip(sessions[i - 1])"
         :data-testid="`session-tab-${sessions[i - 1].id}`"
+        :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
         @click="emit('loadSession', sessions[i - 1].id)"
       >
         <!-- Single icon slot. Non-human sessions swap the role


### PR DESCRIPTION
Follow-up to 2 unaddressed CodeRabbit actionable comments on merged PR #679.

## Summary
- Label assertion at `session-tab-bar.spec.ts:23` used `toContainText(\"Hello from\")` for both tabs — matches both SESSION_A and SESSION_B since both previews share that prefix. Swap to the distinguishing suffix.
- Active-tab assertion at `session-tab-bar.spec.ts:87` read `data-testid` from the tab it had just selected by that id — tautological, would pass even if the tabs were swapped. Add `aria-current=\"page\"` to the active tab and query by that instead.

## Items to Confirm / Review
- **Source change**: `aria-current=\"page\"` on the active tab. Standard a11y pattern; no visible styling change. Relying on `undefined` (not `\"false\"`) so the attribute is absent on inactive tabs rather than present-but-false.
- **Label assertion**: `\"session A\"` / `\"session B\"` are 9 chars, within the 20-char MAX_LABEL_CHARS cap — no truncation concern.
- The 4 existing tests still pass; no new tests added since the fix is purely about tightening existing assertions.

## User Prompt
> 24時間以内のPRを全部見て、closeしているのにコメント対応してないののを対応
> […調査 → 4 本の独立 PR 分割提案 → 承認…]
> はい、１つ１つPRで全部

This is PR 3 of 4. Companions: #687 (role sync + invalid HTML), #689 (wiki route params). Remaining: README anchor links.

## Implementation
- `src/components/SessionTabBar.vue:19` — add `:aria-current=\"sessions[i - 1].id === currentSessionId ? 'page' : undefined\"`.
- `e2e/tests/session-tab-bar.spec.ts:22-23` — `toContainText(\"Hello from\")` → `toContainText(\"session A\")` / `\"session B\"` + explanatory comment.
- `e2e/tests/session-tab-bar.spec.ts:85-87` — replace tautological `tabB.getAttribute(\"data-testid\")` with `page.locator(\"button[aria-current='page'][data-testid^='session-tab-']\").getAttribute(\"data-testid\")` + explanatory comment.

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (pre-existing v-html warnings only)
- [x] `yarn format` clean
- [x] `yarn build` succeeds
- [x] `yarn test:e2e --grep session-tab-bar` — all 4 pass
- [ ] Manual: sanity-check that `aria-current=\"page\"` appears on the active tab in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)