### PR TITLE
feat: dev mode + Debug role (PR 1 of feat-encore plan)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Client locale for vue-i18n. Supported: "en" (default), "ja".
 # Picked up at build/dev time via import.meta.env.VITE_LOCALE.
 # VITE_LOCALE=en
+
+# Dev mode. Set to "1" to surface the Debug role in the UI dropdown
+# and (in PR 2 onward) load test plugins under `src/plugins/_*`.
+# Off in production. Drives both server-side (`env.devMode`) and
+# client-side (`import.meta.env.VITE_DEV_MODE`, mirrored by Vite).
+# DEV_MODE=1

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -65,6 +65,13 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
 
   await page.route(urlEndsWith("/api/roles"), (route) => route.fulfill({ json: DEFAULT_ROLES }));
 
+  // System config — `useSystemConfig` fetches this once on boot.
+  // Default to dev-mode-off so the Debug role doesn't surface in
+  // tests that don't care about it. Tests exercising the Debug role
+  // override this route with `{ devMode: true }` BEFORE calling
+  // mockAllApis (Playwright last-registered-first).
+  await page.route(urlEndsWith("/api/system/config"), (route) => route.fulfill({ json: { devMode: false } }));
+
   await page.route(urlEndsWith("/api/sessions"), (route) => {
     if (route.request().method() === "GET") {
       // Envelope shape from #205. Any test that wants to simulate

--- a/e2e/tests/debug-role.spec.ts
+++ b/e2e/tests/debug-role.spec.ts
@@ -1,0 +1,46 @@
+// E2E for the Debug-role gate. The role appears in the dropdown
+// only when /api/system/config reports `devMode: true`. This proves
+// the runtime endpoint flows through `useSystemConfig` →
+// `applyDevModeFilter` → the visible RoleSelector list.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+async function mockSystemConfig(page: Page, devMode: boolean) {
+  // Registered AFTER mockAllApis so Playwright's
+  // last-registered-first ordering puts this override ahead of the
+  // default `{ devMode: false }` mock baked into mockAllApis.
+  await page.route(urlEndsWith("/api/system/config"), (route: Route) => route.fulfill({ json: { devMode } }));
+}
+
+test.describe("Debug role gate", () => {
+  test("DEV_MODE off → Debug role absent from the dropdown", async ({ page }) => {
+    await mockAllApis(page);
+    // mockAllApis already mocks `/api/system/config` to devMode: false,
+    // so no extra override needed for this case.
+    await page.goto("/chat");
+
+    // Open the dropdown so role options render.
+    await page.getByTestId("role-selector-btn").click();
+
+    // General is always present — sanity check the dropdown rendered.
+    await expect(page.getByTestId("role-option-general")).toBeVisible();
+    // Debug must not be in the option list.
+    await expect(page.getByTestId("role-option-debug")).toHaveCount(0);
+  });
+
+  test("DEV_MODE on → Debug role visible in the dropdown", async ({ page }) => {
+    await mockAllApis(page);
+    await mockSystemConfig(page, true);
+    await page.goto("/chat");
+
+    await page.getByTestId("role-selector-btn").click();
+
+    await expect(page.getByTestId("role-option-debug")).toBeVisible();
+    await expect(page.getByTestId("role-option-debug")).toContainText("Debug");
+  });
+});

--- a/server/api/routes/system.ts
+++ b/server/api/routes/system.ts
@@ -1,0 +1,21 @@
+import { Router, type Request, type Response } from "express";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { env } from "../../system/env.js";
+
+// Lightweight host-level runtime-config endpoint. The frontend reads
+// this once on boot via `useSystemConfig()` so flags driven by the
+// server's `.env` (currently just `DEV_MODE`) can shape the UI
+// without baking values into the bundle. Adding a new flag is one
+// field on the response shape plus a read in `env.ts`.
+
+export interface SystemConfigResponse {
+  devMode: boolean;
+}
+
+const router = Router();
+
+router.get(API_ROUTES.system.config, (_req: Request, res: Response<SystemConfigResponse>) => {
+  res.json({ devMode: env.devMode });
+});
+
+export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import { provisionWikiHistoryHook } from "./workspace/wiki-history/provision.js"
 import pdfRoutes from "./api/routes/pdf.js";
 import filesRoutes from "./api/routes/files.js";
 import configRoutes from "./api/routes/config.js";
+import systemRoutes from "./api/routes/system.js";
 import skillsRoutes from "./api/routes/skills.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
@@ -458,6 +459,7 @@ app.use("/api/wiki", wikiHistoryRoutes);
 app.use(pdfRoutes);
 app.use(filesRoutes);
 app.use(configRoutes);
+app.use(systemRoutes);
 app.use(skillsRoutes);
 app.use(runtimePluginRoutes);
 async function listSessionsForBridge(opts: { limit: number; offset: number }) {

--- a/server/system/env.ts
+++ b/server/system/env.ts
@@ -56,6 +56,12 @@ export const env = Object.freeze({
   nodeEnv: process.env.NODE_ENV ?? "development",
   isProduction: process.env.NODE_ENV === "production",
 
+  // Dev-mode flag. Surfaces the `Debug` role in the UI dropdown and
+  // (in PR 2) gates registration of `_*` test plugins. Off in
+  // production. Mirror to `VITE_DEV_MODE` is handled in
+  // `vite.config.ts` so a single `.env` line drives both sides.
+  devMode: asFlag(process.env.DEV_MODE),
+
   // Sandbox / Docker
   disableSandbox: asFlag(process.env.DISABLE_SANDBOX),
   // Debug aid: also persist `tool_call` events to the session

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -3,17 +3,32 @@
 // useCurrentRole — selection is a UI-local concern and lives next
 // to the dropdown that drives it.
 
-import { ref, type Ref } from "vue";
+import { computed, ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
-import { ROLES, type Role } from "../config/roles";
+import { BUILTIN_ROLE_IDS, ROLES, type Role } from "../config/roles";
 import { mergeRoles } from "../utils/role/merge";
 import { apiGet } from "../utils/api";
+import { useSystemConfig } from "./useSystemConfig";
+
+export function applyDevModeFilter(allRoles: Role[], isDevMode: boolean): Role[] {
+  if (isDevMode) return allRoles;
+  return allRoles.filter((role) => role.id !== BUILTIN_ROLE_IDS.debug);
+}
 
 export function useRoles(): {
   roles: Ref<Role[]>;
   refreshRoles: () => Promise<void>;
 } {
-  const roles = ref<Role[]>(ROLES);
+  // Composable invocation must happen inside the function body, not
+  // at module top level. `useSystemConfig` triggers an `apiGet` on
+  // first call; the bearer token is set from main.ts at boot, so the
+  // first invocation has to land in setup-function timing (App.vue's
+  // `<script setup>`) rather than during static module evaluation.
+  const { devMode } = useSystemConfig();
+  const allRoles = ref<Role[]>(ROLES);
+  // Reactive: when `useSystemConfig` resolves and flips devMode, the
+  // filtered list updates without consumers re-subscribing.
+  const roles = computed(() => applyDevModeFilter(allRoles.value, devMode.value));
 
   async function refreshRoles(): Promise<void> {
     const result = await apiGet<Role[]>(API_ROUTES.roles.list);
@@ -23,7 +38,7 @@ export function useRoles(): {
       console.warn(`[useRoles] refreshRoles failed: ${result.status} ${result.error}`);
       return;
     }
-    roles.value = mergeRoles(ROLES, result.data);
+    allRoles.value = mergeRoles(ROLES, result.data);
   }
 
   return { roles, refreshRoles };

--- a/src/composables/useSystemConfig.ts
+++ b/src/composables/useSystemConfig.ts
@@ -1,0 +1,50 @@
+// Module-singleton view of the host's runtime config — currently
+// just `devMode`. Initial value is read synchronously from
+// `import.meta.env.VITE_DEV_MODE` (mirrored from `DEV_MODE` by
+// vite.config.ts) so consumers can render correctly on first paint;
+// the runtime endpoint then confirms / overrides for the production
+// case where the client bundle was built before the server's
+// `DEV_MODE` was flipped.
+
+import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
+import { apiGet } from "../utils/api";
+
+interface SystemConfig {
+  devMode: boolean;
+}
+
+// `import.meta.env` is injected by Vite at build / dev time. It's
+// undefined when this module is imported by `node:test` (which is
+// how unit tests reach the composable). Guard the access so the
+// module loads cleanly in both runtimes — under Node we fall back
+// to "off" and let the test exercise `applyDevModeFilter` against
+// an explicit boolean argument.
+const importMetaEnv = (import.meta as { env?: { VITE_DEV_MODE?: string } }).env;
+const initialDevMode = importMetaEnv?.VITE_DEV_MODE === "1";
+const devMode = ref<boolean>(initialDevMode);
+let refreshPromise: Promise<void> | null = null;
+
+async function fetchOnce(): Promise<void> {
+  const result = await apiGet<SystemConfig>(API_ROUTES.system.config);
+  if (!result.ok) {
+    // Keep the compile-time fallback. Logging through console because
+    // the structured logger is server-only.
+    console.warn(`[useSystemConfig] fetch failed: ${result.status} ${result.error}`);
+    return;
+  }
+  devMode.value = result.data.devMode;
+}
+
+export function useSystemConfig(): {
+  devMode: Ref<boolean>;
+  refresh: () => Promise<void>;
+} {
+  if (!refreshPromise) {
+    refreshPromise = fetchOnce();
+  }
+  return {
+    devMode,
+    refresh: () => fetchOnce(),
+  };
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -144,6 +144,13 @@ const HOST_API_ROUTES = {
     translate: "/api/translation",
   },
 
+  // Lightweight runtime-config endpoint — currently exposes only
+  // `devMode` for the Debug-role gate. Future host-level runtime
+  // flags can join here without minting a new namespace per flag.
+  system: {
+    config: "/api/system/config",
+  },
+
   // Plugin-owned endpoints that don't follow a single naming pattern.
   // Names match the plugin tool name or the short verb the plugin uses.
   plugins: {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -32,36 +32,45 @@ export const RoleSchema = z.object({
 
 export type Role = z.infer<typeof RoleSchema>;
 
+// Shared prompt + plugin set between General and Debug. Debug ships
+// the same surface as General so PR 2's `_*` test plugins (added to
+// `DEBUG_AVAILABLE_PLUGINS` once they exist) are the only difference
+// — keeps the developer-facing role identical to the user-facing one
+// for everything except the test surface under inspection.
+const GENERAL_PROMPT =
+  "You are a helpful assistant with access to the user's workspace. Help with tasks, answer questions, and use available tools when appropriate.\n\n" +
+  "## Asking the user to choose\n\n" +
+  "When the user must pick from a small set of options, toggle features, or answer yes/no, call presentForm with the appropriate fields (radio for one-of, checkbox for many-of, text/textarea for free-form). Group related questions into one form. Prefer this strongly over phrasing the choice in plain prose — the form gives the user clickable controls and sends the answers back as a markdown bullet list.\n\n" +
+  "Mark every field the user must answer as `required: true`. The form blocks submission until required fields are filled, which prevents the LLM from receiving partial responses.\n\n" +
+  "## Wiki\n\n" +
+  "A personal knowledge wiki lives at `data/wiki/` in the workspace.\n\n" +
+  "- **Ingest**: fetch or read the source, save raw to `data/wiki/sources/<slug>.md`, create/update pages in `data/wiki/pages/`, update `data/wiki/index.md`, append to `data/wiki/log.md`. Wiki page Writes/Edits render inline in the chat automatically — no extra display call needed.\n" +
+  "- **Browse / lint**: direct the user to the `/wiki` UI — catalog at `/wiki`, a specific page at `/wiki/pages/<slug>`, activity log at `/wiki/log`, or the Lint button on `/wiki` for a health check.\n\n" +
+  "Page format: YAML frontmatter (title, created, updated, tags) + markdown body + `[[wiki links]]` for cross-references. Slugs are lowercase hyphen-separated. Always keep `data/wiki/index.md` current and append to `data/wiki/log.md` after any change. The page-list section of `index.md` is a flat, recency-ordered log: prepend new pages at the top, and when a page is updated (content, description, tags, or rename) move its entry to the top — don't group by category. The Tags section (if present) still needs its per-tag page lists updated on add / rename / delete, but the tag order itself is not reordered by recency. Read `config/helps/wiki.md` for full details.";
+
+const GENERAL_AVAILABLE_PLUGINS = [
+  // manageTodoList: runtime plugin (`@mulmoclaude/todo-plugin`,
+  // #1145) — runtime-loaded plugins are auto-included in every
+  // role's active tool set regardless of `availablePlugins`, so
+  // it doesn't need to be listed here.
+  TOOL_NAMES.manageCalendar,
+  TOOL_NAMES.presentDocument,
+  TOOL_NAMES.presentForm,
+  TOOL_NAMES.presentMulmoScript,
+  TOOL_NAMES.generateImage,
+  TOOL_NAMES.presentHtml,
+  TOOL_NAMES.readXPost,
+  TOOL_NAMES.searchX,
+  TOOL_NAMES.notify,
+] as const satisfies readonly ToolName[];
+
 export const ROLES: Role[] = [
   {
     id: "general",
     name: "General",
     icon: "star",
-    prompt:
-      "You are a helpful assistant with access to the user's workspace. Help with tasks, answer questions, and use available tools when appropriate.\n\n" +
-      "## Asking the user to choose\n\n" +
-      "When the user must pick from a small set of options, toggle features, or answer yes/no, call presentForm with the appropriate fields (radio for one-of, checkbox for many-of, text/textarea for free-form). Group related questions into one form. Prefer this strongly over phrasing the choice in plain prose — the form gives the user clickable controls and sends the answers back as a markdown bullet list.\n\n" +
-      "Mark every field the user must answer as `required: true`. The form blocks submission until required fields are filled, which prevents the LLM from receiving partial responses.\n\n" +
-      "## Wiki\n\n" +
-      "A personal knowledge wiki lives at `data/wiki/` in the workspace.\n\n" +
-      "- **Ingest**: fetch or read the source, save raw to `data/wiki/sources/<slug>.md`, create/update pages in `data/wiki/pages/`, update `data/wiki/index.md`, append to `data/wiki/log.md`. Wiki page Writes/Edits render inline in the chat automatically — no extra display call needed.\n" +
-      "- **Browse / lint**: direct the user to the `/wiki` UI — catalog at `/wiki`, a specific page at `/wiki/pages/<slug>`, activity log at `/wiki/log`, or the Lint button on `/wiki` for a health check.\n\n" +
-      "Page format: YAML frontmatter (title, created, updated, tags) + markdown body + `[[wiki links]]` for cross-references. Slugs are lowercase hyphen-separated. Always keep `data/wiki/index.md` current and append to `data/wiki/log.md` after any change. The page-list section of `index.md` is a flat, recency-ordered log: prepend new pages at the top, and when a page is updated (content, description, tags, or rename) move its entry to the top — don't group by category. The Tags section (if present) still needs its per-tag page lists updated on add / rename / delete, but the tag order itself is not reordered by recency. Read `config/helps/wiki.md` for full details.",
-    availablePlugins: [
-      // manageTodoList: runtime plugin (`@mulmoclaude/todo-plugin`,
-      // #1145) — runtime-loaded plugins are auto-included in every
-      // role's active tool set regardless of `availablePlugins`, so
-      // it doesn't need to be listed here.
-      TOOL_NAMES.manageCalendar,
-      TOOL_NAMES.presentDocument,
-      TOOL_NAMES.presentForm,
-      TOOL_NAMES.presentMulmoScript,
-      TOOL_NAMES.generateImage,
-      TOOL_NAMES.presentHtml,
-      TOOL_NAMES.readXPost,
-      TOOL_NAMES.searchX,
-      TOOL_NAMES.notify,
-    ],
+    prompt: GENERAL_PROMPT,
+    availablePlugins: [...GENERAL_AVAILABLE_PLUGINS],
     queries: [
       "Tell me about this app, MulmoClaude.",
       "What is the wiki in this app and how do I use it?",
@@ -261,6 +270,20 @@ export const ROLES: Role[] = [
       "I posted yesterday's rent entry to the wrong account — fix it",
     ],
   },
+  // Dev-only role. Only surfaced in the dropdown when `DEV_MODE=1`
+  // (gated client-side by `useSystemConfig`). Same prompt + plugins
+  // as General; PR 2 adds `_*` test-plugin tool names to this role's
+  // `availablePlugins` so the engineer testing the Notifier engine
+  // has a real plugin to drive without it leaking into user-facing
+  // roles.
+  {
+    id: "debug",
+    name: "Debug",
+    icon: "code",
+    prompt: GENERAL_PROMPT,
+    availablePlugins: [...GENERAL_AVAILABLE_PLUGINS],
+    queries: [],
+  },
 ];
 
 export const BUILTIN_ROLES = ROLES;
@@ -282,6 +305,7 @@ export const BUILTIN_ROLE_IDS = {
   storyteller: "storyteller",
   settings: "settings",
   accounting: "accounting",
+  debug: "debug",
 } as const;
 
 export type BuiltInRoleId = (typeof BUILTIN_ROLE_IDS)[keyof typeof BUILTIN_ROLE_IDS];

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_LOCALE?: "en" | "ja";
+  // Mirrored from `DEV_MODE` by vite.config.ts. "1" enables the
+  // Debug role; anything else is off. Read by `useSystemConfig` as
+  // the initial value before the runtime endpoint confirms.
+  readonly VITE_DEV_MODE?: "1" | "0";
 }
 
 interface ImportMeta {

--- a/test/composables/test_useRoles_filter.ts
+++ b/test/composables/test_useRoles_filter.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyDevModeFilter } from "../../src/composables/useRoles.ts";
+import { ROLES, BUILTIN_ROLE_IDS, type Role } from "../../src/config/roles.ts";
+
+describe("applyDevModeFilter", () => {
+  it("hides the Debug role when devMode is false", () => {
+    const filtered = applyDevModeFilter(ROLES, false);
+    const ids = filtered.map((role) => role.id);
+    assert.ok(!ids.includes(BUILTIN_ROLE_IDS.debug), `Debug role leaked into the dropdown when devMode=false: ${ids.join(", ")}`);
+  });
+
+  it("includes the Debug role when devMode is true", () => {
+    const filtered = applyDevModeFilter(ROLES, true);
+    const ids = filtered.map((role) => role.id);
+    assert.ok(ids.includes(BUILTIN_ROLE_IDS.debug), `Debug role missing when devMode=true: ${ids.join(", ")}`);
+  });
+
+  it("keeps every non-debug role intact when devMode is false", () => {
+    const filtered = applyDevModeFilter(ROLES, false);
+    const expected = ROLES.filter((role) => role.id !== BUILTIN_ROLE_IDS.debug).map((role) => role.id);
+    assert.deepEqual(
+      filtered.map((role) => role.id),
+      expected,
+    );
+  });
+
+  it("does not mutate the input array", () => {
+    const snapshot: Role[] = [...ROLES];
+    applyDevModeFilter(ROLES, false);
+    assert.deepEqual(ROLES, snapshot, "input was mutated");
+  });
+});

--- a/test/routes/test_systemRoute.ts
+++ b/test/routes/test_systemRoute.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Request, Response } from "express";
+import systemRouter from "../../server/api/routes/system.ts";
+import { env } from "../../server/system/env.ts";
+
+// Lightweight handler-extraction (same pattern as test_configRoute).
+// The route under test is a thin reader that returns
+// `{ devMode: env.devMode }` — we only need to confirm the response
+// shape and that the value tracks the env snapshot. The flag itself
+// is provided by `server/system/env.ts`, which is exercised by
+// existing env-coverage tests.
+
+type Handler = (req: Request, res: Response) => void;
+
+interface StackFrame {
+  route?: {
+    path: string;
+    stack: { method: string; handle: Handler }[];
+  };
+}
+
+interface RouterInternals {
+  stack: StackFrame[];
+}
+
+function extractHandler(routePath: string): Handler {
+  const router = systemRouter as unknown as RouterInternals;
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === "get");
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route GET ${routePath} not registered`);
+}
+
+function buildResMock(): { json: (body: unknown) => void; captured: { body: unknown } } {
+  const captured: { body: unknown } = { body: undefined };
+  return {
+    captured,
+    json(body: unknown) {
+      captured.body = body;
+    },
+  };
+}
+
+describe("GET /api/system/config", () => {
+  it("returns { devMode } reflecting env.devMode", () => {
+    const handler = extractHandler("/api/system/config");
+    const res = buildResMock();
+    handler({} as Request, res as unknown as Response);
+    assert.deepEqual(res.captured.body, { devMode: env.devMode });
+  });
+
+  it("response is JSON-serializable with a single boolean field", () => {
+    const handler = extractHandler("/api/system/config");
+    const res = buildResMock();
+    handler({} as Request, res as unknown as Response);
+    const body = res.captured.body as Record<string, unknown>;
+    assert.equal(typeof body.devMode, "boolean");
+    assert.deepEqual(Object.keys(body), ["devMode"]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import fs from 'node:fs'
@@ -108,7 +108,23 @@ function runtimeImportmapBuildPlugin(): Plugin {
   }
 }
 
-export default defineConfig({
+// Mirrors `DEV_MODE` from `.env` / `process.env` to a baked-in
+// `import.meta.env.VITE_DEV_MODE` so a single env line drives both
+// the server (`server/system/env.ts` → `env.devMode`) and the
+// client. PR 2 will use the compile-time form to tree-shake test
+// plugin imports out of production bundles; PR 1 just needs it for
+// the Debug role's initial visibility (the `/api/system/config`
+// endpoint then confirms / overrides at runtime).
+function readDevMode(mode: string): "1" | "0" {
+  const fromEnvFile = loadEnv(mode, process.cwd(), '').DEV_MODE
+  const raw = process.env.DEV_MODE ?? fromEnvFile
+  return raw === '1' ? '1' : '0'
+}
+
+export default defineConfig(({ mode }) => ({
+  define: {
+    'import.meta.env.VITE_DEV_MODE': JSON.stringify(readDevMode(mode)),
+  },
   plugins: [vue(), tailwindcss(), mulmoclaudeAuthTokenPlugin(), runtimeImportmapBuildPlugin()],
   build: {
     outDir: 'dist/client',
@@ -178,4 +194,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
## Summary

PR 1 of the [Encore plan](plans/feat-encore.md). Adds dev-mode infrastructure that future test plugins (first one: `_notifierTest` in PR 2) live behind. Same plugin set as General; the only difference is whether the role appears in the dropdown.

- **`DEV_MODE` env flag.** Server reads via \`env.devMode\` (\`server/system/env.ts\`); \`vite.config.ts\` mirrors to \`VITE_DEV_MODE\` so a single \`.env\` line drives both.
- **Debug role** in \`src/config/roles.ts\` — same prompt + plugin list as General, factored into shared consts so the two stay in lockstep.
- **\`/api/system/config\` endpoint** returning \`{ devMode }\`. Lightweight host-level runtime-config surface; future flags can join here without minting a new namespace per flag.
- **\`useSystemConfig\` composable** — reads \`VITE_DEV_MODE\` synchronously for first paint, then confirms via the runtime endpoint (handles the production case where the bundle is built before \`DEV_MODE\` is flipped server-side).
- **\`useRoles\` filters the Debug role** out unless \`devMode\` is true. Non-mutating; reactive to the runtime endpoint resolving.
- **Tests**: unit (\`applyDevModeFilter\`), route (\`GET /api/system/config\`), and E2E (\`debug-role.spec.ts\`) covering both off/on visibility paths. Default \`{ devMode: false }\` mock added to \`mockAllApis\` so existing E2E tests don't drift.

Acceptance bar from the plan: with no test plugins yet present, the Debug role appears (when enabled) with the same plugin set as General. ✓

## Test plan

- [x] \`yarn typecheck\`
- [x] \`yarn lint\`
- [x] \`yarn test\` (4163 tests, all pass)
- [x] \`yarn build\`
- [x] \`yarn test:e2e --grep "Debug role gate"\` (2 specs pass)
- [x] \`yarn test:e2e --grep "role|chat-flow|health"\` (19 adjacent specs pass — no regressions)
- [ ] Manual: with \`DEV_MODE=1\` in \`.env\` and \`yarn dev\`, confirm Debug appears in the role dropdown; without it, confirm it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dev-mode gated Debug role and shared role configuration, wired through new system config plumbing.

New Features:
- Add a Debug role mirroring the General role, gated by a DEV_MODE flag surfaced via system config.
- Expose a /api/system/config endpoint and useSystemConfig composable to provide runtime devMode configuration to the client.
- Mirror DEV_MODE to VITE_DEV_MODE in the Vite config to unify server and client dev-mode toggling.

Enhancements:
- Refactor General role prompt and plugin list into shared constants reused by both General and Debug roles.
- Make useRoles composable filter roles reactively based on devMode via applyDevModeFilter and system config.
- Extend API route configuration and server wiring to include the new system config endpoint.

Tests:
- Add unit, route, and E2E tests covering the system config endpoint and Debug role visibility, and update E2E API mocks to include default devMode config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Debug role that conditionally appears when development mode is enabled via the DEV_MODE environment variable.

* **Documentation**
  * Added DEV_MODE environment variable documentation describing its use in enabling debug UI features for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->