### PR TITLE
feat(role): user-owned selector + session-role header

### DIFF
--- a/e2e/tests/internal-link-navigation.spec.ts
+++ b/e2e/tests/internal-link-navigation.spec.ts
@@ -95,7 +95,7 @@ test.describe("internal link navigation", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     // The sidebar should show the text-response preview card.
-    const previewCard = page.getByTestId("tool-results-scroll").locator("> div").nth(1);
+    const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);
     await expect(previewCard).toBeVisible();
 
     // Click the preview card (which contains markdown-rendered <a> tags).
@@ -110,7 +110,7 @@ test.describe("internal link navigation", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     // Select the text-response result to show it in the canvas.
-    const previewCard = page.getByTestId("tool-results-scroll").locator("> div").nth(1);
+    const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);
     await previewCard.click();
 
     // Find the wiki page link in the rendered markdown content.
@@ -129,7 +129,7 @@ test.describe("internal link navigation", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     // Select the text-response result.
-    const previewCard = page.getByTestId("tool-results-scroll").locator("> div").nth(1);
+    const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);
     await previewCard.click();
 
     // Find the config file link.

--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -107,33 +107,27 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     expect(stored).toBe("single");
   });
 
-  test("Cmd/Ctrl+1 re-syncs the role selector to the resumed session's role (#665 follow-up)", async ({ page }) => {
-    // Regression: resumeOrCreateChatSession() used to call
-    // navigateToSession() directly on the cached-session branch,
-    // bypassing currentRoleId sync. The selector would stay on
-    // whichever role the user picked on /files / /wiki / etc.
+  test("Cmd/Ctrl+1 keeps the user's role selector pick when resuming a session (#701)", async ({ page }) => {
+    // The role selector is user-owned: only the dropdown mutates it.
+    // Resuming a session from another page must not yank the selector
+    // back to the session's own roleId.
     //
-    // Fixture sessions are created with roleId "general". Change
-    // the selector to "artist" on /files (which is a no-op for
-    // the session since !isChatPage), then Cmd+1 back to /chat
-    // and confirm the selector reverted to "general".
+    // Fixture sessions are created with roleId "general". Change the
+    // selector to "artist" on /files, then Cmd+1 back to /chat and
+    // confirm the selector still shows "Artist" even though the
+    // resumed session is tagged "general".
     await page.goto("/chat");
-    // Wait for /chat → /chat/<id> redirect to settle — resumeOrCreate
-    // reads the top-of-list session on Cmd+1, so we need the initial
-    // session list loaded.
     await page.waitForURL(/\/chat\//);
 
     await page.goto("/files");
     await expect(page).toHaveURL(/\/files/);
 
-    // Flip role to Artist via the selector.
     await page.getByTestId("role-selector-btn").click();
     await page.getByTestId("role-option-artist").click();
     await expect(page.getByTestId("role-selector-btn")).toContainText("Artist");
 
-    // Cmd+1 → back to /chat; resumed session's role is "general".
     await pressShortcut(page, "1");
     await expect(page).toHaveURL(/\/chat\//);
-    await expect(page.getByTestId("role-selector-btn")).toContainText("General");
+    await expect(page.getByTestId("role-selector-btn")).toContainText("Artist");
   });
 });

--- a/plans/feat-role-user-only-mutation.md
+++ b/plans/feat-role-user-only-mutation.md
@@ -1,0 +1,141 @@
+# Plan: `currentRoleId` changes only via user dropdown action
+
+## Goal
+
+Make the role dropdown fully user-owned. The only code that writes
+`currentRoleId.value` should be the `update:currentRoleId` emit from
+`RoleSelector.vue` (i.e. v-model in `App.vue:31`). Every other mutation
+site is removed.
+
+## Motivation
+
+Today the selector doubles as both a UI control and a reflection of the
+active session's role. That means the dropdown can change without the
+user touching it (session tab click, agent `switchRole`, URL
+`?role=`, session restore on mount). The goal of this change is a
+clearer mental model: the selector shows *what the user chose*, not
+*what the current session happens to be using*.
+
+## Scope
+
+Only the `currentRoleId` ref in `src/composables/useRoles.ts` is in
+scope. **Session-level** `session.roleId` is out of scope — sessions
+still own their own role and nothing about agent runs, SSE payloads,
+or session records changes.
+
+## Current mutation sites (from audit)
+
+| # | Location | Trigger | Decision |
+|---|---|---|---|
+| 1 | `useRoles.ts:19` — `ref(ROLES[0].id)` | Module init | **Keep** (initial default) |
+| 2 | `App.vue:31` v-model emit | User picks from dropdown | **Keep** (the only sanctioned path) |
+| 3 | `App.vue:326` watch `route.query.role` | URL `?role=` on nav | **Remove** |
+| 4 | `App.vue:560` in `createNewSession` | Every new session | **Remove** |
+| 5 | `App.vue:621` in `activateSession` | Tab click / session restore | **Remove** |
+| 6 | `App.vue:690` `setCurrentRoleId` | Agent `switchRole` SSE event | **Remove** |
+| 7 | `App.vue:849` in `startNewChat` | Plugin override restore | **Remove** (becomes unnecessary once #4 is gone) |
+| 8 | `App.vue:886` in `onMounted` | URL `?role=` on boot | **Remove** |
+
+## User-visible consequences (decide before coding)
+
+These are the behavior changes the user will actually see. Each one is
+a deliberate tradeoff of this refactor, not a bug to fix afterwards.
+
+1. **Session tab click no longer syncs the dropdown.** If the user is
+   viewing a "General" session and clicks a tab whose session was
+   created under "Wiki", the dropdown keeps showing "General" even
+   though the loaded session is a Wiki session. The transcript and
+   tool list shown in the sidebar derive from `currentRole`, so they
+   also stay on General. Sessions remain internally tagged with their
+   own `session.roleId`, but the UI no longer surfaces it.
+
+2. **Agent-initiated role switch no longer updates the selector.** The
+   `switchRole` SSE event is currently the agent saying "the user's
+   request is better handled by role X, switch." After this change
+   the agent can no longer influence the dropdown. *(See "Open
+   questions" for whether the event itself should be removed server-
+   side or just ignored client-side.)*
+
+3. **URL `?role=` becomes purely informational.** A link like
+   `/chat?role=wiki` will no longer preselect Wiki on load. The query
+   param can still be kept on outgoing URLs (via `buildRoleQuery`),
+   but inbound sync is gone.
+
+4. **`onMounted` URL sync is removed.** Hard-loading a URL with
+   `?role=wiki` lands the user on their last-used role, not Wiki.
+
+5. **Plugin `startNewChat(msg, roleId)` override.** Currently this
+   forces a one-shot role for the new session and then restores the
+   previous selector role. Under the new rules the selector never
+   moved in the first place, so the restore at `App.vue:849`
+   disappears. The new session still records the override on
+   `session.roleId`.
+
+## Required code changes
+
+### 1. `src/App.vue`
+
+- **Delete** the watcher at lines 317–328 (`watch(() => route.query.role, …)`).
+- **`createNewSession` (L554–565)**: remove line 560 (`currentRoleId.value = rId;`). The function still takes an optional `roleId` arg and tags the new session with it; it just stops mutating the global ref.
+- **`activateSession` (L615–626)**: remove line 621. `roleId` param is now unused — remove from the signature and from both call sites (`resumeOrCreateChatSession` L603, `loadSession` L646 and L662). Update the comment at L618–620 to reflect the new contract.
+- **`buildAgentEventContext` (L683–)**: remove `setCurrentRoleId` from the returned context object (L689–691).
+- **`startNewChat` (L833–852)**: drop the `previousRoleId` bookkeeping (L839, L848–850). The function reduces to `createNewSession(roleId)` + `sendMessage(message)`.
+- **`onMounted` (L871–915)**: remove the URL-role sync block at L883–887.
+
+### 2. `src/utils/agent/eventDispatch.ts`
+
+- **`AgentEventContext`**: remove the `setCurrentRoleId` and `onRoleChange` fields (L12–13).
+- **`EVENT_TYPES.switchRole` handler (L35–40)**: either delete the case entirely, or keep it as a no-op with a comment. Preferred: delete the case and, in a follow-up pass (see Open Questions), stop the server from emitting the event.
+- Update `AgentEventContext` callers anywhere else (grep for `setCurrentRoleId`).
+
+### 3. No changes to
+
+- `src/composables/useRoles.ts` — `currentRoleId` itself stays; only its writers change.
+- `src/components/RoleSelector.vue` — the sanctioned writer.
+- `session.roleId` and any server code — out of scope.
+- `buildRoleQuery()` at App.vue:270 — can still emit `?role=` on outgoing URLs. Nothing reads it back in, which is fine.
+
+## Open questions (resolve before implementing)
+
+1. **`EVENT_TYPES.switchRole`**: if the client ignores it, does the
+   server need to stop emitting it? Keeping it as dead weight is
+   cheap; removing it is cleaner. Recommend: client ignores in this
+   PR, file a follow-up issue to drop the event.
+2. **Should the new session's role still be the dropdown's role?**
+   Yes — `createNewSession()` without arg still reads
+   `currentRoleId.value` at L557 and stamps it onto the new session.
+   Only the *reverse* direction (session → dropdown) is severed.
+3. **`rolesUpdated` event** already does not touch `currentRoleId` —
+   no change needed.
+4. **`?role=` on outbound URLs**: keep or strip? Keeping it is
+   harmless (and lets URLs still carry the user's intent for
+   bookmarking/sharing, even if we no longer honour them on load).
+   Recommend: keep as-is.
+
+## Test plan
+
+- **Unit**: existing tests in `test/` that exercise `eventDispatch`
+  need `AgentEventContext` updated (remove `setCurrentRoleId`,
+  `onRoleChange` from mocks).
+- **E2E (Playwright)**:
+  - Pick role → send message → verify dropdown stays on picked role.
+  - Pick role A → agent emits `switchRole` B → dropdown still A.
+  - Open session X (role A), click tab for session Y (role B) →
+    dropdown still A; session Y transcript still renders correctly
+    (session Y's own `roleId` drives the agent on its next run, not
+    the dropdown).
+  - Hard-load `/chat?role=wiki` with last-used role General →
+    dropdown shows General.
+  - `+` while on Wiki role → new session tagged `wiki`. Pick General
+    from dropdown on `/chat` → `onRoleChange` creates a new General
+    session (unchanged behaviour).
+- **Manual**: exercise the plugin `startNewChat(msg, roleId)` path
+  (wiki Lint action, if still present) and confirm the new session
+  gets the override `roleId` while the dropdown does not flicker.
+- Run `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`.
+
+## Rollout
+
+Single PR. No feature flag — the behaviour change is small enough to
+review in one diff, and splitting would leave the intermediate state
+inconsistent (half of the paths honouring the session, half not).

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,6 +74,8 @@
           :is-running="isRunning"
           :status-message="statusMessage"
           :pending-calls="pendingCalls"
+          :session-role-name="sessionRoleName"
+          :session-role-icon="sessionRoleIcon"
           @select="onSidebarItemClick"
           @activate="activePane = 'sidebar'"
         />
@@ -122,6 +124,8 @@
             :selected-result-uuid="selectedResultUuid"
             :result-timestamps="activeSession?.resultTimestamps ?? new Map()"
             :send-text-message="sendMessage"
+            :session-role-name="sessionRoleName"
+            :session-role-icon="sessionRoleIcon"
             @select="(uuid) => (selectedResultUuid = uuid)"
             @update-result="handleUpdateResult"
           />
@@ -209,6 +213,7 @@ import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import { applyAgentEvent, type AgentEventContext } from "./utils/agent/eventDispatch";
 import { pushErrorMessage, beginUserTurn, updateResult } from "./utils/session/sessionHelpers";
 import { maybeSeedRoleDefault } from "./utils/session/seedRoleDefault";
+import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
 import { resolveNotificationTarget } from "./utils/notification/dispatch";
@@ -336,6 +341,20 @@ const { selectedResultUuid } = useSelectedResult({
   activeSession,
   sessionMap,
   currentSessionId,
+});
+
+// Display name and icon of the role the active session was created
+// under, so the message list can show which role is driving the
+// conversation (independent of what the dropdown currently shows).
+const sessionRoleName = computed(() => {
+  const roleId = activeSession.value?.roleId;
+  if (!roleId) return "";
+  return roleName(roles.value, roleId);
+});
+const sessionRoleIcon = computed(() => {
+  const roleId = activeSession.value?.roleId;
+  if (!roleId) return "";
+  return roleIcon(roles.value, roleId);
 });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────

--- a/src/App.vue
+++ b/src/App.vue
@@ -314,19 +314,6 @@ watch(
   },
 );
 
-// External URL changes for ?role= → sync into currentRoleId.
-// This doesn't trigger onRoleChange (which creates a new session) —
-// the user is just navigating back/forward between sessions that
-// were already associated with a role.
-watch(
-  () => route.query.role,
-  (newRole) => {
-    if (typeof newRole !== "string" || newRole === currentRoleId.value) return;
-    const roleExists = roles.value.some((role) => role.id === newRole);
-    if (roleExists) currentRoleId.value = newRole;
-  },
-);
-
 // --- Global state ---
 const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
 
@@ -557,7 +544,6 @@ function createNewSession(roleId?: string): ActiveSession {
   const rId = roleId ?? currentRoleId.value;
   const session = createEmptySession(uuidv4(), rId);
   sessionMap.set(session.id, session);
-  currentRoleId.value = rId;
   navigateToSession(session.id, replace);
   suggestionsPanelRef.value?.collapse();
   nextTick(() => focusChatInput());
@@ -569,9 +555,7 @@ function onRoleChange() {
   // the role that future new-chat actions should use — don't yank
   // them onto /chat by creating a session here. currentRoleId is
   // already updated by RoleSelector's v-model, so future "+" clicks
-  // or composer sends will pick it up. Agent-triggered role switches
-  // (EVENT_TYPES.switchRole) always fire during an active run on
-  // /chat, so the guard doesn't affect them.
+  // or composer sends will pick it up.
   if (!isChatPage.value) return;
   const session = createNewSession(currentRoleId.value);
   maybeSeedRoleDefault(session);
@@ -594,13 +578,7 @@ async function resumeOrCreateChatSession(): Promise<void> {
     return;
   }
   if (sessionMap.has(topId)) {
-    // Already in memory — activate so the role selector re-syncs to
-    // the session's role. Going through navigateToSession alone would
-    // push `/chat/:topId` without touching `currentRoleId`, leaving
-    // the selector stuck on whatever role the user picked on the
-    // page they're coming from.
-    const live = sessionMap.get(topId)!;
-    activateSession(topId, live.roleId, false);
+    activateSession(topId, false);
     return;
   }
   await loadSession(topId);
@@ -612,13 +590,9 @@ async function resumeOrCreateChatSession(): Promise<void> {
   }
 }
 
-function activateSession(sessionId: string, roleId: string, replace: boolean): void {
+function activateSession(sessionId: string, replace: boolean): void {
   const reactiveSession = sessionMap.get(sessionId);
   if (reactiveSession) ensureSessionSubscription(reactiveSession);
-  // Set role before navigating: buildRoleQuery() reads currentRoleId to
-  // build ?role=, and the route.query.role watcher would otherwise fire
-  // after navigation and revert currentRoleId to the previous session's role.
-  currentRoleId.value = roleId;
   navigateToSession(sessionId, replace);
   // Closing the history popup is no longer explicit — navigating to
   // /chat/:id via navigateToSession changes the route, and the
@@ -643,7 +617,7 @@ async function loadSession(sessionId: string) {
 
   const live = sessionMap.get(sessionId);
   if (live) {
-    activateSession(sessionId, live.roleId, replaced);
+    activateSession(sessionId, replaced);
     return;
   }
 
@@ -659,7 +633,7 @@ async function loadSession(sessionId: string) {
     nowIso: new Date().toISOString(),
   });
   sessionMap.set(sessionId, newSession);
-  activateSession(sessionId, newSession.roleId, replaced);
+  activateSession(sessionId, replaced);
 }
 
 // Re-fetch the transcript from the server and patch any entries the
@@ -686,10 +660,6 @@ function buildAgentEventContext(session: ActiveSession): AgentEventContext {
     get session() {
       return sessionMap.get(sessionId) ?? session;
     },
-    setCurrentRoleId: (roleId) => {
-      currentRoleId.value = roleId;
-    },
-    onRoleChange,
     refreshRoles,
     scrollSidebarToBottom: () => rightSidebarRef.value?.scrollToBottom(),
     onGenerationsDrained: () => {
@@ -836,18 +806,7 @@ function startNewChat(message: string, roleId?: string): void {
   // in the new session rather than whatever was previously active.
   // Cross-route push behaviour (so browser Back returns to /wiki)
   // is now handled inside createNewSession via the isChatPage check.
-  const previousRoleId = currentRoleId.value;
-  createNewSession(roleId ?? previousRoleId);
-  // `createNewSession` mutates `currentRoleId.value` to the role it
-  // just used. When the caller passed an explicit `roleId` override
-  // (e.g. wiki Lint spawns a General-role chat regardless of the
-  // role the user is currently viewing the wiki under), restore the
-  // previously-selected role afterwards so future `+` clicks and
-  // role-aware UI don't inherit this one-shot override. The newly-
-  // created session keeps the overridden role on its own record.
-  if (roleId && roleId !== previousRoleId) {
-    currentRoleId.value = previousRoleId;
-  }
+  createNewSession(roleId);
   void sendMessage(message);
 }
 
@@ -879,12 +838,6 @@ onMounted(async () => {
   // createNewSession() picks a roleId that exists in the merged
   // role list (built-in + custom).
   await refreshRoles();
-
-  // If the URL specifies a role, apply it before session creation.
-  const urlRole = typeof route.query.role === "string" ? route.query.role : null;
-  if (urlRole && roles.value.some((role) => role.id === urlRole)) {
-    currentRoleId.value = urlRole;
-  }
 
   // Session bootstrap only applies on /chat. On /files, /todos, /wiki,
   // etc. we must not create or load a chat session — doing so would

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -1,5 +1,9 @@
 <template>
   <div ref="containerRef" class="h-full overflow-y-auto bg-gray-50 p-4 space-y-3" data-testid="stack-scroll">
+    <div v-if="sessionRoleName" class="flex items-center gap-1 text-xs text-gray-400" data-testid="stack-role-header">
+      <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
+      <span>{{ sessionRoleName }}</span>
+    </div>
     <div v-if="toolResults.length === 0" class="flex items-center justify-center h-full text-gray-400 text-sm">{{ t("common.noResultsYet") }}</div>
     <div
       v-for="result in toolResults"
@@ -113,6 +117,8 @@ const props = defineProps<{
   selectedResultUuid: string | null;
   resultTimestamps: Map<string, number>;
   sendTextMessage?: (text: string) => void;
+  sessionRoleName?: string;
+  sessionRoleIcon?: string;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -6,6 +6,10 @@
     data-testid="tool-results-scroll"
     @mousedown="emit('activate')"
   >
+    <div v-if="sessionRoleName" class="flex items-center gap-1 text-xs text-gray-400" data-testid="sidebar-role-header">
+      <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
+      <span>{{ sessionRoleName }}</span>
+    </div>
     <div
       v-for="result in results"
       :key="result.uuid"
@@ -69,6 +73,8 @@ defineProps<{
   isRunning: boolean;
   statusMessage: string;
   pendingCalls: PendingCall[];
+  sessionRoleName?: string;
+  sessionRoleIcon?: string;
 }>();
 
 const emit = defineEmits<{

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -9,8 +9,6 @@ import { pushErrorMessage, applyTextEvent, applyToolResultToSession } from "../s
 
 export interface AgentEventContext {
   session: ActiveSession;
-  setCurrentRoleId: (roleId: string) => void;
-  onRoleChange: () => void;
   refreshRoles: () => Promise<void>;
   scrollSidebarToBottom: () => void;
   onGenerationsDrained: () => void;
@@ -33,10 +31,9 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       session.statusMessage = event.message;
       return;
     case EVENT_TYPES.switchRole:
-      setTimeout(() => {
-        ctx.setCurrentRoleId(event.roleId);
-        ctx.onRoleChange();
-      }, 0);
+      // The role selector is now user-owned; agent-initiated role
+      // switches no longer mutate it. Session.roleId still comes
+      // from the server on session load.
       return;
     case EVENT_TYPES.rolesUpdated:
       await ctx.refreshRoles();


### PR DESCRIPTION
## Summary

- Make `currentRoleId` writable only via the `RoleSelector` dropdown. Six out-of-band mutation paths are removed: the `route.query.role` watcher, `createNewSession`, `activateSession` (param dropped), the agent `switchRole` SSE handler, `startNewChat` override bookkeeping, and the `onMounted` URL sync. `EVENT_TYPES.switchRole` becomes a client no-op (server still emits; removal is a follow-up).
- Show the active session's role (Material icon + name) as a small grey row at the top of both the stack view canvas and the left sidebar's tool-results list, so the user can still see which role is driving the current conversation when the dropdown no longer reflects it.
- Full rationale and user-visible consequences: `plans/feat-role-user-only-mutation.md`.

## Test plan

- [ ] Pick role → send message → dropdown stays on picked role.
- [ ] Pick role A → agent emits `switchRole` B → dropdown still A; session record unaffected.
- [ ] Open session X (role A), click tab for session Y (role B) → dropdown still A; session Y's transcript renders with its own role driving subsequent agent runs. Header row above the list shows role Y on session Y, role A on session X.
- [ ] Hard-load `/chat?role=wiki` with last-used role General → dropdown shows General.
- [ ] `+` while on Wiki role → new session tagged `wiki`.
- [ ] Plugin `startNewChat(msg, roleId)` override (e.g. wiki Lint) → new session tagged with the override role, dropdown does not flicker.
- [ ] Role header icon renders at 12px (matches the `text-xs` label), no border, stack mode + sidebar mode both correct.
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session role name and icon now display in results panels and view headers

* **Behavior Changes**
  * Role selection is now exclusively controlled through the dropdown; automatic role changes from URL parameters or session switches no longer occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->