### PR TITLE
refactor(ui): session-history toolbar icons + expand mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mammoth": "^1.12.0",
     "marked": "^18.0.2",
     "material-icons": "^1.13.14",
+    "material-symbols": "^0.44.4",
     "mulmocast": "^2.6.8",
     "node-pty": "^1.1.0",
     "puppeteer": "^24.42.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,7 +53,8 @@
            owns the full-page experience. -->
       <div
         v-if="sidePanelVisible"
-        class="w-72 flex-shrink-0 border-r border-gray-200 bg-white text-gray-900 flex flex-col"
+        class="border-r border-gray-200 bg-white text-gray-900 flex flex-col min-w-0 overflow-hidden"
+        :class="sidePanelExpanded ? 'flex-1' : 'w-72 flex-shrink-0'"
         data-testid="session-history-side-panel"
       >
         <!-- Panel header. Stacked over two rows because w-72 can't
@@ -90,7 +91,8 @@
               :history-open="currentPage === 'history'"
               @toggle-history="handleHistoryClick"
             />
-            <SessionHistoryToggleButton :model-value="sidePanelVisible" @update:model-value="setSidePanelVisible" />
+            <SessionHistoryExpandButton :model-value="sidePanelExpanded" @update:model-value="(value: boolean) => (sidePanelExpanded = value)" />
+            <SessionHistoryToggleButton :model-value="sidePanelVisible" @update:model-value="setSidePanelVisibleAndCollapse" />
           </div>
         </div>
         <div class="flex-1 min-h-0">
@@ -105,7 +107,7 @@
       </div>
 
       <!-- Sidebar (Single layout only) -->
-      <div v-if="!isStackLayout" class="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col bg-white text-gray-900 relative">
+      <div v-if="!isStackLayout && !sidePanelExpanded" class="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col bg-white text-gray-900 relative">
         <!-- Tool result previews -->
         <ToolResultsPanel
           ref="toolResultsPanelRef"
@@ -133,7 +135,7 @@
       </div>
 
       <!-- Canvas column -->
-      <div class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden relative">
+      <div v-if="!sidePanelExpanded" class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden relative">
         <div ref="canvasRef" class="flex-1 overflow-hidden outline-none min-h-0" tabindex="0" @mousedown="activePane = 'main'" @keydown="handleCanvasKeydown">
           <!-- Chat page: single or stack layout -->
           <template v-if="isChatPage && layoutMode === 'single'">
@@ -196,7 +198,7 @@
            page — system prompt / tools / tool-call history are all
            agent-context and have no meaning on plugin views. -->
       <RightSidebar
-        v-if="showRightSidebar && isChatPage"
+        v-if="showRightSidebar && isChatPage && !sidePanelExpanded"
         ref="rightSidebarRef"
         :tool-call-history="toolCallHistory"
         :available-tools="availableTools"
@@ -232,6 +234,7 @@ import RoleSelector from "./components/RoleSelector.vue";
 import SessionTabBar from "./components/SessionTabBar.vue";
 import SuggestionsPanel from "./components/SuggestionsPanel.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
+import SessionHistoryExpandButton from "./components/SessionHistoryExpandButton.vue";
 import SessionHistoryNavButton from "./components/SessionHistoryNavButton.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import SessionHistoryToggleButton from "./components/SessionHistoryToggleButton.vue";
@@ -424,6 +427,14 @@ const showSettings = ref(false);
 
 const { layoutMode, setLayoutMode, toggleLayoutMode } = useLayoutMode();
 const { sidePanelVisible, setSidePanelVisible } = useSidePanelVisible();
+// Transient full-width mode for the session-history side panel.
+// Not persisted: reopening the panel should always start collapsed.
+const sidePanelExpanded = ref(false);
+
+function setSidePanelVisibleAndCollapse(value: boolean): void {
+  setSidePanelVisible(value);
+  if (!value) sidePanelExpanded.value = false;
+}
 const { preHistoryUrl } = useHistoryEntrance();
 
 // Current page derives from the route. The chat page has a layout
@@ -494,10 +505,12 @@ const { isStackLayout, displayedCurrentSessionId } = useViewLayout({
 });
 
 function handleSessionSelect(sessionId: string): void {
+  sidePanelExpanded.value = false;
   loadSession(sessionId);
 }
 
 function handleNewSessionClick(): void {
+  sidePanelExpanded.value = false;
   createNewSession();
 }
 

--- a/src/components/SessionHistoryExpandButton.vue
+++ b/src/components/SessionHistoryExpandButton.vue
@@ -1,0 +1,26 @@
+<template>
+  <button
+    class="flex items-center justify-center w-8 h-8 rounded text-gray-400 hover:text-gray-700 transition-colors hover:bg-gray-100"
+    :title="modelValue ? t('sessionHistoryExpand.collapseTooltip') : t('sessionHistoryExpand.expandTooltip')"
+    :aria-label="modelValue ? t('sessionHistoryExpand.collapse') : t('sessionHistoryExpand.expand')"
+    :aria-pressed="modelValue"
+    :data-testid="`session-history-expand-${modelValue ? 'on' : 'off'}`"
+    @click="emit('update:modelValue', !modelValue)"
+  >
+    <span class="material-icons text-lg" aria-hidden="true">{{ modelValue ? "close_fullscreen" : "open_in_full" }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+
+defineProps<{
+  modelValue: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: boolean];
+}>();
+</script>

--- a/src/components/SessionHistoryToggleButton.vue
+++ b/src/components/SessionHistoryToggleButton.vue
@@ -1,16 +1,13 @@
 <template>
   <button
-    class="flex items-center justify-center w-8 h-8 rounded transition-colors hover:bg-gray-100"
-    :class="modelValue ? 'text-blue-500' : 'text-gray-400 hover:text-gray-700'"
+    class="flex items-center justify-center w-8 h-8 rounded text-gray-400 hover:text-gray-700 transition-colors hover:bg-gray-100"
     :title="modelValue ? t('sessionHistoryToggle.hideTooltip') : t('sessionHistoryToggle.showTooltip')"
     :aria-label="modelValue ? t('sessionHistoryToggle.hide') : t('sessionHistoryToggle.show')"
     :aria-pressed="modelValue"
     :data-testid="`session-history-toggle-${modelValue ? 'on' : 'off'}`"
     @click="emit('update:modelValue', !modelValue)"
   >
-    <!-- `view_sidebar` visually communicates "side panel", matching
-         the on/off semantics of this toggle. -->
-    <span class="material-icons text-lg" aria-hidden="true">view_sidebar</span>
+    <span class="material-symbols-outlined text-lg" aria-hidden="true">{{ modelValue ? "dock_to_right" : "toolbar" }}</span>
   </button>
 </template>
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -151,6 +151,12 @@ const deMessages = {
     show: "Sitzungsverlauf anzeigen",
     hide: "Sitzungsverlauf ausblenden",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "Sitzungsverlauf-Panel auf volle Breite erweitern",
+    collapseTooltip: "Sitzungsverlauf-Panel verkleinern",
+    expand: "Sitzungsverlauf erweitern",
+    collapse: "Sitzungsverlauf verkleinern",
+  },
   settingsWorkspaceDirs: {
     explanation:
       "Benutzerdefinierte Verzeichnisse zur Organisation von Dateien unter {dataDir} und {artifactsDir}. Claude nutzt sie, um das Speichern von Dateien zu steuern.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -173,6 +173,12 @@ const enMessages = {
     show: "Show session history",
     hide: "Hide session history",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "Expand session history panel to full width",
+    collapseTooltip: "Collapse session history panel",
+    expand: "Expand session history",
+    collapse: "Collapse session history",
+  },
   settingsWorkspaceDirs: {
     explanation: "Custom directories for organizing files under {dataDir} and {artifactsDir}. Claude uses these to route file saves.",
     noEntries: "No custom directories configured.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -157,6 +157,12 @@ const esMessages = {
     show: "Mostrar historial de sesiones",
     hide: "Ocultar historial de sesiones",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "Expandir el panel de historial de sesiones a ancho completo",
+    collapseTooltip: "Contraer el panel de historial de sesiones",
+    expand: "Expandir historial de sesiones",
+    collapse: "Contraer historial de sesiones",
+  },
   settingsWorkspaceDirs: {
     explanation:
       "Directorios personalizados para organizar archivos dentro de {dataDir} y {artifactsDir}. Claude los utiliza para decidir dónde guardar los archivos.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -151,6 +151,12 @@ const frMessages = {
     show: "Afficher l'historique des sessions",
     hide: "Masquer l'historique des sessions",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "Agrandir le panneau d'historique des sessions en pleine largeur",
+    collapseTooltip: "Réduire le panneau d'historique des sessions",
+    expand: "Agrandir l'historique des sessions",
+    collapse: "Réduire l'historique des sessions",
+  },
   settingsWorkspaceDirs: {
     explanation:
       "Répertoires personnalisés pour organiser les fichiers sous {dataDir} et {artifactsDir}. Claude s'en sert pour router l'enregistrement des fichiers.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -156,6 +156,12 @@ const jaMessages = {
     show: "セッション履歴を表示",
     hide: "セッション履歴を閉じる",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "セッション履歴パネルを全画面表示",
+    collapseTooltip: "セッション履歴パネルを元のサイズに戻す",
+    expand: "セッション履歴を拡大",
+    collapse: "セッション履歴を縮小",
+  },
   settingsWorkspaceDirs: {
     explanation: "{dataDir} および {artifactsDir} 配下でファイルを整理するためのカスタムディレクトリ。Claude がファイル保存先を振り分けるために使用します。",
     noEntries: "カスタムディレクトリは未設定です。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -157,6 +157,12 @@ const koMessages = {
     show: "세션 기록 표시",
     hide: "세션 기록 숨기기",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "세션 기록 패널을 전체 너비로 확장",
+    collapseTooltip: "세션 기록 패널 축소",
+    expand: "세션 기록 확장",
+    collapse: "세션 기록 축소",
+  },
   settingsWorkspaceDirs: {
     explanation: "{dataDir} 와 {artifactsDir} 아래에서 파일을 정리하기 위한 커스텀 디렉터리입니다. Claude 는 이를 참조해 파일 저장 위치를 결정합니다.",
     noEntries: "설정된 커스텀 디렉터리가 없습니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -151,6 +151,12 @@ const ptBRMessages = {
     show: "Mostrar histórico de sessões",
     hide: "Ocultar histórico de sessões",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "Expandir o painel de histórico de sessões para largura total",
+    collapseTooltip: "Recolher o painel de histórico de sessões",
+    expand: "Expandir histórico de sessões",
+    collapse: "Recolher histórico de sessões",
+  },
   settingsWorkspaceDirs: {
     explanation: "Diretórios personalizados para organizar arquivos em {dataDir} e {artifactsDir}. O Claude os usa para decidir onde salvar arquivos.",
     noEntries: "Nenhum diretório personalizado configurado.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -154,6 +154,12 @@ const zhMessages = {
     show: "显示会话历史",
     hide: "隐藏会话历史",
   },
+  sessionHistoryExpand: {
+    expandTooltip: "将会话历史面板展开为全宽",
+    collapseTooltip: "收起会话历史面板",
+    expand: "展开会话历史",
+    collapse: "收起会话历史",
+  },
   settingsWorkspaceDirs: {
     explanation: "自定义用于在 {dataDir} 和 {artifactsDir} 下组织文件的目录。Claude 会参照这些来决定文件保存路径。",
     noEntries: "未配置自定义目录。",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { setAuthToken } from "./utils/api";
 import { readAuthTokenFromMeta } from "./utils/dom/authTokenMeta";
 import "./index.css";
 import "material-icons/iconfont/material-icons.css";
+import "material-symbols/outlined.css";
 
 import.meta.glob(["../node_modules/@gui-chat-plugin/*/dist/style.css", "../node_modules/@mulmochat-plugin/*/dist/style.css"], { eager: true });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,6 +5840,11 @@ material-icons@^1.13.14:
   resolved "https://registry.yarnpkg.com/material-icons/-/material-icons-1.13.14.tgz#65ae8693550b9f789036bd4cf29e775f1bd389ed"
   integrity sha512-kZOfc7xCC0rAT8Q3DQixYAeT+tBqZnxkseQtp2bxBxz7q5pMAC+wmit7vJn1g/l7wRU+HEPq23gER4iPjGs5Cg==
 
+material-symbols@^0.44.4:
+  version "0.44.4"
+  resolved "https://registry.yarnpkg.com/material-symbols/-/material-symbols-0.44.4.tgz#11db6f12f32972f062edd74b15d7fa5c662b19d1"
+  integrity sha512-ccUeNNV+zdpO/ZB/IYgLFBk8HLBdT6O/89SYtMZFLizAwVokbCzhpWkJq67im781OOB3PYpe2Cm2sVy+Nbs36A==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
## Summary

Two coordinated UI refactors to the session-history side panel, laying the groundwork for removing the separate `/history` page.

- **Alternate toggle icons.** The side-panel open/close toggle now shows two Material Symbols glyphs (`dock_to_right` when open, `toolbar` when closed) instead of a single `view_sidebar` icon that only flipped color. State reads at a glance without relying on blue/gray. Pulls in `material-symbols` to supply the new glyphs alongside the existing `material-icons` font.
- **Expand toggle for full-width browsing.** Adds an expand/collapse button (`open_in_full` / `close_fullscreen`) to the panel's Row 2 toolbar. Clicking it swaps the panel between `w-72` and `flex-1`, hiding the sidebar, canvas, and right-sidebar columns so history browsing takes the full viewport. State is transient — picking a session, starting a new session, or closing the panel all collapse back to panel width so the next interaction lands in a familiar layout.

### Step toward removing the history page

With the expanded side panel offering the same full-width browsing experience as `/history`, the standalone route is largely redundant. This PR doesn't delete it yet, but is the prerequisite step — once we decide the route's deep-link value (e.g. `/history/unread` bookmarks) isn't worth the duplication, removal becomes a mechanical follow-up.

### Implementation notes

- `min-w-0 overflow-hidden` on the panel wrapper prevents flex-item intrinsic-width from pushing past the viewport in expanded mode.
- i18n keys added in all 8 locales (`sessionHistoryExpand.{expandTooltip,collapseTooltip,expand,collapse}`).
- E2E testids preserved: `session-history-toggle-on/off` unchanged; new `session-history-expand-on/off`.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`
- [x] `yarn test` (29 unit tests pass)
- [x] `yarn test:e2e` (345 Playwright tests pass)
- [ ] Manual: open side panel → click expand → history list fills screen; click a session → collapses back
- [ ] Manual: open side panel → click expand → click "+" new session → collapses back
- [ ] Manual: expand → click close (dock icon) → panel closes; reopen → starts collapsed (not expanded)
- [ ] Manual: verify glyphs render (not literal text) in all four toolbar icons
- [ ] Manual: all 8 locales show translated tooltips on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session history panel can now be expanded to full width with a new expand/collapse button
  * When expanded, the panel takes over the layout for focused viewing
  * Panel automatically collapses when switching sessions or creating new ones
  * Expand/collapse controls are available in 8 languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->