### PR TITLE
fix(attachments): preserve original file extension on save

### DIFF
--- a/server/api/routes/attachment.ts
+++ b/server/api/routes/attachment.ts
@@ -66,7 +66,7 @@ router.post(
       bytes: Math.floor((parsed.base64.length * 3) / 4),
     });
     try {
-      const original = await saveAttachment(parsed.base64, parsed.mimeType);
+      const original = await saveAttachment(parsed.base64, parsed.mimeType, filename);
       if (parsed.mimeType === PPTX_MIME) {
         const pdfBuf = await convertPptxToPdf(parsed.base64);
         if (!pdfBuf) {

--- a/server/utils/files/attachment-store.ts
+++ b/server/utils/files/attachment-store.ts
@@ -39,10 +39,11 @@ async function safeResolve(relativePath: string): Promise<string> {
   return result;
 }
 
-// MIME ↔ extension mapping. Kept narrow on purpose — anything not
-// in this table falls back to `.bin` so we don't have to guess.
-// `inferMimeFromExtension()` is the inverse, used when reading a
-// stored file back to build a Claude content block.
+// MIME ↔ extension mapping. Used as a fallback when the upload has
+// no usable filename — saveAttachment() prefers the original file's
+// extension so types outside this table (e.g. text/x-python → .py)
+// still round-trip. `inferMimeFromExtension()` is the inverse, used
+// when reading a stored file back to build a Claude content block.
 const MIME_EXT: Readonly<Record<string, string>> = {
   "image/png": ".png",
   "image/jpeg": ".jpg",
@@ -96,9 +97,37 @@ export function extensionForMime(mimeType: string): string {
   return MIME_EXT[mimeType] ?? ".bin";
 }
 
+// Pick the on-disk extension. Prefer the original filename's
+// extension when present and well-formed — this preserves types
+// outside MIME_EXT (e.g. text/x-python → `.py`) so the round-trip
+// through inferMimeFromExtension() succeeds. We only honour the
+// filename extension when we can read it back unambiguously: either
+// it's already a known extension, or the upload's MIME is text/* (so
+// the text/plain fallback below is safe). Image/* MIMEs we don't
+// recognise (e.g. image/heic) still fall through to MIME_EXT —
+// returning `.bin` is better than writing binary bytes the loader
+// would later interpret as text.
+function pickExtension(filename: string | undefined, mimeType: string): string {
+  if (filename) {
+    const ext = path.posix.extname(filename).toLowerCase();
+    if (/^\.[a-z0-9]+$/.test(ext) && (EXT_MIME[ext] || mimeType.startsWith("text/"))) {
+      return ext;
+    }
+  }
+  return extensionForMime(mimeType);
+}
+
+// Map an on-disk filename back to a MIME type. Known extensions
+// resolve via EXT_MIME. Unknown extensions fall back to text/plain
+// because saveAttachment() only writes a non-EXT_MIME extension when
+// the source was text/*. `.bin` (anything we couldn't classify on
+// save) returns undefined so the agent loop skips bytes rather than
+// shipping binary as text.
 export function inferMimeFromExtension(filename: string): string | undefined {
   const ext = path.extname(filename).toLowerCase();
-  return EXT_MIME[ext];
+  if (EXT_MIME[ext]) return EXT_MIME[ext];
+  if (ext === ".bin") return undefined;
+  return "text/plain";
 }
 
 export interface SavedAttachment {
@@ -111,11 +140,14 @@ export interface SavedAttachment {
 
 /** Save a single attachment under data/attachments/YYYY/MM/. The
  *  caller picks the ID; companions (e.g. PPTX → PDF) reuse it via
- *  `saveCompanion()` so they share the same numeric prefix. */
-export async function saveAttachment(base64Data: string, mimeType: string): Promise<SavedAttachment> {
+ *  `saveCompanion()` so they share the same numeric prefix.
+ *  `originalFilename` (when supplied) drives the on-disk extension
+ *  so types outside MIME_EXT — e.g. `script.py` (text/x-python) —
+ *  preserve their extension instead of collapsing to `.bin`. */
+export async function saveAttachment(base64Data: string, mimeType: string, originalFilename?: string): Promise<SavedAttachment> {
   await ensureAttachmentsDir();
   const partition = yearMonthUtc();
-  const ext = extensionForMime(mimeType);
+  const ext = pickExtension(originalFilename, mimeType);
   const filename = `${shortId()}${ext}`;
   const absPath = path.join(ATTACHMENTS_DIR, partition, filename);
   await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));

--- a/src/App.vue
+++ b/src/App.vue
@@ -840,11 +840,11 @@ async function sendMessage(text?: string) {
   const fileSnapshot = pastedFile.value;
   pastedFile.value = null;
 
-  // Pasted/dropped images get pre-uploaded to a workspace file so the
-  // server (and the LLM downstream) sees a relative path, not a data:
-  // URI. Non-image attachments still flow as data URIs through the
-  // legacy mergeAttachments() path. On upload failure, restore both
-  // userInput and pastedFile so the user can retry without retyping.
+  // Pasted/dropped/picked attachments (image, PDF, text, Office, …)
+  // are pre-uploaded to a workspace file so the server (and the LLM
+  // downstream) sees a relative path, not a data: URI. On upload
+  // failure, restore both userInput and pastedFile so the user can
+  // retry without retyping.
   let attachmentForRequest: string | undefined;
   if (fileSnapshot) {
     const resolved = await resolvePastedAttachment(fileSnapshot);
@@ -852,7 +852,7 @@ async function sendMessage(text?: string) {
       userInput.value = message;
       pastedFile.value = fileSnapshot;
       const recoverySession = sessionMap.get(currentSessionId.value);
-      if (recoverySession) pushErrorMessage(recoverySession, `Failed to attach image: ${resolved.error}`);
+      if (recoverySession) pushErrorMessage(recoverySession, `Failed to attach file: ${resolved.error}`);
       return;
     }
     attachmentForRequest = resolved.value;


### PR DESCRIPTION
## Summary

Stacked follow-up on #1046 addressing review feedback that non-image attachments outside `MIME_EXT` (e.g. `script.py` → `text/x-python`) were collapsing to `.bin` on save and losing their type round-trip.

- `saveAttachment()` now accepts an optional `originalFilename`; `pickExtension()` prefers the source filename's extension when it is well-formed and resolvable on read (already in `EXT_MIME` or the upload is `text/*`)
- `inferMimeFromExtension()` falls back to `text/plain` for unknown extensions and returns `undefined` for `.bin` so the agent loop skips bytes it cannot classify rather than shipping binary as text
- Broaden the upload-failure toast from "Failed to attach image" to "Failed to attach file" now that paste/drop pre-upload covers all attachment kinds

## Test plan

- [ ] Paste/drop a `.py` file — saved file keeps `.py`, agent loop reads it back as `text/plain`
- [ ] Paste/drop a `.png` — still saved as `.png` via the MIME fallback path
- [ ] Upload an unrecognised binary (e.g. `image/heic`) — falls through to `.bin`, agent loop skips it instead of decoding as text
- [ ] Trigger an upload failure — toast reads "Failed to attach file"

🤖 Generated with [Claude Code](https://claude.com/claude-code)