### PR TITLE
fix(accounting): activate sales-tax accounts in the default chart

### DIFF
--- a/server/accounting/defaultAccounts.ts
+++ b/server/accounting/defaultAccounts.ts
@@ -24,7 +24,11 @@ export const DEFAULT_ACCOUNTS: readonly Account[] = [
   // Pairs with 2400 Sales Tax Payable for the tax-excluded (税抜)
   // booking method: input tax paid on purchases sits here as an
   // asset and is netted against output-tax collected at filing time.
-  { code: "1310", name: "Sales Tax Receivable", type: "asset", active: false },
+  // Active by default — most jurisdictions levy a consumption /
+  // sales / VAT tax, so flipping this on out of the box matches
+  // first-run expectations. Users in genuinely tax-free contexts
+  // can deactivate from Manage Accounts.
+  { code: "1310", name: "Sales Tax Receivable", type: "asset" },
   { code: "1500", name: "Equipment", type: "asset" },
   { code: "1510", name: "Furniture & Fixtures", type: "asset", active: false },
   { code: "1520", name: "Vehicles", type: "asset", active: false },
@@ -34,7 +38,8 @@ export const DEFAULT_ACCOUNTS: readonly Account[] = [
   { code: "2100", name: "Credit Card", type: "liability" },
   { code: "2200", name: "Loans Payable", type: "liability" },
   { code: "2300", name: "Accrued Expenses", type: "liability", active: false },
-  { code: "2400", name: "Sales Tax Payable", type: "liability", active: false },
+  // Active by default; pairs with 1310 Sales Tax Receivable.
+  { code: "2400", name: "Sales Tax Payable", type: "liability" },
   { code: "2500", name: "Payroll Liabilities", type: "liability", active: false },
   // Equity
   // Required for opening balances: setOpeningBalances dumps the


### PR DESCRIPTION
## Summary

Flips `1310 Sales Tax Receivable` and `2400 Sales Tax Payable` from `active: false` to active in `server/accounting/defaultAccounts.ts`.

Almost every jurisdiction levies a consumption / sales / VAT tax, so a fresh book that hides both accounts behind Manage Accounts forces the user through an extra step on the very first 税抜 (tax-excluded) entry. Users in genuinely tax-free contexts can still deactivate the pair from Manage Accounts with one click each.

## Test plan

- [ ] Create a fresh book → confirm `1310 Sales Tax Receivable` and `2400 Sales Tax Payable` appear in the entry-form account dropdown without first activating them
- [ ] Existing books are unaffected (the seed only runs at book creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sales Tax Receivable and Sales Tax Payable accounts are now active by default in the chart of accounts setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->