### PR TITLE
feat(automations): show prompt and role per task

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -275,6 +275,9 @@ const deMessages = {
     runFailed: "Ausführung fehlgeschlagen: {error}",
     toggleFailed: "Umschalten fehlgeschlagen: {error}",
     deleteFailed: "Löschen fehlgeschlagen: {error}",
+    detailsToggle: "Details anzeigen",
+    promptLabel: "Prompt",
+    roleLabel: "Rolle",
   },
   pluginCanvas: {
     undo: "Rückgängig",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -295,6 +295,9 @@ const enMessages = {
     runFailed: "Run failed: {error}",
     toggleFailed: "Toggle failed: {error}",
     deleteFailed: "Delete failed: {error}",
+    detailsToggle: "Show details",
+    promptLabel: "Prompt",
+    roleLabel: "Role",
   },
   pluginCanvas: {
     undo: "Undo",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -281,6 +281,9 @@ const esMessages = {
     runFailed: "Error al ejecutar: {error}",
     toggleFailed: "Error al alternar: {error}",
     deleteFailed: "Error al eliminar: {error}",
+    detailsToggle: "Mostrar detalles",
+    promptLabel: "Prompt",
+    roleLabel: "Rol",
   },
   pluginCanvas: {
     undo: "Deshacer",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -275,6 +275,9 @@ const frMessages = {
     runFailed: "Échec de l'exécution : {error}",
     toggleFailed: "Échec du basculement : {error}",
     deleteFailed: "Échec de la suppression : {error}",
+    detailsToggle: "Afficher les détails",
+    promptLabel: "Prompt",
+    roleLabel: "Rôle",
   },
   pluginCanvas: {
     undo: "Annuler",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -279,6 +279,9 @@ const jaMessages = {
     runFailed: "実行失敗: {error}",
     toggleFailed: "切替失敗: {error}",
     deleteFailed: "削除失敗: {error}",
+    detailsToggle: "詳細を表示",
+    promptLabel: "プロンプト",
+    roleLabel: "ロール",
   },
   pluginCanvas: {
     undo: "元に戻す",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -279,6 +279,9 @@ const koMessages = {
     runFailed: "실행 실패: {error}",
     toggleFailed: "토글 실패: {error}",
     deleteFailed: "삭제 실패: {error}",
+    detailsToggle: "상세 보기",
+    promptLabel: "프롬프트",
+    roleLabel: "역할",
   },
   pluginCanvas: {
     undo: "실행 취소",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -274,6 +274,9 @@ const ptBRMessages = {
     runFailed: "Falha na execução: {error}",
     toggleFailed: "Falha ao alternar: {error}",
     deleteFailed: "Falha ao excluir: {error}",
+    detailsToggle: "Mostrar detalhes",
+    promptLabel: "Prompt",
+    roleLabel: "Função",
   },
   pluginCanvas: {
     undo: "Desfazer",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -275,6 +275,9 @@ const zhMessages = {
     runFailed: "运行失败: {error}",
     toggleFailed: "切换失败: {error}",
     deleteFailed: "删除失败: {error}",
+    detailsToggle: "显示详情",
+    promptLabel: "提示词",
+    roleLabel: "角色",
   },
   pluginCanvas: {
     undo: "撤销",

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -104,10 +104,35 @@
             <span v-if="task.state?.nextScheduledAt">{{ t("pluginSchedulerTasks.nextRun", { time: formatShortTime(task.state.nextScheduledAt) }) }}</span>
           </div>
 
-          <!-- Description -->
-          <div v-if="task.description" class="mt-1 text-xs text-gray-400 truncate">
+          <!-- Description (full, not truncated — users need to know what
+               each task actually does). System tasks have only this
+               line; user / skill tasks have an expandable details
+               block below with the prompt + role. -->
+          <div v-if="task.description" class="mt-1 text-xs text-gray-500 whitespace-pre-line">
             {{ task.description }}
           </div>
+
+          <!-- Prompt + role (user / skill tasks only). Collapsed by
+               default to keep the list compact; click to inspect. -->
+          <details v-if="task.prompt" class="mt-2" :data-testid="`scheduler-task-details-${task.id}`">
+            <summary class="text-xs text-gray-500 cursor-pointer select-none hover:text-gray-700">
+              {{ t("pluginSchedulerTasks.detailsToggle") }}
+            </summary>
+            <div class="mt-1.5 space-y-1.5 ml-4">
+              <div v-if="task.roleId" class="text-xs text-gray-600">
+                <span class="font-medium">{{ t("pluginSchedulerTasks.roleLabel") }}:</span>
+                <code class="ml-1 px-1 py-0.5 rounded bg-gray-100 text-gray-700">{{ task.roleId }}</code>
+              </div>
+              <div class="text-xs text-gray-600">
+                <div class="font-medium mb-0.5">{{ t("pluginSchedulerTasks.promptLabel") }}:</div>
+                <pre
+                  class="px-2 py-1.5 rounded bg-gray-50 border border-gray-200 text-gray-700 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed"
+                  :data-testid="`scheduler-task-prompt-${task.id}`"
+                  >{{ task.prompt }}</pre
+                >
+              </div>
+            </div>
+          </details>
         </div>
       </div>
     </div>
@@ -146,6 +171,12 @@ interface SchedulerTask {
   origin: string;
   enabled?: boolean;
   state?: TaskState;
+  // user / skill tasks carry the agent prompt + role on the wire;
+  // system tasks omit them (their "what does this do" is the
+  // description text plus the source code behind the id).
+  prompt?: string;
+  roleId?: string;
+  missedRunPolicy?: string;
 }
 
 // Hints showing common task cadences. Stored as structured schedules


### PR DESCRIPTION
## Summary

Make each entry on the Automations tab self-explanatory. Previously the row showed name + schedule + truncated description, with no way to see what the task would actually run. Now:

- Description renders in full (drops `truncate`, keeps newlines via `whitespace-pre-line`)
- User/skill tasks get a collapsible **Show details** block exposing the prompt (preformatted) and the `roleId`
- System tasks are unchanged — they're internal Node functions, no prompt to show

## Items to Confirm / Review

- [ ] On `/automations`, expand a user task and confirm the prompt is readable (whitespace + newlines preserved, long prompts wrap rather than overflow)
- [ ] System tasks still render with description-only, no Show-details affordance
- [ ] All 8 locales (`en`, `ja`, `zh`, `ko`, `es`, `pt-BR`, `fr`, `de`) display the 3 new strings — `detailsToggle`, `promptLabel`, `roleLabel`
- [ ] No regression to the existing run / toggle / delete buttons

## User Prompt

> automationsのページ、それぞれのタスクが実際になにしているかわからない。

## Implementation

- `src/plugins/scheduler/TasksTab.vue`
  - Extended the local `SchedulerTask` interface with optional `prompt`, `roleId`, `missedRunPolicy` (already returned by `GET /api/scheduler/tasks` for user tasks via `PersistedUserTask`)
  - Removed `truncate` from the description block; replaced with `whitespace-pre-line` so multi-line descriptions stay legible
  - Added a `<details>` block (collapsed by default) that renders the prompt inside a `<pre>` with `whitespace-pre-wrap break-words` for long lines, and the `roleId` in a `<code>` chip
- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`
  - Added 3 keys under `pluginSchedulerTasks`: `detailsToggle`, `promptLabel`, `roleLabel`

System tasks are unaffected because the server-side scheduler adapter only returns `id / name / description / schedule / state` for them — they have no prompt to leak.