### PR TITLE
fix(lint): prefer-destructuring in useGlobalImageErrorRepair

### DIFF
--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -51,7 +51,7 @@ export function repairImageSrc(img: HTMLImageElement): boolean {
 // document scope is safe — it never touches non-image-bearing UI.
 export function useGlobalImageErrorRepair(): void {
   function onError(event: Event): void {
-    const target = event.target;
+    const { target } = event;
     if (target instanceof HTMLImageElement) repairImageSrc(target);
   }
 


### PR DESCRIPTION
## Summary

Fix the single lint error blocking CI on main ([run 25100204205](https://github.com/receptron/mulmoclaude/actions/runs/25100204205/job/73547133272)):

\`\`\`
src/composables/useImageErrorRepair.ts
  54:11  error  Use object destructuring  prefer-destructuring
\`\`\`

One-line mechanical change: `const target = event.target` → `const { target } = event`.

## Items to Confirm / Review

- Reproduced locally on `main@ab6a2f90` before the fix; lint clean (0 errors, 68 warnings) after.
- Behaviour unchanged — destructuring is purely syntactic.
- `yarn typecheck` still green.
- No `yarn.lock` changes included — `yarn install` produced unrelated drift that was reverted, so this PR carries the one source-line edit only.