### PR TITLE
chore: daily refactor sweep 2026-04-24

### DIFF
--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -54,7 +54,14 @@ export function allocateRandomPort() {
 // `{ ok: false, attempts, elapsedMs, lastError }` after timeout.
 // The injectable fetch is what makes this unit-testable without
 // actually standing up an HTTP server.
-export async function pollHttp({ url, timeoutMs = DEFAULT_BOOT_TIMEOUT_MS, intervalMs = DEFAULT_POLL_INTERVAL_MS, fetchImpl = globalThis.fetch, now = Date.now, sleep = defaultSleep } = {}) {
+export async function pollHttp({
+  url,
+  timeoutMs = DEFAULT_BOOT_TIMEOUT_MS,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  fetchImpl = globalThis.fetch,
+  now = Date.now,
+  sleep = defaultSleep,
+} = {}) {
   const startedAt = now();
   let attempts = 0;
   let lastError = null;
@@ -97,24 +104,39 @@ export function buildInstallerPackageJson({ tarballName } = {}) {
 
 // Spawn a child process, collect stdout/stderr as strings, enforce a
 // timeout. Returns `{ code, signal, stdout, stderr, timedOut }`.
+//
+// On timeout we send SIGTERM, then escalate to SIGKILL if the child
+// still hasn't exited after `KILL_GRACE_MS` — npm subprocesses under
+// load can ignore SIGTERM long enough to hang a CI job past its
+// overall budget, so the hard kill is a safety net.
 async function runCommand(cmd, args, { cwd, timeoutMs, env } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, { cwd, env: env ?? process.env, stdio: ["ignore", "pipe", "pipe"] });
     const stdout = [];
     const stderr = [];
     let timedOut = false;
+    let sigkillTimer = null;
     const killTimer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
+      sigkillTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+      }, KILL_GRACE_MS);
     }, timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS);
+    const clearKillTimers = () => {
+      clearTimeout(killTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+    };
     child.stdout?.on("data", (chunk) => stdout.push(chunk));
     child.stderr?.on("data", (chunk) => stderr.push(chunk));
     child.once("error", (err) => {
-      clearTimeout(killTimer);
+      clearKillTimers();
       reject(err);
     });
     child.once("close", (code, signal) => {
-      clearTimeout(killTimer);
+      clearKillTimers();
       resolve({
         code,
         signal,
@@ -162,6 +184,12 @@ async function installTarball({ workDir, tarballAbsolutePath, installTimeoutMs }
 // `logFile`, wait for the poll helper to get a 200. Returns the
 // probe outcome and a reference to the child so the caller can
 // clean it up — even on success — to free the port.
+//
+// Spawn failures (ENOENT on the bin, EACCES, etc.) race the HTTP
+// probe via `Promise.race` — otherwise `pollHttp` would eat the
+// full boot timeout waiting for a child that never started, and
+// the smoke would look like a boot-too-slow failure instead of
+// the actual install/permission bug.
 async function bootAndProbe({ workDir, port, bootTimeoutMs, logFile }) {
   const bin = path.join(workDir, "node_modules", ".bin", "mulmoclaude");
   const child = spawn(bin, ["--no-open", "--port", String(port)], {
@@ -180,10 +208,23 @@ async function bootAndProbe({ workDir, port, bootTimeoutMs, logFile }) {
   };
   await attachSink(child.stdout, "out");
   await attachSink(child.stderr, "err");
-  const probe = await pollHttp({
-    url: `http://127.0.0.1:${port}/`,
-    timeoutMs: bootTimeoutMs ?? DEFAULT_BOOT_TIMEOUT_MS,
+  const spawnErrorPromise = new Promise((resolve) => {
+    child.once("error", (err) => {
+      resolve({
+        ok: false,
+        attempts: 0,
+        elapsedMs: 0,
+        lastError: `launcher spawn failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    });
   });
+  const probe = await Promise.race([
+    pollHttp({
+      url: `http://127.0.0.1:${port}/`,
+      timeoutMs: bootTimeoutMs ?? DEFAULT_BOOT_TIMEOUT_MS,
+    }),
+    spawnErrorPromise,
+  ]);
   return { probe, child };
 }
 
@@ -202,7 +243,15 @@ async function killGracefully(child) {
 // caller passes a malformed `root`. Cleanup is best-effort: the
 // tarball, the work dir, and the process are all tidied up in a
 // finally block before returning.
+//
+// Cleanup policy: on **success** we remove the tarball and, if we
+// allocated the work dir ourselves, remove it too — keeping the
+// workspace tidy across repeated local runs. On **failure** we
+// leave both in place so investigators can inspect the installed
+// tree and the packed artifact. A caller-provided `workDir` is
+// always left alone (CI typically uploads it as an artifact).
 export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, bootTimeoutMs, packTimeoutMs, installTimeoutMs, port } = {}) {
+  const weAllocatedWorkDir = !workDir;
   const runDir = workDir ?? (await mkdtemp(path.join(os.tmpdir(), "mc-smoke-")));
   const resolvedLog = logFile ?? path.join(runDir, "launcher.log");
   await mkdir(runDir, { recursive: true });
@@ -211,12 +260,14 @@ export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, 
 
   let tarballPath = null;
   let child = null;
+  let succeeded = false;
   try {
     tarballPath = await packTarball({ root, packTimeoutMs });
     await installTarball({ workDir: runDir, tarballAbsolutePath: tarballPath, installTimeoutMs });
     const resolvedPort = port ?? (await allocateRandomPort());
     const booted = await bootAndProbe({ workDir: runDir, port: resolvedPort, bootTimeoutMs, logFile: resolvedLog });
     child = booted.child;
+    succeeded = booted.probe.ok;
     return {
       ok: booted.probe.ok,
       port: resolvedPort,
@@ -240,10 +291,14 @@ export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, 
     };
   } finally {
     if (child) await killGracefully(child);
-    // Tarball cleanup is conservative — leaving it around after a
-    // failure is actually useful for post-mortem (inspect contents,
-    // reproduce install locally). Only nuke on success + when we
-    // created the work dir ourselves.
+    if (succeeded) {
+      if (tarballPath) {
+        await rm(tarballPath, { force: true }).catch(() => {});
+      }
+      if (weAllocatedWorkDir) {
+        await rm(runDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }
   }
 }
 

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -5,12 +5,15 @@
       <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
       <div class="ml-auto flex items-center gap-1">
         <button
+          type="button"
           class="text-gray-400 hover:text-gray-700"
           :class="{ 'text-blue-500': showRightSidebar }"
           :title="t('sidebarHeader.toolCallHistory')"
+          :aria-label="t('sidebarHeader.toolCallHistory')"
+          :aria-pressed="showRightSidebar"
           @click="emit('toggle-right-sidebar')"
         >
-          <span class="material-icons text-lg">build</span>
+          <span class="material-icons text-lg" aria-hidden="true">build</span>
         </button>
         <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
       </div>

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -5,12 +5,15 @@
       <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
       <div class="ml-auto flex items-center gap-1">
         <button
+          type="button"
           class="text-gray-400 hover:text-gray-700"
           :class="{ 'text-blue-500': showRightSidebar }"
           :title="t('sidebarHeader.toolCallHistory')"
+          :aria-label="t('sidebarHeader.toolCallHistory')"
+          :aria-pressed="showRightSidebar"
           @click="emit('toggle-right-sidebar')"
         >
-          <span class="material-icons text-lg">build</span>
+          <span class="material-icons text-lg" aria-hidden="true">build</span>
         </button>
         <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
       </div>


### PR DESCRIPTION
## Summary

First run of the new `/daily-refactoring` skill. Sweep covered PRs merged on 2026-04-23; this PR ships only the items that were **actually still open** after cross-checking against follow-up PRs.

**Fixes (3 bot reviews on scripts + 2 bot reviews on a11y):**
- `scripts/mulmoclaude/tarball.mjs` — SIGKILL escalation in `runCommand`, `error`-handler race in `bootAndProbe`, tmp cleanup on success in `runTarballSmoke`
- `src/components/StackView.vue` + `ToolResultsPanel.vue` — wrench-icon toggle gains `type="button"`, `aria-label`, `aria-pressed`; icon marked `aria-hidden`

**Already fixed, verified during sweep (no action):**
- #669 `deps.mjs:119` catch-all — narrowed to ENOENT only
- #671 Wiki tag filter "All" chip — present at View.vue line 77
- #671 helps/wiki.md non-ASCII examples — false positive; `HASHTAG_PATTERN` uses `\p{L}\p{N}` (Unicode)
- #676 `SourcesManager.vue` hardcoded English — all errors already go through `errorKey` → `t()`
- #676 `sources-page.spec.ts` misleading comment — rewritten to match handler
- #679 session-tab-bar E2E tautologies — fixed in #690
- #665 `<button><h1>` + role sync — fixed in #687

**Deferred, tracked separately in follow-up issues:**
- #665 P2 codex (currentRoleId semantics) — deliberate opposite direction taken in #701; needs a short design-record doc
- #676 i18n hardcoded-English audit — worth a repo-wide scan to catch other components with the same pattern

## Items to Confirm / Review

- **tarball.mjs cleanup semantics** — on success we remove the tarball and the auto-allocated tmp work dir. Caller-provided `workDir` is preserved. Failures leave everything for post-mortem. Is that the cleanup shape you want, or would you rather keep tarballs around even on success?
- **Wrench button labels** reuse `sidebarHeader.toolCallHistory` ("Tool call history") across all 8 locales. If you'd rather distinguish the stack/single buttons from the header variant, say so and I'll add a dedicated key set.

## User Prompt

> 昨日のPRを振り返ってコメントで対応してないものがないか確認。またPRでDRYとか定数とか、server/utils以下の関数（ネットワーク、ファイルシステム、文字列など）を使ってないものがないか確認。daily refactringとしてスキル化して。
>
> 1はtmpを掃除として全部対応する / 2全部対応 / 3対応する。他にも同様の問題がありそうなので、チケット化して調べる / 4 5 はもっと具体的な例を含めて日本語でチケット化して。ユースケース書いてね。

Items 4 & 5 turned out to already be addressed in the codebase (verified above). Item 3's scan-for-others follow-up is filed as a separate issue.

## Test plan

- [x] `yarn typecheck:vue` — clean
- [x] `yarn lint` — no new warnings
- [x] `npx tsx --test test/scripts/mulmoclaude/test_tarball.ts` — 11/11 pass
- [ ] Manually trigger a tarball smoke failure (bad bin path) → confirm `lastError` is `launcher spawn failed: ENOENT ...` rather than the 45s timeout message
- [ ] Screen reader check on `StackView` / `ToolResultsPanel` wrench button → announces "Tool call history, pressed/not pressed"

## Related
- Skill: `.claude/skills/daily-refactoring/SKILL.md` (added in an earlier commit)
- Dataset: `plans/pr-review-analysis/raw/` (untracked — untracked deliberately, ~470 review records for re-analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)