### PR TITLE
feat(accounting): edit opening from journal row; hide redundant tab

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -585,6 +585,7 @@ const deMessages = {
       accountLabel: "Konto",
       allAccounts: "Alle Konten",
       void: "Stornieren",
+      edit: "Bearbeiten",
       voidConfirm: "Diesen Eintrag stornieren? Das Original bleibt im Journal; ein Stornopaar wird angehängt.",
       voidReason: "Grund (optional):",
       columns: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -601,6 +601,7 @@ const enMessages = {
       accountLabel: "Account",
       allAccounts: "All accounts",
       void: "Void",
+      edit: "Edit",
       voidConfirm: "Void this entry? The original stays in the journal; a reversing pair is appended.",
       voidReason: "Reason (optional):",
       columns: { date: "Date", kind: "Kind", memo: "Memo", lines: "Lines" },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -586,6 +586,7 @@ const esMessages = {
       accountLabel: "Cuenta",
       allAccounts: "Todas",
       void: "Anular",
+      edit: "Editar",
       voidConfirm: "¿Anular esta entrada? La original permanece en el diario; se añade un par de reversión.",
       voidReason: "Motivo (opcional):",
       columns: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -580,6 +580,7 @@ const frMessages = {
       accountLabel: "Compte",
       allAccounts: "Tous",
       void: "Annuler",
+      edit: "Modifier",
       voidConfirm: "Annuler cette écriture ? L'originale reste dans le journal ; une paire de contre-passation est ajoutée.",
       voidReason: "Motif (optionnel) :",
       columns: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -576,6 +576,7 @@ const jaMessages = {
       accountLabel: "勘定科目",
       allAccounts: "すべての科目",
       void: "取消",
+      edit: "編集",
       voidConfirm: "この仕訳を取り消しますか？元の仕訳は journal に残り、逆仕訳が追記されます。",
       voidReason: "理由（任意）:",
       columns: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -576,6 +576,7 @@ const koMessages = {
       accountLabel: "계정",
       allAccounts: "모든 계정",
       void: "취소",
+      edit: "편집",
       voidConfirm: "이 분개를 취소하시겠습니까? 원 분개는 분개장에 남고 반대 분개가 추가됩니다.",
       voidReason: "사유(선택):",
       columns: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -578,6 +578,7 @@ const ptBRMessages = {
       accountLabel: "Conta",
       allAccounts: "Todas as contas",
       void: "Estornar",
+      edit: "Editar",
       voidConfirm: "Estornar este lançamento? O original permanece no diário e um par de reversão é anexado.",
       voidReason: "Motivo (opcional):",
       columns: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -572,6 +572,7 @@ const zhMessages = {
       accountLabel: "科目",
       allAccounts: "所有科目",
       void: "冲销",
+      edit: "编辑",
       voidConfirm: "冲销此分录？原始分录保留在日记账中，会追加一对反向分录。",
       voidReason: "原因（可选）:",
       columns: {

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -21,16 +21,11 @@
       </header>
       <nav class="flex items-center gap-0.5 px-3 py-1.5 border-b border-gray-100 shrink-0 overflow-x-auto" data-testid="accounting-tabs">
         <button
-          v-for="tab in TABS"
+          v-for="tab in visibleTabs"
           :key="tab.key"
-          :disabled="isTabDisabled(tab.key)"
           :class="[
             'h-8 px-2.5 flex items-center gap-1 rounded text-sm whitespace-nowrap',
-            isTabDisabled(tab.key)
-              ? 'text-gray-300 cursor-not-allowed'
-              : currentTab === tab.key
-                ? 'bg-blue-50 text-blue-600 font-medium'
-                : 'text-gray-600 hover:bg-gray-50',
+            currentTab === tab.key ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-600 hover:bg-gray-50',
           ]"
           :data-testid="`accounting-tab-${tab.key}`"
           @click="currentTab = tab.key"
@@ -53,6 +48,7 @@
             :currency="activeCurrency"
             :version="bookVersion"
             @changed="bumpLocalVersion"
+            @edit-opening="currentTab = 'opening'"
           />
           <JournalEntryForm
             v-else-if="currentTab === 'newEntry'"
@@ -255,10 +251,14 @@ async function refetchOpening(): Promise<void> {
 // so the user can delete the book if they don't want to proceed.
 const openingGateActive = computed(() => activeBookId.value !== null && hasOpening.value === false);
 
-function isTabDisabled(key: TabKey): boolean {
-  if (!openingGateActive.value) return false;
-  return key !== "opening" && key !== "settings";
-}
+// Gated → only Opening + Settings render in the strip. Ungated →
+// Opening hides itself; users reach the form via the Edit button
+// on the active opening row in the journal, which transiently
+// switches `currentTab` to "opening" (kept visible while there).
+const visibleTabs = computed<readonly TabDef[]>(() => {
+  if (openingGateActive.value) return TABS.filter((tab) => tab.key === "opening" || tab.key === "settings");
+  return TABS.filter((tab) => tab.key !== "opening" || currentTab.value === "opening");
+});
 
 function onBookSelected(bookId: string): void {
   activeBookId.value = bookId;
@@ -295,11 +295,12 @@ watch(
   { immediate: true },
 );
 
-// Force-route to the Opening tab whenever the gate engages. Tab
-// buttons are also `:disabled` so a stray click can't bypass it,
-// but this watcher handles the programmatic case (book switch,
-// initial mount with a no-opening book, LLM-supplied initialTab
-// pointing at a gated tab).
+// Force-route to the Opening tab whenever the gate engages.
+// Other tabs are hidden from the strip while gated, but this
+// watcher handles the programmatic case where currentTab still
+// points at a now-hidden tab (book switch, initial mount with a
+// no-opening book, LLM-supplied initialTab pointing at a gated
+// tab) — without it, `<main>` would render nothing.
 watch(openingGateActive, (active) => {
   if (!active) return;
   if (currentTab.value === "opening" || currentTab.value === "settings") return;

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -277,8 +277,12 @@ function onEntrySubmitted(): void {
 }
 
 async function onBookDeleted(): Promise<void> {
-  await refetchBooks();
+  // Reset the tab BEFORE awaiting so a fast delete-then-create
+  // can't race: if the new book's gate engages while we're still
+  // awaiting refetchBooks, the gate watcher needs to see a
+  // non-"settings" currentTab to route the user to Opening.
   currentTab.value = "journal";
+  await refetchBooks();
 }
 
 watch(activeBookId, (next) => {
@@ -300,10 +304,15 @@ watch(
 // watcher handles the programmatic case where currentTab still
 // points at a now-hidden tab (book switch, initial mount with a
 // no-opening book, LLM-supplied initialTab pointing at a gated
-// tab) — without it, `<main>` would render nothing.
+// tab, or fresh-book creation right after deleting from the
+// settings tab) — without it, `<main>` would render nothing or
+// the user would be stranded on the prior book's settings view.
+// We don't exempt "settings" here: the user can still click back
+// to it from the (gated) tab strip if they want to delete the
+// new book instead of setting it up.
 watch(openingGateActive, (active) => {
   if (!active) return;
-  if (currentTab.value === "opening" || currentTab.value === "settings") return;
+  if (currentTab.value === "opening") return;
   currentTab.value = "opening";
 });
 

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -62,6 +62,14 @@
             >
               {{ t("pluginAccounting.journalList.void") }}
             </button>
+            <button
+              v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
+              class="text-xs text-blue-600 hover:underline"
+              :data-testid="`accounting-edit-opening-${entry.id}`"
+              @click="emit('editOpening')"
+            >
+              {{ t("pluginAccounting.journalList.edit") }}
+            </button>
           </td>
         </tr>
       </tbody>
@@ -79,7 +87,7 @@ import { useLatestRequest } from "./useLatestRequest";
 const { t } = useI18n();
 
 const props = defineProps<{ bookId: string; accounts: Account[]; currency: string; version: number }>();
-const emit = defineEmits<{ changed: [] }>();
+const emit = defineEmits<{ changed: []; editOpening: [] }>();
 
 const from = ref("");
 const toDate = ref("");


### PR DESCRIPTION
## Summary

- Replace the always-visible **Opening** tab with a row-level **Edit** button on the active opening entry in the journal (mirroring the **Void** button on normal entries). The tab strip now hides Opening once an opening exists, and shows only `[Opening, Settings]` while the gate is engaged — making the setup-vs-use distinction visual instead of just a disabled state.
- Fix a coupled race where deleting the last book from the **Settings** tab and immediately creating a new one would strand the user on Settings instead of routing to Opening for the new book's setup.

## Test plan

- [ ] On a book with an opening: Opening tab is hidden from the strip; the journal row for the opening kind shows an **Edit** button.
- [ ] Click **Edit** → the Opening form loads and submitting replaces the opening (the prior one becomes voided in the journal, no Edit button on it).
- [ ] On a book without an opening: only `[Opening, Settings]` show in the strip.
- [ ] Delete the last book while on the Settings tab, then create a new book → the new book gates correctly and currentTab routes to Opening, not Settings.
- [ ] All 8 locales render the new `journalList.edit` string.
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Edit" action in the Accounting journal list with translations for all supported locales.
  * Journal list can trigger direct navigation into the opening tab for quick edits.
* **Bug Fixes**
  * Improved tab visibility and navigation when account-opening gating changes.
  * Fixed book-deletion flow to avoid race conditions after deleting a book.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->