### PR TITLE
feat(memory): typed memory storage utilities (#1029 PR-A)

### DIFF
--- a/plans/feat-memory-storage-utilities.md
+++ b/plans/feat-memory-storage-utilities.md
@@ -50,8 +50,11 @@ filename for type.
 - [印象派](interest_impressionism.md) — 美術鑑賞の主軸
 ```
 
-Index is generated from frontmatter. Lines beyond the entries are kept
-verbatim so a heading at the top of the file (added by humans) survives.
+Index is fully derived from the live frontmatters and **overwritten in
+place** on every `regenerateIndex` call. Humans edit individual entry
+files (frontmatter is the source of truth); `MEMORY.md` is system-owned
+and not user-editable. Hand-written prefix/suffix content is not
+preserved.
 
 ## IO surface (initial)
 

--- a/plans/feat-memory-storage-utilities.md
+++ b/plans/feat-memory-storage-utilities.md
@@ -1,0 +1,103 @@
+# Memory storage utilities (PR-A of #1029)
+
+Implements the storage layer for typed memory entries — schema, IO, and
+migration — but does NOT wire it into runtime yet. The wiring + agent
+prompt change ships atomically as PR-B so the workspace never sits in a
+half-migrated state where read and write disagree.
+
+## Scope (this PR)
+
+- `server/workspace/memory/types.ts` — schema types and frontmatter shape.
+- `server/workspace/memory/io.ts` — load all entries, write entry, regenerate index.
+- `server/workspace/memory/migrate.ts` — split existing `memory.md` into typed files. Library only; not invoked by `workspace.ts` yet.
+- `server/workspace/memory/paths.ts` — local path constants (mirrors `journal/paths.ts`).
+- Add `memoryDir` / `memoryIndex` keys to `WORKSPACE_DIRS` / `WORKSPACE_FILES` / `WORKSPACE_PATHS` so PR-B can wire without further plumbing.
+- Tests under `test/workspace/memory/`.
+
+## Out of scope
+
+- `workspace.ts` calling migration on first start → PR-B
+- `server/agent/prompt.ts` read/write side update → PR-B (atomic with migration)
+- Index auto-regeneration on file change (human edit drift) → phase 2
+- `/memory` UI route → #1032
+- Expiration / archive → #1033
+- Tag-based loading → #1034
+- Proactive recall → #1035
+
+## Schema
+
+Each entry is a markdown file with YAML frontmatter:
+
+```yaml
+---
+name: yarn を使う
+description: パッケージマネージャは yarn 固定（npm 不可）
+type: preference
+---
+本文（markdown）…
+```
+
+`type` ∈ `preference | interest | fact | reference`.
+
+Filename convention: `<type>_<slug>.md`. Convention is for ergonomics —
+`type` in frontmatter is the source of truth. Reader must not depend on
+filename for type.
+
+`MEMORY.md` is an index, one line per entry:
+
+```
+- [yarn を使う](preference_yarn.md) — npm 不可
+- [印象派](interest_impressionism.md) — 美術鑑賞の主軸
+```
+
+Index is generated from frontmatter. Lines beyond the entries are kept
+verbatim so a heading at the top of the file (added by humans) survives.
+
+## IO surface (initial)
+
+```ts
+loadAllMemoryEntries(root: string): Promise<MemoryEntry[]>
+writeMemoryEntry(root: string, entry: MemoryEntry): Promise<string>  // returns relative path written
+regenerateIndex(root: string): Promise<void>                          // rebuilds MEMORY.md from current files
+```
+
+Reader silently skips files that fail frontmatter parse (logs once per
+file) so a corrupt entry doesn't kill the whole load.
+
+Writer goes through `writeFileAtomic` with `uniqueTmp: true`.
+
+## Migration
+
+`migrateLegacyMemory(root: string, llm: TypeClassifier): Promise<MigrationResult>`
+
+1. Read `conversations/memory.md`. If absent → no-op.
+2. Split by `^## ` (H2 headings).
+3. For each bullet-line entry under each H2: ask the LLM "is this preference / interest / fact / reference?" via the classifier callback.
+4. Write each entry as a typed file under `conversations/memory/`.
+5. Rebuild `MEMORY.md`.
+6. Rename `memory.md` → `memory.md.backup`. Backup file is never deleted.
+
+`MigrationResult` carries counts (entries written per type, lines skipped, errors). Caller logs.
+
+The classifier is injected so tests can use a stub. The real
+implementation in PR-B will reuse the prompt from
+`journal/memoryExtractor.ts`.
+
+## Tests (added in this PR)
+
+- `test_io.ts`
+  - parse round-trip: write entry → read back → fields match
+  - missing frontmatter: file skipped, others still loaded
+  - regenerateIndex: index reflects every entry, sorted by type then name
+- `test_migrate.ts`
+  - golden: fixture memory.md → expected per-type files
+  - empty memory.md: no-op
+  - missing memory.md: no-op
+  - typeClassifier returning `null`: entry skipped + counted
+  - backup file is created with original contents
+
+## Followups (PR-B and beyond)
+
+- PR-B wiring (separate plan file)
+- Index auto-regeneration on `conversations/memory/*.md` writes (covers human edits via file explorer; needed once #1032 lands)
+- Reader caching if the file count grows large

--- a/server/workspace/memory/io.ts
+++ b/server/workspace/memory/io.ts
@@ -1,0 +1,139 @@
+// Memory storage IO (#1029 PR-A).
+//
+// Read all entries, write a single entry, regenerate the index file.
+// Reader is forgiving: a corrupt frontmatter on one entry logs and
+// is skipped, the rest still load. Writer is atomic.
+//
+// `MEMORY.md` is rebuilt from the live frontmatters whenever
+// `regenerateIndex` is called — so every write that changes name /
+// description / type should be followed by a regenerate. The legacy
+// `memory.md` is intentionally NOT touched here; migration handles it.
+
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown/frontmatter.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { readDirSafeAsync, readTextSafe, statSafeAsync } from "../../utils/files/safe.js";
+import { log } from "../../system/logger/index.js";
+import { isMemoryType, type MemoryEntry, type MemoryType } from "./types.js";
+
+// On-disk directory and index file for typed memory entries.
+// Callers pass the workspace root; this returns the absolute paths.
+export function memoryDirOf(workspaceRoot: string): string {
+  return path.join(workspaceRoot, "conversations", "memory");
+}
+
+export function memoryIndexOf(workspaceRoot: string): string {
+  return path.join(memoryDirOf(workspaceRoot), "MEMORY.md");
+}
+
+// Load every entry from `<workspaceRoot>/conversations/memory/`. The
+// index file (`MEMORY.md`) and any sub-directory (e.g. future
+// `archived/` from #1033) are skipped. Files that fail frontmatter
+// parsing or carry an unknown `type` are logged and excluded.
+export async function loadAllMemoryEntries(workspaceRoot: string): Promise<MemoryEntry[]> {
+  const dir = memoryDirOf(workspaceRoot);
+  const filenames = await listEntryFiles(dir);
+  const loaded: MemoryEntry[] = [];
+  for (const filename of filenames) {
+    const parsed = await readMemoryFile(path.join(dir, filename));
+    if (parsed) loaded.push(parsed);
+  }
+  return loaded;
+}
+
+// Persist a single entry. Filename is `<slug>.md`. Returns the
+// workspace-relative path that was written so callers can log /
+// reference the destination.
+export async function writeMemoryEntry(workspaceRoot: string, entry: MemoryEntry): Promise<string> {
+  const dir = memoryDirOf(workspaceRoot);
+  await mkdir(dir, { recursive: true });
+  const filename = `${entry.slug}.md`;
+  const absPath = path.join(dir, filename);
+  const content = serializeWithFrontmatter({ name: entry.name, description: entry.description, type: entry.type }, entry.body);
+  await writeFileAtomic(absPath, content, { uniqueTmp: true });
+  return path.posix.join("conversations", "memory", filename);
+}
+
+// Rebuild `MEMORY.md` from current entry frontmatters. Sorted by type
+// (preference / interest / fact / reference order) then by name so
+// the index reads consistently. Empty memory directory writes a
+// placeholder index (still useful as the marker that the new layout
+// is in effect).
+export async function regenerateIndex(workspaceRoot: string): Promise<void> {
+  const dir = memoryDirOf(workspaceRoot);
+  await mkdir(dir, { recursive: true });
+  const all = await loadAllMemoryEntries(workspaceRoot);
+  const sorted = [...all].sort(compareEntries);
+  const lines: string[] = ["# Memory", ""];
+  for (const entry of sorted) {
+    lines.push(`- [${entry.name}](${entry.slug}.md) — ${entry.description}`);
+  }
+  if (sorted.length === 0) lines.push("_(no entries yet)_");
+  lines.push("");
+  await writeFileAtomic(memoryIndexOf(workspaceRoot), lines.join("\n"), { uniqueTmp: true });
+}
+
+const TYPE_ORDER: readonly MemoryType[] = ["preference", "interest", "fact", "reference"];
+
+function typeOrderKey(type: MemoryType): number {
+  const idx = TYPE_ORDER.indexOf(type);
+  return idx < 0 ? TYPE_ORDER.length : idx;
+}
+
+function compareEntries(left: MemoryEntry, right: MemoryEntry): number {
+  const typeDelta = typeOrderKey(left.type) - typeOrderKey(right.type);
+  if (typeDelta !== 0) return typeDelta;
+  return left.name.localeCompare(right.name);
+}
+
+async function listEntryFiles(dir: string): Promise<string[]> {
+  // Missing memory dir → treat as empty. `readDirSafeAsync` already
+  // returns `[]` on ENOENT, so no explicit branch needed.
+  const dirents = await readDirSafeAsync(dir);
+  const out: string[] = [];
+  for (const dirent of dirents) {
+    const { name } = dirent;
+    if (name === "MEMORY.md") continue;
+    if (!name.endsWith(".md")) continue;
+    if (name.startsWith(".")) continue;
+    if (!dirent.isFile()) {
+      // Symlinks / non-regular entries: stat to resolve, skip on
+      // failure or non-file. A corrupt entry should not poison the
+      // read path.
+      const stat = await statSafeAsync(path.join(dir, name));
+      if (!stat?.isFile()) continue;
+    }
+    out.push(name);
+  }
+  return out.sort();
+}
+
+async function readMemoryFile(absPath: string): Promise<MemoryEntry | null> {
+  const raw = await readTextSafe(absPath);
+  if (raw === null) {
+    log.warn("memory", "failed to read entry", { path: absPath });
+    return null;
+  }
+  const parsed = parseFrontmatter(raw);
+  if (!parsed.hasHeader) {
+    log.warn("memory", "entry missing frontmatter", { path: absPath });
+    return null;
+  }
+  const name = stringField(parsed.meta.name);
+  const description = stringField(parsed.meta.description);
+  const { type } = parsed.meta;
+  if (!name || !description || !isMemoryType(type)) {
+    log.warn("memory", "entry frontmatter incomplete", { path: absPath });
+    return null;
+  }
+  const slug = path.basename(absPath, ".md");
+  return { name, description, type, body: parsed.body, slug };
+}
+
+function stringField(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/server/workspace/memory/io.ts
+++ b/server/workspace/memory/io.ts
@@ -73,10 +73,14 @@ export function isSafeMemorySlug(slug: string): boolean {
   if (slug.length > 200) return false;
   if (slug.includes("/") || slug.includes("\\")) return false;
   if (slug.includes("\0")) return false;
-  // `.`, `..`, leading `.` (dotfiles), or a literal `MEMORY` would
-  // each conflict with how the reader scans the directory.
+  // `.`, `..`, leading `.` (dotfiles), or any case-fold of `MEMORY`
+  // would conflict with how the reader scans the directory. The
+  // case-fold covers `Memory` / `memory` collisions on macOS /
+  // Windows where the filesystem is case-insensitive — a case-
+  // sensitive comparison would let `slug = "Memory"` produce
+  // `Memory.md`, which aliases `MEMORY.md` and shadows the index.
   if (slug.startsWith(".")) return false;
-  if (slug === "MEMORY") return false;
+  if (slug.toUpperCase() === "MEMORY") return false;
   return true;
 }
 

--- a/server/workspace/memory/io.ts
+++ b/server/workspace/memory/io.ts
@@ -45,8 +45,15 @@ export async function loadAllMemoryEntries(workspaceRoot: string): Promise<Memor
 
 // Persist a single entry. Filename is `<slug>.md`. Returns the
 // workspace-relative path that was written so callers can log /
-// reference the destination.
+// reference the destination. Slugs are validated against
+// `isSafeMemorySlug` — `..` segments, separators, dotfiles, and
+// reserved filenames are rejected so a caller-supplied slug cannot
+// escape the memory directory or collide with `MEMORY.md`. PR-B
+// will surface this same check at the agent-write boundary.
 export async function writeMemoryEntry(workspaceRoot: string, entry: MemoryEntry): Promise<string> {
+  if (!isSafeMemorySlug(entry.slug)) {
+    throw new Error(`refusing to write memory entry with unsafe slug: ${JSON.stringify(entry.slug)}`);
+  }
   const dir = memoryDirOf(workspaceRoot);
   await mkdir(dir, { recursive: true });
   const filename = `${entry.slug}.md`;
@@ -54,6 +61,23 @@ export async function writeMemoryEntry(workspaceRoot: string, entry: MemoryEntry
   const content = serializeWithFrontmatter({ name: entry.name, description: entry.description, type: entry.type }, entry.body);
   await writeFileAtomic(absPath, content, { uniqueTmp: true });
   return path.posix.join("conversations", "memory", filename);
+}
+
+// Slug shape gate. Allows arbitrary unicode (so non-ASCII names slug
+// fine via `slugifyMemoryName`'s hash fallback) but rejects anything
+// that would let a caller escape the memory directory or shadow
+// reserved filenames.
+export function isSafeMemorySlug(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  if (slug.length === 0) return false;
+  if (slug.length > 200) return false;
+  if (slug.includes("/") || slug.includes("\\")) return false;
+  if (slug.includes("\0")) return false;
+  // `.`, `..`, leading `.` (dotfiles), or a literal `MEMORY` would
+  // each conflict with how the reader scans the directory.
+  if (slug.startsWith(".")) return false;
+  if (slug === "MEMORY") return false;
+  return true;
 }
 
 // Rebuild `MEMORY.md` from current entry frontmatters. Sorted by type

--- a/server/workspace/memory/migrate.ts
+++ b/server/workspace/memory/migrate.ts
@@ -1,0 +1,199 @@
+// Migration of legacy `conversations/memory.md` into the typed
+// directory layout (#1029 PR-A). This module is a library — it does
+// NOT decide when to run. PR-B wires it into `workspace.ts`'s init
+// path so the conversion happens once on first start after the new
+// layout ships.
+//
+// Steps:
+//   1. Read existing `conversations/memory.md`. Absent → no-op.
+//   2. Split by `## ` (H2). Each H2 block becomes a candidate entry
+//      (one per top-level bullet).
+//   3. Ask the supplied classifier "preference / interest / fact /
+//      reference?" per candidate. Null verdict → skip + count.
+//   4. Write each kept candidate as `<type>_<slug>.md`.
+//   5. Rebuild `MEMORY.md`.
+//   6. Rename source to `memory.md.backup` (never deleted).
+
+import { mkdir, rename } from "node:fs/promises";
+import path from "node:path";
+
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { readTextSafe } from "../../utils/files/safe.js";
+import { log } from "../../system/logger/index.js";
+import { errorMessage } from "../../utils/errors.js";
+import { regenerateIndex, writeMemoryEntry } from "./io.js";
+import { isMemoryType, slugifyMemoryName, type MemoryEntry, type MemoryType } from "./types.js";
+
+export interface MemoryClassification {
+  type: MemoryType;
+  /** Optional one-line description. Falls back to a truncated body. */
+  description?: string;
+}
+
+export type MemoryClassifier = (candidate: MemoryCandidate) => Promise<MemoryClassification | null>;
+
+export interface MemoryCandidate {
+  /** H2 section header the bullet was found under. Empty string for
+   *  bullets that appeared before any H2. */
+  section: string;
+  /** Single-line text of the bullet (lead-in `- ` already stripped). */
+  body: string;
+}
+
+export interface MigrationResult {
+  /** Set when there was nothing to migrate (no `memory.md`). */
+  noop: boolean;
+  /** Count of candidates accepted, broken down by type. */
+  written: Record<MemoryType, number>;
+  /** Candidates the classifier returned `null` for. */
+  skippedByClassifier: number;
+  /** Candidates that errored on write — caller may want to retry or
+   *  surface to the user. The migration continues past write errors
+   *  so a single bad entry doesn't strand the whole batch. */
+  writeErrors: number;
+}
+
+export async function migrateLegacyMemory(workspaceRoot: string, classify: MemoryClassifier): Promise<MigrationResult> {
+  const sourcePath = path.join(workspaceRoot, "conversations", "memory.md");
+  const raw = await readTextSafe(sourcePath);
+  if (raw === null) {
+    return emptyResult(true);
+  }
+
+  const candidates = parseCandidates(raw);
+  const result = emptyResult(false);
+  const usedSlugs = new Set<string>();
+
+  for (const candidate of candidates) {
+    const classification = await safeClassify(classify, candidate);
+    if (!classification) {
+      result.skippedByClassifier += 1;
+      continue;
+    }
+    const entry = buildEntry(candidate, classification, usedSlugs);
+    try {
+      await writeMemoryEntry(workspaceRoot, entry);
+      usedSlugs.add(entry.slug);
+      result.written[entry.type] += 1;
+    } catch (err) {
+      log.warn("memory", "migration: write failed", {
+        slug: entry.slug,
+        error: errorMessage(err),
+      });
+      result.writeErrors += 1;
+    }
+  }
+
+  await regenerateIndex(workspaceRoot);
+  await renameToBackup(sourcePath);
+  return result;
+}
+
+function emptyResult(noop: boolean): MigrationResult {
+  return {
+    noop,
+    written: { preference: 0, interest: 0, fact: 0, reference: 0 },
+    skippedByClassifier: 0,
+    writeErrors: 0,
+  };
+}
+
+// Split the legacy file into candidate bullets. We accept either
+// `- ` or `* ` as bullet markers and ignore continuation lines (a
+// candidate is one bullet line). The H2 header — when present —
+// rides along as `section` so the classifier can use it as context.
+// Parsing is character-driven (no regex) to keep sonar happy and to
+// make the bullet-vs-header classification obvious from the code.
+function parseCandidates(raw: string): MemoryCandidate[] {
+  const lines = raw.split("\n");
+  let section = "";
+  const out: MemoryCandidate[] = [];
+  for (const lineRaw of lines) {
+    const line = stripCarriageReturn(lineRaw);
+    const header = extractHeader(line);
+    if (header !== null) {
+      section = header;
+      continue;
+    }
+    const bullet = extractBullet(line);
+    if (bullet) out.push({ section, body: bullet });
+  }
+  return out;
+}
+
+function stripCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function extractHeader(line: string): string | null {
+  if (!line.startsWith("## ")) return null;
+  return line.slice(3).trim();
+}
+
+function extractBullet(line: string): string | null {
+  const trimmedLeft = line.replace(/^[\t ]+/, "");
+  if (!trimmedLeft.startsWith("- ") && !trimmedLeft.startsWith("* ")) return null;
+  const body = trimmedLeft.slice(2).trim();
+  return body.length > 0 ? body : null;
+}
+
+async function safeClassify(classify: MemoryClassifier, candidate: MemoryCandidate): Promise<MemoryClassification | null> {
+  try {
+    const verdict = await classify(candidate);
+    if (verdict && isMemoryType(verdict.type)) return verdict;
+    return null;
+  } catch (err) {
+    log.warn("memory", "migration: classifier threw", {
+      preview: candidate.body.slice(0, 80),
+      error: errorMessage(err),
+    });
+    return null;
+  }
+}
+
+function buildEntry(candidate: MemoryCandidate, classification: MemoryClassification, usedSlugs: Set<string>): MemoryEntry {
+  const name = candidate.body.length > 80 ? `${candidate.body.slice(0, 77)}…` : candidate.body;
+  const description = classification.description?.trim() || truncateForDescription(candidate.body);
+  const baseSlug = slugifyMemoryName(candidate.body, classification.type);
+  const slug = uniqueSlug(baseSlug, usedSlugs);
+  return {
+    name,
+    description,
+    type: classification.type,
+    body: candidate.body,
+    slug,
+  };
+}
+
+function truncateForDescription(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > 120 ? `${oneLine.slice(0, 117)}…` : oneLine;
+}
+
+function uniqueSlug(base: string, used: Set<string>): string {
+  if (!used.has(base)) return base;
+  let counter = 2;
+  while (used.has(`${base}-${counter}`)) counter += 1;
+  return `${base}-${counter}`;
+}
+
+async function renameToBackup(sourcePath: string): Promise<void> {
+  const backupPath = `${sourcePath}.backup`;
+  try {
+    await rename(sourcePath, backupPath);
+  } catch (err) {
+    log.warn("memory", "migration: backup rename failed", {
+      sourcePath,
+      error: errorMessage(err),
+    });
+  }
+}
+
+// Bare write of the source file used in tests for setup. Production
+// callers don't need this — `memory.md` is created by user activity
+// or by an older mulmoclaude version.
+export async function writeLegacyMemoryForTest(workspaceRoot: string, content: string): Promise<void> {
+  const sourcePath = path.join(workspaceRoot, "conversations", "memory.md");
+  await mkdir(path.dirname(sourcePath), { recursive: true });
+  await writeFileAtomic(sourcePath, content);
+}

--- a/server/workspace/memory/types.ts
+++ b/server/workspace/memory/types.ts
@@ -1,0 +1,64 @@
+// Typed memory schema (#1029). Each entry is a markdown file with a
+// YAML frontmatter envelope. The directory layout, filename
+// convention, and field set are documented in
+// `plans/feat-memory-storage-utilities.md`.
+//
+// `type` is the source of truth for an entry's classification —
+// filenames follow `<type>_<slug>.md` for ergonomics but the reader
+// must trust the frontmatter, never the filename.
+
+export const MEMORY_TYPES = ["preference", "interest", "fact", "reference"] as const;
+
+export type MemoryType = (typeof MEMORY_TYPES)[number];
+
+export interface MemoryEntry {
+  /** One-line human-readable label. Becomes the link text in MEMORY.md. */
+  name: string;
+  /** Short blurb shown after the link in MEMORY.md and used as the
+   *  description hint when the agent decides whether to read the
+   *  full entry. */
+  description: string;
+  type: MemoryType;
+  /** Markdown body. The frontmatter envelope is stripped on parse and
+   *  re-applied on write. */
+  body: string;
+  /** Filename without extension. Stable identifier used by the index
+   *  link target. */
+  slug: string;
+}
+
+export function isMemoryType(value: unknown): value is MemoryType {
+  return typeof value === "string" && (MEMORY_TYPES as readonly string[]).includes(value);
+}
+
+// Slugify a name into a filename-safe token. ASCII-only conversion of
+// [a-zA-Z0-9] segments; everything else collapses into a single `-`.
+// Non-ASCII (Japanese / 中文) input falls back to the type prefix +
+// short hash so two entries with all-non-ASCII names don't collide on
+// the empty string. Uses an explicit char loop instead of regex so a
+// deeply-recursive name can't trigger pathological backtracking.
+export function slugifyMemoryName(name: string, type: MemoryType): string {
+  const ascii = compactAlnum(name.toLowerCase());
+  if (ascii.length > 0) return `${type}_${ascii}`;
+  let hash = 0;
+  for (let index = 0; index < name.length; index += 1) {
+    hash = (hash * 31 + name.charCodeAt(index)) >>> 0;
+  }
+  return `${type}_${hash.toString(36)}`;
+}
+
+function compactAlnum(text: string): string {
+  const out: string[] = [];
+  let lastWasSep = true;
+  for (const char of text) {
+    if ((char >= "a" && char <= "z") || (char >= "0" && char <= "9")) {
+      out.push(char);
+      lastWasSep = false;
+    } else if (!lastWasSep) {
+      out.push("-");
+      lastWasSep = true;
+    }
+  }
+  while (out.length > 0 && out[out.length - 1] === "-") out.pop();
+  return out.join("");
+}

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -43,6 +43,11 @@ export const workspacePath = path.join(homedir(), "mulmoclaude");
 export const WORKSPACE_DIRS = {
   // conversations/
   chat: "conversations/chat",
+  // Typed memory entries (#1029). One markdown file per fact, indexed
+  // by `MEMORY.md` (= WORKSPACE_FILES.memoryIndex). Replaces the
+  // single-file `memory.md`; the legacy file is kept as
+  // `memory.md.backup` after migration.
+  memoryDir: "conversations/memory",
   summaries: "conversations/summaries",
   // Tool-trace output for WebSearch (one .md per search, referenced
   // from chat JSONL `contentRef`). Lives alongside chat/ so search
@@ -121,6 +126,7 @@ export const WORKSPACE_PATHS = {
   news: path.join(workspacePath, WORKSPACE_DIRS.news),
   sources: path.join(workspacePath, WORKSPACE_DIRS.sources),
   attachments: path.join(workspacePath, WORKSPACE_DIRS.attachments),
+  memoryDir: path.join(workspacePath, WORKSPACE_DIRS.memoryDir),
   summaries: path.join(workspacePath, WORKSPACE_DIRS.summaries),
   searches: path.join(workspacePath, WORKSPACE_DIRS.searches),
   htmls: path.join(workspacePath, WORKSPACE_DIRS.htmls),
@@ -133,6 +139,7 @@ export const WORKSPACE_PATHS = {
   wikiHistory: path.join(workspacePath, WORKSPACE_DIRS.wikiHistory),
   // files
   memory: path.join(workspacePath, WORKSPACE_FILES.memory),
+  memoryIndex: path.join(workspacePath, WORKSPACE_FILES.memoryIndex),
   sessionToken: path.join(workspacePath, WORKSPACE_FILES.sessionToken),
   serverPort: path.join(workspacePath, WORKSPACE_FILES.serverPort),
   wikiIndex: path.join(workspacePath, WORKSPACE_FILES.wikiIndex),

--- a/src/config/workspacePaths.ts
+++ b/src/config/workspacePaths.ts
@@ -10,6 +10,7 @@
 /** Well-known individual files. Values are workspace-relative paths. */
 export const WORKSPACE_FILES = {
   memory: "conversations/memory.md",
+  memoryIndex: "conversations/memory/MEMORY.md",
   sessionToken: ".session-token",
   /** Port the parent server bound to. Written at `app.listen` so
    *  out-of-process helpers (currently the LLM wiki-write hook —

--- a/test/workspace/memory/test_io.ts
+++ b/test/workspace/memory/test_io.ts
@@ -1,0 +1,153 @@
+// Unit tests for memory storage IO (#1029 PR-A).
+//
+// Covers the round-trip (write then read), the index regeneration
+// shape, and the reader's tolerance of malformed files — a single
+// corrupt entry must not block the rest of the directory.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { loadAllMemoryEntries, memoryDirOf, memoryIndexOf, regenerateIndex, writeMemoryEntry } from "../../../server/workspace/memory/io.js";
+import type { MemoryEntry } from "../../../server/workspace/memory/types.js";
+
+let workspaceRoot: string;
+
+before(async () => {
+  workspaceRoot = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-"));
+});
+
+after(async () => {
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("memory/io — write + read round-trip", () => {
+  it("writes an entry with a frontmatter envelope and reads the same fields back", async () => {
+    const entry: MemoryEntry = {
+      name: "yarn を使う",
+      description: "パッケージマネージャは yarn 固定（npm 不可）",
+      type: "preference",
+      body: "yarn install / yarn add しか使わない。",
+      slug: "preference_yarn",
+    };
+    const writtenRel = await writeMemoryEntry(workspaceRoot, entry);
+    assert.equal(writtenRel, "conversations/memory/preference_yarn.md");
+
+    const all = await loadAllMemoryEntries(workspaceRoot);
+    assert.equal(all.length, 1);
+    const [loaded] = all;
+    assert.equal(loaded.name, entry.name);
+    assert.equal(loaded.description, entry.description);
+    assert.equal(loaded.type, entry.type);
+    assert.equal(loaded.slug, entry.slug);
+    assert.match(loaded.body, /yarn install/);
+  });
+});
+
+describe("memory/io — reader tolerance", () => {
+  let scopedRoot: string;
+
+  before(async () => {
+    scopedRoot = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-tol-"));
+  });
+
+  after(async () => {
+    await rm(scopedRoot, { recursive: true, force: true });
+  });
+
+  it("skips files without a frontmatter envelope but loads the rest", async () => {
+    const dir = memoryDirOf(scopedRoot);
+    await writeMemoryEntry(scopedRoot, {
+      name: "印象派",
+      description: "美術鑑賞の主軸",
+      type: "interest",
+      body: "monet / renoir.",
+      slug: "interest_impressionism",
+    });
+    // Drop a malformed file alongside.
+    await writeFile(path.join(dir, "broken.md"), "no frontmatter here.\n", "utf8");
+
+    const all = await loadAllMemoryEntries(scopedRoot);
+    assert.equal(all.length, 1);
+    assert.equal(all[0].slug, "interest_impressionism");
+  });
+
+  it("skips MEMORY.md and dotfiles in the directory listing", async () => {
+    const dir = memoryDirOf(scopedRoot);
+    await writeFile(path.join(dir, "MEMORY.md"), "# index\n", "utf8");
+    await writeFile(path.join(dir, ".hidden.md"), "irrelevant\n", "utf8");
+
+    const all = await loadAllMemoryEntries(scopedRoot);
+    // Still exactly the one valid entry from the previous test.
+    assert.equal(all.length, 1);
+  });
+
+  it("returns an empty array when the memory directory does not exist", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-empty-"));
+    try {
+      const all = await loadAllMemoryEntries(fresh);
+      assert.deepEqual(all, []);
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("memory/io — regenerateIndex", () => {
+  let scopedRoot: string;
+
+  before(async () => {
+    scopedRoot = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-idx-"));
+    await writeMemoryEntry(scopedRoot, {
+      name: "印象派",
+      description: "美術鑑賞の主軸",
+      type: "interest",
+      body: "monet / renoir.",
+      slug: "interest_impressionism",
+    });
+    await writeMemoryEntry(scopedRoot, {
+      name: "yarn を使う",
+      description: "npm 不可",
+      type: "preference",
+      body: "yarn 固定。",
+      slug: "preference_yarn",
+    });
+    await writeMemoryEntry(scopedRoot, {
+      name: "エジプト旅行を計画中",
+      description: "ナイル川クルーズ案",
+      type: "fact",
+      body: "ピラミッド + 博物館中心。",
+      slug: "fact_egypt",
+    });
+  });
+
+  after(async () => {
+    await rm(scopedRoot, { recursive: true, force: true });
+  });
+
+  it("emits a markdown index sorted by type then name", async () => {
+    await regenerateIndex(scopedRoot);
+    const indexPath = memoryIndexOf(scopedRoot);
+    const content = await readFile(indexPath, "utf8");
+    // preference first, then interest, then fact.
+    const prefIdx = content.indexOf("preference_yarn.md");
+    const intIdx = content.indexOf("interest_impressionism.md");
+    const factIdx = content.indexOf("fact_egypt.md");
+    assert.ok(prefIdx !== -1 && intIdx !== -1 && factIdx !== -1, "all entries appear");
+    assert.ok(prefIdx < intIdx, "preference precedes interest");
+    assert.ok(intIdx < factIdx, "interest precedes fact");
+  });
+
+  it("writes an empty placeholder when there are no entries", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-empty-idx-"));
+    try {
+      await regenerateIndex(fresh);
+      const content = await readFile(memoryIndexOf(fresh), "utf8");
+      assert.match(content, /no entries yet/);
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/workspace/memory/test_io.ts
+++ b/test/workspace/memory/test_io.ts
@@ -116,6 +116,15 @@ describe("memory/io — slug safety", () => {
     assert.equal(isSafeMemorySlug("MEMORY"), false);
   });
 
+  it("rejects every case-fold of the reserved index name (case-insensitive FS safety)", () => {
+    // macOS / Windows are case-insensitive by default — `Memory.md`
+    // aliases `MEMORY.md` on those filesystems and would shadow the
+    // index. The check must be case-fold, not byte-equal.
+    assert.equal(isSafeMemorySlug("Memory"), false);
+    assert.equal(isSafeMemorySlug("memory"), false);
+    assert.equal(isSafeMemorySlug("MeMoRy"), false);
+  });
+
   it("writeMemoryEntry throws on unsafe slug instead of writing outside the memory directory", async () => {
     const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-slug-"));
     try {

--- a/test/workspace/memory/test_io.ts
+++ b/test/workspace/memory/test_io.ts
@@ -10,7 +10,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { loadAllMemoryEntries, memoryDirOf, memoryIndexOf, regenerateIndex, writeMemoryEntry } from "../../../server/workspace/memory/io.js";
+import { isSafeMemorySlug, loadAllMemoryEntries, memoryDirOf, memoryIndexOf, regenerateIndex, writeMemoryEntry } from "../../../server/workspace/memory/io.js";
 import type { MemoryEntry } from "../../../server/workspace/memory/types.js";
 
 let workspaceRoot: string;
@@ -89,6 +89,44 @@ describe("memory/io — reader tolerance", () => {
     try {
       const all = await loadAllMemoryEntries(fresh);
       assert.deepEqual(all, []);
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("memory/io — slug safety", () => {
+  it("accepts a typical generated slug", () => {
+    assert.equal(isSafeMemorySlug("preference_yarn"), true);
+    assert.equal(isSafeMemorySlug("fact_egypt-trip-2"), true);
+    assert.equal(isSafeMemorySlug("interest_印象派"), true);
+  });
+
+  it("rejects slugs that would escape the memory directory", () => {
+    assert.equal(isSafeMemorySlug(".."), false);
+    assert.equal(isSafeMemorySlug("../foo"), false);
+    assert.equal(isSafeMemorySlug("a/b"), false);
+    assert.equal(isSafeMemorySlug("a\\b"), false);
+    assert.equal(isSafeMemorySlug("foo\0bar"), false);
+  });
+
+  it("rejects empty / dotfile / reserved slugs", () => {
+    assert.equal(isSafeMemorySlug(""), false);
+    assert.equal(isSafeMemorySlug(".hidden"), false);
+    assert.equal(isSafeMemorySlug("MEMORY"), false);
+  });
+
+  it("writeMemoryEntry throws on unsafe slug instead of writing outside the memory directory", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-io-slug-"));
+    try {
+      const malicious: MemoryEntry = {
+        name: "evil",
+        description: "should not write",
+        type: "fact",
+        body: "x",
+        slug: "../../../../tmp/pwn",
+      };
+      await assert.rejects(() => writeMemoryEntry(fresh, malicious), /unsafe slug/);
     } finally {
       await rm(fresh, { recursive: true, force: true });
     }

--- a/test/workspace/memory/test_migrate.ts
+++ b/test/workspace/memory/test_migrate.ts
@@ -1,0 +1,142 @@
+// Unit tests for legacy `memory.md` migration (#1029 PR-A).
+//
+// The classifier is injected as a stub so these tests run without
+// any LLM dependency. Real production migration in PR-B will pass
+// in a real LLM-backed classifier.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { loadAllMemoryEntries, memoryDirOf, memoryIndexOf } from "../../../server/workspace/memory/io.js";
+import { migrateLegacyMemory, writeLegacyMemoryForTest, type MemoryClassifier } from "../../../server/workspace/memory/migrate.js";
+import type { MemoryType } from "../../../server/workspace/memory/types.js";
+
+// Predictable classifier: name → type. Anything not listed → null
+// (skipped). Lets the test assert exactly which lines moved.
+function classifierFor(map: Record<string, MemoryType>): MemoryClassifier {
+  return async ({ body }) => {
+    for (const [needle, type] of Object.entries(map)) {
+      if (body.includes(needle)) return { type };
+    }
+    return null;
+  };
+}
+
+describe("memory/migrate — happy path", () => {
+  let workspaceRoot: string;
+
+  before(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-"));
+    await writeLegacyMemoryForTest(
+      workspaceRoot,
+      [
+        "# Memory",
+        "",
+        "## Preferences",
+        "- yarn を使う（npm は不可）",
+        "- Emacs を愛用",
+        "",
+        "## Project",
+        "- mulmoclaude のレポは ~/ss/llm/mulmoclaude4",
+        "",
+        "## Travel",
+        "- エジプト旅行を計画中",
+        "",
+        "## Junk",
+        "- 5 文字以上の意味不明な行",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  after(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("classifies bullets, writes typed entries, regenerates the index, and renames the source", async () => {
+    const result = await migrateLegacyMemory(
+      workspaceRoot,
+      classifierFor({
+        yarn: "preference",
+        Emacs: "preference",
+        "mulmoclaude のレポ": "reference",
+        エジプト: "fact",
+      }),
+    );
+    assert.equal(result.noop, false);
+    assert.equal(result.written.preference, 2);
+    assert.equal(result.written.fact, 1);
+    assert.equal(result.written.reference, 1);
+    assert.equal(result.written.interest, 0);
+    assert.equal(result.skippedByClassifier, 1, "the unclassified bullet is counted as skipped");
+
+    const all = await loadAllMemoryEntries(workspaceRoot);
+    const types = all.map((entry) => entry.type).sort();
+    assert.deepEqual(types, ["fact", "preference", "preference", "reference"]);
+
+    const indexBody = await readFile(memoryIndexOf(workspaceRoot), "utf8");
+    assert.match(indexBody, /yarn を使う/);
+    assert.match(indexBody, /エジプト/);
+
+    // memory.md → memory.md.backup
+    const sourceGone = await stat(path.join(workspaceRoot, "conversations", "memory.md")).catch(() => null);
+    assert.equal(sourceGone, null);
+    const backup = await readFile(path.join(workspaceRoot, "conversations", "memory.md.backup"), "utf8");
+    assert.match(backup, /yarn を使う/);
+  });
+});
+
+describe("memory/migrate — edge cases", () => {
+  it("returns noop when memory.md does not exist", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-empty-"));
+    try {
+      const result = await migrateLegacyMemory(fresh, async () => null);
+      assert.equal(result.noop, true);
+      // No memory dir was provisioned.
+      const dirGone = await stat(memoryDirOf(fresh)).catch(() => null);
+      assert.equal(dirGone, null);
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("counts skips when classifier returns null for every candidate", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-skip-"));
+    try {
+      await writeLegacyMemoryForTest(fresh, ["# Memory", "## Junk", "- one", "- two", "- three", ""].join("\n"));
+      const result = await migrateLegacyMemory(fresh, async () => null);
+      assert.equal(result.skippedByClassifier, 3);
+      assert.equal(result.written.preference, 0);
+      const all = await loadAllMemoryEntries(fresh);
+      assert.deepEqual(all, []);
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("counts a write error without aborting the rest of the batch", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-err-"));
+    try {
+      await writeLegacyMemoryForTest(fresh, ["# Memory", "## Mixed", "- A", "- B", ""].join("\n"));
+      // Classifier returns a malformed verdict for "A" by claiming a
+      // type the schema rejects. The migration counts the skip and
+      // still writes "B".
+      const classifier: MemoryClassifier = async ({ body }) => {
+        if (body === "A") return { type: "bogus" as MemoryType };
+        return { type: "fact" };
+      };
+      const result = await migrateLegacyMemory(fresh, classifier);
+      assert.equal(result.written.fact, 1);
+      assert.equal(result.skippedByClassifier, 1);
+      assert.equal(result.writeErrors, 0);
+      const all = await loadAllMemoryEntries(fresh);
+      assert.equal(all.length, 1);
+      assert.equal(all[0].type, "fact");
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -29,6 +29,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "htmls",
     "images",
     "markdowns",
+    "memoryDir",
     "news",
     "roles",
     "scheduler",


### PR DESCRIPTION
## Summary

- Adds the typed memory storage layer (schema + IO + migration) **without wiring it into runtime**.
- This is PR-A of #1029. PR-B will land the `workspace.ts` wire + agent prompt update **atomically** so the workspace never sits in a half-migrated state where read and write disagree.

## Items to Confirm / Review

- **Schema**: 4 types (`preference / interest / fact / reference`). Filename convention `<slug>.md` with type carried in frontmatter — filename is ergonomic only, type field is the source of truth. OK?
- **Slug strategy**: ASCII compaction; non-ASCII names fall back to `<type>_<hash36>`. Implemented with an explicit char loop (no regex) to keep sonarjs happy and remove any DoS angle.
- **Reader tolerance**: a corrupt frontmatter on one entry logs and is skipped; the rest still load. Acceptable?
- **Migration**: classifier is injected (`MemoryClassifier`) so tests run with a stub. PR-B will wire in the real LLM-backed classifier.
- **Backup**: `memory.md` → `memory.md.backup` via `rename`. If the rename fails (e.g. backup already present from a previous aborted run) we log and continue — the typed files are already written. Good enough or do we want collision handling?
- **Type-shape test**: `test/workspace/test_paths_shape.ts` snapshot was updated to include `memoryDir`.

## User Prompt

> 1029〜1035のメモリ周り。まずは分割と、それの読み込みを実装したいけど、どういう順が良い？
> writeだけ書き換えると、そのごreadがうまくいかなくない？まとめていれないとだめじゃない？

→ split & read を実装するために、まず storage layer を独立 PR として準備（PR-A）。runtime の挙動変更は PR-B にまとめる、というアプローチ。

## Implementation approach

Per `plans/feat-memory-storage-utilities.md`:

1. `server/workspace/memory/types.ts` — schema types + slug helper.
2. `server/workspace/memory/io.ts` — `loadAllMemoryEntries` / `writeMemoryEntry` / `regenerateIndex`. Uses existing `readDirSafeAsync` / `readTextSafe` / `statSafeAsync` helpers from `utils/files/safe.ts` so ENOENT branches stay consistent with the rest of the codebase. Writes go through `writeFileAtomic` with `uniqueTmp: true`.
3. `server/workspace/memory/migrate.ts` — `migrateLegacyMemory`: parse legacy `memory.md` by H2 + bullet (character-driven, no regex), call classifier per candidate, write typed files, regenerate index, rename source to `.backup`.
4. Adds `memoryDir` and `memoryIndex` to `WORKSPACE_DIRS` / `WORKSPACE_FILES` / `WORKSPACE_PATHS` so PR-B's wiring is plumbing-only.
5. Tests cover round-trip, reader tolerance, index regeneration, happy-path migration, no-source, classifier-all-null, malformed verdict.

## Out of scope (deferred)

- **PR-B** (next): `workspace.ts` wire + `prompt.ts:26 + 77` updates (atomic).
- Index auto-regeneration on `conversations/memory/*.md` writes (human edit drift) — deferred until #1032 lands.
- `/memory` UI (#1032), expiration (#1033), tags (#1034), proactive recall (#1035).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (only pre-existing warnings in `src/utils/image/htmlSrcAttrs.ts`)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — full suite green; 7 new memory tests pass
- [ ] CI: confirm Windows / macOS / Linux pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduces a typed memory storage system supporting multiple memory categories: preferences, interests, facts, and references.
  * Adds automatic migration from legacy memory format to the new structured system.
  * Generates and maintains an organized memory index for quick access and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->