### PR TITLE
chore(lint): graduate @typescript-eslint/no-use-before-define typedefs to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -146,8 +146,14 @@ export default [
       // before its declaration line). #920. Function declarations are
       // exempt — TS hoists them safely, and top-down narrative-style
       // (`main()` first, helpers below) is a common pattern in the
-      // codebase. Type references are also exempt: type position is
-      // erased at runtime, so the order doesn't affect execution.
+      // codebase. Runtime type references are exempt via
+      // `ignoreTypeReferences` — type position is erased at runtime,
+      // so order doesn't affect execution.
+      //
+      // `typedefs: true` graduated to error after measuring zero
+      // violations across the codebase — the codebase already orders
+      // type/interface declarations correctly, so the rule is free
+      // value going forward (catches future drift without churn).
       "no-use-before-define": "off",
       "@typescript-eslint/no-use-before-define": [
         "error",
@@ -156,7 +162,7 @@ export default [
           classes: true,
           variables: true,
           enums: true,
-          typedefs: false,
+          typedefs: true,
           ignoreTypeReferences: true,
         },
       ],


### PR DESCRIPTION
## Summary

Graduate the \`typedefs\` flag of \`@typescript-eslint/no-use-before-define\` from \`false\` → \`true\`. Zero violations across the codebase, so this is pure future-drift protection — no reorder churn anywhere.

## Why now

When the rule was first introduced (#920), \`typedefs: false\` and \`functions: false\` were both kept off as a hedge against pre-existing violations. Re-measured today on \`main\`:

| flag | violations |
|---|---|
| \`functions: true\` | 452 (top-down narrative-style is pervasive across bridges / e2e / src — staying \`false\`) |
| \`typedefs: true\` | **0** |

\`typedefs\` is free to graduate; \`functions\` stays a deliberate style allowance.

## Items to Confirm / Review

- The rule with the new flag fires for `interface` / `type` / `enum` declarations used before their definition line. Currently the codebase has none of those, so the diff is just the config flip + a comment update explaining the measurement.
- \`functions: false\` is **deliberately** kept — the "main() at the top, helpers below" pattern is a readability convention, not a defect. Changing that is a separate (and bigger) judgement call.

## Test plan

- [x] \`yarn lint\` clean (no new violations introduced)
- [x] \`yarn typecheck\` clean
- [x] \`yarn test\` clean
- [ ] CI on the PR

## User Prompt

> "no-use-before-define": "off"になっているけど、これってerrorにしたい。というか一度したはずなんだけど。。。

Confirmed user's recall — the TS-aware version is already \`error\` (the base rule has to stay \`off\` to avoid double-firing with \`@typescript-eslint\`). This PR strengthens the TS version's \`typedefs\` sub-flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)