### PR TITLE
chore(lint): enable @typescript-eslint/no-use-before-define (#920)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -135,6 +135,24 @@ export default [
           ],
         },
       ],
+      // Catch TDZ-style `use-before-define` (e.g. accessing a `const`
+      // before its declaration line). #920. Function declarations are
+      // exempt — TS hoists them safely, and top-down narrative-style
+      // (`main()` first, helpers below) is a common pattern in the
+      // codebase. Type references are also exempt: type position is
+      // erased at runtime, so the order doesn't affect execution.
+      "no-use-before-define": "off",
+      "@typescript-eslint/no-use-before-define": [
+        "error",
+        {
+          functions: false,
+          classes: true,
+          variables: true,
+          enums: true,
+          typedefs: false,
+          ignoreTypeReferences: true,
+        },
+      ],
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/packages/bridges/irc/src/index.ts
+++ b/packages/bridges/irc/src/index.ts
@@ -36,12 +36,12 @@ const password = process.env.IRC_PASSWORD;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
+const irc = new IrcClient();
+
 mulmo.onPush((pushEvent) => {
   // pushEvent.chatId is the channel name
   irc.say(pushEvent.chatId, pushEvent.message);
 });
-
-const irc = new IrcClient();
 
 irc.connect({
   host: server,

--- a/packages/bridges/matrix/src/index.ts
+++ b/packages/bridges/matrix/src/index.ts
@@ -36,14 +36,14 @@ const allowAll = allowedRooms.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
-mulmo.onPush((pushEvent) => {
-  matrixClient.sendTextMessage(pushEvent.chatId, pushEvent.message).catch((err: unknown) => console.error(`[matrix] push send failed: ${err}`));
-});
-
 const matrixClient: MatrixClient = createClient({
   baseUrl: homeserverUrl,
   accessToken,
   userId,
+});
+
+mulmo.onPush((pushEvent) => {
+  matrixClient.sendTextMessage(pushEvent.chatId, pushEvent.message).catch((err: unknown) => console.error(`[matrix] push send failed: ${err}`));
 });
 
 // The matrix-js-sdk event emitter types are narrowly typed; the

--- a/packages/bridges/signal/src/index.ts
+++ b/packages/bridges/signal/src/index.ts
@@ -113,6 +113,11 @@ function extractGroupId(dataMessage: JsonRecord): string {
   return "";
 }
 
+// E.164: `+` followed by 1-15 digits, first digit non-zero. Signal
+// accepts this exact shape; the bot can only reply to senders whose
+// phone is on file.
+const E164_PHONE = /^\+[1-9]\d{1,14}$/;
+
 function parseEnvelope(raw: string): IncomingSignal | null {
   let parsed: unknown;
   try {
@@ -139,11 +144,6 @@ function parseEnvelope(raw: string): IncomingSignal | null {
   const chatId = groupId ? `group.${groupId}` : sourceNumber;
   return { sourceNumber, chatId, isGroup: Boolean(groupId), text };
 }
-
-// E.164: `+` followed by 1-15 digits, first digit non-zero. Signal
-// accepts this exact shape; the bot can only reply to senders whose
-// phone is on file.
-const E164_PHONE = /^\+[1-9]\d{1,14}$/;
 
 async function handleEnvelope(raw: string): Promise<void> {
   const msg = parseEnvelope(raw);

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -56,7 +56,11 @@ function waitUntilReady(portNum, onReady) {
   const timeoutMs = 15000;
   const intervalMs = 300;
 
-  const attempt = () => {
+  // `function` declarations (not arrow consts) so the mutual
+  // reference between `attempt` and `retry` works without TDZ
+  // ordering problems. Both forms are hoisted to the top of the
+  // enclosing function scope.
+  function attempt() {
     const req = httpGet({ host: "127.0.0.1", port: portNum, path: "/", timeout: 1000 }, (res) => {
       res.resume();
       onReady();
@@ -66,12 +70,12 @@ function waitUntilReady(portNum, onReady) {
       req.destroy();
       retry();
     });
-  };
+  }
 
-  const retry = () => {
+  function retry() {
     if (Date.now() - startedAt > timeoutMs) return;
     setTimeout(attempt, intervalMs);
-  };
+  }
 
   attempt();
 }

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -232,6 +232,13 @@ async function loadScriptFromDisk(filePath: string, res: Response): Promise<Scri
   };
 }
 
+// Module-level dedup so a foreground SSE call and a fire-and-forget
+// background call can't race on the same script. Keyed by the realpath
+// (absoluteFilePath) so two different wire spellings of the same file
+// still collide. The set is intentionally process-local — a multi-
+// process deployment would need an external lock; that's out of scope.
+const inFlightMovies = new Set<string>();
+
 function triggerAutoBackgroundMovie(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): void {
   if (inFlightMovies.has(absoluteFilePath)) return;
   inFlightMovies.add(absoluteFilePath);
@@ -608,13 +615,6 @@ router.post(API_ROUTES.mulmoScript.renderBeat, async (req: Request<object, objec
     publishGeneration(chatSessionId, GENERATION_KINDS.beatImage, filePath, key, true, genError);
   }
 });
-
-// Module-level dedup so a foreground SSE call and a fire-and-forget
-// background call can't race on the same script. Keyed by the realpath
-// (absoluteFilePath) so two different wire spellings of the same file
-// still collide. The set is intentionally process-local — a multi-
-// process deployment would need an external lock; that's out of scope.
-const inFlightMovies = new Set<string>();
 
 type MovieGenerationResult = { ok: true; outputPath: string } | { ok: false; error: string };
 

--- a/server/api/routes/todosColumnsHandlers.ts
+++ b/server/api/routes/todosColumnsHandlers.ts
@@ -161,6 +161,8 @@ export function resyncDoneMembership(items: TodoItem[], newDoneId: string): { it
 // so two columns being merged together (handleDeleteColumn's refuge
 // case) end up with unique, contiguous orders rather than colliding
 // 1000s from each side.
+const ORDER_STEP = 1000;
+
 function rebuildColumnOrder(items: TodoItem[], columnId: string): TodoItem[] {
   const inColumn = items.filter((item) => item.status === columnId).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
   const newOrders = new Map<string, number>();
@@ -171,8 +173,6 @@ function rebuildColumnOrder(items: TodoItem[], columnId: string): TodoItem[] {
     return { ...item, order: newOrder };
   });
 }
-
-const ORDER_STEP = 1000;
 
 // ── Action handlers ───────────────────────────────────────────────
 

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -85,6 +85,17 @@ async function renewTokenViaPty(): Promise<boolean> {
     let responded = false;
     let buffer = "";
     let settled = false;
+    // Mutual reference: `finish`'s body needs `timeout` (clearTimeout)
+    // and `timeout`'s callback needs `finish`. Predeclared with `let`
+    // and assigned exactly once below. `prefer-const` would prefer a
+    // direct `const timeout = setTimeout(...)` form, but that needs
+    // `finish` already in scope inside the callback, which then
+    // forces `clearTimeout(timeout)` inside `finish`'s body to
+    // reference an undefined-at-textual-position const — i.e. the
+    // chicken-and-egg pair has no const-only spelling. The actual
+    // value is single-write at runtime; lint heuristic disagrees.
+    // eslint-disable-next-line prefer-const -- mutual-reference pair, see comment above
+    let timeout: ReturnType<typeof setTimeout>;
 
     const finish = (success: boolean) => {
       if (settled) return;
@@ -94,7 +105,7 @@ async function renewTokenViaPty(): Promise<boolean> {
       resolve(success);
     };
 
-    const timeout = setTimeout(() => {
+    timeout = setTimeout(() => {
       log.error("credentials", `Token renewal timed out after ${PTY_TIMEOUT_MS / ONE_SECOND_MS}s`);
       finish(false);
     }, PTY_TIMEOUT_MS);

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -162,6 +162,11 @@ export interface DailyFileEntry {
   day: string;
 }
 
+const YEAR_RE = /^\d{4}$/;
+const MONTH_RE = /^\d{2}$/;
+const isYearDir = (name: string) => YEAR_RE.test(name);
+const isMonthDir = (name: string) => MONTH_RE.test(name);
+
 export async function listDailyFiles(rootOverride?: string): Promise<DailyFileEntry[]> {
   const dailyRoot = path.join(summariesRoot(root(rootOverride)), DAILY_DIR);
   const years = await safeReaddir(dailyRoot);
@@ -172,11 +177,6 @@ export async function listDailyFiles(rootOverride?: string): Promise<DailyFileEn
   }
   return out;
 }
-
-const YEAR_RE = /^\d{4}$/;
-const MONTH_RE = /^\d{2}$/;
-const isYearDir = (name: string) => YEAR_RE.test(name);
-const isMonthDir = (name: string) => MONTH_RE.test(name);
 
 async function listDaysForYear(dailyRoot: string, year: string): Promise<DailyFileEntry[]> {
   const months = await safeReaddir(path.join(dailyRoot, year));

--- a/src/components/SourcesManager.vue
+++ b/src/components/SourcesManager.vue
@@ -312,6 +312,7 @@ const props = defineProps<{
 }>();
 
 const localSources = ref<Source[] | null>(props.initialData?.sources ?? null);
+const sources = computed<Source[]>(() => localSources.value ?? []);
 const lastRebuild = ref<RebuildSummary | null>(props.initialData?.lastRebuild ?? null);
 const highlightSlugLocal = ref<string | null>(props.initialData?.highlightSlug ?? null);
 const actionMessage = ref("");
@@ -631,7 +632,6 @@ async function rebuildInline(): Promise<void> {
   await loadBrief(summary.isoDate);
 }
 
-const sources = computed<Source[]>(() => localSources.value ?? []);
 const highlightSlug = computed(() => highlightSlugLocal.value);
 
 // Filter chip state (#768). Single-select. `all` is the implicit

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -177,25 +177,12 @@ const backgroundImage = computed(() => {
 let uploadInFlight = false;
 let pendingSave = false;
 
-// Undo/redo kick off the library's async redraw; give it a tick to
-// composite before we snapshot-and-upload.
-const undo = () => {
-  canvasRef.value?.undo();
-  setTimeout(saveDrawing, 50);
-};
-const redo = () => {
-  canvasRef.value?.redo();
-  setTimeout(saveDrawing, 50);
-};
-const clear = () => {
-  canvasRef.value?.reset();
-  saveDrawing();
-};
-
 // Snapshot the current bitmap and PUT it back to the pre-allocated
 // file. No result mutation — the path is fixed from canvas creation,
-// so nothing upstream needs to know about saves.
-const saveDrawing = async (): Promise<void> => {
+// so nothing upstream needs to know about saves. `function` (not
+// `const`) so the undo/redo/clear handlers below can reference it
+// without TDZ ordering problems.
+async function saveDrawing(): Promise<void> {
   if (!canvasRef.value || !imagePath.value) return;
   if (uploadInFlight) {
     pendingSave = true;
@@ -219,6 +206,21 @@ const saveDrawing = async (): Promise<void> => {
       void saveDrawing();
     }
   }
+}
+
+// Undo/redo kick off the library's async redraw; give it a tick to
+// composite before we snapshot-and-upload.
+const undo = () => {
+  canvasRef.value?.undo();
+  setTimeout(saveDrawing, 50);
+};
+const redo = () => {
+  canvasRef.value?.redo();
+  setTimeout(saveDrawing, 50);
+};
+const clear = () => {
+  canvasRef.value?.reset();
+  saveDrawing();
 };
 
 const updateCanvasSize = () => {

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -42,6 +42,12 @@ async function fetchContent(): Promise<void> {
 fetchContent();
 watch(() => props.result.data?.markdown, fetchContent);
 
+const resolvedMarkdown = computed(() => {
+  const raw = props.result.data?.markdown;
+  if (!raw) return "";
+  return isFilePath(raw) ? fetchedContent.value : raw;
+});
+
 const displayTitle = computed(() => {
   if (props.result.title) {
     return props.result.title;
@@ -52,12 +58,6 @@ const displayTitle = computed(() => {
     if (heading) return heading;
   }
   return "Markdown Document";
-});
-
-const resolvedMarkdown = computed(() => {
-  const raw = props.result.data?.markdown;
-  if (!raw) return "";
-  return isFilePath(raw) ? fetchedContent.value : raw;
 });
 
 function extractPreview(markdown: string): string {

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -282,6 +282,7 @@ import { API_ROUTES } from "../../config/apiRoutes";
 import TasksTab from "./TasksTab.vue";
 import { isToday } from "../../utils/format/date";
 import { errorMessage } from "../../utils/errors";
+import { SCHEDULER_VIEW, SCHEDULER_VIEW_MODES as VIEW_MODES, SCHEDULER_TAB, type SchedulerViewMode as ViewMode, type SchedulerTab } from "./viewModes";
 
 const { t } = useI18n();
 
@@ -337,8 +338,6 @@ watch(
 );
 
 // ── View mode ──────────────────────────────────────────────────────────────
-
-import { SCHEDULER_VIEW, SCHEDULER_VIEW_MODES as VIEW_MODES, SCHEDULER_TAB, type SchedulerViewMode as ViewMode, type SchedulerTab } from "./viewModes";
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const MAX_MONTH_ITEMS = 3;
@@ -516,6 +515,10 @@ function parseYaml(text: string): {
 const selectedId = ref<string | null>(null);
 const yamlText = ref("");
 const yamlError = ref("");
+// JSON source editor state (used by the watcher below as well, so
+// declared up here to avoid TDZ ordering with the items-watch handler).
+const editorText = ref("");
+const parseError = ref("");
 
 function selectItem(item: ScheduledItem) {
   if (selectedId.value === item.id) {
@@ -562,8 +565,10 @@ function toJson(its: ScheduledItem[]) {
   return JSON.stringify(its, null, 2);
 }
 
-const editorText = ref(toJson(items.value));
-const parseError = ref("");
+// Seed the editor text now that toJson is in scope (the ref itself
+// was declared earlier so the watcher above can reference it).
+editorText.value = toJson(items.value);
+
 // Last POST /api/scheduler failure. Cleared on the next successful call
 // so the banner disappears as soon as things recover.
 const apiError = ref<string | null>(null);

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -202,6 +202,11 @@ function isFilePath(value: unknown): value is string {
   return typeof value === "string" && value.startsWith("artifacts/spreadsheets/") && value.endsWith(".json");
 }
 
+// Editor textarea backing ref. Declared up here (rather than next to
+// the other view-state refs further down) so the `fetchSheets().then`
+// initializer below can assign to it without TDZ.
+const editableData = ref(JSON.stringify(resolvedSheets.value || [], null, 2));
+
 async function fetchSheets(): Promise<void> {
   const raw = props.selectedResult.data?.sheets;
   // Clear any stale error from a previous result BEFORE the early
@@ -273,7 +278,9 @@ async function persistSheets(sheets: SpreadsheetSheet[]): Promise<void> {
 }
 
 const activeSheetIndex = ref(0);
-const editableData = ref(JSON.stringify(resolvedSheets.value || [], null, 2));
+// Editor state declared together with the other refs above. Seeded
+// in the on-mount `fetchSheets().then(...)` block above (the `.value`
+// assignment is in scope by the time that .then callback fires).
 const editorTextarea = ref<HTMLTextAreaElement | null>(null);
 const editorDetails = ref<HTMLDetailsElement | null>(null);
 const tableContainer = ref<HTMLDivElement | null>(null);

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -145,6 +145,11 @@ const roleTheme = computed(() => {
 
 const hasChanges = computed(() => editedText.value !== editorSource.value);
 
+// `<details>` element ref. Declared together with the editing state
+// just below, but hoisted up here so `applyChanges` can close the
+// panel after a save without TDZ ordering trouble.
+const detailsEl = ref<HTMLDetailsElement>();
+
 function applyChanges() {
   if (!hasChanges.value) return;
 
@@ -189,7 +194,6 @@ function openLinksInNewTab(event: MouseEvent): void {
 
 const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
 
-const detailsEl = ref<HTMLDetailsElement>();
 const editing = ref(false);
 
 function onDetailsToggle(event: Event) {

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -268,6 +268,7 @@ const WIKI_DATA_DIR = "data/wiki";
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
+const appApi = useAppApi();
 
 const props = defineProps<{
   selectedResult?: ToolResultComplete<WikiData>;
@@ -599,7 +600,9 @@ function navigatePage(pageName: string) {
 }
 
 // --- Per-page chat composer ---
-const appApi = useAppApi();
+// (`appApi` itself is hoisted to the top of <script setup> alongside
+// route/router/t so the lint-by-line analysis is happy with earlier
+// uses in `startLintChat` etc.)
 
 const isStandaloneWikiRoute = computed(() => route.name === PAGE_ROUTES.wiki);
 


### PR DESCRIPTION
## Summary

Enables `@typescript-eslint/no-use-before-define` so TDZ-style "use before declaration" patterns get caught at lint time instead of at runtime / refactor time. First Tier-A item from the lint roadmap (#927).

24 violations surfaced on first enable; all fixed by reordering declarations or hoisting via `function` syntax. **Net behavioral change: zero** — only declaration positions moved.

## Items to Confirm / Review

- [ ] **`functions: false`** in the rule options — `function` declarations remain free to be referenced before their textual position because TS hoists them safely. Top-down narrative-style and mutually-recursive function declarations stay legal.
- [ ] **`server/system/credentials.ts` mutual-reference pair** — the only fix that *introduced* a lint disable: `let timeout` + `const finish` + `timeout = setTimeout(...)` (single-write at runtime). The chicken-and-egg pair (`finish` needs `timeout`, `timeout`'s callback needs `finish`) has no const-only spelling. Disabled `prefer-const` per-line with rationale.
- [ ] **`packages/mulmoclaude/bin/mulmoclaude.js`** — converted mutually-recursive `attempt` ⇄ `retry` from arrow consts to `function` declarations (hoisted). Same observable behavior.
- [ ] **`src/plugins/canvas/View.vue`** — converted `saveDrawing` from arrow const to `async function` so undo/redo/clear handlers above it can call it.
- [ ] **`src/plugins/scheduler/View.vue`** — moved a mid-file `import` (line 341) up to the top imports block; predeclared `editorText`/`parseError` refs above the watcher that uses them, and seeded `editorText` after `toJson` is in scope.
- [ ] **No tests touched** — this is purely a lint enable + declaration-order refactor. 3317 / 3317 unit tests pass.

## User Prompt

> lint ruleってもっと厳しくできる？定義前に変数を使わない、、、みたいなの、ひっかからなかったような。  
> issue にして、1つ1つ。  
> はい。順に。

## Implementation

### Rule config

```ts
"no-use-before-define": "off",  // base rule disabled
"@typescript-eslint/no-use-before-define": [
  "error",
  {
    functions: false,        // function declarations hoist safely
    classes: true,
    variables: true,
    enums: true,
    typedefs: false,         // type-only refs erase at runtime
    ignoreTypeReferences: true,
  },
],
```

### Files changed (16)

| File | Fix |
|---|---|
| `eslint.config.mjs` | enable rule with options |
| `server/api/routes/todosColumnsHandlers.ts` | hoist `ORDER_STEP` const |
| `server/system/credentials.ts` | `let timeout` predecl + `prefer-const` disable rationale |
| `packages/bridges/{irc,matrix}/src/index.ts` | client construction before `mulmo.onPush` |
| `packages/bridges/signal/src/index.ts` | hoist `E164_PHONE` regex |
| `packages/mulmoclaude/bin/mulmoclaude.js` | mutually-recursive arrows → `function` declarations |
| `server/api/routes/mulmo-script.ts` | hoist `inFlightMovies` Set |
| `server/utils/files/journal-io.ts` | hoist YEAR_RE/MONTH_RE/isYearDir/isMonthDir |
| `src/components/SourcesManager.vue` | hoist `sources` computed |
| `src/plugins/canvas/View.vue` | `saveDrawing` arrow → `async function` |
| `src/plugins/markdown/Preview.vue` | swap `displayTitle`/`resolvedMarkdown` order |
| `src/plugins/scheduler/View.vue` | mid-file import → top; predeclare editor refs |
| `src/plugins/spreadsheet/View.vue` | hoist `editableData` ref |
| `src/plugins/textResponse/View.vue` | hoist `detailsEl` ref |
| `src/plugins/wiki/View.vue` | hoist `appApi = useAppApi()` |

### Plan reference

This is the first PR in the **Tier A** lint roadmap tracked by #927. Following PRs will tackle: #921 `eqeqeq`, #922 `no-throw-literal`, #923 `no-implicit-coercion`, #924 `no-unneeded-ternary` + `no-else-return`, then Tier B (#925 strict) and Tier C (#926 type-checked).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 24 warnings (all pre-existing `vue/no-v-html`)
- [x] `yarn build:client` clean
- [x] `tsx --test` 3317 / 3317 pass
- [ ] `yarn typecheck` — fails on `src/utils/markdown/frontmatter.ts:13` (missing `@types/js-yaml`). Confirmed pre-existing on main; not introduced by this PR.

Closes #920
🤖 Generated with [Claude Code](https://claude.com/claude-code)