### PR TITLE
refactor: split Scheduler into Calendar + Actions (#758)

### DIFF
--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -6,8 +6,10 @@
 // After the layout/page split:
 //  - Cmd+1 toggles layout (single ↔ stack) when on /chat; on other
 //    pages it navigates back to /chat without toggling.
-//  - Cmd+2–7 navigate directly to /files, /todos, /scheduler, /wiki,
+//  - Cmd+2–7 navigate directly to /files, /todos, /calendar, /wiki,
 //    /skills, /roles.
+//  - Cmd+9 navigates to /automations (added by #758 when Scheduler
+//    was split into Calendar + Actions).
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
@@ -37,12 +39,20 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     await expect(page).toHaveURL(/\/todos(?:$|\?)/);
   });
 
-  test("Cmd/Ctrl+4 navigates to /scheduler", async ({ page }) => {
+  test("Cmd/Ctrl+4 navigates to /calendar", async ({ page }) => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
     await pressShortcut(page, "4");
-    await expect(page).toHaveURL(/\/scheduler(?:$|\?)/);
+    await expect(page).toHaveURL(/\/calendar(?:$|\?)/);
+  });
+
+  test("Cmd/Ctrl+9 navigates to /automations", async ({ page }) => {
+    await page.goto("/chat");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    await pressShortcut(page, "9");
+    await expect(page).toHaveURL(/\/automations(?:$|\?)/);
   });
 
   test("Cmd/Ctrl+5 navigates to /wiki", async ({ page }) => {

--- a/e2e/tests/plugin-launcher.spec.ts
+++ b/e2e/tests/plugin-launcher.spec.ts
@@ -24,8 +24,12 @@ test.describe("plugin launcher — navigation path", () => {
     await clickLauncherAndAssertPath(page, "todos", "/todos");
   });
 
-  test("Scheduler button navigates to /scheduler", async ({ page }) => {
-    await clickLauncherAndAssertPath(page, "scheduler", "/scheduler");
+  test("Calendar button navigates to /calendar", async ({ page }) => {
+    await clickLauncherAndAssertPath(page, "calendar", "/calendar");
+  });
+
+  test("Actions button navigates to /automations", async ({ page }) => {
+    await clickLauncherAndAssertPath(page, "automations", "/automations");
   });
 
   test("Wiki button navigates to /wiki", async ({ page }) => {

--- a/e2e/tests/right-sidebar-toggle.spec.ts
+++ b/e2e/tests/right-sidebar-toggle.spec.ts
@@ -47,7 +47,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
 
   test("is hidden on plugin views even when the preference is on", async ({ page }) => {
     // User has the panel toggled on — should still hide on wiki / todos /
-    // scheduler etc. because those views have no agent context.
+    // calendar / automations etc. because those views have no agent context.
     await page.addInitScript(() => localStorage.setItem("right_sidebar_visible", "true"));
 
     await page.goto("/chat");
@@ -56,7 +56,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
     await expect(page.getByTitle("Tool call history")).toBeVisible();
 
-    for (const route of ["/wiki", "/todos", "/scheduler", "/skills", "/roles", "/files"] as const) {
+    for (const route of ["/wiki", "/todos", "/calendar", "/automations", "/skills", "/roles", "/files"] as const) {
       await page.goto(route);
       await expect(page.getByText("MulmoClaude")).toBeVisible();
       // Panel content gone.

--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -153,10 +153,22 @@ test.describe("page routing", () => {
     expect(new URL(page.url()).pathname).toBe("/todos");
   });
 
-  test("/scheduler loads the scheduler page", async ({ page }) => {
-    await page.goto("/scheduler");
+  test("/calendar loads the calendar page", async ({ page }) => {
+    await page.goto("/calendar");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    expect(new URL(page.url()).pathname).toBe("/scheduler");
+    expect(new URL(page.url()).pathname).toBe("/calendar");
+  });
+
+  test("/automations loads the automations page", async ({ page }) => {
+    await page.goto("/automations");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe("/automations");
+  });
+
+  test("/scheduler redirects to /calendar (bookmark preservation for #758)", async ({ page }) => {
+    await page.goto("/scheduler");
+    await page.waitForURL(/\/calendar(?:$|\?)/);
+    expect(new URL(page.url()).pathname).toBe("/calendar");
   });
 
   test("/wiki loads the wiki page", async ({ page }) => {

--- a/plans/refactor-scheduler-split.md
+++ b/plans/refactor-scheduler-split.md
@@ -1,0 +1,174 @@
+# plan: split Scheduler into Calendar + Automations
+
+Tracking: #758
+
+## Goal
+
+Surface Calendar and Automations as two peer menu entries with their
+own routes, views, icons, and keyboard shortcuts. Remove the shared
+tab bar that made Tasks a second-class citizen behind Calendar.
+
+## Non-goals
+
+- Backend / API changes. `/api/scheduler/*`, `SCHEDULER_ACTIONS`,
+  `workspacePaths.scheduler*`, and the `manageScheduler` MCP tool
+  all stay unchanged — this is a pure UI-navigation refactor.
+- Per-page URL state (filters, sort order). Deferred.
+- Badge counts on either icon. Deferred.
+- Renaming the underlying plugin folder to match new UI names.
+  Keeping `src/plugins/scheduler/` intact keeps the MCP tool-result
+  rendering path simple — the top-level pages import the same
+  sub-components for consistency.
+
+## Design
+
+### Routing
+
+- Add `PAGE_ROUTES.calendar = "calendar"` and `PAGE_ROUTES.automations = "automations"`.
+- Add routes `/calendar` and `/automations` to `src/router/index.ts`.
+- Replace the existing `/scheduler` entry with a redirect to
+  `/calendar` so bookmarks keep working. Removal can come later
+  once telemetry shows nobody hits it.
+- Drop `PAGE_ROUTES.scheduler`? No — we keep it un-used as a
+  sentinel for anything still referencing it during the transition.
+  Actually clean removal is simpler; check all call sites first
+  (see "References to update" below).
+
+### Page views
+
+Two new page-level wrappers under `src/plugins/scheduler/` (same
+folder to keep scheduler-domain code co-located):
+
+- `src/plugins/scheduler/CalendarView.vue` — extracted calendar-only
+  content from current `View.vue` (template lines 32–204 + calendar
+  state).
+- `src/plugins/scheduler/AutomationsView.vue` — thin wrapper around
+  the existing `TasksTab.vue`. Renders the same component; standalone
+  heading reads "Automations" via a new i18n key.
+
+The existing `src/plugins/scheduler/View.vue` stays for tool-result
+rendering context (MCP `manageScheduler` responses inside /chat).
+Its tab-switcher continues to work the same way — `detectInitialTab`
+already picks the right sub-view from result data shape.
+
+### App.vue dispatch
+
+Replace:
+
+```vue
+<SchedulerView v-else-if="currentPage === 'scheduler'" />
+```
+
+with:
+
+```vue
+<CalendarView v-else-if="currentPage === 'calendar'" />
+<AutomationsView v-else-if="currentPage === 'automations'" />
+```
+
+### PluginLauncher
+
+Replace the single entry at `src/components/PluginLauncher.vue:55`:
+
+```ts
+{ key: "scheduler", kind: "view", icon: "event" }
+```
+
+with two:
+
+```ts
+{ key: "calendar",    kind: "view", icon: "calendar_month" },
+{ key: "automations", kind: "view", icon: "schedule" },
+```
+
+### Keyboard shortcuts
+
+`src/App.vue:439–446` `PAGE_SHORTCUT_KEYS` change:
+
+```ts
+// Before
+"4": PAGE_ROUTES.scheduler,
+
+// After
+"4": PAGE_ROUTES.calendar,
+"9": PAGE_ROUTES.automations,
+```
+
+### i18n (8 locales lockstep per CLAUDE.md)
+
+- Add `pluginLauncher.calendar = { label, title }` and
+  `pluginLauncher.automations = { label, title }`. Titles reference
+  the new shortcuts: "Open calendar (⌘4)" and "Open automations (⌘9)".
+- Remove `pluginLauncher.scheduler`.
+- Add `pluginAutomations.heading` (= "Automations") for the standalone
+  page heading.
+- Keep `pluginScheduler.*` / `pluginSchedulerTasks.*` keys as-is —
+  they're still used by the combined View.vue and TasksTab.vue in
+  the tool-result context. Renaming them is code churn without value.
+
+### Role sample queries
+
+`src/config/roles.ts:60` — replace `"Show me the scheduler"` with
+two queries on the General role:
+
+- `"Show me my calendar"`
+- `"Show me my automations"`
+
+Keeps the hint surface consistent with the two new pages.
+
+## References to update (exhaustive)
+
+- `src/router/index.ts` — add 2 routes, remove (or keep as redirect) `/scheduler`.
+- `src/App.vue` — `PAGE_SHORTCUT_KEYS` + view dispatch + imports.
+- `src/components/PluginLauncher.vue` — key union + entries list.
+- `src/config/roles.ts` — General role sample queries.
+- `src/plugins/scheduler/CalendarView.vue` — NEW.
+- `src/plugins/scheduler/AutomationsView.vue` — NEW.
+- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — `pluginLauncher.*` split + `pluginAutomations.heading`.
+- `docs/scheduler-guide.md` / `docs/scheduler-guide.en.md` — rename page references.
+- `docs/developer.md` — check for "Scheduler page" mentions.
+- `e2e/tests/files-scheduler-preview.spec.ts` — existing testids
+  (`scheduler-tab-calendar`/`tasks`) are used through the files-preview
+  path, not the main page route; verify they still resolve against
+  the combined `View.vue` in tool-result context.
+
+## Testing
+
+### Automated
+
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean.
+- Existing e2e passes — no test currently navigates directly to `/scheduler`.
+
+### New e2e (optional, small)
+
+Add a short spec `e2e/tests/calendar-automations-nav.spec.ts`:
+- Click Calendar launcher → URL becomes `/calendar`, calendar view visible.
+- Click Automations launcher → URL `/automations`, tasks list visible.
+- ⌘4 / ⌘9 shortcuts land on the right pages from elsewhere.
+- `/scheduler` redirects to `/calendar`.
+
+Optional but cheap; adds discoverability-regression protection.
+
+### Manual
+
+- Navigate to `/scheduler` → should redirect to `/calendar`.
+- Confirm both launchers render distinct icons.
+- Confirm no dead-link on old bookmarks.
+- Confirm that inside /chat, a `manageScheduler` tool result still
+  renders its tab-switcher correctly (the plugin-side View.vue is
+  unchanged).
+
+## Rollout
+
+Single PR. No feature flag needed — the change is additive on the
+navigation side and redirect-preserving for legacy URLs.
+
+## Done when
+
+- Both icons reachable from PluginLauncher with distinct visuals.
+- Direct nav to `/calendar` and `/automations` works.
+- `/scheduler` redirects.
+- ⌘4 / ⌘9 shortcuts work.
+- i18n present in all 8 locales.
+- CI green.
+- PR merged.

--- a/src/App.vue
+++ b/src/App.vue
@@ -153,7 +153,8 @@
           <!-- Distinct pages -->
           <FilesView v-else-if="currentPage === 'files'" :refresh-token="filesRefreshToken" @load-session="handleSessionSelect" />
           <TodoExplorer v-else-if="currentPage === 'todos'" />
-          <SchedulerView v-else-if="currentPage === 'scheduler'" />
+          <CalendarView v-else-if="currentPage === 'calendar'" />
+          <AutomationsView v-else-if="currentPage === 'automations'" />
           <WikiView v-else-if="currentPage === 'wiki'" />
           <SkillsView v-else-if="currentPage === 'skills'" />
           <RolesView v-else-if="currentPage === 'roles'" />
@@ -216,7 +217,8 @@ import PluginLauncher from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
 import TodoExplorer from "./components/TodoExplorer.vue";
-import SchedulerView from "./plugins/scheduler/View.vue";
+import CalendarView from "./plugins/scheduler/CalendarView.vue";
+import AutomationsView from "./plugins/scheduler/AutomationsView.vue";
 import WikiView from "./plugins/wiki/View.vue";
 import { buildWikiRouteParams } from "./plugins/wiki/route";
 import SkillsView from "./plugins/manageSkills/View.vue";
@@ -439,10 +441,11 @@ watch(sidePanelVisible, (visible, prev) => {
 const PAGE_SHORTCUT_KEYS: Record<string, PageRouteName> = {
   "2": PAGE_ROUTES.files,
   "3": PAGE_ROUTES.todos,
-  "4": PAGE_ROUTES.scheduler,
+  "4": PAGE_ROUTES.calendar,
   "5": PAGE_ROUTES.wiki,
   "6": PAGE_ROUTES.skills,
   "7": PAGE_ROUTES.roles,
+  "9": PAGE_ROUTES.automations,
 };
 
 function handleViewModeShortcut(event: KeyboardEvent): void {

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -66,8 +66,10 @@ const TARGETS: PluginLauncherTarget[] = [
 ];
 
 // Index AFTER which the visual separator is inserted (between data
-// plugins on the left and management on the right).
-const SEPARATOR_AFTER_INDEX = 4;
+// plugins on the left and management on the right). Data plugins are
+// todos / calendar / automations / wiki / sources (indices 0-4), so
+// the divider renders before index 5 (skills).
+const SEPARATOR_AFTER_INDEX = 5;
 
 function isActive(target: PluginLauncherTarget): boolean {
   return props.activeViewMode === target.key;

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -43,7 +43,7 @@ export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated vie
 // strings out of this file avoids duplication across locales.
 export interface PluginLauncherTarget {
   /** Stable key for testid + dispatch in App.vue. */
-  key: "todos" | "scheduler" | "wiki" | "sources" | "skills" | "roles" | "files";
+  key: "todos" | "calendar" | "automations" | "wiki" | "sources" | "skills" | "roles" | "files";
   kind: PluginLauncherKind;
   /** Material-icons glyph. */
   icon: string;
@@ -52,7 +52,11 @@ export interface PluginLauncherTarget {
 const TARGETS: PluginLauncherTarget[] = [
   // ─── Data plugins ───
   { key: "todos", kind: "view", icon: "checklist" },
-  { key: "scheduler", kind: "view", icon: "event" },
+  // Calendar + Automations were a single "Scheduler" entry until
+  // #758 split them. Calendar keeps the former ⌘4 shortcut; the
+  // Automations entry picks up ⌘9 (the first unused number).
+  { key: "calendar", kind: "view", icon: "calendar_month" },
+  { key: "automations", kind: "view", icon: "schedule" },
   { key: "wiki", kind: "view", icon: "menu_book" },
   { key: "sources", kind: "view", icon: "rss_feed" },
   // ─── Management / navigation ───

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -57,7 +57,8 @@ export const ROLES: Role[] = [
       "Show my wiki index",
       "Lint my wiki",
       "Show my todo list",
-      "Show me the scheduler",
+      "Show me my calendar",
+      "Show my scheduled actions",
     ],
   },
   {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -182,7 +182,8 @@ const deMessages = {
   },
   pluginLauncher: {
     todos: { label: "To-dos", title: "To-dos öffnen (⌘4)" },
-    scheduler: { label: "Zeitplan", title: "Zeitplan öffnen (⌘5)" },
+    calendar: { label: "Kalender", title: "Kalender öffnen (⌘4)" },
+    automations: { label: "Aktionen", title: "Aktionen öffnen (⌘9)" },
     wiki: { label: "Wiki", title: "Wiki öffnen (⌘6)" },
     sources: { label: "Quellen", title: "Informationsquellen öffnen" },
     skills: { label: "Skills", title: "Skills öffnen (⌘7)" },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -203,7 +203,8 @@ const enMessages = {
   },
   pluginLauncher: {
     todos: { label: "Todos", title: "Open todos (⌘4)" },
-    scheduler: { label: "Schedule", title: "Open schedule (⌘5)" },
+    calendar: { label: "Calendar", title: "Open calendar (⌘4)" },
+    automations: { label: "Actions", title: "Open actions (⌘9)" },
     wiki: { label: "Wiki", title: "Open wiki (⌘6)" },
     sources: { label: "Sources", title: "Open information sources" },
     skills: { label: "Skills", title: "Open skills (⌘7)" },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -188,7 +188,8 @@ const esMessages = {
   },
   pluginLauncher: {
     todos: { label: "Tareas", title: "Abrir tareas (⌘4)" },
-    scheduler: { label: "Agenda", title: "Abrir agenda (⌘5)" },
+    calendar: { label: "Calendario", title: "Abrir calendario (⌘4)" },
+    automations: { label: "Acciones", title: "Abrir acciones (⌘9)" },
     wiki: { label: "Wiki", title: "Abrir wiki (⌘6)" },
     sources: { label: "Fuentes", title: "Abrir fuentes de información" },
     skills: { label: "Skills", title: "Abrir skills (⌘7)" },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -182,7 +182,8 @@ const frMessages = {
   },
   pluginLauncher: {
     todos: { label: "Tâches", title: "Ouvrir les tâches (⌘4)" },
-    scheduler: { label: "Planning", title: "Ouvrir le planning (⌘5)" },
+    calendar: { label: "Calendrier", title: "Ouvrir le calendrier (⌘4)" },
+    automations: { label: "Actions", title: "Ouvrir les actions (⌘9)" },
     wiki: { label: "Wiki", title: "Ouvrir le wiki (⌘6)" },
     sources: { label: "Sources", title: "Ouvrir les sources d'information" },
     skills: { label: "Skills", title: "Ouvrir les skills (⌘7)" },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -186,7 +186,8 @@ const jaMessages = {
   },
   pluginLauncher: {
     todos: { label: "Todo", title: "Todo を開く (⌘4)" },
-    scheduler: { label: "スケジュール", title: "スケジュールを開く (⌘5)" },
+    calendar: { label: "カレンダー", title: "カレンダーを開く (⌘4)" },
+    automations: { label: "自動化", title: "自動化を開く (⌘9)" },
     wiki: { label: "Wiki", title: "Wiki を開く (⌘6)" },
     sources: { label: "ソース", title: "情報ソースを開く" },
     skills: { label: "スキル", title: "スキルを開く (⌘7)" },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -187,7 +187,8 @@ const koMessages = {
   },
   pluginLauncher: {
     todos: { label: "할 일", title: "할 일 열기 (⌘4)" },
-    scheduler: { label: "일정", title: "일정 열기 (⌘5)" },
+    calendar: { label: "캘린더", title: "캘린더 열기 (⌘4)" },
+    automations: { label: "자동화", title: "자동화 열기 (⌘9)" },
     wiki: { label: "위키", title: "위키 열기 (⌘6)" },
     sources: { label: "소스", title: "정보 소스 열기" },
     skills: { label: "스킬", title: "스킬 열기 (⌘7)" },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -181,7 +181,8 @@ const ptBRMessages = {
   },
   pluginLauncher: {
     todos: { label: "Tarefas", title: "Abrir tarefas (⌘4)" },
-    scheduler: { label: "Agenda", title: "Abrir agenda (⌘5)" },
+    calendar: { label: "Calendário", title: "Abrir calendário (⌘4)" },
+    automations: { label: "Ações", title: "Abrir ações (⌘9)" },
     wiki: { label: "Wiki", title: "Abrir wiki (⌘6)" },
     sources: { label: "Fontes", title: "Abrir fontes de informação" },
     skills: { label: "Skills", title: "Abrir skills (⌘7)" },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -183,7 +183,8 @@ const zhMessages = {
   },
   pluginLauncher: {
     todos: { label: "待办", title: "打开待办 (⌘4)" },
-    scheduler: { label: "日程", title: "打开日程 (⌘5)" },
+    calendar: { label: "日历", title: "打开日历 (⌘4)" },
+    automations: { label: "自动化", title: "打开自动化 (⌘9)" },
     wiki: { label: "百科", title: "打开 Wiki (⌘6)" },
     sources: { label: "信息源", title: "打开信息源" },
     skills: { label: "技能", title: "打开技能 (⌘7)" },

--- a/src/plugins/scheduler/AutomationsView.vue
+++ b/src/plugins/scheduler/AutomationsView.vue
@@ -1,0 +1,14 @@
+<template>
+  <!-- Standalone Automations page (#758). Surfaces the scheduler's
+       Tasks tab as a peer page to Calendar. Same delegation pattern
+       as CalendarView: forces the tab, hides the bar. The underlying
+       TasksTab renders user-registered cron/interval/daily tasks,
+       skill-scheduled runs, and source-watcher pipeline runs — i.e.
+       every task the task-manager knows about. -->
+  <SchedulerView :force-tab="SCHEDULER_TAB.tasks" />
+</template>
+
+<script setup lang="ts">
+import SchedulerView from "./View.vue";
+import { SCHEDULER_TAB } from "./viewModes";
+</script>

--- a/src/plugins/scheduler/CalendarView.vue
+++ b/src/plugins/scheduler/CalendarView.vue
@@ -1,0 +1,11 @@
+<template>
+  <!-- Standalone Calendar page (#758). Delegates to the shared
+       SchedulerView with the tab locked to calendar and the tab bar
+       hidden. Mounted by App.vue on route /calendar. -->
+  <SchedulerView :force-tab="SCHEDULER_TAB.calendar" />
+</template>
+
+<script setup lang="ts">
+import SchedulerView from "./View.vue";
+import { SCHEDULER_TAB } from "./viewModes";
+</script>

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -5,8 +5,14 @@
     <div v-if="apiError" class="px-4 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700" role="alert" data-testid="scheduler-api-error">
       {{ t("pluginScheduler.apiError", { error: apiError }) }}
     </div>
-    <!-- Top-level tab bar: Calendar / Tasks -->
-    <div class="flex border-b border-gray-200 px-6">
+    <!-- Top-level tab bar: Calendar / Tasks. Hidden when the
+         component is mounted as a standalone page (`forceTab`
+         set by CalendarView / AutomationsView) — the page itself
+         already identifies which feature the user is on, so a
+         tab bar would duplicate that affordance. Still rendered
+         when the component appears as a `manageScheduler` tool
+         result inside /chat, where the user can switch freely. -->
+    <div v-if="!forceTab" class="flex border-b border-gray-200 px-6">
       <button
         class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
         :class="activeTab === SCHEDULER_TAB.calendar ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
@@ -269,6 +275,11 @@ type YamlScalar = string | number | boolean | null;
 
 const props = defineProps<{
   selectedResult?: ToolResultComplete<SchedulerData>;
+  // Standalone page mode: when set, hides the tab bar and locks the
+  // view to the given tab. Used by CalendarView / AutomationsView
+  // wrappers (#758). Undefined in the /chat tool-result context, so
+  // there the tab-switcher stays interactive.
+  forceTab?: SchedulerTab;
 }>();
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
@@ -280,7 +291,15 @@ function detectInitialTab(result?: ToolResultComplete<SchedulerData>): Scheduler
   return SCHEDULER_TAB.calendar;
 }
 
-const activeTab = ref<SchedulerTab>(detectInitialTab(props.selectedResult));
+const activeTab = ref<SchedulerTab>(props.forceTab ?? detectInitialTab(props.selectedResult));
+// In standalone page mode the tab is locked; swapping routes should
+// re-lock so the view follows. No-op in tool-result mode.
+watch(
+  () => props.forceTab,
+  (next) => {
+    if (next) activeTab.value = next;
+  },
+);
 const items = ref<ScheduledItem[]>(props.selectedResult?.data?.items ?? []);
 
 const { refresh } = useFreshPluginData<ScheduledItem[]>({

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,9 +1,9 @@
 // Vue-router setup (history mode — clean URLs without #).
 //
-// Each page has its own route: /chat, /files, /todos, /scheduler,
-// /wiki, /skills, /roles, /sources. Layout preference (single vs.
-// stack) is a separate concern persisted in localStorage — it is
-// not part of the URL.
+// Each page has its own route: /chat, /files, /todos, /calendar,
+// /automations, /wiki, /skills, /roles, /sources. Layout preference
+// (single vs. stack) is a separate concern persisted in localStorage
+// — it is not part of the URL.
 //
 // History mode requires the server to serve index.html for any path
 // that doesn't match an API route or static file. In production the
@@ -22,7 +22,8 @@ export const PAGE_ROUTES = {
   chat: "chat",
   files: "files",
   todos: "todos",
-  scheduler: "scheduler",
+  calendar: "calendar",
+  automations: "automations",
   wiki: "wiki",
   skills: "skills",
   roles: "roles",
@@ -43,7 +44,11 @@ const routes: RouteRecordRaw[] = [
   // selected". See plans/feat-files-path-url.md.
   { path: "/files/:pathMatch(.*)*", name: PAGE_ROUTES.files, component: Stub },
   { path: "/todos", name: PAGE_ROUTES.todos, component: Stub },
-  { path: "/scheduler", name: PAGE_ROUTES.scheduler, component: Stub },
+  { path: "/calendar", name: PAGE_ROUTES.calendar, component: Stub },
+  { path: "/automations", name: PAGE_ROUTES.automations, component: Stub },
+  // Legacy Scheduler URL — split into Calendar + Automations (#758).
+  // Redirect preserves bookmarks; delete once telemetry shows no hits.
+  { path: "/scheduler", redirect: "/calendar" },
   // Wiki sub-views live on the path rather than in query params so
   // URLs mirror the filesystem layout (`data/wiki/pages/<slug>.md`)
   // and stay sibling-safe (no query-key bleed from other routes).

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -29,7 +29,8 @@ export type NotificationActionType = (typeof NOTIFICATION_ACTION_TYPES)[keyof ty
 
 export const NOTIFICATION_VIEWS = {
   todos: "todos",
-  scheduler: "scheduler",
+  calendar: "calendar",
+  automations: "automations",
   files: "files",
   chat: "chat",
 } as const;

--- a/src/utils/notification/dispatch.ts
+++ b/src/utils/notification/dispatch.ts
@@ -4,7 +4,7 @@ import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_VIEWS, type NotificationAction 
 
 // Views that map directly to a canvas view mode (excludes "chat"
 // which is handled as a session navigation).
-type CanvasNotificationView = "todos" | "scheduler" | "files";
+type CanvasNotificationView = "todos" | "calendar" | "automations" | "files";
 
 export type NotificationTarget = { kind: "session"; sessionId: string } | { kind: "view"; view: CanvasNotificationView } | null;
 
@@ -15,7 +15,12 @@ export function resolveNotificationTarget(action: NotificationAction): Notificat
   if (action.view === NOTIFICATION_VIEWS.chat && action.sessionId) {
     return { kind: "session", sessionId: action.sessionId };
   }
-  if (action.view === NOTIFICATION_VIEWS.todos || action.view === NOTIFICATION_VIEWS.scheduler || action.view === NOTIFICATION_VIEWS.files) {
+  if (
+    action.view === NOTIFICATION_VIEWS.todos ||
+    action.view === NOTIFICATION_VIEWS.calendar ||
+    action.view === NOTIFICATION_VIEWS.automations ||
+    action.view === NOTIFICATION_VIEWS.files
+  ) {
     return { kind: "view", view: action.view };
   }
   return null;


### PR DESCRIPTION
## Summary
- Split the old Scheduler page (two-tab `Calendar` / `Tasks`) into two peer pages with distinct icons + shortcuts: **Calendar** (`calendar_month`, ⌘4) and **Actions** (`schedule`, ⌘9).
- `/scheduler` redirects to `/calendar` to keep existing bookmarks working.
- No backend / MCP changes. The scheduler plugin's combined `View.vue` is reused through a new `forceTab` prop, so the `manageScheduler` tool still renders exactly as before.

## Items to Confirm / Review
- **Label choice: "Actions" (not "Automations").** After iterating on label length in 8 locales, we landed on the shorter *Actions* concept for Western locales (avoids 11–17 char labels crowding the toolbar) while keeping CJK as `自動化 / 自动化 / 자동화` since they're already optimal at 3 chars. The internal key (`automations`), the agent-side tool (`manageScheduler`), and the plan file still refer to "Automations" — only user-visible labels changed. Flag if you prefer a different term or want naming unified across internal + UI.
- **Shortcut assignment.** Calendar inherits the former Scheduler shortcut (⌘4), Actions picks up ⌘9 (first unused). Worth confirming muscle memory for existing users.
- **`forceTab` prop approach** on `View.vue` — preferred over duplicating ~500 lines into two new page components. Tab bar is hidden when `forceTab` is set; a `watch` re-locks the tab when the prop changes (handles route switches).
- **`/scheduler` → `/calendar` redirect.** Left in router indefinitely for bookmark preservation; plan file notes removing once telemetry confirms zero hits.
- **i18n lockstep.** All 8 locales updated in this PR per CLAUDE.md. Sample query in the General role (`src/config/roles.ts`) also split into two entries.

## User Prompt
> スケジュールのなかにタブでタスクがあるけどカレンダーとタスクは機能としては別なので分けたうえでメニューのアイコンもわけてほしい

Follow-ups during the conversation:
- Resolve routing / shortcut / tool-result questions (documented in `plans/refactor-scheduler-split.md`)
- Label length refinement for ja → `自動化`, then for en/es/fr/de/pt-BR → shorter "Actions" concept

## Design
Plan: [`plans/refactor-scheduler-split.md`](plans/refactor-scheduler-split.md) (committed in the first commit on this branch).

### Files changed
- `src/router/index.ts` — `PAGE_ROUTES.scheduler` → `calendar` + `automations`; `/scheduler` redirect.
- `src/plugins/scheduler/View.vue` — new `forceTab` prop; tab bar hidden when set; watch re-locks on prop change.
- `src/plugins/scheduler/CalendarView.vue` — new, delegates to `View.vue` with `forceTab=calendar`.
- `src/plugins/scheduler/AutomationsView.vue` — new, delegates with `forceTab=tasks`.
- `src/App.vue` — `PAGE_SHORTCUT_KEYS` (⌘4 calendar, ⌘9 automations); view dispatch; imports.
- `src/components/PluginLauncher.vue` — key union + TARGETS with two entries + separator update.
- `src/config/roles.ts` — General role sample queries split.
- `src/lang/{en,ja,zh,ko,es,fr,de,pt-BR}.ts` — `pluginLauncher.calendar` + `pluginLauncher.automations` (replaces `pluginLauncher.scheduler`).

### What stays the same
- MCP `manageScheduler` tool, its backend routes, and scheduler plugin `definition.ts` / `index.ts` are untouched.
- When the scheduler tool emits a tool result, the chat still renders it through the shared `View.vue` (no `forceTab`) — `detectInitialTab` picks the sub-view from the data shape as before.

## Test plan
- [ ] ⌘4 opens Calendar, ⌘9 opens Actions
- [ ] `/scheduler` redirects to `/calendar`
- [ ] Scheduler tool result (via chat) still renders with correct sub-view auto-selected
- [ ] `PluginLauncher` shows two buttons with `calendar_month` + `schedule` icons, separator between data plugins and management plugins preserved
- [ ] Labels render correctly in all 8 locales; no overflow at 640 px toolbar width
- [ ] Compact mode (icon-only) still works at narrow widths

Closes #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split scheduler navigation into separate Calendar and Automations pages for improved organization.
  * Updated keyboard shortcuts: Calendar (⌘4) and Automations (⌘9).
  * Legacy scheduler URLs redirect to Calendar to preserve existing bookmarks.
  * Internationalization updated across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->