### PR TITLE
ci(codex): drop ready_for_review trigger to stop draft→ready double-fire

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -37,8 +37,12 @@ on:
   # collapses to one review against the final commit) and the Azure
   # deployment's 5000 TPM ceiling. A docs-only PR review is cheap
   # and occasionally catches a typo or broken link the bots missed.
+  # `ready_for_review` is intentionally NOT in `types`: `opened` already
+  # fires on draft PRs, so promoting draft → ready would otherwise re-run
+  # Codex on the identical SHA (no new commits to review). If a fresh
+  # take is wanted on draft promotion, use `workflow_dispatch` instead.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches: [main]
   # Manual escalation: run on demand against any PR (re-review,
   # one-off check on a closed PR, etc.).


### PR DESCRIPTION
## Summary

- Codex auto-review ワークフローのトリガから `ready_for_review` を削除
- `opened` がすでに draft PR でも発火しているため、draft から ready に変更する際に **同一 SHA** に対して Codex がもう一度走っていた（純粋な重複）
- 必要なら `workflow_dispatch` で手動再走させられる導線は残す

## Items to Confirm / Review

- `ready_for_review` を外した結果、想定外のケース（例: 長期間 draft で放置 → 久しぶりに昇格した時に最新版で再レビューしたい）で困らないか。困る場合は `workflow_dispatch` で十分か、別途ガードを足すべきか。
- ヘッダーコメントに記した経緯（`opened` が draft も拾う）の説明が後から workflow を読む人に通じるか。

## User Prompt

- 「github actions に codex review 追加されている？どんな設定になっているか確認して」
- 「実行トリガーどうなっている？むだうちが多い気がする」+ #1104 を共有
- 調査結果に対して「A が良いかな」（= `ready_for_review` を `types` から外す案）

## 背景 — #1104 で観測された無駄打ち

| 時刻 | event | head SHA | Codex 結果 |
|---|---|---|---|
| 04:10 | `opened` (draft) | `b6d20b95` | CHANGES REQUESTED × 3 |
| 05:18 | `ready_for_review` | `b6d20b95` (差分ゼロ) | CHANGES REQUESTED ×（同じ 3 件 + 1） |

差分のない同一 SHA に対して Codex が 2 回走り、同じ指摘が再投稿されていた。プロンプトの "iteration-aware"（過去 verdict を読んでから指摘）ロジックも、修正コミットが入っていない以上 "解決済み" 判定にならず重複を防げない。

## 変更内容

`.github/workflows/codex_review.yaml`

```diff
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
```

ヘッダーコメントに以下を追記：

- `ready_for_review` を入れない理由（`opened` が draft も拾うため二度焚きになる）
- draft→ready 昇格時に再レビューがほしい場合は `workflow_dispatch` を使う

## 想定される効果

- draft で開発 → ready に昇格、というよくあるフローで Codex 1 回分のコール（Azure OpenAI 利用 + GHA 分）が削減される
- 過去 ~2 日で 84 runs のうち、こうした draft→ready 二度焚きがどの程度含まれていたかは未計測。少なくとも #1104 のような明示ケースは消える。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation workflow trigger to run on pull request open, synchronize, and reopen events only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->