### PR TITLE
ci: upload smoke-verified mulmoclaude tarball as artifact

### DIFF
--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -106,6 +106,32 @@ jobs:
           DISABLE_SANDBOX: "1"
         run: node scripts/mulmoclaude/smoke.mjs
 
+      # Preserve the smoke-verified tarball as a downloadable
+      # artifact. tarball.mjs packs the launcher into
+      # packages/mulmoclaude/mulmoclaude-<X.Y.Z>.tgz and leaves it
+      # in place after a successful HTTP 200 probe — so what you
+      # grab here is exactly the tarball that just booted cleanly
+      # in a clean dir, with prepare-dist applied.
+      #
+      # Use case: a release engineer can download the artifact
+      # straight from the Actions run page and run
+      # `npx <downloaded>.tgz` locally to validate the UX before
+      # publishing, without having to rebuild the whole repo. CI
+      # fail paths also upload because the launcher log artifact
+      # alone isn't enough to reproduce — having the .tgz too
+      # lets you retry the install locally.
+      - name: Upload smoke-verified tarball
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mulmoclaude-tarball
+          path: packages/mulmoclaude/mulmoclaude-*.tgz
+          if-no-files-found: ignore
+          # Slightly longer than the launcher log — tarballs are
+          # useful for "did v0.4.1 actually work?" forensics weeks
+          # out, whereas a boot log goes stale fast.
+          retention-days: 30
+
       # Launcher stdout/stderr teed to /tmp/mc-smoke-*/launcher.log
       # by the tarball stage. Upload so a failed boot is diagnosable
       # without re-running locally. `if-no-files-found: ignore`


### PR DESCRIPTION
## Summary

Adds an artifact upload step to \`mulmoclaude_smoke.yaml\` so every green run preserves the \`.tgz\` that just passed the three-stage smoke (deps / drift / tarball HTTP 200). Release engineers can then download the exact tarball straight from the Actions run page to \`npm install\` it locally and validate UX before publishing — no need to rebuild the whole repo.

Fail runs also upload so a broken install is reproducible with the same bytes that CI saw.

## Items to Confirm / Review

- **30-day retention**: chosen vs. the launcher-log artifact's 7 days because a tarball's \"did v0.4.1 actually work at the time?\" forensic value extends further. Adjust if 30 feels long.
- **\`if: always()\`**: intentional — the \`.tgz\` is useful even on fail so you can try installing it locally without re-running CI.
- **Artifact name is \`mulmoclaude-tarball\`** (no suffix). GitHub scopes artifacts per run so they don't collide; the run's URL provides the version context. Adding a sha suffix is possible if preferred but makes the download name longer.
- **\`if-no-files-found: ignore\`**: defensive — if \`tarball.mjs\` somehow runs but doesn't leave the \`.tgz\` (shouldn't happen, but), the step degrades to a no-op rather than a workflow failure.

## User Prompt

> publishしたものを、artifactで保存してdlできるようにしたいね

Delivered as: the smoke-verified tarball (the next thing short of a real publish) now persists as a GitHub artifact on every workflow run.

## Test plan

- [x] \`yarn lint\` — no errors
- [ ] CI — expect the workflow to still pass, with \`mulmoclaude-tarball\` attached to the successful run
- [ ] Verify the artifact downloads and installs cleanly: \`npm install ./mulmoclaude-*.tgz && mulmoclaude --no-open --port 3099\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)