### PR TITLE
chore(lint): graduate sonarjs/different-types-comparison warn → error (#943-1)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,13 +116,13 @@ export default [
     },
   },
   {
-    // Type-checked rules need tsc-backed parser services. Scope this
-    // block to files that are in a tsconfig — excludes `.mjs`/`.cjs`/
-    // `.cts` which are not part of any project's `include` array. Vue
-    // SFCs get parserOptions set in their own block at the bottom.
-    // Type-checked rules need tsc-backed parser services. Vue SFCs
+    // Type-checked rules need tsc-backed parser services. Scope to
+    // src/server/test/e2e — packages/ live in their own workspaces
+    // with separate tsconfigs and aren't worth the extra memory /
+    // wall-clock cost the project-service graph adds. `.mjs`/`.cjs`
+    // are also excluded (not in any tsconfig's `include`). Vue SFCs
     // get parserOptions in their own block at the bottom.
-    files: ["**/*.{ts,tsx}"],
+    files: ["{src,server,test,e2e}/**/*.{ts,tsx}"],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -134,11 +134,11 @@ export default [
     // Rules block — applies to both TS and Vue files. Type-checked
     // rules are demoted to warn pending dedicated cleanup PRs
     // (analogous to #925's no-non-null-assertion handling).
-    files: ["**/*.{ts,tsx,vue}"],
+    files: ["{src,server,test,e2e}/**/*.{ts,tsx,vue}"],
     rules: {
       "@typescript-eslint/no-floating-promises": "warn",
       // Bug-detection-signal-positive sonarjs type-checked rules.
-      "sonarjs/different-types-comparison": "warn",
+      "sonarjs/different-types-comparison": "error",
       "sonarjs/no-misleading-array-reverse": "warn",
       "sonarjs/deprecation": "warn",
       // Stylistic / preference rules with low real-bug signal —

--- a/server/agent/mcp-tools/x.ts
+++ b/server/agent/mcp-tools/x.ts
@@ -73,10 +73,11 @@ function formatTweet(tweet: XTweet, author?: XUser, url?: string): string {
     ? `Likes: ${tweet.public_metrics.like_count} | Retweets: ${tweet.public_metrics.retweet_count} | Replies: ${tweet.public_metrics.reply_count}`
     : "";
   const link = url ?? "";
-  return [byline, "", tweet.text, "", metrics, link]
-    .filter((line) => line !== undefined)
-    .join("\n")
-    .trimEnd();
+  // Each entry is `string` (`?? ""` / ternary returns) — no undefined
+  // is possible, so the historical `.filter((line) => line !== undefined)`
+  // was dead code. `trimEnd` strips trailing blank-line padding from
+  // the empty separators when metrics/link are empty.
+  return [byline, "", tweet.text, "", metrics, link].join("\n").trimEnd();
 }
 
 export const readXPost = {

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -54,11 +54,12 @@ const TOOL_ARGS_LOG_PREVIEW_MAX = 200;
 function previewJson(value: unknown): string {
   let serialised: string;
   try {
-    serialised = JSON.stringify(value);
+    // `?? ""` handles `JSON.stringify(undefined) === undefined` —
+    // the lib type lies; runtime can return undefined.
+    serialised = JSON.stringify(value) ?? "";
   } catch {
     return "[unserialisable]";
   }
-  if (serialised === undefined) return "";
   return serialised.length > TOOL_ARGS_LOG_PREVIEW_MAX ? `${serialised.slice(0, TOOL_ARGS_LOG_PREVIEW_MAX)}…` : serialised;
 }
 

--- a/server/api/routes/chart.ts
+++ b/server/api/routes/chart.ts
@@ -70,12 +70,10 @@ function isValidChartEntry(value: unknown): value is ChartEntry {
 
 router.post(API_ROUTES.chart.present, async (req: Request<object, unknown, PresentChartBody>, res: Response<PresentChartResponse>) => {
   const { document, title } = req.body;
+  const charts = (document as { charts?: unknown[] } | null | undefined)?.charts;
   log.info("chart", "present: start", {
     titlePreview: typeof title === "string" ? previewSnippet(title) : undefined,
-    chartCount:
-      typeof document === "object" && document !== null && Array.isArray((document as { charts?: unknown[] }).charts)
-        ? (document as { charts: unknown[] }).charts.length
-        : undefined,
+    chartCount: Array.isArray(charts) ? charts.length : undefined,
   });
 
   if (!isValidChartDocument(document)) {

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -72,17 +72,20 @@ interface SaveMulmoScriptBody {
   autoGenerateMovie?: boolean;
 }
 
+// Express body types reflect the *untrusted JSON* shape: every
+// field is optional because the client can send anything. Runtime
+// guards in the handlers reject missing / wrong-shape fields.
 interface RenderBeatBody {
-  filePath: string;
-  beatIndex: number;
+  filePath?: string;
+  beatIndex?: number;
   force?: boolean;
   chatSessionId?: string;
 }
 
 interface UploadBeatImageBody {
-  filePath: string;
-  beatIndex: number;
-  imageData: string; // base64 data URI
+  filePath?: string;
+  beatIndex?: number;
+  imageData?: string; // base64 data URI
 }
 
 type ErrorResponse = { error: string };
@@ -119,7 +122,9 @@ interface ScriptOutcome {
 router.post(API_ROUTES.mulmoScript.save, async (req: Request<object, object, SaveMulmoScriptBody>, res: Response) => {
   const { script, filename, filePath, autoGenerateMovie } = req.body ?? {};
 
-  const hasScript = script !== undefined && script !== null;
+  // Loose `!= null` covers both `undefined` and `null`. The body
+  // is untrusted JSON so callers can send either.
+  const hasScript = script != null;
   const hasFilePath = typeof filePath === "string" && filePath !== "";
   if (hasScript === hasFilePath) {
     badRequest(
@@ -519,8 +524,9 @@ router.post(
       object,
       object,
       {
-        filePath: string;
-        beatIndex: number;
+        // Untrusted JSON — runtime guard below validates shape.
+        filePath?: string;
+        beatIndex?: number;
         force?: boolean;
         chatSessionId?: string;
       }

--- a/server/utils/markdown/frontmatter.ts
+++ b/server/utils/markdown/frontmatter.ts
@@ -43,7 +43,7 @@ export function parseFrontmatter(raw: string): ParsedMarkdown {
   }
   const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
   const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
-  if (!closeMatch || closeMatch.index === undefined) {
+  if (!closeMatch) {
     return { meta: {}, body: raw, hasHeader: false };
   }
   const yamlText = afterOpen.slice(0, closeMatch.index);

--- a/server/workspace/news/reader.ts
+++ b/server/workspace/news/reader.ts
@@ -36,7 +36,11 @@ export interface NewsItem {
 interface DailyJsonShape {
   itemCount?: number;
   byCategory?: Record<string, number>;
-  items?: NewsItem[];
+  // `unknown[]` not `NewsItem[]` — the JSON is untrusted, so the
+  // defensive `.filter((item): item is NewsItem => …)` below has
+  // a real job to do. Pre-typing this as `NewsItem[]` made the
+  // runtime null/typeof checks look dead to ESLint.
+  items?: unknown[];
 }
 
 // Walk the markdown linearly to find the LAST ```json ... ``` fence
@@ -84,15 +88,15 @@ export function extractDailyJsonIndex(markdown: string): NewsItem[] | null {
   // Defensive filter: drop entries that don't carry the fields the
   // viewer relies on.
   return shape.items.filter((item): item is NewsItem => {
+    if (typeof item !== "object" || item === null) return false;
+    const obj = item as Record<string, unknown>;
     return (
-      typeof item === "object" &&
-      item !== null &&
-      typeof item.id === "string" &&
-      typeof item.title === "string" &&
-      typeof item.url === "string" &&
-      typeof item.publishedAt === "string" &&
-      typeof item.sourceSlug === "string" &&
-      Array.isArray(item.categories)
+      typeof obj.id === "string" &&
+      typeof obj.title === "string" &&
+      typeof obj.url === "string" &&
+      typeof obj.publishedAt === "string" &&
+      typeof obj.sourceSlug === "string" &&
+      Array.isArray(obj.categories)
     );
   });
 }

--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -388,9 +388,11 @@ function openConfigForm(entry: McpCatalogEntry): void {
   configFormErrors.value = [];
   configFormValues.value = readDraftFromStorage(entry.id);
   // Pre-fill any missing keys with empty strings so reactive bindings
-  // work without `v-model` warnings.
+  // work without `v-model` warnings. `in` operator handles missing
+  // keys correctly without triggering `different-types-comparison`
+  // (Record indexed access lies about being `T | undefined`).
   for (const field of entry.configSchema) {
-    if (configFormValues.value[field.key] === undefined) configFormValues.value[field.key] = "";
+    if (!(field.key in configFormValues.value)) configFormValues.value[field.key] = "";
   }
 }
 

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -891,7 +891,11 @@ function playAudio(index: number) {
     audioProgress.value = 0;
     if (lightbox.value?.index === index) {
       lightboxMove(1);
+      // After `lightboxMove(1)` the reactive ref points at a new
+      // value; TS narrowing from the previous `?.index === index`
+      // check is stale, so the explicit re-read is intentional.
       const nextIndex = lightbox.value?.index;
+      // eslint-disable-next-line sonarjs/different-types-comparison -- nextIndex is `number | undefined` (reactive ref re-read; narrowing above is stale after lightboxMove)
       if (nextIndex !== undefined && nextIndex !== index && beatAudios[nextIndex]) {
         playAudio(nextIndex);
       }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -85,10 +85,14 @@ function buildQueryString(query: ApiQuery | undefined): string {
 
 function buildHeaders(opts: { headers?: Record<string, string> }, hasBody: boolean): Record<string, string> {
   const headers: Record<string, string> = { ...(opts.headers ?? {}) };
-  if (hasBody && headers["Content-Type"] === undefined) {
+  // `in` operator handles the missing-key case directly; using
+  // `headers[key] === undefined` triggers `different-types-comparison`
+  // because TS's Record indexed access lies (returns `string`,
+  // never `undefined`).
+  if (hasBody && !("Content-Type" in headers)) {
     headers["Content-Type"] = "application/json";
   }
-  if (authToken && headers["Authorization"] === undefined) {
+  if (authToken && !("Authorization" in headers)) {
     headers["Authorization"] = `Bearer ${authToken}`;
   }
   return headers;

--- a/src/utils/markdown/frontmatter.ts
+++ b/src/utils/markdown/frontmatter.ts
@@ -47,7 +47,7 @@ export function parseFrontmatter(raw: string): ParsedMarkdown {
   }
   const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
   const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
-  if (!closeMatch || closeMatch.index === undefined) {
+  if (!closeMatch) {
     return { meta: {}, body: raw, hasHeader: false };
   }
   const yamlText = afterOpen.slice(0, closeMatch.index);

--- a/src/utils/mcp/interpolateSpec.ts
+++ b/src/utils/mcp/interpolateSpec.ts
@@ -48,12 +48,14 @@ export function interpolateMcpSpec(
   const replace = (input: string): string =>
     input.replace(PLACEHOLDER, (_match, key: string) => {
       seenPlaceholders.add(key);
-      const value = values[key];
-      if (value === undefined || value === "") {
+      // Indexed Record access lies in TS (returns the value type,
+      // not `T | undefined`). Use `in` to detect missing keys
+      // before reading.
+      if (!(key in values) || values[key] === "") {
         if (requiredKeys.has(key)) missing.add(key);
         return "";
       }
-      return value;
+      return values[key];
     });
 
   let resolved: McpServerSpec;

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -86,8 +86,11 @@ describe("buildCliArgs", () => {
     });
     const pIdx = args.indexOf("-p");
     // `-p` is followed by either another flag or end-of-args, never
-    // by a plain text message.
+    // by a plain text message. Out-of-bounds array access returns
+    // undefined at runtime even though TS types `args[i]` as
+    // `string` (no noUncheckedIndexedAccess in tsconfig).
     const afterP = args[pIdx + 1];
+    // eslint-disable-next-line sonarjs/different-types-comparison -- `afterP` is `string | undefined` at runtime
     assert.ok(afterP === undefined || afterP.startsWith("--"));
   });
 

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -40,6 +40,10 @@ function seedSession(
   writeFileSync(join(chatDir, `${sessionId}.json`), JSON.stringify({ roleId, startedAt }));
   const lines: string[] = [];
   for (let i = 0; i < Math.max(userMessages.length, assistantMessages.length); i++) {
+    // Out-of-bounds array access returns undefined at runtime even
+    // though TS types `arr[i]` as the element type (no
+    // noUncheckedIndexedAccess in tsconfig).
+    // eslint-disable-next-line sonarjs/different-types-comparison -- `arr[i]` is `string | undefined` at runtime
     if (userMessages[i] !== undefined) {
       lines.push(
         JSON.stringify({
@@ -49,6 +53,7 @@ function seedSession(
         }),
       );
     }
+    // eslint-disable-next-line sonarjs/different-types-comparison -- `arr[i]` is `string | undefined` at runtime
     if (assistantMessages[i] !== undefined) {
       lines.push(
         JSON.stringify({


### PR DESCRIPTION
## Summary

First cleanup PR off of #943's roadmap. Triages every `sonarjs/different-types-comparison` warn from #941 and graduates the rule to error. **Zero real bugs found** — every hit was a case where TS's static narrowing is stricter than the runtime, and the existing checks are correct defensive code.

Also narrows `parserOptions.projectService` to `{src,server,test,e2e}` (excludes `packages/` workspaces) to bound lint memory cost without losing test/e2e coverage of type-checked rules.

**Stacked on #941** (the type-checked-mode enable PR). Base will auto-redirect to `main` once #941 merges.

## Items to Confirm / Review

- [ ] **No behavior changes** — every fix preserves the runtime check that the rule complained about. The form changes (`!= null`, `?? ""`, `in` operator, `unknown[]` cast, optional body fields) match the original semantics.
- [ ] **Untrusted Express body shape change** — `RenderBeatBody.beatIndex: number` → `beatIndex?: number` etc. This makes the type honest about JSON parsing returning whatever the client sent. Routes still validate at runtime; downstream callers were already checking.
- [ ] **`DailyJsonShape.items: NewsItem[]` → `unknown[]`** in `server/workspace/news/reader.ts`. The downstream `.filter((item): item is NewsItem => …)` was already doing real validation work; pre-typing as `NewsItem[]` made it look dead. Filter body adjusted to narrow `unknown` → `Record<string, unknown>` first.
- [ ] **`projectService` scope narrowing** — `**/*.{ts,tsx}` → `{src,server,test,e2e}/**/*.{ts,tsx}`. `packages/` workspaces have separate tsconfigs and the type-info graph cost wasn't worth it for them. Test/e2e stays in scope per project preference.
- [ ] **Per-line disables (3 sites)** in cases where TS narrowing genuinely can't track the runtime semantics:
  - `src/plugins/presentMulmoScript/View.vue:901` — reactive ref re-read after a mutation
  - `test/agent/test_agent_config.ts:94`, `test/chat-index/test_indexer.ts:47,57` — array out-of-bounds (no `noUncheckedIndexedAccess` in tsconfig)

## User Prompt

> さてこのまま直せるものは直していこう。つぎのPRとして。  
> その変更、副作用ない？できるだけテストも考慮して直してね  
> ちょっと941, 現実的にバグになる可能性のたかいruleにしぼる？  
> #943-1で、941をそこにとりこんでからすすめよう

## Implementation

### Categorisation of all 19 original hits

| Pattern | Count | Fix |
|---|---|---|
| A. `JSON.stringify` lib type lies | 1 | `?? ""` fallback |
| B. Untrusted Express body required-fields | 5 | Make body field types optional + `!= null` idiom |
| C. Record indexed-access lies | 4 | `in` operator |
| D. JSON cast lies about structure | 1 | Type as `unknown[]`, narrow inside filter |
| E. `RegExpExecArray.index` no longer optional | 2 | Remove dead check |
| F. Array out-of-bounds | 4 | Remove dead `.filter(undefined)` (1) / per-line disable (3 in test) |
| G. Reactive ref re-read | 1 | Per-line disable |
| Already covered by other fixes earlier | 1 | (count off-by-one in initial 19→18 reconciliation) |

### Plan reference

Tracker: #927. This is the first cleanup PR for #943's SonarJS type-checked rules. Future PRs in #943: graduate `no-misleading-array-reverse` (11 hits) and `deprecation` (1 hit). #942 separately tracks `no-floating-promises` graduation.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 4527 warnings (down from 4534, 7 different-types-comparison errors resolved)
- [x] `yarn build:client` clean
- [x] `tsx --test` 3367 / 3367 pass

Closes #943 partially (different-types-comparison portion)
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Promote the `sonarjs/different-types-comparison` ESLint rule to an error and adjust code and configs so existing defensive runtime checks remain valid without changing behavior.

Bug Fixes:
- Align Express request body types and JSON-derived shapes with their actual untrusted runtime inputs so defensive validation logic type-checks cleanly.
- Simplify and harden various runtime checks (e.g. record key presence, JSON stringify result, regex exec results, chart document inspection) without altering observable behavior.

Enhancements:
- Refine type annotations for untrusted request/JSON payloads and internal utilities to better reflect real runtime shapes and avoid misleading type guarantees.
- Replace fragile equality/undefined checks with safer patterns such as `!= null`, `in`-operator key checks, and more direct object/array handling.
- Remove dead filtering and optionality checks where runtime states cannot occur, and document intentional edge cases where TypeScript narrowing does not match runtime semantics.
- Narrow the scope of type-checked ESLint parser services to core `src`, `server`, `test`, and `e2e` paths to reduce linting memory and time costs while preserving coverage.

Tests:
- Add targeted inline ESLint rule disables in a few test and reactive-code sites where array bounds and ref re-reads intentionally rely on runtime behavior not captured by TypeScript’s type system.