### PR TITLE
fix(dev-loader): strip duplicate [plugins/dev] prefix from fatalMessages

### DIFF
--- a/server/plugins/dev-loader.ts
+++ b/server/plugins/dev-loader.ts
@@ -132,15 +132,17 @@ export type DevPluginGate = { ok: true; plugins: readonly RuntimePlugin[] } | { 
  *  fatalMessage and `process.exit(1)`s; tests assert on the verdict
  *  shape directly. */
 export function evaluateDevPluginGate(devLoad: LoadDevPluginsResult, otherPlugins: readonly RuntimePlugin[]): DevPluginGate {
+  // The caller logs each message under the `plugins/dev` category, so
+  // the structured logger already prepends `[plugins/dev]`. Don't bake
+  // the prefix into the message strings — that would print it twice.
   if (devLoad.errors.length > 0) {
-    const messages = devLoad.errors.map((entry) => `[plugins/dev] ${entry}`);
-    messages.push(`[plugins/dev] ${devLoad.errors.length} dev plugin(s) failed to load — refusing to start.`);
+    const messages = [...devLoad.errors, `${devLoad.errors.length} dev plugin(s) failed to load — refusing to start.`];
     return { ok: false, fatalMessages: messages };
   }
   const collisions = detectDevCollisions(devLoad.plugins, otherPlugins);
   if (collisions.length > 0) {
-    const messages = collisions.map((collision) => `[plugins/dev] name collision: ${collision.name} sources=${JSON.stringify(collision.sources)}`);
-    messages.push("[plugins/dev] dev plugin name collides with installed plugin or another dev plugin — refusing to start.");
+    const messages = collisions.map((collision) => `name collision: ${collision.name} sources=${JSON.stringify(collision.sources)}`);
+    messages.push("dev plugin name collides with installed plugin or another dev plugin — refusing to start.");
     return { ok: false, fatalMessages: messages };
   }
   return { ok: true, plugins: devLoad.plugins };


### PR DESCRIPTION
## Summary

Follow-up on the CodeRabbit comment on #1167 (already merged) that surfaced after merge. The \`evaluateDevPluginGate\` helper introduced by #1167's automation pass embeds \`[plugins/dev]\` in every \`fatalMessage\`, but the call site in \`server/index.ts\` logs each one via \`log.error(\"plugins/dev\", message)\` — and the structured logger already prepends its category. So a real failure today logs:

\`\`\`
[plugins/dev] [plugins/dev] name collision: @example/x sources=[...]
\`\`\`

Strip the literal prefix from the helper and let the logger own scoping.

## Items to Confirm / Review

- The bug was introduced by my own refactor in #1167 (commit \`9f788f65\`) that pulled the inline if-blocks into a pure helper. The original inline code at \`server/index.ts:766\` did \`log.error(\"plugins/dev\", \\\`name collision: …\\\`)\` — single prefix. The helper added another one. Single-line fix.
- Existing tests use \`assert.match(joined, /refusing to start/)\` etc. without expecting the literal \`[plugins/dev]\` substring, so they still pass — no test changes needed.

## User Prompt

> comment読んで対応 (read PR comments + handle)

(Triaged the post-merge CodeRabbit thread on #1167.)

## Test Plan

- [x] \`yarn lint\` / \`yarn typecheck\` clean
- [x] \`yarn test\` — 4018 pass, 0 fail (\`evaluateDevPluginGate\` block all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure dev plugin loader fatal messages no longer include a hardcoded [plugins/dev] prefix so they are not logged twice under the plugins/dev category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting in development plugin loading. Error messages for plugin load failures and name collision warnings now display cleaner output without redundant formatting prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->