### PR TITLE
fix(chat-service): accept path-only attachments in parseAttachments (#1050 follow-up)

### DIFF
--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -320,23 +320,34 @@ function parseAttachments(raw: unknown): Attachment[] | undefined {
   let totalBytes = 0;
   for (const item of raw) {
     if (valid.length >= MAX_ATTACHMENT_COUNT) break;
-    if (
-      item &&
-      typeof item === "object" &&
-      typeof (item as Record<string, unknown>).mimeType === "string" &&
-      typeof (item as Record<string, unknown>).data === "string"
-    ) {
-      const data = (item as Record<string, unknown>).data as string;
-      totalBytes += data.length;
+    const entry = parseOneAttachment(item);
+    if (!entry) continue;
+    if (entry.data) {
+      totalBytes += entry.data.length;
       if (totalBytes > MAX_ATTACHMENT_TOTAL_BYTES) break;
-      const entry: Attachment = {
-        mimeType: (item as Record<string, unknown>).mimeType as string,
-        data,
-      };
-      const fn = (item as Record<string, unknown>).filename;
-      if (typeof fn === "string" && fn.length > 0) entry.filename = fn;
-      valid.push(entry);
     }
+    valid.push(entry);
   }
   return valid.length > 0 ? valid : undefined;
+}
+
+// Accept either the inline `{ data, mimeType }` shape (bridges
+// shipping raw bytes) or the path-only `{ path }` shape (Vue UI and
+// any bridge that uploads to `data/attachments/` first). Either is
+// valid per the exported `Attachment` type. The earlier parser only
+// recognised the first shape, so a typed `{ path }` payload from a
+// socket client passed type-check but got silently dropped at the
+// wire boundary (#1050 review).
+function parseOneAttachment(item: unknown): Attachment | null {
+  if (!item || typeof item !== "object") return null;
+  const record = item as Record<string, unknown>;
+  const filename = typeof record.filename === "string" && record.filename.length > 0 ? record.filename : undefined;
+  if (typeof record.mimeType === "string" && typeof record.data === "string") {
+    return { mimeType: record.mimeType, data: record.data, ...(filename ? { filename } : {}) };
+  }
+  if (typeof record.path === "string" && record.path.length > 0) {
+    const mimeType = typeof record.mimeType === "string" ? record.mimeType : undefined;
+    return { path: record.path, ...(mimeType ? { mimeType } : {}), ...(filename ? { filename } : {}) };
+  }
+  return null;
 }

--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -338,14 +338,30 @@ function parseAttachments(raw: unknown): Attachment[] | undefined {
 // recognised the first shape, so a typed `{ path }` payload from a
 // socket client passed type-check but got silently dropped at the
 // wire boundary (#1050 review).
-function parseOneAttachment(item: unknown): Attachment | null {
+//
+// Wire-boundary path guard: a malicious bridge can ship arbitrary
+// strings as `path`. The downstream `isAttachmentPath` enforcement
+// in the server is the authoritative gate, but defence-in-depth at
+// each layer is required for external code (#1099 review). Reject
+// absolute paths and any traversal segment up front so a payload
+// like `path: "../../etc/passwd"` never reaches the relay.
+function isSafeAttachmentPath(value: string): boolean {
+  if (value.length === 0) return false;
+  if (value.startsWith("/") || value.startsWith("\\")) return false;
+  for (const segment of value.split(/[/\\]/)) {
+    if (segment === "..") return false;
+  }
+  return true;
+}
+
+export function parseOneAttachment(item: unknown): Attachment | null {
   if (!item || typeof item !== "object") return null;
   const record = item as Record<string, unknown>;
   const filename = typeof record.filename === "string" && record.filename.length > 0 ? record.filename : undefined;
   if (typeof record.mimeType === "string" && typeof record.data === "string") {
     return { mimeType: record.mimeType, data: record.data, ...(filename ? { filename } : {}) };
   }
-  if (typeof record.path === "string" && record.path.length > 0) {
+  if (typeof record.path === "string" && isSafeAttachmentPath(record.path)) {
     const mimeType = typeof record.mimeType === "string" ? record.mimeType : undefined;
     return { path: record.path, ...(mimeType ? { mimeType } : {}), ...(filename ? { filename } : {}) };
   }

--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -314,7 +314,7 @@ function parseMessagePayload(payload: MessagePayload): ParsedMessage {
 const MAX_ATTACHMENT_COUNT = 10;
 const MAX_ATTACHMENT_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB base64
 
-function parseAttachments(raw: unknown): Attachment[] | undefined {
+export function parseAttachments(raw: unknown): Attachment[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined;
   const valid: Attachment[] = [];
   let totalBytes = 0;
@@ -345,9 +345,16 @@ function parseAttachments(raw: unknown): Attachment[] | undefined {
 // each layer is required for external code (#1099 review). Reject
 // absolute paths and any traversal segment up front so a payload
 // like `path: "../../etc/passwd"` never reaches the relay.
+// Windows-style drive-letter absolute path (`C:\…` or `C:/…`).
+// `isSafeAttachmentPath` rejects these too — a malicious bridge
+// can't ship a host-absolute path under any platform convention
+// (#1099 review iter-2).
+const WINDOWS_DRIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
+
 function isSafeAttachmentPath(value: string): boolean {
   if (value.length === 0) return false;
   if (value.startsWith("/") || value.startsWith("\\")) return false;
+  if (WINDOWS_DRIVE_PATH_RE.test(value)) return false;
   for (const segment of value.split(/[/\\]/)) {
     if (segment === "..") return false;
   }

--- a/packages/chat-service/test/test_socket.ts
+++ b/packages/chat-service/test/test_socket.ts
@@ -4,7 +4,7 @@ import http from "http";
 import express from "express";
 import { io as ioClient, Socket as ClientSocket } from "socket.io-client";
 import { Server as SocketServer } from "socket.io";
-import { attachChatSocket, CHAT_SOCKET_EVENTS, CHAT_SOCKET_PATH, parseOneAttachment } from "../src/socket.js";
+import { attachChatSocket, CHAT_SOCKET_EVENTS, CHAT_SOCKET_PATH, parseAttachments, parseOneAttachment } from "../src/socket.js";
 import { createPushQueue } from "../src/push-queue.js";
 import type { RelayParams, RelayResult } from "../src/relay.js";
 import type { Logger } from "../src/types.js";
@@ -157,6 +157,70 @@ describe("chat-service socket — no auth", () => {
     assert.equal(forwarded[1].data, "AAAA");
     client.disconnect();
   });
+
+  it("caps attachments at MAX_ATTACHMENT_COUNT regardless of shape (#1099 iter-2)", async () => {
+    // Send 12 items mixing both shapes. The internal cap is 10;
+    // entries past that point must be dropped on the floor — and the
+    // path-only items must count toward the cap exactly like inline
+    // ones (the count gate runs before the data-byte gate).
+    const client = connectClient(harness.url, { transportId: "cli" });
+    await waitConnect(client);
+    const items: unknown[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      items.push({ path: `data/attachments/2026/05/p${i}.png` });
+      items.push({ mimeType: "image/png", data: `D${i}` });
+    }
+    const ack = await emitMessage(client, { externalChatId: "terminal", text: "cap", attachments: items });
+    assert.equal(ack.ok, true);
+    const forwarded = harness.relayCalls[0].attachments ?? [];
+    assert.equal(forwarded.length, 10, "MAX_ATTACHMENT_COUNT must cap at 10");
+    client.disconnect();
+  });
+});
+
+// Unit-level coverage for the bytes / count caps. Going through the
+// socket harness for the bytes case is impractical — socket.io's
+// default `maxHttpBufferSize` is 1MB, so a 20+MB payload trips the
+// transport cap before reaching our parser. Calling `parseAttachments`
+// directly pins the same contract without that bottleneck.
+describe("chat-service socket — parseAttachments cap behavior", () => {
+  it("caps at MAX_ATTACHMENT_COUNT (10) regardless of shape", () => {
+    const items: unknown[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      items.push({ path: `data/attachments/2026/05/p${i}.png` });
+      items.push({ mimeType: "image/png", data: `D${i}` });
+    }
+    const out = parseAttachments(items) ?? [];
+    assert.equal(out.length, 10);
+  });
+
+  it("caps inline `data` byte total at MAX_ATTACHMENT_TOTAL_BYTES; path-only entries don't add to that budget (#1099 iter-2)", () => {
+    // First inline (11MB) accepted. A path-only entry between the
+    // two inlines is also accepted (its data size is 0). The second
+    // inline (11MB) would push the running total to 22MB and break
+    // the loop, so the trailing entries never get through.
+    const elevenMB = "A".repeat(11 * 1024 * 1024);
+    const out =
+      parseAttachments([
+        { mimeType: "image/png", data: elevenMB },
+        { path: "data/attachments/2026/05/path-only.png" },
+        { mimeType: "image/png", data: elevenMB },
+        { path: "data/attachments/2026/05/after-trip.png" },
+      ]) ?? [];
+    assert.equal(out.length, 2);
+    assert.equal(out[0].data?.length, elevenMB.length);
+    assert.equal(out[1].path, "data/attachments/2026/05/path-only.png");
+  });
+
+  it("returns undefined when given a non-array", () => {
+    assert.equal(parseAttachments(undefined), undefined);
+    assert.equal(parseAttachments(null), undefined);
+    assert.equal(parseAttachments({}), undefined);
+  });
+
+  it("returns undefined when every entry is invalid (no valid items left)", () => {
+    assert.equal(parseAttachments([{ wrongShape: true }, { path: "/etc/passwd" }, "string"]), undefined);
+  });
 });
 
 describe("chat-service socket — parseOneAttachment", () => {
@@ -179,6 +243,12 @@ describe("chat-service socket — parseOneAttachment", () => {
   it("rejects absolute paths (wire-boundary defence-in-depth, #1099)", () => {
     assert.equal(parseOneAttachment({ path: "/etc/passwd" }), null);
     assert.equal(parseOneAttachment({ path: "\\\\Windows\\\\System32\\\\config" }), null);
+  });
+
+  it("rejects Windows-style drive-letter absolute paths (#1099 iter-2)", () => {
+    assert.equal(parseOneAttachment({ path: "C:\\\\Windows\\\\System32\\\\config" }), null);
+    assert.equal(parseOneAttachment({ path: "C:/Windows/System32/config" }), null);
+    assert.equal(parseOneAttachment({ path: "z:/data" }), null);
   });
 
   it("rejects any traversal segment", () => {

--- a/packages/chat-service/test/test_socket.ts
+++ b/packages/chat-service/test/test_socket.ts
@@ -4,7 +4,7 @@ import http from "http";
 import express from "express";
 import { io as ioClient, Socket as ClientSocket } from "socket.io-client";
 import { Server as SocketServer } from "socket.io";
-import { attachChatSocket, CHAT_SOCKET_EVENTS, CHAT_SOCKET_PATH } from "../src/socket.js";
+import { attachChatSocket, CHAT_SOCKET_EVENTS, CHAT_SOCKET_PATH, parseOneAttachment } from "../src/socket.js";
 import { createPushQueue } from "../src/push-queue.js";
 import type { RelayParams, RelayResult } from "../src/relay.js";
 import type { Logger } from "../src/types.js";
@@ -118,6 +118,92 @@ describe("chat-service socket — no auth", () => {
     assert.equal(harness.relayCalls[0].text, "hi");
 
     client.disconnect();
+  });
+
+  it("forwards a path-only attachment to relay unchanged (#1099)", async () => {
+    // Regression for #1050: the socket parser was inline-only and
+    // silently dropped `{ path }` payloads. Pin the wire shape so a
+    // future refactor can't reintroduce the drop.
+    const client = connectClient(harness.url, { transportId: "cli" });
+    await waitConnect(client);
+    const ack = await emitMessage(client, {
+      externalChatId: "terminal",
+      text: "look at this",
+      attachments: [{ path: "data/attachments/2026/05/x.png", mimeType: "image/png" }],
+    });
+    assert.equal(ack.ok, true);
+    assert.equal(harness.relayCalls.length, 1);
+    assert.deepEqual(harness.relayCalls[0].attachments, [{ path: "data/attachments/2026/05/x.png", mimeType: "image/png" }]);
+    client.disconnect();
+  });
+
+  it("forwards only the valid entries when the array mixes valid + invalid items", async () => {
+    const client = connectClient(harness.url, { transportId: "cli" });
+    await waitConnect(client);
+    const ack = await emitMessage(client, {
+      externalChatId: "terminal",
+      text: "mixed bag",
+      attachments: [
+        { path: "data/attachments/2026/05/a.png" },
+        { somethingElse: "wrong shape" },
+        { mimeType: "image/png" /* missing data + path */ },
+        { mimeType: "image/png", data: "AAAA" },
+      ],
+    });
+    assert.equal(ack.ok, true);
+    const forwarded = harness.relayCalls[0].attachments ?? [];
+    assert.equal(forwarded.length, 2);
+    assert.equal(forwarded[0].path, "data/attachments/2026/05/a.png");
+    assert.equal(forwarded[1].data, "AAAA");
+    client.disconnect();
+  });
+});
+
+describe("chat-service socket — parseOneAttachment", () => {
+  it("accepts the inline `{ data, mimeType }` shape", () => {
+    assert.deepEqual(parseOneAttachment({ mimeType: "image/png", data: "AAAA" }), { mimeType: "image/png", data: "AAAA" });
+  });
+
+  it("accepts the path-only `{ path }` shape", () => {
+    assert.deepEqual(parseOneAttachment({ path: "data/attachments/2026/05/x.png" }), { path: "data/attachments/2026/05/x.png" });
+  });
+
+  it("preserves optional `filename` and `mimeType` on path-only entries", () => {
+    assert.deepEqual(parseOneAttachment({ path: "data/attachments/2026/05/x.png", mimeType: "image/png", filename: "x.png" }), {
+      path: "data/attachments/2026/05/x.png",
+      mimeType: "image/png",
+      filename: "x.png",
+    });
+  });
+
+  it("rejects absolute paths (wire-boundary defence-in-depth, #1099)", () => {
+    assert.equal(parseOneAttachment({ path: "/etc/passwd" }), null);
+    assert.equal(parseOneAttachment({ path: "\\\\Windows\\\\System32\\\\config" }), null);
+  });
+
+  it("rejects any traversal segment", () => {
+    assert.equal(parseOneAttachment({ path: "../../etc/passwd" }), null);
+    assert.equal(parseOneAttachment({ path: "data/attachments/../../etc/shadow" }), null);
+    assert.equal(parseOneAttachment({ path: "data/attachments\\..\\..\\etc\\hosts" }), null);
+  });
+
+  it("rejects empty / non-string payload", () => {
+    assert.equal(parseOneAttachment(null), null);
+    assert.equal(parseOneAttachment("not-an-object"), null);
+    assert.equal(parseOneAttachment({ path: "" }), null);
+    assert.equal(parseOneAttachment({}), null);
+  });
+});
+
+describe("chat-service socket — no auth (cont)", () => {
+  let harness: Harness;
+
+  beforeEach(async () => {
+    harness = await startHarness();
+  });
+
+  afterEach(async () => {
+    await stopHarness(harness);
   });
 
   it("rejects the handshake when transportId is missing", async () => {


### PR DESCRIPTION
## Summary

The exported \`Attachment\` type in \`packages/chat-service/src/types.ts\` allows either \`{ data, mimeType }\` (inline bytes) or \`{ path }\` (workspace path) — both fields optional. \`parseAttachments\` in \`socket.ts\` only recognised the first shape, so a typed \`{ path }\` payload from an external socket client passed type-check and got silently dropped at the wire boundary.

Split the per-item parse into \`parseOneAttachment\` that accepts either shape, preserves optional \`filename\`, and allows an optional \`mimeType\` alongside a path. Total-byte cap only applies to \`data\`-bearing entries.

## Items to Confirm / Review

- The socket-level wire boundary now agrees with the package's exported type contract.
- Path-only entries don't count toward the \`MAX_ATTACHMENT_TOTAL_BYTES\` cap (they ship no bytes here).
- No new test added — \`parseAttachments\` is module-internal and unit-testing would require exporting it. Type-check is the existing safeguard, and the socket integration tests in \`test_socket.ts\` continue to pass.

## User Prompt

PR Quality Sweep batch B9: item 2.1 from \`plans/sweep-2026-05-01/all-findings.md\`.

## Test plan

- [x] \`yarn build:packages && yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File attachments now support both inline data and path-based references, with optional filename/mime metadata.
  * Path references are validated for safety to block empty, absolute, or traversal-containing paths.

* **Bug Fixes**
  * Attachment limits enforced: total item count capped and byte cap applied only to inline data (path-only entries excluded).

* **Tests**
  * Expanded tests covering parsing, validation, caps, and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->