### PR TITLE
feat(files): atomic writes for v2 sites of #881 (3 sites + dead-code drop)

### DIFF
--- a/plans/feat-atomic-writes-v2.md
+++ b/plans/feat-atomic-writes-v2.md
@@ -1,0 +1,28 @@
+# Atomic writes v2 of #881
+
+GitHub: https://github.com/receptron/mulmoclaude/issues/881
+Continues from PR #885 (v1 = HIGH 6 sites, merged).
+
+## Scope (v2 — MEDIUM 4 sites in the issue, 3 in this PR)
+
+| Site | Action |
+|---|---|
+| `server/api/routes/mulmo-script.ts:621, 693` | Replace `writeFileSync(path, Buffer)` with `await writeFileAtomic(path, Buffer)`. Both are inside async route handlers, so unblocking is fine. Drop the now-redundant `mkdirSync(path.dirname(...), { recursive: true })`. |
+| `server/workspace/tool-trace/writeSearch.ts:90` | Change the default `writeFile` deps adapter from `fsp.writeFile(...)` to `writeFileAtomic(...)`. Tests inject their own adapter so behaviour stays mockable. |
+| `server/utils/files/json.ts:saveJsonFile` | Zero production callers (only test files reference it). Remove the function + its barrel re-export, migrate the existing tests to `writeJsonAtomic`. |
+
+## Out of scope
+
+- **`server/workspace/wiki-backlinks/index.ts:42,97`** — owned by **PR #883** (`refactor(wiki): consolidate page writes into writeWikiPage choke point`). #883 will route every wiki page write through a single helper, including the backlinks adapter, so duplicating that work here would just create a merge conflict.
+- LOW (append-only) sites — logger / session-io / source archive / tool-trace JSONL append. Different correctness model (append-only doesn't have the half-write problem the same way).
+- Migration scripts (`scripts/migrate-*`) — one-shot, user-invoked.
+
+## Verification
+
+- `yarn typecheck / lint / format / build / test` clean
+- `grep` over the touched files: zero remaining `writeFile` / `writeFileSync` / `fsp.writeFile` outside of intentional cases
+- Unit tests for the new `writeJsonAtomic` migration path stay green (the pre-existing tests already cover the atomic semantics)
+
+## Why split from PR #885
+
+PR #885 was already a meaningful slice (atomic + Buffer widening + 6 stores). Adding the v2 sites would have buried two unrelated kinds of change in one diff — the deps-adapter swap and the route-handler sync→async conversion. Keeping v2 separate makes review easier and unblocks #883's wiki work cleanly.

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from "express";
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync } from "fs";
 import path from "path";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { stripDataUri } from "../../utils/files/image-store.js";
 import { writeJsonAtomic } from "../../utils/files/json.js";
 import {
@@ -615,10 +616,10 @@ router.post(API_ROUTES.mulmoScript.uploadBeatImage, async (req: Request<object, 
 
   await withStoryContext(res, filePath, {}, async ({ context }) => {
     const { imagePath } = getBeatPngImagePath(context, beatIndex);
-    mkdirSync(path.dirname(imagePath), { recursive: true });
-
+    // writeFileAtomic creates parent dirs and prevents a half-
+    // written PNG from surviving a crash mid-write (#881 v2).
     const base64 = stripDataUri(imageData);
-    writeFileSync(imagePath, Buffer.from(base64, "base64"));
+    await writeFileAtomic(imagePath, Buffer.from(base64, "base64"));
 
     res.json({ image: fileToDataUri(imagePath, "image/png") });
   });
@@ -687,10 +688,10 @@ router.post(
 
     await withStoryContext(res, filePath, {}, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
-      mkdirSync(path.dirname(imagePath), { recursive: true });
-
+      // writeFileAtomic creates parent dirs and prevents a half-
+      // written PNG from surviving a crash mid-write (#881 v2).
       const base64 = stripDataUri(imageData);
-      writeFileSync(imagePath, Buffer.from(base64, "base64"));
+      await writeFileAtomic(imagePath, Buffer.from(base64, "base64"));
 
       res.json({ image: fileToDataUri(imagePath, "image/png") });
     });

--- a/server/utils/files/index.ts
+++ b/server/utils/files/index.ts
@@ -8,14 +8,14 @@
 //
 //   atomic.ts        — write-then-rename primitives
 //   safe.ts          — ENOENT-swallowing wrappers (stat, readdir, readText, resolveWithinRoot)
-//   json.ts          — JSON read/write (sync legacy + async atomic)
+//   json.ts          — JSON sync read + async atomic write
 //   workspace-io.ts  — workspace-aware helpers (path resolve + I/O in one call)
 
 export { writeFileAtomic, writeFileAtomicSync, type WriteAtomicOptions } from "./atomic.js";
 
 export { isEnoent, readTextSafeSync, statSafe, statSafeAsync, readDirSafe, readDirSafeAsync, readTextOrNull, resolveWithinRoot } from "./safe.js";
 
-export { loadJsonFile, saveJsonFile, writeJsonAtomic, readJsonOrNull } from "./json.js";
+export { loadJsonFile, writeJsonAtomic, readJsonOrNull } from "./json.js";
 
 export {
   resolveWorkspacePath,

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -1,10 +1,14 @@
-// JSON file helpers — synchronous (legacy) and async (preferred).
+// JSON file helpers — synchronous read, async atomic write.
 //
 // Moved from server/utils/file.ts (issue #366 Phase 1). The old
 // file re-exports these for backwards compat.
+//
+// `saveJsonFile` (sync, non-atomic write) was removed in #881 v2 —
+// it had no production callers and the synchronous code path
+// couldn't offer the atomic-rename guarantee that `writeJsonAtomic`
+// already does. Reach for `writeJsonAtomic` from now on.
 
-import { mkdirSync, promises, readFileSync, writeFileSync } from "fs";
-import path from "path";
+import { promises, readFileSync } from "fs";
 import { writeFileAtomic } from "./atomic.js";
 import { isEnoent } from "./safe.js";
 import { log } from "../../system/logger/index.js";
@@ -38,11 +42,6 @@ export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
     });
     return defaultValue;
   }
-}
-
-export function saveJsonFile(filePath: string, data: unknown): void {
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
 // ── Async ───────────────────────────────────────────────────────

--- a/server/workspace/tool-trace/writeSearch.ts
+++ b/server/workspace/tool-trace/writeSearch.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { slugify } from "../../utils/slug.js";
 import { toUtcIsoDate } from "../../utils/date.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 
 export const SEARCHES_DIR = WORKSPACE_DIRS.searches;
@@ -87,7 +88,11 @@ const defaultDeps: WriteSearchDeps = {
   mkdir: async (dir) => {
     await fsp.mkdir(dir, { recursive: true });
   },
-  writeFile: (filePath, content) => fsp.writeFile(filePath, content, "utf-8"),
+  // Atomic write so a crash mid-flight can't leave a half-written
+  // search markdown that the jsonl `contentRef` then points at
+  // (#881 v2). Tests inject their own adapter so behaviour stays
+  // mockable.
+  writeFile: (filePath, content) => writeFileAtomic(filePath, content),
 };
 
 /**

--- a/test/utils/files/test_json.ts
+++ b/test/utils/files/test_json.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { loadJsonFile, saveJsonFile, writeJsonAtomic, readJsonOrNull } from "../../../server/utils/files/json.js";
+import { loadJsonFile, writeJsonAtomic, readJsonOrNull } from "../../../server/utils/files/json.js";
 
 let tmpDir: string;
 
@@ -34,20 +34,6 @@ describe("loadJsonFile (sync)", () => {
   });
 });
 
-describe("saveJsonFile (sync)", () => {
-  it("writes pretty-printed JSON", () => {
-    const file = path.join(tmpDir, "save.json");
-    saveJsonFile(file, { b: 2 });
-    assert.deepEqual(JSON.parse(readFileSync(file, "utf-8")), { b: 2 });
-  });
-
-  it("creates parent directories", () => {
-    const file = path.join(tmpDir, "save-deep", "nested.json");
-    saveJsonFile(file, [1, 2, 3]);
-    assert.deepEqual(JSON.parse(readFileSync(file, "utf-8")), [1, 2, 3]);
-  });
-});
-
 describe("writeJsonAtomic (async)", () => {
   it("writes atomically and pretty-prints", async () => {
     const file = path.join(tmpDir, "atomic.json");
@@ -56,6 +42,15 @@ describe("writeJsonAtomic (async)", () => {
     assert.deepEqual(JSON.parse(raw), { c: true });
     // Pretty-printed: contains newlines
     assert.ok(raw.includes("\n"));
+  });
+
+  it("creates parent directories", async () => {
+    // Old `saveJsonFile` covered this via mkdirSync(); after the
+    // #881 v2 removal, writeJsonAtomic inherits parent-dir creation
+    // from writeFileAtomic and should still pass the same shape.
+    const file = path.join(tmpDir, "atomic-deep", "nested.json");
+    await writeJsonAtomic(file, [1, 2, 3]);
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf-8")), [1, 2, 3]);
   });
 });
 

--- a/test/utils/test_file.ts
+++ b/test/utils/test_file.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
-import { loadJsonFile, saveJsonFile, writeFileAtomic, writeJsonAtomic, readJsonOrNull } from "../../server/utils/files/index.js";
+import { loadJsonFile, writeFileAtomic, writeJsonAtomic, readJsonOrNull } from "../../server/utils/files/index.js";
 
 let tmpDir = "";
 
@@ -37,16 +37,6 @@ describe("loadJsonFile (existing)", () => {
     assert.deepEqual(loadJsonFile<{ x: number }>(filePath, { x: 42 }), {
       x: 42,
     });
-  });
-});
-
-describe("saveJsonFile (existing)", () => {
-  it("creates the parent directory and writes pretty JSON", () => {
-    const filePath = path.join(tmpDir, "nested", "deep", "x.json");
-    saveJsonFile(filePath, { a: 1, b: [2, 3] });
-    const raw = readFileSync(filePath, "utf-8");
-    assert.ok(raw.includes("\n"), "JSON should be pretty-printed");
-    assert.deepEqual(JSON.parse(raw), { a: 1, b: [2, 3] });
   });
 });
 


### PR DESCRIPTION
## Summary

Continues the audit from #881. PR #885 closed the HIGH bucket (artifact stores). This PR takes the 3 still-open MEDIUM sites; the 4th (wiki-backlinks) is deferred to **PR #883** which is consolidating wiki page writes through a single helper anyway, so duplicating that work here would just create a merge conflict.

## Items to Confirm / Review

- [ ] **\`saveJsonFile\` removal is safe** — verified zero production call sites via \`grep -rn saveJsonFile server packages scripts\`. The two test files referencing it have been migrated to \`writeJsonAtomic\`, so the same invariants (pretty-print + parent-dir creation + nested values) stay covered.
- [ ] **Sync→async route conversion** — \`mulmo-script.ts:621/693\` were already inside async handlers, so \`await writeFileAtomic\` is a clean swap with no caller-shape change. The redundant \`mkdirSync(path.dirname(imagePath), { recursive: true })\` lines are dropped because \`writeFileAtomic\` creates the parent dir itself.
- [ ] **Tool-trace deps adapter** — \`defaultDeps.writeFile\` now uses \`writeFileAtomic\`. The injection point (\`Partial<WriteSearchDeps>\` via the second parameter) is unchanged, so test adapters still work.
- [ ] **wiki-backlinks deferred** — body of #881 asks for it but the issue itself defers it to #763 PR1, which lives on PR #883. Confirmed #883 is open and modifying \`server/workspace/wiki-backlinks/\`.

## Files

- \`server/api/routes/mulmo-script.ts\` — two route handlers swapped, \`writeFileSync\` import dropped, \`mkdirSync\` redundancy removed.
- \`server/workspace/tool-trace/writeSearch.ts\` — default deps adapter swapped.
- \`server/utils/files/json.ts\` — \`saveJsonFile\` deleted, header comment updated.
- \`server/utils/files/index.ts\` — barrel re-export updated.
- \`test/utils/files/test_json.ts\`, \`test/utils/test_file.ts\` — \`saveJsonFile\` block migrated to \`writeJsonAtomic\`.
- \`plans/feat-atomic-writes-v2.md\` — design notes.

## User Prompt

> 続きを

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads and search result indexing now use atomic file writes to prevent partially written or corrupted files during unexpected interruptions.
  * Improved file operation reliability against crash scenarios.

* **Tests**
  * Updated test coverage to validate atomic write operations for file outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->