### PR TITLE
feat(chat-service): //{skill} [args...] bridge shortcut for reset+run

### DIFF
--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -13,6 +13,11 @@ import type { ChatStateStore, TransportChatState } from "./chat-state.js";
 export interface CommandResult {
   reply: string;
   nextState?: TransportChatState;
+  /** When set, the relay must NOT short-circuit with `reply`. It
+   *  adopts `nextState` as the active chat state and forwards
+   *  `forwardAs` to the agent as the user message. Used by the
+   *  `//{skill}` shortcut: reset + run skill in one bridge turn. */
+  forwardAs?: string;
 }
 
 export type CommandHandler = (text: string, transportId: string, chatState: TransportChatState) => Promise<CommandResult | null>;
@@ -109,6 +114,7 @@ export function createCommandHandler(opts: {
     ];
     if (skills.length > 0) {
       lines.push("", "Skills:", ...skills.map((s) => `  /${s.name} — ${s.description}`));
+      lines.push("", "Tip: //<skill> [args...] starts a fresh session and runs the skill in one shot.");
     }
     lines.push("", "Send any other text to chat with the assistant.");
     return lines.join("\n");
@@ -270,6 +276,27 @@ export function createCommandHandler(opts: {
 
   const handleCommand: CommandHandler = async (text, transportId, chatState) => {
     if (!text.startsWith("/")) return null;
+
+    // `//{skill} [args...]` shortcut — start a new session AND run
+    // the skill in one bridge turn. Args after the skill name are
+    // forwarded verbatim, so `//mag2 https://x.com/post` resets and
+    // runs `/mag2 https://x.com/post`.
+    if (text.startsWith("//")) {
+      const skills = await fetchSkills();
+      const [head, ...rest] = text.split(/\s+/);
+      const skillName = head.slice(2);
+      if (skillName && skills.some((s) => s.name === skillName)) {
+        const nextState = await resetChatState(transportId, chatState.externalChatId, chatState.roleId);
+        const forwardAs = rest.length > 0 ? `/${skillName} ${rest.join(" ")}` : `/${skillName}`;
+        return {
+          reply: `Session reset. Running ${forwardAs}`,
+          nextState,
+          forwardAs,
+        };
+      }
+      return { reply: `Unknown command: ${text}\n\n${buildHelpText(skills)}` };
+    }
+
     const [command, ...args] = text.split(/\s+/);
 
     switch (command) {

--- a/packages/chat-service/src/relay.ts
+++ b/packages/chat-service/src/relay.ts
@@ -55,7 +55,8 @@ export function createRelay(deps: RelayDeps): RelayFn {
   const { store, handleCommand, startChat, onSessionEvent, getRole, defaultRoleId, logger } = deps;
 
   return async function relayMessage(params: RelayParams): Promise<RelayResult> {
-    const { transportId, externalChatId, text, attachments, bridgeOptions } = params;
+    const { transportId, externalChatId, attachments, bridgeOptions } = params;
+    let { text } = params;
 
     // Log attachment summary (count + mimeTypes) — NEVER log raw
     // base64 data (performance, log size, information leak risk).
@@ -85,7 +86,14 @@ export function createRelay(deps: RelayDeps): RelayFn {
 
     const commandResult = await handleCommand(text, transportId, chatState);
     if (commandResult) {
-      return { kind: "ok", reply: commandResult.reply };
+      // `forwardAs` means "reset/mutate state AND continue into the
+      // agent with rewritten text" (see //{skill} shortcut). Without
+      // it, short-circuit with the canned reply.
+      if (!commandResult.forwardAs) {
+        return { kind: "ok", reply: commandResult.reply };
+      }
+      if (commandResult.nextState) chatState = commandResult.nextState;
+      text = commandResult.forwardAs;
     }
 
     const result = await startChat({

--- a/packages/chat-service/test/test_commands.ts
+++ b/packages/chat-service/test/test_commands.ts
@@ -253,6 +253,102 @@ describe("unknown slash command", () => {
   });
 });
 
+describe("//{skill} shortcut", () => {
+  it("returns forwardAs and resets state when the skill is registered", async () => {
+    const resetCalls: Array<{ transportId: string; chatId: string; roleId: string }> = [];
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: (id) => roles.find((r) => r.id === id) ?? roles[0],
+      resetChatState: async (transportId, chatId, roleId) => {
+        resetCalls.push({ transportId, chatId, roleId });
+        return makeState({ roleId, sessionId: "sess-new" });
+      },
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [{ name: "shiritori", description: "Play shiritori" }],
+    });
+    const result = await handler("//shiritori", "telegram", makeState({ roleId: "office" }));
+    assert.ok(result);
+    assert.equal(result.forwardAs, "/shiritori");
+    assert.ok(result.nextState);
+    assert.equal(result.nextState?.sessionId, "sess-new");
+    assert.equal(resetCalls.length, 1);
+    assert.equal(resetCalls[0].roleId, "office");
+  });
+
+  it("rejects // with a skill that is not registered", async () => {
+    let resetCalled = false;
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => {
+        resetCalled = true;
+        return makeState({ roleId });
+      },
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [{ name: "shiritori", description: "Play shiritori" }],
+    });
+    const result = await handler("//notaskill", "telegram", makeState());
+    assert.ok(result);
+    assert.equal(result.forwardAs, undefined);
+    assert.ok(result.reply.includes("Unknown command: //notaskill"));
+    assert.equal(resetCalled, false);
+  });
+
+  it("rejects bare // (empty skill name never matches)", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [{ name: "", description: "wat" }],
+    });
+    const result = await handler("//", "telegram", makeState());
+    assert.ok(result);
+    assert.equal(result.forwardAs, undefined);
+    assert.ok(result.reply.includes("Unknown command: //"));
+  });
+
+  it("forwards args after the skill name verbatim", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId, sessionId: "sess-new" }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [{ name: "mag2", description: "Write a newsletter from a URL" }],
+    });
+    const result = await handler("//mag2 https://example.com/post", "telegram", makeState());
+    assert.ok(result);
+    assert.equal(result.forwardAs, "/mag2 https://example.com/post");
+    assert.equal(result.nextState?.sessionId, "sess-new");
+  });
+
+  it("forwards multi-token args after the skill name", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [{ name: "mag2", description: "Write a newsletter" }],
+    });
+    const result = await handler("//mag2 https://x.com/u/1 in Japanese", "telegram", makeState());
+    assert.ok(result);
+    assert.equal(result.forwardAs, "/mag2 https://x.com/u/1 in Japanese");
+  });
+
+  it("rejects // when no skill list is wired", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+    });
+    const result = await handler("//shiritori", "telegram", makeState());
+    assert.ok(result);
+    assert.equal(result.forwardAs, undefined);
+    assert.ok(result.reply.includes("Unknown command: //shiritori"));
+  });
+});
+
 describe("/help command", () => {
   it("omits the Skills section when no skill list is wired", async () => {
     const handler = createCommandHandler({
@@ -296,5 +392,19 @@ describe("/help command", () => {
     assert.ok(result.reply.includes("Skills:"));
     assert.ok(result.reply.includes("/shiritori — Play shiritori"));
     assert.ok(result.reply.includes("/haiku — Compose a haiku"));
+    assert.ok(result.reply.includes("//<skill>"));
+  });
+
+  it("omits the //<skill> tip when no skills are registered", async () => {
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: () => roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async () => makeState(),
+      listRegisteredSkills: async () => [],
+    });
+    const result = await handler("/help", "telegram", makeState());
+    assert.ok(result);
+    assert.ok(!result.reply.includes("//<skill>"));
   });
 });

--- a/plans/feat-bridge-skill-shortcut.md
+++ b/plans/feat-bridge-skill-shortcut.md
@@ -1,0 +1,138 @@
+# `//{skill}` — bridge shortcut for "reset + start skill"
+
+## Why
+
+Bridge users (Telegram, etc.) often want to **start a fresh chat with a
+specific skill** from a remote device. Today that requires two messages:
+
+```
+/reset
+/shiritori
+```
+
+On a phone keyboard that's two send actions and a wait between them. We
+want a single-message shortcut: `//shiritori` → "new session, run skill."
+
+The naming follows familiar precedent: `//` is "do twice / forcefully
+fresh," analogous to how some shells use `!!` or how Slack treats `//`
+as a stronger variant of `/`.
+
+## Scope
+
+**In scope.** Bridge slash-command handler (`packages/chat-service`)
+only. Web UI is unaffected — it has no equivalent slash flow; users
+there hit the **+** button to start a new chat.
+
+**Out of scope.** Role switching shortcut (e.g. `//role:office /skill`)
+or any UI changes.
+
+## Design
+
+### New behaviour
+
+`//{skill_id} [args...]`:
+
+1. Split on whitespace. The first token (after stripping the leading
+   `//`) is the skill name; the rest are args forwarded verbatim.
+2. Validate `{skill_id}` against the registered skill list (same
+   allowlist that today gates plain `/{skill}` forwarding).
+3. If it doesn't match a registered skill → reply with the standard
+   "Unknown command" + help footer (no reset, no forward).
+4. If it matches → call `resetChatState(transportId, externalChatId,
+   currentRoleId)` (preserve the role, mirror plain `/reset`).
+5. Forward `/{skill_id} {args}` to the agent on the **new** session.
+   Real example: `//mag2 https://x.com/u/1` resets and forwards
+   `/mag2 https://x.com/u/1`.
+
+### Wire-level change
+
+`CommandResult` gains one optional field:
+
+```ts
+export interface CommandResult {
+  reply: string;
+  nextState?: TransportChatState;
+  /** When set, instead of short-circuiting with `reply`, the relay
+   *  must continue into `startChat` using `forwardAs` as the message
+   *  text and `nextState` as the active chat state. Used by the
+   *  `//{skill}` shortcut: reset + forward in one turn. */
+  forwardAs?: string;
+}
+```
+
+### Relay change
+
+In `packages/chat-service/src/relay.ts`, the post-command branch
+becomes:
+
+```ts
+const commandResult = await handleCommand(text, transportId, chatState);
+if (commandResult) {
+  if (!commandResult.forwardAs) {
+    return { kind: "ok", reply: commandResult.reply };
+  }
+  // forwardAs path: adopt the new state and continue into startChat
+  // with the rewritten text below.
+  if (commandResult.nextState) chatState = commandResult.nextState;
+  text = commandResult.forwardAs;
+}
+```
+
+We let it fall through into the existing `startChat(...)` block. No
+duplicate code path.
+
+### Help text
+
+Add one line under the Skills section of `buildHelpText()`:
+
+```
+Tip: //<skill> starts a fresh session and runs the skill in one shot.
+```
+
+(Only when at least one skill is registered — keeps the help concise
+for hosts that don't expose any.)
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `packages/chat-service/src/commands.ts` | Add `forwardAs?` field; add `//` prefix branch in `handleCommand`; update help text |
+| `packages/chat-service/src/relay.ts` | Honour `forwardAs` — adopt `nextState`, rewrite `text`, fall through |
+| `packages/chat-service/test/test_commands.ts` | New `describe("//{skill} shortcut")` block |
+| `server/workspace/helps/telegram.md` | Mention `//<skill>` next to `/reset` |
+
+No host-app changes needed — the chat-service factory already exposes
+`resetChatState` and `listRegisteredSkills` as DI hooks.
+
+## Tests
+
+Unit tests in `test_commands.ts`:
+
+1. `//shiritori` with skill registered → returns `{ reply, nextState,
+   forwardAs: "/shiritori" }`; `resetChatState` was called once with
+   the existing `roleId`.
+2. `//notaskill` with skills registered → returns standard
+   "Unknown command" reply; `resetChatState` was NOT called.
+3. `//` (bare) → "Unknown command" (empty skill name never matches).
+4. `//mag2 https://example.com/post` → `forwardAs` =
+   `/mag2 https://example.com/post`; `resetChatState` was called.
+5. `//mag2 a b c` (multi-token args) → `forwardAs` = `/mag2 a b c`.
+6. `//shiritori` when no skill list is wired → "Unknown command"
+   (same fallback as plain `/{skill}` with no list).
+
+## Risks / tradeoffs
+
+- **Discoverability.** `//` is non-obvious. The `/help` line + a
+  mention in `helps/telegram.md` is the entire surface area for
+  teaching it; we accept that early-adopters learn from the docs.
+- **Surface area.** One new optional field on `CommandResult` and one
+  fall-through branch in `relay.ts`. No new modules, no new types
+  beyond the field.
+- **Compatibility.** Plain `/reset` and `/{skill}` keep working
+  identically. The only new path is double-slash.
+
+## Rollout
+
+Single PR. No flag — the feature is purely additive behind a syntax
+that today returns "Unknown command", so existing users see no
+regression.

--- a/server/workspace/helps/telegram.md
+++ b/server/workspace/helps/telegram.md
@@ -108,6 +108,7 @@ These are typed directly into the Telegram chat. They mirror the CLI:
 - `/roles` — list available roles.
 - `/role <id>` — switch to a specific role (e.g. `/role office`).
 - `/status` — show the current session info (session ID, current role).
+- `//<skill> [args...]` — shortcut for `/reset` followed by `/<skill> [args...]`: start a fresh session and run the skill (with any args) in one tap (e.g. `//mag2 https://example.com/post`).
 
 Any other text is treated as a message to the assistant.
 


### PR DESCRIPTION
## Summary

- One-message bridge shortcut: `//mag2 https://example.com/post` resets the chat session and forwards `/mag2 https://example.com/post` to the agent in one tap — replaces the two-message flow of `/reset` then `/mag2 …`.
- Args after the skill name pass through verbatim (URLs, multi-token payloads, etc.). Unknown skill names hit the existing "Unknown command" reply with **no** reset side effect.
- Implementation: extend `CommandResult` with an optional `forwardAs`; the relay falls through into the existing `startChat` path when set, so there's no duplicate code path. Plan in `plans/feat-bridge-skill-shortcut.md`.

## Test plan

- [x] New unit tests in `packages/chat-service/test/test_commands.ts` covering: registered skill (resets + forwards), unknown skill (no reset), bare `//`, no skill list wired, single-arg passthrough, multi-token-arg passthrough, `/help` tip presence.
- [x] `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn test` (64/64 chat-service), `yarn build` — all green.
- [x] Manually exercised end-to-end via the Telegram bridge against a workspace skill (`//mag2 <URL>`): fresh session created, skill ran with the URL arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `//{skill} [args...]` shortcut command to reset the current session and invoke a registered skill in a single turn.
  * Unknown or unregistered skill names return an "Unknown command" error with updated help documentation.

* **Documentation**
  * Updated help text and command reference to document the new double-slash shortcut syntax and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->