### PR TITLE
fix: route Skills Run button through startNewChat

### DIFF
--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -196,8 +196,10 @@ test.describe("manageSkills plugin", () => {
     await expect(page.getByTestId("skill-body-rendered")).toContainText("CI Enable");
     await page.getByTestId("skill-run-btn").click();
 
-    // Run button routes through App.vue's sendMessage via the
-    // useAppApi() provide/inject contract (#227). The slash command
+    // Run button routes through App.vue's startNewChat via the
+    // useAppApi() provide/inject contract (#227) — startNewChat (not
+    // sendMessage) so the user is routed to /chat to see the response,
+    // since Skills view is only rendered on /skills. The slash command
     // form (`/<name>`) is what Claude CLI resolves against
     // ~/.claude/skills/ natively, so we don't need to ship the body.
     await expect.poll(() => agentPosts.length, { timeout: 5 * ONE_SECOND_MS }).toBeGreaterThan(0);

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -289,12 +289,13 @@ async function saveEdit(): Promise<void> {
 // Run = send the skill invocation as a Claude Code slash command.
 // Claude CLI already knows about every ~/.claude/skills/<name>/SKILL.md
 // at spawn, so sending `/<name>` is enough — no need to ship the body.
-// Routes through App.vue's sendMessage via provide/inject (#227).
+// Uses startNewChat (not sendMessage) so the user is routed to /chat
+// to see the response — Skills view is only rendered on /skills.
 const appApi = useAppApi();
 
 function runSkill(): void {
   if (!selectedName.value) return;
-  appApi.sendMessage(`/${selectedName.value}`);
+  appApi.startNewChat(`/${selectedName.value}`);
 }
 
 // Delete is project-scope only — see saveProjectSkill / deleteProjectSkill


### PR DESCRIPTION
## Summary
- The Run button in `SkillsView` called `appApi.sendMessage()`, which only delivers a message into `currentSessionId` without navigating. Since the view is only rendered on `/skills` (`App.vue:174`), the user never saw the response — and on a fresh `/skills` load with no session, `sendMessage` returned early at `App.vue:864` (`if (!session) return`).
- Switched to `appApi.startNewChat()`, matching the pattern used by `wiki/View.vue:361` and `PageChatComposer.vue:57`: creates a new session and routes the user to `/chat` so they actually see the slash command run.

## Test plan
- [ ] On `/skills`, select a skill and click **Run** → app navigates to `/chat` with a fresh session, slash command (`/<name>`) appears as the first message and the agent response streams in.
- [ ] Existing e2e: `e2e/tests/skills.spec.ts` "Run button sends the skill invocation as a slash command" still passes (asserts only on `agentPosts[0]?.message`, which is unchanged).
- [ ] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected skill execution to route users to the chat page for viewing results.

* **Tests**
  * Updated skill execution tests to reflect the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->