### PR TITLE
refactor: route auxiliary callers through LLMBackend.generate (PR #2)

### DIFF
--- a/plans/refactor-llm-backend-abstraction.md
+++ b/plans/refactor-llm-backend-abstraction.md
@@ -4,7 +4,15 @@
 
 Make the server-side agent loop pluggable so MulmoClaude can later support backends other than Claude Code (OpenAI Codex, Ollama native, Gemini API, etc.). Today the agent loop is hard-wired to spawn the `claude` CLI as a subprocess. We want a single seam — an `LLMBackend` interface — that everything above the seam talks to, and a `ClaudeCodeBackend` adapter that preserves today's behavior exactly.
 
-This plan is the **first of three** PRs. It is a **pure refactor — no behavior change.**
+## Status
+
+| PR | Scope | Status |
+|---|---|---|
+| #1 | Define `LLMBackend`, extract `ClaudeCodeBackend`, rewire `runAgent` | **Landed** (`3254f0f8`) |
+| #2 | Migrate journal / chat-index / sources to `backend.generate` + per-backend tuning config | **In progress** |
+| #3 | Add a second backend (probably OpenAI) — real validation of the interface | Not started |
+
+Other deferred work tracked at the end of this doc.
 
 ## Background
 
@@ -15,175 +23,249 @@ The server already has thinner Claude coupling than you might expect:
 - **Tool schemas are portable** (`gui-chat-protocol`'s JSON-Schema-based `ToolDefinition`).
 - **MCP is vendor-neutral** — other backends can either speak MCP or call MulmoClaude's `/api/...` endpoints directly the way `mcp-server.ts` does today.
 
-The Claude-specific surface is concentrated in just a few files:
+After PR #1 the Claude-specific surface is concentrated in:
 
 | File | What's Claude-specific |
 |---|---|
-| `server/agent/index.ts` | `spawnClaude()`, `readAgentEvents()` (parses Claude CLI JSON), `runAgent()` orchestrator |
-| `server/agent/config.ts` | `buildCliArgs()` (Claude CLI flags), `buildDockerSpawnArgs()`, `buildUserMessageLine()` (stream-JSON input) |
+| `server/agent/backend/claude-code.ts` | Spawn + stream-JSON parse for the agent loop |
+| `server/agent/config.ts` | `buildCliArgs()`, `buildDockerSpawnArgs()`, `buildUserMessageLine()` |
 | `server/agent/stream.ts` | `createStreamParser()` translating Claude CLI events → portable `AgentEvent` |
-| `server/agent/resumeFailover.ts` | Stale-`--resume` recovery, only meaningful for Claude |
-| `server/api/routes/agent.ts` | Reads/writes `claudeSessionId` in session meta; orchestrates `runAgent()` |
-| Three auxiliary CLI calls | `journal/archivist-cli.ts`, `chat-index/summarizer.ts`, `sources/classifier.ts` (all `spawn("claude", ...)`) |
+| `server/agent/resumeFailover.ts` | Stale-`--resume` recovery |
+| `server/api/routes/agent.ts` | Reads/writes `claudeSessionId` in session meta |
+| `server/workspace/journal/archivist-cli.ts` | One-shot `claude -p` for journal summarization |
+| `server/workspace/chat-index/summarizer.ts` | One-shot `claude --json-schema` for session titles |
+| `server/workspace/sources/classifier.ts` | One-shot `claude --json-schema` for source classification |
+| `server/workspace/sources/pipeline/summarize.ts` | One-shot `claude --output-format json` for daily-brief markdown |
 
-## Out of scope (for this PR)
+The first five are agent-loop concerns and stay where they are. The last four are the auxiliary callers PR #2 migrates.
 
-- **Auxiliary CLI calls** (journal / chat-index / sources). Migrating those is PR #2 — they already accept injectable summarize functions, so it's a small isolated change.
-- **A second backend.** That's PR #3 and is what actually validates the interface. Expect interface refinements then.
-- **Renaming `claudeSessionId` → `llmSessionToken`.** This touches `@mulmobridge/protocol` (a published wire-format) and 15 files. Deferred to a small follow-up PR after #1 lands.
-- **Migrating the existing `feat-mulmoclaude-ollama-support.md` plan.** That plan takes a different approach — env-passthrough to leverage Claude Code CLI's Anthropic-compat mode. Both can coexist; the env-passthrough route stays useful for Anthropic-compatible endpoints, and the abstraction below is what unlocks non-Anthropic-shaped backends (OpenAI function calling, Gemini, etc.).
+---
 
-## Design
+## PR #1 — landed
 
-### The interface
+The shipped design (for reference):
 
-New file: `server/agent/backend/types.ts`
+### Interface (`server/agent/backend/types.ts`)
 
 ```typescript
-import type { Attachment } from "@mulmobridge/protocol";
-import type { Role } from "../../../src/config/roles.js";
-import type { AgentEvent } from "../stream.js";
-
-/** Inputs the orchestrator passes to a backend for one user turn.
- *  The orchestrator owns role expansion, system prompt building, and
- *  MCP config writing. The backend owns spawn / SDK call + stream
- *  translation into AgentEvent. */
-export interface AgentInput {
-  systemPrompt: string;
-  message: string;
-  role: Role;
-  workspacePath: string;
-  sessionId: string;
-  port: number;
-  /** Opaque, backend-specific resume token. For Claude this is the
-   *  CLI's session id; other backends interpret it differently or
-   *  ignore it entirely (capabilities.sessionResume === false). */
-  sessionToken?: string;
-  attachments?: Attachment[];
-  /** Active MCP plugin names (subset of role.availablePlugins that
-   *  is registered in MCP_PLUGINS). The orchestrator already filtered
-   *  these — backends should not re-derive. */
-  activePlugins: string[];
-  /** When set, the path the backend should hand to its MCP loader.
-   *  Pre-resolved for host-vs-container by the orchestrator. */
-  mcpConfigPath?: string;
-  /** Extra allowed-tool names from settings + user MCP servers. */
-  extraAllowedTools: string[];
-  /** When fired, the backend must terminate any in-flight subprocess
-   *  / connection. */
-  abortSignal?: AbortSignal;
-  userTimezone?: string;
-}
-
-export interface BackendCapabilities {
-  /** Can the backend resume a prior conversation by an opaque token?
-   *  Claude: yes (--resume <id>). OpenAI: no. Ollama: no. Used by
-   *  the orchestrator to decide whether to replay transcript instead. */
-  sessionResume: boolean;
-  /** Does the backend speak MCP natively? Claude: yes. Others: emulate
-   *  or skip. Today only Claude consumes activePlugins / mcpConfigPath. */
-  mcp: boolean;
-}
-
 export interface LLMBackend {
   readonly id: string;
   readonly capabilities: BackendCapabilities;
-  /** Run one user turn. Yields portable AgentEvents. */
   runAgent(input: AgentInput): AsyncIterable<AgentEvent>;
 }
 ```
 
-Note: the interface is intentionally narrow. Auxiliary "summarize one shot" calls (PR #2) get a separate `generate` / `generateStructured` pair on a future expansion of this interface; we don't add them now because we don't need them yet and shapes are clearer once we have the second backend.
+`AgentInput` carries `systemPrompt`, `message`, `role`, MCP config path, attachments, abort signal, and an opaque `sessionToken` (today: the Claude CLI's session id; tomorrow: whatever the backend uses for resume).
 
-### The adapter
+### Adapter (`server/agent/backend/claude-code.ts`)
 
-New file: `server/agent/backend/claude-code.ts`
+Owns the spawn + stream-JSON parser. Pure helpers (`buildCliArgs`, `buildDockerSpawnArgs`, `buildUserMessageLine`, `createStreamParser`) stay in their existing home so `test/agent/` keeps working unchanged.
 
-`ClaudeCodeBackend` owns everything that's currently in `spawnClaude()`, `readAgentEvents()`, `buildCliArgs()`, `buildDockerSpawnArgs()`, `buildUserMessageLine()`, and `createStreamParser()`. The functions don't move physically — they stay in `server/agent/{config,stream}.ts` because they're testable utilities — the adapter just **calls** them. This keeps the diff small and the existing tests untouched.
-
-```typescript
-export const claudeCodeBackend: LLMBackend = {
-  id: "claude-code",
-  capabilities: { sessionResume: true, mcp: true },
-  async *runAgent(input) {
-    // existing spawnClaude + readAgentEvents flow, lifted from index.ts
-  },
-};
-```
-
-### The factory
-
-New file: `server/agent/backend/index.ts`
+### Factory (`server/agent/backend/index.ts`)
 
 ```typescript
 export function getActiveBackend(): LLMBackend {
-  // Today: always claude-code. Future: switch on env / settings.
-  return claudeCodeBackend;
+  return claudeCodeBackend;  // Future: switch on env / settings.
 }
 ```
 
-A factory rather than a direct export so PR #3 can flip on env without touching every call site.
+### Result
 
-### Rewired orchestrator
+`server/agent/index.ts` shrunk from 266 → 132 lines. `runAgent()` keeps its signature; the spawn/stream half delegates to `backend.runAgent(input)`.
 
-`runAgent()` in `server/agent/index.ts` keeps its signature and responsibilities — the orchestrator still:
+---
 
-1. Filters role plugins
-2. Loads user MCP servers + checks Docker availability
-3. Refreshes credentials (macOS sandbox)
-4. Builds the full system prompt
-5. Writes the MCP config file
-6. Loads settings (extra allowed tools)
+## PR #2 — auxiliary callers via tuning config
 
-…but instead of building CLI args + spawning + streaming itself, it builds an `AgentInput` and calls `getActiveBackend().runAgent(input)`. Yields the events through unchanged.
+### Why a separate tuning file per backend
 
-The stale-`--resume` recovery in `server/api/routes/agent.ts` stays where it is (Claude-specific failure mode, can be moved into the backend later when a non-Claude backend exists to compare against).
+The three auxiliary callers each have backend-specific knobs: `--model haiku`, `--max-budget-usd 0.15`, `--no-session-persistence`, `cwd: tmpdir()` to skip project context. An earlier sketch tried to lift those into a portable `tier: "fast"` / `maxBudgetUsd?: number` shape on `GenerateInput`. That just put Claude-shaped concepts in a hat and called them portable — adapters for OpenAI / Ollama / Gemini would have to ignore the budget cap, invent a "fast tier" mapping, etc.
 
-## File-level changes
+The fix: **the portable surface carries only a profile name; each backend has its own tuning file.** The set of profile names is shared across backends (caller picks one); the knobs are not (each backend's tuning file uses its own vocabulary). Different vocabularies don't pretend to translate.
+
+### Interface extension (`server/agent/backend/types.ts`)
+
+```typescript
+/** Tuning profile names. Each backend's tuning file must have an
+ *  entry for every name in this union — enforced at compile time
+ *  via `satisfies Record<ProfileName, ...>` in each backend's
+ *  tuning module. */
+export type ProfileName =
+  | "journal-archivist"
+  | "chat-index-summary"
+  | "source-classify"
+  | "source-summarize";
+
+export interface GenerateInput {
+  systemPrompt: string;
+  userPrompt: string;
+  profile: ProfileName;
+}
+
+export interface LLMBackend {
+  // ... existing runAgent
+  generate(input: GenerateInput): Promise<string>;
+  generateStructured<T>(input: GenerateInput, schema: object): Promise<T>;
+}
+```
+
+`generate` is for free-text output (today: journal-archivist, source-summarize). `generateStructured` is for JSON-schema-constrained output (today: chat-index-summary, source-classify). Each backend decides which one matches the profile and throws if the wrong method is called.
+
+### Per-backend tuning module
+
+`server/agent/backend/claude-code.tuning.ts`:
+
+```typescript
+import { ONE_MINUTE_MS } from "../../utils/time.js";
+import type { ProfileName } from "./types.js";
+
+interface ClaudeCodeProfile {
+  /** Three Claude-CLI invocation shapes the four callers use today:
+   *   - "text-stdin": prompt via stdin, --output-format text
+   *     (journal: prompts can be huge, no envelope needed)
+   *   - "text-envelope": prompt via argv -p, --output-format json
+   *     without --json-schema; adapter extracts envelope.result
+   *     (sources/pipeline/summarize: free-form markdown but wants
+   *     structured-error detection on stdout)
+   *   - "json-schema": prompt via argv -p, --output-format json
+   *     with --json-schema; adapter extracts envelope.structured_output
+   *     (chat-index, sources/classifier) */
+  outputFormat: "text-stdin" | "text-envelope" | "json-schema";
+  model?: "haiku" | "sonnet" | "opus";
+  maxBudgetUsd?: number;
+  noSessionPersistence?: boolean;
+  /** Run from tmpdir() so the CLI doesn't load the project's
+   *  CLAUDE.md / plugins / memory and inflate the prompt. */
+  isolatedFromProject?: boolean;
+  timeoutMs: number;
+}
+
+export const claudeCodeTuning = {
+  "journal-archivist": {
+    outputFormat: "text-stdin",
+    timeoutMs: 5 * ONE_MINUTE_MS,
+  },
+  "source-summarize": {
+    outputFormat: "text-envelope",
+    model: "haiku",
+    maxBudgetUsd: 0.25,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 5 * ONE_MINUTE_MS,
+  },
+  "chat-index-summary": {
+    outputFormat: "json-schema",
+    model: "haiku",
+    maxBudgetUsd: 0.15,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 2 * ONE_MINUTE_MS,
+  },
+  "source-classify": {
+    outputFormat: "json-schema",
+    model: "haiku",
+    maxBudgetUsd: 0.05,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 2 * ONE_MINUTE_MS,
+  },
+} as const satisfies Record<ProfileName, ClaudeCodeProfile>;
+```
+
+The `satisfies Record<ProfileName, ClaudeCodeProfile>` is load-bearing: it forces every profile in the portable union to have a tuning entry, and every entry to match the Claude profile shape. Adding a new profile in `types.ts` is a compile error in this file until the entry exists. A future `openai.tuning.ts` would have the same `satisfies` line against a completely different `OpenAIProfile` shape — no shared knob vocabulary, no leaky abstraction.
+
+**Why TS over JSON.** A TS module gives you the union-completeness check above for free; a JSON file would need a runtime zod schema + load step + startup error path to get the same property. The cost of TS is that bumping `maxBudgetUsd` from 0.15 to 0.20 needs a rebuild — for tuning that lives next to the adapter and changes on the order of months, that's the right trade. If the values ever become user-editable, that's the time to flip to JSON.
+
+### Adapter implementation
+
+`ClaudeCodeBackend` adds two methods that look up the profile, validate the output-format kind, and spawn `claude` with the right flags:
+
+```typescript
+async function generate(input: GenerateInput): Promise<string> {
+  const profile = claudeCodeTuning[input.profile];
+  if (profile.outputFormat === "json-schema") {
+    throw new Error(`profile ${input.profile} is structured — use generateStructured()`);
+  }
+  // text-stdin (journal) vs text-envelope (sources/pipeline/summarize)
+  // routes to two different spawn helpers but both return Promise<string>.
+  return profile.outputFormat === "text-stdin" ? spawnTextStdin(input, profile) : spawnTextEnvelope(input, profile);
+}
+
+async function generateStructured<T>(input: GenerateInput, schema: object): Promise<T> {
+  const profile = claudeCodeTuning[input.profile];
+  if (profile.outputFormat !== "json-schema") {
+    throw new Error(`profile ${input.profile} is text — use generate()`);
+  }
+  const stdout = await spawnJsonSchema(input, schema, profile);
+  return parseClaudeJsonEnvelope<T>(stdout);
+}
+```
+
+The three private spawn helpers are lifted from the bodies of `runClaudeCli` (archivist-cli.ts), `spawnClaudeSummarize` in summarizer.ts and pipeline/summarize.ts, and `spawnClaudeClassify` (classifier.ts). The shared envelope parser handles `{is_error, structured_output, result}` — the same lesson PR #94 learned about errors landing on stdout.
+
+### Caller migration
+
+The four callers' default impls become thin wrappers; **the public DI signatures don't change**, so injected fakes in tests keep working unchanged.
+
+```typescript
+// archivist-cli.ts (after)
+export const runClaudeCli: Summarize = (systemPrompt, userPrompt) =>
+  getActiveBackend().generate({ systemPrompt, userPrompt, profile: "journal-archivist" });
+
+// summarizer.ts (after)
+export const defaultSummarize: SummarizeFn = async (input) => {
+  const result = await getActiveBackend().generateStructured<unknown>(
+    { systemPrompt: SYSTEM_PROMPT, userPrompt: input, profile: "chat-index-summary" },
+    SUMMARY_SCHEMA,
+  );
+  return validateSummaryResult(result);  // existing lenient normalizer
+};
+
+// classifier.ts and pipeline/summarize.ts — analogous
+```
+
+Pure helpers stay where they are: `extractText`, `truncate`, `validateSummaryResult`, `validateClassifyResult`, `buildClassifyPrompt`, `parseSummarizeOutput`, `buildSummarizePromptBody`. The Claude-CLI-specific envelope parsing moves into the adapter — it's the adapter's protocol, not the caller's concern.
+
+### Error portability
+
+`ClaudeCliNotFoundError` (currently in `archivist-cli.ts`, re-imported by summarizer / classifier / pipeline-summarize) becomes a portable `LLMBackendUnavailableError` exported from the backend module. To avoid touching ~10 `instanceof ClaudeCliNotFoundError` catch sites in production code and tests, `archivist-cli.ts` re-exports `LLMBackendUnavailableError as ClaudeCliNotFoundError` — same class, two names. New code can catch the portable name; existing catches keep working.
+
+### File-level changes
 
 **New files:**
-
-- `server/agent/backend/types.ts` — interface + types
-- `server/agent/backend/claude-code.ts` — Claude adapter (calls existing helpers)
-- `server/agent/backend/index.ts` — `getActiveBackend()` factory
+- `server/agent/backend/claude-code.tuning.ts`
 
 **Modified files:**
+- `server/agent/backend/types.ts` — add `ProfileName`, `GenerateInput`, extend `LLMBackend`, export `LLMBackendUnavailableError`
+- `server/agent/backend/claude-code.ts` — implement `generate` / `generateStructured`, lift spawn helpers from the four caller files
+- `server/workspace/journal/archivist-cli.ts` — `runClaudeCli` becomes a wrapper; spawn body + `ClaudeCliFailedError` deleted; `ClaudeCliNotFoundError` becomes a re-export alias
+- `server/workspace/chat-index/summarizer.ts` — `defaultSummarize` becomes a wrapper; `spawnClaudeSummarize` + `parseClaudeJsonResult` deleted
+- `server/workspace/sources/classifier.ts` — `defaultClassify` becomes a wrapper; `spawnClaudeClassify` + envelope-parse half of `parseClassifyOutput` deleted
+- `server/workspace/sources/pipeline/summarize.ts` — `makeDefaultSummarize` becomes a wrapper; `spawnClaudeSummarize` deleted; `parseSummarizeOutput` keeps its `result`-extraction role (adapter returns the envelope's `result` field as a string)
 
-- `server/agent/index.ts` — `runAgent()` keeps its signature but delegates the spawn/stream half to the active backend. `spawnClaude()` and `readAgentEvents()` move into the adapter.
+**Untouched:**
+- All callers of `Summarize` / `SummarizeFn` / `ClassifyFn` (`dailyPass.ts`, indexer, source registry, daily-brief writer)
+- All tests under `test/journal/`, `test/chat-index/`, `test/sources/` — they inject fakes, not the spawn layer
 
-**Untouched** (verifies the boundary is right):
+### Acceptance criteria
 
-- `server/agent/config.ts`
-- `server/agent/stream.ts`
-- `server/agent/prompt.ts`
-- `server/agent/resumeFailover.ts`
-- `server/api/routes/agent.ts`
-- All tests under `test/agent/`
+- `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` all clean
+- `git grep "spawn.*\\bclaude\\b" server/workspace/` returns zero hits
+- Every existing fake injected by tests still satisfies `Summarize` / `SummarizeFn` / `ClassifyFn` without changes
 
-## Sequencing inside this PR
+---
 
-1. Add `server/agent/backend/types.ts` (pure types)
-2. Add `server/agent/backend/claude-code.ts` (lifts `spawnClaude` + `readAgentEvents` from `index.ts`)
-3. Add `server/agent/backend/index.ts` (factory)
-4. Rewire `runAgent()` in `index.ts` to build `AgentInput` and delegate
-5. Run `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
+## Follow-up PRs (after #2)
 
-## Acceptance criteria
-
-- `yarn typecheck`, `yarn lint`, `yarn build`, `yarn test` all pass
-- `runAgent()` keeps the same exported signature
-- No behavior change observable from `server/api/routes/agent.ts` or tests
-- `server/agent/backend/types.ts` is the only file imported by any future second backend
-- `git grep "spawn.*claude"` outside `server/agent/backend/` and the three auxiliary files returns zero hits
-
-## Follow-up PRs (not in this one)
-
-- **PR #2:** Migrate `journal/archivist-cli.ts`, `chat-index/summarizer.ts`, `sources/classifier.ts` to a `generate` / `generateStructured` extension of `LLMBackend`. Three files, all already test-injectable.
 - **PR #2.5 (optional):** Rename `claudeSessionId` → `llmSessionToken` across server, tests, and `@mulmobridge/protocol`. Wire-format change — coordinate package version bump.
-- **PR #3:** Add a second backend (probably OpenAI). Real validation of the interface; expect refinements.
+- **PR #3:** Add a second backend (probably OpenAI). Real validation of the interface; expect refinements. Will exercise both `runAgent` and `generate*` paths and clarify whether the orchestrator's MCP-config-writing belongs there or behind a `capabilities.mcp` check.
+
+## Out of scope
+
+- **Migrating the existing `feat-mulmoclaude-ollama-support.md` plan.** That plan takes a different approach — env-passthrough to leverage Claude Code CLI's Anthropic-compat mode. Both can coexist; the env-passthrough route stays useful for Anthropic-compatible endpoints, and the abstraction in this doc is what unlocks non-Anthropic-shaped backends (OpenAI function calling, Gemini, etc.).
 
 ## Risks
 
-- The orchestrator/backend split has to put MCP config writing on the *orchestrator* side (it's filesystem state, not LLM call), but `mcpConfigPath` only matters to the Claude adapter. That's OK as long as we keep `BackendCapabilities.mcp` and let other adapters ignore the field.
-- `BackendCapabilities` is meant to be honest, not enforcing. The orchestrator may grow `if (backend.capabilities.sessionResume) { ... }` branches over time. That's the right place for them; resist the temptation to push them into adapters as no-ops.
-- The interface is provisional. Don't optimize for it being perfect on PR #1 — it will refine in PR #3.
+- **`generate` / `generateStructured` are provisional.** Their signatures will refine when PR #3 wires up a real second backend — that's the only thing that proves the per-profile tuning file is the right unit. Don't optimize for perfect now.
+- **Output-format mismatch is a runtime error.** Calling `generate` for a profile whose tuning has `outputFormat: "json"` (or vice versa) throws. Compile-time discrimination would need discriminated-union profiles, which complicates the tuning shape. Tests cover each profile's correct path; the runtime check is a defensive net.
+- **`ProfileName` is a closed union.** Adding a profile is a 2-step change: extend the union *and* add the entry to every backend's tuning module. The compiler enforces both halves; this is the same load-bearing property that makes the design work.

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -10,6 +10,7 @@
 // unchanged.
 
 import { spawn, type ChildProcessByStdio } from "child_process";
+import { tmpdir } from "node:os";
 import type { Readable, Writable } from "stream";
 import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine } from "../config.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
@@ -18,9 +19,15 @@ import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../str
 import { log } from "../../system/logger/index.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
-import type { AgentInput, LLMBackend } from "./types.js";
+import { formatSpawnFailure } from "../../utils/spawn.js";
+import { errorMessage } from "../../utils/errors.js";
+import { isRecord } from "../../utils/types.js";
+import { LLMBackendUnavailableError, type AgentInput, type GenerateInput, type LLMBackend } from "./types.js";
+import { claudeCodeTuning, type ClaudeCodeProfile } from "./claude-code.tuning.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
+
+const SPAWN_PREFIX = "[claude-code]";
 
 function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[]): ClaudeProc {
   if (!useDocker) {
@@ -163,8 +170,199 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
   }
 }
 
+// ── One-shot generation ─────────────────────────────────────────────
+
+interface SpawnOpts {
+  args: string[];
+  cwd?: string;
+  /** When set, the payload is written to stdin and the pipe is
+   *  closed after the write drains. Otherwise stdin is "ignore". */
+  stdinPayload?: string;
+  timeoutMs: number;
+}
+
+function runClaudeOneShot(opts: SpawnOpts): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const stdinPayload = opts.stdinPayload;
+    const stdio: ["pipe" | "ignore", "pipe", "pipe"] = [stdinPayload !== undefined ? "pipe" : "ignore", "pipe", "pipe"];
+    const proc = spawn("claude", opts.args, { cwd: opts.cwd, stdio });
+
+    // stdio[1] and stdio[2] are always "pipe" so stdout/stderr are
+    // guaranteed non-null. Narrow once via aliases instead of the
+    // `?.` everywhere below.
+    const procStdout = proc.stdout;
+    const procStderr = proc.stderr;
+    if (!procStdout || !procStderr) {
+      reject(new Error(`${SPAWN_PREFIX} failed to attach to claude stdout/stderr pipes`));
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const settleOnce = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      action();
+    };
+
+    const timer = setTimeout(() => {
+      settleOnce(() => {
+        proc.kill("SIGKILL");
+        reject(new Error(`${SPAWN_PREFIX} claude timed out after ${opts.timeoutMs}ms`));
+      });
+    }, opts.timeoutMs);
+
+    procStdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    procStderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on("error", (err: Error & { code?: string }) => {
+      settleOnce(() => {
+        clearTimeout(timer);
+        if (err.code === "ENOENT") {
+          reject(new LLMBackendUnavailableError("`claude` CLI is not available on PATH"));
+        } else {
+          reject(err);
+        }
+      });
+    });
+
+    proc.on("close", (code) => {
+      settleOnce(() => {
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(formatSpawnFailure(SPAWN_PREFIX, code, stdout, stderr)));
+          return;
+        }
+        resolve(stdout);
+      });
+    });
+
+    if (stdinPayload !== undefined && proc.stdin) {
+      const procStdin = proc.stdin;
+      procStdin.on("error", (err: Error) => {
+        settleOnce(() => {
+          clearTimeout(timer);
+          reject(err);
+        });
+      });
+      // Send the full prompt in one write. If Node's stream layer
+      // signals backpressure (write returns false), wait for "drain"
+      // before calling end() so we don't close stdin while the
+      // buffer still has data to flush. Typical archivist prompts
+      // never hit this path; very large day excerpts can.
+      const flushed = procStdin.write(stdinPayload);
+      if (flushed) {
+        procStdin.end();
+      } else {
+        procStdin.once("drain", () => procStdin.end());
+      }
+    }
+  });
+}
+
+interface ClaudeJsonEnvelope {
+  is_error?: boolean;
+  structured_output?: unknown;
+  result?: string;
+  errors?: unknown;
+  subtype?: string;
+}
+
+function parseEnvelope(stdout: string): ClaudeJsonEnvelope {
+  let parsed: ClaudeJsonEnvelope;
+  try {
+    parsed = JSON.parse(stdout.trim()) as ClaudeJsonEnvelope;
+  } catch (err) {
+    throw new Error(`${SPAWN_PREFIX} failed to parse claude json output: ${errorMessage(err)}`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${SPAWN_PREFIX} claude json output is not an object`);
+  }
+  if (parsed.is_error) {
+    const fromErrors = Array.isArray(parsed.errors) ? parsed.errors.filter((value): value is string => typeof value === "string").join("; ") : "";
+    const fromSubtypeResult = parsed.subtype && parsed.result ? `${parsed.subtype}: ${parsed.result}` : "";
+    const msg = fromErrors || fromSubtypeResult || parsed.result || parsed.subtype || "unknown";
+    throw new Error(`${SPAWN_PREFIX} claude returned error: ${msg}`);
+  }
+  return parsed;
+}
+
+function buildJsonArgs(input: GenerateInput, profile: ClaudeCodeProfile, schema?: object): string[] {
+  const args: string[] = ["--print"];
+  if (profile.noSessionPersistence) args.push("--no-session-persistence");
+  args.push("--output-format", "json");
+  if (profile.model) args.push("--model", profile.model);
+  if (profile.maxBudgetUsd !== undefined) args.push("--max-budget-usd", String(profile.maxBudgetUsd));
+  if (schema) args.push("--json-schema", JSON.stringify(schema));
+  args.push("--system-prompt", input.systemPrompt);
+  args.push("-p", input.userPrompt);
+  return args;
+}
+
+// "text-stdin" — journal-archivist pattern. Concatenate system + user
+// with a `---` separator and pipe the whole thing as stdin so very
+// large prompts (full day's transcripts) don't hit shell argv limits.
+async function spawnTextStdin(input: GenerateInput, profile: ClaudeCodeProfile): Promise<string> {
+  const payload = `${input.systemPrompt}\n\n---\n\n${input.userPrompt}`;
+  return runClaudeOneShot({
+    args: ["-p", "--output-format", "text"],
+    stdinPayload: payload,
+    timeoutMs: profile.timeoutMs,
+  });
+}
+
+// "text-envelope" — sources/pipeline/summarize pattern. argv-based
+// prompt, json envelope (no schema). Adapter extracts the model's
+// free-form text from envelope.result.
+async function spawnTextEnvelope(input: GenerateInput, profile: ClaudeCodeProfile): Promise<string> {
+  const args = buildJsonArgs(input, profile);
+  const cwd = profile.isolatedFromProject ? tmpdir() : undefined;
+  const stdout = await runClaudeOneShot({ args, cwd, timeoutMs: profile.timeoutMs });
+  const envelope = parseEnvelope(stdout);
+  const result = typeof envelope.result === "string" ? envelope.result : "";
+  if (!result) {
+    throw new Error(`${SPAWN_PREFIX} claude returned empty / missing result`);
+  }
+  return result;
+}
+
+// "json-schema" — chat-index-summary / source-classify pattern.
+// argv-based prompt, json envelope with --json-schema. Adapter
+// extracts envelope.structured_output as T.
+async function spawnJsonSchema<T>(input: GenerateInput, schema: object, profile: ClaudeCodeProfile): Promise<T> {
+  const args = buildJsonArgs(input, profile, schema);
+  const cwd = profile.isolatedFromProject ? tmpdir() : undefined;
+  const stdout = await runClaudeOneShot({ args, cwd, timeoutMs: profile.timeoutMs });
+  const envelope = parseEnvelope(stdout);
+  return envelope.structured_output as T;
+}
+
+async function generate(input: GenerateInput): Promise<string> {
+  const profile = claudeCodeTuning[input.profile];
+  if (profile.outputFormat === "json-schema") {
+    throw new Error(`${SPAWN_PREFIX} profile '${input.profile}' is structured — use generateStructured()`);
+  }
+  return profile.outputFormat === "text-stdin" ? spawnTextStdin(input, profile) : spawnTextEnvelope(input, profile);
+}
+
+async function generateStructured<T>(input: GenerateInput, schema: object): Promise<T> {
+  const profile = claudeCodeTuning[input.profile];
+  if (profile.outputFormat !== "json-schema") {
+    throw new Error(`${SPAWN_PREFIX} profile '${input.profile}' is text — use generate()`);
+  }
+  return spawnJsonSchema<T>(input, schema, profile);
+}
+
 export const claudeCodeBackend: LLMBackend = {
   id: "claude-code",
   capabilities: { sessionResume: true, mcp: true },
   runAgent: runClaudeAgent,
+  generate,
+  generateStructured,
 };

--- a/server/agent/backend/claude-code.tuning.ts
+++ b/server/agent/backend/claude-code.tuning.ts
@@ -1,0 +1,94 @@
+// Per-profile tuning for the Claude Code backend. The shape here is
+// intentionally Claude-CLI-shaped — `model`, `maxBudgetUsd`,
+// `noSessionPersistence` are CLI flags, not portable concepts. Other
+// backends (openai.tuning.ts, ollama.tuning.ts) own their own files
+// with their own knob vocabulary; nothing is shared except the
+// ProfileName union from types.ts.
+//
+// The `satisfies Record<ProfileName, ClaudeCodeProfile>` line at the
+// bottom is load-bearing: adding a name to ProfileName is a compile
+// error here until an entry exists, and every entry must match the
+// Claude profile shape.
+
+import { ONE_MINUTE_MS } from "../../utils/time.js";
+import type { ProfileName } from "./types.js";
+
+export interface ClaudeCodeProfile {
+  /** Three Claude-CLI invocation shapes the auxiliary callers use:
+   *
+   *   "text-stdin" — prompt via stdin, `--output-format text`.
+   *     Used when prompts can be very large (full day's chat
+   *     transcripts) and shouldn't go through argv. No structured
+   *     error envelope; non-zero exit surfaces as plain stderr.
+   *
+   *   "text-envelope" — prompt via argv `-p`, `--output-format json`
+   *     without `--json-schema`. The model emits free-form text
+   *     (e.g. markdown) which the adapter extracts from the
+   *     envelope's `result` field. Used when callers want
+   *     structured-error detection (budget exhaustion, auth) but
+   *     the output itself is free-form.
+   *
+   *   "json-schema" — prompt via argv `-p`, `--output-format json`
+   *     with `--json-schema`. The model's structured output is
+   *     extracted from the envelope's `structured_output` field
+   *     and returned to the caller as `T`. */
+  outputFormat: "text-stdin" | "text-envelope" | "json-schema";
+  /** --model. Omit to use the CLI's default. One-shot summarization
+   *  workloads typically use haiku for cost; the agent loop uses
+   *  the default. */
+  model?: "haiku" | "sonnet" | "opus";
+  /** --max-budget-usd. Omit for no cap. */
+  maxBudgetUsd?: number;
+  /** --no-session-persistence: don't record this turn in the user's
+   *  ~/.claude session log. Appropriate for one-shot batch work. */
+  noSessionPersistence?: boolean;
+  /** Run from tmpdir() so the CLI doesn't load the project's
+   *  CLAUDE.md / plugins / memory and inflate the prompt. */
+  isolatedFromProject?: boolean;
+  /** Wall-clock cap per invocation. */
+  timeoutMs: number;
+}
+
+export const claudeCodeTuning = {
+  "journal-archivist": {
+    outputFormat: "text-stdin",
+    timeoutMs: 5 * ONE_MINUTE_MS,
+  },
+  "source-summarize": {
+    outputFormat: "text-envelope",
+    model: "haiku",
+    // A daily brief is longer + more expensive than a classify call,
+    // so the cap is higher than the classifier's 0.05. 0.25 covers
+    // several hundred items comfortably.
+    maxBudgetUsd: 0.25,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 5 * ONE_MINUTE_MS,
+  },
+  "chat-index-summary": {
+    outputFormat: "json-schema",
+    model: "haiku",
+    // Previously 0.05 was tight enough that a first-burst call —
+    // which pays a one-time cache-creation cost on haiku (~28k
+    // cache-creation tokens) — would trip the cap and fail with
+    // `error_max_budget_usd` even for tiny 600-char transcripts.
+    // 0.15 leaves headroom for cache creation + a generous output
+    // allowance while still capping a 100-session backfill to well
+    // under $20.
+    maxBudgetUsd: 0.15,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 2 * ONE_MINUTE_MS,
+  },
+  "source-classify": {
+    outputFormat: "json-schema",
+    model: "haiku",
+    // Cheap one-shot — small prompt, no cache-creation amortization
+    // needed because the prompt doesn't trigger the haiku
+    // first-burst cost the way chat-index does.
+    maxBudgetUsd: 0.05,
+    noSessionPersistence: true,
+    isolatedFromProject: true,
+    timeoutMs: 2 * ONE_MINUTE_MS,
+  },
+} as const satisfies Record<ProfileName, ClaudeCodeProfile>;

--- a/server/agent/backend/index.ts
+++ b/server/agent/backend/index.ts
@@ -7,7 +7,8 @@
 import { claudeCodeBackend } from "./claude-code.js";
 import type { LLMBackend } from "./types.js";
 
-export type { AgentInput, BackendCapabilities, LLMBackend } from "./types.js";
+export type { AgentInput, BackendCapabilities, GenerateInput, LLMBackend, ProfileName } from "./types.js";
+export { LLMBackendUnavailableError } from "./types.js";
 
 export function getActiveBackend(): LLMBackend {
   return claudeCodeBackend;

--- a/server/agent/backend/types.ts
+++ b/server/agent/backend/types.ts
@@ -57,9 +57,51 @@ export interface BackendCapabilities {
   mcp: boolean;
 }
 
+/** Tuning profile names for one-shot LLM calls (generate /
+ *  generateStructured). Each backend has a tuning module
+ *  (e.g. claude-code.tuning.ts) mapping every name in this union to
+ *  its own knob vocabulary — enforced at compile time via
+ *  `satisfies Record<ProfileName, ...>` in each tuning module.
+ *  Adding a new profile here is a 2-step change: extend the union
+ *  AND add the entry to every backend's tuning module. */
+export type ProfileName = "journal-archivist" | "chat-index-summary" | "source-classify" | "source-summarize";
+
+/** Inputs for one-shot generation calls. The portable surface is
+ *  intentionally tiny: backend-specific tuning (model, budget cap,
+ *  output format, isolation, timeout) is looked up by `profile` in
+ *  the active backend's tuning module rather than passed here. */
+export interface GenerateInput {
+  systemPrompt: string;
+  userPrompt: string;
+  profile: ProfileName;
+}
+
+/** Thrown when the configured backend isn't available on this host
+ *  (e.g. `claude` CLI missing on PATH for ClaudeCodeBackend). Each
+ *  caller decides what to do — journal disables itself for the
+ *  rest of the server lifetime; chat-index / sources log and skip.
+ *
+ *  Re-exported from server/workspace/journal/archivist-cli.ts as
+ *  `ClaudeCliNotFoundError` for back-compat with existing catch
+ *  sites (same class, two names). */
+export class LLMBackendUnavailableError extends Error {
+  constructor(message: string = "LLM backend is not available") {
+    super(message);
+    this.name = "LLMBackendUnavailableError";
+  }
+}
+
 export interface LLMBackend {
   readonly id: string;
   readonly capabilities: BackendCapabilities;
   /** Run one user turn. Yields portable AgentEvents. */
   runAgent(input: AgentInput): AsyncIterable<AgentEvent>;
+  /** One-shot text generation (no tools, no streaming). Throws if
+   *  the profile's tuning declares structured output. */
+  generate(input: GenerateInput): Promise<string>;
+  /** One-shot structured generation against a JSON schema. Throws
+   *  if the profile's tuning declares free-text output. The schema
+   *  is the JSON Schema object the backend hands to its provider
+   *  (Claude: --json-schema; OpenAI: response_format; etc.). */
+  generateStructured<T>(input: GenerateInput, schema: object): Promise<T>;
 }

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -1,27 +1,29 @@
 // Summarizes a single session jsonl into a title / summary /
-// keywords triple using the Claude Code CLI. Cherry-picked and
+// keywords triple via the active LLM backend. Cherry-picked and
 // trimmed from the closed PR #94.
 //
-// Splits cleanly into three layers so tests can exercise the pure
-// bits without spawning the CLI:
+// Splits cleanly into two layers so tests can exercise the pure
+// bits without invoking the backend:
 //
 //   extractText / truncate         — jsonl → prompt input
-//   parseClaudeJsonResult          — CLI stdout → SummaryResult
 //   validateSummaryResult          — unknown → SummaryResult
 //
-// `defaultSummarize` composes them with the real spawn; tests
-// inject their own SummarizeFn via `IndexerDeps.summarize`.
+// `defaultSummarize` composes them and calls
+// `backend.generateStructured`. Tests inject their own SummarizeFn
+// via `IndexerDeps.summarize`.
 
-import { spawn } from "node:child_process";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { readFile } from "node:fs/promises";
-import { formatSpawnFailure } from "../../utils/spawn.js";
-import { tmpdir } from "node:os";
+import { getActiveBackend } from "../../agent/backend/index.js";
 import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { errorMessage } from "../../utils/errors.js";
+import { formatSpawnFailure } from "../../utils/spawn.js";
 import type { SummaryResult } from "./types.js";
-import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { isRecord } from "../../utils/types.js";
+
+// Re-export so chat-index callers keep their existing import path
+// (../chat-index/summarizer or ../journal/archivist-cli — both work).
+export { ClaudeCliNotFoundError };
 
 const SYSTEM_PROMPT =
   "You summarize a single chat session. Output strict JSON matching the provided schema. " +
@@ -43,18 +45,6 @@ const MAX_INPUT_CHARS = 8000;
 const HEAD_CHARS = 3000;
 const TAIL_CHARS = 5000;
 const PER_MESSAGE_MAX = 500;
-
-// Spawn / budget constants.
-const DEFAULT_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
-// Budget cap per summarization call, forwarded to `claude
-// --max-budget-usd`. Previously 0.05 but that was tight enough
-// that a first-burst call — which pays a one-time cache creation
-// cost on haiku (~28k cache-creation tokens) — would trip the cap
-// and fail with `error_max_budget_usd` even for tiny 600-char
-// transcripts. 0.15 leaves comfortable headroom for cache
-// creation + a generous output allowance while still capping a
-// full 100-session backfill to well under $20.
-const MAX_BUDGET_USD = 0.15;
 
 // Any module that wants to drive the summarizer — including the
 // indexer — takes a SummarizeFn so tests can supply a deterministic
@@ -95,53 +85,12 @@ export function extractText(jsonlContent: string): string {
 }
 
 // Long sessions are truncated to first ~3000 + last ~5000 chars so
-// claude sees both the original topic and the most recent state.
+// the model sees both the original topic and the most recent state.
 export function truncate(text: string): string {
   if (text.length <= MAX_INPUT_CHARS) return text;
   const head = text.slice(0, HEAD_CHARS);
   const tail = text.slice(-TAIL_CHARS);
   return `${head}\n\n…\n\n${tail}`;
-}
-
-interface ClaudeJsonResult {
-  type?: string;
-  is_error?: boolean;
-  structured_output?: unknown;
-  result?: string;
-}
-
-// Parse the JSON envelope that `claude --output-format json`
-// prints, raising a useful error if the envelope is malformed or
-// the CLI reported an error.
-export function parseClaudeJsonResult(stdout: string): SummaryResult {
-  let parsed: ClaudeJsonResult;
-  try {
-    parsed = JSON.parse(stdout.trim());
-  } catch (err) {
-    throw new Error(`[chat-index] failed to parse claude json output: ${errorMessage(err)}`);
-  }
-  if (parsed.is_error) {
-    throw new Error(`[chat-index] claude returned error: ${parsed.result ?? "unknown"}`);
-  }
-  return validateSummaryResult(parsed.structured_output);
-}
-
-// Build the error message for a non-zero `claude` CLI exit.
-//
-// The claude CLI writes its structured result — including error
-// envelopes like `{"is_error":true,"subtype":"error_max_budget_usd",
-// "errors":["Reached maximum budget ($0.05)"]}` — to **stdout**,
-// not stderr. Our previous handler only inspected stderr, so
-// budget-exhaustion and similar failures surfaced as
-// `claude summarize exited 1:` with no details at all, making
-// them impossible to diagnose from the log.
-//
-// Strategy: try to parse stdout as a claude JSON envelope first
-// and extract a human-readable reason from `errors[]` /
-// `subtype` / `result`; fall back to stderr, then to a raw
-// stdout slice, then to a generic "no error output".
-export function formatSpawnError(code: number | null, stdout: string, stderr: string): string {
-  return formatSpawnFailure("[chat-index]", code, stdout, stderr);
 }
 
 // Runtime-validate an arbitrary value into a SummaryResult. Missing
@@ -159,8 +108,42 @@ export function validateSummaryResult(obj: unknown): SummaryResult {
   return { title, summary, keywords };
 }
 
+interface ClaudeJsonResult {
+  type?: string;
+  is_error?: boolean;
+  structured_output?: unknown;
+  result?: string;
+}
+
+// Pure: parse the JSON envelope `claude --output-format json`
+// prints, raising a useful error if the envelope is malformed or
+// the CLI reported an error. Retained as a test-callable helper
+// that documents the envelope shape; the production path goes
+// through `backend.generateStructured`, which extracts
+// `structured_output` itself.
+export function parseClaudeJsonResult(stdout: string): SummaryResult {
+  let parsed: ClaudeJsonResult;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch (err) {
+    throw new Error(`[chat-index] failed to parse claude json output: ${errorMessage(err)}`);
+  }
+  if (parsed.is_error) {
+    throw new Error(`[chat-index] claude returned error: ${parsed.result ?? "unknown"}`);
+  }
+  return validateSummaryResult(parsed.structured_output);
+}
+
+// Curried log prefix for `formatSpawnFailure`. Retained as a
+// test-callable helper covering the structured-error-on-stdout
+// path; production code uses `formatSpawnFailure` directly via
+// the adapter.
+export function formatSpawnError(code: number | null, stdout: string, stderr: string): string {
+  return formatSpawnFailure("[chat-index]", code, stdout, stderr);
+}
+
 // Read a jsonl file and produce the pre-truncated transcript that
-// goes into the CLI prompt. Returns the empty string for an empty
+// goes into the prompt. Returns the empty string for an empty
 // or unreadable file so the caller can decide whether to skip.
 export async function loadJsonlInput(jsonlPath: string): Promise<string> {
   try {
@@ -171,77 +154,16 @@ export async function loadJsonlInput(jsonlPath: string): Promise<string> {
   }
 }
 
-// --- spawn layer ----------------------------------------------------
-
-function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const args = [
-      "--print",
-      "--no-session-persistence",
-      "--output-format",
-      "json",
-      "--model",
-      "haiku",
-      "--max-budget-usd",
-      String(MAX_BUDGET_USD),
-      "--json-schema",
-      JSON.stringify(SUMMARY_SCHEMA),
-      "--system-prompt",
-      SYSTEM_PROMPT,
-      "-p",
-      input,
-    ];
-    // Run from tmpdir so claude does not load the project's
-    // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", args, {
-      cwd: tmpdir(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      proc.kill("SIGKILL");
-      reject(new Error(`[chat-index] claude summarize timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    proc.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    proc.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    proc.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-    proc.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(formatSpawnError(code, stdout, stderr)));
-        return;
-      }
-      resolve(stdout);
-    });
-  });
-}
-
-// Production SummarizeFn: prepare the input from a jsonl path and
-// drive the CLI. Tests inject their own SummarizeFn that bypasses
-// the CLI entirely.
+// Production SummarizeFn: drive the active backend. Tests inject
+// their own SummarizeFn that bypasses the backend entirely.
 export const defaultSummarize: SummarizeFn = async (input: string) => {
-  const stdout = await spawnClaudeSummarize(input, DEFAULT_TIMEOUT_MS);
-  return parseClaudeJsonResult(stdout);
+  const result = await getActiveBackend().generateStructured<unknown>(
+    {
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt: input,
+      profile: "chat-index-summary",
+    },
+    SUMMARY_SCHEMA,
+  );
+  return validateSummaryResult(result);
 };

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -1,121 +1,34 @@
-// Transport layer for the journal archivist: wraps the Claude Code
-// CLI as a subprocess so summarization runs against the user's
-// subscription quota rather than the API key budget.
+// Transport layer for the journal archivist: previously spawned the
+// Claude Code CLI as a subprocess directly. As of PR #2 of the LLM
+// backend abstraction (plans/refactor-llm-backend-abstraction.md),
+// the spawn body lives in server/agent/backend/claude-code.ts and
+// this file is a thin wrapper.
 //
-// The pure data shapes (interfaces, prompts, validators) live in
-// `./archivist-schemas.ts`. This file is the only one that touches
-// `node:child_process`, kept thin so dependency injection in tests
-// never has to mock a subprocess.
+// `ClaudeCliNotFoundError` is re-exported here as an alias for
+// `LLMBackendUnavailableError` — same class, two names — so the
+// ~10 existing `instanceof ClaudeCliNotFoundError` catch sites in
+// the journal / chat-index / sources subsystems keep working
+// unchanged. New code should prefer `LLMBackendUnavailableError`.
 
-import { spawn } from "node:child_process";
-import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
+import { getActiveBackend } from "../../agent/backend/index.js";
 
 // (systemPrompt, userPrompt) → raw model output as a string.
 // The daily/optimization passes parse JSON out of the string
 // themselves; this layer stays transport-only.
 export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
 
-// Wall-clock cap per CLI invocation. 5 minutes is comfortably above
-// the worst-case summarization run we've seen and still short enough
-// that a wedged subprocess doesn't tie up resources forever.
-const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
+// Re-export under both names. Catch sites using either spelling
+// land on the same class.
+export { LLMBackendUnavailableError, LLMBackendUnavailableError as ClaudeCliNotFoundError } from "../../agent/backend/types.js";
 
-// Sentinel thrown on ENOENT. Each subsystem catches this and decides
-// what to do — journal disables itself for the rest of the server
-// lifetime; chat-index / sources log and skip. The message is
-// subsystem-neutral so callers logging `err.message` verbatim (e.g.
-// chat-index) don't surface a misleading "journal disabled" warning.
-export class ClaudeCliNotFoundError extends Error {
-  constructor() {
-    super("`claude` CLI is not available on PATH");
-    this.name = "ClaudeCliNotFoundError";
-  }
-}
-
-export class ClaudeCliFailedError extends Error {
-  readonly exitCode: number | null;
-  readonly stderr: string;
-  constructor(exitCode: number | null, stderr: string) {
-    super(`\`claude\` CLI exited ${exitCode ?? "(killed)"}: ${stderr.slice(0, 500)}`);
-    this.name = "ClaudeCliFailedError";
-    this.exitCode = exitCode;
-    this.stderr = stderr;
-  }
-}
-
-// Default summarizer. Spawns `claude -p` and pipes the combined
-// system + user prompt to stdin so we don't hit shell-argv limits
-// for large day excerpts.
+// Default summarizer. Delegates to the active backend's text-output
+// generate path. The backend's tuning module owns per-profile flags
+// (timeout, model, budget cap, etc.); this file no longer has any
+// Claude-CLI-specific knobs.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
-  return new Promise((resolve, reject) => {
-    const child = spawn("claude", ["-p", "--output-format", "text"], {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-    let settled = false;
-
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, CLI_TIMEOUT_MS);
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-
-    child.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-
-    child.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      if (timedOut) {
-        reject(new ClaudeCliFailedError(null, `timed out after ${CLI_TIMEOUT_MS}ms\n${stderr}`));
-        return;
-      }
-      if (code === 0) {
-        resolve(stdout);
-      } else {
-        reject(new ClaudeCliFailedError(code, stderr));
-      }
-    });
-
-    // Surface stdin write errors (e.g. EPIPE if the child exited
-    // before we finished writing) instead of silently dropping them.
-    child.stdin.on("error", (err: Error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      reject(err);
-    });
-
-    // Send the full prompt in one write. If Node's stream layer
-    // signals backpressure (write returns false), wait for "drain"
-    // before calling end() so we don't close stdin while the buffer
-    // still has data to flush. For typical archivist prompts this
-    // path rarely fires, but very large session excerpts can reach
-    // it.
-    const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
-    const flushed = child.stdin.write(payload);
-    if (flushed) {
-      child.stdin.end();
-    } else {
-      child.stdin.once("drain", () => child.stdin.end());
-    }
+  return getActiveBackend().generate({
+    systemPrompt,
+    userPrompt,
+    profile: "journal-archivist",
   });
 };

--- a/server/workspace/sources/classifier.ts
+++ b/server/workspace/sources/classifier.ts
@@ -2,29 +2,25 @@
 //
 // When a user registers a new source, the UI / CLI calls
 // `classifySource({ title, url, sampleTitles, sampleSummaries })`.
-// The classifier spawns `claude` with a strict JSON schema that
-// limits output to the fixed 25-slug taxonomy (see
-// server/sources/taxonomy.ts), so the model can't invent
+// `defaultClassify` drives the active LLM backend with a strict
+// JSON schema that limits output to the fixed 25-slug taxonomy
+// (see server/sources/taxonomy.ts), so the model can't invent
 // `artificial-intelligence` when we already have `ai` — the whole
 // point of the closed enum.
 //
-// Shape of the spawn layer mirrors `server/chat-index/summarizer.ts`
-// so we reuse the "errors on stdout not stderr", "budget
-// exhaustion surfaces cleanly" behaviour that we already got
-// right once.
-//
 // Injection-friendly: production `classifySource` goes through
 // `defaultClassify`. Tests pass their own `ClassifyFn` that
-// skips the CLI entirely.
+// skips the backend entirely.
 
-import { spawn } from "node:child_process";
-import { tmpdir } from "node:os";
+import { getActiveBackend } from "../../agent/backend/index.js";
 import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
-import { formatSpawnFailure } from "../../utils/spawn.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { CATEGORY_SLUGS, normalizeCategories, type CategorySlug } from "./taxonomy.js";
 import { errorMessage } from "../../utils/errors.js";
 import { isRecord } from "../../utils/types.js";
+
+// Re-export so existing callers don't have to change imports.
+export { ClaudeCliNotFoundError };
 
 // Structured input passed to the classifier. Kept small (not the
 // full source content) so the prompt stays cheap — a couple of
@@ -61,16 +57,12 @@ export interface ClassifyResult {
 // `defaultClassify`.
 export type ClassifyFn = (input: ClassifyInput) => Promise<ClassifyResult>;
 
-// Max time we let `claude` run during registration. Registration
+// Max time the LLM call may run during registration. Registration
 // is a foreground user action, so anything longer than 2 min is
-// effectively broken anyway.
+// effectively broken anyway. Kept exported for back-compat with
+// callers that read it; the actual timeout per call now lives in
+// the backend's tuning module.
 export const DEFAULT_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
-
-// Budget cap. Classification is one small call per source (once
-// at registration, rarely re-classified) so $0.05 is fine — we
-// don't pay the first-call cache-creation cost on every source
-// because we warm it once and reuse.
-const MAX_BUDGET_USD = 0.05;
 
 const SYSTEM_PROMPT =
   "You classify an information source (RSS feed, GitHub repo, web site, etc.) into a fixed taxonomy. " +
@@ -140,8 +132,10 @@ interface ClaudeJsonResult {
 }
 
 // Pure: parse the claude `--output-format json` envelope and
-// validate against our result shape. Exported so tests cover the
-// envelope-handling + normalization paths without spawning CLI.
+// validate against our result shape. Retained as a test-callable
+// helper that documents the envelope shape; the production path
+// goes through `backend.generateStructured`, which extracts
+// `structured_output` itself.
 export function parseClassifyOutput(stdout: string): ClassifyResult {
   let parsed: ClaudeJsonResult;
   try {
@@ -182,82 +176,20 @@ export function validateClassifyResult(obj: unknown): ClassifyResult {
   return { categories, rationale };
 }
 
-// --- spawn layer --------------------------------------------------------
-
-function spawnClaudeClassify(userPrompt: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const args = [
-      "--print",
-      "--no-session-persistence",
-      "--output-format",
-      "json",
-      "--model",
-      "haiku",
-      "--max-budget-usd",
-      String(MAX_BUDGET_USD),
-      "--json-schema",
-      JSON.stringify(classifySchema()),
-      "--system-prompt",
-      SYSTEM_PROMPT,
-      "-p",
-      userPrompt,
-    ];
-    // Run from tmpdir so claude doesn't load the project's
-    // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", args, {
-      cwd: tmpdir(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      proc.kill("SIGKILL");
-      reject(new Error(`[sources/classifier] claude timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    proc.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    proc.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    proc.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-    proc.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code !== 0) {
-        // claude writes structured errors (incl.
-        // error_max_budget_usd) to STDOUT in JSON form — same
-        // lesson we learned in chat-index/summarizer. Prefer the
-        // structured message when we can parse it.
-        reject(new Error(formatSpawnFailure("[sources/classifier]", code, stdout, stderr)));
-        return;
-      }
-      resolve(stdout);
-    });
-  });
-}
-
-// Production ClassifyFn — spawns the real claude CLI.
+// Production ClassifyFn. The backend's tuning module owns model /
+// budget / isolation knobs; this layer composes prompt + schema +
+// validator and lets the adapter handle the spawn-and-envelope dance.
 export const defaultClassify: ClassifyFn = async (input) => {
   const userPrompt = buildClassifyPrompt(input);
-  const stdout = await spawnClaudeClassify(userPrompt, DEFAULT_TIMEOUT_MS);
-  return parseClassifyOutput(stdout);
+  const result = await getActiveBackend().generateStructured<unknown>(
+    {
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      profile: "source-classify",
+    },
+    classifySchema(),
+  );
+  return validateClassifyResult(result);
 };
 
 // Public entry. Thin wrapper so tests can inject a ClassifyFn

--- a/server/workspace/sources/pipeline/summarize.ts
+++ b/server/workspace/sources/pipeline/summarize.ts
@@ -1,38 +1,33 @@
 // Daily-summary generator.
 //
-// Takes the cross-source-deduped list of new items and asks
-// `claude` (haiku, budget-capped) to produce the human-readable
-// daily brief markdown. The pipeline then pairs that markdown
-// with a machine-readable JSON block (see write.ts) so the
-// dashboard can consume item metadata without parsing markdown.
+// Takes the cross-source-deduped list of new items and asks the
+// active LLM backend (haiku, budget-capped) to produce the
+// human-readable daily brief markdown. The pipeline then pairs
+// that markdown with a machine-readable JSON block (see write.ts)
+// so the dashboard can consume item metadata without parsing
+// markdown.
 //
-// Shape mirrors `chat-index/summarizer.ts` — same CLI flags, same
-// "errors on STDOUT not stderr" handling, same injectable
-// `SummarizeFn` so tests never invoke the real CLI.
+// `makeDefaultSummarize` composes prompt + backend call. Tests
+// inject their own SummarizeFn via the indexer's deps.
 
-import { spawn } from "node:child_process";
-import { tmpdir } from "node:os";
+import { getActiveBackend } from "../../../agent/backend/index.js";
 import { ClaudeCliNotFoundError } from "../../journal/archivist-cli.js";
-import { formatSpawnFailure } from "../../../utils/spawn.js";
 import { errorMessage } from "../../../utils/errors.js";
 import type { SourceItem } from "../types.js";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../../utils/time.js";
 
+// Re-export so existing callers / tests don't have to update imports.
+export { ClaudeCliNotFoundError };
+
 // A function that takes items and returns markdown. The
-// production implementation spawns claude; tests pass a
-// deterministic stub.
+// production implementation drives the active backend; tests pass
+// a deterministic stub.
 export type SummarizeFn = (items: readonly SourceItem[]) => Promise<string>;
 
-// Wall-clock cap per summarize call. 5 minutes is plenty for a
-// daily brief across a few dozen items; beyond that the call is
-// almost certainly wedged.
+// Wall-clock cap kept exported for back-compat with callers that
+// read it; the actual timeout per call now lives in the backend's
+// tuning module under the "source-summarize" profile.
 export const DEFAULT_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
-
-// Budget per summarize call. A daily brief is longer and more
-// expensive than a classify call, so the cap is higher than the
-// classifier's $0.05. $0.25 covers several hundred items
-// comfortably.
-const MAX_BUDGET_USD = 0.25;
 
 const SYSTEM_PROMPT =
   "You write a daily information brief from a JSON list of items. " +
@@ -44,7 +39,7 @@ const SYSTEM_PROMPT =
   "Do NOT emit a JSON block, table of contents, or anything outside the brief itself — the caller appends machine-readable data separately. " +
   "Output Markdown only — no code fences, no prose commentary.";
 
-// Shape passed to claude. Kept deliberately compact so the
+// Shape passed to the model. Kept deliberately compact so the
 // prompt stays within budget even for a busy day: no `content`
 // field (full body), just `summary` truncated to 200 chars.
 interface PromptItem {
@@ -58,7 +53,7 @@ interface PromptItem {
 }
 
 // Build the user-prompt JSON body. Exported so tests can verify
-// the exact shape the CLI sees, and so a future "generate a
+// the exact shape the model sees, and so a future "generate a
 // test brief without summarizing" workflow can use the same
 // input format.
 export function buildSummarizePromptBody(items: readonly SourceItem[], isoDate: string): string {
@@ -85,7 +80,10 @@ export function buildEmptyDayMarkdown(isoDate: string): string {
 }
 
 // Pure: parse the CLI envelope, surface structured errors,
-// return the markdown body.
+// return the markdown body. Retained as a test-callable helper
+// that documents the envelope shape; the production path goes
+// through `backend.generate` (text-envelope mode), which
+// extracts `result` itself.
 export function parseSummarizeOutput(stdout: string): string {
   let parsed: {
     is_error?: boolean;
@@ -108,82 +106,17 @@ export function parseSummarizeOutput(stdout: string): string {
   return result;
 }
 
-// --- spawn layer --------------------------------------------------------
-
-function spawnClaudeSummarize(userPrompt: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // `--output-format json` returns a result envelope containing
-    // the model's text response as `.result` — we don't use
-    // `--json-schema` here because the model produces free-form
-    // markdown. Same "errors on stdout" handling as the
-    // classifier / chat-index summarizer.
-    const args = [
-      "--print",
-      "--no-session-persistence",
-      "--output-format",
-      "json",
-      "--model",
-      "haiku",
-      "--max-budget-usd",
-      String(MAX_BUDGET_USD),
-      "--system-prompt",
-      SYSTEM_PROMPT,
-      "-p",
-      userPrompt,
-    ];
-    const proc = spawn("claude", args, {
-      cwd: tmpdir(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      proc.kill("SIGKILL");
-      reject(new Error(`[sources/summarize] claude timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    proc.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    proc.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    proc.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-    proc.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(formatSpawnFailure("[sources/summarize]", code, stdout, stderr)));
-        return;
-      }
-      resolve(stdout);
-    });
-  });
-}
-
 // Build the production SummarizeFn. `isoDate` is captured once
 // per pipeline run so every call in that run uses the same date
 // header (even if the run crosses midnight).
-export function makeDefaultSummarize(isoDate: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): SummarizeFn {
+export function makeDefaultSummarize(isoDate: string): SummarizeFn {
   return async (items) => {
     if (items.length === 0) return buildEmptyDayMarkdown(isoDate);
-    const prompt = buildSummarizePromptBody(items, isoDate);
-    const stdout = await spawnClaudeSummarize(prompt, timeoutMs);
-    return parseSummarizeOutput(stdout);
+    const userPrompt = buildSummarizePromptBody(items, isoDate);
+    return getActiveBackend().generate({
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      profile: "source-summarize",
+    });
   };
 }

--- a/test/sources/test_pipelineSummarize.ts
+++ b/test/sources/test_pipelineSummarize.ts
@@ -105,12 +105,14 @@ describe("parseSummarizeOutput", () => {
 });
 
 describe("makeDefaultSummarize — empty day short-circuit", () => {
-  it("returns the empty-day markdown without invoking claude for an empty list", async () => {
-    // Use makeDefaultSummarize — with no items it should never
-    // even attempt to spawn the CLI. The timeout is short just
-    // as a defensive backstop (if it ever DID try, the test
-    // would time out fast rather than hang).
-    const summarize = makeDefaultSummarize("2026-04-13", 500);
+  it("returns the empty-day markdown without invoking the LLM backend for an empty list", async () => {
+    // With no items, makeDefaultSummarize should short-circuit
+    // and never reach the backend at all — no spawn, no
+    // network. The assertions below only need to verify the
+    // empty-day markdown shape; if the short-circuit ever
+    // regressed, the call would fail fast (no `claude` on test
+    // PATH) rather than block the run.
+    const summarize = makeDefaultSummarize("2026-04-13");
     const out = await summarize([]);
     assert.match(out, /^# Daily brief — 2026-04-13/);
     assert.match(out, /No new items today/);


### PR DESCRIPTION
## Summary

PR #2 of three from [plans/refactor-llm-backend-abstraction.md](./plans/refactor-llm-backend-abstraction.md). Pure refactor — **no behavior change.**

Adds `generate` / `generateStructured` to the `LLMBackend` interface and migrates the four one-shot callers off direct `spawn("claude", ...)`:

- `server/workspace/journal/archivist-cli.ts` — journal day summarization
- `server/workspace/chat-index/summarizer.ts` — chat session title / summary / keywords
- `server/workspace/sources/classifier.ts` — source taxonomy classification
- `server/workspace/sources/pipeline/summarize.ts` — daily brief markdown

## Design — per-backend typed tuning module

The Claude-CLI-shaped knobs (`model`, `maxBudgetUsd`, `noSessionPersistence`, `isolatedFromProject`, ...) **don't** leak into the portable `GenerateInput`. Instead the portable surface carries only a profile name; each backend has its own tuning module mapping every profile name to its own knob vocabulary.

```typescript
// server/agent/backend/types.ts
export type ProfileName =
  | "journal-archivist"
  | "chat-index-summary"
  | "source-classify"
  | "source-summarize";

// server/agent/backend/claude-code.tuning.ts
export const claudeCodeTuning = {
  "journal-archivist":   { outputFormat: "text-stdin",    timeoutMs: 5 * ONE_MINUTE_MS },
  "source-summarize":    { outputFormat: "text-envelope", model: "haiku", maxBudgetUsd: 0.25, ... },
  "chat-index-summary":  { outputFormat: "json-schema",   model: "haiku", maxBudgetUsd: 0.15, ... },
  "source-classify":     { outputFormat: "json-schema",   model: "haiku", maxBudgetUsd: 0.05, ... },
} as const satisfies Record<ProfileName, ClaudeCodeProfile>;
```

The `as const satisfies Record<ProfileName, ClaudeCodeProfile>` line is load-bearing: drift between the portable profile union and any backend's tuning entries becomes a compile error. A future `openai.tuning.ts` would have the same `satisfies` line against a completely different `OpenAIProfile` shape.

## Adapter

Three private spawn helpers in `server/agent/backend/claude-code.ts` — `spawnTextStdin`, `spawnTextEnvelope`, `spawnJsonSchema` — match the three CLI invocation shapes today's callers use. A shared envelope parser handles `{is_error, structured_output, result, errors, subtype}`. ENOENT throws `LLMBackendUnavailableError`; structured budget/auth errors come through `formatSpawnFailure`.

## Caller migration is back-compat-safe

- Public DI hooks (`Summarize`, `SummarizeFn`, `ClassifyFn`) keep their signatures, so every test that injects a fake keeps working.
- `ClaudeCliNotFoundError` is re-exported as an alias of `LLMBackendUnavailableError` (same class, two names), so the ~10 `instanceof ClaudeCliNotFoundError` catch sites need no changes.
- Pure helpers (`extractText`, `validateSummaryResult`, `parseClassifyOutput`, `parseSummarizeOutput`, `formatSpawnError`) stay where they are as test-callable utilities documenting the envelope shape; production goes through the adapter.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (5 pre-existing v-html warnings unrelated)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 3,371 tests, 0 failures
- [ ] Manual: trigger a journal pass, chat-index summarize, source register-with-classify, and daily brief; verify each still produces the same output as before

## What's NOT in this PR

- A real second backend (PR #3 — the only thing that actually validates the interface).
- Renaming `claudeSessionId` → `llmSessionToken` (touches `@mulmobridge/protocol` wire format) — separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added structured output generation for schema-validated results in summarization, classification, and analysis tasks.

* **Improvements**
  * Unified LLM backend abstraction for consistent error handling and enhanced system flexibility across all operations.
  * Enhanced error reporting for unavailable or unsupported backend scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->