### PR TITLE
fix(test): comment out notify-tool happy-path tests that fire real macOS Reminders

### DIFF
--- a/test/agent/test_notify_tool.ts
+++ b/test/agent/test_notify_tool.ts
@@ -23,27 +23,33 @@ describe("notify MCP tool — input validation", () => {
   });
 });
 
-describe("notify MCP tool — happy path", () => {
-  it("returns a confirmation including the title", async () => {
-    const result = await notify.handler({ title: "Build done" });
-    assert.match(result, /Notification sent: Build done/);
-  });
-
-  it("appends the body line when supplied", async () => {
-    const result = await notify.handler({ title: "Build done", body: "All 12 steps green" });
-    assert.equal(result, "Notification sent: Build done\nAll 12 steps green");
-  });
-
-  it("trims surrounding whitespace from title and body", async () => {
-    const result = await notify.handler({ title: "  hi  ", body: "  there  " });
-    assert.equal(result, "Notification sent: hi\nthere");
-  });
-
-  it("treats a whitespace-only body as missing", async () => {
-    const result = await notify.handler({ title: "hi", body: "   " });
-    assert.equal(result, "Notification sent: hi");
-  });
-});
+// Happy-path tests disabled — they call the real
+// `publishNotification`, which on darwin spawns `osascript` and adds a
+// real entry to the user's Reminders.app every time `yarn test` runs
+// (#789 follow-up). Until publishNotification is injectable into the
+// notify tool, leave these commented out.
+//
+// describe("notify MCP tool — happy path", () => {
+//   it("returns a confirmation including the title", async () => {
+//     const result = await notify.handler({ title: "Build done" });
+//     assert.match(result, /Notification sent: Build done/);
+//   });
+//
+//   it("appends the body line when supplied", async () => {
+//     const result = await notify.handler({ title: "Build done", body: "All 12 steps green" });
+//     assert.equal(result, "Notification sent: Build done\nAll 12 steps green");
+//   });
+//
+//   it("trims surrounding whitespace from title and body", async () => {
+//     const result = await notify.handler({ title: "  hi  ", body: "  there  " });
+//     assert.equal(result, "Notification sent: hi\nthere");
+//   });
+//
+//   it("treats a whitespace-only body as missing", async () => {
+//     const result = await notify.handler({ title: "hi", body: "   " });
+//     assert.equal(result, "Notification sent: hi");
+//   });
+// });
 
 describe("notify MCP tool — definition shape", () => {
   it("declares title as required and body as optional", () => {


### PR DESCRIPTION
## Summary

\`yarn test\` を darwin で走らせるたびに、\`notify\` MCP tool の happy-path テスト 4 件が **本物の \`publishNotification\` を経由して osascript を spawn し、Reminders.app に "Build done" / "hi" 等のエントリを毎回作っていた** のを発見しました(本日 18:13 周辺の Reminders スパムの一因)。

\`publishNotification\` を \`notify\` ツールに inject 可能にする refactor が入るまで、happy-path テストはコメントアウトで停止します。input-validation と definition-shape のテストは早期 return で副作用に到達しないので維持。

## Root Cause

- \`notify.handler({ title: "Build done" })\` → \`publishNotification(...)\` → \`pushToMacosReminder(...)\` → 実 osascript → 実 Reminders エントリ
- darwin + 未 opt-out → 毎回ヒット
- 4 happy-path × yarn test 走行回数だけ累積

## Fix

\`test/agent/test_notify_tool.ts\` の 4 \`it\` ブロックをコメントアウト + TODO コメント。

## Verification

\`yarn test\` を走らせても Reminders.app に新しいエントリが追加されないことを確認(input-validation 系は早期 return なので OK)。

## Follow-up issue?

\`publishNotification\` を DI 可能にして mock テストできるようにする refactor は別 issue 化可能。優先度低。

🤖 Generated with [Claude Code](https://claude.com/claude-code)