### PR TITLE
refactor: introduce LLMBackend interface and ClaudeCodeBackend adapter

### DIFF
--- a/plans/refactor-llm-backend-abstraction.md
+++ b/plans/refactor-llm-backend-abstraction.md
@@ -1,0 +1,189 @@
+# refactor: LLM backend abstraction
+
+## Goal
+
+Make the server-side agent loop pluggable so MulmoClaude can later support backends other than Claude Code (OpenAI Codex, Ollama native, Gemini API, etc.). Today the agent loop is hard-wired to spawn the `claude` CLI as a subprocess. We want a single seam — an `LLMBackend` interface — that everything above the seam talks to, and a `ClaudeCodeBackend` adapter that preserves today's behavior exactly.
+
+This plan is the **first of three** PRs. It is a **pure refactor — no behavior change.**
+
+## Background
+
+The server already has thinner Claude coupling than you might expect:
+
+- **No Anthropic SDK imports.** Everything goes through `spawn("claude", ...)`.
+- **Event format is already abstracted.** `AgentEvent` (`server/agent/stream.ts`) and `SseEvent` (`src/types/sse.ts`) carry no SDK types to the frontend.
+- **Tool schemas are portable** (`gui-chat-protocol`'s JSON-Schema-based `ToolDefinition`).
+- **MCP is vendor-neutral** — other backends can either speak MCP or call MulmoClaude's `/api/...` endpoints directly the way `mcp-server.ts` does today.
+
+The Claude-specific surface is concentrated in just a few files:
+
+| File | What's Claude-specific |
+|---|---|
+| `server/agent/index.ts` | `spawnClaude()`, `readAgentEvents()` (parses Claude CLI JSON), `runAgent()` orchestrator |
+| `server/agent/config.ts` | `buildCliArgs()` (Claude CLI flags), `buildDockerSpawnArgs()`, `buildUserMessageLine()` (stream-JSON input) |
+| `server/agent/stream.ts` | `createStreamParser()` translating Claude CLI events → portable `AgentEvent` |
+| `server/agent/resumeFailover.ts` | Stale-`--resume` recovery, only meaningful for Claude |
+| `server/api/routes/agent.ts` | Reads/writes `claudeSessionId` in session meta; orchestrates `runAgent()` |
+| Three auxiliary CLI calls | `journal/archivist-cli.ts`, `chat-index/summarizer.ts`, `sources/classifier.ts` (all `spawn("claude", ...)`) |
+
+## Out of scope (for this PR)
+
+- **Auxiliary CLI calls** (journal / chat-index / sources). Migrating those is PR #2 — they already accept injectable summarize functions, so it's a small isolated change.
+- **A second backend.** That's PR #3 and is what actually validates the interface. Expect interface refinements then.
+- **Renaming `claudeSessionId` → `llmSessionToken`.** This touches `@mulmobridge/protocol` (a published wire-format) and 15 files. Deferred to a small follow-up PR after #1 lands.
+- **Migrating the existing `feat-mulmoclaude-ollama-support.md` plan.** That plan takes a different approach — env-passthrough to leverage Claude Code CLI's Anthropic-compat mode. Both can coexist; the env-passthrough route stays useful for Anthropic-compatible endpoints, and the abstraction below is what unlocks non-Anthropic-shaped backends (OpenAI function calling, Gemini, etc.).
+
+## Design
+
+### The interface
+
+New file: `server/agent/backend/types.ts`
+
+```typescript
+import type { Attachment } from "@mulmobridge/protocol";
+import type { Role } from "../../../src/config/roles.js";
+import type { AgentEvent } from "../stream.js";
+
+/** Inputs the orchestrator passes to a backend for one user turn.
+ *  The orchestrator owns role expansion, system prompt building, and
+ *  MCP config writing. The backend owns spawn / SDK call + stream
+ *  translation into AgentEvent. */
+export interface AgentInput {
+  systemPrompt: string;
+  message: string;
+  role: Role;
+  workspacePath: string;
+  sessionId: string;
+  port: number;
+  /** Opaque, backend-specific resume token. For Claude this is the
+   *  CLI's session id; other backends interpret it differently or
+   *  ignore it entirely (capabilities.sessionResume === false). */
+  sessionToken?: string;
+  attachments?: Attachment[];
+  /** Active MCP plugin names (subset of role.availablePlugins that
+   *  is registered in MCP_PLUGINS). The orchestrator already filtered
+   *  these — backends should not re-derive. */
+  activePlugins: string[];
+  /** When set, the path the backend should hand to its MCP loader.
+   *  Pre-resolved for host-vs-container by the orchestrator. */
+  mcpConfigPath?: string;
+  /** Extra allowed-tool names from settings + user MCP servers. */
+  extraAllowedTools: string[];
+  /** When fired, the backend must terminate any in-flight subprocess
+   *  / connection. */
+  abortSignal?: AbortSignal;
+  userTimezone?: string;
+}
+
+export interface BackendCapabilities {
+  /** Can the backend resume a prior conversation by an opaque token?
+   *  Claude: yes (--resume <id>). OpenAI: no. Ollama: no. Used by
+   *  the orchestrator to decide whether to replay transcript instead. */
+  sessionResume: boolean;
+  /** Does the backend speak MCP natively? Claude: yes. Others: emulate
+   *  or skip. Today only Claude consumes activePlugins / mcpConfigPath. */
+  mcp: boolean;
+}
+
+export interface LLMBackend {
+  readonly id: string;
+  readonly capabilities: BackendCapabilities;
+  /** Run one user turn. Yields portable AgentEvents. */
+  runAgent(input: AgentInput): AsyncIterable<AgentEvent>;
+}
+```
+
+Note: the interface is intentionally narrow. Auxiliary "summarize one shot" calls (PR #2) get a separate `generate` / `generateStructured` pair on a future expansion of this interface; we don't add them now because we don't need them yet and shapes are clearer once we have the second backend.
+
+### The adapter
+
+New file: `server/agent/backend/claude-code.ts`
+
+`ClaudeCodeBackend` owns everything that's currently in `spawnClaude()`, `readAgentEvents()`, `buildCliArgs()`, `buildDockerSpawnArgs()`, `buildUserMessageLine()`, and `createStreamParser()`. The functions don't move physically — they stay in `server/agent/{config,stream}.ts` because they're testable utilities — the adapter just **calls** them. This keeps the diff small and the existing tests untouched.
+
+```typescript
+export const claudeCodeBackend: LLMBackend = {
+  id: "claude-code",
+  capabilities: { sessionResume: true, mcp: true },
+  async *runAgent(input) {
+    // existing spawnClaude + readAgentEvents flow, lifted from index.ts
+  },
+};
+```
+
+### The factory
+
+New file: `server/agent/backend/index.ts`
+
+```typescript
+export function getActiveBackend(): LLMBackend {
+  // Today: always claude-code. Future: switch on env / settings.
+  return claudeCodeBackend;
+}
+```
+
+A factory rather than a direct export so PR #3 can flip on env without touching every call site.
+
+### Rewired orchestrator
+
+`runAgent()` in `server/agent/index.ts` keeps its signature and responsibilities — the orchestrator still:
+
+1. Filters role plugins
+2. Loads user MCP servers + checks Docker availability
+3. Refreshes credentials (macOS sandbox)
+4. Builds the full system prompt
+5. Writes the MCP config file
+6. Loads settings (extra allowed tools)
+
+…but instead of building CLI args + spawning + streaming itself, it builds an `AgentInput` and calls `getActiveBackend().runAgent(input)`. Yields the events through unchanged.
+
+The stale-`--resume` recovery in `server/api/routes/agent.ts` stays where it is (Claude-specific failure mode, can be moved into the backend later when a non-Claude backend exists to compare against).
+
+## File-level changes
+
+**New files:**
+
+- `server/agent/backend/types.ts` — interface + types
+- `server/agent/backend/claude-code.ts` — Claude adapter (calls existing helpers)
+- `server/agent/backend/index.ts` — `getActiveBackend()` factory
+
+**Modified files:**
+
+- `server/agent/index.ts` — `runAgent()` keeps its signature but delegates the spawn/stream half to the active backend. `spawnClaude()` and `readAgentEvents()` move into the adapter.
+
+**Untouched** (verifies the boundary is right):
+
+- `server/agent/config.ts`
+- `server/agent/stream.ts`
+- `server/agent/prompt.ts`
+- `server/agent/resumeFailover.ts`
+- `server/api/routes/agent.ts`
+- All tests under `test/agent/`
+
+## Sequencing inside this PR
+
+1. Add `server/agent/backend/types.ts` (pure types)
+2. Add `server/agent/backend/claude-code.ts` (lifts `spawnClaude` + `readAgentEvents` from `index.ts`)
+3. Add `server/agent/backend/index.ts` (factory)
+4. Rewire `runAgent()` in `index.ts` to build `AgentInput` and delegate
+5. Run `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
+
+## Acceptance criteria
+
+- `yarn typecheck`, `yarn lint`, `yarn build`, `yarn test` all pass
+- `runAgent()` keeps the same exported signature
+- No behavior change observable from `server/api/routes/agent.ts` or tests
+- `server/agent/backend/types.ts` is the only file imported by any future second backend
+- `git grep "spawn.*claude"` outside `server/agent/backend/` and the three auxiliary files returns zero hits
+
+## Follow-up PRs (not in this one)
+
+- **PR #2:** Migrate `journal/archivist-cli.ts`, `chat-index/summarizer.ts`, `sources/classifier.ts` to a `generate` / `generateStructured` extension of `LLMBackend`. Three files, all already test-injectable.
+- **PR #2.5 (optional):** Rename `claudeSessionId` → `llmSessionToken` across server, tests, and `@mulmobridge/protocol`. Wire-format change — coordinate package version bump.
+- **PR #3:** Add a second backend (probably OpenAI). Real validation of the interface; expect refinements.
+
+## Risks
+
+- The orchestrator/backend split has to put MCP config writing on the *orchestrator* side (it's filesystem state, not LLM call), but `mcpConfigPath` only matters to the Claude adapter. That's OK as long as we keep `BackendCapabilities.mcp` and let other adapters ignore the field.
+- `BackendCapabilities` is meant to be honest, not enforcing. The orchestrator may grow `if (backend.capabilities.sessionResume) { ... }` branches over time. That's the right place for them; resist the temptation to push them into adapters as no-ops.
+- The interface is provisional. Don't optimize for it being perfect on PR #1 — it will refine in PR #3.

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -1,0 +1,170 @@
+// Claude Code backend: spawns the `claude` CLI as a subprocess (or
+// inside the mulmoclaude-sandbox Docker image) and translates its
+// stream-json output into portable AgentEvents.
+//
+// This file is the single seam between the orchestrator in
+// server/agent/index.ts (which is backend-agnostic) and the Claude
+// CLI specifics. Pure helpers it depends on (CLI arg construction,
+// Docker arg construction, stream parsing) stay in their existing
+// home so the existing test suite under test/agent/ keeps working
+// unchanged.
+
+import { spawn, type ChildProcessByStdio } from "child_process";
+import type { Readable, Writable } from "stream";
+import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine } from "../config.js";
+import { resolveSandboxAuth } from "../sandboxMounts.js";
+import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
+import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
+import { log } from "../../system/logger/index.js";
+import { EVENT_TYPES } from "../../../src/types/events.js";
+import { env } from "../../system/env.js";
+import type { AgentInput, LLMBackend } from "./types.js";
+
+type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
+
+function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[]): ClaudeProc {
+  if (!useDocker) {
+    return spawn("claude", cliArgs, {
+      cwd: workspacePath,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  }
+  const sandboxAuth = resolveSandboxAuth({
+    sshAgentForward: env.sandboxSshAgentForward,
+    sshAllowedHosts: env.sandboxSshAllowedHosts,
+    configMountNames: env.sandboxMountConfigs,
+    sshAuthSock: process.env.SSH_AUTH_SOCK,
+  });
+  const refDirArgs = referenceDirMountArgs(getCachedReferenceDirs());
+  const dockerArgs = buildDockerSpawnArgs({
+    workspacePath,
+    cliArgs,
+    uid: process.getuid?.() ?? 1000,
+    gid: process.getgid?.() ?? 1000,
+    platform: process.platform,
+    sandboxAuthArgs: [...sandboxAuth.args, ...refDirArgs],
+    sshAgentForward: env.sandboxSshAgentForward,
+  });
+  return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
+}
+
+// Track MCP tool usage to detect silent MCP server failures.
+// If ToolSearch was called but no mcp__* tool was ever invoked,
+// the MCP server likely crashed on startup (e.g. module resolution
+// failure inside Docker). See #430.
+function createMcpTracker() {
+  let toolSearchCalled = false;
+  let mcpToolCalled = false;
+  return {
+    track(event: AgentEvent) {
+      if (event.type !== EVENT_TYPES.toolCall) return;
+      if (event.toolName === "ToolSearch") toolSearchCalled = true;
+      if (event.toolName.startsWith("mcp__")) mcpToolCalled = true;
+    },
+    logIfSuspicious() {
+      if (toolSearchCalled && !mcpToolCalled) {
+        log.warn(
+          "agent",
+          "ToolSearch was used but no MCP tool was called — the MCP server may have crashed. " +
+            "Check Docker volume mounts and package.json exports. " +
+            "Run: npx tsx --test test/agent/test_mcp_docker_smoke.ts",
+        );
+      }
+    },
+  };
+}
+
+async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
+  let stderrOutput = "";
+  let stderrBuffer = "";
+  proc.stderr.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stderrOutput += text;
+    stderrBuffer += text;
+    const lines = stderrBuffer.split("\n");
+    stderrBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) log.error("agent-stderr", line);
+    }
+  });
+
+  // Stateful parser tracks whether text was already streamed via
+  // assistant content blocks so the final `result` event's duplicate
+  // text is suppressed. See createStreamParser() in stream.ts.
+  const parser = createStreamParser();
+
+  const mcpTracker = createMcpTracker();
+
+  let buffer = "";
+  for await (const chunk of proc.stdout) {
+    buffer += (chunk as Buffer).toString();
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let event: RawStreamEvent;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      for (const agentEvent of parser.parse(event)) {
+        mcpTracker.track(agentEvent);
+        yield agentEvent;
+      }
+    }
+  }
+
+  const exitCode = await new Promise<number>((resolve) => proc.on("close", resolve));
+
+  if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
+  log.info("agent", "claude exited", { exitCode });
+  mcpTracker.logIfSuspicious();
+
+  if (exitCode !== 0) {
+    yield {
+      type: EVENT_TYPES.error,
+      message: stderrOutput || `claude exited with code ${exitCode}`,
+    };
+  }
+}
+
+async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
+  const cliArgs = buildCliArgs({
+    systemPrompt: input.systemPrompt,
+    activePlugins: input.activePlugins,
+    claudeSessionId: input.sessionToken,
+    mcpConfigPath: input.mcpConfigPath,
+    extraAllowedTools: input.extraAllowedTools,
+  });
+
+  const proc = spawnClaude(input.useDocker, input.workspacePath, cliArgs);
+
+  // stream-json input mode: stream the user turn as a single JSON
+  // line to stdin, then close the pipe so the CLI knows no further
+  // turns are coming. Writing before attaching the abort handler is
+  // fine — if the write fails because the process already died for
+  // other reasons, the readAgentEvents loop below surfaces it.
+  const messageLine = await buildUserMessageLine(input.message, input.attachments);
+  proc.stdin.write(messageLine);
+  proc.stdin.end();
+
+  const onAbort = () => {
+    if (!proc.killed) proc.kill();
+  };
+  input.abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    yield* readAgentEvents(proc);
+  } finally {
+    input.abortSignal?.removeEventListener("abort", onAbort);
+    if (!proc.killed) proc.kill();
+  }
+}
+
+export const claudeCodeBackend: LLMBackend = {
+  id: "claude-code",
+  capabilities: { sessionResume: true, mcp: true },
+  runAgent: runClaudeAgent,
+};

--- a/server/agent/backend/index.ts
+++ b/server/agent/backend/index.ts
@@ -1,0 +1,14 @@
+// Backend factory. Today there is only ClaudeCodeBackend; future
+// backends (OpenAI, Ollama native, Gemini) are selected here based on
+// env / settings. Callers go through getActiveBackend() rather than
+// importing a concrete adapter so adding a backend doesn't require
+// touching every call site.
+
+import { claudeCodeBackend } from "./claude-code.js";
+import type { LLMBackend } from "./types.js";
+
+export type { AgentInput, BackendCapabilities, LLMBackend } from "./types.js";
+
+export function getActiveBackend(): LLMBackend {
+  return claudeCodeBackend;
+}

--- a/server/agent/backend/types.ts
+++ b/server/agent/backend/types.ts
@@ -1,0 +1,65 @@
+// LLM backend abstraction. Today the only implementation is
+// ClaudeCodeBackend (server/agent/backend/claude-code.ts), which spawns
+// the `claude` CLI as a subprocess. The interface exists so future
+// backends (OpenAI, Ollama native, Gemini, etc.) can plug in here
+// without the orchestrator in server/agent/index.ts knowing which one
+// is active.
+//
+// See plans/refactor-llm-backend-abstraction.md for the broader plan.
+
+import type { Attachment } from "@mulmobridge/protocol";
+import type { Role } from "../../../src/config/roles.js";
+import type { AgentEvent } from "../stream.js";
+
+/** Inputs the orchestrator passes to a backend for one user turn.
+ *  The orchestrator owns role expansion, system prompt building, and
+ *  MCP config writing. The backend owns the LLM call itself plus
+ *  translation of provider-specific stream events into AgentEvent. */
+export interface AgentInput {
+  systemPrompt: string;
+  message: string;
+  role: Role;
+  workspacePath: string;
+  sessionId: string;
+  port: number;
+  /** Opaque, backend-specific resume token. For Claude this is the
+   *  CLI's session id passed to --resume; other backends may
+   *  interpret it differently or ignore it entirely
+   *  (capabilities.sessionResume === false). */
+  sessionToken?: string;
+  attachments?: Attachment[];
+  /** Active MCP plugin names (the subset of role.availablePlugins
+   *  that is actually registered as an MCP plugin). The orchestrator
+   *  has already filtered these — backends should not re-derive. */
+  activePlugins: string[];
+  /** When set, the path the backend should hand to its MCP loader.
+   *  Pre-resolved for host-vs-container by the orchestrator. */
+  mcpConfigPath?: string;
+  /** Extra allowed-tool names from settings + user MCP servers. */
+  extraAllowedTools: string[];
+  /** When fired, the backend must terminate any in-flight
+   *  subprocess / connection. */
+  abortSignal?: AbortSignal;
+  userTimezone?: string;
+  /** Whether the orchestrator detected a usable Docker sandbox.
+   *  Backends that don't sandbox can ignore. */
+  useDocker: boolean;
+}
+
+export interface BackendCapabilities {
+  /** Can the backend resume a prior conversation by an opaque token?
+   *  Claude: yes (--resume <id>). OpenAI / Ollama: no — the
+   *  orchestrator must replay transcript instead. */
+  sessionResume: boolean;
+  /** Does the backend speak MCP natively? Claude: yes. Others:
+   *  emulate or skip. Today only Claude consumes activePlugins /
+   *  mcpConfigPath. */
+  mcp: boolean;
+}
+
+export interface LLMBackend {
+  readonly id: string;
+  readonly capabilities: BackendCapabilities;
+  /** Run one user turn. Yields portable AgentEvents. */
+  runAgent(input: AgentInput): AsyncIterable<AgentEvent>;
+}

--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -1,142 +1,17 @@
-import { spawn, type ChildProcessByStdio } from "child_process";
 import { mkdir, unlink } from "fs/promises";
 import { writeJsonAtomic } from "../utils/files/json.js";
 import { dirname } from "path";
-import type { Readable, Writable } from "stream";
 import { isDockerAvailable } from "../system/docker.js";
 import { refreshCredentials } from "../system/credentials.js";
 import { loadMcpConfig, loadSettings } from "../system/config.js";
 import type { Role } from "../../src/config/roles.js";
 import { loadAllRoles } from "../workspace/roles.js";
 import { buildSystemPrompt } from "./prompt.js";
-import {
-  CONTAINER_WORKSPACE_PATH,
-  buildCliArgs,
-  buildDockerSpawnArgs,
-  buildMcpConfig,
-  buildUserMessageLine,
-  getActivePlugins,
-  prepareUserServers,
-  resolveMcpConfigPaths,
-  userServerAllowedToolNames,
-} from "./config.js";
+import { CONTAINER_WORKSPACE_PATH, buildMcpConfig, getActivePlugins, prepareUserServers, resolveMcpConfigPaths, userServerAllowedToolNames } from "./config.js";
 import type { Attachment } from "@mulmobridge/protocol";
-import { createStreamParser, type AgentEvent, type RawStreamEvent } from "./stream.js";
+import type { AgentEvent } from "./stream.js";
 import { log } from "../system/logger/index.js";
-import { EVENT_TYPES } from "../../src/types/events.js";
-import { env } from "../system/env.js";
-import { resolveSandboxAuth } from "./sandboxMounts.js";
-import { getCachedReferenceDirs, referenceDirMountArgs } from "../workspace/reference-dirs.js";
-
-type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
-
-function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[]): ClaudeProc {
-  if (!useDocker) {
-    return spawn("claude", cliArgs, {
-      cwd: workspacePath,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-  }
-  const sandboxAuth = resolveSandboxAuth({
-    sshAgentForward: env.sandboxSshAgentForward,
-    sshAllowedHosts: env.sandboxSshAllowedHosts,
-    configMountNames: env.sandboxMountConfigs,
-    sshAuthSock: process.env.SSH_AUTH_SOCK,
-  });
-  const refDirArgs = referenceDirMountArgs(getCachedReferenceDirs());
-  const dockerArgs = buildDockerSpawnArgs({
-    workspacePath,
-    cliArgs,
-    uid: process.getuid?.() ?? 1000,
-    gid: process.getgid?.() ?? 1000,
-    platform: process.platform,
-    sandboxAuthArgs: [...sandboxAuth.args, ...refDirArgs],
-    sshAgentForward: env.sandboxSshAgentForward,
-  });
-  return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
-}
-
-// Track MCP tool usage to detect silent MCP server failures.
-// If ToolSearch was called but no mcp__* tool was ever invoked,
-// the MCP server likely crashed on startup (e.g. module resolution
-// failure inside Docker). See #430.
-function createMcpTracker() {
-  let toolSearchCalled = false;
-  let mcpToolCalled = false;
-  return {
-    track(event: AgentEvent) {
-      if (event.type !== EVENT_TYPES.toolCall) return;
-      if (event.toolName === "ToolSearch") toolSearchCalled = true;
-      if (event.toolName.startsWith("mcp__")) mcpToolCalled = true;
-    },
-    logIfSuspicious() {
-      if (toolSearchCalled && !mcpToolCalled) {
-        log.warn(
-          "agent",
-          "ToolSearch was used but no MCP tool was called — the MCP server may have crashed. " +
-            "Check Docker volume mounts and package.json exports. " +
-            "Run: npx tsx --test test/agent/test_mcp_docker_smoke.ts",
-        );
-      }
-    },
-  };
-}
-
-async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
-  let stderrOutput = "";
-  let stderrBuffer = "";
-  proc.stderr.on("data", (chunk: Buffer) => {
-    const text = chunk.toString();
-    stderrOutput += text;
-    stderrBuffer += text;
-    const lines = stderrBuffer.split("\n");
-    stderrBuffer = lines.pop() ?? "";
-    for (const line of lines) {
-      if (line.trim()) log.error("agent-stderr", line);
-    }
-  });
-
-  // Stateful parser tracks whether text was already streamed via
-  // assistant content blocks so the final `result` event's duplicate
-  // text is suppressed. See createStreamParser() in stream.ts.
-  const parser = createStreamParser();
-
-  const mcpTracker = createMcpTracker();
-
-  let buffer = "";
-  for await (const chunk of proc.stdout) {
-    buffer += (chunk as Buffer).toString();
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      let event: RawStreamEvent;
-      try {
-        event = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      for (const agentEvent of parser.parse(event)) {
-        mcpTracker.track(agentEvent);
-        yield agentEvent;
-      }
-    }
-  }
-
-  const exitCode = await new Promise<number>((resolve) => proc.on("close", resolve));
-
-  if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
-  log.info("agent", "claude exited", { exitCode });
-  mcpTracker.logIfSuspicious();
-
-  if (exitCode !== 0) {
-    yield {
-      type: EVENT_TYPES.error,
-      message: stderrOutput || `claude exited with code ${exitCode}`,
-    };
-  }
-}
+import { getActiveBackend } from "./backend/index.js";
 
 export interface RunAgentOptions {
   message: string;
@@ -220,47 +95,38 @@ export async function* runAgent(
   const settings = loadSettings();
   const userServerAllowedTools = userServerAllowedToolNames(userServers, useDocker);
 
-  const cliArgs = buildCliArgs({
-    systemPrompt: fullSystemPrompt,
-    activePlugins,
-    claudeSessionId,
-    mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
-    extraAllowedTools: [...settings.extraAllowedTools, ...userServerAllowedTools],
-  });
-
   // Don't persist raw sessionId into log sinks (esp. the retained
   // file sink). A boolean presence flag is enough for operational
   // debugging and avoids writing identifiers that route back to a
   // specific session into long-lived log files.
-  log.info("agent", "spawning claude", {
+  const backend = getActiveBackend();
+  log.info("agent", "spawning agent", {
+    backend: backend.id,
     roleId: role.id,
     useDocker,
     hasMcp,
     resumed: Boolean(claudeSessionId),
     hasSessionId: Boolean(sessionId),
   });
-  const proc = spawnClaude(useDocker, workspacePath, cliArgs);
-
-  // stream-json input mode: stream the user turn as a single JSON
-  // line to stdin, then close the pipe so the CLI knows no further
-  // turns are coming. Writing before attaching the abort handler
-  // is fine — if the write fails because the process already died
-  // for other reasons, the `readAgentEvents` loop below surfaces it.
-  const messageLine = await buildUserMessageLine(message, attachments);
-  proc.stdin.write(messageLine);
-  proc.stdin.end();
-
-  // If an abort signal is provided, kill the process when it fires.
-  const onAbort = () => {
-    if (!proc.killed) proc.kill();
-  };
-  abortSignal?.addEventListener("abort", onAbort, { once: true });
 
   try {
-    yield* readAgentEvents(proc);
+    yield* backend.runAgent({
+      systemPrompt: fullSystemPrompt,
+      message,
+      role,
+      workspacePath,
+      sessionId,
+      port,
+      sessionToken: claudeSessionId,
+      attachments,
+      activePlugins,
+      mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
+      extraAllowedTools: [...settings.extraAllowedTools, ...userServerAllowedTools],
+      abortSignal,
+      userTimezone,
+      useDocker,
+    });
   } finally {
-    abortSignal?.removeEventListener("abort", onAbort);
-    if (!proc.killed) proc.kill();
     if (hasMcp) unlink(mcpPaths.hostPath).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary

PR #1 of three from [plans/refactor-llm-backend-abstraction.md](./plans/refactor-llm-backend-abstraction.md). Pure refactor — **no behavior change.**

Carves a single seam (`LLMBackend`) so future backends (OpenAI, Ollama native, Gemini) can plug in without the orchestrator knowing which one is active. The Claude-CLI specifics — spawn flow, stream-json parsing, MCP tracker — move into a `ClaudeCodeBackend` adapter behind the new interface.

- **New** `server/agent/backend/types.ts` — `LLMBackend`, `AgentInput`, `BackendCapabilities`
- **New** `server/agent/backend/claude-code.ts` — Claude adapter (lifts `spawnClaude`, `readAgentEvents`, `createMcpTracker` out of `index.ts`)
- **New** `server/agent/backend/index.ts` — `getActiveBackend()` factory
- **Modified** `server/agent/index.ts` — `runAgent()` keeps its signature; builds an `AgentInput` and delegates the spawn/stream half to the active backend (−156 / +22)

## What's NOT in this PR (called out in the plan)

- Migrating the three auxiliary `spawn(\"claude\", ...)` callers (journal / chat-index / sources) → PR #2
- Renaming `claudeSessionId` → `llmSessionToken` (touches `@mulmobridge/protocol` wire format) → small follow-up PR
- A real second backend → PR #3 (the only thing that actually validates the interface)

## Design notes

The orchestrator (`runAgent`) keeps everything that's portable across backends: role expansion, system prompt building, MCP config writing, settings loading. The adapter owns everything Claude-CLI-specific: CLI args, `spawn`, stream-JSON translation. Pure helpers (`buildCliArgs`, `buildDockerSpawnArgs`, `buildUserMessageLine`, `createStreamParser`) stay in their existing home so the existing tests under `test/agent/` keep working unchanged.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (5 pre-existing v-html warnings unrelated to this PR)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean (pre-existing eval warnings in spreadsheet plugin unrelated)
- [x] `yarn test` — all suites pass, including the 3101-test agent suite
- [ ] Manual smoke: start the dev server, send a message in any role, verify the chat round-trips normally and Docker sandbox path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)