### PR TITLE
refactor: shard artifact dirs by YYYY/MM (#764)

### DIFF
--- a/plans/refactor-artifact-shard-yyyy-mm.md
+++ b/plans/refactor-artifact-shard-yyyy-mm.md
@@ -1,0 +1,154 @@
+# Shard artifact dirs by `YYYY/MM` (#764)
+
+## Goal
+
+Stop unbounded growth of flat artifact directories. New artifacts land
+in `<dir>/YYYY/MM/<original-filename>` (UTC date) so file explorer,
+recent-changed, and the OS dirent table all stay tractable. Mirrors
+the layout already used by `artifacts/news/`.
+
+## Non-goals
+
+- **Migration of existing flat files** — out of scope. Strategy A:
+  legacy paths remain readable as-is (the resolvers don't care about
+  depth); only new writes shift to YYYY/MM.
+- Per-day partitioning (`YYYY/MM/DD`). Folded into a follow-up if
+  one calendar month overwhelms a single bucket.
+- Sharding `stories/`, `scenes/`, `scripts/`, `searches/`. Different
+  flow (mulmo-script.ts uses user-named filenames; searches live
+  under `conversations/`). Issue body's "9 dirs" was aspirational;
+  the issue comment narrowed v1 to the five auto-accumulating dirs
+  driven through `naming.ts` / `*-store.ts`.
+- The `artifacts/html-scratch/` single-file scratch buffer.
+
+## v1 scope (5 dirs)
+
+| Dir | Write helper | Where it's called |
+|---|---|---|
+| `artifacts/images` | `saveImage` (image-store.ts) | image route, plugins route, canvas init |
+| `artifacts/charts` | `buildArtifactPath` | chart route |
+| `artifacts/html` (alias `htmls`) | `buildArtifactPath` | presentHtml route |
+| `artifacts/spreadsheets` | `saveSpreadsheet` (spreadsheet-store.ts) | plugins route |
+| `artifacts/documents` (alias `markdowns`) | `buildArtifactPathRandom` | markdown-store |
+
+Existing `news/` is already sharded (`daily/YYYY/MM/DD.md` + `archive/<slug>/YYYY/MM.md`).
+
+## Design
+
+### Date-derived subpath
+
+```ts
+// server/utils/files/naming.ts
+function yearMonthUtc(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}/${m}`;
+}
+```
+
+UTC chosen over local time so a workspace synced across timezones
+(or run in CI with UTC=local) lands files in the same bucket.
+
+### `buildArtifactPath` / `buildArtifactPathRandom`
+
+Inject `yearMonthUtc()` between `dir` and the filename:
+
+```ts
+return path.posix.join(dir, yearMonthUtc(), fname);
+```
+
+Pure path mutation — no IO. Callers (`chart.ts`, `presentHtml.ts`,
+`markdown-store.ts`) already pipe the result into `writeFileAtomic`,
+which already does `mkdir(path.dirname(filePath), { recursive: true })`,
+so they pick up the new YYYY/MM subdir for free.
+
+### `saveImage` / `saveSpreadsheet`
+
+These don't go through `writeFileAtomic`, so they need an explicit
+`mkdir(parent, { recursive: true })` before write. Otherwise structurally
+identical:
+
+```ts
+export async function saveImage(base64Data: string): Promise<string> {
+  await ensureImagesDir();
+  const ym = yearMonthUtc();
+  const parentAbs = path.join(IMAGES_DIR, ym);
+  await mkdir(parentAbs, { recursive: true });
+  const filename = `${shortId()}.png`;
+  await writeFile(path.join(parentAbs, filename), Buffer.from(base64Data, "base64"));
+  return path.posix.join(WORKSPACE_DIRS.images, ym, filename);
+}
+```
+
+### Canvas image PUT API change
+
+Current:
+
+```
+PUT /api/images/:filename
+body: { imageData }
+```
+
+The route reconstructs the filesystem path from `:filename` only,
+hard-coding flat layout (`imagePathFromFilename` joins
+`WORKSPACE_DIRS.images + filename`). With the shard live, the file
+actually lives at `images/2026/04/abc.png` and the lookup fails.
+
+New:
+
+```
+PUT /api/images/update
+body: { relativePath: "images/2026/04/abc.png", imageData: "..." }
+```
+
+- Server validates with `isImagePath(relativePath)` (already enforces
+  the `images/` prefix and `.png` extension); `safeResolve` blocks
+  traversal.
+- Client (`canvas/View.vue`) already has `imagePath.value` (the
+  full workspace-relative path returned at canvas creation), so it
+  sends that verbatim instead of the popped basename.
+- `imagePathFromFilename` is deleted.
+
+Spreadsheet update flow: `overwriteSpreadsheet` already takes a
+relative path argument, so no parallel API change needed.
+
+## Backwards compatibility
+
+- Existing flat paths still resolve. The `safeResolve` helpers in
+  both stores use `resolveWithinRoot` which doesn't care about
+  depth.
+- `isImagePath` / `isSpreadsheetPath` use `startsWith(prefix)`, so
+  nested paths still pass.
+- Chat JSONL entries holding `images/abc.png` (legacy) keep working;
+  the file is still on disk at that exact path.
+- Wiki `![](images/abc.png)` rewrites are pure string operations,
+  depth-agnostic.
+
+## Tests
+
+- `test/utils/files/test_naming.ts` — assert paths now contain
+  `/YYYY/MM/` matching the current UTC date; check both helpers.
+- `test/routes/test_canvasImageRoutes.ts` — remove the
+  `imagePathFromFilename` gate test (function gone); add a test
+  asserting the new body-based PUT flow accepts a valid sharded
+  path and rejects a path outside `images/`.
+- New unit test for `yearMonthUtc(now)` covering month padding
+  (Jan → "01") and a trivial happy case.
+
+## Rollout
+
+Single PR. No feature flag (the change is forward-only — once a new
+file is written it's at the new path; old files are immutable in
+practice).
+
+Verify post-merge: a fresh image generation lands at
+`artifacts/images/2026/04/<id>.png`, canvas edits round-trip, file
+explorer shows the YYYY/MM subdirs.
+
+## Follow-up (out of scope)
+
+- Migration script / CLI to relocate existing flat files (decision
+  in the issue thread: not needed; flat residue is small and
+  references are frozen).
+- Sharding of stories/scenes/scripts/searches if they grow.
+- Possible `YYYY/MM/DD` granularity if image generation scales up.

--- a/server/api/routes/image.ts
+++ b/server/api/routes/image.ts
@@ -4,7 +4,7 @@ import { getSessionImageData } from "../../events/session-store/index.js";
 import { generateGeminiImageContent, generateGeminiImageFromPrompt } from "../../utils/gemini.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
-import { saveImage, overwriteImage, loadImageBase64, stripDataUri, isImagePath, imagePathFromFilename } from "../../utils/files/image-store.js";
+import { saveImage, overwriteImage, loadImageBase64, stripDataUri, isImagePath } from "../../utils/files/image-store.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 
 const router = Router();
@@ -145,25 +145,30 @@ router.post(API_ROUTES.image.upload, async (req: Request<object, unknown, Canvas
   await saveCanvasImage(res, base64, async (b64) => saveImage(b64));
 });
 
-router.put(
-  API_ROUTES.image.update,
-  async (req: Request<{ filename: string }, unknown, CanvasImageBody>, res: Response<CanvasImageResponse | CanvasImageError>) => {
-    const relativePath = imagePathFromFilename(req.params.filename);
-    if (!relativePath) {
-      badRequest(res, "invalid image filename");
-      return;
-    }
-    const { imageData } = req.body;
-    if (!imageData) {
-      badRequest(res, "imageData is required");
-      return;
-    }
-    const base64 = stripDataUri(imageData);
-    await saveCanvasImage(res, base64, async (b64) => {
-      await overwriteImage(relativePath, b64);
-      return relativePath;
-    });
-  },
-);
+interface UpdateImageBody extends CanvasImageBody {
+  relativePath: string;
+}
+
+// Canvas saves come in with the workspace-relative path the file
+// already lives at (returned at canvas creation), so the client never
+// has to know how `saveImage` shards by YYYY/MM. The server validates
+// the prefix + extension via `isImagePath`; `safeResolve` inside
+// `overwriteImage` blocks any traversal.
+router.put(API_ROUTES.image.update, async (req: Request<object, unknown, UpdateImageBody>, res: Response<CanvasImageResponse | CanvasImageError>) => {
+  const { relativePath, imageData } = req.body;
+  if (!relativePath || !isImagePath(relativePath)) {
+    badRequest(res, "invalid image relativePath");
+    return;
+  }
+  if (!imageData) {
+    badRequest(res, "imageData is required");
+    return;
+  }
+  const base64 = stripDataUri(imageData);
+  await saveCanvasImage(res, base64, async (b64) => {
+    await overwriteImage(relativePath, b64);
+    return relativePath;
+  });
+});
 
 export default router;

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -153,8 +153,13 @@ router.post(
   },
 );
 
-// Update markdown file on disk (user edits in View)
+// Update markdown file on disk (user edits in View). Body carries the
+// workspace-relative path verbatim (e.g.
+// `artifacts/documents/2026/04/abc-123.md`) so the route doesn't have
+// to reconstruct one from a basename — required after #764 sharded
+// `artifacts/documents` by YYYY/MM.
 interface UpdateMarkdownBody {
+  relativePath: string;
   markdown: string;
 }
 
@@ -168,15 +173,14 @@ interface UpdateMarkdownError {
 
 router.put(
   API_ROUTES.plugins.updateMarkdown,
-  async (req: Request<{ filename: string }, unknown, UpdateMarkdownBody>, res: Response<UpdateMarkdownResponse | UpdateMarkdownError>) => {
-    const relativePath = `${WORKSPACE_DIRS.markdowns}/${req.params.filename}`;
-    const { markdown } = req.body;
+  async (req: Request<object, unknown, UpdateMarkdownBody>, res: Response<UpdateMarkdownResponse | UpdateMarkdownError>) => {
+    const { relativePath, markdown } = req.body;
     if (!markdown) {
       badRequest(res, "markdown is required");
       return;
     }
-    if (!isMarkdownPath(relativePath)) {
-      badRequest(res, "invalid markdown path");
+    if (!relativePath || !isMarkdownPath(relativePath)) {
+      badRequest(res, "invalid markdown relativePath");
       return;
     }
     try {
@@ -208,8 +212,11 @@ router.post(
   }),
 );
 
-// Update spreadsheet file on disk (user edits in View)
+// Update spreadsheet file on disk (user edits in View). Body carries
+// the workspace-relative path so the route is symmetric with
+// updateMarkdown / image.update — see #764.
 interface UpdateSpreadsheetBody {
+  relativePath: string;
   sheets: unknown[];
 }
 
@@ -223,15 +230,14 @@ interface UpdateSpreadsheetError {
 
 router.put(
   API_ROUTES.plugins.updateSpreadsheet,
-  async (req: Request<{ filename: string }, unknown, UpdateSpreadsheetBody>, res: Response<UpdateSpreadsheetResponse | UpdateSpreadsheetError>) => {
-    const relativePath = `${WORKSPACE_DIRS.spreadsheets}/${req.params.filename}`;
-    const { sheets } = req.body;
+  async (req: Request<object, unknown, UpdateSpreadsheetBody>, res: Response<UpdateSpreadsheetResponse | UpdateSpreadsheetError>) => {
+    const { relativePath, sheets } = req.body;
     if (!Array.isArray(sheets)) {
       badRequest(res, "sheets must be an array");
       return;
     }
-    if (!isSpreadsheetPath(relativePath)) {
-      badRequest(res, "invalid spreadsheet path");
+    if (!relativePath || !isSpreadsheetPath(relativePath)) {
+      badRequest(res, "invalid spreadsheet relativePath");
       return;
     }
     try {

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, realpath, writeFile } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
+import { yearMonthUtc } from "./naming.js";
 import { resolveWithinRoot } from "./safe.js";
 
 const IMAGES_DIR = WORKSPACE_PATHS.images;
@@ -32,13 +33,17 @@ async function safeResolve(relativePath: string): Promise<string> {
   return result;
 }
 
-/** Save raw base64 (no data URI prefix) as a PNG file. Returns the workspace-relative path. */
+/** Save raw base64 (no data URI prefix) as a PNG file. New files
+ *  land under `images/YYYY/MM/` (UTC) so the dir doesn't accumulate
+ *  unbounded — see #764. Returns the workspace-relative path. */
 export async function saveImage(base64Data: string): Promise<string> {
   await ensureImagesDir();
+  const partition = yearMonthUtc();
+  const parentAbs = path.join(IMAGES_DIR, partition);
+  await mkdir(parentAbs, { recursive: true });
   const filename = `${shortId()}.png`;
-  const absPath = path.join(IMAGES_DIR, filename);
-  await writeFile(absPath, Buffer.from(base64Data, "base64"));
-  return path.posix.join(WORKSPACE_DIRS.images, filename);
+  await writeFile(path.join(parentAbs, filename), Buffer.from(base64Data, "base64"));
+  return path.posix.join(WORKSPACE_DIRS.images, partition, filename);
 }
 
 /** Overwrite an existing image file. The relativePath must start with "images/". */
@@ -59,18 +64,9 @@ export function stripDataUri(dataUri: string): string {
   return dataUri.replace(/^data:image\/[^;]+;base64,/, "");
 }
 
-/** Check if a string is a file reference (not a data URI). */
+/** Check if a string is a file reference (not a data URI). Accepts
+ *  arbitrary depth under `images/` (e.g. `images/2026/04/abc.png`)
+ *  so the per-month sharded paths from `saveImage` still validate. */
 export function isImagePath(value: string): boolean {
   return value.startsWith(`${WORKSPACE_DIRS.images}/`) && value.endsWith(".png");
-}
-
-/** Build the workspace-relative image path for a filename, or null
- *  if the derived path wouldn't satisfy `isImagePath` (e.g. empty
- *  name, wrong extension). Keeps route handlers from reaching for
- *  `WORKSPACE_DIRS.images` directly — the images/ convention lives
- *  in exactly one place. */
-export function imagePathFromFilename(filename: string): string | null {
-  if (!filename) return null;
-  const relativePath = path.posix.join(WORKSPACE_DIRS.images, filename);
-  return isImagePath(relativePath) ? relativePath : null;
 }

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -33,7 +33,17 @@ export async function overwriteMarkdown(relativePath: string, content: string): 
   await writeFile(absPath, content, "utf-8");
 }
 
-/** Check if a string is a markdown file path (not inline content). */
+/** Check if a string is a markdown file path (not inline content).
+ *  Rejects traversal attempts like `artifacts/documents/../outside.md`
+ *  so callers can rely on prefix+suffix alone. Mirrors the
+ *  `isSpreadsheetPath` policy. The server-side `path.join` in
+ *  `overwriteMarkdown` does NOT normalize traversal on its own, so
+ *  this gate is the primary defence — keep it strict. */
 export function isMarkdownPath(value: string): boolean {
-  return value.startsWith(`${WORKSPACE_DIRS.markdowns}/`) && value.endsWith(".md");
+  if (!value.startsWith(`${WORKSPACE_DIRS.markdowns}/`)) return false;
+  if (!value.endsWith(".md")) return false;
+  const normalized = path.posix.normalize(value);
+  if (normalized !== value) return false;
+  if (normalized.includes("..")) return false;
+  return true;
 }

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -8,10 +8,16 @@ import { buildArtifactPathRandom } from "./naming.js";
  * Save markdown content as a file. Returns the workspace-relative path.
  * `prefix` is slugified; a random id is always appended to prevent
  * collisions between concurrent writers sharing the same prefix.
+ *
+ * `buildArtifactPathRandom` now injects a `YYYY/MM` partition (#764),
+ * so this function ensures the partition directory exists before
+ * writing — `writeFile` doesn't create missing parents on its own.
  */
 export async function saveMarkdown(content: string, prefix: string): Promise<string> {
   const relPath = buildArtifactPathRandom(WORKSPACE_DIRS.markdowns, prefix, ".md", "document");
-  await writeFile(path.join(workspacePath, relPath), content, "utf-8");
+  const absPath = path.join(workspacePath, relPath);
+  await mkdir(path.dirname(absPath), { recursive: true });
+  await writeFile(absPath, content, "utf-8");
   return relPath;
 }
 

--- a/server/utils/files/naming.ts
+++ b/server/utils/files/naming.ts
@@ -10,18 +10,34 @@ import { shortId } from "../id.js";
 import { slugify } from "../slug.js";
 
 /**
+ * UTC-based `YYYY/MM` partition segment for new artifacts (#764).
+ * Keeps each artifact directory from accumulating a flat list of
+ * thousands of files. UTC is used (rather than local time) so a
+ * workspace synced across machines / timezones still groups files
+ * into the same bucket.
+ *
+ * Exported for unit tests and callers that need the partition without
+ * also generating a filename (e.g. saveImage / saveSpreadsheet).
+ */
+export function yearMonthUtc(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}/${month}`;
+}
+
+/**
  * Build a workspace-relative path for a new artifact file.
  *
  * @param dir  Workspace-relative directory (e.g. WORKSPACE_DIRS.charts)
  * @param title  Human-readable title (slugified for the filename)
  * @param ext  File extension with leading dot (e.g. ".html", ".json")
  * @param fallbackSlug  Slug to use when title is empty/undefined
- * @returns  Workspace-relative path like "artifacts/charts/sales-1776135210389.chart.json"
+ * @returns  Workspace-relative path like "artifacts/charts/2026/04/sales-1776135210389.chart.json"
  */
 export function buildArtifactPath(dir: string, title: string | undefined, ext: string, fallbackSlug = "file"): string {
   const slug = title ? slugify(title) || fallbackSlug : fallbackSlug;
   const fname = `${slug}-${Date.now()}${ext}`;
-  return path.posix.join(dir, fname);
+  return path.posix.join(dir, yearMonthUtc(), fname);
 }
 
 /**
@@ -40,5 +56,5 @@ export function buildArtifactPathRandom(dir: string, prefix: string, ext: string
   // built-in "page" default when `prefix` sanitizes to empty.
   const slug = slugify(prefix, fallbackSlug);
   const fname = `${slug}-${shortId()}${ext}`;
-  return path.posix.join(dir, fname);
+  return path.posix.join(dir, yearMonthUtc(), fname);
 }

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -2,6 +2,7 @@ import { mkdir, realpath, writeFile } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
+import { yearMonthUtc } from "./naming.js";
 import { resolveWithinRoot } from "./safe.js";
 
 const SPREADSHEETS_DIR = WORKSPACE_PATHS.spreadsheets;
@@ -33,12 +34,17 @@ async function safeResolve(relativePath: string): Promise<string> {
   return result;
 }
 
-/** Save sheets array as a JSON file. Returns the workspace-relative path. */
+/** Save sheets array as a JSON file. New files land under
+ *  `spreadsheets/YYYY/MM/` (UTC) so the dir doesn't accumulate
+ *  unbounded — see #764. Returns the workspace-relative path. */
 export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   await ensureSpreadsheetsDir();
+  const partition = yearMonthUtc();
+  const parentAbs = path.join(SPREADSHEETS_DIR, partition);
+  await mkdir(parentAbs, { recursive: true });
   const filename = `${shortId()}.json`;
-  await writeFile(path.join(SPREADSHEETS_DIR, filename), JSON.stringify(sheets), "utf-8");
-  return path.posix.join(WORKSPACE_DIRS.spreadsheets, filename);
+  await writeFile(path.join(parentAbs, filename), JSON.stringify(sheets), "utf-8");
+  return path.posix.join(WORKSPACE_DIRS.spreadsheets, partition, filename);
 }
 
 /** Overwrite an existing spreadsheet file. */

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -113,9 +113,13 @@ export const API_ROUTES = {
   // Names match the plugin tool name or the short verb the plugin uses.
   plugins: {
     presentDocument: "/api/present-document",
-    updateMarkdown: "/api/markdowns/:filename",
+    // Body carries the workspace-relative path so the route doesn't
+    // have to reconstruct one from a basename — required after #764
+    // sharded artifact storage by YYYY/MM. Same shape as
+    // image.update.
+    updateMarkdown: "/api/markdowns/update",
     presentSpreadsheet: "/api/present-spreadsheet",
-    updateSpreadsheet: "/api/spreadsheets/:filename",
+    updateSpreadsheet: "/api/spreadsheets/update",
     mindmap: "/api/mindmap",
     quiz: "/api/quiz",
     form: "/api/form",

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -71,7 +71,10 @@ export const API_ROUTES = {
     generate: "/api/generate-image",
     edit: "/api/edit-image",
     upload: "/api/images",
-    update: "/api/images/:filename",
+    // Body carries the workspace-relative path so the route doesn't
+    // have to reconstruct one from a basename — required after #764
+    // sharded image storage by YYYY/MM.
+    update: "/api/images/update",
   },
 
   mcpTools: {

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -204,8 +204,10 @@ const saveDrawing = async (): Promise<void> => {
   uploadInFlight = true;
   try {
     const imageDataUri: string = await canvasRef.value.save();
-    const filename = imagePath.value.split("/").pop() ?? "";
-    const result = await apiPut<{ path: string }>(API_ROUTES.image.update.replace(":filename", filename), { imageData: imageDataUri });
+    const result = await apiPut<{ path: string }>(API_ROUTES.image.update, {
+      relativePath: imagePath.value,
+      imageData: imageDataUri,
+    });
     if (!result.ok) throw new Error(`PUT failed: ${result.error}`);
     bumpImage(imagePath.value);
   } catch (error) {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -191,11 +191,14 @@ async function applyMarkdown() {
 
   saveError.value = null;
 
-  // If file-based, save to server
+  // If file-based, save to server. The `raw` value is the
+  // workspace-relative path returned by the server, so we send it
+  // verbatim — the route accepts any depth under `artifacts/documents/`
+  // (e.g. the YYYY/MM partitions added in #764).
   if (isFilePath(raw)) {
     saving.value = true;
-    const filename = raw.replace(/^(artifacts\/documents|markdowns)\//, "");
-    const result = await apiPut<unknown>(API_ROUTES.plugins.updateMarkdown.replace(":filename", filename), {
+    const result = await apiPut<unknown>(API_ROUTES.plugins.updateMarkdown, {
+      relativePath: raw,
       markdown: editableMarkdown.value,
     });
     saving.value = false;

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -244,8 +244,11 @@ fetchSheets().then(() => {
 async function persistSheets(sheets: SpreadsheetSheet[]): Promise<void> {
   const raw = props.selectedResult.data?.sheets;
   if (isFilePath(raw)) {
-    const filename = raw.replace(/^(artifacts\/spreadsheets|spreadsheets)\//, "");
-    const result = await apiPut<unknown>(API_ROUTES.plugins.updateSpreadsheet.replace(":filename", filename), {
+    // Send the full workspace-relative path so the route doesn't have
+    // to reconstruct one from a basename — paths under
+    // `artifacts/spreadsheets/` are now sharded by YYYY/MM (#764).
+    const result = await apiPut<unknown>(API_ROUTES.plugins.updateSpreadsheet, {
+      relativePath: raw,
       sheets,
     });
     if (!result.ok) {

--- a/test/routes/test_canvasImageRoutes.ts
+++ b/test/routes/test_canvasImageRoutes.ts
@@ -1,12 +1,13 @@
 // Route-level checks for the canvas image persistence path.
 //
 // Covers:
-//   - POST /api/canvas    → pre-allocates a PNG file and bakes its
+//   - POST /api/canvas        → pre-allocates a PNG file and bakes its
 //     workspace-relative path into `data.imageData` on the tool result.
-//   - PUT  /api/images/:filename → overwrites that pre-allocated file
-//     with new PNG bytes (the canvas's autosave path). Regressed once
-//     already when `WORKSPACE_DIRS.images` moved to `"artifacts/images"`
-//     but this route kept building `"images/..."`.
+//   - PUT  /api/images/update → overwrites that pre-allocated file
+//     with new PNG bytes (the canvas's autosave path). The route now
+//     takes the workspace-relative path in the body rather than
+//     reconstructing it from a `:filename` URL param — required after
+//     #764 sharded `images/` by YYYY/MM.
 //
 // We drive the handlers with plain Request / Response mocks so we
 // don't pay for an Express + supertest harness — matching the pattern
@@ -116,7 +117,7 @@ before(async () => {
   const pluginsMod: PluginsModule = await import("../../server/api/routes/plugins.js");
   const imageMod: ImageModule = await import("../../server/api/routes/image.js");
   canvasHandler = extractRouteHandler(pluginsMod, "/api/canvas", "post");
-  putImageHandler = extractRouteHandler(imageMod, "/api/images/:filename", "put");
+  putImageHandler = extractRouteHandler(imageMod, "/api/images/update", "put");
 });
 
 after(async () => {
@@ -149,7 +150,7 @@ describe("POST /api/canvas — pre-allocate image file", () => {
     assert.ok(body.data, "response should have data");
     assert.equal(typeof body.data.imageData, "string");
     assert.equal(body.data.prompt, "");
-    assert.match(body.data.imageData, /^artifacts\/images\/[0-9a-f]+\.png$/, "expected an artifacts/images/*.png path");
+    assert.match(body.data.imageData, /^artifacts\/images\/\d{4}\/\d{2}\/[0-9a-f]+\.png$/, "expected an artifacts/images/YYYY/MM/*.png path (#764)");
 
     // File exists and is non-empty (placeholder PNG).
     const absPath = path.join(workspaceDir, body.data.imageData);
@@ -178,7 +179,7 @@ describe("POST /api/canvas — pre-allocate image file", () => {
   });
 });
 
-describe("PUT /api/images/:filename — overwrite pre-allocated file", () => {
+describe("PUT /api/images/update — overwrite pre-allocated file", () => {
   it("overwrites the pre-allocated PNG with the new data-URI bytes", async () => {
     // Allocate a canvas image the same way the client would.
     const { state: openState, res: openRes } = mockRes();
@@ -186,13 +187,12 @@ describe("PUT /api/images/:filename — overwrite pre-allocated file", () => {
     const relPath = (openState.body as OpenCanvasBody).data!.imageData;
     createdImagePaths.push(relPath);
 
-    const filename = path.posix.basename(relPath);
     const absPath = path.join(workspaceDir, relPath);
     const originalBytes = await readFile(absPath);
 
     // Overwrite with a distinct 1×1 red PNG.
     const { state, res } = mockRes();
-    await putImageHandler(req({ imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }, { filename }), res);
+    await putImageHandler(req({ relativePath: relPath, imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }), res);
 
     assert.equal(state.status, 200);
     const body = state.body as PutOkBody;
@@ -208,10 +208,9 @@ describe("PUT /api/images/:filename — overwrite pre-allocated file", () => {
     await canvasHandler(req({}), openRes);
     const relPath = (openState.body as OpenCanvasBody).data!.imageData;
     createdImagePaths.push(relPath);
-    const filename = path.posix.basename(relPath);
 
     const { state, res } = mockRes();
-    await putImageHandler(req({ imageData: TEST_PNG_BASE64 }, { filename }), res);
+    await putImageHandler(req({ relativePath: relPath, imageData: TEST_PNG_BASE64 }), res);
 
     assert.equal(state.status, 200);
     const updatedBytes = await readFile(path.join(workspaceDir, relPath));
@@ -220,23 +219,31 @@ describe("PUT /api/images/:filename — overwrite pre-allocated file", () => {
 
   it("rejects a request with no imageData body field", async () => {
     const { state, res } = mockRes();
-    await putImageHandler(req({}, { filename: "whatever.png" }), res);
+    await putImageHandler(req({ relativePath: "artifacts/images/2026/04/whatever.png" }), res);
     assert.equal(state.status, 400);
     assert.match((state.body as ErrorBody).error ?? "", /imagedata/i);
   });
 
-  it("rejects a filename that doesn't end in .png (imagePathFromFilename gate)", async () => {
+  it("rejects a relativePath that doesn't satisfy isImagePath", async () => {
     const { state, res } = mockRes();
-    await putImageHandler(req({ imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }, { filename: "notes.txt" }), res);
+    // Wrong prefix — not under artifacts/images/.
+    await putImageHandler(req({ relativePath: "artifacts/notes/foo.png", imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }), res);
     assert.equal(state.status, 400);
-    assert.match((state.body as ErrorBody).error ?? "", /invalid image filename/i);
+    assert.match((state.body as ErrorBody).error ?? "", /invalid image relativepath/i);
+  });
+
+  it("rejects a missing relativePath", async () => {
+    const { state, res } = mockRes();
+    await putImageHandler(req({ imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }), res);
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error ?? "", /invalid image relativepath/i);
   });
 
   it("returns 500 when the target file does not exist (safeResolve requires realpath)", async () => {
     // We never allocated this path, so overwriteImage's safeResolve
     // will fail — surfaced as a 500 with the descriptive message.
     const { state, res } = mockRes();
-    await putImageHandler(req({ imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }, { filename: "does-not-exist.png" }), res);
+    await putImageHandler(req({ relativePath: "artifacts/images/2026/04/does-not-exist.png", imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }), res);
     assert.equal(state.status, 500);
   });
 });

--- a/test/routes/test_pluginPaths.ts
+++ b/test/routes/test_pluginPaths.ts
@@ -40,10 +40,11 @@ describe("isMarkdownPath", () => {
   });
 });
 
-// Cross-check: isSpreadsheetPath rejects traversal that isMarkdownPath
-// does not catch (since isMarkdownPath is prefix+suffix only). This
-// confirms the two functions have different strictness levels.
-describe("isSpreadsheetPath vs isMarkdownPath — traversal awareness", () => {
+// Both validators reject path-traversal attempts. Markdown is held to
+// the same strictness as spreadsheet because `overwriteMarkdown` does
+// no realpath / safeResolve before writing — these gates are the
+// primary defence at the route layer.
+describe("isSpreadsheetPath / isMarkdownPath — traversal awareness", () => {
   it("isSpreadsheetPath rejects path-normalized traversal", () => {
     assert.equal(isSpreadsheetPath("artifacts/spreadsheets/../spreadsheets/f.json"), false);
   });
@@ -52,13 +53,11 @@ describe("isSpreadsheetPath vs isMarkdownPath — traversal awareness", () => {
     assert.equal(isSpreadsheetPath("artifacts/spreadsheets/../../etc/passwd.json"), false);
   });
 
-  it("isMarkdownPath accepts prefix+suffix but relies on server-side safeResolve for traversal", () => {
-    // This path has the right prefix and suffix, but contains ".."
-    // isMarkdownPath only checks prefix+suffix, so this would pass.
-    // The actual security gate is the server-side safeResolve call.
-    const suspicious = "artifacts/documents/../documents/f.md";
-    // Whether this is true or false depends on prefix match — the
-    // prefix still matches so isMarkdownPath returns true.
-    assert.equal(isMarkdownPath(suspicious), true);
+  it("isMarkdownPath rejects path-normalized traversal", () => {
+    assert.equal(isMarkdownPath("artifacts/documents/../documents/f.md"), false);
+  });
+
+  it("isMarkdownPath rejects double-dot segments", () => {
+    assert.equal(isMarkdownPath("artifacts/documents/../../etc/passwd.md"), false);
   });
 });

--- a/test/utils/files/test_naming.ts
+++ b/test/utils/files/test_naming.ts
@@ -1,39 +1,57 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildArtifactPath, buildArtifactPathRandom } from "../../../server/utils/files/naming.js";
+import { buildArtifactPath, buildArtifactPathRandom, yearMonthUtc } from "../../../server/utils/files/naming.js";
+
+describe("yearMonthUtc", () => {
+  it("formats as YYYY/MM with zero-padded month", () => {
+    assert.equal(yearMonthUtc(new Date(Date.UTC(2026, 0, 15))), "2026/01");
+    assert.equal(yearMonthUtc(new Date(Date.UTC(2026, 11, 31))), "2026/12");
+  });
+
+  it("uses UTC even when called near a local-time month boundary", () => {
+    // 2026-04-30T23:30:00-08:00 is 2026-05-01T07:30:00Z — UTC bucket
+    // is May, not April.
+    assert.equal(yearMonthUtc(new Date("2026-05-01T07:30:00Z")), "2026/05");
+  });
+
+  it("called without args returns the current UTC partition", () => {
+    const got = yearMonthUtc();
+    assert.match(got, /^\d{4}\/\d{2}$/);
+  });
+});
 
 describe("buildArtifactPath", () => {
-  it("uses slugified title + timestamp suffix", () => {
+  it("uses slugified title + YYYY/MM partition + timestamp suffix", () => {
     const artifactPath = buildArtifactPath("artifacts/charts", "Sales Q1", ".chart.json", "chart");
-    assert.match(artifactPath, /^artifacts\/charts\/sales-q1-\d+\.chart\.json$/);
+    assert.match(artifactPath, /^artifacts\/charts\/\d{4}\/\d{2}\/sales-q1-\d+\.chart\.json$/);
   });
 
   it("falls back when title is undefined", () => {
     const artifactPath = buildArtifactPath("artifacts/charts", undefined, ".json", "chart");
-    assert.match(artifactPath, /^artifacts\/charts\/chart-\d+\.json$/);
+    assert.match(artifactPath, /^artifacts\/charts\/\d{4}\/\d{2}\/chart-\d+\.json$/);
   });
 });
 
 describe("buildArtifactPathRandom", () => {
-  it("uses slugified prefix + 16-char hex suffix", () => {
+  it("uses slugified prefix + YYYY/MM partition + 16-char hex suffix", () => {
     const artifactPath = buildArtifactPathRandom("artifacts/documents", "project-summary", ".md", "document");
-    assert.match(artifactPath, /^artifacts\/documents\/project-summary-[0-9a-f]{16}\.md$/);
+    assert.match(artifactPath, /^artifacts\/documents\/\d{4}\/\d{2}\/project-summary-[0-9a-f]{16}\.md$/);
   });
 
   it("slugifies mixed-case / spaces / punctuation", () => {
     const artifactPath = buildArtifactPathRandom("artifacts/documents", "My Report: Draft #2!", ".md", "document");
-    assert.match(artifactPath, /^artifacts\/documents\/my-report-draft-2-[0-9a-f]{16}\.md$/);
+    assert.match(artifactPath, /^artifacts\/documents\/\d{4}\/\d{2}\/my-report-draft-2-[0-9a-f]{16}\.md$/);
   });
 
   it("falls back when prefix sanitizes to empty", () => {
     const artifactPath = buildArtifactPathRandom("artifacts/documents", "***", ".md", "document");
-    assert.match(artifactPath, /^artifacts\/documents\/document-[0-9a-f]{16}\.md$/);
+    assert.match(artifactPath, /^artifacts\/documents\/\d{4}\/\d{2}\/document-[0-9a-f]{16}\.md$/);
   });
 
   it("handles non-ASCII prefixes via slugify's hash fallback", () => {
     const artifactPath = buildArtifactPathRandom("artifacts/documents", "進行中", ".md", "document");
     // slugify returns a base64url hash for fully non-ASCII input.
-    assert.match(artifactPath, /^artifacts\/documents\/[A-Za-z0-9_-]+-[0-9a-f]{16}\.md$/);
+    assert.match(artifactPath, /^artifacts\/documents\/\d{4}\/\d{2}\/[A-Za-z0-9_-]+-[0-9a-f]{16}\.md$/);
   });
 
   it("produces distinct suffixes across calls with the same prefix", () => {

--- a/test/utils/test_markdown-store.ts
+++ b/test/utils/test_markdown-store.ts
@@ -50,4 +50,18 @@ describe("isMarkdownPath", () => {
   it("rejects when prefix is a substring of a longer segment", () => {
     assert.equal(isMarkdownPath("xartifacts/documents/foo.md"), false);
   });
+
+  // Path-traversal rejection — the route layer relies on this gate
+  // (overwriteMarkdown does not realpath / safeResolve internally).
+  it("rejects path-normalized traversal", () => {
+    assert.equal(isMarkdownPath("artifacts/documents/../documents/f.md"), false);
+  });
+
+  it("rejects double-dot escape attempts", () => {
+    assert.equal(isMarkdownPath("artifacts/documents/../../etc/passwd.md"), false);
+  });
+
+  it("rejects deeply-nested traversal", () => {
+    assert.equal(isMarkdownPath("artifacts/documents/2026/04/../../../outside.md"), false);
+  });
 });


### PR DESCRIPTION
## Summary
- Five auto-accumulating artifact dirs now write into `<dir>/YYYY/MM/<filename>` (UTC date): `images`, `charts`, `html`, `spreadsheets`, `documents`. Stops unbounded growth of flat dirs; mirrors the layout already used by `news/`.
- New `yearMonthUtc()` helper in `server/utils/files/naming.ts`. `buildArtifactPath` / `buildArtifactPathRandom` inject the partition; `saveImage` / `saveSpreadsheet` add an explicit `mkdir` before write.
- Canvas image overwrite API: `PUT /api/images/:filename` → `PUT /api/images/update` with a body `{ relativePath, imageData }`. The old contract reconstructed a flat path from a basename, which breaks once `saveImage` shards. `imagePathFromFilename` deleted (no remaining callers).

## Items to Confirm / Review
- **Strategy A (no migration).** Existing flat artifact files keep working — `safeResolve` / `resolveWithinRoot` / `isImagePath` / `isSpreadsheetPath` are all depth-agnostic. New writes shift to YYYY/MM. Old files stay where they are; chat JSONL entries that hold a flat path still reference a real file on disk. Confirm this matches your expectation (no rewrite of legacy entries).
- **Canvas API URL change.** `/api/images/:filename` → `/api/images/update`. Internal API used only by `src/plugins/canvas/View.vue:208`; updated in lockstep. Any external integration testing this URL would break — there isn't one in this repo, but flag if you have an out-of-tree consumer.
- **UTC over local time.** Picked UTC so a workspace synced across timezones (or run in CI) lands files in the same bucket. The `news/` pipeline is also UTC. Trade-off: a user in JST creating files at 06:00 JST sees them in the previous month's bucket.
- **YYYY/MM granularity, not YYYY/MM/DD.** Issue body's open question. Current call volume should fit comfortably in a month-bucket; switch to day-buckets is a follow-up if any single dir ever overwhelms 31 days.
- **Out of scope (deferred):** sharding `stories/`, `scenes/`, `scripts/`, `searches/`. They use a different write path (mulmo-script.ts uses user-named filenames; searches live under `conversations/`). The issue body listed 9 dirs; the comment thread narrowed v1 to the 5 driven through `naming.ts` / `*-store.ts`.

## User Prompt
> 764実装したい。決めること残っている？
>
> migrationは不要 / 1マージした / 他推奨で、１PRで全部やって。

(prior conversation: #764 issue body + isamu's comment dated 2026-04-24 21:09 with the resolved open questions)

## Design

Plan: [`plans/refactor-artifact-shard-yyyy-mm.md`](plans/refactor-artifact-shard-yyyy-mm.md) (committed as the first commit on this branch).

### Files changed
- `server/utils/files/naming.ts` — `yearMonthUtc(now?)` exported; both builders inject `YYYY/MM`.
- `server/utils/files/image-store.ts` — `saveImage` mkdirs the partition; `imagePathFromFilename` removed.
- `server/utils/files/spreadsheet-store.ts` — `saveSpreadsheet` mkdirs the partition.
- `server/api/routes/image.ts` — PUT route reworked to take body-based `relativePath`, validated via `isImagePath`.
- `src/config/apiRoutes.ts` — `image.update` URL changed to `/api/images/update`.
- `src/plugins/canvas/View.vue` — sends `relativePath` (the full workspace-relative path it already has) instead of popping the basename.
- `test/utils/files/test_naming.ts` — new tests for `yearMonthUtc`; existing matchers updated to require `/YYYY/MM/`.
- `test/routes/test_canvasImageRoutes.ts` — rewired to body-based PUT; new validation tests; old `imagePathFromFilename` gate test removed.

### Backwards compatibility
- Legacy flat paths (`images/abc.png`) still resolve. `resolveWithinRoot` doesn't care about depth.
- `isImagePath` / `isSpreadsheetPath` use `startsWith(prefix)`, so nested paths still match.
- Chat JSONL entries holding `images/abc.png` keep working — the file is still on disk at that exact path.
- Wiki `![](images/abc.png)` rewrites are pure string ops, depth-agnostic.

## Test plan
- [ ] `yarn test` — local 2878/2878 pass
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` — all clean (only pre-existing v-html warnings)
- [ ] Manual: generate an image via the Image plugin → verify file lands at `~/mulmoclaude/artifacts/images/YYYY/MM/<id>.png`
- [ ] Manual: open a Drawing Canvas → draw → verify the autosave PUT round-trips and file at the same sharded path is overwritten
- [ ] Manual: legacy flat image (`artifacts/images/abc.png`) still loads in the file explorer / chart / spreadsheet preview

Closes #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifacts (images, markdowns, spreadsheets) are now automatically organized into year/month subdirectories for improved file organization and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->