### PR TITLE
docs(relay): fix README references to unimplemented Slack

### DIFF
--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -4,7 +4,7 @@ Cloudflare Workers relay for MulmoBridge. Receives webhooks from messaging platf
 
 ## Why
 
-Without the relay, webhook-based bridges (LINE, Slack, etc.) need a public URL — typically via ngrok, which requires manual URL updates on every restart.
+Without the relay, webhook-based bridges (LINE, Messenger, Google Chat, Teams, …) need a public URL — typically via ngrok, which requires manual URL updates on every restart. (Slack is supported separately via `@mulmobridge/slack`, which uses Socket Mode on the user's machine and doesn't need the relay.)
 
 With the relay:
 
@@ -156,29 +156,29 @@ The relay uses a plugin architecture. Each platform is a self-contained
 file in `src/webhooks/` that implements `PlatformPlugin`:
 
 ```typescript
-// src/webhooks/slack.ts
-const slackPlugin: PlatformPlugin = {
-  name: PLATFORMS.slack,
-  mode: CONNECTION_MODES.webhook, // or "polling" or "persistent"
-  webhookPath: "/webhook/slack",
-  isConfigured: (env) => !!env.SLACK_SIGNING_SECRET,
+// src/webhooks/google-chat.ts (real example — ship shape)
+const googleChatPlugin: PlatformPlugin = {
+  name: PLATFORMS.googleChat,
+  mode: CONNECTION_MODES.webhook,
+  webhookPath: "/webhook/google-chat",
+  isConfigured: (env) => !!env.GOOGLE_CHAT_PROJECT_NUMBER,
   handleWebhook: async (request, body, env) => {
-    /* ... */
+    /* verify JWT, parse event, return RelayMessage[] */
   },
   sendResponse: async (chatId, text, env) => {
-    /* ... */
+    /* POST to https://chat.googleapis.com/v1/{chatId}/messages */
   },
 };
-registerPlatform(slackPlugin);
+registerPlatform(googleChatPlugin);
 ```
 
-Three connection modes are supported:
+Three connection modes are defined in `CONNECTION_MODES`; today only `webhook` is wired up (every real plugin uses it). `polling` and `persistent` are reserved for future platforms that can't post webhooks — e.g. a Discord Gateway integration would be `persistent`.
 
-| Mode         | Examples                           | Method                          |
-| ------------ | ---------------------------------- | ------------------------------- |
-| `webhook`    | LINE, Messenger, Google Chat       | Platform POSTs to relay URL     |
-| `polling`    | Telegram (alt)                     | Relay fetches from platform API |
-| `persistent` | Slack Socket Mode, Discord Gateway | Relay maintains WS to platform  |
+| Mode         | Examples (shipped)                                       | Method                          |
+| ------------ | -------------------------------------------------------- | ------------------------------- |
+| `webhook`    | LINE, WhatsApp, Messenger, Google Chat, Telegram, Teams  | Platform POSTs to relay URL     |
+| `polling`    | — (reserved)                                             | Relay fetches from platform API |
+| `persistent` | — (reserved)                                             | Relay maintains WS to platform  |
 
 ### Relay vs Bridge packages
 


### PR DESCRIPTION
## Summary

Two spots in \`packages/relay/README.md\` advertised Slack support that doesn't exist in the code. Replaced with accurate information.

## What was wrong

1. **Line 7** — \"webhook-based bridges (LINE, Slack, etc.)\" implied the relay handled Slack webhooks. There's no \`src/webhooks/slack.ts\`. Slack IS supported, but via the standalone \`@mulmobridge/slack\` Socket-Mode bridge that runs on the user's machine — a completely different path from the relay.
2. **Lines 159–181** — the \"adding a new platform\" section used Slack as the copy-paste example. The code snippet referenced a fictional \`src/webhooks/slack.ts\`, and the connection-modes table listed \"Slack Socket Mode, Discord Gateway\" as examples of \`persistent\` mode, which isn't implemented at all yet.

## What changed

- Line 7: list the actually-shipped webhook platforms (LINE, Messenger, Google Chat, Teams …) and add a one-liner cross-reference to \`@mulmobridge/slack\` so readers looking for Slack support still find it.
- Adding-a-new-platform section: swap the example for \`google-chat.ts\` — a real file, so the shape matches ship reality — and mark \`polling\` / \`persistent\` as reserved modes (no shipped plugin uses them today).

## What was NOT changed

\`types.ts:6\` still has \`slack: \"slack\"\` in the \`PLATFORMS\` enum as a forward-compatible stub. Removing it would be a breaking change for any consumer that references the name, and an unused enum entry doesn't confuse anyone by itself.

## User Prompt

> packages/relay/README.md にslackってあるけど、relayってslackサポートしている？
> A

(Option A was: docs fix only, no new implementation.)

## Test plan

- [x] \`grep -i slack packages/relay/README.md\` — only the accurate cross-reference to \`@mulmobridge/slack\` remains
- [x] Example code references \`src/webhooks/google-chat.ts\` which actually exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)