### PR TITLE
feat(agent): elapsed time + per-tool elapsed in Thinking indicator (#731 PR2)

### DIFF
--- a/plans/feat-agent-elapsed-time-731.md
+++ b/plans/feat-agent-elapsed-time-731.md
@@ -1,0 +1,110 @@
+# Agent run elapsed time + per-tool elapsed (#731 PR2)
+
+## ゴール
+
+長時間実行のエージェント中、ユーザに **(A) 全体の経過時間** と **(B) 現在実行中のツール毎の経過時間** を見せる。バックエンド・型・API スキーマを一切変えずにフロントだけで完結させる。
+
+## 背景
+
+#731 (長時間タスクの進捗確認 + 割り込み) の PR シリーズ:
+
+- ✅ **PR1** (#786, merged): Stop ボタン
+- 🚧 **PR2** (本 PR): 経過時間インジケーター
+- 🤔 **PR3** (将来): mid-flight 追加指示 (バックエンド変更が必要、別途検討)
+
+PR2 を出して #731 をクローズ可能にする。PR3 はバックエンドの message-queue 変更が必要で副作用が大きいので別 issue 化する。
+
+## 現状
+
+`src/components/ToolResultsPanel.vue:48-64` の Thinking indicator は既に存在:
+
+- `statusMessage` ("Thinking…" 等) + bouncing dots
+- `pendingCalls` (実行中ツール) のリスト表示
+
+**未実装**: 経過時間表示 (run 全体 / 個別ツール)
+
+## 実装
+
+### A. Run-level elapsed time
+
+新 composable `src/composables/useRunElapsed.ts`:
+
+- `isRunning` を watch
+- `true` 遷移時に `startedAt = Date.now()`、1s tick の `setInterval` を開始
+- `false` 遷移時に interval clear、`startedAt = null`
+- 公開: `elapsedMs: ComputedRef<number | null>`、`teardown(): void`
+- 1秒粒度で十分 (秒未満を表示する必要なし)
+
+### B. Per-tool elapsed time
+
+既存の `usePendingCalls.ts` の 50ms displayTick を流用 (ToolCallHistoryItem.timestamp が開始時刻なので、そこから now() を引くだけ)。`ToolResultsPanel.vue` 側で `formatElapsed(now - call.timestamp)` を表示。
+
+50ms tick は既存仕様で、テンプレート内 inline 計算に流す形が一番自然。
+
+### Format helper
+
+新 pure helper `src/utils/agent/formatElapsed.ts`:
+
+```
+< 1s    → "0.3s"
+< 60s   → "12s"     // 整数秒、小数なし
+< 60min → "1m 23s"
+≥ 60min → "1h 5m"
+```
+
+A 用 (run elapsed) は >= 1s 想定だから "12s" / "1m 23s" / "1h 5m"。  
+B 用 (tool elapsed) は < 1s も出るので "0.3s" 表記を使う。
+
+### UI 配置
+
+`ToolResultsPanel.vue` の `<!-- Thinking indicator -->` ブロック内:
+
+- (A) statusMessage の右に "· 1m 23s" 形式で追加
+- (B) 各 pending call 行の末尾に "· 2.3s" 形式で追加
+
+色は既存の text-gray-400 / 500 をそのまま使う。新しい i18n キーは不要 (時間表記は数字のみ)。
+
+## 副作用範囲
+
+- バックエンド: **変更なし**
+- API スキーマ: **変更なし**
+- 型定義: **変更なし** (composable の返り値型のみ追加)
+- i18n: **変更なし** (時間フォーマットは locale-independent)
+- 既存テスト: **影響なし** (既存の表示は維持、追加要素のみ)
+
+## テスト
+
+### 1. `formatElapsed` 単体テスト (`test/utils/agent/test_formatElapsed.ts`)
+
+- 0ms / 100ms / 999ms (sub-second)
+- 1s / 12s / 59s
+- 60s / 90s / 3599s
+- 3600s / 3660s / 7200s
+- 負の値 (defensive — 0s 表示)
+
+### 2. `useRunElapsed` composable 単体テスト (`test/composables/test_useRunElapsed.ts`)
+
+- isRunning false→true で startedAt セット、tick 開始
+- isRunning true→false で interval clear、elapsedMs 更新停止
+- teardown() で interval cleanup
+- (時間進行は `setInterval` を fake timer でテスト or 簡略化)
+
+### 3. e2e: 既存の todo / chat スペックは動作維持を確認 (CI のみ、手動 e2e は本 PR で追加しない)
+
+## ロールアウトリスク
+
+低。UI 表示の追加のみ。最悪ケースでも既存の Thinking indicator が壊れることはなく、追加要素の表示だけが落ちる。
+
+## #731 のクローズ
+
+PR2 がマージされたら #731 をクローズ。コメントで:
+
+- ✅ PR1: Stop button (#786)
+- ✅ PR2: elapsed time + per-tool elapsed (本 PR)
+- ⚠️ PR3: mid-flight 追加指示 — バックエンド変更が大きいので別 issue で改めて検討
+
+## Items to Confirm / Review
+
+- 1秒粒度の `setInterval` の cost (単一 session、ほぼ無視できるが一応書いておく)
+- 表示位置が混雑しないか (statusMessage が長い locale だと窮屈になる可能性)
+- 60min 超のエージェント runs は実在するか? (ある — scheduler 経由の長時間タスクなど)

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,6 +92,7 @@
           :result-timestamps="activeSession?.resultTimestamps ?? new Map()"
           :is-running="activeSessionRunning"
           :status-message="statusMessage"
+          :run-elapsed-ms="runElapsedMs"
           :pending-calls="pendingCalls"
           :session-role-name="sessionRoleName"
           :session-role-icon="sessionRoleIcon"
@@ -250,6 +251,7 @@ import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
 import { resolveNotificationTarget } from "./utils/notification/dispatch";
 import { usePendingCalls } from "./composables/usePendingCalls";
+import { useRunElapsed } from "./composables/useRunElapsed";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
 import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
@@ -531,6 +533,13 @@ const { availableTools, toolDescriptions, mcpToolsError, fetchMcpToolsStatus } =
 const { pendingCalls, teardown: teardownPendingCalls } = usePendingCalls({
   isRunning: activeSessionRunning,
   toolCallHistory,
+});
+
+// Run-level elapsed time for the Thinking indicator (#731 PR2).
+// Pure UI: ticks once per second while the active session is running,
+// flips back to null on completion. No backend or schema changes.
+const { elapsedMs: runElapsedMs, teardown: teardownRunElapsed } = useRunElapsed({
+  isRunning: activeSessionRunning,
 });
 
 const selectedResult = computed(() => toolResults.value.find((result) => result.uuid === selectedResultUuid.value) ?? null);
@@ -901,7 +910,10 @@ provideActiveSession(activeSession);
 
 useEventListeners({
   onKeyNavigation: handleKeyNavigation,
-  onTeardown: teardownPendingCalls,
+  onTeardown: () => {
+    teardownPendingCalls();
+    teardownRunElapsed();
+  },
 });
 
 onMounted(async () => {

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -54,11 +54,15 @@
             <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 150ms" />
             <span class="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 300ms" />
           </span>
+          <span v-if="runElapsedMs !== null && runElapsedMs >= 1000" class="text-xs text-gray-400 tabular-nums" data-testid="run-elapsed">
+            · {{ formatElapsed(runElapsedMs) }}
+          </span>
         </div>
         <div v-if="pendingCalls.length > 0" class="mt-1 space-y-0.5">
           <div v-for="call in pendingCalls" :key="call.toolUseId" class="flex items-center gap-1.5 text-xs text-gray-400">
             <span class="w-1.5 h-1.5 rounded-full bg-blue-300 shrink-0 animate-pulse" />
             <span class="font-mono truncate">{{ call.toolName }}</span>
+            <span class="text-xs text-gray-300 tabular-nums shrink-0">· {{ formatElapsed(call.elapsedMs) }}</span>
           </div>
         </div>
       </div>
@@ -72,6 +76,7 @@ import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
+import { formatElapsed } from "../utils/agent/formatElapsed";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
 import type { LayoutMode } from "../utils/canvas/layoutMode";
 
@@ -85,6 +90,10 @@ function sourceLabel(result: ToolResultComplete): string {
 interface PendingCall {
   toolUseId: string;
   toolName: string;
+  // Milliseconds since the call started — driven by the 50ms tick in
+  // `usePendingCalls`, so the rendered "· 2.3s" badge updates without
+  // the consumer needing its own ticker.
+  elapsedMs: number;
 }
 
 defineProps<{
@@ -93,6 +102,13 @@ defineProps<{
   resultTimestamps: Map<string, number>;
   isRunning: boolean;
   statusMessage: string;
+  /**
+   * How long the active agent run has been going. `null` while idle
+   * (or for the first <1s, gated in the template so the badge appears
+   * only after a meaningful delay). Updates once per second via
+   * `useRunElapsed`.
+   */
+  runElapsedMs: number | null;
   pendingCalls: PendingCall[];
   sessionRoleName?: string;
   sessionRoleIcon?: string;

--- a/src/components/ToolResultsPanel.vue
+++ b/src/components/ToolResultsPanel.vue
@@ -45,8 +45,10 @@
         <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
       </div>
 
-      <!-- Thinking indicator -->
-      <div v-if="isRunning" class="px-2 py-1 text-sm">
+      <!-- Thinking indicator. `role="status"` + polite live region so
+           screen readers announce status updates (current tool, elapsed
+           tick) without yanking focus. Codex iter-1 #798 follow-up. -->
+      <div v-if="isRunning" class="px-2 py-1 text-sm" role="status" aria-live="polite">
         <div class="flex items-center gap-2 text-gray-500">
           <span class="text-xs">{{ statusMessage }}</span>
           <span class="flex gap-1">

--- a/src/composables/usePendingCalls.ts
+++ b/src/composables/usePendingCalls.ts
@@ -59,7 +59,17 @@ export function usePendingCalls(opts: UsePendingCallsOptions) {
     // unused.
     const __tickDep = displayTick.value;
     const now = Date.now();
-    return opts.toolCallHistory.value.filter((entry) => __tickDep >= 0 && isCallStillPending(entry, now));
+    // Project to a narrower shape that carries `elapsedMs` so the
+    // consumer doesn't need its own ticker for the per-tool badge —
+    // the 50ms re-evaluation here already drives the display
+    // (#731 PR2).
+    return opts.toolCallHistory.value
+      .filter((entry) => __tickDep >= 0 && isCallStillPending(entry, now))
+      .map((entry) => ({
+        toolUseId: entry.toolUseId,
+        toolName: entry.toolName,
+        elapsedMs: now - entry.timestamp,
+      }));
   });
 
   function teardown(): void {

--- a/src/composables/useRunElapsed.ts
+++ b/src/composables/useRunElapsed.ts
@@ -1,0 +1,73 @@
+// Tracks how long the active agent run has been going. While
+// `isRunning` is true, `elapsedMs` updates once per second so the
+// rendered string ("12s" / "1m 23s") moves visibly. When the run
+// ends, `elapsedMs` flips back to null and the timer is cleared.
+//
+// Separated from `usePendingCalls` (which ticks every 50ms for the
+// minimum-visible-duration trick) — the run-elapsed display only
+// needs second-granularity, and the consumer renders one badge per
+// run rather than one per pending row, so a tighter tick would just
+// burn re-renders.
+//
+// Why a watcher + setInterval rather than a `requestAnimationFrame`
+// driven computed: tab-throttled rAF freezes when the tab is in the
+// background, and the user expects the elapsed counter to keep
+// running across tab switches.
+
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+
+const ONE_SECOND_MS = 1000;
+
+interface UseRunElapsedOptions {
+  isRunning: ComputedRef<boolean> | Ref<boolean>;
+}
+
+export function useRunElapsed(opts: UseRunElapsedOptions): {
+  elapsedMs: ComputedRef<number | null>;
+  teardown: () => void;
+} {
+  const startedAt = ref<number | null>(null);
+  const now = ref(0);
+  let interval: ReturnType<typeof setInterval> | null = null;
+
+  watch(
+    opts.isRunning,
+    (running) => {
+      if (running) {
+        // Guard against double-start: if the watcher fires twice with
+        // running=true (e.g. immediate + a synchronous flip), don't
+        // stack a second interval.
+        if (interval !== null) return;
+        startedAt.value = Date.now();
+        now.value = startedAt.value;
+        interval = setInterval(() => {
+          now.value = Date.now();
+        }, ONE_SECOND_MS);
+        return;
+      }
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+      startedAt.value = null;
+    },
+    // immediate so a composable created while a run is already in
+    // flight (mounted mid-stream) starts ticking right away.
+    { immediate: true },
+  );
+
+  const elapsedMs = computed<number | null>(() => {
+    if (startedAt.value === null) return null;
+    return now.value - startedAt.value;
+  });
+
+  function teardown(): void {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+    startedAt.value = null;
+  }
+
+  return { elapsedMs, teardown };
+}

--- a/src/composables/useRunElapsed.ts
+++ b/src/composables/useRunElapsed.ts
@@ -14,7 +14,7 @@
 // background, and the user expects the elapsed counter to keep
 // running across tab switches.
 
-import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { computed, ref, watch, type ComputedRef, type Ref, type WatchStopHandle } from "vue";
 
 const ONE_SECOND_MS = 1000;
 
@@ -29,8 +29,9 @@ export function useRunElapsed(opts: UseRunElapsedOptions): {
   const startedAt = ref<number | null>(null);
   const now = ref(0);
   let interval: ReturnType<typeof setInterval> | null = null;
+  let stopWatch: WatchStopHandle | null = null;
 
-  watch(
+  stopWatch = watch(
     opts.isRunning,
     (running) => {
       if (running) {
@@ -62,6 +63,12 @@ export function useRunElapsed(opts: UseRunElapsedOptions): {
   });
 
   function teardown(): void {
+    // Stop the watcher first — otherwise an isRunning flip after
+    // teardown would recreate the interval (Codex iter-1 #798).
+    if (stopWatch !== null) {
+      stopWatch();
+      stopWatch = null;
+    }
     if (interval !== null) {
       clearInterval(interval);
       interval = null;

--- a/src/utils/agent/formatElapsed.ts
+++ b/src/utils/agent/formatElapsed.ts
@@ -1,0 +1,33 @@
+// Render a millisecond duration as a short, human-readable string for
+// the Thinking indicator. Granularity adapts to the magnitude — sub-
+// second elapsed (typical for fast tool calls) shows one decimal so
+// the user sees movement; minutes/hours collapse to the largest two
+// units so the line stays compact.
+//
+// Used by the agent run-elapsed counter (#731 PR2) and the per-tool
+// elapsed badge in `ToolResultsPanel.vue`.
+
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+
+export function formatElapsed(elapsedMs: number): string {
+  // Defensive: clamp negatives to zero so a clock-skew or stale-tick
+  // race never renders "-0s".
+  const elapsed = elapsedMs > 0 ? elapsedMs : 0;
+  if (elapsed < ONE_SECOND_MS) {
+    const seconds = elapsed / ONE_SECOND_MS;
+    return `${seconds.toFixed(1)}s`;
+  }
+  if (elapsed < ONE_MINUTE_MS) {
+    return `${Math.floor(elapsed / ONE_SECOND_MS)}s`;
+  }
+  if (elapsed < ONE_HOUR_MS) {
+    const minutes = Math.floor(elapsed / ONE_MINUTE_MS);
+    const seconds = Math.floor((elapsed % ONE_MINUTE_MS) / ONE_SECOND_MS);
+    return `${minutes}m ${seconds}s`;
+  }
+  const hours = Math.floor(elapsed / ONE_HOUR_MS);
+  const minutes = Math.floor((elapsed % ONE_HOUR_MS) / ONE_MINUTE_MS);
+  return `${hours}h ${minutes}m`;
+}

--- a/src/utils/agent/formatElapsed.ts
+++ b/src/utils/agent/formatElapsed.ts
@@ -16,8 +16,12 @@ export function formatElapsed(elapsedMs: number): string {
   // race never renders "-0s".
   const elapsed = elapsedMs > 0 ? elapsedMs : 0;
   if (elapsed < ONE_SECOND_MS) {
-    const seconds = elapsed / ONE_SECOND_MS;
-    return `${seconds.toFixed(1)}s`;
+    // Floor to one decimal so the badge never reads ahead of the
+    // clock — `toFixed(1)` rounds half-up and would render 999ms as
+    // "1.0s" (Codex iter-1 #798). Keep the integer-second branch's
+    // "floor not round" rule consistent here.
+    const tenths = Math.floor(elapsed / 100);
+    return `${(tenths / 10).toFixed(1)}s`;
   }
   if (elapsed < ONE_MINUTE_MS) {
     return `${Math.floor(elapsed / ONE_SECOND_MS)}s`;

--- a/test/composables/test_useRunElapsed.ts
+++ b/test/composables/test_useRunElapsed.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { effectScope, nextTick, ref } from "vue";
+import { useRunElapsed } from "../../src/composables/useRunElapsed.js";
+
+// State-transition tests. We don't pin exact tick values (that would
+// be flaky against a real `setInterval`); instead we assert the
+// composable's contract: null while idle, non-null while running,
+// teardown safe to call multiple times. The format/cadence of the
+// rendered string is covered by `test_formatElapsed.ts`.
+
+function withScope<T>(setup: () => T): { result: T; dispose: () => void } {
+  const scope = effectScope();
+  const result = scope.run(setup) as T;
+  return { result, dispose: () => scope.stop() };
+}
+
+describe("useRunElapsed", () => {
+  it("starts as null when isRunning is false", async () => {
+    const isRunning = ref(false);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    await nextTick();
+    assert.equal(result.elapsedMs.value, null);
+    result.teardown();
+    dispose();
+  });
+
+  it("transitions to a non-negative number once isRunning flips true", async () => {
+    const isRunning = ref(false);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    await nextTick();
+    isRunning.value = true;
+    await nextTick();
+    const elapsed = result.elapsedMs.value;
+    assert.notEqual(elapsed, null);
+    assert.ok(elapsed !== null && elapsed >= 0, `expected non-negative elapsedMs, got ${elapsed}`);
+    result.teardown();
+    dispose();
+  });
+
+  it("flips back to null when isRunning goes false", async () => {
+    const isRunning = ref(true);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    // immediate watcher already started the run on creation
+    await nextTick();
+    assert.notEqual(result.elapsedMs.value, null);
+    isRunning.value = false;
+    await nextTick();
+    assert.equal(result.elapsedMs.value, null);
+    result.teardown();
+    dispose();
+  });
+
+  it("immediate-watch starts the run if isRunning is already true at creation", async () => {
+    // A composable mounted mid-stream must observe the running state
+    // right away rather than wait for the next isRunning flip.
+    const isRunning = ref(true);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    await nextTick();
+    assert.notEqual(result.elapsedMs.value, null);
+    result.teardown();
+    dispose();
+  });
+
+  it("guards against double-start (rapid true→true watcher fires don't stack intervals)", async () => {
+    // We can't directly observe the interval count, but we can sanity-
+    // check that elapsedMs stays monotonic and non-null across the
+    // re-trigger — if a stacked interval doubled the start time, the
+    // first reading after the re-trigger would jump backward.
+    const isRunning = ref(false);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    await nextTick();
+    isRunning.value = true;
+    await nextTick();
+    const first = result.elapsedMs.value;
+    // Re-flip true → no-op should occur (watcher fires but if-guard
+    // returns early). Force a synchronous flip to provoke the case.
+    isRunning.value = false;
+    isRunning.value = true;
+    await nextTick();
+    const second = result.elapsedMs.value;
+    assert.notEqual(first, null);
+    assert.notEqual(second, null);
+    result.teardown();
+    dispose();
+  });
+
+  it("teardown is idempotent — safe to call twice", () => {
+    const isRunning = ref(true);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    // Two teardowns in a row must not throw or double-clear.
+    result.teardown();
+    result.teardown();
+    assert.equal(result.elapsedMs.value, null);
+    dispose();
+  });
+
+  it("teardown after never-started run is safe", () => {
+    const isRunning = ref(false);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    // Composable created, but isRunning never flipped true. Teardown
+    // must still no-op cleanly.
+    result.teardown();
+    assert.equal(result.elapsedMs.value, null);
+    dispose();
+  });
+});

--- a/test/composables/test_useRunElapsed.ts
+++ b/test/composables/test_useRunElapsed.ts
@@ -104,4 +104,26 @@ describe("useRunElapsed", () => {
     assert.equal(result.elapsedMs.value, null);
     dispose();
   });
+
+  it("teardown stops the watcher — a later isRunning flip cannot recreate the timer (Codex iter-1 #798)", async () => {
+    // Pre-fix: teardown only cleared the current interval; the
+    // watcher stayed live, so a subsequent isRunning flip would
+    // recreate the timer and elapsedMs would start updating again
+    // — defeating the "final cleanup" contract of teardown().
+    const isRunning = ref(true);
+    const { result, dispose } = withScope(() => useRunElapsed({ isRunning }));
+    await nextTick();
+    assert.notEqual(result.elapsedMs.value, null);
+    result.teardown();
+    assert.equal(result.elapsedMs.value, null);
+    // Flip isRunning after teardown — watcher must be stopped, so
+    // elapsedMs must STAY null. Pre-fix this would have flipped to
+    // a number again.
+    isRunning.value = false;
+    await nextTick();
+    isRunning.value = true;
+    await nextTick();
+    assert.equal(result.elapsedMs.value, null, "watcher must be stopped after teardown");
+    dispose();
+  });
 });

--- a/test/utils/agent/test_formatElapsed.ts
+++ b/test/utils/agent/test_formatElapsed.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatElapsed } from "../../../src/utils/agent/formatElapsed.js";
+
+describe("formatElapsed", () => {
+  describe("sub-second", () => {
+    it("renders 0ms as '0.0s'", () => {
+      // Exact-zero is the boundary for the negative-clamp; render it
+      // as 0.0s so the format is consistent with "0.3s", "0.7s".
+      assert.equal(formatElapsed(0), "0.0s");
+    });
+
+    it("rounds 100ms to one decimal", () => {
+      assert.equal(formatElapsed(100), "0.1s");
+    });
+
+    it("rounds 333ms to one decimal", () => {
+      // toFixed(1) uses banker's rounding edge cases, but 333/1000 =
+      // 0.333 → "0.3" deterministically.
+      assert.equal(formatElapsed(333), "0.3s");
+    });
+
+    it("rounds 999ms to '1.0s' (boundary still in the sub-second branch)", () => {
+      // 999 / 1000 = 0.999 → toFixed(1) → "1.0". Not ideal but the
+      // alternative (special-case the rounding) costs more than it
+      // saves; the very next tick promotes us to the integer-second
+      // branch anyway.
+      assert.equal(formatElapsed(999), "1.0s");
+    });
+  });
+
+  describe("seconds (1s ≤ t < 60s)", () => {
+    it("drops the decimal and uses integer seconds", () => {
+      assert.equal(formatElapsed(1000), "1s");
+      assert.equal(formatElapsed(12_300), "12s");
+      assert.equal(formatElapsed(59_999), "59s");
+    });
+
+    it("floors rather than rounds (so the badge never reads ahead of the clock)", () => {
+      // 12.999s → "12s" not "13s". Users tracking elapsed expect the
+      // counter to lag at most 1s, not jump ahead.
+      assert.equal(formatElapsed(12_999), "12s");
+    });
+  });
+
+  describe("minutes (1m ≤ t < 60m)", () => {
+    it("renders 'Xm Ys' at the minute boundary", () => {
+      assert.equal(formatElapsed(60_000), "1m 0s");
+    });
+
+    it("preserves both components when both are non-zero", () => {
+      assert.equal(formatElapsed(83_000), "1m 23s");
+    });
+
+    it("renders 59m 59s as the upper boundary", () => {
+      assert.equal(formatElapsed(60 * 60_000 - 1000), "59m 59s");
+    });
+  });
+
+  describe("hours (≥ 60m)", () => {
+    it("collapses to 'Xh Ym' at the hour boundary", () => {
+      // No seconds component: hours/minutes is enough resolution at
+      // this scale and the line stays compact.
+      assert.equal(formatElapsed(60 * 60_000), "1h 0m");
+    });
+
+    it("renders 1h 5m correctly", () => {
+      assert.equal(formatElapsed(60 * 60_000 + 5 * 60_000), "1h 5m");
+    });
+
+    it("renders multi-digit hours (long-running scheduler runs)", () => {
+      assert.equal(formatElapsed(12 * 60 * 60_000 + 30 * 60_000), "12h 30m");
+    });
+  });
+
+  describe("defensive — negative input", () => {
+    it("clamps negatives to zero (clock skew / stale tick safety)", () => {
+      // A stale tick that fires after `now` advances less than the
+      // accumulator can theoretically yield a negative; we'd rather
+      // render "0.0s" than "-3.4s".
+      assert.equal(formatElapsed(-1), "0.0s");
+      assert.equal(formatElapsed(-12_345), "0.0s");
+    });
+  });
+});

--- a/test/utils/agent/test_formatElapsed.ts
+++ b/test/utils/agent/test_formatElapsed.ts
@@ -20,12 +20,17 @@ describe("formatElapsed", () => {
       assert.equal(formatElapsed(333), "0.3s");
     });
 
-    it("rounds 999ms to '1.0s' (boundary still in the sub-second branch)", () => {
-      // 999 / 1000 = 0.999 → toFixed(1) → "1.0". Not ideal but the
-      // alternative (special-case the rounding) costs more than it
-      // saves; the very next tick promotes us to the integer-second
-      // branch anyway.
-      assert.equal(formatElapsed(999), "1.0s");
+    it("floors 999ms to '0.9s' (Codex iter-1 #798 — never read ahead of the clock)", () => {
+      // Pre-fix: this rendered "1.0s" because `toFixed(1)` rounds
+      // half-up. The integer-seconds branch already follows a
+      // floor-not-round rule (see test below); the sub-second branch
+      // is now consistent — 999ms stays "0.9s" until the very next
+      // tick promotes to the integer-second branch.
+      assert.equal(formatElapsed(999), "0.9s");
+    });
+
+    it("floors 950ms to '0.9s' (no half-up rounding into the next tenth)", () => {
+      assert.equal(formatElapsed(950), "0.9s");
     });
   });
 


### PR DESCRIPTION
## Summary

- 既存の "Thinking…" インジケーター隣に **run 全体の経過時間** (\`· 1m 23s\`) と **実行中ツール毎の経過時間** (\`· 2.3s\`) を追加。長時間タスクが動いていることが目視できる。
- バックエンド・型・API スキーマ・i18n 全て**未変更**。フロント UI のみ。
- 新コンポーザブル \`useRunElapsed\` (1s 刻み) + 既存 \`usePendingCalls\` の返却値を per-tool elapsed 込みに narrow projection。
- 新 pure helper \`formatElapsed(ms)\` で magnitude-adaptive 表記 (\`0.3s\` / \`12s\` / \`1m 23s\` / \`1h 5m\`)。

## Items to Confirm / Review

- **副作用範囲ゼロ確認**: server / schema / type 変更は本当にゼロか? \`grep\` で既存 \`pendingCalls\` 利用箇所が ToolResultsPanel.vue 1ヶ所だけであることは確認済 (App.vue → ToolResultsPanel.vue → 表示のみ)。
- **1s tick の cost**: アクティブ session 1つにつき 1個の setInterval。ほぼ無視できるが、tab 非アクティブ時も走り続ける選択をしている (rAF だと throttle されて経過カウンタが止まるため)。
- **runElapsedMs >= 1000 ガード**: 1秒未満は表示しない。素早く返ってくる返答で 0s が一瞬光るのを防止。
- **per-tool elapsed の駆動**: 既存の 50ms displayTick (usePendingCalls) を流用。新規 timer なし。
- **format 整数 floor**: 12.999s → "12s" にする (round だと badge が秒針より先に進むのでユーザの体感と合わない)。
- **負の値の clamp**: stale tick race の防御で \`-X\` 入力は \`0.0s\` に丸める。
- **テスト**: \`formatElapsed\` 14ケース (各 magnitude band / boundary / floor / clamp) + \`useRunElapsed\` 7ケース (state transitions / immediate-watch / double-start guard / teardown idempotency)。

## User Prompt

> 731の続きってなにかできる？副作用内レベルで。
> AB セット実装して閉じよう。

(B 相当の "実行中ツール名表示" は実は既に \`pendingCalls\` リストとして存在していたので、本 PR では polish として **per-tool 経過時間を追加**。A の "経過時間" は新規実装。実質これで PR2 のスコープが完了。)

## Implementation

| File | Change |
|---|---|
| \`src/utils/agent/formatElapsed.ts\` (new) | Pure helper. 4段階の magnitude band、defensive negative clamp。|
| \`src/composables/useRunElapsed.ts\` (new) | \`isRunning\` watcher + 1s setInterval。\`{elapsedMs, teardown}\` を返す。 |
| \`src/composables/usePendingCalls.ts\` | 返却 shape を \`{toolUseId, toolName, elapsedMs}[]\` に narrow projection。50ms tick が既に動いているので elapsed が自動的に追従する。 |
| \`src/components/ToolResultsPanel.vue\` | Thinking indicator の \<div\> に run-level + per-tool の elapsed badge を追加。\`runElapsedMs\` prop を追加。 |
| \`src/App.vue\` | \`useRunElapsed\` を呼び出し \`runElapsedMs\` を ToolResultsPanel に渡す。teardown を既存の \`useEventListeners\` cleanup と合体。 |
| \`test/utils/agent/test_formatElapsed.ts\` (new) | 14 cases。 |
| \`test/composables/test_useRunElapsed.ts\` (new) | 7 cases (effectScope ベース)。 |

Plan: \`plans/feat-agent-elapsed-time-731.md\`。

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` (only pre-existing v-html warnings, 0 errors)
- [x] \`yarn typecheck\`
- [x] \`yarn build\`
- [x] \`yarn test\` — 3062/3062 pass (+20 new tests)
- [ ] CI lint_test matrix (Node 22.x / 24.x × ubuntu / macos / windows)
- [ ] CI e2e (Playwright)
- [ ] Manual: 長時間 agent run で経過時間が秒単位で更新されること確認
- [ ] Manual: ツール実行中の per-tool elapsed が更新されること確認
- [ ] Manual: 1秒未満で完了するクイック応答で run-level badge が出ないこと確認

## #731 Closing Plan

このPRがマージされたら #731 をクローズ:
- ✅ PR1 (#786): Stop button
- ✅ PR2 (本 PR): elapsed time + per-tool elapsed
- ⚠️ PR3 (将来): mid-flight 追加指示 — message-queue のバックエンド変更が必要なので別 issue で改めて検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display total agent run elapsed time and per-tool elapsed time during long-running agent execution
  * Show elapsed time badges in the UI alongside pending tool operations
  * Support automatic time formatting with human-readable intervals (seconds, minutes, hours)

* **Tests**
  * Added comprehensive test coverage for elapsed time tracking and formatting logic to ensure accuracy and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->