### PR TITLE
feat(prompt): add proactive memory recall guidance (closes #1035)

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -189,6 +189,16 @@ When you learn something from the conversation that would be useful to remember 
 
 Memory is organised by **topic file**. Each file lives at \`conversations/memory/<type>/<topic>.md\` and groups related bullets under H2 sections. The system prompt's Memory section above shows the existing topics — pick from that list when adding a new bullet, and only create a new topic when nothing fits.
 
+### Using memory proactively
+
+Before answering, scan the Memory section above for topics related to the user's current message. The H2 tags after each \`<type>/<topic>.md\` line are searchable hints — match against the user's words (e.g. art / music / travel / tooling). When a topic looks relevant, \`Read\` the file first and weave the relevant bullets naturally into your answer. Examples:
+
+- The user mentions a trip → check \`fact/travel.md\` (and any related interest topic) before suggesting destinations.
+- The user asks about a tool / language → check \`preference/dev.md\` so you don't suggest something they've already vetoed.
+- The user picks up a long-running project → check the matching \`fact\` or \`reference\` topic for prior context.
+
+Do NOT announce that you are using memory ("according to your memory…"). The recall is for grounding your answer, not for narration. If nothing in memory is relevant, just answer normally.
+
 Each topic file is one markdown document:
 
 \`\`\`yaml

--- a/test/agent/test_topic_memory_context.ts
+++ b/test/agent/test_topic_memory_context.ts
@@ -110,4 +110,16 @@ describe("memory/format-detect — topic workspace", () => {
     assert.match(out, /H2 sections/);
     assert.doesNotMatch(out, /<type>_<short-slug>\.md/);
   });
+
+  it("buildMemoryManagementSection includes the proactive-recall guidance (#1035)", () => {
+    // The recall paragraph turns the topic-mode prompt from
+    // "write here when something is durable" into "AND read this
+    // when answering". Without it, the agent has the index but no
+    // explicit cue to consult it before responding.
+    const out = buildMemoryManagementSection(scoped);
+    assert.match(out, /Using memory proactively/);
+    assert.match(out, /Before answering/);
+    // Recall must NOT instruct the agent to narrate its memory use.
+    assert.match(out, /Do NOT announce/);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a "Using memory proactively" subsection to the topic-format Memory Management prompt.
- Closes #1035. Most of that issue's scope (load index, Read on demand) was already implicit in #1070's topic restructure — what was missing was the explicit cue for the agent to *consult* memory before answering, not just write to it.
- Atomic-format prompt (legacy path) intentionally untouched — it's on the 2026-07-01 cleanup track.

## Items to Confirm / Review

- **Three concrete examples** (travel / tooling / long-running project) chosen as the most common cases. Add or replace if other patterns matter more in your usage.
- **Do NOT announce / narrate** clause is intentional — recall should feel like grounding, not commentary. Trade-off: when the recall is load-bearing for the answer, the user might want to see *why* the agent suggested something. We can iterate if it feels too opaque in practice.
- Section is emitted under `### Using memory proactively` (H3) so it nests under the existing `## Memory Management` block.

## User Prompt

> #1035 → 簡略化：「prompt に proactive recall 1 段落追加する」だけの薄い PR にスコープ縮小、他は close

## Implementation approach

1. Insert the recall paragraph into `TOPIC_MEMORY_MANAGEMENT` in `server/agent/prompt.ts` directly after the "Memory is organised by topic file" framing.
2. Add one test that asserts all three load-bearing pieces (heading / "Before answering" trigger / "Do NOT announce" guardrail) survive future edits.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (only pre-existing `htmlSrcAttrs.ts` warnings)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 3858 / 0 fail (1 new assertion)
- [ ] CI: confirm Windows / macOS / Linux pass