### PR TITLE
refactor(plugins): drop endpoints `as` casts via useRuntime<E>() (D, requires gui-chat-protocol@0.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "echarts": "^6.0.0",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.2",
-    "gui-chat-protocol": "0.3.1",
+    "gui-chat-protocol": "0.3.2",
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.1",
     "mammoth": "^1.12.0",

--- a/src/plugins/todo/Preview.vue
+++ b/src/plugins/todo/Preview.vue
@@ -45,7 +45,11 @@ const props = defineProps<{ result: ToolResultComplete<TodoData> }>();
 
 const items = ref<TodoItem[]>(props.result.data?.items ?? []);
 
-const endpoints = useRuntime().endpoints as unknown as TodoEndpoints;
+const endpoints: TodoEndpoints = (() => {
+  const value = useRuntime<TodoEndpoints>().endpoints;
+  if (!value) throw new Error("todo plugin Preview mounted without endpoints — wrap in <PluginScopedRoot>");
+  return value;
+})();
 
 const { refresh } = useFreshPluginData<TodoItem[]>({
   endpoint: () => endpoints.list.url,

--- a/src/plugins/todo/View.vue
+++ b/src/plugins/todo/View.vue
@@ -123,11 +123,17 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 
 const items = ref<TodoItem[]>(props.selectedResult.data?.items ?? []);
 
-// `runtime.endpoints` is host-populated and typed as
-// `Record<string, string> | undefined` per the protocol; cast to
-// the plugin's typed contract. The `<PluginScopedRoot>` wrapper in
-// `index.ts#wrapWithScope("todos", ...)` guarantees presence.
-const endpoints = useRuntime().endpoints as unknown as TodoEndpoints;
+// `useRuntime<TodoEndpoints>()` (gui-chat-protocol@>=0.3.2) pins the
+// `endpoints` map to the plugin's typed contract — no `as` cast.
+// The `<PluginScopedRoot>` wrapper in `index.ts#wrapWithScope("todos",
+// ...)` guarantees presence; the IIFE below narrows the optional
+// type once at setup time so closures (event handlers, watchers)
+// see `endpoints: TodoEndpoints`, not `TodoEndpoints | undefined`.
+const endpoints: TodoEndpoints = (() => {
+  const value = useRuntime<TodoEndpoints>().endpoints;
+  if (!value) throw new Error("todo plugin View mounted without endpoints — wrap in <PluginScopedRoot>");
+  return value;
+})();
 
 const { refresh } = useFreshPluginData<TodoItem[]>({
   endpoint: () => endpoints.list.url,

--- a/src/plugins/todo/composables/useTodos.ts
+++ b/src/plugins/todo/composables/useTodos.ts
@@ -112,10 +112,15 @@ export function useTodos(initialItems: TodoItem[] = [], initialColumns: StatusCo
   const columns = ref<StatusColumn[]>(initialColumns);
   const error = ref<string | null>(null);
 
-  // Cast through `unknown`: the protocol's `endpoints` field is typed
-  // as `Record<string, string>` but built-in plugins now hand resolved
-  // `{ method, url }` records. Plugin author asserts the typed shape.
-  const endpoints = useRuntime().endpoints as unknown as TodoEndpoints;
+  // `useRuntime<TodoEndpoints>()` (gui-chat-protocol@>=0.3.2) pins
+  // the `endpoints` map's shape — no `as` cast needed. The IIFE
+  // narrows the optional once so the returned action closures see
+  // `endpoints: TodoEndpoints`, not `TodoEndpoints | undefined`.
+  const endpoints: TodoEndpoints = (() => {
+    const value = useRuntime<TodoEndpoints>().endpoints;
+    if (!value) throw new Error("useTodos called outside the todo plugin scope");
+    return value;
+  })();
 
   const { refresh: rawRefresh } = useFreshPluginData<{
     items: TodoItem[];

--- a/src/utils/plugin/runtime.ts
+++ b/src/utils/plugin/runtime.ts
@@ -121,11 +121,12 @@ export function makeBrowserPluginRuntime(deps: MakeBrowserPluginRuntimeDeps): Br
     log: makeScopedLogger(pkgName),
     openUrl: makeOpenUrl(pkgName),
     dispatch: makeDispatch(pkgName),
-    // `BrowserPluginRuntime.endpoints` types this as `Record<string,
-    // string>` (gui-chat-protocol@>=0.3.1). Built-in plugins (#1141)
-    // now hand `{ method, url }` records — same shape on the wire,
-    // wider type. Cast through `unknown` so consumers can assert the
-    // typed shape they expect via `useRuntime().endpoints as TheirShape`.
-    endpoints: endpoints as unknown as Readonly<Record<string, string>> | undefined,
+    // `BrowserPluginRuntime.endpoints` is now typed as the runtime's
+    // `E` type parameter (gui-chat-protocol@>=0.3.2, default
+    // `Readonly<Record<string, unknown>>`). Plugin authors pin the
+    // shape via `useRuntime<TheirShape>()` and read `runtime.endpoints!`
+    // without a cast. No coercion needed at this construction site —
+    // the host populates the field opaquely; each consumer narrows.
+    endpoints,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@ gui-chat-protocol@0.3.0:
   resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.3.0.tgz#06825160b3d1f23250f8d303912cb85f87694f1f"
   integrity sha512-aaDTsiQH/AYMUMlBXiqHmL9q1I8R9FXIB3k9+0DHWKa0BsyxblZpi3Cxrfd5c+LucbiYAjfCjsDoRoIYZQu/kg==
 
-gui-chat-protocol@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.3.1.tgz#fc43de3087ce93201923c5c4a3af5f5ec2c66d7c"
-  integrity sha512-egScB3y6gTtr59v9h5vgv5vhnmZ6F0OkF4pAXuvNPOe77PKsfp8NmKx6z1mdKdPiFB65B5q74Knp+WWjZswWEQ==
+gui-chat-protocol@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.3.2.tgz#2d03580585bfecd031bbbba23414611e40a6faa5"
+  integrity sha512-mZcXj4x4YsVLBqI7GILRwZXP5/6TM7tL2O9gCO2A1Uct/5P2Hk9nHFTsGadeZ9JtY/+eD8eVq1gw4jkR3lsohg==
 
 gui-chat-protocol@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

- Bump `gui-chat-protocol` 0.3.1 → **0.3.2** (just published — additive, generic on `useRuntime<E>()` and `BrowserPluginRuntime<E>`)
- Drop the 3 remaining `as TodoEndpoints` casts in the todo plugin via the new generic
- Drop the cast in `src/utils/plugin/runtime.ts` — the protocol's default `endpoints` type is now `Readonly<Record<string, unknown>>`, matching what the host already passes

## Items to confirm / review

- [ ] IIFE pattern OK? `@typescript-eslint/no-non-null-assertion` is `error` so `!` isn't an option, and a bare `if (!value) throw` doesn't carry narrowing into async closures (event handlers / actions). The IIFE narrows once at setup time so the rest of the file sees `endpoints: TodoEndpoints`, not optional.
- [ ] Behaviour unchanged: the throw is a "wiring bug" guard — `<PluginScopedRoot>` always populates `endpoints`, so the throw path is dead in practice. Same loud-failure character as the old `as unknown as` (which would crash at first `.url` read if `endpoints` were absent).

## User Prompt

> castはしたくないのでpatch versionで対応しておこう

Two-PR sequence:
1. **gui-chat-protocol@0.3.2** ([feat/typed-endpoints-generic-0.3.2](https://github.com/receptron/gui-chat-protocol/tree/feat/typed-endpoints-generic-0.3.2)) — protocol-side generic. Already published to npm.
2. **mulmoclaude** ← this PR — bump dep + rewrite cast sites.

## What changed

| File | Before | After |
|---|---|---|
| `src/plugins/todo/View.vue` | `useRuntime().endpoints as unknown as TodoEndpoints` | `useRuntime<TodoEndpoints>()` + IIFE narrow |
| `src/plugins/todo/Preview.vue` | same | same |
| `src/plugins/todo/composables/useTodos.ts` | same | same |
| `src/utils/plugin/runtime.ts` | `endpoints as unknown as Readonly<Record<string,string>>` | `endpoints` (no coercion — types align) |
| `package.json` | `gui-chat-protocol: 0.3.1` | `gui-chat-protocol: 0.3.2` |

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (no leftover `!` non-null assertions)
- [x] `yarn test` — 4070+ unit tests pass
- [x] `yarn build` succeeds
- [x] `yarn test:e2e --shard=2/2 -g todo` — 6 passed

This closes the original 5-task plugin loose-coupling roadmap (A → C → B → C2 → G → D).