### PR TITLE
fix(pdf): inline workspace-rooted image paths (LLM web-convention shape)

### DIFF
--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -56,7 +56,7 @@ const MIME_BY_EXT: Record<string, string> = {
 // Realpath of the workspace, resolved once at module load. Used to
 // validate that image paths resolved relative to markdowns/ stay
 // inside the workspace after symlink resolution.
-const workspaceReal = realpathSync(resolveWorkspacePath(""));
+const defaultWorkspaceRoot = realpathSync(resolveWorkspacePath(""));
 
 /**
  * Inline local images as base64 data URIs so Puppeteer can render them.
@@ -67,25 +67,33 @@ const workspaceReal = realpathSync(resolveWorkspacePath(""));
  * so an attacker-controlled <img src="../../../etc/passwd"> can't read
  * files outside the workspace.
  */
-function inlineImages(html: string): string {
-  const baseDir = path.join(workspaceReal, WORKSPACE_DIRS.markdowns);
+export function inlineImages(html: string, workspaceRoot: string = defaultWorkspaceRoot): string {
+  const baseDir = path.join(workspaceRoot, WORKSPACE_DIRS.markdowns);
   return html.replace(/(<img\s[^>]*src=")([^"]+)(")/g, (_match, before: string, src: string, after: string) => {
     if (src.startsWith("data:") || src.startsWith("http")) {
       return _match;
     }
-    // Resolve the image path relative to markdowns/ but require the
-    // final realpath to stay inside the workspace root. markdowns/
-    // references like "../images/foo.png" are common so we can't
-    // restrict to markdowns/ itself.
-    const unsafeAbs = path.resolve(baseDir, src);
+    // LLM-generated HTML often emits leading-slash workspace-rooted
+    // paths like "/artifacts/images/2026/04/foo.png" (web convention).
+    // Treat those as workspace-relative; otherwise path.resolve below
+    // sees the slash as host-absolute and the safe-resolve rejects.
+    const workspaceRooted = src.startsWith("/");
+    const resolveBase = workspaceRooted ? workspaceRoot : baseDir;
+    const relSrc = workspaceRooted ? src.slice(1) : src;
+    // Resolve the image path relative to markdowns/ (or workspace root
+    // for the leading-slash case) but require the final realpath to
+    // stay inside the workspace root. markdowns/ references like
+    // "../images/foo.png" are common so we can't restrict to markdowns/
+    // itself.
+    const unsafeAbs = path.resolve(resolveBase, relSrc);
     // Make unsafeAbs relative to the workspace for the
     // resolveWithinRoot check (it expects a relative path).
-    const relToWorkspace = path.relative(workspaceReal, unsafeAbs);
+    const relToWorkspace = path.relative(workspaceRoot, unsafeAbs);
     if (relToWorkspace.startsWith("..") || path.isAbsolute(relToWorkspace)) {
       log.warn("pdf", "image path escapes workspace", { src });
       return _match;
     }
-    const abs = resolveWithinRoot(workspaceReal, relToWorkspace);
+    const abs = resolveWithinRoot(workspaceRoot, relToWorkspace);
     if (!abs) {
       log.warn("pdf", "image path rejected by safe-resolve", { src });
       return _match;

--- a/src/plugins/presentHtml/View.vue
+++ b/src/plugins/presentHtml/View.vue
@@ -28,6 +28,7 @@ import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { PresentHtmlData } from "./index";
+import { rewriteHtmlImageRefs } from "../../utils/image/rewriteHtmlImageRefs";
 
 const { t } = useI18n();
 
@@ -42,7 +43,11 @@ const PRINT_STYLE = `<style>@media print {
 }</style>`;
 
 const data = computed(() => props.selectedResult.data);
-const rawHtml = computed(() => data.value?.html ?? "");
+// LLM-generated HTML often emits <img src="/artifacts/images/…"> using
+// the web convention where `/` is the site root. Inside the iframe
+// srcdoc that resolves to the SPA origin, which does not serve
+// /artifacts. Route those through the workspace file server.
+const rawHtml = computed(() => rewriteHtmlImageRefs(data.value?.html ?? ""));
 const html = computed(() => (rawHtml.value.includes("</head>") ? rawHtml.value.replace("</head>", `${PRINT_STYLE}</head>`) : `${PRINT_STYLE}${rawHtml.value}`));
 const title = computed(() => data.value?.title);
 

--- a/src/utils/image/rewriteHtmlImageRefs.ts
+++ b/src/utils/image/rewriteHtmlImageRefs.ts
@@ -1,0 +1,50 @@
+import { resolveImageSrc } from "./resolve";
+
+// Rewrite `<img src="…">` references in raw HTML so workspace-relative
+// paths are routed through `/api/files/raw`. Counterpart to
+// `rewriteMarkdownImageRefs` for the case where the LLM emits a full
+// HTML document (presentHtml plugin) rather than markdown.
+//
+// Why this is needed:
+//   - The LLM tends to emit `<img src="/artifacts/images/…">` using the
+//     web convention where leading `/` means "site root".
+//   - presentHtml renders the document inside an `<iframe srcdoc>`
+//     under the SPA origin, so the browser tries to fetch
+//     `http://localhost:5173/artifacts/…` — Express does not serve
+//     that path, so the request 404s and the image breaks.
+//   - Rewriting the src to `/api/files/raw?path=artifacts/…` routes
+//     it through the workspace file server.
+//
+// Skipped (returned untouched):
+//   - `data:` URIs (already inline)
+//   - `http://` / `https://` URLs (external)
+//   - Existing `/api/…` paths (already correct)
+//
+// The regex matches double-quoted `src` attributes only (the form the
+// LLM consistently emits). Single-quoted variants are intentionally
+// left alone — extend later if a real case appears.
+
+const IMG_SRC_RE = /(<img\s[^>]*src=")([^"]+)(")/g;
+
+function shouldSkip(src: string): boolean {
+  if (src.startsWith("data:")) return true;
+  if (src.startsWith("http://") || src.startsWith("https://")) return true;
+  if (src.startsWith("/api/")) return true;
+  return false;
+}
+
+// Strip the optional leading slash to convert a "web-rooted" path to a
+// workspace-relative one. `/artifacts/foo.png` → `artifacts/foo.png`,
+// `artifacts/foo.png` → `artifacts/foo.png`.
+function normalizeWorkspacePath(src: string): string {
+  return src.startsWith("/") ? src.slice(1) : src;
+}
+
+export function rewriteHtmlImageRefs(html: string): string {
+  return html.replace(IMG_SRC_RE, (match, before: string, src: string, after: string) => {
+    if (shouldSkip(src)) return match;
+    const workspacePath = normalizeWorkspacePath(src);
+    if (workspacePath.length === 0) return match;
+    return `${before}${resolveImageSrc(workspacePath)}${after}`;
+  });
+}

--- a/test/routes/test_pdfInlineImages.ts
+++ b/test/routes/test_pdfInlineImages.ts
@@ -1,0 +1,86 @@
+// Coverage for inlineImages — the PDF-side helper that turns
+// <img src="..."> references into base64 data URIs so Puppeteer can
+// render them. The hardening from #384 added a workspace-root
+// boundary check; this file pins the LLM-friendly leading-slash
+// case (e.g. "/artifacts/images/2026/04/foo.png") on top of the
+// original markdowns-relative case ("../images/foo.png").
+
+import { beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { inlineImages } from "../../server/api/routes/pdf.js";
+
+let workspaceRoot: string;
+let imagesDir: string;
+let pngPath: string;
+
+const PNG_BYTES = Buffer.from("89504E470D0A1A0A0000000D49484452", "hex"); // PNG header bytes
+
+beforeEach(() => {
+  workspaceRoot = realpathSync(mkdtempSync(path.join(tmpdir(), "pdf-inline-")));
+  imagesDir = path.join(workspaceRoot, "artifacts", "images", "2026", "04");
+  mkdirSync(imagesDir, { recursive: true });
+  // A real markdowns/ dir so "../images/..." resolves through it.
+  mkdirSync(path.join(workspaceRoot, "artifacts", "markdowns"), { recursive: true });
+  pngPath = path.join(imagesDir, "foo.png");
+  writeFileSync(pngPath, PNG_BYTES);
+});
+
+describe("inlineImages — workspace-rooted leading-slash form", () => {
+  it("inlines /artifacts/... paths (the LLM web-convention shape)", () => {
+    const html = '<img src="/artifacts/images/2026/04/foo.png">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.match(out, /^<img src="data:image\/png;base64,[A-Za-z0-9+/=]+">$/);
+  });
+
+  it("inlines paths without leading slash (markdowns-relative shape)", () => {
+    // markdowns/ references go up to artifacts/, then into images/.
+    const html = '<img src="../images/2026/04/foo.png">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.match(out, /^<img src="data:image\/png;base64,[A-Za-z0-9+/=]+">$/);
+  });
+
+  it("leaves data: URIs untouched", () => {
+    const html = '<img src="data:image/png;base64,AAAA">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.equal(out, html);
+  });
+
+  it("leaves http(s):// URLs untouched", () => {
+    const html = '<img src="https://example.com/foo.png">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.equal(out, html);
+  });
+
+  it("rejects path traversal that escapes the workspace", () => {
+    const html = '<img src="../../../../etc/passwd">';
+    const out = inlineImages(html, workspaceRoot);
+    // Original tag preserved (not inlined). Browser will 404 — better
+    // than leaking arbitrary host files into the rendered PDF.
+    assert.equal(out, html);
+  });
+
+  it("rejects /etc/passwd-style host-absolute paths once leading slash is stripped", () => {
+    // After stripping the leading slash, "etc/passwd" is treated as
+    // workspace-relative. It doesn't exist under workspaceRoot, so
+    // safe-resolve rejects it and the tag passes through unchanged.
+    const html = '<img src="/etc/passwd">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.equal(out, html);
+  });
+
+  it("preserves attributes around src", () => {
+    const html = '<img alt="cat" src="/artifacts/images/2026/04/foo.png" width="100">';
+    const out = inlineImages(html, workspaceRoot);
+    assert.match(out, /^<img alt="cat" src="data:image\/png;base64,[^"]+" width="100">$/);
+  });
+
+  it("transforms multiple <img> tags in one pass", () => {
+    const html = '<p><img src="/artifacts/images/2026/04/foo.png"><img src="../images/2026/04/foo.png"></p>';
+    const out = inlineImages(html, workspaceRoot);
+    const matches = out.match(/data:image\/png;base64,/g) ?? [];
+    assert.equal(matches.length, 2, "both tags should be rewritten");
+  });
+});

--- a/test/utils/image/test_rewriteHtmlImageRefs.ts
+++ b/test/utils/image/test_rewriteHtmlImageRefs.ts
@@ -1,0 +1,63 @@
+// Coverage for rewriteHtmlImageRefs — the helper that routes LLM-emitted
+// `<img src="/artifacts/…">` paths through `/api/files/raw` so they
+// render inside the presentHtml iframe srcdoc.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { rewriteHtmlImageRefs } from "../../../src/utils/image/rewriteHtmlImageRefs";
+
+describe("rewriteHtmlImageRefs", () => {
+  it("rewrites leading-slash workspace-rooted paths to /api/files/raw", () => {
+    const out = rewriteHtmlImageRefs('<img src="/artifacts/images/2026/04/foo.png">');
+    assert.equal(out, '<img src="/api/files/raw?path=artifacts%2Fimages%2F2026%2F04%2Ffoo.png">');
+  });
+
+  it("rewrites no-leading-slash workspace-relative paths too", () => {
+    const out = rewriteHtmlImageRefs('<img src="artifacts/images/foo.png">');
+    assert.equal(out, '<img src="/api/files/raw?path=artifacts%2Fimages%2Ffoo.png">');
+  });
+
+  it("leaves data: URIs untouched", () => {
+    const html = '<img src="data:image/png;base64,AAAA">';
+    assert.equal(rewriteHtmlImageRefs(html), html);
+  });
+
+  it("leaves http:// URLs untouched", () => {
+    const html = '<img src="http://example.com/foo.png">';
+    assert.equal(rewriteHtmlImageRefs(html), html);
+  });
+
+  it("leaves https:// URLs untouched", () => {
+    const html = '<img src="https://example.com/foo.png">';
+    assert.equal(rewriteHtmlImageRefs(html), html);
+  });
+
+  it("leaves existing /api/ paths untouched", () => {
+    const html = '<img src="/api/files/raw?path=foo.png">';
+    assert.equal(rewriteHtmlImageRefs(html), html);
+  });
+
+  it("leaves an empty src untouched", () => {
+    // Empty string after stripping the leading slash; treat as no-op.
+    const html = '<img src="/">';
+    assert.equal(rewriteHtmlImageRefs(html), html);
+  });
+
+  it("preserves attributes around src", () => {
+    const out = rewriteHtmlImageRefs('<img alt="cat" src="/artifacts/images/foo.png" width="100">');
+    assert.equal(out, '<img alt="cat" src="/api/files/raw?path=artifacts%2Fimages%2Ffoo.png" width="100">');
+  });
+
+  it("rewrites multiple <img> tags in one pass", () => {
+    const html = '<p><img src="/artifacts/images/a.png"><img src="data:image/png;base64,AAAA"><img src="/artifacts/images/b.png"></p>';
+    const out = rewriteHtmlImageRefs(html);
+    assert.match(out, /path=artifacts%2Fimages%2Fa\.png/);
+    assert.match(out, /data:image\/png;base64,AAAA/);
+    assert.match(out, /path=artifacts%2Fimages%2Fb\.png/);
+  });
+
+  it("encodes non-ASCII characters in path", () => {
+    const out = rewriteHtmlImageRefs('<img src="/artifacts/images/日本語.png">');
+    assert.match(out, /path=artifacts%2Fimages%2F[^"]+\.png/);
+  });
+});


### PR DESCRIPTION
## Summary

Hotfix for image-bearing markdown / HTML failing to PDF. Symptom: server log shows `[pdf] WARN image path escapes workspace src=/artifacts/images/2026/04/foo.png` and the rendered PDF has a broken `<img>` tag.

**Reproduces in v0.5.1** — confirmed by checking out the tag and re-reading the buggy `inlineImages` function. Recommend cutting v0.5.2 right after this lands.

## Root cause

LLMs emit `<img src="/artifacts/images/...">` with the web convention where leading `/` means "site root". The PDF inliner's `path.resolve(baseDir, src)` sees that as host-absolute (POSIX semantics: an absolute second arg discards the first), so the result is the literal `/artifacts/...` on the actual filesystem. The workspace-boundary check from #384 then correctly rejects that as escaping the workspace and bails out without inlining.

The hardening was right; the input handling needed to recognize the leading-slash workspace-rooted form.

## Fix

`server/api/routes/pdf.ts:inlineImages`:
- Detect leading `/` in `src`.
- If present, strip it and resolve against `workspaceRoot` instead of `baseDir` (`markdowns/`).
- Path-traversal rejection still holds: `/etc/passwd` strips to `etc/passwd`, lands outside the workspace, safe-resolve refuses.
- Existing markdowns-relative shape (`../images/foo.png`) keeps working untouched.

Also exported `inlineImages` and parameterised the workspace root so the new test can drive it against a tmpdir.

## Items to Confirm / Review

- Tests cover: leading-slash inline, markdowns-relative inline, data: URI passthrough, http(s): passthrough, traversal rejection, host-absolute (`/etc/passwd`) rejection, attribute preservation around `src`, multi-tag pass.
- Behavior is purely additive — every existing valid path keeps inlining, only the previously-broken leading-slash case starts working.

## User prompt

> MulmoClaudeで、画像付きのHTMLを生成させると、サーバー側でこんなエラーが出て、表示できません。少し前のPDFがダウンロードできない問題と同じかな？
> [server] 2026-04-28T23:48:13.713Z WARN  [pdf] image path escapes workspace src=/artifacts/images/2026/04/235fc0cf25a249a9.png
> 画像付きのMarkdownのPDF化も同じ理由で失敗
> 0.5.1でも再現するらしいので、そこのhot fixで0.5.2を出したほうが良いね

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` 0 errors (warnings unrelated)
- [x] `npx tsx --test test/routes/test_pdfInlineImages.ts` — 8/8 pass
- [ ] CI green
- [ ] Manual: generate a markdown / HTML with an image via the agent, click PDF download, verify the rendered PDF shows the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)