### PR TITLE
fix: address remaining CodeRabbit findings on PR #1125 (collision checks)

### DIFF
--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -162,6 +162,12 @@ const HOST_WORKSPACE_DIRS = {
 const WORKSPACE_DIRS_AGGREGATE = defineHostAggregate(BUILT_IN_PLUGIN_METAS, {
   label: "WORKSPACE_DIRS",
   hostRecord: HOST_WORKSPACE_DIRS,
+  // Reserve `WORKSPACE_FILES` keys too — those land in `WORKSPACE_PATHS`
+  // alongside dir paths and would silently overwrite a plugin's
+  // `workspaceDirs.<sameKey>` at the absolute-path step, leaving
+  // `WORKSPACE_DIRS` and `WORKSPACE_PATHS` disagreeing for that key
+  // (CR review #1125).
+  additionalReservedKeys: new Set(Object.keys(WORKSPACE_FILES)),
   extract: (meta) => meta.workspaceDirs,
   dimension: "workspaceDirs",
 });

--- a/src/plugins/metas.ts
+++ b/src/plugins/metas.ts
@@ -184,6 +184,14 @@ export interface HostAggregateOptions<V> {
   /** Dimension label tagged onto every emitted
    *  `IntraPluginCollision`. */
   readonly dimension: IntraPluginCollision["dimension"];
+  /** Extra reserved keys to drop on collision, ON TOP OF
+   *  `Object.keys(hostRecord)`. Used when a sibling map shares a
+   *  namespace with this aggregate — e.g. `WORKSPACE_DIRS` reserves
+   *  `WORKSPACE_FILES` keys so a plugin can't smuggle in
+   *  `workspaceDirs: { memory: ... }` and silently disagree with
+   *  `WORKSPACE_FILES.memory` (CR review #1125). The reserved keys
+   *  are NOT added to `merged` — only used for collision filtering. */
+  readonly additionalReservedKeys?: ReadonlySet<string>;
 }
 
 export interface HostAggregate<V> {
@@ -203,7 +211,11 @@ export interface HostAggregate<V> {
  *  caller still owns the literal-preserving type cast on `merged`. */
 export function defineHostAggregate<V>(metas: readonly PluginMeta[], opts: HostAggregateOptions<V>): HostAggregate<V> {
   const { aggregate, owner, collisions } = buildPluginAggregate(metas, opts.extract, opts.dimension);
-  const { cleaned, dropped } = filterPluginKeys(opts.label, new Set(Object.keys(opts.hostRecord)), aggregate, owner);
+  const reserved = new Set<string>(Object.keys(opts.hostRecord));
+  if (opts.additionalReservedKeys) {
+    for (const key of opts.additionalReservedKeys) reserved.add(key);
+  }
+  const { cleaned, dropped } = filterPluginKeys(opts.label, reserved, aggregate, owner);
   return {
     merged: { ...opts.hostRecord, ...cleaned },
     hostCollisions: dropped,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,7 +17,24 @@ import type { PluginEntry } from "./types";
 import { getRuntimePluginEntry, getRuntimeToolNames } from "./runtimeLoader";
 import { BUILT_IN_PLUGINS } from "../plugins";
 
-const plugins: Record<string, PluginEntry> = Object.fromEntries(BUILT_IN_PLUGINS.map((registration) => [registration.toolName, registration.entry]));
+// Build the lookup with explicit duplicate detection. `BUILT_IN_PLUGINS`
+// is the union of generated registrations (one per built-in META) and
+// `EXTERNAL_PLUGIN_REGISTRATIONS` (still-unmigrated plugins). The
+// META aggregator already screens its half for collisions, but a
+// duplicate `toolName` between an external registration and a META
+// would slip past `Object.fromEntries` silently with last-writer-wins.
+// Throwing at boot is the right move — silent dispatch hijack is
+// strictly worse than a hard error during start-up (CR review #1125).
+const plugins: Record<string, PluginEntry> = (() => {
+  const out: Record<string, PluginEntry> = {};
+  for (const registration of BUILT_IN_PLUGINS) {
+    if (registration.toolName in out) {
+      throw new Error(`Duplicate built-in plugin registration for "${registration.toolName}"`);
+    }
+    out[registration.toolName] = registration.entry;
+  }
+  return out;
+})();
 
 export function getPlugin(name: string): PluginEntry | null {
   // Static (build-time) plugins win on collision — runtime plugins

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -25,10 +25,19 @@ import { BUILT_IN_PLUGINS } from "../plugins";
 // would slip past `Object.fromEntries` silently with last-writer-wins.
 // Throwing at boot is the right move — silent dispatch hijack is
 // strictly worse than a hard error during start-up (CR review #1125).
+//
+// Use a null-prototype dictionary so:
+//   1. The `in` / `hasOwn` check doesn't walk a prototype chain — a
+//      legitimate `toolName` like `"toString"` or `"hasOwnProperty"`
+//      can't false-positive as a duplicate.
+//   2. The bracket assign at the end can't trigger `__proto__`
+//      prototype-mutation semantics if a future registration value
+//      ever flows from less-trusted code.
+// Codex review on PR #1156.
 const plugins: Record<string, PluginEntry> = (() => {
-  const out: Record<string, PluginEntry> = {};
+  const out: Record<string, PluginEntry> = Object.create(null);
   for (const registration of BUILT_IN_PLUGINS) {
-    if (registration.toolName in out) {
+    if (Object.prototype.hasOwnProperty.call(out, registration.toolName)) {
       throw new Error(`Duplicate built-in plugin registration for "${registration.toolName}"`);
     }
     out[registration.toolName] = registration.entry;

--- a/test/plugins/test_meta_aggregation.ts
+++ b/test/plugins/test_meta_aggregation.ts
@@ -17,7 +17,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { findHostPluginCollisions, buildPluginAggregate, filterPluginKeys, BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
+import { findHostPluginCollisions, buildPluginAggregate, defineHostAggregate, filterPluginKeys, BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
 import { BUILT_IN_SERVER_BINDINGS } from "../../src/plugins/server.js";
 import type { PluginMeta } from "../../src/plugins/meta-types.js";
 
@@ -162,4 +162,50 @@ test("live aggregator modules load without host-vs-plugin or intra-plugin collis
   assert.deepEqual([...apiRoutes.API_ROUTES_INTRA_COLLISIONS], []);
   assert.deepEqual([...pubsub.PUBSUB_CHANNELS_INTRA_COLLISIONS], []);
   assert.deepEqual([...paths.WORKSPACE_DIRS_INTRA_COLLISIONS], []);
+});
+
+// `additionalReservedKeys` (CR review #1125 follow-up) — used by
+// `WORKSPACE_DIRS` to also reserve `WORKSPACE_FILES` keys so a
+// plugin can't smuggle in a `workspaceDirs.<sameKey>` that would
+// silently disagree with `WORKSPACE_PATHS` (file-side wins on the
+// final spread).
+test("defineHostAggregate honours additionalReservedKeys for collision filtering", () => {
+  const hostMeta: PluginMeta = {
+    toolName: "host",
+    apiNamespace: "host",
+    workspaceDirs: { reservedFile: "data/reserved", legitDir: "data/legit" },
+  };
+  const result = defineHostAggregate<string>([hostMeta], {
+    label: "WORKSPACE_DIRS",
+    hostRecord: { hostKey: "data/host" },
+    extract: (meta) => meta.workspaceDirs,
+    dimension: "workspaceDirs",
+    additionalReservedKeys: new Set(["reservedFile"]),
+  });
+  // `legitDir` survives, `reservedFile` is dropped + reported.
+  assert.equal(result.merged.legitDir, "data/legit");
+  assert.equal("reservedFile" in result.merged, false);
+  // The reserved key must NOT leak into `merged` — the helper only
+  // uses it for filtering, not for spreading into the output.
+  assert.equal("reservedFile" in result.merged, false);
+  const droppedKeys = result.hostCollisions.map((collision) => collision.key);
+  assert.ok(droppedKeys.includes("reservedFile"));
+});
+
+test("defineHostAggregate without additionalReservedKeys preserves original behaviour", () => {
+  const meta: PluginMeta = {
+    toolName: "noop",
+    apiNamespace: "noop",
+    workspaceDirs: { reservedFile: "data/x" },
+  };
+  // Without the reservation, `reservedFile` survives because it
+  // doesn't collide with the (empty) host record.
+  const result = defineHostAggregate<string>([meta], {
+    label: "TEST",
+    hostRecord: {},
+    extract: (entry) => entry.workspaceDirs,
+    dimension: "workspaceDirs",
+  });
+  assert.equal(result.merged.reservedFile, "data/x");
+  assert.equal(result.hostCollisions.length, 0);
 });


### PR DESCRIPTION
## Summary

\`/pr-quality-sweep\` found 2 still-actionable CR findings on the already-merged #1125. Both are silent-collision edges that the original \`defineHostAggregate\` refactor didn't cover.

## Items to Confirm / Review

### Finding 9 — `src/tools/index.ts` silent dedup

\`Object.fromEntries(BUILT_IN_PLUGINS.map…)\` lets a duplicate \`toolName\` win silently. The META aggregator already screens its half, but \`BUILT_IN_PLUGINS\` is a union of generated + still-unmigrated \`EXTERNAL_PLUGIN_REGISTRATIONS\`, so cross-boundary duplicates slip past. Replaced with an IIFE that throws on duplicate at module load. Silent dispatch hijack is strictly worse than a hard boot error.

### Finding 11 — `WORKSPACE_FILES` key smuggling

A plugin registering \`workspaceDirs: { memory: "..." }\` survived into \`WORKSPACE_DIRS\` (no host collision because \`memory\` lives in \`WORKSPACE_FILES\`, not \`HOST_WORKSPACE_DIRS\`), then \`WORKSPACE_PATHS = { ...dir_paths, ...file_paths }\` silently overwrote the absolute form on the file-side spread — leaving \`WORKSPACE_DIRS.memory\` (plugin) and \`WORKSPACE_PATHS.memory\` (file) disagreeing.

Extended \`HostAggregateOptions\` with an optional \`additionalReservedKeys: ReadonlySet<string>\` parameter — used purely for filtering, NOT spread into the merged output. \`WORKSPACE_DIRS\` now reserves \`Object.keys(WORKSPACE_FILES)\`.

### Tests

- 2 new tests in \`test/plugins/test_meta_aggregation.ts\` pinning the \`additionalReservedKeys\` contract: drop + report on collision, AND the reserved keys must NOT leak into \`merged\`.
- Baseline test that omitting the option keeps the previous behaviour.
- 13/13 meta-aggregation tests passing.

### Findings verified already addressed (no work needed)

CR findings 1, 2, 3, 4, 5, 6, 7, 8, 10, 12 from the same review were each spot-checked against current main:

- **#1, #11 part 1** (paths.ts auto-derive WORKSPACE_PATHS): done — line 182-184 cites this very review.
- **#2** (\`useNotifications.addLocal\` prune readIds): done — line 139 cites this review.
- **#3, #4, #5** (Object.fromEntries / Object.assign collision behaviours): subsumed by the \`defineHostAggregate\` refactor (\`src/plugins/metas.ts\`).
- **#6, #7, #8** (TOOL_NAMES drift in scheduler / todo / wiki): no longer have hardcoded literals at the called-out lines, or the literals are intentional const declarations the META aggregator pins via \`as const\`.
- **#10** (\`server/plugins/runtime.ts\` notify): the CR comment was an analysis script with no specific bullet — no surface visible to action.
- **#12** (\`useTodos.ts\` endpoints undefined cast): done — line 119-123 uses \`useRuntime<TodoEndpoints>()\` with explicit IIFE narrowing + throw.

## Verification

- \`yarn lint\` → 0 errors, 0 warnings
- \`yarn typecheck\` → ✓
- \`yarn build\` → ✓
- \`npx tsx --test test/plugins/test_meta_aggregation.ts\` → 13/13 passing