### PR TITLE
refactor(sessions): extract loadSessionRow + buildSessionSummary helpers

### DIFF
--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -107,74 +107,98 @@ const router = Router();
 // SESSIONS_LIST_WINDOW_DAYS to override (0 = no cutoff).
 const WINDOW_MS = env.sessionsListWindowDays * ONE_DAY_MS;
 
+interface SessionRowContext {
+  chatDir: string;
+  cutoff: number;
+  indexById: Map<string, ChatIndexEntry>;
+}
+
+interface SessionRow {
+  summary: SessionSummary;
+  changeMs: number;
+}
+
+// Build a SessionSummary from the gathered inputs. Conditional spreads
+// honour the server tsconfig's `exactOptionalPropertyTypes`; that's
+// why each optional field is set with `if (… !== undefined)` rather
+// than spread into the object literal directly.
+function buildSessionSummary(
+  sessionId: string,
+  meta: SessionMeta,
+  indexEntry: ChatIndexEntry | undefined,
+  fileStat: { mtimeMs: number },
+  live: ReturnType<typeof getSession>,
+): SessionSummary {
+  // Prefer AI title → meta.firstUserMessage → empty.
+  const preview = indexEntry?.title ?? meta.firstUserMessage ?? "";
+  const summary: SessionSummary = {
+    id: sessionId,
+    roleId: meta.roleId,
+    startedAt: meta.startedAt,
+    updatedAt: new Date(fileStat.mtimeMs).toISOString(),
+    preview,
+    hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
+  };
+  if (meta.origin) summary.origin = meta.origin;
+  if (meta.isBookmarked) summary.isBookmarked = true;
+  if (indexEntry?.summary !== undefined) summary.summary = indexEntry.summary;
+  if (indexEntry?.keywords !== undefined) summary.keywords = indexEntry.keywords;
+  if (live) {
+    // Background generations (image/audio/movie) keep the session
+    // "busy" even when the agent turn has ended, so the sidebar
+    // indicator stays lit across view navigation.
+    summary.isRunning = live.isRunning || Object.keys(live.pendingGenerations).length > 0;
+    summary.statusMessage = live.statusMessage;
+  }
+  return summary;
+}
+
+// Load one session's row, or null when the session should be skipped
+// (cutoff window, missing meta, any I/O error). The `metaMtimeMs`
+// fallback lets a brand-new session contribute 0 to its changeMs
+// instead of crashing the whole listing.
+async function loadSessionRow(sessionId: string, ctx: SessionRowContext): Promise<SessionRow | null> {
+  try {
+    // stat only — no readFile on .jsonl content
+    const fileStat = await stat(sessionJsonlAbsPath(sessionId));
+    if (ctx.cutoff > 0 && fileStat.mtimeMs < ctx.cutoff) return null;
+
+    const meta = await readSessionMeta(ctx.chatDir, sessionId);
+    if (!meta) return null;
+
+    // The meta sidecar bumps its mtime on hasUnread / origin writes —
+    // feed it into changeMs so cursor-based refetches pick up drains
+    // of background generations (which only touch meta, not the
+    // jsonl).
+    const metaMtimeMs = await stat(sessionMetaAbsPath(sessionId))
+      .then((stats) => stats.mtimeMs)
+      .catch(() => 0);
+
+    const indexEntry = ctx.indexById.get(sessionId);
+    const live = getSession(sessionId);
+    return {
+      summary: buildSessionSummary(sessionId, meta, indexEntry, fileStat, live),
+      changeMs: sessionChangeMs(fileStat.mtimeMs, indexEntry?.indexedAt, metaMtimeMs),
+    };
+  } catch {
+    return null;
+  }
+}
+
 // Read the full session list off disk. Each row carries its
 // `changeMs` — the later of the jsonl mtime and the chat-index
 // `indexedAt` — so the handler can filter against `?since=` and
 // compute the new cursor without re-statting anything.
-export async function loadAllSessions(): Promise<{ summary: SessionSummary; changeMs: number }[]> {
+export async function loadAllSessions(): Promise<SessionRow[]> {
   const chatDir = WORKSPACE_PATHS.chat;
   const manifest = await readManifest(workspacePath);
   const indexById = new Map<string, ChatIndexEntry>(manifest.entries.map((entry) => [entry.id, entry]));
   const cutoff = WINDOW_MS > 0 ? Date.now() - WINDOW_MS : 0;
+  const ctx: SessionRowContext = { chatDir, cutoff, indexById };
 
   const files = (await readdir(chatDir)).filter((fileName) => fileName.endsWith(".jsonl"));
-  const rows = await Promise.all(
-    files.map(async (file) => {
-      const sessionId = file.replace(".jsonl", "");
-      try {
-        // stat only — no readFile on .jsonl content
-        const fileStat = await stat(sessionJsonlAbsPath(sessionId));
-        if (cutoff > 0 && fileStat.mtimeMs < cutoff) return null;
-
-        const meta = await readSessionMeta(chatDir, sessionId);
-        if (!meta) return null;
-
-        // The meta sidecar bumps its mtime on hasUnread / origin
-        // writes — feed it into changeMs so cursor-based refetches
-        // pick up drains of background generations (which only touch
-        // meta, not the jsonl). Missing stat (brand-new session
-        // before its first meta write) contributes 0.
-        const metaMtimeMs = await stat(sessionMetaAbsPath(sessionId))
-          .then((stats) => stats.mtimeMs)
-          .catch(() => 0);
-
-        const indexEntry = indexById.get(sessionId);
-        // Prefer AI title → meta.firstUserMessage → empty.
-        // `summary` and `keywords` are spread conditionally
-        // to respect the server tsconfig's
-        // exactOptionalPropertyTypes.
-        const preview = indexEntry?.title ?? meta.firstUserMessage ?? "";
-
-        const live = getSession(sessionId);
-        const summary: SessionSummary = {
-          id: sessionId,
-          roleId: meta.roleId,
-          startedAt: meta.startedAt,
-          updatedAt: new Date(fileStat.mtimeMs).toISOString(),
-          preview,
-          hasUnread: live?.hasUnread ?? meta.hasUnread ?? false,
-        };
-        if (meta.origin) summary.origin = meta.origin;
-        if (meta.isBookmarked) summary.isBookmarked = true;
-        if (indexEntry?.summary !== undefined) summary.summary = indexEntry.summary;
-        if (indexEntry?.keywords !== undefined) summary.keywords = indexEntry.keywords;
-        if (live) {
-          // Background generations (image/audio/movie) keep the session
-          // "busy" even when the agent turn has ended, so the sidebar
-          // indicator stays lit across view navigation.
-          summary.isRunning = live.isRunning || Object.keys(live.pendingGenerations).length > 0;
-          summary.statusMessage = live.statusMessage;
-        }
-        return {
-          summary,
-          changeMs: sessionChangeMs(fileStat.mtimeMs, indexEntry?.indexedAt, metaMtimeMs),
-        };
-      } catch {
-        return null;
-      }
-    }),
-  );
-  return rows.filter((row): row is { summary: SessionSummary; changeMs: number } => row !== null);
+  const rows = await Promise.all(files.map((file) => loadSessionRow(file.replace(".jsonl", ""), ctx)));
+  return rows.filter((row): row is SessionRow => row !== null);
 }
 
 router.get(API_ROUTES.sessions.list, async (req: Request<object, SessionsResponse, object, SessionsQuery>, res: Response<SessionsResponse>) => {


### PR DESCRIPTION
## Summary

`loadAllSessions` 内の `Promise.all(files.map(async (file) => …))` の async arrow が **complexity 20**(lint warning)だったのを 2 つの helper に分割。Pure refactor、logic 変更ゼロ。

3 件残っていた `complexity` warning(`server/api/routes/files.ts:713` = 22 / `server/api/routes/sessions.ts:122` = 20 / `server/api/routes/sessions.ts:242` = 17)のうち、本 PR は **真ん中の sessions.ts:122** を解消する。残り 2 件は別 PR で。

## What changed

### 抽出した helper

- `buildSessionSummary(sessionId, meta, indexEntry, fileStat, live)` — 条件付きスプレッド(`origin` / `isBookmarked` / `summary` / `keywords` / `live` の `isRunning` + `statusMessage`)を 1 つの pure function に集約。`exactOptionalPropertyTypes` の制約上 `if (… !== undefined)` での代入が必要なので spread には統合できないが、関数化で複雑度の山を 1 つ消す。
- `loadSessionRow(sessionId, ctx)` — I/O + filter chain(`stat` / cutoff / `readSessionMeta` / meta sidecar mtime / `getSession`)を per-call context(`chatDir` / `cutoff` / `indexById`)とともにラップ。

### caller の変化

```ts
// before: 50+ 行の async arrow を直接 map
const rows = await Promise.all(files.map(async (file) => { … }));

// after: 1 行 dispatch
const rows = await Promise.all(files.map((file) => loadSessionRow(file.replace(".jsonl", ""), ctx)));
```

### 副次効果

- `loadAllSessions` が「ファイル列挙 → row 取得 → null 落とし」という意図を 3 行で表現できる。
- `SessionRow` / `SessionRowContext` を interface にしたので、テストから helper を直接突きやすくなった(本 PR では新規テスト未追加)。

## Items to Confirm / Review

- [ ] **logic 不変性**:cutoff / meta-mtime fallback / live state / cursor 用 `changeMs` の組み立てが before と同じこと。特に `cutoff > 0 && fileStat.mtimeMs < cutoff` の判定が `ctx.cutoff > 0` に置き換わっている点。
- [ ] **`buildSessionSummary` の責務**:summary 構築のみで I/O しない。`live` は呼び出し側で取得して渡す形に。
- [ ] **lint warning 数**:before 3 件 / after 2 件(`files.ts:713` = 22、`sessions.ts:266` = 17 が残存。後者は同ファイル別ハンドラなので line 番号がずれている)。

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint --no-cache` — sessions.ts:122 の complexity warning が消滅、エラーなし
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] e2e: `/api/sessions` の listing が(filter / sort / cursor 含めて)before と同じレスポンスを返すこと(既存 e2e がカバー)

## 次

- 残り 2 件:
  - `files.ts:713`(complexity 22、PUT `/api/files/content` ハンドラ)
  - `sessions.ts:266`(complexity 17、JSONL 1 行ずつの `.map` 内 entry parsing)

両方とも同じ extraction パターンで対応可能。それぞれ独立 PR で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session data loading architecture with enhanced error handling and more accurate metadata timestamp calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->