### PR TITLE
feat(e2e-live): wiki image-coverage suite (#1011 Stage C)

### DIFF
--- a/.claude/skills/e2e-live-wiki/SKILL.md
+++ b/.claude/skills/e2e-live-wiki/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: e2e-live-wiki
+description: 実 mulmoclaude を叩く wiki カテゴリ (markdown image coverage) の総合テストを実行する。`yarn dev` が起動済みであることが前提。
+---
+
+## 前提
+
+- `yarn dev` を別ターミナルで起動済み(`http://localhost:5173` が応答する)
+- このカテゴリは LLM を呼ばない (wiki ページを直接ファイルとして seed → 標準ルートでレンダー → naturalWidth を assert) ので、Claude 認証は不要
+
+## 実行
+
+```bash
+yarn test:e2e:live:wiki
+```
+
+## デバッグ時
+
+```bash
+HEADED=1 yarn test:e2e:live:wiki
+```
+
+## カバーするシナリオ
+
+issue #1011 の Stage C 実装。`data/wiki/pages/<slug>.md` の本文に書ける各画像参照形式が、SPA の v-html サーフェス上で実際に decode されるか (`naturalWidth > 0`) を検証する。
+
+- **L-W-S-01**: 生 `<img src="../../../artifacts/images/...">`(Stage A — markdown rewriter が raw `<img>` を扱えるか)
+- **L-W-S-02**: 標準 markdown `![](url)`(常に動くべきパスのリグレッション)
+- **L-W-S-03**: `<picture><source><img></picture>`(Stage B 依存 — 現在は `test.fixme` でスキップ)
+- **L-W-S-04**: 壊れた prefix `<img src="/wrong/prefix/artifacts/images/...">` が `useGlobalImageErrorRepair` で復活するか
+- **L-W-S-05**: `data/wiki/sources/<file>` への相対参照
+
+## 結果の確認
+
+- レポート: `playwright-report-live/wiki/index.html`(カテゴリ専用サブディレクトリに出力)
+- トレース: `npx playwright show-trace test-results-live/wiki/<spec>/trace.zip`
+
+## 関連
+
+- Plan: [`plans/feat-markdown-image-coverage.md`](../../../plans/feat-markdown-image-coverage.md) §自動テスト(e2e-live)
+- Umbrella issue: [#1011](https://github.com/receptron/mulmoclaude/issues/1011)
+- L-W-S-03 を有効化するには Stage B (HTML 側 `rewriteHtmlImageRefs` を `<source>` / `<video poster>` 対応に拡張) が先に必要。

--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -3,7 +3,7 @@
 // install any API mocks — the real Claude API runs end-to-end. Use
 // these helpers from specs in `e2e-live/tests/`.
 
-import { copyFile, mkdir, readFile, rm } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -64,6 +64,75 @@ export async function placeFixtureInWorkspace(fixtureRel: string, workspaceRel: 
 /** Best-effort delete; never throws if the file is already gone. */
 export async function removeFromWorkspace(workspaceRel: string): Promise<void> {
   await rm(resolveWorkspacePath(workspaceRel), { force: true });
+}
+
+/**
+ * Drop a wiki page directly onto disk at `data/wiki/pages/<slug>.md`.
+ * The wiki view fetches /api/wiki?slug=<slug> on navigate, which
+ * reads the same file — so seeding the file is enough to make a page
+ * accessible via the standalone /wiki/pages/<slug> route. Spec-unique
+ * slugs only; do not stomp real user pages.
+ */
+export async function placeWikiPage(slug: string, body: string): Promise<void> {
+  const target = resolveWorkspacePath(`data/wiki/pages/${slug}.md`);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, body, "utf8");
+}
+
+export async function removeWikiPage(slug: string): Promise<void> {
+  await removeFromWorkspace(`data/wiki/pages/${slug}.md`);
+}
+
+const WIKI_PAGE_BODY_SELECTOR = '[data-testid="wiki-page-body"]';
+
+/**
+ * Open a wiki page directly via its standalone route. The SPA's wiki
+ * router fetches /api/wiki?slug=... and renders the page body into
+ * `[data-testid="wiki-page-body"]` (the v-html surface inside
+ * `WikiPageBody.vue`). Used as the entry point for L-W-S-* specs.
+ */
+export async function navigateToWikiPage(page: Page, slug: string): Promise<void> {
+  await page.goto(`/wiki/pages/${encodeURIComponent(slug)}`);
+}
+
+/**
+ * Wait for an `<img>` matching `imgSelector` to appear inside the
+ * rendered wiki page body. Counterpart to `waitForImgInPresentHtml`
+ * for the markdown surface — no iframe boundary, the body is a
+ * direct DOM child of the page.
+ */
+export async function waitForImgInWiki(page: Page, imgSelector: string, timeoutMs: number = ONE_MINUTE_MS): Promise<void> {
+  const body = page.locator(WIKI_PAGE_BODY_SELECTOR);
+  await expect(body.locator(imgSelector)).toBeVisible({ timeout: timeoutMs });
+}
+
+/**
+ * Read the unresolved `src` attribute of the first matching `<img>`
+ * in the wiki body. Lets the caller assert the rewriter produced the
+ * expected `/api/files/raw?path=...` path (or, for self-repair tests,
+ * the final repaired URL).
+ */
+export async function readImgSrcInWiki(page: Page, imgSelector: string): Promise<string | null> {
+  const body = page.locator(WIKI_PAGE_BODY_SELECTOR);
+  const img = body.locator(imgSelector).first();
+  if ((await img.count()) === 0) return null;
+  return await img.getAttribute("src");
+}
+
+/**
+ * Read `naturalWidth` / `naturalHeight` of the first matching `<img>`
+ * in the wiki body. Both 0 means the rewritten URL did not resolve to
+ * a decodable image — that's the failure mode every L-W-S-* spec
+ * guards against.
+ */
+export async function readImgNaturalSizeInWiki(page: Page, imgSelector: string): Promise<{ width: number; height: number } | null> {
+  const body = page.locator(WIKI_PAGE_BODY_SELECTOR);
+  const img = body.locator(imgSelector).first();
+  if ((await img.count()) === 0) return null;
+  return await img.evaluate((node) => {
+    if (!(node instanceof HTMLImageElement)) return { width: 0, height: 0 };
+    return { width: node.naturalWidth, height: node.naturalHeight };
+  });
 }
 
 /**

--- a/e2e-live/tests/wiki.spec.ts
+++ b/e2e-live/tests/wiki.spec.ts
@@ -1,0 +1,126 @@
+import { type Page, expect, test } from "@playwright/test";
+
+import { ONE_MINUTE_MS } from "../../server/utils/time.ts";
+import {
+  navigateToWikiPage,
+  placeFixtureInWorkspace,
+  placeWikiPage,
+  readImgNaturalSizeInWiki,
+  readImgSrcInWiki,
+  removeFromWorkspace,
+  removeWikiPage,
+  waitForImgInWiki,
+} from "../fixtures/live-chat.ts";
+
+// Wiki tests are read-only against the LLM (the page body is seeded
+// directly to disk and the SPA renders it via the standard wiki
+// route), so they do not actually call Claude. They live in
+// `e2e-live/` because they verify the end-to-end image-path pipeline
+// against a live mulmoclaude server, exactly the surface the
+// markdown-image-coverage umbrella issue (#1011) targets.
+
+const SPEC_TIMEOUT_MS = ONE_MINUTE_MS;
+
+// Each scenario seeds its own slug + image, so they don't share
+// state. Run in parallel to cut wall time — same justification as
+// `media.spec.ts`.
+test.describe.configure({ mode: "parallel" });
+
+test.describe("wiki image coverage (real workspace)", () => {
+  test("L-W-S-01: raw <img src='../../../artifacts/images/...'> renders (Stage A — markdown rewriter handles raw <img>)", async ({ page }) => {
+    test.setTimeout(SPEC_TIMEOUT_MS);
+    const slug = "e2e-live-l-w-s-01";
+    const workspaceImageRel = "artifacts/images/e2e-live-l-w-s-01.png";
+    await placeFixtureInWorkspace("images/sample.png", workspaceImageRel);
+    await placeWikiPage(slug, ["# L-W-S-01", "", '<img src="../../../artifacts/images/e2e-live-l-w-s-01.png" alt="raw" />', ""].join("\n"));
+    try {
+      await navigateToWikiPage(page, slug);
+      await waitForImgInWiki(page, 'img[alt="raw"]');
+      await assertImgDecodes(page, 'img[alt="raw"]');
+    } finally {
+      await removeWikiPage(slug);
+      await removeFromWorkspace(workspaceImageRel);
+    }
+  });
+
+  test("L-W-S-02: markdown image ![](url) renders (regression on the always-supported path)", async ({ page }) => {
+    test.setTimeout(SPEC_TIMEOUT_MS);
+    const slug = "e2e-live-l-w-s-02";
+    const workspaceImageRel = "artifacts/images/e2e-live-l-w-s-02.png";
+    await placeFixtureInWorkspace("images/sample.png", workspaceImageRel);
+    await placeWikiPage(slug, ["# L-W-S-02", "", "![md](../../../artifacts/images/e2e-live-l-w-s-02.png)", ""].join("\n"));
+    try {
+      await navigateToWikiPage(page, slug);
+      await waitForImgInWiki(page, 'img[alt="md"]');
+      await assertImgDecodes(page, 'img[alt="md"]');
+    } finally {
+      await removeWikiPage(slug);
+      await removeFromWorkspace(workspaceImageRel);
+    }
+  });
+
+  // L-W-S-03 (`<picture><source>...<img></picture>`) depends on
+  // Stage B widening the rewriter to `<source>` / `<video poster>`.
+  // Until that lands, the inner `<img>` does get rewritten by
+  // Stage A but the `<source srcset>` siblings would 404. Skipped
+  // on purpose so it stays visible in the report as a pending item.
+  test.skip("L-W-S-03: <picture><source><img></picture> renders (depends on Stage B / #1011)", async () => {});
+
+  test("L-W-S-04: broken-prefix <img> is repaired by useGlobalImageErrorRepair", async ({ page }) => {
+    test.setTimeout(SPEC_TIMEOUT_MS);
+    const slug = "e2e-live-l-w-s-04";
+    const filename = "e2e-live-l-w-s-04.png";
+    const workspaceImageRel = `artifacts/images/${filename}`;
+    await placeFixtureInWorkspace("images/sample.png", workspaceImageRel);
+    // Wrong prefix — only the trailing `artifacts/images/<file>`
+    // segment matches the repair pattern. Self-repair must rewrite
+    // the src to `/${match}` so the static mount serves it.
+    await placeWikiPage(slug, ["# L-W-S-04", "", `<img src="/wrong/prefix/artifacts/images/${filename}" alt="repair" />`, ""].join("\n"));
+    try {
+      await navigateToWikiPage(page, slug);
+      await waitForImgInWiki(page, 'img[alt="repair"]');
+      // After repair, the resolved src must contain the artifacts
+      // path. The unresolved attribute may still read the original
+      // wrong-prefix string until the repair fires; assert via
+      // naturalWidth instead, which is the actual end-to-end signal.
+      await assertImgDecodes(page, 'img[alt="repair"]');
+      const repairedSrc = await readImgSrcInWiki(page, 'img[alt="repair"]');
+      expect(repairedSrc, "self-repair must point the src at /artifacts/...").toContain(`artifacts/images/${filename}`);
+    } finally {
+      await removeWikiPage(slug);
+      await removeFromWorkspace(workspaceImageRel);
+    }
+  });
+
+  test("L-W-S-05: relative reference under data/wiki/sources/ renders", async ({ page }) => {
+    test.setTimeout(SPEC_TIMEOUT_MS);
+    const slug = "e2e-live-l-w-s-05";
+    const filename = "e2e-live-l-w-s-05.png";
+    const workspaceImageRel = `data/wiki/sources/${filename}`;
+    await placeFixtureInWorkspace("images/sample.png", workspaceImageRel);
+    // Relative path from `data/wiki/pages/<slug>.md` up to `sources/`.
+    await placeWikiPage(slug, ["# L-W-S-05", "", `![local](../sources/${filename})`, ""].join("\n"));
+    try {
+      await navigateToWikiPage(page, slug);
+      await waitForImgInWiki(page, 'img[alt="local"]');
+      await assertImgDecodes(page, 'img[alt="local"]');
+    } finally {
+      await removeWikiPage(slug);
+      await removeFromWorkspace(workspaceImageRel);
+    }
+  });
+});
+
+/**
+ * Wait for the image to load and assert it has non-zero natural
+ * dimensions. `naturalWidth = 0` is the canonical "broken image"
+ * signal — survives 404s, blocked sandboxes, and decode failures.
+ */
+async function assertImgDecodes(page: Page, imgSelector: string): Promise<void> {
+  const size = await readImgNaturalSizeInWiki(page, imgSelector);
+  if (size === null) {
+    throw new Error(`expected an <img> matching ${imgSelector} inside the wiki body`);
+  }
+  expect(size.width, `${imgSelector} must actually decode (naturalWidth > 0)`).toBeGreaterThan(0);
+  expect(size.height).toBeGreaterThan(0);
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:live": "playwright test --config e2e-live/playwright.config.ts",
     "test:e2e:live:media": "cross-env E2E_LIVE_REPORT_SUBDIR=media playwright test --config e2e-live/playwright.config.ts media.spec.ts",
+    "test:e2e:live:wiki": "cross-env E2E_LIVE_REPORT_SUBDIR=wiki playwright test --config e2e-live/playwright.config.ts wiki.spec.ts",
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts && yarn workspaces run test",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",

--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -- marked.parse output of app-owned wiki page body; trusted in-process render -->
-  <div ref="rootRef" class="px-6 py-4 prose prose-sm max-w-none wiki-content" @click="onClick" v-html="renderedHtml" />
+  <div ref="rootRef" data-testid="wiki-page-body" class="px-6 py-4 prose prose-sm max-w-none wiki-content" @click="onClick" v-html="renderedHtml" />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

Stage C of umbrella #1011. Adds the \`e2e-live/tests/wiki.spec.ts\` suite that seeds wiki pages + fixture images directly in the workspace and asserts each variant of the in-page image syntax decodes (\`naturalWidth > 0\`) when the SPA renders the page through the standard wiki route.

5 tests as specified in [\`plans/feat-markdown-image-coverage.md\`](https://github.com/receptron/mulmoclaude/blob/main/plans/feat-markdown-image-coverage.md#%E8%87%AA%E5%8B%95%E3%83%86%E3%82%B9%E3%83%88e2e-live):

| ID | Surface | Status |
|---|---|---|
| L-W-S-01 | raw \`<img src="../../../artifacts/images/...">\` (Stage A path) | active |
| L-W-S-02 | markdown \`![]()\` (regression guard on the always-supported path) | active |
| L-W-S-03 | \`<picture><source><img></picture>\` | **skipped** — needs Stage B |
| L-W-S-04 | broken-prefix \`<img>\` repaired by \`useGlobalImageErrorRepair\` | active |
| L-W-S-05 | relative ref under \`data/wiki/sources/\` | active |

## Items to Confirm / Review

- **No LLM calls.** Each spec seeds the page body directly via \`placeWikiPage(slug, body)\`; the SPA fetches the seeded file through the regular \`/api/wiki?slug=\` route, so the \`rewriteMarkdownImageRefs\` → \`renderWikiPageHtml\` → \`v-html\` pipeline runs exactly as it does for a real LLM-generated page. Lets the wiki suite run without burning subscription budget.
- **Seeded paths are workspace-rooted.** Wiki page lives at \`data/wiki/pages/<slug>.md\`; \`../../../artifacts/...\` traverses 3 levels up to the workspace root, which is what the rewriter resolves against (verified in \`rewriteMarkdownImageRefs.ts:resolveWorkspacePath\`).
- **L-W-S-03 is intentionally \`test.skip\`** with a comment pointing at Stage B — the inner \`<img>\` would actually pass today (Stage A rewrites it), but the sibling \`<source srcset>\` would 404 and depending on the browser's source/img preference the assertion could be flaky. Re-enable when the rewriter widens to \`<source>\`.
- **\`data-testid="wiki-page-body"\`** added to \`WikiPageBody.vue\` so the helpers can target the rendered surface stably. The \`.wiki-content\` class would have worked too but classes are styling-coupled and easier to rename in a future Tailwind cleanup.
- **Cleanup is finally-block scoped** so a flaky run still removes its seeded files and doesn't pollute \`data/wiki/pages/\` for the next user.
- L-W-PE-01 / L-W-PE-02 (page-edit auto-render via real LLM Write/Edit) from the plan §自動テスト are intentionally NOT in this PR — Stage C scope per the umbrella issue is L-W-01〜L-W-05. Those LLM-driven specs can land separately under a different category.

## Verification

- \`yarn lint\` → 0 errors, 2 unrelated warnings (pre-existing eslint-disable directives)
- \`yarn typecheck\` → ✓
- \`yarn build\` → ✓
- \`npx playwright test --config e2e-live/playwright.config.ts wiki.spec.ts --list\` → 5 tests listed (4 active + 1 skipped)
- Live run not executed in this PR — needs \`yarn dev\` running and is invoked by the new \`/e2e-live-wiki\` skill or directly with \`yarn test:e2e:live:wiki\`

## How to run locally

```bash
yarn dev                     # in another terminal
yarn test:e2e:live:wiki      # or via the /e2e-live-wiki skill
```

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1011 stage Cできる？