### PR TITLE
feat(files): add per-file chat composer to FilesView

### DIFF
--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -44,6 +44,18 @@
         @markdown-link-click="handleMarkdownLinkClick"
         @update-source="saveRawMarkdown"
       />
+      <!-- Per-file chat composer: spawns a fresh chat with a
+           "take a look at this file first" instruction prepended.
+           Mirrors the wiki per-page composer (see plugins/wiki/View.vue).
+           No roleId is passed, so the new chat inherits the user's
+           current role. -->
+      <PageChatComposer
+        v-if="selectedPath && !contentLoading && !contentError"
+        :key="selectedPath"
+        :placeholder="t('filesView.chatPlaceholder')"
+        :prepend-text="`Before answering, take a look at the file at ${selectedPath}.`"
+        test-id-prefix="files-page-chat"
+      />
     </div>
   </div>
 </template>
@@ -51,9 +63,11 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
+import { useI18n } from "vue-i18n";
 import FileTreePane from "./FileTreePane.vue";
 import FileContentHeader from "./FileContentHeader.vue";
 import FileContentRenderer from "./FileContentRenderer.vue";
+import PageChatComposer from "./PageChatComposer.vue";
 import { useFileTree } from "../composables/useFileTree";
 import { useFileSelection, isValidFilePath, readPathMatch } from "../composables/useFileSelection";
 import { useMarkdownMode } from "../composables/useMarkdownMode";
@@ -68,6 +82,7 @@ import { toTodoExplorerResult } from "../utils/filesPreview/todoPreview";
 const RECENT_THRESHOLD_MS = 60 * 1000;
 
 const route = useRoute();
+const { t } = useI18n();
 
 const props = defineProps<{
   refreshToken?: number;

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -211,6 +211,9 @@ const deMessages = {
     pdfPreview: "PDF-Vorschau",
     parseError: "Parse-Fehler",
   },
+  filesView: {
+    chatPlaceholder: "Frage zu dieser Datei stellen…",
+  },
   systemFiles: {
     schemaLabel: "Schema",
     showDetails: "Details anzeigen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -232,6 +232,9 @@ const enMessages = {
     pdfPreview: "PDF preview",
     parseError: "parse error",
   },
+  filesView: {
+    chatPlaceholder: "Ask about this file…",
+  },
   // SystemFileBanner copy. Each id matches a descriptor in
   // src/config/systemFileDescriptors.ts. `title` is the chip-style
   // headline above the file body; `summary` is one or two sentences

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -217,6 +217,9 @@ const esMessages = {
     pdfPreview: "Vista previa PDF",
     parseError: "error al analizar",
   },
+  filesView: {
+    chatPlaceholder: "Pregunta sobre este archivo…",
+  },
   systemFiles: {
     schemaLabel: "Esquema",
     showDetails: "Mostrar detalles",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -211,6 +211,9 @@ const frMessages = {
     pdfPreview: "Aperçu PDF",
     parseError: "erreur d'analyse",
   },
+  filesView: {
+    chatPlaceholder: "Posez une question sur ce fichier…",
+  },
   systemFiles: {
     schemaLabel: "Schéma",
     showDetails: "Afficher les détails",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -215,6 +215,9 @@ const jaMessages = {
     pdfPreview: "PDF プレビュー",
     parseError: "パースエラー",
   },
+  filesView: {
+    chatPlaceholder: "このファイルについて質問…",
+  },
   systemFiles: {
     schemaLabel: "スキーマ",
     showDetails: "詳細を表示",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -216,6 +216,9 @@ const koMessages = {
     pdfPreview: "PDF 미리보기",
     parseError: "파싱 오류",
   },
+  filesView: {
+    chatPlaceholder: "이 파일에 대해 질문하세요…",
+  },
   systemFiles: {
     schemaLabel: "스키마",
     showDetails: "자세히 보기",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -210,6 +210,9 @@ const ptBRMessages = {
     pdfPreview: "Pré-visualização PDF",
     parseError: "erro de análise",
   },
+  filesView: {
+    chatPlaceholder: "Pergunte sobre este arquivo…",
+  },
   systemFiles: {
     schemaLabel: "Esquema",
     showDetails: "Mostrar detalhes",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -212,6 +212,9 @@ const zhMessages = {
     pdfPreview: "PDF 预览",
     parseError: "解析错误",
   },
+  filesView: {
+    chatPlaceholder: "询问关于此文件的问题…",
+  },
   systemFiles: {
     schemaLabel: "架构",
     showDetails: "显示详情",


### PR DESCRIPTION
## Summary

- Adds a `PageChatComposer` to `FilesView` so users can talk to the LLM about whichever file is currently selected.
- Sending the composer spawns a fresh chat with `Before answering, take a look at the file at <selectedPath>.` prepended (so it works for text, images, PDFs, audio, video alike — "take a look at" instead of "read"). The new chat inherits the user's current role, matching the wiki per-page composer's behavior.
- Adds `filesView.chatPlaceholder` to all 8 locales (en, ja, zh, ko, es, pt-BR, fr, de).

## Test plan

- [ ] Open `/files`, pick a markdown file, type a question, hit send → new chat opens with the prepend + question, and the agent reads the file before answering.
- [ ] Repeat for an image / PDF / video file → composer is visible and the prepend uses "take a look at".
- [ ] Composer is hidden when no file is selected, while content is loading, or when load errors.
- [ ] Switching between files resets the textarea (the `:key="selectedPath"` should remount).
- [ ] Spot-check each locale in the language selector — the placeholder is translated, not the English fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)