### PR TITLE
refactor(sessions): split JSONL line parser into typed helpers

### DIFF
--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -246,6 +246,79 @@ interface SessionErrorResponse {
   error: string;
 }
 
+// Narrow type predicate for the presentMulmoScript tool-result shape
+// the enrichment helper inspects. Returning `entry is …` lets the
+// caller drop the redundant nested checks once the predicate passes.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isPresentMulmoScriptToolResult(entry: any): entry is {
+  source: "tool";
+  type: string;
+  result: { toolName: "presentMulmoScript"; data: { filePath: string } & Record<string, unknown> };
+} & Record<string, unknown> {
+  return (
+    entry?.source === "tool" &&
+    entry?.type === EVENT_TYPES.toolResult &&
+    entry?.result?.toolName === "presentMulmoScript" &&
+    typeof entry?.result?.data?.filePath === "string"
+  );
+}
+
+// Re-read the MulmoScript JSON pointed at by `entry.result.data.filePath`
+// and merge it into a copy of the entry. Returns the original entry on
+// any failure (missing file, traversal escape, parse error, absolute
+// path) so the detail route never breaks because of a single rotted
+// link. Path-traversal guard is realpath-based — see
+// resolveWithinRoot for why.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function enrichWithMulmoScript(entry: any): Promise<any> {
+  try {
+    const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
+    let storiesReal: string;
+    try {
+      storiesReal = realpathSync(storiesDir);
+    } catch {
+      return entry;
+    }
+    const scriptRelPath: string = entry.result.data.filePath;
+    if (path.isAbsolute(scriptRelPath)) return entry;
+    const relFromStories = scriptRelPath.startsWith("stories/") ? scriptRelPath.slice("stories/".length) : scriptRelPath;
+    const scriptPath = resolveWithinRoot(storiesReal, relFromStories);
+    if (!scriptPath) return entry;
+    const scriptJson = (await readTextSafe(scriptPath)) ?? "";
+    return {
+      ...entry,
+      result: {
+        ...entry.result,
+        data: {
+          ...entry.result.data,
+          script: JSON.parse(scriptJson),
+        },
+      },
+    };
+  } catch {
+    return entry;
+  }
+}
+
+// Parse one JSONL line into a session entry, applying the legacy-meta
+// skip and the presentMulmoScript enrichment in one place. Returns
+// null when the line should not appear in the response (parse error
+// or legacy meta).
+async function parseSessionEntry(line: string): Promise<unknown> {
+  let entry: unknown;
+  try {
+    entry = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  // Skip legacy metadata entries now stored in .json
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const typed = entry as any;
+  if (typed?.type === EVENT_TYPES.sessionMeta || typed?.type === EVENT_TYPES.claudeSessionId) return null;
+  if (isPresentMulmoScriptToolResult(typed)) return enrichWithMulmoScript(typed);
+  return typed;
+}
+
 router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res: Response<unknown[] | SessionErrorResponse>) => {
   const { id: sessionId } = req.params;
   const chatDir = WORKSPACE_PATHS.chat;
@@ -258,65 +331,7 @@ router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res
       notFound(res, `Session ${sessionId} not found`);
       return;
     }
-    const entries = (
-      await Promise.all(
-        content
-          .split("\n")
-          .filter(Boolean)
-          .map(async (line) => {
-            try {
-              const entry = JSON.parse(line);
-              // Skip legacy metadata entries now stored in .json
-              if (entry.type === EVENT_TYPES.sessionMeta || entry.type === EVENT_TYPES.claudeSessionId) return null;
-              // For presentMulmoScript results, re-read the script from disk
-              if (
-                entry.source === "tool" &&
-                entry.type === EVENT_TYPES.toolResult &&
-                entry.result?.toolName === "presentMulmoScript" &&
-                entry.result?.data?.filePath
-              ) {
-                try {
-                  // Realpath-based traversal check defeats symlink
-                  // escapes — see resolveWithinRoot in utils/fs.ts.
-                  // Resolve the stories dir's realpath so the
-                  // boundary check works even when stories/ itself
-                  // is a legitimate symlink to another disk.
-                  const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
-                  let storiesReal: string;
-                  try {
-                    storiesReal = realpathSync(storiesDir);
-                  } catch {
-                    return entry;
-                  }
-                  const scriptRelPath: string = entry.result.data.filePath;
-                  if (path.isAbsolute(scriptRelPath)) return entry;
-                  // Strip optional "stories/" prefix so the
-                  // remainder is relative to storiesReal.
-                  const relFromStories = scriptRelPath.startsWith("stories/") ? scriptRelPath.slice("stories/".length) : scriptRelPath;
-                  const scriptPath = resolveWithinRoot(storiesReal, relFromStories);
-                  if (!scriptPath) return entry;
-                  const scriptJson = (await readTextSafe(scriptPath)) ?? "";
-                  return {
-                    ...entry,
-                    result: {
-                      ...entry.result,
-                      data: {
-                        ...entry.result.data,
-                        script: JSON.parse(scriptJson),
-                      },
-                    },
-                  };
-                } catch {
-                  // file missing — return original entry
-                }
-              }
-              return entry;
-            } catch {
-              return null;
-            }
-          }),
-      )
-    ).filter(Boolean);
+    const entries = (await Promise.all(content.split("\n").filter(Boolean).map(parseSessionEntry))).filter(Boolean);
     // Prepend metadata as session_meta entry for the frontend
     const result = meta ? [{ type: EVENT_TYPES.sessionMeta, ...meta }, ...entries] : entries;
     log.info("sessions", "detail: ok", { sessionId, entries: result.length });


### PR DESCRIPTION
## Summary

GET `/api/sessions/:id` の handler 内 `content.split("\n").filter(Boolean).map(async (line) => …)` の async arrow が **complexity 17**(lint warning)だったのを 3 つの helper に分割。Pure refactor、logic 変更ゼロ。

3 件残っていた `complexity` warning のうち 2 件目を解消(1 件目は #1012 で merge 済)。残る 1 件は `files.ts:713`(complexity 22)で別 PR。

## What changed

### 抽出した helper

- **`isPresentMulmoScriptToolResult(entry)`** — type predicate。`entry?.source === "tool" && entry?.type === EVENT_TYPES.toolResult && entry?.result?.toolName === "presentMulmoScript" && typeof entry?.result?.data?.filePath === "string"` の 4 句シェイプチェックを named guard に集約。
- **`enrichWithMulmoScript(entry)`** — `realpath` ベースの traversal guard を通して MulmoScript JSON を読み、コピーにマージ。**いずれの失敗モード(missing file / absolute path / traversal escape / parse error)でも元 entry を返す** ので、rot した link 1 本で detail response 全体が壊れる経路はない。
- **`parseSessionEntry(line)`** — `JSON.parse` + legacy-meta skip(`sessionMeta` / `claudeSessionId`)+ enrichment dispatch。レスポンスに乗せたくない行は `null` を返す。

### caller の変化

```ts
// before: 50+ 行の async arrow を直接 map
const entries = (await Promise.all(
  content.split("\n").filter(Boolean).map(async (line) => { … })
)).filter(Boolean);

// after: 1 行 dispatch
const entries = (await Promise.all(
  content.split("\n").filter(Boolean).map(parseSessionEntry)
)).filter(Boolean);
```

### 副次効果

- `isPresentMulmoScriptToolResult` を type predicate にしたので、enrichment 内で `entry.result.data.filePath` を再 narrow せずアクセスできる(ESLint の `no-unsafe-member-access` を黙らせるための `as any` キャストが減る)。
- enrichment と parse / dispatch の責務が分離。今後 「`presentSpreadsheet` も同様に script を再読」みたいな対称拡張があれば、predicate + helper を 1 ペア足すだけで済む。

## Items to Confirm / Review

- [ ] **logic 不変性**:
  - JSON.parse 失敗 → null(変わらず)
  - legacy meta(`sessionMeta` / `claudeSessionId`)→ null(変わらず)
  - presentMulmoScript の `result.data.filePath` enrichment が **同条件・同優先順位**:
    1. realpath 失敗 → 元 entry
    2. `path.isAbsolute(filePath)` → 元 entry(traversal 防止)
    3. `stories/` prefix を strip
    4. `resolveWithinRoot()` 失敗 → 元 entry
    5. `readTextSafe` が null → 空文字を `JSON.parse` → throw → 元 entry(catch)
    6. 成功 → script を merge
- [ ] **`enrichWithMulmoScript`** に `// eslint-disable-next-line @typescript-eslint/no-explicit-any` を 2 箇所付けた点。型は predicate で narrow しているが、`{ ...entry, result: { ...entry.result, data: { ...entry.result.data, script } } }` の spread は `any` を介する方が落ち着く(strict narrow を維持しようとすると型再定義が要る)。
- [ ] **`parseSessionEntry` 内の `typed as any` キャスト**。type predicate の前段では `entry` を `unknown` から narrow したいが、JSON.parse の戻りは any に落ちるため、`typed?.type === …` のアクセスを clean に書くために導入。

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint --no-cache` — sessions.ts:266 の complexity warning 消滅、エラーなし(残るは files.ts:713 = 22 のみ)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] e2e: `/api/sessions/:id` の detail レスポンスが before と byte-identical(presentMulmoScript の script merge 含む)

## Refs

- 直前 PR: #1012(`loadSessionRow` / `buildSessionSummary` 抽出、complexity 20 解消、merged)
- 残り: `files.ts:713` の complexity 22(別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)