### PR TITLE
release: v0.5.2 (hotfix — image rendering in HTML / PDF)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [0.5.2] - 2026-04-29
+
+### Fixed
+
+- **Image rendering in HTML / PDF** — LLM-generated content emitting `<img src="/artifacts/images/…">` (web-rooted convention) now renders correctly. The path-traversal hardening from #384 was correct but didn't recognise the leading-slash form, so:
+  - PDF generation logged `image path escapes workspace` and produced a broken `<img>`.
+  - presentHtml plugin's iframe srcdoc 404'd the image because `/artifacts/` isn't served at the SPA origin.
+  Both paths now treat leading-slash as workspace-rooted while keeping the workspace boundary check intact (e.g. `/etc/passwd` is still rejected). (#961)
+
+---
+
 ## [0.5.1] - 2026-04-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump `mulmoclaude` to **0.5.2** + record the hotfix in `docs/CHANGELOG.md`.

The two fix commits already landed on main via #961:
- `ce2c5289` fix(pdf): inline workspace-rooted image paths
- `b11c3256` fix(presentHtml): rewrite workspace-rooted \<img\> paths for iframe rendering

This PR only carries the version bump + CHANGELOG entry so main reflects the published release.

## Items to Confirm / Review

- 0.5.2 already published to npm (`npm view mulmoclaude version` → `0.5.2`).
- Tag `v0.5.2` and GitHub release [v0.5.2](https://github.com/receptron/mulmoclaude/releases/tag/v0.5.2) created off the `release/v0.5.2` branch (cherry-picks of the fix commits + this bump).
- This PR keeps `main` consistent with what's on npm.

## User Prompt

> 0.5.1のタグから派生してhot fixをつくってほしい / 0.5.2が優先

## Summary by Sourcery

Release version 0.5.2 and align repository metadata and changelog with the published hotfix for image rendering in HTML/PDF outputs.

Bug Fixes:
- Document the hotfix that correctly handles workspace-rooted image paths for HTML and PDF rendering in the changelog.

Build:
- Bump monorepo and mulmoclaude package versions from 0.5.1 to 0.5.2.

Documentation:
- Add changelog entry for v0.5.2 describing the image rendering fix for HTML and PDF outputs.