### PR TITLE
feat(roles): enable presentMulmoScript in General role

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -46,6 +46,7 @@ export const ROLES: Role[] = [
       "manageSource",
       "presentDocument",
       "presentForm",
+      "presentMulmoScript",
       "createMindMap",
       "presentHtml",
       "presentChart",


### PR DESCRIPTION
## Summary
- Add `presentMulmoScript` to the General role's `availablePlugins` so users can create multi-slide presentations without switching to Office.

## Test plan
- [ ] Verify the General role can invoke `presentMulmoScript` end-to-end.
- [ ] Confirm `yarn lint` / `yarn typecheck` stay clean (already passing locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Allow the General role to invoke the presentMulmoScript presentation plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the presentation script capability for users with the General role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->