### PR TITLE
fix(presentHtml): unblock same-origin <img> on Safari (CSP 'self' + dev proxy)

### DIFF
--- a/plans/fix-presenthtml-csp-safari.md
+++ b/plans/fix-presenthtml-csp-safari.md
@@ -1,0 +1,98 @@
+# presentHtml プレビューの CSP が Safari で同一オリジン画像をブロックする問題の修正
+
+## 概要
+
+PR #982 で `presentHtml` のプレビューを `<iframe :src="/artifacts/html/...">` + `sandbox="allow-scripts"` に切り替えてから、Safari で `<img src="../images/...">` がすべて CSP `img-src` 違反でブロックされる:
+
+```
+[Error] Refused to load http://localhost:5173/artifacts/images/2026/04/<hash>.png
+because it does not appear in the img-src directive of the Content Security Policy.
+```
+
+Chrome では同じ HTML が問題なく動く。
+
+## 原因
+
+二段階の問題が重なっていた:
+
+### 1. `'self'` がオパーク・オリジンの iframe で機能しない (Safari)
+
+iframe は `sandbox="allow-scripts"` のみ — `allow-same-origin` を意図的に外している(PR #982 のセキュリティ強化)。CSP3 の仕様上、サンドボックスでオパーク・オリジンになったドキュメントでも `'self'` はドキュメント URL のスキーム/ホスト/ポートに対してマッチすべきだが、**Safari/WebKit は `'self'` をオリジン・タプルに対して評価する**。オパーク・オリジンに同一オリジン URL は決してマッチしないため、`/artifacts/images/...` への参照がすべて拒否される。
+
+Chrome は `'self'` をドキュメント URL に対してマッチする実装(仕様準拠)なので動いてしまう。
+
+PR #982 ではすでに **print iframe**(`srcdoc` でロード → 確実にオパーク・オリジン)で同じ問題に当たっており、`buildPrintCspContent(origin)` で `'self'` を明示オリジンに置き換えるパッチが入っている。**プレビュー側だけ対応漏れだった**。
+
+### 2. dev で Vite proxy が `Host` を書き換えている
+
+サーバが `req.get("host")` から組み立てたオリジンを CSP に入れる素朴な実装だと、dev では誤った値になる:
+
+- ブラウザ: `http://localhost:5173/artifacts/html/...`(Vite dev server 経由)
+- Vite が `/artifacts/html` を `localhost:3001` の Express にプロキシする際、`changeOrigin: true` で `Host` ヘッダを `localhost:3001` に書き換える
+- Express の `req.get("host")` は `localhost:3001` を返す
+- CSP が `img-src http://localhost:3001 ...` で送られる
+- iframe ドキュメントのオリジンは `localhost:5173` → 同一オリジンの画像参照が CSP にマッチせず、結局ブロックされる
+
+prod では Vite 経由ではないので `req.get("host")` で正しいが、dev でだけ壊れる。
+
+## 修正方針
+
+### A. `buildHtmlPreviewCsp` にオプション引数 `origin` を足す
+
+`origin` が渡されたら `img-src 'self' ...` ではなく `img-src ${origin} ...` を出力する。`buildPrintCspContent` と同じ仕組み(後者は前者へ委譲する thin wrapper にする)。
+
+省略時は `'self'` のまま — `wrapHtmlWithPreviewCsp` 経由の `srcdoc` フォールバック(FileContentRenderer の非 `/artifacts/html` パス)はそのまま動く。
+
+### B. Express で X-Forwarded-Host を尊重
+
+`/artifacts/html` のミドルウェアで CSP ヘッダを組み立てるとき:
+
+```ts
+const fwdHost = req.get("x-forwarded-host");
+const fwdProto = req.get("x-forwarded-proto");
+const host = fwdHost ?? req.get("host");
+const proto = fwdProto ?? req.protocol;
+const origin = `${proto}://${host}`;
+res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp(origin));
+```
+
+prod ではフォワード・ヘッダが無いので生の `Host` / `req.protocol` にフォールバック。
+
+### C. Vite に `xfwd: true` を追加
+
+`/artifacts/html` プロキシ・エントリで `changeOrigin: true` と並べて `xfwd: true` を有効化。これで `X-Forwarded-Host` / `X-Forwarded-Proto` がオリジナル値(`localhost:5173` / `http`)で Express に届く。
+
+`changeOrigin` は残すこと — 削るとプロキシ先によっては仮想ホスト・ルーティングが壊れる可能性がある。両方有効化が標準パターン。
+
+## 変更内容
+
+| ファイル | 変更 |
+|---|---|
+| `src/utils/html/previewCsp.ts` | `buildHtmlPreviewCsp(origin?, cdns?)` に拡張。`buildPrintCspContent` を委譲化 |
+| `server/index.ts` | `/artifacts/html` ミドルウェアで `X-Forwarded-Host`/`Proto` を見て origin を組み立てて `buildHtmlPreviewCsp(origin)` に渡す。古いコメント(「`'self'` がサーバ・オリジンにマッチする」)を実態に合わせて差し替え |
+| `vite.config.ts` | `/artifacts/html` プロキシに `xfwd: true` を追加。理由を 1 段落でコメント |
+| `test/utils/html/test_previewCsp.ts` | `buildHtmlPreviewCsp(origin)` の origin 置換テストを追加。既存の `'self'` デフォルト・テストはそのまま |
+
+prod 路線に影響なし(オリジンが正しく取れるだけ)。`srcdoc` フォールバック路線(`wrapHtmlWithPreviewCsp`)もそのまま — `'self'` を使い続ける。
+
+## テスト
+
+### 自動
+
+- `yarn test` — `test_previewCsp.ts` の追加テスト + 既存テストすべて pass
+- `yarn lint` / `yarn typecheck` / `yarn build` 緑
+
+### 手動 (Safari)
+
+1. `yarn dev` 再起動 (Vite config 変更を取り込むため)
+2. `presentHtml` で画像を含むスライドを生成
+3. プレビュー iframe で画像が表示されることを確認
+4. DevTools → Network → `/artifacts/html/<...>.html` のレスポンス・ヘッダを確認:
+   - `Content-Security-Policy: ... img-src http://localhost:5173 ...` (5173 になっていること)
+5. 同じく Chrome で regress していないこと
+6. `Save as PDF` で印刷ダイアログまで進めて画像が乗っていることを確認(print 経路は元から `buildPrintCspContent` を使っているので影響なし、念のため)
+
+## 関連
+
+- PR #982: presentHtml の filePath-only 移行(本問題のリグレッション元)
+- PR #980: `/artifacts/html` static mount の導入

--- a/server/index.ts
+++ b/server/index.ts
@@ -201,11 +201,14 @@ app.use(
 // guard against cross-origin abuse.
 //
 // CSP delivered via HTTP header instead of injecting a `<meta>` tag —
-// keeps the served file pristine, and `'self'` finally matches the
-// server origin (which is what allows `<img src="../images/...">` to
-// reach `/artifacts/images/...`). Sandbox stays `allow-scripts` only,
-// so the iframe document is still opaque-origin and cannot read the
-// parent's cookies / localStorage / DOM.
+// keeps the served file pristine. The explicit request origin is
+// passed into `buildHtmlPreviewCsp` instead of relying on `'self'`:
+// the iframe is `sandbox="allow-scripts"` only, so its document has an
+// opaque origin and Safari/WebKit interprets `'self'` against that
+// (null) origin, blocking every same-origin `<img src="../images/...">`
+// reference. Substituting the absolute origin restores cross-browser
+// parity. Sandbox stays `allow-scripts` only, so the iframe document
+// still cannot read the parent's cookies / localStorage / DOM.
 const HTML_EXT_RE = /\.html?$/i;
 let htmlsDirReal: string | null = null;
 async function getHtmlsDirReal(): Promise<string | null> {
@@ -240,7 +243,17 @@ app.use(
       res.status(404).end();
       return;
     }
-    res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp());
+    // Honour `X-Forwarded-*` so dev (Vite proxies `/artifacts/html` →
+    // `localhost:3001` with `changeOrigin: true`) emits the
+    // browser-visible origin (`localhost:5173`) rather than the upstream
+    // socket. In prod (no proxy) the headers are absent and we fall
+    // back to the raw `Host` / `req.protocol`.
+    const fwdHost = req.get("x-forwarded-host");
+    const fwdProto = req.get("x-forwarded-proto");
+    const host = fwdHost ?? req.get("host");
+    const proto = fwdProto ?? req.protocol;
+    const origin = `${proto}://${host}`;
+    res.setHeader("Content-Security-Policy", buildHtmlPreviewCsp(origin));
     res.setHeader("X-Content-Type-Options", "nosniff");
     next();
   },

--- a/src/utils/html/previewCsp.ts
+++ b/src/utils/html/previewCsp.ts
@@ -19,9 +19,19 @@ export const HTML_PREVIEW_CSP_ALLOWED_CDNS: readonly string[] = [
 /**
  * Build the CSP string. Split from the wrapper so tests can exercise
  * the policy without HTML-template noise.
+ *
+ * `origin`, when provided, replaces `'self'` in `img-src`. The preview
+ * iframe is `sandbox="allow-scripts"` only, so its document has an
+ * opaque origin: Safari/WebKit matches `'self'` against the (opaque)
+ * origin tuple and rejects every same-origin image request. Chrome
+ * matches `'self'` against the document URL and works either way. Pass
+ * the explicit server origin from HTTP-header callers; leave it
+ * undefined for the `srcdoc` fallback (where `'self'` is meaningless
+ * either way and there are no same-origin refs to resolve).
  */
-export function buildHtmlPreviewCsp(cdns: readonly string[] = HTML_PREVIEW_CSP_ALLOWED_CDNS): string {
+export function buildHtmlPreviewCsp(origin?: string, cdns: readonly string[] = HTML_PREVIEW_CSP_ALLOWED_CDNS): string {
   const cdnList = cdns.join(" ");
+  const imgSelf = origin ?? "'self'";
   return [
     "default-src 'none'",
     // LLM-authored HTML almost always uses inline <script> blocks
@@ -37,7 +47,7 @@ export function buildHtmlPreviewCsp(cdns: readonly string[] = HTML_PREVIEW_CSP_A
     // could exfiltrate data via image requests even with connect-src
     // blocked. Widen via HTML_PREVIEW_CSP_ALLOWED_CDNS if LLM output
     // legitimately needs more hosts.
-    `img-src 'self' ${cdnList} data: blob:`,
+    `img-src ${imgSelf} ${cdnList} data: blob:`,
     // Block XHR / fetch / WebSocket so previews can't phone home or
     // exfiltrate anything the inline scripts happen to compute.
     "connect-src 'none'",
@@ -46,25 +56,12 @@ export function buildHtmlPreviewCsp(cdns: readonly string[] = HTML_PREVIEW_CSP_A
 
 /**
  * Build the CSP string for the print-mode hidden iframe (presentHtml's
- * printToPdf). The print iframe loads via `srcdoc`, so its document
- * has an opaque origin: `'self'` no longer matches the server origin
- * and same-origin `<img src="/artifacts/images/...">` would be blocked.
- *
- * Same shape as `buildHtmlPreviewCsp` but with `img-src` widened from
- * `'self'` to the explicit `${origin}` so workspace images keep
- * loading after the `<base href>` injection rewrites their relative
- * URLs to absolute server URLs.
+ * printToPdf). Same policy as the preview header with the explicit
+ * server origin substituted for `'self'` — see `buildHtmlPreviewCsp`
+ * for why the substitution is required.
  */
 export function buildPrintCspContent(origin: string, cdns: readonly string[] = HTML_PREVIEW_CSP_ALLOWED_CDNS): string {
-  const cdnList = cdns.join(" ");
-  return [
-    "default-src 'none'",
-    `script-src 'unsafe-inline' ${cdnList}`,
-    `style-src 'unsafe-inline' ${cdnList}`,
-    `font-src ${cdnList}`,
-    `img-src ${origin} ${cdnList} data: blob:`,
-    "connect-src 'none'",
-  ].join("; ");
+  return buildHtmlPreviewCsp(origin, cdns);
 }
 
 const CSP_META_NONCE = ""; // reserved for future use (per-render nonce)

--- a/test/utils/html/test_previewCsp.ts
+++ b/test/utils/html/test_previewCsp.ts
@@ -42,9 +42,18 @@ describe("buildHtmlPreviewCsp", () => {
   });
 
   it("accepts a custom CDN list", () => {
-    const csp = buildHtmlPreviewCsp(["https://example.com"]);
+    const csp = buildHtmlPreviewCsp(undefined, ["https://example.com"]);
     assert.ok(csp.includes("script-src 'unsafe-inline' https://example.com"));
     assert.ok(!csp.includes("jsdelivr"));
+  });
+
+  it("substitutes the explicit origin for 'self' in img-src when provided", () => {
+    // Required for Safari: the preview iframe is sandbox="allow-scripts"
+    // only, so its document has an opaque origin and 'self' fails to
+    // match same-origin /artifacts/images/... requests.
+    const csp = buildHtmlPreviewCsp("http://localhost:5173");
+    assert.ok(csp.includes("img-src http://localhost:5173 https://cdn.jsdelivr.net"));
+    assert.ok(!csp.includes("img-src 'self'"));
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,9 +77,18 @@ export default defineConfig({
       // `/src/main.ts` into the response, which the iframe (opaque origin) then
       // tries to load and the browser blocks via CORS. Forwarding to Express
       // returns the file untouched plus the CSP HTTP header.
+      //
+      // `xfwd: true` adds `X-Forwarded-Host` / `X-Forwarded-Proto` so Express
+      // can recover the browser-visible origin (`localhost:5173`) when emitting
+      // the CSP `img-src` directive. `changeOrigin: true` rewrites `Host` to
+      // the upstream `localhost:3001`, so without xfwd the CSP would advertise
+      // the wrong origin and Safari would block every `<img src="../images/...">`
+      // request (Chrome happens to be lenient because images route through the
+      // same proxy).
       '/artifacts/html': {
         target: 'http://localhost:3001',
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       },
       '/ws': {
         target: 'ws://localhost:3001',


### PR DESCRIPTION
## Summary

- Preview iframe is `sandbox="allow-scripts"` only → opaque origin. **Safari** evaluates CSP `'self'` against the (null) origin tuple and rejects every `<img src="../images/...">`; **Chrome** matches `'self'` against the document URL and works either way. Same class of bug #982 already fixed for the print iframe — preview path was missed.
- `buildHtmlPreviewCsp` now accepts an optional `origin`; when present, `img-src` uses it instead of `'self'`. `buildPrintCspContent` becomes a thin delegate so there is one source of truth.
- Server pulls the browser-visible origin from `X-Forwarded-Host` / `X-Forwarded-Proto` (falls back to raw `Host` / `req.protocol` in prod). Vite's `/artifacts/html` proxy now sets `xfwd: true` so the original `localhost:5173` survives `changeOrigin: true`'s `Host` rewrite.
- `srcdoc` fallback path (`wrapHtmlWithPreviewCsp`) is untouched — `'self'` is meaningless there but there are no same-origin refs to resolve either.
- Plan: `plans/fix-presenthtml-csp-safari.md`.

## Why

After #982, opening any `presentHtml` result on Safari logs:

```
Refused to load http://localhost:5173/artifacts/images/2026/04/<hash>.png
because it does not appear in the img-src directive of the Content Security Policy.
```

Reported and reproduced; Chrome unaffected.

## Test plan

- [ ] `yarn test` — new origin-substitution test in `test_previewCsp.ts` passes; existing `'self'` tests still pass
- [ ] `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` green
- [ ] Restart `yarn dev`, open a presentHtml result in **Safari** — images render, no CSP errors in console
- [ ] DevTools → Network → response headers on `/artifacts/html/<...>.html`: `Content-Security-Policy: ... img-src http://localhost:5173 ...` (5173, not 3001)
- [ ] Same flow on **Chrome** — no regression
- [ ] **Print** path (`Save as PDF`) still works (already used `buildPrintCspContent`, unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)