### PR TITLE
docs: image-path routing — current audit + design discussion + plan

### DIFF
--- a/docs/discussion-image-path-routing.md
+++ b/docs/discussion-image-path-routing.md
@@ -1,0 +1,305 @@
+# 画像パスのルーティング再設計
+
+issue/PR は別途。本ドキュメントは設計合意の記録 + 段階的実装計画。
+
+## 1. 現状(2026-04-29 時点)
+
+詳細は `docs/image-path-routing.md`(英語、404行)を参照。要点だけ抜粋:
+
+### 1.1 現在のフロー
+
+LLM が markdown / HTML を生成 → ファイル保存 → Vue でレンダリング → rewriter が `<img>` の `src` を `/api/files/raw?path=<workspace-relative>` に書き換え → サーバが `resolveWithinRoot()` でガードしつつファイル提供。
+
+### 1.2 rewriter は2系統
+
+| 用途 | 関数 | 場所 |
+|---|---|---|
+| wiki / markdown / Files | `rewriteMarkdownImageRefs` | `src/utils/image/rewriteMarkdownImageRefs.ts` (marked lexer ベース) |
+| presentHtml | `rewriteHtmlImageRefs` | `src/utils/image/rewriteHtmlImageRefs.ts` (`<img src="…">` 正規表現) |
+
+両方とも `resolveImageSrc()` (`src/utils/image/resolve.ts:6`) を共有、最終出力は `/api/files/raw?path=<encoded>`。
+
+### 1.3 画像保存パスは1箇所
+
+`server/utils/files/image-store.ts:33-40` の `saveImage()` がすべての生成画像(Gemini / canvas / edit)を:
+
+```
+artifacts/images/YYYY/MM/<shortId>.png
+```
+
+に保存。`WORKSPACE_DIRS.images = "artifacts/images"` (#764で YYYY/MM shard 化)。`isImagePath()` も `artifacts/images/` で始まることを必須にしている。
+
+### 1.4 既知の問題(audit §8)
+
+- HTML rewriter は **double-quoted `<img src="…">` のみ** 対応(`<source>` / `<video>` / `<a href>` / CSS `url()` 未対応)
+- markdown 内の **生`<img>` HTML タグ** は marked が `html` token としてスキップ → どちらの rewriter にもかからない
+- `textResponse/View.vue` は rewriter を全く通さない
+- PDF inliner と presentHtml で path 解決ロジックが重複(直近の #961 で leading-`/` バグの hot fix を両方に当てた)
+- `/api/files/*` は bearer-auth 免除(`<img>` がトークン送れないため)
+
+### 1.5 Docker は agent 側だけ
+
+Express サーバはホスト側で動作。`~/mulmoclaude` を直接読む。Docker サンドボックスは agent subprocess の隔離用で、画像 serve には関係しない(`server/workspace/paths.ts:38`)。
+
+### 1.6 直近の修正履歴
+
+- `71a7af9b` (#961) wiki rewriter の `basePath` を旧 `wiki/pages` から `data/wiki/pages` に修正 → `../sources/foo.png` の解決が直る
+- `b11c3256` (#961) presentHtml の `<img>` rewriter を新規作成、leading-`/` を workspace-rooted として解釈
+- `inlineImages` (`server/api/routes/pdf.ts`) も同根の修正(同 PR)
+
+## 2. 目的(再設計の Goals)
+
+1. **LLM に相対パスを書かせる**(おかしな絶対パス・先頭スラッシュ混在を防ぐ)
+2. **ワークスペースのファイルを OS で直接開いた時にも画像が解決する**(markdown viewer / `file://`)
+3. **将来の内部ファイル構成変更に強くする**(rewriter が定数依存しない、既存ファイルを移動する想定はなし)
+4. **rewriter の出力 URL を proxy URL 形式に整理**(`/api/files/raw?path=…` の query param 形式から、普通の path 形式へ)
+
+## 2.5 検討した代替案と却下理由
+
+設計に至るまでに考慮した options を記録。後で「なぜこれにしなかったか」を辿るため。
+
+### 案A: 全面 iframe 化(wiki + presentHtml 両方)
+
+**アイデア**: wiki / HTML 共に `<iframe src="/proxy/...">` で表示。iframe 内のbase URL がワークスペースパスと一致 → 相対パスをブラウザが自然解決 → rewriter 不要。
+
+**却下理由**: wiki 側のUXコストが甚大。
+
+| iframe 化で失うもの | 補填の難易度 |
+|---|---|
+| Vue 親 frame の Tailwind / typography 継承 | iframe srcdoc に CSS 再注入が必要 |
+| ページ高さ自動調整 | `ResizeObserver` + `postMessage` で都度通知 |
+| 内部リンク `[[wiki link]]` の Vue router 連動 | click intercept + postMessage |
+| スクロール / アンカー (`#section`) | iframe boundary を跨ぐ必要 |
+| クリック→Vue router遷移などの統合UX | 全部再構築 |
+
+→ wiki の「v-html 直挿しで親frameと統合される気持ちよさ」が iframe 化で失われる。これを再構築する工数は rewriter の穴埋めより明確に重い。
+
+**部分採用は可能**: presentHtml だけ iframe srcdoc → src=URL に切り替えて rewriter 撤去はあり。が、本設計では一貫性のため両方とも v-html / srcdoc は維持し、rewriter で揃える方針に。
+
+### 案B: `<base href>` を iframe srcdoc に注入
+
+**アイデア**: presentHtml の srcdoc に `<base href="/proxy/artifacts/html/<file>/">` を入れる。iframe 内ドキュメントの base URL が変わり、相対パスがその位置から解決される。
+
+**却下理由(presentHtml 単体には適用可能だが、wiki には不可)**:
+
+- `<base>` は **HTMLドキュメントごとに1つだけ有効**、しかも適用範囲はそのドキュメント全体
+- wiki / markdown のレンダリングは `marked.parse()` の結果を `v-html` で **Vue アプリ本体のDOMに直接挿入**(iframe 境界がない)
+- `<base>` を入れたら **アプリ全体のルーティング・リンク・CSS パスが全部巻き込まれる** → 即死
+- canvas pane に複数 plugin result(wiki + presentHtml + markdown を縦積み)が並ぶケースで、wiki側がアプリDOMにそのまま流れ込むので結局アウト
+
+→ 本設計では使わない(presentHtml の現状の URL 解釈に変更を入れたくないため)。
+
+### 案C: static-mount だけで rewriter 撤去
+
+**アイデア**: `app.use('/data', static)` + `app.use('/artifacts', static)` を設定 → LLM が書く絶対パス(`<img src="/artifacts/images/...">`)はそのまま動く。rewriter 不要。
+
+**却下理由(完全撤去は不可)**:
+
+- ブラウザの相対パス解決は **「ページの現在URL」をbase** にする(ソースファイル位置ではない)
+- wiki ページは Vue ルート `/wiki/pages/my-page` で表示中 → `<img src="../sources/foo.png">` は `/wiki/sources/foo.png` を fetch しようとする → 404
+- 相対パスを正しく解決するには **「このコンテンツがどこから来たか」というサーバ側コンテキスト** が必要 → これは rewriter の仕事
+- HTML 仕様だけで解決する手段はない
+
+→ static-mount だけで救えるのは **LLM が必ず leading-`/` 絶対パスで書く** 場合のみ。現状の出力は3種類混在(`./foo.png`、`data/...`、`/artifacts/...`)なので不可。
+
+### 案D: data URI でインライン化
+
+**アイデア**: 生成時に画像を base64 で `<img src="data:image/png;base64,...">` にインラインしてしまう。URL ルーティング問題が消える。
+
+**却下理由**:
+
+- payload が肥大(画像1枚 ~MB スケール、wiki ページが100KB→数MBに)
+- ブラウザキャッシュ不可(同じ画像でも毎回転送)
+- ファイル共有時に画像も丸ごと埋め込まれる
+- workspace の「ファイルが真実」原則と相性が悪い(画像は別ファイルとして存在する設計)
+
+→ 採用せず。
+
+### 採用: hybrid(rewriter + static mount + onerror fallback)
+
+最終設計(§3 以下)は次の組み合わせ:
+
+| レイヤー | 役割 |
+|---|---|
+| LLM プロンプト | 相対パスを推奨、ハードコード回避 |
+| rewriter | 相対パス → 絶対URLに正規化、絶対パスはパススルー |
+| Express static mount | `/artifacts/images` だけ静的配信(範囲限定で privacy 安全) |
+| ブラウザ `<img onerror>` | 404時に `artifacts/images/<rest>` パターンで再構築 retry |
+
+それぞれが小さくて独立。段階的ロールアウト可能(§4)。
+
+### 派生で確認した事実
+
+- **Docker は agent 側だけ** — Express サーバはホスト側プロセスで動く(`server/workspace/paths.ts:38`)。`~/mulmoclaude` を直接読むので、Docker サンドボックスは画像配信に関係しない。
+- **画像保存先は1箇所** — `saveImage()` (`server/utils/files/image-store.ts:33`) が Gemini / canvas / image edit すべての終点で、出力は `artifacts/images/YYYY/MM/<shortId>.png` 一本(#764で UTC YYYY/MM shard 化)。
+- **`isImagePath()`** (`image-store.ts:59`) も `artifacts/images/` で始まることを必須にしている → 画像は他の場所には置かれない。
+
+→ 上記から `/artifacts/images` 限定 mount で十分という結論。
+
+## 3. 設計
+
+### 3.1 全体方針
+
+**iframe 化はしない**。理由は wiki の v-html 直挿しが Vue の親 frame と密結合(Tailwind / typography 継承、内部リンクが Vue router 連動、スクロール統合)で、iframe 化のUXコストが rewriter 維持より高い。
+
+代わりに:
+
+- **Express で `/artifacts/images` を `express.static` で mount**
+  - `app.use('/artifacts/images', express.static(WORKSPACE_PATHS.images, { dotfiles: 'deny', extensions allowlist }))`
+  - 拡張子 allowlist で `.png/.jpg/.jpeg/.webp/.svg/.gif/.pdf` 等のみ通す
+- **rewriter の出力先を `/artifacts/images/...` に変える**
+  - 既存の `/api/files/raw?path=...` 形式から、URL がワークスペースパスと一致する形式へ
+- **LLM プロンプトで相対パス推奨**(絶対パスも受け入れる)
+- **ブラウザ側の `<img onerror>` で fallback 復旧**
+
+### 3.2 Express mount の正当性
+
+`/artifacts/images` のみ mount で全画像をカバーできる根拠:
+
+- `saveImage()`(`server/utils/files/image-store.ts:33`)が **すべての画像生成パス**(Gemini / canvas / image edit)の終点
+- 保存先は `artifacts/images/YYYY/MM/<shortId>.png` 一本
+- `isImagePath()` (line 59) も `artifacts/images/` で始まることを validation 条件にしている
+- 画像が他の場所(`data/wiki/sources/` 等)に置かれる経路は無い
+
+→ `/artifacts/images` 限定 mount で privacy / 範囲とも適切。
+
+### 3.3 rewriter の入出力
+
+入力:
+```
+content: markdown / HTML 文字列
+sourcePath: ワークスペース相対の md/html パス(例: "data/wiki/pages/my-page.md")
+```
+
+出力ルール:
+
+| 入力 src | 出力 src |
+|---|---|
+| `/artifacts/images/2026/04/foo.png` | パススルー(既に正しい) |
+| `artifacts/images/2026/04/foo.png` | `/artifacts/images/2026/04/foo.png` (先頭`/`を付与) |
+| `../../../artifacts/images/2026/04/foo.png` | source位置から resolve → `/artifacts/images/2026/04/foo.png` |
+| `./foo.png`(`artifacts/images/` 配下に解決されない) | そのまま出力(ブラウザは404、onerror に委ねる) |
+| `data/wiki/sources/foo.png` 等(画像でない想定) | 後方互換のため `/api/files/raw?path=data/wiki/sources/foo.png` を出す(stage 1) |
+| `http://...` / `https://...` / `data:...` | パススルー |
+
+source位置を引数に取ることで、wiki ページが将来 `data/wiki/pages/` 以外に移っても rewriter の改修不要(Goal 3)。
+
+### 3.4 ブラウザ側 onerror による self-repair
+
+すべての rewriter出力 `<img>` に `data-orig` 属性を付与:
+
+```html
+<img src="/artifacts/images/2026/04/abc.png" data-orig="../../../artifacts/images/2026/04/abc.png">
+```
+
+404 時の handler:
+
+```js
+function repair(img) {
+  if (img.dataset.tried) return;            // 無限ループ防止
+  img.dataset.tried = '1';
+
+  const orig = img.dataset.orig || img.src;
+  // "artifacts/images/<rest>" を抽出して URL を再構築
+  const m = orig.match(/artifacts\/images\/.+/);
+  if (m) img.src = '/' + m[0];
+}
+```
+
+すべての画像が `artifacts/images/<...>` 配下にある前提なので、この単純なパターンマッチで:
+
+- `/some/wrong/prefix/artifacts/images/foo.png` → `/artifacts/images/foo.png` ✓
+- `<img src="data/x/artifacts/images/foo.png">` → `/artifacts/images/foo.png` ✓
+- `<img src="random/path.png">` → マッチせず諦め(既知パターン外)
+
+### 3.5 LLM プロンプトの改訂方針
+
+- 画像参照は **ソースファイルからの相対パス推奨**(`![](../../../artifacts/images/...)`)
+- 絶対パス(`/artifacts/images/...`)も許容
+- ハードコードを避ける(`data/wiki/...` のようなディレクトリ名直書きは将来の構成変更で壊れる)
+- 画像生成系プラグイン(Gemini, canvas)は `saveImage()` が返すパスをそのまま参照する規約を維持
+
+### 3.6 file:// での閲覧
+
+- markdown ビューア(VSCode / Obsidian / GitHub):`.md` の位置から相対解決 → 動く ✓
+- HTML を `file://` で直接開く: 一部ブラウザ(Chromium 系)は親 dir への `..` climb をデフォルトで拒否
+  - 同階層・サブディレクトリの参照は確実に動く
+  - 親 climb は browser 設定次第
+  - 許容する(ドキュメントに caveat 記載)
+
+## 4. 段階的ロールアウト
+
+### Stage 1: 画像 dir を mount + rewriter 出力 URL 切替
+
+**変更内容**
+
+- `server/index.ts`(または route 登録箇所)に `app.use('/artifacts/images', express.static(WORKSPACE_PATHS.images, { dotfiles: 'deny' }))` を追加(拡張子 allowlist 付き)
+- `src/utils/image/resolve.ts:resolveImageSrc()` を改修
+  - 入力 path が `artifacts/images/` 配下に解決されるなら `/artifacts/images/<rest>` を返す
+  - それ以外は現状の `/api/files/raw?path=<encoded>` を返す(後方互換)
+- 両 rewriter の `<img>` 出力に `data-orig` 属性追加(stage 3 で使う)
+
+**互換性**
+
+理論上完璧。理由:
+
+- 保存ファイルの中身(LLM-emitted の相対 / 絶対パス)は変更しない
+- rewriter の出力 URL のみ変更、サーバ側は **両 URL form を並走**
+- 既存の `<img src="/api/files/raw?path=...">` は runtime に生成される URL なのでファイルには残らない、ブラウザリロードで新しい URL に切り替わる
+- `data/wiki/sources/...` のような non-image path は `/api/files/raw?path=...` で従来通り解決
+
+**検証**
+
+- 既存 wiki ページを開く → 画像が表示される
+- 既存 presentHtml ページ → 画像が表示される
+- 新規生成画像 → 表示される
+- 直接 `<img src="/artifacts/images/2026/04/foo.png">` を含む markdown → 表示される
+
+### Stage 2: LLM プロンプト改訂
+
+**変更内容**
+
+- 画像参照規約のセクションを `server/agent/prompt.ts` または該当する system prompt 構成に追加
+- 推奨形(相対パス)・許容形(絶対パス)・禁止形(query string、host-absolute)を例示
+- 既存の wiki / HTML 生成系プロンプトの画像言及箇所を整合
+
+**互換性**
+
+prompt 変更のみ、コード挙動は変わらない。LLM 出力が改善されてもされなくても、stage 1 + stage 3 で受け止めるので壊れない。
+
+### Stage 3: ブラウザ側 onerror self-repair
+
+**変更内容**
+
+- wiki/markdown レンダリング箇所(v-html を使う Vue コンポーネント)に global `error` イベントリスナ
+  - `<img>` の error をキャッチ
+  - `data-orig` または `src` から `artifacts/images/<rest>` を抽出して retry
+  - `data-tried` で1回までに制限
+- presentHtml の iframe srcdoc 内にも同等のスクリプトを inject
+
+**互換性**
+
+純加算。既存の正しい URL は1段目で成功、404 のときだけ復旧を試みる。
+
+### Stage 4(後続、別 PR): rewriter §8 ギャップ埋め
+
+優先度は低い。stage 3 の onerror で実用上は塞がっているが、サーバ往復が無駄なので最終的には rewriter 側で吸収:
+
+- HTML rewriter: `<source>`, `<video>`, `<a href>`, CSS `url()`, single-quoted `src`
+- markdown rewriter: 生 `<img>` タグ
+- `textResponse/View.vue` への rewriter 適用
+
+## 5. Open Questions
+
+- **拡張子 allowlist の範囲**: `.png/.jpg/.webp/.svg/.gif` で確定?`.pdf` は別 mount?
+- **`data/wiki/sources/` の扱い**: 画像でないファイル(PDF 等の source 資料)は `/api/files/raw` で従来通りでよいか
+- **mount 経路のセキュリティ監査**: `express.static` の `dotfiles: 'deny'` だけで足りるか、追加ガードを噛ますか
+- **`data-orig` 属性の負荷**: 画像が大量(数百)ある wiki ページで属性増加によるDOM サイズ影響は許容範囲か
+- **`<base>` を試さない確定**: iframe srcdoc 内であれば `<base>` で相対パスを救う案もあるが、本設計では使わない(presentHtml の現状の URL 解釈に変更を入れたくないため)
+
+## 6. 関連
+
+- 現状調査: `docs/image-path-routing.md`
+- 直近の関連修正: PR #961 (`ab0518a6`, `b11c3256`)
+- 画像生成パスの実装: `server/utils/files/image-store.ts`(`saveImage`)
+- workspace dir 定数: `server/workspace/paths.ts:43-94`(`WORKSPACE_DIRS.images = "artifacts/images"`)

--- a/docs/image-path-routing.md
+++ b/docs/image-path-routing.md
@@ -1,0 +1,404 @@
+# Image-path routing — research notes
+
+Read-only audit of how MulmoClaude turns LLM-emitted image references into URLs the browser can fetch.
+Scope: wiki, presentHtml, markdown, news, and the workspace file server. Snapshot of `main` at commit
+`038995ea` (2026-04-29).
+
+> **TL;DR.** Every image reference funnels through one URL shape: `/api/files/raw?path=<workspace-relative>`,
+> served by `server/api/routes/files.ts` and gated by `resolveWithinRoot()` (realpath against
+> `~/mulmoclaude`). The frontend has *two* parallel rewriters — `rewriteMarkdownImageRefs` (uses
+> marked's lexer, accepts a `basePath`) and `rewriteHtmlImageRefs` (regex over `<img src="…">`,
+> no `basePath`) — that share a `shouldSkip` rule and `resolveImageSrc()`. The Docker sandbox is
+> agent-side only; the file server always reads from the host filesystem at `~/mulmoclaude`.
+
+## 1. Topology
+
+```
+LLM markdown / HTML
+        │  (page body or srcdoc)
+        ▼
+[Vue plugin View.vue]
+   wiki/View.vue            rewriteMarkdownImageRefs(body, WIKI_BASE_DIR)
+   markdown/View.vue        rewriteMarkdownImageRefs(body, dir(file))
+   FileContentRenderer.vue  rewriteMarkdownImageRefs(body, dir(file))
+   presentHtml/View.vue     rewriteHtmlImageRefs(html)
+        │  → marked.parse() / iframe srcdoc
+        ▼
+HTML with src="/api/files/raw?path=<encoded-workspace-rel>"
+        │  (browser fetch)
+        ▼
+[Express /api/files/raw]    resolveSafe(relPath) → resolveWithinRoot()
+        │
+        ▼
+fs.createReadStream(absPath)   ← host's ~/mulmoclaude (always — server is host-side)
+        │
+        ▼
+Bytes streamed back with `Content-Type` per extension and CSP `sandbox` header
+```
+
+1. **Plugin View** receives raw markdown / HTML from a tool result, runs the appropriate
+   *rewriter*, hands the result to `marked.parse(...)` (markdown) or to `<iframe srcdoc>` (HTML).
+2. **Rewriters** are pure browser-side string transforms (`src/utils/image/rewriteMarkdownImageRefs.ts`,
+   `src/utils/image/rewriteHtmlImageRefs.ts`) that produce URLs of the shape
+   `/api/files/raw?path=<workspace-relative>`.
+3. **Express file route** (`server/api/routes/files.ts`) accepts that shape, runs path-traversal
+   guards, classifies by extension, applies size caps, sets `Content-Security-Policy: sandbox`,
+   and pipes bytes from `~/mulmoclaude` back to the browser. Range requests are honoured for
+   audio/video.
+4. **Docker sandbox** (`server/system/docker.ts`, `server/agent/sandboxMounts.ts`) is the
+   agent's container only — the Express server runs on the host. The mount mapping affects what
+   the LLM sees inside the container, not what the file server reads.
+
+## 2. Routes
+
+| Route | Method | Handler | Guard | Workspace base |
+|---|---|---|---|---|
+| `/api/files/raw` | GET | `server/api/routes/files.ts:801` | `resolveAndStatFile` → `resolveSafe` (line 205) | `~/mulmoclaude` (`workspaceReal`, line 199) |
+| `/api/files/content` | GET | `server/api/routes/files.ts:643` | `resolveAndStatFile` → `resolveSafe` | same |
+| `/api/files/content` | PUT | `server/api/routes/files.ts:713` | `path.relative` syntactic check + `resolveSafe` | same |
+| `/api/files/dir` | GET | `server/api/routes/files.ts:506` | `resolveSafe` | same |
+| `/api/files/tree` | GET | `server/api/routes/files.ts:486` | walks from `workspaceReal` only | same |
+| `/api/files/ref-roots` | GET | `server/api/routes/files.ts:862` | per-entry `realpathSync(entry.hostPath)` | reference dirs (out of scope) |
+| `/api/images` (POST) | POST | `server/api/routes/image.ts:188` | `saveImage` writes under `WORKSPACE_PATHS.images` | `~/mulmoclaude/artifacts/images` |
+| `/api/images/update` (PUT) | PUT | `server/api/routes/image.ts:207` | `isImagePath` prefix check + `safeResolve` | same |
+| `/api/pdf/markdown` | POST | `server/api/routes/pdf.ts:152` | `inlineImages` → `resolveWithinRoot` (line 96) | host workspace + `WORKSPACE_DIRS.markdowns` base |
+
+The image-display path used by every wiki / HTML / markdown rewriter is **only**
+`/api/files/raw`. There is no per-kind image route — `image.ts` is for *generation /
+upload / overwrite*, not for serving image bytes back to viewers.
+
+`/api/files/raw` accepts every file kind the workspace contains: image, PDF, audio,
+video, text, and binary (PDF and audio/video added range-request streaming in #147 / later).
+MIME is dispatched from `MIME_BY_EXT` at `files.ts:116-136`. Anything not in that map serves
+as `application/octet-stream`.
+
+## 3. Path-traversal defense
+
+The canonical guard is `resolveWithinRoot` in `server/utils/files/safe.ts:77`:
+
+```ts
+// `rootReal` MUST already be a realpath. Returns null on traversal or if either path doesn't exist on disk.
+export function resolveWithinRoot(rootReal: string, relPath: string): string | null {
+  const normalized = path.normalize(relPath || "");
+  const resolved = path.resolve(rootReal, normalized);
+  let resolvedReal: string;
+  try {
+    resolvedReal = realpathSync(resolved);
+  } catch {
+    return null;
+  }
+  if (resolvedReal !== rootReal && !resolvedReal.startsWith(rootReal + path.sep)) {
+    return null;
+  }
+  return resolvedReal;
+}
+```
+
+Two properties this gives you:
+
+- **`..` traversal**: `path.normalize()` collapses `..`, then `path.resolve()` against
+  the realpath'd root will produce a path outside `rootReal`, which the prefix check
+  rejects. `path.sep + ` is critical so that `~/mulmoclaudeOTHER` is not accepted as
+  a prefix of `~/mulmoclaude`.
+- **Symlink escape**: `realpathSync` resolves the *resolved candidate* fully, defeating
+  `workspace/secret -> /etc/passwd` style traps. Both root and candidate are realpath'd
+  so a symlinked workspace home (`~/mulmoclaude` -> `/Volumes/Data/...`) doesn't
+  silently route through the unresolved branch.
+
+Call sites:
+
+| File | Line | Caller | Wraps it as |
+|---|---|---|---|
+| `server/api/routes/files.ts` | 199 | module-load `realpathSync(workspacePath)` | `workspaceReal` (cached) |
+| `server/api/routes/files.ts` | 205-219 | `resolveSafe(relPath)` | adds hidden-dir + `isSensitivePath` filter, used by every `/api/files/*` route |
+| `server/api/routes/files.ts` | 235-268 | `resolveRefPath(prefixedPath)` | reference-dir variant |
+| `server/api/routes/pdf.ts` | 59, 96 | `defaultWorkspaceRoot`, `inlineImages` | rejects `<img>` srcs that escape workspace |
+| `server/api/routes/mulmo-script.ts` | 384 | mulmo-script story dir | story-scoped wrapper |
+| `server/api/routes/sessions.ts` | 4 | session-id lookup | session-scoped wrapper |
+| `server/utils/files/image-store.ts` | 22-30 | `safeResolve` (image overwrite + base64 read) | strips `images/` prefix before checking |
+| `server/utils/files/spreadsheet-store.ts` | 22-26 | `safeResolve` (parallel of image-store) | same shape |
+
+Every workspace endpoint goes through one of these wrappers — there is no route
+that accepts a `path` query and reads bytes without one. The only route that
+serves bytes from the workspace is `/api/files/raw`, and its `resolveAndStatFile`
+helper at `files.ts:585-641` calls `resolveSafe` on every request.
+
+`resolveSafe` (files.ts:205) layers two more rejections on top of `resolveWithinRoot`:
+
+1. **Hidden dirs**: any path component matching `HIDDEN_DIRS = {".git"}` is refused
+   (line 211). The file tree walkers also skip these so they never appear in listings.
+2. **Sensitive basenames + extensions**: `isSensitivePath` (line 66) refuses
+   `.env`, `.env.<x>`, `credentials.json`, `.session-token`, `.npmrc`, `.htpasswd`,
+   SSH private-key names, and `.pem` / `.key` / `.crt` extensions.
+
+`resolveWithinRoot` is also used by the PDF route's `inlineImages` (`pdf.ts:70-110`).
+There the workspace-root realpath is computed at module load (`pdf.ts:59`) and a leading
+slash is stripped to convert `/artifacts/...` into `artifacts/...` (`pdf.ts:80-82`) — see
+PR #961 for the rationale (LLM-emitted web-rooted paths were getting interpreted as
+host-absolute by `path.resolve`).
+
+## 4. Wiki rewrite logic
+
+Source: `src/utils/image/rewriteMarkdownImageRefs.ts`, called from
+`src/plugins/wiki/View.vue:666`:
+
+```ts
+const withImages = rewriteMarkdownImageRefs(body, WIKI_BASE_DIR.value);
+```
+
+`WIKI_BASE_DIR` is computed at `View.vue:593`:
+
+```ts
+const WIKI_BASE_DIR = computed(() => (action.value === "page" ? WIKI_PAGES_DIR : WIKI_DATA_DIR));
+// WIKI_PAGES_DIR = "data/wiki/pages"  (line 344)
+// WIKI_DATA_DIR  = "data/wiki"        (line 345)
+```
+
+So a page-action render uses `data/wiki/pages` as the base; a log / lint-report /
+index uses `data/wiki`.
+
+The rewriter walks marked's token tree (`rewriteMarkdownImageRefs.ts:177-182`),
+descending into containers but skipping `code` / `codespan` / `html` tokens
+(`isSkippable`, line 105). When it finds an `image` token, it:
+
+1. Drops `data:`, `http(s):`, and existing `/api/` URLs untouched (`shouldSkip`, line 35-41).
+2. Resolves `href` against `basePath` via posix-style segment math
+   (`resolveWorkspacePath`, lines 51-69):
+   - leading `/` ⇒ ignore base, treat URL as workspace-rooted (`isAbsolute = true`,
+     `baseSegs = []`)
+   - otherwise start from `basePath` segments; consume `..` by popping, drop `''` and `.`
+   - escape (more `..` than depth) returns `null` and the original token's raw is emitted
+3. Calls `resolveImageSrc` (`src/utils/image/resolve.ts:6`):
+   ```ts
+   export function resolveImageSrc(imageData: string): string {
+     if (imageData.startsWith("data:")) return imageData;
+     return `${API_ROUTES.files.raw}?path=${encodeURIComponent(imageData)}`;
+   }
+   ```
+
+Behaviour table (basePath = `data/wiki/pages`, the page-action case):
+
+| Input markdown | After resolution | Final src | Notes |
+|---|---|---|---|
+| `![](foo.png)` | `data/wiki/pages/foo.png` | `/api/files/raw?path=data%2Fwiki%2Fpages%2Ffoo.png` | bare relative |
+| `![](./foo.png)` | `data/wiki/pages/foo.png` | same | leading `./` collapsed |
+| `![](../sources/foo.png)` | `data/wiki/sources/foo.png` | `/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png` | sibling dir, the #848 fix case |
+| `![](../../../artifacts/images/2026/04/x.png)` | `artifacts/images/2026/04/x.png` | `/api/files/raw?path=artifacts%2Fimages%2F2026%2F04%2Fx.png` | the real LLM-emitted shape |
+| `![](/data/wiki/sources/foo.png)` | `data/wiki/sources/foo.png` | `/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png` | leading `/` resets base |
+| `![](data:image/png;base64,…)` | passthrough | `data:image/png;base64,…` | `shouldSkip` |
+| `![](https://cdn/x.png)` | passthrough | unchanged | `shouldSkip` |
+| `![](/api/files/raw?path=foo)` | passthrough | unchanged | `shouldSkip` (idempotent) |
+| `![](../../../../escape.png)` (depth > base) | `resolveWorkspacePath` returns `null` | original raw emitted untouched | so the user sees a 404 rather than a wrong image |
+| `` `![inside code](x.png)` `` | passthrough | unchanged | code/codespan tokens skipped |
+| `![alt with [nested]](img.png)` | `img.png` | `/api/files/raw?path=img.png` | alt extracted by `extractBracketedAlt` (line 75) — depth counter, not regex |
+| `![w](wiki/Foo_(bar).png)` | `wiki/Foo_(bar).png` | `/api/files/raw?path=wiki%2FFoo_(bar).png` | balanced parens preserved by lexer |
+
+Inside the wiki view template the resulting URL is rendered into `v-html`
+(`wiki/View.vue:265`, `:276`). The rewriter has no DOM step; everything is markdown-
+to-markdown text manipulation, then `marked.parse(...)` (line 672).
+
+The same rewriter drives `src/plugins/markdown/View.vue:173` (basePath = directory
+of the file) and `src/components/FileContentRenderer.vue:183` (basePath = directory
+of `selectedPath`). `textResponse/View.vue` does **not** call this rewriter (see
+"Open questions" §8).
+
+## 5. HTML rewrite logic
+
+Source: `src/utils/image/rewriteHtmlImageRefs.ts`, called from `src/plugins/presentHtml/View.vue:50`:
+
+```ts
+const rawHtml = computed(() => rewriteHtmlImageRefs(data.value?.html ?? ""));
+```
+
+The result is then optionally injected with a print stylesheet (line 51) and fed to
+`<iframe :srcdoc="html" sandbox="allow-scripts allow-same-origin allow-modals">`
+(line 22).
+
+The rewriter is a single regex pass (`rewriteHtmlImageRefs.ts:27`):
+
+```ts
+const IMG_SRC_RE = /(<img\s[^>]*src=")([^"]+)(")/g;
+```
+
+For each match:
+
+1. `shouldSkip` filters `data:`, `http(s):`, `/api/` (lines 29-34).
+2. `normalizeWorkspacePath` strips one leading `/` (lines 39-41).
+3. Empty result after stripping is returned untouched.
+4. `resolveImageSrc(workspacePath)` produces the same URL shape as the markdown
+   rewriter.
+
+Behaviour table:
+
+| Input HTML | Final src | Notes |
+|---|---|---|
+| `<img src="/artifacts/images/2026/04/foo.png">` | `/api/files/raw?path=artifacts%2Fimages%2F2026%2F04%2Ffoo.png` | LLM web-rooted shape, dominant case |
+| `<img src="artifacts/images/foo.png">` | `/api/files/raw?path=artifacts%2Fimages%2Ffoo.png` | already workspace-relative |
+| `<img src="data:image/png;base64,…">` | unchanged | passthrough |
+| `<img src="http://cdn/x.png">` | unchanged | passthrough |
+| `<img src="/">` | unchanged | empty after stripping = no-op |
+| `<img alt="cat" src="/artifacts/images/foo.png" width="100">` | `/api/files/raw?path=artifacts%2Fimages%2Ffoo.png` (other attrs preserved) | regex captures only the src group |
+| `<img src='./foo.png'>` (single-quoted) | **untouched** | regex matches `src="…"` only — see §8 |
+| `<source src="/artifacts/foo.webm">` | **untouched** | regex matches `<img …>` only — see §8 |
+| `<a href="/artifacts/foo.pdf">` | **untouched** | rewriter is image-only — see §8 |
+| `<img src="../../etc/passwd">` | rewritten to `/api/files/raw?path=..%2F..%2Fetc%2Fpasswd` | server-side `resolveSafe` rejects, returns 404 — but the URL is *built* without escape detection (see §8) |
+
+Note the asymmetry vs. the markdown rewriter: the HTML rewriter does **not** carry
+a `basePath` parameter and does **not** detect workspace-escape. It simply strips
+one leading slash and trusts the server's `resolveWithinRoot` for the security gate.
+That is acceptable because the iframe uses `srcdoc`, so the browser has no
+"current document URL" against which `..` could resolve to a sibling page anyway —
+the only sane base for the LLM is the workspace root, which the rewriter encodes
+implicitly.
+
+`presentHtml/View.vue:22` sets `sandbox="allow-scripts allow-same-origin allow-modals"`,
+which means the iframe shares the SPA origin. The image fetch goes to the SPA's
+`/api/files/raw`, served by Express on the same origin. Auth cookies / bearer-token
+headers are *not* attached to `<img>` requests automatically (browsers don't send
+custom headers on image elements), but the project relies on the bearer-token
+exemption in `server/api/auth.ts` for the file routes — verify this is intended
+when redesigning (see §8).
+
+## 6. Docker awareness
+
+Docker is the **agent** sandbox, not the **server** sandbox. The Express server
+*always* runs on the host, reading from `~/mulmoclaude` directly:
+
+- `server/workspace/paths.ts:38` hardcodes `workspacePath = path.join(homedir(), "mulmoclaude")` —
+  no env override, no Docker branch.
+- `server/api/routes/files.ts:199` caches `realpathSync(workspacePath)` at module load.
+- `server/system/docker.ts` only manages the *agent* container image:
+  build / detect at startup, no mount of `~/mulmoclaude` for the file server's purposes.
+
+The two places where Docker container paths matter are:
+
+- `server/agent/sandboxMounts.ts` — host SSH agent / gh CLI / gitconfig mounts for
+  the agent container, exposed as `containerPath` per spec (line 32).
+- `server/workspace/reference-dirs.ts:197-237` — reference-dir mounts for the agent.
+  `useDocker ? containerPath(entry) : entry.hostPath` chooses the path the agent's
+  prompt sees in its `Read`/`Write` tool calls, not the server's view.
+
+So the question "does the file server know about Docker mode?" is **no, by design**.
+A redesign that wants to keep that property doesn't need to plumb a sandbox flag
+through the path resolver. A redesign that wants the *agent* to also serve image
+bytes (e.g. tools running inside the container that emit URLs) would need a new
+mapping; today there's none.
+
+`WORKSPACE_PATHS` (paths.ts:101-143) and `WORKSPACE_DIRS` (paths.ts:43-94) are the
+single source of truth for both reading and writing — both server and agent
+prompt strings derive from these.
+
+## 7. Pattern catalogue
+
+Real-world LLM-emitted patterns observed in `~/mulmoclaude/data/wiki/pages/*.md`:
+
+| Input form | Source | Handler | Final URL | Security note |
+|---|---|---|---|---|
+| `![](https://upload.wikimedia.org/wikipedia/commons/.../x.png)` | wiki | `shouldSkip` (https) | unchanged, browser fetches Wikipedia | trusts the LLM's URL; iframe has no CSP for outbound |
+| `![alt](../../../artifacts/images/2026/04/<short-id>.png)` | wiki page | rewriter resolves with basePath `data/wiki/pages` | `/api/files/raw?path=artifacts%2Fimages%2F2026%2F04%2F<id>.png` | three `..` consume `data`+`wiki`+`pages`, lands at workspace root |
+| `![chart](../sources/foo.png)` | wiki page | rewriter | `/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png` | this is the #848 fix — basePath was `wiki/pages` pre-fix, would 404 |
+| `![](data/wiki/sources/foo.png)` | wiki index | rewriter, basePath `data/wiki` | `/api/files/raw?path=data%2Fwiki%2Fdata%2Fwiki%2Fsources%2Ffoo.png` (bug — see §8) | rare in practice, LLM doesn't emit this from index views |
+| `<img src="/artifacts/images/2026/04/<id>.png">` | presentHtml | rewriter strips leading `/` | `/api/files/raw?path=artifacts%2Fimages%2F2026%2F04%2F<id>.png` | dominant LLM-HTML shape (#961) |
+| `<img src="data:image/png;base64,…">` | presentHtml or wiki | passthrough | inline | trusted in-process render |
+| `<img src='/artifacts/foo.png'>` (single-quoted) | presentHtml | **NOT rewritten** | broken inside iframe | known gap (rewriteHtmlImageRefs.ts:27 regex is double-quote only) |
+| `<img src="../escape.png">` | presentHtml | rewriter encodes `..%2Fescape.png` | server-side `resolveSafe` returns null → 400 "Path outside workspace" | URL leaks the attempted path to the network log, not to disk |
+| `![](../../../../etc/passwd)` from wiki page | wiki | `resolveWorkspacePath` returns null | original raw emitted, browser interprets as relative path under SPA origin | safe — never produces an `/api/files/raw` URL |
+| `![](/etc/passwd)` from wiki | wiki | basePath reset, returns `etc/passwd` | `/api/files/raw?path=etc%2Fpasswd` | server-side `resolveWithinRoot` rejects (no `~/mulmoclaude/etc/passwd` exists), returns 404 |
+| `![inside](images/foo.png)` inside ` ``` ` fenced block | wiki | marked-lexer skip | passthrough | renders as literal text in the rendered code block |
+
+## 8. Open questions / inconsistencies
+
+These are observations, not bugs to fix in this audit.
+
+1. **Wiki rewriter's leading-slash semantics differ from what users expect.**
+   `![](/data/wiki/sources/foo.png)` works (leading `/` resets base, lands at
+   `data/wiki/sources/foo.png`). But `![](data/wiki/sources/foo.png)` from a
+   page-action context resolves with basePath `data/wiki/pages`, yielding
+   `data/wiki/pages/data/wiki/sources/foo.png` — that's almost certainly not what
+   the LLM meant. The markdown rewriter has no "is the URL already workspace-rooted?"
+   heuristic; it always treats absent leading-`/` as relative-to-base. If this
+   pattern ever shows up in the wild it 404s silently (the user sees a broken
+   image, not a clear error). The HTML rewriter accidentally handles this better
+   because it has no basePath at all.
+
+2. **`<source>` / `<video>` / `<audio>` tags are not rewritten in HTML.** The regex
+   at `rewriteHtmlImageRefs.ts:27` is `<img\s[^>]*src="…"` only. LLM-emitted media
+   embeds with workspace-rooted srcs would 404 inside the presentHtml iframe.
+   Real LLM output rarely produces these today; if a redesign aims to support
+   audio/video, this needs to expand.
+
+3. **`<a href="...">` and CSS `url(...)` references are not rewritten.** A
+   `<a href="/artifacts/documents/foo.md">` inside presentHtml would 404 — the
+   iframe lookup hits the SPA origin, which doesn't serve `/artifacts`. Same for
+   `background-image: url("/artifacts/...")` in inline styles. Markdown's
+   `[text](workspace-path)` for non-image links is handled separately by
+   `handleContentClick` in `wiki/View.vue:900-937` (it routes to internal Vue
+   navigation), but the equivalent for HTML is unhandled.
+
+4. **Single-quoted `src='…'` not rewritten.** Comment at
+   `rewriteHtmlImageRefs.ts:24-26` calls this out as intentional ("extend later
+   if a real case appears"). LLMs do sometimes emit single-quoted attributes;
+   confirm with telemetry or just expand the regex.
+
+5. **`textResponse/View.vue` skips the rewriter.** It uses `marked(processedText, …)`
+   at line 122 directly. Tool-result text containing `![](workspace-rel)` will
+   not display images. May be intentional (text responses should be self-
+   contained), but worth confirming when redesigning.
+
+6. **Two parallel rewrite layers with subtly different semantics.** Markdown uses
+   marked's lexer (correct for parens, code blocks, balanced brackets); HTML uses
+   a regex. A future markdown-emitting LLM that includes raw HTML inside markdown
+   gets the markdown rewriter's `html` token skip rule (passthrough), which means
+   `<img>` tags **inside markdown** are not rewritten by either pass. Repro:
+   write a wiki page that opens with raw `<img src="/artifacts/...">` instead of
+   `![](...)`. The wiki rewriter skips it (html token); the wiki view never
+   invokes the HTML rewriter. The image won't render unless the LLM uses
+   markdown image syntax.
+
+7. **PDF inliner duplicates the path-resolution logic.** `server/api/routes/pdf.ts:70-110`
+   re-implements "leading-slash means workspace-rooted, otherwise relative to
+   markdowns/" in inlineImages. This is parallel to (but not shared with) the
+   frontend rewriters. The two encode the same convention but diverge: the
+   frontend HTML rewriter has no `basePath` (always workspace root); the PDF
+   inliner uses `WORKSPACE_DIRS.markdowns` as the relative base. If the
+   convention ever changes, both need to update in lockstep. A redesign could
+   centralise this — see "Where to look first."
+
+8. **Image fetches don't carry the bearer token.** `<img src="/api/files/raw?path=…">`
+   is a regular browser image request; it does not include the `Authorization`
+   header. The `/api/files/*` routes are exempt from auth in
+   `server/api/auth.ts` for this reason (and because file viewing is a core UX
+   need). Worth re-confirming during a redesign that the exemption is still
+   acceptable, especially if the app ever runs in a multi-user context.
+
+9. **`resolveWithinRoot` requires the file to exist on disk.** Because it calls
+   `realpathSync` on the candidate (safe.ts:82), a request for a path inside the
+   workspace that doesn't exist yet returns `null`. `files.ts:611-639` works
+   around this for the PUT case by stat-ing the syntactic candidate first to
+   distinguish 404 from "outside workspace." Other callers (image-store,
+   spreadsheet-store) write through `writeFileAtomic` to the absolute path
+   directly without a safe-resolve check beforehand — they trust their input
+   shape via separate prefix checks (`isImagePath`).
+
+10. **No global `<base>` element in presentHtml's iframe.** Adding `<base href="/">`
+    inside the iframe srcdoc would let LLM-emitted relative paths (no leading `/`)
+    resolve against the SPA origin, but `/artifacts/*` still wouldn't be served.
+    A redesign could either (a) keep rewriting at injection time as today, or
+    (b) inject a `<base>` *plus* a Service Worker / dedicated `/files/...` mount
+    that serves workspace files at a stable URL prefix the LLM can be prompted
+    to emit directly.
+
+---
+
+**Where to look first if redesigning this:**
+
+1. `src/utils/image/rewriteMarkdownImageRefs.ts` and `src/utils/image/rewriteHtmlImageRefs.ts`
+   — the two paths that produce every `/api/files/raw?path=...` URL the browser
+   ever fetches. Any redesign of the URL shape, the base-path convention, or the
+   tag coverage starts here.
+2. `server/api/routes/files.ts` (especially `resolveAndStatFile` at 585 and `resolveSafe`
+   at 205) — the single mouth of the file server. A new URL shape needs a parallel
+   handler here, and any auth or CSP changes are localised to this file.
+3. `server/utils/files/safe.ts:77` — the `resolveWithinRoot` guard. If the
+   redesign introduces a new root (e.g. agent-side `/workspace/` URLs), this is
+   the helper to extend rather than reimplement.

--- a/plans/feat-image-path-routing.md
+++ b/plans/feat-image-path-routing.md
@@ -1,0 +1,195 @@
+# 画像パスのルーティング再設計 — 実装プラン
+
+設計の背景・代替案・却下理由は `docs/discussion-image-path-routing.md` 参照。
+現状の挙動の精密な audit は `docs/image-path-routing.md`(英語)参照。本ファイルは「何をどの順で実装するか」だけを書く。
+
+## ゴール(再掲)
+
+1. LLM に相対パスを書かせる(出力の混乱を抑える)
+2. ワークスペースを OS で直接開いた時にも画像が解決する
+3. 内部ファイル構成変更に強い rewriter にする(定数依存を捨てる)
+4. rewriter の出力 URL を proxy URL 形式(`/artifacts/images/...`)に整理
+
+## 全体構成
+
+| レイヤー | 仕事 |
+|---|---|
+| LLM プロンプト | 相対パスを推奨、絶対パスも許容、ハードコード回避 |
+| rewriter | 相対パス → 絶対URLに正規化、絶対パスはパススルー、source位置を引数化 |
+| Express static mount | `/artifacts/images` だけ静的配信、拡張子 allowlist |
+| ブラウザ `<img onerror>` | 404時に `artifacts/images/<rest>` パターンで URL 再構築 retry |
+
+各レイヤーは独立。段階的ロールアウトが可能。
+
+---
+
+## Stage 1: `/artifacts/images` static mount + rewriter 出力 URL 切替
+
+「**理論上、互換性が完璧**」の段。サーバ側に static mount を追加し、rewriter の出力先を `/artifacts/images/...` 形式に切り替える。既存の `/api/files/raw` ルートは触らないため、既存出力を含めて挙動が一切変わらない。
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `server/index.ts`(または route 登録の中央点) | `app.use('/artifacts/images', express.static(WORKSPACE_PATHS.images, { dotfiles: 'deny', fallthrough: false }))` を追加。拡張子 allowlist middleware を前段に挟む |
+| `src/utils/image/resolve.ts` | `resolveImageSrc()` を改修。入力が `artifacts/images/` 配下なら `/artifacts/images/<rest>`、それ以外は現状の `/api/files/raw?path=<encoded>` を返す |
+| `src/utils/image/rewriteMarkdownImageRefs.ts` | 出力 `<img>` に `data-orig` 属性を付与(stage 3 で使う種を仕込む) |
+| `src/utils/image/rewriteHtmlImageRefs.ts` | 同上 |
+
+### 拡張子 allowlist の中身
+
+`/artifacts/images` は画像配信専用。以下のみ通す:
+
+- `.png` / `.jpg` / `.jpeg` / `.webp` / `.gif` / `.svg`
+
+PDFは `artifacts/images/` には入らないので allowlist 不要。`.png` 以外を Gemini が出すかは要確認(現状 `saveImage` は `.png` 固定 — `image-store.ts:36`)、必要なら拡張する。
+
+### `resolveImageSrc` の挙動表
+
+| 入力 | 出力 |
+|---|---|
+| `/artifacts/images/2026/04/foo.png` | `/artifacts/images/2026/04/foo.png` (パススルー) |
+| `artifacts/images/2026/04/foo.png` | `/artifacts/images/2026/04/foo.png` (`/` 付与) |
+| `data/wiki/sources/foo.png` | `/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png` (現状維持) |
+| `http://...` / `https://...` / `data:...` | パススルー |
+
+ソースファイル位置からの相対 resolve は呼び出し側(`rewriteMarkdownImageRefs`)が事前に行う。`resolveImageSrc` は入力 path を URL に変換するだけのレイヤーに保つ。
+
+### rewriter の source-file 引数化
+
+`rewriteMarkdownImageRefs(content, basePath)` を `rewriteMarkdownImageRefs(content, sourceFilePath)` に変更:
+
+- 入力の `sourceFilePath` は workspace-relative の md/html パス(例: `data/wiki/pages/my-page.md`)
+- 内部で `dirname(sourceFilePath)` を base として相対 resolve
+
+呼び出し側(`src/plugins/wiki/View.vue` 等)は WIKI_BASE_DIR 定数ではなく **実際のソースファイルパス** を渡す。これで Goal 3(構成変更耐性)が達成される。
+
+### 受け入れ条件
+
+- [ ] 既存の wiki ページ(`/artifacts/images/...` への相対 climb で書かれている)が変わらず表示される
+- [ ] 新規生成画像(Gemini)が `/artifacts/images/YYYY/MM/<id>.png` で表示される
+- [ ] 新規生成画像が `<img>` の `src` で `/artifacts/images/...` の URL になっている(devtools で確認)
+- [ ] `/api/files/raw?path=...` で参照していた画像も引き続き表示される
+- [ ] `data/wiki/sources/` の non-image ファイル(あれば)も引き続き `/api/files/raw` 経由で動く
+- [ ] `format` / `lint` / `typecheck` / `build` 全部緑
+- [ ] e2e の image-plugins / wiki 系テストが通る
+
+### Out of scope(stage 1 では触らない)
+
+- LLM プロンプト変更(stage 2)
+- ブラウザ onerror 復旧(stage 3)
+- §8 の rewriter ギャップ埋め(`<source>`, `<video>`, CSS `url()` 等。stage 4)
+
+---
+
+## Stage 2: LLM プロンプト改訂
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `server/agent/prompt.ts`(または該当 system prompt) | 「画像参照規約」セクションを追加 / 既存の画像言及を整合 |
+| 個別ロール / プラグインの prompt | 画像言及があれば同規約に合わせる |
+
+### prompt に書く内容(草案)
+
+```
+## Image references in markdown / HTML
+
+- ALWAYS use a relative path that resolves correctly against the
+  source file (the .md / .html being written).
+  - For images saved by `saveImage` (Gemini / canvas / edit),
+    that path is `artifacts/images/YYYY/MM/<id>.png` —
+    write a relative climb to it from the source file location.
+- Absolute path `/artifacts/images/...` is also accepted.
+- NEVER embed `data/...` or `artifacts/...` as a workspace-rooted
+  no-leading-slash form (e.g. `data/wiki/sources/foo.png`) —
+  the browser misresolves it against the page URL.
+- NEVER write `/api/files/raw?path=...` (server URL form) —
+  it's a runtime artifact, not a stored convention.
+```
+
+### 受け入れ条件
+
+- [ ] prompt 改訂後の生成出力で、画像参照の99%以上が「相対パス または `/artifacts/images/` 始まり」
+- [ ] 1〜2件の wiki 生成、HTML 生成を試して目視確認
+- [ ] CI の prompt 関連テスト(あれば)が通る
+
+### 補足
+
+prompt 変更だけでは LLM の遵守率が100%にならない可能性。残りは stage 3 の onerror で吸収。
+
+---
+
+## Stage 3: ブラウザ側 `<img onerror>` self-repair
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/composables/useImageErrorRepair.ts` (新規) | `<img>` の error イベントをグローバルキャッチして `artifacts/images/<rest>` パターンで URL 再構築する composable |
+| `src/App.vue`(または wiki / markdown View 共通の親) | 上記 composable をマウント |
+| `src/plugins/presentHtml/View.vue` | iframe srcdoc に同等のスクリプトを inject(parent から `postMessage` 経由で composable と統合 or 単独スクリプト) |
+
+### 復旧ロジック
+
+```ts
+function repairImage(img: HTMLImageElement): void {
+  if (img.dataset.tried) return;       // 無限ループ防止
+  img.dataset.tried = '1';
+
+  const orig = img.dataset.orig || img.src;
+  const m = orig.match(/artifacts\/images\/.+/);
+  if (m) {
+    img.src = '/' + m[0];
+  }
+}
+```
+
+`data-orig` は stage 1 で rewriter が付与済み。
+
+### 受け入れ条件
+
+- [ ] 故意に壊した URL(`/wrong/prefix/artifacts/images/foo.png`)を含む test ページを作って、ブラウザで開いた時に画像が復旧する
+- [ ] presentHtml(iframe srcdoc)内でも復旧する
+- [ ] 復旧不能なケース(`artifacts/images/<rest>` パターンが含まれない)で無限ループしない
+- [ ] 既存 e2e が壊れない
+
+---
+
+## Stage 4(別 PR、優先度低): rewriter §8 ギャップ埋め
+
+stage 3 までで実用上は閉じているが、サーバ往復が発生するのを避けるため最終的には rewriter 側で吸収:
+
+| 対応 | 場所 |
+|---|---|
+| HTML rewriter で `<source>`, `<video>`, `<a href>`, CSS `url()` | `rewriteHtmlImageRefs.ts` |
+| HTML rewriter で single-quoted `src` | 同上 |
+| markdown rewriter で生 `<img>` HTML タグ | `rewriteMarkdownImageRefs.ts` |
+| `textResponse/View.vue` への rewriter 適用 | 該当 View |
+
+各々独立した小 PR で良い。Stage 4 は本ドキュメント外で別 issue として trakする。
+
+---
+
+## Rollout 順序
+
+1. Stage 1 を独立 PR で merge → 1〜2日間モニタ → 既存出力に問題なければ
+2. Stage 2 を独立 PR で merge → LLM出力サンプル目視 → 必要なら微調整
+3. Stage 3 を独立 PR で merge → 復旧動作確認
+
+各 stage の独立性は維持(stage 2 / 3 が無くても stage 1 単体で完全動作、後続もそう)。
+
+## Risks / Open Questions
+
+- **拡張子 allowlist の運用**: Gemini が将来 `.webp` を出すなら更新が必要。allowlist は中央化(`server/api/routes/static-image.ts` 等)に置く?
+- **`data-orig` 属性のサイズ影響**: 画像が大量(数百)ある wiki ページで属性増加によるDOM サイズ影響。実測してから判断。
+- **presentHtml iframe srcdoc の onerror**: srcdoc 内には parent と通信する手段がない(同一origin扱いのはず)。実装で工夫が要る。
+- **既存の `data/wiki/sources/` のような `data/` 配下画像**: 現状実測では `artifacts/images/` 一択のはずだが、見落としがあれば mount 拡張が必要。
+
+## 関連
+
+- 設計議論: `docs/discussion-image-path-routing.md`
+- 現状調査: `docs/image-path-routing.md`
+- 直近の関連 PR: #961
+- 画像生成: `server/utils/files/image-store.ts`


### PR DESCRIPTION
## Summary

3つの新規ドキュメント。コード変更なし。後続の実装PRが分かれて読みやすくなるよう、最初に背景・議論・計画だけを切り出して merge する。

| ファイル | 言語 | 内容 |
|---|---|---|
| \`docs/image-path-routing.md\` | English | 現状の精密 audit。Express ルート / rewriter 2系統 / path traversal ガード / Docker 構成 / 既知の穴(§8)。コミット \`038995ea\` 時点のスナップショット |
| \`docs/discussion-image-path-routing.md\` | 日本語 | 設計議論の記録。検討した代替案(全面 iframe / `<base href>` / static-mount のみ / data URI)とそれぞれの却下理由 |
| \`plans/feat-image-path-routing.md\` | 日本語 | 実装プラン。Stage 1 = mount + rewriter URL 切替、Stage 2 = LLM prompt、Stage 3 = ブラウザ onerror self-repair、Stage 4 = §8 ギャップ埋め |

## Items to Confirm / Review

- [ ] **3文書の役割分担**が読みやすいか:
  - audit = 「いま何が動いているか」のスナップショット(英語、サブエージェント生成)
  - discussion = 「なぜそうしないか」を含む議論ログ(日本語)
  - plan = 「何をどの順で実装するか」だけ(日本語)
- [ ] discussion と plan の間で重複しすぎていないか(例: design rationale は discussion、acceptance criteria は plan、で分離している)
- [ ] §2.5(検討した代替案)で却下した4案が公平に書けているか:
  - A 全面 iframe(却下: wiki UX コスト)
  - B `<base href>`(却下: 親 frame leak、wiki 不可)
  - C static-mount のみ(却下: 相対 path 解決はサーバ側コンテキスト必須)
  - D data URI inline(却下: payload・キャッシュ・共有性)
- [ ] plan の Stage 1 が「**理論上、互換性が完璧**」と謳っている根拠が成立しているか:
  - 既存の `/api/files/raw` ルートを残す
  - rewriter の出力 URL のみ切替
  - サーバ側が両 URL form を並走

## What's NOT in this PR

- コード変更なし
- prompt 変更なし
- e2e / lint / typecheck の対象外(docs / plans / md は workflow の \`paths-ignore\` に入っているので CI の lint_test は走らない設計)

## Next steps

merge 後、\`feat/image-path-routing-stage1\` ブランチで Stage 1 から実装着手:
- \`/artifacts/images\` static mount 追加
- \`resolveImageSrc()\` の出力切替
- \`data-orig\` 属性付与(stage 3 の種)
- 既存挙動維持確認(e2e + 手動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive audit documentation of the current image path routing system, covering URL generation, rendering integration, and server-side path resolution with known limitations.
  * Introduced a detailed multi-stage implementation roadmap for image path routing improvements, including planned enhancements to URL handling and error recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->