### PR TITLE
fix(audio): surface real error text in beat audio failures

### DIFF
--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -2,15 +2,24 @@
 // `err instanceof Error ? err.message : String(err)` — searching for
 // one canonical helper is easier than grepping for the inline form.
 //
+// Non-Error objects with a `details` (gRPC convention) or `message`
+// string field have that field surfaced — without this, gRPC errors
+// like `{ code, details, metadata }` show up to users as
+// `[object Object]`.
+//
 // The optional `fallback` covers the common route-handler idiom where
 // a throw of a plain non-Error value should surface as a descriptive
-// message ("rebuild failed") rather than `String(err)` noise like
-// `[object Object]`. Prefer passing a fallback at error-response
-// boundaries — omit it for logging contexts where `String(err)` is
-// fine.
+// message ("rebuild failed") rather than `String(err)` noise. Prefer
+// passing a fallback at error-response boundaries — omit it for
+// logging contexts where `String(err)` is fine.
 
 export function errorMessage(err: unknown, fallback?: string): string {
   if (err instanceof Error) return err.message;
+  if (err !== null && typeof err === "object") {
+    const obj = err as { details?: unknown; message?: unknown };
+    if (typeof obj.details === "string" && obj.details) return obj.details;
+    if (typeof obj.message === "string" && obj.message) return obj.message;
+  }
   if (fallback !== undefined) return fallback;
   return String(err);
 }

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -257,7 +257,9 @@
                   {{ playingAudio?.index === index ? t("pluginMulmoScript.stop") : t("pluginMulmoScript.play") }}
                 </button>
                 <template v-else-if="audioErrors[index]">
-                  <span class="text-xs text-red-400" :title="audioErrors[index]">{{ t("pluginMulmoScript.errPrefix") }}</span>
+                  <span class="text-xs text-red-400 truncate min-w-0 max-w-[20rem]" :title="audioErrors[index]">
+                    {{ t("pluginMulmoScript.errPrefix") }} {{ audioErrors[index] }}
+                  </span>
                   <button
                     v-if="effectiveBeat(index).text"
                     class="text-xs px-2 py-0.5 rounded border border-gray-300 text-gray-500 hover:bg-gray-50 disabled:opacity-50"

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,13 +6,21 @@
 // `err instanceof Error ? err.message : String(err)` — searching for
 // one canonical helper is easier than grepping for the inline form.
 //
+// Non-Error objects with a `details` (gRPC convention) or `message`
+// string field have that field surfaced — without this, gRPC errors
+// like `{ code, details, metadata }` show up as `[object Object]`.
+//
 // The optional `fallback` covers the common idiom of surfacing a
 // descriptive message ("Invalid JSON", "Connection error.") when a
-// throw turns out to be a non-Error value — otherwise `String(err)`
-// yields noise like `[object Object]`.
+// throw turns out to be a non-Error value.
 
 export function errorMessage(err: unknown, fallback?: string): string {
   if (err instanceof Error) return err.message;
+  if (err !== null && typeof err === "object") {
+    const obj = err as { details?: unknown; message?: unknown };
+    if (typeof obj.details === "string" && obj.details) return obj.details;
+    if (typeof obj.message === "string" && obj.message) return obj.message;
+  }
   if (fallback !== undefined) return fallback;
   return String(err);
 }

--- a/test/utils/test_errors.ts
+++ b/test/utils/test_errors.ts
@@ -28,12 +28,27 @@ describe("errorMessage", () => {
     assert.equal(errorMessage(42), "42");
   });
 
-  it("returns '[object Object]' for a plain object without toString", () => {
-    // String() on a plain object falls through to Object.prototype.toString,
-    // which produces "[object Object]". We don't unwrap .message because
-    // an arbitrary object that happens to have a `message` field is not
-    // necessarily an Error and could be misleading.
-    assert.equal(errorMessage({ message: "trick" }), "[object Object]");
+  it("unwraps .details from a gRPC-style error object", () => {
+    // Real-world case: TTS/voice clients throw `{ code, details, metadata }`
+    // which is not an Error instance. Without unwrapping `.details`, users
+    // would see "[object Object]" instead of the actual cause.
+    assert.equal(errorMessage({ code: 3, details: "voice needs model" }), "voice needs model");
+  });
+
+  it("unwraps .message from a non-Error object", () => {
+    assert.equal(errorMessage({ message: "boom" }), "boom");
+  });
+
+  it("prefers .details over .message when both are present", () => {
+    assert.equal(errorMessage({ details: "specific", message: "generic" }), "specific");
+  });
+
+  it("falls through to String(err) when .details and .message are not strings", () => {
+    assert.equal(errorMessage({ details: 42 }), "[object Object]");
+  });
+
+  it("falls through to String(err) when .details and .message are empty", () => {
+    assert.equal(errorMessage({ details: "", message: "" }), "[object Object]");
   });
 
   it("returns the empty string for an empty Error message", () => {


### PR DESCRIPTION
## Summary

Audio generation failures in `presentMulmoScript` rendered as a useless `⚠ Error` with the actual cause hidden in a `:title` tooltip. The cause was lost in two layers:

1. **`errorMessage()` swallowed gRPC errors.** Both `server/utils/errors.ts` and `src/utils/errors.ts` only read `.message` for `Error` instances and fell through to `String(err)` for everything else — producing `[object Object]` for gRPC-style errors like `{ code, details, metadata }` (Google Cloud TTS, Vertex, etc.). Now it unwraps `.details` (gRPC convention) then `.message` from non-Error objects before falling back. Tests updated accordingly — including the prior "we deliberately do NOT unwrap `.message`" case, which we are explicitly reversing because in practice the misleading-`.message`-on-arbitrary-object scenario is rare and the `[object Object]` outcome was clearly worse.
2. **The Vue template only rendered the i18n prefix.** `presentMulmoScript/View.vue` printed `{{ t("pluginMulmoScript.errPrefix") }}` and shoved the actual error into `:title`, so users had to know to hover. Now renders `{prefix} {error}` inline with `truncate min-w-0 max-w-[20rem]`; the `:title` is preserved for full text on hover.

Companion upstream fix in mulmocast-cli: receptron/mulmocast-cli#1358 (without it, the Google TTS path still throws a bare `"TTS Google Error"` with no detail to unwrap — but other gRPC-thrown paths benefit from this PR right away).

## Before

```
⚠ Error      ← title="[object Object]"
```

## After

```
⚠ Error This voice requires a model name to be specified.
                    ← title= full text, truncates if longer than ~20rem
```

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn test && yarn build` clean
- [x] Updated `test/utils/test_errors.ts` covers: `.details` unwrap, `.message` unwrap, `.details` precedence over `.message`, non-string fields fall through, empty strings fall through
- [ ] Manually trigger a failing beat audio generation and confirm the inline error text appears with truncation + tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface clearer error messages for audio generation failures by unwrapping structured error objects and displaying the full error text inline in the Mulmo script audio UI.

Bug Fixes:
- Unwrap gRPC-style error objects (preferring `.details` over `.message`) in the shared errorMessage helper to avoid `[object Object]` messages.
- Fix Mulmo script audio error display to show the localized prefix together with the actual error text inline instead of hiding it only in a tooltip.

Tests:
- Extend errorMessage unit tests to cover unwrapping of `.details` and `.message`, precedence rules, and fallback behavior when those fields are missing or invalid.