### PR TITLE
feat(chat): show attachment chips on user messages

### DIFF
--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -57,10 +57,13 @@ export interface StartChatParams {
   /** Bridge-only legacy carrier for "the user picked this image".
    *  No in-tree bridge populates this today; the field stays on the
    *  type so external bridge clients on older protocol versions still
-   *  type-check. Accepts either a workspace path or a `data:` URL —
-   *  the host app's `startChat` folds it into `attachments[]` before
-   *  any other processing. The Vue UI never sets this; it sends
-   *  path-only attachments via `attachments[]` instead. */
+   *  type-check. Only workspace paths are accepted — `data:` URLs
+   *  are no longer supported and the host app drops them with a
+   *  warn. Bridges that need to ship raw bytes should use the
+   *  modern `attachments[]` field with `{ mimeType, data }` entries;
+   *  the host app persists those to `data/attachments/YYYY/MM/`
+   *  server-side and rewrites them as path-bearing attachments
+   *  before any other processing. */
   selectedImageData?: string;
   attachments?: Attachment[];
   /** Session origin — application-defined (e.g. "human", "bridge") */

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -190,8 +190,18 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     }
   }
 
+  // Collect every workspace path the user attached for this turn so
+  // the user message persists with them. The Vue UI surfaces these as
+  // chips next to the bubble in stack/single mode and after a reload.
+  // Inline (data:) bytes coming from a bridge don't carry a path and
+  // so don't surface as chips — only path-bearing attachments do.
+  const attachedPaths = collectAttachedPaths(normalisedAttachments);
+
   // Append user message for this turn
-  await appendSessionLine(chatSessionId, JSON.stringify({ source: "user", type: EVENT_TYPES.text, message }));
+  await appendSessionLine(
+    chatSessionId,
+    JSON.stringify({ source: "user", type: EVENT_TYPES.text, message, ...(attachedPaths.length > 0 ? { attachments: attachedPaths } : {}) }),
+  );
 
   // Broadcast the user message so other tabs viewing this session
   // see the input in real time. Runs AFTER beginRun so a 409 never
@@ -200,6 +210,7 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     type: EVENT_TYPES.text,
     source: "user",
     message,
+    ...(attachedPaths.length > 0 ? { attachments: attachedPaths } : {}),
   });
 
   const role = getRole(roleId);
@@ -258,6 +269,20 @@ interface RequestExtras {
    *  the request carried only inline bridge bytes (no paths) or
    *  nothing at all. */
   attachedFilePaths: string[];
+}
+
+/** Pluck workspace-relative paths out of `attachments[]`. Used for
+ *  persistence + broadcast of the user message: the Vue UI renders
+ *  these as attachment chips next to the chat bubble. Inline (data:)
+ *  bytes carry no path and are skipped. Order matches declaration
+ *  order so chip order matches the order the user attached them. */
+function collectAttachedPaths(attachments: Attachment[] | undefined): string[] {
+  if (!attachments || attachments.length === 0) return [];
+  const paths: string[] = [];
+  for (const att of attachments) {
+    if (typeof att.path === "string" && att.path.length > 0) paths.push(att.path);
+  }
+  return paths;
 }
 
 /** Bridge-only compat: external bridge clients may still ship a

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -41,9 +41,8 @@ import { isSessionOrigin, type SessionOrigin } from "../../../src/types/session.
 // import { publishNotification } from "../../events/notifications.js";
 import { env } from "../../system/env.js";
 import type { Attachment } from "@mulmobridge/protocol";
-import { parseDataUrl } from "@mulmobridge/client";
 import { isImagePath, loadImageBase64 } from "../../utils/files/image-store.js";
-import { isAttachmentPath, loadAttachmentBase64, inferMimeFromExtension } from "../../utils/files/attachment-store.js";
+import { isAttachmentPath, loadAttachmentBase64, inferMimeFromExtension, saveAttachment } from "../../utils/files/attachment-store.js";
 import { errorMessage } from "../../utils/errors.js";
 
 const router = Router();
@@ -103,11 +102,15 @@ export interface StartChatParams {
   /** Bridge-only legacy carrier for "the user picked this image".
    *  No in-tree bridge sets it today; it remains on the type so
    *  external bridge clients that populate it from older protocol
-   *  versions continue to work. The Vue UI never sets this — paste/
-   *  drop and sidebar picks ride on `attachments[]` as path-only
-   *  entries instead. When set, `startChat` normalises the value
-   *  into a synthetic `Attachment` and prepends it to `attachments`
-   *  before any downstream processing. */
+   *  versions continue to work. Only workspace paths
+   *  (`data/attachments/...` or `artifacts/images/...`) are accepted
+   *  — `data:` URLs are no longer supported and are dropped with a
+   *  warn. Bridges that need to ship raw bytes should use the
+   *  modern `attachments[]` field with `{ mimeType, data }` entries;
+   *  those get persisted to `data/attachments/YYYY/MM/` server-side
+   *  and rewritten as path-bearing attachments. The Vue UI never
+   *  sets this — paste/drop and sidebar picks ride on
+   *  `attachments[]` as path-only entries directly. */
   selectedImageData?: string;
   attachments?: Attachment[];
   /** Where this session originates (#486). Accepts string for
@@ -176,10 +179,40 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     return { kind: "error", error: "Session is already running", status: 409 };
   }
 
-  // Run is committed. Now persist the user message so callers (and
-  // other tabs) see the turn. Metadata first — it powers the sidebar
-  // title cache; the append follows so the jsonl is always a
-  // superset of what metadata advertised.
+  // Run is committed. Process attachments next so any failure here
+  // rolls the run back via `endRun` before we persist or broadcast a
+  // user message — leaving an orphan turn on disk when the request
+  // ultimately rejects would mislead every viewer of this session.
+  // Three things happen in this block, all guarded together:
+  //   1. Bridge inline-bytes (`{ data, mimeType }`) get saved to
+  //      `data/attachments/YYYY/MM/` and rewritten as path-bearing
+  //      attachments. After this every Attachment has a `path`.
+  //   2. `collectAttachedPaths` extracts the workspace paths to
+  //      persist on the user JSONL line and broadcast on the SSE
+  //      event so the UI can render chips for the turn.
+  //   3. `prepareRequestExtras` loads bytes off disk for the LLM
+  //      request. With (1) above this is now a pure path-only walk.
+  // A malformed body (e.g. `attachments` not an array) or a
+  // filesystem I/O failure is logged and converted to a 400 here;
+  // beginRun is rolled back so subsequent turns aren't rejected with
+  // 409 forever.
+  let attachedPaths: string[];
+  let extras: RequestExtras;
+  try {
+    const persistedAttachments = await persistInlineBytesAsPaths(normalisedAttachments);
+    attachedPaths = collectAttachedPaths(persistedAttachments);
+    extras = await prepareRequestExtras(persistedAttachments);
+  } catch (err) {
+    log.warn("agent", "attachment processing failed — rolling back run", { chatSessionId, error: errorMessage(err) });
+    abortController.abort();
+    endRun(chatSessionId);
+    return { kind: "error", error: "Invalid attachments payload", status: 400 };
+  }
+
+  // Now persist the user message so callers (and other tabs) see the
+  // turn. Metadata first — it powers the sidebar title cache; the
+  // append follows so the jsonl is always a superset of what metadata
+  // advertised.
   const validOrigin = isSessionOrigin(params.origin) ? params.origin : undefined;
   if (isFirstTurn) {
     await createSessionMeta(chatSessionId, roleId, message, undefined, validOrigin);
@@ -189,13 +222,6 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
       await backfillOrigin(chatSessionId, validOrigin);
     }
   }
-
-  // Collect every workspace path the user attached for this turn so
-  // the user message persists with them. The Vue UI surfaces these as
-  // chips next to the bubble in stack/single mode and after a reload.
-  // Inline (data:) bytes coming from a bridge don't carry a path and
-  // so don't surface as chips — only path-bearing attachments do.
-  const attachedPaths = collectAttachedPaths(normalisedAttachments);
 
   // Append user message for this turn
   await appendSessionLine(
@@ -224,19 +250,6 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     resumed: Boolean(claudeSessionId),
   });
 
-  // Roll the run back if attachment prep throws (e.g. malformed
-  // HTTP body where `attachments` isn't an array). beginRun already
-  // committed; without endRun + abort the session is stuck and every
-  // future turn is rejected with 409.
-  let extras: RequestExtras;
-  try {
-    extras = await prepareRequestExtras(normalisedAttachments);
-  } catch (err) {
-    log.warn("agent", "prepareRequestExtras failed — rolling back run", { chatSessionId, error: errorMessage(err) });
-    abortController.abort();
-    endRun(chatSessionId);
-    return { kind: "error", error: "Invalid attachments payload", status: 400 };
-  }
   const baseMessage = claudeSessionId ? message : prependJournalPointer(message, workspacePath);
   const decoratedMessage = withAttachedFileMarker(baseMessage, extras.attachedFilePaths);
 
@@ -265,19 +278,29 @@ interface RequestExtras {
    *  selected for this turn, in declaration order. Surfaced to the
    *  LLM via one `[Attached file: <path>]` line per entry, prepended
    *  to the user message so path-passing tools (e.g. `editImages`)
-   *  and the LLM itself can reference each file by path. Empty when
-   *  the request carried only inline bridge bytes (no paths) or
-   *  nothing at all. */
+   *  and the LLM itself can reference each file by path.
+   *  `persistInlineBytesAsPaths` ensures every well-formed attachment
+   *  carries a path before this runs, so this is empty only when the
+   *  request had no attachments at all (or every entry was malformed
+   *  and dropped). */
   attachedFilePaths: string[];
 }
 
 /** Pluck workspace-relative paths out of `attachments[]`. Used for
  *  persistence + broadcast of the user message: the Vue UI renders
- *  these as attachment chips next to the chat bubble. Inline (data:)
- *  bytes carry no path and are skipped. Order matches declaration
- *  order so chip order matches the order the user attached them. */
-function collectAttachedPaths(attachments: Attachment[] | undefined): string[] {
-  if (!attachments || attachments.length === 0) return [];
+ *  these as attachment chips next to the chat bubble.
+ *  `persistInlineBytesAsPaths` runs first, so by the time we get
+ *  here every well-formed entry already carries a `path` and chips
+ *  round-trip for bridge attachments too — not just Vue uploads.
+ *  Order matches declaration order so chip order matches the order
+ *  the user attached them.
+ *
+ *  Defensive: `Array.isArray` guards against a malformed HTTP body
+ *  where `attachments` is a truthy non-array. Without it `for...of`
+ *  would throw and bypass the rollback path that calls `endRun`,
+ *  leaving the session locked as running (#1052 review). */
+export function collectAttachedPaths(attachments: Attachment[] | undefined): string[] {
+  if (!Array.isArray(attachments) || attachments.length === 0) return [];
   const paths: string[] = [];
   for (const att of attachments) {
     if (typeof att.path === "string" && att.path.length > 0) paths.push(att.path);
@@ -297,27 +320,79 @@ function mergeBridgeSelectedImage(selectedImageData: string | undefined, attachm
   return attachments && attachments.length > 0 ? [synthetic, ...attachments] : [synthetic];
 }
 
+/** Convert a legacy `selectedImageData` carrier to an `Attachment`.
+ *  Only workspace paths (`data/attachments/...` or `artifacts/images/
+ *  ...`) are accepted — `data:` URLs are no longer supported. A
+ *  bridge that still wants to ship raw bytes should populate the
+ *  modern `attachments[]` field with `{ mimeType, data }` instead;
+ *  `persistInlineBytesAsPaths` then writes those to
+ *  `data/attachments/YYYY/MM/` and turns them into path-bearing
+ *  entries before any other processing. */
 function synthesiseBridgeAttachment(selectedImageData: string | undefined): Attachment | undefined {
   if (!selectedImageData) return undefined;
   if (isAttachmentPath(selectedImageData) || isImagePath(selectedImageData)) {
     return { path: selectedImageData };
   }
-  const parsed = parseDataUrl(selectedImageData);
-  if (parsed) return { mimeType: parsed.mimeType, data: parsed.data };
-  log.warn("agent", "bridge selectedImageData is neither a known path nor a data: URL — dropping", {
+  log.warn("agent", "bridge selectedImageData is not a workspace path — dropping (data: URLs are no longer supported)", {
     valuePreview: selectedImageData.slice(0, 64),
   });
   return undefined;
 }
 
-/** Walk `attachments[]` once, loading bytes from disk for any
- *  path-only entry, and collect every path-bearing entry so the
- *  caller can emit one `[Attached file: <path>]` marker per file.
- *  Two path roots are accepted:
+/** Persist any inline-bytes attachment to disk as a path-bearing
+ *  entry. Bridges over the socket transport (Telegram, LINE, ...)
+ *  ship raw bytes via `Attachment.data` + `Attachment.mimeType`; the
+ *  Vue UI uploads to disk before posting and already carries a
+ *  `path`. By rewriting inline bytes into
+ *  `data/attachments/YYYY/MM/<id>.<ext>` here we get two properties
+ *  the rest of the pipeline relies on:
+ *
+ *    1. Every well-formed attachment carries a workspace path, so
+ *       chips can round-trip for bridge turns the same way they do
+ *       for Vue paste/drop turns (no `data:` chips, no special
+ *       cases downstream).
+ *    2. `prepareRequestExtras` becomes a path-only walk — the inline
+ *       (`{ data, mimeType }`) shape no longer flows past this layer.
+ *
+ *  Defensive: `Array.isArray` mirrors the guard in
+ *  `collectAttachedPaths` so a malformed payload doesn't throw and
+ *  bypass `endRun`. Per-attachment failures are logged and the
+ *  offending entry is dropped — a single bad upload mustn't poison
+ *  the rest of the turn. */
+async function persistInlineBytesAsPaths(attachments: Attachment[] | undefined): Promise<Attachment[] | undefined> {
+  if (!Array.isArray(attachments) || attachments.length === 0) return undefined;
+  const result: Attachment[] = [];
+  for (const att of attachments) {
+    if (typeof att.path === "string" && att.path.length > 0) {
+      result.push(att);
+      continue;
+    }
+    if (typeof att.data === "string" && att.data.length > 0 && typeof att.mimeType === "string" && att.mimeType.length > 0) {
+      try {
+        const saved = await saveAttachment(att.data, att.mimeType);
+        result.push({ path: saved.relativePath, mimeType: saved.mimeType });
+      } catch (err) {
+        log.warn("agent", "failed to persist inline attachment to disk — dropping", {
+          mimeType: att.mimeType,
+          error: errorMessage(err),
+        });
+      }
+      continue;
+    }
+    log.warn("agent", "attachment has neither path nor inline bytes — dropping");
+  }
+  return result.length > 0 ? result : undefined;
+}
+
+/** Walk `attachments[]` once, loading bytes from disk for every
+ *  path-bearing entry, and collect every path so the caller can emit
+ *  one `[Attached file: <path>]` marker per file. Two path roots
+ *  are accepted:
  *
  *    - `data/attachments/...` — paste/drop/file-picker uploads (any
- *      MIME type from the chat input's accept list). MIME is inferred
- *      from the extension chosen at save time.
+ *      MIME type from the chat input's accept list) and the persisted
+ *      form of bridge inline-bytes attachments. MIME is inferred from
+ *      the extension chosen at save time.
  *    - `artifacts/images/...png` — generated / canvas / edited images
  *      a user picked from the sidebar. Always image/png.
  *
@@ -328,35 +403,30 @@ function synthesiseBridgeAttachment(selectedImageData: string | undefined): Atta
  *  attached and can call Read to load it. Multi-file flows (e.g.
  *  paste one image + pick another in the sidebar → "combine these")
  *  rely on every path showing up in the marker so `editImages` can
- *  receive the full list in `imagePaths`. */
+ *  receive the full list in `imagePaths`.
+ *
+ *  Inline (`{ data, mimeType }`) entries no longer reach this layer —
+ *  `persistInlineBytesAsPaths` rewrites them as path-bearing entries
+ *  before this runs. */
 async function prepareRequestExtras(attachments: Attachment[] | undefined): Promise<RequestExtras> {
-  if (!attachments || attachments.length === 0) {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
     return { attachments: undefined, attachedFilePaths: [] };
   }
   const result: Attachment[] = [];
   const attachedFilePaths: string[] = [];
   for (const att of attachments) {
-    const resolved = await resolveAttachment(att);
-    if (resolved) result.push(resolved);
-    if (typeof att.path === "string" && att.path.length > 0) {
-      attachedFilePaths.push(att.path);
+    if (typeof att.path !== "string" || att.path.length === 0) {
+      log.warn("agent", "attachment has no path after normalisation — dropping");
+      continue;
     }
+    const resolved = await loadFromPath(att.path, att.mimeType);
+    if (resolved) result.push(resolved);
+    attachedFilePaths.push(att.path);
   }
   return {
     attachments: result.length > 0 ? result : undefined,
     attachedFilePaths,
   };
-}
-
-async function resolveAttachment(att: Attachment): Promise<Attachment | undefined> {
-  if (typeof att.path === "string" && att.path.length > 0) {
-    return loadFromPath(att.path, att.mimeType);
-  }
-  if (typeof att.data === "string" && att.data.length > 0) {
-    return att;
-  }
-  log.warn("agent", "attachment has neither path nor data — dropping");
-  return undefined;
 }
 
 async function loadFromPath(value: string, declaredMimeType: string | undefined): Promise<Attachment | undefined> {

--- a/src/App.vue
+++ b/src/App.vue
@@ -862,10 +862,15 @@ async function sendMessage(text?: string) {
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
 
-  beginUserTurn(session, message);
+  // Compute attachment paths up-front so they can be persisted on
+  // the user message AND sent to the agent. The sidebar-picked image
+  // lives on the currently-selected result and is read off `session`
+  // before beginUserTurn appends the new user turn.
   const selectedRes = session.toolResults.find((result) => result.uuid === session.selectedResultUuid) ?? undefined;
   const sidebarPickedPath = extractImageData(selectedRes);
   const attachmentPaths = [attachmentForRequest, sidebarPickedPath].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  beginUserTurn(session, message, attachmentPaths.length > 0 ? attachmentPaths : undefined);
 
   ensureSessionSubscription(session);
 

--- a/src/components/SentAttachmentChip.vue
+++ b/src/components/SentAttachmentChip.vue
@@ -1,0 +1,102 @@
+<template>
+  <img v-if="isImage" :src="rawUrl" :alt="basename" :title="basename" :class="imgClass" data-testid="sent-attachment-chip" :data-variant="variant" />
+  <div v-else :title="basename" :class="fileChipClass" data-testid="sent-attachment-chip" :data-variant="variant">
+    <span class="material-icons" :class="[iconColor, fileIconSize]">{{ icon }}</span>
+    <span class="truncate">{{ basename }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
+
+// "thumb" — small, used by the sidebar Preview (single-mode chat list).
+// "block" — fills the canvas content width, used by the in-bubble
+// View on the canvas (stack and single mode).
+type Variant = "thumb" | "block";
+
+const props = withDefaults(
+  defineProps<{
+    /** Workspace-relative path (e.g. `data/attachments/2026/04/<id>.png`). */
+    path: string;
+    variant?: Variant;
+  }>(),
+  { variant: "thumb" },
+);
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+
+const ext = computed(() => {
+  const dot = props.path.lastIndexOf(".");
+  return dot >= 0 ? props.path.slice(dot).toLowerCase() : "";
+});
+
+const basename = computed(() => {
+  const slash = props.path.lastIndexOf("/");
+  return slash >= 0 ? props.path.slice(slash + 1) : props.path;
+});
+
+const isImage = computed(() => IMAGE_EXTS.has(ext.value));
+
+// `/api/files/raw` is auth-exempt for `<img src>` use (see
+// server/index.ts:114) so the path round-trips without a bearer token.
+const rawUrl = computed(() => `${API_ROUTES.files.raw}?path=${encodeURIComponent(props.path)}`);
+
+const imgClass = computed(() =>
+  props.variant === "block"
+    ? // Canvas: stretch to the bubble's content width, cap height so
+      // tall images don't dominate. `object-contain` preserves aspect
+      // ratio when the natural ratio would push past max-h.
+      "block w-full max-h-[60vh] object-contain rounded-lg border border-gray-200 bg-gray-50"
+    : // Sidebar preview: small thumbnail.
+      "block max-h-16 max-w-24 object-contain rounded border border-gray-300 bg-white",
+);
+
+const fileChipClass = computed(() => {
+  const base = "inline-flex items-center gap-1.5 border border-gray-300 bg-white rounded text-gray-700";
+  return props.variant === "block" ? `${base} px-3 py-2 text-sm max-w-full` : `${base} px-2 py-1 text-xs`;
+});
+
+const fileIconSize = computed(() => (props.variant === "block" ? "text-xl" : "text-base"));
+
+const icon = computed(() => {
+  switch (ext.value) {
+    case ".pdf":
+      return "picture_as_pdf";
+    case ".docx":
+      return "description";
+    case ".xlsx":
+    case ".csv":
+      return "table_chart";
+    case ".pptx":
+      return "slideshow";
+    case ".txt":
+    case ".md":
+      return "article";
+    case ".json":
+    case ".xml":
+    case ".yaml":
+    case ".yml":
+    case ".toml":
+      return "data_object";
+    default:
+      return "insert_drive_file";
+  }
+});
+
+const iconColor = computed(() => {
+  switch (ext.value) {
+    case ".pdf":
+      return "text-red-500";
+    case ".docx":
+      return "text-blue-500";
+    case ".xlsx":
+    case ".csv":
+      return "text-green-600";
+    case ".pptx":
+      return "text-orange-500";
+    default:
+      return "text-gray-500";
+  }
+});
+</script>

--- a/src/plugins/textResponse/Preview.vue
+++ b/src/plugins/textResponse/Preview.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="preview-text p-2 text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
+  <div class="p-2">
+    <div class="preview-text text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
+    <div v-if="attachments.length > 0" class="flex flex-wrap gap-1 mt-1.5" data-testid="text-response-preview-attachments">
+      <SentAttachmentChip v-for="path in attachments" :key="path" :path="path" variant="thumb" />
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -7,6 +12,7 @@ import { computed } from "vue";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "./types";
+import SentAttachmentChip from "../../components/SentAttachmentChip.vue";
 
 const props = defineProps<{
   result: ToolResultComplete<TextResponseData>;
@@ -26,6 +32,8 @@ const textColorClass = computed(() => {
 });
 
 const previewText = computed(() => markdownToPlainText(props.result.data?.text ?? ""));
+
+const attachments = computed<string[]>(() => props.result.data?.attachments ?? []);
 
 function markdownToPlainText(markdown: string): string {
   const html = marked(markdown, { breaks: true, gfm: true }) as string;

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -24,6 +24,9 @@
                 </div>
                 <!-- eslint-disable-next-line vue/no-v-html -- marked.parse output of app-owned assistant response text; trusted in-process render -->
                 <div class="markdown-content prose prose-slate max-w-none leading-relaxed text-gray-900" v-html="renderedHtml"></div>
+                <div v-if="messageAttachments.length > 0" class="space-y-3 mt-3" data-testid="text-response-attachments">
+                  <SentAttachmentChip v-for="path in messageAttachments" :key="path" :path="path" variant="block" />
+                </div>
               </div>
             </div>
           </div>
@@ -52,6 +55,7 @@ import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import type { ToolResult, ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "./types";
+import SentAttachmentChip from "../../components/SentAttachmentChip.vue";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { classifyWorkspacePath } from "../../utils/path/workspaceLinkRouter";
 import { useAppApi } from "../../composables/useAppApi";
@@ -97,6 +101,7 @@ watch(editorSource, (next) => {
 
 const messageRole = computed(() => props.selectedResult.data?.role ?? "assistant");
 const transportKind = computed(() => props.selectedResult.data?.transportKind ?? "");
+const messageAttachments = computed<string[]>(() => props.selectedResult.data?.attachments ?? []);
 
 const renderedHtml = computed(() => {
   if (!messageText.value) return "";

--- a/src/plugins/textResponse/types.ts
+++ b/src/plugins/textResponse/types.ts
@@ -6,6 +6,11 @@ export interface TextResponseData {
   text: string;
   role?: "assistant" | "system" | "user";
   transportKind?: string;
+  // Workspace-relative paths of files the user attached when sending
+  // this turn (paste/drop/file-picker). Persisted on the user message
+  // so the chat history can render an icon / thumbnail chip alongside
+  // the bubble. Empty / undefined for assistant and system turns.
+  attachments?: string[];
 }
 
 export type TextResponseArgs = TextResponseData;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -64,6 +64,10 @@ export interface TextEntry extends SessionEntry {
   source: "user" | "assistant";
   type: typeof EVENT_TYPES.text;
   message: string;
+  // Workspace-relative paths the user attached for this turn. Persisted
+  // alongside the text so the chat history can render attachment chips
+  // after a session reload. Only present on user entries.
+  attachments?: string[];
 }
 
 export interface ToolResultEntry extends SessionEntry {

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -27,6 +27,11 @@ export interface SseText {
   type: typeof EVENT_TYPES.text;
   message: string;
   source?: "user" | "assistant";
+  // Workspace-relative paths attached to this user turn. Forwarded
+  // verbatim from the server's user-text broadcast so observing tabs
+  // can render attachment chips matching the originating tab. Only
+  // populated when `source === "user"`.
+  attachments?: string[];
 }
 
 export interface SseToolResult {

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -34,7 +34,7 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       await ctx.refreshRoles();
       return;
     case EVENT_TYPES.text:
-      applyTextEvent(session, event.message, event.source ?? "assistant");
+      applyTextEvent(session, event.message, event.source ?? "assistant", event.attachments);
       return;
     case EVENT_TYPES.toolResult:
       applyToolResultToSession(session, event.result);

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -20,7 +20,7 @@ export function parseSessionEntries(entries: readonly SessionEntry[]): ToolResul
   for (const entry of entries) {
     if (entry.type === EVENT_TYPES.sessionMeta) continue;
     if (isTextEntry(entry)) {
-      out.push(makeTextResult(entry.message, entry.source));
+      out.push(makeTextResult(entry.message, entry.source, entry.attachments));
     } else if (isToolResultEntry(entry)) {
       out.push(entry.result);
     }

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -28,10 +28,13 @@ export function pushErrorMessage(session: ActiveSession, message: string): void 
   session.selectedResultUuid = errorResult.uuid;
 }
 
-/** Append the user's message so it renders immediately. */
-export function beginUserTurn(session: ActiveSession, message: string): void {
+/** Append the user's message so it renders immediately. `attachments`
+ *  carries the workspace-relative paths the user attached for this
+ *  turn (paste/drop/file-picker) so the chat bubble can render an
+ *  icon / thumbnail chip alongside the text. */
+export function beginUserTurn(session: ActiveSession, message: string, attachments?: readonly string[]): void {
   session.updatedAt = new Date().toISOString();
-  pushResult(session, makeTextResult(message, "user"));
+  pushResult(session, makeTextResult(message, "user", attachments));
   session.runStartIndex = session.toolResults.length;
 }
 
@@ -59,11 +62,13 @@ function isDuplicateUserText(session: ActiveSession, message: string): boolean {
 /** Handle an incoming text event (user or assistant) from the
  *  agent's SSE/pubsub stream. Deduplicates user messages,
  *  streams assistant text into the last card, and selects the
- *  result when appropriate. */
-export function applyTextEvent(session: ActiveSession, message: string, source: "user" | "assistant"): void {
+ *  result when appropriate. `attachments` is forwarded for cross-tab
+ *  user-text broadcasts so observing tabs render chips identically
+ *  to the originating tab. */
+export function applyTextEvent(session: ActiveSession, message: string, source: "user" | "assistant", attachments?: readonly string[]): void {
   if (source === "user") {
     if (!isDuplicateUserText(session, message)) {
-      pushResult(session, makeTextResult(message, "user"));
+      pushResult(session, makeTextResult(message, "user", attachments));
       session.runStartIndex = session.toolResults.length;
     }
     return;

--- a/src/utils/tools/result.ts
+++ b/src/utils/tools/result.ts
@@ -29,12 +29,19 @@ export function extractImageData(result: ToolResultComplete | undefined): string
 
 // Build a synthetic text-response result for either a user or
 // assistant turn. Used by sendMessage and the chat history UI.
-export function makeTextResult(text: string, role: "user" | "assistant"): ToolResultComplete {
+// `attachments` is optional and only meaningful on user turns —
+// they're the workspace paths the user attached for this message
+// and surface as chips next to the bubble.
+export function makeTextResult(text: string, role: "user" | "assistant", attachments?: readonly string[]): ToolResultComplete {
+  const data: Record<string, unknown> = { text, role, transportKind: "text-rest" };
+  if (attachments && attachments.length > 0) {
+    data.attachments = [...attachments];
+  }
   return {
     uuid: uuidv4(),
     toolName: "text-response",
     message: text,
     title: role === "user" ? "You" : "Assistant",
-    data: { text, role, transportKind: "text-rest" },
+    data,
   };
 }

--- a/test/api/routes/test_agentCollectAttachedPaths.ts
+++ b/test/api/routes/test_agentCollectAttachedPaths.ts
@@ -1,0 +1,46 @@
+// Pins the P1 fix from PR #1052 review: `collectAttachedPaths` must
+// not throw on malformed (non-array) `attachments` payloads. The
+// helper runs after `beginRun` has committed the session as running
+// — if it threw, `endRun` would never fire and every subsequent turn
+// would be rejected with 409 until restart.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Attachment } from "@mulmobridge/protocol";
+import { collectAttachedPaths } from "../../../server/api/routes/agent.ts";
+
+describe("collectAttachedPaths", () => {
+  it("returns [] for undefined", () => {
+    assert.deepEqual(collectAttachedPaths(undefined), []);
+  });
+
+  it("returns [] for an empty array", () => {
+    assert.deepEqual(collectAttachedPaths([]), []);
+  });
+
+  it("returns [] for a malformed non-array payload (does not throw)", () => {
+    // Cast through unknown to simulate a body that bypassed type
+    // checking (e.g. a buggy HTTP client posting a string).
+    const malformed = "not-an-array" as unknown as Attachment[];
+    assert.doesNotThrow(() => collectAttachedPaths(malformed));
+    assert.deepEqual(collectAttachedPaths(malformed), []);
+  });
+
+  it("returns [] for `null` posing as the attachments field", () => {
+    const malformed = null as unknown as Attachment[];
+    assert.deepEqual(collectAttachedPaths(malformed), []);
+  });
+
+  it("collects path-bearing entries in declaration order", () => {
+    const attachments: Attachment[] = [
+      { path: "data/attachments/2026/04/foo.png", mimeType: "image/png" },
+      { path: "artifacts/images/2026/04/bar.png", mimeType: "image/png" },
+    ];
+    assert.deepEqual(collectAttachedPaths(attachments), ["data/attachments/2026/04/foo.png", "artifacts/images/2026/04/bar.png"]);
+  });
+
+  it("skips entries with no path (defensive — `persistInlineBytesAsPaths` should rewrite these upstream)", () => {
+    const attachments: Attachment[] = [{ path: "data/attachments/2026/04/foo.png" }, { mimeType: "image/png", data: "AAAA" }, { path: "" }];
+    assert.deepEqual(collectAttachedPaths(attachments), ["data/attachments/2026/04/foo.png"]);
+  });
+});

--- a/test/utils/tools/test_result.ts
+++ b/test/utils/tools/test_result.ts
@@ -109,4 +109,23 @@ describe("makeTextResult", () => {
     const result2 = makeTextResult("x", "user");
     assert.notEqual(result1.uuid, result2.uuid);
   });
+
+  it("attaches workspace paths when provided", () => {
+    const result = makeTextResult("hello", "user", ["data/attachments/2026/04/abc.png"]);
+    assert.deepEqual(result.data, {
+      text: "hello",
+      role: "user",
+      transportKind: "text-rest",
+      attachments: ["data/attachments/2026/04/abc.png"],
+    });
+  });
+
+  it("omits attachments key when array is empty", () => {
+    const result = makeTextResult("hello", "user", []);
+    assert.deepEqual(result.data, {
+      text: "hello",
+      role: "user",
+      transportKind: "text-rest",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Persists attachment paths on user `text-response` results so the chat history surfaces them after send (previously the paths were consumed by the agent request and never written back to the message data).
- Renders chips on user bubbles: image attachments show a thumbnail, other types show a colored icon + filename. Canvas View uses a full-width `block` variant; sidebar Preview uses a small `thumb` variant.
- Survives reload via a new optional `attachments` field on the user JSONL entry, and works across tabs by carrying the same array on the `text` SSE event.

## Implementation notes

- `SentAttachmentChip.vue` (new) takes `path` + `variant?: "thumb" | "block"`. Image src goes through `/api/files/raw`, which is auth-exempt for `<img src>` so no bearer-token plumbing was needed.
- Server side: `agent.ts` now writes `attachments` on the user JSONL line and broadcasts it on the `pushSessionEvent` payload when paths are present. Empty arrays are omitted so existing entries stay byte-identical.
- Old sessions stay bare — there's no signal in the legacy JSONL to backfill from. Only turns sent after this lands will show chips.
- `makeTextResult` keeps backwards-compat: `attachments` is optional, and the field is only set on `data` when the array is non-empty (so existing deepEqual tests still pass).

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`
- [x] `yarn test` (3624+ unit tests, all green)
- [x] `yarn test:e2e` (372 Playwright tests, all green)
- [ ] Manual: paste an image into the chat, send, confirm thumbnail in canvas (single + stack mode) and sidebar
- [ ] Manual: attach a PDF, send, confirm icon chip in canvas + sidebar
- [ ] Manual: reload the session, confirm chips persist
- [ ] Manual: open the same session in two tabs, send from one, confirm the other tab gets chips via SSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments persist with user messages and display as thumbnails or file chips across the chat history and previews.
* **Bug Fixes**
  * Improved handling of malformed/failed attachments to avoid stuck or orphaned sessions and surface errors promptly.
* **Tests**
  * Added tests covering attachment extraction and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->