### PR TITLE
fix(wiki): route GET /api/wiki?slug=... through buildPageResponse

### DIFF
--- a/e2e/tests/wiki-empty-page.spec.ts
+++ b/e2e/tests/wiki-empty-page.spec.ts
@@ -146,6 +146,8 @@ test.describe("wiki empty page — update button", () => {
 
     const body = (await agentReq).postDataJSON() as { message?: string };
     expect(body.message).toContain("empty-file");
+    expect(body.message).toMatch(/update/i);
+    expect(body.message).toContain("wiki page");
   });
 
   test("update button hidden on page with content", async ({ page }) => {

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -331,9 +331,15 @@ export function buildPageResponseData(args: { action: string; pageName: string; 
   };
 }
 
-async function buildPageResponse(action: string, pageName: string): Promise<WikiResponse> {
-  const filePath = await resolvePagePath(pageName);
-  const content = filePath ? readFileOrEmpty(filePath) : "";
+// Pure-ish seam between `resolvePagePath` + `readFileOrEmpty` (the
+// filesystem I/O) and `buildPageResponseData` (the response shape).
+// Exported so tests can exercise the `exists`/`resolvedTitle`
+// computation without spinning up a real wiki directory — the
+// original regression this PR fixed was precisely this layer
+// conflating `content` with `exists`, so pinning it here is worth
+// the extra indirection.
+export function toPageResponse(args: { action: string; pageName: string; filePath: string | null; content: string }): WikiResponse {
+  const { action, pageName, filePath, content } = args;
   const resolvedTitle = filePath ? path.basename(filePath, ".md") : pageName;
   return buildPageResponseData({
     action,
@@ -342,6 +348,12 @@ async function buildPageResponse(action: string, pageName: string): Promise<Wiki
     content,
     exists: !!filePath,
   });
+}
+
+async function buildPageResponse(action: string, pageName: string): Promise<WikiResponse> {
+  const filePath = await resolvePagePath(pageName);
+  const content = filePath ? readFileOrEmpty(filePath) : "";
+  return toPageResponse({ action, pageName, filePath, content });
 }
 
 function buildLogResponse(action: string): WikiResponse {

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -235,24 +235,7 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
 router.get(API_ROUTES.wiki.base, async (req: Request, res: Response<WikiResponse | ErrorResponse>) => {
   const slug = getOptionalStringQuery(req, "slug");
   if (slug) {
-    const filePath = await resolvePagePath(slug);
-    const content = filePath ? readFileOrEmpty(filePath) : "";
-    const resolvedTitle = filePath ? path.basename(filePath, ".md") : slug;
-    const exists = !!filePath;
-    res.json({
-      data: {
-        action: "page",
-        title: resolvedTitle,
-        content,
-        pageName: resolvedTitle,
-        pageExists: exists,
-        error: content ? undefined : `Page not found: ${slug}`,
-      },
-      message: content ? `Showing page: ${resolvedTitle}` : `Page not found: ${slug}`,
-      title: resolvedTitle,
-      instructions: "The wiki page is now displayed on the canvas.",
-      updating: true,
-    });
+    res.json(await buildPageResponse("page", slug));
   } else {
     const content = readFileOrEmpty(indexFile());
     const pageEntries = parseIndexEntries(content);

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -288,11 +288,14 @@ function buildIndexResponse(action: string): WikiResponse {
   };
 }
 
-async function buildPageResponse(action: string, pageName: string): Promise<WikiResponse> {
-  const filePath = await resolvePagePath(pageName);
-  const content = filePath ? readFileOrEmpty(filePath) : "";
-  const resolvedTitle = filePath ? path.basename(filePath, ".md") : pageName;
-  const exists = !!filePath;
+// Pure branching helper extracted from buildPageResponse so the three
+// states (missing / empty / has-content) can be pinned by unit tests
+// without requiring a real filesystem. The I/O wrapper below supplies
+// `exists`, `content`, and `resolvedTitle` from disk; this function
+// builds the response shape — including the error / message /
+// instructions distinctions that the GET and POST handlers share.
+export function buildPageResponseData(args: { action: string; pageName: string; resolvedTitle: string; content: string; exists: boolean }): WikiResponse {
+  const { action, pageName, resolvedTitle, content, exists } = args;
   const hasContent = !!content;
   // Three states:
   //   1. !exists              → page file is missing entirely.
@@ -304,9 +307,8 @@ async function buildPageResponse(action: string, pageName: string): Promise<Wiki
   // instructions now distinguish missing vs empty so the client and
   // the agent get consistent signals.
   const missing = !exists;
-  const empty = exists && !hasContent;
   const slug = wikiSlugify(pageName);
-  const errorMessage = missing ? `Page not found: ${pageName}` : empty ? `Page is empty: ${pageName}` : undefined;
+  const errorMessage = missing ? `Page not found: ${pageName}` : hasContent ? undefined : `Page is empty: ${pageName}`;
   const statusMessage = hasContent ? `Showing page: ${resolvedTitle}` : missing ? `Page not found: ${pageName}` : `Page exists but is empty: ${resolvedTitle}`;
   const statusInstructions = hasContent
     ? "The wiki page is now displayed on the canvas."
@@ -327,6 +329,19 @@ async function buildPageResponse(action: string, pageName: string): Promise<Wiki
     instructions: statusInstructions,
     updating: true,
   };
+}
+
+async function buildPageResponse(action: string, pageName: string): Promise<WikiResponse> {
+  const filePath = await resolvePagePath(pageName);
+  const content = filePath ? readFileOrEmpty(filePath) : "";
+  const resolvedTitle = filePath ? path.basename(filePath, ".md") : pageName;
+  return buildPageResponseData({
+    action,
+    pageName,
+    resolvedTitle,
+    content,
+    exists: !!filePath,
+  });
 }
 
 function buildLogResponse(action: string): WikiResponse {

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -12,6 +12,7 @@ import {
   formatLintReport,
   parseIndexEntries,
   parseTagsCell,
+  toPageResponse,
   wikiSlugify,
   type WikiPageEntry,
 } from "../../server/api/routes/wiki.js";
@@ -596,5 +597,62 @@ describe("buildPageResponseData", () => {
       exists: false,
     });
     assert.match(response.instructions, /wiki\/pages\/video-generation\.md/);
+  });
+});
+
+// Pin the wrapper layer that sits between resolvePagePath (I/O) and
+// buildPageResponseData (shape). The original bug this PR fixes was
+// exactly this layer conflating `content` with `exists` in the old
+// inline GET handler, so tests here guard against re-introducing that
+// conflation in a future refactor of the wrapper.
+describe("toPageResponse", () => {
+  it("filePath=null → exists:false + resolvedTitle falls back to pageName", () => {
+    const response = toPageResponse({
+      action: "page",
+      pageName: "Viverse",
+      filePath: null,
+      content: "",
+    });
+    assert.equal(response.data.pageExists, false);
+    assert.equal(response.title, "Viverse");
+    assert.equal(response.data.error, "Page not found: Viverse");
+  });
+
+  it("filePath set with empty content → exists:true + empty-state response", () => {
+    // Regression guard for the #678 / #744 bug: filePath present
+    // (page file exists) AND content empty (zero-byte file) must
+    // yield pageExists:true + "Page is empty" — NOT "Page not found".
+    const response = toPageResponse({
+      action: "page",
+      pageName: "empty-file",
+      filePath: "/some/abs/wiki/pages/empty-file.md",
+      content: "",
+    });
+    assert.equal(response.data.pageExists, true);
+    assert.equal(response.data.error, "Page is empty: empty-file");
+    assert.match(response.instructions, /has no content yet/);
+  });
+
+  it("filePath set with content → exists:true + populated response", () => {
+    const response = toPageResponse({
+      action: "page",
+      pageName: "existing",
+      filePath: "/some/abs/wiki/pages/existing.md",
+      content: "# Existing\n\nBody.",
+    });
+    assert.equal(response.data.pageExists, true);
+    assert.equal(response.data.error, undefined);
+    assert.equal(response.data.content, "# Existing\n\nBody.");
+  });
+
+  it("derives resolvedTitle from filePath basename, dropping the .md extension", () => {
+    const response = toPageResponse({
+      action: "page",
+      pageName: "Foo",
+      filePath: "/some/abs/wiki/pages/foo-bar.md",
+      content: "body",
+    });
+    assert.equal(response.title, "foo-bar");
+    assert.equal(response.data.pageName, "foo-bar");
   });
 });

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildPageResponseData,
   buildTableColumnMap,
   extractHashTags,
   extractSlugFromBulletHref,
@@ -513,5 +514,87 @@ describe("findTagDrift", () => {
     const entries = [entry("MyPage", ["a"])];
     const frontmatter = new Map<string, string[]>([["mypage", ["a", "b"]]]);
     assert.equal(findTagDrift(entries, frontmatter).length, 1);
+  });
+});
+
+// Regression pin for #744 / #678: the GET and POST handlers now share
+// buildPageResponseData so the missing-vs-empty-vs-has-content
+// distinction is enforced in one place. These tests assert the three
+// branches directly — without them, a future refactor could collapse
+// empty-but-existing back into "Page not found" and only e2e copy
+// would catch it (or miss it entirely, since e2e mocks return the
+// expected shape regardless of server logic).
+describe("buildPageResponseData", () => {
+  it("missing page → error + not-found instructions + pageExists:false", () => {
+    const response = buildPageResponseData({
+      action: "page",
+      pageName: "NonExistent",
+      resolvedTitle: "NonExistent",
+      content: "",
+      exists: false,
+    });
+    assert.equal(response.data.pageExists, false);
+    assert.equal(response.data.error, "Page not found: NonExistent");
+    assert.equal(response.message, "Page not found: NonExistent");
+    assert.match(response.instructions, /does not exist/);
+    assert.match(response.instructions, /You can create it/);
+  });
+
+  it("empty existing page → page-is-empty error + update instructions + pageExists:true", () => {
+    const response = buildPageResponseData({
+      action: "page",
+      pageName: "empty-file",
+      resolvedTitle: "empty-file",
+      content: "",
+      exists: true,
+    });
+    assert.equal(response.data.pageExists, true);
+    assert.equal(response.data.error, "Page is empty: empty-file");
+    assert.equal(response.message, "Page exists but is empty: empty-file");
+    assert.match(response.instructions, /has no content yet/);
+    assert.match(response.instructions, /Research the topic/);
+  });
+
+  it("populated page → no error + normal instructions + pageExists:true", () => {
+    const response = buildPageResponseData({
+      action: "page",
+      pageName: "existing",
+      resolvedTitle: "Existing",
+      content: "# Existing\n\nThis page has content.",
+      exists: true,
+    });
+    assert.equal(response.data.pageExists, true);
+    assert.equal(response.data.error, undefined);
+    assert.equal(response.message, "Showing page: Existing");
+    assert.match(response.instructions, /displayed on the canvas/);
+    assert.equal(response.data.content, "# Existing\n\nThis page has content.");
+  });
+
+  it("reflects resolved title (fuzzy match) in message, but uses pageName in error", () => {
+    // resolvePagePath is fuzzy: asking for "Foo" can resolve to the
+    // file "foo-bar.md" → resolvedTitle "foo-bar". The error echoes
+    // what the caller asked for (pageName) so they can recognise the
+    // mismatch; message/title use the resolved name.
+    const response = buildPageResponseData({
+      action: "page",
+      pageName: "Foo",
+      resolvedTitle: "foo-bar",
+      content: "",
+      exists: true,
+    });
+    assert.equal(response.data.error, "Page is empty: Foo");
+    assert.equal(response.message, "Page exists but is empty: foo-bar");
+    assert.equal(response.title, "foo-bar");
+  });
+
+  it("slugifies pageName for the filesystem hint in instructions", () => {
+    const response = buildPageResponseData({
+      action: "page",
+      pageName: "Video Generation",
+      resolvedTitle: "Video Generation",
+      content: "",
+      exists: false,
+    });
+    assert.match(response.instructions, /wiki\/pages\/video-generation\.md/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the merged #678. That PR introduced the missing-vs-empty-page distinction on the POST path (via \`buildPageResponse\`), but the GET handler had its own inline copy of the old logic and was missed. On a zero-byte existing page, \`GET /api/wiki?slug=<name>\` still returned \`error: "Page not found"\` despite reporting \`pageExists: true\` — inconsistent with the POST response and broken for the tool-result client code path.

This PR:

- Routes the GET slug branch through the shared \`buildPageResponse\` so both paths return identical shape + branching.
- Adds two e2e assertions that the update-button prompt actually contains "update" + "wiki page" — guards against regressing \`requestUpdatePage\` back to \`requestCreatePage\`.

## Items to Confirm / Review

1. **Was #678 supposed to cover this?** Looking at the diff, the GET branch was never touched by #678's fix — probably the author consolidated only the POST path and the GET was overlooked. Confirming this is the intended scope (single source of truth for page-response building).
2. **e2e assertions** — new assertions on the existing \`clicking update button opens a new chat session\` test. They are cheap (no new page load) and catch a specific past regression.

## User Prompt

> あれ、なんか作業中なのがlocalにのこっている
> ひつようなら commit push
> マージされていると思うから確認して新しくPR

(これらの変更は #678 作業中の stash に残っていた抜け漏れです。#678 merged 済みなので新 PR として分離。)

## Test plan

- [x] \`yarn format\` / \`yarn typecheck\` / \`yarn build\` clean
- [ ] Manual (reviewer): GET \`/api/wiki?slug=<non-existent>\` returns \`error: "Page not found"\` + missing-style \`instructions\`
- [ ] Manual (reviewer): GET \`/api/wiki?slug=<empty-file>\` (zero-byte file) returns \`error: "Page is empty"\` + update-style \`instructions\` (was previously reported as not-found)
- [ ] Manual (reviewer): GET \`/api/wiki?slug=<existing>\` returns content + no \`error\` (no change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki pages now provide clearer error messages distinguishing between missing pages and empty existing pages.
  * Enhanced status messaging and instructions tailored to different page states.

* **Tests**
  * Strengthened e2e test verification for wiki page updates.
  * Added comprehensive test coverage for page response generation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->