### PR TITLE
feat(pubsub): per-file change notifications for presentHtml + markdown

### DIFF
--- a/plans/feat-file-change-pubsub.md
+++ b/plans/feat-file-change-pubsub.md
@@ -1,0 +1,174 @@
+# ファイル変更通知 (per-file pub/sub) — 実装プラン
+
+## 背景
+
+`presentHtml` (#982) で「ファイル on-disk が単一の真実の源、`tool_use.data` には `filePath` だけ載せる」路線に切り替えた結果、保存後の UI 更新を「親 ToolResult を emit し直す」フローに頼れない場面が出てきた:
+
+- presentHtml: そもそも `data.html` が無いので emit するものが存在しない。`feat/presenthtml-edit` で追加した Edit パネルは「Apply 後にローカルで `previewVersion` を bump して iframe を `?v=N` で reload」というパッチを当てているが、**自タブの中だけ**の反映で、別タブ・別ブラウザは置き去り
+- markdown: `apiPut` 後に `emit("updateResult", ...)` で親に通知しているが、**別タブ/別ブラウザは置き去り**
+- 同じファイルを表示する他の View(将来の wiki / spreadsheet など)も同期しない
+
+ファイルの変更そのものを「サーバが publish、クライアントが subscribe」する単純な pub/sub にすれば、保存後の UI 更新も multi-tab/multi-browser 同期も同じ仕組みで解決する。プロジェクトの哲学(`workspace is the database; files are the source of truth`)とも素直に揃う。
+
+## スコープ
+
+**含む**
+
+- 汎用ヘルパ: サーバの `publishFileChange(relPath)` / クライアントの `useFileChange(relPath)`
+- presentHtml の `View.vue` 反映(iframe を `?v=<mtime>` でキャッシュバスト・リロード)
+- markdown の `View.vue` 反映(コンテンツ再フェッチ、ローカル編集中は安全に skip / 通知)
+
+**含まない**
+
+- wiki / spreadsheet / files explorer などの他 View(後続 PR)
+- `fs.watch` ベースの外部編集検知(明示 publish のみ)
+- ファイル削除 / リネーム通知
+
+## 全体構成
+
+既存の Socket.IO pub/sub をそのまま使う:
+
+- `server/events/pub-sub/index.ts` — `IPubSub.publish(channel, data)` / `socket.join(channel)` で room ベース
+- `src/composables/usePubSub.ts` — `subscribe(channel, cb): () => void`(再接続時に listener 自動再 subscribe)
+- `src/config/pubsubChannels.ts` — チャンネル名の単一情報源(既存)。ここに `fileChannel(relPath)` ファクトリと `FileChannelPayload` 型を足す
+
+**チャンネル命名**: `file:<workspace-relative-posix-path>`
+
+例: `file:artifacts/html/2026/04/foo.html`、`file:data/documents/2026/04/bar.md`
+
+**ペイロード**:
+
+```ts
+interface FileChannelPayload {
+  path: string;     // workspace-relative POSIX(チャンネル名末尾と一致)
+  mtimeMs: number;  // 書き込み直後の stat().mtimeMs(キャッシュバスト + 順序保証)
+}
+```
+
+## サーバ変更
+
+### 1. ヘルパ追加: `server/events/file-change.ts`
+
+`session-store` と同じ「モジュール singleton + init」パターン。
+
+```ts
+let pubsub: IPubSub | null = null;
+export function initFileChangePublisher(instance: IPubSub): void { pubsub = instance; }
+
+export async function publishFileChange(relativePath: string): Promise<void> {
+  if (!pubsub) return;
+  const absPath = path.join(workspacePath, relativePath);
+  let mtimeMs: number;
+  try {
+    ({ mtimeMs } = await stat(absPath));
+  } catch {
+    mtimeMs = Date.now(); // 書き込み直後に削除されたなど稀なレース
+  }
+  pubsub.publish(fileChannel(relativePath), { path: relativePath, mtimeMs });
+}
+```
+
+mtime は呼び出し側で計測せず、helper 内で `fs.stat` する設計。書き込み直後の正確な値が取れるし、呼び出し側は relativePath だけ知っていればよい。`server/index.ts` の `initSessionStore(pubsub)` の隣で `initFileChangePublisher(pubsub)` を呼ぶ。
+
+### 2. publish 呼び出し点
+
+| ルート | 変更 |
+|---|---|
+| `server/api/routes/presentHtml.ts` POST `/api/html/present` | `writeWorkspaceText` の後で `void publishFileChange(filePath)`(LLM が新規生成したとき) |
+| `server/api/routes/presentHtml.ts` PUT `/api/htmls/update` | `overwriteHtml` の後で `void publishFileChange(relativePath)`(Edit パネルからの保存) |
+| `server/api/routes/plugins.ts` PUT `/api/markdowns/update` | `overwriteMarkdown` の後で `void publishFileChange(relativePath)`(markdown Edit パネル + チェックボックス・トグル) |
+
+`void` で fire-and-forget — publish 失敗(ws 接続エラーなど)で 200 レスポンスを遅らせない。後続 PR で wiki / spreadsheet の write 経路もここに揃える。
+
+将来の汎用化は `writeFileAtomic` から publish する手もあるが、絶対パス → workspace 相対への逆引きが必要なので今回は触らない。
+
+## クライアント変更
+
+### 1. composable: `src/composables/useFileChange.ts`
+
+```ts
+import { ref, onUnmounted, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
+
+export interface FileChangeEvent {
+  path: string;
+  mtimeMs: number;
+}
+
+export function useFileChange(filePath: Ref<string | null>): { version: Ref<number> } {
+  const version = ref(0);
+  const { subscribe } = usePubSub();
+  let unsub: (() => void) | null = null;
+
+  function rebind(p: string | null): void {
+    unsub?.();
+    unsub = null;
+    if (!p) return;
+    unsub = subscribe(`file:${p}`, (data) => {
+      const ev = data as FileChangeEvent;
+      if (ev?.mtimeMs && ev.mtimeMs > version.value) version.value = ev.mtimeMs;
+    });
+  }
+
+  // filePath が null → string へ変わるケース(ToolResult 切り替え)を考慮
+  watch(filePath, rebind, { immediate: true });
+  onUnmounted(() => unsub?.());
+  return { version };
+}
+```
+
+### 2. presentHtml `View.vue`
+
+- 既存の同タブ専用 `previewVersion = ref(0)` + `applyHtml` 内の `previewVersion.value += 1` を削除し、composable の `version` で置き換える
+- iframe の `:src` を `previewUrl + (version > 0 ? "?v=${version}" : "")` に(同じ式)
+- `applyHtml` 成功後はローカル `sourceCache` をユーザが今書いたテキストで上書きしておく(自タブにイベントが戻ってきても **自分の write は再フェッチ不要**)
+- 別タブからの write 時の挙動: `watch(previewVersion)` で `sourceCache[filePath]` を invalidate。エディタが開いている AND 未保存の差分が無い → fetchSource() で `editableHtml` を更新。差分がある → `editableHtml` は触らず `cachedSource` だけ更新(Apply で上書き保存できる状態を保つ)
+  - 重要: invalidation の前に `wasDirty = hasChanges.value` をスナップショットしておく(`hasChanges` は `cachedSource` に依存するので、invalidation 後は false に振れてしまう)
+
+### 3. markdown `View.vue`
+
+- `watchedPath = computed(() => isFilePath(raw) ? raw : null)` で inline content には subscribe しない
+- `watch(fileVersion, ...)` で:
+  - `hasChanges` が `false` → `fetchMarkdownContent()` 静かに再実行
+  - `hasChanges` が `true` → 再フェッチせず、ローカル編集を保護(後続 PR で "remote changed" バナーを足す)
+- 自分の `apiPut` 直後にもイベントは届く(順序: PUT 完了 → publish → 自分が subscribe している channel に到達)。`hasChanges = false` 状態なので静かに再フェッチが走り、結果は同一 → 副作用なし
+
+### 4. 廃止候補(本 PR 範囲外)
+
+- markdown View の `emit("updateResult", ...)`: pub/sub 経由で View 自身が更新されるため大半は不要だが、`pdfPath: undefined` のクリア(content が変わったら PDF も無効化)に使われており、これは pub/sub では伝わらない。剥がすなら別の方法で表現する必要があるので、今回は残す
+- "remote changed" バナー UX: i18n キー追加(8 ロケール × 2 キー × 2 plugin)が必要なので、UX 微調整含めて follow-up で扱う
+
+## マルチタブ動作
+
+- タブ A が `apiPut` → サーバが `file:<path>` に publish → タブ A・B 両方の subscribe が発火
+- タブ A: 直前の save と同じ内容、`hasChanges = false` → 静かに refetch、no-op
+- タブ B: subscribe 中なら version bump → markdown は refetch、html は iframe `?v=` で reload
+
+ブラウザを跨いでも同じ(同一 workspace = 同一 Express → 同一 Socket.IO ルーム)。
+
+## テスト
+
+### 自動
+
+- `test/config/test_pubsubChannels.ts` 拡張: `fileChannel(path)` の prefix / POSIX 正規化 / バックスラッシュ → スラッシュ / 連続セパレータ畳み込みを確認(publisher と subscriber が同じ正規化を経由するので、ここを厳しくしておけばチャンネル名のドリフトが起きない)
+- composable / route の単体テストは見送り — pub/sub 自体が socket-level の I/O で、契約を unit で固める価値が低い。Playwright で multi-tab を回す follow-up で代替
+
+### 手動
+
+1. presentHtml で生成したスライドを開く(タブ A)
+2. 同じセッションを別タブ(タブ B)で開いて同じ result を表示
+3. タブ A の Edit パネルで HTML を編集 → Apply
+   - タブ A: iframe が即 reload
+   - タブ B: iframe が自動で reload
+4. タブ A で agent に「タイトルを変えて再生成」 → 両タブの iframe が更新されること
+5. markdown:
+   - 同じく 2 タブ
+   - タブ A の Edit パネルで本文を編集 → Apply → タブ B のレンダリング更新
+   - タブ B でローカル編集中(`hasChanges = true`)にタブ A から PUT が来ても、タブ B の編集内容が破壊されないこと
+6. 別ブラウザ(Chrome ↔ Safari)を 2 つ開いて同じシナリオ — Socket.IO ルームは origin 単位で broadcast するので動くはず
+
+## 関連
+
+- PR #982: presentHtml filePath-only(本変更の動機)
+- PR #991: Safari CSP fix(別件、先行 merge 想定)
+- 既存 pub/sub: `server/events/pub-sub/`、`src/composables/usePubSub.ts`、`src/config/pubsubChannels.ts`、`server/events/session-store/index.ts`(同パターン参考)

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -14,6 +14,7 @@ import { saveSpreadsheet, overwriteSpreadsheet, isSpreadsheetPath } from "../../
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
+import { publishFileChange } from "../../events/file-change.js";
 
 const router = Router();
 
@@ -140,6 +141,7 @@ router.put(
     try {
       await overwriteMarkdown(relativePath, markdown);
       log.info("plugins", "updateMarkdown: ok", { pathPreview: previewSnippet(relativePath), bytes: markdown.length });
+      void publishFileChange(relativePath);
       res.json({ path: relativePath });
     } catch (err) {
       log.error("plugins", "updateMarkdown: threw", { pathPreview: previewSnippet(relativePath), error: errorMessage(err) });

--- a/server/api/routes/presentHtml.ts
+++ b/server/api/routes/presentHtml.ts
@@ -8,6 +8,7 @@ import { badRequest, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
+import { publishFileChange } from "../../events/file-change.js";
 
 const router = Router();
 
@@ -44,6 +45,8 @@ router.post(API_ROUTES.html.present, async (req: Request<object, unknown, Presen
     const filePath = buildArtifactPath(WORKSPACE_DIRS.htmls, title, ".html", "page");
     await writeWorkspaceText(filePath, html);
     log.info("html", "present: ok", { filePath, bytes: html.length });
+    // Fire-and-forget: any subscribed View tab refetches via cache-bust.
+    void publishFileChange(filePath);
     res.json({
       message: `Saved HTML to ${filePath}`,
       instructions: "Acknowledge that the HTML page has been presented to the user.",
@@ -95,6 +98,7 @@ router.put(
     try {
       await overwriteHtml(relativePath, html);
       log.info("html", "update: ok", { pathPreview: previewSnippet(relativePath), bytes: html.length });
+      void publishFileChange(relativePath);
       res.json({ path: relativePath });
     } catch (err) {
       log.error("html", "update: threw", { pathPreview: previewSnippet(relativePath), error: errorMessage(err) });

--- a/server/events/file-change.ts
+++ b/server/events/file-change.ts
@@ -13,7 +13,7 @@
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import type { IPubSub } from "./pub-sub/index.js";
-import { fileChannel, type FileChannelPayload } from "../../src/config/pubsubChannels.js";
+import { fileChannel, toPosixWorkspacePath, type FileChannelPayload } from "../../src/config/pubsubChannels.js";
 import { workspacePath } from "../workspace/workspace.js";
 import { log } from "../system/logger/index.js";
 
@@ -45,8 +45,22 @@ export async function publishFileChange(relativePath: string): Promise<void> {
     });
     mtimeMs = Date.now();
   }
-  const payload: FileChannelPayload = { path: relativePath, mtimeMs };
-  pubsub.publish(fileChannel(relativePath), payload);
+  // Normalise once so `payload.path` and the channel suffix can't drift
+  // on Windows / mixed-separator inputs.
+  const posixPath = toPosixWorkspacePath(relativePath);
+  const payload: FileChannelPayload = { path: posixPath, mtimeMs };
+  // Callers fire-and-forget via `void publishFileChange(...)`, so a
+  // throw here would surface as an unhandled rejection (Node terminates
+  // the process by default). Missing one notification is strictly less
+  // bad than killing the server.
+  try {
+    pubsub.publish(fileChannel(posixPath), payload);
+  } catch (err) {
+    log.warn("file-change", "publish failed; subscribers will miss this event", {
+      pathPreview: posixPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /** Test-only — clear the module singleton so each test starts clean. */

--- a/server/events/file-change.ts
+++ b/server/events/file-change.ts
@@ -1,0 +1,55 @@
+// File-change publisher. Single place that knows how to broadcast
+// "this workspace file changed" — every route that writes through the
+// app should call `publishFileChange(relPath)` after a successful
+// write so that subscribed UI tabs (and other browsers) refetch.
+//
+// Module-singleton + `init…` pattern, mirroring `session-store`. The
+// singleton is null at import time so unit-tested route handlers can
+// skip wiring and simply observe a no-op publish.
+//
+// Channel name + payload shape live in `src/config/pubsubChannels.ts`
+// so subscribers can't drift from the publisher.
+
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import type { IPubSub } from "./pub-sub/index.js";
+import { fileChannel, type FileChannelPayload } from "../../src/config/pubsubChannels.js";
+import { workspacePath } from "../workspace/workspace.js";
+import { log } from "../system/logger/index.js";
+
+let pubsub: IPubSub | null = null;
+
+export function initFileChangePublisher(instance: IPubSub): void {
+  pubsub = instance;
+}
+
+/**
+ * Publish a file-change event for a workspace-relative path. Reads
+ * the post-write `mtimeMs` via `stat` so subscribers get a monotonic
+ * timestamp suitable for both cache-busting (`?v=<mtime>`) and
+ * out-of-order drops. If the stat fails (file just got deleted, race
+ * with another writer, etc.) we fall back to `Date.now()` rather than
+ * dropping the event — losing the notification is worse than an
+ * approximate timestamp.
+ */
+export async function publishFileChange(relativePath: string): Promise<void> {
+  if (!pubsub) return;
+  const absPath = path.join(workspacePath, relativePath);
+  let mtimeMs: number;
+  try {
+    ({ mtimeMs } = await stat(absPath));
+  } catch (err) {
+    log.warn("file-change", "stat failed; falling back to Date.now()", {
+      pathPreview: relativePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    mtimeMs = Date.now();
+  }
+  const payload: FileChannelPayload = { path: relativePath, mtimeMs };
+  pubsub.publish(fileChannel(relativePath), payload);
+}
+
+/** Test-only — clear the module singleton so each test starts clean. */
+export function _resetFileChangePublisherForTesting(): void {
+  pubsub = null;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import { type NotificationDeps, initNotifications } from "./events/notifications
 import { createChatService } from "@mulmobridge/chat-service";
 import { readSessionJsonl } from "./utils/files/session-io.js";
 import { onSessionEvent, initSessionStore } from "./events/session-store/index.js";
+import { initFileChangePublisher } from "./events/file-change.js";
 import { getRole, loadAllRoles } from "./workspace/roles.js";
 import { discoverSkills } from "./workspace/skills/index.js";
 import { WORKSPACE_PATHS } from "./workspace/paths.js";
@@ -559,6 +560,11 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
 
   // --- Session Store ---
   initSessionStore(pubsub);
+
+  // --- File-change publisher ---
+  // Wired here (not at first publish) so the very first save after
+  // boot already sees a live publisher.
+  initFileChangePublisher(pubsub);
 
   // --- Task Manager ---
   const taskManager = createTaskManager({

--- a/src/composables/useFileChange.ts
+++ b/src/composables/useFileChange.ts
@@ -1,0 +1,53 @@
+// Subscribe to per-file change events from the server pub/sub.
+//
+// Returns a `version` ref that bumps to the post-write `mtimeMs`
+// every time the file at the given path is rewritten anywhere — same
+// tab, sibling tab, another browser, agent loop. View components use
+// this both as a cache-buster (`<iframe :src="url + '?v=' + version">`)
+// and as a watch trigger (refetch source / re-render markdown).
+//
+// `filePath` is reactive: switching `selectedResult` flips it, the
+// composable unsubscribes from the old channel and subscribes to the
+// new one. `version` resets to 0 whenever the path changes so callers
+// can cheaply detect "this file has been modified since I started
+// watching it" via `version.value > 0`.
+
+import { ref, watch, onUnmounted, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
+import { fileChannel, type FileChannelPayload } from "../config/pubsubChannels";
+
+export interface UseFileChangeReturn {
+  /** Latest known `mtimeMs` from the server, or `0` while we have not
+   *  observed a change since the path was set. Monotonic per path. */
+  version: Ref<number>;
+}
+
+export function useFileChange(filePath: Ref<string | null>): UseFileChangeReturn {
+  const version = ref(0);
+  const { subscribe } = usePubSub();
+  let unsubscribe: (() => void) | null = null;
+
+  function bind(nextPath: string | null): void {
+    unsubscribe?.();
+    unsubscribe = null;
+    version.value = 0;
+    if (!nextPath) return;
+    unsubscribe = subscribe(fileChannel(nextPath), (data) => {
+      const event = data as FileChannelPayload;
+      // Drop out-of-order events. Two writers landing within the same
+      // millisecond would also collapse to the later mtime, but that's
+      // fine — we'd refetch once and observe the merged state.
+      if (typeof event?.mtimeMs === "number" && event.mtimeMs > version.value) {
+        version.value = event.mtimeMs;
+      }
+    });
+  }
+
+  watch(filePath, bind, { immediate: true });
+  onUnmounted(() => {
+    unsubscribe?.();
+    unsubscribe = null;
+  });
+
+  return { version };
+}

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -35,11 +35,18 @@ export function sessionChannel(chatSessionId: string): string {
  * Subscribers: `useFileChange(filePath)` — wired from
  * `presentHtml/View.vue` and `markdown/View.vue`.
  */
-export function fileChannel(workspaceRelativePath: string): string {
+/** Normalise a workspace-relative path to the POSIX form used as both
+ *  the `fileChannel` suffix and the `FileChannelPayload.path`. Exposed
+ *  separately so publishers can share one normalised string between the
+ *  channel name and the payload — keeping them in sync is the contract. */
+export function toPosixWorkspacePath(workspaceRelativePath: string): string {
   // Replace backslashes too — covers both Windows (`\`) and any
   // pre-normalised mixed separators from upstream code.
-  const posix = workspaceRelativePath.split(/[\\/]/g).filter(Boolean).join("/");
-  return `file:${posix}`;
+  return workspaceRelativePath.split(/[\\/]/g).filter(Boolean).join("/");
+}
+
+export function fileChannel(workspaceRelativePath: string): string {
+  return `file:${toPosixWorkspacePath(workspaceRelativePath)}`;
 }
 
 /** Payload published on `fileChannel(...)`. `mtimeMs` is the post-write

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -22,6 +22,34 @@ export function sessionChannel(chatSessionId: string): string {
   return `session.${chatSessionId}`;
 }
 
+/**
+ * Channel for "this workspace file just changed". One per workspace-
+ * relative path. The path is normalised to POSIX separators so a
+ * Windows publisher and a Linux subscriber agree on the channel name
+ * (the workspace is per-machine, but tests, fixtures, and future
+ * remote editing all benefit from a portable contract).
+ *
+ * Publishers: any route that writes to disk and wants the UI to
+ * re-render — currently `presentHtml` (POST + PUT) and the markdown
+ * `updateMarkdown` route.
+ * Subscribers: `useFileChange(filePath)` — wired from
+ * `presentHtml/View.vue` and `markdown/View.vue`.
+ */
+export function fileChannel(workspaceRelativePath: string): string {
+  // Replace backslashes too — covers both Windows (`\`) and any
+  // pre-normalised mixed separators from upstream code.
+  const posix = workspaceRelativePath.split(/[\\/]/g).filter(Boolean).join("/");
+  return `file:${posix}`;
+}
+
+/** Payload published on `fileChannel(...)`. `mtimeMs` is the post-write
+ *  `fs.stat().mtimeMs`; subscribers use it both as a cache-buster and
+ *  as a monotonic clock to drop out-of-order events. */
+export interface FileChannelPayload {
+  path: string; // workspace-relative POSIX, matches the channel suffix
+  mtimeMs: number;
+}
+
 /** Payload published on `PUBSUB_CHANNELS.sessions`.
  *  - Empty `{}` for ordinary "something changed, refetch" hints
  *    (run/finish, mark-read, bookmark toggle).

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -164,14 +164,22 @@ const watchedPath = computed(() => {
 });
 const { version: fileVersion } = useFileChange(watchedPath);
 
-// Remote write: if the user has no unsaved edits, refetch silently. If
-// they're mid-edit, skip — `apiPut` Apply will still overwrite, and
-// they can press Cancel to discard their text and pull the disk
-// version on the next focus. (A "remote changed" banner is queued for
-// a follow-up — see plans/feat-file-change-pubsub.md.)
+// Declared early so the `fileVersion` watcher below can reach into the
+// `<details>` element to close the editor when a remote write lands.
+const sourceDetails = ref<HTMLDetailsElement>();
+
+// Remote write: refetch so the rendered view tracks disk. If the
+// editor is open we close it first — `fileVersion` only fires once
+// per remote write, so leaving the panel open and skipping the fetch
+// would strand the view on stale content until the next write
+// (#1001 P1). Discarding in-progress edits is rare enough to be
+// acceptable; a "remote changed" banner is queued for a follow-up —
+// see plans/feat-file-change-pubsub.md.
 watch(fileVersion, (current, previous) => {
   if (current === 0 || current === previous) return;
-  if (hasChanges.value) return;
+  if (sourceDetails.value?.open) {
+    sourceDetails.value.open = false;
+  }
   void fetchMarkdownContent();
 });
 
@@ -217,7 +225,6 @@ watch(
   },
 );
 
-const sourceDetails = ref<HTMLDetailsElement>();
 const editing = ref(false);
 const { copied, copy } = useClipboardCopy();
 

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -91,6 +91,7 @@ import { API_ROUTES } from "../../config/apiRoutes";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 import { buildPdfFilename } from "../../utils/files/filename";
 import { useAppApi } from "../../composables/useAppApi";
+import { useFileChange } from "../../composables/useFileChange";
 
 const { t } = useI18n();
 
@@ -152,6 +153,27 @@ async function fetchMarkdownContent(): Promise<void> {
 fetchMarkdownContent();
 
 const hasChanges = computed(() => editableMarkdown.value !== markdownContent.value);
+
+// Subscribe to per-file change events so any tab / browser / agent run
+// that overwrites the file refreshes this view automatically. The path
+// passed in is the workspace-relative `data.markdown` (only valid when
+// `isFilePath` — inline legacy content has no on-disk twin).
+const watchedPath = computed(() => {
+  const raw = props.selectedResult.data?.markdown;
+  return typeof raw === "string" && isFilePath(raw) ? raw : null;
+});
+const { version: fileVersion } = useFileChange(watchedPath);
+
+// Remote write: if the user has no unsaved edits, refetch silently. If
+// they're mid-edit, skip — `apiPut` Apply will still overwrite, and
+// they can press Cancel to discard their text and pull the disk
+// version on the next focus. (A "remote changed" banner is queued for
+// a follow-up — see plans/feat-file-change-pubsub.md.)
+watch(fileVersion, (current, previous) => {
+  if (current === 0 || current === previous) return;
+  if (hasChanges.value) return;
+  void fetchMarkdownContent();
+});
 
 // Frontmatter-aware view of the loaded content — separates the
 // `---\n...\n---` header (rendered as a properties panel) from the

--- a/src/plugins/presentHtml/View.vue
+++ b/src/plugins/presentHtml/View.vue
@@ -53,6 +53,7 @@ import { apiFetchRaw, apiPut } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { errorMessage } from "../../utils/errors";
 import { buildPrintCspContent } from "../../utils/html/previewCsp";
+import { useFileChange } from "../../composables/useFileChange";
 
 const { t } = useI18n();
 
@@ -82,9 +83,10 @@ const data = computed(() => props.selectedResult.data);
 const title = computed(() => data.value?.title);
 const filePath = computed(() => data.value?.filePath ?? null);
 
-// Bumped after a successful save so the iframe refetches the freshly
-// written file instead of showing the stale cached version.
-const previewVersion = ref(0);
+// `version` bumps to the post-write `mtimeMs` whenever any tab (or
+// browser, or the agent loop) writes this file. Wired to the iframe
+// `:src` as `?v=<mtime>` so the browser cache-busts the stale page.
+const { version: previewVersion } = useFileChange(filePath);
 const previewUrl = computed(() => {
   const base = htmlPreviewUrlFor(filePath.value);
   if (!base) return null;
@@ -173,20 +175,49 @@ async function applyHtml() {
     saveError.value = result.error;
     return;
   }
-  // Commit the new canonical source and force the iframe to refetch.
+  // Commit the just-saved text as the canonical source so the editor
+  // doesn't refetch over its own write when the file-change event
+  // arrives. Iframe cache-bust happens via `previewVersion` when the
+  // event lands.
   sourceCache.value = { ...sourceCache.value, [path]: editableHtml.value };
-  previewVersion.value += 1;
   if (sourceDetails.value) sourceDetails.value.open = false;
 }
 
 // When the user navigates to a different result, reset the editor so
-// stale text from the previous file doesn't carry over.
+// stale text from the previous file doesn't carry over. `previewVersion`
+// resets inside the composable when `filePath` flips.
 watch(filePath, () => {
   if (sourceDetails.value) sourceDetails.value.open = false;
   editableHtml.value = "";
   saveError.value = null;
   sourceError.value = null;
-  previewVersion.value = 0;
+});
+
+// Remote write detected: invalidate the editor's cached source so the
+// next read goes back to disk. If the edit panel is open AND the user
+// has no pending changes, silently refresh `editableHtml` to the new
+// on-disk text. If they have unsaved edits, leave `editableHtml` alone
+// — `cachedSource` becomes the newly-fetched text, `hasChanges` stays
+// true, and pressing Apply overwrites the remote change. (Surfacing a
+// "remote changed" banner is a follow-up — see
+// plans/feat-file-change-pubsub.md.)
+watch(previewVersion, async (current, previous) => {
+  if (current === 0 || current === previous) return;
+  const path = filePath.value;
+  if (!path) return;
+  // Snapshot dirtiness BEFORE invalidating the cache — `hasChanges`
+  // depends on `cachedSource`, which flips to `null` the moment we
+  // delete the entry.
+  const wasDirty = hasChanges.value;
+  const next = { ...sourceCache.value };
+  delete next[path];
+  sourceCache.value = next;
+  if (sourceDetails.value?.open === true) {
+    const fresh = await fetchSource();
+    if (fresh !== null && !wasDirty) {
+      editableHtml.value = fresh;
+    }
+  }
 });
 
 // Build the print-mode HTML by injecting four pieces into <head>:

--- a/src/plugins/presentHtml/View.vue
+++ b/src/plugins/presentHtml/View.vue
@@ -210,7 +210,7 @@ watch(previewVersion, async (current, previous) => {
   // delete the entry.
   const wasDirty = hasChanges.value;
   const next = { ...sourceCache.value };
-  delete next[path];
+  Reflect.deleteProperty(next, path);
   sourceCache.value = next;
   if (sourceDetails.value?.open === true) {
     const fresh = await fetchSource();

--- a/test/config/test_pubsubChannels.ts
+++ b/test/config/test_pubsubChannels.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { PUBSUB_CHANNELS, sessionChannel } from "../../src/config/pubsubChannels.js";
+import { PUBSUB_CHANNELS, fileChannel, sessionChannel } from "../../src/config/pubsubChannels.js";
 
 describe("sessionChannel", () => {
   it("prefixes the session id with `session.`", () => {
@@ -18,6 +18,23 @@ describe("sessionChannel", () => {
     // Edge case — not something callers should rely on, but the
     // factory shouldn't surprise them with a throw.
     assert.equal(sessionChannel(""), "session.");
+  });
+});
+
+describe("fileChannel", () => {
+  it("prefixes the path with `file:` and uses POSIX separators", () => {
+    assert.equal(fileChannel("artifacts/html/2026/04/foo.html"), "file:artifacts/html/2026/04/foo.html");
+  });
+
+  it("normalises backslashes to forward slashes (Windows-published, Linux-subscribed)", () => {
+    assert.equal(fileChannel("artifacts\\html\\2026\\foo.html"), "file:artifacts/html/2026/foo.html");
+  });
+
+  it("collapses runs of separators so a sloppy caller can't drift the channel name", () => {
+    // Publisher and subscriber both pass the same string through the
+    // factory, so a literal "//" in either side would still match —
+    // but the audit trail in logs is cleaner without doubles.
+    assert.equal(fileChannel("artifacts//html///foo.html"), "file:artifacts/html/foo.html");
   });
 });
 


### PR DESCRIPTION
Replace the same-tab `previewVersion` bump in presentHtml with a per-file pub/sub subscription, so any tab / browser / agent run that overwrites the file refreshes every open viewer.

* `src/config/pubsubChannels.ts` — new `fileChannel(relPath)` factory that produces `file:<workspace-relative-posix-path>` and a matching `FileChannelPayload` type. Backslash + multi-separator normalisation so a Windows publisher and a Linux subscriber agree on the channel.
* `server/events/file-change.ts` — module-singleton publisher (`session-store` pattern). `publishFileChange(relPath)` stats the freshly-written file for an accurate `mtimeMs` and broadcasts. Wired into `server/index.ts` next to `initSessionStore(pubsub)`.
* Three publish points: presentHtml POST (`/api/html/present`), presentHtml PUT (`/api/htmls/update`), markdown PUT (`/api/markdowns/update`). All `void publishFileChange(...)` so a pub/sub failure doesn't delay the 200.
* `src/composables/useFileChange.ts` — `usePubSub` wrapper returning a `version` ref (post-write `mtimeMs`, monotonic per path, re-binds when `filePath` flips).
* `presentHtml/View.vue` — replaced local `previewVersion` ref with the composable. Source-cache invalidation watcher that keeps the user's pending edits alive when a remote write lands (snapshots `hasChanges` BEFORE invalidating, since `hasChanges` depends on `cachedSource`).
* `markdown/View.vue` — silent refetch on remote change while `!hasChanges`; skip refetch while user is editing so local text is preserved.

Plan: plans/feat-file-change-pubsub.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented real-time file synchronization across browser tabs and windows. When a file is updated in one view, other open instances are automatically notified and refreshed.
  * Local unsaved edits are now protected; automatic updates only apply when there are no pending changes.

* **Documentation**
  * Added architecture documentation for the file-change notification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->