### PR TITLE
fix: run audio() before images() in movie pipeline

### DIFF
--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -659,11 +659,17 @@ async function runMovieGeneration(absoluteFilePath: string, onProgressEvent: (ev
 
   addSessionProgressCallback(onProgress);
   try {
-    const imagesContext = await images(context);
-    const audioContext = await audio(imagesContext);
-    await movie(audioContext);
+    // Order matters: audio() must run before images(). For html_tailwind
+    // beats with `animation: true`, mulmocast only emits the per-beat
+    // `_animated.mp4` when the beat's duration is already known (see
+    // processHtmlTailwindAnimated in mulmocast). Durations are populated
+    // by audio(), so running images() first leaves the .mp4 files
+    // missing and movie() then fails in validateBeatSource.
+    const audioContext = await audio(context);
+    const imagesContext = await images(audioContext);
+    await movie(imagesContext);
 
-    const outputPath = movieFilePath(audioContext);
+    const outputPath = movieFilePath(imagesContext);
     if (!existsSync(outputPath)) return { ok: false, error: "Movie was not generated" };
     return { ok: true, outputPath };
   } finally {


### PR DESCRIPTION
## Summary

- For `html_tailwind` beats with `animation: true`, mulmocast's `processHtmlTailwindAnimated` only emits the per-beat `_animated.mp4` when the beat's duration is already known. Durations are populated by `audio()`, so the previous `images → audio → movie` order left the `.mp4` files missing and `movie()` then failed in `validateBeatSource` with `studioBeat.imageFile or studioBeat.movieFile is not exist or not file`.
- Switch to `audio → images → movie` so durations are available when animated videos are rendered.
- Also align `movieFilePath()` with the context actually passed to `movie()` for forward-compatibility if mulmocast ever stops mutating contexts in place.

## Test plan

- [ ] Generate a movie from a script with `html_tailwind` beats that have `animation: true` — `_animated.mp4` files should now be produced and the final movie should render without errors.
- [ ] Generate a movie from a script with `html_tailwind` beats without `animation` (static only) — should still work.
- [ ] Generate a movie using LLM-generated images (`image` plugin) — should still work.
- [ ] Generate a movie that embeds a `movie` plugin beat — should still work.
- [ ] If applicable, exercise a beat with `voice_over` / `lipSync` to confirm audio-first ordering does not break those flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix movie generation failures for animated HTML Tailwind beats by ensuring durations are populated before images and movie steps run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the movie generation pipeline to optimize the execution sequence and context flow, potentially improving generation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->