### PR TITLE
chore(eslint): restrict plugin imports to the DI surface (C)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -388,5 +388,61 @@ export default [
       "vue/no-empty-component-block": "error",
     },
   },
+  // Plugin import restrictions — codify the loose-coupling pattern
+  // the recent #1141 / #1143 work established. Plugin code under
+  // `src/plugins/<name>/` must reach the host only through the
+  // documented DI surface (`../api`, META types, scope wrapper); it
+  // must NEVER import host-internal config, tool registry, or
+  // server modules directly.
+  //
+  // Scope: plugin directories only. Top-level infra under
+  // `src/plugins/{api,scope,metas,index,server,_extras,
+  // server-bindings-types,meta-types}.ts` and the codegen output
+  // (`_generated/`) are deliberately excluded — they ARE the host's
+  // plugin infrastructure and need to import host config.
+  //
+  // Phase 1 (this rule): block what's already clean inside plugin
+  // directories — `src/config/*`, `src/tools/*` (value imports),
+  // `server/*`. These three were violation-free as of #1143.
+  //
+  // Phase 2 (deferred — separate cleanup PR): tighten by also
+  // blocking `src/components/*` once the 4 cross-plugin component
+  // imports today (textResponse → SentAttachmentChip, manageSource
+  // → SourcesManager, wiki → PageChatComposer / FilterChip) have
+  // been hoisted into a shared package or moved into the consuming
+  // plugin's directory. Locking the door before the cleanup would
+  // force the rule's violations into a single PR.
+  {
+    files: ["src/plugins/*/**/*.ts", "src/plugins/*/**/*.vue"],
+    ignores: [
+      // The codegen output ships with the bundle but isn't really
+      // plugin code — it composes host registries. Excluded.
+      "src/plugins/_generated/**",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/src/config/*", "../config/*", "../../config/*", "../../../config/*"],
+              message:
+                "Plugin code must not import from `src/config/*`. Use `pluginEndpoints(scope)`, `pluginBuiltinRoleIds()`, or `pluginPageRoute(name)` from `../api` instead — the host wires those at boot via `installHostContext`.",
+            },
+            {
+              group: ["**/src/tools/*", "../../tools/*", "../../../tools/*"],
+              message: "Plugin code must not import value bindings from the host tool registry (`src/tools/*`). Type imports are allowed (`PluginRegistration`, `ToolPlugin`).",
+              allowTypeImports: true,
+            },
+            {
+              group: ["**/server/*", "../../../server/*", "../../../../server/*"],
+              message: "Plugin code must not import server-side modules. Plugin executors run client-side; server-side helpers cross the protocol boundary.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -423,19 +423,27 @@ export default [
       "no-restricted-imports": [
         "error",
         {
+          // Patterns are picomatch globs evaluated against the
+          // import specifier as written. `**/config/**` catches
+          // `../config/foo`, `../../config/foo`, `../../../config/sub/bar`
+          // — depth-agnostic so a plugin file at any nesting level
+          // can't bypass the rule with extra `../` segments (Codex
+          // iter-1 #1144). The leading `**` covers every relative
+          // depth; the trailing `**` covers nested subpaths under
+          // each guarded host directory.
           patterns: [
             {
-              group: ["**/src/config/*", "../config/*", "../../config/*", "../../../config/*"],
+              group: ["**/config/**"],
               message:
                 "Plugin code must not import from `src/config/*`. Use `pluginEndpoints(scope)`, `pluginBuiltinRoleIds()`, or `pluginPageRoute(name)` from `../api` instead — the host wires those at boot via `installHostContext`.",
             },
             {
-              group: ["**/src/tools/*", "../../tools/*", "../../../tools/*"],
+              group: ["**/tools/**"],
               message: "Plugin code must not import value bindings from the host tool registry (`src/tools/*`). Type imports are allowed (`PluginRegistration`, `ToolPlugin`).",
               allowTypeImports: true,
             },
             {
-              group: ["**/server/*", "../../../server/*", "../../../../server/*"],
+              group: ["**/server/**"],
               message: "Plugin code must not import server-side modules. Plugin executors run client-side; server-side helpers cross the protocol boundary.",
               allowTypeImports: true,
             },


### PR DESCRIPTION
## Summary

- Add `no-restricted-imports` config to `src/plugins/*/**/*.{ts,vue}` so plugin code can't reach into host config / tool registry / server modules. Codifies the loose-coupling pattern that #1141 + #1143 established.
- Phase 1 only — blocks what's already clean. Phase 2 (extending to `src/components/*`) needs a separate cleanup of 4 cross-plugin component imports first.

## Items to confirm / review

- [ ] Scope correct: rule applies under `src/plugins/<name>/` directories only, not the top-level infra files (`api.ts`, `scope.ts`, `_extras.ts`, etc.) or the `_generated/` codegen output.
- [ ] Deferred patterns acceptable: `src/components/*` has 4 violations today (textResponse → SentAttachmentChip, manageSource → SourcesManager, wiki → PageChatComposer / FilterChip). The PR body's Phase 2 note tracks the cleanup.
- [ ] `allowTypeImports: true` for `src/tools/*` lets plugins keep importing `PluginRegistration` and `ToolPlugin` (which are protocol-level types in practice).

## User Prompt

> 後はやるべきこと、A から順に 1 つずつ PR にして進める

This is **C** in the prioritized list:
- A. Auto-discovery via codegen ✅ #1143
- C. **ESLint rule for `src/plugins/**`** ← this PR
- B. Error boundary in `<PluginScopedRoot>`
- D. Typed `useRuntime().endpoints` (gui-chat-protocol@0.4)
- G. Plugin runtime API documentation

## What this blocks (with helpful messages)

- `import "../../config/apiRoutes"` → "Use `pluginEndpoints(scope)` from `../api` instead"
- `import "../../tools/somefile"` → "Type imports allowed; value imports forbidden"
- `import "../../../server/whatever"` → "Plugin executors run client-side"

## Test plan

- [x] `yarn lint` passes on the current tree
- [x] Rule fires with the expected message when a plugin file gains an `import { API_ROUTES } from "../../config/apiRoutes"` (verified by temporary edit)
- [x] `yarn typecheck`, `yarn test`, `yarn build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration with stricter import restrictions for plugin source files, enhancing code consistency and preventing unintended module dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->