### PR TITLE
fix(bookmarks-plugin): mutex + exports conditions (#1124 follow-up)

### DIFF
--- a/packages/bookmarks-plugin/package.json
+++ b/packages/bookmarks-plugin/package.json
@@ -7,11 +7,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./vue": {
       "types": "./dist/vue.d.ts",
-      "import": "./dist/vue.js"
+      "import": "./dist/vue.js",
+      "require": "./dist/vue.js",
+      "default": "./dist/vue.js"
     }
   },
   "files": [

--- a/packages/bookmarks-plugin/src/index.ts
+++ b/packages/bookmarks-plugin/src/index.ts
@@ -43,6 +43,23 @@ const Args = z.discriminatedUnion("kind", [
 const DEFAULT_PREFS: Prefs = { sortBy: "addedAt", hidden: [] };
 
 export default definePlugin(({ pubsub, files, log }) => {
+  // Two `add` calls (or `add` + `remove`) hitting in parallel both
+  // read the same `bookmarks.json` snapshot and the later writer wins
+  // — silently dropping the earlier change. Serialise read-modify-
+  // write through a per-plugin promise chain so the file mutations
+  // happen one at a time. Plain `Promise.resolve()` chain — no need
+  // for a real mutex library since this runs in a single Node
+  // process. CodeRabbit review on PR #1124.
+  let writeLock: Promise<unknown> = Promise.resolve();
+  function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = writeLock.catch(() => undefined).then(fn);
+    // Swallow rejection on the chain head so a thrown handler doesn't
+    // poison the next caller; each caller still sees its own error
+    // because we return `next` (not the swallowed copy).
+    writeLock = next.catch(() => undefined);
+    return next;
+  }
+
   async function readAll(): Promise<Bookmark[]> {
     if (!(await files.data.exists("bookmarks.json"))) return [];
     const raw = await files.data.read("bookmarks.json");
@@ -77,36 +94,40 @@ export default definePlugin(({ pubsub, files, log }) => {
       const args = Args.parse(rawArgs);
       switch (args.kind) {
         case "add": {
-          const next: Bookmark = {
-            id: crypto.randomUUID(),
-            url: args.url,
-            title: args.title,
-            addedAt: new Date().toISOString(),
-          };
-          await writeAll([next, ...(await readAll())]);
-          // Log only the host portion of the URL — full URLs can carry
-          // private path segments, search terms, or auth tokens in the
-          // query string (CodeRabbit review on PR #1124). The id is
-          // enough to locate the bookmark on disk if needed.
-          let host = "";
-          try {
-            host = new URL(next.url).host;
-          } catch {
-            host = "<unparseable>";
-          }
-          log.info("bookmark added", { id: next.id, host });
-          return { ok: true, bookmark: next };
+          return withWriteLock(async () => {
+            const next: Bookmark = {
+              id: crypto.randomUUID(),
+              url: args.url,
+              title: args.title,
+              addedAt: new Date().toISOString(),
+            };
+            await writeAll([next, ...(await readAll())]);
+            // Log only the host portion of the URL — full URLs can carry
+            // private path segments, search terms, or auth tokens in the
+            // query string (CodeRabbit review on PR #1124). The id is
+            // enough to locate the bookmark on disk if needed.
+            let host = "";
+            try {
+              host = new URL(next.url).host;
+            } catch {
+              host = "<unparseable>";
+            }
+            log.info("bookmark added", { id: next.id, host });
+            return { ok: true, bookmark: next };
+          });
         }
         case "list": {
           const [items, prefs] = await Promise.all([readAll(), readPrefs()]);
           return { ok: true, bookmarks: sortedAndFiltered(items, prefs) };
         }
         case "remove": {
-          const items = await readAll();
-          const next = items.filter((bookmark) => bookmark.id !== args.id);
-          if (next.length === items.length) return { ok: false, error: "not_found" };
-          await writeAll(next);
-          return { ok: true };
+          return withWriteLock(async () => {
+            const items = await readAll();
+            const next = items.filter((bookmark) => bookmark.id !== args.id);
+            if (next.length === items.length) return { ok: false, error: "not_found" };
+            await writeAll(next);
+            return { ok: true };
+          });
         }
         case "setSort": {
           const prefs = await readPrefs();

--- a/test/plugins/test_bookmarks_integration.ts
+++ b/test/plugins/test_bookmarks_integration.ts
@@ -130,6 +130,32 @@ describe("Bookmarks plugin — end-to-end through the loader", () => {
     assert.deepEqual(res, { ok: false, error: "not_found" });
   });
 
+  // Regression: parallel `add` calls used to read the same snapshot
+  // and the later writer dropped the earlier change. The plugin now
+  // serialises read-modify-write through a per-process mutex —
+  // CodeRabbit review on PR #1124. Asserts: 5 concurrent `add`s land
+  // in the file, none are silently dropped.
+  it("serialises concurrent add calls — no lost updates", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin, "plugin should load");
+    const { execute } = plugin;
+    assert.ok(execute, "execute handler must be present");
+
+    const PARALLEL = 5;
+    const adds = Array.from({ length: PARALLEL }, (_, i) => execute({}, { kind: "add", url: `https://example.com/${i}`, title: `Example ${i}` }));
+    await Promise.all(adds);
+
+    const listed = (await execute({}, { kind: "list" })) as BookmarkResult;
+    assert.equal(listed.bookmarks?.length, PARALLEL, `expected ${PARALLEL} bookmarks after concurrent adds, got ${listed.bookmarks?.length}`);
+  });
+
   it("setSort writes to files.config (not files.data) and publishes prefs-changed", async (ctx) => {
     if (!existsSync(PLUGIN_DIST_INDEX)) {
       ctx.skip("dist not built");


### PR DESCRIPTION
## Summary

Two unaddressed CodeRabbit findings on #1124:

- `packages/bookmarks-plugin/src/index.ts` — concurrent `add` / `remove` lost updates because read-modify-write wasn't serialised. Per-plugin promise-chain mutex (`withWriteLock`) added; regression test asserts 5 concurrent adds all land.
- `packages/bookmarks-plugin/package.json` — `exports` map was missing the `require` / `default` conditions CLAUDE.md requires for Docker CJS mode.

## Items to Confirm / Review

- The mutex shape (plain promise chain, not a real mutex library) — fine for single-process Node and matches the "no extra deps for the sample plugin" spirit of #1110, but flag if you want a proper `Mutex`/`AsyncLock`.
- I deliberately did **not** address one CR finding: `makeScopedFetch` "centralize HTTP error handling". Reasoning is in the commit body — making the bare fetch primitive throw on `!ok` would change the contract; `makeScopedFetchJson` already enforces `ok` for the JSON variant. Push back if you want me to flip it.

## User Prompt

> 1125以外全部 (PR quality sweep follow-up: fix every actionable comment except PR #1125's, which is still open and the author owns).

## Test plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `test/plugins/test_bookmarks_integration.ts` 3/3 pass (including the new mutex regression)
- [x] Full `test/plugins/` suite 70/70 pass