### PR TITLE
refactor(mcp-bridge): skip tool_result POST when handler omits data

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -63,6 +63,22 @@ interface ToolDef {
   endpoint?: string;
 }
 
+// Shape returned by a plugin endpoint dispatch. Only `data` /
+// `message` / `instructions` are read by the bridge; other fields
+// (title, jsonData, action, etc.) flow through to the frontend
+// untouched. `toolName` / `uuid` are listed so the post-spread
+// override in `handleToolCall` is type-checked rather than relying
+// on object-shape coincidence — the bridge always re-asserts them
+// from its own state.
+interface PluginResultEnvelope {
+  data?: unknown;
+  message?: unknown;
+  instructions?: unknown;
+  toolName?: unknown;
+  uuid?: unknown;
+  [key: string]: unknown;
+}
+
 // Combine `description` (one-liner) and `prompt` (detailed usage
 // instructions) into the MCP tool description so Claude CLI sees
 // both. The MCP protocol only has `description` — there's no
@@ -414,7 +430,7 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   // for the slowest realistic completion — see PLUGIN_BRIDGE_TIMEOUT_MS
   // and the timeout-policy comment on `postJson`.
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
-  const result = await res.json();
+  const result = ((await res.json()) ?? {}) as PluginResultEnvelope;
 
   // Push visual ToolResult to the frontend via the session — but only
   // when the handler set `data` (the GUI's preview-eligibility signal,
@@ -426,11 +442,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   // POST keeps the session log clean and avoids the prior bug where a
   // hidden tool_result during a run could trap canvas selection on a
   // stale prior-turn card.
-  if (result && typeof result === "object" && (result as { data?: unknown }).data !== undefined) {
+  if (result.data !== undefined) {
+    // Spread `result` first so the bridge's own `toolName` and `uuid`
+    // are authoritative — a plugin handler that (intentionally or
+    // accidentally) returned those keys can't impersonate a different
+    // tool or collide on uuid.
     await postJson(API_ROUTES.agent.internal.toolResult, {
+      ...result,
       toolName: name,
       uuid: makeUuid(),
-      ...result,
     });
   }
 

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -416,12 +416,23 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
   const result = await res.json();
 
-  // Push visual ToolResult to the frontend via the session
-  await postJson(API_ROUTES.agent.internal.toolResult, {
-    toolName: name,
-    uuid: makeUuid(),
-    ...result,
-  });
+  // Push visual ToolResult to the frontend via the session — but only
+  // when the handler set `data` (the GUI's preview-eligibility signal,
+  // see `src/utils/tools/sidebarVisible.ts`). Narrate-only actions
+  // (e.g. accounting `getReport`, `getBooks`) deliberately omit `data`
+  // and behave like a plain MCP tool call: the LLM gets `message` /
+  // `instructions` via the return value below, and nothing lands in
+  // the session's `toolResults` or its on-disk JSONL log. Skipping the
+  // POST keeps the session log clean and avoids the prior bug where a
+  // hidden tool_result during a run could trap canvas selection on a
+  // stale prior-turn card.
+  if (result && typeof result === "object" && (result as { data?: unknown }).data !== undefined) {
+    await postJson(API_ROUTES.agent.internal.toolResult, {
+      toolName: name,
+      uuid: makeUuid(),
+      ...result,
+    });
+  }
 
   const parts = [result.message, result.instructions].filter(Boolean);
   return parts.length > 0 ? parts.join("\n") : "Done";


### PR DESCRIPTION
## Summary

- Stacked on top of #1176. Treats narrate-only plugin actions (those that return `{ message, instructions? }` without a `data` field) as plain MCP tool calls: the LLM still receives the result via the bridge's return value, but no `tool_result` event is published and nothing lands in the session's `toolResults` or its on-disk JSONL log.
- Removes the structural cause of the bug #1176 fixes — hidden tool_result entries — at the source. #1176 is still needed for backward compat with older sessions that already contain such entries on disk.
- One-conditional change at `server/agent/mcp-server.ts:419`. The two `pushSkillsListResult` / `handleManageSkillsList` callers above it always set `data: { skills }`, so they're unaffected.

## Why this is safe

- The agent SDK's own `tool_call` / `tool_call_result` events still record that the LLM made the call (they go to `toolCallHistory`, not `toolResults`).
- Only the MCP bridge produces `tool_result` events for plugin tools; the pure-MCP path right above (`mcp-server.ts:397-406`) already returns to the LLM without emitting a `tool_result`, which is exactly the semantics narrate-only actions want.
- Hidden results were never user-selectable (sidebar filtered them, keyboard nav skipped them, no view component to mount), so nothing was relying on them being present in `toolResults`.
- Existing on-disk sessions that contain hidden envelopes keep working: `isSidebarVisible` and the predicates wired in #1176 still filter them at load time.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` — clean
- [x] `yarn test` — all passing (no behavior change for unit-tested code paths)
- [ ] Manual: Accounting role with ≥2 books, ask "What is this month's profit?", submit the form, confirm:
  - The text reply takes the canvas in single mode
  - The session sidebar shows only `presentForm` + the text reply, no `manageAccounting(getReport)` envelope
  - Reload the session — the same cards reappear, no orphan entries
- [ ] Manual: a *visible* accounting action (`addEntries`, `openBook`, …) still surfaces a card and steals selection, as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Conditionally emit MCP bridge tool_result events only for tool responses that include UI-previewable data, preventing narrate-only plugin actions from creating hidden toolResult entries.

Bug Fixes:
- Avoid canvas selection getting stuck on stale cards by skipping tool_result events for narrate-only plugin actions without data.

Enhancements:
- Treat narrate-only MCP plugin actions as plain tool calls that return messages to the LLM without persisting toolResults or JSONL log entries.