### PR TITLE
fix(memory): close swap-window detect gap + legacy stat race (#1076 follow-up)

### DIFF
--- a/server/workspace/memory/topic-detect.ts
+++ b/server/workspace/memory/topic-detect.ts
@@ -7,42 +7,60 @@
 //   topic (#1070):  `<type>/<topic>.md` under per-type subdirs,
 //     one topic per file.
 //
-// Detection signal: the topic format is active iff at least one of
-// the canonical type subdirs (`preference/`, `interest/`, `fact/`,
-// `reference/`) exists as a directory under EITHER
-// `conversations/memory/` OR `conversations/memory.next/`. The
-// staging dir is checked too because `swapStagingIntoMemory` first
-// renames `memory` out of the way and only then renames `memory.next`
-// into place. A request that hits this function in that gap would
-// otherwise see no `<type>/` under `memory/` (it was just renamed
-// away), fall back to atomic format, and write a fresh
-// `<type>_<slug>.md` into the newly promoted topic tree — which
-// later topic-mode reads silently ignore. The check is cheap (one
-// stat per type per layout location) and reflects on-disk truth,
-// so a manual swap immediately changes behavior on the next request
-// — no module-level cache.
+// Detection signal: topic format is active iff a canonical type
+// subdir (`preference/` / `interest/` / `fact/` / `reference/`)
+// exists under live `conversations/memory/`. The post-swap state.
+//
+// Special case for the swap window: `swapStagingIntoMemory` first
+// renames `memory/` out of the way and then renames `memory.next/`
+// into place. Inside that gap `memory/` does not exist at all, so
+// requests would otherwise fall back to atomic format and write
+// `<type>_<slug>.md` into the newly promoted topic tree (later
+// topic-mode reads silently ignore those). To bridge the gap, we
+// also accept `memory.next/<type>/` — but ONLY when `memory/` is
+// entirely absent (the actual swap window). When `memory/` still
+// exists with atomic files (staging-in-progress, before the swap),
+// `memory.next/<type>/` is just the clusterer filling staging and
+// must NOT flip detection to topic mode — atomic data is still
+// authoritative and the prompt has to keep reading it.
+// (#1076 / #1087 follow-up — review on prompt-routing regression.)
+//
+// The check is cheap (one stat per type plus a stat on `memory/`)
+// and reflects on-disk truth, so a manual swap immediately changes
+// behavior on the next request — no module-level cache.
 
 import { statSync } from "node:fs";
 import path from "node:path";
 
 import { MEMORY_TYPES } from "./types.js";
 
-export function hasTopicFormat(workspaceRoot: string): boolean {
-  const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
-  const stagingRoot = path.join(workspaceRoot, "conversations", "memory.next");
-  for (const root of [memoryRoot, stagingRoot]) {
-    for (const type of MEMORY_TYPES) {
-      const candidate = path.join(root, type);
-      try {
-        const stat = statSync(candidate);
-        if (stat.isDirectory()) return true;
-      } catch {
-        // ENOENT / EACCES → keep looking. A missing or unreadable
-        // type subdir doesn't disqualify the workspace; only the
-        // presence of one (in either location) promotes the format
-        // to topic.
-      }
-    }
+function isDirectorySafe(absPath: string): boolean {
+  try {
+    return statSync(absPath).isDirectory();
+  } catch {
+    // ENOENT / EACCES → treat as missing.
+    return false;
+  }
+}
+
+function hasAnyTypeSubdir(root: string): boolean {
+  for (const type of MEMORY_TYPES) {
+    if (isDirectorySafe(path.join(root, type))) return true;
   }
   return false;
+}
+
+export function hasTopicFormat(workspaceRoot: string): boolean {
+  const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
+  // Live tree wins: any `memory/<type>/` → post-swap topic mode.
+  if (hasAnyTypeSubdir(memoryRoot)) return true;
+  // If live `memory/` still exists (with atomic files at the root,
+  // or empty), the staging dir is just being filled — atomic format
+  // is still authoritative until the swap renames memory/ out of
+  // the way. Don't let `memory.next/<type>/` flip detection here.
+  if (isDirectorySafe(memoryRoot)) return false;
+  // Live tree absent → could be the swap window OR a fresh
+  // workspace. Consult staging.
+  const stagingRoot = path.join(workspaceRoot, "conversations", "memory.next");
+  return hasAnyTypeSubdir(stagingRoot);
 }

--- a/server/workspace/memory/topic-detect.ts
+++ b/server/workspace/memory/topic-detect.ts
@@ -9,10 +9,18 @@
 //
 // Detection signal: the topic format is active iff at least one of
 // the canonical type subdirs (`preference/`, `interest/`, `fact/`,
-// `reference/`) exists as a directory under
-// `conversations/memory/`. The check is cheap (one stat per type)
-// and reflects on-disk truth, so a manual swap immediately changes
-// behavior on the next request — no module-level cache.
+// `reference/`) exists as a directory under EITHER
+// `conversations/memory/` OR `conversations/memory.next/`. The
+// staging dir is checked too because `swapStagingIntoMemory` first
+// renames `memory` out of the way and only then renames `memory.next`
+// into place. A request that hits this function in that gap would
+// otherwise see no `<type>/` under `memory/` (it was just renamed
+// away), fall back to atomic format, and write a fresh
+// `<type>_<slug>.md` into the newly promoted topic tree — which
+// later topic-mode reads silently ignore. The check is cheap (one
+// stat per type per layout location) and reflects on-disk truth,
+// so a manual swap immediately changes behavior on the next request
+// — no module-level cache.
 
 import { statSync } from "node:fs";
 import path from "node:path";
@@ -21,15 +29,19 @@ import { MEMORY_TYPES } from "./types.js";
 
 export function hasTopicFormat(workspaceRoot: string): boolean {
   const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
-  for (const type of MEMORY_TYPES) {
-    const candidate = path.join(memoryRoot, type);
-    try {
-      const stat = statSync(candidate);
-      if (stat.isDirectory()) return true;
-    } catch {
-      // ENOENT / EACCES → keep looking. A missing or unreadable
-      // type subdir doesn't disqualify the workspace; only the
-      // presence of one promotes the format to topic.
+  const stagingRoot = path.join(workspaceRoot, "conversations", "memory.next");
+  for (const root of [memoryRoot, stagingRoot]) {
+    for (const type of MEMORY_TYPES) {
+      const candidate = path.join(root, type);
+      try {
+        const stat = statSync(candidate);
+        if (stat.isDirectory()) return true;
+      } catch {
+        // ENOENT / EACCES → keep looking. A missing or unreadable
+        // type subdir doesn't disqualify the workspace; only the
+        // presence of one (in either location) promotes the format
+        // to topic.
+      }
     }
   }
   return false;

--- a/server/workspace/memory/topic-run.ts
+++ b/server/workspace/memory/topic-run.ts
@@ -34,7 +34,7 @@ import { loadAllMemoryEntries } from "./io.js";
 import { makeLlmMemoryClusterer } from "./topic-cluster.js";
 import { clusterAtomicIntoStaging, topicStagingPath } from "./topic-migrate.js";
 import { swapStagingIntoMemory } from "./topic-swap.js";
-import { hasTopicFormat } from "./topic-detect.js";
+import { MEMORY_TYPES } from "./types.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
 
@@ -44,8 +44,28 @@ export interface RunTopicMigrationDeps {
   summarize?: Summarize;
 }
 
+// Strict variant of `hasTopicFormat` that only looks at `memory/`,
+// not `memory.next/`. The shared `hasTopicFormat` is intentionally
+// swap-tolerant so prompt routing doesn't fall back to atomic-format
+// rules during the rename window — but the runner's idempotency
+// guard needs the OPPOSITE: when only `memory.next/` exists (a
+// swap-in-progress or a crash mid-swap), the runner must drop into
+// the "existing staging detected" retry-swap branch below, not exit.
+function memoryTreeIsTopicFormat(workspaceRoot: string): boolean {
+  const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
+  for (const type of MEMORY_TYPES) {
+    try {
+      if (statSync(path.join(memoryRoot, type)).isDirectory()) return true;
+    } catch {
+      // ENOENT / EACCES → keep looking; only the actual presence of
+      // a `memory/<type>` dir signals migration completed.
+    }
+  }
+  return false;
+}
+
 export async function runTopicMigrationOnce(workspaceRoot: string, deps: RunTopicMigrationDeps = {}): Promise<void> {
-  if (hasTopicFormat(workspaceRoot)) {
+  if (memoryTreeIsTopicFormat(workspaceRoot)) {
     log.debug("memory", "topic-run: workspace already uses topic format, skipping");
     return;
   }
@@ -69,11 +89,26 @@ export async function runTopicMigrationOnce(workspaceRoot: string, deps: RunTopi
   // and without this clause the topic runner would defer
   // indefinitely waiting for a migration that's never going to
   // happen.
+  //
+  // One guarded `statSync` (no `existsSync` first): the legacy
+  // migration runs in parallel and can rename / delete `memory.md`
+  // between an `existsSync` check and a follow-up `statSync`,
+  // turning the race into an unhandled rejection because this whole
+  // function is invoked as a floating promise on startup. ENOENT
+  // means the legacy file isn't there (or just got renamed away),
+  // so there's nothing to defer for; any other error is swallowed
+  // and the runner proceeds — a permission glitch should never block
+  // the topic restructure.
   const legacyPath = path.join(workspaceRoot, "conversations", "memory.md");
-  if (existsSync(legacyPath)) {
-    const stat = statSync(legacyPath);
+  let legacyStat: ReturnType<typeof statSync> | null;
+  try {
+    legacyStat = statSync(legacyPath);
+  } catch {
+    legacyStat = null;
+  }
+  if (legacyStat && legacyStat.size >= 64) {
     const backupPath = `${legacyPath}.backup`;
-    if (stat.size >= 64 && !existsSync(backupPath)) {
+    if (!existsSync(backupPath)) {
       log.debug("memory", "topic-run: legacy memory.md still in flight, deferring", { legacyPath });
       return;
     }

--- a/test/workspace/memory/test_topic_detect.ts
+++ b/test/workspace/memory/test_topic_detect.ts
@@ -46,9 +46,11 @@ describe("memory/topic-detect — hasTopicFormat", () => {
 
   it("returns true when only `memory.next/<type>` exists — covers the swap-in-progress window", async () => {
     // Reproduces the gap inside swapStagingIntoMemory:
-    //   1. rename memory/ → memory.<ts>.backup
+    //   1. rename memory/ → memory.<ts>.backup  (memory/ now ABSENT)
     //   2. <— hasTopicFormat must still return true here
     //   3. rename memory.next/ → memory/
+    // Note: `memory/` MUST NOT exist for this case to trigger; an
+    // empty live `memory/` is the staging-in-progress case below.
     const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-swap-window-"));
     try {
       await mkdir(path.join(root, "conversations", "memory.next", "preference"), { recursive: true });
@@ -64,6 +66,24 @@ describe("memory/topic-detect — hasTopicFormat", () => {
       await mkdir(path.join(root, "conversations", "memory", "interest"), { recursive: true });
       await mkdir(path.join(root, "conversations", "memory.next", "interest"), { recursive: true });
       assert.equal(hasTopicFormat(root), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns FALSE when memory/ is still atomic and memory.next/<type>/ is being staged (#1087 review)", async () => {
+    // Bug Codex flagged on #1086: during normal startup migration,
+    // clusterAtomicIntoStaging fills memory.next/<type>/ for a long
+    // window before swap completes. If hasTopicFormat returned true
+    // off `memory.next` alone, prompt routing would flip to topic
+    // mode and atomic + legacy memory would silently disappear from
+    // the prompt. Live `memory/` still existing — even with no
+    // type subdirs — must keep us in atomic mode.
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-staging-"));
+    try {
+      await mkdir(path.join(root, "conversations", "memory"), { recursive: true });
+      await mkdir(path.join(root, "conversations", "memory.next", "interest"), { recursive: true });
+      assert.equal(hasTopicFormat(root), false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/test/workspace/memory/test_topic_detect.ts
+++ b/test/workspace/memory/test_topic_detect.ts
@@ -1,0 +1,71 @@
+// Unit tests for `hasTopicFormat`. Pins the swap-window fix
+// (#1076 review): the detector must return true while
+// `swapStagingIntoMemory` has renamed `memory/` out of the way and
+// is about to rename `memory.next/` into place. Without that, a
+// request that hits the gap falls back to atomic-format writes
+// inside the soon-to-be topic tree, and later topic-mode reads
+// silently ignore the new file.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { hasTopicFormat } from "../../../server/workspace/memory/topic-detect.js";
+
+describe("memory/topic-detect — hasTopicFormat", () => {
+  it("returns false on a fresh workspace with no memory tree at all", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-empty-"));
+    try {
+      assert.equal(hasTopicFormat(root), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when only the legacy `memory.md` is present (atomic format)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-atomic-"));
+    try {
+      await mkdir(path.join(root, "conversations", "memory"), { recursive: true });
+      assert.equal(hasTopicFormat(root), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns true when a type subdir exists under `memory/` (post-swap)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-post-swap-"));
+    try {
+      await mkdir(path.join(root, "conversations", "memory", "interest"), { recursive: true });
+      assert.equal(hasTopicFormat(root), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns true when only `memory.next/<type>` exists — covers the swap-in-progress window", async () => {
+    // Reproduces the gap inside swapStagingIntoMemory:
+    //   1. rename memory/ → memory.<ts>.backup
+    //   2. <— hasTopicFormat must still return true here
+    //   3. rename memory.next/ → memory/
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-swap-window-"));
+    try {
+      await mkdir(path.join(root, "conversations", "memory.next", "preference"), { recursive: true });
+      assert.equal(hasTopicFormat(root), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns true when both `memory/<type>` and `memory.next/<type>` exist (mid-swap, before the dest rename)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "mulmoclaude-topic-detect-both-"));
+    try {
+      await mkdir(path.join(root, "conversations", "memory", "interest"), { recursive: true });
+      await mkdir(path.join(root, "conversations", "memory.next", "interest"), { recursive: true });
+      assert.equal(hasTopicFormat(root), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two CodeRabbit blockers from PR #1076 review:

1. **`hasTopicFormat` returned `false` during the swap window** (`server/workspace/memory/topic-detect.ts`). `swapStagingIntoMemory` first renames `conversations/memory` out of the way (to `memory/.atomic-backup/...`), then renames `conversations/memory.next` into place. Any request hitting `hasTopicFormat` in that gap saw no `<type>/` under `memory/` (it was just renamed away), fell back to atomic-format writes, and the new `<type>_<slug>.md` landed inside the newly-promoted topic tree where later topic-mode reads silently ignore it.

2. **`existsSync` + `statSync` race in `topic-run.ts`.** The legacy `memory.md` migration (#1029 PR-B) runs in parallel and can rename / delete the file between the two calls. Because `runTopicMigrationOnce` is invoked as a floating promise on startup, that race becomes an unhandled rejection.

## Items to Confirm / Review

- `hasTopicFormat` now scans both `memory/<type>/` AND `memory.next/<type>/`. Either location signals topic-format.
- The runner needs the OPPOSITE behaviour for its own idempotency guard: only `memory/<type>/` means "migration completed" — otherwise a swap-in-progress workspace would get an early-return and the existing-staging retry-swap branch would never fire. So a local strict helper `memoryTreeIsTopicFormat` lives inside `topic-run.ts` and replaces the call to the shared detector.
- The `statSync` race fix uses one guarded call; ENOENT (or any error) is treated as "not in flight" — a permission glitch should never block the topic restructure.
- New file `test/workspace/memory/test_topic_detect.ts` pins all 5 cases: empty workspace, atomic-only, post-swap, swap-window (only `memory.next/<type>/`), and mid-swap (both exist).
- Existing `test_topic_run.ts` continues to pass — the runner's stricter check preserves the existing-staging retry semantics.

## User Prompt

PR Quality Sweep covering 24h of merged PRs. The user chose option C: fix all blockers, one PR per item — but these two blockers are inseparable (the detector behaviour change forces the runner adjustment), so they batch into one PR. This is PR 5 of 6 covering the 10 blockers identified.

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
- [x] `npx tsx --test test/workspace/memory/test_topic_detect.ts test/workspace/memory/test_topic_run.ts` — 11 tests pass (5 new + 6 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup errors and unhandled rejections caused by race conditions during workspace transition/staging.

* **New Features**
  * Improved detection of topic-based workspace format so migrations and staging windows are handled reliably.

* **Tests**
  * Added comprehensive tests covering topic-detection across migration, staging, and legacy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->