### PR TITLE
fix: switch Notion MCP catalog entry to NOTION_TOKEN (follow-up to #852)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP catalog Notion entry** — switched from the legacy `OPENAPI_MCP_HEADERS` JSON-string form (with a hardcoded `Notion-Version: 2022-06-28`, three years stale) to the official `NOTION_TOKEN` env var, which the upstream README marks as recommended. Users who installed Notion via the catalog before this change still work, but their `~/mulmoclaude/config/mcp.json` keeps the old shape — re-install from Settings → MCP to pick up the new env shape and access the 2025-09-03 API features (data sources, 7 new tools).
+
 ---
 
 ## [0.5.0] - 2026-04-27
@@ -23,7 +27,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 - **Wiki**: tag-based filtering on the index, "Create this wiki page" empty-state CTA, "Lint My Wiki" button, interactive GFM task checkboxes that round-trip to disk, Unicode hashtags accepted in index bullets.
 - **Session history side panel** (#728) — independent toggle (canvas and history can coexist), expand-to-full-width, badge moved onto the toggle button. The standalone `/history` route is retired in favor of the panel.
 - **Files view** (#832) — system-managed file description banner; file-tree icons tinted by edit policy (read-only / system-managed / writable).
-- **Thinking… indicator** (#839, #731 PR2) — shared across slide and stack views, per-tool elapsed time, gated on whether *this* session is running rather than the global isRunning.
+- **Thinking… indicator** (#839, #731 PR2) — shared across slide and stack views, per-tool elapsed time, gated on whether _this_ session is running rather than the global isRunning.
 - **Server observability** (#779) — structured `log.{error,warn,info,debug}` audit; layered logging on 10+ routes (plugin / files / todos / chart / config / html / roles / sessions / skills / image).
 - **Smoke-tested `mulmoclaude` tarball in CI** (#667) — pre-publish smoke workflow verifies the npm package boots before release.
 - **Slack ack reaction** (`@mulmobridge/slack@0.4.0`) — `SLACK_ACK_REACTION=1` adds 👀 on receive so the user sees the bot saw the message before the agent finishes (#695).

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -254,10 +254,12 @@ test.describe("Settings MCP tab — stdio + Docker warnings (Phase 2b)", () => {
 });
 
 // Catalog config form (#823 Phase 2). Notion is the canonical
-// example: 1 secret field (NOTION_API_KEY) wrapped into the
-// OPENAPI_MCP_HEADERS env var. Walks the full toggle → form →
-// validate → install round-trip and asserts the env arrives at
-// the persistence layer with the placeholder resolved.
+// example: 1 secret field (NOTION_API_KEY) interpolated into
+// the recommended `NOTION_TOKEN` env var (per the official
+// @notionhq/notion-mcp-server README). Walks the full
+// toggle → form → validate → install round-trip and asserts
+// the env arrives at the persistence layer with the
+// placeholder resolved.
 test.describe("Settings MCP tab — catalog config (Phase 2)", () => {
   test("config-required entry shows form, validates, and installs with resolved env", async ({ page }) => {
     const { state } = await mockConfigApi(page);
@@ -278,7 +280,7 @@ test.describe("Settings MCP tab — catalog config (Phase 2)", () => {
     await expect(page.locator('[data-testid="mcp-catalog-config-error-notion"]')).toContainText("NOTION_API_KEY");
 
     // Fill the key and install → server appears, env carries the
-    // resolved bearer token wrapped in the OPENAPI_MCP_HEADERS JSON.
+    // resolved token under NOTION_TOKEN (the recommended shape).
     await page.locator('[data-testid="mcp-catalog-config-input-notion-NOTION_API_KEY"]').fill("secret_test_token_xyz");
     await page.locator('[data-testid="mcp-catalog-config-install-notion"]').click();
     await expect(page.locator('[data-testid="mcp-catalog-config-form-notion"]')).not.toBeVisible();
@@ -287,7 +289,7 @@ test.describe("Settings MCP tab — catalog config (Phase 2)", () => {
     await expect.poll(() => state.mcp.servers.find((entry) => entry.id === "notion")?.spec.type).toBe("stdio");
     const installed = state.mcp.servers.find((entry) => entry.id === "notion");
     if (!installed || installed.spec.type !== "stdio") throw new Error("notion server not persisted as stdio");
-    expect(installed.spec.env?.OPENAPI_MCP_HEADERS).toContain("Bearer secret_test_token_xyz");
+    expect(installed.spec.env?.NOTION_TOKEN).toBe("secret_test_token_xyz");
 
     // Toggle off → server is removed.
     await page.locator('[data-testid="mcp-catalog-toggle-notion"]').uncheck();

--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -144,10 +144,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     riskLevel: "low",
   },
 
-  // Notion workspace access. Official Notion MCP server uses an
-  // OPENAPI_MCP_HEADERS env var that wraps the bearer token in
-  // JSON; the user only fills the bare API key and we build the
-  // header here. See https://github.com/makenotion/notion-mcp-server.
+  // Notion workspace access. The official Notion MCP server's
+  // README marks `NOTION_TOKEN` as the recommended env shape (the
+  // older `OPENAPI_MCP_HEADERS` JSON-string form is kept for
+  // "advanced use cases"). Switching to NOTION_TOKEN also stops
+  // pinning a stale Notion-Version — the server falls back to the
+  // current API (2025-09-03 at time of writing) on its own. See
+  // https://github.com/makenotion/notion-mcp-server.
   {
     id: "notion",
     displayName: "settingsMcpTab.catalog.entry.notion.displayName",
@@ -160,7 +163,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
       command: "npx",
       args: ["-y", "@notionhq/notion-mcp-server"],
       env: {
-        OPENAPI_MCP_HEADERS: '{"Authorization":"Bearer ${NOTION_API_KEY}","Notion-Version":"2022-06-28"}',
+        NOTION_TOKEN: "${NOTION_API_KEY}",
       },
     },
     configSchema: [


### PR DESCRIPTION
## Summary

CodeRabbit review on #852 flagged that the Notion catalog entry was using the legacy `OPENAPI_MCP_HEADERS` JSON-string env shape with a hardcoded stale `Notion-Version: 2022-06-28`. The official `@notionhq/notion-mcp-server` README marks `NOTION_TOKEN` as the recommended env var. This PR switches to that shape and drops the stale Notion-Version pin (server falls back to current API 2025-09-03 — gives users the data-sources tools for free).

## Items to Confirm / Review

- **Migration impact**: existing users who installed Notion via the catalog before this change keep `OPENAPI_MCP_HEADERS` in `~/mulmoclaude/config/mcp.json`. Their setup keeps working (env var still recognised by the server) — no auto-migration. The CHANGELOG entry tells them to re-install from Settings → MCP to pick up the new shape and access 2025-09-03 API features. Is the documentation-only migration path OK, or should we add a one-time auto-rewrite on app boot?
- **Re-install path**: re-installing through the MCP tab simply overwrites the entry — verified manually that `interpolateMcpSpec` produces `{ NOTION_TOKEN: "secret_..." }` correctly.

## User Prompt

Triage CodeRabbit feedback on PRs from the last 30 hours and apply fixes that need a judgment call one at a time. The user chose option A (NOTION_TOKEN) over keeping `OPENAPI_MCP_HEADERS` after I cross-checked the official README.

## Implementation

- `src/config/mcpCatalog.ts` — Notion entry env switched from `OPENAPI_MCP_HEADERS: '{"Authorization":"Bearer ${NOTION_API_KEY}","Notion-Version":"2022-06-28"}'` to `NOTION_TOKEN: "\${NOTION_API_KEY}"`. Comment block rewritten to explain the choice and link upstream README.
- `docs/CHANGELOG.md` — `[Unreleased] → Fixed` entry with the re-install note for existing users.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn build` clean
- [x] `yarn test` — 3178 pass
- [ ] Manual: re-install Notion from Settings → MCP after merge, confirm `NOTION_TOKEN` lands in `mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Notion MCP server configuration to use the recommended environment-variable approach, replacing the legacy header-based method. Existing users must reinstall via Settings → MCP to refresh their local configuration.

* **Documentation**
  * Added changelog entry documenting the MCP configuration transition and a minor markdown formatting tweak.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->