### PR TITLE
chore(security): add gitleaks secret-scan CI workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,47 @@
+name: secret-scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  # Least privilege: gitleaks only needs to read the checked-out
+  # repo. No issues / PRs / packages access.
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history scan needs every commit
+
+      # gitleaks-action@v2 は Organization 配下だとライセンスキー必須になったため、
+      # MIT ライセンスの gitleaks CLI バイナリを直接実行する。
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          # SHA256 of gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz from
+          # https://github.com/gitleaks/gitleaks/releases — refresh
+          # alongside any GITLEAKS_VERSION bump.
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${ARCHIVE}"
+          echo "${GITLEAKS_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" gitleaks
+          rm -f "$ARCHIVE"
+          gitleaks version
+
+      - name: Run gitleaks (full history scan)
+        # `detect` scans the full git log by default; `--source .`
+        # just sets the working dir. `.gitleaksignore` at repo root
+        # is honoured automatically. exit-code 1 fails the job on
+        # any unallowlisted finding.
+        run: gitleaks detect --source . --redact --verbose --exit-code 1

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,22 @@
+# gitleaks fingerprints we deliberately allow.
+#
+# Format: <commit-sha>:<file>:<rule>:<line>
+# Each entry silences exactly that one finding — same file at a
+# different line, or the same line in a NEW commit, gets re-scanned.
+#
+# Forward note: fingerprints embed the gitleaks rule id (e.g.
+# `stripe-access-token`). If a future gitleaks version renames the
+# rule, the entry stops matching and the false positive resurfaces.
+# Refresh the entry on gitleaks version bumps if a finding starts
+# firing again.
+#
+# This file is ALSO scanned by gitleaks. Do NOT include the literal
+# fixture string in any rationale comment — gitleaks would flag the
+# rationale itself. Describe the shape, don't reproduce it.
+
+# test/utils/test_promptMeta.ts uses a deliberate Stripe-shaped fake
+# fixture (`sk_live_…`) at line 51 to assert that promptMeta() does
+# NOT leak its input prompt into the returned object. Changing the
+# fixture would defeat the test's intent — we WANT a known-token-
+# shape string so the redaction proof is meaningful. Not a real key.
+9637475787b4b8fa48b2e42b06ee15f08bec2922:test/utils/test_promptMeta.ts:stripe-access-token:51


### PR DESCRIPTION
## Summary

Adds a \`secret-scan\` CI job running \`gitleaks detect\` on every PR + push to main. Detects accidentally-committed API keys / tokens / private keys across the full git history.

Uses the gitleaks **CLI binary** (MIT-licensed, free) directly via curl. \`gitleaks-action@v2\` would fail on this org repo with \`License key is required\` — bypassed by not using the action.

## Items to Confirm / Review

- [ ] **Workflow trigger**: \`pull_request\` (any base) + \`push\` to main. Net cost ~5–10s per run (1.5s scan + setup overhead).
- [ ] **\`.gitleaksignore\` has exactly one entry**: the historical \`sk_live_abcdefg1234567890\` fake fixture in \`test/utils/test_promptMeta.ts:51\`. Fingerprint is \`<commit-sha>:<file>:<rule>:<line>\` — commit-specific, so new Stripe-shaped strings (different file / line / commit) are still detected. The fixture is a deliberate "known token shape" used to assert \`promptMeta()\` doesn't leak input prompts; changing it would defeat the test's intent.
- [ ] **No license issues**: MIT-licensed binary, version pinned to v8.30.1 in the workflow.
- [ ] **Performance**: 1772 commits / 10.96 MB scanned in 1.5s locally. CI shouldn't be meaningfully slower.

## User Prompt

> gitleaks、手元で試せる？  
> aって、そのコミット(9637475787b4)のものだけ除外する感じ？そのご、同じファイルにかかれても検出できる？  
> ok、ではaで。

(User asked whether \`.gitleaksignore\` is commit-specific (yes) and whether new violations in the same file are still caught (yes). Confirmed and chose option A.)

## Implementation

### Files added

- \`.github/workflows/secret-scan.yml\` — workflow with curl-installed gitleaks binary
- \`.gitleaksignore\` — single fingerprint entry with rationale comment

### Why CLI not action

\`gitleaks/gitleaks-action@v2\` requires a paid license for organizations (1 free user, more = paid). The error message is exactly:

\`\`\`
[xxx] is an organization. License key is required.
Error: 🛑 missing gitleaks license.
\`\`\`

The CLI binary itself remains MIT and free. The action only adds PR commenting on top of the binary — by running the binary directly via shell step, we get the full scan with no license requirement and standard CI annotations from the \`--exit-code 1\` failure.

### Why \`.gitleaksignore\` not a fixture rewrite

We considered rewriting the fixture so gitleaks wouldn't trip. Decided against because:
- The test's whole point is "given a Stripe-shaped string in the input, prove \`promptMeta()\` doesn't leak it". Using a non-Stripe fixture weakens the proof — the original fixture demonstrates that even known token-prefix patterns are stripped.
- A history rewrite to remove the historical commit would require force-pushing main (destructive, breaks team mirrors).
- \`.gitleaksignore\` with a commit-specific fingerprint surgically silences only that one finding while keeping the rule active for everything else.

## Test plan

- [x] \`gitleaks detect --source . --redact --no-banner --exit-code 1\` locally → \`no leaks found\` (1772 commits / 10.96 MB / 1.0s)
- [x] Without \`.gitleaksignore\`: same command finds the historical \`stripe-access-token\` (verified before adding the file)
- [x] \`.gitleaksignore\` fingerprint format validated against gitleaks 8.30.1 docs
- [ ] CI green on this PR (the workflow will be triggered by the PR itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated secret scanning to the repository using gitleaks in CI.

CI:
- Introduce a GitHub Actions workflow that runs gitleaks secret scanning on all pull requests and pushes to the main branch using the pinned CLI binary.

Chores:
- Add a gitleaks ignore configuration file to manage known, acceptable findings.