### PR TITLE
feat(roles): translate suggested queries via /api/translation (PR 2 of 2)

### DIFF
--- a/server/services/translation/cache.ts
+++ b/server/services/translation/cache.ts
@@ -8,6 +8,15 @@ export function emptyDictionary(): DictionaryFile {
   return { sentences: {} };
 }
 
+// `obj[userKey] = value` with `userKey === "__proto__"` triggers the
+// inherited setter on Object.prototype and mutates the prototype
+// chain instead of creating an own property — losing the entry and
+// polluting `obj`'s shape. `Object.defineProperty` bypasses the
+// setter and always creates a normal own data property.
+function safeAssign<V>(target: Record<string, V>, key: string, value: V): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true });
+}
+
 export function lookupCached(dict: DictionaryFile, sentence: string, lang: string): string | undefined {
   return dict.sentences[sentence]?.[lang];
 }
@@ -34,9 +43,20 @@ export function splitHitMiss(dict: DictionaryFile, sentences: readonly string[],
 }
 
 export function mergeTranslations(dict: DictionaryFile, lang: string, fresh: ReadonlyMap<string, string>): DictionaryFile {
-  const next: Record<string, Record<string, string>> = { ...dict.sentences };
+  const next: Record<string, Record<string, string>> = {};
+  for (const [source, langs] of Object.entries(dict.sentences)) {
+    safeAssign(next, source, { ...langs });
+  }
   for (const [source, translated] of fresh) {
-    next[source] = { ...next[source], [lang]: translated };
+    // `next[source]` would return `Object.prototype` when source is
+    // `"__proto__"`; `Object.hasOwn` keeps us in own-property territory.
+    const existing = Object.hasOwn(next, source) ? next[source] : {};
+    // `lang` is regex-validated upstream (`^[a-z]{2}(?:-[A-Z]{2})?$`)
+    // so it cannot be `__proto__` / `constructor` / `prototype`; the
+    // outer assignment by user-supplied `source` is the only unsafe
+    // site and uses safeAssign.
+    existing[lang] = translated;
+    safeAssign(next, source, existing);
   }
   return { sentences: next };
 }

--- a/server/services/translation/index.ts
+++ b/server/services/translation/index.ts
@@ -16,6 +16,14 @@ const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
 // eslint-disable-next-line security/detect-unsafe-regex -- single-pass match against a 2- or 5-char locale code, no backtracking.
 const LANGUAGE_RE = /^[a-z]{2}(?:-[A-Z]{2})?$/;
 
+// Bound the request shape so a single call cannot blow past the
+// `claude -p <json>` argv limit (POSIX `E2BIG`, typically ~128 KiB)
+// or balloon the per-call cost. UI-string callers stay well inside
+// these — Role suggested queries are ~5 strings × ~50 chars.
+const MAX_SENTENCES = 256;
+const MAX_SENTENCE_CHARS = 1024;
+const MAX_TOTAL_CHARS = 32 * 1024;
+
 export class TranslationInputError extends Error {
   constructor(message: string) {
     super(message);
@@ -33,9 +41,20 @@ function validateRequest(req: TranslateRequest): void {
   if (!Array.isArray(req.sentences) || req.sentences.length === 0) {
     throw new TranslationInputError("sentences must be a non-empty array");
   }
+  if (req.sentences.length > MAX_SENTENCES) {
+    throw new TranslationInputError(`sentences exceeds ${MAX_SENTENCES} entries`);
+  }
+  let totalChars = 0;
   for (const sentence of req.sentences) {
     if (typeof sentence !== "string" || sentence.length === 0) {
       throw new TranslationInputError("sentences must contain non-empty strings");
+    }
+    if (sentence.length > MAX_SENTENCE_CHARS) {
+      throw new TranslationInputError(`sentence exceeds ${MAX_SENTENCE_CHARS} characters`);
+    }
+    totalChars += sentence.length;
+    if (totalChars > MAX_TOTAL_CHARS) {
+      throw new TranslationInputError(`total sentence length exceeds ${MAX_TOTAL_CHARS} characters`);
     }
   }
 }

--- a/server/utils/files/translation-io.ts
+++ b/server/utils/files/translation-io.ts
@@ -16,8 +16,29 @@ export function dictionaryPath(namespace: string, workspaceRoot?: string): strin
   return path.join(root(workspaceRoot), WORKSPACE_DIRS.translation, `${namespace}.json`);
 }
 
+// Cache files live under the user's workspace and can be hand-edited
+// or corrupted; treat the disk shape as untrusted and fall back to
+// an empty dictionary on anything we can't recognize. Without this
+// guard a `{}` or `{ sentences: null }` file would crash later at
+// `dict.sentences[sentence]` and turn every request for the namespace
+// into a 500 until the file was repaired.
+function isValidDictionary(value: unknown): value is DictionaryFile {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const { sentences } = value as { sentences?: unknown };
+  if (typeof sentences !== "object" || sentences === null || Array.isArray(sentences)) return false;
+  for (const inner of Object.values(sentences)) {
+    if (typeof inner !== "object" || inner === null || Array.isArray(inner)) return false;
+    for (const translated of Object.values(inner as Record<string, unknown>)) {
+      if (typeof translated !== "string") return false;
+    }
+  }
+  return true;
+}
+
 export function loadDictionary(namespace: string, workspaceRoot?: string): DictionaryFile {
-  return loadJsonFile<DictionaryFile>(dictionaryPath(namespace, workspaceRoot), emptyDictionary());
+  const raw = loadJsonFile<unknown>(dictionaryPath(namespace, workspaceRoot), null);
+  if (!isValidDictionary(raw)) return emptyDictionary();
+  return raw;
 }
 
 export async function saveDictionary(namespace: string, dict: DictionaryFile, workspaceRoot?: string): Promise<void> {

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,7 +125,7 @@
           v-model="userInput"
           v-model:pasted-file="pastedFile"
           :is-running="activeSessionRunning"
-          :queries="sessionRole.queries ?? []"
+          :queries="sessionRoleQueries"
           @send="sendMessage()"
           @suggestion-send="(q) => sendMessage(q)"
         />
@@ -209,7 +209,7 @@
             v-model="userInput"
             v-model:pasted-file="pastedFile"
             :is-running="activeSessionRunning"
-            :queries="sessionRole.queries ?? []"
+            :queries="sessionRoleQueries"
             @send="sendMessage()"
             @suggestion-send="(q) => sendMessage(q)"
           />
@@ -303,6 +303,7 @@ import { useSelectedResult } from "./composables/useSelectedResult";
 import { useMcpTools } from "./composables/useMcpTools";
 import { useRoles } from "./composables/useRoles";
 import { useCurrentRole } from "./composables/useCurrentRole";
+import { useTranslatedQueries } from "./composables/useTranslatedQueries";
 import { BUILTIN_ROLE_IDS, type Role } from "./config/roles";
 import { usePubSub } from "./composables/usePubSub";
 import { sessionChannel } from "./config/pubsubChannels";
@@ -318,7 +319,7 @@ import { apiGet } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
 import { classifyWorkspacePath } from "./utils/path/workspaceLinkRouter";
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 // --- Per-session state ---
 // Declared early so that pub/sub callbacks and function declarations
@@ -457,6 +458,12 @@ const sessionRole = computed<Role>(() => {
   }
   return roles.value[0];
 });
+
+// Translated suggested-query strings for the active session's role.
+// Falls back to the role's English source until /api/translation
+// returns; subsequent role swaps hit the in-memory cache.
+const currentLocale = computed(() => String(locale.value));
+const { queries: sessionRoleQueries } = useTranslatedQueries(sessionRole, currentLocale);
 
 const { mergedSessions, tabSessions } = useMergedSessions({
   sessionMap,

--- a/src/composables/useTranslatedQueries.ts
+++ b/src/composables/useTranslatedQueries.ts
@@ -1,0 +1,109 @@
+// Translates a role's suggested queries into the user's current
+// browser locale via /api/translation. Until the response lands the
+// caller keeps seeing the English source — the swap is reactive
+// (Vue updates the SuggestionsPanel when the cache slot fills in).
+//
+// Cache keyed by `${roleId}:${locale}` and shared across all
+// consumers. Concurrent requests for the same key are deduped via
+// an in-flight Promise map.
+//
+// `locale` is taken as a Ref instead of being read from `useI18n()`
+// internally so the composable can be unit-tested outside a Vue
+// setup context.
+
+import { computed, watchEffect, type ComputedRef, type Ref, ref } from "vue";
+import { apiPost } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+import type { Role } from "../config/roles";
+
+const TRANSLATION_NAMESPACE = "role-queries";
+
+interface TranslateResponse {
+  translations: string[];
+}
+
+const cache = new Map<string, Ref<string[] | null>>();
+const inflight = new Map<string, Promise<void>>();
+
+function cacheKey(roleId: string, locale: string): string {
+  return `${roleId}:${locale}`;
+}
+
+function ensureSlot(key: string): Ref<string[] | null> {
+  let slot = cache.get(key);
+  if (!slot) {
+    slot = ref<string[] | null>(null);
+    cache.set(key, slot);
+  }
+  return slot;
+}
+
+async function runFetch(key: string, locale: string, sentences: string[]): Promise<void> {
+  const result = await apiPost<TranslateResponse>(API_ROUTES.translation.translate, {
+    namespace: TRANSLATION_NAMESPACE,
+    targetLanguage: locale,
+    sentences,
+  });
+  if (!result.ok) {
+    console.warn("[useTranslatedQueries] translate failed:", result.error);
+    return;
+  }
+  const { translations } = result.data;
+  if (!Array.isArray(translations) || translations.length !== sentences.length) {
+    console.warn("[useTranslatedQueries] translate returned wrong length", {
+      expected: sentences.length,
+      got: Array.isArray(translations) ? translations.length : "(not array)",
+    });
+    return;
+  }
+  ensureSlot(key).value = [...translations];
+}
+
+function ensureFetch(roleId: string, locale: string, sentences: string[]): void {
+  const key = cacheKey(roleId, locale);
+  if (inflight.has(key)) return;
+  if (ensureSlot(key).value !== null) return;
+  const pending = runFetch(key, locale, sentences).finally(() => {
+    inflight.delete(key);
+  });
+  inflight.set(key, pending);
+}
+
+export interface UseTranslatedQueriesResult {
+  /** Translated queries when available, falling back to the role's
+   *  English source while the request is in flight or fails. */
+  readonly queries: ComputedRef<string[]>;
+}
+
+export function useTranslatedQueries(role: Ref<Role | undefined>, locale: Ref<string>): UseTranslatedQueriesResult {
+  watchEffect(() => {
+    const current = role.value;
+    if (!current) return;
+    const sources = current.queries;
+    if (!sources || sources.length === 0) return;
+    const lang = locale.value;
+    if (lang === "en") return;
+    ensureFetch(current.id, lang, [...sources]);
+  });
+
+  const queries = computed<string[]>(() => {
+    const current = role.value;
+    const sources = current?.queries ?? [];
+    if (sources.length === 0) return [];
+    const lang = locale.value;
+    if (lang === "en" || !current) return [...sources];
+    return cache.get(cacheKey(current.id, lang))?.value ?? [...sources];
+  });
+
+  return { queries };
+}
+
+// ── Test-only hooks ─────────────────────────────────────────────────
+// Vitest / node:test lives in a fresh worker per file, so module
+// state usually cleans itself up. These helpers exist so suites that
+// share a worker can still reset between cases.
+
+export function __resetTranslatedQueriesCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/test/composables/test_useTranslatedQueries.ts
+++ b/test/composables/test_useTranslatedQueries.ts
@@ -1,0 +1,163 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { nextTick, ref } from "vue";
+import { __resetTranslatedQueriesCacheForTests, useTranslatedQueries } from "../../src/composables/useTranslatedQueries.js";
+import type { Role } from "../../src/config/roles.js";
+
+interface FetchCall {
+  readonly url: string;
+  readonly body: unknown;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const originalFetch: any = (globalThis as any).fetch;
+
+let fetchCalls: FetchCall[] = [];
+async function defaultResponder(__call: FetchCall): Promise<Response> {
+  return mockJson(200, { translations: [] });
+}
+let fetchResponder: (call: FetchCall) => Promise<Response> = defaultResponder;
+
+function mockJson(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function installFetchStub(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = async (input: unknown, init?: any) => {
+    const url = typeof input === "string" ? input : (input as { url: string }).url;
+    const body = init?.body !== undefined ? JSON.parse(String(init.body)) : undefined;
+    const call: FetchCall = { url, body };
+    fetchCalls.push(call);
+    return fetchResponder(call);
+  };
+}
+
+function makeRole(roleId: string, queries: string[] | undefined): Role {
+  return {
+    id: roleId,
+    name: roleId,
+    icon: "",
+    prompt: "",
+    availablePlugins: [],
+    queries,
+  } as unknown as Role;
+}
+
+// Wait until the inflight fetch (if any) has settled and Vue has
+// flushed the resulting reactive updates.
+async function settle(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve();
+    await nextTick();
+  }
+}
+
+describe("useTranslatedQueries", () => {
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchResponder = async () => mockJson(200, { translations: [] });
+    __resetTranslatedQueriesCacheForTests();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it("en short-circuit: returns source verbatim, no fetch", async () => {
+    const role = ref<Role | undefined>(makeRole("general", ["Hello", "World"]));
+    const locale = ref("en");
+    const { queries } = useTranslatedQueries(role, locale);
+    await settle();
+    assert.deepEqual(queries.value, ["Hello", "World"]);
+    assert.equal(fetchCalls.length, 0);
+  });
+
+  it("non-en: falls back to source until response lands, then swaps", async () => {
+    fetchResponder = async () => mockJson(200, { translations: ["こんにちは", "世界"] });
+    const role = ref<Role | undefined>(makeRole("general", ["Hello", "World"]));
+    const locale = ref("ja");
+    const { queries } = useTranslatedQueries(role, locale);
+    // initial value before fetch resolves: source
+    assert.deepEqual(queries.value, ["Hello", "World"]);
+    await settle();
+    assert.deepEqual(queries.value, ["こんにちは", "世界"]);
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(fetchCalls[0].url, "/api/translation");
+    assert.deepEqual(fetchCalls[0].body, {
+      namespace: "role-queries",
+      targetLanguage: "ja",
+      sentences: ["Hello", "World"],
+    });
+  });
+
+  it("dedup: two composable instances on the same role+locale share one fetch", async () => {
+    fetchResponder = async () => mockJson(200, { translations: ["こんにちは"] });
+    const roleA = ref<Role | undefined>(makeRole("general", ["Hello"]));
+    const roleB = ref<Role | undefined>(makeRole("general", ["Hello"]));
+    const locale = ref("ja");
+    const { queries: queriesA } = useTranslatedQueries(roleA, locale);
+    const { queries: queriesB } = useTranslatedQueries(roleB, locale);
+    await settle();
+    assert.deepEqual(queriesA.value, ["こんにちは"]);
+    assert.deepEqual(queriesB.value, ["こんにちは"]);
+    assert.equal(fetchCalls.length, 1);
+  });
+
+  it("locale change: re-fetches in the new locale, leaves source as fallback meanwhile", async () => {
+    fetchResponder = async (call) => {
+      const lang = (call.body as { targetLanguage: string }).targetLanguage;
+      const map: Record<string, string[]> = { ja: ["こんにちは"], ko: ["안녕하세요"] };
+      return mockJson(200, { translations: map[lang] ?? [] });
+    };
+    const role = ref<Role | undefined>(makeRole("general", ["Hello"]));
+    const locale = ref("ja");
+    const { queries } = useTranslatedQueries(role, locale);
+    await settle();
+    assert.deepEqual(queries.value, ["こんにちは"]);
+    locale.value = "ko";
+    // English fallback while the second fetch is in flight
+    await Promise.resolve();
+    await nextTick();
+    assert.deepEqual(queries.value, ["Hello"]);
+    await settle();
+    assert.deepEqual(queries.value, ["안녕하세요"]);
+    assert.equal(fetchCalls.length, 2);
+  });
+
+  it("fetch error: keeps source fallback, no throw", async () => {
+    fetchResponder = async () => mockJson(500, { error: "boom" });
+    const role = ref<Role | undefined>(makeRole("general", ["Hello"]));
+    const locale = ref("ja");
+    const { queries } = useTranslatedQueries(role, locale);
+    await settle();
+    assert.deepEqual(queries.value, ["Hello"]);
+    assert.equal(fetchCalls.length, 1);
+  });
+
+  it("length mismatch from server: keeps source fallback", async () => {
+    fetchResponder = async () => mockJson(200, { translations: ["only-one"] });
+    const role = ref<Role | undefined>(makeRole("general", ["Hello", "World"]));
+    const locale = ref("ja");
+    const { queries } = useTranslatedQueries(role, locale);
+    await settle();
+    assert.deepEqual(queries.value, ["Hello", "World"]);
+  });
+
+  it("role with no queries: returns empty array, no fetch", async () => {
+    const role = ref<Role | undefined>(makeRole("empty", undefined));
+    const locale = ref("ja");
+    const { queries } = useTranslatedQueries(role, locale);
+    await settle();
+    assert.deepEqual(queries.value, []);
+    assert.equal(fetchCalls.length, 0);
+  });
+});

--- a/test/services/translation/test_translate.ts
+++ b/test/services/translation/test_translate.ts
@@ -1,6 +1,6 @@
-import { describe, it, before, after, beforeEach } from "node:test";
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, realpathSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { WORKSPACE_DIRS } from "../../../server/workspace/paths.js";
@@ -123,6 +123,7 @@ describe("translation service — validation", () => {
     root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-val-")));
     service = createTranslationService({ translateBatch: makeMock().fn, workspaceRoot: root });
   });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
 
   it("rejects path-traversal namespace", async () => {
     await assert.rejects(() => service.translate({ namespace: "../etc", targetLanguage: "ja", sentences: ["Hi"] }), TranslationInputError);
@@ -163,6 +164,105 @@ describe("translation service — backend contract", () => {
     const wrongLength: TranslateBatchFn = async () => ["only-one"];
     const service = createTranslationService({ translateBatch: wrongLength, workspaceRoot: root });
     await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["A", "B"] }), /returned 1 translations for 2 sentences/);
+  });
+});
+
+describe("translation service — request bounds", () => {
+  let root: string;
+  let service: ReturnType<typeof createTranslationService>;
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-bnd-")));
+    service = createTranslationService({ translateBatch: makeMock().fn, workspaceRoot: root });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("rejects more than 256 sentences", async () => {
+    const tooMany = Array.from({ length: 257 }, (_value, index) => `s${index}`);
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: tooMany }), TranslationInputError);
+  });
+
+  it("rejects a single sentence longer than 1024 chars", async () => {
+    const long = "x".repeat(1025);
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: [long] }), TranslationInputError);
+  });
+
+  it("rejects total payload over 32KiB", async () => {
+    // 64 sentences × 1024 chars = 65536 chars, well over the 32KiB total cap.
+    const sentence = "x".repeat(1024);
+    const tooBig = Array.from({ length: 64 }, () => sentence);
+    await assert.rejects(() => service.translate({ namespace: "ns", targetLanguage: "ja", sentences: tooBig }), TranslationInputError);
+  });
+});
+
+describe("translation service — cache shape robustness", () => {
+  let root: string;
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-shape-")));
+    mkdirSync(path.join(root, WORKSPACE_DIRS.translation), { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function writeRawDict(namespace: string, raw: string): void {
+    writeFileSync(dictPath(root, namespace), raw, "utf-8");
+  }
+
+  it("malformed JSON: parse fails → falls back to empty dict, fresh translation written", async () => {
+    writeRawDict("ns", "{ this is not json");
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello"] });
+    assert.deepEqual(translations, ["[ja]Hello"]);
+    assert.equal(mock.calls.length, 1);
+  });
+
+  it("wrong shape (sentences: null): treated as empty cache, no crash", async () => {
+    writeRawDict("ns", JSON.stringify({ sentences: null }));
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello"] });
+    assert.deepEqual(translations, ["[ja]Hello"]);
+  });
+
+  it("wrong shape (top-level array): treated as empty cache, no crash", async () => {
+    writeRawDict("ns", JSON.stringify([]));
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello"] });
+    assert.deepEqual(translations, ["[ja]Hello"]);
+  });
+
+  it("wrong shape (translation value not a string): treated as empty cache, fresh write replaces it", async () => {
+    writeRawDict("ns", JSON.stringify({ sentences: { Hello: { ja: 42 } } }));
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    const { translations } = await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["Hello"] });
+    assert.deepEqual(translations, ["[ja]Hello"]);
+    assert.deepEqual(readDict(root, "ns"), { sentences: { Hello: { ja: "[ja]Hello" } } });
+  });
+});
+
+describe("translation service — prototype-key safety", () => {
+  let root: string;
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "mulmoclaude-tr-proto-")));
+  });
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  it("a sentence whose value is `__proto__` is stored, retrieved, and never pollutes Object.prototype", async () => {
+    const mock = makeMock();
+    const service = createTranslationService({ translateBatch: mock.fn, workspaceRoot: root });
+    await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["__proto__"] });
+    // Sanity: nothing leaked onto Object.prototype.
+    assert.equal(({} as Record<string, unknown>).ja, undefined);
+
+    // Round-trip through the cache: second call should hit the persisted entry.
+    const { translations } = await service.translate({ namespace: "ns", targetLanguage: "ja", sentences: ["__proto__"] });
+    assert.deepEqual(translations, ["[ja]__proto__"]);
+    assert.equal(mock.calls.length, 1);
+
+    const onDisk = readDict(root, "ns") as { sentences: Record<string, Record<string, string>> };
+    // eslint-disable-next-line no-proto -- the whole point of this test is to verify a literal "__proto__" sentence round-trips as an own property.
+    assert.equal(onDisk.sentences["__proto__"]?.ja, "[ja]__proto__");
   });
 });
 


### PR DESCRIPTION
## Summary

- Wires the translation microservice introduced in #1172 into Role suggested queries.
- When the active session's role has `queries`, the new `useTranslatedQueries` composable swaps the displayed strings to the user's i18n locale via `POST /api/translation` with `namespace: "role-queries"`.
- Locale-aware: `en` returns the source verbatim with no fetch; other locales fall back to the English source while the request is in flight, then swap once the response lands. Vue reactivity drives the swap.
- Module-level cache keyed by `${roleId}:${locale}` shared across consumers, with an in-flight Promise map to dedup concurrent requests for the same key.
- The composable takes `locale` as an explicit `Ref<string>` (rather than calling `useI18n()` internally) so it can be unit-tested outside a Vue setup context. `App.vue` plumbs the locale ref through.

## Stacking

This PR is stacked on top of #1172. Base branch is `feat/translation-service`; once #1172 lands, I'll rebase this onto `main`.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn test` — all 4079 tests pass; new tests cover en short-circuit, source→translated swap, dedup of concurrent instances, locale swap mid-session, fetch error fallback, length-mismatch fallback, and empty-query roles
- [x] `yarn build` clean
- [ ] Manual browser smoke (requires `claude` CLI logged in): open a chat in a non-English locale (e.g. `?lang=ja`), confirm role suggested queries first render in English, then swap to the locale once the response lands. Cached on the second visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)