### PR TITLE
fix(chat): move session UI into the side-panel when opened (#728 feedback)

### DIFF
--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -112,6 +112,24 @@ test.describe("session-history side-panel toggle", () => {
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
   });
 
+  test("history-btn entrypoint to /history stays reachable while the panel is open", async ({ page }) => {
+    // Regression guard for the first Codex review pass: hiding Row 2
+    // removes the SessionTabBar, which contained the only in-app
+    // link to /history. The panel header now mirrors that button so
+    // a one-click jump to the full-page history view survives.
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await page.getByTestId("session-history-toggle-off").click();
+    await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
+
+    // The button still exists (inside the panel header now) and
+    // navigates to /history when clicked.
+    await expect(page.getByTestId("history-btn")).toBeVisible();
+    await page.getByTestId("history-btn").click();
+    await expect(page).toHaveURL(/\/history(\/|$)/);
+  });
+
   test("side panel is hidden on non-chat pages even when toggled on", async ({ page }) => {
     // Enable the toggle on /chat first so the preference is on.
     await page.goto("/chat");

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -30,10 +30,13 @@ test.describe("session-history side-panel toggle", () => {
     await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
     await expect(page.getByTestId("session-history-toggle-off")).toBeVisible();
 
-    // Click the toggle — panel appears and the session list renders.
+    // Click the toggle — SessionTabBar disappears, panel appears with
+    // its own toggle in the header.
     await page.getByTestId("session-history-toggle-off").click();
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
-    await expect(page.getByTestId("session-history-toggle-on")).toBeVisible();
+    // Only one toggle-on button (in the panel) — the SessionTabBar is
+    // unmounted so its toggle is gone too.
+    await expect(page.getByTestId("session-history-toggle-on")).toHaveCount(1);
 
     const sidePanel = page.getByTestId("session-history-side-panel");
     await expect(sidePanel.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
@@ -88,22 +91,22 @@ test.describe("session-history side-panel toggle", () => {
     await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
   });
 
-  test("opening the side panel hides the 6 top session tabs", async ({ page }) => {
+  test("opening the side panel replaces the SessionTabBar entirely", async ({ page }) => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    // Tabs are visible while the side-panel is off.
+    // SessionTabBar is present with its tabs and toggle when the panel is off.
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
+    await expect(page.getByTestId("session-history-toggle-off")).toBeVisible();
 
-    // Turning the panel on collapses the top tab row — the left
-    // panel takes over that role. The toggle itself stays visible
-    // so the user can close the panel again.
+    // Click the toggle — SessionTabBar unmounts completely; the panel
+    // takes over and carries its own toggle in the header.
     await page.getByTestId("session-history-toggle-off").click();
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeHidden();
-    await expect(page.getByTestId("session-history-toggle-on")).toBeVisible();
+    await expect(page.getByTestId("session-history-toggle-off")).toBeHidden();
 
-    // Toggling off brings the top tabs back.
+    // The in-panel toggle returns to the tabs-on-top layout.
     await page.getByTestId("session-history-toggle-on").click();
     await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -88,6 +88,27 @@ test.describe("session-history side-panel toggle", () => {
     await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
   });
 
+  test("opening the side panel hides the 6 top session tabs", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    // Tabs are visible while the side-panel is off.
+    await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
+
+    // Turning the panel on collapses the top tab row — the left
+    // panel takes over that role. The toggle itself stays visible
+    // so the user can close the panel again.
+    await page.getByTestId("session-history-toggle-off").click();
+    await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
+    await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeHidden();
+    await expect(page.getByTestId("session-history-toggle-on")).toBeVisible();
+
+    // Toggling off brings the top tabs back.
+    await page.getByTestId("session-history-toggle-on").click();
+    await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
+    await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
+  });
+
   test("side panel is hidden on non-chat pages even when toggled on", async ({ page }) => {
     // Enable the toggle on /chat first so the preference is on.
     await page.goto("/chat");

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,22 +61,38 @@
         class="w-80 flex-shrink-0 border-r border-gray-200 bg-white text-gray-900 flex flex-col"
         data-testid="session-history-side-panel"
       >
-        <!-- Panel header carries the controls that used to live in
-             Row 2 (RoleSelector, new-session) plus the toggle that
-             closes the panel. With Row 2 hidden, the canvas column
-             can extend up to the SidebarHeader. -->
-        <div class="flex items-center gap-2 px-2 py-1 border-b border-gray-100">
-          <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
-          <button
-            class="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
-            data-testid="new-session-btn"
-            :title="t('sessionTabBar.newSession')"
-            :aria-label="t('sessionTabBar.newSession')"
-            @click="handleNewSessionClick"
-          >
-            <span class="material-icons text-sm">add</span>
-          </button>
-          <div class="ml-auto">
+        <!-- Panel header. Stacked over two rows because w-80 can't
+             fit RoleSelector (w-56) plus three 28–32px buttons on a
+             single line. Row 1 owns the role picker; Row 2 carries
+             the actions (new session, /history nav, close toggle).
+             When Row 2's SessionTabBar is hidden by sidePanelVisible,
+             these controls are the only session UI on /chat, so
+             none of them can be dropped. -->
+        <div class="border-b border-gray-100">
+          <div class="px-2 py-1">
+            <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
+          </div>
+          <div class="flex items-center gap-1 px-2 pb-1">
+            <button
+              class="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+              data-testid="new-session-btn"
+              :title="t('sessionTabBar.newSession')"
+              :aria-label="t('sessionTabBar.newSession')"
+              @click="handleNewSessionClick"
+            >
+              <span class="material-icons text-sm">add</span>
+            </button>
+            <!-- /history entrypoint + per-session stats. Mirrored from
+                 the hidden Row 2 SessionTabBar so the full-page history
+                 view is still reachable in one click when the side
+                 panel is open. -->
+            <SessionHistoryNavButton
+              class="ml-auto"
+              :active-session-count="activeSessionCount"
+              :unread-count="unreadCount"
+              :history-open="currentPage === 'history'"
+              @toggle-history="handleHistoryClick"
+            />
             <SessionHistoryToggleButton :model-value="showSessionHistory" @update:model-value="setShowSessionHistory" />
           </div>
         </div>
@@ -219,6 +235,7 @@ import RoleSelector from "./components/RoleSelector.vue";
 import SessionTabBar from "./components/SessionTabBar.vue";
 import SuggestionsPanel from "./components/SuggestionsPanel.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
+import SessionHistoryNavButton from "./components/SessionHistoryNavButton.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import SessionHistoryToggleButton from "./components/SessionHistoryToggleButton.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,13 +17,17 @@
           <PluginLauncher :active-tool-name="selectedResult?.toolName ?? null" :active-view-mode="currentPage" @navigate="onPluginNavigate" />
         </div>
       </div>
-      <!-- Row 2: role selector + session tabs. The SessionTabBar
-           disappears entirely when the side-panel takes over — the
-           panel has its own toggle to restore this row. -->
-      <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
+      <!-- Row 2: role selector + session tabs.
+           Hidden when the side-panel is actually on-screen (chat +
+           preference on) — in that "vertical" layout the panel
+           header carries RoleSelector + new-session + toggle, so
+           keeping this row would duplicate controls and steal
+           vertical canvas space. On non-chat pages the panel can't
+           render, so Row 2 stays as the only session UI even when
+           the preference is on. -->
+      <div v-if="!sidePanelVisible" class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
         <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
         <SessionTabBar
-          v-if="!showSessionHistory"
           :sessions="tabSessions"
           :current-session-id="displayedCurrentSessionId"
           :is-chat-page="isChatPage"
@@ -53,15 +57,28 @@
            /chat — the existing `/history` route still owns the full-
            page experience on non-chat contexts. -->
       <div
-        v-if="isChatPage && showSessionHistory"
+        v-if="sidePanelVisible"
         class="w-80 flex-shrink-0 border-r border-gray-200 bg-white text-gray-900 flex flex-col"
         data-testid="session-history-side-panel"
       >
-        <!-- In-panel toggle so the user can close the side-panel
-             without hunting for the tab-bar button. Clicking it
-             returns the UI to the tabs-on-top layout. -->
-        <div class="flex items-center justify-end px-2 py-1 border-b border-gray-100">
-          <SessionHistoryToggleButton :model-value="showSessionHistory" @update:model-value="setShowSessionHistory" />
+        <!-- Panel header carries the controls that used to live in
+             Row 2 (RoleSelector, new-session) plus the toggle that
+             closes the panel. With Row 2 hidden, the canvas column
+             can extend up to the SidebarHeader. -->
+        <div class="flex items-center gap-2 px-2 py-1 border-b border-gray-100">
+          <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
+          <button
+            class="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+            data-testid="new-session-btn"
+            :title="t('sessionTabBar.newSession')"
+            :aria-label="t('sessionTabBar.newSession')"
+            @click="handleNewSessionClick"
+          >
+            <span class="material-icons text-sm">add</span>
+          </button>
+          <div class="ml-auto">
+            <SessionHistoryToggleButton :model-value="showSessionHistory" @update:model-value="setShowSessionHistory" />
+          </div>
         </div>
         <div class="flex-1 min-h-0">
           <SessionHistoryPanel
@@ -403,6 +420,13 @@ const currentPage = computed<PageRouteName | null>(() => {
   const name = route.name;
   return typeof name === "string" && isPageRouteName(name) ? name : null;
 });
+
+// True when the SessionHistoryPanel is actually rendered as the
+// leftmost column. Gates both the panel itself and Row 2 (so the
+// two don't render the session UI twice). On non-chat pages the
+// panel is suppressed even when the preference is on, so Row 2
+// stays visible as the only session UI there.
+const sidePanelVisible = computed(() => isChatPage.value && showSessionHistory.value);
 
 // Refresh the files tree after each agent run so newly written files
 // appear without a manual reload.

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,10 +17,13 @@
           <PluginLauncher :active-tool-name="selectedResult?.toolName ?? null" :active-view-mode="currentPage" @navigate="onPluginNavigate" />
         </div>
       </div>
-      <!-- Row 2: role selector + session tabs -->
+      <!-- Row 2: role selector + session tabs. The SessionTabBar
+           disappears entirely when the side-panel takes over — the
+           panel has its own toggle to restore this row. -->
       <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
         <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
         <SessionTabBar
+          v-if="!showSessionHistory"
           :sessions="tabSessions"
           :current-session-id="displayedCurrentSessionId"
           :is-chat-page="isChatPage"
@@ -51,16 +54,24 @@
            page experience on non-chat contexts. -->
       <div
         v-if="isChatPage && showSessionHistory"
-        class="w-80 flex-shrink-0 border-r border-gray-200 bg-white text-gray-900"
+        class="w-80 flex-shrink-0 border-r border-gray-200 bg-white text-gray-900 flex flex-col"
         data-testid="session-history-side-panel"
       >
-        <SessionHistoryPanel
-          :sessions="mergedSessions"
-          :current-session-id="currentSessionId"
-          :roles="roles"
-          :error-message="historyError"
-          @load-session="handleSessionSelect"
-        />
+        <!-- In-panel toggle so the user can close the side-panel
+             without hunting for the tab-bar button. Clicking it
+             returns the UI to the tabs-on-top layout. -->
+        <div class="flex items-center justify-end px-2 py-1 border-b border-gray-100">
+          <SessionHistoryToggleButton :model-value="showSessionHistory" @update:model-value="setShowSessionHistory" />
+        </div>
+        <div class="flex-1 min-h-0">
+          <SessionHistoryPanel
+            :sessions="mergedSessions"
+            :current-session-id="currentSessionId"
+            :roles="roles"
+            :error-message="historyError"
+            @load-session="handleSessionSelect"
+          />
+        </div>
       </div>
 
       <!-- Sidebar (Single layout only) -->
@@ -192,6 +203,7 @@ import SessionTabBar from "./components/SessionTabBar.vue";
 import SuggestionsPanel from "./components/SuggestionsPanel.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
+import SessionHistoryToggleButton from "./components/SessionHistoryToggleButton.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";
 import PluginLauncher from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";

--- a/src/components/SessionHistoryNavButton.vue
+++ b/src/components/SessionHistoryNavButton.vue
@@ -1,0 +1,48 @@
+<template>
+  <!-- Navigates to the full-page `/history` route. Carries two
+       session-wide status badges so the user can see the aggregate
+       count even from a single-glance control:
+         - active-session count (yellow, top-left)
+         - unread-reply count (red, top-right)
+       Rendered both in SessionTabBar (when Row 2 is showing) and in
+       the side-panel header (when the panel is open and Row 2 is
+       hidden) so the /history entrypoint never disappears from the
+       chat surface. -->
+  <button
+    data-testid="history-btn"
+    class="relative flex-shrink-0 flex items-center justify-center w-7 py-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+    :class="{ 'text-blue-500': historyOpen }"
+    :title="t('sessionTabBar.sessionHistory')"
+    @click="emit('toggleHistory')"
+  >
+    <span class="material-icons text-base">expand_more</span>
+    <span
+      v-if="activeSessionCount > 0"
+      class="absolute -top-0.5 -left-0.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+      :title="t('sessionTabBar.activeSessions', activeSessionCount, { named: { count: activeSessionCount } })"
+      >{{ activeSessionCount }}</span
+    >
+    <span
+      v-if="unreadCount > 0"
+      class="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+      :title="t('sessionTabBar.unreadReplies', unreadCount, { named: { count: unreadCount } })"
+      >{{ unreadCount }}</span
+    >
+  </button>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+
+defineProps<{
+  activeSessionCount: number;
+  unreadCount: number;
+  historyOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggleHistory: [];
+}>();
+</script>

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -45,20 +45,12 @@
         @keydown.enter.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
         @keydown.space.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
       >
-        <div class="flex items-center gap-1 text-xs text-gray-500 mb-1">
-          <!-- Role glyph mirrors SessionTabBar: yellow + slow spin
-               while the agent is running, darker gray when unread,
-               otherwise default. Keeps the two session surfaces
-               visually consistent. -->
-          <span class="material-icons text-xs leading-none" :class="roleIconClass(session)">{{ roleIconFor(session.roleId) }}</span>
+        <div class="flex items-center gap-1.5 text-xs text-gray-500 mb-1">
+          <!-- Shared role + origin glyph: same visual treatment as
+               the SessionTabBar tabs. Role name stays next to it so
+               the panel row still identifies the role in text. -->
+          <SessionRoleIcon :session="session" :roles="roles" size="sm" />
           <span>{{ roleNameFor(session.roleId) }}</span>
-          <span
-            v-if="originOf(session) !== 'human'"
-            class="material-icons text-[10px] ml-0.5"
-            :class="originColor(originOf(session))"
-            :title="originOf(session)"
-            >{{ originIcon(originOf(session)) }}</span
-          >
           <span class="ml-auto flex items-center gap-1.5">
             <span v-if="isSessionRunning(session)" class="flex items-center gap-0.5 text-yellow-600 font-medium">
               <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
@@ -91,7 +83,8 @@ import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, isHistoryFilter, type HistoryFilter } from "../config/historyFilters";
 import { PAGE_ROUTES } from "../router";
 import { formatDate } from "../utils/format/date";
-import { roleIcon, roleName } from "../utils/role/icon";
+import { roleName } from "../utils/role/icon";
+import SessionRoleIcon from "./SessionRoleIcon.vue";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -101,20 +94,6 @@ const router = useRouter();
 // shows every unread-flagged session regardless of origin, matching
 // the user expectation that "unread" is the primary question ("what
 // needs my attention?") rather than an origin sub-filter.
-
-const ORIGIN_ICONS: Record<string, string> = {
-  human: "person",
-  scheduler: "event",
-  skill: "auto_fix_high",
-  bridge: "chat",
-};
-
-const ORIGIN_COLORS: Record<string, string> = {
-  human: "text-gray-400",
-  scheduler: "text-blue-500",
-  skill: "text-purple-500",
-  bridge: "text-green-500",
-};
 
 const props = defineProps<{
   sessions: SessionSummary[];
@@ -162,28 +141,10 @@ function countByOrigin(filterKey: HistoryFilter): number {
   return props.sessions.filter((session) => originOf(session) === filterKey).length;
 }
 
-function originIcon(origin: string): string {
-  return ORIGIN_ICONS[origin] ?? "person";
-}
-
-function originColor(origin: string): string {
-  return ORIGIN_COLORS[origin] ?? "text-gray-400";
-}
-
 // ── Role helpers ────────────────────────────────────────────
 
-function roleIconFor(roleId: string): string {
-  return roleIcon(props.roles, roleId);
-}
 function roleNameFor(roleId: string): string {
   return roleName(props.roles, roleId);
-}
-
-// Mirrors SessionTabBar's icon state: running > unread > default.
-function roleIconClass(session: SessionSummary): string {
-  if (isSessionRunning(session)) return "text-yellow-400 animate-spin [animation-duration:3s]";
-  if (isSessionUnread(session)) return "text-gray-900";
-  return "";
 }
 
 function isSessionRunning(session: SessionSummary): boolean {

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -46,7 +46,11 @@
         @keydown.space.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
       >
         <div class="flex items-center gap-1 text-xs text-gray-500 mb-1">
-          <span class="material-icons text-xs">{{ roleIconFor(session.roleId) }}</span>
+          <!-- Role glyph mirrors SessionTabBar: yellow + slow spin
+               while the agent is running, darker gray when unread,
+               otherwise default. Keeps the two session surfaces
+               visually consistent. -->
+          <span class="material-icons text-xs leading-none" :class="roleIconClass(session)">{{ roleIconFor(session.roleId) }}</span>
           <span>{{ roleNameFor(session.roleId) }}</span>
           <span
             v-if="originOf(session) !== 'human'"
@@ -173,6 +177,13 @@ function roleIconFor(roleId: string): string {
 }
 function roleNameFor(roleId: string): string {
   return roleName(props.roles, roleId);
+}
+
+// Mirrors SessionTabBar's icon state: running > unread > default.
+function roleIconClass(session: SessionSummary): string {
+  if (isSessionRunning(session)) return "text-yellow-400 animate-spin [animation-duration:3s]";
+  if (isSessionUnread(session)) return "text-gray-900";
+  return "";
 }
 
 function isSessionRunning(session: SessionSummary): boolean {

--- a/src/components/SessionRoleIcon.vue
+++ b/src/components/SessionRoleIcon.vue
@@ -1,0 +1,72 @@
+<template>
+  <!-- Shared role + origin glyph used by SessionTabBar and
+       SessionHistoryPanel. Visual rules:
+       - Running → yellow with a slow spin (the one place we keep
+         colour because the state is load-bearing)
+       - Unread (not running) → darker gray so the row reads as
+         "something to look at"
+       - Default → light gray
+       - Origin (scheduler / skill / bridge) → tiny B&W badge on the
+         top-right. Human / unknown origin → no badge. -->
+  <span class="relative shrink-0 inline-flex items-center leading-none">
+    <span class="material-icons leading-none" :class="[iconSizeClass, stateClass, spinClass]">{{ glyph }}</span>
+    <span
+      v-if="originGlyph"
+      role="img"
+      class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
+      :title="originTooltip"
+      :aria-label="originTooltip"
+    >
+      <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph }}</span>
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import type { Role } from "../config/roles";
+import { SESSION_ORIGINS, type SessionSummary } from "../types/session";
+import { roleIcon } from "../utils/role/icon";
+
+const { t } = useI18n();
+
+interface Props {
+  session: SessionSummary;
+  roles: Role[];
+  // `base` matches the SessionTabBar tab glyph; `sm` matches the
+  // compact metadata line in SessionHistoryPanel. Adjust only the
+  // role icon itself — the origin badge stays the same size so it
+  // remains legible at both densities.
+  size?: "base" | "sm";
+}
+
+const props = withDefaults(defineProps<Props>(), { size: "base" });
+
+const iconSizeClass = computed(() => (props.size === "sm" ? "text-sm" : "text-base"));
+
+const stateClass = computed(() => {
+  if (props.session.isRunning) return "text-yellow-400";
+  if (props.session.hasUnread) return "text-gray-900";
+  return "text-gray-400";
+});
+
+const spinClass = computed(() => (props.session.isRunning ? "animate-spin [animation-duration:3s]" : ""));
+
+const glyph = computed(() => roleIcon(props.roles, props.session.roleId));
+
+const originGlyph = computed(() => {
+  const origin = props.session.origin;
+  if (!origin || origin === SESSION_ORIGINS.human) return "";
+  if (origin === SESSION_ORIGINS.scheduler) return "schedule";
+  if (origin === SESSION_ORIGINS.skill) return "build";
+  if (origin === SESSION_ORIGINS.bridge) return "sync_alt";
+  return "";
+});
+
+const originTooltip = computed(() => {
+  const origin = props.session.origin;
+  if (!origin || origin === SESSION_ORIGINS.human) return "";
+  return t(`sessionTabBar.origin.${origin}`);
+});
+</script>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -37,27 +37,12 @@
       </button>
       <div v-else class="flex-1" />
     </template>
-    <button
-      data-testid="history-btn"
-      class="relative flex-shrink-0 flex items-center justify-center w-7 py-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-      :class="{ 'text-blue-500': historyOpen }"
-      :title="t('sessionTabBar.sessionHistory')"
-      @click="emit('toggleHistory')"
-    >
-      <span class="material-icons text-base">expand_more</span>
-      <span
-        v-if="activeSessionCount > 0"
-        class="absolute -top-0.5 -left-0.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
-        :title="t('sessionTabBar.activeSessions', activeSessionCount, { named: { count: activeSessionCount } })"
-        >{{ activeSessionCount }}</span
-      >
-      <span
-        v-if="unreadCount > 0"
-        class="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
-        :title="t('sessionTabBar.unreadReplies', unreadCount, { named: { count: unreadCount } })"
-        >{{ unreadCount }}</span
-      >
-    </button>
+    <SessionHistoryNavButton
+      :active-session-count="activeSessionCount"
+      :unread-count="unreadCount"
+      :history-open="historyOpen"
+      @toggle-history="emit('toggleHistory')"
+    />
     <!-- Session-history side-panel toggle. Distinct from the
          expand_more button above (which navigates to /history) —
          this one opens the SessionHistoryPanel as a standalone left
@@ -71,6 +56,7 @@ import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import { type SessionSummary } from "../types/session";
 import { roleName } from "../utils/role/icon";
+import SessionHistoryNavButton from "./SessionHistoryNavButton.vue";
 import SessionHistoryToggleButton from "./SessionHistoryToggleButton.vue";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -19,27 +19,9 @@
         :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
         @click="emit('loadSession', sessions[i - 1].id)"
       >
-        <!-- Role icon is the primary glyph on every tab. Non-human
-             sessions add a small grey circled origin badge on the
-             top-right (schedule / build / sync_alt) so the origin
-             is still readable without hiding the role. Origin is
-             also prepended to the tab `title` tooltip. -->
-        <span class="relative shrink-0 flex items-center leading-none">
-          <span
-            class="material-icons text-base leading-none"
-            :class="[iconColor(sessions[i - 1]), sessions[i - 1].isRunning ? 'animate-spin [animation-duration:3s]' : '']"
-            >{{ iconGlyph(sessions[i - 1]) }}</span
-          >
-          <span
-            v-if="originGlyph(sessions[i - 1].origin)"
-            role="img"
-            class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
-            :title="originTooltip(sessions[i - 1].origin)"
-            :aria-label="originTooltip(sessions[i - 1].origin)"
-          >
-            <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph(sessions[i - 1].origin) }}</span>
-          </span>
-        </span>
+        <!-- Role + origin glyph. Rendering lives in SessionRoleIcon
+             so the SessionHistoryPanel picks up the same treatment. -->
+        <SessionRoleIcon :session="sessions[i - 1]" :roles="roles" />
         <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
         <!-- Unread dot. Suppressed only when the user is actually
              looking at that chat session — otherwise
@@ -87,9 +69,10 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
-import { SESSION_ORIGINS, type SessionOrigin, type SessionSummary } from "../types/session";
-import { roleIcon, roleName } from "../utils/role/icon";
+import { type SessionSummary } from "../types/session";
+import { roleName } from "../utils/role/icon";
 import SessionHistoryToggleButton from "./SessionHistoryToggleButton.vue";
+import SessionRoleIcon from "./SessionRoleIcon.vue";
 
 const { t } = useI18n();
 
@@ -116,20 +99,6 @@ const emit = defineEmits<{
   "update:showSessionHistory": [value: boolean];
 }>();
 
-// Colour for the tab's main (role) icon. Running always wins
-// (yellow is the "work-in-progress" signal); unread bumps it to
-// gray-900; otherwise inactive gray-400. Origin no longer
-// influences this colour — it's conveyed by the overlay badge.
-function iconColor(session: SessionSummary): string {
-  if (session.isRunning) return "text-yellow-400";
-  if (session.hasUnread) return "text-gray-900";
-  return "text-gray-400";
-}
-
-function iconGlyph(session: SessionSummary): string {
-  return roleIcon(props.roles, session.roleId);
-}
-
 // Short label shown next to the role icon so users can tell
 // sessions apart at a glance. Prefers the indexer-generated
 // `summary` (title-like), falls back to the first user-message
@@ -149,20 +118,5 @@ function tabLabel(session: SessionSummary): string {
 // origin badge's own tooltip so the two don't duplicate.
 function tabTooltip(session: SessionSummary): string {
   return session.summary || session.preview || roleName(props.roles, session.roleId);
-}
-
-// Material-icons glyph for the origin badge overlaid on non-human
-// tabs. Empty string means no badge (human sessions, unknown).
-function originGlyph(origin: SessionOrigin | undefined): string {
-  if (!origin || origin === SESSION_ORIGINS.human) return "";
-  if (origin === SESSION_ORIGINS.scheduler) return "schedule";
-  if (origin === SESSION_ORIGINS.skill) return "build";
-  if (origin === SESSION_ORIGINS.bridge) return "sync_alt";
-  return "";
-}
-
-function originTooltip(origin: SessionOrigin | undefined): string {
-  if (!origin || origin === SESSION_ORIGINS.human) return "";
-  return t(`sessionTabBar.origin.${origin}`);
 }
 </script>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -9,61 +9,52 @@
     >
       <span class="material-icons text-sm">add</span>
     </button>
-    <!-- The 6 session tabs. Hidden when the side-panel
-         (SessionHistoryPanel) is showing on the left — it covers the
-         same sessions in a richer layout, so keeping the tabs here
-         is redundant and just steals horizontal space. The spacer
-         below keeps the right-side buttons (history / toggle)
-         right-aligned while tabs are hidden. -->
-    <template v-if="!showSessionHistory">
-      <template v-for="i in 6" :key="i">
-        <button
-          v-if="sessions[i - 1]"
-          class="relative flex-1 min-w-0 flex items-center justify-start gap-1.5 pl-2 pr-2 py-1 rounded overflow-hidden transition-colors"
-          :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
-          :title="tabTooltip(sessions[i - 1])"
-          :data-testid="`session-tab-${sessions[i - 1].id}`"
-          :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
-          @click="emit('loadSession', sessions[i - 1].id)"
-        >
-          <!-- Role icon is the primary glyph on every tab. Non-human
-               sessions add a small grey circled origin badge on the
-               top-right (schedule / build / sync_alt) so the origin
-               is still readable without hiding the role. Origin is
-               also prepended to the tab `title` tooltip. -->
-          <span class="relative shrink-0 flex items-center leading-none">
-            <span
-              class="material-icons text-base leading-none"
-              :class="[iconColor(sessions[i - 1]), sessions[i - 1].isRunning ? 'animate-spin [animation-duration:3s]' : '']"
-              >{{ iconGlyph(sessions[i - 1]) }}</span
-            >
-            <span
-              v-if="originGlyph(sessions[i - 1].origin)"
-              role="img"
-              class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
-              :title="originTooltip(sessions[i - 1].origin)"
-              :aria-label="originTooltip(sessions[i - 1].origin)"
-            >
-              <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph(sessions[i - 1].origin) }}</span>
-            </span>
-          </span>
-          <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
-          <!-- Unread dot. Suppressed only when the user is actually
-               looking at that chat session — otherwise
-               `currentSessionId` keeps pointing at the last chat
-               even when the user is on /wiki, /files, etc., and the
-               dot would silently disappear on the tab that most
-               needs it. -->
+    <template v-for="i in 6" :key="i">
+      <button
+        v-if="sessions[i - 1]"
+        class="relative flex-1 min-w-0 flex items-center justify-start gap-1.5 pl-2 pr-2 py-1 rounded overflow-hidden transition-colors"
+        :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
+        :title="tabTooltip(sessions[i - 1])"
+        :data-testid="`session-tab-${sessions[i - 1].id}`"
+        :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
+        @click="emit('loadSession', sessions[i - 1].id)"
+      >
+        <!-- Role icon is the primary glyph on every tab. Non-human
+             sessions add a small grey circled origin badge on the
+             top-right (schedule / build / sync_alt) so the origin
+             is still readable without hiding the role. Origin is
+             also prepended to the tab `title` tooltip. -->
+        <span class="relative shrink-0 flex items-center leading-none">
           <span
-            v-if="sessions[i - 1].hasUnread && !(isChatPage && sessions[i - 1].id === currentSessionId)"
-            class="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"
-            :aria-label="t('sessionTabBar.unreadDot')"
-          />
-        </button>
-        <div v-else class="flex-1" />
-      </template>
+            class="material-icons text-base leading-none"
+            :class="[iconColor(sessions[i - 1]), sessions[i - 1].isRunning ? 'animate-spin [animation-duration:3s]' : '']"
+            >{{ iconGlyph(sessions[i - 1]) }}</span
+          >
+          <span
+            v-if="originGlyph(sessions[i - 1].origin)"
+            role="img"
+            class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
+            :title="originTooltip(sessions[i - 1].origin)"
+            :aria-label="originTooltip(sessions[i - 1].origin)"
+          >
+            <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph(sessions[i - 1].origin) }}</span>
+          </span>
+        </span>
+        <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
+        <!-- Unread dot. Suppressed only when the user is actually
+             looking at that chat session — otherwise
+             `currentSessionId` keeps pointing at the last chat
+             even when the user is on /wiki, /files, etc., and the
+             dot would silently disappear on the tab that most
+             needs it. -->
+        <span
+          v-if="sessions[i - 1].hasUnread && !(isChatPage && sessions[i - 1].id === currentSessionId)"
+          class="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"
+          :aria-label="t('sessionTabBar.unreadDot')"
+        />
+      </button>
+      <div v-else class="flex-1" />
     </template>
-    <div v-else class="flex-1" />
     <button
       data-testid="history-btn"
       class="relative flex-shrink-0 flex items-center justify-center w-7 py-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -9,52 +9,61 @@
     >
       <span class="material-icons text-sm">add</span>
     </button>
-    <template v-for="i in 6" :key="i">
-      <button
-        v-if="sessions[i - 1]"
-        class="relative flex-1 min-w-0 flex items-center justify-start gap-1.5 pl-2 pr-2 py-1 rounded overflow-hidden transition-colors"
-        :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
-        :title="tabTooltip(sessions[i - 1])"
-        :data-testid="`session-tab-${sessions[i - 1].id}`"
-        :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
-        @click="emit('loadSession', sessions[i - 1].id)"
-      >
-        <!-- Role icon is the primary glyph on every tab. Non-human
-             sessions add a small grey circled origin badge on the
-             top-right (schedule / build / sync_alt) so the origin
-             is still readable without hiding the role. Origin is
-             also prepended to the tab `title` tooltip. -->
-        <span class="relative shrink-0 flex items-center leading-none">
-          <span
-            class="material-icons text-base leading-none"
-            :class="[iconColor(sessions[i - 1]), sessions[i - 1].isRunning ? 'animate-spin [animation-duration:3s]' : '']"
-            >{{ iconGlyph(sessions[i - 1]) }}</span
-          >
-          <span
-            v-if="originGlyph(sessions[i - 1].origin)"
-            role="img"
-            class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
-            :title="originTooltip(sessions[i - 1].origin)"
-            :aria-label="originTooltip(sessions[i - 1].origin)"
-          >
-            <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph(sessions[i - 1].origin) }}</span>
+    <!-- The 6 session tabs. Hidden when the side-panel
+         (SessionHistoryPanel) is showing on the left — it covers the
+         same sessions in a richer layout, so keeping the tabs here
+         is redundant and just steals horizontal space. The spacer
+         below keeps the right-side buttons (history / toggle)
+         right-aligned while tabs are hidden. -->
+    <template v-if="!showSessionHistory">
+      <template v-for="i in 6" :key="i">
+        <button
+          v-if="sessions[i - 1]"
+          class="relative flex-1 min-w-0 flex items-center justify-start gap-1.5 pl-2 pr-2 py-1 rounded overflow-hidden transition-colors"
+          :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
+          :title="tabTooltip(sessions[i - 1])"
+          :data-testid="`session-tab-${sessions[i - 1].id}`"
+          :aria-current="sessions[i - 1].id === currentSessionId ? 'page' : undefined"
+          @click="emit('loadSession', sessions[i - 1].id)"
+        >
+          <!-- Role icon is the primary glyph on every tab. Non-human
+               sessions add a small grey circled origin badge on the
+               top-right (schedule / build / sync_alt) so the origin
+               is still readable without hiding the role. Origin is
+               also prepended to the tab `title` tooltip. -->
+          <span class="relative shrink-0 flex items-center leading-none">
+            <span
+              class="material-icons text-base leading-none"
+              :class="[iconColor(sessions[i - 1]), sessions[i - 1].isRunning ? 'animate-spin [animation-duration:3s]' : '']"
+              >{{ iconGlyph(sessions[i - 1]) }}</span
+            >
+            <span
+              v-if="originGlyph(sessions[i - 1].origin)"
+              role="img"
+              class="absolute -top-[3px] -right-[5px] w-3.5 h-3.5 rounded-full bg-white ring-1 ring-gray-300 flex items-center justify-center"
+              :title="originTooltip(sessions[i - 1].origin)"
+              :aria-label="originTooltip(sessions[i - 1].origin)"
+            >
+              <span class="material-icons !text-[10px] leading-none text-gray-500" aria-hidden="true">{{ originGlyph(sessions[i - 1].origin) }}</span>
+            </span>
           </span>
-        </span>
-        <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
-        <!-- Unread dot. Suppressed only when the user is actually
-             looking at that chat session — otherwise
-             `currentSessionId` keeps pointing at the last chat
-             even when the user is on /wiki, /files, etc., and the
-             dot would silently disappear on the tab that most
-             needs it. -->
-        <span
-          v-if="sessions[i - 1].hasUnread && !(isChatPage && sessions[i - 1].id === currentSessionId)"
-          class="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"
-          :aria-label="t('sessionTabBar.unreadDot')"
-        />
-      </button>
-      <div v-else class="flex-1" />
+          <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
+          <!-- Unread dot. Suppressed only when the user is actually
+               looking at that chat session — otherwise
+               `currentSessionId` keeps pointing at the last chat
+               even when the user is on /wiki, /files, etc., and the
+               dot would silently disappear on the tab that most
+               needs it. -->
+          <span
+            v-if="sessions[i - 1].hasUnread && !(isChatPage && sessions[i - 1].id === currentSessionId)"
+            class="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"
+            :aria-label="t('sessionTabBar.unreadDot')"
+          />
+        </button>
+        <div v-else class="flex-1" />
+      </template>
     </template>
+    <div v-else class="flex-1" />
     <button
       data-testid="history-btn"
       class="relative flex-shrink-0 flex items-center justify-center w-7 py-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"


### PR DESCRIPTION
## Summary

#728 のレビューフィードバック反映。トグルで **上部タブ表示 ↔ 左側パネル表示** を切り替える "display-position switcher" に作り直し、さらに役割アイコン + origin バッジの描画をバー/パネルで共通コンポーネント化しました。

- パネル OFF: Row 2 = \`[RoleSelector] [SessionTabBar (6 タブ + 新規 + /history + toggle)]\` (従来通り)
- パネル ON (/chat のみ): Row 2 が丸ごと消え、パネルヘッダに \`[RoleSelector] [+新規] [toggle]\` が移動。canvas が上まで広がる
- /chat 以外でパネル ON 設定: パネル自体は非表示、Row 2 は残る(唯一のセッション UI になるため)
- 役割アイコン + origin バッジの描画を \`SessionRoleIcon\` に集約。SessionTabBar と SessionHistoryPanel が同じコンポーネントを使うので見た目が完全一致
- 色は「running = 黄色 + slow spin」だけ残し、origin バッジは B&W の右上オーバーレイに統一(色分けは廃止)

## Items to Confirm / Review

- [ ] \`sidePanelVisible = isChatPage && showSessionHistory\` computed で Row 2 / パネルをガード。/files などでは Row 2 が残るので role 切替・新規作成ができる
- [ ] 新規セッションボタンはパネルヘッダ側にも複製。どちらの状態でも \`new-session-btn\` testid が機能
- [ ] \`SessionRoleIcon\` は \`size\` prop (\`base\` | \`sm\`) でアイコンサイズだけ切り替え。origin バッジは同じサイズなので低密度の行でも判別できる
- [ ] 後回しにした TODO: パネル行を 2 行から 1 行に圧縮(別 PR で)

## User Prompt

> 728のfeedback
> 左側に履歴が開いているときには、上部のsessionタブ（６つ）は不要です。左側の履歴が代わりの役割をします。つまりトグルによって表示位置がかわる。
>
> SessionTabBarのトグルは残す。SessionTabBarを押すと、SessionTabBarが消えて、再度のセッション履歴がでる。セッション履歴にもトグルがありそれを押すと、前の状態に戻る
>
> 新規ページの部分まできえてしまう。たぶんこの状態だとroleのところに新規ページのボタンを移動して、トグルでたて表示になった場合には、サイドメニュー（この場合は、セッションヒストリー単体か、それ＋チャットヒストリーのところの上部にロール＋newページぼたんがでて、canvasは上まで行くようなレイアウトになる。。と大改装？）
>
> [小さい修正案 A / 大改装案 B を提示 → user: "B"]
>
> 左側の履歴でも、アイコンの表示は上部のsessionタブに合わせて、動作中のものは回転すべきです。星が黄色くなって回転するのとかだよね
>
> [レビュー指摘を共有]
> 1. 2行ではなく1行で良いと思います  ← 別 PR で対応
> 2. Started by bridge もsessionタブに合わせます(白黒で、アイコンの斜め右上に小さく)
> 3. よほど重要なもの以外、色は使わないでください。  ← #2 に内包
>
> 2 は \`General[chat絵文字]\` の部分。デザインをバーとパネルで統一、できればコンポーネント化(アイコン含め)。3 は 2 に含まれる。1 は後で。

## Implementation

- \`src/App.vue\`
  - Row 2 全体を \`v-if=\"!sidePanelVisible\"\` で gate
  - サイドパネルコンテナを flex column 化してヘッダ行を追加、\`RoleSelector\` + 新規ボタン + \`SessionHistoryToggleButton\` を配置
  - \`sidePanelVisible\` computed を新設 (\`isChatPage && showSessionHistory\`)
- \`src/components/SessionRoleIcon.vue\` (新規)
  - 役割アイコン + origin バッジを描画する共通コンポーネント
  - \`size\` prop: \`base\` (タブ) / \`sm\` (パネル)
  - 色: running=黄色+spin / unread=gray-900 / else=gray-400、origin バッジは B&W 固定
- \`src/components/SessionTabBar.vue\`: インラインで描画していた glyph + badge ブロックを \`<SessionRoleIcon />\` に置換。dead code になった \`iconColor\` / \`iconGlyph\` / \`originGlyph\` / \`originTooltip\` を削除
- \`src/components/SessionHistoryPanel.vue\`: 同じ置換 (\`size=\"sm\"\`)。\`ORIGIN_ICONS\` / \`ORIGIN_COLORS\` / \`originIcon\` / \`originColor\` / \`roleIconFor\` / \`roleIconClass\` を削除
- \`e2e/tests/session-history-side-panel.spec.ts\`: 既存 3 テストを新前提に合わせて調整 + 「opening the side panel replaces the SessionTabBar entirely」シナリオを追加

## Verification

- \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` — green (pre-existing v-html warnings 4 件のみ)
- \`yarn test:e2e -- --grep session-history\` — 6/6 green (dedicated port 45173)
- レイアウト切替挙動 (B 案) はユーザが実機で動作確認済み。アイコン統一コミット (\`c6a07dba\`) 以降は未確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reorganized session history side panel with controls grouped in a dedicated header section.
  * Added activity status indicators displaying active and unread session counts.
  * Enhanced role icons now display origin badges for non-human sessions.

* **Tests**
  * Updated end-to-end tests for session history side panel visibility and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->