### PR TITLE
fix: codex follow-up on #808 — narrow NODE_TEST_CONTEXT gate + registry-integration assertions

### DIFF
--- a/server/system/macosNotify.ts
+++ b/server/system/macosNotify.ts
@@ -67,15 +67,41 @@ interface Deps {
 // here. Without this gate, any test that goes through
 // `publishNotification` (e.g. the route-level scheduleTest tests)
 // fires real osascript and pollutes Reminders.app.
+//
+// Narrowed to the canonical `"child-v8"` value (the only one node's
+// test runner currently emits) rather than "any non-empty string"
+// — that limits the false-positive surface if a user happens to
+// have NODE_TEST_CONTEXT exported in their dev shell with some
+// other sentinel value (codex review on PR #808).
+const NODE_TEST_CONTEXT_VALUES = new Set(["child-v8"]);
+
 function isInsideNodeTest(): boolean {
-  return typeof process.env.NODE_TEST_CONTEXT === "string" && process.env.NODE_TEST_CONTEXT.length > 0;
+  const value = process.env.NODE_TEST_CONTEXT;
+  return typeof value === "string" && NODE_TEST_CONTEXT_VALUES.has(value);
 }
+
+const autoDisabledForTests = isInsideNodeTest();
 
 const defaultDeps: Deps = {
   spawner: spawn,
   platform: process.platform as Platform,
-  disabled: env.disableMacosReminderNotifications || isInsideNodeTest(),
+  disabled: env.disableMacosReminderNotifications || autoDisabledForTests,
 };
+
+// Observability hook — log once at module load if the auto-disable
+// fired but the user didn't set the explicit DISABLE_… flag. Lets a
+// dev who has NODE_TEST_CONTEXT inherited from their shell notice
+// why their reminders aren't firing. We only log on darwin to avoid
+// noise on Linux / Windows where the sink is silent anyway.
+if (autoDisabledForTests && !env.disableMacosReminderNotifications && process.platform === "darwin") {
+  log.info(
+    "macos-notify",
+    "auto-disabled because NODE_TEST_CONTEXT is set; export it only in test runners or set DISABLE_MACOS_REMINDER_NOTIFICATIONS=1 to silence this sink intentionally",
+    {
+      nodeTestContext: process.env.NODE_TEST_CONTEXT,
+    },
+  );
+}
 
 export function pushToMacosReminder(title: string, body?: string): Promise<void> {
   return pushToMacosReminderWithDeps(defaultDeps, title, body);

--- a/test/agent/test_notify_tool.ts
+++ b/test/agent/test_notify_tool.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { notify, makeNotifyTool, type NotifyPublishFn } from "../../server/agent/mcp-tools/notify.js";
+import { mcpTools } from "../../server/agent/mcp-tools/index.js";
 import { NOTIFICATION_KINDS } from "../../src/types/notification.js";
 
 // Capture each `publish` call so tests can assert on the args
@@ -94,5 +95,22 @@ describe("notify MCP tool — definition shape", () => {
     const tool = makeNotifyTool({ publish });
     assert.equal(tool.definition.name, notify.definition.name);
     assert.deepEqual(tool.definition.inputSchema, notify.definition.inputSchema);
+  });
+});
+
+// Codex review on #808 surfaced a gap: the unit tests above exercise
+// the factory in isolation, but never assert that the production
+// singleton is actually wired into the agent's MCP tool registry.
+// Without this, a refactor could quietly drop `notify` from the
+// registry and the agent would lose access — but every existing
+// test would still pass.
+describe("notify MCP tool — registry integration", () => {
+  it("is registered in the production mcpTools array", () => {
+    assert.ok(mcpTools.includes(notify), "notify must be in the mcpTools registry exported from server/agent/mcp-tools/index.ts");
+  });
+
+  it("appears in mcpTools by its canonical name", () => {
+    const byName = mcpTools.find((tool) => tool.definition.name === "notify");
+    assert.equal(byName, notify, "the tool registered under the name 'notify' must be the same object as the exported singleton");
   });
 });


### PR DESCRIPTION
## Summary

PR #808(マージ済み)に対する Codex review で 2 件の VALID-NIT が出たので別ブランチで対応。

| 指摘 | 修正 |
|---|---|
| \`NODE_TEST_CONTEXT\` を bare \`!== undefined\` で見ているので、dev shell に export されてたら \`tsx server/index.ts\` でも sink が silent に disable される | (a) \`"child-v8"\` 値のみ検知に narrow / (b) auto-disable 時に \`log.info\` を 1 回出して観測可能に |
| \`notify\` factory のテストはあるが、本番 \`mcpTools\` 配列への登録が pin されてない(refactor で抜け落ちても気付かない) | \`mcpTools.includes(notify)\` + name で引いて identity を確認する 2 ケースを追加 |

## Codex verdict (iter 1)

\`CODEX VERDICT: CHANGES REQUESTED\` — 詳細は PR #808 のレビューコメント参照。

## Verification

- \`yarn format\` / \`yarn lint\` / \`yarn typecheck\` clean
- 4 describe blocks of notify tests all pass(input validation / happy path / definition shape / **registry integration** [new])
- darwin 上で \`yarn test\` 走らせても Reminders.app に何も追加されないこと変わらず確認

## User Prompt

> /codex-cross-review 808 マージしてしまったけどレビューして問題あれば別ブランチで

🤖 Generated with [Claude Code](https://claude.com/claude-code)