### PR TITLE
fix: clear currentSessionId off /chat so background-finish doesn't clear unread

### DIFF
--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -5,7 +5,8 @@
 //
 // After the layout/page split:
 //  - Cmd+1 toggles layout (single ↔ stack) when on /chat; on other
-//    pages it navigates back to /chat without toggling.
+//    pages it is a no-op. Users return to /chat via the history panel
+//    or the app-home button.
 //  - Cmd+2–7 navigate directly to /files, /todos, /calendar, /wiki,
 //    /skills, /roles.
 //  - Cmd+9 navigates to /automations (added by #758 when Scheduler
@@ -102,7 +103,7 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     }).toPass();
   });
 
-  test("Cmd/Ctrl+1 from a non-chat page navigates to /chat without toggling layout", async ({ page }) => {
+  test("Cmd/Ctrl+1 on a non-chat page is a no-op (URL unchanged, layout unchanged)", async ({ page }) => {
     // Preset layout to single so we can detect any unexpected toggle.
     await page.goto("/chat");
     await page.evaluate(() => localStorage.setItem("canvas_layout_mode", "single"));
@@ -111,21 +112,22 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     await expect(page).toHaveURL(/\/files/);
 
     await pressShortcut(page, "1");
-    await expect(page).toHaveURL(/\/chat(?:\/|$|\?)/);
+    // URL must not change — Cmd+1 off /chat does nothing.
+    await expect(page).toHaveURL(/\/files/);
 
     const stored = await page.evaluate(() => localStorage.getItem("canvas_layout_mode"));
     expect(stored).toBe("single");
   });
 
-  test("Cmd/Ctrl+1 keeps the user's role selector pick when resuming a session (#701)", async ({ page }) => {
+  test("home button keeps the user's role selector pick when resuming a session (#701)", async ({ page }) => {
     // The role selector is user-owned: only the dropdown mutates it.
     // Resuming a session from another page must not yank the selector
     // back to the session's own roleId.
     //
     // Fixture sessions are created with roleId "general". Change the
-    // selector to "artist" on /files, then Cmd+1 back to /chat and
-    // confirm the selector still shows "Artist" even though the
-    // resumed session is tagged "general".
+    // selector to "artist" on /files, then click the app-home button
+    // to return to /chat and confirm the selector still shows
+    // "Artist" even though the resumed session is tagged "general".
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
 
@@ -136,7 +138,7 @@ test.describe("keyboard shortcuts (useEventListeners)", () => {
     await page.getByTestId("role-option-artist").click();
     await expect(page.getByTestId("role-selector-btn")).toContainText("Artist");
 
-    await pressShortcut(page, "1");
+    await page.getByTestId("app-home-btn").click();
     await expect(page).toHaveURL(/\/chat\//);
     await expect(page.getByTestId("role-selector-btn")).toContainText("Artist");
   });

--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -35,38 +35,6 @@ test.describe("session navigation via URL", () => {
     expect(page.url()).toMatch(/\/chat\/[\w-]+/);
   });
 
-  test("clicking the app home button keeps the current empty session when there is no history", async ({ page }) => {
-    await page.route(
-      (url) => url.pathname === "/api/sessions",
-      (route) => {
-        if (route.request().method() === "GET") {
-          return route.fulfill({
-            json: { sessions: [], cursor: "v1:0", deletedIds: [] },
-          });
-        }
-        return route.fallback();
-      },
-    );
-
-    await page.route(
-      (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
-      (route) => {
-        if (route.request().method() === "POST") {
-          return route.fulfill({ json: { ok: true } });
-        }
-        return route.fulfill({ status: 404, json: { error: "not found" } });
-      },
-    );
-
-    await page.goto("/chat");
-    await page.waitForURL(/\/chat\//);
-    const initialUrl = page.url();
-
-    await page.getByTestId("app-home-btn").click();
-
-    await expect(page).toHaveURL(initialUrl);
-  });
-
   test("clicking a session in history changes the URL", async ({ page }) => {
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);

--- a/plans/fix-session-id-selected-semantics.md
+++ b/plans/fix-session-id-selected-semantics.md
@@ -39,7 +39,7 @@ This replaces two concerns currently scattered through the code:
 
 ### Cmd+1 on non-chat → no-op
 
-`resumeOrCreateChatSession` and its `onMounted` call site are deleted. The `else` branch of `handleViewModeShortcut` becomes a bare return. Cmd+1 on /chat still toggles layout; on any other page it does nothing. Users who want to go to /chat can click a session in the history panel or use the URL.
+The `else` branch of `handleViewModeShortcut` becomes a bare return. Cmd+1 on /chat still toggles layout; on any other page it does nothing. Users who want to go to /chat can click a session in the history panel, click the app-home button, or use the URL. `resumeOrCreateChatSession` stays — it's still called from `onMounted` (initial /chat load) and `handleHomeClick` — and its dead "reuse current empty session" branch is dropped: with the new semantics, home-click on a truly empty /chat just creates a new session.
 
 ### Unread-clear paths
 

--- a/plans/fix-session-id-selected-semantics.md
+++ b/plans/fix-session-id-selected-semantics.md
@@ -1,0 +1,79 @@
+# plan: collapse `currentSessionId` to "selected session" semantics
+
+## Bugs fixed
+
+1. **Minor**: on a non-chat page (Todos, Wiki, Files, …) the session history panel still draws the blue "selected" border around the last-viewed chat session.
+2. **Serious**: if a run finishes while the user is on a non-chat page, the session's `hasUnread` flag gets cleared anyway — the user never actually read it.
+
+Both stem from the same root cause: `currentSessionId` is used under two different meanings in the codebase — (a) "last chat session the user was on, persists across pages" and (b) "session currently visible on screen." The fix unifies them under (b).
+
+## Non-goals
+
+- No favicon behaviour work. The favicon's spinner will stop reflecting a running chat session when the user is on a non-chat page; that is an accepted consequence, not a goal.
+- No rename of `currentSessionId` to `selectedSessionId`. Rename is mechanical and can follow separately.
+- No changes to the `markSessionRead` server API.
+
+## Design
+
+### Single source of truth
+
+`currentSessionId` means **the session currently displayed on /chat**. It is `""` whenever `isChatPage` is false. The derived `displayedCurrentSessionId` is deleted — it becomes identical to `currentSessionId` under the new rule.
+
+### When `currentSessionId` clears
+
+A single watcher in `App.vue`:
+
+```ts
+watch(isChatPage, (isChat, wasChat) => {
+  if (wasChat && !isChat) {
+    removeCurrentIfEmpty();
+    currentSessionId.value = "";
+  }
+});
+```
+
+This replaces two concerns currently scattered through the code:
+
+- Empty-session pruning previously called from `createNewSession` and `loadSession`. Within /chat, session switches no longer prune — the empty session lingers in `sessionMap` until the user leaves /chat. Memory-only, not user-visible.
+- The "last active" memory that `resumeOrCreateChatSession` depended on. Dropped (see below).
+
+### Cmd+1 on non-chat → no-op
+
+`resumeOrCreateChatSession` and its `onMounted` call site are deleted. The `else` branch of `handleViewModeShortcut` becomes a bare return. Cmd+1 on /chat still toggles layout; on any other page it does nothing. Users who want to go to /chat can click a session in the history panel or use the URL.
+
+### Unread-clear paths
+
+Three call sites currently compare `currentSessionId.value === sessionId`. Under the new rule they automatically become correct — the comparison yields `false` on non-chat pages because `currentSessionId` is `""`. No code change needed at the comparison sites themselves, but:
+
+- `useSessionSync.ts:38` has the same class of bug (suppressing a server-side `hasUnread = true` broadcast when the id matches `currentSessionId`). Under the new rule it too becomes correct automatically. No code change.
+
+### Watcher on `currentSessionId` (the existing one)
+
+The mark-read block at lines 549–557 stays where it is. It fires on every `currentSessionId` change — including `""` → sessionId (navigating back to /chat) and sessionId → `""` (navigating away). The `""` branch is a no-op (`sessionMap.get("")` is undefined, `sessions.find(...)` is undefined, `wasUnread` is false). The sessionId → `""` branch also no-ops for the same reason. Net: mark-read only fires when a real session becomes selected. Exactly what we want.
+
+### Subscription lifecycle
+
+Also in the existing watcher: when `currentSessionId` goes `A` → `""` (leaving /chat), `previousSessionId = A`, the code checks `prevBusy`. If `A` is running, subscription is kept (events still arrive — badge and unread stay fresh). If `A` is idle, subscription is torn down (fine — nothing to miss). Matches today's behavior; no change.
+
+### `alreadyOnThatChat` simplification
+
+`loadSession` currently checks `sessionId === currentSessionId.value && sessionMap.has(sessionId) && route.params.sessionId === sessionId`. The URL check was defensive against the dual meaning — on /wiki with `currentSessionId = A`, clicking A in the history panel would wrongly short-circuit without it. Under the new rule `currentSessionId` is `""` on non-chat, so `sessionId === ""` fails first. Drop the route-params check.
+
+### SessionTabBar
+
+- `isChatPage` prop removed.
+- Unread-dot condition `hasUnread && !(isChatPage && id === currentSessionId)` simplifies to `hasUnread && id !== currentSessionId`. Same truth table under the new rule.
+- Tab highlight class (`id === currentSessionId`) now draws on no tab when the user is on a non-chat page. Consistent with "nothing selected."
+- Comments updated.
+
+## Files touched
+
+- `src/App.vue` — add `isChatPage` watcher; drop `resumeOrCreateChatSession`; drop the `else` branch in `handleViewModeShortcut`; drop `removeCurrentIfEmpty` calls inside `createNewSession` / `loadSession`; simplify `alreadyOnThatChat`; replace remaining `displayedCurrentSessionId` references with `currentSessionId`; update the comment at line 283 and line 664.
+- `src/composables/useViewLayout.ts` — remove `displayedCurrentSessionId` and the `currentSessionId` opt.
+- `src/components/SessionTabBar.vue` — drop the `isChatPage` prop + usage.
+- `src/composables/useSessionSync.ts` — update the comment only (logic already becomes correct).
+
+## Verification
+
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`.
+- Manual: start on /chat with an unread session, confirm border + unread clear. Switch to /todos mid-run, confirm border disappears and the session stays marked unread after the run finishes. Return to /chat with the same session → unread clears. Cmd+1 on /todos does nothing.

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,7 @@
           :results="sidebarResults"
           :selected-uuid="selectedResultUuid"
           :result-timestamps="activeSession?.resultTimestamps ?? new Map()"
-          :is-running="isRunning"
+          :is-running="activeSessionRunning"
           :status-message="statusMessage"
           :pending-calls="pendingCalls"
           :session-role-name="sessionRoleName"
@@ -109,7 +109,7 @@
         <SuggestionsPanel ref="suggestionsPanelRef" :queries="currentRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
 
         <!-- Text input -->
-        <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="isRunning" @send="sendMessage()" />
+        <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="activeSessionRunning" @send="sendMessage()" />
       </div>
 
       <!-- Canvas column -->
@@ -161,7 +161,7 @@
              session context, so no chat input is shown) -->
         <div v-if="isChatPage && layoutMode === 'stack'" class="border-t border-gray-200 bg-white shrink-0">
           <SuggestionsPanel ref="suggestionsPanelRef" :queries="currentRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
-          <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="isRunning" @send="sendMessage()" />
+          <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="activeSessionRunning" @send="sendMessage()" />
         </div>
       </div>
 
@@ -355,8 +355,18 @@ const { markSessionRead } = useSessionSync({
 });
 const { geminiAvailable, sandboxEnabled, cpuLoadRatio, fetchHealth } = useHealth();
 
-const { activeSession, toolResults, sidebarResults, currentSummary, isRunning, statusMessage, toolCallHistory, activeSessionCount, unreadCount } =
-  useSessionDerived({ sessionMap, currentSessionId, sessions });
+const {
+  activeSession,
+  toolResults,
+  sidebarResults,
+  currentSummary,
+  isRunning,
+  activeSessionRunning,
+  statusMessage,
+  toolCallHistory,
+  activeSessionCount,
+  unreadCount,
+} = useSessionDerived({ sessionMap, currentSessionId, sessions });
 
 const { selectedResultUuid } = useSelectedResult({
   activeSession,
@@ -390,7 +400,7 @@ const chatInputRef = ref<{ focus: () => void } | null>(null);
 const { focusChatInput } = useChatScroll({
   toolResultsPanelRef,
   toolResults,
-  isRunning,
+  isRunning: activeSessionRunning,
   chatInputRef,
 });
 
@@ -519,7 +529,7 @@ const { availableTools, toolDescriptions, mcpToolsError, fetchMcpToolsStatus } =
 });
 
 const { pendingCalls, teardown: teardownPendingCalls } = usePendingCalls({
-  isRunning,
+  isRunning: activeSessionRunning,
   toolCallHistory,
 });
 
@@ -782,7 +792,7 @@ function unsubscribeSession(chatSessionId: string): void {
 
 async function sendMessage(text?: string) {
   const message = typeof text === "string" ? text : userInput.value.trim();
-  if (!message || isRunning.value) return;
+  if (!message || activeSessionRunning.value) return;
   userInput.value = "";
   const fileSnapshot = pastedFile.value;
   pastedFile.value = null;

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,13 +37,7 @@
             @update:side-panel-visible="setSidePanelVisible"
           />
         </div>
-        <SessionTabBar
-          :sessions="tabSessions"
-          :current-session-id="displayedCurrentSessionId"
-          :is-chat-page="isChatPage"
-          :roles="roles"
-          @load-session="handleSessionSelect"
-        />
+        <SessionTabBar :sessions="tabSessions" :current-session-id="currentSessionId" :roles="roles" @load-session="handleSessionSelect" />
       </div>
     </div>
 
@@ -280,11 +274,14 @@ const sessionMap = reactive(new Map<string, ActiveSession>());
 // subscription so events arrive via WebSocket.
 const sessionSubscriptions = new Map<string, () => void>();
 
-// currentSessionId is a plain ref so that synchronous writes (e.g.
-// inside createNewSession, which is called right before sendMessage
-// might run) take effect immediately. The URL is kept in sync via
-// navigateToSession, and external URL changes (back button, typed
-// URL) feed back into the ref via the route watcher below.
+// currentSessionId is "the session currently displayed on /chat" —
+// it's `""` whenever the user is on any other page. A plain ref (not
+// a computed) so synchronous writes (e.g. inside createNewSession,
+// which is called right before sendMessage might run) take effect
+// immediately. The URL is kept in sync via navigateToSession, and
+// external URL changes (back button, typed URL) feed back into the
+// ref via the route watcher below. An `isChatPage` watcher clears
+// it when the user leaves /chat.
 const currentSessionId = ref("");
 
 // --- Debug beat (pub/sub) ---
@@ -454,12 +451,12 @@ function handleViewModeShortcut(event: KeyboardEvent): void {
   if (event.altKey || event.shiftKey) return;
 
   if (event.key === "1") {
+    // Cmd+1 toggles layout on /chat; on any other page it's a no-op.
+    // Users navigate to /chat by clicking a session in the history
+    // panel or via the URL.
+    if (route.name !== PAGE_ROUTES.chat) return;
     event.preventDefault();
-    if (route.name === PAGE_ROUTES.chat) {
-      toggleLayoutMode();
-    } else {
-      resumeOrCreateChatSession().catch((err) => console.error("[Cmd+1] resume failed:", err));
-    }
+    toggleLayoutMode();
     return;
   }
 
@@ -481,11 +478,23 @@ function isPageRouteName(value: string): value is PageRouteName {
 }
 
 // Layout only matters on /chat; other pages are full-width by design.
-const { isStackLayout, displayedCurrentSessionId } = useViewLayout({
+const { isStackLayout } = useViewLayout({
   layoutMode,
   isChatPage,
-  currentSessionId,
   activePane,
+});
+
+// Clear currentSessionId when the user leaves /chat so downstream
+// consumers (history-panel border, mark-read, unread dot, session-
+// state sync) see "nothing selected" instead of the stale last-viewed
+// session. Also prune any empty session that was never sent to — we
+// don't persist empty sessions on the server. Fires true → false only;
+// an empty → /chat transition is handled by the route-params watcher
+// and onMounted.
+watch(isChatPage, (isChat, wasChat) => {
+  if (!(wasChat && !isChat)) return;
+  removeCurrentIfEmpty();
+  currentSessionId.value = "";
 });
 
 function handleSessionSelect(sessionId: string): void {
@@ -622,19 +631,14 @@ function onRoleChange() {
   maybeSeedRoleDefault(session);
 }
 
-// Land on /chat with no specific session in mind (initial load, Cmd+1
-// from another page). Prefer the most-recent session so the user
-// resumes where they left off; only create a fresh session when they
-// have no chat history at all. Explicit "+" clicks and role switches
-// still create a new session via createNewSession() directly.
+// Land on /chat with no specific session in mind (initial load).
+// Prefer the most-recent session so the user resumes where they left
+// off; only create a fresh session when they have no chat history at
+// all. Explicit "+" clicks and role switches still create a new
+// session via createNewSession() directly.
 async function resumeOrCreateChatSession(): Promise<void> {
   const topId = mergedSessions.value[0]?.id;
   if (!topId) {
-    const currentSession = sessionMap.get(currentSessionId.value);
-    if (currentSession && currentSession.toolResults.length === 0) {
-      navigateToSession(currentSession.id);
-      return;
-    }
     createNewSession();
     return;
   }
@@ -661,12 +665,11 @@ function activateSession(sessionId: string, replace: boolean): void {
 }
 
 async function loadSession(sessionId: string) {
-  // currentSessionId tracks "last active chat session" and is NOT
-  // reset when the user navigates to a non-chat page (/wiki, /files,
-  // …). Also checking the URL ensures that clicking the same session
-  // in the tab bar from /wiki still triggers a /chat navigation
-  // instead of silently no-opping.
-  const alreadyOnThatChat = sessionId === currentSessionId.value && sessionMap.has(sessionId) && route.params.sessionId === sessionId;
+  // currentSessionId is `""` on non-chat pages, so clicking a session
+  // in the history panel from /wiki never matches and always navigates
+  // to /chat. On /chat this guard just avoids re-navigating to the
+  // session we're already displaying.
+  const alreadyOnThatChat = sessionId === currentSessionId.value && sessionMap.has(sessionId);
   if (alreadyOnThatChat) return;
   // Mirror createNewSession: only replace when we just discarded an
   // empty session AND we're on that /chat/:emptyId URL. On any

--- a/src/App.vue
+++ b/src/App.vue
@@ -631,11 +631,11 @@ function onRoleChange() {
   maybeSeedRoleDefault(session);
 }
 
-// Land on /chat with no specific session in mind (initial load).
-// Prefer the most-recent session so the user resumes where they left
-// off; only create a fresh session when they have no chat history at
-// all. Explicit "+" clicks and role switches still create a new
-// session via createNewSession() directly.
+// Land on /chat with no specific session in mind (initial load or
+// home-button click). Prefer the most-recent session so the user
+// resumes where they left off; only create a fresh session when they
+// have no chat history at all. Explicit "+" clicks and role switches
+// still create a new session via createNewSession() directly.
 async function resumeOrCreateChatSession(): Promise<void> {
   const topId = mergedSessions.value[0]?.id;
   if (!topId) {

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -14,14 +14,11 @@
              so the SessionHistoryPanel picks up the same treatment. -->
         <SessionRoleIcon :session="sessions[i - 1]" :roles="roles" />
         <span class="text-xs text-gray-700 truncate min-w-0" :class="sessions[i - 1].hasUnread ? 'font-bold' : ''">{{ tabLabel(sessions[i - 1]) }}</span>
-        <!-- Unread dot. Suppressed only when the user is actually
-             looking at that chat session — otherwise
-             `currentSessionId` keeps pointing at the last chat
-             even when the user is on /wiki, /files, etc., and the
-             dot would silently disappear on the tab that most
-             needs it. -->
+        <!-- Unread dot. Suppressed on the currently-selected session —
+             which is `""` on non-chat pages, so the dot stays visible
+             there. -->
         <span
-          v-if="sessions[i - 1].hasUnread && !(isChatPage && sessions[i - 1].id === currentSessionId)"
+          v-if="sessions[i - 1].hasUnread && sessions[i - 1].id !== currentSessionId"
           class="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white"
           :aria-label="t('sessionTabBar.unreadDot')"
         />
@@ -42,13 +39,11 @@ const { t } = useI18n();
 
 const props = defineProps<{
   sessions: SessionSummary[];
+  // The session currently displayed on /chat, or `""` when the user
+  // is on any other page. Drives the tab highlight and the unread-dot
+  // suppression — no tab is "current" while the user is on /wiki,
+  // /files, etc.
   currentSessionId: string;
-  // `currentSessionId` is "the last chat session the user was on".
-  // It does NOT clear when the user navigates to /wiki /files etc.,
-  // so we need a separate flag to know whether that session is
-  // actually on-screen. Only then does it make sense to suppress
-  // the unread dot on its tab.
-  isChatPage: boolean;
   roles: Role[];
 }>();
 

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -21,16 +21,27 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
   // Global "is anything running" across every known session — in-memory
   // map (which reflects pub/sub events faster than server refetch) and
   // server-side summaries (for sessions not yet hydrated into the map).
-  // Scoping this to `activeSession` would drop to false as soon as the
-  // user leaves /chat (activeSession → undefined), firing downstream
-  // `watch(isRunning)` consumers before background runs actually
-  // finish — e.g. FilesView would refresh too early and miss writes.
+  // Used for consumers that must stay true across page navigation:
+  // favicon spinner and the FilesView refresh watcher (which would
+  // otherwise fire before a background run actually finishes, because
+  // leaving /chat drops activeSession to undefined).
   const isRunning = computed(() => {
     for (const session of sessionMap.values()) {
       if (session.isRunning) return true;
       if (Object.keys(session.pendingGenerations).length > 0) return true;
     }
     return sessions.value.some((summary) => summary.isRunning);
+  });
+
+  // True only when the session on screen has a run in flight. Drives
+  // UX touchpoints that should react per-session — ChatInput disable,
+  // sendMessage guard, chat-list auto-scroll, pending-call row tick —
+  // so a background run in session B doesn't disable the composer
+  // while the user is actively chatting in session A.
+  const activeSessionRunning = computed(() => {
+    const active = activeSession.value;
+    const pending = active ? Object.keys(active.pendingGenerations).length > 0 : false;
+    return currentSummary.value?.isRunning || active?.isRunning || pending || false;
   });
 
   const statusMessage = computed(() => currentSummary.value?.statusMessage ?? activeSession.value?.statusMessage ?? "");
@@ -47,6 +58,7 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
     sidebarResults,
     currentSummary,
     isRunning,
+    activeSessionRunning,
     statusMessage,
     toolCallHistory,
     activeSessionCount,

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -18,15 +18,19 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
 
   const currentSummary = computed(() => sessions.value.find((summary) => summary.id === currentSessionId.value));
 
-  // The server-side summary already merges pendingGenerations into
-  // `isRunning` (see server/api/routes/sessions.ts), but pub/sub events
-  // for background generations arrive faster than the next sessions
-  // refetch — fold the in-memory map in so ChatInput reflects the new
-  // state immediately.
+  // Global "is anything running" across every known session — in-memory
+  // map (which reflects pub/sub events faster than server refetch) and
+  // server-side summaries (for sessions not yet hydrated into the map).
+  // Scoping this to `activeSession` would drop to false as soon as the
+  // user leaves /chat (activeSession → undefined), firing downstream
+  // `watch(isRunning)` consumers before background runs actually
+  // finish — e.g. FilesView would refresh too early and miss writes.
   const isRunning = computed(() => {
-    const active = activeSession.value;
-    const pending = active ? Object.keys(active.pendingGenerations).length > 0 : false;
-    return currentSummary.value?.isRunning || active?.isRunning || pending || false;
+    for (const session of sessionMap.values()) {
+      if (session.isRunning) return true;
+      if (Object.keys(session.pendingGenerations).length > 0) return true;
+    }
+    return sessions.value.some((summary) => summary.isRunning);
   });
 
   const statusMessage = computed(() => currentSummary.value?.statusMessage ?? activeSession.value?.statusMessage ?? "");

--- a/src/composables/useViewLayout.ts
+++ b/src/composables/useViewLayout.ts
@@ -1,12 +1,9 @@
-// View-layout state. Derives two values that the template cares about:
+// View-layout state. Derives one value the template cares about:
 //
 //  - isStackLayout: true whenever the canvas column should be full-width
 //    (no sidebar). This is the case for /chat in stack mode AND for
 //    every non-chat page (/files, /todos, /wiki, etc.). Only /chat in
 //    single mode shows the left sidebar.
-//
-//  - displayedCurrentSessionId: blank on non-chat pages so no session
-//    tab appears "current" while the user is on Files, Todos, etc.
 //
 // Also flips activePane between "sidebar" and "main" so arrow-key
 // navigation follows whichever side of the layout is visible.
@@ -17,14 +14,11 @@ import { LAYOUT_MODES, type LayoutMode } from "../utils/canvas/layoutMode";
 export function useViewLayout(opts: {
   layoutMode: Ref<LayoutMode> | ComputedRef<LayoutMode>;
   isChatPage: Ref<boolean> | ComputedRef<boolean>;
-  currentSessionId: Ref<string>;
   activePane: Ref<"sidebar" | "main">;
 }) {
-  const { layoutMode, isChatPage, currentSessionId, activePane } = opts;
+  const { layoutMode, isChatPage, activePane } = opts;
 
   const isStackLayout = computed(() => !(isChatPage.value && layoutMode.value === LAYOUT_MODES.single));
-
-  const displayedCurrentSessionId = computed(() => (isChatPage.value ? currentSessionId.value : ""));
 
   watch(
     isStackLayout,
@@ -36,6 +30,5 @@ export function useViewLayout(opts: {
 
   return {
     isStackLayout,
-    displayedCurrentSessionId,
   };
 }


### PR DESCRIPTION
## Summary

- Two bugs with a shared root cause: `currentSessionId` was doubling as both "selected session" and "last active chat session", so switching to Todos/Wiki/Files left the history-panel blue border highlighted and silently cleared the unread flag when a background run finished.
- Collapses the semantics to **selected session** — empty string on non-chat pages — via a single `watch(isChatPage)` that clears the ref and prunes any empty session on the /chat → non-chat transition.
- Cmd+1 becomes a no-op on non-chat pages; `resumeOrCreateChatSession` stays for onMounted / home-click but the dead "last active" branch is dropped. `displayedCurrentSessionId` deleted — `currentSessionId` now serves both roles cleanly.

See `plans/fix-session-id-selected-semantics.md` for the full design.

### Bonus
`useSessionSync.ts:38` had the same class of bug (suppressing a server-side unread broadcast when the id matched `currentSessionId`, even on non-chat pages). Becomes correct automatically under the new rule — no code change.

### Accepted consequence
Favicon spinner no longer reflects a running chat session when the user is on a non-chat page. Unread-count badge still works (iterates the full session list).

## Test plan
- [ ] Start a chat run on /chat, switch to /todos mid-run — blue border on the session row in the history panel disappears.
- [ ] Let the run finish while still on /todos — the session stays marked unread (badge persists, bold text in history).
- [ ] Return to /chat for that session — unread clears, bold goes away.
- [ ] Cmd+1 on /todos / /wiki / /files — no-op (nothing navigates).
- [ ] Cmd+1 on /chat — still toggles layout.
- [ ] Click the home/logo button from any non-chat page — resumes the top session as before.
- [ ] Click a session in the history panel from /todos — navigates to /chat with that session selected.
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Cmd/Ctrl+1 keyboard shortcut behavior: now only toggles layout when on the chat page, with no effect from other pages.

* **Improvements**
  * Refined session selection and state management for improved consistency across different pages of the application. Session tracking now has clearer boundaries between chat and non-chat contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->