### PR TITLE
feat: reusable per-page chat composer + News leaf integration

### DIFF
--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -122,6 +122,7 @@
             </div>
           </div>
           <PageChatComposer
+            :key="selected.id"
             :placeholder="t('pluginNews.chatPlaceholder')"
             :prepend-text="`Read this article. ${selected.url}`"
             :allow-empty="true"

--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -88,36 +88,46 @@
       </div>
 
       <!-- Detail pane -->
-      <div class="flex-1 min-w-0 overflow-y-auto" data-testid="news-detail">
-        <div v-if="!selected" class="h-full flex items-center justify-center text-sm text-gray-400">
+      <div class="flex-1 min-w-0 flex flex-col" data-testid="news-detail">
+        <div v-if="!selected" class="flex-1 flex items-center justify-center text-sm text-gray-400">
           {{ t("pluginNews.selectPrompt") }}
         </div>
-        <div v-else class="px-6 py-4 max-w-3xl">
-          <h2 class="text-xl font-semibold text-gray-900 leading-snug">{{ selected.title }}</h2>
-          <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
-            <span>{{ selected.sourceSlug }}</span>
-            <span>{{ formatSmartTime(selected.publishedAt) }}</span>
-            <span v-for="cat in selected.categories" :key="cat" class="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">
-              {{ cat }}
-            </span>
+        <template v-else>
+          <div class="flex-1 min-h-0 overflow-y-auto">
+            <div class="px-6 py-4 max-w-3xl">
+              <h2 class="text-xl font-semibold text-gray-900 leading-snug">{{ selected.title }}</h2>
+              <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+                <span>{{ selected.sourceSlug }}</span>
+                <span>{{ formatSmartTime(selected.publishedAt) }}</span>
+                <span v-for="cat in selected.categories" :key="cat" class="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">
+                  {{ cat }}
+                </span>
+              </div>
+              <a
+                :href="selected.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="mt-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                data-testid="news-open-original"
+              >
+                <span class="material-icons text-sm">open_in_new</span>
+                {{ t("pluginNews.openOriginal") }}
+              </a>
+              <div class="mt-4">
+                <div v-if="bodyLoading" class="text-sm text-gray-400">{{ t("common.loading") }}</div>
+                <div v-else-if="bodyError" class="text-sm text-red-600">{{ t("pluginNews.bodyError", { error: bodyError }) }}</div>
+                <div v-else-if="!body" class="text-sm text-gray-400 italic">{{ t("pluginNews.noBody") }}</div>
+                <div v-else class="markdown-content prose prose-slate max-w-none" v-html="renderedBody"></div>
+              </div>
+            </div>
           </div>
-          <a
-            :href="selected.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="mt-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
-            data-testid="news-open-original"
-          >
-            <span class="material-icons text-sm">open_in_new</span>
-            {{ t("pluginNews.openOriginal") }}
-          </a>
-          <div class="mt-4">
-            <div v-if="bodyLoading" class="text-sm text-gray-400">{{ t("common.loading") }}</div>
-            <div v-else-if="bodyError" class="text-sm text-red-600">{{ t("pluginNews.bodyError", { error: bodyError }) }}</div>
-            <div v-else-if="!body" class="text-sm text-gray-400 italic">{{ t("pluginNews.noBody") }}</div>
-            <div v-else class="markdown-content prose prose-slate max-w-none" v-html="renderedBody"></div>
-          </div>
-        </div>
+          <PageChatComposer
+            :placeholder="t('pluginNews.chatPlaceholder')"
+            :prepend-text="`Read this article. ${selected.url}`"
+            :allow-empty="true"
+            test-id-prefix="news-page-chat"
+          />
+        </template>
       </div>
     </div>
   </div>
@@ -134,6 +144,7 @@ import { formatSmartTime } from "../utils/format/date";
 import { useNewsItems } from "../composables/useNewsItems";
 import { useNewsReadState } from "../composables/useNewsReadState";
 import FilterChip from "./FilterChip.vue";
+import PageChatComposer from "./PageChatComposer.vue";
 
 const { t } = useI18n();
 const route = useRoute();

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="border-t border-gray-200 px-4 py-3 shrink-0 bg-gray-50">
+    <div class="flex gap-2">
+      <textarea
+        v-model="draft"
+        :data-testid="`${testIdPrefix}-input`"
+        :placeholder="placeholder"
+        rows="2"
+        class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
+        @compositionstart="imeEnter.onCompositionStart"
+        @compositionend="imeEnter.onCompositionEnd"
+        @keydown="imeEnter.onKeydown"
+        @blur="imeEnter.onBlur"
+      />
+      <button
+        :data-testid="`${testIdPrefix}-send`"
+        class="bg-blue-600 hover:bg-blue-700 text-white rounded w-8 h-8 flex items-center justify-center shrink-0 disabled:opacity-50 disabled:cursor-not-allowed self-start"
+        :title="t('common.sendChat')"
+        :disabled="!canSend"
+        @click="submit"
+      >
+        <span class="material-icons text-base leading-none">send</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useAppApi } from "../composables/useAppApi";
+import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+
+const props = withDefaults(
+  defineProps<{
+    placeholder: string;
+    prependText: string;
+    disabled?: boolean;
+    testIdPrefix?: string;
+  }>(),
+  { disabled: false, testIdPrefix: "page-chat" },
+);
+
+const { t } = useI18n();
+const appApi = useAppApi();
+const draft = ref("");
+
+const canSend = computed(() => draft.value.trim().length > 0 && !props.disabled);
+
+function submit() {
+  const text = draft.value.trim();
+  if (!text || props.disabled) return;
+  const prompt = `${props.prependText}\n\n${text}`;
+  draft.value = "";
+  appApi.startNewChat(prompt);
+}
+
+const imeEnter = useImeAwareEnter(submit);
+</script>

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -37,20 +37,22 @@ const props = withDefaults(
     prependText: string;
     disabled?: boolean;
     testIdPrefix?: string;
+    allowEmpty?: boolean;
   }>(),
-  { disabled: false, testIdPrefix: "page-chat" },
+  { disabled: false, testIdPrefix: "page-chat", allowEmpty: false },
 );
 
 const { t } = useI18n();
 const appApi = useAppApi();
 const draft = ref("");
 
-const canSend = computed(() => draft.value.trim().length > 0 && !props.disabled);
+const canSend = computed(() => !props.disabled && (props.allowEmpty || draft.value.trim().length > 0));
 
 function submit() {
+  if (props.disabled) return;
   const text = draft.value.trim();
-  if (!text || props.disabled) return;
-  const prompt = `${props.prependText}\n\n${text}`;
+  if (!text && !props.allowEmpty) return;
+  const prompt = text ? `${props.prependText}\n\n${text}` : props.prependText;
   draft.value = "";
   appApi.startNewChat(prompt);
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -14,6 +14,7 @@ const deMessages = {
     saved: "Gespeichert",
     noResultsYet: "Noch keine Ergebnisse",
     noImageYet: "Noch kein Bild",
+    sendChat: "Neuen Chat starten",
   },
   sessionTabBar: {
     newSession: "Neue Sitzung",
@@ -365,7 +366,6 @@ const deMessages = {
     empty: "Das Wiki ist leer. Bitten Sie den Wiki Manager, eine Quelle einzulesen.",
     previewMore: "+ {count} weitere…",
     chatPlaceholder: "Fragen Sie zu dieser Seite…",
-    chatSend: "Neuen Chat zu dieser Seite starten",
     emptyPage: "Die Seite „{title}“ existiert noch nicht.",
     emptyContent: "Die Seite „{title}“ existiert, hat aber keinen Inhalt.",
     createPage: "Erstellung dieser Wiki-Seite anfordern",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -397,6 +397,7 @@ const deMessages = {
     noBody: "Kein Inhalt verfügbar — öffne den Originalartikel.",
     bodyError: "Inhalt konnte nicht geladen werden: {error}",
     loadError: "Nachrichten konnten nicht geladen werden: {error}",
+    chatPlaceholder: "Fragen Sie alles zu diesem Artikel",
   },
   pluginManageSource: {
     titlePlaceholder: "Titel (optional)",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -34,6 +34,7 @@ const enMessages = {
     saved: "Saved",
     noResultsYet: "No results yet",
     noImageYet: "No image yet",
+    sendChat: "Start a new chat",
   },
   sessionTabBar: {
     newSession: "New session",
@@ -385,7 +386,6 @@ const enMessages = {
     empty: "Wiki is empty. Ask the Wiki Manager to ingest a source.",
     previewMore: "+ {count} more…",
     chatPlaceholder: "Ask about this page…",
-    chatSend: "Start a new chat about this page",
     emptyPage: 'The page "{title}" does not exist yet.',
     emptyContent: 'The page "{title}" exists but has no content.',
     createPage: "Request creation of this wiki page",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -416,6 +416,7 @@ const enMessages = {
     noBody: "No body available — open the original article.",
     bodyError: "Failed to load body: {error}",
     loadError: "Failed to load news: {error}",
+    chatPlaceholder: "Ask anything about this article",
   },
   pluginManageSource: {
     titlePlaceholder: "Title (optional)",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -19,6 +19,7 @@ const esMessages = {
     saved: "Guardado",
     noResultsYet: "Aún no hay resultados",
     noImageYet: "Aún no hay imagen",
+    sendChat: "Iniciar un chat nuevo",
   },
   sessionTabBar: {
     newSession: "Nueva sesión",
@@ -371,7 +372,6 @@ const esMessages = {
     empty: "El wiki está vacío. Pide al Wiki Manager que ingiera una fuente.",
     previewMore: "+ {count} más…",
     chatPlaceholder: "Pregunta sobre esta página…",
-    chatSend: "Iniciar un chat nuevo sobre esta página",
     emptyPage: 'La página "{title}" aún no existe.',
     emptyContent: 'La página "{title}" existe pero no tiene contenido.',
     createPage: "Solicitar la creación de esta página wiki",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -402,6 +402,7 @@ const esMessages = {
     noBody: "Sin cuerpo — abre el artículo original.",
     bodyError: "No se pudo cargar el contenido: {error}",
     loadError: "No se pudieron cargar las noticias: {error}",
+    chatPlaceholder: "Pregunta lo que quieras sobre este artículo",
   },
   pluginManageSource: {
     titlePlaceholder: "Título (opcional)",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -14,6 +14,7 @@ const frMessages = {
     saved: "Enregistré",
     noResultsYet: "Aucun résultat pour le moment",
     noImageYet: "Aucune image pour le moment",
+    sendChat: "Démarrer une nouvelle conversation",
   },
   sessionTabBar: {
     newSession: "Nouvelle session",
@@ -365,7 +366,6 @@ const frMessages = {
     empty: "Le wiki est vide. Demandez au Wiki Manager d'ingérer une source.",
     previewMore: "+ {count} de plus…",
     chatPlaceholder: "Posez une question sur cette page…",
-    chatSend: "Démarrer une nouvelle conversation sur cette page",
     emptyPage: "La page « {title} » n'existe pas encore.",
     emptyContent: "La page « {title} » existe mais n'a pas de contenu.",
     createPage: "Demander la création de cette page wiki",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -396,6 +396,7 @@ const frMessages = {
     noBody: "Pas de contenu — ouvre l'article original.",
     bodyError: "Échec du chargement du contenu : {error}",
     loadError: "Échec du chargement des actualités : {error}",
+    chatPlaceholder: "Posez toute question sur cet article",
   },
   pluginManageSource: {
     titlePlaceholder: "Titre (facultatif)",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -19,6 +19,7 @@ const jaMessages = {
     saved: "保存しました",
     noResultsYet: "まだ結果はありません",
     noImageYet: "画像はまだありません",
+    sendChat: "新しいチャットを開始",
   },
   sessionTabBar: {
     newSession: "新しいセッション",
@@ -369,7 +370,6 @@ const jaMessages = {
     empty: "Wiki は空です。Wiki Manager にソースの取り込みを依頼してください。",
     previewMore: "+ {count} 件…",
     chatPlaceholder: "このページについて質問…",
-    chatSend: "このページについて新しいチャットを開始",
     emptyPage: "「{title}」のページはまだありません。",
     emptyContent: "「{title}」のページは存在しますが、内容がありません。",
     createPage: "この Wiki ページの作成をお願いする",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -400,6 +400,7 @@ const jaMessages = {
     noBody: "本文がありません — 元の記事を開いてください。",
     bodyError: "本文の取得に失敗: {error}",
     loadError: "ニュースの取得に失敗: {error}",
+    chatPlaceholder: "この記事について何でも質問",
   },
   pluginManageSource: {
     titlePlaceholder: "タイトル（省略可）",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -19,6 +19,7 @@ const koMessages = {
     saved: "저장됨",
     noResultsYet: "아직 결과가 없습니다",
     noImageYet: "아직 이미지가 없습니다",
+    sendChat: "새 채팅 시작",
   },
   sessionTabBar: {
     newSession: "새 세션",
@@ -369,7 +370,6 @@ const koMessages = {
     empty: "Wiki 가 비어 있습니다. Wiki Manager 에게 소스를 수집하도록 요청하세요.",
     previewMore: "+ {count}개 더…",
     chatPlaceholder: "이 페이지에 대해 질문…",
-    chatSend: "이 페이지에 대한 새 채팅 시작",
     emptyPage: "「{title}」 페이지가 아직 없습니다.",
     emptyContent: "「{title}」 페이지는 존재하지만 내용이 없습니다.",
     createPage: "이 Wiki 페이지 작성 요청",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -400,6 +400,7 @@ const koMessages = {
     noBody: "본문이 없습니다 — 원문을 열어주세요.",
     bodyError: "본문 로드 실패: {error}",
     loadError: "뉴스 로드 실패: {error}",
+    chatPlaceholder: "이 기사에 대해 무엇이든 질문",
   },
   pluginManageSource: {
     titlePlaceholder: "제목 (선택)",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -14,6 +14,7 @@ const ptBRMessages = {
     saved: "Salvo",
     noResultsYet: "Ainda não há resultados",
     noImageYet: "Ainda não há imagem",
+    sendChat: "Iniciar um novo chat",
   },
   sessionTabBar: {
     newSession: "Nova sessão",
@@ -364,7 +365,6 @@ const ptBRMessages = {
     empty: "O wiki está vazio. Peça ao Wiki Manager para ingerir uma fonte.",
     previewMore: "+ {count} mais…",
     chatPlaceholder: "Pergunte sobre esta página…",
-    chatSend: "Iniciar um novo chat sobre esta página",
     emptyPage: 'A página "{title}" ainda não existe.',
     emptyContent: 'A página "{title}" existe, mas não tem conteúdo.',
     createPage: "Solicitar a criação desta página wiki",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -395,6 +395,7 @@ const ptBRMessages = {
     noBody: "Sem conteúdo — abra o artigo original.",
     bodyError: "Falha ao carregar o conteúdo: {error}",
     loadError: "Falha ao carregar notícias: {error}",
+    chatPlaceholder: "Pergunte o que quiser sobre este artigo",
   },
   pluginManageSource: {
     titlePlaceholder: "Título (opcional)",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -18,6 +18,7 @@ const zhMessages = {
     saved: "已保存",
     noResultsYet: "暂无结果",
     noImageYet: "暂无图片",
+    sendChat: "开启新对话",
   },
   sessionTabBar: {
     newSession: "新建会话",
@@ -365,7 +366,6 @@ const zhMessages = {
     empty: "Wiki 为空。请让 Wiki 管理器采集一个数据源。",
     previewMore: "+ 还有 {count} 项…",
     chatPlaceholder: "就本页提问…",
-    chatSend: "就本页开启新对话",
     emptyPage: "页面「{title}」尚不存在。",
     emptyContent: "页面「{title}」已存在，但没有内容。",
     createPage: "请求创建此 Wiki 页面",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -396,6 +396,7 @@ const zhMessages = {
     noBody: "无正文 — 请打开原文。",
     bodyError: "加载正文失败: {error}",
     loadError: "加载新闻失败: {error}",
+    chatPlaceholder: "就本文章随意提问",
   },
   pluginManageSource: {
     titlePlaceholder: "标题(可选)",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -185,30 +185,12 @@
          WikiView is mounted as a manageWiki tool result inside /chat:
          the enclosing chat already has its own composer, and spawning
          a nested new session from there is confusing. -->
-    <div v-if="action === 'page' && content && isStandaloneWikiRoute" class="border-t border-gray-200 px-4 py-3 shrink-0 bg-gray-50">
-      <div class="flex gap-2">
-        <textarea
-          v-model="chatDraft"
-          data-testid="wiki-page-chat-input"
-          :placeholder="t('pluginWiki.chatPlaceholder')"
-          rows="2"
-          class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
-          @compositionstart="imeEnter.onCompositionStart"
-          @compositionend="imeEnter.onCompositionEnd"
-          @keydown="imeEnter.onKeydown"
-          @blur="imeEnter.onBlur"
-        />
-        <button
-          data-testid="wiki-page-chat-send"
-          class="bg-blue-600 hover:bg-blue-700 text-white rounded w-8 h-8 flex items-center justify-center shrink-0 disabled:opacity-50 disabled:cursor-not-allowed self-start"
-          :title="t('pluginWiki.chatSend')"
-          :disabled="!canSendChat"
-          @click="submitChat"
-        >
-          <span class="material-icons text-base leading-none">send</span>
-        </button>
-      </div>
-    </div>
+    <PageChatComposer
+      v-if="action === 'page' && content && isStandaloneWikiRoute && currentSlug() !== null"
+      :placeholder="t('pluginWiki.chatPlaceholder')"
+      :prepend-text="`Before answering, read the wiki page at data/wiki/pages/${currentSlug()}.md.`"
+      test-id-prefix="wiki-page-chat"
+    />
   </div>
 </template>
 
@@ -222,10 +204,10 @@ import type { WikiData, WikiPageEntry } from "./index";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { classifyWorkspacePath, resolveWikiHref } from "../../utils/path/workspaceLinkRouter";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
-import { useImeAwareEnter } from "../../composables/useImeAwareEnter";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { useAppApi } from "../../composables/useAppApi";
 import { renderWikiLinks } from "./helpers";
+import PageChatComposer from "../../components/PageChatComposer.vue";
 import { BUILTIN_ROLE_IDS } from "../../config/roles";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { extractFrontmatter } from "../../utils/format/frontmatter";
@@ -459,10 +441,8 @@ function navigatePage(pageName: string) {
 
 // --- Per-page chat composer ---
 const appApi = useAppApi();
-const chatDraft = ref("");
 
 const isStandaloneWikiRoute = computed(() => route.name === PAGE_ROUTES.wiki);
-const canSendChat = computed(() => chatDraft.value.trim().length > 0 && currentSlug() !== null);
 
 // Always route wiki create/update CTAs through BUILTIN_ROLE_IDS.general
 // (the wiki-capable role) so the new chat has the tools needed to
@@ -496,17 +476,6 @@ function currentSlug(): string | null {
       : (props.selectedResult?.data?.pageName ?? null);
   return isSafeWikiSlug(raw) ? raw : null;
 }
-
-function submitChat() {
-  const text = chatDraft.value.trim();
-  const slug = currentSlug();
-  if (!text || !slug) return;
-  const prompt = `Before answering, read the wiki page at data/wiki/pages/${slug}.md.\n\n${text}`;
-  chatDraft.value = "";
-  appApi.startNewChat(prompt);
-}
-
-const imeEnter = useImeAwareEnter(submitChat);
 
 /** Base directory for wiki content, adjusted by the current view. */
 const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -187,6 +187,7 @@
          a nested new session from there is confusing. -->
     <PageChatComposer
       v-if="action === 'page' && content && isStandaloneWikiRoute && currentSlug() !== null"
+      :key="currentSlug() ?? ''"
       :placeholder="t('pluginWiki.chatPlaceholder')"
       :prepend-text="`Before answering, read the wiki page at data/wiki/pages/${currentSlug()}.md.`"
       test-id-prefix="wiki-page-chat"


### PR DESCRIPTION
## Summary

- Extract the wiki leaf-page chat composer into a reusable `PageChatComposer` component (`src/components/PageChatComposer.vue`). Hosts pass `placeholder` + `prependText`; the component owns draft state, IME-aware Enter, and the `appApi.startNewChat` call (which still respects the current role-dropdown selection).
- Mount the composer at the bottom of the News detail pane. Prepended instruction is just `Read this article. {url}`; the agent fetches the page itself.
- New `allowEmpty` prop (default `false`) so the News case can send with no extra question — the prepend text alone is a valid prompt there. Wiki keeps the empty-disabled behavior.
- i18n: shared `common.sendChat` for the send-button tooltip in all 8 locales (replaces the wiki-only `pluginWiki.chatSend`); add `pluginNews.chatPlaceholder` in all 8 locales.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`
- [x] `yarn test:e2e e2e/tests/wiki-page-chat.spec.ts` — all 7 tests pass after the wiki migration
- [x] Manual: News leaf composer sends with empty text and lands on `/chat`; sends with text correctly prepends the URL instruction
- [ ] Re-run `e2e/tests/news-view.spec.ts` in CI to confirm the detail-pane restructure didn't regress existing News tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat composer to the News view for discussing selected articles with contextual prompts.

* **Refactor**
  * Reorganized chat input UI into a reusable component for consistent functionality across features.

* **Localization**
  * Updated chat-related UI labels across all supported languages (English, German, Spanish, French, Japanese, Korean, Portuguese, Simplified Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->