### PR TITLE
chore(ci): skip e2e on i18n-only PRs

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,6 +23,34 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether a PR has any changes outside src/lang/**. Translation-only
+  # PRs are gated out of e2e because rendered strings don't change browser
+  # behavior, and `vue-tsc` (in lint_test below) already enforces the
+  # 8-locale lockstep at the type level — a missing or extra key fails the
+  # type check before it can land. Push events always run the full suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_e2e: ${{ steps.filter.outputs.run_e2e }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qv '^src/lang/'; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint_test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -81,6 +109,8 @@ jobs:
     - run: yarn run test:coverage
 
   e2e:
+    needs: changes
+    if: needs.changes.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Split the 268-test e2e suite across 2 parallel runners via


### PR DESCRIPTION
## Summary

Add a setup job that decides whether e2e is needed. Translation-only PRs (`src/lang/**` only) skip e2e; `lint_test` (which includes `vue-tsc` and the i18n schema lockstep enforcement) always runs.

## Why

PRs that only touch `src/lang/*.ts` add or tweak translation strings — they don't change browser behavior, so the e2e suite has nothing new to exercise. The 8-locale lockstep across `en/ja/zh/ko/es/fr/de/pt-BR` is already enforced at the type level (the `typeof enMessages` module augmentation in `src/types/vue-i18n.d.ts` makes any missing or extra key a `vue-tsc` error in `lint_test`), so a translation-only PR with a typo or schema drift is caught before merge regardless of e2e.

## How

Added a small `changes` job that diffs the PR head against base and exposes `run_e2e=true|false`. The `e2e` job gains `needs: changes` + `if: needs.changes.outputs.run_e2e == 'true'`. Push events to main always run the full suite (fall-through).

## Items to Confirm / Review

- [ ] **Branch protection**: if `e2e (1)` / `e2e (2)` are listed as required status checks, GitHub's required-check semantics need to treat conditionally-skipped jobs as "satisfied". Modern GitHub does (2023+), but worth verifying on this PR — open a draft i18n-only follow-up to confirm the merge button stays available.
- [ ] **`changes` job adds ~20-30s** to the critical path before e2e starts. Acceptable trade-off for the i18n-only skip case (saves ~8 min); negligible on regular PRs.
- [ ] **Mixed PRs (i18n + code)**: still trigger e2e because the `git diff | grep -qv '^src/lang/'` finds at least one non-i18n file. ✓ correct.
- [ ] **Docs-only PRs**: still skip the whole workflow via the existing top-level `paths-ignore`. ✓ unchanged.

## Test plan

- [ ] After merge, the next i18n-only PR should show `e2e (1)` / `e2e (2)` as `Skipped` and `lint_test (...)` as `Passed`. Merge button should remain available.
- [ ] A PR mixing `src/lang/en.ts` + `src/foo.ts` should still run e2e in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)