### PR TITLE
refactor(gemini): extract pure helpers + graduate server complexity to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -334,13 +334,14 @@ export default [
     },
   },
   {
-    // Server-side override: cyclomatic `complexity` stays at `warn`
-    // here because the API route handlers have several legitimately
+    // API-route override: cyclomatic `complexity` stays at `warn`
+    // here because the route handlers have several legitimately
     // branchy functions (validation + auth + business logic in one
     // place) that would need a coordinated split before they can
-    // graduate. Frontend / shared `src/` code has no such concentration
-    // and is held to `error`; over time `server/` should converge.
-    files: ["server/**/*.{ts,js}"],
+    // graduate. Everything else under `server/` (utils, agent,
+    // workspace, …) is held to `error`; over time `server/api/routes/`
+    // should converge.
+    files: ["server/api/routes/**/*.{ts,js}"],
     rules: {
       complexity: ["warn", { max: 15 }],
     },

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI, type GenerateContentParameters } from "@google/genai";
+import { GoogleGenAI, type GenerateContentParameters, type GenerateContentResponse, type Part } from "@google/genai";
 import { env } from "../system/env.js";
 import { log } from "../system/logger/index.js";
 import { errorMessage } from "./errors.js";
@@ -27,6 +27,32 @@ export interface GeminiImageResult {
   // Optional text part returned alongside the image (or in lieu of
   // it). Used as a fallback message when imageData is empty.
   message?: string;
+}
+
+// Pull the first candidate's `content.parts` array out of a Gemini
+// response, defaulting to `[]` when any layer of the optional chain is
+// absent. Pure — exported for unit tests.
+export function firstCandidateParts(response: GenerateContentResponse): readonly Part[] {
+  return response.candidates?.[0]?.content?.parts ?? [];
+}
+
+// Pull the first candidate's `finishReason` (used in debug logs).
+// Pure — exported for unit tests.
+export function firstFinishReason(response: GenerateContentResponse): string | undefined {
+  return response.candidates?.[0]?.finishReason;
+}
+
+// Reduce a Gemini response's `parts` array down to the {imageData,
+// message} pair the rest of the app cares about. Last text wins; last
+// inline-image wins. Parts without text or `inlineData.data` are
+// skipped. Pure — exported for unit tests.
+export function extractImageResult(parts: readonly Part[]): GeminiImageResult {
+  const result: GeminiImageResult = {};
+  for (const part of parts) {
+    if (part.text) result.message = part.text;
+    if (part.inlineData?.data) result.imageData = part.inlineData.data;
+  }
+  return result;
 }
 
 // Low-level wrapper around `ai.models.generateContent` that pulls
@@ -62,18 +88,14 @@ export async function generateGeminiImageContent(
     log.debug("gemini", "generateContent: SDK threw", { model, error: errorMessage(err) });
     throw err;
   }
-  const parts = response.candidates?.[0]?.content?.parts ?? [];
-  const result: GeminiImageResult = {};
-  for (const part of parts) {
-    if (part.text) result.message = part.text;
-    if (part.inlineData?.data) result.imageData = part.inlineData.data;
-  }
+  const parts = firstCandidateParts(response);
+  const result = extractImageResult(parts);
   log.debug("gemini", "generateContent: response", {
     model,
     parts: parts.length,
     hasImage: Boolean(result.imageData),
     hasText: Boolean(result.message),
-    finishReason: response.candidates?.[0]?.finishReason,
+    finishReason: firstFinishReason(response),
   });
   return result;
 }

--- a/test/utils/test_gemini.ts
+++ b/test/utils/test_gemini.ts
@@ -1,0 +1,113 @@
+// Unit tests for the pure helpers in `server/utils/gemini.ts`.
+//
+// `generateGeminiImageContent` itself is a thin wrapper over the
+// `@google/genai` SDK and isn't unit-tested here — exercising it
+// would mean stubbing the SDK client, which buys little signal over
+// just verifying the parts extraction (the only meaningful logic
+// the wrapper does on its own). The three exported helpers below
+// cover the response-shape narrowing exhaustively, which is where
+// real bugs would surface (e.g. a Gemini response shape change
+// silently dropping an image).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { GenerateContentResponse, Part } from "@google/genai";
+import { extractImageResult, firstCandidateParts, firstFinishReason } from "../../server/utils/gemini.js";
+
+// Construct a minimal GenerateContentResponse-shaped object for the
+// helpers to read. Only the fields the helpers touch are populated;
+// everything else stays undefined. Cast at the boundary so callers
+// don't have to write the full SDK type.
+function makeResponse(candidate: { content?: { parts?: Part[] } | null; finishReason?: string } | null = null): GenerateContentResponse {
+  if (candidate === null) return {} as GenerateContentResponse;
+  return { candidates: [candidate] } as GenerateContentResponse;
+}
+
+describe("extractImageResult", () => {
+  it("returns an empty object for no parts", () => {
+    assert.deepEqual(extractImageResult([]), {});
+  });
+
+  it("captures a plain text part as `message`", () => {
+    const parts: Part[] = [{ text: "hello there" }];
+    assert.deepEqual(extractImageResult(parts), { message: "hello there" });
+  });
+
+  it("captures a plain inline-image part as `imageData`", () => {
+    const parts: Part[] = [{ inlineData: { data: "BASE64==" } }];
+    assert.deepEqual(extractImageResult(parts), { imageData: "BASE64==" });
+  });
+
+  it("captures both fields when a single part has text + inlineData.data", () => {
+    const parts: Part[] = [{ text: "caption", inlineData: { data: "AAAA" } }];
+    assert.deepEqual(extractImageResult(parts), { message: "caption", imageData: "AAAA" });
+  });
+
+  it("captures across multiple parts (last non-empty wins)", () => {
+    const parts: Part[] = [{ text: "first" }, { text: "second" }, { inlineData: { data: "X" } }, { inlineData: { data: "Y" } }];
+    assert.deepEqual(extractImageResult(parts), { message: "second", imageData: "Y" });
+  });
+
+  it("skips parts whose text is empty / undefined / null", () => {
+    const parts: Part[] = [{ text: "" }, { text: undefined }, { inlineData: { data: "IMG" } }];
+    assert.deepEqual(extractImageResult(parts), { imageData: "IMG" });
+  });
+
+  it("skips parts whose inlineData has no `data`", () => {
+    const parts: Part[] = [{ inlineData: { mimeType: "image/png" } }, { text: "fallback" }];
+    assert.deepEqual(extractImageResult(parts), { message: "fallback" });
+  });
+
+  it("skips parts where inlineData.data is the empty string", () => {
+    // Falsy guard on `inlineData?.data` — Gemini occasionally returns
+    // an empty `data` when the safety filter trims the image.
+    const parts: Part[] = [{ inlineData: { data: "" } }];
+    assert.deepEqual(extractImageResult(parts), {});
+  });
+
+  it("ignores parts that have neither field", () => {
+    // Function-call / executable-code parts surface in the array
+    // alongside text/image parts. Helpers must tolerate them.
+    const parts: Part[] = [{ functionCall: { name: "tool", args: {} } } as Part, { text: "tail" }];
+    assert.deepEqual(extractImageResult(parts), { message: "tail" });
+  });
+});
+
+describe("firstCandidateParts", () => {
+  it("returns the first candidate's `content.parts`", () => {
+    const parts: Part[] = [{ text: "hi" }];
+    const out = firstCandidateParts(makeResponse({ content: { parts } }));
+    assert.deepEqual(out, parts);
+  });
+
+  it("returns [] when `candidates` is missing", () => {
+    assert.deepEqual(firstCandidateParts(makeResponse(null)), []);
+  });
+
+  it("returns [] when the first candidate has no `content`", () => {
+    assert.deepEqual(firstCandidateParts(makeResponse({})), []);
+  });
+
+  it("returns [] when content has no `parts`", () => {
+    assert.deepEqual(firstCandidateParts(makeResponse({ content: {} })), []);
+  });
+
+  it("returns [] when `content` is null (SDK can emit this on safety blocks)", () => {
+    assert.deepEqual(firstCandidateParts(makeResponse({ content: null })), []);
+  });
+});
+
+describe("firstFinishReason", () => {
+  it("returns the first candidate's finish reason", () => {
+    const response = makeResponse({ finishReason: "STOP" });
+    assert.equal(firstFinishReason(response), "STOP");
+  });
+
+  it("returns undefined when finishReason is absent", () => {
+    assert.equal(firstFinishReason(makeResponse({})), undefined);
+  });
+
+  it("returns undefined when there are no candidates", () => {
+    assert.equal(firstFinishReason(makeResponse(null)), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes bundled because the second depends on the first:

1. **\`generateGeminiImageContent\` complexity 16 → 9**: extract three pure helpers from \`server/utils/gemini.ts\` that map the Gemini SDK response shape down to the values the app uses. The wrapper now does the SDK call + debug logs only.
2. **Graduate \`complexity\` warn → error outside \`server/api/routes/\`**: the warn was previously \`server/**/*\` -wide. With gemini.ts cleared, all remaining complexity violations are in \`server/api/routes/\` (4 sites in files.ts / sessions.ts × 2 / wiki.ts). Narrow the warn override to that path so the rest of \`server/\` is held to error going forward.

## Items to Confirm / Review

- **Three new exported pure helpers** in \`server/utils/gemini.ts\`:
  - \`firstCandidateParts(response): readonly Part[]\` — \`response.candidates?.[0]?.content?.parts ?? []\`
  - \`firstFinishReason(response): string | undefined\` — \`response.candidates?.[0]?.finishReason\`
  - \`extractImageResult(parts): GeminiImageResult\` — last-text-wins / last-image-wins reducer with falsy guards

- **Behavioural equivalence**: the \`for (const part of parts) { if (part.text) … if (part.inlineData?.data) … }\` loop is a literal copy. Last-write-wins for both fields. Worth a sanity glance.

- **Test coverage** (17 new tests in \`test/utils/test_gemini.ts\`):
  - \`extractImageResult\`: 9 cases (empty, text-only, image-only, both, multi-part last-wins, falsy text, missing data, empty-string data, non-image/non-text part)
  - \`firstCandidateParts\`: 5 cases (happy path, missing candidates, missing content, missing parts, null content for safety blocks)
  - \`firstFinishReason\`: 3 cases (present, absent, no candidates)

- **\`generateGeminiImageContent\` is intentionally not unit-tested** — it's a thin wrapper over the live \`@google/genai\` SDK; mocking the client buys little signal over verifying the parts extraction (which the helpers above cover).

- **Override scope narrowed from \`server/**/*\` to \`server/api/routes/**/*\`**: comment updated to spell out which directories now hold to \`error\`. The 4 remaining warns in \`server/api/routes/\` are unaffected.

## User Prompt

> server/utils/gemini.ts
>   43:8  warning  Async function 'generateGeminiImageContent' has a complexity of 16. Maximum allowed is 15  complexity  直しつつpure関数にできるものは関数にしてunit test追加
> そのご、server/api/routes/以外はcomplexityはerrorに。

## Verification

- \`yarn lint\`: 0 errors, 36 warnings (was 38)
- \`yarn typecheck\`: pass
- \`yarn build\`: pass
- \`yarn test\`: 3463 pass, 0 fail (was 3446; +17 gemini tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)