### PR TITLE
feat(protocol): semver policy + 0.2.0 graduation (Phase 1b / #1043 C-5)

### DIFF
--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "discord.js": "^14.26.3",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "imapflow": "^1.0.170",
     "mailparser": "^3.7.2",

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0"
   },

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "irc-framework": "^4.14.0",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0"
   },

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "ws": "^8.20.0"
   },

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "matrix-js-sdk": "^41.4.0"
   },

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "ws": "^8.20.0"
   },

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0"
   },

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "nostr-tools": "^2.10.4"
   },

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "ws": "^8.20.0"
   },

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -23,7 +23,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "@slack/socket-mode": "^2.0.6",
     "@slack/web-api": "^7.15.1",
     "dotenv": "^17.0.0"

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "botbuilder": "^4.23.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -31,7 +31,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0"
   },

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "@xmpp/client": "^0.14.0",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -22,7 +22,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/chat-service/package.json
+++ b/packages/chat-service/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/protocol": "^0.1.4"
+    "@mulmobridge/protocol": "^0.2.0"
   },
   "peerDependencies": {
     "express": "^5.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "socket.io-client": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "express": "^5.1.0",
     "socket.io": "^4.8.3"
   },

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -28,7 +28,7 @@
     "@gui-chat-plugin/weather": "^0.1.0",
     "@mulmobridge/chat-service": "^0.1.2",
     "@mulmobridge/client": "^0.1.4",
-    "@mulmobridge/protocol": "^0.1.4",
+    "@mulmobridge/protocol": "^0.2.0",
     "@mulmocast/types": "^2.6.9",
     "@mulmochat-plugin/quiz": "0.4.0",
     "@mulmochat-plugin/ui-image": "^0.3.0",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to `@mulmobridge/protocol` are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+under the rules described in [README.md → Versioning](./README.md#versioning).
+
+## [Unreleased]
+
+## [0.2.0] — 2026-05-01
+
+First release under the published semver policy. No code change versus 0.1.4 —
+the minor bump signals that the public surface (`EVENT_TYPES`, `Attachment`,
+`CHAT_SOCKET_*`, `CHAT_SERVICE_ROUTES`, `GENERATION_KINDS`, `BridgeOptions`)
+is now governed by the rules in [README.md → Versioning](./README.md#versioning),
+and that breaking changes will be flagged with a major bump and a
+[`MIGRATIONS.md`](./MIGRATIONS.md) entry.
+
+### Changed
+
+- Declare semver policy and add `CHANGELOG.md` / `MIGRATIONS.md`. Bridges and
+  internal consumers should pin against `^0.2.0`.
+
+## [0.1.4] — 2026-04-22
+
+### Added
+
+- `BridgeOptions` — opaque options passthrough from a bridge's environment to
+  the host app, narrowed to flat primitives.
+
+## [0.1.3] — 2026-04-19
+
+### Added
+
+- Background generation for MulmoScript:
+  - `GENERATION_KINDS` / `GenerationKind`
+  - `GenerationEvent` event payload type
+  - `PendingGeneration` state interface
+  - `generationKey` helper (with delimiter-collision hardening)
+
+## [0.1.2] — 2026-04-18
+
+### Added
+
+- First public publishable release of `@mulmobridge/protocol` (renamed from
+  `@mulmobridge/types`).
+- Wire-level constants: `EVENT_TYPES`, `EventType`, `CHAT_SOCKET_PATH`,
+  `CHAT_SOCKET_EVENTS`, `ChatSocketEvent`, `CHAT_SERVICE_ROUTES`.
+- Shared types: `Attachment`, `BridgeHandshakeAuth`.
+- Package shape: `dist`-only `files`, dual `import`/`require`/`default`
+  conditions in `exports`.
+
+[Unreleased]: https://github.com/receptron/mulmoclaude/compare/@mulmobridge/protocol@0.2.0...HEAD
+[0.2.0]: https://github.com/receptron/mulmoclaude/compare/@mulmobridge/protocol@0.1.4...@mulmobridge/protocol@0.2.0
+[0.1.4]: https://github.com/receptron/mulmoclaude/compare/@mulmobridge/protocol@0.1.3...@mulmobridge/protocol@0.1.4
+[0.1.3]: https://github.com/receptron/mulmoclaude/compare/@mulmobridge/protocol@0.1.2...@mulmobridge/protocol@0.1.3
+[0.1.2]: https://github.com/receptron/mulmoclaude/releases/tag/@mulmobridge/protocol@0.1.2

--- a/packages/protocol/MIGRATIONS.md
+++ b/packages/protocol/MIGRATIONS.md
@@ -1,0 +1,29 @@
+# Migrations
+
+Step-by-step instructions for crossing a major-version boundary in
+`@mulmobridge/protocol`. Patch and minor releases are documented in
+[`CHANGELOG.md`](./CHANGELOG.md); breaking changes are documented here in
+addition to the changelog.
+
+If a release does not appear here, it did not introduce a breaking change.
+
+## Format for new entries
+
+When a future major bump lands, add a new section using this shape:
+
+> ### `X.Y.Z` → `(X+1).0.0`
+>
+> **Why this is breaking** — one or two sentences on the contract change.
+>
+> **Affected exports** — bullet list of types / constants whose shape moved.
+>
+> **What you need to do** — concrete diff-style steps. Include either a
+> codemod command or hand-port instructions.
+>
+> **If you can't migrate yet** — name the last version that supported the old
+> shape (`@mulmobridge/protocol@<X.Y.Z>`).
+
+## `0.1.x` → `0.2.0`
+
+Not breaking — the 0.2.0 bump only declares the semver policy. Pinning your
+dependency to `^0.2.0` is enough; no source code change is required.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -48,6 +48,31 @@ const attachment: Attachment = {
 };
 ```
 
+## Versioning
+
+This package follows [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html).
+External authors writing bridges or other consumers can rely on the rules below.
+
+| Bump | Triggered by |
+|---|---|
+| **MAJOR** | Breaking change to a published export — renaming or removing a field on `EVENT_TYPES` / `Attachment` / `CHAT_SOCKET_*` / `CHAT_SERVICE_ROUTES` / `GENERATION_*` / `BridgeOptions`, or any other type or constant exported from `index.ts`. |
+| **MINOR** | Additive change — new optional fields, new event/discriminant entries, new exported helpers. Always backwards-compatible. |
+| **PATCH** | Bug fixes, doc updates, build metadata. No public-API surface change. |
+
+Every release is recorded in [`CHANGELOG.md`](./CHANGELOG.md). Breaking
+releases also get a [`MIGRATIONS.md`](./MIGRATIONS.md) entry with concrete
+upgrade steps.
+
+**Pinning.** Pin against the caret (`^`) range that matches the semver tier
+you care about — e.g. `"@mulmobridge/protocol": "^0.2.0"`. This receives all
+backwards-compatible 0.2.x changes, and any future 0.3.0+ bump will require an
+explicit upgrade.
+
+**Pre-1.0.** While we are still on 0.x, a minor bump (`0.x → 0.(x+1)`) is
+treated as a breaking change per the SemVer 0.x convention. We declare the
+contract stable enough to depend on — but reserve the option to evolve it
+without going to 1.0.0 first.
+
 ## Part of the MulmoBridge ecosystem
 
 | Package | Description |

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/protocol",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Shared types and constants for the MulmoBridge protocol",
   "type": "module",
   "main": "./dist/index.js",
@@ -15,7 +15,9 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md",
+    "MIGRATIONS.md"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Declare the public-API stability commitment for \`@mulmobridge/protocol\` so external bridge / plugin authors can pin against semver guarantees.
- Add \`CHANGELOG.md\` (Keep a Changelog format with backfilled 0.1.x history) and \`MIGRATIONS.md\` (template for breaking-version entries).
- Bump \`@mulmobridge/protocol\` 0.1.4 → 0.2.0 and update all 28 internal consumers from \`^0.1.4\` to \`^0.2.0\`.
- **No code change** to \`packages/protocol/src/\` — the 0.2.0 graduation is a policy declaration, not a contract change.

## Items to Confirm / Review

- **0.2.0 vs 1.0.0** — chose 0.2.0 to keep a "we may still tweak" buffer (per the plan default). The README's pre-1.0 paragraph is explicit that a 0.x → 0.(x+1) bump is treated as breaking. Switch to 1.0.0 if you want to declare full stability now.
- **Backfilled changelog accuracy** — entries reconstructed from git log (\`git log -- packages/protocol/\`):
  - 0.1.2: first publishable release (renamed from \`@mulmobridge/types\`, dist-only \`files\`, dual conditions)
  - 0.1.3: \`GENERATION_KINDS\` / \`GenerationKind\` / \`GenerationEvent\` / \`PendingGeneration\` / \`generationKey\` (background generation work)
  - 0.1.4: \`BridgeOptions\` opaque options passthrough (flat primitives)

  Please double-check these match what was actually published — I derived them from commits between the existing tags (\`@mulmobridge/protocol@0.1.2\` / \`0.1.3\` / \`0.1.4\`), but I didn't diff the published tarballs.
- **Bridge-version cascade** — all 28 consumers (chat-service, client, mock-server, mulmoclaude, 24 bridges) get their \`^0.1.4\` caret bumped to \`^0.2.0\` in this PR. In yarn workspaces dev the local linking ignores the range, but on-npm resolution does not — keeping them in lockstep here avoids a future "bridge published with stale protocol caret" footgun. The bridges themselves are NOT version-bumped; a separate \`/publish\` pass can bump and republish them when ready.
- **\`MIGRATIONS.md\` shape** — declared the 0.1.x → 0.2.0 step as non-breaking (policy declaration only). The format stub at the top is what future major bumps should follow.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1043 これやりたいけど、既存のコードの影響どれくらいある？@mulmochat-plugin/quizなどそのままうごく？動的ロードの安全性などをしりたい。他のリスクや難易度も。
>
> おすすめの、 1. C-1 + C-5、 2. C-3までやるとして、まずissueにコメントで残しておいて。そしてplanをかいてすすめる
>
> b (multi-PR split)
>
> はい (proceed with Phase 1b)

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean (3 pre-existing unrelated warnings)
- [x] \`yarn test\` passes (server + 22 workspace test suites)
- [x] \`yarn build\` clean
- [x] All 28 dependent caret ranges updated (verified via grep)
- [ ] CI green on this PR
- [ ] Smoke: \`yarn install\` resolves correctly with the new range (workspace resolution should still link locally)

## Plan / tracking

- Plan: \`plans/feat-plugin-sdk-rollout.md\`
- Tracking: #1043 (umbrella for plugin SDK / dynamic install / marketplace)
- Phase 1a (\`#1064\`, merged): manifest-driven plugin registration
- Phase 2 (next PR): C-3 SDK — \`npx create-mulmoclaude-plugin\` scaffold + public-types from \`gui-chat-protocol\` + \`docs/plugin-development.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Protocol library updated to version 0.2.0 across all bridges and services

* **Documentation**
  * Added versioning documentation explaining how protocol versions relate to API changes
  * Introduced changelog with protocol release history
  * Created migration guide template for communicating breaking changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->