### PR TITLE
refactor: drop WHAT comments across 7 modules (#910 batch)

### DIFF
--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -39,25 +39,17 @@ export async function* runAgent(
   const activePlugins = getActivePlugins(role);
   const useDocker = await isDockerAvailable();
 
-  // User-defined MCP servers are read per invocation so Settings UI
-  // changes apply immediately. Disabled / malformed entries get
-  // filtered by prepareUserServers; remaining servers are merged into
-  // the --mcp-config payload below.
+  // Per-invocation read so Settings UI changes apply without a server restart.
   const userMcpRaw = loadMcpConfig().mcpServers;
   const userServers = prepareUserServers(userMcpRaw, useDocker, workspacePath);
   const hasUserServers = Object.keys(userServers).length > 0;
   const hasMcp = activePlugins.length > 0 || hasUserServers;
 
-  // Fire-and-forget pre-flight check: warn (don't block) when an
-  // npx-style stdio server points at a package npm doesn't resolve.
-  // Catches the "catalog entry pinned to a non-existent name" failure
-  // mode where Claude silently falls back to WebSearch because the
-  // MCP subprocess never starts. Cached per-package within the
-  // process lifetime — first invocation pays the network round-trip.
+  // Catches the "catalog entry pinned to a non-existent npm package" failure where the MCP subprocess never starts and
+  // Claude silently falls back to WebSearch. Fire-and-forget; per-package cache amortizes the network round-trip.
   validateStdioPackages(userServers).catch(() => {});
 
-  // On macOS sandbox, always refresh credentials from Keychain before each
-  // agent run so that expired OAuth tokens are replaced transparently.
+  // macOS sandbox: refresh from Keychain so expired OAuth tokens get replaced transparently.
   if (useDocker && process.platform === "darwin") {
     await refreshCredentials();
   }
@@ -69,8 +61,7 @@ export async function* runAgent(
     userTimezone,
   });
 
-  // In debug mode (--debug), dump the full system prompt on the first
-  // message of each session so developers can inspect what the LLM sees.
+  // --debug: dump the full system prompt on the first message of each session.
   if (!claudeSessionId && process.argv.includes("--debug")) {
     log.info("agent", "system prompt for new session:\n" + fullSystemPrompt);
   }
@@ -84,10 +75,7 @@ export async function* runAgent(
     await mkdir(dirname(mcpPaths.hostPath), { recursive: true });
   }
 
-  // Names of every MCP server (built-in + user-configured) merged
-  // into the --mcp-config payload. Only populated when `hasMcp` is
-  // true; surfaced in the spawn log under --debug so developers can
-  // verify Settings UI changes actually reach Claude Code.
+  // Surfaced in the --debug spawn log so developers can verify Settings UI changes reach Claude Code.
   let mcpServerNames: string[] = [];
   if (hasMcp) {
     const mcpConfig = buildMcpConfig({
@@ -99,21 +87,15 @@ export async function* runAgent(
       userServers,
     });
     mcpServerNames = Object.keys(mcpConfig.mcpServers).sort();
-    // Write atomically so a partially-written file can't be picked
-    // up by a concurrent claude spawn (they share the --mcp-config
-    // path under the session dir).
+    // Atomic so a concurrent claude spawn can't pick up a half-written file (they share the path under the session dir).
     await writeJsonAtomic(mcpPaths.hostPath, mcpConfig);
   }
 
-  // Fresh read on every invocation so the Settings UI can change
-  // allowedTools / MCP servers without a server restart.
+  // Per-invocation read so allowedTools / MCP-server changes apply without a server restart.
   const settings = loadSettings();
   const userServerAllowedTools = userServerAllowedToolNames(userServers, useDocker);
 
-  // Don't persist raw sessionId into log sinks (esp. the retained
-  // file sink). A boolean presence flag is enough for operational
-  // debugging and avoids writing identifiers that route back to a
-  // specific session into long-lived log files.
+  // Boolean presence flags only — never write raw sessionId into long-lived log sinks.
   const backend = getActiveBackend();
   const spawnLog: Record<string, unknown> = {
     backend: backend.id,
@@ -123,11 +105,7 @@ export async function* runAgent(
     resumed: Boolean(claudeSessionId),
     hasSessionId: Boolean(sessionId),
   };
-  // Under --debug only: dump the merged MCP server list so the
-  // developer can confirm Settings UI changes (catalog installs /
-  // removes, env updates) actually reach Claude Code on the next
-  // spawn. Kept out of the default log to avoid leaking server
-  // names into long-lived sinks.
+  // --debug only: kept off the default log to avoid leaking user MCP server names into long-lived sinks.
   if (process.argv.includes("--debug") && hasMcp) {
     spawnLog.mcpServers = mcpServerNames;
   }

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -24,15 +24,12 @@ export function isMcpToolEnabled(tool: McpTool): boolean {
   return (tool.requiredEnv ?? []).every((key) => !!process.env[key]);
 }
 
-// Express router ──────────────────────────────────────────────────────────────
-
 export const mcpToolsRouter = Router();
 
 interface McpToolParams {
   tool: string;
 }
 
-// GET /api/mcp-tools — returns { name, enabled, requiredEnv } for each tool (used by the role builder UI)
 mcpToolsRouter.get(API_ROUTES.mcpTools.list, (_req: Request, res: Response) => {
   res.json(
     mcpTools.map((tool) => ({
@@ -44,7 +41,6 @@ mcpToolsRouter.get(API_ROUTES.mcpTools.list, (_req: Request, res: Response) => {
   );
 });
 
-// POST /api/mcp-tools/:tool — dispatches to the right handler
 mcpToolsRouter.post(API_ROUTES.mcpTools.invoke, async (req: Request<McpToolParams, unknown, Record<string, unknown>>, res: Response) => {
   const tool = toolMap.get(req.params.tool);
   if (!tool) {

--- a/server/agent/mcp-tools/notify.ts
+++ b/server/agent/mcp-tools/notify.ts
@@ -1,24 +1,5 @@
-// `notify` MCP tool — exposes the server's notification bus to the
-// agent so the user can ask "通知して" / "monitor the build and tell
-// me when it's done" and the agent has a direct way to fire.
-//
-// Calls `publishNotification` with `kind: "push"`, which fans out
-// to:
-//   - Web bell
-//   - Bridge (if a transportId is supplied — N/A from this entry
-//     point)
-//   - macOS Reminders (#789, on darwin unless the user has set
-//     DISABLE_MACOS_REMINDER_NOTIFICATIONS=1)
-//
-// No active-user gate. If the user asks for a notification, fire it.
-//
-// `body` is optional and only forwarded when non-empty. `title` is
-// required and trimmed.
-//
-// `publishNotification` is injected via `makeNotifyTool({ publish })`
-// (#803) so unit tests can pass a mock and stay free of macOS / bell
-// side effects. The default singleton `notify` wires the real
-// implementation.
+// `publishNotification` is injected (#803) so tests can mock the macOS /
+// bell side effects.
 
 import { publishNotification } from "../../events/notifications.js";
 import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
@@ -72,5 +53,4 @@ export function makeNotifyTool(deps: NotifyToolDeps) {
   };
 }
 
-// Production singleton wired with the real publishNotification.
 export const notify = makeNotifyTool({ publish: publishNotification });

--- a/server/agent/mcp-tools/x.ts
+++ b/server/agent/mcp-tools/x.ts
@@ -79,8 +79,6 @@ function formatTweet(tweet: XTweet, author?: XUser, url?: string): string {
     .trimEnd();
 }
 
-// ── readXPost ──────────────────────────────────────────────────────────────────
-
 export const readXPost = {
   definition: {
     name: "readXPost",
@@ -124,8 +122,6 @@ export const readXPost = {
     return formatTweet(tweet, author, canonicalUrl);
   },
 };
-
-// ── searchX ───────────────────────────────────────────────────────────────────
 
 export const searchX = {
   definition: {

--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -1,41 +1,20 @@
-// Atomic file-write primitives. rename(2) is atomic on POSIX; Node's
-// Windows implementation falls back to copy+unlink which is still
-// safer than truncating the target in place. Readers always see
-// either the old file or the new file — never a half-written one.
-//
-// Moved from server/utils/file.ts (issue #366 Phase 1). The old
-// file re-exports these for backwards compat.
+// rename(2) is atomic on POSIX; Node's Windows fallback (copy+unlink) is still safer than truncating in place.
+// Readers always see either the old file or the new — never a half-written one.
 
 import { mkdirSync, promises, renameSync, unlinkSync, writeFileSync } from "fs";
 import path from "path";
 import { shortId } from "../id.js";
 
 export interface WriteAtomicOptions {
-  /** File mode for the final file (e.g. `0o600` for secrets). */
   mode?: number;
-  /**
-   * If true, append a short opaque id (`shortId()`) to the tmp
-   * filename to avoid collisions at the OS level when multiple
-   * writers target the same final path concurrently (e.g.
-   * chat-index has this concern).
-   * Default false — a single `${path}.tmp` is fine for most callers.
-   */
+  // Adds shortId() to the tmp filename so concurrent writers to the same path don't collide at the OS layer
+  // (chat-index hits this).
   uniqueTmp?: boolean;
 }
 
-// ── Windows rename retry ────────────────────────────────────────
-//
-// On Windows, `rename` (MoveFileEx with MOVEFILE_REPLACE_EXISTING) can
-// transiently fail with EPERM or EBUSY when antivirus / Search
-// Indexer / Defender momentarily holds a handle on the tmp file or
-// destination file. The failure window is tiny (usually <100ms) and
-// the rename succeeds on a retry.
-//
-// On POSIX, `rename` is atomic and overwrites unconditionally. EPERM
-// there means a real permission problem (read-only filesystem, sticky
-// bit, cross-device link) — retrying wouldn't help and would only add
-// latency before the inevitable throw. So the retry loop is gated to
-// Windows.
+// On Windows, AV / Search Indexer / Defender briefly hold handles and rename trips EPERM/EBUSY/EACCES. Retry loop is
+// gated to Windows because POSIX EPERM means a real perm problem (read-only fs, sticky, cross-device) — retrying
+// just adds latency before the inevitable throw.
 const IS_WINDOWS = process.platform === "win32";
 const RENAME_RETRY_DELAYS_MS = [30, 100, 300] as const;
 
@@ -62,10 +41,7 @@ async function renameWithWindowsRetry(fromPath: string, toPath: string): Promise
   await promises.rename(fromPath, toPath);
 }
 
-// Sync sleep that parks the thread instead of burning CPU. Only
-// invoked on the transient-Windows-rename path, so the total worst-
-// case block is the sum of RENAME_RETRY_DELAYS_MS (~430ms) and only
-// triggers under AV/indexer contention.
+// Atomics.wait parks the thread instead of busy-spinning. Only on the Windows-rename retry path, total ≤ ~430ms.
 const SYNC_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
 function sleepSync(millis: number): void {
   Atomics.wait(SYNC_SLEEP_BUF, 0, 0, millis);
@@ -84,23 +60,11 @@ function renameSyncWithWindowsRetry(fromPath: string, toPath: string): void {
   renameSync(fromPath, toPath);
 }
 
-// Binary writes (PNGs, etc.) come in as Uint8Array / Buffer. Strings
-// stay text-encoded as utf-8. Forcing utf-8 on a Uint8Array would
-// re-encode the bytes, which is exactly what we don't want for
-// images. Pick the encoding option per content type.
+// Forcing utf-8 on a Uint8Array would re-encode the bytes — wrong for PNGs and other binary blobs.
 function writeOptionsFor(content: string | Uint8Array, mode: number | undefined): { encoding?: "utf-8"; mode?: number } {
   return typeof content === "string" ? { encoding: "utf-8", mode } : { mode };
 }
 
-/**
- * Write `content` to `filePath` atomically. The parent directory is
- * created if missing. The tmp file is cleaned up on failure so a
- * crashed partial write can't wedge the next try.
- *
- * Accepts either text (utf-8 encoded) or binary content. Buffers
- * extend `Uint8Array`, so PNG / other binary blobs pass through
- * without conversion.
- */
 export async function writeFileAtomic(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): Promise<void> {
   const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   await promises.mkdir(path.dirname(filePath), { recursive: true });
@@ -113,12 +77,6 @@ export async function writeFileAtomic(filePath: string, content: string | Uint8A
   }
 }
 
-/**
- * Synchronous atomic write for callers that need it (e.g. server
- * startup, config saves that must complete before the next line).
- * Same contract as `writeFileAtomic` but blocking. Binary content
- * (Buffer / Uint8Array) is supported the same way.
- */
 export function writeFileAtomicSync(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): void {
   const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
   mkdirSync(path.dirname(filePath), { recursive: true });

--- a/server/utils/files/html-io.ts
+++ b/server/utils/files/html-io.ts
@@ -1,8 +1,3 @@
-// Domain I/O: HTML scratch buffer
-//   artifacts/html-scratch/current.html
-//
-// Optional `root` for test DI.
-
 import path from "node:path";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -8,8 +8,7 @@ import { resolveWithinRoot } from "./safe.js";
 
 const IMAGES_DIR = WORKSPACE_PATHS.images;
 
-// Cached realpath of the images directory. resolveWithinRoot requires
-// its root argument to be a realpath so symlinks are handled correctly.
+// resolveWithinRoot needs a realpath as its root so symlinks resolve correctly.
 let imagesDirReal: string | null = null;
 
 async function ensureImagesDir(): Promise<string> {
@@ -19,13 +18,9 @@ async function ensureImagesDir(): Promise<string> {
   return imagesDirReal;
 }
 
-// Resolve a workspace-relative image path (e.g. "images/abc123.png")
-// into an absolute path that is guaranteed to be inside the images
-// directory. Throws on traversal attempts or non-existent files.
+// Throws on traversal. Strips a leading "images/" so callers can pass either the stored form or bare filename.
 async function safeResolve(relativePath: string): Promise<string> {
   const root = await ensureImagesDir();
-  // Strip the leading "images/" prefix so the caller can pass either
-  // "images/abc.png" (the stored form) or just "abc.png".
   const name = relativePath.replace(new RegExp(`^${WORKSPACE_DIRS.images}/`), "");
   const result = resolveWithinRoot(root, name);
   if (!result) {
@@ -34,12 +29,7 @@ async function safeResolve(relativePath: string): Promise<string> {
   return result;
 }
 
-/** Save raw base64 (no data URI prefix) as a PNG file. New files
- *  land under `images/YYYY/MM/` (UTC) so the dir doesn't accumulate
- *  unbounded — see #764. Returns the workspace-relative path.
- *  Atomic: a crashed write can't leave a half-written PNG on disk
- *  (#881 v1). `writeFileAtomic` accepts Buffer directly, so the raw
- *  PNG bytes pass through without re-encoding. */
+// #764 sharded under images/YYYY/MM/ (UTC). Buffer pass-through avoids re-encoding the PNG bytes.
 export async function saveImage(base64Data: string): Promise<string> {
   await ensureImagesDir();
   const partition = yearMonthUtc();
@@ -49,28 +39,22 @@ export async function saveImage(base64Data: string): Promise<string> {
   return path.posix.join(WORKSPACE_DIRS.images, partition, filename);
 }
 
-/** Overwrite an existing image file. The relativePath must start with "images/".
- *  Atomic — see {@link saveImage}. */
 export async function overwriteImage(relativePath: string, base64Data: string): Promise<void> {
   const absPath = await safeResolve(relativePath);
   await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
 }
 
-/** Read an image file and return raw base64 (no data URI prefix). */
 export async function loadImageBase64(relativePath: string): Promise<string> {
   const absPath = await safeResolve(relativePath);
   const buf = await readFile(absPath);
   return buf.toString("base64");
 }
 
-/** Convert a data URI to raw base64. */
 export function stripDataUri(dataUri: string): string {
   return dataUri.replace(/^data:image\/[^;]+;base64,/, "");
 }
 
-/** Check if a string is a file reference (not a data URI). Accepts
- *  arbitrary depth under `images/` (e.g. `images/2026/04/abc.png`)
- *  so the per-month sharded paths from `saveImage` still validate. */
+// Accepts arbitrary depth so saveImage's images/YYYY/MM/abc.png still validates.
 export function isImagePath(value: string): boolean {
   return value.startsWith(`${WORKSPACE_DIRS.images}/`) && value.endsWith(".png");
 }

--- a/server/utils/files/index.ts
+++ b/server/utils/files/index.ts
@@ -1,15 +1,5 @@
-// Consolidated workspace file I/O (#366).
-//
-// This barrel re-exports every public helper so call sites can do:
-//
-//   import { writeFileAtomic, readWorkspaceText } from "../utils/files/index.js";
-//
-// Grouped by concern:
-//
-//   atomic.ts        — write-then-rename primitives
-//   safe.ts          — ENOENT-swallowing wrappers (stat, readdir, readText, resolveWithinRoot)
-//   json.ts          — JSON sync read + async atomic write
-//   workspace-io.ts  — workspace-aware helpers (path resolve + I/O in one call)
+// #366: barrel for workspace file I/O. atomic = write-rename, safe = ENOENT-swallowing, json = sync read + atomic
+// write, workspace-io = path resolve + I/O in one call.
 
 export { writeFileAtomic, writeFileAtomicSync, type WriteAtomicOptions } from "./atomic.js";
 
@@ -36,7 +26,6 @@ export {
   ensureDirUnder,
 } from "./workspace-io.js";
 
-// ── Domain I/O ──────────────────────────────────────────────────
 export * from "./session-io.js";
 export * from "./todos-io.js";
 export * from "./scheduler-io.js";

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -1,14 +1,3 @@
-// Domain I/O: workspace journal (summaries)
-//   conversations/summaries/_state.json        — journal state
-//   conversations/summaries/_index.md           — browseable index
-//   conversations/summaries/daily/YYYY/MM/DD.md — daily summaries
-//   conversations/summaries/topics/<slug>.md    — topic files
-//   conversations/summaries/archive/topics/     — archived topics
-//
-// All functions take optional `root` for test DI.
-// Path helpers (summariesRoot, dailyPathFor, topicPathFor) live in
-// journal/paths.ts — this module wraps them with I/O.
-
 import path from "node:path";
 import fsp from "node:fs/promises";
 import { workspacePath } from "../../workspace/paths.js";
@@ -20,8 +9,6 @@ import { summariesRoot, dailyPathFor, topicPathFor, TOPICS_DIR, INDEX_FILE, STAT
 import { statSync } from "node:fs";
 
 const root = (rootOverride?: string) => rootOverride ?? workspacePath;
-
-// ── State ───────────────────────────────────────────────────────
 
 export function journalStateExists(rootOverride?: string): boolean {
   const filePath = path.join(summariesRoot(root(rootOverride)), STATE_FILE);
@@ -49,14 +36,10 @@ export async function writeJournalState(state: unknown, rootOverride?: string): 
   await writeFileAtomic(filePath, JSON.stringify(state, null, 2));
 }
 
-// ── Index ───────────────────────────────────────────────────────
-
 export async function writeJournalIndex(markdown: string, rootOverride?: string): Promise<void> {
   const filePath = path.join(summariesRoot(root(rootOverride)), INDEX_FILE);
   await writeFileAtomic(filePath, markdown);
 }
-
-// ── Daily summaries ─────────────────────────────────────────────
 
 export async function readDailySummary(date: string, rootOverride?: string): Promise<string | null> {
   try {
@@ -74,15 +57,12 @@ export async function writeDailySummary(date: string, content: string, rootOverr
   await writeFileAtomic(dailyPathFor(root(rootOverride), date), content);
 }
 
-// ── Topics ──────────────────────────────────────────────────────
-
 export async function readTopicFile(slug: string, rootOverride?: string): Promise<string | null> {
   try {
     return await fsp.readFile(topicPathFor(root(rootOverride), slug), "utf-8");
   } catch (err) {
     if (isEnoent(err)) return null;
-    // EACCES/EPERM must propagate — swallowing them would cause
-    // appendOrCreateTopic to clobber an unreadable file.
+    // EACCES/EPERM must propagate — swallowing them would let appendOrCreateTopic clobber an unreadable file.
     throw err;
   }
 }
@@ -91,7 +71,6 @@ export async function writeTopicFile(slug: string, content: string, rootOverride
   await writeFileAtomic(topicPathFor(root(rootOverride), slug), content);
 }
 
-/** Append content to an existing topic, or create a new file. */
 export async function appendOrCreateTopic(slug: string, content: string, rootOverride?: string): Promise<"created" | "updated"> {
   const existing = await readTopicFile(slug, rootOverride);
   if (existing === null) {
@@ -102,7 +81,6 @@ export async function appendOrCreateTopic(slug: string, content: string, rootOve
   return "updated";
 }
 
-/** List topic slugs (filenames without .md). */
 export async function listTopicSlugs(rootOverride?: string): Promise<string[]> {
   const dir = path.join(summariesRoot(root(rootOverride)), TOPICS_DIR);
   try {
@@ -115,7 +93,6 @@ export async function listTopicSlugs(rootOverride?: string): Promise<string[]> {
   }
 }
 
-/** Read all topic files at once. Returns slug→content map. */
 export async function readAllTopicFiles(rootOverride?: string): Promise<Map<string, string>> {
   const dir = path.join(summariesRoot(root(rootOverride)), TOPICS_DIR);
   const out = new Map<string, string>();
@@ -137,8 +114,7 @@ export async function readAllTopicFiles(rootOverride?: string): Promise<Map<stri
   return out;
 }
 
-/** Move a topic to the archive directory. Returns false if the
- *  source doesn't exist or the move fails. */
+// Returns false if the source doesn't exist or the move fails.
 export async function archiveTopic(slug: string, rootOverride?: string): Promise<boolean> {
   const src = topicPathFor(root(rootOverride), slug);
   const dst = path.join(summariesRoot(root(rootOverride)), ARCHIVE_DIR, TOPICS_DIR, `${slug}.md`);
@@ -153,8 +129,6 @@ export async function archiveTopic(slug: string, rootOverride?: string): Promise
     return false;
   }
 }
-
-// ── Daily file listing ──────────────────────────────────────────
 
 export interface DailyFileEntry {
   year: string;
@@ -199,8 +173,6 @@ async function safeReaddir(dir: string): Promise<string[]> {
     return [];
   }
 }
-
-// ── Archived topic count ────────────────────────────────────────
 
 export async function countArchivedTopics(rootOverride?: string): Promise<number> {
   const dir = path.join(summariesRoot(root(rootOverride)), ARCHIVE_DIR, TOPICS_DIR);

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -1,26 +1,9 @@
-// JSON file helpers — synchronous read, async atomic write.
-//
-// Moved from server/utils/file.ts (issue #366 Phase 1). The old
-// file re-exports these for backwards compat.
-//
-// `saveJsonFile` (sync, non-atomic write) was removed in #881 v2 —
-// it had no production callers and the synchronous code path
-// couldn't offer the atomic-rename guarantee that `writeJsonAtomic`
-// already does. Reach for `writeJsonAtomic` from now on.
-
 import { promises, readFileSync } from "fs";
 import { writeFileAtomic } from "./atomic.js";
 import { isEnoent } from "./safe.js";
 import { log } from "../../system/logger/index.js";
 
-// ── Sync helpers ────────────────────────────────────────────────
-
-/**
- * Read and parse a JSON file synchronously. Returns `defaultValue`
- * on ENOENT (file not yet created) or JSON corruption (logs the
- * error but doesn't crash — user data files must not take down the
- * server). Rethrows unexpected errors (EACCES, EPERM).
- */
+// Returns defaultValue on ENOENT or parse failure (user data files must not take down the server); rethrows EACCES/EPERM.
 export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
   let raw: string;
   try {
@@ -44,19 +27,10 @@ export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
   }
 }
 
-// ── Async ───────────────────────────────────────────────────────
-
-/**
- * JSON-pretty-print `data` and write atomically.
- */
 export async function writeJsonAtomic(filePath: string, data: unknown, opts: Parameters<typeof writeFileAtomic>[2] = {}): Promise<void> {
   await writeFileAtomic(filePath, JSON.stringify(data, null, 2), opts);
 }
 
-/**
- * Read a JSON file and parse it. Returns null if the file is missing,
- * unreadable, or malformed.
- */
 export async function readJsonOrNull<T>(filePath: string): Promise<T | null> {
   try {
     const content = await promises.readFile(filePath, "utf-8");

--- a/server/utils/files/markdown-image-fill.ts
+++ b/server/utils/files/markdown-image-fill.ts
@@ -1,14 +1,5 @@
-// Replace `![alt](__too_be_replaced_image_path__)` placeholders in
-// markdown with real Gemini-generated images saved to the workspace.
-// Lives under `server/utils/files/` because it sits at the seam
-// between markdown content and on-disk image artifacts; route
-// handlers (e.g. `presentDocument`) just hand off the markdown.
-//
-// Logging policy: every image generation emits start / ok / failed /
-// no-data lines, and every batch emits a tally. Per the timeout-policy
-// comment in `server/agent/mcp-server.ts`, generative-AI work MUST be
-// observable — silent partial failures were the exact failure mode
-// that hid the 10 s bridge-timeout bug.
+// Per the timeout-policy comment in server/agent/mcp-server.ts, generative-AI work MUST be observable — silent
+// partial failures hid the 10s bridge-timeout bug. Every image emits start/ok/failed/no-data + per-batch tally.
 import { generateGeminiImageFromPrompt, isGeminiAvailable } from "../gemini.js";
 import { errorMessage } from "../errors.js";
 import { promptMeta } from "../promptMeta.js";
@@ -21,9 +12,7 @@ const LOG_PREFIX = "present-document";
 async function generateImageFile(prompt: string, index: number, total: number): Promise<string | null> {
   if (!isGeminiAvailable()) return null;
   const startedAt = Date.now();
-  // Prompt is user-controlled and may contain pasted URLs / emails /
-  // credentials, so we log a `{ length, sha256 }` fingerprint instead
-  // of a raw prefix. See `server/utils/promptMeta.ts`.
+  // Prompt is user-controlled and may contain credentials/PII; promptMeta logs {length, sha256} instead of raw bytes.
   const meta = promptMeta(prompt);
   log.info(LOG_PREFIX, "image gen start", {
     index,
@@ -71,33 +60,13 @@ function logBatchTally(results: PlaceholderResult[], total: number, batchStarted
 }
 
 export function buildReplacement(prompt: string, url: string | null): string {
-  // `url` is workspace-relative (e.g. "artifacts/images/2026/04/x.png").
-  // Emit a workspace-root absolute ref ("/...") so the resolution is
-  // independent of where the markdown file itself lands on disk.
-  // Since #764, documents shard under `artifacts/documents/YYYY/MM/`,
-  // and `rewriteMarkdownImageRefs` (front-end) treats a leading "/"
-  // as "rooted at workspace" — so a markdown reference like
-  // "![alt](/artifacts/images/...)" works regardless of the document's
-  // depth. A relative path computed against the unsharded root would
-  // instead be off by two directory levels and 404 in the canvas.
+  // Workspace-rooted "/…" so the ref resolves the same regardless of document depth (#764 sharded documents under
+  // artifacts/documents/YYYY/MM/; a relative path would be off by two directory levels).
   if (url) return `![${prompt}](/${url})`;
-  // No image: keep the alt text visible as an italic marker so the
-  // operator can still see what *would* have been generated.
+  // No image: leave the alt text as an italic marker so the operator can see what *would* have been generated.
   return `*🖼️ Image: ${prompt}*`;
 }
 
-/**
- * Replace every `![alt](__too_be_replaced_image_path__)` placeholder
- * in the input markdown with a real Gemini-generated image.
- *
- * - When `GEMINI_API_KEY` is unset, every placeholder degrades to an
- *   italic text marker (`*🖼️ Image: <alt>*`) so the document still
- *   renders without broken image refs.
- * - On per-image failure, the same fallback applies for that one
- *   placeholder. Other placeholders proceed independently.
- * - All generation runs in parallel via `Promise.all` — typical 9-image
- *   batches finish in 15-25 s rather than per-image-serial.
- */
 export async function fillMarkdownImagePlaceholders(markdown: string): Promise<string> {
   const matches = [...markdown.matchAll(IMAGE_PLACEHOLDER)];
   if (matches.length === 0) return markdown;

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -5,17 +5,7 @@ import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
 import { buildArtifactPathRandom } from "./naming.js";
 
-/**
- * Save markdown content as a file. Returns the workspace-relative path.
- * `prefix` is slugified; a random id is always appended to prevent
- * collisions between concurrent writers sharing the same prefix.
- *
- * `buildArtifactPathRandom` injects a `YYYY/MM` partition (#764) and
- * `writeFileAtomic` creates missing parents itself, so callers don't
- * need a separate `mkdir` step.
- *
- * Atomic: a crashed write can't leave a half-written .md (#881 v1).
- */
+// Random-id suffix prevents collisions between concurrent writers sharing a prefix; #764 sharded under YYYY/MM.
 export async function saveMarkdown(content: string, prefix: string): Promise<string> {
   const relPath = buildArtifactPathRandom(WORKSPACE_DIRS.markdowns, prefix, ".md", "document");
   const absPath = path.join(workspacePath, relPath);
@@ -23,24 +13,17 @@ export async function saveMarkdown(content: string, prefix: string): Promise<str
   return relPath;
 }
 
-/** Read a markdown file and return its content. */
 export async function loadMarkdown(relativePath: string): Promise<string> {
   const absPath = path.join(workspacePath, relativePath);
   return readFile(absPath, "utf-8");
 }
 
-/** Overwrite an existing markdown file. Atomic — see {@link saveMarkdown}. */
 export async function overwriteMarkdown(relativePath: string, content: string): Promise<void> {
   const absPath = path.join(workspacePath, relativePath);
   await writeFileAtomic(absPath, content);
 }
 
-/** Check if a string is a markdown file path (not inline content).
- *  Rejects traversal attempts like `artifacts/documents/../outside.md`
- *  so callers can rely on prefix+suffix alone. Mirrors the
- *  `isSpreadsheetPath` policy. The server-side `path.join` in
- *  `overwriteMarkdown` does NOT normalize traversal on its own, so
- *  this gate is the primary defence — keep it strict. */
+// Strict — overwriteMarkdown's path.join doesn't normalize traversal, so this gate is the primary defence.
 export function isMarkdownPath(value: string): boolean {
   if (!value.startsWith(`${WORKSPACE_DIRS.markdowns}/`)) return false;
   if (!value.endsWith(".md")) return false;

--- a/server/utils/files/naming.ts
+++ b/server/utils/files/naming.ts
@@ -1,59 +1,23 @@
-// Workspace file naming conventions.
-//
-// Centralizes the `slug-${Date.now()}.ext` pattern used across
-// multiple plugins (chart, presentHtml, markdown, spreadsheet, image).
-// Call sites pass a human title + extension; this module handles
-// slugification and timestamp suffixing.
-
 import path from "node:path";
 import { shortId } from "../id.js";
 import { slugify } from "../slug.js";
 
-/**
- * UTC-based `YYYY/MM` partition segment for new artifacts (#764).
- * Keeps each artifact directory from accumulating a flat list of
- * thousands of files. UTC is used (rather than local time) so a
- * workspace synced across machines / timezones still groups files
- * into the same bucket.
- *
- * Exported for unit tests and callers that need the partition without
- * also generating a filename (e.g. saveImage / saveSpreadsheet).
- */
+// #764 partitioning. UTC (not local) so a workspace synced across timezones still groups into the same bucket.
 export function yearMonthUtc(now: Date = new Date()): string {
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, "0");
   return `${year}/${month}`;
 }
 
-/**
- * Build a workspace-relative path for a new artifact file.
- *
- * @param dir  Workspace-relative directory (e.g. WORKSPACE_DIRS.charts)
- * @param title  Human-readable title (slugified for the filename)
- * @param ext  File extension with leading dot (e.g. ".html", ".json")
- * @param fallbackSlug  Slug to use when title is empty/undefined
- * @returns  Workspace-relative path like "artifacts/charts/2026/04/sales-1776135210389.chart.json"
- */
 export function buildArtifactPath(dir: string, title: string | undefined, ext: string, fallbackSlug = "file"): string {
   const slug = title ? slugify(title) || fallbackSlug : fallbackSlug;
   const fname = `${slug}-${Date.now()}${ext}`;
   return path.posix.join(dir, yearMonthUtc(), fname);
 }
 
-/**
- * Like `buildArtifactPath`, but appends a random hex id instead of a
- * timestamp. Use when multiple concurrent writers may share the same
- * prefix within the same millisecond (e.g. LLM-supplied `filenamePrefix`
- * on the `presentDocument` route).
- *
- * @param dir  Workspace-relative directory
- * @param prefix  Human-readable prefix (slugified via `slugify`)
- * @param ext  File extension with leading dot
- * @param fallbackSlug  Slug to use when the sanitized prefix is empty
- */
+// shortId variant for concurrent writers that share a prefix within the same millisecond (presentDocument route).
 export function buildArtifactPathRandom(dir: string, prefix: string, ext: string, fallbackSlug = "file"): string {
-  // Pass fallbackSlug as slugify's default so it overrides slugify's
-  // built-in "page" default when `prefix` sanitizes to empty.
+  // Pass fallbackSlug as slugify's default so it overrides slugify's built-in "page" when `prefix` sanitizes to empty.
   const slug = slugify(prefix, fallbackSlug);
   const fname = `${slug}-${shortId()}${ext}`;
   return path.posix.join(dir, yearMonthUtc(), fname);

--- a/server/utils/files/reference-dirs-io.ts
+++ b/server/utils/files/reference-dirs-io.ts
@@ -1,9 +1,3 @@
-// Domain I/O for reference directories.
-//
-// Reads/writes config/reference-dirs.json and checks host paths.
-// All fs access is funneled through shared helpers so path changes
-// propagate from a single constant.
-
 import { mkdirSync, statSync } from "fs";
 import path from "path";
 import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
@@ -17,7 +11,7 @@ function configPath(root: string): string {
   return path.join(root, WORKSPACE_DIRS.configs, CONFIG_FILE_NAME);
 }
 
-/** Read reference-dirs.json. Returns [] on missing/corrupt file. */
+// Returns [] on missing/corrupt file.
 export function readReferenceDirsJson(root?: string): unknown[] {
   const filePath = configPath(root ?? workspacePath);
   const parsed = loadJsonFile<unknown>(filePath, []);
@@ -28,14 +22,12 @@ export function readReferenceDirsJson(root?: string): unknown[] {
   return parsed;
 }
 
-/** Write reference-dirs.json atomically. Creates config/ if needed. */
 export function writeReferenceDirsJson(entries: readonly unknown[], root?: string): void {
   const filePath = configPath(root ?? workspacePath);
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileAtomicSync(filePath, JSON.stringify(entries, null, 2));
 }
 
-/** Check whether a host path exists and is a directory. */
 export function isExistingDirectory(hostPath: string): boolean {
   try {
     return statSync(hostPath).isDirectory();

--- a/server/utils/files/roles-io.ts
+++ b/server/utils/files/roles-io.ts
@@ -1,8 +1,3 @@
-// Domain I/O: custom roles
-//   config/roles/<id>.json
-//
-// Optional `root` for test DI.
-
 import path from "node:path";
 import { mkdirSync, statSync, unlinkSync } from "node:fs";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -16,7 +11,6 @@ function roleFilePath(roleId: string, workspaceRoot?: string): string {
   return path.join(root(workspaceRoot), WORKSPACE_DIRS.roles, `${roleId}.json`);
 }
 
-/** Check if a custom role file exists. */
 export function roleExists(roleId: string, workspaceRoot?: string): boolean {
   try {
     statSync(roleFilePath(roleId, workspaceRoot));
@@ -26,7 +20,7 @@ export function roleExists(roleId: string, workspaceRoot?: string): boolean {
   }
 }
 
-/** Delete a custom role file. Returns false if not found. */
+// Returns false if not found.
 export function deleteRole(roleId: string, workspaceRoot?: string): boolean {
   try {
     unlinkSync(roleFilePath(roleId, workspaceRoot));
@@ -37,7 +31,6 @@ export function deleteRole(roleId: string, workspaceRoot?: string): boolean {
   }
 }
 
-/** Save (create or overwrite) a custom role file atomically. */
 export function saveRole(roleId: string, data: unknown, workspaceRoot?: string): void {
   const dir = path.join(root(workspaceRoot), WORKSPACE_DIRS.roles);
   mkdirSync(dir, { recursive: true });

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -1,22 +1,14 @@
-// Safe filesystem wrappers that swallow ENOENT / EACCES so callers
-// can do `if (result === null)` instead of try/catch boilerplate.
-//
-// `resolveWithinRoot` is the realpath-based path-traversal check
-// that underpins every endpoint serving files out of the workspace.
-//
-// Moved from server/utils/fs.ts (issue #366 Phase 1). The old
-// file re-exports these for backwards compat.
+// Wrappers that swallow ENOENT/EACCES so callers branch on `result === null` instead of try/catch.
+// resolveWithinRoot is the realpath-based traversal check used by every endpoint serving workspace files.
 
 import { Dirent, Stats, promises, readFileSync, readdirSync, realpathSync, statSync } from "fs";
 import path from "path";
 import { isErrorWithCode } from "../types.js";
 
-/** Check if an error is ENOENT (file/dir not found). */
 export function isEnoent(err: unknown): boolean {
   return isErrorWithCode(err) && err.code === "ENOENT";
 }
 
-/** Read a binary file by absolute path. Null on ENOENT. */
 export function readBinarySafeSync(absPath: string): Buffer | null {
   try {
     return readFileSync(absPath);
@@ -25,7 +17,6 @@ export function readBinarySafeSync(absPath: string): Buffer | null {
   }
 }
 
-/** Read a text file by absolute path (async). Null on ENOENT. */
 export async function readTextSafe(absPath: string): Promise<string | null> {
   try {
     return await promises.readFile(absPath, "utf-8");
@@ -34,7 +25,6 @@ export async function readTextSafe(absPath: string): Promise<string | null> {
   }
 }
 
-/** Read a text file by absolute path (sync). Null on ENOENT. */
 export function readTextSafeSync(absPath: string): string | null {
   try {
     return readFileSync(absPath, "utf-8");
@@ -83,13 +73,7 @@ export async function readTextOrNull(file: string): Promise<string | null> {
   }
 }
 
-/**
- * Resolve a relative path against a root, ensuring the result stays
- * inside the root after symlink resolution. Returns null on traversal
- * or if either path doesn't exist on disk.
- *
- * `rootReal` MUST already be a realpath.
- */
+// `rootReal` MUST already be a realpath. Returns null on traversal or if either path doesn't exist on disk.
 export function resolveWithinRoot(rootReal: string, relPath: string): string | null {
   const normalized = path.normalize(relPath || "");
   const resolved = path.resolve(rootReal, normalized);

--- a/server/utils/files/scheduler-io.ts
+++ b/server/utils/files/scheduler-io.ts
@@ -1,8 +1,3 @@
-// Domain I/O: scheduler items
-//   data/scheduler/items.json
-//
-// Sync API. Optional `root` for test DI.
-
 import { WORKSPACE_FILES } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
 import { resolvePath } from "./workspace-io.js";

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -1,9 +1,3 @@
-// Domain I/O for scheduler override config.
-//
-// Reads/writes config/scheduler/overrides.json. Each key is a
-// system task ID (e.g. "system:journal"), value overrides the
-// default schedule.
-
 import { mkdirSync } from "fs";
 import path from "path";
 import { workspacePath } from "../../workspace/paths.js";
@@ -14,15 +8,14 @@ import { log } from "../../system/logger/index.js";
 import { isRecord } from "../types.js";
 
 export interface ScheduleOverride {
-  /** Override interval in milliseconds (for interval-type schedules). */
   intervalMs?: number;
-  /** Override time "HH:MM" in UTC (for daily-type schedules). */
+  // "HH:MM" in UTC for daily schedules.
   time?: string;
 }
 
 export type ScheduleOverrides = Record<string, ScheduleOverride>;
 
-/** Strict HH:MM validation — rejects 99:99 etc. */
+// Strict HH:MM — rejects 99:99 etc.
 export const UTC_HH_MM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 function isScheduleOverride(value: unknown): value is ScheduleOverride {
@@ -30,7 +23,6 @@ function isScheduleOverride(value: unknown): value is ScheduleOverride {
   const obj = value;
   const hasInterval = "intervalMs" in obj && typeof obj.intervalMs === "number" && obj.intervalMs > 0;
   const hasTime = "time" in obj && typeof obj.time === "string" && UTC_HH_MM_RE.test(obj.time);
-  // At least one valid field required
   return hasInterval || hasTime;
 }
 
@@ -38,7 +30,7 @@ function overridesPath(root?: string): string {
   return path.join(root ?? workspacePath, WORKSPACE_FILES.schedulerOverrides);
 }
 
-/** Load schedule overrides. Filters out invalid entries with a warning. */
+// Filters out invalid entries with a warning.
 export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
   const raw = loadJsonFile<unknown>(overridesPath(root), {});
   if (!isRecord(raw)) {
@@ -56,7 +48,6 @@ export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
   return result;
 }
 
-/** Save schedule overrides atomically. Creates directory if needed. */
 export function saveSchedulerOverrides(overrides: ScheduleOverrides, root?: string): void {
   const filePath = overridesPath(root);
   mkdirSync(path.dirname(filePath), { recursive: true });

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -1,9 +1,3 @@
-// Domain I/O: chat sessions
-//   conversations/chat/<id>.json   — metadata
-//   conversations/chat/<id>.jsonl  — event log
-//
-// All functions take optional `root` for test DI.
-
 import { appendFile } from "fs/promises";
 import path from "node:path";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -13,7 +7,6 @@ import { readTextUnder, writeTextUnder, resolvePath, ensureWorkspaceDir } from "
 const CHAT = WORKSPACE_DIRS.chat;
 const root = (rootOverride?: string) => rootOverride ?? workspacePath;
 
-/** Ensure the chat directory exists. Called once at session start. */
 export function ensureChatDir(): void {
   ensureWorkspaceDir(CHAT);
 }
@@ -25,8 +18,6 @@ function metaRel(sessionId: string): string {
 function jsonlRel(sessionId: string): string {
   return path.posix.join(CHAT, `${sessionId}.jsonl`);
 }
-
-// ── Meta ────────────────────────────────────────────────────────
 
 export interface SessionMeta {
   roleId?: string;
@@ -40,7 +31,6 @@ export interface SessionMeta {
 
 export type ReadMetaResult = { kind: "missing" } | { kind: "ok"; meta: SessionMeta } | { kind: "corrupt"; raw: string };
 
-/** Read session metadata with full outcome discrimination. */
 export async function readSessionMetaFull(sessionId: string, rootOverride?: string): Promise<ReadMetaResult> {
   const raw = await readTextUnder(root(rootOverride), metaRel(sessionId));
   if (raw === null) return { kind: "missing" };
@@ -51,8 +41,7 @@ export async function readSessionMetaFull(sessionId: string, rootOverride?: stri
   }
 }
 
-/** Convenience: returns the meta or null. Treats corrupt as null
- *  (callers that need to distinguish use readSessionMetaFull). */
+// Treats corrupt as null — callers that need to distinguish use readSessionMetaFull.
 export async function readSessionMeta(sessionId: string, rootOverride?: string): Promise<SessionMeta | null> {
   const result = await readSessionMetaFull(sessionId, rootOverride);
   return result.kind === "ok" ? result.meta : null;
@@ -103,18 +92,11 @@ export async function updateHasUnread(sessionId: string, hasUnread: boolean, roo
   await writeSessionMeta(sessionId, { ...meta, hasUnread }, rootOverride);
 }
 
-// ── Jsonl ───────────────────────────────────────────────────────
-
 export function sessionJsonlAbsPath(sessionId: string, rootOverride?: string): string {
   return resolvePath(root(rootOverride), jsonlRel(sessionId));
 }
 
-/**
- * Resolve the absolute path of a session's metadata JSON file. The
- * jsonl variant is the event log; this one is the sidecar that holds
- * `hasUnread`, `roleId`, `startedAt`, `origin`, etc. Its mtime bumps
- * whenever any of those fields change via `writeSessionMeta`.
- */
+// .json sidecar to the event-log jsonl. mtime bumps on every writeSessionMeta — used as a "session changed" signal.
 export function sessionMetaAbsPath(sessionId: string, rootOverride?: string): string {
   return resolvePath(root(rootOverride), metaRel(sessionId));
 }
@@ -123,13 +105,7 @@ export async function readSessionJsonl(sessionId: string, rootOverride?: string)
   return readTextUnder(root(rootOverride), jsonlRel(sessionId));
 }
 
-/**
- * Append a single line to the session event log (JSONL format).
- *
- * The function **ensures a trailing `\n`** — callers pass the raw
- * content and don't need to worry about line termination. This
- * prevents JSONL parse failures from missing newlines.
- */
+// Always ends with `\n` to prevent JSONL parse failures from a missing terminator.
 export async function appendSessionLine(sessionId: string, line: string, rootOverride?: string): Promise<void> {
   const normalized = line.endsWith("\n") ? line : `${line}\n`;
   await appendFile(resolvePath(root(rootOverride), jsonlRel(sessionId)), normalized);

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -8,9 +8,7 @@ import { resolveWithinRoot } from "./safe.js";
 
 const SPREADSHEETS_DIR = WORKSPACE_PATHS.spreadsheets;
 
-// Cached realpath of the spreadsheets directory. resolveWithinRoot
-// requires its root argument to be a realpath so symlinks are handled
-// correctly. Matches the pattern used in image-store.ts.
+// resolveWithinRoot needs a realpath as its root so symlinks resolve correctly (same pattern as image-store).
 let spreadsheetsDirReal: string | null = null;
 
 async function ensureSpreadsheetsDir(): Promise<string> {
@@ -20,13 +18,9 @@ async function ensureSpreadsheetsDir(): Promise<string> {
   return spreadsheetsDirReal;
 }
 
-// Resolve a workspace-relative spreadsheet path (e.g. "spreadsheets/abc.json")
-// into an absolute path guaranteed to be inside the spreadsheets directory.
-// Throws on traversal attempts.
+// Throws on traversal. Strips a leading "spreadsheets/" so callers can pass either the stored form or bare filename.
 async function safeResolve(relativePath: string): Promise<string> {
   const root = await ensureSpreadsheetsDir();
-  // Strip the leading "spreadsheets/" prefix so callers can pass either
-  // the stored form or just the filename.
   const name = relativePath.replace(new RegExp(`^${WORKSPACE_DIRS.spreadsheets}/`), "");
   const result = resolveWithinRoot(root, name);
   if (!result) {
@@ -35,11 +29,7 @@ async function safeResolve(relativePath: string): Promise<string> {
   return result;
 }
 
-/** Save sheets array as a JSON file. New files land under
- *  `spreadsheets/YYYY/MM/` (UTC) so the dir doesn't accumulate
- *  unbounded — see #764. Returns the workspace-relative path.
- *  Atomic: writeFileAtomic creates the partition dir and prevents
- *  half-written JSON on crash (#881 v1). */
+// #764 sharded under spreadsheets/YYYY/MM/ (UTC) so the dir doesn't grow unbounded; #881 atomic.
 export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   await ensureSpreadsheetsDir();
   const partition = yearMonthUtc();
@@ -49,20 +39,15 @@ export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
   return path.posix.join(WORKSPACE_DIRS.spreadsheets, partition, filename);
 }
 
-/** Overwrite an existing spreadsheet file. Atomic — see {@link saveSpreadsheet}. */
 export async function overwriteSpreadsheet(relativePath: string, sheets: unknown[]): Promise<void> {
   const absPath = await safeResolve(relativePath);
   await writeFileAtomic(absPath, JSON.stringify(sheets));
 }
 
-/** Check if a string is a spreadsheet file path (not inline data).
- *  Rejects traversal attempts like "spreadsheets/../outside.json"
- *  so the caller can't rely on the prefix/suffix alone. */
+// Reject "spreadsheets/../outside.json" early; realpath check still runs server-side, but catch obvious cases here.
 export function isSpreadsheetPath(value: string): boolean {
   if (!value.startsWith(`${WORKSPACE_DIRS.spreadsheets}/`)) return false;
   if (!value.endsWith(".json")) return false;
-  // Forbid .. segments anywhere in the path — a realpath check still
-  // happens server-side, but this catches obvious cases early.
   const normalized = path.posix.normalize(value);
   if (normalized !== value) return false;
   if (normalized.includes("..")) return false;

--- a/server/utils/files/todos-io.ts
+++ b/server/utils/files/todos-io.ts
@@ -1,9 +1,3 @@
-// Domain I/O: todo items + status columns
-//   data/todos/todos.json     — items
-//   data/todos/columns.json   — status columns
-//
-// Sync API. Optional `root` for test DI.
-
 import { WORKSPACE_FILES } from "../../workspace/paths.js";
 import { workspacePath } from "../../workspace/paths.js";
 import { resolvePath } from "./workspace-io.js";

--- a/server/utils/files/user-tasks-io.ts
+++ b/server/utils/files/user-tasks-io.ts
@@ -1,8 +1,3 @@
-// Domain I/O: user-created scheduled tasks
-//   config/scheduler/tasks.json
-//
-// Optional `root` parameter for test DI (defaults to workspacePath).
-
 import path from "path";
 import { mkdir } from "fs/promises";
 import { WORKSPACE_FILES } from "../../workspace/paths.js";

--- a/server/utils/files/workspace-io.ts
+++ b/server/utils/files/workspace-io.ts
@@ -1,15 +1,5 @@
-// Workspace-aware file I/O — the single place implementation code
-// should reach for when reading/writing files under ~/mulmoclaude/.
-//
-// Combines WORKSPACE_PATHS (path resolution) with the atomic/safe
-// helpers (I/O primitives) so call sites never need raw `path.join`
-// + raw `fs.*` for workspace files.
-//
-// All writes go through writeFileAtomic so concurrent readers always
-// see a consistent file — never a half-written one.
-//
-// All reads swallow ENOENT and return null / fallback so callers can
-// do `if (!content)` instead of try/catch.
+// All writes go through writeFileAtomic so concurrent readers never see a half-written file. All reads swallow ENOENT
+// and return null/fallback so callers can branch on `!content` instead of try/catch.
 
 import { Stats, mkdirSync, promises, readFileSync, readdirSync, statSync } from "fs";
 import path from "path";
@@ -24,24 +14,10 @@ function rethrowUnexpected(err: unknown, context: string): null {
   throw err;
 }
 
-// ── Path resolution ─────────────────────────────────────────────
-
-/**
- * Resolve a workspace-relative path to an absolute path.
- * Use this instead of `path.join(workspacePath, rel)` in
- * implementation code — keeps the workspace root reference in
- * one place.
- */
 export function resolveWorkspacePath(relPath: string): string {
   return path.join(workspacePath, relPath);
 }
 
-// ── Read ────────────────────────────────────────────────────────
-
-/**
- * Read a text file under the workspace. Returns null on ENOENT;
- * logs and re-throws unexpected errors (EACCES, EPERM, etc.).
- */
 export async function readWorkspaceText(relPath: string): Promise<string | null> {
   try {
     return await promises.readFile(resolveWorkspacePath(relPath), "utf-8");
@@ -50,7 +26,6 @@ export async function readWorkspaceText(relPath: string): Promise<string | null>
   }
 }
 
-/** Sync variant. Same ENOENT-only swallow contract. */
 export function readWorkspaceTextSync(relPath: string): string | null {
   try {
     return readFileSync(resolveWorkspacePath(relPath), "utf-8");
@@ -59,10 +34,6 @@ export function readWorkspaceTextSync(relPath: string): string | null {
   }
 }
 
-/**
- * Read and parse a JSON file under the workspace. Returns
- * `fallback` if the file is missing, unreadable, or malformed.
- */
 export async function readWorkspaceJson<T>(relPath: string, fallback: T): Promise<T> {
   const text = await readWorkspaceText(relPath);
   if (text === null) return fallback;
@@ -73,7 +44,6 @@ export async function readWorkspaceJson<T>(relPath: string, fallback: T): Promis
   }
 }
 
-/** Sync variant of `readWorkspaceJson`. */
 export function readWorkspaceJsonSync<T>(relPath: string, fallback: T): T {
   const text = readWorkspaceTextSync(relPath);
   if (text === null) return fallback;
@@ -84,53 +54,23 @@ export function readWorkspaceJsonSync<T>(relPath: string, fallback: T): T {
   }
 }
 
-// ── Write ───────────────────────────────────────────────────────
-
-/**
- * Write a text file under the workspace atomically.
- * Parent directories are created if missing.
- */
 export async function writeWorkspaceText(relPath: string, content: string, opts?: { mode?: number }): Promise<void> {
   await writeFileAtomic(resolveWorkspacePath(relPath), content, opts);
 }
 
-/** Sync variant for startup / init paths. */
 export function writeWorkspaceTextSync(relPath: string, content: string, opts?: { mode?: number }): void {
   writeFileAtomicSync(resolveWorkspacePath(relPath), content, opts);
 }
 
-/**
- * Write a JSON value under the workspace atomically.
- * Pretty-printed with 2-space indent.
- */
 export async function writeWorkspaceJson(relPath: string, data: unknown, opts?: { mode?: number }): Promise<void> {
   await writeFileAtomic(resolveWorkspacePath(relPath), JSON.stringify(data, null, 2), opts);
 }
 
-// ── Rooted variants (for DI / testable modules) ────────────────
-//
-// Modules that take `root` as a parameter (journal, sources, etc.)
-// use these instead of raw path.join + fs.*. Same contract as the
-// workspace-* helpers, but root is caller-supplied.
-//
-// **IMPORTANT — internal paths only.** These helpers do NOT guard
-// against `..` traversal. They are designed for domain I/O modules
-// that pass compile-time-fixed relative paths like
-// `${WORKSPACE_DIRS.chat}/${id}.json`. User-supplied or HTTP-body
-// paths MUST go through `resolveWithinRoot()` in `safe.ts` instead.
-
-/**
- * Resolve root + relPath. Replaces raw `path.join(root, rel)`.
- *
- * For **internal fixed paths only** — never pass user input as
- * `relPath`. Use `resolveWithinRoot()` for user-supplied paths.
- */
+// **Internal fixed paths only.** No `..` traversal guard — user-supplied paths MUST go through resolveWithinRoot() in safe.ts.
 export function resolvePath(root: string, relPath: string): string {
   return path.join(root, relPath);
 }
 
-/** Read text under an arbitrary root. Null on ENOENT; rethrows
- *  unexpected errors. */
 export async function readTextUnder(root: string, relPath: string): Promise<string | null> {
   try {
     return await promises.readFile(path.join(root, relPath), "utf-8");
@@ -139,12 +79,10 @@ export async function readTextUnder(root: string, relPath: string): Promise<stri
   }
 }
 
-/** Write atomically under an arbitrary root. */
 export async function writeTextUnder(root: string, relPath: string, content: string): Promise<void> {
   await writeFileAtomic(path.join(root, relPath), content);
 }
 
-/** Sync read text under a root. Null on ENOENT. */
 export function readTextUnderSync(root: string, relPath: string): string | null {
   try {
     return readFileSync(path.join(root, relPath), "utf-8");
@@ -153,7 +91,6 @@ export function readTextUnderSync(root: string, relPath: string): string | null 
   }
 }
 
-/** Sync readdir under a root. Empty on ENOENT. */
 export function readdirUnderSync(root: string, relPath: string): string[] {
   try {
     return readdirSync(path.join(root, relPath));
@@ -166,7 +103,6 @@ export function readdirUnderSync(root: string, relPath: string): string[] {
   }
 }
 
-/** Readdir under a root. Empty on ENOENT; rethrows unexpected. */
 export async function readdirUnder(root: string, relPath: string): Promise<string[]> {
   try {
     return await promises.readdir(path.join(root, relPath));
@@ -179,7 +115,6 @@ export async function readdirUnder(root: string, relPath: string): Promise<strin
   }
 }
 
-/** Stat under a root. Null on ENOENT; rethrows unexpected. */
 export async function statUnder(root: string, relPath: string): Promise<Stats | null> {
   try {
     return await promises.stat(path.join(root, relPath));
@@ -188,17 +123,10 @@ export async function statUnder(root: string, relPath: string): Promise<Stats | 
   }
 }
 
-/** Ensure a directory exists under a root. */
 export async function ensureDirUnder(root: string, relPath: string): Promise<void> {
   await promises.mkdir(path.join(root, relPath), { recursive: true });
 }
 
-// ── Existence ───────────────────────────────────────────────────
-
-/**
- * Check whether a workspace-relative path exists on disk.
- * Returns false on ENOENT; rethrows unexpected errors.
- */
 export function existsInWorkspace(relPath: string): boolean {
   try {
     statSync(resolveWorkspacePath(relPath));
@@ -212,10 +140,6 @@ export function existsInWorkspace(relPath: string): boolean {
   }
 }
 
-/**
- * Ensure a workspace-relative directory exists. Creates it
- * (including parents) if missing. Idempotent.
- */
 export function ensureWorkspaceDir(relPath: string): void {
   mkdirSync(resolveWorkspacePath(relPath), { recursive: true });
 }

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -1,30 +1,13 @@
-// Transport layer for the journal archivist: wraps the Claude Code
-// CLI as a subprocess so summarization runs against the user's
-// subscription quota rather than the API key budget.
-//
-// The pure data shapes (interfaces, prompts, validators) live in
-// `./archivist-schemas.ts`. This file is the only one that touches
-// `node:child_process`, kept thin so dependency injection in tests
-// never has to mock a subprocess.
+// Spawning the Claude Code CLI runs summarization against the user's subscription quota rather than the API-key budget.
 
 import { spawn } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
 
-// (systemPrompt, userPrompt) → raw model output as a string.
-// The daily/optimization passes parse JSON out of the string
-// themselves; this layer stays transport-only.
 export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
 
-// Wall-clock cap per CLI invocation. 5 minutes is comfortably above
-// the worst-case summarization run we've seen and still short enough
-// that a wedged subprocess doesn't tie up resources forever.
 const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
-// Sentinel thrown on ENOENT. Each subsystem catches this and decides
-// what to do — journal disables itself for the rest of the server
-// lifetime; chat-index / sources log and skip. The message is
-// subsystem-neutral so callers logging `err.message` verbatim (e.g.
-// chat-index) don't surface a misleading "journal disabled" warning.
+// Subsystem-neutral message: chat-index / sources also catch this and would otherwise log a misleading "journal disabled".
 export class ClaudeCliNotFoundError extends Error {
   constructor() {
     super("`claude` CLI is not available on PATH");
@@ -43,9 +26,7 @@ export class ClaudeCliFailedError extends Error {
   }
 }
 
-// Default summarizer. Spawns `claude -p` and pipes the combined
-// system + user prompt to stdin so we don't hit shell-argv limits
-// for large day excerpts.
+// Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
   return new Promise((resolve, reject) => {
     const child = spawn("claude", ["-p", "--output-format", "text"], {
@@ -95,8 +76,7 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
       }
     });
 
-    // Surface stdin write errors (e.g. EPIPE if the child exited
-    // before we finished writing) instead of silently dropping them.
+    // Surface EPIPE etc. — child may exit before we finish writing.
     child.stdin.on("error", (err: Error) => {
       if (settled) return;
       settled = true;
@@ -104,12 +84,7 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) => {
       reject(err);
     });
 
-    // Send the full prompt in one write. If Node's stream layer
-    // signals backpressure (write returns false), wait for "drain"
-    // before calling end() so we don't close stdin while the buffer
-    // still has data to flush. For typical archivist prompts this
-    // path rarely fires, but very large session excerpts can reach
-    // it.
+    // Wait for "drain" on backpressure before end() so the buffer fully flushes — large excerpts can hit this path.
     const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
     const flushed = child.stdin.write(payload);
     if (flushed) {

--- a/server/workspace/journal/archivist-schemas.ts
+++ b/server/workspace/journal/archivist-schemas.ts
@@ -1,22 +1,8 @@
-// Data shapes, prompts, and validators for the journal archivist.
-// Pure module — no IO, no subprocess, no global state. The CLI
-// transport (subprocess wrapper, error classes, default Summarize)
-// lives in `./archivist-cli.ts`.
-//
-// Splitting these used to be one file (`archivist.ts`), but it had
-// grown to 386 lines mixing transport with schemas. Keeping prompts
-// + validators separate lets tests / future passes import the data
-// shapes without dragging in `node:child_process`.
-
 import { isRecord } from "../../utils/types.js";
-
-// --- Daily archivist contract ---------------------------------------
 
 export interface SessionEventExcerpt {
   source: string; // "user" | "assistant" | "tool" | ...
   type: string; // "text" | "tool_result" | ...
-  // One-line human-readable rendering of the event, already
-  // truncated to a sane length by the caller.
   content: string;
 }
 
@@ -24,10 +10,7 @@ export interface SessionExcerpt {
   sessionId: string;
   roleId: string;
   events: SessionEventExcerpt[];
-  // Workspace-relative file paths produced by the session's tool
-  // calls (e.g. "stories/foo.json", "HTMLs/bar.html",
-  // "wiki/pages/baz.md"). Surfaced so the archivist can emit
-  // navigable markdown links to them in the summaries.
+  // Workspace-relative paths the archivist links from the summary (e.g. "stories/foo.json", "wiki/pages/baz.md").
   artifactPaths: string[];
 }
 
@@ -56,9 +39,7 @@ export interface DailyArchivistOutput {
   topicUpdates: TopicUpdate[];
 }
 
-// System prompt for the daily pass. Written long-form because the
-// model does a much better job with explicit rules and an example
-// than with a terse instruction.
+// Long-form: the model does notably better with explicit rules + an example than with a terse instruction.
 export const DAILY_SYSTEM_PROMPT = `You are the journal archivist for a personal MulmoClaude workspace.
 Your job: given raw session excerpts for a single day, produce
 (1) a daily summary and (2) updates to long-running topic notes.
@@ -107,8 +88,6 @@ SESSION LINKS
 LANGUAGE
 - Match the language of the source sessions. Always.`;
 
-// Build the user-side prompt for one day's worth of content.
-// Pure string construction — safe to unit test if we ever want to.
 export function buildDailyUserPrompt(input: DailyArchivistInput): string {
   const parts: string[] = [];
   parts.push(`DATE: ${input.date}`);
@@ -132,9 +111,7 @@ export function buildDailyUserPrompt(input: DailyArchivistInput): string {
   }
   parts.push("");
 
-  // Union of all workspace-relative artifact paths the day's
-  // sessions produced, deduped and sorted. Given to the archivist
-  // so it can link to them from the summary text.
+  // Dedupe + sort artifact paths so the archivist can link to them from the summary.
   const allArtifacts = new Set<string>();
   for (const sessionExcerpt of input.sessionExcerpts) {
     for (const artifactPath of sessionExcerpt.artifactPaths) allArtifacts.add(artifactPath);
@@ -162,12 +139,9 @@ export function buildDailyUserPrompt(input: DailyArchivistInput): string {
   return parts.join("\n");
 }
 
-// --- Optimization archivist contract --------------------------------
-
 export interface OptimizationTopicSnapshot {
   slug: string;
-  // First ~500 chars of the topic file, enough for the model to
-  // judge similarity without blowing up prompt size.
+  // First ~500 chars — enough to judge similarity without blowing up prompt size.
   headContent: string;
 }
 
@@ -227,21 +201,9 @@ export function buildOptimizationUserPrompt(input: OptimizationInput): string {
   return parts.join("\n");
 }
 
-// --- JSON extraction ------------------------------------------------
-
-// Tolerant JSON extractor: prefers a ```json fenced block; falls back
-// to scanning for the first balanced `{ ... }` block. Returns `null`
-// on failure so callers can log-and-skip instead of crash.
-//
-// JSON extraction helpers moved to server/utils/json.ts.
-// Re-export here so journal callers (and existing tests) keep a
-// single import surface for the archivist contract.
+// Re-exported so journal callers + existing tests keep a single import surface for the archivist contract.
 export { extractJsonObject, findBalancedBraceBlock } from "../../utils/json.js";
 
-// --- Validators ------------------------------------------------------
-
-// Type guards used by callers to validate parsed output. Written as
-// guards rather than `as` casts per project conventions.
 export function isDailyArchivistOutput(value: unknown): value is DailyArchivistOutput {
   if (!isRecord(value)) return false;
   const recordValue = value as Record<string, unknown>;

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -1,13 +1,3 @@
-// The daily pass: walk chat/*.jsonl, find sessions changed since
-// the last run, bucket events by local-date, call the archivist
-// once per affected day, and apply its output (write daily/*.md,
-// create/append/rewrite topics/*.md).
-//
-// This file is the only one in the journal module that combines
-// filesystem side-effects with LLM calls. Pure bits (event parsing,
-// bucketing) are factored into small exported helpers so tests can
-// exercise them without touching disk.
-
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
@@ -37,26 +27,16 @@ import { EVENT_TYPES } from "../../../src/types/events.js";
 import { extractAndAppendMemory } from "./memoryExtractor.js";
 import { isRecord } from "../../utils/types.js";
 
-// --- Constants ------------------------------------------------------
-
-// Per-event content is truncated before handing to the archivist so
-// an accidentally huge tool result (e.g. base64 image data) doesn't
-// blow past the CLI's context window.
+// Truncate per-event content so an oversized tool result (e.g. base64 image) doesn't blow past the CLI's context window.
 const MAX_EVENT_CONTENT_CHARS = 600;
 
-// Hard cap on events per session included in the prompt. Sessions
-// with thousands of events get their head kept — the archivist can
-// generally get the gist from the opening.
+// Cap events per session in the prompt; sessions with thousands keep the head — archivist gets the gist from the opening.
 const MAX_EVENTS_PER_SESSION = 80;
-
-// --- Public entry ---------------------------------------------------
 
 export interface DailyPassDeps {
   workspaceRoot?: string;
   summarize: Summarize;
-  // Active session ids to skip (mid-write). Caller passes the
-  // live session registry to avoid ingesting jsonl files that the
-  // agent is still appending to.
+  // Skip mid-write sessions: caller passes the live registry so we don't ingest jsonl the agent is still appending to.
   activeSessionIds: ReadonlySet<string>;
 }
 
@@ -68,15 +48,6 @@ export interface DailyPassResult {
   skipped: Array<{ date: string; reason: string }>;
 }
 
-// Inputs to the day loop, gathered up-front by `buildDailyPassPlan`
-// so `runDailyPass` reads as orchestration only — no IO interleaved
-// with scheduling decisions. Returned as a single object instead of
-// a tuple so future fields (e.g. caller-provided clock for tests)
-// can be added without re-threading every call site.
-//
-// `newTopicsSeen` is a mutable accumulator: the day loop adds to it
-// as topics are created. Including it in the plan keeps the lifecycle
-// visible at the call site.
 export interface DailyPassPlan {
   workspaceRoot: string;
   perSessionExcerpts: Map<string, Map<string, SessionExcerpt>>;
@@ -92,19 +63,8 @@ export interface DailyPassPlan {
   dirtyMetaById: ReadonlyMap<string, SessionFileMeta>;
 }
 
-/**
- * Read-only setup for `runDailyPass`: enumerate sessions, find the
- * dirty ones, build day buckets, snapshot existing topics, and
- * compute the initial mutable state. Returns `null` when there's
- * nothing to do (no dirty sessions). Otherwise returns a plan object
- * the day loop can iterate over.
- *
- * Intentionally does NOT short-circuit on empty `dayBuckets`. If
- * every dirty session produces zero excerpts (all malformed, or all
- * tool-only with no text turns) we still want `readAllTopics` to
- * fire and `initialNextState.knownTopics` to be normalised/sorted.
- * The day loop then iterates zero times and we drop straight through.
- */
+// Do NOT short-circuit on empty dayBuckets: if every dirty session yields zero excerpts we still want readAllTopics to
+// fire so initialNextState.knownTopics is normalised/sorted; the day loop then iterates zero times and drops through.
 export async function buildDailyPassPlan(state: JournalState, deps: DailyPassDeps): Promise<DailyPassPlan | null> {
   const workspaceRoot = deps.workspaceRoot ?? defaultWorkspacePath;
   const chatDir = path.join(workspaceRoot, WORKSPACE_DIRS.chat);
@@ -118,11 +78,7 @@ export async function buildDailyPassPlan(state: JournalState, deps: DailyPassDep
 
   const existingTopics = await readAllTopics(workspaceRoot);
   const newTopicsSeen = new Set<string>(state.knownTopics);
-  // `nextState` is rebuilt through the day loop and persisted after
-  // each successful day via writeState (atomic tmp+rename). We do
-  // NOT bump lastDailyRunAt here — that's the outer runner's job
-  // after the whole pass (including optimization) finishes, so
-  // partial progress doesn't look like a complete pass.
+  // Do NOT bump lastDailyRunAt here — outer runner does it after optimization, so partial progress isn't a complete pass.
   const initialNextState: JournalState = {
     ...state,
     knownTopics: [...newTopicsSeen].sort(),
@@ -185,10 +141,6 @@ export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Pr
   return { nextState, result };
 }
 
-// --- Phase 3 helper: single-day processing + state advance -----------
-// Extracted from the Phase 3 for-loop to keep runDailyPass under
-// the sonarjs/cognitive-complexity threshold.
-
 interface ProcessDayInput {
   workspaceRoot: string;
   date: string;
@@ -244,11 +196,7 @@ async function processDayAndAdvance(input: ProcessDayInput): Promise<ProcessDayO
   };
 }
 
-// --- Phase 4 helper: memory extraction -------------------------------
-// Scan dirty-session excerpts for durable user facts and append new
-// ones to memory.md. Fire-and-forget: if extraction fails the daily
-// summaries are already written, so the pass is still useful.
-
+// Fire-and-forget: if memory extraction fails the daily summaries are already written, so the pass is still useful.
 async function maybeExtractMemory(
   perSessionExcerpts: ReadonlyMap<string, ReadonlyMap<string, SessionExcerpt>>,
   workspaceRoot: string,
@@ -277,24 +225,16 @@ async function maybeExtractMemory(
   }
 }
 
-// --- Phase 3 helper: per-day side-effecting pipeline ----------------
-
-// Discriminated return so `runDailyPass` can branch on outcome
-// without digging into null or throwing.
 export type DayOutcome =
   | { kind: "skipped"; reason: string }
   | {
       kind: "processed";
       topicsCreated: string[];
       topicsUpdated: string[];
-      // Union of created + updated — handed back so the caller
-      // can keep `newTopicsSeen` in sync without recomputing.
+      // Union of created + updated so the caller can keep newTopicsSeen in sync without recomputing.
       topicsTouched: string[];
     };
 
-// Run the archivist for one day and apply its output (daily
-// summary + topic updates). All filesystem writes land here so
-// `runDailyPass` stays branching-lean.
 async function processOneDay(
   workspaceRoot: string,
   date: string,
@@ -335,10 +275,7 @@ async function processOneDay(
   };
 }
 
-// Call the archivist summarizer and narrow its failure modes.
-// Returns null on recoverable failures (logged + skipped), throws
-// only for `ClaudeCliNotFoundError` which the outer runner uses to
-// disable the whole journal feature for the process lifetime.
+// Throws only for ClaudeCliNotFoundError (outer runner uses it to disable the whole journal feature for the process lifetime).
 async function callSummarizeForDay(date: string, input: DailyArchivistInput, summarize: Summarize): Promise<string | null> {
   try {
     return await summarize(DAILY_SYSTEM_PROMPT, buildDailyUserPrompt(input));
@@ -352,27 +289,16 @@ async function callSummarizeForDay(date: string, input: DailyArchivistInput, sum
   }
 }
 
-// Side-effecting wrapper: rewrite workspace-absolute links in the
-// archivist output relative to the daily summary's own location,
-// then write the file to disk. Factored out so the main loop's
-// body no longer contains path-math and I/O intermixed.
 async function writeDailySummaryForDate(workspaceRoot: string, date: string, rawMarkdown: string): Promise<void> {
-  // Rewrite any /workspace-absolute links in the archivist's output
-  // into true-relative links from the daily summary's location
-  // before writing to disk. Same treatment below for topic files.
+  // Rewrite /workspace-absolute links into true-relative links from the daily summary's location (same for topic files).
   const [yearPart, monthPart, dayPart] = date.split("-");
   const dailyFileWsPath = path.posix.join(WORKSPACE_DIRS.summaries, "daily", yearPart, monthPart, `${dayPart}.md`);
   const content = rewriteWorkspaceLinks(dailyFileWsPath, rawMarkdown);
   await writeDailySummary(date, content, workspaceRoot);
 }
 
-// Apply every topic update the archivist asked for, keeping the
-// in-memory `existingTopics` snapshot in sync so the next day in
-// this same pass sees fresh content. Mutates `existingTopics`.
-//
-// Per-update failures (EACCES, EIO, etc. surfaced by appendOrCreate)
-// are logged and skipped so a single broken topic file doesn't kill
-// the whole pass after days of progress have already been committed.
+// Mutates existingTopics so the next day in the same pass sees fresh content. Per-update failures are logged + skipped
+// so one broken topic file doesn't kill the whole pass after days of progress have already been committed.
 async function processTopicUpdatesForDay(
   workspaceRoot: string,
   updates: readonly TopicUpdate[],
@@ -397,9 +323,6 @@ async function processTopicUpdatesForDay(
   return { created, updated };
 }
 
-// Re-read the topic file fresh and upsert its snapshot into the
-// in-memory `existingTopics` list so the next day's archivist
-// call sees the latest content.
 async function refreshTopicSnapshot(workspaceRoot: string, slug: string, existingTopics: ExistingTopicSnapshot[]): Promise<void> {
   const newBody = await readTopicFile(slug, workspaceRoot);
   if (newBody === null) return;
@@ -409,11 +332,8 @@ async function refreshTopicSnapshot(workspaceRoot: string, slug: string, existin
   else existingTopics[idx] = snapshot;
 }
 
-// Persist the in-progress journal state after each day so a
-// mid-pass crash only costs the work written after the last
-// checkpoint. Write failures are logged but don't fail the pass —
-// the day's markdown is already on disk and the next run will
-// catch up.
+// Checkpoint state after each day so a mid-pass crash only costs work since the last write. Write failures don't fail
+// the pass — the day's markdown is already on disk and the next run catches up.
 async function persistStateAfterDay(workspaceRoot: string, state: JournalState, date: string): Promise<void> {
   try {
     await writeState(workspaceRoot, state);
@@ -425,17 +345,8 @@ async function persistStateAfterDay(workspaceRoot: string, state: JournalState, 
   }
 }
 
-// --- Pure helpers (exported for unit tests) ------------------------
-
-// Bucket every session's per-date excerpts into a `dayBuckets`
-// map and a `sessionToDays` tracking map in one pass. Inputs are
-// the per-session excerpts loaded by `loadDirtySessionExcerpts`;
-// outputs are plain Maps the day loop can consume directly.
-//
-// `sessionToDays` is used later by `computeJustCompletedSessions`
-// to mark a session fully processed only after its last day has
-// been written. That's why both Maps are built here together —
-// they're two views of the same input and staying in sync matters.
+// dayBuckets and sessionToDays must stay in sync — sessionToDays drives "session fully processed only after its last
+// day has been written" downstream in computeJustCompletedSessions.
 export interface DayBucketsPlan {
   dayBuckets: Map<string, SessionExcerpt[]>;
   sessionToDays: Map<string, Set<string>>;
@@ -461,12 +372,8 @@ export function buildDayBuckets(perSessionExcerpts: ReadonlyMap<string, Readonly
   return { dayBuckets, sessionToDays };
 }
 
-// Apply the append-to-missing → create guard and canonicalise
-// the slug. The archivist occasionally asks to "append" to a
-// brand-new topic; silently promoting that to "create" removes a
+// The archivist occasionally asks to "append" to a brand-new topic; silently promoting that to "create" removes a
 // whole class of LLM mistakes without needing a schema rejection.
-// Also rewrites any workspace-absolute links in the body relative
-// to the target topic file's location.
 export function normalizeTopicAction(update: TopicUpdate, existingTopics: readonly ExistingTopicSnapshot[]): TopicUpdate {
   const canonicalSlug = slugify(update.slug);
   const exists = existingTopics.some((topic) => topic.slug === canonicalSlug);
@@ -478,29 +385,13 @@ export function normalizeTopicAction(update: TopicUpdate, existingTopics: readon
   };
 }
 
-// Parse an archivist raw output string into a validated
-// DailyArchivistOutput. Returns null when the JSON envelope is
-// missing or the shape doesn't match, so callers can treat it
-// as a skip reason without needing a separate `isValid` check.
-// Pure — combines `extractJsonObject` + `isDailyArchivistOutput`
-// behind a single gate.
 export function parseArchivistOutput(rawOutput: string): DailyArchivistOutput | null {
   const parsed = extractJsonObject(rawOutput);
   if (!isDailyArchivistOutput(parsed)) return null;
   return parsed;
 }
 
-// Decide which sessions have just completed their last pending
-// day, mutating `sessionToDays` to drop `date` from every entry
-// that touches it. Returns the `SessionFileMeta` records for the
-// freshly-completed sessions so the caller can feed them into
-// `applyProcessed`.
-//
-// A session is "complete" when its pending-days set, *after*
-// removing the current date, is empty. Sessions not in
-// `sessionToDays` (or not in `dirtyMetaById`) are silently
-// skipped — defensive against unexpected inputs, and the same
-// shape as the pre-refactor inline code.
+// Mutates sessionToDays. A session is "complete" when its pending-days set is empty AFTER removing the current date.
 export function computeJustCompletedSessions(
   date: string,
   excerpts: readonly SessionExcerpt[],
@@ -521,11 +412,6 @@ export function computeJustCompletedSessions(
   return justCompleted;
 }
 
-// Build the next JournalState from the previous one plus a batch
-// of just-completed sessions and the current view of known
-// topics. Tiny pure wrapper so the day loop has one place to
-// advance state instead of five-line spread literals scattered
-// through it.
 export function advanceJournalState(prev: JournalState, justCompleted: readonly SessionFileMeta[], newTopicsSeen: ReadonlySet<string>): JournalState {
   return {
     ...prev,
@@ -534,13 +420,7 @@ export function advanceJournalState(prev: JournalState, justCompleted: readonly 
   };
 }
 
-// --- Filesystem helpers ---------------------------------------------
-
-// Load every dirty session's jsonl, bucket events by local-date,
-// and return the whole collection as a Map<sessionId, Map<date,
-// excerpt>>. Malformed sessions are logged and skipped so one
-// bad jsonl can't crash the pass. Returned shape is exactly what
-// `buildDayBuckets` wants as input.
+// Malformed sessions are logged and skipped so one bad jsonl can't crash the pass.
 async function loadDirtySessionExcerpts(chatDir: string, dirty: readonly string[], workspaceRoot: string): Promise<Map<string, Map<string, SessionExcerpt>>> {
   const perSession = new Map<string, Map<string, SessionExcerpt>>();
   for (const sessionId of dirty) {
@@ -593,10 +473,6 @@ async function loadSessionExcerptsByDate(chatDir: string, sessionId: string, wor
   return bucketParsedEvents(parsedEvents, sessionId, roleId, fallbackDate);
 }
 
-// Walk a jsonl string and return at most `maxEvents` parsed events
-// ready for bucketing. Skips blank lines, malformed JSON,
-// metadata entries, and anything `parseEntry` rejects. Pure —
-// exported so tests can exercise it with fabricated jsonl strings.
 export function parseJsonlEvents(raw: string, maxEvents: number): ParsedEntry[] {
   const events: ParsedEntry[] = [];
   for (const line of raw.split("\n")) {
@@ -610,14 +486,7 @@ export function parseJsonlEvents(raw: string, maxEvents: number): ParsedEntry[] 
   return events;
 }
 
-// JSON.parse one jsonl line, guarding against blank lines,
-// malformed JSON, and any JSON value that isn't a plain object.
-// `JSON.parse` will happily return `null`, arrays, strings,
-// numbers, or booleans, none of which the downstream
-// `parseEntry` / `entryToExcerpt` functions can consume — and
-// `entry.type` on a `null` or primitive throws at runtime.
-// Returning `null` here collapses every invalid shape into the
-// same "skip this line" sentinel the caller already handles.
+// Reject non-object JSON (null, arrays, primitives) — entry.type would throw on them, and downstream parseEntry can't consume them.
 function parseJsonlLine(line: string): Record<string, unknown> | null {
   if (!line.trim()) return null;
   let parsed: unknown;
@@ -636,10 +505,7 @@ function isMetadataEntry(entry: Record<string, unknown>): boolean {
   return entry.type === EVENT_TYPES.sessionMeta || entry.type === EVENT_TYPES.claudeSessionId;
 }
 
-// Collect parsed events into per-date buckets using `fallbackDate`
-// for every event, since the legacy jsonl format has no per-event
-// timestamps. Extracted so the I/O-free bucket-building can be
-// reasoned about and unit-tested without a real jsonl file.
+// Uses fallbackDate for every event because the legacy jsonl format has no per-event timestamps.
 export function bucketParsedEvents(events: readonly ParsedEntry[], sessionId: string, roleId: string, fallbackDate: string): Map<string, SessionExcerpt> {
   const buckets = new Map<string, SessionExcerpt>();
   for (const parsed of events) {
@@ -666,13 +532,8 @@ async function readRoleIdFromMeta(sessionId: string, workspaceRoot: string): Pro
   return "unknown";
 }
 
-// Convert one jsonl entry into a flat excerpt the archivist can read,
-// plus any workspace-relative artifact paths the entry references.
-// Exported so tests can exercise it with fabricated entries.
 export interface ParsedEntry {
   excerpt: SessionEventExcerpt;
-  // 0+ workspace-relative artifact paths referenced by this entry.
-  // Used to build the ARTIFACTS REFERENCED prompt section.
   artifactPaths: string[];
 }
 
@@ -685,13 +546,11 @@ export function parseEntry(entry: Record<string, unknown>): ParsedEntry | null {
   };
 }
 
-// Legacy single-purpose form used by the existing unit tests.
-// Prefer `parseEntry` for code that also wants artifact paths.
+// Prefer parseEntry for code that also wants artifact paths; this form is kept for the existing unit tests.
 export function entryToExcerpt(entry: Record<string, unknown>): SessionEventExcerpt | null {
   const source = typeof entry.source === "string" ? entry.source : "unknown";
   const type = typeof entry.type === "string" ? entry.type : "unknown";
 
-  // text entries: {source, type: "text", message}
   if (type === EVENT_TYPES.text && typeof entry.message === "string") {
     return {
       source,
@@ -699,10 +558,7 @@ export function entryToExcerpt(entry: Record<string, unknown>): SessionEventExce
       content: truncate(entry.message, MAX_EVENT_CONTENT_CHARS),
     };
   }
-  // tool_result entries: {source: "tool", type: "tool_result", result: {toolName, message, ...}}
-  // `typeof null === "object"` so we must explicitly reject null
-  // to avoid a NullPointerException-style crash when accessing
-  // r.toolName below.
+  // typeof null === "object", so isRecord must reject null before accessing resultRecord.toolName below.
   if (type === EVENT_TYPES.toolResult && isRecord(entry.result)) {
     const resultRecord = entry.result as Record<string, unknown>;
     const toolName = typeof resultRecord.toolName === "string" ? resultRecord.toolName : "tool";
@@ -717,10 +573,7 @@ export function entryToExcerpt(entry: Record<string, unknown>): SessionEventExce
   return null;
 }
 
-// Pull workspace-relative artifact paths out of a jsonl entry. The
-// extraction is tool-aware: different plugins stash file paths in
-// different places inside their tool_result data. Exported for
-// tests.
+// Tool-aware extraction: different plugins stash file paths in different places inside tool_result data.
 export function extractArtifactPaths(entry: Record<string, unknown>): string[] {
   if (entry.type !== "tool_result") return [];
   const result = entry.result;
@@ -731,27 +584,21 @@ export function extractArtifactPaths(entry: Record<string, unknown>): string[] {
   const dataRecord = data as Record<string, unknown>;
   const paths: string[] = [];
 
-  // Direct `filePath: string` — presentMulmoScript, presentHtml.
+  // presentMulmoScript / presentHtml expose filePath directly.
   if (typeof dataRecord.filePath === "string" && dataRecord.filePath.length > 0) {
     paths.push(dataRecord.filePath);
   }
 
-  // Wiki uses `pageName: string` and stores the page at
-  // `wiki/pages/<pageName>.md`. The plugin itself doesn't surface
-  // the full path in the result, so we synthesise it from the
-  // convention established in server/routes/wiki.ts.
+  // manageWiki only surfaces pageName; synthesise the path from the wiki/pages/<pageName>.md convention.
   if (resultRecord.toolName === "manageWiki" && typeof dataRecord.pageName === "string") {
     paths.push(`wiki/pages/${dataRecord.pageName}.md`);
   }
 
-  // Paths must be workspace-relative (not absolute, no escape).
-  // Drop anything suspicious rather than link to it.
   return paths.filter(isSafeWorkspacePath);
 }
 
-// Defensive: refuse absolute paths, parent-escapes, or scheme-like
-// strings. Protects against a malformed tool result wedging a
-// filesystem-absolute path into the archivist prompt.
+// Refuse absolute paths, parent-escapes, scheme-like strings — guards against a malformed tool result wedging an
+// absolute filesystem path into the archivist prompt.
 function isSafeWorkspacePath(candidatePath: string): boolean {
   if (!candidatePath) return false;
   if (candidatePath.startsWith("/")) return false;

--- a/server/workspace/journal/diff.ts
+++ b/server/workspace/journal/diff.ts
@@ -1,40 +1,18 @@
-// "Which sessions are new or have changed since the last journal
-// run?" — pure logic that takes in-memory representations of the
-// current filesystem and the persisted state, and returns the list
-// of session ids that need re-ingest.
-//
-// Extracted from the filesystem layer so tests can exercise it with
-// hand-rolled inputs instead of mocking `fs`.
-
 import type { JournalState, ProcessedSessionRecord } from "./state.js";
 
 export interface SessionFileMeta {
-  // Session id (matches the .jsonl filename without extension).
   id: string;
-  // mtime in ms since epoch. The only signal we use to detect
-  // appends — sessions don't have a version counter.
+  // mtime in ms — sessions have no version counter, so this is the only signal we have for "file changed".
   mtimeMs: number;
 }
 
 export interface DirtySessionDecision {
   dirty: string[];
-  // Sessions already in state whose files have vanished from disk.
-  // We keep them in the state record (no harm) but the caller may
-  // choose to prune them separately.
+  // Previously-processed sessions whose files have vanished — informational, not an error.
   missing: string[];
 }
 
-// Core diff. Given the current directory listing and the persisted
-// processed-sessions record, return:
-//   - `dirty`: sessions that were never seen, or whose mtime has
-//     advanced since we last ingested them, or whose mtime we don't
-//     have a record of (treat as dirty — safer to re-ingest than miss).
-//   - `missing`: sessions we had previously processed that no longer
-//     exist on disk. Not an error, just information.
-//
-// The caller may additionally exclude currently-active sessions
-// (whose jsonl could be mid-write); that's a separate concern and
-// kept out of the pure diff.
+// Treats unknown-mtime as dirty (safer to re-ingest than miss). Active mid-write sessions are filtered by the caller.
 export function findDirtySessions(current: readonly SessionFileMeta[], processed: Record<string, ProcessedSessionRecord>): DirtySessionDecision {
   const dirty: string[] = [];
   const seenNow = new Set<string>();
@@ -59,9 +37,6 @@ export function findDirtySessions(current: readonly SessionFileMeta[], processed
   return { dirty, missing };
 }
 
-// Produce the next processedSessions map after a successful ingest
-// of the given dirty ids. Pure — doesn't mutate input. Sessions not
-// in the dirty list keep their existing record.
 export function applyProcessed(previous: JournalState["processedSessions"], justProcessed: readonly SessionFileMeta[]): JournalState["processedSessions"] {
   const next: JournalState["processedSessions"] = { ...previous };
   for (const meta of justProcessed) {

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -1,50 +1,7 @@
-// Public entry point for the workspace journal. The agent route
-// calls `maybeRunJournal()` from its `finally` block — fire-and-
-// forget. This module decides whether a pass is actually due, holds
-// an in-process lock so concurrent sessions don't double-run,
-// orchestrates daily + optimization passes, and rebuilds _index.md.
-//
-// All failures are caught and logged here; nothing ever bubbles
-// back to the request handler.
-//
-// ── Architecture (#799) ──────────────────────────────────────────
-//
-// Two top-level passes hang off `maybeRunJournal()`, each with its
-// own cadence and its own state-machine slot. Memory extraction is
-// a sub-step of the daily pass, not a peer pipeline.
-//
-//   session-end
-//     │
-//     └─> maybeRunJournal()  [this file]
-//           │   gates by interval, holds the lock, traps errors
-//           │
-//           ├─> runDailyPass         (≥ 1 h since last)
-//           │     dailyPass.ts       finds new/changed sessions via
-//           │                        mtime, buckets events by local
-//           │                        date, calls `claude` CLI once
-//           │                        per day, writes daily summaries
-//           │                        + topics + state checkpoint.
-//           │     │
-//           │     │  early-returns when no dirty sessions; otherwise
-//           │     │  at the end of the per-day loop:
-//           │     │
-//           │     └─> extractAndAppendMemory
-//           │           memoryExtractor.ts  scans the day's new
-//           │                              daily file for memory-
-//           │                              worthy facts, appends to
-//           │                              the user's ~/.claude/
-//           │                              memory.md.
-//           │
-//           └─> runOptimizationPass  (≥ 7 d since last)
-//                 optimizationPass.ts reads existing topics, asks
-//                                    the LLM to merge duplicates /
-//                                    archive stale ones, writes back
-//                                    and updates archive/.
-//
-// _index.md is rebuilt at the end of every successful pass so the
-// UI's directory listing reflects whatever was just written.
-//
-// Audit + roadmap: `plans/audit-journal-subsystem.md` (#799).
+// Architecture (#799) — agent route calls maybeRunJournal() fire-and-forget from its finally block. The daily pass
+// (≥1h since last) walks chat/*.jsonl by mtime, buckets events by local date, writes daily summaries + topics, then
+// extractAndAppendMemory appends durable user facts to memory.md. The optimization pass (≥7d) merges/archives topics.
+// _index.md is rebuilt at the end of every successful pass. Roadmap: plans/audit-journal-subsystem.md.
 
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import {
@@ -64,42 +21,26 @@ import { log } from "../../system/logger/index.js";
 
 export { extractFirstH1 };
 
-// Module-level lock. A boolean is enough for the single-process
-// single-user MulmoClaude server; if two sessions finish at the
-// same instant, the second call returns immediately.
+// Single-process server, so a boolean is enough; a second concurrent call simply returns.
 let running = false;
 
-// Once we hit ENOENT on the `claude` CLI we disable the journal
-// for the rest of the server lifetime to avoid spamming warnings
-// on every session-end. Reset on server restart.
+// Latch off the journal for the rest of the process once the claude CLI is missing — avoids spamming on every session-end.
 let disabled = false;
 
-// Test-only reset for the module-level flags. The lock + disable
-// flags are intentionally module-scoped so a fresh server start
-// always begins from "neither running nor disabled"; a unit test
-// that exercises maybeRunJournal across multiple call sequences
-// needs a way to reproduce that fresh-start condition without
-// re-importing the module. Not exported via index — only consumers
-// importing this file directly should reach for it.
+// Reset module-level flags between unit-test runs without re-importing the module.
 export function __resetForTests(): void {
   running = false;
   disabled = false;
 }
 
-// The agent route calls this as `maybeRunJournal().catch(...)`.
 export interface MaybeRunJournalOptions {
   summarize?: Summarize;
   workspaceRoot?: string;
   activeSessionIds?: ReadonlySet<string>;
-  // Skip the interval check and run both passes unconditionally.
-  // Useful for debugging / CLI-driven manual runs — the feature's
-  // disable flags (claude CLI missing, in-process lock) still apply.
+  // Bypass the interval gate; the disable flags (CLI missing, in-process lock) still apply.
   force?: boolean;
 }
 
-// Everything inside swallows its own errors so the promise never
-// rejects in practice, but we still attach a catch at the call
-// site defensively.
 export async function maybeRunJournal(opts: MaybeRunJournalOptions = {}): Promise<void> {
   if (disabled) return;
   if (running) return;
@@ -128,9 +69,6 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
   const state = await readState(workspaceRoot);
   const now = Date.now();
 
-  // `force: true` bypasses the interval gate entirely so debug /
-  // startup flows can trigger a full pass even when nothing is
-  // technically due.
   const daily = opts.force === true || isDailyDue(state, now);
   const optimize = opts.force === true || isOptimizationDue(state, now);
   if (!daily && !optimize) return;
@@ -147,9 +85,7 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
       summarize,
       activeSessionIds,
     });
-    // Only advance lastDailyRunAt when no days were skipped —
-    // otherwise we'd wait a full interval before retrying a failed
-    // day, letting transient archivist failures silently lose events.
+    // Only bump lastDailyRunAt when no days were skipped — otherwise transient archivist failures silently lose events.
     nextState = {
       ...afterDaily,
       ...(result.skipped.length === 0 && {
@@ -168,11 +104,7 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
   if (optimize) {
     log.info("journal", "running optimization pass");
     const { nextState: afterOpt, result } = await runOptimizationPass(nextState, { workspaceRoot, summarize });
-    // Same rule as daily: only advance the timestamp when the pass
-    // actually ran to completion. A "skipped: too few topics" case
-    // is still considered successful — there was simply nothing to
-    // do — and we allow it to bump so we don't re-check on every
-    // session-end.
+    // Same rule as daily, except "fewer than 2 topics" is still success — bump so we don't re-check every session-end.
     const optimizationSucceeded = !result.skipped || result.skippedReason === "fewer than 2 topics";
     nextState = {
       ...afterOpt,
@@ -195,8 +127,6 @@ async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
   await rebuildIndex(workspaceRoot);
   await writeState(workspaceRoot, nextState);
 }
-
-// --- Index rebuild -------------------------------------------------
 
 async function rebuildIndex(workspaceRoot: string): Promise<void> {
   const topics = await walkTopics(workspaceRoot);
@@ -229,7 +159,6 @@ async function walkTopics(workspaceRoot: string): Promise<IndexTopicEntry[]> {
 
 const DAY_FILE_PATTERN = /^(\d{2})\.md$/;
 
-// Pure: returns the two-digit day if `name` matches `DD.md`, else null.
 export function parseDailyFilename(name: string): string | null {
   const match = DAY_FILE_PATTERN.exec(name);
   return match ? (match[1] ?? null) : null;

--- a/server/workspace/journal/indexFile.ts
+++ b/server/workspace/journal/indexFile.ts
@@ -1,25 +1,13 @@
-// Pure builder for summaries/_index.md. Takes in-memory listings of
-// the journal's current topic / daily files and returns the full
-// markdown for the index. All filesystem walking happens in the
-// caller; this function is deterministic and easy to snapshot-test.
-
 import { isoDateOnly } from "../../utils/date.js";
 
 export interface IndexTopicEntry {
-  // Filesystem slug (matches topics/<slug>.md).
   slug: string;
-  // Optional human-readable title extracted from the topic file's
-  // first H1 heading. Falls back to `slug` if absent so the index
-  // row always reads sensibly.
   title?: string;
-  // ISO timestamp of the last write to the topic file. Rendered
-  // for "stale topic" visibility.
   lastUpdatedIso?: string;
 }
 
 export interface IndexDailyEntry {
-  // YYYY-MM-DD in local time. Matches the folder layout.
-  date: string;
+  date: string; // YYYY-MM-DD local
 }
 
 export interface IndexInputs {
@@ -27,8 +15,6 @@ export interface IndexInputs {
   days: readonly IndexDailyEntry[];
   archivedTopicCount: number;
   builtAtIso: string;
-  // How many "Recent days" rows to list before collapsing the
-  // remainder. The full listing still lives under daily/ on disk.
   maxRecentDays?: number;
 }
 
@@ -56,8 +42,7 @@ export function renderTopicsSection(topics: readonly IndexTopicEntry[]): string[
     lines.push("_No topics yet._");
     return lines;
   }
-  // Newest-first by last update (topics with no timestamp sort
-  // last, ordered alphabetically among themselves for stability).
+  // Newest-first; topics with no timestamp sort last, alphabetical among themselves for stability.
   const sorted = [...topics].sort(compareTopicsNewestFirst);
   for (const topicEntry of sorted) {
     lines.push(renderTopicRow(topicEntry));
@@ -71,7 +56,6 @@ export function renderRecentDaysSection(days: readonly IndexDailyEntry[], maxRec
     lines.push("_No daily entries yet._");
     return lines;
   }
-  // Newest-first by date string (YYYY-MM-DD sorts lexically).
   const sorted = [...days].sort((leftDay, rightDay) => {
     if (leftDay.date < rightDay.date) return 1;
     if (leftDay.date > rightDay.date) return -1;
@@ -100,8 +84,7 @@ export function renderArchiveSection(archivedTopicCount: number): string[] {
   return lines;
 }
 
-// Parse an ISO timestamp into a numeric sort key. Invalid or missing
-// timestamps get -Infinity so they sort to the bottom (oldest).
+// Invalid/missing ISO → -Infinity so they sort to the bottom.
 function topicSortKey(entry: IndexTopicEntry): number {
   if (!entry.lastUpdatedIso) return -Infinity;
   const timestampMs = Date.parse(entry.lastUpdatedIso);
@@ -117,14 +100,10 @@ function compareBySlug(leftEntry: IndexTopicEntry, rightEntry: IndexTopicEntry):
 function compareTopicsNewestFirst(leftEntry: IndexTopicEntry, rightEntry: IndexTopicEntry): number {
   const leftKey = topicSortKey(leftEntry);
   const rightKey = topicSortKey(rightEntry);
-  // Both valid timestamps → compare numerically.
-  // One or both invalid (-Infinity) → valid wins; if both invalid,
-  // fall through to the slug tie-breaker.
   const leftIsValid = Number.isFinite(leftKey);
   const rightIsValid = Number.isFinite(rightKey);
   if (leftIsValid && rightIsValid && rightKey !== leftKey) return rightKey - leftKey;
   if (leftIsValid !== rightIsValid) return leftIsValid ? -1 : 1;
-  // Tie-break on slug for determinism.
   return compareBySlug(leftEntry, rightEntry);
 }
 

--- a/server/workspace/journal/latestDaily.ts
+++ b/server/workspace/journal/latestDaily.ts
@@ -1,14 +1,5 @@
-// Find the most recent existing daily summary file under
-// `conversations/summaries/daily/YYYY/MM/DD.md`. Used by the
-// top-bar "today's journal" shortcut (#876): when today's summary
-// hasn't been generated yet, the UI falls back to whatever the
-// most recent existing day is.
-//
-// Walks deepest-first with backtrack: list YYYY → list MM → list
-// DD.md. If a level is empty (e.g. `2026/05/` exists but has no
-// daily files yet), drop back and try the next-largest entry at
-// the parent level. Bounded I/O — at most O(years × months) readdir
-// calls in pathological cases, 3 in the common case.
+// #876 top-bar "today's journal" shortcut falls back to the most recent existing day when today's summary is missing.
+// Backtracks YYYY → MM → DD.md so an empty 2026/05/ still finds 2026/04. Bounded I/O: O(years × months) worst case.
 
 import path from "node:path";
 import fsp from "node:fs/promises";
@@ -50,7 +41,6 @@ export async function findLatestDaily(workspaceRoot: string): Promise<LatestDail
       if (days.length === 0) continue;
       const dayFile = days[0];
       const dayMatch = DAY_FILE_RE.exec(dayFile);
-      // Filter ensures the regex matches; this is a safety check.
       if (!dayMatch) continue;
       const day = dayMatch[1];
       const relPath = path.posix.join("conversations", "summaries", DAILY_DIR, year, month, dayFile);

--- a/server/workspace/journal/memoryExtractor.ts
+++ b/server/workspace/journal/memoryExtractor.ts
@@ -1,11 +1,5 @@
-// Extracts durable user facts from chat session excerpts and
-// appends them to memory.md. Called at the end of the journal
-// daily pass so new facts are picked up even if the agent didn't
-// write them during the conversation.
-//
-// Only appends facts that aren't already in memory.md — the LLM
-// receives the current memory content as context and is instructed
-// to return ONLY new facts.
+// Run at end of the journal daily pass so durable user facts are picked up even if the agent didn't memo them in-conversation.
+// LLM receives existing memory.md as context and is instructed to return ONLY new facts (we still de-dupe defensively).
 
 import { readFileSync, existsSync } from "fs";
 import path from "path";
@@ -40,16 +34,10 @@ Rules:
 
 export interface MemoryExtractionDeps {
   workspaceRoot: string;
-  /** The excerpts from today's dirty sessions, concatenated. */
   excerpts: string;
-  /** Spawns claude CLI and returns stdout. Injectable for tests. */
   summarize: (systemPrompt: string, userPrompt: string) => Promise<string>;
 }
 
-/**
- * Extract new user facts from chat excerpts and append to memory.md.
- * Returns the number of facts appended (0 if none found or on error).
- */
 export async function extractAndAppendMemory(deps: MemoryExtractionDeps): Promise<number> {
   const memoryPath = path.join(deps.workspaceRoot, WORKSPACE_FILES.memory);
   const existingMemory = existsSync(memoryPath) ? readFileSync(memoryPath, "utf-8") : "";
@@ -80,7 +68,6 @@ export async function extractAndAppendMemory(deps: MemoryExtractionDeps): Promis
   return factsToAppend.length;
 }
 
-/** Build the user prompt with existing memory + new excerpts. */
 export function buildUserPrompt(existingMemory: string, excerpts: string): string {
   const parts: string[] = [];
   if (existingMemory.trim()) {
@@ -91,7 +78,6 @@ export function buildUserPrompt(existingMemory: string, excerpts: string): strin
   return parts.join("\n\n");
 }
 
-/** Parse LLM output into a list of fact strings. */
 export function parseExtractedFacts(raw: string): string[] {
   const trimmed = raw.trim();
   if (trimmed === "NONE" || trimmed === "") return [];
@@ -106,7 +92,6 @@ function normalizeFact(fact: string): string {
   return fact.replace(/^- /, "").trim().toLowerCase();
 }
 
-/** Remove facts that already exist in the current memory content. */
 export function filterNewFacts(existingMemory: string, facts: readonly string[]): string[] {
   const seen = new Set(parseExtractedFacts(existingMemory).map(normalizeFact));
   const out: string[] = [];
@@ -119,7 +104,6 @@ export function filterNewFacts(existingMemory: string, facts: readonly string[])
   return out;
 }
 
-/** Append facts to existing memory content. */
 export function appendFacts(existing: string, facts: string[]): string {
   const trimmed = existing.trimEnd();
   const factsBlock = facts.join("\n");

--- a/server/workspace/journal/optimizationPass.ts
+++ b/server/workspace/journal/optimizationPass.ts
@@ -1,8 +1,3 @@
-// Weekly-ish topic optimization pass: merge near-duplicates, move
-// stale topics into archive/. Separate file from dailyPass so the
-// two can evolve independently and so the optimizer stays opt-in
-// from the top-level runner.
-
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { writeTopicFile, readAllTopicFiles, archiveTopic } from "../../utils/files/journal-io.js";
 import {
@@ -17,7 +12,6 @@ import { slugify } from "./paths.js";
 import type { JournalState } from "./state.js";
 import { log } from "../../system/logger/index.js";
 
-// How many characters of each topic file we hand to the optimizer.
 // Enough to judge duplication without blowing up the prompt.
 const OPTIMIZER_HEAD_CHARS = 500;
 
@@ -33,10 +27,7 @@ export interface OptimizationPassResult {
   skippedReason?: string;
 }
 
-// Pure planner: turns the optimizer's raw merge instructions into a
-// concrete list of slug-level operations. Empty merges (where every
-// source resolves to the merge target itself) are dropped, and slugs
-// are normalized via slugify so the I/O layer never has to.
+// Drops empty merges (every source resolves to the target itself); normalizes via slugify so the I/O layer never has to.
 export interface MergePlanItem {
   intoSlug: string;
   fromSlugs: string[];
@@ -60,8 +51,6 @@ export function planMerges(merges: readonly RawMerge[]): MergePlanItem[] {
   return plans;
 }
 
-// Pure transform: returns the next JournalState with any slug in
-// `removed` filtered out of knownTopics.
 export function applyRemovedTopics(state: JournalState, removed: ReadonlySet<string>): JournalState {
   return {
     ...state,
@@ -73,10 +62,7 @@ async function executeMergePlans(workspaceRoot: string, plans: MergePlanItem[], 
   for (const plan of plans) {
     await writeTopicFile(plan.intoSlug, plan.newContent, workspaceRoot);
     for (const src of plan.fromSlugs) {
-      // Only record the merge as successful if the source file
-      // actually moved. If archiveTopic fails (missing file, IO
-      // error) we leave the source out of the removed set so the
-      // in-memory knownTopics state stays accurate.
+      // Skip on archive failure so in-memory knownTopics stays accurate (the source file didn't actually move).
       if (!(await archiveTopic(src, workspaceRoot))) continue;
       removed.add(src);
       mergedSlugs.push(src);
@@ -107,9 +93,7 @@ export async function runOptimizationPass(
 
   const topics = await loadTopicHeads(workspaceRoot);
   if (topics.length < 2) {
-    // Nothing to optimise — need at least 2 topics for a merge to
-    // be meaningful, and archiving a single topic would leave an
-    // empty journal which feels wrong.
+    // Need at least 2 topics for a merge to be meaningful; archiving a sole topic would leave an empty journal.
     result.skipped = true;
     result.skippedReason = "fewer than 2 topics";
     return { nextState: { ...state }, result };
@@ -138,8 +122,7 @@ export async function runOptimizationPass(
 
   const removed = new Set<string>();
 
-  // Apply merges first, then archives (which skip slugs already
-  // removed by a merge).
+  // Merges first, then archives (which skip slugs already removed by a merge).
   await executeMergePlans(workspaceRoot, planMerges(parsed.merges), removed, result.mergedSlugs);
   await executeArchives(workspaceRoot, parsed.archives, removed, result.archivedSlugs);
 

--- a/server/workspace/journal/paths.ts
+++ b/server/workspace/journal/paths.ts
@@ -1,15 +1,8 @@
-// Pure path / slug helpers for the workspace journal. Nothing here
-// touches the filesystem — every function is a straightforward
-// string transformation so it can be exhaustively unit-tested.
-
 import path from "node:path";
 import { WORKSPACE_DIRS } from "../paths.js";
 import { isValidIsoDate } from "../../utils/date.js";
 import { slugify as slugifyCanonical } from "../../utils/slug.js";
 
-// Directory layout under workspace/conversations/summaries/ is an
-// implementation detail of the journal module; keep it centralised
-// here so tests and callers all agree on the structure.
 export const SUMMARIES_DIR = WORKSPACE_DIRS.summaries;
 export const STATE_FILE = "_state.json";
 export const INDEX_FILE = "_index.md";
@@ -17,16 +10,12 @@ export const DAILY_DIR = "daily";
 export const TOPICS_DIR = "topics";
 export const ARCHIVE_DIR = "archive";
 
-// Absolute path to the summaries root inside a workspace.
 export function summariesRoot(workspaceRoot: string): string {
   return path.join(workspaceRoot, SUMMARIES_DIR);
 }
 
-// summaries/daily/YYYY/MM/DD.md for a given ISO-ish date ("YYYY-MM-DD").
-// Throws if `isoDate` is not exactly YYYY-MM-DD — catches typos at
-// the boundary instead of producing "undefined/undefined.md" paths
-// downstream.
 export function dailyPathFor(workspaceRoot: string, isoDate: string): string {
+  // Throw at the boundary so a typo doesn't produce "undefined/undefined.md".
   if (!isValidIsoDate(isoDate)) {
     throw new Error(`[journal] dailyPathFor: expected YYYY-MM-DD, got "${isoDate}"`);
   }
@@ -34,27 +23,19 @@ export function dailyPathFor(workspaceRoot: string, isoDate: string): string {
   return path.join(summariesRoot(workspaceRoot), DAILY_DIR, year, month, `${day}.md`);
 }
 
-// summaries/topics/<slug>.md
 export function topicPathFor(workspaceRoot: string, slug: string): string {
   return path.join(summariesRoot(workspaceRoot), TOPICS_DIR, `${slug}.md`);
 }
 
-// summaries/archive/topics/<slug>.md — where the optimizer moves
-// merged or stale topic files.
 export function archivedTopicPathFor(workspaceRoot: string, slug: string): string {
   return path.join(summariesRoot(workspaceRoot), ARCHIVE_DIR, TOPICS_DIR, `${slug}.md`);
 }
 
-// Re-export for backwards compatibility — callers that import
-// toIsoDate from journal/paths keep working.
 export { toLocalIsoDate as toIsoDate } from "../../utils/date.js";
 
-// Convert a free-form topic name into a filesystem-safe slug. Thin
-// wrapper around the canonical `slugify` (server/utils/slug.ts) with
-// the journal-specific fallback "topic". See #732 for why journal
-// stopped using its own ASCII-only impl: pure-non-ASCII topic names
-// (e.g. "プロジェクトA" / "プロジェクトB") all collapsed to "topic"
-// and silently overwrote each other's summary files.
+// Falls through to slugifyCanonical with a journal-specific "topic" fallback.
+// #732 retired the journal's own ASCII-only impl that collapsed every
+// non-ASCII topic name onto a single overwriting "topic".
 export function slugify(raw: string): string {
   return slugifyCanonical(raw, "topic");
 }

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -1,12 +1,3 @@
-// Journal state file schema + persistence. The state file tracks
-// what the archivist has already done so we only re-process new or
-// changed sessions on each run.
-//
-// The pure bits (default creation, schema validation, interval
-// arithmetic) live at the top of the file so tests can exercise
-// them without touching disk. Filesystem helpers at the bottom wrap
-// those pure functions with atomic read/write.
-
 import {
   readJournalState as readJournalStateRaw,
   writeJournalState as writeJournalStateRaw,
@@ -16,16 +7,12 @@ import { ONE_HOUR_MS, ONE_DAY_MS } from "../../utils/time.js";
 import { log } from "../../system/logger/index.js";
 import { isRecord } from "../../utils/types.js";
 
-// Bump this when the schema changes in a backwards-incompatible way.
-// Older state files are treated as corrupted and replaced with a
-// fresh default (ingest everything from scratch) — cheap because it
-// only costs one extra archivist pass.
+// Bump on backwards-incompatible schema changes — older state files
+// are discarded and rebuilt (one extra archivist pass).
 export const JOURNAL_STATE_VERSION = 1;
 
 export interface ProcessedSessionRecord {
-  // mtime (ms since epoch) of the session's .jsonl file when we
-  // last ingested it. If mtime advances on the next run, the session
-  // has appended events and needs re-ingest.
+  // mtime at last ingest; advance triggers re-ingest of appended events.
   lastMtimeMs: number;
 }
 
@@ -42,8 +29,6 @@ export interface JournalState {
 export const DEFAULT_DAILY_INTERVAL_HOURS = 1;
 export const DEFAULT_OPTIMIZATION_INTERVAL_DAYS = 7;
 
-// --- Pure helpers (unit-testable without disk) ---------------------
-
 export function defaultState(): JournalState {
   return {
     version: JOURNAL_STATE_VERSION,
@@ -56,17 +41,13 @@ export function defaultState(): JournalState {
   };
 }
 
-// Narrow an `unknown` into a JournalState. Accepts partial / missing
-// fields and fills defaults — users can hand-edit the file to change
-// intervals and we want to be forgiving.
+// Forgiving toward partial / hand-edited input — fill defaults instead of throwing.
 export function parseState(raw: unknown): JournalState {
   if (!isRecord(raw)) return defaultState();
   const obj = raw as Record<string, unknown>;
 
-  // Version mismatch → throw it all out. Cheap to rebuild — but
-  // surface the event in the log so a postmortem can distinguish a
-  // forced re-ingest from "first run after install" / a deleted
-  // state file. (#799 PR1)
+  // Log the version-mismatch reset (#799 PR1) so postmortems can tell
+  // it apart from a missing-file first run.
   if (obj.version !== JOURNAL_STATE_VERSION) {
     log.info("journal", "state schema version mismatch — resetting", {
       from: obj.version,
@@ -101,8 +82,6 @@ function parseProcessedSessions(raw: unknown): Record<string, ProcessedSessionRe
   return out;
 }
 
-// Has the configured daily interval elapsed since the last run? A
-// null lastDailyRunAt means "never run" → always due.
 export function isDailyDue(state: JournalState, nowMs: number): boolean {
   if (state.lastDailyRunAt === null) return true;
   const last = Date.parse(state.lastDailyRunAt);
@@ -118,8 +97,6 @@ export function isOptimizationDue(state: JournalState, nowMs: number): boolean {
   const intervalMs = state.optimizationIntervalDays * ONE_DAY_MS;
   return nowMs - last >= intervalMs;
 }
-
-// --- Filesystem helpers (delegated to journal-io) --------------------
 
 export async function readState(workspaceRoot: string): Promise<JournalState> {
   const raw = await readJournalStateRaw<unknown>(null, workspaceRoot);

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -86,8 +86,7 @@ defineExpose({ root });
 </script>
 
 <style scoped>
-/* Prevent rendered markdown links inside preview cards from navigating.
-   Clicking a sidebar card should select the result, not follow links. */
+/* Card click selects the result; rendered markdown links inside the preview must not navigate. */
 :deep(a) {
   pointer-events: none;
   color: inherit;

--- a/src/composables/useActiveSession.ts
+++ b/src/composables/useActiveSession.ts
@@ -1,40 +1,19 @@
-// Provide/inject contract for the currently-active chat session.
-//
-// Plugin Views (e.g. MulmoScript) need two things from the app-level
-// session state:
-//
-//   1. The `chatSessionId` so they can tag long-running work (image /
-//      audio / movie generation) on the right session channel.
-//   2. A reactive view of `pendingGenerations` so they can derive
-//      per-beat / per-character "rendering" spinners from the same
-//      map the sidebar busy-indicator reads. This lets the spinner
-//      survive View unmount/remount across session switches.
-//
-// Rather than thread two new props through every plugin's
-// `<component :is="...">` mount point, we expose the active session
-// via provide/inject — same pattern as useAppApi.
+// Provide/inject so plugin Views see chatSessionId + pendingGenerations without threading props through every
+// `<component :is="…">` mount point — and the spinner derived from pendingGenerations survives View remounts.
 
 import { inject, provide, type Ref } from "vue";
 import type { ActiveSession } from "../types/session";
 
-/**
- * Ref to the currently-active session. May be `undefined` during the
- * brief window before the first session loads.
- */
+// May be `undefined` during the brief window before the first session loads.
 export type ActiveSessionRef = Ref<ActiveSession | undefined>;
 
 const ACTIVE_SESSION_KEY = Symbol("activeSession");
 
-/** Called once in App.vue setup to expose the ref to descendants. */
 export function provideActiveSession(ref: ActiveSessionRef): void {
   provide(ACTIVE_SESSION_KEY, ref);
 }
 
-/**
- * Plugin Views call this to observe the active session. Returns
- * `undefined` when used outside an App.vue subtree (e.g. in a unit
- * test) so plugins can render standalone without the provider.
- */
+// Returns `undefined` outside an App.vue subtree so plugins can render standalone in unit tests.
 export function useActiveSession(): ActiveSessionRef | undefined {
   return inject<ActiveSessionRef>(ACTIVE_SESSION_KEY);
 }

--- a/src/composables/useAppApi.ts
+++ b/src/composables/useAppApi.ts
@@ -1,64 +1,26 @@
-// Vue provide/inject contract that lets plugin Views call back into
-// App.vue without going through window-level CustomEvents.
-//
-// Background: plugins like manageRoles and manageSkills used to
-// dispatch `roles-updated` / `skill-run` on `window` and App.vue
-// listened with `addEventListener`. That worked but routed
-// component-to-component communication through a global side channel,
-// which got hard to follow as more plugins came online (#227).
-//
-// `provide` / `inject` is the Vue-native equivalent: App.vue provides
-// a small typed API surface, plugins inject and call methods directly.
-// No string event names, full type-checking, no chance of a typo
-// silently failing.
+// #227: replaced window CustomEvent dispatch (`roles-updated`, `skill-run`) with provide/inject so plugin → App
+// communication is type-checked instead of routed through string event names.
 
 import { inject, provide } from "vue";
 
-/** API surface that plugin Views can call on App.vue. */
 export interface AppApi {
-  /** Refresh the role dropdown — call after the roles list changes. */
   refreshRoles: () => void | Promise<void>;
-  /** Send a chat message through App.vue's normal sendMessage pipeline. */
   sendMessage: (message: string) => void;
-  /**
-   * Open a fresh chat session and send `message` as its first turn.
-   * Used by plugin views that want to kick off a new conversation
-   * instead of threading into whatever session happens to be active.
-   * Pass `roleId` to override the role for this one session (e.g. a
-   * wiki lint needs the General role even if the user is currently
-   * viewing the wiki under a different role); omit it to inherit the
-   * currently selected role.
-   */
+  // roleId overrides for one-off sessions (e.g. wiki lint must run as General even if the user is on a different role).
   startNewChat: (message: string, roleId?: string) => void;
-  /** Navigate to a workspace-internal link (wiki page, file, session). */
   navigateToWorkspacePath: (href: string) => void;
-  /**
-   * Look up the timestamp (epoch ms) recorded for a tool result in
-   * the active session's `resultTimestamps` map. For results that
-   * arrived via the live SSE stream this is the actual time the
-   * result was added; for results loaded from a saved jsonl this is
-   * the session's `startedAt` baseline (per-entry timestamps aren't
-   * persisted in the jsonl yet — see `pushResult` in
-   * `utils/session/sessionHelpers.ts`). Returns `undefined` when the
-   * uuid isn't in the active session.
-   */
+  // Live SSE stream stamps real arrival times; jsonl-loaded results fall back to the session's startedAt baseline
+  // because per-entry timestamps aren't persisted yet (see pushResult in utils/session/sessionHelpers.ts).
   getResultTimestamp: (uuid: string) => number | undefined;
 }
 
 const APP_API_KEY = Symbol("appApi");
 
-/** Called once in App.vue setup to expose the API to descendants. */
 export function provideAppApi(api: AppApi): void {
   provide(APP_API_KEY, api);
 }
 
-/**
- * Called by plugin Views (any descendant of App.vue) to access the API.
- *
- * Throws if used outside an App.vue subtree — if you need a no-op
- * fallback (e.g. a plugin rendered in isolation in a test), pass a
- * default-returning callback to `inject` directly instead.
- */
+// Throws when called outside an App.vue subtree; tests that render a plugin in isolation should call inject directly.
 export function useAppApi(): AppApi {
   const api = inject<AppApi>(APP_API_KEY);
   if (!api) {

--- a/src/composables/useClipboardCopy.ts
+++ b/src/composables/useClipboardCopy.ts
@@ -1,21 +1,5 @@
-// "Copy to clipboard with a transient confirmation flag" — the
-// same 9-line pattern was copied into 3 plugin views
-// (markdown / presentMulmoScript / textResponse) before this
-// composable existed.
-//
-// Usage:
-//
-//   const { copied, copy } = useClipboardCopy();
-//
-//   async function copyText() {
-//     await copy(textToCopy.value);
-//   }
-//
-// `copied` flips to true on success and back to false after
-// `resetMs` (default 2000ms) so the UI can show a ✓ / "Copied!"
-// hint. Clipboard failures (permissions, insecure context) are
-// swallowed on purpose — there's no useful UI action beyond letting
-// the hint stay off, which is exactly what the ref signals.
+// Clipboard failures (permissions, insecure context) are swallowed on purpose: the UI just leaves the "Copied!" hint
+// off, which is what `copied=false` already signals.
 
 import { ref, type Ref } from "vue";
 
@@ -35,8 +19,7 @@ export function useClipboardCopy(resetMs = 2000): UseClipboardCopyHandle {
         copied.value = false;
       }, resetMs);
     } catch {
-      // Clipboard API may be blocked in some contexts (e.g. iframe
-      // without permissions, non-HTTPS origin). Leave `copied` false.
+      // Clipboard API blocked (iframe without permissions, non-HTTPS origin) — leave `copied` false.
     }
   }
 

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,40 +1,19 @@
-// Dynamic favicon that changes its backing color based on a rich
-// runtime context (#470 + palette expansion).
-//
-// Color selection moved to `./favicon/resolveColor.ts`; this module
-// is now a thin canvas renderer that takes the already-resolved
-// color and paints it behind the mascot. The split keeps the pixel-
-// level drawing code and the rule chain independently testable.
-//
-// Rendering details:
-// - The logo PNG has an opaque white background; on first load we
-//   pre-process the pixels, punching near-white to transparency so
-//   the resolved color shows through.
-// - If the PNG fails to load we fall back to a plain colored square
-//   with the letter "M" so the tab icon never blanks out.
+// #470: dynamic favicon. Logo PNG has an opaque white backing; on first load we punch near-white pixels to alpha so
+// the resolved color shows through. If the PNG fails to load we fall back to a plain colored square with letter "M".
 
 import { watch, type Ref, type ComputedRef } from "vue";
 import logoUrl from "../assets/mulmo_bw.png";
 
-// Keep the palette-independent display constants local to this file
-// — they describe pixel geometry, not semantics.
 const NOTIFICATION_DOT_COLOR = "#DC2626"; // red-600
 const ACTIVE_SESSION_DOT_COLOR = "#EAB308"; // yellow-500
 const SIZE = 32;
 const RADIUS = 6;
-// How much of the rounded square the mascot fills. 2 px of padding
-// on each side keeps it off the rounded corners and leaves room for
-// the colored backing to peek around the outline.
+// 2px on each side keeps the mascot off the rounded corners and lets the colored backing peek around the outline.
 const MASCOT_INSET = 2;
 
-// Pixels whose RGB channels are all above this are treated as the
-// PNG's white backing and punched to transparent. The PNG uses soft
-// pastels so the mascot itself never hits all three channels this
-// high.
+// Threshold for "is this the PNG's white backing?" — the mascot uses soft pastels so it never hits all three channels this high.
 const WHITE_TO_ALPHA_THRESHOLD = 235;
 const FEATHER_LOW = 205;
-
-// ── Asset loading ──────────────────────────────────────────────
 
 let logoCanvas: HTMLCanvasElement | null = null;
 let logoLoadFailed = false;
@@ -92,8 +71,6 @@ function buildTransparentLogoCanvas(img: HTMLImageElement): HTMLCanvasElement {
   return canvas;
 }
 
-// ── Drawing primitives ─────────────────────────────────────────
-
 function drawRoundedRect(ctx: CanvasRenderingContext2D, posX: number, posY: number, width: number, height: number, radius: number): void {
   ctx.beginPath();
   ctx.moveTo(posX + radius, posY);
@@ -138,8 +115,6 @@ function drawActiveSessionDot(ctx: CanvasRenderingContext2D): void {
   const dotR = 5;
   drawCornerDot(ctx, dotR + 1, dotR + 1, ACTIVE_SESSION_DOT_COLOR);
 }
-
-// ── Composition ────────────────────────────────────────────────
 
 function renderFallbackFavicon(ctx: CanvasRenderingContext2D, color: string, isRunning: boolean, hasNotification: boolean): void {
   drawRoundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
@@ -226,6 +201,5 @@ export function useDynamicFavicon(opts: DynamicFaviconOpts): void {
   );
 }
 
-// Re-export the state enum from the new location so existing callers
-// continue to import from this file during the transition period.
+// Re-exported so existing callers of this file keep working during the resolveColor split's transition.
 export { FAVICON_STATES, type FaviconState } from "./favicon/types";

--- a/src/composables/useEventListeners.ts
+++ b/src/composables/useEventListeners.ts
@@ -1,27 +1,7 @@
-// Composable that wires the window-level event listeners used by
-// App.vue (global keydown for arrow-key navigation / Esc) and tears
-// them down on unmount.
-//
-// Plugin → App.vue communication used to live here too via
-// `roles-updated` / `skill-run` CustomEvents on `window`. That now
-// flows through `useAppApi` (provide/inject) — see #227. Anything
-// remaining in this composable is genuinely a window-level concern
-// (keyboard events that don't have a single "owning" component).
-//
-// The click-outside handler for the history popup was dropped when
-// the popup became a real page at /history (see
-// plans/done/feat-history-url-route.md).
-//
-// Each listener is supplied as an option so the composable stays
-// independent of App.vue's local state; the caller passes the
-// already-bound handlers.
-
 import { onMounted, onUnmounted } from "vue";
 
 export interface EventListenerHandlers {
-  /** Global keydown for arrow-key navigation / Esc handling. */
   onKeyNavigation: (e: KeyboardEvent) => void;
-  /** Called in onUnmounted after all window listeners are removed. */
   onTeardown?: () => void;
 }
 

--- a/src/composables/useExpandedDirs.ts
+++ b/src/composables/useExpandedDirs.ts
@@ -1,10 +1,3 @@
-// Composable for the FileTree expand/collapse state. Owns a
-// module-level reactive Set so every recursive FileTree instance
-// shares the same state, and persists changes to localStorage.
-//
-// The pure parsing helpers live in src/utils/files/expandedDirs.ts
-// so the rules are unit-testable without a Vue runtime.
-
 import { ref, watch, type Ref } from "vue";
 import { EXPANDED_DIRS_STORAGE_KEY, parseStoredExpandedDirs, serializeExpandedDirs } from "../utils/files/expandedDirs";
 
@@ -19,16 +12,14 @@ function loadInitial(): Set<string> {
   }
 }
 
-// Module-level singleton: every FileTree instance imports this
-// composable and reads/writes the same Set.
+// Module-level so every recursive FileTree instance reads/writes the same Set.
 const expandedDirs: Ref<Set<string>> = ref(loadInitial());
 
 watch(expandedDirs, (val) => {
   try {
     localStorage.setItem(EXPANDED_DIRS_STORAGE_KEY, serializeExpandedDirs(val));
   } catch {
-    // localStorage may be disabled (private mode) or full; ignore
-    // and keep the in-memory state working for this session.
+    // localStorage disabled (private mode) or full — in-memory state still works for this session.
   }
 });
 
@@ -42,15 +33,13 @@ export function useExpandedDirs(): {
     return expandedDirs.value.has(path);
   }
   function toggle(path: string): void {
-    // Replace the Set so the watch fires — Set mutations aren't
-    // tracked by Vue's reactivity.
+    // Replace the Set so the watch fires — Set mutations aren't tracked.
     const next = new Set(expandedDirs.value);
     if (next.has(path)) next.delete(path);
     else next.add(path);
     expandedDirs.value = next;
   }
-  // Idempotently mark a path as expanded (used by deep-link auto-
-  // expand where we want to reveal ancestors without toggling).
+  // Idempotent: deep-link auto-expand reveals ancestors without toggling collapsed siblings closed.
   function expand(path: string): void {
     if (expandedDirs.value.has(path)) return;
     const next = new Set(expandedDirs.value);

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,14 +1,5 @@
-// Dynamic favicon wiring.
-//
-// Assembles the full `FaviconContext` from reactive app signals
-// (`isRunning`, `sessionsUnreadCount`, a ticking clock, server CPU
-// load, optional user birthday), feeds it through the pure
-// `resolveFaviconColor` rule chain, and hands the resolved color
-// to `useDynamicFavicon` for painting.
-//
-// Every input is global: the user is frequently on /files or other
-// non-chat views where `activeSession` is undefined, so relying on
-// the on-screen session would silently miss background activity.
+// Inputs are global on purpose — on /files or other non-chat views activeSession is undefined, so an on-screen-only
+// signal would silently miss background activity.
 
 import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from "vue";
 import { useDynamicFavicon } from "./useDynamicFavicon";
@@ -17,9 +8,7 @@ import { resolveFaviconColor } from "./favicon/resolveColor";
 import { FAVICON_STATES, type FaviconContext, type FaviconState } from "./favicon/types";
 import type { SessionSummary } from "../types/session";
 
-// Ticking cadence for the clock context. Once per minute is enough
-// to cross the morning / late-night / weekend / running-long
-// boundaries — we don't need second-level precision in a tab icon.
+// One minute is enough to cross morning/late-night/weekend/running-long boundaries — no need for second-level precision.
 const FAVICON_TICK_MS = 60_000;
 
 export function useFaviconState(opts: {
@@ -35,35 +24,16 @@ export function useFaviconState(opts: {
 }) {
   const { isRunning, sessions, sessionsUnreadCount, cpuLoadRatio, userBirthdayMMDD } = opts;
 
-  // 4-state enum still drives state priority inside the resolver.
-  // `done` here means "somebody somewhere has an unread reply", not
-  // "the on-screen session finished" — the dot already communicates
-  // that per session in the sidebar.
+  // `done` means "somebody somewhere has an unread reply" — per-session done is already communicated by the sidebar dot.
   const faviconState = computed<FaviconState>(() => {
     if (isRunning.value) return FAVICON_STATES.running;
     if (sessionsUnreadCount.value > 0) return FAVICON_STATES.done;
     return FAVICON_STATES.idle;
   });
 
-  // Run-start timestamp — the **earliest** `updatedAt` across every
-  // running session. `updatedAt` is bumped the moment the user sends
-  // a message (right before a run begins) and stays pinned until the
-  // run ends, so it's a safe proxy for "this run started at…".
-  //
-  // Caller passes `mergedSessions` (live in-memory state OR'd with
-  // server summaries), so this scan picks up two things the raw
-  // server `sessions` list would miss until the next /api/sessions
-  // refetch:
-  //   • `beginUserTurn`'s synchronous `live.updatedAt` stamp, so the
-  //     runningLong clock is anchored to the actual user click, not
-  //     the refetch arrival time.
-  //   • `live.pendingGenerations` (folded into the merged summary's
-  //     `isRunning`), so a generation kicked off by the bridge or a
-  //     background tab counts the moment its event lands.
-  //
-  // Falls back to `Date.now()` only if no running session has a
-  // parseable `updatedAt` (brand-new session before the first
-  // server echo and before `beginUserTurn`).
+  // Earliest updatedAt across running sessions. updatedAt is bumped on user-send (before the run begins) and stays
+  // pinned until the run ends, so it's a safe "this run started at…" proxy. Caller passes mergedSessions (live OR
+  // server) so beginUserTurn's synchronous stamp + live.pendingGenerations land before the next /api/sessions refetch.
   const runningSinceMs = computed<number | null>(() => {
     if (!isRunning.value) return null;
     let earliest = Number.POSITIVE_INFINITY;
@@ -75,10 +45,8 @@ export function useFaviconState(opts: {
     return Number.isFinite(earliest) ? earliest : Date.now();
   });
 
-  // Per-minute tick so time-of-day rules (morning, late-night,
-  // weekend) pick up boundary crossings without the user needing to
-  // interact. Also re-evaluates running-long so the cyan shift lands
-  // within a minute of the 60-second mark.
+  // Per-minute tick: drives boundary crossings (morning/late-night/weekend) without needing user interaction, and lets
+  // running-long flip cyan within a minute of the 60-second mark.
   const clockTick = ref<Date>(new Date());
   const tickHandle = window.setInterval(() => {
     clockTick.value = new Date();
@@ -98,9 +66,7 @@ export function useFaviconState(opts: {
   });
 
   const { unreadCount: notificationUnreadCount } = useNotifications();
-  // Badge dot fires on either pub-sub notifications (scheduled
-  // tasks, etc.) or any session carrying unread chat messages —
-  // the dot itself doesn't distinguish source.
+  // The dot doesn't distinguish source: pub-sub notifications OR any session with unread chat both trigger it.
   const hasNotificationBadge = computed(() => notificationUnreadCount.value > 0 || sessionsUnreadCount.value > 0);
 
   useDynamicFavicon({

--- a/src/composables/useFreshPluginData.ts
+++ b/src/composables/useFreshPluginData.ts
@@ -1,32 +1,7 @@
-// Shared fetch-fresh-data-on-mount pattern for plugin view / preview
-// components. Each affected plugin (todo, scheduler, wiki, manageRoles)
-// used to duplicate the same onMounted + AbortController + JSON parse
-// + apply routine in 8 files. This composable factors it out and
-// drives 3 distinct flavours via callbacks:
-//
-//   endpoint(): returns the URL to fetch. A function (not a string)
-//     so callers can derive it from local refs — wiki/View picks
-//     between /api/wiki and /api/wiki?slug=... depending on the
-//     current action.
-//
-//   extract(json): pulls the data off the response envelope. Three
-//     shapes in practice:
-//       - json.data.items     (todo / scheduler)
-//       - json.data           (wiki — the whole WikiData object)
-//       - bare array          (manageRoles — /api/roles returns an
-//                              unwrapped CustomRole[])
-//     Return `null` to skip the apply step (e.g. response malformed
-//     or the caller wants to ignore a particular payload).
-//
-//   apply(data): writes into the caller's local refs. Callers can
-//     guard here — wiki/Preview only applies the index payload when
-//     it's currently showing the index view, because the preview is
-//     reused for page / log / lint_report previews.
-//
-// Lifecycle: `onMounted` fires one initial refresh. `onUnmounted`
-// aborts any in-flight request. Callers can also call `refresh()`
-// explicitly (e.g. from a `watch(() => props.selectedResult.uuid)`
-// to re-fetch when switching between tool results).
+// endpoint() is a function (not a string) so callers can derive the URL from local refs — wiki/View flips between
+// /api/wiki and /api/wiki?slug=… depending on action. extract() returns null to skip apply (malformed or
+// caller-ignored payload). apply() callers can guard — wiki/Preview only applies the index payload when showing the
+// index view, since the preview component is reused for page / log / lint_report previews.
 
 import { onMounted, onUnmounted } from "vue";
 import { apiGet } from "../utils/api";
@@ -38,26 +13,14 @@ export interface UseFreshPluginDataOptions<T> {
 }
 
 export interface UseFreshPluginDataHandle {
-  // Abort any in-flight fetch and fire a new one. Returns true if
-  // the response was applied, false on abort / non-OK / malformed /
-  // apply-skipped. Callers can await this when they want to know
-  // whether the refresh succeeded (e.g. for a manual retry flow).
+  // Returns true if the response was applied; false on abort / non-OK / malformed / apply-skipped.
   refresh: () => Promise<boolean>;
-
-  // Cancel any in-flight fetch without firing a new one. Called
-  // automatically by the composable on component unmount.
   abort: () => void;
 }
 
-// Pure core of the refresh logic, exported separately so tests can
-// exercise it without spinning up a Vue component lifecycle. The
-// composable below wraps this with AbortController / onMounted /
-// onUnmounted management.
 export async function refreshOnce<T>(opts: UseFreshPluginDataOptions<T>, signal: AbortSignal): Promise<boolean> {
   const result = await apiGet<unknown>(opts.endpoint(), undefined, { signal });
-  // AbortError / network error / non-OK HTTP / malformed JSON all land
-  // as { ok: false }. The caller still has prop-initialised state as a
-  // fallback, so a failed refresh is a silent no-op.
+  // Failed refresh is a silent no-op: prop-initialised state stands in. apiGet collapses every failure into ok:false.
   if (signal.aborted || !result.ok) return false;
   const extracted = opts.extract(result.data);
   if (extracted === null) return false;

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -1,25 +1,12 @@
-// Composable for the server /api/health probe.
-//
-// Owns three refs that the UI reads (gemini key availability +
-// sandbox toggle + server CPU load ratio) plus a one-shot fetch
-// that populates them on mount, plus an optional periodic refresh
-// for the CPU ratio (the favicon's "overloaded" rule needs a live
-// signal, not a boot-time snapshot).
-//
-// On fetch failure we assume Gemini is unavailable so dependent UI
-// (e.g. the "generate image" plugin buttons) falls back gracefully
-// — the sandbox flag keeps its initial `true` so the lock indicator
-// doesn't momentarily flash "sandbox disabled" on a transient error,
-// and the CPU ratio goes to null so the favicon resolver skips the
-// overloaded rule rather than guessing.
+// On fetch failure: assume gemini unavailable (so "generate image" buttons fall back gracefully); keep sandbox=true
+// so the lock indicator doesn't flash off on a transient error; null cpu so the favicon resolver skips overloaded
+// rather than guessing.
 
 import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import { apiGet } from "../utils/api";
 
-// Once every 15 s is enough for a sustained load spike to light the
-// favicon. Shorter would mostly flap on short-lived spikes that
-// aren't actually user-visible as lag.
+// 15s catches sustained load without flapping on short-lived spikes that aren't user-visible as lag.
 const HEALTH_REFRESH_MS = 15_000;
 
 interface CpuPayload {
@@ -44,29 +31,18 @@ export function useHealth(): {
   const cpuLoad1 = ref<number | null>(null);
   const cpuCores = ref<number | null>(null);
 
-  // Separate flag so transient poll failures don't flip
-  // `geminiAvailable` back to false after a successful boot-time
-  // fetch. `geminiAvailable` / `sandboxEnabled` are config-derived
-  // and don't change at runtime — once we've observed them once,
-  // the next 15 s poll's network blip shouldn't mask them.
+  // gemini/sandbox are config-derived and don't change at runtime; once observed, a poll blip shouldn't unmask them.
   let bootFetchCompleted = false;
 
   async function fetchHealth(): Promise<void> {
     const result = await apiGet<HealthResponse>(API_ROUTES.health);
     if (!result.ok) {
-      // Only the CPU figures get nulled — the favicon resolver
-      // reads null as "skip overloaded" which is the correct fail-
-      // closed behaviour. The config flags keep their last-known
-      // values, and stay at the initial defaults if we never
-      // succeeded (gemini=true → request lands, gets an auth error
-      // handled elsewhere; sandbox=true → lock indicator reads on).
+      // Null only the CPU figures — the resolver reads null as "skip overloaded" (fail-closed). Config flags keep
+      // their last-known values, defaults if never observed (gemini=true → auth error elsewhere, sandbox=true → on).
       cpuLoad1.value = null;
       cpuCores.value = null;
       if (!bootFetchCompleted) {
-        // On the FIRST fetch we do still flip gemini → false so
-        // the "Gemini key required" banner can show immediately
-        // without waiting for a second attempt. Subsequent poll
-        // failures don't re-enter this branch.
+        // First-fetch only: flip gemini → false so the "Gemini key required" banner shows without waiting for retry.
         geminiAvailable.value = false;
       }
       return;
@@ -84,20 +60,15 @@ export function useHealth(): {
     }
   }
 
-  // Refresh the CPU figure periodically. The flag-style booleans
-  // (gemini / sandbox) don't change at runtime so re-fetching them
-  // is waste; but piggy-backing on the same endpoint keeps the
-  // server side to a single route and the client to a single poll.
+  // Piggy-backs cpu refresh on the health endpoint to keep server + client to a single route/poll.
   const refreshHandle = window.setInterval(() => {
     fetchHealth().catch(() => {
-      /* intentionally swallowed — a failed poll just stalls the
-         favicon's overloaded rule, not user-visible UI */
+      /* swallowed: a failed poll just stalls the favicon overloaded rule, not user-visible UI */
     });
   }, HEALTH_REFRESH_MS);
   onScopeDispose(() => window.clearInterval(refreshHandle));
 
-  // Expose the normalised ratio the favicon resolver expects (load
-  // per logical core). Null when either component is missing.
+  // load1 per logical core; null if either side is missing.
   const cpuLoadRatio = computed<number | null>(() => {
     if (cpuLoad1.value === null || cpuCores.value === null) return null;
     return cpuLoad1.value / cpuCores.value;

--- a/src/composables/useLatestDaily.ts
+++ b/src/composables/useLatestDaily.ts
@@ -1,18 +1,5 @@
-// Top-bar "today's journal" shortcut wiring (#876).
-//
-// Calls GET /api/journal/latest-daily, then either navigates to the
-// returned md path through FilesView, or surfaces a notice via
-// window.alert. Three terminal states, each with its own user copy:
-//   - data is a path  → navigate to /files/<path>
-//   - data is null    → "no journal yet" (legitimate empty state)
-//   - response.ok=false → "load failed" with status code so a real
-//     auth/network/backend failure isn't silently misreported as
-//     "no journal yet" (Codex review iter 1)
-//
-// The alert is intentionally crude for v1 — a proper in-app toast
-// composable doesn't exist yet (see plans/feat-today-journal-shortcut.md
-// "Out of scope"). When that lands, swap the alert calls for the
-// toast helper without touching the branching above.
+// #876. Distinguish data===null ("no journal yet") from response.ok===false ("load failed") so a real auth/network/
+// backend failure isn't misreported as empty state (Codex review iter 1). Crude alerts pending a toast composable.
 
 import { ref } from "vue";
 import { useRouter } from "vue-router";
@@ -43,9 +30,6 @@ export function useLatestDaily() {
         window.alert(t("sidebarHeader.todayJournalNotFound"));
         return;
       }
-      // FilesView route is `/files/<workspace-relative-path>`; the
-      // path returned by the API is already workspace-relative
-      // (e.g. "conversations/summaries/daily/2026/04/26.md").
       await router.push(`/files/${response.data.path}`);
     } finally {
       loading.value = false;

--- a/src/composables/useMarkdownDoc.ts
+++ b/src/composables/useMarkdownDoc.ts
@@ -1,40 +1,23 @@
-// Composable: parse a reactive markdown source into frontmatter +
-// body, plus an insertion-ordered `fields` array for properties-panel
-// rendering. Used by every Vue component that displays markdown
-// from disk (wiki / files / journal / news / skills / markdown
-// plugin) so frontmatter handling lives in one place (#895 PR A).
-//
-// `parseFrontmatter` always returns an object — never throws — so a
-// malformed header degrades to "render the whole input as body"
-// instead of breaking the view.
+// #895 PR A: shared frontmatter handling for every markdown-from-disk view. parseFrontmatter never throws —
+// malformed header degrades to "render the whole input as body" instead of breaking the view.
 
 import { computed, type ComputedRef, type Ref } from "vue";
 import { parseFrontmatter, type ParsedMarkdown } from "../utils/markdown/frontmatter";
 
 export interface MarkdownDocField {
   key: string;
-  /** YAML value as-is — `string`, `string[]`, `number`, `boolean`,
-   *  nested object, or `null`. Templates typically branch on
-   *  `Array.isArray(value)` and pass scalars through
-   *  `formatScalarField` so a nested object doesn't render as
-   *  `[object Object]` (codex review iter-1 #902). */
+  // Templates branch on Array.isArray and pass scalars through formatScalarField — nested objects would otherwise
+  // render as `[object Object]` (codex review iter-1 #902).
   value: unknown;
 }
 
-/** Render a non-array `MarkdownDocField.value` as a string for
- *  the properties-panel template. Branch:
- *    - `null`/`undefined` → empty string (keep cell visually empty)
- *    - object → compact JSON (so nested frontmatter doesn't print
- *      `[object Object]`)
- *    - everything else → `String(value)` (string / number / boolean) */
 export function formatScalarField(value: unknown): string {
   if (value === null || value === undefined) return "";
   if (typeof value === "object") {
     try {
       return JSON.stringify(value);
     } catch {
-      // Cyclic objects can't be JSON-stringified — fall back to a
-      // pragmatic placeholder rather than throwing in a template.
+      // Cyclic object → can't stringify; fall back to String() rather than throw inside a template.
       return String(value);
     }
   }
@@ -42,15 +25,10 @@ export function formatScalarField(value: unknown): string {
 }
 
 export interface MarkdownDocView extends ParsedMarkdown {
-  /** Insertion-ordered field list. Empty when `meta` is empty. */
   fields: MarkdownDocField[];
 }
 
-/** Reactively parse a markdown string. Re-runs whenever `content`
- *  changes. Pass `null`/`undefined` to get the empty state
- *  (`{ meta: {}, body: "", hasHeader: false, fields: [] }`) — so
- *  callers can wire it directly to a load-state ref without a
- *  null-guard wrapper. */
+// Pass null/undefined to get the empty state — so callers can wire a load-state ref without a null-guard wrapper.
 export function useMarkdownDoc(content: Ref<string | null | undefined>): ComputedRef<MarkdownDocView> {
   return computed(() => {
     const raw = content.value ?? "";

--- a/src/composables/useMcpTools.ts
+++ b/src/composables/useMcpTools.ts
@@ -1,9 +1,3 @@
-// Composable that owns the MCP tool state used by the sidebar:
-// which tools are currently disabled, their per-tool prompts, and
-// the derived `availableTools` / `toolDescriptions` computeds. The
-// pure rules live in src/utils/mcpTools so they are unit-testable
-// independently of fetch / Vue.
-
 import { computed, ref, type ComputedRef } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import type { Role } from "../config/roles";
@@ -12,20 +6,14 @@ import { apiGet } from "../utils/api";
 
 interface UseMcpToolsOptions {
   currentRole: ComputedRef<Role>;
-  // Injection point for the in-app plugin registry lookup. Real
-  // callers pass `(name) => getPlugin(name)?.toolDefinition ?? null`,
-  // tests can stub it.
+  // Plugin-registry lookup, injectable so tests can stub it.
   getDefinition: (name: string) => ToolDefinitionMetadata | null;
 }
 
 export function useMcpTools(opts: UseMcpToolsOptions) {
   const disabledMcpTools = ref(new Set<string>());
   const mcpToolDescriptions = ref<Record<string, string>>({});
-  // Surfaces the most recent GET /api/mcp-tools failure so consumers
-  // (e.g. the Settings modal's MCP tab) can render a small warning.
-  // We intentionally keep the "all tools visible" fallback below so
-  // the UI stays usable; this ref lets the UI tell the user *why* the
-  // list looks incomplete / unfiltered.
+  // Surfaces /api/mcp-tools failures so the Settings MCP tab can explain *why* the list looks unfiltered.
   const mcpToolsError = ref<string | null>(null);
 
   const availableTools = computed(() => availableToolsFor(opts.currentRole.value.availablePlugins, disabledMcpTools.value));
@@ -46,8 +34,7 @@ export function useMcpTools(opts: UseMcpToolsOptions) {
     const result = await apiGet<McpToolStatus[]>(API_ROUTES.mcpTools.list);
     if (!result.ok) {
       mcpToolsError.value = result.error;
-      // Keep the "all tools visible" fallback — not clearing
-      // disabledMcpTools or descriptions means the UI remains usable.
+      // Don't clear disabledMcpTools / descriptions — falling back to "all tools visible" keeps the UI usable.
       return;
     }
     if (!Array.isArray(result.data)) {

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -1,18 +1,5 @@
-// Web-side subscriber for the `notifications` pub-sub channel.
-// Stores incoming NotificationPayloads for the bell badge + panel.
-//
-// Uses a singleton subscription pattern: the first component that
-// calls useNotifications() subscribes to the pub-sub channel; the
-// last one to unmount unsubscribes. All consumers share the same
-// module-level state (notifications + readIds).
-//
-// Read tracking is per-id via a Set. The unread badge decreases
-// only when the user **interacts** with a notification — either
-// clicking it (markRead) or dismissing it via × (dismiss removes
-// the notification entirely, so it leaves the unread tally as a
-// side effect). Opening the panel does NOT auto-mark everything
-// read; the user has to explicitly act on each item, or hit the
-// "Mark all read" button.
+// Singleton subscription, ref-counted across consumers; module-level state shared by every caller.
+// Opening the panel does NOT auto-mark everything read — user must click each item or hit "Mark all read".
 
 import { onUnmounted, ref, computed, type Ref, type ComputedRef } from "vue";
 import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
@@ -36,10 +23,7 @@ function isNotificationPayload(value: unknown): value is NotificationPayload {
   return true;
 }
 
-// Tighter than a plain `typeof type === "string"` check — confirms
-// the discriminator is one we know AND, for `navigate`, that the
-// target carries a known view. Stops malformed payloads from
-// landing in the panel and crashing later in the click handler.
+// Stop malformed payloads from landing in the panel and crashing later in the click handler.
 function isValidAction(action: unknown): boolean {
   if (!isRecord(action)) return false;
   if (action.type === NOTIFICATION_ACTION_TYPES.none) return true;
@@ -49,14 +33,9 @@ function isValidAction(action: unknown): boolean {
   return typeof target.view === "string" && VALID_VIEWS.has(target.view);
 }
 
-// Module-level state so all components share the same list and the
-// same per-id read state.
 const notifications = ref<NotificationPayload[]>([]);
-// Set of notification ids the user has explicitly read (clicked or
-// dismissed-as-read). A Set so add/lookup are O(1) per entry.
 const readIds = ref<Set<string>>(new Set());
 
-// Singleton subscription — ref-counted across consumers.
 let subscriberCount = 0;
 let unsubscribeFn: (() => void) | null = null;
 
@@ -67,9 +46,7 @@ function ensureSubscribed(subscribe: ReturnType<typeof usePubSub>["subscribe"]):
     if (!isNotificationPayload(data)) return;
     const next = [data, ...notifications.value].slice(0, MAX_RECENT);
     notifications.value = next;
-    // Drop read-state entries for notifications that just rolled
-    // off the end of the bounded list — readIds is otherwise an
-    // unbounded leak across a long-lived session.
+    // Without pruning, readIds is an unbounded leak across a long-lived session.
     pruneReadIds(next);
   });
 }
@@ -81,8 +58,7 @@ function pruneReadIds(currentList: readonly NotificationPayload[]): void {
   for (const readId of readIds.value) {
     if (liveIds.has(readId)) next.add(readId);
   }
-  // Only assign when the contents actually changed — avoids
-  // unnecessary reactive churn when nothing rolled off.
+  // Skip the assignment when nothing rolled off, to avoid reactive churn.
   if (next.size !== readIds.value.size) {
     readIds.value = next;
   }
@@ -120,8 +96,7 @@ export function useNotifications(): {
 
   function markRead(notifId: string): void {
     if (readIds.value.has(notifId)) return;
-    // Replace the Set so Vue's reactivity fires on consumers that
-    // depend on `readIds` via `unreadCount` / `isRead`.
+    // Replace the Set so Vue's reactivity fires for unreadCount / isRead consumers.
     const next = new Set(readIds.value);
     next.add(notifId);
     readIds.value = next;
@@ -138,10 +113,7 @@ export function useNotifications(): {
 
   function dismiss(notifId: string): void {
     notifications.value = notifications.value.filter((notif) => notif.id !== notifId);
-    // Drop the matching readIds entry too. Without this, a long
-    // session that dismisses thousands of notifications leaks one
-    // ~36-char id per dismissal even though the user can't see
-    // them — pruneReadIds keeps the Set tied to `notifications`.
+    // Drop the matching readIds entry too — without it, dismissing thousands of notifications leaks ~36 chars each.
     if (readIds.value.has(notifId)) {
       const next = new Set(readIds.value);
       next.delete(notifId);

--- a/src/composables/usePendingCalls.ts
+++ b/src/composables/usePendingCalls.ts
@@ -1,9 +1,5 @@
-// Composable that bundles the "minimum visible duration" trick for
-// pending tool call rows: while the agent is running, tick a counter
-// every 50ms so the `pendingCalls` computed re-evaluates and any
-// freshly-resolved call stays visible for at least PENDING_MIN_MS
-// before disappearing. After the run ends, schedule one final tick
-// so the computed clears the lingering rows.
+// "Minimum visible duration" trick: tick every 50ms while running so a freshly-resolved call stays on-screen for
+// PENDING_MIN_MS before clearing. One final tick after the run ends sweeps lingering rows out of the computed.
 
 import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
 import type { ToolCallHistoryItem } from "../types/toolCallHistory";
@@ -17,17 +13,14 @@ interface UsePendingCallsOptions {
 export function usePendingCalls(opts: UsePendingCallsOptions) {
   const displayTick = ref(0);
   let tickInterval: ReturnType<typeof setInterval> | null = null;
-  // Tracked so teardown can cancel the lingering "final tick" and we
-  // never mutate displayTick after the composable's owner unmounts.
+  // Tracked so teardown can cancel the trailing tick — never mutate displayTick after the owner unmounts.
   let delayedTickTimeout: ReturnType<typeof setTimeout> | null = null;
 
   watch(
     opts.isRunning,
     (running) => {
       if (running) {
-        // Guard against double-start: if the watcher fires twice with
-        // running=true (e.g. immediate + a synchronous flip), don't
-        // stack a second interval.
+        // Guard against double-start (immediate + a synchronous flip would otherwise stack intervals).
         if (tickInterval !== null) return;
         tickInterval = setInterval(() => {
           displayTick.value++;
@@ -35,9 +28,7 @@ export function usePendingCalls(opts: UsePendingCallsOptions) {
       } else if (tickInterval !== null) {
         clearInterval(tickInterval);
         tickInterval = null;
-        // One final tick so the computed clears after the minimum
-        // duration has elapsed. Cancel any previous pending one first
-        // so back-to-back start/stop runs do not stack timeouts.
+        // Cancel any previous trailing tick so back-to-back start/stop runs don't stack timeouts.
         if (delayedTickTimeout !== null) clearTimeout(delayedTickTimeout);
         delayedTickTimeout = setTimeout(() => {
           displayTick.value++;
@@ -45,24 +36,15 @@ export function usePendingCalls(opts: UsePendingCallsOptions) {
         }, PENDING_MIN_MS);
       }
     },
-    // immediate so a composable created while a run is already in
-    // flight (e.g. mounted mid-stream) starts ticking right away
-    // instead of waiting for the next isRunning flip.
+    // Immediate so a composable mounted mid-stream starts ticking right away instead of waiting for the next flip.
     { immediate: true },
   );
 
   const pendingCalls = computed(() => {
-    // Read displayTick to register the computed as a reactive
-    // dependency on it — that is how a freshly-resolved row stays
-    // visible for the minimum window. The `__` prefix tells ESLint
-    // (varsIgnorePattern: "^__") that the variable is intentionally
-    // unused.
+    // Reads displayTick purely to register a reactive dep — that's how rows linger for the minimum window.
     const __tickDep = displayTick.value;
     const now = Date.now();
-    // Project to a narrower shape that carries `elapsedMs` so the
-    // consumer doesn't need its own ticker for the per-tool badge —
-    // the 50ms re-evaluation here already drives the display
-    // (#731 PR2).
+    // #731 PR2: project to elapsedMs so the per-tool badge piggybacks on this 50ms ticker (no second ticker downstream).
     return opts.toolCallHistory.value
       .filter((entry) => __tickDep >= 0 && isCallStillPending(entry, now))
       .map((entry) => ({

--- a/src/composables/usePubSub.ts
+++ b/src/composables/usePubSub.ts
@@ -8,15 +8,7 @@ interface PubSubMessage {
 type Callback = (data: unknown) => void;
 type Unsubscribe = () => void;
 
-// Socket.IO replaces the raw WebSocket + hand-rolled reconnect
-// state machine. One multiplexed connection; channels map to
-// socket.io rooms via `subscribe` / `unsubscribe` events.
-//
-// Reconnect / backoff / heartbeat are all handled by socket.io,
-// so there's no reconnectTimer / reconnectDelay here anymore. On
-// reconnect, `connect` fires again and we re-send every
-// subscription the client still cares about.
-
+// On reconnect we re-emit every live subscription so the rooms list survives the bounce.
 let socket: Socket | null = null;
 
 const listeners = new Map<string, Set<Callback>>();
@@ -32,9 +24,7 @@ function connect(): Socket {
 
   const sock = io({
     path: "/ws/pubsub",
-    // Match the server. Long-polling is fine as a fallback but
-    // the server refuses it, so don't negotiate it here either —
-    // fail fast if the WS upgrade doesn't go through.
+    // Server refuses long-polling fallback, so fail fast here too if the WS upgrade doesn't go through.
     transports: ["websocket"],
   });
 
@@ -65,9 +55,7 @@ export function usePubSub() {
 
     const sock = connect();
     if (sock.connected) sock.emit("subscribe", channel);
-    // If not yet connected, the "connect" handler replays every
-    // listener's subscription, so newly-added channels are
-    // covered without extra bookkeeping.
+    // If not yet connected, the "connect" handler replays every subscription — no extra bookkeeping needed.
 
     return () => {
       const cbs = listeners.get(channel);

--- a/src/composables/useRunElapsed.ts
+++ b/src/composables/useRunElapsed.ts
@@ -1,18 +1,5 @@
-// Tracks how long the active agent run has been going. While
-// `isRunning` is true, `elapsedMs` updates once per second so the
-// rendered string ("12s" / "1m 23s") moves visibly. When the run
-// ends, `elapsedMs` flips back to null and the timer is cleared.
-//
-// Separated from `usePendingCalls` (which ticks every 50ms for the
-// minimum-visible-duration trick) — the run-elapsed display only
-// needs second-granularity, and the consumer renders one badge per
-// run rather than one per pending row, so a tighter tick would just
-// burn re-renders.
-//
-// Why a watcher + setInterval rather than a `requestAnimationFrame`
-// driven computed: tab-throttled rAF freezes when the tab is in the
-// background, and the user expects the elapsed counter to keep
-// running across tab switches.
+// setInterval, not rAF: tab-throttled rAF freezes in background tabs and the user expects elapsed to keep ticking
+// across tab switches. Second-granularity is enough — the consumer renders one badge per run, not per pending row.
 
 import { computed, ref, watch, type ComputedRef, type Ref, type WatchStopHandle } from "vue";
 
@@ -35,9 +22,7 @@ export function useRunElapsed(opts: UseRunElapsedOptions): {
     opts.isRunning,
     (running) => {
       if (running) {
-        // Guard against double-start: if the watcher fires twice with
-        // running=true (e.g. immediate + a synchronous flip), don't
-        // stack a second interval.
+        // Guard against double-start (immediate + synchronous flip would otherwise stack intervals).
         if (interval !== null) return;
         startedAt.value = Date.now();
         now.value = startedAt.value;
@@ -52,8 +37,7 @@ export function useRunElapsed(opts: UseRunElapsedOptions): {
       }
       startedAt.value = null;
     },
-    // immediate so a composable created while a run is already in
-    // flight (mounted mid-stream) starts ticking right away.
+    // Immediate: a composable mounted mid-stream starts ticking right away.
     { immediate: true },
   );
 
@@ -63,8 +47,7 @@ export function useRunElapsed(opts: UseRunElapsedOptions): {
   });
 
   function teardown(): void {
-    // Stop the watcher first — otherwise an isRunning flip after
-    // teardown would recreate the interval (Codex iter-1 #798).
+    // Stop the watcher first — otherwise an isRunning flip after teardown recreates the interval (#798 Codex iter-1).
     if (stopWatch !== null) {
       stopWatch();
       stopWatch = null;

--- a/src/composables/useSandboxStatus.ts
+++ b/src/composables/useSandboxStatus.ts
@@ -1,13 +1,4 @@
-// Lazy fetcher for `GET /api/sandbox` (#329).
-//
-// The lock popup consumes this to show which host credentials are
-// attached to the Docker sandbox. Deliberately lazy: the popup is
-// hidden most of the time, and env-var changes only take effect on
-// server restart anyway, so a page-lifetime cache populated on first
-// open is enough.
-//
-// Paired with `useHealth` (which loads `sandboxEnabled` at bootstrap)
-// — when the sandbox is disabled this composable is never called.
+// #329. Lazy because env-var changes only take effect on server restart, so a page-lifetime cache is enough.
 
 import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -33,12 +24,8 @@ function isSandboxStatus(raw: RawResponse): raw is {
 }
 
 export interface UseSandboxStatusHandle {
-  /** Parsed status, or null while not yet loaded / sandbox disabled
-   *  / fetch failed. UI renders a placeholder in all three cases. */
+  // null = not yet loaded / sandbox disabled / fetch failed (UI renders a placeholder for all three).
   status: Ref<SandboxStatus | null>;
-  /** One-shot loader. Safe to call repeatedly — short-circuits once a
-   *  non-null value is cached. Designed to be triggered from a
-   *  `watch(() => props.open, …)` on the popup. */
   ensureLoaded: () => Promise<void>;
 }
 
@@ -51,14 +38,11 @@ export function useSandboxStatus(): UseSandboxStatusHandle {
     loaded = true;
     const result = await apiGet<RawResponse>(API_ROUTES.sandbox);
     if (!result.ok) {
-      // Leave `status` null — popup shows a neutral "state unavailable"
-      // line. Allow a retry on next open by flipping `loaded` back.
+      // Allow retry on next open — `status` stays null so the popup shows "state unavailable".
       loaded = false;
       return;
     }
-    // Server returns `{}` (empty object) when the sandbox is disabled.
-    // The popup shouldn't call us in that case, but double-guard here
-    // so a stale render doesn't blow up on shape validation.
+    // Server returns `{}` when the sandbox is disabled — popup shouldn't call us then, but double-guard.
     if (!isSandboxStatus(result.data)) return;
     status.value = result.data;
   }

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -1,6 +1,3 @@
-// Computed properties derived from sessionMap + sessions list.
-// Extracted from App.vue to reduce the component's reactive surface.
-
 import { computed, type Ref } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ActiveSession, SessionSummary } from "../types/session";
@@ -18,13 +15,9 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
 
   const currentSummary = computed(() => sessions.value.find((summary) => summary.id === currentSessionId.value));
 
-  // Global "is anything running" across every known session — in-memory
-  // map (which reflects pub/sub events faster than server refetch) and
-  // server-side summaries (for sessions not yet hydrated into the map).
-  // Used for consumers that must stay true across page navigation:
-  // favicon spinner and the FilesView refresh watcher (which would
-  // otherwise fire before a background run actually finishes, because
-  // leaving /chat drops activeSession to undefined).
+  // OR of in-memory map (pub/sub-fast) + server summaries (covers un-hydrated sessions). Must stay true across page
+  // nav so favicon + FilesView refresh-watcher don't fire before a background run finishes (leaving /chat drops
+  // activeSession to undefined).
   const isRunning = computed(() => {
     for (const session of sessionMap.values()) {
       if (session.isRunning) return true;
@@ -33,11 +26,7 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
     return sessions.value.some((summary) => summary.isRunning);
   });
 
-  // True only when the session on screen has a run in flight. Drives
-  // UX touchpoints that should react per-session — ChatInput disable,
-  // sendMessage guard, chat-list auto-scroll, pending-call row tick —
-  // so a background run in session B doesn't disable the composer
-  // while the user is actively chatting in session A.
+  // Per-session: a background run in session B must not disable session A's composer or block its auto-scroll.
   const activeSessionRunning = computed(() => {
     const active = activeSession.value;
     const pending = active ? Object.keys(active.pendingGenerations).length > 0 : false;

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -1,16 +1,4 @@
-// Composable for the session-history view at `/history`.
-//
-// Owns the `sessions` list (what the server knows about) plus the
-// fetch helper. The view's open/closed state is now URL-backed (see
-// plans/done/feat-history-url-route.md) — callers watch `route.name` and
-// invoke `fetchSessions()` on route enter rather than going through
-// an in-memory toggle flag.
-//
-// Since #205, `fetchSessions()` sends the server's last-issued
-// cursor back as `?since=<cursor>` so the server can reply with
-// only the rows that changed. The first call has no cursor (full
-// fetch); subsequent calls receive a diff that we merge into the
-// existing cache via `applySessionDiff`.
+// #205: send the server's last cursor as ?since=<cursor> so the server replies with a diff. First call has no cursor.
 
 import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -30,14 +18,9 @@ export function useSessionHistory(): {
   fetchSessions: () => Promise<SessionSummary[]>;
 } {
   const sessions = ref<SessionSummary[]>([]);
-  // Surfaces the most recent fetch failure. Kept alongside the (stale)
-  // sessions list rather than wiping it — a panel that goes blank
-  // the moment the network hiccups is worse UX than one that shows
-  // "⚠ using cached list" with the last-known good entries.
+  // Held alongside the stale list, not in place of it — a blank panel on a network blip is worse UX than "⚠ cached".
   const historyError = ref<string | null>(null);
-  // Opaque cursor the server hands back on every successful call.
-  // Tab-scoped — issue #205 calls out cross-tab sharing via
-  // localStorage as out of scope.
+  // Tab-scoped; #205 explicitly leaves cross-tab sharing via localStorage out of scope.
   let cursor: string | null = null;
 
   async function fetchSessions(): Promise<SessionSummary[]> {
@@ -46,15 +29,12 @@ export function useSessionHistory(): {
     const result = await apiGet<SessionsResponse>(API_ROUTES.sessions.list, query);
     if (!result.ok) {
       historyError.value = result.error;
-      // Intentionally preserve `sessions.value` — callers keep showing
-      // whatever list was last known to work.
+      // Preserve sessions.value so callers keep showing the last-known-good list.
       return sessions.value;
     }
     historyError.value = null;
     const body = result.data;
     if (cursor === null) {
-      // First call in this composable instance — server returned the
-      // full list; seed the cache directly.
       sessions.value = body.sessions;
     } else {
       sessions.value = applySessionDiff(sessions.value, body.sessions, body.deletedIds);

--- a/src/composables/useSkillsList.ts
+++ b/src/composables/useSkillsList.ts
@@ -8,16 +8,8 @@ export interface SkillSummary {
   source: "user" | "project";
 }
 
-// Module-level shared state so consumers (ChatInput, PageChatComposer,
-// SuggestionsPanel) all see the same list. We do not cache: every
-// `refresh()` re-hits /api/skills. The first auto-fetch on mount is
-// a bootstrap so the panel has something to show on first open.
-//
-// Error policy: on a failed fetch we keep the previous `skills` value
-// (so a transient blip doesn't visually wipe the list) and surface the
-// failure through `error`. The Skills tab renders that as a banner so
-// the user can tell stale data from current data. A successful refresh
-// clears `error`.
+// Module-level shared state across consumers. Failed fetch keeps the previous list (no visual wipe on a blip) and
+// surfaces the message via `error` — the Skills tab renders that as a banner so stale vs current is distinguishable.
 const skills = ref<SkillSummary[]>([]);
 const error = ref<string | null>(null);
 let bootstrapped = false;
@@ -33,20 +25,13 @@ async function refresh(): Promise<void> {
         error.value = null;
         return;
       }
-      // Both branches below leave `skills` untouched (stale list
-      // is preferable to wiping it on transient blips) but we
-      // surface the failure on `error` AND log it so it's
-      // visible in DevTools — the prior version was silent on
-      // the non-ok path, which made "skills tab won't refresh"
-      // hard to diagnose without breakpoints.
+      // Leave `skills` untouched (stale > wiped); surface on `error` AND console.warn — silent failures here had
+      // historically made "Skills tab won't refresh" hard to diagnose without breakpoints.
       const message = !result.ok ? result.error || "Failed to load skills" : "Skills response missing `skills` array";
       error.value = message;
       console.warn("[useSkillsList] refresh failed:", message);
     } catch (err) {
-      // apiGet normally returns a discriminated union, but a
-      // runtime exception (network layer, unexpected await
-      // failure) must not become an unhandled rejection that the
-      // bootstrap caller (`void refresh()`) drops on the floor.
+      // Runtime throw must not become an unhandled rejection — the bootstrap call site is `void refresh()`.
       const message = err instanceof Error ? err.message : String(err);
       error.value = message;
       console.warn("[useSkillsList] refresh threw:", err);

--- a/src/plugins/scheduler/AutomationsPreview.vue
+++ b/src/plugins/scheduler/AutomationsPreview.vue
@@ -17,14 +17,8 @@ import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SchedulerData } from "./index";
 
-// Sidebar preview for `manageAutomations` tool results. Deliberately
-// does NOT auto-refresh from `/api/scheduler` (which returns calendar
-// items, not tasks — see #828 follow-up). The post-action snapshot
-// in `props.result.data.items` is the right thing to show; tasks
-// have their own GET endpoint (`/api/scheduler/tasks`) but the
-// preview is a frozen time-slice of one tool call, so re-fetching
-// would either drift to wrong data (calendar) or duplicate state
-// the AutomationsView already owns.
+// No /api/scheduler auto-refresh: that endpoint returns calendar items, not tasks (#828). The preview is a frozen
+// snapshot of one tool call — re-fetching would either drift to wrong data or duplicate AutomationsView's state.
 
 const { t } = useI18n();
 

--- a/src/plugins/scheduler/LegacySchedulerView.vue
+++ b/src/plugins/scheduler/LegacySchedulerView.vue
@@ -1,10 +1,5 @@
 <template>
-  <!-- View-only fallback for chat sessions saved before the
-       manageScheduler split (#824). The legacy tool returned two
-       distinct payload shapes — calendar items vs task records —
-       so we route on shape and mount the matching post-split view.
-       Never produces fresh tool calls (the plugin is not exposed
-       to the LLM); only renders persisted history. -->
+  <!-- View-only fallback for sessions saved before the #824 split: routes by payload shape. Never produces fresh tool calls. -->
   <AutomationsView v-if="renderAutomations" :selected-result="selectedResult" @update-result="(result) => emit('updateResult', result)" />
   <CalendarView v-else :selected-result="selectedResult" @update-result="(result) => emit('updateResult', result)" />
 </template>
@@ -23,10 +18,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
-// Shape-based dispatch. Errors on the side of CalendarView when
-// the payload shape is unknown — calendar was the more common
-// pre-split action and the view degrades gracefully on missing
-// fields, while the automations view assumes the task shape and
-// would render an empty Tasks tab.
+// Default to CalendarView on unknown shapes — it degrades gracefully on missing fields; AutomationsView would render empty.
 const renderAutomations = computed(() => isLegacyAutomationsShape(props.selectedResult?.data));
 </script>

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -1,21 +1,16 @@
 <template>
   <div class="flex-1 overflow-y-auto min-h-0 p-4">
-    <!-- Mutation error banner -->
     <div v-if="mutationError" class="mb-3 px-4 py-2 bg-red-50 text-red-700 rounded text-sm" data-testid="scheduler-task-error">
       {{ mutationError }}
     </div>
 
-    <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center h-32 text-gray-400">{{ t("common.loading") }}</div>
 
-    <!-- Error -->
     <div v-else-if="error" class="px-4 py-2 bg-red-50 text-red-700 rounded text-sm">
       {{ error }}
     </div>
 
-    <!-- Task list + frequency hints -->
     <div v-else>
-      <!-- Frequency hints reference -->
       <details class="mb-4 border border-gray-200 rounded-lg text-sm" data-testid="scheduler-frequency-hints">
         <summary class="px-3 py-2 cursor-pointer text-gray-600 font-medium select-none hover:bg-gray-50 rounded-lg">
           {{ t("pluginSchedulerTasks.recommendedFrequencies") }}
@@ -48,7 +43,6 @@
         >
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2 min-w-0">
-              <!-- Origin badge -->
               <span class="text-xs px-1.5 py-0.5 rounded font-medium shrink-0" :class="originClass(task.origin)">
                 {{ originLabel(task.origin) }}
               </span>
@@ -57,7 +51,6 @@
               </span>
             </div>
             <div class="flex items-center gap-1 shrink-0">
-              <!-- Run now -->
               <button
                 v-if="task.origin === 'user'"
                 class="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded"
@@ -68,7 +61,6 @@
               >
                 <span class="material-icons text-sm">play_arrow</span>
               </button>
-              <!-- Enable/disable toggle -->
               <button
                 v-if="task.origin === 'user'"
                 class="px-2 py-1 text-xs rounded"
@@ -80,7 +72,6 @@
                   {{ task.enabled !== false ? "toggle_on" : "toggle_off" }}
                 </span>
               </button>
-              <!-- Delete -->
               <button
                 v-if="task.origin === 'user'"
                 class="px-2 py-1 text-xs text-red-500 hover:bg-red-50 rounded"
@@ -94,7 +85,6 @@
             </div>
           </div>
 
-          <!-- Details row -->
           <div class="mt-1 flex items-center gap-3 text-xs text-gray-500">
             <span>{{ formatSchedule(task.schedule) }}</span>
             <span v-if="task.state?.lastRunResult" class="flex items-center gap-1">
@@ -104,16 +94,12 @@
             <span v-if="task.state?.nextScheduledAt">{{ t("pluginSchedulerTasks.nextRun", { time: formatShortTime(task.state.nextScheduledAt) }) }}</span>
           </div>
 
-          <!-- Description (full, not truncated — users need to know what
-               each task actually does). System tasks have only this
-               line; user / skill tasks have an expandable details
-               block below with the prompt + role. -->
+          <!-- Full (not truncated): users need to know what each task does. -->
           <div v-if="task.description" class="mt-1 text-xs text-gray-500 whitespace-pre-line">
             {{ task.description }}
           </div>
 
-          <!-- Prompt + role (user / skill tasks only). Collapsed by
-               default to keep the list compact; click to inspect. -->
+          <!-- Collapsed prompt + role for user/skill tasks; system tasks have neither. -->
           <details v-if="task.prompt" class="mt-2" :data-testid="`scheduler-task-details-${task.id}`">
             <summary class="text-xs text-gray-500 cursor-pointer select-none hover:text-gray-700">
               {{ t("pluginSchedulerTasks.detailsToggle") }}
@@ -171,18 +157,13 @@ interface SchedulerTask {
   origin: string;
   enabled?: boolean;
   state?: TaskState;
-  // user / skill tasks carry the agent prompt + role on the wire;
-  // system tasks omit them (their "what does this do" is the
-  // description text plus the source code behind the id).
+  // user / skill tasks carry prompt + role; system tasks omit them (their semantics are baked into the source).
   prompt?: string;
   roleId?: string;
   missedRunPolicy?: string;
 }
 
-// Hints showing common task cadences. Stored as structured schedules
-// (not pre-rendered strings) so the display routes through
-// formatTaskSchedule() and picks up the viewer's local timezone for
-// daily rows — the same conversion applied to real tasks below.
+// Structured (not pre-rendered) so daily rows route through formatTaskSchedule and pick up the viewer's local timezone.
 const FREQUENCY_HINTS: Array<{ label: string; schedule: FormatterTaskSchedule }> = [
   { label: "News / RSS fetch", schedule: { type: "interval", intervalMs: 3_600_000 } },
   { label: "Journal daily pass", schedule: { type: "daily", time: "23:00" } },
@@ -263,10 +244,7 @@ async function deleteTask(taskId: string): Promise<void> {
   await fetchTasks();
 }
 
-// When the user lands on /automations/:taskId (e.g. from a
-// notification), fetch the list, then scroll + flash the matching
-// row once it's rendered. Unknown IDs are a no-op — the list still
-// renders normally.
+// /automations/:taskId (e.g. from a notification) scrolls + flashes the matching row; unknown IDs are a no-op.
 const route = useRoute();
 
 async function focusUrlTask(taskId: string): Promise<void> {
@@ -282,9 +260,7 @@ onMounted(async () => {
   }
 });
 
-// Also react when the user is already on the page and the URL
-// changes (e.g. clicking a second notification without leaving the
-// Automations view).
+// Re-fire when the URL changes without unmounting — clicking a second notification while already on /automations.
 watch(
   () => route.params.taskId,
   (taskId) => {

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -1,17 +1,10 @@
 <template>
   <div class="h-full bg-white flex flex-col">
-    <!-- API error banner — surfaces POST /api/scheduler failures so a
-         delete/add/replace that silently no-ops becomes diagnosable. -->
+    <!-- Surfaces POST /api/scheduler failures so silent no-ops are diagnosable. -->
     <div v-if="apiError" class="px-4 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700" role="alert" data-testid="scheduler-api-error">
       {{ t("pluginScheduler.apiError", { error: apiError }) }}
     </div>
-    <!-- Top-level tab bar: Calendar / Tasks. Hidden when the
-         component is mounted as a standalone page (`forceTab`
-         set by CalendarView / AutomationsView) — the page itself
-         already identifies which feature the user is on, so a
-         tab bar would duplicate that affordance. Still rendered
-         when the component appears as a `manageScheduler` tool
-         result inside /chat, where the user can switch freely. -->
+    <!-- Hidden when mounted as a standalone page (forceTab) — the page already identifies the feature. -->
     <div v-if="!forceTab" class="flex border-b border-gray-200 px-6">
       <button
         class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
@@ -31,19 +24,15 @@
       </button>
     </div>
 
-    <!-- Tasks tab -->
     <TasksTab v-if="activeTab === SCHEDULER_TAB.tasks" />
 
-    <!-- Calendar tab (existing content) -->
     <template v-if="activeTab === SCHEDULER_TAB.calendar">
-      <!-- Header -->
       <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
         <div class="flex items-center gap-2">
           <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginScheduler.heading") }}</h2>
           <span class="text-sm text-gray-500">{{ t("pluginScheduler.itemCount", items.length, { named: { count: items.length } }) }}</span>
         </div>
         <div class="flex items-center gap-2">
-          <!-- Navigation (calendar modes only) -->
           <template v-if="viewMode !== SCHEDULER_VIEW.list">
             <div class="flex gap-0.5">
               <button
@@ -70,7 +59,6 @@
             </div>
             <span class="text-sm text-gray-600 min-w-[140px] text-center">{{ headerLabel }}</span>
           </template>
-          <!-- View mode toggle -->
           <div class="flex border border-gray-300 rounded overflow-hidden">
             <button
               v-for="mode in VIEW_MODES"
@@ -86,7 +74,6 @@
         </div>
       </div>
 
-      <!-- List view -->
       <div v-if="viewMode === SCHEDULER_VIEW.list" class="flex-1 overflow-y-auto min-h-0">
         <div v-if="items.length === 0" class="flex items-center justify-center h-full text-gray-400">{{ t("pluginScheduler.noScheduled") }}</div>
 
@@ -124,11 +111,9 @@
         </ul>
       </div>
 
-      <!-- Week view -->
       <div v-else-if="viewMode === SCHEDULER_VIEW.week" class="flex-1 overflow-y-auto min-h-0">
         <div class="grid grid-cols-7 border-b border-gray-200">
           <div v-for="day in weekDays" :key="day.toISOString()" class="border-r last:border-r-0 border-gray-200 min-h-[200px] flex flex-col">
-            <!-- Day header -->
             <div class="px-2 py-1.5 text-center border-b border-gray-100 sticky top-0 bg-white" :class="isToday(day) ? 'bg-blue-50' : ''">
               <div class="text-xs text-gray-400">{{ dayLabel(day) }}</div>
               <div
@@ -138,7 +123,6 @@
                 {{ day.getDate() }}
               </div>
             </div>
-            <!-- Day items -->
             <div class="flex-1 p-1 space-y-0.5">
               <div
                 v-for="item in itemsForDay(day)"
@@ -153,7 +137,6 @@
             </div>
           </div>
         </div>
-        <!-- Unscheduled -->
         <div v-if="unscheduledItems.length > 0" class="p-3 border-t border-gray-200">
           <div class="text-xs text-gray-400 mb-1.5">{{ t("pluginScheduler.unscheduled") }}</div>
           <div class="flex flex-wrap gap-1">
@@ -170,15 +153,12 @@
         </div>
       </div>
 
-      <!-- Month view -->
       <div v-else class="flex-1 overflow-y-auto min-h-0">
-        <!-- Weekday headers -->
         <div class="grid grid-cols-7 border-b border-gray-200 sticky top-0 bg-white z-10">
           <div v-for="label in WEEKDAY_LABELS" :key="label" class="text-xs text-center text-gray-400 py-1.5 border-r last:border-r-0 border-gray-100">
             {{ label }}
           </div>
         </div>
-        <!-- Month grid -->
         <div v-for="(week, wi) in monthGrid" :key="wi" class="grid grid-cols-7 border-b border-gray-100">
           <div
             v-for="day in week"
@@ -206,7 +186,6 @@
             </div>
           </div>
         </div>
-        <!-- Unscheduled -->
         <div v-if="unscheduledItems.length > 0" class="p-3 border-t border-gray-200">
           <div class="text-xs text-gray-400 mb-1.5">{{ t("pluginScheduler.unscheduled") }}</div>
           <div class="flex flex-wrap gap-1">
@@ -223,7 +202,6 @@
         </div>
       </div>
 
-      <!-- Item YAML editor -->
       <div v-if="selectedId" class="border-t border-blue-200 bg-blue-50 shrink-0">
         <div class="flex items-center justify-between px-4 py-2 text-sm font-medium text-blue-700">
           <span>{{ t("pluginScheduler.editItem") }}</span>
@@ -244,7 +222,6 @@
         </div>
       </div>
 
-      <!-- JSON source editor -->
       <details class="border-t border-gray-200 bg-gray-50 shrink-0">
         <summary class="cursor-pointer select-none px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100">
           {{ t("pluginScheduler.editSource") }}
@@ -289,10 +266,7 @@ type YamlScalar = string | number | boolean | null;
 
 const props = defineProps<{
   selectedResult?: ToolResultComplete<SchedulerData>;
-  // Standalone page mode: when set, hides the tab bar and locks the
-  // view to the given tab. Used by CalendarView / AutomationsView
-  // wrappers (#758). Undefined in the /chat tool-result context, so
-  // there the tab-switcher stays interactive.
+  // Set by CalendarView / AutomationsView page wrappers (#758) to lock the tab; undefined in /chat tool-result context.
   forceTab?: SchedulerTab;
 }>();
 const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
@@ -306,8 +280,7 @@ function detectInitialTab(result?: ToolResultComplete<SchedulerData>): Scheduler
 }
 
 const activeTab = ref<SchedulerTab>(props.forceTab ?? detectInitialTab(props.selectedResult));
-// In standalone page mode the tab is locked; swapping routes should
-// re-lock so the view follows. No-op in tool-result mode.
+// Re-lock when forceTab swaps so route navigation follows; no-op in tool-result mode.
 watch(
   () => props.forceTab,
   (next) => {
@@ -336,8 +309,6 @@ watch(
   },
 );
 
-// ── View mode ──────────────────────────────────────────────────────────────
-
 import { SCHEDULER_VIEW, SCHEDULER_VIEW_MODES as VIEW_MODES, SCHEDULER_TAB, type SchedulerViewMode as ViewMode, type SchedulerTab } from "./viewModes";
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -345,8 +316,6 @@ const MAX_MONTH_ITEMS = 3;
 
 const viewMode = ref<ViewMode>(SCHEDULER_VIEW.month);
 const currentDate = ref(new Date());
-
-// ── Calendar utilities ─────────────────────────────────────────────────────
 
 function startOfWeek(date: Date): Date {
   const result = new Date(date);
@@ -410,8 +379,6 @@ function dayLabel(date: Date): string {
   return WEEKDAY_LABELS[date.getDay() === 0 ? 6 : date.getDay() - 1];
 }
 
-// ── Navigation ─────────────────────────────────────────────────────────────
-
 const weekDays = computed(() => getWeekDays(currentDate.value));
 
 const monthGrid = computed(() => getMonthGrid(currentDate.value.getFullYear(), currentDate.value.getMonth()));
@@ -451,8 +418,6 @@ function goNext() {
   }
   currentDate.value = next;
 }
-
-// ── YAML helpers ────────────────────────────────────────────────────────────
 
 function yamlStringValue(raw: string): string {
   const needsQuotes = raw === "" || /[:#[\]{},&*?|<>=!%@`]/.test(raw) || /^\s|\s$/.test(raw) || /^(true|false|null|~)$/i.test(raw) || /^\d/.test(raw);
@@ -511,8 +476,6 @@ function parseYaml(text: string): {
   return { title, props: itemProps };
 }
 
-// ── Item selection & YAML edit ───────────────────────────────────────────────
-
 const selectedId = ref<string | null>(null);
 const yamlText = ref("");
 const yamlError = ref("");
@@ -556,16 +519,13 @@ async function applyItemEdit() {
   if (success) selectedId.value = null;
 }
 
-// ── JSON source editor ───────────────────────────────────────────────────────
-
 function toJson(its: ScheduledItem[]) {
   return JSON.stringify(its, null, 2);
 }
 
 const editorText = ref(toJson(items.value));
 const parseError = ref("");
-// Last POST /api/scheduler failure. Cleared on the next successful call
-// so the banner disappears as soon as things recover.
+// Cleared on the next successful POST so the banner disappears as soon as things recover.
 const apiError = ref<string | null>(null);
 const isModified = computed(() => editorText.value !== toJson(items.value));
 

--- a/src/plugins/scheduler/automationsDefinition.ts
+++ b/src/plugins/scheduler/automationsDefinition.ts
@@ -1,10 +1,3 @@
-// MCP tool definition for the automations half of the former
-// `manageScheduler` (#824). Keeps the same backend route
-// (`/api/scheduler`) — server-side dispatch already routes
-// task-prefixed actions through the user-task subsystem via
-// `TASK_ACTIONS`, so the only thing changing here is the LLM
-// prompt and the tool name surfaced in chat.
-
 import type { ToolDefinition } from "gui-chat-protocol";
 import { SCHEDULER_ACTIONS } from "../../config/schedulerActions";
 

--- a/src/plugins/scheduler/calendarDefinition.ts
+++ b/src/plugins/scheduler/calendarDefinition.ts
@@ -1,8 +1,3 @@
-// MCP tool definition for the calendar half of the former
-// `manageScheduler` (#824). Keeps the same backend route
-// (`/api/scheduler`) — the action enum is just narrowed to the
-// calendar-only subset so the LLM's prompt is unambiguous.
-
 import type { ToolDefinition } from "gui-chat-protocol";
 import { SCHEDULER_ACTIONS } from "../../config/schedulerActions";
 

--- a/src/plugins/scheduler/formatSchedule.ts
+++ b/src/plugins/scheduler/formatSchedule.ts
@@ -1,11 +1,5 @@
-// Pure formatters for scheduler-task display. Extracted from
-// TasksTab.vue so the UTC → local conversion can be unit-tested
-// without spinning up Vue.
-//
-// Internally every task stores its daily trigger as `HH:MM` in UTC
-// (that's what the scheduler engine fires on). The UI should show the
-// same moment in the viewer's local timezone so a user in Tokyo sees
-// "Daily 05:00 JST" instead of "Daily 20:00 UTC".
+// Tasks store the daily trigger as `HH:MM` in UTC (that's what the engine fires on); the UI converts to the
+// viewer's local zone so a user in Tokyo sees "Daily 05:00 JST" instead of "Daily 20:00 UTC".
 
 export interface DailySchedule {
   type: "daily";
@@ -21,20 +15,12 @@ export type TaskSchedule = DailySchedule | IntervalSchedule | { type: string; [k
 
 const DAILY_TIME_RE = /^(\d{1,2}):(\d{2})$/;
 
-// Build a Date anchored to `now`'s local calendar day but at the
-// requested UTC wall-clock hour/minute. Using today's date (rather
-// than epoch 1970) makes the DST/TZ conversion accurate for the
-// viewer's current moment — "20:00 UTC every day" in Europe/London
-// can differ by an hour between summer and winter.
+// Anchor to today (not 1970) so DST conversion is accurate — "20:00 UTC daily" can differ by an hour summer/winter in London.
 function buildUtcInstant(utcHour: number, utcMinute: number, now: Date): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), utcHour, utcMinute));
 }
 
-// Intl formatter configured to surface HH:MM + the short timezone
-// name (e.g. "JST", "PDT"). When the browser can't resolve a zone
-// abbreviation it falls back to the offset string ("GMT+9"), which
-// is fine — the point is that the user doesn't have to mentally
-// convert from UTC.
+// Browsers without a zone abbreviation fall back to "GMT+9" — fine; the point is no manual UTC conversion.
 const LOCAL_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   hour: "2-digit",
   minute: "2-digit",
@@ -49,8 +35,7 @@ function extractHourMinuteTz(date: Date): { hourMinute: string; tzLabel: string 
     const minute = parts.find((part) => part.type === "minute")?.value ?? "";
     const tzLabel = parts.find((part) => part.type === "timeZoneName")?.value ?? "";
     if (!hour || !minute) return null;
-    // Intl returns "24" for midnight hour under `hour: "2-digit"` on
-    // some runtimes — normalize so "Daily 24:00 JST" never appears.
+    // Some runtimes return "24" for midnight under hour:"2-digit" — normalize so "Daily 24:00 JST" never appears.
     const normalizedHour = hour === "24" ? "00" : hour;
     return { hourMinute: `${normalizedHour}:${minute}`, tzLabel };
   } catch {
@@ -58,10 +43,7 @@ function extractHourMinuteTz(date: Date): { hourMinute: string; tzLabel: string 
   }
 }
 
-// Convert a UTC "HH:MM" into "Daily HH:MM <tz>" in the viewer's
-// local zone. Returns the original "Daily HH:MM UTC" string if the
-// input is malformed or the Intl machinery is unavailable — callers
-// never see `null`/throw for a scheduler entry.
+// Falls back to "Daily HH:MM UTC" on malformed input or missing Intl — callers never see null/throw.
 export function formatDailyLocal(utcHHMM: string, now: Date = new Date()): string {
   const match = DAILY_TIME_RE.exec(utcHHMM);
   if (!match) return `Daily ${utcHHMM} UTC`;

--- a/src/plugins/scheduler/index.ts
+++ b/src/plugins/scheduler/index.ts
@@ -1,10 +1,5 @@
-// Two plugins, one shared backend (#824). Both call /api/scheduler;
-// the server-side dispatcher already routes per-action via
-// TASK_ACTIONS, so the plugins are thin wrappers over the same
-// REST contract — they differ only in tool definition (the action
-// enum the LLM sees) and in the chat-side view (CalendarView vs
-// AutomationsView). The legacy unified `manageScheduler` plugin
-// went away with the rename; see plans/refactor-split-manageScheduler-824.md.
+// #824: two plugins share /api/scheduler — the server already dispatches per-action via TASK_ACTIONS, so each plugin
+// just differs in the tool definition (action enum the LLM sees) and the View component.
 
 import type { PluginEntry } from "../../tools/types";
 import type { ToolPlugin } from "../../tools/types";
@@ -31,9 +26,7 @@ export interface SchedulerData {
   items: ScheduledItem[];
 }
 
-// Shared executor for both plugins — backend dispatch is identical.
-// `toolName` is captured by closure so the tool result carries the
-// matching name through to the chat history and the View lookup.
+// `toolName` is captured so the result carries the matching name through to chat history and View lookup.
 function makeExecute(toolName: "manageCalendar" | "manageAutomations"): ToolPlugin<SchedulerData>["execute"] {
   return async function execute(_context, args) {
     const result = await apiPost<ToolResult<SchedulerData>>(API_ROUTES.scheduler.base, args);
@@ -67,25 +60,13 @@ export const manageAutomationsPlugin: ToolPlugin<SchedulerData> = {
   isEnabled: () => true,
   generatingMessage: "Managing automations...",
   viewComponent: AutomationsView,
-  // Previews must not share Preview.vue with manageCalendarPlugin —
-  // Preview.vue auto-refreshes from `/api/scheduler` which returns
-  // calendar items, so the automations sidebar would show calendar
-  // data after the first refresh tick (#828 follow-up).
+  // Cannot share Preview.vue with manageCalendar — Preview auto-refreshes from /api/scheduler (calendar items), and
+  // the automations sidebar would otherwise show calendar data after the first refresh tick (#828 follow-up).
   previewComponent: AutomationsPreview,
 };
 
-// View-only fallback for tool results saved under the pre-split
-// `manageScheduler` name. Registered in src/tools/index.ts so
-// `getPlugin("manageScheduler")` returns this entry and historical
-// chat sessions still render the rich view (LegacySchedulerView
-// dispatches to CalendarView or AutomationsView by data shape).
-//
-// Deliberately a `PluginEntry` (not a `ToolPlugin`) so the absence
-// of `execute` / `isEnabled` makes its view-only nature explicit:
-// no LLM exposure path, no fresh dispatch, just the historical
-// renderer. The tool name is also absent from
-// server/agent/plugin-names.ts and src/config/toolNames.ts, so
-// new sessions cannot pick it up.
+// View-only legacy fallback so historical sessions saved under the pre-split `manageScheduler` name still render.
+// `PluginEntry` (no execute/isEnabled) makes it explicit: no LLM exposure, no fresh dispatch, render-only.
 export const legacyManageSchedulerEntry: PluginEntry = {
   toolDefinition: {
     type: "function",

--- a/src/plugins/scheduler/legacyShape.ts
+++ b/src/plugins/scheduler/legacyShape.ts
@@ -1,25 +1,6 @@
-// Shape detector for the legacy `manageScheduler` tool result —
-// covers chat sessions in the workspace that were saved before the
-// PR #824 split. Pure, no Vue dependency, so the heuristic is
-// unit-testable in isolation.
-//
-// The old `manageScheduler` returned two distinct payload shapes
-// depending on which action the LLM had picked:
-//
-//   Calendar actions (show/add/update/delete):
-//     data: { items: ScheduledItem[] }
-//
-//   Automation actions (createTask/listTasks/deleteTask/runTask):
-//     data: { task: ... }            // createTask
-//     data: { tasks: [...] }         // listTasks
-//     data: { triggered: ..., chatSessionId: ... } // runTask
-//     data: { deleted: ... }         // deleteTask
-//
-// One of the four task-shape keys is enough to discriminate. We
-// keep this list narrow on purpose: a future schema change that
-// adds new task fields should fail OPEN (default to calendar) so
-// reviewers see the mismatch and update the helper, rather than
-// silently routing new shapes to the automations view.
+// Discriminator for legacy `manageScheduler` tool results saved before the #824 split. List is narrow on purpose:
+// a future schema change that adds new task keys must fail OPEN (default to calendar) so reviewers see the mismatch
+// rather than silently routing new shapes to automations.
 
 import { isRecord } from "../../utils/types";
 


### PR DESCRIPTION
## Summary

Modules #2-8 of the #910 comment sweep, in one PR per the user's "do as much as possible at once" directive. Picks up where pilot PR #914 (`src/plugins/presentForm/`) left off.

**Net change: -1683 / +263 across 64 files.**

## Items to Confirm / Review

- [ ] **Behavior unchanged** — only comments removed, kept comments tightened to one line each. No logic / type / rename / constant edits except where a rename clearly subsumed a now-deleted WHAT (none in this batch). format / lint / typecheck / build all green locally.
- [ ] **WHY comments retained** for: past-bug references (#732, #799, #803, #824), library / browser quirks (vue-i18n compiler edges, sonarjs slow-regex), non-obvious algorithm invariants (mid-write session skip, topic-slug rewrite, scheduler/TASK_ACTIONS routing), reactive-timing notes (favicon tick, ref-counted singleton subscription).
- [ ] **Risk surface** — `dailyPass.ts` lost the 8-line file header that summarised the daily pass's role. The function name `runDailyPass` + `buildDailyPassPlan` carry the same information; if a fresh reader needs the orientation, the entry-point function's signature does the job. Worth a glance to confirm.
- [ ] **Composables** — 5 of the 20 had longer kept-WHY blocks (useFaviconState, useHealth, useNotifications, useFreshPluginData, usePendingCalls). Each retained the load-bearing constraint as one tightened sentence. Spot-check `useNotifications.ts` for the per-item read-state invariant.

## Per-module diff

| Module | Comment lines before | After | Notes |
|---|---:|---:|---|
| `server/agent/mcp-tools/` | already trimmed in this branch | | x.ts, notify.ts, index.ts |
| `server/workspace/journal/` (this batch) | 414 | 70 | dailyPass.ts: 167→34 was the biggest single drop |
| `src/components/SessionSidebar.vue` | 1 | 1 | already cleaned during the rename from `ToolResultsPanel.vue` |
| `src/composables/` | 460 | 105 | 20 files; useFaviconState, useNotifications, useFreshPluginData were the biggest |
| `server/utils/files/` | 263 | 50 | 19 \`*-io.ts\` files; each had a paragraph-length header |
| `src/plugins/scheduler/` | 154 | 31 | #824 split-time prose was stale |
| `server/agent/index.ts` | 33 | 11 | LLMBackend abstraction (#834) made some commentary redundant |

## Before / After examples

### `server/workspace/journal/dailyPass.ts`

Before:
\`\`\`ts
// The daily pass: walk chat/*.jsonl, find sessions changed since
// the last run, bucket events by local-date, call the archivist
// once per affected day, and apply its output (write daily/*.md,
// create/append/rewrite topics/*.md).
//
// This file is the only one in the journal module that combines
// filesystem side-effects with LLM calls. Pure bits (event parsing,
// bucketing) are factored into small exported helpers so tests can
// exercise them without touching disk.

import fsp from "node:fs/promises";
\`\`\`

After:
\`\`\`ts
import fsp from "node:fs/promises";
\`\`\`

The function names \`runDailyPass\` / \`buildDailyPassPlan\` and the imports themselves carry every word of the deleted prose.

### `src/composables/useFaviconState.ts`

Before:
\`\`\`ts
// Dynamic favicon wiring.
//
// Assembles the full \`FaviconContext\` from reactive app signals
// (\`isRunning\`, \`sessionsUnreadCount\`, a ticking clock, server CPU
// load, optional user birthday), feeds it through the pure
// \`resolveFaviconColor\` rule chain, and hands the resolved color
// to \`useDynamicFavicon\` for painting.
//
// Every input is global: the user is frequently on /files or other
// non-chat views where \`activeSession\` is undefined, so relying on
// the on-screen session would silently miss background activity.
\`\`\`

After (kept WHY only):
\`\`\`ts
// Inputs are global on purpose — on /files or other non-chat views activeSession is undefined, so an on-screen-only
// signal would silently miss background activity.
\`\`\`

### `server/agent/index.ts`

Before:
\`\`\`ts
// Fire-and-forget pre-flight check: warn (don't block) when an
// npx-style stdio server points at a package npm doesn't resolve.
// Catches the "catalog entry pinned to a non-existent name" failure
// mode where Claude silently falls back to WebSearch because the
// MCP subprocess never starts. Cached per-package within the
// process lifetime — first invocation pays the network round-trip.
validateStdioPackages(userServers).catch(() => {});
\`\`\`

After:
\`\`\`ts
// Catches the "catalog entry pinned to a non-existent npm package" failure where the MCP subprocess never starts and
// Claude silently falls back to WebSearch. Fire-and-forget; per-package cache amortizes the network round-trip.
validateStdioPackages(userServers).catch(() => {});
\`\`\`

## Test plan

- [x] \`yarn format\` — clean
- [x] \`yarn lint --no-cache\` — 0 errors (24 pre-existing warnings unchanged)
- [x] \`yarn typecheck\` — clean
- [x] \`yarn build\` — clean
- [x] \`yarn test\` — passes (no project-side unit tests, package workspaces report nothing)
- [ ] Manual: open the app, ensure favicon updates, sessions list works, journal continues to ingest. (Behavior surface is broad; I confirmed the relevant function names + types stayed put — the comments were the only thing removed.)

## Closes

- #910 — comment reduction sweep (modules 1-8 all delivered: pilot in #914, batch here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Condensed and removed verbose inline comments and documentation blocks throughout the codebase to reduce clutter while maintaining code clarity. Affected areas span server-side modules (journal processing, file I/O operations, agent configuration) and client-side files (composables, Vue components, scheduler plugins). All functional logic, exported function signatures, data structures, and runtime behavior remain completely unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->