### PR TITLE
chore(lint): enable no-implicit-coercion (#923)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,6 +170,7 @@ export default [
       // #921.
       eqeqeq: ["error", "smart"],
       "no-throw-literal": "error",
+      "no-implicit-coercion": ["error", { boolean: true, number: true, string: true, disallowTemplateShorthand: false }],
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",

--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -180,7 +180,7 @@ const googleChatPlugin: PlatformPlugin = {
   webhookPath: "/webhook/google-chat",
 
   isConfigured(env: Env): boolean {
-    return !!env.GOOGLE_CHAT_PROJECT_NUMBER;
+    return Boolean(env.GOOGLE_CHAT_PROJECT_NUMBER);
   },
 
   async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {

--- a/packages/relay/src/webhooks/line.ts
+++ b/packages/relay/src/webhooks/line.ts
@@ -43,7 +43,7 @@ const linePlugin: PlatformPlugin = {
   webhookPath: "/webhook/line",
 
   isConfigured(env: Env): boolean {
-    return !!env.LINE_CHANNEL_SECRET;
+    return Boolean(env.LINE_CHANNEL_SECRET);
   },
 
   async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {

--- a/packages/relay/src/webhooks/messenger.ts
+++ b/packages/relay/src/webhooks/messenger.ts
@@ -50,7 +50,7 @@ const messengerPlugin: PlatformPlugin = {
   webhookPath: "/webhook/messenger",
 
   isConfigured(env: Env): boolean {
-    return !!env.MESSENGER_APP_SECRET && !!env.MESSENGER_PAGE_ACCESS_TOKEN;
+    return Boolean(env.MESSENGER_APP_SECRET) && Boolean(env.MESSENGER_PAGE_ACCESS_TOKEN);
   },
 
   handleVerification(request: Request, env: Env): Response {

--- a/packages/relay/src/webhooks/telegram.ts
+++ b/packages/relay/src/webhooks/telegram.ts
@@ -21,7 +21,7 @@ const telegramPlugin: PlatformPlugin = {
   webhookPath: "/webhook/telegram",
 
   isConfigured(env: Env): boolean {
-    return !!env.TELEGRAM_BOT_TOKEN && !!env.TELEGRAM_WEBHOOK_SECRET;
+    return Boolean(env.TELEGRAM_BOT_TOKEN) && Boolean(env.TELEGRAM_WEBHOOK_SECRET);
   },
 
   async handleWebhook(request: Request, body: string, env: Env): Promise<RelayMessage[]> {

--- a/packages/relay/src/webhooks/whatsapp.ts
+++ b/packages/relay/src/webhooks/whatsapp.ts
@@ -50,7 +50,7 @@ const whatsappPlugin: PlatformPlugin = {
   webhookPath: "/webhook/whatsapp",
 
   isConfigured(env: Env): boolean {
-    return !!env.WHATSAPP_APP_SECRET && !!env.WHATSAPP_ACCESS_TOKEN;
+    return Boolean(env.WHATSAPP_APP_SECRET) && Boolean(env.WHATSAPP_ACCESS_TOKEN);
   },
 
   handleVerification(request: Request, env: Env): Response {

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -21,7 +21,7 @@ export const mcpTools: McpTool[] = [readXPost, searchX, notify];
 const toolMap = new Map(mcpTools.map((tool) => [tool.definition.name, tool]));
 
 export function isMcpToolEnabled(tool: McpTool): boolean {
-  return (tool.requiredEnv ?? []).every((key) => !!process.env[key]);
+  return (tool.requiredEnv ?? []).every((key) => Boolean(process.env[key]));
 }
 
 export const mcpToolsRouter = Router();

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -321,7 +321,7 @@ function buildIndexResponse(action: string): WikiResponse {
 // instructions distinctions that the GET and POST handlers share.
 export function buildPageResponseData(args: { action: string; pageName: string; resolvedTitle: string; content: string; exists: boolean }): WikiResponse {
   const { action, pageName, resolvedTitle, content, exists } = args;
-  const hasContent = !!content;
+  const hasContent = Boolean(content);
   // Three states:
   //   1. !exists              → page file is missing entirely.
   //   2. exists && !hasContent → page file exists but is empty (e.g.,
@@ -371,7 +371,7 @@ export function toPageResponse(args: { action: string; pageName: string; filePat
     pageName,
     resolvedTitle,
     content,
-    exists: !!filePath,
+    exists: Boolean(filePath),
   });
 }
 

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -48,7 +48,7 @@ export async function generateGeminiImageContent(
   const client = getGeminiClient();
   log.debug("gemini", "generateContent: request", {
     model,
-    hasConfig: !!config,
+    hasConfig: Boolean(config),
     aspectRatio: config?.imageConfig?.aspectRatio,
   });
   let response;
@@ -71,8 +71,8 @@ export async function generateGeminiImageContent(
   log.debug("gemini", "generateContent: response", {
     model,
     parts: parts.length,
-    hasImage: !!result.imageData,
-    hasText: !!result.message,
+    hasImage: Boolean(result.imageData),
+    hasText: Boolean(result.message),
     finishReason: response.candidates?.[0]?.finishReason,
   });
   return result;

--- a/src/App.vue
+++ b/src/App.vue
@@ -579,7 +579,7 @@ watch(currentSessionId, (sessionId) => {
   // event, leaving the session's busy indicator stuck on.
   if (previousSessionId && previousSessionId !== sessionId) {
     const prevSession = sessionMap.get(previousSessionId);
-    const prevBusy = !!prevSession && (prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
+    const prevBusy = Boolean(prevSession) && (prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
     if (prevSession && !prevBusy) {
       unsubscribeSession(previousSessionId);
     }
@@ -775,7 +775,7 @@ function buildAgentEventContext(session: ActiveSession): AgentEventContext {
 
 function hasPendingGenerations(sessionId: string): boolean {
   const live = sessionMap.get(sessionId);
-  return !!live && Object.keys(live.pendingGenerations).length > 0;
+  return Boolean(live) && Object.keys(live.pendingGenerations).length > 0;
 }
 
 function handleSessionFinished(sessionId: string): void {

--- a/src/composables/useHealth.ts
+++ b/src/composables/useHealth.ts
@@ -47,8 +47,8 @@ export function useHealth(): {
       }
       return;
     }
-    geminiAvailable.value = !!result.data.geminiAvailable;
-    sandboxEnabled.value = !!result.data.sandboxEnabled;
+    geminiAvailable.value = Boolean(result.data.geminiAvailable);
+    sandboxEnabled.value = Boolean(result.data.sandboxEnabled);
     bootFetchCompleted = true;
     const cpu = result.data.cpu;
     if (cpu && typeof cpu.load1 === "number" && Number.isFinite(cpu.load1) && typeof cpu.cores === "number" && cpu.cores > 0) {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -1066,21 +1066,21 @@ async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
-  Object.keys(renderState).forEach((key) => delete renderState[+key]);
-  Object.keys(renderedImages).forEach((key) => delete renderedImages[+key]);
-  Object.keys(renderErrors).forEach((key) => delete renderErrors[+key]);
-  Object.keys(sourceOpen).forEach((key) => delete sourceOpen[+key]);
-  Object.keys(sourceText).forEach((key) => delete sourceText[+key]);
-  Object.keys(beatSaveErrors).forEach((key) => delete beatSaveErrors[+key]);
-  Object.keys(beatSaving).forEach((key) => delete beatSaving[+key]);
-  Object.keys(localOverrides).forEach((key) => delete localOverrides[+key]);
-  Object.keys(beatAudios).forEach((key) => delete beatAudios[+key]);
-  Object.keys(audioState).forEach((key) => delete audioState[+key]);
-  Object.keys(audioErrors).forEach((key) => delete audioErrors[+key]);
+  Object.keys(renderState).forEach((key) => delete renderState[Number(key)]);
+  Object.keys(renderedImages).forEach((key) => delete renderedImages[Number(key)]);
+  Object.keys(renderErrors).forEach((key) => delete renderErrors[Number(key)]);
+  Object.keys(sourceOpen).forEach((key) => delete sourceOpen[Number(key)]);
+  Object.keys(sourceText).forEach((key) => delete sourceText[Number(key)]);
+  Object.keys(beatSaveErrors).forEach((key) => delete beatSaveErrors[Number(key)]);
+  Object.keys(beatSaving).forEach((key) => delete beatSaving[Number(key)]);
+  Object.keys(localOverrides).forEach((key) => delete localOverrides[Number(key)]);
+  Object.keys(beatAudios).forEach((key) => delete beatAudios[Number(key)]);
+  Object.keys(audioState).forEach((key) => delete audioState[Number(key)]);
+  Object.keys(audioErrors).forEach((key) => delete audioErrors[Number(key)]);
   Object.keys(charRenderState).forEach((key) => delete charRenderState[key]);
   Object.keys(charImages).forEach((key) => delete charImages[key]);
   Object.keys(charErrors).forEach((key) => delete charErrors[key]);
-  Object.keys(beatDragOver).forEach((key) => delete beatDragOver[+key]);
+  Object.keys(beatDragOver).forEach((key) => delete beatDragOver[Number(key)]);
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -38,7 +38,7 @@ function buildLiveSummary(live: ActiveSession, serverEntry: SessionSummary | und
   // OR them so any one is enough. `live.isRunning` is always defined on
   // an ActiveSession, so the summary always carries a boolean here.
   const pending = live.pendingGenerations ?? {};
-  const isRunning = !!serverEntry?.isRunning || live.isRunning || Object.keys(pending).length > 0;
+  const isRunning = Boolean(serverEntry?.isRunning) || live.isRunning || Object.keys(pending).length > 0;
   // Carry summary / keywords ONLY if the server already has them.
   // Object-spread with a conditional object keeps us from adding
   // `undefined` values that would otherwise show up as explicit


### PR DESCRIPTION
## Summary

Adds `no-implicit-coercion` so `!!x` / `+x` / `"" + x` short-forms must be written as explicit `Boolean(x)` / `Number(x)` / `String(x)`. Improves review readability at zero behavioral cost.

## Items to Confirm / Review

- [ ] **Option `disallowTemplateShorthand: false`** — `\`\${x}\`` template literals stay legal. The rule's `disallowTemplateShorthand` is meant to catch `\`\${x}\`` used purely as a coercion shortcut (i.e., to convert a value to string), but distinguishing legit interpolation from coercion-only usage is too noisy. Keeping it off matches typical projects.
- [ ] **31 violations, all mechanical** — `!!x` → `Boolean(x)` (19) and `+key` → `Number(key)` (12). Zero behavioral change; the explicit forms are observationally identical to the short forms for these inputs.
- [ ] **No tests touched** — pure lint enable + mechanical refactor. 3317 / 3317 unit tests pass.

## User Prompt

> はい。順に。  
> mergeしてつぎへ  
> つぎにすすめて。eslintのファイルにコメント不要。git履歴でわかる  
> つぎ

## Implementation

### Rule

```ts
"no-implicit-coercion": ["error", { boolean: true, number: true, string: true, disallowTemplateShorthand: false }],
```

### Files changed (13)

| File | Change |
|---|---|
| `eslint.config.mjs` | enable rule |
| `packages/relay/src/webhooks/{google-chat,line,messenger,telegram,whatsapp}.ts` | `!!env.X` → `Boolean(env.X)` in `isConfigured` checks |
| `server/agent/mcp-tools/index.ts` | `!!process.env[key]` → `Boolean(process.env[key])` |
| `server/api/routes/wiki.ts` | `!!content`, `!!filePath` → Boolean(...) |
| `server/utils/gemini.ts` | 3 `!!` log fields → Boolean(...) |
| `src/App.vue` | `!!prevSession`, `!!live` → Boolean(...) |
| `src/composables/useHealth.ts` | `!!result.data.{geminiAvailable,sandboxEnabled}` → Boolean(...) |
| `src/plugins/presentMulmoScript/View.vue` | 12 `+key` → Number(key) in delete-loops |
| `src/utils/session/mergeSessions.ts` | `!!serverEntry?.isRunning` → Boolean(...) |

### Plan reference

Tier A roadmap item from #927. Following PR: #924 `no-unneeded-ternary` + `no-else-return`. Then Tier B (#925 strict), then Tier C (#926 type-checked).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 5 warnings (pre-existing `vue/no-v-html`)
- [x] `yarn build:client` clean
- [x] `tsx --test` 3317 / 3317 pass

Closes #923
🤖 Generated with [Claude Code](https://claude.com/claude-code)