### PR TITLE
feat(presentMulmoScript): scrollable lightbox with progress bar + caption toolbar

### DIFF
--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -365,7 +365,24 @@
           >
             ‹
           </button>
-          <img :src="lightbox.src" class="max-w-[80vw] max-h-[85vh] object-contain rounded shadow-2xl" />
+          <div class="flex flex-col items-center">
+            <img :src="lightbox.src" class="max-w-[80vw] max-h-[85vh] object-contain rounded shadow-2xl" />
+            <div v-if="!lightbox.isCharacter && beats.length > 1" class="relative w-full h-1.5">
+              <div class="flex gap-1 h-full">
+                <div
+                  v-for="i in beats.length"
+                  :key="i - 1"
+                  class="flex-1"
+                  :class="i - 1 === lightbox.index ? 'bg-white/80' : i - 1 < lightbox.index ? 'bg-white/40' : 'bg-white/20'"
+                />
+              </div>
+              <div
+                v-if="playingAudio && playingAudio.index === lightbox.index"
+                class="absolute top-1/2 w-3.5 h-3.5 rounded-full bg-white shadow ring-2 ring-black/30 -translate-y-1/2 -translate-x-1/2 pointer-events-none"
+                :style="{ left: `${((lightbox.index + audioProgress) / beats.length) * 100}%` }"
+              />
+            </div>
+          </div>
           <button
             v-if="!lightbox.isCharacter"
             class="text-white/60 hover:text-white disabled:opacity-20 text-5xl leading-none"
@@ -466,6 +483,7 @@ const beatAudios = reactive<Record<number, string>>({});
 const audioState = reactive<Record<number, "generating" | "done" | "error">>({});
 const audioErrors = reactive<Record<number, string>>({});
 const playingAudio = ref<{ index: number; audio: HTMLAudioElement } | null>(null);
+const audioProgress = ref(0);
 const beatListEl = ref<HTMLElement | null>(null);
 const lightbox = ref<{
   src: string;
@@ -518,6 +536,7 @@ function stopPlayingAudio() {
   if (!playingAudio.value) return;
   playingAudio.value.audio.pause();
   playingAudio.value = null;
+  audioProgress.value = 0;
 }
 
 function openLightbox(index: number) {
@@ -830,9 +849,15 @@ function playAudio(index: number) {
   if (!src) return;
   const audio = new Audio(src);
   playingAudio.value = { index, audio };
+  audioProgress.value = 0;
+  audio.addEventListener("timeupdate", () => {
+    if (playingAudio.value?.index !== index) return;
+    if (audio.duration > 0) audioProgress.value = audio.currentTime / audio.duration;
+  });
   audio.addEventListener("ended", () => {
     if (playingAudio.value?.index !== index) return;
     playingAudio.value = null;
+    audioProgress.value = 0;
     if (lightbox.value?.index === index) {
       lightboxMove(1);
       const nextIndex = lightbox.value?.index;

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -351,42 +351,42 @@
     </div>
 
     <!-- Lightbox -->
-    <div v-if="lightbox" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80" @click="closeLightbox">
-      <div class="flex items-center gap-4" @click.stop>
-        <button
-          v-if="!lightbox.isCharacter"
-          class="text-white/60 hover:text-white disabled:opacity-20 text-4xl leading-none"
-          :disabled="!hasPrev"
-          @click="lightboxMove(-1)"
-        >
-          ‹
-        </button>
-        <div class="flex flex-col items-center gap-3">
-          <img :src="lightbox.src" class="max-w-[80vw] max-h-[80vh] object-contain rounded shadow-2xl" />
-          <div class="flex items-center gap-4">
-            <p v-if="lightbox.text" class="max-w-[80vw] text-center text-white text-2xl leading-relaxed">
-              {{ lightbox.text }}
-            </p>
-            <button
-              v-if="beatAudios[lightbox.index]"
-              class="shrink-0 text-sm px-3 py-1 rounded border"
-              :class="
-                playingAudio?.index === lightbox.index ? 'border-red-400 text-red-400 hover:bg-red-400/20' : 'border-white/60 text-white/60 hover:bg-white/20'
-              "
-              @click="playAudio(lightbox.index)"
-            >
-              {{ playingAudio?.index === lightbox.index ? t("pluginMulmoScript.stop") : t("pluginMulmoScript.play") }}
-            </button>
-          </div>
+    <div v-if="lightbox" class="fixed inset-0 z-50 bg-black/80 overflow-y-auto" @click="closeLightbox">
+      <button class="fixed top-2 right-4 z-10 text-white/60 hover:text-white text-3xl leading-none" :title="t('common.close')" @click.stop="closeLightbox">
+        ✕
+      </button>
+      <div class="flex flex-col items-center gap-4 pt-4 pb-8" @click.stop>
+        <div class="flex items-center gap-4">
+          <button
+            v-if="!lightbox.isCharacter"
+            class="text-white/60 hover:text-white disabled:opacity-20 text-5xl leading-none"
+            :disabled="!hasPrev"
+            @click="lightboxMove(-1)"
+          >
+            ‹
+          </button>
+          <img :src="lightbox.src" class="max-w-[80vw] max-h-[85vh] object-contain rounded shadow-2xl" />
+          <button
+            v-if="!lightbox.isCharacter"
+            class="text-white/60 hover:text-white disabled:opacity-20 text-5xl leading-none"
+            :disabled="!hasNext"
+            @click="lightboxMove(1)"
+          >
+            ›
+          </button>
         </div>
-        <button
-          v-if="!lightbox.isCharacter"
-          class="text-white/60 hover:text-white disabled:opacity-20 text-4xl leading-none"
-          :disabled="!hasNext"
-          @click="lightboxMove(1)"
-        >
-          ›
-        </button>
+        <div v-if="lightbox.text || beatAudios[lightbox.index]" class="relative w-screen flex justify-center px-16">
+          <p v-if="lightbox.text" class="max-w-[80vw] text-center text-white leading-relaxed text-[clamp(0.8rem,1.76vw,1.6rem)]">
+            {{ lightbox.text }}
+          </p>
+          <button
+            v-if="beatAudios[lightbox.index]"
+            class="absolute top-0 right-4 text-sm px-3 py-1 rounded border border-white/60 text-white/60 hover:bg-white/20"
+            @click="playAudio(lightbox.index)"
+          >
+            {{ playingAudio?.index === lightbox.index ? t("pluginMulmoScript.stop") : t("pluginMulmoScript.play") }}
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -372,11 +372,23 @@
                 <div
                   v-for="i in beats.length"
                   :key="i - 1"
-                  class="flex-1 cursor-pointer relative"
-                  :class="i - 1 === lightbox.index ? 'bg-white/80' : i - 1 < lightbox.index ? 'bg-white/40' : 'bg-white/20'"
+                  class="group flex-1 cursor-pointer relative transition-colors"
+                  :class="
+                    i - 1 === lightbox.index
+                      ? 'bg-white/80 hover:bg-white'
+                      : i - 1 < lightbox.index
+                        ? 'bg-white/40 hover:bg-white/60'
+                        : 'bg-white/20 hover:bg-white/40'
+                  "
                   @click="jumpToBeat(i - 1)"
                 >
                   <span class="absolute -inset-y-3 inset-x-0" />
+                  <div
+                    v-if="beatTooltip(i - 1)"
+                    class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 z-20 px-2 py-1 rounded bg-black/90 text-white text-xs leading-tight w-48 max-h-[53px] overflow-hidden opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
+                  >
+                    {{ beatTooltip(i - 1) }}
+                  </div>
                 </div>
               </div>
               <div
@@ -614,6 +626,11 @@ function jumpToBeat(index: number) {
   if (wasPlaying && beatAudios[index]) {
     playAudio(index);
   }
+}
+
+function beatTooltip(index: number): string {
+  const text = effectiveBeat(index).text ?? "";
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
 }
 
 function lightboxMove(delta: number) {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -367,14 +367,17 @@
           </button>
           <div class="flex flex-col items-center">
             <img :src="lightbox.src" class="max-w-[80vw] max-h-[85vh] object-contain rounded shadow-2xl" />
-            <div v-if="!lightbox.isCharacter && beats.length > 1" class="relative w-full h-1.5">
+            <div v-if="!lightbox.isCharacter && beats.length > 1" class="relative w-full h-1">
               <div class="flex gap-1 h-full">
                 <div
                   v-for="i in beats.length"
                   :key="i - 1"
-                  class="flex-1"
+                  class="flex-1 cursor-pointer relative"
                   :class="i - 1 === lightbox.index ? 'bg-white/80' : i - 1 < lightbox.index ? 'bg-white/40' : 'bg-white/20'"
-                />
+                  @click="jumpToBeat(i - 1)"
+                >
+                  <span class="absolute -inset-y-3 inset-x-0" />
+                </div>
               </div>
               <div
                 v-if="playingAudio && playingAudio.index === lightbox.index"
@@ -601,6 +604,17 @@ const hasNext = computed(() => {
   }
   return false;
 });
+
+function jumpToBeat(index: number) {
+  if (!lightbox.value) return;
+  if (index === lightbox.value.index) return;
+  if (!renderedImages[index]) return;
+  const wasPlaying = playingAudio.value !== null;
+  openLightbox(index);
+  if (wasPlaying && beatAudios[index]) {
+    playAudio(index);
+  }
+}
 
 function lightboxMove(delta: number) {
   if (!lightbox.value) return;


### PR DESCRIPTION
## Summary

Reworks the MulmoScript lightbox into a scrollable column with a custom per-beat progress bar and a clearer caption / chrome layout.

- **Scrollable lightbox**: backdrop is now `overflow-y-auto`, the close (✕) button is fixed at top-right while the rest of the content (image, prev/next arrows, progress bar, caption, play/stop) scrolls together.
- **Progress bar** under the image: equal-width segments, one per beat, with past / current / future tints. While narration audio is playing, a small white scrubber circle moves through the active segment driven by the audio element's `timeupdate` event.
- **Clickable segments**: hovering a segment brightens it one tier (`transition-colors`) and shows a custom tooltip above the bar with the first 80 chars of that beat's text. Clicking jumps the lightbox there; if audio was playing, playback resumes on the new beat.
- **Caption row**: screen-wide so the play/stop button can sit at `right-4` (aligned with the close button) while the centered text stays on-axis. Caption font scales fluidly via `clamp(0.8rem, 1.76vw, 1.6rem)`. Stop no longer flips to red — same white outline as Play.
- **Prev/next arrows** bumped to `text-5xl` so they read as full-size chrome controls.

## Test plan

- [ ] Open a MulmoScript and click a generated beat image → lightbox opens with image, progress bar flush against the image bottom, and caption + play button below.
- [ ] Verify the scrollable column actually scrolls when the image is tall enough to push the caption below the viewport, while the close ✕ stays pinned at top-right.
- [ ] Click ◀ / ▶ → image, caption, and progress bar update; if audio was playing, playback continues on the new beat.
- [ ] Press Play → scrubber circle moves smoothly through the current segment; on `ended`, lightbox advances and audio chains to the next beat.
- [ ] Hover each progress segment → segment brightens one tier; tooltip appears above with the beat's text (max 3 lines, no 4th-line peek).
- [ ] Click a non-current segment that has a rendered image → jumps to that beat (carries audio if playing).
- [ ] Click a segment with no rendered image → silently does nothing.
- [ ] Confirm the character lightbox (image-prompt thumbnails) still works and does NOT show the progress bar or prev/next arrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework the MulmoScript lightbox into a scrollable, beat-aware viewer with integrated audio progress feedback and improved caption layout.

New Features:
- Add a per-beat progress bar beneath the lightbox image with hover tooltips and a moving scrubber tied to narration audio playback.
- Allow clicking progress bar segments to jump directly to other beats while optionally continuing audio playback from the new beat.

Enhancements:
- Make the MulmoScript lightbox scrollable with a fixed close button and enlarged previous/next controls for better usability.
- Refine the caption and playback controls into a full-width toolbar that keeps text centered while aligning the play/stop button with the close control at the screen edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned lightbox modal with vertical scrolling and explicit close control
  * Larger navigation arrows for improved usability
  * Beat timeline bar supporting click-to-jump navigation
  * Playback progress indicator synchronized with audio playback
  * Timeline tooltips on hover displaying beat information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->