### PR TITLE
refactor(wiki): use WIKI_ACTION.save constant (#795 follow-up)

### DIFF
--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -541,7 +541,7 @@ async function persistWikiPage(pageName: string, newContent: string, generation:
   if (currentSlug() !== pageName) return;
 
   const response = await apiPost<{ data?: { content?: string } }>(API_ROUTES.wiki.base, {
-    action: "save",
+    action: WIKI_ACTION.save,
     pageName,
     content: newContent,
   });

--- a/src/plugins/wiki/route.ts
+++ b/src/plugins/wiki/route.ts
@@ -30,6 +30,7 @@ export const WIKI_ACTION = {
   page: "page",
   log: "log",
   lintReport: "lint_report",
+  save: "save",
 } as const;
 
 export type WikiAction = (typeof WIKI_ACTION)[keyof typeof WIKI_ACTION];


### PR DESCRIPTION
## Summary

CodeRabbit flagged `src/plugins/wiki/View.vue:544` on PR #795 — the line emits `action: "save"` as a string literal while every other action site in the same file already uses the `WIKI_ACTION` `as const` object (`.index`, `.page`, `.lintReport`). CLAUDE.md rule "Never use raw string literals for scheduler types, event types, API routes, or tool names" applies here.

Adds `save: "save"` to `WIKI_ACTION` (route.ts) and threads the constant through. Wire format unchanged — the server already handles `case "save":` at `wiki.ts:601`.

## User Prompt

> /daily-refactoring → 全部別 PR で対応できるものは全部する

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` / `yarn format` clean
- [x] `yarn test` — 3084/3084
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)