### PR TITLE
fix(wiki): self-heal taskPersistChain on rejection (#795 follow-up)

### DIFF
--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -629,7 +629,15 @@ function onTaskCheckboxClick(event: MouseEvent, target: HTMLInputElement): void 
   // the chain has been broken (by a prior failure) by the time it
   // runs. See `persistWikiPage` for the semantics.
   const generation = saveQueueGeneration;
-  taskPersistChain = taskPersistChain.then(() => persistWikiPage(pageName, newContent, generation));
+  // `.catch` keeps the chain self-healing: if `persistWikiPage`
+  // throws (e.g. its post-failure `refresh()` rejects with a network
+  // error), an un-caught rejection would leave `taskPersistChain` in
+  // a permanently-rejected state, and every subsequent click's
+  // `.then()` would short-circuit silently — no more toggles ever
+  // persist. Swallow the rejection here so the next click starts
+  // from a fresh resolved chain. The error is already surfaced via
+  // `navError` inside `persistWikiPage`'s `!response.ok` branch.
+  taskPersistChain = taskPersistChain.then(() => persistWikiPage(pageName, newContent, generation)).catch(() => undefined);
 }
 
 function handleContentClick(event: MouseEvent) {


### PR DESCRIPTION
## Summary

CodeRabbit flagged `src/plugins/wiki/View.vue:597`. `persistWikiPage` calls `await refresh()` inside the `!response.ok` branch — if refresh rejects (network blip, etc.), the rejection escapes `.then()` and `taskPersistChain` becomes permanently rejected. From then on, every click's `.then(() => persistWikiPage(...))` short-circuits silently → toggles look-but-don't-persist forever.

Fix: append `.catch(() => undefined)` so the chain self-heals. The original error is already shown to the user via `navError` inside `persistWikiPage`'s `!response.ok` branch.

## Items to Confirm / Review

- The `.catch` swallows the rejection silently — that's intentional because `persistWikiPage` has already populated `navError` for the user-visible failure path (the only realistic source of rejection here is the post-failure `refresh()` itself, and that's a transient state). If we ever add a log sink, this is the spot to wire it.

## User Prompt

> /daily-refactoring → 全部別 PR で対応できるものは全部する

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` / `yarn format` clean
- [x] `yarn test` — 3084/3084
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)