### PR TITLE
refactor(spreadsheet): extract pure keyboard-nav helpers + unit tests

### DIFF
--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -123,6 +123,7 @@ import {
   type CellValue,
 } from "./engine";
 import { applyCellHighlights, clearCellHighlights } from "./cellHighlights";
+import { getArrowKeyOffset, isWithinSheetBounds } from "./keyboardNav";
 import { errorMessage as formatErrorMessage } from "../../utils/errors";
 
 // Import all spreadsheet functions to populate the function registry
@@ -628,56 +629,24 @@ watch(
   { flush: "post" },
 );
 
-// Keyboard navigation handler
-function handleKeyboardNavigation(event: KeyboardEvent) {
-  // Only handle arrow keys when mini editor is open and not focused on input
-  if (!miniEditorOpen.value || !miniEditorCell.value) return;
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+}
 
-  // Don't interfere if user is typing in an input field
-  const target = event.target as HTMLElement;
-  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
-    return;
-  }
+function handleKeyboardNavigation(event: KeyboardEvent) {
+  if (!miniEditorOpen.value || !miniEditorCell.value) return;
+  if (isEditableTarget(event.target)) return;
 
   const { row, col } = miniEditorCell.value;
-  let newRow = row;
-  let newCol = col;
+  const next = getArrowKeyOffset(event.key, row, col);
+  if (!next) return;
 
-  // Determine new position based on arrow key
-  switch (event.key) {
-    case "ArrowUp":
-      newRow = Math.max(0, row - 1);
-      break;
-    case "ArrowDown":
-      newRow = row + 1;
-      break;
-    case "ArrowLeft":
-      newCol = Math.max(0, col - 1);
-      break;
-    case "ArrowRight":
-      newCol = col + 1;
-      break;
-    default:
-      return; // Not an arrow key, ignore
-  }
-
-  // Get current sheet data to validate bounds
   try {
     const sheets = JSON.parse(editableData.value);
-    const currentSheet = sheets[activeSheetIndex.value];
-
-    if (!currentSheet || !currentSheet.data) return;
-
-    // Validate new position is within bounds
-    if (newRow < 0 || newRow >= currentSheet.data.length || newCol < 0 || !currentSheet.data[newRow] || newCol >= currentSheet.data[newRow].length) {
-      return; // Out of bounds, ignore
-    }
-
-    // Prevent default scrolling behavior
+    if (!isWithinSheetBounds(sheets[activeSheetIndex.value], next.row, next.col)) return;
     event.preventDefault();
-
-    // Move to new cell
-    openMiniEditor(newRow, newCol);
+    openMiniEditor(next.row, next.col);
   } catch (error) {
     console.error("Failed to navigate cells:", error);
   }

--- a/src/plugins/spreadsheet/keyboardNav.ts
+++ b/src/plugins/spreadsheet/keyboardNav.ts
@@ -1,0 +1,38 @@
+// Pure helpers behind the spreadsheet mini-editor's arrow-key
+// navigation. Lifted out of View.vue so each rule can be unit-tested
+// without spinning up Vue or a DOM.
+
+export interface CellPosition {
+  row: number;
+  col: number;
+}
+
+// Sheet shape we actually rely on — the mini-editor only reads
+// `data` as a 2D array, so the type is intentionally loose to match
+// what arrives from `JSON.parse(editableData.value)`.
+export interface SheetLike {
+  data?: unknown[][];
+}
+
+export function getArrowKeyOffset(key: string, row: number, col: number): CellPosition | null {
+  switch (key) {
+    case "ArrowUp":
+      return { row: Math.max(0, row - 1), col };
+    case "ArrowDown":
+      return { row: row + 1, col };
+    case "ArrowLeft":
+      return { row, col: Math.max(0, col - 1) };
+    case "ArrowRight":
+      return { row, col: col + 1 };
+    default:
+      return null;
+  }
+}
+
+export function isWithinSheetBounds(sheet: SheetLike | null | undefined, row: number, col: number): boolean {
+  if (!sheet?.data) return false;
+  if (row < 0 || row >= sheet.data.length) return false;
+  const rowData = sheet.data[row];
+  if (!rowData) return false;
+  return col >= 0 && col < rowData.length;
+}

--- a/test/plugins/spreadsheet/test_keyboardNav.ts
+++ b/test/plugins/spreadsheet/test_keyboardNav.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getArrowKeyOffset, isWithinSheetBounds } from "../../../src/plugins/spreadsheet/keyboardNav.js";
+
+describe("getArrowKeyOffset", () => {
+  it("ArrowUp decrements row", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowUp", 3, 5), { row: 2, col: 5 });
+  });
+
+  it("ArrowDown increments row (no upper clamp — bounds check happens later)", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowDown", 3, 5), { row: 4, col: 5 });
+  });
+
+  it("ArrowLeft decrements col", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowLeft", 3, 5), { row: 3, col: 4 });
+  });
+
+  it("ArrowRight increments col", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowRight", 3, 5), { row: 3, col: 6 });
+  });
+
+  it("ArrowUp clamps row at 0", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowUp", 0, 5), { row: 0, col: 5 });
+  });
+
+  it("ArrowLeft clamps col at 0", () => {
+    assert.deepEqual(getArrowKeyOffset("ArrowLeft", 3, 0), { row: 3, col: 0 });
+  });
+
+  it("returns null for non-arrow keys", () => {
+    for (const key of ["Enter", "Tab", "Escape", "a", " ", "Shift"]) {
+      assert.equal(getArrowKeyOffset(key, 3, 5), null, `expected null for ${JSON.stringify(key)}`);
+    }
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(getArrowKeyOffset("", 3, 5), null);
+  });
+});
+
+describe("isWithinSheetBounds", () => {
+  const sheet = {
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+  };
+
+  it("accepts an in-range cell", () => {
+    assert.equal(isWithinSheetBounds(sheet, 0, 0), true);
+    assert.equal(isWithinSheetBounds(sheet, 1, 2), true);
+  });
+
+  it("rejects negative row", () => {
+    assert.equal(isWithinSheetBounds(sheet, -1, 0), false);
+  });
+
+  it("rejects negative col", () => {
+    assert.equal(isWithinSheetBounds(sheet, 0, -1), false);
+  });
+
+  it("rejects row past data length", () => {
+    assert.equal(isWithinSheetBounds(sheet, 2, 0), false);
+  });
+
+  it("rejects col past row length", () => {
+    assert.equal(isWithinSheetBounds(sheet, 0, 3), false);
+  });
+
+  it("rejects when sheet is undefined", () => {
+    assert.equal(isWithinSheetBounds(undefined, 0, 0), false);
+  });
+
+  it("rejects when sheet is null", () => {
+    assert.equal(isWithinSheetBounds(null, 0, 0), false);
+  });
+
+  it("rejects when sheet.data is missing", () => {
+    assert.equal(isWithinSheetBounds({}, 0, 0), false);
+  });
+
+  it("rejects when the target row entry is missing (sparse array)", () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const sparse = { data: [[1, 2], , [3, 4]] as unknown[][] };
+    assert.equal(isWithinSheetBounds(sparse, 1, 0), false);
+  });
+
+  it("handles a row of zero length (col always rejected)", () => {
+    const empty = { data: [[]] };
+    assert.equal(isWithinSheetBounds(empty, 0, 0), false);
+  });
+});


### PR DESCRIPTION
## Summary

Reduce \`handleKeyboardNavigation\`'s cyclomatic complexity from **18 → below the 15 cap** (lint warning eliminated) by extracting two pure helpers into a new \`src/plugins/spreadsheet/keyboardNav.ts\` and adding unit tests.

## Items to Confirm / Review

- **\`getArrowKeyOffset(key, row, col)\`** — pure mapping from a keyboard key + current cell to the next cell; returns \`null\` for non-arrow keys. Clamps row/col at 0 (matching the previous inline behaviour).
- **\`isWithinSheetBounds(sheet, row, col)\`** — defensive bounds check that handles \`undefined\` / \`null\` sheets, missing \`data\`, sparse arrays, and zero-length rows.
- **\`isEditableTarget\`** stays inline in \`View.vue\` because it's a two-line DOM-instanceof guard and not interesting in isolation.
- **18 unit tests** in \`test/plugins/spreadsheet/test_keyboardNav.ts\` cover happy paths, clamping, non-arrow keys, and every boundary edge of the bounds check.
- Behaviour is unchanged. \`yarn lint\` (0 errors), \`yarn typecheck\`, \`yarn build\`, \`npx tsx --test\` (29/29 spreadsheet tests pass) all green.

## User Prompt

> fix src/plugins/spreadsheet/View.vue
>   632:1  warning  Function 'handleKeyboardNavigation' has a complexity of 18. Maximum allowed is 15  complexity
>
> できればpure functionにできるものはして、unit testを