### PR TITLE
feat(accounting): clickable B/S+P&L rows, B/S period shortcuts, journal detail panel, edit-in-place

### DIFF
--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -49,10 +49,45 @@ interface FakeEntry {
   createdAt: string;
 }
 
+/** Minimal shapes for the report mocks. Mirror the public response
+ *  shapes from `server/accounting/report.ts` closely enough that the
+ *  client renders rows; tests only populate the fields they assert on. */
+export interface BalanceSheetRowMock {
+  accountCode: string;
+  accountName: string;
+  balance: number;
+}
+export interface BalanceSheetSectionMock {
+  type: "asset" | "liability" | "equity";
+  rows: BalanceSheetRowMock[];
+  total: number;
+}
+export interface BalanceSheetMock {
+  asOf?: string;
+  sections: BalanceSheetSectionMock[];
+  imbalance?: number;
+}
+export interface ProfitLossRowMock {
+  accountCode: string;
+  accountName: string;
+  amount: number;
+}
+export interface ProfitLossMock {
+  from?: string;
+  to?: string;
+  income: { rows: ProfitLossRowMock[]; total: number };
+  expense: { rows: ProfitLossRowMock[]; total: number };
+  netIncome?: number;
+}
+
 interface AccountingState {
   books: FakeBook[];
   accountsByBook: Map<string, FakeAccount[]>;
   entriesByBook: Map<string, FakeEntry[]>;
+  /** Optional canned report data injected via `mockAccountingApi`'s
+   *  `reports` option. Lets tests render non-empty Balance Sheet /
+   *  P&L tables without standing up the real aggregation pipeline. */
+  reports?: { balanceSheet?: BalanceSheetMock; profitLoss?: ProfitLossMock };
 }
 
 const SEED_ACCOUNTS: FakeAccount[] = [
@@ -306,15 +341,17 @@ function handleGetReport(state: AccountingState, body: DispatchBody): MockRespon
   if (typeof resolved !== "string") return resolved;
   const kind = typeof body.kind === "string" ? body.kind : "balance";
   if (kind === "pl") {
+    const injected = state.reports?.profitLoss;
     return ok({
       bookId: resolved,
-      profitLoss: { from: "2026-04-01", to: "2026-04-30", income: { rows: [], total: 0 }, expense: { rows: [], total: 0 }, netIncome: 0 },
+      profitLoss: injected ?? { from: "2026-04-01", to: "2026-04-30", income: { rows: [], total: 0 }, expense: { rows: [], total: 0 }, netIncome: 0 },
     });
   }
   if (kind === "ledger") {
     return ok({ bookId: resolved, ledger: { accountCode: "1000", accountName: "Cash", rows: [], closingBalance: 0 } });
   }
-  return ok({ bookId: resolved, balanceSheet: { asOf: "2026-04-30", sections: [], imbalance: 0 } });
+  const injected = state.reports?.balanceSheet;
+  return ok({ bookId: resolved, balanceSheet: injected ?? { asOf: "2026-04-30", sections: [], imbalance: 0 } });
 }
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
@@ -363,8 +400,12 @@ export interface AccountingSeedBook {
  *  with pre-existing books — useful for tests that need to drive
  *  `openBook` against a real bookId without first running through
  *  the createBook flow. */
-export async function mockAccountingApi(page: Page, opts: { books?: readonly AccountingSeedBook[] } = {}): Promise<AccountingState> {
+export async function mockAccountingApi(
+  page: Page,
+  opts: { books?: readonly AccountingSeedBook[]; reports?: { balanceSheet?: BalanceSheetMock; profitLoss?: ProfitLossMock } } = {},
+): Promise<AccountingState> {
   const state = makeState();
+  if (opts.reports) state.reports = opts.reports;
   for (const seed of opts.books ?? []) {
     state.books.push({
       id: seed.id,

--- a/e2e/tests/accounting-detail-and-shortcuts.spec.ts
+++ b/e2e/tests/accounting-detail-and-shortcuts.spec.ts
@@ -1,0 +1,327 @@
+// E2E coverage for the accounting plugin's row-click behaviors and
+// the Balance Sheet's period shortcut dropdown.
+//
+// Three feature surfaces are pinned here:
+//   1. Balance Sheet / Profit & Loss rows are clickable; clicking
+//      routes to the Ledger tab pre-filtered to that account (mirrors
+//      the existing AccountsList → Ledger handoff).
+//   2. Balance Sheet's Period dropdown ("This month / Last month /
+//      Last quarter / Last year") snaps the `<input type=month>` to
+//      the chosen shortcut.
+//   3. Journal entries open an inline detail panel with separate
+//      Debit / Credit / Memo / T-number columns. Edit replaces the
+//      detail content with the JournalEntryForm (in-place edit);
+//      Cancel returns to the read-only detail; the close (X) button
+//      collapses the panel.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { mockAccountingApi, makeAccountingToolResult, type AccountingSeedBook, type BalanceSheetMock, type ProfitLossMock } from "../fixtures/accounting";
+
+const SESSION_ID = "accounting-detail-session";
+
+interface SetupOpts {
+  books?: readonly AccountingSeedBook[];
+  envelope: { bookId: string | null; initialTab?: string };
+  reports?: { balanceSheet?: BalanceSheetMock; profitLoss?: ProfitLossMock };
+}
+
+async function setupSession(page: Page, opts: SetupOpts): Promise<void> {
+  await mockAllApis(page, {
+    sessions: [
+      {
+        id: SESSION_ID,
+        title: "Accounting Detail Session",
+        roleId: "general",
+        startedAt: "2026-04-14T10:00:00Z",
+        updatedAt: "2026-04-14T10:05:00Z",
+      },
+    ],
+  });
+
+  await mockAccountingApi(page, { books: opts.books, reports: opts.reports });
+
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: SESSION_ID },
+          { type: "text", source: "user", message: "Open my books" },
+          makeAccountingToolResult(opts.envelope),
+        ],
+      }),
+  );
+}
+
+test.describe("Balance Sheet — row click and period shortcuts", () => {
+  test("clicking a balance-sheet row routes to the Ledger pre-filtered to that account", async ({ page }) => {
+    const SEED_BOOK_ID = "book-bs-row-click";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "BS Click Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "balanceSheet" },
+      reports: {
+        balanceSheet: {
+          asOf: "2026-04-30",
+          imbalance: 0,
+          sections: [
+            { type: "asset", rows: [{ accountCode: "1000", accountName: "Cash", balance: 250 }], total: 250 },
+            { type: "liability", rows: [{ accountCode: "2000", accountName: "Accounts payable", balance: 100 }], total: 100 },
+            { type: "equity", rows: [{ accountCode: "3000", accountName: "Equity", balance: 150 }], total: 150 },
+          ],
+        },
+      },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-app")).toBeVisible();
+    await expect(page.getByTestId("accounting-balance-sheet")).toBeVisible();
+
+    const cashRow = page.getByTestId("accounting-bs-row-1000");
+    await expect(cashRow).toBeVisible();
+    await expect(cashRow).toHaveAttribute("role", "button");
+    await expect(cashRow).toHaveAttribute("tabindex", "0");
+
+    await cashRow.click();
+    await expect(page.getByTestId("accounting-ledger")).toBeVisible();
+    await expect(page.getByTestId("accounting-ledger-account")).toHaveValue("1000");
+  });
+
+  test("the synthetic _currentEarnings B/S row is not clickable", async ({ page }) => {
+    // The server appends a synthetic equity row with the sentinel
+    // accountCode `_currentEarnings` so the B/S balances mid-period.
+    // It has no underlying account, so the View must keep it
+    // non-clickable (and out of the row testid namespace).
+    const SEED_BOOK_ID = "book-bs-earnings-skip";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Earnings Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "balanceSheet" },
+      reports: {
+        balanceSheet: {
+          asOf: "2026-04-30",
+          imbalance: 0,
+          sections: [
+            { type: "asset", rows: [{ accountCode: "1000", accountName: "Cash", balance: 100 }], total: 100 },
+            {
+              type: "equity",
+              rows: [{ accountCode: "_currentEarnings", accountName: "Current period earnings", balance: 100 }],
+              total: 100,
+            },
+          ],
+        },
+      },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-balance-sheet")).toBeVisible();
+
+    // The earnings row deliberately does NOT carry an `accounting-bs-row-…`
+    // testid (so Playwright can't reach it the way it would a real
+    // account row). Real account rows still expose the testid.
+    await expect(page.getByTestId("accounting-bs-row-1000")).toBeVisible();
+    await expect(page.getByTestId("accounting-bs-row-_currentEarnings")).toHaveCount(0);
+  });
+
+  test("Balance Sheet shortcut dropdown drives the Period input", async ({ page }) => {
+    const SEED_BOOK_ID = "book-bs-shortcut";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Shortcut Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "balanceSheet" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-balance-sheet")).toBeVisible();
+
+    const period = page.getByTestId("accounting-bs-period");
+    const shortcut = page.getByTestId("accounting-bs-shortcut");
+
+    // Each shortcut snaps the month input to a different YYYY-MM.
+    // We don't pin specific values (the test runs against the system
+    // clock), but each option must land on a distinct YYYY-MM string
+    // to prove the four code paths are wired.
+    await shortcut.selectOption("thisMonth");
+    const thisMonth = await period.inputValue();
+    expect(thisMonth).toMatch(/^\d{4}-\d{2}$/);
+
+    await shortcut.selectOption("lastMonth");
+    const lastMonth = await period.inputValue();
+    expect(lastMonth).toMatch(/^\d{4}-\d{2}$/);
+    expect(lastMonth).not.toEqual(thisMonth);
+
+    await shortcut.selectOption("lastQuarter");
+    const lastQuarter = await period.inputValue();
+    expect(lastQuarter).toMatch(/^\d{4}-\d{2}$/);
+
+    await shortcut.selectOption("lastYear");
+    const lastYear = await period.inputValue();
+    expect(lastYear).toMatch(/^\d{4}-12$/);
+    // Last year must be strictly older than this month.
+    expect(lastYear < thisMonth).toBe(true);
+  });
+});
+
+test.describe("Profit & Loss — row click", () => {
+  test("clicking a P&L income or expense row routes to the Ledger pre-filtered", async ({ page }) => {
+    const SEED_BOOK_ID = "book-pl-row-click";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "PL Click Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "profitLoss" },
+      reports: {
+        profitLoss: {
+          from: "2026-01-01",
+          to: "2026-12-31",
+          income: { rows: [{ accountCode: "4000", accountName: "Sales", amount: 500 }], total: 500 },
+          expense: { rows: [{ accountCode: "5000", accountName: "Rent expense", amount: 200 }], total: 200 },
+          netIncome: 300,
+        },
+      },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-profit-loss")).toBeVisible();
+
+    const incomeRow = page.getByTestId("accounting-pl-row-4000");
+    await expect(incomeRow).toBeVisible();
+    await expect(incomeRow).toHaveAttribute("role", "button");
+    await incomeRow.click();
+    await expect(page.getByTestId("accounting-ledger")).toBeVisible();
+    await expect(page.getByTestId("accounting-ledger-account")).toHaveValue("4000");
+
+    // Bounce back to P&L and pin the expense-side path too — the two
+    // tables share a click handler, but a regression that tied the
+    // emit to only one tbody would slip through if we only tested
+    // income.
+    await page.getByTestId("accounting-tab-profitLoss").click();
+    const expenseRow = page.getByTestId("accounting-pl-row-5000");
+    await expenseRow.focus();
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("accounting-ledger")).toBeVisible();
+    await expect(page.getByTestId("accounting-ledger-account")).toHaveValue("5000");
+  });
+});
+
+test.describe("Journal — clickable rows and inline detail panel", () => {
+  // The fixture's withEmptyOpening already seeds an opening row, but
+  // the inline detail flow only triggers on `kind: 'normal'` rows
+  // (Edit/Void show only there). Each test posts one balanced normal
+  // entry via the inline form before driving the detail behavior —
+  // matches the existing accounting-flow shape.
+  async function postNormalEntry(page: Page, opts: { debit?: string; credit?: string } = {}): Promise<void> {
+    await page.getByTestId("accounting-journal-new-entry").click();
+    await page.getByTestId("accounting-entry-line-account-0").selectOption("1000");
+    await page.getByTestId("accounting-entry-line-debit-0").fill(opts.debit ?? "100");
+    await page.getByTestId("accounting-entry-line-account-1").selectOption("4000");
+    await page.getByTestId("accounting-entry-line-credit-1").fill(opts.credit ?? "100");
+    await page.getByTestId("accounting-entry-submit").click();
+    await expect(page.getByTestId("accounting-journal-inline-form")).toHaveCount(0);
+  }
+
+  async function findNormalRow(page: Page) {
+    // The fixture's `withEmptyOpening: true` seeds an opening row
+    // first; postNormalEntry then appends a normal entry, so the
+    // last `accounting-journal-row-…` (excluding voided ones) closes
+    // over the normal entry we just posted. The View renders entries
+    // in the order the API returns them, which is append order.
+    const lastRow = page.locator("[data-testid^='accounting-journal-row-']:not([data-testid*='accounting-journal-row-voided-'])").last();
+    await expect(lastRow).toBeVisible();
+    const rowTestId = await lastRow.getAttribute("data-testid");
+    expect(rowTestId).toMatch(/^accounting-journal-row-/);
+    return page.getByTestId(rowTestId as string);
+  }
+
+  test("clicking a journal row toggles the detail panel and renders Debit / Credit columns", async ({ page }) => {
+    const SEED_BOOK_ID = "book-journal-detail";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Detail Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "journal" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-app")).toBeVisible();
+    await postNormalEntry(page);
+
+    const row = await findNormalRow(page);
+    await expect(row).toHaveAttribute("role", "button");
+    await expect(row).toHaveAttribute("tabindex", "0");
+
+    // Initially collapsed.
+    await expect(page.locator("[data-testid^='accounting-journal-detail-']:not([data-testid*='-close-']):not([data-testid*='-edit-'])")).toHaveCount(0);
+
+    // Click expands. Detail panel uses a dedicated testid family.
+    await row.click();
+    const detailPanel = page.locator("[data-testid^='accounting-journal-detail-']:not([data-testid*='-close-']):not([data-testid*='-edit-'])");
+    await expect(detailPanel).toHaveCount(1);
+
+    // Detail header surfaces Edit / Void / Close.
+    await expect(page.locator("[data-testid^='accounting-edit-']:not([data-testid*='accounting-edit-opening-'])").first()).toBeVisible();
+    await expect(page.locator("[data-testid^='accounting-void-']").first()).toBeVisible();
+    await expect(page.locator("[data-testid^='accounting-journal-detail-close-']").first()).toBeVisible();
+
+    // Detail body has dedicated Debit / Credit columns — the inner
+    // table headers spell them out. We rely on the (locale-stable)
+    // English column headers since the test runs against the default
+    // locale build; if a future test fixture switches locales, swap
+    // these for `accounting-` testids on the inner table.
+    await expect(detailPanel.first()).toContainText("Debit");
+    await expect(detailPanel.first()).toContainText("Credit");
+  });
+
+  test("clicking the detail close button collapses the panel", async ({ page }) => {
+    const SEED_BOOK_ID = "book-journal-close";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Close Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "journal" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await postNormalEntry(page);
+
+    const row = await findNormalRow(page);
+    await row.click();
+
+    const closeButton = page.locator("[data-testid^='accounting-journal-detail-close-']").first();
+    await expect(closeButton).toBeVisible();
+    await closeButton.click();
+
+    // After close, the detail panel is gone but the row stays.
+    await expect(page.locator("[data-testid^='accounting-journal-detail-']:not([data-testid*='-close-']):not([data-testid*='-edit-'])")).toHaveCount(0);
+    await expect(row).toBeVisible();
+  });
+
+  test("clicking Edit in the detail panel replaces it with the in-place form; Cancel returns to read-only", async ({ page }) => {
+    const SEED_BOOK_ID = "book-journal-edit-inplace";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Edit-in-place Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "journal" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await postNormalEntry(page);
+
+    const row = await findNormalRow(page);
+    await row.click();
+
+    // Edit lives inside the detail panel (no longer in the row's
+    // action cell). Click it; the read-only detail collapses and the
+    // JournalEntryForm mounts in its place inside the same row's
+    // expanded slot, NOT at the top of the page.
+    const editButton = page.locator("[data-testid^='accounting-edit-']:not([data-testid*='accounting-edit-opening-'])").first();
+    await editButton.click();
+
+    // Top-bar form must NOT open — that path is reserved for "+ New
+    // entry". The in-place form has its own dedicated testid prefix.
+    await expect(page.getByTestId("accounting-journal-inline-form")).toHaveCount(0);
+    const inPlaceForm = page.locator("[data-testid^='accounting-journal-detail-edit-']");
+    await expect(inPlaceForm).toHaveCount(1);
+
+    // Cancel from the in-place edit returns to the read-only detail
+    // for the same row (panel stays expanded; edit form unmounts).
+    await page.getByTestId("accounting-entry-cancel-edit").click();
+    await expect(inPlaceForm).toHaveCount(0);
+    const detailPanel = page.locator("[data-testid^='accounting-journal-detail-']:not([data-testid*='-close-']):not([data-testid*='-edit-'])");
+    await expect(detailPanel).toHaveCount(1);
+    // Edit/Void/Close are back in the read-only header.
+    await expect(page.locator("[data-testid^='accounting-edit-']:not([data-testid*='accounting-edit-opening-'])").first()).toBeVisible();
+    await expect(page.locator("[data-testid^='accounting-journal-detail-close-']").first()).toBeVisible();
+  });
+});

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -164,23 +164,38 @@ test.describe("accounting plugin — flow", () => {
     await expect(newEntryButton).toBeVisible();
     const journalTable = page.getByTestId("accounting-journal-table");
     await expect(journalTable).toBeVisible();
-    // Normal-entry Edit buttons only — the opening row uses the
-    // distinct `accounting-edit-opening-…` testid and routes to a
-    // different handler (it switches to the Opening tab instead of
-    // the inline form).
+
+    // Edit / Void now live inside the row's expanded detail panel —
+    // collapsed rows expose neither button. Locate the just-posted
+    // normal entry's row by exclusion (skip the opening row + any
+    // voided row) and expand it.
+    const normalRow = page.locator("[data-testid^='accounting-journal-row-']:not([data-testid*='accounting-journal-row-voided-'])").last();
+    await expect(normalRow).toBeVisible();
+    await normalRow.click();
+
+    // Inside the now-expanded panel: normal-entry Edit (the opening
+    // row uses the distinct `accounting-edit-opening-…` testid and
+    // a different handler — it switches to the Opening tab).
     const normalEditButtons = page.locator("[data-testid^='accounting-edit-']:not([data-testid*='accounting-edit-opening-'])");
     await expect(normalEditButtons.first()).toBeVisible();
 
-    // Click Edit on the just-posted row → form re-opens prefilled.
+    // Click Edit on the just-posted row → the JournalEntryForm
+    // mounts in-place inside the expanded detail panel (NOT in the
+    // top-bar, which stays reserved for "+ New entry"), prefilled
+    // from the row.
     await normalEditButtons.first().click();
-    await expect(inlineForm).toBeVisible();
+    await expect(inlineForm).toHaveCount(0);
+    const inPlaceEdit = page.locator("[data-testid^='accounting-journal-detail-edit-']");
+    await expect(inPlaceEdit).toHaveCount(1);
     // The date input should hold the posted date (today by default).
     const dateInput = page.getByTestId("accounting-entry-date");
     await expect(dateInput).toHaveValue(/^\d{4}-\d{2}-\d{2}$/);
 
-    // Cancel from edit mode dismisses the panel and the toolbar
-    // button comes back.
+    // Cancel from in-place edit drops the form back to the read-
+    // only detail view for the same row; the top-bar "+ New entry"
+    // button stays visible the whole time (it was never replaced).
     await page.getByTestId("accounting-entry-cancel-edit").click();
+    await expect(inPlaceEdit).toHaveCount(0);
     await expect(inlineForm).toHaveCount(0);
     await expect(newEntryButton).toBeVisible();
   });

--- a/packages/todo-plugin/src/index.ts
+++ b/packages/todo-plugin/src/index.ts
@@ -22,10 +22,13 @@ export default definePlugin(({ log }) => ({
   async manageTodoList(_args: unknown) {
     // PR1 stub. PR2/3 fills this in with the items + columns +
     // dispatch logic moved out of `server/api/routes/todos*.ts`.
-    log.warn("manageTodoList runtime-plugin handler called — PR1 scaffold should not be the active handler. Static plugin's collision-win policy was bypassed somehow. Returning explicit error to avoid silent no-op.");
+    log.warn(
+      "manageTodoList runtime-plugin handler called — PR1 scaffold should not be the active handler. Static plugin's collision-win policy was bypassed somehow. Returning explicit error to avoid silent no-op.",
+    );
     return {
       ok: false as const,
-      error: "todo-plugin handler not yet migrated; falling back to the built-in static plugin (which should win the collision). If you see this in production, the runtime-vs-static collision policy regressed.",
+      error:
+        "todo-plugin handler not yet migrated; falling back to the built-in static plugin (which should win the collision). If you see this in production, the runtime-vs-static collision policy regressed.",
     };
   },
 }));

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -705,7 +705,7 @@ const deMessages = {
       total: "Summe",
       imbalance: "Differenz: {amount}",
       currentEarnings: "Periodenergebnis",
-      shortcutLabel: "Verknüpfung",
+      shortcutLabel: "Schnellauswahl",
       thisMonth: "Dieser Monat",
       lastMonth: "Letzter Monat",
       lastQuarter: "Letztes Quartal",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -705,6 +705,11 @@ const deMessages = {
       total: "Summe",
       imbalance: "Differenz: {amount}",
       currentEarnings: "Periodenergebnis",
+      shortcutLabel: "Verknüpfung",
+      thisMonth: "Dieser Monat",
+      lastMonth: "Letzter Monat",
+      lastQuarter: "Letztes Quartal",
+      lastYear: "Letztes Jahr",
     },
     profitLoss: {
       fromLabel: "Von",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -697,6 +697,11 @@ const enMessages = {
       total: "Total",
       imbalance: "Imbalance: {amount}",
       currentEarnings: "Current period earnings",
+      shortcutLabel: "Shortcut",
+      thisMonth: "This month",
+      lastMonth: "Last month",
+      lastQuarter: "Last quarter",
+      lastYear: "Last year",
     },
     profitLoss: { fromLabel: "From", toLabel: "To", income: "Income", expense: "Expense", netIncome: "Net income:" },
     accounts: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -639,7 +639,7 @@ const enMessages = {
     entryForm: {
       title: "New journal entry",
       editTitle: "Edit journal entry",
-      editBanner: "The original entry is voided and replaced by this one when you submit.",
+      editBanner: "When you submit, the original entry will be voided and replaced by this one.",
       dateLabel: "Date",
       memoLabel: "Memo",
       accountLabel: "Account",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -702,6 +702,11 @@ const esMessages = {
       total: "Total",
       imbalance: "Descuadre: {amount}",
       currentEarnings: "Resultado del período",
+      shortcutLabel: "Atajo",
+      thisMonth: "Este mes",
+      lastMonth: "Mes anterior",
+      lastQuarter: "Último trimestre",
+      lastYear: "Año anterior",
     },
     profitLoss: {
       fromLabel: "Desde",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -634,7 +634,7 @@ const esMessages = {
     entryForm: {
       title: "Nueva entrada",
       editTitle: "Editar entrada",
-      editBanner: "Al enviar, la entrada original se anula y se sustituye por esta.",
+      editBanner: "Al enviar, la entrada original será anulada y sustituida por esta.",
       dateLabel: "Fecha",
       memoLabel: "Memo",
       accountLabel: "Cuenta",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -697,6 +697,11 @@ const frMessages = {
       total: "Total",
       imbalance: "Déséquilibre : {amount}",
       currentEarnings: "Résultat de la période",
+      shortcutLabel: "Raccourci",
+      thisMonth: "Ce mois-ci",
+      lastMonth: "Mois précédent",
+      lastQuarter: "Trimestre précédent",
+      lastYear: "Année précédente",
     },
     profitLoss: {
       fromLabel: "Du",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -629,7 +629,7 @@ const frMessages = {
     entryForm: {
       title: "Nouvelle écriture",
       editTitle: "Modifier l'écriture",
-      editBanner: "À l'envoi, l'écriture d'origine est contre-passée et remplacée par celle-ci.",
+      editBanner: "À l'envoi, l'écriture d'origine sera contre-passée et remplacée par celle-ci.",
       dateLabel: "Date",
       memoLabel: "Mémo",
       accountLabel: "Compte",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -692,6 +692,11 @@ const jaMessages = {
       total: "合計",
       imbalance: "差額: {amount}",
       currentEarnings: "当期純損益",
+      shortcutLabel: "ショートカット",
+      thisMonth: "今月",
+      lastMonth: "先月",
+      lastQuarter: "前四半期",
+      lastYear: "前年",
     },
     profitLoss: {
       fromLabel: "開始日",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -693,6 +693,11 @@ const koMessages = {
       total: "합계",
       imbalance: "차액: {amount}",
       currentEarnings: "당기 순손익",
+      shortcutLabel: "바로가기",
+      thisMonth: "이번 달",
+      lastMonth: "지난달",
+      lastQuarter: "지난 분기",
+      lastYear: "지난 연도",
     },
     profitLoss: {
       fromLabel: "시작",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -695,6 +695,11 @@ const ptBRMessages = {
       total: "Total",
       imbalance: "Diferença: {amount}",
       currentEarnings: "Resultado do período",
+      shortcutLabel: "Atalho",
+      thisMonth: "Este mês",
+      lastMonth: "Mês anterior",
+      lastQuarter: "Último trimestre",
+      lastYear: "Ano anterior",
     },
     profitLoss: {
       fromLabel: "De",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -627,7 +627,7 @@ const ptBRMessages = {
     entryForm: {
       title: "Novo lançamento",
       editTitle: "Editar lançamento",
-      editBanner: "Ao enviar, o lançamento original é estornado e substituído por este.",
+      editBanner: "Ao enviar, o lançamento original será estornado e substituído por este.",
       dateLabel: "Data",
       memoLabel: "Memo",
       accountLabel: "Conta",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -686,6 +686,11 @@ const zhMessages = {
       total: "合计",
       imbalance: "差额: {amount}",
       currentEarnings: "当期净损益",
+      shortcutLabel: "快捷方式",
+      thisMonth: "本月",
+      lastMonth: "上月",
+      lastQuarter: "上季度",
+      lastYear: "上年",
     },
     profitLoss: {
       fromLabel: "起始",

--- a/src/plugins/accounting/View.vue
+++ b/src/plugins/accounting/View.vue
@@ -88,7 +88,13 @@
             :opening-date="activeOpeningDate"
             :preselect-account-code="ledgerPreselectAccountCode"
           />
-          <BalanceSheet v-else-if="currentTab === 'balanceSheet'" :book-id="activeBookId" :currency="activeCurrency" :version="bookVersion" />
+          <BalanceSheet
+            v-else-if="currentTab === 'balanceSheet'"
+            :book-id="activeBookId"
+            :currency="activeCurrency"
+            :version="bookVersion"
+            @select-account="onAccountSelected"
+          />
           <ProfitLoss
             v-else-if="currentTab === 'profitLoss'"
             :book-id="activeBookId"
@@ -96,6 +102,7 @@
             :version="bookVersion"
             :fiscal-year-end="activeFiscalYearEnd"
             :opening-date="activeOpeningDate"
+            @select-account="onAccountSelected"
           />
           <BookSettings
             v-else-if="currentTab === 'settings'"

--- a/src/plugins/accounting/components/BalanceSheet.vue
+++ b/src/plugins/accounting/components/BalanceSheet.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="flex flex-col gap-3" data-testid="accounting-balance-sheet">
-    <div class="flex items-end gap-3">
+    <div class="flex flex-wrap items-end gap-3">
+      <label class="text-xs text-gray-500 flex flex-col gap-1">
+        {{ t("pluginAccounting.balanceSheet.shortcutLabel") }}
+        <select
+          :value="selectedShortcut"
+          class="h-8 px-2 rounded border border-gray-300 text-sm bg-white"
+          data-testid="accounting-bs-shortcut"
+          @change="onShortcutChange(($event.target as HTMLSelectElement).value)"
+        >
+          <option value="" hidden></option>
+          <option value="thisMonth">{{ t("pluginAccounting.balanceSheet.thisMonth") }}</option>
+          <option value="lastMonth">{{ t("pluginAccounting.balanceSheet.lastMonth") }}</option>
+          <option value="lastQuarter">{{ t("pluginAccounting.balanceSheet.lastQuarter") }}</option>
+          <option value="lastYear">{{ t("pluginAccounting.balanceSheet.lastYear") }}</option>
+        </select>
+      </label>
       <label class="text-xs text-gray-500 flex flex-col gap-1">
         {{ t("pluginAccounting.balanceSheet.asOfLabel") }}
         <input v-model="period" type="month" class="h-8 px-2 rounded border border-gray-300 text-sm" data-testid="accounting-bs-period" />
@@ -17,7 +32,23 @@
           <h4 class="text-sm font-semibold mb-2">{{ sectionLabel(section.type) }}</h4>
           <table class="w-full text-sm">
             <tbody>
-              <tr v-for="row in section.rows" :key="row.accountCode" class="border-b border-gray-100" :class="isEarningsRow(row) ? 'italic text-gray-600' : ''">
+              <tr
+                v-for="row in section.rows"
+                :key="row.accountCode"
+                class="border-b border-gray-100"
+                :class="
+                  isEarningsRow(row)
+                    ? 'italic text-gray-600'
+                    : 'hover:bg-blue-50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400'
+                "
+                :tabindex="isEarningsRow(row) ? -1 : 0"
+                :role="isEarningsRow(row) ? undefined : 'button'"
+                :aria-label="isEarningsRow(row) ? undefined : t('pluginAccounting.accounts.openLedgerAria', { code: row.accountCode, name: row.accountName })"
+                :data-testid="isEarningsRow(row) ? undefined : `accounting-bs-row-${row.accountCode}`"
+                @click="onRowClick(row)"
+                @keydown.enter.prevent.self="onKeyActivate($event, row)"
+                @keydown.space.prevent.self="onKeyActivate($event, row)"
+              >
                 <td class="py-1 px-1">
                   <span v-if="!isEarningsRow(row)" class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
                   >{{ rowName(row) }}
@@ -42,16 +73,17 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { getBalanceSheet, type BalanceSheet } from "../api";
 import { formatAmount as formatAmountWithCurrency } from "../currencies";
-import { localMonthString } from "../dates";
+import { decemberOfPreviousYearString, lastMonthOfPreviousQuarterString, localMonthString, previousMonthString } from "../dates";
 import { useLatestRequest } from "./useLatestRequest";
 
 const { t } = useI18n();
 
 const props = defineProps<{ bookId: string; currency: string; version: number }>();
+const emit = defineEmits<{ selectAccount: [code: string] }>();
 
 const period = ref(localMonthString());
 const balanceSheet = ref<BalanceSheet | null>(null);
@@ -90,6 +122,46 @@ function isEarningsRow(row: BSRow): boolean {
 
 function rowName(row: BSRow): string {
   return isEarningsRow(row) ? t("pluginAccounting.balanceSheet.currentEarnings") : row.accountName;
+}
+
+// Earnings row is synthetic (no underlying account on file), so it
+// can't be drilled into. Real-account rows route to the Ledger tab
+// pre-filtered to that account — same pattern as AccountsList.
+function onRowClick(row: BSRow): void {
+  if (isEarningsRow(row)) return;
+  emit("selectAccount", row.accountCode);
+}
+
+function onKeyActivate(event: KeyboardEvent, row: BSRow): void {
+  if (event.repeat) return;
+  if (isEarningsRow(row)) return;
+  emit("selectAccount", row.accountCode);
+}
+
+// Mirrors the DateRangePicker pattern: hidden "" sentinel for the
+// "no preset matches" custom state, otherwise the dropdown shows
+// whichever shortcut produces the current period. Re-evaluates `now`
+// on every read so the labels stay correct across midnight without
+// any cache-invalidation plumbing.
+type Shortcut = "thisMonth" | "lastMonth" | "lastQuarter" | "lastYear";
+type SelectedShortcut = Shortcut | "";
+
+const selectedShortcut = computed<SelectedShortcut>(() => {
+  const value = period.value;
+  const now = new Date();
+  if (value === localMonthString(now)) return "thisMonth";
+  if (value === previousMonthString(now)) return "lastMonth";
+  if (value === lastMonthOfPreviousQuarterString(now)) return "lastQuarter";
+  if (value === decemberOfPreviousYearString(now)) return "lastYear";
+  return "";
+});
+
+function onShortcutChange(raw: string): void {
+  const now = new Date();
+  if (raw === "thisMonth") period.value = localMonthString(now);
+  else if (raw === "lastMonth") period.value = previousMonthString(now);
+  else if (raw === "lastQuarter") period.value = lastMonthOfPreviousQuarterString(now);
+  else if (raw === "lastYear") period.value = decemberOfPreviousYearString(now);
 }
 
 async function refresh(): Promise<void> {

--- a/src/plugins/accounting/components/BalanceSheet.vue
+++ b/src/plugins/accounting/components/BalanceSheet.vue
@@ -147,7 +147,7 @@ type Shortcut = "thisMonth" | "lastMonth" | "lastQuarter" | "lastYear";
 type SelectedShortcut = Shortcut | "";
 
 const selectedShortcut = computed<SelectedShortcut>(() => {
-  const value = period.value;
+  const { value } = period;
   const now = new Date();
   if (value === localMonthString(now)) return "thisMonth";
   if (value === previousMonthString(now)) return "lastMonth";

--- a/src/plugins/accounting/components/JournalEntryForm.vue
+++ b/src/plugins/accounting/components/JournalEntryForm.vue
@@ -1,30 +1,19 @@
 <template>
   <form class="flex flex-col gap-3" data-testid="accounting-entry-form" @submit.prevent="onSubmit">
-    <div class="flex items-center justify-between gap-2">
-      <h3 class="text-base font-semibold">
-        {{ isEditing ? t("pluginAccounting.entryForm.editTitle") : t("pluginAccounting.entryForm.title") }}
-      </h3>
-      <button
-        type="button"
-        class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
-        data-testid="accounting-entry-manage-accounts"
-        @click="showAccountsModal = true"
-      >
-        <span class="material-icons text-base">tune</span>
-        <span>{{ t("pluginAccounting.accounts.manageButton") }}</span>
-      </button>
-    </div>
-    <p v-if="isEditing" class="text-xs text-gray-500" data-testid="accounting-entry-edit-banner">
-      {{ t("pluginAccounting.entryForm.editBanner") }}
-    </p>
+    <!-- Edit mode mounts inside the row's expanded detail panel,
+         which already gives the user enough context (the row above
+         shows date / kind / memo / lines). Hide the redundant
+         "Edit journal entry" title there; the editBanner below
+         still surfaces the void-and-replace consequence. -->
+    <h3 v-if="!isEditing" class="text-base font-semibold">{{ t("pluginAccounting.entryForm.title") }}</h3>
     <div class="flex flex-wrap gap-3">
       <label class="text-xs text-gray-500 flex flex-col gap-1">
         {{ t("pluginAccounting.entryForm.dateLabel") }}
-        <input v-model="date" type="date" required class="h-8 px-2 rounded border border-gray-300 text-sm" data-testid="accounting-entry-date" />
+        <input v-model="date" type="date" required class="h-8 px-2 rounded border border-gray-300 text-sm bg-white" data-testid="accounting-entry-date" />
       </label>
       <label class="text-xs text-gray-500 flex flex-col gap-1 grow min-w-0">
         {{ t("pluginAccounting.entryForm.memoLabel") }}
-        <input v-model="memo" type="text" class="h-8 px-2 rounded border border-gray-300 text-sm" data-testid="accounting-entry-memo" />
+        <input v-model="memo" type="text" class="h-8 px-2 rounded border border-gray-300 text-sm bg-white" data-testid="accounting-entry-memo" />
       </label>
     </div>
     <table class="w-full text-sm">
@@ -55,7 +44,7 @@
               type="number"
               :step="step"
               min="0"
-              class="h-8 px-2 w-full rounded border border-gray-300 text-sm text-right"
+              class="h-8 px-2 w-full rounded border border-gray-300 text-sm text-right bg-white"
               :data-testid="`accounting-entry-line-debit-${idx}`"
               @input="onDebitInput(line)"
             />
@@ -66,7 +55,7 @@
               type="number"
               :step="step"
               min="0"
-              class="h-8 px-2 w-full rounded border border-gray-300 text-sm text-right"
+              class="h-8 px-2 w-full rounded border border-gray-300 text-sm text-right bg-white"
               :data-testid="`accounting-entry-line-credit-${idx}`"
               @input="onCreditInput(line)"
             />
@@ -85,7 +74,7 @@
                 :maxlength="MAX_TAX_REGISTRATION_ID_LENGTH"
                 :placeholder="t('pluginAccounting.entryForm.taxRegistrationIdPlaceholder')"
                 :class="[
-                  'h-8 px-2 w-full rounded border text-sm font-mono focus:outline-none',
+                  'h-8 px-2 w-full rounded border text-sm font-mono bg-white focus:outline-none',
                   isTaxRegistrationIdInvalid(line)
                     ? 'border-red-500 ring-1 ring-red-500'
                     : isTaxRegistrationIdMissing(line)
@@ -120,38 +109,60 @@
       </tbody>
     </table>
     <div class="flex items-center justify-between">
-      <button
-        type="button"
-        class="h-8 px-2.5 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
-        data-testid="accounting-entry-add-line"
-        @click="addLine"
-      >
-        <span class="material-icons text-base align-middle">add</span>{{ t("pluginAccounting.entryForm.addLine") }}
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
+          data-testid="accounting-entry-add-line"
+          @click="addLine"
+        >
+          <span class="material-icons text-base">add</span>
+          <span>{{ t("pluginAccounting.entryForm.addLine") }}</span>
+        </button>
+        <button
+          type="button"
+          class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
+          data-testid="accounting-entry-manage-accounts"
+          @click="showAccountsModal = true"
+        >
+          <span class="material-icons text-base">tune</span>
+          <span>{{ t("pluginAccounting.accounts.manageButton") }}</span>
+        </button>
+      </div>
       <span :class="balanced ? 'text-green-600' : 'text-red-500'" class="text-xs" data-testid="accounting-entry-balance">
         {{ balanced ? t("pluginAccounting.entryForm.balanced") : t("pluginAccounting.entryForm.imbalance", { amount: imbalanceText }) }}
       </span>
     </div>
     <p v-if="error" class="text-xs text-red-500" data-testid="accounting-entry-error">{{ error }}</p>
     <p v-if="successMessage" class="text-xs text-green-600" data-testid="accounting-entry-success">{{ successMessage }}</p>
-    <div class="flex justify-end gap-2">
-      <button
-        type="button"
-        class="h-8 px-3 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
-        :disabled="submitting"
-        data-testid="accounting-entry-cancel-edit"
-        @click="emit('cancel')"
-      >
-        {{ t("pluginAccounting.common.cancel") }}
-      </button>
-      <button
-        type="submit"
-        class="h-8 px-3 rounded bg-blue-600 hover:bg-blue-700 text-white text-sm disabled:opacity-50"
-        :disabled="!balanced || submitting || editLocked"
-        data-testid="accounting-entry-submit"
-      >
-        {{ submitButtonLabel }}
-      </button>
+    <div class="flex items-center justify-between gap-2">
+      <!-- editBanner sits on the action row in edit mode (instead
+           of as a separate paragraph above the form) so the panel
+           is shorter and the user reads the void-and-replace
+           consequence right next to the button that triggers it. -->
+      <p v-if="isEditing" class="text-xs text-gray-500 flex-1 min-w-0" data-testid="accounting-entry-edit-banner">
+        {{ t("pluginAccounting.entryForm.editBanner") }}
+      </p>
+      <span v-else></span>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="h-8 px-3 rounded border border-gray-300 text-sm text-gray-600 hover:bg-gray-50"
+          :disabled="submitting"
+          data-testid="accounting-entry-cancel-edit"
+          @click="emit('cancel')"
+        >
+          {{ t("pluginAccounting.common.cancel") }}
+        </button>
+        <button
+          type="submit"
+          class="h-8 px-3 rounded bg-blue-600 hover:bg-blue-700 text-white text-sm disabled:opacity-50"
+          :disabled="!balanced || submitting || editLocked"
+          data-testid="accounting-entry-submit"
+        >
+          {{ submitButtonLabel }}
+        </button>
+      </div>
     </div>
   </form>
   <!-- Sibling of the parent <form> on purpose: the modal renders

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-3">
+  <div class="flex flex-col h-full gap-3">
     <!-- Top-row toolbar slot. Renders the embedded entry form
          in "+ New entry" mode here; Edit-mode for a row's existing
          entry is rendered IN-PLACE inside that row's expanded
@@ -40,143 +40,178 @@
         <span class="material-icons text-base align-middle">refresh</span>
       </button>
     </div>
-    <p v-if="loading" class="text-xs text-gray-400">{{ t("pluginAccounting.common.loading") }}</p>
-    <p v-else-if="error" class="text-xs text-red-500">{{ t("pluginAccounting.common.error", { error }) }}</p>
-    <p v-else-if="filteredEntries.length === 0" class="text-xs text-gray-400">{{ t("pluginAccounting.common.empty") }}</p>
-    <table v-else class="w-full text-sm" data-testid="accounting-journal-table">
-      <thead>
-        <tr class="text-xs text-gray-500 border-b border-gray-200">
-          <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.date") }}</th>
-          <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.kind") }}</th>
-          <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.memo") }}</th>
-          <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.lines") }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <template v-for="entry in filteredEntries" :key="entry.id">
-          <tr
-            :class="[
-              voidedEntryIds.has(entry.id) ? 'text-gray-400 line-through' : '',
-              'border-b border-gray-100 align-top cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
-            ]"
-            :data-testid="voidedEntryIds.has(entry.id) ? `accounting-journal-row-voided-${entry.id}` : `accounting-journal-row-${entry.id}`"
-            tabindex="0"
-            role="button"
-            :aria-expanded="expandedEntryId === entry.id"
-            @click="toggleExpanded(entry.id)"
-            @keydown.enter.prevent.self="onKeyToggle($event, entry.id)"
-            @keydown.space.prevent.self="onKeyToggle($event, entry.id)"
-          >
-            <td class="py-1 px-2 whitespace-nowrap">{{ entry.date }}</td>
-            <td class="py-1 px-2 text-xs">{{ kindLabel(entry.kind) }}</td>
-            <td class="py-1 px-2">
-              <span v-if="entry.memo">{{ entry.memo }}</span>
-            </td>
-            <td class="py-1 px-2">
-              <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
-                <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
-                <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
-                <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
-                <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
-              </div>
-            </td>
+    <!-- Scrollable list area: only the entries list scrolls below
+         this point. The new-entry slot + filter bar above stay
+         pinned by virtue of NOT being inside this scroll container,
+         and the column-header row stays visible via `position:
+         sticky` on its <th>s. `min-h-0` is required for the flex-1
+         child to actually shrink below its content height in a
+         flex-col parent. -->
+    <div class="flex-1 min-h-0 overflow-auto">
+      <p v-if="loading" class="text-xs text-gray-400">{{ t("pluginAccounting.common.loading") }}</p>
+      <p v-else-if="error" class="text-xs text-red-500">{{ t("pluginAccounting.common.error", { error }) }}</p>
+      <p v-else-if="filteredEntries.length === 0" class="text-xs text-gray-400">{{ t("pluginAccounting.common.empty") }}</p>
+      <table v-else class="w-full text-sm" data-testid="accounting-journal-table">
+        <thead>
+          <tr class="text-xs text-gray-500 border-b border-gray-200">
+            <!-- Per-<th> sticky (rather than `<thead class="sticky">`)
+                 for compatibility — `position: sticky` on the
+                 table-header-group display is brittle in some
+                 browsers, but on `<th>` it's universally supported.
+                 `bg-white` is required so the scrolled rows beneath
+                 don't bleed through. -->
+            <th class="sticky top-0 bg-white text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.date") }}</th>
+            <th class="sticky top-0 bg-white text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.kind") }}</th>
+            <th class="sticky top-0 bg-white text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.memo") }}</th>
+            <th class="sticky top-0 bg-white text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.lines") }}</th>
           </tr>
-          <tr v-if="expandedEntryId === entry.id" class="bg-gray-50" :data-testid="`accounting-journal-detail-${entry.id}`">
-            <td :colspan="4" class="px-6 py-2">
-              <!-- Edit-in-place: the JournalEntryForm replaces the
+        </thead>
+        <tbody>
+          <template v-for="entry in filteredEntries" :key="entry.id">
+            <tr
+              :class="[
+                voidedEntryIds.has(entry.id) ? 'text-gray-400 line-through' : '',
+                'border-b border-gray-100 align-top cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
+              ]"
+              :data-testid="voidedEntryIds.has(entry.id) ? `accounting-journal-row-voided-${entry.id}` : `accounting-journal-row-${entry.id}`"
+              tabindex="0"
+              role="button"
+              :aria-expanded="expandedEntryId === entry.id"
+              @click="toggleExpanded(entry.id)"
+              @keydown.enter.prevent.self="onKeyToggle($event, entry.id)"
+              @keydown.space.prevent.self="onKeyToggle($event, entry.id)"
+            >
+              <td class="py-1 px-2 whitespace-nowrap">{{ entry.date }}</td>
+              <td class="py-1 px-2 text-xs">{{ kindLabel(entry.kind) }}</td>
+              <td class="py-1 px-2">
+                <span v-if="entry.memo">{{ entry.memo }}</span>
+              </td>
+              <td class="py-1 px-2">
+                <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
+                  <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
+                  <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
+                  <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
+                  <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
+                </div>
+              </td>
+            </tr>
+            <tr v-if="expandedEntryId === entry.id" class="bg-gray-50" :data-testid="`accounting-journal-detail-${entry.id}`">
+              <td :colspan="4" class="px-6 py-2">
+                <!-- Edit-in-place: the JournalEntryForm replaces the
                    read-only detail content for this row when the
                    user clicks Edit. Submit / cancel collapses back
                    (submit also voids the original, so we clear the
                    selection); top-bar "+ New entry" stays a separate
                    path that opens the same form above the table. -->
-              <div v-if="entryBeingEdited?.id === entry.id" :data-testid="`accounting-journal-detail-edit-${entry.id}`">
-                <JournalEntryForm
-                  :book-id="bookId"
-                  :accounts="accounts"
-                  :currency="currency"
-                  :country="country"
-                  :entry-to-edit="entryBeingEdited"
-                  @submitted="onFormSubmitted"
-                  @cancel="onFormCancel"
-                />
-              </div>
-              <template v-else>
-                <!-- Detail header: Edit / Void on the left (when the
+                <div v-if="entryBeingEdited?.id === entry.id" :data-testid="`accounting-journal-detail-edit-${entry.id}`">
+                  <JournalEntryForm
+                    :book-id="bookId"
+                    :accounts="accounts"
+                    :currency="currency"
+                    :country="country"
+                    :entry-to-edit="entryBeingEdited"
+                    @submitted="onFormSubmitted"
+                    @cancel="onFormCancel"
+                  />
+                </div>
+                <template v-else>
+                  <!-- Detail header: Edit / Void on the left (when the
                      entry kind allows them), Close on the right. -->
-                <div class="flex items-center justify-between mb-2">
-                  <div class="flex items-center gap-3">
-                    <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
-                      <button class="text-xs text-blue-600 hover:underline" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+                  <div class="flex items-center justify-between mb-2">
+                    <div class="flex items-center gap-3">
+                      <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
+                        <button class="text-xs text-blue-600 hover:underline" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+                          {{ t("pluginAccounting.journalList.edit") }}
+                        </button>
+                        <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
+                          {{ t("pluginAccounting.journalList.void") }}
+                        </button>
+                      </template>
+                      <button
+                        v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
+                        class="text-xs text-blue-600 hover:underline"
+                        :data-testid="`accounting-edit-opening-${entry.id}`"
+                        @click="emit('editOpening')"
+                      >
                         {{ t("pluginAccounting.journalList.edit") }}
                       </button>
-                      <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
-                        {{ t("pluginAccounting.journalList.void") }}
-                      </button>
-                    </template>
+                    </div>
                     <button
-                      v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
-                      class="text-xs text-blue-600 hover:underline"
-                      :data-testid="`accounting-edit-opening-${entry.id}`"
-                      @click="emit('editOpening')"
+                      type="button"
+                      class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+                      :data-testid="`accounting-journal-detail-close-${entry.id}`"
+                      :aria-label="t('pluginAccounting.common.cancel')"
+                      @click="expandedEntryId = null"
                     >
-                      {{ t("pluginAccounting.journalList.edit") }}
+                      <span class="material-icons text-base">close</span>
                     </button>
                   </div>
-                  <button
-                    type="button"
-                    class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
-                    :data-testid="`accounting-journal-detail-close-${entry.id}`"
-                    :aria-label="t('pluginAccounting.common.cancel')"
-                    @click="expandedEntryId = null"
-                  >
-                    <span class="material-icons text-base">close</span>
-                  </button>
-                </div>
-                <table class="w-full text-xs">
-                  <thead>
-                    <tr class="text-gray-500 border-b border-gray-200">
-                      <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
-                      <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
-                      <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
-                      <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.memoLabel") }}</th>
-                      <th v-if="entryHasTaxIds(entry)" class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr v-for="(line, idx) in entry.lines" :key="idx" class="border-b border-gray-100 text-gray-700">
-                      <td class="py-1 px-2">
-                        <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
-                        <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
-                      </td>
-                      <td class="py-1 px-2 text-right font-mono">
-                        <template v-if="line.debit">{{ formatAmount(line.debit, currency) }}</template>
-                      </td>
-                      <td class="py-1 px-2 text-right font-mono">
-                        <template v-if="line.credit">{{ formatAmount(line.credit, currency) }}</template>
-                      </td>
-                      <td class="py-1 px-2">
-                        <template v-if="line.memo">{{ line.memo }}</template>
-                      </td>
-                      <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">
-                        <template v-if="line.taxRegistrationId">{{ line.taxRegistrationId }}</template>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tfoot>
-                    <tr class="font-semibold border-t border-gray-300 text-gray-700">
-                      <td class="py-1 px-2 text-gray-500">{{ t("pluginAccounting.balanceSheet.total") }}</td>
-                      <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryDebitTotal(entry), currency) }}</td>
-                      <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryCreditTotal(entry), currency) }}</td>
-                      <td :colspan="entryHasTaxIds(entry) ? 2 : 1"></td>
-                    </tr>
-                  </tfoot>
-                </table>
-              </template>
-            </td>
-          </tr>
-        </template>
-      </tbody>
-    </table>
+                  <!-- Entry-level metadata. The row above the panel
+                     shows these too, but with the new sticky-thead
+                     scroll behaviour the source row can scroll out
+                     of view while the panel remains pinned. Repeating
+                     date and (if present) memo here keeps the panel
+                     self-describing. Memo is only rendered when set
+                     so the line stays compact for terse entries. -->
+                  <div class="text-xs mb-2 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                    <div class="text-gray-700">
+                      <span class="font-mono">{{ entry.date }}</span>
+                      <span v-if="entry.memo">{{ memoSuffix(entry.memo) }}</span>
+                    </div>
+                    <!-- Posting timestamp (entry.createdAt). Distinct
+                       from entry.date — backdated entries diverge,
+                       and the void-replace edit flow stamps a fresh
+                       createdAt on the replacement. ml-auto keeps it
+                       flush right on wide rows; flex-wrap drops it
+                       to a new line when space is tight. -->
+                    <div class="text-gray-400 ml-auto font-mono">{{ formatCreatedAt(entry.createdAt) }}</div>
+                  </div>
+                  <table class="w-full text-xs">
+                    <thead>
+                      <tr class="text-gray-500 border-b border-gray-200">
+                        <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
+                        <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
+                        <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
+                        <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.memoLabel") }}</th>
+                        <th v-if="entryHasTaxIds(entry)" class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(line, idx) in entry.lines" :key="idx" class="border-b border-gray-100 text-gray-700">
+                        <td class="py-1 px-2">
+                          <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
+                          <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
+                        </td>
+                        <td class="py-1 px-2 text-right font-mono">
+                          <template v-if="line.debit">{{ formatAmount(line.debit, currency) }}</template>
+                        </td>
+                        <td class="py-1 px-2 text-right font-mono">
+                          <template v-if="line.credit">{{ formatAmount(line.credit, currency) }}</template>
+                        </td>
+                        <td class="py-1 px-2">
+                          <template v-if="line.memo">{{ line.memo }}</template>
+                        </td>
+                        <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">
+                          <template v-if="line.taxRegistrationId">{{ line.taxRegistrationId }}</template>
+                        </td>
+                      </tr>
+                    </tbody>
+                    <tfoot>
+                      <tr class="font-semibold border-t border-gray-300 text-gray-700">
+                        <td class="py-1 px-2 text-gray-500">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+                        <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryDebitTotal(entry), currency) }}</td>
+                        <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryCreditTotal(entry), currency) }}</td>
+                        <td :colspan="entryHasTaxIds(entry) ? 2 : 1"></td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </template>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -304,6 +339,25 @@ function formatAccountLabel(account: Account): string {
   // human-meaningful word; the code goes in trailing parens.
   // Same convention used by JournalEntryForm and Ledger pickers.
   return `${account.name} (${account.code})`;
+}
+// Memo suffix for the metadata line: turns `"rent payment"` into
+// `": rent payment"`. The leading ": " is built here so the template
+// stays free of raw-text literals (vue-i18n/no-raw-text flags string
+// literals — even in mustache expressions).
+function memoSuffix(memo: string): string {
+  return `: ${memo}`;
+}
+
+// `entry.createdAt` is server-stamped ISO 8601. We render local
+// date+time (no seconds, no timezone) in YYYY-MM-DD HH:MM form to
+// match `entry.date`'s style and keep the line compact. Parens are
+// baked in here so the template doesn't carry raw text (the
+// vue-i18n/no-raw-text rule flags literal strings in mustache).
+function formatCreatedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return `(${iso})`;
+  const pad = (num: number): string => String(num).padStart(2, "0");
+  return `(${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())})`;
 }
 const accountNameByCode = computed(() => {
   const map = new Map<string, string>();

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -50,7 +50,7 @@
     <div class="flex-1 min-h-0 overflow-auto">
       <p v-if="loading" class="text-xs text-gray-400">{{ t("pluginAccounting.common.loading") }}</p>
       <p v-else-if="error" class="text-xs text-red-500">{{ t("pluginAccounting.common.error", { error }) }}</p>
-      <p v-else-if="filteredEntries.length === 0" class="text-xs text-gray-400">{{ t("pluginAccounting.common.empty") }}</p>
+      <p v-else-if="visibleEntries.length === 0" class="text-xs text-gray-400">{{ t("pluginAccounting.common.empty") }}</p>
       <table v-else class="w-full text-sm" data-testid="accounting-journal-table">
         <thead>
           <tr class="text-xs text-gray-500 border-b border-gray-200">
@@ -67,7 +67,7 @@
           </tr>
         </thead>
         <tbody>
-          <template v-for="entry in filteredEntries" :key="entry.id">
+          <template v-for="entry in visibleEntries" :key="entry.id">
             <tr
               :class="[
                 voidedEntryIds.has(entry.id) ? 'text-gray-400 line-through' : '',
@@ -140,7 +140,7 @@
                       type="button"
                       class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
                       :data-testid="`accounting-journal-detail-close-${entry.id}`"
-                      :aria-label="t('pluginAccounting.common.cancel')"
+                      :aria-label="t('common.close')"
                       @click="expandedEntryId = null"
                     >
                       <span class="material-icons text-base">close</span>
@@ -428,6 +428,28 @@ async function refresh(): Promise<void> {
 }
 
 const filteredEntries = computed(() => entries.value);
+
+// Visible-list view that pins the entry currently being edited at
+// the top when a filter change or pubsub-driven refetch would
+// otherwise drop it from `filteredEntries`. Without this, the
+// in-place edit form (which is nested under the row's v-if /
+// v-for) would unmount and silently discard the user's draft when:
+//   • the user adjusts the date range or account filter,
+//   • a sibling tab / LLM tool voids the entry out-of-band and the
+//     SSE pubsub bumps `bookVersion`, refetching this list,
+//   • or a sibling tab / LLM tool deletes the underlying book.
+// Pinning the editing entry from the local snapshot (entryBeingEdited)
+// keeps the form mounted across all three. The pinned row sits at
+// the top of the table while editing; on submit / cancel the
+// snapshot clears and the list reverts to filteredEntries.
+const visibleEntries = computed<JournalEntry[]>(() => {
+  const list = filteredEntries.value;
+  const editing = entryBeingEdited.value;
+  if (editing && !list.some((entry) => entry.id === editing.id)) {
+    return [editing, ...list];
+  }
+  return list;
+});
 
 // Set of original entry ids that have been voided. The server
 // computes this from the *unfiltered* journal (so an account-filtered

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -148,10 +148,18 @@
                         <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
                         <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
                       </td>
-                      <td class="py-1 px-2 text-right font-mono">{{ line.debit ? formatAmount(line.debit, currency) : "" }}</td>
-                      <td class="py-1 px-2 text-right font-mono">{{ line.credit ? formatAmount(line.credit, currency) : "" }}</td>
-                      <td class="py-1 px-2">{{ line.memo ?? "" }}</td>
-                      <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">{{ line.taxRegistrationId ?? "" }}</td>
+                      <td class="py-1 px-2 text-right font-mono">
+                        <template v-if="line.debit">{{ formatAmount(line.debit, currency) }}</template>
+                      </td>
+                      <td class="py-1 px-2 text-right font-mono">
+                        <template v-if="line.credit">{{ formatAmount(line.credit, currency) }}</template>
+                      </td>
+                      <td class="py-1 px-2">
+                        <template v-if="line.memo">{{ line.memo }}</template>
+                      </td>
+                      <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">
+                        <template v-if="line.taxRegistrationId">{{ line.taxRegistrationId }}</template>
+                      </td>
                     </tr>
                   </tbody>
                   <tfoot>
@@ -209,6 +217,13 @@ const emit = defineEmits<{ editOpening: [] }>();
 // submit label; the top-bar instance always passes null.
 const showNewForm = ref(false);
 const entryBeingEdited = ref<JournalEntry | null>(null);
+// Single-selection detail expansion. Clicking a row swaps the
+// selection (or collapses if it's already the selected row).
+// Cleared on book switch via the closeForm watcher; entries deleted
+// between fetches simply drop out of filteredEntries, so a stale id
+// here just renders no detail row. Declared early so the
+// onFormSubmitted / bookId-watcher callbacks below can reference it.
+const expandedEntryId = ref<string | null>(null);
 
 function onOpenNewEntry(): void {
   entryBeingEdited.value = null;
@@ -298,13 +313,6 @@ const accountNameByCode = computed(() => {
 function accountNameFor(code: string): string | null {
   return accountNameByCode.value.get(code) ?? null;
 }
-
-// Single-selection detail expansion. Clicking a row swaps the
-// selection (or collapses if it's already the selected row).
-// Cleared on book switch via the closeForm watcher; entries deleted
-// between fetches simply drop out of filteredEntries, so a stale id
-// here just renders no detail row.
-const expandedEntryId = ref<string | null>(null);
 
 function toggleExpanded(entryId: string): void {
   // While the row is in edit mode for itself, ignore clicks on the

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -50,7 +50,6 @@
           <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.kind") }}</th>
           <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.memo") }}</th>
           <th class="text-left py-1 px-2">{{ t("pluginAccounting.journalList.columns.lines") }}</th>
-          <th class="py-1 px-2"></th>
         </tr>
       </thead>
       <tbody>
@@ -81,40 +80,45 @@
                 <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
               </div>
             </td>
-            <!-- Stop the toggle from firing when the user reaches for
-                 Edit / Void — those rails already handle their own
-                 navigation / confirm dialog and shouldn't double as a
-                 detail-expand trigger. -->
-            <td class="py-1 px-2 text-right whitespace-nowrap" @click.stop>
-              <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
-                <button class="text-xs text-blue-600 hover:underline mr-2" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
-                  {{ t("pluginAccounting.journalList.edit") }}
-                </button>
-                <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
-                  {{ t("pluginAccounting.journalList.void") }}
-                </button>
-              </template>
-              <button
-                v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
-                class="text-xs text-blue-600 hover:underline"
-                :data-testid="`accounting-edit-opening-${entry.id}`"
-                @click="emit('editOpening')"
-              >
-                {{ t("pluginAccounting.journalList.edit") }}
-              </button>
-            </td>
           </tr>
           <tr v-if="expandedEntryId === entry.id" class="bg-gray-50" :data-testid="`accounting-journal-detail-${entry.id}`">
-            <td :colspan="5" class="px-6 py-2 relative">
-              <button
-                type="button"
-                class="absolute top-1 right-2 h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
-                :data-testid="`accounting-journal-detail-close-${entry.id}`"
-                :aria-label="t('pluginAccounting.common.cancel')"
-                @click="expandedEntryId = null"
-              >
-                <span class="material-icons text-base">close</span>
-              </button>
+            <td :colspan="4" class="px-6 py-2">
+              <!-- Detail header: Edit / Void on the left (when the
+                   entry kind allows them), Close on the right. The
+                   Edit / Void buttons used to live in a per-row
+                   action cell on the journal table — moving them
+                   here keeps the row clean and gives the buttons
+                   more breathing room next to the detail panel they
+                   act on. -->
+              <div class="flex items-center justify-between mb-2">
+                <div class="flex items-center gap-3">
+                  <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
+                    <button class="text-xs text-blue-600 hover:underline" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+                      {{ t("pluginAccounting.journalList.edit") }}
+                    </button>
+                    <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
+                      {{ t("pluginAccounting.journalList.void") }}
+                    </button>
+                  </template>
+                  <button
+                    v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
+                    class="text-xs text-blue-600 hover:underline"
+                    :data-testid="`accounting-edit-opening-${entry.id}`"
+                    @click="emit('editOpening')"
+                  >
+                    {{ t("pluginAccounting.journalList.edit") }}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+                  :data-testid="`accounting-journal-detail-close-${entry.id}`"
+                  :aria-label="t('pluginAccounting.common.cancel')"
+                  @click="expandedEntryId = null"
+                >
+                  <span class="material-icons text-base">close</span>
+                </button>
+              </div>
               <table class="w-full text-xs">
                 <thead>
                   <tr class="text-gray-500 border-b border-gray-200">

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="flex flex-col gap-3">
     <!-- Top-row toolbar slot. Renders the embedded entry form
-         in-place when the user opens "New entry" or clicks Edit
-         on a journal row; otherwise just the "+ New entry"
-         button. The date picker / account filter / table below
-         stay visible in either state. -->
-    <div v-if="showForm" class="border border-gray-200 rounded p-3" data-testid="accounting-journal-inline-form">
+         in "+ New entry" mode here; Edit-mode for a row's existing
+         entry is rendered IN-PLACE inside that row's expanded
+         detail panel below. The date picker / account filter /
+         table below stay visible in either state. -->
+    <div v-if="showNewForm" class="border border-gray-200 rounded p-3" data-testid="accounting-journal-inline-form">
       <JournalEntryForm
         :book-id="bookId"
         :accounts="accounts"
         :currency="currency"
         :country="country"
-        :entry-to-edit="entryBeingEdited"
+        :entry-to-edit="null"
         @submitted="onFormSubmitted"
         @cancel="onFormCancel"
       />
@@ -83,73 +83,87 @@
           </tr>
           <tr v-if="expandedEntryId === entry.id" class="bg-gray-50" :data-testid="`accounting-journal-detail-${entry.id}`">
             <td :colspan="4" class="px-6 py-2">
-              <!-- Detail header: Edit / Void on the left (when the
-                   entry kind allows them), Close on the right. The
-                   Edit / Void buttons used to live in a per-row
-                   action cell on the journal table — moving them
-                   here keeps the row clean and gives the buttons
-                   more breathing room next to the detail panel they
-                   act on. -->
-              <div class="flex items-center justify-between mb-2">
-                <div class="flex items-center gap-3">
-                  <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
-                    <button class="text-xs text-blue-600 hover:underline" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+              <!-- Edit-in-place: the JournalEntryForm replaces the
+                   read-only detail content for this row when the
+                   user clicks Edit. Submit / cancel collapses back
+                   (submit also voids the original, so we clear the
+                   selection); top-bar "+ New entry" stays a separate
+                   path that opens the same form above the table. -->
+              <div v-if="entryBeingEdited?.id === entry.id" :data-testid="`accounting-journal-detail-edit-${entry.id}`">
+                <JournalEntryForm
+                  :book-id="bookId"
+                  :accounts="accounts"
+                  :currency="currency"
+                  :country="country"
+                  :entry-to-edit="entryBeingEdited"
+                  @submitted="onFormSubmitted"
+                  @cancel="onFormCancel"
+                />
+              </div>
+              <template v-else>
+                <!-- Detail header: Edit / Void on the left (when the
+                     entry kind allows them), Close on the right. -->
+                <div class="flex items-center justify-between mb-2">
+                  <div class="flex items-center gap-3">
+                    <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
+                      <button class="text-xs text-blue-600 hover:underline" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+                        {{ t("pluginAccounting.journalList.edit") }}
+                      </button>
+                      <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
+                        {{ t("pluginAccounting.journalList.void") }}
+                      </button>
+                    </template>
+                    <button
+                      v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
+                      class="text-xs text-blue-600 hover:underline"
+                      :data-testid="`accounting-edit-opening-${entry.id}`"
+                      @click="emit('editOpening')"
+                    >
                       {{ t("pluginAccounting.journalList.edit") }}
                     </button>
-                    <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
-                      {{ t("pluginAccounting.journalList.void") }}
-                    </button>
-                  </template>
+                  </div>
                   <button
-                    v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
-                    class="text-xs text-blue-600 hover:underline"
-                    :data-testid="`accounting-edit-opening-${entry.id}`"
-                    @click="emit('editOpening')"
+                    type="button"
+                    class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+                    :data-testid="`accounting-journal-detail-close-${entry.id}`"
+                    :aria-label="t('pluginAccounting.common.cancel')"
+                    @click="expandedEntryId = null"
                   >
-                    {{ t("pluginAccounting.journalList.edit") }}
+                    <span class="material-icons text-base">close</span>
                   </button>
                 </div>
-                <button
-                  type="button"
-                  class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
-                  :data-testid="`accounting-journal-detail-close-${entry.id}`"
-                  :aria-label="t('pluginAccounting.common.cancel')"
-                  @click="expandedEntryId = null"
-                >
-                  <span class="material-icons text-base">close</span>
-                </button>
-              </div>
-              <table class="w-full text-xs">
-                <thead>
-                  <tr class="text-gray-500 border-b border-gray-200">
-                    <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
-                    <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
-                    <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
-                    <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.memoLabel") }}</th>
-                    <th v-if="entryHasTaxIds(entry)" class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="(line, idx) in entry.lines" :key="idx" class="border-b border-gray-100 text-gray-700">
-                    <td class="py-1 px-2">
-                      <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
-                      <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
-                    </td>
-                    <td class="py-1 px-2 text-right font-mono">{{ line.debit ? formatAmount(line.debit, currency) : "" }}</td>
-                    <td class="py-1 px-2 text-right font-mono">{{ line.credit ? formatAmount(line.credit, currency) : "" }}</td>
-                    <td class="py-1 px-2">{{ line.memo ?? "" }}</td>
-                    <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">{{ line.taxRegistrationId ?? "" }}</td>
-                  </tr>
-                </tbody>
-                <tfoot>
-                  <tr class="font-semibold border-t border-gray-300 text-gray-700">
-                    <td class="py-1 px-2 text-gray-500">{{ t("pluginAccounting.balanceSheet.total") }}</td>
-                    <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryDebitTotal(entry), currency) }}</td>
-                    <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryCreditTotal(entry), currency) }}</td>
-                    <td :colspan="entryHasTaxIds(entry) ? 2 : 1"></td>
-                  </tr>
-                </tfoot>
-              </table>
+                <table class="w-full text-xs">
+                  <thead>
+                    <tr class="text-gray-500 border-b border-gray-200">
+                      <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
+                      <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
+                      <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
+                      <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.memoLabel") }}</th>
+                      <th v-if="entryHasTaxIds(entry)" class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(line, idx) in entry.lines" :key="idx" class="border-b border-gray-100 text-gray-700">
+                      <td class="py-1 px-2">
+                        <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
+                        <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
+                      </td>
+                      <td class="py-1 px-2 text-right font-mono">{{ line.debit ? formatAmount(line.debit, currency) : "" }}</td>
+                      <td class="py-1 px-2 text-right font-mono">{{ line.credit ? formatAmount(line.credit, currency) : "" }}</td>
+                      <td class="py-1 px-2">{{ line.memo ?? "" }}</td>
+                      <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">{{ line.taxRegistrationId ?? "" }}</td>
+                    </tr>
+                  </tbody>
+                  <tfoot>
+                    <tr class="font-semibold border-t border-gray-300 text-gray-700">
+                      <td class="py-1 px-2 text-gray-500">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+                      <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryDebitTotal(entry), currency) }}</td>
+                      <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryCreditTotal(entry), currency) }}</td>
+                      <td :colspan="entryHasTaxIds(entry) ? 2 : 1"></td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </template>
             </td>
           </tr>
         </template>
@@ -185,15 +199,16 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ editOpening: [] }>();
 
-// Inline-form state. The form replaces the toolbar slot when either
-// rail is active:
-//   • showNewForm = true → blank draft (the "+ New entry" button).
-//   • entryBeingEdited != null → edit mode, prefilled from the row.
-// Both flow through the same <JournalEntryForm>; the form looks at
-// `entryToEdit` to decide its title / submit label.
+// Inline-form state. Two distinct surfaces, one component:
+//   • showNewForm = true → blank draft, rendered above the table
+//     where the "+ New entry" button used to be.
+//   • entryBeingEdited != null → edit mode, rendered IN-PLACE inside
+//     the matching row's expanded detail panel (replacing the read-
+//     only debit/credit table for that row).
+// `<JournalEntryForm>` looks at `entryToEdit` to decide its title /
+// submit label; the top-bar instance always passes null.
 const showNewForm = ref(false);
 const entryBeingEdited = ref<JournalEntry | null>(null);
-const showForm = computed<boolean>(() => showNewForm.value || entryBeingEdited.value !== null);
 
 function onOpenNewEntry(): void {
   entryBeingEdited.value = null;
@@ -219,6 +234,10 @@ function onFormSubmitted(): void {
   // tab repaint, and skipping it here also makes the e2e mock
   // path (no pubsub replay) deterministic.
   closeForm();
+  // After an in-place edit submit, the original entry is voided
+  // and replaced. Collapse the detail panel since it was pointing
+  // at an entry that's now superseded.
+  expandedEntryId.value = null;
   void refresh();
 }
 
@@ -288,7 +307,16 @@ function accountNameFor(code: string): string | null {
 const expandedEntryId = ref<string | null>(null);
 
 function toggleExpanded(entryId: string): void {
+  // While the row is in edit mode for itself, ignore clicks on the
+  // row chrome (date / kind / memo / lines cells) — the user is
+  // actively typing into the form below and a stray cell click
+  // shouldn't collapse the panel. Cancel / Submit on the form, or
+  // clicking a different row, are the deliberate exits.
+  if (entryBeingEdited.value?.id === entryId) return;
   expandedEntryId.value = expandedEntryId.value === entryId ? null : entryId;
+  // Switching to a different row (or collapsing) drops any
+  // in-progress edit on the prior row.
+  entryBeingEdited.value = null;
 }
 
 function onKeyToggle(event: KeyboardEvent, entryId: string): void {

--- a/src/plugins/accounting/components/JournalList.vue
+++ b/src/plugins/accounting/components/JournalList.vue
@@ -54,45 +54,101 @@
         </tr>
       </thead>
       <tbody>
-        <tr
-          v-for="entry in filteredEntries"
-          :key="entry.id"
-          :class="voidedEntryIds.has(entry.id) ? 'text-gray-400 line-through' : ''"
-          :data-testid="voidedEntryIds.has(entry.id) ? `accounting-journal-row-voided-${entry.id}` : `accounting-journal-row-${entry.id}`"
-          class="border-b border-gray-100 align-top"
-        >
-          <td class="py-1 px-2 whitespace-nowrap">{{ entry.date }}</td>
-          <td class="py-1 px-2 text-xs">{{ kindLabel(entry.kind) }}</td>
-          <td class="py-1 px-2">
-            <span v-if="entry.memo">{{ entry.memo }}</span>
-          </td>
-          <td class="py-1 px-2">
-            <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
-              <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
-              <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
-              <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
-              <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
-            </div>
-          </td>
-          <td class="py-1 px-2 text-right whitespace-nowrap">
-            <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
-              <button class="text-xs text-blue-600 hover:underline mr-2" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+        <template v-for="entry in filteredEntries" :key="entry.id">
+          <tr
+            :class="[
+              voidedEntryIds.has(entry.id) ? 'text-gray-400 line-through' : '',
+              'border-b border-gray-100 align-top cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
+            ]"
+            :data-testid="voidedEntryIds.has(entry.id) ? `accounting-journal-row-voided-${entry.id}` : `accounting-journal-row-${entry.id}`"
+            tabindex="0"
+            role="button"
+            :aria-expanded="expandedEntryId === entry.id"
+            @click="toggleExpanded(entry.id)"
+            @keydown.enter.prevent.self="onKeyToggle($event, entry.id)"
+            @keydown.space.prevent.self="onKeyToggle($event, entry.id)"
+          >
+            <td class="py-1 px-2 whitespace-nowrap">{{ entry.date }}</td>
+            <td class="py-1 px-2 text-xs">{{ kindLabel(entry.kind) }}</td>
+            <td class="py-1 px-2">
+              <span v-if="entry.memo">{{ entry.memo }}</span>
+            </td>
+            <td class="py-1 px-2">
+              <div v-for="(line, idx) in entry.lines" :key="idx" class="text-xs flex gap-2 items-baseline">
+                <span class="font-mono text-[10px] text-gray-400">{{ line.accountCode }}</span>
+                <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
+                <span v-if="line.debit">{{ formatDebit(line.debit) }}</span>
+                <span v-if="line.credit">{{ formatCredit(line.credit) }}</span>
+              </div>
+            </td>
+            <!-- Stop the toggle from firing when the user reaches for
+                 Edit / Void — those rails already handle their own
+                 navigation / confirm dialog and shouldn't double as a
+                 detail-expand trigger. -->
+            <td class="py-1 px-2 text-right whitespace-nowrap" @click.stop>
+              <template v-if="entry.kind === 'normal' && !voidedEntryIds.has(entry.id)">
+                <button class="text-xs text-blue-600 hover:underline mr-2" :data-testid="`accounting-edit-${entry.id}`" @click="onEditEntry(entry)">
+                  {{ t("pluginAccounting.journalList.edit") }}
+                </button>
+                <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
+                  {{ t("pluginAccounting.journalList.void") }}
+                </button>
+              </template>
+              <button
+                v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
+                class="text-xs text-blue-600 hover:underline"
+                :data-testid="`accounting-edit-opening-${entry.id}`"
+                @click="emit('editOpening')"
+              >
                 {{ t("pluginAccounting.journalList.edit") }}
               </button>
-              <button class="text-xs text-red-500 hover:underline" :data-testid="`accounting-void-${entry.id}`" @click="onVoid(entry)">
-                {{ t("pluginAccounting.journalList.void") }}
+            </td>
+          </tr>
+          <tr v-if="expandedEntryId === entry.id" class="bg-gray-50" :data-testid="`accounting-journal-detail-${entry.id}`">
+            <td :colspan="5" class="px-6 py-2 relative">
+              <button
+                type="button"
+                class="absolute top-1 right-2 h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+                :data-testid="`accounting-journal-detail-close-${entry.id}`"
+                :aria-label="t('pluginAccounting.common.cancel')"
+                @click="expandedEntryId = null"
+              >
+                <span class="material-icons text-base">close</span>
               </button>
-            </template>
-            <button
-              v-else-if="entry.kind === 'opening' && !voidedEntryIds.has(entry.id)"
-              class="text-xs text-blue-600 hover:underline"
-              :data-testid="`accounting-edit-opening-${entry.id}`"
-              @click="emit('editOpening')"
-            >
-              {{ t("pluginAccounting.journalList.edit") }}
-            </button>
-          </td>
-        </tr>
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="text-gray-500 border-b border-gray-200">
+                    <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.accountLabel") }}</th>
+                    <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.debitLabel") }}</th>
+                    <th class="text-right py-1 px-2">{{ t("pluginAccounting.entryForm.creditLabel") }}</th>
+                    <th class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.memoLabel") }}</th>
+                    <th v-if="entryHasTaxIds(entry)" class="text-left py-1 px-2">{{ t("pluginAccounting.entryForm.taxRegistrationIdLabel") }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(line, idx) in entry.lines" :key="idx" class="border-b border-gray-100 text-gray-700">
+                    <td class="py-1 px-2">
+                      <span class="font-mono text-[10px] text-gray-400 mr-2">{{ line.accountCode }}</span>
+                      <span v-if="accountNameFor(line.accountCode)">{{ accountNameFor(line.accountCode) }}</span>
+                    </td>
+                    <td class="py-1 px-2 text-right font-mono">{{ line.debit ? formatAmount(line.debit, currency) : "" }}</td>
+                    <td class="py-1 px-2 text-right font-mono">{{ line.credit ? formatAmount(line.credit, currency) : "" }}</td>
+                    <td class="py-1 px-2">{{ line.memo ?? "" }}</td>
+                    <td v-if="entryHasTaxIds(entry)" class="py-1 px-2 font-mono text-[10px]">{{ line.taxRegistrationId ?? "" }}</td>
+                  </tr>
+                </tbody>
+                <tfoot>
+                  <tr class="font-semibold border-t border-gray-300 text-gray-700">
+                    <td class="py-1 px-2 text-gray-500">{{ t("pluginAccounting.balanceSheet.total") }}</td>
+                    <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryDebitTotal(entry), currency) }}</td>
+                    <td class="py-1 px-2 text-right font-mono">{{ formatAmount(entryCreditTotal(entry), currency) }}</td>
+                    <td :colspan="entryHasTaxIds(entry) ? 2 : 1"></td>
+                  </tr>
+                </tfoot>
+              </table>
+            </td>
+          </tr>
+        </template>
       </tbody>
     </table>
   </div>
@@ -101,7 +157,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { getJournalEntries, voidEntry, type Account, type JournalEntry, type JournalEntryKind } from "../api";
+import { getJournalEntries, voidEntry, type Account, type JournalEntry, type JournalEntryKind, type JournalLine } from "../api";
 import { formatAmount } from "../currencies";
 import { currentFiscalYearRange, resolveFiscalYearEnd, type DateRange, type FiscalYearEnd } from "../fiscalYear";
 import type { SupportedCountryCode } from "../countries";
@@ -173,7 +229,10 @@ function onFormCancel(): void {
 // neutral "+ New entry" surface.
 watch(
   () => props.bookId,
-  () => closeForm(),
+  () => {
+    closeForm();
+    expandedEntryId.value = null;
+  },
 );
 
 const resolvedFiscalYearEnd = computed<FiscalYearEnd>(() => resolveFiscalYearEnd(props.fiscalYearEnd));
@@ -215,6 +274,38 @@ const accountNameByCode = computed(() => {
 });
 function accountNameFor(code: string): string | null {
   return accountNameByCode.value.get(code) ?? null;
+}
+
+// Single-selection detail expansion. Clicking a row swaps the
+// selection (or collapses if it's already the selected row).
+// Cleared on book switch via the closeForm watcher; entries deleted
+// between fetches simply drop out of filteredEntries, so a stale id
+// here just renders no detail row.
+const expandedEntryId = ref<string | null>(null);
+
+function toggleExpanded(entryId: string): void {
+  expandedEntryId.value = expandedEntryId.value === entryId ? null : entryId;
+}
+
+function onKeyToggle(event: KeyboardEvent, entryId: string): void {
+  if (event.repeat) return;
+  toggleExpanded(entryId);
+}
+
+function entryHasTaxIds(entry: JournalEntry): boolean {
+  return entry.lines.some((line) => Boolean(line.taxRegistrationId));
+}
+
+function sumLines(lines: JournalLine[], pick: (line: JournalLine) => number | undefined): number {
+  return lines.reduce((acc, line) => acc + (pick(line) ?? 0), 0);
+}
+
+function entryDebitTotal(entry: JournalEntry): number {
+  return sumLines(entry.lines, (line) => line.debit);
+}
+
+function entryCreditTotal(entry: JournalEntry): number {
+  return sumLines(entry.lines, (line) => line.credit);
 }
 
 async function refresh(): Promise<void> {

--- a/src/plugins/accounting/components/ProfitLoss.vue
+++ b/src/plugins/accounting/components/ProfitLoss.vue
@@ -13,7 +13,18 @@
         <h4 class="text-sm font-semibold mb-2">{{ t("pluginAccounting.profitLoss.income") }}</h4>
         <table class="w-full text-sm">
           <tbody>
-            <tr v-for="row in profitLoss.income.rows" :key="row.accountCode" class="border-b border-gray-100">
+            <tr
+              v-for="row in profitLoss.income.rows"
+              :key="row.accountCode"
+              class="border-b border-gray-100 hover:bg-blue-50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              tabindex="0"
+              role="button"
+              :aria-label="t('pluginAccounting.accounts.openLedgerAria', { code: row.accountCode, name: row.accountName })"
+              :data-testid="`accounting-pl-row-${row.accountCode}`"
+              @click="onRowClick(row.accountCode)"
+              @keydown.enter.prevent.self="onKeyActivate($event, row.accountCode)"
+              @keydown.space.prevent.self="onKeyActivate($event, row.accountCode)"
+            >
               <td class="py-1 px-1">
                 <span class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
                 >{{ row.accountName }}
@@ -33,7 +44,18 @@
         <h4 class="text-sm font-semibold mb-2">{{ t("pluginAccounting.profitLoss.expense") }}</h4>
         <table class="w-full text-sm">
           <tbody>
-            <tr v-for="row in profitLoss.expense.rows" :key="row.accountCode" class="border-b border-gray-100">
+            <tr
+              v-for="row in profitLoss.expense.rows"
+              :key="row.accountCode"
+              class="border-b border-gray-100 hover:bg-blue-50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              tabindex="0"
+              role="button"
+              :aria-label="t('pluginAccounting.accounts.openLedgerAria', { code: row.accountCode, name: row.accountName })"
+              :data-testid="`accounting-pl-row-${row.accountCode}`"
+              @click="onRowClick(row.accountCode)"
+              @keydown.enter.prevent.self="onKeyActivate($event, row.accountCode)"
+              @keydown.space.prevent.self="onKeyActivate($event, row.accountCode)"
+            >
               <td class="py-1 px-1">
                 <span class="font-mono text-[10px] text-gray-400 mr-2">{{ row.accountCode }}</span
                 >{{ row.accountName }}
@@ -79,7 +101,18 @@ const props = defineProps<{
   openingDate?: string;
 }>();
 
+const emit = defineEmits<{ selectAccount: [code: string] }>();
+
 const resolvedFiscalYearEnd = computed<FiscalYearEnd>(() => resolveFiscalYearEnd(props.fiscalYearEnd));
+
+function onRowClick(code: string): void {
+  emit("selectAccount", code);
+}
+
+function onKeyActivate(event: KeyboardEvent, code: string): void {
+  if (event.repeat) return;
+  emit("selectAccount", code);
+}
 
 // Default = current fiscal year. Reset by the bookId/fiscalYearEnd
 // watcher below so switching books or changing the FY-end in

--- a/src/plugins/accounting/dates.ts
+++ b/src/plugins/accounting/dates.ts
@@ -29,3 +29,23 @@ export function localMonthString(now: Date = new Date()): string {
 export function localStartOfYearString(now: Date = new Date()): string {
   return `${now.getFullYear()}-01-01`;
 }
+
+/** Previous calendar month as `YYYY-MM` in the user's local timezone. */
+export function previousMonthString(now: Date = new Date()): string {
+  const d = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
+}
+
+/** Last month of the previous calendar quarter as `YYYY-MM`. Calendar
+ *  quarters: Q1=Jan–Mar, Q2=Apr–Jun, Q3=Jul–Sep, Q4=Oct–Dec. When the
+ *  current month is in Q1, this rolls back to December of last year. */
+export function lastMonthOfPreviousQuarterString(now: Date = new Date()): string {
+  const firstMonthOfCurrentQuarter = Math.floor(now.getMonth() / 3) * 3;
+  const d = new Date(now.getFullYear(), firstMonthOfCurrentQuarter - 1, 1);
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
+}
+
+/** December of the previous calendar year as `YYYY-MM`. */
+export function decemberOfPreviousYearString(now: Date = new Date()): string {
+  return `${now.getFullYear() - 1}-12`;
+}

--- a/src/plugins/accounting/dates.ts
+++ b/src/plugins/accounting/dates.ts
@@ -32,8 +32,8 @@ export function localStartOfYearString(now: Date = new Date()): string {
 
 /** Previous calendar month as `YYYY-MM` in the user's local timezone. */
 export function previousMonthString(now: Date = new Date()): string {
-  const d = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
+  const target = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${target.getFullYear()}-${pad2(target.getMonth() + 1)}`;
 }
 
 /** Last month of the previous calendar quarter as `YYYY-MM`. Calendar
@@ -41,8 +41,8 @@ export function previousMonthString(now: Date = new Date()): string {
  *  current month is in Q1, this rolls back to December of last year. */
 export function lastMonthOfPreviousQuarterString(now: Date = new Date()): string {
   const firstMonthOfCurrentQuarter = Math.floor(now.getMonth() / 3) * 3;
-  const d = new Date(now.getFullYear(), firstMonthOfCurrentQuarter - 1, 1);
-  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
+  const target = new Date(now.getFullYear(), firstMonthOfCurrentQuarter - 1, 1);
+  return `${target.getFullYear()}-${pad2(target.getMonth() + 1)}`;
 }
 
 /** December of the previous calendar year as `YYYY-MM`. */

--- a/test/plugins/accounting/test_dates.ts
+++ b/test/plugins/accounting/test_dates.ts
@@ -1,0 +1,62 @@
+// Boundary tests for the local-calendar shortcut helpers added to
+// src/plugins/accounting/dates.ts. These drive the Balance Sheet's
+// Period dropdown (This month / Last month / Last quarter / Last
+// year), so a regression here would silently hand the user the
+// wrong as-of period.
+//
+// Pure functions — no Vue / DOM. Each helper accepts an injected
+// `now` so we don't depend on the test runner's clock.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { decemberOfPreviousYearString, lastMonthOfPreviousQuarterString, previousMonthString } from "../../../src/plugins/accounting/dates.ts";
+
+describe("previousMonthString", () => {
+  it("returns the previous calendar month as YYYY-MM", () => {
+    assert.equal(previousMonthString(new Date(2026, 4, 15)), "2026-04");
+    assert.equal(previousMonthString(new Date(2026, 6, 1)), "2026-06");
+    assert.equal(previousMonthString(new Date(2026, 11, 31)), "2026-11");
+  });
+
+  it("rolls back to December of last year when current month is January", () => {
+    assert.equal(previousMonthString(new Date(2026, 0, 1)), "2025-12");
+    assert.equal(previousMonthString(new Date(2026, 0, 31)), "2025-12");
+  });
+});
+
+describe("lastMonthOfPreviousQuarterString", () => {
+  it("Q2 → March of the same year", () => {
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 3, 1)), "2026-03");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 4, 15)), "2026-03");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 5, 30)), "2026-03");
+  });
+
+  it("Q3 → June of the same year", () => {
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 6, 1)), "2026-06");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 8, 30)), "2026-06");
+  });
+
+  it("Q4 → September of the same year", () => {
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 9, 1)), "2026-09");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 11, 31)), "2026-09");
+  });
+
+  it("Q1 → December of last year", () => {
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 0, 1)), "2025-12");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 1, 28)), "2025-12");
+    assert.equal(lastMonthOfPreviousQuarterString(new Date(2026, 2, 31)), "2025-12");
+  });
+});
+
+describe("decemberOfPreviousYearString", () => {
+  it("returns YYYY-12 for the year before `now`", () => {
+    assert.equal(decemberOfPreviousYearString(new Date(2026, 4, 15)), "2025-12");
+    assert.equal(decemberOfPreviousYearString(new Date(2026, 0, 1)), "2025-12");
+    assert.equal(decemberOfPreviousYearString(new Date(2026, 11, 31)), "2025-12");
+  });
+
+  it("crosses the millennium boundary correctly", () => {
+    assert.equal(decemberOfPreviousYearString(new Date(2000, 0, 1)), "1999-12");
+  });
+});


### PR DESCRIPTION
## Summary

A bundle of accounting UX improvements that all flow from one premise: **rows you can read should be rows you can click**. Adds drill-down on Balance Sheet and P&L, gives the journal a real detail view, moves entry editing where the user is already looking, and adds period shortcuts to the B/S as-of picker.

### Drill-down from reports → ledger
- **Balance Sheet** rows are now clickable; clicking routes to the Ledger tab pre-filtered to that account. Mirrors the existing `AccountsList → Ledger` handoff: `role=button`, `tabindex=0`, Enter / Space activation, `accounting-bs-row-<code>` testids. The synthetic `_currentEarnings` row stays non-clickable (it has no underlying account).
- **Profit & Loss** rows on both income and expense sides do the same, with `accounting-pl-row-<code>` testids.

### Balance Sheet period shortcuts
- New "Shortcut" dropdown beside the as-of input: **This month / Last month / Last quarter / Last year**.
- Calendar-based: "Last quarter" picks the last month of the previous calendar quarter; "Last year" picks December of the previous calendar year. Three new pure helpers in `dates.ts` (with unit tests covering Q1 → December-of-prev-year and millennium boundaries).
- Auto-detection: the dropdown reflects which preset matches the current Period; manual edits show the blank "custom" sentinel.
- Five new keys (`shortcutLabel`, `thisMonth`, `lastMonth`, `lastQuarter`, `lastYear`) added to all 8 locales.

### Journal entry detail panel
- Click a journal row to expand a detail panel below it. Single-selection — opening another row swaps; an explicit close (X) button collapses.
- Detail body shows each line in dedicated **Account / Debit / Credit / Memo / T-number** columns, with a totals footer. The T-number column only renders when at least one line carries a `taxRegistrationId`.
- Edit / Void buttons moved out of the per-row action cell and into the detail panel header, alongside the close button — frees up table real estate and gives those buttons more breathing room.
- Panel surfaces entry-level metadata in a single line: `<accounting date>: <memo>` on the left, `(<posting timestamp YYYY-MM-DD HH:MM>)` on the right. Memo is omitted when blank; createdAt is formatted from the server-stamped ISO string.

### Edit-in-place
- Clicking Edit on an expanded row mounts the `JournalEntryForm` **in place** of the read-only detail content for that row — no longer at the top of the page. Submit collapses the panel (the original was just voided); Cancel returns to read-only.
- "+ New entry" still opens the form above the table as before — the two paths stay distinct.
- A click-guard on the row chrome ignores clicks on the row's own date/kind/memo/lines cells while in edit mode, so a stray click can't drop the draft.

### Other UI tweaks
- Manage accounts moved next to Add line on the entry form's bottom toolbar (was in the form header).
- Edit-mode hides the redundant "Edit journal entry" title; the explanatory banner ("When you submit, the original entry will be voided…") sits on the action row beside Cancel / Update Entry, shortening the panel.
- editBanner reworded across en/es/pt-BR/fr to make the future-tense conditional unambiguous (the original simple-present "is voided" read like it had already happened).
- All form inputs now explicitly `bg-white` to stay crisp inside the gray detail panel (only `<select>` had it before — a long-standing inconsistency that only became visible once the form started mounting on a non-white background).
- Journal list is now split-scroll: the "+ New entry" slot, the date-range / account / refresh filter bar, and the column-header row stay pinned; only the entries scroll. Header pinning is per-`<th>` sticky for browser compatibility.

## Test plan
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 18 unit suites pass (incl. new `test_dates.ts`)
- [x] `yarn test:e2e` — 389 specs pass, including 7 new ones in `accounting-detail-and-shortcuts.spec.ts` covering: B/S row click → Ledger; B/S earnings row stays non-clickable; B/S shortcut dropdown drives the Period input; P&L income + expense rows route to Ledger; journal row toggles detail with Debit/Credit columns; close button collapses; Edit replaces detail with the in-place form and Cancel returns to read-only.
- [ ] Manual: open the journal tab, scroll past several entries — column headers should stay visible while rows scroll; expand a row and verify the detail metadata line shows the date / memo / posting timestamp.
- [ ] Manual: open Balance Sheet, click a row → lands on Ledger pre-filtered. Repeat from P&L. Verify the synthetic earnings row on B/S is not clickable.
- [ ] Manual: edit an entry from the detail panel — form should mount in-place, not at the top. Submit voids the original and collapses the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added date range shortcuts (this month, last month, last quarter, last year) to Balance Sheet for faster period selection
  * Introduced expandable inline details for journal entries with built-in edit capability
  * Made Balance Sheet and Profit & Loss account rows clickable and keyboard-accessible for direct navigation to Ledger

* **Improvements**
  * Enhanced table row interactions with improved keyboard accessibility and hover indicators
  * Updated journal entry edit messaging

* **Localization**
  * Added translations for date shortcuts across all supported languages
  * Updated journal entry editing copy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->