### PR TITLE
fix(ci/codex): switch back to Responses API + bump default api-version

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -96,12 +96,14 @@ jobs:
           # Default to a known Azure API version; override with
           # `AZURE_OPENAI_API_VERSION` secret if a newer deployment
           # demands a different one.
-          # `2024-10-21` is the latest GA API version that broadly
-          # supports Chat Completions on Azure deployments. Override
-          # via the optional `AZURE_OPENAI_API_VERSION` secret if
-          # the deployment needs a newer preview (e.g. for the
-          # Responses API).
-          AZURE_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION || '2024-10-21' }}
+          # Codex CLI 0.125.0 dropped `wire_api = "chat"` support
+          # (https://github.com/openai/codex/discussions/7782) — the
+          # only supported transport is now the Responses API. On
+          # Azure that requires `2025-03-01-preview` or later;
+          # earlier versions return "API version not supported".
+          # Override via the `AZURE_OPENAI_API_VERSION` secret if a
+          # newer preview is needed for a specific deployment.
+          AZURE_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION || '2025-03-01-preview' }}
           # Deployment name on the Azure resource (the LLM model
           # alias the workspace administrator created). Codex passes
           # this through as `model = ...` in the request body.
@@ -118,12 +120,12 @@ jobs:
           name = "Azure OpenAI"
           base_url = "${BASE_URL}/openai/v1"
           env_key = "OPENAI_API_KEY"
-          # Chat Completions is GA on every Azure deployment. The
-          # Responses API (wire_api = "responses") requires a newer
-          # API version that is not enabled on every Azure resource
-          # by default — switch back via the AZURE_OPENAI_API_VERSION
-          # secret + this field once confirmed available.
-          wire_api = "chat"
+          # Codex CLI 0.125.0 only supports `responses` (Chat
+          # Completions wire was removed). On Azure this needs
+          # `api-version = 2025-03-01-preview` or newer + a
+          # deployment that exposes the Responses surface (recent
+          # gpt-4o / gpt-4.1 / gpt-5 family does).
+          wire_api = "responses"
           query_params = { "api-version" = "${AZURE_API_VERSION}" }
           TOML
           # Sanity log: print the config without the URL host so we


### PR DESCRIPTION
## Summary

Iter-2 dispatch (run 25192366569) failed because Codex CLI 0.125.0 dropped \`wire_api = "chat"\` support entirely:

```
Error loading config.toml: \`wire_api = "chat"\` is no longer supported.
How to fix: set \`wire_api = "responses"\` in your provider config.
More info: https://github.com/openai/codex/discussions/7782
```

Switch back to Responses + bump the default API version to \`2025-03-01-preview\` (which Microsoft documents as supporting the \`/responses\` surface on Azure). The \`AZURE_OPENAI_API_VERSION\` secret still wins if a specific deployment needs a different preview.

## Items to Confirm / Review

- This is iter-3 of the Azure auth dance. Test plan: dispatch on PR #1061 again post-merge.
- If \`2025-03-01-preview\` also fails, the resource may need an even newer preview, OR the \`gpt-5.4-mini\` deployment may not expose the Responses API. Either case is a quick secret update — no further workflow change.

## User Prompt

> CI通ったら #1060 をマージして、その後 Actions UI で workflow_dispatch を使って既存の open PR に対する codex review をテストして

(continuation of the iter-loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)