### PR TITLE
fix(a11y): surface missing-Gemini-key state in settings button label (#717)

### DIFF
--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -25,8 +25,8 @@
       <button
         class="relative text-gray-400 hover:text-gray-700"
         data-testid="settings-btn"
-        :title="t('sidebarHeader.settings')"
-        :aria-label="t('sidebarHeader.settings')"
+        :title="settingsLabel"
+        :aria-label="settingsLabel"
         @click="emit('openSettings')"
       >
         <span class="material-icons">settings</span>
@@ -52,7 +52,7 @@ import logoUrl from "../assets/mulmo_bw.png";
 
 const { t } = useI18n();
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     sandboxEnabled: boolean;
     geminiAvailable?: boolean;
@@ -67,6 +67,13 @@ const emit = defineEmits<{
   openSettings: [];
   home: [];
 }>();
+
+// Settings button accessible name has to convey the `!` badge's
+// meaning (missing API key) to screen-reader users — the badge
+// itself is decorative (aria-hidden), so without this the a11y
+// tree just announces "Settings" and the whole point of the
+// attention signal is lost.
+const settingsLabel = computed(() => (props.geminiAvailable ? t("sidebarHeader.settings") : t("sidebarHeader.settingsGeminiMissing")));
 
 const lockPopupOpen = ref(false);
 const lockPopup = ref<{

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -65,6 +65,7 @@ const deMessages = {
     home: "Zum neuesten Chat",
     toolCallHistory: "Tool-Aufrufverlauf",
     settings: "Einstellungen",
+    settingsGeminiMissing: "Einstellungen — Gemini-API-Schlüssel fehlt",
   },
   rightSidebar: {
     toggleSystemPrompt: "System-Prompt umschalten",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -87,6 +87,7 @@ const enMessages = {
     home: "Go to latest chat",
     toolCallHistory: "Tool call history",
     settings: "Settings",
+    settingsGeminiMissing: "Settings — Gemini API key missing",
   },
   rightSidebar: {
     toggleSystemPrompt: "Toggle system prompt",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -70,6 +70,7 @@ const esMessages = {
     home: "Ir al chat más reciente",
     toolCallHistory: "Historial de llamadas a herramientas",
     settings: "Ajustes",
+    settingsGeminiMissing: "Ajustes — Falta la clave API de Gemini",
   },
   rightSidebar: {
     toggleSystemPrompt: "Alternar system prompt",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -65,6 +65,7 @@ const frMessages = {
     home: "Aller à la dernière conversation",
     toolCallHistory: "Historique des appels d'outils",
     settings: "Paramètres",
+    settingsGeminiMissing: "Paramètres — Clé API Gemini manquante",
   },
   rightSidebar: {
     toggleSystemPrompt: "Basculer le system prompt",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -72,6 +72,7 @@ const jaMessages = {
     home: "最新のチャットに移動",
     toolCallHistory: "ツール呼び出し履歴",
     settings: "設定",
+    settingsGeminiMissing: "設定 — Gemini API キー未設定",
   },
   rightSidebar: {
     toggleSystemPrompt: "システムプロンプトの表示切替",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -72,6 +72,7 @@ const koMessages = {
     home: "최신 채팅으로 이동",
     toolCallHistory: "도구 호출 기록",
     settings: "설정",
+    settingsGeminiMissing: "설정 — Gemini API 키 없음",
   },
   rightSidebar: {
     toggleSystemPrompt: "시스템 프롬프트 토글",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -65,6 +65,7 @@ const ptBRMessages = {
     home: "Ir para o chat mais recente",
     toolCallHistory: "Histórico de chamadas de ferramentas",
     settings: "Configurações",
+    settingsGeminiMissing: "Configurações — Chave da API Gemini ausente",
   },
   rightSidebar: {
     toggleSystemPrompt: "Alternar system prompt",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -70,6 +70,7 @@ const zhMessages = {
     home: "前往最新对话",
     toolCallHistory: "工具调用历史",
     settings: "设置",
+    settingsGeminiMissing: "设置 — 缺少 Gemini API 密钥",
   },
   rightSidebar: {
     toggleSystemPrompt: "切换系统提示词",


### PR DESCRIPTION
## Summary

Address CodeRabbit review on PR #717. The yellow \`!\` badge on the Settings button is \`aria-hidden\` (purely decorative CSS \`::before\`), so the button's accessible name stayed "Settings" regardless — screen-reader users never learned the badge was signalling a missing API key.

Thread \`geminiAvailable\` into a computed \`settingsLabel\` and bind it to both \`title\` and \`aria-label\`:
- available → "Settings" (unchanged)
- missing   → "Settings — Gemini API key missing" + 7 other locales

Badge stays \`aria-hidden\` — the information now lives in the button's accessible name, so no double-announcement.

## Items to Confirm / Review

- **New i18n key** \`sidebarHeader.settingsGeminiMissing\` added to all 8 locales (en / ja / ko / zh / es / pt-BR / fr / de). Wording kept parallel to the existing \`sidebarHeader.settings\` ("Settings").
- **Hover tooltip** also benefits — mouse users on hover see "Settings — Gemini API key missing" as a courtesy.
- **Computed source** \`geminiAvailable\` comes from \`useHealth\` via props, already reactive — so the label flips as soon as the \`/api/health\` poll updates.

## User Prompt

> それぞれわけてPRのみで。 (splitting daily refactoring sweep findings into per-item PRs)

## Test plan

- [x] \`yarn typecheck:vue\` — clean
- [x] \`yarn lint\` — no new warnings
- [ ] Screen-reader check: with Gemini unavailable, the settings button should announce "Settings — Gemini API key missing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)