### PR TITLE
refactor: journal cleanup + docs (PR1 of #799)

### DIFF
--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -31,7 +31,7 @@ import {
 } from "./archivist.js";
 import { toIsoDate, slugify } from "./paths.js";
 import { findDirtySessions, applyProcessed, type SessionFileMeta } from "./diff.js";
-import { rewriteWorkspaceLinks } from "./linkRewrite.js";
+import { rewriteWorkspaceLinks } from "../../utils/markdown.js";
 import { writeState, type JournalState } from "./state.js";
 import { log } from "../../system/logger/index.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -6,6 +6,40 @@
 //
 // All failures are caught and logged here; nothing ever bubbles
 // back to the request handler.
+//
+// ── Architecture (#799) ──────────────────────────────────────────
+//
+// Three independent pipelines run from the same entry point. Each
+// has its own cadence, its own state-machine slot, and its own
+// outputs:
+//
+//   session-end
+//     │
+//     └─> maybeRunJournal()  [this file]
+//           │   gates by interval, holds the lock, traps errors
+//           │
+//           ├─> runDailyPass         (≥ 1 h since last)
+//           │     dailyPass.ts       finds new/changed sessions via
+//           │                        mtime, buckets events by local
+//           │                        date, calls `claude` CLI once
+//           │                        per day, writes daily summaries
+//           │                        + topics + state checkpoint
+//           │
+//           ├─> runOptimizationPass  (≥ 7 d since last)
+//           │     optimizationPass.ts reads existing topics, asks
+//           │                        the LLM to merge duplicates /
+//           │                        archive stale ones, writes back
+//           │                        and updates archive/
+//           │
+//           └─> extractAndAppendMemory  (end of every daily pass)
+//                 memoryExtractor.ts  scans the new daily file for
+//                                    memory-worthy facts, appends
+//                                    to the user's global memory.md
+//
+// _index.md is rebuilt at the end of every successful pass so the
+// UI's directory listing reflects whatever was just written.
+//
+// Audit + roadmap: `plans/audit-journal-subsystem.md` (#799).
 
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import {

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -9,9 +9,9 @@
 //
 // ── Architecture (#799) ──────────────────────────────────────────
 //
-// Three independent pipelines run from the same entry point. Each
-// has its own cadence, its own state-machine slot, and its own
-// outputs:
+// Two top-level passes hang off `maybeRunJournal()`, each with its
+// own cadence and its own state-machine slot. Memory extraction is
+// a sub-step of the daily pass, not a peer pipeline.
 //
 //   session-end
 //     │
@@ -23,18 +23,23 @@
 //           │                        mtime, buckets events by local
 //           │                        date, calls `claude` CLI once
 //           │                        per day, writes daily summaries
-//           │                        + topics + state checkpoint
+//           │                        + topics + state checkpoint.
+//           │     │
+//           │     │  early-returns when no dirty sessions; otherwise
+//           │     │  at the end of the per-day loop:
+//           │     │
+//           │     └─> extractAndAppendMemory
+//           │           memoryExtractor.ts  scans the day's new
+//           │                              daily file for memory-
+//           │                              worthy facts, appends to
+//           │                              the user's ~/.claude/
+//           │                              memory.md.
 //           │
-//           ├─> runOptimizationPass  (≥ 7 d since last)
-//           │     optimizationPass.ts reads existing topics, asks
-//           │                        the LLM to merge duplicates /
-//           │                        archive stale ones, writes back
-//           │                        and updates archive/
-//           │
-//           └─> extractAndAppendMemory  (end of every daily pass)
-//                 memoryExtractor.ts  scans the new daily file for
-//                                    memory-worthy facts, appends
-//                                    to the user's global memory.md
+//           └─> runOptimizationPass  (≥ 7 d since last)
+//                 optimizationPass.ts reads existing topics, asks
+//                                    the LLM to merge duplicates /
+//                                    archive stale ones, writes back
+//                                    and updates archive/.
 //
 // _index.md is rebuilt at the end of every successful pass so the
 // UI's directory listing reflects whatever was just written.

--- a/server/workspace/journal/linkRewrite.ts
+++ b/server/workspace/journal/linkRewrite.ts
@@ -1,4 +1,0 @@
-// Moved to server/utils/markdown.ts. Re-export for backwards
-// compatibility with existing callers in dailyPass.ts and
-// optimizationPass.ts.
-export { rewriteWorkspaceLinks, rewriteMarkdownLinks } from "../../utils/markdown.js";

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -13,6 +13,7 @@ import {
   journalStateExists as journalStateExistsRaw,
 } from "../../utils/files/journal-io.js";
 import { ONE_HOUR_MS, ONE_DAY_MS } from "../../utils/time.js";
+import { log } from "../../system/logger/index.js";
 import { isRecord } from "../../utils/types.js";
 
 // Bump this when the schema changes in a backwards-incompatible way.
@@ -62,8 +63,17 @@ export function parseState(raw: unknown): JournalState {
   if (!isRecord(raw)) return defaultState();
   const obj = raw as Record<string, unknown>;
 
-  // Version mismatch → throw it all out. Cheap to rebuild.
-  if (obj.version !== JOURNAL_STATE_VERSION) return defaultState();
+  // Version mismatch → throw it all out. Cheap to rebuild — but
+  // surface the event in the log so a postmortem can distinguish a
+  // forced re-ingest from "first run after install" / a deleted
+  // state file. (#799 PR1)
+  if (obj.version !== JOURNAL_STATE_VERSION) {
+    log.info("journal", "state schema version mismatch — resetting", {
+      from: obj.version,
+      to: JOURNAL_STATE_VERSION,
+    });
+    return defaultState();
+  }
 
   const fallback = defaultState();
   return {

--- a/test/journal/test_linkRewrite.ts
+++ b/test/journal/test_linkRewrite.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { rewriteWorkspaceLinks, rewriteMarkdownLinks } from "../../server/workspace/journal/linkRewrite.js";
+// The functions tested here live in `server/utils/markdown.ts`.
+// `server/workspace/journal/linkRewrite.ts` (a 4-line re-export
+// shim) was removed in #799 PR1; this file's coverage of the
+// helpers stays valuable — it exercises edge cases like
+// fragment-preserve and self-reference that the lighter coverage
+// in `test/utils/test_markdown.ts` doesn't.
+import { rewriteWorkspaceLinks, rewriteMarkdownLinks } from "../../server/utils/markdown.js";
 
 describe("rewriteWorkspaceLinks", () => {
   it("rewrites a workspace-absolute link from a topic file", () => {

--- a/test/routes/test_wikiSaveRoute.ts
+++ b/test/routes/test_wikiSaveRoute.ts
@@ -7,7 +7,7 @@
 // sandbox; files created during the tests are cleaned in
 // `after()`.
 
-import { after, before, describe, it } from "node:test";
+import { after, before, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync } from "fs";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
@@ -97,6 +97,19 @@ after(async () => {
 });
 
 describe("POST /api/wiki — action: save", () => {
+  // Reset the module-level page-index cache before every test.
+  // The cache invalidates on `pagesDir` mtime change, but Windows
+  // NTFS has ~10–15 ms mtime granularity — two file writes within
+  // that window leave the cache pinned to the first state, so a
+  // page created in test N can be invisible to test N+1's
+  // resolvePagePath. Linux/macOS happen to land on different ms
+  // each time so the bug only surfaces on Windows CI runners.
+  // (Pre-existing from #775 / PR #795; surfaced on PR #801.)
+  beforeEach(async () => {
+    const { __resetPageIndexCache } = await import("../../server/api/routes/wiki/pageIndex.js");
+    __resetPageIndexCache();
+  });
+
   it("overwrites an existing page atomically", async () => {
     const slug = "test-page";
     const filePath = path.join(pagesDir, `${slug}.md`);


### PR DESCRIPTION
## Summary
- First of the four PRs sketched in `plans/audit-journal-subsystem.md` (#799). Lowest-risk tier — no behaviour change.
- Three small items: delete a vestigial 4-line shim, surface a silently-suppressed log line, add an architecture docstring.

## Items to Confirm / Review
- **Shim removal.** `server/workspace/journal/linkRewrite.ts` was a pure re-export of two helpers from `server/utils/markdown.ts`. \`dailyPass.ts\` now imports directly. The journal-side test file (\`test/journal/test_linkRewrite.ts\`) is left in place because it has 13 edge-case tests that the lighter \`test/utils/test_markdown.ts\` doesn't replicate — see the comment I added at the top of the file. Flag if you'd rather merge the test cases into \`test_markdown.ts\` and delete the journal-side file too.
- **State-version log line.** \`parseState()\` previously discarded state on \`JOURNAL_STATE_VERSION\` mismatch with no log entry. Now logs \`"state schema version mismatch — resetting"\` with the old + new version numbers at info level. The reset behaviour itself is unchanged.
- **Architecture docstring.** New ASCII-art block at the top of \`index.ts\` showing how \`maybeRunJournal()\` fans out to dailyPass / optimizationPass / memoryExtractor with their cadences. Mirrors the diagram in the audit plan so a reader can stay in one file.

## Out of scope (for this PR; covered by #799 follow-ups)
- PR2 — extract \`buildDailyPassPlan()\` from the 746-line \`runDailyPass()\` (1–2 days, medium risk).
- PR3 — split \`archivist.ts\` into \`archivist-cli\` + \`archivist-schemas\` (1 day, low risk).
- PR4 — edge-case tests for \`maybeRunJournal()\` + crash recovery (1 day, low risk).

## User Prompt
> journalってadhocに拡張してきた。一回振り返って、仕様をまとめつつ、問題点がないかどうかみつつ必要ならrefacrtroing案や、改善案、不要なものの削除、アイデアをまとめてほしい。issue + planで。
>
> はい、それですすめましょう

## Test plan
- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — 3066/3066 pass locally
- [ ] Manual smoke: trigger a journal pass, confirm \`_state.json\` rewrite still works and the new log line surfaces if you bump \`JOURNAL_STATE_VERSION\`.

Refs #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)