### PR TITLE
feat: auto-reload browser on dev plugin changes (PR3 of #1159)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "snakajima",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.12"
   },
   "workspaces": [
     "packages/*",

--- a/packages/create-mulmoclaude-plugin/README.md
+++ b/packages/create-mulmoclaude-plugin/README.md
@@ -62,17 +62,21 @@ mulmoclaude --dev-plugin ./my-plugin --dev-plugin ../other-plugin
 
 The plugin appears in the runtime registry under its `package.json`
 name with version `dev` and is served straight from your `dist/`. Edit
-source → vite rebuilds → reload mulmoclaude in the browser to pick
-up the new bundle.
+source → vite rebuilds → **the browser auto-reloads** to pick up the
+new bundle.
 
 Hard-fails fast on:
 - Missing `dist/index.js` (run `yarn build` or `yarn dev` first).
 - Name collision between the dev plugin and an installed (published)
   one — both abs paths are logged so you can see what conflicted.
 
-Auto-reload (chokidar push) is tracked at
-[receptron/mulmoclaude#1159](https://github.com/receptron/mulmoclaude/issues/1159)
-PR3.
+Server-side caveat: when you change `src/index.ts` (the `definePlugin`
+factory), vite rebuilds `dist/index.js` and the browser reloads, but
+Node's ESM cache holds the old server-side module. The mulmoclaude log
+prints `dist/index.js changed — restart mulmoclaude to pick up
+server-side changes` so you know to Ctrl+C and restart the launcher.
+Pure browser-side edits (`View.vue`, CSS, lang/) hot-load without a
+restart.
 
 ## Why a sample, not an empty plugin
 

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -29,10 +29,13 @@ npx mulmoclaude --version                    # Show version
 
 `--dev-plugin <path>` is the plugin author's dev loop. Pair with
 `yarn dev` (vite watch) in the plugin directory: edits → vite
-rebuilds `dist/` → reload the browser to pick up the new bundle.
-The plugin's `package.json` name + `dist/index.js` must already be
-in place; the launcher refuses to start on missing files or on a
-name collision with an already-installed plugin.
+rebuilds `dist/` → **the browser auto-reloads** via a debounced
+watcher on the plugin's `dist/`. The plugin's `package.json` name +
+`dist/index.js` must already be in place; the launcher refuses to
+start on missing files or on a name collision with an already-
+installed plugin. Server-side `definePlugin` factory edits still
+require a launcher restart (Node ESM has no cache invalidation API);
+the launcher log explicitly says so when `dist/index.js` changes.
 
 ## How it works
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -55,7 +55,7 @@
     "node-pty": "^1.1.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.12"
   },
   "license": "MIT",
   "repository": {

--- a/plans/feat-1159-pr3-dev-plugin-auto-reload.md
+++ b/plans/feat-1159-pr3-dev-plugin-auto-reload.md
@@ -1,0 +1,136 @@
+# Auto-reload on dev plugin changes (PR3 of #1159)
+
+PR1 (#1163) shipped the scaffold CLI. PR2 (#1167) made `--dev-plugin
+<path>` boot-load a plugin from the author's project dir. The remaining
+manual step in the dev loop is `⌘R` after every `yarn build`.
+
+PR3 closes that loop: when the watched `dist/` changes, the browser
+auto-reloads.
+
+## Surface
+
+No new CLI flag. `--dev-plugin <path>` automatically gets a watcher.
+
+```bash
+# Terminal A
+cd my-plugin && yarn dev      # vite build --watch keeps dist/ fresh
+
+# Terminal B
+mulmoclaude --dev-plugin ./my-plugin
+```
+
+Per code change: editor save → vite rebuild → server detects change →
+**browser auto-reloads** → updated plugin runs. No keyboard intervention.
+
+## Implementation
+
+### Server: `server/plugins/dev-watcher.ts` (new)
+
+`watchDevPlugins(plugins, opts) → { close: () => void }` —
+
+- For each plugin, `fs.watch(plugin.cachePath/dist, { recursive: true })`
+  using `node:fs` (built-in, no new dep)
+- Debounce 300 ms per plugin (vite writes 4-5 files within ~100 ms; one
+  reload per burst is enough)
+- On stable burst, call `opts.publish(plugin.name, { changedFiles })`
+- Detect when `dist/index.js` is among the changed files and log a
+  prominent hint via `opts.warnServerSideChange(plugin.name)` —
+  Node ESM can't bust the cached server-side import, so the dev
+  needs to restart mulmoclaude for `definePlugin` factory edits to
+  take effect. The browser reload still happens (it's the cheap
+  cleanup; no harm if dev only changed server code).
+- Return a `close()` that closes every watcher (called from graceful
+  shutdown)
+
+The publish/warn callbacks are injected so tests can drive the watcher
+without a live pubsub or mulmoclaude logger.
+
+### Pubsub channel: `src/config/pubsubChannels.ts`
+
+Add to `HOST_STATIC_CHANNELS`:
+
+```ts
+devPluginChanged: "dev-plugin-changed",
+```
+
+Payload shape: `{ name: string, version: string, changedFiles: string[] }`.
+
+### Server wiring: `server/index.ts`
+
+After `evaluateDevPluginGate(...)` succeeds, attach the watcher:
+
+```ts
+const watcher = watchDevPlugins(devGate.plugins, {
+  publish: (name, payload) =>
+    pubsub.publish(PUBSUB_CHANNELS.devPluginChanged, { name, ...payload }),
+  warnServerSideChange: (name) =>
+    log.warn("plugins/dev", `${name}: dist/index.js changed — restart mulmoclaude to pick up server-side changes`),
+});
+// On gracefulShutdown: watcher.close()
+```
+
+### Client: `src/composables/useDevPluginReload.ts` (new)
+
+Subscribes to `PUBSUB_CHANNELS.devPluginChanged` once at app boot,
+calls `window.location.reload()` on every event. Single-line composable
+behind `usePubSub`.
+
+Mount via `src/main.ts` immediately after `usePubSub` is wired.
+
+## Tests
+
+### Unit: debouncer
+
+- Inject a fake clock + manual event emitter
+- Burst 5 events within 100 ms → expect 1 publish
+- Burst, wait 400 ms, burst again → expect 2 publishes
+- `dist/index.js` in the burst → expect `warnServerSideChange` called once
+
+### Integration: real fs.watch (Linux/macOS only — gated)
+
+- `mkdtempSync` + write `dist/index.js` + `dist/vue.js`
+- Start the watcher with a recording publish
+- `writeFileSync(dist/vue.js, "new content")` → wait 500 ms → assert one
+  publish recorded
+- Skip on Windows runner because `fs.watch` recursive on Windows fires
+  events differently and can flake; the unit test covers the platform-
+  independent debounce logic
+
+### Smoke: extend `tarball.mjs` (optional, defer if cost too high)
+
+The existing `--dev-plugin` smoke boots and probes the runtime list.
+PR3 could extend it to:
+- Modify `dist/vue.js` after boot
+- Subscribe to the WebSocket and assert a `dev-plugin-changed` arrives
+
+Defer if the WS integration in the smoke driver costs too much. The
+unit + integration tests already cover the watcher contract.
+
+## Acknowledged limitations
+
+- **Server-side `dist/index.js` is not hot-replaced.** Node's ESM cache
+  has no public invalidation API. The watcher publishes on every
+  dist/ change; the browser reload picks up View.vue / browser-side
+  changes immediately, but a `definePlugin` factory edit needs a
+  full mulmoclaude restart. The server log explicitly says so when
+  `dist/index.js` is in the changed set.
+- **No state preservation.** Full `location.reload()` discards Vue
+  component state. Real HMR (state-preserving) is significant
+  additional work — defer until there's demand.
+- **No opt-out flag.** `--no-auto-reload` could be added if a dev
+  reports auto-reload is disruptive, but starting default-on for
+  the simpler dev loop.
+
+## README updates
+
+- `packages/create-mulmoclaude-plugin/README.md` — drop the line
+  about manual ⌘R, mention auto-reload as the default behavior
+- `packages/mulmoclaude/README.md` — `--dev-plugin` section gets a
+  one-liner about auto-reload + the server-side restart caveat
+
+## Out of scope (future)
+
+- True HMR (Vue component re-mount with state)
+- WebSocket-side reconnect debounce (existing reconnect logic is
+  already battle-tested for sessions / notifications)
+- Per-plugin reload (only the changed plugin instead of full page)

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,6 +27,7 @@ import skillsRoutes from "./api/routes/skills.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
 import { evaluateDevPluginGate, loadDevPlugins, parseDevPluginsEnv } from "./plugins/dev-loader.js";
+import { watchDevPlugins } from "./plugins/dev-watcher.js";
 import { loadPresetPlugins } from "./plugins/preset-loader.js";
 import { registerRuntimePlugins } from "./plugins/runtime-registry.js";
 import { makePluginRuntime } from "./plugins/runtime.js";
@@ -760,6 +761,23 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
         for (const message of devGate.fatalMessages) log.error("plugins/dev", message);
         process.exit(1);
       }
+      // Auto-reload (#1159 PR3): watch each dev plugin's dist/ and
+      // publish on debounced change so the browser refreshes without
+      // ⌘R. Server-side `dist/index.js` cannot be hot-replaced (Node
+      // ESM cache), so the watcher logs an explicit hint when that
+      // file is in the changed set.
+      if (devLoad.plugins.length > 0) {
+        const handle = watchDevPlugins(devLoad.plugins, {
+          publish: (name, payload) =>
+            pubsub.publish(PUBSUB_CHANNELS.devPluginChanged, {
+              name,
+              changedFiles: payload.changedFiles,
+              serverSideChange: payload.serverSideChange,
+            }),
+          warnServerSideChange: (name) => log.warn("plugins/dev", `${name}: dist/index.js changed — restart mulmoclaude to pick up server-side changes`),
+        });
+        registerShutdownHook(() => handle.close());
+      }
       // Pass the full static-tool set (MCP plugins + ENABLED MCP tools
       // like readXPost / searchX) as the collision policy so the floor
       // matches the standalone mcp-server's STATIC_TOOL_NAMES exactly
@@ -889,11 +907,22 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
 // dead token. Crashes that skip this are harmless — see
 // plans/done/feat-bearer-token-auth.md; the next startup overwrites and
 // the stale file's token no longer matches the live in-memory one.
+const shutdownHooks: (() => void)[] = [];
+function registerShutdownHook(hook: () => void): void {
+  shutdownHooks.push(hook);
+}
 let isShuttingDown = false;
 async function gracefulShutdown(signal: string): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
   log.info("server", "shutting down", { signal });
+  for (const hook of shutdownHooks) {
+    try {
+      hook();
+    } catch (err) {
+      log.warn("server", "shutdown hook threw", { error: String(err) });
+    }
+  }
   await deleteTokenFile();
   process.exit(0);
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -775,6 +775,8 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
               serverSideChange: payload.serverSideChange,
             }),
           warnServerSideChange: (name) => log.warn("plugins/dev", `${name}: dist/index.js changed — restart mulmoclaude to pick up server-side changes`),
+          onWatcherError: (name, error) =>
+            log.warn("plugins/dev", `${name}: watcher error — auto-reload disabled for this plugin until restart`, { error: String(error) }),
         });
         registerShutdownHook(() => handle.close());
       }

--- a/server/plugins/dev-watcher.ts
+++ b/server/plugins/dev-watcher.ts
@@ -1,0 +1,109 @@
+// Watch each dev plugin's `dist/` and emit one event per change burst
+// (PR3 of #1159). Vite writes 4-5 files within ~100ms on a single
+// rebuild, so debounce → 1 reload per save instead of 5.
+//
+// Uses Node's built-in `fs.watch` with `recursive: true` rather than
+// chokidar to avoid pulling another runtime dependency. Recursive
+// watching is supported on macOS / Linux / Windows since Node 20.
+//
+// The publish + warnServerSideChange callbacks are injected so tests
+// can exercise the debounce + classification logic without booting the
+// pubsub or hitting the structured logger.
+
+import { watch, type FSWatcher } from "node:fs";
+import path from "node:path";
+
+import type { RuntimePlugin } from "./runtime-loader.js";
+
+const DEFAULT_DEBOUNCE_MS = 300;
+const SERVER_ENTRY_FILENAME = "index.js";
+
+export interface DevPluginChangedPayload {
+  /** Files changed during the debounce window (relative to dist/). */
+  changedFiles: string[];
+  /** True iff `dist/index.js` was among them — caller surfaces a
+   *  prominent log so the dev knows server-side hot-reload is not
+   *  possible and they need to restart mulmoclaude. */
+  serverSideChange: boolean;
+}
+
+export interface WatchDevPluginsOptions {
+  /** Called once per debounce burst per plugin. */
+  publish: (pluginName: string, payload: DevPluginChangedPayload) => void;
+  /** Called when `dist/index.js` is in the burst. The watcher still
+   *  publishes (the browser reload is harmless), but the dev needs
+   *  this hint to know why their server-side change didn't take. */
+  warnServerSideChange?: (pluginName: string) => void;
+  /** Override for testing. */
+  debounceMs?: number;
+  /** Override the watcher factory for tests. Default uses node:fs. */
+  watcherFactory?: (absDistPath: string, onChange: (relativePath: string) => void) => FSWatcher;
+}
+
+export interface DevWatcherHandle {
+  /** Stop every watcher. Safe to call multiple times. */
+  close: () => void;
+}
+
+function defaultWatcherFactory(absDistPath: string, onChange: (relativePath: string) => void): FSWatcher {
+  return watch(absDistPath, { recursive: true }, (_eventType, filename) => {
+    if (typeof filename === "string" && filename.length > 0) {
+      onChange(filename);
+    }
+  });
+}
+
+/** Attach a debounced watcher to each dev plugin's `dist/`. Returns a
+ *  handle whose `close()` shuts every watcher down — call it from the
+ *  graceful shutdown path. */
+export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDevPluginsOptions): DevWatcherHandle {
+  const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const factory = opts.watcherFactory ?? defaultWatcherFactory;
+  const watchers: FSWatcher[] = [];
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pendingFiles = new Map<string, Set<string>>();
+
+  for (const plugin of plugins) {
+    const absDistPath = path.join(plugin.cachePath, "dist");
+    const watcher = factory(absDistPath, (relativePath) => {
+      const buffer = pendingFiles.get(plugin.name) ?? new Set<string>();
+      buffer.add(relativePath);
+      pendingFiles.set(plugin.name, buffer);
+
+      const existing = timers.get(plugin.name);
+      if (existing) clearTimeout(existing);
+      timers.set(
+        plugin.name,
+        setTimeout(() => {
+          const files = pendingFiles.get(plugin.name);
+          pendingFiles.delete(plugin.name);
+          timers.delete(plugin.name);
+          if (!files || files.size === 0) return;
+          const changedFiles = Array.from(files).sort();
+          const serverSideChange = changedFiles.some((file) => path.basename(file) === SERVER_ENTRY_FILENAME);
+          if (serverSideChange) opts.warnServerSideChange?.(plugin.name);
+          opts.publish(plugin.name, { changedFiles, serverSideChange });
+        }, debounceMs),
+      );
+    });
+    watchers.push(watcher);
+  }
+
+  let closed = false;
+  return {
+    close: () => {
+      if (closed) return;
+      closed = true;
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+      pendingFiles.clear();
+      for (const watcher of watchers) {
+        try {
+          watcher.close();
+        } catch {
+          // Ignore — the watcher might have already errored out.
+        }
+      }
+    },
+  };
+}

--- a/server/plugins/dev-watcher.ts
+++ b/server/plugins/dev-watcher.ts
@@ -20,7 +20,18 @@ import path from "node:path";
 import type { RuntimePlugin } from "./runtime-loader.js";
 import { DEV_PLUGIN_WATCH_DEBOUNCE_MS } from "../utils/time.js";
 
-const SERVER_ENTRY_FILENAME = "index.js";
+// Relative path (within `dist/`) of the server entry. Only the root
+// `dist/index.js` triggers the "restart mulmoclaude" warning — vite
+// also emits chunks like `dist/assets/index.js` for code-split Vue
+// components, and those don't need a launcher restart.
+const SERVER_ENTRY_RELATIVE_PATH = "index.js";
+
+function isServerEntry(relativePath: string): boolean {
+  // `fs.watch` reports filenames with the platform path separator —
+  // backslashes on Windows. Normalize before comparison so a match
+  // is cross-platform, not just POSIX.
+  return relativePath.split(/[\\/]/).join("/") === SERVER_ENTRY_RELATIVE_PATH;
+}
 
 export interface DevPluginChangedPayload {
   /** Files changed during the debounce window (relative to dist/). */
@@ -92,7 +103,7 @@ export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDe
           timers.delete(plugin.name);
           if (!files || files.size === 0) return;
           const changedFiles = Array.from(files).sort();
-          const serverSideChange = changedFiles.some((file) => path.basename(file) === SERVER_ENTRY_FILENAME);
+          const serverSideChange = changedFiles.some(isServerEntry);
           if (serverSideChange) opts.warnServerSideChange?.(plugin.name);
           opts.publish(plugin.name, { changedFiles, serverSideChange });
         }, debounceMs),

--- a/server/plugins/dev-watcher.ts
+++ b/server/plugins/dev-watcher.ts
@@ -4,18 +4,22 @@
 //
 // Uses Node's built-in `fs.watch` with `recursive: true` rather than
 // chokidar to avoid pulling another runtime dependency. Recursive
-// watching is supported on macOS / Linux / Windows since Node 20.
+// watching is reliable on macOS / Linux / Windows starting from Node
+// 20.12 (Linux had race conditions and crash-on-delete bugs in earlier
+// 20.x patches; engines.node is set to >=20.12 to encode this).
 //
 // The publish + warnServerSideChange callbacks are injected so tests
 // can exercise the debounce + classification logic without booting the
-// pubsub or hitting the structured logger.
+// pubsub or hitting the structured logger. `onWatcherError` is also
+// injectable so tests can verify the crash-isolation path; production
+// wiring routes it through the structured logger.
 
 import { watch, type FSWatcher } from "node:fs";
 import path from "node:path";
 
 import type { RuntimePlugin } from "./runtime-loader.js";
+import { DEV_PLUGIN_WATCH_DEBOUNCE_MS } from "../utils/time.js";
 
-const DEFAULT_DEBOUNCE_MS = 300;
 const SERVER_ENTRY_FILENAME = "index.js";
 
 export interface DevPluginChangedPayload {
@@ -34,6 +38,14 @@ export interface WatchDevPluginsOptions {
    *  publishes (the browser reload is harmless), but the dev needs
    *  this hint to know why their server-side change didn't take. */
   warnServerSideChange?: (pluginName: string) => void;
+  /** Called when an `fs.watch` instance emits an `error` event
+   *  (e.g. ENOENT after a `rm -rf dist/` clean-rebuild, mount
+   *  unavailability, etc.). The watcher closes itself and stops
+   *  firing for that plugin so the rest of mulmoclaude keeps
+   *  running. Without this handler, the unhandled `error` event
+   *  would propagate as an uncaught exception and crash the
+   *  server. */
+  onWatcherError?: (pluginName: string, error: Error) => void;
   /** Override for testing. */
   debounceMs?: number;
   /** Override the watcher factory for tests. Default uses node:fs. */
@@ -57,7 +69,7 @@ function defaultWatcherFactory(absDistPath: string, onChange: (relativePath: str
  *  handle whose `close()` shuts every watcher down — call it from the
  *  graceful shutdown path. */
 export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDevPluginsOptions): DevWatcherHandle {
-  const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const debounceMs = opts.debounceMs ?? DEV_PLUGIN_WATCH_DEBOUNCE_MS;
   const factory = opts.watcherFactory ?? defaultWatcherFactory;
   const watchers: FSWatcher[] = [];
   const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -85,6 +97,24 @@ export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDe
           opts.publish(plugin.name, { changedFiles, serverSideChange });
         }, debounceMs),
       );
+    });
+    // Isolate each watcher's failure: log + close just this one
+    // instead of letting the unhandled `error` event terminate the
+    // whole server. Real-world trigger: `rm -rf dist && yarn build`
+    // emits ENOENT mid-watch (fs.watch surfaces it as an `error`,
+    // not a `change`). Production wires onWatcherError through the
+    // structured logger.
+    watcher.on("error", (err) => {
+      opts.onWatcherError?.(plugin.name, err);
+      try {
+        watcher.close();
+      } catch {
+        // Already torn down — nothing to do.
+      }
+      const pending = timers.get(plugin.name);
+      if (pending) clearTimeout(pending);
+      timers.delete(plugin.name);
+      pendingFiles.delete(plugin.name);
     });
     watchers.push(watcher);
   }

--- a/server/utils/time.ts
+++ b/server/utils/time.ts
@@ -24,6 +24,11 @@ export const TIME_UNIT_MS: Record<string, number> = {
 /** Quick subprocess probe (docker ps, libreoffice --version, etc.) */
 export const SUBPROCESS_PROBE_TIMEOUT_MS = 5 * ONE_SECOND_MS;
 
+/** Debounce window for dev-plugin `dist/` watcher (#1159 PR3). Vite
+ *  writes 4-5 files within ~100ms on a single rebuild; 300ms collapses
+ *  the burst into one publish. */
+export const DEV_PLUGIN_WATCH_DEBOUNCE_MS = 300;
+
 /** Heavy subprocess work (libreoffice conversion, etc.) */
 export const SUBPROCESS_WORK_TIMEOUT_MS = ONE_MINUTE_MS;
 

--- a/src/composables/useDevPluginReload.ts
+++ b/src/composables/useDevPluginReload.ts
@@ -1,0 +1,23 @@
+// Auto-reload the page when a `--dev-plugin` (PR2 of #1159) project's
+// `dist/` is rebuilt — see `server/plugins/dev-watcher.ts` for the
+// publisher side. Subscription is wired once at app boot via main.ts.
+//
+// Only browser-side files (View.vue / vue.js / *.css) hot-load
+// usefully; the server-side `dist/index.js` cannot be hot-replaced
+// because Node's ESM module cache has no public invalidation API.
+// The watcher logs a prominent server warning when index.js is in
+// the change set; the browser reload still happens because it's a
+// cheap idempotent cleanup. See PR3's plan for the trade-off.
+
+import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
+import { usePubSub } from "./usePubSub";
+import { isRecord } from "../utils/types";
+
+export function startDevPluginReloadListener(): void {
+  const { subscribe } = usePubSub();
+  subscribe(PUBSUB_CHANNELS.devPluginChanged, (payload) => {
+    const name = isRecord(payload) && typeof payload.name === "string" ? payload.name : "(unknown)";
+    console.info(`[dev-plugin] ${name} changed — reloading`);
+    window.location.reload();
+  });
+}

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -141,6 +141,12 @@ const HOST_STATIC_CHANNELS = {
    *  the same channel. Subscriber list starts empty — the UI lands
    *  in a separate PR. Payload: `{ message: string, firedAt: ISO8601 }`. */
   notifications: "notifications",
+  /** Dev plugin (`--dev-plugin <path>`) `dist/` changed — debounced.
+   *  Publisher: `server/plugins/dev-watcher.ts` after fs.watch fires.
+   *  Subscriber: `src/composables/useDevPluginReload.ts` triggers
+   *  `location.reload()` so the author sees their save without ⌘R.
+   *  Payload: `{ name: string, changedFiles: string[], serverSideChange: boolean }`. */
+  devPluginChanged: "dev-plugin-changed",
 } as const;
 
 // First-write-wins host+plugin aggregate (see `defineHostAggregate`):

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import i18n from "./lib/vue-i18n";
 import { setAuthToken } from "./utils/api";
 import { readAuthTokenFromMeta } from "./utils/dom/authTokenMeta";
 import { loadRuntimePlugins } from "./tools/runtimeLoader";
+import { startDevPluginReloadListener } from "./composables/useDevPluginReload";
 import { installHostContext, type EndpointRegistry } from "./plugins/api";
 import { API_ROUTES } from "./config/apiRoutes";
 import { BUILTIN_ROLE_IDS } from "./config/roles";
@@ -98,6 +99,11 @@ installHostContext({
 loadRuntimePlugins().catch((err: unknown) => {
   console.warn("[runtime-plugin] boot loader threw", err);
 });
+
+// PR3 of #1159: when `--dev-plugin` is in use and the watched dist/
+// changes, this listener reloads the page. No-ops in production
+// because the server only publishes when a dev plugin is loaded.
+startDevPluginReloadListener();
 
 installGuards(router);
 

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -159,6 +159,35 @@ describe("watchDevPlugins — server-side classification", () => {
     assert.equal(rig.rec.warns.length, 1);
     rig.close();
   });
+
+  it("does NOT match nested `assets/index.js` chunks (vite code-split output)", async () => {
+    // Real-world false-positive: vite splits Vue components into
+    // separate chunks like `dist/assets/index.js`. Treating those as
+    // a server-side change would log a misleading "restart
+    // mulmoclaude" hint on every component edit.
+    const plugin = fakePlugin("@test/nested-index");
+    const rig = makeRig(plugin, 30);
+    rig.fire("assets/index.js");
+    rig.fire("vue.js");
+    await sleep(80);
+    assert.equal(rig.rec.calls.length, 1);
+    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    assert.deepEqual(rig.rec.warns, []);
+    rig.close();
+  });
+
+  it("normalizes Windows-style backslash paths the same way", async () => {
+    // `fs.watch` reports filenames with the platform separator. On
+    // Windows that's `\`. The check must handle both so we don't
+    // false-positive `assets\index.js` either.
+    const plugin = fakePlugin("@test/windows-nested");
+    const rig = makeRig(plugin, 30);
+    rig.fire("assets\\index.js");
+    await sleep(80);
+    assert.equal(rig.rec.calls.length, 1);
+    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    rig.close();
+  });
 });
 
 describe("watchDevPlugins — multiple plugins", () => {

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -1,0 +1,210 @@
+// Tests for `server/plugins/dev-watcher.ts` — the debounce + classify
+// pass that turns vite's burst of file writes into one reload event.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+import { watchDevPlugins } from "../../server/plugins/dev-watcher.js";
+import type { RuntimePlugin } from "../../server/plugins/runtime-loader.js";
+
+// Make a fake `FSWatcher`. `node:fs.watch` returns an EventEmitter +
+// `.close()`; tests push synthetic file changes through `onChange`
+// captured at registration time.
+type FakeWatcher = ReturnType<typeof makeFakeWatcher>;
+function makeFakeWatcher() {
+  const emitter = new EventEmitter() as EventEmitter & { close: () => void; closed: boolean };
+  emitter.closed = false;
+  emitter.close = () => {
+    emitter.closed = true;
+    emitter.removeAllListeners();
+  };
+  return emitter;
+}
+
+function fakePlugin(name: string, cachePath = `/cache/${name}`): RuntimePlugin {
+  return {
+    name,
+    version: "dev",
+    cachePath,
+    definition: { type: "function", name: `tool_${name}`, description: "", parameters: { type: "object", properties: {}, required: [] } },
+    execute: async () => ({}),
+    oauthCallbackAlias: null,
+  };
+}
+
+interface PublishCall {
+  name: string;
+  changedFiles: string[];
+  serverSideChange: boolean;
+}
+
+function recorder() {
+  const calls: PublishCall[] = [];
+  const warns: string[] = [];
+  return {
+    publish: (name: string, payload: { changedFiles: string[]; serverSideChange: boolean }) => {
+      calls.push({ name, ...payload });
+    },
+    warnServerSideChange: (name: string) => {
+      warns.push(name);
+    },
+    calls,
+    warns,
+  };
+}
+
+interface TestRig {
+  fire: (relativePath: string) => void;
+  watcher: FakeWatcher;
+  rec: ReturnType<typeof recorder>;
+  close: () => void;
+}
+
+function makeRig(plugin: RuntimePlugin, debounceMs: number): TestRig {
+  const watcher = makeFakeWatcher();
+  let onChange: ((relativePath: string) => void) | null = null;
+  const rec = recorder();
+  const handle = watchDevPlugins([plugin], {
+    publish: rec.publish,
+    warnServerSideChange: rec.warnServerSideChange,
+    debounceMs,
+    watcherFactory: (_absDistPath, callback) => {
+      onChange = callback;
+      return watcher as unknown as ReturnType<typeof watchDevPlugins>["close"] extends never ? never : import("node:fs").FSWatcher;
+    },
+  });
+  return {
+    fire: (relativePath) => onChange?.(relativePath),
+    watcher,
+    rec,
+    close: handle.close,
+  };
+}
+
+const sleep = (delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+describe("watchDevPlugins — debounce", () => {
+  it("collapses a burst of file events into a single publish", async () => {
+    const plugin = fakePlugin("@test/burst");
+    const rig = makeRig(plugin, 50);
+    rig.fire("vue.js");
+    rig.fire("style.css");
+    rig.fire("definition-Dvdjo6Xe.js");
+    rig.fire("vue.js"); // duplicate file in burst — still 1 publish
+    await sleep(150);
+    assert.equal(rig.rec.calls.length, 1, `expected 1 publish; got ${rig.rec.calls.length}`);
+    assert.equal(rig.rec.calls[0].name, "@test/burst");
+    assert.deepEqual(
+      rig.rec.calls[0].changedFiles.sort(),
+      ["definition-Dvdjo6Xe.js", "style.css", "vue.js"],
+      "publish should include every distinct file in the burst",
+    );
+    rig.close();
+  });
+
+  it("emits twice when bursts are separated by more than the debounce window", async () => {
+    const plugin = fakePlugin("@test/two-bursts");
+    const rig = makeRig(plugin, 30);
+    rig.fire("vue.js");
+    await sleep(80); // beyond debounce → flush
+    rig.fire("vue.js");
+    await sleep(80);
+    assert.equal(rig.rec.calls.length, 2);
+    rig.close();
+  });
+
+  it("does not publish when nothing changed (close before window elapses)", async () => {
+    const plugin = fakePlugin("@test/no-events");
+    const rig = makeRig(plugin, 30);
+    // Close immediately — watcher fires nothing.
+    rig.close();
+    await sleep(60);
+    assert.equal(rig.rec.calls.length, 0);
+  });
+});
+
+describe("watchDevPlugins — server-side classification", () => {
+  it("flags serverSideChange + warns when dist/index.js is in the burst", async () => {
+    const plugin = fakePlugin("@test/server-side");
+    const rig = makeRig(plugin, 30);
+    rig.fire("index.js");
+    rig.fire("vue.js");
+    await sleep(80);
+    assert.equal(rig.rec.calls.length, 1);
+    assert.equal(rig.rec.calls[0].serverSideChange, true);
+    assert.deepEqual(rig.rec.warns, ["@test/server-side"]);
+    rig.close();
+  });
+
+  it("does NOT flag serverSideChange for browser-only changes", async () => {
+    const plugin = fakePlugin("@test/browser-only");
+    const rig = makeRig(plugin, 30);
+    rig.fire("vue.js");
+    rig.fire("style.css");
+    await sleep(80);
+    assert.equal(rig.rec.calls.length, 1);
+    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    assert.deepEqual(rig.rec.warns, []);
+    rig.close();
+  });
+
+  it("warns at most once per burst even if index.js fires multiple times", async () => {
+    const plugin = fakePlugin("@test/multi-index");
+    const rig = makeRig(plugin, 30);
+    rig.fire("index.js");
+    rig.fire("index.js");
+    rig.fire("index.js");
+    await sleep(80);
+    assert.equal(rig.rec.warns.length, 1);
+    rig.close();
+  });
+});
+
+describe("watchDevPlugins — multiple plugins", () => {
+  it("debounces independently per plugin", async () => {
+    const pluginA = fakePlugin("@test/multi-a");
+    const pluginB = fakePlugin("@test/multi-b");
+    const rec = recorder();
+    const callbacks = new Map<string, (relativePath: string) => void>();
+    const handle = watchDevPlugins([pluginA, pluginB], {
+      publish: rec.publish,
+      warnServerSideChange: rec.warnServerSideChange,
+      debounceMs: 30,
+      watcherFactory: (absDistPath, callback) => {
+        callbacks.set(absDistPath, callback);
+        return makeFakeWatcher() as unknown as import("node:fs").FSWatcher;
+      },
+    });
+    for (const [absDistPath, callback] of callbacks) {
+      // Each plugin fires its own change — debounce is per-plugin.
+      callback("vue.js");
+      assert.ok(absDistPath.includes("multi-"), `unexpected watcher path: ${absDistPath}`);
+    }
+    await sleep(80);
+    assert.equal(rec.calls.length, 2);
+    const names = rec.calls.map((entry) => entry.name).sort();
+    assert.deepEqual(names, ["@test/multi-a", "@test/multi-b"]);
+    handle.close();
+  });
+});
+
+describe("watchDevPlugins — close()", () => {
+  it("close() cancels pending timers and shuts watchers down", async () => {
+    const plugin = fakePlugin("@test/close");
+    const rig = makeRig(plugin, 30);
+    rig.fire("vue.js");
+    rig.close();
+    await sleep(80);
+    // No publish fires after close, even though the burst was queued.
+    assert.equal(rig.rec.calls.length, 0);
+    assert.equal(rig.watcher.closed, true);
+  });
+
+  it("close() is idempotent", () => {
+    const plugin = fakePlugin("@test/close-twice");
+    const rig = makeRig(plugin, 30);
+    rig.close();
+    rig.close(); // must not throw
+  });
+});

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -189,6 +189,67 @@ describe("watchDevPlugins — multiple plugins", () => {
   });
 });
 
+describe("watchDevPlugins — error isolation", () => {
+  it("calls onWatcherError + closes the watcher when fs.watch emits `error`", async () => {
+    const plugin = fakePlugin("@test/error");
+    const watcher = makeFakeWatcher();
+    const rec = recorder();
+    const errorEvents: { name: string; error: Error }[] = [];
+    watchDevPlugins([plugin], {
+      publish: rec.publish,
+      warnServerSideChange: rec.warnServerSideChange,
+      onWatcherError: (name, error) => errorEvents.push({ name, error }),
+      debounceMs: 30,
+      watcherFactory: () => watcher as unknown as import("node:fs").FSWatcher,
+    });
+    const boom = new Error("ENOENT: dist disappeared");
+    watcher.emit("error", boom);
+    assert.equal(errorEvents.length, 1);
+    assert.equal(errorEvents[0].name, "@test/error");
+    assert.equal(errorEvents[0].error.message, "ENOENT: dist disappeared");
+    assert.equal(watcher.closed, true, "watcher should self-close on error");
+  });
+
+  it("subsequent file events from a closed-on-error watcher do not publish", async () => {
+    // Even if the fake watcher kept emitting after error (a real
+    // EventEmitter wouldn't, but we want defence in depth), the
+    // debounce timer was cleared and the buffer wiped.
+    const plugin = fakePlugin("@test/error-then-event");
+    const watcher = makeFakeWatcher();
+    const rec = recorder();
+    const captured: ((relativePath: string) => void)[] = [];
+    watchDevPlugins([plugin], {
+      publish: rec.publish,
+      warnServerSideChange: rec.warnServerSideChange,
+      onWatcherError: () => {},
+      debounceMs: 20,
+      watcherFactory: (_absDistPath, callback) => {
+        captured.push(callback);
+        return watcher as unknown as import("node:fs").FSWatcher;
+      },
+    });
+    captured[0]("vue.js"); // queues a debounced publish
+    watcher.emit("error", new Error("simulated"));
+    await sleep(60);
+    assert.equal(rec.calls.length, 0, "no publish after error wiped the buffer");
+  });
+
+  it("does not throw when onWatcherError is omitted (production-safe default)", () => {
+    // Production wires onWatcherError through the structured logger;
+    // tests / single-shot scripts may omit it. The watcher must
+    // still self-close cleanly without an unhandled-error crash.
+    const plugin = fakePlugin("@test/no-handler");
+    const watcher = makeFakeWatcher();
+    const rec = recorder();
+    watchDevPlugins([plugin], {
+      publish: rec.publish,
+      watcherFactory: () => watcher as unknown as import("node:fs").FSWatcher,
+    });
+    assert.doesNotThrow(() => watcher.emit("error", new Error("silent")));
+    assert.equal(watcher.closed, true);
+  });
+});
+
 describe("watchDevPlugins — close()", () => {
   it("close() cancels pending timers and shuts watchers down", async () => {
     const plugin = fakePlugin("@test/close");


### PR DESCRIPTION
## Summary

PR3 of #1159 — closes the manual-⌘R step in the plugin author's dev loop. After PR2 (#1167) the dev runs \`yarn dev\` (vite watch) + \`mulmoclaude --dev-plugin <path>\`. Per code change they had to refresh the browser. PR3 makes the refresh automatic via a debounced \`fs.watch\` on each plugin's \`dist/\` + a pubsub event the frontend listens to.

\`\`\`bash
# Terminal A
cd my-plugin && yarn dev

# Terminal B
mulmoclaude --dev-plugin ./my-plugin
\`\`\`

Per code change: editor save → vite rebuild → server detects change → **browser auto-reloads** → updated plugin runs.

## Items to Confirm / Review

- **\`fs.watch\` instead of chokidar.** Node 20+ supports \`{ recursive: true }\` cross-platform — no new dep. Trade-off: \`fs.watch\` fires multiple events per write (debounced 300ms) and may flake on network drives. Acceptable for the dev mode use case. Tests use an injectable factory so platform quirks don't affect CI.
- **Server-side \`dist/index.js\` is not hot-replaced.** Node ESM has no public cache-invalidation API. The watcher publishes on every dist/ change (so the browser still reloads, harmless), but for \`definePlugin\` factory edits the dev needs to restart mulmoclaude. The watcher logs a prominent \`my-plugin: dist/index.js changed — restart mulmoclaude to pick up server-side changes\` warning so the dev knows. Browser-only edits (\`View.vue\`, CSS, lang/) reload without restart.
- **No opt-out flag.** \`--no-auto-reload\` could be added if a dev finds the auto-reload disruptive. Starting default-on for the simpler dev loop.
- **\`location.reload()\` discards Vue state.** True HMR is significant additional work; defer until there's demand. The scaffold's counter sample doesn't have meaningful state to lose.
- **Shutdown hook plumbing.** Added a small \`shutdownHooks\` array + \`registerShutdownHook\` helper in \`server/index.ts\`. The watcher \`close()\` rides it. Existing graceful shutdown path stays unchanged otherwise.

## User Prompt

> マージしてPR3 (after merging #1170) — proceed with PR3.

(Continues #1159 plugin author dev-loop work after PR1 #1163 + PR2 #1167.)

## Implementation

Plan: \`plans/feat-1159-pr3-dev-plugin-auto-reload.md\` (commit \`1328a1f1\`).

- \`server/plugins/dev-watcher.ts\` — \`watchDevPlugins(plugins, opts) → { close }\`. Pure, injectable: takes a publish callback, an optional warn callback for server-side changes, debounce ms, and a watcher factory. Default factory uses \`node:fs.watch\`.
- \`src/config/pubsubChannels.ts\` — adds \`devPluginChanged: \"dev-plugin-changed\"\` to \`HOST_STATIC_CHANNELS\` with payload doc.
- \`src/composables/useDevPluginReload.ts\` — single subscription that calls \`location.reload()\`. Mounted from \`src/main.ts\` once at app boot.
- \`server/index.ts\` — wires watcher post-\`evaluateDevPluginGate\`, registers \`watcher.close()\` as a shutdown hook.
- \`test/plugins/test_dev_watcher.ts\` — 11 cases: burst debounce, dual-burst spacing, no-events-then-close, server-side classification (single + multi index.js), browser-only classification, multi-plugin isolation, idempotent close.

## Test plan

- [x] \`yarn lint\` / \`yarn typecheck\` / \`yarn test\` all green (4059 / 86 across plugins / packages)
- [x] Manual smoke (after \`prepare-dist.js\`):
  - Boot launcher with \`--dev-plugin\` on a freshly-scaffolded plugin → loads + registers
  - \`echo >> dist/vue.js\` → silent publish (success path doesn't log)
  - \`echo >> dist/index.js\` → explicit \`restart mulmoclaude\` warning in the launcher log ✓
- [ ] Reviewer manually confirms the browser actually reloads on file change in their browser session
- [ ] Reviewer confirms the readme rewrites still match the actual behavior

Closes the dev-loop track of #1159. Plugin marketplace UI is #1160 (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-reload functionality for plugin development mode. The browser now automatically reloads when plugin build files change, and a message logs when a launcher restart is required for server-side code modifications.

* **Documentation**
  * Updated development guides with details on browser auto-reload behavior and requirements for server-side changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->