### PR TITLE
fix: address coderabbit review of #883 (wiki classifier slug guard)

### DIFF
--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -131,7 +131,17 @@ export function classifyAsWikiPage(absPath: string, opts: WikiPageWriteOptions =
   // wrongly rejected it).
   if (rel.includes(path.sep)) return { wiki: false };
   if (!rel.endsWith(".md")) return { wiki: false };
-  return { wiki: true, slug: rel.slice(0, -".md".length) };
+  const slug = rel.slice(0, -".md".length);
+  // Mirror isSafeSlug at the classifier so any path the classifier
+  // accepts is one writeWikiPage can actually handle. The two
+  // documented escapes are `<pagesDir>/.md` (rel = ".md", slug = "")
+  // and the literal "." / ".." filenames (`.md.md` is fine, `..md`
+  // is fine too — those are valid filenames). Without this check,
+  // writeWikiPage's wikiPagePath() throws "refusing unsafe slug" and
+  // the caller (files PUT) bubbles a 500 instead of falling through
+  // to the generic writeFileAtomic path. Coderabbit review #883.
+  if (!isSafeSlug(slug)) return { wiki: false };
+  return { wiki: true, slug };
 }
 
 // ── Internal: snapshot stub ────────────────────────────────────

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -205,6 +205,16 @@ describe("wiki-pages/io — classifyAsWikiPage", () => {
     assert.deepEqual(out, { wiki: false });
   });
 
+  // CodeRabbit review #883: classifier used to accept `<pagesDir>/.md`
+  // and return slug = "", which then crashed downstream wikiPagePath()
+  // with "refusing unsafe slug". Mirroring isSafeSlug here makes the
+  // classifier produce the clean fallback (wiki: false → routes to
+  // generic writeFileAtomic) instead of a 500.
+  it("rejects bare `.md` filename (slug would be empty)", () => {
+    const out = classifyAsWikiPage(path.join(pagesDir, ".md"), { workspaceRoot: root });
+    assert.deepEqual(out, { wiki: false });
+  });
+
   it("rejects pagesDir itself (no slug)", () => {
     const out = classifyAsWikiPage(pagesDir, { workspaceRoot: root });
     assert.deepEqual(out, { wiki: false });


### PR DESCRIPTION
Follow-up to #883 addressing one CodeRabbit comment on `server/workspace/wiki-pages/io.ts`.

## Items fixed
- `classifyAsWikiPage` used to accept `<pagesDir>/.md` and return `{wiki: true, slug: ""}`, which then crashed downstream `writeWikiPage("")` via `wikiPagePath()`'s `isSafeSlug` guard with `refusing unsafe slug`. The PUT route caller (`server/api/routes/files.ts`) caught the throw as a 500 instead of falling through to the generic `writeFileAtomic` path the classifier was meant to route to. Now mirrors `isSafeSlug` at the classifier level so accepted paths are always writable.
- Adds a regression test in `test/workspace/wiki-pages/test_io.ts`.

## Items deliberately skipped
- The read-then-write race comment on lines 91-92 (`readTextSafe` → `rename` not atomic vs concurrent writers) is documented as "Not actionable in PR 1" by CodeRabbit and a heads-up for #763 PR 2's snapshot work. Left for that follow-up.
- The symlink-resolution comment was already fixed before this sweep (current comment correctly states "pure path-string math — no symlink resolution").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename validation for wiki pages to prevent server errors; system now gracefully falls back to default behavior when encountering unsafe filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->