### PR TITLE
fix(mulmoclaude): bundle sandbox build context (0.5.3 hotfix)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [0.5.3] - 2026-04-29
+
+### Fixed
+
+- **Sandbox mode silently disabled in published npm package** — `Dockerfile.sandbox` and `sandbox-entrypoint.sh` were not bundled into the `mulmoclaude` tarball, so on `npx mulmoclaude` the server logged `Failed to set up sandbox, running unrestricted` and fell back to unrestricted execution. Both files are now copied by `prepare-dist.js` and listed in `files`, and `scripts/mulmoclaude/tarball.mjs` asserts their presence in the packed tarball to prevent regressions.
+- **`mulmoclaude --version` printed stale `0.5.1`** — the launcher had a hard-coded version string that drifted from `package.json` after 0.5.2. Now matches the published version.
+
+---
+
 ## [0.5.2] - 2026-04-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/.gitignore
+++ b/packages/mulmoclaude/.gitignore
@@ -3,6 +3,8 @@
 client/
 server/
 src/
+Dockerfile.sandbox
+sandbox-entrypoint.sh
 node_modules/
 
 # npm pack output + accidental tarball expansions during local tests.

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -108,7 +108,7 @@ Options:
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.5.1");
+  console.log("mulmoclaude 0.5.3");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/bin/prepare-dist.js
+++ b/packages/mulmoclaude/bin/prepare-dist.js
@@ -31,7 +31,7 @@
 // ── Publish ───────────────────────────────────────────────────
 //   cd packages/mulmoclaude && npm publish --access public
 
-import { cpSync, existsSync, rmSync } from "fs";
+import { copyFileSync, cpSync, existsSync, rmSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -42,10 +42,15 @@ const rootDir = join(pkgDir, "..", "..");
 // ── Clean ───────────────────────────────────────────────────
 
 // Include `dist` so leftovers from the older pre-built-JS layout are
-// wiped on re-run.
+// wiped on re-run. Stale sandbox files are removed too so a renamed
+// or deleted source file doesn't ride along into the tarball.
 for (const dir of ["dist", "client", "server", "src"]) {
   const target = join(pkgDir, dir);
   if (existsSync(target)) rmSync(target, { recursive: true });
+}
+for (const file of ["Dockerfile.sandbox", "sandbox-entrypoint.sh"]) {
+  const target = join(pkgDir, file);
+  if (existsSync(target)) rmSync(target);
 }
 
 // ── Client dist (Vite build output) ─────────────────────────
@@ -88,6 +93,17 @@ cpSync(join(rootDir, "src"), join(pkgDir, "src"), {
   filter: (src) => !src.endsWith(".map"),
 });
 console.log("✓ shared src/");
+
+// ── Sandbox build context ───────────────────────────────────
+// `server/system/docker.ts` builds the sandbox image via `docker build
+// -f Dockerfile.sandbox .` with cwd = pkgDir. The Dockerfile in turn
+// `COPY`s `sandbox-entrypoint.sh`, so both files must sit at pkgDir
+// or sandbox mode silently falls back to unrestricted execution.
+
+for (const file of ["Dockerfile.sandbox", "sandbox-entrypoint.sh"]) {
+  copyFileSync(join(rootDir, file), join(pkgDir, file));
+}
+console.log("✓ sandbox build context");
 
 console.log("\nReady to publish. Run:");
 console.log("  cd packages/mulmoclaude && npm publish --access public");

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
@@ -15,7 +15,9 @@
     "bin/",
     "client/",
     "server/",
-    "src/"
+    "src/",
+    "Dockerfile.sandbox",
+    "sandbox-entrypoint.sh"
   ],
   "dependencies": {
     "@google/genai": "^1.50.1",

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -13,11 +13,19 @@
 // "install the whole launcher and boot it" costs more than it saves.
 
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile, readdir, appendFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile, readdir, appendFile, stat } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+
+// Sandbox build context: `server/system/docker.ts` runs `docker build
+// -f Dockerfile.sandbox .` from the launcher's package dir, so both
+// the Dockerfile and the entrypoint script it COPYs must be inside
+// the published tarball. 0.5.2 silently shipped without them and
+// sandbox mode fell back to unrestricted execution at runtime — this
+// list is what the smoke verifies post-install.
+const REQUIRED_SANDBOX_FILES = ["Dockerfile.sandbox", "sandbox-entrypoint.sh"];
 
 const DEFAULT_BOOT_TIMEOUT_MS = 45_000;
 const DEFAULT_POLL_INTERVAL_MS = 500;
@@ -167,6 +175,24 @@ async function packTarball({ root, packTimeoutMs }) {
   return path.join(pkgDir, tarball);
 }
 
+// Verify the sandbox build context made it through `npm pack` / `npm
+// install`. Keeps the assertion out of `bootAndProbe` so a missing
+// file fails loudly with a precise reason instead of silently letting
+// sandbox mode degrade.
+export async function verifySandboxFiles({ workDir, files = REQUIRED_SANDBOX_FILES, statImpl = stat } = {}) {
+  const installedPkgDir = path.join(workDir, "node_modules", "mulmoclaude");
+  const missing = [];
+  for (const file of files) {
+    try {
+      const info = await statImpl(path.join(installedPkgDir, file));
+      if (!info.isFile()) missing.push(file);
+    } catch {
+      missing.push(file);
+    }
+  }
+  return { ok: missing.length === 0, missing, checkedDir: installedPkgDir };
+}
+
 // Lay out a throwaway install dir and `npm install` the tarball.
 async function installTarball({ workDir, tarballAbsolutePath, installTimeoutMs }) {
   const pkg = buildInstallerPackageJson({ tarballName: path.basename(tarballAbsolutePath) });
@@ -264,6 +290,10 @@ export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, 
   try {
     tarballPath = await packTarball({ root, packTimeoutMs });
     await installTarball({ workDir: runDir, tarballAbsolutePath: tarballPath, installTimeoutMs });
+    const sandboxCheck = await verifySandboxFiles({ workDir: runDir });
+    if (!sandboxCheck.ok) {
+      throw new Error(`sandbox build context missing from tarball: ${sandboxCheck.missing.join(", ")} (under ${sandboxCheck.checkedDir})`);
+    }
     const resolvedPort = port ?? (await allocateRandomPort());
     const booted = await bootAndProbe({ workDir: runDir, port: resolvedPort, bootTimeoutMs, logFile: resolvedLog });
     child = booted.child;


### PR DESCRIPTION
## Summary

- Bundle `Dockerfile.sandbox` + `sandbox-entrypoint.sh` into the published `mulmoclaude` tarball so sandbox mode actually engages on `npx mulmoclaude`.
- Add a post-install assertion to the tarball smoke (CI on every PR) so this regression can't ship again.
- Align the launcher's hard-coded `--version` string with `package.json` and bump to **0.5.3**.

## Items to Confirm / Review

- The two files are referenced via `process.cwd()` in `server/system/docker.ts:60,66` and via `COPY` in `Dockerfile.sandbox:94`. The launcher (`bin/mulmoclaude.js:199`) sets `cwd: PKG_DIR`, so placing both at the package root is sufficient.
- `prepare-dist.js` now removes stale copies on re-run so a renamed/deleted source file doesn't ride along into the tarball.
- `packages/mulmoclaude/.gitignore` excludes the build-artifact copies so `git status` stays clean after `prepare-dist.js`.
- `scripts/mulmoclaude/tarball.mjs` exports `verifySandboxFiles` for unit testing if we want it later; the orchestration already runs in CI via `smoke.mjs`.
- Local smoke verified: ` ✓ deps   ✓ drift   ✓ tarball  HTTP 200 on port 49686 (3521ms)`. Tarball inspection shows `package/Dockerfile.sandbox` + `package/sandbox-entrypoint.sh` are present.

## Symptom (from the user's npx session)

\`\`\`
2026-04-29T01:45:09.723Z INFO  [sandbox] Docker available — building sandbox image if needed
2026-04-29T01:45:09.723Z ERROR [sandbox] Failed to set up sandbox, running unrestricted
  error="Error: ENOENT: no such file or directory,
  open '/Users/.../node_modules/mulmoclaude/Dockerfile.sandbox'"
\`\`\`

## User Prompt

> dockerファイルが同梱されないので、dockermodeが無効。これもhotfixする。他に同梱すべきファイルがないかしらべる