### PR TITLE
feat(accounting): show account name with code as small/gray prefix

### DIFF
--- a/src/plugins/accounting/components/BalanceSheet.vue
+++ b/src/plugins/accounting/components/BalanceSheet.vue
@@ -18,16 +18,16 @@
           <table class="w-full text-sm">
             <tbody>
               <tr v-for="row in section.rows" :key="row.accountCode" class="border-b border-gray-100" :class="isEarningsRow(row) ? 'italic text-gray-600' : ''">
-                <td class="py-1 px-1 font-mono text-xs">
-                  <span v-if="!isEarningsRow(row)">{{ row.accountCode }}</span>
+                <td class="py-1 px-1">
+                  <span v-if="!isEarningsRow(row)" class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
+                  >{{ rowName(row) }}
                 </td>
-                <td class="py-1 px-1">{{ rowName(row) }}</td>
                 <td class="py-1 px-1 text-right font-mono">{{ formatAmount(row.balance) }}</td>
               </tr>
             </tbody>
             <tfoot>
               <tr class="font-semibold border-t border-gray-300">
-                <td colspan="2" class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+                <td class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
                 <td class="py-1 px-1 text-right">{{ formatAmount(section.total) }}</td>
               </tr>
             </tfoot>

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -47,8 +47,9 @@
             <span v-if="entry.memo">{{ entry.memo }}</span>
           </td>
           <td class="py-1 px-2">
-            <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2">
-              <span class="font-mono">{{ line.accountCode }}</span>
+            <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
+              <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
+              <span>{{ accountNameFor(line.accountCode) }}</span>
               <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
               <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
             </div>
@@ -113,6 +114,14 @@ function formatCredit(value: number): string {
 }
 function formatAccountLabel(account: Account): string {
   return `${account.code} — ${account.name}`;
+}
+const accountNameByCode = computed(() => {
+  const map = new Map<string, string>();
+  for (const account of props.accounts) map.set(account.code, account.name);
+  return map;
+});
+function accountNameFor(code: string): string {
+  return accountNameByCode.value.get(code) ?? code;
 }
 
 async function refresh(): Promise<void> {

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -49,7 +49,7 @@
           <td class="py-1 px-2">
             <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
               <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
-              <span>{{ accountNameFor(line.accountCode) }}</span>
+              <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
               <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
               <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
             </div>
@@ -120,8 +120,8 @@ const accountNameByCode = computed(() => {
   for (const account of props.accounts) map.set(account.code, account.name);
   return map;
 });
-function accountNameFor(code: string): string {
-  return accountNameByCode.value.get(code) ?? code;
+function accountNameFor(code: string): string | null {
+  return accountNameByCode.value.get(code) ?? null;
 }
 
 async function refresh(): Promise<void> {

--- a/src/plugins/accounting/components/OpeningBalancesForm.vue
+++ b/src/plugins/accounting/components/OpeningBalancesForm.vue
@@ -23,8 +23,8 @@
       <tbody>
         <tr v-for="account in bsAccounts" :key="account.code" class="border-b border-gray-100">
           <td class="py-1 px-2">
-            <span class="font-mono text-xs">{{ account.code }}</span>
-            <span class="ml-2">{{ account.name }}</span>
+            <span class="font-mono text-[10px] text-gray-400 mr-2">{{ account.code }}</span>
+            <span>{{ account.name }}</span>
             <span class="ml-2 text-xs text-gray-400">{{ account.type }}</span>
           </td>
           <td class="py-1 px-2">

--- a/src/plugins/accounting/components/ProfitLoss.vue
+++ b/src/plugins/accounting/components/ProfitLoss.vue
@@ -21,14 +21,16 @@
         <table class="w-full text-sm">
           <tbody>
             <tr v-for="row in profitLoss.income.rows" :key="row.accountCode" class="border-b border-gray-100">
-              <td class="py-1 px-1 font-mono text-xs">{{ row.accountCode }}</td>
-              <td class="py-1 px-1">{{ row.accountName }}</td>
+              <td class="py-1 px-1">
+                <span class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
+                >{{ row.accountName }}
+              </td>
               <td class="py-1 px-1 text-right font-mono">{{ formatAmount(row.amount) }}</td>
             </tr>
           </tbody>
           <tfoot>
             <tr class="font-semibold border-t border-gray-300">
-              <td colspan="2" class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+              <td class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
               <td class="py-1 px-1 text-right">{{ formatAmount(profitLoss.income.total) }}</td>
             </tr>
           </tfoot>
@@ -39,14 +41,16 @@
         <table class="w-full text-sm">
           <tbody>
             <tr v-for="row in profitLoss.expense.rows" :key="row.accountCode" class="border-b border-gray-100">
-              <td class="py-1 px-1 font-mono text-xs">{{ row.accountCode }}</td>
-              <td class="py-1 px-1">{{ row.accountName }}</td>
+              <td class="py-1 px-1">
+                <span class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
+                >{{ row.accountName }}
+              </td>
               <td class="py-1 px-1 text-right font-mono">{{ formatAmount(row.amount) }}</td>
             </tr>
           </tbody>
           <tfoot>
             <tr class="font-semibold border-t border-gray-300">
-              <td colspan="2" class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+              <td class="py-1 px-1">{{ t("pluginAccounting.balanceSheet.total") }}</td>
               <td class="py-1 px-1 text-right">{{ formatAmount(profitLoss.expense.total) }}</td>
             </tr>
           </tfoot>


### PR DESCRIPTION
## Summary
- Journal, balance sheet, P&L, and opening-balances tables previously showed only the bare 4-digit account code (e.g. `1010`). Users had to translate codes back to names mentally.
- Render the code as a small/gray monospace prefix (`text-[10px] text-gray-400 font-mono`) followed by the account name in normal weight. Code is still visible for reference; name leads.
- All 4-digit codes line up vertically because monospace + same length, with `mr-2` (~1ch) spacing before the name.
- `JournalList` builds an `accountCode → accountName` map from its existing `accounts` prop with a fallback to the bare code if the account is not found (e.g. deleted). `BalanceSheet` / `ProfitLoss` already have `accountName` on each row from the server. `OpeningBalancesForm` reordered an existing local layout.
- Skipped the `<select>` dropdowns in `JournalList`, `JournalEntryForm`, and `Ledger` — browsers don't honor inline styling on `<option>` elements.

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean (only pre-existing unrelated warnings)
- [x] `yarn test` passes
- [x] `yarn test:e2e` — all 376 tests pass
- [ ] Manual: open a book in the canvas, confirm Journal, Balance Sheet, Profit & Loss, and Opening Balances tabs each show `<code> <name>` with the code dim and the name primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Restructured accounting table layouts to display account codes and names together in single cells for improved visual organization
  * Updated account code styling with monospaced typography and refined spacing across financial statement views
  * Refined table footer formatting in financial statement displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->