### PR TITLE
fix(presentMulmoScript): split provider guidance per param section

### DIFF
--- a/src/plugins/presentMulmoScript/definition.ts
+++ b/src/plugins/presentMulmoScript/definition.ts
@@ -14,7 +14,13 @@ Two modes — provide EXACTLY ONE of \`script\` or \`filePath\`:
 
 Optional \`autoGenerateMovie: true\` kicks off movie generation in the background, so the final video is ready by the time the user opens the canvas. Movie generation is expensive (multiple image + audio API calls + video encoding) — only set this when the user has explicitly asked for the movie. Default \`false\`.
 
-Always use Google providers when creating new scripts. Required structure:
+Provider rules for new scripts:
+- \`speechParams.speakers.<name>.provider\`: \`"gemini"\` — pairs with Gemini voices like \`"Kore"\`, \`"Aoede"\`, \`"Puck"\`. Do NOT use \`"google"\` here — that routes to Google Cloud TTS, where Gemini-class voices fail with "This voice requires a model name to be specified." unless an explicit \`model\` is set.
+- \`imageParams.provider\`: \`"google"\`
+- \`movieParams.provider\`: \`"google"\`
+- Do NOT add a top-level \`provider\` field to \`speechParams\` — provider belongs per-speaker only.
+
+Required structure:
 
 {
   "$mulmocast": { "version": "1.1" },


### PR DESCRIPTION
## Summary

The tool description told the LLM **"Always use Google providers when creating new scripts"**, which it interpreted as `"provider": "google"` everywhere — including `speechParams.speakers.*` and a spurious top-level `speechParams.provider`. Routing speech through `provider: "google"` sends it to Google Cloud TTS, where Gemini voices like `Kore` require an explicit `model` name and otherwise fail with:

```
Error: TTS Google Error: This voice requires a model name to be specified.
```

(That error text is what surfaces today thanks to #903 + receptron/mulmocast-cli#1358; before those, the user just saw a useless "Error".)

## Change

Replace the one-line directive with per-section rules:

- `speechParams.speakers.<name>.provider`: `"gemini"` — pairs with Gemini voices like `Kore`, `Aoede`, `Puck`. Names the failure mode inline so the model has a concrete reason to follow the rule.
- `imageParams.provider`: `"google"`
- `movieParams.provider`: `"google"`
- Do NOT add a top-level `provider` field to `speechParams` — provider is per-speaker only.

The required-structure sample below it (which already uses `"provider": "gemini"` for the speaker) is unchanged.

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build` clean
- [ ] Generate a fresh MulmoScript via the LLM (e.g. with the 47news skill) and confirm the speaker block emits `"provider": "gemini"`, no top-level `speechParams.provider`, and audio synthesis succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update MulmoScript provider guidance to use Gemini for speech speakers and Google for image and movie providers, avoiding invalid top-level speechParams providers.