### PR TITLE
feat(spotify): Player Controls + Premium gate (#1162 PR 3)

### DIFF
--- a/docs/tips/spotify-setup.en.md
+++ b/docs/tips/spotify-setup.en.md
@@ -79,14 +79,23 @@ The PKCE flow doesn't use a Client Secret in the first place. The Client ID by i
 
 ## What you can read
 
-Read-only v1 surfaces:
+| Feature | Free / Open | Premium |
+|---|---|---|
+| Liked Songs | ✓ | ✓ |
+| Playlist list / tracks within a playlist | ✓ | ✓ |
+| Recently played (last 50, Spotify API ceiling) | ✓ | ✓ |
+| Currently playing (display only) | ✓ | ✓ |
+| Search (track / artist / album / playlist) | ✓ | ✓ |
+| Device list (`getDevices`) | ✓ | ✓ |
+| **Playback control (play / pause / next / prev / seek / volume / transferPlayback)** | ✗ | ✓ |
 
-- Liked Songs
-- Playlist list / tracks within a playlist
-- Recently played (last 50, Spotify API ceiling)
-- Currently playing
+Playback controls require **Spotify Premium** (Spotify Web API restriction). For Free / Open accounts the Player Controls panel is hidden, and LLM-issued `play` etc. return a `premium_required` error.
 
-Playback control (play / pause / skip) and write actions (add to liked / create playlist) land in a follow-up PR.
+Write actions for the user's library (add to liked / create playlist / playlist edits) land in a follow-up PR.
+
+## Reconnecting after PR 3 (existing users)
+
+PR 3 added two OAuth scopes (`user-read-playback-state`, `user-modify-playback-state`). Users who connected during PR 1 / PR 2 will see `403 Insufficient client scope` on player calls — click Reconnect in the View (or delete `tokens.json` and Connect again) to re-authorise with the new scopes.
 
 ## Related docs
 

--- a/docs/tips/spotify-setup.md
+++ b/docs/tips/spotify-setup.md
@@ -78,14 +78,23 @@ PKCE フローを使っているので Client Secret はそもそも持ちませ
 
 ## 何が取れる?
 
-read-only v1 では以下が取れます:
+| 機能 | Free / Open | Premium |
+|---|---|---|
+| お気に入り (Liked Songs) | ✓ | ✓ |
+| Playlists 一覧 / 各 playlist のトラック | ✓ | ✓ |
+| 最近聞いた曲 (直近 50 曲、Spotify API の上限) | ✓ | ✓ |
+| 今再生中の曲 (表示のみ) | ✓ | ✓ |
+| Search (track / artist / album / playlist) | ✓ | ✓ |
+| デバイス一覧 (`getDevices`) | ✓ | ✓ |
+| **再生制御 (play / pause / next / prev / seek / volume / transferPlayback)** | ✗ | ✓ |
 
-- お気に入り(Liked Songs)
-- Playlists 一覧 / 各 playlist のトラック
-- 最近聞いた曲(直近 50 曲、Spotify API の上限)
-- 今再生中の曲
+再生制御は **Spotify Premium が必須**です(Spotify Web API 側の制限)。Free / Open アカウントの場合、View 上では Player Controls は隠され、LLM 経由で `play` 等を呼んでも `premium_required` エラーが返ります。
 
-Playback 制御(再生 / 一時停止 / スキップ)や書き込み(Liked に追加 / playlist 作成)は別 PR で対応予定です。
+Liked への追加・削除、playlist 作成、編集は別 PR で対応予定です。
+
+## 既存接続の再認可 (PR 3 以降)
+
+PR 3 で OAuth scope を 2 個追加 (`user-read-playback-state`, `user-modify-playback-state`) しました。PR 1 / 2 のみで接続済みのユーザは再生制御を呼ぶと `403 Insufficient client scope` が返るので、View の「Reconnect」(または `tokens.json` 削除 → 再 Connect) で再認可してください。
 
 ## 関連ドキュメント
 

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -268,6 +268,14 @@ onUnmounted(() => {
         <template v-else>
           <span class="spotify-connected-pill">{{ t.connected }}</span>
           <span class="spotify-expiry">{{ t.expiresAt }}: {{ expiryDisplay }}</span>
+          <!-- PR 3 added two OAuth scopes; existing PR 1/2 connections
+               work for read-only kinds but Player Controls hit
+               `403 Insufficient client scope` until reconnect. The
+               Reconnect button is always available so the user can
+               re-authorise without manually deleting tokens.json. -->
+          <button type="button" class="spotify-reconnect" :disabled="isConnecting" @click="startConnect">
+            {{ isConnecting ? t.connecting : t.reconnect }}
+          </button>
         </template>
       </div>
     </header>
@@ -471,6 +479,23 @@ onUnmounted(() => {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 500;
+}
+.spotify-reconnect {
+  margin-left: auto;
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: #374151;
+}
+.spotify-reconnect:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+.spotify-reconnect:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 .spotify-expiry {
   font-size: 0.75rem;

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -81,11 +81,31 @@ async function saveClientId(): Promise<void> {
   }
 }
 
+// Spotify's redirect-URI policy:
+//   1. `localhost` is rejected — must use `127.0.0.1` or `[::1]`
+//   2. URI must match the one registered in the Dashboard EXACTLY
+//
+// In Vite dev, `window.location.origin` is the Vite dev server
+// (`localhost:5173`). Using that as the redirectUri would (a)
+// break Spotify's `127.0.0.1`-only rule, and (b) require the user
+// to register both the Vite-dev URI and the production-server URI
+// in their Dashboard.
+//
+// Always use `127.0.0.1:3001` so the Dashboard URI is a single
+// stable string that matches `docs/tips/spotify-setup.md`. Users
+// running the server on a different port (`npm run server -- --port
+// 3099`) need to substitute the port and register the same URI in
+// the Dashboard — the host's runtime registry doesn't expose its
+// own port to plugins, so we can't auto-detect.
+const SPOTIFY_REDIRECT_URI = "http://127.0.0.1:3001/api/plugins/runtime/oauth-callback/spotify";
+
 async function startConnect(): Promise<void> {
   isConnecting.value = true;
   try {
-    const redirectUri = `${window.location.origin}/api/plugins/runtime/oauth-callback/spotify`;
-    const response = await dispatch<{ ok: boolean; data?: { authorizeUrl?: string }; message?: string }>({ kind: "connect", redirectUri });
+    const response = await dispatch<{ ok: boolean; data?: { authorizeUrl?: string }; message?: string }>({
+      kind: "connect",
+      redirectUri: SPOTIFY_REDIRECT_URI,
+    });
     if (response.ok && response.data?.authorizeUrl) {
       window.location.href = response.data.authorizeUrl;
     } else {

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -107,7 +107,14 @@ async function startConnect(): Promise<void> {
       redirectUri: SPOTIFY_REDIRECT_URI,
     });
     if (response.ok && response.data?.authorizeUrl) {
-      window.location.href = response.data.authorizeUrl;
+      // Open the consent screen in a new tab. The original tab
+      // keeps the View; the server's `connected` pubsub event
+      // (fired after the OAuth callback) refreshes status here so
+      // the user sees Premium controls populate without manually
+      // reloading. `noopener,noreferrer` for the standard
+      // tab-isolation hygiene; the new tab navigates within
+      // accounts.spotify.com → 127.0.0.1:3001 which is fine.
+      window.open(response.data.authorizeUrl, "_blank", "noopener,noreferrer");
     } else {
       log.warn("connect failed", { response });
     }

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -383,10 +383,10 @@ onUnmounted(() => {
           <section v-else-if="status?.isPremium === true" class="spotify-player">
             <h3>{{ t.playerControls }}</h3>
             <div class="spotify-player-buttons">
-              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPrevious">⏮</button>
-              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPause">⏸</button>
-              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPlay">▶</button>
-              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerNext">⏭</button>
+              <button type="button" class="spotify-player-btn" :aria-label="t.btnPrevious" :disabled="isPlayerBusy" @click="playerPrevious">⏮</button>
+              <button type="button" class="spotify-player-btn" :aria-label="t.btnPause" :disabled="isPlayerBusy" @click="playerPause">⏸</button>
+              <button type="button" class="spotify-player-btn" :aria-label="t.btnPlay" :disabled="isPlayerBusy" @click="playerPlay">▶</button>
+              <button type="button" class="spotify-player-btn" :aria-label="t.btnNext" :disabled="isPlayerBusy" @click="playerNext">⏭</button>
             </div>
             <div class="spotify-player-volume">
               <label for="spotify-volume">{{ t.volume }}: {{ volumeInput }}</label>

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -15,13 +15,15 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRuntime } from "gui-chat-protocol/vue";
 import { useT } from "./lang";
-import type { NormalisedPlaylist, NormalisedTrack, RecentlyPlayedItem } from "./types";
+import type { NormalisedDevice, NormalisedPlaylist, NormalisedTrack, RecentlyPlayedItem } from "./types";
 
 interface StatusData {
   clientIdConfigured: boolean;
   connected: boolean;
   expiresAt: string | null;
   scopes: string[];
+  isPremium?: boolean | null;
+  displayName?: string;
 }
 
 interface StatusResponse {
@@ -48,6 +50,12 @@ const isSavingClientId = ref(false);
 const saveError = ref<string | null>(null);
 
 const isConnecting = ref(false);
+
+// Player Controls (PR 3)
+const devices = ref<NormalisedDevice[]>([]);
+const playerError = ref<string | null>(null);
+const isPlayerBusy = ref(false);
+const volumeInput = ref(50);
 
 async function refreshStatus(): Promise<void> {
   try {
@@ -112,6 +120,10 @@ async function loadNowPlaying(): Promise<void> {
   const response = await dispatch<{ ok: boolean; data?: NormalisedTrack | null; message?: string }>({ kind: "nowPlaying" });
   if (response.ok) nowPlaying.value = response.data ?? null;
   else tabError.value = response.message ?? t.value.loadFailed;
+  // Always also (re)load devices so the dropdown stays current —
+  // free users see the list (no controls) and premium users see
+  // controls + dropdown together.
+  void loadDevices();
 }
 
 const TAB_LOADERS: Record<Tab, () => Promise<void>> = {
@@ -153,6 +165,55 @@ function selectTab(next: Tab): void {
 
 function refreshActiveTab(): void {
   void loadActiveTab(true);
+}
+
+// Player Controls (PR 3) — Premium-gated; getDevices works for Free
+// users too so the dropdown loads regardless of plan.
+async function loadDevices(): Promise<void> {
+  try {
+    const response = await dispatch<{ ok: boolean; data?: NormalisedDevice[]; message?: string }>({ kind: "getDevices" });
+    if (response.ok && response.data) devices.value = response.data;
+  } catch (err) {
+    log.warn("getDevices failed", { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function dispatchPlayer(args: object, busyMessage: string): Promise<void> {
+  isPlayerBusy.value = true;
+  playerError.value = null;
+  try {
+    const response = await dispatch<{ ok: boolean; message?: string }>(args);
+    if (!response.ok) {
+      playerError.value = response.message ?? busyMessage;
+    } else {
+      // Refresh now-playing card after a successful action so the
+      // user sees the new track / pause state.
+      await loadNowPlaying();
+    }
+  } catch (err) {
+    playerError.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    isPlayerBusy.value = false;
+  }
+}
+
+function playerPlay(): void {
+  void dispatchPlayer({ kind: "play" }, t.value.loadFailed);
+}
+function playerPause(): void {
+  void dispatchPlayer({ kind: "pause" }, t.value.loadFailed);
+}
+function playerNext(): void {
+  void dispatchPlayer({ kind: "next" }, t.value.loadFailed);
+}
+function playerPrevious(): void {
+  void dispatchPlayer({ kind: "previous" }, t.value.loadFailed);
+}
+function playerVolume(): void {
+  void dispatchPlayer({ kind: "setVolume", volumePercent: volumeInput.value }, t.value.loadFailed);
+}
+function playerTransfer(deviceId: string): void {
+  void dispatchPlayer({ kind: "transferPlayback", deviceId, play: false }, t.value.loadFailed).then(() => loadDevices());
 }
 
 // `NormalisedTrack.url` is optional (locally-uploaded tracks and
@@ -298,17 +359,62 @@ onUnmounted(() => {
         </ul>
         <p v-else-if="activeTab === 'recent'" class="spotify-empty">{{ t.emptyRecent }}</p>
 
-        <div v-else-if="activeTab === 'nowPlaying' && nowPlaying" class="spotify-now-playing">
-          <button type="button" class="spotify-track-link" @click="safeOpenUrl(nowPlaying.url)">
-            <img v-if="nowPlaying.imageUrl" :src="nowPlaying.imageUrl" alt="" class="spotify-now-cover" />
-            <span class="spotify-track-meta">
-              <span class="spotify-track-name">{{ nowPlaying.name }}</span>
-              <span class="spotify-track-artists">{{ t.trackBy }} {{ nowPlaying.artists.join(", ") }}</span>
-              <span class="spotify-track-album">{{ nowPlaying.album }}</span>
-            </span>
-          </button>
-        </div>
-        <p v-else-if="activeTab === 'nowPlaying'" class="spotify-empty">{{ t.emptyNowPlaying }}</p>
+        <template v-else-if="activeTab === 'nowPlaying'">
+          <div v-if="nowPlaying" class="spotify-now-playing">
+            <button type="button" class="spotify-track-link" @click="safeOpenUrl(nowPlaying.url)">
+              <img v-if="nowPlaying.imageUrl" :src="nowPlaying.imageUrl" alt="" class="spotify-now-cover" />
+              <span class="spotify-track-meta">
+                <span class="spotify-track-name">{{ nowPlaying.name }}</span>
+                <span class="spotify-track-artists">{{ t.trackBy }} {{ nowPlaying.artists.join(", ") }}</span>
+                <span class="spotify-track-album">{{ nowPlaying.album }}</span>
+              </span>
+            </button>
+          </div>
+          <p v-else class="spotify-empty">{{ t.emptyNowPlaying }}</p>
+
+          <!-- Player Controls (PR 3). Premium-gated: Free users see
+               a notice instead of buttons. The device dropdown is
+               always visible (helps the user transfer playback to
+               a different device + diagnose "no active device"). -->
+          <section v-if="status?.isPremium === false" class="spotify-player-locked">
+            <h3>{{ t.playerControls }}</h3>
+            <p>{{ t.premiumRequired }}</p>
+          </section>
+          <section v-else-if="status?.isPremium === true" class="spotify-player">
+            <h3>{{ t.playerControls }}</h3>
+            <div class="spotify-player-buttons">
+              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPrevious">⏮</button>
+              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPause">⏸</button>
+              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerPlay">▶</button>
+              <button type="button" class="spotify-player-btn" :disabled="isPlayerBusy" @click="playerNext">⏭</button>
+            </div>
+            <div class="spotify-player-volume">
+              <label for="spotify-volume">{{ t.volume }}: {{ volumeInput }}</label>
+              <input id="spotify-volume" v-model.number="volumeInput" type="range" min="0" max="100" :disabled="isPlayerBusy" @change="playerVolume" />
+            </div>
+            <p v-if="playerError" class="spotify-error">{{ playerError }}</p>
+          </section>
+
+          <section v-if="devices.length > 0" class="spotify-devices">
+            <h3>{{ t.devices }}</h3>
+            <ul class="spotify-list">
+              <li v-for="device in devices" :key="device.id" class="spotify-device-row">
+                <span class="spotify-device-name">{{ device.name }}</span>
+                <span class="spotify-device-type">{{ device.type }}</span>
+                <span v-if="device.isActive" class="spotify-device-active">{{ t.deviceActive }}</span>
+                <button
+                  v-else-if="status?.isPremium === true"
+                  type="button"
+                  class="spotify-device-transfer"
+                  :disabled="isPlayerBusy"
+                  @click="playerTransfer(device.id)"
+                >
+                  {{ t.transferToDevice }}
+                </button>
+              </li>
+            </ul>
+          </section>
+        </template>
       </div>
     </div>
   </div>
@@ -513,6 +619,86 @@ onUnmounted(() => {
   border: 1px solid #e5e7eb;
   border-radius: 0.5rem;
   padding: 1rem;
+}
+.spotify-player,
+.spotify-player-locked,
+.spotify-devices {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+.spotify-player-locked {
+  background: #fafafa;
+  color: #6b7280;
+}
+.spotify-player h3,
+.spotify-player-locked h3,
+.spotify-devices h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+}
+.spotify-player-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.spotify-player-btn {
+  flex: 1;
+  padding: 0.5rem;
+  background: #1ed760;
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+.spotify-player-btn:disabled {
+  background: #d1d5db;
+  cursor: not-allowed;
+}
+.spotify-player-volume {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+.spotify-player-volume input[type="range"] {
+  flex: 1;
+}
+.spotify-device-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+}
+.spotify-device-name {
+  flex: 1;
+  font-weight: 500;
+}
+.spotify-device-type {
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+.spotify-device-active {
+  background: #1ed760;
+  color: white;
+  padding: 0 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+}
+.spotify-device-transfer {
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
 }
 .spotify-now-cover {
   width: 4rem;

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -85,26 +85,27 @@ async function saveClientId(): Promise<void> {
 //   1. `localhost` is rejected — must use `127.0.0.1` or `[::1]`
 //   2. URI must match the one registered in the Dashboard EXACTLY
 //
-// In Vite dev, `window.location.origin` is the Vite dev server
-// (`localhost:5173`). Using that as the redirectUri would (a)
-// break Spotify's `127.0.0.1`-only rule, and (b) require the user
-// to register both the Vite-dev URI and the production-server URI
-// in their Dashboard.
+// We honour the actual page origin so that:
+//   - Custom port via `--port 3099` → redirectUri uses 3099 (user
+//     registers `127.0.0.1:3099/api/...` in their Dashboard).
+//   - Vite dev (`5173`) → redirectUri uses 5173 (Vite proxy
+//     forwards `/api/*` to the server).
+//   - Production (server serves the SPA on 3001) → matches.
 //
-// Always use `127.0.0.1:3001` so the Dashboard URI is a single
-// stable string that matches `docs/tips/spotify-setup.md`. Users
-// running the server on a different port (`npm run server -- --port
-// 3099`) need to substitute the port and register the same URI in
-// the Dashboard — the host's runtime registry doesn't expose its
-// own port to plugins, so we can't auto-detect.
-const SPOTIFY_REDIRECT_URI = "http://127.0.0.1:3001/api/plugins/runtime/oauth-callback/spotify";
+// `localhost` is coerced to `127.0.0.1` because Spotify rejects
+// `localhost` outright — the proxy / browser still hits the same
+// loopback address either way.
+function computeRedirectUri(): string {
+  const origin = window.location.origin.replace("//localhost:", "//127.0.0.1:").replace("//localhost/", "//127.0.0.1/");
+  return `${origin}/api/plugins/runtime/oauth-callback/spotify`;
+}
 
 async function startConnect(): Promise<void> {
   isConnecting.value = true;
   try {
     const response = await dispatch<{ ok: boolean; data?: { authorizeUrl?: string }; message?: string }>({
       kind: "connect",
-      redirectUri: SPOTIFY_REDIRECT_URI,
+      redirectUri: computeRedirectUri(),
     });
     if (response.ok && response.data?.authorizeUrl) {
       // Open the consent screen in a new tab. The original tab

--- a/packages/spotify-plugin/src/View.vue
+++ b/packages/spotify-plugin/src/View.vue
@@ -434,7 +434,12 @@ onUnmounted(() => {
           <section v-if="devices.length > 0" class="spotify-devices">
             <h3>{{ t.devices }}</h3>
             <ul class="spotify-list">
-              <li v-for="device in devices" :key="device.id" class="spotify-device-row">
+              <!-- Some Spotify devices ship with `id: null` (restricted
+                   for DRM / account-state reasons). They're displayed
+                   informationally but the Transfer button is disabled —
+                   `playerTransfer` requires a usable ID. Fallback key
+                   is `name` so Vue's :key stays unique-ish. -->
+              <li v-for="(device, idx) in devices" :key="device.id ?? `name:${device.name}:${idx}`" class="spotify-device-row">
                 <span class="spotify-device-name">{{ device.name }}</span>
                 <span class="spotify-device-type">{{ device.type }}</span>
                 <span v-if="device.isActive" class="spotify-device-active">{{ t.deviceActive }}</span>
@@ -442,8 +447,9 @@ onUnmounted(() => {
                   v-else-if="status?.isPremium === true"
                   type="button"
                   class="spotify-device-transfer"
-                  :disabled="isPlayerBusy"
-                  @click="playerTransfer(device.id)"
+                  :disabled="isPlayerBusy || device.id === null"
+                  :aria-disabled="device.id === null"
+                  @click="device.id !== null && playerTransfer(device.id)"
                 >
                   {{ t.transferToDevice }}
                 </button>

--- a/packages/spotify-plugin/src/definition.ts
+++ b/packages/spotify-plugin/src/definition.ts
@@ -41,6 +41,34 @@ export const TOOL_DEFINITION = {
         type: "string",
         description: "Spotify playlist ID (bare ID, not a URI). Obtained from a prior `playlists` response.",
       },
+      // Player Controls (PR 3) — Spotify Premium required at runtime
+      // for play / pause / next / previous / seek / setVolume /
+      // transferPlayback. `getDevices` works for Free accounts too.
+      deviceId: {
+        type: "string",
+        description: "Spotify Connect device ID. Obtained from `getDevices`. Optional for play/pause/etc; defaults to the active device.",
+      },
+      contextUri: {
+        type: "string",
+        description: "Spotify URI for an album / playlist / artist context to play (e.g. `spotify:playlist:abc123`). Mutually exclusive with `trackUris`.",
+      },
+      trackUris: {
+        type: "array",
+        items: { type: "string" },
+        description: "Explicit list of track URIs to play (`spotify:track:abc123`). Mutually exclusive with `contextUri`.",
+      },
+      positionMs: {
+        type: "number",
+        description: "Seek position in milliseconds (`seek` only).",
+      },
+      volumePercent: {
+        type: "number",
+        description: "Volume 0-100 inclusive (`setVolume` only).",
+      },
+      play: {
+        type: "boolean",
+        description: "When transferring playback, whether to start playing on the new device. Default false.",
+      },
     },
     required: ["kind"],
   },

--- a/packages/spotify-plugin/src/index.ts
+++ b/packages/spotify-plugin/src/index.ts
@@ -553,9 +553,9 @@ function mapPlayerError(error: SpotifyClientError, kind: PlayerKind) {
     return {
       ok: false,
       error: "scope_missing",
-      message: "新しい権限の追加が必要です。「Connect」をやり直してください。",
+      message: "新しい権限の追加が必要です。Spotify View ヘッダの「Reconnect」ボタンを押して再認可してください。",
       instructions:
-        "PR 3 で追加された Player 制御は新しい OAuth scope を要求します。View の「Disconnect」→「Connect」を再実行することで scope が更新されます。",
+        "PR 3 で追加された Player 制御は新しい OAuth scope を要求します。View 右上の「Reconnect」ボタンで Spotify の同意画面を開き直すと scope が更新されます。",
     };
   }
   return mapClientError(error);

--- a/packages/spotify-plugin/src/index.ts
+++ b/packages/spotify-plugin/src/index.ts
@@ -28,7 +28,7 @@ import { readClientConfig, readTokens, writeClientConfig, writeTokens } from "./
 import { ONE_SECOND_MS } from "./time";
 import type { NormalisedDevice, SpotifyClientConfig, SpotifyTokens } from "./types";
 import { fetchLiked, fetchNowPlaying, fetchPlaylistTracks, fetchPlaylists, fetchRecent } from "./listening";
-import { getProfile, isPremium } from "./profile";
+import { clearProfileCache, getProfile, isPremium } from "./profile";
 import { playerGetDevices, playerNext, playerPause, playerPlay, playerPrevious, playerSeek, playerSetVolume, playerTransfer } from "./playback";
 import type { SpotifyClientError } from "./client";
 
@@ -215,6 +215,12 @@ export default definePlugin((pluginRuntime) => {
         redirectUri: pending.redirectUri,
       });
       await writeTokens(files.config, tokens);
+      // Invalidate the profile cache: a fresh Connect may be a
+      // different Spotify account, so the previous user's `product`
+      // must not leak through the 24h TTL (Codex review on PR
+      // #1171). The next `getProfile` call will fetch the new
+      // user's snapshot.
+      await clearProfileCache(files.config);
       pubsub.publish("connected", { scopes: tokens.scopes });
       log.info("tokens written", { scopes: tokens.scopes });
       return {
@@ -360,6 +366,17 @@ export default definePlugin((pluginRuntime) => {
   }
 
   async function handlePlayer(args: Extract<DispatchArgs, { kind: PlayerKind }>) {
+    // Spotify's `/v1/me/player/play` 400s if a body carries both
+    // `context_uri` and `uris[]`. Catching this here (since we
+    // can't .refine() inside a discriminatedUnion arm) gives a
+    // clean error instead of a confusing 4xx from Spotify.
+    if (args.kind === "play" && args.contextUri && args.trackUris) {
+      return {
+        ok: false,
+        error: "invalid_args",
+        message: "play: `contextUri` と `trackUris` は同時に指定できません。どちらか一方を選んでください。",
+      };
+    }
     const ready = await loadCredentials();
     if (!ready.ok) return ready.errorResponse;
     const deps = { runtime: pluginRuntime, clientId: ready.clientConfig.clientId, tokens: ready.tokens };

--- a/packages/spotify-plugin/src/index.ts
+++ b/packages/spotify-plugin/src/index.ts
@@ -26,8 +26,10 @@ import { DispatchArgsSchema, type DispatchArgs } from "./schemas";
 import { buildAuthorizeUrl, consumePendingAuthorization, deriveCodeChallenge, generateRandomToken, registerPendingAuthorization } from "./oauth";
 import { readClientConfig, readTokens, writeClientConfig, writeTokens } from "./tokens";
 import { ONE_SECOND_MS } from "./time";
-import type { SpotifyClientConfig, SpotifyTokens } from "./types";
+import type { NormalisedDevice, SpotifyClientConfig, SpotifyTokens } from "./types";
 import { fetchLiked, fetchNowPlaying, fetchPlaylistTracks, fetchPlaylists, fetchRecent } from "./listening";
+import { getProfile, isPremium } from "./profile";
+import { playerGetDevices, playerNext, playerPause, playerPlay, playerPrevious, playerSeek, playerSetVolume, playerTransfer } from "./playback";
 import type { SpotifyClientError } from "./client";
 
 export { TOOL_DEFINITION };
@@ -41,9 +43,20 @@ export { TOOL_DEFINITION };
 // startup diagnostics.
 export const OAUTH_CALLBACK_ALIAS = "spotify";
 
-/** Read-only scope set for v1. Sorted so the authorize URL is
- *  stable across boots. */
-const SPOTIFY_SCOPES: readonly string[] = ["playlist-read-private", "user-library-read", "user-read-currently-playing", "user-read-recently-played"] as const;
+/** Scope set requested at OAuth time. Two extra scopes were added
+ *  in PR 3 for Player Controls: `user-read-playback-state` (read
+ *  active device + playback state) and `user-modify-playback-state`
+ *  (play/pause/next/seek/volume/transfer). Existing users from
+ *  PR 1/2 will hit `403 Insufficient client scope` on the new
+ *  player kinds and need to reconnect. */
+const SPOTIFY_SCOPES: readonly string[] = [
+  "playlist-read-private",
+  "user-library-read",
+  "user-modify-playback-state",
+  "user-read-currently-playing",
+  "user-read-playback-state",
+  "user-read-recently-played",
+] as const;
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 const SPOTIFY_TOKEN_HOST = "accounts.spotify.com";
@@ -105,6 +118,15 @@ export default definePlugin((pluginRuntime) => {
           return handleListening("recent", args);
         case "nowPlaying":
           return handleListening("nowPlaying", args);
+        case "play":
+        case "pause":
+        case "next":
+        case "previous":
+        case "seek":
+        case "setVolume":
+        case "transferPlayback":
+        case "getDevices":
+          return handlePlayer(args);
         default: {
           const exhaustive: never = args;
           throw new Error(`Unhandled kind: ${JSON.stringify(exhaustive)}`);
@@ -217,6 +239,18 @@ export default definePlugin((pluginRuntime) => {
   async function handleStatus() {
     const clientConfig = await readClientConfig(files.config);
     const tokens = await readTokens(files.config);
+    let premium: boolean | null = null;
+    let displayName = "";
+    // Only call /v1/me when we have tokens — otherwise there's
+    // nothing to authenticate with. Cache hit is the common case
+    // (24h TTL) so most `status` calls don't go to Spotify.
+    if (tokens && clientConfig) {
+      const profileResult = await getProfile({ runtime: pluginRuntime, clientId: clientConfig.clientId, tokens });
+      if (profileResult.ok) {
+        premium = isPremium(profileResult.profile);
+        displayName = profileResult.profile.displayName;
+      }
+    }
     return {
       ok: true,
       message: tokens ? "Connected." : clientConfig ? "Client ID is configured but you haven't connected yet." : "Client ID is not configured.",
@@ -225,6 +259,10 @@ export default definePlugin((pluginRuntime) => {
         connected: tokens !== null,
         expiresAt: tokens?.expiresAt ?? null,
         scopes: tokens?.scopes ?? [],
+        // PR 3 — null when we couldn't determine (no tokens, or
+        // /v1/me failed). View renders the player gate accordingly.
+        isPremium: premium,
+        displayName,
       },
     };
   }
@@ -321,6 +359,23 @@ export default definePlugin((pluginRuntime) => {
     return { ok: true, message: summariseListening(kind, result.data), data: result.data };
   }
 
+  async function handlePlayer(args: Extract<DispatchArgs, { kind: PlayerKind }>) {
+    const ready = await loadCredentials();
+    if (!ready.ok) return ready.errorResponse;
+    const deps = { runtime: pluginRuntime, clientId: ready.clientConfig.clientId, tokens: ready.tokens };
+    // `getDevices` is read-only and works for Free accounts (the View
+    // uses it to populate a dropdown even before upgrade). All other
+    // player kinds require Premium; gate them up front so we don't
+    // burn a wasted Spotify API call for a 403 we can predict.
+    if (args.kind !== "getDevices") {
+      const gate = await premiumGate(deps);
+      if (gate) return gate;
+    }
+    const result = await invokePlayer(args, deps);
+    if (!result.ok) return mapPlayerError(result.error, args.kind);
+    return summarisePlayerResult(args.kind, result.data);
+  }
+
   async function loadCredentials(): Promise<
     | { ok: true; clientConfig: SpotifyClientConfig; tokens: SpotifyTokens }
     | { ok: false; errorResponse: { ok: false; error: string; message: string; instructions?: string } }
@@ -351,6 +406,29 @@ export default definePlugin((pluginRuntime) => {
     return { ok: true, clientConfig, tokens };
   }
 });
+
+type PlayerKind = "play" | "pause" | "next" | "previous" | "seek" | "setVolume" | "transferPlayback" | "getDevices";
+
+async function invokePlayer(args: Extract<DispatchArgs, { kind: PlayerKind }>, deps: { runtime: PluginRuntime; clientId: string; tokens: SpotifyTokens }) {
+  switch (args.kind) {
+    case "play":
+      return playerPlay(deps, { deviceId: args.deviceId, contextUri: args.contextUri, trackUris: args.trackUris });
+    case "pause":
+      return playerPause(deps, args.deviceId);
+    case "next":
+      return playerNext(deps, args.deviceId);
+    case "previous":
+      return playerPrevious(deps, args.deviceId);
+    case "seek":
+      return playerSeek(deps, args.positionMs, args.deviceId);
+    case "setVolume":
+      return playerSetVolume(deps, args.volumePercent, args.deviceId);
+    case "transferPlayback":
+      return playerTransfer(deps, args.deviceId, args.play);
+    case "getDevices":
+      return playerGetDevices(deps);
+  }
+}
 
 async function invokeListening(
   kind: "liked" | "playlists" | "playlistTracks" | "recent" | "nowPlaying",
@@ -400,31 +478,97 @@ function summariseListening(kind: "liked" | "playlists" | "playlistTracks" | "re
   return `${title} (${data.length}):\n${lines.join("\n")}`;
 }
 
+async function premiumGate(deps: {
+  runtime: PluginRuntime;
+  clientId: string;
+  tokens: SpotifyTokens;
+}): Promise<{ ok: false; error: string; message: string; instructions?: string } | null> {
+  const profileResult = await getProfile(deps);
+  if (!profileResult.ok) return mapClientError(profileResult.error);
+  if (isPremium(profileResult.profile)) return null;
+  return {
+    ok: false,
+    error: "premium_required",
+    message: "Spotify Premium が必要な操作です。Free アカウントでは再生制御は使えません。",
+    instructions: "Spotify Premium にアップグレードしてください。再生制御以外 (Liked / Playlists / Recent / Search) は Free でも引き続き利用できます。",
+  };
+}
+
+function summarisePlayerResult(kind: PlayerKind, data: NormalisedDevice[] | null) {
+  if (kind === "getDevices") {
+    const devices = (data ?? []) as NormalisedDevice[];
+    if (devices.length === 0) {
+      return {
+        ok: true,
+        message: "アクティブな Spotify デバイスがありません。Spotify アプリを起動してから再度お試しください。",
+        data: devices,
+      };
+    }
+    const lines = devices.map((d, i) => `${i + 1}. ${d.name} (${d.type})${d.isActive ? " — active" : ""}`);
+    return { ok: true, message: `Devices (${devices.length}):\n${lines.join("\n")}`, data: devices };
+  }
+  return { ok: true, message: PLAYER_SUCCESS_MESSAGES[kind] };
+}
+
+const PLAYER_SUCCESS_MESSAGES: Record<Exclude<PlayerKind, "getDevices">, string> = {
+  play: "再生を開始しました。",
+  pause: "再生を一時停止しました。",
+  next: "次の曲に進みました。",
+  previous: "前の曲に戻りました。",
+  seek: "位置をシークしました。",
+  setVolume: "音量を変更しました。",
+  transferPlayback: "再生をデバイスに移しました。",
+};
+
+function mapPlayerError(error: SpotifyClientError, kind: PlayerKind) {
+  // Spotify returns 404 for "no active device" on most player
+  // endpoints. Surface a user-friendly hint that points at the
+  // device dropdown instead of the generic API-error message.
+  if (error.kind === "spotify_api_error" && error.status === 404 && kind !== "getDevices") {
+    return {
+      ok: false,
+      error: "no_active_device",
+      message: "アクティブな Spotify デバイスがありません。Spotify アプリ (デスクトップ / モバイル / Web) を起動してから再度お試しください。",
+      instructions: "View の Player タブから対象デバイスを選んで「Transfer」を押すか、Spotify アプリ側で何か再生してから再試行してください。",
+    };
+  }
+  if (error.kind === "spotify_api_error" && error.status === 403 && error.body.includes("scope")) {
+    return {
+      ok: false,
+      error: "scope_missing",
+      message: "新しい権限の追加が必要です。「Connect」をやり直してください。",
+      instructions:
+        "PR 3 で追加された Player 制御は新しい OAuth scope を要求します。View の「Disconnect」→「Connect」を再実行することで scope が更新されます。",
+    };
+  }
+  return mapClientError(error);
+}
+
 function mapClientError(error: SpotifyClientError) {
   switch (error.kind) {
     case "auth_expired":
       return {
-        ok: false,
+        ok: false as const,
         error: "auth_expired",
         message: "認可が無効化されました。「Connect」をやり直してください。",
         detail: error.detail,
       };
     case "rate_limited":
       return {
-        ok: false,
+        ok: false as const,
         error: "rate_limited",
         message: `Spotify から rate limit を返されました。${error.retryAfterSec} 秒後に再試行してください。`,
         retryAfterSec: error.retryAfterSec,
       };
     case "spotify_api_error":
       return {
-        ok: false,
+        ok: false as const,
         error: "spotify_api_error",
         message: `Spotify API がエラーを返しました (${error.status})`,
         detail: error.body,
       };
     case "not_connected":
-      return { ok: false, error: "not_connected", message: "Spotify に未接続です。" };
+      return { ok: false as const, error: "not_connected", message: "Spotify に未接続です。" };
   }
 }
 

--- a/packages/spotify-plugin/src/lang/en.ts
+++ b/packages/spotify-plugin/src/lang/en.ts
@@ -47,4 +47,8 @@ export default {
   devices: "Devices",
   deviceActive: "active",
   transferToDevice: "Transfer here",
+  btnPrevious: "Previous track",
+  btnPause: "Pause",
+  btnPlay: "Play",
+  btnNext: "Next track",
 } as const;

--- a/packages/spotify-plugin/src/lang/en.ts
+++ b/packages/spotify-plugin/src/lang/en.ts
@@ -39,4 +39,12 @@ export default {
   tracksCount: "tracks",
 
   previewSummary: "Spotify",
+
+  // Player Controls (PR 3)
+  playerControls: "Playback",
+  premiumRequired: "Spotify Premium is required to control playback. Free / open accounts cannot use these controls; the rest of the plugin still works.",
+  volume: "Volume",
+  devices: "Devices",
+  deviceActive: "active",
+  transferToDevice: "Transfer here",
 } as const;

--- a/packages/spotify-plugin/src/lang/en.ts
+++ b/packages/spotify-plugin/src/lang/en.ts
@@ -14,6 +14,7 @@ export default {
   connect: "Connect Spotify",
   connecting: "Opening Spotify consent…",
   connected: "Connected.",
+  reconnect: "Reconnect",
   disconnect: "Disconnect",
   refresh: "Refresh",
   setupGuideLink: "How do I get a Client ID?",

--- a/packages/spotify-plugin/src/lang/ja.ts
+++ b/packages/spotify-plugin/src/lang/ja.ts
@@ -40,4 +40,12 @@ export default {
   tracksCount: "曲",
 
   previewSummary: "Spotify",
+
+  // Player Controls (PR 3)
+  playerControls: "再生制御",
+  premiumRequired: "再生制御には Spotify Premium が必要です。Free / Open アカウントでは利用できません。それ以外の機能はそのまま使えます。",
+  volume: "音量",
+  devices: "デバイス",
+  deviceActive: "アクティブ",
+  transferToDevice: "ここに移す",
 } as const;

--- a/packages/spotify-plugin/src/lang/ja.ts
+++ b/packages/spotify-plugin/src/lang/ja.ts
@@ -48,4 +48,8 @@ export default {
   devices: "デバイス",
   deviceActive: "アクティブ",
   transferToDevice: "ここに移す",
+  btnPrevious: "前の曲",
+  btnPause: "一時停止",
+  btnPlay: "再生",
+  btnNext: "次の曲",
 } as const;

--- a/packages/spotify-plugin/src/lang/ja.ts
+++ b/packages/spotify-plugin/src/lang/ja.ts
@@ -15,6 +15,7 @@ export default {
   connect: "Spotify に接続",
   connecting: "Spotify の同意画面を開きます…",
   connected: "接続済み",
+  reconnect: "再接続",
   disconnect: "切断",
   refresh: "更新",
   setupGuideLink: "Client ID の取得方法",

--- a/packages/spotify-plugin/src/playback.ts
+++ b/packages/spotify-plugin/src/playback.ts
@@ -1,0 +1,144 @@
+// Player Controls (PR 3). Handlers for the 8 dispatch kinds added
+// in PR 3. Spotify Premium is required at runtime — the dispatcher
+// in `index.ts` checks `getProfile()` before calling any of these
+// (except `getDevices`, which is read-only and works for Free
+// accounts too — useful for the View's device dropdown even before
+// upgrade).
+//
+// Spotify's Player API is mostly side-effects: `play`, `pause`,
+// `next`, etc. all return 204 on success. The handlers below
+// translate the (mostly-empty) response into a friendly
+// `{ ok, message }` so the LLM can confirm the action. `getDevices`
+// is the only one with an interesting payload.
+
+import type { PluginRuntime } from "gui-chat-protocol";
+
+import { spotifyApi } from "./client";
+import type { SpotifyClientError } from "./client";
+import type { NormalisedDevice, SpotifyTokens } from "./types";
+
+export interface PlaybackDeps {
+  runtime: PluginRuntime;
+  clientId: string;
+  tokens: SpotifyTokens;
+  now?: () => Date;
+}
+
+type Result<T> = { ok: true; data: T } | { ok: false; error: SpotifyClientError };
+
+interface PlayArgs {
+  deviceId?: string;
+  contextUri?: string;
+  trackUris?: string[];
+}
+
+export async function playerPlay(deps: PlaybackDeps, args: PlayArgs): Promise<Result<null>> {
+  const body: Record<string, unknown> = {};
+  if (args.contextUri) body.context_uri = args.contextUri;
+  if (args.trackUris) body.uris = args.trackUris;
+  const path = withDeviceId("/v1/me/player/play", args.deviceId);
+  // Spotify's `play` accepts PUT with empty body (resume) or with
+  // {context_uri, uris, offset, position_ms} (start specific
+  // content). Pass an empty body when no `contextUri`/`trackUris`
+  // were supplied — that's the "resume" semantics.
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, Object.keys(body).length > 0 ? { body } : {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerPause(deps: PlaybackDeps, deviceId?: string): Promise<Result<null>> {
+  const path = withDeviceId("/v1/me/player/pause", deviceId);
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerNext(deps: PlaybackDeps, deviceId?: string): Promise<Result<null>> {
+  const path = withDeviceId("/v1/me/player/next", deviceId);
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "POST", path, {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerPrevious(deps: PlaybackDeps, deviceId?: string): Promise<Result<null>> {
+  const path = withDeviceId("/v1/me/player/previous", deviceId);
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "POST", path, {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerSeek(deps: PlaybackDeps, positionMs: number, deviceId?: string): Promise<Result<null>> {
+  const params = new URLSearchParams({ position_ms: String(positionMs) });
+  const path = appendQueryParam(`/v1/me/player/seek?${params.toString()}`, "device_id", deviceId);
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerSetVolume(deps: PlaybackDeps, volumePercent: number, deviceId?: string): Promise<Result<null>> {
+  const params = new URLSearchParams({ volume_percent: String(volumePercent) });
+  const path = appendQueryParam(`/v1/me/player/volume?${params.toString()}`, "device_id", deviceId);
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, {}, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerTransfer(deps: PlaybackDeps, deviceId: string, play: boolean | undefined): Promise<Result<null>> {
+  const body: Record<string, unknown> = { device_ids: [deviceId] };
+  if (play !== undefined) body.play = play;
+  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", "/v1/me/player", { body }, deps.now);
+  return mapVoidResult(result);
+}
+
+export async function playerGetDevices(deps: PlaybackDeps): Promise<Result<NormalisedDevice[]>> {
+  const result = await spotifyApi<unknown>(deps.runtime, deps.clientId, deps.tokens, "GET", "/v1/me/player/devices", {}, deps.now);
+  if (!result.ok) return result;
+  return { ok: true, data: normaliseDevices(result.data) };
+}
+
+function withDeviceId(basePath: string, deviceId: string | undefined): string {
+  if (!deviceId) return basePath;
+  return `${basePath}?${new URLSearchParams({ device_id: deviceId }).toString()}`;
+}
+
+function appendQueryParam(path: string, key: string, value: string | undefined): string {
+  if (!value) return path;
+  return `${path}&${new URLSearchParams({ [key]: value }).toString()}`;
+}
+
+/** Player API success responses are 204 No Content; `data` is null
+ *  in our client wrapper. Normalise so the dispatcher can use a
+ *  uniform `{ ok, message }` shape. */
+function mapVoidResult(result: Result<unknown>): Result<null> {
+  if (!result.ok) return result;
+  return { ok: true, data: null };
+}
+
+interface RawDevice {
+  id?: unknown;
+  name?: unknown;
+  type?: unknown;
+  is_active?: unknown;
+  volume_percent?: unknown;
+}
+
+function normaliseDevices(raw: unknown): NormalisedDevice[] {
+  if (typeof raw !== "object" || raw === null) return [];
+  const devices = (raw as { devices?: unknown }).devices;
+  if (!Array.isArray(devices)) return [];
+  const out: NormalisedDevice[] = [];
+  for (const candidate of devices) {
+    const normalised = normaliseDevice(candidate);
+    if (normalised) out.push(normalised);
+  }
+  return out;
+}
+
+function normaliseDevice(raw: unknown): NormalisedDevice | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const device = raw as RawDevice;
+  if (typeof device.id !== "string" || device.id.length === 0) return null;
+  if (typeof device.name !== "string") return null;
+  const volumePercent = typeof device.volume_percent === "number" && Number.isFinite(device.volume_percent) ? device.volume_percent : undefined;
+  return {
+    id: device.id,
+    name: device.name,
+    type: typeof device.type === "string" ? device.type : "",
+    isActive: device.is_active === true,
+    ...(volumePercent !== undefined ? { volumePercent } : {}),
+  };
+}

--- a/packages/spotify-plugin/src/playback.ts
+++ b/packages/spotify-plugin/src/playback.ts
@@ -131,11 +131,17 @@ function normaliseDevices(raw: unknown): NormalisedDevice[] {
 function normaliseDevice(raw: unknown): NormalisedDevice | null {
   if (typeof raw !== "object" || raw === null) return null;
   const device = raw as RawDevice;
-  if (typeof device.id !== "string" || device.id.length === 0) return null;
+  // Spotify can return restricted devices with a `name` + `type`
+  // but no `id` (DRM / account-state quirks). Preserve them — the
+  // View renders them with the Transfer button disabled — so the
+  // user isn't left wondering "why isn't my speaker listed?"
+  // (Codex review on PR #1171). `name` is still required: an
+  // anonymous nameless device is not useful to surface.
   if (typeof device.name !== "string") return null;
+  const id = typeof device.id === "string" && device.id.length > 0 ? device.id : null;
   const volumePercent = typeof device.volume_percent === "number" && Number.isFinite(device.volume_percent) ? device.volume_percent : undefined;
   return {
-    id: device.id,
+    id,
     name: device.name,
     type: typeof device.type === "string" ? device.type : "",
     isActive: device.is_active === true,

--- a/packages/spotify-plugin/src/profile.ts
+++ b/packages/spotify-plugin/src/profile.ts
@@ -27,6 +27,7 @@ const PROFILE_TTL_MS = 24 * 60 * 60 * ONE_SECOND_MS;
 const PREMIUM_PRODUCT = "premium";
 
 interface RawProfile {
+  id?: unknown;
   product?: unknown;
   display_name?: unknown;
 }
@@ -46,6 +47,11 @@ export async function readProfile(files: FileOps): Promise<SpotifyProfile | null
     if (typeof parsed.product !== "string") return null;
     if (typeof parsed.fetchedAtMs !== "number" || !Number.isFinite(parsed.fetchedAtMs)) return null;
     return {
+      // userId may be missing from caches written before the
+      // account-scoping fix landed; treat as empty so a
+      // reconnect-then-replay doesn't trip the equality check
+      // until the next /v1/me round-trip refreshes it.
+      userId: typeof parsed.userId === "string" ? parsed.userId : "",
       product: parsed.product,
       displayName: typeof parsed.displayName === "string" ? parsed.displayName : "",
       fetchedAtMs: parsed.fetchedAtMs,
@@ -65,7 +71,14 @@ function isCacheFresh(profile: SpotifyProfile, now: Date): boolean {
 
 /** Get the cached profile if fresh; otherwise fetch + persist a
  *  new snapshot. On API failure with a stale cache we keep the
- *  stale value (better than locking the user out). */
+ *  stale value (better than locking the user out — a network blip
+ *  shouldn't break playback).
+ *
+ *  Account scoping: cache is invalidated by `clearProfileCache`
+ *  whenever new tokens are written (i.e. after `oauthCallback`),
+ *  so reconnecting with a different Spotify account starts with a
+ *  fresh fetch and never serves the previous account's `product`
+ *  (Codex review on PR #1171). */
 export async function getProfile(deps: ProfileDeps): Promise<{ ok: true; profile: SpotifyProfile } | { ok: false; error: SpotifyClientError }> {
   const now = deps.now ?? (() => new Date());
   const cached = await readProfile(deps.runtime.files.config);
@@ -86,10 +99,11 @@ async function fetchProfile(deps: ProfileDeps): Promise<{ ok: true; profile: Spo
   const result = await spotifyApi<RawProfile>(deps.runtime, deps.clientId, deps.tokens, "GET", "/v1/me", {}, deps.now);
   if (!result.ok) return result;
   const raw = result.data;
+  const userId = typeof raw.id === "string" ? raw.id : "";
   const product = typeof raw.product === "string" ? raw.product : "free";
   const displayName = typeof raw.display_name === "string" ? raw.display_name : "";
   const now = deps.now ?? (() => new Date());
-  return { ok: true, profile: { product, displayName, fetchedAtMs: now().getTime() } };
+  return { ok: true, profile: { userId, product, displayName, fetchedAtMs: now().getTime() } };
 }
 
 export function isPremium(profile: SpotifyProfile): boolean {

--- a/packages/spotify-plugin/src/profile.ts
+++ b/packages/spotify-plugin/src/profile.ts
@@ -1,0 +1,116 @@
+// Spotify user profile cache (PR 3). Reads `/v1/me` once and
+// caches the `product` field so the player-control gate doesn't
+// need a fresh API roundtrip on every `play` dispatch.
+//
+// TTL is 24 h: long enough that a typical user paying for Premium
+// once doesn't get rate-limited extra GETs to `/v1/me`, short
+// enough that a Free → Premium upgrade is reflected within a day
+// without manually reconnecting.
+//
+// On a stale cache miss the loader fires `/v1/me` once and writes
+// the result to `profile.json`. If the API call fails we keep the
+// stale snapshot rather than locking the user out — the player
+// gate then errs on the side of "let them try" with a softer error
+// message. This intentionally trades strict correctness for UX:
+// a network blip on Spotify's side shouldn't break playback.
+
+import type { FileOps, PluginRuntime } from "gui-chat-protocol";
+
+import { spotifyApi } from "./client";
+import type { SpotifyClientError } from "./client";
+import { ONE_SECOND_MS } from "./time";
+import type { SpotifyProfile, SpotifyTokens } from "./types";
+
+const PROFILE_FILE = "profile.json";
+const PROFILE_TTL_MS = 24 * 60 * 60 * ONE_SECOND_MS;
+
+const PREMIUM_PRODUCT = "premium";
+
+interface RawProfile {
+  product?: unknown;
+  display_name?: unknown;
+}
+
+export interface ProfileDeps {
+  runtime: PluginRuntime;
+  clientId: string;
+  tokens: SpotifyTokens;
+  now?: () => Date;
+}
+
+export async function readProfile(files: FileOps): Promise<SpotifyProfile | null> {
+  if (!(await files.exists(PROFILE_FILE))) return null;
+  try {
+    const raw = await files.read(PROFILE_FILE);
+    const parsed = JSON.parse(raw) as Partial<SpotifyProfile>;
+    if (typeof parsed.product !== "string") return null;
+    if (typeof parsed.fetchedAtMs !== "number" || !Number.isFinite(parsed.fetchedAtMs)) return null;
+    return {
+      product: parsed.product,
+      displayName: typeof parsed.displayName === "string" ? parsed.displayName : "",
+      fetchedAtMs: parsed.fetchedAtMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeProfile(files: FileOps, profile: SpotifyProfile): Promise<void> {
+  await files.write(PROFILE_FILE, JSON.stringify(profile, null, 2));
+}
+
+function isCacheFresh(profile: SpotifyProfile, now: Date): boolean {
+  return now.getTime() - profile.fetchedAtMs < PROFILE_TTL_MS;
+}
+
+/** Get the cached profile if fresh; otherwise fetch + persist a
+ *  new snapshot. On API failure with a stale cache we keep the
+ *  stale value (better than locking the user out). */
+export async function getProfile(deps: ProfileDeps): Promise<{ ok: true; profile: SpotifyProfile } | { ok: false; error: SpotifyClientError }> {
+  const now = deps.now ?? (() => new Date());
+  const cached = await readProfile(deps.runtime.files.config);
+  if (cached && isCacheFresh(cached, now())) return { ok: true, profile: cached };
+  const fresh = await fetchProfile(deps);
+  if (fresh.ok) {
+    await writeProfile(deps.runtime.files.config, fresh.profile);
+    return { ok: true, profile: fresh.profile };
+  }
+  if (cached) {
+    deps.runtime.log.warn("profile fetch failed; serving stale cache", { detail: errorMessage(fresh.error) });
+    return { ok: true, profile: cached };
+  }
+  return fresh;
+}
+
+async function fetchProfile(deps: ProfileDeps): Promise<{ ok: true; profile: SpotifyProfile } | { ok: false; error: SpotifyClientError }> {
+  const result = await spotifyApi<RawProfile>(deps.runtime, deps.clientId, deps.tokens, "GET", "/v1/me", {}, deps.now);
+  if (!result.ok) return result;
+  const raw = result.data;
+  const product = typeof raw.product === "string" ? raw.product : "free";
+  const displayName = typeof raw.display_name === "string" ? raw.display_name : "";
+  const now = deps.now ?? (() => new Date());
+  return { ok: true, profile: { product, displayName, fetchedAtMs: now().getTime() } };
+}
+
+export function isPremium(profile: SpotifyProfile): boolean {
+  return profile.product === PREMIUM_PRODUCT;
+}
+
+function errorMessage(error: SpotifyClientError): string {
+  switch (error.kind) {
+    case "auth_expired":
+      return error.detail;
+    case "rate_limited":
+      return `rate limited (retry ${error.retryAfterSec}s)`;
+    case "spotify_api_error":
+      return `${error.status}: ${error.body}`;
+    case "not_connected":
+      return "not connected";
+  }
+}
+
+/** Test-only: clear the cache. Production callers should not need
+ *  this — the TTL handles it. */
+export async function clearProfileCache(files: FileOps): Promise<void> {
+  if (await files.exists(PROFILE_FILE)) await files.unlink(PROFILE_FILE);
+}

--- a/packages/spotify-plugin/src/schemas.ts
+++ b/packages/spotify-plugin/src/schemas.ts
@@ -146,12 +146,15 @@ export const DispatchArgsSchema = z.discriminatedUnion("kind", [
      *  active device. */
     deviceId: z.string().min(1).max(128).optional(),
     /** Optional: a Spotify URI for an album / playlist / artist
-     *  context to play (e.g. `spotify:playlist:abc123`). */
+     *  context to play (e.g. `spotify:playlist:abc123`). Mutually
+     *  exclusive with `trackUris` — the dispatcher in `index.ts`
+     *  rejects when both are set, because Zod's
+     *  `discriminatedUnion` doesn't accept refined arms (refining
+     *  this arm would corrupt the kind discriminator). */
     contextUri: z.string().min(1).max(256).optional(),
     /** Optional: explicit list of track URIs to queue
      *  (`spotify:track:abc123`). Mutually exclusive with
-     *  `contextUri` per Spotify's API rules — Spotify rejects a
-     *  body containing both. */
+     *  `contextUri` (see comment above). */
     trackUris: z.array(z.string().min(1).max(256)).min(1).max(100).optional(),
   }),
   z.object({

--- a/packages/spotify-plugin/src/schemas.ts
+++ b/packages/spotify-plugin/src/schemas.ts
@@ -20,6 +20,18 @@ export const SPOTIFY_KINDS = {
   playlistTracks: "playlistTracks",
   recent: "recent",
   nowPlaying: "nowPlaying",
+  // Player Controls (PR 3). All except `getDevices` require the
+  // user to have Spotify Premium — the plugin gates them at the
+  // dispatch boundary by reading `/v1/me/{product}` and refusing
+  // with `premium_required` for free-tier accounts.
+  play: "play",
+  pause: "pause",
+  next: "next",
+  previous: "previous",
+  seek: "seek",
+  setVolume: "setVolume",
+  transferPlayback: "transferPlayback",
+  getDevices: "getDevices",
 } as const;
 
 /** Kinds the LLM is allowed to invoke directly (= advertised in
@@ -37,6 +49,14 @@ export const LLM_CALLABLE_KINDS = [
   SPOTIFY_KINDS.playlistTracks,
   SPOTIFY_KINDS.recent,
   SPOTIFY_KINDS.nowPlaying,
+  SPOTIFY_KINDS.play,
+  SPOTIFY_KINDS.pause,
+  SPOTIFY_KINDS.next,
+  SPOTIFY_KINDS.previous,
+  SPOTIFY_KINDS.seek,
+  SPOTIFY_KINDS.setVolume,
+  SPOTIFY_KINDS.transferPlayback,
+  SPOTIFY_KINDS.getDevices,
 ] as const;
 
 /** Persisted at `runtime.files.config/tokens.json`. Per-machine
@@ -120,6 +140,54 @@ export const DispatchArgsSchema = z.discriminatedUnion("kind", [
     limit: z.number().int().min(1).max(50).optional(),
   }),
   z.object({ kind: z.literal(SPOTIFY_KINDS.nowPlaying) }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.play),
+    /** Optional: target a specific device. Defaults to the user's
+     *  active device. */
+    deviceId: z.string().min(1).max(128).optional(),
+    /** Optional: a Spotify URI for an album / playlist / artist
+     *  context to play (e.g. `spotify:playlist:abc123`). */
+    contextUri: z.string().min(1).max(256).optional(),
+    /** Optional: explicit list of track URIs to queue
+     *  (`spotify:track:abc123`). Mutually exclusive with
+     *  `contextUri` per Spotify's API rules — Spotify rejects a
+     *  body containing both. */
+    trackUris: z.array(z.string().min(1).max(256)).min(1).max(100).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.pause),
+    deviceId: z.string().min(1).max(128).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.next),
+    deviceId: z.string().min(1).max(128).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.previous),
+    deviceId: z.string().min(1).max(128).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.seek),
+    /** Position in milliseconds. Spotify caps at the track length;
+     *  positions past the end stop playback. */
+    positionMs: z.number().int().min(0).max(86_400_000),
+    deviceId: z.string().min(1).max(128).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.setVolume),
+    /** 0-100 inclusive. */
+    volumePercent: z.number().int().min(0).max(100),
+    deviceId: z.string().min(1).max(128).optional(),
+  }),
+  z.object({
+    kind: z.literal(SPOTIFY_KINDS.transferPlayback),
+    /** Spotify ID of the device to transfer to. Get from `getDevices`. */
+    deviceId: z.string().min(1).max(128),
+    /** When true, playback continues after transfer. Default false
+     *  (matches Spotify's API default). */
+    play: z.boolean().optional(),
+  }),
+  z.object({ kind: z.literal(SPOTIFY_KINDS.getDevices) }),
 ]);
 
 export type DispatchArgs = z.infer<typeof DispatchArgsSchema>;

--- a/packages/spotify-plugin/src/types.ts
+++ b/packages/spotify-plugin/src/types.ts
@@ -105,6 +105,12 @@ export interface NormalisedDevice {
  *  upgrading from Free → Premium sees controls within ~24h
  *  without manually reconnecting. */
 export interface SpotifyProfile {
+  /** Spotify user ID (`/v1/me`'s `id` field). Bound to the cache
+   *  so reconnecting with a different Spotify account doesn't
+   *  serve the previous account's `product` for the rest of the
+   *  TTL — Codex review on PR #1171. Empty string for cache
+   *  records persisted before the account-scoping fix landed. */
+  userId: string;
   /** "premium" / "free" / "open" (open is a legacy free-tier
    *  marker Spotify still emits for some accounts). */
   product: string;

--- a/packages/spotify-plugin/src/types.ts
+++ b/packages/spotify-plugin/src/types.ts
@@ -85,3 +85,31 @@ export interface RecentlyPlayedItem {
   /** ISO-8601 timestamp from Spotify's `played_at`. */
   playedAt: string;
 }
+
+/** Spotify Connect device (a place where the user can play music —
+ *  desktop app, phone, web player, smart speaker). The View shows
+ *  a dropdown so the user can pick a target device. */
+export interface NormalisedDevice {
+  id: string;
+  name: string;
+  /** "Computer" / "Smartphone" / "Speaker" — Spotify's `type`. */
+  type: string;
+  isActive: boolean;
+  /** 0-100, present when the device exposes volume control. */
+  volumePercent?: number;
+}
+
+/** Persisted at `runtime.files.config/profile.json`. Caches
+ *  `/v1/me`'s `product` field so we don't re-call Spotify on every
+ *  `play` dispatch. TTL keeps the cache fresh enough that a user
+ *  upgrading from Free → Premium sees controls within ~24h
+ *  without manually reconnecting. */
+export interface SpotifyProfile {
+  /** "premium" / "free" / "open" (open is a legacy free-tier
+   *  marker Spotify still emits for some accounts). */
+  product: string;
+  /** Free-form display name from `/v1/me`; surfaced in `diagnose`. */
+  displayName: string;
+  /** Epoch ms when this snapshot was fetched. */
+  fetchedAtMs: number;
+}

--- a/packages/spotify-plugin/src/types.ts
+++ b/packages/spotify-plugin/src/types.ts
@@ -88,9 +88,16 @@ export interface RecentlyPlayedItem {
 
 /** Spotify Connect device (a place where the user can play music —
  *  desktop app, phone, web player, smart speaker). The View shows
- *  a dropdown so the user can pick a target device. */
+ *  a dropdown so the user can pick a target device.
+ *
+ *  `id` may be null when Spotify returns a restricted device — for
+ *  some account states / DRM restrictions, Spotify lists a device
+ *  but withholds its ID, leaving it informational but un-targetable.
+ *  Dropping these would underreport the user's setup; the View
+ *  surfaces them but disables the Transfer button (Codex review on
+ *  PR #1171). */
 export interface NormalisedDevice {
-  id: string;
+  id: string | null;
   name: string;
   /** "Computer" / "Smartphone" / "Speaker" — Spotify's `type`. */
   type: string;

--- a/test/plugins/spotify/test_playback.ts
+++ b/test/plugins/spotify/test_playback.ts
@@ -1,0 +1,205 @@
+// Tests for the Player Controls handlers (PR 3). Verifies URL
+// shape (method, query params, body) for each kind and the
+// device-list normalisation. Mocks `runtime.fetch`; no live API.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  playerGetDevices,
+  playerNext,
+  playerPause,
+  playerPlay,
+  playerPrevious,
+  playerSeek,
+  playerSetVolume,
+  playerTransfer,
+} from "../../../packages/spotify-plugin/src/playback.js";
+import type { SpotifyTokens } from "../../../packages/spotify-plugin/src/types.js";
+
+const NOW = () => new Date("2026-05-05T00:00:00.000Z");
+const validTokens: SpotifyTokens = {
+  accessToken: "at-current",
+  refreshToken: "rt-current",
+  expiresAt: "2026-05-05T05:00:00.000Z",
+  scopes: ["user-modify-playback-state"],
+};
+
+interface CallRecord {
+  url: string;
+  method?: string;
+  body?: string;
+}
+
+function makeFakeRuntime(responses: Response[]) {
+  const calls: CallRecord[] = [];
+  const queue = [...responses];
+  return {
+    runtime: {
+      fetch: async (url: string, init?: { method?: string; body?: string }) => {
+        calls.push({ url, method: init?.method, body: init?.body });
+        const next = queue.shift();
+        if (!next) throw new Error("fetch over-called");
+        return next;
+      },
+      files: {
+        config: {
+          exists: async () => false,
+          read: async () => "",
+          readBytes: async () => new Uint8Array(),
+          write: async () => {},
+          readDir: async () => [],
+          stat: async () => ({ mtimeMs: 0, size: 0 }),
+          unlink: async () => {},
+        },
+        data: {
+          exists: async () => false,
+          read: async () => "",
+          readBytes: async () => new Uint8Array(),
+          write: async () => {},
+          readDir: async () => [],
+          stat: async () => ({ mtimeMs: 0, size: 0 }),
+          unlink: async () => {},
+        },
+      },
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      pubsub: { publish: () => {} },
+      locale: "en",
+      fetchJson: async () => {
+        throw new Error("not used");
+      },
+    },
+    calls,
+  };
+}
+
+function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+describe("playerPlay", () => {
+  it("PUTs /v1/me/player/play with NO body for plain resume", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, {});
+    assert.equal(handle.calls[0].method, "PUT");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/play");
+    assert.equal(handle.calls[0].body, undefined);
+  });
+
+  it("includes context_uri in the body when provided", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, { contextUri: "spotify:playlist:abc" });
+    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { context_uri: "spotify:playlist:abc" });
+  });
+
+  it("includes uris[] in the body for trackUris (mutually exclusive with contextUri)", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    await playerPlay(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW },
+      { trackUris: ["spotify:track:a", "spotify:track:b"] },
+    );
+    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { uris: ["spotify:track:a", "spotify:track:b"] });
+  });
+
+  it("appends device_id query param when targeting a specific device", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, { deviceId: "dev1" });
+    assert.match(handle.calls[0].url, /\?device_id=dev1$/);
+  });
+});
+
+describe("playerPause / next / previous", () => {
+  it("pause uses PUT /v1/me/player/pause", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerPause({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(handle.calls[0].method, "PUT");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/pause");
+  });
+
+  it("next uses POST /v1/me/player/next", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerNext({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(handle.calls[0].method, "POST");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/next");
+  });
+
+  it("previous uses POST /v1/me/player/previous", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerPrevious({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(handle.calls[0].method, "POST");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/previous");
+  });
+});
+
+describe("playerSeek + playerSetVolume", () => {
+  it("seek puts position_ms in the URL query", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerSeek({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 30_000);
+    assert.match(handle.calls[0].url, /\/seek\?position_ms=30000/);
+    assert.equal(handle.calls[0].method, "PUT");
+  });
+
+  it("setVolume puts volume_percent in the URL query", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerSetVolume({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 75);
+    assert.match(handle.calls[0].url, /\/volume\?volume_percent=75/);
+  });
+});
+
+describe("playerTransfer", () => {
+  it("PUTs /v1/me/player with device_ids body", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerTransfer({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "device-x", undefined);
+    assert.equal(handle.calls[0].method, "PUT");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player");
+    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { device_ids: ["device-x"] });
+  });
+
+  it("includes play: true when requested", async () => {
+    const handle = makeFakeRuntime([noContent()]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await playerTransfer({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "device-x", true);
+    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { device_ids: ["device-x"], play: true });
+  });
+});
+
+describe("playerGetDevices — normalisation", () => {
+  it("collapses Spotify devices[] to NormalisedDevice[]", async () => {
+    const handle = makeFakeRuntime([
+      new Response(
+        JSON.stringify({
+          devices: [
+            { id: "d1", name: "iPhone", type: "Smartphone", is_active: true, volume_percent: 60 },
+            { id: "d2", name: "MacBook", type: "Computer", is_active: false },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await playerGetDevices({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.data.length, 2);
+    assert.deepEqual(result.data[0], { id: "d1", name: "iPhone", type: "Smartphone", isActive: true, volumePercent: 60 });
+    assert.deepEqual(result.data[1], { id: "d2", name: "MacBook", type: "Computer", isActive: false });
+  });
+
+  it("returns [] when Spotify returns no devices field", async () => {
+    const handle = makeFakeRuntime([new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } })]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await playerGetDevices({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.deepEqual(result.data, []);
+  });
+});

--- a/test/plugins/spotify/test_playback.ts
+++ b/test/plugins/spotify/test_playback.ts
@@ -195,6 +195,40 @@ describe("playerGetDevices — normalisation", () => {
     assert.deepEqual(result.data[1], { id: "d2", name: "MacBook", type: "Computer", isActive: false });
   });
 
+  it("preserves restricted devices that have a null/missing `id` (Codex review on PR #1171)", async () => {
+    const handle = makeFakeRuntime([
+      new Response(
+        JSON.stringify({
+          devices: [
+            { id: null, name: "Restricted Speaker", type: "Speaker", is_active: false },
+            { name: "AnonymousId", type: "Computer", is_active: false }, // missing id field
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await playerGetDevices({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.data.length, 2);
+    assert.equal(result.data[0].id, null);
+    assert.equal(result.data[0].name, "Restricted Speaker");
+    assert.equal(result.data[1].id, null);
+  });
+
+  it("still drops devices with no `name` (a nameless device is not useful to surface)", async () => {
+    const handle = makeFakeRuntime([
+      new Response(JSON.stringify({ devices: [{ id: "d1", type: "Speaker", is_active: false }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await playerGetDevices({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.deepEqual(result.data, []);
+  });
+
   it("returns [] when Spotify returns no devices field", async () => {
     const handle = makeFakeRuntime([new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } })]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/plugins/spotify/test_profile.ts
+++ b/test/plugins/spotify/test_profile.ts
@@ -1,0 +1,172 @@
+// Tests for the profile cache (PR 3). The cache backs the
+// Premium-gate decision; getting the TTL or fallback semantics
+// wrong has user-visible consequences (Free users locked into
+// Premium UI or Premium users blocked from controls).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { getProfile, isPremium } from "../../../packages/spotify-plugin/src/profile.js";
+import type { SpotifyTokens } from "../../../packages/spotify-plugin/src/types.js";
+
+const NOW_DATE = new Date("2026-05-05T00:00:00.000Z");
+const NOW = () => NOW_DATE;
+
+const validTokens: SpotifyTokens = {
+  accessToken: "at-current",
+  refreshToken: "rt-current",
+  expiresAt: "2026-05-05T05:00:00.000Z",
+  scopes: ["user-library-read"],
+};
+
+function makeFakeRuntime(responses: Response[], initialFiles: Record<string, string> = {}) {
+  const calls: { url: string }[] = [];
+  const queue = [...responses];
+  const store = new Map<string, string>(Object.entries(initialFiles));
+  return {
+    runtime: {
+      fetch: async (url: string) => {
+        calls.push({ url });
+        const next = queue.shift();
+        if (!next) throw new Error(`fetch over-called`);
+        return next;
+      },
+      files: {
+        config: {
+          exists: async (rel: string) => store.has(rel),
+          read: async (rel: string) => {
+            const value = store.get(rel);
+            if (value === undefined) throw new Error("not found");
+            return value;
+          },
+          readBytes: async () => new Uint8Array(),
+          write: async (rel: string, content: string | Uint8Array) => {
+            store.set(rel, typeof content === "string" ? content : new TextDecoder().decode(content));
+          },
+          readDir: async () => Array.from(store.keys()),
+          stat: async () => ({ mtimeMs: 0, size: 0 }),
+          unlink: async (rel: string) => {
+            store.delete(rel);
+          },
+        },
+        data: {
+          exists: async () => false,
+          read: async () => "",
+          readBytes: async () => new Uint8Array(),
+          write: async () => {},
+          readDir: async () => [],
+          stat: async () => ({ mtimeMs: 0, size: 0 }),
+          unlink: async () => {},
+        },
+      },
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      pubsub: { publish: () => {} },
+      locale: "en",
+      fetchJson: async () => {
+        throw new Error("not used");
+      },
+    },
+    calls,
+    store,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("getProfile — fresh fetch + cache write", () => {
+  it("calls /v1/me when there's no cached snapshot, then persists profile.json", async () => {
+    const handle = makeFakeRuntime([jsonResponse({ product: "premium", display_name: "Test User" })]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.profile.product, "premium");
+    assert.equal(result.profile.displayName, "Test User");
+    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me");
+    // profile.json should be written.
+    assert.ok(handle.store.has("profile.json"));
+  });
+
+  it("treats Free / Open accounts as non-premium", async () => {
+    const handle = makeFakeRuntime([jsonResponse({ product: "free", display_name: "Free User" })]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(isPremium(result.profile), false);
+  });
+});
+
+describe("getProfile — cache hit", () => {
+  it("does not call /v1/me when cache is fresh (within TTL)", async () => {
+    const fresh = JSON.stringify({ product: "premium", displayName: "Cached", fetchedAtMs: NOW_DATE.getTime() - 1000 });
+    const handle = makeFakeRuntime([], { "profile.json": fresh });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.profile.displayName, "Cached");
+    assert.equal(handle.calls.length, 0); // no fetch
+  });
+
+  it("re-fetches when cache is older than the TTL (24h)", async () => {
+    const stale = JSON.stringify({ product: "premium", displayName: "Stale", fetchedAtMs: NOW_DATE.getTime() - 25 * 60 * 60 * 1000 });
+    const handle = makeFakeRuntime([jsonResponse({ product: "free", display_name: "Refreshed" })], { "profile.json": stale });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.profile.product, "free");
+    assert.equal(result.profile.displayName, "Refreshed");
+    assert.equal(handle.calls.length, 1);
+  });
+});
+
+describe("getProfile — fallback to stale cache on API failure", () => {
+  it("returns the stale cache when /v1/me fails (network blip shouldn't block users)", async () => {
+    const stale = JSON.stringify({ product: "premium", displayName: "Stale", fetchedAtMs: NOW_DATE.getTime() - 25 * 60 * 60 * 1000 });
+    const handle = makeFakeRuntime([new Response("server err", { status: 500 })], { "profile.json": stale });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.profile.product, "premium"); // stale, but better than nothing
+  });
+
+  it("returns the API error when there's no cache to fall back on", async () => {
+    const handle = makeFakeRuntime([new Response("server err", { status: 500 })]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "spotify_api_error");
+  });
+});
+
+describe("getProfile — corrupted cache", () => {
+  it("treats unparseable profile.json as a cache miss", async () => {
+    const handle = makeFakeRuntime([jsonResponse({ product: "premium", display_name: "Re-fetched" })], { "profile.json": "{not-json" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.profile.displayName, "Re-fetched");
+    assert.equal(handle.calls.length, 1);
+  });
+
+  it("treats a profile.json missing required fields as a cache miss", async () => {
+    const handle = makeFakeRuntime([jsonResponse({ product: "premium" })], { "profile.json": JSON.stringify({ displayName: "missing-fetchedAtMs" }) });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await getProfile({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(handle.calls.length, 1);
+  });
+});
+
+describe("isPremium discriminator", () => {
+  it("returns true only for product === 'premium'", () => {
+    assert.equal(isPremium({ product: "premium", displayName: "", fetchedAtMs: 0 }), true);
+    assert.equal(isPremium({ product: "free", displayName: "", fetchedAtMs: 0 }), false);
+    assert.equal(isPremium({ product: "open", displayName: "", fetchedAtMs: 0 }), false);
+    assert.equal(isPremium({ product: "PREMIUM", displayName: "", fetchedAtMs: 0 }), false); // case-sensitive
+  });
+});

--- a/test/plugins/spotify/test_profile.ts
+++ b/test/plugins/spotify/test_profile.ts
@@ -164,9 +164,9 @@ describe("getProfile — corrupted cache", () => {
 
 describe("isPremium discriminator", () => {
   it("returns true only for product === 'premium'", () => {
-    assert.equal(isPremium({ product: "premium", displayName: "", fetchedAtMs: 0 }), true);
-    assert.equal(isPremium({ product: "free", displayName: "", fetchedAtMs: 0 }), false);
-    assert.equal(isPremium({ product: "open", displayName: "", fetchedAtMs: 0 }), false);
-    assert.equal(isPremium({ product: "PREMIUM", displayName: "", fetchedAtMs: 0 }), false); // case-sensitive
+    assert.equal(isPremium({ userId: "u", product: "premium", displayName: "", fetchedAtMs: 0 }), true);
+    assert.equal(isPremium({ userId: "u", product: "free", displayName: "", fetchedAtMs: 0 }), false);
+    assert.equal(isPremium({ userId: "u", product: "open", displayName: "", fetchedAtMs: 0 }), false);
+    assert.equal(isPremium({ userId: "u", product: "PREMIUM", displayName: "", fetchedAtMs: 0 }), false); // case-sensitive
   });
 });


### PR DESCRIPTION
## Summary

Adds the Spotify Web API Player Controls (play / pause / next / previous / seek / setVolume / transferPlayback / getDevices) gated behind Spotify Premium. The plugin reads `/v1/me`'s `product` field, caches it for 24h, and refuses Premium-only kinds with `premium_required` instead of letting Spotify 403 each call. View grows a Player panel under Now Playing — visible to Premium users only — and a device list (free for everyone, useful for diagnosing "no active device" errors).

## Items to Confirm / Review

- **Profile cache TTL = 24h**. Long enough that we don't burn `/v1/me` on every action, short enough that a Free → Premium upgrade unlocks controls within a day. Reasonable?
- **Stale-cache fallback on `/v1/me` failure**: if Spotify is down and the cache is older than the TTL, we serve the stale snapshot rather than locking the user out. Trade-off: a Free → Premium upgrade in the past 24h won't show through if `/v1/me` is unreachable. Right call?
- **`getDevices` is Free-friendly**. The Premium gate is bypassed for `getDevices` so Free users can see what devices they have (helps them understand why controls don't work). Aligns with Spotify's API behaviour. OK?
- **Empty `play` body**: when the LLM calls `play` with no `contextUri` / `trackUris[]`, the plugin sends a PUT with no body, which Spotify treats as "resume". Matches API docs. Worth noting in the tool description?
- **2 new OAuth scopes** (`user-read-playback-state`, `user-modify-playback-state`): existing PR1/2 users will hit 403 Insufficient client scope on player kinds. The handler maps 403+scope to a `scope_missing` error with reconnect guidance. View doesn't yet add a one-click Reconnect button — currently the user has to delete `tokens.json` and re-Connect. Worth a follow-up.

## User Prompt

「コメントよんで修正しマージまでいってから3かな。」「残課題あるなら続けて実装。」 — PR 6 (Search) のレビューを修正中、待ち時間を活用して PR 3 (Player Controls) を main から並行 branch して実装。Premium 判定 → controls on/off は最初の design 質問で確定済み。

## Implementation approach

### Server-side

`SPOTIFY_KINDS` に 8 個追加 (`play` / `pause` / `next` / `previous` / `seek` / `setVolume` / `transferPlayback` / `getDevices`)。`LLM_CALLABLE_KINDS` も同期。`DispatchArgsSchema` の各 arm に必要な args:
- play/pause/next/previous: optional `deviceId`
- play: optional `contextUri` (`spotify:playlist:abc`) or `trackUris[]` (mutually exclusive)
- seek: required `positionMs` (0..86_400_000)
- setVolume: required `volumePercent` (0..100)
- transferPlayback: required `deviceId`, optional `play: boolean`

`profile.ts` (新規): `/v1/me` を呼んで `{product, displayName, fetchedAtMs}` を `profile.json` に永続化、24h TTL でキャッシュ。API 失敗時に stale cache があれば serve、なければエラー pass through。

`playback.ts` (新規): 8 kinds の handler。Spotify の Player API は side-effect が多くレスポンスは 204 が大半なので、`mapVoidResult` で `{ ok, message }` 形に揃える。`getDevices` だけ payload あり (NormalisedDevice[])。

`index.ts` dispatcher:
- `handlePlayer(args)` で `getDevices` 以外を `premiumGate(deps)` でガード
- `mapPlayerError` で 404 (no active device) / 403 (scope_missing) を user-friendly メッセージに変換
- `handleStatus` を拡張: `isPremium: boolean | null`, `displayName: string` を含める (cached profile を内部で参照)

### Vue

View.vue の Now Playing タブの下に Player Controls panel を追加。状態によって表示が分岐:
- `isPremium === false` → "Spotify Premium required" notice
- `isPremium === true` → Prev / Pause / Play / Next + volume slider + デバイス transfer
- 接続なし → そもそも表示されない

デバイス一覧は Premium / Free 両方で表示される (Free では transfer ボタン非表示)。

### Tests (21 new cases、累計 86)

- `test_profile.ts` (9): cache miss → fetch → write、cache hit、TTL miss、stale fallback、no-cache + API error、corrupted JSON、missing required fields、isPremium discriminator
- `test_playback.ts` (12): 各 kind の URL/method/body 検証 + デバイス normaliser

### Docs

`docs/tips/spotify-setup.{md,en.md}` に Free vs Premium の機能比較表 + PR 3 後の reconnect 案内を追加。

## Test plan

- [ ] `yarn test` で 86/86 pass
- [ ] dev サーバ再起動 → Spotify View → Reconnect → 新 scope で再認可
- [ ] **Free アカウント**: Now Playing タブの下に "Premium required" 注意書きが見える、controls は出ない
- [ ] **Premium アカウント**: Play / Pause / Next / Prev / Volume slider が動く
- [ ] デバイスが複数あるときは "Transfer here" で切替が効く
- [ ] アクティブデバイスなしで `play` を呼ぶと `no_active_device` エラーが出てデバイス一覧へ誘導される
- [ ] LLM から `manageSpotify({ kind: "play", contextUri: "spotify:playlist:..." })` で再生開始
- [ ] LLM 経由で `pause` / `next` / `previous` / `setVolume` / `seek` が動く
- [ ] PR 1/2 の機能 (Liked / Playlists / Recent / NowPlaying / Search) が引き続き動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)