### PR TITLE
feat(observability): logging on files / todos / plugin routes (#779 PR α+β)

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -9,6 +9,8 @@ import { getOptionalStringQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { GitignoreFilter } from "../../utils/gitignore.js";
 import { getCachedReferenceDirs } from "../../workspace/reference-dirs.js";
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
 
 const router = Router();
 
@@ -476,6 +478,7 @@ export async function listDirShallow(absPath: string, relPath: string, gitFilter
 }
 
 router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown, object>, res: Response<TreeNode | ErrorResponse>) => {
+  log.info("files", "GET tree: start");
   try {
     // Start with an empty filter — the workspace root's .gitignore
     // is for git (excluding github/ from commits), NOT for the
@@ -486,6 +489,7 @@ router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown,
     const tree = await buildTreeAsync(workspaceReal, "");
     res.json(tree);
   } catch (err) {
+    log.error("files", "GET tree: threw", { error: errorMessage(err) });
     serverError(res, `Failed to read workspace: ${errorMessage(err)}`);
   }
 });
@@ -495,16 +499,19 @@ router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown,
 // `path` is optional; empty / missing = workspace root.
 router.get(API_ROUTES.files.dir, async (req: Request<object, unknown, unknown, PathQuery>, res: Response<TreeNode | ErrorResponse>) => {
   const relPath = getOptionalStringQuery(req, "path") ?? "";
+  log.info("files", "GET dir: start", { pathPreview: previewSnippet(relPath) });
 
   // Reference directory branch — resolve against the registered ref dir
   if (isRefPath(relPath)) {
     const absPath = resolveRefPath(relPath);
     if (!absPath) {
+      log.warn("files", "GET dir: ref dir not found", { pathPreview: previewSnippet(relPath) });
       notFound(res, "Not found");
       return;
     }
     const stat = await statSafeAsync(absPath);
     if (!stat || !stat.isDirectory()) {
+      log.warn("files", "GET dir: ref path missing or not a dir", { pathPreview: previewSnippet(relPath) });
       notFound(res, "Not found");
       return;
     }
@@ -516,15 +523,18 @@ router.get(API_ROUTES.files.dir, async (req: Request<object, unknown, unknown, P
   // Workspace path — existing logic
   const absPath = resolveSafe(relPath);
   if (!absPath) {
+    log.warn("files", "GET dir: path outside workspace", { pathPreview: previewSnippet(relPath) });
     notFound(res, "Not found");
     return;
   }
   const stat = await statSafeAsync(absPath);
   if (!stat) {
+    log.warn("files", "GET dir: not found", { pathPreview: previewSnippet(relPath) });
     notFound(res, "Not found");
     return;
   }
   if (!stat.isDirectory()) {
+    log.warn("files", "GET dir: not a directory", { pathPreview: previewSnippet(relPath) });
     badRequest(res, "path is not a directory");
     return;
   }
@@ -542,6 +552,7 @@ router.get(API_ROUTES.files.dir, async (req: Request<object, unknown, unknown, P
     const listing = await listDirShallow(absPath, path.relative(workspaceReal, absPath), filter);
     res.json(listing);
   } catch (err) {
+    log.error("files", "GET dir: threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
     serverError(res, `Failed to read directory: ${errorMessage(err)}`);
   }
 });
@@ -624,8 +635,16 @@ function resolveAndStatFile<T>(
 }
 
 router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, PathQuery>, res: Response<FileContentResponse | ErrorResponse>) => {
+  const requestedPath = getOptionalStringQuery(req, "path") ?? "";
+  log.info("files", "GET content: start", { pathPreview: previewSnippet(requestedPath) });
   const ctx = resolveAndStatFile(req, res);
-  if (!ctx) return;
+  if (!ctx) {
+    // resolveAndStatFile already wrote the 4xx; surface the gate
+    // miss so the operator can correlate the user-visible error
+    // with a concrete reason in the log without re-running.
+    log.warn("files", "GET content: gated by resolve/stat", { pathPreview: previewSnippet(requestedPath) });
+    return;
+  }
   const { relPath, absPath, stat } = ctx;
 
   const meta = {
@@ -671,9 +690,11 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
   try {
     content = readFileSync(absPath, "utf-8");
   } catch (err) {
+    log.error("files", "GET content: read threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
     serverError(res, `Failed to read file: ${errorMessage(err)}`);
     return;
   }
+  log.info("files", "GET content: ok", { pathPreview: previewSnippet(relPath), bytes: stat.size });
   res.json({ kind: "text", ...meta, content });
 });
 
@@ -683,15 +704,22 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
 // The file must already exist; creating new files is out of scope.
 router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteContentRequest>, res: Response<WriteContentResponse | ErrorResponse>) => {
   const { path: relPathRaw, content: contentRaw } = req.body ?? {};
+  log.info("files", "PUT content: start", {
+    pathPreview: typeof relPathRaw === "string" ? previewSnippet(relPathRaw) : undefined,
+    bytes: typeof contentRaw === "string" ? Buffer.byteLength(contentRaw, "utf-8") : undefined,
+  });
   if (typeof relPathRaw !== "string" || relPathRaw.length === 0) {
+    log.warn("files", "PUT content: missing path");
     badRequest(res, "path required");
     return;
   }
   if (typeof contentRaw !== "string") {
+    log.warn("files", "PUT content: missing content", { pathPreview: previewSnippet(relPathRaw) });
     badRequest(res, "content required");
     return;
   }
   if (Buffer.byteLength(contentRaw, "utf-8") > MAX_PREVIEW_BYTES) {
+    log.warn("files", "PUT content: too large", { pathPreview: previewSnippet(relPathRaw), bytes: Buffer.byteLength(contentRaw, "utf-8") });
     badRequest(res, `content exceeds ${MAX_PREVIEW_BYTES} byte limit`);
     return;
   }
@@ -730,10 +758,15 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
     // other's staging file and race through the rename.
     await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
   } catch (err) {
+    log.error("files", "PUT content: write threw", { pathPreview: previewSnippet(relPathRaw), error: errorMessage(err) });
     serverError(res, `Failed to write file: ${errorMessage(err)}`);
     return;
   }
   const fresh = await statSafeAsync(absPath);
+  log.info("files", "PUT content: ok", {
+    pathPreview: previewSnippet(relPathRaw),
+    bytes: fresh?.size ?? Buffer.byteLength(contentRaw, "utf-8"),
+  });
   res.json({
     path: relPathRaw,
     size: fresh?.size ?? Buffer.byteLength(contentRaw, "utf-8"),
@@ -742,11 +775,17 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
 });
 
 router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQuery>, res: Response<ErrorResponse>) => {
+  const requestedPath = getOptionalStringQuery(req, "path") ?? "";
+  log.info("files", "GET raw: start", { pathPreview: previewSnippet(requestedPath) });
   const ctx = resolveAndStatFile(req, res);
-  if (!ctx) return;
+  if (!ctx) {
+    log.warn("files", "GET raw: gated by resolve/stat", { pathPreview: previewSnippet(requestedPath) });
+    return;
+  }
   const { absPath, stat } = ctx;
 
   if (stat.size > MAX_RAW_BYTES) {
+    log.warn("files", "GET raw: too large", { pathPreview: previewSnippet(requestedPath), bytes: stat.size });
     sendError(res, 413, `File too large to stream (${stat.size} bytes, limit ${MAX_RAW_BYTES})`);
     return;
   }
@@ -795,6 +834,7 @@ router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQue
 // prefix so subsequent /dir and /content requests route correctly.
 
 router.get(API_ROUTES.files.refRoots, async (_req: Request, res: Response<TreeNode[]>) => {
+  log.info("files", "GET ref-roots: start");
   const entries = getCachedReferenceDirs();
   const nodes: TreeNode[] = [];
   for (const entry of entries) {
@@ -807,6 +847,7 @@ router.get(API_ROUTES.files.refRoots, async (_req: Request, res: Response<TreeNo
       modifiedMs: stat.mtimeMs,
     });
   }
+  log.info("files", "GET ref-roots: ok", { configured: entries.length, mounted: nodes.length });
   res.json(nodes);
 });
 

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -12,6 +12,8 @@ import { fillMarkdownImagePlaceholders } from "../../utils/files/markdown-image-
 import { saveMarkdown, overwriteMarkdown, isMarkdownPath } from "../../utils/files/markdown-store.js";
 import { saveSpreadsheet, overwriteSpreadsheet, isSpreadsheetPath } from "../../utils/files/spreadsheet-store.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
 
 const router = Router();
 
@@ -29,15 +31,27 @@ interface PluginErrorResponse {
 // default and each plugin's execute function does its own runtime
 // validation — matching the behavior of the inline handlers this
 // replaces.
+//
+// Logging policy (#779): a single entry/success/error log here covers
+// every route that adopts this wrapper (mindmap / quiz / form /
+// canvas / present3d / presentSpreadsheet). Without it, plugin
+// errors used to land as a generic 500 response with no server-log
+// trace — exactly the silent-failure pattern the audit is closing.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function wrapPluginExecute<TBody = any, TResult = unknown>(
   execute: (req: Request<object, unknown, TBody>) => Promise<TResult>,
 ): (req: Request<object, unknown, TBody>, res: Response<TResult | PluginErrorResponse>) => Promise<void> {
   return async (req, res) => {
+    // `req.path` here is the absolute path under the router's mount —
+    // useful as a per-call identifier without having to thread the
+    // plugin name through every call site.
+    log.info("plugins", "execute: start", { route: req.path });
     try {
       const result = await execute(req);
+      log.info("plugins", "execute: ok", { route: req.path });
       res.json(result);
     } catch (err) {
+      log.error("plugins", "execute: threw", { route: req.path, error: errorMessage(err) });
       res.status(500).json({ message: errorMessage(err) });
     }
   };
@@ -64,12 +78,19 @@ router.post(
   API_ROUTES.plugins.presentDocument,
   async (req: Request<object, unknown, PresentDocumentBody>, res: Response<PresentDocumentSuccess | PresentDocumentError>) => {
     const { title, markdown, filenamePrefix } = req.body;
+    log.info("plugins", "presentDocument: start", {
+      titlePreview: typeof title === "string" ? previewSnippet(title) : undefined,
+      prefixPreview: typeof filenamePrefix === "string" ? previewSnippet(filenamePrefix) : undefined,
+      markdownBytes: typeof markdown === "string" ? markdown.length : undefined,
+    });
     if (typeof filenamePrefix !== "string" || filenamePrefix.trim().length === 0) {
+      log.warn("plugins", "presentDocument: missing filenamePrefix");
       badRequest(res, "filenamePrefix is required");
       return;
     }
     const filledMarkdown = await fillMarkdownImagePlaceholders(markdown);
     const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
+    log.info("plugins", "presentDocument: ok", { markdownPath, bytes: filledMarkdown.length });
     res.json({
       message: `Document "${title}" is ready.`,
       title,
@@ -100,18 +121,28 @@ router.put(
   API_ROUTES.plugins.updateMarkdown,
   async (req: Request<object, unknown, UpdateMarkdownBody>, res: Response<UpdateMarkdownResponse | UpdateMarkdownError>) => {
     const { relativePath, markdown } = req.body;
+    log.info("plugins", "updateMarkdown: start", {
+      pathPreview: typeof relativePath === "string" ? previewSnippet(relativePath) : undefined,
+      bytes: typeof markdown === "string" ? markdown.length : undefined,
+    });
     if (!markdown) {
+      log.warn("plugins", "updateMarkdown: missing markdown");
       badRequest(res, "markdown is required");
       return;
     }
     if (!relativePath || !isMarkdownPath(relativePath)) {
+      log.warn("plugins", "updateMarkdown: invalid relativePath", {
+        pathPreview: typeof relativePath === "string" ? previewSnippet(relativePath) : undefined,
+      });
       badRequest(res, "invalid markdown relativePath");
       return;
     }
     try {
       await overwriteMarkdown(relativePath, markdown);
+      log.info("plugins", "updateMarkdown: ok", { pathPreview: previewSnippet(relativePath), bytes: markdown.length });
       res.json({ path: relativePath });
     } catch (err) {
+      log.error("plugins", "updateMarkdown: threw", { pathPreview: previewSnippet(relativePath), error: errorMessage(err) });
       serverError(res, errorMessage(err));
     }
   },
@@ -157,18 +188,28 @@ router.put(
   API_ROUTES.plugins.updateSpreadsheet,
   async (req: Request<object, unknown, UpdateSpreadsheetBody>, res: Response<UpdateSpreadsheetResponse | UpdateSpreadsheetError>) => {
     const { relativePath, sheets } = req.body;
+    log.info("plugins", "updateSpreadsheet: start", {
+      pathPreview: typeof relativePath === "string" ? previewSnippet(relativePath) : undefined,
+      sheetCount: Array.isArray(sheets) ? sheets.length : undefined,
+    });
     if (!Array.isArray(sheets)) {
+      log.warn("plugins", "updateSpreadsheet: sheets not an array");
       badRequest(res, "sheets must be an array");
       return;
     }
     if (!relativePath || !isSpreadsheetPath(relativePath)) {
+      log.warn("plugins", "updateSpreadsheet: invalid relativePath", {
+        pathPreview: typeof relativePath === "string" ? previewSnippet(relativePath) : undefined,
+      });
       badRequest(res, "invalid spreadsheet relativePath");
       return;
     }
     try {
       await overwriteSpreadsheet(relativePath, sheets);
+      log.info("plugins", "updateSpreadsheet: ok", { pathPreview: previewSnippet(relativePath), sheetCount: sheets.length });
       res.json({ path: relativePath });
     } catch (err) {
+      log.error("plugins", "updateSpreadsheet: threw", { pathPreview: previewSnippet(relativePath), error: errorMessage(err) });
       serverError(res, errorMessage(err));
     }
   },

--- a/server/api/routes/todos.ts
+++ b/server/api/routes/todos.ts
@@ -28,6 +28,8 @@ import {
 import { respondWithDispatchResult, type DispatchSuccessResponse, type DispatchErrorResponse } from "./dispatchResponse.js";
 
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { log } from "../../system/logger/index.js";
+import { previewSnippet } from "../../utils/logPreview.js";
 
 const router = Router();
 
@@ -101,8 +103,12 @@ const READ_ONLY_ACTIONS = new Set(["show", "list_labels"]);
 
 router.post(API_ROUTES.todos.dispatch, (req: Request<object, unknown, TodoBody>, res: Response<DispatchSuccessResponse<TodoItem> | DispatchErrorResponse>) => {
   const { action, ...input } = req.body;
+  log.info("todos", "POST dispatch: start", { action: previewSnippet(action) });
   const items = loadTodos();
   const result = dispatchTodos(action, items, input);
+  if (result.kind === "error") {
+    log.warn("todos", "POST dispatch: error", { action: previewSnippet(action), error: result.error });
+  }
   respondWithDispatchResult(res, result, {
     shouldPersist: !READ_ONLY_ACTIONS.has(action),
     instructions: "Display the updated todo list to the user.",
@@ -131,14 +137,17 @@ interface ColumnIdParams {
 
 // POST /api/todos/items — create a new todo
 router.post(API_ROUTES.todos.items, (req: Request<object, unknown, CreateInput>, res: Response<ItemResponse | DispatchErrorResponse>) => {
+  log.info("todos", "POST item: start");
   const items = loadTodos();
   const columns = loadColumns();
   const result = handleCreate(items, columns, req.body);
   if (result.kind === "error") {
+    log.warn("todos", "POST item: error", { error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveTodos(result.items);
+  log.info("todos", "POST item: ok", { itemId: result.item?.id, total: result.items.length });
   res.json({
     data: { items: result.items, columns },
     ...(result.item && { item: result.item }),
@@ -147,14 +156,17 @@ router.post(API_ROUTES.todos.items, (req: Request<object, unknown, CreateInput>,
 
 // PATCH /api/todos/items/:id — partial update
 router.patch(API_ROUTES.todos.item, (req: Request<ItemIdParams, unknown, PatchInput>, res: Response<ItemResponse | DispatchErrorResponse>) => {
+  log.info("todos", "PATCH item: start", { itemId: req.params.id });
   const items = loadTodos();
   const columns = loadColumns();
   const result = handlePatch(items, columns, req.params.id, req.body);
   if (result.kind === "error") {
+    log.warn("todos", "PATCH item: error", { itemId: req.params.id, error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveTodos(result.items);
+  log.info("todos", "PATCH item: ok", { itemId: req.params.id });
   res.json({
     data: { items: result.items, columns },
     ...(result.item && { item: result.item }),
@@ -163,14 +175,17 @@ router.patch(API_ROUTES.todos.item, (req: Request<ItemIdParams, unknown, PatchIn
 
 // POST /api/todos/items/:id/move — drag & drop persistence
 router.post(API_ROUTES.todos.itemMove, (req: Request<ItemIdParams, unknown, MoveInput>, res: Response<ItemResponse | DispatchErrorResponse>) => {
+  log.info("todos", "POST item-move: start", { itemId: req.params.id });
   const items = loadTodos();
   const columns = loadColumns();
   const result = handleMove(items, columns, req.params.id, req.body);
   if (result.kind === "error") {
+    log.warn("todos", "POST item-move: error", { itemId: req.params.id, error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveTodos(result.items);
+  log.info("todos", "POST item-move: ok", { itemId: req.params.id });
   res.json({
     data: { items: result.items, columns },
     ...(result.item && { item: result.item }),
@@ -179,14 +194,17 @@ router.post(API_ROUTES.todos.itemMove, (req: Request<ItemIdParams, unknown, Move
 
 // DELETE /api/todos/items/:id
 router.delete(API_ROUTES.todos.item, (req: Request<ItemIdParams>, res: Response<ItemResponse | DispatchErrorResponse>) => {
+  log.info("todos", "DELETE item: start", { itemId: req.params.id });
   const items = loadTodos();
   const columns = loadColumns();
   const result = handleDeleteItem(items, req.params.id);
   if (result.kind === "error") {
+    log.warn("todos", "DELETE item: error", { itemId: req.params.id, error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveTodos(result.items);
+  log.info("todos", "DELETE item: ok", { itemId: req.params.id, remaining: result.items.length });
   res.json({ data: { items: result.items, columns } });
 });
 
@@ -215,48 +233,60 @@ router.get(API_ROUTES.todos.columns, (_req: Request, res: Response<ColumnsRespon
 });
 
 router.post(API_ROUTES.todos.columns, (req: Request<object, unknown, AddColumnBody>, res: Response<ColumnsResponse | DispatchErrorResponse>) => {
+  log.info("todos", "POST column: start");
   const items = loadTodos();
   const result = handleAddColumn(loadColumns(), items, req.body);
   if (result.kind === "error") {
+    log.warn("todos", "POST column: error", { error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveColumns(result.columns);
   if (result.items) saveTodos(result.items);
+  log.info("todos", "POST column: ok", { columns: result.columns.length });
   res.json({ data: { items: loadTodos(), columns: result.columns } });
 });
 
 router.patch(API_ROUTES.todos.column, (req: Request<ColumnIdParams, unknown, PatchColumnBody>, res: Response<ColumnsResponse | DispatchErrorResponse>) => {
+  log.info("todos", "PATCH column: start", { columnId: req.params.id });
   const items = loadTodos();
   const result = handlePatchColumn(loadColumns(), req.params.id, req.body, items);
   if (result.kind === "error") {
+    log.warn("todos", "PATCH column: error", { columnId: req.params.id, error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveColumns(result.columns);
   if (result.items) saveTodos(result.items);
+  log.info("todos", "PATCH column: ok", { columnId: req.params.id });
   res.json({ data: { items: loadTodos(), columns: result.columns } });
 });
 
 router.delete(API_ROUTES.todos.column, (req: Request<ColumnIdParams>, res: Response<ColumnsResponse | DispatchErrorResponse>) => {
+  log.info("todos", "DELETE column: start", { columnId: req.params.id });
   const items = loadTodos();
   const result = handleDeleteColumn(loadColumns(), req.params.id, items);
   if (result.kind === "error") {
+    log.warn("todos", "DELETE column: error", { columnId: req.params.id, error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveColumns(result.columns);
   if (result.items) saveTodos(result.items);
+  log.info("todos", "DELETE column: ok", { columnId: req.params.id, remaining: result.columns.length });
   res.json({ data: { items: loadTodos(), columns: result.columns } });
 });
 
 router.put(API_ROUTES.todos.columnsOrder, (req: Request<object, unknown, ReorderColumnsBody>, res: Response<ColumnsResponse | DispatchErrorResponse>) => {
+  log.info("todos", "PUT columns-order: start", { count: req.body.ids?.length ?? 0 });
   const result = handleReorderColumns(loadColumns(), req.body.ids ?? []);
   if (result.kind === "error") {
+    log.warn("todos", "PUT columns-order: error", { error: result.error });
     res.status(result.status).json({ error: result.error });
     return;
   }
   saveColumns(result.columns);
+  log.info("todos", "PUT columns-order: ok", { columns: result.columns.length });
   res.json({ data: { items: loadTodos(), columns: result.columns } });
 });
 


### PR DESCRIPTION
## Summary

PR #784 (#779 first pass) で wiki / scheduler / sources/pipeline を塞いだあと、findings.md で `coverage: none` 高優先度に挙がっていた **`files.ts`**, **`todos.ts`**, **`plugins.ts`** にログを足す。

- **files.ts**: tree / dir / content GET / content PUT / raw / ref-roots
  - 各 route エントリで `info`、gate-miss (not-found / outside-workspace / not-a-directory / too-large) で `warn`、async catch で `error`、content GET/PUT と ref-roots は `bytes` 付き success
- **todos.ts**: 全 mutation route (dispatch / item POST/PATCH/move/DELETE / column POST/PATCH/DELETE / order PUT)
  - エントリ + `result.kind === "error"` で warn (理由付き) + 保存成功で itemId/columnId/件数を含む success
  - read-only GET (list, columns) は意図的に quiet — 頻度が高くノイズになる
- **plugins.ts**: `wrapPluginExecute` で 6 route 一括 (mindmap / quiz / form / canvas / present3d / presentSpreadsheet) + presentDocument / updateMarkdown / updateSpreadsheet を個別計測
  - `wrapPluginExecute` 経由のものは `req.path` で route 識別、entry / ok / threw 3点
  - 直書きハンドラはエントリ + 各 validation warn + success + threw

ログ運用の意図 = 「ユーザが『プラグインが反応しない』『todos に追加が反映されない』『file save が失敗』と言ったら sessionId と route + path/id でそのリクエストが見つかる」。

## Items to Confirm / Review

- **previewSnippet vs promptMeta**: path/id 系は識別子なので `previewSnippet` を使用 (#784 のヘルパー表に準拠)
- **read-only GET の quiet 化**: `/api/todos`, `/api/todos/columns` の GET は quiet。前者は configured/mounted カウント差分が運用情報になるが、頻度が高いので debug レベルに移すかは要相談
- **`req.path` を route 識別子に**: 文字列ハードコードを避けるために plugin route 名を `req.path` で識別している。テストが path リテラルに依存するなら、固有のラベル文字列に切り替え可能
- **handler ファイル (`todosHandlers.ts` / `todosColumnsHandlers.ts` / `todosItemsHandlers.ts`)**: 内部 try/catch なし、純粋 validation の `{kind:"error",error}` を返すだけ。route 側の warn が同じ error 文字列を運ぶため、内部にログを足しても重複する → 触らず

## User Prompt

> 779 って残課題ある？ → (triage 後) 順次上から。 → そのまま B へ → 同じブランチで

#779 残課題の順次対応 PR の最初。issue body の audit リスト + PR #784 の `findings.md` で確認した followup を上から順に塞ぐ計画。

## Implementation

- `server/api/routes/files.ts` — log/previewSnippet import、tree/dir/content/raw/refRoots に entry + warn + error + success を追加
- `server/api/routes/todos.ts` — 同 import、9 mutation route に entry + warn(error result) + success
- `server/api/routes/plugins.ts` — 同 import、wrapPluginExecute に entry/ok/threw、presentDocument/updateMarkdown/updateSpreadsheet を個別計測

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean (5 既存 v-html warning のみ)
- [x] `yarn format` — clean
- [x] `yarn build` — clean
- [x] `yarn test` — 3008/3008
- [ ] CI 通過確認
- [ ] 手動: file save → サーバログに `[files] PUT content: ok pathPreview=… bytes=…`
- [ ] 手動: todo 追加・移動・削除 → 各操作の entry + success ログが残る
- [ ] 手動: openCanvas / mindmap / quiz / form を呼ぶ → `[plugins] execute: ok route=…` が残る

Refs #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)