### PR TITLE
refactor(mcp-bridge): strict-gate on data, drop residual hidden-result comments

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -63,18 +63,18 @@ interface ToolDef {
   endpoint?: string;
 }
 
-// Shape returned by a plugin endpoint dispatch. `data` / `jsonData`
-// are the two protocol-defined "view payload" fields — either one
-// being set means the plugin wants to surface a card. `message` /
-// `instructions` are read by the bridge for the LLM-facing return
-// value; other fields (title, action, etc.) flow through to the
-// frontend untouched. `toolName` / `uuid` are listed so the
-// post-spread override in `handleToolCall` is type-checked rather
-// than relying on object-shape coincidence — the bridge always
-// re-asserts them from its own state.
+// Shape returned by a plugin endpoint dispatch. `data` is the
+// protocol's render-eligibility signal — present means "render a
+// card", absent means narrate-only (see `gui-chat-protocol`'s
+// `ToolResult` docs). `message` / `instructions` are read by the
+// bridge for the LLM-facing return value; other fields (title,
+// jsonData, action, etc.) flow through to the frontend untouched.
+// `toolName` / `uuid` are listed so the post-spread override in
+// `handleToolCall` is type-checked rather than relying on
+// object-shape coincidence — the bridge always re-asserts them
+// from its own state.
 interface PluginResultEnvelope {
   data?: unknown;
-  jsonData?: unknown;
   message?: unknown;
   instructions?: unknown;
   toolName?: unknown;
@@ -435,19 +435,17 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
   const result = ((await res.json()) ?? {}) as PluginResultEnvelope;
 
-  // Push visual ToolResult to the frontend via the session — but only
-  // when the handler set a view payload (`data` or `jsonData`).
-  // Narrate-only actions (e.g. accounting `getReport`, `getBooks`,
-  // plugin validation-error branches) deliberately omit both and
-  // behave like a plain MCP tool call: the LLM gets `message` /
-  // `instructions` via the return value below, and nothing lands in
-  // the session's `toolResults` or its on-disk JSONL log. Skipping
-  // the POST keeps the session log clean and avoids the prior bug
-  // where a hidden tool_result during a run could trap canvas
-  // selection on a stale prior-turn card. Both fields are accepted
-  // because the protocol leaves the choice to the plugin: presentForm
-  // sets both, accounting sets `data`, quiz sets only `jsonData`.
-  if (result.data !== undefined || result.jsonData !== undefined) {
+  // Push visual ToolResult to the frontend via the session — but
+  // only when the handler set `data`, which is the protocol's
+  // render-eligibility signal. Narrate-only actions (e.g.
+  // accounting `getReport`, `getBooks`, plugin validation-error
+  // branches) deliberately omit `data` and behave like a plain
+  // MCP tool call: the LLM gets `message` / `instructions` via
+  // the return value below, and nothing lands in the session's
+  // `toolResults` or its on-disk JSONL log. (`jsonData` is
+  // orthogonal — the LLM-readable copy — and does NOT gate
+  // rendering on its own.)
+  if (result.data !== undefined) {
     // Spread `result` first so the bridge's own `toolName` and `uuid`
     // are authoritative — a plugin handler that (intentionally or
     // accidentally) returned those keys can't impersonate a different

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -31,16 +31,13 @@ export function parseSessionEntries(entries: readonly SessionEntry[]): ToolResul
 // Pick the `selectedResultUuid` the session should restore to.
 // Rules:
 //   1. If the URL carries `?result=<uuid>` AND that uuid actually
-//      exists in the loaded list, honour it verbatim. This lets
-//      bookmarks restore the exact result the user was viewing —
-//      we honour even sidebar-hidden uuids here because the URL is
-//      an explicit user choice (a fresh "auto-pick" should never
-//      land on a hidden result, but a deliberate bookmark can).
-//   2. Otherwise fall back to the heuristic over visible-only
-//      results: the most recent non-text tool result (images, wiki
-//      pages, etc. carry more visual information than bare text).
-//   3. If there are no non-text visible results, use the last
-//      visible result of any kind.
+//      exists in the loaded list, honour it verbatim — bookmarks
+//      restore the exact result the user was viewing.
+//   2. Otherwise pick the most recent non-text tool result —
+//      images, wiki pages, etc. carry more visual information
+//      than a bare text response.
+//   3. If every result is `text-response`, fall back to the last
+//      one.
 //   4. If the list is empty, return null.
 //
 export function resolveSelectedUuid(toolResults: readonly ToolResultComplete[], urlResult: string | null): string | null {


### PR DESCRIPTION
## Summary

Follow-up to [#1178](https://github.com/receptron/mulmoclaude/pull/1178) and [#1180](https://github.com/receptron/mulmoclaude/pull/1180). With every audited plugin now emitting \`data\` for renderable results (quiz upgraded to 0.4.2 in #1180), the bridge can match the [gui-chat-protocol 0.3.3 contract](https://github.com/receptron/gui-chat-protocol/pull/13) exactly: **\`data\` is the render-eligibility signal**. \`jsonData\` is orthogonal (LLM-readable copy) and does NOT gate rendering.

\`jsonData\` still flows end-to-end via the toolResult spread, so views that read it (e.g. quiz's \`data ?? jsonData\` fallback for legacy transcripts) keep working — only the bridge's local type stops naming a field it doesn't itself inspect.

## Changes

### \`server/agent/mcp-server.ts\`

- Drop \`|| result.jsonData !== undefined\` from the bridge gate.
- Drop \`jsonData?: unknown\` from \`PluginResultEnvelope\` (the index signature on the type still carries arbitrary extra keys).
- Tighten the surrounding comment block to reflect the simpler contract.

### \`src/utils/session/sessionEntries.ts\`

- Refresh the \`resolveSelectedUuid\` doc comment, which still referenced "sidebar-hidden uuids" / "visible-only results" / "no non-text visible results" — leftover phrasing from the pre-#1178 era when the function filtered by an injected \`isVisible\` predicate. The implementation has scanned \`toolResults\` directly since #1178 ([\`refactor: remove isSidebarVisible plumbing\`](https://github.com/receptron/mulmoclaude/commit/978987a7)); the comment now matches.

## Test plan

- [x] \`yarn format\`, \`yarn lint\`, \`yarn typecheck\`, \`yarn build\`, \`yarn test\` — all clean
- [ ] Manual: Accounting role — \`getReport\` etc. still narrate-only (no card), \`addEntries\`/\`openBook\` still surface cards
- [ ] Manual: Quiz tool still renders correctly under the strict gate (now via the \`data\` field set in 0.4.2)
- [ ] Manual: Image/markdown/chart/etc. plugins regress check — all still surface cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)