### PR TITLE
test: edge-case coverage for journal feature gates + crash recovery (PR4 of #799)

### DIFF
--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -74,6 +74,18 @@ let running = false;
 // on every session-end. Reset on server restart.
 let disabled = false;
 
+// Test-only reset for the module-level flags. The lock + disable
+// flags are intentionally module-scoped so a fresh server start
+// always begins from "neither running nor disabled"; a unit test
+// that exercises maybeRunJournal across multiple call sequences
+// needs a way to reproduce that fresh-start condition without
+// re-importing the module. Not exported via index — only consumers
+// importing this file directly should reach for it.
+export function __resetForTests(): void {
+  running = false;
+  disabled = false;
+}
+
 // The agent route calls this as `maybeRunJournal().catch(...)`.
 export interface MaybeRunJournalOptions {
   summarize?: Summarize;

--- a/test/journal/test_dailyPass_crashRecovery.ts
+++ b/test/journal/test_dailyPass_crashRecovery.ts
@@ -73,12 +73,12 @@ describe("runDailyPass — crash recovery", () => {
     // skipped rather than the whole pass crashing. The session-
     // ingest checkpoint for day 1 still commits via persistStateAfterDay.
     let dailySummarizeCalls = 0;
-    let memorySummarizeCalls = 0;
     // Match by system prompt header — DAILY_SYSTEM_PROMPT starts with
     // "You are the journal archivist", memoryExtractor's prompt starts
     // with "You are a personal-fact extractor". Day 1 succeeds, day 2
-    // throws, memory always succeeds (returning empty so nothing gets
-    // appended — keeps the test focused on per-day checkpoint behaviour).
+    // throws; memory always succeeds with an empty result so nothing
+    // gets appended — keeps the test focused on per-day checkpoint
+    // behaviour and the day count assertion stays unambiguous.
     const stubFlaky: Summarize = async (systemPrompt) => {
       if (systemPrompt.startsWith("You are the journal archivist")) {
         dailySummarizeCalls++;
@@ -87,7 +87,6 @@ describe("runDailyPass — crash recovery", () => {
         }
         throw new Error("simulated mid-pass crash");
       }
-      memorySummarizeCalls++;
       return '{"facts":[]}';
     };
 

--- a/test/journal/test_dailyPass_crashRecovery.ts
+++ b/test/journal/test_dailyPass_crashRecovery.ts
@@ -1,0 +1,137 @@
+// Crash-recovery integration test for `runDailyPass` (#799 PR4).
+//
+// `dailyPass.ts` writes _state.json after each successful day via
+// `persistStateAfterDay`. Comments around the day loop claim
+// per-day checkpointing makes the pass crash-safe — if the process
+// dies mid-loop, the next run picks up only the days that hadn't
+// committed.
+//
+// Until now nothing in the test suite exercised that claim. This
+// file simulates a mid-pass failure by injecting a Summarize stub
+// that succeeds for the first day's call and throws for subsequent
+// ones, then re-runs with a working stub and asserts the second
+// day catches up cleanly.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { runDailyPass } from "../../server/workspace/journal/dailyPass.js";
+import { defaultState, parseState } from "../../server/workspace/journal/state.js";
+import type { Summarize } from "../../server/workspace/journal/archivist-cli.js";
+
+let workspaceRoot: string;
+const SESSION_DAY1 = "11111111-1111-1111-1111-111111111111";
+const SESSION_DAY2 = "22222222-2222-2222-2222-222222222222";
+
+// dailyPass buckets a session by its file mtime (`stat.mtimeMs` →
+// `toIsoDate`), not by per-event timestamps. Force two days by
+// utimes-ing the session files explicitly to different dates.
+const DAY_ONE_DATE = "2026-04-23";
+const DAY_TWO_DATE = "2026-04-24";
+const dayOneEpoch = new Date(`${DAY_ONE_DATE}T12:00:00Z`).getTime() / 1000;
+const dayTwoEpoch = new Date(`${DAY_TWO_DATE}T12:00:00Z`).getTime() / 1000;
+
+before(async () => {
+  workspaceRoot = await mkdtemp(path.join(tmpdir(), "mulmo-daily-crash-recovery-"));
+  const chatDir = path.join(workspaceRoot, "conversations", "chat");
+  await mkdir(chatDir, { recursive: true });
+
+  // `parseEntry` only accepts EVENT_TYPES.text / .toolResult.
+  const dayOneFile = path.join(chatDir, `${SESSION_DAY1}.jsonl`);
+  const dayTwoFile = path.join(chatDir, `${SESSION_DAY2}.jsonl`);
+  await writeFile(dayOneFile, JSON.stringify({ source: "user", type: "text", message: "day one" }) + "\n");
+  await writeFile(dayTwoFile, JSON.stringify({ source: "user", type: "text", message: "day two" }) + "\n");
+  await utimes(dayOneFile, dayOneEpoch, dayOneEpoch);
+  await utimes(dayTwoFile, dayTwoEpoch, dayTwoEpoch);
+});
+
+after(async () => {
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+async function readPersistedState(): Promise<ReturnType<typeof defaultState>> {
+  // Canonical state path lives at conversations/summaries/_state.json
+  // — see server/utils/files/journal-io.ts. journal-io's `summariesRoot`
+  // joins workspaceRoot + WORKSPACE_DIRS.summaries
+  // (= "conversations/summaries").
+  const statePath = path.join(workspaceRoot, "conversations", "summaries", "_state.json");
+  try {
+    const text = await readFile(statePath, "utf-8");
+    return parseState(JSON.parse(text));
+  } catch {
+    return defaultState();
+  }
+}
+
+describe("runDailyPass — crash recovery", () => {
+  it("a failing day is checkpointed as skipped; the next run picks it up cleanly", async () => {
+    // Phase 1 — Summarize that succeeds for the first call,
+    // throws for the second. `callSummarizeForDay` swallows
+    // non-ENOENT errors and returns null, so the day is marked
+    // skipped rather than the whole pass crashing. The session-
+    // ingest checkpoint for day 1 still commits via persistStateAfterDay.
+    let dailySummarizeCalls = 0;
+    let memorySummarizeCalls = 0;
+    // Match by system prompt header — DAILY_SYSTEM_PROMPT starts with
+    // "You are the journal archivist", memoryExtractor's prompt starts
+    // with "You are a personal-fact extractor". Day 1 succeeds, day 2
+    // throws, memory always succeeds (returning empty so nothing gets
+    // appended — keeps the test focused on per-day checkpoint behaviour).
+    const stubFlaky: Summarize = async (systemPrompt) => {
+      if (systemPrompt.startsWith("You are the journal archivist")) {
+        dailySummarizeCalls++;
+        if (dailySummarizeCalls === 1) {
+          return '{"dailySummaryMarkdown":"# day 1","topicUpdates":[]}';
+        }
+        throw new Error("simulated mid-pass crash");
+      }
+      memorySummarizeCalls++;
+      return '{"facts":[]}';
+    };
+
+    const { result: firstResult } = await runDailyPass(defaultState(), {
+      workspaceRoot,
+      summarize: stubFlaky,
+      activeSessionIds: new Set(),
+    });
+
+    assert.equal(dailySummarizeCalls, 2, "daily summarize should have been called for both days");
+    assert.deepEqual(firstResult.daysTouched, [DAY_ONE_DATE], "only day-one should land");
+    assert.equal(firstResult.skipped.length, 1, "day-two should be marked skipped");
+    assert.equal(firstResult.skipped[0]?.date, DAY_TWO_DATE);
+    assert.match(firstResult.skipped[0]?.reason ?? "", /summarize/i);
+
+    // The day-1 session was ingested before the day-2 failure, so
+    // its checkpoint must be on disk. Day-2's session ID must not
+    // appear in `processedSessions` — that's the resumability
+    // invariant the journal's per-day commit is meant to guarantee.
+    const persisted = await readPersistedState();
+    const processedIds = Object.keys(persisted.processedSessions);
+    assert.ok(processedIds.includes(SESSION_DAY1), "day-one session must be marked processed");
+    assert.ok(!processedIds.includes(SESSION_DAY2), "day-two session must NOT be marked processed");
+
+    // Phase 2 — re-run with a healthy stub. Day-one is already
+    // committed so its session shouldn't be in the dirty set;
+    // only day-two reaches the new stub.
+    let secondDailyCalls = 0;
+    const stubHealthy: Summarize = async (systemPrompt) => {
+      if (systemPrompt.startsWith("You are the journal archivist")) {
+        secondDailyCalls++;
+        return '{"dailySummaryMarkdown":"# day 2","topicUpdates":[]}';
+      }
+      // Memory extractor — return empty so nothing's appended.
+      return '{"facts":[]}';
+    };
+    const { result } = await runDailyPass(persisted, {
+      workspaceRoot,
+      summarize: stubHealthy,
+      activeSessionIds: new Set(),
+    });
+
+    assert.equal(secondDailyCalls, 1, "only day-two should reach the second-run daily summarize");
+    assert.deepEqual(result.daysTouched, [DAY_TWO_DATE], "exactly day-two should land");
+    assert.deepEqual(result.skipped, [], "no day should be marked skipped on the resume");
+  });
+});

--- a/test/journal/test_maybeRunJournal.ts
+++ b/test/journal/test_maybeRunJournal.ts
@@ -1,0 +1,97 @@
+// Coverage for two of the three feature gates inside `maybeRunJournal`:
+// the ENOENT-disable latch and the `force` flag that bypasses the
+// interval check (#799 PR4).
+//
+// The third gate — the in-process lock — is intentionally NOT covered
+// here. Exercising it deterministically requires holding the first
+// call mid-flight while a second runs, which means leaving an
+// unresolved Promise around the module-level `running` flag. Any
+// failure path before the explicit release leaks `running = true`
+// into sibling tests and corrupts their state. The lock itself is
+// trivially correct (one synchronous boolean check at the top of
+// `maybeRunJournal`); leaving it to manual inspection beats
+// flake-prone unit coverage.
+
+import { beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { __resetForTests, maybeRunJournal } from "../../server/workspace/journal/index.js";
+import { ClaudeCliNotFoundError, type Summarize } from "../../server/workspace/journal/archivist-cli.js";
+
+async function makeFreshWorkspace(): Promise<string> {
+  const tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-maybe-run-journal-"));
+  // One text event so dailyPass has something to summarise.
+  // `parseEntry` only accepts EVENT_TYPES.text / .toolResult — a
+  // session with zero parseable events bucketizes empty and the
+  // archivist is never called, which would defeat the test.
+  const sessionId = "11111111-1111-1111-1111-111111111111";
+  const sessionFile = path.join(tmpRoot, "conversations", "chat", `${sessionId}.jsonl`);
+  await mkdir(path.dirname(sessionFile), { recursive: true });
+  await writeFile(sessionFile, JSON.stringify({ source: "user", type: "text", message: "hi" }) + "\n");
+  return tmpRoot;
+}
+
+describe("maybeRunJournal — feature gates", () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    __resetForTests();
+    workspaceRoot = await makeFreshWorkspace();
+  });
+
+  it("trips the disable latch on ClaudeCliNotFoundError; subsequent calls return without invoking summarize", async () => {
+    let summarizeCalls = 0;
+    const summarize: Summarize = async () => {
+      summarizeCalls++;
+      throw new ClaudeCliNotFoundError();
+    };
+
+    await maybeRunJournal({ workspaceRoot, summarize, force: true });
+    assert.equal(summarizeCalls, 1, "first call should hit summarize and trip the disable latch");
+
+    let secondSummarizeCalls = 0;
+    const livelyStub: Summarize = async () => {
+      secondSummarizeCalls++;
+      return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
+    };
+    await maybeRunJournal({ workspaceRoot, summarize: livelyStub, force: true });
+    assert.equal(secondSummarizeCalls, 0, "after disable, summarize must not be reached");
+  });
+
+  it("force: true bypasses the interval gate even when timestamps say not-due", async () => {
+    // Seed _state.json (canonical path is conversations/summaries/_state.json
+    // — see server/utils/files/journal-io.ts) with very recent run
+    // timestamps. Without force, the wrapper should short-circuit at
+    // isDailyDue / isOptimizationDue and never call summarize.
+    const stateDir = path.join(workspaceRoot, "conversations", "summaries");
+    await mkdir(stateDir, { recursive: true });
+    const recentIso = new Date().toISOString();
+    await writeFile(
+      path.join(stateDir, "_state.json"),
+      JSON.stringify({
+        version: 1,
+        lastDailyRunAt: recentIso,
+        lastOptimizationRunAt: recentIso,
+        dailyIntervalHours: 1,
+        optimizationIntervalDays: 7,
+        processedSessions: {},
+        knownTopics: [],
+      }),
+      "utf-8",
+    );
+
+    let summarizeCalls = 0;
+    const summarize: Summarize = async () => {
+      summarizeCalls++;
+      return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
+    };
+
+    await maybeRunJournal({ workspaceRoot, summarize });
+    assert.equal(summarizeCalls, 0, "without force the recent timestamps should gate out");
+
+    await maybeRunJournal({ workspaceRoot, summarize, force: true });
+    assert.ok(summarizeCalls >= 1, "force must bypass the interval gate and reach summarize");
+  });
+});


### PR DESCRIPTION
## Summary
- Last of the four PRs from \`plans/audit-journal-subsystem.md\` (#799). Closes the roadmap.
- Two new test files plus a small \`__resetForTests()\` seam on \`journal/index.ts\` so the module-level lock + disable booleans can be reset between cases.
- 3100/3100 unit tests pass locally.

## Items to Confirm / Review
- **\`__resetForTests()\` seam.** The audit's \"PR4 = tests only, low risk\" framing called for unit coverage of \`maybeRunJournal\`'s feature gates. Those gates live in module-level state, which means a test seam is required. Confined to a single export with a comment explaining why; no other callers should reach for it.
- **Lock test deliberately omitted.** The lock case is a single synchronous boolean check, but exercising it deterministically requires holding an unresolved Promise inside the running flag. Any failure path before the release leaks state into sibling tests and corrupts them. The omission is documented inline at the top of \`test_maybeRunJournal.ts\`. If you'd rather have it covered I'm happy to add it via a separate isolation strategy (e.g. spawning the test in its own subprocess).
- **Crash-recovery test stub matches by system-prompt header** to distinguish the daily archivist call from the memoryExtractor call. Day-1 succeeds, day-2 throws, memory always returns empty. The invariant being tested is: per-day commit lands BEFORE the throw, so the next run only re-processes day-2.
- **No production code changes.** Only the test seam in \`index.ts\` and the two new test files.

## What's NOT in this PR
Audit roadmap is complete with this PR. Forward-looking items (browser UI / retention policy / topic pinning / memory cross-links / index cache) live in #799's "Ideas" section, each waiting for its own driver.

## User Prompt
> このまま次行ける？
>
> 次は？
>
> (continuing the journal cleanup roadmap from #799 / PR1 #801 / PR2 #805 / PR3 #810 → this PR4)

## Test plan
- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\` — 3100/3100 pass locally
- [ ] CI run, particularly the Windows lint_test cells.

Refs #799 — completes the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating daily pass crash recovery and session state persistence across failures
  * Added unit tests for feature gates including graceful degradation when dependencies are unavailable and rate limiting behavior

* **Chores**
  * Added test utility for resetting module state between test runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->