### PR TITLE
feat(e2e-live): L-05 generateImage + L-07/08/09 roles + KEEP_SESSIONS gate

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -125,6 +125,7 @@ Stable hooks for tests / chat references when a tool result is selected on the r
 | Plugin | testid | What it points at |
 |---|---|---|
 | `presentHtml` | `[present-html-iframe]` | The `<iframe :src="/artifacts/html/...">` rendering the saved HTML page |
+| `generateImage` | `[generate-image-view]` | The wrapper around `<ImageView>` showing a generated image (`<img src="/artifacts/images/...">`) |
 | `textResponse` | `[text-response-pdf-button]` | The "PDF" button on an assistant text response (`usePdfDownload` → `/api/pdf/markdown`) |
 | `textResponse` | `[text-response-edit]` / `[text-response-edit-summary]` / `[text-response-edit-textarea]` / `[text-response-apply-btn]` | The collapsible source editor on an assistant text response |
 

--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -298,6 +298,48 @@ export async function readImgRepairAttempted(page: Page, imgSelector: string): P
   return marker !== null;
 }
 
+const GENERATE_IMAGE_VIEW_SELECTOR = '[data-testid="generate-image-view"]';
+
+/**
+ * Wait for the generateImage canvas view to render an `<img>` — i.e.
+ * the LLM called the tool, the server returned an `imageData` path,
+ * and the SPA mounted ImageView with a non-empty `resolvedSrc`. Use
+ * before reading src / naturalWidth so the spec does not race the
+ * ImageView placeholder ("No image yet").
+ */
+export async function waitForGeneratedImage(page: Page, timeoutMs: number = ONE_MINUTE_MS): Promise<void> {
+  const view = page.locator(GENERATE_IMAGE_VIEW_SELECTOR);
+  await expect(view.locator("img").first()).toBeVisible({ timeout: timeoutMs });
+}
+
+/**
+ * Read the unresolved `src` attribute of the generated image. After
+ * PR #969 / #972 introduced the `/artifacts/images/` static mount,
+ * `resolveImageSrcFresh` produces `/artifacts/images/<path>?v=<bump>`,
+ * so the caller can assert the prefix to catch regressions in the
+ * image storage / resolve chain.
+ */
+export async function readGeneratedImageSrc(page: Page): Promise<string | null> {
+  const img = page.locator(GENERATE_IMAGE_VIEW_SELECTOR).locator("img").first();
+  if ((await img.count()) === 0) return null;
+  return await img.getAttribute("src");
+}
+
+/**
+ * Read `naturalWidth` / `naturalHeight` of the generated image. Both
+ * 0 means the static mount returned a non-decodable response (404,
+ * empty file, wrong MIME) — that is the failure mode we want to
+ * detect end-to-end, paralleling the iframe-side `readImgNaturalSize`.
+ */
+export async function readGeneratedImageNaturalSize(page: Page): Promise<{ width: number; height: number } | null> {
+  const img = page.locator(GENERATE_IMAGE_VIEW_SELECTOR).locator("img").first();
+  if ((await img.count()) === 0) return null;
+  return await img.evaluate((node) => {
+    if (!(node instanceof HTMLImageElement)) return { width: 0, height: 0 };
+    return { width: node.naturalWidth, height: node.naturalHeight };
+  });
+}
+
 const PDF_MAGIC = Buffer.from("%PDF-", "ascii");
 const PDF_EOF = Buffer.from("%%EOF", "ascii");
 // PDF spec writes %%EOF in the last few hundred bytes; widen to

--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -162,8 +162,30 @@ export function getCurrentSessionId(page: Page): string | null {
  */
 const DELETE_BUTTON_TIMEOUT_MS = 10_000;
 
+// Opt-in QA hold-mode. When the runner sets E2E_LIVE_KEEP_SESSIONS=1
+// every spec leaves its session intact in history so a human can
+// inspect the residue (chat transcript, generated artifacts, plugin
+// state) after the test finishes — pair with HEADED=1 for the
+// "watch it drive, then poke at the result" flow. Cleanup falls to
+// the user (sidebar kebab → 削除) once they're done.
+//
+// We gate inside deleteSession itself so every existing spec
+// (L-01..L-14 and onwards) inherits the behaviour without any
+// per-spec retrofit — every cleanup site already routes through
+// here in a `finally { ... }` block.
+const KEEP_SESSIONS_ENV = "E2E_LIVE_KEEP_SESSIONS";
+
+function shouldKeepSessions(): boolean {
+  return process.env[KEEP_SESSIONS_ENV] === "1";
+}
+
 export async function deleteSession(page: Page, sessionId: string): Promise<void> {
   if (page.isClosed()) return;
+  if (shouldKeepSessions()) {
+    // QA-mode breadcrumb so the runner can confirm the gate fired.
+    console.log(`[${KEEP_SESSIONS_ENV}=1] keeping session ${sessionId} for inspection`);
+    return;
+  }
   try {
     // Step away from /chat/<id> first — the server's isRunning
     // guard rejects DELETE on whichever session the page is

--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -211,6 +211,18 @@ export async function sendChatMessage(page: Page, text: string): Promise<void> {
 }
 
 /**
+ * Switch the active role via the dropdown. App.vue's `onRoleChange`
+ * spins up a fresh session in the new role on chat pages, so callers
+ * are expected to capture the new session id (after the next user
+ * turn) for cleanup. Idempotent: calling with the already-active role
+ * still works because the dropdown emits `change` on every selection.
+ */
+export async function selectRole(page: Page, roleId: string): Promise<void> {
+  await page.getByTestId("role-selector-btn").click();
+  await page.getByTestId(`role-option-${roleId}`).click();
+}
+
+/**
  * Wait for an `<img>` matching the selector to appear *inside* the
  * presentHtml iframe. The iframe element itself is appended to the
  * DOM before its srcdoc finishes rendering, so a plain `iframe`

--- a/e2e-live/tests/media.spec.ts
+++ b/e2e-live/tests/media.spec.ts
@@ -9,6 +9,8 @@ import {
   deleteSession,
   getCurrentSessionId,
   placeFixtureInWorkspace,
+  readGeneratedImageNaturalSize,
+  readGeneratedImageSrc,
   readImgNaturalSize,
   readImgRepairAttempted,
   readImgSrcInPresentHtml,
@@ -18,6 +20,7 @@ import {
   sendChatMessage,
   startNewSession,
   waitForAssistantResponseComplete,
+  waitForGeneratedImage,
   waitForImgInPresentHtml,
 } from "../fixtures/live-chat.ts";
 
@@ -29,6 +32,12 @@ const L02_TIMEOUT_MS = 3 * ONE_MINUTE_MS;
 // headroom for the slowest TTS provider on a cold cache.
 const L03_TIMEOUT_MS = 10 * ONE_MINUTE_MS;
 const L03_GENERATION_TIMEOUT_MS = 8 * ONE_MINUTE_MS;
+// L-05 has to absorb the LLM picking the generateImage tool plus the
+// Gemini image-gen round trip. Cold Gemini calls land in 30–60s in
+// practice; 4 minutes leaves slack for slow networks without inviting
+// a hung run to soak up the wall clock.
+const L05_TIMEOUT_MS = 4 * ONE_MINUTE_MS;
+const L05_IMAGE_VISIBLE_TIMEOUT_MS = 3 * ONE_MINUTE_MS;
 // Floor for "the route returned a real PDF, not a stub". The actual
 // size depends on how verbose the LLM's reply happens to be that
 // run, so this is loose on purpose — `readPdfDownload` already
@@ -79,6 +88,33 @@ test.describe("media (real LLM)", () => {
       await downloadAndAssertPdf(page);
     } finally {
       await cleanupSessionAndWorkspace(page, workspaceImageRel);
+    }
+  });
+
+  test("L-05: generateImage プラグインで実画像が描画される", async ({ page }) => {
+    test.setTimeout(L05_TIMEOUT_MS);
+    // Pure Gemini-side path — no fixture seeding needed. The server's
+    // /api/image/generate-image route saves the result under
+    // ~/mulmoclaude/artifacts/images/<YYYY>/<MM>/<id>.png and
+    // returns `data.imageData` as the workspace-relative path; the
+    // SPA's resolveImageSrcFresh maps that to /artifacts/images/...
+    // via the static mount (PR #969 / #972 / #983).
+    //
+    // GEMINI_API_KEY must be configured server-side (.env or shell
+    // for `yarn dev`). Without it the route returns no imageData and
+    // ImageView stays on the placeholder, so the visibility wait
+    // fails cleanly with a meaningful timeout. We deliberately do
+    // not skip on `process.env.GEMINI_API_KEY` here because the test
+    // process lives in a different env from `yarn dev` — the dev
+    // shell loads .env via dotenv, but the spec runner does not.
+    try {
+      await startNewSession(page);
+      await sendL05Prompt(page);
+      await assertL05GeneratedImage(page);
+      await waitForAssistantResponseComplete(page);
+    } finally {
+      const sessionId = getCurrentSessionId(page);
+      if (sessionId) await deleteSession(page, sessionId);
     }
   });
 
@@ -272,6 +308,49 @@ async function generateAndDownloadMovie(page: Page): Promise<void> {
   await downloadBtn.click();
   const movie = await readMovieDownload(await downloadPromise);
   expect(movie.length, "movie should not be a near-empty stub").toBeGreaterThan(MIN_MOVIE_BYTES);
+}
+
+/**
+ * Push the LLM toward the generateImage tool (vs returning a text
+ * description). The "ツールを使ってください — 文章での描写ではなく実画像が必要です"
+ * line is what flips Claude away from offering ASCII art / verbal
+ * descriptions when the prompt is ambiguous. Subject is intentionally
+ * mundane to keep generation fast and avoid Gemini's safety triggers.
+ */
+async function sendL05Prompt(page: Page): Promise<void> {
+  const message = [
+    "猫が窓辺で日向ぼっこしているシンプルなイラストを 1 枚生成してください。",
+    "generateImage ツールを使ってください — 文章での描写ではなく実画像が必要です。",
+  ].join("\n");
+  await sendChatMessage(page, message);
+}
+
+/**
+ * End-to-end signal that generateImage worked: the SPA mounted the
+ * canvas view, the resolved src points at the static mount, and the
+ * browser actually decoded the file. `naturalWidth > 0` is the
+ * decisive bit — a 404 / wrong MIME / empty file all fail there.
+ */
+async function assertL05GeneratedImage(page: Page): Promise<void> {
+  await waitForGeneratedImage(page, L05_IMAGE_VISIBLE_TIMEOUT_MS);
+  const src = await readGeneratedImageSrc(page);
+  if (src === null) {
+    throw new Error("generateImage view should contain an <img>");
+  }
+  // resolveImageSrcFresh maps `artifacts/images/...` paths to
+  // `/artifacts/images/...?v=<bump>`, so the leading slash + prefix
+  // is the marker that the static-mount routing chain stayed intact.
+  expect(src, "image src should resolve via the artifacts/images static mount").toMatch(/^\/artifacts\/images\//);
+  // naturalWidth/Height race the decode — wait until the browser
+  // has actually loaded the bytes before asserting.
+  await expect(async () => {
+    const size = await readGeneratedImageNaturalSize(page);
+    if (size === null) {
+      throw new Error("generateImage <img> disappeared before naturalSize could be read");
+    }
+    expect(size.width, "image must actually decode").toBeGreaterThan(0);
+    expect(size.height).toBeGreaterThan(0);
+  }).toPass({ timeout: ONE_MINUTE_MS });
 }
 
 /**

--- a/e2e-live/tests/roles.spec.ts
+++ b/e2e-live/tests/roles.spec.ts
@@ -64,19 +64,28 @@ test.describe("roles (real LLM)", () => {
   });
 });
 
+const SESSION_URL_PATTERN = /\/chat\/[0-9a-f-]+/;
+
 /**
  * Shared B-41 canary for non-default roles. Switches into `roleId`
  * (App.vue's onRoleChange spins up a fresh session in that role on
  * chat pages — see useCurrentRole + createNewSession), runs one
- * tool-free turn, and asserts the session id stuck. The earlier
- * General session is intentionally orphaned without cleanup since it
- * carries no messages and {@link deleteSession} only handles the
- * final session captured in the URL.
+ * tool-free turn, and asserts the session id stuck.
+ *
+ * Cleanup deletes BOTH the auto-created General session and the
+ * role-switched session. Earlier versions only deleted the latter,
+ * which leaked one empty General session per L-07/L-08/L-09 run —
+ * harmless per-run but unbounded across CI cycles. deleteSession is
+ * best-effort + idempotent so the loop is safe even if one delete
+ * misses (e.g., sidebar race).
  */
 async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
-  let sessionIdForCleanup: string | null = null;
+  const sessionsToCleanup: string[] = [];
   try {
     await startNewSession(page);
+    await page.waitForURL(SESSION_URL_PATTERN);
+    const generalSessionId = getCurrentSessionId(page);
+    if (generalSessionId !== null) sessionsToCleanup.push(generalSessionId);
     await selectRole(page, roleId);
     // Wait for the role chip to flip to the new id before driving
     // the input — the selection is async (App.vue spins up a new
@@ -88,8 +97,16 @@ async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
     await waitForAssistantResponseComplete(page);
     const sessionId = getCurrentSessionId(page);
     expect(sessionId, `session id should be present after a successful ${roleId} turn (B-41 canary)`).not.toBeNull();
-    sessionIdForCleanup = sessionId;
+    if (sessionId !== null && sessionId !== generalSessionId) {
+      sessionsToCleanup.push(sessionId);
+    }
   } finally {
-    if (sessionIdForCleanup !== null) await deleteSession(page, sessionIdForCleanup);
+    // Delete the General placeholder first, then the role-switched
+    // session — keeps the page on a stable /chat/<id> while the
+    // first delete walks the sidebar, and lets deleteSession's own
+    // "step away from current /chat/<id>" branch handle the second.
+    for (const sid of sessionsToCleanup) {
+      await deleteSession(page, sid);
+    }
   }
 }

--- a/e2e-live/tests/roles.spec.ts
+++ b/e2e-live/tests/roles.spec.ts
@@ -1,19 +1,27 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 import { ONE_MINUTE_MS } from "../../server/utils/time.ts";
-import { deleteSession, getCurrentSessionId, sendChatMessage, startNewSession, waitForAssistantResponseComplete } from "../fixtures/live-chat.ts";
+import { deleteSession, getCurrentSessionId, selectRole, sendChatMessage, startNewSession, waitForAssistantResponseComplete } from "../fixtures/live-chat.ts";
 
-const L06_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
+const ROLE_TURN_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
+// "single word: hello" intentionally stays a no-tool-call prompt so
+// every role variant pays the same flat agent round-trip — no MCP
+// fan-out, no image gen, no spreadsheet build. The turn is purely a
+// canary for B-41 (deferred-tools switch had broken every role's
+// first-turn dispatch) and the role-selector wiring (B-15 used to
+// keep input disabled on roles that needed Gemini).
+const SINGLE_WORD_PROMPT = "Reply with the single word: hello";
 
 test.describe.configure({ mode: "parallel" });
 
 test.describe("roles (real LLM)", () => {
   test("L-06: General ロールで 1 ターン → 入力欄 enabled + 応答完走", async ({ page }) => {
-    test.setTimeout(L06_TIMEOUT_MS);
+    test.setTimeout(ROLE_TURN_TIMEOUT_MS);
     // Covers B-15 (General used to be disabled when GEMINI_API_KEY
     // was missing) and B-41 (deferred-tools switch broke role tool
-    // calls). The "single word" prompt is enough to drive a full
-    // turn without paying for TTS / image generation.
+    // calls). General is the default, so unlike L-07/08/09 we do not
+    // call selectRole — startNewSession lands us here directly and
+    // we assert that as the B-15 canary.
     let sessionIdForCleanup: string | null = null;
     try {
       await startNewSession(page);
@@ -25,7 +33,7 @@ test.describe("roles (real LLM)", () => {
       // specifically).
       await expect(page.getByTestId("role-selector-btn"), "default role must be General — B-15 canary").toHaveAttribute("data-role", "general");
       await expect(page.getByTestId("user-input"), "input must be enabled — B-15 used to disable it on this role").toBeEnabled();
-      await sendChatMessage(page, "Reply with the single word: hello");
+      await sendChatMessage(page, SINGLE_WORD_PROMPT);
       await waitForAssistantResponseComplete(page);
       // The empty-session placeholder lingers in DOM longer than the
       // thinking-indicator on chromium even after the reply lands, so
@@ -39,4 +47,49 @@ test.describe("roles (real LLM)", () => {
       if (sessionIdForCleanup !== null) await deleteSession(page, sessionIdForCleanup);
     }
   });
+
+  test("L-07: Office ロールで 1 ターン → 応答完走", async ({ page }) => {
+    test.setTimeout(ROLE_TURN_TIMEOUT_MS);
+    await runRoleSampleTurn(page, "office");
+  });
+
+  test("L-08: Tutor ロールで 1 ターン → 応答完走", async ({ page }) => {
+    test.setTimeout(ROLE_TURN_TIMEOUT_MS);
+    await runRoleSampleTurn(page, "tutor");
+  });
+
+  test("L-09: Storyteller ロールで 1 ターン → 応答完走", async ({ page }) => {
+    test.setTimeout(ROLE_TURN_TIMEOUT_MS);
+    await runRoleSampleTurn(page, "storyteller");
+  });
 });
+
+/**
+ * Shared B-41 canary for non-default roles. Switches into `roleId`
+ * (App.vue's onRoleChange spins up a fresh session in that role on
+ * chat pages — see useCurrentRole + createNewSession), runs one
+ * tool-free turn, and asserts the session id stuck. The earlier
+ * General session is intentionally orphaned without cleanup since it
+ * carries no messages and {@link deleteSession} only handles the
+ * final session captured in the URL.
+ */
+async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
+  let sessionIdForCleanup: string | null = null;
+  try {
+    await startNewSession(page);
+    await selectRole(page, roleId);
+    // Wait for the role chip to flip to the new id before driving
+    // the input — the selection is async (App.vue spins up a new
+    // session in the new role) and a too-eager send would land in
+    // the old General session.
+    await expect(page.getByTestId("role-selector-btn"), `role chip must reflect ${roleId} after switch (B-41 canary)`).toHaveAttribute("data-role", roleId);
+    await expect(page.getByTestId("user-input"), "input must be enabled on this role").toBeEnabled();
+    await sendChatMessage(page, SINGLE_WORD_PROMPT);
+    await waitForAssistantResponseComplete(page);
+    const sessionId = getCurrentSessionId(page);
+    expect(sessionId, `session id should be present after a successful ${roleId} turn (B-41 canary)`).not.toBeNull();
+    sessionIdForCleanup = sessionId;
+  } finally {
+    if (sessionIdForCleanup !== null) await deleteSession(page, sessionIdForCleanup);
+  }
+}

--- a/e2e-live/tests/roles.spec.ts
+++ b/e2e-live/tests/roles.spec.ts
@@ -85,7 +85,17 @@ async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
     await startNewSession(page);
     await page.waitForURL(SESSION_URL_PATTERN);
     const generalSessionId = getCurrentSessionId(page);
-    if (generalSessionId !== null) sessionsToCleanup.push(generalSessionId);
+    // The waitForURL above guarantees the URL matches /chat/<id>,
+    // so getCurrentSessionId's regex capture cannot fail here.
+    // Fail loud if it ever does so the diagnostic is "URL shape
+    // changed" rather than "60s navigationTimeout" coming from the
+    // ?? "" fallback below silently inverting the predicate
+    // (CodeRabbit + Claude iter-1 convergence: endsWith("") is
+    // always true, which would make the next waitForURL hang).
+    if (generalSessionId === null) {
+      throw new Error("getCurrentSessionId returned null after waitForURL(SESSION_URL_PATTERN) — startNewSession or URL pattern likely drifted");
+    }
+    sessionsToCleanup.push(generalSessionId);
     await selectRole(page, roleId);
     // Capture the role-switched session id as soon as the URL
     // settles on /chat/<id>, BEFORE the downstream assertions —
@@ -94,7 +104,7 @@ async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
     // role session into history (Codex iter 2 question-level
     // catch). waitForURL forces a real navigation rather than
     // re-reading the General id.
-    await page.waitForURL((url) => SESSION_URL_PATTERN.test(url.pathname) && !url.pathname.endsWith(generalSessionId ?? ""));
+    await page.waitForURL((url) => SESSION_URL_PATTERN.test(url.pathname) && !url.pathname.endsWith(generalSessionId));
     const roleSessionId = getCurrentSessionId(page);
     if (roleSessionId !== null && roleSessionId !== generalSessionId) {
       sessionsToCleanup.push(roleSessionId);

--- a/e2e-live/tests/roles.spec.ts
+++ b/e2e-live/tests/roles.spec.ts
@@ -87,6 +87,18 @@ async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
     const generalSessionId = getCurrentSessionId(page);
     if (generalSessionId !== null) sessionsToCleanup.push(generalSessionId);
     await selectRole(page, roleId);
+    // Capture the role-switched session id as soon as the URL
+    // settles on /chat/<id>, BEFORE the downstream assertions —
+    // otherwise an early failure (role chip mismatch, disabled
+    // input, send failure) would skip the capture and leak the
+    // role session into history (Codex iter 2 question-level
+    // catch). waitForURL forces a real navigation rather than
+    // re-reading the General id.
+    await page.waitForURL((url) => SESSION_URL_PATTERN.test(url.pathname) && !url.pathname.endsWith(generalSessionId ?? ""));
+    const roleSessionId = getCurrentSessionId(page);
+    if (roleSessionId !== null && roleSessionId !== generalSessionId) {
+      sessionsToCleanup.push(roleSessionId);
+    }
     // Wait for the role chip to flip to the new id before driving
     // the input — the selection is async (App.vue spins up a new
     // session in the new role) and a too-eager send would land in
@@ -97,9 +109,7 @@ async function runRoleSampleTurn(page: Page, roleId: string): Promise<void> {
     await waitForAssistantResponseComplete(page);
     const sessionId = getCurrentSessionId(page);
     expect(sessionId, `session id should be present after a successful ${roleId} turn (B-41 canary)`).not.toBeNull();
-    if (sessionId !== null && sessionId !== generalSessionId) {
-      sessionsToCleanup.push(sessionId);
-    }
+    expect(sessionId, "post-turn session id should match the role-switched id captured earlier").toBe(roleSessionId);
   } finally {
     // Delete the General placeholder first, then the role-switched
     // session — keeps the page on a stable /chat/<id> while the

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -671,6 +671,28 @@ HEADED=1 yarn test:e2e:live:media   # Chromium ウィンドウが開き、slowMo
 - 新規シナリオ実装中・既存シナリオ修正時に使用
 - 通常の定期実行は headless で OK
 
+#### QA hold-mode（C: テスト後にセッションを残して目視）
+
+`E2E_LIVE_KEEP_SESSIONS=1` を立てて走らせると、 各 spec が `finally` で呼ぶ `deleteSession` が **early-return に切り替わり session が history に残る**。 spec 側は 1 行も触らない。 全既存 spec (L-01 以降すべて) と今後追加する spec が retrofit ゼロでこのモードに対応する。
+
+```bash
+# QA 目視: HEADED で動作を見つつ、 終了後も session が残る
+E2E_LIVE_KEEP_SESSIONS=1 HEADED=1 yarn test:e2e:live:media -g "L-05" --project=chromium
+
+# テスト終了後:
+#   - http://localhost:5173 を開く
+#   - SPA 右側の session 履歴サイドパネルから残った session をクリック
+#   - chat 内容 / 生成 artifact / plugin view の状態を目視確認
+#   - OK なら sidebar の kebab → 削除 で手動 cleanup
+```
+
+意図と非意図:
+- **意図**: 「spec を編集して cleanup を一旦消す → 確認 → spec を戻す → もう一度走らせる」 という二度手間 (旧フロー) を消すこと。 QA 目視のたびに spec を書き換える運用は時間ロスが大きい
+- **非意図**: 自動回帰 / CI 用途。 history が膨らむので routine 実行では立てない
+- **scope**: 残すのは session のみ。 `placeFixtureInWorkspace` で seed したファイル (画像 / mulmo json) は別経路 (`removeFromWorkspace`) で消える。 fixture も残したい場合は別フラグの導入を検討
+
+実装は `e2e-live/fixtures/live-chat.ts` の `deleteSession` 冒頭の env gate 1 ブロックのみ。
+
 #### Claude / skill 側の実行
 
 | 観点 | やり方 | 理由 |

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -339,10 +339,13 @@ e2e-live/
 | **L-03** mulmoScript 動画 DL | ✅ 実装済 | media.spec.ts、 fixture json (`e2e-live/fixtures/mulmo/l03-two-beat.json`) を `artifacts/stories/e2e-live-l03-<project>.json` に seed → LLM に filePath 指示 → Generate Movie ボタン → Download Movie ボタン → MP4 `ftyp` magic bytes 検証 (B-21)。 全 beat `text: ""` + textSlide で TTS / image API 呼ばず、 ffmpeg 不在時は `which ffmpeg` で `test.skip`。 worker 衝突回避のため fixture 名に project slug を埋める |
 | **L-05** generateImage 実画像描画 | ✅ 実装済 | media.spec.ts、 「猫の絵」 prompt + `generateImage ツールを使ってください` 指示で tool 呼出 → `[generate-image-view]` testid を `src/plugins/generateImage/View.vue` に追加 → `<img>` の src が `/artifacts/images/...` で始まること + `naturalWidth > 0` を assert (decode を待つため `expect.toPass`)。 `GEMINI_API_KEY` は server 側に必要 (test process 側では skip 判定しない、 dotenv が test runner で動かないため) |
 | **L-06** General role 1 ターン | ✅ 実装済 | roles.spec.ts、 `Reply with the single word: hello` で 1 ターン → role-selector が "General" + user-input enabled (B-15) + session id が払い出される (B-41) を検証 |
+| **L-07** Office role 1 ターン | ✅ 実装済 | roles.spec.ts、 `selectRole(page, "office")` で role 切替 → `data-role="office"` 確認 → 同じ single-word prompt で 1 ターン (B-41 canary)。 `runRoleSampleTurn` ヘルパ経由で L-08/L-09 と共有 |
+| **L-08** Tutor role 1 ターン | ✅ 実装済 | roles.spec.ts、 `runRoleSampleTurn(page, "tutor")` (B-41 canary、 L-07 と同型) |
+| **L-09** Storyteller role 1 ターン | ✅ 実装済 | roles.spec.ts、 `runRoleSampleTurn(page, "storyteller")` (B-41 canary、 L-07 と同型) |
 | **L-11** session reload 復元 | ✅ 実装済 | session.spec.ts、 `Reply with the single word: pong` 後に reload → 2 段階の locale-agnostic assertion (B-14): (1) `getCurrentSessionId(page)` で URL `/chat/<id>` から session id を抽出して reload 前後の equality を比較、 (2) `page.getByText("Reply with ...")` で **ユーザーが送ったプロンプト文字列** (locale 非依存) が DOM に visible なことを assert して transcript hydration を検証。 visible 系の chrome-side 文字列 (e.g. 「Start a conversation」) は 8 locale lockstep の都合で使わない |
 | **L-14** wiki 内部リンク | ✅ 実装済 | wiki-nav.spec.ts、 fixture wiki page 2 件 seed → wikilink `[[slug]]` を click → `/wiki/pages/<target>` に遷移 (B-23/B-24/B-25)、 catch-all で `/chat` に飛ばないこと |
 | **L-EDIT** beat 編集永続化 | 🟡 skip 中 | mulmo-script-edit.spec.ts、 #1074 で報告された「`Saving…` から戻らない」 症状を再現する spec として on disk。 **unskip trigger**: issue #1074 が close + その fix を merge した状態で `yarn test:e2e:live:mulmo-script-edit --project=chromium` を 1 回手動実行 (任意で `HEADED=1` を付けて UI で挙動を観察すると false-negative を避けやすい) し、 pass が確認できたら `test.skip(true, ...)` を削除する。 dormant 化を防ぐオーナーは #1074 を close する人 |
-| L-04, L-07〜L-10, L-12〜L-30 | 未実装 | 後続 PR で順次。 横串で 「未登録系」 (リソース不在時の UI、 #1073 系) を機能別 spec として追加予定 |
+| L-04, L-10, L-12〜L-30 | 未実装 | 後続 PR で順次。 横串で 「未登録系」 (リソース不在時の UI、 #1073 系) を機能別 spec として追加予定 |
 
 ## 実装の詳細
 
@@ -354,6 +357,7 @@ e2e-live/
 |---|---|
 | `startNewSession(page)` | `/` に goto → `new-session-btn` クリック |
 | `sendChatMessage(page, text)` | `user-input` fill → `send-btn` click |
+| `selectRole(page, roleId)` | `role-selector-btn` click → `role-option-<roleId>` click (chat page では新セッション払い出し) |
 | `waitForAssistantResponseComplete(page, timeoutMs?)` | `thinking-indicator` testid が hidden になるまで待つ |
 | `waitForImgInPresentHtml(page, imgSelector, timeoutMs?)` | presentHtml iframe 内の `<img>` が visible になるまで待つ |
 | `readImgSrcInPresentHtml(page, imgSelector)` | iframe 内の `<img>` の `src` 属性を取得（リライト後の URL 検証用） |

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -337,11 +337,12 @@ e2e-live/
 | **L-01** presentHtml 画像描画 | ✅ 実装済 | media.spec.ts、fixture 画像を workspace に配置 → naturalWidth > 0、self-repair guard (readImgRepairAttempted) 追加済 |
 | **L-02** PDF DL | ✅ 実装済 | media.spec.ts、textResponse の PDF ボタン経由 |
 | **L-03** mulmoScript 動画 DL | ✅ 実装済 | media.spec.ts、 fixture json (`e2e-live/fixtures/mulmo/l03-two-beat.json`) を `artifacts/stories/e2e-live-l03-<project>.json` に seed → LLM に filePath 指示 → Generate Movie ボタン → Download Movie ボタン → MP4 `ftyp` magic bytes 検証 (B-21)。 全 beat `text: ""` + textSlide で TTS / image API 呼ばず、 ffmpeg 不在時は `which ffmpeg` で `test.skip`。 worker 衝突回避のため fixture 名に project slug を埋める |
+| **L-05** generateImage 実画像描画 | ✅ 実装済 | media.spec.ts、 「猫の絵」 prompt + `generateImage ツールを使ってください` 指示で tool 呼出 → `[generate-image-view]` testid を `src/plugins/generateImage/View.vue` に追加 → `<img>` の src が `/artifacts/images/...` で始まること + `naturalWidth > 0` を assert (decode を待つため `expect.toPass`)。 `GEMINI_API_KEY` は server 側に必要 (test process 側では skip 判定しない、 dotenv が test runner で動かないため) |
 | **L-06** General role 1 ターン | ✅ 実装済 | roles.spec.ts、 `Reply with the single word: hello` で 1 ターン → role-selector が "General" + user-input enabled (B-15) + session id が払い出される (B-41) を検証 |
 | **L-11** session reload 復元 | ✅ 実装済 | session.spec.ts、 `Reply with the single word: pong` 後に reload → 2 段階の locale-agnostic assertion (B-14): (1) `getCurrentSessionId(page)` で URL `/chat/<id>` から session id を抽出して reload 前後の equality を比較、 (2) `page.getByText("Reply with ...")` で **ユーザーが送ったプロンプト文字列** (locale 非依存) が DOM に visible なことを assert して transcript hydration を検証。 visible 系の chrome-side 文字列 (e.g. 「Start a conversation」) は 8 locale lockstep の都合で使わない |
 | **L-14** wiki 内部リンク | ✅ 実装済 | wiki-nav.spec.ts、 fixture wiki page 2 件 seed → wikilink `[[slug]]` を click → `/wiki/pages/<target>` に遷移 (B-23/B-24/B-25)、 catch-all で `/chat` に飛ばないこと |
 | **L-EDIT** beat 編集永続化 | 🟡 skip 中 | mulmo-script-edit.spec.ts、 #1074 で報告された「`Saving…` から戻らない」 症状を再現する spec として on disk。 **unskip trigger**: issue #1074 が close + その fix を merge した状態で `yarn test:e2e:live:mulmo-script-edit --project=chromium` を 1 回手動実行 (任意で `HEADED=1` を付けて UI で挙動を観察すると false-negative を避けやすい) し、 pass が確認できたら `test.skip(true, ...)` を削除する。 dormant 化を防ぐオーナーは #1074 を close する人 |
-| L-04, L-05, L-07〜L-10, L-12〜L-30 | 未実装 | 後続 PR で順次。 横串で 「未登録系」 (リソース不在時の UI、 #1073 系) を機能別 spec として追加予定 |
+| L-04, L-07〜L-10, L-12〜L-30 | 未実装 | 後続 PR で順次。 横串で 「未登録系」 (リソース不在時の UI、 #1073 系) を機能別 spec として追加予定 |
 
 ## 実装の詳細
 
@@ -357,6 +358,9 @@ e2e-live/
 | `waitForImgInPresentHtml(page, imgSelector, timeoutMs?)` | presentHtml iframe 内の `<img>` が visible になるまで待つ |
 | `readImgSrcInPresentHtml(page, imgSelector)` | iframe 内の `<img>` の `src` 属性を取得（リライト後の URL 検証用） |
 | `readImgNaturalSize(page, imgSelector)` | iframe 内の `<img>` の `naturalWidth/Height` を取得（実描画確認） |
+| `waitForGeneratedImage(page, timeoutMs?)` | generateImage View 内 (`[generate-image-view]`) の `<img>` が visible になるまで待つ |
+| `readGeneratedImageSrc(page)` | generateImage View 内の `<img>` の `src` 属性を取得（`/artifacts/images/...` 検証用） |
+| `readGeneratedImageNaturalSize(page)` | generateImage View 内の `<img>` の `naturalWidth/Height` を取得（実描画確認） |
 | `readPdfDownload(download)` | `Download` を読み込み `%PDF-` magic bytes を検証、Buffer 返す |
 | `readMovieDownload(download)` | `Download` を読み込み MP4 の `ftyp` magic bytes を検証、Buffer 返す（L-03 用） |
 | `placeFixtureInWorkspace(fixtureRel, workspaceRel)` | `e2e-live/fixtures/<fixtureRel>` を `~/mulmoclaude/<workspaceRel>` にコピー |
@@ -366,7 +370,7 @@ e2e-live/
 
 ### testid 必要時の追加方針
 
-実装済の追加: `present-html-iframe`（`src/plugins/presentHtml/View.vue` の iframe）、`text-response-pdf-button`（`src/plugins/textResponse/View.vue` の PDF ボタン）、`mulmo-script-generate-movie-button` / `mulmo-script-download-movie-button` / `mulmo-script-regenerate-movie-button`（`src/plugins/presentMulmoScript/View.vue` の動画操作 3 ボタン、 L-03 用）。
+実装済の追加: `present-html-iframe`（`src/plugins/presentHtml/View.vue` の iframe）、`text-response-pdf-button`（`src/plugins/textResponse/View.vue` の PDF ボタン）、`mulmo-script-generate-movie-button` / `mulmo-script-download-movie-button` / `mulmo-script-regenerate-movie-button`（`src/plugins/presentMulmoScript/View.vue` の動画操作 3 ボタン、 L-03 用）、 `generate-image-view`（`src/plugins/generateImage/View.vue` の wrapper、 L-05 用）。
 
 新規 testid を追加する時は:
 - `data-testid="<plugin>-<role>"` の kebab-case で命名（既存規則）
@@ -884,7 +888,7 @@ artifact name: `mulmoclaude-tarball`（10 MB 程度、`.tgz`）。
 - [x] ~~**#974 self-repair で L-01 の `naturalWidth > 0` が甘くなる件の緩和策決定**~~ → `data-image-repair-tried` マーカ参照 guard を採用（上記 「要対応」 セクション参照）
 - [x] ~~**Safari (webkit) project の追加**~~ → 反映済（`e2e-live/playwright.config.ts` に `webkit` project + `testMatch: "media.spec.ts"`）
 - [x] ~~**webkit で L-01 が `naturalWidth=0` で fail する件の調査と修正**~~ → #1015 close 済（real bug ではなく dev server stale だっただけ。 上の 「真の原因」 セクション参照。 dev 再起動後に webkit L-01 + L-02 pass 確認）
-- [ ] **L-05 (generateImage)** 実装時に #983 の path-in-message を活用（path のキャプチャが容易になる）
+- [x] ~~**L-05 (generateImage)** 実装時に #983 の path-in-message を活用~~ → 実装済（path 文字列キャプチャは不要だった: `[generate-image-view]` testid 経由で `<img>.src` を読めば `/artifacts/images/...` の prefix が取れるので tool message を parse する必要がない。 #983 で server message に path が乗るのは agent 側の hint として有用、 spec 側は DOM-only assertion で十分）
 
 ---
 

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -689,9 +689,37 @@ E2E_LIVE_KEEP_SESSIONS=1 HEADED=1 yarn test:e2e:live:media -g "L-05" --project=c
 意図と非意図:
 - **意図**: 「spec を編集して cleanup を一旦消す → 確認 → spec を戻す → もう一度走らせる」 という二度手間 (旧フロー) を消すこと。 QA 目視のたびに spec を書き換える運用は時間ロスが大きい
 - **非意図**: 自動回帰 / CI 用途。 history が膨らむので routine 実行では立てない
-- **scope**: 残すのは session のみ。 `placeFixtureInWorkspace` で seed したファイル (画像 / mulmo json) は別経路 (`removeFromWorkspace`) で消える。 fixture も残したい場合は別フラグの導入を検討
+- **scope**: 残すのは session のみ。 `placeFixtureInWorkspace` で seed したファイル (画像 / mulmo json) は別経路 (`removeFromWorkspace`) で消える。 fixture も残したい場合は別フラグの導入を検討 (下記)
 
 実装は `e2e-live/fixtures/live-chat.ts` の `deleteSession` 冒頭の env gate 1 ブロックのみ。
+
+#### 派生: `E2E_LIVE_KEEP_FIXTURES` (将来導入候補、 未実装)
+
+`KEEP_SESSIONS` は session 状態だけを残す。 一方で fixture (テスト用ダミーファイル: `e2e-live/fixtures/images/sample.png` を `~/mulmoclaude/artifacts/images/e2e-live-l01.png` に seed する等) は spec 終了時に `removeFromWorkspace` で消える。
+
+QA 目視で「fixture が server 側でどう serve / 配置されたか」 まで実機で見たい場合 (例: 「L-01 の画像が `artifacts/images/e2e-live-l01.png` に居て、 mtime が想定通りか」 「L-03 の mulmoScript json が `artifacts/stories/...` に居るか」 を確認したい) は session だけ残しても足りない。
+
+その時点で導入する想定の追加フラグ:
+
+```bash
+# fixture も残す (workspace に置きっぱなし)
+E2E_LIVE_KEEP_FIXTURES=1 yarn test:e2e:live:media
+
+# session + fixture の両方を残す (フル QA 目視)
+E2E_LIVE_KEEP_SESSIONS=1 E2E_LIVE_KEEP_FIXTURES=1 HEADED=1 yarn test:e2e:live:media -g "L-01"
+```
+
+実装方針 (実装時用メモ):
+- `removeFromWorkspace` (`e2e-live/fixtures/live-chat.ts`) の冒頭に `process.env.E2E_LIVE_KEEP_FIXTURES === "1"` early-return を 1 ブロック
+- `KEEP_SESSIONS` と同じパターンで spec 側はノータッチ、 全既存 spec が retroactive に対応
+- fixture path 前提のテスト (placeFixtureInWorkspace で seed → 読み取り → 削除) で「seed が確かに行われたか」 「server がそのパスを正しく serve したか」 をユーザーが直接見られる
+- 削除は手動 (`rm ~/mulmoclaude/artifacts/images/e2e-live-*.png` など)、 もしくは次回テスト走行時の seed 上書きで自然解決
+
+導入トリガー:
+- L-01 系 / L-03 系で fixture 配置自体を疑うバグが出たとき
+- QA 目視で「session 残っても workspace の中身は分からない」 という不満が出たとき
+
+それまでは導入しない (デフォルト挙動が増えるほど混乱するため、 必要になったタイミングで初めて入れる)。
 
 #### Claude / skill 側の実行
 

--- a/src/plugins/generateImage/View.vue
+++ b/src/plugins/generateImage/View.vue
@@ -1,5 +1,7 @@
 <template>
-  <ImageView v-if="imageResult" :selected-result="imageResult" />
+  <div data-testid="generate-image-view" class="w-full h-full">
+    <ImageView v-if="imageResult" :selected-result="imageResult" />
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

実 LLM e2e (`e2e-live/`) スイートを 4 シナリオ拡張し、 さらに「QA 担当者が画面で動作を見られる」 という当初設計目的を実装に落とすための env gate (`E2E_LIVE_KEEP_SESSIONS=1`) を追加する。

- **L-05 generateImage** — Gemini 経由で実画像が `/artifacts/images/...` に保存され SPA で描画されることを end-to-end で検証 (`naturalWidth > 0`)
- **L-07 / L-08 / L-09** — Office / Tutor / Storyteller の各 role で 1 ターン (single-word reply) を回し B-41 (deferred-tools 切替で role の tool 呼出が壊れた件) の canary とする
- **`E2E_LIVE_KEEP_SESSIONS=1`** — `deleteSession` 1 ヶ所に env gate を入れただけで、 既存全 spec (L-01..L-14) が retroactive にこのモードに対応する。 spec ファイルは 1 行も触っていない

## Items to Confirm / Review

AI 生成コードを含むので、 以下を人間レビュアー側で重点的に見てほしい。

1. **L-05 の prompt 文言** — `e2e-live/tests/media.spec.ts` の `sendL05Prompt`。 「`generateImage` ツールを使ってください」 という明示指示を入れているが、 LLM 揺れで text-only で返してくる可能性ゼロではない。 過去 50 回程度の手元実行で再現未確認だが、 flaky になったら prompt 補強の余地あり
2. **`E2E_LIVE_KEEP_SESSIONS` env 名** — 別案 (`E2E_LIVE_HOLD`, `E2E_LIVE_NO_CLEANUP`) も検討可。 名前が定着する前に好み確認したい

## User Prompt

- `/make-e2e-live` で `plans/feat-e2e-live.md` の優先度に従って次のシナリオを実装したい (L-05 が plan TODO で「#983 path-in-message を活用」 と着手準備済だった)
- L-05 だけでなく追加で複数シナリオを (今回は roles カテゴリの L-07 / L-08 / L-09 をバッチで)
- 旧フロー (spec を編集して cleanup を一旦消す → run → 確認 → spec 戻す → 再 run) は時間の無駄。 コマンド実行時の env 1 個で off/on できるようにし、 **L-01 まで遡って適用**
- `/codex-cross-review` で Codex に二人目のレビュアーをやらせて convergence させてから PR を出す

## Implementation Details

### 5 commits

| commit | 内容 |
|---|---|
| `5969339b` | feat: L-05 generateImage real-image scenario |
| `afdb1a25` | feat: L-07 / L-08 / L-09 role-turn scenarios |
| `19dda4cc` | feat: `E2E_LIVE_KEEP_SESSIONS` gate (retroactive on L-01..L-14) |
| `32fcb31b` | fix: address codex iter 1 — orphan General session cleanup |
| `662b6494` | fix: address codex iter 2 — early-failure cleanup |

### L-05 (`media.spec.ts`)

- `[generate-image-view]` testid を `src/plugins/generateImage/View.vue` に追加 (wrapper div)
- `live-chat.ts` に `waitForGeneratedImage` / `readGeneratedImageSrc` / `readGeneratedImageNaturalSize` の 3 helper
- assertion: `<img>.src` が `/artifacts/images/...` で始まる + `naturalWidth > 0` (decode race を `expect.toPass` で吸収)
- `GEMINI_API_KEY` は server 側に必要 (test runner と `yarn dev` の env scope は別なので process.env での skip 判定はしない)

### L-07 / L-08 / L-09 (`roles.spec.ts`)

- L-06 の single-word canary を `runRoleSampleTurn(page, roleId)` ヘルパに抽出 → 3 role 分量産
- `selectRole(page, roleId)` を `live-chat.ts` に追加 (`role-selector-btn` → `role-option-<id>`)
- role 切替で SPA が新 session を払い出す自然な挙動に従い、 General + role-switched の **2 セッションを cleanup** (Codex iter 1 fix)
- `waitForURL` で role 切替後の新 URL を待ってから session id capture (early-failure 経路でも cleanup 漏れなし、 Codex iter 2 fix)
- 末尾で `expect(sessionId).toBe(roleSessionId)` を追加 — 将来的に spec shape が変わって turn が別 session に飛んだら fail させる guardrail

### `E2E_LIVE_KEEP_SESSIONS` gate (`live-chat.ts`)

- `deleteSession` 冒頭で `process.env.E2E_LIVE_KEEP_SESSIONS === "1"` を見て early-return
- breadcrumb log: `[E2E_LIVE_KEEP_SESSIONS=1] keeping session <id> for inspection`
- spec 側は **1 行も触らない** — 全既存 spec が `finally { await deleteSession(...) }` で routing しているため、 関数内 gate で全カバー
- 用途:
  ```bash
  E2E_LIVE_KEEP_SESSIONS=1 HEADED=1 yarn test:e2e:live:media -g "L-05" --project=chromium
  # 終了後 http://localhost:5173 → 右の session 履歴から残った session を目視
  # OK なら sidebar の kebab → 削除 で手動 cleanup
  ```

### plan / docs 更新

- `plans/feat-e2e-live.md` — 実装ステータス表 (L-05/L-07/L-08/L-09 を ✅)、 helper 表、 testid 追加履歴、 「QA hold-mode (C:)」 セクション追加 (旧フローを time-waste として明示)
- `docs/ui-cheatsheet.md` — Canvas plugin views 表に `[generate-image-view]` 行追加

## Verification

### chromium full pass

| spec | 結果 | 時間 |
|---|---|---|
| `media.spec.ts` (L-01 / L-02 / L-03 / L-05) | 4/4 ✅ | 45s |
| `roles.spec.ts` (L-06 / L-07 / L-08 / L-09) | 4/4 ✅ | 17s |

### HEADED 目視確認 (KEEP_SESSIONS=1)

L-01 / L-02 / L-03 / L-05 / L-07 / L-08 / L-09 の 7 シナリオを HEADED + KEEP_SESSIONS で個別実行し、 SPA 履歴サイドパネルから残った session を直接目視確認済。 L-04 は plan 上未実装。

### KEEP_SESSIONS gate smoke

- env=1 で disk 上 session が残ることを確認 (delta +2 .json/.jsonl)
- env なしで `runRoleSampleTurn` を 4 spec 走らせて disk delta 1/8 (parallel sidebar race; 旧実装の deterministic 3/4 leak から大幅改善)

### Cross-review

`/codex-cross-review` で 3 iteration の convergence:

| iter | Codex verdict | 対応 |
|---|---|---|
| 1 | CHANGES REQUESTED (1 must-fix) | runRoleSampleTurn の orphan cleanup 修正 (`32fcb31b`) |
| 2 | LGTM (1 question) | early-failure 経路の cleanup gap を埋める (`662b6494`) |
| 3 | **LGTM (no findings)** | 両 reviewer 合意 |

## Out of scope

- L-04 (animation:true) — 別 PR で実装予定 (image gen API cost、 mulmocast schema 確認が必要)
- L-10 (Gemini key 不要 General) — 別 PR で実装予定 (key 一時 unset の仕組みが要る)
- `deleteSession` の parallel sidebar race 改善 — 別 issue (pre-existing、 cleanup の reliability 問題)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation plugin functionality now verified end-to-end with comprehensive testing.
  * Role switching capability added with dedicated test coverage.

* **Tests**
  * New e2e test scenarios for image generation, role switching, and session management.
  * Added test helpers for role selection and image rendering verification.

* **Documentation**
  * Updated UI cheat sheet with new testid references.
  * Updated feature plan to reflect completed test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->