### PR TITLE
fix: stop flaky e2e notification chat-target test

### DIFF
--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -247,7 +247,26 @@ test.describe("notification permalinks", () => {
 
   for (const scenario of SCENARIOS) {
     test(scenario.description, async ({ page }) => {
-      await mockAllApis(page, { sessions: [] });
+      // Chat-target scenarios reference a specific sessionId. If that
+      // session 404s on the mock, App.vue's route-watcher falls back
+      // to `createNewSession()` (App.vue:362-365), which clobbers the
+      // post-click URL with a fresh sessionId AND drops the
+      // `?result=<uuid>` query the test is asserting on. Pre-populate
+      // the mock so loadSession succeeds and the fallback never runs.
+      const target = scenario.payload.action?.type === "navigate" ? scenario.payload.action.target : undefined;
+      const targetSessionId = target && "sessionId" in target ? target.sessionId : undefined;
+      const sessions = targetSessionId
+        ? [
+            {
+              id: targetSessionId,
+              title: "Notification target session",
+              roleId: "general",
+              startedAt: "2026-04-25T00:00:00Z",
+              updatedAt: "2026-04-25T00:00:00Z",
+            },
+          ]
+        : [];
+      await mockAllApis(page, { sessions });
       await installNotificationStream(page, scenario.payload);
 
       // Start on /todos rather than /. The home redirect lands on


### PR DESCRIPTION
## Summary

The \`chat target with session + result\` scenario in \`e2e/tests/notifications.spec.ts\` has been intermittently failing in CI. Run [24966179019](https://github.com/receptron/mulmoclaude/actions/runs/24966179019) is the proximate trigger; same failure also seen on main commits \`ebe9ecfa\` and \`1e8ad5be\` yesterday.

## Items to Confirm / Review

- The diagnosis: the watcher in \`App.vue:357-368\` calls \`createNewSession()\` when \`loadSession\` 404s on the URL's sessionId, which clobbers the post-click URL.
- The fix is test-only — production behaviour unchanged. (Production has its own arguable bug here: a non-existent session URL silently creates a new session and drops query params. Out of scope; can file separately if wanted.)
- Pre-populating the mock with the scenario's target sessionId only for chat-target scenarios — non-chat scenarios keep the empty-sessions baseline.

## Root cause

The test mocked an empty sessions list. When the click-handler navigated to \`/chat/sess-xyz?result=uuid-abc\`:

1. App.vue's route-param watcher fired → \`loadSession("sess-xyz")\`
2. Mock returned 404 → \`sessionMap\` stayed empty
3. Watcher's fallback \`createNewSession()\` ran → router replaced URL with \`/chat/<fresh-uuid>\`
4. Test asserted URL, sometimes catching step 1's intent, sometimes step 3's clobber

## Test plan

- [x] Local: \`yarn test:e2e e2e/tests/notifications.spec.ts\` — 10/10 pass
- [x] Local: \`yarn test:e2e --grep "chat target with session" --repeat-each 3\` — 3/3 pass
- [x] \`yarn lint\` 0 errors
- [x] \`yarn typecheck\` clean
- [x] \`yarn test\` 3178/3178 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)