### PR TITLE
chore(e2e-live): drop unused eslint-disable-next-line no-console

### DIFF
--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -106,11 +106,9 @@ async function performInPageSessionDelete(page: Page, url: string): Promise<void
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
       if (!response.ok) {
-        // eslint-disable-next-line no-console -- visible cleanup signal
         console.warn(`deleteSession: ${target} returned HTTP ${response.status}`);
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn(`deleteSession: network error for ${target}`, err);
     }
   }, url);


### PR DESCRIPTION
## Summary

- 2 unused `eslint-disable-next-line no-console` directives in `e2e-live/fixtures/live-chat.ts:109,113` were emitting `Unused eslint-disable directive` warnings.
- Root cause: the global ESLint config has `\"no-console\": \"off\"` (`eslint.config.mjs:254`), so these directives never had anything to suppress.
- Removed both directives; the `console.warn` calls themselves stay (they live inside `page.evaluate`, which runs in the browser — the server-side `log()` is not reachable; Playwright surfaces them via its `console` event).

## Items to Confirm / Review

- The two `console.warn` calls remain unchanged; only the comments were deleted. Diagnostic output from inside `page.evaluate` is unaffected.
- No new disables added (per project rule: `eslint-disable-next-line` is the last resort).

## User Prompt

> なんかふえた。。。これもたいおうして
> /Users/isamu/ss/llm/mulmoclaude/e2e-live/fixtures/live-chat.ts
>   109:9  warning  Unused eslint-disable directive (no problems were reported from 'no-console')
>   113:7  warning  Unused eslint-disable directive (no problems were reported from 'no-console')

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` — 0 warnings (was 2)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean