### PR TITLE
chore(plugins): remove manageRoles MCP tool, keep /roles UI (#949)

### DIFF
--- a/plans/chore-remove-manage-roles-tool.md
+++ b/plans/chore-remove-manage-roles-tool.md
@@ -1,0 +1,76 @@
+# manageRoles MCP tool 削除
+
+Issue: #949 (manage\* プラグインのアーキテクチャ整理)
+
+## 背景
+
+#949 の議論で確定した方針:
+
+- **wiki**: LLM Write/Edit 直 + chat 履歴 derive
+- **roles / skills / sources**: 用途に応じて維持・削除を判断
+- **manageRoles は削除** — 実用上 Skill で十分カバーでき、tool 追加は無駄に増やさない方針
+
+実装の前提:
+
+- 既存の `/roles` フロントエンド画面 (`src/plugins/manageRoles/View.vue` を `App.vue:173` で `currentPage === 'roles'` 時に表示) は **そのまま残す**
+- ユーザは UI から create / edit / delete 可能のまま
+- 失う機能は「LLM が tool 呼び出しで role を作る」一点のみ — Skill で代替可
+
+## 変更内容
+
+### 削除
+
+| ファイル                                | 役割                       |
+| --------------------------------------- | -------------------------- |
+| `src/plugins/manageRoles/definition.ts` | tool schema                |
+| `src/plugins/manageRoles/index.ts`      | ToolPlugin wrapper         |
+| `src/plugins/manageRoles/Preview.vue`   | chat preview (tool 結果用) |
+
+### 移動
+
+| 元                                 | 先                             |
+| ---------------------------------- | ------------------------------ |
+| `src/plugins/manageRoles/View.vue` | `src/components/RolesView.vue` |
+
+### 修正
+
+- `src/App.vue` — import path 更新 (`./plugins/manageRoles/View.vue` → `./components/RolesView.vue`)
+- `src/tools/index.ts` — `manageRoles: manageRolesPlugin,` 行と import を削除
+- `src/config/toolNames.ts` — `manageRoles: "manageRoles",` 削除
+- `server/agent/plugin-names.ts` — `ManageRolesDef` import / TOOL_ENDPOINTS / PLUGIN_DEFS から削除
+- `server/agent/mcp-server.ts` — `if (name === "manageRoles") { ... }` ブロック削除
+- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — `pluginManageRoles.previewCount` キーを削除 (Preview.vue 専用、他は View.vue が使うので残す)
+
+### 変更なし
+
+- `server/api/routes/roles.ts` — `/api/roles` / `/api/roles/manage` route はフロントエンドが使用継続
+- `test/routes/test_rolesManage.ts` — server-side テストはそのまま意味あり
+- `test/composables/test_useFreshPluginData.ts` — `/api/roles` response shape の例として使ってるだけで manageRoles プラグインに依存してない
+
+## ビルトイン role への影響確認
+
+`src/config/roles.ts` の builtin 4 role の `availablePlugins` を grep — **`manageRoles` を含むものは無し**。安全に削除可能。
+
+## prompt への影響
+
+prompt 内に `manageRoles` の言及があれば削除。grep で確認。
+
+## テスト戦略
+
+- 既存テストが全 pass する前提
+- `RolesView.vue` 移動後も `/roles` ページが動作することは既存 e2e で担保 (あれば)
+- 新規テスト不要 (削除のみ + ファイル移動)
+
+## 完了条件
+
+- [ ] manageRoles plugin の 3 ファイル削除 + View.vue 移動
+- [ ] server / src の 4 ファイル修正 (App.vue / tools/index / toolNames / plugin-names / mcp-server)
+- [ ] 8 locale から `previewCount` 削除
+- [ ] `yarn typecheck && yarn lint && yarn build && yarn test` clean
+- [ ] LLM が manageRoles tool を呼んだ時の挙動 — もう存在しない tool なので tool not found エラー (動作上問題なし)
+- [ ] フロントエンド `/roles` 画面が引き続き動作
+
+## Out of scope
+
+- manageWiki の削除 (次の PR、lint_report の HTTP 化が前提)
+- manageRoles の代替として Skill の機能拡張 (別 issue)

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -352,22 +352,6 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
     return `Switching to ${args.roleId} role`;
   }
 
-  if (name === "manageRoles") {
-    const res = await postJson(API_ROUTES.roles.manage, args);
-    const result = await res.json();
-
-    // For the list action, push a visual canvas result so the viewer renders
-    if (args.action === "list" && result.success) {
-      await postJson(API_ROUTES.agent.internal.toolResult, {
-        toolName: "manageRoles",
-        uuid: makeUuid(),
-        ...result,
-      });
-    }
-
-    return result.message ?? (result.error ? `Error: ${result.error}` : "Done");
-  }
-
   if (name === "manageSkills") return handleManageSkills(args);
 
   // Pure MCP tools — call via /api/mcp-tools/:tool, return text directly

--- a/server/agent/plugin-names.ts
+++ b/server/agent/plugin-names.ts
@@ -8,7 +8,6 @@ import TodoDef from "../../src/plugins/todo/definition.js";
 import ManageCalendarDef from "../../src/plugins/scheduler/calendarDefinition.js";
 import ManageAutomationsDef from "../../src/plugins/scheduler/automationsDefinition.js";
 import PresentMulmoScriptDef from "../../src/plugins/presentMulmoScript/definition.js";
-import ManageRolesDef from "../../src/plugins/manageRoles/definition.js";
 import ManageSkillsDef from "../../src/plugins/manageSkills/definition.js";
 import ManageSourceDef from "../../src/plugins/manageSource/definition.js";
 import WikiDef from "../../src/plugins/wiki/definition.js";
@@ -44,7 +43,6 @@ export const TOOL_ENDPOINTS: Record<string, string> = {
   [PresentChartDef.name]: API_ROUTES.chart.present,
   [EditImageDef.name]: API_ROUTES.image.edit,
   [Present3DDef.name]: API_ROUTES.plugins.present3d,
-  [ManageRolesDef.name]: API_ROUTES.roles.manage,
   [ManageSkillsDef.name]: API_ROUTES.skills.create,
   [ManageSourceDef.name]: API_ROUTES.sources.manage,
   [PresentMulmoScriptDef.name]: API_ROUTES.mulmoScript.save,
@@ -68,7 +66,6 @@ export const PLUGIN_DEFS = [
   PresentChartDef,
   EditImageDef,
   Present3DDef,
-  ManageRolesDef,
   ManageSkillsDef,
   ManageSourceDef,
   WikiDef,

--- a/src/App.vue
+++ b/src/App.vue
@@ -249,7 +249,7 @@ import AutomationsView from "./plugins/scheduler/AutomationsView.vue";
 import WikiView from "./plugins/wiki/View.vue";
 import { buildWikiRouteParams } from "./plugins/wiki/route";
 import SkillsView from "./plugins/manageSkills/View.vue";
-import RolesView from "./plugins/manageRoles/View.vue";
+import RolesView from "./components/RolesView.vue";
 import SourcesView from "./components/SourcesView.vue";
 import NewsView from "./components/NewsView.vue";
 import SettingsModal from "./components/SettingsModal.vue";

--- a/src/components/RolesView.vue
+++ b/src/components/RolesView.vue
@@ -1,0 +1,562 @@
+<template>
+  <div class="h-full bg-white flex flex-col">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
+      <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageRoles.heading") }}</h2>
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", customRoles.length, { named: { count: customRoles.length } }) }}</span>
+        <button
+          v-if="!creating"
+          data-testid="role-add-btn"
+          class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+          @click="startCreate"
+        >
+          {{ t("pluginManageRoles.addButton") }}
+        </button>
+      </div>
+    </div>
+
+    <div class="flex-1 overflow-y-auto">
+      <!-- New role creation panel -->
+      <div v-if="creating" class="m-4 border border-blue-300 bg-blue-50 rounded-lg p-4 space-y-3">
+        <div class="text-sm font-semibold text-gray-700">{{ t("pluginManageRoles.createPanel") }}</div>
+
+        <!-- ID + Name + Icon row -->
+        <div class="flex gap-3">
+          <div class="w-40">
+            <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldId") }}</label>
+            <input
+              v-model="newForm.id"
+              type="text"
+              placeholder="unique-id"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+            />
+          </div>
+          <div class="flex-1">
+            <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldName") }}</label>
+            <input
+              v-model="newForm.name"
+              type="text"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+            />
+          </div>
+          <div class="w-32">
+            <label class="block text-xs font-medium text-gray-600 mb-1">
+              {{ t("pluginManageRoles.fieldIcon") }}
+              <a class="text-blue-400 font-normal ml-1" href="https://fonts.google.com/icons" target="_blank" rel="noopener">{{
+                t("pluginManageRoles.helpLink")
+              }}</a>
+            </label>
+            <input
+              v-model="newForm.icon"
+              type="text"
+              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+            />
+          </div>
+        </div>
+
+        <!-- Prompt -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldPrompt") }}</label>
+          <textarea
+            v-model="newForm.prompt"
+            rows="6"
+            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono resize-y focus:outline-none focus:border-blue-400"
+            spellcheck="false"
+          />
+        </div>
+
+        <!-- Plugins -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-2">{{ t("pluginManageRoles.fieldPlugins") }}</label>
+          <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+            <label
+              v-for="plugin in availablePlugins"
+              :key="plugin.name"
+              class="flex items-center gap-2 text-sm cursor-pointer"
+              :class="plugin.enabled ? 'text-gray-700' : 'text-gray-400 cursor-not-allowed'"
+              :title="plugin.enabled ? '' : t('pluginManageRoles.requiresEnv', { env: plugin.requiredEnv.join(', ') })"
+            >
+              <input
+                v-model="newForm.selectedPlugins"
+                type="checkbox"
+                :value="plugin.name"
+                :disabled="!plugin.enabled"
+                class="cursor-pointer disabled:cursor-not-allowed"
+              />
+              {{ plugin.name }}
+              <span v-if="!plugin.enabled" class="text-xs text-gray-400">{{ t("pluginManageRoles.missingEnv", { env: plugin.requiredEnv.join(", ") }) }}</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Starter queries -->
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">
+            {{ t("pluginManageRoles.fieldStarterQueries") }}
+            <span class="text-gray-400 font-normal">{{ t("pluginManageRoles.onePerLine") }}</span>
+          </label>
+          <textarea
+            v-model="newForm.queriesText"
+            rows="3"
+            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+          />
+        </div>
+
+        <!-- Buttons -->
+        <div class="flex gap-2 pt-1">
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            :disabled="saving || !!newFormError"
+            :title="newFormError ?? ''"
+            @click="saveNew"
+          >
+            {{ saving ? t("pluginManageRoles.creating") : t("pluginManageRoles.create") }}
+          </button>
+          <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="cancelCreate">
+            {{ t("common.cancel") }}
+          </button>
+        </div>
+        <div v-if="newFormError" class="text-xs text-gray-500" data-testid="role-form-hint">
+          {{ newFormError }}
+        </div>
+        <div v-if="createError" class="text-xs text-red-500">
+          {{ createError }}
+        </div>
+      </div>
+
+      <div v-if="!creating && customRoles.length === 0" class="h-full flex items-center justify-center text-gray-400 text-sm">
+        {{ t("pluginManageRoles.emptyHint") }}
+      </div>
+
+      <ul v-if="customRoles.length > 0" class="p-4 space-y-2">
+        <li v-for="role in customRoles" :key="role.id" class="rounded-lg border" :class="selectedId === role.id ? 'border-blue-400' : 'border-gray-200'">
+          <!-- Role header row -->
+          <div
+            class="flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 rounded-lg"
+            :class="selectedId === role.id ? 'rounded-b-none' : ''"
+            @click="selectRole(role)"
+          >
+            <span class="material-icons text-gray-500">{{ role.icon }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-sm text-gray-800">
+                {{ role.name }}
+                <span class="ml-1 text-xs font-mono text-gray-400">{{ t("pluginManageRoles.idFormatted", { id: role.id }) }}</span>
+              </div>
+              <div class="text-xs text-gray-400 truncate">
+                {{ role.availablePlugins.join(", ") }}
+              </div>
+            </div>
+            <span
+              class="material-icons text-gray-400 text-sm"
+              :title="selectedId === role.id ? t('pluginManageRoles.collapse') : t('pluginManageRoles.expand')"
+            >
+              {{ selectedId === role.id ? "expand_less" : "expand_more" }}
+            </span>
+          </div>
+
+          <!-- Inline editor -->
+          <div v-if="selectedId === role.id" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+            <!-- ID + Name + Icon row -->
+            <div class="flex gap-3">
+              <div class="w-40">
+                <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldId") }}</label>
+                <input
+                  v-model="editForm.id"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+                />
+              </div>
+              <div class="flex-1">
+                <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldName") }}</label>
+                <input
+                  v-model="editForm.name"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+                  @keydown.enter="saveEdit(role.id)"
+                />
+              </div>
+              <div class="w-32">
+                <label class="block text-xs font-medium text-gray-600 mb-1">
+                  {{ t("pluginManageRoles.fieldIcon") }}
+                  <a class="text-blue-400 font-normal ml-1" href="https://fonts.google.com/icons" target="_blank" rel="noopener">{{
+                    t("pluginManageRoles.helpLink")
+                  }}</a>
+                </label>
+                <input
+                  v-model="editForm.icon"
+                  type="text"
+                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono focus:outline-none focus:border-blue-400"
+                />
+              </div>
+            </div>
+
+            <!-- Prompt -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">{{ t("pluginManageRoles.fieldPrompt") }}</label>
+              <textarea
+                v-model="editForm.prompt"
+                rows="6"
+                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded font-mono resize-y focus:outline-none focus:border-blue-400"
+                spellcheck="false"
+              />
+            </div>
+
+            <!-- Plugins -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-2">{{ t("pluginManageRoles.fieldPlugins") }}</label>
+              <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+                <label
+                  v-for="plugin in availablePlugins"
+                  :key="plugin.name"
+                  class="flex items-center gap-2 text-sm cursor-pointer"
+                  :class="plugin.enabled ? 'text-gray-700' : 'text-gray-400 cursor-not-allowed'"
+                  :title="plugin.enabled ? '' : t('pluginManageRoles.requiresEnv', { env: plugin.requiredEnv.join(', ') })"
+                >
+                  <input
+                    v-model="editForm.selectedPlugins"
+                    type="checkbox"
+                    :value="plugin.name"
+                    :disabled="!plugin.enabled"
+                    class="cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  {{ plugin.name }}
+                  <span v-if="!plugin.enabled" class="text-xs text-gray-400">{{
+                    t("pluginManageRoles.missingEnv", { env: plugin.requiredEnv.join(", ") })
+                  }}</span>
+                </label>
+              </div>
+            </div>
+
+            <!-- Starter queries -->
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">
+                {{ t("pluginManageRoles.fieldStarterQueries") }}
+                <span class="text-gray-400 font-normal">{{ t("pluginManageRoles.onePerLine") }}</span>
+              </label>
+              <textarea
+                v-model="editForm.queriesText"
+                rows="3"
+                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded resize-y focus:outline-none focus:border-blue-400"
+              />
+            </div>
+
+            <!-- Buttons -->
+            <div class="flex items-center justify-between pt-1">
+              <div class="flex gap-2">
+                <button
+                  class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  :disabled="saving || !!editFormError"
+                  :title="editFormError ?? ''"
+                  @click="saveEdit(role.id)"
+                >
+                  {{ saving ? t("pluginManageRoles.updating") : t("pluginManageRoles.update") }}
+                </button>
+                <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="selectedId = null">
+                  {{ t("common.cancel") }}
+                </button>
+              </div>
+              <button
+                class="px-3 py-1.5 text-sm rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-50"
+                :disabled="saving"
+                @click="deleteRole(role.id)"
+              >
+                {{ t("pluginManageRoles.delete") }}
+              </button>
+            </div>
+            <div v-if="editFormError" class="text-xs text-gray-500">
+              {{ editFormError }}
+            </div>
+            <div v-if="saveError" class="text-xs text-red-500">
+              {{ saveError }}
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+import { useFreshPluginData } from "../composables/useFreshPluginData";
+import { useAppApi } from "../composables/useAppApi";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { getAllPluginNames } from "../tools/index";
+import { apiGet, apiPost } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+// Inlined from the former `src/plugins/manageRoles/index.ts`
+// (deleted alongside the manageRoles MCP tool — #949). RolesView
+// is the only consumer, so co-locating the types here avoids a
+// dangling single-purpose module.
+export interface CustomRole {
+  id: string;
+  name: string;
+  icon: string;
+  prompt: string;
+  availablePlugins: string[];
+  queries?: string[];
+}
+
+export interface ManageRolesData {
+  customRoles: CustomRole[];
+}
+
+const { t } = useI18n();
+
+interface PluginEntry {
+  name: string;
+  enabled: boolean;
+  requiredEnv: string[];
+}
+
+// Plugins the user can assign — exclude internal/auto-managed ones
+const EXCLUDED = new Set(["text-response", "switchRole"]);
+const guiPlugins: PluginEntry[] = getAllPluginNames()
+  .filter((name) => !EXCLUDED.has(name))
+  .map((name) => ({ name, enabled: true, requiredEnv: [] }));
+
+const availablePlugins = ref<PluginEntry[]>(guiPlugins);
+
+onMounted(async () => {
+  const result = await apiGet<PluginEntry[]>(API_ROUTES.mcpTools.list);
+  if (result.ok) {
+    availablePlugins.value = [...guiPlugins, ...result.data];
+  }
+  // Non-critical: MCP tools enrich the plugin palette for role editing
+  // but the view works fine with GUI plugins alone. No error banner needed.
+});
+
+const props = defineProps<{
+  selectedResult?: ToolResultComplete<ManageRolesData>;
+}>();
+const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
+
+const appApi = useAppApi();
+
+const customRoles = ref<CustomRole[]>(props.selectedResult?.data?.customRoles ?? []);
+
+const { refresh: refreshCustomRoles } = useFreshPluginData<CustomRole[]>({
+  endpoint: () => API_ROUTES.roles.list,
+  extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
+  apply: (data) => {
+    customRoles.value = data;
+  },
+});
+
+watch(
+  () => props.selectedResult?.uuid,
+  () => {
+    customRoles.value = props.selectedResult?.data?.customRoles ?? [];
+    void refreshCustomRoles();
+  },
+);
+
+// ── Selection & edit form ─────────────────────────────────────────────────────
+
+const selectedId = ref<string | null>(null);
+const saving = ref(false);
+const saveError = ref("");
+
+interface EditForm {
+  id: string;
+  name: string;
+  icon: string;
+  prompt: string;
+  selectedPlugins: string[];
+  queriesText: string;
+}
+
+const editForm = ref<EditForm>({
+  id: "",
+  name: "",
+  icon: "",
+  prompt: "",
+  selectedPlugins: [],
+  queriesText: "",
+});
+
+const creating = ref(false);
+const createError = ref("");
+const newForm = ref<EditForm>({
+  id: "",
+  name: "",
+  icon: "person",
+  prompt: "",
+  selectedPlugins: [],
+  queriesText: "",
+});
+
+function startCreate() {
+  selectedId.value = null;
+  createError.value = "";
+  newForm.value = {
+    id: "",
+    name: "",
+    icon: "person",
+    prompt: "",
+    selectedPlugins: [],
+    queriesText: "",
+  };
+  creating.value = true;
+}
+
+function cancelCreate() {
+  creating.value = false;
+  createError.value = "";
+}
+
+function selectRole(role: CustomRole) {
+  if (selectedId.value === role.id) {
+    selectedId.value = null;
+    return;
+  }
+  selectedId.value = role.id;
+  saveError.value = "";
+  editForm.value = {
+    id: role.id,
+    name: role.name,
+    icon: role.icon,
+    prompt: role.prompt,
+    selectedPlugins: role.availablePlugins.filter((plugin) => plugin !== "switchRole"),
+    queriesText: (role.queries ?? []).join("\n"),
+  };
+}
+
+// ── API ───────────────────────────────────────────────────────────────────────
+
+interface ManageResult {
+  success?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+async function callManage(body: Record<string, unknown>): Promise<ManageResult> {
+  const result = await apiPost<ManageResult>(API_ROUTES.roles.manage, body);
+  if (!result.ok) {
+    // Prefer the backend's error message (e.g. validation failure
+    // details). Fall back to a status code only when the server didn't
+    // give us anything useful.
+    return {
+      success: false,
+      error:
+        result.status === 0
+          ? result.error || t("pluginManageRoles.errNetworkError")
+          : result.error || t("pluginManageRoles.errServerError", { status: result.status }),
+    };
+  }
+  return result.data;
+}
+
+async function refreshList() {
+  const result = await callManage({ action: "list" });
+  if (result.success) {
+    const data = result as { data?: { customRoles?: CustomRole[] } };
+    customRoles.value = data.data?.customRoles ?? [];
+    if (props.selectedResult) {
+      emit("updateResult", {
+        ...props.selectedResult,
+        ...result,
+        uuid: props.selectedResult.uuid,
+      });
+    }
+    // Let App.vue know the dropdown needs to refresh.
+    await Promise.resolve(appApi.refreshRoles());
+  }
+}
+
+function validateRoleForm(form: EditForm, excludeId: string | null): string | null {
+  const trimmedId = form.id.trim();
+  const trimmedName = form.name.trim();
+  if (!trimmedId) return t("pluginManageRoles.errIdRequired");
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmedId)) {
+    return t("pluginManageRoles.errIdInvalid");
+  }
+  if (!trimmedName) return t("pluginManageRoles.errNameRequired");
+  if (customRoles.value.some((existing) => existing.id === trimmedId && existing.id !== excludeId)) {
+    return t("pluginManageRoles.errIdDuplicate", { id: trimmedId });
+  }
+  return null;
+}
+
+const newFormError = computed<string | null>(() => validateRoleForm(newForm.value, null));
+
+const editFormError = computed<string | null>(() => validateRoleForm(editForm.value, selectedId.value));
+
+function buildNewRole(): CustomRole {
+  return {
+    id: newForm.value.id.trim(),
+    name: newForm.value.name.trim(),
+    icon: newForm.value.icon.trim() || "person",
+    prompt: newForm.value.prompt,
+    availablePlugins: newForm.value.selectedPlugins,
+    queries: newForm.value.queriesText
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+  };
+}
+
+async function saveNew() {
+  if (newFormError.value) {
+    createError.value = newFormError.value;
+    return;
+  }
+  saving.value = true;
+  createError.value = "";
+  const result = await callManage({ action: "create", role: buildNewRole() });
+  if (result.success) {
+    creating.value = false;
+    await refreshList();
+  } else {
+    createError.value = result.error ?? t("pluginManageRoles.errCreateFailed");
+  }
+  saving.value = false;
+}
+
+async function saveEdit(originalId: string) {
+  if (editFormError.value) {
+    saveError.value = editFormError.value;
+    return;
+  }
+  saving.value = true;
+  saveError.value = "";
+  const role: CustomRole = {
+    id: editForm.value.id.trim(),
+    name: editForm.value.name.trim(),
+    icon: editForm.value.icon.trim(),
+    prompt: editForm.value.prompt,
+    availablePlugins: editForm.value.selectedPlugins,
+    queries: editForm.value.queriesText
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+  };
+  const result = await callManage({
+    action: "update",
+    role,
+    oldRoleId: originalId,
+  });
+  if (result.success) {
+    selectedId.value = null;
+    await refreshList();
+  } else {
+    saveError.value = result.error ?? t("pluginManageRoles.errSaveFailed");
+  }
+  saving.value = false;
+}
+
+async function deleteRole(roleId: string) {
+  saving.value = true;
+  saveError.value = "";
+  const result = await callManage({ action: "delete", roleId });
+  if (result.success) {
+    selectedId.value = null;
+    await refreshList();
+  } else {
+    saveError.value = result.error ?? t("pluginManageRoles.errDeleteFailed");
+  }
+  saving.value = false;
+}
+</script>

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -1,21 +1,32 @@
 import { z } from "zod";
-import { ALL_TOOL_NAMES, type ToolName } from "./toolNames";
+import { ALL_TOOL_NAMES, isToolName, type ToolName } from "./toolNames";
 
 // `availablePlugins` accepts every literal listed in `TOOL_NAMES`.
-// Runtime: validate with a literal-union z.enum so a typo or an
-// unknown tool name (e.g. from a future user-defined role loaded off
-// disk) rejects at boundary instead of silently dropping at runtime.
 // Compile time: roles.ts static definitions below get typed as
 // `ToolName[]` via RoleSchema's zod inference, so `presentHTML` vs
 // `presentHtml` kind of typos are caught immediately.
+//
+// Runtime: take any string array and filter out unknown names
+// rather than failing the whole parse. A persisted custom role
+// file may still reference a tool that was removed in a later
+// release (e.g. `manageRoles` post-#949 / #951), and we want
+// such a role to keep loading with the dead reference silently
+// dropped — the alternative is `loadCustomRoles` swallowing the
+// whole role, which makes the user's edits disappear from
+// `/roles` for no obvious reason. Frontend create/update goes
+// through a plugin-picker UI that only emits valid names, so the
+// lenient parse doesn't weaken create-time validation.
 const toolNameEnum = z.enum(ALL_TOOL_NAMES as readonly [ToolName, ...ToolName[]]);
+const availablePluginsSchema = z
+  .union([z.array(z.string()), z.array(toolNameEnum)])
+  .transform((plugins) => plugins.filter((plugin): plugin is ToolName => isToolName(plugin)));
 
 export const RoleSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string(),
   prompt: z.string(),
-  availablePlugins: z.array(toolNameEnum),
+  availablePlugins: availablePluginsSchema,
   queries: z.array(z.string()).optional(),
 });
 

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -28,7 +28,6 @@ export const TOOL_NAMES = {
   // a 1:1 mapping between tool name and domain.
   manageCalendar: "manageCalendar",
   manageAutomations: "manageAutomations",
-  manageRoles: "manageRoles",
   manageSkills: "manageSkills",
   manageSource: "manageSource",
   manageWiki: "manageWiki",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -786,7 +786,6 @@ const deMessages = {
   pluginManageRoles: {
     heading: "Benutzerdefinierte Rollen",
     roleCount: "{count} Rolle | {count} Rollen",
-    previewCount: "{count} benutzerdefinierte Rolle | {count} benutzerdefinierte Rollen",
     addButton: "+ Hinzufügen",
     createPanel: "Neue Rolle erstellen",
     fieldId: "ID",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -803,7 +803,6 @@ const enMessages = {
   pluginManageRoles: {
     heading: "Custom Roles",
     roleCount: "{count} role | {count} roles",
-    previewCount: "{count} custom role | {count} custom roles",
     addButton: "+ Add",
     createPanel: "Create new role",
     fieldId: "ID",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -787,7 +787,6 @@ const esMessages = {
   pluginManageRoles: {
     heading: "Roles personalizados",
     roleCount: "{count} rol | {count} roles",
-    previewCount: "{count} rol personalizado | {count} roles personalizados",
     addButton: "+ Añadir",
     createPanel: "Crear nuevo rol",
     fieldId: "ID",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -779,7 +779,6 @@ const frMessages = {
   pluginManageRoles: {
     heading: "Rôles personnalisés",
     roleCount: "{count} rôle | {count} rôles",
-    previewCount: "{count} rôle personnalisé | {count} rôles personnalisés",
     addButton: "+ Ajouter",
     createPanel: "Créer un nouveau rôle",
     fieldId: "ID",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -778,7 +778,6 @@ const jaMessages = {
   pluginManageRoles: {
     heading: "カスタムロール",
     roleCount: "{count} 件",
-    previewCount: "カスタムロール {count} 件",
     addButton: "+ 追加",
     createPanel: "新しいロールを作成",
     fieldId: "ID",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -778,7 +778,6 @@ const koMessages = {
   pluginManageRoles: {
     heading: "커스텀 역할",
     roleCount: "{count}개 역할",
-    previewCount: "{count}개 커스텀 역할",
     addButton: "+ 추가",
     createPanel: "새 역할 만들기",
     fieldId: "ID",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -777,7 +777,6 @@ const ptBRMessages = {
   pluginManageRoles: {
     heading: "Papéis personalizados",
     roleCount: "{count} papel | {count} papéis",
-    previewCount: "{count} papel personalizado | {count} papéis personalizados",
     addButton: "+ Adicionar",
     createPanel: "Criar novo papel",
     fieldId: "ID",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -774,7 +774,6 @@ const zhMessages = {
   pluginManageRoles: {
     heading: "自定义角色",
     roleCount: "{count} 个角色",
-    previewCount: "{count} 个自定义角色",
     addButton: "+ 添加",
     createPanel: "创建新角色",
     fieldId: "ID",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,7 +13,6 @@ import Present3DPlugin from "@gui-chat-plugin/present3d/vue";
 import WeatherPlugin from "@gui-chat-plugin/weather/vue";
 import todoPlugin from "../plugins/todo/index";
 import { manageCalendarPlugin, manageAutomationsPlugin, legacyManageSchedulerEntry } from "../plugins/scheduler/index";
-import manageRolesPlugin from "../plugins/manageRoles/index";
 import manageSkillsPlugin from "../plugins/manageSkills/index";
 import manageSourcePlugin from "../plugins/manageSource/index";
 import wikiPlugin from "../plugins/wiki/index";
@@ -31,7 +30,6 @@ const plugins: Record<string, PluginEntry> = {
   // the LLM (absent from server/agent/plugin-names.ts and
   // src/config/toolNames.ts) — strictly historical rendering.
   manageScheduler: legacyManageSchedulerEntry,
-  manageRoles: manageRolesPlugin,
   manageSkills: manageSkillsPlugin,
   manageSource: manageSourcePlugin,
   manageWiki: wikiPlugin,

--- a/test/roles/test_role_schema.ts
+++ b/test/roles/test_role_schema.ts
@@ -16,17 +16,41 @@ describe("RoleSchema", () => {
     assert.deepStrictEqual(result, valid);
   });
 
-  it("rejects a role whose availablePlugins includes an unknown tool", () => {
-    const invalid = {
+  it("silently drops unknown plugin names from availablePlugins (lenient parse — #951)", () => {
+    // Pre-#951 the schema rejected the whole role when it
+    // referenced an unknown tool. That cost exceeded the typo-
+    // catching benefit when a tool was removed in a later release
+    // (e.g. `manageRoles` itself in #951): a legitimate role file
+    // would silently disappear from `/roles` because
+    // `loadCustomRoles` swallows zod failures. The schema now
+    // filters the array instead so the role survives the load.
+    const input = {
       id: "test",
       name: "Test",
       icon: "star",
       prompt: "prompt",
-      // `presentHTML` is the historical typo of `presentHtml`; the
-      // enum-backed schema catches it at the boundary.
-      availablePlugins: ["presentHTML"],
+      availablePlugins: ["manageTodoList", "presentHTML", "generateImage"],
     };
-    assert.throws(() => RoleSchema.parse(invalid));
+    const result = RoleSchema.parse(input);
+    assert.deepStrictEqual(result.availablePlugins, ["manageTodoList", "generateImage"]);
+  });
+
+  it("recovers a legacy role file that references the removed `manageRoles` tool (#951 regression guard)", () => {
+    // Before #951 a role with `manageRoles` validated and the
+    // role loaded; after #951 the tool name is gone from
+    // TOOL_NAMES. Without lenient parsing the role would now
+    // disappear from the list. Pin that the lenient parse keeps
+    // it alive (dropping the dead reference but preserving every
+    // other plugin).
+    const legacyRole = {
+      id: "my-role",
+      name: "My Role",
+      icon: "star",
+      prompt: "prompt",
+      availablePlugins: ["manageRoles", "manageTodoList", "generateImage"],
+    };
+    const result = RoleSchema.parse(legacyRole);
+    assert.deepStrictEqual(result.availablePlugins, ["manageTodoList", "generateImage"]);
   });
 
   it("accepts a valid role without optional queries", () => {


### PR DESCRIPTION
## Summary

#949 で確定した方針 (「skill で十分カバーできるので manageRoles tool は廃止」) に従って、LLM-facing の `manageRoles` MCP tool を削除する PR。

`/roles` フロントエンド画面 は **そのまま残す** — `/api/roles/manage` エンドポイントを直接叩いてるだけで、tool surface には依存していなかった。

ユーザの体験変化:
- ✅ `/roles` UI で custom role 作成 / 編集 / 削除 → **変化なし**
- ❌ LLM が tool call で role を作る → tool が無くなる (本当に必要なら Write tool で `~/mulmoclaude/roles/<id>.json` を書ける、稀ケース)

## Items to Confirm / Review

- **`/roles` UI は機能継続**: View.vue を `src/plugins/manageRoles/View.vue` → `src/components/RolesView.vue` に移動、import path を更新するだけ
- **削除した型の inline**: 旧 `index.ts` の `CustomRole` / `ManageRolesData` interface は RolesView.vue のみが使ってたので component 上部に inline。単一目的の小さい module を残すより co-locate が clean
- **server route 維持**: `/api/roles` / `/api/roles/manage` はフロントエンドが使い続けるので変更なし、`test_rolesManage.ts` も意味あり
- **i18n**: 8 locale から `pluginManageRoles.previewCount` のみ削除 (Preview 専用)。他 `pluginManageRoles.*` キーは RolesView が使用中で維持
- **Builtin role config**: `src/config/roles.ts` の builtin 4 role の `availablePlugins` に `manageRoles` を含むものは無し → 何も壊れない

## User Prompt

> manageRoles も無くて良いと思います（ほとんどの場合、skill で十分なので）。という方向で。manageXXX を完全になくさないけど、無駄に増やさないで、なくせるものはなくしていく方向で。
> まずはマイルドに、manageRoles を削除しよう

(prior context: #949 で manage\* プラグインのアーキテクチャ整理。wiki は LLM Write 直 + chat 履歴 derive、roles/skills/source は domain ごとに最適解が違う議論。manageRoles は skill で代替可能と判断。)

## Implementation

### 削除
- `src/plugins/manageRoles/definition.ts` (tool schema)
- `src/plugins/manageRoles/index.ts` (ToolPlugin wrapper + 型)
- `src/plugins/manageRoles/Preview.vue` (chat 結果 preview)

### 移動
- `src/plugins/manageRoles/View.vue` → `src/components/RolesView.vue`
- `CustomRole` / `ManageRolesData` 型を RolesView.vue 上部に inline

### 修正
- `src/App.vue` — RolesView の import path 更新
- `src/tools/index.ts` — `manageRoles: manageRolesPlugin` 行 + import 削除
- `src/config/toolNames.ts` — `manageRoles: "manageRoles"` 削除
- `server/agent/plugin-names.ts` — `ManageRolesDef` import / `TOOL_ENDPOINTS` / `PLUGIN_DEFS` から除去
- `server/agent/mcp-server.ts` — `if (name === "manageRoles") { ... }` ブロック削除
- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — `pluginManageRoles.previewCount` 削除 (8 locale lockstep)

## テスト手順

### 自動

```bash
yarn typecheck   # clean
yarn lint        # clean (333 pre-existing warnings unchanged, 0 errors)
yarn build       # clean

# Targeted unit:
tsx --test test/composables/test_useFreshPluginData.ts \
           test/routes/test_rolesManage.ts
```

期待: 19 cases pass。`test_useFreshPluginData.ts` の "manageRoles shape" ケース は `/api/roles` のレスポンス shape を例として参照しているだけで、tool 削除に影響なし。

### 手動

1. `npm run dev`
2. `/roles` を開く → custom role 一覧表示 / Add ボタン / 既存 role の編集など、UI が **削除前と完全に同じ** 動作することを確認
3. Settings から builtin role (general 等) を選択 → 動作変化なし
4. LLM に「カスタム role を作って」とお願いする → manageRoles tool は無いので LLM は対応できない or Write tool で `~/mulmoclaude/roles/<id>.json` を直接書く (どちらでも regression なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the LLM-facing manageRoles MCP tool while keeping the /roles UI functional and wired directly to the existing roles API.

Enhancements:
- Move the roles management view to a shared RolesView component and keep it integrated with the roles REST endpoints.
- Simplify roles plugin typing by inlining CustomRole and ManageRolesData types into the RolesView component and centralizing role CRUD logic there.

Documentation:
- Add an internal plan document describing the manageRoles tool removal and its impact.

Chores:
- Clean up tool/plugin registrations and server routing related to the removed manageRoles tool, including tool names, plugin defs, and MCP server handling.
- Remove an unused previewCount i18n key for manageRoles across all supported locales.