### PR TITLE
feat(prompt): allow raw HTML tags in .md files (Stage D / #1011)

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -45,6 +45,8 @@ When you write a \`.md\` or \`.html\` file that embeds images, follow this conve
 
 This applies to markdown image syntax (\`![alt](path)\`), HTML \`<img src="path">\`, and any other element that takes a path to an image (\`<source>\`, \`<video poster>\`, CSS \`url()\`).
 
+Raw HTML tags work inside \`.md\` files too — use them when markdown's \`![]()\` can't express what you need (e.g. \`<picture>\` + \`<source>\` for art-direction / responsive images, \`<video poster>\` for thumbnailed video, inline \`<img width>\` for size control). Same path rules apply: write a relative climb from the \`.md\` file to the asset, not an absolute or workspace-rooted path.
+
 ## Task Scheduling
 
 Skills and tasks can be scheduled via SKILL.md frontmatter (\`schedule: "daily HH:MM"\` or \`schedule: "interval Nh"\`). When the user asks to schedule something, recommend an appropriate frequency:

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -234,6 +234,10 @@ describe("buildSystemPrompt", () => {
     assert.match(result, /never use an \*\*absolute path\*\*/i);
     assert.match(result, /never use a workspace-rooted, no-leading-slash form/i);
     assert.match(result, /never write `\/api\/files\/raw\?path=\.\.\.` urls/i);
+    // Stage D (#1011): explicit OK to use raw HTML tags inside .md
+    // files when markdown's ![]() can't express what's needed
+    // (`<picture>`, `<video poster>`, `<img width>`). Same path rules.
+    assert.match(result, /raw html tags work inside `\.md` files/i);
   });
 
   it("contains today's date", () => {


### PR DESCRIPTION
## Summary

Stage D of the markdown / wiki image-coverage rollout (#1011). Tiny prompt-text change: tell the LLM that raw HTML tags are a legitimate choice inside \`.md\` files when markdown's \`![]()\` can't express what's needed.

Stage A (#1013) already taught the rewriter to handle raw \`<img>\` tokens inside markdown bodies. Without this prompt nudge, the LLM may keep falling back to \`![]()\` even when \`<picture>\` / \`<source>\` / \`<video poster>\` would be the right shape, leaving Stage A's coverage unused in practice.

## Items to Confirm / Review

- **Wording**: the new sentence sits right after the existing "This applies to markdown image syntax / HTML \`<img>\` / \`<source>\` / \`<video poster>\` / CSS \`url()\`" line, which already lists the targets. The addition is the explicit "yes, raw HTML inside .md is a fine choice — same path rules" permission, plus three example use cases (responsive images, video posters, inline width control).
- **Test pin**: extended \`test/agent/test_agent_prompt.ts\` with a regex assertion so a future refactor that drops the line trips a test failure rather than silently regressing.
- **Path rules**: deliberately re-state "same path rules apply" inline so the new bullet is self-contained — readers don't have to scroll up to remember the convention.

## User Prompt

> Dを

(Following on from Stage A merged in #1013; the user picked Stage D as the smallest next step in #1011 over Stage B / C.)

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn test\` — \`test/agent/test_agent_prompt.ts\` passes; new regex pin asserts the new sentence is present
- [ ] CI on the PR
- [ ] Manual: ask the agent under any wiki-capable role to write a wiki page that needs an art-directed image. Should now produce a \`<picture>\` / \`<source>\` block with relative paths, not a fallback to \`![]()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for raw HTML in Markdown files when standard syntax is insufficient, enabling responsive images, video thumbnails, and custom image sizing with consistent path conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->