### PR TITLE
fix(chat): keep selection on assistant text after hidden tool calls

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -63,6 +63,22 @@ interface ToolDef {
   endpoint?: string;
 }
 
+// Shape returned by a plugin endpoint dispatch. Only `data` /
+// `message` / `instructions` are read by the bridge; other fields
+// (title, jsonData, action, etc.) flow through to the frontend
+// untouched. `toolName` / `uuid` are listed so the post-spread
+// override in `handleToolCall` is type-checked rather than relying
+// on object-shape coincidence — the bridge always re-asserts them
+// from its own state.
+interface PluginResultEnvelope {
+  data?: unknown;
+  message?: unknown;
+  instructions?: unknown;
+  toolName?: unknown;
+  uuid?: unknown;
+  [key: string]: unknown;
+}
+
 // Combine `description` (one-liner) and `prompt` (detailed usage
 // instructions) into the MCP tool description so Claude CLI sees
 // both. The MCP protocol only has `description` — there's no
@@ -414,7 +430,7 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   // for the slowest realistic completion — see PLUGIN_BRIDGE_TIMEOUT_MS
   // and the timeout-policy comment on `postJson`.
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
-  const result = await res.json();
+  const result = ((await res.json()) ?? {}) as PluginResultEnvelope;
 
   // Push visual ToolResult to the frontend via the session — but only
   // when the handler set `data` (the GUI's preview-eligibility signal,
@@ -426,11 +442,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   // POST keeps the session log clean and avoids the prior bug where a
   // hidden tool_result during a run could trap canvas selection on a
   // stale prior-turn card.
-  if (result && typeof result === "object" && (result as { data?: unknown }).data !== undefined) {
+  if (result.data !== undefined) {
+    // Spread `result` first so the bridge's own `toolName` and `uuid`
+    // are authoritative — a plugin handler that (intentionally or
+    // accidentally) returned those keys can't impersonate a different
+    // tool or collide on uuid.
     await postJson(API_ROUTES.agent.internal.toolResult, {
+      ...result,
       toolName: name,
       uuid: makeUuid(),
-      ...result,
     });
   }
 

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -416,12 +416,23 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
   const result = await res.json();
 
-  // Push visual ToolResult to the frontend via the session
-  await postJson(API_ROUTES.agent.internal.toolResult, {
-    toolName: name,
-    uuid: makeUuid(),
-    ...result,
-  });
+  // Push visual ToolResult to the frontend via the session — but only
+  // when the handler set `data` (the GUI's preview-eligibility signal,
+  // see `src/utils/tools/sidebarVisible.ts`). Narrate-only actions
+  // (e.g. accounting `getReport`, `getBooks`) deliberately omit `data`
+  // and behave like a plain MCP tool call: the LLM gets `message` /
+  // `instructions` via the return value below, and nothing lands in
+  // the session's `toolResults` or its on-disk JSONL log. Skipping the
+  // POST keeps the session log clean and avoids the prior bug where a
+  // hidden tool_result during a run could trap canvas selection on a
+  // stale prior-turn card.
+  if (result && typeof result === "object" && (result as { data?: unknown }).data !== undefined) {
+    await postJson(API_ROUTES.agent.internal.toolResult, {
+      toolName: name,
+      uuid: makeUuid(),
+      ...result,
+    });
+  }
 
   const parts = [result.message, result.instructions].filter(Boolean);
   return parts.length > 0 ? parts.join("\n") : "Done";

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -35,7 +35,10 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       await ctx.refreshRoles();
       return;
     case EVENT_TYPES.text:
-      applyTextEvent(session, event.message, event.source ?? "assistant", event.attachments);
+      // Pass `isSidebarVisible` so a sidebar-hidden tool result
+      // emitted earlier in this run (e.g. accounting `getReport`)
+      // does not suppress selecting the text reply on canvas.
+      applyTextEvent(session, event.message, event.source ?? "assistant", event.attachments, isSidebarVisible);
       return;
     case EVENT_TYPES.toolResult:
       // Skip auto-select for sidebar-hidden results; otherwise the

--- a/src/utils/agent/toolCalls.ts
+++ b/src/utils/agent/toolCalls.ts
@@ -44,19 +44,36 @@ export function findPendingToolCall(history: readonly ToolCallHistoryItem[], too
 }
 
 // Decide whether a newly-arrived assistant text message should
-// become the selected canvas result. Rule: yes, iff no plugin
-// tool result has landed during this run. A plugin result — e.g.
-// an image, a todo list update — is visually richer than a bare
-// text response and should stay selected once emitted.
+// become the selected canvas result. Rule: yes, iff no
+// sidebar-*visible* plugin tool result has landed during this
+// run. A visible plugin result — e.g. an image, a todo list
+// update — is visually richer than a bare text response and
+// should stay selected once emitted. Sidebar-hidden results
+// (e.g. accounting `getReport`, which carries no `data` field)
+// have no card on canvas, so they must not block selection of
+// the text reply — otherwise selection silently sticks on a
+// prior-turn card the user can no longer act on.
 //
 // `runStartIndex` is the index into `toolResults` at which the
 // current run's outputs begin. Results before that index belong
 // to previous turns and don't count.
 //
+// `isVisible` mirrors the predicate used by
+// `applyToolResultToSession`'s auto-select branch so the two
+// stay aligned. Default `() => true` matches the legacy
+// behaviour (used by tests that don't care about visibility).
+//
 // Pure — returns a boolean for the caller to act on.
-export function shouldSelectAssistantText(toolResults: readonly ToolResultComplete[], runStartIndex: number): boolean {
+export function shouldSelectAssistantText(
+  toolResults: readonly ToolResultComplete[],
+  runStartIndex: number,
+  isVisible: (result: ToolResultComplete) => boolean = () => true,
+): boolean {
   for (let i = runStartIndex; i < toolResults.length; i++) {
-    if (toolResults[i].toolName !== "text-response") return false;
+    const result = toolResults[i];
+    if (result.toolName === "text-response") continue;
+    if (!isVisible(result)) continue;
+    return false;
   }
   return true;
 }

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -64,8 +64,17 @@ function isDuplicateUserText(session: ActiveSession, message: string): boolean {
  *  streams assistant text into the last card, and selects the
  *  result when appropriate. `attachments` is forwarded for cross-tab
  *  user-text broadcasts so observing tabs render chips identically
- *  to the originating tab. */
-export function applyTextEvent(session: ActiveSession, message: string, source: "user" | "assistant", attachments?: readonly string[]): void {
+ *  to the originating tab. `isVisible` is forwarded to
+ *  `shouldSelectAssistantText` so sidebar-hidden tool results in
+ *  the current run don't suppress text-reply selection (default
+ *  `() => true` keeps tests / off-thread callers behaviour-compat). */
+export function applyTextEvent(
+  session: ActiveSession,
+  message: string,
+  source: "user" | "assistant",
+  attachments?: readonly string[],
+  isVisible: (result: ToolResultComplete) => boolean = () => true,
+): void {
   if (source === "user") {
     if (!isDuplicateUserText(session, message)) {
       pushResult(session, makeTextResult(message, "user", attachments));
@@ -76,7 +85,7 @@ export function applyTextEvent(session: ActiveSession, message: string, source: 
   if (appendToLastAssistantText(session, message)) return;
   const textResult = makeTextResult(message, "assistant");
   pushResult(session, textResult);
-  if (shouldSelectAssistantText(session.toolResults, session.runStartIndex)) {
+  if (shouldSelectAssistantText(session.toolResults, session.runStartIndex, isVisible)) {
     session.selectedResultUuid = textResult.uuid;
   }
 }

--- a/test/utils/agent/test_toolCalls.ts
+++ b/test/utils/agent/test_toolCalls.ts
@@ -136,6 +136,32 @@ describe("shouldSelectAssistantText — boundary conditions", () => {
   });
 });
 
+describe("shouldSelectAssistantText — sidebar-hidden results don't block selection", () => {
+  it("hidden plugin result in run is ignored when isVisible filters it out", () => {
+    // Repro of the accounting / presentForm bug: a getReport
+    // tool result lands during the run with no `data` field, so
+    // isSidebarVisible returns false. The trailing text reply
+    // should still become the selected canvas result instead of
+    // leaving the previous-turn form card highlighted.
+    const results = [makeToolResult("user", "text-response"), makeToolResult("hidden", "manageAccounting"), makeToolResult("text", "text-response")];
+    const isVisible = (result: ToolResultComplete) => result.uuid !== "hidden";
+    assert.equal(shouldSelectAssistantText(results, 0, isVisible), true);
+  });
+
+  it("visible plugin result in run still blocks selection", () => {
+    const results = [makeToolResult("user", "text-response"), makeToolResult("visible", "generateImage"), makeToolResult("text", "text-response")];
+    const isVisible = () => true;
+    assert.equal(shouldSelectAssistantText(results, 0, isVisible), false);
+  });
+
+  it("default predicate (no arg) preserves legacy behaviour", () => {
+    // Same shape as above but without the isVisible arg —
+    // existing callers / tests must keep getting `false`.
+    const results = [makeToolResult("user", "text-response"), makeToolResult("plugin", "generateImage"), makeToolResult("text", "text-response")];
+    assert.equal(shouldSelectAssistantText(results, 0), false);
+  });
+});
+
 describe("shouldSelectAssistantText — multi-turn regression (#stale-runStartIndex)", () => {
   it("turn 2 with a plugin result in turn 1 → true for text-only turn 2", () => {
     // Simulates the two-turn bug:


### PR DESCRIPTION
## Summary

- In single mode, asking the Accounting role for "this month's profit" with multiple books surfaces a `presentForm` to choose a book. After the user submits, the LLM calls `manageAccounting({action:"getReport"})` and replies with text — but the canvas stays stuck on the (now-stale) form card and the text reply goes unseen.
- Root cause: `shouldSelectAssistantText` returns `false` whenever any non-text result lands during the run, including **sidebar-hidden** ones. `getReport` is not in `PREVIEW_ACTIONS` (`server/api/routes/accounting.ts:195`), so its tool result carries no `data` field and `isSidebarVisible` returns `false` — there is no card on canvas, but the predicate still counted it as "richer content" and kept the prior-turn form selected.
- Fix: thread `isSidebarVisible` into `shouldSelectAssistantText` so it filters the loop the same way `applyToolResultToSession`'s auto-select branch already does. The two predicates are now aligned: a hidden tool result no longer suppresses selection of a trailing text reply.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` — clean
- [x] `yarn test` — all 20 cases in `test_toolCalls.ts` pass, including 3 new cases (`sidebar-hidden results don't block selection`)
- [ ] Manual: in Accounting role with ≥2 books, ask "What is this month's profit?", submit the book-picker form, confirm the LLM's text reply takes the canvas in single mode (and that stack mode still highlights the same uuid)
- [ ] Manual regression: a *visible* plugin result mid-run (e.g. `generateImage`) still wins selection over a trailing text reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text reply auto-selection to consistently account for sidebar visibility during message processing.
  * Text selection behavior now aligns with how tool results are handled when the sidebar is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->