### PR TITLE
docs: add fence languages to runtime-plugin docs (#1077 follow-up)

### DIFF
--- a/docs/plugin-runtime.md
+++ b/docs/plugin-runtime.md
@@ -42,7 +42,7 @@ mv gui-chat-plugin-weather-*.tgz ~/mulmoclaude/plugins/
 
 Restart the server. Boot log:
 
-```
+```text
 [plugins/runtime] loaded requested=1 succeeded=1
 [plugins/runtime] registered runtime plugins presets=0 userInstalled=1 registered=1 collisions=0
 ```
@@ -65,7 +65,7 @@ There are three flavours of collision and the behaviour differs by source:
 
 1. **Runtime plugin name collides with a manifest-listed GUI plugin or a pure MCP tool** (everything fed into `MCP_PLUGIN_NAMES` plus `mcpToolDefs` keys: `notify`, `readXPost`, `searchX`, plus the manifest entries in [`config/plugins.registry.ts`](../config/plugins.registry.ts)). The runtime loader **rejects** the entry at registration time. The boot log records this:
 
-   ```
+   ```text
    [plugins/registry] skipping runtime plugin — name collides with static tool plugin=@x/notify-clone tool=notify
    ```
 
@@ -88,7 +88,7 @@ yarn dev
 
 Expected boot log (with weather installed in the ledger):
 
-```
+```text
 [plugins/runtime] loaded requested=1 succeeded=1
 [plugins/runtime] registered runtime plugins presets=0 userInstalled=1 registered=1 collisions=0
 ```

--- a/plans/feat-plugin-c2-impl.md
+++ b/plans/feat-plugin-c2-impl.md
@@ -19,7 +19,7 @@ Tracking: #1043 — umbrella for plugin SDK / dynamic install / marketplace.
 
 ### Workspace 配置
 
-```
+```text
 ~/mulmoclaude/
   plugins/
     plugins.json                      ← install 台帳 (source of truth)
@@ -86,7 +86,7 @@ export * from "vue";
 
 各 runtime plugin は同じ generic endpoint を共有:
 
-```
+```http
 POST /api/plugins/runtime/:pkgEncoded/dispatch
 body: { tool: string, args: Record<string, unknown> }
 ```


### PR DESCRIPTION
## Summary

CodeRabbit MD040 nits on the runtime-plugin docs that landed with #1077:

- \`docs/plugin-runtime.md\`: 3 boot-log blocks → \`text\`
- \`plans/feat-plugin-c2-impl.md\`: directory-tree → \`text\`, HTTP example → \`http\`

## Items already addressed in parent PRs (not in this PR)

- \`plans/feat-accounting-manage-accounts.md\` (#1112): fences already had languages on merge.
- \`plans/feat-e2e-live.md\` (#1104): line 341 already uses URL-only \`getCurrentSessionId(page)\` equality, line 343 already includes \`--project=chromium\` + \`HEADED=1\` in the unskip command.
- \`plans/feat-memory-edit-ui.md\` (#1109): trimmed in #1117.

## User Prompt

24h PR Quality Sweep — plan-doc cleanup batch.

## Test plan

- [x] Doc-only change; no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)