### PR TITLE
chore(ci): e2e shard + Windows cache wins

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -48,15 +48,32 @@ jobs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
     # Windows: cache node_modules directly (faster than yarn cache
-    # because it skips the tar extract → yarn install file-write cycle)
+    # because it skips the tar extract → yarn install file-write cycle).
+    # restore-keys lets a yarn.lock change land on a warm node_modules
+    # tree (yarn install fills in the diff) instead of a cold cache.
     - name: Cache node_modules (Windows)
       if: runner.os == 'Windows'
       uses: actions/cache@v4
       with:
         path: node_modules
         key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          win-node-modules-${{ matrix.node-version }}-
     - run: yarn install --frozen-lockfile --network-timeout 120000
+    # Cache the output of `yarn build:packages` keyed on the source
+    # files it consumes. The 25 @mulmobridge/* workspaces all run tsc
+    # serially / pairwise — slowest non-install step on Windows. When
+    # no package source / tsconfig / package.json changed, skip the
+    # build step entirely. Cache key includes runner.os and node
+    # version because emitted JS can differ across them.
+    - name: Cache packages/dist
+      id: pkg-dist-cache
+      uses: actions/cache@v4
+      with:
+        path: packages/*/dist
+        key: pkg-dist-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'config/tsconfig.packages.json') }}
     - name: Build internal packages (required before typecheck)
+      if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
       run: yarn build:packages
     - run: yarn run typecheck
     - run: yarn run lint
@@ -83,7 +100,17 @@ jobs:
         node-version: 22.x
         cache: 'yarn'
     - run: yarn install --frozen-lockfile --network-timeout 120000
+    # Same packages/dist cache as lint_test — shares the cache key
+    # across both jobs on ubuntu-latest + node 22.x, so whichever
+    # finishes building first warms the cache for the other.
+    - name: Cache packages/dist
+      id: pkg-dist-cache
+      uses: actions/cache@v4
+      with:
+        path: packages/*/dist
+        key: pkg-dist-${{ runner.os }}-22.x-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'config/tsconfig.packages.json') }}
     - name: Build internal packages
+      if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
       run: yarn build:packages
     - name: Install Playwright browsers
       run: npx playwright install chromium webkit --with-deps

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -66,6 +66,15 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Split the 268-test e2e suite across 2 parallel runners via
+    # Playwright's --shard. Wall clock drops from ~8 min to ~4-5 min
+    # at the cost of running twice the runner-minutes (no impact for
+    # OSS / free tier). fail-fast off so a flake on shard 1 doesn't
+    # mask a real failure on shard 2.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
     - uses: actions/checkout@v6
     - name: Use Node.js 22.x
@@ -78,12 +87,12 @@ jobs:
       run: yarn build:packages
     - name: Install Playwright browsers
       run: npx playwright install chromium webkit --with-deps
-    - name: Run E2E tests
-      run: yarn test:e2e
+    - name: Run E2E tests (shard ${{ matrix.shard }}/2)
+      run: yarn test:e2e --shard=${{ matrix.shard }}/2
     - name: Upload test results on failure
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: playwright-results
+        name: playwright-results-shard-${{ matrix.shard }}
         path: test-results/
         retention-days: 7


### PR DESCRIPTION
## Summary

Two CI workflow tweaks. Followup to #862 (which only landed the paths-ignore part — these commits were pushed to a stale branch after #862 merged, recovered to a fresh branch here).

1. **e2e shard** — split the 268-test e2e suite across 2 parallel runners via Playwright \`--shard=N/2\`. Wall clock 8min → ~4-5min.
2. **Cache improvements** — restore-keys for the Windows node_modules cache + new \`packages/*/dist\` cache keyed on source/tsconfig/package.json hashes; \`yarn build:packages\` skipped entirely on cache hit.

## Items to Confirm / Review

- **Shard balance** — \`yarn test:e2e --shard=1/2 --list\` reports 179 tests / 25 files; \`--shard=2/2\` reports 175 tests / 20 files. Within ~2%.
- **fail-fast off on e2e** — flake on shard 1 must not mask a real bug on shard 2.
- **Failure artifact naming** — was \`playwright-results\`, now \`playwright-results-shard-{N}\` so the two shards' uploads don't collide.
- **packages/dist cache key** — includes \`runner.os\` + \`matrix.node-version\` because emitted JS can differ. Hash covers \`packages/*/src/**\`, \`packages/*/tsconfig.json\`, \`packages/*/package.json\`, \`config/tsconfig.packages.json\`. Any change in those busts the cache.
- **Cross-job sharing** — e2e (Linux + 22.x) and lint_test (Linux/22.x cell) share the same cache key, so whichever finishes building packages first warms the other.

## Background

- e2e is the biggest single PR-time consumer; sharding is the cheapest large speedup.
- Windows lint_test runs 6-8min — restore-keys + dist cache target the two costliest steps (cold yarn install on lockfile change; tsc-ing 25 workspaces).

## Test plan

- [ ] This PR self-tests: it touches \`.github/workflows/\` (NOT in paths-ignore from #862) → CI MUST run
- [ ] Two e2e jobs visible: \`e2e (1)\` and \`e2e (2)\`
- [ ] First run: \`Cache packages/dist\` shows \`Cache miss\`, build:packages runs
- [ ] Subsequent run on same branch: \`Cache hit\`, build:packages skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)