### PR TITLE
chore: bump gui-chat-protocol 0.2.0 → 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "echarts": "^6.0.0",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.2",
-    "gui-chat-protocol": "0.2.0",
+    "gui-chat-protocol": "0.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.2",
-    "gui-chat-protocol": "0.2.0",
+    "gui-chat-protocol": "0.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,10 +4736,10 @@ groq-sdk@^0.30.0:
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"
 
-gui-chat-protocol@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.2.0.tgz#acd54ecb4d4943f528d1d6920122a7327ee98b45"
-  integrity sha512-w0CPpZMXTtYoJsX7nMBy+3fI6Qil1lLgiVwciGpNRPthuWwG+X5xACOPxrb4hR27VGmF4dQyXNK1HlM2Z35tSA==
+gui-chat-protocol@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.3.0.tgz#06825160b3d1f23250f8d303912cb85f87694f1f"
+  integrity sha512-aaDTsiQH/AYMUMlBXiqHmL9q1I8R9FXIB3k9+0DHWKa0BsyxblZpi3Cxrfd5c+LucbiYAjfCjsDoRoIYZQu/kg==
 
 gui-chat-protocol@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

Bumps \`gui-chat-protocol\` from 0.2.0 to 0.3.0 in both the root \`package.json\` and \`packages/mulmoclaude/package.json\` (launcher tarball).

v0.3.0 ships:
- \`definePlugin\` — strict-handler factory
- \`useRuntime\` — composition API for plugin runtime context
- \`eslint-preset\` — opinionated lint rules for plugin authors
- All additive — existing 0.2.0 surface (\`ToolDefinition\`, \`ToolPlugin\`, \`Attachment\`, \`ToolResult\`, \`action\` field, etc.) is unchanged.

## Items to Confirm / Review

- This PR is dep-bump only. No in-tree call sites migrate to the new APIs yet — the \`definePlugin\` / \`useRuntime\` adoption is a separate refactor (existing static plugins under \`src/plugins/*\` keep their current shapes).
- \`packages/mulmoclaude\` (the npm-publishable launcher) is bumped in lockstep; per the \`/publish-mulmoclaude\` skill the dep audit / drift check would otherwise fail at next publish time.

## Test plan

- [x] \`yarn install && yarn format && yarn lint && yarn typecheck && yarn build && yarn test\`
- [x] \`node_modules/gui-chat-protocol/package.json\` shows 0.3.0
- [x] No type errors → existing 0.2.0 surface still resolves under 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's protocol dependency to version 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->