### PR TITLE
chore(wiki): rename log field issues→summary in lint_report (#784 follow-up)

### DIFF
--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -594,7 +594,11 @@ router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>
       }
       case "lint_report": {
         const response = await buildLintReportResponse(action);
-        log.info("wiki", "POST lint_report: ok", { issues: response.message });
+        // `summary` not `issues`: the field is the human-readable
+        // result string ("Wiki is healthy" / "N issue(s) found"),
+        // not a count. Aggregators that group by `issues` would
+        // otherwise treat the same string as a numeric facet.
+        log.info("wiki", "POST lint_report: ok", { summary: response.message });
         res.json(response);
         return;
       }


### PR DESCRIPTION
## Summary

CodeRabbit flagged `server/api/routes/wiki.ts:549` on PR #784: the lint_report success log emitted `{ issues: response.message }`, but `response.message` is a human-readable string ("Wiki is healthy" / "N issue(s) found"), not a count. Aggregators that group by `issues` would otherwise treat the same string as a numeric facet.

Renamed to `summary` (which is what the value actually is) and added an inline note for posterity.

## User Prompt

> /daily-refactoring → 全部別 PR で対応できるものは全部する

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test` — 3084/3084
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)