### PR TITLE
feat(plugins): include artifact path in presentDocument and generateImage tool results

### DIFF
--- a/server/api/routes/image.ts
+++ b/server/api/routes/image.ts
@@ -62,7 +62,7 @@ async function respondWithImage(
   const imagePath = await saveImage(imageData);
   const label = kind === "generation" ? "Generated" : "Edited";
   res.json({
-    message: `image ${kind} succeeded`,
+    message: `Saved image to ${imagePath}`,
     instructions: `Acknowledge that the image was ${kind === "generation" ? "generated" : "edited"} and has been presented to the user.`,
     title: `${label} Image`,
     data: { imageData: imagePath, prompt },

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -66,6 +66,7 @@ interface PresentDocumentBody {
 
 interface PresentDocumentSuccess {
   message: string;
+  instructions: string;
   title: string;
   data: { markdown: string; filenamePrefix: string };
 }
@@ -92,7 +93,8 @@ router.post(
     const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
     log.info("plugins", "presentDocument: ok", { markdownPath, bytes: filledMarkdown.length });
     res.json({
-      message: `Document "${title}" is ready.`,
+      message: `Saved markdown to ${markdownPath}`,
+      instructions: "Acknowledge that the document has been presented to the user.",
       title,
       data: { markdown: markdownPath, filenamePrefix },
     });


### PR DESCRIPTION
## Summary
- `presentDocument` now returns `message: \"Saved markdown to <path>\"` plus an `instructions` line, matching the existing `presentHtml` shape.
- `generateImage` / `editImage` change the message from the opaque `\"image generation succeeded\"` to `\"Saved image to <path>\"`.
- The MCP bridge joins `message + instructions` into the tool-call response, so the agent now sees the saved workspace-relative path instead of a generic acknowledgement string. Frontend behavior is unchanged — `data.markdown` / `data.imageData` already carried the path.

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
- [x] `yarn test` — 29/29 pass
- [ ] Manual: in a session with a General role, ask Claude to generate an image and to write a document; confirm the agent's follow-up text references the saved path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Image operations now include specific file paths in success responses, replacing generic confirmation messages for better file tracking
  * Document generation operations now provide the exact markdown file location and additional guidance in responses for clearer confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->