### PR TITLE
chore(slack): bump @mulmobridge/slack to 0.4.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Changed
+
+- `@mulmobridge/slack` (v0.3.0 → **v0.4.0**) — Opt-in ack-reaction feature. When `SLACK_ACK_REACTION` is set, the bridge adds an emoji reaction to every inbound message it processes, giving the user an immediate "the bot saw me" signal before the agent finishes thinking. Single dual-purpose env var — `1` enables with the default `:eyes:` 👀, any other emoji shortcode selects a custom emoji. Off by default; requires the `reactions:write` Bot Token Scope when enabled. Fire-and-forget: failures (missing scope, rate limit, etc.) log a warning without blocking the handler. Reaction is not removed when the reply arrives — it stays as a "seen" marker (#696, closes #695).
+
+### Packages published during this cycle
+
+- `@mulmobridge/slack@0.4.0`
+
 ---
 
 ## [0.4.0] - 2026-04-23

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/slack",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Slack bridge for MulmoBridge — connect a Slack bot to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps \`@mulmobridge/slack\` from 0.3.0 → **0.4.0** (minor — new opt-in feature, non-breaking).
- Adds the release entry to \`docs/CHANGELOG.md\` under \`[Unreleased]\`.

## Items to Confirm / Review

1. **Version bump level** — 0.3.0 → 0.4.0 (minor). Reasoning: new \`SLACK_ACK_REACTION\` env var is opt-in and off by default, so no existing deployment changes behavior on upgrade. Minor, not patch, because it's a feature addition; not major because pre-1.0 + opt-in.
2. **CHANGELOG placement** — slotted under the current \`[Unreleased]\` cycle so it groups with any other in-progress work. Follows the same structure used for the previous \`@mulmobridge/slack\` 0.3.0 entry.
3. Same publish flow as #663 planned for after merge: \`npm publish --access public\` → \`git tag @mulmobridge/slack@0.4.0\` → \`gh release create ... --latest=false\`.

## User Prompt

Following merge of #696:

> B

(Agreed to merge #696 + proceed with the publish flow.)

## Test plan

- [x] \`yarn install\` — clean
- [x] \`yarn format\` / \`yarn typecheck\` / \`yarn build\` — clean
- [x] \`yarn workspace @mulmobridge/slack test\` — done pre-merge in #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)