### PR TITLE
chore(eslint): restrict cross-package + host imports in packages/* (C2)

### DIFF
--- a/config/eslint.packages.mjs
+++ b/config/eslint.packages.mjs
@@ -26,38 +26,25 @@ export default [
       // into another package's `src/` or into the host's `src/` /
       // `server/`.
       //
-      // The threshold for "boundary-crossing" is at least 2 `../`
-      // segments before `src/` or `server/`. A test inside the
-      // package importing its own `../src/types` (one `../`) is
-      // legitimate same-package and stays allowed. Five levels of
-      // depth cover every realistic file location; extend if the
-      // package layout convention changes.
+      // Depth-agnostic via `regex`: the threshold for "boundary-
+      // crossing" is at least 2 `../` segments before `src/` or
+      // `server/`. A test inside the package importing its own
+      // `../src/types` (one `../`) stays allowed; anything deeper
+      // (`../../*/src/...`, `../../../src/...`, `../../../../src/...`,
+      // …) fires regardless of how nested the source file is. Earlier
+      // depth-enumerated globs left a Codex-flagged bypass at depth 6.
       "no-restricted-imports": [
         "error",
         {
           patterns: [
             {
-              group: [
-                "../../src/**",
-                "../../../src/**",
-                "../../../../src/**",
-                "../../../../../src/**",
-                "../../*/src/**",
-                "../../../*/src/**",
-                "../../../../*/src/**",
-                "../../../../../*/src/**",
-              ],
+              regex: "^(\\.\\./){2,}.*src(/|$)",
               message:
                 "Workspace packages must not deep-import another package's `src/` (or the host's `src/`). Use the package name (and its `package.json#exports`) instead — the boundary exists so each package can publish independently.",
               allowTypeImports: true,
             },
             {
-              group: [
-                "../../server/**",
-                "../../../server/**",
-                "../../../../server/**",
-                "../../../../../server/**",
-              ],
+              regex: "^(\\.\\./){2,}.*server(/|$)",
               message:
                 "Workspace packages must not import the host's `server/*` modules. Packages run as their own processes / bundles; reaching into server code couples them to the host runtime.",
               allowTypeImports: true,

--- a/config/eslint.packages.mjs
+++ b/config/eslint.packages.mjs
@@ -36,18 +36,24 @@ export default [
       "no-restricted-imports": [
         "error",
         {
+          // `allowTypeImports` deliberately omitted: a type-only
+          // `import type { ... } from "../../sibling/src/..."` still
+          // couples the package's PUBLISHED type surface to a
+          // sibling's internal source, which means publishing the
+          // package independently breaks (the consumer can't resolve
+          // the type from the package alone). Codex iter-2 #1148
+          // flagged the original `allowTypeImports: true` as a real
+          // hole in the boundary policy.
           patterns: [
             {
               regex: "^(\\.\\./){2,}.*src(/|$)",
               message:
-                "Workspace packages must not deep-import another package's `src/` (or the host's `src/`). Use the package name (and its `package.json#exports`) instead — the boundary exists so each package can publish independently.",
-              allowTypeImports: true,
+                "Workspace packages must not deep-import another package's `src/` (or the host's `src/`) — type-only imports included. Use the package name (and its `package.json#exports`) instead — the boundary exists so each package can publish independently.",
             },
             {
               regex: "^(\\.\\./){2,}.*server(/|$)",
               message:
-                "Workspace packages must not import the host's `server/*` modules. Packages run as their own processes / bundles; reaching into server code couples them to the host runtime.",
-              allowTypeImports: true,
+                "Workspace packages must not import the host's `server/*` modules — type-only imports included. Packages run as their own processes / bundles; reaching into server code couples them to the host runtime.",
             },
           ],
         },

--- a/config/eslint.packages.mjs
+++ b/config/eslint.packages.mjs
@@ -19,6 +19,52 @@ export default [
         "error",
         { argsIgnorePattern: "^__", varsIgnorePattern: "^__" },
       ],
+      // Workspace-package boundary restriction (C2 / #1141 family).
+      // Each package should be self-contained and reachable from the
+      // rest of the repo only through its declared package name
+      // (and `package.json#exports`), never via deep relative paths
+      // into another package's `src/` or into the host's `src/` /
+      // `server/`.
+      //
+      // The threshold for "boundary-crossing" is at least 2 `../`
+      // segments before `src/` or `server/`. A test inside the
+      // package importing its own `../src/types` (one `../`) is
+      // legitimate same-package and stays allowed. Five levels of
+      // depth cover every realistic file location; extend if the
+      // package layout convention changes.
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "../../src/**",
+                "../../../src/**",
+                "../../../../src/**",
+                "../../../../../src/**",
+                "../../*/src/**",
+                "../../../*/src/**",
+                "../../../../*/src/**",
+                "../../../../../*/src/**",
+              ],
+              message:
+                "Workspace packages must not deep-import another package's `src/` (or the host's `src/`). Use the package name (and its `package.json#exports`) instead — the boundary exists so each package can publish independently.",
+              allowTypeImports: true,
+            },
+            {
+              group: [
+                "../../server/**",
+                "../../../server/**",
+                "../../../../server/**",
+                "../../../../../server/**",
+              ],
+              message:
+                "Workspace packages must not import the host's `server/*` modules. Packages run as their own processes / bundles; reaching into server code couples them to the host runtime.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
     },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
## Summary

- Apply the loose-coupling pattern from #1144 (plugin code) to the `packages/*` workspaces. Each package's source must reach the host or its siblings only through its published package name, never via deep relative paths.
- Rule lives in `config/eslint.packages.mjs` (the shared base every package extends). Root-level `eslint.config.mjs` doesn't reach package files because each `packages/<pkg>/` has its own nearest config — discovered the hard way during this PR; documented in the commit so it's not re-discovered.

## Items to confirm / review

- [ ] Same-package paths stay allowed: a test file inside `packages/<pkg>/test/` can still `import { x } from "../src/types"` (single `../` doesn't cross the package boundary)
- [ ] Boundary-crossing patterns blocked: 2+ `../` before `src/` or `server/` is the threshold
- [ ] Depth covered: 5 levels deep (cover every realistic file location); the comment explains the convention if it changes
- [ ] Pre-existing test/build failures on main (todo-plugin vite, loadPresetPlugins) are unrelated to this PR — verified by stashing the change and reproducing on clean main

## User Prompt

> packagesいかもeslintの参照ルールほしいね。

Adapted from C (#1144) for the workspace packages. Same depth-agnostic philosophy adjusted for the package-boundary semantics — same-package `../src/...` (1 segment up) is fine, cross-package `../../<sib>/src/...` or host `../../../src/...` is not.

## Verification

| Injection | Result |
|---|---|
| `packages/protocol/src/index.ts` adds `import "../../chat-service/src/types"` | ✅ rule fires |
| `packages/protocol/src/index.ts` adds `import "../../../src/types/events"` | ✅ rule fires |
| `packages/protocol/src/index.ts` adds `import "../../../server/system/credentials"` | ✅ rule fires |
| `packages/relay/test/test_types.ts` keeps `import "../src/types.js"` | ✅ no error (legitimate same-package) |

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] All 3 violation cases fire with the expected message; same-package case stays clean
- [x] `yarn test` — pre-existing `loadPresetPlugins` failure documented as unrelated; reproduces on clean main
- [x] `yarn build` — pre-existing todo-plugin vite failure documented as unrelated; reproduces on clean main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code organization rules to enforce cleaner separation of concerns across the codebase, improving maintainability and reducing unintended dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->