### PR TITLE
feat(self-repair): extend useGlobalImageErrorRepair to <source> (#1011 Stage E narrow)

### DIFF
--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -74,6 +74,9 @@ document.addEventListener("error", function (event) {
     }
   } else if (target.tagName === "SOURCE") {
     fixSource(target);
+  } else if (target.tagName === "AUDIO" || target.tagName === "VIDEO") {
+    var mediaSources = target.querySelectorAll(":scope > source");
+    for (var j = 0; j < mediaSources.length; j++) fixSource(mediaSources[j]);
   }
 }, true);
 `.trim();
@@ -124,13 +127,13 @@ export function repairSourceSrc(source: HTMLSourceElement): boolean {
   return repaired;
 }
 
-// Attach a document-level capture-phase error listener so any <img>
-// or <source> 404 in the app shell (wiki / markdown / news / Files
-// preview etc) gets one repair attempt. Capture phase is required
-// because img/source error events don't bubble. The repair is a
-// no-op for src values that don't match the artifacts/images
-// pattern, so attaching at document scope is safe — it never
-// touches non-image-bearing UI.
+// Attach a document-level capture-phase error listener so any
+// `<img>` / `<source>` / `<audio>` / `<video>` 404 in the app
+// shell (wiki / markdown / news / Files preview etc) gets one
+// repair attempt. Capture phase is required because the relevant
+// error events don't bubble. The repair is a no-op for src values
+// that don't match the artifacts/images pattern, so attaching at
+// document scope is safe — it never touches non-image-bearing UI.
 export function useGlobalImageErrorRepair(): void {
   function onError(event: Event): void {
     const { target } = event;
@@ -148,6 +151,14 @@ export function useGlobalImageErrorRepair(): void {
       }
     } else if (target instanceof HTMLSourceElement) {
       repairSourceSrc(target);
+    } else if (target instanceof HTMLMediaElement) {
+      // `<audio>` / `<video>` fire `error` on themselves when ALL
+      // their `<source>` children fail. The source elements never
+      // get a target of their own in that path, so reach into
+      // each child and repair it.
+      for (const src of target.querySelectorAll<HTMLSourceElement>(":scope > source")) {
+        repairSourceSrc(src);
+      }
     }
   }
 

--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -11,21 +11,70 @@ import { onMounted, onBeforeUnmount } from "vue";
 // Stage 3 of the image-path-routing redesign — see
 // plans/feat-image-path-routing.md and
 // docs/discussion-image-path-routing.md.
+//
+// Stage E (umbrella #1011) extends the same self-repair to <source>
+// elements (used by <picture> / <audio> / <video>) so wrong-prefix
+// `srcset` / `src` attributes get the same one-shot rewrite.
 export const IMAGE_REPAIR_PATTERN = /artifacts\/images\/.+/;
 
-// Inline script body that the presentHtml plugin injects into its
-// iframe srcdoc. Same logic as `repairImageSrc` below; kept as a
-// string so it can be embedded into the rendered HTML and run in the
-// sandboxed iframe. Update both together if the repair rule changes.
+// Whitespace- and comma-bounded URL token inside a `srcset` value.
+// `srcset` is a comma-list of `<url> [descriptor]` entries; the
+// regex picks each non-whitespace, non-comma run so the descriptor
+// (`1x`, `2x`, `100w`, …) survives the repair pass untouched.
+const SRCSET_TOKEN_RE = /[^\s,]+/g;
+
+// Inline script body intended for iframe surfaces (presentHtml,
+// Files HTML preview, …). Same decision tree as
+// `useGlobalImageErrorRepair` below; kept as a string so it can be
+// embedded into the rendered HTML and run inside the iframe. The
+// regex literal is interpolated from `IMAGE_REPAIR_PATTERN` so the
+// two stay in lock step automatically.
+//
+// **Currently not wired up.** When presentHtml moved off `srcdoc`
+// onto `/artifacts/html` static mounts, the original injection
+// site disappeared. Re-wiring is tracked in #1025. Until that
+// lands, only the document-scope handler from
+// `useGlobalImageErrorRepair` is active in the app shell.
 export const IMAGE_REPAIR_INLINE_SCRIPT = `
 document.addEventListener("error", function (event) {
   var target = event.target;
-  if (!target || target.tagName !== "IMG") return;
-  if (target.dataset.imageRepairTried) return;
-  var match = String(target.src).match(/artifacts\\/images\\/.+/);
-  if (!match) return;
-  target.dataset.imageRepairTried = "1";
-  target.src = "/" + match[0];
+  if (!target) return;
+  var pattern = ${IMAGE_REPAIR_PATTERN.toString()};
+  function fixImg(img) {
+    if (img.dataset.imageRepairTried) return;
+    var m = String(img.src).match(pattern);
+    if (!m) return;
+    img.dataset.imageRepairTried = "1";
+    img.src = "/" + m[0];
+  }
+  function fixSource(src) {
+    if (src.dataset.imageRepairTried) return;
+    var changed = false;
+    var srcAttr = src.getAttribute("src");
+    if (srcAttr) {
+      var m = srcAttr.match(pattern);
+      if (m) { src.setAttribute("src", "/" + m[0]); changed = true; }
+    }
+    if (src.srcset) {
+      var orig = src.srcset;
+      var next = orig.replace(/[^\\s,]+/g, function (tok) {
+        var mm = tok.match(pattern);
+        return mm ? "/" + mm[0] : tok;
+      });
+      if (next !== orig) { src.srcset = next; changed = true; }
+    }
+    if (changed) src.dataset.imageRepairTried = "1";
+  }
+  if (target.tagName === "IMG") {
+    fixImg(target);
+    var pic = target.closest && target.closest("picture");
+    if (pic) {
+      var sources = pic.querySelectorAll("source");
+      for (var i = 0; i < sources.length; i++) fixSource(sources[i]);
+    }
+  } else if (target.tagName === "SOURCE") {
+    fixSource(target);
+  }
 }, true);
 `.trim();
 
@@ -43,16 +92,63 @@ export function repairImageSrc(img: HTMLImageElement): boolean {
   return true;
 }
 
+// Repair a `<source>` element used inside `<picture>` / `<audio>` /
+// `<video>`. Handles both shapes:
+//   - `srcset="..."` (the picture form, often comma-list with size
+//     descriptors)
+//   - `src="..."` (the audio/video form, single URL)
+// One-shot via the same `imageRepairTried` marker as <img>.
+export function repairSourceSrc(source: HTMLSourceElement): boolean {
+  if (source.dataset.imageRepairTried) return false;
+  let repaired = false;
+  const src = source.getAttribute("src");
+  if (src) {
+    const match = src.match(IMAGE_REPAIR_PATTERN);
+    if (match) {
+      source.setAttribute("src", `/${match[0]}`);
+      repaired = true;
+    }
+  }
+  if (source.srcset) {
+    const original = source.srcset;
+    const next = original.replace(SRCSET_TOKEN_RE, (token) => {
+      const tokenMatch = token.match(IMAGE_REPAIR_PATTERN);
+      return tokenMatch ? `/${tokenMatch[0]}` : token;
+    });
+    if (next !== original) {
+      source.srcset = next;
+      repaired = true;
+    }
+  }
+  if (repaired) source.dataset.imageRepairTried = "1";
+  return repaired;
+}
+
 // Attach a document-level capture-phase error listener so any <img>
-// 404 in the app shell (wiki / markdown / news / Files preview etc)
-// gets one repair attempt. Capture phase is required because <img>
-// error events don't bubble. The repair is a no-op for src values
-// that don't match the artifacts/images pattern, so attaching at
-// document scope is safe — it never touches non-image-bearing UI.
+// or <source> 404 in the app shell (wiki / markdown / news / Files
+// preview etc) gets one repair attempt. Capture phase is required
+// because img/source error events don't bubble. The repair is a
+// no-op for src values that don't match the artifacts/images
+// pattern, so attaching at document scope is safe — it never
+// touches non-image-bearing UI.
 export function useGlobalImageErrorRepair(): void {
   function onError(event: Event): void {
     const { target } = event;
-    if (target instanceof HTMLImageElement) repairImageSrc(target);
+    if (target instanceof HTMLImageElement) {
+      repairImageSrc(target);
+      // Source-element error events don't fire reliably in Chromium
+      // when a `<picture><source>` srcset 404s — only the inner
+      // `<img>` reaches a target. Walk siblings so a wrong-prefix
+      // `<source>` next to a repairable `<img>` gets the same fix.
+      const picture = target.closest("picture");
+      if (picture) {
+        for (const src of picture.querySelectorAll("source")) {
+          repairSourceSrc(src);
+        }
+      }
+    } else if (target instanceof HTMLSourceElement) {
+      repairSourceSrc(target);
+    }
   }
 
   onMounted(() => {

--- a/test/composables/test_useImageErrorRepair.ts
+++ b/test/composables/test_useImageErrorRepair.ts
@@ -159,14 +159,21 @@ describe("repairSourceSrc", () => {
 });
 
 describe("IMAGE_REPAIR_INLINE_SCRIPT — Stage E parity", () => {
-  it("references both <IMG> and <SOURCE> tag handlers", () => {
+  it("references all four tag-name branches the document listener handles", () => {
     // Drift guard: the iframe-inlined script must match the TS
     // dispatcher in `useGlobalImageErrorRepair`. If the TS gains a
-    // new branch, the inline must too — otherwise presentHtml's
-    // self-repair silently regresses for that surface.
+    // new branch, the inline must too — otherwise iframe surfaces
+    // (presentHtml etc) silently regress for that case.
     assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "IMG"/);
     assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "SOURCE"/);
+    // <audio>/<video> propagate child-source errors up to themselves.
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "AUDIO"/);
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "VIDEO"/);
     // The picture-sibling walk must also be in lock step.
     assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /closest\("picture"\)/);
+    // The audio/video child walk uses `:scope > source` to avoid
+    // grabbing the inner <picture><source> case (which is already
+    // handled by the IMG branch via `closest("picture")`).
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /:scope > source/);
   });
 });

--- a/test/composables/test_useImageErrorRepair.ts
+++ b/test/composables/test_useImageErrorRepair.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { repairImageSrc, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_INLINE_SCRIPT } from "../../src/composables/useImageErrorRepair.js";
+import { repairImageSrc, repairSourceSrc, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_INLINE_SCRIPT } from "../../src/composables/useImageErrorRepair.js";
 
 // A tiny stand-in for HTMLImageElement — only the attributes the
 // repair function reads/writes. Lets us exercise the pure function
@@ -63,10 +63,110 @@ describe("repairImageSrc", () => {
     assert.equal(img.src, "/still/wrong/artifacts/images/foo.png");
   });
 
-  it("matches the inline script's regex literally", () => {
-    // Both the TS function and the iframe-inlined script use the same
-    // pattern. Drift would silently break presentHtml's repair.
-    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /artifacts\\\/images\\\/\.\+/);
+  it("interpolates the same regex literal into the inline script", () => {
+    // The inline script must reference the literal form of
+    // `IMAGE_REPAIR_PATTERN` — not a hand-typed copy. If someone
+    // edits the regex on the TS side and forgets the script string,
+    // this test catches the drift via substring presence.
     assert.equal(IMAGE_REPAIR_PATTERN.source, "artifacts\\/images\\/.+");
+    assert.ok(IMAGE_REPAIR_INLINE_SCRIPT.includes(IMAGE_REPAIR_PATTERN.toString()), "inline script must embed `IMAGE_REPAIR_PATTERN.toString()` verbatim");
+  });
+});
+
+// Stand-in for HTMLSourceElement covering only what `repairSourceSrc`
+// reads/writes. `getAttribute` / `setAttribute` mock keeps the test
+// in the same plain-JS shape as the <img> stand-in above.
+interface FakeSource {
+  srcset?: string;
+  attrs: Record<string, string>;
+  dataset: { imageRepairTried?: string };
+  getAttribute: (name: string) => string | null;
+  setAttribute: (name: string, value: string) => void;
+}
+
+function makeSource(opts: { srcset?: string; src?: string } = {}): FakeSource {
+  const attrs: Record<string, string> = {};
+  if (opts.src !== undefined) attrs.src = opts.src;
+  return {
+    srcset: opts.srcset,
+    attrs,
+    dataset: {},
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+    },
+    setAttribute(name, value) {
+      attrs[name] = value;
+    },
+  };
+}
+
+describe("repairSourceSrc", () => {
+  it("rewrites a wrong-prefix `src` attribute (audio/video <source> shape)", () => {
+    const source = makeSource({ src: "/wrong/prefix/artifacts/images/foo.png" });
+    const ok = repairSourceSrc(source as unknown as HTMLSourceElement);
+    assert.equal(ok, true);
+    assert.equal(source.attrs.src, "/artifacts/images/foo.png");
+    assert.equal(source.dataset.imageRepairTried, "1");
+  });
+
+  it("rewrites a wrong-prefix `srcset` attribute (picture <source> shape)", () => {
+    const source = makeSource({ srcset: "../../../artifacts/images/foo.png" });
+    const ok = repairSourceSrc(source as unknown as HTMLSourceElement);
+    assert.equal(ok, true);
+    assert.equal(source.srcset, "/artifacts/images/foo.png");
+  });
+
+  it("preserves srcset descriptors while repairing each URL token", () => {
+    const source = makeSource({ srcset: "../wrong/artifacts/images/foo.png 1x, ../wrong/artifacts/images/foo@2x.png 2x" });
+    const ok = repairSourceSrc(source as unknown as HTMLSourceElement);
+    assert.equal(ok, true);
+    assert.equal(source.srcset, "/artifacts/images/foo.png 1x, /artifacts/images/foo@2x.png 2x");
+  });
+
+  it("leaves a `srcset` token that does not match the pattern alone", () => {
+    const source = makeSource({ srcset: "https://external.example.com/foo.png 1x" });
+    const ok = repairSourceSrc(source as unknown as HTMLSourceElement);
+    assert.equal(ok, false);
+    assert.equal(source.srcset, "https://external.example.com/foo.png 1x");
+    // No marker on a no-match — same invariant as repairImageSrc.
+    assert.equal(source.dataset.imageRepairTried, undefined);
+  });
+
+  it("repairs both `src` and `srcset` in one call when both match", () => {
+    const source = makeSource({
+      src: "/wrong/prefix/artifacts/images/poster.png",
+      srcset: "../wrong/artifacts/images/foo.png 1x",
+    });
+    const ok = repairSourceSrc(source as unknown as HTMLSourceElement);
+    assert.equal(ok, true);
+    assert.equal(source.attrs.src, "/artifacts/images/poster.png");
+    assert.equal(source.srcset, "/artifacts/images/foo.png 1x");
+  });
+
+  it("does not retry once tried", () => {
+    const source = makeSource({ srcset: "/wrong/artifacts/images/foo.png" });
+    assert.equal(repairSourceSrc(source as unknown as HTMLSourceElement), true);
+    source.srcset = "/still/wrong/artifacts/images/foo.png";
+    assert.equal(repairSourceSrc(source as unknown as HTMLSourceElement), false);
+    assert.equal(source.srcset, "/still/wrong/artifacts/images/foo.png");
+  });
+
+  it("treats a missing src and missing srcset as a no-op", () => {
+    const source = makeSource();
+    assert.equal(repairSourceSrc(source as unknown as HTMLSourceElement), false);
+    assert.equal(source.dataset.imageRepairTried, undefined);
+  });
+});
+
+describe("IMAGE_REPAIR_INLINE_SCRIPT — Stage E parity", () => {
+  it("references both <IMG> and <SOURCE> tag handlers", () => {
+    // Drift guard: the iframe-inlined script must match the TS
+    // dispatcher in `useGlobalImageErrorRepair`. If the TS gains a
+    // new branch, the inline must too — otherwise presentHtml's
+    // self-repair silently regresses for that surface.
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "IMG"/);
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /tagName === "SOURCE"/);
+    // The picture-sibling walk must also be in lock step.
+    assert.match(IMAGE_REPAIR_INLINE_SCRIPT, /closest\("picture"\)/);
   });
 });


### PR DESCRIPTION
## Summary

Stage E (narrow) of umbrella #1011. Extends \`useGlobalImageErrorRepair\` so a wrong-prefix \`<source>\` element gets the same one-shot \`/artifacts/images/...\` repair that \`<img>\` already enjoys, in both the standalone-element and \`<picture>\`-child shapes.

The iframe-injection wiring of \`IMAGE_REPAIR_INLINE_SCRIPT\` (currently dead code since PR #980's static-mount migration) is split into a follow-up: **#1025**.

## Items to Confirm / Review

### Coverage

| Trigger | Path |
|---|---|
| \`<img>\` 404 with no \`<picture>\` parent | repair the \`<img>\` (existing behaviour) |
| \`<img>\` 404 inside \`<picture>\` | repair the \`<img>\` AND walk sibling \`<source>\` elements |
| \`<source>\` 404 fires on \`<source>\` directly (audio/video shape) | repair via \`repairSourceSrc\` |
| \`<picture><source srcset>\` 404 — Chromium fires error on the inner \`<img>\` only | reached via the picture-sibling walk above |
| \`<video poster>\` 404 | **not in scope** — error events for posters are unreliable, deferred |

### DRY between document handler and inline script

- The regex literal flows from a single source: \`IMAGE_REPAIR_INLINE_SCRIPT\` interpolates \`IMAGE_REPAIR_PATTERN.toString()\` instead of hand-escaping. Drift between the two now requires actively breaking the parity test.
- The dispatch tree (IMG vs SOURCE vs picture-walk) is mirrored manually and tested via substring assertions. Real runtime sharing isn't possible because the inline script must be self-contained for an iframe context.
- Comment block on \`IMAGE_REPAIR_INLINE_SCRIPT\` clarifies that it's currently not wired up and points at #1025 for the wire-up.

### Tests

\`test/composables/test_useImageErrorRepair.ts\` gains:

- 7 unit tests for \`repairSourceSrc\` covering the \`src\` shape, the \`srcset\` shape (single + multi-token with descriptors), the no-match invariant, the no-double-retry invariant, and the missing-both-attributes no-op.
- 1 Stage-E parity guard for \`IMAGE_REPAIR_INLINE_SCRIPT\` (must reference both \`tagName === "IMG"\` and \`tagName === "SOURCE"\`, must walk \`closest("picture")\`).
- Existing 6 tests still pass; the regex-parity test was rewritten to assert the inline script embeds \`IMAGE_REPAIR_PATTERN.toString()\` verbatim instead of grepping for a hand-escaped form.

14/14 tests passing.

### Why narrow

The plan §Stage E note flagged two distinct workstreams: (1) extend the runtime logic, (2) wire up iframe injection. (1) is verifiable in unit tests, (2) is a server-middleware change touching response streaming. Bundling them would force iframe e2e verification into this PR's review surface unnecessarily. #1025 carries (2).

## Verification

- \`yarn lint\` → 0 errors, no new warnings
- \`yarn typecheck\` → ✓
- \`yarn build\` → ✓
- \`npx tsx --test test/composables/test_useImageErrorRepair.ts\` → 14/14 passing

## User Prompt

> Eもあるのか！対応して。
>
> はい、Cの方針で。なのでissueはたてて、コマ間いまのを進めて。