### PR TITLE
fix(server): normalise comma-chained X-Forwarded-* in CSP origin (#1056 follow-up)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -290,12 +290,25 @@ async function getHtmlsDirReal(): Promise<string | null> {
 // visible origin (`localhost:5173`) rather than the upstream socket.
 // In prod (no proxy) the headers are absent and we fall back to the
 // raw `Host` / `req.protocol`.
+//
+// `X-Forwarded-*` values can be a comma-separated proxy chain (each
+// hop appends its own value). The CSP origin only needs the
+// outermost hop — the value the browser actually sees — so we take
+// the first entry and trim. Without this, a multi-hop deployment
+// would emit `https://a.example.com, b.example.com://x` and break
+// preview resource loading at the browser (#1056 review).
 function browserVisibleOrigin(req: Request): string {
-  const fwdHost = req.get("x-forwarded-host");
-  const fwdProto = req.get("x-forwarded-proto");
+  const fwdHost = firstForwardedValue(req.get("x-forwarded-host"));
+  const fwdProto = firstForwardedValue(req.get("x-forwarded-proto"));
   const host = fwdHost ?? req.get("host");
   const proto = fwdProto ?? req.protocol;
   return `${proto}://${host}`;
+}
+
+function firstForwardedValue(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const first = raw.split(",")[0]?.trim();
+  return first && first.length > 0 ? first : undefined;
 }
 app.use(
   "/artifacts/html",


### PR DESCRIPTION
## Summary

\`X-Forwarded-Host\` and \`X-Forwarded-Proto\` can be a comma-separated proxy chain (each hop appends its own value). \`browserVisibleOrigin\` used the raw header verbatim, so multi-hop deployments produced \`https://a.example.com, b.example.com://x\` for the CSP \`script-src\` / \`style-src\` origin and broke preview resource loading at the browser.

Strip to the first entry (outermost hop = what the browser sees) and trim. Empty / whitespace-only values fall back to \`req.get("host")\` / \`req.protocol\` as before.

## Items to Confirm / Review

- Single-hop (no commas) is unchanged — \`split(",")[0].trim()\` returns the original string.
- Empty proxy header (\`x-forwarded-host: ""\`) now treats the same as absent — falls back to \`Host\`.
- Helper \`firstForwardedValue\` extracted so the two header reads stay readable.

## User Prompt

PR Quality Sweep batch B10: item 4.1 from \`plans/sweep-2026-05-01/all-findings.md\`.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)