### PR TITLE
chore(lint): narrow complexity warn override to 3 specific files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -334,14 +334,16 @@ export default [
     },
   },
   {
-    // API-route override: cyclomatic `complexity` stays at `warn`
-    // here because the route handlers have several legitimately
-    // branchy functions (validation + auth + business logic in one
-    // place) that would need a coordinated split before they can
-    // graduate. Everything else under `server/` (utils, agent,
-    // workspace, …) is held to `error`; over time `server/api/routes/`
-    // should converge.
-    files: ["server/api/routes/**/*.{ts,js}"],
+    // Per-file complexity exemptions. These three route handlers
+    // each have one or more legitimately branchy functions
+    // (validation + auth + business logic in one place) that need a
+    // coordinated split. Until then keep the rule at `warn` for
+    // these files only — every other file in the repo is held to
+    // `error` so a regression elsewhere fails CI immediately.
+    //   - files.ts:    one ≥20 branch
+    //   - sessions.ts: two ≥15 branches
+    //   - wiki.ts:     parseTableRow ≥15
+    files: ["server/api/routes/files.ts", "server/api/routes/sessions.ts", "server/api/routes/wiki.ts"],
     rules: {
       complexity: ["warn", { max: 15 }],
     },


### PR DESCRIPTION
## Summary

Follow-up to #997. The complexity \`warn\` override was applied to \`server/api/routes/**/*\` as a whole, but only three files in that directory actually have violations. Narrow the override to those three so any new complexity ≥16 elsewhere in the routes directory (or anywhere else in the repo) fails CI immediately.

| File | Violations |
|---|---|
| \`server/api/routes/files.ts\` | one branch at complexity 22 |
| \`server/api/routes/sessions.ts\` | two branches at complexity 17, 20 |
| \`server/api/routes/wiki.ts\` | \`parseTableRow\` at complexity 18 |

Every other file is held to \`error\`. Lint state is unchanged: 4 warnings (the 4 known sites), 0 errors.

## Items to Confirm / Review

- **Files allow-list literal**: \`["server/api/routes/files.ts", "server/api/routes/sessions.ts", "server/api/routes/wiki.ts"]\`. ESLint flat config matches files exactly when no glob is used; the whitelist is fail-safe (any new file under \`server/api/routes/\` is held to error).
- **Comment block** in eslint.config.mjs spells out which file is exempt for which reason so a future cleanup PR can graduate them one at a time.

## User Prompt

> これ15以上はwarnで20いじょうはエラーにできる？
> complexity のlintのwarn, 既存の３つのファイルだけ指定して他はerrorにしようか。

## Verification

- \`yarn lint\`: 4 warnings (unchanged), 0 errors
- \`yarn typecheck\`: pass
- \`yarn test\`: 3465 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)