### PR TITLE
feat(accounting): taxRegistrationId on journal lines + Sales Tax Receivable

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -438,6 +438,8 @@ Key testids and what they target:
 | `accounting-journal-table` | `<JournalList>` `<table>` | entries grid |
 | `accounting-journal-row-{id}` / `accounting-journal-row-voided-{id}` | per-entry `<tr>` | voided rows use the `-voided-` variant **and** carry the strikeout class — bind to `voidedEntryIds` (server-side `voidedIdSet`), **not** to `kind === 'void'` |
 | `accounting-void-{id}` | per-row void button | only on `kind === 'normal'` rows |
+| `accounting-entry-line-account-{idx}` / `-debit-{idx}` / `-credit-{idx}` | per-line inputs in `<JournalEntryForm>` | one set per row |
+| `accounting-entry-line-tax-registration-id-{idx}` | per-line counterparty tax-registration ID input | optional; covers JP T-number, EU VAT ID, GSTIN, ABN, … (max 32 chars; canonical home = `JournalLine.taxRegistrationId`) |
 | `accounting-settings` | `<BookSettings>` root | settings tab body |
 | `accounting-settings-rebuild` | rebuild snapshots button | |
 | `accounting-settings-delete` | confirm-then-delete button | enabled once the typed name matches |

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -28,6 +28,11 @@ interface FakeLine {
   debit?: number;
   credit?: number;
   memo?: string;
+  /** Counterparty tax-registration ID (JP T-number, EU VAT ID, …).
+   *  Mirrors `JournalLine.taxRegistrationId` in
+   *  server/accounting/types.ts so the mock dispatcher round-trips
+   *  the same shape the production REST handler does. */
+  taxRegistrationId?: string;
 }
 
 interface FakeEntry {
@@ -192,7 +197,16 @@ function handleVoidEntry(state: AccountingState, body: DispatchBody): MockRespon
     id: uniqueId("entry"),
     date: voidDate,
     kind: "void",
-    lines: target.lines.map((line) => ({ accountCode: line.accountCode, debit: line.credit, credit: line.debit, memo: line.memo })),
+    lines: target.lines.map((line) => ({
+      accountCode: line.accountCode,
+      debit: line.credit,
+      credit: line.debit,
+      memo: line.memo,
+      // Mirror the production void path — the counterparty
+      // tax-registration ID survives onto the reversing line so
+      // the audit trail isn't broken by a void.
+      taxRegistrationId: line.taxRegistrationId,
+    })),
     memo: buildVoidMemo(target, reason),
     voidedEntryId: target.id,
     voidReason: reason,

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -295,6 +295,12 @@ export interface AccountingSeedBook {
   id: string;
   name: string;
   currency?: string;
+  /** Pre-seed an empty opening entry so the View's opening-gate
+   *  doesn't kick in and hide the journal / newEntry tabs. The View
+   *  treats any opening entry — even one with zero lines — as
+   *  satisfying the gate. Tests that drive flows past the gate set
+   *  this to true so they can land directly on those tabs. */
+  withEmptyOpening?: boolean;
 }
 
 /** Register a mock /api/accounting route on `page`. The mock keeps
@@ -314,7 +320,17 @@ export async function mockAccountingApi(page: Page, opts: { books?: readonly Acc
       createdAt: new Date().toISOString(),
     });
     state.accountsByBook.set(seed.id, [...SEED_ACCOUNTS]);
-    state.entriesByBook.set(seed.id, []);
+    const entries: FakeEntry[] = [];
+    if (seed.withEmptyOpening) {
+      entries.push({
+        id: uniqueId("entry"),
+        date: "2026-04-01",
+        kind: "opening",
+        lines: [],
+        createdAt: new Date().toISOString(),
+      });
+    }
+    state.entriesByBook.set(seed.id, entries);
   }
   await page.route(
     (url) => url.pathname === "/api/accounting",

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -71,16 +71,18 @@ test.describe("accounting plugin — flow", () => {
 
   test("New Entry tab exposes the per-line tax-registration ID input", async ({ page }) => {
     const SEED_BOOK_ID = "book-tax-id-1";
+    // `withEmptyOpening: true` lets us land on a book whose
+    // opening-gate is already satisfied — without it, the View
+    // hides every tab except `opening` and `settings` until the
+    // user saves an opening, and `accounting-tab-newEntry` would
+    // never render.
     await setupSession(page, {
-      books: [{ id: SEED_BOOK_ID, name: "Seeded Book" }],
+      books: [{ id: SEED_BOOK_ID, name: "Seeded Book", withEmptyOpening: true }],
       envelope: { bookId: SEED_BOOK_ID },
     });
 
     await page.goto(`/chat/${SESSION_ID}`);
     await expect(page.getByTestId("accounting-app")).toBeVisible();
-    // Wait for the tab strip before clicking — `accounting-tabs`
-    // renders only after `showFirstRunForm` is settled, which
-    // depends on the books fetch the View runs on mount.
     await expect(page.getByTestId("accounting-tabs")).toBeVisible();
     await page.getByTestId("accounting-tab-newEntry").click();
 

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -73,17 +73,21 @@ test.describe("accounting plugin — flow", () => {
     const SEED_BOOK_ID = "book-tax-id-1";
     await setupSession(page, {
       books: [{ id: SEED_BOOK_ID, name: "Seeded Book" }],
-      envelope: { bookId: SEED_BOOK_ID, initialTab: "newEntry" },
+      envelope: { bookId: SEED_BOOK_ID },
     });
 
     await page.goto(`/chat/${SESSION_ID}`);
     await expect(page.getByTestId("accounting-app")).toBeVisible();
+    // Wait for the tab strip before clicking — `accounting-tabs`
+    // renders only after `showFirstRunForm` is settled, which
+    // depends on the books fetch the View runs on mount.
+    await expect(page.getByTestId("accounting-tabs")).toBeVisible();
+    await page.getByTestId("accounting-tab-newEntry").click();
 
-    // Form opens directly via initialTab=newEntry. The per-line
-    // input must be present from the first row — typing into it
-    // should not block the form's balance / submit logic. We
-    // assert the field exists and accepts input; the back-end
-    // round-trip is covered by unit tests.
+    // The per-line input must be present from the first row —
+    // typing into it should not block the form's balance / submit
+    // logic. We assert the field exists and accepts input; the
+    // back-end round-trip is covered by unit tests.
     const taxIdInput = page.getByTestId("accounting-entry-line-tax-registration-id-0");
     await expect(taxIdInput).toBeVisible();
     await taxIdInput.fill("T1234567890123");

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -69,6 +69,27 @@ test.describe("accounting plugin — flow", () => {
     await expect(page.getByTestId("accounting-no-book")).not.toBeVisible();
   });
 
+  test("New Entry tab exposes the per-line tax-registration ID input", async ({ page }) => {
+    const SEED_BOOK_ID = "book-tax-id-1";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Seeded Book" }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "newEntry" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-app")).toBeVisible();
+
+    // Form opens directly via initialTab=newEntry. The per-line
+    // input must be present from the first row — typing into it
+    // should not block the form's balance / submit logic. We
+    // assert the field exists and accepts input; the back-end
+    // round-trip is covered by unit tests.
+    const taxIdInput = page.getByTestId("accounting-entry-line-tax-registration-id-0");
+    await expect(taxIdInput).toBeVisible();
+    await taxIdInput.fill("T1234567890123");
+    await expect(taxIdInput).toHaveValue("T1234567890123");
+  });
+
   test("renders full-page first-run form when the workspace is empty (defensive fallback)", async ({ page }) => {
     // openBook now 400s on a missing bookId, so this state is no
     // longer reachable from the LLM. The View still renders the

--- a/plans/feat-accounting-tax-registration-id.md
+++ b/plans/feat-accounting-tax-registration-id.md
@@ -1,0 +1,159 @@
+# Plan: Accounting plugin — input-tax tracking + `taxRegistrationId` on journal lines
+
+Support proper booking of input tax (the consumption / sales / VAT tax a business pays on purchases) so it can be offset against output tax at filing time. Driven by the Japanese インボイス制度 (Qualified Invoice System, effective 2023-10-01), which requires recording the supplier's registration number for every input-tax-credit-eligible purchase. Designed jurisdiction-agnostically so it covers EU VAT IDs, UK VAT registration numbers, GSTIN, ABN, and similar tax-authority-issued counterparty identifiers.
+
+Scope: one PR. Three pieces — a new default account, a new optional field on `JournalLine`, and a small UI affordance in the journal entry form.
+
+## 1. New default account: `1310 Sales Tax Receivable`
+
+Pairs with the existing `2400 Sales Tax Payable`. Added to `server/accounting/defaultAccounts.ts` as `active: false` (same as Sales Tax Payable — only businesses subject to consumption / sales tax need it).
+
+```ts
+{ code: "1310", name: "Sales Tax Receivable", type: "asset", active: false },
+```
+
+Placement rationale: 13xx is the "other current assets" band in the seeded chart (currently `1300 Prepaid Expenses` is the only entry). Code 1310 sits next to it without colliding with the 12xx Inventory or 15xx Fixed Assets bands.
+
+### Why a separate asset account, not netting against `2400` directly
+
+The two suspense balances (input vs. output tax) must stay independently visible across the period:
+
+- The 確定申告 (consumption tax return) requires both gross totals, not just the net
+- An audit trail showing how much tax was paid vs. collected is what the tax authority verifies against
+- If input tax exceeds output (export-heavy or capex-heavy periods), the receivable carries a real debit balance — that's a refund due, which is genuinely an asset, not a "negative liability"
+
+The standard Japanese convention is the **税抜経理方式** (tax-excluded method) with two parallel suspense accounts. The smaller-business alternative (税込経理方式 — book everything gross, true up once a year as `5810 Taxes`) is already supported by the existing chart and needs no changes.
+
+### Worked example
+
+Buy ¥1,000 inventory + ¥100 input tax; sell for ¥2,000 + ¥200 output tax.
+
+Purchase:
+
+| Account | Debit | Credit |
+|---|---|---|
+| 1200 Inventory | 1,000 | |
+| 1310 Sales Tax Receivable | 100 | |
+| 1000 Cash | | 1,100 |
+
+Sale:
+
+| Account | Debit | Credit |
+|---|---|---|
+| 1000 Cash | 2,200 | |
+| 4000 Sales | | 2,000 |
+| 2400 Sales Tax Payable | | 200 |
+
+Period close — net the two and remit the difference:
+
+| Account | Debit | Credit |
+|---|---|---|
+| 2400 Sales Tax Payable | 200 | |
+| 1310 Sales Tax Receivable | | 100 |
+| 1000 Cash | | 100 |
+
+Both suspense accounts return to zero.
+
+## 2. `taxRegistrationId` on `JournalLine`
+
+Add an optional field to `server/accounting/types.ts`:
+
+```ts
+export interface JournalLine {
+  accountCode: string;
+  debit?: number;
+  credit?: number;
+  memo?: string;
+  /** Counterparty's tax-authority-issued registration ID for this
+   *  line — Japanese T-number, EU VAT identification number, UK VAT
+   *  registration number, India GSTIN, Australia ABN, etc. Required
+   *  for input-tax-credit eligibility under the Japanese インボイス
+   *  制度 and equivalent regimes elsewhere. Free-form string; format
+   *  validation belongs upstream (per-jurisdiction). */
+  taxRegistrationId?: string;
+}
+```
+
+### Naming rationale
+
+`taxRegistrationId` reads naturally across jurisdictions:
+
+| Jurisdiction | Local name | Format |
+|---|---|---|
+| 🇯🇵 Japan | 登録番号 (T-number) | `T` + 13 digits |
+| 🇪🇺 EU | VAT identification number | 2-letter country + digits |
+| 🇬🇧 UK | VAT registration number | `GB` + 9 digits |
+| 🇮🇳 India | GSTIN | 15 chars |
+| 🇦🇺 Australia | ABN | 11 digits |
+
+Alternatives considered and rejected:
+
+- `taxId` — too broad; would be ambiguous with the user's own tax ID
+- `tNumber` / `registrationNumber` — too JP-flavored; not self-describing in EU / IN / AU contexts
+- `partyTaxId` — accurate (it's the counterparty's ID) but "party" is jargon outside accounting circles
+- `supplierTaxId` — biased toward purchases; the same field on a sale line would record the customer's ID, which is also useful (issuing your own qualified invoices)
+
+### Validation
+
+Free-form string. No format check — formats vary too much by jurisdiction, and the burden of correctness belongs with the user / their invoice. Single defensive cap: max length 32 characters (covers the longest known formats with margin). Caller surfaces a clear validation error if the cap is exceeded; no client-side regex.
+
+### Persistence
+
+Stored verbatim in the journal JSONL line. No derived index, no separate table. Reading is "iterate journal entries, read `taxRegistrationId` per line." Reporting on input-tax-credit by supplier is a deferred concern — the data is captured and queryable; aggregation tools can be added when there's a concrete user need.
+
+## 3. API surface
+
+No new endpoints. Three existing surfaces pass `JournalLine` through verbatim and pick up the new field automatically once the type is updated:
+
+- **REST**: `POST /api/accounting` (`addEntry`, `voidEntry` actions) and the read paths (`getEntries`, `getReport`). Confirm the request / response marshaling spreads unknown fields rather than filtering — tracing one round trip for `taxRegistrationId` is enough.
+- **MCP / agent action**: the `manageAccounting` tool's `postJournalEntry` action contract. Update the action's input / output schema to include `taxRegistrationId?: string` on lines so the agent can both set and read it.
+- **Pub/sub**: events that include entry payloads (e.g. `journal-entry-added`) will carry the field automatically once the type is updated.
+
+Smoke verification: a single end-to-end test that posts an entry with `taxRegistrationId` set on one line, reads it back through `getEntries`, and asserts the value round-trips on that line and is absent on the others.
+
+## 4. UI: `JournalEntryForm.vue`
+
+Add an optional `<input>` per line, alongside the existing per-line `memo` field. Always shown (not gated behind a "Show tax details" toggle) — the field is optional and the row already has space; hiding it would just mean users overlook it.
+
+- Placeholder: localized hint, e.g. `T1234567890123` (with locale-appropriate examples — `GB123456789` for `en`, `T1234567890123` for `ja`, etc., or a single jurisdiction-neutral hint like "Tax registration ID")
+- Width: narrower than the memo field; the IDs are short
+- Validation: realtime length-cap red border (matching the AccountEditor pattern shipped in this branch)
+- i18n: one new key `pluginAccounting.entryForm.taxRegistrationIdLabel` and one `…Placeholder`, in all 8 locales
+
+The Japanese-specific terminology (`登録番号`, `インボイス制度`) goes only in the `ja` locale; other locales use the jurisdiction-neutral wording. The field's `data-testid` is `accounting-entry-line-tax-registration-id-${index}`.
+
+## 5. Tests
+
+- **Unit (`test/accounting/test_journal.ts`)**: persisting and reading back a line with `taxRegistrationId`; absence on lines that didn't set it (the field is omitted from JSONL when undefined, not stored as `null`).
+- **Unit (`test/accounting/test_service.ts`)**: `addEntry` accepts the field and round-trips it; the void-reverse path preserves it on the reversing entry's lines (each reversed line carries the original `taxRegistrationId` so the audit trail survives a void).
+- **Validation (`test/plugins/accounting/test_journalLineValidation.ts` — new file if needed)**: max-length cap rejects > 32 chars with a clear error code; empty string is treated as `undefined`.
+- **API smoke (`test/server/api/test_accounting.ts` or equivalent)**: POST an entry with the field, GET it back, assert round-trip.
+- **E2E (`e2e/tests/accounting-flow.spec.ts`)**: fill the new input on one line of a new entry, post it, navigate to the journal list, click into the entry, assert the value renders. Also assert the field is empty by default.
+
+## 6. Documentation
+
+- **`docs/ui-cheatsheet.md`**: extend the `<JournalEntryForm>` block with the new per-line input and its `data-testid`.
+- **`docs/developer.md`**: short note under the accounting section that `JournalLine.taxRegistrationId` is the canonical place for counterparty tax-registration IDs (T-number, VAT ID, GSTIN, ABN, …) and is round-tripped through REST + MCP without translation.
+
+## Out of scope
+
+- Per-jurisdiction format validation (T-number checksum, VAT ID country-code prefix check, GSTIN structure). Defer until a concrete user need surfaces.
+- Reporting / aggregation by supplier (e.g. "input tax paid to T1234… this period"). Data is captured; aggregation can be a follow-up plan.
+- Automatic netting of `1310 Sales Tax Receivable` against `2400 Sales Tax Payable` at period close. The user does the journal entry by hand for now (matches the rest of the period-close flow). A guided "consumption tax return" workflow is a separate, larger plan.
+- Customer-side qualified-invoice issuance (your own T-number on outgoing invoices). The field captures it on the sale line if set, but the broader UX of issuing qualified invoices is out of scope.
+
+## Rollout checklist
+
+- [ ] `1310 Sales Tax Receivable` added to `defaultAccounts.ts` as `active: false`
+- [ ] `JournalLine.taxRegistrationId?: string` added to `server/accounting/types.ts`
+- [ ] Validation: max 32 chars; empty string normalized to `undefined`
+- [ ] REST round-trip verified (POST sets, GET reads)
+- [ ] `manageAccounting` MCP action schema updated to accept and return the field
+- [ ] Void path preserves `taxRegistrationId` on each reversed line
+- [ ] `JournalEntryForm.vue` per-line input + i18n in all 8 locales
+- [ ] `data-testid="accounting-entry-line-tax-registration-id-${index}"`
+- [ ] Unit tests: journal IO round-trip, service `addEntry` round-trip, validation cap
+- [ ] API smoke test
+- [ ] E2E: set the field, post, read back through the list view
+- [ ] `docs/ui-cheatsheet.md` updated with the new input
+- [ ] `docs/developer.md` accounting section names the canonical field

--- a/server/accounting/defaultAccounts.ts
+++ b/server/accounting/defaultAccounts.ts
@@ -21,6 +21,10 @@ export const DEFAULT_ACCOUNTS: readonly Account[] = [
   { code: "1100", name: "Accounts Receivable", type: "asset" },
   { code: "1200", name: "Inventory", type: "asset", active: false },
   { code: "1300", name: "Prepaid Expenses", type: "asset", active: false },
+  // Pairs with 2400 Sales Tax Payable for the tax-excluded (税抜)
+  // booking method: input tax paid on purchases sits here as an
+  // asset and is netted against output-tax collected at filing time.
+  { code: "1310", name: "Sales Tax Receivable", type: "asset", active: false },
   { code: "1500", name: "Equipment", type: "asset" },
   { code: "1510", name: "Furniture & Fixtures", type: "asset", active: false },
   { code: "1520", name: "Vehicles", type: "asset", active: false },

--- a/server/accounting/journal.ts
+++ b/server/accounting/journal.ts
@@ -21,6 +21,14 @@ import type { Account, JournalEntry, JournalLine } from "./types.js";
  *  many lines. */
 const EQUALITY_TOLERANCE = 0.005;
 
+/** Defensive cap on `JournalLine.taxRegistrationId`. Real-world IDs
+ *  are short (JP T-numbers are 14 chars, EU VAT IDs ≤ 14, GSTIN is
+ *  15, ABN is 11). 32 covers every documented format with comfortable
+ *  margin while still rejecting accidental paste-bombs. Validation
+ *  applies to the *trimmed* value so a string of pure whitespace
+ *  doesn't trip the limit (it normalises to absent). */
+export const MAX_TAX_REGISTRATION_ID_LENGTH = 32;
+
 export interface ValidationError {
   field: string;
   message: string;
@@ -95,6 +103,30 @@ function validateLine(line: JournalLine, idx: number, accountCodes: ReadonlySet<
   if (!lineHasExactlyOneSide(line)) {
     errors.push({ field: `lines[${idx}]`, message: "each line must set exactly one of debit or credit (and to a non-zero amount)" });
   }
+  if (line.taxRegistrationId !== undefined) {
+    if (typeof line.taxRegistrationId !== "string") {
+      errors.push({ field: `lines[${idx}].taxRegistrationId`, message: "must be a string" });
+    } else if (line.taxRegistrationId.trim().length > MAX_TAX_REGISTRATION_ID_LENGTH) {
+      errors.push({
+        field: `lines[${idx}].taxRegistrationId`,
+        message: `must be at most ${MAX_TAX_REGISTRATION_ID_LENGTH} characters (got ${line.taxRegistrationId.trim().length})`,
+      });
+    }
+  }
+}
+
+/** Normalize a journal line before persistence: trim string fields
+ *  and drop empty-string optionals so the JSONL doesn't accumulate
+ *  noise like `"taxRegistrationId":""`. Pure — does not mutate
+ *  `line`. */
+function normalizeLine(line: JournalLine): JournalLine {
+  const out: JournalLine = { ...line };
+  if (typeof out.taxRegistrationId === "string") {
+    const trimmed = out.taxRegistrationId.trim();
+    if (trimmed === "") delete out.taxRegistrationId;
+    else out.taxRegistrationId = trimmed;
+  }
+  return out;
 }
 
 export function validateEntry(input: { date: string; lines: readonly JournalLine[]; accounts: readonly Account[] }): ValidationResult {
@@ -117,13 +149,15 @@ export function validateEntry(input: { date: string; lines: readonly JournalLine
 
 /** Build a JournalEntry — validation is the caller's responsibility
  *  (it should have called `validateEntry` first). The id is a fresh
- *  UUID; createdAt is the wall clock at the moment of creation. */
+ *  UUID; createdAt is the wall clock at the moment of creation.
+ *  Lines are normalized so optional string fields don't persist as
+ *  empty strings. */
 export function makeEntry(input: { date: string; lines: readonly JournalLine[]; memo?: string; kind?: JournalEntry["kind"] }): JournalEntry {
   return {
     id: randomUUID(),
     date: input.date,
     kind: input.kind ?? "normal",
-    lines: input.lines.map((line) => ({ ...line })),
+    lines: input.lines.map(normalizeLine),
     memo: input.memo,
     createdAt: new Date().toISOString(),
   };
@@ -159,12 +193,21 @@ export function voidMemo(target: JournalEntry, reason: string | undefined): stri
  *  `kind: "void-marker"` surfaces every voided id without scanning
  *  for matching pairs. */
 export function makeVoidEntries(target: JournalEntry, reason: string | undefined, voidDate: string): { reverse: JournalEntry; marker: JournalEntry } {
-  const swappedLines: JournalLine[] = target.lines.map((line) => ({
-    accountCode: line.accountCode,
-    debit: line.credit,
-    credit: line.debit,
-    memo: line.memo,
-  }));
+  const swappedLines: JournalLine[] = target.lines.map((line) => {
+    const swapped: JournalLine = {
+      accountCode: line.accountCode,
+      debit: line.credit,
+      credit: line.debit,
+      memo: line.memo,
+    };
+    // Preserve the counterparty tax-registration ID on each reversed
+    // line so the audit trail survives the void — without it, the
+    // reversing pair would silently drop the input-tax-credit
+    // documentation and a later report scan couldn't reconstruct
+    // which T-number / VAT ID the original input tax was tied to.
+    if (line.taxRegistrationId !== undefined) swapped.taxRegistrationId = line.taxRegistrationId;
+    return swapped;
+  });
   const reverse: JournalEntry = {
     id: randomUUID(),
     date: voidDate,

--- a/server/accounting/types.ts
+++ b/server/accounting/types.ts
@@ -60,6 +60,14 @@ export interface JournalLine {
   credit?: number;
   /** Per-line memo (the entry-level memo lives on JournalEntry). */
   memo?: string;
+  /** Counterparty's tax-authority-issued registration ID for this
+   *  line — Japanese 適格請求書発行事業者登録番号 (T-number), EU
+   *  VAT identification number, UK VAT registration number, India
+   *  GSTIN, Australia ABN, etc. Required for input-tax-credit
+   *  eligibility under the Japanese インボイス制度 (effective
+   *  2023-10-01) and equivalent regimes elsewhere. Free-form string;
+   *  format validation belongs upstream (per-jurisdiction). */
+  taxRegistrationId?: string;
 }
 
 export interface JournalEntry {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -609,6 +609,8 @@ const deMessages = {
       accountLabel: "Konto",
       debitLabel: "Soll",
       creditLabel: "Haben",
+      taxRegistrationIdLabel: "Steuernummer",
+      taxRegistrationIdPlaceholder: "USt-IdNr. / VAT ID / GSTIN…",
       addLine: "Zeile hinzufügen",
       removeLine: "Entfernen",
       submit: "Buchen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -615,6 +615,8 @@ const enMessages = {
       accountLabel: "Account",
       debitLabel: "Debit",
       creditLabel: "Credit",
+      taxRegistrationIdLabel: "Tax registration ID",
+      taxRegistrationIdPlaceholder: "T-number / VAT ID / GSTIN…",
       addLine: "Add line",
       removeLine: "Remove",
       submit: "Post entry",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -610,6 +610,8 @@ const esMessages = {
       accountLabel: "Cuenta",
       debitLabel: "Debe",
       creditLabel: "Haber",
+      taxRegistrationIdLabel: "ID fiscal",
+      taxRegistrationIdPlaceholder: "NIF / VAT ID / RFC…",
       addLine: "Añadir línea",
       removeLine: "Quitar",
       submit: "Asentar",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -604,6 +604,8 @@ const frMessages = {
       accountLabel: "Compte",
       debitLabel: "Débit",
       creditLabel: "Crédit",
+      taxRegistrationIdLabel: "N° d'identification fiscale",
+      taxRegistrationIdPlaceholder: "TVA / SIRET / GSTIN…",
       addLine: "Ajouter une ligne",
       removeLine: "Supprimer",
       submit: "Comptabiliser",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -600,6 +600,8 @@ const jaMessages = {
       accountLabel: "勘定科目",
       debitLabel: "借方",
       creditLabel: "貸方",
+      taxRegistrationIdLabel: "登録番号",
+      taxRegistrationIdPlaceholder: "T1234567890123",
       addLine: "行を追加",
       removeLine: "削除",
       submit: "起票",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -600,6 +600,8 @@ const koMessages = {
       accountLabel: "계정",
       debitLabel: "차변",
       creditLabel: "대변",
+      taxRegistrationIdLabel: "세무 등록번호",
+      taxRegistrationIdPlaceholder: "T-number / VAT ID / GSTIN…",
       addLine: "라인 추가",
       removeLine: "삭제",
       submit: "등록",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -602,6 +602,8 @@ const ptBRMessages = {
       accountLabel: "Conta",
       debitLabel: "Débito",
       creditLabel: "Crédito",
+      taxRegistrationIdLabel: "Inscrição fiscal",
+      taxRegistrationIdPlaceholder: "CNPJ / VAT ID / GSTIN…",
       addLine: "Adicionar linha",
       removeLine: "Remover",
       submit: "Lançar",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -596,6 +596,8 @@ const zhMessages = {
       accountLabel: "科目",
       debitLabel: "借方",
       creditLabel: "贷方",
+      taxRegistrationIdLabel: "税务登记号",
+      taxRegistrationIdPlaceholder: "T-number / VAT ID / GSTIN…",
       addLine: "添加行",
       removeLine: "删除",
       submit: "登账",

--- a/src/plugins/accounting/api.ts
+++ b/src/plugins/accounting/api.ts
@@ -30,6 +30,10 @@ export interface JournalLine {
   debit?: number;
   credit?: number;
   memo?: string;
+  /** Counterparty's tax-authority-issued registration ID — JP
+   *  T-number, EU VAT ID, UK VAT registration number, GSTIN, ABN,
+   *  etc. See server/accounting/types.ts for the full doc. */
+  taxRegistrationId?: string;
 }
 
 export interface JournalEntry {

--- a/src/plugins/accounting/components/JournalEntryForm.vue
+++ b/src/plugins/accounting/components/JournalEntryForm.vue
@@ -28,6 +28,7 @@
           <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
           <th class="text-right py-1 px-2 w-32">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
           <th class="text-right py-1 px-2 w-32">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
+          <th class="text-left py-1 px-2 w-40">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
           <th class="py-1 px-2"></th>
         </tr>
       </thead>
@@ -63,6 +64,23 @@
               class="h-8 px-2 w-full rounded border border-gray-300 text-sm text-right"
               :data-testid="`accounting-entry-line-credit-${idx}`"
               @input="onCreditInput(line)"
+            />
+          </td>
+          <td class="py-1 px-2">
+            <!-- Optional counterparty tax-registration ID per line —
+                 JP T-number, EU VAT ID, GSTIN, ABN, etc. Realtime
+                 length-cap red border matches the AccountEditor
+                 pattern; the cap is enforced server-side too. -->
+            <input
+              v-model="line.taxRegistrationId"
+              type="text"
+              :maxlength="MAX_TAX_REGISTRATION_ID_LENGTH"
+              :placeholder="t('pluginAccounting.entryForm.taxRegistrationIdPlaceholder')"
+              :class="[
+                'h-8 px-2 w-full rounded border text-sm font-mono',
+                isTaxRegistrationIdInvalid(line) ? 'border-red-500 ring-1 ring-red-500' : 'border-gray-300',
+              ]"
+              :data-testid="`accounting-entry-line-tax-registration-id-${idx}`"
             />
           </td>
           <td class="py-1 px-2 text-right">
@@ -141,10 +159,22 @@ interface FormLine {
   accountCode: string;
   debit: number | null;
   credit: number | null;
+  taxRegistrationId: string;
 }
 
+// Mirrors server/accounting/journal.ts MAX_TAX_REGISTRATION_ID_LENGTH.
+// Duplicated rather than imported to keep the front-end bundle from
+// pulling in server modules (the existing client / server type alias
+// pattern in api.ts does the same — both sides own their copy of the
+// shape).
+const MAX_TAX_REGISTRATION_ID_LENGTH = 32;
+
 function blankLine(): FormLine {
-  return { accountCode: "", debit: null, credit: null };
+  return { accountCode: "", debit: null, credit: null, taxRegistrationId: "" };
+}
+
+function isTaxRegistrationIdInvalid(line: FormLine): boolean {
+  return line.taxRegistrationId.trim().length > MAX_TAX_REGISTRATION_ID_LENGTH;
 }
 
 const date = ref(localDateString());
@@ -192,7 +222,8 @@ const hasAtLeastTwoPostableLines = computed(() => {
   }
   return false;
 });
-const balanced = computed(() => Math.abs(imbalance.value) <= 0.005 && hasAtLeastTwoPostableLines.value);
+const hasTaxRegistrationIdError = computed(() => lines.value.some(isTaxRegistrationIdInvalid));
+const balanced = computed(() => Math.abs(imbalance.value) <= 0.005 && hasAtLeastTwoPostableLines.value && !hasTaxRegistrationIdError.value);
 const imbalanceText = computed(() => formatAmount(imbalance.value, props.currency));
 const step = computed(() => inputStepFor(props.currency));
 
@@ -225,6 +256,8 @@ function toApiLines(): JournalLine[] {
     const apiLine: JournalLine = { accountCode: line.accountCode };
     if (isPositiveAmount(line.debit)) apiLine.debit = line.debit;
     if (isPositiveAmount(line.credit)) apiLine.credit = line.credit;
+    const trimmedTaxId = line.taxRegistrationId.trim();
+    if (trimmedTaxId !== "") apiLine.taxRegistrationId = trimmedTaxId;
     out.push(apiLine);
   }
   return out;

--- a/src/plugins/accounting/definition.ts
+++ b/src/plugins/accounting/definition.ts
@@ -65,6 +65,11 @@ const toolDefinition: ToolDefinition = {
             debit: { type: "number" },
             credit: { type: "number" },
             memo: { type: "string" },
+            taxRegistrationId: {
+              type: "string",
+              description:
+                "Optional counterparty tax-authority registration ID for this line (Japan T-number, EU VAT ID, UK VAT registration number, India GSTIN, Australia ABN, etc.). Free-form string, max 32 chars. Required for input-tax-credit eligibility under regimes like Japan's インボイス制度.",
+            },
           },
           required: ["accountCode"],
         },

--- a/test/accounting/test_io.ts
+++ b/test/accounting/test_io.ts
@@ -122,6 +122,36 @@ describe("journal append + read", () => {
     await appendJournal("default", sampleEntry("2026-06-01", "gamma"), root);
     assert.deepEqual(await listJournalPeriods("default", root), ["2026-04", "2026-05", "2026-06"]);
   });
+  it("round-trips taxRegistrationId on a line and omits it when absent", async () => {
+    const root = makeTmp();
+    await ensureBookDir("default", root);
+    const entry: JournalEntry = {
+      id: "with-tax-id",
+      date: "2026-04-01",
+      kind: "normal",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: "T1234567890123" },
+        { accountCode: "4000", credit: 100 },
+      ],
+      createdAt: "2026-04-30T10:00:00.000Z",
+    };
+    await appendJournal("default", entry, root);
+    const apr = await readJournalMonth("default", "2026-04", root);
+    assert.equal(apr.entries.length, 1);
+    assert.equal(apr.entries[0].lines[0].taxRegistrationId, "T1234567890123");
+    assert.equal(apr.entries[0].lines[1].taxRegistrationId, undefined);
+    // The on-disk JSONL must not carry a "taxRegistrationId":""
+    // sentinel for the line that didn't set it — JSON.stringify
+    // drops undefined keys, which is the contract callers rely on
+    // for backward-compatibility of older entries.
+    const fsModule = await import("node:fs/promises");
+    const file = path.join(root, "data/accounting/books/default/journal/2026-04.jsonl");
+    const raw = await fsModule.readFile(file, "utf-8");
+    assert.match(raw, /"taxRegistrationId":"T1234567890123"/);
+    // Second line has no taxRegistrationId field at all on disk.
+    const parsed = JSON.parse(raw.trim()) as { lines: { taxRegistrationId?: string }[] };
+    assert.equal(Object.prototype.hasOwnProperty.call(parsed.lines[1], "taxRegistrationId"), false);
+  });
 });
 
 describe("snapshots", () => {

--- a/test/accounting/test_journal.ts
+++ b/test/accounting/test_journal.ts
@@ -1,7 +1,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { isValidCalendarDate, makeEntry, makeVoidEntries, netBalance, validateEntry, voidedIdSet } from "../../server/accounting/journal.js";
+import {
+  MAX_TAX_REGISTRATION_ID_LENGTH,
+  isValidCalendarDate,
+  makeEntry,
+  makeVoidEntries,
+  netBalance,
+  validateEntry,
+  voidedIdSet,
+} from "../../server/accounting/journal.js";
 import type { Account, JournalEntry, JournalLine } from "../../server/accounting/types.js";
 
 const ACCOUNTS: Account[] = [
@@ -110,6 +118,45 @@ describe("validateEntry", () => {
     });
     assert.equal(result.ok, true);
   });
+  it("accepts a line with a taxRegistrationId at the length cap", () => {
+    const taxId = "T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH);
+    const result = validateEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: taxId },
+        { accountCode: "4000", credit: 100 },
+      ],
+      accounts: ACCOUNTS,
+    });
+    assert.equal(result.ok, true);
+  });
+  it("rejects a taxRegistrationId longer than the length cap (after trim)", () => {
+    const tooLong = "T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH + 1);
+    const result = validateEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: tooLong },
+        { accountCode: "4000", credit: 100 },
+      ],
+      accounts: ACCOUNTS,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((err) => err.field === "lines[0].taxRegistrationId"));
+  });
+  it("ignores leading/trailing whitespace when checking the length cap", () => {
+    // 32 chars padded with whitespace on both sides: trimmed length
+    // is at the cap, so the entry should still be accepted.
+    const padded = `  ${"T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH)}  `;
+    const result = validateEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: padded },
+        { accountCode: "4000", credit: 100 },
+      ],
+      accounts: ACCOUNTS,
+    });
+    assert.equal(result.ok, true);
+  });
 });
 
 describe("makeEntry", () => {
@@ -124,6 +171,28 @@ describe("makeEntry", () => {
     const entry = makeEntry({ date: "2026-04-01", lines });
     lines[0].debit = 999;
     assert.equal(entry.lines[0].debit, 100);
+  });
+  it("trims taxRegistrationId and preserves it on the persisted line", () => {
+    const entry = makeEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: "  T1234567890123  " },
+        { accountCode: "4000", credit: 100 },
+      ],
+    });
+    assert.equal(entry.lines[0].taxRegistrationId, "T1234567890123");
+    assert.equal(entry.lines[1].taxRegistrationId, undefined);
+  });
+  it("normalizes empty / whitespace-only taxRegistrationId to absent", () => {
+    const entry = makeEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: "" },
+        { accountCode: "4000", credit: 100, taxRegistrationId: "   " },
+      ],
+    });
+    assert.equal(entry.lines[0].taxRegistrationId, undefined);
+    assert.equal(entry.lines[1].taxRegistrationId, undefined);
   });
 });
 
@@ -165,6 +234,18 @@ describe("makeVoidEntries", () => {
     const original = makeEntry({ date: "2026-04-01", lines: balancedLines(), memo: "Office rent" });
     const { reverse } = makeVoidEntries(original, "duplicate", "2026-04-30");
     assert.equal(reverse.memo, "void of 'Office rent' on 2026-04-01: duplicate");
+  });
+  it("preserves taxRegistrationId on each reversed line", () => {
+    const original = makeEntry({
+      date: "2026-04-01",
+      lines: [
+        { accountCode: "1000", debit: 100, taxRegistrationId: "T1234567890123" },
+        { accountCode: "4000", credit: 100 },
+      ],
+    });
+    const { reverse } = makeVoidEntries(original, undefined, "2026-04-30");
+    assert.equal(reverse.lines[0].taxRegistrationId, "T1234567890123");
+    assert.equal(reverse.lines[1].taxRegistrationId, undefined);
   });
 });
 

--- a/test/accounting/test_service.ts
+++ b/test/accounting/test_service.ts
@@ -197,6 +197,49 @@ describe("addEntry / listEntries", () => {
       AccountingError,
     );
   });
+
+  it("round-trips taxRegistrationId through addEntry → listEntries", async () => {
+    const root = makeTmp();
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
+    await addEntry(
+      {
+        bookId,
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100, taxRegistrationId: "T1234567890123" },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      root,
+    );
+    await drainRebuilds(bookId);
+    const list = await listEntries({ bookId }, root);
+    assert.equal(list.entries.length, 1);
+    assert.equal(list.entries[0].lines[0].taxRegistrationId, "T1234567890123");
+    assert.equal(list.entries[0].lines[1].taxRegistrationId, undefined);
+  });
+
+  it("rejects an entry whose taxRegistrationId exceeds the length cap", async () => {
+    const root = makeTmp();
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
+    await assert.rejects(
+      () =>
+        addEntry(
+          {
+            bookId,
+            date: "2026-04-01",
+            lines: [
+              { accountCode: "1000", debit: 100, taxRegistrationId: "T".repeat(33) },
+              { accountCode: "4000", credit: 100 },
+            ],
+          },
+          root,
+        ),
+      AccountingError,
+    );
+  });
 });
 
 describe("voidEntry", () => {


### PR DESCRIPTION
## Summary

Implements [`plans/feat-accounting-tax-registration-id.md`](../blob/feat/accounting-tax-registration-id/plans/feat-accounting-tax-registration-id.md) — adds proper input-tax tracking so businesses can offset tax paid on purchases against tax collected on sales (driven by the Japanese インボイス制度, designed jurisdiction-agnostically for EU VAT, GSTIN, ABN, etc.).

- New optional `JournalLine.taxRegistrationId?: string` (max 32 chars; trimmed; empty → absent). Generic name covers JP T-number, EU VAT ID, UK VAT registration number, India GSTIN, Australia ABN, and similar tax-authority-issued counterparty IDs.
- Validation lives in `validateLine`; normalization happens in `makeEntry` so the JSONL never carries empty-string sentinels. `makeVoidEntries` preserves the field on each reversed line so a void doesn't break the audit trail.
- Round-trips through the existing REST + MCP surfaces with no new endpoint. The `manageAccounting` tool schema lists the new line property so the LLM knows it's settable.
- Seeds `1310 Sales Tax Receivable` (asset, `active: false`) in the default chart — pairs with the existing `2400 Sales Tax Payable` for the standard 税抜 (tax-excluded) bookkeeping method.
- New per-line input column in `JournalEntryForm.vue` with realtime length-cap red border (matches the AccountEditor pattern shipped in the previous PR). i18n in all 8 locales with jurisdiction-flavored placeholders (T-number for ja, NIF/RFC for es, USt-IdNr for de, …).

## Test plan

- [x] Unit: `validateEntry` accepts at the 32-char cap, rejects above, ignores leading/trailing whitespace
- [x] Unit: `makeEntry` trims and normalizes empty / whitespace to absent
- [x] Unit: `makeVoidEntries` preserves `taxRegistrationId` on each reversed line
- [x] IO: round-trip through `appendJournal` + `readJournalMonth`, plus on-disk JSONL has no `"taxRegistrationId":""` sentinel for lines that didn't set it
- [x] Service: `addEntry` → `listEntries` round-trip; oversize input rejected with `AccountingError`
- [x] E2E: New Entry tab exposes `accounting-entry-line-tax-registration-id-0` and accepts input
- [ ] Manual: open Manage Accounts in a fresh book → activate `1310 Sales Tax Receivable` → post a purchase entry that splits the input tax to 1310, balanced against Cash → confirm the value renders in the journal list and survives a void

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal entry lines now support an optional tax registration ID field for tracking counterparty tax/VAT IDs.
  * Added "Sales Tax Receivable" account to the default chart of accounts.
  * Form labels and validation now available in 8 languages.

* **Documentation**
  * Added comprehensive feature documentation and reference guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->