### PR TITLE
chore: add Claude Code rule for German typographic quotes in de.ts

### DIFF
--- a/.claude/rules/i18n-de.md
+++ b/.claude/rules/i18n-de.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "src/lang/de.ts"
+---
+
+# German locale — typographic quote handling
+
+## Problem
+
+`de.ts` uses German typographic quotes `„"` (U+201E opening, U+201C closing).
+The closing `"` (U+201C) is visually identical to ASCII `"` (U+0022) but is a
+different character. If ASCII `"` is used instead of U+201C inside a
+double-quoted JS string, it terminates the string early and causes a parse error.
+
+Claude's token output converts U+201C to ASCII `"`, so the Edit tool and Write
+tool silently produce broken code when writing these characters.
+
+## Rules
+
+- **NEVER** use the Edit tool with `new_string` containing `„` or `"` — the
+  output will corrupt the file.
+- **NEVER** use `sed` to modify lines containing these characters.
+- When adding or modifying lines with German quotes, use `node -e` with
+  Unicode escapes `\u201E` (opening `„`) and `\u201C` (closing `"`):
+
+```bash
+node -e "
+const fs = require('fs');
+const file = 'src/lang/de.ts';
+const content = fs.readFileSync(file, 'utf8');
+const newLine = '    key: \"Die Seite \u201E{title}\u201C existiert.\",';
+const updated = content.replace('    nextKey:', newLine + '\n    nextKey:');
+fs.writeFileSync(file, updated, 'utf8');
+"
+```
+
+- When editing parts of a line that do **not** contain `„"`, the Edit tool is
+  safe — existing Unicode bytes are preserved if they are not in `old_string`
+  or `new_string`.
+- After any edit to `de.ts`, verify bytes with:
+  `sed -n '<line>p' src/lang/de.ts | xxd` — look for `e2 80 9e` (U+201E)
+  and `e2 80 9c` (U+201C).


### PR DESCRIPTION
## Summary

- de.ts のドイツ語引用符 `„"` (U+201E/U+201C) を Claude が Edit/Write で書くと ASCII `"` に変換されパースエラーになる問題の対策
- `.claude/rules/i18n-de.md` を追加し、`src/lang/de.ts` 編集時に自動でロードされるルールとして回避策を明示

## Items to Confirm / Review

- ルールは `paths: ["src/lang/de.ts"]` でスコープされており、他のファイル編集時にはロードされない
- 回避策: `node -e` で `\u201E` / `\u201C` エスケープを使う

## User Prompt

PR #678 の作業中にドイツ語引用符の問題で何度もパースエラーが発生。Claude の出力制約（U+201C → ASCII `"` 変換）を `.claude/rules/` に記録し、今後同じ問題が起きないようにする。

## Background

- Claude のトークン出力は `"` (U+201C) を ASCII `"` (U+0022) として生成する
- de.ts のドイツ語閉じ引用符 `"` (U+201C) が JS の文字列デリミタ `"` (U+0022) と衝突してパースエラーになる
- Edit ツールの `new_string` に含めると壊れるが、`node -e` の `\u201C` エスケープなら正しく書ける
- 特殊文字を含まない部分だけを Edit で編集する場合は既存の特殊文字は保持される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for maintaining proper German language support, ensuring correct handling of German typographic characters in translations to preserve formatting integrity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->