### PR TITLE
refactor: encapsulate currentRole inside SessionHeaderControls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,7 +27,6 @@
       <div v-if="!sidePanelVisible" class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
         <div class="w-[264px] shrink-0">
           <SessionHeaderControls
-            v-model:current-role-id="currentRoleId"
             :roles="roles"
             :side-panel-visible="sidePanelVisible"
             :active-session-count="activeSessionCount"
@@ -62,7 +61,6 @@
              button, so no second row is needed. -->
         <div class="flex items-center px-3 py-2 border-b border-gray-100">
           <SessionHeaderControls
-            v-model:current-role-id="currentRoleId"
             :roles="roles"
             :side-panel-visible="sidePanelVisible"
             :active-session-count="activeSessionCount"
@@ -106,7 +104,7 @@
         />
 
         <!-- Sample queries (expandable pane) -->
-        <SuggestionsPanel ref="suggestionsPanelRef" :queries="currentRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
+        <SuggestionsPanel ref="suggestionsPanelRef" :queries="sessionRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
 
         <!-- Text input -->
         <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="activeSessionRunning" @send="sendMessage()" />
@@ -160,7 +158,7 @@
         <!-- Bottom bar (Stack chat only — plugin views have no
              session context, so no chat input is shown) -->
         <div v-if="isChatPage && layoutMode === 'stack'" class="border-t border-gray-200 bg-white shrink-0">
-          <SuggestionsPanel ref="suggestionsPanelRef" :queries="currentRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
+          <SuggestionsPanel ref="suggestionsPanelRef" :queries="sessionRole.queries ?? []" @send="(q) => sendMessage(q)" @edit="onQueryEdit" />
           <ChatInput ref="chatInputRef" v-model="userInput" v-model:pasted-file="pastedFile" :is-running="activeSessionRunning" @send="sendMessage()" />
         </div>
       </div>
@@ -173,7 +171,7 @@
         ref="rightSidebarRef"
         :tool-call-history="toolCallHistory"
         :available-tools="availableTools"
-        :role-prompt="currentRole.prompt"
+        :role-prompt="sessionRole.prompt"
         :tool-descriptions="toolDescriptions"
       />
     </div>
@@ -249,7 +247,7 @@ import { useSidePanelVisible } from "./composables/useSidePanelVisible";
 import { useSelectedResult } from "./composables/useSelectedResult";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
-import { BUILTIN_ROLE_IDS } from "./config/roles";
+import { BUILTIN_ROLE_IDS, type Role } from "./config/roles";
 import { usePubSub } from "./composables/usePubSub";
 import { sessionChannel } from "./config/pubsubChannels";
 import { useHealth } from "./composables/useHealth";
@@ -293,20 +291,12 @@ const { subscribe: pubsubSubscribe } = usePubSub();
 const route = useRoute();
 const router = useRouter();
 
-// Omit ?role= for the default role to keep URLs clean.
-function buildRoleQuery(): Record<string, string> {
-  const roleId = currentRoleId.value;
-  if (!roleId || roles.value.length === 0 || roleId === roles.value[0]?.id) return {};
-  return { role: roleId };
-}
-
 function navigateToSession(sessionId: string, replace = false): void {
   currentSessionId.value = sessionId;
   const method = replace ? router.replace : router.push;
   method({
     name: PAGE_ROUTES.chat,
     params: { sessionId },
-    query: buildRoleQuery(),
   }).catch((err) => {
     if (err?.type !== 16) {
       console.error("[navigateToSession] push failed:", err);
@@ -341,7 +331,11 @@ watch(
 );
 
 // --- Global state ---
-const { roles, currentRoleId, currentRole, refreshRoles } = useRoles();
+// `currentRoleId` / `currentRole` deliberately do NOT live here:
+// they're owned by SessionHeaderControls (via useCurrentRole). Code
+// that needs "the role of the conversation in progress" reads
+// `sessionRole` below, which derives from the active session.
+const { roles, refreshRoles } = useRoles();
 
 const userInput = ref("");
 const pastedFile = ref<PastedFile | null>(null);
@@ -386,6 +380,20 @@ const sessionRoleIcon = computed(() => {
   const roleId = activeSession.value?.roleId;
   if (!roleId) return "";
   return roleIcon(roles.value, roleId);
+});
+
+// Role of the conversation in progress. Drives the suggested-query
+// list, the right-sidebar role-prompt, and the MCP tool filter so
+// they all match the active session (not the role-selector
+// dropdown — which is owned by SessionHeaderControls and whose
+// selection only matters at "+" / role-change time).
+const sessionRole = computed<Role>(() => {
+  const sessionRoleId = activeSession.value?.roleId;
+  if (sessionRoleId) {
+    const match = roles.value.find((role) => role.id === sessionRoleId);
+    if (match) return match;
+  }
+  return roles.value[0];
 });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
@@ -512,9 +520,9 @@ function handleSessionSelect(sessionId: string): void {
   loadSession(sessionId);
 }
 
-function handleNewSessionClick(): void {
+function handleNewSessionClick(roleId: string): void {
   sidePanelExpanded.value = false;
-  createNewSession();
+  createNewSession(roleId);
 }
 
 function handleHomeClick(): void {
@@ -524,7 +532,7 @@ function handleHomeClick(): void {
 const rightSidebarRef = ref<InstanceType<typeof RightSidebar> | null>(null);
 
 const { availableTools, toolDescriptions, mcpToolsError, fetchMcpToolsStatus } = useMcpTools({
-  currentRole,
+  currentRole: sessionRole,
   getDefinition: (name) => getPlugin(name)?.toolDefinition ?? null,
 });
 
@@ -621,7 +629,12 @@ function removeCurrentIfEmpty(): boolean {
 function createNewSession(roleId?: string): ActiveSession {
   const removedEmpty = removeCurrentIfEmpty();
   const replace = removedEmpty && isChatPage.value;
-  const rId = roleId ?? currentRoleId.value;
+  // The "+" button and role-change handler always supply roleId
+  // (read from SessionHeaderControls). The fallback covers callers
+  // that don't have a specific role in mind — initial bootstrap,
+  // post-failure recovery — where the first available role is the
+  // sensible default.
+  const rId = roleId ?? roles.value[0]?.id ?? "";
   const session = createEmptySession(uuidv4(), rId);
   sessionMap.set(session.id, session);
   navigateToSession(session.id, replace);
@@ -630,14 +643,14 @@ function createNewSession(roleId?: string): ActiveSession {
   return sessionMap.get(session.id)!;
 }
 
-function onRoleChange() {
+function onRoleChange(roleId: string) {
   // On non-chat pages (wiki, files, etc.) the user is just picking
   // the role that future new-chat actions should use — don't yank
-  // them onto /chat by creating a session here. currentRoleId is
-  // already updated by RoleSelector's v-model, so future "+" clicks
-  // or composer sends will pick it up.
+  // them onto /chat by creating a session here. The new selection
+  // is preserved inside SessionHeaderControls (useCurrentRole) and
+  // future "+" clicks will read it from there.
   if (!isChatPage.value) return;
-  const session = createNewSession(currentRoleId.value);
+  const session = createNewSession(roleId);
   maybeSeedRoleDefault(session);
 }
 
@@ -701,7 +714,7 @@ async function loadSession(sessionId: string) {
   const newSession = buildLoadedSession({
     id: sessionId,
     entries: response.data,
-    defaultRoleId: currentRoleId.value,
+    defaultRoleId: roles.value[0]?.id ?? "",
     urlResult: typeof route.query.result === "string" ? route.query.result : null,
     serverSummary: sessions.value.find((summary) => summary.id === sessionId),
     nowIso: new Date().toISOString(),
@@ -801,7 +814,6 @@ async function sendMessage(text?: string) {
   if (!session) return;
 
   beginUserTurn(session, message);
-  const sessionRole = roles.value.find((role) => role.id === session.roleId) ?? roles.value[0];
   const selectedRes = session.toolResults.find((result) => result.uuid === session.selectedResultUuid) ?? undefined;
 
   ensureSessionSubscription(session);
@@ -809,7 +821,7 @@ async function sendMessage(text?: string) {
   const result = await postAgentRun(
     buildAgentRequestBody({
       message,
-      role: sessionRole,
+      role: sessionRole.value,
       chatSessionId: session.id,
       selectedImageData: fileSnapshot?.dataUrl ?? extractImageData(selectedRes),
     }),

--- a/src/App.vue
+++ b/src/App.vue
@@ -247,6 +247,7 @@ import { useSidePanelVisible } from "./composables/useSidePanelVisible";
 import { useSelectedResult } from "./composables/useSelectedResult";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
+import { useCurrentRole } from "./composables/useCurrentRole";
 import { BUILTIN_ROLE_IDS, type Role } from "./config/roles";
 import { usePubSub } from "./composables/usePubSub";
 import { sessionChannel } from "./config/pubsubChannels";
@@ -331,11 +332,17 @@ watch(
 );
 
 // --- Global state ---
-// `currentRoleId` / `currentRole` deliberately do NOT live here:
-// they're owned by SessionHeaderControls (via useCurrentRole). Code
-// that needs "the role of the conversation in progress" reads
+// `roles` is the merged list (built-in + custom). `currentRoleId`
+// is the role-selector dropdown's current pick — App.vue reads it
+// as the fallback in createNewSession() so plugin callers like
+// wiki's `appApi.startNewChat(message)` (no roleId) start their
+// chat in whatever role the user last selected, instead of silently
+// reverting to the first built-in role. Writes to `currentRoleId`
+// happen only inside SessionHeaderControls (the dropdown owner).
+// Code that needs "the role of the conversation in progress" reads
 // `sessionRole` below, which derives from the active session.
 const { roles, refreshRoles } = useRoles();
+const { currentRoleId } = useCurrentRole(roles);
 
 const userInput = ref("");
 const pastedFile = ref<PastedFile | null>(null);
@@ -630,11 +637,12 @@ function createNewSession(roleId?: string): ActiveSession {
   const removedEmpty = removeCurrentIfEmpty();
   const replace = removedEmpty && isChatPage.value;
   // The "+" button and role-change handler always supply roleId
-  // (read from SessionHeaderControls). The fallback covers callers
-  // that don't have a specific role in mind — initial bootstrap,
-  // post-failure recovery — where the first available role is the
-  // sensible default.
-  const rId = roleId ?? roles.value[0]?.id ?? "";
+  // (read from SessionHeaderControls). When omitted (plugin-driven
+  // startNewChat, initial bootstrap, post-failure recovery) inherit
+  // the dropdown's current selection so the new chat uses the role
+  // the user last picked. Final fallback to roles[0] only matters
+  // before the dropdown has seeded (very early bootstrap).
+  const rId = roleId ?? (currentRoleId.value || roles.value[0]?.id || "");
   const session = createEmptySession(uuidv4(), rId);
   sessionMap.set(session.id, session);
   navigateToSession(session.id, replace);

--- a/src/components/SessionHeaderControls.vue
+++ b/src/components/SessionHeaderControls.vue
@@ -8,22 +8,21 @@
        so the controls don't visually shift when the panel toggles).
        Toggle behaviour differs slightly between callers — the side
        panel also collapses when hidden — so we emit a plain
-       `update:sidePanelVisible` and let the parent decide. -->
+       `update:sidePanelVisible` and let the parent decide.
+
+       This component owns the dropdown's selected role via
+       useCurrentRole (module-singleton state). The "+" button reads
+       it and forwards it through `newSession` so callers don't need
+       to track the selection themselves. -->
   <div class="flex items-center gap-2 w-full min-w-0">
-    <RoleSelector
-      :current-role-id="currentRoleId"
-      :roles="roles"
-      fluid
-      @update:current-role-id="(value: string) => emit('update:currentRoleId', value)"
-      @change="() => emit('roleChange')"
-    />
+    <RoleSelector v-model:current-role-id="currentRoleId" :roles="roles" fluid @change="emit('roleChange', currentRoleId)" />
     <div class="flex items-center gap-0.5 shrink-0">
       <button
         class="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
         data-testid="new-session-btn"
         :title="t('sessionTabBar.newSession')"
         :aria-label="t('sessionTabBar.newSession')"
-        @click="emit('newSession')"
+        @click="emit('newSession', currentRoleId)"
       >
         <span class="material-icons text-sm">add</span>
       </button>
@@ -38,25 +37,27 @@
 </template>
 
 <script setup lang="ts">
+import { toRef } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
+import { useCurrentRole } from "../composables/useCurrentRole";
 import RoleSelector from "./RoleSelector.vue";
 import SessionHistoryToggleButton from "./SessionHistoryToggleButton.vue";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   roles: Role[];
-  currentRoleId: string;
   sidePanelVisible: boolean;
   activeSessionCount: number;
   unreadCount: number;
 }>();
 
 const emit = defineEmits<{
-  "update:currentRoleId": [value: string];
-  roleChange: [];
-  newSession: [];
+  roleChange: [roleId: string];
+  newSession: [roleId: string];
   "update:sidePanelVisible": [value: boolean];
 }>();
+
+const { currentRoleId } = useCurrentRole(toRef(props, "roles"));
 </script>

--- a/src/composables/useCurrentRole.ts
+++ b/src/composables/useCurrentRole.ts
@@ -1,0 +1,33 @@
+// Singleton state for the role-selector dropdown's selected role.
+// Lives at module scope so SessionHeaderControls — which mounts and
+// unmounts whenever the session-history side panel toggles — keeps
+// the user's choice across remounts.
+//
+// Only SessionHeaderControls is allowed to import this composable;
+// every other consumer reads the role from the active session
+// (`activeSession.value.roleId`) instead.
+
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import type { Role } from "../config/roles";
+
+const currentRoleId = ref<string>("");
+
+export function useCurrentRole(roles: Ref<Role[]> | ComputedRef<Role[]>): {
+  currentRoleId: Ref<string>;
+  currentRole: ComputedRef<Role>;
+} {
+  // Seed once roles arrive (the initial fetch is async) and re-seed
+  // if the chosen id disappears from the list (e.g. a custom role
+  // was deleted out from under us).
+  watch(
+    roles,
+    (next) => {
+      if (next.length === 0) return;
+      const exists = next.some((role) => role.id === currentRoleId.value);
+      if (!exists) currentRoleId.value = next[0].id;
+    },
+    { immediate: true },
+  );
+  const currentRole = computed(() => roles.value.find((role) => role.id === currentRoleId.value) ?? roles.value[0]);
+  return { currentRoleId, currentRole };
+}

--- a/src/composables/useCurrentRole.ts
+++ b/src/composables/useCurrentRole.ts
@@ -1,11 +1,10 @@
 // Singleton state for the role-selector dropdown's selected role.
 // Lives at module scope so SessionHeaderControls — which mounts and
 // unmounts whenever the session-history side panel toggles — keeps
-// the user's choice across remounts.
-//
-// Only SessionHeaderControls is allowed to import this composable;
-// every other consumer reads the role from the active session
-// (`activeSession.value.roleId`) instead.
+// the user's choice across remounts, and so App.vue can read the
+// current selection when creating a new session for callers that
+// don't pass an explicit roleId (e.g. wiki composer's
+// `appApi.startNewChat(message)` — see useAppApi).
 
 import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
 import type { Role } from "../config/roles";

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -1,9 +1,9 @@
-// Composable that owns the active role list, the currently
-// selected role id, and the refresh-from-server fetch. The merge
-// rule lives in src/utils/roleMerge so it can be unit-tested
-// independently.
+// Composable that owns the active role list and its server-merge
+// fetch. The selected role is owned by SessionHeaderControls via
+// useCurrentRole — selection is a UI-local concern and lives next
+// to the dropdown that drives it.
 
-import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import { ROLES, type Role } from "../config/roles";
 import { mergeRoles } from "../utils/role/merge";
@@ -11,13 +11,9 @@ import { apiGet } from "../utils/api";
 
 export function useRoles(): {
   roles: Ref<Role[]>;
-  currentRoleId: Ref<string>;
-  currentRole: ComputedRef<Role>;
   refreshRoles: () => Promise<void>;
 } {
   const roles = ref<Role[]>(ROLES);
-  const currentRoleId = ref(ROLES[0].id);
-  const currentRole = computed(() => roles.value.find((role) => role.id === currentRoleId.value) ?? roles.value[0]);
 
   async function refreshRoles(): Promise<void> {
     const result = await apiGet<Role[]>(API_ROUTES.roles.list);
@@ -30,5 +26,5 @@ export function useRoles(): {
     roles.value = mergeRoles(ROLES, result.data);
   }
 
-  return { roles, currentRoleId, currentRole, refreshRoles };
+  return { roles, refreshRoles };
 }


### PR DESCRIPTION
## Summary

- Move the role-selector dropdown's selected-role state out of `App.vue` and into `SessionHeaderControls` (the component that owns the dropdown, "+" button, and side-panel toggle). New `useCurrentRole` composable holds the state at module scope so it survives the remount that happens when the side panel toggles.
- The "+" button now reads the current role and ships it through the `newSession` event; `roleChange` likewise carries the role id. `App.vue`'s `createNewSession` / `onRoleChange` take the id from the event payload — no other code touches `currentRole`.
- Fix a latent bug along the way: `SuggestionsPanel`, the right-sidebar role-prompt, and `useMcpTools` all read the dropdown state, so they would silently disagree with the conversation in progress whenever the dropdown changed without starting a new chat. They now read `sessionRole`, derived strictly from `activeSession.roleId` with `roles[0]` as the cold-start fallback.
- Drop the `?role=` URL query — it had no readers.

## Test plan

- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` — all green locally
- [ ] `yarn test` — passes locally
- [ ] Open the app, switch the dropdown role on `/wiki`, navigate to `/chat`, click `+` — new session uses the dropdown role
- [ ] Open two sessions with different roles; switching tabs updates suggestions, right-sidebar role prompt, and tool list to match the active session (not the dropdown)
- [ ] Toggle the session-history side panel — selected role survives the remount
- [ ] `yarn test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Role selection is now associated with individual sessions; the active role is determined from the current session state
  * Removed URL-based role selection via `?role=` parameter; role selection now occurs explicitly during session creation
  * Session and role management are now more tightly integrated across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->