### PR TITLE
fix: resolve wiki page image refs under data/wiki layout

### DIFF
--- a/plans/fix-wiki-image-basepath.md
+++ b/plans/fix-wiki-image-basepath.md
@@ -1,0 +1,64 @@
+# Wiki ページの画像参照が 404 になる問題の修正
+
+## 概要
+
+Wiki ページの Markdown 内で workspace 相対の画像参照（例: `![](../sources/foo/bar.png)`）が表示されない。`/api/files/raw` への解決パスが古いレイアウト（`wiki/...`）のままになっており、現行レイアウト（`data/wiki/...`）にファイルが存在するため 404 になる。
+
+## 再現
+
+- ページ: `data/wiki/pages/<slug>.md`
+- 参照: `![](../sources/<slug>/slides/foo.png)`
+- 実ファイル: `~/mulmoclaude/data/wiki/sources/<slug>/slides/foo.png` ✅
+- ブラウザがリクエストする URL: `/api/files/raw?path=wiki/sources/<slug>/slides/foo.png` → **404**
+
+## 原因
+
+[src/plugins/wiki/View.vue:402](../src/plugins/wiki/View.vue#L402) の `basePath` が issue #284（workspace レイアウト変更: `wiki/` → `data/wiki/`）の更新から漏れていた。
+
+```ts
+// 現状（バグ）
+const basePath = action.value === "page" ? "wiki/pages" : "wiki";
+```
+
+同ファイルの [L517](../src/plugins/wiki/View.vue#L517) には正しいプレフィックスを持つ `WIKI_BASE_DIR` がすでに存在する:
+
+```ts
+const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
+```
+
+`rewriteMarkdownImageRefs` の `basePath` 引数は `resolveWorkspacePath` で URL の `..` / `./` を解決する基準ディレクトリとして使われ、その結果が `/api/files/raw?path=...` の `path` パラメータになる（[src/utils/image/rewriteMarkdownImageRefs.ts](../src/utils/image/rewriteMarkdownImageRefs.ts)、[src/utils/image/resolve.ts](../src/utils/image/resolve.ts)）。`basePath` が `wiki/pages` だと `..` 解決後に `wiki/sources/...` が出力され、現行レイアウトに対しては必ず 404。
+
+## 修正方針
+
+`renderedContent` で使う `basePath` を `WIKI_BASE_DIR` と同じ値に揃える。L402 と L517 を同じ computed から派生させ、再発を防ぐ。
+
+### 変更内容
+
+[src/plugins/wiki/View.vue](../src/plugins/wiki/View.vue):
+
+1. `WIKI_BASE_DIR` を `renderedContent` より前の位置に移動（または定義順を整える）
+2. L402 を `const basePath = WIKI_BASE_DIR.value;` に置き換える
+3. 古いコメント（"basePath = wiki/pages for individual pages"）を新しい値に合わせて更新
+
+## テスト
+
+### 手動確認
+
+1. `~/mulmoclaude/data/wiki/pages/<slug>.md` に `![](../sources/foo/bar.png)` を含むページを開く
+2. 画像が表示されることを確認
+3. DevTools の Network タブで `/api/files/raw?path=data/wiki/sources/foo/bar.png` が 200 で返ることを確認
+4. インデックスビュー（`action !== "page"`）で `![](sources/foo/bar.png)` のような相対参照も解決されることを確認
+
+### 自動テスト
+
+`rewriteMarkdownImageRefs` 自体は単体テスト済みのため、`basePath` の値を渡しているだけの View.vue 側はリグレッションを起こしにくい。E2E で wiki ページの画像が `200` を返すことを確認するテストの追加は任意（既存のスナップショット系テストで十分か検討）。
+
+## 影響範囲
+
+- 修正は `src/plugins/wiki/View.vue` の 1 行のみ
+- 同ファイル内の他の参照（`WIKI_BASE_DIR`、`Create a wiki page about ... data/wiki/pages/` などの prompt 文字列）はすでに正しい
+- サーバー側のルート / 他プラグイン（`markdown/View.vue`、`FilesView.vue`）は今回の修正とは独立
+
+## 備考
+
+- 過去の似た移行漏れに [`plans/fix-legacy-path-migration-773.md`](fix-legacy-path-migration-773.md) があり、issue #284 由来のレガシーパス整理が継続的に発生している。今回も同系統。

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -365,6 +365,9 @@ watch(content, async () => {
   if (scrollRef.value) scrollRef.value.scrollTop = 0;
 });
 
+/** Base directory for wiki content, adjusted by the current view. */
+const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
+
 const renderedContent = computed(() => {
   if (!content.value) return "";
   // Strip YAML frontmatter before rendering — marked doesn't parse
@@ -375,10 +378,9 @@ const renderedContent = computed(() => {
   // Rewrite workspace-relative image refs (`![alt](images/foo.png)`)
   // to `/api/files/raw?path=...` BEFORE marked parses them — without
   // this, the browser tries to fetch against the SPA route URL
-  // (/chat/…/images/foo.png) and 404s. basePath = wiki/pages for
-  // individual pages so `../images/foo.png` resolves correctly.
-  const basePath = action.value === "page" ? "wiki/pages" : "wiki";
-  const withImages = rewriteMarkdownImageRefs(body, basePath);
+  // (/chat/…/images/foo.png) and 404s. Reuse WIKI_BASE_DIR so a
+  // page's `../images/foo.png` resolves under `data/wiki/`.
+  const withImages = rewriteMarkdownImageRefs(body, WIKI_BASE_DIR.value);
   // Strip marked's `disabled=""` from GFM task checkboxes and tag
   // them with `class="md-task"` so `handleContentClick` can find
   // them via DOM delegation (#775). Other view modes (index / log /
@@ -477,9 +479,6 @@ function currentSlug(): string | null {
       : (props.selectedResult?.data?.pageName ?? null);
   return isSafeWikiSlug(raw) ? raw : null;
 }
-
-/** Base directory for wiki content, adjusted by the current view. */
-const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
 
 // Serialised POST chain for rapid task-checkbox clicks (#775). Each
 // click queues onto the previous so a slower network can't reorder


### PR DESCRIPTION
## Summary

Wiki ページの Markdown 内に書かれた workspace 相対の画像参照（例 `![](../sources/foo/bar.png)`）が常に 404 になっていたバグを修正します。原因は issue #284 で workspace レイアウトが `wiki/` → `data/wiki/` に移行した際、`src/plugins/wiki/View.vue` の `renderedContent` 内で使われている `basePath` の更新が漏れていたことです。

同ファイルにはすでに新レイアウトに合わせた `WIKI_BASE_DIR` computed が存在していたため、これを再利用する形で 1 箇所のみの修正に留めました。再発防止のため `WIKI_BASE_DIR` を `renderedContent` の前に移動して、画像参照の書き換えと wiki リンク解決の両方が同じソースから prefix を取るようにしています。

## Items to Confirm / Review

- [ ] `WIKI_BASE_DIR` の定義位置を移動した結果、`renderedContent` のリアクティビティに想定外の影響が無いか（`computed` 同士なので問題ないと判断していますが念のため）
- [ ] `action.value === "page"` 以外のビュー（index / log / lint_report 等）でも `data/wiki` ベースで画像が解決されることは妥当か（旧コードでも `wiki` ベースで揃えていたので等価な置換です）
- [ ] 自動テストは追加していません。`rewriteMarkdownImageRefs` 自体は単体テスト済みで、View.vue 側は引数を渡しているだけの薄い箇所です。E2E まで追加する必要があれば指摘してください
- [ ] `plans/fix-wiki-image-basepath.md` を同 PR に含めています（プロジェクト規約に従ったプランの永続化）

## User Prompt

> `plans/fix-wiki-image-basepath.md` これを実装して

（プランファイル本文の意図を要約: Wiki ページ画像参照が 404 になる問題を、`src/plugins/wiki/View.vue` の `basePath` を新レイアウト `data/wiki/...` に揃える方針で修正する。既存の `WIKI_BASE_DIR` computed を再利用して 1 箇所に集約する。）

## 原因

`src/plugins/wiki/View.vue` の `renderedContent` (修正前 L380) は次のように古いレイアウトを参照していました:

```ts
const basePath = action.value === "page" ? "wiki/pages" : "wiki";
```

一方、同ファイル下部 (修正前 L482) には既に正しい computed が存在していました:

```ts
const WIKI_BASE_DIR = computed(() => (action.value === "page" ? "data/wiki/pages" : "data/wiki"));
```

`basePath` は `rewriteMarkdownImageRefs` → `resolveWorkspacePath` で `..` / `./` を解決する起点になり、その結果が `/api/files/raw?path=...` の `path` パラメータに乗るため、起点が `wiki/pages` のままだと現行レイアウト (`data/wiki/...`) のファイルには絶対に当たらず 404 になります。

## 変更内容

`src/plugins/wiki/View.vue` のみ:

1. `WIKI_BASE_DIR` の `computed` を `renderedContent` の直前に移動
2. `renderedContent` 内の `basePath` 変数を削除し、`rewriteMarkdownImageRefs(body, WIKI_BASE_DIR.value)` で直接利用
3. 古いコメント（"basePath = wiki/pages for individual pages"）を新しい挙動に合わせて更新

サーバー側のルートや他プラグイン (`markdown/View.vue`、`FilesView.vue`) は影響なし。

## 検証

- `yarn format` ✅
- `yarn lint` ✅（pre-existing な v-html warning のみ、本変更由来のエラーは 0）
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅（unit tests all green）

### 手動

1. `~/mulmoclaude/data/wiki/pages/<slug>.md` に `![](../sources/foo/bar.png)` を含むページを開く
2. 画像が表示されること
3. DevTools の Network で `/api/files/raw?path=data/wiki/sources/foo/bar.png` が **200** で返ること

## 参考

- 過去の同系統の移行漏れ: `plans/fix-legacy-path-migration-773.md`
- 関連 issue: #284 (workspace レイアウト変更)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wiki page markdown images failing to load with 404 errors. Image path resolution now correctly points to wiki content directories, enabling relative image references to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->