### PR TITLE
fix(presentMulmoScript): post-#891 review follow-ups

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -109,15 +109,9 @@ app.use(requireSameOrigin);
 //
 // /api/files/* is exempt because <img src="/api/files/raw?path=...">
 // tags in rendered markdown can't attach Authorization headers.
-// /api/mulmo-script/download-movie is exempt for the same reason —
-// the presentMulmoScript canvas surfaces the rendered movie via an
-// `<a href download>`, and a plain anchor click can't attach a
-// bearer header. The route still validates moviePath through
-// resolveStoryPath (realpath confinement to the stories directory),
-// and the CSRF origin check + loopback-only binding still apply.
+// The CSRF origin check + loopback-only binding still apply.
 app.use("/api", (req, res, next) => {
   if (req.path.startsWith("/files/")) return next();
-  if (req.path === "/mulmo-script/download-movie") return next();
   bearerAuth(req, res, next);
 });
 

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -21,10 +21,15 @@
              been generated, which is our proxy for "every beat has both
              an image and audio on disk". Green outline + green icon
              share the visual idiom with the (filled) Download button so
-             both completed-artifact actions read as the same family. -->
+             both completed-artifact actions read as the same family.
+             `isPlayReady` ensures we don't open the lightbox before the
+             first beat's image (and audio, if it has text) finish their
+             async load — moviePath can be set while loadExistingBeatImage
+             is still in flight. -->
         <button
           v-if="moviePath && !movieGenerating"
-          class="h-8 w-8 flex items-center justify-center rounded border border-green-600 text-green-600 hover:bg-green-50 transition-colors"
+          class="h-8 w-8 flex items-center justify-center rounded border border-green-600 text-green-600 hover:bg-green-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          :disabled="!isPlayReady"
           :title="t('pluginMulmoScript.playPresentation')"
           :aria-label="t('pluginMulmoScript.playPresentation')"
           @click="playPresentation"
@@ -534,8 +539,25 @@ function closeLightbox() {
 // beat has audio), so one click runs the whole presentation. Only wired
 // to the toolbar button when moviePath is set, which is our proxy for
 // "every beat has both image and audio on disk".
+//
+// `moviePath` arrives synchronously from /movie-status, but the per-beat
+// image and audio data URIs are populated asynchronously by
+// loadExistingBeatImage / loadExistingBeatAudio in initializeScript().
+// The Play button can therefore become visible before beat 0's assets
+// hydrate — `isPlayReady` gates the click so the lightbox never opens
+// with an undefined src or silent narration on a beat that does have
+// text.
+const isPlayReady = computed<boolean>(() => {
+  if (beats.value.length === 0) return false;
+  if (!renderedImages[0]) return false;
+  // Audio is only required when the beat has text (the source of TTS).
+  // Beats without text are valid; they just play silently.
+  if (effectiveBeat(0).text && !beatAudios[0]) return false;
+  return true;
+});
+
 function playPresentation() {
-  if (beats.value.length === 0) return;
+  if (!isPlayReady.value) return;
   openLightbox(0);
   if (beatAudios[0]) playAudio(0);
 }

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -666,21 +666,6 @@ async function applySource() {
     return;
   }
 
-  // Snapshot the per-beat visual source BEFORE we re-initialize so we
-  // can identify which beats had their image / imagePrompt change in
-  // the source edit. initializeScript() prefers the on-disk PNG by
-  // default; for these changed beats that PNG is now stale, so we
-  // mark them invalidated and force a fresh render.
-  const oldImageSources = beats.value.map((beat, i) => beatImageSource(localOverrides[i] ?? beat));
-  const newBeats = (parsed.beats ?? []) as Beat[];
-  const invalidatedImageIndices = new Set<number>();
-  newBeats.forEach((newBeat, i) => {
-    if (i >= oldImageSources.length) return;
-    if (oldImageSources[i] !== beatImageSource(newBeat)) {
-      invalidatedImageIndices.add(i);
-    }
-  });
-
   // Update the UI with the new script.
   // Note: the parent's handleUpdateResult uses Object.assign (in-place
   // mutation), so the watcher on props.selectedResult won't fire.
@@ -692,15 +677,7 @@ async function applySource() {
   });
 
   if (sourceDetails.value) sourceDetails.value.open = false;
-  await initializeScript({ invalidatedImageIndices });
-}
-
-// Stable string key over the visual-source fields of a beat — `image`
-// (deterministic types) and `imagePrompt` (AI-generated). Used by
-// applySource to diff old vs new beats so a stale on-disk PNG doesn't
-// linger after a source edit.
-function beatImageSource(beat: Beat): string {
-  return JSON.stringify({ image: beat.image, imagePrompt: beat.imagePrompt });
+  await initializeScript();
 }
 
 async function copyText() {
@@ -1014,40 +991,7 @@ async function generateAllCharacters() {
   await Promise.all(characterKeys.value.filter((key) => charRenderState[key] !== "rendering").map((key) => renderCharacter(key, false)));
 }
 
-// Mount-time policy: prefer the cached PNG on disk over re-rendering.
-// Deterministic beat types (textSlide/markdown/chart/mermaid/html_tailwind)
-// are cheap to render but not free — every renderBeat round-trips,
-// flips renderState to "rendering", and emits publishGeneration
-// start/finish events that flicker the global busy indicator. So if
-// the image already exists (e.g. after a movie generation, or a
-// previous mount of the same result), we just load it. Only fall
-// through to renderBeat when the disk has nothing yet AND the type is
-// safe to auto-render (deterministic content, no characters waiting).
-//
-// `forceRefresh` skips the disk-load branch entirely — used by
-// applySource() so beats whose visual source changed in the source
-// edit get a fresh render instead of the now-stale cached PNG.
-async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolean, autoRenderTypes: readonly string[], forceRefresh: boolean): Promise<void> {
-  if (!forceRefresh) {
-    await loadExistingBeatImage(index);
-    if (renderedImages[index]) return;
-  }
-  if (shouldAutoRenderBeat(beat, hasCharacters, autoRenderTypes)) {
-    await renderBeat(index);
-  }
-}
-
-interface InitializeScriptOptions {
-  /**
-   * Beat indices whose visual source changed since the last mount.
-   * Used by applySource() to invalidate stale on-disk PNGs after a
-   * source edit; mount-time callers leave this empty and rely on the
-   * disk cache.
-   */
-  invalidatedImageIndices?: ReadonlySet<number>;
-}
-
-async function initializeScript(opts: InitializeScriptOptions = {}) {
+async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
@@ -1069,11 +1013,26 @@ async function initializeScript(opts: InitializeScriptOptions = {}) {
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 
+  // Mount-time policy: deterministic beat types
+  // (textSlide/markdown/chart/mermaid/html_tailwind) re-render every
+  // mount so a script edit always reflects the current source — the
+  // cached PNG on disk could be stale, and tracking every invalidation
+  // path (applySource, hasCharacters flips, beat additions) added more
+  // complexity than the brief mount-time spinner saves. mulmocast
+  // hashes by content server-side, so unchanged beats short-circuit
+  // without doing real work.
+  //
+  // imagePrompt beats stay on the load-existing path because their
+  // re-render is a paid AI call — users explicitly trigger refresh via
+  // the per-beat ↺. Same for audio (paid TTS).
   const AUTO_RENDER_TYPES = ["textSlide", "markdown", "chart", "mermaid", "html_tailwind"] as const;
   const hasCharacters = characterKeys.value.length > 0;
-  const invalidated = opts.invalidatedImageIndices;
   beats.value.forEach((beat, index) => {
-    void hydrateBeatImage(beat, index, hasCharacters, AUTO_RENDER_TYPES, invalidated?.has(index) ?? false);
+    if (shouldAutoRenderBeat(beat, hasCharacters, AUTO_RENDER_TYPES)) {
+      renderBeat(index);
+    } else if (beat.imagePrompt) {
+      loadExistingBeatImage(index);
+    }
     if (beat.text) loadExistingBeatAudio(index);
   });
 
@@ -1094,13 +1053,8 @@ async function initializeScript(opts: InitializeScriptOptions = {}) {
   }
 }
 
-onMounted(() => initializeScript());
-// Wrap in arrow so Vue's (newVal, oldVal) watcher args don't collide
-// with the new `InitializeScriptOptions` parameter signature.
-watch(
-  () => props.selectedResult,
-  () => initializeScript(),
-);
+onMounted(initializeScript);
+watch(() => props.selectedResult, initializeScript);
 
 // Keep the view in sync with generations that started from a different
 // view mount or a parallel tab. When a generation for this script

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -36,16 +36,22 @@
         >
           <span class="material-icons text-base">play_arrow</span>
         </button>
-        <!-- Download Movie -->
-        <a
+        <!-- Download Movie: bearer-authenticated blob fetch, then a
+             synthetic <a download> click. The natural <a href download>
+             approach can't attach the Authorization header, which would
+             have forced a bearer-auth exemption on the route — the
+             reviewer's P1 was that any sibling process could then read
+             a caller-controlled movie path. Going through apiFetchRaw
+             (auto-attaches bearer) keeps the auth boundary intact. -->
+        <button
           v-if="moviePath && !movieGenerating"
-          :href="`${downloadMovieBase}?moviePath=${encodeURIComponent(moviePath)}`"
-          download
-          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm transition-colors"
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          :disabled="movieDownloading"
+          @click="downloadMovie"
         >
           <span class="material-icons text-base">download</span>
           <span>{{ t("pluginMulmoScript.movie") }}</span>
-        </a>
+        </button>
         <!-- Regenerate Movie (icon-only): collapses to a square once a
              movie exists — the adjacent Download / Play already make
              the subject clear, so the "Movie" label only adds noise. -->
@@ -436,10 +442,6 @@ const script = computed<MulmoScript>(() => data.value?.script ?? {});
 const filePath = computed(() => data.value?.filePath ?? "");
 const beats = computed<Beat[]>(() => script.value.beats ?? []);
 
-// Exposed to the template so the `<a :href="...">` download button
-// can compose a query-string URL without inlining the API path.
-const downloadMovieBase = API_ROUTES.mulmoScript.downloadMovie;
-
 // Per-beat render state
 type RenderState = "idle" | "rendering" | "done" | "error";
 const renderState = reactive<Record<number, RenderState>>({});
@@ -456,6 +458,7 @@ const beatSaveErrors = reactive<Record<number, BeatSaveError>>({});
 const beatSaving = reactive<Record<number, boolean>>({});
 const localOverrides = reactive<Record<number, Beat>>({});
 const movieGenerating = ref(false);
+const movieDownloading = ref(false);
 const moviePath = ref<string | null>(null);
 const beatAudios = reactive<Record<number, string>>({});
 const audioState = reactive<Record<number, "generating" | "done" | "error">>({});
@@ -1188,6 +1191,40 @@ async function generateMovie() {
     alert(extractErrorMessage(err));
   } finally {
     movieGenerating.value = false;
+  }
+}
+
+// Bearer-authenticated movie download. apiFetchRaw auto-attaches the
+// Authorization header (which a plain `<a href download>` cannot), so
+// the route stays behind the standard /api/* bearer guard. The blob
+// is hooked to a synthetic anchor whose `download` attribute carries
+// the filename — the browser still surfaces a native save dialog.
+async function downloadMovie() {
+  if (!moviePath.value || movieDownloading.value) return;
+  movieDownloading.value = true;
+  let objectUrl: string | null = null;
+  try {
+    const res = await apiFetchRaw(API_ROUTES.mulmoScript.downloadMovie, {
+      method: "GET",
+      query: { moviePath: moviePath.value },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const blob = await res.blob();
+    objectUrl = URL.createObjectURL(blob);
+    const filename = moviePath.value.split("/").pop() ?? "movie.mp4";
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } catch (err) {
+    alert(extractErrorMessage(err));
+  } finally {
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+    movieDownloading.value = false;
   }
 }
 </script>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -991,6 +991,19 @@ async function generateAllCharacters() {
   await Promise.all(characterKeys.value.filter((key) => charRenderState[key] !== "rendering").map((key) => renderCharacter(key, false)));
 }
 
+// Probe the server for an existing beat PNG before triggering any
+// generation. Only auto-renders when the disk is empty AND the beat
+// is a deterministic type — imagePrompt beats are left empty so the
+// user clicks Generate explicitly (avoids surprise paid text2image
+// calls on every page refresh).
+async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolean, autoRenderTypes: readonly string[]): Promise<void> {
+  await loadExistingBeatImage(index);
+  if (renderedImages[index]) return;
+  if (shouldAutoRenderBeat(beat, hasCharacters, autoRenderTypes)) {
+    await renderBeat(index);
+  }
+}
+
 async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
@@ -1013,26 +1026,23 @@ async function initializeScript() {
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 
-  // Mount-time policy: deterministic beat types
-  // (textSlide/markdown/chart/mermaid/html_tailwind) re-render every
-  // mount so a script edit always reflects the current source — the
-  // cached PNG on disk could be stale, and tracking every invalidation
-  // path (applySource, hasCharacters flips, beat additions) added more
-  // complexity than the brief mount-time spinner saves. mulmocast
-  // hashes by content server-side, so unchanged beats short-circuit
-  // without doing real work.
+  // Mount-time policy: prefer the existing PNG on the server. Every
+  // beat — deterministic AND imagePrompt — first probes /beat-image,
+  // and we only fall through to renderBeat() when the disk has nothing
+  // yet AND the type is safe to auto-render (deterministic content,
+  // no characters waiting). Without this probe a refresh would re-fire
+  // generateBeatImage for every beat, and for imagePrompt beats that
+  // means a paid text2image call against an image we already have.
   //
-  // imagePrompt beats stay on the load-existing path because their
-  // re-render is a paid AI call — users explicitly trigger refresh via
-  // the per-beat ↺. Same for audio (paid TTS).
+  // Stale-after-edit: if the user edits the script source the on-disk
+  // PNG is no longer in sync with the new content, but we don't try to
+  // detect that here — the per-beat ↺ button is one click away and a
+  // page refresh re-runs this same probe, so the user can opt back into
+  // a fresh render whenever they need to.
   const AUTO_RENDER_TYPES = ["textSlide", "markdown", "chart", "mermaid", "html_tailwind"] as const;
   const hasCharacters = characterKeys.value.length > 0;
   beats.value.forEach((beat, index) => {
-    if (shouldAutoRenderBeat(beat, hasCharacters, AUTO_RENDER_TYPES)) {
-      renderBeat(index);
-    } else if (beat.imagePrompt) {
-      loadExistingBeatImage(index);
-    }
+    void hydrateBeatImage(beat, index, hasCharacters, AUTO_RENDER_TYPES);
     if (beat.text) loadExistingBeatAudio(index);
   });
 

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -663,6 +663,21 @@ async function applySource() {
     return;
   }
 
+  // Snapshot the per-beat visual source BEFORE we re-initialize so we
+  // can identify which beats had their image / imagePrompt change in
+  // the source edit. initializeScript() prefers the on-disk PNG by
+  // default; for these changed beats that PNG is now stale, so we
+  // mark them invalidated and force a fresh render.
+  const oldImageSources = beats.value.map((beat, i) => beatImageSource(localOverrides[i] ?? beat));
+  const newBeats = (parsed.beats ?? []) as Beat[];
+  const invalidatedImageIndices = new Set<number>();
+  newBeats.forEach((newBeat, i) => {
+    if (i >= oldImageSources.length) return;
+    if (oldImageSources[i] !== beatImageSource(newBeat)) {
+      invalidatedImageIndices.add(i);
+    }
+  });
+
   // Update the UI with the new script.
   // Note: the parent's handleUpdateResult uses Object.assign (in-place
   // mutation), so the watcher on props.selectedResult won't fire.
@@ -674,7 +689,15 @@ async function applySource() {
   });
 
   if (sourceDetails.value) sourceDetails.value.open = false;
-  await initializeScript();
+  await initializeScript({ invalidatedImageIndices });
+}
+
+// Stable string key over the visual-source fields of a beat — `image`
+// (deterministic types) and `imagePrompt` (AI-generated). Used by
+// applySource to diff old vs new beats so a stale on-disk PNG doesn't
+// linger after a source edit.
+function beatImageSource(beat: Beat): string {
+  return JSON.stringify({ image: beat.image, imagePrompt: beat.imagePrompt });
 }
 
 async function copyText() {
@@ -998,20 +1021,30 @@ async function generateAllCharacters() {
 // through to renderBeat when the disk has nothing yet AND the type is
 // safe to auto-render (deterministic content, no characters waiting).
 //
-// Edits invalidate cached PNGs through other paths: per-beat saves
-// already do `delete renderedImages[index]; renderBeat(index)` on
-// image change in updateBeat(), and the per-beat ↺ regenerate button
-// is always available — so a stale PNG is one click away from being
-// refreshed.
-async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolean, autoRenderTypes: readonly string[]): Promise<void> {
-  await loadExistingBeatImage(index);
-  if (renderedImages[index]) return;
+// `forceRefresh` skips the disk-load branch entirely — used by
+// applySource() so beats whose visual source changed in the source
+// edit get a fresh render instead of the now-stale cached PNG.
+async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolean, autoRenderTypes: readonly string[], forceRefresh: boolean): Promise<void> {
+  if (!forceRefresh) {
+    await loadExistingBeatImage(index);
+    if (renderedImages[index]) return;
+  }
   if (shouldAutoRenderBeat(beat, hasCharacters, autoRenderTypes)) {
     await renderBeat(index);
   }
 }
 
-async function initializeScript() {
+interface InitializeScriptOptions {
+  /**
+   * Beat indices whose visual source changed since the last mount.
+   * Used by applySource() to invalidate stale on-disk PNGs after a
+   * source edit; mount-time callers leave this empty and rely on the
+   * disk cache.
+   */
+  invalidatedImageIndices?: ReadonlySet<number>;
+}
+
+async function initializeScript(opts: InitializeScriptOptions = {}) {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
@@ -1035,8 +1068,9 @@ async function initializeScript() {
 
   const AUTO_RENDER_TYPES = ["textSlide", "markdown", "chart", "mermaid", "html_tailwind"] as const;
   const hasCharacters = characterKeys.value.length > 0;
+  const invalidated = opts.invalidatedImageIndices;
   beats.value.forEach((beat, index) => {
-    void hydrateBeatImage(beat, index, hasCharacters, AUTO_RENDER_TYPES);
+    void hydrateBeatImage(beat, index, hasCharacters, AUTO_RENDER_TYPES, invalidated?.has(index) ?? false);
     if (beat.text) loadExistingBeatAudio(index);
   });
 
@@ -1057,8 +1091,13 @@ async function initializeScript() {
   }
 }
 
-onMounted(initializeScript);
-watch(() => props.selectedResult, initializeScript);
+onMounted(() => initializeScript());
+// Wrap in arrow so Vue's (newVal, oldVal) watcher args don't collide
+// with the new `InitializeScriptOptions` parameter signature.
+watch(
+  () => props.selectedResult,
+  () => initializeScript(),
+);
 
 // Keep the view in sync with generations that started from a different
 // view mount or a parallel tab. When a generation for this script


### PR DESCRIPTION
## Summary

Three follow-ups to PR #891 reviewer comments that landed after the merge.

- **Guard Play presentation until beat 0 media is loaded** (chatgpt-codex P2 + isamu) — `playPresentation()` opened the lightbox immediately, but `moviePath` arrives synchronously from `/movie-status` while the per-beat image and audio data URIs hydrate asynchronously via `loadExistingBeatImage` / `loadExistingBeatAudio`. A click in that window left the user with an undefined `<img src>` and silent narration. Add an `isPlayReady` computed (image required; audio required only when beat 0 has text — silent slides are valid) and bind it to the button's `:disabled`. The handler also short-circuits as defense in depth.

- **Invalidate stale PNGs on `applySource`** (isamu) — `hydrateBeatImage` prefers any existing PNG on disk before rendering, but `applySource()` reuses `initializeScript()`, so a script-level edit kept showing the now-stale cached image until the user clicked the per-beat ↺. Snapshot the per-beat visual source (`{ image, imagePrompt }`) before saving, diff against the new beats, and pass changed indices through `initializeScript({ invalidatedImageIndices })`. `hydrateBeatImage` skips the disk-load branch for those and renders fresh; mount-time callers leave the option empty and keep the cached fast path.

- **Revert bearer-auth exemption — bearer-authenticated movie download** (isamu P1) — exempting `GET /api/mulmo-script/download-movie` from `bearerAuth` weakened the sibling-process protection the API layer relies on; `resolveStoryPath` confined the path to the stories tree but did not restore authorization. Drop the exemption and replace the View's `<a href download>` with a click handler that uses `apiFetchRaw` (auto-attaches the Bearer token) → `res.blob()` → synthetic `<a download>` bound to `URL.createObjectURL`. The native browser save dialog still surfaces with the right filename. Trade-off: the ~10–50 MB MulmoScript movies pass through JS memory; for substantially larger artifacts a signed-URL pattern would be the next step, but that's overkill at our current scale.

## Test plan

- [ ] Open a freshly opened MulmoScript with a generated movie immediately after switching to the canvas — the green Play button is briefly disabled while beat 0 hydrates, then becomes clickable.
- [ ] Click Play before beat 0 image/audio finish loading — nothing happens (the disabled state holds).
- [ ] Edit the source via Edit Script Source → Apply Changes, changing one beat's `image.markdown` content — that beat re-renders fresh, untouched beats keep their cached PNG.
- [ ] Click Movie Download — the file downloads with the correct filename, no 401 in the network tab.
- [ ] `curl http://localhost:3001/api/mulmo-script/download-movie?moviePath=...` without `Authorization` header — returns 401 (bearer guard restored).
- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all green (run + verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Play button validation—now waits for beat 0's rendered image and narration audio before enabling playback.
  * Improved download functionality with authenticated API integration and loading state feedback.

* **Bug Fixes**
  * Fixed stale image caching issue—edited beats now display fresh renders instead of outdated cached versions.

* **Security**
  * Download endpoint now enforces authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->