### PR TITLE
refactor(client,relay): introduce makeUuid helpers (#723)

### DIFF
--- a/packages/relay/src/utils/id.ts
+++ b/packages/relay/src/utils/id.ts
@@ -1,0 +1,16 @@
+// ID helper for the relay Worker. Copy of `src/utils/id.ts` — the
+// relay is an independent npm package and can't import across
+// repositories, so the helper is duplicated. Keep the two in sync
+// when the signature changes. See issue #723 for the design
+// rationale.
+
+/**
+ * Full UUID v4 (36 chars, hyphenated).
+ *
+ * Used as the per-message `id` on `RelayMessage` payloads emitted
+ * from webhook handlers so the forwarding pipeline can de-dupe and
+ * correlate replies.
+ */
+export function makeUuid(): string {
+  return crypto.randomUUID();
+}

--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -15,6 +15,7 @@ import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
+import { makeUuid } from "../utils/id.js";
 
 const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
 const JWKS_URL = "https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com";
@@ -192,7 +193,7 @@ const googleChatPlugin: PlatformPlugin = {
 
     return [
       {
-        id: crypto.randomUUID(),
+        id: makeUuid(),
         platform: PLATFORMS.googleChat,
         senderId: parsed.spaceName,
         chatId: parsed.spaceName,

--- a/packages/relay/src/webhooks/line.ts
+++ b/packages/relay/src/webhooks/line.ts
@@ -3,6 +3,7 @@
 import { chunkText } from "@mulmobridge/client/text";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { makeUuid } from "../utils/id.js";
 
 interface LineEvent {
   type: string;
@@ -62,7 +63,7 @@ const linePlugin: PlatformPlugin = {
       const chatId = event.source?.groupId ?? event.source?.roomId ?? event.source?.userId ?? "unknown";
 
       messages.push({
-        id: crypto.randomUUID(),
+        id: makeUuid(),
         platform: PLATFORMS.line,
         senderId: event.source?.userId ?? "unknown",
         chatId,

--- a/packages/relay/src/webhooks/messenger.ts
+++ b/packages/relay/src/webhooks/messenger.ts
@@ -10,6 +10,7 @@ import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
 import { FIFTEEN_SECONDS_MS } from "../time.js";
+import { makeUuid } from "../utils/id.js";
 
 const MAX_MESSENGER_TEXT = 2000;
 
@@ -62,7 +63,7 @@ const messengerPlugin: PlatformPlugin = {
     if (!valid) throw new Error("Messenger signature verification failed");
 
     return extractMessages(JSON.parse(body)).map((msg) => ({
-      id: crypto.randomUUID(),
+      id: makeUuid(),
       platform: PLATFORMS.messenger,
       senderId: msg.senderId,
       chatId: msg.senderId,

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -29,6 +29,7 @@ import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
 import { validateTokenClaims, validateJwkEndorsement, isAllowedSender, type AppType } from "./teams-verify.js";
+import { makeUuid } from "../utils/id.js";
 
 const MULTITENANT_ISSUER = "https://api.botframework.com";
 const MULTITENANT_JWKS_URL = "https://login.botframework.com/v1/.well-known/keys";
@@ -313,7 +314,7 @@ const teamsPlugin: PlatformPlugin = {
 
     return [
       {
-        id: crypto.randomUUID(),
+        id: makeUuid(),
         platform: PLATFORMS.teams,
         senderId: activity.senderAadObjectId || activity.senderId,
         chatId: activity.conversationId,

--- a/packages/relay/src/webhooks/telegram.ts
+++ b/packages/relay/src/webhooks/telegram.ts
@@ -2,6 +2,7 @@
 
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
+import { makeUuid } from "../utils/id.js";
 
 interface TelegramUpdate {
   message?: {
@@ -40,7 +41,7 @@ const telegramPlugin: PlatformPlugin = {
 
     return [
       {
-        id: crypto.randomUUID(),
+        id: makeUuid(),
         platform: PLATFORMS.telegram,
         senderId: String(msg.from?.id ?? "unknown"),
         chatId: String(msg.chat.id),

--- a/packages/relay/src/webhooks/whatsapp.ts
+++ b/packages/relay/src/webhooks/whatsapp.ts
@@ -11,6 +11,7 @@ import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { verifyMetaSignature, handleMetaVerification } from "./meta.js";
 import { FIFTEEN_SECONDS_MS } from "../time.js";
+import { makeUuid } from "../utils/id.js";
 
 const WHATSAPP_API_VERSION = "v21.0";
 const MAX_WA_TEXT = 4096;
@@ -62,7 +63,7 @@ const whatsappPlugin: PlatformPlugin = {
     if (!valid) throw new Error("WhatsApp signature verification failed");
 
     return extractWaMessages(JSON.parse(body)).map((msg) => ({
-      id: crypto.randomUUID(),
+      id: makeUuid(),
       platform: PLATFORMS.whatsapp,
       senderId: msg.from,
       chatId: msg.from,

--- a/src/plugins/canvas/index.ts
+++ b/src/plugins/canvas/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 const canvasPlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
@@ -15,14 +16,14 @@ const canvasPlugin: ToolPlugin<ImageToolData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/chart/index.ts
+++ b/src/plugins/chart/index.ts
@@ -5,6 +5,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface ChartEntry {
   title?: string;
@@ -31,14 +32,14 @@ const presentChartPlugin: ToolPlugin<PresentChartData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/editImage/index.ts
+++ b/src/plugins/editImage/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 const editImagePlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
@@ -15,14 +16,14 @@ const editImagePlugin: ToolPlugin<ImageToolData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/generateImage/index.ts
+++ b/src/plugins/generateImage/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 function createUploadedImageResult(imageData: string, fileName: string, prompt: string): ToolResult<ImageToolData, never> {
   return {
@@ -24,14 +25,14 @@ const generateImagePlugin: ToolPlugin<ImageToolData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/manageRoles/index.ts
+++ b/src/plugins/manageRoles/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface CustomRole {
   id: string;
@@ -27,14 +28,14 @@ const manageRolesPlugin: ToolPlugin = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
   isEnabled: () => true,

--- a/src/plugins/manageSkills/index.ts
+++ b/src/plugins/manageSkills/index.ts
@@ -4,6 +4,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiGet } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface SkillSummary {
   name: string;
@@ -25,7 +26,7 @@ const manageSkillsPlugin: ToolPlugin<ManageSkillsData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: `Failed to load skills: ${result.error}`,
         error: `Failed to load skills: ${result.error}`,
       };
@@ -33,7 +34,7 @@ const manageSkillsPlugin: ToolPlugin<ManageSkillsData> = {
     const skills = result.data.skills;
     return {
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
       title: "Skills",
       message: `Found ${skills.length} skill${skills.length === 1 ? "" : "s"}.`,
       data: { skills },

--- a/src/plugins/manageSource/index.ts
+++ b/src/plugins/manageSource/index.ts
@@ -5,6 +5,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 // Mirrors server/sources/types.ts#Source. Re-declared here so the
 // frontend doesn't have to import a server package.
@@ -46,14 +47,14 @@ const manageSourcePlugin: ToolPlugin<ManageSourceData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
   isEnabled: () => true,

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 const markdownPlugin: ToolPlugin<MarkdownToolData> = {
   toolDefinition,
@@ -15,14 +16,14 @@ const markdownPlugin: ToolPlugin<MarkdownToolData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/presentHtml/index.ts
+++ b/src/plugins/presentHtml/index.ts
@@ -5,6 +5,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface PresentHtmlData {
   html: string;
@@ -20,14 +21,14 @@ const presentHtmlPlugin: ToolPlugin<PresentHtmlData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface MulmoScriptData {
   script: MulmoScript;
@@ -20,14 +21,14 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/scheduler/index.ts
+++ b/src/plugins/scheduler/index.ts
@@ -5,6 +5,7 @@ import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface ScheduledItem {
   id: string;
@@ -25,14 +26,14 @@ const schedulerPlugin: ToolPlugin<SchedulerData> = {
     if (!result.ok) {
       return {
         toolName: "manageScheduler",
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: "manageScheduler",
-      uuid: result.data.uuid ?? crypto.randomUUID(),
+      uuid: result.data.uuid ?? makeUuid(),
     };
   },
 

--- a/src/plugins/spreadsheet/index.ts
+++ b/src/plugins/spreadsheet/index.ts
@@ -6,6 +6,7 @@ import View from "./View.vue";
 import Preview from "./Preview.vue";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 const spreadsheetPlugin: ToolPlugin<SpreadsheetToolData> = {
   toolDefinition,
@@ -15,14 +16,14 @@ const spreadsheetPlugin: ToolPlugin<SpreadsheetToolData> = {
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: TOOL_NAME,
-      uuid: crypto.randomUUID(),
+      uuid: makeUuid(),
     };
   },
 

--- a/src/plugins/todo/index.ts
+++ b/src/plugins/todo/index.ts
@@ -5,6 +5,7 @@ import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export type TodoPriority = "low" | "medium" | "high" | "urgent";
 
@@ -41,14 +42,14 @@ const todoPlugin: ToolPlugin<TodoData> = {
     if (!result.ok) {
       return {
         toolName: "manageTodoList",
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: result.error,
       };
     }
     return {
       ...result.data,
       toolName: "manageTodoList",
-      uuid: result.data.uuid ?? crypto.randomUUID(),
+      uuid: result.data.uuid ?? makeUuid(),
     };
   },
 

--- a/src/plugins/wiki/index.ts
+++ b/src/plugins/wiki/index.ts
@@ -5,6 +5,7 @@ import Preview from "./Preview.vue";
 import toolDefinition from "./definition";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { makeUuid } from "../../utils/id";
 
 export interface WikiPageEntry {
   title: string;
@@ -34,14 +35,14 @@ const wikiPlugin: ToolPlugin<WikiData> = {
       const prefix = result.status === 0 ? "Wiki request failed" : `Wiki API error ${result.status}`;
       return {
         toolName: "manageWiki",
-        uuid: crypto.randomUUID(),
+        uuid: makeUuid(),
         message: `${prefix}: ${result.error}`,
       };
     }
     return {
       ...result.data,
       toolName: "manageWiki",
-      uuid: result.data.uuid ?? crypto.randomUUID(),
+      uuid: result.data.uuid ?? makeUuid(),
     };
   },
 

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,18 @@
+// Client-side ID helpers. Mirrors `server/utils/id.ts` for the
+// frontend — see issue #723 for the full design rationale.
+//
+// The client only needs `makeUuid()` at the moment: all per-action
+// tool-call `uuid` fields emitted by `src/plugins/*/index.ts`. If a
+// client-side file-naming use case emerges, mirror `shortId()` from
+// the server helper.
+
+/**
+ * Full UUID v4 (36 chars, hyphenated).
+ *
+ * Used as the per-action `uuid` on ToolResult payloads so the
+ * renderer can track which action a result belongs to across a
+ * session.
+ */
+export function makeUuid(): string {
+  return crypto.randomUUID();
+}


### PR DESCRIPTION
## Summary

#736 の follow-up。client (`src/plugins/*`) と relay package に残っていた `crypto.randomUUID()` 直呼びを helper 経由に統一します。

- **Client** (`src/utils/id.ts` 新設): 14 plugin ファイル / 32 箇所を \`makeUuid()\` に置換
- **Relay** (`packages/relay/src/utils/id.ts` にコピー): 6 webhook ファイルを \`makeUuid()\` に置換。独立 npm package なので \`server/\` や \`src/\` から import 不可、helper 冒頭に複製理由を明記

## Items to Confirm / Review

- [ ] client 側は \`src/utils/id.ts\` のみに \`makeUuid()\` を持たせ、\`shortId()\` は作っていません(現状 client で短縮 id が必要な call site が存在しないため)。将来必要になったら server と合わせて追加
- [ ] relay の helper は server 側とコードは同じ内容ですが、重複を許容しています(build 境界の都合)。header コメントで意図を明記
- [ ] \`server/utils/files/atomic.ts\` と \`packages/chat-service/src/atomic-write.ts\` の \`randomUUID()\` は tmp filename 用で ID ではないためスコープ外

## User Prompt

> [#723 残課題のうち] １はやる。２はコピーで。

(1=client plugins, 2=relay with copied helper)

## Implementation

### Client (`src/utils/id.ts`)

\`\`\`ts
export function makeUuid(): string {
  return crypto.randomUUID();
}
\`\`\`

### 移行した call sites

**client (14 files / 32 calls):**
\`generateImage, manageRoles, spreadsheet, chart, manageSkills, markdown, scheduler, presentHtml, wiki, canvas, todo, editImage, presentMulmoScript, manageSource\` の各 \`index.ts\`

**relay (6 files / 6 calls):**
\`line, whatsapp, messenger, google-chat, telegram, teams\` の各 webhook

## Verification

- \`yarn format\` / \`yarn lint\` — green (4 pre-existing v-html warnings)
- \`yarn typecheck\` — clean(最近 main で pre-existing \`BridgeOptions\` エラーも解消済み)
- 残った \`crypto.randomUUID()\` 直呼びは \`packages/relay/src/utils/id.ts\` (helper の実装本体) と tmp-filename 用の 2 箇所のみ

## Follow-up

- daily-refactoring skill / CLAUDE.md にパターンを追記(別 PR / 小さなドキュメント変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)