### PR TITLE
chore: bump @mulmobridge/protocol 0.1.4 + chat-service 0.1.2 (options passthrough)

### DIFF
--- a/packages/chat-service/package.json
+++ b/packages/chat-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/chat-service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Server-side chat service for MulmoBridge — socket.io + REST bridge to Claude Code agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,7 +27,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/protocol": "^0.1.3"
+    "@mulmobridge/protocol": "^0.1.4"
   },
   "peerDependencies": {
     "express": "^5.0.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/protocol",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared types and constants for the MulmoBridge protocol",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

\`@mulmobridge/client@0.1.3\` (bumped in #729) の公開に必要な companion bumps:

- **\`@mulmobridge/protocol\`**: \`0.1.3 → 0.1.4\` (新規 type exports: \`BridgeOptions\`, \`BridgeHandshakeAuth\`)
- **\`@mulmobridge/chat-service\`**: \`0.1.1 → 0.1.2\` (runtime: handshake sanitiser + bridgeOptions forwarding)
- **chat-service → protocol dep** を \`^0.1.3\` → \`^0.1.4\` に tighten

## Why all three need to ship

| Package | 何が変わったか | publish しないと何が壊れるか |
|---|---|---|
| protocol | 型 \`BridgeOptions\` / \`BridgeHandshakeAuth\` 追加 | client@0.1.3 の \`.d.ts\` がこれらを import する → 未 publish だと consumer の typecheck が fail |
| chat-service | runtime で sanitise + forward を実装 | 未 publish だと、mulmoclaude launcher が npm install する chat-service@0.1.1 が古い挙動のまま → \`SLACK_BRIDGE_DEFAULT_ROLE\` が silent no-op |
| client | \`readBridgeEnvOptions\` 新規 export (#729 で 0.1.3 bump 済み) | 未 publish だと機能そのものが consumer 側に届かない |

## Verification

- \`yarn typecheck\` / \`yarn lint\` / \`yarn build\` clean
- smoke drift: \`2 package(s) ok, 1 pending publish (client@0.1.3), 0 skipped\` (この PR マージ後は client 含め publish 待ち)
- mulmoclaude launcher の dep は \`^0.1.1\` / \`^0.1.3\` なので自動で新 version を拾う (dep 編集不要)

## Next (マージ後)

1. \`git pull origin main\`
2. 依存順に publish: protocol → chat-service → client
3. 各パッケージで \`git tag @mulmobridge/<name>@<version>\` + \`gh release create … --latest=false\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions and internal dependencies to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->