### PR TITLE
fix: route workspace-internal links in wiki view to correct views

### DIFF
--- a/plans/fix-wiki-internal-link-routing.md
+++ b/plans/fix-wiki-internal-link-routing.md
@@ -37,7 +37,7 @@ textResponse View には `classifyWorkspacePath` + `navigateToWorkspacePath` に
 
 `handleContentClick` のハンドラチェーンを拡張:
 
-```
+```text
 wiki リンク → 外部リンク → ワークスペースパス（新規）→ ブラウザデフォルト
 ```
 

--- a/plans/fix-wiki-internal-link-routing.md
+++ b/plans/fix-wiki-internal-link-routing.md
@@ -1,0 +1,61 @@
+# fix: Wiki ページ内の内部リンクが /chat にリダイレクトされる
+
+## 問題
+
+Wiki ページ内のマークダウンリンク（`<a>` タグ）でワークスペース内ファイルを指すものをクリックすると、Router の catch-all (`/:pathMatch(.*)*` → `/chat`) にヒットして chat ページにリダイレクトされる。
+
+### 再現手順
+
+1. ソースファイルや出典リンクを含む wiki ページを開く
+2. 出典セクションのソースファイルリンク（例: `../sources/<slug>.md`）をクリック
+3. → `/chat` にリダイレクトされる（期待: `/files/data/wiki/sources/<slug>.md` で表示）
+
+### 影響するリンクの例
+
+- ソースファイル: `../sources/<slug>.md`
+- セッションログ: `../../../conversations/chat/<session-id>.jsonl`
+
+## 原因
+
+Wiki View の `handleContentClick` は以下のみ処理している:
+
+1. `[[Page Name]]` → wiki 内遷移（`navigatePage`）
+2. 外部 URL（cross-origin http/https）→ 新タブで開く
+
+**ワークスペース内部リンク（`../sources/...`, `../../../conversations/...`）のハンドラがない。**
+
+textResponse View には `classifyWorkspacePath` + `navigateToWorkspacePath` による同等の処理が実装済み。
+
+## 修正方針
+
+### 変更ファイル
+
+1. **`src/plugins/wiki/View.vue`** — `handleContentClick` にワークスペースパスの処理を追加
+2. **`src/utils/path/workspaceLinkRouter.ts`** — 相対パス解決用のヘルパー追加（または View 側で解決）
+
+### 実装詳細
+
+`handleContentClick` のハンドラチェーンを拡張:
+
+```
+wiki リンク → 外部リンク → ワークスペースパス（新規）→ ブラウザデフォルト
+```
+
+#### 相対パスの解決
+
+Wiki ページ内のリンクはファイルシステム相対パス（`../sources/...`）で書かれている。
+`classifyWorkspacePath` はワークスペースルート相対パスを期待するため、
+クリック時に wiki ページの workspace 位置（`data/wiki/pages/`）を基準に解決してから渡す。
+
+例:
+- href: `../sources/my-source.md`
+- 基準: `data/wiki/pages/<slug>`
+- 解決後: `data/wiki/sources/my-source.md`
+- 分類結果: `{ kind: "file", path: "data/wiki/sources/my-source.md" }`
+
+### デグレリスク
+
+- **低リスク**: 既存の wiki リンク・外部リンクハンドラには触れない
+- 新規処理はチェーンの末尾に追加するだけ
+- `classifyWorkspacePath` は純粋関数で実績あり（textResponse で使用中）
+- 影響するのは「現在壊れている動作」のみ

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -216,6 +216,7 @@ import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
+import { classifyWorkspacePath } from "../../utils/path/workspaceLinkRouter";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { useImeAwareEnter } from "../../composables/useImeAwareEnter";
 import { usePdfDownload } from "../../composables/usePdfDownload";
@@ -491,6 +492,23 @@ function submitChat() {
 
 const imeEnter = useImeAwareEnter(submitChat);
 
+/** Wiki pages live at `data/wiki/pages/` in the workspace. */
+const WIKI_PAGES_DIR = "data/wiki/pages";
+
+/**
+ * Resolve a potentially-relative href against the wiki pages directory
+ * so that `classifyWorkspacePath` can normalize `../` segments.
+ *
+ * Example: `../sources/foo.md` → `data/wiki/pages/../sources/foo.md`
+ *        → (after normalization) `data/wiki/sources/foo.md`
+ */
+function resolveWikiHref(href: string): string {
+  if (href.startsWith("./") || href.startsWith("../")) {
+    return `${WIKI_PAGES_DIR}/${href}`;
+  }
+  return href;
+}
+
 function handleContentClick(event: MouseEvent) {
   // 1. Internal wiki links: `[[Page Name]]` was rewritten to a
   //    `<span class="wiki-link">` during markdown pre-processing,
@@ -505,7 +523,18 @@ function handleContentClick(event: MouseEvent) {
   //    in a new tab so clicking them doesn't navigate the whole
   //    SPA away from MulmoClaude. Same-origin and non-http links
   //    (mailto:, tel:, anchors) fall through to the browser default.
-  handleExternalLinkClick(event);
+  if (handleExternalLinkClick(event)) return;
+  // 3. Workspace-internal links: resolve relative paths against the
+  //    wiki page's filesystem location and route to the appropriate view.
+  const anchor = target.closest("a");
+  if (!anchor) return;
+  const href = anchor.getAttribute("href");
+  if (!href || href.startsWith("#")) return;
+  const resolved = resolveWikiHref(href);
+  if (classifyWorkspacePath(resolved)) {
+    event.preventDefault();
+    appApi.navigateToWorkspacePath(resolved);
+  }
 }
 </script>
 

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -216,7 +216,7 @@ import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
-import { classifyWorkspacePath } from "../../utils/path/workspaceLinkRouter";
+import { classifyWorkspacePath, resolveWikiHref } from "../../utils/path/workspaceLinkRouter";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { useImeAwareEnter } from "../../composables/useImeAwareEnter";
 import { usePdfDownload } from "../../composables/usePdfDownload";
@@ -492,22 +492,8 @@ function submitChat() {
 
 const imeEnter = useImeAwareEnter(submitChat);
 
-/** Wiki pages live at `data/wiki/pages/` in the workspace. */
-const WIKI_PAGES_DIR = "data/wiki/pages";
-
-/**
- * Resolve a potentially-relative href against the wiki pages directory
- * so that `classifyWorkspacePath` can normalize `../` segments.
- *
- * Example: `../sources/foo.md` → `data/wiki/pages/../sources/foo.md`
- *        → (after normalization) `data/wiki/sources/foo.md`
- */
-function resolveWikiHref(href: string): string {
-  if (href.startsWith("./") || href.startsWith("../")) {
-    return `${WIKI_PAGES_DIR}/${href}`;
-  }
-  return href;
-}
+/** Base directory for wiki content, adjusted by the current view. */
+const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
 
 function handleContentClick(event: MouseEvent) {
   // 1. Internal wiki links: `[[Page Name]]` was rewritten to a
@@ -525,12 +511,15 @@ function handleContentClick(event: MouseEvent) {
   //    (mailto:, tel:, anchors) fall through to the browser default.
   if (handleExternalLinkClick(event)) return;
   // 3. Workspace-internal links: resolve relative paths against the
-  //    wiki page's filesystem location and route to the appropriate view.
+  //    wiki content's filesystem location and route to the appropriate view.
+  //    Skip modifier-key clicks and middle clicks so the browser's
+  //    "open in new tab" behaviour is preserved.
+  if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey) return;
   const anchor = target.closest("a");
   if (!anchor) return;
   const href = anchor.getAttribute("href");
   if (!href || href.startsWith("#")) return;
-  const resolved = resolveWikiHref(href);
+  const resolved = resolveWikiHref(href, WIKI_BASE_DIR.value);
   if (classifyWorkspacePath(resolved)) {
     event.preventDefault();
     appApi.navigateToWorkspacePath(resolved);

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -55,6 +55,23 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
   return { kind: "file", path: normalized };
 }
 
+/**
+ * Resolve a potentially-relative href against a workspace base directory.
+ * Relative paths (`./`, `../`) are prepended with `baseDir` so that
+ * `classifyWorkspacePath` can normalize the `../` segments.
+ * Bare filenames (no `/`) are also treated as relative to `baseDir`.
+ *
+ * Example: resolveWikiHref("../sources/foo.md", "data/wiki/pages")
+ *        → "data/wiki/pages/../sources/foo.md"
+ *        → (after normalization by classifyWorkspacePath) "data/wiki/sources/foo.md"
+ */
+export function resolveWikiHref(href: string, baseDir: string): string {
+  if (href.startsWith("./") || href.startsWith("../") || !href.includes("/")) {
+    return `${baseDir}/${href}`;
+  }
+  return href;
+}
+
 function stripFragmentAndQuery(str: string): string {
   const hashIdx = str.indexOf("#");
   const queryIdx = str.indexOf("?");

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -66,6 +66,7 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
  *        → (after normalization by classifyWorkspacePath) "data/wiki/sources/foo.md"
  */
 export function resolveWikiHref(href: string, baseDir: string): string {
+  if (isExternalHref(href)) return href;
   if (href.startsWith("./") || href.startsWith("../") || !href.includes("/")) {
     return `${baseDir}/${href}`;
   }

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -109,6 +109,38 @@ describe("classifyWorkspacePath", () => {
     });
   });
 
+  // ── Wiki relative path resolution ─────────────────────────
+  // Wiki pages link to sources/sessions with relative paths like
+  // `../sources/foo.md`. The wiki View prepends `data/wiki/pages/`
+  // before calling classifyWorkspacePath so that `../` segments
+  // resolve correctly against the wiki page's filesystem location.
+
+  describe("wiki relative paths (pre-resolved with data/wiki/pages/ prefix)", () => {
+    it("resolves ../sources/<name>.md to a file", () => {
+      const resolved = "data/wiki/pages/../sources/my-source.md";
+      const result = classifyWorkspacePath(resolved);
+      assert.deepEqual(result, { kind: "file", path: "data/wiki/sources/my-source.md" });
+    });
+
+    it("resolves ../../../conversations/chat/<id>.jsonl to a session", () => {
+      const resolved = "data/wiki/pages/../../../conversations/chat/550e8400-e29b-41d4-a716-446655440000.jsonl";
+      const result = classifyWorkspacePath(resolved);
+      assert.deepEqual(result, { kind: "session", sessionId: "550e8400-e29b-41d4-a716-446655440000" });
+    });
+
+    it("resolves ./other-page.md to a wiki page", () => {
+      const resolved = "data/wiki/pages/./other-page.md";
+      const result = classifyWorkspacePath(resolved);
+      assert.deepEqual(result, { kind: "wiki", slug: "other-page" });
+    });
+
+    it("resolves sibling page reference (no prefix needed)", () => {
+      const resolved = "data/wiki/pages/sibling.md";
+      const result = classifyWorkspacePath(resolved);
+      assert.deepEqual(result, { kind: "wiki", slug: "sibling" });
+    });
+  });
+
   // ── Fragment / query stripping ────────────────────────────
 
   describe("strips fragment and query", () => {

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { classifyWorkspacePath } from "../../../src/utils/path/workspaceLinkRouter.js";
+import { classifyWorkspacePath, resolveWikiHref } from "../../../src/utils/path/workspaceLinkRouter.js";
 
 describe("classifyWorkspacePath", () => {
   // ── Wiki page links ───────────────────────────────────────
@@ -157,6 +157,45 @@ describe("classifyWorkspacePath", () => {
     it("strips both fragment and query", () => {
       const result = classifyWorkspacePath("data/wiki/pages/foo.md?bar=1#baz");
       assert.deepEqual(result, { kind: "wiki", slug: "foo" });
+    });
+  });
+});
+
+describe("resolveWikiHref", () => {
+  const PAGES_BASE = "data/wiki/pages";
+  const WIKI_BASE = "data/wiki";
+
+  describe("relative paths (./ and ../)", () => {
+    it("prepends baseDir for ../ paths", () => {
+      assert.equal(resolveWikiHref("../sources/foo.md", PAGES_BASE), "data/wiki/pages/../sources/foo.md");
+    });
+
+    it("prepends baseDir for ./ paths", () => {
+      assert.equal(resolveWikiHref("./sibling.md", PAGES_BASE), "data/wiki/pages/./sibling.md");
+    });
+
+    it("uses wiki base for log-relative paths", () => {
+      assert.equal(resolveWikiHref("./pages/foo.md", WIKI_BASE), "data/wiki/./pages/foo.md");
+    });
+  });
+
+  describe("bare filenames (no /)", () => {
+    it("treats bare .md filename as relative", () => {
+      assert.equal(resolveWikiHref("sibling.md", PAGES_BASE), "data/wiki/pages/sibling.md");
+    });
+
+    it("treats bare name without extension as relative", () => {
+      assert.equal(resolveWikiHref("config", PAGES_BASE), "data/wiki/pages/config");
+    });
+  });
+
+  describe("absolute workspace paths (contains /)", () => {
+    it("passes through workspace-root-relative paths unchanged", () => {
+      assert.equal(resolveWikiHref("data/wiki/sources/foo.md", PAGES_BASE), "data/wiki/sources/foo.md");
+    });
+
+    it("passes through conversations path unchanged", () => {
+      assert.equal(resolveWikiHref("conversations/chat/abc.jsonl", PAGES_BASE), "conversations/chat/abc.jsonl");
     });
   });
 });

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -189,6 +189,24 @@ describe("resolveWikiHref", () => {
     });
   });
 
+  describe("external schemes (must pass through unchanged)", () => {
+    it("passes through mailto: links", () => {
+      assert.equal(resolveWikiHref("mailto:user@example.com", PAGES_BASE), "mailto:user@example.com");
+    });
+
+    it("passes through tel: links", () => {
+      assert.equal(resolveWikiHref("tel:+819012345678", PAGES_BASE), "tel:+819012345678");
+    });
+
+    it("passes through custom scheme links", () => {
+      assert.equal(resolveWikiHref("slack://channel/general", PAGES_BASE), "slack://channel/general");
+    });
+
+    it("passes through https: links", () => {
+      assert.equal(resolveWikiHref("https://example.com", PAGES_BASE), "https://example.com");
+    });
+  });
+
   describe("absolute workspace paths (contains /)", () => {
     it("passes through workspace-root-relative paths unchanged", () => {
       assert.equal(resolveWikiHref("data/wiki/sources/foo.md", PAGES_BASE), "data/wiki/sources/foo.md");


### PR DESCRIPTION
## Summary

- Wiki ページ内のマークダウンリンク（ソースファイル、セッションログ等）をクリックすると Router の catch-all で `/chat` にリダイレクトされていたバグを修正
- `handleContentClick` にワークスペースパス分類（`classifyWorkspacePath`）を追加し、textResponse View と同じパターンでルーティング
- 相対パス（`../sources/...`）を `data/wiki/pages/` 基準で解決してから分類

## Items to Confirm / Review

- `handleExternalLinkClick` の戻り値を使った early return は textResponse View:171 と同一パターン。変更前は戻り値を捨てていたが、後続処理がなかったため実害なし
- `resolveWikiHref` は wiki 固有の薄い関数。`classifyWorkspacePath` 本体には変更なし

## User Prompt

- Wiki ページの出典セクションにあるソースファイルリンク（`../sources/<slug>.md`）をクリックすると `/chat` にリダイレクトされる問題を修正してほしい
- セッションログリンク（`../../../conversations/chat/<id>.jsonl`）も同様に正しい画面に遷移するようにしてほしい

## 実装詳細

### 原因

Wiki View の `handleContentClick` は `[[wiki リンク]]` と外部 URL のみ処理しており、ワークスペース内部リンクのハンドラがなかった。textResponse View には `classifyWorkspacePath` + `navigateToWorkspacePath` による同等の処理が実装済み。

### 変更内容

| ファイル | 変更 |
|---------|------|
| `src/plugins/wiki/View.vue` | `handleContentClick` にワークスペースパス分類を追加。相対パスを `data/wiki/pages/` 基準で解決する `resolveWikiHref` を追加 |
| `test/utils/path/test_workspaceLinkRouter.ts` | wiki 相対パス解決パターンのテスト 4 件追加 |
| `plans/fix-wiki-internal-link-routing.md` | 修正計画 |

### テスト

- ユニットテスト: 26 件全パス（新規 4 件追加）
- ブラウザ動作確認（Playwright MCP）:
  - ソースリンク → `/files/data/wiki/sources/<slug>.md` に遷移 ✓
  - セッションリンク → `/chat/<session-id>` に遷移 ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki internal link navigation now correctly resolves relative links (e.g., ../sources/file.md, ../../../conversations/chat/<id>, or sibling wiki pages) and routes to workspace content instead of the app catch-all.

* **Tests**
  * Added coverage for relative path resolution and normalization across sources, conversations, and wiki pages.

* **Documentation**
  * Added a design note describing the relative-link handling and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->