### PR TITLE
chore: ignore playwright test-results directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ server/logs/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 playwright-report/
+test-results/
 .playwright-mcp/
 .mcp.json


### PR DESCRIPTION
## Summary
- Add `test-results/` to `.gitignore` alongside the existing `playwright-report/` and `.playwright-mcp/` entries so local Playwright artifacts don't get accidentally committed.

## Test plan
- [x] Confirm the entry sits next to the other Playwright-related ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add Playwright `test-results/` directory to .gitignore to prevent committing local test artifacts.