### PR TITLE
fix(chat): stop auto-attaching the selected sidebar image to user messages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -259,7 +259,6 @@ import { PAGE_ROUTES, type PageRouteName } from "./router";
 import type { SseEvent } from "./types/sse";
 import type { SessionEntry, ActiveSession } from "./types/session";
 import { EVENT_TYPES } from "./types/events";
-import { extractImageData } from "./utils/tools/result";
 import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import { resolvePastedAttachment } from "./utils/agent/pastedAttachment";
 import { applyAgentEvent, type AgentEventContext } from "./utils/agent/eventDispatch";
@@ -842,10 +841,9 @@ async function sendMessage(text?: string) {
 
   // Pasted / dropped files are pre-uploaded to a workspace file so
   // the server (and the LLM downstream) sees a relative path — never
-  // a data: URI. The path then rides on `attachments[]` (path-only
-  // entries) alongside any sidebar-picked image. On upload failure,
-  // restore both userInput and pastedFile so the user can retry
-  // without retyping.
+  // a data: URI. The path then rides on `attachments[]` as a path-only
+  // entry. On upload failure, restore both userInput and pastedFile so
+  // the user can retry without retyping.
   let attachmentForRequest: string | undefined;
   if (fileSnapshot) {
     const resolved = await resolvePastedAttachment(fileSnapshot);
@@ -862,15 +860,14 @@ async function sendMessage(text?: string) {
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
 
-  // Compute attachment paths up-front so they can be persisted on
-  // the user message AND sent to the agent. The sidebar-picked image
-  // lives on the currently-selected result and is read off `session`
-  // before beginUserTurn appends the new user turn.
-  const selectedRes = session.toolResults.find((result) => result.uuid === session.selectedResultUuid) ?? undefined;
-  const sidebarPickedPath = extractImageData(selectedRes);
-  const attachmentPaths = [attachmentForRequest, sidebarPickedPath].filter((value): value is string => typeof value === "string" && value.length > 0);
+  // Only files the user explicitly attached this turn (paste / drop /
+  // file-picker) ride on the message. Do NOT auto-attach whatever
+  // image happens to be selected in the sidebar — selection moves to
+  // the latest generated image automatically, which would silently
+  // glue the previous picture onto every follow-up comment.
+  const attachmentPaths = attachmentForRequest ? [attachmentForRequest] : undefined;
 
-  beginUserTurn(session, message, attachmentPaths.length > 0 ? attachmentPaths : undefined);
+  beginUserTurn(session, message, attachmentPaths);
 
   ensureSessionSubscription(session);
 
@@ -879,7 +876,7 @@ async function sendMessage(text?: string) {
       message,
       role: sessionRole.value,
       chatSessionId: session.id,
-      attachmentPaths: attachmentPaths.length > 0 ? attachmentPaths : undefined,
+      attachmentPaths,
     }),
   );
   if (!result.ok) {

--- a/src/utils/tools/result.ts
+++ b/src/utils/tools/result.ts
@@ -16,17 +16,6 @@ export function isUserTextResponse(res: ToolResultComplete): boolean {
   return data.role === "user";
 }
 
-// Pull out the optional base64 image attached to a tool result, if
-// any. Returns `undefined` for results that have no `data.imageData`
-// or where it isn't a string.
-export function extractImageData(result: ToolResultComplete | undefined): string | undefined {
-  const data = result?.data;
-  if (isRecord(data) && typeof data.imageData === "string") {
-    return data.imageData;
-  }
-  return undefined;
-}
-
 // Build a synthetic text-response result for either a user or
 // assistant turn. Used by sendMessage and the chat history UI.
 // `attachments` is optional and only meaningful on user turns —

--- a/test/utils/tools/test_result.ts
+++ b/test/utils/tools/test_result.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isUserTextResponse, extractImageData, makeTextResult } from "../../../src/utils/tools/result.js";
+import { isUserTextResponse, makeTextResult } from "../../../src/utils/tools/result.js";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 function makeResult(over: Partial<ToolResultComplete>): ToolResultComplete {
@@ -55,30 +55,6 @@ describe("isUserTextResponse", () => {
       data: { text: "hi" },
     });
     assert.equal(isUserTextResponse(toolResult), false);
-  });
-});
-
-describe("extractImageData", () => {
-  it("returns the imageData string when present", () => {
-    const toolResult = makeResult({ data: { imageData: "BASE64..." } });
-    assert.equal(extractImageData(toolResult), "BASE64...");
-  });
-
-  it("returns undefined when imageData is missing", () => {
-    assert.equal(extractImageData(makeResult({ data: { foo: "bar" } })), undefined);
-  });
-
-  it("returns undefined when imageData is not a string", () => {
-    const toolResult = makeResult({ data: { imageData: 42 } });
-    assert.equal(extractImageData(toolResult), undefined);
-  });
-
-  it("returns undefined when result is undefined", () => {
-    assert.equal(extractImageData(undefined), undefined);
-  });
-
-  it("returns undefined when data is null", () => {
-    assert.equal(extractImageData(makeResult({ data: null })), undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

- `sendMessage` was reading the currently-selected result's `data.imageData` and folding it into `attachments[]`. Tool-result completion auto-moves the selection to the freshly-generated image, so any follow-up comment ("looks delicious") silently shipped the previous picture as an attachment — visible as a chip on the user bubble and forwarded to the LLM. There is no UI affordance to clear it, so this was strictly a leak, not a feature.
- Drop the auto-pick path entirely. Only files the user explicitly attached this turn (paste / drop / file-picker) ride on the message.
- Removes the now-unused `extractImageData` helper and its tests, and refreshes a stale comment in `sendMessage`.

Server-side `selectedImageData` (`server/api/routes/agent.ts`) is left untouched: it is a compat shim for external bridge clients (Telegram / LINE / etc.) and is documented as never set by the Vue UI.

## Repro (before fix)

1. "水茄子の画像を作って" → image generated, sidebar selection auto-moves to it.
2. "美味しそう" → comment appears in chat with the previously-generated image attached as a chip.

## Test plan

- [x] `yarn format`
- [x] `yarn lint` (0 errors; 3 pre-existing warnings unrelated to this change)
- [x] `yarn typecheck`
- [x] `yarn test` (18/18 pass)
- [x] `yarn build`
- [x] `yarn test:e2e` (372/372 pass)
- [ ] Manual: generate an image, then send a plain-text follow-up — chip and `attachments[]` should both be absent on the new bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic image attachment behavior. Previously, sidebar-selected images were automatically attached to subsequent messages. Images must now be explicitly attached each time to be included with a message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->