### PR TITLE
fix: address coderabbit review of #882 (zh schemaLabel + plan local path)

### DIFF
--- a/plans/done/feat-system-file-banner-i18n.md
+++ b/plans/done/feat-system-file-banner-i18n.md
@@ -57,7 +57,12 @@ Total: 21×2 + 5 + 3 = **50 keys per locale × 8 locales = ~400 entries**.
 - Each locale gets a real translation, not English copy. Confirm with native conventions.
 - Keep titles short (chip-friendly) and summaries to ≤2 sentences.
 - Edit policies are chips — keep them terse (1–3 words).
-- German file: respect `~/.claude/rules/i18n-de.md` typographic-quote rule.
+- German file: avoid German typographic quotes (U+201E / U+201C) in
+  string literals — the tokenizer can collapse U+201C to ASCII `"`,
+  silently terminating the surrounding JS string. Use ASCII quotes
+  inside the source; if user-facing typographic quotes are needed,
+  inject them via Unicode escapes from a Node one-liner instead of
+  the Edit / Write tools.
 - vue-tsc enforces lockstep — missing keys in any locale = build fail.
 
 ## Validation

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -207,7 +207,7 @@ const zhMessages = {
     parseError: "解析错误",
   },
   systemFiles: {
-    schemaLabel: "Schema",
+    schemaLabel: "架构",
     showDetails: "显示详情",
     hideDetails: "隐藏详情",
     editPolicy: {


### PR DESCRIPTION
Follow-up to #882 addressing two CodeRabbit comments.

## Items fixed
- `src/lang/zh.ts:210` `systemFiles.schemaLabel` was left as English "Schema" while the rest of the zh `systemFiles` block is fully localised. Translated to 架构.
- `plans/done/feat-system-file-banner-i18n.md:60` referenced `~/.claude/rules/i18n-de.md` which is environment-specific. Replaced with an inline summary of the German typographic-quote rule so the doc is portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)