### PR TITLE
feat(e2e-live): guard L-01 against self-repair masking LLM regression

### DIFF
--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -204,6 +204,27 @@ export async function readImgNaturalSize(page: Page, imgSelector: string): Promi
   });
 }
 
+/**
+ * Detect whether the in-iframe onerror self-repair (PR #974) fired
+ * on an `<img>`. The repair script tags the element with
+ * `data-image-repair-tried="1"` before rewriting `src` to
+ * `/artifacts/images/<rest>`, so the marker's presence after the
+ * image has loaded is a direct signal that the original LLM-emitted
+ * src was broken and the browser silently rescued it.
+ *
+ * Without this check, an LLM regression that emits a path containing
+ * the `artifacts/images/` segment behind a wrong prefix would still
+ * pass `naturalWidth > 0` because self-repair masks the 404. Reading
+ * the marker preserves the suite's ability to catch convention drift.
+ */
+export async function readImgRepairAttempted(page: Page, imgSelector: string): Promise<boolean | null> {
+  const frame = page.frameLocator(PRESENT_HTML_IFRAME_SELECTOR).first();
+  const img = frame.locator(imgSelector).first();
+  if ((await img.count()) === 0) return null;
+  const marker = await img.getAttribute("data-image-repair-tried");
+  return marker !== null;
+}
+
 const PDF_MAGIC = Buffer.from("%PDF-", "ascii");
 const PDF_EOF = Buffer.from("%%EOF", "ascii");
 // PDF spec writes %%EOF in the last few hundred bytes; widen to

--- a/e2e-live/tests/media.spec.ts
+++ b/e2e-live/tests/media.spec.ts
@@ -6,6 +6,7 @@ import {
   getCurrentSessionId,
   placeFixtureInWorkspace,
   readImgNaturalSize,
+  readImgRepairAttempted,
   readImgSrcInPresentHtml,
   readPdfDownload,
   removeFromWorkspace,
@@ -112,6 +113,13 @@ async function assertL01PresentHtml(page: Page): Promise<void> {
   }
   expect(size.width, "image must actually decode (B-18 regression)").toBeGreaterThan(0);
   expect(size.height).toBeGreaterThan(0);
+  // PR #974's onerror self-repair would otherwise mask an LLM
+  // regression that embeds `artifacts/images/...` behind a wrong
+  // prefix — the browser rewrites the src to `/artifacts/images/<rest>`,
+  // the image loads, naturalWidth > 0, and the convention drift goes
+  // unnoticed. The repair script tags the element on activation.
+  const repaired = await readImgRepairAttempted(page, L01_IMG_LOCATOR);
+  expect(repaired, "self-repair must not fire — LLM regressed from the relative-path convention").toBe(false);
 }
 
 async function sendL02Prompt(page: Page, workspaceImageRel: string): Promise<void> {

--- a/e2e-live/tests/media.spec.ts
+++ b/e2e-live/tests/media.spec.ts
@@ -113,11 +113,18 @@ async function assertL01PresentHtml(page: Page): Promise<void> {
   }
   expect(size.width, "image must actually decode (B-18 regression)").toBeGreaterThan(0);
   expect(size.height).toBeGreaterThan(0);
-  // PR #974's onerror self-repair would otherwise mask an LLM
-  // regression that embeds `artifacts/images/...` behind a wrong
-  // prefix — the browser rewrites the src to `/artifacts/images/<rest>`,
-  // the image loads, naturalWidth > 0, and the convention drift goes
-  // unnoticed. The repair script tags the element on activation.
+  await assertL01NoSelfRepair(page);
+}
+
+/**
+ * PR #974's onerror self-repair would otherwise mask an LLM
+ * regression that embeds `artifacts/images/...` behind a wrong
+ * prefix — the browser rewrites the src to `/artifacts/images/<rest>`,
+ * the image loads, naturalWidth > 0, and the convention drift goes
+ * unnoticed. The repair script tags the element on activation, so
+ * an unset marker means the original src was already correct.
+ */
+async function assertL01NoSelfRepair(page: Page): Promise<void> {
   const repaired = await readImgRepairAttempted(page, L01_IMG_LOCATOR);
   expect(repaired, "self-repair must not fire — LLM regressed from the relative-path convention").toBe(false);
 }

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -334,7 +334,7 @@ e2e-live/
 
 | シナリオ | 状態 | 備考 |
 |---|---|---|
-| **L-01** presentHtml 画像描画 | ✅ 実装済 | media.spec.ts、fixture 画像を workspace に配置 → naturalWidth > 0 |
+| **L-01** presentHtml 画像描画 | ✅ 実装済 | media.spec.ts、fixture 画像を workspace に配置 → naturalWidth > 0、self-repair guard (readImgRepairAttempted) 追加済 |
 | **L-02** PDF DL | ✅ 実装済 | media.spec.ts、textResponse の PDF ボタン経由 |
 | L-03〜L-30 | 未実装 | カテゴリごとの後続 PR で順次 |
 
@@ -400,6 +400,7 @@ L-01 の検証ポイント:
 - `src` 属性が `e2e-live-l01.png` を含むこと（リテラル一致）
 - `src` が `/artifacts/...` で始まら**ない**こと（LLM が新ルール違反していないかの guard）
 - `naturalWidth > 0`（end-to-end の本質的な signal — 画像が実際に decode されたか）
+- `readImgRepairAttempted` が `false`（PR #974 の onerror self-repair が発火していないこと — self-repair は `/artifacts/images/...` の絶対パスを修正するため、LLM が絶対パスを吐いても naturalWidth > 0 になって false-pass になる罠を防ぐ）
 
 `/artifacts/images/...` は依然 Express 静的マウントで配信されているので、 ブラウザは `<base href>` (= iframe の `src` の親ディレクトリ `/artifacts/html/<YYYY>/<MM>/`) に対して `../../../images/<file>` を解決して `/artifacts/images/<file>` を fetch する。
 
@@ -789,11 +790,10 @@ artifact name: `mulmoclaude-tarball`（10 MB 程度、`.tgz`）。
 
 ### 要対応（PR #971 には未反映、 後続 PR で見直し）
 
-- **#974 onerror self-repair (Stage 3)**: `<img>` が 404 した時にブラウザ側で `src` を `/artifacts/images/<rest>` に書き換えて自動 retry する。 これは **L-01 の `naturalWidth > 0` チェックが甘くなる** リスク:
-  - LLM が古い絶対パス convention に戻っても、 self-repair で表示は救われる
-  - assert がパスしてしまい、 「LLM が convention を守っているか」 を検出できない
-  - 緩和策: console error 監視 / `page.on("requestfailed")` で初回 fetch の 404 をフェイルさせる / `<img>` の `src` 変更を検出する MutationObserver
-  - 重要度: **中**（B-18 系の本質的な regression は naturalWidth で拾えるが、 LLM 退行の検知力は落ちる）
+- **#974 onerror self-repair (Stage 3)** ✅ guard 反映済: `<img>` が 404 した時にブラウザ側で `src` を `/artifacts/images/<rest>` に書き換えて自動 retry する仕組みで、 そのままだと **L-01 の `naturalWidth > 0` チェックが甘くなる** （LLM が `artifacts/images/` を含む間違った prefix を emit しても表示が救われ assert がパスする）。
+  - 採用ガード: self-repair が発火すると repair script が `<img>` に `data-image-repair-tried="1"` マーカを付ける。 L-01 の assertion で `naturalWidth > 0` 確認後に **マーカ未セット** を assert する形に変更。 helper `readImgRepairAttempted` を `e2e-live/fixtures/live-chat.ts` に追加。
+  - 既存の `not.toMatch(/^\/artifacts\//)` 絶対パス退行 guard と直交する（こちらは self-repair が発火しない 「直接 200 が返る絶対パス」 を検出、 マーカ guard は self-repair に救われた間接退行を検出）。
+  - 検討した他案: console error 監視 / `page.on("requestfailed")` / `<img>.src` MutationObserver。 マーカ参照が最も直接的（「self-repair が発火した」 = 「LLM が convention 違反した」 そのもの）かつ実装が局所的なので採用。
 - **#983 presentDocument / generateImage の path 入り message**: tool result の message 文字列に `Saved … to <path>` が乗るようになり LLM が path を正しく扱える。 → **L-05 (generateImage)** の prompt から `<path>` キャプチャが楽になる（spec 実装時に活用）
 - **#991 Safari preview iframe CSP** ✅ webkit project 追加 + 動作確認済: `e2e-live/playwright.config.ts` の projects に `webkit` を追加 (`testMatch: "media.spec.ts"` で対象 spec を絞り、 `e2e/playwright.config.ts` の chromium+webkit 分割を踏襲)。 spec 側は手を入れていない。
   - **当初の誤観測**: webkit 走行で L-01 が `naturalWidth=0` で fail し、 #991 の fix が e2e-live 経路に届いていないと推定して issue #1015 を起票した。
@@ -809,7 +809,7 @@ artifact name: `mulmoclaude-tarball`（10 MB 程度、`.tgz`）。
 - [ ] 実行時間実測 → 30 シナリオ × 2 モードで何分か
 - [ ] CI 化のタイミング（手動運用が安定したら GitHub Actions 検討）
 - [ ] L-22 で使う skill の選定（dry-run 可能なものに絞る）
-- [ ] **#974 self-repair で L-01 の `naturalWidth > 0` が甘くなる件の緩和策決定**（console error 監視 / requestfailed リスナ / src MutationObserver のいずれか）
+- [x] ~~**#974 self-repair で L-01 の `naturalWidth > 0` が甘くなる件の緩和策決定**~~ → `data-image-repair-tried` マーカ参照 guard を採用（上記 「要対応」 セクション参照）
 - [x] ~~**Safari (webkit) project の追加**~~ → 反映済（`e2e-live/playwright.config.ts` に `webkit` project + `testMatch: "media.spec.ts"`）
 - [x] ~~**webkit で L-01 が `naturalWidth=0` で fail する件の調査と修正**~~ → #1015 close 済（real bug ではなく dev server stale だっただけ。 上の 「真の原因」 セクション参照。 dev 再起動後に webkit L-01 + L-02 pass 確認）
 - [ ] **L-05 (generateImage)** 実装時に #983 の path-in-message を活用（path のキャプチャが容易になる）


### PR DESCRIPTION
## Summary

L-01（presentHtml 画像描画テスト）に self-repair 未発火 assertion を 1 行追加し、 PR #974 の onerror self-repair が「LLM が `artifacts/images/` を含む間違った prefix の path に退行したケース」を見えなくしていた弱点を塞いだ。 既存の絶対パス退行 guard (`not.toMatch(/^\/artifacts\//)`) と直交する 2 段目の safety net で、 healthy path は従来通り pass する preventive な tightening。

新規シナリオ追加はなし。 plans/feat-e2e-live.md の「要対応」(#974) を ✅ 反映済に更新。

## Items to Confirm / Review

- **assertion の置き場所**: `naturalWidth > 0` 確認直後に置いた。 self-repair 発火後にマーカが付くタイミング → image decode 完了後 → naturalWidth > 0 が見える、 という順序前提。 timing race の懸念があれば指摘ください。
- **マーカ参照方式の選定**: 検討した他案（`page.on("requestfailed")` での 404 監視 / `<img>.src` MutationObserver / console error 監視）を退け、 `data-image-repair-tried` 属性参照を採用しています。 「self-repair が発火した = LLM が convention 違反した」 を直接シグナル化でき、 実装も局所的なため。 別案を推す根拠があれば指摘ください。
- **L-02 への波及**: L-02 は textResponse + サーバ側 PDF inline 経路で、 ブラウザの onerror self-repair は介在しない。 そのため L-02 にはガード追加せず（L-01 のみで完結）。

## User Prompt

`/make-e2e-live` skill を起動して、 1 PR 分の着手項目を自動選定して進めるよう依頼。 Phase 2 の選定ルールに従い、 main 動向の「要対応」 のうち未消化だった #974 self-repair 緩和（B カテゴリ）を採用した。

## 変更内容

| ファイル | 変更 |
|---|---|
| `e2e-live/fixtures/live-chat.ts` | helper `readImgRepairAttempted` を追加（presentHtml iframe 内 `<img>` の `data-image-repair-tried` 属性を読む） |
| `e2e-live/tests/media.spec.ts` | L-01 の `assertL01PresentHtml` に self-repair 未発火 assertion を 1 行追加 |
| `plans/feat-e2e-live.md` | 「要対応」 (#974) を ✅ 反映済に書き換え + 「未確定事項 / TODO」 該当エントリを close |

## 検出できるようになる退行

LLM が `<img src="/wrong/prefix/artifacts/images/foo.png">` のような「`artifacts/images/` を含むけど prefix が間違った path」 に退行した場合。 従来は self-repair が `/artifacts/images/foo.png` に書き直して救うため `naturalWidth > 0` が pass してしまい検出できなかった。 今回のガードで「self-repair に救われた退行」 を別個にフェイルさせられる。

## チェック

- [x] format / lint / typecheck:e2e-live / build すべて pass
- [x] 実 Claude API での L-01 実走（chromium / webkit ともに pass、 21.7s — [comment](https://github.com/receptron/mulmoclaude/pull/1027#issuecomment-4351788592)）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced image rendering validation to detect and prevent potential repair mechanisms from masking regressions.

* **Documentation**
  * Updated testing guidelines for image handling verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->