### PR TITLE
feat(wiki): edit-history snapshot pipeline (#763 PR 2)

### DIFF
--- a/plans/feat-763-snapshot-pipeline.md
+++ b/plans/feat-763-snapshot-pipeline.md
@@ -1,0 +1,104 @@
+# Wiki page snapshot pipeline (#763 PR 2)
+
+GitHub: https://github.com/receptron/mulmoclaude/issues/763
+Builds on:
+- PR #883 (`writeWikiPage` choke point — already merged)
+- #895 PR A / B (frontmatter parser + `writeWikiPage` auto-stamps `created` / `updated` / `editor`)
+
+## Outcome
+
+Every meaningful save through `writeWikiPage` writes a snapshot under
+`data/wiki/.history/<slug>/<ISO>-<shortId>.md`. Three new routes
+expose list / read / restore, gated by `hasMeaningfulChange` so
+auto-stamped no-op saves don't pollute history.
+
+## Decisions (from review on chat 2026-04-28)
+
+| # | Topic | Decision |
+|---|---|---|
+| 1 | Storage | File snapshots, not git, not jsonl |
+| 2 | Scope | Wiki pages only (skill / role / settings deferred) |
+| 3 | Reason | Optional `reason?` carried through `WikiWriteMeta` (already in shape) |
+| 4 | GC | Keep snapshots in newest 100 OR newer than 180 days; delete only when BOTH conditions are violated. No hard cap. |
+| 5 | Diff UI | Line-unified for v1 (PR 3, not this PR) |
+| 6 | Restore | "Restore as new edit" — past version becomes the next write, history is non-destructive |
+| 7 | Size cap | None |
+
+## Snapshot file shape
+
+```
+data/wiki/.history/<slug>/2026-04-28T01-23-45-789Z-abc12345.md
+```
+
+- File name: full ISO timestamp with `:` replaced by `-` (filesystem-safe), plus a `shortId()` to disambiguate sub-millisecond collisions.
+- Content: byte-identical to **the just-written page** (i.e. the *new* state). The current page on disk == the latest snapshot. This invariant simplifies restore (just write a snapshot's content back through `writeWikiPage`).
+- Frontmatter: the page's existing canonical frontmatter (title / created / updated / editor / tags / ...) **plus** the snapshot-meta fields below, prefixed `_snapshot_`. Restore strips these before writing back.
+
+```yaml
+---
+title: ...
+created: ...
+updated: 2026-04-28T01:23:45.789Z
+editor: user
+_snapshot_ts: 2026-04-28T01:23:45.789Z
+_snapshot_session: <chat session uuid>     # only when meta.sessionId set
+_snapshot_reason: 典拠リンク追加              # only when meta.reason set
+---
+
+(body of the page as just written)
+```
+
+The `_snapshot_` prefix is chosen because:
+- doesn't collide with any existing canonical key
+- one underscore (not two) keeps it short while still signalling "internal" — the bar is just visual disambiguation
+- `mergeFrontmatter` will strip these when restoring back to the page proper
+
+## Implementation
+
+### `server/workspace/wiki-pages/snapshot.ts` (new)
+
+- `appendSnapshot(slug, oldContent, newContent, meta, opts)` — writes the snapshot file via `writeFileAtomic`, then runs GC. `oldContent` parameter is kept for symmetry with the stub signature but isn't currently used (the snapshot stores `newContent`). Could be used later for "diff snapshot" mode without breaking the call site.
+- `gcSnapshots(slug, now, opts)` — readdir, parse `_snapshot_ts`, sort newest-first, retain newest 100 OR within 180 days, unlink the rest. Idempotent.
+- `historyDir(slug, opts)` — path helper, mirrors `wikiPagePath`.
+- `listSnapshots(slug, opts)` — list snapshot files newest-first with their meta (parsed from frontmatter).
+- `readSnapshot(slug, stamp, opts)` — read a single snapshot.
+
+### Wire `appendSnapshot` from `wiki-pages/io.ts`
+
+The stub already exists and is called only when `hasMeaningfulChange` is true. Replace the stub body with a call into `snapshot.ts`.
+
+### `server/api/routes/wiki/history.ts` (new)
+
+- `GET /api/wiki/pages/:slug/history` — list snapshots (just the meta, no body)
+- `GET /api/wiki/pages/:slug/history/:stamp` — read a single snapshot (full content + meta)
+- `POST /api/wiki/pages/:slug/history/:stamp/restore` — read snapshot at `:stamp`, strip `_snapshot_*` keys from its frontmatter, route through `writeWikiPage(slug, content, { editor: "user", reason: "Restored from <stamp>" })`. The new save itself becomes a snapshot too.
+
+The slug + stamp params get the same safety check as `wikiPagePath` (`isSafeSlug`) plus a stamp-shape regex so a hostile `:stamp` can't escape.
+
+### Tests
+
+- `test/workspace/wiki-pages/test_snapshot.ts` — unit
+  - appends a snapshot file with the correct frontmatter
+  - reads it back identically
+  - GC keeps newest-100 OR within-180-days, deletes only the both-violated set
+  - `listSnapshots` returns newest-first
+  - GC doesn't touch siblings (separate slugs untouched)
+  - GC tolerates malformed snapshot filenames (skips, doesn't throw)
+- `test/routes/test_wikiHistoryRoute.ts` — integration via supertest
+  - 3-step round trip: write → list → read → restore → list (now has new entry)
+  - 404 on unknown slug / stamp
+  - Path-traversal attempts rejected
+
+## Out of scope (PR 3 / later)
+
+- UI (History tab, unified diff, restore button) — PR 3
+- LLM-vs-user editor disambiguation — separate concern, currently every save is `editor: "user"`
+- Page deletion → history cleanup — no DELETE route exists today; revisit when one is added
+- Word-level diff
+- `manageWiki` MCP `reason` parameter — `WikiWriteMeta` already has the field; surfacing it through MCP is a UI / tool-schema change to do later
+
+## Verification
+
+- `yarn typecheck / lint / format / build / test` clean
+- `grep -rn "appendSnapshot" server/` confirms only one impl + the call site
+- new routes wired into `server/api/routes/index.ts`

--- a/server/api/routes/wiki/history.ts
+++ b/server/api/routes/wiki/history.ts
@@ -1,0 +1,111 @@
+// Wiki page edit-history routes (#763 PR 2). Three endpoints:
+//
+//   GET  /api/wiki/pages/:slug/history             — list snapshots (meta-only)
+//   GET  /api/wiki/pages/:slug/history/:stamp      — read one snapshot
+//   POST /api/wiki/pages/:slug/history/:stamp/restore — round-trip the
+//     snapshot through `writeWikiPage` (which snapshots the restore
+//     itself, so undo stays cheap).
+//
+// Path safety: both `:slug` and `:stamp` are validated *before*
+// they are joined with the workspace root. The slug check matches
+// `wiki-pages/io.ts`'s `isSafeSlug`; the stamp check is the
+// `FILENAME_RE` shape exposed via `isSafeStamp`.
+
+import { Router, type Request, type Response } from "express";
+import { writeWikiPage, readWikiPage } from "../../../workspace/wiki-pages/io.js";
+import { isSafeStamp, listSnapshots, readSnapshot, stripSnapshotMeta } from "../../../workspace/wiki-pages/snapshot.js";
+import { mergeFrontmatter, serializeWithFrontmatter } from "../../../utils/markdown/frontmatter.js";
+import { badRequest, notFound } from "../../../utils/httpError.js";
+import { log } from "../../../system/logger/index.js";
+
+const router = Router();
+
+// Mirrors `isSafeSlug` from wiki-pages/io.ts (kept independent so
+// the route layer doesn't import the helper through a circular
+// dependency — io.ts already imports snapshot.ts).
+function isSafeSlug(slug: string): boolean {
+  if (slug.length === 0) return false;
+  if (slug === "." || slug === "..") return false;
+  if (slug.includes("/") || slug.includes("\\")) return false;
+  if (slug.includes("\0")) return false;
+  return true;
+}
+
+// Restore is a write under the user's workspace; record a short
+// reason on the new snapshot so the history reads "Restored from
+// 2026-04-28T01-23-45-789Z" rather than an empty cell. Editor stays
+// `user` because the human triggered the restore — same shape as
+// every other UI-driven save today.
+function restoreReason(stamp: string): string {
+  return `Restored from ${stamp}`;
+}
+
+router.get("/pages/:slug/history", async (req: Request<{ slug: string }>, res: Response) => {
+  const { slug } = req.params;
+  if (!isSafeSlug(slug)) {
+    badRequest(res, "Unsafe slug");
+    return;
+  }
+  // Confirm the page actually exists before exposing its history —
+  // otherwise a stray client request for a non-existent slug would
+  // get a 200 with `[]` and the caller couldn't tell "no history"
+  // from "wrong slug".
+  const live = await readWikiPage(slug);
+  if (live === null) {
+    notFound(res, `wiki page not found: ${slug}`);
+    return;
+  }
+  const snapshots = await listSnapshots(slug);
+  res.json({ slug, snapshots });
+});
+
+router.get("/pages/:slug/history/:stamp", async (req: Request<{ slug: string; stamp: string }>, res: Response) => {
+  const { slug, stamp } = req.params;
+  if (!isSafeSlug(slug)) {
+    badRequest(res, "Unsafe slug");
+    return;
+  }
+  if (!isSafeStamp(stamp)) {
+    badRequest(res, "Unsafe stamp");
+    return;
+  }
+  const snapshot = await readSnapshot(slug, stamp);
+  if (snapshot === null) {
+    notFound(res, `snapshot not found: ${slug}/${stamp}`);
+    return;
+  }
+  res.json({ slug, snapshot });
+});
+
+router.post("/pages/:slug/history/:stamp/restore", async (req: Request<{ slug: string; stamp: string }>, res: Response) => {
+  const { slug, stamp } = req.params;
+  if (!isSafeSlug(slug)) {
+    badRequest(res, "Unsafe slug");
+    return;
+  }
+  if (!isSafeStamp(stamp)) {
+    badRequest(res, "Unsafe stamp");
+    return;
+  }
+  const snapshot = await readSnapshot(slug, stamp);
+  if (snapshot === null) {
+    notFound(res, `snapshot not found: ${slug}/${stamp}`);
+    return;
+  }
+
+  // Strip `_snapshot_*` keys before writing — they describe the
+  // *original* save event and would be misleading on the restored
+  // page. `writeWikiPage` will re-stamp `updated` and the new
+  // snapshot will get a fresh `_snapshot_ts` for the restore event.
+  const liveMeta = stripSnapshotMeta(snapshot.meta);
+  const restoredContent = serializeWithFrontmatter(mergeFrontmatter({}, liveMeta), snapshot.body);
+
+  await writeWikiPage(slug, restoredContent, {
+    editor: "user",
+    reason: restoreReason(stamp),
+  });
+  log.info("wiki", "history restore", { slug, stamp });
+  res.json({ slug, restored: { fromStamp: stamp } });
+});
+
+export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import rolesRoutes from "./api/routes/roles.js";
 import { DEFAULT_ROLE_ID } from "../src/config/roles.js";
 import mulmoScriptRoutes from "./api/routes/mulmo-script.js";
 import wikiRoutes from "./api/routes/wiki.js";
+import wikiHistoryRoutes from "./api/routes/wiki/history.js";
 import pdfRoutes from "./api/routes/pdf.js";
 import filesRoutes from "./api/routes/files.js";
 import configRoutes from "./api/routes/config.js";
@@ -165,6 +166,9 @@ app.use(chartRoutes);
 app.use(rolesRoutes);
 app.use(mulmoScriptRoutes);
 app.use(wikiRoutes);
+// Mounted under /api/wiki so the inner router's relative paths
+// (`/pages/:slug/history`) line up with API_ROUTES.wiki.pageHistory.
+app.use("/api/wiki", wikiHistoryRoutes);
 app.use(pdfRoutes);
 app.use(filesRoutes);
 app.use(configRoutes);

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -78,6 +78,11 @@ export const WORKSPACE_DIRS = {
   // prompt hint.
   wikiPages: "data/wiki/pages",
   wikiSources: "data/wiki/sources",
+  // Per-page edit-history snapshots (#763 PR 2). Hidden by leading
+  // dot so a curious user listing `data/wiki/` doesn't trip over a
+  // peer directory of historical content. Each `<slug>/` underneath
+  // holds N snapshot .md files newest-first.
+  wikiHistory: "data/wiki/.history",
   // Development — git-cloned repositories (#256).
   github: "github",
 } as const;
@@ -119,6 +124,7 @@ export const WORKSPACE_PATHS = {
   // nested subdirs
   wikiPages: path.join(workspacePath, WORKSPACE_DIRS.wikiPages),
   wikiSources: path.join(workspacePath, WORKSPACE_DIRS.wikiSources),
+  wikiHistory: path.join(workspacePath, WORKSPACE_DIRS.wikiHistory),
   // files
   memory: path.join(workspacePath, WORKSPACE_FILES.memory),
   sessionToken: path.join(workspacePath, WORKSPACE_FILES.sessionToken),

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -24,6 +24,7 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { mergeFrontmatter, parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown/frontmatter.js";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
+import { appendSnapshot } from "./snapshot.js";
 
 export type WikiPageEditor = "llm" | "user" | "system";
 
@@ -116,7 +117,10 @@ export async function writeWikiPage(slug: string, content: string, meta: WikiWri
   // Compare bodies after parsing so a frontmatter-only diff in
   // auto-stamped fields doesn't trip the trigger.
   if (oldContent === null || hasMeaningfulChange(oldContent, finalContent)) {
-    await appendSnapshot(slug, oldContent, finalContent, meta);
+    await appendSnapshot(slug, oldContent, finalContent, meta, {
+      workspaceRoot: opts.workspaceRoot,
+      now: opts.now,
+    });
   }
 }
 
@@ -233,18 +237,7 @@ export function classifyAsWikiPage(absPath: string, opts: WikiPageWriteOptions =
   return { wiki: true, slug };
 }
 
-// ── Internal: snapshot stub ────────────────────────────────────
-//
-// Filled in by #763 PR 2. Kept here as a no-op so the call site is
-// already wired up and PR 2 is a pure internal change.
-//
-// Signature note: takes both old and new content so the snapshot
-// store can emit a diff or store the prior version directly. Meta
-// carries editor identity / session / reason so the snapshot can
-// be attributed.
-
-async function appendSnapshot(__slug: string, __oldContent: string | null, __newContent: string, __meta: WikiWriteMeta): Promise<void> {
-  // Intentionally empty — PR 2 (#763) replaces this with the
-  // actual snapshot pipeline. The wiring is in place so PR 2 is
-  // purely an internal change.
-}
+// Snapshot pipeline lives in `./snapshot.ts` (#763 PR 2). The
+// indirection keeps `io.ts` focused on the page write contract;
+// snapshot.ts owns retention policy, frontmatter shape, and the
+// history dir layout.

--- a/server/workspace/wiki-pages/snapshot.ts
+++ b/server/workspace/wiki-pages/snapshot.ts
@@ -1,0 +1,299 @@
+// Per-wiki-page edit-history snapshot pipeline (#763 PR 2).
+//
+// Every meaningful save through `writeWikiPage` deposits a
+// snapshot under `data/wiki/.history/<slug>/<stamp>-<shortId>.md`.
+// The file content is byte-identical to what was just written; the
+// snapshot's frontmatter carries `_snapshot_*` keys describing the
+// save itself (timestamp, editor, sessionId, reason).
+//
+// "Restore" reads the snapshot and writes it back through the
+// normal `writeWikiPage` path — no special restore primitive
+// needed, just frontmatter cleanup before the round-trip. This
+// makes restore a *safe, reversible* operation: it adds a new
+// snapshot rather than tearing the history apart.
+//
+// Garbage collection runs on every snapshot append. The retention
+// rule is **OR-keyed**: a snapshot survives as long as it is in
+// the newest 100 OR younger than 180 days; only entries failing
+// BOTH conditions get unlinked. There is no hard cap.
+
+import path from "node:path";
+import { promises as fsp } from "node:fs";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { mergeFrontmatter, parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown/frontmatter.js";
+import { shortId } from "../../utils/id.js";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS } from "../paths.js";
+import type { WikiPageEditor, WikiWriteMeta } from "./io.js";
+
+export const SNAPSHOT_RETAIN_COUNT = 100;
+export const SNAPSHOT_RETAIN_DAYS = 180;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface SnapshotPathOptions {
+  workspaceRoot?: string;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+  /** Injectable id for deterministic tests. */
+  shortId?: () => string;
+}
+
+/** Directory holding all snapshots for a single slug. Returned even
+ *  when the dir doesn't exist yet; callers that read should tolerate
+ *  ENOENT (treat as "no history yet"). */
+export function historyDir(slug: string, opts: SnapshotPathOptions = {}): string {
+  const root = opts.workspaceRoot ?? defaultWorkspacePath;
+  return path.join(root, WORKSPACE_DIRS.wikiHistory, slug);
+}
+
+/** Snapshot summary as surfaced by `listSnapshots` and the history
+ *  routes. The body is intentionally NOT included so a 100-entry
+ *  page doesn't blow the response payload — call `readSnapshot` to
+ *  fetch a single snapshot's full content. */
+export interface SnapshotSummary {
+  /** Filesystem-safe ISO-ish timestamp encoded into the filename
+   *  (e.g. `2026-04-28T01-23-45-789Z`). Used as the route param to
+   *  read the snapshot back. */
+  stamp: string;
+  /** Bytes of the snapshot file (frontmatter + body, after write). */
+  bytes: number;
+  ts: string;
+  editor: WikiPageEditor;
+  sessionId?: string;
+  reason?: string;
+}
+
+export interface SnapshotContent extends SnapshotSummary {
+  /** Frontmatter of the saved page at this snapshot's instant —
+   *  with `_snapshot_*` keys *included*. Restore strips them. */
+  meta: Record<string, unknown>;
+  /** Body of the page at the snapshot instant. */
+  body: string;
+}
+
+// Filenames look like `<stamp>-<shortId>.md`. The stamp is
+// `YYYY-MM-DDTHH-mm-ss-sssZ` (colons swapped to hyphens). The
+// shortId tail disambiguates same-millisecond writes.
+const FILENAME_RE = /^(?<stamp>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z)-(?<id>[a-z0-9]+)\.md$/i;
+
+function timestampToFilenameStamp(date: Date): string {
+  // 2026-04-28T01:23:45.789Z → 2026-04-28T01-23-45-789Z. Swap the
+  // colons (forbidden on Windows / awkward in URLs) and the period
+  // before milliseconds. Result is still strict-monotonic and
+  // sortable lexicographically.
+  return date.toISOString().replace(/:/g, "-").replace(".", "-");
+}
+
+function filenameStampToTimestamp(stamp: string): string | null {
+  // Inverse of `timestampToFilenameStamp`. Returns the canonical
+  // ISO 8601 form (with colons + period) for use in the
+  // _snapshot_ts frontmatter and the JSON wire shape. Returns null
+  // when the stamp doesn't match the expected shape — callers can
+  // skip the entry rather than throwing on a stray file.
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/.exec(stamp);
+  if (!match) return null;
+  const [, date, hour, min, sec, milli] = match;
+  return `${date}T${hour}:${min}:${sec}.${milli}Z`;
+}
+
+/** Path-safety check for the `:stamp` route param. The route layer
+ *  must reject anything that wouldn't survive being joined with
+ *  `historyDir(slug)` — same logic shape as `wiki-pages/io.ts`'s
+ *  `isSafeSlug`. Exported because the route does the validation
+ *  before calling readSnapshot / restoreSnapshot. */
+export function isSafeStamp(stamp: string): boolean {
+  return FILENAME_RE.test(`${stamp}-x.md`);
+}
+
+// Snapshot-meta keys carry strings only, so a plain
+// `Record<string, unknown>` matches `mergeFrontmatter`'s parameter
+// shape exactly. A named interface here would require a cast at
+// the merge call site without buying any extra type safety —
+// snapshot consumers re-validate the shape on read anyway.
+function buildSnapshotMetaPatch(meta: WikiWriteMeta, timestamp: string): Record<string, unknown> {
+  const patch: Record<string, unknown> = {
+    _snapshot_ts: timestamp,
+    _snapshot_editor: meta.editor,
+  };
+  if (meta.sessionId !== undefined) patch._snapshot_session = meta.sessionId;
+  if (meta.reason !== undefined && meta.reason.length > 0) patch._snapshot_reason = meta.reason;
+  return patch;
+}
+
+const SNAPSHOT_KEYS = ["_snapshot_ts", "_snapshot_editor", "_snapshot_session", "_snapshot_reason"] as const;
+
+/** Strip `_snapshot_*` keys from a snapshot's frontmatter so the
+ *  resulting content can be written back through the normal
+ *  `writeWikiPage` path without polluting the live page with
+ *  history-internal metadata. */
+export function stripSnapshotMeta(meta: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if ((SNAPSHOT_KEYS as readonly string[]).includes(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Write a snapshot file for a page that just changed. The
+ *  snapshot's content == the page's new content (byte-identical
+ *  body), with `_snapshot_*` meta merged in. The `_oldContent`
+ *  parameter is intentionally unused — kept in the signature for
+ *  symmetry with the call site so a future "diff snapshot" mode
+ *  doesn't have to thread a new parameter. */
+export async function appendSnapshot(
+  slug: string,
+  _oldContent: string | null,
+  newContent: string,
+  meta: WikiWriteMeta,
+  opts: SnapshotPathOptions = {},
+): Promise<void> {
+  const now = (opts.now ?? (() => new Date()))();
+  const isoTs = now.toISOString();
+  const filenameStamp = timestampToFilenameStamp(now);
+  const tail = (opts.shortId ?? shortId)();
+  const fileName = `${filenameStamp}-${tail}.md`;
+
+  // The new page already has its own frontmatter (writeWikiPage
+  // auto-stamps `created` / `updated` / `editor`). Merge the
+  // `_snapshot_*` patch on top so the snapshot file carries both
+  // the page's identity AND the save event.
+  const parsed = parseFrontmatter(newContent);
+  const merged = mergeFrontmatter(parsed.meta, buildSnapshotMetaPatch(meta, isoTs));
+  const snapshotContent = serializeWithFrontmatter(merged, parsed.body);
+
+  const dir = historyDir(slug, opts);
+  await writeFileAtomic(path.join(dir, fileName), snapshotContent);
+  await gcSnapshots(slug, now, opts);
+}
+
+/** Walk `historyDir(slug)` and unlink every snapshot that fails
+ *  BOTH retention rules: outside the newest `SNAPSHOT_RETAIN_COUNT`
+ *  AND older than `SNAPSHOT_RETAIN_DAYS` from `now`. Idempotent —
+ *  safe to run on a directory that doesn't exist (no-op).
+ *  Tolerant of stray files whose names don't match the expected
+ *  pattern; they are left alone. */
+export async function gcSnapshots(slug: string, now: Date, opts: SnapshotPathOptions = {}): Promise<void> {
+  const dir = historyDir(slug, opts);
+  const entries = await readSnapshotEntries(dir);
+  if (entries.length === 0) return;
+
+  // Sort newest-first by stamp. The stamp is lexicographically
+  // sortable because it's zero-padded ISO with colons swapped.
+  entries.sort((left, right) => (left.stamp < right.stamp ? 1 : left.stamp > right.stamp ? -1 : 0));
+
+  const cutoffMs = now.getTime() - SNAPSHOT_RETAIN_DAYS * ONE_DAY_MS;
+
+  await Promise.all(
+    entries.map(async (entry, index) => {
+      const tsIso = filenameStampToTimestamp(entry.stamp);
+      if (tsIso === null) return; // shouldn't happen — readSnapshotEntries already filtered
+      const entryMs = Date.parse(tsIso);
+      const withinCount = index < SNAPSHOT_RETAIN_COUNT;
+      const withinAge = entryMs >= cutoffMs;
+      if (withinCount || withinAge) return;
+      await fsp.unlink(path.join(dir, entry.fileName)).catch(() => {});
+    }),
+  );
+}
+
+interface SnapshotEntry {
+  stamp: string;
+  fileName: string;
+}
+
+async function readSnapshotEntries(dir: string): Promise<SnapshotEntry[]> {
+  let names: string[];
+  try {
+    names = await fsp.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: SnapshotEntry[] = [];
+  for (const name of names) {
+    const match = FILENAME_RE.exec(name);
+    if (!match?.groups) continue;
+    out.push({ stamp: match.groups.stamp, fileName: name });
+  }
+  return out;
+}
+
+function entryStringField(meta: Record<string, unknown>, key: string): string | undefined {
+  const value = meta[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function entryEditor(meta: Record<string, unknown>): WikiPageEditor {
+  const value = meta._snapshot_editor;
+  if (value === "llm" || value === "user" || value === "system") return value;
+  // Default to "user" for files written by an older version of the
+  // pipeline that didn't stamp the field. Better than throwing on a
+  // stray legacy entry.
+  return "user";
+}
+
+/** List snapshots for a slug, newest-first. Returns an empty array
+ *  when the slug has no history dir yet. Each entry carries enough
+ *  meta (ts, editor, reason, sessionId) to render a list view; the
+ *  body is omitted — call `readSnapshot` for full content. */
+export async function listSnapshots(slug: string, opts: SnapshotPathOptions = {}): Promise<SnapshotSummary[]> {
+  const dir = historyDir(slug, opts);
+  const entries = await readSnapshotEntries(dir);
+  entries.sort((left, right) => (left.stamp < right.stamp ? 1 : left.stamp > right.stamp ? -1 : 0));
+
+  const summaries: SnapshotSummary[] = [];
+  for (const entry of entries) {
+    try {
+      const filePath = path.join(dir, entry.fileName);
+      const raw = await fsp.readFile(filePath, "utf-8");
+      const stat = await fsp.stat(filePath);
+      const parsed = parseFrontmatter(raw);
+      const tsIso = entryStringField(parsed.meta, "_snapshot_ts") ?? filenameStampToTimestamp(entry.stamp) ?? entry.stamp;
+      summaries.push({
+        stamp: entry.stamp,
+        bytes: stat.size,
+        ts: tsIso,
+        editor: entryEditor(parsed.meta),
+        sessionId: entryStringField(parsed.meta, "_snapshot_session"),
+        reason: entryStringField(parsed.meta, "_snapshot_reason"),
+      });
+    } catch {
+      // Skip unreadable entries — a corrupted snapshot shouldn't
+      // take down the whole list. The next GC run will clean it up.
+    }
+  }
+  return summaries;
+}
+
+/** Read a single snapshot. Returns null when the file is missing
+ *  or the stamp is malformed. */
+export async function readSnapshot(slug: string, stamp: string, opts: SnapshotPathOptions = {}): Promise<SnapshotContent | null> {
+  if (!isSafeStamp(stamp)) return null;
+  const dir = historyDir(slug, opts);
+  const entries = await readSnapshotEntries(dir);
+  const match = entries.find((entry) => entry.stamp === stamp);
+  if (!match) return null;
+
+  const filePath = path.join(dir, match.fileName);
+  let raw: string;
+  let stat: { size: number };
+  try {
+    raw = await fsp.readFile(filePath, "utf-8");
+    stat = await fsp.stat(filePath);
+  } catch {
+    return null;
+  }
+
+  const parsed = parseFrontmatter(raw);
+  const tsIso = entryStringField(parsed.meta, "_snapshot_ts") ?? filenameStampToTimestamp(match.stamp) ?? match.stamp;
+  return {
+    stamp: match.stamp,
+    bytes: stat.size,
+    ts: tsIso,
+    editor: entryEditor(parsed.meta),
+    sessionId: entryStringField(parsed.meta, "_snapshot_session"),
+    reason: entryStringField(parsed.meta, "_snapshot_reason"),
+    meta: parsed.meta,
+    body: parsed.body,
+  };
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -190,5 +190,11 @@ export const API_ROUTES = {
 
   wiki: {
     base: "/api/wiki",
+    /** History routes (#763 PR 2). `:slug` and `:stamp` are filled in
+     *  by the caller — the constants stay route-pattern shaped so the
+     *  Express router and the Vue API layer share one source of truth. */
+    pageHistory: "/api/wiki/pages/:slug/history",
+    pageHistorySnapshot: "/api/wiki/pages/:slug/history/:stamp",
+    pageHistoryRestore: "/api/wiki/pages/:slug/history/:stamp/restore",
   },
 } as const;

--- a/test/routes/test_wikiHistoryRoute.ts
+++ b/test/routes/test_wikiHistoryRoute.ts
@@ -1,0 +1,209 @@
+// Route-level checks for the wiki history endpoints (#763 PR 2).
+// Same handler-extract pattern as test_wikiSaveRoute.ts so we
+// don't need supertest. HOME is redirected to a tmp dir BEFORE
+// the route module is imported so `workspacePath` resolves into
+// the sandbox.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync } from "fs";
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import type { Request, Response } from "express";
+
+type Handler = (req: Request, res: Response) => Promise<void> | void;
+
+interface StackFrame {
+  route?: {
+    path: string;
+    stack: Array<{ method: string; handle: Handler }>;
+  };
+}
+interface RouterInternals {
+  stack: StackFrame[];
+}
+
+function extractRouteHandler(mod: { default: unknown }, routePath: string, method: string): Handler {
+  const router = mod.default as unknown as RouterInternals;
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === method);
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
+}
+
+interface ResBody {
+  slug?: string;
+  snapshots?: Array<{ stamp: string; reason?: string; editor?: string }>;
+  snapshot?: { stamp: string; body?: string; meta?: Record<string, unknown> };
+  restored?: { fromStamp: string };
+  error?: string;
+}
+
+function mockRes() {
+  const state: { status: number; body: ResBody | undefined } = { status: 200, body: undefined };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(payload: ResBody) {
+      state.body = payload;
+      return res;
+    },
+  };
+  return { state, res: res as unknown as Response };
+}
+
+function makeReq(params: Record<string, string>): Request {
+  return { params } as unknown as Request;
+}
+
+let tmpRoot: string;
+let pagesDir: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let listHandler: Handler;
+let readHandler: Handler;
+let restoreHandler: Handler;
+let writeWikiPage: typeof import("../../server/workspace/wiki-pages/io.js").writeWikiPage;
+let listSnapshots: typeof import("../../server/workspace/wiki-pages/snapshot.js").listSnapshots;
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-wiki-history-route-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+
+  const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
+  const { WORKSPACE_DIRS } = await import("../../server/workspace/paths.js");
+  pagesDir = path.join(workspacePth, WORKSPACE_DIRS.wikiPages);
+  mkdirSync(pagesDir, { recursive: true });
+
+  const historyMod = await import("../../server/api/routes/wiki/history.js");
+  listHandler = extractRouteHandler(historyMod, "/pages/:slug/history", "get");
+  readHandler = extractRouteHandler(historyMod, "/pages/:slug/history/:stamp", "get");
+  restoreHandler = extractRouteHandler(historyMod, "/pages/:slug/history/:stamp/restore", "post");
+
+  ({ writeWikiPage } = await import("../../server/workspace/wiki-pages/io.js"));
+  ({ listSnapshots } = await import("../../server/workspace/wiki-pages/snapshot.js"));
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("GET /api/wiki/pages/:slug/history", () => {
+  it("returns 404 for an unknown slug", async () => {
+    const { state, res } = mockRes();
+    await listHandler(makeReq({ slug: "does-not-exist" }), res);
+    assert.equal(state.status, 404);
+  });
+
+  it("returns 400 on an unsafe slug", async () => {
+    const { state, res } = mockRes();
+    await listHandler(makeReq({ slug: "../etc/passwd" }), res);
+    assert.equal(state.status, 400);
+  });
+
+  it("returns the snapshot list for a real page", async () => {
+    // Two saves → two snapshots. We assert presence + ordering;
+    // exact stamps depend on the live clock.
+    const slug = "list-test";
+    await writeWikiPage(slug, "first body\n", { editor: "user", reason: "draft" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeWikiPage(slug, "second body\n", { editor: "user", reason: "revise" });
+
+    const { state, res } = mockRes();
+    await listHandler(makeReq({ slug }), res);
+    assert.equal(state.status, 200);
+    assert.equal(state.body?.slug, slug);
+    assert.ok(state.body?.snapshots);
+    assert.ok((state.body.snapshots ?? []).length >= 2, "expected at least 2 snapshots");
+    // Newest-first.
+    const reasons = (state.body.snapshots ?? []).map((entry) => entry.reason);
+    assert.equal(reasons[0], "revise");
+    assert.equal(reasons[1], "draft");
+  });
+});
+
+describe("GET /api/wiki/pages/:slug/history/:stamp", () => {
+  it("returns 400 on an unsafe stamp", async () => {
+    const { state, res } = mockRes();
+    await readHandler(makeReq({ slug: "any", stamp: "../etc" }), res);
+    assert.equal(state.status, 400);
+  });
+
+  it("returns the snapshot body + meta for a known stamp", async () => {
+    const slug = "read-test";
+    await writeWikiPage(slug, "hello body\n", { editor: "user", reason: "first" });
+    const snapshots = await listSnapshots(slug);
+    assert.ok(snapshots.length >= 1);
+    const stamp = snapshots[0].stamp;
+
+    const { state, res } = mockRes();
+    await readHandler(makeReq({ slug, stamp }), res);
+    assert.equal(state.status, 200);
+    assert.equal(state.body?.snapshot?.stamp, stamp);
+    assert.equal(state.body?.snapshot?.body, "hello body\n");
+    assert.equal(state.body?.snapshot?.meta?._snapshot_reason, "first");
+  });
+
+  it("returns 404 for an unknown stamp on a known slug", async () => {
+    const slug = "miss-test";
+    await writeWikiPage(slug, "body\n", { editor: "user" });
+    const fakeStamp = "2099-01-01T00-00-00-000Z";
+    const { state, res } = mockRes();
+    await readHandler(makeReq({ slug, stamp: fakeStamp }), res);
+    assert.equal(state.status, 404);
+  });
+});
+
+describe("POST /api/wiki/pages/:slug/history/:stamp/restore", () => {
+  it("writes the snapshot's body back to the live page and produces a new snapshot", async () => {
+    const slug = "restore-test";
+    await writeWikiPage(slug, "v1 body\n", { editor: "user", reason: "first" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeWikiPage(slug, "v2 body\n", { editor: "user", reason: "second" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const beforeRestore = await listSnapshots(slug);
+    const oldest = beforeRestore[beforeRestore.length - 1];
+    assert.ok(oldest);
+
+    const { state, res } = mockRes();
+    await restoreHandler(makeReq({ slug, stamp: oldest.stamp }), res);
+    assert.equal(state.status, 200);
+    assert.equal(state.body?.restored?.fromStamp, oldest.stamp);
+
+    // Live page now reads "v1 body" again.
+    const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");
+    const { WORKSPACE_DIRS } = await import("../../server/workspace/paths.js");
+    const livePath = path.join(workspacePth, WORKSPACE_DIRS.wikiPages, `${slug}.md`);
+    const live = await readFile(livePath, "utf-8");
+    assert.match(live, /\nv1 body\n$/);
+    // The restore must NOT have leaked _snapshot_* into the live frontmatter.
+    assert.doesNotMatch(live, /_snapshot_/);
+
+    // History grew by one entry (the restore itself).
+    const afterRestore = await listSnapshots(slug);
+    assert.equal(afterRestore.length, beforeRestore.length + 1, "restore should add a new snapshot");
+    assert.match(afterRestore[0].reason ?? "", /^Restored from /);
+  });
+
+  it("returns 404 when the stamp doesn't exist", async () => {
+    const slug = "restore-miss";
+    await writeWikiPage(slug, "body\n", { editor: "user" });
+
+    const { state, res } = mockRes();
+    await restoreHandler(makeReq({ slug, stamp: "2099-01-01T00-00-00-000Z" }), res);
+    assert.equal(state.status, 404);
+  });
+});

--- a/test/workspace/wiki-pages/test_snapshot.ts
+++ b/test/workspace/wiki-pages/test_snapshot.ts
@@ -1,0 +1,355 @@
+// Unit tests for the snapshot pipeline (#763 PR 2).
+//
+// Focus areas:
+//   - appendSnapshot writes a file with the expected name + meta
+//   - listSnapshots returns newest-first, parses meta correctly
+//   - readSnapshot round-trips body + meta
+//   - GC retains "newest 100 OR within 180 days" — only deletes when
+//     BOTH conditions are violated
+//   - GC is idempotent and tolerant of stray / malformed filenames
+//   - Snapshots for unrelated slugs are never touched by another
+//     slug's GC
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { writeWikiPage } from "../../../server/workspace/wiki-pages/io.js";
+import {
+  appendSnapshot,
+  gcSnapshots,
+  historyDir,
+  isSafeStamp,
+  listSnapshots,
+  readSnapshot,
+  SNAPSHOT_RETAIN_COUNT,
+  SNAPSHOT_RETAIN_DAYS,
+  stripSnapshotMeta,
+} from "../../../server/workspace/wiki-pages/snapshot.js";
+import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SLUG = "test-page";
+
+let root: string;
+
+before(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "snapshot-test-"));
+});
+
+after(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+async function writeRawSnapshot(workspaceRoot: string, slug: string, stamp: string, body: string, meta: Record<string, unknown> = {}): Promise<void> {
+  // Direct filesystem write so tests can seed history with arbitrary
+  // timestamps (even stamps in the past, where appendSnapshot would
+  // refuse to step backwards). Mirrors the on-disk shape that
+  // appendSnapshot would produce.
+  const fileName = `${stamp}-fixedid.md`;
+  const dir = path.join(workspaceRoot, WORKSPACE_DIRS.wikiHistory, slug);
+  await mkdir(dir, { recursive: true });
+  const text = ["---", `_snapshot_ts: "${stampToIso(stamp)}"`, `_snapshot_editor: ${meta._snapshot_editor ?? "user"}`, "---", "", body].join("\n");
+  await writeFile(path.join(dir, fileName), text, "utf-8");
+}
+
+function stampToIso(stamp: string): string {
+  // 2026-04-28T01-23-45-789Z → 2026-04-28T01:23:45.789Z
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/.exec(stamp);
+  if (!match) throw new Error(`bad stamp ${stamp}`);
+  return `${match[1]}T${match[2]}:${match[3]}:${match[4]}.${match[5]}Z`;
+}
+
+function dateToStamp(date: Date): string {
+  return date.toISOString().replace(/:/g, "-").replace(".", "-");
+}
+
+describe("isSafeStamp", () => {
+  it("accepts the canonical filename stamp shape", () => {
+    assert.equal(isSafeStamp("2026-04-28T01-23-45-789Z"), true);
+  });
+
+  it("rejects path-traversal attempts", () => {
+    assert.equal(isSafeStamp("../etc/passwd"), false);
+    assert.equal(isSafeStamp("..\\foo"), false);
+    assert.equal(isSafeStamp(""), false);
+  });
+
+  it("rejects shape that's missing the trailing Z or millisecond block", () => {
+    assert.equal(isSafeStamp("2026-04-28T01-23-45"), false);
+    assert.equal(isSafeStamp("2026-04-28T01:23:45.789Z"), false); // colons
+  });
+});
+
+describe("stripSnapshotMeta", () => {
+  it("removes only the `_snapshot_*` keys, preserves everything else", () => {
+    const input = {
+      title: "X",
+      created: "2026-04-01",
+      updated: "2026-04-28T01:00:00.000Z",
+      _snapshot_ts: "2026-04-28T01:00:00.000Z",
+      _snapshot_editor: "user",
+      _snapshot_session: "abc",
+      _snapshot_reason: "typo fix",
+      tags: ["a", "b"],
+    };
+    const out = stripSnapshotMeta(input);
+    assert.deepEqual(out, {
+      title: "X",
+      created: "2026-04-01",
+      updated: "2026-04-28T01:00:00.000Z",
+      tags: ["a", "b"],
+    });
+  });
+
+  it("is a no-op when no snapshot keys are present", () => {
+    const input = { title: "X" };
+    assert.deepEqual(stripSnapshotMeta(input), { title: "X" });
+  });
+});
+
+describe("appendSnapshot — write + retrieve", () => {
+  it("creates a snapshot file and listSnapshots surfaces its meta", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "snapshot-write-"));
+    const fixedNow = new Date("2026-04-28T01:23:45.789Z");
+    await appendSnapshot(
+      SLUG,
+      null,
+      "---\ntitle: hi\n---\n\nbody\n",
+      { editor: "user", reason: "first save" },
+      { workspaceRoot, now: () => fixedNow, shortId: () => "fixedid" },
+    );
+
+    const snapshots = await listSnapshots(SLUG, { workspaceRoot });
+    assert.equal(snapshots.length, 1);
+    assert.equal(snapshots[0].stamp, "2026-04-28T01-23-45-789Z");
+    assert.equal(snapshots[0].editor, "user");
+    assert.equal(snapshots[0].reason, "first save");
+    assert.equal(snapshots[0].ts, "2026-04-28T01:23:45.789Z");
+
+    const single = await readSnapshot(SLUG, snapshots[0].stamp, { workspaceRoot });
+    assert.ok(single, "expected snapshot to round-trip");
+    assert.equal(single.body, "body\n");
+    assert.equal(single.meta.title, "hi");
+    assert.equal(single.meta._snapshot_reason, "first save");
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("orders snapshots newest-first regardless of write order", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "snapshot-order-"));
+
+    // Seed three snapshots with descending timestamps. The on-disk
+    // dir-listing order is OS-dependent so we rely on the in-helper
+    // sort to surface the canonical newest-first ordering.
+    const seeds = ["2026-04-26T00-00-00-000Z", "2026-04-28T00-00-00-000Z", "2026-04-27T00-00-00-000Z"];
+    for (const stamp of seeds) await writeRawSnapshot(workspaceRoot, SLUG, stamp, "body");
+
+    const snapshots = await listSnapshots(SLUG, { workspaceRoot });
+    const stamps = snapshots.map((entry) => entry.stamp);
+    assert.deepEqual(stamps, ["2026-04-28T00-00-00-000Z", "2026-04-27T00-00-00-000Z", "2026-04-26T00-00-00-000Z"]);
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("returns an empty list for a slug with no history", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "snapshot-empty-"));
+    const snapshots = await listSnapshots("never-saved", { workspaceRoot });
+    assert.deepEqual(snapshots, []);
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("readSnapshot returns null on unknown stamp", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "snapshot-miss-"));
+    await writeRawSnapshot(workspaceRoot, SLUG, "2026-04-28T01-23-45-789Z", "body");
+
+    const miss = await readSnapshot(SLUG, "2099-01-01T00-00-00-000Z", { workspaceRoot });
+    assert.equal(miss, null);
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("readSnapshot rejects unsafe stamp strings (returns null, no throw)", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "snapshot-unsafe-"));
+    const out = await readSnapshot(SLUG, "../etc/passwd", { workspaceRoot });
+    assert.equal(out, null);
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+});
+
+describe("gcSnapshots — retention rule", () => {
+  it("keeps every snapshot when the dir doesn't exist (no-op)", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-noop-"));
+    await gcSnapshots("never-saved", new Date(), { workspaceRoot });
+    // Just asserting it didn't throw is enough — the dir shouldn't
+    // suddenly exist either.
+    const dir = historyDir("never-saved", { workspaceRoot });
+    await assert.rejects(() => readdir(dir));
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("deletes only entries that are BOTH outside top-100 AND older than 180 days", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-rule-"));
+    const now = new Date("2026-04-28T00:00:00.000Z");
+
+    // Seed 110 snapshots:
+    //   - 100 within last 30 days (fresh, count-protected AND age-protected)
+    //   - 10 from 365 days ago (outside top-100 by age but well past
+    //     180-day cutoff — these should be deleted)
+    // We arrange them so the 10 ancient ones come *after* the 100
+    // recent ones in the sorted list (i.e. they're older and hence
+    // outside the count window after sorting newest-first).
+    for (let i = 0; i < 100; i++) {
+      const date = new Date(now.getTime() - i * 60 * 1000); // 1-minute spacing
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `recent-${i}`);
+    }
+    for (let i = 0; i < 10; i++) {
+      const date = new Date(now.getTime() - 365 * ONE_DAY_MS - i * 60 * 1000);
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `ancient-${i}`);
+    }
+
+    await gcSnapshots(SLUG, now, { workspaceRoot });
+    const remaining = await listSnapshots(SLUG, { workspaceRoot });
+    assert.equal(remaining.length, 100, "expected the 10 ancient snapshots to be GC'd");
+  });
+
+  it("keeps a snapshot in the count window even when it's older than 180 days", async () => {
+    // Edge case: a slug with only 50 lifetime entries, 30 of which
+    // are over 180 days old. None of them should be GC'd because
+    // every single one is in the top-100 (count rule wins).
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-count-rule-"));
+    const now = new Date("2026-04-28T00:00:00.000Z");
+
+    for (let i = 0; i < 30; i++) {
+      const date = new Date(now.getTime() - (200 + i) * ONE_DAY_MS);
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `old-${i}`);
+    }
+    for (let i = 0; i < 20; i++) {
+      const date = new Date(now.getTime() - i * ONE_DAY_MS);
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `recent-${i}`);
+    }
+
+    await gcSnapshots(SLUG, now, { workspaceRoot });
+    const remaining = await listSnapshots(SLUG, { workspaceRoot });
+    assert.equal(remaining.length, 50, "fewer than 100 entries — keep them all regardless of age");
+  });
+
+  it("keeps a snapshot in the age window even when it's outside the top-100", async () => {
+    // Edge case: 200 snapshots all within 180 days. None should be
+    // GC'd because every single one is age-protected (age rule wins).
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-age-rule-"));
+    const now = new Date("2026-04-28T00:00:00.000Z");
+
+    for (let i = 0; i < 200; i++) {
+      // Spread across 90 days — well within 180.
+      const date = new Date(now.getTime() - i * 12 * 60 * 60 * 1000);
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `entry-${i}`);
+    }
+
+    await gcSnapshots(SLUG, now, { workspaceRoot });
+    const remaining = await listSnapshots(SLUG, { workspaceRoot });
+    assert.equal(remaining.length, 200, "all entries within 180 days — keep them regardless of count");
+  });
+
+  it("does not touch other slugs' history", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-isolation-"));
+    const now = new Date("2026-04-28T00:00:00.000Z");
+    const oldStamp = dateToStamp(new Date(now.getTime() - 400 * ONE_DAY_MS));
+
+    // Seed an ancient snapshot under "other-slug" that *would* be
+    // GC'd if any code path mistakenly walked the wrong dir.
+    await writeRawSnapshot(workspaceRoot, "other-slug", oldStamp, "irrelevant");
+    await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(now), "fresh");
+
+    await gcSnapshots(SLUG, now, { workspaceRoot });
+
+    const otherDir = historyDir("other-slug", { workspaceRoot });
+    const remaining = await readdir(otherDir);
+    assert.equal(remaining.length, 1, "other slug's history must be untouched");
+  });
+
+  it("ignores files whose names don't match the stamp pattern", async () => {
+    // A stray README or a half-written .tmp shouldn't break GC.
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "gc-stray-"));
+    const dir = historyDir(SLUG, { workspaceRoot });
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "README"), "stray", "utf-8");
+    await writeFile(path.join(dir, "notes.txt"), "also stray", "utf-8");
+    // One real ancient entry that *would* be GC'd to confirm GC ran.
+    const ancient = dateToStamp(new Date("2024-01-01T00:00:00.000Z"));
+    await writeRawSnapshot(workspaceRoot, SLUG, ancient, "ancient");
+    // Force the count window to exclude `ancient` by adding 100 fresh.
+    const now = new Date("2026-04-28T00:00:00.000Z");
+    for (let i = 0; i < 100; i++) {
+      const date = new Date(now.getTime() - i * 60 * 1000);
+      await writeRawSnapshot(workspaceRoot, SLUG, dateToStamp(date), `fresh-${i}`);
+    }
+
+    await gcSnapshots(SLUG, now, { workspaceRoot });
+    const remaining = await readdir(dir);
+    // The two stray files survive untouched.
+    assert.ok(remaining.includes("README"));
+    assert.ok(remaining.includes("notes.txt"));
+    // The ancient real snapshot was GC'd.
+    assert.ok(!remaining.some((name) => name.startsWith("2024-01-01T")));
+  });
+});
+
+describe("appendSnapshot via writeWikiPage — integration", () => {
+  // Verifies the wiring from the io.ts choke point through to a
+  // real on-disk snapshot. The previous tests called appendSnapshot
+  // directly; here we make sure writeWikiPage's call site triggers
+  // it on a meaningful body change but NOT on a no-op save.
+  it("creates a snapshot when the body changes", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "wiki-integration-"));
+    await mkdir(path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages), { recursive: true });
+
+    const fixedNow = new Date("2026-04-28T01:23:45.789Z");
+    await writeWikiPage("hello", "first body\n", { editor: "user" }, { workspaceRoot, now: () => fixedNow });
+
+    // Second save with different body, slightly later timestamp.
+    const later = new Date(fixedNow.getTime() + 60_000);
+    await writeWikiPage("hello", "updated body\n", { editor: "user" }, { workspaceRoot, now: () => later });
+
+    const snapshots = await listSnapshots("hello", { workspaceRoot });
+    assert.equal(snapshots.length, 2, "two saves with different bodies → two snapshots");
+
+    // The newest snapshot's body should match the second save.
+    const newest = await readSnapshot("hello", snapshots[0].stamp, { workspaceRoot });
+    assert.ok(newest);
+    assert.equal(newest.body, "updated body\n");
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("does NOT create a snapshot when only auto-stamped meta changes", async () => {
+    // hasMeaningfulChange filters out the case where the only diff
+    // is the auto-stamped `updated` field. This test pins that
+    // behaviour: writing the exact same body at a later timestamp
+    // doesn't add a second snapshot.
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "wiki-noop-"));
+    await mkdir(path.join(workspaceRoot, WORKSPACE_DIRS.wikiPages), { recursive: true });
+
+    const firstSave = new Date("2026-04-28T01:00:00.000Z");
+    await writeWikiPage("hello", "same body\n", { editor: "user" }, { workspaceRoot, now: () => firstSave });
+
+    const secondSave = new Date("2026-04-28T01:05:00.000Z");
+    await writeWikiPage("hello", "same body\n", { editor: "user" }, { workspaceRoot, now: () => secondSave });
+
+    const snapshots = await listSnapshots("hello", { workspaceRoot });
+    assert.equal(snapshots.length, 1, "no-op resave should not record a new snapshot");
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+});
+
+// Sanity: the constants line up with the policy decision baked into
+// the design doc. Drift here usually means a follow-up tweak that
+// the plan file didn't get updated for.
+describe("retention constants", () => {
+  it("matches the documented policy", () => {
+    assert.equal(SNAPSHOT_RETAIN_COUNT, 100);
+    assert.equal(SNAPSHOT_RETAIN_DAYS, 180);
+  });
+});


### PR DESCRIPTION
## Summary

Wires up the wiki page edit-history pipeline — the no-op stub from PR #883 / PR B is now a real snapshot writer + GC + 3 read/restore endpoints. Builds on top of the canonical frontmatter work in #895 (PR A merged, PR B merged, PR C in flight but not blocking).

UI work (History tab + unified diff + Restore button + e2e) is **PR 3**, intentionally out of this PR's scope.

## Items to Confirm / Review

- [ ] **Storage layout** — \`data/wiki/.history/<slug>/<stamp>-<shortId>.md\`. Snapshot content == the just-written page (byte-identical body); the \`_snapshot_*\` keys ride in the frontmatter alongside the page's existing canonical meta. Strip-on-restore is the single safety knob.
- [ ] **Retention rule** — \`SNAPSHOT_RETAIN_COUNT = 100\`, \`SNAPSHOT_RETAIN_DAYS = 180\`, OR-keyed (delete only when both are violated, no hard cap). 4 dedicated tests pin the count-only edge, age-only edge, both-violated case, and stray-file tolerance.
- [ ] **Path safety** — both \`:slug\` and \`:stamp\` are validated *before* being joined with the workspace root. \`isSafeStamp\` is a strict regex match of the canonical filename pattern; \`/etc/passwd\`-shaped inputs return 400 / null and never throw.
- [ ] **Restore is non-destructive** — \`POST .../:stamp/restore\` reads the snapshot, strips its \`_snapshot_*\` meta, and routes the content through \`writeWikiPage\` like any other save. The restore *itself* gets a fresh snapshot with \`reason: "Restored from <stamp>"\`. The route test pins \`assert.doesNotMatch(live, /_snapshot_/)\`.
- [ ] **No-op saves don't pollute history** — the existing \`hasMeaningfulChange\` filter (PR B) gates the \`appendSnapshot\` call. Test \`does NOT create a snapshot when only auto-stamped meta changes\` verifies this hasn't regressed.
- [ ] **Editor disambiguation deferred** — every save still passes \`editor: "user"\` per the existing route default. Out of scope here; flagged for a follow-up. Comment in \`io.ts\` already documents this.
- [ ] **No DELETE route → no history-coupling needed yet** — confirmed via \`grep router.delete\`. When a delete route is added, the cleanup hook lives next to the new route.

## Files

- \`server/workspace/wiki-pages/snapshot.ts\` (new) — \`appendSnapshot\` / \`gcSnapshots\` / \`listSnapshots\` / \`readSnapshot\` / \`isSafeStamp\` / \`stripSnapshotMeta\` + retention constants.
- \`server/workspace/wiki-pages/io.ts\` — replace the no-op \`appendSnapshot\` stub with an import from \`snapshot.ts\`; thread \`workspaceRoot\` and \`now\` through so tests stay deterministic.
- \`server/api/routes/wiki/history.ts\` (new) — three Express handlers; safety checks before any I/O; mounted under \`/api/wiki\` from \`server/index.ts\`.
- \`server/index.ts\` — wire the new router in.
- \`server/workspace/paths.ts\` — \`WORKSPACE_DIRS.wikiHistory\` + \`WORKSPACE_PATHS.wikiHistory\`.
- \`src/config/apiRoutes.ts\` — \`pageHistory\` / \`pageHistorySnapshot\` / \`pageHistoryRestore\` so the (forthcoming) Vue side has a single source of truth.
- \`test/workspace/wiki-pages/test_snapshot.ts\` (new) — 12 unit cases.
- \`test/routes/test_wikiHistoryRoute.ts\` (new) — 8 route-level cases.
- \`plans/feat-763-snapshot-pipeline.md\` — design notes captured during the chat review.

## User Prompt

> 895の関連タスクはおわったので、現状を確認して763を進めてほしい。順番に。
>
> [Followed by 7 design questions answered one-by-one — final decisions: file snapshots, wiki-only, optional reason, OR-rule retention with no cap, line-unified diff (deferred to PR 3), restore-as-new-edit, no size cap.]