### PR TITLE
fix: add missing pluginPresentForm i18n keys across all 8 locales

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -447,6 +447,18 @@ const deMessages = {
     taskCountMismatch:
       "Wiki-Quelle und gerendertes Ergebnis stimmen in der Anzahl der Aufgaben nicht überein. Die Umschaltung wurde abgelehnt, um eine Beschädigung der Datei zu vermeiden.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "Formular",
+    fieldCount: "{count} Feld | {count} Felder",
+    submitted: "Gesendet",
+    errorSummary: "Bitte korrigieren Sie die folgenden Fehler",
+    requiredMarker: "*",
+    selectOption: "Bitte auswählen",
+    charactersCount: "{current} / {max} Zeichen",
+    charactersCountNoMax: "{current} Zeichen",
+    submit: "Senden",
+    progress: "{filled} von {total} Pflichtfeldern ausgefüllt",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",
     pdf: "PDF",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -466,6 +466,18 @@ const enMessages = {
     lintChat: "Lint My Wiki",
     taskCountMismatch: "Wiki source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "Form",
+    fieldCount: "{count} field | {count} fields",
+    submitted: "Submitted",
+    errorSummary: "Please fix the following errors",
+    requiredMarker: "*",
+    selectOption: "Select an option",
+    charactersCount: "{current} / {max} characters",
+    charactersCountNoMax: "{current} characters",
+    submit: "Submit",
+    progress: "{filled} of {total} required fields completed",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Save as PDF (opens print dialog)",
     pdf: "PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -452,6 +452,18 @@ const esMessages = {
     lintChat: "Revisar mi wiki",
     taskCountMismatch: "La fuente del wiki y la salida renderizada difieren en el número de tareas. Se rechazó el cambio para evitar dañar el archivo.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "Formulario",
+    fieldCount: "{count} campo | {count} campos",
+    submitted: "Enviado",
+    errorSummary: "Por favor, corrija los siguientes errores",
+    requiredMarker: "*",
+    selectOption: "Seleccione una opción",
+    charactersCount: "{current} / {max} caracteres",
+    charactersCountNoMax: "{current} caracteres",
+    submit: "Enviar",
+    progress: "{filled} de {total} campos obligatorios completados",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",
     pdf: "PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -446,6 +446,18 @@ const frMessages = {
     lintChat: "Vérifier mon wiki",
     taskCountMismatch: "La source du wiki et le rendu diffèrent sur le nombre de tâches. La modification a été refusée pour éviter de corrompre le fichier.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "Formulaire",
+    fieldCount: "{count} champ | {count} champs",
+    submitted: "Envoyé",
+    errorSummary: "Veuillez corriger les erreurs suivantes",
+    requiredMarker: "*",
+    selectOption: "Sélectionnez une option",
+    charactersCount: "{current} / {max} caractères",
+    charactersCountNoMax: "{current} caractères",
+    submit: "Envoyer",
+    progress: "{filled} sur {total} champs obligatoires remplis",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",
     pdf: "PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -450,6 +450,18 @@ const jaMessages = {
     lintChat: "Wiki を Lint",
     taskCountMismatch: "Wiki ソースと描画結果でタスク数が一致しないため、ファイル破損を避けるためトグル操作を中止しました。",
   },
+  pluginPresentForm: {
+    fallbackTitle: "フォーム",
+    fieldCount: "{count} 項目",
+    submitted: "送信済み",
+    errorSummary: "次のエラーを修正してください",
+    requiredMarker: "*",
+    selectOption: "選択してください",
+    charactersCount: "{current} / {max} 文字",
+    charactersCountNoMax: "{current} 文字",
+    submit: "送信",
+    progress: "必須項目 {total} 件中 {filled} 件入力済み",
+  },
   pluginPresentHtml: {
     saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",
     pdf: "PDF",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -450,6 +450,18 @@ const koMessages = {
     lintChat: "Wiki 점검",
     taskCountMismatch: "Wiki 원본과 렌더링 결과의 작업 수가 일치하지 않아, 파일 손상을 방지하기 위해 토글이 거부되었습니다.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "양식",
+    fieldCount: "{count}개 항목",
+    submitted: "제출됨",
+    errorSummary: "다음 오류를 수정해주세요",
+    requiredMarker: "*",
+    selectOption: "선택하세요",
+    charactersCount: "{current} / {max} 자",
+    charactersCountNoMax: "{current} 자",
+    submit: "제출",
+    progress: "필수 항목 {total}개 중 {filled}개 입력됨",
+  },
   pluginPresentHtml: {
     saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",
     pdf: "PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -445,6 +445,18 @@ const ptBRMessages = {
     lintChat: "Revisar meu wiki",
     taskCountMismatch: "A fonte do wiki e a saída renderizada divergem no número de tarefas. A alternância foi recusada para evitar corromper o arquivo.",
   },
+  pluginPresentForm: {
+    fallbackTitle: "Formulário",
+    fieldCount: "{count} campo | {count} campos",
+    submitted: "Enviado",
+    errorSummary: "Por favor, corrija os seguintes erros",
+    requiredMarker: "*",
+    selectOption: "Selecione uma opção",
+    charactersCount: "{current} / {max} caracteres",
+    charactersCountNoMax: "{current} caracteres",
+    submit: "Enviar",
+    progress: "{filled} de {total} campos obrigatórios preenchidos",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",
     pdf: "PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -446,6 +446,18 @@ const zhMessages = {
     lintChat: "检查 Wiki",
     taskCountMismatch: "Wiki 源与渲染输出的任务数不一致，为避免文件损坏，已拒绝切换。",
   },
+  pluginPresentForm: {
+    fallbackTitle: "表单",
+    fieldCount: "{count} 个字段",
+    submitted: "已提交",
+    errorSummary: "请修正以下错误",
+    requiredMarker: "*",
+    selectOption: "请选择",
+    charactersCount: "{current} / {max} 字符",
+    charactersCountNoMax: "{current} 字符",
+    submit: "提交",
+    progress: "已填写 {filled} / {total} 个必填字段",
+  },
   pluginPresentHtml: {
     saveAsPdf: "另存为 PDF(打开打印对话框)",
     pdf: "PDF",


### PR DESCRIPTION
## Summary

- The presentForm plugin's `View.vue` and `Preview.vue` reference 10 i18n keys under `pluginPresentForm.*` (submit, submitted, progress, fallbackTitle, fieldCount, errorSummary, requiredMarker, selectOption, charactersCount, charactersCountNoMax) — the entire namespace was missing from every locale file.
- Result: forms rendered raw key paths (e.g. `pluginPresentForm.submit`) instead of localized labels.
- Added the namespace to all 8 locales (`en, ja, zh, ko, es, pt-BR, fr, de`) per the CLAUDE.md "all 8 locales in lockstep" rule, with proper translations (placeholders kept verbatim).

## Out of scope

The validation messages inside `View.vue` (`validateText`, `validateNumber`, `validateDate`, `validateCheckbox`, the `(none)` fallback in `renderValue`) are still hardcoded English. Left for a follow-up since they interpolate field labels and limits — bigger change.

## Test plan

- [x] `yarn typecheck` — passes (catches missing keys via `typeof enMessages` augmentation)
- [x] `yarn lint` — clean (only pre-existing warnings unrelated to this change)
- [x] `yarn format` — clean
- [ ] Manually verify: trigger `presentForm` from a chat, confirm submit button label, progress text, submitted state, dropdown placeholder, character counter, and error summary all render localized strings in EN + JA

🤖 Generated with [Claude Code](https://claude.com/claude-code)