### PR TITLE
feat(translation): add translation microservice (PR 1 of 2)

### DIFF
--- a/plans/feat-translation-service.md
+++ b/plans/feat-translation-service.md
@@ -1,0 +1,172 @@
+# Translation service
+
+A server-side microservice that translates short English UI strings
+into other locales, backed by a per-dictionary JSON cache so the
+LLM is only called on misses.
+
+First consumer (separate PR): Role suggested queries, translated
+asynchronously to the user's browser locale when a chat session is
+opened.
+
+## Why a separate service
+
+Role queries are short, finite, and rarely change — close to the
+ideal shape for an English-keyed cache that warms once and stays
+warm. Building the service generically (rather than baking a
+translation step into the roles config) keeps it reusable for other
+short-string surfaces (helps text, role descriptions, plugin labels)
+without each consumer growing its own caching strategy.
+
+## API shape
+
+```text
+POST /api/translation
+{
+  "namespace": "role-queries",       // dictionary namespace + filename
+  "targetLanguage": "ja",            // BCP-47 short code
+  "sentences": ["Hello", "World"]    // English source
+}
+→ 200
+{ "translations": ["こんにちは", "世界"] }   // same length, same order
+```
+
+`namespace` partitions translations by context, not by content hash.
+We may only ever use one namespace (`role-queries`) but the parameter
+keeps the option open for context-disambiguated translations later
+(e.g. "Save" in a toolbar vs. a dialog). Validated against
+`^[a-zA-Z0-9_-]+$` so it can't escape the cache directory.
+
+## Cache file
+
+Path: `{workspace}/data/translation/{namespace}.json`
+
+```json
+{
+  "sentences": {
+    "Hello": { "ja": "こんにちは", "ko": "안녕하세요" },
+    "World": { "ja": "世界" }
+  }
+}
+```
+
+- Source English is the dictionary key — debuggable (`cat` shows
+  exactly what's been translated), collision-free, no hash step.
+- Files are KB-scale even with all 8 locales × hundreds of strings;
+  loaded on each request, no in-memory cache layer.
+- Orphan keys (English source got reworded) are left in place.
+  Costs nothing; pruning would risk dropping live entries during
+  partial deploys.
+
+## Service flow
+
+1. **`en` short-circuit** — if `targetLanguage === "en"`, return
+   `sentences` as-is. No cache I/O, no LLM call.
+2. **Validate inputs** — `namespace` matches the safe regex,
+   `targetLanguage` matches `^[a-z]{2}(-[A-Z]{2})?$`, `sentences`
+   is a non-empty array of non-empty strings.
+3. **Load cache** — read `{namespace}.json` if it exists, else
+   start with `{ sentences: {} }`.
+4. **Split hit / miss** — for each input sentence, check
+   `cache.sentences[sentence]?.[targetLanguage]`.
+5. **Translate misses** — call the injected `translateBatch`
+   function with only the missing sentences. Validate the returned
+   array length matches the request.
+6. **Merge + write** — fold new translations into the cache,
+   atomic-write back via `writeFileAtomic`.
+7. **Return** — assemble the output array in the original input
+   order (cached entries + freshly-translated, mapped back).
+
+## Single-flight per namespace
+
+Concurrent requests for the same `namespace` would race on
+read-merge-write. An in-memory `Map<namespace, Promise<void>>`
+serializes the cache update step per namespace. Held only for the
+duration of the LLM call + write; released regardless of outcome.
+
+## LLM call (production)
+
+Spawn the `claude` CLI in print mode:
+
+```bash
+claude -p "<prompt>" --output-format json
+```
+
+This piggybacks on the same auth model the existing
+`server/agent/backend/claude-code.ts` already uses (no new
+dependency, no `ANTHROPIC_API_KEY` required). The prompt asks
+for a JSON array of translations matching the input order; we
+parse and length-check before merging.
+
+Subprocess wrapped in `server/services/translation/llm.ts` and
+injected into the service factory, so unit tests pass a mock
+function and never spawn anything.
+
+Timeout: reuse `SUBPROCESS_WORK_TIMEOUT_MS` from
+`server/utils/time.ts`. On timeout the request fails with 503;
+the cache is not written.
+
+## File layout
+
+```text
+server/
+  services/translation/
+    index.ts        ← createTranslationService({ translateBatch })
+    cache.ts        ← load / merge / mapping helpers (pure)
+    llm.ts          ← prod translateBatch impl (spawns claude -p)
+    types.ts
+  utils/files/translation-io.ts   ← atomic read/write per project rule
+  api/routes/translation.ts       ← Express handler
+
+src/config/apiRoutes.ts            ← +translation: "/api/translation"
+server/workspace/paths.ts          ← +translation: "data/translation"
+
+test/services/translation/
+  test_translate.ts                ← cache hit/miss/partial, en short-circuit, order, merge, validation
+  test_cache.ts                    ← pure cache helpers
+```
+
+## Test plan (PR 1)
+
+All against an injected mock `translateBatch`. Real workspace I/O
+into a temp dir per the existing `test/journal/` pattern.
+
+- **cold**: empty cache → mock called with all sentences → cache
+  file created with new entries → result matches mock output.
+- **warm**: full cache → mock NOT called → result from cache only.
+- **partial**: 2 of 5 cached → mock called with 3 misses only →
+  result is in original input order (interleaved cached + fresh).
+- **merge**: cache has `{Hello: {ja}}`, request `ko` → final cache
+  has `{Hello: {ja, ko}}` (existing language preserved).
+- **`en` short-circuit**: targetLanguage `en` → mock NOT called,
+  cache file not touched, returns input verbatim.
+- **length mismatch**: mock returns wrong-length array → throws.
+- **namespace validation**: `../etc` rejected.
+- **single-flight**: two concurrent calls on the same namespace →
+  mock invoked exactly once for the overlapping misses, both
+  promises resolve with consistent results.
+
+## Out of scope (PR 1)
+
+- Role-queries integration (separate PR — see below).
+- LRU / TTL eviction (orphan keys are cheap; no need).
+- Cross-process cache coordination (single-flight is per Node
+  process; we run one server).
+- Streaming partial results (synchronous JSON response).
+
+## PR 2 (separate): wire to Role suggested queries
+
+When the chat session opens:
+
+1. Read browser locale via the existing i18n composable.
+2. If `en`, render queries as-is.
+3. Otherwise, fire `POST /api/translation` with
+   `namespace: "role-queries"` and the role's English queries.
+4. Render English immediately; swap to translations when the
+   response arrives (progressive enhancement, never blocks the
+   chat UI).
+5. Use `apiPost` from `src/utils/api.ts` (auto-attaches bearer
+   token).
+
+PR 2 also picks the right place in the role-rendering path to
+stash the translated queries (likely a composable that wraps the
+role config rather than mutating it in place).

--- a/server/api/routes/translation.ts
+++ b/server/api/routes/translation.ts
@@ -1,0 +1,44 @@
+// Translation HTTP route — POST /api/translation. Thin handler that
+// delegates to the translation service; validation lives there.
+
+import { Router, type Request, type Response } from "express";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { createTranslationService, TranslationInputError } from "../../services/translation/index.js";
+import { defaultTranslateBatch } from "../../services/translation/llm.js";
+import { log } from "../../system/logger/index.js";
+import type { TranslateBatchFn, TranslateRequest, TranslateResponse } from "../../services/translation/types.js";
+
+export interface TranslationRouteDeps {
+  /** Override for tests — defaults to the live workspace root. */
+  workspaceRoot?: string;
+  /** Override for tests — defaults to the production claude-CLI backend. */
+  translateBatch?: TranslateBatchFn;
+}
+
+interface TranslateErrorBody {
+  error: string;
+}
+
+export function createTranslationRouter(deps: TranslationRouteDeps = {}): Router {
+  const router = Router();
+  const service = createTranslationService({
+    translateBatch: deps.translateBatch ?? defaultTranslateBatch,
+    workspaceRoot: deps.workspaceRoot,
+  });
+
+  router.post(API_ROUTES.translation.translate, async (req: Request, res: Response<TranslateResponse | TranslateErrorBody>) => {
+    try {
+      const result = await service.translate(req.body as TranslateRequest);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof TranslationInputError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      log.error("translation-route", "translate failed", { error: String(err) });
+      res.status(500).json({ error: "translation failed" });
+    }
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import { makePluginRuntime } from "./plugins/runtime.js";
 import { MCP_PLUGIN_NAMES } from "./agent/plugin-names.js";
 import { createNotificationsRouter } from "./api/routes/notifications.js";
 import { createJournalRouter } from "./api/routes/journal.js";
+import { createTranslationRouter } from "./api/routes/translation.js";
 import { type NotificationDeps, initNotifications } from "./events/notifications.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
 import { createChatService } from "@mulmobridge/chat-service";
@@ -541,6 +542,7 @@ const notificationDeps: NotificationDeps = {
 };
 app.use(createNotificationsRouter(notificationDeps));
 app.use(createJournalRouter());
+app.use(createTranslationRouter());
 app.use(mcpToolsRouter);
 app.use(schedulerTasksRoutes);
 

--- a/server/services/translation/cache.ts
+++ b/server/services/translation/cache.ts
@@ -1,0 +1,52 @@
+// Pure helpers for the translation cache. Kept side-effect free so
+// the unit tests can exercise the lookup / merge / assemble logic
+// without touching the filesystem or any LLM.
+
+import type { DictionaryFile } from "./types.js";
+
+export function emptyDictionary(): DictionaryFile {
+  return { sentences: {} };
+}
+
+export function lookupCached(dict: DictionaryFile, sentence: string, lang: string): string | undefined {
+  return dict.sentences[sentence]?.[lang];
+}
+
+export interface SplitResult {
+  /** Map from input sentence to its cached translation. */
+  readonly cached: Map<string, string>;
+  /** Distinct sentences that need a fresh LLM translation. */
+  readonly misses: readonly string[];
+}
+
+export function splitHitMiss(dict: DictionaryFile, sentences: readonly string[], lang: string): SplitResult {
+  const cached = new Map<string, string>();
+  const missesSet = new Set<string>();
+  for (const sentence of sentences) {
+    const translated = lookupCached(dict, sentence, lang);
+    if (translated !== undefined) {
+      cached.set(sentence, translated);
+    } else {
+      missesSet.add(sentence);
+    }
+  }
+  return { cached, misses: Array.from(missesSet) };
+}
+
+export function mergeTranslations(dict: DictionaryFile, lang: string, fresh: ReadonlyMap<string, string>): DictionaryFile {
+  const next: Record<string, Record<string, string>> = { ...dict.sentences };
+  for (const [source, translated] of fresh) {
+    next[source] = { ...next[source], [lang]: translated };
+  }
+  return { sentences: next };
+}
+
+export function assembleResult(sentences: readonly string[], cached: ReadonlyMap<string, string>, fresh: ReadonlyMap<string, string>): string[] {
+  return sentences.map((sentence) => {
+    const translated = cached.get(sentence) ?? fresh.get(sentence);
+    if (translated === undefined) {
+      throw new Error(`[translation] missing translation for ${JSON.stringify(sentence)}`);
+    }
+    return translated;
+  });
+}

--- a/server/services/translation/index.ts
+++ b/server/services/translation/index.ts
@@ -1,0 +1,87 @@
+// Translation service factory. Reads the on-disk cache, routes
+// only the missing sentences through an injected `translateBatch`,
+// merges new translations back, and returns the assembled result
+// in the caller's input order.
+//
+// The injection seam is deliberate: production wires
+// `defaultTranslateBatch` from `./llm.ts` (which spawns the
+// `claude` CLI), unit tests pass a deterministic fake.
+
+import { loadDictionary, saveDictionary } from "../../utils/files/translation-io.js";
+import { assembleResult, mergeTranslations, splitHitMiss } from "./cache.js";
+import type { TranslateRequest, TranslateResponse, TranslationService, TranslationServiceDeps } from "./types.js";
+
+const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
+// Fixed-length alternation, no nested quantifiers — safe from ReDoS.
+// eslint-disable-next-line security/detect-unsafe-regex -- single-pass match against a 2- or 5-char locale code, no backtracking.
+const LANGUAGE_RE = /^[a-z]{2}(?:-[A-Z]{2})?$/;
+
+export class TranslationInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TranslationInputError";
+  }
+}
+
+function validateRequest(req: TranslateRequest): void {
+  if (typeof req.namespace !== "string" || !NAMESPACE_RE.test(req.namespace)) {
+    throw new TranslationInputError(`invalid namespace: ${JSON.stringify(req.namespace)}`);
+  }
+  if (typeof req.targetLanguage !== "string" || !LANGUAGE_RE.test(req.targetLanguage)) {
+    throw new TranslationInputError(`invalid targetLanguage: ${JSON.stringify(req.targetLanguage)}`);
+  }
+  if (!Array.isArray(req.sentences) || req.sentences.length === 0) {
+    throw new TranslationInputError("sentences must be a non-empty array");
+  }
+  for (const sentence of req.sentences) {
+    if (typeof sentence !== "string" || sentence.length === 0) {
+      throw new TranslationInputError("sentences must contain non-empty strings");
+    }
+  }
+}
+
+export function createTranslationService(deps: TranslationServiceDeps): TranslationService {
+  const { translateBatch, workspaceRoot } = deps;
+  // Per-namespace serialization chain. Two concurrent translate() calls
+  // on the same namespace would otherwise race the read-merge-write
+  // step; chaining ensures the second sees the first's persisted output.
+  const chains = new Map<string, Promise<unknown>>();
+
+  async function runOnce(req: TranslateRequest): Promise<TranslateResponse> {
+    const dict = loadDictionary(req.namespace, workspaceRoot);
+    const { cached, misses } = splitHitMiss(dict, req.sentences, req.targetLanguage);
+    if (misses.length === 0) {
+      return { translations: assembleResult(req.sentences, cached, new Map()) };
+    }
+    const translated = await translateBatch({ targetLanguage: req.targetLanguage, sentences: misses });
+    if (translated.length !== misses.length) {
+      throw new Error(`[translation] translateBatch returned ${translated.length} translations for ${misses.length} sentences`);
+    }
+    const fresh = new Map<string, string>();
+    misses.forEach((sentence, index) => fresh.set(sentence, translated[index]));
+    const next = mergeTranslations(dict, req.targetLanguage, fresh);
+    await saveDictionary(req.namespace, next, workspaceRoot);
+    return { translations: assembleResult(req.sentences, cached, fresh) };
+  }
+
+  function serialize<T>(namespace: string, runner: () => Promise<T>): Promise<T> {
+    const prev = chains.get(namespace) ?? Promise.resolve();
+    const next = prev.catch(() => undefined).then(runner);
+    const tracked = next.catch(() => undefined);
+    chains.set(namespace, tracked);
+    tracked.then(() => {
+      if (chains.get(namespace) === tracked) chains.delete(namespace);
+    });
+    return next;
+  }
+
+  async function translate(req: TranslateRequest): Promise<TranslateResponse> {
+    validateRequest(req);
+    if (req.targetLanguage === "en") {
+      return { translations: [...req.sentences] };
+    }
+    return serialize(req.namespace, () => runOnce(req));
+  }
+
+  return { translate };
+}

--- a/server/services/translation/llm.ts
+++ b/server/services/translation/llm.ts
@@ -1,0 +1,137 @@
+// Production `translateBatch`: spawns the `claude` CLI in print
+// mode with a JSON schema so the response array length is
+// guaranteed to match the request. Same auth model as the rest of
+// the server (no API key required).
+//
+// Patterned after `server/workspace/chat-index/summarizer.ts`.
+
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
+import { errorMessage } from "../../utils/errors.js";
+import { formatSpawnFailure } from "../../utils/spawn.js";
+import { isRecord } from "../../utils/types.js";
+import { ClaudeCliNotFoundError } from "../../workspace/journal/archivist-cli.js";
+import type { TranslateBatchFn } from "./types.js";
+
+const SYSTEM_PROMPT =
+  "You are a translation engine. The user input is a JSON object with `targetLanguage` (BCP-47) " +
+  "and `sentences` (an array of English source strings). Translate each sentence into the target " +
+  "language and return strict JSON matching the provided schema. The output `translations` array " +
+  "MUST have the same length and order as the input `sentences` array. Preserve placeholders " +
+  "such as `{name}`, `{count}`, `%s`, and HTML tags verbatim.";
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    translations: {
+      type: "array",
+      items: { type: "string" },
+    },
+  },
+  required: ["translations"],
+};
+
+// Small per-call cap. A few dozen short UI strings on haiku costs
+// fractions of a cent; this guards against runaway prompts only.
+const MAX_BUDGET_USD = 0.5;
+
+interface ClaudeJsonEnvelope {
+  is_error?: boolean;
+  result?: string;
+  structured_output?: unknown;
+}
+
+export function parseTranslations(stdout: string): string[] {
+  let parsed: ClaudeJsonEnvelope;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch (err) {
+    throw new Error(`[translation] failed to parse claude json output: ${errorMessage(err)}`);
+  }
+  if (parsed.is_error) {
+    throw new Error(`[translation] claude returned error: ${parsed.result ?? "unknown"}`);
+  }
+  if (!isRecord(parsed.structured_output)) {
+    throw new Error("[translation] structured_output missing or not an object");
+  }
+  const { translations } = parsed.structured_output as Record<string, unknown>;
+  if (!Array.isArray(translations) || !translations.every((value): value is string => typeof value === "string")) {
+    throw new Error("[translation] translations is not a string array");
+  }
+  return translations;
+}
+
+function buildArgs(promptInput: string): string[] {
+  return [
+    "--print",
+    "--no-session-persistence",
+    "--output-format",
+    "json",
+    "--model",
+    "haiku",
+    "--max-budget-usd",
+    String(MAX_BUDGET_USD),
+    "--json-schema",
+    JSON.stringify(SCHEMA),
+    "--system-prompt",
+    SYSTEM_PROMPT,
+    "-p",
+    promptInput,
+  ];
+}
+
+function spawnClaudeTranslate(promptInput: string, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Run from tmpdir so claude does not load the project's
+    // CLAUDE.md / plugins / memory and inflate the context.
+    const proc = spawn("claude", buildArgs(promptInput), {
+      cwd: tmpdir(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      proc.kill("SIGKILL");
+      reject(new Error(`[translation] claude translate timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    proc.on("error", (err: Error & { code?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err.code === "ENOENT") {
+        reject(new ClaudeCliNotFoundError());
+      } else {
+        reject(err);
+      }
+    });
+    proc.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(formatSpawnFailure("[translation]", code, stdout, stderr)));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+export const defaultTranslateBatch: TranslateBatchFn = async ({ targetLanguage, sentences }) => {
+  const promptInput = JSON.stringify({ targetLanguage, sentences });
+  const stdout = await spawnClaudeTranslate(promptInput, CLI_SUBPROCESS_TIMEOUT_MS);
+  return parseTranslations(stdout);
+};

--- a/server/services/translation/types.ts
+++ b/server/services/translation/types.ts
@@ -1,0 +1,35 @@
+// Public types for the translation service. The on-disk dictionary
+// shape is the authoritative cache format — see plans/feat-translation-service.md.
+
+export interface TranslateRequest {
+  /** Dictionary namespace; also the cache filename. */
+  readonly namespace: string;
+  /** BCP-47 short code, e.g. `ja`, `pt-BR`. */
+  readonly targetLanguage: string;
+  /** English source sentences in the order the caller wants them returned. */
+  readonly sentences: readonly string[];
+}
+
+export interface TranslateResponse {
+  readonly translations: readonly string[];
+}
+
+export interface DictionaryFile {
+  readonly sentences: Record<string, Record<string, string>>;
+}
+
+export interface TranslateBatchInput {
+  readonly targetLanguage: string;
+  readonly sentences: readonly string[];
+}
+
+export type TranslateBatchFn = (input: TranslateBatchInput) => Promise<string[]>;
+
+export interface TranslationServiceDeps {
+  readonly translateBatch: TranslateBatchFn;
+  readonly workspaceRoot?: string;
+}
+
+export interface TranslationService {
+  readonly translate: (req: TranslateRequest) => Promise<TranslateResponse>;
+}

--- a/server/utils/files/translation-io.ts
+++ b/server/utils/files/translation-io.ts
@@ -1,0 +1,25 @@
+// Domain file I/O for the translation cache. One JSON file per
+// namespace under `data/translation/`. All writes go through the
+// atomic helper per project rule.
+
+import path from "node:path";
+import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
+import { loadJsonFile, writeJsonAtomic } from "./json.js";
+import { emptyDictionary } from "../../services/translation/cache.js";
+import type { DictionaryFile } from "../../services/translation/types.js";
+
+function root(workspaceRoot?: string): string {
+  return workspaceRoot ?? workspacePath;
+}
+
+export function dictionaryPath(namespace: string, workspaceRoot?: string): string {
+  return path.join(root(workspaceRoot), WORKSPACE_DIRS.translation, `${namespace}.json`);
+}
+
+export function loadDictionary(namespace: string, workspaceRoot?: string): DictionaryFile {
+  return loadJsonFile<DictionaryFile>(dictionaryPath(namespace, workspaceRoot), emptyDictionary());
+}
+
+export async function saveDictionary(namespace: string, dict: DictionaryFile, workspaceRoot?: string): Promise<void> {
+  await writeJsonAtomic(dictionaryPath(namespace, workspaceRoot), dict);
+}

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -103,6 +103,7 @@ const HOST_WORKSPACE_DIRS = {
   contacts: "data/contacts",
   scheduler: "data/scheduler",
   sources: "data/sources",
+  translation: "data/translation",
   // Pasted/dropped chat attachments — saved at upload time so the
   // LLM can be handed a stable workspace path instead of inline
   // base64. Conversion artefacts (e.g. PPTX → PDF) live alongside

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -140,6 +140,10 @@ const HOST_API_ROUTES = {
     markdown: "/api/pdf/markdown",
   },
 
+  translation: {
+    translate: "/api/translation",
+  },
+
   // Plugin-owned endpoints that don't follow a single naming pattern.
   // Names match the plugin tool name or the short verb the plugin uses.
   plugins: {

--- a/test/services/translation/test_cache.ts
+++ b/test/services/translation/test_cache.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { assembleResult, emptyDictionary, lookupCached, mergeTranslations, splitHitMiss } from "../../../server/services/translation/cache.js";
+
+describe("translation cache helpers", () => {
+  it("emptyDictionary returns a fresh empty object on each call", () => {
+    const first = emptyDictionary();
+    const second = emptyDictionary();
+    first.sentences["Hello"] = { ja: "こんにちは" };
+    assert.deepEqual(second, { sentences: {} });
+  });
+
+  it("lookupCached returns the translation when present", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは", ko: "안녕" } } };
+    assert.equal(lookupCached(dict, "Hello", "ja"), "こんにちは");
+  });
+
+  it("lookupCached returns undefined when sentence or language is missing", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは" } } };
+    assert.equal(lookupCached(dict, "Hello", "ko"), undefined);
+    assert.equal(lookupCached(dict, "World", "ja"), undefined);
+  });
+
+  it("splitHitMiss separates cached entries from misses, dedupes misses", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは" } } };
+    const { cached, misses } = splitHitMiss(dict, ["Hello", "World", "Hello", "Foo"], "ja");
+    assert.equal(cached.get("Hello"), "こんにちは");
+    assert.equal(cached.size, 1);
+    assert.deepEqual([...misses].sort(), ["Foo", "World"]);
+  });
+
+  it("mergeTranslations preserves existing language entries when adding a new one", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは" } } };
+    const fresh = new Map([["Hello", "안녕"]]);
+    const next = mergeTranslations(dict, "ko", fresh);
+    assert.deepEqual(next.sentences.Hello, { ja: "こんにちは", ko: "안녕" });
+    // original untouched (pure helper)
+    assert.deepEqual(dict.sentences.Hello, { ja: "こんにちは" });
+  });
+
+  it("mergeTranslations adds new sentence keys", () => {
+    const dict = emptyDictionary();
+    const fresh = new Map([
+      ["Hello", "こんにちは"],
+      ["World", "世界"],
+    ]);
+    const next = mergeTranslations(dict, "ja", fresh);
+    assert.deepEqual(next.sentences, {
+      Hello: { ja: "こんにちは" },
+      World: { ja: "世界" },
+    });
+  });
+
+  it("assembleResult preserves caller's input order across cached + fresh", () => {
+    const cached = new Map([["Hello", "こんにちは"]]);
+    const fresh = new Map([
+      ["World", "世界"],
+      ["Foo", "フー"],
+    ]);
+    const result = assembleResult(["World", "Hello", "Foo", "Hello"], cached, fresh);
+    assert.deepEqual(result, ["世界", "こんにちは", "フー", "こんにちは"]);
+  });
+
+  it("assembleResult throws when a sentence is in neither map", () => {
+    assert.throws(() => assembleResult(["Hello"], new Map(), new Map()), /missing translation/);
+  });
+});

--- a/test/services/translation/test_translate.ts
+++ b/test/services/translation/test_translate.ts
@@ -1,0 +1,211 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, existsSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
+import { createTranslationService, TranslationInputError } from "../../../server/services/translation/index.js";
+import type { TranslateBatchFn, TranslateBatchInput } from "../../../server/services/translation/types.js";
+
+interface MockBackend {
+  readonly fn: TranslateBatchFn;
+  readonly calls: TranslateBatchInput[];
+}
+
+function makeMock(fakeTranslate: (sentence: string, lang: string) => string = (sentence, lang) => `[${lang}]${sentence}`): MockBackend {
+  const calls: TranslateBatchInput[] = [];
+  const runner: TranslateBatchFn = async (input) => {
+    calls.push({ targetLanguage: input.targetLanguage, sentences: [...input.sentences] });
+    return input.sentences.map((sentence) => fakeTranslate(sentence, input.targetLanguage));
+  };
+  return { fn: runner, calls };
+}
+
+function dictPath(root: string, namespace: string): string {
+  return path.join(root, WORKSPACE_DIRS.translation, `${namespace}.json`);
+}
+
+function readDict(root: string, namespace: string): unknown {
+  return JSON.parse(readFileSync(dictPath(root, namespace), "utf-8"));
+}
+
+describe("translation service — cold/warm/partial", () => {
+  let root: string;
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-")));
+  });
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  it("cold: missing cache → mock called with all sentences, file written, result matches", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({
+      namespace: "cold",
+      targetLanguage: "ja",
+      sentences: ["Hello", "World"],
+    });
+    assert.deepEqual(translations, ["[ja]Hello", "[ja]World"]);
+    assert.equal(mock.calls.length, 1);
+    assert.deepEqual([...mock.calls[0].sentences].sort(), ["Hello", "World"]);
+    assert.deepEqual(readDict(root, "cold"), {
+      sentences: {
+        Hello: { ja: "[ja]Hello" },
+        World: { ja: "[ja]World" },
+      },
+    });
+  });
+
+  it("warm: full cache hit → mock NOT called", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    // primed by the previous test
+    const { translations } = await service.translate({
+      namespace: "cold",
+      targetLanguage: "ja",
+      sentences: ["World", "Hello"],
+    });
+    assert.deepEqual(translations, ["[ja]World", "[ja]Hello"]);
+    assert.equal(mock.calls.length, 0);
+  });
+
+  it("partial: some cached, some missing → mock called only with misses, result preserves input order", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({
+      namespace: "cold",
+      targetLanguage: "ja",
+      sentences: ["Hello", "Foo", "World", "Bar"],
+    });
+    assert.deepEqual(translations, ["[ja]Hello", "[ja]Foo", "[ja]World", "[ja]Bar"]);
+    assert.equal(mock.calls.length, 1);
+    assert.deepEqual([...mock.calls[0].sentences].sort(), ["Bar", "Foo"]);
+  });
+
+  it("merge: adding a new language preserves existing one", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    await service.translate({
+      namespace: "cold",
+      targetLanguage: "ko",
+      sentences: ["Hello"],
+    });
+    const dict = readDict(root, "cold") as { sentences: Record<string, Record<string, string>> };
+    assert.deepEqual(dict.sentences.Hello, { ja: "[ja]Hello", ko: "[ko]Hello" });
+  });
+});
+
+describe("translation service — en short-circuit", () => {
+  let root: string;
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-en-")));
+  });
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  it("targetLanguage en → mock NOT called, no cache file, returns input verbatim", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({
+      namespace: "en-test",
+      targetLanguage: "en",
+      sentences: ["Hello", "World"],
+    });
+    assert.deepEqual(translations, ["Hello", "World"]);
+    assert.equal(mock.calls.length, 0);
+    assert.equal(existsSync(dictPath(root, "en-test")), false);
+  });
+});
+
+describe("translation service — validation", () => {
+  let root: string;
+  let service: ReturnType<typeof createTranslationService>;
+
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-val-")));
+    service = createTranslationService({ translateBatch: makeMock().fn, workspaceRoot: root });
+  });
+
+  it("rejects path-traversal namespace", async () => {
+    await assert.rejects(() => service.translate({ namespace: "../etc", targetLanguage: "ja", sentences: ["Hi"] }), TranslationInputError);
+  });
+
+  it("rejects empty namespace", async () => {
+    await assert.rejects(() => service.translate({ namespace: "", targetLanguage: "ja", sentences: ["Hi"] }), TranslationInputError);
+  });
+
+  it("rejects malformed targetLanguage", async () => {
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "Japanese", sentences: ["Hi"] }), TranslationInputError);
+  });
+
+  it("accepts BCP-47 region code (pt-BR)", async () => {
+    const mock = makeMock();
+    const svc = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await svc.translate({ namespace: "ns", targetLanguage: "pt-BR", sentences: ["Hi"] });
+    assert.deepEqual(translations, ["[pt-BR]Hi"]);
+  });
+
+  it("rejects empty sentences array", async () => {
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: [] }), TranslationInputError);
+  });
+
+  it("rejects sentences with empty strings", async () => {
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hi", ""] }), TranslationInputError);
+  });
+});
+
+describe("translation service — backend contract", () => {
+  let root: string;
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-bad-")));
+  });
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  it("throws when translateBatch returns the wrong number of strings", async () => {
+    const wrongLength: TranslateBatchFn = async () => ["only-one"];
+    const service = createTranslationService({ translateBatch: wrongLength, workspaceRoot: root });
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["A", "B"] }), /returned 1 translations for 2 sentences/);
+  });
+});
+
+describe("translation service — single-flight serialization", () => {
+  let root: string;
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-sf-")));
+  });
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  it("two concurrent calls on the same namespace serialize: the second sees the first's writes", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const calls: TranslateBatchInput[] = [];
+    let callIndex = 0;
+    const gated: TranslateBatchFn = async (input) => {
+      calls.push({ targetLanguage: input.targetLanguage, sentences: [...input.sentences] });
+      callIndex += 1;
+      if (callIndex === 1) {
+        await firstGate;
+      }
+      return input.sentences.map((sentence) => `[${input.targetLanguage}]${sentence}`);
+    };
+
+    const service = createTranslationService({ translateBatch: gated, workspaceRoot: root });
+
+    const firstCall = service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello"] });
+    const secondCall = service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello", "World"] });
+
+    // Yield so the second call can register its serialization continuation behind the first.
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseFirst?.();
+
+    const [resA, resB] = await Promise.all([firstCall, secondCall]);
+    assert.deepEqual(resA.translations, ["[ja]Hello"]);
+    assert.deepEqual(resB.translations, ["[ja]Hello", "[ja]World"]);
+
+    // First mock invocation handled "Hello"; second should have been called only with "World".
+    assert.equal(calls.length, 2);
+    assert.deepEqual([...calls[0].sentences], ["Hello"]);
+    assert.deepEqual([...calls[1].sentences], ["World"]);
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -45,6 +45,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "spreadsheets",
     "stories",
     "summaries",
+    "translation",
     "transports",
     "wiki",
     "wikiHistory",


### PR DESCRIPTION
## Summary

- Adds a server-side translation microservice that translates short English UI strings into other locales, backed by a per-namespace JSON cache so the LLM is only called on misses.
- One endpoint: `POST /api/translation { namespace, targetLanguage, sentences[] }` → `{ translations[] }` (same length, same order).
- Cache file lives at `{workspace}/data/translation/{namespace}.json`, keyed by the English source string. Single-flight per namespace serializes concurrent read-merge-write.
- `en` short-circuits to the input verbatim — no cache I/O, no LLM call.
- Production backend spawns `claude --print --json-schema ...` from tmpdir (same auth model as the existing summarizer / archivist subprocesses, no new dependency, no API key required). The backend is dependency-injected so unit tests run against a deterministic mock.

Plan: `plans/feat-translation-service.md`.

## Out of scope (follow-up PR)

Wiring this into Role suggested queries — async on chat-session open, falling back to the English source while the response is in flight.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn test` — all 4072 server tests pass; new tests cover cold/warm/partial cache, language merge, `en` short-circuit, namespace + locale validation, backend length-mismatch guard, and concurrent-call serialization
- [x] `yarn build` clean
- [ ] Manual smoke against `/api/translation` once a follow-up consumer lands (no UI surface in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server-side translation service with API endpoint for translating text batches to multiple languages
  * Implemented per-namespace translation cache to avoid redundant translations and improve performance
  * Added input validation and error handling for translation requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->