### PR TITLE
refactor: unify filter chips across panels with shared FilterChip

### DIFF
--- a/e2e/tests/history-filter.spec.ts
+++ b/e2e/tests/history-filter.spec.ts
@@ -22,8 +22,8 @@ test.describe("session-history filter pills", () => {
     await page.getByTestId("session-history-toggle-off").click();
 
     await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
-    // Class derived in the component: active pill gets bg-blue-500.
-    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-500/);
+    // Class derived in the component: active pill gets bg-blue-600.
+    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-600/);
   });
 
   test("clicking Unread highlights the pill", async ({ page }) => {
@@ -33,8 +33,8 @@ test.describe("session-history filter pills", () => {
 
     await page.getByTestId("session-filter-unread").click();
 
-    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-500/);
-    await expect(page.getByTestId("session-filter-all")).not.toHaveClass(/bg-blue-500/);
+    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-600/);
+    await expect(page.getByTestId("session-filter-all")).not.toHaveClass(/bg-blue-600/);
   });
 
   test("Human pill keeps default-origin sessions visible", async ({ page }) => {
@@ -44,7 +44,7 @@ test.describe("session-history filter pills", () => {
 
     await page.getByTestId("session-filter-human").click();
 
-    await expect(page.getByTestId("session-filter-human")).toHaveClass(/bg-blue-500/);
+    await expect(page.getByTestId("session-filter-human")).toHaveClass(/bg-blue-600/);
     // Default-origin sessions (no `origin` field) render as `human`
     // per `originOf`, so they remain visible under the Human filter.
     await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeVisible();
@@ -89,7 +89,7 @@ test.describe("session-history filter pills", () => {
     await page.goto("/chat");
     await page.getByTestId("session-history-toggle-off").click();
     await page.getByTestId("session-filter-unread").click();
-    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-500/);
+    await expect(page.getByTestId("session-filter-unread")).toHaveClass(/bg-blue-600/);
 
     // Close (dock toggle in panel header).
     await page.getByTestId("session-history-toggle-on").click();
@@ -97,6 +97,6 @@ test.describe("session-history filter pills", () => {
 
     // Reopen.
     await page.getByTestId("session-history-toggle-off").click();
-    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-500/);
+    await expect(page.getByTestId("session-filter-all")).toHaveClass(/bg-blue-600/);
   });
 });

--- a/plans/refactor-filter-chip-component.md
+++ b/plans/refactor-filter-chip-component.md
@@ -1,0 +1,129 @@
+# plan: unify filter chips across panels with a shared `<FilterChip>` component
+
+## Goal
+
+Filter chips currently live in four panels (Wiki, History, Sources, News) with
+four different visual languages — different blues, different text sizes
+(`text-[10px]` / `text-[11px]` / `text-xs`), different count formats (separate
+`<span>` vs inline `(N)`), and inconsistent borders. Standardize all four on
+the Wiki spec via a single shared `<FilterChip>` Vue component.
+
+## Non-goals
+
+- No behavioral change: single-vs-multi-select, "All" semantics, sort order,
+  testid names, i18n keys, ARIA — all preserved per panel.
+- No change to **toolbar mode toggles** (e.g. News' Unread/All segmented
+  control). Those stay in the toolbar with chrome-standard `h-8` styling.
+- No change to **inline tag pills** like Wiki's `entry-tag-chip` (used inside
+  list items, not as filter rows).
+- No change to **action buttons** that share the filter row (e.g. News'
+  "Mark all read", Sources' "Clear filter").
+- No new filter UX (clear-all chip, multi-select toggling, etc.).
+
+## Design
+
+### Standard
+
+Adopt Wiki's existing `tag-chip` spec verbatim:
+
+| Property | Value |
+|---|---|
+| Padding | `px-2 py-0.5` |
+| Text | `text-xs leading-4` (12px / 16px line-height) |
+| Shape | `rounded-full`, 1px border always |
+| Active | `bg-blue-600 text-white border-blue-600` |
+| Inactive | `bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-200` |
+| Count format | inline `label (N)` — no separate span |
+
+### New component — `src/components/FilterChip.vue`
+
+```vue
+<script setup lang="ts">
+defineProps<{
+  active: boolean;
+  label: string;
+  count?: number;  // omit to hide the count
+}>();
+defineEmits<{ click: [] }>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="active"
+    :class="[
+      'inline-flex items-center px-2 py-0.5 text-xs leading-4 rounded-full border transition-colors cursor-pointer',
+      active
+        ? 'bg-blue-600 text-white border-blue-600'
+        : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-200',
+    ]"
+    @click="$emit('click')"
+  >
+    {{ label }}<template v-if="count !== undefined"> ({{ count }})</template>
+  </button>
+</template>
+```
+
+`data-testid` and other attrs flow to the root `<button>` via Vue's default
+attrs passthrough — callers keep their existing testid strings.
+
+### Migration (4 sites)
+
+**1. Wiki** — `src/plugins/wiki/View.vue` lines 124–147
+- Replace three `<button class="tag-chip ...">` blocks with `<FilterChip>`.
+- Remove scoped CSS for `.tag-chip` / `.tag-chip-active` / `.tag-chip-inactive`
+  (lines 686–709). **Do NOT** remove `.entry-tag-chip` (still used in list
+  items).
+- Visual change: none.
+
+**2. History** — `src/components/SessionHistoryPanel.vue` lines 10–21
+- Replace the `v-for` button with `<FilterChip>`.
+- For the `all` filter, pass `:count="undefined"` (current code suppresses the
+  count for `all`).
+- Visual change: blue-500 → blue-600; inactive bg `white` → `gray-100`; count
+  format `12` → `(12)`. Minor.
+
+**3. Sources** — `src/components/SourcesManager.vue` lines 149–160
+- Replace the `v-for` button with `<FilterChip>`.
+- Pass `:count="filterCounts[key]"` for every chip (current code shows count on
+  all keys including `all`).
+- Visual change: inactive bg `white` → `gray-100`; count format `12` → `(12)`.
+  Minor.
+
+**4. News (source row only)** — `src/components/NewsView.vue` lines 41–52
+- Replace the `v-for` button with `<FilterChip>`.
+- Visual change: largest of the four. Active goes from light `bg-blue-100
+  text-blue-700` to solid `bg-blue-600 text-white`; borders added; text
+  `text-[11px]` → `text-xs`. Worth eyeballing in the browser before merge.
+
+### Out of scope but worth noting
+
+The header rows that **contain** these filter chip rows have their own padding
+mismatches (`px-3 py-2` / `px-4 py-2` / `px-5 py-3` / no padding). This plan
+does NOT touch container padding — that's a separate cleanup. Filed mentally
+for a follow-up if/when we standardize panel header chrome.
+
+## Files touched
+
+- `src/components/FilterChip.vue` — new
+- `src/plugins/wiki/View.vue` — replace chips, remove scoped CSS for tag-chip
+- `src/components/SessionHistoryPanel.vue` — replace chips
+- `src/components/SourcesManager.vue` — replace chips
+- `src/components/NewsView.vue` — replace source-filter chips only
+
+## Tests
+
+E2E tests select these chips by `data-testid` (e.g. `wiki-tag-filter-${tag}`,
+`session-filter-${f}`, `sources-filter-chip-${key}`, `news-source-${slug}`).
+testids are preserved verbatim, so existing tests should keep passing.
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` per
+CLAUDE.md before considering done. Manual eyeball pass on each of the 4
+panels (especially News) before PR.
+
+## Open questions
+
+- Whether the `bg-blue-600 / white` active style is too loud for the News
+  source row, where chips can number 5+ and previously used a softer fill.
+  Decision: ship as-specified per the user's "Wiki に統一" call; revisit only
+  if visually jarring once landed.

--- a/src/components/FilterChip.vue
+++ b/src/components/FilterChip.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+defineProps<{
+  active: boolean;
+  label: string;
+  count?: number;
+}>();
+defineEmits<{ click: [] }>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="active"
+    :class="[
+      'inline-flex items-center px-2 py-0.5 text-xs leading-4 rounded-full border transition-colors cursor-pointer',
+      active ? 'bg-blue-600 text-white border-blue-600' : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-200',
+    ]"
+    @click="$emit('click')"
+  >
+    {{ label }}<template v-if="count !== undefined"> ({{ count }})</template>
+  </button>
+</template>

--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -38,18 +38,15 @@
 
     <!-- Source filter chip row (only sources with items). -->
     <div v-if="sourceChoices.length > 1" class="px-5 py-2 border-b border-gray-100 flex flex-wrap items-center gap-1 shrink-0">
-      <button
+      <FilterChip
         v-for="choice in sourceChoices"
         :key="choice.slug"
-        :class="[
-          'text-[11px] px-2 py-0.5 rounded transition-colors',
-          sourceFilter === choice.slug ? 'bg-blue-100 text-blue-700 font-medium' : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
-        ]"
+        :active="sourceFilter === choice.slug"
+        :label="choice.label"
+        :count="choice.count"
         :data-testid="`news-source-${choice.slug}`"
         @click="sourceFilter = choice.slug"
-      >
-        {{ choice.label }}<span class="ml-1 opacity-60">({{ choice.count }})</span>
-      </button>
+      />
     </div>
 
     <!-- Body: list (left) + detail (right). -->
@@ -136,6 +133,7 @@ import { apiGet } from "../utils/api";
 import { formatSmartTime } from "../utils/format/date";
 import { useNewsItems } from "../composables/useNewsItems";
 import { useNewsReadState } from "../composables/useNewsReadState";
+import FilterChip from "./FilterChip.vue";
 
 const { t } = useI18n();
 const route = useRoute();

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -6,18 +6,16 @@
   <div ref="root" class="h-full overflow-y-auto bg-white select-none">
     <div class="p-2 space-y-2">
       <!-- Origin filter bar -->
-      <div class="flex gap-1 mb-1 flex-wrap" data-testid="session-filter-bar">
-        <button
+      <div class="flex gap-1 mb-3 flex-wrap" data-testid="session-filter-bar">
+        <FilterChip
           v-for="f in HISTORY_FILTER_ORDER"
           :key="f"
-          class="px-2 py-0.5 text-[10px] rounded-full border transition-colors"
-          :class="activeFilter === f ? 'bg-blue-500 text-white border-blue-500' : 'bg-white text-gray-500 border-gray-300 hover:bg-gray-50'"
+          :active="activeFilter === f"
+          :label="t(`sessionHistoryPanel.filters.${f}`)"
+          :count="f === HISTORY_FILTERS.all ? undefined : countByOrigin(f)"
           :data-testid="`session-filter-${f}`"
           @click="activeFilter = f"
-        >
-          {{ t(`sessionHistoryPanel.filters.${f}`) }}
-          <span v-if="f !== HISTORY_FILTERS.all" class="ml-0.5 opacity-70">{{ countByOrigin(f) }}</span>
-        </button>
+        />
       </div>
 
       <div
@@ -81,6 +79,7 @@ import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../config/historyFilters";
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
+import FilterChip from "./FilterChip.vue";
 
 const { t } = useI18n();
 

--- a/src/components/SourcesManager.vue
+++ b/src/components/SourcesManager.vue
@@ -146,18 +146,15 @@
           role="toolbar"
           :aria-label="t('pluginManageSource.filter.all')"
         >
-          <button
+          <FilterChip
             v-for="key in visibleFilterKeys"
             :key="key"
-            class="text-[11px] px-2 py-0.5 rounded-full border transition-colors"
-            :class="filterKey === key ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'"
+            :active="filterKey === key"
+            :label="filterChipLabel(key)"
+            :count="filterCounts[key]"
             :data-testid="`sources-filter-chip-${key}`"
-            :aria-pressed="filterKey === key"
             @click="selectFilter(key)"
-          >
-            {{ filterChipLabel(key) }}
-            <span class="ml-1 text-[10px] opacity-80">{{ filterCounts[key] }}</span>
-          </button>
+          />
         </div>
 
         <!-- Filter-only empty state. Distinct from the no-sources
@@ -272,6 +269,7 @@ import type { ManageSourceData, RebuildSummary, Source } from "../plugins/manage
 import { apiGet, apiPost, apiDelete } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { SOURCE_FILTER_KEYS, countByFilter, matchesSourceFilter, type SourceFilterKey } from "../utils/sources/filter";
+import FilterChip from "./FilterChip.vue";
 
 const { t } = useI18n();
 

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -121,30 +121,24 @@
     <!-- Index: tag filter + page card list -->
     <div v-else-if="action === 'index' && pageEntries && pageEntries.length > 0" class="flex-1 flex flex-col overflow-hidden">
       <div v-if="allTags.length > 0 || selectedTag !== null" class="shrink-0 border-b border-gray-100 px-4 py-2 flex flex-wrap gap-1">
-        <button
-          :class="['tag-chip', selectedTag === null ? 'tag-chip-active' : 'tag-chip-inactive']"
-          data-testid="wiki-tag-filter-all"
-          @click="selectedTag = null"
-        >
-          {{ t("pluginWiki.tagFilterAll") }}
-        </button>
-        <button
+        <FilterChip :active="selectedTag === null" :label="t('pluginWiki.tagFilterAll')" data-testid="wiki-tag-filter-all" @click="selectedTag = null" />
+        <FilterChip
           v-for="[tag, count] in allTags"
           :key="tag"
-          :class="['tag-chip', selectedTag === tag ? 'tag-chip-active' : 'tag-chip-inactive']"
+          :active="selectedTag === tag"
+          :label="tag"
+          :count="count"
           :data-testid="`wiki-tag-filter-${tag}`"
           @click="toggleTagFilter(tag)"
-        >
-          {{ tag }} ({{ count }})
-        </button>
-        <button
+        />
+        <FilterChip
           v-if="selectedTag !== null && !allTags.some(([tag]) => tag === selectedTag)"
-          class="tag-chip tag-chip-active"
+          :active="true"
+          :label="selectedTag"
+          :count="1"
           :data-testid="`wiki-tag-filter-${selectedTag}`"
           @click="toggleTagFilter(selectedTag)"
-        >
-          {{ `${selectedTag} (1)` }}
-        </button>
+        />
       </div>
       <div v-if="visibleEntries.length === 0 && selectedTag" class="flex-1 flex items-center justify-center text-gray-400 text-sm px-4 text-center">
         {{ t("pluginWiki.noMatches", { tag: selectedTag }) }}
@@ -240,6 +234,7 @@ import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { PAGE_ROUTES } from "../../router";
 import { WIKI_ACTION, WIKI_ROUTE_SECTION, buildWikiRouteParams, isSafeWikiSlug, readWikiRouteTarget, wikiActionFor, type WikiTarget } from "./route";
+import FilterChip from "../../components/FilterChip.vue";
 
 type WikiTabView = typeof WIKI_ACTION.log | typeof WIKI_ACTION.lintReport;
 
@@ -683,30 +678,6 @@ function handleContentClick(event: MouseEvent) {
 </script>
 
 <style scoped>
-.tag-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.125rem 0.5rem;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  border-radius: 9999px;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-.tag-chip-active {
-  background-color: #2563eb;
-  color: white;
-  border-color: #2563eb;
-}
-.tag-chip-inactive {
-  background-color: #f3f4f6;
-  color: #374151;
-  border-color: #e5e7eb;
-}
-.tag-chip-inactive:hover {
-  background-color: #e5e7eb;
-}
 .entry-tag-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- New `<FilterChip>` component standardizes filter-chip styling across **Wiki**, **History**, **Sources**, and **News** (source row).
- Adopts Wiki's existing spec verbatim: `bg-blue-600 / white` active, `bg-gray-100 / gray-700` inactive, `text-xs leading-4`, `rounded-full` with 1px border, inline `(N)` count format.
- Removes scoped CSS for `.tag-chip*` from Wiki (now lives in the shared component); inline tag pills (`entry-tag-chip`) intentionally untouched.
- Widens History panel filter row's bottom margin (`mb-1` → `mb-3`) so chips don't crowd the session list.
- Toolbar mode toggles (e.g. News' Unread/All) and one-shot action buttons are intentionally **out of scope** — see plan doc for the rationale.

## Visual change per panel

| Panel | Change |
|---|---|
| Wiki | None (was the standard) |
| History | `bg-blue-500` → `bg-blue-600`; inactive bg `white` → `gray-100`; count format `12` → `(12)` |
| Sources | Inactive bg `white` → `gray-100`; count format `12` → `(12)` |
| News (source row) | Largest change: active `bg-blue-100 text-blue-700` → `bg-blue-600 text-white`; borders added |

Plan: `plans/refactor-filter-chip-component.md`

## Test plan

- [x] `yarn format`
- [x] `yarn lint` (no new warnings)
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test` (unit)
- [x] `yarn test:e2e` (updated `history-filter.spec.ts` color regex `bg-blue-500` → `bg-blue-600`)
- [ ] Manual eyeball on each panel — Wiki, History, Sources, News (esp. News, which changes the most)

🤖 Generated with [Claude Code](https://claude.com/claude-code)