### PR TITLE
chore(lint): graduate sonarjs/no-misleading-array-reverse warn → error (#943-2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,7 +139,7 @@ export default [
       "@typescript-eslint/no-floating-promises": "warn",
       // Bug-detection-signal-positive sonarjs type-checked rules.
       "sonarjs/different-types-comparison": "warn",
-      "sonarjs/no-misleading-array-reverse": "warn",
+      "sonarjs/no-misleading-array-reverse": "error",
       "sonarjs/deprecation": "warn",
       // Stylistic / preference rules with low real-bug signal —
       // disabled to cut warning noise + lint cost.

--- a/server/agent/resumeFailover.ts
+++ b/server/agent/resumeFailover.ts
@@ -99,12 +99,12 @@ function selectMostRecent(entries: TranscriptEntry[], maxChars: number): { kept:
     const entry = entries[i];
     const entrySize = entry.source.length + entry.text.length + 3; // ": " + "\n"
     if (size + entrySize > maxChars) {
-      return { kept: picked.reverse(), truncated: true };
+      return { kept: picked.toReversed(), truncated: true };
     }
     picked.push(entry);
     size += entrySize;
   }
-  return { kept: picked.reverse(), truncated: false };
+  return { kept: picked.toReversed(), truncated: false };
 }
 
 function formatPreamble(entries: TranscriptEntry[], truncated: boolean): string {

--- a/server/index.ts
+++ b/server/index.ts
@@ -177,7 +177,7 @@ app.use(configRoutes);
 app.use(skillsRoutes);
 async function listSessionsForBridge(opts: { limit: number; offset: number }) {
   const rows = await loadAllSessions();
-  const sorted = rows.sort((leftSession, rightSession) => rightSession.changeMs - leftSession.changeMs);
+  const sorted = rows.toSorted((leftSession, rightSession) => rightSession.changeMs - leftSession.changeMs);
   const total = sorted.length;
   const sessions = sorted.slice(opts.offset, opts.offset + opts.limit).map((row) => ({
     id: row.summary.id,

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -139,7 +139,7 @@ describe("useSessionHistory — cursor-aware incremental fetch (#205)", () => {
     await fetchSessions();
 
     const ids = sessions.value.map((session) => session.id);
-    assert.deepEqual(ids.sort(), ["a", "b", "c"].sort(), "diff should upsert a/c while preserving untouched b");
+    assert.deepEqual(ids.toSorted(), ["a", "b", "c"].toSorted(), "diff should upsert a/c while preserving untouched b");
     const sessionA = sessions.value.find((session) => session.id === "a");
     assert.equal(sessionA?.preview, "updated", "a must have the diff's fields");
   });

--- a/test/journal/test_diff.ts
+++ b/test/journal/test_diff.ts
@@ -9,7 +9,7 @@ describe("findDirtySessions", () => {
       { id: "b", mtimeMs: 2000 },
     ];
     const { dirty, missing } = findDirtySessions(current, {});
-    assert.deepEqual(dirty.sort(), ["a", "b"]);
+    assert.deepEqual(dirty.toSorted(), ["a", "b"]);
     assert.deepEqual(missing, []);
   });
 
@@ -66,7 +66,7 @@ describe("findDirtySessions", () => {
       unchanged: { lastMtimeMs: 1000 },
       deleted: { lastMtimeMs: 100 },
     });
-    assert.deepEqual(dirty.sort(), ["changed", "new"]);
+    assert.deepEqual(dirty.toSorted(), ["changed", "new"]);
     assert.deepEqual(missing, ["deleted"]);
   });
 });

--- a/test/logger/test_rotation.ts
+++ b/test/logger/test_rotation.ts
@@ -57,6 +57,6 @@ describe("listLogFiles / enforceMaxFiles", () => {
     await enforceMaxFiles(dir, 0);
     await enforceMaxFiles(dir, -5);
     const filesAfter = await readdir(dir);
-    assert.deepEqual(filesAfter.sort(), filesBefore.sort());
+    assert.deepEqual(filesAfter.toSorted(), filesBefore.toSorted());
   });
 });

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -231,7 +231,7 @@ describe("detectMulmobridgeDeps", () => {
     const names = await drift.detectMulmobridgeDeps({
       root: path.join(FIXTURES, "drift-drifted"),
     });
-    assert.deepEqual(names.sort(), ["client", "protocol"]);
+    assert.deepEqual(names.toSorted(), ["client", "protocol"]);
   });
 
   it("returns empty when the launcher has no bridge deps", async () => {

--- a/test/sources/test_pipelineFetch.ts
+++ b/test/sources/test_pipelineFetch.ts
@@ -108,7 +108,7 @@ describe("runFetchPhase — success path", () => {
       deps: makeDeps(),
       getFetcher: makeGetFetcher([fetcher]),
     });
-    assert.deepEqual(callLog.sort(), ["a", "b"]);
+    assert.deepEqual(callLog.toSorted(), ["a", "b"]);
     assert.equal(result.outcomes.length, 2);
     for (const outcome of result.outcomes) {
       assert.equal(outcome.kind, "success");

--- a/test/utils/mcp/test_interpolateSpec.ts
+++ b/test/utils/mcp/test_interpolateSpec.ts
@@ -55,7 +55,7 @@ describe("interpolateMcpSpec — stdio", () => {
     const out = interpolateMcpSpec(template, {}, new Set(["A", "B", "C"]));
     assert.equal(out.ok, false);
     if (out.ok) return;
-    assert.deepEqual(out.missing.sort(), ["A", "B", "C"]);
+    assert.deepEqual(out.missing.toSorted(), ["A", "B", "C"]);
   });
 
   it("collapses optional placeholders to empty string when missing", () => {


### PR DESCRIPTION
## Summary

Second cleanup PR off of #943's roadmap. Replaces every in-place `.sort()` / `.reverse()` chained as if it returned a new array with the immutable equivalents (`.toSorted()` / `.toReversed()`, Node 20+). All 11 hits triaged; rule graduated `warn → error`.

## Items to Confirm / Review

- [ ] **Behaviour preserved**. `.toSorted()` / `.toReversed()` are stage-4 ECMAScript and behave like `[...arr].sort()` / `[...arr].reverse()` — same comparator, just non-mutating. Where the original `.sort()` was called on a returned-from-function array (no other reference held), the immutability change is invisible to callers.
- [ ] **Node 20+ runtime requirement** is already declared in `engines.node` of `package.json`. `.toSorted` shipped in V8 around Node 20.0; CI matrix is 22.x and 24.x.
- [ ] **2 production sites + 9 test sites**, all the same one-method swap. No semantic refactor required.

## User Prompt

> つぎいこう。mainをとりこんで。

## Implementation

Production:
- `server/agent/resumeFailover.ts` — `pickRecentEntries` returns `picked.toReversed()` (was `.reverse()` on a local array)
- `server/index.ts:180` — `listSessionsForBridge` uses `.toSorted()` (the local `rows` is a fresh array from `loadAllSessions`, so the previous in-place sort was already non-shared, but the immutable form makes that explicit)

Test:
- `test/composables/test_useSessionHistory.ts:142`
- `test/journal/test_diff.ts:12, 69`
- `test/logger/test_rotation.ts:60` (two sites on the same line)
- `test/scripts/mulmoclaude/test_drift.ts:234`
- `test/sources/test_pipelineFetch.ts:111`
- `test/utils/mcp/test_interpolateSpec.ts:58`

All test sites were `assert.deepEqual(arr.sort(), …)` patterns — sorting a local array purely to make the assertion order-independent. `.toSorted()` reads identically.

## Plan reference

Tracker: #927. After this lands, only `sonarjs/deprecation` (1 hit) remains in #943. #942 separately tracks `no-floating-promises` graduation.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors, 4534 warnings (down 11 from before this PR's fixes)
- [x] `yarn build:client` clean
- [x] `tsx --test` 3367 / 3367 pass (immutable variants don't change observable test behaviour)

Closes #943 partially (no-misleading-array-reverse portion)
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace in-place array sorting/reversing with immutable equivalents to satisfy stricter linting and graduate the sonarjs/no-misleading-array-reverse rule to an error.

Enhancements:
- Use Array.prototype.toReversed in resumeFailover transcript selection to avoid mutating local arrays.
- Use Array.prototype.toSorted when ordering sessions for the bridge to keep sorting immutable.
- Tighten lint configuration by promoting sonarjs/no-misleading-array-reverse from a warning to an error.

Tests:
- Update tests that relied on arr.sort() in assertions to use arr.toSorted() for non-mutating, order-independent comparisons.