### PR TITLE
chore(lint): graduate security/detect-unsafe-regex warn → error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -296,8 +296,8 @@ export default [
       //     testid prefixes — controlled inputs, not attacker-supplied.
       //     27 warnings / 0 actionable.
       // The remaining rules (detect-eval-with-expression, detect-
-      // child-process, detect-unsafe-regex, detect-possible-timing-
-      // attacks, detect-non-literal-require, detect-pseudoRandomBytes,
+      // child-process, detect-possible-timing-attacks,
+      // detect-non-literal-require, detect-pseudoRandomBytes,
       // detect-buffer-noassert, detect-disable-mustache-escape,
       // detect-no-csrf-before-method-override, detect-bidi-characters,
       // detect-new-buffer) stay as warnings — tripwires for future
@@ -305,6 +305,11 @@ export default [
       "security/detect-non-literal-fs-filename": "off",
       "security/detect-object-injection": "off",
       "security/detect-non-literal-regexp": "off",
+      // `detect-unsafe-regex` is graduated to error: every legitimate
+      // site (currently the two regexes in `src/utils/image/htmlSrcAttrs.ts`)
+      // already has a `// eslint-disable-next-line` with a ReDoS-safety
+      // rationale and a unit test pinning the bound.
+      "security/detect-unsafe-regex": "error",
     },
     plugins: {
       prettier: prettierPlugin,

--- a/src/utils/image/htmlSrcAttrs.ts
+++ b/src/utils/image/htmlSrcAttrs.ts
@@ -48,7 +48,7 @@ export const RESOLVABLE_TAG_ATTRS: Readonly<Record<string, readonly string[]>> =
 // alternation here. The unit test in test_htmlSrcAttrs.ts pins this
 // in lockstep so the two never disagree silently.
 //
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded alternatives, ReDoS-safe (test in test_htmlSrcAttrs.ts)
+// eslint-disable-next-line security/detect-unsafe-regex -- bounded alternatives, ReDoS-safe (test in test_htmlSrcAttrs.ts)
 const RESOLVABLE_TAG_OUTER_RE = /<(?:img|source|video|audio)\b(?:[^>"']|"[^"]*"|'[^']*')*\/?>/gi;
 // Tag-name extractor for the matched outer tag. Anchored so we only
 // read the leading `<name`, never an attribute value that happens to
@@ -70,7 +70,7 @@ const TAG_NAME_RE = /^<([a-z]+)/i;
 //      quote as the value
 //
 // All quantifiers bounded — verified ReDoS-safe in test_htmlSrcAttrs.ts.
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity -- bounded quantifiers, ReDoS-safe (test in test_htmlSrcAttrs.ts)
+// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity, security/detect-unsafe-regex -- bounded quantifiers, ReDoS-safe (test in test_htmlSrcAttrs.ts)
 const ATTR_ITER_RE = /(\s+)([A-Za-z][\w:-]*)(?:(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s>"'][^\s>]*)))?/g;
 
 /** Transform every URL-bearing attribute on a recognised tag.


### PR DESCRIPTION
## Summary

Drops the only 3 lint warnings on \`main\` and graduates the rule that drove them.

\`yarn lint\` was reporting:
- 2× \`security/detect-unsafe-regex\` (warn) on the two regexes in \`src/utils/image/htmlSrcAttrs.ts\`
- 1× "Unused eslint-disable directive" on the same file

Both regexes are already ReDoS-safe (bounded alternatives / quantifiers) and pinned by the existing tests in \`test/utils/image/test_htmlSrcAttrs.ts\`. The per-line \`eslint-disable\` only mentioned the sister sonarjs rules (\`slow-regex\`, \`regex-complexity\`), so the security one slipped through. Fix: extend the disables to cover \`security/detect-unsafe-regex\` and graduate the rule to error.

## Items to Confirm / Review

- \`RESOLVABLE_TAG_OUTER_RE\` (line 52): the previous disable listed sonarjs rules that don't actually fire on this pattern, so it was reported as "unused". Replaced with \`security/detect-unsafe-regex\` — the rule that's actually firing.
- \`ATTR_ITER_RE\` (line 74): the sonarjs disables ARE active here (verified by removing them experimentally and seeing both rules fire). Extended the disable to also cover \`security/detect-unsafe-regex\`.
- \`eslint.config.mjs\`: \`security/detect-unsafe-regex\` graduated from default (warn) to error. The only two sites in the codebase are now documented, audited, and tested — a future regression has to either explicitly disable the rule with rationale or be a real ReDoS bug.

## Verification

- \`yarn lint\` → 0 errors, **0 warnings** (was 0 errors, 3 warnings)
- \`yarn typecheck\` → ✓
- \`yarn build\` → ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint security configuration to enhance regex pattern validation with appropriate suppression comments for specific regex expressions in image utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->