### PR TITLE
feat(mcp-catalog): GitHub PAT / Linear API key (Phase C)

### DIFF
--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -393,6 +393,80 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     riskLevel: "medium",
   },
 
+  // GitHub repos / issues / PRs / search via the official MCP server.
+  // Auth is a single Personal Access Token (classic or fine-grained).
+  // Token scope dictates the risk: a `repo` scope can write to any
+  // repository the user has access to, so we flag this medium-to-high
+  // and tell users to scope down in the help text.
+  //
+  // TODO(reviewer): pin version. The package has been actively
+  // maintained as of 2026-04.
+  {
+    id: "github",
+    displayName: "settingsMcpTab.catalog.entry.github.displayName",
+    description: "settingsMcpTab.catalog.entry.github.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
+    setupGuideUrl: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-github"],
+      env: {
+        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+      },
+    },
+    configSchema: [
+      {
+        key: "GITHUB_PERSONAL_ACCESS_TOKEN",
+        label: "settingsMcpTab.catalog.entry.github.field.token.label",
+        kind: "secret",
+        placeholder: "ghp_…",
+        required: true,
+        helpUrl: "https://github.com/settings/tokens",
+        helpText: "settingsMcpTab.catalog.entry.github.field.token.help",
+      },
+    ],
+    // Token scope is on the user — high if `repo` is granted, low if
+    // it's read-only public. Default to medium.
+    riskLevel: "medium",
+  },
+
+  // Linear issues / projects / cycles via a community MCP server.
+  // Auth is a single Linear API key from the user's Linear settings.
+  //
+  // TODO(reviewer): pin the most-active Linear MCP — as of 2026-04
+  // candidates include `@tacticlaunch/mcp-linear` and various
+  // smithery-hosted variants.
+  {
+    id: "linear",
+    displayName: "settingsMcpTab.catalog.entry.linear.displayName",
+    description: "settingsMcpTab.catalog.entry.linear.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/tacticlaunch/mcp-linear",
+    setupGuideUrl: "https://linear.app/docs/personal-api-keys",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@tacticlaunch/mcp-linear"],
+      env: {
+        LINEAR_API_KEY: "${LINEAR_API_KEY}",
+      },
+    },
+    configSchema: [
+      {
+        key: "LINEAR_API_KEY",
+        label: "settingsMcpTab.catalog.entry.linear.field.apiKey.label",
+        kind: "secret",
+        placeholder: "lin_api_…",
+        required: true,
+        helpUrl: "https://linear.app/settings/api",
+        helpText: "settingsMcpTab.catalog.entry.linear.field.apiKey.help",
+      },
+    ],
+    riskLevel: "medium",
+  },
+
   // TODO(reviewer): pick the most-active community package — as of
   // 2026-04 candidates include `mcp-server-open-meteo` and
   // `@cloud-rocket/mcp-server-open-meteo`.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -322,6 +322,27 @@ const deMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Liest Repos, Issues, PRs und führt Suchen mit einem Personal Access Token aus. Begrenze den Token-Scope — Schreibrechte (z.B. `repo`) erlauben dem Agenten Pushes auf jeden zugänglichen Repo.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. Bevorzuge fine-grained tokens, die nur auf Repos beschränkt sind, in denen der Agent arbeiten soll.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Liest und aktualisiert Linear-Issues, -Projekte und -Cycles mit einem persönlichen API-Key.",
+          field: {
+            apiKey: {
+              label: "Linear-API-Key",
+              help: "Linear → Settings → API → Personal API keys. Klicke auf 🔑, um die Seite zu öffnen, und dann auf Create key.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Wetter (Open-Meteo)",
           description: "Kostenlose Wettervorhersagen und aktuelle Bedingungen weltweit — ohne API-Key.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -341,6 +341,27 @@ const enMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Read repos, issues, PRs and run searches with a Personal Access Token. Scope the token narrowly — write scopes (e.g. `repo`) let the agent push to any repo you can access.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. Prefer fine-grained tokens limited to the repos you want the agent to touch.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Read and update Linear issues, projects and cycles via a personal API key.",
+          field: {
+            apiKey: {
+              label: "Linear API key",
+              help: "Linear → Settings → API → Personal API keys. Click 🔑 to open the page and click Create key.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Weather (Open-Meteo)",
           description: "Free weather forecasts and current conditions worldwide — no API key needed.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -328,6 +328,27 @@ const esMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Lee repos, issues, PRs y ejecuta búsquedas con un Personal Access Token. Limita el alcance del token — los permisos de escritura (`repo`) dejan al agente hacer push a cualquier repo accesible.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. Se recomienda usar fine-grained tokens limitados a los repos donde quieras que el agente actúe.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Lee y actualiza issues, proyectos y ciclos de Linear con una clave API personal.",
+          field: {
+            apiKey: {
+              label: "Clave API de Linear",
+              help: "Linear → Settings → API → Personal API keys. Pulsa 🔑 para abrir la página y haz clic en Create key.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Pronósticos meteorológicos gratuitos y condiciones actuales en todo el mundo — sin clave API.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -322,6 +322,27 @@ const frMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Lit les repos, issues, PRs et exécute des recherches avec un Personal Access Token. Limitez la portée du token — les permissions d'écriture (`repo`) laissent l'agent push sur n'importe quel repo accessible.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. Préférez les fine-grained tokens limités aux repos où l'agent doit agir.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Lit et met à jour les issues, projets et cycles Linear avec une clé d'API personnelle.",
+          field: {
+            apiKey: {
+              label: "Clé d'API Linear",
+              help: "Linear → Settings → API → Personal API keys. Cliquez sur 🔑 pour ouvrir la page et sur Create key.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Météo (Open-Meteo)",
           description: "Prévisions météo gratuites et conditions actuelles dans le monde entier — sans clé d'API.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -324,6 +324,27 @@ const jaMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Personal Access Token でリポジトリ / Issue / PR / 検索にアクセス。スコープは絞ってください — 書き込み権限（`repo` 等）を渡すとアクセス可能な全リポジトリに push できてしまいます。",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens。エージェントに触らせたいリポジトリだけ指定する fine-grained token を推奨。",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Personal API key で Linear の Issue / プロジェクト / サイクルを読み書き。",
+          field: {
+            apiKey: {
+              label: "Linear API キー",
+              help: "Linear → Settings → API → Personal API keys。🔑 から発行ページを開き Create key を押してください。",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "天気予報（Open-Meteo）",
           description: "世界各地の天気予報と現在の気象情報 — API キー不要で無料利用可能。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -325,6 +325,27 @@ const koMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Personal Access Token으로 리포지토리 / 이슈 / PR / 검색 액세스. 토큰 범위를 좁게 설정하세요 — 쓰기 범위(`repo` 등)를 부여하면 에이전트가 접근 가능한 모든 리포지토리에 push할 수 있습니다.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. 에이전트가 다룰 리포지토리만 지정하는 fine-grained token을 권장합니다.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Personal API key로 Linear의 이슈 / 프로젝트 / 사이클 읽기·쓰기.",
+          field: {
+            apiKey: {
+              label: "Linear API 키",
+              help: "Linear → Settings → API → Personal API keys. 🔑 를 눌러 페이지를 열고 Create key 를 클릭하세요.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "날씨 (Open-Meteo)",
           description: "전 세계 무료 일기예보와 현재 기상 정보 — API 키 불필요.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -321,6 +321,27 @@ const ptBRMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "Lê repos, issues, PRs e executa buscas com um Personal Access Token. Limite o escopo — permissões de escrita (`repo`) deixam o agente fazer push em qualquer repo acessível.",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens. Prefira fine-grained tokens limitados aos repos onde o agente deve atuar.",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "Lê e atualiza issues, projetos e ciclos do Linear com uma chave de API pessoal.",
+          field: {
+            apiKey: {
+              label: "Chave de API do Linear",
+              help: "Linear → Settings → API → Personal API keys. Clique em 🔑 para abrir a página e em Create key.",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "Clima (Open-Meteo)",
           description: "Previsão do tempo gratuita e condições atuais no mundo todo — sem chave de API.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -321,6 +321,27 @@ const zhMessages = {
             },
           },
         },
+        github: {
+          displayName: "GitHub",
+          description:
+            "通过 Personal Access Token 读取仓库 / Issues / PRs 并执行搜索。请窄化 token 权限 — 写权限（如 `repo`）允许 agent 推送到任何可访问的仓库。",
+          field: {
+            token: {
+              label: "Personal Access Token",
+              help: "GitHub → Settings → Developer settings → Personal access tokens。建议使用 fine-grained token 仅限于希望 agent 操作的仓库。",
+            },
+          },
+        },
+        linear: {
+          displayName: "Linear",
+          description: "通过 Personal API key 读写 Linear 的 Issue / 项目 / 周期。",
+          field: {
+            apiKey: {
+              label: "Linear API 密钥",
+              help: "Linear → Settings → API → Personal API keys。点击 🔑 打开页面并点击 Create key。",
+            },
+          },
+        },
         weatherOpenMeteo: {
           displayName: "天气（Open-Meteo）",
           description: "全球免费天气预报和当前气象 — 无需 API 密钥。",


### PR DESCRIPTION
## Summary

Adds two token-based catalog entries to the MCP catalog. Both use a single-secret-field install (no OAuth dance):

- **GitHub** — official `@modelcontextprotocol/server-github` with a Personal Access Token
- **Linear** — community Linear MCP with a personal API key

Phase C of the community-expansion sweep started in #867 (A — Apple Native) and #868 (B — Gmail / Calendar / Drive). Phase D (Spotify / YouTube transcript) will land in a separate PR.

## Items to Confirm / Review

- **Package pins** — both use TODO(reviewer). Linear's package (`@tacticlaunch/mcp-linear`) is the most prominent candidate but the ecosystem is fragmented; please verify activity before merge.
- **Risk levels** — both flagged `medium`. GitHub help text steers users toward fine-grained tokens scoped to specific repos because a classic `repo`-scope PAT lets the agent push to any accessible repo. Worth reviewing whether the wording is sufficiently clear.
- **i18n** — 8 locales updated in lockstep per CLAUDE.md rule.

## User Prompt

> あー、その楽な方で実装してほしい。community MCP serverでできるのひととおりサポートできるとよいね
>
> はい。一気に、１つのPRで。ただし１回目のcommitでPRをつくって、そのPRにつんでいく
>
> （続けて — Phase C 進行中）

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn format\` applied
- [x] \`yarn lint\` 0 errors
- [ ] Each entry renders in Settings → MCP catalog with correct displayName / description / field labels
- [ ] Install + smoke-test at least one entry end-to-end (pasting a PAT / API key)
- [ ] CI green

## Refs

- #823 — umbrella (open, ongoing long-list expansion)
- #867 — Phase A (Apple Native, merged)
- #868 — Phase B (Gmail / Google Calendar / Drive, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)