### PR TITLE
refactor: standardize UI control sizing across top bar and plugin-view toolbars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,17 @@ NEVER use raw `fs.readFile` / `fs.writeFile` in route handlers. Use `server/util
 
 NEVER escape backticks with `\`` in `gh` commands. Use single-quoted heredoc (`<<'EOF'`).
 
+### UI controls — standard height and spacing
+
+Top-bar and panel-header controls share one sizing language. Use these exact classes when adding or editing a control that sits in a chrome row (anything outside the canvas itself):
+
+- **Icon-only button** (bell, settings, lock, toggle, `+`): `h-8 w-8 flex items-center justify-center rounded` — 32px square.
+- **Icon + label pill** (launcher buttons, role selector, tabs): `h-8 px-2.5 flex items-center gap-1` — 32px tall with 10px horizontal padding and 4px icon-to-label gap.
+- **Row container** (outer wrapper holding multiple control groups): `flex items-center gap-2 px-3 py-2` — 8px between groups, 12/8 outer padding.
+- **Icon-cluster group** (a run of adjacent icon-only buttons like lock/bell/settings): `flex gap-0.5` — 2px gap, tight but still visibly separated.
+
+Do NOT introduce new heights (`h-7`, `h-9`, `py-1.5`, etc.) or new gap values for chrome controls. The logo in `SidebarHeader` is the one sanctioned exception — it escapes row padding via negative margins (`-my-3.5`) because it's a brand mark, not a control.
+
 ### i18n — all 8 locales in lockstep
 
 Supported UI locales live under `src/lang/`: `en.ts`, `ja.ts`, `zh.ts`, `ko.ts`, `es.ts`, `pt-BR.ts`, `fr.ts`, `de.ts`. `src/lang/en.ts` is the schema source of truth; `typeof enMessages` is threaded through `createI18n` in `src/lib/vue-i18n.ts`, so `vue-tsc` treats every missing or extra key as a type error.

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <!-- Global top bar — shown in every view mode -->
     <div class="shrink-0 bg-white text-gray-900">
       <!-- Row 1: title + plugin launcher -->
-      <div class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-200">
         <SidebarHeader
           :sandbox-enabled="sandboxEnabled"
           :gemini-available="geminiAvailable"
@@ -58,9 +58,9 @@
              button, so no second row is needed. -->
         <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
           <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" fluid @change="onRoleChange" />
-          <div class="flex items-center gap-1 shrink-0">
+          <div class="flex items-center gap-0.5 shrink-0">
             <button
-              class="flex-shrink-0 flex items-center justify-center w-7 py-1 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+              class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
               data-testid="new-session-btn"
               :title="t('sessionTabBar.newSession')"
               :aria-label="t('sessionTabBar.newSession')"

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,20 +19,30 @@
       </div>
       <!-- Row 2: role selector + session tabs. Shown whenever the
            side panel is hidden — Row 2 and the side panel are
-           mutually exclusive. -->
+           mutually exclusive. The header-controls wrapper is pinned
+           to 264px (w-72 minus px-3 padding on each side) so that
+           RoleSelector / + / toggle occupy the exact same x-range as
+           they do inside the open side panel — toggling the panel
+           therefore doesn't shift those controls. -->
       <div v-if="!sidePanelVisible" class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
-        <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" @change="onRoleChange" />
+        <div class="w-[264px] shrink-0">
+          <SessionHeaderControls
+            v-model:current-role-id="currentRoleId"
+            :roles="roles"
+            :side-panel-visible="sidePanelVisible"
+            :active-session-count="activeSessionCount"
+            :unread-count="unreadCount"
+            @role-change="onRoleChange"
+            @new-session="handleNewSessionClick"
+            @update:side-panel-visible="setSidePanelVisible"
+          />
+        </div>
         <SessionTabBar
           :sessions="tabSessions"
           :current-session-id="displayedCurrentSessionId"
           :is-chat-page="isChatPage"
           :roles="roles"
-          :active-session-count="activeSessionCount"
-          :unread-count="unreadCount"
-          :side-panel-visible="sidePanelVisible"
-          @new-session="handleNewSessionClick"
           @load-session="handleSessionSelect"
-          @update:side-panel-visible="setSidePanelVisible"
         />
       </div>
     </div>
@@ -47,7 +57,7 @@
            role selector + new-session button instead. -->
       <div
         v-if="sidePanelVisible"
-        class="group relative border-r border-gray-200 bg-white text-gray-900 flex flex-col min-w-0 overflow-hidden"
+        class="relative border-r border-gray-200 bg-white text-gray-900 flex flex-col min-w-0 overflow-hidden"
         :class="sidePanelExpanded ? 'flex-1' : 'w-72 flex-shrink-0'"
         data-testid="session-history-side-panel"
       >
@@ -56,27 +66,19 @@
              close toggle. The expand affordance lives on the panel's
              right edge as a hover-reveal handle instead of a header
              button, so no second row is needed. -->
-        <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
-          <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" fluid @change="onRoleChange" />
-          <div class="flex items-center gap-0.5 shrink-0">
-            <button
-              class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
-              data-testid="new-session-btn"
-              :title="t('sessionTabBar.newSession')"
-              :aria-label="t('sessionTabBar.newSession')"
-              @click="handleNewSessionClick"
-            >
-              <span class="material-icons text-sm">add</span>
-            </button>
-            <SessionHistoryToggleButton
-              :model-value="sidePanelVisible"
-              :active-session-count="activeSessionCount"
-              :unread-count="unreadCount"
-              @update:model-value="setSidePanelVisibleAndCollapse"
-            />
-          </div>
+        <div class="flex items-center px-3 py-2 border-b border-gray-100">
+          <SessionHeaderControls
+            v-model:current-role-id="currentRoleId"
+            :roles="roles"
+            :side-panel-visible="sidePanelVisible"
+            :active-session-count="activeSessionCount"
+            :unread-count="unreadCount"
+            @role-change="onRoleChange"
+            @new-session="handleNewSessionClick"
+            @update:side-panel-visible="setSidePanelVisibleAndCollapse"
+          />
         </div>
-        <div class="relative flex-1 min-h-0">
+        <div class="group relative flex-1 min-h-0">
           <SessionHistoryPanel
             :sessions="mergedSessions"
             :current-session-id="currentSessionId"
@@ -205,13 +207,12 @@ import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import RightSidebar from "./components/RightSidebar.vue";
 import SidebarHeader from "./components/SidebarHeader.vue";
-import RoleSelector from "./components/RoleSelector.vue";
+import SessionHeaderControls from "./components/SessionHeaderControls.vue";
 import SessionTabBar from "./components/SessionTabBar.vue";
 import SuggestionsPanel from "./components/SuggestionsPanel.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
 import SessionHistoryExpandButton from "./components/SessionHistoryExpandButton.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
-import SessionHistoryToggleButton from "./components/SessionHistoryToggleButton.vue";
 import ToolResultsPanel from "./components/ToolResultsPanel.vue";
 import PluginLauncher from "./components/PluginLauncher.vue";
 import StackView from "./components/StackView.vue";

--- a/src/components/LockStatusPopup.vue
+++ b/src/components/LockStatusPopup.vue
@@ -3,7 +3,10 @@
     <button
       ref="button"
       data-testid="sandbox-lock-button"
-      :class="sandboxEnabled ? 'text-gray-400 hover:text-gray-700' : 'text-amber-400 hover:text-amber-500'"
+      :class="[
+        'h-8 w-8 flex items-center justify-center rounded',
+        sandboxEnabled ? 'text-gray-400 hover:text-gray-700' : 'text-amber-400 hover:text-amber-500',
+      ]"
       :title="sandboxEnabled ? t('lockStatusPopup.sandboxEnabledTooltip') : t('lockStatusPopup.noSandboxTooltip')"
       @click="emit('update:open', !open)"
     >

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -73,7 +73,7 @@ function handleDismiss(event: Event, notificationId: string): void {
   <div ref="rootRef" class="relative">
     <!-- Bell button -->
     <button
-      class="relative text-gray-400 hover:text-gray-700"
+      class="relative h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700"
       data-testid="notification-bell"
       :aria-label="t('notificationBell.notifications')"
       @click="toggle"

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -5,7 +5,7 @@
       <div v-if="idx === SEPARATOR_AFTER_INDEX" class="w-px bg-gray-300 my-0.5" />
       <button
         :class="[
-          'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+          'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
           isActive(target) ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
         ]"
         :title="t(`pluginLauncher.${target.key}.title`)"

--- a/src/components/RoleSelector.vue
+++ b/src/components/RoleSelector.vue
@@ -2,7 +2,7 @@
   <div class="flex items-center gap-2 relative" :class="fluid ? 'min-w-0 flex-1' : 'w-56 shrink-0'">
     <button
       ref="button"
-      class="flex-1 flex items-center gap-2 bg-white border border-gray-300 rounded px-2 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
+      class="flex-1 h-8 flex items-center gap-1 bg-white border border-gray-300 rounded px-2.5 text-sm text-gray-900 hover:bg-gray-50 text-left"
       data-testid="role-selector-btn"
       @click="open = !open"
     >

--- a/src/components/SessionHeaderControls.vue
+++ b/src/components/SessionHeaderControls.vue
@@ -1,0 +1,62 @@
+<template>
+  <!-- Shared header cluster: role selector + new-session + side-panel
+       toggle. Rendered in two places:
+       1. Row 2 (top bar) when the session-history side panel is closed
+       2. The side-panel's own header row when it's open
+       The outer is `w-full`; parents constrain the width (the Row 2
+       wrapper forces 264px to match the side-panel's internal width,
+       so the controls don't visually shift when the panel toggles).
+       Toggle behaviour differs slightly between callers — the side
+       panel also collapses when hidden — so we emit a plain
+       `update:sidePanelVisible` and let the parent decide. -->
+  <div class="flex items-center gap-2 w-full min-w-0">
+    <RoleSelector
+      :current-role-id="currentRoleId"
+      :roles="roles"
+      fluid
+      @update:current-role-id="(value: string) => emit('update:currentRoleId', value)"
+      @change="() => emit('roleChange')"
+    />
+    <div class="flex items-center gap-0.5 shrink-0">
+      <button
+        class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+        data-testid="new-session-btn"
+        :title="t('sessionTabBar.newSession')"
+        :aria-label="t('sessionTabBar.newSession')"
+        @click="emit('newSession')"
+      >
+        <span class="material-icons text-sm">add</span>
+      </button>
+      <SessionHistoryToggleButton
+        :model-value="sidePanelVisible"
+        :active-session-count="activeSessionCount"
+        :unread-count="unreadCount"
+        @update:model-value="(value: boolean) => emit('update:sidePanelVisible', value)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { Role } from "../config/roles";
+import RoleSelector from "./RoleSelector.vue";
+import SessionHistoryToggleButton from "./SessionHistoryToggleButton.vue";
+
+const { t } = useI18n();
+
+defineProps<{
+  roles: Role[];
+  currentRoleId: string;
+  sidePanelVisible: boolean;
+  activeSessionCount: number;
+  unreadCount: number;
+}>();
+
+const emit = defineEmits<{
+  "update:currentRoleId": [value: string];
+  roleChange: [];
+  newSession: [];
+  "update:sidePanelVisible": [value: boolean];
+}>();
+</script>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex-1 flex gap-1 items-center min-w-0">
     <button
-      class="flex-shrink-0 flex items-center justify-center w-7 py-1 rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+      class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
       data-testid="new-session-btn"
       :title="t('sessionTabBar.newSession')"
       :aria-label="t('sessionTabBar.newSession')"
@@ -12,7 +12,7 @@
     <template v-for="i in 6" :key="i">
       <button
         v-if="sessions[i - 1]"
-        class="relative flex-1 min-w-0 flex items-center justify-start gap-1.5 pl-2 pr-2 py-1 rounded overflow-hidden transition-colors"
+        class="relative flex-1 min-w-0 h-8 flex items-center justify-start gap-1 px-2 rounded overflow-hidden transition-colors"
         :class="sessions[i - 1].id === currentSessionId ? 'border border-gray-300 bg-white shadow-sm' : 'hover:bg-gray-100'"
         :title="tabTooltip(sessions[i - 1])"
         :data-testid="`session-tab-${sessions[i - 1].id}`"

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="flex-1 flex gap-1 items-center min-w-0">
-    <button
-      class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
-      data-testid="new-session-btn"
-      :title="t('sessionTabBar.newSession')"
-      :aria-label="t('sessionTabBar.newSession')"
-      @click="emit('newSession')"
-    >
-      <span class="material-icons text-sm">add</span>
-    </button>
     <template v-for="i in 6" :key="i">
       <button
         v-if="sessions[i - 1]"
@@ -37,15 +28,6 @@
       </button>
       <div v-else class="flex-1" />
     </template>
-    <!-- Session-history side-panel toggle. Carries the aggregate
-         session-status badges (active = yellow, unread = red) that
-         used to live on the separate /history entry button. -->
-    <SessionHistoryToggleButton
-      :model-value="sidePanelVisible"
-      :active-session-count="activeSessionCount"
-      :unread-count="unreadCount"
-      @update:model-value="(value: boolean) => emit('update:sidePanelVisible', value)"
-    />
   </div>
 </template>
 
@@ -54,7 +36,6 @@ import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import { type SessionSummary } from "../types/session";
 import { roleName } from "../utils/role/icon";
-import SessionHistoryToggleButton from "./SessionHistoryToggleButton.vue";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 
 const { t } = useI18n();
@@ -69,15 +50,10 @@ const props = defineProps<{
   // the unread dot on its tab.
   isChatPage: boolean;
   roles: Role[];
-  activeSessionCount: number;
-  unreadCount: number;
-  sidePanelVisible: boolean;
 }>();
 
 const emit = defineEmits<{
-  newSession: [];
   loadSession: [id: string];
-  "update:sidePanelVisible": [value: boolean];
 }>();
 
 // Short label shown next to the role icon so users can tell

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -13,7 +13,7 @@
            the brand label here is a clickable logo, not a page heading. -->
       <span data-testid="app-title" class="text-sm font-semibold text-gray-800 mr-1" :style="titleStyle">MulmoClaude</span>
     </button>
-    <div class="flex gap-2">
+    <div class="flex gap-0.5">
       <LockStatusPopup
         ref="lockPopup"
         :sandbox-enabled="sandboxEnabled"
@@ -23,7 +23,7 @@
       />
       <NotificationBell :force-close="lockPopupOpen" @navigate="(action) => emit('notificationNavigate', action)" @update:open="onNotificationOpen" />
       <button
-        class="relative text-gray-400 hover:text-gray-700"
+        class="relative h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700"
         data-testid="settings-btn"
         :title="settingsLabel"
         :aria-label="settingsLabel"

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="flex-1 min-h-0 flex flex-col bg-gray-100">
-    <div class="shrink-0 flex items-center gap-1 text-xs text-gray-400 px-2 pt-2 pb-1" data-testid="sidebar-role-header">
+    <div class="shrink-0 flex items-center gap-2 text-xs text-gray-400 px-3 py-2 border-b border-gray-100" data-testid="sidebar-role-header">
       <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
-      <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
-      <div class="ml-auto flex items-center gap-1">
+      <span v-if="sessionRoleName" class="truncate">{{ sessionRoleName }}</span>
+      <div class="ml-auto flex items-center gap-0.5 shrink-0">
         <button
           type="button"
-          class="text-gray-400 hover:text-gray-700"
-          :class="{ 'text-blue-500': showRightSidebar }"
+          class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          :class="{ '!text-blue-500': showRightSidebar }"
           :title="t('sidebarHeader.toolCallHistory')"
           :aria-label="t('sidebarHeader.toolCallHistory')"
           :aria-pressed="showRightSidebar"

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -10,14 +10,16 @@
       <div class="text-gray-500">{{ t("pluginMarkdown.noContent") }}</div>
     </div>
     <template v-else>
-      <div class="flex justify-end px-4 py-2 border-b border-gray-100 shrink-0">
-        <div class="button-group">
-          <button class="download-btn download-btn-green" :disabled="pdfDownloading" @click="downloadPdf">
-            <span class="material-icons">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
-            {{ t("pluginMarkdown.pdf") }}
-          </button>
-        </div>
-        <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginMarkdown.pdfFailedShort") }}</span>
+      <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+        <button
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          :disabled="pdfDownloading"
+          @click="downloadPdf"
+        >
+          <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+          {{ t("pluginMarkdown.pdf") }}
+        </button>
+        <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginMarkdown.pdfFailedShort") }}</span>
       </div>
       <div v-if="loadError" class="load-error-banner" role="alert">
         {{ t("pluginMarkdown.refreshFailed", { error: loadError }) }}
@@ -245,36 +247,6 @@ watch(
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-}
-
-.button-group {
-  display: flex;
-  gap: 0.5em;
-}
-
-.download-btn {
-  padding: 0.5em 1em;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9em;
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-}
-
-.download-btn-green {
-  background-color: #4caf50;
-}
-
-.download-btn .material-icons {
-  font-size: 1.2em;
-}
-
-.download-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 .markdown-content :deep(h1) {

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -16,12 +16,16 @@
             <h1 class="title">
               {{ selectedResult.title || t("pluginSpreadsheet.untitled") }}
             </h1>
-            <div class="button-group">
-              <button class="download-btn excel-btn" @click="downloadExcel">
-                <span class="material-icons">download</span>
-                {{ t("pluginSpreadsheet.excel") }}
-              </button>
-            </div>
+            <!-- `download-btn` class kept as a name hook — referenced by
+                 e2e/tests/spreadsheet.spec.ts via `button.download-btn`.
+                 Styling is inline Tailwind; the class has no CSS rules. -->
+            <button
+              class="download-btn h-8 px-2.5 flex items-center gap-1 rounded bg-[#217346] hover:bg-[#1e6a3f] active:bg-[#1a5c36] text-white text-sm transition-colors"
+              @click="downloadExcel"
+            >
+              <span class="material-icons text-base">download</span>
+              {{ t("pluginSpreadsheet.excel") }}
+            </button>
           </div>
 
           <!-- Sheet tabs (if multiple sheets) -->
@@ -702,40 +706,6 @@ onUnmounted(() => {
   font-size: 2em;
   margin: 0;
   font-weight: bold;
-}
-
-.button-group {
-  display: flex;
-  gap: 0.5em;
-}
-
-.download-btn {
-  padding: 0.5em 1em;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9em;
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-  transition: background-color 0.2s;
-}
-
-.excel-btn {
-  background-color: #217346;
-}
-
-.excel-btn:hover {
-  background-color: #1e6a3f;
-}
-
-.excel-btn:active {
-  background-color: #1a5c36;
-}
-
-.download-btn .material-icons {
-  font-size: 1.2em;
 }
 
 /* Sheet tabs */

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="h-full flex flex-col">
-    <div v-if="isAssistant" class="flex justify-end px-4 py-2 border-b border-gray-100 shrink-0">
-      <div class="button-group">
-        <button class="download-btn download-btn-green" :disabled="pdfDownloading" @click="downloadPdf">
-          <span class="material-icons">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
-          {{ t("pluginTextResponse.pdf") }}
-        </button>
-      </div>
-      <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginTextResponse.pdfFailed") }}</span>
+    <div v-if="isAssistant" class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+      <button
+        class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        :disabled="pdfDownloading"
+        @click="downloadPdf"
+      >
+        <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+        {{ t("pluginTextResponse.pdf") }}
+      </button>
+      <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginTextResponse.pdfFailed") }}</span>
     </div>
     <div class="flex-1 overflow-hidden relative" @click.capture="openLinksInNewTab">
       <div class="text-response-container">
@@ -449,37 +451,6 @@ async function downloadPdf() {
 
 .apply-btn:disabled:hover {
   background: #cccccc;
-}
-
-/* Toolbar button styles */
-.button-group {
-  display: flex;
-  gap: 0.5em;
-}
-
-.download-btn {
-  padding: 0.5em 1em;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9em;
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-}
-
-.download-btn-green {
-  background-color: #4caf50;
-}
-
-.download-btn .material-icons {
-  font-size: 1.2em;
-}
-
-.download-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 .copy-btn {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -1,33 +1,43 @@
 <template>
   <div class="h-full bg-white flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between px-6 py-2 border-b border-gray-100 shrink-0">
-      <div class="flex items-center gap-3">
-        <button v-if="action !== 'index'" class="text-gray-400 hover:text-gray-700" :title="t('pluginWiki.backToIndex')" @click="router.back()">
+    <div class="flex items-center justify-between gap-2 px-6 py-2 border-b border-gray-100 shrink-0">
+      <div class="flex items-center gap-2 min-w-0">
+        <button
+          v-if="action !== 'index'"
+          class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          :title="t('pluginWiki.backToIndex')"
+          @click="router.back()"
+        >
           <span class="material-icons text-base">arrow_back</span>
         </button>
-        <h2 class="text-lg font-semibold text-gray-800">{{ title }}</h2>
+        <h2 class="text-lg font-semibold text-gray-800 truncate">{{ title }}</h2>
       </div>
-      <div class="flex gap-1 items-center">
+      <div class="flex items-center gap-2">
         <template v-if="action === 'page' && content">
-          <div class="button-group">
-            <button class="download-btn download-btn-green" :disabled="pdfDownloading" @click="downloadPdf">
-              <span class="material-icons">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
-              {{ t("pluginWiki.pdf") }}
-            </button>
-          </div>
-          <span v-if="pdfError" class="text-xs text-red-500 self-center ml-2" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
-        </template>
-        <div v-if="action === 'index'" class="button-group">
-          <button class="download-btn download-btn-green" data-testid="wiki-lint-chat-button" @click="startLintChat">
-            <span class="material-icons">rule</span>
-            {{ t("pluginWiki.lintChat") }}
+          <button
+            class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            :disabled="pdfDownloading"
+            @click="downloadPdf"
+          >
+            <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+            {{ t("pluginWiki.pdf") }}
           </button>
-        </div>
+          <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
+        </template>
+        <button
+          v-if="action === 'index'"
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm transition-colors"
+          data-testid="wiki-lint-chat-button"
+          @click="startLintChat"
+        >
+          <span class="material-icons text-base">rule</span>
+          {{ t("pluginWiki.lintChat") }}
+        </button>
         <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
           <button
             :class="[
-              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
               action === 'index' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
             ]"
             @click="navigate('index')"
@@ -37,7 +47,7 @@
           </button>
           <button
             :class="[
-              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
               action === 'log' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
             ]"
             @click="navigate('log')"
@@ -47,7 +57,7 @@
           </button>
           <button
             :class="[
-              'px-2.5 py-1 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
               action === 'lint_report' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
             ]"
             @click="navigate('lint_report')"
@@ -567,31 +577,6 @@ function handleContentClick(event: MouseEvent) {
 .entry-tag-chip:hover {
   background-color: #dbeafe;
   color: #1d4ed8;
-}
-.button-group {
-  display: flex;
-  gap: 0.5em;
-}
-.download-btn {
-  padding: 0.5em 1em;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9em;
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-}
-.download-btn-green {
-  background-color: #4caf50;
-}
-.download-btn .material-icons {
-  font-size: 1.2em;
-}
-.download-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 .wiki-content :deep(.wiki-link) {
   color: #2563eb;


### PR DESCRIPTION
## Summary

- **New sizing convention documented in `CLAUDE.md`** — interactive chrome controls standardize on `h-8` (32px), with `h-8 w-8` icon-only buttons, `h-8 px-2.5 gap-1` icon+label pills, `gap-2` between control groups, and `gap-0.5` inside icon clusters.
- **Applied the convention** to every top-bar and panel-header row: `PluginLauncher`, the lock/bell/settings cluster, `RoleSelector`, `SessionTabBar`, the new-session `+` button, and the session-history toggle.
- **Extracted `SessionHeaderControls`** — a shared component that renders RoleSelector + `+` + side-panel toggle. Used both in Row 2 (side panel closed) and the side-panel's own header. Row 2 wraps it in `w-[264px]` so the controls occupy the same x-range as they do inside the open panel — toggling the panel no longer shifts them.
- **History-panel hover fix** — the right-edge expand handle used to reveal when hovering anywhere in the panel (including the toolbar). It now only reveals when hovering the list area.
- **Swept plugin-view toolbars** — `textResponse`, `markdown`, `spreadsheet`, and `wiki` Views each had a near-duplicate `.button-group` / `.download-btn` scoped-CSS pattern. All four now use inline Tailwind matching the convention (action buttons `h-8 px-2.5 gap-1 rounded bg-green-600 …`; spreadsheet keeps its Excel `#217346` green). Wiki's back button becomes `h-8 w-8` and its three tab pills become `h-8 px-2.5` to match the `PluginLauncher` pattern.

Net: **~260 lines of CSS replaced with ~160 lines of Tailwind**, one new shared component, one new CLAUDE.md section.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck` — all green
- [x] `yarn test` — 29/29 unit tests pass
- [x] `yarn test:e2e` — all 343 Playwright tests pass (includes `plugin-launcher`, `session-tab-bar`, `session-history-side-panel`, `spreadsheet`, `wiki-*`)
- [ ] Manual smoke: toggle the history side panel on/off on `/chat` — the role selector / `+` / toggle trio should stay at the exact same x position
- [ ] Manual smoke: confirm hovering the panel header no longer reveals the right-edge expand handle
- [ ] Manual smoke: open each plugin view (textResponse, markdown, spreadsheet, wiki page + index + log + lint_report) and confirm the toolbars render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified session header controls component for improved header organization.

* **Style**
  * Standardized sizing and spacing across UI controls throughout the application.
  * Refined button dimensions and padding for consistent visual hierarchy.
  * Improved header layout spacing and alignment across multiple interface areas.

* **Refactor**
  * Reorganized header UI controls for better component structure and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->