### PR TITLE
refactor(server): centralise err-instanceof-Error fallback on errorMe…

### DIFF
--- a/server/api/routes/chat-index.ts
+++ b/server/api/routes/chat-index.ts
@@ -13,6 +13,7 @@ import { Router, Request, Response } from "express";
 import { backfillAllSessions } from "../../workspace/chat-index/index.js";
 import { log } from "../../system/logger/index.js";
 import { serverError } from "../../utils/httpError.js";
+import { errorMessage } from "../../utils/errors.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 
 interface RebuildResponse {
@@ -39,7 +40,7 @@ router.post(API_ROUTES.chatIndex.rebuild, async (_req: Request, res: Response<Re
     res.json(result);
   } catch (err) {
     log.warn("chat-index", "rebuild failed", { error: String(err) });
-    serverError(res, err instanceof Error ? err.message : "unknown error");
+    serverError(res, errorMessage(err, "unknown error"));
   }
 });
 

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -12,6 +12,7 @@ import {
   type McpServerEntry,
 } from "../../system/config.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
+import { errorMessage } from "../../utils/errors.js";
 import { isRecord } from "../../utils/types.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { loadCustomDirs, saveCustomDirs, ensureCustomDirs, validateCustomDirs, type CustomDirEntry } from "../../workspace/custom-dirs.js";
@@ -53,7 +54,7 @@ function parseMcpPayloadOrFail(res: ConfigRes, servers: McpServerEntry[]): McpCo
   try {
     return fromMcpEntries(servers);
   } catch (err) {
-    badRequest(res, err instanceof Error ? err.message : "invalid mcp entries");
+    badRequest(res, errorMessage(err, "invalid mcp entries"));
     return null;
   }
 }
@@ -66,7 +67,7 @@ function runSaveOrFail(res: ConfigRes, save: () => void, fallback: string): bool
     save();
     return true;
   } catch (err) {
-    serverError(res, err instanceof Error ? err.message : fallback);
+    serverError(res, errorMessage(err, fallback));
     return false;
   }
 }
@@ -173,7 +174,7 @@ router.put(
       ensureCustomDirs(result.entries);
       res.json({ dirs: result.entries });
     } catch (err) {
-      serverError(res, err instanceof Error ? err.message : "save failed");
+      serverError(res, errorMessage(err, "save failed"));
     }
   },
 );
@@ -201,7 +202,7 @@ router.put(
       saveReferenceDirs(result.entries);
       res.json({ dirs: result.entries });
     } catch (err) {
-      serverError(res, err instanceof Error ? err.message : "save failed");
+      serverError(res, errorMessage(err, "save failed"));
     }
   },
 );
@@ -250,7 +251,7 @@ router.put(
 
       res.json({ overrides: loadSchedulerOverrides() });
     } catch (err) {
-      serverError(res, err instanceof Error ? err.message : "save failed");
+      serverError(res, errorMessage(err, "save failed"));
     }
   },
 );

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -486,7 +486,7 @@ router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown,
     const tree = await buildTreeAsync(workspaceReal, "");
     res.json(tree);
   } catch (err) {
-    res.status(500).json({ error: `Failed to read workspace: ${errorMessage(err)}` });
+    serverError(res, `Failed to read workspace: ${errorMessage(err)}`);
   }
 });
 
@@ -671,7 +671,7 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
   try {
     content = readFileSync(absPath, "utf-8");
   } catch (err) {
-    res.status(500).json({ error: `Failed to read file: ${errorMessage(err)}` });
+    serverError(res, `Failed to read file: ${errorMessage(err)}`);
     return;
   }
   res.json({ kind: "text", ...meta, content });

--- a/server/api/routes/sources.ts
+++ b/server/api/routes/sources.ts
@@ -33,6 +33,7 @@ import {
 } from "../../workspace/sources/types.js";
 import { normalizeCategories, type CategorySlug } from "../../workspace/sources/taxonomy.js";
 import { badRequest, conflict, sendError, serverError } from "../../utils/httpError.js";
+import { errorMessage } from "../../utils/errors.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { isNonEmptyString, isRecord } from "../../utils/types.js";
 
@@ -60,7 +61,7 @@ router.get(API_ROUTES.sources.list, async (_req: Request, res: Response<ListSour
     res.json({ sources });
   } catch (err) {
     log.warn("sources", "list failed", { error: String(err) });
-    serverError(res, err instanceof Error ? err.message : "unknown error");
+    serverError(res, errorMessage(err, "unknown error"));
   }
 });
 
@@ -114,7 +115,7 @@ router.post(API_ROUTES.sources.create, async (req: Request<object, unknown, Regi
   try {
     await writeSource(workspacePath, source);
   } catch (err) {
-    serverError(res, err instanceof Error ? err.message : "failed to write source");
+    serverError(res, errorMessage(err, "failed to write source"));
     return;
   }
   log.info("sources", "source registered", {
@@ -192,7 +193,7 @@ router.post(API_ROUTES.sources.rebuild, async (req: Request<object, unknown, Reb
     });
   } catch (err) {
     log.warn("sources", "rebuild failed", { error: String(err) });
-    serverError(res, err instanceof Error ? err.message : "rebuild failed");
+    serverError(res, errorMessage(err, "rebuild failed"));
   }
 });
 
@@ -261,7 +262,7 @@ router.post(API_ROUTES.sources.manage, async (req: Request<object, unknown, Mana
     }
   } catch (err) {
     log.warn("sources", "manage failed", { action, error: String(err) });
-    serverError(res, err instanceof Error ? err.message : "manage failed");
+    serverError(res, errorMessage(err, "manage failed"));
   }
 });
 

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -1,7 +1,16 @@
 // Shared error helpers. Use `errorMessage(err)` instead of inlining
 // `err instanceof Error ? err.message : String(err)` — searching for
 // one canonical helper is easier than grepping for the inline form.
+//
+// The optional `fallback` covers the common route-handler idiom where
+// a throw of a plain non-Error value should surface as a descriptive
+// message ("rebuild failed") rather than `String(err)` noise like
+// `[object Object]`. Prefer passing a fallback at error-response
+// boundaries — omit it for logging contexts where `String(err)` is
+// fine.
 
-export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+export function errorMessage(err: unknown, fallback?: string): string {
+  if (err instanceof Error) return err.message;
+  if (fallback !== undefined) return fallback;
+  return String(err);
 }


### PR DESCRIPTION
…ssage

Phase 3 of today's daily-refactoring sweep turned up 10 sites across 3 route handlers that inline the same pattern:

    err instanceof Error ? err.message : "<specific fallback>"

`server/utils/errors.ts` already exported `errorMessage(err)` but only produced `String(err)` on non-Error input — which loses the handler's context-rich fallback string ("rebuild failed" vs "[object Object]").

Extend `errorMessage` with an optional second argument:

    errorMessage(err, "rebuild failed")

and migrate the 10 sites in `chat-index.ts`, `sources.ts`, `config.ts` to use it. Single-source-of-truth grep target, same user-visible text.

Also fold two hand-rolled `res.status(500).json({ error })` calls in `files.ts` into the existing `serverError()` helper — matched the pattern flagged by the daily-refactoring skill but wasn't on yesterday's diff, only surfaced once we widened the sweep to the full tree.