### PR TITLE
fix: tool / MIME constant cleanup (#1050 follow-up)

### DIFF
--- a/server/api/routes/image.ts
+++ b/server/api/routes/image.ts
@@ -154,7 +154,12 @@ interface SourceImage {
 async function loadSourceImage(imagePath: string): Promise<SourceImage> {
   if (isImagePath(imagePath)) {
     const data = await loadImageBase64(imagePath);
-    return { data, mimeType: "image/png" };
+    // `isImagePath` only requires `.png`, but historically `saveImage`
+    // also wrote `.jpg` / `.webp`. Defer to extension inference and
+    // fall back to `image/png` so a workspace seeded by an older build
+    // still reports a sensible MIME (#1050 review).
+    const mimeType = inferMimeFromExtension(imagePath) ?? "image/png";
+    return { data, mimeType };
   }
   if (isAttachmentPath(imagePath)) {
     const mimeType = inferMimeFromExtension(imagePath);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -46,7 +46,7 @@ const plugins: Record<string, PluginEntry> = {
   openCanvas: canvasPlugin,
   presentHtml: presentHtmlPlugin,
   presentChart: presentChartPlugin,
-  editImages: editImagesPlugin,
+  [TOOL_NAMES.editImages]: editImagesPlugin,
   present3D: Present3DPlugin.plugin,
   weather: WeatherPlugin.plugin,
 };


### PR DESCRIPTION
## Summary

Two CodeRabbit findings on PR #1050 that didn't make commit \`8ce1385b\`:

1. **\`image.ts\` hardcoded \`image/png\`** for the \`isImagePath\` branch — defers to \`inferMimeFromExtension\` now, falling back to PNG only when the extension can't be classified.
2. **\`tools/index.ts\` registry key** used string literal \`"editImages"\` — switched to \`[TOOL_NAMES.editImages]\` (mirrors the existing \`[TOOL_NAMES.manageAccounting]\` entry).

## Items to Confirm / Review

- The original B7 batch was 4 items (2.4, 2.6, 2.8, 10.2). Items 2.6 / 10.2 — and the related 2.5 / 2.7 / 10.1 — already landed in main (commits \`8ce1385b\` for #1050 and the e2e-live follow-up). Verified via grep before this PR. Only 2.4 and 2.8 remained.
- Lower-noise change set than the original tracker projected; no new tests added — the existing \`isImagePath\` / TOOL_NAMES coverage is unchanged in shape.

## User Prompt

PR Quality Sweep batch B7: items 2.4, 2.8 from \`plans/sweep-2026-05-01/all-findings.md\`. Items 2.5, 2.6, 2.7, 10.1, 10.2 already landed in main.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)