### PR TITLE
chore(lint): enable no-throw-literal (#922)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,6 +169,7 @@ export default [
       // null-or-undefined guards don't all need to be rewritten.
       // #921.
       eqeqeq: ["error", "smart"],
+      "no-throw-literal": "error",
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",

--- a/test/routes/test_dispatchResponse.ts
+++ b/test/routes/test_dispatchResponse.ts
@@ -214,6 +214,7 @@ describe("respondWithDispatchResult — persist throws", () => {
         shouldPersist: true,
         instructions: "x",
         persist: () => {
+          // eslint-disable-next-line no-throw-literal -- intentional non-Error throw, asserting respondWithDispatchResult handles unknown thrown values
           throw "string thrown directly";
         },
       },

--- a/test/routes/test_mulmoScriptHelpers.ts
+++ b/test/routes/test_mulmoScriptHelpers.ts
@@ -144,6 +144,7 @@ describe("withStoryContext — handler throws", () => {
       "stories/x.json",
       {},
       async () => {
+        // eslint-disable-next-line no-throw-literal -- intentional non-Error throw, asserting withStoryContext converts unknown rejections to 500
         throw "plain string";
       },
       {

--- a/test/sources/test_pipelineFetch.ts
+++ b/test/sources/test_pipelineFetch.ts
@@ -191,6 +191,7 @@ describe("runFetchPhase — failure isolation (Q8)", () => {
 
   it("converts non-Error throws to string error messages", async () => {
     const fetcher = fakeFetcher("rss", async () => {
+      // eslint-disable-next-line no-throw-literal -- intentional non-Error throw, asserting runFetchPhase converts unknown rejections to string messages
       throw "string error";
     });
     const result = await runFetchPhase({


### PR DESCRIPTION
## Summary

Adds the base `no-throw-literal` rule. Catches `throw "string"` / `throw 42` / `throw true` patterns where stack traces are lost.

## Items to Confirm / Review

- [ ] **Base rule, not `only-throw-error`** — the TS-aware `@typescript-eslint/only-throw-error` requires `parserOptions.projectService: true` (type-checked mode), which is the scope of #926. Deferring there. The base rule catches the most common foot-gun (literal throws); the TS-aware version additionally catches throwing arbitrary objects that aren't `Error`-derived, which is rare in this codebase.
- [ ] **3 violations all in tests, all intentional** — each is a test deliberately throwing a non-Error to assert that production code (`respondWithDispatchResult`, `withStoryContext`, `runFetchPhase`) converts unknown rejections correctly. Per-line `eslint-disable-next-line` with rationale on each, rather than a blanket test-file override (the override would also allow accidental string-throws in unrelated tests).
- [ ] **No production violations** — `server/`, `src/`, `packages/` are all clean.

## User Prompt

> はい。順に。  
> mergeしてつぎへ  
> つぎにすすめて。eslintのファイルにコメント不要。git履歴でわかる

(Following the lint-stricter roadmap from #927, with the additional convention going forward of keeping `eslint.config.mjs` rule entries terse — git blame shows the rationale.)

## Implementation

### Rule

```ts
"no-throw-literal": "error",
```

### Per-line allows in tests

3 instances in `test/routes/test_dispatchResponse.ts:217`, `test/routes/test_mulmoScriptHelpers.ts:147`, `test/sources/test_pipelineFetch.ts:194`. Each carries an `eslint-disable-next-line no-throw-literal -- intentional non-Error throw, asserting <X> handles unknown thrown values` comment.

### Plan reference

Tier A roadmap item from #927. Following PR: #923 `no-implicit-coercion`. Then #924 (`no-unneeded-ternary` + `no-else-return`), then Tier B (#925 strict), then Tier C (#926 type-checked) — at which point `only-throw-error` upgrades automatically.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 5 warnings (pre-existing `vue/no-v-html`)
- [x] `tsx --test` 3317 / 3317 pass

Closes #922
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable literal-throw linting and update tests that intentionally throw non-Error values.

Enhancements:
- Enable the eslint no-throw-literal rule to prevent throwing bare literals in application code.

Tests:
- Annotate intentional non-Error throws in tests with per-line eslint disables to keep coverage of unknown rejection handling while satisfying the new lint rule.