### PR TITLE
feat(chat): add copy-as-Markdown button to chat toolbar

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -43,7 +43,8 @@ The `w-80` left column inside the chat page (and any other view that mounts it).
 ```
 ┌─<SessionSidebar>──────────────────────────────┐
 │ ┌─[sidebar-role-header]─────────────────────┐ │
-│ │ ⭐ General                       🔧  ▦/▥  │ │  ← role icon + name
+│ │ ⭐ General              [copy-chat-md] 🔧 ▦/▥│ │  ← role icon + name
+│ │                                            │ │     copy session as Markdown (content_copy)
 │ │                                            │ │     toggle right sidebar (build icon)
 │ │                                            │ │     <CanvasViewToggle> single/stack
 │ └────────────────────────────────────────────┘ │
@@ -64,7 +65,7 @@ The `w-80` left column inside the chat page (and any other view that mounts it).
 └────────────────────────────────────────────────┘
 ```
 
-In **Stack layout** this sidebar isn't rendered; the same data flows through `<StackView>` which inlines result bodies into the main column. Only single layout shows the preview list.
+In **Stack layout** this sidebar isn't rendered; the same data flows through `<StackView>` which inlines result bodies into the main column. Only single layout shows the preview list. `<StackView>`'s own header (`[stack-role-header]`) carries the same control cluster — `[copy-chat-md]` (content_copy → check on success), tool-call-history toggle, and `<CanvasViewToggle>` — so the affordance lives in the same visual slot regardless of layout.
 
 ## NotificationBell expanded
 

--- a/src/components/CopyChatButton.vue
+++ b/src/components/CopyChatButton.vue
@@ -27,6 +27,8 @@ import { ref, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { exportChatToMarkdown } from "../utils/chat/exportMarkdown";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
 
 const COPIED_FEEDBACK_MS = 1500;
 
@@ -41,10 +43,17 @@ const props = defineProps<{
 const justCopied = ref(false);
 let resetTimeout: ReturnType<typeof setTimeout> | null = null;
 
+async function readWorkspaceFile(path: string): Promise<string | null> {
+  const result = await apiGet<{ content?: string }>(API_ROUTES.files.content, { path });
+  if (!result.ok) return null;
+  return result.data.content ?? null;
+}
+
 async function onCopy(): Promise<void> {
-  const markdown = exportChatToMarkdown(props.results, {
+  const markdown = await exportChatToMarkdown(props.results, {
     sessionRoleName: props.sessionRoleName,
     resultTimestamps: props.resultTimestamps,
+    readFile: readWorkspaceFile,
   });
   try {
     await navigator.clipboard.writeText(markdown);

--- a/src/components/CopyChatButton.vue
+++ b/src/components/CopyChatButton.vue
@@ -1,0 +1,67 @@
+<template>
+  <!-- Copies the current chat session to the clipboard as Markdown.
+       Lives in both <SessionSidebar> (single layout) and <StackView>
+       (stack layout) so the affordance is in the same visual slot
+       regardless of which layout the user is in.
+
+       Success feedback is local: the icon swaps to a check for ~1.5s.
+       No global toast composable yet (#TODO once one exists), and a
+       transient icon swap is enough since the user's hand is already
+       on the button. -->
+  <button
+    type="button"
+    class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    :class="{ '!text-green-600': justCopied }"
+    data-testid="copy-chat-md"
+    :disabled="results.length === 0"
+    :title="justCopied ? t('sidebarHeader.copiedMarkdown') : t('sidebarHeader.copyMarkdown')"
+    :aria-label="justCopied ? t('sidebarHeader.copiedMarkdown') : t('sidebarHeader.copyMarkdown')"
+    @click="onCopy"
+  >
+    <span class="material-icons text-lg" aria-hidden="true">{{ justCopied ? "check" : "content_copy" }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { ref, onUnmounted } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { exportChatToMarkdown } from "../utils/chat/exportMarkdown";
+
+const COPIED_FEEDBACK_MS = 1500;
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  results: ToolResultComplete[];
+  resultTimestamps: Map<string, number>;
+  sessionRoleName?: string;
+}>();
+
+const justCopied = ref(false);
+let resetTimeout: ReturnType<typeof setTimeout> | null = null;
+
+async function onCopy(): Promise<void> {
+  const markdown = exportChatToMarkdown(props.results, {
+    sessionRoleName: props.sessionRoleName,
+    resultTimestamps: props.resultTimestamps,
+  });
+  try {
+    await navigator.clipboard.writeText(markdown);
+    justCopied.value = true;
+    if (resetTimeout !== null) clearTimeout(resetTimeout);
+    resetTimeout = setTimeout(() => {
+      justCopied.value = false;
+      resetTimeout = null;
+    }, COPIED_FEEDBACK_MS);
+  } catch {
+    // Clipboard write can reject when the document isn't focused or
+    // permission is denied. The missing visual confirmation is itself
+    // the user-facing signal; logging would only spam the console.
+  }
+}
+
+onUnmounted(() => {
+  if (resetTimeout !== null) clearTimeout(resetTimeout);
+});
+</script>

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -4,6 +4,7 @@
       <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
       <span v-if="sessionRoleName" class="truncate">{{ sessionRoleName }}</span>
       <div class="ml-auto flex items-center gap-0.5 shrink-0">
+        <CopyChatButton :results="results" :result-timestamps="resultTimestamps" :session-role-name="sessionRoleName" />
         <button
           type="button"
           class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
@@ -55,6 +56,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
+import CopyChatButton from "./CopyChatButton.vue";
 import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -3,11 +3,12 @@
     <div class="shrink-0 flex items-center gap-1 text-xs text-gray-400 px-4 pt-3 pb-2" data-testid="stack-role-header">
       <span v-if="sessionRoleIcon" class="material-icons text-xs leading-none">{{ sessionRoleIcon }}</span>
       <span v-if="sessionRoleName">{{ sessionRoleName }}</span>
-      <div class="ml-auto flex items-center gap-1">
+      <div class="ml-auto flex items-center gap-0.5">
+        <CopyChatButton :results="toolResults" :result-timestamps="resultTimestamps" :session-role-name="sessionRoleName" />
         <button
           type="button"
-          class="text-gray-400 hover:text-gray-700"
-          :class="{ 'text-blue-500': showRightSidebar }"
+          class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          :class="{ '!text-blue-500': showRightSidebar }"
           :title="t('sidebarHeader.toolCallHistory')"
           :aria-label="t('sidebarHeader.toolCallHistory')"
           :aria-pressed="showRightSidebar"
@@ -104,6 +105,7 @@ import type { TextResponseData } from "../plugins/textResponse/types";
 import { formatSmartTime } from "../utils/format/date";
 import { isRecord } from "../utils/types";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
+import CopyChatButton from "./CopyChatButton.vue";
 import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -71,6 +71,8 @@ const deMessages = {
     todayJournal: "Heutige Zusammenfassung",
     todayJournalNotFound: "Noch keine Zusammenfassung — chatte etwas und das Journal erstellt eine.",
     todayJournalLoadFailed: "Journal konnte nicht geladen werden (Status {status}): {error}",
+    copyMarkdown: "Chat als Markdown kopieren",
+    copiedMarkdown: "Kopiert!",
   },
   rightSidebar: {
     toggleSystemPrompt: "System-Prompt umschalten",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -93,6 +93,8 @@ const enMessages = {
     todayJournal: "Today's journal",
     todayJournalNotFound: "No journal summary yet — chat for a while and the journal will generate one.",
     todayJournalLoadFailed: "Failed to load journal (status {status}): {error}",
+    copyMarkdown: "Copy chat as Markdown",
+    copiedMarkdown: "Copied!",
   },
   rightSidebar: {
     toggleSystemPrompt: "Toggle system prompt",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -76,6 +76,8 @@ const esMessages = {
     todayJournal: "Resumen de hoy",
     todayJournalNotFound: "Aún no hay resumen — chatea un rato y el journal lo generará.",
     todayJournalLoadFailed: "Error al cargar el journal (status {status}): {error}",
+    copyMarkdown: "Copiar la conversación como Markdown",
+    copiedMarkdown: "¡Copiado!",
   },
   rightSidebar: {
     toggleSystemPrompt: "Alternar system prompt",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -71,6 +71,8 @@ const frMessages = {
     todayJournal: "Résumé du jour",
     todayJournalNotFound: "Pas encore de résumé — discutez un peu et le journal en générera un.",
     todayJournalLoadFailed: "Échec du chargement du journal (status {status}) : {error}",
+    copyMarkdown: "Copier la conversation en Markdown",
+    copiedMarkdown: "Copié !",
   },
   rightSidebar: {
     toggleSystemPrompt: "Basculer le system prompt",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -78,6 +78,8 @@ const jaMessages = {
     todayJournal: "今日のまとめ",
     todayJournalNotFound: "まだまとめがありません — しばらく会話するとjournalが生成します。",
     todayJournalLoadFailed: "journal の読み込みに失敗しました (status {status}): {error}",
+    copyMarkdown: "チャットを Markdown としてコピー",
+    copiedMarkdown: "コピーしました",
   },
   rightSidebar: {
     toggleSystemPrompt: "システムプロンプトの表示切替",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -78,6 +78,8 @@ const koMessages = {
     todayJournal: "오늘의 요약",
     todayJournalNotFound: "아직 요약이 없습니다 — 잠시 대화하면 journal이 생성합니다.",
     todayJournalLoadFailed: "journal 로드에 실패했습니다 (status {status}): {error}",
+    copyMarkdown: "대화를 Markdown으로 복사",
+    copiedMarkdown: "복사됨",
   },
   rightSidebar: {
     toggleSystemPrompt: "시스템 프롬프트 토글",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -71,6 +71,8 @@ const ptBRMessages = {
     todayJournal: "Resumo de hoje",
     todayJournalNotFound: "Ainda sem resumo — converse um pouco e o journal será gerado.",
     todayJournalLoadFailed: "Falha ao carregar o journal (status {status}): {error}",
+    copyMarkdown: "Copiar conversa como Markdown",
+    copiedMarkdown: "Copiado!",
   },
   rightSidebar: {
     toggleSystemPrompt: "Alternar system prompt",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -76,6 +76,8 @@ const zhMessages = {
     todayJournal: "今日总结",
     todayJournalNotFound: "暂无总结 — 多聊一会儿，journal 会自动生成。",
     todayJournalLoadFailed: "加载 journal 失败 (status {status}): {error}",
+    copyMarkdown: "将对话复制为 Markdown",
+    copiedMarkdown: "已复制",
   },
   rightSidebar: {
     toggleSystemPrompt: "切换系统提示词",

--- a/src/utils/chat/exportMarkdown.ts
+++ b/src/utils/chat/exportMarkdown.ts
@@ -2,27 +2,43 @@
 // items + per-uuid timestamps) into a self-contained Markdown document
 // suitable for pasting into a doc, an issue, or another chat.
 //
-// Design (Option A — blockquoted turns):
-//   Each speaker turn is rendered as `### 👤 Speaker · HH:MM` followed
-//   by the message body prefixed line-by-line with `> `. The blockquote
-//   guarantees that any markdown the message itself contains (headings,
-//   tables, code fences, raw HTML) renders inside a visually distinct
-//   quote region rather than colliding with the export's own structure.
+// Each turn is rendered as a `## ⬜︎ Speaker · HH:MM` heading followed
+// by the message body, with `---` horizontal rules between turns.
+// Headings inside message bodies are demoted by 2 levels (e.g. an
+// assistant `# Heading` becomes `### Heading`) so the speaker headings
+// always sit above message-internal structure in the document outline.
 //
-// Tool calls (anything other than `text-response`) are rendered as a
-// single italic line `*🔧 toolName — title*`, outside the blockquote.
-// Their full payloads are intentionally omitted to keep the export
-// readable; users wanting fidelity can view the raw JSONL.
+// Tool calls (anything other than `text-response`) render as a `## ⬛︎
+// toolName HH:MM` heading — a compact marker showing which tools the
+// assistant invoked. Tool payloads are intentionally omitted to keep
+// the export readable; users wanting fidelity can view the raw JSONL.
+// The one exception is `presentDocument`: its `data.markdown` is
+// itself a piece of prose worth reading out of context, so we inline
+// the document body (demoted by 2 levels) under the marker. In real
+// sessions `data.markdown` is usually a workspace path
+// (`artifacts/documents/*.md`) rather than inline text, so the export
+// is async — callers pass a `readFile` resolver that reads the file
+// off the workspace, mirroring the in-app Markdown View's loader.
 
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { isRecord } from "../types";
 
 const TEXT_RESPONSE_TOOL = "text-response";
+const PRESENT_DOCUMENT_TOOL = "presentDocument";
+
+/** Heuristic for the file-path mode of presentDocument's `markdown` field
+ *  (server-side documents stored under `artifacts/documents/*.md`). When
+ *  matched, the value is a path — not inline content — and the export
+ *  has to read the file off the workspace via the caller-supplied
+ *  resolver to inline the body. */
+function looksLikeDocumentPath(value: string): boolean {
+  return value.endsWith(".md") && value.startsWith("artifacts/documents/");
+}
 
 const ROLE_LABELS = {
-  user: "👤 You",
-  assistant: "🤖 Assistant",
-  system: "⚙️ System",
+  user: "⬜︎ You",
+  assistant: "⬛︎ Assistant",
+  system: "◇ System",
 } as const;
 
 type Role = keyof typeof ROLE_LABELS;
@@ -34,6 +50,11 @@ export interface ExportChatOptions {
   exportedAt?: string;
   /** Per-uuid epoch-ms map matching `ActiveSession.resultTimestamps`. */
   resultTimestamps?: Map<string, number>;
+  /** Resolver for workspace-relative file paths (currently the
+   *  `artifacts/documents/*.md` form used by presentDocument). Returns
+   *  the file's text content, or null if the read fails. Omit it to
+   *  skip file-mode resolution and emit only the marker line. */
+  readFile?: (path: string) => Promise<string | null>;
 }
 
 /** Format `epochMs` as `HH:MM` in 24h, locale-independent. */
@@ -42,16 +63,6 @@ function formatHHMM(epochMs: number): string {
   const hours = String(date.getHours()).padStart(2, "0");
   const minutes = String(date.getMinutes()).padStart(2, "0");
   return `${hours}:${minutes}`;
-}
-
-/** Prefix every line with `> `. Empty lines become bare `>` so the quote
- *  block stays contiguous (CommonMark breaks the quote on a fully blank line). */
-function blockquote(text: string): string {
-  if (text.length === 0) return ">";
-  return text
-    .split(/\r\n|\r|\n/)
-    .map((line) => (line.length === 0 ? ">" : `> ${line}`))
-    .join("\n");
 }
 
 /** Narrow `data?.role` to a known speaker label. Defaults to "assistant". */
@@ -75,19 +86,75 @@ function isTextResponse(result: ToolResultComplete): boolean {
   return result.toolName === TEXT_RESPONSE_TOOL;
 }
 
+const FENCE_RE = /^(`{3,}|~{3,})/;
+const ATX_HEADING_RE = /^(#{1,6})([ \t].*)$/;
+
+/** Demote every ATX heading inside `markdown` by `levels` (`#` → `#`+levels),
+ *  capping at h6. Skips lines inside fenced code blocks (``` / ~~~) so
+ *  `# comment` lines in code samples are left alone. */
+function demoteHeadings(markdown: string, levels: number): string {
+  if (levels <= 0 || markdown.length === 0) return markdown;
+  const out: string[] = [];
+  let inFence = false;
+  for (const line of markdown.split(/\r\n|\r|\n/)) {
+    if (FENCE_RE.test(line)) {
+      inFence = !inFence;
+      out.push(line);
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    const match = ATX_HEADING_RE.exec(line);
+    if (!match) {
+      out.push(line);
+      continue;
+    }
+    const [, hashes, rest] = match;
+    const newDepth = Math.min(6, hashes.length + levels);
+    out.push(`${"#".repeat(newDepth)}${rest}`);
+  }
+  return out.join("\n");
+}
+
 function renderTextTurn(result: ToolResultComplete, timestamps: Map<string, number>): string {
   const role = roleOf(result);
   const epochMs = timestamps.get(result.uuid);
   const time = epochMs ? ` · ${formatHHMM(epochMs)}` : "";
-  const body = textOf(result).trim();
-  return `### ${ROLE_LABELS[role]}${time}\n${blockquote(body)}`;
+  // Speaker is `##`; demote any in-body heading by 2 so it always sits
+  // strictly below the speaker (`#` → `###`, `##` → `####`, …).
+  const body = demoteHeadings(textOf(result).trim(), 2);
+  return body.length > 0 ? `## ${ROLE_LABELS[role]}${time}\n\n${body}` : `## ${ROLE_LABELS[role]}${time}`;
 }
 
-function renderToolTurn(result: ToolResultComplete, timestamps: Map<string, number>): string {
+/** Resolve presentDocument's `data.markdown` to inline content. If the
+ *  value is a workspace path, defer to `readFile`; otherwise treat it
+ *  as inline markdown. Returns null when the data is missing/empty or
+ *  the file read fails. */
+async function presentDocumentBody(result: ToolResultComplete, readFile: ExportChatOptions["readFile"]): Promise<string | null> {
+  const { data } = result;
+  if (!isRecord(data)) return null;
+  const { markdown } = data;
+  if (typeof markdown !== "string" || markdown.length === 0) return null;
+  if (!looksLikeDocumentPath(markdown)) return markdown;
+  if (!readFile) return null;
+  return readFile(markdown);
+}
+
+async function renderToolTurn(result: ToolResultComplete, timestamps: Map<string, number>, readFile: ExportChatOptions["readFile"]): Promise<string> {
   const epochMs = timestamps.get(result.uuid);
-  const time = epochMs ? ` · ${formatHHMM(epochMs)}` : "";
-  const label = result.title?.trim() ? `${result.toolName} — ${result.title.trim()}` : result.toolName;
-  return `*🔧 ${label}${time}*`;
+  const time = epochMs ? ` ${formatHHMM(epochMs)}` : "";
+  const marker = `## ⬛︎ ${result.toolName}${time}`;
+
+  if (result.toolName === PRESENT_DOCUMENT_TOOL) {
+    const documentBody = await presentDocumentBody(result, readFile);
+    if (documentBody !== null) {
+      return `${marker}\n\n${demoteHeadings(documentBody.trim(), 2)}`;
+    }
+  }
+
+  return marker;
 }
 
 /** Build the document header. Title and the "Exported" subtitle are
@@ -101,12 +168,17 @@ function renderHeader(opts: ExportChatOptions): string {
   return `${title}\n\n*Exported ${dateStamp} UTC*\n\n---`;
 }
 
-/** Convert a chat session to a Markdown string. Pure function; safe to
- *  call from anywhere. Returns at minimum a non-empty header so callers
- *  never have to special-case empty sessions. */
-export function exportChatToMarkdown(results: readonly ToolResultComplete[], options: ExportChatOptions = {}): string {
+/** Convert a chat session to a Markdown string. Async because
+ *  presentDocument's body may live on disk and need a `readFile` round
+ *  trip. Returns at minimum a non-empty header so callers never have
+ *  to special-case empty sessions. */
+export async function exportChatToMarkdown(results: readonly ToolResultComplete[], options: ExportChatOptions = {}): Promise<string> {
   const timestamps = options.resultTimestamps ?? new Map<string, number>();
-  const turns = results.map((result) => (isTextResponse(result) ? renderTextTurn(result, timestamps) : renderToolTurn(result, timestamps)));
+  const turns = await Promise.all(
+    results.map((result) =>
+      isTextResponse(result) ? Promise.resolve(renderTextTurn(result, timestamps)) : renderToolTurn(result, timestamps, options.readFile),
+    ),
+  );
   const body = turns.join("\n\n---\n\n");
   const header = renderHeader(options);
   return body.length > 0 ? `${header}\n\n${body}\n` : `${header}\n`;

--- a/src/utils/chat/exportMarkdown.ts
+++ b/src/utils/chat/exportMarkdown.ts
@@ -86,23 +86,55 @@ function isTextResponse(result: ToolResultComplete): boolean {
   return result.toolName === TEXT_RESPONSE_TOOL;
 }
 
-const FENCE_RE = /^(`{3,}|~{3,})/;
+const FENCE_RUN_RE = /^(`{3,}|~{3,})/;
 const ATX_HEADING_RE = /^(#{1,6})([ \t].*)$/;
 
+interface OpenFence {
+  char: "`" | "~";
+  len: number;
+}
+
+/** Match the leading run of fence characters on `line`, if any. Captures
+ *  the fence char + length so the closing logic can apply GFM's rules
+ *  (close fence must be the same char and at least as long as the open). */
+function matchFenceRun(line: string): OpenFence | null {
+  const match = FENCE_RUN_RE.exec(line);
+  if (!match) return null;
+  const [, run] = match;
+  return { char: run[0] as "`" | "~", len: run.length };
+}
+
+/** A line closes `open` only when it uses the same fence char, has at
+ *  least as many of them, and carries no info-string after the run.
+ *  Anything else inside the fence is content (including a different
+ *  fence type or a shorter run). */
+function isClosingFence(line: string, fence: OpenFence, open: OpenFence): boolean {
+  if (fence.char !== open.char) return false;
+  if (fence.len < open.len) return false;
+  return line.slice(fence.len).trim() === "";
+}
+
 /** Demote every ATX heading inside `markdown` by `levels` (`#` → `#`+levels),
- *  capping at h6. Skips lines inside fenced code blocks (``` / ~~~) so
- *  `# comment` lines in code samples are left alone. */
+ *  capping at h6. Skips lines inside fenced code blocks so `# comment`
+ *  lines in code samples are left alone. Honours GFM fence rules: a
+ *  block opened with N backticks (or N tildes) only closes on a line of
+ *  the same character with ≥N of them and nothing else, so nested
+ *  shorter fences and the opposite fence char both count as content. */
 function demoteHeadings(markdown: string, levels: number): string {
   if (levels <= 0 || markdown.length === 0) return markdown;
   const out: string[] = [];
-  let inFence = false;
+  let openFence: OpenFence | null = null;
   for (const line of markdown.split(/\r\n|\r|\n/)) {
-    if (FENCE_RE.test(line)) {
-      inFence = !inFence;
+    const fence = matchFenceRun(line);
+    if (openFence !== null) {
+      if (fence !== null && isClosingFence(line, fence, openFence)) {
+        openFence = null;
+      }
       out.push(line);
       continue;
     }
-    if (inFence) {
+    if (fence !== null) {
+      openFence = fence;
       out.push(line);
       continue;
     }
@@ -121,7 +153,11 @@ function demoteHeadings(markdown: string, levels: number): string {
 function renderTextTurn(result: ToolResultComplete, timestamps: Map<string, number>): string {
   const role = roleOf(result);
   const epochMs = timestamps.get(result.uuid);
-  const time = epochMs ? ` · ${formatHHMM(epochMs)}` : "";
+  // Use `!== undefined` rather than truthiness so a 0 (Unix epoch)
+  // timestamp still renders. Practically irrelevant for live chat, but
+  // it removes a foot-gun for any synthetic / migrated session that
+  // ends up with that boundary value.
+  const time = epochMs !== undefined ? ` · ${formatHHMM(epochMs)}` : "";
   // Speaker is `##`; demote any in-body heading by 2 so it always sits
   // strictly below the speaker (`#` → `###`, `##` → `####`, …).
   const body = demoteHeadings(textOf(result).trim(), 2);
@@ -139,12 +175,18 @@ async function presentDocumentBody(result: ToolResultComplete, readFile: ExportC
   if (typeof markdown !== "string" || markdown.length === 0) return null;
   if (!looksLikeDocumentPath(markdown)) return markdown;
   if (!readFile) return null;
-  return readFile(markdown);
+  // Honour the documented "returns null on failure" contract — a
+  // single rejected resolver shouldn't blow up the whole export.
+  try {
+    return await readFile(markdown);
+  } catch {
+    return null;
+  }
 }
 
 async function renderToolTurn(result: ToolResultComplete, timestamps: Map<string, number>, readFile: ExportChatOptions["readFile"]): Promise<string> {
   const epochMs = timestamps.get(result.uuid);
-  const time = epochMs ? ` ${formatHHMM(epochMs)}` : "";
+  const time = epochMs !== undefined ? ` ${formatHHMM(epochMs)}` : "";
   const marker = `## ⬛︎ ${result.toolName}${time}`;
 
   if (result.toolName === PRESENT_DOCUMENT_TOOL) {

--- a/src/utils/chat/exportMarkdown.ts
+++ b/src/utils/chat/exportMarkdown.ts
@@ -1,0 +1,113 @@
+// Convert an in-memory chat session (a sequence of ToolResultComplete
+// items + per-uuid timestamps) into a self-contained Markdown document
+// suitable for pasting into a doc, an issue, or another chat.
+//
+// Design (Option A — blockquoted turns):
+//   Each speaker turn is rendered as `### 👤 Speaker · HH:MM` followed
+//   by the message body prefixed line-by-line with `> `. The blockquote
+//   guarantees that any markdown the message itself contains (headings,
+//   tables, code fences, raw HTML) renders inside a visually distinct
+//   quote region rather than colliding with the export's own structure.
+//
+// Tool calls (anything other than `text-response`) are rendered as a
+// single italic line `*🔧 toolName — title*`, outside the blockquote.
+// Their full payloads are intentionally omitted to keep the export
+// readable; users wanting fidelity can view the raw JSONL.
+
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { isRecord } from "../types";
+
+const TEXT_RESPONSE_TOOL = "text-response";
+
+const ROLE_LABELS = {
+  user: "👤 You",
+  assistant: "🤖 Assistant",
+  system: "⚙️ System",
+} as const;
+
+type Role = keyof typeof ROLE_LABELS;
+
+export interface ExportChatOptions {
+  /** Friendly role / persona name shown in the document title (e.g. "General"). */
+  sessionRoleName?: string;
+  /** ISO string for the document's "Exported …" line. Defaults to `new Date()`. */
+  exportedAt?: string;
+  /** Per-uuid epoch-ms map matching `ActiveSession.resultTimestamps`. */
+  resultTimestamps?: Map<string, number>;
+}
+
+/** Format `epochMs` as `HH:MM` in 24h, locale-independent. */
+function formatHHMM(epochMs: number): string {
+  const date = new Date(epochMs);
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/** Prefix every line with `> `. Empty lines become bare `>` so the quote
+ *  block stays contiguous (CommonMark breaks the quote on a fully blank line). */
+function blockquote(text: string): string {
+  if (text.length === 0) return ">";
+  return text
+    .split(/\r\n|\r|\n/)
+    .map((line) => (line.length === 0 ? ">" : `> ${line}`))
+    .join("\n");
+}
+
+/** Narrow `data?.role` to a known speaker label. Defaults to "assistant". */
+function roleOf(result: ToolResultComplete): Role {
+  const { data } = result;
+  if (isRecord(data) && typeof data.role === "string" && data.role in ROLE_LABELS) {
+    return data.role as Role;
+  }
+  return "assistant";
+}
+
+/** Pull the displayable text from a text-response result. Falls back to
+ *  `message` for older/saved sessions where `data.text` may be missing. */
+function textOf(result: ToolResultComplete): string {
+  const { data } = result;
+  if (isRecord(data) && typeof data.text === "string") return data.text;
+  return result.message ?? "";
+}
+
+function isTextResponse(result: ToolResultComplete): boolean {
+  return result.toolName === TEXT_RESPONSE_TOOL;
+}
+
+function renderTextTurn(result: ToolResultComplete, timestamps: Map<string, number>): string {
+  const role = roleOf(result);
+  const epochMs = timestamps.get(result.uuid);
+  const time = epochMs ? ` · ${formatHHMM(epochMs)}` : "";
+  const body = textOf(result).trim();
+  return `### ${ROLE_LABELS[role]}${time}\n${blockquote(body)}`;
+}
+
+function renderToolTurn(result: ToolResultComplete, timestamps: Map<string, number>): string {
+  const epochMs = timestamps.get(result.uuid);
+  const time = epochMs ? ` · ${formatHHMM(epochMs)}` : "";
+  const label = result.title?.trim() ? `${result.toolName} — ${result.title.trim()}` : result.toolName;
+  return `*🔧 ${label}${time}*`;
+}
+
+/** Build the document header. Title and the "Exported" subtitle are
+ *  intentionally plain — the conversation body is what the reader cares
+ *  about. The horizontal rule separates header from first turn. */
+function renderHeader(opts: ExportChatOptions): string {
+  const role = opts.sessionRoleName?.trim();
+  const exportedAt = new Date(opts.exportedAt ?? new Date().toISOString());
+  const dateStamp = exportedAt.toISOString().slice(0, 16).replace("T", " ");
+  const title = role ? `# Conversation · ${role}` : "# Conversation";
+  return `${title}\n\n*Exported ${dateStamp} UTC*\n\n---`;
+}
+
+/** Convert a chat session to a Markdown string. Pure function; safe to
+ *  call from anywhere. Returns at minimum a non-empty header so callers
+ *  never have to special-case empty sessions. */
+export function exportChatToMarkdown(results: readonly ToolResultComplete[], options: ExportChatOptions = {}): string {
+  const timestamps = options.resultTimestamps ?? new Map<string, number>();
+  const turns = results.map((result) => (isTextResponse(result) ? renderTextTurn(result, timestamps) : renderToolTurn(result, timestamps)));
+  const body = turns.join("\n\n---\n\n");
+  const header = renderHeader(options);
+  return body.length > 0 ? `${header}\n\n${body}\n` : `${header}\n`;
+}

--- a/test/utils/chat/test_exportMarkdown.ts
+++ b/test/utils/chat/test_exportMarkdown.ts
@@ -56,6 +56,23 @@ describe("exportChatToMarkdown", () => {
     assert.match(out, /^#### Real heading$/m);
   });
 
+  it("treats a shorter inner fence as content (4-backtick block containing a 3-backtick block)", async () => {
+    // Outer fence is 4 backticks; inner ``` is just content. The `#` on
+    // line 3 must stay untouched, and `## After` after the real close
+    // must be demoted normally.
+    const inner = "````md\n```\n# Inside inner\n```\n````\n\n## After";
+    const out = await exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# Inside inner$/m); // untouched
+    assert.match(out, /^#### After$/m); // demoted
+  });
+
+  it("treats the opposite fence char as content (~~~ inside ```)", async () => {
+    const inner = "```\n~~~\n# Inside\n~~~\n```\n\n## After";
+    const out = await exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# Inside$/m); // untouched (~~~ doesn't close a ``` fence)
+    assert.match(out, /^#### After$/m);
+  });
+
   it("renders a non-text tool call as a single `## ⬛︎ toolName HH:MM` heading line", async () => {
     const stamps = new Map<string, number>([["tool-1", Date.UTC(2026, 3, 30, 15, 17)]]);
     const out = await exportChatToMarkdown([textResult("user", "open it"), toolResult("openCanvas", "Untitled", "tool-1"), textResult("assistant", "done")], {
@@ -111,6 +128,27 @@ describe("exportChatToMarkdown", () => {
     assert.match(out, /^Server body\.$/m);
   });
 
+  it("falls back to marker-only when the readFile resolver throws", async () => {
+    const presentDoc: ToolResultComplete = {
+      toolName: "presentDocument",
+      uuid: "doc-throw",
+      message: "doc",
+      title: "Throws",
+      data: {
+        markdown: "artifacts/documents/throws.md",
+        filenamePrefix: "throws",
+      },
+    };
+    const out = await exportChatToMarkdown([presentDoc], {
+      exportedAt: "2026-04-30T12:00:00Z",
+      readFile: async () => {
+        throw new Error("network down");
+      },
+    });
+    assert.match(out, /^## ⬛︎ presentDocument$/m);
+    assert.doesNotMatch(out, /network down/);
+  });
+
   it("falls back to marker-only when the readFile resolver returns null", async () => {
     const presentDoc: ToolResultComplete = {
       toolName: "presentDocument",
@@ -154,6 +192,13 @@ describe("exportChatToMarkdown", () => {
 
   it("includes time stamps when resultTimestamps has the uuid", async () => {
     const stamps = new Map<string, number>([["t-user", Date.UTC(2026, 3, 30, 14, 35)]]);
+    const out = await exportChatToMarkdown([textResult("user", "hi")], { resultTimestamps: stamps, exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /## ⬜︎ You · \d{2}:\d{2}/);
+  });
+
+  it("renders the time even when the timestamp is the Unix epoch (0)", async () => {
+    // Boundary case: `epochMs ? …` would silently drop this.
+    const stamps = new Map<string, number>([["t-user", 0]]);
     const out = await exportChatToMarkdown([textResult("user", "hi")], { resultTimestamps: stamps, exportedAt: "2026-04-30T12:00:00Z" });
     assert.match(out, /## ⬜︎ You · \d{2}:\d{2}/);
   });

--- a/test/utils/chat/test_exportMarkdown.ts
+++ b/test/utils/chat/test_exportMarkdown.ts
@@ -22,62 +22,144 @@ function toolResult(toolName: string, title: string | undefined, uuid: string): 
 }
 
 describe("exportChatToMarkdown", () => {
-  it("renders a user/assistant exchange as blockquoted turns", () => {
-    const out = exportChatToMarkdown([textResult("user", "hello"), textResult("assistant", "hi there")], { exportedAt: "2026-04-30T12:00:00Z" });
+  it("renders a user/assistant exchange as plain-markdown turns", async () => {
+    const out = await exportChatToMarkdown([textResult("user", "hello"), textResult("assistant", "hi there")], { exportedAt: "2026-04-30T12:00:00Z" });
     assert.match(out, /^# Conversation/);
-    assert.match(out, /### 👤 You/);
-    assert.match(out, /### 🤖 Assistant/);
-    assert.match(out, /^> hello$/m);
-    assert.match(out, /^> hi there$/m);
+    assert.match(out, /## ⬜︎ You/);
+    assert.match(out, /## ⬛︎ Assistant/);
+    assert.match(out, /^hello$/m);
+    assert.match(out, /^hi there$/m);
+    assert.match(out, /\n\n---\n\n/);
   });
 
-  it("includes the role name in the title when provided", () => {
-    const out = exportChatToMarkdown([textResult("user", "hi")], { sessionRoleName: "General", exportedAt: "2026-04-30T12:00:00Z" });
+  it("includes the role name in the title when provided", async () => {
+    const out = await exportChatToMarkdown([textResult("user", "hi")], { sessionRoleName: "General", exportedAt: "2026-04-30T12:00:00Z" });
     assert.match(out, /^# Conversation · General/);
   });
 
-  it("preserves markdown inside a message by quoting every line", () => {
-    const inner = "# Heading\n\nBody line\n\n## Sub\n- item";
-    const out = exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
-    // every non-empty source line becomes "> ..."
-    assert.match(out, /^> # Heading$/m);
-    assert.match(out, /^> Body line$/m);
-    assert.match(out, /^> ## Sub$/m);
-    assert.match(out, /^> - item$/m);
-    // blank lines inside the message stay inside the quote (bare ">")
-    assert.match(out, /^>$/m);
+  it("demotes headings inside a message body by 2 levels (cap at h6)", async () => {
+    const inner = "# H1\n\n## H2\n\n### H3\n\n##### H5\n\n###### H6\n\nBody line\n- item";
+    const out = await exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^### H1$/m);
+    assert.match(out, /^#### H2$/m);
+    assert.match(out, /^##### H3$/m);
+    assert.match(out, /^###### H5$/m);
+    assert.match(out, /^###### H6$/m);
+    assert.match(out, /^Body line$/m);
+    assert.match(out, /^- item$/m);
   });
 
-  it("renders non-text tool calls as a single italic line", () => {
-    const out = exportChatToMarkdown(
-      [textResult("user", "show todos"), toolResult("manageTodoList", "Today's todos", "tool-1"), textResult("assistant", "here you go")],
-      { exportedAt: "2026-04-30T12:00:00Z" },
-    );
-    assert.match(out, /\*🔧 manageTodoList — Today's todos.*\*/);
-    // tool line is NOT inside a blockquote
-    assert.doesNotMatch(out, /^> \*🔧 manageTodoList/m);
+  it("does not demote headings inside fenced code blocks", async () => {
+    const inner = "```md\n# This is sample syntax\n```\n\n## Real heading";
+    const out = await exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# This is sample syntax$/m);
+    assert.match(out, /^#### Real heading$/m);
   });
 
-  it("falls back to tool name when title is missing", () => {
-    const out = exportChatToMarkdown([toolResult("manageWiki", undefined, "tool-2")], { exportedAt: "2026-04-30T12:00:00Z" });
-    assert.match(out, /\*🔧 manageWiki\*/);
+  it("renders a non-text tool call as a single `## ⬛︎ toolName HH:MM` heading line", async () => {
+    const stamps = new Map<string, number>([["tool-1", Date.UTC(2026, 3, 30, 15, 17)]]);
+    const out = await exportChatToMarkdown([textResult("user", "open it"), toolResult("openCanvas", "Untitled", "tool-1"), textResult("assistant", "done")], {
+      exportedAt: "2026-04-30T12:00:00Z",
+      resultTimestamps: stamps,
+    });
+    assert.match(out, /^## ⬛︎ openCanvas \d{2}:\d{2}$/m);
+    assert.doesNotMatch(out, /\*▸ openCanvas/);
+    assert.doesNotMatch(out, /openCanvas — Untitled/);
   });
 
-  it("renders a header even for an empty session", () => {
-    const out = exportChatToMarkdown([], { exportedAt: "2026-04-30T12:00:00Z" });
+  it("renders the tool heading without a time when no timestamp is available", async () => {
+    const out = await exportChatToMarkdown([toolResult("manageWiki", undefined, "tool-2")], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^## ⬛︎ manageWiki$/m);
+  });
+
+  it("inlines presentDocument's inline markdown body (demoted) under the marker line", async () => {
+    const presentDoc: ToolResultComplete = {
+      toolName: "presentDocument",
+      uuid: "doc-1",
+      message: "doc",
+      title: "Trip plan",
+      data: {
+        markdown: "# Trip plan\n\n## Day 1\n\nFly to Tokyo.",
+        filenamePrefix: "trip-plan",
+      },
+    };
+    const out = await exportChatToMarkdown([presentDoc], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^## ⬛︎ presentDocument$/m);
+    assert.match(out, /^### Trip plan$/m);
+    assert.match(out, /^#### Day 1$/m);
+    assert.match(out, /^Fly to Tokyo\.$/m);
+  });
+
+  it("inlines presentDocument's file-mode body via the readFile resolver", async () => {
+    const presentDoc: ToolResultComplete = {
+      toolName: "presentDocument",
+      uuid: "doc-2",
+      message: "doc",
+      title: "Saved doc",
+      data: {
+        markdown: "artifacts/documents/saved-doc.md",
+        filenamePrefix: "saved-doc",
+      },
+    };
+    const files = new Map<string, string>([["artifacts/documents/saved-doc.md", "# Saved doc\n\nServer body."]]);
+    const out = await exportChatToMarkdown([presentDoc], {
+      exportedAt: "2026-04-30T12:00:00Z",
+      readFile: async (path) => files.get(path) ?? null,
+    });
+    assert.match(out, /^## ⬛︎ presentDocument$/m);
+    assert.match(out, /^### Saved doc$/m); // # → ###
+    assert.match(out, /^Server body\.$/m);
+  });
+
+  it("falls back to marker-only when the readFile resolver returns null", async () => {
+    const presentDoc: ToolResultComplete = {
+      toolName: "presentDocument",
+      uuid: "doc-3",
+      message: "doc",
+      title: "Missing",
+      data: {
+        markdown: "artifacts/documents/missing.md",
+        filenamePrefix: "missing",
+      },
+    };
+    const out = await exportChatToMarkdown([presentDoc], {
+      exportedAt: "2026-04-30T12:00:00Z",
+      readFile: async () => null,
+    });
+    assert.match(out, /^## ⬛︎ presentDocument$/m);
+    assert.doesNotMatch(out, /artifacts\/documents\/missing\.md/);
+  });
+
+  it("falls back to marker-only when no readFile resolver is supplied for a file-mode reference", async () => {
+    const presentDoc: ToolResultComplete = {
+      toolName: "presentDocument",
+      uuid: "doc-4",
+      message: "doc",
+      title: "Saved doc",
+      data: {
+        markdown: "artifacts/documents/saved-doc.md",
+        filenamePrefix: "saved-doc",
+      },
+    };
+    const out = await exportChatToMarkdown([presentDoc], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^## ⬛︎ presentDocument$/m);
+    assert.doesNotMatch(out, /artifacts\/documents\/saved-doc\.md/);
+  });
+
+  it("renders a header even for an empty session", async () => {
+    const out = await exportChatToMarkdown([], { exportedAt: "2026-04-30T12:00:00Z" });
     assert.match(out, /^# Conversation/);
     assert.match(out, /Exported 2026-04-30/);
   });
 
-  it("includes time stamps when resultTimestamps has the uuid", () => {
+  it("includes time stamps when resultTimestamps has the uuid", async () => {
     const stamps = new Map<string, number>([["t-user", Date.UTC(2026, 3, 30, 14, 35)]]);
-    const out = exportChatToMarkdown([textResult("user", "hi")], { resultTimestamps: stamps, exportedAt: "2026-04-30T12:00:00Z" });
-    // 14:35 UTC will be locale-shifted on the renderer; assert "·" + HH:MM shape.
-    assert.match(out, /### 👤 You · \d{2}:\d{2}/);
+    const out = await exportChatToMarkdown([textResult("user", "hi")], { resultTimestamps: stamps, exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /## ⬜︎ You · \d{2}:\d{2}/);
   });
 
-  it("treats system role correctly", () => {
-    const out = exportChatToMarkdown([textResult("system", "session started")], { exportedAt: "2026-04-30T12:00:00Z" });
-    assert.match(out, /### ⚙️ System/);
+  it("treats system role correctly", async () => {
+    const out = await exportChatToMarkdown([textResult("system", "session started")], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /## ◇ System/);
   });
 });

--- a/test/utils/chat/test_exportMarkdown.ts
+++ b/test/utils/chat/test_exportMarkdown.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { exportChatToMarkdown } from "../../../src/utils/chat/exportMarkdown.js";
+
+function textResult(role: "user" | "assistant" | "system", text: string, uuid = `t-${role}`): ToolResultComplete {
+  return {
+    toolName: "text-response",
+    uuid,
+    message: text,
+    data: { role, text },
+  };
+}
+
+function toolResult(toolName: string, title: string | undefined, uuid: string): ToolResultComplete {
+  return {
+    toolName,
+    uuid,
+    message: title ?? toolName,
+    title,
+  };
+}
+
+describe("exportChatToMarkdown", () => {
+  it("renders a user/assistant exchange as blockquoted turns", () => {
+    const out = exportChatToMarkdown([textResult("user", "hello"), textResult("assistant", "hi there")], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# Conversation/);
+    assert.match(out, /### 👤 You/);
+    assert.match(out, /### 🤖 Assistant/);
+    assert.match(out, /^> hello$/m);
+    assert.match(out, /^> hi there$/m);
+  });
+
+  it("includes the role name in the title when provided", () => {
+    const out = exportChatToMarkdown([textResult("user", "hi")], { sessionRoleName: "General", exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# Conversation · General/);
+  });
+
+  it("preserves markdown inside a message by quoting every line", () => {
+    const inner = "# Heading\n\nBody line\n\n## Sub\n- item";
+    const out = exportChatToMarkdown([textResult("assistant", inner)], { exportedAt: "2026-04-30T12:00:00Z" });
+    // every non-empty source line becomes "> ..."
+    assert.match(out, /^> # Heading$/m);
+    assert.match(out, /^> Body line$/m);
+    assert.match(out, /^> ## Sub$/m);
+    assert.match(out, /^> - item$/m);
+    // blank lines inside the message stay inside the quote (bare ">")
+    assert.match(out, /^>$/m);
+  });
+
+  it("renders non-text tool calls as a single italic line", () => {
+    const out = exportChatToMarkdown(
+      [textResult("user", "show todos"), toolResult("manageTodoList", "Today's todos", "tool-1"), textResult("assistant", "here you go")],
+      { exportedAt: "2026-04-30T12:00:00Z" },
+    );
+    assert.match(out, /\*🔧 manageTodoList — Today's todos.*\*/);
+    // tool line is NOT inside a blockquote
+    assert.doesNotMatch(out, /^> \*🔧 manageTodoList/m);
+  });
+
+  it("falls back to tool name when title is missing", () => {
+    const out = exportChatToMarkdown([toolResult("manageWiki", undefined, "tool-2")], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /\*🔧 manageWiki\*/);
+  });
+
+  it("renders a header even for an empty session", () => {
+    const out = exportChatToMarkdown([], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /^# Conversation/);
+    assert.match(out, /Exported 2026-04-30/);
+  });
+
+  it("includes time stamps when resultTimestamps has the uuid", () => {
+    const stamps = new Map<string, number>([["t-user", Date.UTC(2026, 3, 30, 14, 35)]]);
+    const out = exportChatToMarkdown([textResult("user", "hi")], { resultTimestamps: stamps, exportedAt: "2026-04-30T12:00:00Z" });
+    // 14:35 UTC will be locale-shifted on the renderer; assert "·" + HH:MM shape.
+    assert.match(out, /### 👤 You · \d{2}:\d{2}/);
+  });
+
+  it("treats system role correctly", () => {
+    const out = exportChatToMarkdown([textResult("system", "session started")], { exportedAt: "2026-04-30T12:00:00Z" });
+    assert.match(out, /### ⚙️ System/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `content_copy` button next to the layout toggle in both single mode (`<SessionSidebar>`) and stack mode (`<StackView>`) that serializes the active chat session to Markdown and writes it to the clipboard. Icon swaps to a check for ~1.5s on success.
- Each speaker turn is rendered as a `## ⬜︎ You` / `## ⬛︎ Assistant` / `## ◇ System` heading followed by the message body. Tool calls render as a single `## ⬛︎ toolName HH:MM` heading; the only tool whose payload is inlined is `presentDocument`, whose body is fetched off the workspace via `apiGet(API_ROUTES.files.content)` (same loader the Markdown View uses).
- Headings inside message bodies are demoted by 2 levels (`#` → `###`, etc., cap at h6, fenced code blocks left alone) so the speaker headings always sit above message-internal structure in the document outline.
- Adds 13 unit tests covering the user/assistant exchange, role label in the title, heading demotion, fenced-code preservation, tool markers (with/without timestamps), presentDocument inline + file-mode + missing-resolver paths, empty session, and timestamps.
- i18n strings added to all 8 locales (en/ja/zh/ko/es/pt-BR/fr/de). UI cheatsheet updated to reflect the new button.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (3 pre-existing warnings in unrelated files)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 3681 unit tests pass (13 new)
- [x] `yarn test:e2e` — 372 Playwright tests pass
- [ ] Manual: click the copy button in single layout, paste somewhere — verify speaker headings, tool markers, and presentDocument bodies render
- [ ] Manual: same in stack layout
- [ ] Manual: empty session — button should be disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy chat sessions as Markdown from sidebar and stack view headers
  * Markdown export includes speaker labels, timestamps, tool markers, and inlined document content when available

* **Localization**
  * Added UI strings for the copy-action and success confirmation in EN, DE, ES, FR, JA, KO, PT‑BR, ZH

* **Tests**
  * Added comprehensive tests covering Markdown export formatting and edge cases

* **Documentation**
  * Updated UI cheatsheet to document the new copy-as-Markdown affordance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->