### PR TITLE
chore(lint): graduate four zero-violation rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -234,11 +234,11 @@ export default [
       "import/no-mutable-exports": "error",
       "import/no-self-import": "error",
       "import/no-useless-path-segments": "error",
-      "consistent-return": "warn",
+      "consistent-return": "error",
       "class-methods-use-this": "error",
-      "prefer-destructuring": "warn",
+      "prefer-destructuring": "error",
       complexity: ["warn", { max: 15 }],
-      "max-depth": ["warn", { max: 4 }],
+      "max-depth": ["error", { max: 4 }],
       "max-params": ["error", { max: 6 }],
       quotes: "off",
       "no-shadow": "error",
@@ -360,10 +360,11 @@ export default [
       // (`src/plugins/<name>/View.vue`). The Vue-recommended rule
       // against single-word names fights that on purpose.
       "vue/multi-word-component-names": "off",
-      // `wiki/View.vue` uses `v-html` intentionally to render
-      // sanitised markdown. Warn so the justified usage doesn't
-      // block CI — audit per-use at review time.
-      "vue/no-v-html": "warn",
+      // Legitimate v-html usages (sanitised markdown / app-owned
+      // HTML) carry per-line eslint-disable comments with a
+      // rationale. Promote to error so any new unjustified usage
+      // fails CI.
+      "vue/no-v-html": "error",
       "vue/no-useless-mustaches": "error",
       "vue/no-useless-v-bind": "error",
       "vue/prefer-true-attribute-shorthand": "error",


### PR DESCRIPTION
## Summary

Pure eslint config change. Four rules graduated from \`warn → error\` after the recent cleanup pass cleared all open violations:

- \`consistent-return\` — 0 violations (cleared by #959 + #965)
- \`prefer-destructuring\` — 0 violations (#959 + #965)
- \`max-depth\` — 0 violations (already clean)
- \`vue/no-v-html\` — 0 violations; the three legitimate usages (spreadsheet / markdown / manageSkills) carry per-line \`eslint-disable\` comments with rationale, so any *new* unjustified \`v-html\` now fails CI.

## Items to Confirm / Review

- No code changes — only \`eslint.config.mjs\` rule severity edits.
- Verified \`yarn lint\` still reports 0 errors. Total count unchanged at 68 warnings — those are the remaining \`no-dynamic-delete\` (32), \`no-non-null-assertion\` (22), \`complexity\` (14) categories which need real refactoring.

## User Prompt

> prefer-destructuringはいけそう？

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — 0 errors, 68 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)