### PR TITLE
feat(files): atomic writes for artifact stores (closes #881 v1)

### DIFF
--- a/plans/feat-atomic-artifacts-stores.md
+++ b/plans/feat-atomic-artifacts-stores.md
@@ -1,0 +1,43 @@
+# Atomic artifact stores (v1 of #881)
+
+GitHub: https://github.com/receptron/mulmoclaude/issues/881
+
+## Outcome
+
+The 3 artifact stores (markdown / spreadsheet / image) all route their
+`save*` and `overwrite*` writes through `writeFileAtomic` instead of
+`fs/promises.writeFile` directly. A crashed write can no longer leave
+a half-written file on disk; Windows rename retries are inherited
+"for free" via the existing helper.
+
+## Steps
+
+1. **Widen `writeFileAtomic` signature** to accept binary too.
+   - `content: string | Uint8Array` (Buffer extends Uint8Array, so PNG
+     bytes flow through without conversion).
+   - Drop the hardcoded `encoding: "utf-8"` option when content isn't
+     a string — Node's `writeFile` auto-dispatches.
+   - Same widening for `writeFileAtomicSync`.
+
+2. **Update the 3 stores** (6 call sites total):
+   - `server/utils/files/markdown-store.ts`: `saveMarkdown`,
+     `overwriteMarkdown` — string content.
+   - `server/utils/files/spreadsheet-store.ts`: `saveSpreadsheet`,
+     `overwriteSpreadsheet` — JSON-string content.
+   - `server/utils/files/image-store.ts`: `saveImage`, `overwriteImage`
+     — Buffer content (`Buffer.from(base64, "base64")`).
+
+3. **Tests** in `test/utils/files/test_atomic.ts` (extend or add):
+   - Buffer round-trip (write → read → bytes match).
+   - String round-trip still works after the type widening.
+   - Tmp cleanup on crash still triggers regardless of content type.
+
+4. Local checks (`yarn format / lint / typecheck / build / test`),
+   plus a grep over `server/utils/files/` to confirm no remaining
+   bare `writeFile` / `writeFileSync` in the 3 stores.
+
+## Out of scope
+
+- v2 items in #881 (wiki-backlinks, tool-trace, json.ts sync, mulmo-script)
+- Append-only paths (logger / session-io)
+- Migration scripts

--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -84,19 +84,28 @@ function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
   renameSync(fromPath, toPath);
 }
 
+// Binary writes (PNGs, etc.) come in as Uint8Array / Buffer. Strings
+// stay text-encoded as utf-8. Forcing utf-8 on a Uint8Array would
+// re-encode the bytes, which is exactly what we don't want for
+// images. Pick the encoding option per content type.
+function writeOptionsFor(content: string | Uint8Array, mode: number | undefined): { encoding?: "utf-8"; mode?: number } {
+  return typeof content === "string" ? { encoding: "utf-8", mode } : { mode };
+}
+
 /**
  * Write `content` to `filePath` atomically. The parent directory is
  * created if missing. The tmp file is cleaned up on failure so a
  * crashed partial write can't wedge the next try.
+ *
+ * Accepts either text (utf-8 encoded) or binary content. Buffers
+ * extend `Uint8Array`, so PNG / other binary blobs pass through
+ * without conversion.
  */
-export async function writeFileAtomic(filePath: string, content: string, opts: WriteAtomicOptions = {}): Promise<void> {
+export async function writeFileAtomic(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): Promise<void> {
   const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   await promises.mkdir(path.dirname(filePath), { recursive: true });
   try {
-    await promises.writeFile(tmp, content, {
-      encoding: "utf-8",
-      mode: opts.mode,
-    });
+    await promises.writeFile(tmp, content, writeOptionsFor(content, opts.mode));
     await renameWithWindowsRetry(tmp, filePath);
   } catch (err) {
     await promises.unlink(tmp).catch(() => {});
@@ -107,13 +116,14 @@ export async function writeFileAtomic(filePath: string, content: string, opts: W
 /**
  * Synchronous atomic write for callers that need it (e.g. server
  * startup, config saves that must complete before the next line).
- * Same contract as `writeFileAtomic` but blocking.
+ * Same contract as `writeFileAtomic` but blocking. Binary content
+ * (Buffer / Uint8Array) is supported the same way.
  */
-export function writeFileAtomicSync(filePath: string, content: string, opts: WriteAtomicOptions = {}): void {
+export function writeFileAtomicSync(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): void {
   const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   mkdirSync(path.dirname(filePath), { recursive: true });
   try {
-    writeFileSync(tmp, content, { encoding: "utf-8", mode: opts.mode });
+    writeFileSync(tmp, content, writeOptionsFor(content, opts.mode));
     renameSyncWithWindowsRetry(tmp, filePath);
   } catch (err) {
     try {

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile, realpath, writeFile } from "fs/promises";
+import { mkdir, readFile, realpath } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
+import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
 import { resolveWithinRoot } from "./safe.js";
 
@@ -35,21 +36,24 @@ async function safeResolve(relativePath: string): Promise<string> {
 
 /** Save raw base64 (no data URI prefix) as a PNG file. New files
  *  land under `images/YYYY/MM/` (UTC) so the dir doesn't accumulate
- *  unbounded — see #764. Returns the workspace-relative path. */
+ *  unbounded — see #764. Returns the workspace-relative path.
+ *  Atomic: a crashed write can't leave a half-written PNG on disk
+ *  (#881 v1). `writeFileAtomic` accepts Buffer directly, so the raw
+ *  PNG bytes pass through without re-encoding. */
 export async function saveImage(base64Data: string): Promise<string> {
   await ensureImagesDir();
   const partition = yearMonthUtc();
-  const parentAbs = path.join(IMAGES_DIR, partition);
-  await mkdir(parentAbs, { recursive: true });
   const filename = `${shortId()}.png`;
-  await writeFile(path.join(parentAbs, filename), Buffer.from(base64Data, "base64"));
+  const absPath = path.join(IMAGES_DIR, partition, filename);
+  await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
   return path.posix.join(WORKSPACE_DIRS.images, partition, filename);
 }
 
-/** Overwrite an existing image file. The relativePath must start with "images/". */
+/** Overwrite an existing image file. The relativePath must start with "images/".
+ *  Atomic — see {@link saveImage}. */
 export async function overwriteImage(relativePath: string, base64Data: string): Promise<void> {
   const absPath = await safeResolve(relativePath);
-  await writeFile(absPath, Buffer.from(base64Data, "base64"));
+  await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
 }
 
 /** Read an image file and return raw base64 (no data URI prefix). */

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
+import { writeFileAtomic } from "./atomic.js";
 import { buildArtifactPathRandom } from "./naming.js";
 
 /**
@@ -9,15 +10,16 @@ import { buildArtifactPathRandom } from "./naming.js";
  * `prefix` is slugified; a random id is always appended to prevent
  * collisions between concurrent writers sharing the same prefix.
  *
- * `buildArtifactPathRandom` now injects a `YYYY/MM` partition (#764),
- * so this function ensures the partition directory exists before
- * writing — `writeFile` doesn't create missing parents on its own.
+ * `buildArtifactPathRandom` injects a `YYYY/MM` partition (#764) and
+ * `writeFileAtomic` creates missing parents itself, so callers don't
+ * need a separate `mkdir` step.
+ *
+ * Atomic: a crashed write can't leave a half-written .md (#881 v1).
  */
 export async function saveMarkdown(content: string, prefix: string): Promise<string> {
   const relPath = buildArtifactPathRandom(WORKSPACE_DIRS.markdowns, prefix, ".md", "document");
   const absPath = path.join(workspacePath, relPath);
-  await mkdir(path.dirname(absPath), { recursive: true });
-  await writeFile(absPath, content, "utf-8");
+  await writeFileAtomic(absPath, content);
   return relPath;
 }
 
@@ -27,10 +29,10 @@ export async function loadMarkdown(relativePath: string): Promise<string> {
   return readFile(absPath, "utf-8");
 }
 
-/** Overwrite an existing markdown file. */
+/** Overwrite an existing markdown file. Atomic — see {@link saveMarkdown}. */
 export async function overwriteMarkdown(relativePath: string, content: string): Promise<void> {
   const absPath = path.join(workspacePath, relativePath);
-  await writeFile(absPath, content, "utf-8");
+  await writeFileAtomic(absPath, content);
 }
 
 /** Check if a string is a markdown file path (not inline content).

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -1,7 +1,8 @@
-import { mkdir, realpath, writeFile } from "fs/promises";
+import { mkdir, realpath } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
+import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
 import { resolveWithinRoot } from "./safe.js";
 
@@ -36,21 +37,22 @@ async function safeResolve(relativePath: string): Promise<string> {
 
 /** Save sheets array as a JSON file. New files land under
  *  `spreadsheets/YYYY/MM/` (UTC) so the dir doesn't accumulate
- *  unbounded — see #764. Returns the workspace-relative path. */
+ *  unbounded — see #764. Returns the workspace-relative path.
+ *  Atomic: writeFileAtomic creates the partition dir and prevents
+ *  half-written JSON on crash (#881 v1). */
 export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   await ensureSpreadsheetsDir();
   const partition = yearMonthUtc();
-  const parentAbs = path.join(SPREADSHEETS_DIR, partition);
-  await mkdir(parentAbs, { recursive: true });
   const filename = `${shortId()}.json`;
-  await writeFile(path.join(parentAbs, filename), JSON.stringify(sheets), "utf-8");
+  const absPath = path.join(SPREADSHEETS_DIR, partition, filename);
+  await writeFileAtomic(absPath, JSON.stringify(sheets));
   return path.posix.join(WORKSPACE_DIRS.spreadsheets, partition, filename);
 }
 
-/** Overwrite an existing spreadsheet file. */
+/** Overwrite an existing spreadsheet file. Atomic — see {@link saveSpreadsheet}. */
 export async function overwriteSpreadsheet(relativePath: string, sheets: unknown[]): Promise<void> {
   const absPath = await safeResolve(relativePath);
-  await writeFile(absPath, JSON.stringify(sheets), "utf-8");
+  await writeFileAtomic(absPath, JSON.stringify(sheets));
 }
 
 /** Check if a string is a spreadsheet file path (not inline data).

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -128,4 +128,23 @@ describe("writeFileAtomic — binary content (#881 v1)", () => {
     assert.equal(read.length, 4);
     assert.deepEqual([...read], [0x80, 0x81, 0xfe, 0xff]);
   });
+
+  it("applies file mode for Buffer content", async () => {
+    if (process.platform === "win32") return; // chmod no-op on Windows
+    const file = path.join(tmpDir, "bin-mode.bin");
+    await writeFileAtomic(file, Buffer.from([1, 2, 3]), { mode: 0o600 });
+    const stat = statSync(file);
+    assert.equal(stat.mode & 0o777, 0o600);
+  });
+
+  it("cleans up tmp file on Buffer write failure", async () => {
+    // Targeting a directory forces writeFile to reject regardless
+    // of content type — same shape as the string failure test, just
+    // pinning that the binary path also unlinks the tmp.
+    const dir = path.join(tmpDir, "bin-is-a-dir");
+    mkdirSync(dir, { recursive: true });
+    await assert.rejects(() => writeFileAtomic(dir, Buffer.from([1, 2, 3])));
+    const siblings = readdirSync(path.dirname(dir));
+    assert.equal(siblings.filter((file) => file.endsWith(".tmp")).length, 0);
+  });
 });

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -84,3 +84,48 @@ describe("writeFileAtomicSync", () => {
     assert.equal(siblings.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 });
+
+describe("writeFileAtomic — binary content (#881 v1)", () => {
+  // PNG signature + IHDR for a 1x1 transparent PNG. Easier to write
+  // a real-shaped byte sequence than to assert "any bytes" — we want
+  // to confirm the bytes round-trip *exactly*, with no utf-8 mangling.
+  const PNG_BYTES = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+    0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+  ]);
+
+  it("writes a Buffer round-trip without re-encoding (async)", async () => {
+    const file = path.join(tmpDir, "bin-async.png");
+    await writeFileAtomic(file, PNG_BYTES);
+    const read = readFileSync(file);
+    assert.deepEqual([...read], [...PNG_BYTES]);
+  });
+
+  it("writes a Buffer round-trip without re-encoding (sync)", () => {
+    const file = path.join(tmpDir, "bin-sync.png");
+    writeFileAtomicSync(file, PNG_BYTES);
+    const read = readFileSync(file);
+    assert.deepEqual([...read], [...PNG_BYTES]);
+  });
+
+  it("accepts a plain Uint8Array (not just Buffer)", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const file = path.join(tmpDir, "bin-u8.bin");
+    await writeFileAtomic(file, bytes);
+    const read = readFileSync(file);
+    assert.deepEqual([...read], [1, 2, 3, 4, 5]);
+  });
+
+  it("does NOT re-encode bytes as utf-8 — high bytes survive", async () => {
+    // 0x80–0xFF are valid bytes in a binary file but invalid stand-
+    // alone utf-8 sequences; if the implementation accidentally
+    // forced encoding="utf-8" the file would gain replacement
+    // characters and the size would change.
+    const bytes = Buffer.from([0x80, 0x81, 0xfe, 0xff]);
+    const file = path.join(tmpDir, "bin-high.bin");
+    await writeFileAtomic(file, bytes);
+    const read = readFileSync(file);
+    assert.equal(read.length, 4);
+    assert.deepEqual([...read], [0x80, 0x81, 0xfe, 0xff]);
+  });
+});


### PR DESCRIPTION
## Summary

The 3 artifact stores (markdown / spreadsheet / image) used to call \`fs/promises.writeFile\` directly. A crash mid-write could leave a half-written file on disk and the next reader would see corruption. This PR routes every \`save*\` / \`overwrite*\` through \`writeFileAtomic\` so readers always see the old file or the new file — never anything in between. Windows rename retries are inherited from the existing helper for free.

Closes #881 (v1 — HIGH bucket).

## Items to Confirm / Review

- [ ] **Buffer support widening** — \`writeFileAtomic\` / \`writeFileAtomicSync\` signatures gain \`Uint8Array\`. The encoding option is dropped for binary content so high bytes (0x80–0xFF) round-trip verbatim. Pinned by a regression test using a real 33-byte PNG header plus a 0x80/0x81/0xFE/0xFF probe.
- [ ] **No re-encoding for images** — \`Buffer.from(base64, "base64")\` is now passed straight to \`writeFileAtomic\`. Confirmed there's no detour through utf-8.
- [ ] **mkdir step removed where possible** — \`writeFileAtomic\` creates the parent dir itself, so the explicit \`mkdir(parentAbs, { recursive: true })\` calls in the 3 stores are gone. The \`ensureXxxDir\` realpath caches stay (still needed by \`safeResolve\`).
- [ ] **No remaining direct fs.writeFile in the 3 stores** — \`grep -nE 'writeFile(Sync)?' server/utils/files/{markdown,spreadsheet,image}-store.ts | grep -v writeFileAtomic\` returns zero hits.
- [ ] **v2 deferred** — \`wiki-backlinks\`, \`tool-trace\`, \`json.ts:saveJsonFile\`, \`mulmo-script:621 writeFileSync\` are explicitly out of scope; tracked on #881.

## Files

- \`server/utils/files/atomic.ts\` — type widen + helper to pick the encoding option per content type.
- \`server/utils/files/{markdown,spreadsheet,image}-store.ts\` — 6 call sites converted, redundant \`mkdir\` lines dropped.
- \`test/utils/files/test_atomic.ts\` — 4 new binary-content tests (Buffer async, Buffer sync, plain Uint8Array, 0x80–0xFF passthrough).
- \`plans/feat-atomic-artifacts-stores.md\` — design / scope notes.

## User Prompt

> このチケットの概要、ざっくりおしえて
> あ、おけ。v1すすめて。