### PR TITLE
refactor(client): mirror errorMessage fallback arg on the Vue side

### DIFF
--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -5,6 +5,7 @@ import { ref } from "vue";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { isNonEmptyString } from "../utils/types";
 
 interface TextContent {
   kind: "text";
@@ -43,7 +44,7 @@ export function readPathMatch(raw: unknown): string | null {
     if (raw.length === 0) return null;
     return raw.join("/");
   }
-  if (typeof raw === "string" && raw.length > 0) return raw;
+  if (isNonEmptyString(raw)) return raw;
   return null;
 }
 

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -261,6 +261,7 @@ import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import TasksTab from "./TasksTab.vue";
 import { isToday } from "../../utils/format/date";
+import { errorMessage } from "../../utils/errors";
 
 const { t } = useI18n();
 
@@ -566,7 +567,7 @@ async function applyChanges() {
     parsed = JSON.parse(editorText.value);
     if (!Array.isArray(parsed)) throw new Error("Expected a JSON array");
   } catch (err) {
-    parseError.value = err instanceof Error ? err.message : "Invalid JSON";
+    parseError.value = errorMessage(err, "Invalid JSON");
     return;
   }
   callApi({ action: "replace", items: parsed });

--- a/src/plugins/spreadsheet/engine/responseDecoder.ts
+++ b/src/plugins/spreadsheet/engine/responseDecoder.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SheetData } from "./types.js";
+import { errorMessage } from "../../../utils/errors";
 
 /** Shape of the `/api/files/content` response we care about. The
  *  server returns more fields (kind, size, modifiedMs, …) but this
@@ -51,7 +52,7 @@ export function decodeSpreadsheetResponse(body: FilesContentResponseLike): Decod
   } catch (err) {
     return {
       kind: "error",
-      message: `Spreadsheet JSON is malformed: ${err instanceof Error ? err.message : "parse error"}`,
+      message: `Spreadsheet JSON is malformed: ${errorMessage(err, "parse error")}`,
     };
   }
   if (!Array.isArray(parsed)) {

--- a/src/router/guards.ts
+++ b/src/router/guards.ts
@@ -9,6 +9,7 @@
 import type { Router } from "vue-router";
 import { readPathMatch } from "../composables/useFileSelection";
 import { readWikiRouteTarget } from "../plugins/wiki/route";
+import { isNonEmptyString } from "../utils/types";
 
 // Basic sanity check for a session ID. Real existence verification
 // happens in App.vue's onMounted / loadSession — we can't do async
@@ -27,7 +28,7 @@ export function installGuards(router: Router): void {
   router.beforeEach((dest) => {
     if (dest.name === "chat") {
       const sessionId = dest.params.sessionId;
-      if (typeof sessionId === "string" && sessionId.length > 0 && !isValidSessionId(sessionId)) {
+      if (isNonEmptyString(sessionId) && !isValidSessionId(sessionId)) {
         return { name: "chat", params: {}, query: {}, replace: true };
       }
     }
@@ -53,7 +54,7 @@ export function installGuards(router: Router): void {
       // before the traversal check so `?path=../bad` also lands in
       // the `..` rejection below.
       const legacyPath = dest.query.path;
-      if (typeof legacyPath === "string" && legacyPath.length > 0) {
+      if (isNonEmptyString(legacyPath)) {
         const cleaned = { ...dest.query };
         delete cleaned.path;
         return {

--- a/src/utils/agent/request.ts
+++ b/src/utils/agent/request.ts
@@ -4,6 +4,7 @@ import type { Role } from "../../config/roles";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { apiFetchRaw } from "../api";
 import { errorMessage } from "../errors";
+import { isNonEmptyString } from "../types";
 
 export interface AgentRequestBodyParams {
   message: string;
@@ -31,7 +32,7 @@ export interface AgentRequestBody {
 function resolveBrowserTimezone(): string | undefined {
   try {
     const zoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return typeof zoneId === "string" && zoneId.length > 0 ? zoneId : undefined;
+    return isNonEmptyString(zoneId) ? zoneId : undefined;
   } catch {
     return undefined;
   }

--- a/src/utils/agent/request.ts
+++ b/src/utils/agent/request.ts
@@ -3,6 +3,7 @@
 import type { Role } from "../../config/roles";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { apiFetchRaw } from "../api";
+import { errorMessage } from "../errors";
 
 export interface AgentRequestBodyParams {
   message: string;
@@ -68,7 +69,7 @@ export async function postAgentRun(body: AgentRequestBody): Promise<{ ok: true }
     console.error("[agent] fetch error:", err);
     return {
       ok: false,
-      error: err instanceof Error ? err.message : "Connection error.",
+      error: errorMessage(err, "Connection error."),
     };
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,7 +5,14 @@
 // Use `errorMessage(err)` instead of inlining
 // `err instanceof Error ? err.message : String(err)` — searching for
 // one canonical helper is easier than grepping for the inline form.
+//
+// The optional `fallback` covers the common idiom of surfacing a
+// descriptive message ("Invalid JSON", "Connection error.") when a
+// throw turns out to be a non-Error value — otherwise `String(err)`
+// yields noise like `[object Object]`.
 
-export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+export function errorMessage(err: unknown, fallback?: string): string {
+  if (err instanceof Error) return err.message;
+  if (fallback !== undefined) return fallback;
+  return String(err);
 }


### PR DESCRIPTION
## Summary

Symmetric follow-up to the server-side \`errorMessage\` change that landed in #718 — the same inline pattern

    err instanceof Error ? err.message : "<fallback>"

appears in 3 Vue-side sites. Extend \`src/utils/errors.ts#errorMessage\` with the same optional second-arg as its server twin and migrate the call sites.

## Items to Confirm / Review

- \`src/utils/errors.ts\` now accepts \`errorMessage(err, fallback?)\`. When \`err\` is not an \`Error\`, the fallback (if given) wins over \`String(err)\` — preserves the context-rich message the inline pattern was carrying.
- Migrated sites:
  - \`src/plugins/spreadsheet/engine/responseDecoder.ts\` — "parse error"
  - \`src/plugins/scheduler/View.vue\` — "Invalid JSON"
  - \`src/utils/agent/request.ts\` — "Connection error."
- Kept the two \`errors.ts\` files (server + client) structurally identical so cross-boundary editing doesn't require mentally diffing them.

## User Prompt

> 持ち越しの、全部issueにして。他、utils系の抜けないかさらに確認。srcのvue部分も作っているよね。

Broadened the Phase 3 sweep to \`src/\` (Vue side). The 3 sites above were the only hits — \`typeof x === "object" && x !== null\` manual checks, raw \`fetch()\` in place of \`apiGet/apiPost\`, and hardcoded \`/api/\` strings all came back empty across the Vue tree (\`apiRoutes.ts\` + \`utils/api.ts\` are being used consistently).

## Test plan

- [x] \`yarn typecheck:vue\` — clean
- [x] \`yarn lint\` — no new warnings
- [ ] \`yarn test:e2e\` — not run locally; CI will exercise the scheduler View.vue JSON editor path that calls this

🤖 Generated with [Claude Code](https://claude.com/claude-code)