### PR TITLE
feat(bridge): expose registered skills via slash commands and /help

### DIFF
--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -49,8 +49,16 @@ export function createCommandHandler(opts: {
     messages: Array<{ source: string; text: string }>;
     total: number;
   }>;
+  /** Predicate the bridge command handler uses to decide whether an
+   *  unknown slash command (e.g. `/release-app`) names a registered
+   *  skill — when true the text is forwarded to the agent so the
+   *  Claude CLI's slash-command resolver can run the skill. When
+   *  omitted (or it returns false) the command is rejected with the
+   *  standard "Unknown command" reply, so an unknown bridge slash
+   *  never silently reaches the agent. */
+  isRegisteredSkill?: (name: string) => boolean | Promise<boolean>;
 }): CommandHandler {
-  const { loadAllRoles, getRole, resetChatState, connectSession, listSessions, getSessionHistory } = opts;
+  const { loadAllRoles, getRole, resetChatState, connectSession, listSessions, getSessionHistory, isRegisteredSkill } = opts;
 
   // Cache /sessions results per chat so /switch resolves to the correct list.
   // Key: "transportId:externalChatId". Bounded with max entries + TTL.
@@ -273,10 +281,19 @@ export function createCommandHandler(opts: {
         return handleRole(transportId, chatState, args[0]);
       case "/status":
         return handleStatus(chatState);
-      case "/":
+      default: {
+        // Forward to the agent only if the command names a registered
+        // skill; otherwise reply with the standard "Unknown command"
+        // help. We deliberately do NOT pass arbitrary slash text
+        // through, so a typo can't accidentally invoke the agent and
+        // a slash that doesn't match anything stays a transport-level
+        // error.
+        const skillName = command.slice(1);
+        if (skillName && isRegisteredSkill && (await isRegisteredSkill(skillName))) {
+          return null;
+        }
         return { reply: `Unknown command: ${command}\n\n${getHelpText()}` };
-      default:
-        return null;
+      }
     }
   };
 

--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -5,7 +5,7 @@
 // reset arrive via the factory so this file has zero imports from
 // the host app — only sibling module types.
 
-import type { Role, SessionSummary } from "./types.js";
+import type { BridgeSkillSummary, Role, SessionSummary } from "./types.js";
 import type { ChatStateStore, TransportChatState } from "./chat-state.js";
 
 // ── Types ────────────────────────────────────────────────────
@@ -49,16 +49,14 @@ export function createCommandHandler(opts: {
     messages: Array<{ source: string; text: string }>;
     total: number;
   }>;
-  /** Predicate the bridge command handler uses to decide whether an
-   *  unknown slash command (e.g. `/release-app`) names a registered
-   *  skill — when true the text is forwarded to the agent so the
-   *  Claude CLI's slash-command resolver can run the skill. When
-   *  omitted (or it returns false) the command is rejected with the
-   *  standard "Unknown command" reply, so an unknown bridge slash
-   *  never silently reaches the agent. */
-  isRegisteredSkill?: (name: string) => boolean | Promise<boolean>;
+  /** Lists the skills the bridge command handler should expose.
+   *  Drives both the slash-command allowlist (only matching names
+   *  are forwarded to the agent) and the "Skills:" section in the
+   *  `/help` reply. When omitted, every unknown slash is rejected
+   *  and `/help` shows only the built-in commands. */
+  listRegisteredSkills?: () => Promise<BridgeSkillSummary[]>;
 }): CommandHandler {
-  const { loadAllRoles, getRole, resetChatState, connectSession, listSessions, getSessionHistory, isRegisteredSkill } = opts;
+  const { loadAllRoles, getRole, resetChatState, connectSession, listSessions, getSessionHistory, listRegisteredSkills } = opts;
 
   // Cache /sessions results per chat so /switch resolves to the correct list.
   // Key: "transportId:externalChatId". Bounded with max entries + TTL.
@@ -93,8 +91,12 @@ export function createCommandHandler(opts: {
 
   const getRolesText = (): string => ["Available roles:", ...loadAllRoles().map((r) => `  ${r.id} — ${r.name}`)].join("\n");
 
-  const getHelpText = (): string =>
-    [
+  // Built each time so `/help` reflects the live skill list. The
+  // `skills` argument is fetched once per command turn (see the
+  // `default:` branch and `case "/help"`) so we don't fs-scan twice
+  // when the handler both checks membership and renders help.
+  const buildHelpText = (skills: BridgeSkillSummary[]): string => {
+    const lines = [
       "Commands:",
       "  /reset  — Start a new session",
       "  /sessions [page] — List recent sessions (e.g. /sessions 2)",
@@ -104,9 +106,15 @@ export function createCommandHandler(opts: {
       "  /roles  — List available roles",
       "  /role <id> — Switch role",
       "  /status — Show current session info",
-      "",
-      "Send any other text to chat with the assistant.",
-    ].join("\n");
+    ];
+    if (skills.length > 0) {
+      lines.push("", "Skills:", ...skills.map((s) => `  /${s.name} — ${s.description}`));
+    }
+    lines.push("", "Send any other text to chat with the assistant.");
+    return lines.join("\n");
+  };
+
+  const fetchSkills = async (): Promise<BridgeSkillSummary[]> => (listRegisteredSkills ? await listRegisteredSkills() : []);
 
   const handleReset = async (transportId: string, chatState: TransportChatState): Promise<CommandResult> => {
     const nextState = await resetChatState(transportId, chatState.externalChatId, chatState.roleId);
@@ -274,7 +282,7 @@ export function createCommandHandler(opts: {
       case "/history":
         return handleHistory(chatState, args[0]);
       case "/help":
-        return { reply: getHelpText() };
+        return { reply: buildHelpText(await fetchSkills()) };
       case "/roles":
         return { reply: getRolesText() };
       case "/role":
@@ -287,12 +295,12 @@ export function createCommandHandler(opts: {
         // help. We deliberately do NOT pass arbitrary slash text
         // through, so a typo can't accidentally invoke the agent and
         // a slash that doesn't match anything stays a transport-level
-        // error.
+        // error. Reuse the same skill list for the membership check
+        // and the help text to avoid scanning the skills dir twice.
+        const skills = await fetchSkills();
         const skillName = command.slice(1);
-        if (skillName && isRegisteredSkill && (await isRegisteredSkill(skillName))) {
-          return null;
-        }
-        return { reply: `Unknown command: ${command}\n\n${getHelpText()}` };
+        if (skillName && skills.some((s) => s.name === skillName)) return null;
+        return { reply: `Unknown command: ${command}\n\n${buildHelpText(skills)}` };
       }
     }
   };

--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -273,8 +273,10 @@ export function createCommandHandler(opts: {
         return handleRole(transportId, chatState, args[0]);
       case "/status":
         return handleStatus(chatState);
-      default:
+      case "/":
         return { reply: `Unknown command: ${command}\n\n${getHelpText()}` };
+      default:
+        return null;
     }
   };
 

--- a/packages/chat-service/src/index.ts
+++ b/packages/chat-service/src/index.ts
@@ -84,6 +84,7 @@ export function createChatService(deps: ChatServiceDeps): ChatService {
     connectSession: store.connectSession,
     listSessions: deps.listSessions,
     getSessionHistory: deps.getSessionHistory,
+    isRegisteredSkill: deps.isRegisteredSkill,
   });
   const relay = createRelay({
     store,

--- a/packages/chat-service/src/index.ts
+++ b/packages/chat-service/src/index.ts
@@ -84,7 +84,7 @@ export function createChatService(deps: ChatServiceDeps): ChatService {
     connectSession: store.connectSession,
     listSessions: deps.listSessions,
     getSessionHistory: deps.getSessionHistory,
-    isRegisteredSkill: deps.isRegisteredSkill,
+    listRegisteredSkills: deps.listRegisteredSkills,
   });
   const relay = createRelay({
     store,

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -110,12 +110,26 @@ export interface ChatServiceDeps {
     total: number;
   }>;
   /**
-   * Decide whether an unknown bridge slash command (e.g. `/foo` from
-   * Telegram) names a registered skill the agent should run. Only
-   * true → the text is forwarded to startChat() so the Claude CLI's
-   * slash-command resolver picks it up. False → the bridge replies
-   * "Unknown command" without ever invoking the agent. When omitted
-   * the command handler treats every unknown slash as unknown.
+   * Return the skills the bridge command handler should expose. The
+   * handler uses the result for two things:
+   *   (1) Decide whether an unknown bridge slash command (e.g. `/foo`
+   *       from Telegram) names a registered skill — only matching
+   *       names are forwarded to the agent so the Claude CLI's
+   *       slash-command resolver runs the skill. Non-matches stay a
+   *       transport-level "Unknown command" reply.
+   *   (2) Render a "Skills:" section in the bridge `/help` text and
+   *       in the "Unknown command" fallback so a bridge user can
+   *       discover what skills exist without leaving the chat.
+   * When omitted, every unknown slash is rejected and `/help` shows
+   * only the built-in commands.
    */
-  isRegisteredSkill?: (name: string) => boolean | Promise<boolean>;
+  listRegisteredSkills?: () => Promise<BridgeSkillSummary[]>;
+}
+
+/** Minimal skill info the bridge command handler needs to render the
+ *  `/help` text and decide whether a slash command should be forwarded
+ *  to the agent. Sourced from SKILL.md frontmatter on the host side. */
+export interface BridgeSkillSummary {
+  name: string;
+  description: string;
 }

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -109,4 +109,13 @@ export interface ChatServiceDeps {
     messages: Array<{ source: string; text: string }>;
     total: number;
   }>;
+  /**
+   * Decide whether an unknown bridge slash command (e.g. `/foo` from
+   * Telegram) names a registered skill the agent should run. Only
+   * true → the text is forwarded to startChat() so the Claude CLI's
+   * slash-command resolver picks it up. False → the bridge replies
+   * "Unknown command" without ever invoking the agent. When omitted
+   * the command handler treats every unknown slash as unknown.
+   */
+  isRegisteredSkill?: (name: string) => boolean | Promise<boolean>;
 }

--- a/packages/chat-service/test/test_commands.ts
+++ b/packages/chat-service/test/test_commands.ts
@@ -181,3 +181,68 @@ describe("/history command", () => {
     assert.ok(page2.reply.includes("welcome"));
   });
 });
+
+describe("unknown slash command", () => {
+  it("rejects an unknown slash with help text when no skill predicate is wired", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+    });
+    const result = await handler("/foo", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Unknown command: /foo"));
+  });
+
+  it("forwards to the agent (returns null) when the slash names a registered skill", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      isRegisteredSkill: (name) => name === "review",
+    });
+    const result = await handler("/review", "telegram", makeState());
+    assert.equal(result, null);
+  });
+
+  it("rejects an unregistered slash even when a skill predicate is wired", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      isRegisteredSkill: (name) => name === "review",
+    });
+    const result = await handler("/notaskill", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Unknown command: /notaskill"));
+  });
+
+  it("treats bare `/` as unknown (slice produces empty string, predicate skipped)", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      // Even a permissive predicate must NOT match the empty skill name.
+      isRegisteredSkill: () => true,
+    });
+    const result = await handler("/", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Unknown command: /"));
+  });
+
+  it("supports an async predicate", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      isRegisteredSkill: async (name) => name === "review",
+    });
+    const result = await handler("/review", "telegram", makeState());
+    assert.equal(result, null);
+  });
+});

--- a/packages/chat-service/test/test_commands.ts
+++ b/packages/chat-service/test/test_commands.ts
@@ -183,7 +183,7 @@ describe("/history command", () => {
 });
 
 describe("unknown slash command", () => {
-  it("rejects an unknown slash with help text when no skill predicate is wired", async () => {
+  it("rejects an unknown slash with help text when no skill list is wired", async () => {
     const handler = createCommandHandler({
       loadAllRoles: () => roles,
       getRole: () => roles[0],
@@ -201,48 +201,100 @@ describe("unknown slash command", () => {
       getRole: () => roles[0],
       resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
       connectSession: async () => makeState(),
-      isRegisteredSkill: (name) => name === "review",
+      listRegisteredSkills: async () => [{ name: "shiritori", description: "Play shiritori" }],
     });
-    const result = await handler("/review", "telegram", makeState());
+    const result = await handler("/shiritori", "telegram", makeState());
     assert.equal(result, null);
   });
 
-  it("rejects an unregistered slash even when a skill predicate is wired", async () => {
+  it("rejects an unregistered slash even when a skill list is wired", async () => {
     const handler = createCommandHandler({
       loadAllRoles: () => roles,
       getRole: () => roles[0],
       resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
       connectSession: async () => makeState(),
-      isRegisteredSkill: (name) => name === "review",
+      listRegisteredSkills: async () => [{ name: "shiritori", description: "Play shiritori" }],
     });
     const result = await handler("/notaskill", "telegram", makeState());
     assert.ok(result);
     assert.ok(result.reply.includes("Unknown command: /notaskill"));
   });
 
-  it("treats bare `/` as unknown (slice produces empty string, predicate skipped)", async () => {
+  it("treats bare `/` as unknown (slice produces empty string, list ignored)", async () => {
     const handler = createCommandHandler({
       loadAllRoles: () => roles,
       getRole: () => roles[0],
       resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
       connectSession: async () => makeState(),
-      // Even a permissive predicate must NOT match the empty skill name.
-      isRegisteredSkill: () => true,
+      // Even a permissive list must NOT match the empty skill name.
+      listRegisteredSkills: async () => [{ name: "", description: "wat" }],
     });
     const result = await handler("/", "telegram", makeState());
     assert.ok(result);
     assert.ok(result.reply.includes("Unknown command: /"));
   });
 
-  it("supports an async predicate", async () => {
+  it("includes registered skills in the unknown-command help footer", async () => {
     const handler = createCommandHandler({
       loadAllRoles: () => roles,
       getRole: () => roles[0],
       resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
       connectSession: async () => makeState(),
-      isRegisteredSkill: async (name) => name === "review",
+      listRegisteredSkills: async () => [
+        { name: "shiritori", description: "Play shiritori" },
+        { name: "haiku", description: "Compose a haiku" },
+      ],
     });
-    const result = await handler("/review", "telegram", makeState());
-    assert.equal(result, null);
+    const result = await handler("/foo", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Skills:"));
+    assert.ok(result.reply.includes("/shiritori — Play shiritori"));
+    assert.ok(result.reply.includes("/haiku — Compose a haiku"));
+  });
+});
+
+describe("/help command", () => {
+  it("omits the Skills section when no skill list is wired", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+    });
+    const result = await handler("/help", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Commands:"));
+    assert.ok(!result.reply.includes("Skills:"));
+  });
+
+  it("omits the Skills section when the skill list is empty", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [],
+    });
+    const result = await handler("/help", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(!result.reply.includes("Skills:"));
+  });
+
+  it("lists registered skills with descriptions in the Skills section", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [
+        { name: "shiritori", description: "Play shiritori" },
+        { name: "haiku", description: "Compose a haiku" },
+      ],
+    });
+    const result = await handler("/help", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(result.reply.includes("Skills:"));
+    assert.ok(result.reply.includes("/shiritori — Play shiritori"));
+    assert.ok(result.reply.includes("/haiku — Compose a haiku"));
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import { loadAllSessions } from "./api/routes/sessions.js";
 import { readSessionJsonl } from "./utils/files/session-io.js";
 import { onSessionEvent } from "./events/session-store/index.js";
 import { getRole, loadAllRoles } from "./workspace/roles.js";
+import { discoverSkills } from "./workspace/skills/index.js";
 import { WORKSPACE_PATHS } from "./workspace/paths.js";
 import { serverError } from "./utils/httpError.js";
 import { makeUuid } from "./utils/id.js";
@@ -202,6 +203,18 @@ async function getSessionHistoryForBridge(sessionId: string, opts: { limit: numb
   const messages = allMessages.slice(opts.offset, opts.offset + opts.limit);
   return { messages, total };
 }
+// Allowlist used by the bridge command handler: a slash command
+// from a bridge (e.g. `/release-app` from Telegram) is forwarded to
+// the agent only if it names a discoverable skill under
+// ~/.claude/skills/ or <workspace>/.claude/skills/. fs is hit on
+// every unknown bridge slash, which is fine because bridge slashes
+// are infrequent and the workspace skill directory is small. Stays
+// fresh against skill add/remove without any cache invalidation.
+async function isRegisteredSkill(name: string): Promise<boolean> {
+  const skills = await discoverSkills({ workspaceRoot: workspacePath });
+  return skills.some((skill) => skill.name === name);
+}
+
 const chatService = createChatService({
   startChat,
   onSessionEvent,
@@ -215,6 +228,7 @@ const chatService = createChatService({
   tokenProvider: getCurrentToken,
   listSessions: listSessionsForBridge,
   getSessionHistory: getSessionHistoryForBridge,
+  isRegisteredSkill,
 });
 app.use(chatService.router);
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -206,13 +206,16 @@ async function getSessionHistoryForBridge(sessionId: string, opts: { limit: numb
 // Allowlist used by the bridge command handler: a slash command
 // from a bridge (e.g. `/release-app` from Telegram) is forwarded to
 // the agent only if it names a discoverable skill under
-// ~/.claude/skills/ or <workspace>/.claude/skills/. fs is hit on
-// every unknown bridge slash, which is fine because bridge slashes
-// are infrequent and the workspace skill directory is small. Stays
-// fresh against skill add/remove without any cache invalidation.
-async function isRegisteredSkill(name: string): Promise<boolean> {
+// ~/.claude/skills/ or <workspace>/.claude/skills/. The same list
+// drives the "Skills:" section in the bridge `/help` reply, so the
+// command handler calls this once per turn (membership check + help
+// rendering share the result). fs is hit on every help/unknown
+// bridge slash, which is fine because bridge slashes are infrequent
+// and the workspace skill directory is small. Stays fresh against
+// skill add/remove without any cache invalidation.
+async function listRegisteredSkills(): Promise<{ name: string; description: string }[]> {
   const skills = await discoverSkills({ workspaceRoot: workspacePath });
-  return skills.some((skill) => skill.name === name);
+  return skills.map((skill) => ({ name: skill.name, description: skill.description }));
 }
 
 const chatService = createChatService({
@@ -228,7 +231,7 @@ const chatService = createChatService({
   tokenProvider: getCurrentToken,
   listSessions: listSessionsForBridge,
   getSessionHistory: getSessionHistoryForBridge,
-  isRegisteredSkill,
+  listRegisteredSkills,
 });
 app.use(chatService.router);
 


### PR DESCRIPTION
## Summary

Lets bridge users (Telegram, LINE, etc.) discover and run user-installed skills via slash commands, while keeping arbitrary slash text from silently reaching the agent.

- **Skill execution**: an unknown bridge slash (e.g. `/shiritori`) is forwarded to the agent only when it names a discoverable skill under `~/.claude/skills/` or `<workspace>/.claude/skills/`. Anything else stays a transport-level "Unknown command" reply, so typos surface as errors and built-in destructive surfaces (or random text) can't be invoked by accident.
- **Discovery**: `/help` and the "Unknown command" footer now append a `Skills:` section with each registered skill's name and description, so bridge users see what's available without leaving chat. Built-in CLI skills are not listed (they don't live on disk under `.claude/skills/`), which keeps the bridge surface scoped to skills the workspace owner intentionally installed.

The host wires up `ChatServiceDeps.listRegisteredSkills` via `discoverSkills()` (no caching — bridge slashes are infrequent and the skills dir is small, so we stay fresh against skill add/remove without an invalidation path). The chat-service package stays free of host-app imports per its `@package-contract`.

## Commits in this PR

1. `feat(bridge): pass unknown slash commands through to the agent` — base behavior change; preserves `/` alone as the help trigger.
2. `feat(bridge): allowlist bridge slash commands to registered skills only` — tightens (1) so only discoverable skills pass through; introduces the `isRegisteredSkill` predicate (later replaced).
3. `feat(bridge): list registered skills in /help and unknown-command reply` — replaces the predicate with `listRegisteredSkills` (name + description), renders the `Skills:` section in both `/help` and the unknown-command reply.

## Test plan

- [x] `yarn workspace @mulmobridge/chat-service run test` — 57 tests pass (8 new cases for the unknown-slash and `/help` behavior)
- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` — all clean
- [x] Manual: `/help` from Telegram lists user-installed skills only (built-ins like `/review` correctly do not appear, since they're bundled in the CLI rather than on disk under `.claude/skills/`)
- [ ] Manual: invoking a registered skill from a bridge runs it end-to-end (verified by reporter)
- [ ] Manual: an unregistered slash from a bridge replies "Unknown command" without invoking the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `/help` output to display registered skills when available.
  * Improved slash command handling to recognize and process commands matching registered skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->