### PR TITLE
chore(lint): clean test/e2e warnings (19 → 0)

### DIFF
--- a/e2e/tests/chat-flow.spec.ts
+++ b/e2e/tests/chat-flow.spec.ts
@@ -225,7 +225,7 @@ test.describe("sending a chat message", () => {
       (route) => {
         if (route.request().method() !== "GET") return route.fallback();
         const sessionId = route.request().url().split("/api/sessions/").pop() ?? "";
-        capturedSessionId = sessionId.split("?")[0]; // strip query
+        [capturedSessionId] = sessionId.split("?"); // strip query
         return route.fulfill({
           json: [
             {

--- a/e2e/tests/streaming-autoscroll.spec.ts
+++ b/e2e/tests/streaming-autoscroll.spec.ts
@@ -46,8 +46,14 @@ async function streamEventsToSocket(webSocket: { send: (data: string) => void },
 }
 
 function handleSocketFrame(text: string, webSocket: { send: (data: string) => void }, events: readonly unknown[]): void {
-  if (text === "2") return webSocket.send("3");
-  if (text === "40") return webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+  if (text === "2") {
+    webSocket.send("3");
+    return;
+  }
+  if (text === "40") {
+    webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+    return;
+  }
   if (!text.startsWith("42")) return;
   let parsed: unknown;
   try {

--- a/e2e/tests/todo-columns.spec.ts
+++ b/e2e/tests/todo-columns.spec.ts
@@ -33,6 +33,7 @@ async function setupTodoMocks(page: Page): Promise<void> {
           columns: state.columns.map((col) => (col.id === columnId ? { ...col, label: "Renamed" } : col)),
         };
       }
+      return undefined;
     },
   });
 }

--- a/e2e/tests/todo-items-crud.spec.ts
+++ b/e2e/tests/todo-items-crud.spec.ts
@@ -99,6 +99,7 @@ async function setupItemsCrudMocks(page: Page): Promise<void> {
       if (method === "DELETE" && idSegment) {
         return { items: state.items.filter((todoItem) => todoItem.id !== idSegment) };
       }
+      return undefined;
     },
   });
 }

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -435,7 +435,7 @@ describe("buildInlinedHelpFiles", () => {
     writeHelp("big.md", `# Big Help\n\nFirst real content paragraph explaining the feature.${bigBody}`);
     const result = buildInlinedHelpFiles("See config/helps/big.md", workspace);
     assert.equal(result.length, 1);
-    const section = result[0];
+    const [section] = result;
     assert.ok(section.includes("### config/helps/big.md"));
     assert.ok(section.includes("Big Help"));
     assert.ok(section.includes("First real content paragraph"));

--- a/test/notifications/test_scheduler.ts
+++ b/test/notifications/test_scheduler.ts
@@ -79,8 +79,9 @@ describe("scheduleTestNotification — fires once after the delay", () => {
     mock.timers.tick(1_000);
 
     assert.equal(deps.publishCalls.length, 1);
-    assert.equal(deps.publishCalls[0].channel, PUBSUB_CHANNELS.notifications);
-    const { payload } = deps.publishCalls[0];
+    const [firstPublish] = deps.publishCalls;
+    assert.equal(firstPublish.channel, PUBSUB_CHANNELS.notifications);
+    const { payload } = firstPublish;
     assert.ok(isNotificationPayload(payload));
     assert.equal(payload.title, "my-msg");
     // Legacy bridge push uses custom transport/chat
@@ -105,7 +106,7 @@ describe("scheduleTestNotification — defaults", () => {
     assert.equal(scheduled.delaySeconds, 60);
     mock.timers.tick(60_000);
     assert.equal(deps.publishCalls.length, 1);
-    const { payload } = deps.publishCalls[0];
+    const [{ payload }] = deps.publishCalls;
     assert.ok(isNotificationPayload(payload));
     assert.equal(payload.title, DEFAULT_NOTIFICATION_MESSAGE);
     assert.deepEqual(deps.pushCalls, [

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -189,7 +189,7 @@ describe("GET /api/sessions — full fetch (no ?since=)", () => {
     await getHandler({ query: {} } as unknown as Request, res);
 
     assert.equal(state.status, 200);
-    const body = state.body;
+    const { body } = state;
     assert.ok(body);
     assert.equal(body.sessions.length, 2);
     assert.deepEqual(body.deletedIds, [], "deletedIds is always [] today");

--- a/test/routes/test_todosHandlers.ts
+++ b/test/routes/test_todosHandlers.ts
@@ -482,7 +482,7 @@ describe("kanban field preservation", () => {
     const result = handleUpdate([item], { text: "old", newText: "New" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const updated = result.items[0];
+    const [updated] = result.items;
     assert.equal(updated?.text, "New");
     assert.equal(updated?.status, "in-progress");
     assert.equal(updated?.priority, "high");
@@ -503,7 +503,7 @@ describe("kanban field preservation", () => {
     const result = handleCheck([item], { text: "x" });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const updated = result.items[0];
+    const [updated] = result.items;
     assert.equal(updated?.completed, true);
     assert.equal(updated?.status, "in-progress");
     assert.equal(updated?.priority, "urgent");
@@ -524,7 +524,7 @@ describe("kanban field preservation", () => {
     const result = handleAddLabel([item], { text: "x", labels: ["urgent"] });
     assert.equal(result.kind, "success");
     if (result.kind !== "success") return;
-    const updated = result.items[0];
+    const [updated] = result.items;
     assert.deepEqual(updated?.labels, ["work", "urgent"]);
     assert.equal(updated?.status, "todo");
     assert.equal(updated?.priority, "medium");

--- a/test/routes/test_wikiHistoryRoute.ts
+++ b/test/routes/test_wikiHistoryRoute.ts
@@ -166,7 +166,7 @@ describe("GET /api/wiki/pages/:slug/history/:stamp", () => {
     await writeWikiPage(slug, "hello body\n", { editor: "user", reason: "first" });
     const snapshots = await listSnapshots(slug);
     assert.ok(snapshots.length >= 1);
-    const { stamp } = snapshots[0];
+    const [{ stamp }] = snapshots;
 
     const { state, res } = mockRes();
     await readHandler(makeReq({ slug, stamp }), res);

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -56,12 +56,14 @@ const saved: Record<string, string | undefined> = {};
 beforeEach(() => {
   for (const key of ENV_KEYS) {
     saved[key] = process.env[key];
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is from a fixed ENV_KEYS allow-list
     delete process.env[key];
   }
 });
 
 afterEach(() => {
   for (const key of ENV_KEYS) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is from a fixed ENV_KEYS allow-list
     if (saved[key] === undefined) delete process.env[key];
     else process.env[key] = saved[key];
   }

--- a/test/sources/test_pipelineWrite.ts
+++ b/test/sources/test_pipelineWrite.ts
@@ -55,7 +55,7 @@ describe("buildDailyJsonIndex", () => {
 
   it("strips `summary` / `content` — only compact metadata goes into JSON", () => {
     const idx = buildDailyJsonIndex([makeItem({ summary: "s", content: "c" })]);
-    const item = idx.items[0];
+    const [item] = idx.items;
     assert.equal("summary" in item, false);
     assert.equal("content" in item, false);
   });

--- a/test/utils/test_id.ts
+++ b/test/utils/test_id.ts
@@ -48,7 +48,7 @@ describe("makeId", () => {
 
   it("ends with 6 hex characters", () => {
     const generatedId = makeId("test");
-    const hex = generatedId.split("_")[2];
+    const [, , hex] = generatedId.split("_");
     assert.equal(hex.length, 6);
     assert.match(hex, /^[0-9a-f]{6}$/);
   });


### PR DESCRIPTION
## Summary

Cleans up the 19 lint warnings under \`test/\` and \`e2e/\` introduced
by #957's stricter rules. Production code (\`src/\`, \`server/\`,
\`packages/\`) is unchanged.

## Items to Confirm / Review

- **\`handleSocketFrame\` restructure** in
  \`e2e/tests/streaming-autoscroll.spec.ts\`: the function returns
  \`void\`, but lines like \`if (text === \"2\") return webSocket.send(\"3\");\`
  pass through whatever \`webSocket.send\` returns. The fix splits
  these into block bodies (\`{ webSocket.send(\"3\"); return; }\`).
  Behavior unchanged — \`webSocket.send\` returns \`void\` in this mock.
- **\`return undefined;\` fallthrough** added to two
  \`MutableTodoOptions\` dispatch handlers
  (\`dispatchColumn\` / \`dispatchItem\`). The signature already
  permits \`DispatchResult | undefined\` so this is a no-op for
  the mock framework.
- **\`test_env.ts\` per-line disable** for \`delete process.env[key]\`
  in env-restoration before/afterEach. Rationale: \`key\` comes
  from a fixed \`ENV_KEYS\` allow-list, not user input.
- **\`test_id.ts\` triple-skip destructure**
  \`generatedId.split(\"_\")[2]\` → \`const [, , hex] = generatedId.split(\"_\")\`.
  Equivalent semantics; verify the test still asserts the
  third segment.

## User Prompt

> マージしたら、test/e2e以下のlint warnは直して。

## What changed

### prefer-destructuring (11 sites)

- \`e2e/tests/chat-flow.spec.ts\` — array
- \`test/agent/test_agent_prompt.ts\` — array
- \`test/notifications/test_scheduler.ts\` — split into named local
- \`test/routes/test_sessionsRoute.ts\` — auto-fixed
- \`test/routes/test_todosHandlers.ts\` — 3 sites, all
  \`result.items[0]\` → \`[updated] = result.items\`
- \`test/routes/test_wikiHistoryRoute.ts\` — \`[{ stamp }] = snapshots\`
- \`test/sources/test_pipelineWrite.ts\` — \`[item] = idx.items\`
- \`test/utils/test_id.ts\` — \`[, , hex] = parts\`

### consistent-return (6 sites)

- \`e2e/tests/streaming-autoscroll.spec.ts:48-60\` — split
  \`return webSocket.send()\` into \`{ send(); return; }\` blocks
- \`e2e/tests/todo-columns.spec.ts:14\` — \`return undefined;\` fallthrough
- \`e2e/tests/todo-items-crud.spec.ts:86\` — same

### no-dynamic-delete (2 sites)

- \`test/server/test_env.ts:59,65\` — per-line disable with rationale

## Verification

- \`yarn lint\`: 0 errors, 118 warnings (down from 137; 0 under test/e2e)
- \`yarn typecheck\`: pass
- \`yarn build\`: pass
- \`yarn test\`: 3396 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)