### PR TITLE
refactor(ui): apply chrome-row standard to page headers

### DIFF
--- a/src/components/FileContentHeader.vue
+++ b/src/components/FileContentHeader.vue
@@ -1,11 +1,11 @@
 <template>
-  <div v-if="selectedPath" class="px-4 py-2 border-b border-gray-200 text-xs text-gray-500 font-mono shrink-0 flex items-center gap-2">
+  <div v-if="selectedPath" class="flex items-center gap-2 px-3 py-2 border-b border-gray-200 text-xs text-gray-500 font-mono shrink-0">
     <span class="truncate min-w-0">{{ selectedPath }}</span>
     <span v-if="size !== null" class="text-gray-400 shrink-0">· {{ formatBytes(size) }}</span>
     <span v-if="modifiedMs !== null" class="text-gray-400 shrink-0">· {{ formatDateTime(modifiedMs) }}</span>
     <button
       v-if="isMarkdown"
-      class="ml-auto shrink-0 px-2 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
+      class="ml-auto shrink-0 h-8 px-2.5 flex items-center gap-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-100 font-sans"
       :title="mdRawMode ? t('fileContentHeader.showRendered') : t('fileContentHeader.showRaw')"
       @click="emit('toggleMdRaw')"
     >
@@ -13,7 +13,7 @@
     </button>
     <button
       type="button"
-      class="shrink-0 px-1 py-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+      class="shrink-0 h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100"
       :class="{ 'ml-auto': !isMarkdown }"
       :title="t('fileContentHeader.closeFile')"
       :aria-label="t('fileContentHeader.closeFile')"

--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -1,29 +1,31 @@
 <template>
   <div class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50">
-    <div class="flex justify-end items-center gap-2 px-1 pb-1 text-xs">
+    <div class="flex justify-end items-center gap-2 pb-1 text-xs">
       <span class="text-gray-400">{{ t("fileTreePane.sort") }}</span>
-      <button
-        type="button"
-        class="px-2 py-0.5 rounded transition-colors"
-        :class="sortMode === 'name' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
-        :aria-pressed="sortMode === 'name'"
-        :title="t('fileTreePane.sortByName')"
-        data-testid="file-sort-name"
-        @click="emit('update:sortMode', 'name')"
-      >
-        {{ t("fileTreePane.name") }}
-      </button>
-      <button
-        type="button"
-        class="px-2 py-0.5 rounded transition-colors"
-        :class="sortMode === 'recent' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-500 hover:bg-gray-200'"
-        :aria-pressed="sortMode === 'recent'"
-        :title="t('fileTreePane.sortByRecent')"
-        data-testid="file-sort-recent"
-        @click="emit('update:sortMode', 'recent')"
-      >
-        {{ t("fileTreePane.recent") }}
-      </button>
+      <div class="flex border border-gray-300 rounded overflow-hidden">
+        <button
+          type="button"
+          class="h-8 px-2.5 flex items-center gap-1 transition-colors"
+          :class="sortMode === 'name' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
+          :aria-pressed="sortMode === 'name'"
+          :title="t('fileTreePane.sortByName')"
+          data-testid="file-sort-name"
+          @click="emit('update:sortMode', 'name')"
+        >
+          {{ t("fileTreePane.name") }}
+        </button>
+        <button
+          type="button"
+          class="h-8 px-2.5 flex items-center gap-1 transition-colors"
+          :class="sortMode === 'recent' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
+          :aria-pressed="sortMode === 'recent'"
+          :title="t('fileTreePane.sortByRecent')"
+          data-testid="file-sort-recent"
+          @click="emit('update:sortMode', 'recent')"
+        >
+          {{ t("fileTreePane.recent") }}
+        </button>
+      </div>
     </div>
     <div v-if="treeError" class="p-2 text-xs text-red-600">
       {{ treeError }}

--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full flex flex-col bg-white" data-testid="news-view">
     <!-- Header: title + filter chips + actions. -->
-    <div class="px-5 py-3 border-b border-gray-200 flex flex-wrap items-center gap-2 shrink-0">
+    <div class="px-3 py-2 border-b border-gray-200 flex flex-wrap items-center gap-2 shrink-0">
       <h1 class="text-base font-semibold text-gray-900 mr-3">{{ t("pluginNews.title") }}</h1>
       <span class="text-xs text-gray-500" data-testid="news-counts">{{
         t("pluginNews.itemCount", {
@@ -10,12 +10,12 @@
         })
       }}</span>
       <div class="ml-auto flex items-center gap-2">
-        <div class="flex border border-gray-300 rounded overflow-hidden text-xs" role="tablist">
+        <div class="flex border border-gray-300 rounded overflow-hidden" role="tablist">
           <button
             v-for="filter in readFilterChoices"
             :key="filter.value"
             :class="[
-              'px-2.5 py-1 transition-colors',
+              'h-8 px-2.5 flex items-center gap-1 text-sm transition-colors',
               readFilter === filter.value ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
             ]"
             :data-testid="`news-filter-${filter.value}`"
@@ -26,7 +26,7 @@
           </button>
         </div>
         <button
-          class="text-xs px-2.5 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="unreadCount === 0"
           data-testid="news-mark-all-read"
           @click="markAllReadNow"
@@ -37,7 +37,7 @@
     </div>
 
     <!-- Source filter chip row (only sources with items). -->
-    <div v-if="sourceChoices.length > 1" class="px-5 py-2 border-b border-gray-100 flex flex-wrap items-center gap-1 shrink-0">
+    <div v-if="sourceChoices.length > 1" class="px-3 py-2 border-b border-gray-100 flex flex-wrap items-center gap-1 shrink-0">
       <button
         v-for="choice in sourceChoices"
         :key="choice.slug"

--- a/src/components/SourcesManager.vue
+++ b/src/components/SourcesManager.vue
@@ -1,25 +1,25 @@
 <template>
   <div class="h-full flex flex-col overflow-hidden">
-    <div class="px-4 py-2 border-b border-gray-100 shrink-0 flex items-center justify-between gap-2">
+    <div class="px-3 py-2 border-b border-gray-100 shrink-0 flex items-center justify-between gap-2">
       <span class="text-sm font-medium text-gray-700 truncate"> {{ t("pluginManageSource.heading") }} </span>
       <div class="flex items-center gap-2 shrink-0">
         <span class="text-xs text-gray-500"> {{ t("pluginManageSource.sourceCount", sources.length, { named: { count: sources.length } }) }} </span>
         <button
-          class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
           :disabled="initialLoading || initialLoadError !== null || adding || busy === 'rebuild'"
           data-testid="sources-add-btn"
           @click="startAdd"
         >
-          <span class="material-icons text-sm align-middle">add</span>
+          <span class="material-icons text-sm">add</span>
           {{ t("pluginManageSource.addButton") }}
         </button>
         <button
-          class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
           :disabled="initialLoading || initialLoadError !== null || busy === 'rebuild'"
           data-testid="sources-rebuild-btn"
           @click="rebuild"
         >
-          <span class="material-icons text-sm align-middle">refresh</span>
+          <span class="material-icons text-sm">refresh</span>
           {{ busy === "rebuild" ? t("pluginManageSource.rebuilding") : t("pluginManageSource.rebuildNow") }}
         </button>
       </div>

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -10,7 +10,7 @@
           data-testid="todo-search"
           type="text"
           :placeholder="t('todoExplorer.searchPlaceholder')"
-          class="h-8 px-2 text-sm border border-gray-200 rounded w-44 focus:outline-none focus:border-blue-400"
+          class="h-8 px-2.5 text-sm border border-gray-200 rounded w-44 focus:outline-none focus:border-blue-400"
         />
       </div>
       <div class="flex items-center gap-2">

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-full bg-white flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between px-4 py-2 border-b border-gray-100 shrink-0 gap-3">
-      <div class="flex items-center gap-3 min-w-0">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+      <div class="flex items-center gap-2 min-w-0">
         <h2 class="text-base font-semibold text-gray-800 shrink-0">{{ t("todoExplorer.heading") }}</h2>
         <span class="text-xs text-gray-500 shrink-0">{{ t("todoExplorer.doneRatio", { done: completedCount, total: items.length }) }}</span>
         <input
@@ -10,29 +10,33 @@
           data-testid="todo-search"
           type="text"
           :placeholder="t('todoExplorer.searchPlaceholder')"
-          class="px-2 py-1 text-xs border border-gray-200 rounded w-44 focus:outline-none focus:border-blue-400"
+          class="h-8 px-2 text-sm border border-gray-200 rounded w-44 focus:outline-none focus:border-blue-400"
         />
       </div>
       <div class="flex items-center gap-2">
         <!-- Add button -->
-        <button data-testid="todo-add-btn" class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" @click="addOpen = true">
+        <button
+          data-testid="todo-add-btn"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+          @click="addOpen = true"
+        >
           {{ t("todoExplorer.addButton") }}
         </button>
         <!-- Add column button (kanban only) -->
         <button
           v-if="viewMode === TODO_VIEW.kanban"
           data-testid="todo-column-add-btn"
-          class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
           @click="addColumnOpen = true"
         >
           {{ t("todoExplorer.addColumnButton") }}
         </button>
         <!-- View mode toggle -->
-        <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
+        <div class="flex border border-gray-300 rounded overflow-hidden">
           <button
             v-for="mode in VIEW_MODES"
             :key="mode.key"
-            class="px-2.5 py-1"
+            class="h-8 w-8 flex items-center justify-center"
             :class="viewMode === mode.key ? 'bg-blue-500 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'"
             :data-testid="`todo-view-${mode.key}`"
             :title="mode.label"

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="h-full bg-white flex flex-col">
-    <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
       <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageRoles.heading") }}</h2>
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-2">
         <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", customRoles.length, { named: { count: customRoles.length } }) }}</span>
-        <button v-if="!creating" data-testid="role-add-btn" class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600" @click="startCreate">
+        <button
+          v-if="!creating"
+          data-testid="role-add-btn"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+          @click="startCreate"
+        >
           {{ t("pluginManageRoles.addButton") }}
         </button>
       </div>

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full bg-white flex flex-col overflow-hidden">
     <!-- Header -->
-    <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 shrink-0">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
       <div>
         <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageSkills.heading") }}</h2>
         <p class="text-xs text-gray-400 mt-0.5">{{ t("pluginManageSkills.subheading", { count: skills.length }) }}</p>
@@ -55,51 +55,51 @@
             <div class="flex items-center gap-2 shrink-0">
               <template v-if="editing">
                 <button
-                  class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 flex items-center gap-1"
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
                   data-testid="skill-cancel-btn"
                   @click="cancelEdit"
                 >
                   {{ t("common.cancel") }}
                 </button>
                 <button
-                  class="px-3 py-1.5 text-sm rounded bg-green-600 hover:bg-green-700 text-white disabled:opacity-40 flex items-center gap-1"
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-green-600 hover:bg-green-700 text-white disabled:opacity-40"
                   :disabled="saving"
                   data-testid="skill-save-btn"
                   @click="saveEdit"
                 >
-                  <span class="material-icons text-base">save</span>
+                  <span class="material-icons text-sm">save</span>
                   {{ t("common.save") }}
                 </button>
               </template>
               <template v-else>
                 <button
                   v-if="detail && detail.source === 'project'"
-                  class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40 flex items-center gap-1"
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
                   :disabled="detailLoading"
                   data-testid="skill-edit-btn"
                   @click="startEdit"
                 >
-                  <span class="material-icons text-base">edit</span>
+                  <span class="material-icons text-sm">edit</span>
                   {{ t("pluginManageSkills.btnEdit") }}
                 </button>
                 <button
                   v-if="detail && detail.source === 'project'"
-                  class="px-3 py-1.5 text-sm rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-40 flex items-center gap-1"
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-40"
                   :disabled="detailLoading || deleting"
                   data-testid="skill-delete-btn"
                   :title="t('pluginManageSkills.deleteProjectSkill')"
                   @click="deleteSkill"
                 >
-                  <span class="material-icons text-base">delete</span>
+                  <span class="material-icons text-sm">delete</span>
                   {{ t("pluginManageSkills.btnDelete") }}
                 </button>
                 <button
-                  class="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40 flex items-center gap-1"
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-40"
                   :disabled="detailLoading || !detail"
                   data-testid="skill-run-btn"
                   @click="runSkill"
                 >
-                  <span class="material-icons text-base">play_arrow</span>
+                  <span class="material-icons text-sm">play_arrow</span>
                   {{ t("pluginManageSkills.btnRun") }}
                 </button>
               </template>

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -37,31 +37,45 @@
     <!-- Calendar tab (existing content) -->
     <template v-if="activeTab === SCHEDULER_TAB.calendar">
       <!-- Header -->
-      <div class="flex items-center justify-between px-6 py-3 border-b border-gray-100">
-        <div class="flex items-center gap-3">
+      <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
+        <div class="flex items-center gap-2">
           <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginScheduler.heading") }}</h2>
           <span class="text-sm text-gray-500">{{ t("pluginScheduler.itemCount", items.length, { named: { count: items.length } }) }}</span>
         </div>
         <div class="flex items-center gap-2">
           <!-- Navigation (calendar modes only) -->
           <template v-if="viewMode !== SCHEDULER_VIEW.list">
-            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" :title="t('pluginScheduler.prev')" @click="goPrev">
-              <span class="material-icons text-sm">chevron_left</span>
-            </button>
-            <button class="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded" :title="t('pluginScheduler.goToday')" @click="goToday">
-              {{ t("pluginScheduler.today") }}
-            </button>
-            <button class="px-2 py-1 text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded" :title="t('pluginScheduler.next')" @click="goNext">
-              <span class="material-icons text-sm">chevron_right</span>
-            </button>
+            <div class="flex gap-0.5">
+              <button
+                class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:text-gray-800 hover:bg-gray-100"
+                :title="t('pluginScheduler.prev')"
+                @click="goPrev"
+              >
+                <span class="material-icons text-sm">chevron_left</span>
+              </button>
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 text-sm rounded text-gray-600 hover:bg-gray-100"
+                :title="t('pluginScheduler.goToday')"
+                @click="goToday"
+              >
+                {{ t("pluginScheduler.today") }}
+              </button>
+              <button
+                class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:text-gray-800 hover:bg-gray-100"
+                :title="t('pluginScheduler.next')"
+                @click="goNext"
+              >
+                <span class="material-icons text-sm">chevron_right</span>
+              </button>
+            </div>
             <span class="text-sm text-gray-600 min-w-[140px] text-center">{{ headerLabel }}</span>
           </template>
           <!-- View mode toggle -->
-          <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
+          <div class="flex border border-gray-300 rounded overflow-hidden">
             <button
               v-for="mode in VIEW_MODES"
               :key="mode.key"
-              class="px-2.5 py-1"
+              class="h-8 w-8 flex items-center justify-center"
               :class="viewMode === mode.key ? 'bg-blue-500 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'"
               :title="mode.label"
               @click="viewMode = mode.key"

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full bg-white flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between gap-2 px-6 py-2 border-b border-gray-100 shrink-0">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
       <div class="flex items-center gap-2 min-w-0">
         <button
           v-if="action !== 'index'"
@@ -34,7 +34,7 @@
           <span class="material-icons text-base">rule</span>
           {{ t("pluginWiki.lintChat") }}
         </button>
-        <div class="flex border border-gray-300 rounded overflow-hidden text-xs">
+        <div class="flex border border-gray-300 rounded overflow-hidden">
           <button
             :class="[
               'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',


### PR DESCRIPTION
## Summary

Align eight page headers with the CLAUDE.md "UI controls — standard height and spacing" rule, so that every chrome row across the app shares one sizing language.

- Row container: `flex items-center gap-2 px-3 py-2`
- Icon-only button: `h-8 w-8 flex items-center justify-center rounded`
- Icon + label / text-only pill: `h-8 px-2.5 flex items-center gap-1`
- Icon-cluster (calendar prev/today/next): `flex gap-0.5`

| Page | File(s) |
|---|---|
| Todo | `src/components/TodoExplorer.vue` |
| Calendar | `src/plugins/scheduler/View.vue` |
| Wiki | `src/plugins/wiki/View.vue` |
| Sources | `src/components/SourcesManager.vue` |
| News | `src/components/NewsView.vue` |
| Skills | `src/plugins/manageSkills/View.vue` |
| Roles | `src/plugins/manageRoles/View.vue` |
| Files | `src/components/FileTreePane.vue`, `src/components/FileContentHeader.vue` |

Actions (`TasksTab.vue`) has no chrome row — task rows are canvas elements per the CLAUDE.md exemption ("anything outside the canvas itself").

## Test plan

- [ ] Visual check of each page in dev (`npm run dev`): Todo, Calendar, Wiki, Sources, News, Skills, Roles, Files
- [ ] Confirm icon-only buttons (close, prev/next, view-mode toggle) are 32×32 squares
- [ ] Confirm pill buttons (Add, Rebuild, Run, etc.) sit at 32px height
- [ ] Confirm Calendar's prev/today/next cluster has the tighter `gap-0.5`
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` ✅ already green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Standardized button sizing and spacing (fixed heights, consistent padding, flex alignment) across interface components for a unified appearance.
  * Refined header and container padding throughout the application for improved visual balance.
  * Restructured sort and toggle controls with better layout organization.
  * Updated action button styling in headers, detail panes, and filter controls for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->