### PR TITLE
fix(memory): correct prompt copy about MEMORY.md auto-regeneration (#1076 follow-up)

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -220,7 +220,7 @@ Adding a new bullet:
 2. \`Read\` that topic file. Pick the H2 section the bullet fits under (or add a new H2 if none fits — H2 sections are optional, you may also append directly under H1 for a small / new topic).
 3. Append your bullet. Keep it short, one line ideally.
 4. \`Write\` the file back.
-5. The system regenerates \`MEMORY.md\` automatically — you do NOT need to update it by hand.
+5. \`MEMORY.md\` is rebuilt during clustering and on explicit \`regenerateTopicIndex\` calls; individual topic-file writes do NOT update the index immediately. If your bullet adds a new H2 that should appear in the index right away, also \`Write\` an updated \`MEMORY.md\` line for that topic.
 
 Creating a new topic file:
 

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -226,6 +226,7 @@ Creating a new topic file:
 
 - Filename: \`<type>/<topic>.md\` where \`<topic>\` is a short lowercase ASCII slug (a-z, 0-9, hyphenated). Examples: \`interest/music.md\`, \`fact/travel.md\`, \`reference/tasks.md\`.
 - Body: H1 with a humanised topic name + bullet(s) under it. H2 sections are optional and best added once the topic has enough material to warrant grouping.
+- After the topic file is written, also \`Write\` a matching line into \`conversations/memory/MEMORY.md\` so the new topic is discoverable in the next turn's Memory context. Same caveat as adding an H2: individual topic-file writes do NOT update \`MEMORY.md\` automatically — the index is only rebuilt during clustering or on explicit \`regenerateTopicIndex\` calls.
 
 Write when: the fact is durable, not derivable from code or git history, and not already covered by an existing bullet. Update an existing bullet instead of adding a near-duplicate.
 


### PR DESCRIPTION
## Summary

Two findings from CodeRabbit on PR #1076 about the topic-format index lifecycle:

1. **11.2 prompt copy** (`server/agent/prompt.ts:215`) — the prompt told the agent "The system regenerates \`MEMORY.md\` automatically — you do NOT need to update it by hand." That's false: in the current topic-format implementation \`MEMORY.md\` is only rebuilt during clustering and on explicit \`regenerateTopicIndex\` calls. An agent that follows the old wording would leave new topics absent from the index until the next cluster pass.
2. **11.3 second-attempt scheduling** (\`server/index.ts:102\`) — already addressed in main by commit \`84dceaf8\` ("fix(memory): chain legacy + topic migrations"), which wires \`runMemoryMigrationOnce.then(runTopicMigrationOnce)\` so the topic runner picks up after legacy settles in the same boot. No additional change needed here.

## Items to Confirm / Review

- The new prompt text tells the agent: index rebuilds only at clustering / explicit regen, and asks it to update \`MEMORY.md\` itself when a write introduces a new topic. This trades a false claim for an actionable instruction.
- 11.3 closure: confirmed via \`git log -- server/index.ts\` that the chain landed in 84dceaf8 (5/1).

## User Prompt

PR Quality Sweep covering 24h of merged PRs. Batch B4: covering items 11.2, 11.3 from \`plans/sweep-2026-05-01/all-findings.md\`.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\`
- [x] No code path changes — system-prompt copy edit only

🤖 Generated with [Claude Code](https://claude.com/claude-code)