### PR TITLE
chore: ignore local-only dirs (.claude/worktrees, .vite, .vscode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ server/system/logs/
 server/logs/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
+.vite/
+.vscode/
 playwright-report/
 test-results/
 .playwright-mcp/


### PR DESCRIPTION
## Summary

ローカル環境でのみ生成・利用されるディレクトリを `.gitignore` に追加し、誤って commit されることを防ぎます。

- `.claude/worktrees/` — Claude Code の `EnterWorktree` が作る一時 worktree
- `.vite/` — Vite の依存関係キャッシュ
- `.vscode/` — 個人利用のエディタ設定（チーム共有しない方針）

## Items to Confirm / Review
- `.vite/` / `.claude/worktrees/` は完全にローカル生成物なので ignore で問題ないはず

## User Prompt

> `.claude/worktrees/` は ignore して良いか？
> `.vite/` と `.vscode/` も同様に ignore で良いか？（`.vscode/` は個人で使うので OK）

## Changes

`.gitignore` に以下 3 行を追加:

```
.claude/worktrees/
.vite/
.vscode/
```

## Summary by Sourcery

Chores:
- Add .claude/worktrees/, .vite/, and .vscode/ to .gitignore as local-only directories.