### PR TITLE
refactor(ui): move layout toggle and tool-call button into role header

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,19 +15,9 @@
         <div class="flex-1 min-w-0">
           <PluginLauncher :active-tool-name="selectedResult?.toolName ?? null" :active-view-mode="currentPage" @navigate="onPluginNavigate" />
         </div>
-        <button
-          v-if="isChatPage"
-          class="text-gray-400 hover:text-gray-700"
-          :class="{ 'text-blue-500': showRightSidebar }"
-          :title="t('sidebarHeader.toolCallHistory')"
-          @click="toggleRightSidebar"
-        >
-          <span class="material-icons">build</span>
-        </button>
       </div>
-      <!-- Row 2: canvas toggle + role selector + session tabs -->
+      <!-- Row 2: role selector + session tabs -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
-        <CanvasViewToggle v-if="isChatPage" :model-value="layoutMode" @update:model-value="setLayoutMode" />
         <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
         <SessionTabBar
           :sessions="tabSessions"
@@ -76,8 +66,12 @@
           :pending-calls="pendingCalls"
           :session-role-name="sessionRoleName"
           :session-role-icon="sessionRoleIcon"
+          :layout-mode="layoutMode"
+          :show-right-sidebar="showRightSidebar"
           @select="onSidebarItemClick"
           @activate="activePane = 'sidebar'"
+          @update:layout-mode="setLayoutMode"
+          @toggle-right-sidebar="toggleRightSidebar"
         />
 
         <!-- Sample queries (expandable pane) -->
@@ -126,8 +120,12 @@
             :send-text-message="sendMessage"
             :session-role-name="sessionRoleName"
             :session-role-icon="sessionRoleIcon"
+            :layout-mode="layoutMode"
+            :show-right-sidebar="showRightSidebar"
             @select="(uuid) => (selectedResultUuid = uuid)"
             @update-result="handleUpdateResult"
+            @update:layout-mode="setLayoutMode"
+            @toggle-right-sidebar="toggleRightSidebar"
           />
           <!-- Distinct pages -->
           <FilesView v-else-if="currentPage === 'files'" :refresh-token="filesRefreshToken" @load-session="handleSessionSelect" />
@@ -190,7 +188,6 @@ import SuggestionsPanel from "./components/SuggestionsPanel.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";
-import CanvasViewToggle from "./components/CanvasViewToggle.vue";
 import PluginLauncher from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -1,30 +1,42 @@
 <template>
-  <div ref="containerRef" class="h-full overflow-y-auto bg-gray-50 p-4 space-y-3" data-testid="stack-scroll">
-    <div v-if="sessionRoleName" class="flex items-center gap-1 text-xs text-gray-400" data-testid="stack-role-header">
+  <div class="h-full flex flex-col bg-gray-50">
+    <div class="shrink-0 flex items-center gap-1 text-xs text-gray-400 px-4 pt-3 pb-2" data-testid="stack-role-header">
       <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
-      <span>{{ sessionRoleName }}</span>
+      <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
+      <div class="ml-auto flex items-center gap-1">
+        <button
+          class="text-gray-400 hover:text-gray-700"
+          :class="{ 'text-blue-500': showRightSidebar }"
+          :title="t('sidebarHeader.toolCallHistory')"
+          @click="emit('toggle-right-sidebar')"
+        >
+          <span class="material-icons text-lg">build</span>
+        </button>
+        <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
+      </div>
     </div>
-    <div v-if="toolResults.length === 0" class="flex items-center justify-center h-full text-gray-400 text-sm">{{ t("common.noResultsYet") }}</div>
-    <div
-      v-for="result in toolResults"
-      :key="result.uuid"
-      :ref="(element) => setItemRef(result.uuid, element as HTMLElement | null)"
-      class="bg-white rounded-lg border transition-colors"
-      :class="result.uuid === selectedResultUuid ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
-    >
-      <button
-        class="w-full flex items-center gap-2 px-3 py-2 border-b border-gray-100 text-left hover:bg-gray-50"
-        :title="result.title || result.toolName"
-        @click="emit('select', result.uuid)"
+    <div ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
+      <div v-if="toolResults.length === 0" class="flex items-center justify-center h-full text-gray-400 text-sm">{{ t("common.noResultsYet") }}</div>
+      <div
+        v-for="result in toolResults"
+        :key="result.uuid"
+        :ref="(element) => setItemRef(result.uuid, element as HTMLElement | null)"
+        class="bg-white rounded-lg border transition-colors"
+        :class="result.uuid === selectedResultUuid ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
       >
-        <span class="material-icons text-sm text-gray-400">{{ iconFor(result.toolName) }}</span>
-        <span class="text-sm font-medium text-gray-800 truncate">{{ result.title || result.toolName }}</span>
-        <span v-if="resultTimestamps.get(result.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
-          formatSmartTime(resultTimestamps.get(result.uuid)!)
-        }}</span>
-        <span class="font-mono text-xs text-gray-400 shrink-0">{{ result.toolName }}</span>
-      </button>
-      <!-- text-response: render the message as Markdown via the
+        <button
+          class="w-full flex items-center gap-2 px-3 py-2 border-b border-gray-100 text-left hover:bg-gray-50"
+          :title="result.title || result.toolName"
+          @click="emit('select', result.uuid)"
+        >
+          <span class="material-icons text-sm text-gray-400">{{ iconFor(result.toolName) }}</span>
+          <span class="text-sm font-medium text-gray-800 truncate">{{ result.title || result.toolName }}</span>
+          <span v-if="resultTimestamps.get(result.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
+            formatSmartTime(resultTimestamps.get(result.uuid)!)
+          }}</span>
+          <span class="font-mono text-xs text-gray-400 shrink-0">{{ result.toolName }}</span>
+        </button>
+        <!-- text-response: render the message as Markdown via the
            underlying plugin View. The .stack-text-response class below
            collapses the plugin's own card chrome (outer p-6, inner
            rounded/border/shadow box, role header) so only the stack
@@ -35,38 +47,39 @@
            "open external links in a new tab" click handler. Attach
            the same handler here via @click.capture so cross-origin
            links in assistant Markdown don't navigate the SPA away. -->
-      <div v-if="isTextResponse(result)" class="stack-text-response" @click.capture="handleExternalLinkClick">
-        <TextResponseOriginalView :selected-result="result" />
-      </div>
-      <!-- Document-like plugins: let the content flow at its natural
+        <div v-if="isTextResponse(result)" class="stack-text-response" @click.capture="handleExternalLinkClick">
+          <TextResponseOriginalView :selected-result="result" />
+        </div>
+        <!-- Document-like plugins: let the content flow at its natural
            height by overriding the plugin's internal h-full / overflow
            / flex-1 via the .stack-natural scoped styles below. For
            plugins that embed iframes (e.g. presentHtml) we also size
            each iframe to its content after load. -->
-      <div
-        v-else-if="isStackNatural(result.toolName)"
-        :ref="(element) => setNaturalWrapperRef(result.uuid, element as HTMLElement | null)"
-        class="stack-natural"
-      >
-        <component
-          :is="getPlugin(result.toolName)?.viewComponent"
-          v-if="getPlugin(result.toolName)?.viewComponent"
-          :selected-result="result"
-          :send-text-message="sendTextMessage"
-          @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
-        />
-      </div>
-      <!-- Other plugins: fixed height wrapper so plugins that rely on
+        <div
+          v-else-if="isStackNatural(result.toolName)"
+          :ref="(element) => setNaturalWrapperRef(result.uuid, element as HTMLElement | null)"
+          class="stack-natural"
+        >
+          <component
+            :is="getPlugin(result.toolName)?.viewComponent"
+            v-if="getPlugin(result.toolName)?.viewComponent"
+            :selected-result="result"
+            :send-text-message="sendTextMessage"
+            @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
+          />
+        </div>
+        <!-- Other plugins: fixed height wrapper so plugins that rely on
            h-full continue to render properly. -->
-      <div v-else :style="{ height: PLUGIN_HEIGHT }">
-        <component
-          :is="getPlugin(result.toolName)?.viewComponent"
-          v-if="getPlugin(result.toolName)?.viewComponent"
-          :selected-result="result"
-          :send-text-message="sendTextMessage"
-          @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
-        />
-        <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(result, null, 2) }}</pre>
+        <div v-else :style="{ height: PLUGIN_HEIGHT }">
+          <component
+            :is="getPlugin(result.toolName)?.viewComponent"
+            v-if="getPlugin(result.toolName)?.viewComponent"
+            :selected-result="result"
+            :send-text-message="sendTextMessage"
+            @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
+          />
+          <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(result, null, 2) }}</pre>
+        </div>
       </div>
     </div>
   </div>
@@ -84,6 +97,8 @@ import { handleExternalLinkClick } from "../utils/dom/externalLink";
 import type { TextResponseData } from "../plugins/textResponse/types";
 import { formatSmartTime } from "../utils/format/date";
 import { isRecord } from "../utils/types";
+import CanvasViewToggle from "./CanvasViewToggle.vue";
+import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 // Most plugin viewComponents use h-full internally, so a defined parent
 // height is required for them to render. text-response and the
@@ -119,11 +134,15 @@ const props = defineProps<{
   sendTextMessage?: (text: string) => void;
   sessionRoleName?: string;
   sessionRoleIcon?: string;
+  layoutMode: LayoutMode;
+  showRightSidebar: boolean;
 }>();
 
 const emit = defineEmits<{
   select: [uuid: string];
   updateResult: [result: ToolResultComplete];
+  "update:layoutMode": [mode: LayoutMode];
+  "toggle-right-sidebar": [];
 }>();
 
 const containerRef = ref<HTMLDivElement | null>(null);

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -1,49 +1,62 @@
 <template>
-  <div
-    ref="root"
-    class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 bg-gray-100 outline-none"
-    tabindex="0"
-    data-testid="tool-results-scroll"
-    @mousedown="emit('activate')"
-  >
-    <div v-if="sessionRoleName" class="flex items-center gap-1 text-xs text-gray-400" data-testid="sidebar-role-header">
+  <div class="flex-1 min-h-0 flex flex-col bg-gray-100">
+    <div class="shrink-0 flex items-center gap-1 text-xs text-gray-400 px-2 pt-2 pb-1" data-testid="sidebar-role-header">
       <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
-      <span>{{ sessionRoleName }}</span>
+      <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
+      <div class="ml-auto flex items-center gap-1">
+        <button
+          class="text-gray-400 hover:text-gray-700"
+          :class="{ 'text-blue-500': showRightSidebar }"
+          :title="t('sidebarHeader.toolCallHistory')"
+          @click="emit('toggle-right-sidebar')"
+        >
+          <span class="material-icons text-lg">build</span>
+        </button>
+        <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
+      </div>
     </div>
     <div
-      v-for="result in results"
-      :key="result.uuid"
-      class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
-      :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
-      @click="emit('select', result.uuid)"
+      ref="root"
+      class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 outline-none"
+      tabindex="0"
+      data-testid="tool-results-scroll"
+      @mousedown="emit('activate')"
     >
-      <span class="absolute top-0 left-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none">
-        {{ sourceLabel(result) }}
-      </span>
-      <span
-        v-if="resultTimestamps.get(result.uuid)"
-        class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
+      <div
+        v-for="result in results"
+        :key="result.uuid"
+        class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
+        :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
+        @click="emit('select', result.uuid)"
       >
-        {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
-      </span>
-      <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
-      <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
-    </div>
-
-    <!-- Thinking indicator -->
-    <div v-if="isRunning" class="px-2 py-1 text-sm">
-      <div class="flex items-center gap-2 text-gray-500">
-        <span class="text-xs">{{ statusMessage }}</span>
-        <span class="flex gap-1">
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 0ms" />
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 150ms" />
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 300ms" />
+        <span class="absolute top-0 left-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none">
+          {{ sourceLabel(result) }}
         </span>
+        <span
+          v-if="resultTimestamps.get(result.uuid)"
+          class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
+        >
+          {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
+        </span>
+        <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
+        <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
       </div>
-      <div v-if="pendingCalls.length > 0" class="mt-1 space-y-0.5">
-        <div v-for="call in pendingCalls" :key="call.toolUseId" class="flex items-center gap-1.5 text-xs text-gray-400">
-          <span class="w-1.5 h-1.5 rounded-full bg-blue-300 shrink-0 animate-pulse" />
-          <span class="font-mono truncate">{{ call.toolName }}</span>
+
+      <!-- Thinking indicator -->
+      <div v-if="isRunning" class="px-2 py-1 text-sm">
+        <div class="flex items-center gap-2 text-gray-500">
+          <span class="text-xs">{{ statusMessage }}</span>
+          <span class="flex gap-1">
+            <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 0ms" />
+            <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 150ms" />
+            <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 300ms" />
+          </span>
+        </div>
+        <div v-if="pendingCalls.length > 0" class="mt-1 space-y-0.5">
+          <div v-for="call in pendingCalls" :key="call.toolUseId" class="flex items-center gap-1.5 text-xs text-gray-400">
+            <span class="w-1.5 h-1.5 rounded-full bg-blue-300 shrink-0 animate-pulse" />
+            <span class="font-mono truncate">{{ call.toolName }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -52,9 +65,14 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
+import CanvasViewToggle from "./CanvasViewToggle.vue";
+import type { LayoutMode } from "../utils/canvas/layoutMode";
+
+const { t } = useI18n();
 
 function sourceLabel(result: ToolResultComplete): string {
   if (result.toolName === "text-response") return result.title ?? "Assistant";
@@ -75,11 +93,15 @@ defineProps<{
   pendingCalls: PendingCall[];
   sessionRoleName?: string;
   sessionRoleIcon?: string;
+  layoutMode: LayoutMode;
+  showRightSidebar: boolean;
 }>();
 
 const emit = defineEmits<{
   select: [uuid: string];
   activate: [];
+  "update:layoutMode": [mode: LayoutMode];
+  "toggle-right-sidebar": [];
 }>();
 
 const root = ref<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Summary
- Relocate the stack/single `CanvasViewToggle` and the tool-call-history wrench from the global top bar into the role-header area of each chat panel (`StackView` and `ToolResultsPanel`).
- Restructure both panels so the role header sits in a non-scrollable strip above the scrollable content — the toggle and wrench stay visible regardless of scroll position.
- `App.vue` passes `layoutMode` / `showRightSidebar` down as props and reacts to `update:layoutMode` / `toggle-right-sidebar` events; top-bar row 1 keeps only the title + plugin launcher, row 2 keeps only the role selector + session tabs.

## Test plan
- [ ] Run `yarn dev` and confirm the wrench + layout toggle appear at the right end of the role-header strip in **single** mode.
- [ ] Toggle to **stack** mode and confirm the same two buttons appear at the right end of `StackView`'s role header.
- [ ] Scroll the chat content in both modes and verify the header (role icon/name + both buttons) stays pinned.
- [ ] Click the wrench: the right sidebar opens/closes and the button's blue-active state matches `showRightSidebar`.
- [ ] Click the toggle: layout flips between single/stack and the button reflects the new mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Enhancements**
  * Integrated layout view toggle and sidebar controls directly into tool panels for improved accessibility
  * Restructured panel layouts with fixed headers and scrollable content areas for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->