### PR TITLE
feat: shared HTML URL-attr rewriter (#1011 Stage B)

### DIFF
--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -11,6 +11,7 @@ import { resolveWorkspacePath } from "../../utils/files/workspace-io.js";
 import { parseFrontmatter } from "../../utils/markdown/frontmatter.js";
 import { log } from "../../system/logger/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { transformResolvableUrlsInHtml } from "../../../src/utils/image/htmlSrcAttrs.js";
 
 const router = Router();
 
@@ -74,44 +75,11 @@ export interface InlineImagesOptions {
   sourceDir?: string;
 }
 
-// Outer regex: scan an `<img>` tag, respecting quoted attribute values
-// so `>` characters that appear inside `alt="x > y"` don't terminate
-// the tag prematurely (Codex iter-2 finding). The body is one of:
-//   - any non-`>` non-quote char     `[^>"']`
-//   - a complete double-quoted span  `"[^"]*"`
-//   - a complete single-quoted span  `'[^']*'`
-// All branches are bounded — no nested quantifiers, no overlap. The
-// 100KB ReDoS test pins linear time.
-//
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded alternatives, ReDoS-safe (test in test_pdfInlineImages.ts)
-const IMG_TAG_RE = /<img\b(?:[^>"']|"[^"]*"|'[^']*')*\/?>/gi;
-// Attribute iterator: walks each `name=value` pair inside a tag. The
-// leading `\s+` ensures we only match real attribute boundaries, not
-// `src=` text embedded inside another attribute's quoted value (e.g.
-// `<img alt="x src=oops" src="real.png">` — the alt-internal `src=`
-// has no whitespace prefix from the regex's POV because we parse
-// attribute-by-attribute, never against the free-form tag body).
-// Namespaced attrs (`xml:src`, `xlink:src`) match as their full name
-// and are filtered below by `name.toLowerCase() !== "src"`.
-// Capture groups:
-//   1: leading whitespace
-//   2: attribute name
-//   3: `=` with surrounding spaces (only when value present)
-//   4: full quoted/unquoted value
-//   5: double-quoted value (without quotes)
-//   6: single-quoted value (without quotes)
-//   7: unquoted value — refuses leading `"` / `'` so a malformed
-//      `<img src="aaaa` (no closing quote) doesn't capture the stray
-//      quote as the value
-//
-// Why the disables: this regex has 3 alternation branches plus an
-// optional value group, which trips sonarjs/regex-complexity (rule
-// counts disjunctions). All quantifiers are bounded by `\s` or
-// character-class negations — verified ReDoS-safe by the 100KB test
-// (`test_pdfInlineImages.ts`). Refactoring to multiple passes would
-// be slower and harder to read.
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded quantifiers, ReDoS-safe (test in test_pdfInlineImages.ts)
-const IMG_ATTR_RE = /(\s+)([A-Za-z][\w:-]*)(?:(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s>"'][^\s>]*)))?/g;
+// Tag scanning + attribute iteration live in the shared helper
+// (`src/utils/image/htmlSrcAttrs.ts`) so the Markdown surface
+// (`rewriteImgSrcAttrsInHtml`) and this PDF surface stay in lockstep.
+// Adding a tag / attribute (Stage B's `<source>` / `<video poster>`
+// / `<audio src>`) updates both surfaces with one diff (#1011 Stage B).
 
 function isSafeSourceDir(dir: string): boolean {
   if (!dir) return true;
@@ -157,40 +125,23 @@ function loadImageAsDataUri(abs: string): string | null {
   return `data:${mime};base64,${buf.toString("base64")}`;
 }
 
-interface SrcAttrMatch {
-  /** The portion of the matched attribute that we keep verbatim:
-   *  leading whitespace + attribute name + `=` (with surrounding
-   *  spaces). Only the value part is replaced. */
-  prefix: string;
-  doubleQuoted?: string;
-  singleQuoted?: string;
-  bare?: string;
-  full: string;
-}
-
-function inlineSingleImg(match: SrcAttrMatch, workspaceRoot: string, baseDir: string): string {
-  const src = (match.doubleQuoted ?? match.singleQuoted ?? match.bare ?? "").trim();
-  if (!src) return match.full;
-  if (src.startsWith("data:") || src.startsWith("http")) return match.full;
-  const abs = resolveImageAbsPath(src, workspaceRoot, baseDir);
-  if (!abs) return match.full;
-  const dataUri = loadImageAsDataUri(abs);
-  if (!dataUri) return match.full;
-  const quote = match.doubleQuoted !== undefined ? '"' : match.singleQuoted !== undefined ? "'" : '"';
-  return `${match.prefix}${quote}${dataUri}${quote}`;
-}
-
 /**
- * Inline local images as base64 data URIs so Puppeteer can render them.
- * Resolves `<img>` `src` references against `sourceDir` (workspace-
- * relative); for example, a Wiki page (`data/wiki/pages/X.md`)
- * referencing `../../../artifacts/images/foo.png` resolves to
+ * Inline local images as base64 data URIs so Puppeteer can render
+ * them. Resolves URL-bearing attributes (currently `<img src>`,
+ * `<source src>`, `<video poster|src>`, `<audio src>`) against
+ * `sourceDir` (workspace-relative); for example, a Wiki page
+ * (`data/wiki/pages/X.md`) referencing
+ * `../../../artifacts/images/foo.png` resolves to
  * `artifacts/images/foo.png`.
  *
- * Handles double-quoted, single-quoted, and unquoted `src` values.
- * Skips data: URIs and http(s) URLs. Refuses values that escape the
+ * Handles double-quoted, single-quoted, and unquoted values. Skips
+ * `data:` URIs and `http(s)` URLs. Refuses values that escape the
  * workspace root after resolution — the workspace boundary is
  * enforced by `resolveWithinRoot`, regardless of `sourceDir`.
+ *
+ * Tag + attribute coverage is shared with the browser markdown
+ * surface (`rewriteImgSrcAttrsInHtml`) via `RESOLVABLE_TAG_ATTRS` in
+ * `src/utils/image/htmlSrcAttrs.ts`.
  */
 export function inlineImages(html: string, options: InlineImagesOptions = {}): string {
   const workspaceRoot = options.workspaceRoot ?? defaultWorkspaceRoot;
@@ -201,30 +152,12 @@ export function inlineImages(html: string, options: InlineImagesOptions = {}): s
   }
   const sourceDir = dirIsSafe && requestedDir ? requestedDir : WORKSPACE_DIRS.markdowns;
   const baseDir = path.join(workspaceRoot, sourceDir);
-  return html.replace(IMG_TAG_RE, (tag) =>
-    // Walk each attribute. Only `src` (case-insensitive, namespaced
-    // attrs like `xml:src` / `xlink:src` filtered out) gets the
-    // value rewritten. Other attributes — and `src=`-shaped text
-    // inside their quoted values — are preserved verbatim because
-    // we parse attribute-by-attribute, not by free-form regex.
-    tag.replace(IMG_ATTR_RE, (...captures: unknown[]) => replaceSrcAttr(captures, workspaceRoot, baseDir)),
-  );
-}
-
-function replaceSrcAttr(captures: unknown[], workspaceRoot: string, baseDir: string): string {
-  const [full, leading, name, eqWithSpaces, , doubleQuoted, singleQuoted, bare] = captures as [
-    string,
-    string,
-    string,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-  ];
-  if (!eqWithSpaces || name.toLowerCase() !== "src") return full;
-  const prefix = `${leading}${name}${eqWithSpaces}`;
-  return inlineSingleImg({ prefix, doubleQuoted, singleQuoted, bare, full }, workspaceRoot, baseDir);
+  return transformResolvableUrlsInHtml(html, (url) => {
+    if (url.startsWith("data:") || url.startsWith("http")) return null;
+    const abs = resolveImageAbsPath(url, workspaceRoot, baseDir);
+    if (!abs) return null;
+    return loadImageAsDataUri(abs);
+  });
 }
 
 function wrapHtml(body: string, css: string): string {

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -125,6 +125,17 @@ function loadImageAsDataUri(abs: string): string | null {
   return `data:${mime};base64,${buf.toString("base64")}`;
 }
 
+// Video / audio extensions Stage B (#1011) added to the rewriter.
+// In PDF rendering puppeteer can't play them, so inlining a large
+// `.mp4` as base64 just blows up the HTML and times out the page
+// load (`Navigation timeout of 30000 ms exceeded`). The `<video
+// poster>` attribute IS an image and stays inlined — that's the
+// only thing the user actually sees in a PDF anyway. The `<video
+// src>` / `<source src>` (in a `<video>`) / `<audio src>` URL is
+// left as the original relative path; puppeteer's fetch will fail
+// quickly and `networkidle0` still resolves.
+const PDF_SKIP_MEDIA_EXT_RE = /\.(mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)(\?|#|$)/i;
+
 /**
  * Inline local images as base64 data URIs so Puppeteer can render
  * them. Resolves URL-bearing attributes (currently `<img src>`,
@@ -154,6 +165,10 @@ export function inlineImages(html: string, options: InlineImagesOptions = {}): s
   const baseDir = path.join(workspaceRoot, sourceDir);
   return transformResolvableUrlsInHtml(html, (url) => {
     if (url.startsWith("data:") || url.startsWith("http")) return null;
+    // Skip media (mp4 / mp3 / webm / ...) — see PDF_SKIP_MEDIA_EXT_RE
+    // comment. `<video poster="x.png">` still inlines because the
+    // poster value's URL ends in an image extension.
+    if (PDF_SKIP_MEDIA_EXT_RE.test(url)) return null;
     const abs = resolveImageAbsPath(url, workspaceRoot, baseDir);
     if (!abs) return null;
     return loadImageAsDataUri(abs);

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -134,7 +134,29 @@ function loadImageAsDataUri(abs: string): string | null {
 // src>` / `<source src>` (in a `<video>`) / `<audio src>` URL is
 // left as the original relative path; puppeteer's fetch will fail
 // quickly and `networkidle0` still resolves.
-const PDF_SKIP_MEDIA_EXT_RE = /\.(mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)(\?|#|$)/i;
+//
+// Anchored at end-of-pathname (callers strip query / fragment first
+// via `urlPathname` below) so a query-string-only mention of the
+// extension doesn't false-positive — e.g. `foo.png?clip.mp4` must
+// inline the PNG, not be treated as an mp4 (codex review iter-1).
+const PDF_SKIP_MEDIA_EXT_RE = /\.(mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)$/i;
+
+function urlPathname(url: string): string {
+  const queryStart = url.indexOf("?");
+  const fragStart = url.indexOf("#");
+  const limit = [queryStart, fragStart].filter((idx) => idx >= 0).reduce((min, idx) => Math.min(min, idx), url.length);
+  return url.slice(0, limit);
+}
+
+/** Whether a URL points at a video / audio file that should NOT be
+ *  base64-inlined into a PDF. Exported for direct unit testing —
+ *  filesystem-level resolver checks (`resolveImageAbsPath`) can mask
+ *  the regex's behaviour because a missing file also returns null,
+ *  so the in-line callback's output looks identical for "skip" vs
+ *  "resolve-failed". */
+export function shouldSkipMediaForPdf(url: string): boolean {
+  return PDF_SKIP_MEDIA_EXT_RE.test(urlPathname(url));
+}
 
 /**
  * Inline local images as base64 data URIs so Puppeteer can render
@@ -167,8 +189,10 @@ export function inlineImages(html: string, options: InlineImagesOptions = {}): s
     if (url.startsWith("data:") || url.startsWith("http")) return null;
     // Skip media (mp4 / mp3 / webm / ...) — see PDF_SKIP_MEDIA_EXT_RE
     // comment. `<video poster="x.png">` still inlines because the
-    // poster value's URL ends in an image extension.
-    if (PDF_SKIP_MEDIA_EXT_RE.test(url)) return null;
+    // poster value's pathname ends in an image extension. The
+    // pathname slice means `foo.png?cacheBust=clip.mp4` correctly
+    // routes through the PNG inline path (codex iter-1).
+    if (shouldSkipMediaForPdf(url)) return null;
     const abs = resolveImageAbsPath(url, workspaceRoot, baseDir);
     if (!abs) return null;
     return loadImageAsDataUri(abs);

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -93,13 +93,19 @@ function isSafeSourceDir(dir: string): boolean {
 // Logs the reason so the developer can grep when a PDF image is
 // missing.
 function resolveImageAbsPath(src: string, workspaceRoot: string, baseDir: string): string | null {
+  // Strip query / fragment before any filesystem-level resolution —
+  // a `<img src="foo.png?v=123">` cache-bust must still find the
+  // file at `foo.png` on disk. Without this strip, `path.resolve`
+  // bakes the `?v=123` into the candidate path and the safe-resolve
+  // / readBinarySafeSync reject (codex review iter-2 #1028).
+  const pathPart = urlPathname(src);
   // LLM-generated HTML often emits leading-slash workspace-rooted
   // paths like "/artifacts/images/2026/04/foo.png" (web convention).
   // Treat those as workspace-relative; otherwise path.resolve below
   // sees the slash as host-absolute and the safe-resolve rejects.
-  const workspaceRooted = src.startsWith("/");
+  const workspaceRooted = pathPart.startsWith("/");
   const resolveBase = workspaceRooted ? workspaceRoot : baseDir;
-  const relSrc = workspaceRooted ? src.slice(1) : src;
+  const relSrc = workspaceRooted ? pathPart.slice(1) : pathPart;
   const unsafeAbs = path.resolve(resolveBase, relSrc);
   const relToWorkspace = path.relative(workspaceRoot, unsafeAbs);
   if (relToWorkspace.startsWith("..") || path.isAbsolute(relToWorkspace)) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -133,15 +133,21 @@ app.use("/api", (req, res, next) => {
 // stays loopback-only.
 //
 // Three-layer guard:
-//  1. Extension allowlist — reject anything that isn't an image
-//     extension (saveImage currently writes `.png` only; the list
-//     stays slightly wider so future formats don't reopen the review).
+//  1. Extension allowlist — reject anything that isn't an image,
+//     video, or audio extension. `saveImage` currently writes `.png`
+//     only, but Stage B (#1011) extends the markdown / wiki rewriter
+//     to `<source>` / `<video poster|src>` / `<audio src>`; an LLM
+//     placing a `.mp4` poster's source video alongside its image at
+//     `artifacts/images/<id>.mp4` (or any user-dropped media file
+//     under that dir) needs to round-trip through this mount the
+//     same way image refs do — otherwise the rewritten URL hits this
+//     mount and 404s before `express.static` gets a chance.
 //  2. realpath-based traversal check via `resolveWithinRoot` — same
 //     guard `/api/files/raw` uses. Catches symlinks pointing outside
 //     the images dir, which `express.static` would otherwise follow.
 //  3. `dotfiles: deny` + `fallthrough: false` on `express.static`
 //     itself, plus its built-in `..` normalize for path traversal.
-const IMAGE_EXT_RE = /\.(png|jpe?g|webp|gif|svg)$/i;
+const IMAGE_EXT_RE = /\.(png|jpe?g|webp|gif|svg|mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)$/i;
 let imagesDirReal: string | null = null;
 async function getImagesDirReal(): Promise<string | null> {
   if (imagesDirReal) return imagesDirReal;
@@ -221,12 +227,15 @@ app.use(
 // parity. Sandbox stays `allow-scripts` only, so the iframe document
 // still cannot read the parent's cookies / localStorage / DOM.
 //
-// `HTML_PREVIEW_EXT_RE` widens the allowlist to images so inline
-// `<img src="...png">` references resolve through this same mount
-// (no separate /artifacts/images round-trip). The CSP header is
-// only set for HTML responses (`HTML_DOCUMENT_EXT_RE`); CSP doesn't
-// apply to image subresources.
-const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico)$/i;
+// `HTML_PREVIEW_EXT_RE` widens the allowlist to images, video and
+// audio so inline `<img src="...png">` / `<source>` / `<video src>` /
+// `<audio src>` references resolve through this same mount (no
+// separate /artifacts/images round-trip). The CSP header is only set
+// for HTML responses (`HTML_DOCUMENT_EXT_RE`); CSP doesn't apply to
+// image / media subresources.
+//
+// eslint-disable-next-line sonarjs/regex-complexity -- flat extension allowlist with no nested quantifiers, ReDoS-safe; complexity is just the disjunction count
+const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico|mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)$/i;
 const HTML_DOCUMENT_EXT_RE = /\.html?$/i;
 let htmlsDirReal: string | null = null;
 async function getHtmlsDirReal(): Promise<string | null> {

--- a/src/utils/image/htmlSrcAttrs.ts
+++ b/src/utils/image/htmlSrcAttrs.ts
@@ -1,0 +1,122 @@
+// Shared HTML-tag URL rewriter — used by:
+//   - browser markdown surface (`rewriteImgSrcAttrsInHtml` in
+//     `rewriteMarkdownImageRefs.ts`) → rewrites to
+//     `/api/files/raw?path=...`
+//   - server PDF surface (`inlineImages` in
+//     `server/api/routes/pdf.ts`) → rewrites to `data:` URIs
+//
+// Both used to keep their own copy of the same regex shape with a
+// `// Mirrors the shape used by …` comment. That mirroring drifts the
+// moment one side adds a tag (`<source>`, `<video poster>`) and the
+// other doesn't. Single helper here, two callers, one tag list — the
+// drift becomes structurally impossible (#1011 Stage B).
+//
+// `srcset` (comma-separated descriptor list) and SVG `<image href>` /
+// CSS `url()` are deliberately out of scope — see the deferred-list
+// comment on `RESOLVABLE_TAG_ATTRS` below.
+
+// Tag (lowercased) → URL-bearing attribute(s). Adding a row here
+// extends both Markdown and PDF surfaces simultaneously.
+//
+// Deferred (NOT here):
+//   - `srcset` on `<img>` / `<source>` — comma-separated list with
+//     descriptors (`url 1x, url2 2x`), needs a separate split/rewrite
+//     pass. Tracked under #1011 Stage B follow-up.
+//   - SVG `<image href>` — gap table item #9, low priority per plan
+//     §修正提案 P3-A.
+//   - CSS `url()` in `style=` attributes — gap table item #8, same
+//     priority.
+export const RESOLVABLE_TAG_ATTRS: Readonly<Record<string, readonly string[]>> = {
+  img: ["src"],
+  source: ["src"],
+  video: ["poster", "src"],
+  audio: ["src"],
+};
+
+// Outer regex: scan any tag whose name appears in `RESOLVABLE_TAG_ATTRS`,
+// respecting quoted attribute values so `>` inside e.g. `alt="x>y"`
+// doesn't terminate the tag early. The body is one of:
+//   - any non-`>` non-quote char     `[^>"']`
+//   - a complete double-quoted span  `"[^"]*"`
+//   - a complete single-quoted span  `'[^']*'`
+// All branches bounded — no nested quantifiers, no overlap.
+//
+// The tag-name alternation is hand-listed rather than computed from
+// `Object.keys(RESOLVABLE_TAG_ATTRS)` so the regex is a const string
+// (lint-friendly) and the alternation order matches the readable
+// declaration order. Adding a tag means: update the map AND the
+// alternation here. The unit test in test_htmlSrcAttrs.ts pins this
+// in lockstep so the two never disagree silently.
+//
+// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded alternatives, ReDoS-safe (test in test_htmlSrcAttrs.ts)
+const RESOLVABLE_TAG_OUTER_RE = /<(?:img|source|video|audio)\b(?:[^>"']|"[^"]*"|'[^']*')*\/?>/gi;
+// Tag-name extractor for the matched outer tag. Anchored so we only
+// read the leading `<name`, never an attribute value that happens to
+// look like a tag.
+const TAG_NAME_RE = /^<([a-z]+)/i;
+
+// Attribute iterator: walks each `name=value` pair inside a tag. The
+// leading `\s+` ensures we only match real attribute boundaries, not
+// `src=` text embedded inside another attribute's quoted value.
+// Capture groups:
+//   1: leading whitespace
+//   2: attribute name
+//   3: `=` with surrounding spaces (only when value present)
+//   4: full quoted/unquoted value (unused but captured for clarity)
+//   5: double-quoted value (without quotes)
+//   6: single-quoted value (without quotes)
+//   7: unquoted value — refuses leading `"` / `'` so a malformed
+//      `<img src="aaaa` (no closing quote) doesn't capture the stray
+//      quote as the value
+//
+// All quantifiers bounded — verified ReDoS-safe in test_htmlSrcAttrs.ts.
+// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded quantifiers, ReDoS-safe (test in test_htmlSrcAttrs.ts)
+const ATTR_ITER_RE = /(\s+)([A-Za-z][\w:-]*)(?:(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s>"'][^\s>]*)))?/g;
+
+/** Transform every URL-bearing attribute on a recognised tag.
+ *
+ *  `transform` is invoked once per matching attribute value. Return:
+ *    - `string` to substitute the value (callee is responsible for
+ *      not breaking out of the surrounding quotes — most callers
+ *      route through `encodeURIComponent` or a fixed-prefix path)
+ *    - `null` to leave the attribute untouched (e.g. external URL,
+ *      `data:` URI, escape-the-workspace path)
+ *
+ *  Other attributes (alt, class, style, …) and `src=`-shaped text
+ *  inside their quoted values are preserved verbatim because we
+ *  parse attribute-by-attribute, not by free-form regex.
+ *
+ *  Recognised tags + attributes live in `RESOLVABLE_TAG_ATTRS`. Any
+ *  tag whose name isn't in the map is returned untouched. Any
+ *  attribute on a recognised tag whose name isn't in the map's entry
+ *  is also untouched. */
+export function transformResolvableUrlsInHtml(html: string, transform: (url: string) => string | null): string {
+  if (!html) return html;
+  return html.replace(RESOLVABLE_TAG_OUTER_RE, (tag) => {
+    const tagNameMatch = TAG_NAME_RE.exec(tag);
+    if (!tagNameMatch) return tag;
+    const resolvableAttrs = RESOLVABLE_TAG_ATTRS[tagNameMatch[1].toLowerCase()];
+    if (!resolvableAttrs) return tag;
+    return tag.replace(ATTR_ITER_RE, (...captures: unknown[]) => replaceAttrIfResolvable(captures, resolvableAttrs, transform));
+  });
+}
+
+function replaceAttrIfResolvable(captures: unknown[], resolvableAttrs: readonly string[], transform: (url: string) => string | null): string {
+  const [full, leading, name, eqWithSpaces, , doubleQuoted, singleQuoted, bare] = captures as [
+    string,
+    string,
+    string,
+    string | undefined,
+    string | undefined,
+    string | undefined,
+    string | undefined,
+    string | undefined,
+  ];
+  if (!eqWithSpaces || !resolvableAttrs.includes(name.toLowerCase())) return full;
+  const value = (doubleQuoted ?? singleQuoted ?? bare ?? "").trim();
+  if (!value) return full;
+  const replacement = transform(value);
+  if (replacement === null) return full;
+  const quote = doubleQuoted !== undefined ? '"' : singleQuoted !== undefined ? "'" : '"';
+  return `${leading}${name}${eqWithSpaces}${quote}${replacement}${quote}`;
+}

--- a/src/utils/image/rewriteMarkdownImageRefs.ts
+++ b/src/utils/image/rewriteMarkdownImageRefs.ts
@@ -1,6 +1,7 @@
 import { marked } from "marked";
 import type { Token, Tokens } from "marked";
 import { resolveImageSrc } from "./resolve";
+import { transformResolvableUrlsInHtml } from "./htmlSrcAttrs";
 
 // Pre-`marked` pass that rewrites workspace-relative image references
 // in markdown source so they render through the backend file server.
@@ -102,101 +103,39 @@ function rewriteImageToken(token: Tokens.Image, basePath: string): string | null
   return `![${alt}](${newHref})`;
 }
 
-// Rewrite the `src` attribute of every `<img>` tag inside an HTML
-// fragment, applying the same basePath / shouldSkip / resolveImageSrc
-// pipeline used for `![alt](url)` markdown images. Other attributes
-// (alt, class, style, id, …) are preserved verbatim.
+// Rewrite URL-bearing attributes of every recognised tag inside an
+// HTML fragment, applying the same basePath / shouldSkip /
+// resolveImageSrc pipeline used for `![alt](url)` markdown images.
+// Other attributes (alt, class, style, id, …) are preserved verbatim.
 //
-// Handles the common quoting variations:
-//   - <img src="path">              double-quoted
-//   - <img src='path'>              single-quoted
-//   - <img src=path>                unquoted (HTML5 allows this when
-//                                   the value has no spaces / quotes
-//                                   / `>` / `=` / backticks)
-//   - <img alt="x" src="..." />     attribute order doesn't matter
-//   - <img\n  src="..." />          newlines inside the tag work
+// Tags + attributes covered (single source of truth at
+// `htmlSrcAttrs.ts:RESOLVABLE_TAG_ATTRS`): `<img src>`, `<source src>`,
+// `<video poster|src>`, `<audio src>`. Add a row there to extend
+// coverage; both this rewriter and the server-side PDF rewriter pick
+// it up automatically (#1011 Stage B).
 //
-// Tags without a `src`, or with a `src` that already passes
-// `shouldSkip` (data: URI / http / /api/), are returned untouched.
+// Output URLs come from `resolveImageSrc`, which either returns a
+// mount-rooted path (`/artifacts/images/<file>`) or runs the input
+// through `encodeURIComponent`. `"` becomes `%22`, `'` becomes `%27`,
+// `<` / `>` are encoded — the rewritten attribute can't break out of
+// its own quotes or close the tag.
 //
-// Robustness / safety notes:
-//
-//   - All regex quantifiers are bounded by `[^>]` or character-class
-//     negations so no input can drive exponential backtracking.
-//     A 100KB-no-closing-> probe runs in linear time.
-//   - The unquoted-value branch refuses to start with `"` or `'`. So
-//     malformed input like `<img src="aaaa alt=x>` (missing closing
-//     quote) is left alone instead of capturing `"aaaa` as the value.
-//   - Output URLs come from `resolveImageSrc`, which either returns a
-//     mount-rooted path (`/artifacts/images/<file>`) or runs the input
-//     through `encodeURIComponent`. `"` becomes `%22`, `'` becomes
-//     `%27`, `<` / `>` are encoded — the rewritten attribute can't
-//     break out of its own quotes or close the tag.
-//   - Defensive against `token.raw` being unexpectedly empty: an
-//     empty string short-circuits the outer replace.
-//
-// Known limitations (acceptable for #1011 Stage A):
-//
-//   - Only `<img>` is matched. `<picture><source>` / `<video poster>` /
-//     SVG `<image>` / CSS `url()` are tracked under #1011 Stage B / E.
-//   - A regex can't perfectly distinguish a real `<img>` tag from a
-//     `<img>` substring embedded inside another attribute, e.g.
-//     `<div data-x="<img src='foo.png'>">`. Such cases get rewritten
-//     too — harmless because the rewritten URL is encoded safely, and
-//     the rewrite makes the embedded reference resolve correctly if
-//     it's later inserted into the DOM by JS.
-// Attribute iterator for the inner pass — see the comment block on
-// `IMG_ATTR_RE` in `server/api/routes/pdf.ts` for the rationale on
-// parsing attribute-by-attribute (handles `src=` text inside another
-// attribute's value, namespaced attrs like `xml:src`).
-//
-// Capture groups:
-//   1: leading whitespace
-//   2: attribute name
-//   3: `=` with surrounding spaces (only when value present)
-//   4: full quoted/unquoted value
-//   5: double-quoted value (without quotes)
-//   6: single-quoted value (without quotes)
-//   7: unquoted value (refuses leading quote so malformed
-//      `<img src="aaaa` doesn't capture the stray quote)
-//
-// All quantifiers bounded — verified ReDoS-safe by 100KB test in
-// test_rewriteMarkdownImageRefs.ts. The disables silence sonarjs's
-// alternation-counting heuristic.
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded quantifiers, ReDoS-safe (test in test_rewriteMarkdownImageRefs.ts)
-const IMG_ATTR_ITER_RE = /(\s+)([A-Za-z][\w:-]*)(?:(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s>"'][^\s>]*)))?/g;
-
-function rewriteSrcAttr(captures: unknown[], basePath: string): string {
-  const [full, leading, name, eqWithSpaces, , doubleQuoted, singleQuoted, bare] = captures as [
-    string,
-    string,
-    string,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-  ];
-  if (!eqWithSpaces || name.toLowerCase() !== "src") return full;
-  const url = (doubleQuoted ?? singleQuoted ?? bare ?? "").trim();
-  if (!url || shouldSkip(url)) return full;
-  const resolved = resolveWorkspacePath(basePath, url);
-  if (resolved === null) return full;
-  const newUrl = resolveImageSrc(resolved);
-  const quote = doubleQuoted !== undefined ? '"' : singleQuoted !== undefined ? "'" : '"';
-  return `${leading}${name}${eqWithSpaces}${quote}${newUrl}${quote}`;
-}
-
-// Outer regex: respects quoted attribute values so a `>` inside
-// `alt="x > y"` doesn't terminate the tag early (Codex iter-2
-// finding on #1023). All branches bounded; ReDoS-safe.
-//
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded alternatives, ReDoS-safe (test in test_rewriteMarkdownImageRefs.ts)
-const IMG_TAG_OUTER_RE = /<img\b(?:[^>"']|"[^"]*"|'[^']*')*\/?>/gi;
-
+// Limitations:
+//   - `srcset` (comma-separated descriptor list) is deferred —
+//     tracked under #1011 Stage B follow-up.
+//   - SVG `<image href>` and CSS `url()` are deferred per plan
+//     §修正提案 P3-A.
+//   - A regex can't perfectly distinguish a real tag from one
+//     embedded in another attribute's value; embedded matches get
+//     rewritten too. Harmless because the rewritten URL is encoded
+//     safely.
 export function rewriteImgSrcAttrsInHtml(html: string, basePath: string): string {
-  if (!html) return html;
-  return html.replace(IMG_TAG_OUTER_RE, (tag) => tag.replace(IMG_ATTR_ITER_RE, (...captures: unknown[]) => rewriteSrcAttr(captures, basePath)));
+  return transformResolvableUrlsInHtml(html, (url) => {
+    if (shouldSkip(url)) return null;
+    const resolved = resolveWorkspacePath(basePath, url);
+    if (resolved === null) return null;
+    return resolveImageSrc(resolved);
+  });
 }
 
 function isSkippable(token: Token): boolean {

--- a/test/routes/test_pdfInlineImages.ts
+++ b/test/routes/test_pdfInlineImages.ts
@@ -246,4 +246,34 @@ describe("inlineImages — extended tag coverage (Stage B)", () => {
     const out = inlineImages(html, { workspaceRoot });
     assert.equal(out, html);
   });
+
+  it("does NOT inline <video src=mp4> — poster image is what shows in PDF", () => {
+    // The actual file doesn't have to exist; the URL extension is
+    // what gates the skip. Inlining a 100MB mp4 as base64 would
+    // blow up puppeteer's page-load timeout.
+    const html = '<video src="/artifacts/images/2026/04/clip.mp4"></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.equal(out, html, ".mp4 must NOT be inlined in PDF");
+  });
+
+  it("inlines <video poster> while leaving <video src=mp4> alone", () => {
+    // Poster is an image → inlined. The mp4 src → left as relative
+    // URL; puppeteer's fetch fails quickly, `networkidle0` resolves.
+    const html = '<video poster="/artifacts/images/2026/04/foo.png" src="/artifacts/images/2026/04/clip.mp4"></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /poster="data:image\/png;base64,/);
+    assert.match(out, /src="\/artifacts\/images\/2026\/04\/clip\.mp4"/);
+  });
+
+  it("does NOT inline <audio src=mp3>", () => {
+    const html = '<audio src="/artifacts/images/2026/04/track.mp3"></audio>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.equal(out, html);
+  });
+
+  it("skips media URL with query string (?v=…cache-bust)", () => {
+    const html = '<video src="/artifacts/images/2026/04/clip.mp4?v=123"></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.equal(out, html);
+  });
 });

--- a/test/routes/test_pdfInlineImages.ts
+++ b/test/routes/test_pdfInlineImages.ts
@@ -211,3 +211,39 @@ describe("inlineImages — attribute-boundary correctness (Codex #1023 review)",
     assert.match(out, /\bsrc="data:image\/png;base64,/);
   });
 });
+
+describe("inlineImages — extended tag coverage (Stage B)", () => {
+  it("inlines <source src> on a video child", () => {
+    const html = '<video controls><source src="/artifacts/images/2026/04/foo.png" type="image/png"></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /<source src="data:image\/png;base64,[A-Za-z0-9+/=]+"/);
+  });
+
+  it("inlines <video poster>", () => {
+    const html = '<video poster="/artifacts/images/2026/04/foo.png" controls></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /<video poster="data:image\/png;base64,[A-Za-z0-9+/=]+"/);
+  });
+
+  it("inlines <audio src>", () => {
+    // The asset is a PNG but the `<audio>` tag still routes through
+    // the same resolver — the Stage B change is purely about which
+    // tag/attribute pairs get scanned, not MIME validation.
+    const html = '<audio src="/artifacts/images/2026/04/foo.png"></audio>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /<audio src="data:image\/png;base64,[A-Za-z0-9+/=]+"/);
+  });
+
+  it("inlines both <video poster> and <video src> on the same tag", () => {
+    const html = '<video poster="/artifacts/images/2026/04/foo.png" src="/artifacts/images/2026/04/foo.png"></video>';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /poster="data:image\/png;base64,/);
+    assert.match(out, /src="data:image\/png;base64,/);
+  });
+
+  it("does NOT touch <source srcset> (deferred)", () => {
+    const html = '<source srcset="/artifacts/images/2026/04/foo.png 2x" type="image/png">';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.equal(out, html);
+  });
+});

--- a/test/routes/test_pdfInlineImages.ts
+++ b/test/routes/test_pdfInlineImages.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { inlineImages } from "../../server/api/routes/pdf.js";
+import { inlineImages, shouldSkipMediaForPdf } from "../../server/api/routes/pdf.js";
 
 let workspaceRoot: string;
 let imagesDir: string;
@@ -275,5 +275,33 @@ describe("inlineImages — extended tag coverage (Stage B)", () => {
     const html = '<video src="/artifacts/images/2026/04/clip.mp4?v=123"></video>';
     const out = inlineImages(html, { workspaceRoot });
     assert.equal(out, html);
+  });
+});
+
+describe("shouldSkipMediaForPdf", () => {
+  it("returns true for plain media extensions", () => {
+    assert.equal(shouldSkipMediaForPdf("/artifacts/images/2026/04/clip.mp4"), true);
+    assert.equal(shouldSkipMediaForPdf("/track.mp3"), true);
+    assert.equal(shouldSkipMediaForPdf("/v.webm"), true);
+  });
+
+  it("returns true for media URL with query / fragment", () => {
+    assert.equal(shouldSkipMediaForPdf("/clip.mp4?v=123"), true);
+    assert.equal(shouldSkipMediaForPdf("/clip.mp4#t=10"), true);
+  });
+
+  it("returns false for image URL even when query string mentions media (codex iter-1 #1028)", () => {
+    // `foo.png?cacheBust=clip.mp4` is a PNG. Without pathname slicing
+    // the regex over the whole URL would false-positive on `.mp4`
+    // at the end. With slicing, only `foo.png` is tested -> no skip.
+    assert.equal(shouldSkipMediaForPdf("/artifacts/images/2026/04/foo.png?cacheBust=clip.mp4"), false);
+    assert.equal(shouldSkipMediaForPdf("/foo.png#anchor.mp4"), false);
+    assert.equal(shouldSkipMediaForPdf("/foo.jpg?ref=bar.mp3"), false);
+  });
+
+  it("returns false for non-media extensions", () => {
+    assert.equal(shouldSkipMediaForPdf("/foo.png"), false);
+    assert.equal(shouldSkipMediaForPdf("/foo.jpg"), false);
+    assert.equal(shouldSkipMediaForPdf("/foo.svg"), false);
   });
 });

--- a/test/routes/test_pdfInlineImages.ts
+++ b/test/routes/test_pdfInlineImages.ts
@@ -276,6 +276,22 @@ describe("inlineImages — extended tag coverage (Stage B)", () => {
     const out = inlineImages(html, { workspaceRoot });
     assert.equal(out, html);
   });
+
+  it("inlines a PNG with cache-bust query string end-to-end (codex iter-2 #1028)", () => {
+    // The skip regex correctly recognises this as an image (codex
+    // iter-1 fix), but the resolver must also strip the query before
+    // hitting the filesystem — otherwise a real `<img src="…png?v=1">`
+    // still fails to inline. End-to-end test pins both paths.
+    const html = '<img src="/artifacts/images/2026/04/foo.png?cacheBust=clip.mp4">';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /^<img src="data:image\/png;base64,[A-Za-z0-9+/=]+">$/);
+  });
+
+  it("inlines a PNG with fragment end-to-end", () => {
+    const html = '<img src="/artifacts/images/2026/04/foo.png#anchor">';
+    const out = inlineImages(html, { workspaceRoot });
+    assert.match(out, /^<img src="data:image\/png;base64,[A-Za-z0-9+/=]+">$/);
+  });
 });
 
 describe("shouldSkipMediaForPdf", () => {

--- a/test/utils/image/test_htmlSrcAttrs.ts
+++ b/test/utils/image/test_htmlSrcAttrs.ts
@@ -1,0 +1,146 @@
+// Tests for the shared HTML URL-attribute rewriter (#1011 Stage B).
+// Two callers depend on this:
+//   - `rewriteImgSrcAttrsInHtml` (markdown surface, browser)
+//   - `inlineImages` (PDF surface, server)
+// Both wire a transform callback and inherit identical tag / quote /
+// attribute-iteration semantics from this helper.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { transformResolvableUrlsInHtml, RESOLVABLE_TAG_ATTRS } from "../../../src/utils/image/htmlSrcAttrs";
+
+// `transform` that wraps every value with `R(...)` so substitutions
+// are visible at a glance and unchanged input is obvious.
+function tag(url: string): string {
+  return `R(${url})`;
+}
+
+describe("transformResolvableUrlsInHtml — tag coverage", () => {
+  it("rewrites <img src>", () => {
+    const out = transformResolvableUrlsInHtml('<img src="a.png">', tag);
+    assert.equal(out, '<img src="R(a.png)">');
+  });
+
+  it("rewrites <source src>", () => {
+    const out = transformResolvableUrlsInHtml('<source src="a.webm" type="video/webm">', tag);
+    assert.equal(out, '<source src="R(a.webm)" type="video/webm">');
+  });
+
+  it("rewrites <video poster> and <video src>", () => {
+    const out = transformResolvableUrlsInHtml('<video poster="p.jpg" src="m.mp4">', tag);
+    assert.equal(out, '<video poster="R(p.jpg)" src="R(m.mp4)">');
+  });
+
+  it("rewrites <audio src>", () => {
+    const out = transformResolvableUrlsInHtml('<audio src="a.ogg" controls>', tag);
+    assert.equal(out, '<audio src="R(a.ogg)" controls>');
+  });
+
+  it("does NOT rewrite <a href> (out of scope)", () => {
+    const html = '<a href="link.html">x</a>';
+    assert.equal(transformResolvableUrlsInHtml(html, tag), html);
+  });
+
+  it("does NOT rewrite <iframe src> (out of scope — iframe loading is a separate concern)", () => {
+    const html = '<iframe src="page.html"></iframe>';
+    assert.equal(transformResolvableUrlsInHtml(html, tag), html);
+  });
+
+  it("walks a <picture> with <source> + inner <img>", () => {
+    const html = '<picture><source srcset="hi.webp" type="image/webp"><source src="m.webp"><img src="lo.png" alt="x"></picture>';
+    const out = transformResolvableUrlsInHtml(html, tag);
+    // <source srcset> deferred — only `src` rewrites for now
+    assert.match(out, /<source srcset="hi\.webp"/);
+    assert.match(out, /<source src="R\(m\.webp\)"/);
+    assert.match(out, /<img src="R\(lo\.png\)"/);
+  });
+});
+
+describe("transformResolvableUrlsInHtml — RESOLVABLE_TAG_ATTRS / regex lockstep", () => {
+  it("the outer regex covers every tag listed in the map", () => {
+    // If a future contributor adds a tag to the map but forgets to
+    // extend the alternation in `RESOLVABLE_TAG_OUTER_RE`, the regex
+    // simply wouldn't fire on that tag — silent regression. Pin it.
+    for (const tagName of Object.keys(RESOLVABLE_TAG_ATTRS)) {
+      const html = `<${tagName} src="a.png">`;
+      const out = transformResolvableUrlsInHtml(html, tag);
+      assert.notEqual(out, html, `tag ${tagName} declared in RESOLVABLE_TAG_ATTRS must be matched by the outer regex`);
+    }
+  });
+
+  it("returns null from transform → attribute unchanged", () => {
+    const out = transformResolvableUrlsInHtml('<img src="skip.png">', () => null);
+    assert.equal(out, '<img src="skip.png">');
+  });
+
+  it("returns the original substring when no recognised tag matches", () => {
+    const html = "<div><span>plain text</span></div>";
+    assert.equal(transformResolvableUrlsInHtml(html, tag), html);
+  });
+});
+
+describe("transformResolvableUrlsInHtml — quoting variations", () => {
+  it("preserves double quotes", () => {
+    assert.equal(transformResolvableUrlsInHtml('<img src="a">', tag), '<img src="R(a)">');
+  });
+
+  it("preserves single quotes", () => {
+    assert.equal(transformResolvableUrlsInHtml("<img src='a'>", tag), "<img src='R(a)'>");
+  });
+
+  it("preserves unquoted (no spaces in value)", () => {
+    assert.equal(transformResolvableUrlsInHtml("<img src=a.png>", tag), '<img src="R(a.png)">');
+  });
+
+  it("respects quoted attribute values containing >", () => {
+    // `alt="x>y"` must not terminate the tag at the > inside the alt.
+    const out = transformResolvableUrlsInHtml('<img alt="x>y" src="a">', tag);
+    assert.equal(out, '<img alt="x>y" src="R(a)">');
+  });
+
+  it("does not capture a stray opening quote (malformed input)", () => {
+    // `<img src="aaaa` (no closing quote) — refuse to capture; leave
+    // alone rather than emit a corrupt rewrite.
+    const html = '<img src="aaaa>';
+    assert.equal(transformResolvableUrlsInHtml(html, tag), html);
+  });
+
+  it("ignores a `src=`-shaped substring inside another attribute's value", () => {
+    // The alt value contains `src=oops`; the real attribute is the
+    // following `src=real`. Only the real one should rewrite.
+    const out = transformResolvableUrlsInHtml('<img alt="x src=oops" src="real">', tag);
+    assert.equal(out, '<img alt="x src=oops" src="R(real)">');
+  });
+
+  it("ignores namespaced look-alikes (xlink:src on a recognised tag)", () => {
+    const html = '<img xlink:src="ns.png">';
+    assert.equal(transformResolvableUrlsInHtml(html, tag), html);
+  });
+});
+
+describe("transformResolvableUrlsInHtml — edge cases", () => {
+  it("returns empty string for empty input", () => {
+    assert.equal(transformResolvableUrlsInHtml("", tag), "");
+  });
+
+  it("ReDoS-safe: 100KB no-closing-> input runs in linear time", () => {
+    const blob = `<img src="a"${" alt=".repeat(1)} ${"x".repeat(100_000)}`;
+    const start = Date.now();
+    transformResolvableUrlsInHtml(blob, tag);
+    const elapsed = Date.now() - start;
+    // 1s ceiling — generous; worst observed is single-digit ms.
+    assert.ok(elapsed < 1000, `100KB probe took ${elapsed}ms`);
+  });
+
+  it("self-closing tag form still rewrites", () => {
+    assert.equal(transformResolvableUrlsInHtml('<img src="a" />', tag), '<img src="R(a)" />');
+  });
+
+  it("rewrites even when the value is empty (caller decides via `if (!url) return null` pattern)", () => {
+    // Helper passes empty value to caller as empty string; caller's
+    // standard pattern is to return null for empty / unwanted values.
+    // Document the wire shape: the helper itself does NOT skip empty.
+    const out = transformResolvableUrlsInHtml('<img src="">', () => "REPLACED");
+    assert.equal(out, '<img src="">', "empty values short-circuit before transform");
+  });
+});

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -674,3 +674,48 @@ describe("rewriteMarkdownImageRefs — adversarial markdown", () => {
     assert.ok(!out.includes("<script>alert(1)</script>") || out.includes(markdownSource));
   });
 });
+
+describe("rewriteImgSrcAttrsInHtml — extended tag coverage (Stage B)", () => {
+  it("rewrites <source src> on a video child", () => {
+    const html = '<video controls><source src="video.mp4" type="video/mp4"></video>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.match(out, /<source src="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Fvideo\.mp4"/);
+  });
+
+  it("rewrites <video poster>", () => {
+    const html = '<video poster="thumb.png" controls></video>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.match(out, /<video poster="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Fthumb\.png"/);
+  });
+
+  it("rewrites <video src>", () => {
+    const html = '<video src="movie.webm"></video>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.match(out, /<video src="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Fmovie\.webm"/);
+  });
+
+  it("rewrites <audio src>", () => {
+    const html = '<audio src="track.ogg" controls></audio>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.match(out, /<audio src="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Ftrack\.ogg"/);
+  });
+
+  it("rewrites all attributes on <video poster> + <video src> together", () => {
+    const html = '<video poster="thumb.png" src="movie.mp4"></video>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.match(out, /poster="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Fthumb\.png"/);
+    assert.match(out, /src="\/api\/files\/raw\?path=data%2Fwiki%2Fpages%2Fmovie\.mp4"/);
+  });
+
+  it("does NOT rewrite <source srcset> (deferred to follow-up)", () => {
+    const html = '<source srcset="hi.png 2x, lo.png 1x" type="image/png">';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.equal(out, html, "srcset is comma-separated descriptor list — Stage B follow-up");
+  });
+
+  it("leaves <video poster> unchanged when http(s)", () => {
+    const html = '<video poster="https://cdn.example.com/poster.jpg"></video>';
+    const out = rewriteImgSrcAttrsInHtml(html, "data/wiki/pages");
+    assert.equal(out, html);
+  });
+});


### PR DESCRIPTION
## Summary

Stage B of #1011's markdown / wiki image-coverage rollout. Extracts the duplicated regex / quote-handling / attribute-iteration logic from the two surfaces (browser markdown rewriter + server PDF inliner) into a single shared helper, then extends coverage to `<source>`, `<video poster | src>`, `<audio src>`.

The two surfaces previously kept their own copy of the same regex shape with a `// Mirrors the shape used by …` comment. Mirroring drifts the moment one side adds a tag — exactly the situation Stage B was meant to prevent. Single helper, single tag list, both surfaces share semantics by construction.

## Items to Confirm / Review

- **`RESOLVABLE_TAG_ATTRS` is the only place where tag / attribute pairs live**. Adding a row extends both surfaces simultaneously. The outer regex's tag alternation is hand-listed (lint-friendly const), and a unit test pins lockstep so a future contributor adding a row to the map but forgetting the regex trips the test.
- **Three deferred targets, called out explicitly in code + comment + plan**:
  - `srcset` (`<img>` / `<source>`) — comma-separated descriptor list, needs separate split/rewrite pass.
  - SVG `<image href>` — gap table #9, plan §修正提案 P3-A.
  - CSS `url()` in `style=` — gap table #8, same.
- **No security regression**: workspace-boundary check (`resolveWithinRoot` server-side, `resolveWorkspacePath` browser-side) still gates every URL after the helper hands it back. The shared helper has no I/O — it's purely structural.
- **PDF surface API unchanged**: `inlineImages(html, options)` keeps its signature; only its body shrinks.
- **Markdown surface API unchanged**: `rewriteImgSrcAttrsInHtml(html, basePath)` keeps its name + signature.

## User Prompt

> B進められる？ → 続けて

(Triggered after #1023 / #1024 merged unblocked Stage B; per the user's explicit DRY guidance two messages back, the shared helper extraction is folded into the same PR rather than deferred.)

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn build` clean
- [x] `yarn test` — 4 new describe blocks in `test_htmlSrcAttrs.ts` + Stage B coverage tests on both surfaces, all green; existing markdown / PDF tests pass without modification
- [ ] CI on the PR
- [ ] Manual: open the PR #1013 fixture wiki page and verify ① `<source src>` inside `<picture>` / `<video>`, ② `<video poster>`, ③ `<audio src>` all render. Then PDF download the same page and verify the same tags inline as base64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * PDF generation now properly embeds resources for video elements (including poster images), audio sources, and images
  * Extended media URL resolution across multiple HTML element types in generated documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->