### PR TITLE
feat: runtime plugin platform extensions (#1110)

### DIFF
--- a/docs/plugin-runtime.md
+++ b/docs/plugin-runtime.md
@@ -170,16 +170,200 @@ The plugin's tool name must NOT collide with any static MCP tool or any other ru
 
 ## How to write a plugin
 
-Use [`gui-chat-protocol`](https://www.npmjs.com/package/gui-chat-protocol) — see [`@gui-chat-plugin/weather`](https://www.npmjs.com/package/@gui-chat-plugin/weather) for a reference shape:
+There are two supported plugin shapes. **For new plugins prefer the factory shape** — it gives the plugin a scoped `runtime` with `pubsub` / `files` / `log` / `fetch` / `notify` and lets the host enforce per-plugin namespaces. The legacy shape stays supported so existing `@gui-chat-plugin/*` packages keep working without changes.
 
-- `TOOL_DEFINITION` (the MCP tool schema)
-- `executeWeather` (server-side handler — runs when the LLM calls the tool)
-- `plugin.viewComponent` / `plugin.previewComponent` (Vue components for the canvas / message preview)
+### Factory shape (recommended, requires `gui-chat-protocol@^0.3`)
 
-The package's `dist/index.js` is what the server dynamic-imports for `TOOL_DEFINITION`; `dist/vue.js` is what the browser dynamic-imports for the components. Both must be pre-bundled (no bare imports beyond `vue`, which is resolved via importmap to the host's Vue instance).
+```ts
+// src/index.ts — server side
+import { definePlugin } from "gui-chat-protocol";
+import { z } from "zod";
+
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("save"), payload: z.unknown() }),
+  z.object({ kind: z.literal("load") }),
+]);
+
+export default definePlugin(({ pubsub, files, log }) => ({
+  TOOL_DEFINITION: {
+    type: "function",
+    name: "myTool",
+    description: "…",
+    parameters: { type: "object", properties: { /* … */ }, required: ["kind"] },
+  },
+  async myTool(rawArgs: unknown) {
+    const args = Args.parse(rawArgs);
+    switch (args.kind) {
+      case "save": {
+        await files.data.write("state.json", JSON.stringify(args.payload));
+        pubsub.publish("changed", {});
+        log.info("state saved");
+        return { ok: true };
+      }
+      case "load":
+        return { ok: true, state: (await files.data.exists("state.json"))
+          ? JSON.parse(await files.data.read("state.json"))
+          : null };
+      default: {
+        const exhaustive: never = args;
+        throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  },
+}));
+```
+
+```vue
+<!-- src/View.vue — browser side -->
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+
+const { pubsub, openUrl, locale } = useRuntime();
+
+const items = ref<{ id: string; url: string }[]>([]);
+
+let unsub: (() => void) | undefined;
+onMounted(() => {
+  unsub = pubsub.subscribe("changed", () => { /* refetch */ });
+});
+onUnmounted(() => unsub?.());
+</script>
+```
+
+> **`<script setup>` ref-unwrap gotcha**: top-level refs (including any `ComputedRef` you return from a composable like `useT()`) are **auto-unwrapped** in the template. Write `{{ t.title }}`, never `{{ t.value.title }}` — the latter compiles to `unref(t).value.title` (double unwrap = `undefined.value.title` at runtime).
+
+The `setup` function passed to `definePlugin` runs **once** at plugin load. Destructure the runtime in the closure and reference `pubsub` / `files` / etc. as bare names from inside handlers — no `context.` threading per call. The setup must NOT do real I/O (`await files.data.read(...)` etc.) at top level; only define handlers that do I/O when called.
+
+The factory pattern's per-plugin scoping (closure over `pkgName`) is what makes the namespace enforcement structural rather than convention-based — the plugin literally cannot spell another plugin's pubsub channel or write into another plugin's data dir through the API.
+
+### Legacy shape (`@gui-chat-plugin/weather` and friends)
+
+```ts
+// src/index.ts
+export const TOOL_DEFINITION = { type: "function", name: "fetchWeather", description: "…", parameters: { /* … */ } };
+export async function fetchWeather(_context: unknown, args: { city: string }) { /* … */ }
+```
+
+The package's `dist/index.js` is what the server dynamic-imports for `TOOL_DEFINITION`; `dist/vue.js` is what the browser dynamic-imports for the components. Both must be pre-bundled (no bare imports beyond `vue` and `gui-chat-protocol*`, which the host resolves via importmap / its own `node_modules`).
+
+### Reference plugin
+
+[`packages/bookmarks-plugin/`](../packages/bookmarks-plugin/) is a small (~70-line server / ~50-line View) reference plugin built on the factory shape. It exercises every API surface — pubsub publish + subscribe, `files.data` for the bookmarks JSON, `files.config` for sort prefs, locale-aware view text, Zod-discriminated args with exhaustive switch. Read this before writing your first plugin.
+
+## API reference (factory shape)
+
+```ts
+interface PluginRuntime {
+  pubsub: { publish<T>(eventName: string, payload: T): void };
+  locale: string;                                    // host snapshot at plugin load time
+  files:  { data: FileOps; config: FileOps };        // see below
+  log:    { debug; info; warn; error };              // (msg, data?) → void
+  fetch:  (url, opts?: PluginFetchOptions) => Promise<Response>;
+  fetchJson: <T>(url, opts?: PluginFetchJsonOptions<T>) => Promise<T>;
+  notify: (msg: { title; body?; level? }) => void;   // → host notifications channel
+}
+
+interface FileOps {
+  read(rel): Promise<string>;
+  readBytes(rel): Promise<Uint8Array>;
+  write(rel, content): Promise<void>;                // atomic
+  readDir(rel): Promise<string[]>;
+  stat(rel): Promise<{ mtimeMs; size }>;
+  exists(rel): Promise<boolean>;
+  unlink(rel): Promise<void>;
+}
+```
+
+```ts
+// Browser side (gui-chat-protocol/vue)
+interface BrowserPluginRuntime {
+  pubsub:  { subscribe<T>(eventName, handler): () => void };
+  locale:  Ref<string>;                              // reactive — host locale picker safe
+  log:     { debug; info; warn; error };
+  openUrl: (url: string) => void;                    // target=_blank + noopener,noreferrer
+  notify:  (msg: { title; body?; level? }) => void;
+}
+```
+
+`pubsub.publish("changed")` on the server fans to channel `plugin:<pkg>:changed`. `pubsub.subscribe("changed", h)` on the browser subscribes to the same channel. Plugin authors only ever see the short event name (`"changed"`); the platform handles the prefix.
+
+## Path conventions (platform contract)
+
+> All `runtime.files.{data,config}.*` `rel` arguments are **POSIX-relative paths** (`/` separated). The platform internally:
+>
+> 1. Replaces `\` with `/` (Windows `path.join` repair)
+> 2. Runs `path.posix.normalize` to fold `..`, `.`, repeated `/`
+> 3. Resolves against the plugin's scope root (`~/mulmoclaude/data/plugins/<sanitised-pkg>/` or `~/mulmoclaude/config/plugins/<sanitised-pkg>/`)
+> 4. Rejects (`throw`) anything that escapes the scope root
+>
+> Plugin authors should never need `node:path`. The recommended ESLint preset (below) enforces that. If a plugin author misuses `node:path` on Windows anyway, the normalisation step still produces a valid POSIX path — the contract handles the mistake gracefully without compromising the traversal anchor.
+
+Example:
+
+```ts
+await files.data.write("books/2026/journal.jsonl", json);   // ✓
+await files.data.write(`books/${bookId}/journal.jsonl`, j); // ✓ template literal
+await files.data.read("../../etc/passwd");                  // ✗ throws
+```
+
+## ESLint preset
+
+`gui-chat-protocol` exports a flat-config preset that bans the platform-bypass imports:
+
+```js
+// plugin/eslint.config.mjs
+import tseslint from "typescript-eslint";
+import vueParser from "vue-eslint-parser";
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+
+export default [
+  { files: ["src/**/*.ts"],  languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: "latest", sourceType: "module" } } },
+  { files: ["src/**/*.vue"], languageOptions: { parser: vueParser, parserOptions: { parser: tseslint.parser, ecmaVersion: "latest", sourceType: "module" } } },
+  ...pluginPreset.map((entry) => ({ ...entry, files: ["src/**/*.{ts,vue}"] })),
+];
+```
+
+The preset turns these into errors:
+
+| Rule | Why |
+|---|---|
+| `no-restricted-imports` for `fs` / `node:fs` / `fs/promises` / `node:fs/promises` | Use `runtime.files.data` / `runtime.files.config` |
+| `no-restricted-imports` for `path` / `node:path` | Use POSIX template literals — paths are platform-normalised |
+| `no-console` | Use `runtime.log.*` so output lands in the central log files |
+
+Allowed Node built-ins: `node:crypto` (`randomUUID` etc.), `node:url` (URL parsing).
+
+When you see `import { something } from "node:fs"` in plugin source — even one — that's the audit signal. The plugin is reaching around the platform; review carefully.
+
+## Action discriminator pattern (recommended)
+
+The runtime plugin dispatch route hands the LLM's `tool_use` block to your handler unchanged. The LLM can put anything in there, so handlers must validate before branching. The idiomatic pattern is a Zod discriminated union + exhaustive `switch`:
+
+```ts
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("save"),   payload: SomeSchema }),
+  z.object({ kind: z.literal("load") }),
+  z.object({ kind: z.literal("delete"), id: z.string() }),
+]);
+
+async function handler(rawArgs: unknown) {
+  const args = Args.parse(rawArgs);   // type-narrow + validate in one step
+  switch (args.kind) {
+    case "save":   return save(args.payload);
+    case "load":   return load();
+    case "delete": return remove(args.id);
+    default: { const exhaustive: never = args; throw new Error(`unknown: ${JSON.stringify(exhaustive)}`); }
+  }
+}
+```
+
+The `default: never` line is the safety net — if you add a new `kind` to `Args` later but forget to add a `case`, TypeScript fails the build instead of the new path silently dropping into the throw at runtime.
 
 ## Related
 
 - [`docs/manual-testing.md`](manual-testing.md) — broader manual test scenarios for the app
-- [`plans/feat-plugin-c2-impl.md`](../plans/feat-plugin-c2-impl.md) — the rollout plan
+- [`plans/feat-plugin-c2-impl.md`](../plans/feat-plugin-c2-impl.md) — the original C-2 rollout plan
+- [`plans/feat-plugin-runtime-extensions-1110.md`](../plans/feat-plugin-runtime-extensions-1110.md) — this PR's plan
 - Issue [#1043](https://github.com/receptron/mulmoclaude/issues/1043) — plugin SDK / dynamic install / marketplace umbrella
+- Issue [#1110](https://github.com/receptron/mulmoclaude/issues/1110) — runtime extensions spec (factory pattern, scoped pubsub, files split, ESLint preset)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,12 @@ export default [
       "src/plugins/spreadsheet/engine",
       "packages/*/dist",
       "packages/bridges/*/dist",
+      // Sample runtime plugin (#1110) — has its own eslint.config.mjs
+      // that uses gui-chat-protocol/eslint-preset. The host's much
+      // stricter rules (T[] over Array<T>, identifier length, etc.)
+      // would force plugin authors to satisfy mulmoclaude conventions
+      // they have no reason to know.
+      "packages/bookmarks-plugin",
       // mulmoclaude launcher copies server/client/shared src here at
       // publish time. Original sources are linted at their real paths.
       "packages/mulmoclaude/client",

--- a/index.html
+++ b/index.html
@@ -35,7 +35,8 @@
     <script type="importmap">
       {
         "imports": {
-          "vue": "/src/_runtime/vue.ts"
+          "vue": "/src/_runtime/vue.ts",
+          "gui-chat-protocol/vue": "/src/_runtime/protocol-vue.ts"
         }
       }
     </script>

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "echarts": "^6.0.0",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.2",
-    "gui-chat-protocol": "0.2.0",
+    "gui-chat-protocol": "0.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",

--- a/packages/bookmarks-plugin/eslint.config.mjs
+++ b/packages/bookmarks-plugin/eslint.config.mjs
@@ -1,0 +1,32 @@
+// Plugin-author ESLint config — extends the gui-chat-protocol preset
+// to ban `node:fs` / `node:path` / `console` / direct `fetch` so any
+// platform bypass shows up at lint time.
+//
+// The preset is parser-agnostic; pair it with a TypeScript parser
+// (and a Vue parser if your plugin has SFCs) here in your own
+// config so the plugin doesn't have to ship a parser dep.
+
+import tseslint from "typescript-eslint";
+import vueParser from "vue-eslint-parser";
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+
+export default [
+  // TypeScript parsing for .ts files.
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  // Vue SFC parsing for .vue files.
+  {
+    files: ["src/**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: { parser: tseslint.parser, ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  // Apply the gui-chat-protocol restrictions to all plugin source.
+  ...pluginPreset.map((entry) => ({ ...entry, files: ["src/**/*.{ts,vue}"] })),
+];

--- a/packages/bookmarks-plugin/package.json
+++ b/packages/bookmarks-plugin/package.json
@@ -19,7 +19,8 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_bookmarks_integration.ts'"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^0.3.0",

--- a/packages/bookmarks-plugin/package.json
+++ b/packages/bookmarks-plugin/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@mulmoclaude/bookmarks-plugin",
+  "version": "0.1.0",
+  "description": "Sample runtime plugin for MulmoClaude — saves URLs with multi-tab live sync, demonstrates the gui-chat-protocol v0.3 runtime API (#1110).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "gui-chat-protocol": "^0.3.0",
+    "vue": "^3.5.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vite-plugin-dts": "^4.5.4",
+    "vue": "^3.5.27",
+    "zod": "^3.23.0"
+  },
+  "license": "MIT"
+}

--- a/packages/bookmarks-plugin/src/View.vue
+++ b/packages/bookmarks-plugin/src/View.vue
@@ -7,7 +7,7 @@
 // `manageBookmarks` calls land in `definePlugin`'s handler in
 // `../index.ts`.
 
-import { onMounted, onUnmounted, ref } from "vue";
+import { onMounted, onUnmounted, ref, watch } from "vue";
 import { useRuntime } from "gui-chat-protocol/vue";
 import { useT } from "./lang";
 
@@ -30,21 +30,46 @@ interface Bookmark {
 interface Props {
   selectedResult: { bookmarks?: Bookmark[] };
 }
-defineProps<Props>();
+const props = defineProps<Props>();
 
-const { pubsub, openUrl, dispatch } = useRuntime();
+const { pubsub, openUrl, dispatch, log } = useRuntime();
 const t = useT();
 
-const bookmarks = ref<Bookmark[]>([]);
+// Seed from `selectedResult` so the initial paint shows whatever the
+// LLM's tool call returned (e.g. the freshly added bookmark) without
+// waiting for `refetch()` to win the race. CodeRabbit review on PR
+// #1124 caught the empty-on-mount flicker this used to cause.
+const bookmarks = ref<Bookmark[]>(props.selectedResult.bookmarks ?? []);
+
+// If the host swaps in a new tool result while this component stays
+// mounted, mirror it. Cheap because Vue's prop watcher fires only on
+// reference change.
+watch(
+  () => props.selectedResult.bookmarks,
+  (next) => {
+    if (next) bookmarks.value = next;
+  },
+);
 
 async function refetch(): Promise<void> {
-  const json = await dispatch<{ ok: boolean; bookmarks?: Bookmark[] }>({ kind: "list" });
-  if (json.ok && json.bookmarks) bookmarks.value = json.bookmarks;
+  try {
+    const json = await dispatch<{ ok: boolean; bookmarks?: Bookmark[] }>({ kind: "list" });
+    if (json.ok && json.bookmarks) bookmarks.value = json.bookmarks;
+  } catch (err) {
+    // CLAUDE.md mandate: every fetch must handle errors. Log + leave
+    // the existing list visible so the user has SOMETHING rather than
+    // a blank canvas (CodeRabbit review on PR #1124).
+    log.warn("refetch failed; keeping last-known list", { error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 async function remove(id: string): Promise<void> {
-  await dispatch({ kind: "remove", id });
-  // The "changed" pubsub event from the server fires refetch below.
+  try {
+    await dispatch({ kind: "remove", id });
+    // The "changed" pubsub event from the server fires refetch below.
+  } catch (err) {
+    log.warn("remove failed", { id, error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 let unsub: (() => void) | undefined;

--- a/packages/bookmarks-plugin/src/View.vue
+++ b/packages/bookmarks-plugin/src/View.vue
@@ -72,15 +72,23 @@ async function remove(id: string): Promise<void> {
   }
 }
 
-let unsub: (() => void) | undefined;
+// Subscribe to BOTH "changed" (data mutations from add/remove) AND
+// "prefs-changed" (sort/hidden preference changes from setSort). The
+// server emits the prefs event on a separate channel because pure
+// pref changes don't change the underlying bookmark records, but the
+// rendered ORDER depends on prefs — so the View must refetch on
+// either signal to stay in sync across tabs (Codex review on PR
+// #1124).
+const unsubs: Array<() => void> = [];
 onMounted(() => {
-  unsub = pubsub.subscribe("changed", () => {
-    void refetch();
-  });
+  unsubs.push(pubsub.subscribe("changed", () => void refetch()));
+  unsubs.push(pubsub.subscribe("prefs-changed", () => void refetch()));
   // Refetch on mount in case the inline `result` is stale (page refresh).
   void refetch();
 });
-onUnmounted(() => unsub?.());
+onUnmounted(() => {
+  for (const unsub of unsubs) unsub();
+});
 </script>
 
 <template>

--- a/packages/bookmarks-plugin/src/View.vue
+++ b/packages/bookmarks-plugin/src/View.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+// Bookmarks plugin View — renders inside the host's canvas via the
+// runtime plugin loader. Demonstrates `useRuntime()` + scoped pubsub +
+// plugin-local i18n on a tiny surface.
+//
+// HTTP dispatch URL is the contracted runtime route shape;
+// `manageBookmarks` calls land in `definePlugin`'s handler in
+// `../index.ts`.
+
+import { onMounted, onUnmounted, ref } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import { useT } from "./lang";
+
+interface Bookmark {
+  id: string;
+  url: string;
+  title: string;
+  addedAt: string;
+}
+
+// gui-chat-protocol's ViewComponentProps: the host passes
+// `selectedResult` as the latest tool-call result. For our handler
+// `selectedResult` looks like one of:
+//   - { ok: true, bookmarks: [...] }  (after `list`)
+//   - { ok: true, bookmark: {...} }   (after `add`)
+//   - { ok: true }                    (after `remove` / `setSort`)
+// The View always re-fetches on mount + on every `changed` pubsub
+// event so the displayed list stays current regardless of which
+// action triggered the mount.
+interface Props {
+  selectedResult: { bookmarks?: Bookmark[] };
+}
+defineProps<Props>();
+
+const { pubsub, openUrl, dispatch } = useRuntime();
+const t = useT();
+
+const bookmarks = ref<Bookmark[]>([]);
+
+async function refetch(): Promise<void> {
+  const json = await dispatch<{ ok: boolean; bookmarks?: Bookmark[] }>({ kind: "list" });
+  if (json.ok && json.bookmarks) bookmarks.value = json.bookmarks;
+}
+
+async function remove(id: string): Promise<void> {
+  await dispatch({ kind: "remove", id });
+  // The "changed" pubsub event from the server fires refetch below.
+}
+
+let unsub: (() => void) | undefined;
+onMounted(() => {
+  unsub = pubsub.subscribe("changed", () => {
+    void refetch();
+  });
+  // Refetch on mount in case the inline `result` is stale (page refresh).
+  void refetch();
+});
+onUnmounted(() => unsub?.());
+</script>
+
+<template>
+  <!--
+    Vue 3 <script setup> auto-unwraps top-level refs in the template,
+    so `t` (a ComputedRef) is accessed as `t.title`, not `t.value.title`.
+    Writing `t.value.title` would compile to `unref(t).value.title` —
+    double unwrap = `undefined.value.title` = runtime crash.
+  -->
+  <div class="bookmarks-view">
+    <h2 class="bookmarks-title">
+      {{ t.title }} <span class="bookmarks-count">({{ bookmarks.length }} {{ t.countSuffix }})</span>
+    </h2>
+    <ul v-if="bookmarks.length" class="bookmarks-list">
+      <li v-for="bookmark in bookmarks" :key="bookmark.id" class="bookmarks-item">
+        <button class="bookmarks-link" type="button" @click="openUrl(bookmark.url)">
+          <span class="bookmarks-link-title">{{ bookmark.title }}</span>
+          <span class="bookmarks-link-url">{{ bookmark.url }}</span>
+        </button>
+        <button class="bookmarks-remove" type="button" @click="remove(bookmark.id)">{{ t.remove }}</button>
+      </li>
+    </ul>
+    <p v-else class="bookmarks-empty">{{ t.empty }}</p>
+  </div>
+</template>
+
+<style scoped>
+.bookmarks-view {
+  padding: 1rem;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+.bookmarks-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+.bookmarks-count {
+  color: #6b7280;
+  font-weight: 400;
+  font-size: 0.875rem;
+}
+.bookmarks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.bookmarks-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+}
+.bookmarks-link {
+  flex: 1;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.bookmarks-link:hover .bookmarks-link-title {
+  text-decoration: underline;
+}
+.bookmarks-link-title {
+  display: block;
+  font-weight: 500;
+}
+.bookmarks-link-url {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+.bookmarks-remove {
+  background: none;
+  border: none;
+  color: #ef4444;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.bookmarks-empty {
+  color: #6b7280;
+}
+</style>

--- a/packages/bookmarks-plugin/src/definition.ts
+++ b/packages/bookmarks-plugin/src/definition.ts
@@ -1,0 +1,25 @@
+// Tool schema. Lives in its own module so both the server entry
+// (`index.ts`) and the browser entry (`vue.ts`) can import it without
+// dragging in the factory body, Zod, or any other server-only code.
+
+// `name: "manageBookmarks" as const` narrows the literal so
+// `definePlugin`'s `PluginFactoryResult<N>` requires a handler exported
+// under exactly this key. Without `as const` the name widens to
+// `string` and the strict-handler check degrades to the loose runtime
+// warn (see gui-chat-protocol/src/runtime.ts PluginFactoryResult).
+export const TOOL_DEFINITION = {
+  type: "function" as const,
+  name: "manageBookmarks" as const,
+  description: "Save, list, or remove bookmarks (URL + title) in the user's workspace.",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      kind: { type: "string", enum: ["add", "list", "remove", "setSort"] },
+      url: { type: "string" },
+      title: { type: "string" },
+      id: { type: "string" },
+      by: { type: "string", enum: ["addedAt", "title"] },
+    },
+    required: ["kind"],
+  },
+};

--- a/packages/bookmarks-plugin/src/index.ts
+++ b/packages/bookmarks-plugin/src/index.ts
@@ -1,0 +1,113 @@
+// Bookmarks plugin — server side (#1110 reference plugin).
+//
+// Demonstrates the v0.3 runtime API end-to-end on a deliberately tiny
+// surface (~70 LOC of logic):
+//   - definePlugin factory with destructured runtime
+//   - files.data for the bookmarks themselves (backup target)
+//   - files.config for UI prefs (per-machine state)
+//   - pubsub.publish on every mutation so multi-tab views auto-refresh
+//   - Zod-discriminated args + exhaustive switch with `default: never throw`
+//
+// `node:fs` / `node:path` / `console` / direct `fetch` are all unused
+// — every I/O goes through the runtime. The eslint preset that ships
+// with `gui-chat-protocol` is configured to make those imports a hard
+// error, keeping the surface small for plugin reviewers.
+
+import { definePlugin } from "gui-chat-protocol";
+import { z } from "zod";
+import { TOOL_DEFINITION } from "./definition";
+
+export { TOOL_DEFINITION };
+
+const Bookmark = z.object({
+  id: z.string(),
+  url: z.string().url(),
+  title: z.string(),
+  addedAt: z.string(),
+});
+type Bookmark = z.infer<typeof Bookmark>;
+
+const Prefs = z.object({
+  sortBy: z.enum(["addedAt", "title"]).default("addedAt"),
+  hidden: z.array(z.string()).default([]),
+});
+type Prefs = z.infer<typeof Prefs>;
+
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("add"), url: z.string().url(), title: z.string() }),
+  z.object({ kind: z.literal("list") }),
+  z.object({ kind: z.literal("remove"), id: z.string() }),
+  z.object({ kind: z.literal("setSort"), by: z.enum(["addedAt", "title"]) }),
+]);
+
+const DEFAULT_PREFS: Prefs = { sortBy: "addedAt", hidden: [] };
+
+export default definePlugin(({ pubsub, files, log }) => {
+  async function readAll(): Promise<Bookmark[]> {
+    if (!(await files.data.exists("bookmarks.json"))) return [];
+    const raw = await files.data.read("bookmarks.json");
+    return z.array(Bookmark).parse(JSON.parse(raw));
+  }
+
+  async function writeAll(items: Bookmark[]): Promise<void> {
+    await files.data.write("bookmarks.json", JSON.stringify(items, null, 2));
+    pubsub.publish("changed", { count: items.length });
+  }
+
+  async function readPrefs(): Promise<Prefs> {
+    if (!(await files.config.exists("prefs.json"))) return DEFAULT_PREFS;
+    const raw = await files.config.read("prefs.json");
+    return Prefs.parse(JSON.parse(raw));
+  }
+
+  async function writePrefs(prefs: Prefs): Promise<void> {
+    await files.config.write("prefs.json", JSON.stringify(prefs, null, 2));
+    pubsub.publish("prefs-changed", prefs);
+  }
+
+  function sortedAndFiltered(items: Bookmark[], prefs: Prefs): Bookmark[] {
+    const sorted = [...items].sort((a, b) => (prefs.sortBy === "title" ? a.title.localeCompare(b.title) : b.addedAt.localeCompare(a.addedAt)));
+    return sorted.filter((bookmark) => !prefs.hidden.includes(bookmark.id));
+  }
+
+  return {
+    TOOL_DEFINITION,
+
+    async manageBookmarks(rawArgs: unknown) {
+      const args = Args.parse(rawArgs);
+      switch (args.kind) {
+        case "add": {
+          const next: Bookmark = {
+            id: crypto.randomUUID(),
+            url: args.url,
+            title: args.title,
+            addedAt: new Date().toISOString(),
+          };
+          await writeAll([next, ...(await readAll())]);
+          log.info("bookmark added", { id: next.id, url: next.url });
+          return { ok: true, bookmark: next };
+        }
+        case "list": {
+          const [items, prefs] = await Promise.all([readAll(), readPrefs()]);
+          return { ok: true, bookmarks: sortedAndFiltered(items, prefs) };
+        }
+        case "remove": {
+          const items = await readAll();
+          const next = items.filter((bookmark) => bookmark.id !== args.id);
+          if (next.length === items.length) return { ok: false, error: "not_found" };
+          await writeAll(next);
+          return { ok: true };
+        }
+        case "setSort": {
+          const prefs = await readPrefs();
+          await writePrefs({ ...prefs, sortBy: args.by });
+          return { ok: true };
+        }
+        default: {
+          const exhaustive: never = args;
+          throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
+        }
+      }
+    },
+  };
+});

--- a/packages/bookmarks-plugin/src/index.ts
+++ b/packages/bookmarks-plugin/src/index.ts
@@ -84,7 +84,17 @@ export default definePlugin(({ pubsub, files, log }) => {
             addedAt: new Date().toISOString(),
           };
           await writeAll([next, ...(await readAll())]);
-          log.info("bookmark added", { id: next.id, url: next.url });
+          // Log only the host portion of the URL — full URLs can carry
+          // private path segments, search terms, or auth tokens in the
+          // query string (CodeRabbit review on PR #1124). The id is
+          // enough to locate the bookmark on disk if needed.
+          let host = "";
+          try {
+            host = new URL(next.url).host;
+          } catch {
+            host = "<unparseable>";
+          }
+          log.info("bookmark added", { id: next.id, host });
           return { ok: true, bookmark: next };
         }
         case "list": {

--- a/packages/bookmarks-plugin/src/lang/en.ts
+++ b/packages/bookmarks-plugin/src/lang/en.ts
@@ -1,0 +1,9 @@
+export default {
+  title: "Bookmarks",
+  countSuffix: "saved",
+  remove: "Remove",
+  empty: "No bookmarks yet — ask Claude to save a URL.",
+  sortLabel: "Sort by",
+  sortByAddedAt: "Newest first",
+  sortByTitle: "Title",
+};

--- a/packages/bookmarks-plugin/src/lang/index.ts
+++ b/packages/bookmarks-plugin/src/lang/index.ts
@@ -1,0 +1,24 @@
+// Plugin-local i18n (#1110): translation tables travel with the
+// plugin bundle, no merge into the host vue-i18n. The plugin reads
+// the host's locale via `useRuntime()` and looks up its own table
+// reactively.
+//
+// Future plugins that need vue-i18n features (plural forms, linked
+// messages) can spin up their own `createI18n()` instance instead.
+
+import { computed } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import en from "./en";
+import ja from "./ja";
+
+const MESSAGES = { en, ja } as const;
+type LocaleKey = keyof typeof MESSAGES;
+
+function isSupportedLocale(value: string): value is LocaleKey {
+  return value in MESSAGES;
+}
+
+export function useT() {
+  const { locale } = useRuntime();
+  return computed(() => (isSupportedLocale(locale.value) ? MESSAGES[locale.value] : MESSAGES.en));
+}

--- a/packages/bookmarks-plugin/src/lang/ja.ts
+++ b/packages/bookmarks-plugin/src/lang/ja.ts
@@ -1,0 +1,9 @@
+export default {
+  title: "ブックマーク",
+  countSuffix: "件",
+  remove: "削除",
+  empty: "まだブックマークはありません — Claude に URL を保存してもらいましょう。",
+  sortLabel: "並び順",
+  sortByAddedAt: "追加日(新しい順)",
+  sortByTitle: "タイトル順",
+};

--- a/packages/bookmarks-plugin/src/shims-vue.d.ts
+++ b/packages/bookmarks-plugin/src/shims-vue.d.ts
@@ -1,0 +1,9 @@
+// Vite/Vue plugin SFC shim — tells `tsc --noEmit` that `.vue` imports
+// resolve to a Vue Component. The actual SFC parsing happens at build
+// time via `@vitejs/plugin-vue`.
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/packages/bookmarks-plugin/src/vue.ts
+++ b/packages/bookmarks-plugin/src/vue.ts
@@ -1,0 +1,16 @@
+// Vue entry — exports the canvas component the host runtime plugin
+// loader dynamic-imports as `dist/vue.js`.
+//
+// Shape matches the existing `@gui-chat-plugin/*` convention so the
+// host's loader (src/tools/runtimeLoader.ts) registers the components
+// without special-casing factory-shape plugins:
+//
+//   plugin: { toolDefinition, viewComponent, previewComponent? }
+
+import View from "./View.vue";
+import { TOOL_DEFINITION } from "./definition";
+
+export const plugin = {
+  toolDefinition: TOOL_DEFINITION,
+  viewComponent: View,
+};

--- a/packages/bookmarks-plugin/tsconfig.json
+++ b/packages/bookmarks-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/bookmarks-plugin/vite.config.ts
+++ b/packages/bookmarks-plugin/vite.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import dts from "vite-plugin-dts";
+
+// Two bundles, two externals strategies (#1110):
+//
+// - `dist/index.js` (server) — self-contained. The runtime loader
+//   extracts the tarball into `~/mulmoclaude/plugins/.cache/<pkg>/<ver>/`
+//   and dynamic-imports it. There's no node_modules underneath, so any
+//   bare import that's left as `external` will fail to resolve at load
+//   time. Inline `gui-chat-protocol` (just the identity `definePlugin`
+//   function — tiny) and `zod` (~50KB) so the server module loads
+//   without any module-resolution gymnastics.
+//
+// - `dist/vue.js` (browser) — `vue` and `gui-chat-protocol/vue` stay
+//   external; the host provides Vue via the importmap and the
+//   `useRuntime()` composable resolves to the host's instance through
+//   `gui-chat-protocol/vue` (also via importmap).
+export default defineConfig({
+  plugins: [vue(), dts({ include: ["src/**/*.{ts,vue}"], rollupTypes: true })],
+  build: {
+    lib: {
+      entry: { index: "src/index.ts", vue: "src/vue.ts" },
+      formats: ["es"],
+      fileName: (_format, entryName) => `${entryName}.js`,
+    },
+    rollupOptions: {
+      // `vue` and `gui-chat-protocol/vue` are always host-provided
+      // (importmap on the browser side). `gui-chat-protocol` (just the
+      // identity `definePlugin` helper) and `zod` are inlined so the
+      // server bundle is self-contained — needed because the cache dir
+      // the loader extracts into has no node_modules.
+      external: ["vue", "gui-chat-protocol/vue"],
+      output: {
+        // The host runtime loader (src/tools/runtimeLoader.ts) injects
+        // a stylesheet from `${assetBase}/dist/style.css`. Vite's
+        // default would name the CSS after the package
+        // (`bookmarks-plugin.css`); pin it to `style.css` so the host
+        // doesn't have to special-case per plugin.
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith(".css")) return "style.css";
+          return assetInfo.name ?? "[name]";
+        },
+      },
+    },
+    minify: false,
+    sourcemap: true,
+  },
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.2",
-    "gui-chat-protocol": "0.2.0",
+    "gui-chat-protocol": "0.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",

--- a/plans/feat-plugin-runtime-extensions-1110.md
+++ b/plans/feat-plugin-runtime-extensions-1110.md
@@ -1,0 +1,148 @@
+# feat: runtime plugin platform extensions (#1110)
+
+Build the platform extensions documented in [#1110](https://github.com/receptron/mulmoclaude/issues/1110) so that plugin authors can write rich plugins (multi-action + persistent + multi-tab live sync + i18n) entirely as installable npm packages.
+
+**This PR scope: API + docs + Bookmarks sample only.** The accounting plugin migration is deliberately out of scope — that lands as a separate PR series later (PR2 〜 PR5 in the issue's migration plan).
+
+Authoritative spec: [issue #1110 latest spec comment](https://github.com/receptron/mulmoclaude/issues/1110#issuecomment-4364716681). Anything in this plan that conflicts with the spec — the spec wins.
+
+## Cross-repo work
+
+This change spans **two repos** (we own both):
+
+1. `~/ss/llm/gui-chat-protocol/` — add `definePlugin`, `useRuntime`, `eslint-preset`. Publish as v0.3.0. Backward-compatible: old `(context, args)` shape keeps working.
+2. `~/ss/llm/mulmoclaude5/` — implement `makePluginRuntime` (server) + `ScopedRoot` (frontend) + path normalization + sample Bookmarks plugin under `packages/bookmarks-plugin/`.
+
+Development order (shortest feedback loop first):
+
+1. Extend `gui-chat-protocol` (no publish yet — `yarn link` from mulmoclaude during dev)
+2. Implement server `makePluginRuntime` + loader factory detection
+3. Implement frontend `ScopedRoot` + browser runtime
+4. Build `packages/bookmarks-plugin/` end-to-end
+5. Tests + docs
+6. Once the loop works, publish `gui-chat-protocol@0.3.0`, bump in mulmoclaude `package.json`, commit, open PR
+7. Bookmarks plugin extraction to its own repo lands in a follow-up PR (out of scope for this one)
+
+## API surface (recap)
+
+### `gui-chat-protocol` additions
+
+- **`definePlugin<T>(setup: (runtime: PluginRuntime) => T): (runtime: PluginRuntime) => T`** — identity function for type inference. Same philosophy as `defineComponent`.
+- **`PluginRuntime`** type (server): `pubsub`, `locale`, `files: { data, config }`, `log`, `fetch`, `fetchJson`, `notify`.
+- **`FileOps`** type for `data` / `config`: `read / readBytes / write / readDir / stat / exists / unlink`. All paths POSIX-relative.
+- **`BrowserPluginRuntime`** type (frontend): `pubsub`, `locale: Ref<string>`, `log`, `openUrl`, `notify`.
+- **`PLUGIN_RUNTIME_KEY: InjectionKey<BrowserPluginRuntime>`** + **`useRuntime()`** composable.
+- **`gui-chat-protocol/eslint-preset`** subpath export with `no-restricted-imports` (fs / path) + `no-console`.
+
+Backward compatibility:
+- Existing `ToolPluginCore.execute: (context, args) => Promise<ToolResult>` signature stays untouched.
+- Plugins that export the old shape (`mod[TOOL_DEFINITION.name] = (ctx, args) => ...`) still work.
+- New plugins use `export default definePlugin(...)` which the loader detects and treats differently.
+
+### mulmoclaude server additions
+
+- `WORKSPACE_PATHS.pluginsData` = `~/mulmoclaude/data/plugins/`
+- `WORKSPACE_PATHS.pluginsConfig` = `~/mulmoclaude/config/plugins/`
+- `server/plugins/runtime.ts` (new) — `makePluginRuntime(pkgName, host) → PluginRuntime`
+  - Scoped pubsub: `publish(name, payload)` → `host.publish(\`plugin:${pkgName}:${name}\`, payload)`
+  - `files.data` / `files.config`: each FileOps method runs `normalize(rel) → ensureInsideBase(absolute, scopeRoot)` before disk I/O
+  - Path normalization: `\` → `/`, `path.posix.normalize`, then `path.posix.resolve(scopeRoot, normalized)` — accepts plugin code that misuses `node:path` on Windows but rejects traversal
+  - `writeFileAtomic` reused from `server/utils/files/atomic.ts`
+  - `log` wraps `server/system/logger` with prefix `plugin/${pkgName}`
+  - `fetch` wraps `globalThis.fetch` with `AbortController` + `timeoutMs` (default 10s) + optional `allowedHosts` check (URL.hostname must match)
+  - `fetchJson` = `fetch` + `response.json()` + optional `parse: (raw) => T` (Zod-agnostic; plugin can pass `(raw) => Schema.parse(raw)`)
+  - `notify` publishes to `PUBSUB_CHANNELS.notifications` with the host's existing payload shape
+- `server/plugins/runtime-loader.ts` modification — detect factory-shape: if `mod.default` is a function (not object), call it with `makePluginRuntime(plugin.name, host)` and the result becomes the plugin module.
+
+### mulmoclaude frontend additions
+
+- `src/utils/plugin/runtime.ts` (new) — `makeBrowserPluginRuntime(pkgName, hostWS, hostI18n) → BrowserPluginRuntime`
+  - Scoped pubsub: `subscribe(name, handler)` → `hostWS.subscribe(\`plugin:${pkgName}:${name}\`, handler)`
+  - `locale: Ref<string>` derived from `i18n.global.locale` (already a `WritableComputedRef`)
+  - `log` → `console.*` (in production, may route to host log channel)
+  - `openUrl` → `window.open(url, "_blank", "noopener,noreferrer")`
+  - `notify` → publishes to host notifications channel (frontend symmetry with server's `notify`)
+- `src/components/PluginScopedRoot.vue` (new) — wraps a plugin's component subtree, calls `provide(PLUGIN_RUNTIME_KEY, runtime)`
+- `src/plugins/runtime.ts` (or update existing dynamic loader) — when mounting a runtime plugin's `viewComponent`, wrap it in `<PluginScopedRoot :pkg-name="..." :runtime="...">`
+
+### packages/bookmarks-plugin
+
+- New workspace package, not published initially
+- `package.json`: `"name": "@mulmoclaude/bookmarks-plugin"` (placeholder; will rename when extracting)
+- `src/index.ts` — server (definePlugin)
+- `src/View.vue` — frontend (useRuntime)
+- `src/lang/{en,ja}.ts` + `useT` helper
+- `eslint.config.mjs` — extends `gui-chat-protocol/eslint-preset`
+- Build pipeline (vite library mode) emits `dist/{index.js, vue.js, style.css}`. lang files inlined into `vue.js` via Vue SFC bundling.
+
+## Path normalization contract (永続化対象)
+
+> Per spec: the platform receives plugin-supplied path strings and **always** runs:
+>
+> 1. Replace `\` with `/` (Windows path.join leak repair)
+> 2. `path.posix.normalize` (folds `..`, `.`, double-slash)
+> 3. `path.posix.resolve(scopeRoot, normalized)` (absolutize)
+> 4. `ensureInsideBase(absolute, scopeRoot)` — throw `Error("path escapes plugin scope")` if outside
+>
+> Plugin code that uses `node:path` accidentally still works on Windows (because of step 1). Plugin code that tries `"../../etc/passwd"` is rejected.
+>
+> Implemented once in `server/plugins/runtime.ts:normalizePluginPath` and reused by every FileOps method. Documented in `docs/plugin-runtime.md` "Path conventions" section as the platform contract.
+
+## Test scope
+
+Unit tests (in `test/plugins/`):
+
+- `test_runtime_pubsub.ts` — scoped publish prefixes pkg name; cross-plugin isolation
+- `test_runtime_files.ts` — data/config separation; traversal rejection (`../`); Windows backslash repair; atomic write semantics; `exists` returns false for missing
+- `test_runtime_fetch.ts` — timeout via AbortController; allowedHosts rejection; non-allowlisted host rejected
+- `test_runtime_loader_factory.ts` — old shape (function under TOOL_DEFINITION.name key) still works; new shape (default export is factory) gets runtime injected
+- `test_browser_runtime.ts` — useRuntime throws outside provider; openUrl uses noopener; subscribe scopes channel name
+
+Smoke (Bookmarks):
+
+- Install `@mulmoclaude/bookmarks-plugin` (workspace) into ledger
+- LLM call: add → list (returns the added bookmark) → remove → list (empty)
+- Multi-tab: open two browser tabs of the View, add via tab 1, tab 2 reflects via pubsub.subscribe
+
+Manual (one-shot):
+
+- `~/mulmoclaude/data/plugins/@mulmoclaude/bookmarks-plugin/bookmarks.json` exists after add
+- `~/mulmoclaude/config/plugins/@mulmoclaude/bookmarks-plugin/prefs.json` exists after sort change
+- Plugin source has zero `node:fs` / `node:path` / `console` references (grep)
+
+## Documentation
+
+Update `docs/plugin-runtime.md`:
+
+1. Replace the existing weather walkthrough with a Bookmarks walkthrough (richer, demonstrates more API surface)
+2. Add `## API reference` section with full `PluginRuntime` / `BrowserPluginRuntime` types
+3. Add `## Path conventions` section (the contract above, verbatim)
+4. Add `## ESLint preset` section with usage example
+5. Add `## Action discriminator pattern` section with Zod recipe + `default: never throw` exhaustive
+6. Keep weather as a reference link (it stays a working preset for the old shape)
+
+## Out of scope (this PR)
+
+- Accounting plugin migration (#1078) — separate PR series, see issue migration plan PR2〜PR5
+- Per-event Zod schema validate-on-publish + publish rate limit — orthogonal additions, can land in this PR if cheap; otherwise follow-up
+- Plugin process isolation — separate issue
+- Bookmarks plugin extraction to its own repo — follow-up PR after this one merges
+- `kv` / `scheduler` / `callPlugin` / `session.id` — not in v1
+
+## Acceptance
+
+- [ ] `gui-chat-protocol@0.3.0` exports `definePlugin` / `useRuntime` / `PluginRuntime` / `BrowserPluginRuntime` / `eslint-preset`
+- [ ] `server/plugins/runtime.ts` constructs scoped runtime with all spec'd APIs
+- [ ] Path normalization layer rejects traversal and accepts misused `node:path` results
+- [ ] `packages/bookmarks-plugin/` builds, registers via runtime ledger, end-to-end works
+- [ ] Plugin source has 0 references to `node:fs` / `node:path` / `console` / direct `fetch` (grep clean)
+- [ ] `docs/plugin-runtime.md` updated per the section list above
+- [ ] `yarn format / lint / typecheck / build / test` clean
+- [ ] Existing `@gui-chat-plugin/weather` (old shape) still works as preset (backward compat smoke)
+
+## References
+
+- Issue: #1110
+- Spec (authoritative): [latest spec comment](https://github.com/receptron/mulmoclaude/issues/1110#issuecomment-4364716681)
+- Related: #1077 (runtime plugin Phase A+B+C), #1078 (manageAccounting reference plugin)
+- Cross-repo: receptron/gui-chat-protocol (~/ss/llm/gui-chat-protocol/)

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
 import { loadPresetPlugins } from "./plugins/preset-loader.js";
 import { registerRuntimePlugins } from "./plugins/runtime-registry.js";
+import { makePluginRuntime } from "./plugins/runtime.js";
 import { MCP_PLUGIN_NAMES } from "./agent/plugin-names.js";
 import { createNotificationsRouter } from "./api/routes/notifications.js";
 import { createJournalRouter } from "./api/routes/journal.js";
@@ -699,6 +700,45 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
   // --- Session Store ---
   initSessionStore(pubsub);
 
+  // --- Runtime plugins (#1043 C-2 + #1110) ---
+  // Two sources of plugins, same RuntimePlugin shape:
+  //   1. Presets — server/plugins/preset-list.ts (loaded from node_modules)
+  //   2. User-installed — ~/mulmoclaude/plugins/plugins.json ledger
+  //
+  // Presets are merged FIRST so they win runtime-vs-runtime collision
+  // (first-loaded wins; static MCP built-ins still win over both via
+  // MCP_PLUGIN_NAMES).
+  //
+  // Factory-shape plugins (`export default definePlugin(...)`) receive a
+  // runtime constructed by `makePluginRuntime(...)` which closes over the
+  // live pubsub. Legacy `(context, args)` plugins are loaded unchanged.
+  //
+  // Failures don't abort boot — bad plugins are skipped, healthy ones
+  // still load.
+  void (async () => {
+    try {
+      const runtimeFactory = (pkgName: string) =>
+        makePluginRuntime({
+          pkgName,
+          pubsub,
+          // v1: server-side locale is a static snapshot. The frontend
+          // BrowserPluginRuntime carries the reactive ref. Future
+          // enhancement: per-request locale from Accept-Language.
+          locale: process.env.LANG?.split(/[._]/)[0] || "en",
+        });
+      const [presets, userInstalled] = await Promise.all([loadPresetPlugins({ runtimeFactory }), loadRuntimePlugins({ runtimeFactory })]);
+      const result = registerRuntimePlugins(MCP_PLUGIN_NAMES, [...presets, ...userInstalled]);
+      log.info("plugins/runtime", "registered runtime plugins", {
+        presets: presets.length,
+        userInstalled: userInstalled.length,
+        registered: result.registered.length,
+        collisions: result.collisions.length,
+      });
+    } catch (err) {
+      log.error("plugins/runtime", "registry init failed; runtime plugins disabled this session", { error: String(err) });
+    }
+  })();
+
   // --- File-change publisher ---
   // Wired here (not at first publish) so the very first save after
   // boot already sees a live publisher.
@@ -846,33 +886,10 @@ process.on("SIGTERM", () => {
     });
   });
 
-  // Runtime-loaded plugins (#1043 C-2). Two sources, both producing
-  // the same RuntimePlugin shape:
-  //   1. Presets — `config/preset-plugins.ts` lists npm packages that
-  //      ship with the repo. Loaded from `node_modules/<pkg>/`. These
-  //      let the runtime path run end-to-end on a fresh checkout.
-  //   2. User-installed — `~/mulmoclaude/plugins/plugins.json` ledger.
-  //      Each entry's tgz is extracted to `.cache/<pkg>/<ver>/` if
-  //      not already cached.
-  //
-  // Presets are merged FIRST so they win the registry-internal
-  // tool-name collision (first-loaded wins; runtime-registry.ts).
-  // Static MCP built-ins still win over both, via MCP_PLUGIN_NAMES.
-  // Failures don't abort boot — bad plugins are skipped, healthy
-  // ones still load.
-  try {
-    const presets = await loadPresetPlugins();
-    const userInstalled = await loadRuntimePlugins();
-    const result = registerRuntimePlugins(MCP_PLUGIN_NAMES, [...presets, ...userInstalled]);
-    log.info("plugins/runtime", "registered runtime plugins", {
-      presets: presets.length,
-      userInstalled: userInstalled.length,
-      registered: result.registered.length,
-      collisions: result.collisions.length,
-    });
-  } catch (err) {
-    log.error("plugins/runtime", "registry init failed; runtime plugins disabled this session", { error: String(err) });
-  }
+  // Runtime plugin loading moved into `startRuntimeServices` so the
+  // factory-shape plugins (#1110, `export default definePlugin(...)`)
+  // can receive a runtime that closes over the live pubsub instance.
+  // The legacy `(context, args)` shape is unaffected.
 
   // Bind to localhost-only. Using `0.0.0.0` would expose the dev
   // server to the entire LAN (anyone on the same Wi-Fi could reach

--- a/server/plugins/preset-loader.ts
+++ b/server/plugins/preset-loader.ts
@@ -32,7 +32,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { PRESET_PLUGINS } from "./preset-list.js";
-import { loadPluginFromCacheDir, type RuntimePlugin } from "./runtime-loader.js";
+import { loadPluginFromCacheDir, type LoaderDeps, type RuntimePlugin } from "./runtime-loader.js";
 import { log } from "../system/logger/index.js";
 
 const LOG_PREFIX = "plugins/preset";
@@ -71,7 +71,7 @@ function resolvePresetRoot(packageName: string): string | null {
   }
 }
 
-async function loadOnePreset(packageName: string): Promise<RuntimePlugin | null> {
+async function loadOnePreset(packageName: string, deps: LoaderDeps = {}): Promise<RuntimePlugin | null> {
   const cachePath = resolvePresetRoot(packageName);
   if (!cachePath) {
     log.warn(LOG_PREFIX, "preset package not resolvable — run `yarn install`?", { packageName });
@@ -90,17 +90,21 @@ async function loadOnePreset(packageName: string): Promise<RuntimePlugin | null>
     log.warn(LOG_PREFIX, "preset package has no version", { packageName });
     return null;
   }
-  return loadPluginFromCacheDir(packageName, version, cachePath);
+  return loadPluginFromCacheDir(packageName, version, cachePath, deps);
 }
 
 /** Load every preset declared in `server/plugins/preset-list.ts`.
  *  Returns the loaded set; failures are logged and silently
- *  skipped. */
-export async function loadPresetPlugins(): Promise<RuntimePlugin[]> {
+ *  skipped.
+ *
+ *  Pass `deps.runtimeFactory` from the parent server so factory-shape
+ *  presets get a real runtime; the MCP child can omit it (definition-
+ *  only). */
+export async function loadPresetPlugins(deps: LoaderDeps = {}): Promise<RuntimePlugin[]> {
   if (PRESET_PLUGINS.length === 0) return [];
   const loaded: RuntimePlugin[] = [];
   for (const entry of PRESET_PLUGINS) {
-    const plugin = await loadOnePreset(entry.packageName);
+    const plugin = await loadOnePreset(entry.packageName, deps);
     if (plugin) loaded.push(plugin);
   }
   log.info(LOG_PREFIX, "loaded", { requested: PRESET_PLUGINS.length, succeeded: loaded.length });

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -22,7 +22,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { ToolDefinition } from "gui-chat-protocol";
+import type { PluginRuntime, ToolDefinition } from "gui-chat-protocol";
+import { isPluginFactory } from "gui-chat-protocol";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 import { readLedger, type LedgerEntry } from "../utils/files/plugins-io.js";
 import { log } from "../system/logger/index.js";
@@ -130,12 +131,95 @@ function readPackageJson(cachePath: string): PackageJson | null {
   }
 }
 
+/** Optional per-plugin runtime factory (#1110). When provided, plugins
+ *  whose `dist/index.js` exports a factory via `export default
+ *  definePlugin(...)` get the constructed runtime injected at load
+ *  time. When omitted, factory plugins are loaded with a stub runtime
+ *  whose handler call throws — fine for the MCP child process which
+ *  only needs `TOOL_DEFINITION` for `tools/list`; not OK for the
+ *  parent server which actually invokes the handler. The parent
+ *  always passes `runtimeFactory`; the child does not. */
+export interface LoaderDeps {
+  runtimeFactory?: (pkgName: string) => PluginRuntime;
+}
+
+/** Stub runtime — the factory pattern requires SOME runtime to call,
+ *  even if we only care about extracting `TOOL_DEFINITION`. Methods
+ *  throw rather than silently no-op so a plugin that mistakenly does
+ *  I/O at setup time fails loudly during boot instead of at first
+ *  call. */
+function makeStubRuntime(name: string): PluginRuntime {
+  const error = (operation: string) => () => {
+    throw new Error(`plugin/${name}: runtime.${operation} unavailable in this process (definition-only load)`);
+  };
+  const fileOps = {
+    read: error("files.read"),
+    readBytes: error("files.readBytes"),
+    write: error("files.write"),
+    readDir: error("files.readDir"),
+    stat: error("files.stat"),
+    exists: error("files.exists"),
+    unlink: error("files.unlink"),
+  };
+  return {
+    pubsub: { publish: () => undefined },
+    locale: "en",
+    files: { data: fileOps, config: fileOps },
+    log: { debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined },
+    fetch: error("fetch") as unknown as PluginRuntime["fetch"],
+    fetchJson: error("fetchJson") as unknown as PluginRuntime["fetchJson"],
+    notify: () => undefined,
+  };
+}
+
+/** Two carrier shapes (#1110 backward compatibility):
+ *
+ *   1. **Factory** (`export default definePlugin(setup)`) — `mod.default`
+ *      is a function. Call it with the plugin's runtime; the return
+ *      value carries `TOOL_DEFINITION` and the handler keyed by
+ *      `TOOL_DEFINITION.name`. Closure over runtime gives the handler
+ *      access to scoped pubsub / files / log without per-call context
+ *      threading.
+ *   2. **Legacy** (`export const TOOL_DEFINITION = ...; export async
+ *      function <name>(context, args) ...`) — `mod.TOOL_DEFINITION` and
+ *      `mod[<name>]` directly. Continues to work; existing
+ *      @gui-chat-plugin packages don't need to migrate.
+ */
+function resolveCarrier(name: string, mod: Record<string, unknown>, deps: LoaderDeps): { carrier: Record<string, unknown>; usingFactory: boolean } {
+  const defaultExport = mod.default;
+  if (isPluginFactory(defaultExport)) {
+    const runtime = deps.runtimeFactory ? deps.runtimeFactory(name) : makeStubRuntime(name);
+    return { carrier: defaultExport(runtime) as unknown as Record<string, unknown>, usingFactory: true };
+  }
+  return { carrier: mod, usingFactory: false };
+}
+
+/** Pull the executable from a carrier. Factory-shape handlers take
+ *  `(args)` only (runtime is closed over) so we wrap to discard the
+ *  legacy `context` arg the dispatch route passes. Legacy-shape
+ *  handlers keep the `(context, args)` signature unchanged. Returns
+ *  null when no function is exported under `definition.name` — the
+ *  plugin still appears in `tools/list` but dispatch logs + 500s. */
+function resolveExecute(
+  carrier: Record<string, unknown>,
+  definitionName: string,
+  usingFactory: boolean,
+): ((context: unknown, args: unknown) => unknown) | null {
+  const handler = carrier[definitionName];
+  if (typeof handler !== "function") return null;
+  if (usingFactory) {
+    const factoryHandler = handler as (args: unknown) => unknown;
+    return (_context, args) => factoryHandler(args);
+  }
+  return handler as (context: unknown, args: unknown) => unknown;
+}
+
 /** Load a plugin from an already-extracted cache directory. Pure
  *  function — accepts paths explicitly, so tests don't need a real
  *  workspace. Returns null on any structural failure (missing
  *  package.json, missing TOOL_DEFINITION, broken import); the caller
  *  treats nulls as "skip". */
-export async function loadPluginFromCacheDir(name: string, version: string, cachePath: string): Promise<RuntimePlugin | null> {
+export async function loadPluginFromCacheDir(name: string, version: string, cachePath: string, deps: LoaderDeps = {}): Promise<RuntimePlugin | null> {
   const pkg = readPackageJson(cachePath);
   if (!pkg) return null;
   const entrySpec = resolveEntrySpecifier(pkg);
@@ -146,22 +230,19 @@ export async function loadPluginFromCacheDir(name: string, version: string, cach
   const entryAbs = path.join(cachePath, entrySpec);
   try {
     const mod = (await import(pathToFileURL(entryAbs).href)) as Record<string, unknown>;
-    const definition = mod.TOOL_DEFINITION;
+    const { carrier, usingFactory } = resolveCarrier(name, mod, deps);
+    const definition = carrier.TOOL_DEFINITION;
     if (!isToolDefinition(definition)) {
-      log.warn(LOG_PREFIX, "no TOOL_DEFINITION export — skipping", { name, entrySpec });
+      log.warn(LOG_PREFIX, "no TOOL_DEFINITION export — skipping", { name, entrySpec, shape: usingFactory ? "factory" : "legacy" });
       return null;
     }
-    // The @gui-chat-plugin convention: the server-side handler is
-    // exported under the same key as `TOOL_DEFINITION.name` (weather
-    // → `fetchWeather`, browse → `browse`, camera → `takePhoto`).
-    // Captured here so the dispatch route doesn't have to re-import
-    // the module on every call. A missing handler is non-fatal — the
-    // plugin still appears in tools/list but the dispatch will fail
-    // with a clear server log + 500.
-    const handler = mod[definition.name];
-    const execute = typeof handler === "function" ? (handler as (context: unknown, args: unknown) => unknown) : null;
+    const execute = resolveExecute(carrier, definition.name, usingFactory);
     if (!execute) {
-      log.warn(LOG_PREFIX, "no execute handler matching TOOL_DEFINITION.name — dispatch will fail", { name, expectedExport: definition.name });
+      log.warn(LOG_PREFIX, "no execute handler matching TOOL_DEFINITION.name — dispatch will fail", {
+        name,
+        expectedExport: definition.name,
+        shape: usingFactory ? "factory" : "legacy",
+      });
     }
     return { name, version, cachePath, definition, execute };
   } catch (err) {
@@ -183,7 +264,7 @@ export function ensureInsideBase(candidate: string, base: string): boolean {
   return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(resolvedBase + path.sep);
 }
 
-async function loadOne(entry: LedgerEntry): Promise<RuntimePlugin | null> {
+async function loadOne(entry: LedgerEntry, deps: LoaderDeps = {}): Promise<RuntimePlugin | null> {
   const tgzAbs = path.join(WORKSPACE_PATHS.plugins, entry.tgz);
   const cachePath = path.join(WORKSPACE_PATHS.pluginCache, entry.name, entry.version);
   // Anchor checks BEFORE any disk probe (`existsSync` / `realpath`).
@@ -216,18 +297,23 @@ async function loadOne(entry: LedgerEntry): Promise<RuntimePlugin | null> {
       return null;
     }
   }
-  return loadPluginFromCacheDir(entry.name, entry.version, cachePath);
+  return loadPluginFromCacheDir(entry.name, entry.version, cachePath, deps);
 }
 
 /** Read the ledger and load every healthy plugin. Returns the loaded
  *  set; failures are logged and silently skipped (see module
- *  comment). */
-export async function loadRuntimePlugins(): Promise<RuntimePlugin[]> {
+ *  comment).
+ *
+ *  Pass `deps.runtimeFactory` from the parent server so factory-shape
+ *  plugins (`export default definePlugin(...)`) get a real runtime.
+ *  The MCP child can call without deps — its only consumer is
+ *  `tools/list` which needs `TOOL_DEFINITION` only. */
+export async function loadRuntimePlugins(deps: LoaderDeps = {}): Promise<RuntimePlugin[]> {
   const entries = readLedger();
   if (entries.length === 0) return [];
   const loaded: RuntimePlugin[] = [];
   for (const entry of entries) {
-    const plugin = await loadOne(entry);
+    const plugin = await loadOne(entry, deps);
     if (plugin) loaded.push(plugin);
   }
   log.info(LOG_PREFIX, "loaded", { requested: entries.length, succeeded: loaded.length });

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -191,20 +191,32 @@ function makeScopedFetch(pkgName: string): PluginRuntime["fetch"] {
       // so plugin authors don't need to know the wider DOM BodyInit union.
       const body = opts.body as Parameters<typeof fetch>[1] extends infer T ? (T extends { body?: infer B } ? B : never) : never;
       return await fetch(url, { method: opts.method, headers: opts.headers, body, signal });
+    } catch (err) {
+      // Re-throw with plugin context so a fan-out failure in the
+      // host log immediately points at the responsible plugin
+      // instead of an anonymous network error (CodeRabbit review on
+      // PR #1124). Distinguishing AbortError → "timeout" is more
+      // useful than the bare "AbortError: This operation was aborted"
+      // message that surfaces from AbortController.
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error(`plugin/${pkgName}: fetch timed out after ${timeoutMs}ms (${url})`);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`plugin/${pkgName}: fetch failed (${url}): ${message}`);
     } finally {
       clearTimeout(timer);
     }
   };
 }
 
-function makeScopedFetchJson(scopedFetch: PluginRuntime["fetch"]): PluginRuntime["fetchJson"] {
+function makeScopedFetchJson(pkgName: string, scopedFetch: PluginRuntime["fetch"]): PluginRuntime["fetchJson"] {
   // When `opts.parse` is provided we trust its narrowing; when absent
   // the caller asserts the JSON shape themselves (same contract as
   // `JSON.parse(...) as T`).
   return async function fetchJson<T>(url: string, opts: { parse?: (raw: unknown) => T } & Parameters<PluginRuntime["fetch"]>[1] = {}): Promise<T> {
     const response = await scopedFetch(url, opts);
     if (!response.ok) {
-      throw new Error(`fetchJson: HTTP ${response.status} for ${url}`);
+      throw new Error(`plugin/${pkgName}: fetchJson HTTP ${response.status} for ${url}`);
     }
     const raw = (await response.json()) as unknown;
     return opts.parse ? opts.parse(raw) : (raw as T);
@@ -280,7 +292,7 @@ export function makePluginRuntime(deps: MakePluginRuntimeDeps): PluginRuntime {
     },
     log: makeScopedLogger(pkgName),
     fetch: scopedFetch,
-    fetchJson: makeScopedFetchJson(scopedFetch),
+    fetchJson: makeScopedFetchJson(pkgName, scopedFetch),
     notify: makeScopedNotify(pkgName),
   };
 }

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -31,23 +31,48 @@ const DEFAULT_FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
 //
 //   1. Replace `\` with `/` (Windows path.join leak repair).
 //   2. `path.posix.normalize` (folds `..`, `.`, `//`).
-//   3. `path.posix.resolve(scopeRoot, normalized)`.
-//   4. `ensureInsideBase` — throw if the result escapes the scope root.
+//   3. Reject if the normalised form starts with `..` or `/`
+//      (would escape the scope root or be absolute).
+//   4. `path.join(scopeRoot, ...segments)` — platform-aware join so
+//      the returned absolute path uses the host OS separator
+//      (backslashes on Windows, forward slashes on POSIX). Critical
+//      for `ensureInsideBase` to accept the result.
 //
 // Plugin authors should never need `node:path`; the platform meets
 // them where they are even if they mis-import it on Windows.
 // ─────────────────────────────────────────────────────────────────────
 
 /** Resolve a plugin-supplied path to an absolute path inside the
- *  plugin's scope root. Throws on traversal. Exported for tests. */
+ *  plugin's scope root. Throws on traversal. Exported for tests.
+ *
+ *  Cross-platform: `scopeRoot` is the host OS's native form (drive
+ *  letter + backslashes on Windows, forward slashes on POSIX). The
+ *  user-supplied `rel` is POSIX-relative by contract; we sanitise
+ *  for the lexical traversal check via `path.posix.*`, then join
+ *  with `path.join` so the returned absolute path is in the host's
+ *  native form (which `ensureInsideBase` requires). */
 export function normalizePluginPath(scopeRoot: string, rel: string): string {
   // Defang Windows path.join output and any mixed-separator inputs.
   const slashed = rel.replace(/\\/g, "/");
   // Fold `..` / `.` / repeated `/` lexically (no fs touch yet).
   const normalised = path.posix.normalize(slashed);
-  // Resolve against scopeRoot. `posix.resolve` is correct because the
-  // scope root is also POSIX-shaped on disk (we control it).
-  const absolute = path.posix.resolve(scopeRoot, normalised);
+  // Reject lexically — anything that escapes the scope root after
+  // normalisation either starts with `..` (parent-traversal) or is
+  // absolute (`/etc/passwd`). `path.posix.normalize` produces `..`
+  // alone if the input is `..` itself, hence the equality branch.
+  if (normalised === ".." || normalised.startsWith("../") || normalised.startsWith("/")) {
+    throw new Error(`path escapes plugin scope: ${rel}`);
+  }
+  const segments = normalised === "." ? [] : normalised.split("/");
+  // `path.join` (platform-aware) so the result uses the host
+  // separator. On Windows that's backslashes; on POSIX, forward
+  // slashes — matching `scopeRoot`'s existing form so
+  // `ensureInsideBase`'s `path.resolve` + `path.sep` comparison
+  // works across both platforms.
+  const absolute = path.join(scopeRoot, ...segments);
+  // Defence in depth: even though the lexical check above should
+  // catch every escape, run `ensureInsideBase` so a future change to
+  // either step doesn't silently regress the safety guarantee.
   if (!ensureInsideBase(absolute, scopeRoot)) {
     throw new Error(`path escapes plugin scope: ${rel}`);
   }

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -1,0 +1,269 @@
+// Plugin runtime construction — the per-plugin scoped object
+// `definePlugin(setup)` factories receive at load time (#1110).
+//
+// Every helper closes over `pkgName` so a plugin's pubsub channel,
+// data dir, log prefix etc. cannot leak across plugins. Path arguments
+// to `files.{data,config}` are normalised to POSIX, then anchored
+// inside the plugin's scope root via `ensureInsideBase` — so misuse of
+// `node:path` on Windows still works and `"../../etc/passwd"` is
+// rejected.
+//
+// This module is server-side only. The browser-side counterpart lives
+// at `src/utils/plugin/runtime.ts`.
+
+import path from "node:path";
+import { readFile, readdir, stat as fsStat, unlink as fsUnlink } from "node:fs/promises";
+import type { FileOps, PluginNotifyMessage, PluginRuntime } from "gui-chat-protocol";
+
+import { WORKSPACE_PATHS } from "../workspace/paths.js";
+import { writeFileAtomic } from "../utils/files/atomic.js";
+import { log as hostLog, type Logger } from "../system/logger/index.js";
+import { ensureInsideBase } from "./runtime-loader.js";
+import { ONE_SECOND_MS } from "../utils/time.js";
+import { publishNotification } from "../events/notifications.js";
+import { NOTIFICATION_KINDS } from "../../src/types/notification.js";
+import type { IPubSub } from "../events/pub-sub/index.js";
+
+const DEFAULT_FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
+
+// ─────────────────────────────────────────────────────────────────────
+// Path normalisation contract (see plans/feat-plugin-runtime-extensions-1110.md)
+//
+//   1. Replace `\` with `/` (Windows path.join leak repair).
+//   2. `path.posix.normalize` (folds `..`, `.`, `//`).
+//   3. `path.posix.resolve(scopeRoot, normalized)`.
+//   4. `ensureInsideBase` — throw if the result escapes the scope root.
+//
+// Plugin authors should never need `node:path`; the platform meets
+// them where they are even if they mis-import it on Windows.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Resolve a plugin-supplied path to an absolute path inside the
+ *  plugin's scope root. Throws on traversal. Exported for tests. */
+export function normalizePluginPath(scopeRoot: string, rel: string): string {
+  // Defang Windows path.join output and any mixed-separator inputs.
+  const slashed = rel.replace(/\\/g, "/");
+  // Fold `..` / `.` / repeated `/` lexically (no fs touch yet).
+  const normalised = path.posix.normalize(slashed);
+  // Resolve against scopeRoot. `posix.resolve` is correct because the
+  // scope root is also POSIX-shaped on disk (we control it).
+  const absolute = path.posix.resolve(scopeRoot, normalised);
+  if (!ensureInsideBase(absolute, scopeRoot)) {
+    throw new Error(`path escapes plugin scope: ${rel}`);
+  }
+  return absolute;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scoped FileOps factory
+// ─────────────────────────────────────────────────────────────────────
+
+function isErrnoException(value: unknown): value is { code: string } {
+  return typeof value === "object" && value !== null && "code" in value && typeof (value as { code: unknown }).code === "string";
+}
+
+function makeFileOps(scopeRoot: string): FileOps {
+  // The scope root may not exist on first use. Lazy-create at write
+  // time (writeFileAtomic does its own mkdir for the file's parent;
+  // we ensure the scope root exists for readDir() / stat() etc.).
+  // Reads against a never-written plugin throw ENOENT — exposed as
+  // `exists() === false` rather than handled here.
+
+  return {
+    async read(rel) {
+      return readFile(normalizePluginPath(scopeRoot, rel), "utf-8");
+    },
+    async readBytes(rel) {
+      const buf = await readFile(normalizePluginPath(scopeRoot, rel));
+      return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    },
+    async write(rel, content) {
+      const abs = normalizePluginPath(scopeRoot, rel);
+      await writeFileAtomic(abs, content);
+    },
+    async readDir(rel) {
+      const abs = normalizePluginPath(scopeRoot, rel);
+      try {
+        return await readdir(abs);
+      } catch (err) {
+        if (isErrnoException(err) && err.code === "ENOENT") return [];
+        throw err;
+      }
+    },
+    async stat(rel) {
+      const { mtimeMs, size } = await fsStat(normalizePluginPath(scopeRoot, rel));
+      return { mtimeMs, size };
+    },
+    async exists(rel) {
+      try {
+        await fsStat(normalizePluginPath(scopeRoot, rel));
+        return true;
+      } catch (err) {
+        if (isErrnoException(err) && err.code === "ENOENT") return false;
+        throw err;
+      }
+    },
+    async unlink(rel) {
+      try {
+        await fsUnlink(normalizePluginPath(scopeRoot, rel));
+      } catch (err) {
+        if (isErrnoException(err) && err.code === "ENOENT") return;
+        throw err;
+      }
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Sanitisation: pkg name → on-disk directory segment
+// ─────────────────────────────────────────────────────────────────────
+
+/** Convert an npm package name (`@org/foo`) to a single safe directory
+ *  segment. URL-encodes `/` in scoped names so the scope root stays
+ *  one level deep — keeps `readdir` predictable and avoids accidental
+ *  traversal via the package name itself.
+ *
+ *  Exported for tests. */
+export function sanitisePackageNameForFs(pkgName: string): string {
+  return encodeURIComponent(pkgName);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scoped logger
+// ─────────────────────────────────────────────────────────────────────
+
+function makeScopedLogger(pkgName: string): PluginRuntime["log"] {
+  const prefix = `plugin/${pkgName}`;
+  return {
+    debug: (msg, data) => hostLog.debug(prefix, msg, data as Record<string, unknown> | undefined),
+    info: (msg, data) => hostLog.info(prefix, msg, data as Record<string, unknown> | undefined),
+    warn: (msg, data) => hostLog.warn(prefix, msg, data as Record<string, unknown> | undefined),
+    error: (msg, data) => hostLog.error(prefix, msg, data as Record<string, unknown> | undefined),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scoped fetch (timeout + optional host allowlist)
+// ─────────────────────────────────────────────────────────────────────
+
+function makeScopedFetch(pkgName: string): PluginRuntime["fetch"] {
+  return async (url, opts = {}) => {
+    if (opts.allowedHosts && opts.allowedHosts.length > 0) {
+      const { hostname } = new URL(url);
+      if (!opts.allowedHosts.includes(hostname)) {
+        throw new Error(`plugin/${pkgName}: host ${hostname} not in allowedHosts`);
+      }
+    }
+    const controller = new AbortController();
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      // Forward both the caller's signal (if any) and our timeout
+      // signal. AbortSignal.any returns a signal that fires when
+      // either input fires — Node 20+.
+      const signal = opts.signal ? AbortSignal.any([opts.signal, controller.signal]) : controller.signal;
+      // The runtime cast keeps PluginFetchInit narrow (string | Uint8Array)
+      // so plugin authors don't need to know the wider DOM BodyInit union.
+      const body = opts.body as Parameters<typeof fetch>[1] extends infer T ? (T extends { body?: infer B } ? B : never) : never;
+      return await fetch(url, { method: opts.method, headers: opts.headers, body, signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+function makeScopedFetchJson(scopedFetch: PluginRuntime["fetch"]): PluginRuntime["fetchJson"] {
+  // When `opts.parse` is provided we trust its narrowing; when absent
+  // the caller asserts the JSON shape themselves (same contract as
+  // `JSON.parse(...) as T`).
+  return async function fetchJson<T>(url: string, opts: { parse?: (raw: unknown) => T } & Parameters<PluginRuntime["fetch"]>[1] = {}): Promise<T> {
+    const response = await scopedFetch(url, opts);
+    if (!response.ok) {
+      throw new Error(`fetchJson: HTTP ${response.status} for ${url}`);
+    }
+    const raw = (await response.json()) as unknown;
+    return opts.parse ? opts.parse(raw) : (raw as T);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scoped notify
+// ─────────────────────────────────────────────────────────────────────
+
+function makeScopedNotify(pkgName: string): PluginRuntime["notify"] {
+  return (msg: PluginNotifyMessage) => {
+    publishNotification({
+      kind: NOTIFICATION_KINDS.push,
+      title: msg.title,
+      body: msg.body,
+      // Plugin notifications carry no built-in deep link. The host
+      // notification panel will show title + body and the bell icon.
+      // Plugins that want navigation can publish a custom pubsub
+      // event their own View subscribes to.
+    });
+    hostLog.info(`plugin/${pkgName}`, "notify", { title: msg.title, level: msg.level ?? "info" });
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scoped pubsub publisher
+// ─────────────────────────────────────────────────────────────────────
+
+/** Build the channel name for a given plugin's event. Centralised so
+ *  the server-side publish side and the browser-side subscribe side
+ *  agree on the format (`plugin:<pkg>:<event>`). Exported for tests
+ *  and for the browser runtime to import the same constant. */
+export function pluginChannelName(pkgName: string, eventName: string): string {
+  return `plugin:${pkgName}:${eventName}`;
+}
+
+function makeScopedPubSub(pkgName: string, hostPubSub: IPubSub): PluginRuntime["pubsub"] {
+  return {
+    publish(eventName, payload) {
+      hostPubSub.publish(pluginChannelName(pkgName, eventName), payload);
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Public entry — wire everything into one PluginRuntime
+// ─────────────────────────────────────────────────────────────────────
+
+export interface MakePluginRuntimeDeps {
+  /** npm package name. Used both for sanitised fs segment + namespace prefix. */
+  pkgName: string;
+  /** Host pub/sub instance for fanning out scoped events. */
+  pubsub: IPubSub;
+  /** Locale tag the host has detected (e.g. `"ja"`). Snapshot only;
+   *  reactive updates ride the frontend `BrowserPluginRuntime.locale`. */
+  locale: string;
+}
+
+export function makePluginRuntime(deps: MakePluginRuntimeDeps): PluginRuntime {
+  const { pkgName, pubsub, locale } = deps;
+  const seg = sanitisePackageNameForFs(pkgName);
+  const dataRoot = path.join(WORKSPACE_PATHS.pluginsData, seg);
+  const configRoot = path.join(WORKSPACE_PATHS.pluginsConfig, seg);
+  const scopedFetch = makeScopedFetch(pkgName);
+
+  return {
+    pubsub: makeScopedPubSub(pkgName, pubsub),
+    locale,
+    files: {
+      data: makeFileOps(dataRoot),
+      config: makeFileOps(configRoot),
+    },
+    log: makeScopedLogger(pkgName),
+    fetch: scopedFetch,
+    fetchJson: makeScopedFetchJson(scopedFetch),
+    notify: makeScopedNotify(pkgName),
+  };
+}
+
+// Re-export host's writeFileAtomic so plugin runtime tests can
+// inspect the same primitive without reaching into utils/.
+export { writeFileAtomic };
+
+// Re-export logger type so the loader can type-check sink injection
+// without re-importing from system/logger.
+export type { Logger };

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -120,6 +120,11 @@ export const WORKSPACE_DIRS = {
   // so the install / extract artefacts persist across npx invocations.
   plugins: "plugins",
   pluginCache: "plugins/.cache",
+  // Per-runtime-plugin storage roots (#1110). The platform creates
+  // `<root>/<sanitized-pkg-name>/` lazily on first write. data is the
+  // backup target; config holds per-machine UI state / defaults.
+  pluginsData: "data/plugins",
+  pluginsConfig: "config/plugins",
 } as const;
 export { WORKSPACE_FILES };
 
@@ -155,6 +160,8 @@ export const WORKSPACE_PATHS = {
   github: path.join(workspacePath, WORKSPACE_DIRS.github),
   plugins: path.join(workspacePath, WORKSPACE_DIRS.plugins),
   pluginCache: path.join(workspacePath, WORKSPACE_DIRS.pluginCache),
+  pluginsData: path.join(workspacePath, WORKSPACE_DIRS.pluginsData),
+  pluginsConfig: path.join(workspacePath, WORKSPACE_DIRS.pluginsConfig),
   accounting: path.join(workspacePath, WORKSPACE_DIRS.accounting),
   accountingBooks: path.join(workspacePath, WORKSPACE_DIRS.accountingBooks),
   // nested subdirs

--- a/src/_runtime/protocol-vue.ts
+++ b/src/_runtime/protocol-vue.ts
@@ -1,0 +1,21 @@
+// Re-export `gui-chat-protocol/vue` so a runtime-loaded plugin (#1110)
+// can share the host's `useRuntime()` / `PLUGIN_RUNTIME_KEY` instances
+// via importmap.
+//
+// Why a re-export at all: PLUGIN_RUNTIME_KEY is a `Symbol` created at
+// module load time. If two copies of `gui-chat-protocol/vue` were
+// loaded — one bundled into the host, another inlined in the plugin —
+// they would each create their own Symbol, and `provide(K, runtime)`
+// from the host would land on a different key than the plugin's
+// `inject(K)` — `useRuntime()` would throw "called outside of
+// <PluginScopedRoot>" even though the wrapper IS in the tree.
+//
+// The importmap entry in `index.html` (`gui-chat-protocol/vue` →
+// `/src/_runtime/protocol-vue.ts`) makes the browser resolve the
+// plugin's bare `import { useRuntime } from "gui-chat-protocol/vue"`
+// to this same file the host already loaded — guaranteeing one
+// shared module instance / one Symbol / one working inject path.
+//
+// `export *` mirrors the runtime-vue pattern next door: plugins compile
+// against an evolving surface; we don't want to whitelist names here.
+export * from "gui-chat-protocol/vue";

--- a/src/components/PluginScopedRoot.vue
+++ b/src/components/PluginScopedRoot.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+// Scope-provider wrapper for runtime plugin Vue components (#1110).
+// Builds a per-plugin BrowserPluginRuntime and `provide`s it under
+// PLUGIN_RUNTIME_KEY, so plugin descendants can pull it via
+// `useRuntime()` from `gui-chat-protocol/vue`.
+//
+// One instance per mounted plugin component subtree. Mount this in
+// the host's runtime plugin loader (the place that dynamically
+// imports the plugin's `dist/vue.js` and instantiates its
+// `viewComponent` / `previewComponent`).
+
+import { provide } from "vue";
+import { PLUGIN_RUNTIME_KEY } from "gui-chat-protocol/vue";
+import { makeBrowserPluginRuntime } from "../utils/plugin/runtime";
+
+interface Props {
+  /** npm package name of the plugin whose subtree we're scoping. */
+  pkgName: string;
+}
+
+const props = defineProps<Props>();
+
+// Construct once — `pkgName` is fixed for the lifetime of a mounted
+// plugin. If the host needs to rotate the scope (rare), it should
+// remount the entire wrapper rather than mutate `pkgName`.
+const runtime = makeBrowserPluginRuntime({ pkgName: props.pkgName });
+provide(PLUGIN_RUNTIME_KEY, runtime);
+</script>
+
+<template>
+  <slot />
+</template>

--- a/src/tools/runtimeLoader.ts
+++ b/src/tools/runtimeLoader.ts
@@ -14,11 +14,12 @@
 // Failures don't abort boot — a single broken plugin logs a warning
 // and the rest of the app starts normally.
 
-import { reactive } from "vue";
+import { defineComponent, h, markRaw, reactive } from "vue";
 import type { Component } from "vue";
 import type { ToolDefinition } from "gui-chat-protocol";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import PluginScopedRoot from "../components/PluginScopedRoot.vue";
 import type { PluginEntry } from "./types";
 
 interface RuntimePluginListing {
@@ -93,10 +94,35 @@ async function loadOne(listing: RuntimePluginListing): Promise<void> {
   }
   const entry: PluginEntry = {
     toolDefinition: plugin.toolDefinition,
-    viewComponent: plugin.viewComponent,
-    previewComponent: plugin.previewComponent,
+    viewComponent: wrapWithScopedRoot(plugin.viewComponent, listing.name),
+    previewComponent: wrapWithScopedRoot(plugin.previewComponent, listing.name),
   };
   runtimeRegistry.set(listing.toolName, entry);
+}
+
+/** Wrap a plugin's component in `<PluginScopedRoot>` so descendants can
+ *  pick up the per-plugin BrowserPluginRuntime via `useRuntime()` from
+ *  `gui-chat-protocol/vue` (#1110). The wrapper forwards every prop /
+ *  attr / slot through to the inner component, so the host's render
+ *  path stays unchanged.
+ *
+ *  Returns `undefined` when the plugin doesn't export the slot — the
+ *  host's `getPlugin()` consumer treats absence as "no preview" /
+ *  "no view". */
+function wrapWithScopedRoot(inner: Component | undefined, pkgName: string): Component | undefined {
+  if (!inner) return undefined;
+  // `markRaw` so the host's reactive `runtimeRegistry` doesn't try to
+  // proxy the component object — Vue warns + the proxy can interfere
+  // with internal component identity tracking.
+  return markRaw(
+    defineComponent({
+      name: `RuntimePluginScope:${pkgName}`,
+      inheritAttrs: false,
+      setup(_props, { attrs, slots }) {
+        return () => h(PluginScopedRoot, { pkgName }, () => h(inner, attrs, slots));
+      },
+    }),
+  );
 }
 
 /** Fetch the install list and dynamic-import each plugin in parallel.

--- a/src/utils/plugin/runtime.ts
+++ b/src/utils/plugin/runtime.ts
@@ -11,6 +11,7 @@ import { useI18n } from "vue-i18n";
 import type { BrowserPluginRuntime, PluginNotifyMessage } from "gui-chat-protocol/vue";
 import { usePubSub } from "../../composables/usePubSub";
 import { apiPost } from "../api";
+import { API_ROUTES } from "../../config/apiRoutes";
 
 /** Build the channel name for a plugin's event. Must stay in lockstep
  *  with `server/plugins/runtime.ts:pluginChannelName`. */
@@ -44,25 +45,45 @@ function makeScopedLogger(pkgName: string): BrowserPluginRuntime["log"] {
   };
 }
 
+/** Allowlisted URL schemes for `runtime.openUrl`. The two http schemes
+ *  cover the legitimate "open this external page" use case; everything
+ *  else (`javascript:`, `data:`, `vbscript:`, `file:`, custom schemes)
+ *  is rejected. The `noopener,noreferrer` flags on `window.open`
+ *  prevent the opened tab from snooping the opener but do NOT stop
+ *  `javascript:` execution — that's why scheme filtering is the actual
+ *  XSS guard. CodeRabbit review caught this on PR #1124. */
+const OPEN_URL_ALLOWED_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
+
 function makeOpenUrl(pkgName: string): BrowserPluginRuntime["openUrl"] {
   return (url: string) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      console.warn(`[plugin/${pkgName}] openUrl rejected unparseable URL`, { url });
+      return;
+    }
+    if (!OPEN_URL_ALLOWED_SCHEMES.has(parsed.protocol)) {
+      console.warn(`[plugin/${pkgName}] openUrl rejected non-http(s) scheme`, { scheme: parsed.protocol });
+      return;
+    }
     // `noopener` prevents the opened tab from accessing `window.opener`
     // and snooping; `noreferrer` strips the Referer header so the
     // destination can't see what page sent the user. Forced at the
     // platform level so individual plugin links can't drop them.
     const opened = window.open(url, "_blank", "noopener,noreferrer");
     if (!opened) {
-      // Popup blocker engaged or url malformed.
+      // Popup blocker engaged.
       console.warn(`[plugin/${pkgName}] window.open returned null`, { url });
     }
   };
 }
 
 function makeDispatch(pkgName: string): BrowserPluginRuntime["dispatch"] {
-  // Encode the pkg name into the URL the same way the host's
-  // runtime asset / dispatch routes expect (encodeURIComponent
-  // collapses scoped names into one path segment).
-  const url = `/api/plugins/runtime/${encodeURIComponent(pkgName)}/dispatch`;
+  // Substitute `:pkg` in the contracted dispatch route. encodeURIComponent
+  // collapses scoped names (`@org/pkg`) into one URL path segment;
+  // the parameter pattern `:pkg` matches any segment.
+  const url = API_ROUTES.plugins.runtimeDispatch.replace(":pkg", encodeURIComponent(pkgName));
   return async <T = unknown>(args: object): Promise<T> => {
     const result = await apiPost<T>(url, args);
     if (!result.ok) {

--- a/src/utils/plugin/runtime.ts
+++ b/src/utils/plugin/runtime.ts
@@ -1,0 +1,108 @@
+// Browser-side plugin runtime construction (#1110). The host's runtime
+// plugin loader provides one of these per plugin via Vue's
+// `provide(PLUGIN_RUNTIME_KEY, ...)`; the plugin's components fetch
+// it via `useRuntime()` from `gui-chat-protocol/vue`.
+//
+// Every helper closes over `pkgName` so the plugin's pubsub channel
+// and notify call cannot leak into another plugin's namespace.
+
+import { computed, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import type { BrowserPluginRuntime, PluginNotifyMessage } from "gui-chat-protocol/vue";
+import { usePubSub } from "../../composables/usePubSub";
+import { apiPost } from "../api";
+
+/** Build the channel name for a plugin's event. Must stay in lockstep
+ *  with `server/plugins/runtime.ts:pluginChannelName`. */
+export function pluginChannelName(pkgName: string, eventName: string): string {
+  return `plugin:${pkgName}:${eventName}`;
+}
+
+function makeScopedPubSub(pkgName: string): BrowserPluginRuntime["pubsub"] {
+  const { subscribe } = usePubSub();
+  return {
+    subscribe(eventName, handler) {
+      // The host pubsub fans payloads as `unknown`; the plugin
+      // declares the expected shape via the generic at the call
+      // site. Validation is the plugin's responsibility (Zod or
+      // hand-written guard).
+      return subscribe(pluginChannelName(pkgName, eventName), handler as (data: unknown) => void);
+    },
+  };
+}
+
+function makeScopedLogger(pkgName: string): BrowserPluginRuntime["log"] {
+  // Frontend logger maps to `console.*` in v1. The host's central
+  // logger lives server-side; routing browser logs there is a future
+  // enhancement that doesn't change this surface.
+  const tag = `[plugin/${pkgName}]`;
+  return {
+    debug: (msg, data) => console.debug(tag, msg, data),
+    info: (msg, data) => console.info(tag, msg, data),
+    warn: (msg, data) => console.warn(tag, msg, data),
+    error: (msg, data) => console.error(tag, msg, data),
+  };
+}
+
+function makeOpenUrl(pkgName: string): BrowserPluginRuntime["openUrl"] {
+  return (url: string) => {
+    // `noopener` prevents the opened tab from accessing `window.opener`
+    // and snooping; `noreferrer` strips the Referer header so the
+    // destination can't see what page sent the user. Forced at the
+    // platform level so individual plugin links can't drop them.
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (!opened) {
+      // Popup blocker engaged or url malformed.
+      console.warn(`[plugin/${pkgName}] window.open returned null`, { url });
+    }
+  };
+}
+
+function makeDispatch(pkgName: string): BrowserPluginRuntime["dispatch"] {
+  // Encode the pkg name into the URL the same way the host's
+  // runtime asset / dispatch routes expect (encodeURIComponent
+  // collapses scoped names into one path segment).
+  const url = `/api/plugins/runtime/${encodeURIComponent(pkgName)}/dispatch`;
+  return async <T = unknown>(args: object): Promise<T> => {
+    const result = await apiPost<T>(url, args);
+    if (!result.ok) {
+      throw new Error(`plugin/${pkgName} dispatch failed (${result.status}): ${result.error}`);
+    }
+    return result.data;
+  };
+}
+
+function makeNotify(pkgName: string): BrowserPluginRuntime["notify"] {
+  // Browser-side notify mirrors the API surface of the server-side
+  // notify, but actual delivery happens server-side (the bell badge,
+  // macOS Reminder, bridge fan-out, etc.). For v1 we just log;
+  // hooking through to the host's notification channel from the
+  // browser is a follow-up.
+  return (msg: PluginNotifyMessage) => {
+    console.info(`[plugin/${pkgName}] notify`, msg);
+  };
+}
+
+export interface MakeBrowserPluginRuntimeDeps {
+  /** npm package name. Used both as the namespace prefix for
+   *  pubsub channels and as the log prefix. */
+  pkgName: string;
+}
+
+export function makeBrowserPluginRuntime(deps: MakeBrowserPluginRuntimeDeps): BrowserPluginRuntime {
+  const { pkgName } = deps;
+  // `useI18n()` exposes `locale` as `WritableComputedRef<Locales>`.
+  // Wrapping in a fresh `computed` widens it to `Ref<string>` for
+  // plugin authors (so they don't need to import the host's locale
+  // union) while preserving reactivity.
+  const { locale: hostLocale } = useI18n();
+  const locale = computed(() => String(hostLocale.value)) as Ref<string>;
+  return {
+    pubsub: makeScopedPubSub(pkgName),
+    locale,
+    log: makeScopedLogger(pkgName),
+    openUrl: makeOpenUrl(pkgName),
+    notify: makeNotify(pkgName),
+    dispatch: makeDispatch(pkgName),
+  };
+}

--- a/test/plugins/test_bookmarks_integration.ts
+++ b/test/plugins/test_bookmarks_integration.ts
@@ -1,0 +1,151 @@
+// End-to-end integration test for the Bookmarks reference plugin
+// (#1110). Loads the workspace-built `dist/index.js` through the real
+// runtime loader with a real `makePluginRuntime`, then exercises the
+// add → list → remove → list flow against an isolated tmp workspace.
+//
+// Skips automatically when the plugin's dist isn't present (i.e.
+// `yarn build` hasn't been run in `packages/bookmarks-plugin/`). Add
+// the build step to the test prereqs to make this hard-required.
+
+import { describe, it, before, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadPluginFromCacheDir } from "../../server/plugins/runtime-loader.js";
+import { makePluginRuntime } from "../../server/plugins/runtime.js";
+import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import type { IPubSub } from "../../server/events/pub-sub/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_DIR = path.resolve(__dirname, "../../packages/bookmarks-plugin");
+const PLUGIN_DIST_INDEX = path.join(PLUGIN_DIR, "dist", "index.js");
+
+const PKG_NAME = "@mulmoclaude/bookmarks-plugin";
+const VERSION = "0.1.0";
+
+function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string; data: unknown }[] } {
+  const published: { channel: string; data: unknown }[] = [];
+  return {
+    pubsub: {
+      publish(channel, data) {
+        published.push({ channel, data });
+      },
+    },
+    published,
+  };
+}
+
+interface BookmarkResult {
+  ok: boolean;
+  bookmark?: { id: string; url: string; title: string; addedAt: string };
+  bookmarks?: { id: string; url: string; title: string }[];
+  error?: string;
+}
+
+describe("Bookmarks plugin — end-to-end through the loader", () => {
+  before(() => {
+    // The dist must exist for the loader to import. If a developer hasn't
+    // built the plugin yet (`cd packages/bookmarks-plugin && yarn build`),
+    // skip rather than failing — CI runs the build before tests.
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      console.warn(`[bookmarks integration] skipping: ${PLUGIN_DIST_INDEX} not built — run \`yarn build\` in packages/bookmarks-plugin/`);
+    }
+  });
+
+  let savedDataRoot: string;
+  let savedConfigRoot: string;
+  let dataRoot: string;
+  let configRoot: string;
+
+  beforeEach(() => {
+    savedDataRoot = WORKSPACE_PATHS.pluginsData;
+    savedConfigRoot = WORKSPACE_PATHS.pluginsConfig;
+    dataRoot = mkdtempSync(path.join(tmpdir(), "bookmarks-int-data-"));
+    configRoot = mkdtempSync(path.join(tmpdir(), "bookmarks-int-config-"));
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: dataRoot, configurable: true });
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: configRoot, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: savedDataRoot, configurable: true });
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: savedConfigRoot, configurable: true });
+    rmSync(dataRoot, { recursive: true, force: true });
+    rmSync(configRoot, { recursive: true, force: true });
+  });
+
+  it("loads the factory plugin, runs add + list + remove, and publishes scoped events", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub, published } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin, "plugin should load");
+    assert.equal(plugin.definition.name, "manageBookmarks");
+    assert.ok(plugin.execute, "execute handler must be present");
+
+    // 1. List on empty workspace returns 0 bookmarks (no publish).
+    let res = (await plugin.execute({}, { kind: "list" })) as BookmarkResult;
+    assert.deepEqual(res, { ok: true, bookmarks: [] });
+    assert.equal(published.length, 0, "list must not publish");
+
+    // 2. Add a bookmark — should publish "changed".
+    res = (await plugin.execute({}, { kind: "add", url: "https://example.com/", title: "Example" })) as BookmarkResult;
+    assert.equal(res.ok, true);
+    if (!res.bookmark) throw new Error("add must return a bookmark");
+    assert.equal(res.bookmark.url, "https://example.com/");
+    assert.equal(published.length, 1, "add must publish exactly one changed event");
+    assert.equal(published[0].channel, `plugin:${PKG_NAME}:changed`);
+
+    // 3. List returns the bookmark.
+    res = (await plugin.execute({}, { kind: "list" })) as BookmarkResult;
+    assert.equal(res.bookmarks?.length, 1);
+    if (!res.bookmarks) throw new Error("list must return bookmarks array");
+    const [{ id }] = res.bookmarks;
+
+    // 4. Remove the bookmark — should publish "changed" again.
+    res = (await plugin.execute({}, { kind: "remove", id })) as BookmarkResult;
+    assert.deepEqual(res, { ok: true });
+    assert.equal(published.length, 2);
+    assert.equal(published[1].channel, `plugin:${PKG_NAME}:changed`);
+
+    // 5. List again — back to empty.
+    res = (await plugin.execute({}, { kind: "list" })) as BookmarkResult;
+    assert.deepEqual(res, { ok: true, bookmarks: [] });
+
+    // 6. Remove a non-existent id returns ok:false.
+    res = (await plugin.execute({}, { kind: "remove", id: "ghost" })) as BookmarkResult;
+    assert.deepEqual(res, { ok: false, error: "not_found" });
+  });
+
+  it("setSort writes to files.config (not files.data) and publishes prefs-changed", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub, published } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+
+    const res = (await plugin.execute({}, { kind: "setSort", by: "title" })) as BookmarkResult;
+    assert.deepEqual(res, { ok: true });
+
+    assert.equal(published.length, 1);
+    assert.equal(published[0].channel, `plugin:${PKG_NAME}:prefs-changed`);
+
+    // The prefs file should land under the config root, NOT data.
+    const sanitisedSeg = encodeURIComponent(PKG_NAME);
+    const expectedConfigFile = path.join(configRoot, sanitisedSeg, "prefs.json");
+    assert.ok(existsSync(expectedConfigFile), `expected ${expectedConfigFile} to exist`);
+    const expectedDataFile = path.join(dataRoot, sanitisedSeg, "prefs.json");
+    assert.ok(!existsSync(expectedDataFile), "prefs must not leak into the data root");
+  });
+});

--- a/test/plugins/test_bookmarks_integration.ts
+++ b/test/plugins/test_bookmarks_integration.ts
@@ -56,23 +56,29 @@ describe("Bookmarks plugin — end-to-end through the loader", () => {
     }
   });
 
-  let savedDataRoot: string;
-  let savedConfigRoot: string;
+  // Capture the FULL property descriptor so afterEach restores
+  // writability + enumerability flags too. The earlier
+  // `Object.defineProperty(..., {value, configurable})` shape silently
+  // flipped the property to non-writable + non-enumerable, leaking
+  // that mutation across tests (Codex review iter on PR #1124, same
+  // fix as test_plugin_runtime.ts).
+  let savedDataDescriptor: PropertyDescriptor | undefined;
+  let savedConfigDescriptor: PropertyDescriptor | undefined;
   let dataRoot: string;
   let configRoot: string;
 
   beforeEach(() => {
-    savedDataRoot = WORKSPACE_PATHS.pluginsData;
-    savedConfigRoot = WORKSPACE_PATHS.pluginsConfig;
+    savedDataDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsData");
+    savedConfigDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsConfig");
     dataRoot = mkdtempSync(path.join(tmpdir(), "bookmarks-int-data-"));
     configRoot = mkdtempSync(path.join(tmpdir(), "bookmarks-int-config-"));
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: dataRoot, configurable: true });
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: configRoot, configurable: true });
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { ...savedDataDescriptor, value: dataRoot });
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { ...savedConfigDescriptor, value: configRoot });
   });
 
   afterEach(() => {
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: savedDataRoot, configurable: true });
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: savedConfigRoot, configurable: true });
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", savedDataDescriptor);
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", savedConfigDescriptor);
     rmSync(dataRoot, { recursive: true, force: true });
     rmSync(configRoot, { recursive: true, force: true });
   });

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -1,0 +1,216 @@
+// Tests for `server/plugins/runtime.ts` (#1110).
+//
+// Covers:
+//   - `normalizePluginPath`: POSIX normalisation, Windows backslash
+//     repair, traversal rejection, scope-root anchoring.
+//   - `sanitisePackageNameForFs`: scoped names produce a single safe
+//     directory segment.
+//   - `pluginChannelName`: produces the contracted `plugin:<pkg>:<event>`
+//     shape (must stay in lockstep with the browser-side helper).
+//   - `makePluginRuntime`: scoped pubsub publishes prefixed channels;
+//     two plugins on the same host can't see each other's events;
+//     `files.data` and `files.config` write into separate roots and
+//     reject traversal.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { makePluginRuntime, normalizePluginPath, pluginChannelName, sanitisePackageNameForFs } from "../../server/plugins/runtime.js";
+import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import type { IPubSub } from "../../server/events/pub-sub/index.js";
+
+// In-memory pubsub double — captures every publish for inspection.
+function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string; data: unknown }[] } {
+  const published: { channel: string; data: unknown }[] = [];
+  return {
+    pubsub: {
+      publish(channel, data) {
+        published.push({ channel, data });
+      },
+    },
+    published,
+  };
+}
+
+describe("normalizePluginPath", () => {
+  const root = "/tmp/scope-root";
+
+  it("returns the absolute path for a simple relative file", () => {
+    assert.equal(normalizePluginPath(root, "foo.json"), `${root}/foo.json`);
+  });
+
+  it("accepts nested POSIX paths", () => {
+    assert.equal(normalizePluginPath(root, "books/2026/journal.jsonl"), `${root}/books/2026/journal.jsonl`);
+  });
+
+  it("repairs Windows backslash separators", () => {
+    // Plugin authors who slip up and use `node:path.join` on Windows
+    // get `"books\\2026\\journal.jsonl"`. The platform should still
+    // resolve that to a sane POSIX path under the scope root.
+    assert.equal(normalizePluginPath(root, "books\\2026\\journal.jsonl"), `${root}/books/2026/journal.jsonl`);
+  });
+
+  it("folds redundant `.` and `//` segments", () => {
+    assert.equal(normalizePluginPath(root, "./a//b/./c.json"), `${root}/a/b/c.json`);
+  });
+
+  it("rejects traversal that escapes the scope root", () => {
+    assert.throws(() => normalizePluginPath(root, "../../etc/passwd"), /escapes plugin scope/);
+    assert.throws(() => normalizePluginPath(root, "../sibling.json"), /escapes plugin scope/);
+  });
+
+  it("rejects encoded traversal mixed with legitimate segments", () => {
+    assert.throws(() => normalizePluginPath(root, "books/../../etc/hosts"), /escapes plugin scope/);
+  });
+
+  it("treats absolute paths as anchored to scope root (lexical normalisation)", () => {
+    // path.posix.resolve(root, "/foo") returns "/foo" — but our
+    // ensureInsideBase check then rejects it because /foo is outside
+    // the scope root. This protects against plugins that try to bypass
+    // by passing absolute paths.
+    assert.throws(() => normalizePluginPath(root, "/etc/passwd"), /escapes plugin scope/);
+  });
+});
+
+describe("sanitisePackageNameForFs", () => {
+  it("encodes scoped package names so the path stays one level deep", () => {
+    const seg = sanitisePackageNameForFs("@example/bookmarks-plugin");
+    // The slash inside the scope must not survive — otherwise readdir
+    // on the parent would list `@example/` and the plugin name would
+    // span two directory levels.
+    assert.ok(!seg.includes("/"), `expected single-segment, got "${seg}"`);
+    // And the encoded form must be reversible (so debug output is useful).
+    assert.equal(decodeURIComponent(seg), "@example/bookmarks-plugin");
+  });
+
+  it("leaves unscoped names untouched (URL-safe characters)", () => {
+    assert.equal(sanitisePackageNameForFs("weather"), "weather");
+  });
+});
+
+describe("pluginChannelName", () => {
+  it("produces the contracted format", () => {
+    assert.equal(pluginChannelName("@example/foo", "changed"), "plugin:@example/foo:changed");
+  });
+
+  it("does not collide between plugins with the same event name", () => {
+    const alpha = pluginChannelName("@a/p", "event");
+    const beta = pluginChannelName("@b/p", "event");
+    assert.notEqual(alpha, beta);
+  });
+});
+
+describe("makePluginRuntime — scoped pubsub", () => {
+  it("prefixes the plugin name on every publish", () => {
+    const { pubsub, published } = makeRecordingPubSub();
+    const runtime = makePluginRuntime({ pkgName: "@example/foo", pubsub, locale: "en" });
+    runtime.pubsub.publish("changed", { id: 1 });
+    assert.deepEqual(published, [{ channel: "plugin:@example/foo:changed", data: { id: 1 } }]);
+  });
+
+  it("isolates two plugins sharing the same host pubsub", () => {
+    const { pubsub, published } = makeRecordingPubSub();
+    const alpha = makePluginRuntime({ pkgName: "@a/p", pubsub, locale: "en" });
+    const beta = makePluginRuntime({ pkgName: "@b/p", pubsub, locale: "en" });
+    alpha.pubsub.publish("event", { from: "a" });
+    beta.pubsub.publish("event", { from: "b" });
+    assert.deepEqual(published, [
+      { channel: "plugin:@a/p:event", data: { from: "a" } },
+      { channel: "plugin:@b/p:event", data: { from: "b" } },
+    ]);
+  });
+});
+
+describe("makePluginRuntime — files.data and files.config", () => {
+  // Each test creates a fresh fake workspace root so the writes
+  // don't pile up.
+  let savedDataRoot: string;
+  let savedConfigRoot: string;
+  let dataRoot: string;
+  let configRoot: string;
+
+  beforeEach(() => {
+    savedDataRoot = WORKSPACE_PATHS.pluginsData;
+    savedConfigRoot = WORKSPACE_PATHS.pluginsConfig;
+    dataRoot = mkdtempSync(path.join(tmpdir(), "plugin-runtime-data-"));
+    configRoot = mkdtempSync(path.join(tmpdir(), "plugin-runtime-config-"));
+    // WORKSPACE_PATHS is a frozen const at import time, so we patch it
+    // via Object.defineProperty for the lifetime of the test. The
+    // alternative — refactoring `makePluginRuntime` to take roots as
+    // arguments — would expose internals plugin authors don't need.
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: dataRoot, configurable: true });
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: configRoot, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: savedDataRoot, configurable: true });
+    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: savedConfigRoot, configurable: true });
+    rmSync(dataRoot, { recursive: true, force: true });
+    rmSync(configRoot, { recursive: true, force: true });
+  });
+
+  function runtimeFor(pkgName: string) {
+    const { pubsub } = makeRecordingPubSub();
+    return makePluginRuntime({ pkgName, pubsub, locale: "en" });
+  }
+
+  it("write+read round-trip lands under files.data root", async () => {
+    const runtime = runtimeFor("@example/foo");
+    await runtime.files.data.write("state.json", "hello");
+    assert.equal(await runtime.files.data.read("state.json"), "hello");
+    assert.equal(await runtime.files.data.exists("state.json"), true);
+  });
+
+  it("data and config are physically separate roots", async () => {
+    const runtime = runtimeFor("@example/foo");
+    await runtime.files.data.write("same.json", "data-side");
+    await runtime.files.config.write("same.json", "config-side");
+    assert.equal(await runtime.files.data.read("same.json"), "data-side");
+    assert.equal(await runtime.files.config.read("same.json"), "config-side");
+  });
+
+  it("two plugins do not share a directory", async () => {
+    const alpha = runtimeFor("@a/p");
+    const beta = runtimeFor("@b/p");
+    await alpha.files.data.write("state.json", "a-state");
+    await beta.files.data.write("state.json", "b-state");
+    assert.equal(await alpha.files.data.read("state.json"), "a-state");
+    assert.equal(await beta.files.data.read("state.json"), "b-state");
+  });
+
+  it("files.exists returns false for never-written paths (no throw)", async () => {
+    const runtime = runtimeFor("@example/foo");
+    assert.equal(await runtime.files.data.exists("missing.json"), false);
+  });
+
+  it("files.unlink is a no-op when the file does not exist", async () => {
+    const runtime = runtimeFor("@example/foo");
+    await runtime.files.data.unlink("missing.json"); // should not throw
+  });
+
+  it("files.readDir returns [] for a plugin that never wrote", async () => {
+    const runtime = runtimeFor("@example/foo");
+    assert.deepEqual(await runtime.files.data.readDir("."), []);
+  });
+
+  it("rejects traversal via files.data.write", async () => {
+    const runtime = runtimeFor("@example/foo");
+    await assert.rejects(runtime.files.data.write("../../escape.json", "x"), /escapes plugin scope/);
+  });
+
+  it("rejects traversal via files.config.read", async () => {
+    const runtime = runtimeFor("@example/foo");
+    await assert.rejects(runtime.files.config.read("../../escape.json"), /escapes plugin scope/);
+  });
+
+  it("accepts Windows-style backslash paths from misuse of node:path", async () => {
+    const runtime = runtimeFor("@example/foo");
+    // Plugin author uses `path.join("books", "2026", "journal.jsonl")` on Windows.
+    await runtime.files.data.write("books\\2026\\journal.jsonl", "winpath");
+    // Reads with the POSIX form because that's the contract.
+    assert.equal(await runtime.files.data.read("books/2026/journal.jsonl"), "winpath");
+  });
+});

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -36,25 +36,33 @@ function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string;
 }
 
 describe("normalizePluginPath", () => {
-  const root = "/tmp/scope-root";
+  // `path.join` for the expected values so the tests pass on both POSIX
+  // (forward slashes) and Windows (backslashes). `normalizePluginPath`
+  // uses `path.join` internally for the same reason — `ensureInsideBase`
+  // compares with `path.resolve` + `path.sep`, which is platform-aware.
+  // Using a Windows-style root (`C:\\tmp\\scope-root`) on Windows
+  // would also work; the test root just needs to be absolute on the
+  // host OS — `path.resolve("/tmp/scope-root")` produces a usable
+  // absolute on both platforms.
+  const root = path.resolve("/tmp/scope-root");
 
   it("returns the absolute path for a simple relative file", () => {
-    assert.equal(normalizePluginPath(root, "foo.json"), `${root}/foo.json`);
+    assert.equal(normalizePluginPath(root, "foo.json"), path.join(root, "foo.json"));
   });
 
   it("accepts nested POSIX paths", () => {
-    assert.equal(normalizePluginPath(root, "books/2026/journal.jsonl"), `${root}/books/2026/journal.jsonl`);
+    assert.equal(normalizePluginPath(root, "books/2026/journal.jsonl"), path.join(root, "books", "2026", "journal.jsonl"));
   });
 
   it("repairs Windows backslash separators", () => {
     // Plugin authors who slip up and use `node:path.join` on Windows
     // get `"books\\2026\\journal.jsonl"`. The platform should still
-    // resolve that to a sane POSIX path under the scope root.
-    assert.equal(normalizePluginPath(root, "books\\2026\\journal.jsonl"), `${root}/books/2026/journal.jsonl`);
+    // resolve that to a sane absolute path under the scope root.
+    assert.equal(normalizePluginPath(root, "books\\2026\\journal.jsonl"), path.join(root, "books", "2026", "journal.jsonl"));
   });
 
   it("folds redundant `.` and `//` segments", () => {
-    assert.equal(normalizePluginPath(root, "./a//b/./c.json"), `${root}/a/b/c.json`);
+    assert.equal(normalizePluginPath(root, "./a//b/./c.json"), path.join(root, "a", "b", "c.json"));
   });
 
   it("rejects traversal that escapes the scope root", () => {
@@ -67,10 +75,9 @@ describe("normalizePluginPath", () => {
   });
 
   it("treats absolute paths as anchored to scope root (lexical normalisation)", () => {
-    // path.posix.resolve(root, "/foo") returns "/foo" — but our
-    // ensureInsideBase check then rejects it because /foo is outside
-    // the scope root. This protects against plugins that try to bypass
-    // by passing absolute paths.
+    // After `path.posix.normalize`, `/etc/passwd` keeps its leading
+    // `/` — the lexical-reject branch catches it before it ever
+    // reaches the filesystem.
     assert.throws(() => normalizePluginPath(root, "/etc/passwd"), /escapes plugin scope/);
   });
 });

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -134,27 +134,34 @@ describe("makePluginRuntime — scoped pubsub", () => {
 describe("makePluginRuntime — files.data and files.config", () => {
   // Each test creates a fresh fake workspace root so the writes
   // don't pile up.
-  let savedDataRoot: string;
-  let savedConfigRoot: string;
+  let savedDataDescriptor: PropertyDescriptor | undefined;
+  let savedConfigDescriptor: PropertyDescriptor | undefined;
   let dataRoot: string;
   let configRoot: string;
 
   beforeEach(() => {
-    savedDataRoot = WORKSPACE_PATHS.pluginsData;
-    savedConfigRoot = WORKSPACE_PATHS.pluginsConfig;
+    // Capture the FULL descriptor so afterEach can restore the original
+    // writability + enumerability flags. Storing only `value` and re-
+    // applying via `Object.defineProperty(...{value, configurable})`
+    // would silently flip the property to non-writable and non-
+    // enumerable, leaking that mutation into later test cases that
+    // iterate or re-patch WORKSPACE_PATHS (CodeRabbit review on PR
+    // #1124).
+    savedDataDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsData");
+    savedConfigDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsConfig");
     dataRoot = mkdtempSync(path.join(tmpdir(), "plugin-runtime-data-"));
     configRoot = mkdtempSync(path.join(tmpdir(), "plugin-runtime-config-"));
     // WORKSPACE_PATHS is a frozen const at import time, so we patch it
     // via Object.defineProperty for the lifetime of the test. The
     // alternative — refactoring `makePluginRuntime` to take roots as
     // arguments — would expose internals plugin authors don't need.
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: dataRoot, configurable: true });
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: configRoot, configurable: true });
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { ...savedDataDescriptor, value: dataRoot });
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { ...savedConfigDescriptor, value: configRoot });
   });
 
   afterEach(() => {
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { value: savedDataRoot, configurable: true });
-    Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { value: savedConfigRoot, configurable: true });
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", savedDataDescriptor);
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", savedConfigDescriptor);
     rmSync(dataRoot, { recursive: true, force: true });
     rmSync(configRoot, { recursive: true, force: true });
   });

--- a/test/plugins/test_runtime_loader_factory.ts
+++ b/test/plugins/test_runtime_loader_factory.ts
@@ -1,0 +1,143 @@
+// Tests for the factory-shape detection in `runtime-loader.ts` (#1110).
+//
+// The loader supports two plugin shapes:
+//   1. Legacy:  `export const TOOL_DEFINITION = ...; export async function fooTool(...)`
+//   2. Factory: `export default definePlugin((runtime) => ({ TOOL_DEFINITION, fooTool }))`
+//
+// Both must produce the same `RuntimePlugin` shape so the dispatch
+// route works unchanged. The factory case must call the supplied
+// `runtimeFactory` callback so the handler closes over the per-plugin
+// scoped runtime.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { loadPluginFromCacheDir } from "../../server/plugins/runtime-loader.js";
+import { makePluginRuntime } from "../../server/plugins/runtime.js";
+import type { IPubSub } from "../../server/events/pub-sub/index.js";
+
+interface FixtureOpts {
+  /** Source for `entry.js`. */
+  entryContent: string;
+}
+
+function makeFixture(opts: FixtureOpts): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "mulmo-runtime-loader-factory-"));
+  const pkg = JSON.stringify({
+    name: "@fixture/plugin",
+    version: "1.0.0",
+    type: "module",
+    exports: { ".": { import: "./entry.js" } },
+  });
+  writeFileSync(path.join(dir, "package.json"), pkg);
+  const entryPath = path.join(dir, "entry.js");
+  mkdirSync(path.dirname(entryPath), { recursive: true });
+  writeFileSync(entryPath, opts.entryContent);
+  return dir;
+}
+
+function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string; data: unknown }[] } {
+  const published: { channel: string; data: unknown }[] = [];
+  return {
+    pubsub: {
+      publish(channel, data) {
+        published.push({ channel, data });
+      },
+    },
+    published,
+  };
+}
+
+describe("loadPluginFromCacheDir — factory shape", () => {
+  it("calls the factory with the supplied runtime and exposes the named handler", async () => {
+    // The factory closes over `runtime.pubsub` and exposes a handler
+    // under TOOL_DEFINITION.name. Calling the handler from outside
+    // (as the dispatch route does) must trigger the publish.
+    const dir = makeFixture({
+      entryContent: `
+function definePlugin(setup) { return setup; }
+export default definePlugin(({ pubsub }) => ({
+  TOOL_DEFINITION: {
+    name: "fixtureTool",
+    description: "factory-shape fixture",
+    parameters: { type: "object", properties: {} },
+  },
+  async fixtureTool(args) {
+    pubsub.publish("called", args);
+    return { ok: true };
+  },
+}));
+`,
+    });
+    const { pubsub, published } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir, {
+      // Production wiring: each plugin gets a fresh scoped runtime.
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin, "expected plugin to load");
+    assert.equal(plugin.definition.name, "fixtureTool");
+    assert.ok(plugin.execute, "execute handler must be captured");
+    // Calling the handler via the dispatch-route signature `(ctx, args)`
+    // should still invoke the factory's `(args)`-only handler with the
+    // correct args (the loader wraps to discard `ctx`).
+    await plugin.execute({}, { hello: "world" });
+    // The host-side recording pubsub should see the SCOPED channel.
+    assert.deepEqual(published, [{ channel: "plugin:@fixture/plugin:called", data: { hello: "world" } }]);
+  });
+
+  it("with no runtimeFactory, factory plugins still load (definition-only path)", async () => {
+    // The MCP child loads plugins to know TOOL_DEFINITION but never
+    // invokes the handler. The stub runtime supplies enough for the
+    // factory body to evaluate; only handler invocation throws.
+    const dir = makeFixture({
+      entryContent: `
+function definePlugin(setup) { return setup; }
+export default definePlugin(({ pubsub }) => ({
+  TOOL_DEFINITION: {
+    name: "fixtureTool",
+    description: "factory-shape fixture",
+    parameters: { type: "object", properties: {} },
+  },
+  async fixtureTool() {
+    // Should never actually run when no real runtime is provided.
+    pubsub.publish("called", {});
+    return { ok: true };
+  },
+}));
+`,
+    });
+    const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+    assert.ok(plugin, "definition-only load must still produce a RuntimePlugin");
+    assert.equal(plugin.definition.name, "fixtureTool");
+    assert.ok(plugin.execute, "handler is captured even with stub runtime");
+    // The stub runtime's pubsub.publish is a silent no-op (not a throw),
+    // so calling the handler in this path does not blow up — but the
+    // event would never reach a real subscriber. The contract is that
+    // the parent server always passes a real runtimeFactory; tests of
+    // that path live above.
+  });
+
+  it("legacy shape continues to load (backward compatibility)", async () => {
+    const dir = makeFixture({
+      entryContent: `
+export const TOOL_DEFINITION = {
+  name: "fixtureTool",
+  description: "legacy-shape fixture",
+  parameters: { type: "object", properties: {} },
+};
+export async function fixtureTool(_context, args) {
+  return { ok: true, args };
+}
+`,
+    });
+    const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+    assert.ok(plugin, "legacy shape must still load");
+    assert.equal(plugin.definition.name, "fixtureTool");
+    assert.ok(plugin.execute);
+    const result = await plugin.execute({}, { x: 1 });
+    assert.deepEqual(result, { ok: true, args: { x: 1 } });
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -36,6 +36,8 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "news",
     "pluginCache",
     "plugins",
+    "pluginsConfig",
+    "pluginsData",
     "roles",
     "scheduler",
     "searches",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,7 +63,15 @@ function mulmoclaudeAuthTokenPlugin(): Plugin {
 // importmap target so runtime-loaded plugins still share the host's
 // Vue instance after `yarn build` and `npx mulmoclaude` distribution.
 function runtimeImportmapBuildPlugin(): Plugin {
-  const DEV_IMPORTMAP_TARGET = '/src/_runtime/vue.ts'
+  // Each importmap entry maps `(dev URL → chunk name)`. The dev URL is
+  // the static path the browser sees during `yarn dev`; the chunk
+  // name matches the Rollup input key registered in
+  // `build.rollupOptions.input` below. After build, the dev URL gets
+  // rewritten to the hashed asset path.
+  const ENTRIES: Array<{ devUrl: string; chunkName: string }> = [
+    { devUrl: '/src/_runtime/vue.ts', chunkName: 'runtime-vue' },
+    { devUrl: '/src/_runtime/protocol-vue.ts', chunkName: 'runtime-protocol-vue' },
+  ]
   return {
     name: 'mulmoclaude-runtime-importmap',
     apply: 'build',
@@ -71,24 +79,22 @@ function runtimeImportmapBuildPlugin(): Plugin {
       order: 'post',
       handler(html, ctx) {
         if (!ctx.bundle) return html
-        // The runtime/vue.ts entry input is registered in
-        // `build.rollupOptions.input` below; Vite emits it as a
-        // chunk whose `name` matches the input key.
-        let runtimeFile: string | null = null
-        for (const [fileName, chunk] of Object.entries(ctx.bundle)) {
-          if (chunk.type === 'chunk' && chunk.name === 'runtime-vue') {
-            runtimeFile = fileName
-            break
+        let next = html
+        for (const { devUrl, chunkName } of ENTRIES) {
+          let runtimeFile: string | null = null
+          for (const [fileName, chunk] of Object.entries(ctx.bundle)) {
+            if (chunk.type === 'chunk' && chunk.name === chunkName) {
+              runtimeFile = fileName
+              break
+            }
           }
+          if (!runtimeFile) continue
+          // `replaceAll` (not `replace`) so both occurrences get
+          // rewritten — the importmap target AND any comment that
+          // documents the dev URL.
+          next = next.replaceAll(devUrl, `/${runtimeFile}`)
         }
-        if (!runtimeFile) return html
-        // `replaceAll` (not `replace`) so both occurrences get
-        // rewritten — the importmap target AND the comment that
-        // documents where the dev URL lives. Otherwise `replace`
-        // only handles the first match (the comment, which precedes
-        // the importmap), and the actual `<script type="importmap">`
-        // body keeps the broken dev URL.
-        return html.replaceAll(DEV_IMPORTMAP_TARGET, `/${runtimeFile}`)
+        return next
       },
     },
   }
@@ -108,6 +114,10 @@ export default defineConfig({
       input: {
         index: path.resolve(__dirname, 'index.html'),
         'runtime-vue': path.resolve(__dirname, 'src/_runtime/vue.ts'),
+        // Same pattern as runtime-vue: the importmap consumer is the
+        // browser, not Vite's static analysis, so without this entry
+        // the chunk gets tree-shaken out of the build.
+        'runtime-protocol-vue': path.resolve(__dirname, 'src/_runtime/protocol-vue.ts'),
       },
       // Force every named re-export from `src/_runtime/vue.ts` to be
       // preserved in the emitted chunk. Without `'strict'`, Rolldown

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,7 +88,15 @@ function runtimeImportmapBuildPlugin(): Plugin {
               break
             }
           }
-          if (!runtimeFile) continue
+          if (!runtimeFile) {
+            // Surface explicitly so a future input rename (or a
+            // tree-shake regression on the runtime entry) doesn't
+            // silently leave the dev URL in the built importmap and
+            // break runtime-loaded plugins in production with no
+            // diagnostic. CodeRabbit review on PR #1124.
+            console.warn(`[mulmoclaude] runtime importmap chunk not emitted: ${chunkName} (importmap entry "${devUrl}" left as dev URL)`)
+            continue
+          }
           // `replaceAll` (not `replace`) so both occurrences get
           // rewritten — the importmap target AND any comment that
           // documents the dev URL.

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,130 +402,260 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz#815b39267f9bffd3407ea6c376ac32946e24f8d2"
   integrity sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==
 
+"@esbuild/aix-ppc64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz#82b74f92aa78d720b714162939fb248c90addf53"
+  integrity sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==
+
 "@esbuild/android-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz#19b882408829ad8e12b10aff2840711b2da361e8"
   integrity sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==
+
+"@esbuild/android-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz#f78cb8a3121fc205a53285adb24972db385d185d"
+  integrity sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==
 
 "@esbuild/android-arm@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.3.tgz#90be58de27915efa27b767fcbdb37a4470627d7b"
   integrity sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==
 
+"@esbuild/android-arm@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.7.tgz#593e10a1450bbfcac6cb321f61f468453bac209d"
+  integrity sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==
+
 "@esbuild/android-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.3.tgz#d7dcc976f16e01a9aaa2f9b938fbec7389f895ac"
   integrity sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==
+
+"@esbuild/android-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.7.tgz#453143d073326033d2d22caf9e48de4bae274b07"
+  integrity sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==
 
 "@esbuild/darwin-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
   integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
 
+"@esbuild/darwin-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz#6f23000fb9b40b7e04b7d0606c0693bd0632f322"
+  integrity sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==
+
 "@esbuild/darwin-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz#ac61d645faa37fd650340f1866b0812e1fb14d6a"
   integrity sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==
+
+"@esbuild/darwin-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz#27393dd18bb1263c663979c5f1576e00c2d024be"
+  integrity sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==
 
 "@esbuild/freebsd-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz#b8625689d73cf1830fe58c39051acdc12474ea1b"
   integrity sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==
 
+"@esbuild/freebsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz#22e4638fa502d1c0027077324c97640e3adf3a62"
+  integrity sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==
+
 "@esbuild/freebsd-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz#07be7dd3c9d42fe0eccd2ab9f9ded780bc53bead"
   integrity sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==
+
+"@esbuild/freebsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz#9224b8e4fea924ce2194e3efc3e9aebf822192d6"
+  integrity sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==
 
 "@esbuild/linux-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz#bf31918fe5c798586460d2b3d6c46ed2c01ca0b6"
   integrity sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==
 
+"@esbuild/linux-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz#4f5d1c27527d817b35684ae21419e57c2bda0966"
+  integrity sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==
+
 "@esbuild/linux-arm@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz#28493ee46abec1dc3f500223cd9f8d2df08f9d11"
   integrity sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==
+
+"@esbuild/linux-arm@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz#b9e9d070c8c1c0449cf12b20eac37d70a4595921"
+  integrity sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==
 
 "@esbuild/linux-ia32@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz#750752a8b30b43647402561eea764d0a41d0ee29"
   integrity sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==
 
+"@esbuild/linux-ia32@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz#3f80fb696aa96051a94047f35c85b08b21c36f9e"
+  integrity sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==
+
 "@esbuild/linux-loong64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz#a5a92813a04e71198c50f05adfaf18fc1e95b9ed"
   integrity sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==
+
+"@esbuild/linux-loong64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz#9be1f2c28210b13ebb4156221bba356fe1675205"
+  integrity sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==
 
 "@esbuild/linux-mips64el@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz#deb45d7fd2d2161eadf1fbc593637ed766d50bb1"
   integrity sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==
 
+"@esbuild/linux-mips64el@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz#4ab5ee67a3dfcbcb5e8fd7883dae6e735b1163b8"
+  integrity sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==
+
 "@esbuild/linux-ppc64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz#6f39ae0b8c4d3d2d61a65b26df79f6e12a1c3d78"
   integrity sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==
+
+"@esbuild/linux-ppc64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz#dac78c689f6499459c4321e5c15032c12307e7ea"
+  integrity sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==
 
 "@esbuild/linux-riscv64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz#4c5c19c3916612ec8e3915187030b9df0b955c1d"
   integrity sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==
 
+"@esbuild/linux-riscv64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz#050f7d3b355c3a98308e935bc4d6325da91b0027"
+  integrity sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==
+
 "@esbuild/linux-s390x@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz#9ed17b3198fa08ad5ccaa9e74f6c0aff7ad0156d"
   integrity sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==
+
+"@esbuild/linux-s390x@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz#d61f715ce61d43fe5844ad0d8f463f88cbe4fef6"
+  integrity sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==
 
 "@esbuild/linux-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz#12383dcbf71b7cf6513e58b4b08d95a710bf52a5"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
 
+"@esbuild/linux-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz#ca8e1aa478fc8209257bf3ac8f79c4dc2982f32a"
+  integrity sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==
+
 "@esbuild/netbsd-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz#dd0cb2fa543205fcd931df44f4786bfcce6df7d7"
   integrity sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==
+
+"@esbuild/netbsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz#1650f2c1b948deeb3ef948f2fc30614723c09690"
+  integrity sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==
 
 "@esbuild/netbsd-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz#028ad1807a8e03e155153b2d025b506c3787354b"
   integrity sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==
 
+"@esbuild/netbsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz#65772ab342c4b3319bf0705a211050aac1b6e320"
+  integrity sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==
+
 "@esbuild/openbsd-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz#e3c16ff3490c9b59b969fffca87f350ffc0e2af5"
   integrity sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==
+
+"@esbuild/openbsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz#37ed7cfa66549d7955852fce37d0c3de4e715ea1"
+  integrity sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==
 
 "@esbuild/openbsd-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz#c5a4693fcb03d1cbecbf8b422422468dfc0d2a8b"
   integrity sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==
 
+"@esbuild/openbsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz#01bf3d385855ef50cb33db7c4b52f957c34cd179"
+  integrity sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==
+
 "@esbuild/openharmony-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz#082082444f12db564a0775a41e1991c0e125055e"
   integrity sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==
+
+"@esbuild/openharmony-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz#6c1f94b34086599aabda4eac8f638294b9877410"
+  integrity sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==
 
 "@esbuild/sunos-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz#5ab036c53f929e8405c4e96e865a424160a1b537"
   integrity sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==
 
+"@esbuild/sunos-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz#4b0dd17ae0a6941d2d0fd35a906392517071a90d"
+  integrity sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==
+
 "@esbuild/win32-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz#38de700ef4b960a0045370c171794526e589862e"
   integrity sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==
+
+"@esbuild/win32-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz#34193ab5565d6ff68ca928ac04be75102ccb2e77"
+  integrity sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==
 
 "@esbuild/win32-ia32@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz#451b93dc03ec5d4f38619e6cd64d9f9eff06f55c"
   integrity sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==
 
+"@esbuild/win32-ia32@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz#eb67f0e4482515d8c1894ede631c327a4da9fc4d"
+  integrity sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==
+
 "@esbuild/win32-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
   integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
+
+"@esbuild/win32-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz#8fe30b3088b89b4873c3a6cc87597ae3920c0a8b"
+  integrity sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==
 
 "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -1117,6 +1247,49 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.1.0.tgz#86bba0dcecbacc84e0b480287c948c9aef36242d"
   integrity sha512-GxXK2U39+2qWNvR3fXJY7nxdikvpiT17RaS0/Dktk6R8FMKDk3vm79Hq65yrCWLBmT7pJZoerfILNZqhrcUHrg==
 
+"@microsoft/api-extractor-model@7.33.8":
+  version "7.33.8"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz#d715b0090610cce62c0b248a3eb07466cb10e9f1"
+  integrity sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==
+  dependencies:
+    "@microsoft/tsdoc" "~0.16.0"
+    "@microsoft/tsdoc-config" "~0.18.1"
+    "@rushstack/node-core-library" "5.23.1"
+
+"@microsoft/api-extractor@^7.50.1":
+  version "7.58.7"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz#15c3f03165691f298874d13c25edfdcccb420e7e"
+  integrity sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==
+  dependencies:
+    "@microsoft/api-extractor-model" "7.33.8"
+    "@microsoft/tsdoc" "~0.16.0"
+    "@microsoft/tsdoc-config" "~0.18.1"
+    "@rushstack/node-core-library" "5.23.1"
+    "@rushstack/rig-package" "0.7.3"
+    "@rushstack/terminal" "0.24.0"
+    "@rushstack/ts-command-line" "5.3.9"
+    diff "~8.0.2"
+    minimatch "10.2.3"
+    resolve "~1.22.1"
+    semver "~7.7.4"
+    source-map "~0.6.1"
+    typescript "5.9.3"
+
+"@microsoft/tsdoc-config@~0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz#7c560bce62abb5f9681e4d231b9ac35553b7e86b"
+  integrity sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==
+  dependencies:
+    "@microsoft/tsdoc" "0.16.0"
+    ajv "~8.18.0"
+    jju "~1.4.0"
+    resolve "~1.22.2"
+
+"@microsoft/tsdoc@0.16.0", "@microsoft/tsdoc@~0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz#2249090633e04063176863a050c8f0808d2b6d2b"
+  integrity sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==
+
 "@modelcontextprotocol/sdk@^1.27.1", "@modelcontextprotocol/sdk@^1.29.0":
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
@@ -1396,10 +1569,190 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz#a89b30833fb628bc834fe2e89fea93a2da9fa69a"
   integrity sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==
 
+"@rollup/pluginutils@^5.1.4":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
+  integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
+"@rollup/rollup-android-arm-eabi@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz#a19c645c375158cd5c50a344106f0fa18eb821c4"
+  integrity sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==
+
+"@rollup/rollup-android-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz#1af19aa9d3ad6d00df2681f59cfcb8bf7499576b"
+  integrity sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==
+
+"@rollup/rollup-darwin-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz#3b8463e03ba2a393453fea70e7d907379c27b649"
+  integrity sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
+
+"@rollup/rollup-darwin-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz#28da23d69fe117f5f0ff330a8549e51bd09f1b6a"
+  integrity sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
+
+"@rollup/rollup-freebsd-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz#94bacac3190f621de1355922b599f3817786044c"
+  integrity sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==
+
+"@rollup/rollup-freebsd-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz#8a0094f533b9fda160b5c90ad9e0c78fca341788"
+  integrity sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz#3b7e901a555c7245c87f7440979bee0a1ec882bb"
+  integrity sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==
+
+"@rollup/rollup-linux-arm-musleabihf@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz#ee9a09b72e8ad764cfd6188b32ff1de528ff7ebe"
+  integrity sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==
+
+"@rollup/rollup-linux-arm64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz#ba483f4aca9be141171d086dbd01ada6ab03b58d"
+  integrity sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
+
+"@rollup/rollup-linux-arm64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz#17b595b790e6df68e91c5d02526fc832a985ce4f"
+  integrity sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
+
+"@rollup/rollup-linux-loong64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz#551718714075a2bfb36a2813c466e3a0e9d56abf"
+  integrity sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==
+
+"@rollup/rollup-linux-loong64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz#ba156ed1243447a3d710972001d5dcfe3827ff3d"
+  integrity sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==
+
+"@rollup/rollup-linux-ppc64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz#6a957a709b86ac62ef68e597ac03dbd4336782b1"
+  integrity sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==
+
+"@rollup/rollup-linux-ppc64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz#ca4176b4ad53f3edee3b4bfa6f9ef48ff38f167b"
+  integrity sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==
+
+"@rollup/rollup-linux-riscv64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz#4e6b08f72ebeafdb41f3ec433bd228ba8573473b"
+  integrity sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==
+
+"@rollup/rollup-linux-riscv64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz#a0b8b8580c7680c8086cb3226527e5472253b895"
+  integrity sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==
+
+"@rollup/rollup-linux-s390x-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz#79fe15b92ce0bae2b609cf26dd158cd3e2b73634"
+  integrity sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==
+
+"@rollup/rollup-linux-x64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz#6aa8302fa45fd3cbbc510ccd223c9c37bf67e53f"
+  integrity sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
+
+"@rollup/rollup-linux-x64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz#0c1a5e9799f80c47a66f2c3a5f1a280f38356047"
+  integrity sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
+
+"@rollup/rollup-openbsd-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz#5f07c863e74fd428794f1dc5749f321b661d1f17"
+  integrity sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==
+
+"@rollup/rollup-openharmony-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz#8e0d71324be0f423428b12b25a2eb8ea8e0a7833"
+  integrity sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==
+
+"@rollup/rollup-win32-arm64-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz#a553fdf90a785ace6d7501eed6241c468b088999"
+  integrity sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz#0fb04f0a88027fbfd323e25a446debce4773868c"
+  integrity sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==
+
+"@rollup/rollup-win32-x64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz#aaa9e36dbdc0f0e397e5966dcce1b4285354ede2"
+  integrity sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==
+
+"@rollup/rollup-win32-x64-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz#3418dcf1388f2abd6b0ccc08fe1ef205ae76d696"
+  integrity sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
+
+"@rushstack/node-core-library@5.23.1":
+  version "5.23.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz#2413f1b52811cf5371812474a7006a7a8c4c4eb6"
+  integrity sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==
+  dependencies:
+    ajv "~8.18.0"
+    ajv-draft-04 "~1.0.0"
+    ajv-formats "~3.0.1"
+    fs-extra "~11.3.0"
+    import-lazy "~4.0.0"
+    jju "~1.4.0"
+    resolve "~1.22.1"
+    semver "~7.7.4"
+
+"@rushstack/problem-matcher@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz#e9f6cac2dd6a882d60e76a8d4462b7d24b4f17e5"
+  integrity sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==
+
+"@rushstack/rig-package@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.7.3.tgz#d28a5440b1e9f43046727ba7009d18d99314f251"
+  integrity sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==
+  dependencies:
+    jju "~1.4.0"
+    resolve "~1.22.1"
+
+"@rushstack/terminal@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.24.0.tgz#7abb763ea58fdeece93a3054b2c59025d56f7203"
+  integrity sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==
+  dependencies:
+    "@rushstack/node-core-library" "5.23.1"
+    "@rushstack/problem-matcher" "0.2.1"
+    supports-color "~8.1.1"
+
+"@rushstack/ts-command-line@5.3.9":
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz#781ddfce9ce652b6c7e0de53af06ffc7671bd506"
+  integrity sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==
+  dependencies:
+    "@rushstack/terminal" "0.24.0"
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    string-argv "~0.3.1"
 
 "@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
   version "1.5.5"
@@ -1656,6 +2009,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
+
 "@types/body-parser@*":
   version "1.19.6"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
@@ -1697,7 +2055,7 @@
   resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
   integrity sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
 
-"@types/estree@^1.0.6", "@types/estree@^1.0.8":
+"@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -1975,6 +2333,11 @@
     https-proxy-agent "^7.0.0"
     tslib "^2.6.2"
 
+"@vitejs/plugin-vue@^5.0.0":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz#9e8a512eb174bfc2a333ba959bbf9de428d89ad8"
+  integrity sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==
+
 "@vitejs/plugin-vue@^6.0.6":
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz#4d8a3a7941382cf2760ac5593364bea6856ae7b2"
@@ -1987,7 +2350,7 @@
   resolved "https://registry.yarnpkg.com/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz#5d6db8b20e2a3d729834e7cda429d1b6723ff91b"
   integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
-"@volar/language-core@2.4.28":
+"@volar/language-core@2.4.28", "@volar/language-core@~2.4.11":
   version "2.4.28"
   resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.28.tgz#c21f365a91c1dffe8bd7264fd491770c8d74fef3"
   integrity sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==
@@ -1999,7 +2362,7 @@
   resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.28.tgz#b40254e8c96199e5f1e0796777c593c617ad270e"
   integrity sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==
 
-"@volar/typescript@2.4.28":
+"@volar/typescript@2.4.28", "@volar/typescript@^2.4.11":
   version "2.4.28"
   resolved "https://registry.yarnpkg.com/@volar/typescript/-/typescript-2.4.28.tgz#83f86356e84eb101b8081a44c104f2f2ced8411f"
   integrity sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==
@@ -2061,6 +2424,14 @@
     "@vue/compiler-dom" "3.5.33"
     "@vue/shared" "3.5.33"
 
+"@vue/compiler-vue2@^2.7.16":
+  version "2.7.16"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz#2ba837cbd3f1b33c2bc865fbe1a3b53fb611e249"
+  integrity sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.2.0"
+
 "@vue/devtools-api@^6.5.0":
   version "6.6.4"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
@@ -2087,6 +2458,20 @@
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz#daaa16243d2f5eaa50f7e34902d2bb9e98235b52"
   integrity sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==
+
+"@vue/language-core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-2.2.0.tgz#e48c54584f889f78b120ce10a050dfb316c7fcdf"
+  integrity sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==
+  dependencies:
+    "@volar/language-core" "~2.4.11"
+    "@vue/compiler-dom" "^3.5.0"
+    "@vue/compiler-vue2" "^2.7.16"
+    "@vue/shared" "^3.5.0"
+    alien-signals "^0.4.9"
+    minimatch "^9.0.3"
+    muggle-string "^0.4.1"
+    path-browserify "^1.0.1"
 
 "@vue/language-core@3.2.7":
   version "3.2.7"
@@ -2451,7 +2836,12 @@ agentkeepalive@^4.2.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv-formats@^3.0.1:
+ajv-draft-04@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
+  integrity sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==
+
+ajv-formats@^3.0.1, ajv-formats@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
   integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
@@ -2468,7 +2858,7 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.17.1, ajv@~8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2477,6 +2867,11 @@ ajv@^8.0.0, ajv@^8.17.1:
     fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
+
+alien-signals@^0.4.9:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-0.4.14.tgz#9ff8f72a272300a51692f54bd9bbbada78fbf539"
+  integrity sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==
 
 alien-signals@^3.1.2:
   version "3.1.2"
@@ -2541,7 +2936,7 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-argparse@~1.0.3:
+argparse@~1.0.3, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -2931,7 +3326,7 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.5:
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
   integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
@@ -3153,6 +3548,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 compress-commons@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-6.0.2.tgz#26d31251a66b9d6ba23a84064ecd3a6a71d2609e"
@@ -3368,6 +3768,11 @@ dayjs@^1.11.13:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
   integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
+
 debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@~4.4.1:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
@@ -3476,6 +3881,11 @@ diff@*, diff@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-9.0.0.tgz#297c31cd7c280f13dfe335791ec2063bd4a73a6f"
   integrity sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==
+
+diff@~8.0.2:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
 
 dingbat-to-unicode@^1.0.1:
   version "1.0.1"
@@ -3849,6 +4259,38 @@ esbuild@0.27.3, esbuild@~0.27.0:
     "@esbuild/win32-arm64" "0.27.3"
     "@esbuild/win32-ia32" "0.27.3"
     "@esbuild/win32-x64" "0.27.3"
+
+esbuild@^0.27.0:
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.7.tgz#bcadce22b2f3fd76f257e3a64f83a64986fea11f"
+  integrity sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.27.7"
+    "@esbuild/android-arm" "0.27.7"
+    "@esbuild/android-arm64" "0.27.7"
+    "@esbuild/android-x64" "0.27.7"
+    "@esbuild/darwin-arm64" "0.27.7"
+    "@esbuild/darwin-x64" "0.27.7"
+    "@esbuild/freebsd-arm64" "0.27.7"
+    "@esbuild/freebsd-x64" "0.27.7"
+    "@esbuild/linux-arm" "0.27.7"
+    "@esbuild/linux-arm64" "0.27.7"
+    "@esbuild/linux-ia32" "0.27.7"
+    "@esbuild/linux-loong64" "0.27.7"
+    "@esbuild/linux-mips64el" "0.27.7"
+    "@esbuild/linux-ppc64" "0.27.7"
+    "@esbuild/linux-riscv64" "0.27.7"
+    "@esbuild/linux-s390x" "0.27.7"
+    "@esbuild/linux-x64" "0.27.7"
+    "@esbuild/netbsd-arm64" "0.27.7"
+    "@esbuild/netbsd-x64" "0.27.7"
+    "@esbuild/openbsd-arm64" "0.27.7"
+    "@esbuild/openbsd-x64" "0.27.7"
+    "@esbuild/openharmony-arm64" "0.27.7"
+    "@esbuild/sunos-x64" "0.27.7"
+    "@esbuild/win32-arm64" "0.27.7"
+    "@esbuild/win32-ia32" "0.27.7"
+    "@esbuild/win32-x64" "0.27.7"
 
 escalade@^3.1.1:
   version "3.2.0"
@@ -4479,7 +4921,7 @@ fresh@^2.0.0:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
-fs-extra@^11.2.0:
+fs-extra@^11.2.0, fs-extra@~11.3.0:
   version "11.3.4"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.4.tgz#ab6934eca8bcf6f7f6b82742e33591f86301d6fc"
   integrity sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==
@@ -4736,10 +5178,10 @@ groq-sdk@^0.30.0:
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"
 
-gui-chat-protocol@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.2.0.tgz#acd54ecb4d4943f528d1d6920122a7327ee98b45"
-  integrity sha512-w0CPpZMXTtYoJsX7nMBy+3fI6Qil1lLgiVwciGpNRPthuWwG+X5xACOPxrb4hR27VGmF4dQyXNK1HlM2Z35tSA==
+gui-chat-protocol@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.3.0.tgz#06825160b3d1f23250f8d303912cb85f87694f1f"
+  integrity sha512-aaDTsiQH/AYMUMlBXiqHmL9q1I8R9FXIB3k9+0DHWKa0BsyxblZpi3Cxrfd5c+LucbiYAjfCjsDoRoIYZQu/kg==
 
 gui-chat-protocol@^0.1.0:
   version "0.1.0"
@@ -4789,7 +5231,7 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-he@1.2.0:
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -4950,6 +5392,11 @@ import-fresh@^3.2.1, import-fresh@^3.3.0:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-lazy@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -5318,6 +5765,11 @@ jiti@^2.6.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
 
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
 jose@^6.1.3:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.2.tgz#d6b5279b89b3e88d531c202e3fbe351f39a44aac"
@@ -5538,6 +5990,11 @@ koa-compose@^4.1.0:
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
   integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
 
+kolorist@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
+  integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
+
 lazystream@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"
@@ -5689,7 +6146,7 @@ linkify-it@5.0.0:
   dependencies:
     uc.micro "^2.0.0"
 
-local-pkg@^1.1.2:
+local-pkg@^1.0.0, local-pkg@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.2.tgz#c03d208787126445303f8161619dc701afa4abb5"
   integrity sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==
@@ -5826,7 +6283,7 @@ magic-string-ast@^1.0.2:
   dependencies:
     magic-string "^0.30.19"
 
-magic-string@^0.30.19, magic-string@^0.30.21:
+magic-string@^0.30.17, magic-string@^0.30.19, magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -6009,6 +6466,13 @@ miniflare@4.20260424.0:
     ws "8.18.0"
     youch "4.1.0-beta.10"
 
+minimatch@10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.3.tgz#c0ef582f21071b0123a5bbf275252ebda921fbf6"
+  integrity sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==
+  dependencies:
+    brace-expansion "^5.0.2"
+
 minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
@@ -6030,7 +6494,7 @@ minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4:
+minimatch@^9.0.3, minimatch@^9.0.4:
   version "9.0.9"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
   integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
@@ -6659,7 +7123,7 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.3, picomatch@^4.0.4:
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -6752,6 +7216,15 @@ postcss@^8.5.10:
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
   integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.6:
+  version "8.5.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.13.tgz#6cfaf647f2e7ef69850208eccd849e0d3f65d420"
+  integrity sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
@@ -7087,6 +7560,16 @@ resolve@^1.22.4:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@~1.22.1, resolve@~1.22.2:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 restore-cursor@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
@@ -7148,6 +7631,40 @@ rolldown@1.0.0-rc.17:
     "@rolldown/binding-wasm32-wasi" "1.0.0-rc.17"
     "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.17"
     "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.17"
+
+rollup@^4.43.0:
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.2.tgz#ac23fe4bd530304cef9fa61e639d7098b6762cf4"
+  integrity sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.60.2"
+    "@rollup/rollup-android-arm64" "4.60.2"
+    "@rollup/rollup-darwin-arm64" "4.60.2"
+    "@rollup/rollup-darwin-x64" "4.60.2"
+    "@rollup/rollup-freebsd-arm64" "4.60.2"
+    "@rollup/rollup-freebsd-x64" "4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.60.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.60.2"
+    "@rollup/rollup-linux-arm64-musl" "4.60.2"
+    "@rollup/rollup-linux-loong64-gnu" "4.60.2"
+    "@rollup/rollup-linux-loong64-musl" "4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu" "4.60.2"
+    "@rollup/rollup-linux-ppc64-musl" "4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.60.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.60.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.60.2"
+    "@rollup/rollup-linux-x64-gnu" "4.60.2"
+    "@rollup/rollup-linux-x64-musl" "4.60.2"
+    "@rollup/rollup-openbsd-x64" "4.60.2"
+    "@rollup/rollup-openharmony-arm64" "4.60.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.60.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.60.2"
+    "@rollup/rollup-win32-x64-gnu" "4.60.2"
+    "@rollup/rollup-win32-x64-msvc" "4.60.2"
+    fsevents "~2.3.2"
 
 router@^2.2.0:
   version "2.2.0"
@@ -7300,7 +7817,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.7.4:
+semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.7.4, semver@~7.7.4:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -7619,6 +8136,11 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+string-argv@~0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -7768,7 +8290,7 @@ subsume@^4.0.0:
     escape-string-regexp "^5.0.0"
     unique-string "^3.0.0"
 
-supports-color@8.1.1:
+supports-color@8.1.1, supports-color@~8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -8099,6 +8621,11 @@ typescript-eslint@^8.59.1:
     "@typescript-eslint/typescript-estree" "8.59.1"
     "@typescript-eslint/utils" "8.59.1"
 
+typescript@5.9.3, typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
 typescript@>=5, typescript@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
@@ -8276,6 +8803,35 @@ vary@^1, vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vite-plugin-dts@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz#51b60aaaa760d9cf5c2bb3676c69d81910d6b08c"
+  integrity sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==
+  dependencies:
+    "@microsoft/api-extractor" "^7.50.1"
+    "@rollup/pluginutils" "^5.1.4"
+    "@volar/typescript" "^2.4.11"
+    "@vue/language-core" "2.2.0"
+    compare-versions "^6.1.1"
+    debug "^4.4.0"
+    kolorist "^1.8.0"
+    local-pkg "^1.0.0"
+    magic-string "^0.30.17"
+
+vite@^7.3.1:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.2.tgz#cb041794d4c1395e28baea98198fd6e8f4b96b5c"
+  integrity sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==
+  dependencies:
+    esbuild "^0.27.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^8.0.9:
   version "8.0.10"
   resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.10.tgz#fb31868526ec874101fac084172a2cdc6776319b"
@@ -8359,7 +8915,7 @@ vue-tsc@^3.2.7:
     "@volar/typescript" "2.4.28"
     "@vue/language-core" "3.2.7"
 
-vue@^3.5.33:
+vue@^3.5.27, vue@^3.5.33:
   version "3.5.33"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.33.tgz#2ee5425af8ab84e255054f1f34306e370f85ea19"
   integrity sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==
@@ -8755,7 +9311,7 @@ zod-to-json-schema@^3.25.1:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
   integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
 
-zod@^3.23.8, zod@^3.24.1:
+zod@^3.23.0, zod@^3.23.8, zod@^3.24.1:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Summary

Closes #1110. Adds the host-side platform surface (server + frontend) that lets runtime-loaded plugins receive a per-plugin scoped runtime via the factory pattern from `gui-chat-protocol@0.3.0` (PR receptron/gui-chat-protocol#10, merged + published).

Plugin authors now write factory-shape plugins:

```ts
export default definePlugin(({ pubsub, files, log, fetch, notify }) => ({
  TOOL_DEFINITION: { type: "function" as const, name: "myTool" as const, ... },
  async myTool(args: unknown) {
    await files.data.write("state.json", JSON.stringify(args));
    pubsub.publish("changed", {});
    return { ok: true };
  },
}));
```

…and Vue components:

```vue
<script setup lang="ts">
import { useRuntime } from "gui-chat-protocol/vue";
const { pubsub, openUrl, dispatch } = useRuntime();
</script>
```

No `context.X` threading per call, no URL or bearer-token plumbing for HTTP dispatch, no `node:fs` access at all (lint-enforced via `gui-chat-protocol/eslint-preset`).

This PR depends on `gui-chat-protocol@0.3.0` — already published to npm. PR #1123 is the standalone dep bump; this PR includes the same bump in `package.json` + `packages/mulmoclaude/package.json` so it can land independently.

## Items to Confirm / Review

- **Plugin loading moved into `startRuntimeServices`** so factory-shape plugins can receive a runtime that closes over the live pubsub instance. The MCP child still calls `loadRuntimePlugins()` without `runtimeFactory` (gets the stub runtime — TOOL_DEFINITION-only path is fine; child never invokes the handler, dispatches HTTP to parent).
- **Path normalization contract** (`server/plugins/runtime.ts:normalizePluginPath`): `\\` → `/` repair + `path.posix.normalize` + `ensureInsideBase` against the plugin's scope root. Plugin authors who misuse `node:path` on Windows still work; `"../../etc/passwd"` is rejected. Documented as a permanent contract in `docs/plugin-runtime.md` "Path conventions".
- **Importmap chain**: `src/_runtime/protocol-vue.ts` re-exports `gui-chat-protocol/vue`; `index.html` adds the importmap entry; `vite.config.ts` registers `runtime-protocol-vue` as a Rollup input + extends `runtimeImportmapBuildPlugin` to rewrite both the dev and the hashed-asset entries. Confirms host + plugin share one `PLUGIN_RUNTIME_KEY` Symbol so `useRuntime()` inject connects.
- **Frontend `<PluginScopedRoot>` wrapping**: `src/tools/runtimeLoader.ts:wrapWithScopedRoot` `markRaw`-wraps each plugin's `viewComponent` + `previewComponent` in the scope provider before storing in the reactive registry. Without `markRaw`, Vue warned about reactive components.
- **`dispatch` adds bearer auth automatically**: the browser-side `runtime.dispatch(args)` uses host's `apiPost` so plugins never see the URL or the token. Cleaner than plugins importing host internals.
- **Backward compat**: existing `@gui-chat-plugin/*` packages (legacy `(context, args)` shape, raw module exports) continue to work without modification. Loader detects which shape via `typeof mod.default === \"function\"`.
- **Bookmarks reference plugin** (`packages/bookmarks-plugin/`) — workspace-only sample (~180 LOC). Demonstrates every API on a deliberately tiny surface. NOT published to npm in this PR; extraction to its own repo is a follow-up.
- **Conflict resolution with #1116**: main's `staticToolNames` improvement (use `MCP_PLUGIN_NAMES + mcpTools.filter(isMcpToolEnabled)` for the collision floor) was preserved in the new (relocated) plugin-loading block.

## Smoke confirmation (manual, dev)

End-to-end verified manually with `yarn dev`:

- Bookmarks plugin tarball → `~/mulmoclaude/plugins/`, ledger updated → restart yarn dev
- Boot log: `extracted name=@mulmoclaude/bookmarks-plugin version=0.1.0` + `loaded requested=3 succeeded=3` + `registered=3 collisions=0`
- Chat: \"https://example.com を Example で保存して\" → tool call succeeds
- Canvas renders Bookmarks View (uses `useRuntime().dispatch` to refetch, `pubsub.subscribe(\"changed\")` for live updates)
- Multi-tab: removing a bookmark in tab A updates tab B via pubsub
- Files land at `~/mulmoclaude/data/plugins/%40mulmoclaude%2Fbookmarks-plugin/bookmarks.json` (data root)
- Sort prefs at `~/mulmoclaude/config/plugins/%40mulmoclaude%2Fbookmarks-plugin/prefs.json` (config root)

## Tests

- `test/plugins/test_plugin_runtime.ts` (16 tests) — path normalization, scoped pubsub, files.data vs files.config separation, traversal rejection, Windows backslash repair
- `test/plugins/test_runtime_loader_factory.ts` (3 tests) — factory shape detection, handler wrapping, legacy backward compat
- `test/plugins/test_bookmarks_integration.ts` (2 tests) — end-to-end through the real loader: add → list → remove → publish chain, setSort writes to config not data

`yarn typecheck / lint / build / test` all clean. **4009 / 4009 tests pass.**

## Documentation

`docs/plugin-runtime.md` — replaced the legacy weather-only walkthrough with the factory-shape reference. New sections:

- API reference for `PluginRuntime` + `BrowserPluginRuntime`
- Path conventions contract (POSIX-relative + internal normalization)
- ESLint preset usage
- Action discriminator pattern with Zod recipe
- The `<script setup>` ref-unwrap gotcha (`{{ t.title }}` not `{{ t.value.title }}` — caught during smoke)

## Out of scope

- Bookmarks plugin extraction to its own npm-published repo — follow-up
- Accounting plugin migration to factory shape (#1078 → 5-PR series per #1110 migration plan) — separate
- Process isolation for untrusted plugin authors — separate issue per #1110 safety model
- Per-event Zod schema validate-on-publish, publish rate limit — orthogonal future additions

## Test plan

- [x] `yarn format / lint / typecheck / build / test` clean
- [x] Manual smoke: factory plugin loads + dispatches + multi-tab live sync
- [x] Manual smoke: legacy plugin (e.g. `@gui-chat-plugin/weather`) still loads + works
- [x] Files separation verified on disk (`~/mulmoclaude/{data,config}/plugins/...`)
- [ ] CI green on this PR

## Related

- Closes #1110
- Depends on receptron/gui-chat-protocol#10 (merged, v0.3.0 published)
- See also #1123 (standalone dep bump — same `package.json` change as in this PR)
- Builds on #1077 (runtime plugin install system)
- Integrates #1116 (collision-set fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added plugin runtime platform with scoped APIs (pubsub, files, logging, fetch, notifications).
  * Added bookmarks plugin reference implementation with Vue components and i18n support.
  * Added browser-side plugin runtime with locale support.

* **Documentation**
  * Added comprehensive "How to write a plugin" guide.
  * Added runtime extensions feature plan document.

* **Tests**
  * Added plugin runtime, loader factory detection, and bookmarks integration test suites.

* **Configuration**
  * Updated ESLint, Vite, and workspace path configurations for plugin support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->