### PR TITLE
fix(memory): tighten topic-slug + frontmatter validation (#1072 follow-up)

### DIFF
--- a/server/workspace/memory/topic-io.ts
+++ b/server/workspace/memory/topic-io.ts
@@ -160,10 +160,20 @@ function parseTopicFile(absPath: string, raw: string | null, expectedType: Memor
     log.warn("memory", "topic-io: missing topic", { path: absPath });
     return null;
   }
-  if (!isSafeTopicSlug(topic.trim())) {
+  const topicTrimmed = topic.trim();
+  if (!isSafeTopicSlug(topicTrimmed)) {
     log.warn("memory", "topic-io: unsafe topic slug", { path: absPath, topic });
     return null;
   }
+  // Filename is the source of truth — the index links to it.
+  // A frontmatter `topic` that disagrees with the basename produces
+  // dangling index entries (`type/topic.md` doesn't exist on disk),
+  // which the swap promotes verbatim.
+  const fileTopic = path.basename(absPath, ".md");
+  if (topicTrimmed !== fileTopic) {
+    log.warn("memory", "topic-io: topic / filename mismatch", { path: absPath, topic: topicTrimmed, fileTopic });
+    return null;
+  }
   const sections = extractH2Sections(parsed.body);
-  return { type, topic: topic.trim(), body: parsed.body, sections };
+  return { type, topic: topicTrimmed, body: parsed.body, sections };
 }

--- a/server/workspace/memory/topic-types.ts
+++ b/server/workspace/memory/topic-types.ts
@@ -55,6 +55,36 @@ function stripCarriageReturn(line: string): string {
 // suffixed result still fits.
 export const MAX_TOPIC_SLUG_LENGTH = 60;
 
+// Windows refuses to create files with these basenames even with an
+// extension (`con.md` is blocked). Without this gate a clusterer
+// that returns "CON" would slugify to `con`, pass `isSafeTopicSlug`,
+// and then fail migration on Windows. Listed in lowercase since the
+// slugifier lowercases first.
+const WINDOWS_RESERVED_BASENAMES = new Set([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+]);
+
 // Slugify a topic name for use as a filename. `<type>/<topic>.md`
 // must keep `topic` filesystem-safe and short. Collapses anything
 // non-alnum into a single `-`, lowercases, trims trailing
@@ -76,7 +106,10 @@ export function slugifyTopicName(name: string): string | null {
   }
   while (out.length > 0 && out[out.length - 1] === "-") out.pop();
   const compact = out.slice(0, MAX_TOPIC_SLUG_LENGTH).join("");
-  return compact.length > 0 ? trimTrailing(compact, "-") : null;
+  if (compact.length === 0) return null;
+  const trimmed = trimTrailing(compact, "-");
+  if (WINDOWS_RESERVED_BASENAMES.has(trimmed)) return null;
+  return trimmed;
 }
 
 function trimTrailing(text: string, char: string): string {
@@ -104,5 +137,6 @@ export function isSafeTopicSlug(slug: string): boolean {
     if (!ok) return false;
   }
   if (slug === "memory") return false;
+  if (WINDOWS_RESERVED_BASENAMES.has(slug)) return false;
   return true;
 }

--- a/test/workspace/memory/test_topic_io.ts
+++ b/test/workspace/memory/test_topic_io.ts
@@ -94,6 +94,22 @@ describe("memory/topic-io — reader tolerance", () => {
     assert.equal(all[0].topic, "art");
   });
 
+  it("skips files whose frontmatter topic disagrees with the filename", async () => {
+    // Otherwise the index would link to `interest/imposter.md` (the
+    // frontmatter topic) — a path that doesn't exist on disk — and
+    // every reader following the link gets a dangling 404.
+    const isolated = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-io-mismatch-"));
+    try {
+      const root = topicMemoryRoot(isolated);
+      await mkdir(path.join(root, "interest"), { recursive: true });
+      await writeFile(path.join(root, "interest", "music.md"), "---\ntype: interest\ntopic: imposter\n---\n\n# Music\n\n- something", "utf-8");
+      const all = await loadAllTopicFiles(isolated);
+      assert.deepEqual(all, []);
+    } finally {
+      await rm(isolated, { recursive: true, force: true });
+    }
+  });
+
   it("returns empty when the memory dir does not exist", async () => {
     const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-io-empty-"));
     try {

--- a/test/workspace/memory/test_topic_types.ts
+++ b/test/workspace/memory/test_topic_types.ts
@@ -77,4 +77,24 @@ describe("memory/topic-types — isSafeTopicSlug", () => {
     assert.equal(isSafeTopicSlug("Memory"), false);
     assert.equal(isSafeTopicSlug("memory"), false);
   });
+
+  it("rejects Windows-reserved basenames so migration doesn't fail on Win32", () => {
+    // Windows refuses to create `con.md` / `prn.md` etc. even with
+    // an extension; without this gate a clusterer that returned
+    // "CON" would slugify to `con`, pass validation, and then
+    // explode on the writeTopicFileToStaging call on Windows.
+    for (const reserved of ["con", "prn", "aux", "nul", "com1", "com9", "lpt1", "lpt9"]) {
+      assert.equal(isSafeTopicSlug(reserved), false, `slug "${reserved}" should be rejected`);
+    }
+  });
+});
+
+describe("memory/topic-types — slugifyTopicName Windows-reserved gate", () => {
+  it("returns null for Windows-reserved basenames so the caller falls back", () => {
+    // Mirrors the isSafeTopicSlug gate so the slugifier never emits
+    // a slug that the validator would later reject.
+    for (const reserved of ["CON", "Prn", "aux", "Nul", "COM1", "lpt9"]) {
+      assert.equal(slugifyTopicName(reserved), null, `slugify("${reserved}") should be null`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Two CodeRabbit findings from PR #1072 review on the topic-based memory schema (`server/workspace/memory/topic-{types,io}.ts`):

1. **Reject Windows-reserved basenames in the slug gate.** A clusterer returning \`\"CON\"\` / \`\"PRN\"\` / \`\"COM1\"\` / \`\"LPT1\"\` would slugify to \`con\` / \`prn\` / \`com1\` / \`lpt1\`, pass \`isSafeTopicSlug\`, and then fail migration on Windows because the OS refuses to create those filenames even with an extension. Add a hard-coded set of reserved names (\`con\`, \`prn\`, \`aux\`, \`nul\`, \`com1\`–\`com9\`, \`lpt1\`–\`lpt9\`) and reject in both \`slugifyTopicName\` and \`isSafeTopicSlug\` so the slugifier never emits one and the validator never accepts one.
2. **Reject frontmatter topic that disagrees with filename.** \`parseTopicFile\` trusted the frontmatter \`topic\` without checking it against the basename of \`absPath\`. A file at \`interest/music.md\` with \`topic: imposter\` produced an index entry \`interest/imposter.md\` — a path that doesn't exist on disk — and every reader following the link gets a dangling 404.

## Items to Confirm / Review

- Reserved names are matched **after** slugification (lowercase + alnum-only), so \`Con\`, \`con \`, and \`CON.md\` all get caught.
- Both gates are aligned: \`slugifyTopicName(\"CON\")\` returns \`null\` so the caller falls back to a hash; \`isSafeTopicSlug(\"con\")\` returns \`false\` so any pre-existing \`con.md\` in a workspace gets refused on read instead of silently linked.
- The filename check uses \`path.basename(absPath, \".md\")\` which is platform-correct (the existing \`isCandidateFilename\` only accepts files ending in \`.md\`).
- 3 new tests pin the behaviour: Windows-reserved gate in \`isSafeTopicSlug\` and \`slugifyTopicName\`, plus the frontmatter-mismatch rejection.

## User Prompt

PR Quality Sweep covering 24h of merged PRs. The user chose option C: fix all blockers, one PR per item. This is PR 4 of 6 covering the 10 blockers identified.

The user's framing of \"#1072 topic-migrate slug validation — clusterer can inject \`../escape\`\" — the \`../escape\` injection is already blocked by \`slugifyTopicName\` (strips dots/slashes) + \`isSafeTopicSlug\` (a-z/0-9/- only). So this PR addresses the **other** real slug-validation concerns CodeRabbit flagged on #1072: the Windows-reserved gap and the frontmatter mismatch.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] \`npx tsx --test test/workspace/memory/test_topic_types.ts test/workspace/memory/test_topic_io.ts\` — all topic tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)