### PR TITLE
refactor(memory): replace hardcoded path literals with WORKSPACE_DIRS / WORKSPACE_FILES

### DIFF
--- a/server/workspace/memory/io.ts
+++ b/server/workspace/memory/io.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 
 import { parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown/frontmatter.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { WORKSPACE_DIRS, WORKSPACE_FILES } from "../paths.js";
 import { readDirSafe, readDirSafeAsync, readTextSafe, readTextSafeSync, statSafe, statSafeAsync } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
 import { isMemoryType, type MemoryEntry, type MemoryType } from "./types.js";
@@ -22,11 +23,11 @@ import { isMemoryType, type MemoryEntry, type MemoryType } from "./types.js";
 // On-disk directory and index file for typed memory entries.
 // Callers pass the workspace root; this returns the absolute paths.
 export function memoryDirOf(workspaceRoot: string): string {
-  return path.join(workspaceRoot, "conversations", "memory");
+  return path.join(workspaceRoot, WORKSPACE_DIRS.memoryDir);
 }
 
 export function memoryIndexOf(workspaceRoot: string): string {
-  return path.join(memoryDirOf(workspaceRoot), "MEMORY.md");
+  return path.join(workspaceRoot, WORKSPACE_FILES.memoryIndex);
 }
 
 // Load every entry from `<workspaceRoot>/conversations/memory/`. The
@@ -61,7 +62,7 @@ export async function writeMemoryEntry(workspaceRoot: string, entry: MemoryEntry
   const absPath = path.join(dir, filename);
   const content = serializeWithFrontmatter({ name: entry.name, description: entry.description, type: entry.type }, entry.body);
   await writeFileAtomic(absPath, content, { uniqueTmp: true });
-  return path.posix.join("conversations", "memory", filename);
+  return path.posix.join(WORKSPACE_DIRS.memoryDir, filename);
 }
 
 // Slug shape gate. Allows arbitrary unicode (so non-ASCII names slug

--- a/server/workspace/memory/migrate.ts
+++ b/server/workspace/memory/migrate.ts
@@ -25,6 +25,7 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { readTextSafe } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { WORKSPACE_FILES } from "../paths.js";
 import { regenerateIndex, writeMemoryEntry } from "./io.js";
 import { isMemoryType, slugifyMemoryName, type MemoryEntry, type MemoryType } from "./types.js";
 
@@ -71,7 +72,7 @@ const CLASSIFY_CONCURRENCY = 4;
 const PROGRESS_LOG_INTERVAL = 5;
 
 export async function migrateLegacyMemory(workspaceRoot: string, classify: MemoryClassifier): Promise<MigrationResult> {
-  const sourcePath = path.join(workspaceRoot, "conversations", "memory.md");
+  const sourcePath = path.join(workspaceRoot, WORKSPACE_FILES.memory);
   const raw = await readTextSafe(sourcePath);
   if (raw === null) {
     return emptyResult(true);
@@ -249,7 +250,7 @@ async function renameToBackup(sourcePath: string): Promise<void> {
 // callers don't need this — `memory.md` is created by user activity
 // or by an older mulmoclaude version.
 export async function writeLegacyMemoryForTest(workspaceRoot: string, content: string): Promise<void> {
-  const sourcePath = path.join(workspaceRoot, "conversations", "memory.md");
+  const sourcePath = path.join(workspaceRoot, WORKSPACE_FILES.memory);
   await mkdir(path.dirname(sourcePath), { recursive: true });
   await writeFileAtomic(sourcePath, content);
 }

--- a/server/workspace/memory/topic-detect.ts
+++ b/server/workspace/memory/topic-detect.ts
@@ -32,6 +32,7 @@
 import { statSync } from "node:fs";
 import path from "node:path";
 
+import { WORKSPACE_DIRS } from "../paths.js";
 import { MEMORY_TYPES } from "./types.js";
 
 function isDirectorySafe(absPath: string): boolean {
@@ -51,7 +52,7 @@ function hasAnyTypeSubdir(root: string): boolean {
 }
 
 export function hasTopicFormat(workspaceRoot: string): boolean {
-  const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
+  const memoryRoot = path.join(workspaceRoot, WORKSPACE_DIRS.memoryDir);
   // Live tree wins: any `memory/<type>/` → post-swap topic mode.
   if (hasAnyTypeSubdir(memoryRoot)) return true;
   // If live `memory/` still exists (with atomic files at the root,
@@ -61,6 +62,6 @@ export function hasTopicFormat(workspaceRoot: string): boolean {
   if (isDirectorySafe(memoryRoot)) return false;
   // Live tree absent → could be the swap window OR a fresh
   // workspace. Consult staging.
-  const stagingRoot = path.join(workspaceRoot, "conversations", "memory.next");
+  const stagingRoot = path.join(workspaceRoot, WORKSPACE_DIRS.memoryStaging);
   return hasAnyTypeSubdir(stagingRoot);
 }

--- a/server/workspace/memory/topic-io.ts
+++ b/server/workspace/memory/topic-io.ts
@@ -21,15 +21,16 @@ import { parseFrontmatter, serializeWithFrontmatter } from "../../utils/markdown
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { readDirSafe, readDirSafeAsync, readTextSafe, readTextSafeSync } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
+import { WORKSPACE_DIRS, WORKSPACE_FILES } from "../paths.js";
 import { isMemoryType, MEMORY_TYPES, type MemoryType } from "./types.js";
 import { extractH2Sections, isSafeTopicSlug, type TopicMemoryFile } from "./topic-types.js";
 
 export function topicMemoryRoot(workspaceRoot: string): string {
-  return path.join(workspaceRoot, "conversations", "memory");
+  return path.join(workspaceRoot, WORKSPACE_DIRS.memoryDir);
 }
 
 export function topicMemoryIndexPath(workspaceRoot: string): string {
-  return path.join(topicMemoryRoot(workspaceRoot), "MEMORY.md");
+  return path.join(workspaceRoot, WORKSPACE_FILES.memoryIndex);
 }
 
 export function topicFilePath(workspaceRoot: string, type: MemoryType, topic: string): string {
@@ -92,7 +93,7 @@ export async function writeTopicFile(workspaceRoot: string, file: TopicMemoryFil
   const absPath = path.join(dir, `${file.topic}.md`);
   const content = serializeWithFrontmatter({ type: file.type, topic: file.topic }, file.body);
   await writeFileAtomic(absPath, content, { uniqueTmp: true });
-  return path.posix.join("conversations", "memory", file.type, `${file.topic}.md`);
+  return path.posix.join(WORKSPACE_DIRS.memoryDir, file.type, `${file.topic}.md`);
 }
 
 // Rebuild `MEMORY.md` from the live topic files. Sorted by type

--- a/server/workspace/memory/topic-migrate.ts
+++ b/server/workspace/memory/topic-migrate.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { WORKSPACE_DIRS } from "../paths.js";
 import { loadAllMemoryEntries } from "./io.js";
 import { MEMORY_TYPES, type MemoryEntry, type MemoryType } from "./types.js";
 import type { ClusterMap, ClusterTopic, MemoryClusterer } from "./topic-cluster.js";
@@ -37,10 +38,8 @@ export interface TopicMigrationResult {
   stagingPath: string;
 }
 
-export const STAGING_DIR_NAME = "memory.next";
-
 export function topicStagingPath(workspaceRoot: string): string {
-  return path.join(workspaceRoot, "conversations", STAGING_DIR_NAME);
+  return path.join(workspaceRoot, WORKSPACE_DIRS.memoryStaging);
 }
 
 interface WrittenTopic {

--- a/server/workspace/memory/topic-run.ts
+++ b/server/workspace/memory/topic-run.ts
@@ -30,6 +30,7 @@ import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { runClaudeCli, ClaudeCliNotFoundError, type Summarize } from "../journal/archivist-cli.js";
+import { WORKSPACE_DIRS, WORKSPACE_FILES } from "../paths.js";
 import { loadAllMemoryEntries } from "./io.js";
 import { makeLlmMemoryClusterer } from "./topic-cluster.js";
 import { clusterAtomicIntoStaging, topicStagingPath } from "./topic-migrate.js";
@@ -52,7 +53,7 @@ export interface RunTopicMigrationDeps {
 // swap-in-progress or a crash mid-swap), the runner must drop into
 // the "existing staging detected" retry-swap branch below, not exit.
 function memoryTreeIsTopicFormat(workspaceRoot: string): boolean {
-  const memoryRoot = path.join(workspaceRoot, "conversations", "memory");
+  const memoryRoot = path.join(workspaceRoot, WORKSPACE_DIRS.memoryDir);
   for (const type of MEMORY_TYPES) {
     try {
       if (statSync(path.join(memoryRoot, type)).isDirectory()) return true;
@@ -99,7 +100,7 @@ export async function runTopicMigrationOnce(workspaceRoot: string, deps: RunTopi
   // so there's nothing to defer for; any other error is swallowed
   // and the runner proceeds — a permission glitch should never block
   // the topic restructure.
-  const legacyPath = path.join(workspaceRoot, "conversations", "memory.md");
+  const legacyPath = path.join(workspaceRoot, WORKSPACE_FILES.memory);
   let legacyStat: ReturnType<typeof statSync> | null;
   try {
     legacyStat = statSync(legacyPath);

--- a/server/workspace/memory/topic-swap.ts
+++ b/server/workspace/memory/topic-swap.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { WORKSPACE_DIRS } from "../paths.js";
 import { topicStagingPath } from "./topic-migrate.js";
 
 export interface SwapResult {
@@ -35,7 +36,7 @@ export interface SwapResult {
 
 export async function swapStagingIntoMemory(workspaceRoot: string): Promise<SwapResult> {
   const stagingPath = topicStagingPath(workspaceRoot);
-  const memoryPath = path.join(workspaceRoot, "conversations", "memory");
+  const memoryPath = path.join(workspaceRoot, WORKSPACE_DIRS.memoryDir);
   const stagingExists = await pathExists(stagingPath);
   if (!stagingExists) {
     return { swapped: false, backupPath: null, reason: "staging dir not found" };

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -48,6 +48,12 @@ export const WORKSPACE_DIRS = {
   // single-file `memory.md`; the legacy file is kept as
   // `memory.md.backup` after migration.
   memoryDir: "conversations/memory",
+  // Staging dir for the atomic→topic migration (#1070 PR-A). Cluster
+  // output lands here; the user reviews via `diff`, then `topic-swap`
+  // promotes it to `memoryDir`. The dir name is also matched verbatim
+  // by `topicStagingPath` and the swap-window detection in
+  // `topic-detect.ts`, so changes here ripple through both places.
+  memoryStaging: "conversations/memory.next",
   summaries: "conversations/summaries",
   // Tool-trace output for WebSearch (one .md per search, referenced
   // from chat JSONL `contentRef`). Lives alongside chat/ so search
@@ -134,6 +140,7 @@ export const WORKSPACE_PATHS = {
   sources: path.join(workspacePath, WORKSPACE_DIRS.sources),
   attachments: path.join(workspacePath, WORKSPACE_DIRS.attachments),
   memoryDir: path.join(workspacePath, WORKSPACE_DIRS.memoryDir),
+  memoryStaging: path.join(workspacePath, WORKSPACE_DIRS.memoryStaging),
   summaries: path.join(workspacePath, WORKSPACE_DIRS.summaries),
   searches: path.join(workspacePath, WORKSPACE_DIRS.searches),
   htmls: path.join(workspacePath, WORKSPACE_DIRS.htmls),

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -32,6 +32,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "images",
     "markdowns",
     "memoryDir",
+    "memoryStaging",
     "news",
     "roles",
     "scheduler",


### PR DESCRIPTION
## Summary

Sweep across the memory subsystem to replace hardcoded `"conversations"` / `"memory"` / `"memory.next"` / `"memory.md"` literals with the canonical workspace constants. Per CLAUDE.md: "NEVER hardcode workspace paths — use WORKSPACE_PATHS / WORKSPACE_DIRS / WORKSPACE_FILES constants".

CodeRabbit reviews on #1058, #1072, and #1076 all flagged the same class of issue at multiple sites; bundling into one PR keeps the diff coherent (one commit, one theme).

Adds `WORKSPACE_DIRS.memoryStaging = "conversations/memory.next"` — used by `topicStagingPath` and the swap-window detection in `topic-detect.ts`. Drops the now-redundant `STAGING_DIR_NAME` export from `topic-migrate.ts` (it was only referenced inside the same file).

## Items to Confirm / Review

- All 7 memory modules pass through the same constants now: io, migrate, topic-io, topic-swap, topic-migrate, topic-run, topic-detect.
- `WORKSPACE_PATHS.memoryStaging` added so the path-shape snapshot test stays consistent and out-of-process consumers can address staging if needed.
- No behavioural change — only literal → constant substitution.
- Test snapshot in `test/workspace/test_paths_shape.ts` updated to include `memoryStaging`.

## User Prompt

PR Quality Sweep covering 24h of merged PRs. After the user confirmed all 53 findings should be addressed (with markdown nits in archived plan files skipped), the remaining 35 items got batched into 12 PRs. This is **batch B1**: memory-subsystem constants sweep, covering items 5.1, 5.3, 9.2, 9.4, 9.6, 11.5 from `plans/sweep-2026-05-01/all-findings.md`.

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
- [x] `test_paths_shape.ts` snapshot updated for the new `memoryStaging` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)