### PR TITLE
docs: memory system spec + README link sweep

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,59 +4,70 @@
 
 Guides for using MulmoClaude. No programming knowledge required.
 
-| Document | Language | Description |
-|---|---|---|
-| [MulmoBridge ガイド](mulmobridge-guide.md) | 日本語 | メッセージアプリから自宅PCのAIと話す方法 |
-| [MulmoBridge Guide](mulmobridge-guide.en.md) | English | Connect messaging apps to your home PC's AI agent |
-| [スケジューラー ガイド](scheduler-guide.md) | 日本語 | カレンダーと定期タスクの使い方 |
-| [Scheduler Guide](scheduler-guide.en.md) | English | Calendar and recurring tasks |
-| [Telegram Setup](message_apps/telegram/README.md) | English | Create and connect a Telegram Bot |
-| [Telegram セットアップ](message_apps/telegram/README.ja.md) | 日本語 | Telegram Bot の作成と接続手順 |
-| [LINE Setup](message_apps/line/README.md) | English | Create and connect a LINE bot (requires ngrok) |
-| [LINE セットアップ](message_apps/line/README.ja.md) | 日本語 | LINE bot の作成と接続手順 (ngrok 必要) |
-| [Relay Setup](message_apps/relay/README.md) | English | Deploy a cloud relay — no ngrok, offline queue |
-| [Relay セットアップ](message_apps/relay/README.ja.md) | 日本語 | クラウドリレーのデプロイ — ngrok 不要、オフラインキュー |
+| Document                                                    | Language | Description                                             |
+| ----------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| [MulmoBridge ガイド](mulmobridge-guide.md)                  | 日本語   | メッセージアプリから自宅PCのAIと話す方法                |
+| [MulmoBridge Guide](mulmobridge-guide.en.md)                | English  | Connect messaging apps to your home PC's AI agent       |
+| [スケジューラー ガイド](scheduler-guide.md)                 | 日本語   | カレンダーと定期タスクの使い方                          |
+| [Scheduler Guide](scheduler-guide.en.md)                    | English  | Calendar and recurring tasks                            |
+| [Telegram Setup](message_apps/telegram/README.md)           | English  | Create and connect a Telegram Bot                       |
+| [Telegram セットアップ](message_apps/telegram/README.ja.md) | 日本語   | Telegram Bot の作成と接続手順                           |
+| [LINE Setup](message_apps/line/README.md)                   | English  | Create and connect a LINE bot (requires ngrok)          |
+| [LINE セットアップ](message_apps/line/README.ja.md)         | 日本語   | LINE bot の作成と接続手順 (ngrok 必要)                  |
+| [Relay Setup](message_apps/relay/README.md)                 | English  | Deploy a cloud relay — no ngrok, offline queue          |
+| [Relay セットアップ](message_apps/relay/README.ja.md)       | 日本語   | クラウドリレーのデプロイ — ngrok 不要、オフラインキュー |
 
 ## Tips & Integrations
 
-| Document | Language | Description |
-|---|---|---|
-| [Obsidian 連携](tips/obsidian.md) | 日本語 | MulmoClaude のワークスペースを Obsidian で閲覧、既存 vault を Claude に参照させる |
-| [Obsidian Integration](tips/obsidian.en.md) | English | Browse MulmoClaude output in Obsidian, let Claude reference your vault |
+| Document                                                            | Language | Description                                                                                  |
+| ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| [Obsidian 連携](tips/obsidian.md)                                   | 日本語   | MulmoClaude のワークスペースを Obsidian で閲覧、既存 vault を Claude に参照させる            |
+| [Obsidian Integration](tips/obsidian.en.md)                         | English  | Browse MulmoClaude output in Obsidian, let Claude reference your vault                       |
+| [Claude Code × Ollama セットアップ知見](tips/claude-code-ollama.md) | 日本語   | ローカル LLM (Ollama) で Claude Code を動かすときの context 長 / モデル選定知見              |
+| [Claude Code × Ollama Setup Notes](tips/claude-code-ollama.en.md)   | English  | Running Claude Code against a local Ollama backend — context-window, model picks             |
+| [Runtime Plugin デバッグ知見](tips/runtime-plugin-debugging.md)     | 日本語   | `npx mulmoclaude` で runtime plugin が呼べないときに踏んだ silent failure 4 パターンと直し方 |
+| [Bedrock Deployment](bedrock-deployment.en.md)                      | English  | Run MulmoClaude against Anthropic Claude on AWS Bedrock                                      |
+| [Bedrock デプロイ](bedrock-deployment.md)                           | 日本語   | AWS Bedrock 経由の Anthropic Claude で動かす手順                                             |
 
 ## Architecture & Design
 
-| Document | Language | Description |
-|---|---|---|
-| [Bridge Session Design](bridge-session-design.md) | English | Session identification, caching, and multi-user scaling plan |
+| Document                                                          | Language | Description                                                                                                        |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| [Memory](memory.md)                                               | English  | Topic-based memory store under `conversations/memory/` — schema, agent read/write contract, atomic→topic migration |
+| [Runtime Plugins](plugin-runtime.md)                              | English  | Workspace-installed runtime plugins (#1043 C-2) — install, dispatch, asset routes, collisions                      |
+| [Bridge Session Design](bridge-session-design.md)                 | English  | Session identification, caching, and multi-user scaling plan                                                       |
+| [Image-path Routing — Research](image-path-routing.md)            | English  | Read-only audit of how the LLM's image references become browser-loadable URLs                                     |
+| [Image-path Routing — 設計議論](discussion-image-path-routing.md) | 日本語   | 画像パスのルーティング再設計の議論メモと段階的実装計画                                                             |
+| [Wiki / HTML 表示サーフェス](wiki-html-render-surfaces.md)        | 日本語   | Wiki / HTML / Markdown が表示される複数箇所の差異 (権限・画像パス解決) を整理                                      |
 
 ## Developers
 
 Code structure, APIs, and build instructions.
 
-| Document | Language | Description |
-|---|---|---|
-| [Developer Guide](developer.md) | English | Environment variables, scripts, workspace structure, CI, internal packages |
-| [Bridge Protocol](bridge-protocol.md) | English | MulmoBridge wire protocol spec (socket.io events, auth) |
-| [Task Manager](task-manager.md) | English | Server tick loop + @receptron/task-scheduler integration |
-| [Logging](logging.md) | English | Log levels, formats, rotation |
-| [Sandbox Credentials](sandbox-credentials.md) | English | Docker sandbox credential forwarding |
-| [Manual Testing](manual-testing.md) | English | Manual test items not covered by E2E |
+| Document                                      | Language | Description                                                                                                                         |
+| --------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Developer Guide](developer.md)               | English  | Environment variables, scripts, workspace structure, CI, internal packages                                                          |
+| [UI Cheatsheet](ui-cheatsheet.md)             | English  | ASCII layouts of every major UI surface, anchored to component / `data-testid` names so chat / PR text can reference them precisely |
+| [Bridge Protocol](bridge-protocol.md)         | English  | MulmoBridge wire protocol spec (socket.io events, auth)                                                                             |
+| [Task Manager](task-manager.md)               | English  | Server tick loop + @receptron/task-scheduler integration                                                                            |
+| [Logging](logging.md)                         | English  | Log levels, formats, rotation                                                                                                       |
+| [Sandbox Credentials](sandbox-credentials.md) | English  | Docker sandbox credential forwarding                                                                                                |
+| [Manual Testing](manual-testing.md)           | English  | Manual test items not covered by E2E                                                                                                |
 
 ## Project
 
-| Document | Language | Description |
-|---|---|---|
-| [CHANGELOG](CHANGELOG.md) | English | Release history (Keep a Changelog format) |
-| [PR紹介](PR-ja.md) | 日本語 | MulmoClaude の紹介・PR用テキスト |
-| [v0.1.0 Release Notes](releases/v0.1.0.md) | English | First tagged release |
-| [v0.1.1 Release Notes](releases/v0.1.1.md) | English | Monorepo + streaming + bridges |
+| Document                                   | Language | Description                               |
+| ------------------------------------------ | -------- | ----------------------------------------- |
+| [CHANGELOG](CHANGELOG.md)                  | English  | Release history (Keep a Changelog format) |
+| [PR紹介](PR-ja.md)                         | 日本語   | MulmoClaude の紹介・PR用テキスト          |
+| [v0.1.0 Release Notes](releases/v0.1.0.md) | English  | First tagged release                      |
+| [v0.1.1 Release Notes](releases/v0.1.1.md) | English  | Monorepo + streaming + bridges            |
 
 ## Packages
 
 Each package has its own README inside `packages/`.
 
-| Document | Description |
-|---|---|
-| [packages/README.md](../packages/README.md) | MulmoBridge package overview |
-| Individual package READMEs | Published to npm package pages |
+| Document                                    | Description                    |
+| ------------------------------------------- | ------------------------------ |
+| [packages/README.md](../packages/README.md) | MulmoBridge package overview   |
+| Individual package READMEs                  | Published to npm package pages |

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,123 @@
+# Memory
+
+MulmoClaude keeps a small, durable "what I know about the user" store under `~/mulmoclaude/conversations/memory/`. The agent reads it as part of every turn's system prompt and writes new entries silently when something durable comes up in conversation. The entries are **plain markdown files** the user can read, edit, and version-control.
+
+This doc covers the on-disk layout, the agent's read/write contract, and the one-shot migration that flips a workspace from the legacy "atomic" layout to the current topic-grouped layout.
+
+## File layout (current — topic format)
+
+```
+~/mulmoclaude/conversations/memory/
+├── MEMORY.md                  # system-owned index (link list per type)
+├── preference/
+│   ├── tools.md               # one topic file per .md
+│   └── workflow.md
+├── interest/
+│   ├── music.md
+│   └── ai-research.md
+├── fact/
+│   └── travel.md
+└── reference/
+    └── repos.md
+```
+
+Each topic file is a single markdown document with YAML frontmatter:
+
+```yaml
+---
+type: interest
+topic: music
+---
+# Music
+
+## Rock / Metal
+- Pantera, Metallica, Megadeth — long-running listens
+- Saw Iron Maiden live in 2024
+
+## Classical
+- Chopin nocturnes for focus work
+```
+
+- **`type`** — one of `preference` / `interest` / `fact` / `reference`. Source of truth for classification; the directory name is just for ergonomics.
+- **`topic`** — slug matching the filename without `.md`. Stable identifier the index links to. Lowercase ASCII, hyphenated, ≤ 60 chars.
+- **Body** — H1 with the humanised topic name, then optional H2 sections, then bullets. H2 headings double as "tags" the index surfaces.
+
+The four types and their meanings (also shown to the agent in the Memory Management prompt):
+
+| Type         | What goes here                                 | Examples                                                                 |
+| ------------ | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `preference` | Durable habits, preferences, conventions.      | "uses yarn (npm not allowed)", "writes commits in English"               |
+| `interest`   | Topics / hobbies / domains followed long-term. | "AI research papers", "Impressionist painting"                           |
+| `fact`       | Concrete personal facts that may become stale. | "planning a trip to Egypt", "owns a toaster oven"                        |
+| `reference`  | Pointers to internal or external resources.    | "main repo at ~/ss/llm/mulmoclaude", "weekly art-exhibitions-watch task" |
+
+## How the agent reads it
+
+`buildMemoryContext()` in [`server/agent/prompt.ts`](../server/agent/prompt.ts) injects the current memory directly into the system prompt under a `## Memory` section, wrapped in a `<reference type="memory">` envelope so a poisoned entry can't impersonate instructions. The full body of every topic file lands inline; the agent doesn't have to round-trip a tool call to read memory.
+
+`MEMORY.md` is the index, not the source of truth — its line per topic file is `- [name](slug.md) — description` and the H2 headings the file contains. The agent reads the index for shape, then reads bullet bodies inline.
+
+Detection between the legacy "atomic" layout and the current "topic" layout is done at request time in [`topic-detect.ts`](../server/workspace/memory/topic-detect.ts): if any of the canonical type subdirectories (`preference/` / `interest/` / `fact/` / `reference/`) exists under `memory/`, topic format wins. No module-level cache — a manual swap takes effect on the next request.
+
+## How the agent writes it
+
+When the conversation produces something durable enough to remember, the agent writes the new bullet into the topic file that already covers the subject (preferring "append a bullet" over "create a new topic"). The Memory Management section of the system prompt encodes the policy:
+
+1. Pick the topic file from the existing list shown in the Memory section.
+2. `Read` it. Choose an H2 section, or append directly under H1 if the topic is small.
+3. `Write` the updated file back through the agent's `Write` tool (which routes through `writeFileAtomic` so a crash mid-write can't half-finish).
+4. If the bullet introduces a new H2 the user will see in the index, also `Write` a matching `MEMORY.md` line. Otherwise the index regenerates on the next clustering pass.
+
+What NOT to write: ephemeral task state, sensitive material (credentials, SSH keys), duplicates, or anything the user asked the agent to forget.
+
+## The atomic → topic migration
+
+Two on-disk formats coexist for the duration of the migration window. Both are still readable until every active workspace has flipped:
+
+| Layout                     | Filename pattern                               | When written      |
+| -------------------------- | ---------------------------------------------- | ----------------- |
+| **Atomic** (legacy, #1029) | `<type>_<slug>.md` flat at the memory dir root | Pre-#1070 builds  |
+| **Topic** (current, #1070) | `<type>/<topic>.md` under per-type subdirs     | Post-#1070 builds |
+
+The migration is one-shot, idempotent, and runs in the background on server startup. Pipeline:
+
+1. **Pre-conditions** ([`topic-run.ts`](../server/workspace/memory/topic-run.ts)) — workspace has atomic entries; legacy `memory.md` migration has already run; topic format isn't already active. Anything else, return early.
+2. **Cluster** ([`topic-cluster.ts`](../server/workspace/memory/topic-cluster.ts)) — call out to an LLM with the full atomic entry list. The LLM returns `{ type → topic → bullets[] }`. The clusterer is injectable so tests use a stub.
+3. **Stage** ([`topic-migrate.ts`](../server/workspace/memory/topic-migrate.ts)) — write the clustered files to `conversations/memory.next/<type>/<topic>.md` plus a regenerated `MEMORY.md`. The original `memory/` directory is untouched.
+4. **Inspect** — the user diffs `memory/` vs `memory.next/` manually. Auto-swap is opt-in (see below) precisely so the user gets a chance to look first.
+5. **Swap** ([`topic-swap.ts`](../server/workspace/memory/topic-swap.ts)) — atomic rename: `memory/` → `memory/.atomic-backup-<ts>/`, then `memory.next/` → `memory/`. The backup name carries a timestamp so re-runs from a richer workspace don't clobber prior backups.
+
+After step 5, the next request reads topic format. The atomic backup stays under `.atomic-backup-<ts>/` indefinitely — it's tiny, and keeping it there means the user can always grep their old layout without restoring anything.
+
+### CLI helper
+
+A user can drive the swap manually:
+
+```bash
+yarn memory:swap
+```
+
+The script ([`scripts/memory-swap-topic-staging.ts`](../scripts/memory-swap-topic-staging.ts)) wraps `topic-swap.ts`'s library function with a friendly summary.
+
+### Auto-swap window
+
+When the runner detects staging from a prior crash mid-swap, it retries the swap rather than burning another LLM cluster call. The detection is conservative: `memory.next/<type>/` is treated as a "real" topic dir for format-detection purposes ONLY when `memory/` is entirely absent (the actual swap window). When `memory/` still exists with atomic files, `memory.next/<type>/` is just staging being filled and detection stays atomic — see the long comment at the top of [`topic-detect.ts`](../server/workspace/memory/topic-detect.ts) for why this matters.
+
+## Cleanup horizon
+
+The migration scaffolding is one-shot. After every active workspace has flipped, the following code goes in one sweep (search for the `CLEANUP 2026-07-01` markers):
+
+- `topic-migrate.ts`, `topic-cluster.ts`, `topic-swap.ts`, `topic-run.ts`
+- `scripts/memory-swap-topic-staging.ts` and the `yarn memory:swap` script entry
+- The migration call in `server/index.ts` startup
+- The `else` branch in `buildMemoryContext` (atomic + legacy readers) and the `ATOMIC_MEMORY_MANAGEMENT` constant in `server/agent/prompt.ts`
+- `io.ts`, `migrate.ts`, `run.ts`, `llm-classifier.ts`, `types.ts` — the atomic-format reader chain
+
+What stays: `topic-types.ts`, `topic-io.ts`, `topic-detect.ts` (minus the atomic-format branch), and the topic half of `buildMemoryContext`.
+
+## Where to read more
+
+- [`plans/feat-memory-topic-restructure.md`](../plans/feat-memory-topic-restructure.md) — design notes for the topic format (#1070 PR-A)
+- [`plans/feat-memory-topic-wire.md`](../plans/feat-memory-topic-wire.md) — wire-through plan (#1070 PR-B)
+- [`plans/done/feat-memory-storage-utilities.md`](../plans/done/feat-memory-storage-utilities.md) — atomic-format storage layer (#1029 PR-A, legacy)
+- [`plans/done/feat-memory-storage-wire.md`](../plans/done/feat-memory-storage-wire.md) — atomic-format wire-through (#1029 PR-B, legacy)


### PR DESCRIPTION
## Summary

- New `docs/memory.md` — spec for the topic-based memory store (#1070): file layout, topic file shape, type taxonomy, agent read/write contract, atomic→topic migration, and the `CLEANUP 2026-07-01` horizon.
- `docs/README.md` link sweep — adds memory + several other docs that had landed without a README pointer (plugin-runtime, image-path-routing, discussion-image-path-routing, wiki-html-render-surfaces, ui-cheatsheet, tips/runtime-plugin-debugging, tips/claude-code-ollama, bedrock-deployment).

## Items to Confirm / Review

- 内容の正確性 — 特に "atomic → topic migration" の手順と "Cleanup horizon" のリスト（CLEANUP 2026-07-01 マーカーで grep して書いた）
- `docs/README.md` の分類 — memory.md は "Architecture & Design" に入れたが、users 向けにも見えてほしいなら別カテゴリへ
- 未リスト doc の説明文 — `wiki-html-render-surfaces.md` などは原文の冒頭を読んで要約したつもりだが、表現に違和感があれば指摘を

## User Prompt

> 新しくしたmemoryについてdocumentを書いている？なければ書いて追加。あとdoc の README 古ければ更新して

## Test plan

- [x] `yarn format` 適用済み
- [x] `yarn typecheck` 通過
- [ ] レビュアーが `docs/memory.md` を読んで実装と乖離がないか確認
- [ ] `docs/README.md` のリンク先がすべて存在するか目視確認 (全 11 件、既存ファイルのみ)