### PR TITLE
chore(self-repair): convert IMAGE_REPAIR_INLINE_SCRIPT to const/let

### DIFF
--- a/src/composables/useImageErrorRepair.ts
+++ b/src/composables/useImageErrorRepair.ts
@@ -37,28 +37,28 @@ const SRCSET_TOKEN_RE = /[^\s,]+/g;
 // `useGlobalImageErrorRepair` is active in the app shell.
 export const IMAGE_REPAIR_INLINE_SCRIPT = `
 document.addEventListener("error", function (event) {
-  var target = event.target;
+  const target = event.target;
   if (!target) return;
-  var pattern = ${IMAGE_REPAIR_PATTERN.toString()};
+  const pattern = ${IMAGE_REPAIR_PATTERN.toString()};
   function fixImg(img) {
     if (img.dataset.imageRepairTried) return;
-    var m = String(img.src).match(pattern);
+    const m = String(img.src).match(pattern);
     if (!m) return;
     img.dataset.imageRepairTried = "1";
     img.src = "/" + m[0];
   }
   function fixSource(src) {
     if (src.dataset.imageRepairTried) return;
-    var changed = false;
-    var srcAttr = src.getAttribute("src");
+    let changed = false;
+    const srcAttr = src.getAttribute("src");
     if (srcAttr) {
-      var m = srcAttr.match(pattern);
+      const m = srcAttr.match(pattern);
       if (m) { src.setAttribute("src", "/" + m[0]); changed = true; }
     }
     if (src.srcset) {
-      var orig = src.srcset;
-      var next = orig.replace(/[^\\s,]+/g, function (tok) {
-        var mm = tok.match(pattern);
+      const orig = src.srcset;
+      const next = orig.replace(/[^\\s,]+/g, function (tok) {
+        const mm = tok.match(pattern);
         return mm ? "/" + mm[0] : tok;
       });
       if (next !== orig) { src.srcset = next; changed = true; }
@@ -67,16 +67,12 @@ document.addEventListener("error", function (event) {
   }
   if (target.tagName === "IMG") {
     fixImg(target);
-    var pic = target.closest && target.closest("picture");
-    if (pic) {
-      var sources = pic.querySelectorAll("source");
-      for (var i = 0; i < sources.length; i++) fixSource(sources[i]);
-    }
+    const pic = target.closest && target.closest("picture");
+    if (pic) for (const s of pic.querySelectorAll("source")) fixSource(s);
   } else if (target.tagName === "SOURCE") {
     fixSource(target);
   } else if (target.tagName === "AUDIO" || target.tagName === "VIDEO") {
-    var mediaSources = target.querySelectorAll(":scope > source");
-    for (var j = 0; j < mediaSources.length; j++) fixSource(mediaSources[j]);
+    for (const s of target.querySelectorAll(":scope > source")) fixSource(s);
   }
 }, true);
 `.trim();


### PR DESCRIPTION
## Summary

Drops the last `var` usages in the codebase. They lived inside the `IMAGE_REPAIR_INLINE_SCRIPT` template literal in `src/composables/useImageErrorRepair.ts` — left over from when the snippet was written ES5-safe for old iframe runtimes. mulmoclaude targets modern browsers, so const/let is fine there.

## Context

The project already enforces:

- `no-var: error` (via `eslint:recommended`)
- `prefer-const: error`

…but ESLint cannot see inside string templates, so the inline script was outside the rule's reach. This PR is purely visual / convention alignment.

## Items to Confirm / Review

- The mutated variable (`changed`) becomes `let`; everything else becomes `const`.
- The two manual counter for-loops collapse to `for (const s of ...)` — NodeList iteration is supported in every browser we ship to.
- Behaviour is identical: 14/14 existing unit tests still pass, and the parity guards on the inline-script body (tag-name branches + `closest("picture")` + `:scope > source`) are unaffected by the var/const swap.

## Verification

- `yarn lint` → 0 errors
- `yarn typecheck` → ✓
- `yarn build` → ✓
- `npx tsx --test test/composables/test_useImageErrorRepair.ts` → 14/14 passing
- `grep "var " src/ server/ packages/ --include="*.ts" --include="*.js" --include="*.vue"` → only matches in comments / esbuild output / lang strings (no actual `var` declarations remain in production source)

## User Prompt

> 今mergeしたPR,変数にvarをつかっていた。varは禁止で基本const, どうしても必要なときだけletにしたい。lintで制限できる？
>
> はい。できれば全部変更してほしい。