### PR TITLE
fix: address coderabbit review of #874 (fr.ts Spotify register)

### DIFF
--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -458,7 +458,7 @@ const frMessages = {
           field: {
             clientId: {
               label: "Client ID",
-              help: "Spotify Developer Dashboard → Create app, configure la Redirect URI à http://127.0.0.1:8888/callback, copie le Client ID. Puis exécute une fois dans le terminal `SPOTIFY_CLIENT_ID=<id> npx spotify-mcp@latest auth` pour se connecter (refresh token mis en cache dans ~/.spotify-mcp/tokens.json).",
+              help: "Spotify Developer Dashboard → Create app, configurez la Redirect URI à http://127.0.0.1:8888/callback, copiez le Client ID. Puis exécutez une fois dans le terminal `SPOTIFY_CLIENT_ID=<id> npx spotify-mcp@latest auth` pour vous connecter (refresh token mis en cache dans ~/.spotify-mcp/tokens.json).",
             },
           },
         },


### PR DESCRIPTION
Follow-up to #874 addressing one unaddressed CodeRabbit review comment.

## Items fixed
- `src/lang/fr.ts:461` — Spotify catalog `help` text used informal `tu` form (configure la / copie le / exécute / pour se connecter) while the rest of `fr.ts` and the rest of the catalog use the formal `vous` imperative (Téléchargez / Réutilisez / Cliquez sur 🔑). Aligned with project convention.

## Items deliberately skipped
- `server/agent/mcpHealth.ts:null` race-condition / cache-poisoning comment — this was already addressed in commit `9ed97e7e fix: address codex review iteration-1` on the original PR (the comment was on a pre-fix version). Current code rejects on timeout, has `if (timedOut) return` in the exit handler, and `checkNpmPackage` declines to cache ambiguous failures, so no action needed here.
- `server/agent/mcpHealth.ts:31` finding was just a CodeRabbit analysis log ("Confirm the expected constant exists"), not an actionable code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)