### PR TITLE
feat: add create-mulmoclaude-plugin CLI scaffold (PR1 of #1159)

### DIFF
--- a/packages/create-mulmoclaude-plugin/README.md
+++ b/packages/create-mulmoclaude-plugin/README.md
@@ -19,7 +19,7 @@ logic with whatever your plugin actually does, ship.
 
 ## Output
 
-```
+```text
 my-plugin/
   package.json           name set to your argument; peer-deps and scripts ready
   tsconfig.json

--- a/packages/create-mulmoclaude-plugin/README.md
+++ b/packages/create-mulmoclaude-plugin/README.md
@@ -1,0 +1,74 @@
+# create-mulmoclaude-plugin
+
+Scaffold a new MulmoClaude runtime plugin.
+
+```bash
+npx create-mulmoclaude-plugin my-plugin
+# or
+npx create-mulmoclaude-plugin @example/cool-plugin
+```
+
+Creates a directory in the current working directory with a runnable
+counter sample plugin: server-side `definePlugin` factory, `View.vue`
+canvas component, plugin-local i18n, and the build / lint config the
+in-tree reference plugins (`bookmarks-plugin`, `accounting-plugin`,
+`todo-plugin`) use.
+
+The output is a starting point — rename the tool, replace the counter
+logic with whatever your plugin actually does, ship.
+
+## Output
+
+```
+my-plugin/
+  package.json           name set to your argument; peer-deps and scripts ready
+  tsconfig.json
+  vite.config.ts         two bundles: dist/index.js (server) + dist/vue.js (browser)
+  eslint.config.mjs      extends gui-chat-protocol/eslint-preset
+  .gitignore
+  README.md              dev-loop instructions for your new plugin
+  src/
+    index.ts             definePlugin factory + sample handler
+    definition.ts        TOOL_DEFINITION shared between server + browser
+    vue.ts               browser entry: { toolDefinition, viewComponent }
+    View.vue             canvas SFC using useRuntime() + dispatch + pubsub
+    shims-vue.d.ts
+    lang/
+      en.ts ja.ts        translation tables
+      index.ts           useT() composable reading runtime.locale
+```
+
+## Next steps after scaffolding
+
+```bash
+cd my-plugin
+yarn install
+yarn build
+```
+
+To develop against MulmoClaude before publishing, the current path is
+`yarn link`:
+
+```bash
+# In the plugin directory:
+yarn link
+
+# In the mulmoclaude monorepo:
+yarn link my-plugin
+```
+
+A first-class "install from local path" surface is being tracked at
+[receptron/mulmoclaude#1159](https://github.com/receptron/mulmoclaude/issues/1159)
+PR2 / PR3.
+
+## Why a sample, not an empty plugin
+
+Every line of the counter sample exists because a plugin author
+needs to know *how* to do that thing. Boilerplate is fine if it
+demonstrates the runtime API surface. The trade-off is a handful of
+deletions when you're ready to write your real plugin — small price
+for not having to reverse-engineer the API on day one.
+
+## License
+
+MIT

--- a/packages/create-mulmoclaude-plugin/package.json
+++ b/packages/create-mulmoclaude-plugin/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "create-mulmoclaude-plugin",
+  "version": "0.1.0",
+  "description": "Scaffold a new MulmoClaude runtime plugin: `npx create-mulmoclaude-plugin <name>`.",
+  "type": "module",
+  "bin": {
+    "create-mulmoclaude-plugin": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test ./test/*.ts"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/receptron/mulmoclaude/tree/main/packages/create-mulmoclaude-plugin",
+  "keywords": [
+    "mulmoclaude",
+    "plugin",
+    "scaffold",
+    "create"
+  ]
+}

--- a/packages/create-mulmoclaude-plugin/src/index.ts
+++ b/packages/create-mulmoclaude-plugin/src/index.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// CLI entry — `npx create-mulmoclaude-plugin <name>`.
+//
+// Single positional argument: the plugin's npm package name. Writes
+// a self-contained plugin directory in cwd and prints next-step
+// instructions. No interactive prompts (Phase 1).
+
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { directoryNameFor, validatePluginName } from "./validate.js";
+import { applyPlaceholders, TEMPLATE_FILES } from "./template.js";
+
+const USAGE = `Usage: npx create-mulmoclaude-plugin <package-name>
+
+Examples:
+  npx create-mulmoclaude-plugin my-plugin
+  npx create-mulmoclaude-plugin @example/cool-plugin
+
+Creates a directory matching the package name (or the local part of a
+scoped name) in the current directory, populated with a runnable
+counter sample plugin. Edit src/* to evolve into your own plugin.`;
+
+interface CliResult {
+  exitCode: number;
+}
+
+export async function runCli(argv: readonly string[], cwd: string, write: (output: string) => void): Promise<CliResult> {
+  const positional = argv.filter((arg) => !arg.startsWith("-"));
+  if (positional.length === 0) {
+    write(`${USAGE}\n`);
+    return { exitCode: 1 };
+  }
+  const [packageName] = positional;
+  const validation = validatePluginName(packageName);
+  if (!validation.ok) {
+    write(`Invalid package name: ${validation.reason}\n`);
+    write(`${USAGE}\n`);
+    return { exitCode: 1 };
+  }
+  const dirName = directoryNameFor(packageName);
+  const target = path.resolve(cwd, dirName);
+  if (await pathExists(target)) {
+    write(`Refusing to overwrite existing path: ${target}\n`);
+    return { exitCode: 1 };
+  }
+  await scaffoldInto(target, packageName);
+  write(formatSuccessMessage(dirName, packageName));
+  return { exitCode: 0 };
+}
+
+async function scaffoldInto(target: string, packageName: string): Promise<void> {
+  await mkdir(target, { recursive: true });
+  for (const entry of TEMPLATE_FILES) {
+    const filePath = path.join(target, entry.path);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, applyPlaceholders(entry.content, packageName), "utf-8");
+  }
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatSuccessMessage(dirName: string, packageName: string): string {
+  return [
+    "",
+    `✓ Created ${dirName}/`,
+    "",
+    "Next:",
+    "",
+    `  cd ${dirName}`,
+    "  yarn install",
+    "  yarn build",
+    "",
+    "  # Link into mulmoclaude for local dev (PR2 of receptron/mulmoclaude#1159 will replace this with a UI install-from-path mode):",
+    "  yarn link",
+    `  cd ../mulmoclaude && yarn link ${packageName}`,
+    "",
+    "  # Publish when ready:",
+    "  npm publish",
+    "",
+    "Read the README in the new directory for the full dev loop.",
+    "",
+  ].join("\n");
+}
+
+// Only run the CLI when invoked directly. Importing `index.ts` from
+// tests should not exit the process.
+const invokedDirectly = process.argv[1] && (process.argv[1].endsWith("/dist/index.js") || process.argv[1].endsWith("/src/index.ts"));
+if (invokedDirectly) {
+  runCli(process.argv.slice(2), process.cwd(), (text) => process.stdout.write(text)).then((result) => {
+    process.exit(result.exitCode);
+  });
+}

--- a/packages/create-mulmoclaude-plugin/src/index.ts
+++ b/packages/create-mulmoclaude-plugin/src/index.ts
@@ -5,9 +5,11 @@
 // a self-contained plugin directory in cwd and prints next-step
 // instructions. No interactive prompts (Phase 1).
 
+import { realpathSync } from "node:fs";
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import { directoryNameFor, validatePluginName } from "./validate.js";
 import { applyPlaceholders, TEMPLATE_FILES } from "./template.js";
@@ -29,6 +31,11 @@ interface CliResult {
 export async function runCli(argv: readonly string[], cwd: string, write: (output: string) => void): Promise<CliResult> {
   const positional = argv.filter((arg) => !arg.startsWith("-"));
   if (positional.length === 0) {
+    write(`${USAGE}\n`);
+    return { exitCode: 1 };
+  }
+  if (positional.length > 1) {
+    write(`Expected exactly one package name, got ${positional.length}: ${positional.join(", ")}\n`);
     write(`${USAGE}\n`);
     return { exitCode: 1 };
   }
@@ -92,10 +99,26 @@ function formatSuccessMessage(dirName: string, packageName: string): string {
 }
 
 // Only run the CLI when invoked directly. Importing `index.ts` from
-// tests should not exit the process.
-const invokedDirectly = process.argv[1] && (process.argv[1].endsWith("/dist/index.js") || process.argv[1].endsWith("/src/index.ts"));
-if (invokedDirectly) {
-  runCli(process.argv.slice(2), process.cwd(), (text) => process.stdout.write(text)).then((result) => {
-    process.exit(result.exitCode);
-  });
+// tests should not exit the process. Compare resolved paths (handles
+// Windows separators, symlinks via npm bin shims, and any future
+// `dist/index.mjs` build target).
+function isInvokedDirectly(): boolean {
+  const [, entry] = process.argv;
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
+  runCli(process.argv.slice(2), process.cwd(), (text) => process.stdout.write(text))
+    .then((result) => {
+      process.exit(result.exitCode);
+    })
+    .catch((error) => {
+      process.stderr.write(`Unexpected error: ${String(error)}\n`);
+      process.exit(1);
+    });
 }

--- a/packages/create-mulmoclaude-plugin/src/index.ts
+++ b/packages/create-mulmoclaude-plugin/src/index.ts
@@ -102,17 +102,16 @@ function formatSuccessMessage(dirName: string, packageName: string): string {
 // tests should not exit the process. Compare resolved paths (handles
 // Windows separators, symlinks via npm bin shims, and any future
 // `dist/index.mjs` build target).
-function isInvokedDirectly(): boolean {
-  const [, entry] = process.argv;
+export function entryMatchesModule(entry: string | undefined, moduleUrl: string): boolean {
   if (!entry) return false;
   try {
-    return realpathSync(entry) === fileURLToPath(import.meta.url);
+    return realpathSync(entry) === fileURLToPath(moduleUrl);
   } catch {
     return false;
   }
 }
 
-if (isInvokedDirectly()) {
+if (entryMatchesModule(process.argv[1], import.meta.url)) {
   runCli(process.argv.slice(2), process.cwd(), (text) => process.stdout.write(text))
     .then((result) => {
       process.exit(result.exitCode);

--- a/packages/create-mulmoclaude-plugin/src/template.ts
+++ b/packages/create-mulmoclaude-plugin/src/template.ts
@@ -309,6 +309,11 @@ interface Counter {
   value: number;
 }
 
+interface DispatchResult {
+  ok?: boolean;
+  counter?: Counter;
+}
+
 export interface Props {
   selectedResult: { counter?: Counter };
 }
@@ -323,7 +328,7 @@ const counter = ref<Counter>(props.selectedResult.counter ?? { value: 0 });
 const busy = ref(false);
 
 async function refetch(): Promise<void> {
-  const result = await dispatch({ kind: "get" });
+  const result = await dispatch<DispatchResult>({ kind: "get" });
   if (result?.ok && result.counter) counter.value = result.counter;
 }
 
@@ -331,7 +336,7 @@ async function increment(): Promise<void> {
   if (busy.value) return;
   busy.value = true;
   try {
-    const result = await dispatch({ kind: "increment", by: 1 });
+    const result = await dispatch<DispatchResult>({ kind: "increment", by: 1 });
     if (result?.ok && result.counter) counter.value = result.counter;
   } catch (err) {
     log.warn("increment failed", { error: String(err) });
@@ -344,7 +349,7 @@ async function reset(): Promise<void> {
   if (busy.value) return;
   busy.value = true;
   try {
-    const result = await dispatch({ kind: "reset" });
+    const result = await dispatch<DispatchResult>({ kind: "reset" });
     if (result?.ok && result.counter) counter.value = result.counter;
   } finally {
     busy.value = false;
@@ -354,10 +359,8 @@ async function reset(): Promise<void> {
 let unsubscribe: (() => void) | null = null;
 
 onMounted(() => {
-  refetch();
-  unsubscribe = pubsub.subscribe("changed", (next: Counter) => {
-    counter.value = next;
-  });
+  void refetch();
+  unsubscribe = pubsub.subscribe("changed", () => void refetch());
 });
 
 onUnmounted(() => {

--- a/packages/create-mulmoclaude-plugin/src/template.ts
+++ b/packages/create-mulmoclaude-plugin/src/template.ts
@@ -1,0 +1,557 @@
+// Template files emitted by the CLI. Inline string constants —
+// keeping them out of `src/templates/*.ts` so tsc / eslint don't
+// trip on the placeholder syntax (`{{PLUGIN_NAME}}`) or on the
+// `.vue` SFC syntax inside template strings.
+//
+// Each entry: relative path under the new plugin directory + raw
+// content (with placeholders). The CLI substitutes placeholders and
+// writes the file verbatim — no parsing, no other transformations.
+
+export interface TemplateFile {
+  /** POSIX-style path relative to the new plugin's root. */
+  path: string;
+  /** Raw content with placeholders. */
+  content: string;
+}
+
+// Sole placeholder. Substituted in package.json + README.
+export const PLUGIN_NAME_PLACEHOLDER = "{{PLUGIN_NAME}}";
+
+const PACKAGE_JSON = `{
+  "name": "${PLUGIN_NAME_PLACEHOLDER}",
+  "version": "0.1.0",
+  "description": "MulmoClaude runtime plugin scaffolded with create-mulmoclaude-plugin.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js",
+      "require": "./dist/vue.js",
+      "default": "./dist/vue.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src",
+    "dev": "vite build --watch"
+  },
+  "peerDependencies": {
+    "gui-chat-protocol": "^0.3.0",
+    "vue": "^3.5.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "eslint": "^9.0.0",
+    "gui-chat-protocol": "^0.3.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.0.0",
+    "vite": "^7.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vue": "^3.5.0",
+    "vue-eslint-parser": "^10.0.0",
+    "zod": "^3.23.0"
+  },
+  "license": "MIT"
+}
+`;
+
+const TSCONFIG = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["src/**/*"]
+}
+`;
+
+const VITE_CONFIG = `import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import dts from "vite-plugin-dts";
+
+// Two bundles, two externals strategies (mirrors the in-tree
+// bookmarks-plugin reference):
+//
+// - dist/index.js (server) — self-contained. The mulmoclaude
+//   runtime loader extracts the package into
+//   ~/mulmoclaude/plugins/.cache/<pkg>/<ver>/ and dynamic-imports
+//   it. There's no node_modules underneath, so any bare import left
+//   external would fail to resolve at load time. Inline
+//   gui-chat-protocol (just the identity definePlugin function) and
+//   zod so the server module is self-contained.
+//
+// - dist/vue.js (browser) — vue and gui-chat-protocol/vue stay
+//   external; the host provides Vue via the importmap and the
+//   useRuntime() composable resolves to the host's instance through
+//   gui-chat-protocol/vue (also via importmap).
+export default defineConfig({
+  plugins: [vue(), dts({ include: ["src/**/*.{ts,vue}"], rollupTypes: true })],
+  build: {
+    lib: {
+      entry: { index: "src/index.ts", vue: "src/vue.ts" },
+      formats: ["es"],
+      fileName: (_format, entryName) => \`\${entryName}.js\`,
+    },
+    rollupOptions: {
+      external: ["vue", "gui-chat-protocol/vue"],
+      output: {
+        // The host runtime loader injects a stylesheet from
+        // \`\${assetBase}/dist/style.css\`. Vite's default would name
+        // the CSS after the package; pin it to style.css.
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith(".css")) return "style.css";
+          return assetInfo.name ?? "[name]";
+        },
+      },
+    },
+    minify: false,
+    sourcemap: true,
+  },
+});
+`;
+
+const ESLINT_CONFIG = `// Plugin-author ESLint config — extends the gui-chat-protocol preset
+// to ban node:fs / node:path / console / direct fetch so any platform
+// bypass shows up at lint time.
+//
+// The preset is parser-agnostic; pair it with a TypeScript parser
+// (and a Vue parser if your plugin has SFCs) here in your own config
+// so the plugin doesn't have to ship a parser dep.
+
+import tseslint from "typescript-eslint";
+import vueParser from "vue-eslint-parser";
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+
+export default [
+  // TypeScript parsing for .ts files.
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  // Vue SFC parsing for .vue files.
+  {
+    files: ["src/**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: { parser: tseslint.parser, ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  // Apply the gui-chat-protocol restrictions to all plugin source.
+  ...pluginPreset.map((entry) => ({ ...entry, files: ["src/**/*.{ts,vue}"] })),
+];
+`;
+
+const GITIGNORE = `node_modules/
+dist/
+*.tgz
+.DS_Store
+`;
+
+const SHIMS_VUE = `// Vite/Vue plugin SFC shim — tells \`tsc --noEmit\` that \`.vue\`
+// imports resolve to a Vue Component. The actual SFC parsing happens
+// at build time via @vitejs/plugin-vue.
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}
+`;
+
+const DEFINITION_TS = `// Tool schema. Lives in its own module so both the server entry
+// (index.ts) and the browser entry (vue.ts) can import it without
+// dragging in the factory body, Zod, or any other server-only code.
+//
+// \`name: "incrementCounter" as const\` narrows the literal so
+// \`definePlugin\`'s \`PluginFactoryResult<N>\` requires a handler
+// exported under exactly this key.
+
+export const TOOL_DEFINITION = {
+  type: "function" as const,
+  name: "incrementCounter" as const,
+  description: "Increment, reset, or read a counter stored in the user's workspace.",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      kind: { type: "string", enum: ["increment", "reset", "get"] },
+      by: { type: "number", description: "increment delta (default 1)" },
+    },
+    required: ["kind"],
+  },
+};
+`;
+
+const INDEX_TS = `// Plugin server entry — runs inside the host's Node process.
+//
+// Demonstrates the v0.3 runtime API end-to-end on a tiny surface:
+//   - definePlugin factory with destructured runtime
+//   - files.data for persistent state (backup target)
+//   - pubsub.publish on every mutation so multi-tab views auto-refresh
+//   - Zod-discriminated args + exhaustive switch
+//
+// node:fs / node:path / console / direct fetch are all unused —
+// every I/O goes through the runtime. The eslint preset enforces it.
+
+import { definePlugin } from "gui-chat-protocol";
+import { z } from "zod";
+import { TOOL_DEFINITION } from "./definition";
+
+export { TOOL_DEFINITION };
+
+const Counter = z.object({ value: z.number().int() });
+type Counter = z.infer<typeof Counter>;
+
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("increment"), by: z.number().optional() }),
+  z.object({ kind: z.literal("reset") }),
+  z.object({ kind: z.literal("get") }),
+]);
+
+const COUNTER_FILE = "counter.json";
+const DEFAULT: Counter = { value: 0 };
+
+export default definePlugin(({ pubsub, files, log }) => {
+  // Serialise read-modify-write so two parallel \`increment\` calls
+  // don't both read the same snapshot and silently drop one update.
+  let writeLock: Promise<unknown> = Promise.resolve();
+  function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = writeLock.catch(() => undefined).then(fn);
+    writeLock = next.catch(() => undefined);
+    return next;
+  }
+
+  async function read(): Promise<Counter> {
+    if (!(await files.data.exists(COUNTER_FILE))) return DEFAULT;
+    const raw = await files.data.read(COUNTER_FILE);
+    return Counter.parse(JSON.parse(raw));
+  }
+
+  async function write(counter: Counter): Promise<void> {
+    await files.data.write(COUNTER_FILE, JSON.stringify(counter, null, 2));
+    pubsub.publish("changed", counter);
+  }
+
+  return {
+    TOOL_DEFINITION,
+
+    async incrementCounter(rawArgs: unknown) {
+      const args = Args.parse(rawArgs);
+      switch (args.kind) {
+        case "increment": {
+          return withWriteLock(async () => {
+            const current = await read();
+            const next: Counter = { value: current.value + (args.by ?? 1) };
+            await write(next);
+            log.info("counter incremented", { from: current.value, to: next.value });
+            return { ok: true, counter: next };
+          });
+        }
+        case "reset": {
+          return withWriteLock(async () => {
+            await write(DEFAULT);
+            return { ok: true, counter: DEFAULT };
+          });
+        }
+        case "get": {
+          return { ok: true, counter: await read() };
+        }
+        default: {
+          const exhaustive: never = args;
+          throw new Error(\`unknown kind: \${JSON.stringify(exhaustive)}\`);
+        }
+      }
+    },
+  };
+});
+`;
+
+const VUE_TS = `// Vue entry — exports the canvas component the host runtime plugin
+// loader dynamic-imports as \`dist/vue.js\`.
+
+import View from "./View.vue";
+import { TOOL_DEFINITION } from "./definition";
+
+export const plugin = {
+  toolDefinition: TOOL_DEFINITION,
+  viewComponent: View,
+};
+`;
+
+const VIEW_VUE = `<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import { useT } from "./lang";
+
+interface Counter {
+  value: number;
+}
+
+export interface Props {
+  selectedResult: { counter?: Counter };
+}
+const props = defineProps<Props>();
+
+const { pubsub, dispatch, log } = useRuntime();
+const t = useT();
+
+// Seed from the latest tool result so the first paint matches what
+// the LLM call returned, even before the refetch fires.
+const counter = ref<Counter>(props.selectedResult.counter ?? { value: 0 });
+const busy = ref(false);
+
+async function refetch(): Promise<void> {
+  const result = await dispatch({ kind: "get" });
+  if (result?.ok && result.counter) counter.value = result.counter;
+}
+
+async function increment(): Promise<void> {
+  if (busy.value) return;
+  busy.value = true;
+  try {
+    const result = await dispatch({ kind: "increment", by: 1 });
+    if (result?.ok && result.counter) counter.value = result.counter;
+  } catch (err) {
+    log.warn("increment failed", { error: String(err) });
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function reset(): Promise<void> {
+  if (busy.value) return;
+  busy.value = true;
+  try {
+    const result = await dispatch({ kind: "reset" });
+    if (result?.ok && result.counter) counter.value = result.counter;
+  } finally {
+    busy.value = false;
+  }
+}
+
+let unsubscribe: (() => void) | null = null;
+
+onMounted(() => {
+  refetch();
+  unsubscribe = pubsub.subscribe("changed", (next: Counter) => {
+    counter.value = next;
+  });
+});
+
+onUnmounted(() => {
+  unsubscribe?.();
+});
+</script>
+
+<template>
+  <div class="counter">
+    <h1>{{ t.title }}</h1>
+    <p class="value">{{ counter.value }}</p>
+    <div class="actions">
+      <button :disabled="busy" @click="increment">{{ t.increment }}</button>
+      <button :disabled="busy" @click="reset">{{ t.reset }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.counter {
+  padding: 1rem;
+  font-family: system-ui, sans-serif;
+}
+.value {
+  font-size: 3rem;
+  font-weight: 600;
+  margin: 1rem 0;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>
+`;
+
+const LANG_EN = `export default {
+  title: "Counter",
+  increment: "Increment",
+  reset: "Reset",
+};
+`;
+
+const LANG_JA = `export default {
+  title: "カウンター",
+  increment: "+1",
+  reset: "リセット",
+};
+`;
+
+const LANG_INDEX = `// Plugin-local i18n. Translation tables travel with the plugin
+// bundle. The plugin reads the host's locale via \`useRuntime()\` and
+// looks up its own table reactively.
+
+import { computed } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import en from "./en";
+import ja from "./ja";
+
+const MESSAGES = { en, ja } as const;
+type LocaleKey = keyof typeof MESSAGES;
+
+function isSupportedLocale(value: string): value is LocaleKey {
+  return value in MESSAGES;
+}
+
+export function useT() {
+  const { locale } = useRuntime();
+  return computed(() => (isSupportedLocale(locale.value) ? MESSAGES[locale.value] : MESSAGES.en));
+}
+`;
+
+const README = `# ${PLUGIN_NAME_PLACEHOLDER}
+
+MulmoClaude runtime plugin scaffolded with \`create-mulmoclaude-plugin\`.
+
+The included sample is a counter — one tool (\`incrementCounter\`)
+with three actions (increment / reset / get), persistent state in
+\`files.data\`, pubsub on every mutation, and a Vue View that
+reflects changes live across tabs. Use it as a starting point;
+rename and reshape as you go.
+
+## Build
+
+\`\`\`bash
+yarn install
+yarn build
+\`\`\`
+
+\`yarn build\` produces \`dist/index.js\` (server entry) and
+\`dist/vue.js\` (browser entry) plus matching \`.d.ts\` files.
+
+## Develop against MulmoClaude
+
+For now the smoothest local-development path is \`yarn link\`:
+
+\`\`\`bash
+# In this plugin directory:
+yarn link
+
+# In the mulmoclaude monorepo:
+yarn link ${PLUGIN_NAME_PLACEHOLDER}
+
+# Add the plugin to mulmoclaude's preset list (server/plugins/preset-list.ts)
+# or install it via the runtime install UI.
+
+yarn dev   # mulmoclaude
+\`\`\`
+
+A first-class "install from local path" workflow is being tracked at
+[receptron/mulmoclaude#1159](https://github.com/receptron/mulmoclaude/issues/1159) PR2 / PR3.
+
+When you edit plugin source you need to rebuild
+(\`yarn build\` or \`yarn dev\` — \`vite build --watch\`) and ask
+mulmoclaude to reload the plugin (restart server is the current
+fallback).
+
+## Publish
+
+When the plugin is ready:
+
+\`\`\`bash
+npm publish
+\`\`\`
+
+## Plugin runtime API
+
+This plugin uses the \`gui-chat-protocol\` v0.3 runtime API:
+
+- \`definePlugin(({ runtime }) => ({ TOOL_DEFINITION, [toolName]: handler }))\` —
+  factory that returns the handler bound to the runtime's destructured
+  pieces.
+- \`runtime.files.data\` — persistent JSON / text under
+  \`~/mulmoclaude/data/plugins/<encoded-pkg>/\`. Backup target.
+- \`runtime.files.config\` — per-machine UI prefs.
+- \`runtime.pubsub.publish(channel, payload)\` — broadcast to every
+  open tab of mulmoclaude. The View calls \`pubsub.subscribe\` to
+  refresh when mutations land.
+- \`runtime.log\` — structured logging that lands in the host's log
+  file.
+- Browser side: \`useRuntime()\` (from \`gui-chat-protocol/vue\`)
+  exposes \`pubsub\`, \`dispatch\` (calls back into the server
+  handler), \`locale\`, \`openUrl\`, and \`log\`.
+
+The eslint preset (\`gui-chat-protocol/eslint-preset\`) bans direct
+\`node:fs\` / \`node:path\` / \`console\` / \`fetch\` calls — every
+I/O goes through the runtime.
+
+## Layout
+
+\`\`\`
+src/
+  index.ts          server: definePlugin factory, persistent state, pubsub
+  definition.ts     TOOL_DEFINITION shared between server + browser
+  vue.ts            browser: { toolDefinition, viewComponent }
+  View.vue          canvas SFC, useRuntime + dispatch + pubsub.subscribe
+  shims-vue.d.ts    Vue SFC type shim for tsc
+  lang/
+    en.ts           translation table
+    ja.ts           Japanese translations
+    index.ts        useT() composable that reads runtime.locale
+\`\`\`
+
+## License
+
+MIT
+`;
+
+export const TEMPLATE_FILES: TemplateFile[] = [
+  { path: "package.json", content: PACKAGE_JSON },
+  { path: "tsconfig.json", content: TSCONFIG },
+  { path: "vite.config.ts", content: VITE_CONFIG },
+  { path: "eslint.config.mjs", content: ESLINT_CONFIG },
+  { path: ".gitignore", content: GITIGNORE },
+  { path: "README.md", content: README },
+  { path: "src/index.ts", content: INDEX_TS },
+  { path: "src/definition.ts", content: DEFINITION_TS },
+  { path: "src/vue.ts", content: VUE_TS },
+  { path: "src/View.vue", content: VIEW_VUE },
+  { path: "src/shims-vue.d.ts", content: SHIMS_VUE },
+  { path: "src/lang/en.ts", content: LANG_EN },
+  { path: "src/lang/ja.ts", content: LANG_JA },
+  { path: "src/lang/index.ts", content: LANG_INDEX },
+];
+
+export function applyPlaceholders(content: string, pluginName: string): string {
+  return content.split(PLUGIN_NAME_PLACEHOLDER).join(pluginName);
+}

--- a/packages/create-mulmoclaude-plugin/src/template.ts
+++ b/packages/create-mulmoclaude-plugin/src/template.ts
@@ -328,8 +328,12 @@ const counter = ref<Counter>(props.selectedResult.counter ?? { value: 0 });
 const busy = ref(false);
 
 async function refetch(): Promise<void> {
-  const result = await dispatch<DispatchResult>({ kind: "get" });
-  if (result?.ok && result.counter) counter.value = result.counter;
+  try {
+    const result = await dispatch<DispatchResult>({ kind: "get" });
+    if (result?.ok && result.counter) counter.value = result.counter;
+  } catch (err) {
+    log.warn("refetch failed", { error: String(err) });
+  }
 }
 
 async function increment(): Promise<void> {
@@ -351,6 +355,8 @@ async function reset(): Promise<void> {
   try {
     const result = await dispatch<DispatchResult>({ kind: "reset" });
     if (result?.ok && result.counter) counter.value = result.counter;
+  } catch (err) {
+    log.warn("reset failed", { error: String(err) });
   } finally {
     busy.value = false;
   }

--- a/packages/create-mulmoclaude-plugin/src/validate.ts
+++ b/packages/create-mulmoclaude-plugin/src/validate.ts
@@ -41,7 +41,7 @@ function reject(reason: string): ValidationResult {
 export function validatePluginName(raw: string): ValidationResult {
   if (typeof raw !== "string") return reject("name must be a string");
   if (raw.length === 0) return reject("name is required");
-  if (raw.length > MAX_LENGTH) return reject(`name too long (max ${MAX_LENGTH} charars)`);
+  if (raw.length > MAX_LENGTH) return reject(`name too long (max ${MAX_LENGTH} chars)`);
   if (raw !== raw.toLowerCase()) return reject("name must be lowercase");
   if (/\s/.test(raw)) return reject("name must not contain whitespace");
 

--- a/packages/create-mulmoclaude-plugin/src/validate.ts
+++ b/packages/create-mulmoclaude-plugin/src/validate.ts
@@ -6,7 +6,16 @@
 // The validator is exported so tests can pin every accept/reject
 // case.
 
+import { builtinModules } from "node:module";
+
 const MAX_LENGTH = 214; // npm spec — total length including scope
+
+// Names npm itself rejects on publish — guarding here so the user
+// doesn't get a clean scaffold and then hit a publish failure later.
+// Sources: validate-npm-package-name's blacklist + builtinModules.
+// Scoped names are exempt (npm allows `@scope/http`); we only check
+// the unscoped path.
+const RESERVED_NAMES = new Set<string>(["node_modules", "favicon.ico", ...builtinModules]);
 
 function isSegmentChar(char: string): boolean {
   return (char >= "a" && char <= "z") || (char >= "0" && char <= "9") || char === "." || char === "_" || char === "-";
@@ -64,12 +73,13 @@ function validateScoped(raw: string): ValidationResult {
 function validateUnscoped(raw: string): ValidationResult {
   if (raw.startsWith(".") || raw.startsWith("_")) return reject("name must not start with `.` or `_`");
   if (!isValidSegment(raw)) return reject(`invalid name: ${raw}`);
+  if (RESERVED_NAMES.has(raw)) return reject(`name is reserved (npm/Node built-in): ${raw}`);
   return OK_RESULT;
 }
 
 // Extract the directory name from a package name. For unscoped names
 // this is the name itself; for scoped names we use the local part so
-// `npx create-mulmoclaude-plugin @example/foo` lands in `foo/`, whichar
+// `npx create-mulmoclaude-plugin @example/foo` lands in `foo/`, which
 // is what `npm init` and friends do too.
 export function directoryNameFor(packageName: string): string {
   if (packageName.startsWith("@")) {

--- a/packages/create-mulmoclaude-plugin/src/validate.ts
+++ b/packages/create-mulmoclaude-plugin/src/validate.ts
@@ -1,0 +1,80 @@
+// Pluggable name validation. The full npm package-name spec is
+// elaborate (see `validate-npm-package-name`); we implement the
+// subset that matters for plugin scaffolding: lowercase, no spaces,
+// optional `@scope/` prefix, hyphenated segments, length bound.
+//
+// The validator is exported so tests can pin every accept/reject
+// case.
+
+const MAX_LENGTH = 214; // npm spec — total length including scope
+
+function isSegmentChar(char: string): boolean {
+  return (char >= "a" && char <= "z") || (char >= "0" && char <= "9") || char === "." || char === "_" || char === "-";
+}
+
+function isAlnum(char: string): boolean {
+  return (char >= "a" && char <= "z") || (char >= "0" && char <= "9");
+}
+
+function isValidSegment(seg: string): boolean {
+  if (seg.length === 0) return false;
+  if (!isAlnum(seg[0])) return false;
+  if (!isAlnum(seg[seg.length - 1])) return false;
+  for (const char of seg) {
+    if (!isSegmentChar(char)) return false;
+  }
+  return true;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  /** Human-readable error message; empty string when ok. */
+  reason: string;
+}
+
+const OK_RESULT: ValidationResult = { ok: true, reason: "" };
+
+function reject(reason: string): ValidationResult {
+  return { ok: false, reason };
+}
+
+export function validatePluginName(raw: string): ValidationResult {
+  if (typeof raw !== "string") return reject("name must be a string");
+  if (raw.length === 0) return reject("name is required");
+  if (raw.length > MAX_LENGTH) return reject(`name too long (max ${MAX_LENGTH} charars)`);
+  if (raw !== raw.toLowerCase()) return reject("name must be lowercase");
+  if (/\s/.test(raw)) return reject("name must not contain whitespace");
+
+  if (raw.startsWith("@")) return validateScoped(raw);
+  return validateUnscoped(raw);
+}
+
+function validateScoped(raw: string): ValidationResult {
+  const slash = raw.indexOf("/");
+  if (slash < 0) return reject("scoped name must include `/`");
+  const scope = raw.slice(1, slash); // drop leading `@`
+  const local = raw.slice(slash + 1);
+  if (scope.length === 0) return reject("scope is empty");
+  if (local.length === 0) return reject("local name is empty");
+  if (!isValidSegment(scope)) return reject(`invalid scope: ${scope}`);
+  if (!isValidSegment(local)) return reject(`invalid local name: ${local}`);
+  return OK_RESULT;
+}
+
+function validateUnscoped(raw: string): ValidationResult {
+  if (raw.startsWith(".") || raw.startsWith("_")) return reject("name must not start with `.` or `_`");
+  if (!isValidSegment(raw)) return reject(`invalid name: ${raw}`);
+  return OK_RESULT;
+}
+
+// Extract the directory name from a package name. For unscoped names
+// this is the name itself; for scoped names we use the local part so
+// `npx create-mulmoclaude-plugin @example/foo` lands in `foo/`, whichar
+// is what `npm init` and friends do too.
+export function directoryNameFor(packageName: string): string {
+  if (packageName.startsWith("@")) {
+    const slash = packageName.indexOf("/");
+    return packageName.slice(slash + 1);
+  }
+  return packageName;
+}

--- a/packages/create-mulmoclaude-plugin/test/test_create.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_create.ts
@@ -86,6 +86,13 @@ describe("runCli — error paths", () => {
     assert.match(outputs.join(""), /Usage:/);
   });
 
+  it("rejects multiple positional arguments", async () => {
+    outputs = [];
+    const result = await runCli(["foo", "bar"], workdir, captureOutput);
+    assert.equal(result.exitCode, 1);
+    assert.match(outputs.join(""), /Expected exactly one package name/);
+  });
+
   it("rejects an invalid name", async () => {
     outputs = [];
     const result = await runCli(["My Bad Name"], workdir, captureOutput);

--- a/packages/create-mulmoclaude-plugin/test/test_create.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_create.ts
@@ -1,0 +1,117 @@
+// Integration test: run the CLI in a temp directory and verify the
+// resulting plugin tree. Skips the actual `yarn install / yarn build`
+// — that's outside the CLI's responsibility and would slow CI down.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runCli } from "../src/index.js";
+
+let workdir: string;
+let outputs: string[];
+
+function captureOutput(text: string): void {
+  outputs.push(text);
+}
+
+before(async () => {
+  workdir = await mkdtemp(path.join(tmpdir(), "create-mulmoclaude-plugin-"));
+  outputs = [];
+});
+
+after(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("runCli — happy path", () => {
+  it("creates the expected file tree for an unscoped name", async () => {
+    outputs = [];
+    const result = await runCli(["my-plugin"], workdir, captureOutput);
+    assert.equal(result.exitCode, 0);
+
+    const root = path.join(workdir, "my-plugin");
+    const expected = [
+      "package.json",
+      "tsconfig.json",
+      "vite.config.ts",
+      "eslint.config.mjs",
+      ".gitignore",
+      "README.md",
+      "src/index.ts",
+      "src/definition.ts",
+      "src/vue.ts",
+      "src/View.vue",
+      "src/shims-vue.d.ts",
+      "src/lang/en.ts",
+      "src/lang/ja.ts",
+      "src/lang/index.ts",
+    ];
+    for (const rel of expected) {
+      const full = path.join(root, rel);
+      const stats = await stat(full);
+      assert.ok(stats.isFile(), `expected file: ${rel}`);
+    }
+
+    const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf-8"));
+    assert.equal(pkg.name, "my-plugin");
+    assert.equal(pkg.type, "module");
+
+    const indexTs = await readFile(path.join(root, "src/index.ts"), "utf-8");
+    assert.match(indexTs, /definePlugin/);
+
+    const allOutput = outputs.join("");
+    assert.match(allOutput, /Created my-plugin/);
+    assert.match(allOutput, /yarn build/);
+  });
+
+  it("creates a directory matching the local part for a scoped name", async () => {
+    outputs = [];
+    const result = await runCli(["@example/cool-plugin"], workdir, captureOutput);
+    assert.equal(result.exitCode, 0);
+
+    const root = path.join(workdir, "cool-plugin");
+    const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf-8"));
+    assert.equal(pkg.name, "@example/cool-plugin");
+  });
+});
+
+describe("runCli — error paths", () => {
+  it("prints usage and exits 1 when no name is given", async () => {
+    outputs = [];
+    const result = await runCli([], workdir, captureOutput);
+    assert.equal(result.exitCode, 1);
+    assert.match(outputs.join(""), /Usage:/);
+  });
+
+  it("rejects an invalid name", async () => {
+    outputs = [];
+    const result = await runCli(["My Bad Name"], workdir, captureOutput);
+    assert.equal(result.exitCode, 1);
+    assert.match(outputs.join(""), /Invalid package name/);
+  });
+
+  it("refuses to overwrite an existing directory", async () => {
+    const fresh = await mkdtemp(path.join(tmpdir(), "create-mulmoclaude-plugin-overwrite-"));
+    try {
+      // Pre-create the target dir to simulate a name collision.
+      const collisionTarget = path.join(fresh, "exists-already");
+      await (await import("node:fs/promises")).mkdir(collisionTarget);
+      // Add a marker so we can prove it survived.
+      await writeFile(path.join(collisionTarget, "marker.txt"), "untouched");
+
+      const captured: string[] = [];
+      const result = await runCli(["exists-already"], fresh, (text) => captured.push(text));
+      assert.equal(result.exitCode, 1);
+      assert.match(captured.join(""), /Refusing to overwrite/);
+
+      // Marker is still there — we did not blow away the user's data.
+      const marker = await readFile(path.join(collisionTarget, "marker.txt"), "utf-8");
+      assert.equal(marker, "untouched");
+    } finally {
+      await rm(fresh, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/create-mulmoclaude-plugin/test/test_invoke.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_invoke.ts
@@ -1,0 +1,64 @@
+// Regression tests for the direct-invocation gate.
+//
+// History: an earlier revision used `argv[1].endsWith("/dist/index.js")`,
+// which is POSIX-only and silently no-ops on Windows where argv paths use
+// backslashes. The replacement compares resolved real paths through
+// `realpathSync` + `fileURLToPath`, which handles separators AND symlinks
+// (npm bin shims). These tests pin the contract — anyone reverting to a
+// suffix-string check will trip the symlink case.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { realpathSync } from "node:fs";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { entryMatchesModule } from "../src/index.js";
+
+let workdir: string;
+
+before(async () => {
+  // realpath the tmpdir so macOS's /var → /private/var symlink doesn't
+  // skew the comparison — entryMatchesModule resolves entry via
+  // realpathSync but takes the module URL verbatim.
+  workdir = realpathSync(await mkdtemp(path.join(tmpdir(), "create-mulmoclaude-plugin-invoke-")));
+});
+
+after(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("entryMatchesModule", () => {
+  it("returns true when entry resolves to the same file as the module URL", async () => {
+    const real = path.join(workdir, "real.js");
+    await writeFile(real, "// real entry");
+    assert.equal(entryMatchesModule(real, pathToFileURL(real).href), true);
+  });
+
+  it("returns true when entry is a symlink to the module file (npm bin shim)", async () => {
+    const real = path.join(workdir, "shim-target.js");
+    const link = path.join(workdir, "shim-link.js");
+    await writeFile(real, "// real entry");
+    await symlink(real, link);
+    assert.equal(entryMatchesModule(link, pathToFileURL(real).href), true);
+  });
+
+  it("returns false when entry points to a different file", async () => {
+    const real = path.join(workdir, "real-a.js");
+    const other = path.join(workdir, "real-b.js");
+    await writeFile(real, "// a");
+    await writeFile(other, "// b");
+    assert.equal(entryMatchesModule(other, pathToFileURL(real).href), false);
+  });
+
+  it("returns false when entry is undefined (no argv[1])", () => {
+    assert.equal(entryMatchesModule(undefined, "file:///anything.js"), false);
+  });
+
+  it("returns false when entry path does not exist (realpathSync throws)", () => {
+    const ghost = path.join(workdir, "does-not-exist.js");
+    assert.equal(entryMatchesModule(ghost, pathToFileURL(ghost).href), false);
+  });
+});

--- a/packages/create-mulmoclaude-plugin/test/test_template.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_template.ts
@@ -1,0 +1,102 @@
+// Tests for the template content + placeholder substitution.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyPlaceholders, PLUGIN_NAME_PLACEHOLDER, TEMPLATE_FILES } from "../src/template.js";
+
+describe("TEMPLATE_FILES — shape", () => {
+  it("includes every file the plugin layout needs", () => {
+    const paths = TEMPLATE_FILES.map((entry) => entry.path).sort();
+    assert.deepEqual(
+      paths,
+      [
+        ".gitignore",
+        "README.md",
+        "eslint.config.mjs",
+        "package.json",
+        "src/View.vue",
+        "src/definition.ts",
+        "src/index.ts",
+        "src/lang/en.ts",
+        "src/lang/index.ts",
+        "src/lang/ja.ts",
+        "src/shims-vue.d.ts",
+        "src/vue.ts",
+        "tsconfig.json",
+        "vite.config.ts",
+      ].sort(),
+    );
+  });
+
+  it("every entry has non-empty content", () => {
+    for (const entry of TEMPLATE_FILES) {
+      assert.ok(entry.content.length > 0, `empty content: ${entry.path}`);
+    }
+  });
+
+  it("uses POSIX path separators only", () => {
+    for (const entry of TEMPLATE_FILES) {
+      assert.equal(entry.path.includes("\\"), false, `Windows separator in ${entry.path}`);
+    }
+  });
+});
+
+describe("applyPlaceholders", () => {
+  it("substitutes {{PLUGIN_NAME}} verbatim — package.json", () => {
+    const pkg = TEMPLATE_FILES.find((entry) => entry.path === "package.json");
+    assert.ok(pkg);
+    assert.match(pkg.content, /"name": "\{\{PLUGIN_NAME\}\}"/);
+    const result = applyPlaceholders(pkg.content, "my-plugin");
+    assert.match(result, /"name": "my-plugin"/);
+    assert.doesNotMatch(result, /\{\{PLUGIN_NAME\}\}/);
+  });
+
+  it("substitutes scoped names too", () => {
+    const pkg = TEMPLATE_FILES.find((entry) => entry.path === "package.json");
+    assert.ok(pkg);
+    const result = applyPlaceholders(pkg.content, "@example/cool-plugin");
+    assert.match(result, /"name": "@example\/cool-plugin"/);
+  });
+
+  it("substitutes README's {{PLUGIN_NAME}} mentions in every place", () => {
+    const readme = TEMPLATE_FILES.find((entry) => entry.path === "README.md");
+    assert.ok(readme);
+    const occurrences = readme.content.split(PLUGIN_NAME_PLACEHOLDER).length - 1;
+    assert.ok(occurrences >= 2, `README should reference plugin name multiple times; got ${occurrences}`);
+    const result = applyPlaceholders(readme.content, "my-plugin");
+    assert.doesNotMatch(result, /\{\{PLUGIN_NAME\}\}/);
+  });
+
+  it("leaves files without placeholders unchanged", () => {
+    const tsconfig = TEMPLATE_FILES.find((entry) => entry.path === "tsconfig.json");
+    assert.ok(tsconfig);
+    const result = applyPlaceholders(tsconfig.content, "my-plugin");
+    assert.equal(result, tsconfig.content);
+  });
+});
+
+describe("template — server / browser entry shape", () => {
+  it("server entry references definePlugin", () => {
+    const indexTs = TEMPLATE_FILES.find((entry) => entry.path === "src/index.ts");
+    assert.ok(indexTs);
+    assert.match(indexTs.content, /definePlugin/);
+    assert.match(indexTs.content, /TOOL_DEFINITION/);
+    assert.match(indexTs.content, /pubsub\.publish/);
+    assert.match(indexTs.content, /files\.data/);
+  });
+
+  it("browser entry exports the plugin shape the host expects", () => {
+    const vueTs = TEMPLATE_FILES.find((entry) => entry.path === "src/vue.ts");
+    assert.ok(vueTs);
+    assert.match(vueTs.content, /toolDefinition/);
+    assert.match(vueTs.content, /viewComponent/);
+  });
+
+  it("View uses the runtime composable", () => {
+    const view = TEMPLATE_FILES.find((entry) => entry.path === "src/View.vue");
+    assert.ok(view);
+    assert.match(view.content, /useRuntime/);
+    assert.match(view.content, /pubsub\.subscribe/);
+  });
+});

--- a/packages/create-mulmoclaude-plugin/test/test_validate.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_validate.ts
@@ -1,0 +1,72 @@
+// Tests for plugin name validation.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { directoryNameFor, validatePluginName } from "../src/validate.js";
+
+describe("validatePluginName — accepts canonical shapes", () => {
+  it("accepts unscoped lowercase + hyphens", () => {
+    assert.equal(validatePluginName("my-plugin").ok, true);
+    assert.equal(validatePluginName("counter").ok, true);
+    assert.equal(validatePluginName("foo123-bar").ok, true);
+  });
+
+  it("accepts scoped names", () => {
+    assert.equal(validatePluginName("@scope/plugin").ok, true);
+    assert.equal(validatePluginName("@example/cool-plugin").ok, true);
+  });
+
+  it("accepts dots in the segment (npm-legal: foo.bar)", () => {
+    assert.equal(validatePluginName("foo.bar").ok, true);
+  });
+});
+
+describe("validatePluginName — rejects malformed inputs", () => {
+  it("rejects empty", () => {
+    assert.equal(validatePluginName("").ok, false);
+  });
+
+  it("rejects uppercase", () => {
+    assert.equal(validatePluginName("MyPlugin").ok, false);
+    assert.equal(validatePluginName("@Scope/plugin").ok, false);
+  });
+
+  it("rejects whitespace anywhere", () => {
+    assert.equal(validatePluginName("my plugin").ok, false);
+    assert.equal(validatePluginName("my-plugin ").ok, false);
+  });
+
+  it("rejects leading dot or underscore on unscoped names", () => {
+    assert.equal(validatePluginName(".plugin").ok, false);
+    assert.equal(validatePluginName("_plugin").ok, false);
+  });
+
+  it("rejects scoped names with empty parts", () => {
+    assert.equal(validatePluginName("@/plugin").ok, false);
+    assert.equal(validatePluginName("@scope/").ok, false);
+    assert.equal(validatePluginName("@scope").ok, false);
+  });
+
+  it("rejects names that exceed 214 chars", () => {
+    const long = "a".repeat(215);
+    assert.equal(validatePluginName(long).ok, false);
+  });
+
+  it("rejects punctuation that isn't dot/hyphen/underscore", () => {
+    assert.equal(validatePluginName("my!plugin").ok, false);
+    assert.equal(validatePluginName("foo$bar").ok, false);
+    assert.equal(validatePluginName("with/slash").ok, false);
+  });
+});
+
+describe("directoryNameFor", () => {
+  it("returns the name verbatim for unscoped packages", () => {
+    assert.equal(directoryNameFor("my-plugin"), "my-plugin");
+  });
+
+  it("strips the scope from scoped packages", () => {
+    assert.equal(directoryNameFor("@example/cool-plugin"), "cool-plugin");
+    assert.equal(directoryNameFor("@scope/foo"), "foo");
+  });
+});

--- a/packages/create-mulmoclaude-plugin/test/test_validate.ts
+++ b/packages/create-mulmoclaude-plugin/test/test_validate.ts
@@ -58,6 +58,24 @@ describe("validatePluginName — rejects malformed inputs", () => {
     assert.equal(validatePluginName("foo$bar").ok, false);
     assert.equal(validatePluginName("with/slash").ok, false);
   });
+
+  it("rejects npm-reserved names that would fail at publish time", () => {
+    assert.equal(validatePluginName("node_modules").ok, false);
+    assert.equal(validatePluginName("favicon.ico").ok, false);
+  });
+
+  it("rejects Node built-in module names", () => {
+    // builtinModules tracks per-Node-version; pick a few known stable ones
+    assert.equal(validatePluginName("http").ok, false);
+    assert.equal(validatePluginName("fs").ok, false);
+    assert.equal(validatePluginName("crypto").ok, false);
+    assert.equal(validatePluginName("path").ok, false);
+  });
+
+  it("still accepts the same names when scoped (npm permits @scope/http)", () => {
+    assert.equal(validatePluginName("@example/http").ok, true);
+    assert.equal(validatePluginName("@example/node_modules").ok, true);
+  });
 });
 
 describe("directoryNameFor", () => {

--- a/packages/create-mulmoclaude-plugin/tsconfig.json
+++ b/packages/create-mulmoclaude-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/plans/feat-create-mulmoclaude-plugin-cli.md
+++ b/plans/feat-create-mulmoclaude-plugin-cli.md
@@ -55,7 +55,7 @@ argument verbatim; everything else stays as the counter sample.
 
 No interactive prompts (Phase 1). The CLI prints next steps:
 
-```
+```text
 ✓ Created notes-plugin/
 
 Next:
@@ -75,7 +75,7 @@ Next:
 
 ## Implementation
 
-```
+```text
 packages/create-mulmoclaude-plugin/
   package.json                 — declares `bin: { "create-mulmoclaude-plugin": "./dist/index.js" }`
   tsconfig.json

--- a/plans/feat-create-mulmoclaude-plugin-cli.md
+++ b/plans/feat-create-mulmoclaude-plugin-cli.md
@@ -1,0 +1,146 @@
+# `create-mulmoclaude-plugin` CLI (PR1 of #1159)
+
+Scaffold a new MulmoClaude runtime plugin with one command:
+
+```bash
+npx create-mulmoclaude-plugin my-plugin
+```
+
+The CLI lives in `packages/create-mulmoclaude-plugin/` (workspace
+package, published to npm). Output is a self-contained plugin
+directory the user can `cd` into and `yarn install && yarn build`.
+
+## What the user gets
+
+A `my-plugin/` directory with:
+
+- `package.json` — name set to the user's argument; `peerDependencies`
+  on `gui-chat-protocol` / `vue` / `zod` aligned with the bookmarks-
+  plugin reference; `main` / `exports` / `files` / `scripts` ready
+  for npm publish.
+- `tsconfig.json` / `vite.config.ts` / `eslint.config.mjs` / `.gitignore`
+  matching the in-tree plugin convention (mirrors bookmarks-plugin).
+- `README.md` — dev loop walkthrough (build, link to mulmoclaude,
+  reload on change, publish).
+- `src/`
+  - `index.ts` — server entry: `definePlugin` factory with one
+    sample action (`incrementCounter`) using `files.data` and
+    `pubsub.publish`.
+  - `definition.ts` — `TOOL_DEFINITION` with the matching schema.
+  - `vue.ts` — browser entry exporting `{ toolDefinition,
+    viewComponent }`.
+  - `View.vue` — minimal Vue SFC using `useRuntime()` to dispatch
+    the action and subscribe to the pubsub channel.
+  - `shims-vue.d.ts` — Vue SFC type shim for `tsc --noEmit`.
+  - `lang/{en,ja,index}.ts` — plugin-local i18n via the runtime's
+    `locale` ref.
+
+The sample is a counter (~80 LOC of plugin code) — interactive
+enough to exercise read / write / pubsub / dispatch, small enough
+that the user can rename and reshape without fighting boilerplate.
+
+## CLI behavior
+
+Single positional argument: the plugin name.
+
+```bash
+npx create-mulmoclaude-plugin notes-plugin
+npx create-mulmoclaude-plugin @example/cool-plugin
+```
+
+Validates against npm package-name rules (lowercase, optional `@scope/`
+prefix, hyphens, no spaces, length ≤ 214). Refuses to overwrite an
+existing directory. The package name in `package.json` is set to the
+argument verbatim; everything else stays as the counter sample.
+
+No interactive prompts (Phase 1). The CLI prints next steps:
+
+```
+✓ Created notes-plugin/
+
+Next:
+
+  cd notes-plugin
+  yarn install
+  yarn build
+
+  # Link into mulmoclaude for local dev (PR2 will replace this with
+  # a UI install-from-path mode):
+  yarn link
+  cd ../mulmoclaude && yarn link notes-plugin
+
+  # Publish when ready:
+  npm publish
+```
+
+## Implementation
+
+```
+packages/create-mulmoclaude-plugin/
+  package.json                 — declares `bin: { "create-mulmoclaude-plugin": "./dist/index.js" }`
+  tsconfig.json
+  src/
+    index.ts                   — CLI entry: parse argv, validate, write
+    validate.ts                — pure name validator
+    template.ts                — template file table (path → content)
+  test/
+    test_validate.ts           — happy / boundary / reject cases
+    test_template.ts           — every entry has expected placeholder slots
+    test_create.ts             — integration: spawn CLI in mkdtemp, assert tree
+  README.md
+```
+
+The template files live as **string constants in `template.ts`** rather
+than as separate files on disk. Reasons:
+
+1. `tsc --noEmit` would lint template `.vue` / `.ts` files and trip
+   on `{{PLUGIN_NAME}}` placeholders.
+2. The eslint preset `plugin-imports-banned` would flag the template's
+   `gui-chat-protocol` import (templates aren't real source).
+3. Bundling the CLI to a single `dist/index.js` is simpler when the
+   template is inline.
+
+The trade-off is that template edits require re-typing the source as a
+string literal. With ~10 template files and ~300 total LOC of template
+content, this is acceptable.
+
+## Placeholders
+
+Only one substitution: `{{PLUGIN_NAME}}` → the user's argument.
+
+Substituted in:
+- `package.json` `name` field
+- `README.md` for example commands
+- `vite.config.ts` build output names (where applicable — usually not
+  needed because `lib.entry` already names them)
+
+Everything else (tool name, action names, file names) stays as the
+counter sample. The user renames as they evolve their plugin.
+
+## Out of scope (future PRs)
+
+- Runtime loader local-path install (PR2 of #1159)
+- Settings UI for installed-plugin reload (PR3 of #1159)
+- Hot reload (deferred; vite HMR through the runtime loader is non-
+  trivial)
+- Interactive prompt mode (Phase 2 if there's demand)
+- Different template flavours (e.g. UI-less plugin, bridge plugin) —
+  one template = one cognitive load; specialise later
+
+## Tests
+
+- `validate.ts` — accepts unscoped / scoped / hyphenated; rejects
+  spaces, uppercase, overlong, empty, leading dot, etc.
+- `template.ts` — every template entry referencing `{{PLUGIN_NAME}}`
+  produces a non-empty string after substitution.
+- Integration — run the CLI in an `mkdtemp`'d directory, assert
+  every expected file is present and contains the correct package
+  name. Skip the actual `yarn install / yarn build` (CI-expensive
+  and not what the CLI is responsible for).
+
+## Publish flow
+
+The CLI itself ships via the existing `/publish` skill. First release:
+`create-mulmoclaude-plugin@0.1.0`. Tag style follows
+`@scope/name@X.Y.Z` per project convention; this one is unscoped, so
+the tag is `create-mulmoclaude-plugin@0.1.0`.


### PR DESCRIPTION
## Summary

PR1 of #1159 — adds a `create-mulmoclaude-plugin` npm package so external authors can scaffold a runnable plugin in one command:

```bash
npx create-mulmoclaude-plugin my-plugin
# or
npx create-mulmoclaude-plugin @example/cool-plugin
```

The output is a counter-sample plugin (server `definePlugin` factory, `View.vue` canvas, plugin-local i18n, build/lint config matching in-tree reference plugins like `bookmarks-plugin` / `todo-plugin`). Authors edit `src/*` to evolve it into their own plugin.

This is **PR1 only** — local-path install (PR2) and reload UI (PR3) remain on #1159.

## Items to Confirm / Review

- **Counter sample as the template** — chosen because every line demonstrates the runtime API surface (`pubsub.publish`, `files.data`, `useRuntime`, `dispatch`). Trade-off: a handful of deletions when an author starts their real plugin. Alternative was an empty plugin; rejected because authors then have to reverse-engineer the API from the in-tree references.
- **Inline template strings (`src/template.ts`)** — keeps `{{PLUGIN_NAME}}` placeholders out of TS/ESLint's parse paths. Alternative was a `templates/` directory of real files copied at runtime; rejected because they'd either need `.tmpl` extensions (uglier) or the placeholders would break tsc on the package itself.
- **`@scope/name` → `name/` directory** — matches `npm init`'s convention. Tested in `test_create.ts`.
- **No interactive prompts (Phase 1)** — single positional arg only. Author preferences (locale, plugin description, etc.) come later if there's demand.
- **Author dev loop documentation** — `README.md` points at `yarn link` as the current path and references #1159 PR2 for the future "install from path" surface.

## User Prompt

> c3やる？  → ok

(Continuing the umbrella-issue split from #1043 close: C-3 became #1159, this is its PR1.)

## Implementation

- `src/validate.ts` — pure name validator (lowercase, optional `@scope/`, length ≤ 214) + `directoryNameFor(name)`. Refactored from a regex to a character-loop predicate to satisfy `security/detect-unsafe-regex`.
- `src/template.ts` — 14 inline template strings + `applyPlaceholders(content, name)`. Single `{{PLUGIN_NAME}}` placeholder.
- `src/index.ts` — CLI entry: parses argv, validates name, refuses to overwrite, scaffolds, prints next-step message. Exports `runCli(argv, cwd, write)` so tests don't have to spawn a process.
- `test/test_validate.ts` — accept/reject coverage (canonical, scoped, empty, uppercase, whitespace, leading dot/underscore, length cap, punctuation).
- `test/test_template.ts` — file-tree shape, placeholder substitution (`package.json`, README), entry-point shape sanity.
- `test/test_create.ts` — integration: run `runCli` in `mkdtemp`, verify 14 files, `package.json.name`, error paths (no name, invalid name, refuse-overwrite).

## Test Plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all green
- [x] 27/27 package tests pass
- [x] Smoke test: `npx` equivalent in a tmpdir produces the 14-file plugin tree
- [ ] Reviewer manually `cd packages/create-mulmoclaude-plugin && yarn build && node dist/index.js my-plugin` in a scratch dir → `cd my-plugin && yarn install && yarn build` succeeds
- [ ] Reviewer confirms the counter sample exercises the runtime API the way they'd want a learner to encounter it

Closes part of #1159 (PR1 only — PR2 / PR3 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI tool to scaffold MulmoClaude runtime plugins using `npx create-mulmoclaude-plugin <name>`
  * Automatically generates complete plugin project structure with build configuration, Vue components, and internationalization support
  * Validates package names and prevents overwriting existing directories

* **Documentation**
  * Included setup guide with next steps for new plugin projects

* **Tests**
  * Added comprehensive test coverage for CLI functionality and package validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->