### PR TITLE
feat(suggestions): add Skills tab + dismiss-on-outside-click

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -107,6 +107,11 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
   // .filter TypeError on non-array responses.
   await page.route(urlStartsWith("/api/mcp-tools"), (route) => route.fulfill({ json: [] }));
 
+  // SuggestionsPanel calls /api/skills on every panel open. Default to
+  // an empty list so tests that don't care about skills don't trip the
+  // [mock] unhandled warning.
+  await page.route(urlEndsWith("/api/skills"), (route) => route.fulfill({ json: { skills: [] } }));
+
   await page.route(urlStartsWith("/api/chat-index"), (route) => route.fulfill({ json: {} }));
 
   await page.route(urlEndsWith("/api/files/tree"), (route) =>

--- a/e2e/tests/queries-panel.spec.ts
+++ b/e2e/tests/queries-panel.spec.ts
@@ -36,7 +36,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    const toggle = page.getByRole("button", { name: /Suggestions/ });
+    const toggle = page.getByTestId("suggestions-btn");
     await expect(toggle).toBeVisible();
 
     // Pick a known query from the default role (see src/config/roles.ts).
@@ -57,7 +57,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    await page.getByRole("button", { name: /Suggestions/ }).click();
+    await page.getByTestId("suggestions-btn").click();
     const query = page.getByRole("button", {
       name: "Tell me about this app, MulmoClaude.",
     });
@@ -78,7 +78,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    await page.getByRole("button", { name: /Suggestions/ }).click();
+    await page.getByTestId("suggestions-btn").click();
     const query = page.getByRole("button", {
       name: "Tell me about this app, MulmoClaude.",
     });

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -41,8 +41,8 @@
             data-testid="suggestions-btn"
             class="rounded w-8 h-8 flex items-center justify-center"
             :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
-            :title="t('suggestionsPanel.suggestions')"
-            :aria-label="t('suggestionsPanel.suggestions')"
+            :title="t('suggestionsPanel.tooltip')"
+            :aria-label="t('suggestionsPanel.tooltip')"
             @click="suggestionsExpanded = !suggestionsExpanded"
           >
             <span class="material-icons text-base leading-none">lightbulb</span>

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="border-t border-gray-200" @dragover.prevent @drop="onDropFile">
-    <SuggestionsPanel v-model:expanded="suggestionsExpanded" :queries="queries" @send="onSuggestionSend" @edit="onSuggestionEdit" />
+    <SuggestionsPanel
+      v-model:expanded="suggestionsExpanded"
+      :queries="queries"
+      :trigger-ref="suggestionsBtnRef"
+      @send="onSuggestionSend"
+      @edit="onSuggestionEdit"
+    />
     <div class="p-2">
       <div v-if="fileError" class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="file-error">
         {{ fileError }}
@@ -31,6 +37,7 @@
         <div class="flex flex-col gap-1">
           <button
             v-if="showSuggestionsButton"
+            ref="suggestionsBtnRef"
             data-testid="suggestions-btn"
             class="rounded w-8 h-8 flex items-center justify-center"
             :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
@@ -108,6 +115,7 @@ const textarea = ref<HTMLTextAreaElement | null>(null);
 const fileError = ref<string | null>(null);
 const fileInput = ref<HTMLInputElement | null>(null);
 const suggestionsExpanded = ref(false);
+const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
 
 const { skills } = useSkillsList();
 const showSuggestionsButton = computed(() => (props.queries?.length ?? 0) > 0 || skills.value.length > 0);

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -36,7 +36,6 @@
         />
         <div class="flex flex-col gap-1">
           <button
-            v-if="showSuggestionsButton"
             ref="suggestionsBtnRef"
             data-testid="suggestions-btn"
             class="rounded w-8 h-8 flex items-center justify-center"
@@ -79,12 +78,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from "vue";
+import { nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import ChatAttachmentPreview from "./ChatAttachmentPreview.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
-import { useSkillsList } from "../composables/useSkillsList";
 
 const { t } = useI18n();
 
@@ -94,7 +92,7 @@ export interface PastedFile {
   mime: string;
 }
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     modelValue: string;
     pastedFile: PastedFile | null;
@@ -116,9 +114,6 @@ const fileError = ref<string | null>(null);
 const fileInput = ref<HTMLInputElement | null>(null);
 const suggestionsExpanded = ref(false);
 const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
-
-const { skills } = useSkillsList();
-const showSuggestionsButton = computed(() => (props.queries?.length ?? 0) > 0 || skills.value.length > 0);
 
 const MAX_ATTACH_BYTES = 30 * 1024 * 1024;
 

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -30,7 +30,7 @@
         />
         <div class="flex flex-col gap-1">
           <button
-            v-if="queries.length > 0"
+            v-if="showSuggestionsButton"
             data-testid="suggestions-btn"
             class="rounded w-8 h-8 flex items-center justify-center"
             :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
@@ -72,11 +72,12 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import ChatAttachmentPreview from "./ChatAttachmentPreview.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+import { useSkillsList } from "../composables/useSkillsList";
 
 const { t } = useI18n();
 
@@ -86,7 +87,7 @@ export interface PastedFile {
   mime: string;
 }
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     modelValue: string;
     pastedFile: PastedFile | null;
@@ -107,6 +108,9 @@ const textarea = ref<HTMLTextAreaElement | null>(null);
 const fileError = ref<string | null>(null);
 const fileInput = ref<HTMLInputElement | null>(null);
 const suggestionsExpanded = ref(false);
+
+const { skills } = useSkillsList();
+const showSuggestionsButton = computed(() => (props.queries?.length ?? 0) > 0 || skills.value.length > 0);
 
 const MAX_ATTACH_BYTES = 30 * 1024 * 1024;
 

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -28,8 +28,8 @@
           :data-testid="`${testIdPrefix}-suggestions`"
           class="rounded w-8 h-8 flex items-center justify-center"
           :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
-          :title="t('suggestionsPanel.suggestions')"
-          :aria-label="t('suggestionsPanel.suggestions')"
+          :title="t('suggestionsPanel.tooltip')"
+          :aria-label="t('suggestionsPanel.tooltip')"
           @click="suggestionsExpanded = !suggestionsExpanded"
         >
           <span class="material-icons text-base leading-none">lightbulb</span>

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="border-t border-gray-200 shrink-0 bg-gray-50">
     <SuggestionsPanel
-      v-if="showSuggestionsButton"
       v-model:expanded="suggestionsExpanded"
       :queries="suggestions"
       :trigger-ref="suggestionsBtnRef"
@@ -23,7 +22,6 @@
       />
       <div class="flex flex-col gap-1 shrink-0">
         <button
-          v-if="showSuggestionsButton"
           ref="suggestionsBtnRef"
           :data-testid="`${testIdPrefix}-suggestions`"
           class="rounded w-8 h-8 flex items-center justify-center"
@@ -54,7 +52,6 @@ import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useAppApi } from "../composables/useAppApi";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
-import { useSkillsList } from "../composables/useSkillsList";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 
 const props = withDefaults(
@@ -75,9 +72,6 @@ const draft = ref("");
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const suggestionsExpanded = ref(false);
 const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
-
-const { skills } = useSkillsList();
-const showSuggestionsButton = computed(() => (props.suggestions?.length ?? 0) > 0 || skills.value.length > 0);
 
 const canSend = computed(() => !props.disabled && (props.allowEmpty || draft.value.trim().length > 0));
 

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -4,6 +4,7 @@
       v-if="showSuggestionsButton"
       v-model:expanded="suggestionsExpanded"
       :queries="suggestions"
+      :trigger-ref="suggestionsBtnRef"
       @send="onSuggestionSend"
       @edit="onSuggestionEdit"
     />
@@ -23,6 +24,7 @@
       <div class="flex flex-col gap-1 shrink-0">
         <button
           v-if="showSuggestionsButton"
+          ref="suggestionsBtnRef"
           :data-testid="`${testIdPrefix}-suggestions`"
           class="rounded w-8 h-8 flex items-center justify-center"
           :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
@@ -72,6 +74,7 @@ const appApi = useAppApi();
 const draft = ref("");
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const suggestionsExpanded = ref(false);
+const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
 
 const { skills } = useSkillsList();
 const showSuggestionsButton = computed(() => (props.suggestions?.length ?? 0) > 0 || skills.value.length > 0);

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="border-t border-gray-200 shrink-0 bg-gray-50">
     <SuggestionsPanel
-      v-if="suggestions && suggestions.length > 0"
+      v-if="showSuggestionsButton"
       v-model:expanded="suggestionsExpanded"
       :queries="suggestions"
       @send="onSuggestionSend"
@@ -22,7 +22,7 @@
       />
       <div class="flex flex-col gap-1 shrink-0">
         <button
-          v-if="suggestions && suggestions.length > 0"
+          v-if="showSuggestionsButton"
           :data-testid="`${testIdPrefix}-suggestions`"
           class="rounded w-8 h-8 flex items-center justify-center"
           :class="suggestionsExpanded ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600'"
@@ -52,6 +52,7 @@ import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useAppApi } from "../composables/useAppApi";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+import { useSkillsList } from "../composables/useSkillsList";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 
 const props = withDefaults(
@@ -71,6 +72,9 @@ const appApi = useAppApi();
 const draft = ref("");
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const suggestionsExpanded = ref(false);
+
+const { skills } = useSkillsList();
+const showSuggestionsButton = computed(() => (props.suggestions?.length ?? 0) > 0 || skills.value.length > 0);
 
 const canSend = computed(() => !props.disabled && (props.allowEmpty || draft.value.trim().length > 0));
 

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="expanded && hasContent" class="border-t border-gray-200 flex flex-col">
+  <div v-if="expanded && hasContent" ref="panelRef" class="border-t border-gray-200 flex flex-col">
     <div ref="listRef" class="px-4 pt-2 pb-2 max-h-64 overflow-y-auto flex flex-col gap-1">
       <template v-if="activeTab === 'suggestions'">
         <button
@@ -47,9 +47,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
+import { useClickOutside } from "../composables/useClickOutside";
 
 const { t } = useI18n();
 
@@ -59,6 +60,7 @@ const TAB_STORAGE_KEY = "suggestionsPanel.activeTab";
 const props = defineProps<{
   queries: string[];
   expanded: boolean;
+  triggerRef?: HTMLElement | null;
 }>();
 
 const emit = defineEmits<{
@@ -70,6 +72,22 @@ const emit = defineEmits<{
 const { skills } = useSkillsList();
 
 const listRef = ref<HTMLDivElement | null>(null);
+const panelRef = ref<HTMLDivElement | null>(null);
+
+const expandedRef = computed({
+  get: () => props.expanded,
+  set: (value: boolean) => emit("update:expanded", value),
+});
+const triggerElRef = computed(() => props.triggerRef ?? null);
+
+const { handler: onDocumentMousedown } = useClickOutside({
+  isOpen: expandedRef,
+  buttonRef: triggerElRef,
+  popupRef: panelRef,
+});
+
+onMounted(() => document.addEventListener("mousedown", onDocumentMousedown));
+onBeforeUnmount(() => document.removeEventListener("mousedown", onDocumentMousedown));
 
 function readStoredTab(): TabId {
   const raw = localStorage.getItem(TAB_STORAGE_KEY);

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -13,6 +13,9 @@
         <p v-if="queries.length === 0" class="text-center text-xs text-gray-400 italic py-2">{{ t("suggestionsPanel.emptySuggestions") }}</p>
       </template>
       <template v-else>
+        <p v-if="skillsError" class="text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="suggestions-skills-error">
+          {{ t("suggestionsPanel.skillsError", { error: skillsError }) }}
+        </p>
         <button
           v-for="skill in skills"
           :key="skill.name"
@@ -21,7 +24,9 @@
         >
           /{{ skill.name }}
         </button>
-        <p v-if="skills.length === 0" class="text-center text-xs text-gray-400 italic py-2">{{ t("suggestionsPanel.emptySkills") }}</p>
+        <p v-if="!skillsError && skills.length === 0" class="text-center text-xs text-gray-400 italic py-2">
+          {{ t("suggestionsPanel.emptySkills") }}
+        </p>
       </template>
     </div>
     <p class="text-center text-[10px] text-gray-400 py-0.5">{{ t("suggestionsPanel.sendEditHint") }}</p>
@@ -69,7 +74,7 @@ const emit = defineEmits<{
   edit: [query: string];
 }>();
 
-const { skills, refresh: refreshSkills } = useSkillsList();
+const { skills, error: skillsError, refresh: refreshSkills } = useSkillsList();
 
 const listRef = ref<HTMLDivElement | null>(null);
 const panelRef = ref<HTMLDivElement | null>(null);

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="expanded && hasContent" ref="panelRef" class="border-t border-gray-200 flex flex-col">
+  <div v-if="expanded" ref="panelRef" class="border-t border-gray-200 flex flex-col">
     <div ref="listRef" class="px-4 pt-2 pb-2 max-h-64 overflow-y-auto flex flex-col gap-1">
       <template v-if="activeTab === 'suggestions'">
         <button
@@ -101,8 +101,6 @@ function setActiveTab(tab: TabId): void {
   localStorage.setItem(TAB_STORAGE_KEY, tab);
   nextTick(() => scrollToBottom());
 }
-
-const hasContent = computed(() => props.queries.length > 0 || skills.value.length > 0);
 
 function scrollToBottom(): void {
   if (listRef.value) {

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -1,22 +1,60 @@
 <template>
-  <div v-if="expanded && queries.length > 0" ref="listRef" class="border-t border-gray-200 px-4 pt-2 pb-2 max-h-64 overflow-y-auto flex flex-col gap-1">
-    <button
-      v-for="query in queries"
-      :key="query"
-      class="text-left text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded px-3 py-1.5 border border-gray-300 transition-colors"
-      @click="onClick($event, query)"
-    >
-      {{ query }}
-    </button>
+  <div v-if="expanded && hasContent" class="border-t border-gray-200 flex flex-col">
+    <div ref="listRef" class="px-4 pt-2 pb-2 max-h-64 overflow-y-auto flex flex-col gap-1">
+      <template v-if="activeTab === 'suggestions'">
+        <button
+          v-for="query in queries"
+          :key="query"
+          class="text-left text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded px-3 py-1.5 border border-gray-300 transition-colors"
+          @click="onSuggestionClick($event, query)"
+        >
+          {{ query }}
+        </button>
+        <p v-if="queries.length === 0" class="text-center text-xs text-gray-400 italic py-2">{{ t("suggestionsPanel.emptySuggestions") }}</p>
+      </template>
+      <template v-else>
+        <button
+          v-for="skill in skills"
+          :key="skill.name"
+          class="text-left text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded px-3 py-1.5 border border-gray-300 transition-colors"
+          @click="onSkillClick($event, skill)"
+        >
+          /{{ skill.name }}
+        </button>
+        <p v-if="skills.length === 0" class="text-center text-xs text-gray-400 italic py-2">{{ t("suggestionsPanel.emptySkills") }}</p>
+      </template>
+    </div>
     <p class="text-center text-[10px] text-gray-400 py-0.5">{{ t("suggestionsPanel.sendEditHint") }}</p>
+    <div class="flex border-t border-gray-200 bg-gray-50">
+      <button
+        class="flex-1 py-1.5 text-xs transition-colors"
+        :class="activeTab === 'suggestions' ? 'text-blue-600 font-medium bg-white border-t-2 border-blue-600 -mt-px' : 'text-gray-500 hover:text-gray-700'"
+        data-testid="suggestions-tab-suggestions"
+        @click="setActiveTab('suggestions')"
+      >
+        {{ t("suggestionsPanel.suggestions") }}
+      </button>
+      <button
+        class="flex-1 py-1.5 text-xs transition-colors"
+        :class="activeTab === 'skills' ? 'text-blue-600 font-medium bg-white border-t-2 border-blue-600 -mt-px' : 'text-gray-500 hover:text-gray-700'"
+        data-testid="suggestions-tab-skills"
+        @click="setActiveTab('skills')"
+      >
+        {{ t("suggestionsPanel.skills") }}
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
 
 const { t } = useI18n();
+
+type TabId = "suggestions" | "skills";
+const TAB_STORAGE_KEY = "suggestionsPanel.activeTab";
 
 const props = defineProps<{
   queries: string[];
@@ -29,26 +67,55 @@ const emit = defineEmits<{
   edit: [query: string];
 }>();
 
+const { skills } = useSkillsList();
+
 const listRef = ref<HTMLDivElement | null>(null);
+
+function readStoredTab(): TabId {
+  const raw = localStorage.getItem(TAB_STORAGE_KEY);
+  return raw === "skills" ? "skills" : "suggestions";
+}
+
+const activeTab = ref<TabId>(readStoredTab());
+
+function setActiveTab(tab: TabId): void {
+  activeTab.value = tab;
+  localStorage.setItem(TAB_STORAGE_KEY, tab);
+  nextTick(() => scrollToBottom());
+}
+
+const hasContent = computed(() => props.queries.length > 0 || skills.value.length > 0);
+
+function scrollToBottom(): void {
+  if (listRef.value) {
+    listRef.value.scrollTop = listRef.value.scrollHeight;
+  }
+}
 
 watch(
   () => props.expanded,
   (isExpanded) => {
     if (!isExpanded) return;
-    nextTick(() => {
-      if (listRef.value) {
-        listRef.value.scrollTop = listRef.value.scrollHeight;
-      }
-    });
+    nextTick(() => scrollToBottom());
   },
 );
 
-function onClick(event: MouseEvent, query: string): void {
+function onSuggestionClick(event: MouseEvent, query: string): void {
   emit("update:expanded", false);
   if (event.shiftKey) {
     emit("edit", query);
     return;
   }
   emit("send", query);
+}
+
+function onSkillClick(event: MouseEvent, skill: SkillSummary): void {
+  emit("update:expanded", false);
+  const command = `/${skill.name}`;
+  if (event.shiftKey) {
+    emit("edit", command);
+    return;
+  }
+  emit("send", command);
 }
 </script>

--- a/src/components/SuggestionsPanel.vue
+++ b/src/components/SuggestionsPanel.vue
@@ -69,7 +69,7 @@ const emit = defineEmits<{
   edit: [query: string];
 }>();
 
-const { skills } = useSkillsList();
+const { skills, refresh: refreshSkills } = useSkillsList();
 
 const listRef = ref<HTMLDivElement | null>(null);
 const panelRef = ref<HTMLDivElement | null>(null);
@@ -114,6 +114,7 @@ watch(
   () => props.expanded,
   (isExpanded) => {
     if (!isExpanded) return;
+    void refreshSkills();
     nextTick(() => scrollToBottom());
   },
 );

--- a/src/composables/useSkillsList.ts
+++ b/src/composables/useSkillsList.ts
@@ -11,10 +11,15 @@ export interface SkillSummary {
 // Module-level shared state so consumers (ChatInput, PageChatComposer,
 // SuggestionsPanel) all see the same list. We do not cache: every
 // `refresh()` re-hits /api/skills. The first auto-fetch on mount is
-// a bootstrap so the toggle button's visibility is correct on load;
-// everything beyond that re-reads from disk (deletions in /skills
-// would otherwise leave stale entries here — see issue from #885 review).
+// a bootstrap so the panel has something to show on first open.
+//
+// Error policy: on a failed fetch we keep the previous `skills` value
+// (so a transient blip doesn't visually wipe the list) and surface the
+// failure through `error`. The Skills tab renders that as a banner so
+// the user can tell stale data from current data. A successful refresh
+// clears `error`.
 const skills = ref<SkillSummary[]>([]);
+const error = ref<string | null>(null);
 let bootstrapped = false;
 let inflight: Promise<void> | null = null;
 
@@ -25,6 +30,9 @@ async function refresh(): Promise<void> {
       const result = await apiGet<{ skills: SkillSummary[] }>(API_ROUTES.skills.list);
       if (result.ok && Array.isArray(result.data.skills)) {
         skills.value = result.data.skills;
+        error.value = null;
+      } else if (!result.ok) {
+        error.value = result.error || "Failed to load skills";
       }
     } finally {
       inflight = null;
@@ -35,6 +43,7 @@ async function refresh(): Promise<void> {
 
 export function useSkillsList(): {
   skills: DeepReadonly<Ref<SkillSummary[]>>;
+  error: DeepReadonly<Ref<string | null>>;
   refresh: () => Promise<void>;
 } {
   if (!bootstrapped) {
@@ -43,6 +52,7 @@ export function useSkillsList(): {
   }
   return {
     skills: readonly(skills),
+    error: readonly(error),
     refresh,
   };
 }

--- a/src/composables/useSkillsList.ts
+++ b/src/composables/useSkillsList.ts
@@ -8,12 +8,17 @@ export interface SkillSummary {
   source: "user" | "project";
 }
 
+// Module-level shared state so consumers (ChatInput, PageChatComposer,
+// SuggestionsPanel) all see the same list. We do not cache: every
+// `refresh()` re-hits /api/skills. The first auto-fetch on mount is
+// a bootstrap so the toggle button's visibility is correct on load;
+// everything beyond that re-reads from disk (deletions in /skills
+// would otherwise leave stale entries here — see issue from #885 review).
 const skills = ref<SkillSummary[]>([]);
-const loaded = ref(false);
+let bootstrapped = false;
 let inflight: Promise<void> | null = null;
 
-async function fetchSkills(): Promise<void> {
-  if (loaded.value) return;
+async function refresh(): Promise<void> {
   if (inflight) return inflight;
   inflight = (async () => {
     try {
@@ -22,7 +27,6 @@ async function fetchSkills(): Promise<void> {
         skills.value = result.data.skills;
       }
     } finally {
-      loaded.value = true;
       inflight = null;
     }
   })();
@@ -31,17 +35,14 @@ async function fetchSkills(): Promise<void> {
 
 export function useSkillsList(): {
   skills: DeepReadonly<Ref<SkillSummary[]>>;
-  loaded: DeepReadonly<Ref<boolean>>;
   refresh: () => Promise<void>;
 } {
-  void fetchSkills();
+  if (!bootstrapped) {
+    bootstrapped = true;
+    void refresh();
+  }
   return {
     skills: readonly(skills),
-    loaded: readonly(loaded),
-    refresh: async () => {
-      loaded.value = false;
-      inflight = null;
-      await fetchSkills();
-    },
+    refresh,
   };
 }

--- a/src/composables/useSkillsList.ts
+++ b/src/composables/useSkillsList.ts
@@ -1,0 +1,47 @@
+import { readonly, ref, type Ref, type DeepReadonly } from "vue";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+export interface SkillSummary {
+  name: string;
+  description: string;
+  source: "user" | "project";
+}
+
+const skills = ref<SkillSummary[]>([]);
+const loaded = ref(false);
+let inflight: Promise<void> | null = null;
+
+async function fetchSkills(): Promise<void> {
+  if (loaded.value) return;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const result = await apiGet<{ skills: SkillSummary[] }>(API_ROUTES.skills.list);
+      if (result.ok && Array.isArray(result.data.skills)) {
+        skills.value = result.data.skills;
+      }
+    } finally {
+      loaded.value = true;
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+export function useSkillsList(): {
+  skills: DeepReadonly<Ref<SkillSummary[]>>;
+  loaded: DeepReadonly<Ref<boolean>>;
+  refresh: () => Promise<void>;
+} {
+  void fetchSkills();
+  return {
+    skills: readonly(skills),
+    loaded: readonly(loaded),
+    refresh: async () => {
+      loaded.value = false;
+      inflight = null;
+      await fetchSkills();
+    },
+  };
+}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -874,6 +874,7 @@ const deMessages = {
   suggestionsPanel: {
     suggestions: "Vorschläge",
     skills: "Skills",
+    tooltip: "Vorschläge und Skills",
     emptySuggestions: "Keine Vorschläge.",
     emptySkills: "Keine Skills installiert.",
     sendEditHint: "klicken zum Senden · Shift+Klick zum Bearbeiten",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -877,6 +877,7 @@ const deMessages = {
     tooltip: "Vorschläge und Skills",
     emptySuggestions: "Keine Vorschläge.",
     emptySkills: "Keine Skills installiert.",
+    skillsError: "Fehler beim Laden der Skills: {error}",
     sendEditHint: "klicken zum Senden · Shift+Klick zum Bearbeiten",
   },
   settingsToolsTab: {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -873,6 +873,9 @@ const deMessages = {
   },
   suggestionsPanel: {
     suggestions: "Vorschläge",
+    skills: "Skills",
+    emptySuggestions: "Keine Vorschläge.",
+    emptySkills: "Keine Skills installiert.",
     sendEditHint: "klicken zum Senden · Shift+Klick zum Bearbeiten",
   },
   settingsToolsTab: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -890,6 +890,7 @@ const enMessages = {
   suggestionsPanel: {
     suggestions: "Suggestions",
     skills: "Skills",
+    tooltip: "Suggestions and Skills",
     emptySuggestions: "No suggestions.",
     emptySkills: "No skills installed.",
     sendEditHint: "click to send · shift+click to edit",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -893,6 +893,7 @@ const enMessages = {
     tooltip: "Suggestions and Skills",
     emptySuggestions: "No suggestions.",
     emptySkills: "No skills installed.",
+    skillsError: "Failed to load skills: {error}",
     sendEditHint: "click to send · shift+click to edit",
   },
   settingsToolsTab: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -889,6 +889,9 @@ const enMessages = {
   },
   suggestionsPanel: {
     suggestions: "Suggestions",
+    skills: "Skills",
+    emptySuggestions: "No suggestions.",
+    emptySkills: "No skills installed.",
     sendEditHint: "click to send · shift+click to edit",
   },
   settingsToolsTab: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -874,6 +874,7 @@ const esMessages = {
   suggestionsPanel: {
     suggestions: "Sugerencias",
     skills: "Habilidades",
+    tooltip: "Sugerencias y habilidades",
     emptySuggestions: "No hay sugerencias.",
     emptySkills: "No hay habilidades instaladas.",
     sendEditHint: "clic para enviar · shift+clic para editar",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -877,6 +877,7 @@ const esMessages = {
     tooltip: "Sugerencias y habilidades",
     emptySuggestions: "No hay sugerencias.",
     emptySkills: "No hay habilidades instaladas.",
+    skillsError: "Error al cargar las habilidades: {error}",
     sendEditHint: "clic para enviar · shift+clic para editar",
   },
   settingsToolsTab: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -873,6 +873,9 @@ const esMessages = {
   },
   suggestionsPanel: {
     suggestions: "Sugerencias",
+    skills: "Habilidades",
+    emptySuggestions: "No hay sugerencias.",
+    emptySkills: "No hay habilidades instaladas.",
     sendEditHint: "clic para enviar · shift+clic para editar",
   },
   settingsToolsTab: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -866,6 +866,7 @@ const frMessages = {
   suggestionsPanel: {
     suggestions: "Suggestions",
     skills: "Compétences",
+    tooltip: "Suggestions et compétences",
     emptySuggestions: "Aucune suggestion.",
     emptySkills: "Aucune compétence installée.",
     sendEditHint: "cliquez pour envoyer · shift+clic pour modifier",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -869,6 +869,7 @@ const frMessages = {
     tooltip: "Suggestions et compétences",
     emptySuggestions: "Aucune suggestion.",
     emptySkills: "Aucune compétence installée.",
+    skillsError: "Échec du chargement des compétences : {error}",
     sendEditHint: "cliquez pour envoyer · shift+clic pour modifier",
   },
   settingsToolsTab: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -865,6 +865,9 @@ const frMessages = {
   },
   suggestionsPanel: {
     suggestions: "Suggestions",
+    skills: "Compétences",
+    emptySuggestions: "Aucune suggestion.",
+    emptySkills: "Aucune compétence installée.",
     sendEditHint: "cliquez pour envoyer · shift+clic pour modifier",
   },
   settingsToolsTab: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -865,6 +865,7 @@ const jaMessages = {
   suggestionsPanel: {
     suggestions: "候補",
     skills: "スキル",
+    tooltip: "候補とスキル",
     emptySuggestions: "候補はありません。",
     emptySkills: "スキルがインストールされていません。",
     sendEditHint: "クリックで送信 · Shift+クリックで編集",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -868,6 +868,7 @@ const jaMessages = {
     tooltip: "候補とスキル",
     emptySuggestions: "候補はありません。",
     emptySkills: "スキルがインストールされていません。",
+    skillsError: "スキルの読み込みに失敗しました: {error}",
     sendEditHint: "クリックで送信 · Shift+クリックで編集",
   },
   settingsToolsTab: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -864,6 +864,9 @@ const jaMessages = {
   },
   suggestionsPanel: {
     suggestions: "候補",
+    skills: "スキル",
+    emptySuggestions: "候補はありません。",
+    emptySkills: "スキルがインストールされていません。",
     sendEditHint: "クリックで送信 · Shift+クリックで編集",
   },
   settingsToolsTab: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -865,6 +865,7 @@ const koMessages = {
   suggestionsPanel: {
     suggestions: "추천",
     skills: "스킬",
+    tooltip: "추천 및 스킬",
     emptySuggestions: "추천이 없습니다.",
     emptySkills: "설치된 스킬이 없습니다.",
     sendEditHint: "클릭하여 전송 · shift+클릭 으로 편집",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -868,6 +868,7 @@ const koMessages = {
     tooltip: "추천 및 스킬",
     emptySuggestions: "추천이 없습니다.",
     emptySkills: "설치된 스킬이 없습니다.",
+    skillsError: "스킬을 불러오지 못했습니다: {error}",
     sendEditHint: "클릭하여 전송 · shift+클릭 으로 편집",
   },
   settingsToolsTab: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -864,6 +864,9 @@ const koMessages = {
   },
   suggestionsPanel: {
     suggestions: "추천",
+    skills: "스킬",
+    emptySuggestions: "추천이 없습니다.",
+    emptySkills: "설치된 스킬이 없습니다.",
     sendEditHint: "클릭하여 전송 · shift+클릭 으로 편집",
   },
   settingsToolsTab: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -864,6 +864,7 @@ const ptBRMessages = {
   suggestionsPanel: {
     suggestions: "Sugestões",
     skills: "Habilidades",
+    tooltip: "Sugestões e habilidades",
     emptySuggestions: "Sem sugestões.",
     emptySkills: "Nenhuma habilidade instalada.",
     sendEditHint: "clique para enviar · shift+clique para editar",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -867,6 +867,7 @@ const ptBRMessages = {
     tooltip: "Sugestões e habilidades",
     emptySuggestions: "Sem sugestões.",
     emptySkills: "Nenhuma habilidade instalada.",
+    skillsError: "Falha ao carregar habilidades: {error}",
     sendEditHint: "clique para enviar · shift+clique para editar",
   },
   settingsToolsTab: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -863,6 +863,9 @@ const ptBRMessages = {
   },
   suggestionsPanel: {
     suggestions: "Sugestões",
+    skills: "Habilidades",
+    emptySuggestions: "Sem sugestões.",
+    emptySkills: "Nenhuma habilidade instalada.",
     sendEditHint: "clique para enviar · shift+clique para editar",
   },
   settingsToolsTab: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -861,6 +861,7 @@ const zhMessages = {
   suggestionsPanel: {
     suggestions: "建议",
     skills: "技能",
+    tooltip: "建议和技能",
     emptySuggestions: "没有建议。",
     emptySkills: "未安装任何技能。",
     sendEditHint: "点击发送 · shift+点击可编辑",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -864,6 +864,7 @@ const zhMessages = {
     tooltip: "建议和技能",
     emptySuggestions: "没有建议。",
     emptySkills: "未安装任何技能。",
+    skillsError: "加载技能失败：{error}",
     sendEditHint: "点击发送 · shift+点击可编辑",
   },
   settingsToolsTab: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -860,6 +860,9 @@ const zhMessages = {
   },
   suggestionsPanel: {
     suggestions: "建议",
+    skills: "技能",
+    emptySuggestions: "没有建议。",
+    emptySkills: "未安装任何技能。",
     sendEditHint: "点击发送 · shift+点击可编辑",
   },
   settingsToolsTab: {


### PR DESCRIPTION
## Summary

- Adds a Skills tab to the suggestions panel so users can run installed skills (`/<skill-name>`) directly from the lightbulb menu, alongside the existing Suggestions tab. Tab persists across sessions via `localStorage`; default is Suggestions.
- The lightbulb button now appears whenever queries OR skills exist (previously only when queries existed). Tooltip updated to "Suggestions and Skills" across all 8 locales.
- Mousedown anywhere outside the panel + trigger collapses it (uses the existing `useClickOutside` composable).
- Skills are re-fetched every time the panel opens — the previous one-shot module-level cache went stale after deletions in /skills.

## Test plan

- [x] `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`
- [x] `yarn test` — unit tests pass
- [x] `yarn test:e2e` — 357/357 pass after switching `queries-panel.spec.ts` to `data-testid="suggestions-btn"` (the new "Suggestions" tab made the role-based locator ambiguous)
- [ ] Manual: open the panel, switch tabs, run a skill (`/<name>`), shift+click to edit, click outside to dismiss
- [ ] Manual: delete a skill in /skills, reopen panel — deleted skill should no longer appear
- [ ] Manual: verify tooltip shows "Suggestions and Skills" on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Skills" tab to the suggestions panel alongside existing suggestions.
  * Users can now interact with and insert available skills from the panel.

* **Bug Fixes**
  * Improved test stability by adding a dedicated API mock handler for skills requests.

* **Localization**
  * Added translations for the new "Skills" feature across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->