### PR TITLE
fix(notify): inject publishNotification + auto-disable macOS sink under node:test (#803)

### DIFF
--- a/server/agent/mcp-tools/notify.ts
+++ b/server/agent/mcp-tools/notify.ts
@@ -4,60 +4,73 @@
 //
 // Calls `publishNotification` with `kind: "push"`, which fans out
 // to:
-//   - Web bell (always)
-//   - Bridge (if a transportId is supplied)
-//   - macOS Reminders (#789, if MACOS_REMINDER_NOTIFICATIONS=1
-//     + darwin)
+//   - Web bell
+//   - Bridge (if a transportId is supplied — N/A from this entry
+//     point)
+//   - macOS Reminders (#789, on darwin unless the user has set
+//     DISABLE_MACOS_REMINDER_NOTIFICATIONS=1)
 //
-// No active-user suppression — the original `/notify` skill had a
-// client-side "user typed recently → silent" gate, but the agent
-// is the wrong place to second-guess the user's intent. If the user
-// asked for a notification, fire it. (The web bell tab dedupes its
-// own visual badge anyway.)
+// No active-user gate. If the user asks for a notification, fire it.
 //
 // `body` is optional and only forwarded when non-empty. `title` is
 // required and trimmed.
+//
+// `publishNotification` is injected via `makeNotifyTool({ publish })`
+// (#803) so unit tests can pass a mock and stay free of macOS / bell
+// side effects. The default singleton `notify` wires the real
+// implementation.
 
 import { publishNotification } from "../../events/notifications.js";
 import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
 
-export const notify = {
-  definition: {
-    name: "notify",
-    description:
-      "Send the user a push-style notification (web bell + macOS Reminders if MACOS_REMINDER_NOTIFICATIONS=1 + bridge). Use to report completion of long-running tasks, surface monitoring results, or proactively notify the user when they may be away from the keyboard.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: {
-          type: "string",
-          description: "Short notification headline. Keep it concise — emojis OK.",
+export type NotifyPublishFn = typeof publishNotification;
+
+export interface NotifyToolDeps {
+  publish: NotifyPublishFn;
+}
+
+export function makeNotifyTool(deps: NotifyToolDeps) {
+  return {
+    definition: {
+      name: "notify",
+      description:
+        "Send the user a push-style notification (web bell + macOS Reminders if MACOS_REMINDER_NOTIFICATIONS=1 + bridge). Use to report completion of long-running tasks, surface monitoring results, or proactively notify the user when they may be away from the keyboard.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+            description: "Short notification headline. Keep it concise — emojis OK.",
+          },
+          body: {
+            type: "string",
+            description: "Optional longer detail line. Omit when the title is self-explanatory.",
+          },
         },
-        body: {
-          type: "string",
-          description: "Optional longer detail line. Omit when the title is self-explanatory.",
-        },
+        required: ["title"],
       },
-      required: ["title"],
     },
-  },
 
-  prompt:
-    "Use the `notify` MCP tool — NOT a user-installed `/notify` skill — when the user asks for a notification ('通知して' / 'remind me' / 'tell me when …') or when reporting completion of a long-running task / monitoring summary / scheduled reminder firing. " +
-    "This is the canonical built-in notification path: it fans out to the web bell, any active bridge transport, and macOS Reminders (when MACOS_REMINDER_NOTIFICATIONS=1 + darwin), and has NO active-user suppression — if the user asks for a notification, fire one. " +
-    "After firing, briefly tell the user you sent the notification.",
+    prompt:
+      "Use the `notify` MCP tool — NOT a user-installed `/notify` skill — when the user asks for a notification ('通知して' / 'remind me' / 'tell me when …') or when reporting completion of a long-running task / monitoring summary / scheduled reminder firing. " +
+      "This is the canonical built-in notification path: it fans out to the web bell, any active bridge transport, and macOS Reminders (when MACOS_REMINDER_NOTIFICATIONS=1 + darwin), and has NO active-user suppression — if the user asks for a notification, fire one. " +
+      "After firing, briefly tell the user you sent the notification.",
 
-  async handler(args: Record<string, unknown>): Promise<string> {
-    const title = typeof args.title === "string" ? args.title.trim() : "";
-    if (!title) return "notify: `title` is required (non-empty string).";
-    const bodyRaw = typeof args.body === "string" ? args.body.trim() : "";
-    const body = bodyRaw.length > 0 ? bodyRaw : undefined;
+    async handler(args: Record<string, unknown>): Promise<string> {
+      const title = typeof args.title === "string" ? args.title.trim() : "";
+      if (!title) return "notify: `title` is required (non-empty string).";
+      const bodyRaw = typeof args.body === "string" ? args.body.trim() : "";
+      const body = bodyRaw.length > 0 ? bodyRaw : undefined;
 
-    publishNotification({
-      kind: NOTIFICATION_KINDS.push,
-      title,
-      body,
-    });
-    return body ? `Notification sent: ${title}\n${body}` : `Notification sent: ${title}`;
-  },
-};
+      deps.publish({
+        kind: NOTIFICATION_KINDS.push,
+        title,
+        body,
+      });
+      return body ? `Notification sent: ${title}\n${body}` : `Notification sent: ${title}`;
+    },
+  };
+}
+
+// Production singleton wired with the real publishNotification.
+export const notify = makeNotifyTool({ publish: publishNotification });

--- a/server/system/macosNotify.ts
+++ b/server/system/macosNotify.ts
@@ -62,10 +62,19 @@ interface Deps {
   disabled: boolean;
 }
 
+// Auto-disable inside `node:test`. The runner sets
+// `NODE_TEST_CONTEXT` on the child process so we can detect it
+// here. Without this gate, any test that goes through
+// `publishNotification` (e.g. the route-level scheduleTest tests)
+// fires real osascript and pollutes Reminders.app.
+function isInsideNodeTest(): boolean {
+  return typeof process.env.NODE_TEST_CONTEXT === "string" && process.env.NODE_TEST_CONTEXT.length > 0;
+}
+
 const defaultDeps: Deps = {
   spawner: spawn,
   platform: process.platform as Platform,
-  disabled: env.disableMacosReminderNotifications,
+  disabled: env.disableMacosReminderNotifications || isInsideNodeTest(),
 };
 
 export function pushToMacosReminder(title: string, body?: string): Promise<void> {

--- a/test/agent/test_notify_tool.ts
+++ b/test/agent/test_notify_tool.ts
@@ -1,10 +1,18 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { notify } from "../../server/agent/mcp-tools/notify.js";
+import { notify, makeNotifyTool, type NotifyPublishFn } from "../../server/agent/mcp-tools/notify.js";
+import { NOTIFICATION_KINDS } from "../../src/types/notification.js";
 
-// Note: `publishNotification` itself is fire-and-forget and gracefully
-// handles uninitialized deps (logs a warn, no throw), so the handler
-// can run in tests without any setup.
+// Capture each `publish` call so tests can assert on the args
+// without firing the real publishNotification (which on darwin
+// spawns osascript and adds a real entry to Reminders.app, #803).
+function makeMockPublish(): { publish: NotifyPublishFn; calls: Parameters<NotifyPublishFn>[0][] } {
+  const calls: Parameters<NotifyPublishFn>[0][] = [];
+  const publish: NotifyPublishFn = (opts) => {
+    calls.push(opts);
+  };
+  return { publish, calls };
+}
 
 describe("notify MCP tool — input validation", () => {
   it("rejects an empty title", async () => {
@@ -21,35 +29,54 @@ describe("notify MCP tool — input validation", () => {
     const result = await notify.handler({ title: "   " });
     assert.match(result, /title.*required/i);
   });
+
+  it("does NOT call publish when validation fails", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    await tool.handler({ title: "" });
+    await tool.handler({ title: "   " });
+    await tool.handler({ title: 42 });
+    assert.equal(calls.length, 0);
+  });
 });
 
-// Happy-path tests disabled — they call the real
-// `publishNotification`, which on darwin spawns `osascript` and adds a
-// real entry to the user's Reminders.app every time `yarn test` runs
-// (#789 follow-up). Until publishNotification is injectable into the
-// notify tool, leave these commented out.
-//
-// describe("notify MCP tool — happy path", () => {
-//   it("returns a confirmation including the title", async () => {
-//     const result = await notify.handler({ title: "Build done" });
-//     assert.match(result, /Notification sent: Build done/);
-//   });
-//
-//   it("appends the body line when supplied", async () => {
-//     const result = await notify.handler({ title: "Build done", body: "All 12 steps green" });
-//     assert.equal(result, "Notification sent: Build done\nAll 12 steps green");
-//   });
-//
-//   it("trims surrounding whitespace from title and body", async () => {
-//     const result = await notify.handler({ title: "  hi  ", body: "  there  " });
-//     assert.equal(result, "Notification sent: hi\nthere");
-//   });
-//
-//   it("treats a whitespace-only body as missing", async () => {
-//     const result = await notify.handler({ title: "hi", body: "   " });
-//     assert.equal(result, "Notification sent: hi");
-//   });
-// });
+describe("notify MCP tool — happy path", () => {
+  it("returns a confirmation including the title", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    const result = await tool.handler({ title: "Build done" });
+    assert.match(result, /Notification sent: Build done/);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].title, "Build done");
+    assert.equal(calls[0].body, undefined);
+    assert.equal(calls[0].kind, NOTIFICATION_KINDS.push);
+  });
+
+  it("appends the body line when supplied", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    const result = await tool.handler({ title: "Build done", body: "All 12 steps green" });
+    assert.equal(result, "Notification sent: Build done\nAll 12 steps green");
+    assert.equal(calls[0].body, "All 12 steps green");
+  });
+
+  it("trims surrounding whitespace from title and body", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    const result = await tool.handler({ title: "  hi  ", body: "  there  " });
+    assert.equal(result, "Notification sent: hi\nthere");
+    assert.equal(calls[0].title, "hi");
+    assert.equal(calls[0].body, "there");
+  });
+
+  it("treats a whitespace-only body as missing", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    const result = await tool.handler({ title: "hi", body: "   " });
+    assert.equal(result, "Notification sent: hi");
+    assert.equal(calls[0].body, undefined);
+  });
+});
 
 describe("notify MCP tool — definition shape", () => {
   it("declares title as required and body as optional", () => {
@@ -60,5 +87,12 @@ describe("notify MCP tool — definition shape", () => {
     assert.deepEqual(schema.required, ["title"]);
     assert.ok(schema.properties.title);
     assert.ok(schema.properties.body);
+  });
+
+  it("makeNotifyTool produces a definition matching the production singleton", () => {
+    const { publish } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    assert.equal(tool.definition.name, notify.definition.name);
+    assert.deepEqual(tool.definition.inputSchema, notify.definition.inputSchema);
   });
 });


### PR DESCRIPTION
## Summary

\`yarn test\` を darwin で走らせるたびに macOS Reminders.app にエントリが追加される問題(#803)を 2 段防御で修正。

1. **Factory pattern** — \`notify\` MCP tool を \`makeNotifyTool({ publish })\` 化。テストでは mock publish を注入するので、handler は本物の publishNotification 経路を通らない。
2. **NODE_TEST_CONTEXT gate** — node の test runner(\`tsx --test\` 含む)が child process にこの env var をセットすることを利用。\`server/system/macosNotify.ts\` で module load 時に検知し、自動 disabled 化。route-level \`scheduleTestNotification\` テスト等、DI されていない経路も塞ぐ。

Closes #803.

## Items to Confirm / Review

- [ ] **NODE_TEST_CONTEXT** は \`tsx --test\` でも自動セットされる(検証済: \`child-v8\`)
- [ ] **本番挙動は変わらない** — \`notify\` const は factory 経由で publishNotification を実装注入、agent は同じ tool object を見る
- [ ] **PR #802 でコメントアウトしたテスト 4 件を復活** + mock 呼び出しの引数検証も追加
- [ ] gate 二重化は冗長だが defence-in-depth — 1 つ崩れてもう 1 つで救う設計

## Verification

darwin 上で \`yarn test\` 実行前後の Reminders.app エントリ数を計測:

| 状態 | yarn test 前 | yarn test 後 | 差分 |
|---|---|---|---|
| 修正前 | 378 | 405 | +27 |
| **修正後** | **459** | **459** | **0** |

\`yarn format\` / \`yarn lint\` / \`yarn typecheck\` clean。

## User Prompt

> ticket化 → すぐやる？

(Issue #803 で起票、即着手)

## Implementation

| File | Change |
|---|---|
| \`server/agent/mcp-tools/notify.ts\` | factory \`makeNotifyTool({ publish })\` に分離、\`notify\` は本番 publishNotification を注入した singleton |
| \`server/system/macosNotify.ts\` | \`NODE_TEST_CONTEXT\` 検知、defaultDeps の disabled に \`OR\` で合成 |
| \`test/agent/test_notify_tool.ts\` | mock publish で 4 happy-path + 1 "no fire on validation failure" 追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)