### PR TITLE
chore(roles): remove manageSkills/manageSource from Office

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -101,8 +101,6 @@ export const ROLES: Role[] = [
       "readXPost",
       "searchX",
       "notify",
-      "manageSkills",
-      "manageSource",
       "switchRole",
     ],
     queries: [


### PR DESCRIPTION
## Summary
- Office ロールの `availablePlugins` から `manageSkills` / `manageSource` を削除
- これらは #1004 で導入する Settings ロール側に集約され、Office は文書・表計算・プレゼン作成に集中する構成にする

## Why
Office ロールは「業務系コンテンツ作成」が本筋。skills / sources の管理は設定タスクなので Settings ロールへ寄せる方が一貫する(#1004 の方針に揃える)。

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` が通る
- [ ] UI で Office ロール選択時、プラグインランチャに manageSkills / manageSource が表示されないこと
- [ ] 他のロールに影響がないこと

Note: #1004 がマージされた後にマージしてください(順序依存)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)