### PR TITLE
chore: reduce parseTableRow complexity in wiki.ts

### DIFF
--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -104,6 +104,28 @@ export function buildTableColumnMap(headerRow: string): Map<string, number> {
   return map;
 }
 
+interface TableColumnIndices {
+  slug: number;
+  title: number;
+  summary: number;
+  /** Undefined when the table has no `tags` column — caller skips
+   *  the tags lookup entirely and the row gets `tags: []`. */
+  tags: number | undefined;
+}
+
+/** Resolve the per-column indices the row parser needs. Falls back
+ *  to positional defaults (0/1/2) when the table has no header map.
+ *  "summary" is the canonical column name; "description" is accepted
+ *  as a legacy alias used by older fixtures. */
+function resolveTableColumnIndices(columnMap: Map<string, number> | null): TableColumnIndices {
+  return {
+    slug: columnMap?.get("slug") ?? 0,
+    title: columnMap?.get("title") ?? 1,
+    summary: columnMap?.get("summary") ?? columnMap?.get("description") ?? 2,
+    tags: columnMap?.get("tags"),
+  };
+}
+
 // Each parser returns the entry it produced (if any). The parent
 // loop tries them in order; the first non-null result wins.
 function parseTableRow(trimmed: string, columnMap: Map<string, number> | null): WikiPageEntry | null {
@@ -112,19 +134,14 @@ function parseTableRow(trimmed: string, columnMap: Map<string, number> | null): 
     .slice(1, -1)
     .map((column) => column.trim().replace(/^`|`$/g, ""));
   if (cols.length < 2) return null;
-  const slugIdx = columnMap?.get("slug") ?? 0;
-  const titleIdx = columnMap?.get("title") ?? 1;
-  // Accept either "summary" (the canonical column name in
-  // server/workspace/helps/wiki.md) or "description" (used by the
-  // existing unit test fixture). Fall back to column 2 when the
-  // table has no header map.
-  const summaryIdx = columnMap?.get("summary") ?? columnMap?.get("description") ?? 2;
-  const tagsIdx = columnMap?.get("tags");
-  const slug = cols[slugIdx] ?? "";
-  const title = cols[titleIdx] || slug;
-  const description = cols[summaryIdx] ?? "";
-  const tags = tagsIdx !== undefined ? parseTagsCell(cols[tagsIdx] ?? "") : [];
+
+  const idx = resolveTableColumnIndices(columnMap);
+  const slug = cols[idx.slug] ?? "";
+  const title = cols[idx.title] || slug;
   if (!slug || !title) return null;
+
+  const description = cols[idx.summary] ?? "";
+  const tags = idx.tags !== undefined ? parseTagsCell(cols[idx.tags] ?? "") : [];
   return { title, slug, description, tags };
 }
 


### PR DESCRIPTION
## Summary

Extracts the column-index lookup logic from `parseTableRow` (in `server/api/routes/wiki.ts`) into a small `resolveTableColumnIndices` helper, bringing the function under the project's `complexity: 15` rule (was 18).

## Items to Confirm / Review

- **Behaviour**: identical. Same positional fallbacks (slug=0, title=1, summary=2), same `summary` / `description` column-name alias, same `tags`-absent → `tags: []` rule.
- **Helper placement**: kept in the same file (next to its only caller). Not exported — purely internal.

## User Prompt

> server/api/routes/wiki.ts
>   109:1  warning  Function 'parseTableRow' has a complexity of 18. Maximum allowed is 15  complexity　直せる？

## Test plan

- [x] `yarn lint` — `parseTableRow` complexity warning at wiki.ts:109 is gone
- [x] `yarn typecheck` — clean
- [x] `yarn test` — clean
- [x] `yarn build` — clean
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)