### PR TITLE
feat: interactive GFM task checkboxes in markdown viewer (#775, partial)

### DIFF
--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -14,6 +14,7 @@
 
 import { test, expect, type Page, type WebSocketRoute } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
+import type { SessionFixture } from "../fixtures/sessions";
 import type { NotificationPayload } from "../../src/types/notification";
 import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_KINDS, NOTIFICATION_PRIORITIES, NOTIFICATION_VIEWS } from "../../src/types/notification";
 
@@ -30,7 +31,24 @@ interface NotificationScenario {
   // path+search+hash, so specs with query strings use the full
   // string. Leave undefined when only the pathname matters.
   fullUrl?: string;
+  // Sessions to pre-seed in the mock. The chat-target scenario
+  // needs this: when the notification click pushes /chat/<id>,
+  // App.vue's session-load watcher fetches the session from the
+  // server. If the fetch 404s the watcher falls back to
+  // createNewSession(), clobbering the URL with a freshly-created
+  // UUID. Pre-seeding keeps the URL stable. Other scenarios don't
+  // need a session so the field defaults to an empty list.
+  seedSessions?: SessionFixture[];
 }
+
+const CHAT_TARGET_SESSION: SessionFixture = {
+  id: "sess-xyz",
+  title: "Notification target session",
+  roleId: "general",
+  startedAt: "2026-04-25T05:00:00Z",
+  updatedAt: "2026-04-25T05:00:00Z",
+  preview: "Stub for the notification permalink E2E",
+};
 
 function buildPayload(notifId: string, title: string, action: NotificationPayload["action"]): NotificationPayload {
   return {
@@ -53,6 +71,7 @@ const SCENARIOS: readonly NotificationScenario[] = [
     }),
     expectedPathname: "/chat/sess-xyz",
     fullUrl: "/chat/sess-xyz?result=uuid-abc",
+    seedSessions: [CHAT_TARGET_SESSION],
   },
   {
     description: "todos target with itemId",
@@ -247,7 +266,7 @@ test.describe("notification permalinks", () => {
 
   for (const scenario of SCENARIOS) {
     test(scenario.description, async ({ page }) => {
-      await mockAllApis(page, { sessions: [] });
+      await mockAllApis(page, { sessions: scenario.seedSessions ?? [] });
       await installNotificationStream(page, scenario.payload);
 
       // Start on /todos rather than /. The home redirect lands on

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -539,6 +539,8 @@ const deMessages = {
     saveError: "⚠ {error}",
     copyLabel: "Kopieren",
     copiedLabel: "Kopiert!",
+    taskCountMismatch:
+      "Die Anzahl der Aufgaben in der Markdown-Quelle und im gerenderten Ergebnis stimmt nicht überein. Das Umschalten wurde abgelehnt, um eine Beschädigung der Datei zu vermeiden.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -561,6 +561,7 @@ const enMessages = {
     saveError: "⚠ Save failed: {error}",
     copyLabel: "Copy",
     copiedLabel: "Copied!",
+    taskCountMismatch: "Markdown source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -547,6 +547,7 @@ const esMessages = {
     saveError: "⚠ Error al guardar: {error}",
     copyLabel: "Copiar",
     copiedLabel: "¡Copiado!",
+    taskCountMismatch: "El número de tareas no coincide entre la fuente Markdown y la salida renderizada. Se rechazó el cambio para evitar dañar el archivo.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -539,6 +539,7 @@ const frMessages = {
     saveError: "⚠ {error}",
     copyLabel: "Copier",
     copiedLabel: "Copié !",
+    taskCountMismatch: "Le nombre de tâches diffère entre la source Markdown et le rendu. La modification a été refusée pour éviter de corrompre le fichier.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -545,6 +545,7 @@ const jaMessages = {
     saveError: "⚠ 保存失敗: {error}",
     copyLabel: "コピー",
     copiedLabel: "コピーしました！",
+    taskCountMismatch: "Markdown ソースと描画結果でタスク数が一致しないため、ファイル破損を避けるためトグル操作を中止しました。",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -545,6 +545,7 @@ const koMessages = {
     saveError: "⚠ 저장 실패: {error}",
     copyLabel: "복사",
     copiedLabel: "복사됨!",
+    taskCountMismatch: "Markdown 원본과 렌더링 결과의 작업 수가 일치하지 않아, 파일 손상을 방지하기 위해 토글이 거부되었습니다.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -537,6 +537,7 @@ const ptBRMessages = {
     saveError: "⚠ {error}",
     copyLabel: "Copiar",
     copiedLabel: "Copiado!",
+    taskCountMismatch: "O número de tarefas diverge entre a fonte Markdown e a saída renderizada. A alternância foi recusada para evitar corromper o arquivo.",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -541,6 +541,7 @@ const zhMessages = {
     saveError: "⚠ 保存失败: {error}",
     copyLabel: "复制",
     copiedLabel: "已复制!",
+    taskCountMismatch: "Markdown 源与渲染输出的任务数不一致，为避免文件损坏，已拒绝切换。",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -312,7 +312,7 @@ function onMarkdownClick(event: MouseEvent): void {
   const sourceTasks = findTaskLines(markdownContent.value);
   if (sourceTasks.length !== taskInputs.length) {
     target.checked = !target.checked;
-    saveError.value = "Markdown source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.";
+    saveError.value = t("pluginMarkdown.taskCountMismatch");
     return;
   }
 

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -63,7 +63,7 @@ const { t } = useI18n();
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
-import { makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
+import { findTaskLines, makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { apiGet, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
@@ -301,6 +301,20 @@ function onMarkdownClick(event: MouseEvent): void {
   const taskInputs = root.querySelectorAll<HTMLInputElement>("input.md-task");
   const taskIndex = Array.from(taskInputs).indexOf(target);
   if (taskIndex < 0) return;
+
+  // Cross-check: if the source-side walker sees a different number
+  // of tasks than `marked` rendered into the DOM, the index map
+  // can't be trusted. The most common cause is a `- [ ]`-shaped line
+  // inside a 4-space indented code block (the source walker treats
+  // it as a task; marked treats it as code) — toggling source by
+  // index would corrupt the file. Refuse all clicks when this
+  // happens.
+  const sourceTasks = findTaskLines(markdownContent.value);
+  if (sourceTasks.length !== taskInputs.length) {
+    target.checked = !target.checked;
+    saveError.value = "Markdown source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.";
+    return;
+  }
 
   const updated = toggleTaskAt(markdownContent.value, taskIndex);
   if (updated === null) {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -254,20 +254,26 @@ async function applyMarkdown() {
 let taskPersistChain: Promise<unknown> = Promise.resolve();
 
 async function persistTaskMarkdown(relativePath: string, markdown: string): Promise<void> {
+  // Bail if the user navigated to a different result while this PUT
+  // was queued — the snapshot belongs to a document that's no longer
+  // on screen, and persisting it would clobber unrelated state.
+  if (props.selectedResult.data?.markdown !== relativePath) return;
+
   const result = await apiPut<unknown>(API_ROUTES.plugins.updateMarkdown, {
     relativePath,
     markdown,
   });
   if (!result.ok) {
     saveError.value = result.error;
-    // The optimistic local update no longer matches the server. Pull
-    // the canonical content back so the next click computes against
-    // the right source.
-    void fetchMarkdownContent();
-  } else {
-    // Clear any stale error from a prior failed click.
-    saveError.value = null;
+    // Refetch synchronously inside the chain so subsequent queued
+    // clicks observe the canonical (server-side) markdown before
+    // computing their own toggle. Detaching this with `void` could
+    // let the refetch land after a newer click already wrote.
+    await fetchMarkdownContent();
+    return;
   }
+  // Clear any stale error from a prior failed click.
+  saveError.value = null;
 }
 
 function onMarkdownClick(event: MouseEvent): void {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -26,7 +26,11 @@
       </div>
       <div class="markdown-content-wrapper">
         <div class="p-4">
-          <div class="markdown-content prose prose-slate max-w-none" v-html="renderedHtml"></div>
+          <!-- Click delegation: a single listener on the wrapper picks
+               up every interactive checkbox inserted by v-html. We
+               cannot bind @click directly on each `<input>` because
+               v-html bypasses Vue's template compiler. -->
+          <div class="markdown-content prose prose-slate max-w-none" @click="onMarkdownClick" v-html="renderedHtml"></div>
         </div>
       </div>
 
@@ -59,6 +63,7 @@ const { t } = useI18n();
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
+import { makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { apiGet, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
@@ -135,7 +140,12 @@ const renderedHtml = computed(() => {
   const raw = props.selectedResult.data?.markdown;
   const basePath = typeof raw === "string" && isFilePath(raw) ? raw.slice(0, raw.lastIndexOf("/")) : "";
   const withImages = rewriteMarkdownImageRefs(markdownContent.value, basePath);
-  return marked(withImages) as string;
+  // Strip the `disabled=""` attribute marked puts on GFM task
+  // checkboxes and tag them so `onMarkdownClick` can find them
+  // (#775). Inline content (no file backing) gets the same
+  // treatment so non-file-backed sessions still feel responsive,
+  // even though clicks there only update local state.
+  return makeTasksInteractive(marked(withImages) as string);
 });
 
 // Watch for scroll requests from viewState
@@ -226,6 +236,85 @@ async function applyMarkdown() {
 
   // Close the edit panel
   if (sourceDetails.value) sourceDetails.value.open = false;
+}
+
+// ── Inline task-list checkbox toggle (#775) ──────────────────────
+//
+// Click delegation handler bound to the rendered viewer. When the
+// user clicks a GFM task checkbox we:
+//   1. compute the new source via `toggleTaskAt`
+//   2. update local state optimistically (v-html re-renders to match)
+//   3. for file-backed docs, queue a PUT through the existing
+//      `/api/markdowns/update` route
+//
+// Skipped while the source editor is open — the textarea has its own
+// edit/apply flow and a checkbox click would race with whatever the
+// user is typing.
+
+let taskPersistChain: Promise<unknown> = Promise.resolve();
+
+async function persistTaskMarkdown(relativePath: string, markdown: string): Promise<void> {
+  const result = await apiPut<unknown>(API_ROUTES.plugins.updateMarkdown, {
+    relativePath,
+    markdown,
+  });
+  if (!result.ok) {
+    saveError.value = result.error;
+    // The optimistic local update no longer matches the server. Pull
+    // the canonical content back so the next click computes against
+    // the right source.
+    void fetchMarkdownContent();
+  } else {
+    // Clear any stale error from a prior failed click.
+    saveError.value = null;
+  }
+}
+
+function onMarkdownClick(event: MouseEvent): void {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+  if (target.type !== "checkbox") return;
+  if (!target.classList.contains("md-task")) return;
+  if (editing.value) {
+    // Edit panel open — let the textarea own the source. Reverting
+    // here keeps the visual in sync with the still-untouched markdown.
+    target.checked = !target.checked;
+    return;
+  }
+
+  const root = event.currentTarget as HTMLElement;
+  const taskInputs = root.querySelectorAll<HTMLInputElement>("input.md-task");
+  const taskIndex = Array.from(taskInputs).indexOf(target);
+  if (taskIndex < 0) return;
+
+  const updated = toggleTaskAt(markdownContent.value, taskIndex);
+  if (updated === null) {
+    // Source/DOM drift — refuse to write something we can't trace.
+    target.checked = !target.checked;
+    return;
+  }
+
+  // Optimistic local update — v-html will re-render and the
+  // textarea (if anyone opens it next) sees the same content.
+  markdownContent.value = updated;
+  editableMarkdown.value = updated;
+
+  const raw = props.selectedResult.data?.markdown;
+  if (typeof raw === "string" && isFilePath(raw)) {
+    // Serialize PUTs so quick successive clicks don't race each
+    // other on the wire — the chain captures `updated` per click.
+    taskPersistChain = taskPersistChain.then(() => persistTaskMarkdown(raw, updated));
+  } else {
+    // Inline content — emit so the parent stores the edit.
+    emit("updateResult", {
+      ...props.selectedResult,
+      data: {
+        ...props.selectedResult.data,
+        markdown: updated,
+        pdfPath: undefined,
+      },
+    });
+  }
 }
 
 // Watch for external changes to selectedResult (when user clicks different result)

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -263,6 +263,15 @@ async function persistTaskMarkdown(relativePath: string, markdown: string): Prom
     relativePath,
     markdown,
   });
+
+  // The user may have switched results during the round-trip. Skip
+  // every state mutation past this point — the watcher on
+  // `selectedResult.data?.markdown` already loads the new document,
+  // and writing `saveError` / triggering a refetch here would touch
+  // unrelated state (or refetch the *new* doc, masking edits the
+  // user just made there).
+  if (props.selectedResult.data?.markdown !== relativePath) return;
+
   if (!result.ok) {
     saveError.value = result.error;
     // Refetch synchronously inside the chain so subsequent queued

--- a/src/utils/markdown/taskList.ts
+++ b/src/utils/markdown/taskList.ts
@@ -20,14 +20,15 @@
 // markers (`>`, possibly nested), so:
 //   - [ ] foo
 //   * [x] bar
-//   1. [ ] baz
+//   1. [ ] dot-style ordered
+//   1) [ ] paren-style ordered
 //   > - [ ] quoted
 //   > > - [ ] nested-quoted
 // all match. `marked` renders all of these as a real task checkbox,
 // so they need to be counted (and writable) by the index walker.
 //
 // Captures: prefix (indent + any `>` chains), bullet, separator, mark.
-const TASK_LINE = /^(\s*(?:>\s*)*)([-*+]|\d+\.)(\s+)\[([ xX])\]/;
+const TASK_LINE = /^(\s*(?:>\s*)*)([-*+]|\d+[.)])(\s+)\[([ xX])\]/;
 
 // Fenced code block opener/closer. CommonMark allows fences to be
 // indented up to 3 spaces; ≥ 4 leading spaces makes the line literal
@@ -87,6 +88,30 @@ function flipMark(line: string, match: RegExpMatchArray): string {
   return `${prefix}${bullet}${sep}[${flipped}]` + line.slice(whole.length);
 }
 
+/** Find the source-line index of every task-list item, in document
+ *  order, skipping content inside fenced code blocks. Returned array
+ *  length is the total task count the source-side walker sees.
+ *
+ *  Exported so callers can cross-check the count against marked's
+ *  rendered DOM (`input.md-task` element count). When the two
+ *  disagree the source has tasks that marked is treating as code
+ *  (e.g. content of a 4-space indented code block) — the only safe
+ *  reaction is to refuse the click, never blindly toggle the
+ *  source-side n-th line.
+ */
+export function findTaskLines(source: string): number[] {
+  const lines = source.split("\n");
+  const fence: FenceState = { inFence: false, marker: null };
+  const taskLines: number[] = [];
+
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx];
+    if (stepFence(line, fence)) continue;
+    if (TASK_LINE.test(line)) taskLines.push(lineIdx);
+  }
+  return taskLines;
+}
+
 /** Toggle the n-th task-list checkbox in `source`. Returns the new
  *  markdown, or `null` if the index is out of range or the matched
  *  line isn't actually a task line (defensive against source/DOM
@@ -99,31 +124,22 @@ function flipMark(line: string, match: RegExpMatchArray): string {
  *  even though `marked` renders it verbatim. Full CommonMark indented-
  *  code-block detection is context-dependent (needs blank-line
  *  history, list-continuation column, etc.); the practical workaround
- *  is to use fences for code samples that contain task syntax. The
- *  click handler short-circuits via the `null` return when the source
- *  and DOM index lists disagree, so the worst case is a no-op click,
- *  not data corruption.
+ *  is twofold: (1) prefer fenced code for samples that contain task
+ *  syntax, and (2) the caller cross-checks `findTaskLines(source).length`
+ *  against the rendered DOM's `input.md-task` count and refuses to
+ *  write when they disagree, so the worst case is a no-op click — not
+ *  data corruption.
  */
 export function toggleTaskAt(source: string, taskIndex: number): string | null {
   if (!Number.isInteger(taskIndex) || taskIndex < 0) return null;
+  const taskLines = findTaskLines(source);
+  if (taskIndex >= taskLines.length) return null;
+  const lineIdx = taskLines[taskIndex];
   const lines = source.split("\n");
-  const fence: FenceState = { inFence: false, marker: null };
-  let counter = 0;
-
-  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
-    const line = lines[lineIdx];
-    if (stepFence(line, fence)) continue;
-
-    const taskMatch = line.match(TASK_LINE);
-    if (!taskMatch) continue;
-
-    if (counter === taskIndex) {
-      lines[lineIdx] = flipMark(line, taskMatch);
-      return lines.join("\n");
-    }
-    counter++;
-  }
-  return null;
+  const taskMatch = lines[lineIdx].match(TASK_LINE);
+  if (!taskMatch) return null;
+  lines[lineIdx] = flipMark(lines[lineIdx], taskMatch);
+  return lines.join("\n");
 }
 
 /** Strip `disabled=""` from rendered GFM task checkboxes and tag them

--- a/src/utils/markdown/taskList.ts
+++ b/src/utils/markdown/taskList.ts
@@ -15,16 +15,26 @@
 //    (which is also used by wiki/View.vue, where this PR doesn't yet
 //    enable interactive tasks).
 
-// Matches a GFM task-list marker at the start of a list line.
+// Matches a GFM task-list marker at the start of a list line. The
+// `prefix` group absorbs leading whitespace plus any blockquote
+// markers (`>`, possibly nested), so:
 //   - [ ] foo
 //   * [x] bar
 //   1. [ ] baz
-// Captures: indent, bullet, separator, mark.
-const TASK_LINE = /^(\s*)([-*+]|\d+\.)(\s+)\[([ xX])\]/;
+//   > - [ ] quoted
+//   > > - [ ] nested-quoted
+// all match. `marked` renders all of these as a real task checkbox,
+// so they need to be counted (and writable) by the index walker.
+//
+// Captures: prefix (indent + any `>` chains), bullet, separator, mark.
+const TASK_LINE = /^(\s*(?:>\s*)*)([-*+]|\d+\.)(\s+)\[([ xX])\]/;
 
-// Fenced code block opener/closer. ``` and ~~~ both legal in GFM; the
-// closing fence must use the same marker as the opener.
-const FENCE_LINE = /^(\s*)(```+|~~~+)/;
+// Fenced code block opener/closer. CommonMark allows fences to be
+// indented up to 3 spaces; ≥ 4 leading spaces makes the line literal
+// content of an indented code block, so we must NOT treat that as a
+// fence — otherwise the index-counter drifts. ``` and ~~~ are both
+// legal; the closing fence must use the same character as the opener.
+const FENCE_LINE = /^( {0,3})(`{3,}|~{3,})/;
 
 // Mutable state for the line walker. Pulled out so the main toggle
 // function reads as a flat loop rather than a state-machine swamp.
@@ -43,23 +53,31 @@ function stepFence(line: string, state: FenceState): boolean {
     if (!state.inFence) {
       state.inFence = true;
       state.marker = marker;
-    } else if (state.marker && marker.startsWith(state.marker[0])) {
-      // Closing fence must use the same marker character as the
-      // opener and be at least as long, per CommonMark.
+      return true;
+    }
+    // Closer must (a) use the same character as the opener and
+    // (b) be at least as long. Per CommonMark — a 3-backtick line
+    // does not close a 4-backtick fence; the inner line is content.
+    if (state.marker && marker[0] === state.marker[0] && marker.length >= state.marker.length) {
       state.inFence = false;
       state.marker = null;
+      return true;
     }
+    // A fence-shaped line that doesn't satisfy the closer rule is
+    // still inside the open fence — skip it like any other content.
     return true;
   }
   return state.inFence;
 }
 
 // Apply the [ ]/[x] flip captured by `TASK_LINE` and rebuild the line
-// with the rest of the original text intact.
+// with the rest of the original text intact. `prefix` includes any
+// indentation plus blockquote markers so quoted tasks like
+// `> - [ ] foo` round-trip cleanly.
 function flipMark(line: string, match: RegExpMatchArray): string {
-  const [whole, indent, bullet, sep, mark] = match;
+  const [whole, prefix, bullet, sep, mark] = match;
   const flipped = mark === " " ? "x" : " ";
-  return `${indent}${bullet}${sep}[${flipped}]` + line.slice(whole.length);
+  return `${prefix}${bullet}${sep}[${flipped}]` + line.slice(whole.length);
 }
 
 /** Toggle the n-th task-list checkbox in `source`. Returns the new
@@ -67,6 +85,17 @@ function flipMark(line: string, match: RegExpMatchArray): string {
  *  line isn't actually a task line (defensive against source/DOM
  *  drift). Indexing matches `marked`'s render order: top-down,
  *  document order, skipping content inside fenced code blocks.
+ *
+ *  Known limitation: 4-space *indented* code blocks (the alternative
+ *  to fenced) aren't tracked, so a `    - [ ] foo` line written as
+ *  literal code inside an indented block would be counted as a task
+ *  even though `marked` renders it verbatim. Full CommonMark indented-
+ *  code-block detection is context-dependent (needs blank-line
+ *  history, list-continuation column, etc.); the practical workaround
+ *  is to use fences for code samples that contain task syntax. The
+ *  click handler short-circuits via the `null` return when the source
+ *  and DOM index lists disagree, so the worst case is a no-op click,
+ *  not data corruption.
  */
 export function toggleTaskAt(source: string, taskIndex: number): string | null {
   if (!Number.isInteger(taskIndex) || taskIndex < 0) return null;

--- a/src/utils/markdown/taskList.ts
+++ b/src/utils/markdown/taskList.ts
@@ -1,0 +1,105 @@
+// GFM task-list helpers for the markdown viewer (#775).
+//
+// Two pieces, both pure / DOM-free so they can be unit tested:
+//
+//  - `toggleTaskAt(markdown, taskIndex)` — toggle the n-th `- [ ]` /
+//    `- [x]` line in the source. Walks lines and skips fenced code
+//    blocks so a literal task-looking line inside ``` ... ``` is not
+//    counted, matching what `marked` renders.
+//
+//  - `makeTasksInteractive(html)` — strip the `disabled=""` attribute
+//    that marked puts on rendered task checkboxes and tag them with
+//    `class="md-task"` so the click handler can find them via DOM
+//    delegation. We post-process the HTML rather than override
+//    marked's renderer to avoid mutating the global `marked` instance
+//    (which is also used by wiki/View.vue, where this PR doesn't yet
+//    enable interactive tasks).
+
+// Matches a GFM task-list marker at the start of a list line.
+//   - [ ] foo
+//   * [x] bar
+//   1. [ ] baz
+// Captures: indent, bullet, separator, mark.
+const TASK_LINE = /^(\s*)([-*+]|\d+\.)(\s+)\[([ xX])\]/;
+
+// Fenced code block opener/closer. ``` and ~~~ both legal in GFM; the
+// closing fence must use the same marker as the opener.
+const FENCE_LINE = /^(\s*)(```+|~~~+)/;
+
+// Mutable state for the line walker. Pulled out so the main toggle
+// function reads as a flat loop rather than a state-machine swamp.
+interface FenceState {
+  inFence: boolean;
+  marker: string | null;
+}
+
+// Update fence state for a single line. Returns true when the line is
+// part of a fence (opener, closer, or interior) and should be skipped
+// by the task counter.
+function stepFence(line: string, state: FenceState): boolean {
+  const fenceMatch = line.match(FENCE_LINE);
+  if (fenceMatch) {
+    const marker = fenceMatch[2];
+    if (!state.inFence) {
+      state.inFence = true;
+      state.marker = marker;
+    } else if (state.marker && marker.startsWith(state.marker[0])) {
+      // Closing fence must use the same marker character as the
+      // opener and be at least as long, per CommonMark.
+      state.inFence = false;
+      state.marker = null;
+    }
+    return true;
+  }
+  return state.inFence;
+}
+
+// Apply the [ ]/[x] flip captured by `TASK_LINE` and rebuild the line
+// with the rest of the original text intact.
+function flipMark(line: string, match: RegExpMatchArray): string {
+  const [whole, indent, bullet, sep, mark] = match;
+  const flipped = mark === " " ? "x" : " ";
+  return `${indent}${bullet}${sep}[${flipped}]` + line.slice(whole.length);
+}
+
+/** Toggle the n-th task-list checkbox in `source`. Returns the new
+ *  markdown, or `null` if the index is out of range or the matched
+ *  line isn't actually a task line (defensive against source/DOM
+ *  drift). Indexing matches `marked`'s render order: top-down,
+ *  document order, skipping content inside fenced code blocks.
+ */
+export function toggleTaskAt(source: string, taskIndex: number): string | null {
+  if (!Number.isInteger(taskIndex) || taskIndex < 0) return null;
+  const lines = source.split("\n");
+  const fence: FenceState = { inFence: false, marker: null };
+  let counter = 0;
+
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx];
+    if (stepFence(line, fence)) continue;
+
+    const taskMatch = line.match(TASK_LINE);
+    if (!taskMatch) continue;
+
+    if (counter === taskIndex) {
+      lines[lineIdx] = flipMark(line, taskMatch);
+      return lines.join("\n");
+    }
+    counter++;
+  }
+  return null;
+}
+
+/** Strip `disabled=""` from rendered GFM task checkboxes and tag them
+ *  with `class="md-task"` so the viewer's click delegation can find
+ *  them. Idempotent — running twice on the same HTML is a no-op on
+ *  the second pass (the `disabled` attribute is gone). */
+export function makeTasksInteractive(html: string): string {
+  // marked v18 default output:
+  //   <input disabled="" type="checkbox">         (unchecked)
+  //   <input checked="" disabled="" type="checkbox">  (checked)
+  // Both end with ` type="checkbox">`. Capture everything between
+  // `<input ` and `disabled=""` (typically empty or `checked="" `)
+  // and re-emit with `class="md-task"` in disabled's slot.
+  return html.replace(/<input ([^>]*)disabled="" type="checkbox">/g, '<input $1class="md-task" type="checkbox">');
+}

--- a/src/utils/markdown/taskList.ts
+++ b/src/utils/markdown/taskList.ts
@@ -35,7 +35,15 @@ const TASK_LINE = /^(\s*(?:>\s*)*)([-*+]|\d+[.)])(\s+)\[([ xX])\]/;
 // content of an indented code block, so we must NOT treat that as a
 // fence — otherwise the index-counter drifts. ``` and ~~~ are both
 // legal; the closing fence must use the same character as the opener.
+//
+// `stepFence` strips any leading blockquote prefix before applying
+// this regex so blockquote-wrapped fences (`> ``` ... `> ``` `) are
+// recognised. Without that, content inside a quoted fence would
+// be walked at top level and any `> - [ ]`-shaped line inside would
+// be miscounted as a task — making the View's count-cross-check
+// refuse all toggles in the whole document.
 const FENCE_LINE = /^( {0,3})(`{3,}|~{3,})/;
+const BLOCKQUOTE_PREFIX = /^(\s*(?:>\s?)+)/;
 
 // Mutable state for the line walker. Pulled out so the main toggle
 // function reads as a flat loop rather than a state-machine swamp.
@@ -48,7 +56,15 @@ interface FenceState {
 // part of a fence (opener, closer, or interior) and should be skipped
 // by the task counter.
 function stepFence(line: string, state: FenceState): boolean {
-  const fenceMatch = line.match(FENCE_LINE);
+  // Strip a blockquote prefix (one or more `>` markers) so a fence
+  // line written as `> ```` is recognised the same as a top-level
+  // ` ``` `. Inside the blockquote, the 0-3-space indent rule of
+  // FENCE_LINE still applies relative to the post-quote content, so
+  // `>     ``` ` (≥ 4 spaces of content indent) is correctly NOT a
+  // fence.
+  const quoteMatch = line.match(BLOCKQUOTE_PREFIX);
+  const content = quoteMatch ? line.slice(quoteMatch[0].length) : line;
+  const fenceMatch = content.match(FENCE_LINE);
   if (fenceMatch) {
     const marker = fenceMatch[2];
     if (!state.inFence) {
@@ -65,7 +81,9 @@ function stepFence(line: string, state: FenceState): boolean {
     //   (c) NO info string — only whitespace allowed after the marker
     // Without (c), a line like "``` js" inside a fence would be
     // wrongly treated as the closer; marked keeps it as content.
-    const afterMarker = line.slice(fenceMatch[0].length);
+    // (Slice from `content`, not `line` — fenceMatch[0] is relative
+    // to the post-blockquote-strip content.)
+    const afterMarker = content.slice(fenceMatch[0].length);
     if (state.marker && marker[0] === state.marker[0] && marker.length >= state.marker.length && /^\s*$/.test(afterMarker)) {
       state.inFence = false;
       state.marker = null;

--- a/src/utils/markdown/taskList.ts
+++ b/src/utils/markdown/taskList.ts
@@ -51,14 +51,21 @@ function stepFence(line: string, state: FenceState): boolean {
   if (fenceMatch) {
     const marker = fenceMatch[2];
     if (!state.inFence) {
+      // Openers may carry an info string after the marker
+      // (e.g. "```ts"). We don't need to keep it — just enter
+      // the fenced region.
       state.inFence = true;
       state.marker = marker;
       return true;
     }
-    // Closer must (a) use the same character as the opener and
-    // (b) be at least as long. Per CommonMark — a 3-backtick line
-    // does not close a 4-backtick fence; the inner line is content.
-    if (state.marker && marker[0] === state.marker[0] && marker.length >= state.marker.length) {
+    // Closer rules per CommonMark §4.5:
+    //   (a) same character as opener
+    //   (b) length ≥ opener
+    //   (c) NO info string — only whitespace allowed after the marker
+    // Without (c), a line like "``` js" inside a fence would be
+    // wrongly treated as the closer; marked keeps it as content.
+    const afterMarker = line.slice(fenceMatch[0].length);
+    if (state.marker && marker[0] === state.marker[0] && marker.length >= state.marker.length && /^\s*$/.test(afterMarker)) {
       state.inFence = false;
       state.marker = null;
       return true;

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { marked } from "marked";
 import { findTaskLines, toggleTaskAt, makeTasksInteractive } from "../../../src/utils/markdown/taskList.js";
 
 describe("toggleTaskAt", () => {
@@ -231,5 +232,71 @@ describe("makeTasksInteractive", () => {
   it("is idempotent on already-transformed HTML", () => {
     const transformed = '<input class="md-task" type="checkbox">';
     assert.equal(makeTasksInteractive(transformed), transformed);
+  });
+});
+
+// `makeTasksInteractive` is a regex over the literal string `marked`
+// happens to emit today (`<input disabled="" type="checkbox">` and
+// `<input checked="" disabled="" type="checkbox">`). If a future
+// marked version reorders attributes, drops the empty-value form, or
+// changes whitespace, the regex stops matching — and the breakage is
+// silent at runtime (checkboxes render but never toggle). These tests
+// exercise the actual marked output we ship against, so any such
+// drift fails the test BEFORE it hits production.
+describe("makeTasksInteractive — marked output compatibility lock", () => {
+  it("strips disabled and tags both unchecked and checked tasks rendered by marked", () => {
+    const markdown = "- [ ] todo\n- [x] done\n";
+    const html = marked(markdown) as string;
+    // Lock the marked-side assumption: both the unchecked and the
+    // checked render forms must end with `disabled="" type="checkbox">`
+    // — that's what the regex anchors on.
+    assert.ok(html.includes('<input disabled="" type="checkbox">'), `marked unchecked form changed; got: ${html}`);
+    assert.ok(html.includes('<input checked="" disabled="" type="checkbox">'), `marked checked form changed; got: ${html}`);
+
+    const interactive = makeTasksInteractive(html);
+    assert.ok(interactive.includes('<input class="md-task" type="checkbox">'), "unchecked input was not made interactive");
+    assert.ok(interactive.includes('<input checked="" class="md-task" type="checkbox">'), "checked input was not made interactive");
+    assert.ok(!interactive.includes("disabled"), "disabled attribute leaked through into the rewritten HTML");
+  });
+
+  it("works through marked's full pipeline: source → render → interactive → click finds the n-th input", () => {
+    // End-to-end shape check: rendering 3 tasks must yield 3 inputs
+    // tagged with `class="md-task"` so `querySelectorAll('input.md-task')`
+    // in View.vue's click handler matches the source-side index.
+    const markdown = "- [ ] zero\n- [x] one\n- [ ] two\n";
+    const interactive = makeTasksInteractive(marked(markdown) as string);
+    const matches = interactive.match(/<input[^>]*class="md-task"[^>]*>/g) ?? [];
+    assert.equal(matches.length, 3, `expected 3 interactive inputs, got ${matches.length} in: ${interactive}`);
+  });
+});
+
+// View.vue cross-checks `findTaskLines(source).length` against the
+// rendered `input.md-task` count and refuses to toggle on mismatch
+// (locked-in pluginMarkdown.taskCountMismatch error). These tests
+// prove the hazard scenarios are real and detectable purely from
+// `findTaskLines` + marked output — i.e. the cross-check has
+// something to actually catch.
+describe("findTaskLines vs marked render — cross-check justification", () => {
+  it("an indented-code-block task line counts in source but renders as code (no input)", () => {
+    // 4-space indent makes this content of an indented code block.
+    // Source walker still sees a task line (documented limitation);
+    // marked renders the line as `<pre><code>` with no checkbox.
+    const markdown = "    - [ ] looks-like-task\n- [ ] real\n";
+    const sourceCount = findTaskLines(markdown).length;
+    const inputCount = (marked(markdown) as string).match(/<input[^>]*type="checkbox">/g)?.length ?? 0;
+    assert.equal(sourceCount, 2, "source walker should count both lines");
+    assert.equal(inputCount, 1, "marked should render only the un-indented task as a checkbox");
+    // 2 vs 1 → mismatch → View.vue refuses click → no corruption.
+  });
+
+  it("counts agree on a clean document (no false-positive refuses)", () => {
+    // The cross-check must not fire for the common case — otherwise
+    // every click would refuse. Verify a normal mixed task / non-task
+    // / blockquote / fence / ordered-list document agrees.
+    const markdown = ["# Heading", "- [ ] a", "- [x] b", "Some prose.", "1. [ ] ordered", "> - [ ] quoted", "```", "- [ ] inside-fence", "```"].join("\n");
+    const sourceCount = findTaskLines(markdown).length;
+    const inputCount = (marked(markdown) as string).match(/<input[^>]*type="checkbox">/g)?.length ?? 0;
+    assert.equal(sourceCount, inputCount, `mismatch on the happy path — source ${sourceCount}, dom ${inputCount}`);
+    assert.equal(sourceCount, 4, "expected 4 real tasks (a, b, ordered, quoted)");
   });
 });

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { toggleTaskAt, makeTasksInteractive } from "../../../src/utils/markdown/taskList.js";
+import { findTaskLines, toggleTaskAt, makeTasksInteractive } from "../../../src/utils/markdown/taskList.js";
 
 describe("toggleTaskAt", () => {
   it("toggles unchecked → checked", () => {
@@ -30,9 +30,18 @@ describe("toggleTaskAt", () => {
     assert.equal(toggleTaskAt(markdown, 0), "- [x] foo **bold** [link](#)\n");
   });
 
-  it("ignored ordered-list task syntax counts toward the index", () => {
+  it("ordered-list task syntax counts toward the index (dot marker)", () => {
     const markdown = "1. [ ] alpha\n2. [ ] beta\n";
     assert.equal(toggleTaskAt(markdown, 1), "1. [ ] alpha\n2. [x] beta\n");
+  });
+
+  it("ordered-list task syntax counts toward the index (paren marker)", () => {
+    // CommonMark / GFM also accepts `1)` style ordered markers, and
+    // marked renders them as task checkboxes — so the source walker
+    // must too.
+    const markdown = "1) [ ] alpha\n2) [x] beta\n";
+    assert.equal(toggleTaskAt(markdown, 0), "1) [x] alpha\n2) [x] beta\n");
+    assert.equal(toggleTaskAt(markdown, 1), "1) [ ] alpha\n2) [ ] beta\n");
   });
 
   it("skips fenced code blocks (``` … ```) — task-looking lines inside don't count", () => {
@@ -141,6 +150,38 @@ describe("toggleTaskAt", () => {
     const markdown = ["```", "- [ ] inside", "```   ", "- [ ] outside"].join("\n");
     const out = toggleTaskAt(markdown, 0);
     assert.equal(out, ["```", "- [ ] inside", "```   ", "- [x] outside"].join("\n"));
+  });
+});
+
+describe("findTaskLines", () => {
+  it("returns the 0-indexed line of every task", () => {
+    const markdown = ["intro", "- [ ] zero", "skip", "- [x] one", "  * [ ] two-nested"].join("\n");
+    assert.deepEqual(findTaskLines(markdown), [1, 3, 4]);
+  });
+
+  it("skips fenced code blocks", () => {
+    const markdown = ["- [ ] real-0", "```", "- [ ] fake", "```", "- [ ] real-1"].join("\n");
+    assert.deepEqual(findTaskLines(markdown), [0, 4]);
+  });
+
+  it("counts blockquoted tasks", () => {
+    const markdown = ["- [ ] top", "> - [ ] quoted", "> > - [ ] nested-quoted"].join("\n");
+    assert.deepEqual(findTaskLines(markdown), [0, 1, 2]);
+  });
+
+  it("returns an empty array when source has no tasks", () => {
+    assert.deepEqual(findTaskLines("just text\n* regular bullet\n"), []);
+  });
+
+  // Documents the known limitation called out in the docstring: a
+  // `- [ ] foo` line buried in a 4-space indented code block is still
+  // counted by the source walker. The View layer cross-checks this
+  // count against the rendered DOM and refuses to toggle on
+  // disagreement, so the corruption never reaches disk.
+  it("currently counts indented-code-block lines that LOOK like tasks (limitation)", () => {
+    // Note this test pins existing behaviour, not desired behaviour.
+    const markdown = "    - [ ] looks-like-task\n- [ ] real\n";
+    assert.deepEqual(findTaskLines(markdown), [0, 1]);
   });
 });
 

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -151,6 +151,25 @@ describe("toggleTaskAt", () => {
     const out = toggleTaskAt(markdown, 0);
     assert.equal(out, ["```", "- [ ] inside", "```   ", "- [x] outside"].join("\n"));
   });
+
+  it("recognises fences nested inside blockquotes", () => {
+    // `> \`\`\`` opens a fenced block inside a blockquote. Without
+    // blockquote stripping the walker would miscount the inner
+    // `> - [ ] inside` as a real task; with the strip the only
+    // counted task is the unquoted one outside.
+    const markdown = ["> ```", "> - [ ] inside-fence", "> ```", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["> ```", "> - [ ] inside-fence", "> ```", "- [x] outside"].join("\n"));
+  });
+
+  it("blockquoted fence requires content indent ≤ 3 spaces", () => {
+    // Inside a blockquote, the post-quote indent of `   ` ` ` ` ` is
+    // 3 spaces — still a fence. (Compare with the next test for the
+    // 4-space case which is NOT a fence.)
+    const markdown = ["> ```", "> - [ ] in", "> ```", "- [ ] out"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["> ```", "> - [ ] in", "> ```", "- [x] out"].join("\n"));
+  });
 });
 
 describe("findTaskLines", () => {

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toggleTaskAt, makeTasksInteractive } from "../../../src/utils/markdown/taskList.js";
+
+describe("toggleTaskAt", () => {
+  it("toggles unchecked → checked", () => {
+    const out = toggleTaskAt("- [ ] one\n- [ ] two\n", 0);
+    assert.equal(out, "- [x] one\n- [ ] two\n");
+  });
+
+  it("toggles checked → unchecked", () => {
+    const out = toggleTaskAt("- [x] done\n", 0);
+    assert.equal(out, "- [ ] done\n");
+  });
+
+  it("targets the n-th task by index", () => {
+    const markdown = "- [ ] zero\n- [x] one\n- [ ] two\n";
+    assert.equal(toggleTaskAt(markdown, 1), "- [ ] zero\n- [ ] one\n- [ ] two\n");
+    assert.equal(toggleTaskAt(markdown, 2), "- [ ] zero\n- [x] one\n- [x] two\n");
+  });
+
+  it("preserves indentation and bullet style", () => {
+    const markdown = "  * [ ] indented star\n  + [X] indented plus\n";
+    assert.equal(toggleTaskAt(markdown, 0), "  * [x] indented star\n  + [X] indented plus\n");
+    assert.equal(toggleTaskAt(markdown, 1), "  * [ ] indented star\n  + [ ] indented plus\n");
+  });
+
+  it("preserves trailing content after the marker", () => {
+    const markdown = "- [ ] foo **bold** [link](#)\n";
+    assert.equal(toggleTaskAt(markdown, 0), "- [x] foo **bold** [link](#)\n");
+  });
+
+  it("ignored ordered-list task syntax counts toward the index", () => {
+    const markdown = "1. [ ] alpha\n2. [ ] beta\n";
+    assert.equal(toggleTaskAt(markdown, 1), "1. [ ] alpha\n2. [x] beta\n");
+  });
+
+  it("skips fenced code blocks (``` … ```) — task-looking lines inside don't count", () => {
+    const markdown = ["- [ ] real-1", "```", "- [ ] not-a-task", "- [x] also-not", "```", "- [ ] real-2"].join("\n");
+    // Index 1 is real-2 (the inside-fence lines are skipped).
+    const out = toggleTaskAt(markdown, 1);
+    assert.equal(out, ["- [ ] real-1", "```", "- [ ] not-a-task", "- [x] also-not", "```", "- [x] real-2"].join("\n"));
+  });
+
+  it("skips tilde-fenced code blocks", () => {
+    const markdown = ["- [ ] real-1", "~~~", "- [ ] inside", "~~~", "- [ ] real-2"].join("\n");
+    const out = toggleTaskAt(markdown, 1);
+    assert.equal(out, ["- [ ] real-1", "~~~", "- [ ] inside", "~~~", "- [x] real-2"].join("\n"));
+  });
+
+  it("opener and closer fence markers must use the same character", () => {
+    // ``` opens, ~~~ does NOT close it — anything between the ``` and
+    // the matching ``` is fenced.
+    const markdown = ["```", "- [ ] inside", "~~~", "- [ ] also-inside", "```", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["```", "- [ ] inside", "~~~", "- [ ] also-inside", "```", "- [x] outside"].join("\n"));
+  });
+
+  it("returns null when index is out of range", () => {
+    assert.equal(toggleTaskAt("- [ ] only\n", 1), null);
+    assert.equal(toggleTaskAt("no tasks here\n", 0), null);
+  });
+
+  it("returns null for negative or non-integer indices", () => {
+    assert.equal(toggleTaskAt("- [ ] x\n", -1), null);
+    assert.equal(toggleTaskAt("- [ ] x\n", 0.5), null);
+    assert.equal(toggleTaskAt("- [ ] x\n", Number.NaN), null);
+  });
+
+  it("does not modify lines that aren't task list markers", () => {
+    const markdown = "- regular bullet\n- [ ] task\n- another bullet\n";
+    assert.equal(toggleTaskAt(markdown, 0), "- regular bullet\n- [x] task\n- another bullet\n");
+  });
+
+  it("preserves trailing newline / no-trailing-newline shape", () => {
+    assert.equal(toggleTaskAt("- [ ] x", 0), "- [x] x");
+    assert.equal(toggleTaskAt("- [ ] x\n", 0), "- [x] x\n");
+  });
+});
+
+describe("makeTasksInteractive", () => {
+  it("strips disabled and adds class on an unchecked task", () => {
+    const before = '<li><input disabled="" type="checkbox"> Foo</li>';
+    const after = '<li><input class="md-task" type="checkbox"> Foo</li>';
+    assert.equal(makeTasksInteractive(before), after);
+  });
+
+  it("strips disabled and adds class on a checked task", () => {
+    const before = '<li><input checked="" disabled="" type="checkbox"> Bar</li>';
+    const after = '<li><input checked="" class="md-task" type="checkbox"> Bar</li>';
+    assert.equal(makeTasksInteractive(before), after);
+  });
+
+  it("transforms multiple tasks in one HTML blob", () => {
+    const before = '<ul><li><input disabled="" type="checkbox"> A</li><li><input checked="" disabled="" type="checkbox"> B</li></ul>';
+    const after = '<ul><li><input class="md-task" type="checkbox"> A</li><li><input checked="" class="md-task" type="checkbox"> B</li></ul>';
+    assert.equal(makeTasksInteractive(before), after);
+  });
+
+  it("leaves non-task inputs alone", () => {
+    const html = '<input type="text" name="hi">';
+    assert.equal(makeTasksInteractive(html), html);
+  });
+
+  it("is idempotent on already-transformed HTML", () => {
+    const transformed = '<input class="md-task" type="checkbox">';
+    assert.equal(makeTasksInteractive(transformed), transformed);
+  });
+});

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -76,6 +76,56 @@ describe("toggleTaskAt", () => {
     assert.equal(toggleTaskAt("- [ ] x", 0), "- [x] x");
     assert.equal(toggleTaskAt("- [ ] x\n", 0), "- [x] x\n");
   });
+
+  // ── Blockquoted tasks ─────────────────────────────────────────
+  // marked renders these as real task checkboxes; the index walker
+  // must count them so DOM and source stay aligned.
+
+  it("toggles a task inside a single-level blockquote", () => {
+    assert.equal(toggleTaskAt("> - [ ] quoted\n", 0), "> - [x] quoted\n");
+  });
+
+  it("toggles a task inside a nested blockquote", () => {
+    assert.equal(toggleTaskAt("> > - [ ] nested\n", 0), "> > - [x] nested\n");
+  });
+
+  it("counts blockquoted tasks alongside top-level tasks", () => {
+    const markdown = "- [ ] top-0\n> - [ ] quoted-1\n- [ ] top-2\n";
+    assert.equal(toggleTaskAt(markdown, 1), "- [ ] top-0\n> - [x] quoted-1\n- [ ] top-2\n");
+    assert.equal(toggleTaskAt(markdown, 2), "- [ ] top-0\n> - [ ] quoted-1\n- [x] top-2\n");
+  });
+
+  it("handles indented blockquote prefixes", () => {
+    assert.equal(toggleTaskAt("   > - [ ] indented quote\n", 0), "   > - [x] indented quote\n");
+  });
+
+  // ── Fence indent / length corner cases ────────────────────────
+
+  it("does NOT treat a 4-space-indented ``` as a fence opener", () => {
+    // CommonMark allows fences indented up to 3 spaces; ≥ 4 is
+    // literal content of an indented code block. Verified by the
+    // top-level task matching at index 0 — if the 4-space ``` had
+    // (incorrectly) opened a fence, the task counter would never
+    // reach the real task on the bottom line.
+    const markdown = "    ```\n- [ ] real\n    ```\n";
+    assert.equal(toggleTaskAt(markdown, 0), "    ```\n- [x] real\n    ```\n");
+  });
+
+  it("a shorter closer does NOT close a longer opener", () => {
+    // ```` (4 backticks) opens; ``` (3 backticks) is too short to
+    // close per CommonMark — the closer must be ≥ opener length.
+    const markdown = ["````", "- [ ] inside", "```", "- [x] still-inside", "````", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["````", "- [ ] inside", "```", "- [x] still-inside", "````", "- [x] outside"].join("\n"));
+  });
+
+  it("a longer closer DOES close a shorter opener", () => {
+    // ``` (3) opens; ```` (4 ≥ 3) closes. Then a top-level task at
+    // the bottom is index 0.
+    const markdown = ["```", "- [ ] inside", "````", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["```", "- [ ] inside", "````", "- [x] outside"].join("\n"));
+  });
 });
 
 describe("makeTasksInteractive", () => {

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -126,6 +126,22 @@ describe("toggleTaskAt", () => {
     const out = toggleTaskAt(markdown, 0);
     assert.equal(out, ["```", "- [ ] inside", "````", "- [x] outside"].join("\n"));
   });
+
+  it("a closer with an info string is NOT a valid closer", () => {
+    // Per CommonMark §4.5, fence closers can't carry an info
+    // string — only trailing whitespace is allowed. "``` js" mid-
+    // fence is content, not the close. The bottom task is index 0.
+    const markdown = ["```", "- [ ] inside", "``` js", "- [x] still-inside", "```", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["```", "- [ ] inside", "``` js", "- [x] still-inside", "```", "- [x] outside"].join("\n"));
+  });
+
+  it("a closer with only trailing whitespace IS a valid closer", () => {
+    // Whitespace after the marker is fine for a closer.
+    const markdown = ["```", "- [ ] inside", "```   ", "- [ ] outside"].join("\n");
+    const out = toggleTaskAt(markdown, 0);
+    assert.equal(out, ["```", "- [ ] inside", "```   ", "- [x] outside"].join("\n"));
+  });
 });
 
 describe("makeTasksInteractive", () => {


### PR DESCRIPTION
## Summary
- Clicking a `- [ ]` / `- [x]` checkbox in the markdown plugin viewer now toggles the source line and persists via the existing `PUT /api/markdowns/update` route. No edit-source panel needed for simple progress ticks.
- New pure helper `src/utils/markdown/taskList.ts`: `toggleTaskAt(source, n)` walks the source, skips fenced code blocks, flips the n-th `[ ]`/`[x]`. `makeTasksInteractive(html)` strips `disabled=""` from rendered checkboxes and tags them so the click handler can find them.
- Markdown plugin only. Wiki plugin half of #775 needs a new server-side save action and is deferred to a follow-up.

## Items to Confirm / Review
- **Source/DOM index correspondence.** Both `marked` and the source-side counter walk the document top-down and skip fenced code blocks, so the n-th `input.md-task` in the DOM matches the n-th non-fenced `- [ ]` line. If they diverge for any reason (e.g., marked's GFM extension treats some edge case differently), `toggleTaskAt` returns `null` and the click is rolled back visually — no garbage gets PUT.
- **Optimistic write strategy.** Per the issue thread: agreed on optimistic, no conflict detection. PUTs are serialized through a Promise chain so quick clicks don't race on the wire, but the server may be running stale content if an LLM is rewriting in parallel. On a PUT failure we re-fetch the canonical file so the next click computes against fresh source.
- **Why HTML post-process instead of a marked renderer override.** The wiki plugin shares the global `marked` import and isn't part of this PR. A renderer override would either leak to wiki (checkboxes look interactive but do nothing) or require a local `Marked` instance — extra ceremony for a 1-line `replace`.
- **Disabled while source editor is open.** Click handler short-circuits + reverts the visual when `<details>` is open — the textarea owns the source there and a checkbox toggle would race the user's typing.

## User Prompt
> issue; md viewer で checkbox とかを操作するとデータが update されるようにしたい
>
> 1 markdown 内のみ / 2 ok / 3 wiki も / 4 含めない / 5 楽観で / issue化
>
> issueに書いておいて。そのうえで簡単のだけすすめて。

(The wiki half is documented in #775 with a difficulty / implementation comment; this PR is the markdown half — the simpler one.)

## Files changed
- `src/utils/markdown/taskList.ts` (new) — `toggleTaskAt` + `makeTasksInteractive`
- `src/plugins/markdown/View.vue` — post-process rendered HTML, click delegation, queued PUT
- `test/utils/markdown/test_taskList.ts` (new) — 18 unit tests

## Test plan
- [ ] `yarn test` — local 2900/2900 pass
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` — all clean (only pre-existing v-html warnings)
- [ ] Manual: open a markdown document with `- [ ] foo` → click checkbox → verify file on disk now contains `- [x] foo` and the viewer state stays in sync
- [ ] Manual: open the source editor, click a checkbox → click is ignored (textarea wins). Close editor, click works again
- [ ] Manual: rapid double-click on different checkboxes — both toggles persist in order

Refs #775 (issue stays open until the wiki half lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive GFM task checkboxes in rendered markdown viewer - click checkboxes to toggle task completion and changes persist automatically to both file-backed documents and inline content.
  * Robust task list handling across markdown contexts including blockquotes, ordered/unordered lists, and code fences for reliable checkbox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->