### PR TITLE
refactor(githubIssues): extract pure formatIssueTitle + unit tests

### DIFF
--- a/server/workspace/sources/fetchers/githubIssues.ts
+++ b/server/workspace/sources/fetchers/githubIssues.ts
@@ -93,6 +93,17 @@ export function parseGithubIssue(raw: unknown): ParsedIssue | null {
   };
 }
 
+// Title annotations: `[PR]` for pulls, `[closed]` for closed
+// state so the daily summary makes state visible at a glance.
+// Pure — exported for unit tests.
+export function formatIssueTitle(issue: ParsedIssue): string {
+  const parts: string[] = [];
+  if (issue.isPr) parts.push("[PR]");
+  if (issue.state === "closed") parts.push("[closed]");
+  const baseTitle = issue.title ?? `#${issue.number ?? "?"}`;
+  return parts.length > 0 ? `${parts.join(" ")} ${baseTitle}` : baseTitle;
+}
+
 // Build a SourceItem from a parsed issue + the parent Source.
 // Returns null when the item should be skipped (missing URL,
 // cursor-old, PR when PRs excluded).
@@ -110,21 +121,12 @@ export function issueToSourceItem(issue: ParsedIssue, source: Source, params: Is
 
   const normalizedUrl = normalizeUrl(issue.htmlUrl);
   if (!normalizedUrl) return null;
-  const itemId = stableItemId(normalizedUrl);
-
-  // Title annotations: `[PR]` for pulls, `[closed]` for closed
-  // state so the daily summary makes state visible at a glance.
-  const parts: string[] = [];
-  if (issue.isPr) parts.push("[PR]");
-  if (issue.state === "closed") parts.push("[closed]");
-  const baseTitle = issue.title ?? `#${issue.number ?? "?"}`;
-  const title = parts.length > 0 ? `${parts.join(" ")} ${baseTitle}` : baseTitle;
 
   const summary = issue.body ? firstParagraph(issue.body) : null;
 
   return {
-    id: itemId,
-    title,
+    id: stableItemId(normalizedUrl),
+    title: formatIssueTitle(issue),
     url: normalizedUrl,
     publishedAt: new Date(updatedTs).toISOString(),
     ...(summary !== null && { summary }),

--- a/test/sources/test_githubIssues.ts
+++ b/test/sources/test_githubIssues.ts
@@ -4,6 +4,7 @@ import {
   githubIssuesFetcher,
   parseGithubIssue,
   issueToSourceItem,
+  formatIssueTitle,
   updateIssuesCursor,
   processIssuesResponse,
   resolveIssuesParams,
@@ -205,6 +206,63 @@ describe("parseGithubIssue", () => {
     assert.equal(parseGithubIssue("str"), null);
     assert.equal(parseGithubIssue([1, 2]), null);
     assert.equal(parseGithubIssue(null), null);
+  });
+});
+
+// --- formatIssueTitle (pure helper) --------------------------------------
+
+describe("formatIssueTitle", () => {
+  // Build a minimal ParsedIssue. We don't go through parseGithubIssue
+  // because the helper's contract is over the ParsedIssue shape, not
+  // the raw GitHub payload.
+  function makeParsed(overrides: Partial<Parameters<typeof formatIssueTitle>[0]> = {}): Parameters<typeof formatIssueTitle>[0] {
+    return {
+      id: 1,
+      number: 7,
+      title: "fix the thing",
+      htmlUrl: "https://example.test/i/7",
+      body: null,
+      updatedAt: "2026-04-30T00:00:00Z",
+      createdAt: "2026-04-29T00:00:00Z",
+      isPr: false,
+      state: "open",
+      ...overrides,
+    };
+  }
+
+  it("returns the bare title for a plain open issue", () => {
+    assert.equal(formatIssueTitle(makeParsed()), "fix the thing");
+  });
+
+  it("prefixes [PR] for pull requests", () => {
+    assert.equal(formatIssueTitle(makeParsed({ isPr: true })), "[PR] fix the thing");
+  });
+
+  it("prefixes [closed] for closed items", () => {
+    assert.equal(formatIssueTitle(makeParsed({ state: "closed" })), "[closed] fix the thing");
+  });
+
+  it("combines [PR] [closed] in that order for closed PRs", () => {
+    assert.equal(formatIssueTitle(makeParsed({ isPr: true, state: "closed" })), "[PR] [closed] fix the thing");
+  });
+
+  it("falls back to `#<number>` when the title is missing", () => {
+    assert.equal(formatIssueTitle(makeParsed({ title: null })), "#7");
+  });
+
+  it("combines annotation and number fallback", () => {
+    assert.equal(formatIssueTitle(makeParsed({ title: null, isPr: true })), "[PR] #7");
+  });
+
+  it("falls back to `#?` when both title and number are missing", () => {
+    assert.equal(formatIssueTitle(makeParsed({ title: null, number: null })), "#?");
+  });
+
+  it("treats unknown state as not-closed (no [closed] prefix)", () => {
+    // GitHub only returns "open" / "closed" today, but the field is
+    // typed `string | null` so we should not annotate anything else.
+    assert.equal(formatIssueTitle(makeParsed({ state: "draft" })), "fix the thing");
+    assert.equal(formatIssueTitle(makeParsed({ state: null })), "fix the thing");
   });
 });
 


### PR DESCRIPTION
## Summary

\`server/workspace/sources/fetchers/githubIssues.ts\` line 99 had a
\`complexity 17\` lint warn on \`issueToSourceItem\` (limit 15). The
title-annotation block (PR / closed markers, \`#<number>\` /
\`#?\` fallbacks) was 5 of those 17 decision points and is a
self-contained pure transformation, so extracting it as a helper
both clears the warn and makes the title-shaping logic separately
testable.

## Items to Confirm / Review

- **Pure helper signature**: \`formatIssueTitle(issue: ParsedIssue): string\`. \`ParsedIssue\` is the existing internal shape; the function reads only \`isPr\`, \`state\`, \`title\`, \`number\`. No mutation, no I/O.
- **Behavioural equivalence**: the helper is a literal copy of the inline block. The existing \`issueToSourceItem — title annotations\` integration tests still pass (4 cases: bare PR, bare closed, combined PR + closed, \`#<n>\` fallback). New \`formatIssueTitle\` block adds 4 more focused cases (combined annotation + number fallback, both missing → \`#?\`, unknown state \`"draft"\`, null state).
- **Export**: \`formatIssueTitle\` is now exported with a \`Pure — exported for unit tests.\` comment, mirroring the existing \`parseGithubIssue\` convention in the same file.
- **Other complexity warnings in the codebase** (handleNotification, processMessage, handleStanza, etc.) are unrelated and stay in their own follow-ups.

## User Prompt

> fix server/workspace/sources/fetchers/githubIssues.ts
>   99:8  warning  Function 'issueToSourceItem' has a complexity of 17. Maximum allowed is 15  complexity
>
> できればpure functionにできるものはして、unit testを

## Verification

- \`yarn lint\`: 0 errors, 67 warnings (was 68 — \`issueToSourceItem\` complexity warn gone; \`issueToSourceItem\` is now at 12)
- \`tsx --test test/sources/test_githubIssues.ts\`: 40 pass (was 32; 8 new)
- \`yarn typecheck\` / \`yarn test\` (full): pass — 3431 tests, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)