### PR TITLE
refactor(bridges,relay): extract pure parse helpers to drop complexity

### DIFF
--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "tsx --test test/test_*.ts"
   },
   "license": "MIT",
   "author": "Receptron Team",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -16,7 +16,8 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { extractIncomingLineMessage, parseLineWebhookBody } from "./parse.js";
 
 const TRANSPORT_ID = "line";
 const PORT = Number(process.env.LINE_BRIDGE_PORT) || 3002;
@@ -96,37 +97,22 @@ app.post("/webhook", async (req: Request, res: Response) => {
 
   res.status(200).send("OK");
 
-  let body: {
-    events: {
-      type: string;
-      replyToken?: string;
-      source?: { userId?: string; type?: string };
-      message?: { type: string; text?: string };
-    }[];
-  };
-  try {
-    body = JSON.parse(bodyStr);
-  } catch {
+  const body = parseLineWebhookBody(bodyStr);
+  if (!body) {
     console.error("[line] malformed JSON in webhook body");
     return;
   }
 
   for (const event of body.events) {
-    if (event.type !== "message" || event.message?.type !== "text") continue;
-    const userId = event.source?.userId;
-    const text = event.message?.text ?? "";
-    if (!userId || !text.trim()) continue;
+    const incoming = extractIncomingLineMessage(event);
+    if (!incoming) continue;
+    const { userId, text } = incoming;
 
     console.log(`[line] message user=${userId} len=${text.length}`);
 
     try {
       const ack = await client.send(userId, text);
-      if (ack.ok) {
-        await pushMessage(userId, ack.reply ?? "");
-      } else {
-        const status = ack.status ? ` (${ack.status})` : "";
-        await pushMessage(userId, `Error${status}: ${ack.error ?? "unknown"}`);
-      }
+      await pushMessage(userId, formatAckReply(ack));
     } catch (err) {
       console.error(`[line] message handling failed: ${err}`);
     }

--- a/packages/bridges/line/src/parse.ts
+++ b/packages/bridges/line/src/parse.ts
@@ -1,0 +1,44 @@
+// Pure parsing helpers for the LINE bridge webhook.
+
+export interface LineEvent {
+  type: string;
+  replyToken?: string;
+  source?: { userId?: string; type?: string };
+  message?: { type: string; text?: string };
+}
+
+export interface LineWebhookBody {
+  events: LineEvent[];
+}
+
+export interface IncomingLineMessage {
+  userId: string;
+  text: string;
+}
+
+/**
+ * Reduce a LINE webhook event to the actionable userId / text pair.
+ * Returns null for non-text events, missing fields, or whitespace-only
+ * text. Pure — no side effects, no allowlist check.
+ */
+export function extractIncomingLineMessage(event: LineEvent): IncomingLineMessage | null {
+  if (event.type !== "message") return null;
+  if (event.message?.type !== "text") return null;
+  const userId = event.source?.userId;
+  const text = event.message.text ?? "";
+  if (!userId || !text.trim()) return null;
+  return { userId, text };
+}
+
+/** Best-effort JSON parse for the webhook body — null on malformed input. */
+export function parseLineWebhookBody(raw: string): LineWebhookBody | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || !Array.isArray((parsed as { events?: unknown }).events)) {
+      return null;
+    }
+    return parsed as LineWebhookBody;
+  } catch {
+    return null;
+  }
+}

--- a/packages/bridges/line/test/test_parse.ts
+++ b/packages/bridges/line/test/test_parse.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractIncomingLineMessage, parseLineWebhookBody, type LineEvent } from "../src/parse.js";
+
+function textEvent(overrides: Partial<LineEvent> = {}): LineEvent {
+  return {
+    type: "message",
+    message: { type: "text", text: "hello" },
+    source: { userId: "U1234" },
+    ...overrides,
+  };
+}
+
+describe("extractIncomingLineMessage", () => {
+  it("returns userId + text for a normal text message", () => {
+    assert.deepEqual(extractIncomingLineMessage(textEvent()), { userId: "U1234", text: "hello" });
+  });
+
+  it("returns null for non-message event types", () => {
+    assert.equal(extractIncomingLineMessage(textEvent({ type: "follow" })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ type: "unfollow" })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ type: "postback" })), null);
+  });
+
+  it("returns null when message type is not 'text'", () => {
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "image" } })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "sticker" } })), null);
+  });
+
+  it("returns null when message is missing entirely", () => {
+    assert.equal(extractIncomingLineMessage({ type: "message", source: { userId: "U1" } }), null);
+  });
+
+  it("returns null when source.userId is missing", () => {
+    assert.equal(extractIncomingLineMessage(textEvent({ source: { type: "user" } })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ source: undefined })), null);
+  });
+
+  it("returns null for empty / whitespace text", () => {
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "text", text: "" } })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "text", text: "   " } })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "text" } })), null);
+  });
+
+  it("preserves text without trimming (sender's whitespace inside is intentional)", () => {
+    const result = extractIncomingLineMessage(textEvent({ message: { type: "text", text: "  hello  world  " } }));
+    assert.equal(result?.text, "  hello  world  ");
+  });
+});
+
+describe("parseLineWebhookBody", () => {
+  it("returns the body for valid JSON with events array", () => {
+    const json = JSON.stringify({ events: [{ type: "message" }] });
+    assert.deepEqual(parseLineWebhookBody(json), { events: [{ type: "message" }] });
+  });
+
+  it("returns body with empty events array", () => {
+    assert.deepEqual(parseLineWebhookBody('{"events": []}'), { events: [] });
+  });
+
+  it("returns null for malformed JSON", () => {
+    assert.equal(parseLineWebhookBody("not json"), null);
+    assert.equal(parseLineWebhookBody("{"), null);
+    assert.equal(parseLineWebhookBody(""), null);
+  });
+
+  it("returns null when 'events' is missing", () => {
+    assert.equal(parseLineWebhookBody("{}"), null);
+    assert.equal(parseLineWebhookBody('{"foo": "bar"}'), null);
+  });
+
+  it("returns null when 'events' is not an array", () => {
+    assert.equal(parseLineWebhookBody('{"events": "nope"}'), null);
+    assert.equal(parseLineWebhookBody('{"events": null}'), null);
+    assert.equal(parseLineWebhookBody('{"events": {}}'), null);
+  });
+
+  it("returns null for JSON null / number / string", () => {
+    assert.equal(parseLineWebhookBody("null"), null);
+    assert.equal(parseLineWebhookBody("42"), null);
+    assert.equal(parseLineWebhookBody('"string"'), null);
+  });
+});

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "tsx --test test/test_*.ts"
   },
   "license": "MIT",
   "author": "Receptron Team",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/ws": "^8.18.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -22,7 +22,8 @@
 
 import "dotenv/config";
 import WebSocket from "ws";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { isObj, parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
 
 const TRANSPORT_ID = "mastodon";
 const MAX_STATUS_LEN = 500; // Mastodon's default soft limit; many instances raise to 1000+
@@ -56,12 +57,6 @@ mulmo.onPush((pushEvent) => {
 });
 
 // ── Mastodon API ─────────────────────────────────────────────────
-
-type JsonRecord = Record<string, unknown>;
-
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
 
 interface PostStatusOptions {
   inReplyTo: string | null;
@@ -120,61 +115,6 @@ async function postStatus(chatId: string, text: string, inReplyTo: string | null
   }
 }
 
-// ── HTML → plain text ───────────────────────────────────────────
-
-function stripTags(input: string): string {
-  // Walk char-by-char so we avoid regex backtracking on malformed HTML.
-  const out: string[] = [];
-  let inTag = false;
-  for (const char of input) {
-    if (char === "<") inTag = true;
-    else if (char === ">") inTag = false;
-    else if (!inTag) out.push(char);
-  }
-  return out.join("");
-}
-
-function decodeEntities(input: string): string {
-  return input
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
-}
-
-function htmlToText(html: string): string {
-  const withNewlines = html.replace(/<br\s*\/?>/gi, "\n").replace(/<\/p>\s*<p>/gi, "\n\n");
-  return decodeEntities(stripTags(withNewlines)).trim();
-}
-
-// Bounded regex with no nested quantifier overlap — matches at most
-// one mention token at a time. Safe against ReDoS even on adversarial
-// input because the engine commits to a single mention's bounded
-// `[A-Za-z0-9_.]+` / `[A-Za-z0-9_.-]+` runs and either advances or
-// fails in O(n) per match. eslint-plugin-security's safe-regex
-// heuristic flags any `(...)?` containing `+` generically, even
-// when the surrounding pattern can't drive exponential backtracking.
-// eslint-disable-next-line security/detect-unsafe-regex -- single-mention pattern, no nested-quantifier overlap; the iterative caller bounds total work to O(N) in the input length
-const SINGLE_MENTION_RE = /^@[A-Za-z0-9_.]+(?:@[A-Za-z0-9_.-]+)?\s+/;
-
-function stripLeadingMentions(text: string): string {
-  // Iterative strip — peel off one leading "@acct" / "@acct@instance"
-  // mention per pass until the prefix no longer matches. Avoids the
-  // outer `+` over a group with nested `+` quantifiers (the previous
-  // `(?:@[\w.]+(?:@[\w.-]+)?\s+)+` form), which `eslint-plugin-security`
-  // / `safe-regex` flag as ReDoS-prone on inputs like long runs of
-  // `@a@a@a…` without a trailing space.
-  let stripped = text;
-  while (true) {
-    const match = SINGLE_MENTION_RE.exec(stripped);
-    if (!match) break;
-    stripped = stripped.slice(match[0].length);
-  }
-  return stripped.trim();
-}
-
 // ── Attachment fetching ─────────────────────────────────────────
 
 interface MulmoAttachment {
@@ -209,45 +149,23 @@ async function collectImageAttachments(media: unknown): Promise<MulmoAttachment[
 
 // ── Notification handling ───────────────────────────────────────
 
-interface ParsedStatus {
-  statusId: string;
-  senderAcct: string;
-  visibility: string;
-  text: string;
-  media: unknown;
-}
-
-function parseMentionStatus(notification: JsonRecord): ParsedStatus | null {
-  if (notification.type !== "mention") return null;
-  const { status } = notification;
-  if (!isObj(status)) return null;
-  const statusId = typeof status.id === "string" ? status.id : "";
-  const visibility = typeof status.visibility === "string" ? status.visibility : "public";
-  const account = isObj(status.account) ? status.account : null;
-  const senderAcct = account && typeof account.acct === "string" ? account.acct : "";
-  const content = typeof status.content === "string" ? status.content : "";
-  const text = stripLeadingMentions(htmlToText(content));
-  if (!statusId || !senderAcct) return null;
-  return { statusId, senderAcct, visibility, text, media: status.media_attachments };
+function shouldSkipNotification(parsed: ParsedStatus): string | null {
+  if (dmOnly && parsed.visibility !== "direct") {
+    return `skip non-DM from=${parsed.senderAcct} visibility=${parsed.visibility}`;
+  }
+  if (!allowAll && !allowedAccts.has(parsed.senderAcct)) {
+    return `denied from=${parsed.senderAcct}`;
+  }
+  return null;
 }
 
 async function handleNotification(raw: string): Promise<void> {
-  let notif: unknown;
-  try {
-    notif = JSON.parse(raw);
-  } catch {
-    return;
-  }
-  if (!isObj(notif)) return;
-  const parsed = parseMentionStatus(notif);
+  const parsed = parseNotificationRaw(raw);
   if (!parsed) return;
 
-  if (dmOnly && parsed.visibility !== "direct") {
-    console.log(`[mastodon] skip non-DM from=${parsed.senderAcct} visibility=${parsed.visibility}`);
-    return;
-  }
-  if (!allowAll && !allowedAccts.has(parsed.senderAcct)) {
-    console.log(`[mastodon] denied from=${parsed.senderAcct}`);
+  const skipReason = shouldSkipNotification(parsed);
+  if (skipReason) {
+    console.log(`[mastodon] ${skipReason}`);
     return;
   }
 
@@ -259,37 +177,13 @@ async function handleNotification(raw: string): Promise<void> {
 
   try {
     const ack = await mulmo.send(parsed.senderAcct, parsed.text, attachments.length > 0 ? attachments : undefined);
-    if (ack.ok) {
-      await postStatus(parsed.senderAcct, ack.reply ?? "", parsed.statusId, parsed.visibility);
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await postStatus(parsed.senderAcct, `Error${status}: ${ack.error ?? "unknown"}`, parsed.statusId, parsed.visibility);
-    }
+    await postStatus(parsed.senderAcct, formatAckReply(ack), parsed.statusId, parsed.visibility);
   } catch (err) {
     console.error(`[mastodon] message handling failed: ${err}`);
   }
 }
 
 // ── WebSocket stream ────────────────────────────────────────────
-
-interface StreamFrame {
-  event: string;
-  payload: string;
-}
-
-function parseFrame(raw: unknown): StreamFrame | null {
-  if (typeof raw !== "string") return null;
-  try {
-    const msg: unknown = JSON.parse(raw);
-    if (!isObj(msg)) return null;
-    const event = typeof msg.event === "string" ? msg.event : "";
-    const payload = typeof msg.payload === "string" ? msg.payload : "";
-    if (!event || !payload) return null;
-    return { event, payload };
-  } catch {
-    return null;
-  }
-}
 
 function connect(): void {
   const socket = new WebSocket(streamUrl);

--- a/packages/bridges/mastodon/src/parse.ts
+++ b/packages/bridges/mastodon/src/parse.ts
@@ -1,0 +1,117 @@
+// Pure parsing helpers for the Mastodon bridge — HTML→text,
+// leading-mention strip, mention-status extraction.
+
+export type JsonRecord = Record<string, unknown>;
+
+export function isObj(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null;
+}
+
+export interface ParsedStatus {
+  statusId: string;
+  senderAcct: string;
+  visibility: string;
+  text: string;
+  media: unknown;
+}
+
+function stripTags(input: string): string {
+  // Walk char-by-char so we avoid regex backtracking on malformed HTML.
+  const out: string[] = [];
+  let inTag = false;
+  for (const char of input) {
+    if (char === "<") inTag = true;
+    else if (char === ">") inTag = false;
+    else if (!inTag) out.push(char);
+  }
+  return out.join("");
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+export function htmlToText(html: string): string {
+  const withNewlines = html.replace(/<br\s*\/?>/gi, "\n").replace(/<\/p>\s*<p>/gi, "\n\n");
+  return decodeEntities(stripTags(withNewlines)).trim();
+}
+
+// Bounded regex with no nested quantifier overlap — matches at most
+// one mention token at a time. Safe against ReDoS even on adversarial
+// input because the engine commits to a single mention's bounded
+// `[A-Za-z0-9_.]+` / `[A-Za-z0-9_.-]+` runs and either advances or
+// fails in O(n) per match. eslint-plugin-security's safe-regex
+// heuristic flags any `(...)?` containing `+` generically, even
+// when the surrounding pattern can't drive exponential backtracking.
+// eslint-disable-next-line security/detect-unsafe-regex -- single-mention pattern, no nested-quantifier overlap; the iterative caller bounds total work to O(N) in the input length
+const SINGLE_MENTION_RE = /^@[A-Za-z0-9_.]+(?:@[A-Za-z0-9_.-]+)?\s+/;
+
+export function stripLeadingMentions(text: string): string {
+  // Iterative strip — peel off one leading "@acct" / "@acct@instance"
+  // mention per pass until the prefix no longer matches. Avoids the
+  // outer `+` over a group with nested `+` quantifiers (the previous
+  // `(?:@[\w.]+(?:@[\w.-]+)?\s+)+` form), which `eslint-plugin-security`
+  // / `safe-regex` flag as ReDoS-prone on inputs like long runs of
+  // `@a@a@a…` without a trailing space.
+  let stripped = text;
+  while (true) {
+    const match = SINGLE_MENTION_RE.exec(stripped);
+    if (!match) break;
+    stripped = stripped.slice(match[0].length);
+  }
+  return stripped.trim();
+}
+
+export function parseMentionStatus(notification: JsonRecord): ParsedStatus | null {
+  if (notification.type !== "mention") return null;
+  const { status } = notification;
+  if (!isObj(status)) return null;
+  const statusId = typeof status.id === "string" ? status.id : "";
+  const visibility = typeof status.visibility === "string" ? status.visibility : "public";
+  const account = isObj(status.account) ? status.account : null;
+  const senderAcct = account && typeof account.acct === "string" ? account.acct : "";
+  const content = typeof status.content === "string" ? status.content : "";
+  const text = stripLeadingMentions(htmlToText(content));
+  if (!statusId || !senderAcct) return null;
+  return { statusId, senderAcct, visibility, text, media: status.media_attachments };
+}
+
+/**
+ * Wraps JSON.parse + shape validation + parseMentionStatus so the
+ * orchestration layer can branch on a single null / non-null result.
+ */
+export function parseNotificationRaw(raw: string): ParsedStatus | null {
+  let notif: unknown;
+  try {
+    notif = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isObj(notif)) return null;
+  return parseMentionStatus(notif);
+}
+
+export interface StreamFrame {
+  event: string;
+  payload: string;
+}
+
+export function parseFrame(raw: unknown): StreamFrame | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const msg: unknown = JSON.parse(raw);
+    if (!isObj(msg)) return null;
+    const event = typeof msg.event === "string" ? msg.event : "";
+    const payload = typeof msg.payload === "string" ? msg.payload : "";
+    if (!event || !payload) return null;
+    return { event, payload };
+  } catch {
+    return null;
+  }
+}

--- a/packages/bridges/mastodon/test/test_parse.ts
+++ b/packages/bridges/mastodon/test/test_parse.ts
@@ -1,0 +1,197 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isObj, htmlToText, stripLeadingMentions, parseMentionStatus, parseNotificationRaw, parseFrame } from "../src/parse.js";
+
+describe("isObj", () => {
+  it("returns true for plain objects and arrays", () => {
+    assert.equal(isObj({}), true);
+    assert.equal(isObj({ a: 1 }), true);
+    assert.equal(isObj([]), true);
+  });
+
+  it("returns false for null / primitives", () => {
+    assert.equal(isObj(null), false);
+    assert.equal(isObj(undefined), false);
+    assert.equal(isObj("str"), false);
+    assert.equal(isObj(42), false);
+    assert.equal(isObj(true), false);
+  });
+});
+
+describe("htmlToText", () => {
+  it("strips paragraph tags and converts to plain text", () => {
+    assert.equal(htmlToText("<p>Hello world</p>"), "Hello world");
+  });
+
+  it("turns <br> into newlines", () => {
+    assert.equal(htmlToText("a<br>b<br/>c<br />d"), "a\nb\nc\nd");
+  });
+
+  it("turns </p><p> into double newlines", () => {
+    assert.equal(htmlToText("<p>line1</p><p>line2</p>"), "line1\n\nline2");
+  });
+
+  it("decodes HTML entities", () => {
+    assert.equal(htmlToText("a &amp; b &lt;x&gt; &quot;y&quot; &#39;z&#39; &nbsp;w"), "a & b <x> \"y\" 'z'  w");
+  });
+
+  it("returns empty string for empty / whitespace-only input", () => {
+    assert.equal(htmlToText(""), "");
+    assert.equal(htmlToText("   "), "");
+  });
+
+  it("handles malformed tags by walking char-by-char", () => {
+    // unbalanced < without > — the rest is in tag state, never closes
+    assert.equal(htmlToText("hello <world"), "hello");
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(htmlToText("  <p>  body  </p>  "), "body");
+  });
+});
+
+describe("stripLeadingMentions", () => {
+  it("strips a single leading mention", () => {
+    assert.equal(stripLeadingMentions("@bot hello"), "hello");
+  });
+
+  it("strips multiple leading mentions iteratively", () => {
+    assert.equal(stripLeadingMentions("@bot @other@instance.example hello"), "hello");
+  });
+
+  it("strips federated mentions with instance", () => {
+    assert.equal(stripLeadingMentions("@bot@example.social good morning"), "good morning");
+  });
+
+  it("does not strip mid-text mentions", () => {
+    assert.equal(stripLeadingMentions("hello @bot"), "hello @bot");
+  });
+
+  it("returns trimmed text when there are no mentions", () => {
+    assert.equal(stripLeadingMentions("  bare body  "), "bare body");
+  });
+
+  it("returns empty string when input is only mentions", () => {
+    assert.equal(stripLeadingMentions("@a @b@c.d "), "");
+  });
+
+  it("does not loop infinitely on adversarial input without trailing space", () => {
+    // No trailing space → no match → no strip → returns trimmed input.
+    const adversarial = "@a@a@a@a@a";
+    assert.equal(stripLeadingMentions(adversarial), adversarial);
+  });
+});
+
+describe("parseMentionStatus", () => {
+  function notif(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      type: "mention",
+      status: {
+        id: "s1",
+        visibility: "direct",
+        account: { acct: "alice@example.social" },
+        content: "<p>hello</p>",
+        media_attachments: [],
+        ...((overrides.status as Record<string, unknown> | undefined) ?? {}),
+      },
+      ...overrides,
+    };
+  }
+
+  it("parses a normal mention notification", () => {
+    const out = parseMentionStatus(notif());
+    assert.deepEqual(out, {
+      statusId: "s1",
+      senderAcct: "alice@example.social",
+      visibility: "direct",
+      text: "hello",
+      media: [],
+    });
+  });
+
+  it("strips leading bot mention from text", () => {
+    const out = parseMentionStatus(notif({ status: { id: "s1", visibility: "direct", account: { acct: "alice" }, content: "<p>@bot hi there</p>" } }));
+    assert.equal(out?.text, "hi there");
+  });
+
+  it("returns null when type is not 'mention'", () => {
+    assert.equal(parseMentionStatus({ ...notif(), type: "follow" }), null);
+    assert.equal(parseMentionStatus({ ...notif(), type: "favourite" }), null);
+  });
+
+  it("returns null when status is missing or non-object", () => {
+    assert.equal(parseMentionStatus({ type: "mention" }), null);
+    assert.equal(parseMentionStatus({ type: "mention", status: "string" }), null);
+    assert.equal(parseMentionStatus({ type: "mention", status: null }), null);
+  });
+
+  it("returns null when status.id is missing", () => {
+    assert.equal(parseMentionStatus(notif({ status: { visibility: "direct", account: { acct: "alice" }, content: "<p>x</p>" } })), null);
+  });
+
+  it("returns null when account.acct is missing", () => {
+    assert.equal(parseMentionStatus(notif({ status: { id: "s1", visibility: "direct", account: {}, content: "<p>x</p>" } })), null);
+    assert.equal(parseMentionStatus(notif({ status: { id: "s1", visibility: "direct", content: "<p>x</p>" } })), null);
+  });
+
+  it("defaults visibility to 'public' when missing", () => {
+    const out = parseMentionStatus(notif({ status: { id: "s1", account: { acct: "alice" }, content: "<p>x</p>" } }));
+    assert.equal(out?.visibility, "public");
+  });
+
+  it("defaults content to empty string when missing", () => {
+    const out = parseMentionStatus(notif({ status: { id: "s1", account: { acct: "alice" } } }));
+    assert.equal(out?.text, "");
+  });
+});
+
+describe("parseNotificationRaw", () => {
+  it("parses a valid notification JSON", () => {
+    const raw = JSON.stringify({ type: "mention", status: { id: "s1", visibility: "direct", account: { acct: "alice" }, content: "<p>hi</p>" } });
+    const out = parseNotificationRaw(raw);
+    assert.equal(out?.statusId, "s1");
+  });
+
+  it("returns null for malformed JSON", () => {
+    assert.equal(parseNotificationRaw("not json"), null);
+    assert.equal(parseNotificationRaw(""), null);
+    assert.equal(parseNotificationRaw("{"), null);
+  });
+
+  it("returns null for non-object JSON", () => {
+    assert.equal(parseNotificationRaw("null"), null);
+    assert.equal(parseNotificationRaw("42"), null);
+    assert.equal(parseNotificationRaw('"string"'), null);
+  });
+
+  it("returns null when notification type is not 'mention'", () => {
+    const raw = JSON.stringify({ type: "favourite", status: { id: "s1" } });
+    assert.equal(parseNotificationRaw(raw), null);
+  });
+});
+
+describe("parseFrame", () => {
+  it("parses a valid event frame", () => {
+    const raw = JSON.stringify({ event: "notification", payload: '{"type":"mention"}' });
+    assert.deepEqual(parseFrame(raw), { event: "notification", payload: '{"type":"mention"}' });
+  });
+
+  it("returns null for non-string input", () => {
+    assert.equal(parseFrame(null), null);
+    assert.equal(parseFrame(42), null);
+    assert.equal(parseFrame({}), null);
+  });
+
+  it("returns null for malformed JSON", () => {
+    assert.equal(parseFrame("not json"), null);
+  });
+
+  it("returns null when event or payload is missing / non-string", () => {
+    assert.equal(parseFrame(JSON.stringify({ payload: "x" })), null);
+    assert.equal(parseFrame(JSON.stringify({ event: "x" })), null);
+    assert.equal(parseFrame(JSON.stringify({ event: 1, payload: "x" })), null);
+    assert.equal(parseFrame(JSON.stringify({ event: "x", payload: 1 })), null);
+    assert.equal(parseFrame(JSON.stringify({ event: "", payload: "x" })), null);
+    assert.equal(parseFrame(JSON.stringify({ event: "x", payload: "" })), null);
+  });
+});

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -22,7 +22,7 @@
 import "dotenv/config";
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, formatAckReply } from "@mulmobridge/client";
 import { buildExternalChatId, effectiveThreadTs, parseExternalChatId, parseGranularity } from "./sessionId.js";
 import { parseAckReaction } from "./ackReaction.js";
 import { redactUser } from "./redactUser.js";
@@ -108,18 +108,7 @@ socketMode.on("message", async ({ event, ack }) => {
 
   try {
     const ackResult = await client.send(externalChatId, text);
-    if (ackResult.ok) {
-      await sendChunked(channelId, threadTs, ackResult.reply ?? "");
-    } else {
-      const status = ackResult.status ? ` (${ackResult.status})` : "";
-      await web.chat
-        .postMessage({
-          channel: channelId,
-          text: `Error${status}: ${ackResult.error ?? "unknown"}`,
-          ...(threadTs ? { thread_ts: threadTs } : {}),
-        })
-        .catch((err) => console.error(`[slack] error notification failed: ${err}`));
-    }
+    await sendChunked(channelId, threadTs, formatAckReply(ackResult));
   } catch (err) {
     console.error(`[slack] message handling failed: ${err}`);
   }

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "tsx --test test/test_*.ts"
   },
   "license": "MIT",
   "author": "Receptron Team",
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/bridges/teams/src/index.ts
+++ b/packages/bridges/teams/src/index.ts
@@ -20,7 +20,8 @@
 import "dotenv/config";
 import express, { type Request, type Response } from "express";
 import { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext, type Activity } from "botbuilder";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { extractIncomingMessage } from "./parse.js";
 
 const TRANSPORT_ID = "teams";
 const MAX_TEAMS_TEXT = 28_000; // Teams message limit is 40k; leave headroom for formatting
@@ -96,14 +97,9 @@ async function sendChunked(context: TurnContext, text: string): Promise<void> {
 // ── Incoming handler ────────────────────────────────────────────
 
 async function processMessage(context: TurnContext): Promise<void> {
-  if (context.activity.type !== "message") return;
-
-  const senderId = context.activity.from?.aadObjectId ?? context.activity.from?.id ?? "";
-  const chatId = context.activity.conversation?.id ?? "";
-  const text = (context.activity.text ?? "").trim();
-
-  if (!senderId || !chatId) return;
-  if (!text) return;
+  const incoming = extractIncomingMessage(context.activity);
+  if (!incoming) return;
+  const { senderId, chatId, text } = incoming;
 
   if (!allowAll && !allowedUsers.has(senderId)) {
     console.log(`[teams] denied from=${senderId}`);
@@ -117,12 +113,7 @@ async function processMessage(context: TurnContext): Promise<void> {
 
   try {
     const ack = await mulmo.send(chatId, text);
-    if (ack.ok) {
-      await sendChunked(context, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await sendChunked(context, `Error${status}: ${ack.error ?? "unknown"}`);
-    }
+    await sendChunked(context, formatAckReply(ack));
   } catch (err) {
     console.error(`[teams] message handling failed: ${err}`);
   }

--- a/packages/bridges/teams/src/parse.ts
+++ b/packages/bridges/teams/src/parse.ts
@@ -1,0 +1,26 @@
+// Pure parsing helpers for the Teams bridge.
+
+import type { Activity } from "botbuilder";
+
+export interface IncomingTeamsMessage {
+  senderId: string;
+  chatId: string;
+  text: string;
+}
+
+/**
+ * Pull the senderId / chatId / text triple out of a Teams Activity,
+ * or return null when the activity isn't an actionable user message
+ * (non-message type, blank body, missing identifiers, …).
+ *
+ * Pure — no I/O, no allowlist check. The orchestration layer in
+ * index.ts decides what to do with the parsed result.
+ */
+export function extractIncomingMessage(activity: Activity): IncomingTeamsMessage | null {
+  if (activity.type !== "message") return null;
+  const senderId = activity.from?.aadObjectId ?? activity.from?.id ?? "";
+  const chatId = activity.conversation?.id ?? "";
+  const text = (activity.text ?? "").trim();
+  if (!senderId || !chatId || !text) return null;
+  return { senderId, chatId, text };
+}

--- a/packages/bridges/teams/test/test_parse.ts
+++ b/packages/bridges/teams/test/test_parse.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Activity } from "botbuilder";
+import { extractIncomingMessage } from "../src/parse.js";
+
+function makeActivity(overrides: Partial<Activity>): Activity {
+  return {
+    type: "message",
+    from: { id: "user-123", aadObjectId: "aad-abc" },
+    conversation: { id: "conv-1" },
+    text: "hello",
+    ...overrides,
+  } as Activity;
+}
+
+describe("extractIncomingMessage", () => {
+  it("returns the parsed message for a normal user activity", () => {
+    const out = extractIncomingMessage(makeActivity({}));
+    assert.deepEqual(out, { senderId: "aad-abc", chatId: "conv-1", text: "hello" });
+  });
+
+  it("falls back to from.id when aadObjectId is missing", () => {
+    const out = extractIncomingMessage(makeActivity({ from: { id: "user-99" } }));
+    assert.deepEqual(out, { senderId: "user-99", chatId: "conv-1", text: "hello" });
+  });
+
+  it("trims surrounding whitespace from text", () => {
+    const out = extractIncomingMessage(makeActivity({ text: "   hi   " }));
+    assert.equal(out?.text, "hi");
+  });
+
+  it("returns null when activity type is not 'message'", () => {
+    assert.equal(extractIncomingMessage(makeActivity({ type: "conversationUpdate" })), null);
+    assert.equal(extractIncomingMessage(makeActivity({ type: "typing" })), null);
+  });
+
+  it("returns null when both aadObjectId and id are missing", () => {
+    assert.equal(extractIncomingMessage(makeActivity({ from: {} as Activity["from"] })), null);
+  });
+
+  it("returns null when from is undefined", () => {
+    assert.equal(extractIncomingMessage(makeActivity({ from: undefined })), null);
+  });
+
+  it("returns null when conversation.id is missing", () => {
+    assert.equal(extractIncomingMessage(makeActivity({ conversation: {} as Activity["conversation"] })), null);
+  });
+
+  it("returns null for empty / whitespace-only text", () => {
+    assert.equal(extractIncomingMessage(makeActivity({ text: "" })), null);
+    assert.equal(extractIncomingMessage(makeActivity({ text: "   " })), null);
+    assert.equal(extractIncomingMessage(makeActivity({ text: undefined })), null);
+  });
+
+  it("preserves long text without truncation", () => {
+    const long = "x".repeat(10_000);
+    assert.equal(extractIncomingMessage(makeActivity({ text: long }))?.text, long);
+  });
+});

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "tsx --test test/test_*.ts"
   },
   "license": "MIT",
   "author": "Receptron Team",
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/bridges/xmpp/src/index.ts
+++ b/packages/bridges/xmpp/src/index.ts
@@ -26,7 +26,8 @@
 
 import "dotenv/config";
 import xmppPkg, { type XmlElement } from "@xmpp/client";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { splitJid, parseStanzaFields } from "./parse.js";
 
 const { client, xml } = xmppPkg;
 
@@ -62,17 +63,6 @@ if (!username || !domain) {
   process.exit(1);
 }
 
-function splitJid(fullJid: string): { username: string; domain: string } {
-  const atIdx = fullJid.indexOf("@");
-  if (atIdx < 0) return { username: "", domain: "" };
-  return { username: fullJid.slice(0, atIdx), domain: fullJid.slice(atIdx + 1) };
-}
-
-function bareJid(fullJid: string): string {
-  const slashIdx = fullJid.indexOf("/");
-  return (slashIdx < 0 ? fullJid : fullJid.slice(0, slashIdx)).toLowerCase();
-}
-
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
 const xmpp = client({ service, domain, username, password, resource });
@@ -97,17 +87,15 @@ async function sendChat(toJid: string, text: string): Promise<void> {
 // ── Receive ─────────────────────────────────────────────────────
 
 async function handleStanza(stanza: XmlElement): Promise<void> {
-  if (!stanza.is("message")) return;
-  const stanzaType = stanza.attrs.type ?? "";
-  if (stanzaType !== "chat" && stanzaType !== "normal") return;
-
-  const from = typeof stanza.attrs.from === "string" ? stanza.attrs.from : "";
-  const body = stanza.getChildText("body");
-  if (!from || !body) return;
-
-  const senderBare = bareJid(from);
-  const selfBare = `${username}@${domain}`.toLowerCase();
-  if (senderBare === selfBare) return; // ignore echo
+  const parsed = parseStanzaFields({
+    isMessage: stanza.is("message"),
+    type: stanza.attrs.type,
+    from: stanza.attrs.from,
+    body: stanza.getChildText("body"),
+    selfBare: `${username}@${domain}`.toLowerCase(),
+  });
+  if (!parsed) return;
+  const { from, senderBare, body } = parsed;
 
   if (!allowAll && !allowedJids.has(senderBare)) {
     console.log(`[xmpp] denied from=${senderBare}`);
@@ -125,12 +113,7 @@ async function handleStanza(stanza: XmlElement): Promise<void> {
 
   try {
     const ack = await mulmo.send(senderBare, body);
-    if (ack.ok) {
-      await sendChat(replyTo, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await sendChat(replyTo, `Error${status}: ${ack.error ?? "unknown"}`);
-    }
+    await sendChat(replyTo, formatAckReply(ack));
   } catch (err) {
     console.error(`[xmpp] handleStanza error: ${err}`);
   }

--- a/packages/bridges/xmpp/src/parse.ts
+++ b/packages/bridges/xmpp/src/parse.ts
@@ -1,0 +1,47 @@
+// Pure parsing helpers for the XMPP bridge.
+
+export function splitJid(fullJid: string): { username: string; domain: string } {
+  const atIdx = fullJid.indexOf("@");
+  if (atIdx < 0) return { username: "", domain: "" };
+  return { username: fullJid.slice(0, atIdx), domain: fullJid.slice(atIdx + 1) };
+}
+
+export function bareJid(fullJid: string): string {
+  const slashIdx = fullJid.indexOf("/");
+  return (slashIdx < 0 ? fullJid : fullJid.slice(0, slashIdx)).toLowerCase();
+}
+
+export interface ParsedStanza {
+  from: string;
+  senderBare: string;
+  body: string;
+}
+
+export interface StanzaFields {
+  isMessage: boolean;
+  type: string | undefined;
+  from: unknown;
+  body: string | null;
+  selfBare: string;
+}
+
+/**
+ * Reduce the raw fields lifted out of an XMPP message stanza to the
+ * actionable {from, senderBare, body} triple. Returns null when the
+ * stanza is not a chat/normal message, fields are missing, or the
+ * stanza is an echo of our own message.
+ *
+ * Pure — no XmlElement dependency, no allowlist check. The caller
+ * supplies the fields after touching the @xmpp/client API.
+ */
+export function parseStanzaFields(fields: StanzaFields): ParsedStanza | null {
+  if (!fields.isMessage) return null;
+  const stanzaType = fields.type ?? "";
+  if (stanzaType !== "chat" && stanzaType !== "normal") return null;
+  const from = typeof fields.from === "string" ? fields.from : "";
+  const body = fields.body ?? "";
+  if (!from || !body) return null;
+  const senderBare = bareJid(from);
+  if (senderBare === fields.selfBare) return null; // ignore echo
+  return { from, senderBare, body };
+}

--- a/packages/bridges/xmpp/test/test_parse.ts
+++ b/packages/bridges/xmpp/test/test_parse.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { splitJid, bareJid, parseStanzaFields } from "../src/parse.js";
+
+describe("splitJid", () => {
+  it("splits user@domain into username and domain", () => {
+    assert.deepEqual(splitJid("alice@example.com"), { username: "alice", domain: "example.com" });
+  });
+
+  it("returns empty fields for a JID with no @", () => {
+    assert.deepEqual(splitJid("alice"), { username: "", domain: "" });
+    assert.deepEqual(splitJid(""), { username: "", domain: "" });
+  });
+
+  it("treats a JID starting with @ as no username", () => {
+    assert.deepEqual(splitJid("@example.com"), { username: "", domain: "example.com" });
+  });
+
+  it("preserves the resource part in the domain when present", () => {
+    // splitJid does NOT strip resources — the domain field includes /resource.
+    assert.deepEqual(splitJid("alice@example.com/phone"), { username: "alice", domain: "example.com/phone" });
+  });
+});
+
+describe("bareJid", () => {
+  it("strips the resource", () => {
+    assert.equal(bareJid("alice@example.com/phone"), "alice@example.com");
+  });
+
+  it("returns the JID unchanged when there is no resource", () => {
+    assert.equal(bareJid("alice@example.com"), "alice@example.com");
+  });
+
+  it("lowercases the result", () => {
+    assert.equal(bareJid("Alice@Example.COM/Phone"), "alice@example.com");
+    assert.equal(bareJid("BOB@DOMAIN.NET"), "bob@domain.net");
+  });
+
+  it("handles edge cases without throwing", () => {
+    assert.equal(bareJid(""), "");
+    assert.equal(bareJid("/"), "");
+  });
+});
+
+describe("parseStanzaFields", () => {
+  function fields(overrides: Partial<Parameters<typeof parseStanzaFields>[0]> = {}) {
+    return {
+      isMessage: true,
+      type: "chat",
+      from: "alice@example.com/phone",
+      body: "hello",
+      selfBare: "bot@example.com",
+      ...overrides,
+    };
+  }
+
+  it("returns the parsed message for a normal chat stanza", () => {
+    assert.deepEqual(parseStanzaFields(fields()), {
+      from: "alice@example.com/phone",
+      senderBare: "alice@example.com",
+      body: "hello",
+    });
+  });
+
+  it("accepts type='normal' as well as 'chat'", () => {
+    const out = parseStanzaFields(fields({ type: "normal" }));
+    assert.equal(out?.body, "hello");
+  });
+
+  it("returns null when isMessage is false", () => {
+    assert.equal(parseStanzaFields(fields({ isMessage: false })), null);
+  });
+
+  it("returns null for groupchat / headline / error types", () => {
+    assert.equal(parseStanzaFields(fields({ type: "groupchat" })), null);
+    assert.equal(parseStanzaFields(fields({ type: "headline" })), null);
+    assert.equal(parseStanzaFields(fields({ type: "error" })), null);
+  });
+
+  it("treats missing type as default (returns null since no chat/normal)", () => {
+    // Spec says missing type defaults to "normal" — but the bridge
+    // mirrors the original index.ts behaviour, which used the bare
+    // attrs.type and only allowed "chat"/"normal" exact strings.
+    assert.equal(parseStanzaFields(fields({ type: undefined })), null);
+  });
+
+  it("returns null when from is missing or non-string", () => {
+    assert.equal(parseStanzaFields(fields({ from: undefined })), null);
+    assert.equal(parseStanzaFields(fields({ from: 42 })), null);
+    assert.equal(parseStanzaFields(fields({ from: null })), null);
+    assert.equal(parseStanzaFields(fields({ from: "" })), null);
+  });
+
+  it("returns null when body is missing or empty", () => {
+    assert.equal(parseStanzaFields(fields({ body: null })), null);
+    assert.equal(parseStanzaFields(fields({ body: "" })), null);
+  });
+
+  it("ignores echoes of our own message (senderBare === selfBare)", () => {
+    assert.equal(parseStanzaFields(fields({ from: "bot@example.com/server", selfBare: "bot@example.com" })), null);
+  });
+
+  it("matches selfBare case-insensitively via bareJid lowercasing", () => {
+    assert.equal(parseStanzaFields(fields({ from: "BOT@EXAMPLE.COM/server", selfBare: "bot@example.com" })), null);
+  });
+
+  it("preserves the full JID in the from field", () => {
+    const out = parseStanzaFields(fields({ from: "alice@example.com/laptop" }));
+    assert.equal(out?.from, "alice@example.com/laptop");
+    assert.equal(out?.senderBare, "alice@example.com");
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,6 +8,8 @@ export { readBridgeEnvOptions } from "./options.js";
 
 export { chunkText } from "./text.js";
 
+export { formatAckReply } from "./reply.js";
+
 export {
   mimeFromExtension,
   isImageMime,

--- a/packages/client/src/reply.ts
+++ b/packages/client/src/reply.ts
@@ -1,0 +1,21 @@
+// Shared reply formatting for bridges.
+//
+// Every bridge converts a `MessageAck` from `BridgeClient.send()`
+// into a single string to send back over its native transport. The
+// happy-path / error-path shape is identical across bridges
+// (LINE / Slack / Teams / Mastodon / XMPP all do the same thing
+// modulo the send call), so the formatting belongs here.
+
+import type { MessageAck } from "./client.js";
+
+/**
+ * Format a `MessageAck` as a single user-facing string.
+ *
+ * - `ok` ack → `reply` content (or empty string if absent).
+ * - Failed ack → `"Error[ (status)]: <error or 'unknown'>"`.
+ */
+export function formatAckReply(ack: MessageAck): string {
+  if (ack.ok) return ack.reply ?? "";
+  const status = ack.status ? ` (${ack.status})` : "";
+  return `Error${status}: ${ack.error ?? "unknown"}`;
+}

--- a/packages/client/test/test_reply.ts
+++ b/packages/client/test/test_reply.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatAckReply } from "../src/index.ts";
+
+describe("formatAckReply", () => {
+  it("returns the reply on success", () => {
+    assert.equal(formatAckReply({ ok: true, reply: "hello" }), "hello");
+  });
+
+  it("returns empty string when ok with no reply", () => {
+    assert.equal(formatAckReply({ ok: true }), "");
+    assert.equal(formatAckReply({ ok: true, reply: undefined }), "");
+  });
+
+  it("preserves an empty-string reply on success", () => {
+    assert.equal(formatAckReply({ ok: true, reply: "" }), "");
+  });
+
+  it("formats error without status", () => {
+    assert.equal(formatAckReply({ ok: false, error: "boom" }), "Error: boom");
+  });
+
+  it("formats error with status code", () => {
+    assert.equal(formatAckReply({ ok: false, error: "boom", status: 503 }), "Error (503): boom");
+  });
+
+  it("falls back to 'unknown' when error is missing", () => {
+    assert.equal(formatAckReply({ ok: false }), "Error: unknown");
+    assert.equal(formatAckReply({ ok: false, status: 500 }), "Error (500): unknown");
+  });
+
+  it("treats status 0 as no status (falsy)", () => {
+    assert.equal(formatAckReply({ ok: false, error: "x", status: 0 }), "Error: x");
+  });
+
+  it("does not coerce numeric status to a different format", () => {
+    assert.equal(formatAckReply({ ok: false, error: "rate-limited", status: 429 }), "Error (429): rate-limited");
+  });
+});

--- a/packages/relay/src/webhooks/line.ts
+++ b/packages/relay/src/webhooks/line.ts
@@ -5,7 +5,7 @@ import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { makeUuid } from "../utils/id.js";
 
-interface LineEvent {
+export interface LineEvent {
   type: string;
   message?: { type: string; text?: string; id?: string };
   source?: { userId?: string; groupId?: string; roomId?: string };
@@ -18,6 +18,28 @@ interface LineWebhookBody {
 
 const MAX_LINE_MESSAGES_PER_REQUEST = 5;
 const MAX_LINE_TEXT = 5000;
+
+export interface ParsedLineEvent {
+  chatId: string;
+  senderId: string;
+  text: string;
+  replyToken?: string;
+}
+
+/**
+ * Pure: reduce a LINE webhook event to the actionable
+ * chatId / senderId / text triple, or null when the event isn't a
+ * deliverable text message. Group / room source IDs win over the
+ * sender's userId so a single LINE chat session maps to one
+ * MulmoClaude chatId.
+ */
+export function parseLineMessageEvent(event: LineEvent): ParsedLineEvent | null {
+  if (event.type !== "message" || event.message?.type !== "text") return null;
+  if (!event.message.text) return null;
+  const chatId = event.source?.groupId ?? event.source?.roomId ?? event.source?.userId ?? "unknown";
+  const senderId = event.source?.userId ?? "unknown";
+  return { chatId, senderId, text: event.message.text, replyToken: event.replyToken };
+}
 
 // ── Signature verification ──────────────────────────────────────
 
@@ -57,19 +79,16 @@ const linePlugin: PlatformPlugin = {
     const messages: RelayMessage[] = [];
 
     for (const event of parsed.events) {
-      if (event.type !== "message" || event.message?.type !== "text") continue;
-      if (!event.message.text) continue;
-
-      const chatId = event.source?.groupId ?? event.source?.roomId ?? event.source?.userId ?? "unknown";
-
+      const parsedEvent = parseLineMessageEvent(event);
+      if (!parsedEvent) continue;
       messages.push({
         id: makeUuid(),
         platform: PLATFORMS.line,
-        senderId: event.source?.userId ?? "unknown",
-        chatId,
-        text: event.message.text,
+        senderId: parsedEvent.senderId,
+        chatId: parsedEvent.chatId,
+        text: parsedEvent.text,
         receivedAt: new Date().toISOString(),
-        replyToken: event.replyToken,
+        replyToken: parsedEvent.replyToken,
       });
     }
 

--- a/packages/relay/test/test_line_webhook.ts
+++ b/packages/relay/test/test_line_webhook.ts
@@ -1,0 +1,87 @@
+// Regression tests for the LINE webhook event parser. Same shape as
+// test_google_chat_webhook.ts / test_teams_webhook.ts: only the pure
+// helper is exercised here — HMAC signature verification is out of
+// scope.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseLineMessageEvent, type LineEvent } from "../src/webhooks/line.ts";
+
+function textEvent(overrides: Partial<LineEvent> = {}): LineEvent {
+  return {
+    type: "message",
+    message: { type: "text", text: "hello" },
+    source: { userId: "U123" },
+    replyToken: "tok-1",
+    ...overrides,
+  };
+}
+
+describe("parseLineMessageEvent", () => {
+  it("parses a 1:1 text message — chatId falls back to userId", () => {
+    assert.deepEqual(parseLineMessageEvent(textEvent()), {
+      chatId: "U123",
+      senderId: "U123",
+      text: "hello",
+      replyToken: "tok-1",
+    });
+  });
+
+  it("uses groupId for the chatId when available (group win over user)", () => {
+    const out = parseLineMessageEvent(textEvent({ source: { groupId: "G1", userId: "U123" } }));
+    assert.deepEqual(out, { chatId: "G1", senderId: "U123", text: "hello", replyToken: "tok-1" });
+  });
+
+  it("uses roomId when no groupId is present", () => {
+    const out = parseLineMessageEvent(textEvent({ source: { roomId: "R1", userId: "U123" } }));
+    assert.deepEqual(out, { chatId: "R1", senderId: "U123", text: "hello", replyToken: "tok-1" });
+  });
+
+  it("groupId wins over roomId", () => {
+    const out = parseLineMessageEvent(textEvent({ source: { groupId: "G1", roomId: "R1", userId: "U123" } }));
+    assert.equal(out?.chatId, "G1");
+  });
+
+  it("uses 'unknown' when no source identifier is present", () => {
+    const out = parseLineMessageEvent(textEvent({ source: {} }));
+    assert.deepEqual(out, { chatId: "unknown", senderId: "unknown", text: "hello", replyToken: "tok-1" });
+  });
+
+  it("uses 'unknown' for both fields when source is missing entirely", () => {
+    const out = parseLineMessageEvent(textEvent({ source: undefined }));
+    assert.deepEqual(out, { chatId: "unknown", senderId: "unknown", text: "hello", replyToken: "tok-1" });
+  });
+
+  it("returns null for non-message event types", () => {
+    assert.equal(parseLineMessageEvent(textEvent({ type: "follow" })), null);
+    assert.equal(parseLineMessageEvent(textEvent({ type: "unfollow" })), null);
+    assert.equal(parseLineMessageEvent(textEvent({ type: "postback" })), null);
+  });
+
+  it("returns null when message type is not 'text'", () => {
+    assert.equal(parseLineMessageEvent(textEvent({ message: { type: "image" } })), null);
+    assert.equal(parseLineMessageEvent(textEvent({ message: { type: "sticker" } })), null);
+  });
+
+  it("returns null when message is missing entirely", () => {
+    assert.equal(parseLineMessageEvent({ type: "message", source: { userId: "U1" } }), null);
+  });
+
+  it("returns null when text field is missing or empty", () => {
+    assert.equal(parseLineMessageEvent(textEvent({ message: { type: "text" } })), null);
+    assert.equal(parseLineMessageEvent(textEvent({ message: { type: "text", text: "" } })), null);
+  });
+
+  it("preserves whitespace text (does not trim — caller decides)", () => {
+    const out = parseLineMessageEvent(textEvent({ message: { type: "text", text: "  hi  " } }));
+    assert.equal(out?.text, "  hi  ");
+  });
+
+  it("preserves replyToken", () => {
+    assert.equal(parseLineMessageEvent(textEvent({ replyToken: "abc" }))?.replyToken, "abc");
+  });
+
+  it("returns undefined replyToken when not present", () => {
+    assert.equal(parseLineMessageEvent(textEvent({ replyToken: undefined }))?.replyToken, undefined);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,6 +1065,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -3056,6 +3063,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@14.0.0:
   version "14.0.0"
@@ -6032,10 +6044,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -7828,6 +7847,17 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.13:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
+  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8617,6 +8647,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
> Stacked on top of #984. Base reverts to \`main\` automatically once that PR merges.

## Summary

- 6 cognitive-complexity violations across \`packages/bridges/\` and \`packages/relay/\` (line, mastodon, slack, teams, xmpp, relay/line) — eliminated by extracting pure parse / format helpers into per-package \`parse.ts\` modules with full \`node:test\` coverage.
- Net: **lint 46 → 40 warnings** (all 6 \`complexity\` rule violations in \`bridges/\` + \`relay/\` cleared). Test count: ~3810 total, all pass.
- Adds one shared helper to \`@mulmobridge/client\`: \`formatAckReply(ack: MessageAck): string\`. Replaces the same 5-line \`if (ack.ok) ack.reply ?? "" else "Error..."\` duplicated across 5 bridges. 8 unit tests for the helper.

## Items to Confirm / Review

- **Slack error-path log shape change.** Previously, a failed \`web.chat.postMessage\` for the *error notification* logged \`[slack] error notification failed: <err>\` via a local \`.catch\`. With the refactor, errors flow through \`sendChunked\` (same call path as ok replies) and surface as \`[slack] message handling failed: <err>\` via the existing outer try/catch. User-visible output is identical for the short error string (fits in one chunk). Same severity, just a different log prefix. Worth flagging because anyone grepping for the old prefix will need to switch.
- **\`@mulmobridge/client\` adds a new export (\`formatAckReply\`).** Locally fine via yarn workspace symlink; for published bridges to use it, \`client\` needs a version bump + \`/publish\` *before* the next bridges release. No publishing happens in this PR. Same coordination story as \`/publish-mulmoclaude\` already documents for client→bridge updates.
- **Mastodon parse extraction.** \`htmlToText\` / \`stripLeadingMentions\` / \`parseMentionStatus\` / \`parseFrame\` are now in \`parse.ts\` and tested directly. The \`security/detect-unsafe-regex\` disable on the SINGLE_MENTION_RE moved with the regex — same audited rationale, same iterative caller.
- **XMPP \`parseStanzaFields\`.** Takes a plain \`StanzaFields\` object (\`isMessage\`, \`type\`, \`from\`, \`body\`, \`selfBare\`) rather than an \`XmlElement\`, so it stays purely testable; the caller does the API touching (\`stanza.is(...)\`, \`stanza.attrs.type\`, \`stanza.getChildText("body")\`) and feeds the result in.
- **\`teams\` / \`mastodon\` / \`xmpp\` / \`line\` bridges had no test runner before.** Their \`package.json\` switched from \`echo no tests yet\` → \`tsx --test test/test_*.ts\` and \`tsx\` is a new devDep on each.

## User Prompt

> bridageとrelayのcomplexityは直す。そのときにきちんと関数化して、できればpure関数化できるものは関数化してunit testを追加して。

## What pure helpers were extracted

| Bridge | New pure helper(s) | Tests |
|---|---|---|
| \`@mulmobridge/client\` | \`formatAckReply\` | 8 |
| \`bridges/teams\` | \`extractIncomingMessage(activity)\` | 9 |
| \`bridges/line\` | \`extractIncomingLineMessage\`, \`parseLineWebhookBody\` | 13 |
| \`bridges/mastodon\` | \`htmlToText\`, \`stripLeadingMentions\`, \`parseMentionStatus\`, \`parseNotificationRaw\`, \`parseFrame\`, \`isObj\` | 32 |
| \`bridges/xmpp\` | \`splitJid\`, \`bareJid\`, \`parseStanzaFields\` | 18 |
| \`relay/line\` | \`parseLineMessageEvent\` | 13 |
| \`bridges/slack\` | (uses shared \`formatAckReply\`; no new helper file) | — |

## Validation

- \`yarn format\` ✓
- \`yarn lint\` ✓ (46 → 40 warnings, 0 errors; complexity violations in bridges/ + relay/ all gone)
- \`yarn typecheck\` ✓
- \`yarn build\` ✓
- \`yarn test\` ✓ (3810 tests across all packages, all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)