### PR TITLE
fix(plugins): runtime plugin polish — exports parser, full static-tool set, file-domain helper, route URL constant (#1077 follow-up)

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -129,7 +129,10 @@ const runtimeReady: Promise<void> = (async () => {
     const userInstalled = await loadRuntimePlugins();
     registerRuntimePlugins(STATIC_TOOL_NAMES, [...presets, ...userInstalled]);
     for (const plugin of getRuntimePlugins()) {
-      const endpoint = `/api/plugins/runtime/${encodeURIComponent(plugin.name)}/dispatch`;
+      // Build from the canonical route constant so a future rename
+      // ripples here automatically — `runtime-plugin.ts` registers
+      // the same `:pkg` pattern (#1077 review).
+      const endpoint = API_ROUTES.plugins.runtimeDispatch.replace(":pkg", encodeURIComponent(plugin.name));
       ALL_TOOLS[plugin.definition.name] = fromPackage(plugin.definition, endpoint);
     }
     // Runtime plugins are auto-included regardless of role.availablePlugins

--- a/server/api/routes/runtime-plugin.ts
+++ b/server/api/routes/runtime-plugin.ts
@@ -19,8 +19,7 @@
 // routes means the plugin isn't installed (or failed to load — see
 // boot logs).
 
-import path from "node:path";
-import { realpathSync, promises as fsp } from "node:fs";
+import { realpathSync } from "node:fs";
 import { Router, type Request, type Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { getRuntimePlugins } from "../../plugins/runtime-registry.js";
@@ -28,6 +27,7 @@ import { notFound, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
 import { isRecord } from "../../utils/types.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
+import { readPluginAsset } from "../../utils/files/plugins-io.js";
 import { log } from "../../system/logger/index.js";
 
 const LOG_PREFIX = "api/plugins/runtime";
@@ -139,9 +139,7 @@ router.get(API_ROUTES.plugins.runtimeAsset, async (req: Request<{ pkg: string; v
     return;
   }
   try {
-    const data = await fsp.readFile(resolved);
-    const ext = path.extname(resolved).toLowerCase();
-    const contentType = contentTypeFor(ext);
+    const { data, contentType } = await readPluginAsset(resolved);
     res.setHeader("Content-Type", contentType);
     res.send(data);
   } catch (err) {
@@ -149,35 +147,5 @@ router.get(API_ROUTES.plugins.runtimeAsset, async (req: Request<{ pkg: string; v
     serverError(res, "asset read failed");
   }
 });
-
-function contentTypeFor(ext: string): string {
-  switch (ext) {
-    case ".js":
-    case ".mjs":
-    case ".cjs":
-      return "application/javascript; charset=utf-8";
-    case ".css":
-      return "text/css; charset=utf-8";
-    case ".json":
-      return "application/json; charset=utf-8";
-    case ".map":
-      return "application/json; charset=utf-8";
-    case ".html":
-      return "text/html; charset=utf-8";
-    case ".svg":
-      return "image/svg+xml";
-    case ".png":
-      return "image/png";
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".woff":
-      return "font/woff";
-    case ".woff2":
-      return "font/woff2";
-    default:
-      return "application/octet-stream";
-  }
-}
 
 export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -863,7 +863,14 @@ process.on("SIGTERM", () => {
   try {
     const presets = await loadPresetPlugins();
     const userInstalled = await loadRuntimePlugins();
-    const result = registerRuntimePlugins(MCP_PLUGIN_NAMES, [...presets, ...userInstalled]);
+    // Pass the full static-tool set (MCP plugins + MCP tools like
+    // readXPost / searchX) as the collision policy. The standalone
+    // mcp-server already does this via STATIC_TOOL_NAMES; keeping
+    // index.ts narrower meant a runtime plugin could shadow an MCP
+    // tool in the parent registry while colliding cleanly in the
+    // bridge — visibly inconsistent (#1077 review).
+    const staticToolNames = new Set([...MCP_PLUGIN_NAMES, ...mcpTools.map((tool) => tool.definition.name)]);
+    const result = registerRuntimePlugins(staticToolNames, [...presets, ...userInstalled]);
     log.info("plugins/runtime", "registered runtime plugins", {
       presets: presets.length,
       userInstalled: userInstalled.length,

--- a/server/index.ts
+++ b/server/index.ts
@@ -863,13 +863,21 @@ process.on("SIGTERM", () => {
   try {
     const presets = await loadPresetPlugins();
     const userInstalled = await loadRuntimePlugins();
-    // Pass the full static-tool set (MCP plugins + MCP tools like
-    // readXPost / searchX) as the collision policy. The standalone
+    // Pass the full static-tool set (MCP plugins + ENABLED MCP tools
+    // like readXPost / searchX) as the collision policy. The standalone
     // mcp-server already does this via STATIC_TOOL_NAMES; keeping
     // index.ts narrower meant a runtime plugin could shadow an MCP
     // tool in the parent registry while colliding cleanly in the
     // bridge — visibly inconsistent (#1077 review).
-    const staticToolNames = new Set([...MCP_PLUGIN_NAMES, ...mcpTools.map((tool) => tool.definition.name)]);
+    //
+    // Filter via `isMcpToolEnabled` so the floor matches the child
+    // process exactly. The mcp-server's `mcpToolDefs` only includes
+    // enabled tools (`mcpTools.filter(isMcpToolEnabled)`), so if the
+    // parent reserved DISABLED tools too, a runtime plugin colliding
+    // with a disabled tool would be rejected here but accepted by the
+    // child — and the child's `/dispatch` would 404 because the
+    // parent never registered a route for it (#1116 review).
+    const staticToolNames = new Set([...MCP_PLUGIN_NAMES, ...mcpTools.filter(isMcpToolEnabled).map((tool) => tool.definition.name)]);
     const result = registerRuntimePlugins(staticToolNames, [...presets, ...userInstalled]);
     log.info("plugins/runtime", "registered runtime plugins", {
       presets: presets.length,

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -94,12 +94,32 @@ function resolveExportsField(exportsField: PackageJson["exports"]): string | nul
   // Form 1: top-level string sugar.
   if (typeof exportsField === "string") return exportsField;
   if (!isRecord(exportsField)) return null;
-  // Form 2: conditional root (e.g. { import, require }) — `import` wins.
-  if (typeof exportsField.import === "string") return exportsField.import;
+  // Form 2: conditional root (e.g. `{ import, require, default }`).
+  // `import` wins for ESM; `default` is the spec-mandated fallback
+  // that "always matches" when no other condition does (Codex review
+  // on #1116). An ESM-only package may publish
+  // `{ "default": "./dist/index.js" }` with no `import` key at all —
+  // Node resolves it via `default`, so we must too.
+  const rootCondition = pickEsmCondition(exportsField);
+  if (rootCondition) return rootCondition;
   // Form 3 / 4: subpath map keyed by `.`.
   const root = exportsField["."];
   if (typeof root === "string") return root;
-  if (isRecord(root) && typeof root.import === "string") return root.import;
+  if (isRecord(root)) {
+    const dotCondition = pickEsmCondition(root);
+    if (dotCondition) return dotCondition;
+  }
+  return null;
+}
+
+/** Pick the ESM target from a condition object per Node.js spec
+ *  ordering: `import` (the import-condition match) first, then
+ *  `default` (the universal fallback). Returns null when neither is
+ *  a string (e.g. only `require` is present, or the conditions are
+ *  nested objects this loader doesn't recurse into). */
+function pickEsmCondition(conditions: Record<string, unknown>): string | null {
+  if (typeof conditions.import === "string") return conditions.import;
+  if (typeof conditions.default === "string") return conditions.default;
   return null;
 }
 

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -57,7 +57,7 @@ export interface RuntimePlugin {
 interface PackageJson {
   name?: string;
   version?: string;
-  exports?: Record<string, unknown>;
+  exports?: string | Record<string, unknown>;
   main?: string;
   module?: string;
 }
@@ -69,14 +69,37 @@ const isToolDefinition = (value: unknown): value is ToolDefinition => {
   return typeof value.name === "string" && typeof value.description === "string";
 };
 
-/** Resolve the entry-point path from a plugin's `package.json`. Falls
- *  through `exports["."].import` → `module` → `main` so we cover both
- *  the modern `exports` shape and legacy `main`-only packages. */
+/** Resolve the entry-point path from a plugin's `package.json`. Covers
+ *  the four legal `exports` shapes per the Node.js spec, then falls
+ *  through to `module` / `main` for legacy packages.
+ *
+ *  Legal `exports` forms (Node.js docs):
+ *    1. String sugar:     `"exports": "./index.js"`
+ *    2. Conditional root: `"exports": { "import": "./esm.js", … }`
+ *    3. Subpath map:      `"exports": { ".": "./index.js", "./util": "./util.js", … }`
+ *    4. Subpath + cond.:  `"exports": { ".": { "import": "./esm.js", "require": "./cjs.js" } }`
+ *
+ *  Earlier the loader only matched form (4) and fell straight through
+ *  to `module` / `main`. Real npm packages using forms (1)-(3) failed
+ *  to load (#1077 review). */
 function resolveEntrySpecifier(pkg: PackageJson): string | null {
-  const root = pkg.exports?.["."];
-  if (isRecord(root) && typeof root.import === "string") return root.import;
+  const fromExports = resolveExportsField(pkg.exports);
+  if (fromExports) return fromExports;
   if (typeof pkg.module === "string") return pkg.module;
   if (typeof pkg.main === "string") return pkg.main;
+  return null;
+}
+
+function resolveExportsField(exportsField: PackageJson["exports"]): string | null {
+  // Form 1: top-level string sugar.
+  if (typeof exportsField === "string") return exportsField;
+  if (!isRecord(exportsField)) return null;
+  // Form 2: conditional root (e.g. { import, require }) — `import` wins.
+  if (typeof exportsField.import === "string") return exportsField.import;
+  // Form 3 / 4: subpath map keyed by `.`.
+  const root = exportsField["."];
+  if (typeof root === "string") return root;
+  if (isRecord(root) && typeof root.import === "string") return root.import;
   return null;
 }
 

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -92,35 +92,46 @@ function resolveEntrySpecifier(pkg: PackageJson): string | null {
 
 function resolveExportsField(exportsField: PackageJson["exports"]): string | null {
   // Form 1: top-level string sugar.
-  if (typeof exportsField === "string") return exportsField;
-  if (!isRecord(exportsField)) return null;
+  // Form A: array fallback chain (e.g. ["./dist/index.js", "./fallback.js"]).
   // Form 2: conditional root (e.g. `{ import, require, default }`).
-  // `import` wins for ESM; `default` is the spec-mandated fallback
-  // that "always matches" when no other condition does (Codex review
-  // on #1116). An ESM-only package may publish
-  // `{ "default": "./dist/index.js" }` with no `import` key at all —
-  // Node resolves it via `default`, so we must too.
-  const rootCondition = pickEsmCondition(exportsField);
-  if (rootCondition) return rootCondition;
-  // Form 3 / 4: subpath map keyed by `.`.
-  const root = exportsField["."];
-  if (typeof root === "string") return root;
-  if (isRecord(root)) {
-    const dotCondition = pickEsmCondition(root);
-    if (dotCondition) return dotCondition;
+  // Form 3 / 4: subpath map keyed by `.` — value can be a string,
+  //   array, or condition object (Codex review iter-2 on #1116).
+  const root = pickExportsTarget(exportsField);
+  if (root) return root;
+  if (isRecord(exportsField)) {
+    return pickExportsTarget(exportsField["."]);
   }
   return null;
 }
 
-/** Pick the ESM target from a condition object per Node.js spec
- *  ordering: `import` (the import-condition match) first, then
- *  `default` (the universal fallback). Returns null when neither is
- *  a string (e.g. only `require` is present, or the conditions are
- *  nested objects this loader doesn't recurse into). */
-function pickEsmCondition(conditions: Record<string, unknown>): string | null {
-  if (typeof conditions.import === "string") return conditions.import;
-  if (typeof conditions.default === "string") return conditions.default;
-  return null;
+/** Walk a Node.js `exports` value and return the first string entry
+ *  point this ESM loader can use. Handles every legal target shape:
+ *
+ *    - string: return it directly.
+ *    - array: try each element in order; first resolvable wins.
+ *      Per the spec arrays are a fallback chain — Node tries each
+ *      until one resolves on disk. We don't probe disk here, so
+ *      "first string-or-resolvable-condition" approximates that.
+ *    - condition object: prefer `import` (ESM-specific), then
+ *      `default` (universal fallback).
+ *    - everything else (e.g. only `require`, only nested arrays of
+ *      condition objects with no string targets): null. */
+function pickExportsTarget(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const resolved = pickExportsTarget(entry);
+      if (resolved) return resolved;
+    }
+    return null;
+  }
+  if (!isRecord(value)) return null;
+  // Condition object — `import` first (the ESM-specific condition
+  // match), then `default` (the universal fallback that "always
+  // matches" per the Node.js spec).
+  const fromImport = pickExportsTarget(value.import);
+  if (fromImport) return fromImport;
+  return pickExportsTarget(value.default);
 }
 
 /** Sentinel file written at the end of a successful extract. The

--- a/server/utils/files/plugins-io.ts
+++ b/server/utils/files/plugins-io.ts
@@ -16,7 +16,7 @@
 // atomic helper, so a crashed install can't leave a corrupt file.
 
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadJsonFile, writeJsonAtomic } from "./json.js";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
@@ -55,4 +55,46 @@ export async function writeLedger(entries: readonly LedgerEntry[]): Promise<void
     await mkdir(dir, { recursive: true });
   }
   await writeJsonAtomic(WORKSPACE_PATHS.pluginsLedger, [...entries]);
+}
+
+/** Read a runtime-plugin asset (extracted under
+ *  `plugins/.cache/<name>/<version>/`) and return its bytes plus
+ *  the inferred Content-Type. The route handler in
+ *  `runtime-plugin.ts` was previously calling `fs.readFile` directly
+ *  — per `CLAUDE.md` route handlers must go through a domain helper,
+ *  so the lookup table + read live here (#1077 review). */
+export interface PluginAsset {
+  data: Buffer;
+  contentType: string;
+}
+
+export async function readPluginAsset(absPath: string): Promise<PluginAsset> {
+  const data = await readFile(absPath);
+  const ext = path.extname(absPath).toLowerCase();
+  return { data, contentType: pluginAssetContentType(ext) };
+}
+
+// Lookup table over a switch — flat data structure stays under
+// `sonarjs/cognitive-complexity` while keeping the per-extension
+// mapping easy to scan.
+const PLUGIN_ASSET_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".cjs": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+export function pluginAssetContentType(ext: string): string {
+  return PLUGIN_ASSET_CONTENT_TYPES[ext] ?? "application/octet-stream";
 }

--- a/test/plugins/test_runtime_loader.ts
+++ b/test/plugins/test_runtime_loader.ts
@@ -227,5 +227,34 @@ describe("loadPluginFromCacheDir", () => {
       assert.ok(plugin, "legacy `main`-only packages must still load");
       assert.equal(plugin.definition.name, "fixture");
     });
+
+    it("falls back to `default` in a top-level conditional `exports` (ESM-only package, no `import` key)", async () => {
+      // Node.js resolves `exports: { default: "./entry.js" }` via the
+      // `default` condition because it "always matches" when no
+      // earlier condition fired. ESM-only packages may publish in
+      // exactly this shape with no `import` key at all (Codex review
+      // on #1116).
+      const dir = makeFixture({ exportsField: { default: "./entry.js" } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "top-level `exports.default` must resolve to the entry");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it('falls back to `default` in a subpath conditional `exports["."]`', async () => {
+      const dir = makeFixture({ exportsField: { ".": { default: "./entry.js" } } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "subpath `exports['.'].default` must resolve to the entry");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it("prefers `import` over `default` in a conditional object", async () => {
+      // When both keys are present, `import` is the more-specific
+      // condition and wins. Sanity: a fixture pointing `default` at a
+      // file we never write proves the loader didn't pick `default`.
+      const dir = makeFixture({ exportsField: { import: "./entry.js", default: "./never-written.js" } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "`import` must take precedence over `default`");
+      assert.equal(plugin.definition.name, "fixture");
+    });
   });
 });

--- a/test/plugins/test_runtime_loader.ts
+++ b/test/plugins/test_runtime_loader.ts
@@ -14,22 +14,39 @@ interface FixtureOpts {
   omitPackageJson?: boolean;
   /** When true, write malformed JSON in `package.json`. */
   corruptPackageJson?: boolean;
+  /** Override the `exports` field shape entirely. Used to exercise
+   *  the four legal Node.js shapes (#1077 review). When set, the
+   *  default conditional-subpath shape is skipped. */
+  exportsField?: unknown;
+  /** When true, omit `exports` and use `main` instead (legacy form). */
+  useMainOnly?: string;
 }
 
 function makeFixture(opts: FixtureOpts = {}): string {
   const dir = mkdtempSync(path.join(tmpdir(), "mulmo-runtime-loader-"));
   if (opts.omitPackageJson) return dir;
-  const pkg = opts.corruptPackageJson
-    ? "{ broken json"
-    : JSON.stringify({
-        name: "@fixture/plugin",
-        version: "1.0.0",
-        type: "module",
-        exports: { ".": { import: opts.exportsImport ?? "./entry.js" } },
-      });
+  const entrySpec = opts.exportsImport ?? "./entry.js";
+  let pkgRecord: Record<string, unknown>;
+  if (opts.useMainOnly) {
+    pkgRecord = {
+      name: "@fixture/plugin",
+      version: "1.0.0",
+      type: "module",
+      main: opts.useMainOnly,
+    };
+  } else {
+    pkgRecord = {
+      name: "@fixture/plugin",
+      version: "1.0.0",
+      type: "module",
+      exports: opts.exportsField ?? { ".": { import: entrySpec } },
+    };
+  }
+  const pkg = opts.corruptPackageJson ? "{ broken json" : JSON.stringify(pkgRecord);
   writeFileSync(path.join(dir, "package.json"), pkg);
   if (opts.corruptPackageJson) return dir;
-  const entryPath = path.join(dir, opts.exportsImport ?? "entry.js");
+  const entryRel = opts.useMainOnly ?? opts.exportsImport ?? "entry.js";
+  const entryPath = path.join(dir, entryRel);
   mkdirSync(path.dirname(entryPath), { recursive: true });
   writeFileSync(
     entryPath,
@@ -175,5 +192,40 @@ describe("loadPluginFromCacheDir", () => {
     );
     const plugin = await loadPluginFromCacheDir("@x/missing-entry", "1.0.0", dir);
     assert.equal(plugin, null);
+  });
+
+  // Cover the four legal `exports` shapes per the Node.js spec.
+  // Earlier the loader only matched the conditional-subpath form
+  // (form 4) and silently fell through to `module` / `main` for the
+  // others. Real npm packages using the simpler forms wouldn't load
+  // (#1077 review).
+  describe("resolveEntrySpecifier — `exports` field shapes", () => {
+    it("loads a plugin with top-level string `exports` (form 1: sugar)", async () => {
+      const dir = makeFixture({ exportsField: "./entry.js" });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "string-form `exports` must resolve to the entry");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it("loads a plugin with conditional-root `exports` (form 2: { import, require })", async () => {
+      const dir = makeFixture({ exportsField: { import: "./entry.js", require: "./entry.cjs" } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "conditional-root `exports.import` must resolve to the entry");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it('loads a plugin with subpath-string `exports["."]` (form 3)', async () => {
+      const dir = makeFixture({ exportsField: { ".": "./entry.js" } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "subpath-string `exports['.']` must resolve to the entry");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it("falls back to `main` when `exports` is absent (legacy)", async () => {
+      const dir = makeFixture({ useMainOnly: "./entry.js" });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "legacy `main`-only packages must still load");
+      assert.equal(plugin.definition.name, "fixture");
+    });
   });
 });

--- a/test/plugins/test_runtime_loader.ts
+++ b/test/plugins/test_runtime_loader.ts
@@ -256,5 +256,34 @@ describe("loadPluginFromCacheDir", () => {
       assert.ok(plugin, "`import` must take precedence over `default`");
       assert.equal(plugin.definition.name, "fixture");
     });
+
+    it("resolves a top-level array fallback chain", async () => {
+      // Per Node.js spec, `exports` may be an array of fallback
+      // targets. We don't probe disk per element — we pick the first
+      // string. Codex review iter-2 on #1116.
+      const dir = makeFixture({ exportsField: ["./entry.js", "./never-written.js"] });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "top-level array `exports` first element must resolve");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it('resolves an `exports["."]` array fallback chain', async () => {
+      const dir = makeFixture({ exportsField: { ".": ["./entry.js", "./never-written.js"] } });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "subpath array `exports['.'][0]` must resolve");
+      assert.equal(plugin.definition.name, "fixture");
+    });
+
+    it("resolves an array containing condition objects", async () => {
+      // A real-world shape from packages that ship multiple module
+      // formats: an array of condition objects. The loader picks the
+      // first one with a usable ESM target (`import` then `default`).
+      const dir = makeFixture({
+        exportsField: { ".": [{ require: "./cjs.js" }, { import: "./entry.js" }] },
+      });
+      const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+      assert.ok(plugin, "array of condition objects must surface the ESM target");
+      assert.equal(plugin.definition.name, "fixture");
+    });
   });
 });


### PR DESCRIPTION
## Summary

CodeRabbit review on PR #1077 (runtime plugin install) surfaced several follow-ups. This PR bundles the 4 substantive ones into one coherent change since they're all in the runtime-plugin code path:

1. **`runtime-loader.resolveEntrySpecifier` only matched 1 of 4 legal `exports` shapes** — packages using string sugar (\`\"exports\": \"./index.js\"\`), conditional root (\`{ import: \"…\" }\`), or subpath-string (\`{ \".\": \"./index.js\" }\`) silently fell through to the legacy `module`/`main` fallback. Now walks all four Node.js spec forms.
2. **`server/index.ts` passed only `MCP_PLUGIN_NAMES`** as collision set to `registerRuntimePlugins` while `mcp-server.ts` used the full `STATIC_TOOL_NAMES` (MCP plugins ∪ MCP tools). A runtime plugin could register parent-side and collide bridge-side. Aligned both.
3. **`runtime-plugin.ts` called `fs.readFile` directly.** Moved read + content-type lookup into `server/utils/files/plugins-io.readPluginAsset` per CLAUDE.md route-I/O rule. Content-type table changed from `switch` to `Record<>` lookup to stay under cognitive-complexity threshold.
4. **`mcp-server.ts` literal dispatch URL** → \`API_ROUTES.plugins.runtimeDispatch.replace(\":pkg\", ...)\`.

Adds 4 unit tests in `test_runtime_loader.ts` covering each `exports` shape (form 1: string sugar, form 2: conditional root, form 3: subpath-string, form 4: subpath conditional — already covered + legacy `main`-only fallback).

## Items deliberately skipped (from CodeRabbit's original list)

- **`mcp-server.ts:143` `process.stderr.write` → structured logger**: the standalone stdio process intentionally avoids the structured logger (which pulls in console/file/telemetry sinks). Diagnostic stderr output is the correct contract for a child of the Claude CLI.
- **`verify-phase-c.mts` component-shape assertions**: separate concern, deferred.
- **Markdown fence-language nits** in `plans/feat-plugin-c2-impl.md` / `docs/plugin-runtime.md`: bundled into a separate doc-cleanup PR.

## User Prompt

24h PR Quality Sweep — runtime plugin cluster from #1077.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] 19 \`runtime-loader\` tests pass (15 existing + 4 new \`exports\` shape coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved runtime plugin registration with expanded tool collision handling
  * Enhanced package resolution to support additional entry point configurations
  * Streamlined plugin asset serving with automatic content-type detection

* **Tests**
  * Added comprehensive coverage for plugin entry resolution across supported configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->