### PR TITLE
feat(observability): server logging audit + layered logging on 4 high-traffic routes (#779)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -503,7 +503,14 @@ Routes that do anything more than echo state should follow this shape, mirroring
 | Internal exception (we threw, not the SDK) | `error` | input preview + `errorMessage(err)` |
 | External SDK request/response shape | `debug` | only inside the SDK wrapper (`server/utils/gemini.ts` etc.); never inside route files |
 
-Use `previewSnippet` from [`server/utils/logPreview.ts`](../server/utils/logPreview.ts) to clamp prompts / wiki bodies / search queries to 120 chars. **Never log** API keys, bearer tokens, cookies, full prompts, full markdown bodies, or absolute paths that include `/Users/<name>` (use the workspace-relative path instead).
+Two helpers, picked by call-site shape:
+
+| Helper | Use for | Output |
+|---|---|---|
+| [`promptMeta`](../server/utils/promptMeta.ts) | freeform user-supplied prompts / pasted text — anything that could carry credentials, URLs, or PII | `{ length, sha256: <12-hex> }` — fingerprint only |
+| [`previewSnippet`](../server/utils/logPreview.ts) | identifier-shaped fields with grep value (slug, page name, action verb) | first 120 chars + `…` |
+
+Default to `promptMeta` for any field a user types or pastes freely; reserve `previewSnippet` for fields the user picks from a closed set (a slug, an action name) or that the system already constrains (a page name routed through a slugifier). **Never log** API keys, bearer tokens, cookies, full prompts, full markdown bodies, or absolute paths that include `/Users/<name>` (use the workspace-relative path instead).
 
 ### Operational note: hard-to-reproduce error reports
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -489,7 +489,25 @@ Full reference: [`docs/logging.md`](logging.md). Two rules to keep in mind when 
 1. **Never call `console.*` outside `server/system/logger/`.** Import and use `log.{error,warn,info,debug}(prefix, msg, data?)` instead. The structured payload powers JSON file shipping and grep-friendly text output. The only sanctioned `console.error` is the file-sink fallback inside the logger itself.
 2. **Prefix is lowercase, hyphenated, no brackets.** The text formatter wraps it in `[ ]`. Keep payload values scalar; nested objects are JSON-stringified.
 
-Existing prefixes in use: `agent`, `agent-stderr`, `server`, `workspace`, `sandbox`, `mcp`, `task-manager`, `journal`, `chat-index`, `pdf`, `config`.
+Existing prefixes in use: `agent`, `agent-stderr`, `server`, `workspace`, `sandbox`, `mcp`, `task-manager`, `journal`, `chat-index`, `pdf`, `config`, `image`, `wiki`, `pipeline`, `pipeline.fetch`, `scheduler`, `scheduler-tasks`, `sources`, `notifications`, `auth`.
+
+### Layered logging template (#779)
+
+Routes that do anything more than echo state should follow this shape, mirroring [`server/api/routes/image.ts`](../server/api/routes/image.ts) (PR #780) and [`server/api/routes/wiki.ts`](../server/api/routes/wiki.ts):
+
+| Stage | Level | Required payload |
+|---|---|---|
+| Entry, after input validation | `info` | route name + key id (sessionId / slug / path) + `previewSnippet(prompt)` for any user-supplied freeform text |
+| Success | `info` | bytes / item count / generated id |
+| External SDK / fetch returned no data | `warn` | input preview + reason |
+| Internal exception (we threw, not the SDK) | `error` | input preview + `errorMessage(err)` |
+| External SDK request/response shape | `debug` | only inside the SDK wrapper (`server/utils/gemini.ts` etc.); never inside route files |
+
+Use `previewSnippet` from [`server/utils/logPreview.ts`](../server/utils/logPreview.ts) to clamp prompts / wiki bodies / search queries to 120 chars. **Never log** API keys, bearer tokens, cookies, full prompts, full markdown bodies, or absolute paths that include `/Users/<name>` (use the workspace-relative path instead).
+
+### Operational note: hard-to-reproduce error reports
+
+When a user reports "this failed with no UI feedback" and you can't reproduce it, **start by auditing the relevant route's log coverage**. If the file has zero `log.*` calls (or only catch-block logs without an entry log), there's nothing to grep against — the first move is to add the layered logging template above and ship it as its own PR before continuing the bug hunt. The current state of every route is tracked in [`plans/log-audit/findings.md`](../plans/log-audit/findings.md); if the route you're touching is marked "none" or "partial", upgrading it counts as in-scope groundwork.
 
 ---
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -497,13 +497,13 @@ Routes that do anything more than echo state should follow this shape, mirroring
 
 | Stage | Level | Required payload |
 |---|---|---|
-| Entry, after input validation | `info` | route name + key id (sessionId / slug / path) + `previewSnippet(prompt)` for any user-supplied freeform text |
+| Entry, after input validation | `info` | route name + key id (sessionId / slug / path) + `promptMeta(prompt)` for freeform user input, or `previewSnippet(slug)` for identifier-shaped fields |
 | Success | `info` | bytes / item count / generated id |
-| External SDK / fetch returned no data | `warn` | input preview + reason |
-| Internal exception (we threw, not the SDK) | `error` | input preview + `errorMessage(err)` |
+| External SDK / fetch returned no data | `warn` | input fingerprint + reason |
+| Internal exception (we threw, not the SDK) | `error` | input fingerprint + `errorMessage(err)` |
 | External SDK request/response shape | `debug` | only inside the SDK wrapper (`server/utils/gemini.ts` etc.); never inside route files |
 
-Two helpers, picked by call-site shape:
+The "input fingerprint" in the warn / error rows is whichever helper the entry log used — `promptMeta` for freeform prompts, `previewSnippet` for identifiers. Pick by call-site shape, per the table below:
 
 | Helper | Use for | Output |
 |---|---|---|

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -14,6 +14,7 @@
 
 import { test, expect, type Page, type WebSocketRoute } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
+import type { SessionFixture } from "../fixtures/sessions";
 import type { NotificationPayload } from "../../src/types/notification";
 import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_KINDS, NOTIFICATION_PRIORITIES, NOTIFICATION_VIEWS } from "../../src/types/notification";
 
@@ -30,7 +31,24 @@ interface NotificationScenario {
   // path+search+hash, so specs with query strings use the full
   // string. Leave undefined when only the pathname matters.
   fullUrl?: string;
+  // Sessions to pre-seed in the mock. The chat-target scenario
+  // needs this: when the notification click pushes /chat/<id>,
+  // App.vue's session-load watcher fetches the session from the
+  // server. If the fetch 404s the watcher falls back to
+  // createNewSession(), clobbering the URL with a freshly-created
+  // UUID. Pre-seeding keeps the URL stable. Other scenarios don't
+  // need a session so the field defaults to an empty list.
+  seedSessions?: SessionFixture[];
 }
+
+const CHAT_TARGET_SESSION: SessionFixture = {
+  id: "sess-xyz",
+  title: "Notification target session",
+  roleId: "general",
+  startedAt: "2026-04-25T05:00:00Z",
+  updatedAt: "2026-04-25T05:00:00Z",
+  preview: "Stub for the notification permalink E2E",
+};
 
 function buildPayload(notifId: string, title: string, action: NotificationPayload["action"]): NotificationPayload {
   return {
@@ -53,6 +71,7 @@ const SCENARIOS: readonly NotificationScenario[] = [
     }),
     expectedPathname: "/chat/sess-xyz",
     fullUrl: "/chat/sess-xyz?result=uuid-abc",
+    seedSessions: [CHAT_TARGET_SESSION],
   },
   {
     description: "todos target with itemId",
@@ -247,7 +266,7 @@ test.describe("notification permalinks", () => {
 
   for (const scenario of SCENARIOS) {
     test(scenario.description, async ({ page }) => {
-      await mockAllApis(page, { sessions: [] });
+      await mockAllApis(page, { sessions: scenario.seedSessions ?? [] });
       await installNotificationStream(page, scenario.payload);
 
       // Start on /todos rather than /. The home redirect lands on

--- a/plans/feat-server-log-audit-779.md
+++ b/plans/feat-server-log-audit-779.md
@@ -1,0 +1,120 @@
+# feat: server-side logging audit — start with the four highest-traffic routes
+
+Issue: [#779](https://github.com/receptron/mulmoclaude/issues/779)
+Reference PR (pattern source): [#780](https://github.com/receptron/mulmoclaude/pull/780) — image generation observability.
+
+## Problem
+
+When a user reports "this failed with no UI feedback," the first move is `grep` over `server/system/logs/`. For 17 of 27 server route handlers there's nothing to grep — the file has zero `log.*` calls. PR #780 fixed this for image generation; everything else is still in the same silent-failure state.
+
+## Scope of this PR (PR-1, the anchor)
+
+1. **Audit doc** at `plans/log-audit/findings.md`. Table-format, one row per route handler / MCP tool / external SDK call site. Records:
+   - Current logging coverage (none / partial / good)
+   - What's missing (entry log, success log, catch-block warn/error, debug for SDK shape)
+   - Priority (high / med / low) — "high" iff users currently report errors against this surface
+   - Which PR covers it (this one or a follow-up issue)
+2. **Layered logging on the four highest-priority routes** (matches the issue's listing):
+   - `server/api/routes/wiki.ts`
+   - `server/api/routes/agent.ts`
+   - `server/api/routes/sources.ts` + `server/workspace/sources/pipeline/*.ts`
+   - `server/api/routes/scheduler*.ts`
+3. **Process docs**:
+   - `daily-refactoring` skill (Phase 3) — add a "try/catch logging" item.
+   - `docs/developer.md` — add an operational note: *for hard-to-reproduce error reports, start by auditing the route's log coverage*.
+   - Optional `CONTRIBUTING.md` entry if one exists; otherwise developer.md is enough.
+4. **Shared helper**: extract the `previewPrompt` / `previewSnippet` pattern (currently inline in `server/api/routes/image.ts`) into `server/utils/logPreview.ts` so the four new files share one definition. Same 120-char cap, same `…` ellipsis suffix.
+
+## Out of scope (tracked as follow-up)
+
+The remaining 13 lower-priority routes get a one-line entry per route in `findings.md` with a "follow-up" tag. After this PR lands, isamu (or whoever picks up #779) opens individual issues per group:
+
+- `files.ts` / `chart.ts` / `html.ts` / `presentHtml.ts` / `mulmoScriptValidate.ts`
+- `sessions.ts` / `sessionsCursor.ts` / `roles.ts` / `config.ts`
+- `todos.ts` + `todos*Handlers.ts` (4 files, share one issue)
+- `dispatchResponse.ts` (utility, may not need its own logging — covered by the dispatching route)
+- MCP tool handlers (`server/agent/mcp-tools/*.ts`)
+- Plugin server-side handlers under `src/plugins/*/index.ts`
+- Bridge packages (`packages/bridges/*`)
+
+The `LOG_FILE_DIR` test/dev separation issue called out at the bottom of #779 stays a fully separate ticket — different problem (log routing, not log content).
+
+## Layered-logging template
+
+Mirrors PR #780. Every covered route follows this shape:
+
+```ts
+// Top-of-file: import shared helpers
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
+import { errorMessage } from "../../utils/errors.js";
+
+// Inside each handler:
+router.post(..., async (req, res) => {
+  const { prompt, sessionId } = req.body;
+  if (!prompt) {
+    log.warn("<prefix>", "<verb>: missing prompt", { sessionId });
+    return badRequest(res, "prompt is required");
+  }
+  log.info("<prefix>", "<verb>: start", {
+    promptPreview: previewSnippet(prompt),
+    sessionId,
+  });
+  try {
+    const result = await externalCall(prompt);
+    if (!result.data) {
+      log.warn("<prefix>", "<verb>: external returned no data", {
+        promptPreview: previewSnippet(prompt),
+        sessionId,
+      });
+    } else {
+      log.info("<prefix>", "<verb>: ok", {
+        promptPreview: previewSnippet(prompt),
+        sessionId,
+        bytes: result.data.length,
+      });
+    }
+    res.json(result);
+  } catch (err) {
+    log.error("<prefix>", "<verb>: call threw", {
+      promptPreview: previewSnippet(prompt),
+      sessionId,
+      error: errorMessage(err),
+    });
+    serverError(res, errorMessage(err));
+  }
+});
+```
+
+Rules:
+
+- `log.info` for entry + success.
+- `log.warn` for "external SDK returned nothing useful" (recoverable; fallback message displayed to the user).
+- `log.error` for "we threw" (we crashed, not the SDK refusing politely).
+- `log.debug` for SDK request/response shapes — only inside the SDK wrapper, never inside the route file itself.
+- **prompt preview only** via `previewSnippet` (120-char cap).
+- **never log** API keys, bearer tokens, cookies, full sessions, full markdown bodies, or raw filesystem paths that include `/Users/<name>` (use the workspace-relative path).
+
+## PII / secrets discipline
+
+- `previewSnippet(text)` truncates at 120 chars + `…`. Use for any user-supplied freeform text (prompts, wiki bodies, search queries).
+- `sessionId` is fine to log raw — it's a UUID, not user-meaningful.
+- `path` arguments must be passed through `path.relative(WORKSPACE_PATHS.root, abs)` if they were absolute. Routes that already deal in slug / relative paths can log them verbatim.
+- Wiki page titles and source feed titles are fine to log raw — they're chosen by the user but treated as identifiers, not secrets.
+
+## Verification
+
+Manual:
+- `yarn dev`, hit each touched route with both happy-path and forced-failure inputs, confirm log lines land on `server/system/logs/server-YYYY-MM-DD.log`.
+
+Automated:
+- Existing tests stay green. New behaviour is observability — assert by reading the log file in a unit test would couple the test to the log format. Defer to manual inspection per the issue's intent.
+
+## Execution order
+
+1. Plan doc (this file) committed first.
+2. `server/utils/logPreview.ts` shared helper.
+3. `plans/log-audit/findings.md` — write the audit table covering all 27 routes + MCP tools + SDK call sites.
+4. Add logging to the four target routes one at a time (one commit per route group), each followed by `yarn typecheck && yarn lint && yarn build`.
+5. Process docs.
+6. Format / lint / typecheck / build / test clean run, push, open PR.

--- a/plans/feat-server-log-audit-779.md
+++ b/plans/feat-server-log-audit-779.md
@@ -23,7 +23,9 @@ When a user reports "this failed with no UI feedback," the first move is `grep` 
    - `daily-refactoring` skill (Phase 3) — add a "try/catch logging" item.
    - `docs/developer.md` — add an operational note: *for hard-to-reproduce error reports, start by auditing the route's log coverage*.
    - Optional `CONTRIBUTING.md` entry if one exists; otherwise developer.md is enough.
-4. **Shared helper**: extract the `previewPrompt` / `previewSnippet` pattern (currently inline in `server/api/routes/image.ts`) into `server/utils/logPreview.ts` so the four new files share one definition. Same 120-char cap, same `…` ellipsis suffix.
+4. **Shared helpers**:
+   - Extract a `previewSnippet` truncate-and-show helper into `server/utils/logPreview.ts`. Same 120-char cap as the original `previewPrompt` in `image.ts`. Used in this PR for **identifier-shaped** fields (wiki slug, page name, action verb) — places where retaining grep value matters.
+   - **Also note**: while this PR was in review, PR #783 landed on main introducing a stricter `promptMeta()` (`{ length, sha256 }`) helper for freeform user prompts, and migrated `image.ts` to it. After the main-merge, `image.ts` no longer uses `previewSnippet`; new prompt logging in subsequent route follow-ups should default to `promptMeta` instead. `previewSnippet` survives for identifier-shaped fields. See `findings.md` § "Helpers in play".
 
 ## Out of scope (tracked as follow-up)
 

--- a/plans/log-audit/findings.md
+++ b/plans/log-audit/findings.md
@@ -19,7 +19,7 @@ Snapshot taken 2026-04-25 from the branch landing this PR. Counts are `grep -c "
 | `dispatchResponse.ts` | 0 | n/a | utility, not a route — covered by callers | leave |
 | `files.ts` | 0 | none | tree / dir / content / raw all silent on failure | followup (high — file IO is core) |
 | `html.ts` | 0 | none | generate / edit / present silent | followup |
-| `image.ts` | 11 | good | landed in #780 | leave |
+| `image.ts` | 11 | good | landed in #780; #783 migrated prompt logging from `previewSnippet` to `promptMeta` (sha256 fingerprint) | leave |
 | `mulmoScriptValidate.ts` | 0 | none | validation handler silent | followup (low — validation, not state mutation) |
 | `mulmo-script.ts` | 3 | partial | save, render, generate-movie — covers some, misses others | followup |
 | `notifications.ts` | 1 | partial | scheduling logged, but the action / kind context lost | followup (low) |
@@ -27,9 +27,9 @@ Snapshot taken 2026-04-25 from the branch landing this PR. Counts are `grep -c "
 | `plugins.ts` | 0 | none | every present-* handler silent | followup |
 | `presentHtml.ts` | 0 | none | silent | followup |
 | `roles.ts` | 0 | none | silent | followup |
-| `scheduler.ts` | 3 | partial | manual-run + task-action errors logged; createTask success entry missing | **THIS PR** (gap fill) |
+| `scheduler.ts` | partial → good (this PR) | good | every action handler now logs entry + success + validation warns + error | **THIS PR** ✅ |
 | `schedulerHandlers.ts` | 0 | none | every handler silent | followup |
-| `schedulerTasks.ts` | 5 | partial | create / update / delete / run errors logged; entry / list missing | **THIS PR** (gap fill) |
+| `schedulerTasks.ts` | partial → good (this PR) | good | list / create / update / delete / run all log entry + success + validation warns + error | **THIS PR** ✅ |
 | `sessions.ts` | 0 | none | list / detail / mark-read silent | followup |
 | `sessionsCursor.ts` | 0 | none | cursor advance silent | followup |
 | `skills.ts` | 3 | partial | create / update / delete partly covered | followup |
@@ -38,19 +38,19 @@ Snapshot taken 2026-04-25 from the branch landing this PR. Counts are `grep -c "
 | `todosColumnsHandlers.ts` | 0 | none | silent | followup |
 | `todosHandlers.ts` | 0 | none | silent | followup |
 | `todosItemsHandlers.ts` | 0 | none | silent | followup |
-| `wiki.ts` | 0 | none | every action silent — issue #779's top "wiki empty" complaint maps here | **THIS PR** |
+| `wiki.ts` | none → good (this PR) | good | GET + POST handlers log entry + success + page-not-found warn + uncaught throw error; every action covered | **THIS PR** ✅ |
 
 ## Server workspace utilities
 
 | File | Calls | Coverage | Plan |
 |---|---:|---|---|
-| `workspace/sources/pipeline/dedup.ts` | 0 | none | **THIS PR** — pipeline step logs |
-| `workspace/sources/pipeline/fetch.ts` | 0 | none | **THIS PR** — RSS / arXiv / GitHub HTTP failures must surface |
-| `workspace/sources/pipeline/index.ts` | 1 | partial | **THIS PR** — top-level entry log |
-| `workspace/sources/pipeline/notify.ts` | 0 | none | **THIS PR** — score+publish trace |
-| `workspace/sources/pipeline/plan.ts` | 0 | none | **THIS PR** — plan size |
-| `workspace/sources/pipeline/summarize.ts` | 0 | none | **THIS PR** — bytes in / out |
-| `workspace/sources/pipeline/write.ts` | 0 | none | **THIS PR** — files written |
+| `workspace/sources/pipeline/dedup.ts` | 0 | none | followup — small pure helper; entry log lives in `pipeline/index.ts` |
+| `workspace/sources/pipeline/fetch.ts` | none → good (this PR) | good | per-source debug start/ok + warn on missing fetcher / fetcher throw | **THIS PR** ✅ |
+| `workspace/sources/pipeline/index.ts` | partial → good (this PR) | good | start, registry-loaded, planned, fetched (with per-failure warns), deduped, wrote, done — full stage trace | **THIS PR** ✅ |
+| `workspace/sources/pipeline/notify.ts` | 0 | none | followup — score+publish trace |
+| `workspace/sources/pipeline/plan.ts` | 0 | none | followup — small filter, summarised by `index.ts` |
+| `workspace/sources/pipeline/summarize.ts` | 0 | none | followup — bytes in / out (uses claude CLI, prompt would need promptMeta) |
+| `workspace/sources/pipeline/write.ts` | 0 | none | followup — covered partially by `pipeline/index.ts` "wrote" line |
 | `workspace/sources/interests.ts` | 1 | partial | leave (read-only profile load) |
 | `workspace/sources/registry.ts` | 1 | partial | followup (storage layer) |
 | `workspace/journal/dailyPass.ts` | 12 | good | leave |
@@ -87,6 +87,15 @@ Out of scope. Each bridge has its own logger and conventions. Tracked separately
 
 - **Test output bleeds into the dev log**: `server/system/logs/server-YYYY-MM-DD.log` ends up dominated by `yarn test` output. The dev server's real logs are hard to find. Suggested fix: `LOG_FILE_DIR` env override + a NULL sink for the test runner. **Not** in this PR — file as a discrete issue.
 - **Log rotation / retention**: not yet defined. Currently: one file per UTC date, no compression, no purge. Out of scope.
+
+## Helpers in play
+
+| Helper | Use for | Output shape |
+|---|---|---|
+| `server/utils/promptMeta.ts` (`promptMeta`) | freeform user-supplied prompts, search queries, pasted text | `{ length, sha256: <12-hex prefix> }` — no content, fingerprint only. Migrated #780 → #783. |
+| `server/utils/logPreview.ts` (`previewSnippet`) | identifier-shaped fields with grep value (slug, page name, action verb) | first 120 chars + `…` |
+
+Choose `promptMeta` for anything a user pastes; `previewSnippet` for anything they pick from a closed set or type as a deliberate identifier. When in doubt, `promptMeta` is the safer default — it can't leak a fragment of an API key by accident.
 
 ## Pattern (replicated from #780)
 

--- a/plans/log-audit/findings.md
+++ b/plans/log-audit/findings.md
@@ -1,0 +1,142 @@
+# Server Logging Audit (#779)
+
+Snapshot taken 2026-04-25 from the branch landing this PR. Counts are `grep -c "log\."` against each file at HEAD; per-call-site quality is read by hand. "Coverage" categorises the file holistically:
+
+- **good** — entry, success, every catch logs at the right level; PII discipline observed.
+- **partial** — some handlers logged, others silent; or catch-blocks log but entry is missing.
+- **none** — zero `log.*` calls.
+
+"This-PR" = covered by the PR landing this audit. "Followup" = tracked as a discrete follow-up issue.
+
+## Server route handlers (`server/api/routes/*.ts`)
+
+| File | Calls | Coverage | Gaps | Plan |
+|---|---:|---|---|---|
+| `agent.ts` | 8 | good | request received, completion, retry, tool-call, errors all covered | leave |
+| `chart.ts` | 0 | none | every handler silent | followup |
+| `chat-index.ts` | 3 | partial | entry + a couple of failures; some handlers silent | followup |
+| `config.ts` | 0 | none | settings / mcp.json read+write silent | followup |
+| `dispatchResponse.ts` | 0 | n/a | utility, not a route — covered by callers | leave |
+| `files.ts` | 0 | none | tree / dir / content / raw all silent on failure | followup (high — file IO is core) |
+| `html.ts` | 0 | none | generate / edit / present silent | followup |
+| `image.ts` | 11 | good | landed in #780 | leave |
+| `mulmoScriptValidate.ts` | 0 | none | validation handler silent | followup (low — validation, not state mutation) |
+| `mulmo-script.ts` | 3 | partial | save, render, generate-movie — covers some, misses others | followup |
+| `notifications.ts` | 1 | partial | scheduling logged, but the action / kind context lost | followup (low) |
+| `pdf.ts` | 5 | good | render path covered | leave |
+| `plugins.ts` | 0 | none | every present-* handler silent | followup |
+| `presentHtml.ts` | 0 | none | silent | followup |
+| `roles.ts` | 0 | none | silent | followup |
+| `scheduler.ts` | 3 | partial | manual-run + task-action errors logged; createTask success entry missing | **THIS PR** (gap fill) |
+| `schedulerHandlers.ts` | 0 | none | every handler silent | followup |
+| `schedulerTasks.ts` | 5 | partial | create / update / delete / run errors logged; entry / list missing | **THIS PR** (gap fill) |
+| `sessions.ts` | 0 | none | list / detail / mark-read silent | followup |
+| `sessionsCursor.ts` | 0 | none | cursor advance silent | followup |
+| `skills.ts` | 3 | partial | create / update / delete partly covered | followup |
+| `sources.ts` | 12 | good | register, delete, rebuild, manage all logged | leave |
+| `todos.ts` | 0 | none | dispatch + items + columns all silent | followup (high — visible to users) |
+| `todosColumnsHandlers.ts` | 0 | none | silent | followup |
+| `todosHandlers.ts` | 0 | none | silent | followup |
+| `todosItemsHandlers.ts` | 0 | none | silent | followup |
+| `wiki.ts` | 0 | none | every action silent — issue #779's top "wiki empty" complaint maps here | **THIS PR** |
+
+## Server workspace utilities
+
+| File | Calls | Coverage | Plan |
+|---|---:|---|---|
+| `workspace/sources/pipeline/dedup.ts` | 0 | none | **THIS PR** — pipeline step logs |
+| `workspace/sources/pipeline/fetch.ts` | 0 | none | **THIS PR** — RSS / arXiv / GitHub HTTP failures must surface |
+| `workspace/sources/pipeline/index.ts` | 1 | partial | **THIS PR** — top-level entry log |
+| `workspace/sources/pipeline/notify.ts` | 0 | none | **THIS PR** — score+publish trace |
+| `workspace/sources/pipeline/plan.ts` | 0 | none | **THIS PR** — plan size |
+| `workspace/sources/pipeline/summarize.ts` | 0 | none | **THIS PR** — bytes in / out |
+| `workspace/sources/pipeline/write.ts` | 0 | none | **THIS PR** — files written |
+| `workspace/sources/interests.ts` | 1 | partial | leave (read-only profile load) |
+| `workspace/sources/registry.ts` | 1 | partial | followup (storage layer) |
+| `workspace/journal/dailyPass.ts` | 12 | good | leave |
+| `workspace/journal/index.ts` | 10 | good | leave |
+| `workspace/journal/memoryExtractor.ts` | 3 | partial | followup |
+| `workspace/journal/optimizationPass.ts` | 3 | partial | followup |
+| `workspace/journal/diff.ts` | 1 | partial | followup |
+| `workspace/journal/archivist.ts` | 1 | partial | followup |
+| `workspace/journal/state.ts` | 0 | none | followup (state read-only) |
+| `workspace/journal/indexFile.ts` | 0 | none | followup |
+| `workspace/journal/linkRewrite.ts` | 0 | none | followup (low — pure transformer) |
+| `workspace/journal/paths.ts` | 0 | none | leave (path constants only, no IO) |
+
+## External SDK call sites
+
+| Wrapper | Calls | Plan |
+|---|---:|---|
+| `server/utils/gemini.ts` | 3 | leave (#780) |
+| Claude Agent SDK invocation in `server/agent/index.ts` | partial | followup — verify spawn / abort / parse paths |
+| `server/agent/mcp-tools/x.ts` (X / Twitter API) | 0 | followup |
+| `server/agent/mcp-tools/index.ts` (dispatch only) | 0 | n/a |
+
+## MCP tool plugins (`src/plugins/*/index.ts` + companion server routes)
+
+These are layered: the plugin runs client-side, but most call back into a server route via `apiPost`. Where the route is silent, so is the plugin. Coverage = the route's coverage.
+
+Skipping this section for the PR-1 audit pass; the route-level table above already pinpoints the gap. A follow-up issue per plugin grouping (e.g. "todo + spreadsheet route logging") will revisit.
+
+## Bridge packages (`packages/bridges/*`)
+
+Out of scope. Each bridge has its own logger and conventions. Tracked separately as the bridge work re-converges (see #729 and the Slack work).
+
+## Logging-runtime concerns (separate issue)
+
+- **Test output bleeds into the dev log**: `server/system/logs/server-YYYY-MM-DD.log` ends up dominated by `yarn test` output. The dev server's real logs are hard to find. Suggested fix: `LOG_FILE_DIR` env override + a NULL sink for the test runner. **Not** in this PR — file as a discrete issue.
+- **Log rotation / retention**: not yet defined. Currently: one file per UTC date, no compression, no purge. Out of scope.
+
+## Pattern (replicated from #780)
+
+```ts
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
+import { errorMessage } from "../../utils/errors.js";
+
+router.post(API_ROUTES.feature.action, async (req, res) => {
+  const { input, sessionId } = req.body;
+  if (!input) {
+    log.warn("feature", "action: missing input", { sessionId });
+    return badRequest(res, "input is required");
+  }
+  log.info("feature", "action: start", { inputPreview: previewSnippet(input), sessionId });
+  try {
+    const result = await someExternalCall(input);
+    if (!result.data) {
+      log.warn("feature", "action: external returned no data", { inputPreview: previewSnippet(input), sessionId });
+    } else {
+      log.info("feature", "action: ok", { inputPreview: previewSnippet(input), sessionId, bytes: result.data.length });
+    }
+    res.json(result);
+  } catch (err) {
+    log.error("feature", "action: call threw", { inputPreview: previewSnippet(input), sessionId, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+```
+
+Rules summarised:
+
+| Level | When |
+|---|---|
+| `info` | entry (after input validation) and success (with byte/count summary) |
+| `warn` | external SDK / fetch returned no useful data, recoverable |
+| `error` | we threw — internal inconsistency, missing file, parse failure |
+| `debug` | only inside SDK wrappers, for request/response shape — never inside route files |
+
+Never log: API keys, bearer tokens, cookies, full prompts, full markdown bodies, absolute paths that include `/Users/<name>`. Use `previewSnippet` (120-char cap) and workspace-relative paths.
+
+## Follow-up issues to file once this PR lands
+
+(Will be filed by the PR author after merge; placed here so they're not forgotten.)
+
+1. **Files / Wiki / Todo route logging** — `files.ts`, `todos*.ts`. High priority — user-visible.
+2. **Sessions / config / roles route logging** — `sessions.ts`, `sessionsCursor.ts`, `config.ts`, `roles.ts`. Medium.
+3. **Plugin server route logging** — `plugins.ts`, `chart.ts`, `html.ts`, `presentHtml.ts`, `mulmoScriptValidate.ts`, `mulmo-script.ts`. Medium.
+4. **Scheduler-handler / chat-index gap-fill** — `schedulerHandlers.ts`, `chat-index.ts`, `skills.ts` (partial → good). Low.
+5. **MCP tool handler logging** — `server/agent/mcp-tools/x.ts` and any new ones. Medium.
+6. **Journal partial → good** — `memoryExtractor.ts`, `optimizationPass.ts`, `diff.ts`, `archivist.ts`, `state.ts`. Low.
+7. **`LOG_FILE_DIR` test/dev separation** — distinct concern, distinct fix.
+8. **`daily-refactoring` skill checklist update** — referenced by #779 but the skill doesn't ship with this repo (must live as a private user skill). Captured here so the operator who maintains that skill can pick it up: add a "try/catch logging missing → upgrade route to the layered template" item to its Phase 3 checklist.

--- a/plans/log-audit/findings.md
+++ b/plans/log-audit/findings.md
@@ -29,7 +29,7 @@ Snapshot taken 2026-04-25 from the branch landing this PR. Counts are `grep -c "
 | `roles.ts` | 0 | none | silent | followup |
 | `scheduler.ts` | partial → good (this PR) | good | every action handler now logs entry + success + validation warns + error | **THIS PR** ✅ |
 | `schedulerHandlers.ts` | 0 | none | every handler silent | followup |
-| `schedulerTasks.ts` | partial → good (this PR) | good | list / create / update / delete / run all log entry + success + validation warns + error | **THIS PR** ✅ |
+| `schedulerTasks.ts` | partial → good (this PR) | good | list / create / update / delete / run / logs all log entry + success; validation warns on bad input; not-found warns on missing taskId; error catches surround all I/O paths | **THIS PR** ✅ |
 | `sessions.ts` | 0 | none | list / detail / mark-read silent | followup |
 | `sessionsCursor.ts` | 0 | none | cursor advance silent | followup |
 | `skills.ts` | 3 | partial | create / update / delete partly covered | followup |

--- a/server/api/routes/image.ts
+++ b/server/api/routes/image.ts
@@ -7,15 +7,15 @@ import { badRequest, serverError } from "../../utils/httpError.js";
 import { saveImage, overwriteImage, loadImageBase64, stripDataUri, isImagePath } from "../../utils/files/image-store.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
 
 // Image-generation routes were silent on success and on failure. When
 // the canvas showed "missing image" with no server-side trace, there
 // was nothing to grep. The new log lines surface the request
 // (prompt preview, model, optional sessionId) and the outcome.
-const PROMPT_PREVIEW_LIMIT = 120;
-function previewPrompt(prompt: string): string {
-  return prompt.length > PROMPT_PREVIEW_LIMIT ? `${prompt.slice(0, PROMPT_PREVIEW_LIMIT)}…` : prompt;
-}
+// Local alias kept for readability of the call sites — every other
+// route that adopts the same pattern uses `previewSnippet` directly.
+const previewPrompt = previewSnippet;
 
 const router = Router();
 

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -66,9 +66,11 @@ router.post(
 );
 
 async function handleTaskAction(action: string, input: Record<string, unknown>, res: Response): Promise<void> {
+  log.info("scheduler", "task action: start", { action });
   try {
     if (action === SCHEDULER_ACTIONS.listTasks) {
       const tasks = loadUserTasks();
+      log.info("scheduler", "task action: listTasks ok", { tasks: tasks.length });
       res.json({
         uuid: makeUuid(),
         message: `${tasks.length} scheduled task(s) found.`,
@@ -80,6 +82,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
     if (action === SCHEDULER_ACTIONS.createTask) {
       const result = validateAndCreate(input);
       if (result.kind === "error") {
+        log.warn("scheduler", "task action: createTask validation failed", { error: result.error });
         badRequest(res, result.error);
         return;
       }
@@ -87,6 +90,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       tasks.push(result.task);
       await saveUserTasks(tasks);
       await refreshUserTasks();
+      log.info("scheduler", "task action: createTask ok", { id: result.task.id, name: result.task.name });
       res.json({
         uuid: makeUuid(),
         message: `Task "${result.task.name}" created and scheduled.`,
@@ -100,6 +104,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       const tasks = loadUserTasks();
       const idx = tasks.findIndex((task) => task.id === taskId);
       if (idx === -1) {
+        log.warn("scheduler", "task action: deleteTask not found", { taskId });
         notFound(res, `task not found: ${taskId}`);
         return;
       }
@@ -107,6 +112,7 @@ async function handleTaskAction(action: string, input: Record<string, unknown>, 
       tasks.splice(idx, 1);
       await saveUserTasks(tasks);
       await refreshUserTasks();
+      log.info("scheduler", "task action: deleteTask ok", { taskId, name });
       res.json({
         uuid: makeUuid(),
         message: `Task "${name}" deleted.`,

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -25,6 +25,7 @@ const router = Router();
 // ── List all tasks ──────────────────────────────────────────────
 
 router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
+  log.info("scheduler-tasks", "list: start");
   // getSchedulerTasks() returns system-only tasks (registered via
   // initScheduler at startup — journal, chat-index, sources, etc.).
   // origin: "system" is correct, not an overwrite — these tasks
@@ -32,13 +33,14 @@ router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
   const systemTasks = getSchedulerTasks();
   const userTasks = loadUserTasks();
   const all = [...systemTasks.map((task) => ({ ...task, origin: "system" as const })), ...userTasks.map((task) => ({ ...task, origin: "user" as const }))];
-  log.info("scheduler-tasks", "list ok", { system: systemTasks.length, user: userTasks.length });
+  log.info("scheduler-tasks", "list: ok", { system: systemTasks.length, user: userTasks.length });
   res.json({ tasks: all });
 });
 
 // ── Create user task ────────────────────────────────────────────
 
 router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
+  log.info("scheduler-tasks", "create: start");
   const validated = validateAndCreate(req.body);
   if (validated.kind === "error") {
     log.warn("scheduler-tasks", "create: validation failed", { error: validated.error });
@@ -50,10 +52,10 @@ router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
       tasks: [...tasks, validated.task],
       result: validated.task,
     }));
-    log.info("scheduler-tasks", "create ok", { id: task.id, name: task.name });
+    log.info("scheduler-tasks", "create: ok", { id: task.id, name: task.name });
     res.status(201).json({ task });
   } catch (err) {
-    log.error("scheduler-tasks", "create failed", {
+    log.error("scheduler-tasks", "create: failed", {
       error: String(err),
     });
     serverError(res, "Failed to create task");
@@ -64,6 +66,7 @@ router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
 
 router.put(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, res: Response) => {
   const { id: taskId } = req.params;
+  log.info("scheduler-tasks", "update: start", { taskId });
   try {
     const updated = await withUserTaskLock(async (tasks) => {
       const result = applyUpdate(tasks, taskId, req.body);
@@ -73,14 +76,16 @@ router.put(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, res: 
       const task = result.tasks.find((taskItem) => taskItem.id === taskId);
       return { tasks: result.tasks, result: task };
     });
+    log.info("scheduler-tasks", "update: ok", { taskId });
     res.json({ task: updated });
   } catch (err) {
     const msg = errorMessage(err);
     if (msg.startsWith("task not found") || msg.startsWith("request body")) {
+      log.warn("scheduler-tasks", "update: validation failed", { taskId, reason: msg });
       notFound(res, msg);
       return;
     }
-    log.error("scheduler-tasks", "update failed", { error: msg });
+    log.error("scheduler-tasks", "update: failed", { taskId, error: msg });
     serverError(res, "Failed to update task");
   }
 });
@@ -89,6 +94,7 @@ router.put(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, res: 
 
 router.delete(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, res: Response) => {
   const { id: taskId } = req.params;
+  log.info("scheduler-tasks", "delete: start", { taskId });
   try {
     await withUserTaskLock(async (tasks) => {
       const index = tasks.findIndex((task) => task.id === taskId);
@@ -96,14 +102,16 @@ router.delete(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, re
       const next = tasks.filter((task) => task.id !== taskId);
       return { tasks: next, result: undefined };
     });
+    log.info("scheduler-tasks", "delete: ok", { taskId });
     res.json({ deleted: taskId });
   } catch (err) {
     const msg = errorMessage(err);
     if (msg.startsWith("task not found")) {
+      log.warn("scheduler-tasks", "delete: not found", { taskId });
       notFound(res, msg);
       return;
     }
-    log.error("scheduler-tasks", "delete failed", { error: msg });
+    log.error("scheduler-tasks", "delete: failed", { taskId, error: msg });
     serverError(res, "Failed to delete task");
   }
 });
@@ -112,12 +120,14 @@ router.delete(API_ROUTES.scheduler.task, async (req: Request<{ id: string }>, re
 
 router.post(API_ROUTES.scheduler.taskRun, async (req: Request<{ id: string }>, res: Response) => {
   const { id: taskId } = req.params;
+  log.info("scheduler-tasks", "run: start", { taskId });
   // Check user tasks first
   const userTasks = loadUserTasks();
   const userTask = userTasks.find((task) => task.id === taskId);
   if (userTask) {
     const chatSessionId = makeUuid();
-    log.info("scheduler-tasks", "manual run (user task)", {
+    log.info("scheduler-tasks", "run: user task triggered", {
+      taskId,
       name: userTask.name,
       chatSessionId,
     });
@@ -127,7 +137,8 @@ router.post(API_ROUTES.scheduler.taskRun, async (req: Request<{ id: string }>, r
       chatSessionId,
       origin: SESSION_ORIGINS.scheduler,
     }).catch((err) => {
-      log.error("scheduler-tasks", "manual run failed", {
+      log.error("scheduler-tasks", "run: startChat failed", {
+        taskId,
         error: String(err),
       });
     });
@@ -138,10 +149,12 @@ router.post(API_ROUTES.scheduler.taskRun, async (req: Request<{ id: string }>, r
   const systemTasks = getSchedulerTasks();
   const found = systemTasks.find((task) => task.id === taskId);
   if (!found) {
+    log.warn("scheduler-tasks", "run: not found", { taskId });
     notFound(res, `task not found: ${taskId}`);
     return;
   }
   // System tasks don't have a prompt to startChat with — return 400
+  log.warn("scheduler-tasks", "run: refused (system task)", { taskId });
   badRequest(res, "manual run is only supported for user tasks");
 });
 

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -32,6 +32,7 @@ router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
   const systemTasks = getSchedulerTasks();
   const userTasks = loadUserTasks();
   const all = [...systemTasks.map((task) => ({ ...task, origin: "system" as const })), ...userTasks.map((task) => ({ ...task, origin: "user" as const }))];
+  log.info("scheduler-tasks", "list ok", { system: systemTasks.length, user: userTasks.length });
   res.json({ tasks: all });
 });
 
@@ -40,6 +41,7 @@ router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
 router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
   const validated = validateAndCreate(req.body);
   if (validated.kind === "error") {
+    log.warn("scheduler-tasks", "create: validation failed", { error: validated.error });
     badRequest(res, validated.error);
     return;
   }
@@ -48,6 +50,7 @@ router.post(API_ROUTES.scheduler.tasks, async (req: Request, res: Response) => {
       tasks: [...tasks, validated.task],
       result: validated.task,
     }));
+    log.info("scheduler-tasks", "create ok", { id: task.id, name: task.name });
     res.status(201).json({ task });
   } catch (err) {
     log.error("scheduler-tasks", "create failed", {

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -26,15 +26,25 @@ const router = Router();
 
 router.get(API_ROUTES.scheduler.tasks, (_req: Request, res: Response) => {
   log.info("scheduler-tasks", "list: start");
-  // getSchedulerTasks() returns system-only tasks (registered via
-  // initScheduler at startup — journal, chat-index, sources, etc.).
-  // origin: "system" is correct, not an overwrite — these tasks
-  // have no origin field of their own.
-  const systemTasks = getSchedulerTasks();
-  const userTasks = loadUserTasks();
-  const all = [...systemTasks.map((task) => ({ ...task, origin: "system" as const })), ...userTasks.map((task) => ({ ...task, origin: "user" as const }))];
-  log.info("scheduler-tasks", "list: ok", { system: systemTasks.length, user: userTasks.length });
-  res.json({ tasks: all });
+  try {
+    // getSchedulerTasks() returns system-only tasks (registered via
+    // initScheduler at startup — journal, chat-index, sources, etc.).
+    // origin: "system" is correct, not an overwrite — these tasks
+    // have no origin field of their own.
+    const systemTasks = getSchedulerTasks();
+    const userTasks = loadUserTasks();
+    const all = [...systemTasks.map((task) => ({ ...task, origin: "system" as const })), ...userTasks.map((task) => ({ ...task, origin: "user" as const }))];
+    log.info("scheduler-tasks", "list: ok", { system: systemTasks.length, user: userTasks.length });
+    res.json({ tasks: all });
+  } catch (err) {
+    // loadUserTasks reads JSON from disk and getSchedulerTasks
+    // queries the in-memory registry — neither is supposed to
+    // throw, but a corrupted user-tasks.json or an early-startup
+    // registry race would. Without the catch the route would 500
+    // with no trace, which is the original #779 complaint pattern.
+    log.error("scheduler-tasks", "list: failed", { error: errorMessage(err) });
+    serverError(res, "Failed to list tasks");
+  }
 });
 
 // ── Create user task ────────────────────────────────────────────
@@ -171,12 +181,20 @@ router.get(API_ROUTES.scheduler.logs, async (req: Request<object, unknown, objec
   const rawLimitStr = getOptionalStringQuery(req, "limit");
   const rawLimit = rawLimitStr ? parseInt(rawLimitStr, 10) : undefined;
   const limit = Number.isFinite(rawLimit) && rawLimit! > 0 ? Math.min(rawLimit!, MAX_LIMIT) : undefined;
-  const logs = await getSchedulerLogs({
-    since: getOptionalStringQuery(req, "since"),
-    taskId: getOptionalStringQuery(req, "taskId"),
-    limit,
-  });
-  res.json({ logs });
+  const taskId = getOptionalStringQuery(req, "taskId");
+  log.info("scheduler-tasks", "logs: start", { taskId, limit });
+  try {
+    const logs = await getSchedulerLogs({
+      since: getOptionalStringQuery(req, "since"),
+      taskId,
+      limit,
+    });
+    log.info("scheduler-tasks", "logs: ok", { entries: logs.length, taskId });
+    res.json({ logs });
+  } catch (err) {
+    log.error("scheduler-tasks", "logs: failed", { taskId, error: errorMessage(err) });
+    serverError(res, "Failed to read scheduler logs");
+  }
 });
 
 export default router;

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -7,6 +7,13 @@ import { parseFrontmatterTags } from "./wiki/frontmatter.js";
 import { badRequest } from "../../utils/httpError.js";
 import { getOptionalStringQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
+// Aliased because `buildPageResponseData` below declares a local
+// string named `errorMessage`; importing the errors util under a
+// different name avoids the no-shadow clash without renaming the
+// long-standing local.
+import { errorMessage as formatError } from "../../utils/errors.js";
 
 const router = Router();
 
@@ -235,18 +242,32 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
 router.get(API_ROUTES.wiki.base, async (req: Request, res: Response<WikiResponse | ErrorResponse>) => {
   const slug = getOptionalStringQuery(req, "slug");
   if (slug) {
-    res.json(await buildPageResponse("page", slug));
-  } else {
-    const content = readFileOrEmpty(indexFile());
-    const pageEntries = parseIndexEntries(content);
-    res.json({
-      data: { action: "index", title: "Wiki Index", content, pageEntries },
-      message: content ? `Wiki index — ${pageEntries.length} page(s)` : "Wiki index is empty.",
-      title: "Wiki Index",
-      instructions: "The wiki index is now displayed on the canvas.",
-      updating: true,
-    });
+    log.info("wiki", "GET page: start", { slugPreview: previewSnippet(slug) });
+    try {
+      const response = await buildPageResponse("page", slug);
+      if (!response.data.pageExists) {
+        log.warn("wiki", "GET page: not found", { slugPreview: previewSnippet(slug) });
+      } else {
+        log.info("wiki", "GET page: ok", { slugPreview: previewSnippet(slug), bytes: response.data.content.length });
+      }
+      res.json(response);
+    } catch (err) {
+      log.error("wiki", "GET page: threw", { slugPreview: previewSnippet(slug), error: formatError(err) });
+      throw err;
+    }
+    return;
   }
+  log.info("wiki", "GET index: start");
+  const content = readFileOrEmpty(indexFile());
+  const pageEntries = parseIndexEntries(content);
+  log.info("wiki", "GET index: ok", { pages: pageEntries.length, bytes: content.length });
+  res.json({
+    data: { action: "index", title: "Wiki Index", content, pageEntries },
+    message: content ? `Wiki index — ${pageEntries.length} page(s)` : "Wiki index is empty.",
+    title: "Wiki Index",
+    instructions: "The wiki index is now displayed on the canvas.",
+    updating: true,
+  });
 });
 
 interface WikiBody {
@@ -492,25 +513,49 @@ async function buildLintReportResponse(action: string): Promise<WikiResponse> {
 
 router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>, res: Response<WikiResponse | ErrorResponse>) => {
   const { action, pageName } = req.body;
-  switch (action) {
-    case "index":
-      res.json(buildIndexResponse(action));
-      return;
-    case "page":
-      if (!pageName) {
-        badRequest(res, "pageName required for page action");
+  log.info("wiki", "POST: start", { action, pageNamePreview: pageName ? previewSnippet(pageName) : undefined });
+  try {
+    switch (action) {
+      case "index": {
+        const response = buildIndexResponse(action);
+        log.info("wiki", "POST index: ok", { pages: response.data.pageEntries?.length ?? 0 });
+        res.json(response);
         return;
       }
-      res.json(await buildPageResponse(action, pageName));
-      return;
-    case "log":
-      res.json(buildLogResponse(action));
-      return;
-    case "lint_report":
-      res.json(await buildLintReportResponse(action));
-      return;
-    default:
-      badRequest(res, `Unknown action: ${action}`);
+      case "page": {
+        if (!pageName) {
+          log.warn("wiki", "POST page: missing pageName");
+          badRequest(res, "pageName required for page action");
+          return;
+        }
+        const response = await buildPageResponse(action, pageName);
+        if (!response.data.pageExists) {
+          log.warn("wiki", "POST page: not found", { pageNamePreview: previewSnippet(pageName) });
+        } else {
+          log.info("wiki", "POST page: ok", { pageNamePreview: previewSnippet(pageName), bytes: response.data.content.length });
+        }
+        res.json(response);
+        return;
+      }
+      case "log": {
+        const response = buildLogResponse(action);
+        log.info("wiki", "POST log: ok", { bytes: response.data.content.length });
+        res.json(response);
+        return;
+      }
+      case "lint_report": {
+        const response = await buildLintReportResponse(action);
+        log.info("wiki", "POST lint_report: ok", { issues: response.message });
+        res.json(response);
+        return;
+      }
+      default:
+        log.warn("wiki", "POST: unknown action", { action });
+        badRequest(res, `Unknown action: ${action}`);
+    }
+  } catch (err) {
+    log.error("wiki", "POST: threw", { action, pageNamePreview: pageName ? previewSnippet(pageName) : undefined, error: formatError(err) });
+    throw err;
   }
 });
 

--- a/server/utils/logPreview.ts
+++ b/server/utils/logPreview.ts
@@ -1,0 +1,24 @@
+// Truncating preview for log payloads.
+//
+// Logs of user-supplied freeform text (prompts, wiki bodies, search
+// queries) must never include the full body — partly to keep log
+// files small, partly to limit accidental PII / secret leakage when
+// logs are shared during debugging. 120 chars + an ellipsis is the
+// shape the image-generation logging (PR #780) settled on; this
+// module exists so other routes use the same constant rather than
+// hand-rolling their own cap.
+//
+// Usage:
+//   log.info("wiki", "page: start", { pageNamePreview: previewSnippet(pageName) });
+//
+// `null` / `undefined` → empty string, so the logger never has to
+// guard against missing input.
+
+const PREVIEW_CHAR_LIMIT = 120;
+const ELLIPSIS = "…";
+
+export function previewSnippet(input: string | null | undefined): string {
+  if (!input) return "";
+  if (input.length <= PREVIEW_CHAR_LIMIT) return input;
+  return `${input.slice(0, PREVIEW_CHAR_LIMIT)}${ELLIPSIS}`;
+}

--- a/server/workspace/sources/pipeline/fetch.ts
+++ b/server/workspace/sources/pipeline/fetch.ts
@@ -16,6 +16,7 @@ import type { FetcherKind, Source, SourceState } from "../types.js";
 import { defaultSourceState } from "../types.js";
 import { errorMessage } from "../../../utils/errors.js";
 import { ONE_MINUTE_MS, ONE_HOUR_MS, ONE_DAY_MS } from "../../../utils/time.js";
+import { log } from "../../../system/logger/index.js";
 
 // Outcome of one source's fetch attempt.
 export type FetchOutcome =
@@ -64,14 +65,27 @@ async function fetchOneSource(
 ): Promise<FetchOutcome> {
   const fetcher = getFetcher(source.fetcherKind);
   if (!fetcher) {
+    log.warn("pipeline.fetch", "no fetcher registered", {
+      sourceSlug: source.slug,
+      fetcherKind: source.fetcherKind,
+    });
     return {
       kind: "no-fetcher",
       sourceSlug: source.slug,
       error: `no fetcher registered for kind "${source.fetcherKind}"`,
     };
   }
+  log.debug("pipeline.fetch", "fetcher start", {
+    sourceSlug: source.slug,
+    fetcherKind: source.fetcherKind,
+  });
   try {
     const result = await fetcher.fetch(source, state, deps);
+    log.debug("pipeline.fetch", "fetcher ok", {
+      sourceSlug: source.slug,
+      fetcherKind: source.fetcherKind,
+      items: result.items.length,
+    });
     return {
       kind: "success",
       sourceSlug: source.slug,
@@ -79,6 +93,15 @@ async function fetchOneSource(
       cursor: result.cursor,
     };
   } catch (err) {
+    // Per-source warn: the pipeline's outer catch in
+    // computeNextState handles backoff, but without this log a
+    // single bad RSS feed throws no trace anywhere — the user's
+    // exact complaint in #779.
+    log.warn("pipeline.fetch", "fetcher threw", {
+      sourceSlug: source.slug,
+      fetcherKind: source.fetcherKind,
+      error: errorMessage(err),
+    });
     return {
       kind: "error",
       sourceSlug: source.slug,

--- a/server/workspace/sources/pipeline/index.ts
+++ b/server/workspace/sources/pipeline/index.ts
@@ -108,6 +108,8 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
   const fallbackMonth = toLocalYearMonth(startMs);
   const summarizeFn = input.summarizeFn ?? makeDefaultSummarize(isoDate);
 
+  log.info("pipeline", "run: start", { scheduleType, isoDate });
+
   // --- 0. Auto-discover arXiv sources from interests ------------------
   // Best-effort: a bad interests.json or FS error must not abort the
   // entire pipeline. The daily news fetch is more important than
@@ -128,6 +130,7 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
     workspaceRoot,
     allSources.map((source) => source.slug),
   );
+  log.info("pipeline", "run: registry loaded", { sources: allSources.length });
 
   // --- 2. Plan ------------------------------------------------------
   onProgress("plan");
@@ -137,6 +140,7 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
     scheduleType,
     nowMs: startMs,
   });
+  log.info("pipeline", "run: planned", { eligible: eligible.length, total: allSources.length });
   if (eligible.length === 0) {
     // Write an empty-day daily file so it's clear the pipeline
     // ran. Archive append is a no-op. State untouched.
@@ -174,11 +178,24 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
     deps: fetcherDeps,
     getFetcher,
   });
+  const fetchSummary = summariseOutcomes(outcomes);
+  log.info("pipeline", "run: fetched", fetchSummary);
+  for (const failure of fetchSummary.failures) {
+    // One warn per failed source so the slug is greppable. The
+    // pipeline isolates errors per-source, but without this trace
+    // a silently-failing fetcher disappears entirely.
+    log.warn("pipeline", "run: fetcher failed", failure);
+  }
 
   // --- 4. Dedup -----------------------------------------------------
   onProgress("dedup");
   const rawItems = flattenItems(outcomes);
   const dedup = dedupAcrossSources(rawItems);
+  log.info("pipeline", "run: deduped", {
+    raw: rawItems.length,
+    unique: dedup.stats.uniqueCount,
+    duplicates: dedup.stats.duplicateCount,
+  });
 
   // --- 5. Notify (user interest matching) ----------------------------
   onProgress("notify");
@@ -191,6 +208,12 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
   onProgress("write"); // step 7
   const dailyPath = await writeDailyFile(workspaceRoot, isoDate, markdown, dedup.items);
   const archiveResult = await appendItemsToArchives(workspaceRoot, dedup.items, fallbackMonth);
+  log.info("pipeline", "run: wrote", {
+    items: dedup.items.length,
+    dailyBytes: markdown.length,
+    archiveFiles: archiveResult.writtenPaths.length,
+    archiveErrors: archiveResult.errors.length,
+  });
 
   // --- 8. Persist state ---------------------------------------------
   onProgress("persist");
@@ -198,6 +221,11 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
   await writeManyStates(workspaceRoot, nextStates);
 
   onProgress("done");
+  log.info("pipeline", "run: done", {
+    plannedCount: eligible.length,
+    items: dedup.items.length,
+    elapsedMs: nowMs() - startMs,
+  });
   return {
     plannedCount: eligible.length,
     outcomes,
@@ -209,6 +237,35 @@ export async function runSourcesPipeline(input: RunPipelineInput): Promise<RunPi
     nextStates,
     isoDate,
   };
+}
+
+// Cheap one-pass scan over outcomes producing the counters and the
+// per-failure log payload the pipeline emits in the `fetched` log.
+// Kept inline rather than reused elsewhere — only the pipeline
+// summarises outcomes this way.
+function summariseOutcomes(outcomes: readonly FetchOutcome[]): {
+  total: number;
+  success: number;
+  noFetcher: number;
+  errored: number;
+  failures: Array<{ sourceSlug: string; kind: "no-fetcher" | "error"; error: string }>;
+} {
+  let success = 0;
+  let noFetcher = 0;
+  let errored = 0;
+  const failures: Array<{ sourceSlug: string; kind: "no-fetcher" | "error"; error: string }> = [];
+  for (const outcome of outcomes) {
+    if (outcome.kind === "success") {
+      success++;
+    } else if (outcome.kind === "no-fetcher") {
+      noFetcher++;
+      failures.push({ sourceSlug: outcome.sourceSlug, kind: "no-fetcher", error: outcome.error });
+    } else {
+      errored++;
+      failures.push({ sourceSlug: outcome.sourceSlug, kind: "error", error: outcome.error });
+    }
+  }
+  return { total: outcomes.length, success, noFetcher, errored, failures };
 }
 
 // Flatten successful-outcome items into a single list for


### PR DESCRIPTION
## Summary

Anchor PR for #779. Mirrors the layered logging template PR #780 introduced for image generation, and brings the four highest-traffic routes (the ones most often referenced in user error reports) up to the same coverage. Also lands the audit doc that scopes the remaining work.

## Items to Confirm / Review

- [ ] **Audit doc accuracy** — `plans/log-audit/findings.md` rates every route as `good` / `partial` / `none`. The "good" calls (image, agent, sources, pdf, journal) are based on a quick read of the call sites, not deep inspection. If you spot a `good` that should really be `partial`, leave a line comment.
- [ ] **Pipeline log volume** — `pipeline.fetch` emits one `debug` per fetcher start + ok, plus a `warn` per failure. On a 30-source workspace this is 60+ debug lines per run. If the volume feels excessive at default log level, drop the success-path debug to a single aggregate at `pipeline` level (the per-source warns on failure are the load-bearing ones).
- [ ] **Wiki POST log on uncaught throw** — wraps the existing switch in try/catch and re-throws after logging. Confirms the original error semantics still propagate to Express's error middleware. If we're missing such middleware, the rethrow will show as 500 with no body — same as today.
- [ ] **Out-of-scope list** — `findings.md` proposes follow-up issues for files/todos/sessions/plugins/etc. Confirm the cut at "wiki + pipeline + scheduler-gap-fill" feels right for PR-1, or pull more in.

## User Prompt

> issue #779 を実装。さっきの提案どおりに（PR-1: audit doc + 高優先4 routes + process docs）。新しいブランチで。

## Implementation

Plan: [plans/feat-server-log-audit-779.md](https://github.com/receptron/mulmoclaude/blob/feat/log-audit-779/plans/feat-server-log-audit-779.md).

### Files

| Path | Change |
|---|---|
| \`plans/log-audit/findings.md\` | New — audit table for 27 routes + workspace utils + SDK call sites |
| \`server/utils/logPreview.ts\` | New — shared 120-char preview helper (extracted from image.ts) |
| \`server/api/routes/image.ts\` | Replace inline \`previewPrompt\` with alias to shared helper |
| \`server/api/routes/wiki.ts\` | Full layered coverage — was zero log calls |
| \`server/workspace/sources/pipeline/index.ts\` | Top-level pipeline trace + per-stage summary |
| \`server/workspace/sources/pipeline/fetch.ts\` | Per-source fetch debug / warn (RSS/arXiv/GitHub failures) |
| \`server/api/routes/scheduler.ts\` | Entry + success logs on createTask / deleteTask / listTasks |
| \`server/api/routes/schedulerTasks.ts\` | Same gap fill on the REST path |
| \`docs/developer.md\` | Layered-logging template + operational guideline ("audit log coverage before debugging hard-to-reproduce reports") |

### Out of scope

Tracked in findings.md "Follow-up issues to file once this PR lands":
- Lower-priority route logging (files / todos / sessions / config / roles / plugin handlers / chart / html / presentHtml / mulmoScriptValidate / mulmo-script / chat-index / skills / sessionsCursor / schedulerHandlers)
- MCP tool handlers (\`server/agent/mcp-tools/x.ts\`)
- Bridge packages (\`packages/bridges/*\`)
- \`LOG_FILE_DIR\` test/dev separation (different problem)
- \`daily-refactoring\` skill checklist (skill lives outside the repo)

## Test plan

- [x] \`yarn format\` — clean
- [x] \`yarn lint\` — 0 errors (only pre-existing v-html warnings)
- [x] \`yarn typecheck\` — clean
- [x] \`yarn build:client\` — clean
- [x] \`yarn test\` — 10/10 unit suites pass
- [ ] Manual: \`yarn dev\`, hit GET / POST /api/wiki, kick a sources rebuild — confirm new lines land in \`server/system/logs/server-YYYY-MM-DD.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded logging conventions with new namespaces and standardized layered logging requirements across server routes.
  * Added comprehensive server-side logging audit documentation with coverage assessments and follow-up guidance.

* **Chores**
  * Enhanced structured logging instrumentation across scheduler, wiki, and pipeline components for improved observability and error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->