### PR TITLE
feat(accounting): preview gate + LLM-facing API audit

### DIFF
--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -107,7 +107,7 @@ function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse
   return ok({ kind: "accounting-app", bookId, initialTab });
 }
 
-function handleListBooks(state: AccountingState): MockResponse {
+function handleGetBooks(state: AccountingState): MockResponse {
   return ok({ activeBookId: state.activeBookId, books: state.books });
 }
 
@@ -144,7 +144,7 @@ function handleDeleteBook(state: AccountingState, body: DispatchBody): MockRespo
   return ok({ deletedBookId: bookId, activeBookId: state.activeBookId });
 }
 
-function handleListAccounts(state: AccountingState, body: DispatchBody): MockResponse {
+function handleGetAccounts(state: AccountingState, body: DispatchBody): MockResponse {
   const bookId = bookIdFrom(state, body);
   if (bookId === null) return noActiveBook();
   return ok({ bookId, accounts: state.accountsByBook.get(bookId) ?? [] });
@@ -158,7 +158,7 @@ function voidedIdsFrom(entries: readonly FakeEntry[]): string[] {
   return Array.from(set).sort();
 }
 
-function handleListEntries(state: AccountingState, body: DispatchBody): MockResponse {
+function handleGetJournalEntries(state: AccountingState, body: DispatchBody): MockResponse {
   const bookId = bookIdFrom(state, body);
   if (bookId === null) return noActiveBook();
   const entries = state.entriesByBook.get(bookId) ?? [];
@@ -264,12 +264,12 @@ function handleGetReport(state: AccountingState, body: DispatchBody): MockRespon
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
   openApp: handleOpenApp,
-  listBooks: handleListBooks,
+  getBooks: handleGetBooks,
   createBook: handleCreateBook,
   setActiveBook: handleSetActiveBook,
   deleteBook: handleDeleteBook,
-  listAccounts: handleListAccounts,
-  getJournalEntries: handleListEntries,
+  getAccounts: handleGetAccounts,
+  getJournalEntries: handleGetJournalEntries,
   addEntry: handleAddEntry,
   voidEntry: handleVoidEntry,
   getOpeningBalances: handleGetOpening,

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -41,7 +41,6 @@ interface FakeEntry {
 }
 
 interface AccountingState {
-  activeBookId: string | null;
   books: FakeBook[];
   accountsByBook: Map<string, FakeAccount[]>;
   entriesByBook: Map<string, FakeEntry[]>;
@@ -68,30 +67,28 @@ interface MockResponse {
 type ActionHandler = (state: AccountingState, body: DispatchBody) => MockResponse;
 
 function makeState(): AccountingState {
-  return { activeBookId: null, books: [], accountsByBook: new Map(), entriesByBook: new Map() };
+  return { books: [], accountsByBook: new Map(), entriesByBook: new Map() };
 }
 
 function uniqueId(prefix: string): string {
   return `${prefix}-${randomUUID().slice(0, 8)}`;
 }
 
-/** Resolve the book id the way the real service does: the explicit
- *  one wins, else activeBookId, else null. Returning null preserves
- *  the "no active book" state so handlers can surface the same
- *  empty-workspace error path the server emits — the fixture must
- *  not silently mask that with `""`. */
-function bookIdFrom(state: AccountingState, body: DispatchBody): string | null {
-  if (typeof body.bookId === "string") return body.bookId;
-  return state.activeBookId;
+/** Resolve the book id the way the real service does: required
+ *  explicit `bookId` from the request body, or null if missing.
+ *  Returning null lets handlers surface the same 400 error path
+ *  the server emits — the fixture must not silently mask that. */
+function bookIdFrom(body: DispatchBody): string | null {
+  return typeof body.bookId === "string" ? body.bookId : null;
 }
 
 const ok = (body: unknown): MockResponse => ({ status: 200, body });
 const err = (status: number, message: string): MockResponse => ({ status, body: { error: message } });
-const noActiveBook = (): MockResponse => err(409, "no active book; create or select one first");
+const missingBookId = (): MockResponse => err(400, "bookId is required");
 
 function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse {
   const requested = typeof body.bookId === "string" ? body.bookId : null;
-  const bookId = requested && state.books.some((book) => book.id === requested) ? requested : state.activeBookId;
+  const bookId = requested && state.books.some((book) => book.id === requested) ? requested : null;
   const initialTab = typeof body.initialTab === "string" ? body.initialTab : undefined;
   if (state.books.length === 0) {
     // Mirrors the server's no-book LLM-facing message — see
@@ -108,7 +105,7 @@ function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse
 }
 
 function handleGetBooks(state: AccountingState): MockResponse {
-  return ok({ activeBookId: state.activeBookId, books: state.books });
+  return ok({ books: state.books });
 }
 
 function handleCreateBook(state: AccountingState, body: DispatchBody): MockResponse {
@@ -118,15 +115,7 @@ function handleCreateBook(state: AccountingState, body: DispatchBody): MockRespo
   state.books.push(book);
   state.accountsByBook.set(book.id, [...SEED_ACCOUNTS]);
   state.entriesByBook.set(book.id, []);
-  if (state.activeBookId === null) state.activeBookId = book.id;
   return ok({ book });
-}
-
-function handleSetActiveBook(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = typeof body.bookId === "string" ? body.bookId : "";
-  if (!state.books.some((book) => book.id === bookId)) return err(404, `book ${JSON.stringify(bookId)} not found`);
-  state.activeBookId = bookId;
-  return ok({ activeBookId: bookId });
 }
 
 function handleDeleteBook(state: AccountingState, body: DispatchBody): MockResponse {
@@ -137,16 +126,12 @@ function handleDeleteBook(state: AccountingState, body: DispatchBody): MockRespo
   state.books.splice(idx, 1);
   state.accountsByBook.delete(bookId);
   state.entriesByBook.delete(bookId);
-  if (state.activeBookId === bookId) {
-    const [newest] = [...state.books].sort((lhs, rhs) => rhs.createdAt.localeCompare(lhs.createdAt));
-    state.activeBookId = newest ? newest.id : null;
-  }
-  return ok({ deletedBookId: bookId, activeBookId: state.activeBookId });
+  return ok({ deletedBookId: bookId });
 }
 
 function handleGetAccounts(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   return ok({ bookId, accounts: state.accountsByBook.get(bookId) ?? [] });
 }
 
@@ -159,15 +144,15 @@ function voidedIdsFrom(entries: readonly FakeEntry[]): string[] {
 }
 
 function handleGetJournalEntries(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const entries = state.entriesByBook.get(bookId) ?? [];
   return ok({ bookId, entries, voidedEntryIds: voidedIdsFrom(entries) });
 }
 
 function handleAddEntry(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const entry: FakeEntry = {
     id: uniqueId("entry"),
     date: typeof body.date === "string" ? body.date : "2026-04-01",
@@ -193,8 +178,8 @@ function buildVoidMemo(target: FakeEntry, reason: string | undefined): string {
 }
 
 function handleVoidEntry(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const list = state.entriesByBook.get(bookId) ?? [];
   const targetId = typeof body.entryId === "string" ? body.entryId : "";
   const target = list.find((entry) => entry.id === targetId);
@@ -226,15 +211,15 @@ function handleVoidEntry(state: AccountingState, body: DispatchBody): MockRespon
 }
 
 function handleGetOpening(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const list = state.entriesByBook.get(bookId) ?? [];
   return ok({ bookId, opening: list.find((entry) => entry.kind === "opening") ?? null });
 }
 
 function handleSetOpening(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const opening: FakeEntry = {
     id: uniqueId("entry"),
     date: typeof body.asOfDate === "string" ? body.asOfDate : "2026-01-01",
@@ -250,8 +235,8 @@ function handleSetOpening(state: AccountingState, body: DispatchBody): MockRespo
 }
 
 function handleGetReport(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(state, body);
-  if (bookId === null) return noActiveBook();
+  const bookId = bookIdFrom(body);
+  if (bookId === null) return missingBookId();
   const kind = typeof body.kind === "string" ? body.kind : "balance";
   if (kind === "pl") {
     return ok({ bookId, profitLoss: { from: "2026-04-01", to: "2026-04-30", income: { rows: [], total: 0 }, expense: { rows: [], total: 0 }, netIncome: 0 } });
@@ -266,7 +251,6 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   openApp: handleOpenApp,
   getBooks: handleGetBooks,
   createBook: handleCreateBook,
-  setActiveBook: handleSetActiveBook,
   deleteBook: handleDeleteBook,
   getAccounts: handleGetAccounts,
   getJournalEntries: handleGetJournalEntries,
@@ -275,8 +259,16 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   getOpeningBalances: handleGetOpening,
   setOpeningBalances: handleSetOpening,
   getReport: handleGetReport,
-  getBookMeta: (state) => ok({ bookId: state.activeBookId, meta: null }),
-  rebuildSnapshots: (state) => ok({ bookId: state.activeBookId, rebuilt: [] }),
+  getBookMeta: (_state, body) => {
+    const bookId = bookIdFrom(body);
+    if (bookId === null) return missingBookId();
+    return ok({ bookId, meta: null });
+  },
+  rebuildSnapshots: (_state, body) => {
+    const bookId = bookIdFrom(body);
+    if (bookId === null) return missingBookId();
+    return ok({ bookId, rebuilt: [] });
+  },
 };
 
 function dispatch(state: AccountingState, body: DispatchBody): MockResponse {

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -269,7 +269,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   setActiveBook: handleSetActiveBook,
   deleteBook: handleDeleteBook,
   listAccounts: handleListAccounts,
-  listEntries: handleListEntries,
+  getJournalEntries: handleListEntries,
   addEntry: handleAddEntry,
   voidEntry: handleVoidEntry,
   getOpeningBalances: handleGetOpening,

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -97,11 +97,12 @@ function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse
       kind: "accounting-app",
       bookId,
       initialTab,
+      books: state.books,
       message:
         "No books in this workspace yet. The accounting UI is showing a form asking the user to create their first book (name + currency) before any accounting feature can be used.",
     });
   }
-  return ok({ kind: "accounting-app", bookId, initialTab });
+  return ok({ kind: "accounting-app", bookId, initialTab, books: state.books });
 }
 
 function handleGetBooks(state: AccountingState): MockResponse {
@@ -123,10 +124,11 @@ function handleDeleteBook(state: AccountingState, body: DispatchBody): MockRespo
   if (body.confirm !== true) return err(400, "deleteBook requires confirm: true");
   const idx = state.books.findIndex((book) => book.id === bookId);
   if (idx < 0) return err(404, `book ${JSON.stringify(bookId)} not found`);
+  const target = state.books[idx];
   state.books.splice(idx, 1);
   state.accountsByBook.delete(bookId);
   state.entriesByBook.delete(bookId);
-  return ok({ deletedBookId: bookId });
+  return ok({ deletedBookId: bookId, deletedBookName: target.name });
 }
 
 function handleGetAccounts(state: AccountingState, body: DispatchBody): MockResponse {
@@ -234,7 +236,7 @@ function handleSetOpening(state: AccountingState, body: DispatchBody): MockRespo
   return ok({ bookId, openingEntry: opening, replacedExisting: false });
 }
 
-function handleGetReport(state: AccountingState, body: DispatchBody): MockResponse {
+function handleGetReport(_state: AccountingState, body: DispatchBody): MockResponse {
   const bookId = bookIdFrom(body);
   if (bookId === null) return missingBookId();
   const kind = typeof body.kind === "string" ? body.kind : "balance";
@@ -259,11 +261,6 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   getOpeningBalances: handleGetOpening,
   setOpeningBalances: handleSetOpening,
   getReport: handleGetReport,
-  getBookMeta: (_state, body) => {
-    const bookId = bookIdFrom(body);
-    if (bookId === null) return missingBookId();
-    return ok({ bookId, meta: null });
-  },
   rebuildSnapshots: (_state, body) => {
     const bookId = bookIdFrom(body);
     if (bookId === null) return missingBookId();

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -8,6 +8,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { Page, Route } from "@playwright/test";
+import { ACCOUNTING_ACTIONS } from "../../src/plugins/accounting/actions";
 
 interface FakeBook {
   id: string;
@@ -74,17 +75,24 @@ function uniqueId(prefix: string): string {
   return `${prefix}-${randomUUID().slice(0, 8)}`;
 }
 
-/** Resolve the book id the way the real service does: required
- *  explicit `bookId` from the request body, or null if missing.
- *  Returning null lets handlers surface the same 400 error path
- *  the server emits — the fixture must not silently mask that. */
-function bookIdFrom(body: DispatchBody): string | null {
-  return typeof body.bookId === "string" ? body.bookId : null;
-}
-
 const ok = (body: unknown): MockResponse => ({ status: 200, body });
 const err = (status: number, message: string): MockResponse => ({ status, body: { error: message } });
 const missingBookId = (): MockResponse => err(400, "bookId is required");
+
+/** Resolve the book id the way the real service does (see
+ *  `resolveBookId` in `server/accounting/service.ts`): require an
+ *  explicit string `bookId` (else 400) AND require it to exist in
+ *  state (else 404). Returning a `MockResponse` for the unhappy
+ *  paths lets the fixture mirror production's status-code shape so
+ *  e2e flows that exercise stale / typo'd ids see the real 404
+ *  rather than a silent 200 with empty data. */
+function resolveBookId(state: AccountingState, body: DispatchBody): string | MockResponse {
+  if (typeof body.bookId !== "string") return missingBookId();
+  if (!state.books.some((book) => book.id === body.bookId)) {
+    return err(404, `book ${JSON.stringify(body.bookId)} not found`);
+  }
+  return body.bookId;
+}
 
 function handleOpenApp(state: AccountingState, body: DispatchBody): MockResponse {
   const requested = typeof body.bookId === "string" ? body.bookId : null;
@@ -132,9 +140,9 @@ function handleDeleteBook(state: AccountingState, body: DispatchBody): MockRespo
 }
 
 function handleGetAccounts(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
-  return ok({ bookId, accounts: state.accountsByBook.get(bookId) ?? [] });
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
+  return ok({ bookId: resolved, accounts: state.accountsByBook.get(resolved) ?? [] });
 }
 
 function voidedIdsFrom(entries: readonly FakeEntry[]): string[] {
@@ -146,15 +154,15 @@ function voidedIdsFrom(entries: readonly FakeEntry[]): string[] {
 }
 
 function handleGetJournalEntries(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
-  const entries = state.entriesByBook.get(bookId) ?? [];
-  return ok({ bookId, entries, voidedEntryIds: voidedIdsFrom(entries) });
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
+  const entries = state.entriesByBook.get(resolved) ?? [];
+  return ok({ bookId: resolved, entries, voidedEntryIds: voidedIdsFrom(entries) });
 }
 
 function handleAddEntry(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
   const entry: FakeEntry = {
     id: uniqueId("entry"),
     date: typeof body.date === "string" ? body.date : "2026-04-01",
@@ -163,10 +171,10 @@ function handleAddEntry(state: AccountingState, body: DispatchBody): MockRespons
     memo: typeof body.memo === "string" ? body.memo : undefined,
     createdAt: new Date().toISOString(),
   };
-  const list = state.entriesByBook.get(bookId) ?? [];
+  const list = state.entriesByBook.get(resolved) ?? [];
   list.push(entry);
-  state.entriesByBook.set(bookId, list);
-  return ok({ bookId, entry });
+  state.entriesByBook.set(resolved, list);
+  return ok({ bookId: resolved, entry });
 }
 
 function buildVoidMemo(target: FakeEntry, reason: string | undefined): string {
@@ -180,9 +188,9 @@ function buildVoidMemo(target: FakeEntry, reason: string | undefined): string {
 }
 
 function handleVoidEntry(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
-  const list = state.entriesByBook.get(bookId) ?? [];
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
+  const list = state.entriesByBook.get(resolved) ?? [];
   const targetId = typeof body.entryId === "string" ? body.entryId : "";
   const target = list.find((entry) => entry.id === targetId);
   if (!target) return err(404, `entry ${JSON.stringify(targetId)} not found`);
@@ -208,20 +216,20 @@ function handleVoidEntry(state: AccountingState, body: DispatchBody): MockRespon
     createdAt: new Date().toISOString(),
   };
   list.push(reverse, marker);
-  state.entriesByBook.set(bookId, list);
-  return ok({ bookId, reverseEntry: reverse, markerEntry: marker });
+  state.entriesByBook.set(resolved, list);
+  return ok({ bookId: resolved, reverseEntry: reverse, markerEntry: marker });
 }
 
 function handleGetOpening(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
-  const list = state.entriesByBook.get(bookId) ?? [];
-  return ok({ bookId, opening: list.find((entry) => entry.kind === "opening") ?? null });
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
+  const list = state.entriesByBook.get(resolved) ?? [];
+  return ok({ bookId: resolved, opening: list.find((entry) => entry.kind === "opening") ?? null });
 }
 
 function handleSetOpening(state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
   const opening: FakeEntry = {
     id: uniqueId("entry"),
     date: typeof body.asOfDate === "string" ? body.asOfDate : "2026-01-01",
@@ -230,41 +238,44 @@ function handleSetOpening(state: AccountingState, body: DispatchBody): MockRespo
     memo: typeof body.memo === "string" ? body.memo : "Opening balances",
     createdAt: new Date().toISOString(),
   };
-  const list = state.entriesByBook.get(bookId) ?? [];
+  const list = state.entriesByBook.get(resolved) ?? [];
   list.push(opening);
-  state.entriesByBook.set(bookId, list);
-  return ok({ bookId, openingEntry: opening, replacedExisting: false });
+  state.entriesByBook.set(resolved, list);
+  return ok({ bookId: resolved, openingEntry: opening, replacedExisting: false });
 }
 
-function handleGetReport(_state: AccountingState, body: DispatchBody): MockResponse {
-  const bookId = bookIdFrom(body);
-  if (bookId === null) return missingBookId();
+function handleGetReport(state: AccountingState, body: DispatchBody): MockResponse {
+  const resolved = resolveBookId(state, body);
+  if (typeof resolved !== "string") return resolved;
   const kind = typeof body.kind === "string" ? body.kind : "balance";
   if (kind === "pl") {
-    return ok({ bookId, profitLoss: { from: "2026-04-01", to: "2026-04-30", income: { rows: [], total: 0 }, expense: { rows: [], total: 0 }, netIncome: 0 } });
+    return ok({
+      bookId: resolved,
+      profitLoss: { from: "2026-04-01", to: "2026-04-30", income: { rows: [], total: 0 }, expense: { rows: [], total: 0 }, netIncome: 0 },
+    });
   }
   if (kind === "ledger") {
-    return ok({ bookId, ledger: { accountCode: "1000", accountName: "Cash", rows: [], closingBalance: 0 } });
+    return ok({ bookId: resolved, ledger: { accountCode: "1000", accountName: "Cash", rows: [], closingBalance: 0 } });
   }
-  return ok({ bookId, balanceSheet: { asOf: "2026-04-30", sections: [], imbalance: 0 } });
+  return ok({ bookId: resolved, balanceSheet: { asOf: "2026-04-30", sections: [], imbalance: 0 } });
 }
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
-  openApp: handleOpenApp,
-  getBooks: handleGetBooks,
-  createBook: handleCreateBook,
-  deleteBook: handleDeleteBook,
-  getAccounts: handleGetAccounts,
-  getJournalEntries: handleGetJournalEntries,
-  addEntry: handleAddEntry,
-  voidEntry: handleVoidEntry,
-  getOpeningBalances: handleGetOpening,
-  setOpeningBalances: handleSetOpening,
-  getReport: handleGetReport,
-  rebuildSnapshots: (_state, body) => {
-    const bookId = bookIdFrom(body);
-    if (bookId === null) return missingBookId();
-    return ok({ bookId, rebuilt: [] });
+  [ACCOUNTING_ACTIONS.openApp]: handleOpenApp,
+  [ACCOUNTING_ACTIONS.getBooks]: handleGetBooks,
+  [ACCOUNTING_ACTIONS.createBook]: handleCreateBook,
+  [ACCOUNTING_ACTIONS.deleteBook]: handleDeleteBook,
+  [ACCOUNTING_ACTIONS.getAccounts]: handleGetAccounts,
+  [ACCOUNTING_ACTIONS.getJournalEntries]: handleGetJournalEntries,
+  [ACCOUNTING_ACTIONS.addEntry]: handleAddEntry,
+  [ACCOUNTING_ACTIONS.voidEntry]: handleVoidEntry,
+  [ACCOUNTING_ACTIONS.getOpeningBalances]: handleGetOpening,
+  [ACCOUNTING_ACTIONS.setOpeningBalances]: handleSetOpening,
+  [ACCOUNTING_ACTIONS.getReport]: handleGetReport,
+  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (state, body) => {
+    const resolved = resolveBookId(state, body);
+    if (typeof resolved !== "string") return resolved;
+    return ok({ bookId: resolved, rebuilt: [] });
   },
 };
 

--- a/server/accounting/eventPublisher.ts
+++ b/server/accounting/eventPublisher.ts
@@ -38,9 +38,9 @@ export function publishBookChange(bookId: string, payload: AccountingBookChannel
   safePublish(accountingBookChannel(bookId), payload);
 }
 
-/** Fired when the *list* of books changes (createBook, deleteBook,
- *  setActiveBook). Payload is intentionally empty — subscribers
- *  refetch from /api/accounting. */
+/** Fired when the *list* of books changes (createBook, deleteBook).
+ *  Payload is intentionally empty — subscribers refetch from
+ *  /api/accounting. */
 export function publishBooksChanged(): void {
   safePublish(PUBSUB_CHANNELS.accountingBooks, {});
 }

--- a/server/accounting/service.ts
+++ b/server/accounting/service.ts
@@ -59,7 +59,7 @@ const DEFAULT_CURRENCY = "USD";
 const GENERATED_ID_RETRIES = 8;
 
 function emptyConfig(): AccountingConfig {
-  return { activeBookId: null, books: [] };
+  return { books: [] };
 }
 
 async function loadOrInitConfig(workspaceRoot?: string): Promise<AccountingConfig> {
@@ -71,15 +71,18 @@ function findBook(config: AccountingConfig, bookId: string): BookSummary | null 
   return config.books.find((book) => book.id === bookId) ?? null;
 }
 
-function resolveBookId(config: AccountingConfig, requested?: string): string {
-  if (requested && findBook(config, requested)) return requested;
-  if (requested) {
+function resolveBookId(config: AccountingConfig, requested: string | undefined): string {
+  // Every book-touching action now requires an explicit `bookId` —
+  // there's no server-side "active book" to fall back on. Callers
+  // are the LLM (which is told to pass bookId on each call) and the
+  // View (which tracks the current selection in localStorage).
+  if (!requested) {
+    throw new AccountingError(400, "bookId is required");
+  }
+  if (!findBook(config, requested)) {
     throw new AccountingError(404, `book ${JSON.stringify(requested)} not found`);
   }
-  if (!config.activeBookId || !findBook(config, config.activeBookId)) {
-    throw new AccountingError(409, "no active book; create or select one first");
-  }
-  return config.activeBookId;
+  return requested;
 }
 
 async function generateBookId(config: AccountingConfig, workspaceRoot?: string): Promise<string> {
@@ -115,9 +118,9 @@ async function readAllEntries(bookId: string, workspaceRoot?: string): Promise<J
 
 // ── books ──────────────────────────────────────────────────────────
 
-export async function listBooks(workspaceRoot?: string): Promise<{ activeBookId: string | null; books: BookSummary[] }> {
+export async function listBooks(workspaceRoot?: string): Promise<{ books: BookSummary[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
-  return { activeBookId: config.activeBookId, books: config.books };
+  return { books: config.books };
 }
 
 export async function createBook(input: { id?: string; name: string; currency?: string }, workspaceRoot?: string): Promise<{ book: BookSummary }> {
@@ -149,29 +152,13 @@ export async function createBook(input: { id?: string; name: string; currency?: 
   await ensureBookDir(bookId, workspaceRoot);
   await writeAccounts(bookId, [...DEFAULT_ACCOUNTS], workspaceRoot);
   await writeMeta(bookId, { createdAt: book.createdAt }, workspaceRoot);
-  const nextConfig: AccountingConfig = {
-    activeBookId: config.activeBookId ?? bookId,
-    books: [...config.books, book],
-  };
+  const nextConfig: AccountingConfig = { books: [...config.books, book] };
   await writeConfig(nextConfig, workspaceRoot);
   publishBooksChanged();
   return { book };
 }
 
-export async function setActiveBook(input: { bookId: string }, workspaceRoot?: string): Promise<{ activeBookId: string }> {
-  const config = await loadOrInitConfig(workspaceRoot);
-  if (!findBook(config, input.bookId)) {
-    throw new AccountingError(404, `book ${JSON.stringify(input.bookId)} not found`);
-  }
-  await writeConfig({ ...config, activeBookId: input.bookId }, workspaceRoot);
-  publishBooksChanged();
-  return { activeBookId: input.bookId };
-}
-
-export async function deleteBook(
-  input: { bookId: string; confirm: boolean },
-  workspaceRoot?: string,
-): Promise<{ deletedBookId: string; activeBookId: string | null }> {
+export async function deleteBook(input: { bookId: string; confirm: boolean }, workspaceRoot?: string): Promise<{ deletedBookId: string }> {
   if (!input.confirm) {
     throw new AccountingError(400, "deleteBook requires confirm: true");
   }
@@ -186,22 +173,9 @@ export async function deleteBook(
   await awaitRebuildIdle(input.bookId);
   await removeBookDir(input.bookId, workspaceRoot);
   const remaining = config.books.filter((book) => book.id !== input.bookId);
-  // When the deleted book was the active one, promote the most
-  // recently created remaining book — that's the most user-meaningful
-  // default. When nothing remains, activeBookId becomes null and the
-  // View renders its empty state with the "create a book" prompt.
-  let nextActive: string | null = config.activeBookId;
-  if (config.activeBookId === input.bookId || nextActive === null) {
-    if (remaining.length === 0) {
-      nextActive = null;
-    } else {
-      const [newest] = [...remaining].sort((lhs, rhs) => rhs.createdAt.localeCompare(lhs.createdAt));
-      nextActive = newest.id;
-    }
-  }
-  await writeConfig({ activeBookId: nextActive, books: remaining }, workspaceRoot);
+  await writeConfig({ books: remaining }, workspaceRoot);
   publishBooksChanged();
-  return { deletedBookId: input.bookId, activeBookId: nextActive };
+  return { deletedBookId: input.bookId };
 }
 
 // ── accounts ───────────────────────────────────────────────────────

--- a/server/accounting/service.ts
+++ b/server/accounting/service.ts
@@ -28,11 +28,9 @@ import {
   readAccounts,
   readConfig,
   readJournalMonth,
-  readMeta,
   removeBookDir,
   writeAccounts,
   writeConfig,
-  writeMeta,
 } from "../utils/files/accounting-io.js";
 import { findActiveOpening, validateOpening } from "./openingBalances.js";
 import { localDateString, makeEntry, makeVoidEntries, validateEntry, voidedIdSet } from "./journal.js";
@@ -124,6 +122,9 @@ export async function listBooks(workspaceRoot?: string): Promise<{ books: BookSu
 }
 
 export async function createBook(input: { id?: string; name: string; currency?: string }, workspaceRoot?: string): Promise<{ book: BookSummary }> {
+  if (typeof input.name !== "string" || input.name.trim() === "") {
+    throw new AccountingError(400, "name is required");
+  }
   const config = await loadOrInitConfig(workspaceRoot);
   // Auto-generate when no caller id is supplied — every book,
   // including the very first one, gets a generated id. Explicit
@@ -132,8 +133,8 @@ export async function createBook(input: { id?: string; name: string; currency?: 
   // adopt it.
   const bookId = input.id ?? (await generateBookId(config, workspaceRoot));
   // Guard against caller-supplied path-traversal ids before any
-  // fs touch (createBook → ensureBookDir → writeAccounts /
-  // writeMeta → writeConfig). Auto-generated ids always pass.
+  // fs touch (createBook → ensureBookDir → writeAccounts →
+  // writeConfig). Auto-generated ids always pass.
   if (!isSafeBookId(bookId)) {
     throw new AccountingError(400, `invalid book id ${JSON.stringify(bookId)} — allowed characters are A-Z a-z 0-9 _ - (1-64 chars; cannot start with _ or -)`);
   }
@@ -151,19 +152,22 @@ export async function createBook(input: { id?: string; name: string; currency?: 
   };
   await ensureBookDir(bookId, workspaceRoot);
   await writeAccounts(bookId, [...DEFAULT_ACCOUNTS], workspaceRoot);
-  await writeMeta(bookId, { createdAt: book.createdAt }, workspaceRoot);
   const nextConfig: AccountingConfig = { books: [...config.books, book] };
   await writeConfig(nextConfig, workspaceRoot);
   publishBooksChanged();
   return { book };
 }
 
-export async function deleteBook(input: { bookId: string; confirm: boolean }, workspaceRoot?: string): Promise<{ deletedBookId: string }> {
+export async function deleteBook(
+  input: { bookId: string; confirm: boolean },
+  workspaceRoot?: string,
+): Promise<{ deletedBookId: string; deletedBookName: string }> {
   if (!input.confirm) {
     throw new AccountingError(400, "deleteBook requires confirm: true");
   }
   const config = await loadOrInitConfig(workspaceRoot);
-  if (!findBook(config, input.bookId)) {
+  const target = findBook(config, input.bookId);
+  if (!target) {
     throw new AccountingError(404, `book ${JSON.stringify(input.bookId)} not found`);
   }
   // Stop any in-flight rebuild before removing the directory; otherwise
@@ -175,7 +179,9 @@ export async function deleteBook(input: { bookId: string; confirm: boolean }, wo
   const remaining = config.books.filter((book) => book.id !== input.bookId);
   await writeConfig({ books: remaining }, workspaceRoot);
   publishBooksChanged();
-  return { deletedBookId: input.bookId };
+  // Capture the name BEFORE the splice so the LLM-facing message
+  // can reference the human-readable book the user just deleted.
+  return { deletedBookId: input.bookId, deletedBookName: target.name };
 }
 
 // ── accounts ───────────────────────────────────────────────────────
@@ -186,7 +192,10 @@ export async function listAccounts(input: { bookId?: string }, workspaceRoot?: s
   return { bookId, accounts: await readAccounts(bookId, workspaceRoot) };
 }
 
-export async function upsertAccount(input: { bookId?: string; account: Account }, workspaceRoot?: string): Promise<{ bookId: string; accounts: Account[] }> {
+export async function upsertAccount(
+  input: { bookId?: string; account: Account },
+  workspaceRoot?: string,
+): Promise<{ bookId: string; account: Account; accounts: Account[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   // Account codes starting with `_` are reserved for synthetic
@@ -219,7 +228,7 @@ export async function upsertAccount(input: { bookId?: string; account: Account }
     await invalidateAllSnapshots(bookId, workspaceRoot);
   }
   publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.accounts });
-  return { bookId, accounts: next };
+  return { bookId, account: { ...input.account }, accounts: next };
 }
 
 // ── journal entries ────────────────────────────────────────────────
@@ -449,14 +458,6 @@ export async function rebuildSnapshots(input: { bookId?: string }, workspaceRoot
   const result = await rebuildAllSnapshots(bookId, workspaceRoot);
   publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsReady });
   return { bookId, rebuilt: result.rebuilt };
-}
-
-// ── meta (read-only convenience) ───────────────────────────────────
-
-export async function getBookMeta(input: { bookId?: string }, workspaceRoot?: string): Promise<{ bookId: string; meta: Awaited<ReturnType<typeof readMeta>> }> {
-  const config = await loadOrInitConfig(workspaceRoot);
-  const bookId = resolveBookId(config, input.bookId);
-  return { bookId, meta: await readMeta(bookId, workspaceRoot) };
 }
 
 // Direct access for tests / lazy paths that want to bypass the

--- a/server/accounting/types.ts
+++ b/server/accounting/types.ts
@@ -49,10 +49,6 @@ export interface BookSummary {
 }
 
 export interface AccountingConfig {
-  /** ID of the currently-selected book, or `null` when the workspace
-   *  has zero books. `createBook` sets this on first creation;
-   *  `deleteBook` clears it when the last book is removed. */
-  activeBookId: string | null;
   books: BookSummary[];
 }
 

--- a/server/accounting/types.ts
+++ b/server/accounting/types.ts
@@ -5,7 +5,6 @@
 //   data/accounting/books/<id>/accounts.json    ← Account[]
 //   data/accounting/books/<id>/journal/YYYY-MM.jsonl  ← JournalEntry per line
 //   data/accounting/books/<id>/snapshots/YYYY-MM.json ← MonthSnapshot (cache)
-//   data/accounting/books/<id>/meta.json        ← BookMeta
 //
 // Snapshots are cache only — journal is the single source of truth.
 
@@ -27,16 +26,6 @@ export interface Account {
   /** Optional free-form note (tax bucket, parent group, …). Not
    *  interpreted by the engine — passes through verbatim. */
   note?: string;
-}
-
-export interface BookMeta {
-  /** Fiscal year start as MM-DD (e.g. "01-01" or "04-01"). Cosmetic
-   *  for now; report period selectors use the calendar year, not the
-   *  fiscal year. */
-  fiscalYearStart?: string;
-  createdAt: string; // ISO timestamp
-  /** Free-form description of the book purpose. */
-  description?: string;
 }
 
 export interface BookSummary {

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -178,7 +178,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
 // Reads (lists / reports) and View-driven maintenance ops stay
 // silent — they're invoked from inside the canvas and the LLM will
 // summarise reads in its text reply anyway.
-const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook", "upsertAccount", "addEntry", "voidEntry"]);
+const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook", "upsertAccount", "addEntry", "voidEntry", "setOpeningBalances"]);
 
 // LLM-facing `message` tacked onto YES actions. The shared trailer
 // ("The accounting view is shown to the user.") tells the LLM that a
@@ -187,34 +187,35 @@ const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook
 // should narrate what was *done*, not re-list what's on screen.
 const VIEW_VISIBLE_TRAILER = "The accounting view is shown to the user.";
 
+type MessageBuilder = (fields: Record<string, unknown>) => string;
+
+const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
+  openApp: () => "Mounted the accounting app in the canvas.",
+  createBook: (fields) => {
+    const book = fields.book as { name?: string } | undefined;
+    const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
+    return `${subject} has been created.`;
+  },
+  setActiveBook: (fields) => `Switched the active book to ${JSON.stringify((fields.activeBookId as string | undefined) ?? "")}.`,
+  upsertAccount: () => "Updated the chart of accounts.",
+  addEntry: (fields) => {
+    const entry = fields.entry as { date?: string } | undefined;
+    return `Posted a journal entry on ${entry?.date ?? "the requested date"}.`;
+  },
+  voidEntry: (fields) => {
+    const reverse = fields.reverseEntry as { date?: string } | undefined;
+    return `Voided the entry; a reversing pair was posted on ${reverse?.date ?? "today"}.`;
+  },
+  setOpeningBalances: (fields) => {
+    const opening = fields.openingEntry as { date?: string } | undefined;
+    const verb = fields.replacedExisting === true ? "replaced" : "set";
+    return `Opening balances were ${verb} as of ${opening?.date ?? "the requested date"}.`;
+  },
+};
+
 function previewMessage(action: string, fields: Record<string, unknown>): string {
-  switch (action) {
-    case "openApp":
-      return `Mounted the accounting app in the canvas. ${VIEW_VISIBLE_TRAILER}`;
-    case "createBook": {
-      const book = fields.book as { id?: string; name?: string } | undefined;
-      const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
-      return `${subject} has been created. ${VIEW_VISIBLE_TRAILER}`;
-    }
-    case "setActiveBook": {
-      const bookId = fields.activeBookId as string | undefined;
-      return `Switched the active book to ${JSON.stringify(bookId ?? "")}. ${VIEW_VISIBLE_TRAILER}`;
-    }
-    case "upsertAccount":
-      return `Updated the chart of accounts. ${VIEW_VISIBLE_TRAILER}`;
-    case "addEntry": {
-      const entry = fields.entry as { date?: string } | undefined;
-      const date = entry?.date ?? "the requested date";
-      return `Posted a journal entry on ${date}. ${VIEW_VISIBLE_TRAILER}`;
-    }
-    case "voidEntry": {
-      const reverse = fields.reverseEntry as { date?: string } | undefined;
-      const date = reverse?.date ?? "today";
-      return `Voided the entry; a reversing pair was posted on ${date}. ${VIEW_VISIBLE_TRAILER}`;
-    }
-    default:
-      return VIEW_VISIBLE_TRAILER;
-  }
+  const head = MESSAGE_BUILDERS[action]?.(fields);
+  return head ? `${head} ${VIEW_VISIBLE_TRAILER}` : VIEW_VISIBLE_TRAILER;
 }
 
 async function dispatch(body: AccountingActionBody): Promise<unknown> {

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -218,6 +218,14 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
   return head ? `${head} ${VIEW_VISIBLE_TRAILER}` : VIEW_VISIBLE_TRAILER;
 }
 
+// Read actions where the LLM needs the actual payload as the tool's
+// text result (the MCP bridge only forwards `message` / `instructions`
+// to the model — `data` and `jsonData` reach the view but not the
+// LLM). Without an explicit message these actions resolve to "Done"
+// from the model's perspective, which is useless for queries the
+// LLM needs to reason about.
+const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["listEntries"]);
+
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;
   const handler = ACTION_HANDLERS[action];
@@ -241,7 +249,13 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // empty-workspace first-run state, which has tighter wording than
   // the generic "view is shown" trailer).
   const handlerMessage = typeof handlerFields.message === "string" ? handlerFields.message : undefined;
-  const messageField = handlerMessage ? {} : PREVIEW_ACTIONS.has(action) ? { message: previewMessage(action, handlerFields) } : {};
+  const messageField = handlerMessage
+    ? {}
+    : PREVIEW_ACTIONS.has(action)
+      ? { message: previewMessage(action, handlerFields) }
+      : PAYLOAD_AS_MESSAGE_ACTIONS.has(action)
+        ? { message: JSON.stringify(handlerFields) }
+        : {};
   return { action, ...handlerFields, ...messageField, ...dataField };
 }
 

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -26,7 +26,6 @@ import {
   listBooks,
   listEntries,
   rebuildSnapshots,
-  setActiveBook,
   setOpeningBalances,
   upsertAccount,
   voidEntry,
@@ -70,15 +69,14 @@ type ActionHandler = (rest: ActionRest) => Promise<unknown>;
 // validateOpening) so the adapters can stay one-liners.
 
 async function handleOpenApp(rest: ActionRest): Promise<OpenAppToolResult> {
-  // Resolving the bookId server-side ensures the LLM's tool result
-  // *describes* what's in the canvas (which book, which tab) so
-  // historical chat replays render accurately. The View handles
-  // the empty-state flow (full-page first-run form so the user
-  // can pick name + currency); the server doesn't try to bootstrap
-  // a default book.
+  // openApp resolves an explicit `bookId` (if the LLM passed one and
+  // it exists) or returns null — the View picks from getBooks +
+  // localStorage on its own. There's no server-side "active book"
+  // anymore; persisting that across calls would make tool replays
+  // ambiguous and couple multiple browser tabs to each other.
   const list = await listBooks();
   const requested = typeof rest.bookId === "string" ? rest.bookId : undefined;
-  const bookId = requested && list.books.some((book) => book.id === requested) ? requested : list.activeBookId;
+  const bookId = requested && list.books.some((book) => book.id === requested) ? requested : null;
   const initialTab = typeof rest.initialTab === "string" ? rest.initialTab : undefined;
   if (list.books.length === 0) {
     // No books yet — the canvas is showing the full-page first-run
@@ -129,7 +127,6 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
       name: String(rest.name ?? ""),
       currency: typeof rest.currency === "string" ? rest.currency : undefined,
     }),
-  setActiveBook: (rest) => setActiveBook({ bookId: String(rest.bookId ?? "") }),
   deleteBook: (rest) => deleteBook({ bookId: String(rest.bookId ?? ""), confirm: rest.confirm === true }),
   getAccounts: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
   upsertAccount: (rest) =>
@@ -178,7 +175,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
 // Reads (lists / reports) and View-driven maintenance ops stay
 // silent — they're invoked from inside the canvas and the LLM will
 // summarise reads in its text reply anyway.
-const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook", "upsertAccount", "addEntry", "voidEntry", "setOpeningBalances"]);
+const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "upsertAccount", "addEntry", "voidEntry", "setOpeningBalances"]);
 
 // LLM-facing `message` tacked onto YES actions. The shared trailer
 // ("The accounting view is shown to the user.") tells the LLM that a
@@ -196,7 +193,6 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
     return `${subject} has been created.`;
   },
-  setActiveBook: (fields) => `Switched the active book to ${JSON.stringify((fields.activeBookId as string | undefined) ?? "")}.`,
   upsertAccount: () => "Updated the chart of accounts.",
   addEntry: (fields) => {
     const entry = fields.entry as { date?: string } | undefined;

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -123,7 +123,7 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
   openApp: handleOpenApp,
-  listBooks: () => listBooks(),
+  getBooks: () => listBooks(),
   createBook: (rest) =>
     createBook({
       name: String(rest.name ?? ""),
@@ -131,7 +131,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
     }),
   setActiveBook: (rest) => setActiveBook({ bookId: String(rest.bookId ?? "") }),
   deleteBook: (rest) => deleteBook({ bookId: String(rest.bookId ?? ""), confirm: rest.confirm === true }),
-  listAccounts: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
+  getAccounts: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
   upsertAccount: (rest) =>
     upsertAccount({
       bookId: rest.bookId as string | undefined,
@@ -224,7 +224,7 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
 // LLM). Without an explicit message these actions resolve to "Done"
 // from the model's perspective, which is useless for queries the
 // LLM needs to reason about.
-const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["getJournalEntries"]);
+const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["getJournalEntries", "getBooks", "getAccounts"]);
 
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -173,6 +173,14 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   rebuildSnapshots: (rest) => rebuildSnapshots({ bookId: rest.bookId as string | undefined }),
 };
 
+// Actions whose tool-result envelope should carry a `data` field so
+// the sidebar renders a preview card. Everything else returns
+// without `data` and the host gates the preview off (silent action).
+// Reads (lists / reports) and View-driven maintenance ops stay
+// silent — they're invoked from inside the canvas and the LLM will
+// summarise reads in its text reply anyway.
+const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook", "upsertAccount", "addEntry", "voidEntry"]);
+
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;
   const handler = ACTION_HANDLERS[action];
@@ -185,7 +193,13 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // Direct browser callers (the AccountingApp view) ignore the field.
   // Service responses that already set `action` win via the spread.
   const result = await handler(rest);
-  return { action, ...(result && typeof result === "object" ? result : { value: result }) };
+  const handlerFields = result && typeof result === "object" ? (result as Record<string, unknown>) : { value: result };
+  // `data` is the host's preview-eligibility signal (see
+  // SessionSidebar.vue's v-if gate). Mirror the handler payload
+  // into it for the actions that should render a card; leave it
+  // off for silent ones so the gate suppresses the preview.
+  const dataField = PREVIEW_ACTIONS.has(action) ? { data: { action, ...handlerFields } } : {};
+  return { action, ...handlerFields, ...dataField };
 }
 
 router.post(API_ROUTES.accounting.dispatch, async (req: Request<object, unknown, AccountingActionBody>, res: Response<unknown | AccountingErrorResponse>) => {

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -126,7 +126,6 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   listBooks: () => listBooks(),
   createBook: (rest) =>
     createBook({
-      id: typeof rest.id === "string" ? rest.id : undefined,
       name: String(rest.name ?? ""),
       currency: typeof rest.currency === "string" ? rest.currency : undefined,
     }),
@@ -194,8 +193,8 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
       return `Mounted the accounting app in the canvas. ${VIEW_VISIBLE_TRAILER}`;
     case "createBook": {
       const book = fields.book as { id?: string; name?: string } | undefined;
-      const name = book?.name ? JSON.stringify(book.name) : "a book";
-      return `Created ${name}. ${VIEW_VISIBLE_TRAILER}`;
+      const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
+      return `${subject} has been created. ${VIEW_VISIBLE_TRAILER}`;
     }
     case "setActiveBook": {
       const bookId = fields.activeBookId as string | undefined;

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -30,6 +30,7 @@ import {
   voidEntry,
 } from "../../accounting/service.js";
 import type { BookSummary } from "../../accounting/types.js";
+import { ACCOUNTING_ACTIONS } from "../../../src/plugins/accounting/actions.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
 
@@ -125,52 +126,52 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
 }
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
-  openApp: handleOpenApp,
-  getBooks: () => listBooks(),
-  createBook: (rest) =>
+  [ACCOUNTING_ACTIONS.openApp]: handleOpenApp,
+  [ACCOUNTING_ACTIONS.getBooks]: () => listBooks(),
+  [ACCOUNTING_ACTIONS.createBook]: (rest) =>
     createBook({
       name: String(rest.name ?? ""),
       currency: typeof rest.currency === "string" ? rest.currency : undefined,
     }),
-  deleteBook: (rest) => deleteBook({ bookId: String(rest.bookId ?? ""), confirm: rest.confirm === true }),
-  getAccounts: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
-  upsertAccount: (rest) =>
+  [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: String(rest.bookId ?? ""), confirm: rest.confirm === true }),
+  [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.upsertAccount]: (rest) =>
     upsertAccount({
       bookId: rest.bookId as string | undefined,
       // Service validates the shape — route doesn't reach into it.
       account: rest.account as never,
     }),
-  addEntry: (rest) =>
+  [ACCOUNTING_ACTIONS.addEntry]: (rest) =>
     addEntry({
       bookId: rest.bookId as string | undefined,
       date: String(rest.date ?? ""),
       lines: (rest.lines ?? []) as never,
       memo: rest.memo as string | undefined,
     }),
-  voidEntry: (rest) =>
+  [ACCOUNTING_ACTIONS.voidEntry]: (rest) =>
     voidEntry({
       bookId: rest.bookId as string | undefined,
       entryId: String(rest.entryId ?? ""),
       reason: rest.reason as string | undefined,
       voidDate: rest.voidDate as string | undefined,
     }),
-  getJournalEntries: (rest) =>
+  [ACCOUNTING_ACTIONS.getJournalEntries]: (rest) =>
     listEntries({
       bookId: rest.bookId as string | undefined,
       from: rest.from as string | undefined,
       to: rest.to as string | undefined,
       accountCode: rest.accountCode as string | undefined,
     }),
-  getOpeningBalances: (rest) => getOpeningBalances({ bookId: rest.bookId as string | undefined }),
-  setOpeningBalances: (rest) =>
+  [ACCOUNTING_ACTIONS.getOpeningBalances]: (rest) => getOpeningBalances({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.setOpeningBalances]: (rest) =>
     setOpeningBalances({
       bookId: rest.bookId as string | undefined,
       asOfDate: String(rest.asOfDate ?? ""),
       lines: (rest.lines ?? []) as never,
       memo: rest.memo as string | undefined,
     }),
-  getReport: handleGetReport,
-  rebuildSnapshots: (rest) => rebuildSnapshots({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.getReport]: handleGetReport,
+  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (rest) => rebuildSnapshots({ bookId: rest.bookId as string | undefined }),
 };
 
 // Actions whose tool-result envelope should carry a `data` field so
@@ -179,7 +180,14 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
 // Reads (lists / reports) and View-driven maintenance ops stay
 // silent — they're invoked from inside the canvas and the LLM will
 // summarise reads in its text reply anyway.
-const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "upsertAccount", "addEntry", "voidEntry", "setOpeningBalances"]);
+const PREVIEW_ACTIONS = new Set<string>([
+  ACCOUNTING_ACTIONS.openApp,
+  ACCOUNTING_ACTIONS.createBook,
+  ACCOUNTING_ACTIONS.upsertAccount,
+  ACCOUNTING_ACTIONS.addEntry,
+  ACCOUNTING_ACTIONS.voidEntry,
+  ACCOUNTING_ACTIONS.setOpeningBalances,
+]);
 
 // LLM-facing `message` tacked onto YES actions. The shared trailer
 // ("The accounting view is shown to the user.") tells the LLM that a
@@ -191,7 +199,7 @@ const VIEW_VISIBLE_TRAILER = "The accounting view is shown to the user.";
 type MessageBuilder = (fields: Record<string, unknown>) => string;
 
 const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
-  openApp: (fields) => {
+  [ACCOUNTING_ACTIONS.openApp]: (fields) => {
     // Include the books list inline so the LLM doesn't need a
     // follow-up getBooks round-trip before deciding what to do
     // next (pick a book, create one, etc.).
@@ -199,7 +207,7 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     const booksFragment = Array.isArray(books) ? ` Books available: ${JSON.stringify(books)}.` : "";
     return `Mounted the accounting app in the canvas.${booksFragment}`;
   },
-  createBook: (fields) => {
+  [ACCOUNTING_ACTIONS.createBook]: (fields) => {
     const book = fields.book as { id?: string; name?: string } | undefined;
     const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
     // The LLM needs book.id to call any follow-up action on this
@@ -208,25 +216,25 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     const idFragment = book?.id ? ` (id: ${book.id})` : "";
     return `${subject} has been created${idFragment}.`;
   },
-  upsertAccount: (fields) => {
+  [ACCOUNTING_ACTIONS.upsertAccount]: (fields) => {
     const account = fields.account as { code?: string; name?: string } | undefined;
     if (account?.code && account?.name) {
       return `Upserted account ${account.code} ${JSON.stringify(account.name)}.`;
     }
     return "Updated the chart of accounts.";
   },
-  addEntry: (fields) => {
+  [ACCOUNTING_ACTIONS.addEntry]: (fields) => {
     const entry = fields.entry as { id?: string; date?: string } | undefined;
     const idFragment = entry?.id ? ` (id: ${entry.id})` : "";
     // The LLM needs the entry id to act on this entry later (e.g.
     // voidEntry), so return it as part of the status message.
     return `Posted a journal entry on ${entry?.date ?? "the requested date"}${idFragment}.`;
   },
-  voidEntry: (fields) => {
+  [ACCOUNTING_ACTIONS.voidEntry]: (fields) => {
     const reverse = fields.reverseEntry as { date?: string } | undefined;
     return `Voided the entry; a reversing pair was posted on ${reverse?.date ?? "today"}.`;
   },
-  setOpeningBalances: (fields) => {
+  [ACCOUNTING_ACTIONS.setOpeningBalances]: (fields) => {
     const opening = fields.openingEntry as { date?: string; lines?: unknown } | undefined;
     const verb = fields.replacedExisting === true ? "replaced" : "set";
     const date = opening?.date ?? "the requested date";
@@ -238,7 +246,7 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     const linesFragment = lines.length > 0 ? ` Lines: ${JSON.stringify(lines)}.` : "";
     return `Opening balances were ${verb} as of ${date}.${linesFragment}`;
   },
-  deleteBook: (fields) => {
+  [ACCOUNTING_ACTIONS.deleteBook]: (fields) => {
     const bookId = fields.deletedBookId as string | undefined;
     const name = fields.deletedBookName as string | undefined;
     const subject = name ? `the book ${JSON.stringify(name)}` : "the book";

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -152,7 +152,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
       reason: rest.reason as string | undefined,
       voidDate: rest.voidDate as string | undefined,
     }),
-  listEntries: (rest) =>
+  getJournalEntries: (rest) =>
     listEntries({
       bookId: rest.bookId as string | undefined,
       from: rest.from as string | undefined,
@@ -224,7 +224,7 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
 // LLM). Without an explicit message these actions resolve to "Done"
 // from the model's perspective, which is useless for queries the
 // LLM needs to reason about.
-const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["listEntries"]);
+const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["getJournalEntries"]);
 
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -18,7 +18,6 @@ import {
   createBook,
   deleteBook,
   getBalanceSheetReport,
-  getBookMeta,
   getLedgerReport,
   getOpeningBalances,
   getProfitLossReport,
@@ -30,6 +29,7 @@ import {
   upsertAccount,
   voidEntry,
 } from "../../accounting/service.js";
+import type { BookSummary } from "../../accounting/types.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
 
@@ -57,6 +57,10 @@ interface OpenAppToolResult {
    *  full-page first-run form and prompts the user to create one. */
   bookId: string | null;
   initialTab?: string;
+  /** Same shape getBooks returns — included so an LLM that calls
+   *  openApp doesn't need a follow-up getBooks round-trip to learn
+   *  what books exist before its next action. */
+  books: BookSummary[];
   message?: string;
 }
 
@@ -87,11 +91,12 @@ async function handleOpenApp(rest: ActionRest): Promise<OpenAppToolResult> {
       kind: "accounting-app",
       bookId,
       initialTab,
+      books: list.books,
       message:
         "No books in this workspace yet. The accounting UI is showing a form asking the user to create their first book (name + currency) before any accounting feature can be used.",
     };
   }
-  return { kind: "accounting-app", bookId, initialTab };
+  return { kind: "accounting-app", bookId, initialTab, books: list.books };
 }
 
 async function handleGetReport(rest: ActionRest): Promise<unknown> {
@@ -165,7 +170,6 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
       memo: rest.memo as string | undefined,
     }),
   getReport: handleGetReport,
-  getBookMeta: (rest) => getBookMeta({ bookId: rest.bookId as string | undefined }),
   rebuildSnapshots: (rest) => rebuildSnapshots({ bookId: rest.bookId as string | undefined }),
 };
 
@@ -187,25 +191,59 @@ const VIEW_VISIBLE_TRAILER = "The accounting view is shown to the user.";
 type MessageBuilder = (fields: Record<string, unknown>) => string;
 
 const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
-  openApp: () => "Mounted the accounting app in the canvas.",
-  createBook: (fields) => {
-    const book = fields.book as { name?: string } | undefined;
-    const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
-    return `${subject} has been created.`;
+  openApp: (fields) => {
+    // Include the books list inline so the LLM doesn't need a
+    // follow-up getBooks round-trip before deciding what to do
+    // next (pick a book, create one, etc.).
+    const { books } = fields;
+    const booksFragment = Array.isArray(books) ? ` Books available: ${JSON.stringify(books)}.` : "";
+    return `Mounted the accounting app in the canvas.${booksFragment}`;
   },
-  upsertAccount: () => "Updated the chart of accounts.",
+  createBook: (fields) => {
+    const book = fields.book as { id?: string; name?: string } | undefined;
+    const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
+    // The LLM needs book.id to call any follow-up action on this
+    // book (getAccounts, addEntry, etc.), so include it in the
+    // status message instead of forcing a round-trip via getBooks.
+    const idFragment = book?.id ? ` (id: ${book.id})` : "";
+    return `${subject} has been created${idFragment}.`;
+  },
+  upsertAccount: (fields) => {
+    const account = fields.account as { code?: string; name?: string } | undefined;
+    if (account?.code && account?.name) {
+      return `Upserted account ${account.code} ${JSON.stringify(account.name)}.`;
+    }
+    return "Updated the chart of accounts.";
+  },
   addEntry: (fields) => {
-    const entry = fields.entry as { date?: string } | undefined;
-    return `Posted a journal entry on ${entry?.date ?? "the requested date"}.`;
+    const entry = fields.entry as { id?: string; date?: string } | undefined;
+    const idFragment = entry?.id ? ` (id: ${entry.id})` : "";
+    // The LLM needs the entry id to act on this entry later (e.g.
+    // voidEntry), so return it as part of the status message.
+    return `Posted a journal entry on ${entry?.date ?? "the requested date"}${idFragment}.`;
   },
   voidEntry: (fields) => {
     const reverse = fields.reverseEntry as { date?: string } | undefined;
     return `Voided the entry; a reversing pair was posted on ${reverse?.date ?? "today"}.`;
   },
   setOpeningBalances: (fields) => {
-    const opening = fields.openingEntry as { date?: string } | undefined;
+    const opening = fields.openingEntry as { date?: string; lines?: unknown } | undefined;
     const verb = fields.replacedExisting === true ? "replaced" : "set";
-    return `Opening balances were ${verb} as of ${opening?.date ?? "the requested date"}.`;
+    const date = opening?.date ?? "the requested date";
+    // Surface the actual lines so the LLM can answer follow-up
+    // questions like "what's my opening cash?" without a separate
+    // getOpeningBalances round-trip. An empty-marker opening
+    // (zero lines, used to unlock the gate) gets no fragment.
+    const lines = Array.isArray(opening?.lines) ? (opening.lines as unknown[]) : [];
+    const linesFragment = lines.length > 0 ? ` Lines: ${JSON.stringify(lines)}.` : "";
+    return `Opening balances were ${verb} as of ${date}.${linesFragment}`;
+  },
+  deleteBook: (fields) => {
+    const bookId = fields.deletedBookId as string | undefined;
+    const name = fields.deletedBookName as string | undefined;
+    const subject = name ? `the book ${JSON.stringify(name)}` : "the book";
+    const idFragment = bookId ? ` (id: ${bookId})` : "";
+    return `Deleted ${subject}${idFragment}.`;
   },
 };
 
@@ -213,14 +251,6 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
   const head = MESSAGE_BUILDERS[action]?.(fields);
   return head ? `${head} ${VIEW_VISIBLE_TRAILER}` : VIEW_VISIBLE_TRAILER;
 }
-
-// Read actions where the LLM needs the actual payload as the tool's
-// text result (the MCP bridge only forwards `message` / `instructions`
-// to the model — `data` and `jsonData` reach the view but not the
-// LLM). Without an explicit message these actions resolve to "Done"
-// from the model's perspective, which is useless for queries the
-// LLM needs to reason about.
-const PAYLOAD_AS_MESSAGE_ACTIONS = new Set<string>(["getJournalEntries", "getBooks", "getAccounts"]);
 
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;
@@ -240,18 +270,24 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // into it for the actions that should render a card; leave it
   // off for silent ones so the gate suppresses the preview.
   const dataField = PREVIEW_ACTIONS.has(action) ? { data: { action, ...handlerFields } } : {};
-  // Attach an LLM-facing `message` for YES actions only — but let a
-  // handler-set message win (handleOpenApp uses one to flag the
-  // empty-workspace first-run state, which has tighter wording than
-  // the generic "view is shown" trailer).
+  // The MCP bridge only forwards `message` / `instructions` to the
+  // LLM (`data` / `jsonData` reach the view but not the model). So
+  // every action MUST set a message — silence resolves to "Done"
+  // and gives the LLM nothing to reason about. Resolution order:
+  //   1. handler-set `message` wins (handleOpenApp uses this to flag
+  //      the empty-workspace first-run state with tighter wording);
+  //   2. an action with a registered MESSAGE_BUILDER gets the
+  //      per-action human-friendly summary; this is decoupled from
+  //      PREVIEW_ACTIONS so silent ops like deleteBook can still
+  //      narrate without earning a card;
+  //   3. everything else returns the JSON-stringified handler
+  //      payload so the LLM can read the raw data.
   const handlerMessage = typeof handlerFields.message === "string" ? handlerFields.message : undefined;
   const messageField = handlerMessage
     ? {}
-    : PREVIEW_ACTIONS.has(action)
+    : MESSAGE_BUILDERS[action]
       ? { message: previewMessage(action, handlerFields) }
-      : PAYLOAD_AS_MESSAGE_ACTIONS.has(action)
-        ? { message: JSON.stringify(handlerFields) }
-        : {};
+      : { message: JSON.stringify(handlerFields) };
   return { action, ...handlerFields, ...messageField, ...dataField };
 }
 

--- a/server/api/routes/accounting.ts
+++ b/server/api/routes/accounting.ts
@@ -181,6 +181,43 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
 // summarise reads in its text reply anyway.
 const PREVIEW_ACTIONS = new Set<string>(["openApp", "createBook", "setActiveBook", "upsertAccount", "addEntry", "voidEntry"]);
 
+// LLM-facing `message` tacked onto YES actions. The shared trailer
+// ("The accounting view is shown to the user.") tells the LLM that a
+// canvas / sidebar surface is already visible, so its text reply
+// shouldn't redundantly enumerate the result the user can see — it
+// should narrate what was *done*, not re-list what's on screen.
+const VIEW_VISIBLE_TRAILER = "The accounting view is shown to the user.";
+
+function previewMessage(action: string, fields: Record<string, unknown>): string {
+  switch (action) {
+    case "openApp":
+      return `Mounted the accounting app in the canvas. ${VIEW_VISIBLE_TRAILER}`;
+    case "createBook": {
+      const book = fields.book as { id?: string; name?: string } | undefined;
+      const name = book?.name ? JSON.stringify(book.name) : "a book";
+      return `Created ${name}. ${VIEW_VISIBLE_TRAILER}`;
+    }
+    case "setActiveBook": {
+      const bookId = fields.activeBookId as string | undefined;
+      return `Switched the active book to ${JSON.stringify(bookId ?? "")}. ${VIEW_VISIBLE_TRAILER}`;
+    }
+    case "upsertAccount":
+      return `Updated the chart of accounts. ${VIEW_VISIBLE_TRAILER}`;
+    case "addEntry": {
+      const entry = fields.entry as { date?: string } | undefined;
+      const date = entry?.date ?? "the requested date";
+      return `Posted a journal entry on ${date}. ${VIEW_VISIBLE_TRAILER}`;
+    }
+    case "voidEntry": {
+      const reverse = fields.reverseEntry as { date?: string } | undefined;
+      const date = reverse?.date ?? "today";
+      return `Voided the entry; a reversing pair was posted on ${date}. ${VIEW_VISIBLE_TRAILER}`;
+    }
+    default:
+      return VIEW_VISIBLE_TRAILER;
+  }
+}
+
 async function dispatch(body: AccountingActionBody): Promise<unknown> {
   const { action, ...rest } = body;
   const handler = ACTION_HANDLERS[action];
@@ -199,7 +236,13 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // into it for the actions that should render a card; leave it
   // off for silent ones so the gate suppresses the preview.
   const dataField = PREVIEW_ACTIONS.has(action) ? { data: { action, ...handlerFields } } : {};
-  return { action, ...handlerFields, ...dataField };
+  // Attach an LLM-facing `message` for YES actions only — but let a
+  // handler-set message win (handleOpenApp uses one to flag the
+  // empty-workspace first-run state, which has tighter wording than
+  // the generic "view is shown" trailer).
+  const handlerMessage = typeof handlerFields.message === "string" ? handlerFields.message : undefined;
+  const messageField = handlerMessage ? {} : PREVIEW_ACTIONS.has(action) ? { message: previewMessage(action, handlerFields) } : {};
+  return { action, ...handlerFields, ...messageField, ...dataField };
 }
 
 router.post(API_ROUTES.accounting.dispatch, async (req: Request<object, unknown, AccountingActionBody>, res: Response<unknown | AccountingErrorResponse>) => {

--- a/server/utils/files/accounting-io.ts
+++ b/server/utils/files/accounting-io.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 
 import { workspacePath, WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
-import type { AccountingConfig, Account, BookMeta, JournalEntry, MonthSnapshot } from "../../accounting/types.js";
+import type { AccountingConfig, Account, JournalEntry, MonthSnapshot } from "../../accounting/types.js";
 
 const root = (workspaceRoot?: string): string => workspaceRoot ?? workspacePath;
 
@@ -53,10 +53,6 @@ export function bookRoot(bookId: string, workspaceRoot?: string): string {
 
 function accountsPath(bookId: string, workspaceRoot?: string): string {
   return path.join(bookRoot(bookId, workspaceRoot), "accounts.json");
-}
-
-function metaPath(bookId: string, workspaceRoot?: string): string {
-  return path.join(bookRoot(bookId, workspaceRoot), "meta.json");
 }
 
 function journalDir(bookId: string, workspaceRoot?: string): string {
@@ -121,16 +117,6 @@ export async function readAccounts(bookId: string, workspaceRoot?: string): Prom
 
 export async function writeAccounts(bookId: string, accounts: Account[], workspaceRoot?: string): Promise<void> {
   await writeFileAtomic(accountsPath(bookId, workspaceRoot), JSON.stringify(accounts, null, 2));
-}
-
-// ── meta.json ──────────────────────────────────────────────────────
-
-export async function readMeta(bookId: string, workspaceRoot?: string): Promise<BookMeta | null> {
-  return readJsonOrNull<BookMeta>(metaPath(bookId, workspaceRoot));
-}
-
-export async function writeMeta(bookId: string, meta: BookMeta, workspaceRoot?: string): Promise<void> {
-  await writeFileAtomic(metaPath(bookId, workspaceRoot), JSON.stringify(meta, null, 2));
 }
 
 // ── journal/YYYY-MM.jsonl (append-only) ────────────────────────────

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -68,9 +68,9 @@ export const WORKSPACE_DIRS = {
   transports: "data/transports",
   // Accounting plugin (opt-in, custom-Role only). Books live under
   // `accounting/books/<bookId>/{accounts.json, journal/YYYY-MM.jsonl,
-  //  snapshots/YYYY-MM.json, meta.json}`. The directory is created
-  // lazily on first createBook so default workspaces don't get a
-  // stub `accounting/` they never use.
+  //  snapshots/YYYY-MM.json}`. The directory is created lazily on
+  // first createBook so default workspaces don't get a stub
+  // `accounting/` they never use.
   accounting: "data/accounting",
   accountingBooks: "data/accounting/books",
   // artifacts/

--- a/src/App.vue
+++ b/src/App.vue
@@ -266,6 +266,7 @@ import { pushErrorMessage, beginUserTurn, updateResult } from "./utils/session/s
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
+import { isSidebarVisible } from "./utils/tools/sidebarVisibleApp";
 import { resolveNotificationTarget } from "./utils/notification/dispatch";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { useRunElapsed } from "./composables/useRunElapsed";
@@ -746,6 +747,9 @@ async function loadSession(sessionId: string) {
     urlResult: typeof route.query.result === "string" ? route.query.result : null,
     serverSummary: sessions.value.find((summary) => summary.id === sessionId),
     nowIso: new Date().toISOString(),
+    // Skip sidebar-hidden results when auto-picking a selection so
+    // the restored session never lands on a card the user can't see.
+    isVisible: isSidebarVisible,
   });
   sessionMap.set(sessionId, newSession);
   activateSession(sessionId, replaced);

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -42,7 +42,11 @@
         >
           {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
         </span>
-        <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
+        <component
+          :is="getPlugin(result.toolName)?.previewComponent"
+          v-if="getPlugin(result.toolName)?.previewComponent && result.data !== undefined"
+          :result="result"
+        />
         <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
       </div>
     </div>

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -27,7 +27,7 @@
       @mousedown="emit('activate')"
     >
       <div
-        v-for="result in results"
+        v-for="result in displayedResults"
         :key="result.uuid"
         class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
         :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
@@ -42,11 +42,7 @@
         >
           {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
         </span>
-        <component
-          :is="getPlugin(result.toolName)?.previewComponent"
-          v-if="getPlugin(result.toolName)?.previewComponent && result.data !== undefined"
-          :result="result"
-        />
+        <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
         <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
       </div>
     </div>
@@ -54,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
@@ -65,7 +61,7 @@ import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   results: ToolResultComplete[];
   selectedUuid: string | null;
   resultTimestamps: Map<string, number>;
@@ -74,6 +70,21 @@ defineProps<{
   layoutMode: LayoutMode;
   showRightSidebar: boolean;
 }>();
+
+// A plugin opts an action out of the sidebar by omitting `data` from
+// its tool result (see protocol: `data` is the view-side payload).
+// We hide the entire card — not just the preview body — so silent
+// actions (e.g. accounting reads, View-driven maintenance) don't
+// leave behind an empty card with just a source-label badge. The
+// LLM still sees the result via `message` / `jsonData`; this only
+// affects the visual sidebar list.
+const displayedResults = computed<ToolResultComplete[]>(() =>
+  props.results.filter((result) => {
+    const plugin = getPlugin(result.toolName);
+    if (!plugin?.previewComponent) return true;
+    return result.data !== undefined;
+  }),
+);
 
 function sourceLabel(result: ToolResultComplete): string {
   if (result.toolName === "text-response") return result.title ?? "Assistant";

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -27,7 +27,7 @@
       @mousedown="emit('activate')"
     >
       <div
-        v-for="result in displayedResults"
+        v-for="result in results"
         :key="result.uuid"
         class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
         :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
@@ -61,7 +61,12 @@ import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();
 
-const props = defineProps<{
+defineProps<{
+  // Already filtered to "what the user should see" by the parent's
+  // `sidebarResults` computed (see useSessionDerived.ts) — keyboard
+  // navigation, selection, and this render all consume the same
+  // visible-only list so a hidden result can't slip into selected
+  // state and leave the sidebar showing no highlight.
   results: ToolResultComplete[];
   selectedUuid: string | null;
   resultTimestamps: Map<string, number>;
@@ -70,21 +75,6 @@ const props = defineProps<{
   layoutMode: LayoutMode;
   showRightSidebar: boolean;
 }>();
-
-// A plugin opts an action out of the sidebar by omitting `data` from
-// its tool result (see protocol: `data` is the view-side payload).
-// We hide the entire card — not just the preview body — so silent
-// actions (e.g. accounting reads, View-driven maintenance) don't
-// leave behind an empty card with just a source-label badge. The
-// LLM still sees the result via `message` / `jsonData`; this only
-// affects the visual sidebar list.
-const displayedResults = computed<ToolResultComplete[]>(() =>
-  props.results.filter((result) => {
-    const plugin = getPlugin(result.toolName);
-    if (!plugin?.previewComponent) return true;
-    return result.data !== undefined;
-  }),
-);
 
 function sourceLabel(result: ToolResultComplete): string {
   if (result.toolName === "text-response") return result.title ?? "Assistant";

--- a/src/composables/useSessionDerived.ts
+++ b/src/composables/useSessionDerived.ts
@@ -3,6 +3,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ActiveSession, SessionSummary } from "../types/session";
 import type { ToolCallHistoryItem } from "../types/toolCallHistory";
 import { deduplicateResults } from "../utils/tools/dedup";
+import { isSidebarVisible } from "../utils/tools/sidebarVisibleApp";
 
 export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>; currentSessionId: Ref<string>; sessions: Ref<SessionSummary[]> }) {
   const { sessionMap, currentSessionId, sessions } = opts;
@@ -11,7 +12,12 @@ export function useSessionDerived(opts: { sessionMap: Map<string, ActiveSession>
 
   const toolResults = computed<ToolResultComplete[]>(() => activeSession.value?.toolResults ?? []);
 
-  const sidebarResults = computed(() => deduplicateResults(toolResults.value));
+  // `sidebarResults` is the canonical "what the user sees and can
+  // navigate through" list — keyboard nav (useKeyNavigation), the
+  // sidebar render, and StackView all consume it. Filtering hidden
+  // results here (rather than only inside <SessionSidebar>) keeps
+  // selection and navigation in sync with the visible list.
+  const sidebarResults = computed(() => deduplicateResults(toolResults.value).filter(isSidebarVisible));
 
   const currentSummary = computed(() => sessions.value.find((summary) => summary.id === currentSessionId.value));
 

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -78,10 +78,9 @@ export interface SessionsChannelPayload {
  * `useAccountingChannel(bookId)`.
  *
  * Book-list-level events (a new book was created, an existing one
- * was deleted, `activeBookId` changed) ride the static
- * `PUBSUB_CHANNELS.accountingBooks` channel below — kept separate
- * so a `JournalList.vue` viewing book A doesn't repaint when the
- * user creates book B from another window.
+ * was deleted) ride the static `PUBSUB_CHANNELS.accountingBooks`
+ * channel below — kept separate so a `JournalList.vue` viewing book
+ * A doesn't repaint when the user creates book B from another window.
  */
 export function accountingBookChannel(bookId: string): string {
   return `accounting:${bookId}`;
@@ -146,8 +145,8 @@ export const PUBSUB_CHANNELS = {
    *  in a separate PR. Payload: `{ message: string, firedAt: ISO8601 }`. */
   notifications: "notifications",
   /** Sent when the *list of books* changes in the accounting plugin
-   *  (createBook / deleteBook / renames / activeBookId flips).
-   *  Per-book data changes ride `accountingBookChannel(bookId)` instead.
+   *  (createBook / deleteBook / renames). Per-book data changes ride
+   *  `accountingBookChannel(bookId)` instead.
    *  Subscribers: BookSwitcher.vue. Payload: empty `{}`. */
   accountingBooks: "accounting:books",
 } as const;

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -97,7 +97,7 @@ import Ledger from "./components/Ledger.vue";
 import BalanceSheet from "./components/BalanceSheet.vue";
 import ProfitLoss from "./components/ProfitLoss.vue";
 import BookSettings from "./components/BookSettings.vue";
-import { getOpeningBalances, listAccounts, listBooks, type Account, type BookSummary } from "./api";
+import { getOpeningBalances, getAccounts, getBooks, type Account, type BookSummary } from "./api";
 import { useAccountingChannel, useAccountingBooksChannel } from "../../composables/useAccountingChannel";
 
 const { t } = useI18n();
@@ -198,7 +198,7 @@ async function refetchBooks(): Promise<void> {
   loadingBooks.value = true;
   bookLoadError.value = null;
   try {
-    const result = await listBooks();
+    const result = await getBooks();
     if (!result.ok) {
       // Surface load failures as a distinct error state so the user
       // doesn't see "No books yet" (and the auto-open modal) when
@@ -234,7 +234,7 @@ async function refetchAccounts(): Promise<void> {
     accounts.value = [];
     return;
   }
-  const result = await listAccounts(activeBookId.value);
+  const result = await getAccounts(activeBookId.value);
   if (!result.ok) return;
   accounts.value = result.data.accounts;
 }

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -183,15 +183,44 @@ function bumpLocalVersion(): void {
   localVersion.value += 1;
 }
 
-function pickActiveBookId(serverActiveBookId: string | null): string | null {
-  // Only ever point activeBookId at a book that actually exists on
-  // disk. Empty workspace returns null; the View renders its empty
-  // state and the auto-opening NewBookForm prompts for creation.
+// localStorage key for "which book is the user currently looking
+// at." There's no server-side active-book state — every other tab /
+// browser keeps its own selection so nothing is shared implicitly.
+const BOOK_ID_STORAGE_KEY = "mulmoclaude.accounting.bookId";
+
+function readStoredBookId(): string | null {
+  try {
+    return localStorage.getItem(BOOK_ID_STORAGE_KEY);
+  } catch {
+    // localStorage can throw in private-browsing or sandboxed iframes;
+    // a missing prior selection is fine, the picker just falls through.
+    return null;
+  }
+}
+
+function writeStoredBookId(bookId: string | null): void {
+  try {
+    if (bookId) localStorage.setItem(BOOK_ID_STORAGE_KEY, bookId);
+    else localStorage.removeItem(BOOK_ID_STORAGE_KEY);
+  } catch {
+    // Best-effort — losing the persisted selection only means the
+    // next mount picks a different default book.
+  }
+}
+
+function pickInitialBookId(): string | null {
+  // Priority: explicit `initialPayload.bookId` (LLM-supplied via
+  // openApp) → previously stored selection → most-recently created
+  // book → null (empty workspace). Always validates the candidate
+  // against the live book list so a stale id from localStorage or
+  // a deleted book doesn't poison the View.
   if (books.value.length === 0) return null;
   const requested = initialPayload.value.bookId;
   if (requested && books.value.some((book) => book.id === requested)) return requested;
-  if (serverActiveBookId && books.value.some((book) => book.id === serverActiveBookId)) return serverActiveBookId;
-  return books.value[0].id;
+  const stored = readStoredBookId();
+  if (stored && books.value.some((book) => book.id === stored)) return stored;
+  const [newest] = [...books.value].sort((lhs, rhs) => rhs.createdAt.localeCompare(lhs.createdAt));
+  return newest.id;
 }
 
 async function refetchBooks(): Promise<void> {
@@ -208,7 +237,7 @@ async function refetchBooks(): Promise<void> {
     }
     books.value = result.data.books;
     const stillExists = activeBookId.value !== null && books.value.some((book) => book.id === activeBookId.value);
-    if (!stillExists) activeBookId.value = pickActiveBookId(result.data.activeBookId);
+    if (!stillExists) activeBookId.value = pickInitialBookId();
     // Auto-open the New Book modal exactly once on first arrival
     // when the workspace is empty. After that, the user can still
     // open it manually via the "+ New book" button.
@@ -282,6 +311,10 @@ async function onBookDeleted(): Promise<void> {
 }
 
 watch(activeBookId, (next) => {
+  // Persist the user's current book selection so the next mount
+  // (refresh, new tab, restart) lands on the same book without a
+  // server round-trip.
+  writeStoredBookId(next);
   if (next) void refetchAccounts();
 });
 

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -183,16 +183,18 @@ function bumpLocalVersion(): void {
   localVersion.value += 1;
 }
 
-// localStorage key for "which book is the user currently looking
-// at." There's no server-side active-book state — every other tab /
-// browser keeps its own selection so nothing is shared implicitly.
+// sessionStorage key for "which book is the user currently looking
+// at." There's no server-side active-book state — sessionStorage is
+// scoped to a single browsing context, so each tab keeps its own
+// selection (localStorage would re-couple tabs through shared origin
+// storage and reintroduce the cross-tab interference we just removed).
 const BOOK_ID_STORAGE_KEY = "mulmoclaude.accounting.bookId";
 
 function readStoredBookId(): string | null {
   try {
-    return localStorage.getItem(BOOK_ID_STORAGE_KEY);
+    return sessionStorage.getItem(BOOK_ID_STORAGE_KEY);
   } catch {
-    // localStorage can throw in private-browsing or sandboxed iframes;
+    // sessionStorage can throw in private-browsing or sandboxed iframes;
     // a missing prior selection is fine, the picker just falls through.
     return null;
   }
@@ -200,8 +202,8 @@ function readStoredBookId(): string | null {
 
 function writeStoredBookId(bookId: string | null): void {
   try {
-    if (bookId) localStorage.setItem(BOOK_ID_STORAGE_KEY, bookId);
-    else localStorage.removeItem(BOOK_ID_STORAGE_KEY);
+    if (bookId) sessionStorage.setItem(BOOK_ID_STORAGE_KEY, bookId);
+    else sessionStorage.removeItem(BOOK_ID_STORAGE_KEY);
   } catch {
     // Best-effort — losing the persisted selection only means the
     // next mount picks a different default book.

--- a/src/plugins/accounting/actions.ts
+++ b/src/plugins/accounting/actions.ts
@@ -1,0 +1,32 @@
+// Single source of truth for the manageAccounting LLM-facing action
+// names. Used by:
+//   - definition.ts (the JSON-schema action enum exposed to the LLM)
+//   - api.ts        (the View's REST helpers — `call(action, args)`)
+//   - server/api/routes/accounting.ts (handler-table keys, PREVIEW
+//     and MESSAGE_BUILDERS membership)
+//   - e2e/fixtures/accounting.ts (mock dispatcher's handler-table)
+//
+// Stays in its own module so server-side callers can import the
+// const without pulling in apiPost / Vue plumbing from `api.ts`.
+//
+// CLAUDE.md "no magic literals — use existing `as const` objects"
+// applies here: never reference an action by raw string at any of
+// the call sites above.
+
+export const ACCOUNTING_ACTIONS = {
+  openApp: "openApp",
+  getBooks: "getBooks",
+  createBook: "createBook",
+  deleteBook: "deleteBook",
+  getAccounts: "getAccounts",
+  upsertAccount: "upsertAccount",
+  addEntry: "addEntry",
+  voidEntry: "voidEntry",
+  getJournalEntries: "getJournalEntries",
+  getOpeningBalances: "getOpeningBalances",
+  setOpeningBalances: "setOpeningBalances",
+  getReport: "getReport",
+  rebuildSnapshots: "rebuildSnapshots",
+} as const;
+
+export type AccountingAction = (typeof ACCOUNTING_ACTIONS)[keyof typeof ACCOUNTING_ACTIONS];

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -107,7 +107,7 @@ export function listBooks(): Promise<ApiResult<{ activeBookId: string | null; bo
   return call("listBooks");
 }
 
-export function createBook(input: { name: string; currency?: string; id?: string }): Promise<ApiResult<{ book: BookSummary }>> {
+export function createBook(input: { name: string; currency?: string }): Promise<ApiResult<{ book: BookSummary }>> {
   return call("createBook", input);
 }
 

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -103,7 +103,7 @@ function call<T>(action: string, args: Record<string, unknown> = {}): Promise<Ap
 
 // ── Books ────────────────────────────────────────────────────────────
 
-export function getBooks(): Promise<ApiResult<{ activeBookId: string | null; books: BookSummary[] }>> {
+export function getBooks(): Promise<ApiResult<{ books: BookSummary[] }>> {
   return call("getBooks");
 }
 
@@ -111,21 +111,17 @@ export function createBook(input: { name: string; currency?: string }): Promise<
   return call("createBook", input);
 }
 
-export function setActiveBook(bookId: string): Promise<ApiResult<{ activeBookId: string }>> {
-  return call("setActiveBook", { bookId });
-}
-
-export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string; activeBookId: string | null }>> {
+export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string }>> {
   return call("deleteBook", { bookId, confirm: true });
 }
 
 // ── Accounts ─────────────────────────────────────────────────────────
 
-export function getAccounts(bookId?: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
+export function getAccounts(bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
   return call("getAccounts", { bookId });
 }
 
-export function upsertAccount(account: Account, bookId?: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
+export function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
   return call("upsertAccount", { account, bookId });
 }
 
@@ -135,7 +131,7 @@ export function addEntry(input: {
   date: string;
   lines: JournalLine[];
   memo?: string;
-  bookId?: string;
+  bookId: string;
 }): Promise<ApiResult<{ bookId: string; entry: JournalEntry }>> {
   return call("addEntry", input);
 }
@@ -143,7 +139,7 @@ export function addEntry(input: {
 export function voidEntry(input: {
   entryId: string;
   reason?: string;
-  bookId?: string;
+  bookId: string;
 }): Promise<ApiResult<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }>> {
   return call("voidEntry", input);
 }
@@ -152,14 +148,14 @@ export function getJournalEntries(input: {
   from?: string;
   to?: string;
   accountCode?: string;
-  bookId?: string;
+  bookId: string;
 }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
   return call("getJournalEntries", input);
 }
 
 // ── Opening balances ─────────────────────────────────────────────────
 
-export function getOpeningBalances(bookId?: string): Promise<ApiResult<{ bookId: string; opening: JournalEntry | null }>> {
+export function getOpeningBalances(bookId: string): Promise<ApiResult<{ bookId: string; opening: JournalEntry | null }>> {
   return call("getOpeningBalances", { bookId });
 }
 
@@ -167,27 +163,27 @@ export function setOpeningBalances(input: {
   asOfDate: string;
   lines: JournalLine[];
   memo?: string;
-  bookId?: string;
+  bookId: string;
 }): Promise<ApiResult<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }>> {
   return call("setOpeningBalances", input);
 }
 
 // ── Reports ──────────────────────────────────────────────────────────
 
-export function getBalanceSheet(period: ReportPeriod, bookId?: string): Promise<ApiResult<{ bookId: string; balanceSheet: BalanceSheet }>> {
+export function getBalanceSheet(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; balanceSheet: BalanceSheet }>> {
   return call("getReport", { kind: "balance", period, bookId });
 }
 
-export function getProfitLoss(period: ReportPeriod, bookId?: string): Promise<ApiResult<{ bookId: string; profitLoss: ProfitLoss }>> {
+export function getProfitLoss(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; profitLoss: ProfitLoss }>> {
   return call("getReport", { kind: "pl", period, bookId });
 }
 
-export function getLedger(accountCode: string, period?: ReportPeriod, bookId?: string): Promise<ApiResult<{ bookId: string; ledger: Ledger }>> {
+export function getLedger(accountCode: string, period: ReportPeriod | undefined, bookId: string): Promise<ApiResult<{ bookId: string; ledger: Ledger }>> {
   return call("getReport", { kind: "ledger", accountCode, period, bookId });
 }
 
 // ── Admin ────────────────────────────────────────────────────────────
 
-export function rebuildSnapshots(bookId?: string): Promise<ApiResult<{ bookId: string; rebuilt: string[] }>> {
+export function rebuildSnapshots(bookId: string): Promise<ApiResult<{ bookId: string; rebuilt: string[] }>> {
   return call("rebuildSnapshots", { bookId });
 }

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -103,8 +103,8 @@ function call<T>(action: string, args: Record<string, unknown> = {}): Promise<Ap
 
 // ── Books ────────────────────────────────────────────────────────────
 
-export function listBooks(): Promise<ApiResult<{ activeBookId: string | null; books: BookSummary[] }>> {
-  return call("listBooks");
+export function getBooks(): Promise<ApiResult<{ activeBookId: string | null; books: BookSummary[] }>> {
+  return call("getBooks");
 }
 
 export function createBook(input: { name: string; currency?: string }): Promise<ApiResult<{ book: BookSummary }>> {
@@ -121,8 +121,8 @@ export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: s
 
 // ── Accounts ─────────────────────────────────────────────────────────
 
-export function listAccounts(bookId?: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
-  return call("listAccounts", { bookId });
+export function getAccounts(bookId?: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
+  return call("getAccounts", { bookId });
 }
 
 export function upsertAccount(account: Account, bookId?: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -111,7 +111,7 @@ export function createBook(input: { name: string; currency?: string }): Promise<
   return call("createBook", input);
 }
 
-export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string }>> {
+export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string; deletedBookName: string }>> {
   return call("deleteBook", { bookId, confirm: true });
 }
 
@@ -121,7 +121,7 @@ export function getAccounts(bookId: string): Promise<ApiResult<{ bookId: string;
   return call("getAccounts", { bookId });
 }
 
-export function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
+export function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; account: Account; accounts: Account[] }>> {
   return call("upsertAccount", { account, bookId });
 }
 

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -148,13 +148,13 @@ export function voidEntry(input: {
   return call("voidEntry", input);
 }
 
-export function listEntries(input: {
+export function getJournalEntries(input: {
   from?: string;
   to?: string;
   accountCode?: string;
   bookId?: string;
 }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
-  return call("listEntries", input);
+  return call("getJournalEntries", input);
 }
 
 // ── Opening balances ─────────────────────────────────────────────────

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -9,6 +9,7 @@
 
 import { apiPost, type ApiResult } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { ACCOUNTING_ACTIONS } from "./actions";
 
 export type AccountType = "asset" | "liability" | "equity" | "income" | "expense";
 export type JournalEntryKind = "normal" | "opening" | "void" | "void-marker";
@@ -104,25 +105,25 @@ function call<T>(action: string, args: Record<string, unknown> = {}): Promise<Ap
 // ── Books ────────────────────────────────────────────────────────────
 
 export function getBooks(): Promise<ApiResult<{ books: BookSummary[] }>> {
-  return call("getBooks");
+  return call(ACCOUNTING_ACTIONS.getBooks);
 }
 
 export function createBook(input: { name: string; currency?: string }): Promise<ApiResult<{ book: BookSummary }>> {
-  return call("createBook", input);
+  return call(ACCOUNTING_ACTIONS.createBook, input);
 }
 
 export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string; deletedBookName: string }>> {
-  return call("deleteBook", { bookId, confirm: true });
+  return call(ACCOUNTING_ACTIONS.deleteBook, { bookId, confirm: true });
 }
 
 // ── Accounts ─────────────────────────────────────────────────────────
 
 export function getAccounts(bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
-  return call("getAccounts", { bookId });
+  return call(ACCOUNTING_ACTIONS.getAccounts, { bookId });
 }
 
 export function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; account: Account; accounts: Account[] }>> {
-  return call("upsertAccount", { account, bookId });
+  return call(ACCOUNTING_ACTIONS.upsertAccount, { account, bookId });
 }
 
 // ── Entries ──────────────────────────────────────────────────────────
@@ -133,7 +134,7 @@ export function addEntry(input: {
   memo?: string;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; entry: JournalEntry }>> {
-  return call("addEntry", input);
+  return call(ACCOUNTING_ACTIONS.addEntry, input);
 }
 
 export function voidEntry(input: {
@@ -141,7 +142,7 @@ export function voidEntry(input: {
   reason?: string;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }>> {
-  return call("voidEntry", input);
+  return call(ACCOUNTING_ACTIONS.voidEntry, input);
 }
 
 export function getJournalEntries(input: {
@@ -150,13 +151,13 @@ export function getJournalEntries(input: {
   accountCode?: string;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
-  return call("getJournalEntries", input);
+  return call(ACCOUNTING_ACTIONS.getJournalEntries, input);
 }
 
 // ── Opening balances ─────────────────────────────────────────────────
 
 export function getOpeningBalances(bookId: string): Promise<ApiResult<{ bookId: string; opening: JournalEntry | null }>> {
-  return call("getOpeningBalances", { bookId });
+  return call(ACCOUNTING_ACTIONS.getOpeningBalances, { bookId });
 }
 
 export function setOpeningBalances(input: {
@@ -165,25 +166,25 @@ export function setOpeningBalances(input: {
   memo?: string;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }>> {
-  return call("setOpeningBalances", input);
+  return call(ACCOUNTING_ACTIONS.setOpeningBalances, input);
 }
 
 // ── Reports ──────────────────────────────────────────────────────────
 
 export function getBalanceSheet(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; balanceSheet: BalanceSheet }>> {
-  return call("getReport", { kind: "balance", period, bookId });
+  return call(ACCOUNTING_ACTIONS.getReport, { kind: "balance", period, bookId });
 }
 
 export function getProfitLoss(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; profitLoss: ProfitLoss }>> {
-  return call("getReport", { kind: "pl", period, bookId });
+  return call(ACCOUNTING_ACTIONS.getReport, { kind: "pl", period, bookId });
 }
 
 export function getLedger(accountCode: string, period: ReportPeriod | undefined, bookId: string): Promise<ApiResult<{ bookId: string; ledger: Ledger }>> {
-  return call("getReport", { kind: "ledger", accountCode, period, bookId });
+  return call(ACCOUNTING_ACTIONS.getReport, { kind: "ledger", accountCode, period, bookId });
 }
 
 // ── Admin ────────────────────────────────────────────────────────────
 
 export function rebuildSnapshots(bookId: string): Promise<ApiResult<{ bookId: string; rebuilt: string[] }>> {
-  return call("rebuildSnapshots", { bookId });
+  return call(ACCOUNTING_ACTIONS.rebuildSnapshots, { bookId });
 }

--- a/src/plugins/accounting/components/BookSwitcher.vue
+++ b/src/plugins/accounting/components/BookSwitcher.vue
@@ -14,7 +14,6 @@
       <option :value="NEW_BOOK_SENTINEL" data-testid="accounting-new-book-option">+ {{ t("pluginAccounting.bookSwitcher.newBook") }}</option>
     </select>
     <NewBookForm v-if="showNewBook" @cancel="showNewBook = false" @created="onCreated" />
-    <p v-if="switchError" class="text-xs text-red-500">{{ switchError }}</p>
   </div>
 </template>
 
@@ -22,7 +21,7 @@
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 import NewBookForm from "./NewBookForm.vue";
-import { setActiveBook, type BookSummary } from "../api";
+import type { BookSummary } from "../api";
 
 const { t } = useI18n();
 
@@ -34,18 +33,17 @@ const emit = defineEmits<{
 
 // Sentinel value for the "+ New book" option living inside the
 // books <select>. Picking it opens the modal and reverts the
-// select's displayed value to the active book — the option must
-// not collide with any real book id, which are nanoid-shaped.
+// select's displayed value to the current selection — the option
+// must not collide with any real book id, which are nanoid-shaped.
 const NEW_BOOK_SENTINEL = "__new__";
 
 const showNewBook = ref(false);
-const switchError = ref<string | null>(null);
 
 function formatBookOption(book: BookSummary): string {
   return `${book.name} (${book.currency})`;
 }
 
-async function onSelect(event: Event): Promise<void> {
+function onSelect(event: Event): void {
   const target = event.target as HTMLSelectElement;
   const bookId = target.value;
   if (bookId === NEW_BOOK_SENTINEL) {
@@ -54,15 +52,9 @@ async function onSelect(event: Event): Promise<void> {
     return;
   }
   if (bookId === props.modelValue) return;
-  const result = await setActiveBook(bookId);
-  if (!result.ok) {
-    target.value = props.modelValue;
-    switchError.value = result.error;
-    return;
-  }
-  switchError.value = null;
+  // The View persists the new selection to localStorage; no server
+  // round-trip needed since there's no shared "active book" state.
   emit("update:modelValue", bookId);
-  emit("books-changed");
 }
 
 function onCreated(book: BookSummary): void {

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -72,7 +72,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { listEntries, voidEntry, type Account, type JournalEntry, type JournalEntryKind } from "../api";
+import { getJournalEntries, voidEntry, type Account, type JournalEntry, type JournalEntryKind } from "../api";
 import { formatAmount } from "../currencies";
 import { useLatestRequest } from "./useLatestRequest";
 
@@ -112,7 +112,7 @@ async function refresh(): Promise<void> {
   loading.value = true;
   error.value = null;
   try {
-    const result = await listEntries({
+    const result = await getJournalEntries({
       bookId: props.bookId,
       from: from.value || undefined,
       to: toDate.value || undefined,

--- a/src/plugins/accounting/components/NewBookForm.vue
+++ b/src/plugins/accounting/components/NewBookForm.vue
@@ -6,8 +6,8 @@
            the workspace has zero books. No backdrop, no cancel:
            the user MUST create their first book to proceed.
        The submit calls createBook directly; on success it emits
-       the new book and its id, leaving the parent to wire
-       activeBookId / refetch. -->
+       the new book and its id, leaving the parent to update its
+       current selection / refetch. -->
   <div :class="wrapperClass" data-testid="accounting-new-book-modal" @click.self="onBackdropClick">
     <form class="bg-white p-4 rounded shadow-lg w-96 flex flex-col gap-3" data-testid="accounting-new-book-form" @submit.prevent="onSubmit">
       <h3 class="text-base font-semibold">{{ t("pluginAccounting.bookSwitcher.newBook") }}</h3>

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -27,11 +27,11 @@ const toolDefinition: ToolDefinition = {
         type: "string",
         enum: [
           "openApp",
-          "listBooks",
+          "getBooks",
           "createBook",
           "setActiveBook",
           "deleteBook",
-          "listAccounts",
+          "getAccounts",
           "upsertAccount",
           "addEntry",
           "voidEntry",

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -52,7 +52,6 @@ const toolDefinition: ToolDefinition = {
       // openApp / createBook
       name: { type: "string", description: "For 'createBook': human-readable book name." },
       currency: { type: "string", description: "For 'createBook': ISO 4217 currency code (default USD). Single-currency per book." },
-      id: { type: "string", description: "For 'createBook': explicit book id. Omit to let the server auto-generate a unique id." },
       initialTab: { type: "string", description: "For 'openApp': initial tab to show (e.g. 'journal', 'opening', 'balanceSheet')." },
       confirm: { type: "boolean", description: "For 'deleteBook': must be true to actually delete (guard against accidental deletion)." },
       // accounts

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -29,7 +29,6 @@ const toolDefinition: ToolDefinition = {
           "openApp",
           "getBooks",
           "createBook",
-          "setActiveBook",
           "deleteBook",
           "getAccounts",
           "upsertAccount",
@@ -47,7 +46,8 @@ const toolDefinition: ToolDefinition = {
       },
       bookId: {
         type: "string",
-        description: "Target book id. Omit to use the currently active book (config.json#activeBookId).",
+        description:
+          "Target book id. Required for every action that reads or writes book data; call 'getBooks' first to enumerate available ids. The only actions that do NOT take a bookId are 'getBooks' and 'createBook' (which creates a fresh one).",
       },
       // openApp / createBook
       name: { type: "string", description: "For 'createBook': human-readable book name." },

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -35,7 +35,7 @@ const toolDefinition: ToolDefinition = {
           "upsertAccount",
           "addEntry",
           "voidEntry",
-          "listEntries",
+          "getJournalEntries",
           "getOpeningBalances",
           "setOpeningBalances",
           "getReport",
@@ -88,10 +88,13 @@ const toolDefinition: ToolDefinition = {
       entryId: { type: "string", description: "For 'voidEntry': id of the entry to void. The reverse + marker pair is appended (journal stays append-only)." },
       reason: { type: "string", description: "For 'voidEntry': human-readable reason." },
       voidDate: { type: "string", description: "For 'voidEntry': YYYY-MM-DD date for the reverse entry (defaults to today)." },
-      // listEntries / getReport ranges
-      from: { type: "string", description: "For 'listEntries': inclusive YYYY-MM-DD lower bound." },
-      to: { type: "string", description: "For 'listEntries': inclusive YYYY-MM-DD upper bound." },
-      accountCode: { type: "string", description: "For 'listEntries' / 'getReport' (kind=ledger): filter to a specific account." },
+      // getJournalEntries / getReport ranges
+      from: { type: "string", description: "For 'getJournalEntries': inclusive YYYY-MM-DD lower bound on entry date." },
+      to: { type: "string", description: "For 'getJournalEntries': inclusive YYYY-MM-DD upper bound on entry date." },
+      accountCode: {
+        type: "string",
+        description: "For 'getJournalEntries' / 'getReport' (kind=ledger): filter to entries that touch a specific account code.",
+      },
       // opening
       asOfDate: {
         type: "string",

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "gui-chat-protocol";
 import { TOOL_NAMES } from "../../config/toolNames";
+import { ACCOUNTING_ACTIONS } from "./actions";
 
 // MCP tool definition for the accounting plugin.
 //
@@ -25,21 +26,7 @@ const toolDefinition: ToolDefinition = {
     properties: {
       action: {
         type: "string",
-        enum: [
-          "openApp",
-          "getBooks",
-          "createBook",
-          "deleteBook",
-          "getAccounts",
-          "upsertAccount",
-          "addEntry",
-          "voidEntry",
-          "getJournalEntries",
-          "getOpeningBalances",
-          "setOpeningBalances",
-          "getReport",
-          "rebuildSnapshots",
-        ],
+        enum: Object.values(ACCOUNTING_ACTIONS),
         description:
           "Operation to perform. 'openApp' mounts the full UI; others perform a single read or write. Use 'openApp' when the user wants to browse / interact, and a specific action when the user named the operation.",
       },

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -38,7 +38,6 @@ const toolDefinition: ToolDefinition = {
           "getOpeningBalances",
           "setOpeningBalances",
           "getReport",
-          "getBookMeta",
           "rebuildSnapshots",
         ],
         description:

--- a/src/plugins/presentForm/Preview.vue
+++ b/src/plugins/presentForm/Preview.vue
@@ -57,7 +57,7 @@ const props = defineProps<{
 
 const formData = computed<FormData | null>(() => {
   if (props.result?.toolName === "presentForm") {
-    return props.result.jsonData as FormData;
+    return (props.result.data ?? props.result.jsonData) as FormData;
   }
   return null;
 });

--- a/src/plugins/presentForm/index.ts
+++ b/src/plugins/presentForm/index.ts
@@ -5,7 +5,7 @@ import { executeForm } from "./plugin";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
 
-const presentFormPlugin: ToolPlugin<never, FormData, FormArgs> = {
+const presentFormPlugin: ToolPlugin<FormData, FormData, FormArgs> = {
   toolDefinition: TOOL_DEFINITION,
   execute: executeForm,
   generatingMessage: "Preparing form...",

--- a/src/plugins/presentForm/plugin.ts
+++ b/src/plugins/presentForm/plugin.ts
@@ -62,7 +62,7 @@ function validateField(field: FormField, index: number, seenIds: Set<string>): v
   validateRangeField(field);
 }
 
-export const executeForm = async (_context: ToolContext, args: FormArgs): Promise<ToolResult<never, FormData>> => {
+export const executeForm = async (_context: ToolContext, args: FormArgs): Promise<ToolResult<FormData, FormData>> => {
   try {
     const { title, description, fields } = args;
     if (!fields || !Array.isArray(fields) || fields.length === 0) {
@@ -76,6 +76,10 @@ export const executeForm = async (_context: ToolContext, args: FormArgs): Promis
     const titleSuffix = title ? `: ${title}` : "";
     return {
       message: `Form created with ${fieldCount}${titleSuffix}`,
+      // `data` is the view's source (also the host's preview-gate
+      // signal); `jsonData` is what the LLM sees in the tool result.
+      // Same payload, two audiences — keep both in sync.
+      data: formData,
       jsonData: formData,
       instructions:
         "The form has been presented to the user. Wait for the user to fill out and submit it. They will reply with a markdown bullet list of `- {label}: {value}` lines.",

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -6,6 +6,7 @@ import type { SseEvent } from "../../types/sse";
 import { EVENT_TYPES, generationKey } from "../../types/events";
 import { findPendingToolCall, toToolCallEntry } from "./toolCalls";
 import { pushErrorMessage, applyTextEvent, applyToolResultToSession } from "../session/sessionHelpers";
+import { isSidebarVisible } from "../tools/sidebarVisibleApp";
 
 export interface AgentEventContext {
   session: ActiveSession;
@@ -37,7 +38,9 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       applyTextEvent(session, event.message, event.source ?? "assistant", event.attachments);
       return;
     case EVENT_TYPES.toolResult:
-      applyToolResultToSession(session, event.result);
+      // Skip auto-select for sidebar-hidden results; otherwise the
+      // user's selection silently jumps to a card they can't see.
+      applyToolResultToSession(session, event.result, isSidebarVisible);
       return;
     case EVENT_TYPES.error:
       console.error("[agent] error event:", event.message);

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -32,26 +32,40 @@ export function parseSessionEntries(entries: readonly SessionEntry[]): ToolResul
 // Rules:
 //   1. If the URL carries `?result=<uuid>` AND that uuid actually
 //      exists in the loaded list, honour it verbatim. This lets
-//      bookmarks restore the exact result the user was viewing.
-//   2. Otherwise fall back to the heuristic: the most recent
-//      non-text tool result (images, wiki pages, etc. carry more
-//      visual information than bare text).
-//   3. If there are no non-text results, use the last result of
-//      any kind.
+//      bookmarks restore the exact result the user was viewing —
+//      we honour even sidebar-hidden uuids here because the URL is
+//      an explicit user choice (a fresh "auto-pick" should never
+//      land on a hidden result, but a deliberate bookmark can).
+//   2. Otherwise fall back to the heuristic over visible-only
+//      results: the most recent non-text tool result (images, wiki
+//      pages, etc. carry more visual information than bare text).
+//   3. If there are no non-text visible results, use the last
+//      visible result of any kind.
 //   4. If the list is empty, return null.
-export function resolveSelectedUuid(toolResults: readonly ToolResultComplete[], urlResult: string | null): string | null {
+//
+// `isVisible` is injected (rather than imported here) so this
+// module stays Vue-free for `node:test` consumers; the live App
+// passes `isSidebarVisible` from `sidebarVisibleApp`. The default
+// `() => true` matches pre-filter behaviour for tests that don't
+// supply one.
+export function resolveSelectedUuid(
+  toolResults: readonly ToolResultComplete[],
+  urlResult: string | null,
+  isVisible: (result: ToolResultComplete) => boolean = () => true,
+): string | null {
   if (urlResult && toolResults.some((result) => result.uuid === urlResult)) {
     return urlResult;
   }
+  const visible = toolResults.filter(isVisible);
+  if (visible.length === 0) return null;
   // Iterate backwards for the "last non-text" lookup so callers
   // don't pay for an intermediate reverse copy.
-  for (let i = toolResults.length - 1; i >= 0; i--) {
-    if (toolResults[i].toolName !== "text-response") {
-      return toolResults[i].uuid;
+  for (let i = visible.length - 1; i >= 0; i--) {
+    if (visible[i].toolName !== "text-response") {
+      return visible[i].uuid;
     }
   }
-  const last = toolResults[toolResults.length - 1];
-  return last?.uuid ?? null;
+  return visible[visible.length - 1].uuid;
 }
 
 // Decide the `startedAt` / `updatedAt` to seed the in-memory
@@ -94,12 +108,16 @@ export function buildLoadedSession(opts: {
   urlResult: string | null;
   serverSummary: SessionSummary | undefined;
   nowIso: string;
+  /** Visibility predicate for the auto-select heuristic — defaults
+   *  to `() => true` so this module stays Vue-free for tests; the
+   *  App wires `isSidebarVisible` from `sidebarVisibleApp`. */
+  isVisible?: (result: ToolResultComplete) => boolean;
 }): ActiveSession {
-  const { id, entries, defaultRoleId, urlResult, serverSummary, nowIso } = opts;
+  const { id, entries, defaultRoleId, urlResult, serverSummary, nowIso, isVisible } = opts;
   const meta = entries.find((entry) => entry.type === EVENT_TYPES.sessionMeta);
   const roleId = meta?.roleId ?? defaultRoleId;
   const toolResults = parseSessionEntries(entries);
-  const selectedResultUuid = resolveSelectedUuid(toolResults, urlResult);
+  const selectedResultUuid = resolveSelectedUuid(toolResults, urlResult, isVisible);
   const { startedAt, updatedAt } = resolveSessionTimestamps(serverSummary, nowIso);
   const resultTimestamps = interpolateTimestamps(toolResults, startedAt, updatedAt);
 

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -91,14 +91,24 @@ export function updateResult(session: ActiveSession, updatedResult: ToolResultCo
 }
 
 /** Handle an incoming tool_result event: upsert into the session's
- *  result list. Selects the result only on insert; in-place updates
- *  preserve the user's current selection. */
-export function applyToolResultToSession(session: ActiveSession, result: ToolResultComplete): void {
+ *  result list. Selects the result only on insert AND only if
+ *  `shouldSelect(result)` is truthy — auto-selecting a sidebar-hidden
+ *  result leaves no card highlighted while the canvas follows an
+ *  invisible selection. In-place updates preserve the user's current
+ *  selection. The default `shouldSelect` always returns true (matches
+ *  pre-filter behaviour for callers / tests that don't supply one);
+ *  the live frontend wires in `isSidebarVisible` from
+ *  `sidebarVisibleApp` via `eventDispatch.ts`. */
+export function applyToolResultToSession(
+  session: ActiveSession,
+  result: ToolResultComplete,
+  shouldSelect: (result: ToolResultComplete) => boolean = () => true,
+): void {
   const idx = session.toolResults.findIndex((existing) => existing.uuid === result.uuid);
   if (idx >= 0) {
     session.toolResults[idx] = result;
   } else {
     pushResult(session, result);
-    session.selectedResultUuid = result.uuid;
+    if (shouldSelect(result)) session.selectedResultUuid = result.uuid;
   }
 }

--- a/src/utils/tools/sidebarVisible.ts
+++ b/src/utils/tools/sidebarVisible.ts
@@ -1,0 +1,30 @@
+// Pure predicate for "should this tool result appear in the sidebar list?"
+// Centralised so the sidebar render, the upstream `sidebarResults`
+// computed, the auto-select-on-insert path, and keyboard navigation
+// all use the exact same definition of "visible". Out-of-sync filters
+// would let a hidden result get auto-selected (no card highlights but
+// the canvas follows an invisible selection) or let arrow-key nav
+// step through items the user can't see.
+//
+// A result is visible iff:
+//   - its plugin has no previewComponent (legacy fallback path —
+//     the sidebar shows a plain title span), OR
+//   - the result carries a `data` field (the gui-chat-protocol's
+//     view-side payload — its presence is the "show me a preview"
+//     signal; absence means the action is fire-and-forget).
+//
+// This module stays free of the Vue plugin registry on purpose:
+// Node test files (e.g. test_sessionEntries.ts) import callers of
+// this predicate, and importing the registry would pull every
+// plugin's .vue file into the test process at module-eval time.
+// Callers that want a default "ask the registry" wiring import
+// `sidebarVisibleApp.ts` instead.
+
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+export type HasPreviewFn = (toolName: string) => boolean;
+
+export function isSidebarVisible(result: ToolResultComplete, hasPreview: HasPreviewFn): boolean {
+  if (!hasPreview(result.toolName)) return true;
+  return result.data !== undefined;
+}

--- a/src/utils/tools/sidebarVisibleApp.ts
+++ b/src/utils/tools/sidebarVisibleApp.ts
@@ -1,0 +1,16 @@
+// Vue-coupled wrapper around the pure `isSidebarVisible` predicate.
+// Imports the plugin registry (which transitively loads .vue files)
+// so it lives in a separate module from the pure predicate — Node
+// test files that import callers of `isSidebarVisible` (with their
+// own injected `hasPreview` lookup) can do so without dragging the
+// registry through `node:test`.
+
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { getPlugin } from "../../tools";
+import { isSidebarVisible as isSidebarVisibleRaw } from "./sidebarVisible";
+
+const hasPreview = (toolName: string): boolean => Boolean(getPlugin(toolName)?.previewComponent);
+
+export function isSidebarVisible(result: ToolResultComplete): boolean {
+  return isSidebarVisibleRaw(result, hasPreview);
+}

--- a/test/accounting/test_io.ts
+++ b/test/accounting/test_io.ts
@@ -58,7 +58,7 @@ describe("config.json", () => {
   it("returns null when missing, round-trips when written", async () => {
     const root = makeTmp();
     assert.equal(await readConfig(root), null);
-    const cfg = { activeBookId: "default", books: [{ id: "default", name: "Default", currency: "USD", createdAt: "2026-04-30T00:00:00Z" }] };
+    const cfg = { books: [{ id: "default", name: "Default", currency: "USD", createdAt: "2026-04-30T00:00:00Z" }] };
     await writeConfig(cfg, root);
     assert.deepEqual(await readConfig(root), cfg);
   });

--- a/test/accounting/test_service.ts
+++ b/test/accounting/test_service.ts
@@ -14,7 +14,6 @@ import {
   getProfitLossReport,
   listBooks,
   listEntries,
-  setActiveBook,
   setOpeningBalances,
   voidEntry,
 } from "../../server/accounting/service.js";
@@ -64,18 +63,20 @@ describe("createBook id validation", () => {
 describe("upsertAccount synthetic-code guard", () => {
   it("rejects account codes starting with _ (reserved for synthetic rows)", async () => {
     const root = makeTmp();
-    await createBook({ name: "X" }, root);
+    const book = await createBook({ name: "X" }, root);
     const { upsertAccount } = await import("../../server/accounting/service.js");
-    await assert.rejects(() => upsertAccount({ account: { code: "_currentEarnings", name: "Synthetic", type: "equity" } }, root), AccountingError);
+    await assert.rejects(
+      () => upsertAccount({ bookId: book.book.id, account: { code: "_currentEarnings", name: "Synthetic", type: "equity" } }, root),
+      AccountingError,
+    );
   });
 });
 
 describe("books lifecycle", () => {
-  it("createBook generates ids, lists, sets active, deletes books in sequence", async () => {
+  it("createBook generates ids, lists, and deletes books in sequence", async () => {
     const root = makeTmp();
     const empty = await listBooks(root);
     assert.deepEqual(empty.books, []);
-    assert.equal(empty.activeBookId, null);
     const first = await createBook({ name: "First" }, root);
     assert.match(first.book.id, /^book-/);
     const second = await createBook({ name: "Second" }, root);
@@ -83,22 +84,21 @@ describe("books lifecycle", () => {
     assert.notEqual(first.book.id, second.book.id);
     const list = await listBooks(root);
     assert.equal(list.books.length, 2);
-    assert.equal(list.activeBookId, first.book.id);
-    const switched = await setActiveBook({ bookId: second.book.id }, root);
-    assert.equal(switched.activeBookId, second.book.id);
-    // delete the active one — auto-promote remaining
     const afterDelete = await deleteBook({ bookId: second.book.id, confirm: true }, root);
-    assert.equal(afterDelete.activeBookId, first.book.id);
+    assert.equal(afterDelete.deletedBookId, second.book.id);
+    const remaining = await listBooks(root);
+    assert.equal(remaining.books.length, 1);
+    assert.equal(remaining.books[0].id, first.book.id);
   });
-  it("deleting the last book leaves activeBookId null and the workspace empty", async () => {
+  it("deleting the last book empties the workspace; ops without a bookId throw 400", async () => {
     const root = makeTmp();
     const only = await createBook({ name: "Only" }, root);
     const result = await deleteBook({ bookId: only.book.id, confirm: true }, root);
-    assert.equal(result.activeBookId, null);
+    assert.equal(result.deletedBookId, only.book.id);
     const list = await listBooks(root);
     assert.equal(list.books.length, 0);
-    assert.equal(list.activeBookId, null);
-    // Subsequent operations without a bookId surface the "no active book" error.
+    // No more "active book" fallback — every action requires an
+    // explicit bookId or the service throws AccountingError(400).
     await assert.rejects(
       () =>
         addEntry(
@@ -114,19 +114,6 @@ describe("books lifecycle", () => {
       AccountingError,
     );
   });
-  it("deleting an active-but-not-last book promotes the most recently created remaining book", async () => {
-    const root = makeTmp();
-    const alpha = await createBook({ name: "A" }, root);
-    // Stagger createdAt so the sort is deterministic without relying on timer resolution.
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    const beta = await createBook({ name: "B" }, root);
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    const gamma = await createBook({ name: "C" }, root);
-    await setActiveBook({ bookId: alpha.book.id }, root);
-    const result = await deleteBook({ bookId: alpha.book.id, confirm: true }, root);
-    assert.equal(result.activeBookId, gamma.book.id);
-    assert.notEqual(result.activeBookId, beta.book.id);
-  });
   it("deleteBook without confirm: true is rejected", async () => {
     const root = makeTmp();
     const first = await createBook({ name: "A" }, root);
@@ -138,9 +125,11 @@ describe("books lifecycle", () => {
 describe("addEntry / listEntries", () => {
   it("appends, lists, and rejects unbalanced", async () => {
     const root = makeTmp();
-    await createBook({ name: "Test" }, root);
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
     const entry = await addEntry(
       {
+        bookId,
         date: "2026-04-01",
         lines: [
           { accountCode: "1000", debit: 100 },
@@ -150,12 +139,13 @@ describe("addEntry / listEntries", () => {
       root,
     );
     assert.equal(entry.entry.kind, "normal");
-    const list = await listEntries({}, root);
+    const list = await listEntries({ bookId }, root);
     assert.equal(list.entries.length, 1);
     await assert.rejects(
       () =>
         addEntry(
           {
+            bookId,
             date: "2026-04-02",
             lines: [
               { accountCode: "1000", debit: 100 },
@@ -172,9 +162,11 @@ describe("addEntry / listEntries", () => {
 describe("voidEntry", () => {
   it("appends a reverse + marker pair; void shows in listEntries", async () => {
     const root = makeTmp();
-    await createBook({ name: "Test" }, root);
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
     const added = await addEntry(
       {
+        bookId,
         date: "2026-04-01",
         lines: [
           { accountCode: "1000", debit: 100 },
@@ -183,8 +175,8 @@ describe("voidEntry", () => {
       },
       root,
     );
-    await voidEntry({ entryId: added.entry.id, reason: "typo" }, root);
-    const list = await listEntries({}, root);
+    await voidEntry({ bookId, entryId: added.entry.id, reason: "typo" }, root);
+    const list = await listEntries({ bookId }, root);
     // Original + reverse + marker = 3 rows
     assert.equal(list.entries.length, 3);
     assert.ok(list.entries.some((entry) => entry.kind === "void"));
@@ -196,9 +188,11 @@ describe("voidEntry", () => {
     // accountCode drops the void-marker row (no lines), so the
     // client must NOT derive voidedEntryIds from the filtered list.
     const root = makeTmp();
-    await createBook({ name: "Test" }, root);
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
     const added = await addEntry(
       {
+        bookId,
         date: "2026-04-01",
         lines: [
           { accountCode: "1000", debit: 100 },
@@ -207,8 +201,8 @@ describe("voidEntry", () => {
       },
       root,
     );
-    await voidEntry({ entryId: added.entry.id, reason: "typo" }, root);
-    const filtered = await listEntries({ accountCode: "1000" }, root);
+    await voidEntry({ bookId, entryId: added.entry.id, reason: "typo" }, root);
+    const filtered = await listEntries({ bookId, accountCode: "1000" }, root);
     // Void-marker has empty lines so it's filtered out; original + reverse remain.
     assert.equal(
       filtered.entries.some((entry) => entry.kind === "void-marker"),
@@ -222,10 +216,11 @@ describe("voidEntry", () => {
 describe("opening balances", () => {
   it("sets opening, rejects when post-dated entries exist, replaces existing on second call", async () => {
     const root = makeTmp();
-    await createBook({ name: "Test" }, root);
-    // Set opening on a fresh book.
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
     await setOpeningBalances(
       {
+        bookId,
         asOfDate: "2026-01-01",
         lines: [
           { accountCode: "1000", debit: 1000 },
@@ -234,12 +229,13 @@ describe("opening balances", () => {
       },
       root,
     );
-    let opening = await getOpeningBalances({}, root);
+    let opening = await getOpeningBalances({ bookId }, root);
     assert.ok(opening.opening);
     assert.equal(opening.opening.kind, "opening");
     // Replace it.
     const second = await setOpeningBalances(
       {
+        bookId,
         asOfDate: "2026-01-01",
         lines: [
           { accountCode: "1000", debit: 1500 },
@@ -249,7 +245,7 @@ describe("opening balances", () => {
       root,
     );
     assert.equal(second.replacedExisting, true);
-    opening = await getOpeningBalances({}, root);
+    opening = await getOpeningBalances({ bookId }, root);
     assert.ok(opening.opening);
     assert.equal(opening.opening.lines[0].debit, 1500);
     // Now book a normal entry after opening, then try to set
@@ -257,6 +253,7 @@ describe("opening balances", () => {
     // refuse.
     await addEntry(
       {
+        bookId,
         date: "2026-02-01",
         lines: [
           { accountCode: "1000", debit: 50 },
@@ -269,6 +266,7 @@ describe("opening balances", () => {
       () =>
         setOpeningBalances(
           {
+            bookId,
             asOfDate: "2026-03-01",
             lines: [
               { accountCode: "1000", debit: 1000 },
@@ -282,11 +280,12 @@ describe("opening balances", () => {
   });
   it("rejects opening with income / expense accounts", async () => {
     const root = makeTmp();
-    await createBook({ name: "Test" }, root);
+    const book = await createBook({ name: "Test" }, root);
     await assert.rejects(
       () =>
         setOpeningBalances(
           {
+            bookId: book.book.id,
             asOfDate: "2026-01-01",
             lines: [
               { accountCode: "1000", debit: 1000 },
@@ -307,8 +306,10 @@ describe("reports end-to-end", () => {
     // → imbalance 200.20. The fix adds a synthetic earnings row.
     const root = makeTmp();
     const book = await createBook({ name: "Pervasive" }, root);
+    const bookId = book.book.id;
     await setOpeningBalances(
       {
+        bookId,
         asOfDate: "2026-04-01",
         lines: [
           { accountCode: "1010", debit: 50000 },
@@ -319,6 +320,7 @@ describe("reports end-to-end", () => {
     );
     await addEntry(
       {
+        bookId,
         date: "2026-04-08",
         lines: [
           { accountCode: "5400", debit: 200.2 },
@@ -328,8 +330,8 @@ describe("reports end-to-end", () => {
       },
       root,
     );
-    await drainRebuilds(book.book.id);
-    const report = await getBalanceSheetReport({ period: { kind: "month", period: "2026-04" } }, root);
+    await drainRebuilds(bookId);
+    const report = await getBalanceSheetReport({ bookId, period: { kind: "month", period: "2026-04" } }, root);
     assert.ok(Math.abs(report.balanceSheet.imbalance) < 0.0001, `imbalance was ${report.balanceSheet.imbalance}`);
     const equity = report.balanceSheet.sections.find((section) => section.type === "equity");
     assert.ok(equity);
@@ -340,8 +342,10 @@ describe("reports end-to-end", () => {
   it("opening + a few entries → consistent B/S and P/L", async () => {
     const root = makeTmp();
     const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
     await setOpeningBalances(
       {
+        bookId,
         asOfDate: "2026-01-01",
         lines: [
           { accountCode: "1000", debit: 1000 },
@@ -352,6 +356,7 @@ describe("reports end-to-end", () => {
     );
     await addEntry(
       {
+        bookId,
         date: "2026-04-10",
         lines: [
           { accountCode: "1000", debit: 200 },
@@ -362,6 +367,7 @@ describe("reports end-to-end", () => {
     );
     await addEntry(
       {
+        bookId,
         date: "2026-04-20",
         lines: [
           { accountCode: "5100", debit: 70 },
@@ -370,13 +376,13 @@ describe("reports end-to-end", () => {
       },
       root,
     );
-    await drainRebuilds(book.book.id);
-    const balanceSheet = await getBalanceSheetReport({ period: { kind: "month", period: "2026-04" } }, root);
+    await drainRebuilds(bookId);
+    const balanceSheet = await getBalanceSheetReport({ bookId, period: { kind: "month", period: "2026-04" } }, root);
     const cashRow = balanceSheet.balanceSheet.sections[0].rows.find((row) => row.accountCode === "1000");
     assert.ok(cashRow);
     // Cash = 1000 (opening) + 200 (sales) - 70 (rent) = 1130
     assert.equal(cashRow.balance, 1130);
-    const profitLoss = await getProfitLossReport({ period: { kind: "month", period: "2026-04" } }, root);
+    const profitLoss = await getProfitLossReport({ bookId, period: { kind: "month", period: "2026-04" } }, root);
     assert.equal(profitLoss.profitLoss.income.total, 200);
     assert.equal(profitLoss.profitLoss.expense.total, 70);
     assert.equal(profitLoss.profitLoss.netIncome, 130);


### PR DESCRIPTION
## Summary

Two intertwined cleanups landed in one branch:

1. **Sidebar preview gate on `result.data`.** The host (`SessionSidebar.vue`) now hides a tool-result card entirely when the plugin's tool result has no `data` field. `data` is documented as the view-side payload, so its absence is a self-documenting "silent action" signal — no new protocol field. Plugins opt their fire-and-forget actions out of the sidebar by simply not setting `data`. `presentForm` now also populates `data` (mirroring `jsonData`) so its preview survives the gate.

2. **`manageAccounting` LLM-facing API audit.** Reshaped every action so an LLM that calls one gets enough information to either act on the result or narrate it to the user. Default-to-payload dispatch (silence resolves to `"Done"` from the model's perspective — useless for queries), per-action friendly messages where they help (`addEntry` and `createBook` now include the new id; `deleteBook` includes the book name; `upsertAccount` names the account; `setOpeningBalances` includes the lines), and several semantic cleanups along the way:

- **Removed server-side `activeBookId`.** It was session state masquerading as "the workspace is the database" — made tool calls non-idempotent (the LLM's `getJournalEntries` returns different things based on prior `setActiveBook` turns), coupled multiple browser tabs through a shared mutable, and forced workarounds in the delete-then-create flow. Every action now requires an explicit `bookId`; the View tracks the user's current selection in `localStorage` (`mulmoclaude.accounting.bookId`).
- **Renamed `listBooks` / `listAccounts` / `listEntries` → `getBooks` / `getAccounts` / `getJournalEntries`** at the LLM/route layer. Service-layer names stay (internal). Sharper param descriptions for the new names.
- **Dropped `getBookMeta`.** Vestigial: nothing in the View used it, only field ever written was `createdAt` (already on `BookSummary`), and it wasn't hooked into the LLM's payload-as-message path. Removed the action, route handler, service function, e2e fixture, `BookMeta` type, `readMeta` / `writeMeta` from `accounting-io.ts`, the `writeMeta` call in `createBook`, and the `meta.json` mention in `paths.ts`.
- **Dropped `id` parameter from `createBook`.** Always auto-generate; service-level `id?` stays for the existing id-validation unit tests but no caller passes one.
- **Validated non-empty `name` in `createBook`** (was silently coerced to `""`).
- **`openApp` returns the books list inline** so the LLM doesn't need a follow-up `getBooks` round-trip.
- **Added Edit button on the active opening in the journal**, plus the gate-routing fix from #1085 (already shipped).

## Final action surface (13 actions)

Reads (LLM gets JSON-stringified payload as message): `getBooks`, `getAccounts`, `getJournalEntries`, `getOpeningBalances`, `getReport`, `rebuildSnapshots`.

Writes / lifecycle (LLM gets a friendly per-action summary): `openApp`, `createBook`, `deleteBook`, `upsertAccount`, `addEntry`, `voidEntry`, `setOpeningBalances`.

Sidebar preview cards (subset of writes): `openApp`, `createBook`, `upsertAccount`, `addEntry`, `voidEntry`, `setOpeningBalances`. `deleteBook` gets a friendly LLM message but no card.

## Test plan

- [ ] Sidebar shows cards only for actions that set `data`; silent ops (`getBooks`, `deleteBook`, `getReport`, …) leave no empty card behind.
- [ ] LLM can call `openApp` once and immediately reason about the books list without a `getBooks` round-trip.
- [ ] LLM can call `addEntry` and reference the returned entry id for a follow-up `voidEntry`.
- [ ] Delete the last book from the Settings tab → create a new book → the new book's gate engages and the View routes to Opening (regression of the race fixed in #1085, now reinforced by removing server-side active state).
- [ ] Switch books across multiple browser tabs → no cross-tab interference (selection is per-tab in localStorage).
- [ ] All 8 locales render the new `journalList.edit` string.
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` clean; accounting e2e (4 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book selections now persist in your browser instead of the server, ensuring your preferences remain even without network connectivity.

* **Bug Fixes**
  * Improved form preview functionality with enhanced data handling.

* **Improvements**
  * Accounting operations now require explicit book selection, streamlining the workflow and removing ambiguous fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->