### PR TITLE
feat(frontmatter): server mirror + writeWikiPage auto-stamp + wiki metadata bar (#895 PR B)

### DIFF
--- a/e2e/tests/wiki-metadata-bar.spec.ts
+++ b/e2e/tests/wiki-metadata-bar.spec.ts
@@ -74,8 +74,11 @@ test.describe("wiki metadata bar (#895 PR B)", () => {
     const bar = page.getByTestId("wiki-page-metadata-bar");
     await expect(bar).toBeVisible();
     await expect(page.getByTestId("wiki-page-metadata-created")).toContainText("2026-04-26");
-    // Updated is reformatted from ISO to `YYYY-MM-DD HH:MM`.
-    await expect(page.getByTestId("wiki-page-metadata-updated")).toContainText("2026-04-27 14:32");
+    // `updated` is formatted from UTC ISO to local-TZ
+    // `YYYY-MM-DD HH:MM`. The HH:MM portion shifts by TZ, so
+    // assert only the year-month prefix — both UTC and reasonable
+    // user TZs (±12h) land in `2026-04-26` or `2026-04-27`.
+    await expect(page.getByTestId("wiki-page-metadata-updated")).toContainText(/2026-04-2[67]/);
     await expect(page.getByTestId("wiki-page-metadata-editor")).toContainText("llm");
     // Tags rendered as chips.
     await expect(page.getByTestId("wiki-page-metadata-tag-demo")).toBeVisible();

--- a/e2e/tests/wiki-metadata-bar.spec.ts
+++ b/e2e/tests/wiki-metadata-bar.spec.ts
@@ -1,0 +1,108 @@
+// E2E for #895 PR B — wiki page metadata bar.
+//
+// User-visible contract: when a wiki page has frontmatter, the
+// view shows a thin row above the rendered body with `Created`,
+// `Updated`, `Editor`, and tags. Header-less pages keep the old
+// look (no bar, just the body) — pre-existing wiki content must
+// not gain an empty bar.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const PAGE_WITH_FRONTMATTER = {
+  action: "page",
+  title: "with-meta",
+  pageName: "with-meta",
+  content: [
+    "---",
+    "title: Onboarding Notes",
+    "created: 2026-04-26",
+    "updated: 2026-04-27T14:32:56.789Z",
+    "editor: llm",
+    "tags: [demo, onboarding]",
+    "---",
+    "",
+    "# Body Heading",
+    "",
+    "This is the body.",
+  ].join("\n"),
+};
+
+const PAGE_HEADER_LESS = {
+  action: "page",
+  title: "no-meta",
+  pageName: "no-meta",
+  content: "# Plain Page\n\nNo frontmatter here.",
+};
+
+const INDEX_PAYLOAD = {
+  action: "index",
+  title: "Wiki Index",
+  content: "# Wiki Index",
+  pageEntries: [
+    { title: "with-meta", slug: "with-meta", description: "", tags: [] },
+    { title: "no-meta", slug: "no-meta", description: "", tags: [] },
+  ],
+};
+
+async function mockWikiApi(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/wiki",
+    async (route) => {
+      const req = route.request();
+      const slug = req.method() === "GET" ? new URL(req.url()).searchParams.get("slug") : ((req.postDataJSON() ?? {}) as { pageName?: string }).pageName;
+      if (slug === "with-meta") return route.fulfill({ json: { data: PAGE_WITH_FRONTMATTER } });
+      if (slug === "no-meta") return route.fulfill({ json: { data: PAGE_HEADER_LESS } });
+      return route.fulfill({ json: { data: INDEX_PAYLOAD } });
+    },
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+  await mockWikiApi(page);
+});
+
+test.describe("wiki metadata bar (#895 PR B)", () => {
+  test("renders Created / Updated / Editor / Tags from frontmatter", async ({ page }) => {
+    await page.goto("/wiki/pages/with-meta");
+
+    // Body content visible (the H1 rendered by marked).
+    await expect(page.getByRole("heading", { level: 1, name: "Body Heading" })).toBeVisible();
+
+    // Bar visible with each field.
+    const bar = page.getByTestId("wiki-page-metadata-bar");
+    await expect(bar).toBeVisible();
+    await expect(page.getByTestId("wiki-page-metadata-created")).toContainText("2026-04-26");
+    // Updated is reformatted from ISO to `YYYY-MM-DD HH:MM`.
+    await expect(page.getByTestId("wiki-page-metadata-updated")).toContainText("2026-04-27 14:32");
+    await expect(page.getByTestId("wiki-page-metadata-editor")).toContainText("llm");
+    // Tags rendered as chips.
+    await expect(page.getByTestId("wiki-page-metadata-tag-demo")).toBeVisible();
+    await expect(page.getByTestId("wiki-page-metadata-tag-onboarding")).toBeVisible();
+
+    // Body must NOT contain the raw `---` fence text — it should
+    // have been stripped before marked() rendered the body.
+    const bodyText = await page.locator(".wiki-content").innerText();
+    expect(bodyText).not.toMatch(/^---$/m);
+    expect(bodyText).not.toContain("title: Onboarding Notes");
+  });
+
+  test("a header-less page shows no metadata bar (no regression)", async ({ page }) => {
+    await page.goto("/wiki/pages/no-meta");
+    await expect(page.getByRole("heading", { level: 1, name: "Plain Page" })).toBeVisible();
+    // Bar must be absent — pages without frontmatter keep the old
+    // look so existing wiki content doesn't gain empty UI furniture.
+    await expect(page.getByTestId("wiki-page-metadata-bar")).toHaveCount(0);
+  });
+
+  test("clicking a tag chip in the metadata bar jumps to the filtered index", async ({ page }) => {
+    await page.goto("/wiki/pages/with-meta");
+    await expect(page.getByTestId("wiki-page-metadata-tag-demo")).toBeVisible();
+
+    await page.getByTestId("wiki-page-metadata-tag-demo").click();
+
+    // Lands on the index view.
+    await page.waitForURL(/\/wiki$/);
+  });
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -37,6 +37,7 @@
     "fast-xml-parser": "^5.7.1",
     "gui-chat-protocol": "0.1.0",
     "ignore": "^7.0.5",
+    "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",
     "marked": "^18.0.2",
     "mulmocast": "^2.6.8",

--- a/plans/feat-895-frontmatter-pr-b-server-wiki-bar.md
+++ b/plans/feat-895-frontmatter-pr-b-server-wiki-bar.md
@@ -1,0 +1,116 @@
+# #895 PR B: server frontmatter mirror + writeWikiPage integration + wiki metadata bar
+
+Issue: https://github.com/receptron/mulmoclaude/issues/895
+
+## ゴール
+
+PR A (#902, merged) で Vue 側 frontmatter 共通化と markdown plugin View の properties panel が land 済。PR B では:
+
+1. **server 側に同形 util を追加** (`js-yaml` ベース、PR A の `src/utils/markdown/frontmatter.ts` と shape 揃え)
+2. **`writeWikiPage` で `created` / `updated` を auto-inject** (lazy-on-write、bulk migration なし)
+3. **`wiki/View.vue` に 1 行 metadata bar 追加** (PR B 議論で追加スコープ — created/updated/editor を視覚化)
+4. **tags 統合** (frontmatter `tags` と `index.md` 由来 tags を共通表示)
+
+## 含めるもの
+
+### 新規 server util
+
+- `server/utils/markdown/frontmatter.ts` — Vue 側と同形:
+  - `parseFrontmatter(raw): { meta, body, hasHeader }` (FAILSAFE_SCHEMA)
+  - `serializeWithFrontmatter(meta, body): string`
+  - `mergeFrontmatter(existing, patch): Record<string, unknown>`
+
+### `writeWikiPage` integration
+
+- 既存 `appendSnapshot` no-op stub の手前で frontmatter merge を実行:
+  ```ts
+  const oldContent = await readTextSafe(absPath);
+  const existingMeta = oldContent ? parseFrontmatter(oldContent).meta : {};
+  const now = (opts.now ?? (() => new Date()))();
+  const merged = mergeFrontmatter(existingMeta, {
+    created: existingMeta.created ?? toIsoDate(now),
+    updated: now.toISOString(),
+    editor: meta.editor,
+  });
+  const finalContent = serializeWithFrontmatter(merged, parseFrontmatter(content).body);
+  await writeFileAtomic(absPath, finalContent, { uniqueTmp: true });
+  ```
+- `now` injection を opts に追加 (テスト可制)
+- caller が body を渡す前提だが、frontmatter を含む raw を渡してきても parse して body を取り出して merge
+
+### wiki/View.vue metadata bar
+
+- 上部に 1 行 bar:
+  ```
+  Created 2026-04-26 · Updated 2026-04-27 14:32 · Editor: llm
+  ```
+- frontmatter から取得、無いキーは省略 (まだ frontmatter 持たない既存 wiki page 互換)
+- tags: `useMarkdownDoc` の `meta.tags` (frontmatter 由来) と `entry.tags` (index.md 由来) を Set で union、既存の chip 表示位置に統合
+
+### Tests (server)
+
+- `test/utils/markdown/test_frontmatter.ts` (server 版) — Vue 側とほぼ同じ 23 ケース
+- `test/workspace/wiki-pages/test_io.ts` 拡張:
+  - 既存 frontmatter なしファイル + write → `created`/`updated`/`editor` 付与
+  - 既存 frontmatter ありファイル + write → `updated` のみ更新、`created` 維持、unknown キー保持
+  - `now` injection で時刻固定
+  - body のみ渡しても OK / frontmatter 含む raw でも OK
+  - 同一 content の 2 度書き → `updated` は変わるが他は維持 (`appendSnapshot` 条件は変えない、別関心)
+
+### Tests (Vue / e2e)
+
+- `wiki/View.vue` の metadata bar 表示テスト (e2e)
+- header なし wiki page → bar 出ない (regression guard)
+
+## 含めないもの (PR C / 後続)
+
+- editor identity の LLM/user 分離 (今は call site 全部 `"user"` placeholder のまま、disambiguation は別 PR)
+- 既存 hand-rolled parser 統合 (sources/registry, skills/parser, wiki/frontmatter)
+- NewsView / SourcesManager の frontmatter 対応
+- `appendSnapshot` 本体実装 (これは #763 PR 2)
+
+## 設計判断
+
+### `created` の意味
+
+- "First time `writeWikiPage` saw this file" — 既存ファイルの birth time は使わない (FS によって信頼できない、cross-platform で不揃い)
+- 既存 frontmatter に `created` があれば維持
+- 既存 frontmatter になければ、初回 write 時の date を採用 (ISO `YYYY-MM-DD` のみ、時刻なし)
+
+### `updated` の format
+
+- ISO 8601 with time (`2026-04-27T14:32:56.789Z`) — `created` の date-only より細かい解像度
+- 同一秒内の 2 書き込みは ms 込みで区別
+
+### `editor` の placeholder 保持
+
+- PR A と同じく `meta.editor` を call site で渡す
+- 今は wiki.ts → `"user"`, files.ts → `"user"`, wiki-backlinks → `"system"`
+- LLM 経路の `"llm"` への分離は別 PR (frontend / API contract 変更が必要)
+
+### body-only vs raw input の柔軟性
+
+- caller (manageWiki MCP / frontend save / wiki-backlinks) は通常 body のみ渡す
+- ただし frontmatter 込みの raw を渡してきても `parseFrontmatter` で body 取り出し、frontmatter は merge 入力として吸収
+- これにより既存 manageWiki tool が frontmatter 込みで送ってきても正しく動く
+
+### Vue 側 metadata bar の視覚設計
+
+- 控えめ: gray-500 text-xs、page title 直下、border-b でなく単独行
+- 順序: Created → Updated → Editor (時系列 + 識別)
+- 値が無い key は表示しない (existing wiki pages without frontmatter で空 bar にならない)
+
+## 完了条件
+
+- [ ] server util + 23 unit cases
+- [ ] `writeWikiPage` `created`/`updated` injection + 6 拡張テスト
+- [ ] wiki/View.vue metadata bar + tags 統合
+- [ ] e2e: frontmatter ある wiki page で bar 表示 / ない wiki page で bar なし
+- [ ] 既存 wiki / wiki-backlinks / files PUT テスト全 pass
+- [ ] `yarn typecheck && yarn lint && yarn build && yarn test` clean
+
+## Out of scope (繰越)
+
+- PR C: NewsView / SourcesManager / 既存 hand-rolled parser 統合
+- editor identity disambiguation (LLM vs user)
+- snapshot 機能本体 (#763 PR 2)

--- a/server/utils/markdown/frontmatter.ts
+++ b/server/utils/markdown/frontmatter.ts
@@ -1,0 +1,112 @@
+// Server-side mirror of `src/utils/markdown/frontmatter.ts`
+// (#895 PR B). The two share the same shape on purpose so the
+// parser/serializer/merger contract is identical on both sides
+// — what writeWikiPage emits round-trips losslessly through the
+// Vue useMarkdownDoc composable.
+//
+// Code is intentionally NOT a shared package: the wrapper is ~10
+// lines on each side, and a workspace package would need cross-
+// build wiring (browser bundle for Vue, plain Node for server)
+// that's not worth it for so little glue. js-yaml does the heavy
+// lifting in both places, identically.
+
+import yaml from "js-yaml";
+
+export interface ParsedMarkdown {
+  /** Parsed YAML object. Empty `{}` when the document has no
+   *  frontmatter or the YAML failed to parse. Insertion order
+   *  matches the source so callers iterating `Object.entries`
+   *  see fields in the order the file declared them. */
+  meta: Record<string, unknown>;
+  /** Body after stripping the frontmatter envelope. The trailing
+   *  newline of the closing `---` line is consumed; a no-frontmatter
+   *  document returns the raw input verbatim. */
+  body: string;
+  /** True iff a well-formed `---\n...\n---\n` envelope was
+   *  detected and parsed. Malformed YAML inside an envelope
+   *  degrades to `hasHeader: false` so a typo in the header
+   *  doesn't break writes. */
+  hasHeader: boolean;
+}
+
+const FRONTMATTER_OPEN = /^---\r?\n/;
+// `(?:^|\r?\n)` lets the closing fence sit at the very start of
+// `afterOpen` — needed for empty envelopes (`---\n---\n`) where
+// the closing `---` is the first thing after the open is stripped.
+const FRONTMATTER_CLOSE = /(?:^|\r?\n)---\s*(?:\r?\n|$)/;
+
+/** Parse a markdown document, splitting frontmatter from body.
+ *  Always returns an object — never throws. */
+export function parseFrontmatter(raw: string): ParsedMarkdown {
+  if (!FRONTMATTER_OPEN.test(raw)) {
+    return { meta: {}, body: raw, hasHeader: false };
+  }
+  const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return { meta: {}, body: raw, hasHeader: false };
+  }
+  const yamlText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  const meta = safeYamlLoad(yamlText);
+  if (meta === null) {
+    return { meta: {}, body: raw, hasHeader: false };
+  }
+  return { meta, body, hasHeader: true };
+}
+
+/** Serialize a meta object + body back into the canonical
+ *  `---\n...\n---\n\nbody` shape. An empty `meta` returns the body
+ *  alone (no envelope) — the lazy-on-write contract: don't add
+ *  ceremony to documents that don't have anything to record.
+ *
+ *  Round-trip semantics: VALUE-preserving, NOT byte-preserving.
+ *  `js-yaml` adds quotes to ambiguous scalars (`'1.20'`, `'true'`)
+ *  so they parse back as the same string under FAILSAFE_SCHEMA.
+ *  Source-text formatting may change on save but the parsed value
+ *  is stable across rounds. */
+export function serializeWithFrontmatter(meta: Record<string, unknown>, body: string): string {
+  if (Object.keys(meta).length === 0) return body;
+  // `lineWidth: -1` disables auto-wrap so long URLs / titles stay on
+  // one line. `noRefs: true` avoids YAML anchor syntax (`&id001`)
+  // which is technically valid but visually noisy in plain-text
+  // markdown.
+  const yamlText = yaml.dump(meta, { lineWidth: -1, noRefs: true }).trimEnd();
+  return `---\n${yamlText}\n---\n\n${body}`;
+}
+
+/** Merge a patch into an existing meta object. Unknown keys in
+ *  `existing` are preserved verbatim; keys present in `patch`
+ *  overwrite. A `null` or `undefined` patch value DELETES the key
+ *  (REST PATCH semantics) — callers that want "leave alone"
+ *  should omit the key entirely. */
+export function mergeFrontmatter(existing: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...existing };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null || value === undefined) {
+      delete out[key];
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function safeYamlLoad(text: string): Record<string, unknown> | null {
+  try {
+    // `FAILSAFE_SCHEMA` keeps every scalar as a string and skips
+    // type coercion. Two motivating cases:
+    //   - YAML 1.1 dates (`created: 2026-04-27`) would become a
+    //     `Date` object under DEFAULT_SCHEMA, breaking round-trip.
+    //   - Numeric-looking strings (`version: 1.20` → 1.2 under
+    //     JSON_SCHEMA) drop trailing zeros on save.
+    // For the wiki-history use case — title / created / updated /
+    // tags / editor — every value that should be a string IS one.
+    const loaded = yaml.load(text, { schema: yaml.FAILSAFE_SCHEMA });
+    if (loaded === null || loaded === undefined) return {};
+    if (typeof loaded !== "object" || Array.isArray(loaded)) return null;
+    return loaded as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -21,6 +21,7 @@
 import path from "node:path";
 import { readTextSafe } from "../../utils/files/safe.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { mergeFrontmatter, parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown/frontmatter.js";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 
@@ -39,6 +40,10 @@ export interface WikiPageWriteOptions {
   /** Override the workspace root for tests. Defaults to the
    *  process's resolved workspace (`workspace.ts`). */
   workspaceRoot?: string;
+  /** Inject the "now" used for `created` / `updated` frontmatter
+   *  injection. Tests pass a fixed `Date` so the round-trip is
+   *  deterministic; production uses the wall clock. */
+  now?: () => Date;
 }
 
 /** Reject slugs that would escape `data/wiki/pages/` once joined.
@@ -82,21 +87,105 @@ export async function readWikiPage(slug: string, opts: WikiPageWriteOptions = {}
   return readTextSafe(wikiPagePath(slug, opts));
 }
 
-/** Write a wiki page atomically and forward (old, new) to the
- *  snapshot pipeline. The snapshot call is currently a no-op stub
- *  (#763 PR 2). `uniqueTmp: true` matches what the generic
- *  `/api/files/content` PUT used pre-consolidation — without it
- *  two simultaneous writes to the same page collide on the shared
- *  `.tmp` staging file (the file-content PUT and the wiki-backlinks
- *  driver are independent and may target the same page in the same
- *  millisecond). */
+/** Write a wiki page atomically and stamp it with `created` /
+ *  `updated` / `editor` frontmatter (lazy-on-write — #895 PR B).
+ *  Existing frontmatter keys are preserved; `created` is set on
+ *  first write and never overwritten; `updated` is bumped on every
+ *  write. Callers may pass either a body-only string or content
+ *  with its own `---\n...\n---` envelope (we re-parse and merge
+ *  so the resulting file always has a single canonical envelope).
+ *
+ *  `uniqueTmp: true` matches what the generic `/api/files/content`
+ *  PUT used pre-consolidation — without it two simultaneous writes
+ *  to the same page collide on the shared `.tmp` staging file
+ *  (the file-content PUT and the wiki-backlinks driver are
+ *  independent and may target the same page in the same
+ *  millisecond).
+ *
+ *  The (old, new) pair still flows into `appendSnapshot` — the
+ *  no-op stub today, real history pipeline in #763 PR 2. */
 export async function writeWikiPage(slug: string, content: string, meta: WikiWriteMeta, opts: WikiPageWriteOptions = {}): Promise<void> {
   const absPath = wikiPagePath(slug, opts);
   const oldContent = await readTextSafe(absPath);
-  await writeFileAtomic(absPath, content, { uniqueTmp: true });
-  if (oldContent !== content) {
-    await appendSnapshot(slug, oldContent, content, meta);
+  const finalContent = stampFrontmatter(oldContent, content, meta, opts);
+  await writeFileAtomic(absPath, finalContent, { uniqueTmp: true });
+  // Snapshot trigger: only fire when the *body* changed (or the
+  // user-supplied meta did) — auto-stamping `updated` on every
+  // save would otherwise flood the snapshot store with no-op
+  // saves where nothing the user cares about actually changed.
+  // Compare bodies after parsing so a frontmatter-only diff in
+  // auto-stamped fields doesn't trip the trigger.
+  if (oldContent === null || hasMeaningfulChange(oldContent, finalContent)) {
+    await appendSnapshot(slug, oldContent, finalContent, meta);
   }
+}
+
+/** True iff the diff between `oldContent` and `newContent` is
+ *  more than just the auto-stamped `updated` / `editor` fields.
+ *  Auto-stamps land on every save; without this guard the
+ *  snapshot pipeline (#763 PR 2) would record a snapshot per
+ *  no-op save. The check compares (body) and (meta minus the
+ *  auto-stamped keys). */
+function hasMeaningfulChange(oldContent: string, newContent: string): boolean {
+  const oldDoc = parseFrontmatter(oldContent);
+  const newDoc = parseFrontmatter(newContent);
+  if (oldDoc.body !== newDoc.body) return true;
+  const oldMeta = withoutAutoStamps(oldDoc.meta);
+  const newMeta = withoutAutoStamps(newDoc.meta);
+  return JSON.stringify(oldMeta) !== JSON.stringify(newMeta);
+}
+
+const AUTO_STAMP_KEYS = new Set(["updated", "editor"]);
+
+function withoutAutoStamps(meta: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (!AUTO_STAMP_KEYS.has(key)) out[key] = value;
+  }
+  return out;
+}
+
+/** Internal — merge `created` / `updated` / `editor` into the
+ *  outgoing content. Splits the caller's `content` so a body-only
+ *  caller and a frontmatter-included caller both produce the
+ *  same canonical envelope on disk. */
+function stampFrontmatter(oldContent: string | null, newContent: string, meta: WikiWriteMeta, opts: WikiPageWriteOptions): string {
+  const existingMeta = oldContent !== null ? parseFrontmatter(oldContent).meta : {};
+  const incoming = parseFrontmatter(newContent);
+  const now = (opts.now ?? (() => new Date()))();
+  const merged = mergeFrontmatter(
+    {
+      ...existingMeta,
+      // Caller's own frontmatter (if they passed any) layers on
+      // top of the existing on-disk meta. Callers rarely do this,
+      // but when manageWiki sends `---\ntitle: …\n---` we honour it.
+      ...incoming.meta,
+    },
+    {
+      // `created` is sticky: keep the existing one if any, else
+      // stamp the date (no time — created is "first save day", not
+      // "first save instant"). Use `existingMeta.created` so the
+      // value isn't reset by an LLM that mistakenly reset it in
+      // its incoming frontmatter.
+      created: typeof existingMeta.created === "string" && existingMeta.created.length > 0 ? existingMeta.created : toIsoDate(now),
+      // `updated` always bumps — full ISO timestamp with ms so
+      // same-second writes still order correctly.
+      updated: now.toISOString(),
+      // `editor` reflects the call-site identity (PR #883). LLM /
+      // user disambiguation lives at the API layer; placeholder
+      // for now is fine.
+      editor: meta.editor,
+    },
+  );
+  return serializeWithFrontmatter(merged, incoming.body);
+}
+
+function toIsoDate(date: Date): string {
+  // YYYY-MM-DD — sortable, locale-free, matches the issue body's
+  // `created: 2026-04-26` example. UTC date deliberately so a
+  // session that crosses midnight in the user's TZ doesn't get
+  // two different `created` values.
+  return date.toISOString().slice(0, 10);
 }
 
 /** Routing helper for the generic `/api/files/content` PUT.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -627,6 +627,9 @@ const deMessages = {
     lintChat: "Wiki prüfen",
     taskCountMismatch:
       "Wiki-Quelle und gerendertes Ergebnis stimmen in der Anzahl der Aufgaben nicht überein. Die Umschaltung wurde abgelehnt, um eine Beschädigung der Datei zu vermeiden.",
+    metadataCreated: "Erstellt",
+    metadataUpdated: "Aktualisiert",
+    metadataEditor: "Bearbeiter",
   },
   pluginPresentForm: {
     fallbackTitle: "Formular",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -642,6 +642,9 @@ const enMessages = {
     noMatches: "No pages tagged #{tag}",
     lintChat: "Lint My Wiki",
     taskCountMismatch: "Wiki source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.",
+    metadataCreated: "Created",
+    metadataUpdated: "Updated",
+    metadataEditor: "Editor",
   },
   pluginPresentForm: {
     fallbackTitle: "Form",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -626,6 +626,9 @@ const esMessages = {
     noMatches: "No hay páginas con la etiqueta #{tag}",
     lintChat: "Revisar mi wiki",
     taskCountMismatch: "La fuente del wiki y la salida renderizada difieren en el número de tareas. Se rechazó el cambio para evitar dañar el archivo.",
+    metadataCreated: "Creado",
+    metadataUpdated: "Actualizado",
+    metadataEditor: "Editor",
   },
   pluginPresentForm: {
     fallbackTitle: "Formulario",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -620,6 +620,9 @@ const frMessages = {
     noMatches: "Aucune page avec le tag #{tag}",
     lintChat: "Vérifier mon wiki",
     taskCountMismatch: "La source du wiki et le rendu diffèrent sur le nombre de tâches. La modification a été refusée pour éviter de corrompre le fichier.",
+    metadataCreated: "Créé",
+    metadataUpdated: "Mis à jour",
+    metadataEditor: "Éditeur",
   },
   pluginPresentForm: {
     fallbackTitle: "Formulaire",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -617,6 +617,9 @@ const jaMessages = {
     noMatches: "#{tag} タグのページがありません",
     lintChat: "Wiki を Lint",
     taskCountMismatch: "Wiki ソースと描画結果でタスク数が一致しないため、ファイル破損を避けるためトグル操作を中止しました。",
+    metadataCreated: "作成",
+    metadataUpdated: "更新",
+    metadataEditor: "編集者",
   },
   pluginPresentForm: {
     fallbackTitle: "フォーム",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -617,6 +617,9 @@ const koMessages = {
     noMatches: "#{tag} 태그가 달린 페이지가 없습니다",
     lintChat: "Wiki 점검",
     taskCountMismatch: "Wiki 원본과 렌더링 결과의 작업 수가 일치하지 않아, 파일 손상을 방지하기 위해 토글이 거부되었습니다.",
+    metadataCreated: "생성",
+    metadataUpdated: "업데이트",
+    metadataEditor: "편집자",
   },
   pluginPresentForm: {
     fallbackTitle: "양식",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -619,6 +619,9 @@ const ptBRMessages = {
     noMatches: "Nenhuma página com a tag #{tag}",
     lintChat: "Revisar meu wiki",
     taskCountMismatch: "A fonte do wiki e a saída renderizada divergem no número de tarefas. A alternância foi recusada para evitar corromper o arquivo.",
+    metadataCreated: "Criado",
+    metadataUpdated: "Atualizado",
+    metadataEditor: "Editor",
   },
   pluginPresentForm: {
     fallbackTitle: "Formulário",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -613,6 +613,9 @@ const zhMessages = {
     noMatches: "没有带 #{tag} 标签的页面",
     lintChat: "检查 Wiki",
     taskCountMismatch: "Wiki 源与渲染输出的任务数不一致，为避免文件损坏，已拒绝切换。",
+    metadataCreated: "创建",
+    metadataUpdated: "更新",
+    metadataEditor: "编辑者",
   },
   pluginPresentForm: {
     fallbackTitle: "表单",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -494,16 +494,28 @@ const hasPageMeta = computed(() => {
   return meta.created !== null || meta.updated !== null || meta.editor !== null || meta.tags.length > 0;
 });
 
-/** Render `updated` ISO timestamp as `YYYY-MM-DD HH:MM` for
- *  display. Falls back to the raw value if it doesn't look like
- *  an ISO timestamp (defensive — user-supplied frontmatter may
- *  have any string here). */
+/** Render `updated` ISO timestamp as `YYYY-MM-DD HH:MM` in the
+ *  user's local timezone. The on-disk value is UTC ISO
+ *  (`2026-04-27T14:32:56.789Z`) — showing the raw `14:32` would
+ *  read like local wall time on a non-UTC machine and mislead
+ *  the user (codex review iter-1 #905). Falls back to the raw
+ *  value if it doesn't parse as a Date (defensive — user-supplied
+ *  frontmatter may have any string here). */
 function formatUpdated(raw: string): string {
-  // Match ISO 8601 `YYYY-MM-DDTHH:MM[:SS][.fff]Z?`. Anything else
-  // is shown verbatim.
-  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(raw);
-  if (!match) return raw;
-  return `${match[1]} ${match[2]}`;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return raw;
+  // `sv-SE` locale gives ISO-like `YYYY-MM-DD HH:MM` (with a
+  // space, no `T`) which matches the original format intent.
+  // `hour12: false` defends against locales that would otherwise
+  // emit AM/PM.
+  return new Intl.DateTimeFormat("sv-SE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(parsed);
 }
 
 const renderedContent = computed(() => {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -170,14 +170,48 @@
       </div>
     </div>
 
-    <!-- Markdown content -->
-    <div
-      v-else
-      ref="scrollRef"
-      class="flex-1 overflow-y-auto px-6 py-4 prose prose-sm max-w-none wiki-content"
-      @click="handleContentClick"
-      v-html="renderedContent"
-    />
+    <!-- Markdown content (with optional metadata bar above) -->
+    <template v-else>
+      <!-- Metadata bar (#895 PR B). One thin row that surfaces
+           `created` / `updated` / `editor` / `tags` from the page's
+           frontmatter. Hidden when the page has no header — keeps
+           the existing header-less content visually unchanged. -->
+      <div
+        v-if="action === 'page' && hasPageMeta"
+        data-testid="wiki-page-metadata-bar"
+        class="shrink-0 border-b border-gray-100 px-6 py-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500"
+      >
+        <span v-if="pageMeta.created" data-testid="wiki-page-metadata-created">
+          <span class="text-gray-400">{{ t("pluginWiki.metadataCreated") }}:</span>
+          {{ pageMeta.created }}
+        </span>
+        <span v-if="pageMeta.updated" data-testid="wiki-page-metadata-updated">
+          <span class="text-gray-400">{{ t("pluginWiki.metadataUpdated") }}:</span>
+          {{ formatUpdated(pageMeta.updated) }}
+        </span>
+        <span v-if="pageMeta.editor" data-testid="wiki-page-metadata-editor">
+          <span class="text-gray-400">{{ t("pluginWiki.metadataEditor") }}:</span>
+          {{ pageMeta.editor }}
+        </span>
+        <span v-if="pageMeta.tags.length > 0" class="flex flex-wrap gap-1" data-testid="wiki-page-metadata-tags">
+          <button
+            v-for="tag in pageMeta.tags"
+            :key="tag"
+            class="entry-tag-chip"
+            :data-testid="`wiki-page-metadata-tag-${tag}`"
+            @click="setTagFilterAndNavigate(tag)"
+          >
+            {{ `#${tag}` }}
+          </button>
+        </span>
+      </div>
+      <div
+        ref="scrollRef"
+        class="flex-1 overflow-y-auto px-6 py-4 prose prose-sm max-w-none wiki-content"
+        @click="handleContentClick"
+        v-html="renderedContent"
+      />
+    </template>
 
     <!-- Per-page chat composer (standalone /wiki route only). Sending
          spawns a fresh chat session with a prepended "read this page
@@ -213,6 +247,7 @@ import PageChatComposer from "../../components/PageChatComposer.vue";
 import { BUILTIN_ROLE_IDS } from "../../config/roles";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { parseFrontmatter } from "../../utils/markdown/frontmatter";
+import { useMarkdownDoc } from "../../composables/useMarkdownDoc";
 import { findTaskLines, makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
 import { apiPost } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
@@ -243,6 +278,11 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const action = ref(props.selectedResult?.data?.action ?? "index");
 const title = ref(props.selectedResult?.data?.title ?? "Wiki");
 const content = ref(props.selectedResult?.data?.content ?? "");
+// Frontmatter view of the loaded page content. Drives the
+// metadata bar (Created / Updated / Editor / Tags) above the
+// rendered body. `useMarkdownDoc` is reactive so editing or
+// switching pages re-derives without manual recomputation.
+const mdDoc = useMarkdownDoc(content);
 const pageEntries = ref<WikiPageEntry[]>(props.selectedResult?.data?.pageEntries ?? []);
 const pageExists = ref(props.selectedResult?.data?.pageExists ?? true);
 // View-local tag filter. Null = no filter. Not persisted to URL —
@@ -379,6 +419,17 @@ function setTagFilter(tag: string) {
   selectedTag.value = tag;
 }
 
+// Tag chips on the page metadata bar (#895 PR B) live in the
+// `action === 'page'` view. Clicking one should jump to the
+// filtered index — both navigating away from the page and
+// pre-selecting the tag the user wants to explore. Without the
+// navigation step the user would need a separate Back-to-index
+// click to see the filter take effect.
+function setTagFilterAndNavigate(tag: string) {
+  setTagFilter(tag);
+  navigate("index");
+}
+
 // Spawn a new chat under the General role (which owns the wiki
 // tooling) regardless of the role the user is currently viewing the
 // wiki under. "lint my wiki" is a direct instruction to the agent,
@@ -407,6 +458,53 @@ watch(content, async () => {
 
 /** Base directory for wiki content, adjusted by the current view. */
 const WIKI_BASE_DIR = computed(() => (action.value === "page" ? WIKI_PAGES_DIR : WIKI_DATA_DIR));
+
+// ── Metadata bar (#895 PR B) ──────────────────────────────────
+//
+// Show a single thin row above the rendered body with
+// `Created` / `Updated` / `Editor` / `Tags` derived from the
+// frontmatter. Hidden when none of those are present (header-less
+// pages render unchanged so old wiki content keeps its current
+// appearance).
+
+/** String accessor that survives the `unknown` type from FAILSAFE
+ *  YAML — `meta` values are all strings under FAILSAFE schema, but
+ *  type-narrowing requires a runtime check. */
+function metaString(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  return value;
+}
+
+/** Array-of-strings accessor for `tags`. Allows the chips template
+ *  to skip a render branch when the field is missing or malformed. */
+function metaStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+const pageMeta = computed(() => ({
+  created: metaString(mdDoc.value.meta.created),
+  updated: metaString(mdDoc.value.meta.updated),
+  editor: metaString(mdDoc.value.meta.editor),
+  tags: metaStringArray(mdDoc.value.meta.tags),
+}));
+
+const hasPageMeta = computed(() => {
+  const meta = pageMeta.value;
+  return meta.created !== null || meta.updated !== null || meta.editor !== null || meta.tags.length > 0;
+});
+
+/** Render `updated` ISO timestamp as `YYYY-MM-DD HH:MM` for
+ *  display. Falls back to the raw value if it doesn't look like
+ *  an ISO timestamp (defensive — user-supplied frontmatter may
+ *  have any string here). */
+function formatUpdated(raw: string): string {
+  // Match ISO 8601 `YYYY-MM-DDTHH:MM[:SS][.fff]Z?`. Anything else
+  // is shown verbatim.
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(raw);
+  if (!match) return raw;
+  return `${match[1]} ${match[2]}`;
+}
 
 const renderedContent = computed(() => {
   if (!content.value) return "";

--- a/test/routes/test_wikiSaveRoute.ts
+++ b/test/routes/test_wikiSaveRoute.ts
@@ -110,7 +110,10 @@ describe("POST /api/wiki — action: save", () => {
     __resetPageIndexCache();
   });
 
-  it("overwrites an existing page atomically", async () => {
+  it("overwrites an existing page atomically (with auto-stamped frontmatter)", async () => {
+    // Post-#895-PR-B: even body-only saves get a frontmatter
+    // envelope stamped with created / updated / editor. The body
+    // content survives verbatim; the wrapper is the new shape.
     const slug = "test-page";
     const filePath = path.join(pagesDir, `${slug}.md`);
     await writeFile(filePath, "# Original\n\n- [ ] task\n", "utf-8");
@@ -121,13 +124,21 @@ describe("POST /api/wiki — action: save", () => {
 
     assert.equal(state.status, 200);
     const onDisk = await readFile(filePath, "utf-8");
-    assert.equal(onDisk, newContent);
-    // Response carries the canonical post-write content.
-    assert.equal(state.body?.data?.content, newContent);
+    // Body must be preserved verbatim, but the file now carries a
+    // frontmatter envelope with auto-stamped fields.
+    assert.match(onDisk, /\n- \[x\] task\n$/);
+    assert.match(onDisk, /^---\n/);
+    assert.match(onDisk, /editor: user/);
+    // Response should reflect the on-disk canonical content.
+    assert.equal(state.body?.data?.content, onDisk);
     assert.equal(state.body?.data?.pageExists, true);
   });
 
   it("preserves frontmatter when the body has been toggled", async () => {
+    // The route now stamps `created` / `updated` / `editor` on save
+    // (#895 PR B). Existing user-supplied keys must still survive
+    // verbatim. Assert the stable fields explicitly rather than
+    // comparing the whole file byte-for-byte.
     const slug = "with-frontmatter";
     const filePath = path.join(pagesDir, `${slug}.md`);
     const original = "---\ntitle: Foo\ntags: [a, b]\n---\n\n- [ ] task one\n- [ ] task two\n";
@@ -139,8 +150,16 @@ describe("POST /api/wiki — action: save", () => {
 
     assert.equal(state.status, 200);
     const onDisk = await readFile(filePath, "utf-8");
-    assert.equal(onDisk, updated);
-    assert.match(onDisk, /^---\ntitle: Foo/, "frontmatter delimiters should round-trip");
+    assert.match(onDisk, /^---\n/, "frontmatter delimiters should round-trip");
+    assert.match(onDisk, /title: Foo/, "user-supplied title preserved");
+    assert.match(onDisk, /\n- \[x\] task one\n- \[ \] task two\n$/, "body toggled correctly");
+    // `tags` round-trips as either flow-style `[a, b]` or block list.
+    // Either is fine — assert both entries appear somewhere in the
+    // header rather than pinning a specific YAML serialisation.
+    const headerEnd = onDisk.indexOf("\n---\n", 4);
+    const header = onDisk.slice(0, headerEnd);
+    assert.match(header, /\ba\b/);
+    assert.match(header, /\bb\b/);
   });
 
   it("rejects a request with no pageName", async () => {

--- a/test/server/utils/markdown/test_frontmatter.ts
+++ b/test/server/utils/markdown/test_frontmatter.ts
@@ -1,0 +1,158 @@
+// Server-side mirror of test/utils/markdown/test_frontmatter.ts
+// (#895 PR B). Pin the same parse/serialize/merge contract on the
+// server because writeWikiPage will round-trip through the same
+// helpers and any drift between Vue and server breaks #763's
+// edit-history pipeline.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mergeFrontmatter, parseFrontmatter, serializeWithFrontmatter } from "../../../../server/utils/markdown/frontmatter.js";
+
+describe("server parseFrontmatter — happy path", () => {
+  it("splits a well-formed envelope into meta + body", () => {
+    const raw = "---\ntitle: Hello\ncreated: 2026-04-27\n---\n\nbody text\n";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.hasHeader, true);
+    assert.deepEqual(out.meta, { title: "Hello", created: "2026-04-27" });
+    assert.equal(out.body, "body text\n");
+  });
+
+  it("preserves insertion order in meta", () => {
+    const raw = "---\nzeta: 1\nalpha: 2\nmiddle: 3\n---\nbody";
+    const out = parseFrontmatter(raw);
+    assert.deepEqual(Object.keys(out.meta), ["zeta", "alpha", "middle"]);
+  });
+
+  it("parses inline arrays and block-list arrays", () => {
+    const inline = parseFrontmatter("---\ntags: [a, b, c]\n---\nbody");
+    assert.deepEqual(inline.meta.tags, ["a", "b", "c"]);
+    const block = parseFrontmatter("---\ntags:\n  - one\n  - two\n---\nbody");
+    assert.deepEqual(block.meta.tags, ["one", "two"]);
+  });
+
+  it("handles unicode (CJK) keys and values", () => {
+    const raw = "---\ntitle: さくらインターネット\ntags: [クラウド, インフラ]\n---\nbody";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.meta.title, "さくらインターネット");
+    assert.deepEqual(out.meta.tags, ["クラウド", "インフラ"]);
+  });
+
+  it("accepts \\r\\n line endings (Windows-authored files)", () => {
+    const raw = "---\r\ntitle: WinFile\r\n---\r\n\r\nbody\r\n";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.hasHeader, true);
+    assert.equal(out.meta.title, "WinFile");
+  });
+});
+
+describe("server parseFrontmatter — degenerate cases", () => {
+  it("returns empty meta + raw body when no envelope present", () => {
+    const raw = "no header here\n\njust body\n";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.hasHeader, false);
+    assert.deepEqual(out.meta, {});
+    assert.equal(out.body, raw);
+  });
+
+  it("treats an unclosed envelope as no header (graceful fallback)", () => {
+    const raw = "---\ntitle: Stuck\n\nbody but no closing fence\n";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.hasHeader, false);
+  });
+
+  it("treats malformed YAML as no header — does not throw", () => {
+    const raw = "---\ntitle: [unclosed\n---\nbody";
+    const out = parseFrontmatter(raw);
+    assert.equal(out.hasHeader, false);
+  });
+
+  it("treats scalar-only / array-only frontmatter as malformed", () => {
+    const out = parseFrontmatter("---\njust a string\n---\nbody");
+    assert.equal(out.hasHeader, false);
+  });
+
+  it("accepts an empty envelope as hasHeader: true with empty meta", () => {
+    const out = parseFrontmatter("---\n---\n\nbody\n");
+    assert.equal(out.hasHeader, true);
+    assert.deepEqual(out.meta, {});
+    assert.equal(out.body, "body\n");
+  });
+
+  it("returns empty body when the document is header-only", () => {
+    const out = parseFrontmatter("---\ntitle: Hello\n---\n");
+    assert.equal(out.hasHeader, true);
+    assert.equal(out.body, "");
+  });
+});
+
+describe("server parseFrontmatter — FAILSAFE schema", () => {
+  it("preserves numeric-looking strings verbatim", () => {
+    const out = parseFrontmatter("---\nversion: 1.20\nzeros: 00123\n---\nbody");
+    assert.equal(out.meta.version, "1.20");
+    assert.equal(out.meta.zeros, "00123");
+  });
+
+  it("keeps numeric / boolean scalars as strings", () => {
+    const out = parseFrontmatter("---\ncount: 5\nenabled: true\n---\nbody");
+    assert.equal(out.meta.count, "5");
+    assert.equal(out.meta.enabled, "true");
+  });
+});
+
+describe("server serializeWithFrontmatter", () => {
+  it("emits envelope + blank line + body", () => {
+    const out = serializeWithFrontmatter({ title: "Hello", tags: ["a", "b"] }, "body text\n");
+    const round = parseFrontmatter(out);
+    assert.equal(round.hasHeader, true);
+    assert.equal(round.meta.title, "Hello");
+    assert.deepEqual(round.meta.tags, ["a", "b"]);
+    assert.equal(round.body, "body text\n");
+  });
+
+  it("returns body verbatim when meta is empty", () => {
+    assert.equal(serializeWithFrontmatter({}, "just body\n"), "just body\n");
+  });
+
+  it("round-trip is value-preserving for ambiguous scalars", () => {
+    const original = "---\nversion: 1.20\nflag: true\n---\nbody";
+    const round1 = parseFrontmatter(original);
+    const text2 = serializeWithFrontmatter(round1.meta, round1.body);
+    const round2 = parseFrontmatter(text2);
+    assert.equal(round2.meta.version, "1.20");
+    assert.equal(round2.meta.flag, "true");
+    // One more cycle — meta is a fixed point.
+    const text3 = serializeWithFrontmatter(round2.meta, round2.body);
+    const round3 = parseFrontmatter(text3);
+    assert.deepEqual(round3.meta, round2.meta);
+  });
+});
+
+describe("server mergeFrontmatter", () => {
+  it("overwrites known keys with patch values", () => {
+    const out = mergeFrontmatter({ title: "Old", tags: ["a"] }, { title: "New" });
+    assert.equal(out.title, "New");
+    assert.deepEqual(out.tags, ["a"]);
+  });
+
+  it("preserves keys not mentioned in the patch", () => {
+    // Custom domain field (e.g. `prerequisites` from a skill file)
+    // must survive a generic update that only touches `updated`.
+    const out = mergeFrontmatter({ prerequisites: "Node 22+", title: "Doc" }, { updated: "2026-04-27" });
+    assert.equal(out.prerequisites, "Node 22+");
+    assert.equal(out.updated, "2026-04-27");
+  });
+
+  it("deletes a key when the patch value is null or undefined", () => {
+    const fromNull = mergeFrontmatter({ title: "Doc", deprecated: true }, { deprecated: null });
+    assert.equal("deprecated" in fromNull, false);
+    const fromUndef = mergeFrontmatter({ title: "Doc", legacy: "yes" }, { legacy: undefined });
+    assert.equal("legacy" in fromUndef, false);
+  });
+
+  it("returns a new object (no mutation)", () => {
+    const existing = { title: "Doc" };
+    const out = mergeFrontmatter(existing, { updated: "now" });
+    assert.notStrictEqual(out, existing);
+    assert.equal("updated" in existing, false);
+  });
+});

--- a/test/workspace/wiki-pages/test_io.ts
+++ b/test/workspace/wiki-pages/test_io.ts
@@ -14,7 +14,13 @@ import { mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, writeFile } f
 import { tmpdir } from "os";
 import path from "path";
 import { classifyAsWikiPage, readWikiPage, wikiPagePath, writeWikiPage } from "../../../server/workspace/wiki-pages/io.js";
+import { parseFrontmatter } from "../../../server/utils/markdown/frontmatter.js";
 import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
+
+/** Helper: a fixed `now` injector so frontmatter timestamps are
+ *  deterministic across tests. */
+const FIXED_NOW = new Date("2026-04-27T12:34:56.789Z");
+const fixedNow = () => FIXED_NOW;
 
 describe("wiki-pages/io — wikiPagePath", () => {
   it("composes data/wiki/pages/<slug>.md under the given workspaceRoot", () => {
@@ -107,23 +113,74 @@ describe("wiki-pages/io — writeWikiPage", () => {
     await rm(workspaceRoot, { recursive: true, force: true });
   });
 
-  it("creates a new page when none exists", async () => {
-    await writeWikiPage("brand-new", "# Brand New\n\nfresh\n", { editor: "user" }, { workspaceRoot });
+  it("creates a new page when none exists, stamping created/updated/editor", async () => {
+    await writeWikiPage("brand-new", "# Brand New\n\nfresh\n", { editor: "user" }, { workspaceRoot, now: fixedNow });
 
     const fileContent = await readFile(wikiPagePath("brand-new", { workspaceRoot }), "utf-8");
-    assert.equal(fileContent, "# Brand New\n\nfresh\n");
+    const parsed = parseFrontmatter(fileContent);
+    assert.equal(parsed.hasHeader, true);
+    assert.equal(parsed.body, "# Brand New\n\nfresh\n");
+    assert.equal(parsed.meta.created, "2026-04-27");
+    assert.equal(parsed.meta.updated, "2026-04-27T12:34:56.789Z");
+    assert.equal(parsed.meta.editor, "user");
   });
 
-  it("overwrites an existing page", async () => {
-    await writeWikiPage("topic-x", "v1\n", { editor: "user" }, { workspaceRoot });
-    await writeWikiPage("topic-x", "v2\n", { editor: "user" }, { workspaceRoot });
+  it("overwrites an existing page; created stays sticky, updated bumps", async () => {
+    const earlier = new Date("2026-04-26T10:00:00.000Z");
+    const later = new Date("2026-04-27T15:30:00.000Z");
+    await writeWikiPage("topic-x", "v1\n", { editor: "user" }, { workspaceRoot, now: () => earlier });
+    await writeWikiPage("topic-x", "v2\n", { editor: "llm", sessionId: "s1" }, { workspaceRoot, now: () => later });
 
     const fileContent = await readFile(wikiPagePath("topic-x", { workspaceRoot }), "utf-8");
-    assert.equal(fileContent, "v2\n");
+    const parsed = parseFrontmatter(fileContent);
+    assert.equal(parsed.body, "v2\n");
+    assert.equal(parsed.meta.created, "2026-04-26"); // first save's date — sticky
+    assert.equal(parsed.meta.updated, "2026-04-27T15:30:00.000Z"); // second save's instant
+    assert.equal(parsed.meta.editor, "llm"); // last writer
+  });
+
+  it("preserves unknown frontmatter keys across saves", async () => {
+    // First save: bring an existing page with custom frontmatter
+    // into being, simulating a hand-edited file already on disk.
+    const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages);
+    await mkdir(pagesDir, { recursive: true });
+    const seedPath = path.join(pagesDir, "with-extras.md");
+    await writeFile(seedPath, "---\ntitle: Has Title\nprerequisites: Node 22+\ntags: [demo, custom]\n---\n\noriginal body\n", "utf-8");
+
+    // User saves a new body — auto-stamped fields appear, but
+    // `title` / `prerequisites` / `tags` survive verbatim.
+    await writeWikiPage("with-extras", "updated body\n", { editor: "user" }, { workspaceRoot, now: fixedNow });
+
+    const fileContent = await readFile(wikiPagePath("with-extras", { workspaceRoot }), "utf-8");
+    const parsed = parseFrontmatter(fileContent);
+    assert.equal(parsed.body, "updated body\n");
+    assert.equal(parsed.meta.title, "Has Title");
+    assert.equal(parsed.meta.prerequisites, "Node 22+");
+    assert.deepEqual(parsed.meta.tags, ["demo", "custom"]);
+    assert.equal(parsed.meta.created, "2026-04-27"); // first writeWikiPage save (file pre-existed but had no `created`)
+    assert.equal(parsed.meta.updated, "2026-04-27T12:34:56.789Z");
+    assert.equal(parsed.meta.editor, "user");
+  });
+
+  it("accepts caller-supplied frontmatter and merges with auto-stamps", async () => {
+    // manageWiki MCP can send `---\nprerequisites: …\n---\nbody`
+    // and the new frontmatter merges into whatever's already on
+    // disk. Auto-stamps still land on top.
+    const incoming = "---\nprerequisites: Node 22+\nupdated: '2020-01-01'\n---\n\nfrom MCP\n";
+    await writeWikiPage("from-mcp", incoming, { editor: "llm", sessionId: "s1" }, { workspaceRoot, now: fixedNow });
+
+    const fileContent = await readFile(wikiPagePath("from-mcp", { workspaceRoot }), "utf-8");
+    const parsed = parseFrontmatter(fileContent);
+    assert.equal(parsed.body, "from MCP\n");
+    assert.equal(parsed.meta.prerequisites, "Node 22+");
+    // The caller's `updated: '2020-01-01'` is overwritten by the
+    // auto-stamp — that field is owned by writeWikiPage.
+    assert.equal(parsed.meta.updated, "2026-04-27T12:34:56.789Z");
+    assert.equal(parsed.meta.editor, "llm");
   });
 
   it("does not leave a .tmp staging file after a successful write", async () => {
-    await writeWikiPage("clean", "content\n", { editor: "user" }, { workspaceRoot });
+    await writeWikiPage("clean", "content\n", { editor: "user" }, { workspaceRoot, now: fixedNow });
 
     const pagesDir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages);
     const entries = await readdir(pagesDir);
@@ -137,26 +194,27 @@ describe("wiki-pages/io — writeWikiPage", () => {
     // ENOENT mid-rename. The test for uniqueTmp is observable as
     // "both writes complete without throwing".
     const writes = Promise.all([
-      writeWikiPage("race", "writer-a\n", { editor: "user" }, { workspaceRoot }),
-      writeWikiPage("race", "writer-b\n", { editor: "system", sessionId: "s" }, { workspaceRoot }),
+      writeWikiPage("race", "writer-a\n", { editor: "user" }, { workspaceRoot, now: fixedNow }),
+      writeWikiPage("race", "writer-b\n", { editor: "system", sessionId: "s" }, { workspaceRoot, now: fixedNow }),
     ]);
     await assert.doesNotReject(writes);
 
-    // The final content is one of the two — we don't assert which,
-    // because rename order is racey and the test asserts isolation,
-    // not last-write-wins semantics.
+    // The final content is one of the two bodies — we don't assert
+    // which because rename order is racey. We only assert that the
+    // serialised body parses to `writer-a\n` or `writer-b\n`.
     const final = await readFile(wikiPagePath("race", { workspaceRoot }), "utf-8");
-    assert.ok(final === "writer-a\n" || final === "writer-b\n", `unexpected content: ${final}`);
+    const body = parseFrontmatter(final).body;
+    assert.ok(body === "writer-a\n" || body === "writer-b\n", `unexpected body: ${body}`);
   });
 
-  it("accepts every editor identity without distinction (PR 1 no-op)", async () => {
-    // PR 1 only consolidates the wiring; the snapshot stub is a
-    // no-op regardless of editor. PR 2 will introduce semantics.
-    await writeWikiPage("by-llm", "llm content\n", { editor: "llm", sessionId: "s1" }, { workspaceRoot });
-    await writeWikiPage("by-system", "system content\n", { editor: "system", sessionId: "s2" }, { workspaceRoot });
+  it("records the editor identity per call site (llm / user / system)", async () => {
+    await writeWikiPage("by-llm", "llm content\n", { editor: "llm", sessionId: "s1" }, { workspaceRoot, now: fixedNow });
+    await writeWikiPage("by-system", "system content\n", { editor: "system", sessionId: "s2" }, { workspaceRoot, now: fixedNow });
 
-    assert.equal(await readWikiPage("by-llm", { workspaceRoot }), "llm content\n");
-    assert.equal(await readWikiPage("by-system", { workspaceRoot }), "system content\n");
+    const llmFile = await readFile(wikiPagePath("by-llm", { workspaceRoot }), "utf-8");
+    const sysFile = await readFile(wikiPagePath("by-system", { workspaceRoot }), "utf-8");
+    assert.equal(parseFrontmatter(llmFile).meta.editor, "llm");
+    assert.equal(parseFrontmatter(sysFile).meta.editor, "system");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Server util** `server/utils/markdown/frontmatter.ts` mirrors PR A's Vue util (same shape, same FAILSAFE_SCHEMA contract — value-preserving round-trip).
- **`writeWikiPage` auto-stamps** every save with `created` / `updated` / `editor` frontmatter (lazy-on-write — header-less existing pages keep their old shape until first save). Snapshot trigger ignores auto-stamped fields so no-op saves don't flood the #763 PR 2 history pipeline.
- **`wiki/View.vue` metadata bar** surfaces the new fields above the rendered body. Tag chips in the bar jump to the filtered index when clicked.
- **i18n lockstep**: 3 new keys (`metadataCreated` / `metadataUpdated` / `metadataEditor`) across all 8 locales.

## Items to Confirm / Review

- **Editor identity placeholder**: today every API path (wiki POST save, files PUT) passes `editor: "user"`. wiki-backlinks correctly tags `"system"`. Disambiguating LLM vs user save needs an API contract change (request body field with auth-side enforcement) — deferred to PR C. The metadata bar will keep showing "user" for both LLM and frontend saves until then.
- **`now` injection**: `WikiPageWriteOptions.now` lets tests pin timestamps. Production uses `() => new Date()`. The injection is intentionally NOT exposed through the wiki POST route — it's an internal seam.
- **Snapshot trigger semantics**: I changed it from "any content change" to "body-or-meta change excluding auto-stamps". Otherwise every save would record a snapshot for nothing more than `updated` flipping. Auto-stamp fields are `["updated", "editor"]` — `created` is naturally stable.
- **Body parse on every save**: even body-only callers go through `parseFrontmatter`. The intent is "treat caller's content uniformly" — if the user pastes a `---\n...\n---\nbody` blob into the editor, we honour it. Performance impact is negligible (regex + js-yaml on a few-KB string per save).
- **Date format**: `created` is `YYYY-MM-DD` UTC (no time — "first save day"). `updated` is full ISO with ms (`2026-04-27T12:34:56.789Z`). UTC deliberately so a TZ change doesn't shift `created`.
- **Out of scope**: NewsView / SourcesManager render sites and the existing hand-rolled parsers (sources/registry.ts, skills/parser.ts, wiki/frontmatter.ts) deferred to PR C.

## User Prompt

> #895 PR Bに推しで足して、すすめて。
> テスト方法を日本語でPRに。

(prior context: PR A landed in #902 — Vue side parser + composable. The user asked whether wiki/View should also show the metadata as part of PR B; we agreed on option B+C — 1-line metadata bar + tags chip integration. This PR is server side + that bar.)

## Implementation

### New
- `server/utils/markdown/frontmatter.ts` — parse / serialize / merge mirror
- `test/server/utils/markdown/test_frontmatter.ts` — 20 cases
- 6 new cases in `test/workspace/wiki-pages/test_io.ts`
- `e2e/tests/wiki-metadata-bar.spec.ts` — 3 cases
- `plans/feat-895-frontmatter-pr-b-server-wiki-bar.md`

### Modified
- `server/workspace/wiki-pages/io.ts` — `writeWikiPage` stamps frontmatter; `WikiPageWriteOptions.now` injection; snapshot trigger uses body-or-meta-without-auto-stamps comparison
- `src/plugins/wiki/View.vue` — metadata bar template + `useMarkdownDoc` wiring + `setTagFilterAndNavigate` helper
- `test/routes/test_wikiSaveRoute.ts` — assertions updated for the new auto-stamped envelope
- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — 3 new i18n keys

## テスト手順

### 自動テスト

```bash
# 型チェック / lint / build (すべて clean が前提)
yarn typecheck
yarn lint
yarn build

# ユニットテスト全体 (~10s)
yarn test

# 関連箇所だけ走らせるなら:
tsx --test ./test/server/utils/markdown/test_frontmatter.ts \
           ./test/workspace/wiki-pages/test_io.ts \
           ./test/routes/test_wikiSaveRoute.ts \
           ./test/wiki-backlinks/test_index.ts

# E2E (本 PR で追加した spec + 既存 wiki / markdown の regression):
yarn test:e2e e2e/tests/wiki-metadata-bar.spec.ts \
              e2e/tests/wiki-navigation.spec.ts \
              e2e/tests/wiki-empty-page.spec.ts \
              e2e/tests/wiki-tag-filter.spec.ts \
              e2e/tests/markdown-frontmatter.spec.ts
```

期待結果:
- `test_frontmatter.ts` (server): **20 pass**
- `test_io.ts` (wiki-pages): **17 pass** (既存 11 + 新 6)
- `test_wikiSaveRoute.ts`: **11 pass**
- `test_index.ts` (wiki-backlinks): **14 pass**
- E2E (5 specs 合計): **41 pass** (うち本 PR 新規 3)

### 手動テスト

事前準備: `~/mulmoclaude/data/wiki/pages/` に既存 wiki page (frontmatter 無し) が 1 個ある状態でスタート。

1. `npm run dev` で起動
2. 既存 wiki page を `/wiki/pages/<slug>` で開く → **metadata bar が出ない** こと (header-less 互換 / regression guard)
3. 同ページを編集 → 保存 (`manageWiki` MCP / `/api/wiki { action: "save" }` / `/api/files/content` PUT のいずれか)
4. リロード → metadata bar が表示される:
   - `Created: 今日の日付` (YYYY-MM-DD)
   - `Updated: 保存時刻` (YYYY-MM-DD HH:MM)
   - `Editor: user`
5. 翌日もう一度編集して保存 → `Created` は **昨日の日付のまま** (sticky)、`Updated` だけ進む
6. 手動でファイルに `tags: [demo, mvp]` を frontmatter に追加して保存
7. リロード → bar に `#demo` `#mvp` chip が出る
8. chip をクリック → `/wiki` (index) にジャンプ + そのタグでフィルタ済

### 既存挙動の regression watch

- header-less wiki page は表示変化なし (e2e #2 でカバー)
- markdown plugin / FileContentRenderer の properties panel (PR A の挙動) は変化なし
- wiki tag filter (index 側) は変化なし
- 同じ body を 2 回続けて save しても snapshot pipeline (PR 2 で実装予定) には no-op として扱われる (snapshot trigger 仕様)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki pages now display a metadata bar showing created/updated timestamps, editor information, and tags
  * Tags in the metadata bar are clickable for filtering and navigation
  * Multi-language support added for metadata labels across 8 languages

* **Chores**
  * Added js-yaml dependency

* **Tests**
  * Added comprehensive test coverage for wiki metadata and frontmatter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->