### PR TITLE
feat(mcp-catalog): Gmail / Google Calendar / Drive (Phase B)

### DIFF
--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -284,6 +284,115 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     riskLevel: "medium",
   },
 
+  // Gmail read / send / label via a community MCP server. BYO OAuth
+  // credentials: the user creates an OAuth client in their own Google
+  // Cloud project, downloads `credentials.json`, and points the entry
+  // at it. Avoids the verified-app / CASA-audit cost — see plan
+  // `plans/feat-mcp-catalog-community-expansion.md`.
+  //
+  // TODO(reviewer): pin the most-active Gmail MCP — as of 2026-04
+  // `@gongrzhe/server-gmail-autoauth-mcp` is widely used; alternatives
+  // include `mcp-gmail` and Smithery-hosted variants.
+  {
+    id: "gmail",
+    displayName: "settingsMcpTab.catalog.entry.gmail.displayName",
+    description: "settingsMcpTab.catalog.entry.gmail.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/GongRzhe/Gmail-MCP-Server",
+    setupGuideUrl: "https://developers.google.com/workspace/guides/create-credentials#desktop-app",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@gongrzhe/server-gmail-autoauth-mcp"],
+      env: {
+        GMAIL_OAUTH_PATH: "${GMAIL_OAUTH_PATH}",
+      },
+    },
+    configSchema: [
+      {
+        key: "GMAIL_OAUTH_PATH",
+        label: "settingsMcpTab.catalog.entry.gmail.field.credentials.label",
+        kind: "path",
+        placeholder: "~/.gmail-mcp/credentials.json",
+        required: true,
+        helpUrl: "https://console.cloud.google.com/apis/credentials",
+        helpText: "settingsMcpTab.catalog.entry.gmail.field.credentials.help",
+      },
+    ],
+    // Full mailbox access if the OAuth scope is broad — high.
+    riskLevel: "high",
+  },
+
+  // Google Calendar via a community MCP server. Same BYO-credentials
+  // pattern as Gmail above.
+  //
+  // TODO(reviewer): pin the most-active GCal MCP — as of 2026-04
+  // `@cocal/google-calendar-mcp` is a candidate.
+  {
+    id: "google-calendar",
+    displayName: "settingsMcpTab.catalog.entry.googleCalendar.displayName",
+    description: "settingsMcpTab.catalog.entry.googleCalendar.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/nspady/google-calendar-mcp",
+    setupGuideUrl: "https://developers.google.com/workspace/guides/create-credentials#desktop-app",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@cocal/google-calendar-mcp"],
+      env: {
+        GOOGLE_OAUTH_CREDENTIALS: "${GOOGLE_OAUTH_CREDENTIALS}",
+      },
+    },
+    configSchema: [
+      {
+        key: "GOOGLE_OAUTH_CREDENTIALS",
+        label: "settingsMcpTab.catalog.entry.googleCalendar.field.credentials.label",
+        kind: "path",
+        placeholder: "~/.gcal-mcp/credentials.json",
+        required: true,
+        helpUrl: "https://console.cloud.google.com/apis/credentials",
+        helpText: "settingsMcpTab.catalog.entry.googleCalendar.field.credentials.help",
+      },
+    ],
+    riskLevel: "medium",
+  },
+
+  // Google Drive via the official-style MCP server. Token-cached
+  // OAuth — the package writes a refresh token next to the
+  // credentials file on first auth.
+  //
+  // TODO(reviewer): the upstream `@modelcontextprotocol/server-gdrive`
+  // was archived; double-check whether to point at the maintained
+  // fork or another community package.
+  {
+    id: "google-drive",
+    displayName: "settingsMcpTab.catalog.entry.googleDrive.displayName",
+    description: "settingsMcpTab.catalog.entry.googleDrive.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gdrive",
+    setupGuideUrl: "https://developers.google.com/workspace/guides/create-credentials#desktop-app",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-gdrive"],
+      env: {
+        GDRIVE_CREDENTIALS_PATH: "${GDRIVE_CREDENTIALS_PATH}",
+      },
+    },
+    configSchema: [
+      {
+        key: "GDRIVE_CREDENTIALS_PATH",
+        label: "settingsMcpTab.catalog.entry.googleDrive.field.credentials.label",
+        kind: "path",
+        placeholder: "~/.gdrive-mcp/credentials.json",
+        required: true,
+        helpUrl: "https://console.cloud.google.com/apis/credentials",
+        helpText: "settingsMcpTab.catalog.entry.googleDrive.field.credentials.help",
+      },
+    ],
+    riskLevel: "medium",
+  },
+
   // TODO(reviewer): pick the most-active community package — as of
   // 2026-04 candidates include `mcp-server-open-meteo` and
   // `@cloud-rocket/mcp-server-open-meteo`.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -291,6 +291,37 @@ const deMessages = {
           displayName: "Native Apple-Apps (macOS)",
           description: "Liest und schreibt Erinnerungen, Kalender, Notizen, Mail und Karten via AppleScript. Nur macOS — keine Zugangsdaten nötig.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description:
+            "Liest, sendet und beschriftet dein Gmail. Nutzt einen Google-OAuth-Client, den du selbst in deinem eigenen Google-Cloud-Projekt erstellst (keine App-Verifizierung nötig).",
+          field: {
+            credentials: {
+              label: "Pfad zu credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth-Client-ID (Desktop app). Lade credentials.json herunter und füge den absoluten Pfad ein.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google Kalender",
+          description: "Liest und erstellt Termine im Google Kalender. Gleiches BYO-credentials.json-Muster wie Gmail.",
+          field: {
+            credentials: {
+              label: "Pfad zu credentials.json",
+              help: "Verwende denselben Google-Cloud-OAuth-Client wie Gmail, oder erstelle einen separaten nur für Calendar.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google Drive",
+          description: "Sucht und liest Google-Drive-Dateien. BYO Google-OAuth-Zugangsdaten — Token wird lokal neben der Datei zwischengespeichert.",
+          field: {
+            credentials: {
+              label: "Pfad zu credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth-Client-ID (Desktop app). Aktiviere die Google-Drive-API im selben Projekt.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Wetter (Open-Meteo)",
           description: "Kostenlose Wettervorhersagen und aktuelle Bedingungen weltweit — ohne API-Key.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -311,6 +311,36 @@ const enMessages = {
           displayName: "Apple Native Apps (macOS)",
           description: "Read and write Reminders, Calendar, Notes, Mail and Maps via AppleScript. macOS only — no credentials needed.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description: "Read, send, and label your Gmail. Uses a Google OAuth client you create in your own Google Cloud project (no app verification needed).",
+          field: {
+            credentials: {
+              label: "Path to credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth client ID (Desktop app). Download credentials.json and paste its absolute path.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google Calendar",
+          description: "Read and create Google Calendar events. Same BYO Google OAuth credentials.json pattern as Gmail.",
+          field: {
+            credentials: {
+              label: "Path to credentials.json",
+              help: "Same Google Cloud OAuth client as Gmail. Reuse the file or create a separate Calendar-scoped one.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google Drive",
+          description: "Search and read Google Drive files. BYO Google OAuth credentials — token is cached locally next to the file.",
+          field: {
+            credentials: {
+              label: "Path to credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth client ID (Desktop app). Enable the Google Drive API in the same project.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Weather (Open-Meteo)",
           description: "Free weather forecasts and current conditions worldwide — no API key needed.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -297,6 +297,37 @@ const esMessages = {
           displayName: "Apps nativas de Apple (macOS)",
           description: "Lee y escribe Recordatorios, Calendario, Notas, Mail y Mapas vía AppleScript. Solo macOS — sin credenciales.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description:
+            "Lee, envía y etiqueta tu Gmail. Usa un cliente OAuth de Google que tú mismo creas en tu propio proyecto de Google Cloud (sin verificación de app).",
+          field: {
+            credentials: {
+              label: "Ruta a credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID de cliente OAuth (Desktop app). Descarga credentials.json y pega su ruta absoluta.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google Calendar",
+          description: "Lee y crea eventos en Google Calendar. Mismo patrón BYO credentials.json que Gmail.",
+          field: {
+            credentials: {
+              label: "Ruta a credentials.json",
+              help: "Reutiliza el mismo cliente OAuth de Google Cloud que Gmail, o crea uno separado para Calendar.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google Drive",
+          description: "Busca y lee archivos de Google Drive. BYO credenciales OAuth de Google — el token se guarda localmente junto al archivo.",
+          field: {
+            credentials: {
+              label: "Ruta a credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID de cliente OAuth (Desktop app). Habilita la API de Google Drive en el mismo proyecto.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Pronósticos meteorológicos gratuitos y condiciones actuales en todo el mundo — sin clave API.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -291,6 +291,37 @@ const frMessages = {
           displayName: "Apps natives Apple (macOS)",
           description: "Lit et écrit Rappels, Calendrier, Notes, Mail et Plans via AppleScript. macOS uniquement — sans identifiants.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description:
+            "Lit, envoie et étiquette votre Gmail. Utilise un client OAuth Google que vous créez dans votre propre projet Google Cloud (sans vérification d'app).",
+          field: {
+            credentials: {
+              label: "Chemin vers credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID client OAuth (Desktop app). Téléchargez credentials.json et collez son chemin absolu.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google Agenda",
+          description: "Lit et crée des événements Google Agenda. Même modèle BYO credentials.json que Gmail.",
+          field: {
+            credentials: {
+              label: "Chemin vers credentials.json",
+              help: "Réutilisez le même client OAuth Google Cloud que Gmail, ou créez-en un séparé pour le Calendar.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google Drive",
+          description: "Recherche et lit les fichiers Google Drive. BYO identifiants OAuth Google — le jeton est mis en cache localement à côté du fichier.",
+          field: {
+            credentials: {
+              label: "Chemin vers credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID client OAuth (Desktop app). Activez l'API Google Drive dans le même projet.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Météo (Open-Meteo)",
           description: "Prévisions météo gratuites et conditions actuelles dans le monde entier — sans clé d'API.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -294,6 +294,36 @@ const jaMessages = {
           displayName: "Apple ネイティブアプリ（macOS）",
           description: "AppleScript 経由で リマインダー / カレンダー / メモ / メール / マップ を読み書き。macOS 限定 — 認証情報不要。",
         },
+        gmail: {
+          displayName: "Gmail",
+          description: "Gmail の読み取り・送信・ラベル付け。自身の Google Cloud プロジェクトで OAuth クライアントを発行して利用（アプリ審査不要）。",
+          field: {
+            credentials: {
+              label: "credentials.json のパス",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth クライアント ID（Desktop app）。credentials.json をダウンロードして絶対パスを貼ってください。",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google カレンダー",
+          description: "Google カレンダーの読み取り・予定作成。Gmail と同じ BYO 方式の credentials.json を使います。",
+          field: {
+            credentials: {
+              label: "credentials.json のパス",
+              help: "Gmail と同じ Google Cloud OAuth クライアントを使い回すか、Calendar 専用に別途作成してください。",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google ドライブ",
+          description: "Google ドライブのファイル検索・読み取り。BYO Google OAuth credentials を使い、リフレッシュトークンはローカルに保存されます。",
+          field: {
+            credentials: {
+              label: "credentials.json のパス",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth クライアント ID（Desktop app）。同じプロジェクトで Google Drive API を有効化してください。",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "天気予報（Open-Meteo）",
           description: "世界各地の天気予報と現在の気象情報 — API キー不要で無料利用可能。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -295,6 +295,36 @@ const koMessages = {
           displayName: "Apple 네이티브 앱 (macOS)",
           description: "AppleScript로 미리 알림 / 캘린더 / 메모 / 메일 / 지도 읽기·쓰기. macOS 전용 — 자격 증명 불필요.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description: "Gmail 읽기·전송·라벨 지정. 사용자 본인의 Google Cloud 프로젝트에서 발급한 OAuth 클라이언트를 사용 (앱 검수 불필요).",
+          field: {
+            credentials: {
+              label: "credentials.json 경로",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth 클라이언트 ID (Desktop app). credentials.json을 다운로드하여 절대 경로를 입력하세요.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google 캘린더",
+          description: "Google 캘린더 일정 읽기·생성. Gmail과 동일한 BYO credentials.json 방식.",
+          field: {
+            credentials: {
+              label: "credentials.json 경로",
+              help: "Gmail과 동일한 Google Cloud OAuth 클라이언트를 재사용하거나, 캘린더 전용으로 별도 생성하세요.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google 드라이브",
+          description: "Google 드라이브 파일 검색·읽기. BYO Google OAuth 자격 증명 — 토큰은 로컬에 캐시됩니다.",
+          field: {
+            credentials: {
+              label: "credentials.json 경로",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth 클라이언트 ID (Desktop app). 동일 프로젝트에서 Google Drive API를 활성화하세요.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "날씨 (Open-Meteo)",
           description: "전 세계 무료 일기예보와 현재 기상 정보 — API 키 불필요.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -290,6 +290,37 @@ const ptBRMessages = {
           displayName: "Apps nativos da Apple (macOS)",
           description: "Lê e escreve em Lembretes, Calendário, Notas, Mail e Mapas via AppleScript. Apenas macOS — sem credenciais.",
         },
+        gmail: {
+          displayName: "Gmail",
+          description:
+            "Lê, envia e etiqueta seu Gmail. Usa um cliente OAuth do Google criado por você no seu próprio projeto do Google Cloud (sem verificação de app).",
+          field: {
+            credentials: {
+              label: "Caminho para credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID do cliente OAuth (Desktop app). Baixe credentials.json e cole o caminho absoluto.",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google Agenda",
+          description: "Lê e cria eventos no Google Agenda. Mesmo padrão BYO credentials.json do Gmail.",
+          field: {
+            credentials: {
+              label: "Caminho para credentials.json",
+              help: "Reutilize o mesmo cliente OAuth do Google Cloud usado no Gmail, ou crie um separado para o Calendar.",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google Drive",
+          description: "Pesquisa e lê arquivos do Google Drive. BYO credenciais OAuth do Google — o token é armazenado localmente ao lado do arquivo.",
+          field: {
+            credentials: {
+              label: "Caminho para credentials.json",
+              help: "Google Cloud Console → APIs & Services → Credentials → ID do cliente OAuth (Desktop app). Habilite a API do Google Drive no mesmo projeto.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Previsão do tempo gratuita e condições atuais no mundo todo — sem chave de API.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -291,6 +291,36 @@ const zhMessages = {
           displayName: "Apple 原生应用（macOS）",
           description: "通过 AppleScript 读写 提醒事项 / 日历 / 备忘录 / 邮件 / 地图。仅限 macOS — 无需凭证。",
         },
+        gmail: {
+          displayName: "Gmail",
+          description: "读取、发送和标记 Gmail 邮件。使用您自己 Google Cloud 项目中创建的 OAuth 客户端（无需应用审核）。",
+          field: {
+            credentials: {
+              label: "credentials.json 路径",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth 客户端 ID（Desktop app）。下载 credentials.json 并粘贴其绝对路径。",
+            },
+          },
+        },
+        googleCalendar: {
+          displayName: "Google 日历",
+          description: "读取和创建 Google 日历事件。与 Gmail 相同的 BYO credentials.json 模式。",
+          field: {
+            credentials: {
+              label: "credentials.json 路径",
+              help: "可复用与 Gmail 相同的 Google Cloud OAuth 客户端，或单独创建一个仅供 Calendar 使用的客户端。",
+            },
+          },
+        },
+        googleDrive: {
+          displayName: "Google 云端硬盘",
+          description: "搜索和读取 Google 云端硬盘文件。BYO Google OAuth 凭证 — 令牌缓存在本地凭证文件旁。",
+          field: {
+            credentials: {
+              label: "credentials.json 路径",
+              help: "Google Cloud Console → APIs & Services → Credentials → OAuth 客户端 ID（Desktop app）。在同一项目中启用 Google Drive API。",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "天气（Open-Meteo）",
           description: "全球免费天气预报和当前气象 — 无需 API 密钥。",


### PR DESCRIPTION
## Summary

Adds three Google-service entries to the MCP catalog using the **BYO OAuth credentials** pattern — the user creates their own OAuth client in GCP, downloads `credentials.json`, and pastes its path. No verified-app audit needed on our side.

Phase A (Apple Native) shipped via #867 already. Phase C (GitHub PAT / Linear) and Phase D (Spotify / YouTube transcript) will land in subsequent PRs on their own branches.

## Items to Confirm / Review

- **Package pins** — every new entry uses TODO(reviewer); please verify and pin the most-active community variant before merge:
  - Gmail: `@gongrzhe/server-gmail-autoauth-mcp`
  - Google Calendar: `@cocal/google-calendar-mcp`
  - Google Drive: `@modelcontextprotocol/server-gdrive` ⚠️ upstream archived — may need a maintained fork
- **Field shape** — single `credentials` path field per entry. Some packages also need a separate `token.json` cache path; if so, the package writes it next to credentials.json by default, so no extra field is needed at install.
- **Risk levels** — Gmail flagged `high` (full mailbox), Calendar `medium`, Drive `medium`.

## User Prompt

> oauth系、gmailとかgoogle カレンダーとか使えると良いね。でもこれってきちんと使うには審査必要だから面倒？
>
> あー、その楽な方で実装してほしい。community MCP serverでできるのひととおりサポートできるとよいね

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` 0 errors
- [x] \`yarn format\` applied
- [ ] Each entry renders in Settings → MCP catalog with correct displayName / description
- [ ] Install + smoke-test at least one Google entry end-to-end (OAuth flow on first use)
- [ ] CI green

## Refs

- #823 — umbrella (open, ongoing long-list expansion)
- #867 — Phase A (Apple Native bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)