### PR TITLE
fix(wiki): dedupe LLM-write hook snapshots against previous

### DIFF
--- a/server/api/routes/wiki/history.ts
+++ b/server/api/routes/wiki/history.ts
@@ -14,7 +14,7 @@
 import { Router, type Request, type Response } from "express";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { writeWikiPage } from "../../../workspace/wiki-pages/io.js";
+import { hasMeaningfulChange, writeWikiPage } from "../../../workspace/wiki-pages/io.js";
 import { WORKSPACE_DIRS } from "../../../workspace/paths.js";
 import { isSafeStamp, listSnapshots, readSnapshot, stripSnapshotMeta } from "../../../workspace/wiki-pages/snapshot.js";
 import { mergeFrontmatter, serializeWithFrontmatter } from "../../../utils/markdown/frontmatter.js";
@@ -44,6 +44,19 @@ function isSafeSlug(slug: string): boolean {
 // every other UI-driven save today.
 function restoreReason(stamp: string): string {
   return `Restored from ${stamp}`;
+}
+
+// Re-build the previous snapshot's content as a single
+// frontmatter+body string for `hasMeaningfulChange` to compare
+// against. `_snapshot_*` keys are stripped first — those are
+// snapshot-event metadata, not part of the page itself, and
+// keeping them in the diff would always flag a difference.
+async function loadPreviousSnapshotContent(slug: string): Promise<string | null> {
+  const recent = await listSnapshots(slug, { workspaceRoot: workspacePath });
+  if (recent.length === 0) return null;
+  const latest = await readSnapshot(slug, recent[0].stamp, { workspaceRoot: workspacePath });
+  if (latest === null) return null;
+  return serializeWithFrontmatter(stripSnapshotMeta(latest.meta), latest.body);
 }
 
 router.get("/pages/:slug/history", async (req: Request<{ slug: string }>, res: Response) => {
@@ -162,6 +175,20 @@ router.post("/internal/snapshot", async (req: Request<object, unknown, InternalS
   const content = await readTextOrNull(pagePath);
   if (content === null) {
     notFound(res, "wiki page not found on disk");
+    return;
+  }
+
+  // Dedupe against the most recent snapshot — Write/Edit hooks
+  // fire for every tool call, including ones that only re-stamp
+  // `updated` / `editor` without touching the body. Without this
+  // guard the history page accumulates duplicate entries (user
+  // report 2026-04-30: two identical bodies snapped 2.6s apart).
+  // `hasMeaningfulChange` already drives the in-process
+  // `writeWikiPage` path; reusing it keeps both paths aligned.
+  const previousContent = await loadPreviousSnapshotContent(slug);
+  if (previousContent !== null && !hasMeaningfulChange(previousContent, content)) {
+    log.info("wiki", "internal snapshot skipped — no meaningful change since previous snapshot", { slug });
+    res.json({ slug, ok: true, skipped: "no-meaningful-change" });
     return;
   }
 

--- a/server/workspace/wiki-pages/io.ts
+++ b/server/workspace/wiki-pages/io.ts
@@ -122,8 +122,13 @@ export async function writeWikiPage(slug: string, content: string, meta: WikiWri
  *  Auto-stamps land on every save; without this guard the
  *  snapshot pipeline (#763 PR 2) would record a snapshot per
  *  no-op save. The check compares (body) and (meta minus the
- *  auto-stamped keys). */
-function hasMeaningfulChange(oldContent: string, newContent: string): boolean {
+ *  auto-stamped keys).
+ *
+ *  Exported so the LLM-write hook callback (`/api/wiki/internal/
+ *  snapshot`) can apply the same dedupe before recording a
+ *  snapshot — without this, the hook records one snapshot per
+ *  Write/Edit even when the LLM only re-stamped `updated`. */
+export function hasMeaningfulChange(oldContent: string, newContent: string): boolean {
   const oldDoc = parseFrontmatter(oldContent);
   const newDoc = parseFrontmatter(newContent);
   if (oldDoc.body !== newDoc.body) return true;

--- a/test/routes/test_wikiInternalSnapshotRoute.ts
+++ b/test/routes/test_wikiInternalSnapshotRoute.ts
@@ -190,29 +190,52 @@ describe("POST /api/wiki/internal/snapshot", () => {
 
   it("skips snapshot + toolResult when the new content matches the previous snapshot (sans auto-stamps)", async () => {
     const slug = "no-meaningful-change";
+    const sessionId = "chat-no-op-1";
     const filePath = path.join(pagesDir, `${slug}.md`);
     await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:00:00.000Z'\neditor: llm\n---\n\nbody A\n", "utf-8");
 
-    // First call records the baseline.
+    // Set up a session so pushToolResult would actually fire if the
+    // dedupe gate let through the no-op call (codex review iter-1
+    // #1017): without this listener we'd only catch a snapshot regression,
+    // not a stray toolResult.
+    const sessionFile = path.join(tmpRoot, `${sessionId}.jsonl`);
+    getOrCreateSession(sessionId, {
+      roleId: "general",
+      resultsFilePath: sessionFile,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    const events: Record<string, unknown>[] = [];
+    const unsubscribe = onSessionEvent(sessionId, (event) => {
+      events.push(event);
+    });
+
+    // First call records the baseline AND publishes a toolResult.
     const first = mockRes();
-    await snapshotHandler(makeReq({ slug }), first.res);
+    await snapshotHandler(makeReq({ slug, sessionId }), first.res);
     assert.equal(first.state.status, 200);
     assert.equal((await listSnapshots(slug)).length, 1, "first call should record baseline");
+    assert.equal(events.length, 1, "first call should publish exactly one toolResult");
 
-    // Second call with only `updated` re-stamped → must be a no-op.
+    // Second call with only `updated` re-stamped → must be a no-op
+    // for BOTH snapshot and toolResult.
     await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:01:00.000Z'\neditor: llm\n---\n\nbody A\n", "utf-8");
     const second = mockRes();
-    await snapshotHandler(makeReq({ slug }), second.res);
+    await snapshotHandler(makeReq({ slug, sessionId }), second.res);
     assert.equal(second.state.status, 200);
     assert.equal((second.state.body as Record<string, unknown> | undefined)?.skipped, "no-meaningful-change");
     assert.equal((await listSnapshots(slug)).length, 1, "no second snapshot for an updated-only diff");
+    assert.equal(events.length, 1, "no second toolResult for an updated-only diff");
 
-    // Third call with a real body change → must record.
+    // Third call with a real body change → must record AND publish.
     await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:02:00.000Z'\neditor: llm\n---\n\nbody B\n", "utf-8");
     const third = mockRes();
-    await snapshotHandler(makeReq({ slug }), third.res);
+    await snapshotHandler(makeReq({ slug, sessionId }), third.res);
     assert.equal(third.state.status, 200);
     assert.equal((await listSnapshots(slug)).length, 2, "real body change must record");
+    assert.equal(events.length, 2, "real body change must publish a toolResult");
+
+    unsubscribe();
   });
 
   it("does not publish a toolResult when sessionId is absent", async () => {

--- a/test/routes/test_wikiInternalSnapshotRoute.ts
+++ b/test/routes/test_wikiInternalSnapshotRoute.ts
@@ -188,6 +188,33 @@ describe("POST /api/wiki/internal/snapshot", () => {
     assert.equal(result.data?.pagePath, `data/wiki/pages/${slug}.md`);
   });
 
+  it("skips snapshot + toolResult when the new content matches the previous snapshot (sans auto-stamps)", async () => {
+    const slug = "no-meaningful-change";
+    const filePath = path.join(pagesDir, `${slug}.md`);
+    await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:00:00.000Z'\neditor: llm\n---\n\nbody A\n", "utf-8");
+
+    // First call records the baseline.
+    const first = mockRes();
+    await snapshotHandler(makeReq({ slug }), first.res);
+    assert.equal(first.state.status, 200);
+    assert.equal((await listSnapshots(slug)).length, 1, "first call should record baseline");
+
+    // Second call with only `updated` re-stamped → must be a no-op.
+    await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:01:00.000Z'\neditor: llm\n---\n\nbody A\n", "utf-8");
+    const second = mockRes();
+    await snapshotHandler(makeReq({ slug }), second.res);
+    assert.equal(second.state.status, 200);
+    assert.equal((second.state.body as Record<string, unknown> | undefined)?.skipped, "no-meaningful-change");
+    assert.equal((await listSnapshots(slug)).length, 1, "no second snapshot for an updated-only diff");
+
+    // Third call with a real body change → must record.
+    await writeFile(filePath, "---\ntitle: x\nupdated: '2026-04-30T00:02:00.000Z'\neditor: llm\n---\n\nbody B\n", "utf-8");
+    const third = mockRes();
+    await snapshotHandler(makeReq({ slug }), third.res);
+    assert.equal(third.state.status, 200);
+    assert.equal((await listSnapshots(slug)).length, 2, "real body change must record");
+  });
+
   it("does not publish a toolResult when sessionId is absent", async () => {
     const slug = "no-publish-without-session";
     await writeFile(path.join(pagesDir, `${slug}.md`), "body\n", "utf-8");


### PR DESCRIPTION
## Summary

The wiki history page was accumulating duplicate snapshot entries — same body, only `updated:` differing, taken seconds apart. Confirmed with a real workspace under `/wiki/pages/test-page-2`: two snapshots at `2026-04-30T07:07:25.237Z` and `…07:07:27.875Z` with byte-identical bodies (1171 bytes each).

Root cause: the PostToolUse hook fires for every Claude `Write` / `Edit`, including no-op re-stamps of `updated`. The callback (`/api/wiki/internal/snapshot`) was calling `appendSnapshot` unconditionally; `writeWikiPage` (the in-process path) already gates on `hasMeaningfulChange`, but the hook path didn't.

## Items to Confirm / Review

- **Behavioural impact**: a hook fire that doesn't change the body OR any user-visible meta is now silently skipped. Real edits still snapshot. The toolResult publish is also skipped on no-op (no point flashing the canvas with an inline preview that's identical to the previous one).
- **Wire shape**: skip path returns `{ slug, ok: true, skipped: "no-meaningful-change" }`. Existing 200 callers (the hook itself) treat the response as fire-and-forget so the extra field is harmless.
- **Test**: new regression case — three `/internal/snapshot` calls, only #1 and #3 record; #2 (only `updated` differs) is marked `skipped`.

## User Prompt

> wikiの履歴、duplicateして２つはいるっぽい。確認して。
> http://localhost:5173/wiki/pages/test-page-2

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (after factoring the dedupe into `loadPreviousSnapshotContent` to keep the route handler under the complexity:15 cap)
- [x] `yarn test` all green; new regression test in `test/routes/test_wikiInternalSnapshotRoute.ts` covers the no-op + real-diff distinction
- [ ] CI on the PR
- [ ] Manual: trigger an LLM Write/Edit on a wiki page, then a second write that only re-stamps `updated:`. The history page now shows one new snapshot instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki snapshots are no longer created when only auto-updated metadata (timestamp, editor) changes, reducing unnecessary storage usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->