### PR TITLE
chore: narrow wiki complexity exemption and add regression test

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -334,14 +334,10 @@ export default [
     },
   },
   {
-    // API-route override: cyclomatic `complexity` stays at `warn`
-    // here because the route handlers have several legitimately
-    // branchy functions (validation + auth + business logic in one
-    // place) that would need a coordinated split before they can
-    // graduate. Everything else under `server/` (utils, agent,
-    // workspace, …) is held to `error`; over time `server/api/routes/`
-    // should converge.
-    files: ["server/api/routes/**/*.{ts,js}"],
+    // Per-file complexity exemptions. Only the route handlers that
+    // still exceed the threshold stay at `warn`; the rest of
+    // `server/api/routes/` is held to `error`.
+    files: ["server/api/routes/files.ts", "server/api/routes/sessions.ts"],
     rules: {
       complexity: ["warn", { max: 15 }],
     },

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -195,6 +195,17 @@ describe("parseIndexEntries", () => {
     assert.equal(entries[0]?.description, "summary");
   });
 
+  it("falls back to positional columns when the header has no recognized names", () => {
+    const markdown = ["| alpha | beta | gamma |", "|-------|------|-------|", "| `slug-1` | Title 1 | Summary 1 |"].join("\n");
+    const entries = parseIndexEntries(markdown);
+    assert.deepEqual(entries[0], {
+      slug: "slug-1",
+      title: "Title 1",
+      description: "Summary 1",
+      tags: [],
+    });
+  });
+
   it("is case- and whitespace-tolerant for the Tags header name", () => {
     const markdown = ["| slug |  TAGS  | title |", "|------|--------|-------|", "| foo | a, b | Foo |"].join("\n");
     const entries = parseIndexEntries(markdown);


### PR DESCRIPTION
Follow-up to PR #1002.

Changes:
- Narrow the API-route complexity exemption to the remaining branchy handlers (`files.ts` and `sessions.ts`). `server/api/routes/wiki.ts` is now back under the normal complexity rule.
- Add a regression test that pins the positional fallback behavior in `parseIndexEntries` when the table header does not contain recognized column names.

Validation:
- `yarn eslint server/api/routes/wiki.ts`
- `yarn eslint test/routes/test_wikiHelpers.ts`
- `node --import tsx --test test/routes/test_wikiHelpers.ts`
- `yarn typecheck:test`