### PR TITLE
chore(lint): low-impact non-null-assertion cleanup in src/ + server/

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -373,12 +373,13 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
 
   const tool = tools.find((toolDef) => toolDef.name === name);
   if (!tool) throw new Error(`Unknown tool: ${name}`);
+  if (!tool.endpoint) throw new Error(`Tool has no endpoint: ${name}`);
 
   // Plugin handlers can fan out to generative AI (image batches via
   // presentDocument, future video). The bridge MUST wait long enough
   // for the slowest realistic completion — see PLUGIN_BRIDGE_TIMEOUT_MS
   // and the timeout-policy comment on `postJson`.
-  const res = await postJson(tool.endpoint!, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
+  const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
   const result = await res.json();
 
   // Push visual ToolResult to the frontend via the session

--- a/server/api/routes/schedulerTasks.ts
+++ b/server/api/routes/schedulerTasks.ts
@@ -180,7 +180,7 @@ router.get(API_ROUTES.scheduler.logs, async (req: Request<object, unknown, objec
   const MAX_LIMIT = 500;
   const rawLimitStr = getOptionalStringQuery(req, "limit");
   const rawLimit = rawLimitStr ? parseInt(rawLimitStr, 10) : undefined;
-  const limit = Number.isFinite(rawLimit) && rawLimit! > 0 ? Math.min(rawLimit!, MAX_LIMIT) : undefined;
+  const limit = rawLimit !== undefined && Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, MAX_LIMIT) : undefined;
   const taskId = getOptionalStringQuery(req, "taskId");
   log.info("scheduler-tasks", "logs: start", { taskId, limit });
   try {

--- a/server/api/routes/todosColumnsHandlers.ts
+++ b/server/api/routes/todosColumnsHandlers.ts
@@ -122,7 +122,10 @@ export function normalizeColumns(raw: unknown): StatusColumn[] {
 // normalizeColumns.
 export function doneColumnId(columns: StatusColumn[]): string {
   const done = columns.find((column) => column.isDone);
-  return done ? done.id : columns[columns.length - 1]!.id;
+  if (done) return done.id;
+  const last = columns[columns.length - 1];
+  if (!last) throw new Error("doneColumnId: empty columns array (normalizeColumns invariant violated)");
+  return last.id;
 }
 
 // id of the first non-done column, used as the default status when
@@ -328,6 +331,10 @@ export function handleReorderColumns(columns: StatusColumn[], ids: string[]): Co
     seen.add(columnId);
   }
   const byId = new Map(columns.map((column) => [column.id, column]));
-  const next = ids.map((columnId) => byId.get(columnId)!);
+  const next = ids.map((columnId) => {
+    const column = byId.get(columnId);
+    if (!column) throw new Error(`reorderColumns: missing column for id "${columnId}" (set-equality check above missed it)`);
+    return column;
+  });
   return { kind: "success", columns: next };
 }

--- a/server/api/routes/todosItemsHandlers.ts
+++ b/server/api/routes/todosItemsHandlers.ts
@@ -66,14 +66,18 @@ export function migrateItems(rawItems: TodoItem[], columns: StatusColumn[]): Tod
   const byStatus = new Map<string, TodoItem[]>();
   for (const item of withStatus) {
     const key = item.status ?? openId;
-    if (!byStatus.has(key)) byStatus.set(key, []);
-    byStatus.get(key)!.push(item);
+    let bucket = byStatus.get(key);
+    if (!bucket) {
+      bucket = [];
+      byStatus.set(key, bucket);
+    }
+    bucket.push(item);
   }
   const orderById = new Map<string, number>();
   for (const [, group] of byStatus) {
     const missing = group.filter((item) => typeof item.order !== "number");
     if (missing.length === 0) continue;
-    const existingMax = group.filter((item) => typeof item.order === "number").reduce((acc, item) => Math.max(acc, item.order!), 0);
+    const existingMax = group.filter((item) => typeof item.order === "number").reduce((acc, item) => Math.max(acc, item.order ?? 0), 0);
     const sorted = [...missing].sort((left, right) => left.createdAt - right.createdAt);
     sorted.forEach((item, i) => {
       orderById.set(item.id, existingMax + (i + 1) * ORDER_STEP);
@@ -370,7 +374,8 @@ export function handleMove(items: TodoItem[], columns: StatusColumn[], itemId: s
     if (newOrder !== undefined) return { ...item, order: newOrder };
     return item;
   });
-  const finalSelf = nextItems.find((item) => item.id === itemId)!;
+  const finalSelf = nextItems.find((item) => item.id === itemId);
+  if (!finalSelf) throw new Error(`reorder result missing item ${itemId}`);
   return { kind: "success", items: nextItems, item: finalSelf };
 }
 

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -234,8 +234,9 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
   const indexContent = readFileOrEmpty(indexFile());
   const entries = parseIndexEntries(indexContent);
   const titleMatch = entries.find((entry) => entry.title === pageName);
-  if (titleMatch && slugs.has(titleMatch.slug)) {
-    return path.join(dir, slugs.get(titleMatch.slug)!);
+  if (titleMatch) {
+    const file = slugs.get(titleMatch.slug);
+    if (file) return path.join(dir, file);
   }
 
   return null;

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -272,7 +272,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
     });
     while (responseQueue.length > 0) {
       if (!socket || socket.readyState !== WebSocket.OPEN) break;
-      const response = responseQueue[0]!;
+      const [response] = responseQueue;
       if (!trySend(response)) break;
       responseQueue.shift();
     }

--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -442,9 +442,10 @@ export function onSessionEvent(chatSessionId: string, listener: SessionEventList
     sessionListeners.set(chatSessionId, listeners);
   }
   listeners.add(listener);
+  const captured = listeners;
   return () => {
-    listeners!.delete(listener);
-    if (listeners!.size === 0) sessionListeners.delete(chatSessionId);
+    captured.delete(listener);
+    if (captured.size === 0) sessionListeners.delete(chatSessionId);
   };
 }
 

--- a/server/events/task-manager/index.ts
+++ b/server/events/task-manager/index.ts
@@ -105,7 +105,8 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
       progress = false;
       const next: TaskDefinition[] = [];
       for (const def of remaining) {
-        if (!succeeded.has(def.dependsOn!)) {
+        const dep = def.dependsOn;
+        if (!dep || !succeeded.has(dep)) {
           next.push(def);
           continue;
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -657,7 +657,7 @@ function createNewSession(roleId?: string): ActiveSession {
   navigateToSession(session.id, replace);
   chatInputRef.value?.collapseSuggestions();
   nextTick(() => focusChatInput());
-  return sessionMap.get(session.id)!;
+  return session;
 }
 
 function onRoleChange(roleId: string) {

--- a/src/components/todo/TodoKanbanView.vue
+++ b/src/components/todo/TodoKanbanView.vue
@@ -191,8 +191,12 @@ const itemsByStatus = computed(() => {
   for (const item of props.filteredItems) {
     const columnId = item.status ?? props.columns[0]?.id;
     if (!columnId) continue;
-    if (!map.has(columnId)) map.set(columnId, []);
-    map.get(columnId)!.push(item);
+    let bucket = map.get(columnId);
+    if (!bucket) {
+      bucket = [];
+      map.set(columnId, bucket);
+    }
+    bucket.push(item);
   }
   for (const list of map.values()) {
     list.sort((left, right) => (left.order ?? 0) - (right.order ?? 0));

--- a/src/composables/usePubSub.ts
+++ b/src/composables/usePubSub.ts
@@ -50,8 +50,12 @@ function maybeDisconnect(): void {
 
 export function usePubSub() {
   function subscribe(channel: string, callback: Callback): Unsubscribe {
-    if (!listeners.has(channel)) listeners.set(channel, new Set());
-    listeners.get(channel)!.add(callback);
+    let entry = listeners.get(channel);
+    if (!entry) {
+      entry = new Set();
+      listeners.set(channel, entry);
+    }
+    entry.add(callback);
 
     const sock = connect();
     if (sock.connected) sock.emit("subscribe", channel);


### PR DESCRIPTION
## Summary

22 \`x!\` assertions removed in production code where the original was a **TS-narrowing limitation, not a real null-safety hole**. Behavior is preserved or strictly more defensive at every site.

## Items to Confirm / Review

Per-site rationale documented in the commit body. Six patterns:

1. **Map.get after has/set guard** — refactor to a captured reference (eliminates the redundant \`has\`+\`get\` round trip too).
2. **Closure narrowing of let-bound variable** — capture the narrowed value into a \`const\` outside the closure.
3. **Round-trip through Map** — return the fresh reference directly when the get() is just retrieving what was just set().
4. **Array indexing after \`length\` check** — \`const [head] = arr\`.
5. **Optional property after upstream guard** — add the missing assertion at the use site (\`if (!x) throw new Error(\"unreachable: ...\")\` with the invariant in the message).
6. **\`Number.isFinite(rawLimit) && rawLimit! > 0\`** — re-shape the guard so TS narrows the binding instead.

Failure modes:
- For sites where I added a defensive \`if (!x) throw\`, the failure mode changes from \`Cannot read properties of undefined\` to \`Error: <invariant description>\`. Strictly more informative; the throwing point is the same.
- For sites where I refactored the data flow (e.g. captured reference, returning the just-set object), the runtime is unchanged.

## Out of scope

- **packages/bridges/* (22 sites)** — env-var \`process.env.X!\` after \`process.exit(1)\` validation. Each bridge needs the same \`requireEnv\` helper refactor; splittable per-bridge follow-up. Skipped here to keep the diff small + uniform.
- \`no-dynamic-delete\` (32), \`complexity\` (14), \`vue/no-v-html\` (6), \`class-methods-use-this\` (2), \`max-params\` (1) — separate triage.

## User Prompt

> 影響少なく直せるlint warnの解消

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — 93 → 71 warnings
- [x] \`yarn build\` — clean
- [x] \`yarn test\` — 3414 / 3414 passing
- [x] \`yarn test:e2e\` — 369 / 369 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)