### PR TITLE
fix(memory): legacy migration correctness — slug seeding + retry-on-empty + split

### DIFF
--- a/server/workspace/memory/migrate.ts
+++ b/server/workspace/memory/migrate.ts
@@ -26,8 +26,8 @@ import { readTextSafe } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { WORKSPACE_FILES } from "../paths.js";
-import { regenerateIndex, writeMemoryEntry } from "./io.js";
-import { isMemoryType, slugifyMemoryName, type MemoryEntry, type MemoryType } from "./types.js";
+import { loadAllMemoryEntries, regenerateIndex, writeMemoryEntry } from "./io.js";
+import { isMemoryType, MEMORY_TYPES, slugifyMemoryName, type MemoryEntry, type MemoryType } from "./types.js";
 
 export interface MemoryClassification {
   type: MemoryType;
@@ -74,9 +74,7 @@ const PROGRESS_LOG_INTERVAL = 5;
 export async function migrateLegacyMemory(workspaceRoot: string, classify: MemoryClassifier): Promise<MigrationResult> {
   const sourcePath = path.join(workspaceRoot, WORKSPACE_FILES.memory);
   const raw = await readTextSafe(sourcePath);
-  if (raw === null) {
-    return emptyResult(true);
-  }
+  if (raw === null) return emptyResult(true);
 
   const candidates = parseCandidates(raw);
   log.info("memory", "migration: classifying candidates", {
@@ -84,44 +82,87 @@ export async function migrateLegacyMemory(workspaceRoot: string, classify: Memor
     concurrency: CLASSIFY_CONCURRENCY,
   });
   const classifications = await classifyInParallel(classify, candidates);
+  const usedSlugs = await seedUsedSlugs(workspaceRoot);
+  const result = await processCandidates(workspaceRoot, candidates, classifications, usedSlugs);
+  await finalizeMigration(workspaceRoot, sourcePath, candidates.length, result);
+  return result;
+}
 
+// Pre-populate the slug-collision set with slugs that already
+// exist on disk. Without this, a re-run after a partial migration
+// (or after the user manually added a typed entry) can synthesize
+// the same slug and `writeMemoryEntry` would overwrite the prior
+// file (#1058 review).
+async function seedUsedSlugs(workspaceRoot: string): Promise<Set<string>> {
+  const existing = await loadAllMemoryEntries(workspaceRoot);
+  return new Set(existing.map((entry) => entry.slug));
+}
+
+async function processCandidates(
+  workspaceRoot: string,
+  candidates: readonly MemoryCandidate[],
+  classifications: readonly (MemoryClassification | null)[],
+  usedSlugs: Set<string>,
+): Promise<MigrationResult> {
   const result = emptyResult(false);
-  const usedSlugs = new Set<string>();
-
   for (let index = 0; index < candidates.length; index += 1) {
-    const classification = classifications[index];
-    const candidate = candidates[index];
-    if (!classification) {
-      result.skippedByClassifier += 1;
-    } else {
-      const entry = buildEntry(candidate, classification, usedSlugs);
-      try {
-        await writeMemoryEntry(workspaceRoot, entry);
-        usedSlugs.add(entry.slug);
-        result.written[entry.type] += 1;
-      } catch (err) {
-        log.warn("memory", "migration: write failed", {
-          slug: entry.slug,
-          error: errorMessage(err),
-        });
-        result.writeErrors += 1;
-      }
-    }
-    const processed = index + 1;
-    if (processed % PROGRESS_LOG_INTERVAL === 0 || processed === candidates.length) {
-      log.info("memory", "migration: progress", {
-        processed,
-        total: candidates.length,
-        written: result.written,
-        skippedByClassifier: result.skippedByClassifier,
-        writeErrors: result.writeErrors,
-      });
-    }
+    await migrateOneCandidate(workspaceRoot, candidates[index], classifications[index], usedSlugs, result);
+    logProgress(index + 1, candidates.length, result);
   }
+  return result;
+}
 
+async function migrateOneCandidate(
+  workspaceRoot: string,
+  candidate: MemoryCandidate,
+  classification: MemoryClassification | null,
+  usedSlugs: Set<string>,
+  result: MigrationResult,
+): Promise<void> {
+  if (!classification) {
+    result.skippedByClassifier += 1;
+    return;
+  }
+  const entry = buildEntry(candidate, classification, usedSlugs);
+  try {
+    await writeMemoryEntry(workspaceRoot, entry);
+    usedSlugs.add(entry.slug);
+    result.written[entry.type] += 1;
+  } catch (err) {
+    log.warn("memory", "migration: write failed", { slug: entry.slug, error: errorMessage(err) });
+    result.writeErrors += 1;
+  }
+}
+
+function logProgress(processed: number, total: number, result: MigrationResult): void {
+  if (processed % PROGRESS_LOG_INTERVAL !== 0 && processed !== total) return;
+  log.info("memory", "migration: progress", {
+    processed,
+    total,
+    written: result.written,
+    skippedByClassifier: result.skippedByClassifier,
+    writeErrors: result.writeErrors,
+  });
+}
+
+// Index regen + legacy backup are gated on "migration actually
+// produced something". If every candidate failed (classifier
+// returned null for all, or every write threw), leaving
+// `memory.md` in place lets a future server start retry without
+// manual recovery (#1058 review). Empty source (no candidates
+// parsed) still gets renamed — the source is exhausted regardless.
+async function finalizeMigration(workspaceRoot: string, sourcePath: string, candidateCount: number, result: MigrationResult): Promise<void> {
+  const totalWritten = MEMORY_TYPES.reduce((sum, type) => sum + result.written[type], 0);
+  if (totalWritten === 0 && candidateCount > 0) {
+    log.warn("memory", "migration: no entries written, leaving legacy source for retry", {
+      candidateCount,
+      skippedByClassifier: result.skippedByClassifier,
+      writeErrors: result.writeErrors,
+    });
+    return;
+  }
   await regenerateIndex(workspaceRoot);
   await renameToBackup(sourcePath);
-  return result;
 }
 
 // Classify candidates with bounded concurrency. Workers pull

--- a/test/workspace/memory/test_migrate.ts
+++ b/test/workspace/memory/test_migrate.ts
@@ -139,4 +139,57 @@ describe("memory/migrate — edge cases", () => {
       await rm(fresh, { recursive: true, force: true });
     }
   });
+
+  it("leaves the legacy source in place when zero entries got written, so a later run can retry", async () => {
+    // Reproduces the #1058 review concern: if the classifier
+    // returned null for every candidate (or every write threw),
+    // the prior code still renamed `memory.md` → `.backup`,
+    // stranding the data unrecoverably.
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-noop-"));
+    try {
+      const sourcePath = path.join(fresh, "conversations", "memory.md");
+      await writeLegacyMemoryForTest(fresh, ["# Memory", "## Junk", "- one", "- two", ""].join("\n"));
+      await migrateLegacyMemory(fresh, async () => null);
+      // Source still present, no .backup yet.
+      const sourceStat = await stat(sourcePath);
+      assert.ok(sourceStat.isFile());
+      const backupGone = await stat(`${sourcePath}.backup`).catch(() => null);
+      assert.equal(backupGone, null, "backup must NOT exist when nothing was written");
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds the slug-dedupe set from existing entries so a re-run can't overwrite a prior file", async () => {
+    // Reproduces the #1058 review concern: previously `usedSlugs`
+    // started empty, so a re-run that re-classified the same
+    // bullet would synthesize the same slug and `writeMemoryEntry`
+    // would happily overwrite the prior file.
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-memory-mig-seed-"));
+    try {
+      // Seed an existing entry with the slug "preference_yarn".
+      const { writeMemoryEntry } = await import("../../../server/workspace/memory/io.js");
+      await writeMemoryEntry(fresh, {
+        name: "yarn (existing)",
+        description: "pinned",
+        type: "preference",
+        body: "yarn を使う",
+        slug: "preference_yarn",
+      });
+      // Now run migration on a memory.md that would synthesize the
+      // same slug.
+      await writeLegacyMemoryForTest(fresh, ["# Memory", "## Preferences", "- yarn を使う", ""].join("\n"));
+      const result = await migrateLegacyMemory(fresh, classifierFor({ yarn: "preference" }));
+      // Should still write, but under a deduped slug — and the
+      // prior file should remain unchanged.
+      const all = await loadAllMemoryEntries(fresh);
+      const yarn = all.find((entry) => entry.slug === "preference_yarn");
+      assert.ok(yarn, "the original `preference_yarn` entry must still be present");
+      assert.equal(yarn.name, "yarn (existing)", "the original entry's name must be preserved");
+      assert.equal(result.writeErrors, 0);
+      assert.equal(all.length, 2, "migration should add a deduped second entry, not overwrite the first");
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Three CodeRabbit findings on PR #1058's legacy `memory.md` → typed-entries migration:

1. **Slug dedupe didn't seed from existing entries.** `usedSlugs` started empty each run, so a re-run after a partial migration (or after the user manually added a typed entry) could synthesize a colliding slug and `writeMemoryEntry` would silently overwrite the prior file. Now seeds from `loadAllMemoryEntries(workspaceRoot)` before generating any new slugs.
2. **`memory.md` got renamed even when zero entries were written.** If the classifier returned null for every candidate (LLM timeout, schema mismatch, etc.), the prior code still ran `renameToBackup`, stranding the source so a later restart couldn't retry. Now skips the rename + index regen when the result has zero writes AND the source had at least one candidate. Empty source (no candidates parsed) still gets renamed — the source is exhausted regardless.
3. **`migrateLegacyMemory` was 52 lines, way over the 20-line guideline.** Split into `seedUsedSlugs`, `processCandidates`, `migrateOneCandidate`, `logProgress`, `finalizeMigration` helpers.

## Items to Confirm / Review

- The retry-on-empty gate uses `MEMORY_TYPES.reduce(...)` to total writes. Tests added for both the all-skipped and the all-write-error paths (the latter via the existing test that uses a malformed verdict).
- Slug-dedupe seeding test seeds an existing `preference_yarn` entry, then runs migration on input that would synthesize the same slug. Asserts both files exist after migration and the original is untouched.
- The split keeps the public API identical (`migrateLegacyMemory(workspaceRoot, classify)`); helpers are module-local.

## Base branch

This PR stacks on top of #1090 (memory constants sweep) — they share the `WORKSPACE_FILES` import. Merge order: #1090 first, then this. GitHub will rebase/retarget automatically once #1090 lands.

## User Prompt

PR Quality Sweep covering 24h of merged PRs. Batch B2: legacy memory migration correctness, covering items 5.2, 5.4, 5.5 from `plans/sweep-2026-05-01/all-findings.md`.

## Test plan

- [x] `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
- [x] 6 migrate tests pass (4 existing + 2 new for retry-on-empty + slug-seeding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)