### PR TITLE
fix(accounting): restore visible focus on the new-account code field (#1115 follow-up)

### DIFF
--- a/src/plugins/accounting/components/AccountEditor.vue
+++ b/src/plugins/accounting/components/AccountEditor.vue
@@ -16,11 +16,17 @@
              editable input is restricted to the trailing 3 digits.
              The prefix span communicates the rule visually without
              needing a separate help string. -->
+        <!-- The trailing-3-digit input has `outline-none bg-transparent`
+             so the prefix span and the editable digits read as one
+             pill. That removes the browser's default focus indicator,
+             so we surface it on the wrapper via `focus-within:ring-1`
+             — same shape as the name input below — to keep the field
+             keyboard-discoverable (#1115 review). -->
         <div
           v-if="isNew"
           :class="[
             'flex items-stretch h-8 rounded border bg-white text-sm font-mono overflow-hidden',
-            codeError ? 'border-red-500 ring-1 ring-red-500' : 'border-gray-300',
+            codeError ? 'border-red-500 ring-1 ring-red-500' : 'border-gray-300 focus-within:ring-1 focus-within:ring-blue-500',
           ]"
         >
           <span


### PR DESCRIPTION
## Summary

Small a11y fix on the accounting Manage Accounts UI. The new-account code editor wraps a prefix span (\`100\`/\`200\`/…) and a trailing-3-digit \`<input>\` inside a styled \`<div>\` so they render as one pill. The input uses \`outline-none bg-transparent\` to keep the visual seamless — but that strips the browser's default focus ring, leaving a keyboard user with no indicator at all.

Mirrors the name-input pattern below (\`focus:ring-1 focus:ring-blue-500\`), but on the wrapper via \`focus-within:\` so the indicator surfaces wherever inside the wrapper has focus. Error path (red ring) is unchanged.

## Items to Confirm / Review

- The related #1113 finding (extract account-normalization into a helper) was already shipped — \`normalizeStoredAccount\` lives in \`server/accounting/accountNormalize.ts\` and is imported by \`upsertAccount\`. No additional work needed.
- Other findings on the accounting cluster (#1088 fixture / actions / sessionStorage; #1112 modal-out-of-form / aria-labelledby; #1113 onToggleActive errors) all already addressed in subsequent merges (#1103 / #1112 / #1113 themselves landed the fixes).

## User Prompt

24h PR Quality Sweep — accounting polish.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)