### PR TITLE
fix(stack-view): pull empty state out of scroll container (#701)

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -18,8 +18,13 @@
         <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
       </div>
     </div>
-    <div ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
-      <div v-if="toolResults.length === 0" class="flex items-center justify-center h-full text-gray-400 text-sm">{{ t("common.noResultsYet") }}</div>
+    <!-- Empty state pulled out of the scroll container so `h-full` +
+         the container's `pb-4` padding can't combine into a stray
+         scrollbar. A sibling `flex-1` slot centers cleanly. -->
+    <div v-if="toolResults.length === 0" class="flex-1 flex items-center justify-center text-gray-400 text-sm" data-testid="stack-empty">
+      {{ t("common.noResultsYet") }}
+    </div>
+    <div v-else ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
       <div
         v-for="result in toolResults"
         :key="result.uuid"


### PR DESCRIPTION
## Summary

Address CodeRabbit review on PR #701. The session-role header added in that PR is a sibling above the scroll container; the empty-state \`"No results yet"\` sat inside the scroll container with \`h-full\`. Combined with the container's \`pb-4\` padding, the computed child box exceeded the usable area → faint scrollbar + off-center empty message.

Move the empty state out of the scroll container. Both are now siblings inside the outer column layout:

\`\`\`
<div class="h-full flex flex-col">
  <div class="shrink-0 ...">role header</div>
  <div v-if="empty" class="flex-1 ...">No results yet</div>
  <div v-else ref="containerRef" class="flex-1 min-h-0 overflow-y-auto ...">tool results...</div>
</div>
\`\`\`

## Items to Confirm / Review

- **Scroll container only mounts when there are results** (\`v-else\` guard) — means \`ref="containerRef"\` and auto-scroll setup skip the no-results case, but nothing else depends on the ref existing before results arrive.
- **ToolResultsPanel.vue was mentioned alongside** in the same CodeRabbit note, but it doesn't actually render an empty-state placeholder. Nothing to fix there.

## Excluded

- **PR C (codex P2 on role-based Gemini warning gating)** was already addressed by commit \`594ce9f "fix(ui): always show Gemini API key warning when key is missing"\` — the entire \`needsGeminiForRole\` path got removed. Not re-raising.

## User Prompt

> それぞれわけてPRのみで。

## Test plan

- [x] \`yarn typecheck:vue\` — clean
- [x] \`yarn test:e2e --grep stack\` — 3/3 pass (existing stack-view tests unaffected)
- [ ] Manual: open a brand-new chat session, verify no scrollbar + message centered
- [ ] Manual: populate the session, verify scroll behaviour still works + header layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)