### PR TITLE
docs: distinct navigation paths for plugin authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,13 +614,15 @@ Full documentation lives in [`docs/`](docs/README.md). Here are the key entry po
 
 ### For developers
 
-| Guide                                              | Description                                             |
-| -------------------------------------------------- | ------------------------------------------------------- |
-| [Developer Guide](docs/developer.md)               | Environment variables, scripts, workspace structure, CI |
-| [Bridge Protocol](docs/bridge-protocol.md)         | Wire-level spec for writing new messaging bridges       |
-| [Sandbox Credentials](docs/sandbox-credentials.md) | Docker sandbox credential forwarding (SSH, GitHub CLI)  |
-| [Logging](docs/logging.md)                         | Log levels, formats, file rotation                      |
-| [CHANGELOG](docs/CHANGELOG.md)                     | Release history                                         |
+| Guide                                                                                | Description                                                                                                                                          |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Developer Guide](docs/developer.md)                                                 | Environment variables, scripts, workspace structure, CI                                                                                              |
+| [Built-in Plugin Development](docs/developer.md#plugin-development)                  | Author a plugin co-located in `src/plugins/<name>/` — META shape, `useRuntime<E>()` API, mounting paths, sync invariants                             |
+| [Runtime-Loaded Plugins](docs/plugin-runtime.md)                                     | Author a plugin distributed as an npm package and installed into a workspace at runtime                                                              |
+| [Bridge Protocol](docs/bridge-protocol.md)                                           | Wire-level spec for writing new messaging bridges                                                                                                    |
+| [Sandbox Credentials](docs/sandbox-credentials.md)                                   | Docker sandbox credential forwarding (SSH, GitHub CLI)                                                                                               |
+| [Logging](docs/logging.md)                                                           | Log levels, formats, file rotation                                                                                                                   |
+| [CHANGELOG](docs/CHANGELOG.md)                                                       | Release history                                                                                                                                      |
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,6 @@ Guides for using MulmoClaude. No programming knowledge required.
 | [Obsidian Integration](tips/obsidian.en.md)                         | English  | Browse MulmoClaude output in Obsidian, let Claude reference your vault                       |
 | [Claude Code × Ollama セットアップ知見](tips/claude-code-ollama.md) | 日本語   | ローカル LLM (Ollama) で Claude Code を動かすときの context 長 / モデル選定知見              |
 | [Claude Code × Ollama Setup Notes](tips/claude-code-ollama.en.md)   | English  | Running Claude Code against a local Ollama backend — context-window, model picks             |
-| [Runtime Plugin デバッグ知見](tips/runtime-plugin-debugging.md)     | 日本語   | `npx mulmoclaude` で runtime plugin が呼べないときに踏んだ silent failure 4 パターンと直し方 |
 | [Bedrock Deployment](bedrock-deployment.en.md)                      | English  | Run MulmoClaude against Anthropic Claude on AWS Bedrock                                      |
 | [Bedrock デプロイ](bedrock-deployment.md)                           | 日本語   | AWS Bedrock 経由の Anthropic Claude で動かす手順                                             |
 
@@ -34,19 +33,36 @@ Guides for using MulmoClaude. No programming knowledge required.
 | Document                                                          | Language | Description                                                                                                        |
 | ----------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
 | [Memory](memory.md)                                               | English  | Topic-based memory store under `conversations/memory/` — schema, agent read/write contract, atomic→topic migration |
-| [Runtime Plugins](plugin-runtime.md)                              | English  | Workspace-installed runtime plugins (#1043 C-2) — install, dispatch, asset routes, collisions                      |
 | [Bridge Session Design](bridge-session-design.md)                 | English  | Session identification, caching, and multi-user scaling plan                                                       |
 | [Image-path Routing — Research](image-path-routing.md)            | English  | Read-only audit of how the LLM's image references become browser-loadable URLs                                     |
 | [Image-path Routing — 設計議論](discussion-image-path-routing.md) | 日本語   | 画像パスのルーティング再設計の議論メモと段階的実装計画                                                             |
 | [Wiki / HTML 表示サーフェス](wiki-html-render-surfaces.md)        | 日本語   | Wiki / HTML / Markdown が表示される複数箇所の差異 (権限・画像パス解決) を整理                                      |
 
+## Plugin Authoring
+
+Two distinct plugin paths — pick by distribution model.
+
+**In-tree (built-in) plugins** ship inside the mulmoclaude bundle. Co-located under `src/plugins/<name>/`; the META owns its identity (toolName, API namespace + routes) and the host barrels regenerate from a `yarn dev` codegen pass.
+
+| Document                                                                           | Description                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Plugin development](developer.md#plugin-development)                              | META shape (`definePluginMeta` + `(method, path)` route tuples), the `useRuntime<E>()` API, two mounting paths, error boundary, sync invariants, ESLint coupling rules                 |
+| [Auto-discovery (no host barrel edits)](developer.md#auto-discovery-no-host-barrel-edits) | How `scripts/codegen-plugin-barrels.ts` rewrites `src/plugins/_generated/*.ts` from each plugin directory — adding a plugin = `mkdir` + write the 5 files + `yarn dev`                |
+
+**Runtime-loaded plugins** are standalone npm packages installed into a workspace at runtime (#1043). Different contract from built-ins — single-dispatch endpoint, factory shape via `definePlugin`, runtime registry.
+
+| Document                                                          | Language | Description                                                                                  |
+| ----------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| [Runtime Plugins](plugin-runtime.md)                              | English  | Install, dispatch, asset routes, collisions, factory + legacy shape                          |
+| [Runtime Plugin デバッグ知見](tips/runtime-plugin-debugging.md)   | 日本語   | `npx mulmoclaude` で runtime plugin が呼べないときに踏んだ silent failure 4 パターンと直し方 |
+
 ## Developers
 
-Code structure, APIs, and build instructions.
+Code structure, APIs, and build instructions for the host itself. Plugin authors should start in **[Plugin Authoring](#plugin-authoring)** above; this section covers everything else.
 
-| Document                                      | Language | Description                                                                                                                         |
-| --------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [Developer Guide](developer.md)               | English  | Environment variables, scripts, workspace structure, CI, internal packages                                                          |
+| Document                                      | Language | Description                                                                                                                                  |
+| --------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Developer Guide](developer.md)               | English  | Environment variables, scripts, workspace structure, CI, internal packages, and the in-tree [plugin development](developer.md#plugin-development) reference |
 | [UI Cheatsheet](ui-cheatsheet.md)             | English  | ASCII layouts of every major UI surface, anchored to component / `data-testid` names so chat / PR text can reference them precisely |
 | [Bridge Protocol](bridge-protocol.md)         | English  | MulmoBridge wire protocol spec (socket.io events, auth)                                                                             |
 | [Task Manager](task-manager.md)               | English  | Server tick loop + @receptron/task-scheduler integration                                                                            |


### PR DESCRIPTION
## Summary

- Add **Plugin Authoring** top-level section to `docs/README.md` with two sub-paths (in-tree built-in vs runtime-loaded npm), each pointing at the right anchor inside `developer.md` or `plugin-runtime.md`
- Surface plugin-author entry points in the root `README.md`'s "For developers" table — currently buried under "Developer Guide / environment variables / scripts"
- Drop `Runtime Plugins` from "Architecture & Design" (it's an authoring guide, not architecture); move `tips/runtime-plugin-debugging.md` into the new section so it sits with its audience

## Items to confirm / review

- [ ] Two-path split makes sense — built-in (in-tree, codegen-driven) vs runtime-loaded (npm, factory shape) cover non-overlapping audiences
- [ ] Anchors live: `developer.md#plugin-development` and `#auto-discovery-no-host-barrel-edits` both exist (verified via `grep ^## / ^###`)
- [ ] No broken duplication: `runtime-plugin-debugging.md` now appears once (under Plugin Authoring), not in Tips

## User Prompt

> documentってこうしんしているっけ？pluginのつくりかと、auto discovery のしくみ、それぞれ。そして、docs/READMEをきちんと維持して、pluginの開発者向けとmulmoclaudeの仕組みのそれぞれをきちんと導線つくっている？

Translation: "Is the documentation up to date? The plugin authoring guide AND the auto-discovery mechanism, both. And is `docs/README` properly maintained with separate navigation paths for plugin developers vs mulmoclaude's system overview?"

Audit found:
- ✅ `developer.md` IS up to date (`## Plugin development` with `### Files per plugin`, `### Auto-discovery (no host barrel edits)`, `### Plugin runtime API`, `### Two mounting paths`, `### Diagnostics`, `### Sync invariants` — all current post-#1141 / #1143 / #1144 / #1147 / #1150)
- ❌ `docs/README.md` had no top-level entry routing plugin authors at the right doc — fixed by this PR
- ❌ Root `README.md`'s "For developers" table didn't surface plugin authoring at all — fixed

## Test plan

- [x] `yarn lint` clean (docs-only change)
- [x] `grep` confirms both anchor IDs exist in `developer.md`
- [x] `Runtime Plugin デバッグ知見` listed exactly once across the doc index (was duplicated otherwise)