### PR TITLE
chore(wiki): correct task-persist-chain comment wording (#795 follow-up)

### DIFF
--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -516,8 +516,10 @@ const imeEnter = useImeAwareEnter(submitChat);
 /** Base directory for wiki content, adjusted by the current view. */
 const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
 
-// Serialised PUT chain for rapid checkbox clicks (#775). Each click
-// queues onto the previous so a slower network can't reorder writes.
+// Serialised POST chain for rapid task-checkbox clicks (#775). Each
+// click queues onto the previous so a slower network can't reorder
+// writes. (The wire call is `POST /api/wiki { action: "save" }`, not
+// PUT — the comment used to say PUT and contradicted the call site.)
 //
 // `saveQueueGeneration` invalidates older queued saves after a
 // failure-triggered refresh: their captured snapshots were computed


### PR DESCRIPTION
## Summary

CodeRabbit flagged `src/plugins/wiki/View.vue:516`. The comment described the chain as "Serialised PUT chain" but the actual wire call is `POST /api/wiki { action: "save" }`. Updates the comment to match the call site so the rationale doesn't contradict the implementation.

## User Prompt

> /daily-refactoring → 全部別 PR で対応できるものは全部する

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test` — 3084/3084
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)