### PR TITLE
fix: comment out agent-completion bell — duplicate of Session History Panel badge

### DIFF
--- a/plans/fix-comment-out-bell-on-agent-completion.md
+++ b/plans/fix-comment-out-bell-on-agent-completion.md
@@ -1,0 +1,130 @@
+# Fix: comment out bell on agent-completion (duplicate of Session History Panel badge)
+
+## The rule
+
+**Never fire two notifications for the same event.** Two badges in
+the same chrome row that flip on the same trigger are noise — the
+user has to dismiss both, and the second one carries no information
+the first one didn't already carry.
+
+## When the duplicate occurs
+
+The double notification only occurs **when a chat session receives
+a new message**. That is the precise condition under which both
+indicators flip together:
+
+1. **Session History Panel toggle button** — the red unread count
+   badge on the panel toggle icon. Driven by
+   `session.hasUnread`. It can only be set by `endRun()` in
+   `server/events/session-store/index.ts` (line 140), which is
+   called once per chat-session turn completion.
+2. **Notification bell** — the red unread count badge on the
+   bell icon. Driven by `publishNotification()` arrivals on the
+   `notifications` pubsub channel.
+
+These are independent signals fed by independent call paths. They
+overlap only when the *same event* triggers both — i.e. when
+`publishNotification` is called from a code path that has just
+posted a new message to a chat session.
+
+## Audit of `publishNotification` call sites
+
+| Call site | Posts a message to a chat session at the same time? | Duplicate? |
+|---|---|---|
+| `server/api/routes/agent.ts:494` (agent-turn finally block, non-human origins) | **Yes** — fires immediately after `endRun(chatSessionId)` in the same `finally` | **Yes — this is the bug** |
+| `server/workspace/sources/pipeline/notify.ts` (news pipeline interesting-article alerts) | No — the pipeline writes to source feeds / data, not to a chat session | No |
+| `server/agent/mcp-tools/notify.ts` (`notify` MCP tool, agent-invoked) | Only when the user explicitly asked the agent for a notification ("通知して" / "tell me when …"). In that case the bell IS the user-requested signal — out of scope here | Out of scope |
+| `server/events/notifications.ts:154` (`scheduleTestNotification`, legacy/dev) | No — dev/test endpoint | No |
+
+So the duplicate exists at exactly **one** call site: the
+`finally` block of `runAgentInBackground` in `agent.ts`, added by
+PR #792 (commit `97aee460`,
+`feat(notify): publishNotification on non-human turn completion
+(#789)`).
+
+## Verified frontend chain
+
+### Surface 1 — Session History Panel toggle button
+
+1. `server/api/routes/agent.ts:487`: `endRun(chatSessionId)` (always, regardless of origin).
+2. `server/events/session-store/index.ts:140`: `session.hasUnread = true`.
+3. `notifySessionsChanged()` propagates to the frontend.
+4. `src/composables/useSessionDerived.ts:53`: `unreadCount = sessions.filter(s => s.hasUnread).length`.
+5. `src/components/SessionHistoryToggleButton.vue:18-22`: red `unreadCount` badge on the panel toggle icon.
+
+### Surface 2 — Notification bell
+
+1. `server/api/routes/agent.ts:494` (this PR comments this out): `publishNotification({ kind: agent, ... })` for non-human origins.
+2. `server/events/notifications.ts:82-84`: publishes to `PUBSUB_CHANNELS.notifications`.
+3. `src/composables/useNotifications.ts:66-69`: subscribes, prepends the payload.
+4. `src/composables/useNotifications.ts:115`: `unreadCount = notifications.filter(n => !readIds.has(n.id)).length`.
+5. `src/components/NotificationBell.vue:94-98`: red `unreadCount` badge on the bell icon.
+
+The initiator of the turn (human, bridge user, scheduled job,
+skill chain, another agent — any of them) does not change this
+analysis. As long as the agent posts a reply to a chat session
+and `publishNotification` fires for the same turn, both badges
+flip together.
+
+## Decision
+
+**Comment out** the `publishNotification` call in `agent.ts`'s
+`finally` block — do not delete it. Keeping the block (and its
+associated imports / helper) commented in-place makes the prior
+intent visible: a future reader sees *why* the line was disabled
+without having to dig through `git log`.
+
+The accompanying inline comment is signed `(by snakajima)` so
+the authority for the decision is explicit at the call site.
+
+## Change
+
+`server/api/routes/agent.ts`:
+
+1. Lines 31-32: comment out the imports of `NOTIFICATION_KINDS`
+   and `publishNotification` (otherwise the unused-import lint
+   rule fires once the call site below is dead).
+2. Lines 387-401: comment out the `completionNotificationTitle`
+   helper (only caller is the commented block; otherwise the
+   unused-function lint rule fires).
+3. Lines 488-499: comment out the `publishNotification` call
+   site, with a header comment that names the duplicate-with-
+   Session-History-Panel reason and ends with `(by snakajima)`.
+
+`SessionOrigin` and `SESSION_ORIGINS` are kept un-commented —
+they are still used by `BackgroundRunParams` and the
+bridge-origin decoration switch elsewhere in the file.
+
+## Side effects
+
+- The macOS Reminder sink (PR #789) is downstream of the same
+  `publishNotification` call. It therefore stops firing on
+  agent completion — which is fine: the agent-completion
+  reminder is exactly the duplicate event; the user already
+  sees the chat-session unread badge in the web UI, and any
+  bridge-originated reply has already been pushed back to the
+  bridge platform's app (Telegram / Slack / etc.), which itself
+  reaches the phone.
+- Other `publishNotification` callers (news pipeline, `notify`
+  MCP tool, scheduled-test endpoint) are **unaffected**. Only
+  the agent-turn-completion call site is suppressed.
+
+## Acceptance
+
+- [ ] Bridge-origin (Telegram / Slack / LINE / …) session
+      completes → Session History Panel toggle button shows
+      the red unread badge, Notification Bell does **not** show
+      a new entry.
+- [ ] Skill-origin session completes → same: history toggle
+      badges, bell does not.
+- [ ] Scheduler-origin session completes → same: history toggle
+      badges, bell does not.
+- [ ] Human-origin session completes → bell unchanged (still no
+      new entry).
+- [ ] News pipeline interesting-article match → bell still fires
+      (regression check; that path doesn't touch a chat session,
+      so it isn't a duplicate).
+- [ ] Agent invokes the `notify` MCP tool ("通知して" /
+      "tell me when …") → bell still fires (regression check).
+- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`,
+      `yarn test` all clean.

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -27,9 +27,18 @@ import { logBackgroundError } from "../../utils/logBackgroundError.js";
 import { createArgsCache, recordToolEvent } from "../../workspace/tool-trace/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
-import { isSessionOrigin, SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
-import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
-import { publishNotification } from "../../events/notifications.js";
+import { isSessionOrigin, type SessionOrigin } from "../../../src/types/session.js";
+// Imports kept commented (instead of deleted) alongside the
+// publishNotification call below — see the duplicate-notification
+// comment near `endRun()` in `runAgentInBackground` for context.
+// `SESSION_ORIGINS` is dragged into this same commented block
+// because every remaining live reference to it lived inside the
+// commented helper / call site; once those went, leaving the value
+// import un-commented would trip the unused-import lint rule.
+// (by snakajima)
+// import { SESSION_ORIGINS } from "../../../src/types/session.js";
+// import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
+// import { publishNotification } from "../../events/notifications.js";
 import { env } from "../../system/env.js";
 import type { Attachment } from "@mulmobridge/protocol";
 import { parseDataUrl } from "@mulmobridge/client";
@@ -384,21 +393,26 @@ async function flushTextAccumulator(ctx: EventContext): Promise<void> {
   );
 }
 
-// Build the title used for the agent-completion notification on
-// non-human runs. Surfaces both the role name and the trigger so
-// the user can read it in passing on a phone lock screen.
-function completionNotificationTitle(roleName: string, origin: SessionOrigin): string {
-  switch (origin) {
-    case SESSION_ORIGINS.scheduler:
-      return `✅ ${roleName} (scheduler) finished`;
-    case SESSION_ORIGINS.skill:
-      return `✅ ${roleName} (skill) finished`;
-    case SESSION_ORIGINS.bridge:
-      return `✅ ${roleName} reply ready`;
-    default:
-      return `✅ ${roleName} finished`;
-  }
-}
+// Helper kept commented (instead of deleted) alongside the
+// publishNotification call below — see the duplicate-notification
+// comment near `endRun()` in `runAgentInBackground` for context.
+// (by snakajima)
+//
+// // Build the title used for the agent-completion notification on
+// // non-human runs. Surfaces both the role name and the trigger so
+// // the user can read it in passing on a phone lock screen.
+// function completionNotificationTitle(roleName: string, origin: SessionOrigin): string {
+//   switch (origin) {
+//     case SESSION_ORIGINS.scheduler:
+//       return `✅ ${roleName} (scheduler) finished`;
+//     case SESSION_ORIGINS.skill:
+//       return `✅ ${roleName} (skill) finished`;
+//     case SESSION_ORIGINS.bridge:
+//       return `✅ ${roleName} reply ready`;
+//     default:
+//       return `✅ ${roleName} finished`;
+//   }
+// }
 
 async function runAgentInBackground(params: BackgroundRunParams): Promise<void> {
   const { decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, resultsFilePath, requestStartedAt, toolArgsCache, attachments, userTimezone } =
@@ -485,18 +499,38 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
     });
   } finally {
     endRun(chatSessionId);
-    // Fire a completion notification for runs the user wasn't sitting
-    // in front of. Human-initiated runs are skipped because the
-    // bell-update is already visible in the UI. The wrapper inside
-    // `publishNotification` handles all sinks (web bell + bridge +
-    // macOS Reminders) so this single call covers every channel.
-    if (params.origin && params.origin !== SESSION_ORIGINS.human) {
-      publishNotification({
-        kind: NOTIFICATION_KINDS.agent,
-        title: completionNotificationTitle(params.role.name, params.origin),
-        sessionId: chatSessionId,
-      });
-    }
+    // Commented out: this would create a duplicate notification.
+    //
+    // `endRun(chatSessionId)` above flips `session.hasUnread = true`
+    // for every chat-session turn completion regardless of origin,
+    // which already lights up the red unread-count badge on the
+    // Session History Panel toggle button (driven by `hasUnread` →
+    // `useSessionDerived.unreadCount` →
+    // `SessionHistoryToggleButton.vue`). Firing
+    // `publishNotification` here adds a *second* red badge — on the
+    // notification bell — for the exact same event, in the same
+    // chrome row. Two indicators, one event = noise.
+    //
+    // The duplicate occurs whenever a chat session receives a new
+    // message, which is exactly what every code path through this
+    // `finally` represents. The initiator of the turn (human, bridge
+    // user, scheduled job, skill chain, another agent) does not
+    // change this — both badges flip together.
+    //
+    // Other `publishNotification` call sites (news pipeline, `notify`
+    // MCP tool, scheduled-test endpoint) do not post a chat-session
+    // message at the same time, so they are not duplicates and
+    // remain enabled.
+    //
+    // (by snakajima)
+    //
+    // if (params.origin && params.origin !== SESSION_ORIGINS.human) {
+    //   publishNotification({
+    //     kind: NOTIFICATION_KINDS.agent,
+    //     title: completionNotificationTitle(params.role.name, params.origin),
+    //     sessionId: chatSessionId,
+    //   });
+    // }
     // Fire-and-forget: journal + chat-index post-processing
     maybeRunJournal({ activeSessionIds: getActiveSessionIds() }).catch(logBackgroundError("journal"));
     maybeIndexSession({


### PR DESCRIPTION
## Summary

Comment out (do not delete) the agent-turn-completion `publishNotification` call in `server/api/routes/agent.ts` because it duplicates the Session History Panel toggle button's unread badge for the same event.

PR #792 (commit `97aee460`) added a `publishNotification` call in `runAgentInBackground`'s `finally` block to fire the notification bell on every non-human-origin turn completion. But `endRun(chatSessionId)` — which always runs in the same `finally`, regardless of origin — already flips `session.hasUnread = true`, which drives the red unread-count badge on the **Session History Panel toggle button**. So every bridge / skill / scheduler reply now lights up **two red badges in the same chrome row** for the same event. Two indicators, one event = noise.

## The rule

**Never fire two notifications for the same event.** Two badges that flip on the same trigger force the user to dismiss both and add no information. The initiator of the turn (human, bridge user, scheduled job, skill chain, another agent) is irrelevant — both badges flip together.

## Where the duplicate exists

The double notification only occurs when a chat session receives a new message. I audited every `publishNotification` caller:

| Call site | Posts a chat-session message at the same time? | Duplicate? |
|---|---|---|
| `agent.ts:494` (this PR) | Yes — runs after `endRun(chatSessionId)` in the same finally | **Yes** |
| `pipeline/notify.ts` (news pipeline) | No — writes to source feeds, not a chat session | No |
| `mcp-tools/notify.ts` (`notify` MCP tool) | Only when the user explicitly asked the agent for a notification — out of scope | Out of scope |
| `notifications.ts:154` (`scheduleTestNotification`) | No — dev/test endpoint | No |

Only the `agent.ts` call site is a duplicate, and that's the only thing this PR touches.

## Why comment out (not delete)

Per request, the call site is **commented out in place** rather than removed. This keeps the prior intent visible to future contributors — they see *why* the line was disabled without having to dig through `git log`. The inline comment is signed `(by snakajima)` so the authority for the decision is explicit at the call site.

The unused imports (`NOTIFICATION_KINDS`, `publishNotification`, `SESSION_ORIGINS`) and the now-uncalled `completionNotificationTitle` helper are commented out alongside, otherwise the unused-import / unused-function lint rules would fire. `SessionOrigin` (the type) and `isSessionOrigin` (used by `BackgroundRunParams`) stay live.

## Side effect: macOS Reminder sink

The macOS Reminder sink (PR #789) is downstream of the same `publishNotification` call, so the iPhone push for agent completion is suppressed too. This is intentional — same duplicate-notification rule applies (the user already sees the chat-session unread badge in the web UI; bridge-originated replies are pushed back to the bridge platform's app, which itself reaches the phone).

Other `publishNotification` callers are unaffected — only the agent-turn-completion call site is suppressed.

## Verified frontend chain

### Surface 1 — Session History Panel toggle button

`endRun()` in `server/events/session-store/index.ts:140` sets `hasUnread = true` → `useSessionDerived.ts:53` computes `unreadCount = sessions.filter(s => s.hasUnread).length` → `SessionHistoryToggleButton.vue:18-22` renders the red badge.

### Surface 2 — Notification bell

`publishNotification()` → `notifications.ts:82-84` publishes to `PUBSUB_CHANNELS.notifications` → `useNotifications.ts:66-69` subscribes → `useNotifications.ts:115` computes `unreadCount` → `NotificationBell.vue:94-98` renders the red badge.

Both surfaces sit in the same chrome row, both flip together for every non-human-origin completion before this PR.

## Test plan

- [ ] Bridge-origin (Telegram / Slack / LINE / …) session completes → Session History Panel toggle button shows the red unread badge, Notification Bell does **not** show a new entry
- [ ] Skill-origin session completes → same: history toggle badges, bell does not
- [ ] Scheduler-origin session completes → same: history toggle badges, bell does not
- [ ] Human-origin session completes → bell unchanged (still no new entry)
- [ ] News pipeline interesting-article match → bell still fires (regression check)
- [ ] Agent invokes the `notify` MCP tool ("通知して" / "tell me when …") → bell still fires (regression check)
- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build` clean

Plan: `plans/fix-comment-out-bell-on-agent-completion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Resolved duplicate notifications on agent completion** – The notification bell will no longer trigger redundantly when an agent operation completes, eliminating overlapping notifications in the Session History Panel and notification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->