### PR TITLE
fix(i18n): localise attach-image failure message (#1045 follow-up)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -855,7 +855,7 @@ async function sendMessage(text?: string) {
       userInput.value = message;
       pastedFile.value = fileSnapshot;
       const recoverySession = sessionMap.get(currentSessionId.value);
-      if (recoverySession) pushErrorMessage(recoverySession, `Failed to attach image: ${resolved.error}`);
+      if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
       return;
     }
     attachmentForRequest = resolved.value;

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -33,6 +33,7 @@ const deMessages = {
     attachFile: "Datei anhängen",
     fileTooLarge: "Datei zu groß ({sizeMB} MB). Das Maximum beträgt 30 MB.",
     unsupportedFileType: "Dateityp nicht unterstützt. Akzeptiert: Bilder, PDF, DOCX, XLSX, PPTX, Textdateien.",
+    attachImageFailed: "Anhängen des Bildes fehlgeschlagen: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -55,6 +55,7 @@ const enMessages = {
     attachFile: "Attach file",
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",
     unsupportedFileType: "File type not supported. Accepted: images, PDF, DOCX, XLSX, PPTX, text files.",
+    attachImageFailed: "Failed to attach image: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -38,6 +38,7 @@ const esMessages = {
     attachFile: "Adjuntar archivo",
     fileTooLarge: "El archivo es demasiado grande ({sizeMB} MB). El máximo es 30 MB.",
     unsupportedFileType: "Tipo de archivo no admitido. Se aceptan: imágenes, PDF, DOCX, XLSX, PPTX y archivos de texto.",
+    attachImageFailed: "No se pudo adjuntar la imagen: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -33,6 +33,7 @@ const frMessages = {
     attachFile: "Joindre un fichier",
     fileTooLarge: "Fichier trop volumineux ({sizeMB} Mo). La limite est de 30 Mo.",
     unsupportedFileType: "Type de fichier non pris en charge. Acceptés : images, PDF, DOCX, XLSX, PPTX, fichiers texte.",
+    attachImageFailed: "Échec de l'attache de l'image : {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -40,6 +40,7 @@ const jaMessages = {
     attachFile: "ファイルを添付",
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",
     unsupportedFileType: "対応していないファイル形式です。画像・PDF・DOCX・XLSX・PPTX・テキストファイルを使用してください。",
+    attachImageFailed: "画像の添付に失敗しました: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -40,6 +40,7 @@ const koMessages = {
     attachFile: "파일 첨부",
     fileTooLarge: "파일이 너무 큽니다 ({sizeMB} MB). 최대 30 MB 까지 가능합니다.",
     unsupportedFileType: "지원되지 않는 파일 형식입니다. 이미지, PDF, DOCX, XLSX, PPTX, 텍스트 파일만 지원됩니다.",
+    attachImageFailed: "이미지를 첨부하지 못했습니다: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -33,6 +33,7 @@ const ptBRMessages = {
     attachFile: "Anexar arquivo",
     fileTooLarge: "Arquivo muito grande ({sizeMB} MB). O limite é 30 MB.",
     unsupportedFileType: "Tipo de arquivo não suportado. Aceitos: imagens, PDF, DOCX, XLSX, PPTX e arquivos de texto.",
+    attachImageFailed: "Falha ao anexar a imagem: {error}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -38,6 +38,7 @@ const zhMessages = {
     attachFile: "附加文件",
     fileTooLarge: "文件过大（{sizeMB} MB）。上限为 30 MB。",
     unsupportedFileType: "不支持的文件类型。支持:图像、PDF、DOCX、XLSX、PPTX、文本文件。",
+    attachImageFailed: "附加图片失败：{error}",
   },
   sessionHistoryPanel: {
     filters: {


### PR DESCRIPTION
## Summary

Hardcoded English fallback in \`src/App.vue:858\` — every locale saw "Failed to attach image: <reason>" regardless of UI language. CodeRabbit flagged on PR #1045.

Adds \`chatInput.attachImageFailed\` to all 8 locales (en / ja / ko / zh / es / pt-BR / fr / de) with \`{error}\` placeholder; wire \`t("chatInput.attachImageFailed", { error })\` in App.vue.

Item 2.7 (canvas auto-style i18n) from the same batch was already fixed in main commit \`8ce1385b\`.

## User Prompt

PR Quality Sweep batch B8: item 1.2 from \`plans/sweep-2026-05-01/all-findings.md\`. Item 2.7 already in main.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] All 8 locales updated; \`vue-tsc\` would otherwise fail on the schema mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)