### PR TITLE
refactor: drop WHAT comments in src/plugins/presentForm/ (#910)

### DIFF
--- a/src/plugins/presentForm/Preview.vue
+++ b/src/plugins/presentForm/Preview.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="w-full h-full flex flex-col items-center justify-center p-4 bg-gradient-to-br from-blue-50 to-indigo-50 rounded-lg border-2 border-gray-200">
     <div class="text-center">
-      <!-- Form Icon -->
       <svg class="w-12 h-12 mx-auto mb-3 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path
           stroke-linecap="round"
@@ -11,15 +10,12 @@
         />
       </svg>
 
-      <!-- Form Title or Default -->
       <h3 class="text-gray-900 font-bold text-lg mb-1 line-clamp-2">
         {{ formData?.title || t("pluginPresentForm.fallbackTitle") }}
       </h3>
 
-      <!-- Field Count -->
       <p class="text-gray-600 text-sm mb-2">{{ t("pluginPresentForm.fieldCount", { count: fieldCount }, fieldCount) }}</p>
 
-      <!-- Completion Status -->
       <div v-if="!isSubmitted" class="flex items-center justify-center gap-2">
         <div class="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">
           <div class="h-full bg-blue-600 transition-all duration-300" :style="{ width: `${completionPercentage}%` }" />
@@ -27,7 +23,6 @@
         <span class="text-xs text-gray-500">{{ `${completionPercentage}%` }}</span>
       </div>
 
-      <!-- Submitted Badge -->
       <div v-else class="inline-flex items-center gap-1 px-3 py-1 bg-green-100 text-green-700 rounded-full text-xs font-semibold">
         <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
           <path

--- a/src/plugins/presentForm/View.vue
+++ b/src/plugins/presentForm/View.vue
@@ -1,17 +1,14 @@
 <template>
   <div class="w-full h-full overflow-y-auto p-8">
     <div v-if="formData" class="max-w-3xl w-full mx-auto">
-      <!-- Form Title -->
       <h2 v-if="formData.title" class="text-gray-900 text-3xl font-bold mb-4 text-center">
         {{ formData.title }}
       </h2>
 
-      <!-- Form Description -->
       <p v-if="formData.description" class="text-gray-600 text-center mb-8 text-lg">
         {{ formData.description }}
       </p>
 
-      <!-- Error Summary -->
       <div v-if="showErrorSummary && fieldErrors.size > 0" class="bg-red-50 border-2 border-red-500 rounded-lg p-4 mb-6" role="alert">
         <h3 class="text-red-800 font-semibold mb-2 flex items-center gap-2">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -32,7 +29,6 @@
         </ul>
       </div>
 
-      <!-- Form Fields -->
       <form @submit.prevent="handleSubmit" class="space-y-6">
         <div
           v-for="field in formData.fields"
@@ -41,7 +37,6 @@
           class="form-field"
           :class="{ 'has-error': hasError(field.id) && touched.has(field.id) }"
         >
-          <!-- Field Label -->
           <label
             :for="`input-${field.id}`"
             class="block text-gray-800 font-semibold mb-2"
@@ -53,12 +48,10 @@
             <span v-if="field.required" class="text-red-500 ml-1" aria-label="required">{{ t("pluginPresentForm.requiredMarker") }}</span>
           </label>
 
-          <!-- Field Description -->
           <p v-if="field.description" class="text-gray-600 text-sm mb-2">
             {{ field.description }}
           </p>
 
-          <!-- Text Field -->
           <input
             v-if="field.type === 'text'"
             :id="`input-${field.id}`"
@@ -76,7 +69,6 @@
             }"
           />
 
-          <!-- Textarea Field -->
           <textarea
             v-else-if="field.type === 'textarea'"
             :id="`input-${field.id}`"
@@ -94,7 +86,6 @@
             }"
           />
 
-          <!-- Number Field -->
           <input
             v-else-if="field.type === 'number'"
             :id="`input-${field.id}`"
@@ -114,7 +105,6 @@
             }"
           />
 
-          <!-- Date Field -->
           <input
             v-else-if="field.type === 'date'"
             :id="`input-${field.id}`"
@@ -133,7 +123,6 @@
             }"
           />
 
-          <!-- Time Field -->
           <input
             v-else-if="field.type === 'time'"
             :id="`input-${field.id}`"
@@ -150,7 +139,6 @@
             }"
           />
 
-          <!-- Radio Field -->
           <div
             v-else-if="field.type === 'radio'"
             class="space-y-2"
@@ -180,7 +168,6 @@
             </label>
           </div>
 
-          <!-- Dropdown Field -->
           <select
             v-else-if="field.type === 'dropdown'"
             :id="`input-${field.id}`"
@@ -201,7 +188,6 @@
             </option>
           </select>
 
-          <!-- Checkbox Field -->
           <div
             v-else-if="field.type === 'checkbox'"
             class="space-y-2"
@@ -230,7 +216,6 @@
             </label>
           </div>
 
-          <!-- Error Message -->
           <div
             v-if="hasError(field.id) && touched.has(field.id)"
             :id="`${field.id}-error`"
@@ -247,7 +232,6 @@
             {{ fieldErrors.get(field.id)?.message }}
           </div>
 
-          <!-- Character Count (for text/textarea with maxLength) -->
           <div
             v-if="showCharCount(field)"
             class="text-sm mt-2"
@@ -265,7 +249,6 @@
           </div>
         </div>
 
-        <!-- Submit Button -->
         <div class="mt-8 flex justify-center">
           <button
             type="submit"
@@ -277,7 +260,6 @@
           </button>
         </div>
 
-        <!-- Progress Indicator -->
         <div class="mt-4 text-center text-gray-600 text-sm">
           {{ t("pluginPresentForm.progress", { filled: filledRequiredCount, total: requiredFieldsCount }) }}
         </div>
@@ -349,7 +331,6 @@ function applyNewResult(newResult: ToolResult): void {
   isRestoring.value = false;
 }
 
-// Initialize form data and restore state
 watch(
   () => props.selectedResult,
   (newResult, oldResult) => {
@@ -360,7 +341,6 @@ watch(
   { immediate: true },
 );
 
-// Save state to viewState - watch all state changes together
 watch(
   [formValues, touched, submitted],
   () => {
@@ -416,9 +396,7 @@ function isEmpty(value: any): boolean {
   return false;
 }
 
-// 254 = RFC 5321 maximum address length. indexOf-based check avoids
-// the chained `[^\s@]+` regex pattern that sonarjs flags as
-// vulnerable to super-linear backtracking.
+// 254 per RFC 5321; bounding upfront keeps the regex below from backtracking.
 const EMAIL_MAX_LENGTH = 254;
 function isValidEmail(email: string): boolean {
   if (!email || email.length > EMAIL_MAX_LENGTH) return false;
@@ -530,7 +508,6 @@ function handleBlur(fieldId: string): void {
 }
 
 function handleInput(fieldId: string): void {
-  // Real-time validation for fields that are already touched
   if (touched.value.has(fieldId)) {
     validateField(fieldId);
   }
@@ -572,27 +549,18 @@ const filledRequiredCount = computed(() => {
 function handleSubmit(): void {
   if (submitted.value) return;
 
-  // Mark all fields as touched
   formData.value?.fields.forEach((field) => {
     touched.value.add(field.id);
     validateField(field.id);
   });
 
-  // Check for errors
   if (fieldErrors.value.size > 0) {
     showErrorSummary.value = true;
-    // Focus first error field
     const firstErrorFieldId = Array.from(fieldErrors.value.keys())[0];
     focusField(firstErrorFieldId);
     return;
   }
 
-  // Build a markdown bullet list of `- {label}: {value}` lines so the
-  // chat history reads naturally for a human while still being trivial
-  // for the LLM to parse. Empty values become "(none)". Titles, labels,
-  // and choice strings are passed through singleLine() to strip any
-  // newlines they might contain — without that, a label like
-  // "Address (street\nand number)" would shatter the bullet structure.
   const lines: string[] = [];
   if (formData.value?.title) lines.push(`**${singleLine(formData.value.title)}**`, "");
   formData.value?.fields.forEach((field) => {
@@ -603,22 +571,15 @@ function handleSubmit(): void {
   props.sendTextMessage(lines.join("\n"));
 }
 
-// Indent every line except the first by 2 spaces — under markdown
-// rules, indented continuations stay attached to the preceding bullet
-// instead of starting a new top-level item. Without this, a textarea
-// value containing newlines would inject phantom bullets into the
-// chat-side payload that the LLM could mis-parse.
+// Indent so multi-line text/textarea values stay attached to their bullet
+// instead of opening a new top-level item under markdown rules.
 function indentContinuation(text: string): string {
   return text.replace(/\n/g, "\n  ");
 }
 
-// Collapse any newline (and surrounding whitespace) into a single
-// space. Used on titles, labels, and choice strings (LLM-authored
-// fields) so they can't smuggle a newline into the markdown bullet
-// structure and reshape the payload. Free-form user input
-// (text/textarea values) uses indentContinuation instead — it
-// preserves multi-line values. Implemented via split-trim-join (not a
-// global regex) to avoid sonarjs's slow-regex flag on `\s*\n\s*`.
+// LLM-authored title/label/choice strings — collapse any newline so they
+// can't smuggle phantom bullets into the payload. split-trim-join avoids
+// sonarjs's slow-regex flag on `\s*\n\s*`.
 function singleLine(text: string): string {
   return text
     .split(/\r?\n/)
@@ -633,10 +594,8 @@ function renderValue(field: FormField, value: any): string {
   if (field.type === "radio" || field.type === "dropdown") {
     return value !== null && value !== undefined ? singleLine(field.choices[value]) : empty;
   }
-  // Checkbox values render as a nested bullet sublist rather than a
-  // comma-joined string. Comma-joining is ambiguous when a choice label
-  // itself contains a comma; the sublist is unambiguous and survives
-  // round-trip parsing.
+  // Sublist (not comma-join): a choice label containing a comma would otherwise
+  // be indistinguishable from two separate selections.
   if (field.type === "checkbox") {
     const items: string[] = (value || []).map((idx: number) => singleLine(field.choices[idx]));
     if (items.length === 0) return empty;

--- a/src/plugins/presentForm/definition.ts
+++ b/src/plugins/presentForm/definition.ts
@@ -1,7 +1,3 @@
-/**
- * Form Tool Definition (Schema)
- */
-
 import type { ToolDefinition } from "gui-chat-protocol";
 
 export const TOOL_NAME = "presentForm";

--- a/src/plugins/presentForm/plugin.ts
+++ b/src/plugins/presentForm/plugin.ts
@@ -1,8 +1,5 @@
-// Local fork of @mulmochat-plugin/form (originally
-// ~/ss/llm/GUIChatPlugins/MulmoChatPluginForm). Forked so the form
-// submission payload (see View.vue:handleSubmit) renders as readable
-// markdown bullets in the chat history instead of a JSON-wrapped
-// object.
+// Forked from @mulmochat-plugin/form so handleSubmit can emit a markdown
+// bullet list instead of the upstream JSON-wrapped payload.
 
 import type { ToolContext, ToolResult } from "gui-chat-protocol";
 import type { FormData, FormArgs, FormField } from "./types";
@@ -31,9 +28,7 @@ function validateCheckboxRange(field: FormField & { type: "checkbox" }): void {
   if (maxSelections !== undefined && maxSelections > choices.length) {
     throw new Error(`Field '${id}': maxSelections cannot exceed number of choices`);
   }
-  // Without this lower-bound check, a form with minSelections > choices.length
-  // would render but be impossible to submit — the user can never satisfy the
-  // minimum because there aren't enough options to pick.
+  // Without this, a form would render but be unsubmittable.
   if (minSelections !== undefined && minSelections > choices.length) {
     throw new Error(`Field '${id}': minSelections cannot exceed number of choices`);
   }

--- a/src/plugins/presentForm/types.ts
+++ b/src/plugins/presentForm/types.ts
@@ -1,18 +1,5 @@
-/**
- * Form Plugin Types
- *
- * Form-specific type definitions only.
- * Common types should be imported directly from gui-chat-protocol.
- */
-
-// ============================================================================
-// Form-specific Types
-// ============================================================================
-
-/** Field type discriminator */
 export type FieldType = "text" | "textarea" | "radio" | "dropdown" | "checkbox" | "date" | "time" | "number";
 
-/** Base field interface */
 export interface BaseField {
   id: string;
   type: FieldType;
@@ -22,7 +9,6 @@ export interface BaseField {
   maxLength?: number;
 }
 
-/** Text field */
 export interface TextField extends BaseField {
   type: "text";
   placeholder?: string;
@@ -32,7 +18,6 @@ export interface TextField extends BaseField {
   maxLength?: number;
 }
 
-/** Textarea field */
 export interface TextareaField extends BaseField {
   type: "textarea";
   placeholder?: string;
@@ -42,14 +27,12 @@ export interface TextareaField extends BaseField {
   defaultValue?: string;
 }
 
-/** Radio field */
 export interface RadioField extends BaseField {
   type: "radio";
   choices: string[];
   defaultValue?: string;
 }
 
-/** Dropdown field */
 export interface DropdownField extends BaseField {
   type: "dropdown";
   choices: string[];
@@ -57,7 +40,6 @@ export interface DropdownField extends BaseField {
   defaultValue?: string;
 }
 
-/** Checkbox field */
 export interface CheckboxField extends BaseField {
   type: "checkbox";
   choices: string[];
@@ -66,7 +48,6 @@ export interface CheckboxField extends BaseField {
   defaultValue?: string[];
 }
 
-/** Date field */
 export interface DateField extends BaseField {
   type: "date";
   minDate?: string;
@@ -75,14 +56,12 @@ export interface DateField extends BaseField {
   defaultValue?: string;
 }
 
-/** Time field */
 export interface TimeField extends BaseField {
   type: "time";
   format?: "12hr" | "24hr";
   defaultValue?: string;
 }
 
-/** Number field */
 export interface NumberField extends BaseField {
   type: "number";
   min?: number;
@@ -91,17 +70,14 @@ export interface NumberField extends BaseField {
   defaultValue?: number;
 }
 
-/** Union type for all fields */
 export type FormField = TextField | TextareaField | RadioField | DropdownField | CheckboxField | DateField | TimeField | NumberField;
 
-/** Form data stored in result.jsonData */
 export interface FormData {
   title?: string;
   description?: string;
   fields: FormField[];
 }
 
-/** Arguments passed to the form tool */
 export interface FormArgs {
   title?: string;
   description?: string;


### PR DESCRIPTION
## Summary

Pilot module pass for #910. Strips WHAT comments (template section markers, function-name restatements, breadcrumb banners, type-name JSDoc) and tightens the WHY comments that capture real hidden context.

**Net change**: -90 / +11 across 5 files. Comment lines in `View.vue` alone: 58 → 17.

## Items to Confirm / Review

- [ ] **Behavior unchanged** — only comments removed, no logic / rename / type / constant edits in this pass. format / lint / typecheck / build all green locally.
- [ ] **WHY comments retained**: `indentContinuation` / `singleLine` / checkbox-sublist rationale, email-validator length-bound (sonarjs slow-regex avoidance), `minSelections > choices.length` lower-bound check. Each is now one short line.
- [ ] **WHY comments deleted**: none — every kept comment justifies its presence.
- [ ] **Risk**: a future reader of `View.vue:handleSubmit` won't see the long "Build a markdown bullet list…" prose that used to sit above the loop. The function name `handleSubmit` + the `lines.push(\`- \${field.label}: …\`)` line carries the same information. Confirm that's enough or call out a specific spot to keep.

## Before / After (representative deletion)

### `types.ts`

Before:

\`\`\`ts
/**
 * Form Plugin Types
 *
 * Form-specific type definitions only.
 * Common types should be imported directly from gui-chat-protocol.
 */

// ============================================================================
// Form-specific Types
// ============================================================================

/** Field type discriminator */
export type FieldType = "text" | "textarea" | "radio" | "dropdown" | "checkbox" | "date" | "time" | "number";

/** Base field interface */
export interface BaseField { … }
\`\`\`

After:

\`\`\`ts
export type FieldType = "text" | "textarea" | "radio" | "dropdown" | "checkbox" | "date" | "time" | "number";

export interface BaseField { … }
\`\`\`

The filename, `export` keyword, and the type names themselves carry every word of the deleted prose.

### `View.vue:handleSubmit`

Before:

\`\`\`vue
  // Mark all fields as touched
  formData.value?.fields.forEach((field) => {
    touched.value.add(field.id);
    validateField(field.id);
  });

  // Check for errors
  if (fieldErrors.value.size > 0) {
    showErrorSummary.value = true;
    // Focus first error field
    const firstErrorFieldId = Array.from(fieldErrors.value.keys())[0];
    focusField(firstErrorFieldId);
    return;
  }

  // Build a markdown bullet list of \`- {label}: {value}\` lines so the
  // chat history reads naturally for a human while still being trivial
  // for the LLM to parse. Empty values become "(none)". Titles, labels,
  // and choice strings are passed through singleLine() to strip any
  // newlines they might contain — without that, a label like
  // "Address (street\\nand number)" would shatter the bullet structure.
  const lines: string[] = [];
\`\`\`

After:

\`\`\`vue
  formData.value?.fields.forEach((field) => {
    touched.value.add(field.id);
    validateField(field.id);
  });

  if (fieldErrors.value.size > 0) {
    showErrorSummary.value = true;
    const firstErrorFieldId = Array.from(fieldErrors.value.keys())[0];
    focusField(firstErrorFieldId);
    return;
  }

  const lines: string[] = [];
\`\`\`

The "why singleLine?" rationale that this block used to repeat now lives once in `singleLine()`'s own (tightened) header comment.

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint --no-cache` — 0 errors (24 pre-existing warnings unchanged)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] Manual: open `/chat` in General role, ask `色は red / blue / green のどれにしますか?`, verify the form still appears and submits as a markdown bullet list.

## Related

- Tracking issue: #910
- Plan: `plans/refactor-comment-sweep.md` — module #1 of 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Streamline the presentForm plugin by removing redundant explanatory comments while keeping concise rationale where behavior is non-obvious.

Enhancements:
- Trim redundant template and type JSDoc comments from presentForm views and types to rely on self-explanatory code and names.
- Condense key inline comments in email validation, markdown rendering, and checkbox range validation to focus on essential behavioral rationale only.