### PR TITLE
fix(ci/codex): use chat-completions wire + GA API version

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -96,7 +96,12 @@ jobs:
           # Default to a known Azure API version; override with
           # `AZURE_OPENAI_API_VERSION` secret if a newer deployment
           # demands a different one.
-          AZURE_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION || '2025-04-01-preview' }}
+          # `2024-10-21` is the latest GA API version that broadly
+          # supports Chat Completions on Azure deployments. Override
+          # via the optional `AZURE_OPENAI_API_VERSION` secret if
+          # the deployment needs a newer preview (e.g. for the
+          # Responses API).
+          AZURE_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION || '2024-10-21' }}
           # Deployment name on the Azure resource (the LLM model
           # alias the workspace administrator created). Codex passes
           # this through as `model = ...` in the request body.
@@ -113,7 +118,12 @@ jobs:
           name = "Azure OpenAI"
           base_url = "${BASE_URL}/openai/v1"
           env_key = "OPENAI_API_KEY"
-          wire_api = "responses"
+          # Chat Completions is GA on every Azure deployment. The
+          # Responses API (wire_api = "responses") requires a newer
+          # API version that is not enabled on every Azure resource
+          # by default — switch back via the AZURE_OPENAI_API_VERSION
+          # secret + this field once confirmed available.
+          wire_api = "chat"
           query_params = { "api-version" = "${AZURE_API_VERSION}" }
           TOML
           # Sanity log: print the config without the URL host so we


### PR DESCRIPTION
## Summary

Iter-1 of the Codex auto-review workflow (#1059) got past the auth issue (provider config now lands correctly via `~/.codex/config.toml`) but surfaced a new error on dispatch:

```
ERROR: {"error":{"code":"BadRequest","message":"API version not supported"}}
```

Cause: `wire_api = "responses"` + `2025-04-01-preview` requires the newer Responses API surface that the Azure resource doesn't expose yet. Drop to Chat Completions + GA `2024-10-21`, both broadly supported.

| Field | Was | Now |
|---|---|---|
| `wire_api` | `"responses"` | `"chat"` |
| `query_params["api-version"]` default | `2025-04-01-preview` | `2024-10-21` |

Both still overridable via `AZURE_OPENAI_API_VERSION` secret.

## Items to Confirm / Review

- This is the second iteration on the workflow. Test plan after merge: dispatch the workflow again on PR #1059 (or any other) via Actions UI → "Run workflow".
- If `2024-10-21` also fails (some Azure resources are pinned to older versions), the next step is checking the Azure portal for the supported API versions on `mulmo-sweden`.
- `pull_request` trigger remains disabled until a clean dispatch run completes end-to-end.

## User Prompt

> reviewのci失敗している
> すすめて

🤖 Generated with [Claude Code](https://claude.com/claude-code)