### PR TITLE
fix(memory): topic error-path polish — don't lie about success

### DIFF
--- a/server/workspace/memory/topic-migrate.ts
+++ b/server/workspace/memory/topic-migrate.ts
@@ -66,13 +66,21 @@ export async function clusterAtomicIntoStaging(workspaceRoot: string, clusterer:
   // swap would happily promote.
   await resetStaging(stagingPath);
   let map: ClusterMap | null = null;
+  let clustererThrew = false;
   try {
     map = await clusterer(entries);
   } catch (err) {
+    clustererThrew = true;
     log.error("memory", "topic-migrate: clusterer threw", { error: errorMessage(err) });
   }
   if (!map) {
-    if (map === null) log.warn("memory", "topic-migrate: clusterer returned null");
+    // Only warn about a graceful null return when the clusterer
+    // didn't already log a throw. Without this, a hard failure
+    // (claude CLI missing, schema mismatch, etc.) showed up as
+    // BOTH `clusterer threw` AND `clusterer returned null`, which
+    // misleads readers into thinking there were two distinct
+    // failure modes (#1072 review).
+    if (!clustererThrew) log.warn("memory", "topic-migrate: clusterer returned null");
     await rm(stagingPath, { recursive: true, force: true });
     return { ...emptyResult(stagingPath), inputCount: entries.length };
   }

--- a/server/workspace/memory/topic-run.ts
+++ b/server/workspace/memory/topic-run.ts
@@ -123,15 +123,27 @@ export async function runTopicMigrationOnce(workspaceRoot: string, deps: RunTopi
   log.info("memory", "topic-run: starting", { entryCount: entries.length });
   try {
     const result = await clusterAtomicIntoStaging(workspaceRoot, clusterer);
+    if (result.noop) {
+      // `clusterAtomicIntoStaging` already logged the failure cause
+      // (`clusterer threw` or `clusterer returned null`) and rm'd
+      // the staging dir. Logging "staged" here would tell the user
+      // to `diff` a directory that no longer exists (#1076 review).
+      log.warn("memory", "topic-run: cluster did not produce staging — see prior log entry");
+      return;
+    }
     log.info("memory", "topic-run: staged", {
       stagingPath: result.stagingPath,
       topicCounts: result.topicCounts,
       bulletsLost: result.bulletsLost,
     });
-    if (!result.noop) {
-      await runSwap(workspaceRoot);
-    }
+    await runSwap(workspaceRoot);
   } catch (err) {
+    // Defensive: `makeLlmMemoryClusterer` swallows summarize errors
+    // and returns null today, and `clusterAtomicIntoStaging` doesn't
+    // re-throw, so this branch is currently unreachable. Kept so a
+    // future change in the clusterer error contract surfaces a
+    // visible log instead of an unhandled rejection (the runner is
+    // invoked as a floating promise on startup).
     if (err instanceof ClaudeCliNotFoundError) {
       log.warn("memory", "topic-run: claude CLI not on PATH; topic restructure deferred");
       return;

--- a/server/workspace/memory/topic-swap.ts
+++ b/server/workspace/memory/topic-swap.ts
@@ -57,10 +57,12 @@ export async function swapStagingIntoMemory(workspaceRoot: string): Promise<Swap
   } catch (err) {
     log.error("memory", "topic-swap: staging rename failed", { from: stagingPath, to: memoryPath, error: errorMessage(err) });
     // Try to put the backup back so the workspace isn't left empty.
+    let rollbackFailed = false;
     if (backupPath) {
       try {
         await rename(backupPath, memoryPath);
       } catch (rollbackErr) {
+        rollbackFailed = true;
         log.error("memory", "topic-swap: rollback failed; manual intervention needed", {
           backupPath,
           memoryPath,
@@ -68,7 +70,12 @@ export async function swapStagingIntoMemory(workspaceRoot: string): Promise<Swap
         });
       }
     }
-    return { swapped: false, backupPath: null, reason: "staging rename failed" };
+    // When rollback ALSO fails, the prior data still lives at
+    // `backupPath`. Returning `backupPath: null` would tell callers
+    // "no recovery point exists" and they'd give up — surface the
+    // path so a human (or a retry loop) can move it back manually
+    // (#1072 review).
+    return { swapped: false, backupPath: rollbackFailed ? backupPath : null, reason: "staging rename failed" };
   }
 
   // Park the backup INSIDE the new memory dir so it travels with


### PR DESCRIPTION
## Summary

Three CodeRabbit findings on PRs #1072 / #1076 about the same class of issue: the topic-migration chain's error paths log or return things that contradict what actually happened.

1. **`topic-swap.ts` rollback failure** — when staging rename fails AND rollback (putting backup back as memory/) also fails, the prior data still lives at `backupPath`. Old code returned `backupPath: null`, telling callers "no recovery point" and they'd give up. Now surfaces the path when rollback failed.
2. **`topic-migrate.ts` cluster null vs throw** — a thrown clusterer logged `clusterer threw` and then ALSO `clusterer returned null` because `map` defaulted to null. Two log lines for one failure. Now tracks `clustererThrew` to suppress the second warn.
3. **`topic-run.ts` "staged" log on swallowed failure** — `clusterAtomicIntoStaging` returns `noop: true` + rm's stagingPath on cluster failure. The subsequent "topic-run: staged" log told users to diff a directory that no longer exists. Now gates success log on `!result.noop`; emits a warn on the failure path so the prior `clusterer threw` log isn't orphaned.

## Items to Confirm / Review

- The `ClaudeCliNotFoundError` catch branch in topic-run.ts is dead today (the clusterer swallows it internally). Kept as defensive — `runTopicMigrationOnce` is invoked as a floating promise on startup, so any future change to the clusterer error contract that re-introduces a throw would otherwise produce an unhandled rejection.
- 9.5 rollback backup is not unit-tested (would require mocking `fs.rename` to fail twice). The fix itself is a 4-line change; reading it is sufficient verification.
- 9.7 / 11.7 are log-only behaviour clarifications — no new test added since the runtime semantics are unchanged.

## User Prompt

PR Quality Sweep covering 24h of merged PRs. Batch B3: topic memory error-path polish, covering items 9.5, 9.7, 11.7 from \`plans/sweep-2026-05-01/all-findings.md\`.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] No behavioural change beyond log clarification + the rollback-path return value; existing topic-swap / topic-migrate / topic-run tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery during topic migration operations, with better tracking of migration states and more robust rollback mechanisms when staging operations fail.

* **Improvements**
  * Enhanced logging to provide clearer diagnostics during migration processes, particularly for distinguishing between different failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->