### PR TITLE
fix(wiki): i18n the task-count-mismatch error (#795 follow-up)

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -373,6 +373,8 @@ const deMessages = {
     tagFilterAll: "Alle",
     noMatches: "Keine Seiten mit dem Tag #{tag}",
     lintChat: "Wiki prüfen",
+    taskCountMismatch:
+      "Wiki-Quelle und gerendertes Ergebnis stimmen in der Anzahl der Aufgaben nicht überein. Die Umschaltung wurde abgelehnt, um eine Beschädigung der Datei zu vermeiden.",
   },
   pluginPresentHtml: {
     saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -393,6 +393,7 @@ const enMessages = {
     tagFilterAll: "All",
     noMatches: "No pages tagged #{tag}",
     lintChat: "Lint My Wiki",
+    taskCountMismatch: "Wiki source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.",
   },
   pluginPresentHtml: {
     saveAsPdf: "Save as PDF (opens print dialog)",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -379,6 +379,7 @@ const esMessages = {
     tagFilterAll: "Todas",
     noMatches: "No hay páginas con la etiqueta #{tag}",
     lintChat: "Revisar mi wiki",
+    taskCountMismatch: "La fuente del wiki y la salida renderizada difieren en el número de tareas. Se rechazó el cambio para evitar dañar el archivo.",
   },
   pluginPresentHtml: {
     saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -373,6 +373,7 @@ const frMessages = {
     tagFilterAll: "Toutes",
     noMatches: "Aucune page avec le tag #{tag}",
     lintChat: "Vérifier mon wiki",
+    taskCountMismatch: "La source du wiki et le rendu diffèrent sur le nombre de tâches. La modification a été refusée pour éviter de corrompre le fichier.",
   },
   pluginPresentHtml: {
     saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -377,6 +377,7 @@ const jaMessages = {
     tagFilterAll: "すべて",
     noMatches: "#{tag} タグのページがありません",
     lintChat: "Wiki を Lint",
+    taskCountMismatch: "Wiki ソースと描画結果でタスク数が一致しないため、ファイル破損を避けるためトグル操作を中止しました。",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -377,6 +377,7 @@ const koMessages = {
     tagFilterAll: "전체",
     noMatches: "#{tag} 태그가 달린 페이지가 없습니다",
     lintChat: "Wiki 점검",
+    taskCountMismatch: "Wiki 원본과 렌더링 결과의 작업 수가 일치하지 않아, 파일 손상을 방지하기 위해 토글이 거부되었습니다.",
   },
   pluginPresentHtml: {
     saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -372,6 +372,7 @@ const ptBRMessages = {
     tagFilterAll: "Todas",
     noMatches: "Nenhuma página com a tag #{tag}",
     lintChat: "Revisar meu wiki",
+    taskCountMismatch: "A fonte do wiki e a saída renderizada divergem no número de tarefas. A alternância foi recusada para evitar corromper o arquivo.",
   },
   pluginPresentHtml: {
     saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -373,6 +373,7 @@ const zhMessages = {
     tagFilterAll: "全部",
     noMatches: "没有带 #{tag} 标签的页面",
     lintChat: "检查 Wiki",
+    taskCountMismatch: "Wiki 源与渲染输出的任务数不一致，为避免文件损坏，已拒绝切换。",
   },
   pluginPresentHtml: {
     saveAsPdf: "另存为 PDF(打开打印对话框)",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -589,7 +589,7 @@ function computeToggledContent(target: HTMLInputElement, root: HTMLElement): str
   const { prefix, body } = splitFrontmatter();
   const sourceTasks = findTaskLines(body);
   if (sourceTasks.length !== taskInputs.length) {
-    navError.value = "Wiki source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.";
+    navError.value = t("pluginWiki.taskCountMismatch");
     return null;
   }
   const updatedBody = toggleTaskAt(body, taskIndex);


### PR DESCRIPTION
## Summary

CodeRabbit flagged `src/plugins/wiki/View.vue:592` on PR #795 for a hardcoded English string set onto `navError.value` (rendered as a user-visible banner). Mirrors the markdown-plugin fix landed in #778: extract to `pluginWiki.taskCountMismatch` and add the key to all 8 locales in lockstep.

## Items to Confirm / Review

- Each locale's translation is genuine (not a copy-paste of the English) — placeholders n/a here, the message has no interpolation
- Wording mirrors the markdown plugin's `pluginMarkdown.taskCountMismatch` shape so the two viewers feel consistent
- `t` was already imported via `useI18n()` (line 248); no new import wiring needed

## User Prompt

> /daily-refactoring → 全部別 PR で対応できるものは全部する

CodeRabbit unaddressed comment from PR #795.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (5 pre-existing v-html warnings only)
- [x] `yarn format` clean
- [x] `yarn test` — 3084/3084
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced localization support for wiki task count mismatch warnings. Users in English, German, Spanish, French, Japanese, Korean, Portuguese, and Chinese-speaking regions now receive localized error notifications when toggle operations are prevented to maintain file safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->