### PR TITLE
fix: hot-fix typecheck failure on main (#932 no-implicit-coercion follow-up)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -579,9 +579,11 @@ watch(currentSessionId, (sessionId) => {
   // event, leaving the session's busy indicator stuck on.
   if (previousSessionId && previousSessionId !== sessionId) {
     const prevSession = sessionMap.get(previousSessionId);
-    const prevBusy = Boolean(prevSession) && (prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
-    if (prevSession && !prevBusy) {
-      unsubscribeSession(previousSessionId);
+    if (prevSession !== undefined) {
+      const prevBusy = prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0;
+      if (!prevBusy) {
+        unsubscribeSession(previousSessionId);
+      }
     }
   }
   previousSessionId = sessionId;
@@ -775,7 +777,8 @@ function buildAgentEventContext(session: ActiveSession): AgentEventContext {
 
 function hasPendingGenerations(sessionId: string): boolean {
   const live = sessionMap.get(sessionId);
-  return Boolean(live) && Object.keys(live.pendingGenerations).length > 0;
+  if (live === undefined) return false;
+  return Object.keys(live.pendingGenerations).length > 0;
 }
 
 function handleSessionFinished(sessionId: string): void {


### PR DESCRIPTION
## Summary

main の typecheck が失敗していたので hot fix。

PR #932 で `no-implicit-coercion` ルールを有効化した際、`!!x` を機械的に `Boolean(x)` に置換した中に、TS の type narrowing が必要だった 2 箇所が含まれていた:

- `src/App.vue:582` — `Boolean(prevSession) && prevSession.isRunning` → TS は `prevSession` を narrow できず `'prevSession' is possibly 'undefined'`
- `src/App.vue:778` — `Boolean(live) && Object.keys(live.pendingGenerations)` → 同じ理由でエラー

failed run: https://github.com/receptron/mulmoclaude/actions/runs/25042209780

## Items to Confirm / Review

- **Runtime is identical to the original `Boolean(x) && rhs` form**. `sessionMap.get()` returns `Session | undefined` (never null/0/""/false), so the `=== undefined` guard catches the same cases the original `Boolean(x)` short-circuit would catch.
- **Lint rule stays enforced** — no `eslint-disable`, no `!!`. The new code uses explicit `=== undefined` checks which TS narrows correctly without violating `no-implicit-coercion`.
- **No `Boolean(...)` wrapping needed** in the new form: inside the guard, `prevSession.isRunning` is `boolean` and `Object.keys(...).length > 0` is `boolean`, so the OR result is already `boolean`.

## User Prompt

> あれ、https://github.com/receptron/mulmoclaude/actions/runs/25042209780/job/73348025902 hot fix で直して
> ルールは厳密化している
> booleanのまえにundefined判定をいれればよくない？
> 不要なコメントは削除してね

## Implementation

```diff
- const prevBusy = Boolean(prevSession) && (prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0);
- if (prevSession && !prevBusy) {
-   unsubscribeSession(previousSessionId);
- }
+ if (prevSession !== undefined) {
+   const prevBusy = prevSession.isRunning || Object.keys(prevSession.pendingGenerations ?? {}).length > 0;
+   if (!prevBusy) {
+     unsubscribeSession(previousSessionId);
+   }
+ }
```

```diff
function hasPendingGenerations(sessionId: string): boolean {
  const live = sessionMap.get(sessionId);
- return Boolean(live) && Object.keys(live.pendingGenerations).length > 0;
+ if (live === undefined) return false;
+ return Object.keys(live.pendingGenerations).length > 0;
}
```

## Test plan

```bash
yarn typecheck    # clean (was failing on main)
yarn lint         # clean
yarn build        # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix TypeScript type checking failures introduced by stricter boolean coercion linting by adding explicit undefined guards around session lookups before accessing their properties.

Bug Fixes:
- Prevent type narrowing errors when checking previous session busy state by guarding against undefined before accessing session properties.
- Avoid possible undefined access in pending generation checks by returning early when the session lookup yields no result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management robustness by strengthening handling of missing or undefined session states.

* **Refactor**
  * Enhanced code clarity for session cleanup and pending state checks with explicit conditional logic instead of implicit type coercions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->