### PR TITLE
fix(files): serve sibling images from /artifacts/html mount

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -190,8 +190,18 @@ app.use(
 // `about:srcdoc` as their base URL, which breaks every relative ref.
 // See plans/feat-files-html-preview-relative-paths.md.
 //
+// Allowlist covers `.html` / `.htm` plus common image extensions so
+// HTML files that reference sibling images (e.g. a shared logo placed
+// alongside a batch of LLM-generated pages) can resolve those refs
+// against the file's URL — same browser-equivalent behavior the user
+// gets when opening the file directly from disk. Non-image / non-html
+// requests are still rejected. CSS / JS are intentionally NOT in the
+// list: `'self'` is absent from `script-src` / `style-src` in the CSP
+// (`previewCsp.ts`) so allowing those extensions would only delivery-
+// vector for blocked resources.
+//
 // Same three-layer guard as `/artifacts/images`:
-//  1. `.html` / `.htm` extension allowlist.
+//  1. extension allowlist (`.html` / `.htm` plus image types).
 //  2. `resolveWithinRoot` symlink-aware traversal check.
 //  3. `dotfiles: deny` + `fallthrough: false` on `express.static`.
 //
@@ -203,10 +213,13 @@ app.use(
 // CSP delivered via HTTP header instead of injecting a `<meta>` tag —
 // keeps the served file pristine, and `'self'` finally matches the
 // server origin (which is what allows `<img src="../images/...">` to
-// reach `/artifacts/images/...`). Sandbox stays `allow-scripts` only,
-// so the iframe document is still opaque-origin and cannot read the
-// parent's cookies / localStorage / DOM.
-const HTML_EXT_RE = /\.html?$/i;
+// reach `/artifacts/images/...`). Header is set for HTML responses
+// only; image responses don't need it (CSP doesn't apply to image
+// MIME types loaded as subresources). Sandbox stays `allow-scripts`
+// only, so the iframe document is still opaque-origin and cannot
+// read the parent's cookies / localStorage / DOM.
+const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico)$/i;
+const HTML_DOCUMENT_EXT_RE = /\.html?$/i;
 let htmlsDirReal: string | null = null;
 async function getHtmlsDirReal(): Promise<string | null> {
   if (htmlsDirReal) return htmlsDirReal;
@@ -220,7 +233,7 @@ async function getHtmlsDirReal(): Promise<string | null> {
 app.use(
   "/artifacts/html",
   async (req, res, next) => {
-    if (!HTML_EXT_RE.test(req.path)) {
+    if (!HTML_PREVIEW_EXT_RE.test(req.path)) {
       res.status(404).end();
       return;
     }
@@ -240,7 +253,9 @@ app.use(
       res.status(404).end();
       return;
     }
-    res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp());
+    if (HTML_DOCUMENT_EXT_RE.test(req.path)) {
+      res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp());
+    }
     res.setHeader("X-Content-Type-Options", "nosniff");
     next();
   },


### PR DESCRIPTION
## Summary

PR #980 で導入した `/artifacts/html` static mount は `.html` / `.htm` 拡張子のみを許可していた。このため、HTML ファイルが **同じディレクトリに置かれた画像を参照する**ケース(共有マスコット画像を `artifacts/html/<sub>/` に置いて複数の LLM 出力 HTML から `<img src="mulmo_logo.png">` で参照する、というユーザ運用)で、ブラウザで直接開けば表示できる HTML が Files ビューだけ画像が出ない、という挙動になっていた。

allowlist に画像拡張子を追加して、ブラウザで直接開いた時と同じ resolved 結果になるようにする。

## 再現

`~/mulmoclaude/artifacts/html/2026/04/<file>.html` 内に `<img alt="..." src="mulmo_logo.png">`、同ディレクトリに `mulmo_logo.png` が置かれている状態:

- ブラウザで直接 `file://...` で開く → ✅ 表示される
- Files ビューで開く → ❌ 画像が壊れアイコンになる

devtools の Network には `GET /artifacts/html/2026/04/mulmo_logo.png` が **404** で出ている — mount の拡張子フィルタに弾かれている。

## 変更内容

`server/index.ts`:

```ts
// Before
const HTML_EXT_RE = /\.html?$/i;

// After
const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico)$/i;
const HTML_DOCUMENT_EXT_RE = /\.html?$/i;  // CSPヘッダはHTML応答のみに
```

加えて CSP HTTP ヘッダを **HTML 応答のみ** に絞る(画像応答に CSP を付けても無害だが、ポリシーは document に対してのみ意味がある)。

## なぜ `.css` / `.js` を入れなかったか

CSP (`src/utils/html/previewCsp.ts:30-31`) の `script-src` / `style-src` には `'self'` を含めていない:

```
script-src 'unsafe-inline' <CDN allowlist>
style-src  'unsafe-inline' <CDN allowlist>
```

つまり同 origin からの `<script>` / `<link rel=stylesheet>` のロードは **どのみち CSP がブロックする**。mount の allowlist に `.css` / `.js` を入れても、配信できるだけで使えない。逆に攻撃面(LLM が同 origin に `.js` ファイルを置けるパス)を増やす効果しかないので、画像のみに留める。

CDN allowlist 経由(jsdelivr / unpkg / cdnjs / Google Fonts)で外部リソースを引く既存パターンは引き続き機能する。

## 三段ガードは維持

`/artifacts/images` mount (PR #969) と同じ三段ガード:

1. **拡張子 allowlist** — 今回広げた範囲のみ通過
2. **`resolveWithinRoot` symlink チェック** — シンボリックリンクで mount root の外を狙う攻撃を阻止
3. **`dotfiles: deny` + `fallthrough: false`** + `express.static` 内蔵の `..` normalize — path-traversal 阻止

bearer auth 免除 / `requireSameOrigin` 適用 / loopback-only listener も継続。

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors(68 warnings は全て pre-existing baseline)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [x] `yarn test` — 全 workspace pass
- [ ] **手動**(reviewer): `~/mulmoclaude/artifacts/html/<sub>/<file>.html` で sibling 画像参照(`<img src="logo.png">`)している HTML を Files ビューで開く → 画像が表示される
- [ ] **手動**(reviewer): Network タブで HTML 応答に CSP ヘッダ、画像応答に CSP ヘッダ無し、を確認
- [ ] **手動**(reviewer): `.css` / `.js` を `artifacts/html/` 配下に置いて URL 直叩きすると 404 が返ること(allowlist が効いている確認)

## Out of scope

- LLM プロンプト変更 — Stage 2 (#972) は引き続き「画像は `artifacts/images/` に置け」と指示する。本変更は **既存ファイル / ユーザ運用パターンへの後方対応**であって、推奨スタイルを変えるものではない
- `/artifacts/html` mount の `.css` / `.js` 配信 — CSP の `script-src` / `style-src` に `'self'` を加えるか、別途設計が必要。本 PR では触らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)