### PR TITLE
chore(ci): paths-ignore + e2e shard + cache wins

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,6 +4,17 @@ on:
   pull_request:
     branches:
       - main
+    # Skip when ALL changed files are docs / plans / top-level markdown.
+    # Applied to lint_test + e2e — both jobs in this workflow are
+    # value-added only when source / config / tests change. PRs that
+    # only move plan files (e.g. plans/ → plans/done/ chore PRs) or
+    # tweak markdown docs go straight to mergeable. paths-ignore is
+    # AND-style: a PR that mixes a code change and a doc change still
+    # runs CI in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'plans/**'
+      - '**/*.md'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Three CI workflow tweaks to cut PR feedback time:

1. **paths-ignore** (commit \`1d7dccf5\`) — skip lint_test + e2e on PRs that only touch \`docs/\`, \`plans/\`, or \`**/*.md\`. AND-style: any code change re-arms full CI.
2. **e2e shard** (commit \`ae26cfb4\`) — split the 268-test e2e suite across 2 parallel runners via Playwright \`--shard=N/2\`. Wall clock 8min → ~4-5min.
3. **Cache improvements** (commit \`a10cf195\`) — restore-keys for Windows node_modules + new \`packages/*/dist\` cache keyed on source/tsconfig/package.json hashes; \`yarn build:packages\` skipped entirely on cache hit.

## Items to Confirm / Review

- **paths-ignore semantics** — confirmed AND-style. Mixed PRs (code + docs) still run CI.
- **push to main** — unaffected. Every main push runs the full suite.
- **Shard balance** — \`yarn test:e2e --shard=1/2 --list\` reports 179 tests / 25 files; \`--shard=2/2\` reports 175 tests / 20 files. Within ~2%.
- **fail-fast off on e2e** — flake on shard 1 must not mask a real bug on shard 2.
- **Failure artifact naming** — was \`playwright-results\`, now \`playwright-results-shard-{N}\` so the two shards' uploads don't collide.
- **packages/dist cache key** — includes \`runner.os\` + \`matrix.node-version\` because emitted JS can differ. Hash covers \`packages/*/src/**\`, \`packages/*/tsconfig.json\`, \`packages/*/package.json\`, \`config/tsconfig.packages.json\`. Any change in those busts the cache.
- **Cross-job sharing** — e2e (Linux + 22.x) and lint_test (Linux/22.x cell) share the same cache key, so whichever finishes building packages first warms the other.

## Background

Recent chore PRs (e.g. #838 plan-file move) ran ~8min CI for a one-line rename. e2e is the biggest single PR-time consumer; sharding is the cheapest large speedup. Windows lint_test runs 6-8min — restore-keys + dist cache target the two costliest steps (cold yarn install on lockfile change; tsc-ing 25 workspaces).

## Test plan

- [ ] This PR self-tests: it touches \`.github/workflows/\` (NOT in paths-ignore) → CI MUST run
- [ ] Two e2e jobs visible: \`e2e (1)\` and \`e2e (2)\`
- [ ] First run: \`Cache packages/dist\` shows \`Cache miss\`, build:packages runs
- [ ] Subsequent run on same branch (push a no-op or trivial change): \`Cache hit\`, build:packages skipped
- [ ] Next markdown-only chore PR shows \`Skipped\` for Node.js CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)