### PR TITLE
fix: migrate legacy markdowns/ + spreadsheets/ refs, reject in Vue validators (#773)

### DIFF
--- a/e2e/tests/spreadsheet.spec.ts
+++ b/e2e/tests/spreadsheet.spec.ts
@@ -8,7 +8,7 @@ import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 // both the file-backed fetchSheets path and the table render.
 
 interface SpreadsheetResultOptions {
-  // Stored file path ("spreadsheets/abc.json") or inline sheets array.
+  // Stored file path ("artifacts/spreadsheets/abc.json") or inline sheets array.
   sheets: string | unknown[];
   sessionId?: string;
   title?: string;
@@ -72,7 +72,7 @@ async function openSpreadsheetView(page: Page, sessionId = "sheet-session", side
 
 test.describe("spreadsheet — rendering", () => {
   test("file-backed spreadsheet renders cell values", async ({ page }) => {
-    const path = "spreadsheets/abc.json";
+    const path = "artifacts/spreadsheets/abc.json";
     const sheets = [
       {
         name: "Sheet1",
@@ -317,7 +317,7 @@ test.describe("spreadsheet — source editor", () => {
 
 test.describe("spreadsheet — error handling", () => {
   test("too-large file shows an error message", async ({ page }) => {
-    const path = "spreadsheets/huge.json";
+    const path = "artifacts/spreadsheets/huge.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await mockFileContent(page, path, {
       kind: "too-large",
@@ -330,7 +330,7 @@ test.describe("spreadsheet — error handling", () => {
   });
 
   test("binary file shows the default 'Cannot load' message", async ({ page }) => {
-    const path = "spreadsheets/blob.json";
+    const path = "artifacts/spreadsheets/blob.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await mockFileContent(page, path, { kind: "binary" });
     await openSpreadsheetView(page);
@@ -338,7 +338,7 @@ test.describe("spreadsheet — error handling", () => {
   });
 
   test("malformed JSON shows a parse error message", async ({ page }) => {
-    const path = "spreadsheets/broken.json";
+    const path = "artifacts/spreadsheets/broken.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await mockFileContent(page, path, {
       kind: "text",
@@ -349,7 +349,7 @@ test.describe("spreadsheet — error handling", () => {
   });
 
   test("non-array content shows a shape error", async ({ page }) => {
-    const path = "spreadsheets/wrong.json";
+    const path = "artifacts/spreadsheets/wrong.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await mockFileContent(page, path, {
       kind: "text",
@@ -362,7 +362,7 @@ test.describe("spreadsheet — error handling", () => {
   });
 
   test("missing content field shows 'no content' message", async ({ page }) => {
-    const path = "spreadsheets/empty.json";
+    const path = "artifacts/spreadsheets/empty.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await mockFileContent(page, path, { kind: "text" });
     await openSpreadsheetView(page);
@@ -370,7 +370,7 @@ test.describe("spreadsheet — error handling", () => {
   });
 
   test("HTTP failure shows a statusText error", async ({ page }) => {
-    const path = "spreadsheets/404.json";
+    const path = "artifacts/spreadsheets/404.json";
     await setupSpreadsheetSession(page, { sheets: path });
     await page.route(
       (url) => url.pathname === "/api/files/content" && url.searchParams.get("path") === path,

--- a/plans/fix-legacy-path-migration-773.md
+++ b/plans/fix-legacy-path-migration-773.md
@@ -1,0 +1,131 @@
+# Fix: Legacy artifact path migration (#773)
+
+## Problem
+
+Sessions whose JSONL (or other text files) still reference legacy prefixes
+(`markdowns/*.md`, `spreadsheets/*.json`) can be **loaded** by the Vue
+side but **fail to save** on the server side. Root cause:
+
+| Side | `markdowns/` | `artifacts/documents/` |
+|---|---|---|
+| Vue `isFilePath` (load) | ✓ accepted | ✓ accepted |
+| Server `isMarkdownPath` (save) | ✗ rejected | ✓ accepted |
+
+Result: user opens legacy-path doc → edits → save → 4xx → edits silently
+lost. The physical directories were already moved by the #284 migration
+(see `~/mulmoclaude/migration-284-manifest.json` — `markdowns → artifacts/documents`,
+`spreadsheets → artifacts/spreadsheets`), so this is purely a
+text-reference cleanup.
+
+## Strategy
+
+**C++ (improved option C): one-shot migration batch script** that walks the
+workspace, rewrites legacy references everywhere, and enables option A
+(reject legacy on Vue side) once complete.
+
+Rejected alternatives:
+- Option A alone (just reject legacy in Vue): legacy refs would render as
+  inline content — confusing, data still broken.
+- Option B (accept legacy on server): reintroduces a path #284 retired,
+  doesn't push toward canonical.
+- Vanilla C (rewrite on session load): runtime overhead, partial coverage,
+  hard to audit.
+
+## Plan
+
+### 1. Pure rewriter (`scripts/lib/legacyPaths.ts`)
+
+```ts
+export function rewriteLegacyPaths(text: string): string {
+  // markdowns/<hex>.md → artifacts/documents/<hex>.md
+  // spreadsheets/<hex>.json → artifacts/spreadsheets/<hex>.json
+  //
+  // Negative lookbehind `(?<![\w/.-])` ensures we don't accidentally
+  // rewrite things like `my-markdowns/foo` or `/path/markdowns/bar`.
+}
+
+export interface LegacyPathScanResult {
+  occurrences: number;
+  before: string;
+  after: string;
+}
+```
+
+Pure function, fully unit-testable.
+
+### 2. CLI wrapper (`scripts/migrate-legacy-artifact-paths.ts`)
+
+```bash
+npx tsx scripts/migrate-legacy-artifact-paths.ts              # dry-run
+npx tsx scripts/migrate-legacy-artifact-paths.ts --write      # apply
+npx tsx scripts/migrate-legacy-artifact-paths.ts --root=/path # override workspace
+```
+
+Targets: walk the workspace recursively, process:
+
+- `conversations/chat/*.jsonl`
+- `conversations/summaries/**/*.md`
+- `conversations/summaries/**/*.json`
+- `data/wiki/pages/*.md`
+- `data/wiki/log.md`
+- `memory.md`
+
+Skips:
+- Any `*.bak` file
+- `migration-*-manifest.json` (historical, don't touch)
+- Binary files (images, PDFs)
+- `artifacts/` directory (actual files are already at canonical paths;
+  references within generated artifact bodies are out of scope — LLM
+  will regenerate if needed)
+
+Behavior:
+- Atomic writes via `writeFileAtomic` (already exists in server/)
+- Idempotent: second run = 0 changes
+- Dry-run default; `--write` to actually mutate
+
+### 3. Option A application
+
+Once migration is dry-run-clean on the real workspace, apply option A:
+- `src/plugins/markdown/definition.ts:17`: drop `|| value.startsWith("markdowns/")`
+- `src/plugins/spreadsheet/View.vue:199`: drop `|| value.startsWith("spreadsheets/")`
+
+Client and server validators are then symmetric.
+
+### 4. Tests
+
+`test/scripts/test_legacyPaths.ts` — exhaustive unit tests for the pure
+rewriter:
+- Happy path (canonical JSON field value)
+- Markdown link `(markdowns/foo.md)`
+- Inline code `` `markdowns/foo.md` ``
+- Spreadsheet variant
+- Idempotency (rewrite twice = rewrite once)
+- No-match cases:
+  - `my-markdowns/foo` (wrong prefix continuation)
+  - `/abs/markdowns/foo` (path continuation)
+  - `markdowns/` with no filename
+  - `markdowns/foo.txt` (wrong extension)
+- Edge: multiple matches in one line
+- Edge: match split across JSON field values
+
+## Acceptance
+
+- [ ] `rewriteLegacyPaths()` exported as pure function with full unit
+      coverage
+- [ ] CLI runs in dry-run by default, shows per-file summary
+- [ ] `--write` applies changes atomically, idempotent
+- [ ] Dry-run on real workspace shows expected match count (spot-checked
+      4 `markdowns/*.md` refs in conversations/chat)
+- [ ] After `--write`: dry-run second time shows 0 matches
+- [ ] Option A applied: Vue validators drop legacy prefix
+- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn test` clean
+
+## Out of scope
+
+- Rewriting legacy references inside generated artifact bodies
+  (e.g. HTML or chart JSON files that happen to mention `markdowns/`);
+  these regenerate on edit anyway
+- `*.bak` files
+- User-defined scripts / notes outside the known workspace layout
+- Automatic backup before `--write` (user should commit their workspace
+  or keep the `migration-284-manifest.json` backup reference)

--- a/scripts/lib/legacyPaths.ts
+++ b/scripts/lib/legacyPaths.ts
@@ -1,0 +1,49 @@
+// Pure text rewriter for the #773 migration. Extracted from the CLI
+// driver so the match/replace rules are unit-testable without any
+// filesystem dependency.
+//
+// Legacy prefixes (#284 moved the directories but left in-file text
+// references untouched):
+//
+//   markdowns/<name>.md      → artifacts/documents/<name>.md
+//   spreadsheets/<name>.json → artifacts/spreadsheets/<name>.json
+//
+// Match constraints:
+//   - Lookbehind `(?<![\w/.-])` prevents rewriting when the prefix is
+//     a suffix of a longer token (e.g. `my-markdowns/`, `a/markdowns/`,
+//     `foo.markdowns/`). Only boundary characters such as `"`, `(`,
+//     `` ` ``, space, line-start are acceptable.
+//   - Filename chars restricted to `[\w.-]+` so we don't eat past the
+//     closing quote/paren/backtick.
+//   - Suffix is required (`.md` / `.json`) to pin the match to actual
+//     artifact file references — free-prose sentences mentioning
+//     "markdowns" in other contexts are left alone.
+
+const MARKDOWNS_RE = /(?<![\w/.\-])markdowns\/([\w.\-]+\.md)/g;
+const SPREADSHEETS_RE = /(?<![\w/.\-])spreadsheets\/([\w.\-]+\.json)/g;
+
+export interface RewriteResult {
+  text: string;
+  // Number of occurrences replaced across all legacy prefixes.
+  occurrences: number;
+}
+
+export function rewriteLegacyPaths(input: string): RewriteResult {
+  let occurrences = 0;
+  const afterMarkdowns = input.replace(MARKDOWNS_RE, (_match, name) => {
+    occurrences++;
+    return `artifacts/documents/${name}`;
+  });
+  const afterSpreadsheets = afterMarkdowns.replace(SPREADSHEETS_RE, (_match, name) => {
+    occurrences++;
+    return `artifacts/spreadsheets/${name}`;
+  });
+  return { text: afterSpreadsheets, occurrences };
+}
+
+export function hasLegacyPaths(input: string): boolean {
+  // Reset lastIndex for safety since the regexes are /g.
+  MARKDOWNS_RE.lastIndex = 0;
+  SPREADSHEETS_RE.lastIndex = 0;
+  return MARKDOWNS_RE.test(input) || SPREADSHEETS_RE.test(input);
+}

--- a/scripts/migrate-legacy-artifact-paths.ts
+++ b/scripts/migrate-legacy-artifact-paths.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env tsx
+// One-shot text migration for issue #773: rewrite legacy artifact path
+// references in session / workspace text files.
+//
+// Background: #284 moved `markdowns/` → `artifacts/documents/` and
+// `spreadsheets/` → `artifacts/spreadsheets/` on disk, but left text
+// references inside session JSONL, summaries, and wiki pages alone.
+// That inconsistency caused #773 (Vue accepts legacy, server rejects
+// → silent save failure). This script rewrites those references in
+// place.
+//
+// Usage:
+//   npx tsx scripts/migrate-legacy-artifact-paths.ts              # dry-run
+//   npx tsx scripts/migrate-legacy-artifact-paths.ts --write      # apply
+//   npx tsx scripts/migrate-legacy-artifact-paths.ts --root=/tmp/ws  # override
+//
+// Safe to re-run: the rewriter is idempotent.
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { rewriteLegacyPaths } from "./lib/legacyPaths.js";
+
+interface CliArgs {
+  write: boolean;
+  root: string;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let write = false;
+  let root = path.join(os.homedir(), "mulmoclaude");
+  for (const arg of argv) {
+    if (arg === "--write") {
+      write = true;
+    } else if (arg.startsWith("--root=")) {
+      root = arg.slice("--root=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      printHelp();
+      process.exit(1);
+    }
+  }
+  return { write, root };
+}
+
+function printHelp(): void {
+  console.error(`Usage: migrate-legacy-artifact-paths.ts [--write] [--root=<path>]
+
+  --write           Apply changes (default is dry-run: print what would change).
+  --root=<path>     Workspace root (default: ~/mulmoclaude).
+`);
+}
+
+// Relative paths under the workspace root that are allowed to be
+// scanned. Keeps the script predictable — we don't recurse into
+// `artifacts/` or `github/` because those either contain canonical
+// paths already or are git working trees whose contents aren't our
+// concern.
+const TARGET_SUBTREES: readonly string[] = [
+  "conversations/chat",
+  "conversations/summaries",
+  "data/wiki/pages",
+];
+
+const TARGET_FILES: readonly string[] = [
+  "memory.md",
+  "data/wiki/log.md",
+  "data/wiki/index.md",
+];
+
+const SUPPORTED_EXTS: ReadonlySet<string> = new Set([".jsonl", ".json", ".md"]);
+
+// `.bak` and migration manifests are historical — leave them alone so
+// the audit trail stays readable.
+function isSkippedFile(name: string): boolean {
+  if (name.endsWith(".bak")) return true;
+  if (name.startsWith("migration-") && name.endsWith("-manifest.json")) return true;
+  return false;
+}
+
+interface FileStats {
+  filePath: string;
+  occurrences: number;
+}
+
+async function processFile(absPath: string, relPath: string, write: boolean): Promise<FileStats | null> {
+  let text: string;
+  try {
+    text = await fs.promises.readFile(absPath, "utf-8");
+  } catch (err) {
+    console.error(`  skip ${relPath}: cannot read (${(err as Error).message})`);
+    return null;
+  }
+  const { text: rewritten, occurrences } = rewriteLegacyPaths(text);
+  if (occurrences === 0) return null;
+  if (write) {
+    // Atomic write: temp file next to the destination, then rename.
+    // Same-FS, so rename is atomic. Keeps partial writes out of the
+    // way if the process dies mid-write.
+    const tmpPath = `${absPath}.migrate-773.tmp`;
+    await fs.promises.writeFile(tmpPath, rewritten, "utf-8");
+    await fs.promises.rename(tmpPath, absPath);
+  }
+  return { filePath: relPath, occurrences };
+}
+
+async function walk(root: string, rel: string, write: boolean, stats: FileStats[]): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(path.join(root, rel), {
+      withFileTypes: true,
+    });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const childRel = rel ? path.posix.join(rel, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      await walk(root, childRel, write, stats);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (isSkippedFile(entry.name)) continue;
+    const ext = path.extname(entry.name).toLowerCase();
+    if (!SUPPORTED_EXTS.has(ext)) continue;
+    const result = await processFile(path.join(root, childRel), childRel, write);
+    if (result) stats.push(result);
+  }
+}
+
+async function processSingleFile(root: string, rel: string, write: boolean, stats: FileStats[]): Promise<void> {
+  const absPath = path.join(root, rel);
+  try {
+    const fileStat = await fs.promises.stat(absPath);
+    if (!fileStat.isFile()) return;
+  } catch {
+    return;
+  }
+  if (isSkippedFile(path.basename(absPath))) return;
+  const result = await processFile(absPath, rel, write);
+  if (result) stats.push(result);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const rootExists = fs.existsSync(args.root);
+  if (!rootExists) {
+    console.error(`Workspace root not found: ${args.root}`);
+    process.exit(1);
+  }
+  console.error(`Workspace root: ${args.root}`);
+  console.error(`Mode: ${args.write ? "WRITE" : "dry-run"}`);
+  console.error("");
+
+  const stats: FileStats[] = [];
+
+  for (const subtree of TARGET_SUBTREES) {
+    await walk(args.root, subtree, args.write, stats);
+  }
+  for (const fileRel of TARGET_FILES) {
+    await processSingleFile(args.root, fileRel, args.write, stats);
+  }
+
+  if (stats.length === 0) {
+    console.error("No legacy references found. Nothing to do.");
+    return;
+  }
+
+  stats.sort((left, right) => left.filePath.localeCompare(right.filePath));
+  for (const entry of stats) {
+    console.log(`${entry.filePath}: ${entry.occurrences} occurrence(s)`);
+  }
+  const totalOccurrences = stats.reduce((acc, entry) => acc + entry.occurrences, 0);
+  console.error("");
+  console.error(`${stats.length} file(s), ${totalOccurrences} occurrence(s) ${args.write ? "rewritten" : "would be rewritten"}.`);
+  if (!args.write) {
+    console.error("Re-run with --write to apply.");
+  }
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/plugins/markdown/definition.ts
+++ b/src/plugins/markdown/definition.ts
@@ -9,12 +9,14 @@ export interface MarkdownToolData {
 }
 
 /** True when the `markdown` field is a workspace-relative file path
- *  rather than inline content. Covers both the post-#284 canonical
- *  path (`artifacts/documents/*.md`) and the legacy `markdowns/*.md`
- *  prefix for sessions whose jsonl hasn't been migrated yet. */
+ *  rather than inline content. Accepts only the canonical
+ *  `artifacts/documents/*.md` prefix now that server-side
+ *  `isMarkdownPath` agrees. Any legacy `markdowns/*.md` references
+ *  in old session JSONL must be migrated via
+ *  `scripts/migrate-legacy-artifact-paths.ts` (#773). */
 export function isFilePath(value: string): boolean {
   if (!value.endsWith(".md")) return false;
-  return value.startsWith("artifacts/documents/") || value.startsWith("markdowns/");
+  return value.startsWith("artifacts/documents/");
 }
 
 const toolDefinition: ToolDefinition = {

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -195,8 +195,11 @@ const loading = ref(false);
 const errorMessage = ref("");
 const resolvedSheets = ref<SpreadsheetSheet[]>([]);
 
+// Accepts only the canonical prefix. Any legacy `spreadsheets/*.json`
+// references in old session JSONL must be migrated via
+// `scripts/migrate-legacy-artifact-paths.ts` (#773).
 function isFilePath(value: unknown): value is string {
-  return typeof value === "string" && (value.startsWith("artifacts/spreadsheets/") || value.startsWith("spreadsheets/")) && value.endsWith(".json");
+  return typeof value === "string" && value.startsWith("artifacts/spreadsheets/") && value.endsWith(".json");
 }
 
 async function fetchSheets(): Promise<void> {

--- a/test/plugins/markdown/test_isFilePath.ts
+++ b/test/plugins/markdown/test_isFilePath.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import { isFilePath } from "../../../src/plugins/markdown/definition.js";
 
 describe("markdown isFilePath", () => {
-  it("accepts a stored markdown file path", () => {
-    assert.equal(isFilePath("markdowns/abc.md"), true);
+  it("accepts the canonical artifacts/documents/ path", () => {
+    assert.equal(isFilePath("artifacts/documents/abc.md"), true);
   });
 
   it("rejects inline markdown content", () => {
@@ -16,35 +16,8 @@ describe("markdown isFilePath", () => {
     assert.equal(isFilePath("wiki/foo.md"), false);
   });
 
-  it("rejects non-.md extensions under markdowns/", () => {
-    assert.equal(isFilePath("markdowns/foo.txt"), false);
-    assert.equal(isFilePath("markdowns/foo"), false);
-  });
-
   it("rejects empty string", () => {
     assert.equal(isFilePath(""), false);
-  });
-
-  it("accepts subdirectory paths under markdowns/", () => {
-    assert.equal(isFilePath("markdowns/sub/nested.md"), true);
-  });
-
-  it("rejects an empty filename (`markdowns/.md`)", () => {
-    // Current behaviour: the prefix/suffix check passes. Documenting
-    // via a test so any future tightening of the helper is intentional
-    // rather than silent.
-    assert.equal(isFilePath("markdowns/.md"), true);
-  });
-
-  it("is case-sensitive on the directory prefix", () => {
-    assert.equal(isFilePath("MARKDOWNS/foo.md"), false);
-    assert.equal(isFilePath("Markdowns/foo.md"), false);
-  });
-
-  // Post-#284 canonical path (artifacts/documents/) — PR #348 added
-  // dual-prefix support; these tests guard the new path.
-  it("accepts post-#284 canonical path (artifacts/documents/)", () => {
-    assert.equal(isFilePath("artifacts/documents/abc.md"), true);
   });
 
   it("accepts nested paths under artifacts/documents/", () => {
@@ -59,5 +32,18 @@ describe("markdown isFilePath", () => {
   it("rejects artifacts/ without documents/ subdirectory", () => {
     assert.equal(isFilePath("artifacts/foo.md"), false);
     assert.equal(isFilePath("artifacts/spreadsheets/foo.md"), false);
+  });
+
+  it("is case-sensitive on the directory prefix", () => {
+    assert.equal(isFilePath("ARTIFACTS/documents/foo.md"), false);
+  });
+
+  // Legacy pre-#284 prefix (`markdowns/`). Support was removed in
+  // #773 — the migration script rewrites old session JSONL to
+  // canonical paths so the validator can be symmetric with the
+  // server.
+  it("rejects the legacy markdowns/ prefix", () => {
+    assert.equal(isFilePath("markdowns/abc.md"), false);
+    assert.equal(isFilePath("markdowns/sub/nested.md"), false);
   });
 });

--- a/test/scripts/test_legacyPaths.ts
+++ b/test/scripts/test_legacyPaths.ts
@@ -1,0 +1,149 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { rewriteLegacyPaths, hasLegacyPaths } from "../../scripts/lib/legacyPaths.js";
+
+describe("rewriteLegacyPaths — happy paths", () => {
+  it("rewrites a quoted markdowns reference inside a JSON string", () => {
+    const input = `{"filePath":"markdowns/abc123.md"}`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, `{"filePath":"artifacts/documents/abc123.md"}`);
+    assert.equal(occurrences, 1);
+  });
+
+  it("rewrites a Markdown link target in parentheses", () => {
+    const input = `See [doc](markdowns/notes.md) for details.`;
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, `See [doc](artifacts/documents/notes.md) for details.`);
+  });
+
+  it("rewrites an inline code reference", () => {
+    const input = "The file `markdowns/foo.md` is legacy.";
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, "The file `artifacts/documents/foo.md` is legacy.");
+  });
+
+  it("rewrites a spreadsheets reference similarly", () => {
+    const input = `{"sheets":"spreadsheets/abc.json"}`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, `{"sheets":"artifacts/spreadsheets/abc.json"}`);
+    assert.equal(occurrences, 1);
+  });
+
+  it("rewrites multiple occurrences in one line", () => {
+    const input = `{"a":"markdowns/x.md","b":"markdowns/y.md","c":"spreadsheets/z.json"}`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, `{"a":"artifacts/documents/x.md","b":"artifacts/documents/y.md","c":"artifacts/spreadsheets/z.json"}`);
+    assert.equal(occurrences, 3);
+  });
+
+  it("handles space-delimited references", () => {
+    const input = "path: markdowns/x.md here";
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, "path: artifacts/documents/x.md here");
+  });
+
+  it("handles line-start references", () => {
+    const input = "markdowns/x.md\nsecond line";
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, "artifacts/documents/x.md\nsecond line");
+  });
+});
+
+describe("rewriteLegacyPaths — idempotency", () => {
+  it("is a no-op on already-canonical paths", () => {
+    const input = `{"filePath":"artifacts/documents/abc.md","sheets":"artifacts/spreadsheets/x.json"}`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("is idempotent (second rewrite of first-rewrite output = same output)", () => {
+    const input = `{"filePath":"markdowns/abc.md"}`;
+    const first = rewriteLegacyPaths(input);
+    const second = rewriteLegacyPaths(first.text);
+    assert.equal(second.text, first.text);
+    assert.equal(second.occurrences, 0);
+  });
+});
+
+describe("rewriteLegacyPaths — boundary / no-match cases", () => {
+  it("does NOT rewrite when prefix is continued from a word char", () => {
+    const input = `{"path":"my-markdowns/foo.md"}`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("does NOT rewrite when preceded by an absolute-path slash", () => {
+    const input = "Under /abs/markdowns/foo.md";
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("does NOT rewrite when preceded by a dot (part of an extension-like token)", () => {
+    const input = "pkg.markdowns/foo.md";
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("does NOT rewrite `markdowns/` without a filename", () => {
+    const input = `The "markdowns/" directory was renamed.`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("does NOT rewrite markdowns/ with wrong extension", () => {
+    const input = `path: markdowns/foo.txt here`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("does NOT rewrite spreadsheets/ without .json extension", () => {
+    const input = `path: spreadsheets/foo.csv here`;
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+
+  it("leaves unrelated prose mentions alone", () => {
+    const input = "The old markdowns directory and spreadsheets directory were merged.";
+    const { text, occurrences } = rewriteLegacyPaths(input);
+    assert.equal(text, input);
+    assert.equal(occurrences, 0);
+  });
+});
+
+describe("rewriteLegacyPaths — real-world shortId refs", () => {
+  it("handles 16-hex shortId filenames from production workspaces", () => {
+    const input = `{"markdown":"markdowns/40d085a3864a424f.md"}`;
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, `{"markdown":"artifacts/documents/40d085a3864a424f.md"}`);
+  });
+
+  it("handles legacy names with underscores and hyphens", () => {
+    const input = `(markdowns/my-doc_v2.md)`;
+    const { text } = rewriteLegacyPaths(input);
+    assert.equal(text, `(artifacts/documents/my-doc_v2.md)`);
+  });
+});
+
+describe("hasLegacyPaths", () => {
+  it("returns true when any legacy reference exists", () => {
+    assert.equal(hasLegacyPaths(`{"x":"markdowns/a.md"}`), true);
+    assert.equal(hasLegacyPaths(`{"x":"spreadsheets/a.json"}`), true);
+  });
+
+  it("returns false when none exist", () => {
+    assert.equal(hasLegacyPaths(`{"x":"artifacts/documents/a.md"}`), false);
+    assert.equal(hasLegacyPaths("just some text"), false);
+    assert.equal(hasLegacyPaths(""), false);
+  });
+
+  it("is not confused by adjacent word boundaries", () => {
+    assert.equal(hasLegacyPaths("my-markdowns/foo.md"), false);
+  });
+});


### PR DESCRIPTION
## Summary

- 新規スクリプト \`scripts/migrate-legacy-artifact-paths.ts\` で、レガシーパス参照(\`markdowns/*.md\` / \`spreadsheets/*.json\`)を workspace 内の session JSONL・summaries・wiki pages・\`memory.md\` 上で一括リライト(dry-run default、\`--write\` で適用、冪等)
- pure な rewrite ロジックを \`scripts/lib/legacyPaths.ts\` に切り出して unit-test 済み(negative lookbehind で部分一致や絶対パス誤置換を防止)
- Vue 側 \`isFilePath\` (markdown / spreadsheet) から legacy prefix 受け入れを削除 — サーバ側と対称化
- 既存 \`isFilePath\` テストを新仕様に合わせて更新

Closes #773.

## Items to Confirm / Review

- [ ] 正規表現の境界条件: \`my-markdowns/foo.md\` や \`/abs/markdowns/foo.md\` のような partial match を誤って置換しないか(unit test で 8 ケース cover)
- [ ] 対象ディレクトリの列挙(\`conversations/chat\`、\`conversations/summaries\`、\`data/wiki/pages\`、\`memory.md\`、\`data/wiki/log.md\`、\`data/wiki/index.md\`)が適切か
- [ ] option A を今のタイミングで入れる是非: 既存ユーザが upgrade 時に script 未実行だと、構造化された legacy 参照(もしあれば)は inline content 扱いになる。ただし #284 で物理移動は完了済みなので、参照先ファイルは既に canonical 側に存在 → script 実行で完全復旧可能
- [ ] 正規表現のサフィックス制約(\`.md\` / \`.json\`): 他拡張子は出現しない想定、問題ないか

## User Prompt

> Cの改良版で、全ファイルを確認して書き換えるバッチを作る、、でよい？
>
> [後続] はい

## Plan(details)

\`plans/fix-legacy-path-migration-773.md\` 参照。

## Verification

- \`yarn test\` 全 pass(既存テスト群 + 新規 \`test_legacyPaths.ts\` 18 ケース + 更新された \`test_isFilePath.ts\`)
- \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` clean
- End-to-end sanity: 一時 workspace で \`test.jsonl\` に legacy ref → dry-run で 1 件検出 → \`--write\` で置換確認 → 2 回目 dry-run で 0 件(idempotent)
- 本番 workspace (\`~/mulmoclaude\`) で dry-run: 0 件(既に clean、#284 migration で構造化フィールドはリライト済みだった)

## Usage

\`\`\`bash
# Check what would change
npx tsx scripts/migrate-legacy-artifact-paths.ts

# Apply in-place (atomic write per file)
npx tsx scripts/migrate-legacy-artifact-paths.ts --write

# Custom workspace root
npx tsx scripts/migrate-legacy-artifact-paths.ts --root=/path/to/ws
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)