### PR TITLE
refactor(client): simplify spreadsheet preview card

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -527,7 +527,6 @@ const deMessages = {
     cancel: "Abbrechen",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 Tabelle",
     previewUntitled: "Tabelle",
     previewSheets: "{count} Blatt | {count} Blätter",
     untitled: "Tabelle",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -549,7 +549,6 @@ const enMessages = {
     cancel: "Cancel",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 Spreadsheet",
     previewUntitled: "Spreadsheet",
     previewSheets: "{count} sheet | {count} sheets",
     untitled: "Spreadsheet",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -535,7 +535,6 @@ const esMessages = {
     cancel: "Cancelar",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 Hoja de cálculo",
     previewUntitled: "Hoja de cálculo",
     previewSheets: "{count} hoja | {count} hojas",
     untitled: "Hoja de cálculo",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -527,7 +527,6 @@ const frMessages = {
     cancel: "Annuler",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 Tableur",
     previewUntitled: "Tableur",
     previewSheets: "{count} feuille | {count} feuilles",
     untitled: "Tableur",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -533,7 +533,6 @@ const jaMessages = {
     cancel: "キャンセル",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 スプレッドシート",
     previewUntitled: "スプレッドシート",
     previewSheets: "{count} シート",
     untitled: "スプレッドシート",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -533,7 +533,6 @@ const koMessages = {
     cancel: "취소",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 스프레드시트",
     previewUntitled: "스프레드시트",
     previewSheets: "{count}개 시트",
     untitled: "스프레드시트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -525,7 +525,6 @@ const ptBRMessages = {
     cancel: "Cancelar",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 Planilha",
     previewUntitled: "Planilha",
     previewSheets: "{count} aba | {count} abas",
     untitled: "Planilha",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -529,7 +529,6 @@ const zhMessages = {
     cancel: "取消",
   },
   pluginSpreadsheet: {
-    previewLabel: "📊 电子表格",
     previewUntitled: "电子表格",
     previewSheets: "{count} 个工作表",
     untitled: "电子表格",

--- a/src/plugins/spreadsheet/Preview.vue
+++ b/src/plugins/spreadsheet/Preview.vue
@@ -1,7 +1,6 @@
 <template>
-  <div class="text-center p-4 bg-green-50 dark:bg-green-900 rounded">
-    <div class="text-green-600 dark:text-green-300 font-medium">{{ t("pluginSpreadsheet.previewLabel") }}</div>
-    <div class="text-sm text-gray-800 dark:text-gray-200 mt-1 font-medium truncate">
+  <div class="p-2 bg-green-50 dark:bg-green-900 rounded">
+    <div class="text-sm text-gray-800 dark:text-gray-200 font-medium break-words">
       {{ displayTitle }}
     </div>
     <div v-if="sheetCount > 1" class="text-xs text-gray-600 dark:text-gray-400 mt-1">


### PR DESCRIPTION
## Summary
- Drop the redundant "📊 Spreadsheet" header row from the sidebar preview — the parent card already renders the tool name and timestamp, so the label was pure duplication.
- Let long spreadsheet titles wrap (`truncate` → `break-words`) so the title is no longer cut off in the narrow sidebar.
- Remove the now-unused `pluginSpreadsheet.previewLabel` i18n key from all 8 locales.

## Test plan
- [ ] Visually verify the sidebar spreadsheet preview shows only the title (wrapping when long) and the "N sheets" line for multi-sheet workbooks.
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass locally (confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed spreadsheet preview label from all supported interface languages: German, English, Spanish, French, Japanese, Korean, Portuguese, and Chinese
  * Updated spreadsheet preview component styling with reduced padding, improved text wrapping behavior, and adjusted text alignment for enhanced visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->