### PR TITLE
refactor(files): split PUT /api/files/content handler into helpers

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -706,94 +706,124 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
   res.json({ kind: "text", ...meta, content });
 });
 
-// Write the body of an existing text file. Only text-classified files
-// (per `classify`) are editable — binary, image, audio, etc. are
-// refused so the endpoint can't be used to ship arbitrary uploads.
-// The file must already exist; creating new files is out of scope.
-router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteContentRequest>, res: Response<WriteContentResponse | ErrorResponse>) => {
-  const { path: relPathRaw, content: contentRaw } = req.body ?? {};
-  log.info("files", "PUT content: start", {
-    pathPreview: typeof relPathRaw === "string" ? previewSnippet(relPathRaw) : undefined,
-    bytes: typeof contentRaw === "string" ? Buffer.byteLength(contentRaw, "utf-8") : undefined,
-  });
+type PutContentValidation =
+  | { ok: true; relPath: string; content: string; bytes: number }
+  | { ok: false; logMsg: string; logExtra: Record<string, unknown>; message: string };
+
+// Runtime-shape gate for PUT /api/files/content's body. Returns either
+// the narrowed inputs + their byte length (computed once and reused
+// downstream), or a structured rejection carrying the log message,
+// log extras, and the response message — so the caller can fan them
+// out into log.warn + badRequest without rebuilding context.
+function validatePutContentRequest(body: unknown): PutContentValidation {
+  const obj = (body ?? {}) as { path?: unknown; content?: unknown };
+  const { path: relPathRaw, content: contentRaw } = obj;
   if (typeof relPathRaw !== "string" || relPathRaw.length === 0) {
-    log.warn("files", "PUT content: missing path");
-    badRequest(res, "path required");
-    return;
+    return { ok: false, logMsg: "PUT content: missing path", logExtra: {}, message: "path required" };
   }
   if (typeof contentRaw !== "string") {
-    log.warn("files", "PUT content: missing content", { pathPreview: previewSnippet(relPathRaw) });
-    badRequest(res, "content required");
-    return;
+    return {
+      ok: false,
+      logMsg: "PUT content: missing content",
+      logExtra: { pathPreview: previewSnippet(relPathRaw) },
+      message: "content required",
+    };
   }
-  if (Buffer.byteLength(contentRaw, "utf-8") > MAX_PREVIEW_BYTES) {
-    log.warn("files", "PUT content: too large", { pathPreview: previewSnippet(relPathRaw), bytes: Buffer.byteLength(contentRaw, "utf-8") });
-    badRequest(res, `content exceeds ${MAX_PREVIEW_BYTES} byte limit`);
-    return;
+  const bytes = Buffer.byteLength(contentRaw, "utf-8");
+  if (bytes > MAX_PREVIEW_BYTES) {
+    return {
+      ok: false,
+      logMsg: "PUT content: too large",
+      logExtra: { pathPreview: previewSnippet(relPathRaw), bytes },
+      message: `content exceeds ${MAX_PREVIEW_BYTES} byte limit`,
+    };
   }
-  // Two-step resolution to distinguish "path outside workspace" (400)
-  // from "file does not exist" (404): realpath throws on ENOENT, so
-  // resolveSafe conflates the two. Stat the syntactic candidate
-  // first; if it exists, THEN run the symlink-hardened resolveSafe.
+  return { ok: true, relPath: relPathRaw, content: contentRaw, bytes };
+}
+
+type ResolvedTextFile = { ok: true; absPath: string } | { ok: false; status: 400 | 404; message: string };
+
+// Two-step path resolution + text-only gate for PUT /api/files/content.
+//
+// Why two steps: `resolveSafe` calls `realpathSync`, which throws
+// ENOENT for missing files. Conflating "path outside workspace"
+// (caller bug, 400) with "file does not exist" (404) loses the
+// signal. Stat the syntactic candidate first; only if it exists
+// do we run the symlink-hardened resolveSafe.
+//
+// The classifier check rejects binary / image / audio / etc. so
+// this endpoint can't be used as an arbitrary upload channel.
+async function resolveExistingTextFile(relPathRaw: string): Promise<ResolvedTextFile> {
   const candidate = path.resolve(workspaceReal, path.normalize(relPathRaw));
   const existing = await statSafeAsync(candidate);
   if (!existing) {
     const relativeFromWorkspace = path.relative(workspaceReal, candidate);
     const escapesSyntactically = relativeFromWorkspace === ".." || relativeFromWorkspace.startsWith(`..${path.sep}`);
-    if (escapesSyntactically) {
-      badRequest(res, "Path outside workspace");
-    } else {
-      notFound(res, "File not found");
-    }
-    return;
+    return escapesSyntactically ? { ok: false, status: 400, message: "Path outside workspace" } : { ok: false, status: 404, message: "File not found" };
   }
-  if (!existing.isFile()) {
-    badRequest(res, "Not a file");
-    return;
-  }
+  if (!existing.isFile()) return { ok: false, status: 400, message: "Not a file" };
   const absPath = resolveSafe(relPathRaw);
-  if (!absPath) {
-    badRequest(res, "Path outside workspace");
+  if (!absPath) return { ok: false, status: 400, message: "Path outside workspace" };
+  if (classify(absPath) !== "text") return { ok: false, status: 400, message: "File type not editable" };
+  return { ok: true, absPath };
+}
+
+// Wiki pages route through `writeWikiPage` so the (old, new) pair
+// reaches the edit-history pipeline (#763). Everything else takes
+// the generic atomic write. `uniqueTmp: true` appends a randomUUID
+// to the tmp filename so two simultaneous PUTs to the same path
+// can't clobber each other's staging file and race through rename
+// (writeWikiPage applies it internally).
+//
+// `workspaceReal` is the already-realpath'd workspace root —
+// resolveSafe returns a realpath'd absPath, so the classifier MUST
+// compare against the same realpath'd root. A symlinked workspace
+// (e.g. `~/mulmoclaude` → some real path elsewhere) would otherwise
+// silently bypass the wiki chokepoint.
+async function writeFileContent(absPath: string, content: string): Promise<void> {
+  const wikiClass = classifyAsWikiPage(absPath, { workspaceRoot: workspaceReal });
+  if (wikiClass.wiki) {
+    await writeWikiPage(wikiClass.slug, content, { editor: "user" }, { workspaceRoot: workspaceReal });
+  } else {
+    await writeFileAtomic(absPath, content, { uniqueTmp: true });
+  }
+}
+
+// Write the body of an existing text file. Only text-classified files
+// (per `classify`) are editable — binary, image, audio, etc. are
+// refused so the endpoint can't be used to ship arbitrary uploads.
+// The file must already exist; creating new files is out of scope.
+router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteContentRequest>, res: Response<WriteContentResponse | ErrorResponse>) => {
+  const validation = validatePutContentRequest(req.body);
+  if (!validation.ok) {
+    log.warn("files", validation.logMsg, validation.logExtra);
+    badRequest(res, validation.message);
     return;
   }
-  if (classify(absPath) !== "text") {
-    badRequest(res, "File type not editable");
+  const { relPath, content, bytes: contentBytes } = validation;
+  log.info("files", "PUT content: start", { pathPreview: previewSnippet(relPath), bytes: contentBytes });
+
+  const resolved = await resolveExistingTextFile(relPath);
+  if (!resolved.ok) {
+    if (resolved.status === 404) notFound(res, resolved.message);
+    else badRequest(res, resolved.message);
     return;
   }
   try {
-    // Wiki pages have their own choke-point write helper that
-    // captures (old, new) for the edit-history pipeline (#763).
-    // Anything else falls back to the generic atomic write.
-    // `uniqueTmp: true` appends a randomUUID to the tmp filename so
-    // two simultaneous PUTs to the same path can't clobber each
-    // other's staging file and race through the rename
-    // (writeWikiPage applies it internally).
-    //
-    // Pass the already-realpath'd `workspaceReal` to the classifier:
-    // `resolveSafe()` returns a realpath'd `absPath`, so the root
-    // we compare against MUST also be realpath'd. Otherwise a
-    // symlinked workspace (e.g. `~/mulmoclaude` → some real path
-    // elsewhere) silently routes wiki writes through the generic
-    // branch and bypasses the chokepoint.
-    const wikiClass = classifyAsWikiPage(absPath, { workspaceRoot: workspaceReal });
-    if (wikiClass.wiki) {
-      await writeWikiPage(wikiClass.slug, contentRaw, { editor: "user" }, { workspaceRoot: workspaceReal });
-    } else {
-      await writeFileAtomic(absPath, contentRaw, { uniqueTmp: true });
-    }
+    await writeFileContent(resolved.absPath, content);
   } catch (err) {
-    log.error("files", "PUT content: write threw", { pathPreview: previewSnippet(relPathRaw), error: errorMessage(err) });
+    log.error("files", "PUT content: write threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
     serverError(res, `Failed to write file: ${errorMessage(err)}`);
     return;
   }
-  const fresh = await statSafeAsync(absPath);
+  const fresh = await statSafeAsync(resolved.absPath);
   log.info("files", "PUT content: ok", {
-    pathPreview: previewSnippet(relPathRaw),
-    bytes: fresh?.size ?? Buffer.byteLength(contentRaw, "utf-8"),
+    pathPreview: previewSnippet(relPath),
+    bytes: fresh?.size ?? contentBytes,
   });
   res.json({
-    path: relPathRaw,
-    size: fresh?.size ?? Buffer.byteLength(contentRaw, "utf-8"),
+    path: relPath,
+    size: fresh?.size ?? contentBytes,
     modifiedMs: fresh?.mtimeMs ?? Date.now(),
   });
 });

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -708,18 +708,22 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
 
 type PutContentValidation =
   | { ok: true; relPath: string; content: string; bytes: number }
-  | { ok: false; logMsg: string; logExtra: Record<string, unknown>; message: string };
+  | { ok: false; logMsg: string; logExtra?: Record<string, unknown>; message: string };
 
 // Runtime-shape gate for PUT /api/files/content's body. Returns either
 // the narrowed inputs + their byte length (computed once and reused
 // downstream), or a structured rejection carrying the log message,
 // log extras, and the response message — so the caller can fan them
-// out into log.warn + badRequest without rebuilding context.
+// out into log.warn + badRequest without rebuilding context. `logExtra`
+// is optional so the missing-path branch can omit it: passing `{}` to
+// `log.warn` would emit `data: {}` (an observable change vs the
+// pre-refactor no-third-arg call); passing `undefined` skips the
+// `data` field entirely.
 function validatePutContentRequest(body: unknown): PutContentValidation {
   const obj = (body ?? {}) as { path?: unknown; content?: unknown };
   const { path: relPathRaw, content: contentRaw } = obj;
   if (typeof relPathRaw !== "string" || relPathRaw.length === 0) {
-    return { ok: false, logMsg: "PUT content: missing path", logExtra: {}, message: "path required" };
+    return { ok: false, logMsg: "PUT content: missing path", message: "path required" };
   }
   if (typeof contentRaw !== "string") {
     return {


### PR DESCRIPTION
## Summary

PUT `/api/files/content` ハンドラの async arrow が **complexity 22**(lint warning、max 15)だったのを 3 つの helper に分割。Pure refactor、logic 変更ゼロ。

これで残っていた 3 件の `complexity` warning すべて解消(#1012 で sessions.ts:122 = 20、#1014 で sessions.ts:266 = 17、本 PR で files.ts:713 = 22)。

## What changed

### 抽出した helper

- **`validatePutContentRequest(body): PutContentValidation`** — runtime-shape gate。narrow した input + computed byte length、または構造化 rejection(`logMsg` / `logExtra` / `message`)を返す。caller は分岐ごとに context を組み立て直さず、`log.warn(validation.logMsg, validation.logExtra)` + `badRequest(res, validation.message)` で fan-out できる。
- **`resolveExistingTextFile(relPath): ResolvedTextFile`** — 2 段階の path 解決(stat-syntactic + symlink-hardened resolveSafe)+ text-classify gate。`{ ok: true; absPath }` または `{ ok: false; status: 400 | 404; message }` を返す。なぜ 2 段階かは元コードの `resolveSafe` realpath の ENOENT が 400 / 404 を区別できなくする問題、そのまま継承。
- **`writeFileContent(absPath, content): Promise<void>`** — wiki vs generic dispatch。`workspaceReal` を realpath 化したまま `classifyAsWikiPage` に渡す note(symlink された workspace で wiki chokepoint を bypass しないため)も保持。

### caller の変化

```ts
// before: 80+ 行の async arrow に 9 段の早期 return が連なる
router.put(API_ROUTES.files.content, async (req, res) => {
  const { path: relPathRaw, content: contentRaw } = req.body ?? {};
  log.info(...);
  if (typeof relPathRaw !== "string" ...) { ... return; }
  if (typeof contentRaw !== "string") { ... return; }
  if (Buffer.byteLength(contentRaw) > MAX) { ... return; }
  // 2-step path resolution inline
  const candidate = path.resolve(...);
  const existing = await statSafeAsync(candidate);
  if (!existing) { ... return; }
  if (!existing.isFile()) { ... return; }
  const absPath = resolveSafe(...);
  if (!absPath) { ... return; }
  if (classify(absPath) !== "text") { ... return; }
  try {
    // wiki vs generic
  } catch { ... return; }
  // respond
});

// after: 1 直線の flow
router.put(API_ROUTES.files.content, async (req, res) => {
  const validation = validatePutContentRequest(req.body);
  if (!validation.ok) { log.warn(...); badRequest(...); return; }
  const { relPath, content, bytes: contentBytes } = validation;
  log.info("files", "PUT content: start", ...);

  const resolved = await resolveExistingTextFile(relPath);
  if (!resolved.ok) {
    if (resolved.status === 404) notFound(res, resolved.message);
    else badRequest(res, resolved.message);
    return;
  }
  try {
    await writeFileContent(resolved.absPath, content);
  } catch (err) { log.error(...); serverError(...); return; }

  const fresh = await statSafeAsync(resolved.absPath);
  log.info(...);
  res.json({...});
});
```

## Items to Confirm / Review

- [ ] **挙動不変性**:
  - 400(path required / content required / content exceeds limit / Path outside workspace / Not a file / File type not editable)と 404(File not found)の境界が同じ。特に `escapesSyntactically` の判定経路。
  - text classifier gate(`classify(absPath) !== "text"` → 400)を守ったまま wiki chokepoint(`classifyAsWikiPage` + `writeWikiPage`)へ届く順序。
  - `workspaceReal` realpath 化済 root を classifier に渡す注意点 note を維持。
- [ ] **log の観測可能な変化**:**`PUT content: start` の log が input validation の AFTER に移動**。malformed request では `log.warn` 1 本のみ(before は start + warn の 2 本)、valid request では before と同じく start + ok の 2 本。logs を読むときの差分がより clean になるが、観測性が必要なら戻せる。
- [ ] **PutContentValidation / ResolvedTextFile の discriminated union**:他の handler でも同じ pattern を使うなら共通 type にできる。今は files.ts ローカル。
- [ ] `contentBytes` を validation 内で 1 回計算 → 後段で再利用。before は `Buffer.byteLength(contentRaw, "utf-8")` を 3 回呼んでいた点も整理(同一値の重複計算回避、副次的改善)。

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint --no-cache` — **complexity warning 全消滅**(3 件 → 0 件)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [ ] e2e: PUT `/api/files/content` の各 status path(200 / 400 各種 / 404 / 500)が before と同じ contract を返す

## Refs

- 直前 PR: #1014(`parseSessionEntry` 抽出、complexity 17 解消、merged)
- その前: #1012(`loadSessionRow` / `buildSessionSummary` 抽出、complexity 20 解消、merged)
- 本 PR: complexity warning シリーズの **最後の 1 件**

🤖 Generated with [Claude Code](https://claude.com/claude-code)