### PR TITLE
feat(presentMulmoScript): load-by-path + background movie generation

### DIFF
--- a/plans/feat-mulmo-script-load-and-background-movie.md
+++ b/plans/feat-mulmo-script-load-and-background-movie.md
@@ -16,8 +16,8 @@ The current tool takes `{ script, filename? }`. The new shape adds two optional 
 | Arg | Type | Required | Meaning |
 |---|---|---|---|
 | `script` | `object` (MulmoScript JSON) | one of `script` / `filePath` | Full script JSON. Use when **creating a new** presentation. Server saves it to disk and returns `{ script, filePath }`. |
-| `filePath` | `string` | one of `script` / `filePath` | Path to an existing `.mulmoscript.json` file inside the workspace. Use when **re-displaying** a previously created presentation. Server reads + validates the file and returns `{ script, filePath }`. |
-| `filename` | `string` | optional | Only meaningful with `script`. Defaults to a slug of the title. Ignored when `filePath` is given. |
+| `filePath` | `string` | one of `script` / `filePath` | Workspace-relative path to an existing MulmoScript JSON file under `stories/` (e.g. `stories/the-life-of-a-star-1700000000000.json`). Use when **re-displaying** a previously created presentation. Server reads + validates the file and returns `{ script, filePath }`. |
+| `filename` | `string` | optional | Only meaningful with `script`. Defaults to a slug of the title. Ignored when `filePath` is given. Slugified server-side (drops `/`, `\`, `..`, etc.) so a hostile value cannot escape `stories/`. |
 | `autoGenerateMovie` | `boolean` | optional, **default `false`** | When `true`, the server kicks off movie generation in the background after save / load. The user does not need to open the view; progress is tracked through the existing `pendingGenerations` channel. |
 
 ### "exactly one of script / filePath"
@@ -27,18 +27,18 @@ JSON Schema cannot cleanly express "exactly one of these two optional fields", s
 - **Tool description** spells out the rule plainly (Claude is the primary enforcer).
 - **Server endpoint** validates the request and rejects with a clear error if both or neither are present.
 
-### Three canonical invocations
+### Four canonical invocations
 
 ```jsonc
 // 1. Create + present (current behaviour, unchanged)
 { "script": { "$mulmocast": { "version": "1.1" }, "title": "...", ... } }
 
 // 2. Re-display an existing script
-{ "filePath": "artifacts/mulmoscripts/the-life-of-a-star.mulmoscript.json" }
+{ "filePath": "stories/the-life-of-a-star-1700000000000.json" }
 
 // 3. Re-display AND start movie generation in the background
 {
-  "filePath": "artifacts/mulmoscripts/the-life-of-a-star.mulmoscript.json",
+  "filePath": "stories/the-life-of-a-star-1700000000000.json",
   "autoGenerateMovie": true
 }
 
@@ -49,41 +49,45 @@ JSON Schema cannot cleanly express "exactly one of these two optional fields", s
 }
 ```
 
-## Server changes
+## Implementation
+
+### One unified endpoint, server-side dispatch
+
+The tool routes to a **single REST endpoint** — `POST /api/mulmo-script` (the existing `mulmoScript.save`). The server inspects the body and dispatches between two helpers:
+
+- `saveScriptToDisk(script, filename)` — schema-validates the incoming script, slugifies the optional filename to neutralize path-traversal, writes via `writeJsonAtomic`, and realpath-resolves the resulting path.
+- `loadScriptFromDisk(filePath)` — enforces `.json` extension, runs `resolveStoryPath` (realpath-based confinement to `stories/`), reads the file, validates against `mulmoScriptSchema`, and returns `toStoryRef(absolute)` as the canonical wire form.
+
+Both helpers return the same `ScriptOutcome` shape (`{ script, wireFilePath, absoluteFilePath, message }`), so the route's tail end (response shaping + `autoGenerateMovie` trigger) is shared.
+
+**Why one endpoint instead of two**: the agent (MCP) layer routes tool calls directly to the REST endpoint listed in `server/agent/plugin-names.ts:TOOL_ENDPOINTS` — bypassing the frontend plugin's `execute()`. Per-mode dispatch on the client would silently no-op on the agent path. Centralizing the branch on the server keeps both call sites in sync.
 
 ### `filePath` mode — safety guards
 
 When `filePath` is supplied, before the file is read:
 
-1. `path.resolve(filePath)` to normalize.
-2. Ensure resolved path's prefix is the workspace root (`WORKSPACE_PATHS`-derived).
-3. After `fs.realpath`, repeat the workspace-prefix check (defends against symlinks pointing outside).
-4. Reject anything whose extension is not `.json`.
-5. Read, `JSON.parse`, validate against `mulmoScriptSchema`. Return `{ script, filePath }` on success; structured error otherwise.
-
-No directory restriction beyond the workspace root.
+1. Reject anything whose extension is not `.json`.
+2. Pass through `resolveStoryPath` which: rejects absolute paths, resolves against the realpath of the stories dir, and rejects results that escape via symlink.
+3. Read, `JSON.parse`, validate against `mulmoScriptSchema`. Return `{ script, filePath }` on success; structured error otherwise.
+4. Canonicalize the returned `filePath` via `toStoryRef(absoluteFilePath)` so `bar.json` and `stories/foo/../bar.json` collapse to the same `stories/<rel>` key — `pendingGenerations` and movie-status lookups depend on that stability.
 
 ### `autoGenerateMovie` — background generation
 
-The current `mulmoScript.generateMovie` route streams SSE to the open view. We add a non-streaming sibling, e.g. `mulmoScript.generateMovieBackground`, that:
+When `autoGenerateMovie === true`, the route calls `triggerAutoBackgroundMovie(absoluteFilePath, wireFilePath, chatSessionId)` in-process — **no separate REST endpoint**. The trigger:
 
-- POST returns 200 immediately (no SSE).
-- Internally runs the same generation pipeline, but reports progress through the **session `pendingGenerations` channel** that the View already watches. (The existing `reflectGenerationStart` / `reflectGenerationFinish` handlers in `View.vue` will pick the work up automatically when the view mounts later.)
-- On per-beat completion, emits `beatImage` / `beatAudio` finish events so the existing watcher reloads each artifact off disk.
-- On terminal error, persists a sidecar (`<filename>.error.txt` next to the script) since there is no synchronous client to surface an `alert()` to.
-- Guards against double-start by rejecting if a `movie` `pendingGeneration` already exists for this `filePath`.
+- Checks the module-level `inFlightMovies` set keyed by realpath; bails if a movie is already running for this script.
+- Otherwise marks the script in-flight and fires `runBackgroundMovieGeneration(...)` as a `void`-awaited Promise (response returns immediately).
+- The background function uses the same `runMovieGeneration()` core that the SSE `generateMovie` route uses, so behavior stays identical across foreground / background.
+- Per-beat completion is mirrored through the session `pendingGenerations` channel (start + finish on `setImmediate`) so the View's existing watcher reloads each artifact off disk without any View changes.
+- Terminal error persists a `<filename>.error.txt` sidecar next to the script — there is no synchronous client to alert. Stale sidecars are cleared on the next attempt.
 
-The interactive **Generate Movie** button in the View should be refactored to share the same internal generation function — only the transport (SSE vs background fire-and-forget) differs.
+`chatSessionId` is read from the MCP-injected `?session=` query (`getSessionQuery(req)`); when absent (e.g. a GUI call), `publishGeneration` no-ops cleanly.
 
 ## Frontend changes
 
 ### Tool plugin (`src/plugins/presentMulmoScript/index.ts`)
 
-`execute()` becomes:
-
-1. POST to `mulmoScript.save` (when `script` is present) **or** `mulmoScript.load` (when `filePath` is present) — pick one based on args.
-2. If `autoGenerateMovie === true` and the save / load succeeded, POST to `mulmoScript.generateMovieBackground` with the resulting `filePath`. Fire-and-forget — do not await on the actual movie work.
-3. Return `{ script, filePath }` as before.
+`execute()` is a one-line `apiPost` pass-through to `mulmoScript.save`. **All dispatch lives on the server.** A doc warning on `src/tools/types.ts:ToolPlugin` calls out that `execute()` is not invoked at runtime in MulmoClaude (the agent path bypasses it via MCP), so future authors don't relapse into client-side branching.
 
 ### View (`src/plugins/presentMulmoScript/View.vue`)
 
@@ -94,7 +98,7 @@ The interactive **Generate Movie** button in the View should be refactored to sh
 The `description` field in `definition.ts` gains a short section above the existing JSON schema explaining:
 
 - "Pass `script` to create-and-present a new MulmoScript."
-- "Pass `filePath` (workspace-relative path to an existing `.mulmoscript.json`) to re-display an already-saved script — much cheaper than re-sending the whole JSON."
+- "Pass `filePath` (workspace-relative path to an existing `stories/*.json`) to re-display an already-saved script — much cheaper than re-sending the whole JSON."
 - "Set `autoGenerateMovie: true` only when the user has explicitly asked for the movie. Movie generation is expensive (multiple image + audio API calls + video encoding); never default it on."
 
 ## Out of scope (for this plan)
@@ -103,8 +107,11 @@ The `description` field in `definition.ts` gains a short section above the exist
 - Per-script error inboxes — the sidecar `.error.txt` is the v1 surface for background failures.
 - Resuming a partially-completed background movie generation across server restarts.
 
+## Known limitations
+
+- **`addSessionProgressCallback` is global**: when two movie generations run concurrently for *different* scripts, beats lacking explicit `id`s fall back to `__index__${index}` — and the same fallback id across scripts confuses the per-callback `idToIndex` filter, so progress meant for script A can flip spinners on script B. Fixing this properly needs mulmocast to attach a per-run identifier to its progress events (or a global serialization gate). Pre-existing behavior; not addressed here.
+
 ## Risks & open questions
 
-- **Path validation drift**: if other routes already do workspace-root validation, consolidate into one helper rather than re-implementing here.
 - **Error UX for background failures**: surface the sidecar file's existence somehow (badge in the view header? toast on next session activity?) — confirm with the user before settling.
-- **Double-start race**: between the tool's `execute()` posting to `generateMovieBackground` and a user clicking the View's "Generate Movie" button. The pending-entry guard on the server handles this, but the UI button should disable itself while a `movie` pending entry exists for this script (it likely already does via `movieGenerating`).
+- **Concurrent multi-script movie gen**: see "Known limitations" above.

--- a/plans/feat-mulmo-script-load-and-background-movie.md
+++ b/plans/feat-mulmo-script-load-and-background-movie.md
@@ -1,0 +1,110 @@
+# presentMulmoScript: load-by-path + background movie generation
+
+## Goal
+
+Extend the `presentMulmoScript` tool so it can:
+
+1. **Re-display an already-saved MulmoScript** by passing a file path (instead of always resending the full JSON), and
+2. **Optionally start movie generation in the background** when the tool is invoked, so the user does not have to open the canvas view to kick it off.
+
+Both are **opt-in additions** — existing call sites that pass a full `script` object continue to work unchanged.
+
+## Tool arguments — the full picture
+
+The current tool takes `{ script, filename? }`. The new shape adds two optional fields and turns `script` itself into "optional but required when `filePath` is absent":
+
+| Arg | Type | Required | Meaning |
+|---|---|---|---|
+| `script` | `object` (MulmoScript JSON) | one of `script` / `filePath` | Full script JSON. Use when **creating a new** presentation. Server saves it to disk and returns `{ script, filePath }`. |
+| `filePath` | `string` | one of `script` / `filePath` | Path to an existing `.mulmoscript.json` file inside the workspace. Use when **re-displaying** a previously created presentation. Server reads + validates the file and returns `{ script, filePath }`. |
+| `filename` | `string` | optional | Only meaningful with `script`. Defaults to a slug of the title. Ignored when `filePath` is given. |
+| `autoGenerateMovie` | `boolean` | optional, **default `false`** | When `true`, the server kicks off movie generation in the background after save / load. The user does not need to open the view; progress is tracked through the existing `pendingGenerations` channel. |
+
+### "exactly one of script / filePath"
+
+JSON Schema cannot cleanly express "exactly one of these two optional fields", so the contract is enforced in two places:
+
+- **Tool description** spells out the rule plainly (Claude is the primary enforcer).
+- **Server endpoint** validates the request and rejects with a clear error if both or neither are present.
+
+### Three canonical invocations
+
+```jsonc
+// 1. Create + present (current behaviour, unchanged)
+{ "script": { "$mulmocast": { "version": "1.1" }, "title": "...", ... } }
+
+// 2. Re-display an existing script
+{ "filePath": "artifacts/mulmoscripts/the-life-of-a-star.mulmoscript.json" }
+
+// 3. Re-display AND start movie generation in the background
+{
+  "filePath": "artifacts/mulmoscripts/the-life-of-a-star.mulmoscript.json",
+  "autoGenerateMovie": true
+}
+
+// 4. Create + present + start movie generation in the background
+{
+  "script": { ... },
+  "autoGenerateMovie": true
+}
+```
+
+## Server changes
+
+### `filePath` mode — safety guards
+
+When `filePath` is supplied, before the file is read:
+
+1. `path.resolve(filePath)` to normalize.
+2. Ensure resolved path's prefix is the workspace root (`WORKSPACE_PATHS`-derived).
+3. After `fs.realpath`, repeat the workspace-prefix check (defends against symlinks pointing outside).
+4. Reject anything whose extension is not `.json`.
+5. Read, `JSON.parse`, validate against `mulmoScriptSchema`. Return `{ script, filePath }` on success; structured error otherwise.
+
+No directory restriction beyond the workspace root.
+
+### `autoGenerateMovie` — background generation
+
+The current `mulmoScript.generateMovie` route streams SSE to the open view. We add a non-streaming sibling, e.g. `mulmoScript.generateMovieBackground`, that:
+
+- POST returns 200 immediately (no SSE).
+- Internally runs the same generation pipeline, but reports progress through the **session `pendingGenerations` channel** that the View already watches. (The existing `reflectGenerationStart` / `reflectGenerationFinish` handlers in `View.vue` will pick the work up automatically when the view mounts later.)
+- On per-beat completion, emits `beatImage` / `beatAudio` finish events so the existing watcher reloads each artifact off disk.
+- On terminal error, persists a sidecar (`<filename>.error.txt` next to the script) since there is no synchronous client to surface an `alert()` to.
+- Guards against double-start by rejecting if a `movie` `pendingGeneration` already exists for this `filePath`.
+
+The interactive **Generate Movie** button in the View should be refactored to share the same internal generation function — only the transport (SSE vs background fire-and-forget) differs.
+
+## Frontend changes
+
+### Tool plugin (`src/plugins/presentMulmoScript/index.ts`)
+
+`execute()` becomes:
+
+1. POST to `mulmoScript.save` (when `script` is present) **or** `mulmoScript.load` (when `filePath` is present) — pick one based on args.
+2. If `autoGenerateMovie === true` and the save / load succeeded, POST to `mulmoScript.generateMovieBackground` with the resulting `filePath`. Fire-and-forget — do not await on the actual movie work.
+3. Return `{ script, filePath }` as before.
+
+### View (`src/plugins/presentMulmoScript/View.vue`)
+
+**No changes required.** The View consumes `{ script, filePath }` and the existing `pendingGenerations` watcher handles the case where movie generation is already in flight when the view mounts. Spinners and final reload are automatic.
+
+## Tool description update
+
+The `description` field in `definition.ts` gains a short section above the existing JSON schema explaining:
+
+- "Pass `script` to create-and-present a new MulmoScript."
+- "Pass `filePath` (workspace-relative path to an existing `.mulmoscript.json`) to re-display an already-saved script — much cheaper than re-sending the whole JSON."
+- "Set `autoGenerateMovie: true` only when the user has explicitly asked for the movie. Movie generation is expensive (multiple image + audio API calls + video encoding); never default it on."
+
+## Out of scope (for this plan)
+
+- Listing / browsing saved MulmoScripts in the UI (a separate "open recent" affordance) — Claude can already locate paths via the file tools.
+- Per-script error inboxes — the sidecar `.error.txt` is the v1 surface for background failures.
+- Resuming a partially-completed background movie generation across server restarts.
+
+## Risks & open questions
+
+- **Path validation drift**: if other routes already do workspace-root validation, consolidate into one helper rather than re-implementing here.
+- **Error UX for background failures**: surface the sidecar file's existence somehow (badge in the view header? toast on next session activity?) — confirm with the user before settling.
+- **Double-start race**: between the tool's `execute()` posting to `generateMovieBackground` and a user clicking the View's "Generate Movie" button. The pending-entry guard on the server handles this, but the UI button should disable itself while a `movie` pending entry exists for this script (it likely already does via `movieGenerating`).

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -143,21 +143,44 @@ router.post(API_ROUTES.mulmoScript.save, async (req: Request<object, object, Sav
 });
 
 async function saveScriptToDisk(script: MulmoScript, filename: string | undefined, res: Response): Promise<ScriptOutcome | null> {
-  if (!Array.isArray(script.beats)) {
-    badRequest(res, "script with beats array is required");
+  // Validate against the same schema the reopen path uses so /save and
+  // /load agree on what counts as a valid MulmoScript — otherwise
+  // /save could persist a script that /load would later refuse, and
+  // autoGenerateMovie could kick off against malformed input.
+  const validation = mulmoScriptSchema.safeParse(script);
+  if (!validation.success) {
+    badRequest(res, "script is not a valid MulmoScript");
     return null;
   }
+  const validatedScript = validation.data;
+
   mkdirSync(storiesDir, { recursive: true });
 
-  const title = script.title || "untitled";
-  const slug = filename ? filename.replace(/\.json$/, "") : slugify(title);
+  const title = validatedScript.title || "untitled";
+  // slugify drops `/`, `\`, and `..`, so a hostile `filename` like
+  // "../../etc/passwd" can never escape storiesDir via the path.join
+  // below — defense in depth on top of the wire-side validation.
+  const slug = filename ? slugify(filename.replace(/\.json$/i, "")) : slugify(title);
   const fname = `${slug}-${Date.now()}.json`;
-  const absoluteFilePath = path.join(storiesDir, fname);
+  const writePath = path.join(storiesDir, fname);
 
-  await writeJsonAtomic(absoluteFilePath, script);
+  await writeJsonAtomic(writePath, validatedScript);
+
+  // Realpath-resolve the freshly written file so `inFlightMovies`
+  // entries created from this code path collide with ones produced by
+  // `resolveStoryPath` (used by reopen / SSE generateMovie / movie-
+  // status). Without this, a symlinked storiesDir would let two movie
+  // generations for the same physical file run concurrently because
+  // their dedup keys differ (path.join vs realpath).
+  let absoluteFilePath: string;
+  try {
+    absoluteFilePath = realpathSync(writePath);
+  } catch {
+    absoluteFilePath = writePath;
+  }
 
   return {
-    script,
+    script: validatedScript,
     wireFilePath: `stories/${fname}`,
     absoluteFilePath,
     message: `Saved MulmoScript to stories/${fname}`,
@@ -194,9 +217,11 @@ async function loadScriptFromDisk(filePath: string, res: Response): Promise<Scri
     return null;
   }
 
-  // Canonicalize the wire form to "stories/<rel>" so pendingGenerations
-  // keys match across save and load regardless of what the caller passed.
-  const wireFilePath = filePath.startsWith("stories/") || filePath === "stories" ? filePath : `stories/${filePath}`;
+  // Canonicalize via the realpath-resolved absoluteFilePath so wire
+  // forms like "bar.json" or "stories/foo/../bar.json" all collapse
+  // to the same "stories/<rel>" key — pendingGenerations and movie-
+  // status lookups depend on that stability.
+  const wireFilePath = toStoryRef(absoluteFilePath);
 
   return {
     script: validation.data,
@@ -613,6 +638,16 @@ async function runMovieGeneration(absoluteFilePath: string, onProgressEvent: (ev
     idToIndex.set(key, index);
   });
 
+  // Known limitation: addSessionProgressCallback is global, so when two
+  // movie generations for *different* scripts run concurrently, both
+  // closures are invoked for every beat event and rely on idToIndex to
+  // filter out the other run's events. That filter is reliable only
+  // when each beat carries an explicit `id`. Beats without one fall
+  // back to "__index__${index}", and identical fallback ids across
+  // scripts collide → progress meant for script A surfaces on script B.
+  // Fixing this properly needs mulmocast to attach a per-run identifier
+  // to its progress events (or a global serialization gate); tracked
+  // separately, out of scope for this PR.
   const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
     if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
     const beatIndex = idToIndex.get(event.id);

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, unlinkSync, writeFileSync } from "fs";
 import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { stripDataUri } from "../../utils/files/image-store.js";
@@ -22,7 +22,7 @@ import {
   removeSessionProgressCallback,
   type MulmoScript,
 } from "mulmocast";
-import type { MulmoBeat, MulmoImagePromptMedia } from "@mulmocast/types";
+import { mulmoScriptSchema, type MulmoBeat, type MulmoImagePromptMedia } from "@mulmocast/types";
 import { slugify } from "../../utils/slug.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -118,6 +118,64 @@ router.post(API_ROUTES.mulmoScript.save, async (req: Request<object, object, Sav
   res.json({
     data: { script, filePath: `stories/${fname}` },
     message: `Saved MulmoScript to stories/${fname}`,
+    instructions: "Display the storyboard to the user.",
+  });
+});
+
+interface LoadMulmoScriptBody {
+  filePath?: string;
+}
+
+// Re-display an already-saved MulmoScript without resending the full
+// JSON. Path is workspace-relative (e.g. "stories/foo.json"); the
+// resolveStoryPath helper enforces realpath-based confinement to the
+// stories directory and a `.json` extension is required to keep this
+// endpoint from doubling as a generic file-read primitive.
+router.post(API_ROUTES.mulmoScript.load, async (req: Request<object, object, LoadMulmoScriptBody>, res: Response) => {
+  const { filePath } = req.body ?? {};
+  if (typeof filePath !== "string" || filePath === "") {
+    badRequest(res, "filePath must be a non-empty string");
+    return;
+  }
+  if (!filePath.toLowerCase().endsWith(".json")) {
+    badRequest(res, "filePath must point to a .json file");
+    return;
+  }
+
+  const absoluteFilePath = resolveStoryPath(filePath, res);
+  if (!absoluteFilePath) return;
+
+  let raw: string;
+  try {
+    raw = readFileSync(absoluteFilePath, "utf-8");
+  } catch (err) {
+    serverError(res, errorMessage(err));
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    badRequest(res, `Invalid JSON: ${errorMessage(err)}`);
+    return;
+  }
+
+  const validation = mulmoScriptSchema.safeParse(parsed);
+  if (!validation.success) {
+    badRequest(res, "File is not a valid MulmoScript");
+    return;
+  }
+
+  // Normalize the returned filePath so the View / future calls always
+  // use the canonical "stories/<rel>" wire form, regardless of what the
+  // caller passed in. Keeps pendingGenerations keys consistent across
+  // save and load.
+  const normalized = filePath.startsWith("stories/") || filePath === "stories" ? filePath : `stories/${filePath}`;
+
+  res.json({
+    data: { script: validation.data, filePath: normalized },
+    message: `Loaded MulmoScript from ${normalized}`,
     instructions: "Display the storyboard to the user.",
   });
 });
@@ -493,6 +551,58 @@ router.post(API_ROUTES.mulmoScript.renderBeat, async (req: Request<object, objec
   }
 });
 
+// Module-level dedup so a foreground SSE call and a fire-and-forget
+// background call can't race on the same script. Keyed by the realpath
+// (absoluteFilePath) so two different wire spellings of the same file
+// still collide. The set is intentionally process-local — a multi-
+// process deployment would need an external lock; that's out of scope.
+const inFlightMovies = new Set<string>();
+
+type MovieGenerationResult = { ok: true; outputPath: string } | { ok: false; error: string };
+
+interface MovieProgressEvent {
+  kind: "image" | "audio";
+  beatIndex: number;
+}
+
+// Shared core for both the SSE-streaming `generateMovie` route and the
+// fire-and-forget `generateMovieBackground` route. Builds the mulmo
+// context, runs images→audio→movie, and reports per-beat progress
+// through the supplied callback. Throws on unexpected pipeline errors;
+// returns a structured failure when the pipeline runs to completion
+// but the output file is missing.
+async function runMovieGeneration(absoluteFilePath: string, onProgressEvent: (event: MovieProgressEvent) => void): Promise<MovieGenerationResult> {
+  const context = await buildContext(absoluteFilePath);
+  if (!context) return { ok: false, error: "Failed to initialize mulmo context" };
+
+  const idToIndex = new Map<string, number>();
+  (context.studio.script.beats as MulmoBeat[]).forEach((beat, index) => {
+    const key = beat.id ?? `__index__${index}`;
+    idToIndex.set(key, index);
+  });
+
+  const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
+    if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
+    const beatIndex = idToIndex.get(event.id);
+    if (beatIndex === undefined) return;
+    if (event.sessionType !== "image" && event.sessionType !== "audio") return;
+    onProgressEvent({ kind: event.sessionType, beatIndex });
+  };
+
+  addSessionProgressCallback(onProgress);
+  try {
+    const imagesContext = await images(context);
+    const audioContext = await audio(imagesContext);
+    await movie(audioContext);
+
+    const outputPath = movieFilePath(audioContext);
+    if (!existsSync(outputPath)) return { ok: false, error: "Movie was not generated" };
+    return { ok: true, outputPath };
+  } finally {
+    removeSessionProgressCallback(onProgress);
+  }
+}
+
 router.post(API_ROUTES.mulmoScript.generateMovie, async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) => {
   const { filePath, chatSessionId } = req.body;
 
@@ -504,65 +614,132 @@ router.post(API_ROUTES.mulmoScript.generateMovie, async (req: Request<object, ob
   const absoluteFilePath = resolveStoryPath(filePath, res);
   if (!absoluteFilePath) return;
 
+  if (inFlightMovies.has(absoluteFilePath)) {
+    badRequest(res, "Movie generation is already in progress for this script");
+    return;
+  }
+
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
 
   const send = (data: unknown) => res.write(`data: ${JSON.stringify(data)}\n\n`);
 
+  inFlightMovies.add(absoluteFilePath);
   publishGeneration(chatSessionId, GENERATION_KINDS.movie, filePath, "", false);
   let genError: string | undefined;
   try {
-    const context = await buildContext(absoluteFilePath);
-    if (!context) {
-      genError = "Failed to initialize mulmo context";
-      send({ type: "error", message: genError });
-      res.end();
+    const result = await runMovieGeneration(absoluteFilePath, (event) => {
+      send({ type: `beat_${event.kind}_done`, beatIndex: event.beatIndex });
+    });
+    if (!result.ok) {
+      genError = result.error;
+      send({ type: "error", message: result.error });
       return;
     }
-
-    // Build id → beatIndex map for the progress callback
-    const idToIndex = new Map<string, number>();
-    (context.studio.script.beats as MulmoBeat[]).forEach((beat, index) => {
-      const key = beat.id ?? `__index__${index}`;
-      idToIndex.set(key, index);
-    });
-
-    const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
-      if (event.kind === "beat" && !event.inSession && event.id !== undefined) {
-        const beatIndex = idToIndex.get(event.id);
-        if (beatIndex !== undefined) {
-          send({ type: `beat_${event.sessionType}_done`, beatIndex });
-        }
-      }
-    };
-
-    addSessionProgressCallback(onProgress);
-    try {
-      const imagesContext = await images(context);
-      const audioContext = await audio(imagesContext);
-      await movie(audioContext);
-
-      const outputPath = movieFilePath(audioContext);
-      if (!existsSync(outputPath)) {
-        genError = "Movie was not generated";
-        send({ type: "error", message: genError });
-        res.end();
-        return;
-      }
-
-      send({ type: "done", moviePath: toStoryRef(outputPath) });
-    } finally {
-      removeSessionProgressCallback(onProgress);
-    }
+    send({ type: "done", moviePath: toStoryRef(result.outputPath) });
   } catch (err) {
     genError = errorMessage(err);
     send({ type: "error", message: genError });
   } finally {
+    inFlightMovies.delete(absoluteFilePath);
     publishGeneration(chatSessionId, GENERATION_KINDS.movie, filePath, "", true, genError);
     res.end();
   }
 });
+
+// Background sibling of `generateMovie`. POST returns 200 immediately;
+// the heavy work runs detached, reporting progress through the same
+// session pendingGenerations channel that the View already watches —
+// so a user opening the canvas mid-generation sees spinners, and a
+// user opening it after completion sees the finished movie loaded
+// from disk by the View's normal mount-time path.
+//
+// Errors are persisted to a `<filename>.error.txt` sidecar next to the
+// script (no synchronous client to alert), and any stale sidecar from
+// a previous failed run is cleared on each new attempt.
+router.post(
+  API_ROUTES.mulmoScript.generateMovieBackground,
+  async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) => {
+    const { filePath, chatSessionId } = req.body;
+
+    if (!filePath) {
+      badRequest(res, "filePath is required");
+      return;
+    }
+
+    const absoluteFilePath = resolveStoryPath(filePath, res);
+    if (!absoluteFilePath) return;
+
+    if (inFlightMovies.has(absoluteFilePath)) {
+      badRequest(res, "Movie generation is already in progress for this script");
+      return;
+    }
+
+    inFlightMovies.add(absoluteFilePath);
+    res.json({ ok: true });
+
+    void runBackgroundMovieGeneration(absoluteFilePath, filePath, chatSessionId);
+  },
+);
+
+async function runBackgroundMovieGeneration(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): Promise<void> {
+  const errorSidecarPath = `${absoluteFilePath}.error.txt`;
+  // Clear stale error from a previous failed run before starting; if it
+  // doesn't exist that's fine. Catch any unexpected fs errors silently —
+  // the worst case is the user sees an out-of-date error file later.
+  try {
+    unlinkSync(errorSidecarPath);
+  } catch {
+    // intentional: ENOENT is the common case, others non-fatal
+  }
+
+  publishGeneration(chatSessionId, GENERATION_KINDS.movie, wireFilePath, "", false);
+  let genError: string | undefined;
+  try {
+    const result = await runMovieGeneration(absoluteFilePath, (event) => {
+      // Mirror per-beat completions through the session channel so the
+      // View's pendingGenerations watcher reloads the asset off disk.
+      // We fire start+finish in two ticks — `setImmediate` lets the SSE
+      // writer flush the start event before the finish removes the
+      // entry, otherwise Vue's batched reactivity could see a net "no
+      // change" and skip the reload.
+      const eventKind = event.kind === "image" ? GENERATION_KINDS.beatImage : GENERATION_KINDS.beatAudio;
+      const key = String(event.beatIndex);
+      publishGeneration(chatSessionId, eventKind, wireFilePath, key, false);
+      setImmediate(() => publishGeneration(chatSessionId, eventKind, wireFilePath, key, true));
+    });
+
+    if (!result.ok) {
+      genError = result.error;
+      writeErrorSidecar(errorSidecarPath, result.error);
+      log.warn("mulmo-script", "background movie generation failed", { filePath: wireFilePath, error: result.error });
+      return;
+    }
+    log.info("mulmo-script", "background movie generation done", {
+      filePath: wireFilePath,
+      outputPath: result.outputPath,
+    });
+  } catch (err) {
+    genError = errorMessage(err);
+    writeErrorSidecar(errorSidecarPath, genError);
+    log.error("mulmo-script", "background movie generation crashed", { filePath: wireFilePath, error: genError });
+  } finally {
+    inFlightMovies.delete(absoluteFilePath);
+    publishGeneration(chatSessionId, GENERATION_KINDS.movie, wireFilePath, "", true, genError);
+  }
+}
+
+function writeErrorSidecar(errorSidecarPath: string, message: string): void {
+  try {
+    writeFileSync(errorSidecarPath, message);
+  } catch (writeErr) {
+    log.error("mulmo-script", "failed to write error sidecar", {
+      errorSidecarPath,
+      error: errorMessage(writeErr),
+    });
+  }
+}
 
 interface CharacterImageQuery {
   filePath?: string;

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -27,7 +27,7 @@ import { slugify } from "../../utils/slug.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, notFound, serverError } from "../../utils/httpError.js";
-import { getOptionalStringQuery } from "../../utils/request.js";
+import { getOptionalStringQuery, getSessionQuery } from "../../utils/request.js";
 import { log } from "../../system/logger/index.js";
 import { validateUpdateBeatBody, validateUpdateScriptBody } from "./mulmoScriptValidate.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -65,8 +65,10 @@ function ensureStoriesReal(): string | null {
 }
 
 interface SaveMulmoScriptBody {
-  script: MulmoScript;
+  script?: MulmoScript;
   filename?: string;
+  filePath?: string;
+  autoGenerateMovie?: boolean;
 }
 
 interface RenderBeatBody {
@@ -98,59 +100,84 @@ interface FilePathQuery {
   filePath?: string;
 }
 
-router.post(API_ROUTES.mulmoScript.save, async (req: Request<object, object, SaveMulmoScriptBody>, res: Response) => {
-  const { script, filename } = req.body;
+interface ScriptOutcome {
+  script: MulmoScript;
+  /** Workspace-relative wire form, e.g. "stories/foo.json". */
+  wireFilePath: string;
+  /** Realpath, used by movie generation and the dedup set. */
+  absoluteFilePath: string;
+  message: string;
+}
 
-  if (!script || !Array.isArray(script.beats)) {
-    badRequest(res, "script with beats array is required");
+// Unified entry point — save a fresh `script` OR re-display an existing
+// one referenced by `filePath`. Folding both modes into one route lets
+// the agent (MCP) and the GUI dispatcher hit the same endpoint without
+// either side needing to know which mode the user picked. The MCP layer
+// in `server/agent/plugin-names.ts` routes the tool name straight here,
+// so any per-mode logic on the client would be invisible to it.
+router.post(API_ROUTES.mulmoScript.save, async (req: Request<object, object, SaveMulmoScriptBody>, res: Response) => {
+  const { script, filename, filePath, autoGenerateMovie } = req.body ?? {};
+
+  const hasScript = script !== undefined && script !== null;
+  const hasFilePath = typeof filePath === "string" && filePath !== "";
+  if (hasScript === hasFilePath) {
+    badRequest(
+      res,
+      hasScript ? "Provide either `script` or `filePath`, not both." : "Provide either `script` (new presentation) or `filePath` (existing presentation).",
+    );
     return;
   }
 
+  const outcome = hasFilePath ? await loadScriptFromDisk(filePath, res) : await saveScriptToDisk(script as MulmoScript, filename, res);
+  if (!outcome) return; // helper already wrote a 4xx/5xx response
+
+  if (autoGenerateMovie === true) {
+    triggerAutoBackgroundMovie(outcome.absoluteFilePath, outcome.wireFilePath, getSessionQuery(req) || undefined);
+  }
+
+  res.json({
+    data: { script: outcome.script, filePath: outcome.wireFilePath },
+    message: outcome.message,
+    instructions: "Display the storyboard to the user.",
+  });
+});
+
+async function saveScriptToDisk(script: MulmoScript, filename: string | undefined, res: Response): Promise<ScriptOutcome | null> {
+  if (!Array.isArray(script.beats)) {
+    badRequest(res, "script with beats array is required");
+    return null;
+  }
   mkdirSync(storiesDir, { recursive: true });
 
   const title = script.title || "untitled";
   const slug = filename ? filename.replace(/\.json$/, "") : slugify(title);
   const fname = `${slug}-${Date.now()}.json`;
-  const filePath = path.join(storiesDir, fname);
+  const absoluteFilePath = path.join(storiesDir, fname);
 
-  await writeJsonAtomic(filePath, script);
+  await writeJsonAtomic(absoluteFilePath, script);
 
-  res.json({
-    data: { script, filePath: `stories/${fname}` },
+  return {
+    script,
+    wireFilePath: `stories/${fname}`,
+    absoluteFilePath,
     message: `Saved MulmoScript to stories/${fname}`,
-    instructions: "Display the storyboard to the user.",
-  });
-});
-
-interface LoadMulmoScriptBody {
-  filePath?: string;
+  };
 }
 
-// Re-display an already-saved MulmoScript without resending the full
-// JSON. Path is workspace-relative (e.g. "stories/foo.json"); the
-// resolveStoryPath helper enforces realpath-based confinement to the
-// stories directory and a `.json` extension is required to keep this
-// endpoint from doubling as a generic file-read primitive.
-router.post(API_ROUTES.mulmoScript.load, async (req: Request<object, object, LoadMulmoScriptBody>, res: Response) => {
-  const { filePath } = req.body ?? {};
-  if (typeof filePath !== "string" || filePath === "") {
-    badRequest(res, "filePath must be a non-empty string");
-    return;
-  }
+async function loadScriptFromDisk(filePath: string, res: Response): Promise<ScriptOutcome | null> {
   if (!filePath.toLowerCase().endsWith(".json")) {
     badRequest(res, "filePath must point to a .json file");
-    return;
+    return null;
   }
-
   const absoluteFilePath = resolveStoryPath(filePath, res);
-  if (!absoluteFilePath) return;
+  if (!absoluteFilePath) return null; // resolveStoryPath already responded
 
   let raw: string;
   try {
     raw = readFileSync(absoluteFilePath, "utf-8");
   } catch (err) {
     serverError(res, errorMessage(err));
-    return;
+    return null;
   }
 
   let parsed: unknown;
@@ -158,27 +185,32 @@ router.post(API_ROUTES.mulmoScript.load, async (req: Request<object, object, Loa
     parsed = JSON.parse(raw);
   } catch (err) {
     badRequest(res, `Invalid JSON: ${errorMessage(err)}`);
-    return;
+    return null;
   }
 
   const validation = mulmoScriptSchema.safeParse(parsed);
   if (!validation.success) {
     badRequest(res, "File is not a valid MulmoScript");
-    return;
+    return null;
   }
 
-  // Normalize the returned filePath so the View / future calls always
-  // use the canonical "stories/<rel>" wire form, regardless of what the
-  // caller passed in. Keeps pendingGenerations keys consistent across
-  // save and load.
-  const normalized = filePath.startsWith("stories/") || filePath === "stories" ? filePath : `stories/${filePath}`;
+  // Canonicalize the wire form to "stories/<rel>" so pendingGenerations
+  // keys match across save and load regardless of what the caller passed.
+  const wireFilePath = filePath.startsWith("stories/") || filePath === "stories" ? filePath : `stories/${filePath}`;
 
-  res.json({
-    data: { script: validation.data, filePath: normalized },
-    message: `Loaded MulmoScript from ${normalized}`,
-    instructions: "Display the storyboard to the user.",
-  });
-});
+  return {
+    script: validation.data,
+    wireFilePath,
+    absoluteFilePath,
+    message: `Loaded MulmoScript from ${wireFilePath}`,
+  };
+}
+
+function triggerAutoBackgroundMovie(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): void {
+  if (inFlightMovies.has(absoluteFilePath)) return;
+  inFlightMovies.add(absoluteFilePath);
+  void runBackgroundMovieGeneration(absoluteFilePath, wireFilePath, chatSessionId);
+}
 
 router.post(API_ROUTES.mulmoScript.updateBeat, async (req: Request<object, object, unknown>, res: Response) => {
   const validation = validateUpdateBeatBody(req.body);
@@ -566,11 +598,11 @@ interface MovieProgressEvent {
 }
 
 // Shared core for both the SSE-streaming `generateMovie` route and the
-// fire-and-forget `generateMovieBackground` route. Builds the mulmo
-// context, runs images→audio→movie, and reports per-beat progress
-// through the supplied callback. Throws on unexpected pipeline errors;
-// returns a structured failure when the pipeline runs to completion
-// but the output file is missing.
+// fire-and-forget background path triggered by `autoGenerateMovie`.
+// Builds the mulmo context, runs images→audio→movie, and reports
+// per-beat progress through the supplied callback. Throws on
+// unexpected pipeline errors; returns a structured failure when the
+// pipeline runs to completion but the output file is missing.
 async function runMovieGeneration(absoluteFilePath: string, onProgressEvent: (event: MovieProgressEvent) => void): Promise<MovieGenerationResult> {
   const context = await buildContext(absoluteFilePath);
   if (!context) return { ok: false, error: "Failed to initialize mulmo context" };
@@ -648,41 +680,15 @@ router.post(API_ROUTES.mulmoScript.generateMovie, async (req: Request<object, ob
   }
 });
 
-// Background sibling of `generateMovie`. POST returns 200 immediately;
-// the heavy work runs detached, reporting progress through the same
-// session pendingGenerations channel that the View already watches —
-// so a user opening the canvas mid-generation sees spinners, and a
-// user opening it after completion sees the finished movie loaded
-// from disk by the View's normal mount-time path.
-//
-// Errors are persisted to a `<filename>.error.txt` sidecar next to the
-// script (no synchronous client to alert), and any stale sidecar from
-// a previous failed run is cleared on each new attempt.
-router.post(
-  API_ROUTES.mulmoScript.generateMovieBackground,
-  async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) => {
-    const { filePath, chatSessionId } = req.body;
-
-    if (!filePath) {
-      badRequest(res, "filePath is required");
-      return;
-    }
-
-    const absoluteFilePath = resolveStoryPath(filePath, res);
-    if (!absoluteFilePath) return;
-
-    if (inFlightMovies.has(absoluteFilePath)) {
-      badRequest(res, "Movie generation is already in progress for this script");
-      return;
-    }
-
-    inFlightMovies.add(absoluteFilePath);
-    res.json({ ok: true });
-
-    void runBackgroundMovieGeneration(absoluteFilePath, filePath, chatSessionId);
-  },
-);
-
+// Detached movie generation. Reports progress through the same session
+// pendingGenerations channel that the View already watches — so a user
+// opening the canvas mid-generation sees spinners, and a user opening
+// it after completion sees the finished movie loaded from disk by the
+// View's normal mount-time path. Errors are persisted to a
+// `<filename>.error.txt` sidecar next to the script (no synchronous
+// client to alert); any stale sidecar from a previous run is cleared on
+// each new attempt. Triggered server-side from the unified save route
+// when the caller passes `autoGenerateMovie: true`.
 async function runBackgroundMovieGeneration(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): Promise<void> {
   const errorSidecarPath = `${absoluteFilePath}.error.txt`;
   // Clear stale error from a previous failed run before starting; if it

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -98,6 +98,7 @@ export const API_ROUTES = {
 
   mulmoScript: {
     save: "/api/mulmo-script",
+    load: "/api/mulmo-script/load",
     updateBeat: "/api/mulmo-script/update-beat",
     updateScript: "/api/mulmo-script/update-script",
     beatImage: "/api/mulmo-script/beat-image",
@@ -110,6 +111,7 @@ export const API_ROUTES = {
     uploadCharacterImage: "/api/mulmo-script/upload-character-image",
     movieStatus: "/api/mulmo-script/movie-status",
     generateMovie: "/api/mulmo-script/generate-movie",
+    generateMovieBackground: "/api/mulmo-script/generate-movie-background",
     downloadMovie: "/api/mulmo-script/download-movie",
   },
 

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -98,7 +98,6 @@ export const API_ROUTES = {
 
   mulmoScript: {
     save: "/api/mulmo-script",
-    load: "/api/mulmo-script/load",
     updateBeat: "/api/mulmo-script/update-beat",
     updateScript: "/api/mulmo-script/update-script",
     beatImage: "/api/mulmo-script/beat-image",
@@ -111,7 +110,6 @@ export const API_ROUTES = {
     uploadCharacterImage: "/api/mulmo-script/upload-character-image",
     movieStatus: "/api/mulmo-script/movie-status",
     generateMovie: "/api/mulmo-script/generate-movie",
-    generateMovieBackground: "/api/mulmo-script/generate-movie-background",
     downloadMovie: "/api/mulmo-script/download-movie",
   },
 

--- a/src/plugins/presentMulmoScript/definition.ts
+++ b/src/plugins/presentMulmoScript/definition.ts
@@ -7,7 +7,14 @@ const toolDefinition: ToolDefinition = {
   name: TOOL_NAME,
   description: `Save and present a MulmoScript story or presentation as a visual storyboard in the canvas.
 
-Always use Google providers. Required structure:
+Two modes — provide EXACTLY ONE of \`script\` or \`filePath\`:
+
+1. **Create new** — pass \`script\` (full MulmoScript JSON). Server saves it to disk and presents it.
+2. **Re-display existing** — pass \`filePath\` (workspace-relative path returned by a previous call, e.g. "stories/my-story-1700000000000.json"). Much cheaper than re-sending the full script. Use whenever the user wants to revisit a presentation that was already created in this workspace.
+
+Optional \`autoGenerateMovie: true\` kicks off movie generation in the background, so the final video is ready by the time the user opens the canvas. Movie generation is expensive (multiple image + audio API calls + video encoding) — only set this when the user has explicitly asked for the movie. Default \`false\`.
+
+Always use Google providers when creating new scripts. Required structure:
 
 {
   "$mulmocast": { "version": "1.1" },
@@ -80,15 +87,26 @@ IMPORTANT: "imagePrompt" and "moviePrompt" are plain string fields on the beat, 
       script: {
         type: "object",
         description:
-          "Complete MulmoScript JSON. Must include $mulmocast, speechParams, imageParams, movieParams, and beats array. Always populate the top-level 'description' field with a concise 1–2 sentence summary of the presentation.",
+          "Complete MulmoScript JSON for a NEW presentation. Must include $mulmocast, speechParams, imageParams, movieParams, and beats array. Always populate the top-level 'description' field with a concise 1–2 sentence summary of the presentation. Do NOT pass alongside `filePath`.",
         additionalProperties: true,
       },
       filename: {
         type: "string",
-        description: "Optional filename without extension. Defaults to a slug of the script title.",
+        description:
+          "Optional filename without extension. Defaults to a slug of the script title. Only meaningful with `script`; ignored when `filePath` is given.",
+      },
+      filePath: {
+        type: "string",
+        description:
+          "Workspace-relative path to an EXISTING MulmoScript JSON file (e.g. 'stories/my-story-1700000000000.json'). Use this to re-display a script previously saved in this workspace, instead of resending the full JSON. Do NOT pass alongside `script`.",
+      },
+      autoGenerateMovie: {
+        type: "boolean",
+        description:
+          "When true, the server starts movie generation in the background after save/load. The user does NOT need to open the canvas — progress streams via the existing session channel. Default false. Only set true when the user has explicitly asked for the movie; generation is expensive.",
       },
     },
-    required: ["script"],
+    required: [],
   },
 };
 

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -13,11 +13,38 @@ export interface MulmoScriptData {
   filePath: string;
 }
 
+interface PresentMulmoScriptArgs {
+  script?: MulmoScript;
+  filename?: string;
+  filePath?: string;
+  autoGenerateMovie?: boolean;
+}
+
 const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
   toolDefinition,
 
   async execute(_context, args) {
-    const result = await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.save, args);
+    const { script, filename, filePath, autoGenerateMovie } = args as PresentMulmoScriptArgs;
+
+    // Enforce "exactly one of script / filePath" — the JSON schema can't
+    // express oneOf cleanly, so we validate here and surface a structured
+    // tool error the LLM can recover from on its next turn.
+    const hasScript = script !== undefined && script !== null;
+    const hasFilePath = typeof filePath === "string" && filePath !== "";
+    if (hasScript === hasFilePath) {
+      return {
+        toolName: TOOL_NAME,
+        uuid: makeUuid(),
+        message: hasScript
+          ? "Provide either `script` or `filePath`, not both."
+          : "Provide either `script` (new presentation) or `filePath` (existing presentation).",
+      };
+    }
+
+    const result = hasFilePath
+      ? await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.load, { filePath })
+      : await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.save, { script, filename });
+
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
@@ -25,6 +52,17 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
         message: result.error,
       };
     }
+
+    const savedFilePath = result.data.data?.filePath;
+    if (autoGenerateMovie === true && savedFilePath) {
+      // Fire-and-forget. The server returns 200 immediately and runs
+      // the heavy work detached; progress flows through the session
+      // pendingGenerations channel that the View already watches.
+      void apiPost(API_ROUTES.mulmoScript.generateMovieBackground, {
+        filePath: savedFilePath,
+      });
+    }
+
     return {
       ...result.data,
       toolName: TOOL_NAME,

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -13,38 +13,16 @@ export interface MulmoScriptData {
   filePath: string;
 }
 
-interface PresentMulmoScriptArgs {
-  script?: MulmoScript;
-  filename?: string;
-  filePath?: string;
-  autoGenerateMovie?: boolean;
-}
-
 const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
   toolDefinition,
 
+  // Pass-through: the agent (MCP) and GUI dispatcher both end up at the
+  // same backend route, which dispatches between create-new (`script`)
+  // and reopen-existing (`filePath`) modes and handles the optional
+  // `autoGenerateMovie` background trigger server-side. Keeping this
+  // function trivial means the two callers can never drift apart.
   async execute(_context, args) {
-    const { script, filename, filePath, autoGenerateMovie } = args as PresentMulmoScriptArgs;
-
-    // Enforce "exactly one of script / filePath" — the JSON schema can't
-    // express oneOf cleanly, so we validate here and surface a structured
-    // tool error the LLM can recover from on its next turn.
-    const hasScript = script !== undefined && script !== null;
-    const hasFilePath = typeof filePath === "string" && filePath !== "";
-    if (hasScript === hasFilePath) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: hasScript
-          ? "Provide either `script` or `filePath`, not both."
-          : "Provide either `script` (new presentation) or `filePath` (existing presentation).",
-      };
-    }
-
-    const result = hasFilePath
-      ? await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.load, { filePath })
-      : await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.save, { script, filename });
-
+    const result = await apiPost<ToolResult<MulmoScriptData>>(API_ROUTES.mulmoScript.save, args);
     if (!result.ok) {
       return {
         toolName: TOOL_NAME,
@@ -52,17 +30,6 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
         message: result.error,
       };
     }
-
-    const savedFilePath = result.data.data?.filePath;
-    if (autoGenerateMovie === true && savedFilePath) {
-      // Fire-and-forget. The server returns 200 immediately and runs
-      // the heavy work detached; progress flows through the session
-      // pendingGenerations channel that the View already watches.
-      void apiPost(API_ROUTES.mulmoScript.generateMovieBackground, {
-        filePath: savedFilePath,
-      });
-    }
-
     return {
       ...result.data,
       toolName: TOOL_NAME,

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -11,7 +11,24 @@ export interface MulmoClaudeToolContextApp extends ToolContextApp {
 }
 
 /**
- * MulmoClaude ToolPlugin — no app-specific server response type needed
+ * MulmoClaude ToolPlugin — no app-specific server response type needed.
+ *
+ * IMPORTANT — `execute()` is NEVER called at runtime in MulmoClaude.
+ * The frontend registry (see `PluginEntry` below and `src/tools/index.ts`)
+ * only consumes `toolDefinition` / `viewComponent` / `previewComponent`.
+ * Tool calls flow Claude → MCP (`server/agent/mcp-server.ts`) → the REST
+ * endpoint listed in `server/agent/plugin-names.ts:TOOL_ENDPOINTS`,
+ * bypassing every `execute()` defined in `src/plugins/<name>/index.ts`.
+ *
+ * Consequences:
+ * - Per-mode dispatch (e.g. branch on which arg is set), arg
+ *   normalization, fan-out side effects, and post-success triggers
+ *   MUST live in the server route, not in `execute()`. Putting them in
+ *   `execute()` looks like it works in dev but silently no-ops in
+ *   production because the agent path never reaches the function.
+ * - The `execute()` body is kept only to satisfy the gui-chat-protocol
+ *   `ToolPlugin` shape (other host apps invoke it). Keeping it as a
+ *   one-line `apiPost` pass-through is the convention — no logic there.
  */
 export type ToolPlugin<T = unknown, J = unknown, A extends object = object> = BaseToolPlugin<T, J, A, InputHandler, Record<string, unknown>>;
 
@@ -19,6 +36,9 @@ export type ToolPlugin<T = unknown, J = unknown, A extends object = object> = Ba
  * View-only plugin entry for the frontend registry.
  * Only the properties actually used on the client side are required.
  * This avoids contravariance issues with execute's args type parameter.
+ *
+ * Note the deliberate absence of `execute` — see the warning on
+ * `ToolPlugin` above for why MulmoClaude does not call it.
  */
 export interface PluginEntry {
   toolDefinition: ToolDefinition;


### PR DESCRIPTION
## Summary

Extend the `presentMulmoScript` tool with two opt-in capabilities, both routed through the existing `/api/mulmo-script` endpoint so the agent (MCP) and the GUI dispatcher reach the same code path:

- **`filePath` arg** — re-display an already-saved MulmoScript instead of resending the full JSON. Path is workspace-relative (canonical `stories/<rel>` form), validated through the existing realpath-based `resolveStoryPath`, and required to end in `.json`.
- **`autoGenerateMovie: true`** — kicks off movie generation in the background after save/load. Progress flows through the existing `pendingGenerations` channel that the View already watches, so spinners/results appear automatically without the user having to open the canvas first.

The unified handler decides between `save-fresh` and `reopen-existing` based on which arg is set, emits a clear "either `script` or `filePath`, not both" error otherwise, and triggers the background movie pipeline in-process when the flag is on. `chatSessionId` is read from the MCP-injected `?session=` query so progress events still route to the right channel.

Plus a doc-only commit on `src/tools/types.ts` warning that `ToolPlugin.execute()` is **not called at runtime in MulmoClaude** — the agent path bypasses it. This catches the class of mistake where dispatch logic lands in `execute()` and silently no-ops.

Plan: [`plans/feat-mulmo-script-load-and-background-movie.md`](plans/feat-mulmo-script-load-and-background-movie.md)

## Test plan

- [ ] `presentMulmoScript({ script: { ... } })` still saves + presents (existing behavior, unchanged)
- [ ] `presentMulmoScript({ filePath: "stories/foo.json" })` loads and presents an existing script
- [ ] `presentMulmoScript({ script | filePath, autoGenerateMovie: true })` kicks off a background movie generation; opening the canvas after start shows in-flight spinners; on completion the download button appears
- [ ] Passing both `script` and `filePath` (or neither) returns a 400 with a clear error
- [ ] Path traversal attempts (`../`, absolute paths, non-`.json`) are rejected
- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Load and re-display existing MulmoScript presentations by referencing file paths
  * Optional automatic background movie generation when saving scripts without requiring canvas interaction

* **Documentation**
  * Improved tool parameter descriptions clarifying usage modes and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->