### PR TITLE
feat: dev-mode Debug role via VITE_DEV_MODE (PR 1 of feat-encore)

### DIFF
--- a/plans/feat-encore.md
+++ b/plans/feat-encore.md
@@ -409,35 +409,41 @@ The standalone route follows the existing pattern: route registered in `src/rout
 
 ## Phasing
 
-**Order of operations**: Dev-mode scaffolding ships first (PR 1), so the Notifier engine (PR 2) can ship with a real test plugin behind a Debug role rather than an HTTP-only harness or a test plugin that pollutes production roles. Encore (PRs 3 + 4) follows once the engine is proven.
+**Order of operations**: A tiny client-only dev-mode gate ships first (PR 1) so the Notifier engine (PR 2) can ship with a real test plugin behind a Debug role rather than an HTTP-only harness or a test plugin that pollutes production roles. Encore (PRs 3 + 4) follows once the engine is proven.
 
-### PR 1 — Dev mode + Debug role (host only, no Notifier, no Encore)
+### PR 1 — Dev mode + Debug role (client-only, ~25-line diff)
 
-A general-purpose dev-only role gate that any future test plugin can sit behind. Encore needs it; the Notifier test plugin in PR 2 is the first consumer; later infrastructure work (mock LLM provider, fake source fetcher, etc.) can reuse it.
+A minimal client-only dropdown gate. PR 2's `_notifierTest` plugin will sit on the same `VITE_DEV_MODE` flag, but the gating mechanism for *roles* lives entirely in the role schema + the dropdown component.
 
-**`DEV_MODE` env flag**:
+**Schema**:
 
-- New `.env` entry `DEV_MODE=1` (defaults `0`). Off in production.
-- Server-side: `server/system/env.ts` adds `devMode: asFlag(process.env.DEV_MODE)`.
-- Client-side: mirrored as `VITE_DEV_MODE` so test-plugin module imports tree-shake out of production bundles.
+- `src/config/roles.ts` — add optional `isDebugRole?: boolean` to `RoleSchema` and the inferred `Role` type. Existing custom roles in workspace files don't need to update — the field is optional.
 
 **Debug role**:
 
-- New entry in `src/config/roles.ts` (id `debug`, name `Debug`, icon `code`). Same prompt and same `availablePlugins` as `general`, plus any test-plugin tool names.
-- `RoleSelector.vue` filters the dropdown — Debug only renders when devMode is true. A new `useSystemConfig()` composable fetches a new lightweight `/api/system/config` endpoint (returning `{ devMode }`) once on boot.
+- New entry at the end of `ROLES` in `src/config/roles.ts`, copied verbatim from General with `isDebugRole: true` set. No factoring of shared prompt/plugin constants — the data is literal so each role stays independently editable.
 
-**Test-plugin convention**:
+**Visibility filter**:
 
-- Live under `src/plugins/_<name>/` — underscore prefix mirrors the existing `_extras.ts` / `_generated/` "non-user-facing" marker.
-- Tool names also underscore-prefixed: `_notifierTest`, `_<other>` later.
-- Registration in `src/plugins/metas.ts` wrapped in a `VITE_DEV_MODE`-guarded conditional so production builds don't ship them.
+- `src/components/RoleSelector.vue` adds a `visibleRoles = computed(...)` that filters out `isDebugRole` entries unless `import.meta.env.VITE_DEV_MODE === "1"`. The `v-for` iterates `visibleRoles`. That's the entire visible behavior change.
 
-**Test coverage**:
+**Env wiring**:
 
-- Unit: `useSystemConfig` returns `{ devMode: false }` when the endpoint reports false; role-list filter excludes Debug accordingly.
-- E2E: with `DEV_MODE=0`, Debug role absent from dropdown; with `DEV_MODE=1`, Debug appears with the General plugin set.
+- Set `VITE_DEV_MODE=1` in `.env`. Vite exposes `VITE_*` to client code by default — no `vite.config.ts` change needed.
+- `src/vite-env.d.ts` types `VITE_DEV_MODE?: "1" | "0"` for the typecheck.
 
-**Acceptance bar**: Debug role appears (when enabled) with the same plugin set as General, no test plugins yet — those land in PR 2 against this scaffold.
+**Out of scope intentionally** (rejected from earlier draft as overengineered for what is a single client-side gate):
+
+- No server-side `DEV_MODE` flag. The server doesn't filter roles in `/api/roles` (it returns custom roles only — built-ins flow client-only via the bundled `ROLES` constant), so there's nothing for the server to gate.
+- No `/api/system/config` endpoint. No runtime config to fetch — the flag is a compile-time constant.
+- No `useSystemConfig` composable. `import.meta.env.VITE_DEV_MODE` is read once where it's needed.
+- No filter inside `useRoles`. The dropdown is the only surface that needs filtering.
+- No `vite.config.ts` mirror plumbing. `VITE_*` is the convention; using `DEV_MODE=1` instead would force one extra `define` line for no real gain.
+- No factoring of `GENERAL_PROMPT` / `GENERAL_AVAILABLE_PLUGINS`. Debug holds a literal copy.
+
+Existing chat sessions tied to a debug role still render normally (icon, history, tabs) — only the dropdown hides Debug. If devMode is off and a user somehow has an active Debug session, it stays usable. New sessions in non-dev-mode simply can't pick the role.
+
+**Acceptance bar**: with `VITE_DEV_MODE=1`, Debug appears at the bottom of the role dropdown with General's plugin set; without it, Debug is absent. Total diff: ~25 lines across 3 files (`roles.ts`, `RoleSelector.vue`, `vite-env.d.ts`).
 
 ### PR 2 — Notifier engine + `_notifierTest` plugin (host only, no Encore)
 
@@ -475,22 +481,20 @@ Encore translates obligation + item state into `notifier.schedule()` calls. All 
 
 ## Open questions
 
-To resolve before PR 1 (Dev mode):
-
-1. **`VITE_DEV_MODE` synchronization with `DEV_MODE`.** Single source of truth in `.env` is preferable. Vite reads `.env` natively but only exposes `VITE_`-prefixed vars to the client. Either (a) require both `DEV_MODE=1` and `VITE_DEV_MODE=1`, (b) re-export at vite-config time, or (c) read server-side and surface only via `/api/system/config`. **Default: (b) — vite-config mirrors `DEV_MODE` to `VITE_DEV_MODE` so a single `.env` line drives both.**
+PR 1 resolved: client-only `VITE_DEV_MODE` flag, no server-side mirror, no runtime endpoint.
 
 To resolve before PR 2 (Notifier):
 
-2. **Declarative vs imperative scheduling.** Plan above is *imperative* — plugin computes each fire time and re-registers. A declarative spec ("every Sunday until acked, escalate after 2 weeks") is more powerful but a bigger surface. Imperative matches how `task-scheduler` already works; declarative may be worth it once we see 3+ plugins repeating the same pattern. **Default: imperative for v1.**
-3. **Type-1 panel affordance: button or checkbox?** Per-row close-button is simplest; leading checkbox + bulk "Acknowledge selected" wins for catch-up sessions where many `fyi` rows pile up. **Default: leading checkbox (covers both — single-row click still works via the row's own close-`×`).**
-4. **Severity → channel mapping config UI.** Hidden file (`config/notifier.json`) for v1, settings page later? Or settings page from day one? **Default: hidden file for v1, settings UI in a follow-up.**
-5. **Re-surface cap.** A reminder ignored for a week should not fire 50 times. Cap at `escalateAt.length` re-surfaces? Hard ceiling of N per 24h? **Default: re-surface only at the explicit `escalateAt` points; no auto-multiplication.**
-6. **Signal namespace.** `"encore:taxes:w2-received"` is the obvious shape, but signals are global. Risk of name collision across plugins. **Default: enforce `<pluginPkg>:` prefix at the Notifier API boundary.**
-7. **Conflict with `task-scheduler`.** The existing scheduler also fires things on a schedule. Notifier is *user-facing reminders*; scheduler is *task execution*. They may share scheduling primitives internally; they should not share API surfaces. **Default: keep them separate; revisit if duplication becomes painful.**
+1. **Declarative vs imperative scheduling.** Plan above is *imperative* — plugin computes each fire time and re-registers. A declarative spec ("every Sunday until acked, escalate after 2 weeks") is more powerful but a bigger surface. Imperative matches how `task-scheduler` already works; declarative may be worth it once we see 3+ plugins repeating the same pattern. **Default: imperative for v1.**
+2. **Type-1 panel affordance: button or checkbox?** Per-row close-button is simplest; leading checkbox + bulk "Acknowledge selected" wins for catch-up sessions where many `fyi` rows pile up. **Default: leading checkbox (covers both — single-row click still works via the row's own close-`×`).**
+3. **Severity → channel mapping config UI.** Hidden file (`config/notifier.json`) for v1, settings page later? Or settings page from day one? **Default: hidden file for v1, settings UI in a follow-up.**
+4. **Re-surface cap.** A reminder ignored for a week should not fire 50 times. Cap at `escalateAt.length` re-surfaces? Hard ceiling of N per 24h? **Default: re-surface only at the explicit `escalateAt` points; no auto-multiplication.**
+5. **Signal namespace.** `"encore:taxes:w2-received"` is the obvious shape, but signals are global. Risk of name collision across plugins. **Default: enforce `<pluginPkg>:` prefix at the Notifier API boundary.**
+6. **Conflict with `task-scheduler`.** The existing scheduler also fires things on a schedule. Notifier is *user-facing reminders*; scheduler is *task execution*. They may share scheduling primitives internally; they should not share API surfaces. **Default: keep them separate; revisit if duplication becomes painful.**
 
 To resolve before PR 3 (Encore CRUD):
 
-8. **i18n surface for Encore.** All 8 locales need the obligation-type vocabulary ("taxes", "registration", "annual physical"). Are these built-in templates the user picks from, or free-form titles the user types? **Default: free-form for v1, suggested templates as a chat-side affordance.**
+7. **i18n surface for Encore.** All 8 locales need the obligation-type vocabulary ("taxes", "registration", "annual physical"). Are these built-in templates the user picks from, or free-form titles the user types? **Default: free-form for v1, suggested templates as a chat-side affordance.**
 
 ---
 

--- a/src/components/RoleSelector.vue
+++ b/src/components/RoleSelector.vue
@@ -13,7 +13,7 @@
     </button>
     <div v-if="open" ref="dropdown" class="absolute left-0 right-0 top-full z-50 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden">
       <button
-        v-for="role in roles"
+        v-for="role in visibleRoles"
         :key="role.id"
         :data-testid="`role-option-${role.id}`"
         class="w-full flex items-center gap-1.5 px-3 py-1 text-sm text-gray-900 hover:bg-gray-50 text-left"
@@ -48,6 +48,16 @@ const button = ref<HTMLButtonElement | null>(null);
 const dropdown = ref<HTMLDivElement | null>(null);
 
 const currentRoleName = computed(() => roleName(props.roles, props.currentRoleId));
+
+// Hide `isDebugRole` entries from the dropdown unless dev mode is
+// on. Set `VITE_DEV_MODE=1` in `.env` to surface them. Existing
+// chat sessions tied to a debug role still render normally elsewhere
+// — this filter only gates the entry point for new sessions.
+const visibleRoles = computed(() => {
+  const devMode = import.meta.env.VITE_DEV_MODE === "1";
+  if (devMode) return props.roles;
+  return props.roles.filter((role) => !role.isDebugRole);
+});
 
 function selectRole(roleId: string): void {
   emit("update:currentRoleId", roleId);

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -28,6 +28,7 @@ export const RoleSchema = z.object({
   prompt: z.string(),
   availablePlugins: availablePluginsSchema,
   queries: z.array(z.string()).optional(),
+  isDebugRole: z.boolean().optional(),
 });
 
 export type Role = z.infer<typeof RoleSchema>;
@@ -261,6 +262,44 @@ export const ROLES: Role[] = [
       "I posted yesterday's rent entry to the wrong account — fix it",
     ],
   },
+  {
+    id: "debug",
+    name: "Debug",
+    icon: "star",
+    prompt:
+      "You are a helpful assistant with access to the user's workspace. Help with tasks, answer questions, and use available tools when appropriate.\n\n" +
+      "## Asking the user to choose\n\n" +
+      "When the user must pick from a small set of options, toggle features, or answer yes/no, call presentForm with the appropriate fields (radio for one-of, checkbox for many-of, text/textarea for free-form). Group related questions into one form. Prefer this strongly over phrasing the choice in plain prose — the form gives the user clickable controls and sends the answers back as a markdown bullet list.\n\n" +
+      "Mark every field the user must answer as `required: true`. The form blocks submission until required fields are filled, which prevents the LLM from receiving partial responses.\n\n" +
+      "## Wiki\n\n" +
+      "A personal knowledge wiki lives at `data/wiki/` in the workspace.\n\n" +
+      "- **Ingest**: fetch or read the source, save raw to `data/wiki/sources/<slug>.md`, create/update pages in `data/wiki/pages/`, update `data/wiki/index.md`, append to `data/wiki/log.md`. Wiki page Writes/Edits render inline in the chat automatically — no extra display call needed.\n" +
+      "- **Browse / lint**: direct the user to the `/wiki` UI — catalog at `/wiki`, a specific page at `/wiki/pages/<slug>`, activity log at `/wiki/log`, or the Lint button on `/wiki` for a health check.\n\n" +
+      "Page format: YAML frontmatter (title, created, updated, tags) + markdown body + `[[wiki links]]` for cross-references. Slugs are lowercase hyphen-separated. Always keep `data/wiki/index.md` current and append to `data/wiki/log.md` after any change. The page-list section of `index.md` is a flat, recency-ordered log: prepend new pages at the top, and when a page is updated (content, description, tags, or rename) move its entry to the top — don't group by category. The Tags section (if present) still needs its per-tag page lists updated on add / rename / delete, but the tag order itself is not reordered by recency. Read `config/helps/wiki.md` for full details.",
+    availablePlugins: [
+      TOOL_NAMES.manageCalendar,
+      TOOL_NAMES.presentDocument,
+      TOOL_NAMES.presentForm,
+      TOOL_NAMES.presentMulmoScript,
+      TOOL_NAMES.generateImage,
+      TOOL_NAMES.presentHtml,
+      TOOL_NAMES.readXPost,
+      TOOL_NAMES.searchX,
+      TOOL_NAMES.notify,
+    ],
+    queries: [
+      "Tell me about this app, MulmoClaude.",
+      "What is the wiki in this app and how do I use it?",
+      "Tell me about the sandbox feature of this app.",
+      "What is the role of the Gemini API key in this app?",
+      "How do I use the Telegram bridge to talk to MulmoClaude from my phone?",
+      "Show my wiki index",
+      "Lint my wiki",
+      "Show my todo list",
+      "Show me my calendar",
+    ],
+    isDebugRole: true,
+  },
 ];
 
 export const BUILTIN_ROLES = ROLES;
@@ -282,6 +321,7 @@ export const BUILTIN_ROLE_IDS = {
   storyteller: "storyteller",
   settings: "settings",
   accounting: "accounting",
+  debug: "debug",
 } as const;
 
 export type BuiltInRoleId = (typeof BUILTIN_ROLE_IDS)[keyof typeof BUILTIN_ROLE_IDS];

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,9 @@
 
 interface ImportMetaEnv {
   readonly VITE_LOCALE?: "en" | "ja";
+  // Set `VITE_DEV_MODE=1` in `.env` to surface `isDebugRole` roles
+  // in the dropdown. Anything else (including unset) hides them.
+  readonly VITE_DEV_MODE?: "1" | "0";
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

PR 1 of the [Encore plan](plans/feat-encore.md). Minimal client-only dropdown gate for dev-only roles. Total diff: ~85 lines, but the *behavior* change is ~25 lines across 3 files — the rest is the plan-doc rewrite.

- **`Role.isDebugRole?: boolean`** added to the role schema.
- **Debug role** appended to `ROLES` — literal copy of General with `isDebugRole: true`.
- **`RoleSelector.vue`** filters `isDebugRole` entries out unless `import.meta.env.VITE_DEV_MODE === "1"`.
- **`vite-env.d.ts`** types the flag.
- **`BUILTIN_ROLE_IDS`** keeps `debug` in sync (enforced by `test/roles/test_builtin_role_ids.ts`).

Set `VITE_DEV_MODE=1` in `.env` to surface the role.

## What was rejected from the earlier overengineered draft

The plan now documents these explicit non-goals:

- No server-side `DEV_MODE` flag — server doesn't filter roles in `/api/roles` (built-ins flow client-only).
- No `/api/system/config` endpoint — there's no runtime config to fetch.
- No `useSystemConfig` composable — `import.meta.env.VITE_DEV_MODE` is a compile-time read.
- No filter inside `useRoles` — the dropdown is the only surface.
- No `vite.config.ts` mirror plumbing — `VITE_*` is the Vite convention.
- No factoring of `GENERAL_PROMPT` / `GENERAL_AVAILABLE_PLUGINS` — Debug holds a literal copy.

Existing chat sessions tied to a debug role still render normally (icon, history, tabs) — only the dropdown hides Debug. New sessions in non-dev-mode simply can't pick the role.

## Test plan

- [x] `yarn format`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (all pass)
- [x] `yarn build`
- [ ] Manual: set `VITE_DEV_MODE=1` in `.env`, restart `yarn dev`, confirm Debug appears at the bottom of the role dropdown. Remove the line, restart, confirm it disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a client-only dev-mode gate that hides a new Debug role from the role dropdown unless enabled via VITE_DEV_MODE.

New Features:
- Add an optional isDebugRole flag to the role schema and introduce a built-in Debug role mirroring the General role’s behavior.
- Gate visibility of debug roles in the RoleSelector dropdown based on the VITE_DEV_MODE environment flag.
- Declare the VITE_DEV_MODE environment variable in vite-env.d.ts for typed access in client code.

Enhancements:
- Update the Encore feature plan documentation to reflect the simplified client-only dev-mode approach and resolved design decisions around VITE_DEV_MODE.