### PR TITLE
fix(smoke): keep tarball in place so CI's upload-artifact step finds it

### DIFF
--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -267,15 +267,24 @@ async function killGracefully(child) {
 
 // End-to-end smoke. Returns `{ ok, ... }` — never throws unless the
 // caller passes a malformed `root`. Cleanup is best-effort: the
-// tarball, the work dir, and the process are all tidied up in a
-// finally block before returning.
+// work dir and the child process are tidied up in a finally block
+// before returning.
 //
-// Cleanup policy: on **success** we remove the tarball and, if we
-// allocated the work dir ourselves, remove it too — keeping the
-// workspace tidy across repeated local runs. On **failure** we
-// leave both in place so investigators can inspect the installed
-// tree and the packed artifact. A caller-provided `workDir` is
-// always left alone (CI typically uploads it as an artifact).
+// Cleanup policy: the **work dir** under `os.tmpdir()` is removed
+// on success when we allocated it ourselves (keeps repeated local
+// runs tidy). On failure we leave it so investigators can inspect
+// the installed tree. A caller-provided `workDir` is always left
+// alone (CI typically uploads it as an artifact).
+//
+// The **tarball** at `packages/mulmoclaude/mulmoclaude-<X.Y.Z>.tgz`
+// is intentionally left in place on both success and failure:
+//   - CI's `upload-artifact` step picks it up as a smoke-verified
+//     downloadable for release-prep validation.
+//   - `packTarball()` (run at the start of every smoke) already
+//     deletes any stale `mulmoclaude-*.tgz` first, so leftover
+//     tarballs don't pile up across runs.
+//   - `*.tgz` is gitignored, so local leftovers never reach a
+//     commit.
 export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, bootTimeoutMs, packTimeoutMs, installTimeoutMs, port } = {}) {
   const weAllocatedWorkDir = !workDir;
   const runDir = workDir ?? (await mkdtemp(path.join(os.tmpdir(), "mc-smoke-")));
@@ -321,13 +330,8 @@ export async function runTarballSmoke({ root = process.cwd(), workDir, logFile, 
     };
   } finally {
     if (child) await killGracefully(child);
-    if (succeeded) {
-      if (tarballPath) {
-        await rm(tarballPath, { force: true }).catch(() => {});
-      }
-      if (weAllocatedWorkDir) {
-        await rm(runDir, { recursive: true, force: true }).catch(() => {});
-      }
+    if (succeeded && weAllocatedWorkDir) {
+      await rm(runDir, { recursive: true, force: true }).catch(() => {});
     }
   }
 }


### PR DESCRIPTION
## Summary

The publish-smoke workflow has an \`actions/upload-artifact@v4\` step that's supposed to publish the smoke-verified tarball as a downloadable, but every successful run reports \`No files were found with the provided path: packages/mulmoclaude/mulmoclaude-*.tgz\` and no artifact appears.

Cause: \`runTarballSmoke()\` in \`scripts/mulmoclaude/tarball.mjs\` deleted the tarball in its \`finally\` block on success — directly contradicting the workflow comment that says it's \"left in place after a successful HTTP 200 probe.\"

Fix: drop the success-time \`rm(tarballPath)\`. Two safeguards make this safe:

1. \`packTarball()\` (run at the start of every smoke) already deletes any stale \`mulmoclaude-*.tgz\` first → repeated runs don't accumulate tarballs.
2. \`*.tgz\` is gitignored → local leftovers never reach a commit.

The temp work-dir cleanup under \`os.tmpdir()\` is unchanged: it can grow large (full installed tree) and there's no benefit to keeping it past a successful run.

## Items to Confirm / Review

- **Cleanup policy comment rewritten** to spell out which path persists (tarball) vs. which is removed (temp work dir). Worth a read-through to make sure it matches the new \`finally\` block.
- **No new tests**: the existing \`test/scripts/mulmoclaude/test_tarball.ts\` covers only the pure helpers (port allocator, pollHttp, package-json builder). The cleanup behavior touches real fs + child processes, which the test suite intentionally avoids — verifying it locally and on the next CI run is the correct level of coverage. (Open to adding a smoke-style integration test if the reviewer wants it.)
- **CI verification**: the failing run that prompted this is https://github.com/receptron/mulmoclaude/actions/runs/25100204202 — once this PR's smoke job runs, the artifact should appear under \"Artifacts → mulmoclaude-tarball\" on the run page.

## User Prompt

> https://github.com/receptron/mulmoclaude/actions/runs/25100204202/job/73547133578　このsmoke testのパッケージ、artifactで保存して。

## Verification

- \`yarn lint\`: 0 errors, 68 warnings
- \`tsx --test test/scripts/mulmoclaude/test_tarball.ts\`: 11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated smoke-run cleanup behavior to retain build artifacts on both successful and failed runs.
  * Refined cleanup logic to selectively remove only temporary work directories on successful execution.
  * Updated related documentation comments to reflect new retention policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->