### PR TITLE
fix(memory): legacy migration polish — abort on CLI-missing, cap desc, isolate tests (#1061 follow-up)

### DIFF
--- a/server/workspace/memory/llm-classifier.ts
+++ b/server/workspace/memory/llm-classifier.ts
@@ -17,7 +17,7 @@
 import type { MemoryClassification, MemoryCandidate, MemoryClassifier } from "./migrate.js";
 import { isMemoryType, type MemoryType } from "./types.js";
 
-import type { Summarize } from "../journal/archivist-cli.js";
+import { ClaudeCliNotFoundError, type Summarize } from "../journal/archivist-cli.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
 
@@ -50,6 +50,14 @@ export function makeLlmMemoryClassifier(deps: DepsForLlmClassifier): MemoryClass
     try {
       raw = await deps.summarize(SYSTEM_PROMPT, userPrompt);
     } catch (err) {
+      // Let `ClaudeCliNotFoundError` escape so the caller can abort
+      // the whole migration. Without this, every candidate runs
+      // through the classifier, gets `null` back, and migrateLegacyMemory
+      // produces an empty result + (pre-#1091) renames the legacy file
+      // to `.backup`. Even with #1091 the user pays N classifier
+      // failures (each spawns claude) before realising the CLI is
+      // missing (#1061 review).
+      if (err instanceof ClaudeCliNotFoundError) throw err;
       log.warn("memory", "llm classifier: summarize threw", {
         preview: candidate.body.slice(0, 80),
         error: errorMessage(err),
@@ -87,7 +95,10 @@ export function parseClassifierVerdict(raw: string): MemoryClassification | null
   // The description is optional from the spec's perspective —
   // migrate.ts falls back to a body-derived description when missing.
   // But if present, normalise to a single line and cap length.
-  return desc.length > 0 ? { type: type as MemoryType, description: oneLine(desc).slice(0, 200) } : { type: type as MemoryType };
+  // Cap matches the prompt's `<=100 chars>` declaration so persisted
+  // entries never exceed the schema the classifier was told to follow
+  // (#1061 review).
+  return desc.length > 0 ? { type: type as MemoryType, description: oneLine(desc).slice(0, 100) } : { type: type as MemoryType };
 }
 
 function stripFenceAndWhitespace(raw: string): string {

--- a/server/workspace/memory/migrate.ts
+++ b/server/workspace/memory/migrate.ts
@@ -25,6 +25,7 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { readTextSafe } from "../../utils/files/safe.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { regenerateIndex, writeMemoryEntry } from "./io.js";
 import { isMemoryType, slugifyMemoryName, type MemoryEntry, type MemoryType } from "./types.js";
 
@@ -199,6 +200,12 @@ async function safeClassify(classify: MemoryClassifier, candidate: MemoryCandida
     if (verdict && isMemoryType(verdict.type)) return verdict;
     return null;
   } catch (err) {
+    // Startup-wide failures (CLI missing) MUST escape so
+    // `runMemoryMigrationOnce` can log once + leave the legacy file
+    // for retry. Without this, every candidate would silently degrade
+    // to `null` and look like normal classifier disagreement
+    // (#1061 review).
+    if (err instanceof ClaudeCliNotFoundError) throw err;
     log.warn("memory", "migration: classifier threw", {
       preview: candidate.body.slice(0, 80),
       error: errorMessage(err),

--- a/test/agent/test_memory_context.ts
+++ b/test/agent/test_memory_context.ts
@@ -3,8 +3,12 @@
 // During the brief window between PR-B shipping and migration
 // finishing, both layouts can coexist on disk. The reader must pick
 // up either, both, or neither.
+//
+// Each case spins up its own workspace via `mkdtemp` so test order
+// can't make a leftover file from one case satisfy the assertions of
+// another (#1061 review).
 
-import { after, before, describe, it } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -12,55 +16,65 @@ import path from "node:path";
 
 import { buildMemoryContext } from "../../server/agent/prompt.js";
 
+async function scopedWorkspace<T>(label: string, body: (root: string) => Promise<T> | T): Promise<T> {
+  const root = await mkdtemp(path.join(tmpdir(), `mulmoclaude-mem-ctx-${label}-`));
+  try {
+    return await body(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
 describe("buildMemoryContext", () => {
-  let scoped: string;
-
-  before(async () => {
-    scoped = await mkdtemp(path.join(tmpdir(), "mulmoclaude-mem-ctx-"));
-  });
-
-  after(async () => {
-    await rm(scoped, { recursive: true, force: true });
-  });
-
-  it("emits only the helps pointer on a fresh workspace (no memory layouts)", () => {
-    const out = buildMemoryContext(scoped);
-    assert.match(out, /## Memory/);
-    assert.match(out, /config\/helps\/index\.md/);
-    // No legacy text and no typed entries.
-    assert.doesNotMatch(out, /yarn/);
-    assert.doesNotMatch(out, /印象派/);
+  it("emits only the helps pointer on a fresh workspace (no memory layouts)", async () => {
+    await scopedWorkspace("fresh", (root) => {
+      const out = buildMemoryContext(root);
+      assert.match(out, /## Memory/);
+      assert.match(out, /config\/helps\/index\.md/);
+      assert.doesNotMatch(out, /yarn/);
+      assert.doesNotMatch(out, /印象派/);
+    });
   });
 
   it("includes legacy memory.md when present", async () => {
-    const legacyDir = path.join(scoped, "conversations");
-    await mkdir(legacyDir, { recursive: true });
-    await writeFile(path.join(legacyDir, "memory.md"), "## Preferences\n- yarn を使う\n", "utf-8");
+    await scopedWorkspace("legacy", async (root) => {
+      const legacyDir = path.join(root, "conversations");
+      await mkdir(legacyDir, { recursive: true });
+      await writeFile(path.join(legacyDir, "memory.md"), "## Preferences\n- yarn を使う\n", "utf-8");
 
-    const out = buildMemoryContext(scoped);
-    assert.match(out, /yarn を使う/);
+      const out = buildMemoryContext(root);
+      assert.match(out, /yarn を使う/);
+    });
   });
 
-  it("includes typed entries from conversations/memory/", async () => {
-    const memDir = path.join(scoped, "conversations", "memory");
-    await mkdir(memDir, { recursive: true });
-    await writeFile(
-      path.join(memDir, "interest_impressionism.md"),
-      "---\nname: 印象派\ndescription: 美術鑑賞の主軸\ntype: interest\n---\n\nMonet, Renoir, etc.\n",
-      "utf-8",
-    );
-    // The system-owned index file is skipped by the reader (otherwise
-    // the link list would appear twice).
-    await writeFile(path.join(memDir, "MEMORY.md"), "# Memory\n\n- [印象派](interest_impressionism.md) — 美術鑑賞の主軸\n", "utf-8");
+  it("includes typed entries from conversations/memory/ alongside legacy memory.md", async () => {
+    await scopedWorkspace("typed", async (root) => {
+      // Seed both layouts so we exercise the dual-mode reader's "both
+      // present" branch (the only branch that surfaced the previous
+      // test-order coupling).
+      const convDir = path.join(root, "conversations");
+      await mkdir(convDir, { recursive: true });
+      await writeFile(path.join(convDir, "memory.md"), "## Preferences\n- yarn を使う\n", "utf-8");
 
-    const out = buildMemoryContext(scoped);
-    assert.match(out, /印象派/);
-    assert.match(out, /Monet/);
-    // legacy text from the previous test still in there.
-    assert.match(out, /yarn を使う/);
-    // index file is not duplicated.
-    const occurrences = (out.match(/interest_impressionism\.md/g) ?? []).length;
-    assert.equal(occurrences, 0, "the index link target should not leak through the reader");
+      const memDir = path.join(convDir, "memory");
+      await mkdir(memDir, { recursive: true });
+      await writeFile(
+        path.join(memDir, "interest_impressionism.md"),
+        "---\nname: 印象派\ndescription: 美術鑑賞の主軸\ntype: interest\n---\n\nMonet, Renoir, etc.\n",
+        "utf-8",
+      );
+      // The system-owned index file is skipped by the reader (otherwise
+      // the link list would appear twice).
+      await writeFile(path.join(memDir, "MEMORY.md"), "# Memory\n\n- [印象派](interest_impressionism.md) — 美術鑑賞の主軸\n", "utf-8");
+
+      const out = buildMemoryContext(root);
+      assert.match(out, /印象派/);
+      assert.match(out, /Monet/);
+      assert.match(out, /yarn を使う/);
+      // index file is not duplicated.
+      const occurrences = (out.match(/interest_impressionism\.md/g) ?? []).length;
+      assert.equal(occurrences, 0, "the index link target should not leak through the reader");
+    });
   });
 
   it("skips dotfiles in the typed memory directory", async () => {

--- a/test/workspace/memory/test_run.ts
+++ b/test/workspace/memory/test_run.ts
@@ -18,7 +18,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runMemoryMigrationOnce } from "../../../server/workspace/memory/run.js";
-import type { Summarize } from "../../../server/workspace/journal/archivist-cli.js";
+import { ClaudeCliNotFoundError, type Summarize } from "../../../server/workspace/journal/archivist-cli.js";
 
 describe("memory/run — idempotency guards", () => {
   let scoped: string;
@@ -137,6 +137,45 @@ describe("memory/run — idempotency guards", () => {
       const backupAfter = await stat(`${legacyPath}.backup`).catch(() => null);
       assert.equal(legacyAfter, null, "legacy file should have been renamed");
       assert.ok(backupAfter !== null && backupAfter.isFile(), ".backup should exist post-migration");
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts cleanly when the Claude CLI is missing — legacy left in place for a later retry", async () => {
+    // Reproduces the #1061 review concern: previously the classifier
+    // swallowed `ClaudeCliNotFoundError` per-candidate and returned
+    // null, so the migration ran to completion with zero writes,
+    // wrote an empty `MEMORY.md`, and renamed `memory.md` to
+    // `.backup` — losing the legacy text from the prompt entirely.
+    // After the fix, the error escapes, the runner catches it, logs
+    // a single warn, and leaves both files untouched.
+    const fresh = await mkdtemp(path.join(tmpdir(), "mulmoclaude-mem-run-cli-missing-"));
+    try {
+      const legacyPath = path.join(fresh, "conversations", "memory.md");
+      await mkdir(path.dirname(legacyPath), { recursive: true });
+      // Same padding strategy as the prior test — get past the
+      // 64-byte placeholder threshold so the runner reaches the
+      // classifier path, where the CLI-missing error would otherwise
+      // have been silently swallowed.
+      await writeFile(
+        legacyPath,
+        ["# Memory", "", "Distilled facts about you and your work.", "", "## Preferences", "- yarn を使う（npm は使わない）", "- Emacs を愛用", ""].join("\n"),
+        "utf-8",
+      );
+
+      const summarize: Summarize = async () => {
+        throw new ClaudeCliNotFoundError();
+      };
+      await runMemoryMigrationOnce(fresh, { summarize });
+
+      // Legacy file untouched, no .backup created, no typed entries.
+      const legacyAfter = await stat(legacyPath).catch(() => null);
+      assert.ok(legacyAfter !== null && legacyAfter.isFile(), "legacy file must remain untouched when CLI is missing");
+      const backupAfter = await stat(`${legacyPath}.backup`).catch(() => null);
+      assert.equal(backupAfter, null, ".backup must NOT be created on CLI-missing");
+      const memDir = await stat(path.join(fresh, "conversations", "memory")).catch(() => null);
+      assert.equal(memDir, null, "no typed memory dir must be created on CLI-missing");
     } finally {
       await rm(fresh, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Three CodeRabbit findings on PR #1061 (memory storage wire):

1. **Description-length cap mismatch** (\`llm-classifier.ts:31\`) — prompt declares \`<=100 chars>\` but parser truncated at 200. Lower cap to 100 so persisted entries match the declared schema.
2. **CLI-missing aborts migration cleanly** (\`run.ts\` / classifier / safeClassify) — previously the classifier swallowed every \`summarize\` failure (including \`ClaudeCliNotFoundError\`) and returned null. With the CLI missing, every candidate got null, the migration ran to completion with zero writes, wrote an empty \`MEMORY.md\`, and renamed \`memory.md\` → \`.backup\` — silently dropping the legacy text from every future prompt. Re-throw \`ClaudeCliNotFoundError\` so it escapes to \`runMemoryMigrationOnce\`'s outer catch.
3. **Test isolation** (\`test_memory_context.ts\`) — first three cases shared a \`scoped\` workspace, making them order-dependent. Refactored to a \`scopedWorkspace\` helper that mkdtemps per case.

## Items to Confirm / Review

- The CLI-missing fix preserves the per-candidate "classifier disagreed" semantic (returns null) for every error EXCEPT \`ClaudeCliNotFoundError\`. Other classifier-internal errors (timeout, malformed JSON, schema mismatch) still get swallowed per-candidate as before.
- New regression test \`aborts cleanly when the Claude CLI is missing\` asserts the legacy file + .backup absence + no typed memory dir. Padding strategy (>= 64 bytes) borrowed from the existing test so the runner reaches the classifier branch.
- The third case in the now-isolated \`buildMemoryContext\` suite explicitly seeds BOTH layouts (legacy + typed) since that's the dual-mode path the test was meant to cover — previously it relied on leftover state from case #2 to land in that state.
- Item 6.1 (markdown nit \`test_llm-classifier.ts\` ↔ \`test_llm_classifier.ts\` reference in an archived plan file) skipped per user direction (markdown nits in archived plans are not in scope).

## User Prompt

PR Quality Sweep covering 24h of merged PRs. Batch B5: covering items 6.2, 6.3, 6.4 from \`plans/sweep-2026-05-01/all-findings.md\`.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] 5 \`memory/run\` tests pass (4 existing + 1 new CLI-missing regression)
- [x] 4 \`buildMemoryContext\` tests pass (refactored to per-case workspaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)