### PR TITLE
refactor(wiki): consolidate page writes into writeWikiPage choke point (#763 PR 1)

### DIFF
--- a/plans/feat-763-wiki-history-pr1-write-consolidation.md
+++ b/plans/feat-763-wiki-history-pr1-write-consolidation.md
@@ -1,0 +1,136 @@
+# #763 PR 1: wiki page write consolidation
+
+Issue: https://github.com/receptron/mulmoclaude/issues/763
+
+## ゴール
+
+wiki page 書き込みを 1 関数に統合する。**履歴機能は入れない**。挙動変化ゼロが目標。後続 PR (snapshot ストレージ / API / UI) のための choke point を main に入れて寝かせる。
+
+副次目標: wiki-backlinks の `fsp.writeFile` 直叩きをアトミック化(独立のバグ修正)。
+
+## 現状の write 経路
+
+| 経路 | 箇所                                                        | 現状                           | trigger                                                       |
+| ---- | ----------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------- |
+| ①    | `server/api/routes/wiki.ts:513` (`saveExistingPage`)        | `writeFileAtomic`              | LLM の `manageWiki` MCP tool / フロントの task-checkbox click |
+| ②    | `server/api/routes/files.ts:766` (`PUT /api/files/content`) | `writeFileAtomic`              | FileContentRenderer のユーザ save                             |
+| ③    | `server/workspace/wiki-backlinks/index.ts:42,97`            | `fsp.writeFile` (非アトミック) | agent 終了時のセッション backlink 自動追加                    |
+
+## 新規モジュール: `server/workspace/wiki-pages/io.ts`
+
+```ts
+export type WikiPageEditor = "llm" | "user" | "system";
+
+export interface WikiWriteMeta {
+  editor: WikiPageEditor;
+  /** Chat session that triggered the edit. Optional — not all
+   *  callers know one (e.g. user opening the file editor). */
+  sessionId?: string;
+  /** Free-form short reason; LLM-supplied or human-supplied. */
+  reason?: string;
+}
+
+/** Resolve the absolute path for a slug. Does not check existence. */
+export function wikiPagePath(slug: string): string;
+
+/** Read a wiki page; null if missing. Used by writeWikiPage to
+ *  capture the pre-write content for future snapshotting. */
+export async function readWikiPage(slug: string): Promise<string | null>;
+
+/** Write a wiki page atomically. Records the (old, new) pair to the
+ *  snapshot pipeline for #763 PR 2. Currently a no-op stub. */
+export async function writeWikiPage(slug: string, content: string, meta: WikiWriteMeta): Promise<void>;
+
+/** Predicate for routing the generic /api/files PUT into the wiki
+ *  pipeline. Matches paths under `data/wiki/pages/*.md`. Returns the
+ *  derived slug on match. */
+export function classifyAsWikiPage(absPath: string): { wiki: true; slug: string } | { wiki: false };
+```
+
+`appendSnapshot` は private no-op stub。signature だけ用意して PR 2 で本体を埋める:
+
+```ts
+async function appendSnapshot(_slug: string, _oldContent: string | null, _newContent: string, _meta: WikiWriteMeta): Promise<void> {
+  // PR 2 で実装。現状は no-op。
+}
+```
+
+## 移行: 各 caller の書き換え
+
+### ① `server/api/routes/wiki.ts`
+
+`saveExistingPage(pageName, content)` の中で:
+
+```ts
+const absPath = await resolvePagePath(pageName);
+if (!absPath) return { ok: false, reason: "not-found" };
+const slug = path.basename(absPath, ".md");
+await writeWikiPage(slug, content, { editor: "user" });
+```
+
+editor は暫定的に `"user"`。LLM 経路かユーザ経路かの分離は PR 2 で扱う(リクエスト側に flag を立てる、または `manageWiki` MCP の側で `editor: "llm"` を送る)。
+
+### ② `server/api/routes/files.ts`
+
+PUT /api/files/content の中で、`absPath` を `classifyAsWikiPage` で振り分け:
+
+```ts
+const wikiClass = classifyAsWikiPage(absPath);
+if (wikiClass.wiki) {
+  await writeWikiPage(wikiClass.slug, contentRaw, { editor: "user" });
+} else {
+  await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
+}
+```
+
+`uniqueTmp` は wiki page では指定しない (writeWikiPage 内部で握る判断)。
+
+### ③ `server/workspace/wiki-backlinks/index.ts`
+
+`defaultDeps.writeFile` を `writeWikiPage(slug, content, { editor: "system", sessionId })` に置き換える。`deps` の seam (テスト用) は残す。
+
+## テスト
+
+新規ユニットテスト `test/workspace/wiki-pages/test_io.ts`:
+
+- `wikiPagePath` が `data/wiki/pages/<slug>.md` を返す (cross-platform: `path.join`)
+- `readWikiPage` が存在ファイルの内容を返す
+- `readWikiPage` が ENOENT で null を返す
+- `writeWikiPage` がファイルを作る (新規)
+- `writeWikiPage` がファイルを上書きする (既存)
+- `writeWikiPage` がアトミック (tmp ファイルがディレクトリに残らない)
+- `classifyAsWikiPage` が `data/wiki/pages/foo.md` を `{ wiki: true, slug: "foo" }` と判定
+- `classifyAsWikiPage` が `data/wiki/index.md` を `{ wiki: false }` と判定
+- `classifyAsWikiPage` が `data/wiki/pages/foo.txt` を `{ wiki: false }` と判定 (拡張子チェック)
+- `classifyAsWikiPage` が path traversal (`..`) で false を返す (defensive)
+
+既存テストは挙動不変のため全て通る前提:
+
+- `test/server/api/routes/test_wiki.ts`
+- `test/workspace/wiki-backlinks/test_*.ts`
+- `test/server/api/routes/test_files.ts`
+
+## 完了条件
+
+- [ ] `server/workspace/wiki-pages/io.ts` 新規追加
+- [ ] 3 経路すべて `writeWikiPage` 経由
+- [ ] wiki-backlinks がアトミック化(クラッシュ耐性向上)
+- [ ] 新規ユニットテスト (上記 9 ケース)
+- [ ] 既存テスト全パス
+- [ ] `yarn typecheck && yarn lint && yarn build && yarn test` clean
+- [ ] e2e: 既存 wiki / files の e2e が通る
+
+## Out of scope (後続 PR)
+
+- snapshot ストレージ実装 (`appendSnapshot` 本体)
+- editor identity の LLM/user 分離 (今は `'user'` placeholder)
+- API endpoints (history list / diff / restore)
+- UI (History tab / unified diff / restore button)
+- GC / 保持ポリシー
+- e2e for history flow
+
+## 詰まりどころ予想
+
+1. **editor の placeholder で議論される** — レビューで「LLM と user は分けるべき」と言われたら "PR 2 で扱う" と答える。今は no-op stub なので機能差なし。
+2. **wiki-backlinks のテストが落ちる** — `deps.writeFile` の signature が `(filePath, content) => Promise<void>` から内部的に `writeWikiPage` 呼び出しになると、テストの mock 互換性が崩れる可能性。`deps` は維持しつつ、デフォルト実装だけ writeWikiPage 経由にする。
+3. **`writeWikiPage` 内で `wikiPagePath(slug)` を呼ぶと `WORKSPACE_PATHS.wikiPages` に依存する** — テストで workspace を override する仕組みが必要かも。既存の `workspaceRoot` injection パターンを踏襲。

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -9,6 +9,7 @@ import { getOptionalStringQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { GitignoreFilter } from "../../utils/gitignore.js";
 import { getCachedReferenceDirs } from "../../workspace/reference-dirs.js";
+import { classifyAsWikiPage, writeWikiPage } from "../../workspace/wiki-pages/io.js";
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
 
@@ -760,10 +761,19 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
     return;
   }
   try {
-    // `uniqueTmp: true` appends a randomUUID to the tmp filename so
-    // two simultaneous PUTs to the same path can't clobber each
-    // other's staging file and race through the rename.
-    await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
+    // Wiki pages have their own choke-point write helper that
+    // captures (old, new) for the edit-history pipeline (#763).
+    // Anything else falls back to the generic atomic write.
+    // `uniqueTmp: true` (generic branch) appends a randomUUID to
+    // the tmp filename so two simultaneous PUTs to the same path
+    // can't clobber each other's staging file and race through
+    // the rename.
+    const wikiClass = classifyAsWikiPage(absPath);
+    if (wikiClass.wiki) {
+      await writeWikiPage(wikiClass.slug, contentRaw, { editor: "user" });
+    } else {
+      await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
+    }
   } catch (err) {
     log.error("files", "PUT content: write threw", { pathPreview: previewSnippet(relPathRaw), error: errorMessage(err) });
     serverError(res, `Failed to write file: ${errorMessage(err)}`);

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -764,13 +764,20 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
     // Wiki pages have their own choke-point write helper that
     // captures (old, new) for the edit-history pipeline (#763).
     // Anything else falls back to the generic atomic write.
-    // `uniqueTmp: true` (generic branch) appends a randomUUID to
-    // the tmp filename so two simultaneous PUTs to the same path
-    // can't clobber each other's staging file and race through
-    // the rename.
-    const wikiClass = classifyAsWikiPage(absPath);
+    // `uniqueTmp: true` appends a randomUUID to the tmp filename so
+    // two simultaneous PUTs to the same path can't clobber each
+    // other's staging file and race through the rename
+    // (writeWikiPage applies it internally).
+    //
+    // Pass the already-realpath'd `workspaceReal` to the classifier:
+    // `resolveSafe()` returns a realpath'd `absPath`, so the root
+    // we compare against MUST also be realpath'd. Otherwise a
+    // symlinked workspace (e.g. `~/mulmoclaude` → some real path
+    // elsewhere) silently routes wiki writes through the generic
+    // branch and bypasses the chokepoint.
+    const wikiClass = classifyAsWikiPage(absPath, { workspaceRoot: workspaceReal });
     if (wikiClass.wiki) {
-      await writeWikiPage(wikiClass.slug, contentRaw, { editor: "user" });
+      await writeWikiPage(wikiClass.slug, contentRaw, { editor: "user" }, { workspaceRoot: workspaceReal });
     } else {
       await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
     }

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { readTextSafeSync, readTextSafe } from "../../utils/files/safe.js";
-import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { writeWikiPage } from "../../workspace/wiki-pages/io.js";
 import { getPageIndex } from "./wiki/pageIndex.js";
 import { parseFrontmatterTags } from "./wiki/frontmatter.js";
 import { badRequest, notFound } from "../../utils/httpError.js";
@@ -508,9 +508,14 @@ type SaveOutcome = { ok: true; absPath: string } | { ok: false; reason: "not-fou
 async function saveExistingPage(pageName: string, content: string): Promise<SaveOutcome> {
   const absPath = await resolvePagePath(pageName);
   if (!absPath) return { ok: false, reason: "not-found" };
-  // Atomic write: tmp file alongside the destination, fsync, rename.
-  // Prevents a crashed write from leaving the wiki page truncated.
-  await writeFileAtomic(absPath, content);
+  // Funnel through the wiki-page write helper. Atomic write is
+  // guaranteed inside; the helper also routes the (old, new) pair
+  // to the snapshot pipeline (#763 PR 2 — currently a no-op stub).
+  // Editor identity defaults to "user" here because the route is
+  // hit by both LLM (`manageWiki` MCP) and frontend saves; PR 2
+  // disambiguates them via a request-side flag.
+  const slug = path.basename(absPath, ".md");
+  await writeWikiPage(slug, content, { editor: "user" });
   return { ok: true, absPath };
 }
 

--- a/server/workspace/wiki-backlinks/index.ts
+++ b/server/workspace/wiki-backlinks/index.ts
@@ -21,6 +21,7 @@ import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 import { log } from "../../system/logger/index.js";
 import { updateSessionBacklinks } from "./sessionBacklinks.js";
+import { writeWikiPage } from "../wiki-pages/io.js";
 import { ONE_SECOND_MS } from "../../utils/time.js";
 
 // Small tolerance for filesystem mtime granularity (some filesystems
@@ -35,12 +36,23 @@ export interface WikiBacklinksDeps {
   writeFile: (filePath: string, content: string) => Promise<void>;
 }
 
-const defaultDeps: WikiBacklinksDeps = {
-  readdir: (dir) => fsp.readdir(dir),
-  stat: (filePath) => fsp.stat(filePath),
-  readFile: (filePath) => fsp.readFile(filePath, "utf-8"),
-  writeFile: (filePath, content) => fsp.writeFile(filePath, content, "utf-8"),
-};
+// Default writers funnel through `writeWikiPage` so the backlink
+// append participates in the same atomic-write + history pipeline
+// as user / LLM edits. Pre-#763 this was a non-atomic
+// `fsp.writeFile` and the call could leave a half-written page on
+// crash. Editor identity is `"system"` so PR 2's snapshot view can
+// distinguish automated edits from human / LLM ones.
+function buildDefaultDeps(workspaceRoot: string, sessionId: string): WikiBacklinksDeps {
+  return {
+    readdir: (dir) => fsp.readdir(dir),
+    stat: (filePath) => fsp.stat(filePath),
+    readFile: (filePath) => fsp.readFile(filePath, "utf-8"),
+    writeFile: async (filePath, content) => {
+      const slug = path.basename(filePath, ".md");
+      await writeWikiPage(slug, content, { editor: "system", sessionId }, { workspaceRoot });
+    },
+  };
+}
 
 export interface MaybeAppendWikiBacklinksOptions {
   chatSessionId: string;
@@ -52,7 +64,7 @@ export interface MaybeAppendWikiBacklinksOptions {
 export async function maybeAppendWikiBacklinks(opts: MaybeAppendWikiBacklinksOptions): Promise<void> {
   if (!opts.chatSessionId) return;
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
-  const deps: WikiBacklinksDeps = { ...defaultDeps, ...(opts.deps ?? {}) };
+  const deps: WikiBacklinksDeps = { ...buildDefaultDeps(workspaceRoot, opts.chatSessionId), ...(opts.deps ?? {}) };
   const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages);
 
   const files = await listPageFiles(pagesDir, deps);

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -41,8 +41,32 @@ export interface WikiPageWriteOptions {
   workspaceRoot?: string;
 }
 
-/** Absolute path for a slug. Does not check existence. */
+/** Reject slugs that would escape `data/wiki/pages/` once joined.
+ *  The chokepoint must defend itself against careless callers — a
+ *  raw `path.join(root, dir, '${slug}.md')` happily resolves
+ *  `../../etc/passwd` outside the wiki tree. Today's three callers
+ *  derive slugs from `path.basename(...)` so they're already safe;
+ *  this guard keeps that property even if a future caller forgets. */
+function isSafeSlug(slug: string): boolean {
+  if (slug.length === 0) return false;
+  // Empty / dot-only / starts-with-dot would either resolve to the
+  // pages dir itself, hide the file (`.foo.md`), or risk collisions
+  // with VCS / OS metadata. Reject as a class.
+  if (slug.startsWith(".")) return false;
+  // Any path separator (forward slash, backslash on Windows, or the
+  // literal `..` segment) means the slug spans directories — not
+  // allowed at the page-write layer.
+  if (slug.includes("/") || slug.includes("\\")) return false;
+  if (slug.includes("\0")) return false;
+  return true;
+}
+
+/** Absolute path for a slug. Throws on slugs that would escape
+ *  `data/wiki/pages/`. Does not check existence. */
 export function wikiPagePath(slug: string, opts: WikiPageWriteOptions = {}): string {
+  if (!isSafeSlug(slug)) {
+    throw new Error(`wiki-pages: refusing unsafe slug ${JSON.stringify(slug)}`);
+  }
   const root = opts.workspaceRoot ?? defaultWorkspacePath;
   return path.join(root, WORKSPACE_DIRS.wikiPages, `${slug}.md`);
 }
@@ -56,22 +80,35 @@ export async function readWikiPage(slug: string, opts: WikiPageWriteOptions = {}
 
 /** Write a wiki page atomically and forward (old, new) to the
  *  snapshot pipeline. The snapshot call is currently a no-op stub
- *  (#763 PR 2). */
+ *  (#763 PR 2). `uniqueTmp: true` matches what the generic
+ *  `/api/files/content` PUT used pre-consolidation — without it
+ *  two simultaneous writes to the same page collide on the shared
+ *  `.tmp` staging file (the file-content PUT and the wiki-backlinks
+ *  driver are independent and may target the same page in the same
+ *  millisecond). */
 export async function writeWikiPage(slug: string, content: string, meta: WikiWriteMeta, opts: WikiPageWriteOptions = {}): Promise<void> {
   const absPath = wikiPagePath(slug, opts);
   const oldContent = await readTextSafe(absPath);
-  await writeFileAtomic(absPath, content);
+  await writeFileAtomic(absPath, content, { uniqueTmp: true });
   if (oldContent !== content) {
     await appendSnapshot(slug, oldContent, content, meta);
   }
 }
 
 /** Routing helper for the generic `/api/files/content` PUT.
- *  Returns `{ wiki: true, slug }` when the absolute path resolves
- *  inside `data/wiki/pages/` AND has a `.md` extension. Anything
- *  outside that exact shape (index.md, sources/, non-md, traversal
- *  attempts after symlink resolution) is `{ wiki: false }` and
- *  should fall back to the generic atomic write. */
+ *  Returns `{ wiki: true, slug }` when `absPath` resolves directly
+ *  under `data/wiki/pages/` AND ends in `.md`. Anything outside
+ *  that exact shape (index.md, sources/, non-md, nested subdirs,
+ *  paths that escape pagesDir via `..`) is `{ wiki: false }` and
+ *  should fall back to the generic atomic write.
+ *
+ *  This function is **pure path-string math** — it does no symlink
+ *  resolution. Callers MUST pass an already-realpath'd `absPath`
+ *  AND an already-realpath'd `workspaceRoot` (or rely on the
+ *  default, which mirrors `defaultWorkspacePath`). Mixing one
+ *  realpath'd side with a symlinked other side is the trap that
+ *  caused #883 review-iter-1 — a symlinked workspace would have
+ *  silently routed wiki writes through the generic writer. */
 export function classifyAsWikiPage(absPath: string, opts: WikiPageWriteOptions = {}): { wiki: true; slug: string } | { wiki: false } {
   const root = opts.workspaceRoot ?? defaultWorkspacePath;
   const pagesDir = path.join(root, WORKSPACE_DIRS.wikiPages);

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -1,0 +1,105 @@
+// Single choke point for `data/wiki/pages/<slug>.md` writes.
+//
+// Every wiki page write — manageWiki MCP tool, the user editing
+// through the file content endpoint, the wiki-backlinks driver
+// appending session links — funnels through `writeWikiPage`.
+// Centralising here gives:
+//
+//   - one atomic-write guarantee (was: wiki-backlinks bypassed it)
+//   - one place to record edit history (#763 PR 2 — currently a
+//     no-op stub; this PR only consolidates the writes)
+//   - editor identity captured at the call site (LLM / user /
+//     system) where it is actually known. A generic `writeFileAtomic`
+//     hook can't tell who originated the edit.
+//
+// PR 1 scope (this commit): consolidation only, behaviour unchanged.
+// PR 2 will fill in `appendSnapshot` with real history pipeline.
+//
+// `appendSnapshot` is a no-op stub on purpose — keeping the call
+// site wired up means PR 2 is purely an internal change.
+
+import path from "node:path";
+import { readTextSafe } from "../../utils/files/safe.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS } from "../paths.js";
+
+export type WikiPageEditor = "llm" | "user" | "system";
+
+export interface WikiWriteMeta {
+  editor: WikiPageEditor;
+  /** Chat session that triggered the edit. Optional — not all
+   *  callers know one (e.g. user save through the file editor). */
+  sessionId?: string;
+  /** Free-form short reason. LLM-supplied or user-supplied. */
+  reason?: string;
+}
+
+export interface WikiPageWriteOptions {
+  /** Override the workspace root for tests. Defaults to the
+   *  process's resolved workspace (`workspace.ts`). */
+  workspaceRoot?: string;
+}
+
+/** Absolute path for a slug. Does not check existence. */
+export function wikiPagePath(slug: string, opts: WikiPageWriteOptions = {}): string {
+  const root = opts.workspaceRoot ?? defaultWorkspacePath;
+  return path.join(root, WORKSPACE_DIRS.wikiPages, `${slug}.md`);
+}
+
+/** Read a wiki page; null if missing. Used internally to capture
+ *  the pre-write content for snapshotting (PR 2). Exposed because
+ *  some callers want the same null-safe reader. */
+export async function readWikiPage(slug: string, opts: WikiPageWriteOptions = {}): Promise<string | null> {
+  return readTextSafe(wikiPagePath(slug, opts));
+}
+
+/** Write a wiki page atomically and forward (old, new) to the
+ *  snapshot pipeline. The snapshot call is currently a no-op stub
+ *  (#763 PR 2). */
+export async function writeWikiPage(slug: string, content: string, meta: WikiWriteMeta, opts: WikiPageWriteOptions = {}): Promise<void> {
+  const absPath = wikiPagePath(slug, opts);
+  const oldContent = await readTextSafe(absPath);
+  await writeFileAtomic(absPath, content);
+  if (oldContent !== content) {
+    await appendSnapshot(slug, oldContent, content, meta);
+  }
+}
+
+/** Routing helper for the generic `/api/files/content` PUT.
+ *  Returns `{ wiki: true, slug }` when the absolute path resolves
+ *  inside `data/wiki/pages/` AND has a `.md` extension. Anything
+ *  outside that exact shape (index.md, sources/, non-md, traversal
+ *  attempts after symlink resolution) is `{ wiki: false }` and
+ *  should fall back to the generic atomic write. */
+export function classifyAsWikiPage(absPath: string, opts: WikiPageWriteOptions = {}): { wiki: true; slug: string } | { wiki: false } {
+  const root = opts.workspaceRoot ?? defaultWorkspacePath;
+  const pagesDir = path.join(root, WORKSPACE_DIRS.wikiPages);
+  // `path.relative` returns "" for equal paths and a "../"-prefixed
+  // string for outside-root paths. Anything starting with ".." (or
+  // absolute on Windows after a drive change) is rejected.
+  const rel = path.relative(pagesDir, absPath);
+  if (rel.length === 0) return { wiki: false };
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return { wiki: false };
+  // The file must live directly in `pages/`, not in a subdirectory
+  // (no nested wiki layout today). Reject anything with a separator.
+  if (rel.includes(path.sep)) return { wiki: false };
+  if (!rel.endsWith(".md")) return { wiki: false };
+  return { wiki: true, slug: rel.slice(0, -".md".length) };
+}
+
+// ── Internal: snapshot stub ────────────────────────────────────
+//
+// Filled in by #763 PR 2. Kept here as a no-op so the call site is
+// already wired up and PR 2 is a pure internal change.
+//
+// Signature note: takes both old and new content so the snapshot
+// store can emit a diff or store the prior version directly. Meta
+// carries editor identity / session / reason so the snapshot can
+// be attributed.
+
+async function appendSnapshot(__slug: string, __oldContent: string | null, __newContent: string, __meta: WikiWriteMeta): Promise<void> {
+  // Intentionally empty — PR 2 (#763) replaces this with the
+  // actual snapshot pipeline. The wiring is in place so PR 2 is
+  // purely an internal change.
+}

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -46,15 +46,19 @@ export interface WikiPageWriteOptions {
  *  raw `path.join(root, dir, '${slug}.md')` happily resolves
  *  `../../etc/passwd` outside the wiki tree. Today's three callers
  *  derive slugs from `path.basename(...)` so they're already safe;
- *  this guard keeps that property even if a future caller forgets. */
+ *  this guard keeps that property even if a future caller forgets.
+ *
+ *  The rule is intentionally narrow — separators / `..` / NUL /
+ *  empty — so it only rejects unambiguous security violations.
+ *  Aesthetic concerns (e.g. dot-prefixed "hidden" filenames) are
+ *  out of scope: a pre-existing `data/wiki/pages/.foo.md` should
+ *  remain writable through the chokepoint, and over-rejection here
+ *  would turn that into a 500 (codex review iter-2 #883). */
 function isSafeSlug(slug: string): boolean {
   if (slug.length === 0) return false;
-  // Empty / dot-only / starts-with-dot would either resolve to the
-  // pages dir itself, hide the file (`.foo.md`), or risk collisions
-  // with VCS / OS metadata. Reject as a class.
-  if (slug.startsWith(".")) return false;
-  // Any path separator (forward slash, backslash on Windows, or the
-  // literal `..` segment) means the slug spans directories — not
+  if (slug === "." || slug === "..") return false;
+  // Any path separator (forward slash, backslash on Windows) or
+  // literal `..` segment means the slug spans directories — not
   // allowed at the page-write layer.
   if (slug.includes("/") || slug.includes("\\")) return false;
   if (slug.includes("\0")) return false;

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -116,14 +116,19 @@ export async function writeWikiPage(slug: string, content: string, meta: WikiWri
 export function classifyAsWikiPage(absPath: string, opts: WikiPageWriteOptions = {}): { wiki: true; slug: string } | { wiki: false } {
   const root = opts.workspaceRoot ?? defaultWorkspacePath;
   const pagesDir = path.join(root, WORKSPACE_DIRS.wikiPages);
-  // `path.relative` returns "" for equal paths and a "../"-prefixed
-  // string for outside-root paths. Anything starting with ".." (or
-  // absolute on Windows after a drive change) is rejected.
+  // `path.relative` returns "" for equal paths, a "../"-prefixed
+  // string when `absPath` is outside `pagesDir`, and an absolute
+  // path on Windows when the two are on different drives.
   const rel = path.relative(pagesDir, absPath);
   if (rel.length === 0) return { wiki: false };
-  if (rel.startsWith("..") || path.isAbsolute(rel)) return { wiki: false };
+  if (path.isAbsolute(rel)) return { wiki: false };
   // The file must live directly in `pages/`, not in a subdirectory
-  // (no nested wiki layout today). Reject anything with a separator.
+  // (no nested wiki layout today). Any separator means the path
+  // either escapes (`../secret.md`) or descends (`subdir/foo.md`)
+  // — both rejected. NOTE: a literal page name like `..foo.md` is
+  // a single segment without a separator and is allowed (codex
+  // review iter-3 #883 — the prior `startsWith("..")` rule
+  // wrongly rejected it).
   if (rel.includes(path.sep)) return { wiki: false };
   if (!rel.endsWith(".md")) return { wiki: false };
   return { wiki: true, slug: rel.slice(0, -".md".length) };

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -1,0 +1,143 @@
+// Unit tests for the new wiki-pages choke-point write helper
+// (#763 PR 1). The actual snapshot pipeline is no-op in PR 1 so the
+// behaviours we lock in are:
+//
+//   - reads/writes hit the right path under the workspace root
+//   - read returns null for missing files (no throw)
+//   - writes are atomic (no leftover .tmp files after success)
+//   - classifyAsWikiPage routes the generic file PUT correctly,
+//     including refusing nested / non-md / outside-root paths
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { classifyAsWikiPage, readWikiPage, wikiPagePath, writeWikiPage } from "../../../server/workspace/wiki-pages/io.js";
+import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
+
+describe("wiki-pages/io — wikiPagePath", () => {
+  it("composes data/wiki/pages/<slug>.md under the given workspaceRoot", () => {
+    const root = "/tmp/ws-test";
+    const out = wikiPagePath("my-page", { workspaceRoot: root });
+    // path.join collapses redundant separators and uses the platform
+    // separator. Compare via path.normalize on both sides for
+    // cross-platform safety.
+    const expected = path.join(root, WORKSPACE_DIRS.wikiPages, "my-page.md");
+    assert.equal(out, expected);
+  });
+});
+
+describe("wiki-pages/io — readWikiPage", () => {
+  let workspaceRoot: string;
+
+  before(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "wiki-pages-read-"));
+  });
+
+  after(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("returns the file content when the page exists", async () => {
+    const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages);
+    await mkdir(pagesDir, { recursive: true });
+    await writeFile(path.join(pagesDir, "topic.md"), "# Topic\n\nbody\n", "utf-8");
+
+    const out = await readWikiPage("topic", { workspaceRoot });
+    assert.equal(out, "# Topic\n\nbody\n");
+  });
+
+  it("returns null when the page does not exist (no throw)", async () => {
+    const out = await readWikiPage("nonexistent", { workspaceRoot });
+    assert.equal(out, null);
+  });
+});
+
+describe("wiki-pages/io — writeWikiPage", () => {
+  let workspaceRoot: string;
+
+  before(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "wiki-pages-write-"));
+  });
+
+  after(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("creates a new page when none exists", async () => {
+    await writeWikiPage("brand-new", "# Brand New\n\nfresh\n", { editor: "user" }, { workspaceRoot });
+
+    const fileContent = await readFile(wikiPagePath("brand-new", { workspaceRoot }), "utf-8");
+    assert.equal(fileContent, "# Brand New\n\nfresh\n");
+  });
+
+  it("overwrites an existing page", async () => {
+    await writeWikiPage("topic-x", "v1\n", { editor: "user" }, { workspaceRoot });
+    await writeWikiPage("topic-x", "v2\n", { editor: "user" }, { workspaceRoot });
+
+    const fileContent = await readFile(wikiPagePath("topic-x", { workspaceRoot }), "utf-8");
+    assert.equal(fileContent, "v2\n");
+  });
+
+  it("does not leave a .tmp staging file after a successful write", async () => {
+    await writeWikiPage("clean", "content\n", { editor: "user" }, { workspaceRoot });
+
+    const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages);
+    const entries = await readdir(pagesDir);
+    const stragglers = entries.filter((name) => name.endsWith(".tmp"));
+    assert.deepEqual(stragglers, []);
+  });
+
+  it("accepts every editor identity without distinction (PR 1 no-op)", async () => {
+    // PR 1 only consolidates the wiring; the snapshot stub is a
+    // no-op regardless of editor. PR 2 will introduce semantics.
+    await writeWikiPage("by-llm", "llm content\n", { editor: "llm", sessionId: "s1" }, { workspaceRoot });
+    await writeWikiPage("by-system", "system content\n", { editor: "system", sessionId: "s2" }, { workspaceRoot });
+
+    assert.equal(await readWikiPage("by-llm", { workspaceRoot }), "llm content\n");
+    assert.equal(await readWikiPage("by-system", { workspaceRoot }), "system content\n");
+  });
+});
+
+describe("wiki-pages/io — classifyAsWikiPage", () => {
+  const root = "/tmp/ws-classify";
+  const pagesDir = path.join(root, WORKSPACE_DIRS.wikiPages);
+
+  it("classifies a direct child .md as wiki", () => {
+    const out = classifyAsWikiPage(path.join(pagesDir, "foo.md"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: true, slug: "foo" });
+  });
+
+  it("rejects index.md (lives one level above pages/)", () => {
+    const out = classifyAsWikiPage(path.join(root, "data", "wiki", "index.md"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("rejects non-md files inside pages/", () => {
+    const out = classifyAsWikiPage(path.join(pagesDir, "foo.txt"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("rejects nested subdirectories under pages/", () => {
+    // No nested wiki layout today; reject defensively.
+    const out = classifyAsWikiPage(path.join(pagesDir, "subdir", "foo.md"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("rejects path traversal attempts (.. escapes pagesDir)", () => {
+    const malicious = path.join(pagesDir, "..", "..", "secrets.md");
+    const out = classifyAsWikiPage(malicious, { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("rejects paths outside the workspace entirely", () => {
+    const out = classifyAsWikiPage("/etc/passwd", { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("rejects pagesDir itself (no slug)", () => {
+    const out = classifyAsWikiPage(pagesDir, { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+});

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -26,6 +26,39 @@ describe("wiki-pages/io — wikiPagePath", () => {
     const expected = path.join(root, WORKSPACE_DIRS.wikiPages, "my-page.md");
     assert.equal(out, expected);
   });
+
+  it("accepts unicode slugs (e.g. CJK page names)", () => {
+    // Wiki has Japanese page slugs in production — the safety guard
+    // must not over-reject the legitimate ones.
+    const out = wikiPagePath("さくらインターネット", { workspaceRoot: "/tmp/ws" });
+    assert.equal(out, path.join("/tmp/ws", WORKSPACE_DIRS.wikiPages, "さくらインターネット.md"));
+  });
+
+  it("throws on path-traversal slugs (..)", () => {
+    // Defensive — today's callers all use path.basename so they're
+    // safe, but the chokepoint must reject if a future caller forgets.
+    assert.throws(() => wikiPagePath("../../etc/passwd", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
+
+  it("throws on slugs containing forward slashes", () => {
+    assert.throws(() => wikiPagePath("nested/page", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
+
+  it("throws on slugs containing backslashes (Windows traversal)", () => {
+    assert.throws(() => wikiPagePath("evil\\..\\foo", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
+
+  it("throws on dot-prefixed slugs (hidden files / VCS metadata)", () => {
+    assert.throws(() => wikiPagePath(".gitignore", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
+
+  it("throws on the empty slug", () => {
+    assert.throws(() => wikiPagePath("", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
+
+  it("throws on slugs with NUL bytes", () => {
+    assert.throws(() => wikiPagePath("foo\0bar", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  });
 });
 
 describe("wiki-pages/io — readWikiPage", () => {
@@ -87,6 +120,24 @@ describe("wiki-pages/io — writeWikiPage", () => {
     const entries = await readdir(pagesDir);
     const stragglers = entries.filter((name) => name.endsWith(".tmp"));
     assert.deepEqual(stragglers, []);
+  });
+
+  it("isolates concurrent writes via uniqueTmp (no .tmp collision)", async () => {
+    // Two concurrent writes to the same slug must each use a
+    // different staging filename, otherwise one will fail with
+    // ENOENT mid-rename. The test for uniqueTmp is observable as
+    // "both writes complete without throwing".
+    const writes = Promise.all([
+      writeWikiPage("race", "writer-a\n", { editor: "user" }, { workspaceRoot }),
+      writeWikiPage("race", "writer-b\n", { editor: "system", sessionId: "s" }, { workspaceRoot }),
+    ]);
+    await assert.doesNotReject(writes);
+
+    // The final content is one of the two — we don't assert which,
+    // because rename order is racey and the test asserts isolation,
+    // not last-write-wins semantics.
+    const final = await readFile(wikiPagePath("race", { workspaceRoot }), "utf-8");
+    assert.ok(final === "writer-a\n" || final === "writer-b\n", `unexpected content: ${final}`);
   });
 
   it("accepts every editor identity without distinction (PR 1 no-op)", async () => {

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -191,6 +191,15 @@ describe("wiki-pages/io — classifyAsWikiPage", () => {
     assert.deepEqual(out, { wiki: false });
   });
 
+  it("accepts page names whose basename starts with `..` (e.g. `..foo.md`)", () => {
+    // Codex iter-3 #883: an over-strict `rel.startsWith("..")` rule
+    // would have wrongly rejected this legitimate single-segment
+    // filename. The proper escape check is the separator presence,
+    // which `..foo.md` doesn't trip.
+    const out = classifyAsWikiPage(path.join(pagesDir, "..foo.md"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: true, slug: "..foo" });
+  });
+
   it("rejects paths outside the workspace entirely", () => {
     const out = classifyAsWikiPage("/etc/passwd", { workspaceRoot: root });
     assert.deepEqual(out, { wiki: false });

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -10,7 +10,7 @@
 
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { classifyAsWikiPage, readWikiPage, wikiPagePath, writeWikiPage } from "../../../server/workspace/wiki-pages/io.js";
@@ -48,8 +48,17 @@ describe("wiki-pages/io — wikiPagePath", () => {
     assert.throws(() => wikiPagePath("evil\\..\\foo", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
   });
 
-  it("throws on dot-prefixed slugs (hidden files / VCS metadata)", () => {
-    assert.throws(() => wikiPagePath(".gitignore", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+  it("accepts dot-prefixed slugs (e.g. existing `.foo.md` files)", () => {
+    // Codex iter-2 #883: previously rejected. Aesthetic concern,
+    // not security — pre-existing dotfile pages must keep working
+    // through the chokepoint.
+    const out = wikiPagePath(".gitignore", { workspaceRoot: "/tmp/ws" });
+    assert.equal(out, path.join("/tmp/ws", WORKSPACE_DIRS.wikiPages, ".gitignore.md"));
+  });
+
+  it("throws on `.` / `..` slugs (resolve outside or into pagesDir itself)", () => {
+    assert.throws(() => wikiPagePath(".", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
+    assert.throws(() => wikiPagePath("..", { workspaceRoot: "/tmp/ws" }), /unsafe slug/);
   });
 
   it("throws on the empty slug", () => {
@@ -190,5 +199,77 @@ describe("wiki-pages/io — classifyAsWikiPage", () => {
   it("rejects pagesDir itself (no slug)", () => {
     const out = classifyAsWikiPage(pagesDir, { workspaceRoot: root });
     assert.deepEqual(out, { wiki: false });
+  });
+});
+
+// Symlink regression for codex iter-1 #883 — the bug was that
+// `resolveSafe()` returns a realpath'd absPath while the un-realpath'd
+// `defaultWorkspacePath` is used as the comparison root, so a
+// symlinked workspace silently routed wiki writes through the
+// generic writer. Pin both behaviours: the buggy mismatch returns
+// `{ wiki: false }`, and the fixed call (both sides realpath'd)
+// returns `{ wiki: true }`.
+describe("wiki-pages/io — classifyAsWikiPage symlink consistency", () => {
+  let realRoot: string;
+  let linkRoot: string;
+  let symlinkSupported = true;
+
+  before(async () => {
+    realRoot = await mkdtemp(path.join(tmpdir(), "wiki-pages-real-"));
+    // mkdtemp on macOS returns a path under /var/folders that is
+    // already a symlink to /private/var/folders. Use realpath to
+    // anchor `realRoot` to the actual filesystem location, so the
+    // "fixed call" branch below is genuinely realpath-vs-realpath.
+    realRoot = await realpath(realRoot);
+    linkRoot = path.join(tmpdir(), `wiki-pages-link-${path.basename(realRoot)}`);
+    try {
+      await symlink(realRoot, linkRoot, "dir");
+    } catch (err) {
+      // Windows requires admin / Developer Mode for unprivileged
+      // symlinks. Skip on environments where that fails so CI
+      // (windows-2022) doesn't hard-fail.
+      const code = (err as { code?: string }).code;
+      if (code === "EPERM" || code === "EACCES") {
+        symlinkSupported = false;
+      } else {
+        throw err;
+      }
+    }
+    if (symlinkSupported) {
+      const realPagesDir = path.join(realRoot, WORKSPACE_DIRS.wikiPages);
+      await mkdir(realPagesDir, { recursive: true });
+    }
+  });
+
+  after(async () => {
+    if (symlinkSupported) {
+      await rm(linkRoot, { force: true });
+    }
+    await rm(realRoot, { recursive: true, force: true });
+  });
+
+  it("buggy mismatch (realpath'd absPath, symlinked root) returns wiki:false", (ctx) => {
+    if (!symlinkSupported) {
+      ctx.skip("symlink creation not supported in this environment");
+      return;
+    }
+    const realPagePath = path.join(realRoot, WORKSPACE_DIRS.wikiPages, "topic.md");
+    // Caller forgot to realpath the workspace root — reproduces the
+    // pre-fix behaviour. The classifier returns `wiki: false` and
+    // the generic writer would have been used, bypassing the chokepoint.
+    const out = classifyAsWikiPage(realPagePath, { workspaceRoot: linkRoot });
+    assert.deepEqual(out, { wiki: false });
+  });
+
+  it("fixed call (both sides realpath'd) returns wiki:true", (ctx) => {
+    if (!symlinkSupported) {
+      ctx.skip("symlink creation not supported in this environment");
+      return;
+    }
+    const realPagePath = path.join(realRoot, WORKSPACE_DIRS.wikiPages, "topic.md");
+    // Caller correctly passes the realpath'd root. This is what
+    // `files.ts` does post-fix (`workspaceReal`).
+    const out = classifyAsWikiPage(realPagePath, { workspaceRoot: realRoot });
+    assert.deepEqual(out, { wiki: true, slug: "topic" });
   });
 });


### PR DESCRIPTION
## Summary

- Funnel all 3 wiki page write call sites through a single `writeWikiPage(slug, content, meta)` helper in `server/workspace/wiki-pages/io.ts`.
- Side-effect: fix the `wiki-backlinks` driver's non-atomic `fsp.writeFile` direct call — it now goes through the same atomic write path.
- `appendSnapshot` is wired in but no-op. PR 2 (#763) fills it in with the actual edit-history pipeline; this PR is a pure refactor.

## Items to Confirm / Review

- **Editor identity placeholder**: the wiki route (`saveExistingPage`) and the generic file PUT both pass `editor: "user"`. The wiki route is hit by both LLM (via `manageWiki` MCP) and the frontend's task-checkbox click — the LLM/user split needs a request-side flag. **Deferred to PR 2** intentionally so this PR stays a no-op refactor. wiki-backlinks correctly tags `editor: "system"` from day 1.
- **`classifyAsWikiPage`** rejects paths under `data/wiki/sources/`, `data/wiki/index.md`, nested subdirs, traversal escapes, and non-md extensions. Verify the predicate isn't too strict for any future layout you're planning (e.g., `data/wiki/pages/foo/bar.md` for nested topics is currently rejected).
- **wiki-backlinks `deps.writeFile` seam**: existing tests inject their own `writeFile` mock and continue to work because the dep dictionary spread is `{ ...buildDefaultDeps(...), ...opts.deps }`. If you have integration tests that rely on the *default* hitting `fsp.writeFile` directly, they'd now go through `writeWikiPage` (which still ends at `writeFileAtomic`).

## User Prompt

#763 を進めて。まず wiki の write は 1 つの関数にまとめたほうが良いね。そのうえで file 書き込み関数には filter 処理追加できるようにする?

(議論の結果、`writeFileAtomic` 自体への hook は YAGNI — editor identity が call site にしかないので、ドメイン関数 `writeWikiPage` で受けるのが正解、と合意。3 PR 分割で進める。これは PR 1。)

## Implementation

### `server/workspace/wiki-pages/io.ts` (new)

- `writeWikiPage(slug, content, meta, opts?)` — atomic write + snapshot stub
- `readWikiPage(slug, opts?)` — null-safe reader
- `wikiPagePath(slug, opts?)` — absolute path resolver
- `classifyAsWikiPage(absPath, opts?)` — `{ wiki: true, slug } | { wiki: false }` predicate for routing
- `WikiPageEditor = "llm" | "user" | "system"` — identity tag captured at the call site
- `appendSnapshot` — private no-op stub, replaced by PR 2

### Migrated callers

| Caller | Before | After |
|---|---|---|
| `server/api/routes/wiki.ts:513` | `writeFileAtomic(absPath, content)` | `writeWikiPage(slug, content, { editor: "user" })` |
| `server/api/routes/files.ts:766` | `writeFileAtomic(absPath, contentRaw, { uniqueTmp: true })` | `classifyAsWikiPage` then either `writeWikiPage` or the generic atomic write |
| `server/workspace/wiki-backlinks/index.ts:43` | `fsp.writeFile(filePath, content, "utf-8")` (**non-atomic!**) | `writeWikiPage(slug, content, { editor: "system", sessionId })` |

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (24 pre-existing warnings unchanged)
- [x] `yarn build` clean
- [x] `yarn test` — new 17 cases pass + existing `wiki-backlinks` (14) + `wikiSaveRoute` (10) still pass
- [ ] CI e2e — verify wiki save / file content PUT flows still green (no UI/API contract changed)

## Out of scope (follow-up PRs)

- **PR 2**: snapshot ストレージ実装 (`appendSnapshot` 本体) + GC + size limit
- **PR 3**: API endpoints (history list / diff / restore) + `View.vue` History tab + restore UX + e2e
- editor identity の LLM/user 分離 (PR 2 で扱う、今は `'user'` placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified wiki write system: wiki page saves, file write endpoints, and backlink updates now flow through a centralized, atomic write and edit-history pipeline to ensure consistent edit tracking.

* **Tests**
  * Added comprehensive tests for wiki I/O: path validation, safe reads, atomic writes (including concurrent writes), and classification rules to prevent unsafe or non-wiki writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->