### PR TITLE
chore: add Claude Code × Ollama setup skill, findings, and MulmoClaude support plan

### DIFF
--- a/.claude/skills/setup-ollama-local/SKILL.md
+++ b/.claude/skills/setup-ollama-local/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: setup-ollama-local
+description: Interactively guide Claude Code + Ollama local LLM setup on Mac — install, model pull, env switch, and verification. Respond in the user's language.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Setup Claude Code × Ollama（ローカル LLM）
+
+Mac 上で Claude Code を Ollama のローカル LLM に接続するセットアップをガイドする。普段はクラウド Claude（Subscription）を使い、必要な時だけローカルに切り替える運用を前提とする。
+
+## 重要な前提知識
+
+- Ollama **v0.14.0 以降**で Anthropic Messages API 互換が追加された
+- 3B クラスの小型モデルではテキスト出力のみ可能（ツール呼び出しは動かない）
+- Function Calling 対応モデル（Gemma 4、gpt-oss 等）なら一定レベルのエージェント動作が期待できる
+
+## Step 1: Ollama の確認・インストール
+
+### 1-1. インストール済みかチェック
+
+```bash
+which ollama && ollama --version
+```
+
+- **インストール済み**: バージョンが **v0.14.0 以上**であることを確認。古い場合はアップデートを案内
+- **未インストール**: 以下のいずれかを案内
+  - 公式インストーラー（推奨）: https://ollama.com/download/mac
+  - Homebrew: `brew install ollama`
+
+### 1-2. Ollama サーバの起動確認
+
+```bash
+curl -s http://localhost:11434/api/tags | head -c 200
+```
+
+- **応答あり**: サーバ起動済み → Step 2 へ
+- **応答なし**: 起動方法を案内
+  - 公式インストーラー版: メニューバーの Ollama アイコンをクリック
+  - Homebrew 版: `brew services start ollama` または `ollama serve`
+
+## Step 2: Claude Code の確認
+
+```bash
+which claude && claude --version
+```
+
+- **インストール済み**: Step 3 へ
+- **未インストール**: インストール方法を案内（npm / 公式スクリプト / Homebrew）
+  - npm（推奨）: `npm install -g @anthropic-ai/claude-code`
+  - 公式スクリプト: `curl -fsSL https://claude.ai/install.sh | sh`
+  - Homebrew: `brew install anthropic/tap/claude-code`
+
+## Step 3: モデルの選択とダウンロード
+
+ユーザーの Mac のメモリ量と用途を確認してから推奨モデルを提示する。
+
+### メモリ別おすすめ
+
+| メモリ | おすすめモデル | サイズ | Tool Calling | 用途 |
+|--------|---------------|--------|-------------|------|
+| 8-16GB | `qwen2.5-coder:7b` | 4.7GB | ○ | コード生成の相棒 |
+| 16GB | `qwen2.5-coder:14b` | 9GB | ○ | コーディング上位 |
+| 16GB | `gemma4:e4b` | ~3GB | ◎ | 軽量エージェント実験 |
+| 24GB+ | `gemma4:26b` | ~15GB | ◎ | **Function Calling 強、バランス良** |
+| 24GB+ | `gpt-oss:20b` | 13GB | ◎ | OpenAI オープンウェイト、推論系 |
+
+> ポイント: エージェント機能（Skill / MCP / ツール呼び出し）を試すなら `gemma4:26b` か `gpt-oss:20b` が第一候補。3B クラスでは Skill はほぼ動かない。
+
+### ダウンロード
+
+ユーザーが選んだモデルを pull する。まずは軽量版で動作確認するのも推奨。
+
+```bash
+ollama pull <選択したモデル>
+```
+
+確認:
+
+```bash
+ollama list
+```
+
+## Step 4: ローカル接続テスト
+
+### 4-1. 環境変数セット（一時的）
+
+**このターミナルセッションだけ**の一時切り替え。ウィンドウを閉じればクラウドに戻る。
+
+```bash
+export ANTHROPIC_AUTH_TOKEN="ollama"
+export ANTHROPIC_API_KEY=""
+export ANTHROPIC_BASE_URL="http://localhost:11434"
+```
+
+各環境変数の役割:
+
+| 環境変数 | 値 | 目的 |
+|----------|-----|------|
+| `ANTHROPIC_AUTH_TOKEN` | `"ollama"` | Ollama モードを有効化 |
+| `ANTHROPIC_API_KEY` | `""`（空） | クラウド用キーを無効化（干渉防止） |
+| `ANTHROPIC_BASE_URL` | `http://localhost:11434` | 接続先をローカルに変更 |
+
+### 4-2. Claude Code をローカルモデルで起動
+
+ユーザーに別ターミナルで以下を実行してもらう（`!` プレフィックスを使う）:
+
+```
+! ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude --model <選択したモデル>
+```
+
+起動できたら簡単な質問（例: 「Hello, what model are you?」）で動作確認する。
+
+## Step 5: クラウドへの戻し方を案内
+
+ローカルモードは **そのターミナルだけ** なので:
+
+1. **ターミナルを閉じて開き直す**だけで OK
+2. または明示的に環境変数を削除:
+   ```bash
+   unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
+   ```
+
+## Step 6: エイリアス設定（オプション）
+
+ユーザーが希望する場合、`~/.zshrc` にエイリアスを追加する提案をする。
+
+```bash
+# ローカル Ollama に切り替え
+alias claude-local='ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude'
+```
+
+追加後:
+```bash
+source ~/.zshrc
+```
+
+使い方:
+```bash
+claude-local --model gemma4:26b   # ローカル
+claude                            # 通常はクラウド
+```
+
+## Key pitfalls to highlight
+
+- Ollama のバージョンが **v0.14.0 未満**だと Anthropic API 互換がない — 必ずバージョン確認
+- `ANTHROPIC_API_KEY` を空にしないと既存のクラウド用キーが干渉する場合がある
+- 3B クラスのモデルでは JSON 形式のツール呼び出しを正しく生成できず、ファイル作成等が失敗する
+- Function Calling 対応モデルでも Anthropic の tool use 形式に完全最適化されてはいないため、複雑な Skill チェーンは不安定
+- 大きいモデル（20B+）はメモリを圧迫する — `ps aux | grep ollama` や Activity Monitor でモニタリングを案内
+- `.zshrc` や `.bashrc` に `export ANTHROPIC_BASE_URL=...` を恒久的に書くと通常のクラウド利用が壊れる — エイリアスのみ推奨
+
+## 参考リンク（ユーザーに共有してよいもの）
+
+- Ollama Claude Code 連携: https://docs.ollama.com/integrations/claude-code
+- Ollama Anthropic 互換ブログ: https://ollama.com/blog/claude
+- Claude Code 公式: https://code.claude.com/docs/en/overview

--- a/.claude/skills/setup-ollama-local/SKILL.md
+++ b/.claude/skills/setup-ollama-local/SKILL.md
@@ -67,9 +67,10 @@ Confirm the user's RAM and use case before recommending. Verified working models
 | 8–16GB | (Claude Code × Ollama is impractical here) | — | Cold start exceeds 10 min timeout |
 | 32GB | **`qwen3.5:9b`** | 6.6GB | Most practical, lightest fit |
 | 32GB | `qwen3.6:35b-a3b` | 23GB | MoE (3B active), heavier but works |
+| 16–32GB | `gemma4:e4b` | 3GB on disk (~10.9 GiB resident) | Verified on 32GB; thinking blocks render correctly |
 | 24GB+ (NVIDIA) | `glm-4.7-flash` | 19GB | 198k context, untested on Mac |
 
-Avoid: `qwen3:14b` (40k training limit), `qwen2.5-coder:14b` (older runner ignores `OLLAMA_CONTEXT_LENGTH`), `gemma4:*` (Content block parse errors), `gpt-oss:20b` (Ollama template bug). See findings doc for details.
+Avoid: `qwen3:14b` (40k training limit), `qwen2.5-coder:14b` (older runner ignores `OLLAMA_CONTEXT_LENGTH`), `gemma4:26b` (Content block parse errors — note: `gemma4:e4b` is fine), `gpt-oss:20b` (Ollama template bug). See findings doc for details.
 
 ```bash
 ollama pull <model>

--- a/.claude/skills/setup-ollama-local/SKILL.md
+++ b/.claude/skills/setup-ollama-local/SKILL.md
@@ -1,156 +1,174 @@
 ---
 name: setup-ollama-local
-description: Interactively guide Claude Code + Ollama local LLM setup on Mac — install, model pull, env switch, and verification. Respond in the user's language.
+description: Interactively guide setup for connecting the Claude Code CLI to a local Ollama LLM on Mac. NOTE — This is for the standalone Claude Code CLI itself, NOT MulmoClaude (MulmoClaude does not currently support Ollama as a backend). Covers Ollama install, model pull, env switching, and verification. Respond in the user's language.
 allowed-tools: Read, Bash, Glob, Grep
 ---
 
-# Setup Claude Code × Ollama（ローカル LLM）
+# Setup Claude Code × Ollama (local LLM)
 
-Mac 上で Claude Code を Ollama のローカル LLM に接続するセットアップをガイドする。普段はクラウド Claude（Subscription）を使い、必要な時だけローカルに切り替える運用を前提とする。
+> **Scope / 適用範囲**
+>
+> This skill sets up the **standalone `claude` CLI** to talk to a local Ollama server. It is **independent of MulmoClaude**; MulmoClaude itself does not currently support Ollama (see `plans/feat-mulmoclaude-ollama-support.md` for a tentative plan).
+>
+> このスキルは **`claude` CLI 単体**をローカルの Ollama サーバに接続するセットアップです。**MulmoClaude とは独立**しており、MulmoClaude 本体は現在 Ollama 接続をサポートしていません（実装案は `plans/feat-mulmoclaude-ollama-support.md` を参照）。
 
-## 重要な前提知識
+For detailed findings and pitfalls, see [`docs/tips/claude-code-ollama.md`](../../../docs/tips/claude-code-ollama.md) (Japanese) / [`docs/tips/claude-code-ollama.en.md`](../../../docs/tips/claude-code-ollama.en.md) (English).
 
-- Ollama **v0.14.0 以降**で Anthropic Messages API 互換が追加された
-- 3B クラスの小型モデルではテキスト出力のみ可能（ツール呼び出しは動かない）
-- Function Calling 対応モデル（Gemma 4、gpt-oss 等）なら一定レベルのエージェント動作が期待できる
+## Prerequisites / 前提知識
 
-## Step 1: Ollama の確認・インストール
+- Ollama **v0.14.0 or later** is required (Anthropic Messages API compatibility was added in that version).
+- Claude Code sends roughly **50,000–57,000 tokens per request**, so the model needs **at least a 64k context window**.
+- 3B-class small models effectively cannot drive Claude Code (no tool calling, broken templates).
+- Even on supported models, the first turn often takes **10+ minutes** on a MacBook Air; subsequent turns benefit from KV cache and drop to 1–3 minutes.
 
-### 1-1. インストール済みかチェック
+## Step 1: Verify / install Ollama
+
+### 1-1. Check existing install
 
 ```bash
 which ollama && ollama --version
 ```
 
-- **インストール済み**: バージョンが **v0.14.0 以上**であることを確認。古い場合はアップデートを案内
-- **未インストール**: 以下のいずれかを案内
-  - 公式インストーラー（推奨）: https://ollama.com/download/mac
+- **Installed and v0.14.0+**: proceed to 1-2.
+- **Older version**: `brew upgrade ollama` and then `brew services restart ollama` (Homebrew installs).
+- **Not installed**: suggest one of:
+  - Official installer (recommended): https://ollama.com/download/mac
   - Homebrew: `brew install ollama`
 
-### 1-2. Ollama サーバの起動確認
+### 1-2. Verify the server is running
 
 ```bash
 curl -s http://localhost:11434/api/tags | head -c 200
 ```
 
-- **応答あり**: サーバ起動済み → Step 2 へ
-- **応答なし**: 起動方法を案内
-  - 公式インストーラー版: メニューバーの Ollama アイコンをクリック
-  - Homebrew 版: `brew services start ollama` または `ollama serve`
+- **Got JSON back**: server is up, go to Step 2.
+- **Empty / connection refused**: start it.
+  - Official app: click the Ollama menu-bar icon.
+  - Homebrew: `brew services start ollama` or `ollama serve`.
 
-## Step 2: Claude Code の確認
+## Step 2: Verify Claude Code
 
 ```bash
 which claude && claude --version
 ```
 
-- **インストール済み**: Step 3 へ
-- **未インストール**: インストール方法を案内（npm / 公式スクリプト / Homebrew）
-  - npm（推奨）: `npm install -g @anthropic-ai/claude-code`
-  - 公式スクリプト: `curl -fsSL https://claude.ai/install.sh | sh`
-  - Homebrew: `brew install anthropic/tap/claude-code`
+- **Installed**: continue to Step 3.
+- **Not installed**: install via npm (recommended), the official script, or Homebrew:
+  - `npm install -g @anthropic-ai/claude-code`
+  - `curl -fsSL https://claude.ai/install.sh | sh`
+  - `brew install anthropic/tap/claude-code`
 
-## Step 3: モデルの選択とダウンロード
+## Step 3: Choose and pull a model
 
-ユーザーの Mac のメモリ量と用途を確認してから推奨モデルを提示する。
+Confirm the user's RAM and use case before recommending. Verified working models on a MacBook Air M4 32GB are summarized in [`docs/tips/claude-code-ollama.md`](../../../docs/tips/claude-code-ollama.md). Quick picks:
 
-### メモリ別おすすめ
+| RAM | Recommended | Size | Notes |
+|-----|-------------|------|-------|
+| 8–16GB | (Claude Code × Ollama is impractical here) | — | Cold start exceeds 10 min timeout |
+| 32GB | **`qwen3.5:9b`** | 6.6GB | Most practical, lightest fit |
+| 32GB | `qwen3.6:35b-a3b` | 23GB | MoE (3B active), heavier but works |
+| 24GB+ (NVIDIA) | `glm-4.7-flash` | 19GB | 198k context, untested on Mac |
 
-| メモリ | おすすめモデル | サイズ | Tool Calling | 用途 |
-|--------|---------------|--------|-------------|------|
-| 8-16GB | `qwen2.5-coder:7b` | 4.7GB | ○ | コード生成の相棒 |
-| 16GB | `qwen2.5-coder:14b` | 9GB | ○ | コーディング上位 |
-| 16GB | `gemma4:e4b` | ~3GB | ◎ | 軽量エージェント実験 |
-| 24GB+ | `gemma4:26b` | ~15GB | ◎ | **Function Calling 強、バランス良** |
-| 24GB+ | `gpt-oss:20b` | 13GB | ◎ | OpenAI オープンウェイト、推論系 |
-
-> ポイント: エージェント機能（Skill / MCP / ツール呼び出し）を試すなら `gemma4:26b` か `gpt-oss:20b` が第一候補。3B クラスでは Skill はほぼ動かない。
-
-### ダウンロード
-
-ユーザーが選んだモデルを pull する。まずは軽量版で動作確認するのも推奨。
+Avoid: `qwen3:14b` (40k training limit), `qwen2.5-coder:14b` (older runner ignores `OLLAMA_CONTEXT_LENGTH`), `gemma4:*` (Content block parse errors), `gpt-oss:20b` (Ollama template bug). See findings doc for details.
 
 ```bash
-ollama pull <選択したモデル>
-```
-
-確認:
-
-```bash
+ollama pull <model>
 ollama list
 ```
 
-## Step 4: ローカル接続テスト
+## Step 4: Start Ollama with the right context window
 
-### 4-1. 環境変数セット（一時的）
+Claude Code requires ≥64k context. The default is 32k, so **always extend it** when launching Ollama for Claude Code:
 
-**このターミナルセッションだけ**の一時切り替え。ウィンドウを閉じればクラウドに戻る。
+```bash
+brew services stop ollama   # if running under brew services
+OLLAMA_CONTEXT_LENGTH=65536 ollama serve
+```
+
+This terminal must stay open for the duration of the session. For longer sessions add `OLLAMA_KEEP_ALIVE=30m` so the KV cache survives idle gaps.
+
+## Step 5: Warm up the model
+
+In a second terminal, load the model into memory and confirm it responds at all:
+
+```bash
+ollama run <model> "hello"
+```
+
+Expect a response within a few seconds. If this hangs, the model is unsuitable for Claude Code.
+
+## Step 6: Run Claude Code against Ollama
+
+In a third terminal, set the env vars and launch:
 
 ```bash
 export ANTHROPIC_AUTH_TOKEN="ollama"
 export ANTHROPIC_API_KEY=""
 export ANTHROPIC_BASE_URL="http://localhost:11434"
+claude --verbose --model <model>
 ```
 
-各環境変数の役割:
+Role of each variable:
 
-| 環境変数 | 値 | 目的 |
-|----------|-----|------|
-| `ANTHROPIC_AUTH_TOKEN` | `"ollama"` | Ollama モードを有効化 |
-| `ANTHROPIC_API_KEY` | `""`（空） | クラウド用キーを無効化（干渉防止） |
-| `ANTHROPIC_BASE_URL` | `http://localhost:11434` | 接続先をローカルに変更 |
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `ANTHROPIC_AUTH_TOKEN` | `"ollama"` | Enables Ollama mode |
+| `ANTHROPIC_API_KEY` | `""` (empty) | Disables the cloud API key (prevents collision) |
+| `ANTHROPIC_BASE_URL` | `http://localhost:11434` | Routes API calls to the local server |
 
-### 4-2. Claude Code をローカルモデルで起動
+Send a simple message (e.g. "Hello, what model are you?") to confirm. **The first turn can take 10+ minutes**; subsequent turns drop to 1–3 minutes once the KV cache is warm.
 
-ユーザーに別ターミナルで以下を実行してもらう（`!` プレフィックスを使う）:
+While waiting, watch the Ollama log in another terminal to see what's happening:
 
+```bash
+tail -f /opt/homebrew/var/log/ollama.log    # Homebrew install
+# or just watch the terminal where `ollama serve` is running
 ```
-! ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude --model <選択したモデル>
-```
 
-起動できたら簡単な質問（例: 「Hello, what model are you?」）で動作確認する。
+Key log signals:
+- `KvSize:65536` ✓ — context is correctly extended
+- `truncating input prompt limit=XXXXX` ✗ — model/runner ignores the env var; switch model
+- `POST /v1/messages 200` ✓ — successful turn
+- `POST /v1/messages 500` ✗ — template incompatibility; switch model
 
-## Step 5: クラウドへの戻し方を案内
+## Step 7: Switching back to cloud Claude
 
-ローカルモードは **そのターミナルだけ** なので:
+The local mode is scoped to the terminal where the env vars were set:
 
-1. **ターミナルを閉じて開き直す**だけで OK
-2. または明示的に環境変数を削除:
+1. **Easiest**: close that terminal and open a fresh one — back to cloud.
+2. Or unset explicitly:
    ```bash
    unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
    ```
 
-## Step 6: エイリアス設定（オプション）
+## Step 8 (optional): Convenience alias
 
-ユーザーが希望する場合、`~/.zshrc` にエイリアスを追加する提案をする。
+If the user wants a one-liner, suggest an alias in `~/.zshrc`. **Do not** put bare `export ANTHROPIC_BASE_URL=...` lines in a startup file — that breaks normal cloud usage everywhere.
 
 ```bash
-# ローカル Ollama に切り替え
 alias claude-local='ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude'
 ```
 
-追加後:
-```bash
-source ~/.zshrc
-```
+After `source ~/.zshrc`, usage is:
 
-使い方:
 ```bash
-claude-local --model gemma4:26b   # ローカル
-claude                            # 通常はクラウド
+claude-local --model qwen3.5:9b   # local
+claude                            # cloud, unchanged
 ```
 
 ## Key pitfalls to highlight
 
-- Ollama のバージョンが **v0.14.0 未満**だと Anthropic API 互換がない — 必ずバージョン確認
-- `ANTHROPIC_API_KEY` を空にしないと既存のクラウド用キーが干渉する場合がある
-- 3B クラスのモデルでは JSON 形式のツール呼び出しを正しく生成できず、ファイル作成等が失敗する
-- Function Calling 対応モデルでも Anthropic の tool use 形式に完全最適化されてはいないため、複雑な Skill チェーンは不安定
-- 大きいモデル（20B+）はメモリを圧迫する — `ps aux | grep ollama` や Activity Monitor でモニタリングを案内
-- `.zshrc` や `.bashrc` に `export ANTHROPIC_BASE_URL=...` を恒久的に書くと通常のクラウド利用が壊れる — エイリアスのみ推奨
+- **Ollama < v0.14.0** has no Anthropic API compatibility — always check the version first.
+- `ANTHROPIC_API_KEY` must be **explicitly empty**; otherwise an existing cloud key may collide.
+- 3B-class models cannot reliably emit Claude's tool-use JSON, so file edits and shell commands fail.
+- Even tool-capable open models (Gemma 4, gpt-oss) are not fully aligned with Anthropic's response format — complex skill chains misbehave.
+- Large models (20B+) eat memory; watch with `vm_stat` or Activity Monitor.
+- Permanent `export ANTHROPIC_BASE_URL=...` in `.zshrc` / `.bashrc` will silently break normal cloud Claude usage. Use an alias instead.
+- The first-turn 10-minute Claude Code timeout is unavoidable, but Ollama keeps processing in the background, so a retry usually succeeds via cache reuse.
 
-## 参考リンク（ユーザーに共有してよいもの）
+## Reference links
 
-- Ollama Claude Code 連携: https://docs.ollama.com/integrations/claude-code
-- Ollama Anthropic 互換ブログ: https://ollama.com/blog/claude
-- Claude Code 公式: https://code.claude.com/docs/en/overview
+- Ollama Claude Code integration: https://docs.ollama.com/integrations/claude-code
+- Ollama Anthropic compatibility blog: https://ollama.com/blog/claude
+- Claude Code official docs: https://code.claude.com/docs/en/overview
+- Local findings: [`docs/tips/claude-code-ollama.md`](../../../docs/tips/claude-code-ollama.md) (ja) / [`.en.md`](../../../docs/tips/claude-code-ollama.en.md) (en)

--- a/docs/tips/claude-code-ollama.en.md
+++ b/docs/tips/claude-code-ollama.en.md
@@ -52,7 +52,7 @@ Example: `qwen3:14b` is trained with a 40960 (40k) limit, so it cannot fit Claud
 | `qwen3:14b` | 9GB | ✗ | Training limit 40k, 50k prompt is truncated |
 | `qwen2.5-coder:14b` | 9GB | ✗ | Old runner, 64k setting ignored, stuck at 32k |
 | `qwen3.6:35b-a3b` | 23GB | ✓ | MoE (3B active), first turn 13 min, Japanese thinking OK |
-| `gemma4:e4b` | 3GB | ✗ | Claude Code hangs for over a minute with no response |
+| `gemma4:e4b` | 3GB (actual weights ~8.9 GiB) | ✓ | Confirmed working on re-test. Earlier failure likely due to missing `OLLAMA_CONTEXT_LENGTH=65536`. Responds with thinking blocks |
 | `gemma4:26b` | 17GB | ✗ | `API Error: Content block not found` (re-verified — thinking block format is incompatible with Claude Code) |
 | `gpt-oss:20b` | 13GB | ✗ | Bug in Ollama's prompt template, 500 error parsing tool definitions |
 | **`qwen3.5:9b`** | **6.6GB** | **✓** | **First turn 10+ min (after timeout, cache reuse succeeds in ~3 min); lightest practical option** |

--- a/docs/tips/claude-code-ollama.en.md
+++ b/docs/tips/claude-code-ollama.en.md
@@ -1,0 +1,160 @@
+# Claude Code × Ollama Setup Findings (verified 2026-04-25)
+
+Findings from running Claude Code against a local Ollama instance on a MacBook Air M4 32GB.
+
+## Test environment
+
+- Machine: MacBook Air M4 32GB (unified memory)
+- Ollama: v0.21.1 (server and client both need v0.14.0+)
+- Claude Code: v2.1.119
+
+## The context-window wall
+
+On every turn Claude Code sends a prompt of about **50,000–57,000 tokens** (system prompt + CLAUDE.md + tool definitions + skill list). A context window of **at least 64k tokens is required**.
+
+### `OLLAMA_CONTEXT_LENGTH` behavior
+
+Default is 32768 (32k). Extend it with:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=65536 ollama serve
+```
+
+But **whether this is honored depends on the Ollama runner**:
+
+| Runner | Honors `OLLAMA_CONTEXT_LENGTH` | Models |
+|--------|:---:|------|
+| `--ollama-engine` (new engine) | ✓ | `qwen3`, `qwen3.5`, `gpt-oss`, etc. |
+| llama.cpp-based (older runner) | ✗ | Some models like `qwen2.5`, `qwen2.5-coder` |
+
+How to tell from logs:
+- `source=server.go ... starting runner cmd="... --ollama-engine ..."` → new engine (env var works)
+- `source=runner.go:153 msg="truncating input prompt"` → llama.cpp runner (env var ignored)
+
+### `PARAMETER num_ctx` in a Modelfile may not work either
+
+We confirmed cases where setting `num_ctx 65536` in a Modelfile is also ignored when the model uses the older runner.
+
+### Model training-time limit
+
+Specifying a context larger than the model's `n_ctx_train` is clamped to the training value with a warning:
+
+```
+msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
+```
+
+Example: `qwen3:14b` is trained with a 40960 (40k) limit, so it cannot fit Claude Code's 57k prompt.
+
+## Per-model results
+
+| Model | Size | Result | Notes |
+|-------|----:|:---:|------|
+| `qwen3:14b` | 9GB | ✗ | Training limit 40k, 50k prompt is truncated |
+| `qwen2.5-coder:14b` | 9GB | ✗ | Old runner, 64k setting ignored, stuck at 32k |
+| `qwen3.6:35b-a3b` | 23GB | ✓ | MoE (3B active), first turn 13 min, Japanese thinking OK |
+| `gemma4:e4b` | 3GB | ✗ | Claude Code hangs for over a minute with no response |
+| `gemma4:26b` | 17GB | ✗ | `API Error: Content block not found` (re-verified — thinking block format is incompatible with Claude Code) |
+| `gpt-oss:20b` | 13GB | ✗ | Bug in Ollama's prompt template, 500 error parsing tool definitions |
+| **`qwen3.5:9b`** | **6.6GB** | **✓** | **First turn 10+ min (after timeout, cache reuse succeeds in ~3 min); lightest practical option** |
+
+### Why `qwen3.5:9b` works
+
+- Uses the new `--ollama-engine`
+- 256k context window (well above Claude Code's 64k requirement)
+- `OLLAMA_CONTEXT_LENGTH=65536` is honored
+
+### `gpt-oss:20b` 500 error details
+
+```
+chat prompt error: template: :108:130: executing "" at <index $prop.Type 0>:
+  error calling index: reflect: slice index out of range
+```
+
+Ollama's prompt template cannot parse the tool definitions Claude Code sends. Whether the bug is on the model side or Ollama's side is not determined.
+
+## Error categories and recoverability
+
+| Error | Nature | User-recoverable? |
+|-------|--------|:---:|
+| `truncating input prompt` | Insufficient context | ✓ (extend `OLLAMA_CONTEXT_LENGTH`, choose a supporting model) |
+| `API Error: Content block not found` | Model's response structure incompatible with Claude Code | ✗ (model/Ollama implementation issue) |
+| `template: ... slice index out of range` | Bug in Ollama's prompt template | ✗ (Ollama implementation issue) |
+
+Only the first category is solved by waiting. The other two will keep failing — the only fix is to avoid that model.
+
+## Performance measurements
+
+With `OLLAMA_CONTEXT_LENGTH=65536` on MacBook Air M4:
+
+### `qwen3.5:9b` (6.6GB)
+
+| Request | Work done | Time |
+|---------|-----------|------|
+| 1st (cold) | Process all 57k tokens | **Over 10 min — Claude Code's 10-minute timeout fires** |
+| 2nd (cache warm) | KV cache reuses common prefix, only diff is processed | **3 min 5 sec, success** |
+| 3rd+ | Same | 1–3 min |
+
+### `qwen3.6:35b-a3b` (23GB, MoE, 3B active)
+
+| Request | Work done | Time |
+|---------|-----------|------|
+| 1st (cold) | Process all 57k tokens, respond with thinking | **About 13 min** |
+| 2nd (cache warm) | Diff-only processing | **About 3 min 55 sec** |
+
+Even though active compute is 3B-equivalent, the first-turn prompt-processing cost is similar. Subsequent turns settle to roughly the same time as `qwen3.5:9b`.
+
+### How the KV cache helps
+
+Claude Code sends the same system prompt + CLAUDE.md + tool definitions on every request. Ollama keeps these in the KV cache, and from the second turn onward only the diff (the new user message) needs processing.
+
+Even when the first turn times out, Ollama keeps processing in the background, so by the time the second request arrives the cache is already warm.
+
+### Extending cache TTL
+
+Default is 5 minutes idle, then the KV cache is dropped (`OLLAMA_KEEP_ALIVE:5m0s`). For longer sessions:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=65536 OLLAMA_KEEP_ALIVE=30m ollama serve
+```
+
+## Practical takeaways
+
+- **What works**: `qwen3.5:9b`, ~1–3 min responses after the cache is warm
+- **What doesn't**: Complex agent flows, tool chaining, scenarios that frequently rebuild context
+- **High first-turn cost**: A cold first turn takes over 10 minutes
+- **Use cases**: "Works offline," "avoid metered cost spikes," and similar fallback scenarios
+
+## Memory footprint (qwen3.5:9b)
+
+- Model weights: 5.6 GiB (Metal)
+- KV cache (64k): 3.2 GiB
+- Compute graph: 1.1 GiB
+- **Total: 10.5 GiB**
+
+Comfortable on a 32GB machine. Even with 15GB used by OS + other apps there is no swap.
+
+## Three-terminal workflow
+
+You need three terminal windows in parallel:
+
+- **Terminal A**: `OLLAMA_CONTEXT_LENGTH=65536 ollama serve` (keep open)
+- **Terminal B**: `ollama run <model> "hello"` (one-shot warm-up; can be closed)
+- **Terminal C**: `claude --verbose --model <model>` (your actual session)
+
+### Switching between cloud and local
+
+If you set the env vars only in Terminal C, closing the terminal restores cloud mode. To make this permanent, prefer an alias rather than `export` in `.zshrc`:
+
+```bash
+alias claude-local='ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude'
+```
+
+## Ollama log location
+
+Homebrew-managed: `/opt/homebrew/var/log/ollama.log`
+Manually-launched `ollama serve`: streamed to the launching terminal directly.
+
+What to watch for in the logs:
+- `truncating input prompt limit=XXXXX` → context too small
+- `KvSize:XXXXX` → context size actually loaded
+- `POST /v1/messages` HTTP status (200 = success, 500 = template/parse error)

--- a/docs/tips/claude-code-ollama.en.md
+++ b/docs/tips/claude-code-ollama.en.md
@@ -39,7 +39,7 @@ We confirmed cases where setting `num_ctx 65536` in a Modelfile is also ignored 
 
 Specifying a context larger than the model's `n_ctx_train` is clamped to the training value with a warning:
 
-```
+```text
 msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
 ```
 
@@ -65,7 +65,7 @@ Example: `qwen3:14b` is trained with a 40960 (40k) limit, so it cannot fit Claud
 
 ### `gpt-oss:20b` 500 error details
 
-```
+```text
 chat prompt error: template: :108:130: executing "" at <index $prop.Type 0>:
   error calling index: reflect: slice index out of range
 ```

--- a/docs/tips/claude-code-ollama.md
+++ b/docs/tips/claude-code-ollama.md
@@ -52,7 +52,7 @@ msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
 | `qwen3:14b` | 9GB | ✗ | 訓練上限 40k、50k プロンプトが切り詰められる |
 | `qwen2.5-coder:14b` | 9GB | ✗ | 古い runner、64k 指定が反映されず 32k 固定 |
 | `qwen3.6:35b-a3b` | 23GB | ◯ | MoE（アクティブ 3B）、初回 13 分で応答・日本語 thinking OK |
-| `gemma4:e4b` | 3GB | ✗ | Claude Code が 1 分以上応答なし |
+| `gemma4:e4b` | 3GB（実 weights 約 8.9 GiB） | ◯ | 再検証で動作確認。前回失敗は `OLLAMA_CONTEXT_LENGTH=65536` 未設定が原因と推測。thinking 付きで応答 |
 | `gemma4:26b` | 17GB | ✗ | `API Error: Content block not found`（再検証でも同じ。thinking ブロックの形式が Claude Code と非互換） |
 | `gpt-oss:20b` | 13GB | ✗ | Ollama のテンプレートにバグ、ツール定義パース失敗で 500 エラー |
 | **`qwen3.5:9b`** | **6.6GB** | **◯** | **初回 10 分超（タイムアウト後 cache 再利用で 3 分強で成功）、軽量で最も実用的** |

--- a/docs/tips/claude-code-ollama.md
+++ b/docs/tips/claude-code-ollama.md
@@ -1,0 +1,160 @@
+# Claude Code × Ollama セットアップ知見（2026-04-25 検証）
+
+MacBook Air M4 32GB での Claude Code + Ollama 動作検証で得られた知見。
+
+## 動作環境
+
+- マシン: MacBook Air M4 32GB（統合メモリ）
+- Ollama: v0.21.1（サーバ・クライアントとも v0.14.0 以上が必要）
+- Claude Code: v2.1.119
+
+## コンテキスト要件の壁
+
+Claude Code は起動時に約 **50,000〜57,000 トークン**のプロンプトを毎回送信する（システムプロンプト + CLAUDE.md + ツール定義 + スキル一覧）。このため **64k 以上のコンテキストウィンドウが必須**。
+
+### OLLAMA_CONTEXT_LENGTH の挙動
+
+デフォルトは 32768（32k）。以下のように拡張する:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=65536 ollama serve
+```
+
+ただし **Ollama の Runner によって適用の可否が異なる**:
+
+| Runner | OLLAMA_CONTEXT_LENGTH 適用 | 該当モデル |
+|--------|:---:|------|
+| `--ollama-engine`（新エンジン） | ◯ | `qwen3`, `qwen3.5`, `gpt-oss` など |
+| llama.cpp 系（古いランナー） | ✗ | `qwen2.5`, `qwen2.5-coder` 等一部モデル |
+
+ログで見分ける:
+- `source=server.go ... starting runner cmd="... --ollama-engine ..."` → 新エンジン（env 有効）
+- `source=runner.go:153 msg="truncating input prompt"` → llama.cpp 系（env 無視される）
+
+### Modelfile の `PARAMETER num_ctx` も効かないことがある
+
+Modelfile で明示的に `num_ctx 65536` を指定しても、Ollama の Runner が古い場合は適用されないケースを確認した。
+
+### モデル訓練時の上限
+
+モデル自体の `n_ctx_train` を超えた指定はログで警告が出て訓練値に丸められる:
+
+```
+msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
+```
+
+例: `qwen3:14b` は 40960（40k）が訓練上限なので Claude Code の 57k プロンプトを受けられない。
+
+## モデル別検証結果
+
+| モデル | サイズ | 結果 | 備考 |
+|--------|-------:|:---:|------|
+| `qwen3:14b` | 9GB | ✗ | 訓練上限 40k、50k プロンプトが切り詰められる |
+| `qwen2.5-coder:14b` | 9GB | ✗ | 古い runner、64k 指定が反映されず 32k 固定 |
+| `qwen3.6:35b-a3b` | 23GB | ◯ | MoE（アクティブ 3B）、初回 13 分で応答・日本語 thinking OK |
+| `gemma4:e4b` | 3GB | ✗ | Claude Code が 1 分以上応答なし |
+| `gemma4:26b` | 17GB | ✗ | `API Error: Content block not found`（再検証でも同じ。thinking ブロックの形式が Claude Code と非互換） |
+| `gpt-oss:20b` | 13GB | ✗ | Ollama のテンプレートにバグ、ツール定義パース失敗で 500 エラー |
+| **`qwen3.5:9b`** | **6.6GB** | **◯** | **初回 10 分超（タイムアウト後 cache 再利用で 3 分強で成功）、軽量で最も実用的** |
+
+### qwen3.5:9b が動く条件
+
+- 新 `--ollama-engine` 対応
+- 256k コンテキストウィンドウ（Claude Code の 64k 要求を余裕で満たす）
+- `OLLAMA_CONTEXT_LENGTH=65536` が適用される
+
+### gpt-oss:20b の 500 エラー詳細
+
+```
+chat prompt error: template: :108:130: executing "" at <index $prop.Type 0>:
+  error calling index: reflect: slice index out of range
+```
+
+Ollama 側のプロンプトテンプレートが Claude Code の送るツール定義をパースできない。モデル側・Ollama 側どちらのバグかは未確認。
+
+## エラー種別と対処可否
+
+| エラー | 性質 | ユーザー側で対処可能か |
+|-------|------|:---:|
+| `truncating input prompt` | コンテキスト不足 | ◯（`OLLAMA_CONTEXT_LENGTH` 拡張、対応モデル選択） |
+| `API Error: Content block not found` | モデルの応答構造が Claude Code と非互換 | ✗（モデル/Ollama 実装の問題） |
+| `template: ... slice index out of range` | Ollama のプロンプトテンプレート側のバグ | ✗（Ollama 実装の問題） |
+
+「待てば解決する」のは最初のパターンのみ。後者 2 つは待っても失敗し続けるため、該当モデルは避けるしかない。
+
+## パフォーマンス実測
+
+OLLAMA_CONTEXT_LENGTH=65536 + MacBook Air M4 での実測:
+
+### `qwen3.5:9b`（6.6GB）
+
+| リクエスト | 処理内容 | 所要時間 |
+|-----------|---------|---------|
+| 1 回目（コールド） | 57k トークン全部を処理 | **10 分超でタイムアウト**（Claude Code の 10 分制限）|
+| 2 回目（cache 温まった後） | KV cache で共通部分は再利用、差分のみ処理 | **3 分 5 秒で成功** |
+| 3 回目以降 | 同上 | 1〜3 分 |
+
+### `qwen3.6:35b-a3b`（23GB、MoE アクティブ 3B）
+
+| リクエスト | 処理内容 | 所要時間 |
+|-----------|---------|---------|
+| 1 回目（コールド） | 57k トークン全部を処理、thinking 付きで応答 | **約 13 分** |
+| 2 回目（cache 温まった後） | 差分のみ処理 | **約 3 分 55 秒** |
+
+MoE なのでアクティブ計算量は 3B 相当だが、コールドスタート時のプロンプト処理に時間がかかる傾向は同じ。2 回目以降は qwen3.5:9b と同等の応答時間に落ち着く。
+
+### KV キャッシュの効き方
+
+Claude Code は毎リクエストで同じシステムプロンプト + CLAUDE.md + ツール定義を送る。Ollama はこれを KV cache として保持し、次回以降は差分（新しいユーザーメッセージ）のみ処理する。
+
+1 回目のタイムアウト後も、Ollama は裏で処理を継続するため、2 回目のリクエスト時にはキャッシュが温まっている状態になる。
+
+### キャッシュ保持時間の延長
+
+デフォルトは 5 分無操作で KV cache が消える（`OLLAMA_KEEP_ALIVE:5m0s`）。長時間使うなら:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=65536 OLLAMA_KEEP_ALIVE=30m ollama serve
+```
+
+## 実用性の結論
+
+- **使える組み合わせ**: `qwen3.5:9b`、2 回目以降は 1〜3 分で応答
+- **使えない**: 複雑なエージェント動作、ツール連鎖、頻繁にコンテキストを作り直す用途
+- **初回コストが大きい**: コールド状態での最初の 1 ターンが 10 分超
+- **割り切り**: 「オフラインでも動く」「課金が気になる場面で」等の緊急用途向け
+
+## メモリ使用量（qwen3.5:9b）
+
+- モデル weights: 5.6 GiB (Metal)
+- KV cache (64k): 3.2 GiB
+- compute graph: 1.1 GiB
+- **合計: 10.5 GiB**
+
+32GB 機なら余裕。OS + 他アプリで 15GB 使っても swap なしで動く。
+
+## 3 ターミナル運用
+
+同時に 3 つのターミナルが必要:
+
+- **ターミナル A**: `OLLAMA_CONTEXT_LENGTH=65536 ollama serve`（開きっぱなし）
+- **ターミナル B**: `ollama run <model> "hello"`（初回モデルロード用、閉じて OK）
+- **ターミナル C**: `claude --verbose --model <model>`（本体）
+
+### クラウド/ローカル切り替え
+
+ターミナル C 内で環境変数を設定する形なら、ターミナルを閉じればクラウドに戻る。`.zshrc` に永続化する場合はエイリアス化が安全:
+
+```bash
+alias claude-local='ANTHROPIC_AUTH_TOKEN="ollama" ANTHROPIC_API_KEY="" ANTHROPIC_BASE_URL="http://localhost:11434" claude'
+```
+
+## Ollama ログ場所
+
+Homebrew 起動時: `/opt/homebrew/var/log/ollama.log`
+手動 `ollama serve` 時: 起動ターミナルに直接出力
+
+ログで確認すべきポイント:
+- `truncating input prompt limit=XXXXX` → コンテキスト不足
+- `KvSize:XXXXX` → 実際にロードされたコンテキストサイズ
+- `POST /v1/messages` の HTTP ステータス（200 なら成功、500 ならテンプレート/パースエラー）

--- a/docs/tips/claude-code-ollama.md
+++ b/docs/tips/claude-code-ollama.md
@@ -39,7 +39,7 @@ Modelfile で明示的に `num_ctx 65536` を指定しても、Ollama の Runner
 
 モデル自体の `n_ctx_train` を超えた指定はログで警告が出て訓練値に丸められる:
 
-```
+```text
 msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
 ```
 
@@ -65,7 +65,7 @@ msg="requested context size too large for model" num_ctx=65536 n_ctx_train=40960
 
 ### gpt-oss:20b の 500 エラー詳細
 
-```
+```text
 chat prompt error: template: :108:130: executing "" at <index $prop.Type 0>:
   error calling index: reflect: slice index out of range
 ```

--- a/plans/feat-mulmoclaude-ollama-support.md
+++ b/plans/feat-mulmoclaude-ollama-support.md
@@ -27,16 +27,15 @@ UX 上の問題も継承される: 検証で動作確認できた最軽量モデ
 
 ### Tier 1: env と CLI フラグのパススルー（50〜100 行、半日）
 
-パワーユーザーが `settings.json` を直接編集してバックエンド切替できる最小実装。
+パワーユーザーが起動時の env でバックエンドを切り替えられる最小実装。**設定の唯一のソースは `process.env`**。`settings.json` 連携は Tier 2 で扱う（永続化と UI が必要になるため、Tier 1 で持ち込むと完了基準が曖昧になる）。これは既存の `GEMINI_API_KEY` の取り回しと同じパターン。
 
 - [server/system/env.ts](../server/system/env.ts): `ollamaBaseUrl?`、`ollamaModel?` を追加（または `llmProvider: "cloud" | "ollama"` のような discriminator）。`process.env` から読み込み。
 - [server/agent/config.ts](../server/agent/config.ts):
   - `buildCliArgs`: ローカルモード時に `"--model", ollamaModel` を追加。
   - `buildDockerSpawnArgs`: ローカルモード時に `-e ANTHROPIC_AUTH_TOKEN=ollama -e ANTHROPIC_API_KEY= -e ANTHROPIC_BASE_URL=http://host.docker.internal:11434` と `--add-host host.docker.internal:host-gateway`（Linux/Mac）を追加。
 - [server/agent/index.ts](../server/agent/index.ts) の `spawnClaude`: ローカルモード時に `env: { ...process.env, ANTHROPIC_* }` を渡す（非 Docker パスは自動継承、Docker パスは上記の `-e` で対応）。
-- [server/system/config.ts](../server/system/config.ts): settings スキーマに `llm` オブジェクト（例: `{ provider: "cloud" | "ollama", ollamaBaseUrl?, ollamaModel? }`）を追加。
 
-完了基準 = `~/mulmoclaude/config/settings.json` の手動編集でバックエンドが切り替わる。
+完了基準 = `OLLAMA_MODEL=qwen3.5:9b OLLAMA_BASE_URL=http://localhost:11434 npm run dev` のように env を渡して起動するとローカル接続される。
 
 ### Tier 2: 設定 UI と接続テスト（300〜500 行、2〜3 日）— **推奨**
 
@@ -44,6 +43,7 @@ UX 上の問題も継承される: 検証で動作確認できた最軽量モデ
 
 Tier 1 に追加で:
 
+- [server/system/config.ts](../server/system/config.ts): settings スキーマに `llm` オブジェクトを追加（例: `{ provider: "cloud" | "ollama", ollamaBaseUrl?, ollamaModel? }`）。優先順位は **env > settings.json > デフォルト（cloud）**。env が未設定なら settings.json を読み、どちらも未設定ならクラウドにフォールバック。
 - [`src/components/`](../src/components/) 配下に新しい Vue セクション（既存設定ペインと並べる）。プロバイダのラジオボタン、base URL 入力（デフォルト `http://localhost:11434`）、モデル選択ドロップダウン。
 - `GET /api/settings/ollama/models` ルート: `GET <baseUrl>/v1/models` をプロキシしてリストを返す。ドロップダウン用。
 - `POST /api/settings/ollama/test` ルート: 最小限の `/v1/messages` リクエストを投げ、`{ ok, kvSize, contextLength, error? }` を返す。「接続テスト」ボタン用。
@@ -51,7 +51,7 @@ Tier 1 に追加で:
 - chat ヘッダーにステータスインジケータを表示（**Cloud** vs **Ollama (モデル名)**）。アクティブバックエンドが曖昧にならないように。
 - UI 上に警告コピー: 速度トレードオフと、tool calling に依存する MulmoClaude プラグイン/スキルがローカルモデルでは不安定であること。
 - テスト:
-  - Unit: env パース、settings の round-trip、両モードでの CLI args 構築（既存の `test/agent/config.test.ts` 風カバレッジ）。
+  - Unit: env パース、settings の round-trip、両モードでの CLI args 構築（既存の `test/agent/test_agent_config.ts` 風カバレッジ）。
   - E2E: `localhost:11434` をモックする fixture で設定 UI フロー + 「接続テスト」パスを検証。
 
 ### Tier 3: プロダクション仕上げ（1000+ 行、1〜2 週間）

--- a/plans/feat-mulmoclaude-ollama-support.md
+++ b/plans/feat-mulmoclaude-ollama-support.md
@@ -1,0 +1,86 @@
+# feat: MulmoClaude × Ollama (local LLM) support
+
+## Status
+
+**Investigation only — no implementation yet.**
+
+This plan documents what it would take to make MulmoClaude itself usable against a local Ollama backend (today only the standalone `claude` CLI works against Ollama; see `.claude/skills/setup-ollama-local/SKILL.md` and `docs/tips/claude-code-ollama.md`).
+
+## Background / Why this is hard
+
+MulmoClaude does not call the Anthropic API directly. The server **spawns the `claude` CLI as a child process** ([server/agent/index.ts](../server/agent/index.ts)) and pipes stream-json over stdin/stdout. Two consequences:
+
+1. **The model selection is whatever `claude` defaults to.** [`buildCliArgs` in server/agent/config.ts](../server/agent/config.ts) does not pass `--model`.
+2. **Backend selection is whatever env vars the parent process has.** When MulmoClaude is started normally, those are the cloud Claude defaults.
+
+For local Ollama to work end-to-end, both the spawned CLI's model flag and its env have to point at the local server. Docker sandbox mode adds a third concern: env vars are not forwarded into the container, and `localhost:11434` from inside the container is not the host's Ollama (`host.docker.internal` would have to be added).
+
+There is also a UX problem inherited from the Claude Code × Ollama work: even on `qwen3.5:9b` (the lightest verified-working model), the **first turn takes 10+ minutes** and subsequent turns 1–3 minutes on a MacBook Air M4 32GB. MulmoClaude's chat UI is interactive; users will not enjoy this. The implementation should at minimum make the trade-off explicit.
+
+## Goal
+
+Let a user opt into a local Ollama backend via settings or env, and have every spawn of `claude` (both bare and inside the Docker sandbox) route to that backend with the chosen model. Cloud usage remains the default and is not regressed.
+
+## Scope tiers
+
+The work has three natural cut points. Recommend stopping at Tier 2 unless there's clear demand.
+
+### Tier 1: env + CLI flag pass-through (~50–100 LoC, ~half a day)
+
+Just enough that a power user editing `settings.json` can switch to Ollama.
+
+- [server/system/env.ts](../server/system/env.ts): add `ollamaBaseUrl?`, `ollamaModel?` (or a `llmProvider: "cloud" | "ollama"` discriminator) read from `process.env`.
+- [server/agent/config.ts](../server/agent/config.ts):
+  - `buildCliArgs`: when local mode, append `"--model", ollamaModel`.
+  - `buildDockerSpawnArgs`: when local mode, add `-e ANTHROPIC_AUTH_TOKEN=ollama -e ANTHROPIC_API_KEY= -e ANTHROPIC_BASE_URL=http://host.docker.internal:11434` and `--add-host host.docker.internal:host-gateway` (Linux/Mac).
+- [server/agent/index.ts](../server/agent/index.ts) `spawnClaude`: pass `env: { ...process.env, ANTHROPIC_* }` when local mode is enabled (non-Docker path inherits naturally; the Docker path is handled in step above).
+- [server/system/config.ts](../server/system/config.ts): add `llm` object to settings schema (e.g. `{ provider: "cloud" | "ollama", ollamaBaseUrl?, ollamaModel? }`).
+
+Done = manually editing `~/mulmoclaude/config/settings.json` flips the backend.
+
+### Tier 2: settings UI + connection check (~300–500 LoC, ~2–3 days) — **recommended**
+
+Make the option discoverable and at least somewhat safe.
+
+Adds on top of Tier 1:
+
+- New Vue section under [`src/components/`](../src/components/) (alongside the existing settings panes). Inputs for provider radio, base URL (default `http://localhost:11434`), model dropdown.
+- `GET /api/settings/ollama/models` route that proxies `GET <baseUrl>/v1/models` and returns the list. Used to populate the dropdown.
+- `POST /api/settings/ollama/test` route: makes a minimal `/v1/messages` request, returns `{ ok, kvSize, contextLength, error? }`. Used by a "Test connection" button.
+- i18n: every new string lands in all 8 locales (`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`) — see CLAUDE.md i18n rules.
+- Status indicator in the chat header showing **Cloud** vs **Ollama (model name)** so the active backend is never ambiguous.
+- Warning copy in the UI explaining the slowness trade-off and that some MulmoClaude plugins/skills depend on tool calling that local models handle poorly.
+- Tests:
+  - Unit: env parsing, settings round-trip, CLI args construction in both modes (mirrors existing `test/agent/config.test.ts`-style coverage).
+  - E2E: a fixture that mocks `localhost:11434` and verifies the settings UI flow + "Test connection" path.
+
+### Tier 3: production polish (~1000+ LoC, 1–2 weeks)
+
+Everything below is optional and only worth doing if local backend becomes a first-class story.
+
+- **Timeout adjustments**: extend the SSE/agent loop timeouts when `provider === "ollama"` so the 10-minute Claude Code default does not kill the first turn.
+- **Warm-up on boot**: when local mode is active, send a one-shot `/v1/messages` `"hello"` at server startup so the KV cache is primed before the first user turn.
+- **Cloud fallback**: detect Ollama down / model missing and either fall back to cloud (with a banner) or surface a clear actionable error.
+- **Plugin/skill compatibility flags**: maintain a list of plugins that depend on tool-use formatting and silently disable them in local mode (or warn in the UI).
+- **Recommended-models check**: on save, compare the chosen model against an allowlist (qwen3.5+, MoE variants confirmed to handle thinking blocks correctly) and warn if unverified.
+- **Progress UI**: parse the Ollama log stream and surface a "processing prompt X/Y tokens" hint in the chat UI so users understand why the first turn takes 10 minutes.
+- **Docs**: update [docs/developer.md](../docs/developer.md), [README.md](../README.md), and the README translations under `packages/`.
+
+## Open questions
+
+- Do we want `provider` per-role (so e.g. the `general` role uses cloud and a `local-fast` role uses Ollama), or globally?
+- Should the Docker sandbox mode be supported for local Ollama at all? Forwarding `host.docker.internal` makes the container less isolated; there's an argument for "local Ollama only works without sandbox".
+- Settings file location: should the `llm` section live in the existing `settings.json`, or in a new `llm.json` to avoid bloating the main file?
+
+## Non-goals
+
+- Supporting OpenAI / other non-Anthropic-compatible backends. Out of scope; would need a different abstraction.
+- Optimising local model performance. That's an Ollama / hardware concern, not a MulmoClaude one.
+- A full provider-abstraction layer. We're piggy-backing on Claude Code's existing Anthropic-compatibility env vars deliberately.
+
+## References
+
+- Findings (Japanese): [`docs/tips/claude-code-ollama.md`](../docs/tips/claude-code-ollama.md)
+- Findings (English): [`docs/tips/claude-code-ollama.en.md`](../docs/tips/claude-code-ollama.en.md)
+- Setup skill (Claude Code only): [`.claude/skills/setup-ollama-local/SKILL.md`](../.claude/skills/setup-ollama-local/SKILL.md)
+- Ollama Claude Code integration: https://docs.ollama.com/integrations/claude-code

--- a/plans/feat-mulmoclaude-ollama-support.md
+++ b/plans/feat-mulmoclaude-ollama-support.md
@@ -1,86 +1,86 @@
-# feat: MulmoClaude × Ollama (local LLM) support
+# feat: MulmoClaude × Ollama（ローカル LLM）対応
 
-## Status
+## ステータス
 
-**Investigation only — no implementation yet.**
+**調査のみ。実装は未着手。**
 
-This plan documents what it would take to make MulmoClaude itself usable against a local Ollama backend (today only the standalone `claude` CLI works against Ollama; see `.claude/skills/setup-ollama-local/SKILL.md` and `docs/tips/claude-code-ollama.md`).
+このプランは、MulmoClaude 本体をローカル Ollama バックエンドで使えるようにする場合の必要作業をまとめたもの。現状動くのは `claude` CLI 単体での Ollama 接続のみ（`.claude/skills/setup-ollama-local/SKILL.md` および `docs/tips/claude-code-ollama.md` 参照）。
 
-## Background / Why this is hard
+## 背景 / なぜ難しいか
 
-MulmoClaude does not call the Anthropic API directly. The server **spawns the `claude` CLI as a child process** ([server/agent/index.ts](../server/agent/index.ts)) and pipes stream-json over stdin/stdout. Two consequences:
+MulmoClaude は Anthropic API を直接叩いていない。サーバが **`claude` CLI を子プロセスとして spawn** し（[server/agent/index.ts](../server/agent/index.ts)）、stream-json を stdin/stdout で受け渡す構造。ここから 2 つの制約が発生する:
 
-1. **The model selection is whatever `claude` defaults to.** [`buildCliArgs` in server/agent/config.ts](../server/agent/config.ts) does not pass `--model`.
-2. **Backend selection is whatever env vars the parent process has.** When MulmoClaude is started normally, those are the cloud Claude defaults.
+1. **モデル指定は `claude` のデフォルト依存**。[server/agent/config.ts の `buildCliArgs`](../server/agent/config.ts) は `--model` を渡していない。
+2. **バックエンド指定は親プロセスの env 依存**。MulmoClaude を通常起動した場合、env はクラウド Claude のデフォルト設定。
 
-For local Ollama to work end-to-end, both the spawned CLI's model flag and its env have to point at the local server. Docker sandbox mode adds a third concern: env vars are not forwarded into the container, and `localhost:11434` from inside the container is not the host's Ollama (`host.docker.internal` would have to be added).
+ローカル Ollama を end-to-end で動かすには、spawn される CLI の `--model` フラグと env の両方をローカル向けにする必要がある。Docker sandbox モードは追加で問題があり、env が container に伝わらず、container 内から `localhost:11434` ではホストの Ollama が見えない（`host.docker.internal` の追加が必須）。
 
-There is also a UX problem inherited from the Claude Code × Ollama work: even on `qwen3.5:9b` (the lightest verified-working model), the **first turn takes 10+ minutes** and subsequent turns 1–3 minutes on a MacBook Air M4 32GB. MulmoClaude's chat UI is interactive; users will not enjoy this. The implementation should at minimum make the trade-off explicit.
+UX 上の問題も継承される: 検証で動作確認できた最軽量モデル `qwen3.5:9b` でも MacBook Air M4 32GB で **初回 10 分超**、2 回目以降 1〜3 分。MulmoClaude の chat UI はインタラクティブ前提なのでユーザー体験は厳しい。実装する場合は最低限このトレードオフを明示する必要がある。
 
-## Goal
+## ゴール
 
-Let a user opt into a local Ollama backend via settings or env, and have every spawn of `claude` (both bare and inside the Docker sandbox) route to that backend with the chosen model. Cloud usage remains the default and is not regressed.
+設定または env でローカル Ollama バックエンドにオプトインできるようにし、`claude` の spawn（通常モード／Docker sandbox 両方）が指定モデルでローカルにルーティングされる状態にする。クラウド利用は引き続きデフォルトで、デグレなし。
 
-## Scope tiers
+## 実装ティア
 
-The work has three natural cut points. Recommend stopping at Tier 2 unless there's clear demand.
+作業は 3 段階に分けられる。明確な需要がない限り Tier 2 で止めるのを推奨。
 
-### Tier 1: env + CLI flag pass-through (~50–100 LoC, ~half a day)
+### Tier 1: env と CLI フラグのパススルー（50〜100 行、半日）
 
-Just enough that a power user editing `settings.json` can switch to Ollama.
+パワーユーザーが `settings.json` を直接編集してバックエンド切替できる最小実装。
 
-- [server/system/env.ts](../server/system/env.ts): add `ollamaBaseUrl?`, `ollamaModel?` (or a `llmProvider: "cloud" | "ollama"` discriminator) read from `process.env`.
+- [server/system/env.ts](../server/system/env.ts): `ollamaBaseUrl?`、`ollamaModel?` を追加（または `llmProvider: "cloud" | "ollama"` のような discriminator）。`process.env` から読み込み。
 - [server/agent/config.ts](../server/agent/config.ts):
-  - `buildCliArgs`: when local mode, append `"--model", ollamaModel`.
-  - `buildDockerSpawnArgs`: when local mode, add `-e ANTHROPIC_AUTH_TOKEN=ollama -e ANTHROPIC_API_KEY= -e ANTHROPIC_BASE_URL=http://host.docker.internal:11434` and `--add-host host.docker.internal:host-gateway` (Linux/Mac).
-- [server/agent/index.ts](../server/agent/index.ts) `spawnClaude`: pass `env: { ...process.env, ANTHROPIC_* }` when local mode is enabled (non-Docker path inherits naturally; the Docker path is handled in step above).
-- [server/system/config.ts](../server/system/config.ts): add `llm` object to settings schema (e.g. `{ provider: "cloud" | "ollama", ollamaBaseUrl?, ollamaModel? }`).
+  - `buildCliArgs`: ローカルモード時に `"--model", ollamaModel` を追加。
+  - `buildDockerSpawnArgs`: ローカルモード時に `-e ANTHROPIC_AUTH_TOKEN=ollama -e ANTHROPIC_API_KEY= -e ANTHROPIC_BASE_URL=http://host.docker.internal:11434` と `--add-host host.docker.internal:host-gateway`（Linux/Mac）を追加。
+- [server/agent/index.ts](../server/agent/index.ts) の `spawnClaude`: ローカルモード時に `env: { ...process.env, ANTHROPIC_* }` を渡す（非 Docker パスは自動継承、Docker パスは上記の `-e` で対応）。
+- [server/system/config.ts](../server/system/config.ts): settings スキーマに `llm` オブジェクト（例: `{ provider: "cloud" | "ollama", ollamaBaseUrl?, ollamaModel? }`）を追加。
 
-Done = manually editing `~/mulmoclaude/config/settings.json` flips the backend.
+完了基準 = `~/mulmoclaude/config/settings.json` の手動編集でバックエンドが切り替わる。
 
-### Tier 2: settings UI + connection check (~300–500 LoC, ~2–3 days) — **recommended**
+### Tier 2: 設定 UI と接続テスト（300〜500 行、2〜3 日）— **推奨**
 
-Make the option discoverable and at least somewhat safe.
+オプションを発見可能にし、ある程度安全にする。
 
-Adds on top of Tier 1:
+Tier 1 に追加で:
 
-- New Vue section under [`src/components/`](../src/components/) (alongside the existing settings panes). Inputs for provider radio, base URL (default `http://localhost:11434`), model dropdown.
-- `GET /api/settings/ollama/models` route that proxies `GET <baseUrl>/v1/models` and returns the list. Used to populate the dropdown.
-- `POST /api/settings/ollama/test` route: makes a minimal `/v1/messages` request, returns `{ ok, kvSize, contextLength, error? }`. Used by a "Test connection" button.
-- i18n: every new string lands in all 8 locales (`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`) — see CLAUDE.md i18n rules.
-- Status indicator in the chat header showing **Cloud** vs **Ollama (model name)** so the active backend is never ambiguous.
-- Warning copy in the UI explaining the slowness trade-off and that some MulmoClaude plugins/skills depend on tool calling that local models handle poorly.
-- Tests:
-  - Unit: env parsing, settings round-trip, CLI args construction in both modes (mirrors existing `test/agent/config.test.ts`-style coverage).
-  - E2E: a fixture that mocks `localhost:11434` and verifies the settings UI flow + "Test connection" path.
+- [`src/components/`](../src/components/) 配下に新しい Vue セクション（既存設定ペインと並べる）。プロバイダのラジオボタン、base URL 入力（デフォルト `http://localhost:11434`）、モデル選択ドロップダウン。
+- `GET /api/settings/ollama/models` ルート: `GET <baseUrl>/v1/models` をプロキシしてリストを返す。ドロップダウン用。
+- `POST /api/settings/ollama/test` ルート: 最小限の `/v1/messages` リクエストを投げ、`{ ok, kvSize, contextLength, error? }` を返す。「接続テスト」ボタン用。
+- i18n: 新しい文字列はすべて 8 ロケール（`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`）に同時追加。CLAUDE.md の i18n ルール参照。
+- chat ヘッダーにステータスインジケータを表示（**Cloud** vs **Ollama (モデル名)**）。アクティブバックエンドが曖昧にならないように。
+- UI 上に警告コピー: 速度トレードオフと、tool calling に依存する MulmoClaude プラグイン/スキルがローカルモデルでは不安定であること。
+- テスト:
+  - Unit: env パース、settings の round-trip、両モードでの CLI args 構築（既存の `test/agent/config.test.ts` 風カバレッジ）。
+  - E2E: `localhost:11434` をモックする fixture で設定 UI フロー + 「接続テスト」パスを検証。
 
-### Tier 3: production polish (~1000+ LoC, 1–2 weeks)
+### Tier 3: プロダクション仕上げ（1000+ 行、1〜2 週間）
 
-Everything below is optional and only worth doing if local backend becomes a first-class story.
+以下はすべてオプション。ローカルバックエンドを first-class なストーリーにする場合のみ着手する価値あり。
 
-- **Timeout adjustments**: extend the SSE/agent loop timeouts when `provider === "ollama"` so the 10-minute Claude Code default does not kill the first turn.
-- **Warm-up on boot**: when local mode is active, send a one-shot `/v1/messages` `"hello"` at server startup so the KV cache is primed before the first user turn.
-- **Cloud fallback**: detect Ollama down / model missing and either fall back to cloud (with a banner) or surface a clear actionable error.
-- **Plugin/skill compatibility flags**: maintain a list of plugins that depend on tool-use formatting and silently disable them in local mode (or warn in the UI).
-- **Recommended-models check**: on save, compare the chosen model against an allowlist (qwen3.5+, MoE variants confirmed to handle thinking blocks correctly) and warn if unverified.
-- **Progress UI**: parse the Ollama log stream and surface a "processing prompt X/Y tokens" hint in the chat UI so users understand why the first turn takes 10 minutes.
-- **Docs**: update [docs/developer.md](../docs/developer.md), [README.md](../README.md), and the README translations under `packages/`.
+- **タイムアウト調整**: `provider === "ollama"` 時に SSE / agent ループのタイムアウトを延長し、Claude Code のデフォルト 10 分タイムアウトで初回が落ちないようにする。
+- **起動時 warmup**: ローカルモード時、サーバ起動直後に `/v1/messages` で `"hello"` を送り KV cache を温めてからユーザーターンに入る。
+- **クラウドフォールバック**: Ollama down / モデル無し検知時にクラウドに自動フォールバック（バナー付き）するか、明確な actionable error を表示。
+- **プラグイン/スキル互換フラグ**: tool-use 形式に依存するプラグインのリストを保持し、ローカルモードでは無効化（または UI で警告）。
+- **推奨モデルチェック**: 保存時に選択モデルを allowlist（thinking ブロックを正しく処理できることが確認された qwen3.5+、MoE バリアント等）と照合し、未検証なら警告。
+- **進捗表示**: Ollama のログストリームをパースし、chat UI に「プロンプト処理中 X/Y トークン」のヒントを表示。10 分かかる理由をユーザーに見せる。
+- **ドキュメント**: [docs/developer.md](../docs/developer.md)、[README.md](../README.md)、`packages/` 配下の README 翻訳を更新。
 
-## Open questions
+## オープンクエスチョン
 
-- Do we want `provider` per-role (so e.g. the `general` role uses cloud and a `local-fast` role uses Ollama), or globally?
-- Should the Docker sandbox mode be supported for local Ollama at all? Forwarding `host.docker.internal` makes the container less isolated; there's an argument for "local Ollama only works without sandbox".
-- Settings file location: should the `llm` section live in the existing `settings.json`, or in a new `llm.json` to avoid bloating the main file?
+- `provider` をロール単位にする（例: `general` ロールはクラウド、`local-fast` ロールは Ollama）か、グローバル設定にするか。
+- Docker sandbox モードでローカル Ollama をサポートすべきか。`host.docker.internal` を通すと container の隔離性が下がるので、「ローカル Ollama は sandbox 無効時のみ」という割り切りもあり得る。
+- 設定ファイルの場所: `llm` セクションは既存の `settings.json` に入れるか、メインファイルが膨らむのを避けて新しい `llm.json` に分けるか。
 
-## Non-goals
+## Non-Goals
 
-- Supporting OpenAI / other non-Anthropic-compatible backends. Out of scope; would need a different abstraction.
-- Optimising local model performance. That's an Ollama / hardware concern, not a MulmoClaude one.
-- A full provider-abstraction layer. We're piggy-backing on Claude Code's existing Anthropic-compatibility env vars deliberately.
+- OpenAI 等、Anthropic 互換でないバックエンドのサポート。スコープ外。別の抽象化が必要になる。
+- ローカルモデルのパフォーマンス改善。Ollama / ハードウェアの問題で、MulmoClaude 側の関心ではない。
+- 完全なプロバイダ抽象化レイヤー。Claude Code の Anthropic 互換 env 仕様に乗っかる方針を意図的に選択している。
 
-## References
+## 参考
 
-- Findings (Japanese): [`docs/tips/claude-code-ollama.md`](../docs/tips/claude-code-ollama.md)
-- Findings (English): [`docs/tips/claude-code-ollama.en.md`](../docs/tips/claude-code-ollama.en.md)
-- Setup skill (Claude Code only): [`.claude/skills/setup-ollama-local/SKILL.md`](../.claude/skills/setup-ollama-local/SKILL.md)
+- 検証知見（日本語）: [`docs/tips/claude-code-ollama.md`](../docs/tips/claude-code-ollama.md)
+- 検証知見（英語）: [`docs/tips/claude-code-ollama.en.md`](../docs/tips/claude-code-ollama.en.md)
+- セットアップスキル（Claude Code 単体向け）: [`.claude/skills/setup-ollama-local/SKILL.md`](../.claude/skills/setup-ollama-local/SKILL.md)
 - Ollama Claude Code integration: https://docs.ollama.com/integrations/claude-code


### PR DESCRIPTION
## Summary

- Claude Code CLI を Ollama ローカル LLM に接続するセットアップスキルを追加（**MulmoClaude 本体ではなく Claude Code CLI 単体向け**）
- MacBook Air M4 32GB での動作検証で得た知見を `docs/tips/claude-code-ollama.{md,en.md}` に bilingual で記録
- MulmoClaude 自体を Ollama 対応させる場合の実装プラン（Tier 1〜3）を `plans/feat-mulmoclaude-ollama-support.md` に追加

## Items to Confirm / Review

- スキルの description で「MulmoClaude ではなく Claude Code CLI 単体向け」と明記したが、表現として十分明確か（誤って MulmoClaude のセットアップだと期待されないか）
- 検証済みモデル一覧（`qwen3.5:9b` ◯、`gpt-oss:20b` ✗ など）は MacBook Air M4 32GB 環境での実測。NVIDIA GPU マシン等では結果が異なる可能性あり
- `plans/feat-mulmoclaude-ollama-support.md` は **実装はまだ行わない方針** で、現状の調査結果と将来の実装案をまとめたもの。Tier 2（UI 付き、推奨）まで進めるべきかどうかは要相談
- bilingual ドキュメントの命名規則は既存の `docs/tips/obsidian.{md,en.md}` に合わせた

## User Prompt

ローカル LLM（Ollama）と Claude Code を Mac で連携させるセットアップ手順をスキル化したい。検証作業を進めながら、得られた知見と検証済みモデル一覧、エラー種別、パフォーマンス実測値を残してほしい。さらに、MulmoClaude 本体を Ollama に対応させるとしたら何が必要かも合わせて調査してまとめておきたい。

## 主な変更内容

### 1. スキル `setup-ollama-local` の整理

- description を「Claude Code CLI 単体向け、MulmoClaude とは独立」と明示するよう刷新
- 冒頭に bilingual な Scope セクションを追加し、誤解されにくい構造に
- 詳細な検証結果は `docs/tips/` に切り出し、スキル本体はワークフローに集中

### 2. 検証知見ドキュメント（bilingual）

`docs/tips/claude-code-ollama.md`（日本語）と `claude-code-ollama.en.md`（英語）を新規作成。内容:

- Ollama v0.14.0+ が必要、Claude Code は 50k〜57k トークン送るため 64k 以上のコンテキストが必須
- `OLLAMA_CONTEXT_LENGTH` の Runner 別挙動（新 ollama-engine では効くが llama.cpp 系では無視）
- 7 モデル検証結果（◯: `qwen3.5:9b`、`qwen3.6:35b-a3b` / ✗: 残り 5 モデル）
- エラー種別と対処可否（`truncating input prompt` は対処可、`Content block not found` や template バグは不可）
- パフォーマンス実測（コールド 10 分超、KV cache 温まると 1〜3 分）
- 3 ターミナル運用、エイリアス設定、ログの場所など

### 3. 実装プラン

`plans/feat-mulmoclaude-ollama-support.md`:

- 現状: MulmoClaude は `claude` CLI を子プロセスで spawn する構造のため、env と `--model` を渡せれば原理的には動作可能
- Tier 1（半日〜1日、50〜100行）: env パススルー、`buildCliArgs` に `--model`、Docker `-e` 追加
- Tier 2（推奨、2〜3日、300〜500行）: 設定 UI、接続テスト、8 ロケール i18n
- Tier 3（1〜2週間、1000+行）: タイムアウト調整、warmup、フォールバック等
- Open questions と Non-goals も記載

## Test plan

- [ ] スキル `/setup-ollama-local` を実行し、ガイドが期待通り動くこと
- [ ] `docs/tips/claude-code-ollama.md` のリンク（`SKILL.md` → docs、`docs` → 関連リンク）が正しく解決すること
- [ ] `plans/feat-mulmoclaude-ollama-support.md` のソースコード参照（`server/agent/index.ts` など）が現存することの目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an interactive setup guide for configuring the Claude CLI to use a local Ollama server on macOS.
  * Added tips for running Claude Code with Ollama (model compatibility, context requirements, performance, logs, and troubleshooting) in English and Japanese.
  * Added a feature plan outlining staged delivery and design considerations for local Ollama support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->