### PR TITLE
feat(favicon): yellow dot for running + ambient-only background

### DIFF
--- a/plans/feat-favicon-status-dots.md
+++ b/plans/feat-favicon-status-dots.md
@@ -1,0 +1,165 @@
+# feat: favicon status dots + decoupled background
+
+## Problem
+
+Today's favicon overloads the background color to communicate two
+different things:
+
+1. **Activity** — is a session running? (blue / cyan)
+2. **Attention** — is a reply waiting? (green / fuchsia)
+
+…on top of the calendar/time-of-day flavour palette (morning, weekend,
+late-night, etc.). Whenever a session is running, the flavour palette
+goes dark — you never see "weekend teal" while Claude is thinking,
+even though weekend-ness has nothing to do with whether the agent is
+busy.
+
+Worse, two of the activity/attention rules consult the **current
+session** (`activeSession.value?.hasUnread`,
+`activeSession.value?.updatedAt`). If the user is on `/files`, the
+sources view, or any non-chat view, `activeSession` is `undefined`
+and the favicon misreports — for example a background session
+running for 3 minutes in another tab won't tip the icon to cyan
+because we only check the foreground session's `updatedAt`.
+
+## Goal
+
+Split the favicon into three independent visual channels that each
+own a single concern:
+
+| Channel | Says | Driven by |
+|---|---|---|
+| **Yellow dot** (top-left) | "at least one session is running" | global `isRunning` |
+| **Red dot** (top-right) | "a reply is waiting somewhere" | global unread + notifications |
+| **Background color** | "ambient context" — error, load, time-of-day, festive | resolver, with running/unread rules removed |
+
+The dots own the activity/attention story; the background owns the
+ambient story. They no longer fight for the same pixels.
+
+Every signal feeding this must be **global**, not per-current-session,
+because the user is regularly on non-chat views.
+
+## Visual changes
+
+### Yellow dot (new)
+
+- 5 px radius, white 1.5 px outline (matching the existing red dot)
+- Top-left corner (`x = dotR + 1`, `y = dotR + 1`)
+- Color: `#EAB308` yellow-500
+- Visible whenever any session has `isRunning === true`
+
+The existing white "running glow" ring is **removed** in this change.
+One running indicator is enough; the dot and the ring both fired on
+the same condition and the ring was the softer / more ambiguous of
+the two. `isRunning` is still wired into the renderer, but now its
+only visual effect is toggling the dot.
+
+### Red dot (unchanged)
+
+- Already top-right, 5 px, red-600 with white outline
+- Trigger condition unchanged (notifications OR any session unread)
+
+### Background color (slimmed)
+
+Drop the two rules whose job is now handled by the dots:
+
+- ❌ `running` (blue) — yellow dot shows it
+- ❌ `hasUnread` (green) — red dot shows it
+
+Keep everything else, including the **escalations** of those states,
+because the dots are binary but the background can convey severity:
+
+- ✅ `error` (red) — still the strongest alert
+- ✅ `overloaded` (orange) — CPU > 0.9
+- ✅ `manyUnread` (fuchsia) — ≥5 unread is more than "yeah there's a reply"
+- ✅ `runningLong` (cyan) — >60 s thinking is more than "started a run"
+- ✅ All flavour rules — birthday, new-year, christmas, late-night, morning, weekend, idle
+
+Net effect: when a single session is running for 10 seconds and the
+user has 1 unread reply, the icon now shows **weekend teal +
+yellow dot + red dot** instead of **plain blue with no calendar
+context**. Festive colors finally show up while the agent works.
+
+### Resolver priority after change
+
+```text
+1. error          (red)
+2. overloaded     (orange)
+3. manyUnread     (fuchsia) ← escalation of "has unread"
+4. runningLong    (cyan)    ← escalation of "running"
+5. birthday       (yellow)
+6. newYear        (deep red)
+7. christmas      (deep green)
+8. lateNight      (indigo)
+9. morning        (amber)
+10. weekend       (teal)
+11. idle          (gray)
+```
+
+The previous rules 5 (`running` blue) and 6 (`hasUnread` green) are
+removed — the dots cover them.
+
+## Decoupling from the current session
+
+`useFaviconState` currently consumes:
+
+- `currentSummary: ComputedRef<SessionSummary | undefined>` — the
+  on-screen session row
+- `activeSession: ComputedRef<ActiveSession | undefined>` — the
+  in-memory entry for the on-screen session
+
+Both go away. Instead it consumes a **global** view:
+
+- `sessions: ComputedRef<SessionSummary[]>` — every known session
+- `sessionsUnreadCount: ComputedRef<number>` — already global, kept
+- `isRunning: ComputedRef<boolean>` — already global (scans the whole
+  session map), kept
+
+Two derived facts that previously read from the current session move
+to whole-list scans:
+
+- **Done state** (`hasUnread`): now derived purely from
+  `sessionsUnreadCount > 0`. The favicon doesn't need to ask "is
+  *this* session unread?" — any unread anywhere counts.
+- **`runningSinceMs`**: now the **earliest `updatedAt`** of any
+  session with `isRunning === true`. If three sessions are running
+  and the oldest started 90 s ago, that 90 s is what triggers the
+  cyan "running long" escalation. Falls back to `Date.now()` if no
+  running session has a parseable `updatedAt`.
+
+## Architecture
+
+Files touched:
+
+| File | Change |
+|---|---|
+| `src/composables/useDynamicFavicon.ts` | Add `drawActiveSessionDot` (top-left). Remove the white "running glow" ring block. Wire the existing `isRunning` flag to call the dot drawer. New constant `ACTIVE_SESSION_DOT_COLOR = "#EAB308"`. |
+| `src/composables/useFaviconState.ts` | Drop `currentSummary` / `activeSession` opts. Add `sessions: ComputedRef<SessionSummary[]>`. Rewrite `faviconState` and `runningSinceMs` to use only global signals. |
+| `src/composables/favicon/resolveColor.ts` | Remove the `running` and `hasUnread` branches from `resolveByState`. Drop the matching entries from `COLORS` and `FAVICON_REASONS`. |
+| `src/composables/favicon/types.ts` | Remove `running` and `hasUnread` from `FAVICON_REASONS`. The 4-state `FAVICON_STATES` enum stays — `running` and `done` still drive priority inside the resolver, even though they no longer paint a unique background. |
+| `src/App.vue` | Update `useFaviconState({…})` call to pass `sessions` instead of `currentSummary` / `activeSession`. |
+| `test/composables/favicon/test_resolveColor.ts` | Drop the two cases asserting blue/green for `running` / `done`; add cases asserting that those states now fall through to flavour. |
+
+## Test plan
+
+- Unit: `resolveFaviconColor({ state: "running", … })` with no
+  escalations and a Saturday afternoon clock now returns weekend
+  teal — not blue.
+- Unit: `resolveFaviconColor({ state: "done", sessionsUnreadCount: 1 })`
+  on a weekday morning returns morning amber — not green. (The red
+  dot covers the unread.)
+- Unit: `resolveFaviconColor({ state: "running", runningSinceMs:
+  90 s ago })` still returns cyan — escalation preserved.
+- Manual: open two sessions, send a message in one, navigate to
+  `/files`, confirm yellow dot appears within ~1 s and persists.
+- Manual: leave a session running for >60 s on a weekend afternoon,
+  confirm icon shows cyan background + yellow dot + (red dot if
+  unread elsewhere).
+- Manual: idle on a Saturday at 14:00, confirm teal background with
+  no dots.
+
+## Out of scope
+
+- Animations on the dots (pulse, fade-in).
+- Per-role / per-origin dot color (e.g. blue dot for scheduler runs).
+- Reflecting *which* session is running — the dot is binary.

--- a/src/App.vue
+++ b/src/App.vue
@@ -378,11 +378,23 @@ const sessionRoleIcon = computed(() => {
   return roleIcon(roles.value, roleId);
 });
 
+const { mergedSessions, tabSessions } = useMergedSessions({
+  sessionMap,
+  sessions,
+});
+
 // ── Dynamic favicon (#470) ──────────────────────────────────
 // Every input here is global, not per-on-screen-session: the user
 // is often on /files or other non-chat views, so the favicon has
 // to react to the whole session list rather than `activeSession`.
-useFaviconState({ isRunning, sessions, sessionsUnreadCount: unreadCount, cpuLoadRatio });
+//
+// `isRunning` is the global scan from useSessionDerived (sessionMap +
+// server summaries), and `mergedSessions` folds the in-memory
+// `updatedAt` / `pendingGenerations` over server summaries — so the
+// runningLong clock picks up `beginUserTurn`'s local stamp on the
+// very same tick as `isRunning` flips, without waiting for the next
+// /api/sessions refetch.
+useFaviconState({ isRunning, sessions: mergedSessions, sessionsUnreadCount: unreadCount, cpuLoadRatio });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
@@ -490,11 +502,6 @@ const { pendingCalls, teardown: teardownPendingCalls } = usePendingCalls({
 });
 
 const selectedResult = computed(() => toolResults.value.find((result) => result.uuid === selectedResultUuid.value) ?? null);
-
-const { mergedSessions, tabSessions } = useMergedSessions({
-  sessionMap,
-  sessions,
-});
 
 // Centralised session-switch handler: subscribe to the current session's
 // pub/sub channel so we receive real-time events even if the session is

--- a/src/App.vue
+++ b/src/App.vue
@@ -355,18 +355,8 @@ const { markSessionRead } = useSessionSync({
 });
 const { geminiAvailable, sandboxEnabled, cpuLoadRatio, fetchHealth } = useHealth();
 
-const {
-  activeSession,
-  toolResults,
-  sidebarResults,
-  currentSummary,
-  isRunning,
-  activeSessionRunning,
-  statusMessage,
-  toolCallHistory,
-  activeSessionCount,
-  unreadCount,
-} = useSessionDerived({ sessionMap, currentSessionId, sessions });
+const { activeSession, toolResults, sidebarResults, isRunning, activeSessionRunning, statusMessage, toolCallHistory, activeSessionCount, unreadCount } =
+  useSessionDerived({ sessionMap, currentSessionId, sessions });
 
 const { selectedResultUuid } = useSelectedResult({
   activeSession,
@@ -389,10 +379,10 @@ const sessionRoleIcon = computed(() => {
 });
 
 // ── Dynamic favicon (#470) ──────────────────────────────────
-// `unreadCount` covers every session (not just the active tab), so
-// the favicon badge lights up when a background session gets a new
-// reply even though the user is looking at a different session.
-useFaviconState({ isRunning, currentSummary, activeSession, sessionsUnreadCount: unreadCount, cpuLoadRatio });
+// Every input here is global, not per-on-screen-session: the user
+// is often on /files or other non-chat views, so the favicon has
+// to react to the whole session list rather than `activeSession`.
+useFaviconState({ isRunning, sessions, sessionsUnreadCount: unreadCount, cpuLoadRatio });
 
 const toolResultsPanelRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);

--- a/src/composables/favicon/resolveColor.ts
+++ b/src/composables/favicon/resolveColor.ts
@@ -13,13 +13,16 @@ import { isBirthday, isChristmas, isLateNight, isManyUnread, isMorning, isNewYea
 // Keeping the palette values adjacent to the resolver (rather than
 // in a separate constants module) makes the "why does this colour
 // fire?" audit a one-file read.
+// "running" and "has-unread" no longer have background colors — the
+// yellow dot (top-left) and red dot (top-right) communicate those
+// states. The background is reserved for ambient context (error,
+// load, calendar, time-of-day) plus the two *escalations* of the
+// dot states (runningLong, manyUnread) that carry severity.
 const COLORS = {
   error: "#DC2626", // red-600
   overloaded: "#EA580C", // orange-600 — machine is burning
   manyUnread: "#D946EF", // fuchsia-500 — attention pile-up
   runningLong: "#06B6D4", // cyan-500 — still thinking (> 60 s)
-  running: "#3B82F6", // blue-500 — default running
-  hasUnread: "#22C55E", // green-500 — reply waiting
   birthday: "#EAB308", // yellow-500
   newYear: "#B91C1C", // red-700 — festive deeper red
   christmas: "#15803D", // green-700 — festive deeper green
@@ -33,8 +36,11 @@ const COLORS = {
 // argument is in one place and each helper stays under the
 // cognitive-complexity threshold.
 
-// Rules 1–6 in the plan: error + load + state-adjusted unread /
-// running. These always fire when applicable, beating any flavour.
+// Rules 1–4: error + load + escalations. These always fire when
+// applicable, beating any flavour. The plain `running` and
+// `hasUnread` rules are gone — the yellow / red corner dots own
+// those signals now, so the background stays free for ambient
+// context even while a session is running.
 function resolveByState(ctx: FaviconContext): FaviconPick | null {
   if (ctx.state === FAVICON_STATES.error) {
     return { color: COLORS.error, reason: FAVICON_REASONS.error };
@@ -45,14 +51,8 @@ function resolveByState(ctx: FaviconContext): FaviconPick | null {
   if (isManyUnread(ctx.sessionsUnreadCount)) {
     return { color: COLORS.manyUnread, reason: FAVICON_REASONS.manyUnread };
   }
-  if (ctx.state === FAVICON_STATES.running) {
-    if (isRunningLong(ctx.runningSinceMs, ctx.now)) {
-      return { color: COLORS.runningLong, reason: FAVICON_REASONS.runningLong };
-    }
-    return { color: COLORS.running, reason: FAVICON_REASONS.running };
-  }
-  if (ctx.state === FAVICON_STATES.done) {
-    return { color: COLORS.hasUnread, reason: FAVICON_REASONS.hasUnread };
+  if (ctx.state === FAVICON_STATES.running && isRunningLong(ctx.runningSinceMs, ctx.now)) {
+    return { color: COLORS.runningLong, reason: FAVICON_REASONS.runningLong };
   }
   return null;
 }

--- a/src/composables/favicon/types.ts
+++ b/src/composables/favicon/types.ts
@@ -20,8 +20,6 @@ export const FAVICON_REASONS = {
   overloaded: "overloaded",
   manyUnread: "many-unread",
   runningLong: "running-long",
-  running: "running",
-  hasUnread: "has-unread",
   birthday: "birthday",
   newYear: "new-year",
   christmas: "christmas",

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -19,6 +19,7 @@ import logoUrl from "../assets/mulmo_bw.png";
 // Keep the palette-independent display constants local to this file
 // — they describe pixel geometry, not semantics.
 const NOTIFICATION_DOT_COLOR = "#DC2626"; // red-600
+const ACTIVE_SESSION_DOT_COLOR = "#EAB308"; // yellow-500
 const SIZE = 32;
 const RADIUS = 6;
 // How much of the rounded square the mascot fills. 2 px of padding
@@ -117,22 +118,30 @@ function drawLogoCentered(ctx: CanvasRenderingContext2D, source: HTMLCanvasEleme
   ctx.drawImage(source, drawX, drawY, drawW, drawH);
 }
 
-function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
+function drawCornerDot(ctx: CanvasRenderingContext2D, dotX: number, dotY: number, color: string): void {
   const dotR = 5;
-  const dotX = SIZE - dotR - 1;
-  const dotY = dotR + 1;
   ctx.beginPath();
   ctx.arc(dotX, dotY, dotR, 0, Math.PI * 2);
-  ctx.fillStyle = NOTIFICATION_DOT_COLOR;
+  ctx.fillStyle = color;
   ctx.fill();
   ctx.strokeStyle = "white";
   ctx.lineWidth = 1.5;
   ctx.stroke();
 }
 
+function drawNotificationDot(ctx: CanvasRenderingContext2D): void {
+  const dotR = 5;
+  drawCornerDot(ctx, SIZE - dotR - 1, dotR + 1, NOTIFICATION_DOT_COLOR);
+}
+
+function drawActiveSessionDot(ctx: CanvasRenderingContext2D): void {
+  const dotR = 5;
+  drawCornerDot(ctx, dotR + 1, dotR + 1, ACTIVE_SESSION_DOT_COLOR);
+}
+
 // ── Composition ────────────────────────────────────────────────
 
-function renderFallbackFavicon(ctx: CanvasRenderingContext2D, color: string, hasNotification: boolean): void {
+function renderFallbackFavicon(ctx: CanvasRenderingContext2D, color: string, isRunning: boolean, hasNotification: boolean): void {
   drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
   ctx.fillStyle = color;
   ctx.fill();
@@ -143,6 +152,7 @@ function renderFallbackFavicon(ctx: CanvasRenderingContext2D, color: string, has
   ctx.textBaseline = "middle";
   ctx.fillText("M", SIZE / 2, SIZE / 2 + 1);
 
+  if (isRunning) drawActiveSessionDot(ctx);
   if (hasNotification) drawNotificationDot(ctx);
 }
 
@@ -157,16 +167,7 @@ function renderLogoFavicon(ctx: CanvasRenderingContext2D, logo: HTMLCanvasElemen
   drawLogoCentered(ctx, logo, MASCOT_INSET);
   ctx.restore();
 
-  // Running glow — kept at a fixed white/translucent ring so it reads
-  // against any resolved color (blue, cyan, orange, whatever) rather
-  // than having to retune per palette entry.
-  if (isRunning) {
-    ctx.strokeStyle = "rgba(255, 255, 255, 0.55)";
-    ctx.lineWidth = 1.5;
-    drawRoundedRect(ctx, 2.25, 2.25, SIZE - 4.5, SIZE - 4.5, Math.max(RADIUS - 1, 2));
-    ctx.stroke();
-  }
-
+  if (isRunning) drawActiveSessionDot(ctx);
   if (hasNotification) drawNotificationDot(ctx);
 }
 
@@ -187,7 +188,7 @@ async function renderFavicon(color: string, isRunning: boolean, hasNotification:
     }
   }
 
-  renderFallbackFavicon(ctx, color, hasNotification);
+  renderFallbackFavicon(ctx, color, isRunning, hasNotification);
   return canvas.toDataURL("image/png");
 }
 

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -50,13 +50,20 @@ export function useFaviconState(opts: {
   // a message (right before a run begins) and stays pinned until the
   // run ends, so it's a safe proxy for "this run started at…".
   //
-  // Scanning all sessions (instead of only the on-screen one) means
-  // a 3-minute-old background run in another session still trips the
-  // cyan runningLong escalation when the user is sitting on /files.
+  // Caller passes `mergedSessions` (live in-memory state OR'd with
+  // server summaries), so this scan picks up two things the raw
+  // server `sessions` list would miss until the next /api/sessions
+  // refetch:
+  //   • `beginUserTurn`'s synchronous `live.updatedAt` stamp, so the
+  //     runningLong clock is anchored to the actual user click, not
+  //     the refetch arrival time.
+  //   • `live.pendingGenerations` (folded into the merged summary's
+  //     `isRunning`), so a generation kicked off by the bridge or a
+  //     background tab counts the moment its event lands.
   //
   // Falls back to `Date.now()` only if no running session has a
   // parseable `updatedAt` (brand-new session before the first
-  // server echo).
+  // server echo and before `beginUserTurn`).
   const runningSinceMs = computed<number | null>(() => {
     if (!isRunning.value) return null;
     let earliest = Number.POSITIVE_INFINITY;

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -5,13 +5,17 @@
 // load, optional user birthday), feeds it through the pure
 // `resolveFaviconColor` rule chain, and hands the resolved color
 // to `useDynamicFavicon` for painting.
+//
+// Every input is global: the user is frequently on /files or other
+// non-chat views where `activeSession` is undefined, so relying on
+// the on-screen session would silently miss background activity.
 
-import { computed, onScopeDispose, ref, type ComputedRef } from "vue";
+import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from "vue";
 import { useDynamicFavicon } from "./useDynamicFavicon";
 import { useNotifications } from "./useNotifications";
 import { resolveFaviconColor } from "./favicon/resolveColor";
 import { FAVICON_STATES, type FaviconContext, type FaviconState } from "./favicon/types";
-import type { ActiveSession, SessionSummary } from "../types/session";
+import type { SessionSummary } from "../types/session";
 
 // Ticking cadence for the clock context. Once per minute is enough
 // to cross the morning / late-night / weekend / running-long
@@ -20,8 +24,8 @@ const FAVICON_TICK_MS = 60_000;
 
 export function useFaviconState(opts: {
   isRunning: ComputedRef<boolean>;
-  currentSummary: ComputedRef<SessionSummary | undefined>;
-  activeSession: ComputedRef<ActiveSession | undefined>;
+  /** Every known session summary — scanned for running / updatedAt. */
+  sessions: Ref<SessionSummary[]> | ComputedRef<SessionSummary[]>;
   /** Unread count across every session, not just the active one. */
   sessionsUnreadCount: ComputedRef<number>;
   /** Server CPU load1 / cores, or null if not yet fetched / Windows. */
@@ -29,38 +33,39 @@ export function useFaviconState(opts: {
   /** User birthday as "MM-DD" parsed from memory.md, or null. */
   userBirthdayMMDD?: ComputedRef<string | null>;
 }) {
-  const { isRunning, currentSummary, activeSession, sessionsUnreadCount, cpuLoadRatio, userBirthdayMMDD } = opts;
+  const { isRunning, sessions, sessionsUnreadCount, cpuLoadRatio, userBirthdayMMDD } = opts;
 
-  // Legacy 4-state enum still drives state priority inside the
-  // resolver. `running` vs `running-long` is split downstream by
-  // the runningSinceMs clock.
+  // 4-state enum still drives state priority inside the resolver.
+  // `done` here means "somebody somewhere has an unread reply", not
+  // "the on-screen session finished" — the dot already communicates
+  // that per session in the sidebar.
   const faviconState = computed<FaviconState>(() => {
     if (isRunning.value) return FAVICON_STATES.running;
-    const hasUnread = currentSummary.value?.hasUnread ?? activeSession.value?.hasUnread ?? false;
-    if (hasUnread) return FAVICON_STATES.done;
+    if (sessionsUnreadCount.value > 0) return FAVICON_STATES.done;
     return FAVICON_STATES.idle;
   });
 
-  // Run-start timestamp, derived from the session's `updatedAt` —
-  // which the server bumps every time the user sends a message, i.e.
-  // right before a run begins. That means:
-  //   1. The clock is correct across a page reload or a second tab:
-  //      a 5-minute-old run stays cyan instead of reverting to blue
-  //      for 60 s after mount.
-  //   2. We don't need a separate server "runStartedAt" field; the
-  //      existing `updatedAt` already serves as the anchor because
-  //      the session is locked during a run, so `updatedAt` can't
-  //      change until this run ends.
-  // Falls back to `Date.now()` only if the session has no
-  // `updatedAt` (brand-new session before the first server echo).
+  // Run-start timestamp — the **earliest** `updatedAt` across every
+  // running session. `updatedAt` is bumped the moment the user sends
+  // a message (right before a run begins) and stays pinned until the
+  // run ends, so it's a safe proxy for "this run started at…".
+  //
+  // Scanning all sessions (instead of only the on-screen one) means
+  // a 3-minute-old background run in another session still trips the
+  // cyan runningLong escalation when the user is sitting on /files.
+  //
+  // Falls back to `Date.now()` only if no running session has a
+  // parseable `updatedAt` (brand-new session before the first
+  // server echo).
   const runningSinceMs = computed<number | null>(() => {
     if (!isRunning.value) return null;
-    const updatedAt = activeSession.value?.updatedAt;
-    if (updatedAt) {
-      const parsed = new Date(updatedAt).getTime();
-      if (Number.isFinite(parsed)) return parsed;
+    let earliest = Number.POSITIVE_INFINITY;
+    for (const session of sessions.value) {
+      if (!session.isRunning) continue;
+      const parsed = new Date(session.updatedAt).getTime();
+      if (Number.isFinite(parsed) && parsed < earliest) earliest = parsed;
     }
-    return Date.now();
+    return Number.isFinite(earliest) ? earliest : Date.now();
   });
 
   // Per-minute tick so time-of-day rules (morning, late-night,

--- a/test/composables/favicon/test_resolveColor.ts
+++ b/test/composables/favicon/test_resolveColor.ts
@@ -22,7 +22,7 @@ function baseIdle(): FaviconContext {
   };
 }
 
-describe("resolveFaviconColor — state-driven rules (priority 1-6)", () => {
+describe("resolveFaviconColor — state-driven rules (priority 1-4)", () => {
   it("error state beats everything, including overload and calendar", () => {
     const pick = resolveFaviconColor({
       ...baseIdle(),
@@ -75,8 +75,10 @@ describe("resolveFaviconColor — state-driven rules (priority 1-6)", () => {
     assert.equal(pick.color, FAVICON_COLORS.runningLong);
   });
 
-  it("short running fires the default running branch", () => {
-    const now = new Date(2026, 3, 23, 14, 0, 10); // 10 s elapsed
+  it("short running falls through to flavour — yellow dot carries the signal, background shows ambient context", () => {
+    // 10 s elapsed on a plain weekday midday — no escalation fires,
+    // so the background should land on the flavour default (idle).
+    const now = new Date(2026, 3, 23, 14, 0, 10);
     const runningSinceMs = new Date(2026, 3, 23, 14, 0).getTime();
     const pick = resolveFaviconColor({
       ...baseIdle(),
@@ -84,18 +86,20 @@ describe("resolveFaviconColor — state-driven rules (priority 1-6)", () => {
       now,
       runningSinceMs,
     });
-    assert.equal(pick.reason, FAVICON_REASONS.running);
-    assert.equal(pick.color, FAVICON_COLORS.running);
+    assert.equal(pick.reason, FAVICON_REASONS.idle);
+    assert.equal(pick.color, FAVICON_COLORS.idle);
   });
 
-  it("has-unread fires for done state with a modest unread count", () => {
+  it("done state with a modest unread count falls through to flavour — red dot carries the signal", () => {
+    // Morning weekday with 2 unread — red dot shows unread, background
+    // paints the morning flavour. Previously this would have been green.
     const pick = resolveFaviconColor({
       ...baseIdle(),
       state: FAVICON_STATES.done,
       sessionsUnreadCount: 2,
+      now: new Date(2026, 3, 23, 7, 0),
     });
-    assert.equal(pick.reason, FAVICON_REASONS.hasUnread);
-    assert.equal(pick.color, FAVICON_COLORS.hasUnread);
+    assert.equal(pick.reason, FAVICON_REASONS.morning);
   });
 });
 
@@ -159,15 +163,27 @@ describe("resolveFaviconColor — flavour rules (priority 7-12)", () => {
 });
 
 describe("resolveFaviconColor — cross-rule priority", () => {
-  it("state-driven rules always beat flavour", () => {
-    // Christmas 00:00 with a running agent — running-blue, not christmas-green.
+  it("short-running agent on Christmas shows christmas flavour (yellow dot will indicate running)", () => {
+    // 1 s elapsed — under the 60 s runningLong threshold, so no state
+    // escalation fires and the flavour rule wins.
     const pick = resolveFaviconColor({
       ...baseIdle(),
       state: FAVICON_STATES.running,
-      runningSinceMs: new Date(2026, 11, 25, 0, 0).getTime() - 1000,
-      now: new Date(2026, 11, 25, 0, 0),
+      runningSinceMs: new Date(2026, 11, 25, 14, 0).getTime() - 1000,
+      now: new Date(2026, 11, 25, 14, 0),
     });
-    assert.equal(pick.reason, FAVICON_REASONS.running);
+    assert.equal(pick.reason, FAVICON_REASONS.christmas);
+  });
+
+  it("long-running agent still beats flavour via the runningLong escalation", () => {
+    // 90 s elapsed on Christmas — runningLong cyan takes priority.
+    const pick = resolveFaviconColor({
+      ...baseIdle(),
+      state: FAVICON_STATES.running,
+      runningSinceMs: new Date(2026, 11, 25, 14, 0).getTime() - 90_000,
+      now: new Date(2026, 11, 25, 14, 0),
+    });
+    assert.equal(pick.reason, FAVICON_REASONS.runningLong);
   });
 
   it("skips overloaded when cpuLoadRatio is null (no data yet / Windows)", () => {


### PR DESCRIPTION
## Summary

- Add a yellow top-left dot to the favicon that fires whenever any session is running. Paired with the existing red top-right dot, the two corner dots now own the "activity" and "attention" signals.
- Decouple the background color from those two signals. The plain `running` (blue) and `hasUnread` (green) background rules are **removed** — the dots cover them. The background keeps only the *escalations* (`runningLong` cyan, `manyUnread` fuchsia) plus error / overload / calendar / time-of-day flavour. Net effect: festive/weekend/morning colors finally show up while Claude is working.
- Drop the translucent white "running glow" ring — the yellow dot is the sole running indicator, one channel per signal.
- Rewire `useFaviconState` to **global** signals only. It no longer reads `currentSummary` / `activeSession`; it scans the full `sessions` list and uses the earliest running `updatedAt` for the runningLong escalation. Fixes a latent bug where a background run wouldn't trip cyan when the user was on `/files` or another non-chat view.

Plan: `plans/feat-favicon-status-dots.md`.

### Files

| File | Change |
|---|---|
| `src/composables/useDynamicFavicon.ts` | `drawActiveSessionDot` at top-left; shared `drawCornerDot` helper; glow ring removed; `isRunning` plumbed through fallback path too |
| `src/composables/favicon/resolveColor.ts` | Drop `running` + `hasUnread` branches and palette entries; keep escalations |
| `src/composables/favicon/types.ts` | Remove `running` / `hasUnread` from `FAVICON_REASONS` |
| `src/composables/useFaviconState.ts` | Swap `currentSummary`/`activeSession` → `sessions`; scan-all for `runningSinceMs`; `done` fires on global `sessionsUnreadCount > 0` |
| `src/App.vue` | Update `useFaviconState` call; drop now-unused `currentSummary` destructure |
| `test/composables/favicon/test_resolveColor.ts` | Replace the two cases asserting removed branches with fall-through assertions; add a runningLong-beats-christmas case |

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green
- [x] `yarn test` green (16/16 favicon resolver tests pass)
- [ ] Manual: open two sessions, send a message in one, navigate to `/files` — confirm yellow dot appears within ~1 s and persists while that run is in flight
- [ ] Manual: leave a session running >60 s on a weekend afternoon — confirm cyan background + yellow dot + (red dot if unread elsewhere)
- [ ] Manual: idle on a Saturday 14:00 — confirm teal background with no dots
- [ ] Manual: run a session during morning hours (05–09) — confirm amber background + yellow dot (previously would have been plain blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced favicon indicators: The favicon now displays a yellow activity indicator dot positioned in the top-left corner when sessions are actively running, while the red unread notification dot remains visible in the top-right corner. The overall favicon appearance has been simplified and refined for improved visual clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->