### PR TITLE
refactor: split journal archivist.ts into cli + schemas (PR3 of #799)

### DIFF
--- a/server/workspace/chat-index/index.ts
+++ b/server/workspace/chat-index/index.ts
@@ -14,7 +14,7 @@
 // point at a `mkdtempSync` directory.
 
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
-import { ClaudeCliNotFoundError } from "../journal/archivist.js";
+import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { indexSession, listSessionIds, type IndexerDeps } from "./indexer.js";
 import { log } from "../../system/logger/index.js";
 

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -17,7 +17,7 @@ import { EVENT_TYPES } from "../../../src/types/events.js";
 import { readFile } from "node:fs/promises";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { tmpdir } from "node:os";
-import { ClaudeCliNotFoundError } from "../journal/archivist.js";
+import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { errorMessage } from "../../utils/errors.js";
 import type { SummaryResult } from "./types.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -1,0 +1,121 @@
+// Transport layer for the journal archivist: wraps the Claude Code
+// CLI as a subprocess so summarization runs against the user's
+// subscription quota rather than the API key budget.
+//
+// The pure data shapes (interfaces, prompts, validators) live in
+// `./archivist-schemas.ts`. This file is the only one that touches
+// `node:child_process`, kept thin so dependency injection in tests
+// never has to mock a subprocess.
+
+import { spawn } from "node:child_process";
+import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
+
+// (systemPrompt, userPrompt) → raw model output as a string.
+// The daily/optimization passes parse JSON out of the string
+// themselves; this layer stays transport-only.
+export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
+
+// Wall-clock cap per CLI invocation. 5 minutes is comfortably above
+// the worst-case summarization run we've seen and still short enough
+// that a wedged subprocess doesn't tie up resources forever.
+const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
+
+// Sentinel we throw on ENOENT so maybeRunJournal can disable the
+// feature for the rest of the server lifetime instead of retrying
+// on every session-end. Re-used by chat-index / sources for the
+// same intent — the `claude` CLI is a project-wide optional dep,
+// not journal-specific.
+export class ClaudeCliNotFoundError extends Error {
+  constructor() {
+    super("[journal] `claude` CLI is not available on PATH — journal disabled");
+    this.name = "ClaudeCliNotFoundError";
+  }
+}
+
+export class ClaudeCliFailedError extends Error {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  constructor(exitCode: number | null, stderr: string) {
+    super(`[journal] \`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(0, 500)}`);
+    this.name = "ClaudeCliFailedError";
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+// Default summarizer. Spawns `claude -p` and pipes the combined
+// system + user prompt to stdin so we don't hit shell-argv limits
+// for large day excerpts.
+export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
+  return new Promise((resolve, reject) => {
+    const child = spawn("claude", ["-p", "--output-format", "text"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, CLI_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err: Error & { code?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (err.code === "ENOENT") {
+        reject(new ClaudeCliNotFoundError());
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(new ClaudeCliFailedError(null, `timed out after ${CLI_TIMEOUT_MS}ms\n${stderr}`));
+        return;
+      }
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new ClaudeCliFailedError(code, stderr));
+      }
+    });
+
+    // Surface stdin write errors (e.g. EPIPE if the child exited
+    // before we finished writing) instead of silently dropping them.
+    child.stdin.on("error", (err: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    // Send the full prompt in one write. If Node's stream layer
+    // signals backpressure (write returns false), wait for "drain"
+    // before calling end() so we don't close stdin while the buffer
+    // still has data to flush. For typical archivist prompts this
+    // path rarely fires, but very large session excerpts can reach
+    // it.
+    const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
+    const flushed = child.stdin.write(payload);
+    if (flushed) {
+      child.stdin.end();
+    } else {
+      child.stdin.once("drain", () => child.stdin.end());
+    }
+  });
+};

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -20,14 +20,14 @@ export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<st
 // that a wedged subprocess doesn't tie up resources forever.
 const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
-// Sentinel we throw on ENOENT so maybeRunJournal can disable the
-// feature for the rest of the server lifetime instead of retrying
-// on every session-end. Re-used by chat-index / sources for the
-// same intent — the `claude` CLI is a project-wide optional dep,
-// not journal-specific.
+// Sentinel thrown on ENOENT. Each subsystem catches this and decides
+// what to do — journal disables itself for the rest of the server
+// lifetime; chat-index / sources log and skip. The message is
+// subsystem-neutral so callers logging `err.message` verbatim (e.g.
+// chat-index) don't surface a misleading "journal disabled" warning.
 export class ClaudeCliNotFoundError extends Error {
   constructor() {
-    super("[journal] `claude` CLI is not available on PATH — journal disabled");
+    super("`claude` CLI is not available on PATH");
     this.name = "ClaudeCliNotFoundError";
   }
 }
@@ -36,7 +36,7 @@ export class ClaudeCliFailedError extends Error {
   readonly exitCode: number | null;
   readonly stderr: string;
   constructor(exitCode: number | null, stderr: string) {
-    super(`[journal] \`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(0, 500)}`);
+    super(`\`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(0, 500)}`);
     this.name = "ClaudeCliFailedError";
     this.exitCode = exitCode;
     this.stderr = stderr;

--- a/server/workspace/journal/archivist-schemas.ts
+++ b/server/workspace/journal/archivist-schemas.ts
@@ -1,122 +1,14 @@
-// Thin wrapper around the Claude Code CLI used as the journal's
-// summarizer. The default `runClaudeCli` spawns `claude -p` as a
-// subprocess so summarization draws from the user's subscription
-// quota rather than the API key budget.
+// Data shapes, prompts, and validators for the journal archivist.
+// Pure module — no IO, no subprocess, no global state. The CLI
+// transport (subprocess wrapper, error classes, default Summarize)
+// lives in `./archivist-cli.ts`.
 //
-// The rest of the journal module receives a `Summarize` function
-// via dependency injection — tests supply a deterministic fake, the
-// production path supplies `runClaudeCli`.
+// Splitting these used to be one file (`archivist.ts`), but it had
+// grown to 386 lines mixing transport with schemas. Keeping prompts
+// + validators separate lets tests / future passes import the data
+// shapes without dragging in `node:child_process`.
 
-import { spawn } from "node:child_process";
-import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
-
-// (systemPrompt, userPrompt) → raw model output as a string.
-// The daily/optimization passes parse JSON out of the string
-// themselves; this layer stays transport-only.
-export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
-
-// Wall-clock cap per CLI invocation. 5 minutes is comfortably above
-// the worst-case summarization run we've seen and still short enough
-// that a wedged subprocess doesn't tie up resources forever.
-const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
-
-// Sentinel we throw on ENOENT so maybeRunJournal can disable the
-// feature for the rest of the server lifetime instead of retrying
-// on every session-end.
-export class ClaudeCliNotFoundError extends Error {
-  constructor() {
-    super("[journal] `claude` CLI is not available on PATH — journal disabled");
-    this.name = "ClaudeCliNotFoundError";
-  }
-}
-
-export class ClaudeCliFailedError extends Error {
-  readonly exitCode: number | null;
-  readonly stderr: string;
-  constructor(exitCode: number | null, stderr: string) {
-    super(`[journal] \`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(0, 500)}`);
-    this.name = "ClaudeCliFailedError";
-    this.exitCode = exitCode;
-    this.stderr = stderr;
-  }
-}
-
-// Default summarizer. Spawns `claude -p` and pipes the combined
-// system + user prompt to stdin so we don't hit shell-argv limits
-// for large day excerpts.
-export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
-  return new Promise((resolve, reject) => {
-    const child = spawn("claude", ["-p", "--output-format", "text"], {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-    let settled = false;
-
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, CLI_TIMEOUT_MS);
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-
-    child.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-
-    child.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      if (timedOut) {
-        reject(new ClaudeCliFailedError(null, `timed out after ${CLI_TIMEOUT_MS}ms\n${stderr}`));
-        return;
-      }
-      if (code === 0) {
-        resolve(stdout);
-      } else {
-        reject(new ClaudeCliFailedError(code, stderr));
-      }
-    });
-
-    // Surface stdin write errors (e.g. EPIPE if the child exited
-    // before we finished writing) instead of silently dropping them.
-    child.stdin.on("error", (err: Error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      reject(err);
-    });
-
-    // Send the full prompt in one write. If Node's stream layer
-    // signals backpressure (write returns false), wait for "drain"
-    // before calling end() so we don't close stdin while the buffer
-    // still has data to flush. For typical archivist prompts this
-    // path rarely fires, but very large session excerpts can reach
-    // it.
-    const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
-    const flushed = child.stdin.write(payload);
-    if (flushed) {
-      child.stdin.end();
-    } else {
-      child.stdin.once("drain", () => child.stdin.end());
-    }
-  });
-};
+import { isRecord } from "../../utils/types.js";
 
 // --- Daily archivist contract ---------------------------------------
 
@@ -342,11 +234,11 @@ export function buildOptimizationUserPrompt(input: OptimizationInput): string {
 // on failure so callers can log-and-skip instead of crash.
 //
 // JSON extraction helpers moved to server/utils/json.ts.
-// Re-export for backwards compatibility with callers that import
-// from this module (dailyPass.ts, optimizationPass.ts).
+// Re-export here so journal callers (and existing tests) keep a
+// single import surface for the archivist contract.
 export { extractJsonObject, findBalancedBraceBlock } from "../../utils/json.js";
 
-import { isRecord } from "../../utils/types.js";
+// --- Validators ------------------------------------------------------
 
 // Type guards used by callers to validate parsed output. Written as
 // guards rather than `as` casts per project conventions.

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -16,7 +16,6 @@ import { writeDailySummary, readDailySummary, readTopicFile, writeTopicFile, app
 import { readSessionMeta as readSessionMetaIO, readSessionJsonl as readSessionJsonlIO } from "../../utils/files/session-io.js";
 import { statUnder } from "../../utils/files/workspace-io.js";
 import {
-  type Summarize,
   type SessionExcerpt,
   type SessionEventExcerpt,
   type ExistingTopicSnapshot,
@@ -27,8 +26,8 @@ import {
   buildDailyUserPrompt,
   extractJsonObject,
   isDailyArchivistOutput,
-  ClaudeCliNotFoundError,
-} from "./archivist.js";
+} from "./archivist-schemas.js";
+import { type Summarize, ClaudeCliNotFoundError } from "./archivist-cli.js";
 import { toIsoDate, slugify } from "./paths.js";
 import { findDirtySessions, applyProcessed, type SessionFileMeta } from "./diff.js";
 import { rewriteWorkspaceLinks } from "../../utils/markdown.js";

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -58,7 +58,7 @@ import { readState, writeState, isDailyDue, isOptimizationDue } from "./state.js
 import { runDailyPass } from "./dailyPass.js";
 import { runOptimizationPass } from "./optimizationPass.js";
 import { buildIndexMarkdown, type IndexTopicEntry, type IndexDailyEntry } from "./indexFile.js";
-import { runClaudeCli, ClaudeCliNotFoundError, type Summarize } from "./archivist.js";
+import { runClaudeCli, ClaudeCliNotFoundError, type Summarize } from "./archivist-cli.js";
 import { extractFirstH1 } from "../../../src/utils/markdown/extractFirstH1.js";
 import { log } from "../../system/logger/index.js";
 

--- a/server/workspace/journal/memoryExtractor.ts
+++ b/server/workspace/journal/memoryExtractor.ts
@@ -12,7 +12,7 @@ import path from "path";
 import { WORKSPACE_FILES } from "../paths.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { log } from "../../system/logger/index.js";
-import { ClaudeCliNotFoundError } from "./archivist.js";
+import { ClaudeCliNotFoundError } from "./archivist-cli.js";
 
 const EXTRACTION_SYSTEM_PROMPT = `You are a personal-fact extractor. Given a batch of chat excerpts between a user and an AI assistant, extract ONLY durable facts about the USER — things that would still be true next week.
 

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -6,14 +6,13 @@
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { writeTopicFile, readAllTopicFiles, archiveTopic } from "../../utils/files/journal-io.js";
 import {
-  type Summarize,
   type OptimizationTopicSnapshot,
   OPTIMIZATION_SYSTEM_PROMPT,
   buildOptimizationUserPrompt,
   extractJsonObject,
   isOptimizationOutput,
-  ClaudeCliNotFoundError,
-} from "./archivist.js";
+} from "./archivist-schemas.js";
+import { type Summarize, ClaudeCliNotFoundError } from "./archivist-cli.js";
 import { slugify } from "./paths.js";
 import type { JournalState } from "./state.js";
 import { log } from "../../system/logger/index.js";

--- a/server/workspace/sources/classifier.ts
+++ b/server/workspace/sources/classifier.ts
@@ -19,7 +19,7 @@
 
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
-import { ClaudeCliNotFoundError } from "../journal/archivist.js";
+import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { CATEGORY_SLUGS, normalizeCategories, type CategorySlug } from "./taxonomy.js";

--- a/server/workspace/sources/pipeline/summarize.ts
+++ b/server/workspace/sources/pipeline/summarize.ts
@@ -12,7 +12,7 @@
 
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
-import { ClaudeCliNotFoundError } from "../../journal/archivist.js";
+import { ClaudeCliNotFoundError } from "../../journal/archivist-cli.js";
 import { formatSpawnFailure } from "../../../utils/spawn.js";
 import { errorMessage } from "../../../utils/errors.js";
 import type { SourceItem } from "../types.js";

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { maybeIndexSession, backfillAllSessions, __resetForTests } from "../../server/workspace/chat-index/index.js";
 import { indexEntryPathFor } from "../../server/workspace/chat-index/paths.js";
-import { ClaudeCliNotFoundError } from "../../server/workspace/journal/archivist.js";
+import { ClaudeCliNotFoundError } from "../../server/workspace/journal/archivist-cli.js";
 import type { SummaryResult } from "../../server/workspace/chat-index/types.js";
 
 let workspace: string;

--- a/test/journal/test_archivist.ts
+++ b/test/journal/test_archivist.ts
@@ -8,7 +8,7 @@ import {
   isOptimizationOutput,
   type DailyArchivistInput,
   type OptimizationInput,
-} from "../../server/workspace/journal/archivist.js";
+} from "../../server/workspace/journal/archivist-schemas.js";
 
 describe("buildDailyUserPrompt", () => {
   const baseInput = (over: Partial<DailyArchivistInput> = {}): DailyArchivistInput => ({

--- a/test/journal/test_archivist_extract.ts
+++ b/test/journal/test_archivist_extract.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { extractJsonObject, findBalancedBraceBlock } from "../../server/workspace/journal/archivist.js";
+import { extractJsonObject, findBalancedBraceBlock } from "../../server/workspace/journal/archivist-schemas.js";
 
 describe("findBalancedBraceBlock", () => {
   it("extracts a simple JSON object", () => {

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -13,7 +13,7 @@ import {
   bucketParsedEvents,
   type ParsedEntry,
 } from "../../server/workspace/journal/dailyPass.js";
-import type { SessionExcerpt, ExistingTopicSnapshot } from "../../server/workspace/journal/archivist.js";
+import type { SessionExcerpt, ExistingTopicSnapshot } from "../../server/workspace/journal/archivist-schemas.js";
 import type { SessionFileMeta } from "../../server/workspace/journal/diff.js";
 import type { JournalState } from "../../server/workspace/journal/state.js";
 


### PR DESCRIPTION
## Summary
- Third of the four PRs sketched in \`plans/audit-journal-subsystem.md\` (#799). Behaviour-preserving refactor.
- The 386-line \`archivist.ts\` was a hotel mixing the Claude CLI subprocess wrapper with all the data shapes, prompts, and validators. Split into \`archivist-cli.ts\` (transport) and \`archivist-schemas.ts\` (pure data + prompts).
- 12 importers updated. No re-export shim — old \`archivist.ts\` deleted outright per the audit's \"don't accumulate shims\" rule.

## Items to Confirm / Review
- **Split line.** \`archivist-cli.ts\` = \`Summarize\` type, \`ClaudeCliNotFoundError\`, \`ClaudeCliFailedError\`, \`runClaudeCli\`. \`archivist-schemas.ts\` = everything else (interfaces, prompts, builders, validators, JSON-extract re-export). Picked because tests / new callers can use the schemas without dragging \`node:child_process\` in.
- **Cross-subsystem callers.** \`chat-index\` and \`sources\` use \`ClaudeCliNotFoundError\` because the \`claude\` CLI is a project-wide optional dep, not journal-specific. They now import from \`archivist-cli.js\` directly. (The class name still references journal in its message string — that's left for a separate name-cleanup pass if anyone cares.)
- **Old archivist.ts deleted.** The audit explicitly flagged re-export shims as clutter (PR1 deleted \`linkRewrite.ts\` for the same reason). No backwards-compat shim added.
- **No new tests.** Pure refactor — existing test files (\`test_archivist.ts\`, \`test_archivist_extract.ts\`, \`test_dailyPass.ts\`, \`test_maybe_index_session.ts\`) have their imports updated but no logic change. 3084/3084 unit tests pass.

## What's NOT in this PR
- PR4 (audit's last optional tier) — \`maybeRunJournal\` lock/disable/force unit tests + crash-recovery integration test.

## Branching note
- Branched off main, not off the open PR2 (#805). Imports in \`dailyPass.ts\` are at lines 18-31 (well above PR2's body changes), so no conflict expected on either merge order.

## User Prompt
> このまま次行ける？
>
> マージしないで次。
>
> 別ブランチで。

## Test plan
- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — 3084/3084 pass locally
- [ ] Manual: trigger a journal pass, confirm the split files compile correctly when packaged for production
- [ ] Verify any in-flight chat-index / sources runs still abort cleanly when the \`claude\` CLI is missing (\`ClaudeCliNotFoundError\` import path moved)

Refs #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure by separating CLI-specific functionality from schema and validation utilities, improving code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->