### PR TITLE
fix(ui): tighten top toolbar layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,18 +6,24 @@
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
         <SidebarHeader
           :sandbox-enabled="sandboxEnabled"
-          :show-right-sidebar="showRightSidebar"
-          :is-chat-page="isChatPage"
           :title-style="debugTitleStyle"
           @test-query="(q) => sendMessage(q)"
           @notification-navigate="handleNotificationNavigate"
-          @toggle-right-sidebar="toggleRightSidebar"
           @open-settings="showSettings = true"
           @home="handleHomeClick"
         />
         <div class="flex-1 min-w-0">
           <PluginLauncher :active-tool-name="selectedResult?.toolName ?? null" :active-view-mode="currentPage" @navigate="onPluginNavigate" />
         </div>
+        <button
+          v-if="isChatPage"
+          class="text-gray-400 hover:text-gray-700"
+          :class="{ 'text-blue-500': showRightSidebar }"
+          :title="t('sidebarHeader.toolCallHistory')"
+          @click="toggleRightSidebar"
+        >
+          <span class="material-icons">build</span>
+        </button>
       </div>
       <!-- Row 2: canvas toggle + role selector + session tabs -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="rootRef" class="flex border border-gray-300 rounded overflow-hidden text-xs" data-testid="plugin-launcher">
+  <div ref="rootRef" class="inline-flex w-fit border border-gray-300 rounded overflow-hidden text-xs" data-testid="plugin-launcher">
     <template v-for="(target, idx) in TARGETS" :key="target.key">
       <!-- Visual separator between data plugins and management plugins -->
       <div v-if="idx === SEPARATOR_AFTER_INDEX" class="w-px bg-gray-300 my-0.5" />

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -23,15 +23,6 @@
       />
       <NotificationBell :force-close="lockPopupOpen" @navigate="(action) => emit('notificationNavigate', action)" @update:open="onNotificationOpen" />
       <button
-        v-if="isChatPage"
-        class="text-gray-400 hover:text-gray-700"
-        :class="{ 'text-blue-500': showRightSidebar }"
-        :title="t('sidebarHeader.toolCallHistory')"
-        @click="emit('toggleRightSidebar')"
-      >
-        <span class="material-icons">build</span>
-      </button>
-      <button
         class="text-gray-400 hover:text-gray-700"
         data-testid="settings-btn"
         :title="t('sidebarHeader.settings')"
@@ -57,15 +48,12 @@ const { t } = useI18n();
 
 defineProps<{
   sandboxEnabled: boolean;
-  showRightSidebar: boolean;
-  isChatPage: boolean;
   titleStyle?: CSSProperties;
 }>();
 
 const emit = defineEmits<{
   testQuery: [query: string];
   notificationNavigate: [action: NotificationPayload["action"]];
-  toggleRightSidebar: [];
   openSettings: [];
   home: [];
 }>();


### PR DESCRIPTION
## Summary
- Moved the tool-call-history (`build` icon) toggle out of `SidebarHeader` and anchored it at the far right of row 1, past the `PluginLauncher`. Removed the now-unused `showRightSidebar` / `isChatPage` props and `toggleRightSidebar` emit from `SidebarHeader`.
- Changed the `PluginLauncher` pill from `flex` to `inline-flex w-fit` so it shrinks to its buttons. Previously the pill filled the `flex-1` parent, leaving dead space inside the rounded border next to the last button (Files) — which made Files look wider than the others.

## Test plan
- [ ] Chat page: tool icon appears at the far right of row 1, lights blue when the right sidebar is open, hides on plugin pages (wiki/todos/scheduler/skills/roles/files).
- [ ] Existing E2E `e2e/tests/right-sidebar-toggle.spec.ts` still passes (selector is `getByTitle("Tool call history")`, unchanged).
- [ ] PluginLauncher buttons are uniformly sized; no extra empty space after Files.
- [ ] Compact mode (icon-only) still triggers on narrow widths (ResizeObserver still watches the `flex-1` parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized right-sidebar toggle control to render directly in the app interface, now visible only during chat sessions
  * Simplified sidebar header by removing the tool call history control
  * Refined plugin launcher layout for improved content alignment and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->