### PR TITLE
refactor(session): split buildLiveSummary + graduate complexity / no-dynamic-delete to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -237,7 +237,7 @@ export default [
       "consistent-return": "error",
       "class-methods-use-this": "error",
       "prefer-destructuring": "error",
-      complexity: ["warn", { max: 15 }],
+      complexity: ["error", { max: 15 }],
       "max-depth": ["error", { max: 4 }],
       "max-params": ["error", { max: 6 }],
       quotes: "off",
@@ -331,6 +331,30 @@ export default [
       // `no-explicit-any` at `error` in production code; demote to
       // warn inside tests.
       "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+  {
+    // Server-side override: cyclomatic `complexity` stays at `warn`
+    // here because the API route handlers have several legitimately
+    // branchy functions (validation + auth + business logic in one
+    // place) that would need a coordinated split before they can
+    // graduate. Frontend / shared `src/` code has no such concentration
+    // and is held to `error`; over time `server/` should converge.
+    files: ["server/**/*.{ts,js}"],
+    rules: {
+      complexity: ["warn", { max: 15 }],
+    },
+  },
+  {
+    // `packages/` is already clean of dynamic-delete (0 violations on
+    // the survey that drove this rule graduation). Hold it to `error`
+    // so a future regression there fails CI immediately. `src/` still
+    // has ~30 violations (concentrated in presentMulmoScript/View.vue)
+    // and `server/` has 3 — both stay at `warn` until those land in
+    // their own cleanup PRs, then this override can widen.
+    files: ["packages/**/*.{ts,js}"],
+    rules: {
+      "@typescript-eslint/no-dynamic-delete": "error",
     },
   },
   {

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -11,6 +11,43 @@
 import { isUserTextResponse } from "../tools/result";
 import type { SessionSummary, ActiveSession } from "../../types/session";
 
+// Server-side fields the sidebar inherits when present. `summary` /
+// `keywords` are AI-generated; `origin` distinguishes scheduler /
+// skill / bridge / human sessions; `isBookmarked` / `hasUnread` /
+// `statusMessage` are server-tracked flags. None of these have a
+// local fallback — copy them only when the server has actually set
+// them, otherwise they'd surface as explicit `undefined` in shallow
+// copies downstream.
+const SERVER_OVERRIDE_KEYS = ["summary", "keywords", "origin", "isBookmarked", "hasUnread", "statusMessage"] as const;
+
+export function pickServerOverrides(serverEntry: SessionSummary | undefined): Partial<SessionSummary> {
+  if (!serverEntry) return {};
+  const overrides: Partial<SessionSummary> = {};
+  for (const key of SERVER_OVERRIDE_KEYS) {
+    const value = serverEntry[key];
+    if (value !== undefined) {
+      Object.assign(overrides, { [key]: value });
+    }
+  }
+  return overrides;
+}
+
+// Fold every in-memory signal into isRunning so the sidebar spinner
+// reacts as fast as the fastest source:
+//   - serverEntry.isRunning: authoritative but arrives on a /api/sessions
+//     refetch
+//   - live.isRunning: mirrored from the server via refreshSessionStates;
+//     may be ahead during the refetch window, and covers live-only
+//     sessions with no serverEntry yet
+//   - live.pendingGenerations: updates on the socket round-trip of a
+//     generationStarted event, before any REST refetch
+// OR them so any one is enough. `live.isRunning` is always defined on
+// an ActiveSession, so the summary always carries a boolean here.
+export function computeLiveIsRunning(serverEntry: SessionSummary | undefined, live: Pick<ActiveSession, "isRunning" | "pendingGenerations">): boolean {
+  const pendingCount = Object.keys(live.pendingGenerations ?? {}).length;
+  return Boolean(serverEntry?.isRunning) || live.isRunning || pendingCount > 0;
+}
+
 // Build the summary shape the sidebar expects for a single live
 // session. Server-side data (AI-generated title, summary,
 // keywords) takes precedence over the local first-user-message
@@ -19,51 +56,14 @@ import type { SessionSummary, ActiveSession } from "../../types/session";
 function buildLiveSummary(live: ActiveSession, serverEntry: SessionSummary | undefined): SessionSummary {
   const firstUserMsg = live.toolResults.find(isUserTextResponse);
   const preview = serverEntry?.preview || (firstUserMsg?.message ?? "");
-  const base: SessionSummary = {
+  return {
     id: live.id,
     roleId: live.roleId,
     startedAt: live.startedAt,
     updatedAt: live.updatedAt,
     preview,
-  };
-  // Fold every in-memory signal into isRunning so the sidebar spinner
-  // reacts as fast as the fastest source:
-  //   - serverEntry.isRunning: authoritative but arrives on a /api/sessions
-  //     refetch
-  //   - live.isRunning: mirrored from the server via refreshSessionStates;
-  //     may be ahead during the refetch window, and covers live-only
-  //     sessions with no serverEntry yet
-  //   - live.pendingGenerations: updates on the socket round-trip of a
-  //     generationStarted event, before any REST refetch
-  // OR them so any one is enough. `live.isRunning` is always defined on
-  // an ActiveSession, so the summary always carries a boolean here.
-  const pending = live.pendingGenerations ?? {};
-  const isRunning = Boolean(serverEntry?.isRunning) || live.isRunning || Object.keys(pending).length > 0;
-  // Carry summary / keywords ONLY if the server already has them.
-  // Object-spread with a conditional object keeps us from adding
-  // `undefined` values that would otherwise show up as explicit
-  // `summary: undefined` in a later shallow-copy.
-  return {
-    ...base,
-    ...(serverEntry?.summary !== undefined && { summary: serverEntry.summary }),
-    ...(serverEntry?.keywords !== undefined && {
-      keywords: serverEntry.keywords,
-    }),
-    // `origin` is set once by the server when the session is created
-    // (scheduler / skill / bridge / human). A live session promoted
-    // from the server list must keep it — the tab bar renders the
-    // non-human glyph off this field.
-    ...(serverEntry?.origin !== undefined && { origin: serverEntry.origin }),
-    ...(serverEntry?.isBookmarked !== undefined && {
-      isBookmarked: serverEntry.isBookmarked,
-    }),
-    isRunning,
-    ...(serverEntry?.hasUnread !== undefined && {
-      hasUnread: serverEntry.hasUnread,
-    }),
-    ...(serverEntry?.statusMessage !== undefined && {
-      statusMessage: serverEntry.statusMessage,
-    }),
+    ...pickServerOverrides(serverEntry),
+    isRunning: computeLiveIsRunning(serverEntry, live),
   };
 }
 

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -4,7 +4,13 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mergeSessionLists, applySessionDiff, compareSessionsByRecency } from "../../../src/utils/session/mergeSessions.js";
+import {
+  mergeSessionLists,
+  applySessionDiff,
+  compareSessionsByRecency,
+  pickServerOverrides,
+  computeLiveIsRunning,
+} from "../../../src/utils/session/mergeSessions.js";
 import type { ActiveSession, SessionSummary } from "../../../src/types/session.js";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
@@ -318,5 +324,91 @@ describe("applySessionDiff — sort + immutability", () => {
     applySessionDiff(cache, diff, ["a"]);
     assert.deepEqual(cache, cacheSnap);
     assert.deepEqual(diff, diffSnap);
+  });
+});
+
+describe("pickServerOverrides", () => {
+  it("returns an empty object when serverEntry is undefined", () => {
+    assert.deepEqual(pickServerOverrides(undefined), {});
+  });
+
+  it("returns an empty object when none of the override fields are set", () => {
+    // makeSummary only sets id/roleId/startedAt/updatedAt/preview —
+    // none of those are override keys, so nothing should be picked.
+    assert.deepEqual(pickServerOverrides(makeSummary()), {});
+  });
+
+  it("picks every override field that is defined", () => {
+    const out = pickServerOverrides(
+      makeSummary({
+        summary: "AI summary",
+        keywords: ["a", "b"],
+        origin: "scheduler",
+        isBookmarked: true,
+        hasUnread: false,
+        statusMessage: "running…",
+      }),
+    );
+    assert.deepEqual(out, {
+      summary: "AI summary",
+      keywords: ["a", "b"],
+      origin: "scheduler",
+      isBookmarked: true,
+      hasUnread: false,
+      statusMessage: "running…",
+    });
+  });
+
+  it("preserves false / empty-string / empty-array — only `undefined` is filtered", () => {
+    const out = pickServerOverrides(makeSummary({ isBookmarked: false, hasUnread: false, statusMessage: "", keywords: [] }));
+    assert.deepEqual(out, { isBookmarked: false, hasUnread: false, statusMessage: "", keywords: [] });
+  });
+
+  it("ignores fields explicitly set to undefined", () => {
+    const out = pickServerOverrides(makeSummary({ summary: undefined, keywords: undefined }));
+    assert.deepEqual(out, {});
+  });
+
+  it("does not pick fields outside the override allowlist (e.g. preview, id)", () => {
+    // `preview` and `id` are sidebar-row identity, not server-only
+    // overrides; they're handled separately by `buildLiveSummary`.
+    const out = pickServerOverrides(makeSummary({ preview: "ignored here" }));
+    assert.equal("preview" in out, false);
+    assert.equal("id" in out, false);
+  });
+});
+
+describe("computeLiveIsRunning", () => {
+  const makeLive = (overrides: Partial<Pick<ActiveSession, "isRunning" | "pendingGenerations">> = {}) => ({
+    isRunning: false,
+    pendingGenerations: {},
+    ...overrides,
+  });
+
+  it("false when no source signals running", () => {
+    assert.equal(computeLiveIsRunning(undefined, makeLive()), false);
+    assert.equal(computeLiveIsRunning(makeSummary(), makeLive()), false);
+  });
+
+  it("true when serverEntry.isRunning is true", () => {
+    assert.equal(computeLiveIsRunning(makeSummary({ isRunning: true }), makeLive()), true);
+  });
+
+  it("true when live.isRunning is true", () => {
+    assert.equal(computeLiveIsRunning(undefined, makeLive({ isRunning: true })), true);
+  });
+
+  it("true when at least one pending generation is queued", () => {
+    assert.equal(computeLiveIsRunning(undefined, makeLive({ pendingGenerations: { gen1: { startedAt: "now" } as never } })), true);
+  });
+
+  it("false for an empty pendingGenerations object", () => {
+    assert.equal(computeLiveIsRunning(undefined, makeLive({ pendingGenerations: {} })), false);
+  });
+
+  it("treats missing pendingGenerations as no-pending", () => {
+    // ActiveSession always has pendingGenerations in practice, but
+    // the helper is defensive — exercise the `?? {}` branch.
+    assert.equal(computeLiveIsRunning(undefined, makeLive({ pendingGenerations: undefined as never })), false);
   });
 });


### PR DESCRIPTION
## Summary

- Split \`buildLiveSummary\` (complexity 21 → ~3) into two pure helpers exported for direct unit testing.
- Graduate \`complexity\` to **error** globally with a \`server/**\` warn override (5 branchy API handlers remain — out of scope here).
- Graduate \`@typescript-eslint/no-dynamic-delete\` to **error** for \`packages/**\` (0 violations today — hold the line so a regression there fails CI).

## Items to Confirm / Review

### Refactor

- **\`pickServerOverrides(serverEntry)\`** — drops six \`...(x !== undefined && {...})\` spreads into one allowlist loop. Preserves the original "carry only when defined" rule so downstream shallow copies don't see \`summary: undefined\`.
- **\`computeLiveIsRunning(serverEntry, live)\`** — collapses the three-source OR into a named boolean. Argument is \`Pick<ActiveSession, "isRunning" | "pendingGenerations">\` so it's testable without a full \`ActiveSession\`.
- Behaviour is identical: 25 existing tests pass unchanged, plus 12 new direct tests for the helpers (false/0/""/empty-array passthrough, explicit undefined filtering, no-pending vs pending edges, allowlist boundary).
- The spread order in \`buildLiveSummary\` puts \`...pickServerOverrides(serverEntry)\` before \`isRunning: computeLiveIsRunning(...)\` so the locally-OR'd \`isRunning\` always wins. Since none of the override keys is \`isRunning\` this is purely defensive.

### ESLint config

- \`complexity\` was \`["warn", { max: 15 }]\` everywhere. Now error globally with a \`server/**\` override that re-demotes to warn. After this PR there are **5 remaining complexity warnings, all in \`server/\`**:
  - \`server/api/routes/files.ts:713\`, \`sessions.ts:122\` & \`:242\`, \`wiki.ts:109\`, \`utils/gemini.ts:43\`. Each is a real branchy handler — to be split in follow-ups.
- \`no-dynamic-delete\` was global \`warn\`. Now error specifically for \`packages/**\` because it's already clean. \`src/\` (30 — mostly \`presentMulmoScript/View.vue\`) and \`server/\` (3) stay at warn pending real fixes.

### Verification

- \`yarn lint\` → 0 errors, 37 warnings (all in src/ + server/, none in the changed file)
- \`yarn build\` → ✓
- \`npx tsx --test test/utils/session/test_mergeSessions.ts\` → 37/37 passing (was 25)

## User Prompt

> src/utils/session/mergeSessions.ts
>   19:1  warning  Function 'buildLiveSummary' has a complexity of 21. Maximum allowed is 15  complexity 安全に直せる？
>
> 可能ならpure関数でunit testを追加
>
> 修正後、server以外はcomplexityをerrorになるようeslintの設定変更
>
> @typescript-eslint/no-dynamic-delete もできる限りerrorにしたい。packageはもう対応できるかな