### PR TITLE
feat(mcp-catalog): community MCP server expansion (Apple / Google / GitHub / Linear / Spotify / YouTube)

### DIFF
--- a/plans/feat-mcp-catalog-community-expansion.md
+++ b/plans/feat-mcp-catalog-community-expansion.md
@@ -1,0 +1,70 @@
+# MCP catalog — community expansion (Phase 5+ of #823)
+
+## User prompt
+
+> oauth系、gmailとかgoogle カレンダーとか使えると良いね。でもこれってきちんと使うには審査必要だから面倒？
+> あー、その楽な方で実装してほしい。community MCP serverでできるのひととおりサポートできるとよいね
+> はい。一気に、１つのPRで。ただし１回目のcommitでPRをつくって、そのPRにつんでいく
+
+→ "BYO OAuth credentials + community MCP server" 路線で catalog を一気に拡張。PR は 1 本、phase ごとにコミットを積む。
+
+## Strategy: BYO credentials, no proprietary OAuth verification
+
+公式 OAuth verification（Google CASA audit など）は restricted scope だと数ヶ月+$$$。
+local-first MulmoClaude は **ユーザが自分の OAuth client を発行 → catalog 経由でトークンを貼る** 方式が現実的:
+
+- 審査責任は community MCP server 側（既に通っている / そもそも client-side 動作）
+- catalog 側は entry 定義 + setupGuideUrl + secret field の提供のみ
+- ユーザは GCP コンソール等で 1 度だけ token を発行する
+
+既存 catalog のパターン（Notion / Slack / Google Maps）と同じ形を踏襲。
+
+## Phases (commits on a single PR)
+
+| Phase | 内容 | entries |
+|---|---|---|
+| A | Apple Native アプリ束 (macOS only, no creds) | 1 |
+| B | Google OAuth: Gmail / Calendar / Drive | 3 |
+| C | Token 系: GitHub PAT / Linear | 2 |
+| D | その他: Spotify / YouTube transcript | 2 |
+
+合計 **8 entries** 追加。
+
+## Per-entry checklist
+
+各 entry で:
+
+1. `src/config/mcpCatalog.ts` に `McpCatalogEntry` を追加
+   - `id` / `displayName` / `description` / `audience` / `upstreamUrl` / `setupGuideUrl` / `spec` / `configSchema` / `riskLevel`
+   - 既存パターンを踏襲（Notion / Slack 参照）
+2. **i18n 8 ロケール** lockstep 更新（CLAUDE.md ルール）
+   - `displayName`、`description`
+   - 各 configSchema field の `label` + `help`
+   - キー順を全ロケール一致させる
+3. **community package は best-effort** — reviewer に PR 上で pin 確認をお願いするコメント
+4. リスク判定: low (no auth) / medium (token, scoped) / high (full account access)
+
+## Package candidates
+
+| Phase | id | package (best-effort) | env / config |
+|---|---|---|---|
+| A | `apple-native` | `apple-mcp` | (none, AppleScript) |
+| B | `gmail` | community Gmail MCP（要 reviewer pin） | OAuth credentials JSON path |
+| B | `google-calendar` | community GCal MCP | OAuth credentials JSON path |
+| B | `google-drive` | `@modelcontextprotocol/server-gdrive` | OAuth credentials JSON path |
+| C | `github` | `@modelcontextprotocol/server-github` | `GITHUB_PERSONAL_ACCESS_TOKEN` |
+| C | `linear` | community Linear MCP | `LINEAR_API_KEY` |
+| D | `spotify` | community Spotify MCP | client ID/secret |
+| D | `youtube-transcript` | `@anaisbetts/mcp-youtube` 等 | (none) |
+
+## Out of scope
+
+- 個別 Apple アプリへの分割（Reminders だけ等の個別 entry）— 1 bundle で先行、需要があれば後続 PR で split
+- OAuth flow 自体の埋め込み UI — token の発行は手動、catalog は token を受け取るのみ
+- Calendar/Email の verified app 化 — 上記の通り audit コスト次第で別議論
+
+## Refs
+
+- 上位 issue: #823（umbrella、close せず継続）
+- 既存 catalog: #825 (Phase 1)、#852 (Phase 2)
+- 直近 follow-up: #860 (Notion env var fix)

--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -257,6 +257,33 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
 
   // Weather forecast / current conditions via Open-Meteo. Open-Meteo
   // is keyless for non-commercial use, so this entry is config-free.
+  // Apple native apps (macOS only) — bundles Reminders / Calendar /
+  // Notes / Mail / Maps / Messages via AppleScript bridges. No
+  // credentials needed since it talks to the local system apps; the
+  // package no-ops on Linux/Windows. Bundle entry keeps install simple;
+  // if per-app granularity is wanted later, split into separate ids.
+  //
+  // TODO(reviewer): pin the most-active bundle package — as of 2026-04
+  // candidates include `apple-mcp` (Dhravya) and per-app variants like
+  // `mcp-server-apple-reminders` / `apple-notes-mcp`.
+  {
+    id: "apple-native",
+    displayName: "settingsMcpTab.catalog.entry.appleNative.displayName",
+    description: "settingsMcpTab.catalog.entry.appleNative.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/Dhravya/apple-mcp",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@dhravya/apple-mcp"],
+    },
+    configSchema: [],
+    // Reads + writes Reminders / Notes / Calendar etc. — flagged
+    // medium because the agent can modify the user's data, even
+    // though no auth secret leaves the box.
+    riskLevel: "medium",
+  },
+
   // TODO(reviewer): pick the most-active community package — as of
   // 2026-04 candidates include `mcp-server-open-meteo` and
   // `@cloud-rocket/mcp-server-open-meteo`.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -287,6 +287,10 @@ const deMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Native Apple-Apps (macOS)",
+          description: "Liest und schreibt Erinnerungen, Kalender, Notizen, Mail und Karten via AppleScript. Nur macOS — keine Zugangsdaten nötig.",
+        },
         weatherOpenMeteo: {
           displayName: "Wetter (Open-Meteo)",
           description: "Kostenlose Wettervorhersagen und aktuelle Bedingungen weltweit — ohne API-Key.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -307,6 +307,10 @@ const enMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apple Native Apps (macOS)",
+          description: "Read and write Reminders, Calendar, Notes, Mail and Maps via AppleScript. macOS only — no credentials needed.",
+        },
         weatherOpenMeteo: {
           displayName: "Weather (Open-Meteo)",
           description: "Free weather forecasts and current conditions worldwide — no API key needed.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -293,6 +293,10 @@ const esMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apps nativas de Apple (macOS)",
+          description: "Lee y escribe Recordatorios, Calendario, Notas, Mail y Mapas vía AppleScript. Solo macOS — sin credenciales.",
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Pronósticos meteorológicos gratuitos y condiciones actuales en todo el mundo — sin clave API.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -287,6 +287,10 @@ const frMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apps natives Apple (macOS)",
+          description: "Lit et écrit Rappels, Calendrier, Notes, Mail et Plans via AppleScript. macOS uniquement — sans identifiants.",
+        },
         weatherOpenMeteo: {
           displayName: "Météo (Open-Meteo)",
           description: "Prévisions météo gratuites et conditions actuelles dans le monde entier — sans clé d'API.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -290,6 +290,10 @@ const jaMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apple ネイティブアプリ（macOS）",
+          description: "AppleScript 経由で リマインダー / カレンダー / メモ / メール / マップ を読み書き。macOS 限定 — 認証情報不要。",
+        },
         weatherOpenMeteo: {
           displayName: "天気予報（Open-Meteo）",
           description: "世界各地の天気予報と現在の気象情報 — API キー不要で無料利用可能。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -291,6 +291,10 @@ const koMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apple 네이티브 앱 (macOS)",
+          description: "AppleScript로 미리 알림 / 캘린더 / 메모 / 메일 / 지도 읽기·쓰기. macOS 전용 — 자격 증명 불필요.",
+        },
         weatherOpenMeteo: {
           displayName: "날씨 (Open-Meteo)",
           description: "전 세계 무료 일기예보와 현재 기상 정보 — API 키 불필요.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -286,6 +286,10 @@ const ptBRMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apps nativos da Apple (macOS)",
+          description: "Lê e escreve em Lembretes, Calendário, Notas, Mail e Mapas via AppleScript. Apenas macOS — sem credenciais.",
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Previsão do tempo gratuita e condições atuais no mundo todo — sem chave de API.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -287,6 +287,10 @@ const zhMessages = {
             },
           },
         },
+        appleNative: {
+          displayName: "Apple 原生应用（macOS）",
+          description: "通过 AppleScript 读写 提醒事项 / 日历 / 备忘录 / 邮件 / 地图。仅限 macOS — 无需凭证。",
+        },
         weatherOpenMeteo: {
           displayName: "天气（Open-Meteo）",
           description: "全球免费天气预报和当前气象 — 无需 API 密钥。",


### PR DESCRIPTION
## Summary

Adds 8 community MCP server entries to the catalog over 4 phases (Apple Native / Google OAuth / Token-based / Other popular). All use BYO-credentials pattern — no Google CASA verification etc. needed since the catalog just collects the user's own tokens.

This PR will be built up across multiple commits — Phase A lands first, B/C/D push as additional commits to this branch.

## Items to Confirm / Review

- **Package pinning** — every new entry uses TODO(reviewer) for the npm package, mirroring the existing pattern (`weatherOpenMeteo`). Reviewer should verify and pin the most-active community variant before merge.
- **Audience grouping** — most entries land in `general`; developer-only ones (e.g. Linear) may move to `developer` per Phase 3 of #823.
- **i18n lockstep** — every entry adds keys to all 8 locales in the same commit (CLAUDE.md rule).
- **OAuth verification trade-off** — see plan file. We deliberately skip Google's restricted-scope verification by relying on community MCP servers + user-supplied OAuth tokens.

## User Prompt

> oauth系、gmailとかgoogle カレンダーとか使えると良いね。でもこれってきちんと使うには審査必要だから面倒？
>
> あー、その楽な方で実装してほしい。community MCP serverでできるのひととおりサポートできるとよいね
>
> はい。一気に、１つのPRで。ただし１回目のcommitでPRをつくって、そのPRにつんでいく

## Phase plan

| Phase | Status | Entries |
|---|---|---|
| A — Apple Native bundle | ✅ this commit | apple-native (macOS Reminders / Calendar / Notes / Mail / Maps) |
| B — Google OAuth | ⏳ next commit | gmail, google-calendar, google-drive |
| C — Token-based | ⏳ pending | github (PAT), linear |
| D — Other popular | ⏳ pending | spotify, youtube-transcript |

Plan doc: `plans/feat-mcp-catalog-community-expansion.md`

## Refs

- #823 — umbrella (stays open for ongoing long-list expansion)
- #825 / #852 — Phase 1 / Phase 2 (catalog UI + per-server config form)
- #860 — recent Notion env-var fix

## Test plan

- [x] `yarn typecheck` clean (Phase A)
- [x] `yarn lint` 0 errors (Phase A)
- [ ] Each entry renders in Settings → MCP catalog with correct displayName / description
- [ ] Install + run smoke for at least one entry per phase
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Apple-native MCP catalog entry enabling access to macOS system apps (Reminders, Calendar, Notes, Mail, Maps) via AppleScript without credential requirements
  * Extended multi-language support across all supported locales for the new catalog integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->