### PR TITLE
refactor(src): replace remaining 30 dynamic-delete sites + graduate rule globally

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -181,7 +181,7 @@ export default [
       "no-unneeded-ternary": ["error", { defaultAssignment: false }],
       "no-else-return": ["error", { allowElseIf: false }],
       "@typescript-eslint/no-non-null-assertion": "warn",
-      "@typescript-eslint/no-dynamic-delete": "warn",
+      "@typescript-eslint/no-dynamic-delete": "error",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-import-type-side-effects": "error",
       "@typescript-eslint/no-useless-empty-export": "error",
@@ -343,17 +343,6 @@ export default [
     files: ["server/**/*.{ts,js}"],
     rules: {
       complexity: ["warn", { max: 15 }],
-    },
-  },
-  {
-    // `packages/` and `server/` are now clean of dynamic-delete; hold
-    // both to `error` so a future regression fails CI immediately. The
-    // remaining ~30 `src/` violations are concentrated in
-    // `presentMulmoScript/View.vue` and stay at `warn` until that file
-    // lands its own cleanup PR — at which point this override widens.
-    files: ["packages/**/*.{ts,js}", "server/**/*.{ts,js}"],
-    rules: {
-      "@typescript-eslint/no-dynamic-delete": "error",
     },
   },
   {

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -746,7 +746,7 @@ function effectiveBeat(index: number): Beat {
 function toggleSource(index: number) {
   if (!sourceOpen[index]) {
     sourceText[index] = JSON.stringify(effectiveBeat(index), null, 2);
-    delete beatSaveErrors[index];
+    Reflect.deleteProperty(beatSaveErrors, index);
   }
   sourceOpen[index] = !sourceOpen[index];
 }
@@ -765,14 +765,14 @@ async function updateBeat(index: number) {
   }
   const prevImage = JSON.stringify(effectiveBeat(index).image);
 
-  delete beatSaveErrors[index];
+  Reflect.deleteProperty(beatSaveErrors, index);
   beatSaving[index] = true;
   const response = await apiPost<unknown>(API_ROUTES.mulmoScript.updateBeat, {
     filePath: filePath.value,
     beatIndex: index,
     beat,
   });
-  delete beatSaving[index];
+  Reflect.deleteProperty(beatSaving, index);
   if (!response.ok) {
     beatSaveErrors[index] = { kind: "saveFailed", error: response.error };
     return;
@@ -782,7 +782,7 @@ async function updateBeat(index: number) {
   sourceOpen[index] = false;
 
   if (JSON.stringify(beat.image) !== prevImage) {
-    delete renderedImages[index];
+    Reflect.deleteProperty(renderedImages, index);
     renderBeat(index);
   }
 }
@@ -810,7 +810,7 @@ async function renderBeat(index: number) {
 }
 
 async function regenerateBeat(index: number) {
-  delete renderedImages[index];
+  Reflect.deleteProperty(renderedImages, index);
   renderState[index] = "rendering";
   const response = await apiPost<{ image?: string; error?: string }>(API_ROUTES.mulmoScript.renderBeat, {
     filePath: filePath.value,
@@ -852,7 +852,7 @@ async function loadExistingBeatAudio(index: number) {
 
 async function generateAudio(index: number) {
   audioState[index] = "generating";
-  delete audioErrors[index];
+  Reflect.deleteProperty(audioErrors, index);
   const response = await apiPost<{ audio?: string; error?: string }>(API_ROUTES.mulmoScript.generateBeatAudio, {
     filePath: filePath.value,
     beatIndex: index,
@@ -920,7 +920,7 @@ async function onBeatDrop(event: DragEvent, index: number) {
   if (!file || !file.type.startsWith("image/")) return;
 
   renderState[index] = "rendering";
-  delete renderErrors[index];
+  Reflect.deleteProperty(renderErrors, index);
   let imageData: string;
   try {
     imageData = await new Promise<string>((resolve, reject) => {
@@ -970,7 +970,7 @@ async function onCharDrop(event: DragEvent, key: string) {
   if (!file || !file.type.startsWith("image/")) return;
 
   charRenderState[key] = "rendering";
-  delete charErrors[key];
+  Reflect.deleteProperty(charErrors, key);
   let imageData: string;
   try {
     imageData = await new Promise<string>((resolve, reject) => {
@@ -1027,7 +1027,7 @@ function refreshMissingCharacterImages() {
 
 async function renderCharacter(key: string, force: boolean) {
   charRenderState[key] = "rendering";
-  delete charErrors[key];
+  Reflect.deleteProperty(charErrors, key);
   const response = await apiPost<{ image?: string; error?: string }>(API_ROUTES.mulmoScript.renderCharacter, {
     filePath: filePath.value,
     key,
@@ -1069,21 +1069,21 @@ async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
   // Reset per-script state
-  Object.keys(renderState).forEach((key) => delete renderState[Number(key)]);
-  Object.keys(renderedImages).forEach((key) => delete renderedImages[Number(key)]);
-  Object.keys(renderErrors).forEach((key) => delete renderErrors[Number(key)]);
-  Object.keys(sourceOpen).forEach((key) => delete sourceOpen[Number(key)]);
-  Object.keys(sourceText).forEach((key) => delete sourceText[Number(key)]);
-  Object.keys(beatSaveErrors).forEach((key) => delete beatSaveErrors[Number(key)]);
-  Object.keys(beatSaving).forEach((key) => delete beatSaving[Number(key)]);
-  Object.keys(localOverrides).forEach((key) => delete localOverrides[Number(key)]);
-  Object.keys(beatAudios).forEach((key) => delete beatAudios[Number(key)]);
-  Object.keys(audioState).forEach((key) => delete audioState[Number(key)]);
-  Object.keys(audioErrors).forEach((key) => delete audioErrors[Number(key)]);
-  Object.keys(charRenderState).forEach((key) => delete charRenderState[key]);
-  Object.keys(charImages).forEach((key) => delete charImages[key]);
-  Object.keys(charErrors).forEach((key) => delete charErrors[key]);
-  Object.keys(beatDragOver).forEach((key) => delete beatDragOver[Number(key)]);
+  Object.keys(renderState).forEach((key) => Reflect.deleteProperty(renderState, key));
+  Object.keys(renderedImages).forEach((key) => Reflect.deleteProperty(renderedImages, key));
+  Object.keys(renderErrors).forEach((key) => Reflect.deleteProperty(renderErrors, key));
+  Object.keys(sourceOpen).forEach((key) => Reflect.deleteProperty(sourceOpen, key));
+  Object.keys(sourceText).forEach((key) => Reflect.deleteProperty(sourceText, key));
+  Object.keys(beatSaveErrors).forEach((key) => Reflect.deleteProperty(beatSaveErrors, key));
+  Object.keys(beatSaving).forEach((key) => Reflect.deleteProperty(beatSaving, key));
+  Object.keys(localOverrides).forEach((key) => Reflect.deleteProperty(localOverrides, key));
+  Object.keys(beatAudios).forEach((key) => Reflect.deleteProperty(beatAudios, key));
+  Object.keys(audioState).forEach((key) => Reflect.deleteProperty(audioState, key));
+  Object.keys(audioErrors).forEach((key) => Reflect.deleteProperty(audioErrors, key));
+  Object.keys(charRenderState).forEach((key) => Reflect.deleteProperty(charRenderState, key));
+  Object.keys(charImages).forEach((key) => Reflect.deleteProperty(charImages, key));
+  Object.keys(charErrors).forEach((key) => Reflect.deleteProperty(charErrors, key));
+  Object.keys(beatDragOver).forEach((key) => Reflect.deleteProperty(beatDragOver, key));
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
 
@@ -1166,15 +1166,15 @@ async function reflectGenerationFinish(entry: PendingGeneration): Promise<void> 
   if (entry.kind === GENERATION_KINDS.beatImage) {
     const idx = Number(entry.key);
     await loadExistingBeatImage(idx);
-    if (renderState[idx] === "rendering") delete renderState[idx];
+    if (renderState[idx] === "rendering") Reflect.deleteProperty(renderState, idx);
   } else if (entry.kind === GENERATION_KINDS.beatAudio) {
     const idx = Number(entry.key);
     await loadExistingBeatAudio(idx);
-    if (audioState[idx] === "generating") delete audioState[idx];
+    if (audioState[idx] === "generating") Reflect.deleteProperty(audioState, idx);
   } else if (entry.kind === GENERATION_KINDS.characterImage) {
     await loadExistingCharacterImage(entry.key);
     if (charRenderState[entry.key] === "rendering") {
-      delete charRenderState[entry.key];
+      Reflect.deleteProperty(charRenderState, entry.key);
     }
   } else if (entry.kind === GENERATION_KINDS.movie) {
     movieGenerating.value = false;

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -61,7 +61,7 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
     }
     case EVENT_TYPES.generationFinished: {
       const mapKey = generationKey(event.kind, event.filePath, event.key);
-      delete session.pendingGenerations[mapKey];
+      Reflect.deleteProperty(session.pendingGenerations, mapKey);
       if (Object.keys(session.pendingGenerations).length === 0) {
         ctx.onGenerationsDrained();
       }

--- a/src/utils/markdown/frontmatter.ts
+++ b/src/utils/markdown/frontmatter.ts
@@ -89,7 +89,7 @@ export function mergeFrontmatter(existing: Record<string, unknown>, patch: Recor
   const out: Record<string, unknown> = { ...existing };
   for (const [key, value] of Object.entries(patch)) {
     if (value === null || value === undefined) {
-      delete out[key];
+      Reflect.deleteProperty(out, key);
     } else {
       out[key] = value;
     }


### PR DESCRIPTION
## Summary

Stacked on top of #995. Replaces the remaining 30 \`delete obj[dynamicKey]\` sites in \`src/\` with \`Reflect.deleteProperty(obj, key)\` and graduates the lint rule to **error globally**. Spec-equivalent — no behavior change, no browser-compat concern (Reflect.deleteProperty is universally supported since ES2015).

## Items to Confirm / Review

### Sites changed

- **\`src/plugins/presentMulmoScript/View.vue\` (28 sites)**: scattered single-key deletes after data updates (per-beat error/saving state, character render state) plus a 15-line block in \`initializeScript\` that resets every per-beat / per-character map. The reset block keeps the same \`Object.keys(...).forEach(...)\` shape — only the inner \`delete\` expression changes.
- **\`src/utils/agent/eventDispatch.ts\` (1)**: drop \`pendingGenerations\` entry on \`generationFinished\`.
- **\`src/utils/markdown/frontmatter.ts\` (1)**: drop key on null/undefined patch value. Mirrors the server-side fix in #995.

### Lint config

- Global \`@typescript-eslint/no-dynamic-delete\`: \`warn\` → **\`error\`**.
- Removed the \`packages/**, server/**, src/**\` override block introduced earlier — the global rule now covers everything we own.
- Vue SFCs are caught via flat-config rule inheritance — the \`**/*.vue\` block later in the config only overrides Vue-specific rules, so the global error level applies to \`<script>\` blocks too. Verified: \`yarn eslint src/plugins/presentMulmoScript/View.vue\` is clean.

### Why \`Reflect.deleteProperty\` over a functional rewrite

The same logic as in #995: every site has a "preserve existing keys, conditionally delete one" semantic. A naive \`Object.fromEntries(filter(...))\` rewrite has a subtle edge case where existing null/undefined values would also be filtered. \`Reflect.deleteProperty\` preserves the original semantics 1:1 — minimum-risk fix.

### Verification

- \`yarn lint\` → **0 errors, 5 warnings** (all 5 are pre-existing \`server/\` complexity warnings, not touched here)
- \`yarn typecheck\` → ✓
- \`yarn build\` → ✓
- \`yarn test\` → ✓ (frontmatter has 44 tests covering both null and undefined deletion paths)

### Stacking note

This branch is built on top of \`fix/server-no-dynamic-delete\` (#995). The PR diff currently shows both PRs' changes; once #995 merges, the diff narrows to just this PR's content.

## User Prompt

> ok　では別ブランチでReflect.deleteProperty全対応しよう。ここから派生したブランでPRはmainにむけて。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized property deletion patterns across the application for improved code consistency and maintainability.

* **Chores**
  * Strengthened ESLint enforcement repository-wide to maintain higher code quality standards and prevent potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->