### PR TITLE
fix: align sources help with on-disk YAML keys (follow-up to #855)

### DIFF
--- a/server/workspace/helps/sources.md
+++ b/server/workspace/helps/sources.md
@@ -6,7 +6,7 @@ This page describes the information-source registry: how to register feeds, how 
 
 ### Register
 
-Ask the user for the canonical URL (RSS feed URL, GitHub repo URL, or arXiv listing URL), infer `fetcherKind` from it, and populate `fetcherParams` accordingly:
+Ask the user for the canonical URL (RSS feed URL, GitHub repo URL, or arXiv listing URL), infer `fetcher_kind` from it, and populate the fetcher-specific params (added as flat top-level YAML keys) accordingly:
 
 - **`rss`** — `{ rss_url: <feed URL> }`
 - **`github-releases`** / **`github-issues`** — `{ github_repo: "<owner>/<name>" }`. Pick releases vs. issues based on user intent.
@@ -30,7 +30,7 @@ Every `manageSource` action's response already includes the refreshed list — y
 
 The pipeline reads and writes these files under the workspace root:
 
-- **`sources/<slug>.md`** — source config. YAML frontmatter: `title`, `url`, `fetcherKind`, `fetcherParams`, `schedule`, `categories`, `maxItemsPerFetch`, `addedAt`, `notes`.
+- **`sources/<slug>.md`** — source config. Flat YAML frontmatter: `slug`, `title`, `url`, `fetcher_kind`, `schedule`, `categories`, `max_items_per_fetch`, `added_at`. Any unrecognized top-level keys (e.g. `rss_url`, `github_repo`, `arxiv_query`) become fetcher-specific params. Body is `notes`.
 - **`sources/_state/<slug>.json`** — runtime state: `lastFetchedAt`, `cursor`, `consecutiveFailures`, `nextAttemptAt`.
 - **`news/daily/YYYY/MM/DD.md`** — the aggregated daily brief: markdown body plus a trailing fenced JSON block listing items.
 - **`news/archive/<slug>/YYYY/MM.md`** — per-source monthly archive. Lossless; no cross-source dedup.


### PR DESCRIPTION
## Summary

CodeRabbit on #855 flagged that `server/workspace/helps/sources.md` listed camelCase frontmatter keys as if they were the on-disk shape. The actual `registry.ts` parser/writer uses snake_case (`fetcher_kind`, `max_items_per_fetch`, `added_at`) with fetcher-specific params **flat** at the top level — there is no nested `fetcherParams`. The agent was being fed a misleading schema whenever it tried to read or write source files directly.

## Items to Confirm / Review

- The body of the source `.md` (which becomes `notes`) is unchanged. Only the frontmatter naming is corrected.
- `_state/<slug>.json` keys remain camelCase (`lastFetchedAt`, `cursor`, `consecutiveFailures`, `nextAttemptAt`) — they're written/read as native JSON via TypeScript, no key-case translation. Help line 34 was already correct.

## User Prompt

Triage CodeRabbit feedback on PRs from the last 30 hours and apply fixes that need a judgment call one at a time. The user approved this fix as part of the no-side-effect batch.

## Implementation

- Line 9: `fetcherKind`/`fetcherParams` → `fetcher_kind` + a one-liner explaining fetcher-specific params land as flat top-level YAML keys.
- Line 33: rewrote frontmatter listing to match `RESERVED_KEYS` in `server/workspace/sources/registry.ts:42`. Mentions `notes` lives in the markdown body, not in frontmatter.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [ ] Manual: create a source via chat, verify the agent uses the snake_case shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)