### PR TITLE
feat(mcp-catalog): Spotify / YouTube transcript (Phase D of community…

### DIFF
--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -484,6 +484,78 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     configSchema: [],
     riskLevel: "low",
   },
+
+  // Spotify Web API access — search tracks, manage playlists, control
+  // playback. Requires a Spotify developer app (Client ID + Client
+  // Secret) which the user creates in their own dashboard. The server
+  // handles the OAuth handshake on first run, caching the refresh
+  // token locally.
+  //
+  // TODO(reviewer): pin the most-active community package — as of
+  // 2026-04 candidates include `@superseoworld/mcp-spotify` and
+  // `spotify-mcp`.
+  {
+    id: "spotify",
+    displayName: "settingsMcpTab.catalog.entry.spotify.displayName",
+    description: "settingsMcpTab.catalog.entry.spotify.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/superseoworld/mcp-spotify",
+    setupGuideUrl: "https://developer.spotify.com/documentation/web-api/concepts/apps",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@superseoworld/mcp-spotify"],
+      env: {
+        SPOTIFY_CLIENT_ID: "${SPOTIFY_CLIENT_ID}",
+        SPOTIFY_CLIENT_SECRET: "${SPOTIFY_CLIENT_SECRET}",
+      },
+    },
+    configSchema: [
+      {
+        key: "SPOTIFY_CLIENT_ID",
+        label: "settingsMcpTab.catalog.entry.spotify.field.clientId.label",
+        kind: "secret",
+        placeholder: "spotify-client-id",
+        required: true,
+        helpUrl: "https://developer.spotify.com/dashboard",
+        helpText: "settingsMcpTab.catalog.entry.spotify.field.clientId.help",
+      },
+      {
+        key: "SPOTIFY_CLIENT_SECRET",
+        label: "settingsMcpTab.catalog.entry.spotify.field.clientSecret.label",
+        kind: "secret",
+        placeholder: "spotify-client-secret",
+        required: true,
+        helpUrl: "https://developer.spotify.com/dashboard",
+        helpText: "settingsMcpTab.catalog.entry.spotify.field.clientSecret.help",
+      },
+    ],
+    riskLevel: "medium",
+  },
+
+  // YouTube transcript fetcher — give it a video URL and it returns
+  // the captions. No auth needed; the package scrapes the public
+  // transcript endpoint. Useful for "summarise this YouTube video"
+  // workflows where Claude Code's built-in WebFetch can't reach the
+  // separate transcript subresource.
+  //
+  // TODO(reviewer): pin the most-active package — as of 2026-04
+  // candidates include `@kimtaeyoon83/mcp-server-youtube-transcript`
+  // and `mcp-youtube-transcript`.
+  {
+    id: "youtube-transcript",
+    displayName: "settingsMcpTab.catalog.entry.youtubeTranscript.displayName",
+    description: "settingsMcpTab.catalog.entry.youtubeTranscript.description",
+    audience: "general",
+    upstreamUrl: "https://github.com/kimtaeyoon83/mcp-server-youtube-transcript",
+    spec: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@kimtaeyoon83/mcp-server-youtube-transcript"],
+    },
+    configSchema: [],
+    riskLevel: "low",
+  },
 ];
 
 /** Look up by id. Returns null when the id isn't in the catalog

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -347,6 +347,24 @@ const deMessages = {
           displayName: "Wetter (Open-Meteo)",
           description: "Kostenlose Wettervorhersagen und aktuelle Bedingungen weltweit — ohne API-Key.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "Suche Tracks, verwalte Playlists, steuere die Wiedergabe. BYO Spotify-Developer-App — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → kopiere die Client ID. Die Redirect URI muss für Desktop-Nutzung keiner echten Seite entsprechen.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "Selbes Developer Dashboard → in der App auf Show client secret klicken. Einmal eingefügt, lokal gecacht.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "YouTube-Transkript",
+          description: "Holt die Untertitel zu jedem öffentlichen YouTube-Video per URL. Keine Zugangsdaten nötig.",
+        },
       },
       config: {
         howToGet: "So erhältst du den Wert",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -366,6 +366,24 @@ const enMessages = {
           displayName: "Weather (Open-Meteo)",
           description: "Free weather forecasts and current conditions worldwide — no API key needed.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "Search tracks, manage playlists, control playback. BYO Spotify developer app — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → copy the Client ID. The redirect URI doesn't need to match an existing site for desktop usage.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "Same Spotify Developer Dashboard → Show client secret on your app. Pasted once and cached locally.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "YouTube transcript",
+          description: "Fetch the captions for any public YouTube video by URL. No credentials needed.",
+        },
       },
       config: {
         howToGet: "How to get this",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -353,6 +353,24 @@ const esMessages = {
           displayName: "Clima (Open-Meteo)",
           description: "Pronósticos meteorológicos gratuitos y condiciones actuales en todo el mundo — sin clave API.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "Busca canciones, gestiona playlists y controla la reproducción. BYO app de desarrollador de Spotify — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → copia el Client ID. La Redirect URI no necesita apuntar a un sitio real para uso de escritorio.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "Mismo Developer Dashboard → en la app, pulsa Show client secret. Se pega una vez y queda en local.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "Transcripción de YouTube",
+          description: "Obtén los subtítulos de cualquier vídeo público de YouTube por URL. Sin credenciales.",
+        },
       },
       config: {
         howToGet: "Cómo obtenerlo",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -347,6 +347,24 @@ const frMessages = {
           displayName: "Météo (Open-Meteo)",
           description: "Prévisions météo gratuites et conditions actuelles dans le monde entier — sans clé d'API.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "Recherche des morceaux, gère les playlists, contrôle la lecture. BYO app développeur Spotify — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → copie le Client ID. La Redirect URI n'a pas besoin de correspondre à un vrai site pour un usage desktop.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "Même Developer Dashboard → dans l'app, clique sur Show client secret. Collé une fois, mis en cache local.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "Transcription YouTube",
+          description: "Récupère les sous-titres de n'importe quelle vidéo YouTube publique par URL. Sans identifiants.",
+        },
       },
       config: {
         howToGet: "Comment l'obtenir",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -349,6 +349,24 @@ const jaMessages = {
           displayName: "天気予報（Open-Meteo）",
           description: "世界各地の天気予報と現在の気象情報 — API キー不要で無料利用可能。",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "曲の検索、プレイリスト管理、再生操作。BYO Spotify Developer アプリ — Client ID と Client Secret を発行してください。",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app で取得。デスクトップ用途では Redirect URI が実在のサイトに一致する必要はありません。",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "同じ Developer Dashboard → アプリの Show client secret から取得。一度貼ればローカルに保存されます。",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "YouTube 字幕",
+          description: "公開 YouTube 動画の URL から字幕を取得。認証情報不要。",
+        },
       },
       config: {
         howToGet: "取得方法",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -350,6 +350,24 @@ const koMessages = {
           displayName: "날씨 (Open-Meteo)",
           description: "전 세계 무료 일기예보와 현재 기상 정보 — API 키 불필요.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "트랙 검색, 플레이리스트 관리, 재생 제어. BYO Spotify 개발자 앱 — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → Client ID를 복사하세요. 데스크톱 용도에서는 Redirect URI가 실제 사이트와 일치하지 않아도 됩니다.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "동일한 Developer Dashboard → 앱의 Show client secret. 한 번 붙여 넣으면 로컬에 캐시됩니다.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "YouTube 자막",
+          description: "공개된 YouTube 동영상의 URL로 자막을 가져옵니다. 자격 증명 불필요.",
+        },
       },
       config: {
         howToGet: "발급 방법",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -346,6 +346,24 @@ const ptBRMessages = {
           displayName: "Clima (Open-Meteo)",
           description: "Previsão do tempo gratuita e condições atuais no mundo todo — sem chave de API.",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "Pesquisa faixas, gerencia playlists e controla a reprodução. BYO app de desenvolvedor do Spotify — Client ID + Client Secret.",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → copie o Client ID. A Redirect URI não precisa apontar para um site real para uso desktop.",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "Mesmo Developer Dashboard → no app, clique em Show client secret. Cola uma vez e fica em cache local.",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "Transcrição do YouTube",
+          description: "Obtém as legendas de qualquer vídeo público do YouTube pela URL. Sem credenciais.",
+        },
       },
       config: {
         howToGet: "Como obter",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -346,6 +346,24 @@ const zhMessages = {
           displayName: "天气（Open-Meteo）",
           description: "全球免费天气预报和当前气象 — 无需 API 密钥。",
         },
+        spotify: {
+          displayName: "Spotify",
+          description: "搜索曲目、管理播放列表、控制播放。BYO Spotify 开发者应用 — Client ID + Client Secret。",
+          field: {
+            clientId: {
+              label: "Client ID",
+              help: "Spotify Developer Dashboard → Create app → 复制 Client ID。桌面用途下 Redirect URI 不需要匹配真实站点。",
+            },
+            clientSecret: {
+              label: "Client Secret",
+              help: "同一 Developer Dashboard → 在应用中点 Show client secret。粘贴一次后会缓存在本地。",
+            },
+          },
+        },
+        youtubeTranscript: {
+          displayName: "YouTube 字幕",
+          description: "通过 URL 获取任意公开 YouTube 视频的字幕。无需凭证。",
+        },
       },
       config: {
         howToGet: "获取方式",


### PR DESCRIPTION
… expansion)

Two final entries closing out the four-phase community sweep (Apple #867 → Google OAuth #868 → GitHub/Linear #869 → Spotify+YouTube).

- spotify — `@superseoworld/mcp-spotify` with BYO Client ID + Client Secret. The Spotify Developer Dashboard issues these in seconds — no app review for personal desktop usage. Risk medium.
- youtube-transcript — `@kimtaeyoon83/mcp-server-youtube-transcript`, no auth, scrapes the public captions endpoint. Useful for "summarise this video" workflows where Claude Code's WebFetch can't reach the transcript subresource. Risk low.

i18n: all 8 locales updated in lockstep (en/ja/zh/ko/es/pt-BR/fr/de).

This PR is **based on `feat/mcp-catalog-github-linear` (PR #869)** and should be retargeted to main once #869 merges. GitHub will recognise the rebased commits automatically.

Plan: plans/feat-mcp-catalog-community-expansion.md
Refs: #823 (umbrella), #867 (A), #868 (B), #869 (C)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spotify Web API integration to access Spotify data and content (requires client ID and secret credentials for authentication)
  * Added YouTube transcript fetcher to retrieve transcripts from public YouTube videos without authentication requirements
  * Extended localization support across 8 languages: English, German, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Simplified Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->