### PR TITLE
chore(lint): enable no-unneeded-ternary + no-else-return (#924)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -171,6 +171,8 @@ export default [
       eqeqeq: ["error", "smart"],
       "no-throw-literal": "error",
       "no-implicit-coercion": ["error", { boolean: true, number: true, string: true, disallowTemplateShorthand: false }],
+      "no-unneeded-ternary": ["error", { defaultAssignment: false }],
+      "no-else-return": ["error", { allowElseIf: false }],
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",

--- a/src/plugins/presentForm/View.vue
+++ b/src/plugins/presentForm/View.vue
@@ -496,10 +496,9 @@ function validateField(fieldId: string): boolean {
       type: "custom",
     });
     return false;
-  } else {
-    fieldErrors.value.delete(fieldId);
-    return true;
   }
+  fieldErrors.value.delete(fieldId);
+  return true;
 }
 
 function handleBlur(fieldId: string): void {


### PR DESCRIPTION
## Summary

Adds two flat-control-flow rules. Almost zero hits — the codebase already prefers early-return narratives and direct boolean expressions, so this is mostly a tripwire for future code.

## Items to Confirm / Review

- [ ] **`no-unneeded-ternary` with `defaultAssignment: false`** — also catches the `a ? a : b` shortcut form. Zero existing violations.
- [ ] **`no-else-return` with `allowElseIf: false`** — fires even on `else if` chains that return. Strict but the codebase already structures most multi-branch logic this way. 1 existing violation found and fixed.
- [ ] **`src/plugins/presentForm/View.vue:499`** — the `else` branch of an `if/else return` pair was flattened. Behavior unchanged: both branches return immediately, and the early-return form reads identically to the original.

## User Prompt

> はい。順に。  
> mergeしてつぎへ  
> つぎにすすめて。eslintのファイルにコメント不要。git履歴でわかる  
> つぎ  
> つづけて

## Implementation

```ts
"no-unneeded-ternary": ["error", { defaultAssignment: false }],
"no-else-return": ["error", { allowElseIf: false }],
```

### Plan reference

This is the **last Tier A item** from #927. Following PRs:
- Tier B: #925 `tseslint.configs.strict` — adds `prefer-nullish-coalescing`, `prefer-optional-chain` etc. Larger violation count expected.
- Tier C: #926 type-checked mode — `no-floating-promises` + sets up `parserOptions.projectService` for `only-throw-error` to upgrade.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 5 warnings (pre-existing `vue/no-v-html`)
- [x] `tsx --test` 3317 / 3317 pass

Closes #924
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce stricter flat-control-flow linting and adjust existing code to comply.

Enhancements:
- Refactor a field validation branch in presentForm View to use an early-return pattern without altering behavior.

Build:
- Enable the ESLint no-unneeded-ternary rule with defaultAssignment disabled.
- Enable the ESLint no-else-return rule with else-if chains disallowed.