### PR TITLE
feat(accounting): book-creation flow polish + opening-balance gate

### DIFF
--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -92,7 +92,19 @@ const noActiveBook = (): MockResponse => err(409, "no active book; create or sel
 function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse {
   const requested = typeof body.bookId === "string" ? body.bookId : null;
   const bookId = requested && state.books.some((book) => book.id === requested) ? requested : state.activeBookId;
-  return ok({ kind: "accounting-app", bookId, initialTab: typeof body.initialTab === "string" ? body.initialTab : undefined });
+  const initialTab = typeof body.initialTab === "string" ? body.initialTab : undefined;
+  if (state.books.length === 0) {
+    // Mirrors the server's no-book LLM-facing message — see
+    // server/api/routes/accounting.ts handleOpenApp.
+    return ok({
+      kind: "accounting-app",
+      bookId,
+      initialTab,
+      message:
+        "No books in this workspace yet. The accounting UI is showing a form asking the user to create their first book (name + currency) before any accounting feature can be used.",
+    });
+  }
+  return ok({ kind: "accounting-app", bookId, initialTab });
 }
 
 function handleListBooks(state: AccountingState): MockResponse {

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -44,16 +44,18 @@ test.describe("accounting plugin — flow", () => {
     await setupSession(page);
   });
 
-  test("openApp envelope mounts <AccountingApp>; empty state surfaces no-book branch", async ({ page }) => {
+  test("openApp envelope mounts <AccountingApp>; empty workspace shows full-page first-run form", async ({ page }) => {
     await page.goto(`/chat/${SESSION_ID}`);
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    // The accounting-app envelope auto-mounts on session load (no
-    // preview click needed — the empty-workspace path immediately
-    // shows the auto-opened NewBookForm modal, which would otherwise
-    // intercept any pointer events on the chat sidebar).
+    // The accounting-app envelope auto-mounts on session load. On
+    // an empty workspace the first-run NewBookForm replaces the
+    // chrome (header + tabs + main) entirely — the regular
+    // no-book empty-state branch does not render in this mode.
     await expect(page.getByTestId("accounting-app")).toBeVisible();
-    await expect(page.getByTestId("accounting-no-book")).toBeVisible();
     await expect(page.getByTestId("accounting-new-book-modal")).toBeVisible();
+    await expect(page.getByTestId("accounting-new-book-firstrun")).toBeVisible();
+    await expect(page.getByTestId("accounting-tabs")).not.toBeVisible();
+    await expect(page.getByTestId("accounting-no-book")).not.toBeVisible();
   });
 });

--- a/server/accounting/openingBalances.ts
+++ b/server/accounting/openingBalances.ts
@@ -90,14 +90,18 @@ function validateAsOfPredatesEverything(input: OpeningValidationInput, errors: O
 
 /** Validate inputs for `setOpeningBalances`. Caller passes the full
  *  list of journal entries in the book so we can check the
- *  "asOfDate must precede every other entry" rule. */
+ *  "asOfDate must precede every other entry" rule. An opening with
+ *  zero lines is accepted as a no-op marker — it satisfies the
+ *  "book has an opening" gate the UI uses without committing the
+ *  user to specific balances on day one (they can replace it
+ *  later). */
 export function validateOpening(input: OpeningValidationInput): OpeningValidationResult {
   const errors: OpeningValidationError[] = [];
   if (!isValidCalendarDate(input.asOfDate)) {
     errors.push({ field: "asOfDate", message: `expected YYYY-MM-DD calendar date, got ${JSON.stringify(input.asOfDate)}` });
   }
-  if (!Array.isArray(input.lines) || input.lines.length < 2) {
-    errors.push({ field: "lines", message: "an opening needs at least two lines" });
+  if (!Array.isArray(input.lines)) {
+    errors.push({ field: "lines", message: "lines must be an array" });
     return { ok: false, errors };
   }
   validateLineAccountTypes(input, errors);

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -49,13 +49,16 @@ interface AccountingErrorResponse {
 // Tool-result envelope for the MCP-driven `openApp` action. The
 // frontend tool-result renderer keys off `kind: "accounting-app"`
 // to mount `<AccountingApp>` (vs the compact `Preview.vue` which
-// renders summaries for every other action).
+// renders summaries for every other action). `message` is picked
+// up by the MCP bridge and surfaced as the tool's text response
+// to the LLM (server/agent/mcp-server.ts).
 interface OpenAppToolResult {
   kind: "accounting-app";
   /** `null` when the workspace has zero books — the View shows its
-   *  empty state and prompts the user to create one. */
+   *  full-page first-run form and prompts the user to create one. */
   bookId: string | null;
   initialTab?: string;
+  message?: string;
 }
 
 type ActionRest = Omit<AccountingActionBody, "action">;
@@ -70,13 +73,26 @@ async function handleOpenApp(rest: ActionRest): Promise<OpenAppToolResult> {
   // Resolving the bookId server-side ensures the LLM's tool result
   // *describes* what's in the canvas (which book, which tab) so
   // historical chat replays render accurately. The View handles
-  // the empty-state flow (auto-opening the New Book modal so the
-  // user can pick name + currency); the server doesn't try to
-  // bootstrap a default book.
+  // the empty-state flow (full-page first-run form so the user
+  // can pick name + currency); the server doesn't try to bootstrap
+  // a default book.
   const list = await listBooks();
   const requested = typeof rest.bookId === "string" ? rest.bookId : undefined;
   const bookId = requested && list.books.some((book) => book.id === requested) ? requested : list.activeBookId;
   const initialTab = typeof rest.initialTab === "string" ? rest.initialTab : undefined;
+  if (list.books.length === 0) {
+    // No books yet — the canvas is showing the full-page first-run
+    // form which the user must complete before any accounting
+    // feature is usable. Tell the LLM via `message` so it knows to
+    // wait for the user rather than attempt follow-up actions.
+    return {
+      kind: "accounting-app",
+      bookId,
+      initialTab,
+      message:
+        "No books in this workspace yet. The accounting UI is showing a form asking the user to create their first book (name + currency) before any accounting feature can be used.",
+    };
+  }
   return { kind: "accounting-app", bookId, initialTab };
 }
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -619,6 +619,8 @@ const deMessages = {
       title: "Eröffnungsbilanz",
       asOfLabel: "Per",
       explainer: "Nur Bilanzkonten (Aktiva/Passiva/Eigenkapital). Σ Soll = Σ Haben; die Differenz fließt in Retained Earnings.",
+      emptyHint:
+        "Sie können das Formular leer speichern — die Eröffnungsbilanz lässt sich später aktualisieren. Es reicht, dass einmalig eine Eröffnung hinterlegt ist, damit die übrigen Tabs freigeschaltet werden.",
       explainer2: "Nur Bilanzkonten.",
       submit: "Eröffnungsbilanz speichern",
       replaceWarning: "Beim Speichern wird die bestehende Eröffnung ersetzt (die alte wird im Journal storniert).",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -626,6 +626,8 @@ const enMessages = {
       asOfLabel: "As of",
       explainer:
         "Enter your balance-sheet positions as of the start date. Income / expense accounts are not allowed here. Σ debit must equal Σ credit; the difference plug-in is Retained Earnings.",
+      emptyHint:
+        "It's fine to save with everything blank — you can update opening balances later. The book just needs an opening on file before other tabs unlock.",
       explainer2: "Balance-sheet accounts only.",
       submit: "Save opening balances",
       replaceWarning: "Saving replaces the existing opening (the old one is voided in the journal).",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -620,6 +620,8 @@ const esMessages = {
       title: "Saldos de apertura",
       asOfLabel: "Al",
       explainer: "Solo cuentas de balance (activo/pasivo/patrimonio). Σ debe = Σ haber; la diferencia va a Retained Earnings.",
+      emptyHint:
+        "Puedes guardar todo en blanco — luego puedes actualizar los saldos de apertura. Solo hace falta tener una apertura registrada para desbloquear las demás pestañas.",
       explainer2: "Solo cuentas de balance.",
       submit: "Guardar saldos de apertura",
       replaceWarning: "Al guardar se reemplaza la apertura existente (la anterior se anula en el diario).",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -614,6 +614,8 @@ const frMessages = {
       title: "Soldes d'ouverture",
       asOfLabel: "Au",
       explainer: "Comptes de bilan uniquement (actif/passif/capitaux). Σ débit = Σ crédit ; le solde tombe sur Retained Earnings.",
+      emptyHint:
+        "Vous pouvez enregistrer en laissant tout vide — les soldes d'ouverture peuvent être mis à jour plus tard. Il suffit qu'une ouverture soit enregistrée pour débloquer les autres onglets.",
       explainer2: "Comptes de bilan uniquement.",
       submit: "Enregistrer les soldes d'ouverture",
       replaceWarning: "Enregistrer remplace l'ouverture existante (l'ancienne est contre-passée dans le journal).",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -610,6 +610,8 @@ const jaMessages = {
       title: "期首残高",
       asOfLabel: "基準日",
       explainer: "B/S 科目（資産・負債・純資産）のみ入力可能。Σ借方=Σ貸方を満たす必要があり、差額は Retained Earnings に集約されます。",
+      emptyHint:
+        "すべて空欄のまま保存しても構いません — 期首残高は後から更新できます。他のタブを利用するには、いったん期首残高が登録されている必要があります。",
       explainer2: "B/S 科目のみ。",
       submit: "期首残高を保存",
       replaceWarning: "保存すると既存の期首残高は journal で取り消されます。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -610,6 +610,8 @@ const koMessages = {
       title: "기초잔액",
       asOfLabel: "기준일",
       explainer: "재무상태표 계정(자산/부채/자본)만 입력 가능. Σ차변=Σ대변이 되어야 하며 차액은 Retained Earnings에 흡수됩니다.",
+      emptyHint:
+        "모두 비워둔 채 저장해도 괜찮습니다 — 기초잔액은 나중에 업데이트할 수 있습니다. 다른 탭을 사용하려면 일단 기초잔액 항목이 등록되어 있어야 합니다.",
       explainer2: "재무상태표 계정만.",
       submit: "기초잔액 저장",
       replaceWarning: "저장 시 기존 기초잔액은 분개장에서 취소됩니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -612,6 +612,8 @@ const ptBRMessages = {
       title: "Saldos iniciais",
       asOfLabel: "Em",
       explainer: "Apenas contas de balanço (ativo/passivo/patrimônio). Σ débito = Σ crédito; a diferença entra em Retained Earnings.",
+      emptyHint:
+        "Você pode salvar tudo em branco — os saldos iniciais podem ser atualizados depois. Basta ter uma abertura registrada para que as outras abas sejam liberadas.",
       explainer2: "Apenas contas de balanço.",
       submit: "Salvar saldos iniciais",
       replaceWarning: "Salvar substitui a abertura existente (a anterior é estornada no diário).",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -606,6 +606,7 @@ const zhMessages = {
       title: "期初余额",
       asOfLabel: "基准日",
       explainer: "仅允许 B/S 科目（资产 / 负债 / 权益）。Σ借方=Σ贷方，差额会落入 Retained Earnings。",
+      emptyHint: "可以全部留空保存——期初余额稍后再更新。账簿只需先存在一条期初记录，其他标签页才会解锁。",
       explainer2: "仅 B/S 科目。",
       submit: "保存期初余额",
       replaceWarning: "保存会替换现有期初余额（旧的会在日记账中冲销）。",

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -23,9 +23,14 @@
         <button
           v-for="tab in TABS"
           :key="tab.key"
+          :disabled="isTabDisabled(tab.key)"
           :class="[
             'h-8 px-2.5 flex items-center gap-1 rounded text-sm whitespace-nowrap',
-            currentTab === tab.key ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-600 hover:bg-gray-50',
+            isTabDisabled(tab.key)
+              ? 'text-gray-300 cursor-not-allowed'
+              : currentTab === tab.key
+                ? 'bg-blue-50 text-blue-600 font-medium'
+                : 'text-gray-600 hover:bg-gray-50',
           ]"
           :data-testid="`accounting-tab-${tab.key}`"
           @click="currentTab = tab.key"
@@ -92,7 +97,7 @@ import Ledger from "./components/Ledger.vue";
 import BalanceSheet from "./components/BalanceSheet.vue";
 import ProfitLoss from "./components/ProfitLoss.vue";
 import BookSettings from "./components/BookSettings.vue";
-import { listAccounts, listBooks, type Account, type BookSummary } from "./api";
+import { getOpeningBalances, listAccounts, listBooks, type Account, type BookSummary } from "./api";
 import { useAccountingChannel, useAccountingBooksChannel } from "../../composables/useAccountingChannel";
 
 const { t } = useI18n();
@@ -154,6 +159,11 @@ const bookLoadError = ref<string | null>(null);
 // `version` prop for sub-components so they `watch` and refetch
 // uniformly.
 const localVersion = ref(0);
+// Tracks whether the active book has an opening entry on file.
+// `null` = unknown / loading; the gate only activates on an
+// explicit `false` so we don't disable tabs during the cold load
+// while the first getOpeningBalances request is still in flight.
+const hasOpening = ref<boolean | null>(null);
 
 const activeBook = computed(() => books.value.find((book) => book.id === activeBookId.value) ?? null);
 const activeBookName = computed(() => activeBook.value?.name ?? "");
@@ -229,6 +239,27 @@ async function refetchAccounts(): Promise<void> {
   accounts.value = result.data.accounts;
 }
 
+async function refetchOpening(): Promise<void> {
+  if (!activeBookId.value) {
+    hasOpening.value = null;
+    return;
+  }
+  const result = await getOpeningBalances(activeBookId.value);
+  if (!result.ok) return;
+  hasOpening.value = result.data.opening !== null;
+}
+
+// A book without an opening on file is in "gated" mode: the user
+// must save an opening (empty is fine — see OpeningBalancesForm)
+// before journal / report tabs unlock. Settings stays accessible
+// so the user can delete the book if they don't want to proceed.
+const openingGateActive = computed(() => activeBookId.value !== null && hasOpening.value === false);
+
+function isTabDisabled(key: TabKey): boolean {
+  if (!openingGateActive.value) return false;
+  return key !== "opening" && key !== "settings";
+}
+
 function onBookSelected(bookId: string): void {
   activeBookId.value = bookId;
 }
@@ -236,7 +267,10 @@ function onBookSelected(bookId: string): void {
 function onEntrySubmitted(): void {
   bumpLocalVersion();
   // After posting an opening or a normal entry, switch to the
-  // journal so the user immediately sees what they booked.
+  // journal so the user immediately sees what they booked. The
+  // bumpLocalVersion above triggers the bookVersion watcher which
+  // refetches hasOpening, so the gate auto-lifts shortly after the
+  // tab switch — no manual unlock needed here.
   if (currentTab.value === "newEntry" || currentTab.value === "opening") {
     currentTab.value = "journal";
   }
@@ -249,6 +283,27 @@ async function onBookDeleted(): Promise<void> {
 
 watch(activeBookId, (next) => {
   if (next) void refetchAccounts();
+});
+
+// Refetch the opening status whenever the active book changes or
+// any pub/sub / child action bumps bookVersion (e.g. an opening
+// got saved or voided). Clears hasOpening when the book goes null
+// so a stale "true" doesn't carry over between books.
+watch(
+  () => [activeBookId.value, bookVersion.value],
+  () => void refetchOpening(),
+  { immediate: true },
+);
+
+// Force-route to the Opening tab whenever the gate engages. Tab
+// buttons are also `:disabled` so a stray click can't bypass it,
+// but this watcher handles the programmatic case (book switch,
+// initial mount with a no-opening book, LLM-supplied initialTab
+// pointing at a gated tab).
+watch(openingGateActive, (active) => {
+  if (!active) return;
+  if (currentTab.value === "opening" || currentTab.value === "settings") return;
+  currentTab.value = "opening";
 });
 
 void refetchBooks();

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -4,71 +4,79 @@
        the entry gate (this mount) runs through the LLM. Pub/sub
        refetches keep multi-tab / sibling-window views in sync. -->
   <div class="h-full bg-white flex flex-col" data-testid="accounting-app">
-    <header class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
-      <div class="flex items-center gap-2 min-w-0">
-        <span class="material-icons text-gray-600">account_balance</span>
-        <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginAccounting.title") }}</h2>
-      </div>
-      <BookSwitcher v-if="!loadingBooks" :model-value="activeBookId ?? ''" :books="books" @update:model-value="onBookSelected" @books-changed="refetchBooks" />
-    </header>
-    <nav class="flex items-center gap-0.5 px-3 py-1.5 border-b border-gray-100 shrink-0 overflow-x-auto" data-testid="accounting-tabs">
-      <button
-        v-for="tab in TABS"
-        :key="tab.key"
-        :class="[
-          'h-8 px-2.5 flex items-center gap-1 rounded text-sm whitespace-nowrap',
-          currentTab === tab.key ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-600 hover:bg-gray-50',
-        ]"
-        :data-testid="`accounting-tab-${tab.key}`"
-        @click="currentTab = tab.key"
-      >
-        <span class="material-icons text-base">{{ tab.icon }}</span>
-        <span>{{ t(tab.labelKey) }}</span>
-      </button>
-    </nav>
-    <main class="flex-1 overflow-auto p-4">
-      <p v-if="loadingBooks" class="text-sm text-gray-400">{{ t("pluginAccounting.common.loading") }}</p>
-      <p v-else-if="bookLoadError" class="text-sm text-red-500" data-testid="accounting-load-error">
-        {{ t("pluginAccounting.common.error", { error: bookLoadError }) }}
-      </p>
-      <p v-else-if="!activeBookId" class="text-sm text-gray-500" data-testid="accounting-no-book">{{ t("pluginAccounting.noBook") }}</p>
-      <template v-else-if="activeBookId">
-        <JournalList
-          v-if="currentTab === 'journal'"
-          :book-id="activeBookId"
-          :accounts="accounts"
-          :currency="activeCurrency"
-          :version="bookVersion"
-          @changed="bumpLocalVersion"
-        />
-        <JournalEntryForm
-          v-else-if="currentTab === 'newEntry'"
-          :book-id="activeBookId"
-          :accounts="accounts"
-          :currency="activeCurrency"
-          @submitted="onEntrySubmitted"
-        />
-        <OpeningBalancesForm
-          v-else-if="currentTab === 'opening'"
-          :book-id="activeBookId"
-          :accounts="accounts"
-          :currency="activeCurrency"
-          :version="bookVersion"
-          @submitted="onEntrySubmitted"
-        />
-        <Ledger v-else-if="currentTab === 'ledger'" :book-id="activeBookId" :accounts="accounts" :currency="activeCurrency" :version="bookVersion" />
-        <BalanceSheet v-else-if="currentTab === 'balanceSheet'" :book-id="activeBookId" :currency="activeCurrency" :version="bookVersion" />
-        <ProfitLoss v-else-if="currentTab === 'profitLoss'" :book-id="activeBookId" :currency="activeCurrency" :version="bookVersion" />
-        <BookSettings
-          v-else-if="currentTab === 'settings'"
-          :book-id="activeBookId"
-          :book-name="activeBookName"
-          @deleted="onBookDeleted"
+    <NewBookForm v-if="showFirstRunForm" first-run full-page @created="onFirstBookCreated" />
+    <template v-else>
+      <header class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="material-icons text-gray-600">account_balance</span>
+          <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginAccounting.title") }}</h2>
+        </div>
+        <BookSwitcher
+          v-if="!loadingBooks"
+          :model-value="activeBookId ?? ''"
+          :books="books"
+          @update:model-value="onBookSelected"
           @books-changed="refetchBooks"
         />
-      </template>
-    </main>
-    <NewBookForm v-if="showFirstRunForm" first-run cancelable @cancel="showFirstRunForm = false" @created="onFirstBookCreated" />
+      </header>
+      <nav class="flex items-center gap-0.5 px-3 py-1.5 border-b border-gray-100 shrink-0 overflow-x-auto" data-testid="accounting-tabs">
+        <button
+          v-for="tab in TABS"
+          :key="tab.key"
+          :class="[
+            'h-8 px-2.5 flex items-center gap-1 rounded text-sm whitespace-nowrap',
+            currentTab === tab.key ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-600 hover:bg-gray-50',
+          ]"
+          :data-testid="`accounting-tab-${tab.key}`"
+          @click="currentTab = tab.key"
+        >
+          <span class="material-icons text-base">{{ tab.icon }}</span>
+          <span>{{ t(tab.labelKey) }}</span>
+        </button>
+      </nav>
+      <main class="flex-1 overflow-auto p-4">
+        <p v-if="loadingBooks" class="text-sm text-gray-400">{{ t("pluginAccounting.common.loading") }}</p>
+        <p v-else-if="bookLoadError" class="text-sm text-red-500" data-testid="accounting-load-error">
+          {{ t("pluginAccounting.common.error", { error: bookLoadError }) }}
+        </p>
+        <p v-else-if="!activeBookId" class="text-sm text-gray-500" data-testid="accounting-no-book">{{ t("pluginAccounting.noBook") }}</p>
+        <template v-else-if="activeBookId">
+          <JournalList
+            v-if="currentTab === 'journal'"
+            :book-id="activeBookId"
+            :accounts="accounts"
+            :currency="activeCurrency"
+            :version="bookVersion"
+            @changed="bumpLocalVersion"
+          />
+          <JournalEntryForm
+            v-else-if="currentTab === 'newEntry'"
+            :book-id="activeBookId"
+            :accounts="accounts"
+            :currency="activeCurrency"
+            @submitted="onEntrySubmitted"
+          />
+          <OpeningBalancesForm
+            v-else-if="currentTab === 'opening'"
+            :book-id="activeBookId"
+            :accounts="accounts"
+            :currency="activeCurrency"
+            :version="bookVersion"
+            @submitted="onEntrySubmitted"
+          />
+          <Ledger v-else-if="currentTab === 'ledger'" :book-id="activeBookId" :accounts="accounts" :currency="activeCurrency" :version="bookVersion" />
+          <BalanceSheet v-else-if="currentTab === 'balanceSheet'" :book-id="activeBookId" :currency="activeCurrency" :version="bookVersion" />
+          <ProfitLoss v-else-if="currentTab === 'profitLoss'" :book-id="activeBookId" :currency="activeCurrency" :version="bookVersion" />
+          <BookSettings
+            v-else-if="currentTab === 'settings'"
+            :book-id="activeBookId"
+            :book-name="activeBookName"
+            @deleted="onBookDeleted"
+            @books-changed="refetchBooks"
+          />
+        </template>
+      </main>
+    </template>
   </div>
 </template>
 
@@ -128,11 +136,13 @@ const books = ref<BookSummary[]>([]);
 const activeBookId = ref<string | null>(null);
 const accounts = ref<Account[]>([]);
 const loadingBooks = ref(true);
-// First-run flow: when the user opens the app on a fresh workspace
-// (zero books), we auto-show the New Book modal so they have to
-// pick a name + currency before proceeding. The modal is the same
-// one used by BookSwitcher's "+ New book" button — extracted to
-// NewBookForm.vue so both call sites share it.
+// First-run flow: when the user opens the app on a fresh
+// workspace (zero books), we render NewBookForm in full-page
+// mode in place of the regular chrome (header + tabs + main),
+// so the user MUST pick a name + currency before proceeding —
+// no popup, no dismiss. Distinct from the modal opened via
+// BookSwitcher's "+ New book" sentinel option, which reuses the
+// same component but with the overlay layout.
 const showFirstRunForm = ref(false);
 const firstRunHandled = ref(false);
 // Distinct from "books is empty" so we don't show the "+ New

--- a/src/plugins/accounting/components/BookSwitcher.vue
+++ b/src/plugins/accounting/components/BookSwitcher.vue
@@ -9,14 +9,10 @@
       @change="onSelect"
     >
       <option v-for="book in books" :key="book.id" :value="book.id">{{ formatBookOption(book) }}</option>
+      <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- decorative separator inside the books <select>, not user copy -->
+      <option disabled>──────────</option>
+      <option :value="NEW_BOOK_SENTINEL" data-testid="accounting-new-book-option">+ {{ t("pluginAccounting.bookSwitcher.newBook") }}</option>
     </select>
-    <button
-      class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
-      data-testid="accounting-new-book"
-      @click="showNewBook = true"
-    >
-      <span class="material-icons text-base">add</span>{{ t("pluginAccounting.bookSwitcher.newBook") }}
-    </button>
     <NewBookForm v-if="showNewBook" @cancel="showNewBook = false" @created="onCreated" />
     <p v-if="switchError" class="text-xs text-red-500">{{ switchError }}</p>
   </div>
@@ -36,6 +32,12 @@ const emit = defineEmits<{
   "books-changed": [];
 }>();
 
+// Sentinel value for the "+ New book" option living inside the
+// books <select>. Picking it opens the modal and reverts the
+// select's displayed value to the active book — the option must
+// not collide with any real book id, which are nanoid-shaped.
+const NEW_BOOK_SENTINEL = "__new__";
+
 const showNewBook = ref(false);
 const switchError = ref<string | null>(null);
 
@@ -46,6 +48,11 @@ function formatBookOption(book: BookSummary): string {
 async function onSelect(event: Event): Promise<void> {
   const target = event.target as HTMLSelectElement;
   const bookId = target.value;
+  if (bookId === NEW_BOOK_SENTINEL) {
+    target.value = props.modelValue;
+    showNewBook.value = true;
+    return;
+  }
   if (bookId === props.modelValue) return;
   const result = await setActiveBook(bookId);
   if (!result.ok) {

--- a/src/plugins/accounting/components/NewBookForm.vue
+++ b/src/plugins/accounting/components/NewBookForm.vue
@@ -1,10 +1,14 @@
 <template>
-  <!-- Modal for creating a new book. Shared between BookSwitcher
-       (the "+ New book" button) and View.vue (auto-opened on first
-       run when the workspace has zero books). The submit calls
-       createBook directly; on success it emits the new book and
-       its id, leaving the parent to wire activeBookId / refetch. -->
-  <div class="fixed inset-0 z-50 bg-black/20 flex items-center justify-center" data-testid="accounting-new-book-modal" @click.self="onCancel">
+  <!-- Form for creating a new book. Two layouts share one body:
+         • modal (default) — used by BookSwitcher's "+ New book…"
+           sentinel option. Backdrop click cancels.
+         • fullPage — used by View.vue on the first-run flow when
+           the workspace has zero books. No backdrop, no cancel:
+           the user MUST create their first book to proceed.
+       The submit calls createBook directly; on success it emits
+       the new book and its id, leaving the parent to wire
+       activeBookId / refetch. -->
+  <div :class="wrapperClass" data-testid="accounting-new-book-modal" @click.self="onBackdropClick">
     <form class="bg-white p-4 rounded shadow-lg w-96 flex flex-col gap-3" data-testid="accounting-new-book-form" @submit.prevent="onSubmit">
       <h3 class="text-base font-semibold">{{ t("pluginAccounting.bookSwitcher.newBook") }}</h3>
       <p v-if="firstRun" class="text-xs text-gray-500" data-testid="accounting-new-book-firstrun">{{ t("pluginAccounting.bookSwitcher.firstRunHint") }}</p>
@@ -20,7 +24,7 @@
       </label>
       <p v-if="error" class="text-xs text-red-500" data-testid="accounting-new-book-error">{{ error }}</p>
       <div class="flex justify-end gap-2 mt-1">
-        <button v-if="cancelable" type="button" class="h-8 px-2.5 rounded border border-gray-300 text-sm text-gray-700 hover:bg-gray-50" @click="onCancel">
+        <button v-if="showCancel" type="button" class="h-8 px-2.5 rounded border border-gray-300 text-sm text-gray-700 hover:bg-gray-50" @click="onCancel">
           {{ t("pluginAccounting.common.cancel") }}
         </button>
         <button
@@ -48,8 +52,9 @@ const props = withDefaults(
   defineProps<{
     firstRun?: boolean;
     cancelable?: boolean;
+    fullPage?: boolean;
   }>(),
-  { firstRun: false, cancelable: true },
+  { firstRun: false, cancelable: true, fullPage: false },
 );
 
 const emit = defineEmits<{
@@ -73,6 +78,22 @@ const options = computed<CurrencyOption[]>(() =>
     label: `${code} — ${localizedCurrencyName(code, locale.value)}`,
   })),
 );
+
+// Full-page mode replaces the AccountingApp chrome — fill the
+// parent flex column with the form centered, no backdrop. Modal
+// mode keeps the original viewport overlay behaviour.
+const wrapperClass = computed(() =>
+  props.fullPage ? "flex-1 bg-white flex items-center justify-center p-6 overflow-auto" : "fixed inset-0 z-50 bg-black/20 flex items-center justify-center",
+);
+
+// Cancel is hidden in full-page mode regardless of `cancelable`
+// — the first-run flow forces the user to create a book.
+const showCancel = computed(() => props.cancelable && !props.fullPage);
+
+function onBackdropClick(): void {
+  if (props.fullPage) return;
+  onCancel();
+}
 
 function onCancel(): void {
   if (!props.cancelable) return;

--- a/src/plugins/accounting/components/OpeningBalancesForm.vue
+++ b/src/plugins/accounting/components/OpeningBalancesForm.vue
@@ -2,6 +2,7 @@
   <form class="flex flex-col gap-3" data-testid="accounting-opening-form" @submit.prevent="onSubmit">
     <h3 class="text-base font-semibold">{{ t("pluginAccounting.openingForm.title") }}</h3>
     <p class="text-xs text-gray-500">{{ t("pluginAccounting.openingForm.explainer") }}</p>
+    <p class="text-xs text-blue-600" data-testid="accounting-opening-empty-hint">{{ t("pluginAccounting.openingForm.emptyHint") }}</p>
     <div v-if="existing" class="text-xs text-gray-500" data-testid="accounting-opening-existing">
       {{ t("pluginAccounting.openingForm.setBy", { date: existing.date }) }}
       <span v-if="existing" class="text-amber-600 ml-2">{{ t("pluginAccounting.openingForm.replaceWarning") }}</span>
@@ -124,14 +125,10 @@ const imbalance = computed<number>(() => {
   }
   return sum;
 });
-const hasAnyNonzero = computed(() => {
-  for (const code of Object.keys(rows.value)) {
-    const row = rows.value[code];
-    if ((row.debit ?? 0) > 0 || (row.credit ?? 0) > 0) return true;
-  }
-  return false;
-});
-const balanced = computed(() => Math.abs(imbalance.value) <= 0.005 && hasAnyNonzero.value);
+// An all-empty form is valid: it submits as a zero-line opening
+// marker so the user can unlock the rest of the UI without
+// committing to specific balances on day one.
+const balanced = computed(() => Math.abs(imbalance.value) <= 0.005);
 const imbalanceText = computed(() => formatAmount(imbalance.value, props.currency));
 const step = computed(() => inputStepFor(props.currency));
 

--- a/test/accounting/test_openingBalances.ts
+++ b/test/accounting/test_openingBalances.ts
@@ -24,6 +24,10 @@ describe("validateOpening", () => {
     const result = validateOpening({ asOfDate: "2026-01-01", lines: BALANCED, accounts: ACCOUNTS, existingEntries: [] });
     assert.equal(result.ok, true);
   });
+  it("accepts an empty opening (zero lines) as a no-op marker", () => {
+    const result = validateOpening({ asOfDate: "2026-01-01", lines: [], accounts: ACCOUNTS, existingEntries: [] });
+    assert.equal(result.ok, true);
+  });
   it("rejects income / expense accounts", () => {
     const result = validateOpening({
       asOfDate: "2026-01-01",


### PR DESCRIPTION
## Summary

Tightens the new-book flow and gates a freshly created book on having an opening on file.

- **"+ New book" lives in the books dropdown.** Removed the standalone button next to `BookSwitcher`; the books `<select>` now ends in a disabled separator and a `+ New book…` sentinel option that opens the modal.
- **First-run form is full-page, not a popup.** When the workspace has zero books, `NewBookForm` (in `fullPage` mode) replaces the whole AccountingApp chrome — header + tabs + main are hidden and there is no dismiss path. The popup layout is still used by the dropdown sentinel.
- **`openApp` tells the LLM about the no-book state.** When the workspace is empty, the tool result includes a `message` so the LLM knows the canvas is gated on the user creating a book.
- **Opening-balance gate.** A book without an opening on file forces `currentTab = "opening"` and disables every tab except `opening` and `settings` (so the user can still delete the book). Submitting saves an opening; submitting blank saves a zero-line opening that satisfies the gate without committing the user to specific balances on day one — they can update later.
  - Server `validateOpening` drops the "at least two lines" rule (zero lines is a valid no-op marker; balance check trivially passes).
  - `OpeningBalancesForm` drops the `hasAnyNonzero` gate and shows an "empty is fine" hint above the table.
  - 8 locales updated with the new `openingForm.emptyHint` key.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` clean
- [x] `yarn test` — `validateOpening` accepts a zero-line opening
- [x] `yarn test:e2e --grep accounting` — all 4 accounting tests green; `accounting-flow.spec.ts` updated to assert the full-page first-run form replaces the chrome
- [x] Manually verified by author: dropdown sentinel opens the modal; first-run form covers everything; submitting a blank opening unlocks the rest of the tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)