### PR TITLE
fix(agent): tighten attachment validation + bubble save failures (#1052 follow-up)

### DIFF
--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -295,6 +295,12 @@ interface RequestExtras {
  *  Order matches declaration order so chip order matches the order
  *  the user attached them.
  *
+ *  Each path is validated against the same allow-list `loadFromPath`
+ *  uses (`data/attachments/...` or `artifacts/images/...png`). A
+ *  request can otherwise pin a bogus path on the chat record + SSE
+ *  + LLM marker even though `loadFromPath` would refuse to read it
+ *  (#1052 review).
+ *
  *  Defensive: `Array.isArray` guards against a malformed HTTP body
  *  where `attachments` is a truthy non-array. Without it `for...of`
  *  would throw and bypass the rollback path that calls `endRun`,
@@ -303,7 +309,9 @@ export function collectAttachedPaths(attachments: Attachment[] | undefined): str
   if (!Array.isArray(attachments) || attachments.length === 0) return [];
   const paths: string[] = [];
   for (const att of attachments) {
-    if (typeof att.path === "string" && att.path.length > 0) paths.push(att.path);
+    if (typeof att.path !== "string" || att.path.length === 0) continue;
+    if (!isAttachmentPath(att.path) && !isImagePath(att.path)) continue;
+    paths.push(att.path);
   }
   return paths;
 }
@@ -316,8 +324,8 @@ export function collectAttachedPaths(attachments: Attachment[] | undefined): str
  *  — it sends path-only attachments directly. */
 function mergeBridgeSelectedImage(selectedImageData: string | undefined, attachments: Attachment[] | undefined): Attachment[] | undefined {
   const synthetic = synthesiseBridgeAttachment(selectedImageData);
-  if (!synthetic) return attachments;
-  return attachments && attachments.length > 0 ? [synthetic, ...attachments] : [synthetic];
+  if (!synthetic) return Array.isArray(attachments) ? attachments : undefined;
+  return Array.isArray(attachments) && attachments.length > 0 ? [synthetic, ...attachments] : [synthetic];
 }
 
 /** Convert a legacy `selectedImageData` carrier to an `Attachment`.
@@ -356,9 +364,16 @@ function synthesiseBridgeAttachment(selectedImageData: string | undefined): Atta
  *
  *  Defensive: `Array.isArray` mirrors the guard in
  *  `collectAttachedPaths` so a malformed payload doesn't throw and
- *  bypass `endRun`. Per-attachment failures are logged and the
- *  offending entry is dropped — a single bad upload mustn't poison
- *  the rest of the turn. */
+ *  bypass `endRun`. A failed save bubbles up so the caller can
+ *  reject the turn — silently dropping the file would persist the
+ *  user message without the attachment they sent and breaks the
+ *  persistence/broadcast contract this layer is enforcing (#1052
+ *  review). The caller's try/catch wraps the whole attachment-prep
+ *  block and rolls the run back via `endRun`, so the failure path
+ *  is well-defined: the user gets a 400, the session unlocks, and
+ *  no orphan turn lands in jsonl. Entries with neither path nor
+ *  inline bytes are still dropped (warn) — that's a malformed entry,
+ *  not an I/O failure. */
 async function persistInlineBytesAsPaths(attachments: Attachment[] | undefined): Promise<Attachment[] | undefined> {
   if (!Array.isArray(attachments) || attachments.length === 0) return undefined;
   const result: Attachment[] = [];
@@ -368,15 +383,8 @@ async function persistInlineBytesAsPaths(attachments: Attachment[] | undefined):
       continue;
     }
     if (typeof att.data === "string" && att.data.length > 0 && typeof att.mimeType === "string" && att.mimeType.length > 0) {
-      try {
-        const saved = await saveAttachment(att.data, att.mimeType);
-        result.push({ path: saved.relativePath, mimeType: saved.mimeType });
-      } catch (err) {
-        log.warn("agent", "failed to persist inline attachment to disk — dropping", {
-          mimeType: att.mimeType,
-          error: errorMessage(err),
-        });
-      }
+      const saved = await saveAttachment(att.data, att.mimeType);
+      result.push({ path: saved.relativePath, mimeType: saved.mimeType });
       continue;
     }
     log.warn("agent", "attachment has neither path nor inline bytes — dropping");

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -416,7 +416,7 @@ async function persistInlineBytesAsPaths(attachments: Attachment[] | undefined):
  *  Inline (`{ data, mimeType }`) entries no longer reach this layer —
  *  `persistInlineBytesAsPaths` rewrites them as path-bearing entries
  *  before this runs. */
-async function prepareRequestExtras(attachments: Attachment[] | undefined): Promise<RequestExtras> {
+export async function prepareRequestExtras(attachments: Attachment[] | undefined): Promise<RequestExtras> {
   if (!Array.isArray(attachments) || attachments.length === 0) {
     return { attachments: undefined, attachedFilePaths: [] };
   }
@@ -428,7 +428,11 @@ async function prepareRequestExtras(attachments: Attachment[] | undefined): Prom
       continue;
     }
     const resolved = await loadFromPath(att.path, att.mimeType);
-    if (resolved) result.push(resolved);
+    if (!resolved) continue;
+    // Only emit the `[Attached file: …]` marker when the file was
+    // actually loaded — otherwise the LLM gets told a bogus path
+    // exists (Codex review on PR #1084 follow-up to #1052).
+    result.push(resolved);
     attachedFilePaths.push(att.path);
   }
   return {

--- a/server/utils/files/attachment-store.ts
+++ b/server/utils/files/attachment-store.ts
@@ -155,8 +155,19 @@ export async function loadAttachmentBytes(relativePath: string): Promise<Buffer>
   return readFile(absPath);
 }
 
+// Reject `.` and `..` segments split on either `/` or `\` so a
+// traversal-shaped value (`data/attachments/../secrets/key.pem`,
+// `data/attachments\..\foo.pdf`) doesn't pass the prefix check
+// and reach `[Attached file: ...]` markers / chat surface
+// (Codex review on PR #1084 follow-up to #1052).
+function hasTraversalSegment(value: string): boolean {
+  return value.split(/[/\\]/).some((segment) => segment === ".." || segment === ".");
+}
+
 export function isAttachmentPath(value: string): boolean {
-  return value.startsWith(`${WORKSPACE_DIRS.attachments}/`);
+  if (!value.startsWith(`${WORKSPACE_DIRS.attachments}/`)) return false;
+  if (hasTraversalSegment(value)) return false;
+  return true;
 }
 
 export function stripDataUri(dataUri: string): { mimeType: string; base64: string } | undefined {

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -54,7 +54,17 @@ export function stripDataUri(dataUri: string): string {
   return dataUri.replace(/^data:image\/[^;]+;base64,/, "");
 }
 
+// Reject `.` / `..` segments split on either `/` or `\` so a
+// traversal-shaped value can't slip past the prefix/suffix gate
+// (Codex review on PR #1084 follow-up to #1052).
+function hasTraversalSegment(value: string): boolean {
+  return value.split(/[/\\]/).some((segment) => segment === ".." || segment === ".");
+}
+
 // Accepts arbitrary depth so saveImage's images/YYYY/MM/abc.png still validates.
 export function isImagePath(value: string): boolean {
-  return value.startsWith(`${WORKSPACE_DIRS.images}/`) && value.endsWith(".png");
+  if (!value.startsWith(`${WORKSPACE_DIRS.images}/`)) return false;
+  if (!value.endsWith(".png")) return false;
+  if (hasTraversalSegment(value)) return false;
+  return true;
 }

--- a/test/api/routes/test_agentCollectAttachedPaths.ts
+++ b/test/api/routes/test_agentCollectAttachedPaths.ts
@@ -62,4 +62,27 @@ describe("collectAttachedPaths", () => {
     const attachments: Attachment[] = [{ path: "artifacts/images/2026/04/foo.gif" }];
     assert.deepEqual(collectAttachedPaths(attachments), []);
   });
+
+  it("rejects traversal-shaped paths that match the prefix (Codex review on #1084)", () => {
+    // The validators were prefix/suffix only before, so a value like
+    // `data/attachments/../secrets/key.pem` passed `startsWith("data/attachments/")`
+    // and reached the chat surface as `[Attached file: ...]` even
+    // though `loadFromPath` would later refuse to read it.
+    const attachments: Attachment[] = [
+      { path: "data/attachments/../secrets/key.pem" },
+      { path: "data/attachments/foo/../../bar.pdf" },
+      { path: "artifacts/images/../escape.png" },
+      // Windows / encoded backslash form. `decodeURIComponent` of `%5C`
+      // produces `\`, and `path.normalize` treats it as a separator
+      // on Windows — the validator must catch it before downstream
+      // resolves it.
+      { path: "data/attachments\\..\\secrets.pdf" },
+      // Single-dot segment: also rejected (defense-in-depth).
+      { path: "data/attachments/./foo.pdf" },
+      // Real entries should still pass.
+      { path: "data/attachments/2026/04/legit.pdf" },
+      { path: "artifacts/images/2026/04/legit.png" },
+    ];
+    assert.deepEqual(collectAttachedPaths(attachments), ["data/attachments/2026/04/legit.pdf", "artifacts/images/2026/04/legit.png"]);
+  });
 });

--- a/test/api/routes/test_agentCollectAttachedPaths.ts
+++ b/test/api/routes/test_agentCollectAttachedPaths.ts
@@ -43,4 +43,23 @@ describe("collectAttachedPaths", () => {
     const attachments: Attachment[] = [{ path: "data/attachments/2026/04/foo.png" }, { mimeType: "image/png", data: "AAAA" }, { path: "" }];
     assert.deepEqual(collectAttachedPaths(attachments), ["data/attachments/2026/04/foo.png"]);
   });
+
+  it("rejects paths outside the allowed workspace roots", () => {
+    // Bogus paths posted directly by a malicious client. `loadFromPath`
+    // would refuse to read them, but the chip + JSONL line + LLM marker
+    // are emitted independently — they have to filter here too.
+    const attachments: Attachment[] = [
+      { path: "/etc/passwd" },
+      { path: "../escape.png" },
+      { path: "secrets/key.pem" },
+      { path: "data/attachments/2026/04/legit.png" },
+      { path: "artifacts/images/2026/04/legit.png" },
+    ];
+    assert.deepEqual(collectAttachedPaths(attachments), ["data/attachments/2026/04/legit.png", "artifacts/images/2026/04/legit.png"]);
+  });
+
+  it("rejects an image path that doesn't end in .png (matches isImagePath)", () => {
+    const attachments: Attachment[] = [{ path: "artifacts/images/2026/04/foo.gif" }];
+    assert.deepEqual(collectAttachedPaths(attachments), []);
+  });
 });

--- a/test/api/routes/test_agentPrepareRequestExtras.ts
+++ b/test/api/routes/test_agentPrepareRequestExtras.ts
@@ -1,0 +1,49 @@
+// Pins the iter-1 fix from PR #1084 review (Codex on #1052 follow-up):
+// `prepareRequestExtras` must NOT push a path into `attachedFilePaths`
+// when `loadFromPath` returns undefined — otherwise the LLM gets told
+// `[Attached file: <bogus>]` for a file that wasn't actually loaded.
+//
+// We don't write fixture files here. The path-validation gate
+// (`isAttachmentPath` / `isImagePath`, both prefix + traversal-segment
+// reject) is what we're verifying: an invalid path makes
+// `loadFromPath` short-circuit returning undefined → both `result`
+// and `attachedFilePaths` should remain empty for that entry.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Attachment } from "@mulmobridge/protocol";
+import { prepareRequestExtras } from "../../../server/api/routes/agent.ts";
+
+describe("prepareRequestExtras — load-failure marker gate", () => {
+  it("returns empty extras for an empty / undefined attachments list", async () => {
+    assert.deepEqual(await prepareRequestExtras(undefined), { attachments: undefined, attachedFilePaths: [] });
+    assert.deepEqual(await prepareRequestExtras([]), { attachments: undefined, attachedFilePaths: [] });
+  });
+
+  it("does NOT push a marker for an invalid path (load fails)", async () => {
+    // Pre-fix this would push the bogus path into `attachedFilePaths`,
+    // emitting `[Attached file: ...]` to the LLM even though the byte
+    // load was rejected.
+    const attachments: Attachment[] = [{ path: "data/attachments/../escape.pdf" }];
+    const out = await prepareRequestExtras(attachments);
+    assert.deepEqual(out.attachedFilePaths, []);
+    assert.equal(out.attachments, undefined);
+  });
+
+  it("does NOT push a marker for a path outside the allow-list roots", async () => {
+    const attachments: Attachment[] = [{ path: "/etc/passwd" }, { path: "secrets/key.pem" }];
+    const out = await prepareRequestExtras(attachments);
+    assert.deepEqual(out.attachedFilePaths, []);
+    assert.equal(out.attachments, undefined);
+  });
+
+  it("does NOT push a marker for an attachment with no path at all", async () => {
+    // Inline-only entries should have been rewritten to path form by
+    // `persistInlineBytesAsPaths` upstream. If one slips through with
+    // no path, drop it — don't fabricate a marker.
+    const attachments: Attachment[] = [{ mimeType: "image/png", data: "AAAA" }];
+    const out = await prepareRequestExtras(attachments);
+    assert.deepEqual(out.attachedFilePaths, []);
+    assert.equal(out.attachments, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Three CodeRabbit blockers from PR #1052 review on `server/api/routes/agent.ts`:

1. **`mergeBridgeSelectedImage` non-array spread crash.** Used `attachments && attachments.length > 0` then spread, so any truthy non-array (`{ length: 5 }` from a buggy bridge) would throw on the spread before reaching the validation block — caller sees 500 instead of clean 400.

2. **`collectAttachedPaths` accepts bogus paths.** Any non-empty `att.path` was written to JSONL, SSE event, and `[Attached file: ...]` marker. `loadFromPath` would later refuse to read it (path is outside allowed roots), but the chip + LLM hint were already emitted with the bogus path — visible in chat history forever and surfaced to the model.

3. **`persistInlineBytesAsPaths` swallows save failures.** A `saveAttachment` failure was logged and the entry dropped. The user message then persisted + broadcast without the file they sent — breaking the persistence/broadcast contract this layer was added to enforce.

## Items to Confirm / Review

- The path validation in `collectAttachedPaths` matches `loadFromPath` (`isAttachmentPath` OR `isImagePath`) — these are the same predicates the bytes-loading branch uses, so chip emission and bytes-load now agree on what's a legal path.
- For (3), I dropped the surrounding try/catch on `saveAttachment` so the error bubbles up. The existing try/catch at `startChat` lines 201-210 wraps the whole attachment-prep block, calls `endRun(chatSessionId)`, and returns `{ kind: "error", error: "Invalid attachments payload", status: 400 }`. So the failure path is well-defined: the user sees a 400, the session unlocks, no orphan turn lands in jsonl. The "neither path nor inline bytes" case is still warn+drop because that's a malformed entry shape, not an I/O failure.
- For (1), `mergeBridgeSelectedImage` runs BEFORE `beginRun`, so a throw there wouldn't leave a stuck session — but it would surface as 500 instead of a clean validation error. The fix downgrades it to a clean 400 path (or in this case, just returns `undefined` and lets later code emit the standard "no attachments" path).

## User Prompt

PR Quality Sweep covering 24h of merged PRs. The user chose option C: fix all blockers, one PR per item — but blockers (1)/(2)/(3) all live in the same attachment-processing flow in `agent.ts` and are inseparable, so they batch into one PR. This is PR 3 of 6 covering the 10 blockers identified.

(The 4th \"blocker\" the user listed earlier was \"beginRun() before attachment prep — session stuck.\" The current code already wraps the attachment block in try/catch with `endRun(chatSessionId)` rollback, so that's already addressed in the original PR — no additional fix needed here.)

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
- [x] `npx tsx --test test/api/routes/test_agentCollectAttachedPaths.ts` — 8 tests pass (6 existing + 2 new for path validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)