### PR TITLE
fix(settings): recompute activeTab when geminiAvailable flips (#717)

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -379,4 +379,28 @@ watch(
   },
   { immediate: true },
 );
+
+// `geminiAvailable` can flip while the modal is already open — the
+// `/api/health` poll in `useHealth` recovers from a transient failure
+// asynchronously. Without this watcher, a user who opened the modal
+// during the failure stays on the `"gemini"` tab even after the tab
+// button disappears (v-if="!geminiAvailable") — leaving them on an
+// empty view until they manually click another tab. Hop to `"tools"`
+// as soon as Gemini recovers; mirror the inverse for the (much rarer)
+// case where Gemini goes away while the modal is open on a
+// non-gemini tab.
+watch(
+  () => props.geminiAvailable,
+  (available) => {
+    if (!props.open) return;
+    if (available && activeTab.value === "gemini") {
+      activeTab.value = "tools";
+    } else if (!available && activeTab.value !== "gemini" && activeTab.value === "tools") {
+      // Only bounce to the warning tab if the user hasn't navigated
+      // away from the default landing tab. Respecting an explicit
+      // pick on dirs / mcp / refs avoids yanking them mid-edit.
+      activeTab.value = "gemini";
+    }
+  },
+);
 </script>


### PR DESCRIPTION
## Summary

Address [chatgpt-codex-connector P2 comment](https://github.com/receptron/mulmoclaude/pull/717#discussion_r...) on PR #717. \`activeTab\` was seeded only in the \`watch(() => props.open)\` block, so a \`geminiAvailable\` flip via the \`/api/health\` poll after the modal opened would strand the user on an empty \`\"gemini\"\` tab (the button itself v-if'd away, but \`activeTab\` stayed on it).

## Items to Confirm / Review

- **Reproduction**: open Settings during a Gemini-unavailable window → modal lands on the gemini warning tab. Wait for \`/api/health\` to report \`geminiAvailable=true\`. Before this fix, \`activeTab\` stays \`\"gemini\"\` and the tab content vanishes (button v-if'd) → blank space until the user clicks away. After: flips to \`\"tools\"\` automatically.
- **Reverse direction**: if Gemini goes missing while the modal is open on \`\"tools\"\`, the watcher hops to \`\"gemini\"\` (landing default). Explicit picks on \`mcp\` / \`dirs\` / \`refs\` are preserved — we don't want to yank someone mid-edit on an unrelated tab.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/723 (context check) → daily refactoring sweep →
> それぞれわけてPRのみで。

## Test plan

- [x] \`yarn typecheck:vue\` — clean
- [x] \`yarn lint\` — no new warnings
- [ ] Manual: kill Gemini env var, open Settings, bring it back, verify tab flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings modal now automatically adjusts the active tab when feature availability changes while the modal is open, ensuring users don't remain on unavailable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->