### PR TITLE
feat(plugins): per-plugin error boundary in PluginScopedRoot (B)

### DIFF
--- a/src/components/PluginScopedRoot.vue
+++ b/src/components/PluginScopedRoot.vue
@@ -18,10 +18,11 @@
 // sees a "crashed" panel with optional stack details and a Retry
 // button that re-mounts the plugin.
 
-import { computed, onErrorCaptured, provide, ref } from "vue";
+import { onErrorCaptured, provide } from "vue";
 import { useI18n } from "vue-i18n";
 import { PLUGIN_RUNTIME_KEY } from "gui-chat-protocol/vue";
 import { makeBrowserPluginRuntime } from "../utils/plugin/runtime";
+import { usePluginErrorBoundary } from "../composables/usePluginErrorBoundary";
 
 interface Props {
   /** npm package name of the plugin whose subtree we're scoping. */
@@ -50,44 +51,17 @@ provide(PLUGIN_RUNTIME_KEY, runtime);
 
 // ── Error boundary state ────────────────────────────────────────
 //
-// `error` is null while the plugin is rendering normally; populated
-// with an Error instance once `errorCaptured` fires. `mountKey`
-// drives `<slot :key>`-style remounting on Retry — bumping it
-// re-creates the inner subtree from scratch so transient bugs
-// (a stale ref, a temporarily-unreachable endpoint) clear cleanly.
-const error = ref<Error | null>(null);
-const showDetails = ref(false);
-const mountKey = ref(0);
-
-const errorDetails = computed((): string => {
-  if (!error.value) return "";
-  const message = error.value.message || String(error.value);
-  const stack = error.value.stack ?? "";
-  return stack ? `${message}\n\n${stack}` : message;
-});
-
+// State + reset logic live in `usePluginErrorBoundary` (testable
+// without a DOM). The Vue lifecycle hook `onErrorCaptured` itself
+// must be wired here — the composable can't call `setup()`-only
+// hooks. Returning `false` from the hook tells Vue we've handled
+// the error; without it, the exception propagates to the parent
+// and ultimately to the global error handler.
+const { error, showDetails, mountKey, errorDetails, captureError, retry } = usePluginErrorBoundary(props.pkgName);
 onErrorCaptured((err) => {
-  // Coerce the unknown to Error so `.stack` access in the template
-  // stays type-safe even when a plugin throws a string.
-  const captured = err instanceof Error ? err : new Error(String(err));
-  // Surface to the dev console with a plugin-tagged prefix so the
-  // owner is obvious. Production users see the visible panel; the
-  // console line is for whoever's debugging.
-  console.error(`[plugin/${props.pkgName}] uncaught error`, captured);
-  error.value = captured;
-  // Returning false prevents Vue from re-throwing up to the
-  // enclosing component / global handler. We've handled it here.
+  captureError(err);
   return false;
 });
-
-function retry(): void {
-  error.value = null;
-  showDetails.value = false;
-  // `key` change → Vue treats the slotted subtree as a brand-new
-  // component. Setup runs again; whatever transient state caused
-  // the crash is gone.
-  mountKey.value += 1;
-}
 </script>
 
 <template>

--- a/src/components/PluginScopedRoot.vue
+++ b/src/components/PluginScopedRoot.vue
@@ -8,8 +8,18 @@
 // the host's runtime plugin loader (the place that dynamically
 // imports the plugin's `dist/vue.js` and instantiates its
 // `viewComponent` / `previewComponent`).
+//
+// Doubles as the per-plugin error boundary: a Vue `errorCaptured`
+// hook catches uncaught errors thrown during the plugin subtree's
+// render / setup / lifecycle and renders a fallback panel instead
+// of letting the exception break out and unmount the whole chat
+// canvas. One bad plugin should fail in place, not take the host
+// with it. The captured error is logged to the console; the user
+// sees a "crashed" panel with optional stack details and a Retry
+// button that re-mounts the plugin.
 
-import { provide } from "vue";
+import { computed, onErrorCaptured, provide, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { PLUGIN_RUNTIME_KEY } from "gui-chat-protocol/vue";
 import { makeBrowserPluginRuntime } from "../utils/plugin/runtime";
 
@@ -29,14 +39,75 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const { t } = useI18n();
+
 // Construct once — `pkgName` and `endpoints` are fixed for the
 // lifetime of a mounted plugin. If the host needs to rotate the
 // scope (rare), it should remount the entire wrapper rather than
 // mutate either prop.
 const runtime = makeBrowserPluginRuntime({ pkgName: props.pkgName, endpoints: props.endpoints });
 provide(PLUGIN_RUNTIME_KEY, runtime);
+
+// ── Error boundary state ────────────────────────────────────────
+//
+// `error` is null while the plugin is rendering normally; populated
+// with an Error instance once `errorCaptured` fires. `mountKey`
+// drives `<slot :key>`-style remounting on Retry — bumping it
+// re-creates the inner subtree from scratch so transient bugs
+// (a stale ref, a temporarily-unreachable endpoint) clear cleanly.
+const error = ref<Error | null>(null);
+const showDetails = ref(false);
+const mountKey = ref(0);
+
+const errorDetails = computed((): string => {
+  if (!error.value) return "";
+  const message = error.value.message || String(error.value);
+  const stack = error.value.stack ?? "";
+  return stack ? `${message}\n\n${stack}` : message;
+});
+
+onErrorCaptured((err) => {
+  // Coerce the unknown to Error so `.stack` access in the template
+  // stays type-safe even when a plugin throws a string.
+  const captured = err instanceof Error ? err : new Error(String(err));
+  // Surface to the dev console with a plugin-tagged prefix so the
+  // owner is obvious. Production users see the visible panel; the
+  // console line is for whoever's debugging.
+  console.error(`[plugin/${props.pkgName}] uncaught error`, captured);
+  error.value = captured;
+  // Returning false prevents Vue from re-throwing up to the
+  // enclosing component / global handler. We've handled it here.
+  return false;
+});
+
+function retry(): void {
+  error.value = null;
+  showDetails.value = false;
+  // `key` change → Vue treats the slotted subtree as a brand-new
+  // component. Setup runs again; whatever transient state caused
+  // the crash is gone.
+  mountKey.value += 1;
+}
 </script>
 
 <template>
-  <slot />
+  <div v-if="error" class="rounded border border-red-200 bg-red-50 p-3 text-sm" data-testid="plugin-error-boundary" role="alert">
+    <div class="flex items-center gap-2 mb-1">
+      <span class="material-icons text-red-500" aria-hidden="true">error_outline</span>
+      <span class="font-medium text-red-800">{{ t("pluginErrorBoundary.title", { pkg: pkgName }) }}</span>
+    </div>
+    <p class="text-red-700 mb-2">{{ t("pluginErrorBoundary.subtitle") }}</p>
+    <div class="flex items-center gap-3">
+      <button type="button" class="text-xs text-red-600 hover:underline" data-testid="plugin-error-toggle-details" @click="showDetails = !showDetails">
+        {{ showDetails ? t("pluginErrorBoundary.hideDetails") : t("pluginErrorBoundary.showDetails") }}
+      </button>
+      <button type="button" class="text-xs text-red-600 hover:underline" data-testid="plugin-error-retry" @click="retry">
+        {{ t("pluginErrorBoundary.retry") }}
+      </button>
+    </div>
+    <pre v-if="showDetails" class="mt-2 text-xs text-red-900 bg-red-100 p-2 rounded overflow-auto max-h-40 whitespace-pre-wrap break-words">{{
+      errorDetails
+    }}</pre>
+  </div>
+  <slot v-else :key="mountKey" />
 </template>

--- a/src/composables/usePluginErrorBoundary.ts
+++ b/src/composables/usePluginErrorBoundary.ts
@@ -1,0 +1,68 @@
+// State and reset logic for the plugin error boundary mounted in
+// `<PluginScopedRoot>`. Extracted from the SFC so the behaviour
+// (error capture, details toggle, retry-remount key bump, error
+// detail composition) can be unit-tested without a DOM — Codex
+// review iter-1 #1147 flagged the absence of automated coverage
+// for the boundary's wiring.
+//
+// The host component still owns `onErrorCaptured` registration —
+// that hook must be called inside `setup()` and is not portable —
+// but every observable side-effect of "an error was captured" lives
+// here and is fully testable in isolation.
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+
+export interface PluginErrorBoundary {
+  /** Captured error object, or `null` while the plugin renders
+   *  normally. The host SFC reads this to switch to the fallback
+   *  panel. */
+  readonly error: Readonly<Ref<Error | null>>;
+  /** Toggle for the "Show details" / "Hide details" disclosure. */
+  readonly showDetails: Ref<boolean>;
+  /** Bumped on every Retry. The SFC binds it as `<slot :key>` so
+   *  Vue treats the slotted subtree as a brand-new component on
+   *  each retry — transient bugs (stale refs, momentary endpoint
+   *  outages) clear without a full page reload. */
+  readonly mountKey: Readonly<Ref<number>>;
+  /** Composed `<message>\n\n<stack>` text shown inside the
+   *  details `<pre>`. Empty string when there's no error. */
+  readonly errorDetails: ComputedRef<string>;
+  /** Forward an unknown thrown value into the boundary's error
+   *  state. Coerces non-Error throws to `new Error(String(err))`
+   *  so `.stack` access stays type-safe in the template. Logs to
+   *  the console with a `[plugin/<pkgName>]` prefix so devs can
+   *  trace which plugin owned the crash. */
+  readonly captureError: (err: unknown) => void;
+  /** Clear the error and bump `mountKey`. */
+  readonly retry: () => void;
+}
+
+/** @param pkgName plugin package name; used as the console log
+ *                 prefix so the owning plugin is obvious in dev
+ *                 tools. */
+export function usePluginErrorBoundary(pkgName: string): PluginErrorBoundary {
+  const error = ref<Error | null>(null);
+  const showDetails = ref(false);
+  const mountKey = ref(0);
+
+  const errorDetails = computed((): string => {
+    if (!error.value) return "";
+    const message = error.value.message || String(error.value);
+    const stack = error.value.stack ?? "";
+    return stack ? `${message}\n\n${stack}` : message;
+  });
+
+  function captureError(err: unknown): void {
+    const captured = err instanceof Error ? err : new Error(String(err));
+    console.error(`[plugin/${pkgName}] uncaught error`, captured);
+    error.value = captured;
+  }
+
+  function retry(): void {
+    error.value = null;
+    showDetails.value = false;
+    mountKey.value += 1;
+  }
+
+  return { error, showDetails, mountKey, errorDetails, captureError, retry };
+}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -71,6 +71,13 @@ const deMessages = {
     intraBody:
       "Die Plugins „{first}“ und „{second}“ registrieren beide {dimension} „{key}“. „{first}“ hat ihn zuerst beansprucht, daher wird die Registrierung von „{second}“ ignoriert.",
   },
+  pluginErrorBoundary: {
+    title: "Plugin {pkg} ist abgestürzt",
+    subtitle: "Das Plugin konnte nicht gerendert werden. Der Fehler wurde in der Konsole protokolliert.",
+    showDetails: "Details anzeigen",
+    hideDetails: "Details ausblenden",
+    retry: "Erneut versuchen",
+  },
   sidebarHeader: {
     home: "Zum neuesten Chat",
     toolCallHistory: "Tool-Aufrufverlauf",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -91,6 +91,13 @@ const enMessages = {
     hostBody: 'Plugin "{plugin}" tried to register the {label} key "{key}" but it is reserved by the host. The plugin\'s entry has been dropped.',
     intraBody: 'Plugins "{first}" and "{second}" both register {dimension} "{key}". "{first}" claimed it first, so "{second}"\'s registration is ignored.',
   },
+  pluginErrorBoundary: {
+    title: "Plugin {pkg} crashed",
+    subtitle: "The plugin failed to render. The error has been logged to the console.",
+    showDetails: "Show details",
+    hideDetails: "Hide details",
+    retry: "Retry",
+  },
   sidebarHeader: {
     home: "Go to latest chat",
     toolCallHistory: "Tool call history",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -75,6 +75,13 @@ const esMessages = {
     intraBody:
       'Los plugins "{first}" y "{second}" registran ambos el {dimension} "{key}". "{first}" lo reclamó primero, por lo que el registro de "{second}" se ignora.',
   },
+  pluginErrorBoundary: {
+    title: "El plugin {pkg} se ha bloqueado",
+    subtitle: "El plugin no se pudo renderizar. El error se ha registrado en la consola.",
+    showDetails: "Mostrar detalles",
+    hideDetails: "Ocultar detalles",
+    retry: "Reintentar",
+  },
   sidebarHeader: {
     home: "Ir al chat más reciente",
     toolCallHistory: "Historial de llamadas a herramientas",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -70,6 +70,13 @@ const frMessages = {
     intraBody:
       "Les plugins « {first} » et « {second} » enregistrent tous deux le {dimension} « {key} ». « {first} » l'a réclamé en premier, donc l'enregistrement de « {second} » est ignoré.",
   },
+  pluginErrorBoundary: {
+    title: "Le plugin {pkg} a planté",
+    subtitle: "Le plugin n'a pas pu être affiché. L'erreur a été consignée dans la console.",
+    showDetails: "Afficher les détails",
+    hideDetails: "Masquer les détails",
+    retry: "Réessayer",
+  },
   sidebarHeader: {
     home: "Aller à la dernière conversation",
     toolCallHistory: "Historique des appels d'outils",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -77,6 +77,13 @@ const jaMessages = {
     intraBody:
       "プラグイン「{first}」と「{second}」が同じ {dimension}「{key}」を登録しています。「{first}」が先に確保したため、「{second}」の登録は無視されます。",
   },
+  pluginErrorBoundary: {
+    title: "プラグイン {pkg} がクラッシュしました",
+    subtitle: "プラグインのレンダリングに失敗しました。エラーはコンソールに記録されています。",
+    showDetails: "詳細を表示",
+    hideDetails: "詳細を隠す",
+    retry: "再試行",
+  },
   sidebarHeader: {
     home: "最新のチャットに移動",
     toolCallHistory: "ツール呼び出し履歴",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -78,6 +78,13 @@ const koMessages = {
     intraBody:
       '플러그인 "{first}"과(와) "{second}"이(가) 동일한 {dimension} "{key}"을(를) 등록합니다. "{first}"이(가) 먼저 등록했으므로 "{second}"의 등록은 무시됩니다.',
   },
+  pluginErrorBoundary: {
+    title: "플러그인 {pkg}이(가) 충돌했습니다",
+    subtitle: "플러그인 렌더링에 실패했습니다. 오류가 콘솔에 기록되었습니다.",
+    showDetails: "세부 정보 표시",
+    hideDetails: "세부 정보 숨기기",
+    retry: "다시 시도",
+  },
   sidebarHeader: {
     home: "최신 채팅으로 이동",
     toolCallHistory: "도구 호출 기록",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -70,6 +70,13 @@ const ptBRMessages = {
     intraBody:
       'Os plugins "{first}" e "{second}" registram o mesmo {dimension} "{key}". "{first}" o reivindicou primeiro, portanto o registro de "{second}" é ignorado.',
   },
+  pluginErrorBoundary: {
+    title: "O plugin {pkg} travou",
+    subtitle: "O plugin falhou ao renderizar. O erro foi registrado no console.",
+    showDetails: "Mostrar detalhes",
+    hideDetails: "Ocultar detalhes",
+    retry: "Tentar novamente",
+  },
   sidebarHeader: {
     home: "Ir para o chat mais recente",
     toolCallHistory: "Histórico de chamadas de ferramentas",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -74,6 +74,13 @@ const zhMessages = {
     hostBody: '插件 "{plugin}" 尝试注册 {label} 键 "{key}",但该键由宿主保留。该插件条目已被丢弃。',
     intraBody: '插件 "{first}" 和 "{second}" 都注册了 {dimension} "{key}"。"{first}" 先注册,因此 "{second}" 的注册被忽略。',
   },
+  pluginErrorBoundary: {
+    title: "插件 {pkg} 已崩溃",
+    subtitle: "插件渲染失败。错误已记录到控制台。",
+    showDetails: "显示详情",
+    hideDetails: "隐藏详情",
+    retry: "重试",
+  },
   sidebarHeader: {
     home: "前往最新对话",
     toolCallHistory: "工具调用历史",

--- a/test/composables/test_usePluginErrorBoundary.ts
+++ b/test/composables/test_usePluginErrorBoundary.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { usePluginErrorBoundary } from "../../src/composables/usePluginErrorBoundary.ts";
+
+// Silence the deliberate `console.error` calls from `captureError`.
+// We assert on the boundary's state, not on the log line.
+const originalError = console.error;
+console.error = () => {};
+process.on("exit", () => {
+  console.error = originalError;
+});
+
+describe("usePluginErrorBoundary", () => {
+  it("starts clean", () => {
+    const boundary = usePluginErrorBoundary("foo");
+    assert.equal(boundary.error.value, null);
+    assert.equal(boundary.showDetails.value, false);
+    assert.equal(boundary.mountKey.value, 0);
+    assert.equal(boundary.errorDetails.value, "");
+  });
+
+  it("captureError flips error state and exposes a composed details string", () => {
+    const boundary = usePluginErrorBoundary("foo");
+    boundary.captureError(new Error("boom"));
+    assert.ok(boundary.error.value instanceof Error);
+    assert.equal(boundary.error.value?.message, "boom");
+    assert.match(boundary.errorDetails.value, /^boom/);
+  });
+
+  it("captureError coerces a non-Error throw to an Error", () => {
+    const boundary = usePluginErrorBoundary("foo");
+    boundary.captureError("string-thrown");
+    assert.ok(boundary.error.value instanceof Error);
+    assert.equal(boundary.error.value?.message, "string-thrown");
+  });
+
+  it("retry clears error, hides details, and bumps mountKey to remount the subtree", () => {
+    const boundary = usePluginErrorBoundary("foo");
+    boundary.captureError(new Error("boom"));
+    boundary.showDetails.value = true;
+    const keyBefore = boundary.mountKey.value;
+    boundary.retry();
+    assert.equal(boundary.error.value, null);
+    assert.equal(boundary.showDetails.value, false);
+    assert.equal(boundary.mountKey.value, keyBefore + 1);
+  });
+
+  it("a second error after retry re-enters the fallback (transient-bug case)", () => {
+    const boundary = usePluginErrorBoundary("foo");
+    boundary.captureError(new Error("first"));
+    assert.equal(boundary.error.value?.message, "first");
+    boundary.retry();
+    boundary.captureError(new Error("second"));
+    assert.equal(boundary.error.value?.message, "second");
+  });
+});


### PR DESCRIPTION
## Summary

- Catch uncaught errors from plugin View / Preview subtrees in PluginScopedRoot via Vue's `onErrorCaptured`. One crashing plugin no longer takes the canvas down — it falls back to an in-place panel.
- Console-tagged error log + visible fallback (title / subtitle / Show details / Retry). Retry remounts the subtree with a fresh setup.
- 5 i18n keys × 8 locales added (`pluginErrorBoundary.*`) per the lockstep rule.

## Items to confirm / review

- [ ] Coupling: error forwarding stays at console + visible UI (skipped bell forwarding deliberately — PluginScopedRoot is the most generic wrapper; pulling in `useNotifications` would tie it to a host-specific notification surface)
- [ ] Retry semantics: `mountKey` bump → fresh `setup()` / refs in the slotted subtree, mirroring how a parent v-if remount works
- [ ] i18n: `{pkg}` in `title` interpolates the npm package name; verified across the 8 locales

## User Prompt

> 後はやるべきこと、A から順に 1 つずつ PR にして進める

This is **B** in the prioritized list:
- A. Auto-discovery via codegen ✅ #1143
- C. ESLint rule for `src/plugins/**` ✅ #1144
- B. **Error boundary in `<PluginScopedRoot>`** ← this PR
- D. Typed `useRuntime().endpoints` (gui-chat-protocol@0.4)
- G. Plugin runtime API documentation

(C2 — same import-restriction pattern for `packages/*` workspaces — was added to the queue per follow-up request and will land after D / G.)

## Test plan

- [x] `yarn typecheck`, `yarn lint`, `yarn test`, `yarn build` clean
- [x] `yarn test:e2e --shard=2/2` — 190 passed
- [ ] Manual: throw inside a plugin's `setup()` → see the fallback panel; click Retry → plugin re-mounts cleanly

## How to verify locally

Add `throw new Error("boom")` to any plugin's `<script setup>` (e.g. `src/plugins/todo/View.vue`), open `/todos`, observe:
- Console: `[plugin/todos] uncaught error <Error>`
- UI: red panel "Plugin todos crashed", optional stack via Show details, Retry button
- Remove the throw → next render succeeds (or click Retry on the existing panel)