### PR TITLE
docs: address coderabbit review of #865 (README cron phrasing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Chat with Claude Code and get back not just text but **interactive visual output
 
 **Access from anywhere**: connect Telegram, Slack, LINE, Discord, or [10 other messaging apps](#messaging-bridges) to talk to your AI agent from your phone.
 
-**Scheduled tasks**: hand off recurring work — daily summaries, periodic checks, timed reminders — to a built-in scheduler that runs your agent on a cron.
+**Scheduled tasks**: hand off recurring work — daily summaries, periodic checks, timed reminders — to a built-in scheduler that runs your agent on a cron schedule.
 
 ## Quick Start
 


### PR DESCRIPTION
Follow-up to #865. `README.md:21` had "runs your agent on a cron" which CodeRabbit flagged as awkward English. Changed to "runs your agent on a cron schedule".

🤖 Generated with [Claude Code](https://claude.com/claude-code)