### PR TITLE
chore(lint): zero-side-effect server/ + bridges/ warning fixes

### DIFF
--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -50,6 +50,7 @@ const granularity = (() => {
   } catch (err) {
     console.error(`[slack] ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
+    return undefined as never;
   }
 })();
 
@@ -59,6 +60,7 @@ const ackEmoji = (() => {
   } catch (err) {
     console.error(`[slack] ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
+    return undefined as never;
   }
 })();
 

--- a/packages/bridges/zulip/src/index.ts
+++ b/packages/bridges/zulip/src/index.ts
@@ -142,9 +142,7 @@ async function pollLoop(): Promise<void> {
     } catch (err) {
       console.error(`[zulip] poll error: ${err}`);
       try {
-        const reg = await registerQueue();
-        queue_id = reg.queue_id;
-        last_event_id = reg.last_event_id;
+        ({ queue_id, last_event_id } = await registerQueue());
       } catch (regErr) {
         console.error(`[zulip] re-register failed: ${regErr}`);
         await new Promise((resolveDelay) => setTimeout(resolveDelay, 5000));

--- a/server/index.ts
+++ b/server/index.ts
@@ -110,7 +110,10 @@ app.use(requireSameOrigin);
 // tags in rendered markdown can't attach Authorization headers.
 // The CSRF origin check + loopback-only binding still apply.
 app.use("/api", (req, res, next) => {
-  if (req.path.startsWith("/files/")) return next();
+  if (req.path.startsWith("/files/")) {
+    next();
+    return;
+  }
   bearerAuth(req, res, next);
 });
 

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -133,7 +133,7 @@ export async function runDailyPass(state: JournalState, deps: DailyPassDeps): Pr
       result.topicsUpdated.push(...dayResult.topicsUpdated);
       result.sessionsIngested.push(...dayResult.sessionsIngested);
     }
-    nextState = dayResult.nextState;
+    ({ nextState } = dayResult);
   }
 
   await maybeExtractMemory(plan.perSessionExcerpts, plan.workspaceRoot, deps);

--- a/server/workspace/journal/latestDaily.ts
+++ b/server/workspace/journal/latestDaily.ts
@@ -39,10 +39,10 @@ export async function findLatestDaily(workspaceRoot: string): Promise<LatestDail
     for (const month of months) {
       const days = await listSorted(path.join(dailyRoot, year, month), DAY_FILE_RE);
       if (days.length === 0) continue;
-      const dayFile = days[0];
+      const [dayFile] = days;
       const dayMatch = DAY_FILE_RE.exec(dayFile);
       if (!dayMatch) continue;
-      const day = dayMatch[1];
+      const [, day] = dayMatch;
       const relPath = path.posix.join("conversations", "summaries", DAILY_DIR, year, month, dayFile);
       return { path: relPath, isoDate: `${year}-${month}-${day}` };
     }

--- a/server/workspace/skills/parser.ts
+++ b/server/workspace/skills/parser.ts
@@ -55,8 +55,8 @@ function parseScheduleValue(raw: string): SkillSchedule["parsed"] {
   // interval Ns / Nm / Nh — must be >= MIN_INTERVAL_MS
   const intervalMatch = trimmed.match(/^interval\s+(\d+)([smh])$/);
   if (intervalMatch) {
-    const value = Number(intervalMatch[1]);
-    const unit = intervalMatch[2];
+    const [, valueRaw, unit] = intervalMatch;
+    const value = Number(valueRaw);
     const unitMs = TIME_UNIT_MS[unit];
     if (!unitMs) return null;
     const intervalMs = value * unitMs;

--- a/server/workspace/sources/pipeline/notify.ts
+++ b/server/workspace/sources/pipeline/notify.ts
@@ -36,7 +36,7 @@ function formatSingleBody(item: SourceItem): string {
 
 function publishBatchNotification(scored: readonly ScoredItem[]): void {
   if (scored.length === 1) {
-    const { item } = scored[0];
+    const [{ item }] = scored;
     publishNotification({
       kind: NOTIFICATION_KINDS.push,
       title: item.title,


### PR DESCRIPTION
## Summary

Same approach as #959 (src/) extended to server/ and packages/bridges/. Closes 10 \`prefer-destructuring\` / \`consistent-return\` warnings without behavior change.

- **prefer-destructuring (7)** — array/object destructuring replaces direct \`obj.foo\` / \`arr[0]\` reads. Same JS semantics.
- **consistent-return (3)** — explicit \`return undefined\` after \`process.exit(1)\` (typed \`never\` but ESLint can't see that), and split \`app.use\` early-return into a statement + explicit return.

## Items to Confirm / Review

- **\`return undefined as never\` after \`process.exit(1)\`** in slack bridge IIFEs: never executes, satisfies the lint without changing runtime. The cleaner \`throw err\` alternative would change the printed error format, so I kept the existing \`console.error → process.exit(1)\` flow intact.
- **server/index.ts middleware split**: \`if (req.path.startsWith("/files/")) return next();\` → \`{ next(); return; }\`. \`next()\` returns void in either case; semantically identical.
- **Out of scope (intentionally)**: no-non-null-assertion (37), no-dynamic-delete (32), complexity (14), vue/no-v-html (6), class-methods-use-this (2), max-params (1). Those need behavior review.

## User Prompt

> mainでさらに影響なく直せるlintは直して。

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — 103 → 93 warnings (10 closed)
- [x] \`yarn build\` — clean
- [x] \`yarn test\` — 3396 / 3396 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code quality improvements across multiple modules, including simplified control flow patterns and enhanced code readability.

---

**Note:** This release contains no user-facing changes. All updates are internal improvements to system stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->