### PR TITLE
feat(image): browser onerror self-repair (stage 3)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -276,6 +276,7 @@ import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
 import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
+import { useGlobalImageErrorRepair } from "./composables/useImageErrorRepair";
 import { useMergedSessions } from "./composables/useMergedSessions";
 import { useLayoutMode } from "./composables/useLayoutMode";
 import { useSidePanelVisible } from "./composables/useSidePanelVisible";
@@ -454,6 +455,7 @@ const { mergedSessions, tabSessions } = useMergedSessions({
 // very same tick as `isRunning` flips, without waiting for the next
 // /api/sessions refetch.
 useFaviconState({ isRunning, sessions: mergedSessions, sessionsUnreadCount: unreadCount, cpuLoadRatio });
+useGlobalImageErrorRepair();
 
 const sessionSidebarRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);

--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -22,18 +22,23 @@ document.addEventListener("error", function (event) {
   var target = event.target;
   if (!target || target.tagName !== "IMG") return;
   if (target.dataset.imageRepairTried) return;
-  target.dataset.imageRepairTried = "1";
   var match = String(target.src).match(/artifacts\\/images\\/.+/);
   if (!match) return;
+  target.dataset.imageRepairTried = "1";
   target.src = "/" + match[0];
 }, true);
 `.trim();
 
 export function repairImageSrc(img: HTMLImageElement): boolean {
   if (img.dataset.imageRepairTried) return false;
-  img.dataset.imageRepairTried = "1";
+  // Set the one-shot marker only AFTER confirming the URL matches the
+  // repair pattern. Otherwise an unrelated 404 (different domain, no
+  // artifacts/images segment) would pin the marker and silently block
+  // any future repair attempt on the same DOM element if the src is
+  // later replaced with a repairable one.
   const match = img.src.match(IMAGE_REPAIR_PATTERN);
   if (!match) return false;
+  img.dataset.imageRepairTried = "1";
   img.src = `/${match[0]}`;
   return true;
 }

--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -1,0 +1,60 @@
+import { onMounted, onBeforeUnmount } from "vue";
+
+// All Gemini / canvas / image-edit output lives at
+// `artifacts/images/YYYY/MM/<id>.png` (see server/utils/files/image-store.ts).
+// If a rendered <img>'s src happens to embed that segment somewhere
+// (e.g. an LLM emitted `<img src="../wrong/prefix/artifacts/images/foo.png">`
+// or the rewriter missed a single-quoted attribute), trim everything before
+// the pattern and retry as `/artifacts/images/<rest>` — the static mount
+// added in stage 1 (server/index.ts) will then serve the file directly.
+//
+// Stage 3 of the image-path-routing redesign — see
+// plans/feat-image-path-routing.md and
+// docs/discussion-image-path-routing.md.
+export const IMAGE_REPAIR_PATTERN = /artifacts\/images\/.+/;
+
+// Inline script body that the presentHtml plugin injects into its
+// iframe srcdoc. Same logic as `repairImageSrc` below; kept as a
+// string so it can be embedded into the rendered HTML and run in the
+// sandboxed iframe. Update both together if the repair rule changes.
+export const IMAGE_REPAIR_INLINE_SCRIPT = `
+document.addEventListener("error", function (event) {
+  var target = event.target;
+  if (!target || target.tagName !== "IMG") return;
+  if (target.dataset.imageRepairTried) return;
+  target.dataset.imageRepairTried = "1";
+  var match = String(target.src).match(/artifacts\\/images\\/.+/);
+  if (!match) return;
+  target.src = "/" + match[0];
+}, true);
+`.trim();
+
+export function repairImageSrc(img: HTMLImageElement): boolean {
+  if (img.dataset.imageRepairTried) return false;
+  img.dataset.imageRepairTried = "1";
+  const match = img.src.match(IMAGE_REPAIR_PATTERN);
+  if (!match) return false;
+  img.src = `/${match[0]}`;
+  return true;
+}
+
+// Attach a document-level capture-phase error listener so any <img>
+// 404 in the app shell (wiki / markdown / news / Files preview etc)
+// gets one repair attempt. Capture phase is required because <img>
+// error events don't bubble. The repair is a no-op for src values
+// that don't match the artifacts/images pattern, so attaching at
+// document scope is safe — it never touches non-image-bearing UI.
+export function useGlobalImageErrorRepair(): void {
+  function onError(event: Event): void {
+    const target = event.target;
+    if (target instanceof HTMLImageElement) repairImageSrc(target);
+  }
+
+  onMounted(() => {
+    document.addEventListener("error", onError, { capture: true });
+  });
+
+  onBeforeUnmount(() => {
+    document.removeEventListener("error", onError, { capture: true });
+  });
+}

--- a/src/plugins/presentHtml/View.vue
+++ b/src/plugins/presentHtml/View.vue
@@ -29,6 +29,7 @@ import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { PresentHtmlData } from "./index";
 import { rewriteHtmlImageRefs } from "../../utils/image/rewriteHtmlImageRefs";
+import { IMAGE_REPAIR_INLINE_SCRIPT } from "../../composables/useImageErrorRepair";
 
 const { t } = useI18n();
 
@@ -42,13 +43,26 @@ const PRINT_STYLE = `<style>@media print {
   @page { margin: 10mm; }
 }</style>`;
 
+// Inline repair script: a 404 on a rewritten <img> inside the iframe
+// retries against /artifacts/images/<rest> — same rule as
+// useImageErrorRepair on the parent doc.
+//
+// The closing tag uses a Unicode-escape for the slash so the literal
+// 9-char sequence does not appear in the source bytes — otherwise the
+// Vue SFC HTML parser would treat it as the end of THIS file's
+// <script setup> block.
+const REPAIR_SCRIPT = `<script>${IMAGE_REPAIR_INLINE_SCRIPT}<\u002Fscript>`;
+
 const data = computed(() => props.selectedResult.data);
 // LLM-generated HTML often emits <img src="/artifacts/images/…"> using
 // the web convention where `/` is the site root. Inside the iframe
 // srcdoc that resolves to the SPA origin, which does not serve
 // /artifacts. Route those through the workspace file server.
 const rawHtml = computed(() => rewriteHtmlImageRefs(data.value?.html ?? ""));
-const html = computed(() => (rawHtml.value.includes("</head>") ? rawHtml.value.replace("</head>", `${PRINT_STYLE}</head>`) : `${PRINT_STYLE}${rawHtml.value}`));
+const headInjection = `${PRINT_STYLE}${REPAIR_SCRIPT}`;
+const html = computed(() =>
+  rawHtml.value.includes("</head>") ? rawHtml.value.replace("</head>", `${headInjection}</head>`) : `${headInjection}${rawHtml.value}`,
+);
 const title = computed(() => data.value?.title);
 
 const sourceOpen = ref(false);

--- a/test/composables/test_useImageErrorRepair.ts
+++ b/test/composables/test_useImageErrorRepair.ts
@@ -35,7 +35,20 @@ describe("repairImageSrc", () => {
     const ok = repairImageSrc(img as unknown as HTMLImageElement);
     assert.equal(ok, false);
     assert.equal(img.src, "/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png");
-    assert.equal(img.dataset.imageRepairTried, "1");
+    // The marker MUST NOT be set on a no-match: otherwise a later
+    // repairable src on the same DOM element would be silently blocked.
+    assert.equal(img.dataset.imageRepairTried, undefined);
+  });
+
+  it("a no-match call doesn't poison a later repairable src on the same element", () => {
+    const img = makeImg("https://external.example.com/some.png");
+    const first = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(first, false);
+    // Same DOM node, src now matches.
+    img.src = "/wrong/prefix/artifacts/images/foo.png";
+    const second = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(second, true);
+    assert.equal(img.src, "/artifacts/images/foo.png");
   });
 
   it("does not retry a second time once tried", () => {

--- a/test/composables/test_useImageErrorRepair.ts
+++ b/test/composables/test_useImageErrorRepair.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { repairImageSrc, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_INLINE_SCRIPT } from "../../src/composables/useImageErrorRepair.js";
+
+// A tiny stand-in for HTMLImageElement — only the attributes the
+// repair function reads/writes. Lets us exercise the pure function
+// without a DOM.
+interface FakeImg {
+  src: string;
+  dataset: { imageRepairTried?: string };
+}
+
+function makeImg(src: string): FakeImg {
+  return { src, dataset: {} };
+}
+
+describe("repairImageSrc", () => {
+  it("rewrites a wrong-prefix path that contains artifacts/images/<rest>", () => {
+    const img = makeImg("http://localhost:5173/wrong/prefix/artifacts/images/2026/04/foo.png");
+    const ok = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(ok, true);
+    assert.equal(img.src, "/artifacts/images/2026/04/foo.png");
+    assert.equal(img.dataset.imageRepairTried, "1");
+  });
+
+  it("rewrites a relative path that contains the pattern", () => {
+    const img = makeImg("../../../artifacts/images/2026/04/foo.png");
+    const ok = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(ok, true);
+    assert.equal(img.src, "/artifacts/images/2026/04/foo.png");
+  });
+
+  it("leaves a src that doesn't contain the pattern alone", () => {
+    const img = makeImg("/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png");
+    const ok = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(ok, false);
+    assert.equal(img.src, "/api/files/raw?path=data%2Fwiki%2Fsources%2Ffoo.png");
+    assert.equal(img.dataset.imageRepairTried, "1");
+  });
+
+  it("does not retry a second time once tried", () => {
+    const img = makeImg("/wrong/artifacts/images/foo.png");
+    const first = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(first, true);
+    assert.equal(img.src, "/artifacts/images/foo.png");
+    // Simulate a second 404 — the flag should block the retry.
+    img.src = "/still/wrong/artifacts/images/foo.png";
+    const second = repairImageSrc(img as unknown as HTMLImageElement);
+    assert.equal(second, false);
+    assert.equal(img.src, "/still/wrong/artifacts/images/foo.png");
+  });
+
+  it("matches the inline script's regex literally", () => {
+    // Both the TS function and the iframe-inlined script use the same
+    // pattern. Drift would silently break presentHtml's repair.
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /artifacts\\\/images\\\/\.\+/);
+    assert.equal(IMAGE_REPAIR_PATTERN.source, "artifacts\\/images\\/.+");
+  });
+});


### PR DESCRIPTION
## Summary

Stage 3 of the image-path-routing redesign (plans/feat-image-path-routing.md). When an `<img>` 404s and its `src` contains the substring `artifacts/images/<rest>` anywhere, trim everything before the pattern and retry as `/artifacts/images/<rest>` — the static mount from Stage 1 (#969) then serves the file directly.

## Items to Confirm / Review

- [ ] **Three repair scenarios** are intentional:
  1. Past wiki/HTML output that the rewriter missed (single-quoted `src`, raw `<img>` in markdown — §8 audit gaps).
  2. LLM-emitted wrong-prefix like `/some/wrong/prefix/artifacts/images/foo.png` → repaired to `/artifacts/images/foo.png`.
  3. Relative paths like `../../../artifacts/images/foo.png` resolved against the page URL → repaired.
- [ ] **Loop guard**: `data-image-repair-tried` marker prevents a second retry. A still-broken URL after repair settles as a regular 404 (no infinite onerror loop).
- [ ] **Document-level capture listener**: `<img>` errors don't bubble, so capture phase is required. The repair function is a pure no-op when the pattern doesn't match — safe to attach at document scope without risking app-shell UI images.
- [ ] **Iframe srcdoc injection**: presentHtml prepends an inline `<script>` to the iframe `<head>` that runs the same repair logic in the sandbox. The closing `</script>` literal is sliced with a Unicode-escape so the source bytes don't terminate this file's own `<script setup>` block at HTML-parse time.
- [ ] **Tests**: `test/composables/test_useImageErrorRepair.ts` (5/5 pass) covers happy path, no-match no-op, retry guard, and confirms the inline-script regex matches the TS function's regex.

## What changes

### `src/composables/useImageErrorRepair.ts` (new)

\`\`\`ts
export function repairImageSrc(img: HTMLImageElement): boolean {
  if (img.dataset.imageRepairTried) return false;
  img.dataset.imageRepairTried = "1";
  const match = img.src.match(IMAGE_REPAIR_PATTERN);
  if (!match) return false;
  img.src = \`/\${match[0]}\`;
  return true;
}

export function useGlobalImageErrorRepair(): void { /* document-level capture listener */ }

export const IMAGE_REPAIR_INLINE_SCRIPT = \`/* same logic as a string */\`;
\`\`\`

### `src/App.vue`

\`\`\`ts
import { useGlobalImageErrorRepair } from "./composables/useImageErrorRepair";
// ...
useGlobalImageErrorRepair();
\`\`\`

### `src/plugins/presentHtml/View.vue`

iframe srcdoc gets an inline repair `<script>` injected before `</head>` (Unicode-escaped slash to avoid prematurely closing the Vue SFC's own script block).

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint --no-cache` — 0 errors
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [x] `yarn test` (project-side: tsx --test on test/composables/test_useImageErrorRepair.ts) — 5/5 pass
- [ ] **Manual**: load a wiki page that already renders correctly → no regression
- [ ] **Manual**: test page with intentionally-broken src like `/wrong/artifacts/images/foo.png` → image loads after repair (no double-fetch loop in Network tab)
- [ ] **Manual**: presentHtml iframe with broken-prefix `<img>` inside → image loads after repair

## Refs

- 設計: `docs/discussion-image-path-routing.md`
- 現状調査: `docs/image-path-routing.md`
- 計画: `plans/feat-image-path-routing.md`
- Stage 1: #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)