### PR TITLE
docs: ASCII UI cheatsheet anchored to data-testid / component names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ Top-bar and panel-header controls share one sizing language. Use these exact cla
 
 Do NOT introduce new heights (`h-7`, `h-9`, `py-1.5`, etc.) or new gap values for chrome controls. The logo in `SidebarHeader` is the one sanctioned exception — it escapes row padding via negative margins (`-my-3.5`) because it's a brand mark, not a control.
 
+### UI references — anchor to testids and components
+
+Big-picture ASCII layouts of the major surfaces (top chrome, NotificationBell, /chat, /calendar, /automations, /wiki, /sources, /todos, /files) live at [`docs/ui-cheatsheet.md`](docs/ui-cheatsheet.md). Use it for:
+
+- **Naming a UI region in chat / PR / issue text**: prefer `[notification-badge]` / `<CalendarView>` / `(:wiki)` over "the bell" / "the calendar widget" / "the wiki page" — names are greppable, prose is not.
+- **Onboarding context**: when proposing UI changes, point at the matching block to disambiguate which component / route is in scope.
+
+When you rename a `data-testid`, restructure a layout, or add a new top-level surface, **update the matching ASCII block in `docs/ui-cheatsheet.md` in the same PR** — same discipline as updating tests when changing API. Out-of-date layout art is worse than no art; if you can't update it cleanly, delete the stale block instead of leaving it.
+
 ### i18n — all 8 locales in lockstep
 
 Supported UI locales live under `src/lang/`: `en.ts`, `ja.ts`, `zh.ts`, `ko.ts`, `es.ts`, `pt-BR.ts`, `fr.ts`, `de.ts`. `src/lang/en.ts` is the schema source of truth; `typeof enMessages` is threaded through `createI18n` in `src/lib/vue-i18n.ts`, so `vue-tsc` treats every missing or extra key as a type error.

--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -1,0 +1,311 @@
+# UI Cheatsheet — ASCII layouts anchored to component / testid names
+
+A quick visual reference so chat instructions about UI ("the bell at the top right has stale state") can be unambiguous without screenshots. Names in `[brackets]` are real `data-testid` values from the source — so you can `grep -rn 'data-testid="<name>"' src/` to jump to the rendering site, and `gh pr review` comments can reference them in plain text.
+
+## Conventions
+
+- `[name]` — a real `data-testid` you can grep for.
+- `<Component>` — a Vue component name (also greppable: `grep -rn 'name: "Component"' src/` or import sites).
+- `(:route)` — the URL route the surface lives under.
+- ASCII art captures **layout intent**, not pixels. Animation, hover state, exact spacing, and CSS regressions are out of scope — use a screenshot for those.
+- This file goes **out of date as the UI evolves**. When you change a layout or rename a testid, update the matching block here in the same PR. Treat it like CHANGELOG entries — small, mechanical updates per PR keep the doc honest.
+
+## Top-level chrome (every route)
+
+```
+┌─[App.vue root]────────────────────────────────────────────────────────┐
+│ ┌─[#header]────────────────────────────────────────────────────────┐  │
+│ │  ⌂[Go to latest chat / brand]  🔓lock_open  🔔[notification-bell]│  │
+│ │                                              ⚙ settings          │  │
+│ └──────────────────────────────────────────────────────────────────┘  │
+│ ┌─<PluginLauncher> [plugin-launcher]──────────────────────────────┐   │
+│ │ ✓Todos │📅Calendar │⏰Actions │📖Wiki │📡Sources │🧠Skills │🎭Roles│📁Files│   │
+│ │ [plugin-launcher-todos] [plugin-launcher-calendar] ...          │   │
+│ └─────────────────────────────────────────────────────────────────┘   │
+│ ┌─[main pane — route-specific]────┐ ┌─<SessionHistoryPanel>────────┐  │
+│ │                                 │ │ [session-history-side-panel] │  │
+│ │  (the active /route's content)  │ │ ┌─[session-filter-bar]─────┐ │  │
+│ │                                 │ │ │ All │Unread│Running│...   │ │  │
+│ │                                 │ │ │ [session-filter-<key>]    │ │  │
+│ │                                 │ │ └──────────────────────────┘ │  │
+│ │                                 │ │ • [session-item-<uuid>]      │  │
+│ │                                 │ │ • [session-item-<uuid>]      │  │
+│ └─────────────────────────────────┘ └──────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+Sidebar visibility toggles via the canvas-layout state. When closed, the main pane is full-width.
+
+## NotificationBell expanded
+
+```
+🔔[notification-bell]──┐
+   🔴[notification-badge: "N"] (red dot, only when unread > 0)
+   │  ┌─[notification-panel] (opens on click)──────────────────┐
+   │  │ Notifications              [notification-mark-all-read]│
+   │  ├─────────────────────────────────────────────────────────┤
+   │  │ 🔵 Title (bold)                                       ✕ │  ← unread
+   │  │ ◯  body line                                            │  data-unread="true"
+   │  │ ◯  N min ago                                            │
+   │  ├─────────────────────────────────────────────────────────┤
+   │  │ ⚪ Title (regular)                                    ✕ │  ← read
+   │  │     body line                                            │  data-unread="false"
+   │  └─────────────────────────────────────────────────────────┘
+   └─ each row: [notification-item-<id>]; click → router.push(target)
+```
+
+Click on a row → `useNotifications.markRead(id)` → badge decrements. The 🔵/⚪ leading dot disappears once read; bold title fades to gray.
+
+## /chat — the chat page
+
+```
+┌─[main pane (chat)] ────────────────────────────────────────────────────┐
+│ ┌─[chat column — left, single layout]──┐ ┌─[canvas column — right]──┐  │
+│ │                                       │ │                          │  │
+│ │  scrollback transcript (text-results, │ │ Selected tool result UI: │  │
+│ │  tool-call cards, agent responses)    │ │  • <CalendarView>        │  │
+│ │                                       │ │  • <MarkdownView>        │  │
+│ │  • text-response (user) ──────────╮   │ │  • <SpreadsheetView>     │  │
+│ │  • text-response (assistant) ─────╯   │ │  • <ChartView>           │  │
+│ │  • tool-call card                     │ │  • ...                   │  │
+│ │    ↳ <Preview> (compact summary)      │ │                          │  │
+│ │      click → selectedResultUuid       │ │ "Edit / Apply / PDF"     │  │
+│ │                                       │ │ buttons may appear at    │  │
+│ │                                       │ │ the top of certain views │  │
+│ │  ┌─<ChatInput> [chat-input/wrapper]─┐ │ │                          │  │
+│ │  │ [user-input]                  …  │ │ │                          │  │
+│ │  │ [send-btn] [stop-btn]            │ │ │                          │  │
+│ │  │ [attach-file-btn]                │ │ │                          │  │
+│ │  │ [expand-input-btn] (modal:       │ │ │                          │  │
+│ │  │   [expanded-input]               │ │ │                          │  │
+│ │  │   [expanded-send-btn])           │ │ │                          │  │
+│ │  └──────────────────────────────────┘ │ │                          │  │
+│ └───────────────────────────────────────┘ └──────────────────────────┘  │
+│                                                                         │
+│ Stack-layout collapses both columns into one (responsive / user-pref).  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The right canvas binds to `currentSession.selectedResultUuid`. Clicking a tool-call card on the left sets the uuid; the right pane re-renders via plugin lookup (`getPlugin(toolName).viewComponent`).
+
+## /calendar — calendar of dated items
+
+```
+┌─[<CalendarView> mounts <SchedulerView force-tab="calendar">]──────────┐
+│                                                                       │
+│  ┌─Header───────────────────────────────────────────────────────────┐ │
+│  │  📅 Calendar  N items     ◀ Today ▶   month ▼   week  list      │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│                                                                       │
+│  ┌─Grid (month/week) or List───────────────────────────────────────┐ │
+│  │  Mo  Tu  We  Th  Fr  Sa  Su                                     │ │
+│  │  …                                                              │ │
+│  │  [scheduler-item-<id>]   "Team meeting" · 10:00                  │ │
+│  │                          (drag to move; click → edit form)      │ │
+│  │  ...                                                             │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│                                                                       │
+│  Edit form (when an item is selected):                                │
+│  ┌───────────────────────────────────────────────────────────────┐   │
+│  │  YAML editor: title + props.{date,time,location,notes,...}    │   │
+│  │  [Apply Changes] [Cancel]                                     │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+In chat, when the agent calls `manageCalendar`, the same `<CalendarView>` mounts inside the right canvas with `selectedResult` populated.
+
+## /automations — scheduled tasks
+
+```
+┌─[<AutomationsView> mounts <SchedulerView force-tab="tasks">]──────────┐
+│                                                                       │
+│  ┌─<TasksTab>──────────────────────────────────────────────────────┐ │
+│  │  ▾ Recommended frequencies (collapsed)  [scheduler-frequency-   │ │
+│  │                                          hints]                 │ │
+│  │                                                                 │ │
+│  │  ┌─Task row [scheduler-task-<id>]──────────────────────────┐    │ │
+│  │  │  user│Finance daily briefing            ▶  ⋯  ✕         │    │ │
+│  │  │      every morning at 06:00 local  · next: tomorrow     │    │ │
+│  │  │      [scheduler-task-run]                               │    │ │
+│  │  │      [scheduler-task-delete]                            │    │ │
+│  │  └─────────────────────────────────────────────────────────┘    │ │
+│  │  ┌─Task row [scheduler-task-<id>]──────────────────────────┐    │ │
+│  │  │  system│Wiki maintenance                ⋯               │    │ │
+│  │  └─────────────────────────────────────────────────────────┘    │ │
+│  │  ...                                                            │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+Origin badges: `system` (bg-gray) / `user` (bg-blue) / `skill` (bg-purple). Disabled tasks render at `opacity-50`.
+
+## /wiki — wiki pages and lint report
+
+Two layouts share `<WikiView>`: the **index** (page list) and a **single page** body.
+
+### Index
+
+```
+┌─[<WikiView> action="index"]────────────────────────────────────┐
+│ Tags filter: [wiki-tag-filter-all] [wiki-tag-filter-<tag>] ... │
+│                                                                │
+│ ┌─Entry list─────────────────────────────────────────────────┐ │
+│ │ • [wiki-page-entry-<slug>]                                 │ │
+│ │   Title  — short description  #tag #tag                    │ │
+│ │   click → /wiki/pages/<slug>                               │ │
+│ │ • [wiki-page-entry-<slug>]                                 │ │
+│ │   ...                                                      │ │
+│ └────────────────────────────────────────────────────────────┘ │
+│                                                                │
+│ [wiki-create-page-button]   [wiki-update-page-button]          │
+│ [wiki-lint-chat-button] (asks the agent to run lint_report)    │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Single page
+
+```
+┌─[<WikiView> action="page" pageName="<slug>"]──────────────────┐
+│ ▮ <slug>                            [wiki-update-page-button] │
+│ ┌─Markdown content (.wiki-content, scrollable)──────────────┐ │
+│ │ # Title                                                   │ │
+│ │ markdown body...                                          │ │
+│ │ ![image](relative/path)  ← rewritten to /api/files/raw    │ │
+│ │ [[wiki-link]]            ← rewritten to /wiki/pages/<slug>│ │
+│ └───────────────────────────────────────────────────────────┘ │
+│ Per-page chat composer:                                       │
+│   [wiki-page-chat-input]  [wiki-page-chat-send]               │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## /sources — registered news/RSS feeds
+
+```
+┌─[<SourcesManager>]─────────────────────────────────────────────────┐
+│ Top bar: [sources-add-btn] [sources-rebuild-btn]                   │
+│                                                                    │
+│ Add form (when adding) [sources-add-form]:                         │
+│ ┌────────────────────────────────────────────────────────────────┐ │
+│ │ kind ▼  [sources-draft-kind]                                   │ │
+│ │ url    [sources-draft-primary]                                 │ │
+│ │ title  [sources-draft-title]                                   │ │
+│ │ [sources-draft-cancel]   [sources-draft-add]                   │ │
+│ │ error  [sources-draft-error]                                   │ │
+│ └────────────────────────────────────────────────────────────────┘ │
+│                                                                    │
+│ Filter chips: [sources-filter-chip-<key>] [sources-filter-clear]   │
+│                                                                    │
+│ ┌─Source row [source-row-<slug>]─────────────────────────────────┐ │
+│ │  RSS │ Federal Reserve  · federal-reserve                      │ │
+│ │       https://www.federalreserve.gov/feeds/press_all.xml       │ │
+│ │       #central-bank                              [source-      │ │
+│ │                                                  remove-<slug>]│ │
+│ └────────────────────────────────────────────────────────────────┘ │
+│ ...                                                                │
+│                                                                    │
+│ Empty state: [sources-empty] (if no feeds yet) → preset buttons    │
+│   [sources-preset-<id>]                                            │
+│                                                                    │
+│ Last rebuild summary at the bottom: [sources-rebuild-summary]      │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## /todos — Kanban / table / list of tasks
+
+```
+┌─[<TodoExplorer>]───────────────────────────────────────────────────┐
+│ Top bar:                                                           │
+│  [todo-search]   [todo-add-btn]   [todo-column-add-btn]            │
+│  view mode: [todo-view-kanban] [todo-view-table] [todo-view-list]  │
+│                                                                    │
+│ Kanban (default):                                                  │
+│ ┌─Backlog─────┐ ┌─Todo──────┐ ┌─In Progress─┐ ┌─Done────────┐      │
+│ │             │ │           │ │             │ │             │      │
+│ │ [todo-card- │ │           │ │             │ │             │      │
+│ │  <id>]      │ │           │ │             │ │             │      │
+│ │   Title     │ │           │ │             │ │             │      │
+│ │   #label    │ │           │ │             │ │             │      │
+│ │             │ │           │ │             │ │             │      │
+│ └─────────────┘ └───────────┘ └─────────────┘ └─────────────┘      │
+│                                                                    │
+│ Drag cards across columns to change state.                         │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## /files — workspace file explorer
+
+```
+┌─[<FilesView>]──────────────────────────────────────────────────────────┐
+│ ┌─Tree pane──────────┐ ┌─Preview pane (route param: pathMatch)───────┐ │
+│ │ ▶ artifacts/       │ │                                             │ │
+│ │ ▼ config/          │ │  Selected file: data/sources/foo.md         │ │
+│ │   • interests.json │ │                                             │ │
+│ │   • mcp.json       │ │  ┌─Preview rendered by FileContentRenderer┐ │ │
+│ │   • settings.json  │ │  │                                        │ │ │
+│ │ ▶ conversations/   │ │  │  • markdown → marked + Vue             │ │ │
+│ │ ▶ data/            │ │  │  • images → <img>                      │ │ │
+│ │ ▼ data/sources/    │ │  │  • todos JSON → <TodoExplorer>         │ │ │
+│ │   • foo.md   ←sel  │ │  │  • scheduler items.json → <CalendarView>│ │ │
+│ │   • bar.md         │ │  │  • code → text                         │ │ │
+│ │ ...                │ │  │                                        │ │ │
+│ └────────────────────┘ │  └────────────────────────────────────────┘ │ │
+│                        └─────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+The preview pane reuses plugin views — clicking a `config/scheduler/items.json` mounts `<CalendarView>` via `toSchedulerResult` (issue #832 / #833 will add a description banner + Edit button on top of this).
+
+## /skills — workspace skills list
+
+```
+┌─[<SkillsManager>]──────────────────────────────────────────────────┐
+│ Add skill form (modal)                                             │
+│                                                                    │
+│ ┌─Skill row──────────────────────────────────────────────────────┐ │
+│ │  📜 daily-briefing-finance                                     │ │
+│ │      "Fetch top 3 articles, cluster, write briefing"           │ │
+│ │                                              ⏵ run  ✏ edit  ✕ │ │
+│ └────────────────────────────────────────────────────────────────┘ │
+│ ...                                                                │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## /roles — role configuration
+
+```
+┌─[<RolesManager>]───────────────────────────────────────────────────┐
+│ ┌─Built-in roles (read-only)─────────────────────────────────────┐ │
+│ │ ⭐ General              "Helpful assistant w/ workspace access" │ │
+│ │ 🎨 Artist                ...                                   │ │
+│ │ 🎓 Tutor                 ...                                   │ │
+│ └────────────────────────────────────────────────────────────────┘ │
+│ ┌─Custom roles────────────────────────────────────────────────── ┐ │
+│ │  + add role                                                    │ │
+│ │  📖 my-role     ✏ edit   ✕                                     │ │
+│ └────────────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## How to use this doc in chat
+
+When asking Claude (or a teammate) to change the UI, name what you mean:
+
+> ❌ "Make the bell smaller"
+> ✅ "Reduce the badge size on `[notification-badge]` — it's overflowing the bell button on narrow screens"
+
+> ❌ "The schedule page is broken"
+> ✅ "On `/automations`, `[scheduler-task-<id>]` rows render at full opacity even when `task.enabled === false` — the `opacity-50` class isn't applying"
+
+> ❌ "Add a button to the wiki page header"
+> ✅ "Next to `[wiki-update-page-button]` in `<WikiView>` action='page', add a `[wiki-export-pdf-button]` that calls `usePdfDownload`"
+
+If a name in this doc no longer matches the source (renamed testid, restructured layout), **update the doc in the same PR as the rename** — same discipline as updating tests when changing API.
+
+## Out of scope
+
+- **Pixel-accurate layout** — use Playwright screenshots or a Figma file.
+- **Hover / focus / animation states** — describe in code comments next to the styles.
+- **Mobile / narrow-screen breakpoints** — captured in `tailwind.config.ts` + the responsive class soup; not redrawn here.
+- **Modal / popover stacking order** — surface in the relevant component's `<!-- -->` doc comment, not here.
+- **Plugin-internal sub-views** that don't have their own route — TodoEditDialog, MindMap, Quiz, Form, etc. Add stubs as the cheat sheet matures.


### PR DESCRIPTION
## Summary

A flat-text reference for talking about the UI without screenshots. Each major surface gets an ASCII layout labelled with real \`data-testid\` values and Vue component names so chat / review / commit conversations can be precise:

> ❌ \"the bell is broken\"
> ✅ \"\`[notification-badge]\` is overflowing on narrow screens\"

Greppable. Unambiguous. Survives copy-paste through any text channel.

\`CLAUDE.md\` now points at it from the chrome-sizing block, with the same-PR update rule (rename a testid → update the matching ASCII block — same discipline as i18n lockstep).

## Items to Confirm / Review

- [ ] **Coverage cut**: top chrome, NotificationBell, /chat, /calendar, /automations, /wiki (index + page), /sources, /todos, /files, /skills, /roles. Plugin-internal sub-views (TodoEditDialog, MindMap, Quiz, Form, …) deferred — see the "Out of scope" section.
- [ ] **Naming convention**: \`[name]\` for testids, \`<Component>\` for Vue components, \`(:route)\` for URLs. Easy to swap to backticks-everywhere if you'd prefer.
- [ ] **Some testids in the cheatsheet are speculative** (e.g. \`[scheduler-task-run]\` / \`[scheduler-task-delete]\`). I grepped where I could but a few rows are derived from common patterns and may need a small correction once you eyeball the running app.
- [ ] **/calendar drag-and-drop, modal flows** are described prose-side rather than ASCII'd — scope cut. Add later if a particular interaction keeps coming up in chat.

## User Prompt

> claude codeに指示するときにUIの部分って指示が難しいよね。アスキーアートでmdにして、UIコンポーネント名をかいて共有しない？
> ↓
> これですすめて。細かい部分はダメでも大枠話がしやすくなると良いよ。docs以下においてつくって！
> ↓
> claude.mdからも参照するようにしておくと良い？

## Test plan

Pure docs change, no code modified.

- [x] File renders cleanly in GitHub markdown preview.
- [x] CLAUDE.md links to it from the UI controls block + spells out the same-PR update rule.
- [ ] Eyeball each ASCII block against \`yarn dev\` and tweak any drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)