### PR TITLE
fix(presentMulmoScript): View polish + Play presentation toolbar

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -109,9 +109,15 @@ app.use(requireSameOrigin);
 //
 // /api/files/* is exempt because <img src="/api/files/raw?path=...">
 // tags in rendered markdown can't attach Authorization headers.
-// The CSRF origin check + loopback-only binding still apply.
+// /api/mulmo-script/download-movie is exempt for the same reason —
+// the presentMulmoScript canvas surfaces the rendered movie via an
+// `<a href download>`, and a plain anchor click can't attach a
+// bearer header. The route still validates moviePath through
+// resolveStoryPath (realpath confinement to the stories directory),
+// and the CSRF origin check + loopback-only binding still apply.
 app.use("/api", (req, res, next) => {
   if (req.path.startsWith("/files/")) return next();
+  if (req.path === "/mulmo-script/download-movie") return next();
   bearerAuth(req, res, next);
 });
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -809,6 +809,8 @@ const deMessages = {
     gen: "Generieren",
     play: "▶ Abspielen",
     stop: "■ Stoppen",
+    playPresentation: "Präsentation abspielen",
+    regenerateMovie: "Video neu generieren",
     errPrefix: "⚠ Fehler",
     noBeats: "Keine Beats im Skript gefunden",
     editSource: "Skript-Quelle bearbeiten",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -826,6 +826,8 @@ const enMessages = {
     gen: "Gen",
     play: "▶ Play",
     stop: "■ Stop",
+    playPresentation: "Play presentation",
+    regenerateMovie: "Regenerate movie",
     errPrefix: "⚠ Error",
     noBeats: "No beats found in script",
     editSource: "Edit Script Source",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -810,6 +810,8 @@ const esMessages = {
     gen: "Generar",
     play: "▶ Reproducir",
     stop: "■ Detener",
+    playPresentation: "Reproducir presentación",
+    regenerateMovie: "Regenerar vídeo",
     errPrefix: "⚠ Error",
     noBeats: "No se encontraron beats en el script",
     editSource: "Editar fuente del script",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -802,6 +802,8 @@ const frMessages = {
     gen: "Générer",
     play: "▶ Lire",
     stop: "■ Arrêter",
+    playPresentation: "Lire la présentation",
+    regenerateMovie: "Régénérer la vidéo",
     errPrefix: "⚠ Erreur",
     noBeats: "Aucun beat trouvé dans le script",
     editSource: "Modifier la source du script",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -801,6 +801,8 @@ const jaMessages = {
     gen: "生成",
     play: "▶ 再生",
     stop: "■ 停止",
+    playPresentation: "プレゼンテーション再生",
+    regenerateMovie: "動画を再生成",
     errPrefix: "⚠ エラー",
     noBeats: "スクリプトにビートが見つかりません",
     editSource: "スクリプトソースを編集",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -801,6 +801,8 @@ const koMessages = {
     gen: "생성",
     play: "▶ 재생",
     stop: "■ 정지",
+    playPresentation: "프레젠테이션 재생",
+    regenerateMovie: "동영상 재생성",
     errPrefix: "⚠ 오류",
     noBeats: "스크립트에서 비트를 찾을 수 없습니다",
     editSource: "스크립트 원본 편집",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -800,6 +800,8 @@ const ptBRMessages = {
     gen: "Gerar",
     play: "▶ Reproduzir",
     stop: "■ Parar",
+    playPresentation: "Reproduzir apresentação",
+    regenerateMovie: "Regenerar vídeo",
     errPrefix: "⚠ Erro",
     noBeats: "Nenhum beat encontrado no script",
     editSource: "Editar fonte do script",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -797,6 +797,8 @@ const zhMessages = {
     gen: "生成",
     play: "▶ 播放",
     stop: "■ 停止",
+    playPresentation: "播放演示",
+    regenerateMovie: "重新生成视频",
     errPrefix: "⚠ 错误",
     noBeats: "脚本中没有找到 beat",
     editSource: "编辑脚本源",

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -15,30 +15,30 @@
           <span v-if="filePath" class="truncate">{{ filePath }}</span>
         </div>
       </div>
-      <div class="ml-4 shrink-0 flex gap-2">
+      <div class="ml-4 shrink-0 flex items-center gap-2">
         <!-- Download Movie -->
         <a
           v-if="moviePath && !movieGenerating"
           :href="`${downloadMovieBase}?moviePath=${encodeURIComponent(moviePath)}`"
           download
-          class="px-3 py-1 text-xs rounded-full border transition-colors border-gray-200 text-gray-500 hover:bg-gray-50 flex items-center justify-center gap-1"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors"
         >
-          <span class="material-icons text-sm leading-none">download</span>
+          <span class="material-icons text-sm">download</span>
           <span>{{ t("pluginMulmoScript.movie") }}</span>
         </a>
         <!-- Generate / Regenerate Movie -->
         <button
-          class="px-3 py-1 text-xs rounded-full border transition-colors border-gray-200 text-gray-500 hover:bg-gray-50 disabled:opacity-40 flex items-center justify-center gap-1"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           :disabled="movieGenerating"
           @click="generateMovie"
         >
-          <svg v-if="movieGenerating" class="animate-spin w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="none">
+          <svg v-if="movieGenerating" class="animate-spin w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
           </svg>
           <span v-if="movieGenerating">{{ t("pluginMulmoScript.generating") }}</span>
           <template v-else>
-            <span class="material-icons text-sm leading-none">refresh</span>
+            <span class="material-icons text-sm">refresh</span>
             <span>{{ t("pluginMulmoScript.movie") }}</span>
           </template>
         </button>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -21,9 +21,9 @@
           v-if="moviePath && !movieGenerating"
           :href="`${downloadMovieBase}?moviePath=${encodeURIComponent(moviePath)}`"
           download
-          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors"
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm transition-colors"
         >
-          <span class="material-icons text-sm">download</span>
+          <span class="material-icons text-base">download</span>
           <span>{{ t("pluginMulmoScript.movie") }}</span>
         </a>
         <!-- Generate / Regenerate Movie -->

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -308,7 +308,7 @@
     </div>
 
     <!-- Lightbox -->
-    <div v-if="lightbox" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80" @click="lightbox = null">
+    <div v-if="lightbox" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80" @click="closeLightbox">
       <div class="flex items-center gap-4" @click.stop>
         <button
           v-if="!lightbox.isCharacter"
@@ -474,16 +474,28 @@ function characterPrompt(key: string): string {
   return (script.value.imageParams?.images?.[key]?.prompt as string) ?? "";
 }
 
+function stopPlayingAudio() {
+  if (!playingAudio.value) return;
+  playingAudio.value.audio.pause();
+  playingAudio.value = null;
+}
+
 function openLightbox(index: number) {
-  if (playingAudio.value) {
-    playingAudio.value.audio.pause();
-    playingAudio.value = null;
-  }
+  stopPlayingAudio();
   lightbox.value = {
     src: renderedImages[index],
     text: effectiveBeat(index).text,
     index,
   };
+}
+
+// Backdrop click handler. Stops any in-flight narration so the audio
+// doesn't keep playing after the lightbox is dismissed — without this,
+// the HTMLAudioElement created by playAudio() outlives the modal and
+// the user hears disembodied narration with no UI to stop it.
+function closeLightbox() {
+  stopPlayingAudio();
+  lightbox.value = null;
 }
 
 const hasPrev = computed(() => {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -16,6 +16,21 @@
         </div>
       </div>
       <div class="ml-4 shrink-0 flex items-center gap-2">
+        <!-- Play presentation: opens the lightbox at beat 0 and starts
+             audio. Same gating as Download Movie — only when a movie has
+             been generated, which is our proxy for "every beat has both
+             an image and audio on disk". Green outline + green icon
+             share the visual idiom with the (filled) Download button so
+             both completed-artifact actions read as the same family. -->
+        <button
+          v-if="moviePath && !movieGenerating"
+          class="h-8 w-8 flex items-center justify-center rounded border border-green-600 text-green-600 hover:bg-green-50 transition-colors"
+          :title="t('pluginMulmoScript.playPresentation')"
+          :aria-label="t('pluginMulmoScript.playPresentation')"
+          @click="playPresentation"
+        >
+          <span class="material-icons text-base">play_arrow</span>
+        </button>
         <!-- Download Movie -->
         <a
           v-if="moviePath && !movieGenerating"
@@ -26,8 +41,23 @@
           <span class="material-icons text-base">download</span>
           <span>{{ t("pluginMulmoScript.movie") }}</span>
         </a>
-        <!-- Generate / Regenerate Movie -->
+        <!-- Regenerate Movie (icon-only): collapses to a square once a
+             movie exists — the adjacent Download / Play already make
+             the subject clear, so the "Movie" label only adds noise. -->
         <button
+          v-if="moviePath && !movieGenerating"
+          class="h-8 w-8 flex items-center justify-center rounded border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors"
+          :title="t('pluginMulmoScript.regenerateMovie')"
+          :aria-label="t('pluginMulmoScript.regenerateMovie')"
+          @click="generateMovie"
+        >
+          <span class="material-icons text-base">refresh</span>
+        </button>
+        <!-- Generate Movie (pill): no movie yet, or one is currently
+             generating. Keeps the label so first-time users know what
+             they're triggering. -->
+        <button
+          v-else
           class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           :disabled="movieGenerating"
           @click="generateMovie"
@@ -496,6 +526,18 @@ function openLightbox(index: number) {
 function closeLightbox() {
   stopPlayingAudio();
   lightbox.value = null;
+}
+
+// "Play presentation" toolbar action. Opens the lightbox at beat 0 and
+// kicks off its narration audio; the existing on-ended hook then chains
+// through the rest of the deck (lightboxMove(1) → playAudio if the next
+// beat has audio), so one click runs the whole presentation. Only wired
+// to the toolbar button when moviePath is set, which is our proxy for
+// "every beat has both image and audio on disk".
+function playPresentation() {
+  if (beats.value.length === 0) return;
+  openLightbox(0);
+  if (beatAudios[0]) playAudio(0);
 }
 
 const hasPrev = computed(() => {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -505,10 +505,20 @@ const hasNext = computed(() => {
 function lightboxMove(delta: number) {
   if (!lightbox.value) return;
   const total = beats.value.length;
+  // If audio was playing when the user clicked the arrow, carry the
+  // playback over to the next beat that has audio. openLightbox()
+  // unconditionally stops any active audio, so we capture the flag
+  // BEFORE that and replay AFTER. The on-ended auto-advance path
+  // already nulls playingAudio before calling lightboxMove, so this
+  // branch won't double-fire there.
+  const wasPlaying = playingAudio.value !== null;
   let i = lightbox.value.index + delta;
   while (i >= 0 && i < total) {
     if (renderedImages[i]) {
       openLightbox(i);
+      if (wasPlaying && beatAudios[i]) {
+        playAudio(i);
+      }
       return;
     }
     i += delta;

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -902,6 +902,29 @@ async function generateAllCharacters() {
   await Promise.all(characterKeys.value.filter((key) => charRenderState[key] !== "rendering").map((key) => renderCharacter(key, false)));
 }
 
+// Mount-time policy: prefer the cached PNG on disk over re-rendering.
+// Deterministic beat types (textSlide/markdown/chart/mermaid/html_tailwind)
+// are cheap to render but not free — every renderBeat round-trips,
+// flips renderState to "rendering", and emits publishGeneration
+// start/finish events that flicker the global busy indicator. So if
+// the image already exists (e.g. after a movie generation, or a
+// previous mount of the same result), we just load it. Only fall
+// through to renderBeat when the disk has nothing yet AND the type is
+// safe to auto-render (deterministic content, no characters waiting).
+//
+// Edits invalidate cached PNGs through other paths: per-beat saves
+// already do `delete renderedImages[index]; renderBeat(index)` on
+// image change in updateBeat(), and the per-beat ↺ regenerate button
+// is always available — so a stale PNG is one click away from being
+// refreshed.
+async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolean, autoRenderTypes: readonly string[]): Promise<void> {
+  await loadExistingBeatImage(index);
+  if (renderedImages[index]) return;
+  if (shouldAutoRenderBeat(beat, hasCharacters, autoRenderTypes)) {
+    await renderBeat(index);
+  }
+}
+
 async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
@@ -927,11 +950,7 @@ async function initializeScript() {
   const AUTO_RENDER_TYPES = ["textSlide", "markdown", "chart", "mermaid", "html_tailwind"] as const;
   const hasCharacters = characterKeys.value.length > 0;
   beats.value.forEach((beat, index) => {
-    if (shouldAutoRenderBeat(beat, hasCharacters, AUTO_RENDER_TYPES)) {
-      renderBeat(index);
-    } else if (beat.imagePrompt) {
-      loadExistingBeatImage(index);
-    }
+    void hydrateBeatImage(beat, index, hasCharacters, AUTO_RENDER_TYPES);
     if (beat.text) loadExistingBeatAudio(index);
   });
 


### PR DESCRIPTION
## Summary

A batch of UX fixes and small additions to the `presentMulmoScript` canvas View, all independent of the backend changes that landed in #888.

- **Cached PNG hydration on mount** — deterministic beat types (textSlide / markdown / chart / mermaid / html_tailwind) used to unconditionally re-render at mount time, flickering spinners and lighting the global busy indicator even when a movie was already on disk. Try `loadExistingBeatImage` first; only fall through to `renderBeat` when nothing is cached.
- **Audio carries across lightbox nav** — clicking ‹ / › during playback used to silence the narration because `openLightbox()` always pauses. Capture `playingAudio` before navigation and replay on the next beat that has audio.
- **Stop narration when lightbox closes** — backdrop click dismissed the modal but left the in-flight `HTMLAudioElement` playing. Funnel through a new `closeLightbox()` that pauses + clears `playingAudio`.
- **Toolbar buttons align with chrome guidelines** — Generate Movie / Download Movie now use the canonical icon+label pill (`h-8 px-2.5 flex items-center gap-1 text-sm rounded`) per CLAUDE.md, dropping ad-hoc `px-3 py-1 text-xs rounded-full`.
- **Download Movie matches Markdown PDF green** — `bg-green-600 hover:bg-green-700 text-white` so both completed-artifact downloads share one visual idiom.
- **Play presentation button (new)** — icon-only, green-outlined toolbar button visible when a movie has been generated. One click opens the lightbox at beat 0 and starts narration; the existing on-ended hook chains through the rest of the deck. Adds `pluginMulmoScript.playPresentation` and `pluginMulmoScript.regenerateMovie` across all 8 locales (en/ja/zh/ko/es/pt-BR/fr/de).
- **Regenerate Movie collapses to icon-only** — once a movie exists, the adjacent Download / Play already make the subject clear, so the "Movie" label is dropped and the button shrinks to `h-8 w-8`.
- **Movie download bearer-auth exemption** — `<a href download>` can't attach an `Authorization` header, so plain-anchor clicks were silently 401'd (no console output anywhere — the browser doesn't surface failed `<a download>` clicks and `unauthorized()` doesn't log). Same browser limitation that already exempted `/api/files/*` for `<img>` tags. The route still has CSRF + loopback + `resolveStoryPath` confinement.

## Test plan

- [ ] Open a MulmoScript with a generated movie — beats load instantly without "Rendering" spinners
- [ ] Click ‹ / › during narration playback — audio carries to the next beat that has audio
- [ ] Close the lightbox during playback — narration stops
- [ ] Click the new green Play button — lightbox opens at beat 0, narration starts, deck advances automatically
- [ ] Click Movie Download — file downloads (the previous 401 silent failure is fixed)
- [ ] Open a MulmoScript without a movie — Generate Movie pill shows with "Movie" label
- [ ] After generation completes — Movie label drops; only Play / Download / icon-only Regenerate remain
- [ ] Switch UI to ja / zh / ko / es / pt-BR / fr / de — Play / Regenerate tooltips all translated
- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Play presentation" button to start presentations from the beginning with narration
  * Reorganized movie actions—separate "Download Movie" and "Regenerate Movie" buttons when available
  * Enhanced narration audio management during lightbox navigation
  * Improved beat image caching and rendering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->