### PR TITLE
chore(lint): remove non-null-assertions from bridges/ env reads

### DIFF
--- a/packages/bridges/chatwork/src/index.ts
+++ b/packages/bridges/chatwork/src/index.ts
@@ -31,11 +31,15 @@ const API_BASE = "https://api.chatwork.com/v2";
 const MAX_MSG_LEN = 40_000; // Chatwork's practical limit is generous; chunk conservatively
 const FETCH_TIMEOUT_MS = 15_000;
 
-const apiToken = process.env.CHATWORK_API_TOKEN;
-if (!apiToken) {
-  console.error("CHATWORK_API_TOKEN is required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { apiToken: string } {
+  const apiToken = process.env.CHATWORK_API_TOKEN;
+  if (!apiToken) {
+    console.error("CHATWORK_API_TOKEN is required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { apiToken };
 }
+const { apiToken } = readRequiredEnv();
 
 const allowedRooms = new Set(
   (process.env.CHATWORK_ALLOWED_ROOMS ?? "")
@@ -89,7 +93,7 @@ function parseRetryAfter(headerValue: string | null): number {
 
 async function cwFetch(method: "GET" | "POST" | "PUT", path: string, form?: Record<string, string>): Promise<unknown> {
   await waitForRateLimit();
-  const headers: Record<string, string> = { "X-ChatWorkToken": apiToken! };
+  const headers: Record<string, string> = { "X-ChatWorkToken": apiToken };
   let body: string | undefined;
   if (form) {
     headers["Content-Type"] = "application/x-www-form-urlencoded";

--- a/packages/bridges/email/src/index.ts
+++ b/packages/bridges/email/src/index.ts
@@ -30,21 +30,32 @@ const DEFAULT_POLL_SEC = 30;
 const RECONNECT_BASE_MS = 2_000;
 const RECONNECT_MAX_MS = 60_000;
 
-const imapHost = process.env.EMAIL_IMAP_HOST;
-const imapUser = process.env.EMAIL_IMAP_USER;
-const imapPass = process.env.EMAIL_IMAP_PASSWORD;
-const smtpHost = process.env.EMAIL_SMTP_HOST;
-const smtpUser = process.env.EMAIL_SMTP_USER;
-const smtpPass = process.env.EMAIL_SMTP_PASSWORD;
-const fromAddress = process.env.EMAIL_FROM;
-
-if (!imapHost || !imapUser || !imapPass || !smtpHost || !smtpUser || !smtpPass || !fromAddress) {
-  console.error(
-    "Required: EMAIL_IMAP_HOST, EMAIL_IMAP_USER, EMAIL_IMAP_PASSWORD, EMAIL_SMTP_HOST, EMAIL_SMTP_USER, EMAIL_SMTP_PASSWORD, EMAIL_FROM.\n" +
-      "See README for setup instructions.",
-  );
-  process.exit(1);
+function readRequiredEnv(): {
+  imapHost: string;
+  imapUser: string;
+  imapPass: string;
+  smtpHost: string;
+  smtpUser: string;
+  smtpPass: string;
+  fromAddress: string;
+} {
+  const imapHost = process.env.EMAIL_IMAP_HOST;
+  const imapUser = process.env.EMAIL_IMAP_USER;
+  const imapPass = process.env.EMAIL_IMAP_PASSWORD;
+  const smtpHost = process.env.EMAIL_SMTP_HOST;
+  const smtpUser = process.env.EMAIL_SMTP_USER;
+  const smtpPass = process.env.EMAIL_SMTP_PASSWORD;
+  const fromAddress = process.env.EMAIL_FROM;
+  if (!imapHost || !imapUser || !imapPass || !smtpHost || !smtpUser || !smtpPass || !fromAddress) {
+    console.error(
+      "Required: EMAIL_IMAP_HOST, EMAIL_IMAP_USER, EMAIL_IMAP_PASSWORD, EMAIL_SMTP_HOST, EMAIL_SMTP_USER, EMAIL_SMTP_PASSWORD, EMAIL_FROM.\n" +
+        "See README for setup instructions.",
+    );
+    process.exit(1);
+  }
+  return { imapHost, imapUser, imapPass, smtpHost, smtpUser, smtpPass, fromAddress };
 }
+const { imapHost, imapUser, imapPass, smtpHost, smtpUser, smtpPass, fromAddress } = readRequiredEnv();
 
 const imapPort = Number(process.env.EMAIL_IMAP_PORT) || 993;
 const imapTls = (process.env.EMAIL_IMAP_TLS ?? "true").toLowerCase() !== "false";
@@ -177,7 +188,7 @@ function parseIncoming(parsed: ParsedMail): Incoming | null {
 }
 
 async function handleIncoming(msg: Incoming): Promise<void> {
-  if (msg.senderAddress === fromAddress!.toLowerCase()) return;
+  if (msg.senderAddress === fromAddress.toLowerCase()) return;
   if (!allowAll && !allowedSenders.has(msg.senderAddress)) {
     console.log(`[email] denied from=${msg.senderAddress}`);
     return;
@@ -233,10 +244,10 @@ async function processUnread(client: ImapFlow): Promise<void> {
 
 function makeImapClient(): ImapFlow {
   return new ImapFlow({
-    host: imapHost!,
+    host: imapHost,
     port: imapPort,
     secure: imapTls,
-    auth: { user: imapUser!, pass: imapPass! },
+    auth: { user: imapUser, pass: imapPass },
     logger: false,
   });
 }

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -35,21 +35,23 @@ const JWT_TTL_SEC = 3_600;
 const TOKEN_REFRESH_MARGIN_SEC = 60;
 const PORT = Number(process.env.LINEWORKS_WEBHOOK_PORT) || 3013;
 
-const clientId = process.env.LINEWORKS_CLIENT_ID;
-const clientSecret = process.env.LINEWORKS_CLIENT_SECRET;
-const serviceAccount = process.env.LINEWORKS_SERVICE_ACCOUNT;
-const botId = process.env.LINEWORKS_BOT_ID;
-const botSecret = process.env.LINEWORKS_BOT_SECRET;
-
-const privateKeyPem = resolvePrivateKey();
-
-if (!clientId || !clientSecret || !serviceAccount || !botId || !botSecret || !privateKeyPem) {
-  console.error(
-    "Required: LINEWORKS_CLIENT_ID, LINEWORKS_CLIENT_SECRET, LINEWORKS_SERVICE_ACCOUNT, LINEWORKS_BOT_ID, LINEWORKS_BOT_SECRET, and one of LINEWORKS_PRIVATE_KEY / LINEWORKS_PRIVATE_KEY_FILE.\n" +
-      "See README for setup instructions.",
-  );
-  process.exit(1);
+function readRequiredEnv(): { clientId: string; clientSecret: string; serviceAccount: string; botId: string; botSecret: string; privateKeyPem: string } {
+  const clientId = process.env.LINEWORKS_CLIENT_ID;
+  const clientSecret = process.env.LINEWORKS_CLIENT_SECRET;
+  const serviceAccount = process.env.LINEWORKS_SERVICE_ACCOUNT;
+  const botId = process.env.LINEWORKS_BOT_ID;
+  const botSecret = process.env.LINEWORKS_BOT_SECRET;
+  const privateKeyPem = resolvePrivateKey();
+  if (!clientId || !clientSecret || !serviceAccount || !botId || !botSecret || !privateKeyPem) {
+    console.error(
+      "Required: LINEWORKS_CLIENT_ID, LINEWORKS_CLIENT_SECRET, LINEWORKS_SERVICE_ACCOUNT, LINEWORKS_BOT_ID, LINEWORKS_BOT_SECRET, and one of LINEWORKS_PRIVATE_KEY / LINEWORKS_PRIVATE_KEY_FILE.\n" +
+        "See README for setup instructions.",
+    );
+    process.exit(1);
+  }
+  return { clientId, clientSecret, serviceAccount, botId, botSecret, privateKeyPem };
 }
+const { clientId, clientSecret, serviceAccount, botId, botSecret, privateKeyPem } = readRequiredEnv();
 
 function resolvePrivateKey(): string | null {
   const inline = process.env.LINEWORKS_PRIVATE_KEY;
@@ -111,7 +113,7 @@ function buildAssertion(): string {
     }),
   );
   const data = `${header}.${payload}`;
-  const sig = crypto.createSign("RSA-SHA256").update(data).sign(privateKeyPem!);
+  const sig = crypto.createSign("RSA-SHA256").update(data).sign(privateKeyPem);
   return `${data}.${base64Url(sig)}`;
 }
 
@@ -120,8 +122,8 @@ async function fetchAccessToken(): Promise<TokenCache> {
   const form = new URLSearchParams({
     assertion,
     grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-    client_id: clientId!,
-    client_secret: clientSecret!,
+    client_id: clientId,
+    client_secret: clientSecret,
     scope: "bot bot.message",
   });
   const res = await fetch("https://auth.worksmobile.com/oauth2/v2.0/token", {
@@ -157,7 +159,7 @@ async function sendLineWorks(userId: string, text: string): Promise<void> {
   for (const chunk of chunks) {
     let res: Response;
     try {
-      res = await fetch(`https://www.worksapis.com/v1.0/bots/${encodeURIComponent(botId!)}/users/${encodeURIComponent(userId)}/messages`, {
+      res = await fetch(`https://www.worksapis.com/v1.0/bots/${encodeURIComponent(botId)}/users/${encodeURIComponent(userId)}/messages`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify({ content: { type: "text", text: chunk } }),
@@ -177,7 +179,7 @@ async function sendLineWorks(userId: string, text: string): Promise<void> {
 // ── Webhook signature verification ─────────────────────────────
 
 function verifySignature(rawBody: string, signature: string): boolean {
-  const expected = crypto.createHmac("sha256", botSecret!).update(rawBody).digest("base64");
+  const expected = crypto.createHmac("sha256", botSecret).update(rawBody).digest("base64");
   if (expected.length !== signature.length) return false;
   try {
     return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -21,12 +21,16 @@ import { createBridgeClient, chunkText } from "@mulmobridge/client";
 const TRANSPORT_ID = "line";
 const PORT = Number(process.env.LINE_BRIDGE_PORT) || 3002;
 
-const channelSecret = process.env.LINE_CHANNEL_SECRET;
-const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
-if (!channelSecret || !channelAccessToken) {
-  console.error("LINE_CHANNEL_SECRET and LINE_CHANNEL_ACCESS_TOKEN are required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { channelSecret: string; channelAccessToken: string } {
+  const channelSecret = process.env.LINE_CHANNEL_SECRET;
+  const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  if (!channelSecret || !channelAccessToken) {
+    console.error("LINE_CHANNEL_SECRET and LINE_CHANNEL_ACCESS_TOKEN are required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { channelSecret, channelAccessToken };
 }
+const { channelSecret, channelAccessToken } = readRequiredEnv();
 
 const client = createBridgeClient({ transportId: TRANSPORT_ID });
 
@@ -70,7 +74,7 @@ async function pushMessage(userId: string, text: string): Promise<void> {
 // ── Signature verification ──────────────────────────────────────
 
 function verifySignature(body: string, signature: string): boolean {
-  const expected = crypto.createHmac("SHA256", channelSecret!).update(body).digest("base64");
+  const expected = crypto.createHmac("SHA256", channelSecret).update(body).digest("base64");
   if (expected.length !== signature.length) return false;
   return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
 }

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -16,12 +16,16 @@ import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "mattermost";
 
-const mmUrl = process.env.MATTERMOST_URL;
-const botToken = process.env.MATTERMOST_BOT_TOKEN;
-if (!mmUrl || !botToken) {
-  console.error("MATTERMOST_URL and MATTERMOST_BOT_TOKEN are required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { mmUrl: string; botToken: string } {
+  const mmUrl = process.env.MATTERMOST_URL;
+  const botToken = process.env.MATTERMOST_BOT_TOKEN;
+  if (!mmUrl || !botToken) {
+    console.error("MATTERMOST_URL and MATTERMOST_BOT_TOKEN are required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { mmUrl, botToken };
 }
+const { mmUrl, botToken } = readRequiredEnv();
 
 const allowedChannels = new Set(
   (process.env.MATTERMOST_ALLOWED_CHANNELS ?? "")
@@ -78,7 +82,7 @@ async function postMessage(channelId: string, text: string): Promise<void> {
 // ── WebSocket event stream ──────────────────────────────────────
 
 function connectWebSocket(): void {
-  const wsUrl = mmUrl!.replace(/^http/, "ws").replace(/\/$/, "");
+  const wsUrl = mmUrl.replace(/^http/, "ws").replace(/\/$/, "");
   const webSocket = new WebSocket(`${wsUrl}/api/v4/websocket`, {
     headers: { Authorization: `Bearer ${botToken}` },
   });

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -19,13 +19,17 @@ import { createBridgeClient, chunkText } from "@mulmobridge/client";
 const TRANSPORT_ID = "messenger";
 const PORT = Number(process.env.MESSENGER_BRIDGE_PORT) || 3004;
 
-const pageAccessToken = process.env.MESSENGER_PAGE_ACCESS_TOKEN;
-const verifyToken = process.env.MESSENGER_VERIFY_TOKEN;
-const appSecret = process.env.MESSENGER_APP_SECRET;
-if (!pageAccessToken || !verifyToken || !appSecret) {
-  console.error("MESSENGER_PAGE_ACCESS_TOKEN, MESSENGER_VERIFY_TOKEN, and MESSENGER_APP_SECRET are required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { pageAccessToken: string; verifyToken: string; appSecret: string } {
+  const pageAccessToken = process.env.MESSENGER_PAGE_ACCESS_TOKEN;
+  const verifyToken = process.env.MESSENGER_VERIFY_TOKEN;
+  const appSecret = process.env.MESSENGER_APP_SECRET;
+  if (!pageAccessToken || !verifyToken || !appSecret) {
+    console.error("MESSENGER_PAGE_ACCESS_TOKEN, MESSENGER_VERIFY_TOKEN, and MESSENGER_APP_SECRET are required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { pageAccessToken, verifyToken, appSecret };
 }
+const { pageAccessToken, verifyToken, appSecret } = readRequiredEnv();
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
@@ -63,7 +67,7 @@ async function sendTextMessage(recipientId: string, text: string): Promise<void>
 // ── Signature verification ──────────────────────────────────────
 
 function verifySignature(rawBody: string, signature: string): boolean {
-  const expected = crypto.createHmac("sha256", appSecret!).update(rawBody).digest("hex");
+  const expected = crypto.createHmac("sha256", appSecret).update(rawBody).digest("hex");
   const provided = signature.replace("sha256=", "");
   if (expected.length !== provided.length) return false;
   return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(provided));

--- a/packages/bridges/rocketchat/src/index.ts
+++ b/packages/bridges/rocketchat/src/index.ts
@@ -23,13 +23,17 @@ const TRANSPORT_ID = "rocketchat";
 const MAX_MSG_LEN = 4_000;
 const FETCH_TIMEOUT_MS = 15_000;
 
-const baseUrl = (process.env.ROCKETCHAT_URL ?? "").replace(/\/$/, "");
-const userId = process.env.ROCKETCHAT_USER_ID;
-const authToken = process.env.ROCKETCHAT_TOKEN;
-if (!baseUrl || !userId || !authToken) {
-  console.error("ROCKETCHAT_URL, ROCKETCHAT_USER_ID, and ROCKETCHAT_TOKEN are required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { baseUrl: string; userId: string; authToken: string } {
+  const baseUrl = (process.env.ROCKETCHAT_URL ?? "").replace(/\/$/, "");
+  const userId = process.env.ROCKETCHAT_USER_ID;
+  const authToken = process.env.ROCKETCHAT_TOKEN;
+  if (!baseUrl || !userId || !authToken) {
+    console.error("ROCKETCHAT_URL, ROCKETCHAT_USER_ID, and ROCKETCHAT_TOKEN are required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { baseUrl, userId, authToken };
 }
+const { baseUrl, userId, authToken } = readRequiredEnv();
 
 const allowedUsers = new Set(
   (process.env.ROCKETCHAT_ALLOWED_USERS ?? "")
@@ -57,8 +61,8 @@ function isObj(value: unknown): value is JsonRecord {
 
 function authHeaders(): Record<string, string> {
   return {
-    "X-Auth-Token": authToken!,
-    "X-User-Id": userId!,
+    "X-Auth-Token": authToken,
+    "X-User-Id": userId,
   };
 }
 
@@ -236,11 +240,13 @@ async function pollLoop(): Promise<void> {
         // /im.history call. A pure `new Date().toISOString()` cursor
         // would place the `oldest` boundary at or after the first
         // message's ts, dropping it with `inclusive: "false"`.
-        if (!cursors.has(roomId)) {
-          cursors.set(roomId, new Date(Date.now() - pollIntervalSec * 1000).toISOString());
+        let cursor = cursors.get(roomId);
+        if (!cursor) {
+          cursor = new Date(Date.now() - pollIntervalSec * 1000).toISOString();
+          cursors.set(roomId, cursor);
         }
         try {
-          const newestIso = await pollRoom(roomId, cursors.get(roomId)!);
+          const newestIso = await pollRoom(roomId, cursor);
           cursors.set(roomId, newestIso);
         } catch (err) {
           console.error(`[rocketchat] pollRoom ${roomId} error: ${err}`);

--- a/packages/bridges/teams/src/index.ts
+++ b/packages/bridges/teams/src/index.ts
@@ -26,12 +26,16 @@ const TRANSPORT_ID = "teams";
 const MAX_TEAMS_TEXT = 28_000; // Teams message limit is 40k; leave headroom for formatting
 const PORT = Number(process.env.TEAMS_BRIDGE_PORT) || 3006;
 
-const appId = process.env.MICROSOFT_APP_ID;
-const appPassword = process.env.MICROSOFT_APP_PASSWORD;
-if (!appId || !appPassword) {
-  console.error("MICROSOFT_APP_ID and MICROSOFT_APP_PASSWORD are required.\nSee README for Azure Bot registration instructions.");
-  process.exit(1);
+function readRequiredEnv(): { appId: string; appPassword: string } {
+  const appId = process.env.MICROSOFT_APP_ID;
+  const appPassword = process.env.MICROSOFT_APP_PASSWORD;
+  if (!appId || !appPassword) {
+    console.error("MICROSOFT_APP_ID and MICROSOFT_APP_PASSWORD are required.\nSee README for Azure Bot registration instructions.");
+    process.exit(1);
+  }
+  return { appId, appPassword };
 }
+const { appId, appPassword } = readRequiredEnv();
 
 const allowedUsers = new Set(
   (process.env.TEAMS_ALLOWED_USERS ?? "")
@@ -74,7 +78,7 @@ mulmo.onPush((pushEvent) => {
     return;
   }
   adapter
-    .continueConversationAsync(appId!, ref, async (context) => {
+    .continueConversationAsync(appId, ref, async (context) => {
       await sendChunked(context, pushEvent.message);
     })
     .catch((err) => console.error(`[teams] push send failed: ${err}`));

--- a/packages/bridges/twilio-sms/src/index.ts
+++ b/packages/bridges/twilio-sms/src/index.ts
@@ -34,13 +34,17 @@ const MAX_SMS_LEN = 1_600; // Twilio concatenates segments up to 1600 chars
 const FETCH_TIMEOUT_MS = 15_000;
 const PORT = Number(process.env.TWILIO_WEBHOOK_PORT) || 3010;
 
-const accountSid = process.env.TWILIO_ACCOUNT_SID;
-const authToken = process.env.TWILIO_AUTH_TOKEN;
-const fromNumber = process.env.TWILIO_FROM_NUMBER;
-if (!accountSid || !authToken || !fromNumber) {
-  console.error("TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER are required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { accountSid: string; authToken: string; fromNumber: string } {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const fromNumber = process.env.TWILIO_FROM_NUMBER;
+  if (!accountSid || !authToken || !fromNumber) {
+    console.error("TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER are required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { accountSid, authToken, fromNumber };
 }
+const { accountSid, authToken, fromNumber } = readRequiredEnv();
 
 const publicUrl = process.env.TWILIO_PUBLIC_URL?.replace(/\/$/, "");
 const allowUnverified = process.env.TWILIO_ALLOW_UNVERIFIED === "1";
@@ -75,7 +79,7 @@ function expectedSignature(url: string, params: Record<string, string>): string 
   // Twilio: sort params by key, concat key+value, prepend URL, sign with auth token.
   const sortedKeys = Object.keys(params).sort();
   const data = sortedKeys.reduce((acc, key) => acc + key + params[key], url);
-  const hmac = crypto.createHmac("sha1", authToken!);
+  const hmac = crypto.createHmac("sha1", authToken);
   hmac.update(data);
   return hmac.digest("base64");
 }
@@ -96,7 +100,7 @@ async function sendSms(toNumber: string, text: string): Promise<void> {
   const auth = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
   const chunks = chunkText(text, MAX_SMS_LEN);
   for (const chunk of chunks) {
-    const form = new URLSearchParams({ From: fromNumber!, To: toNumber, Body: chunk });
+    const form = new URLSearchParams({ From: fromNumber, To: toNumber, Body: chunk });
     let res: Response;
     try {
       res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`, {

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -26,11 +26,15 @@ const FETCH_TIMEOUT_MS = 15_000;
 const PORT = Number(process.env.VIBER_WEBHOOK_PORT) || 3012;
 const VIBER_API = "https://chatapi.viber.com/pa";
 
-const authToken = process.env.VIBER_AUTH_TOKEN;
-if (!authToken) {
-  console.error("VIBER_AUTH_TOKEN is required.\nSee README for setup instructions.");
-  process.exit(1);
+function readRequiredEnv(): { authToken: string } {
+  const authToken = process.env.VIBER_AUTH_TOKEN;
+  if (!authToken) {
+    console.error("VIBER_AUTH_TOKEN is required.\nSee README for setup instructions.");
+    process.exit(1);
+  }
+  return { authToken };
 }
+const { authToken } = readRequiredEnv();
 
 const senderName = process.env.VIBER_SENDER_NAME ?? "MulmoClaude";
 const allowedUsers = new Set(
@@ -70,7 +74,7 @@ async function sendViber(receiverId: string, text: string): Promise<void> {
     try {
       res = await fetch(`${VIBER_API}/send_message`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", "X-Viber-Auth-Token": authToken! },
+        headers: { "Content-Type": "application/json", "X-Viber-Auth-Token": authToken },
         body: JSON.stringify({
           receiver: receiverId,
           type: "text",
@@ -99,7 +103,7 @@ async function sendViber(receiverId: string, text: string): Promise<void> {
 // ── Signature verification ─────────────────────────────────────
 
 function verifySignature(rawBody: string, signature: string): boolean {
-  const expected = crypto.createHmac("sha256", authToken!).update(rawBody).digest("hex");
+  const expected = crypto.createHmac("sha256", authToken).update(rawBody).digest("hex");
   if (expected.length !== signature.length) return false;
   try {
     return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -22,16 +22,20 @@ const TRANSPORT_ID = "whatsapp";
 const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
 const FETCH_TIMEOUT_MS = 30_000;
 
-const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
-const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
-const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
-const appSecret = process.env.WHATSAPP_APP_SECRET;
-if (!accessToken || !phoneNumberId || !verifyToken || !appSecret) {
-  console.error(
-    "WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_VERIFY_TOKEN, and WHATSAPP_APP_SECRET are required.\nSee README for setup instructions.",
-  );
-  process.exit(1);
+function readRequiredEnv(): { accessToken: string; phoneNumberId: string; verifyToken: string; appSecret: string } {
+  const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
+  const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+  const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
+  const appSecret = process.env.WHATSAPP_APP_SECRET;
+  if (!accessToken || !phoneNumberId || !verifyToken || !appSecret) {
+    console.error(
+      "WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_VERIFY_TOKEN, and WHATSAPP_APP_SECRET are required.\nSee README for setup instructions.",
+    );
+    process.exit(1);
+  }
+  return { accessToken, phoneNumberId, verifyToken, appSecret };
 }
+const { accessToken, phoneNumberId, verifyToken, appSecret } = readRequiredEnv();
 
 const allowedNumbers = new Set(
   (process.env.WHATSAPP_ALLOWED_NUMBERS ?? "")
@@ -87,7 +91,7 @@ async function sendWhatsAppMessage(recipientId: string, text: string): Promise<v
 // ── Signature verification (x-hub-signature-256) ────────────────
 
 function verifyWebhookSignature(rawBody: string, signature: string): boolean {
-  const expected = crypto.createHmac("sha256", appSecret!).update(rawBody).digest("hex");
+  const expected = crypto.createHmac("sha256", appSecret).update(rawBody).digest("hex");
   const provided = signature.replace("sha256=", "");
   if (expected.length !== provided.length) return false;
   return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(provided));


### PR DESCRIPTION
## Summary

- Wrap module-level `process.env.X` reads + the `if (!x) process.exit(1)` guard in a small `readRequiredEnv()` per bridge so narrowing survives closures. Destructure the returned object at module level — names, error messages, and exit behavior are unchanged.
- Net: **22 of 68 lint warnings cleared** (`@typescript-eslint/no-non-null-assertion`). Remaining `packages/bridges/` warnings are 5 `complexity` cases that need real refactors and are out of scope.

## Items to Confirm / Review

- The `readRequiredEnv()` helper is duplicated across 11 bridges (10 lines each). I considered pushing it into `@mulmobridge/client` as a shared `requireEnv` export, but that would require bumping + republishing the client *before* bridges can use it — a multi-step release dance. Local helpers keep this PR self-contained and reversible. Happy to extract if you'd prefer.
- For `rocketchat`, also fixed a `cursors.get(roomId)!` Map.get-after-set with the standard "capture the value, set if missing, use the captured value" pattern. Inline pattern, same observable behavior.
- Error messages are byte-identical to before (verified by diff). Same single-line `console.error(...)` + `process.exit(1)` for each missing env var combination.

## User Prompt

> packages/bridges以下のlintエラー、直せるものは直して。

## Bridges touched

chatwork, email, line, line-works, mattermost, messenger, rocketchat, teams, twilio-sms, viber, whatsapp.

## Validation

- `yarn format` ✓
- `yarn lint` ✓ (68 → 46 warnings, 0 errors)
- `yarn typecheck` ✓
- `yarn build` ✓
- `tsx --test ./test/**/test_*.ts` ✓ (all server tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored environment variable validation across all bridge modules (ChatWork, Email, LINE Works, LINE, Mattermost, Messenger, Rocket.Chat, Teams, Twilio SMS, Viber, WhatsApp) to improve type safety and code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->