### PR TITLE
chore(e2e): run Playwright on dedicated port 45173

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   timeout: 30 * ONE_SECOND_MS,
   retries: 0,
   use: {
-    baseURL: "http://localhost:5173",
+    // E2E runs on a dedicated port so a parallel `yarn dev` on the
+    // default 5173 isn't disturbed by Playwright spinning up (or
+    // reusing) a Vite instance. If you want to hit the e2e server
+    // manually, it's http://localhost:45173 while the test is running.
+    baseURL: "http://localhost:45173",
     headless: true,
   },
   projects: [
@@ -18,8 +22,17 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "yarn dev:client",
-    port: 5173,
+    // `dev:client:e2e` runs `vite --port 45173 --strictPort` so it
+    // never collides with the default `yarn dev` on 5173. The user's
+    // running dev server stays untouched.
+    //
+    // `reuseExistingServer: true` — if a previous test run left a
+    // Vite on 45173 we reuse it. If something else is squatting the
+    // port, `--strictPort` makes Vite fail fast instead of silently
+    // hopping to 5175 and leaving Playwright talking to the wrong
+    // server.
+    command: "yarn dev:client:e2e",
+    port: 45173,
     reuseExistingServer: true,
     timeout: 15 * ONE_SECOND_MS,
     // Inject a fixed bearer token into the dev HTML so tests can

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "predev:debug": "yarn build:packages:dev",
     "dev:debug": "concurrently -n server,client -k \"npm run server:debug\" \"sleep 2 && vite\"",
     "dev:client": "vite",
+    "dev:client:e2e": "vite --port 45173 --strictPort",
     "dev:server": "tsx server/index.ts",
     "server": "tsx server/index.ts",
     "server:debug": "tsx server/index.ts --debug",


### PR DESCRIPTION
## Summary

Playwright's webServer was configured for port 5173 — the same default Vite uses for \`yarn dev\`. In practice interactive dev sessions kept getting disrupted when the agent (or a test run) needed to touch the 5173 server to pick up fresh code. Move Playwright to a dedicated port **45173** so the user's \`yarn dev\` on 5173 is never touched.

## Items to Confirm / Review

- New script \`dev:client:e2e\` → \`vite --port 45173 --strictPort\`. The \`--strictPort\` flag is critical: without it Vite would silently hop to the next free port and Playwright would end up talking to a completely wrong server.
- \`e2e/playwright.config.ts\` — \`baseURL\` + \`webServer.command\` + \`webServer.port\` all updated.
- Port choice: 45173 is deliberately far from Vite's 5173-5179 auto-pick range and outside the common 3000s / 8000s dev-tool range. Unlikely to collide with anything.
- \`reuseExistingServer: true\` is preserved so a persistent e2e Vite across test runs is reused.

## User Prompt

> ccがテストするときに5137のポート使っているプロセスをkillしないように、別ポートでvue(playwright?)を使うようにしてほしい
> 5174も使っている可能性があるので、絶対に使わなそうなのが良い

## Test plan

- [x] \`yarn test:e2e e2e/tests/right-sidebar-toggle.spec.ts\` — 3/3 pass, Vite binds to :45173
- [x] Verified user's dev server on :5173 is unaffected during the run (untouched PID before and after)
- [ ] Run the full \`yarn test:e2e\` in CI to confirm no other test hardcodes \`localhost:5173\` via non-\`baseURL\` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)