### PR TITLE
chore(client): bump 0.1.4 → 0.1.5 to acknowledge new formatAckReply export

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Socket.io client library for MulmoBridge — shared by all bridge implementations",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Unblocks every open PR's publish-smoke job. Commit 319dfe16
(\`refactor(bridges,relay): extract pure parse helpers\`) added
\`export { formatAckReply } from \"./reply.js\"\` to
\`packages/client/src/index.ts\` without bumping the package
version, so the published \`@mulmobridge/client@0.1.4\` on npm
ships 5 value-export lines while the local \`src/index.ts\` now has
6. The mulmoclaude publish-smoke §2 drift trap catches this and
fails the \`smoke\` job on every PR (e.g. #991).

Bumping the local \`packages/client/package.json\` from \`0.1.4\` →
\`0.1.5\` flips the drift verdict from \`drifted\` to
\`pending-publish\` — meaning \"the bump signals intent to ship,
the publish to npm is a separate manual step\". That's exactly
what \`drift.mjs:isLocalVersionAhead\` exists for.

The actual cascade publish to npm (§7 of the
publish-mulmoclaude skill) is intentionally NOT done in this PR;
it's the user's release-prep step.

## Items to Confirm / Review

- **Only \`packages/client/package.json\` changes here.** Dependent packages still pin \`@mulmobridge/client: ^0.1.4\` until the npm publish lands. That's correct — semver caret will pick up 0.1.5 once it's on the registry.
- **Verified locally**: \`node scripts/mulmoclaude/smoke.mjs\` reports \`✓ drift  2 package(s) ok, 1 pending publish (client@0.1.5)\` and the tarball boot still returns HTTP 200.
- **No new exports added in this PR** — \`formatAckReply\` was already on main since 319dfe16. This PR only updates the version number to acknowledge that change.

## User Prompt

> ci エラーの原因何？ https://github.com/receptron/mulmoclaude/pull/991/changes
> はい、mainすぐになおして

## Verification

- \`node scripts/mulmoclaude/smoke.mjs\`: all 3 stages green (deps / drift pending-publish / tarball HTTP 200)
- \`yarn lint\`: 0 errors, 38 warnings
- \`yarn typecheck\`: pass
- \`yarn build\`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)