### PR TITLE
refactor: extract buildDailyPassPlan from runDailyPass (PR2 of #799)

### DIFF
--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -69,9 +69,82 @@ export interface DailyPassResult {
   skipped: Array<{ date: string; reason: string }>;
 }
 
-export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Promise<{ nextState: JournalState; result: DailyPassResult }> {
+// Inputs to the day loop, gathered up-front by `buildDailyPassPlan`
+// so `runDailyPass` reads as orchestration only — no IO interleaved
+// with scheduling decisions. Returned as a single object instead of
+// a tuple so future fields (e.g. caller-provided clock for tests)
+// can be added without re-threading every call site.
+//
+// `newTopicsSeen` is a mutable accumulator: the day loop adds to it
+// as topics are created. Including it in the plan keeps the lifecycle
+// visible at the call site.
+export interface DailyPassPlan {
+  workspaceRoot: string;
+  perSessionExcerpts: Map<string, Map<string, SessionExcerpt>>;
+  dayBuckets: ReadonlyMap<string, SessionExcerpt[]>;
+  sessionToDays: Map<string, Set<string>>;
+  /** Day keys in chronological order so an earlier day's topic
+   *  updates are visible to the next day's processing. */
+  orderedDays: string[];
+  existingTopics: ExistingTopicSnapshot[];
+  /** Mutable — the day loop adds new topic slugs as they're created. */
+  newTopicsSeen: Set<string>;
+  initialNextState: JournalState;
+  dirtyMetaById: ReadonlyMap<string, SessionFileMeta>;
+}
+
+/**
+ * Read-only setup for `runDailyPass`: enumerate sessions, find the
+ * dirty ones, build day buckets, snapshot existing topics, and
+ * compute the initial mutable state. Returns `null` when there's
+ * nothing to do (no dirty sessions). Otherwise returns a plan object
+ * the day loop can iterate over.
+ *
+ * Intentionally does NOT short-circuit on empty `dayBuckets`. If
+ * every dirty session produces zero excerpts (all malformed, or all
+ * tool-only with no text turns) we still want `readAllTopics` to
+ * fire and `initialNextState.knownTopics` to be normalised/sorted.
+ * The day loop then iterates zero times and we drop straight through.
+ */
+export async function buildDailyPassPlan(state: JournalState, deps: DailyPassDeps): Promise<DailyPassPlan | null> {
   const workspaceRoot = deps.workspaceRoot ?? defaultWorkspacePath;
   const chatDir = path.join(workspaceRoot, WORKSPACE_DIRS.chat);
+
+  const eligible = (await listSessionMetas(chatDir)).filter((sessionMeta) => !deps.activeSessionIds.has(sessionMeta.id));
+  const { dirty } = findDirtySessions(eligible, state.processedSessions);
+  if (dirty.length === 0) return null;
+
+  const perSessionExcerpts = await loadDirtySessionExcerpts(chatDir, dirty, workspaceRoot);
+  const { dayBuckets, sessionToDays } = buildDayBuckets(perSessionExcerpts);
+
+  const existingTopics = await readAllTopics(workspaceRoot);
+  const newTopicsSeen = new Set<string>(state.knownTopics);
+  // `nextState` is rebuilt through the day loop and persisted after
+  // each successful day via writeState (atomic tmp+rename). We do
+  // NOT bump lastDailyRunAt here — that's the outer runner's job
+  // after the whole pass (including optimization) finishes, so
+  // partial progress doesn't look like a complete pass.
+  const initialNextState: JournalState = {
+    ...state,
+    knownTopics: [...newTopicsSeen].sort(),
+  };
+  const dirtyMetaById = new Map(eligible.map((sessionMeta) => [sessionMeta.id, sessionMeta]));
+  const orderedDays = [...dayBuckets.keys()].sort();
+
+  return {
+    workspaceRoot,
+    perSessionExcerpts,
+    dayBuckets,
+    sessionToDays,
+    orderedDays,
+    existingTopics,
+    newTopicsSeen,
+    initialNextState,
+    dirtyMetaById,
+  };
+}
+
+export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Promise<{ nextState: JournalState; result: DailyPassResult }> {
   const result: DailyPassResult = {
     daysTouched: [],
     sessionsIngested: [],
@@ -80,52 +153,21 @@ export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Pr
     skipped: [],
   };
 
-  // --- Phase 1: figure out what work there is to do ------------------
-  const eligible = (await listSessionMetas(chatDir)).filter((sessionMeta) => !deps.activeSessionIds.has(sessionMeta.id));
-  const { dirty } = findDirtySessions(eligible, state.processedSessions);
-  if (dirty.length === 0) return { nextState: { ...state }, result };
+  const plan = await buildDailyPassPlan(state, deps);
+  if (plan === null) return { nextState: { ...state }, result };
 
-  const perSessionExcerpts = await loadDirtySessionExcerpts(chatDir, dirty, workspaceRoot);
-  const { dayBuckets, sessionToDays } = buildDayBuckets(perSessionExcerpts);
+  let nextState = plan.initialNextState;
 
-  // Note: we intentionally do NOT early-return when `dayBuckets` is
-  // empty. Letting the pipeline fall through preserves the pre-
-  // refactor behaviour for the edge case where every dirty session
-  // produces zero excerpts (all malformed, or all metadata/tool-only
-  // with no text turns): `readAllTopics` still fires, and the
-  // returned `nextState.knownTopics` is still normalized / sorted
-  // from the existing state. The empty `orderedDays` loop then
-  // iterates zero times and we fall through to `return { nextState,
-  // result }`.
-
-  // --- Phase 2: set up per-pass state --------------------------------
-  const existingTopics = await readAllTopics(workspaceRoot);
-  const newTopicsSeen = new Set<string>(state.knownTopics);
-  // `nextState` is rebuilt through the day loop and persisted after
-  // each successful day via writeState (atomic tmp+rename). We do
-  // NOT bump lastDailyRunAt here — that's the outer runner's job
-  // after the whole pass (including optimization) finishes, so
-  // partial progress doesn't look like a complete pass.
-  let nextState: JournalState = {
-    ...state,
-    knownTopics: [...newTopicsSeen].sort(),
-  };
-  const dirtyMetaById = new Map(eligible.map((sessionMeta) => [sessionMeta.id, sessionMeta]));
-  // Process days in chronological order so topic state accumulates
-  // naturally: an earlier day's update is visible to the next day.
-  const orderedDays = [...dayBuckets.keys()].sort();
-
-  // --- Phase 3: process each day -------------------------------------
-  for (const date of orderedDays) {
+  for (const date of plan.orderedDays) {
     const dayResult = await processDayAndAdvance({
-      workspaceRoot,
+      workspaceRoot: plan.workspaceRoot,
       date,
-      dayBuckets,
-      existingTopics,
+      dayBuckets: plan.dayBuckets,
+      existingTopics: plan.existingTopics,
       summarize: deps.summarize,
-      sessionToDays,
-      dirtyMetaById,
-      newTopicsSeen,
+      sessionToDays: plan.sessionToDays,
+      dirtyMetaById: plan.dirtyMetaById,
+      newTopicsSeen: plan.newTopicsSeen,
       nextState,
     });
     if (dayResult.kind === "skipped") {
@@ -139,8 +181,7 @@ export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Pr
     nextState = dayResult.nextState;
   }
 
-  // --- Phase 4: memory extraction ------------------------------------
-  await maybeExtractMemory(perSessionExcerpts, workspaceRoot, deps);
+  await maybeExtractMemory(plan.perSessionExcerpts, plan.workspaceRoot, deps);
 
   return { nextState, result };
 }

--- a/test/journal/test_buildDailyPassPlan.ts
+++ b/test/journal/test_buildDailyPassPlan.ts
@@ -93,4 +93,41 @@ describe("buildDailyPassPlan", () => {
     });
     assert.equal(plan, null);
   });
+
+  it("returns a plan with empty buckets when every dirty session parses to zero excerpts (regression-sensitive)", async () => {
+    // A session jsonl that contains ONLY metadata entries — the
+    // parser drops them via `isMetadataEntry`, so the session is
+    // "dirty" by mtime but produces zero excerpts. The planner is
+    // documented (line 102-108) to NOT short-circuit on this case:
+    // it must still snapshot existingTopics and seed
+    // initialNextState. If a future "simplification" replaces the
+    // helper with `if (perSessionExcerpts.size === 0) return null`,
+    // this test fails loudly.
+    const sessionId = "22222222-2222-2222-2222-222222222222";
+    const sessionFile = path.join(workspaceRoot, "conversations", "chat", `${sessionId}.jsonl`);
+    await mkdir(path.dirname(sessionFile), { recursive: true });
+    // Two metadata-only lines — both filtered by isMetadataEntry,
+    // so `parseJsonlEvents` returns []. No text/tool_result entries
+    // means dayBuckets stays empty.
+    const meta1 = { type: "session_meta", roleId: "general" };
+    const meta2 = { type: "claude_session_id", id: "claude-abc" };
+    await writeFile(sessionFile, `${JSON.stringify(meta1)}\n${JSON.stringify(meta2)}\n`);
+
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set(),
+    });
+
+    assert.ok(plan, "plan should be non-null even when all dirty sessions parse to zero excerpts");
+    assert.equal(plan.dayBuckets.size, 0, "dayBuckets should be empty");
+    assert.equal(plan.perSessionExcerpts.size, 0, "perSessionExcerpts should be empty");
+    assert.equal(plan.orderedDays.length, 0, "no days to process");
+    // initialNextState must still be normalised so a later run sees
+    // a sorted knownTopics list.
+    assert.deepEqual(plan.initialNextState.knownTopics, []);
+    // The dirty session must still be tracked in dirtyMetaById so
+    // anything downstream could (in principle) mark it processed.
+    assert.ok(plan.dirtyMetaById.has(sessionId), "metadata-only session is still tracked as dirty");
+  });
 });

--- a/test/journal/test_buildDailyPassPlan.ts
+++ b/test/journal/test_buildDailyPassPlan.ts
@@ -113,7 +113,18 @@ describe("buildDailyPassPlan", () => {
     const meta2 = { type: "claude_session_id", id: "claude-abc" };
     await writeFile(sessionFile, `${JSON.stringify(meta1)}\n${JSON.stringify(meta2)}\n`);
 
-    const plan = await buildDailyPassPlan(defaultState(), {
+    // Seed the state with deliberately UNSORTED topics so the
+    // `knownTopics: [...newTopicsSeen].sort()` line in the planner
+    // is observably the cause of the post-condition. Without this
+    // seeding the assertion is vacuous (empty list is trivially
+    // sorted) — Codex iter-2 flagged the original version of this
+    // test for exactly that.
+    const seededState = {
+      ...defaultState(),
+      knownTopics: ["zeta", "alpha", "kappa"],
+    };
+
+    const plan = await buildDailyPassPlan(seededState, {
       workspaceRoot,
       summarize: noopSummarize,
       activeSessionIds: new Set(),
@@ -123,9 +134,9 @@ describe("buildDailyPassPlan", () => {
     assert.equal(plan.dayBuckets.size, 0, "dayBuckets should be empty");
     assert.equal(plan.perSessionExcerpts.size, 0, "perSessionExcerpts should be empty");
     assert.equal(plan.orderedDays.length, 0, "no days to process");
-    // initialNextState must still be normalised so a later run sees
-    // a sorted knownTopics list.
-    assert.deepEqual(plan.initialNextState.knownTopics, []);
+    // initialNextState must be normalised — `knownTopics` arrives
+    // unsorted (zeta/alpha/kappa) and must come back sorted.
+    assert.deepEqual(plan.initialNextState.knownTopics, ["alpha", "kappa", "zeta"]);
     // The dirty session must still be tracked in dirtyMetaById so
     // anything downstream could (in principle) mark it processed.
     assert.ok(plan.dirtyMetaById.has(sessionId), "metadata-only session is still tracked as dirty");

--- a/test/journal/test_buildDailyPassPlan.ts
+++ b/test/journal/test_buildDailyPassPlan.ts
@@ -1,0 +1,96 @@
+// Coverage for the `buildDailyPassPlan` extraction (PR2 of #799).
+// The full daily pass is integration-tested via session-end smoke
+// runs; these checks exercise the planner's two top-level shapes:
+// the "no work" early-return and the "work-to-do" plan object. They
+// rely on a real tmp workspace because the planner does filesystem
+// IO end-to-end (chat dir scan, session jsonl read, topic snapshot).
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { buildDailyPassPlan, type DailyPassDeps } from "../../server/workspace/journal/dailyPass.js";
+import { defaultState } from "../../server/workspace/journal/state.js";
+
+// `Summarize` returns a Promise<string>; this stub should never be
+// invoked because `buildDailyPassPlan` doesn't call the summarizer
+// (it only does the read-only setup). If it ever does, the throw
+// surfaces the regression loudly.
+const noopSummarize: DailyPassDeps["summarize"] = async () => {
+  throw new Error("Summarize should not be called from buildDailyPassPlan");
+};
+
+let workspaceRoot: string;
+
+before(async () => {
+  workspaceRoot = await mkdtemp(path.join(tmpdir(), "mulmo-daily-plan-"));
+});
+
+after(async () => {
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("buildDailyPassPlan", () => {
+  it("returns null when the chat dir does not exist (fresh install)", async () => {
+    // Don't create chatDir — listSessionMetas returns empty, no
+    // dirty sessions, planner returns null.
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set(),
+    });
+    assert.equal(plan, null);
+  });
+
+  it("returns null when the chat dir is empty", async () => {
+    await mkdir(path.join(workspaceRoot, "conversations", "chat"), { recursive: true });
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set(),
+    });
+    assert.equal(plan, null);
+  });
+
+  it("returns a plan with workspaceRoot + initialNextState when there's a session to process", async () => {
+    // A minimal session jsonl with one user text turn — enough for
+    // listSessionMetas to find it and findDirtySessions to flag it
+    // as new (empty processedSessions in defaultState).
+    const sessionId = "11111111-1111-1111-1111-111111111111";
+    const sessionFile = path.join(workspaceRoot, "conversations", "chat", `${sessionId}.jsonl`);
+    await mkdir(path.dirname(sessionFile), { recursive: true });
+    const event = {
+      type: "user_message",
+      timestamp: "2026-04-25T01:00:00Z",
+      message: "hello",
+    };
+    await writeFile(sessionFile, JSON.stringify(event) + "\n");
+
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set(),
+    });
+
+    assert.ok(plan, "plan should not be null when there's a dirty session");
+    assert.equal(plan.workspaceRoot, workspaceRoot);
+    assert.ok(Array.isArray(plan.orderedDays));
+    assert.ok(plan.newTopicsSeen instanceof Set);
+    assert.equal(plan.initialNextState.knownTopics.length, 0);
+    assert.ok(plan.dirtyMetaById.has(sessionId), "session should be in dirtyMetaById");
+  });
+
+  it("returns null when the only candidate session is in activeSessionIds (still being written)", async () => {
+    // The previous test left a session file in place. Re-run with
+    // that session marked active — planner should skip it and find
+    // no dirty work.
+    const activeId = "11111111-1111-1111-1111-111111111111";
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set([activeId]),
+    });
+    assert.equal(plan, null);
+  });
+});


### PR DESCRIPTION
## Summary
- Second of the four PRs sketched in `plans/audit-journal-subsystem.md` (#799). Behaviour-preserving refactor — no logic change.
- `runDailyPass` shrinks from ~110 lines to ~30 lines of orchestration; Phases 1-2 (session discovery + plan setup) move into the new exported `buildDailyPassPlan`.

## Items to Confirm / Review
- **Plan shape.** `DailyPassPlan` includes `workspaceRoot`, the day buckets, the topic snapshot, the seed mutable state, and the seed `newTopicsSeen` Set. The Set is included as a mutable accumulator the day loop adds to — flagged in the docstring so future readers don't get confused about "why is a mutable Set in this plan object".
- **Empty-dayBuckets invariant.** The pre-refactor comment said "intentionally do NOT early-return when dayBuckets is empty" because the planner still wants `readAllTopics` and the sort/normalize on `knownTopics` to fire. That comment now lives on the planner docstring; behaviour is unchanged. Codex iter-1 flagged this branch as untested — added a 5th test case in `eeedb426` exercising a metadata-only session jsonl that pins the four invariants of the branch.
- **Public surface.** Two new exports (`DailyPassPlan`, `buildDailyPassPlan`). Picked the natural seams; flag if you'd rather they stay private and the test file go through internals.
- **Test coverage.** Five tests for the planner (no chat dir / empty chat dir / dirty session / activeSessionIds skip / dirty-but-zero-excerpts regression branch). Existing dailyPass tests are untouched and still pass.
- **No behaviour change.** `maybeExtractMemory` still runs after the day loop; the result aggregation is bit-for-bit identical to the pre-refactor flow.

## Bundled fix (called out — minor scope leak)

`test/routes/test_wikiSaveRoute.ts` carries a small `beforeEach(__resetPageIndexCache)` change that's **unrelated** to this refactor — it's the Windows mtime-cache flake fix from PR #801 that didn't make it into the merge. The hunk is 15 lines, all test code (no production change), and its absence makes the `lint_test (windows-2022, 24.x)` job fail intermittently. Splitting it after the fact is more churn than the diff is worth, so flagging it here for review transparency. Codex iter-1 noticed and called it out as scope leak; this is the explicit "yes, we're bundling, here's why".

## What's NOT in this PR
Sticking to the audit's scope split:
- PR3 — `archivist.ts` schema/CLI split
- PR4 — `maybeRunJournal` unit tests + crash recovery integration test

## User Prompt
> はい、それですすめましょう
>
> (continuing the journal cleanup roadmap from #799 / PR #801 → this PR2)

## Test plan
- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` — 3088/3088 pass locally
- [ ] Manual: trigger a journal pass and confirm the new daily summaries / topics appear and `_state.json` advances correctly.

Refs #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)