### PR TITLE
chore(lint): enable eqeqeq (=== over ==) (#921)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -163,6 +163,12 @@ export default [
         },
       ],
       "linebreak-style": ["error", "unix"],
+      // `==`/`!=` triggers JS coercion (`null == undefined` → true,
+      // `"" == 0` → true). `smart` keeps the `x == null` idiom (covers
+      // both null and undefined in one check) so existing
+      // null-or-undefined guards don't all need to be rewritten.
+      // #921.
+      eqeqeq: ["error", "smart"],
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",


### PR DESCRIPTION
## Summary

Adds `eqeqeq: ["error", "smart"]` to `eslint.config.mjs`. **Initial enable surfaced zero violations** — the codebase already uses `===` / `!==` consistently. Pure tripwire for future code.

## Items to Confirm / Review

- [ ] **`smart` mode** preserves the `x == null` idiom (covers both null and undefined in one check). Without `smart`, every `if (foo == null)` would have to become `if (foo === null || foo === undefined)`. Going with smart matches typical TS/JS project conventions.
- [ ] **`src/plugins/spreadsheet/engine/`** uses intentional `==` (e.g. `lookup.ts:58` does `"10" == 10` for spreadsheet semantics). That directory is **already in `eslint.config.mjs#ignores`** — verified that lint doesn't check it. No new ignore needed.
- [ ] **Zero violations**: `yarn lint` confirms no `eqeqeq` flags. The grep below shows the only `==` / `!=` in non-ignored code is in comments.

```
$ grep -rnE '[^=!<>=]== [^=]|[^=!]!= [^=]' src/ server/ packages/
src/plugins/spreadsheet/engine/evaluator.ts:350  // comment
src/plugins/spreadsheet/engine/functions/lookup.ts:58, 61, 322  // intentional, in ignored dir
server/workspace/sources/robots.ts:10  // comment
packages/relay/src/webhooks/teams.ts:15-16  // comments
```

## User Prompt

> はい。順に。  
> マージしてつぎへ

(After merging #928 with the no-use-before-define rule, continue to #921 eqeqeq.)

## Implementation

```ts
// eslint.config.mjs
"linebreak-style": ["error", "unix"],
// `==`/`!=` triggers JS coercion (`null == undefined` → true,
// `"" == 0` → true). `smart` keeps the `x == null` idiom (covers
// both null and undefined in one check) so existing
// null-or-undefined guards don't all need to be rewritten.
// #921.
eqeqeq: ["error", "smart"],
quotes: "off",
```

### Plan reference

Tier A roadmap item from #927. Following PRs: #922 `no-throw-literal`, #923 `no-implicit-coercion`, #924 `no-unneeded-ternary` + `no-else-return`. Then Tier B (#925) and Tier C (#926).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 5 warnings (pre-existing `vue/no-v-html`)
- [x] `yarn build:client` clean
- [x] `tsx --test` 3317 / 3317 pass

Closes #921
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add ESLint eqeqeq rule in smart mode to prevent future use of ==/!= with type coercion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to enforce stricter equality operator standards in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->