### PR TITLE
release: v0.5.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+---
+
+## [0.5.1] - 2026-04-27
+
 ### Fixed
 
-- **MCP catalog Notion entry** — switched from the legacy `OPENAPI_MCP_HEADERS` JSON-string form (with a hardcoded `Notion-Version: 2022-06-28`, three years stale) to the official `NOTION_TOKEN` env var, which the upstream README marks as recommended. Users who installed Notion via the catalog before this change still work, but their `~/mulmoclaude/config/mcp.json` keeps the old shape — re-install from Settings → MCP to pick up the new env shape and access the 2025-09-03 API features (data sources, 7 new tools).
+- **MCP catalog Notion entry** — switched from the legacy `OPENAPI_MCP_HEADERS` JSON-string form (with a hardcoded `Notion-Version: 2022-06-28`, three years stale) to the official `NOTION_TOKEN` env var, which the upstream README marks as recommended. Users who installed Notion via the catalog before this change still work, but their `~/mulmoclaude/config/mcp.json` keeps the old shape — re-install from Settings → MCP to pick up the new env shape and access the 2025-09-03 API features (data sources, 7 new tools). (#852 / #860)
+- **Wiki / sources help text**: align on-disk YAML key names so the help-file driven hints match the keys the agent emits (#855 / #861).
+- **E2E**: stop flakiness in the chat-target notification test (#863); update Notion catalog test for the new `NOTION_TOKEN` env shape.
+
+### Changed
+
+- **CI**: shard e2e across 2 parallel runners; add `restore-keys` + `packages/dist` cache for Windows speedup; skip `lint_test` + `e2e` on docs / plans / markdown-only PRs (#862, #864).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -104,7 +104,7 @@ Options:
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.5.0");
+  console.log("mulmoclaude 0.5.1");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Patch bump `0.5.0` → `0.5.1` in root `package.json`, `packages/mulmoclaude/package.json`, and `bin/mulmoclaude.js`.
- Add the `0.5.1` entry to `docs/CHANGELOG.md`.
- `mulmoclaude@0.5.1` already published to npm (`npm view mulmoclaude version` → `0.5.1`).

## Items to Confirm / Review

- [ ] CHANGELOG accuracy — patches in this cycle are: Notion MCP catalog → `NOTION_TOKEN` env, Wiki/sources YAML key alignment, CI e2e shard + cache + docs-only skip, flaky chat-target notification test fix.

## What changed since v0.5.0

| PR | Change |
|---|---|
| #852 / #860 | Notion MCP catalog entry uses `NOTION_TOKEN` (was legacy `OPENAPI_MCP_HEADERS` JSON-string with stale `2022-06-28` API version) |
| #855 / #861 | Wiki / sources help-file YAML key names aligned with what the agent emits |
| #862 | CI: skip `lint_test` + `e2e` on docs/plans/markdown-only PRs |
| #863 | Stop flakiness in chat-target notification e2e test |
| #864 | CI: shard e2e across 2 parallel runners + add `restore-keys` and `packages/dist` cache for Windows speedup |

## Pre-publish smoke (already passed locally)

| Stage | Result |
|---|---|
| §0 npm whoami | `isamu` ✓ |
| §0 CI smoke on main | green ✓ |
| §1 deps audit | OK |
| §2 workspace drift | OK |
| §3 build | clean |
| §4 tarball boot | HTTP 200 ✓ |
| npm publish | `mulmoclaude@0.5.1` published ✓ |

## Test plan

- [ ] After this merges, run `/release-app 0.5.1` to create the `v0.5.1` git tag on `main` + GitHub Release.
- [ ] Spot-check `npx mulmoclaude@0.5.1 --version` from a fresh shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Notion MCP catalog compatibility issues
  * Fixed Wiki/sources help-text YAML key alignment
  * Addressed E2E chat-target notification test instability
  * Updated Notion catalog test configurations

* **Chores**
  * Version bumped to 0.5.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->