### PR TITLE
feat(frontmatter): finalize #895 — NewsView strip + wiki round-trip e2e (closes #895)

### DIFF
--- a/e2e/tests/news-view.spec.ts
+++ b/e2e/tests/news-view.spec.ts
@@ -143,4 +143,40 @@ test.describe("/news page", () => {
     await expect(page.getByTestId(`news-item-${ITEM_B.id}`)).toBeVisible();
     await expect(page.getByTestId(`news-item-${ITEM_A.id}`)).toBeHidden();
   });
+
+  test("renders body without raw `---` fence when an item carries frontmatter (#895 PR D)", async ({ page }) => {
+    // Regression guard for the NewsView frontmatter strip added in
+    // PR D. RSS feeds normally don't carry markdown frontmatter, but
+    // a feed mirroring a markdown blog could — and `marked()` would
+    // otherwise render the fence as `<hr>` plus the YAML keys as
+    // plain body text. The strip via `parseFrontmatter` is defensive
+    // and a no-op for header-less inputs; this test pins it.
+    const state = await installNewsMocks(page, [ITEM_A]);
+    state.bodies[ITEM_A.id] = [
+      "---",
+      "title: Alpha headline",
+      "tags: [demo]",
+      "---",
+      "",
+      "# Real Body Heading",
+      "",
+      "This is the article body itself.",
+      "",
+    ].join("\n");
+
+    await page.goto("/news");
+    await page.getByTestId(`news-item-${ITEM_A.id}`).click();
+
+    // The body's H1 text comes from `# Real Body Heading` (post-strip).
+    await expect(page.getByText("Real Body Heading")).toBeVisible();
+    await expect(page.getByText("This is the article body itself.")).toBeVisible();
+
+    // Pre-strip the fence would have rendered as `<hr>` and
+    // `title: Alpha headline` would appear as visible text. After
+    // strip, neither remains in the rendered detail pane.
+    const detailPane = page.getByTestId("news-detail");
+    const detailText = await detailPane.innerText();
+    expect(detailText).not.toContain("title: Alpha headline");
+    expect(detailText).not.toMatch(/^---$/m);
+  });
 });

--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -144,6 +144,7 @@ import { apiGet } from "../utils/api";
 import { formatSmartTime } from "../utils/format/date";
 import { useNewsItems } from "../composables/useNewsItems";
 import { useNewsReadState } from "../composables/useNewsReadState";
+import { parseFrontmatter } from "../utils/markdown/frontmatter";
 import FilterChip from "./FilterChip.vue";
 import PageChatComposer from "./PageChatComposer.vue";
 
@@ -191,7 +192,18 @@ const unreadCount = computed(() => items.value.filter((item) => !isRead(item.id)
 
 const selected = computed(() => items.value.find((item) => item.id === selectedId.value) ?? null);
 
-const renderedBody = computed(() => (body.value ? marked(body.value, { breaks: true, gfm: true }) : ""));
+// Strip frontmatter before marked() renders the body. RSS-derived
+// content typically has no `---\n...\n---` envelope, but a feed
+// that mirrors a markdown blog could carry one — and we don't
+// want it to surface as a stray `<hr>` plus key:value plain text.
+// `parseFrontmatter` is a no-op for header-less inputs, so this
+// is safe for the common case (#895 PR D — closes the issue's
+// "Vue 側 ... news ... frontmatter が body に出ない" requirement).
+const renderedBody = computed(() => {
+  if (!body.value) return "";
+  const { body: bodyOnly } = parseFrontmatter(body.value);
+  return marked(bodyOnly, { breaks: true, gfm: true });
+});
 
 function selectItem(itemId: string): void {
   selectedId.value = itemId;

--- a/test/routes/test_wikiSaveRoute.ts
+++ b/test/routes/test_wikiSaveRoute.ts
@@ -162,6 +162,51 @@ describe("POST /api/wiki — action: save", () => {
     assert.match(header, /\bb\b/);
   });
 
+  it("end-to-end: header-less page → save → reload shows frontmatter, body unchanged (#895 完了条件)", async () => {
+    // The issue body's last unchecked completion item:
+    //   "header の無い既存 md を書き込む → 自動で minimal header 付与"
+    //   "e2e: 既存 header なし wiki page を編集 → 次回読み込みで
+    //   header あり / body は変わらない"
+    //
+    // This is the route-level integration test for that flow:
+    //   1. Seed a header-less page on disk (legacy wiki content shape).
+    //   2. POST /api/wiki { action: "save", content: <new body> } —
+    //      same call shape the frontend's task-checkbox toggler uses.
+    //   3. Read the file back and assert (a) frontmatter envelope
+    //      now wraps the body and (b) the body bytes are byte-
+    //      identical to what the caller sent.
+    const slug = "lazy-on-write";
+    const filePath = path.join(pagesDir, `${slug}.md`);
+    const headerlessOriginal = "# Lazy\n\nA pre-existing page that has no frontmatter yet.\n";
+    await writeFile(filePath, headerlessOriginal, "utf-8");
+
+    const newBody = "# Lazy\n\nUpdated body — same shape, different prose.\n";
+    const { state, res } = mockRes();
+    await postWikiHandler(req({ action: "save", pageName: slug, content: newBody }), res);
+
+    assert.equal(state.status, 200);
+
+    // Read back as the user would on a reload.
+    const reloaded = await readFile(filePath, "utf-8");
+
+    // Header now exists with the auto-stamped minimum.
+    assert.match(reloaded, /^---\n/);
+    assert.match(reloaded, /\ncreated: /);
+    assert.match(reloaded, /\nupdated: /);
+    assert.match(reloaded, /\neditor: user\n/);
+    assert.match(reloaded, /\n---\n\n/);
+
+    // Body byte-identical to what the caller sent.
+    const headerEnd = reloaded.indexOf("\n---\n", 4);
+    const bodyAfter = reloaded.slice(headerEnd + "\n---\n".length).trimStart();
+    assert.equal(bodyAfter, newBody);
+
+    // The route's response carries the same canonical content the
+    // next reload would render — so the optimistic update on the
+    // client matches what a fresh reload would show.
+    assert.equal(state.body?.data?.content, reloaded);
+  });
+
   it("rejects a request with no pageName", async () => {
     const { state, res } = mockRes();
     await postWikiHandler(req({ action: "save", content: "anything" }), res);

--- a/test/routes/test_wikiSaveRoute.ts
+++ b/test/routes/test_wikiSaveRoute.ts
@@ -66,11 +66,19 @@ function req(body: unknown): Request {
   return { body } as unknown as Request;
 }
 
+// GET /api/wiki?slug=… mock — the wiki route reads `req.query.slug`
+// (forwarded by `getOptionalStringQuery`), so the test harness only
+// needs to expose that field.
+function getReqWithSlug(slug: string): Request {
+  return { query: { slug } } as unknown as Request;
+}
+
 let tmpRoot: string;
 let pagesDir: string;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
 let postWikiHandler: Handler;
+let getWikiHandler: Handler;
 
 before(async () => {
   tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-wiki-save-route-"));
@@ -86,6 +94,7 @@ before(async () => {
 
   const wikiMod: WikiModule = await import("../../server/api/routes/wiki.js");
   postWikiHandler = extractRouteHandler(wikiMod, "/api/wiki", "post");
+  getWikiHandler = extractRouteHandler(wikiMod, "/api/wiki", "get");
 });
 
 after(async () => {
@@ -162,49 +171,71 @@ describe("POST /api/wiki — action: save", () => {
     assert.match(header, /\bb\b/);
   });
 
-  it("end-to-end: header-less page → save → reload shows frontmatter, body unchanged (#895 完了条件)", async () => {
+  it("end-to-end: header-less page → save → reload (GET) shows frontmatter, body byte-identical (#895 完了条件)", async () => {
     // The issue body's last unchecked completion item:
     //   "header の無い既存 md を書き込む → 自動で minimal header 付与"
     //   "e2e: 既存 header なし wiki page を編集 → 次回読み込みで
     //   header あり / body は変わらない"
     //
-    // This is the route-level integration test for that flow:
+    // Route-level integration test for that flow. We exercise BOTH
+    // the POST save handler and the GET reload handler (codex
+    // review iter-1 #915 — reading the file directly via fs.readFile
+    // doesn't actually pin the GET / buildPageResponse path the
+    // frontend hits on a real reload).
+    //
     //   1. Seed a header-less page on disk (legacy wiki content shape).
     //   2. POST /api/wiki { action: "save", content: <new body> } —
     //      same call shape the frontend's task-checkbox toggler uses.
-    //   3. Read the file back and assert (a) frontmatter envelope
-    //      now wraps the body and (b) the body bytes are byte-
-    //      identical to what the caller sent.
+    //   3. GET  /api/wiki?slug=<slug> — same call the wiki view
+    //      issues on reload.
+    //   4. Read the file too, assert (a) frontmatter envelope
+    //      wraps the body, (b) body bytes BYTE-identical to what
+    //      the caller sent (no `trimStart()` slack — the offset
+    //      includes the canonical envelope spacer `\n---\n\n`),
+    //      (c) GET response content matches the file on disk.
     const slug = "lazy-on-write";
     const filePath = path.join(pagesDir, `${slug}.md`);
     const headerlessOriginal = "# Lazy\n\nA pre-existing page that has no frontmatter yet.\n";
     await writeFile(filePath, headerlessOriginal, "utf-8");
 
     const newBody = "# Lazy\n\nUpdated body — same shape, different prose.\n";
-    const { state, res } = mockRes();
-    await postWikiHandler(req({ action: "save", pageName: slug, content: newBody }), res);
+    const postCtx = mockRes();
+    await postWikiHandler(req({ action: "save", pageName: slug, content: newBody }), postCtx.res);
 
-    assert.equal(state.status, 200);
+    assert.equal(postCtx.state.status, 200);
 
-    // Read back as the user would on a reload.
-    const reloaded = await readFile(filePath, "utf-8");
+    // Read on disk.
+    const onDisk = await readFile(filePath, "utf-8");
 
     // Header now exists with the auto-stamped minimum.
-    assert.match(reloaded, /^---\n/);
-    assert.match(reloaded, /\ncreated: /);
-    assert.match(reloaded, /\nupdated: /);
-    assert.match(reloaded, /\neditor: user\n/);
-    assert.match(reloaded, /\n---\n\n/);
+    assert.match(onDisk, /^---\n/);
+    assert.match(onDisk, /\ncreated: /);
+    assert.match(onDisk, /\nupdated: /);
+    assert.match(onDisk, /\neditor: user\n/);
+    assert.match(onDisk, /\n---\n\n/);
 
-    // Body byte-identical to what the caller sent.
-    const headerEnd = reloaded.indexOf("\n---\n", 4);
-    const bodyAfter = reloaded.slice(headerEnd + "\n---\n".length).trimStart();
+    // BYTE-identical body extraction. `serializeWithFrontmatter`
+    // emits `---\n${yaml}\n---\n\n${body}` — the closing fence
+    // sequence is exactly `\n---\n\n` (closing newline + fence +
+    // newline + spacer line). Slice past those bytes and the
+    // remainder is the user-supplied body verbatim.
+    const fenceEnd = onDisk.indexOf("\n---\n\n", 4);
+    assert.notEqual(fenceEnd, -1, "closing fence + spacer not found");
+    const bodyAfter = onDisk.slice(fenceEnd + "\n---\n\n".length);
     assert.equal(bodyAfter, newBody);
 
-    // The route's response carries the same canonical content the
-    // next reload would render — so the optimistic update on the
-    // client matches what a fresh reload would show.
-    assert.equal(state.body?.data?.content, reloaded);
+    // POST response carries the same canonical content the GET
+    // would return — the optimistic client update matches reload.
+    assert.equal(postCtx.state.body?.data?.content, onDisk);
+
+    // GET /api/wiki?slug=… — the actual reload path the frontend
+    // would take. The response's `data.content` MUST match the
+    // file on disk (i.e. round-trips through `buildPageResponse`).
+    const getCtx = mockRes();
+    await getWikiHandler(getReqWithSlug(slug), getCtx.res);
+    assert.equal(getCtx.state.status, 200);
+    assert.equal(getCtx.state.body?.data?.content, onDisk);
+    assert.equal(getCtx.state.body?.data?.pageExists, true);
   });
 
   it("rejects a request with no pageName", async () => {


### PR DESCRIPTION
## Summary

Closes the last two unchecked items in #895's completion criteria:

1. **NewsView frontmatter strip** — RSS bodies don't normally carry frontmatter, but a feed mirroring a markdown blog could and `marked()` would otherwise render the fence as `<hr>` + YAML as plain text. Defensive strip via `parseFrontmatter`, no-op on header-less inputs.
2. **End-to-end wiki round-trip test** — at the route level: seed a header-less file, POST `{ action: "save" }`, read back, assert the new frontmatter envelope wraps a byte-identical body. Pins the lazy-on-write contract from PR B.

Closes #895.

## Items to Confirm / Review

- **Journal viewer**: the issue lists `wiki / journal / news / FileContentRenderer`. The journal "today" button navigates to `/files/<daily-path>` which renders through `FileContentRenderer` — that component is already wired to `useMarkdownDoc` (PR A). No journal-specific code change needed.
- **NewsView no properties panel**: the strip drops frontmatter from the rendered body without surfacing it in a separate panel. The issue's requirement is just "frontmatter が body に出ない", so a panel isn't required. If we ever start writing news items with frontmatter (currently the RSS pipeline doesn't), a panel can be added later.

## Items NOT in this PR (surfaced for follow-up)

These came up while finalising #895 and deserve their own design:

- **LLM-direct wiki writes bypass `writeWikiPage`**: the LLM uses the Claude Code SDK's built-in `Write` tool which writes to host fs directly (in Docker mode, via bind mount; in non-Docker, plain fs). The chokepoint catches `manageWiki POST` / `files PUT` / `wiki-backlinks` — but not the most common path. This means PR B's auto-stamping and the future #763 PR 2 snapshot pipeline only see non-LLM edits. Solving this needs a fresh issue: candidates are a `PreToolUse` hook redirecting `Write` for `data/wiki/pages/*.md` paths, or a `manageWiki { action: "save" }` MCP tool plus a prompt instruction. Either way, it's a design discussion, not a bug fix.
- **Editor identity disambiguation (was originally PR D)**: today the three reachable paths tag `"user"` / `"system"` correctly. The `"llm"` identity is meaningful only after the bypass above is resolved — it's a no-op until then.
- **`sources/registry.ts` `serializeSource` migration**: deferred indefinitely (round-trip contract is coupled to existing test fixtures).

## User Prompt

> writeWikiPageのことは別で対応を考えるとして、いまやっていたことの残課題ってある？
> はい。それを進めてこれを閉じよう！！

(prior context: PR A #902, PR B #905, PR C #908 merged. PR D was originally editor identity disambiguation but was de-scoped after discovering the LLM-bypass issue.)

## Implementation

### Modified
- `src/components/NewsView.vue` — added `parseFrontmatter` import + body-strip in `renderedBody` computed
- `test/routes/test_wikiSaveRoute.ts` — added one e2e-style integration case (header-less file → save → reload reads frontmatter envelope, body byte-identical)

## テスト手順

### 自動

```bash
yarn typecheck     # clean
yarn lint          # clean
yarn build         # clean

# 関連 unit テスト
tsx --test ./test/routes/test_wikiSaveRoute.ts

# 関連 e2e
yarn test:e2e e2e/tests/wiki-metadata-bar.spec.ts \
              e2e/tests/markdown-frontmatter.spec.ts \
              e2e/tests/news-view.spec.ts
```

期待:
- `test_wikiSaveRoute.ts`: 8 cases pass (新規 1 case + 既存 7)
- e2e: 9 cases pass (本 PR 関連 spec の合計)

### 手動

1. `npm run dev`
2. **NewsView regression**: `/news` を開く → 普通の RSS item を表示 → frontmatter 由来の `---` テキスト等が出ないことを確認 (現在の RSS feed では frontmatter が含まれないので no-op だが、回帰がないことを確認)
3. **Wiki round-trip**: 既存の header-less wiki page を opening → 編集 → 保存 → リロード → metadata bar が出る + body が byte-identical
4. **Journal**: today-journal-btn から daily file を開く → FileContentRenderer 経由で frontmatter があれば properties panel が出る (#895 PR A の動作と同じ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strip markdown frontmatter from news item bodies before rendering and add an integration test to lock in wiki page frontmatter auto-stamping behavior.

New Features:
- Remove frontmatter envelopes from NewsView article bodies prior to markdown rendering so metadata does not appear in the visible content.

Tests:
- Add an end-to-end route-level test verifying that saving a header-less wiki page auto-adds minimal frontmatter while preserving the body content byte-for-byte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * News articles no longer display YAML frontmatter metadata in the detail view.

* **Tests**
  * Added end-to-end regression test for the news page.
  * Added integration test for wiki content save and reload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->