### PR TITLE
refactor(server): use shortId() for tmp-file suffix in writeFileAtomic (#723)

### DIFF
--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -8,15 +8,16 @@
 
 import { mkdirSync, promises, renameSync, unlinkSync, writeFileSync } from "fs";
 import path from "path";
-import { randomUUID } from "crypto";
+import { shortId } from "../id.js";
 
 export interface WriteAtomicOptions {
   /** File mode for the final file (e.g. `0o600` for secrets). */
   mode?: number;
   /**
-   * If true, append a randomUUID to the tmp filename to avoid
-   * collisions at the OS level when multiple writers target the same
-   * final path concurrently (e.g. chat-index has this concern).
+   * If true, append a short opaque id (`shortId()`) to the tmp
+   * filename to avoid collisions at the OS level when multiple
+   * writers target the same final path concurrently (e.g.
+   * chat-index has this concern).
    * Default false — a single `${path}.tmp` is fine for most callers.
    */
   uniqueTmp?: boolean;
@@ -89,7 +90,7 @@ function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
  * crashed partial write can't wedge the next try.
  */
 export async function writeFileAtomic(filePath: string, content: string, opts: WriteAtomicOptions = {}): Promise<void> {
-  const tmp = opts.uniqueTmp ? `${filePath}.${randomUUID()}.tmp` : `${filePath}.tmp`;
+  const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   await promises.mkdir(path.dirname(filePath), { recursive: true });
   try {
     await promises.writeFile(tmp, content, {
@@ -109,7 +110,7 @@ export async function writeFileAtomic(filePath: string, content: string, opts: W
  * Same contract as `writeFileAtomic` but blocking.
  */
 export function writeFileAtomicSync(filePath: string, content: string, opts: WriteAtomicOptions = {}): void {
-  const tmp = opts.uniqueTmp ? `${filePath}.${randomUUID()}.tmp` : `${filePath}.tmp`;
+  const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   mkdirSync(path.dirname(filePath), { recursive: true });
   try {
     writeFileSync(tmp, content, { encoding: "utf-8", mode: opts.mode });


### PR DESCRIPTION
## Summary

Last direct \`randomUUID()\` call left inside \`server/*\` — migrate to \`shortId()\` from \`server/utils/id.ts\`. After this, no \`randomUUID()\` / \`crypto.randomUUID()\` direct call remains in \`server/\` outside \`utils/id.ts\` itself.

## Items to Confirm / Review

- \`writeFileAtomic\` / \`writeFileAtomicSync\` tmp path now uses \`shortId()\` (16 hex chars) instead of \`randomUUID()\` (36 chars). 64 bits of entropy is ample for filename collisions — plus a slightly shorter tmp path on disk.
- \`packages/chat-service/src/atomic-write.ts\` still uses \`randomUUID()\` directly. That's a standalone npm package and can't import from \`server/utils/\` — left as-is, out of scope.
- 9/9 existing \`test_atomic.ts\` tests pass unchanged.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/723 残課題ある？PRみて確認

Verified the merged #736 (server) + #741 (client/relay) migrations. Found **one** straggler in \`atomic.ts\` that those PRs didn't catch — addressed here. That's the last remaining \`randomUUID()\` direct call on the server side.

## Test plan

- [x] \`yarn typecheck:server\` — clean
- [x] \`npx tsx --test test/utils/files/test_atomic.ts\` — 9/9 pass
- [ ] Full CI run

Refs #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)