### PR TITLE
feat(reading-list): in-tree plugin for personal reading list (#1188)

### DIFF
--- a/packages/reading-list-plugin/eslint.config.mjs
+++ b/packages/reading-list-plugin/eslint.config.mjs
@@ -1,0 +1,25 @@
+// Plugin-author ESLint config — extends the gui-chat-protocol preset
+// to ban `node:fs` / `node:path` / `console` / direct `fetch` so any
+// platform bypass shows up at lint time.
+
+import tseslint from "typescript-eslint";
+import vueParser from "vue-eslint-parser";
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  {
+    files: ["src/**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: { parser: tseslint.parser, ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  ...pluginPreset.map((entry) => ({ ...entry, files: ["src/**/*.{ts,vue}"] })),
+];

--- a/packages/reading-list-plugin/package.json
+++ b/packages/reading-list-plugin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@mulmoclaude/reading-list-plugin",
+  "version": "0.1.0",
+  "description": "Personal reading list runtime plugin for MulmoClaude — saves books as markdown-per-file with frontmatter (status, rating, dates, tags) and a notes body. PR-A of #1169 My Library.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js",
+      "require": "./dist/vue.js",
+      "default": "./dist/vue.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_reading_list_integration.ts'"
+  },
+  "peerDependencies": {
+    "gui-chat-protocol": "^0.3.0",
+    "vue": "^3.5.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vite-plugin-dts": "^4.5.4",
+    "vue": "^3.5.27",
+    "zod": "^3.23.0"
+  },
+  "license": "MIT"
+}

--- a/packages/reading-list-plugin/src/View.vue
+++ b/packages/reading-list-plugin/src/View.vue
@@ -1,0 +1,504 @@
+<script setup lang="ts">
+// Reading-list plugin View — renders inside the host's canvas via the
+// runtime plugin loader. Two-pane layout: list on the left, detail
+// (rendered markdown notes) on the right. Subscribes to the plugin's
+// "changed" channel so multi-tab views stay in sync.
+
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import { useT, format } from "./lang";
+
+type ReadingStatus = "want" | "reading" | "read" | "abandoned";
+
+interface BookSummary {
+  slug: string;
+  title: string;
+  author: string;
+  status: ReadingStatus;
+  rating: number | null;
+  tags: string[];
+  updated: string;
+}
+
+interface BookDetail extends BookSummary {
+  isbn: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  created: string;
+  body: string;
+}
+
+// Tool-result shape the host hands us. After list / save / update we
+// get a `books[]`; after delete we get just `{ ok, slug }`. The View
+// always re-fetches via dispatch on mount so the pane stays current
+// regardless of which action triggered it.
+export interface Props {
+  selectedResult: { books?: BookSummary[]; book?: BookSummary };
+}
+const props = defineProps<Props>();
+
+const { pubsub, dispatch, log } = useRuntime();
+const t = useT();
+
+const books = ref<BookSummary[]>(props.selectedResult.books ?? []);
+const selectedSlug = ref<string | null>(books.value[0]?.slug ?? null);
+const detail = ref<BookDetail | null>(null);
+const detailLoading = ref(false);
+const detailError = ref<string | null>(null);
+const deleting = ref(false);
+
+const selected = computed(() => books.value.find((book) => book.slug === selectedSlug.value) ?? null);
+
+const renderedBody = computed(() => {
+  const body = detail.value?.body;
+  if (!body) return "";
+  return renderMarkdownLite(body);
+});
+
+function statusLabel(status: ReadingStatus): string {
+  return t.value.status[status];
+}
+
+// Mirror new tool results (e.g. after the LLM saves a new book).
+watch(
+  () => props.selectedResult.books,
+  (next) => {
+    if (next) {
+      books.value = next;
+      if (!selectedSlug.value || !next.find((book) => book.slug === selectedSlug.value)) {
+        selectedSlug.value = next[0]?.slug ?? null;
+      }
+    }
+  },
+);
+
+async function refetchList(): Promise<void> {
+  try {
+    const json = await dispatch<{ ok: boolean; books?: BookSummary[] }>({ kind: "list" });
+    if (json.ok && json.books) {
+      books.value = json.books;
+      if (!selectedSlug.value || !json.books.find((book) => book.slug === selectedSlug.value)) {
+        selectedSlug.value = json.books[0]?.slug ?? null;
+      }
+    }
+  } catch (err) {
+    log.warn("refetchList failed", { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+watch(
+  selectedSlug,
+  async (slug) => {
+    if (!slug) {
+      detail.value = null;
+      return;
+    }
+    detailLoading.value = true;
+    detailError.value = null;
+    try {
+      const result = await dispatch<{ ok: boolean; book?: BookDetail; error?: string }>({ kind: "read", slug });
+      if (selectedSlug.value !== slug) return;
+      if (result.ok && result.book) {
+        detail.value = result.book;
+      } else {
+        detailError.value = result.error ?? `book not found: ${slug}`;
+        detail.value = null;
+      }
+    } catch (err) {
+      if (selectedSlug.value !== slug) return;
+      detailError.value = err instanceof Error ? err.message : String(err);
+      detail.value = null;
+    }
+    if (selectedSlug.value === slug) detailLoading.value = false;
+  },
+  { immediate: true },
+);
+
+async function deleteBook(): Promise<void> {
+  if (!detail.value) return;
+  const { slug, title } = detail.value;
+  if (!window.confirm(format(t.value.confirmDelete, { title }))) return;
+  deleting.value = true;
+  try {
+    await dispatch({ kind: "delete", slug });
+  } catch (err) {
+    log.warn("delete failed", { slug, error: err instanceof Error ? err.message : String(err) });
+  }
+  deleting.value = false;
+  // The "changed" pubsub event will trigger refetchList, which removes
+  // the deleted slug from the list and advances the selection.
+}
+
+const unsubs: (() => void)[] = [];
+onMounted(() => {
+  unsubs.push(pubsub.subscribe("changed", () => void refetchList()));
+  void refetchList();
+});
+onUnmounted(() => {
+  for (const unsub of unsubs) unsub();
+});
+
+// Tiny markdown subset: headings, paragraphs, bullet / numbered
+// lists, **bold**, *em*. Avoids pulling in a markdown library to
+// keep the plugin bundle small. Anything else renders as plain text.
+function renderMarkdownLite(input: string): string {
+  const escaped = input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const lines = escaped.split(/\r?\n/);
+  const out: string[] = [];
+  let inUl = false;
+  let inOl = false;
+  let buffer: string[] = [];
+  const flushPara = (): void => {
+    if (buffer.length === 0) return;
+    out.push(`<p>${buffer.join(" ")}</p>`);
+    buffer = [];
+  };
+  const closeLists = (): void => {
+    if (inUl) {
+      out.push("</ul>");
+      inUl = false;
+    }
+    if (inOl) {
+      out.push("</ol>");
+      inOl = false;
+    }
+  };
+  for (const line of lines) {
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      flushPara();
+      closeLists();
+      const level = heading[1].length;
+      out.push(`<h${level}>${formatInline(heading[2])}</h${level}>`);
+      continue;
+    }
+    const ul = line.match(/^[-*]\s+(.+)$/);
+    if (ul) {
+      flushPara();
+      if (inOl) {
+        out.push("</ol>");
+        inOl = false;
+      }
+      if (!inUl) {
+        out.push("<ul>");
+        inUl = true;
+      }
+      out.push(`<li>${formatInline(ul[1])}</li>`);
+      continue;
+    }
+    const ol = line.match(/^\d+\.\s+(.+)$/);
+    if (ol) {
+      flushPara();
+      if (inUl) {
+        out.push("</ul>");
+        inUl = false;
+      }
+      if (!inOl) {
+        out.push("<ol>");
+        inOl = true;
+      }
+      out.push(`<li>${formatInline(ol[1])}</li>`);
+      continue;
+    }
+    if (line.trim().length === 0) {
+      flushPara();
+      closeLists();
+      continue;
+    }
+    buffer.push(formatInline(line));
+  }
+  flushPara();
+  closeLists();
+  return out.join("\n");
+}
+
+function formatInline(input: string): string {
+  return input.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>").replace(/\*([^*]+)\*/g, "<em>$1</em>");
+}
+</script>
+
+<template>
+  <div class="books-view">
+    <header class="books-header">
+      <h2 class="books-title">
+        {{ t.title }} <span class="books-count">({{ books.length }} {{ t.countSuffix }})</span>
+      </h2>
+    </header>
+
+    <div class="books-body">
+      <ul class="books-list" :aria-label="t.title">
+        <li v-for="book in books" :key="book.slug">
+          <button
+            type="button"
+            class="books-list-row"
+            :class="{ 'is-active': selectedSlug === book.slug }"
+            :aria-current="selectedSlug === book.slug ? 'true' : undefined"
+            @click="selectedSlug = book.slug"
+          >
+            <span class="books-list-title">{{ book.title }}</span>
+            <span class="books-list-author">{{ book.author }}</span>
+            <span class="books-list-meta">
+              <span class="books-list-status" :data-status="book.status">{{ statusLabel(book.status) }}</span>
+              <span v-if="book.rating !== null" class="books-list-rating">★ {{ book.rating }}</span>
+              <span v-if="book.tags.length > 0" class="books-list-tags">{{ book.tags.join(" · ") }}</span>
+            </span>
+          </button>
+        </li>
+        <li v-if="books.length === 0" class="books-empty">{{ t.empty }}</li>
+      </ul>
+
+      <section class="books-detail">
+        <p v-if="!selected" class="books-detail-hint">{{ t.selectHint }}</p>
+        <template v-else>
+          <div class="books-detail-head">
+            <div class="books-detail-meta">
+              <h3 class="books-detail-title">{{ selected.title }}</h3>
+              <div class="books-detail-author">{{ selected.author }}</div>
+              <div class="books-detail-chips">
+                <span class="books-detail-status" :data-status="selected.status">{{ format(t.statusLabel, { status: statusLabel(selected.status) }) }}</span>
+                <span v-if="detail && detail.rating !== null">{{ format(t.ratingLabel, { rating: detail.rating }) }}</span>
+                <span v-if="detail && detail.startedAt">{{ format(t.startedLabel, { date: detail.startedAt }) }}</span>
+                <span v-if="detail && detail.finishedAt">{{ format(t.finishedLabel, { date: detail.finishedAt }) }}</span>
+              </div>
+              <div v-if="detail && detail.tags.length > 0" class="books-detail-tags">
+                <span v-for="tag in detail.tags" :key="tag" class="books-detail-tag">{{ tag }}</span>
+              </div>
+            </div>
+            <div class="books-detail-actions">
+              <button type="button" class="books-delete" :disabled="detailLoading || deleting" @click="deleteBook">{{ t.delete }}</button>
+            </div>
+          </div>
+          <p v-if="detailError" class="books-detail-error">{{ detailError }}</p>
+          <!-- eslint-disable-next-line vue/no-v-html -- renderMarkdownLite escapes raw input first, so the HTML never carries user-provided unescaped markup -->
+          <div v-else-if="detail && renderedBody" class="books-detail-body" v-html="renderedBody"></div>
+          <p v-else class="books-detail-empty">{{ t.emptyBody }}</p>
+        </template>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.books-view {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: white;
+}
+.books-header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+.books-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+}
+.books-count {
+  color: #6b7280;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-left: 0.5rem;
+}
+.books-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+.books-list {
+  flex: 0 0 18rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-right: 1px solid #f3f4f6;
+  overflow-y: auto;
+  background: #fafafa;
+}
+.books-list-row {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.625rem 1rem;
+  border: none;
+  border-bottom: 1px solid #f3f4f6;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+.books-list-row:hover {
+  background: white;
+}
+.books-list-row:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+}
+.books-list-row.is-active {
+  background: white;
+  box-shadow: inset 2px 0 0 0 #3b82f6;
+}
+.books-list-title {
+  font-weight: 500;
+  color: #1f2937;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.books-list-author {
+  font-size: 0.8125rem;
+  color: #4b5563;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.books-list-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+.books-list-status {
+  font-weight: 500;
+}
+.books-list-status[data-status="reading"] {
+  color: #2563eb;
+}
+.books-list-status[data-status="read"] {
+  color: #059669;
+}
+.books-list-status[data-status="abandoned"] {
+  color: #9ca3af;
+}
+.books-list-rating {
+  color: #d97706;
+}
+.books-list-tags {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.books-empty {
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: #9ca3af;
+  font-style: italic;
+}
+.books-detail {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+.books-detail-hint {
+  color: #9ca3af;
+  font-style: italic;
+  font-size: 0.875rem;
+}
+.books-detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.books-detail-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+  color: #1f2937;
+}
+.books-detail-author {
+  font-size: 0.9375rem;
+  color: #4b5563;
+  margin-bottom: 0.5rem;
+}
+.books-detail-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+.books-detail-status[data-status="reading"] {
+  color: #2563eb;
+}
+.books-detail-status[data-status="read"] {
+  color: #059669;
+}
+.books-detail-status[data-status="abandoned"] {
+  color: #9ca3af;
+}
+.books-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+.books-detail-tag {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background: #f3f4f6;
+  color: #4b5563;
+}
+.books-detail-actions {
+  flex-shrink: 0;
+}
+.books-delete {
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #fca5a5;
+  background: white;
+  color: #dc2626;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+.books-delete:hover:not(:disabled) {
+  background: #fef2f2;
+}
+.books-delete:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.books-detail-error {
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+.books-detail-body {
+  color: #374151;
+  line-height: 1.6;
+}
+.books-detail-body :deep(h2) {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  margin: 1.25rem 0 0.5rem;
+  color: #1f2937;
+}
+.books-detail-body :deep(h3) {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+  color: #1f2937;
+}
+.books-detail-body :deep(ul),
+.books-detail-body :deep(ol) {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+.books-detail-body :deep(li) {
+  margin: 0.25rem 0;
+}
+.books-detail-body :deep(p) {
+  margin: 0.5rem 0;
+}
+.books-detail-empty {
+  color: #9ca3af;
+  font-style: italic;
+}
+</style>

--- a/packages/reading-list-plugin/src/definition.ts
+++ b/packages/reading-list-plugin/src/definition.ts
@@ -1,0 +1,68 @@
+// Tool schema. Lives in its own module so both the server entry
+// (`index.ts`) and the browser entry (`vue.ts`) can import it without
+// dragging in the factory body, Zod, or any other server-only code.
+//
+// `name: "manageReadingList" as const` narrows the literal so
+// `definePlugin`'s `PluginFactoryResult<N>` requires a handler exported
+// under exactly this key.
+
+export const TOOL_DEFINITION = {
+  type: "function" as const,
+  name: "manageReadingList" as const,
+  description:
+    "List, save, update, or delete entries in the user's personal reading list. Each book lives as one markdown file with structured YAML frontmatter (title, author, isbn, status, rating, startedAt, finishedAt, tags) plus a free-form markdown body for notes, quotes, or takeaways.",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      kind: {
+        type: "string",
+        enum: ["list", "read", "save", "update", "delete"],
+        description: "Operation to perform. Default: list. Use `read` to fetch one book's full body + frontmatter by slug.",
+      },
+      slug: {
+        type: "string",
+        description:
+          "Book slug (filename). Required for read / save / update / delete. Lowercase ASCII letters, digits, and hyphens; 1-64 chars; no leading/trailing/consecutive hyphens.",
+      },
+      title: {
+        type: "string",
+        description: "Display title (any unicode). Required for save and update.",
+      },
+      author: {
+        type: "string",
+        description: "Author or authors (free-form, comma-separated when multiple). Required for save and update.",
+      },
+      isbn: {
+        type: "string",
+        description: "ISBN-10 or ISBN-13 (digits only or with hyphens). Optional.",
+      },
+      status: {
+        type: "string",
+        enum: ["want", "reading", "read", "abandoned"],
+        description: "Reading status. Defaults to `want` on save when omitted.",
+      },
+      rating: {
+        type: "integer",
+        description: "User's rating, 1-5 stars. Optional.",
+      },
+      startedAt: {
+        type: "string",
+        description: "Date the user started the book (ISO 8601 date `YYYY-MM-DD` or full timestamp). Optional.",
+      },
+      finishedAt: {
+        type: "string",
+        description: "Date the user finished the book. Optional.",
+      },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        description: "Free-form tags (genre, theme, recommended-by, …). Optional.",
+      },
+      body: {
+        type: "string",
+        description: "Markdown body of the entry — notes, quotes, takeaways. Optional; defaults to empty on save.",
+      },
+    },
+    required: ["kind"],
+  },
+};

--- a/packages/reading-list-plugin/src/index.ts
+++ b/packages/reading-list-plugin/src/index.ts
@@ -1,0 +1,372 @@
+// Reading-list plugin — server side (#1188 / #1169 PR-A My Library).
+//
+// Mirrors recipe-book-plugin (#1175 / #1183) — markdown-per-record
+// storage on the v0.3 runtime API:
+//   - definePlugin factory with destructured runtime (files, pubsub, log)
+//   - files.data hosts one `.md` per book with YAML frontmatter
+//   - readDir + per-file read for the list endpoint
+//   - pubsub.publish("changed", ...) on every mutation so multi-tab
+//     views auto-refresh
+//   - Zod-discriminated args + exhaustive switch with `default: never`
+//
+// `node:fs` / `node:path` / `console` / direct `fetch` are unused —
+// the gui-chat-protocol eslint preset bans them at lint time.
+
+import { definePlugin } from "gui-chat-protocol";
+import { z } from "zod";
+import { TOOL_DEFINITION } from "./definition";
+
+export { TOOL_DEFINITION };
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const isValidSlug = (raw: string): boolean => raw.length > 0 && raw.length <= 64 && SLUG_RE.test(raw);
+
+const BOOKS_DIR = "books";
+const FRONTMATTER_OPEN = /^---\r?\n/;
+const FRONTMATTER_CLOSE = /(?:^|\r?\n)---\s*(?:\r?\n|$)/;
+
+const READING_STATUSES = ["want", "reading", "read", "abandoned"] as const;
+type ReadingStatus = (typeof READING_STATUSES)[number];
+
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("list") }),
+  z.object({ kind: z.literal("read"), slug: z.string() }),
+  z.object({
+    kind: z.literal("save"),
+    slug: z.string(),
+    title: z.string(),
+    author: z.string(),
+    isbn: z.string().optional(),
+    status: z.enum(READING_STATUSES).optional(),
+    rating: z.number().int().min(1).max(5).optional(),
+    startedAt: z.string().optional(),
+    finishedAt: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    body: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("update"),
+    slug: z.string(),
+    title: z.string(),
+    author: z.string(),
+    isbn: z.string().optional(),
+    status: z.enum(READING_STATUSES).optional(),
+    rating: z.number().int().min(1).max(5).optional(),
+    startedAt: z.string().optional(),
+    finishedAt: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    body: z.string().optional(),
+  }),
+  z.object({ kind: z.literal("delete"), slug: z.string() }),
+]);
+
+interface Book {
+  slug: string;
+  title: string;
+  author: string;
+  isbn: string | null;
+  status: ReadingStatus;
+  rating: number | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  tags: string[];
+  created: string;
+  updated: string;
+  body: string;
+}
+
+type BookSummary = Pick<Book, "slug" | "title" | "author" | "status" | "rating" | "tags" | "updated">;
+
+function escapeYamlScalar(value: string): string {
+  const oneLine = value.replace(/\r?\n/g, " ").trim();
+  const needsQuoting = /[:#'"\\[\]{}>|`*&!%@?]/.test(oneLine) || /^\s|\s$/.test(oneLine) || /^(true|false|null|~|yes|no|on|off)$/i.test(oneLine);
+  return needsQuoting ? JSON.stringify(oneLine) : oneLine;
+}
+
+function serialise(book: Book): string {
+  const lines = ["---", `title: ${escapeYamlScalar(book.title)}`, `author: ${escapeYamlScalar(book.author)}`];
+  if (book.isbn !== null) lines.push(`isbn: ${escapeYamlScalar(book.isbn)}`);
+  lines.push(`status: ${book.status}`);
+  if (book.rating !== null) lines.push(`rating: ${book.rating}`);
+  if (book.startedAt !== null) lines.push(`startedAt: ${escapeYamlScalar(book.startedAt)}`);
+  if (book.finishedAt !== null) lines.push(`finishedAt: ${escapeYamlScalar(book.finishedAt)}`);
+  if (book.tags.length > 0) {
+    lines.push("tags:");
+    for (const tag of book.tags) lines.push(`  - ${escapeYamlScalar(tag)}`);
+  }
+  lines.push(`created: ${escapeYamlScalar(book.created)}`);
+  lines.push(`updated: ${escapeYamlScalar(book.updated)}`);
+  lines.push("---", "", book.body.trimEnd(), "");
+  return lines.join("\n");
+}
+
+// Tiny line-by-line frontmatter reader. We only use a handful of
+// keys, all scalar except `tags`, so a YAML library would be
+// overkill (and adds a dep the plugin doesn't otherwise need).
+function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } | null {
+  if (!FRONTMATTER_OPEN.test(raw)) return null;
+  const afterOpen = raw.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = FRONTMATTER_CLOSE.exec(afterOpen);
+  if (!closeMatch || closeMatch.index === undefined) return null;
+  const yamlText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+  const meta: Record<string, string | string[]> = {};
+  let currentArrayKey: string | null = null;
+  for (const line of yamlText.split(/\r?\n/)) {
+    if (line.length === 0) continue;
+    const arrayItem = line.match(/^\s+-\s+(.*)$/);
+    if (arrayItem && currentArrayKey) {
+      const arr = meta[currentArrayKey];
+      if (Array.isArray(arr)) arr.push(unquote(arrayItem[1]));
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!kv) continue;
+    const [, key, valueRaw] = kv;
+    if (valueRaw === "") {
+      meta[key] = [];
+      currentArrayKey = key;
+    } else {
+      meta[key] = unquote(valueRaw);
+      currentArrayKey = null;
+    }
+  }
+  return { meta, body };
+}
+
+function unquote(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value.trim();
+}
+
+function metaInt(meta: Record<string, unknown>, key: string): number | null {
+  const raw = meta[key];
+  if (typeof raw !== "string") return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function metaTags(meta: Record<string, unknown>): string[] {
+  const raw = meta.tags;
+  if (Array.isArray(raw)) return raw.filter((entry): entry is string => typeof entry === "string");
+  return [];
+}
+
+function metaStatus(meta: Record<string, unknown>): ReadingStatus {
+  const raw = meta.status;
+  if (typeof raw === "string" && (READING_STATUSES as readonly string[]).includes(raw)) {
+    return raw as ReadingStatus;
+  }
+  return "want";
+}
+
+function metaString(meta: Record<string, unknown>, key: string): string | null {
+  const raw = meta[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+function deserialise(slug: string, raw: string): Book | null {
+  const parsed = parseFrontmatter(raw);
+  if (!parsed) return null;
+  const title = typeof parsed.meta.title === "string" ? parsed.meta.title : "";
+  if (title.length === 0) return null;
+  const author = typeof parsed.meta.author === "string" ? parsed.meta.author : "";
+  const created = typeof parsed.meta.created === "string" ? parsed.meta.created : "";
+  const updated = typeof parsed.meta.updated === "string" ? parsed.meta.updated : created;
+  return {
+    slug,
+    title,
+    author,
+    isbn: metaString(parsed.meta, "isbn"),
+    status: metaStatus(parsed.meta),
+    rating: metaInt(parsed.meta, "rating"),
+    startedAt: metaString(parsed.meta, "startedAt"),
+    finishedAt: metaString(parsed.meta, "finishedAt"),
+    tags: metaTags(parsed.meta),
+    created,
+    updated,
+    body: parsed.body,
+  };
+}
+
+function bookPath(slug: string): string {
+  return `${BOOKS_DIR}/${slug}.md`;
+}
+
+function summarise(book: Book): BookSummary {
+  return {
+    slug: book.slug,
+    title: book.title,
+    author: book.author,
+    status: book.status,
+    rating: book.rating,
+    tags: book.tags,
+    updated: book.updated,
+  };
+}
+
+export default definePlugin(({ pubsub, files, log }) => {
+  // Serialise read-modify-write through a per-plugin promise chain so
+  // two parallel save / update / delete calls can't race the on-disk
+  // state. Same pattern as bookmarks-plugin / recipe-book-plugin.
+  let writeLock: Promise<unknown> = Promise.resolve();
+  function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = writeLock.catch(() => undefined).then(fn);
+    writeLock = next.catch(() => undefined);
+    return next;
+  }
+
+  async function readBook(slug: string): Promise<Book | null> {
+    if (!isValidSlug(slug)) return null;
+    if (!(await files.data.exists(bookPath(slug)))) return null;
+    const raw = await files.data.read(bookPath(slug));
+    return deserialise(slug, raw);
+  }
+
+  async function listBooks(): Promise<Book[]> {
+    if (!(await files.data.exists(BOOKS_DIR))) return [];
+    const entries = await files.data.readDir(BOOKS_DIR);
+    const out: Book[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const slug = entry.slice(0, -".md".length);
+      if (!isValidSlug(slug)) continue;
+      const raw = await files.data.read(`${BOOKS_DIR}/${entry}`);
+      const book = deserialise(slug, raw);
+      if (book) out.push(book);
+    }
+    // Sort by `updated` desc — most-recently-touched at the top, the
+    // shape the View wants for a "what am I reading right now" feel.
+    out.sort((left, right) => right.updated.localeCompare(left.updated));
+    return out;
+  }
+
+  async function publishChanged(): Promise<void> {
+    pubsub.publish("changed", { at: new Date().toISOString() });
+  }
+
+  return {
+    TOOL_DEFINITION,
+
+    async manageReadingList(rawArgs: unknown) {
+      const args = Args.parse(rawArgs);
+
+      switch (args.kind) {
+        case "list": {
+          const books = await listBooks();
+          return { ok: true, books: books.map(summarise) };
+        }
+
+        case "read": {
+          if (!isValidSlug(args.slug)) {
+            return { ok: false, error: "invalid_slug", slug: args.slug };
+          }
+          const book = await readBook(args.slug);
+          if (!book) return { ok: false, error: "not_found", slug: args.slug };
+          return { ok: true, book };
+        }
+
+        case "save": {
+          if (!isValidSlug(args.slug)) {
+            return { ok: false, error: "invalid_slug", slug: args.slug };
+          }
+          if (args.title.trim().length === 0) {
+            return { ok: false, error: "missing_title" };
+          }
+          if (args.author.trim().length === 0) {
+            return { ok: false, error: "missing_author" };
+          }
+          return withWriteLock(async () => {
+            if (await files.data.exists(bookPath(args.slug))) {
+              return { ok: false, error: "exists", slug: args.slug };
+            }
+            const now = new Date().toISOString();
+            const book: Book = {
+              slug: args.slug,
+              title: args.title.trim(),
+              author: args.author.trim(),
+              isbn: args.isbn ?? null,
+              status: args.status ?? "want",
+              rating: args.rating ?? null,
+              startedAt: args.startedAt ?? null,
+              finishedAt: args.finishedAt ?? null,
+              tags: args.tags ?? [],
+              created: now,
+              updated: now,
+              body: args.body ?? "",
+            };
+            await files.data.write(bookPath(args.slug), serialise(book));
+            log.info("saved", { slug: args.slug });
+            await publishChanged();
+            return { ok: true, book: summarise(book) };
+          });
+        }
+
+        case "update": {
+          if (!isValidSlug(args.slug)) {
+            return { ok: false, error: "invalid_slug", slug: args.slug };
+          }
+          if (args.title.trim().length === 0) {
+            return { ok: false, error: "missing_title" };
+          }
+          if (args.author.trim().length === 0) {
+            return { ok: false, error: "missing_author" };
+          }
+          return withWriteLock(async () => {
+            const existing = await readBook(args.slug);
+            if (!existing) return { ok: false, error: "not_found", slug: args.slug };
+            // Optional metadata preserves the on-disk value when the
+            // caller omits the key. Same metadata-preservation
+            // invariant as recipe-book — a "just add a paragraph to
+            // my notes" update shouldn't wipe the rating or tags.
+            const now = new Date().toISOString();
+            const book: Book = {
+              slug: args.slug,
+              title: args.title.trim(),
+              author: args.author.trim(),
+              isbn: args.isbn ?? existing.isbn,
+              status: args.status ?? existing.status,
+              rating: args.rating ?? existing.rating,
+              startedAt: args.startedAt ?? existing.startedAt,
+              finishedAt: args.finishedAt ?? existing.finishedAt,
+              tags: args.tags ?? existing.tags,
+              created: existing.created || now,
+              updated: now,
+              body: args.body ?? existing.body,
+            };
+            await files.data.write(bookPath(args.slug), serialise(book));
+            log.info("updated", { slug: args.slug });
+            await publishChanged();
+            return { ok: true, book: summarise(book) };
+          });
+        }
+
+        case "delete": {
+          if (!isValidSlug(args.slug)) {
+            return { ok: false, error: "invalid_slug", slug: args.slug };
+          }
+          return withWriteLock(async () => {
+            if (!(await files.data.exists(bookPath(args.slug)))) {
+              return { ok: false, error: "not_found", slug: args.slug };
+            }
+            await files.data.unlink(bookPath(args.slug));
+            log.info("deleted", { slug: args.slug });
+            await publishChanged();
+            return { ok: true, slug: args.slug };
+          });
+        }
+
+        default: {
+          const exhaustive: never = args;
+          throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
+        }
+      }
+    },
+  };
+});

--- a/packages/reading-list-plugin/src/lang/en.ts
+++ b/packages/reading-list-plugin/src/lang/en.ts
@@ -1,0 +1,19 @@
+export default {
+  title: "Reading list",
+  countSuffix: "saved",
+  empty: "No books yet — ask Claude to save one.",
+  emptyBody: "(no notes yet)",
+  delete: "Delete",
+  confirmDelete: 'Delete "{title}" from your reading list?',
+  statusLabel: "Status: {status}",
+  ratingLabel: "Rating: {rating}/5",
+  startedLabel: "Started {date}",
+  finishedLabel: "Finished {date}",
+  selectHint: "Select a book to view your notes.",
+  status: {
+    want: "Want to read",
+    reading: "Reading",
+    read: "Read",
+    abandoned: "Abandoned",
+  },
+};

--- a/packages/reading-list-plugin/src/lang/index.ts
+++ b/packages/reading-list-plugin/src/lang/index.ts
@@ -1,0 +1,30 @@
+// Plugin-local i18n: translation tables travel with the plugin
+// bundle, no merge into the host vue-i18n. The plugin reads the
+// host's locale via `useRuntime()` and looks up its own table
+// reactively.
+
+import { computed } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+import en from "./en";
+import ja from "./ja";
+
+const MESSAGES = { en, ja } as const;
+type LocaleKey = keyof typeof MESSAGES;
+
+function isSupportedLocale(value: string): value is LocaleKey {
+  return value in MESSAGES;
+}
+
+export function useT() {
+  const { locale } = useRuntime();
+  return computed(() => (isSupportedLocale(locale.value) ? MESSAGES[locale.value] : MESSAGES.en));
+}
+
+/** Substitute `{key}` placeholders in a translated string with caller
+ *  values. Lightweight stand-in for vue-i18n's interpolation since the
+ *  plugin doesn't pull in vue-i18n. */
+export function format(template: string, params: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    return Object.prototype.hasOwnProperty.call(params, key) ? String(params[key]) : `{${key}}`;
+  });
+}

--- a/packages/reading-list-plugin/src/lang/ja.ts
+++ b/packages/reading-list-plugin/src/lang/ja.ts
@@ -1,0 +1,19 @@
+export default {
+  title: "読書リスト",
+  countSuffix: "冊",
+  empty: "まだ本がありません — Claude に保存してもらいましょう。",
+  emptyBody: "(メモはまだありません)",
+  delete: "削除",
+  confirmDelete: "「{title}」を読書リストから削除しますか?",
+  statusLabel: "状態: {status}",
+  ratingLabel: "評価: {rating}/5",
+  startedLabel: "開始: {date}",
+  finishedLabel: "読了: {date}",
+  selectHint: "左側から本を選ぶと、メモが表示されます。",
+  status: {
+    want: "読みたい",
+    reading: "読書中",
+    read: "読了",
+    abandoned: "中断",
+  },
+};

--- a/packages/reading-list-plugin/src/shims-vue.d.ts
+++ b/packages/reading-list-plugin/src/shims-vue.d.ts
@@ -1,0 +1,9 @@
+// Vite/Vue plugin SFC shim — tells `tsc --noEmit` that `.vue` imports
+// resolve to a Vue Component. Actual SFC parsing happens at build time
+// via `@vitejs/plugin-vue`.
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/packages/reading-list-plugin/src/vue.ts
+++ b/packages/reading-list-plugin/src/vue.ts
@@ -1,0 +1,10 @@
+// Vue entry — the host runtime plugin loader dynamic-imports
+// `dist/vue.js` and reads `plugin.viewComponent` to mount the canvas.
+
+import View from "./View.vue";
+import { TOOL_DEFINITION } from "./definition";
+
+export const plugin = {
+  toolDefinition: TOOL_DEFINITION,
+  viewComponent: View,
+};

--- a/packages/reading-list-plugin/tsconfig.json
+++ b/packages/reading-list-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/reading-list-plugin/vite.config.ts
+++ b/packages/reading-list-plugin/vite.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import dts from "vite-plugin-dts";
+
+// Two bundles, two externals strategies (mirror of recipe-book-plugin
+// / bookmarks-plugin):
+//
+// - `dist/index.js` (server) — self-contained. The runtime loader
+//   extracts the tarball into `~/mulmoclaude/plugins/.cache/<pkg>/<ver>/`
+//   and dynamic-imports it. There's no node_modules underneath, so any
+//   bare import that's left as `external` will fail to resolve at load
+//   time. Inline `gui-chat-protocol` (just the identity `definePlugin`
+//   helper) and `zod` so the server module loads without any module-
+//   resolution gymnastics.
+//
+// - `dist/vue.js` (browser) — `vue` and `gui-chat-protocol/vue` stay
+//   external; the host provides Vue via the importmap and the
+//   `useRuntime()` composable resolves to the host's instance through
+//   `gui-chat-protocol/vue`.
+export default defineConfig({
+  plugins: [vue(), dts({ include: ["src/**/*.{ts,vue}"], rollupTypes: true })],
+  build: {
+    lib: {
+      entry: { index: "src/index.ts", vue: "src/vue.ts" },
+      formats: ["es"],
+      fileName: (_format, entryName) => `${entryName}.js`,
+    },
+    rollupOptions: {
+      external: ["vue", "gui-chat-protocol/vue"],
+      output: {
+        // Pin the CSS asset to `style.css` so the host loader's
+        // `${assetBase}/dist/style.css` URL resolves regardless of
+        // package name.
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith(".css")) return "style.css";
+          return assetInfo.name ?? "[name]";
+        },
+      },
+    },
+    minify: false,
+    sourcemap: true,
+  },
+});

--- a/plans/feat-reading-list-1188.md
+++ b/plans/feat-reading-list-1188.md
@@ -1,0 +1,88 @@
+# reading-list plugin (PR-A of #1188 / #1169 My Library)
+
+First slice of the **My Library** plugin set from #1169. Same shape
+as recipe-book (#1175 / #1183) — one runtime plugin, one tool, one
+canvas view, one role. Layered as a preset so it ships on every
+fresh checkout.
+
+## Scope
+
+### Plugin: `@mulmoclaude/reading-list-plugin`
+
+- Tool: `manageReadingList` with kinds `list / read / save / update / delete`
+- Storage: one markdown file per book at `<plugin-data>/books/<slug>.md`
+- Frontmatter fields: `title`, `author`, `isbn` (optional), `status`
+  (`want | reading | read | abandoned`), `rating` (1-5, optional),
+  `startedAt` (date, optional), `finishedAt` (date, optional),
+  `tags` (string[]), `created` (ISO 8601), `updated` (ISO 8601)
+- Body: free-form markdown — notes, quotes, takeaways
+- Slug rules: same as recipe-book (lowercase ASCII letters + digits +
+  hyphens, 1-64 chars, no leading/trailing/consecutive hyphens)
+- Multi-tab live sync via `pubsub.publish("changed", ...)` after every
+  mutation; the View subscribes and refetches
+
+### Role: `librarian`
+
+Added in `src/config/roles.ts`:
+
+- Friendly, focused on the user's reading habit — not bookkeeping
+- Workflow prompts for save / list / read / update / delete
+- Hints on slug picking (romanise non-ASCII titles), body convention
+  (`## Notes` for thoughts, optional `## Quotes` for marked passages)
+- Mentions that `articles` and `quotes` siblings are coming in PR-B / PR-C
+- `availablePlugins` lists `presentForm` + `generateImage` (book covers
+  on request) per the recipe-book precedent — `manageReadingList` is
+  auto-included as a runtime plugin
+
+## Files
+
+```
+packages/reading-list-plugin/
+├── eslint.config.mjs
+├── package.json
+├── tsconfig.json
+├── vite.config.ts
+└── src/
+    ├── definition.ts         # TOOL_DEFINITION shared by index.ts + vue.ts
+    ├── index.ts              # definePlugin factory + manageReadingList handler
+    ├── vue.ts                # browser entry exporting { toolDefinition, viewComponent }
+    ├── View.vue              # two-pane list + markdown detail
+    ├── shims-vue.d.ts
+    └── lang/
+        ├── en.ts
+        ├── ja.ts
+        └── index.ts          # useT() composable + format() helper
+```
+
+Host wiring:
+
+- `server/plugins/preset-list.ts` — append the new package
+- `src/config/roles.ts` — append the `librarian` role
+- `package.json` — add `@mulmoclaude/reading-list-plugin` workspace
+  symlink (yarn workspaces handle the rest)
+- `package.json#scripts.build:packages` and `build:packages:dev` — add
+  the new workspace to the parallel build list
+
+## Tests
+
+- `test/plugins/test_reading_list_integration.ts` — end-to-end through
+  the real loader + `makePluginRuntime`. Same shape as
+  `test_recipe_book_integration.ts`:
+  - happy path (save → read → update → delete with field round-trip)
+  - metadata preservation (a body-only update keeps existing tags / rating / dates)
+  - status transitions (`want → reading → read`) preserve `created`
+  - invalid slugs / missing titles rejected
+  - duplicate save returns `{ ok: false, error: "exists" }`
+  - delete is idempotent (`not_found` after first delete)
+- Skip-on-no-dist guard so test runs locally even before
+  `yarn build:packages` if the dev hasn't built yet; CI builds first.
+
+## Out of scope (deferred)
+
+- ISBN lookup (Google Books / OpenLibrary) — comes later, paired
+  with the `browse` plugin
+- Reading-progress tracking (current page, % done) — yagni until
+  asked
+- Cross-plugin queries (Quote linkage from book back to its
+  reading-list entry) — needs PR-C `quotes` first
+- Articles plugin — PR-B

--- a/server/plugins/preset-list.ts
+++ b/server/plugins/preset-list.ts
@@ -44,4 +44,10 @@ export const PRESET_PLUGINS: readonly PresetPlugin[] = [
   // per recipe under the plugin's `files.data` scope; demonstrates
   // markdown-per-record storage on the v0.3 runtime API.
   { packageName: "@mulmoclaude/recipe-book-plugin" },
+  // #1188 / #1169 — reading-list runtime plugin. First slice of the
+  // My Library plugin set. Same markdown-per-record shape as
+  // recipe-book; one file per book at `books/<slug>.md` with
+  // structured frontmatter (title / author / status / rating / dates
+  // / tags) plus a free-form notes body.
+  { packageName: "@mulmoclaude/reading-list-plugin" },
 ];

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -297,6 +297,40 @@ export const ROLES: Role[] = [
     ],
   },
   {
+    id: "librarian",
+    name: "Librarian",
+    icon: "menu_book",
+    prompt:
+      "You are a Librarian assistant. You help the user keep a personal reading list — saving books they want to read, tracking what they're currently reading and what they've finished, and capturing the notes / quotes they want to remember.\n\n" +
+      // The tool name is a literal here (not `TOOL_NAMES.manageReadingList`)
+      // because the reading-list plugin is a RUNTIME plugin — its
+      // toolName is loaded at process start, not at compile time, so
+      // TOOL_NAMES doesn't carry it. Same convention as
+      // `manageRecipes` in the cookingCoach role.
+      "## manageReadingList (runtime plugin)\n\n" +
+      "Use the `manageReadingList` tool for every reading-list operation. The plugin owns its data; you just call the tool with the right `kind`. Each book lives as one markdown file with structured frontmatter (title, author, isbn, status, rating, startedAt, finishedAt, tags, created, updated) and a free-form markdown body for notes.\n\n" +
+      '- **Saving** (`kind: "save"`): when the user mentions a book they want to remember — to read someday, currently reading, or already finished. Pick a kebab-case ASCII slug (use a romanised form for non-ASCII titles, e.g. title `しろいうさぎとくろいうさぎ` → slug `little-white-rabbit`). `status` defaults to `want` when omitted; set it explicitly if the user says they\'re reading it now or already finished it. Body convention: `## Notes` for thoughts, `## Quotes` (optional) for marked passages — both as bullet lists or paragraphs as the user prefers.\n' +
+      '- **Recalling** (`kind: "list"`): when the user asks what they\'ve saved, are reading, or want to read. The canvas surface renders the list automatically.\n' +
+      '- **Updating** (`kind: "update"`): when the user finishes a book (move `status` to `read`, fill `finishedAt`), wants to add notes or a quote (extend the body), or changes their mind on a rating / tag. Read the current version (list first if needed), apply the change, call update with the full set of fields. `created` is preserved automatically; `updated` advances. Omitted optional fields preserve their existing values — a notes-only update will not wipe the rating.\n' +
+      '- **Deleting** (`kind: "delete"`): only when the user explicitly asks to drop a book from the list.\n\n' +
+      "## Visuals\n\n" +
+      'Use `generateImage` to picture a book cover or a scene from the story when the user asks ("show me the cover", "what does this scene look like?") or when it would clearly help. One image per request unless the user asks for variations.\n\n' +
+      "## Tone\n\n" +
+      "Curious about the books, friendly about the act of reading. Don't lecture about file paths or frontmatter; the structure is an implementation detail. When the user shares a takeaway or favorite passage, capture it cleanly into the notes body without paraphrasing — the user's own words are usually what they'll want to recall later.",
+    // manageReadingList is provided by the @mulmoclaude/reading-list-plugin
+    // runtime preset (server/plugins/preset-list.ts). Runtime plugins
+    // are auto-included in every role's active tool set regardless of
+    // `availablePlugins`, so it doesn't need to be listed here. Only
+    // host-static tools the role wants explicit go in this array.
+    availablePlugins: [TOOL_NAMES.presentForm, TOOL_NAMES.generateImage],
+    queries: [
+      "Add Sapiens to my reading list",
+      "Show me what I'm currently reading",
+      "I just finished Atomic Habits — give it 5 stars and add my notes",
+      "What books have I tagged psychology?",
+    ],
+  },
+  {
     id: "debug",
     name: "Debug",
     icon: "star",
@@ -356,6 +390,7 @@ export const BUILTIN_ROLE_IDS = {
   settings: "settings",
   accounting: "accounting",
   cookingCoach: "cookingCoach",
+  librarian: "librarian",
   debug: "debug",
 } as const;
 

--- a/test/plugins/test_reading_list_integration.ts
+++ b/test/plugins/test_reading_list_integration.ts
@@ -1,0 +1,371 @@
+// End-to-end integration test for the Reading List runtime plugin
+// (#1188 / #1169 PR-A My Library). Loads the workspace-built
+// `dist/index.js` through the real runtime loader with a real
+// `makePluginRuntime`, then exercises save → read → update → delete
+// + the metadata-preservation invariant against an isolated tmp
+// workspace.
+//
+// Skips automatically when the plugin's dist isn't present (i.e.
+// `yarn build` hasn't been run in `packages/reading-list-plugin/`).
+// CI runs `yarn build:packages` before tests so this is hard-required
+// in CI.
+
+import { describe, it, before, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadPluginFromCacheDir } from "../../server/plugins/runtime-loader.js";
+import { makePluginRuntime } from "../../server/plugins/runtime.js";
+import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import type { IPubSub } from "../../server/events/pub-sub/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_DIR = path.resolve(__dirname, "../../packages/reading-list-plugin");
+const PLUGIN_DIST_INDEX = path.join(PLUGIN_DIR, "dist", "index.js");
+
+const PKG_NAME = "@mulmoclaude/reading-list-plugin";
+const VERSION = "0.1.0";
+
+type ReadingStatus = "want" | "reading" | "read" | "abandoned";
+
+interface BookSummary {
+  slug: string;
+  title: string;
+  author: string;
+  status: ReadingStatus;
+  rating: number | null;
+  tags: string[];
+  updated: string;
+}
+
+interface Book extends BookSummary {
+  isbn: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  created: string;
+  body: string;
+}
+
+interface BookResult {
+  ok: boolean;
+  book?: Book;
+  books?: BookSummary[];
+  slug?: string;
+  error?: string;
+}
+
+function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string; data: unknown }[] } {
+  const published: { channel: string; data: unknown }[] = [];
+  return {
+    pubsub: {
+      publish(channel, data) {
+        published.push({ channel, data });
+      },
+    },
+    published,
+  };
+}
+
+describe("Reading List plugin — end-to-end through the loader", () => {
+  before(() => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      console.warn(`[reading-list integration] skipping: ${PLUGIN_DIST_INDEX} not built — run \`yarn build\` in packages/reading-list-plugin/`);
+    }
+  });
+
+  // Capture the FULL property descriptor so afterEach restores
+  // writability + enumerability flags too — same pattern as
+  // test_recipe_book_integration.ts.
+  let savedDataDescriptor: PropertyDescriptor | undefined;
+  let savedConfigDescriptor: PropertyDescriptor | undefined;
+  let dataRoot: string;
+  let configRoot: string;
+
+  beforeEach(() => {
+    savedDataDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsData");
+    savedConfigDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsConfig");
+    dataRoot = mkdtempSync(path.join(tmpdir(), "reading-list-int-data-"));
+    configRoot = mkdtempSync(path.join(tmpdir(), "reading-list-int-config-"));
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { ...savedDataDescriptor, value: dataRoot });
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { ...savedConfigDescriptor, value: configRoot });
+  });
+
+  afterEach(() => {
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", savedDataDescriptor);
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", savedConfigDescriptor);
+    rmSync(dataRoot, { recursive: true, force: true });
+    rmSync(configRoot, { recursive: true, force: true });
+  });
+
+  it("save → read → list → delete round-trip with frontmatter preserved", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub, published } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin, "plugin should load");
+    assert.equal(plugin.definition.name, "manageReadingList");
+    assert.ok(plugin.execute, "execute handler must be present");
+
+    // 1. List on empty workspace → []
+    let res = (await plugin.execute({}, { kind: "list" })) as BookResult;
+    assert.deepEqual(res, { ok: true, books: [] });
+    assert.equal(published.length, 0, "list must not publish");
+
+    // 2. Save → ok:true + "changed" pub event. Use a non-ASCII title
+    // to lock in the romanised-slug convention from the role prompt.
+    res = (await plugin.execute(
+      {},
+      {
+        kind: "save",
+        slug: "thinking-fast-and-slow",
+        title: "Thinking, Fast and Slow",
+        author: "Daniel Kahneman",
+        isbn: "9780374533557",
+        status: "read",
+        rating: 5,
+        startedAt: "2025-01-15",
+        finishedAt: "2025-03-20",
+        tags: ["psychology", "behavioral-economics"],
+        body: "## Notes\n- Two systems: fast intuition vs slow reasoning\n\n## Quotes\n- *Nothing in life is as important as you think it is, while you are thinking about it.*\n",
+      },
+    )) as BookResult;
+    assert.equal(res.ok, true);
+    assert.equal(res.book?.slug, "thinking-fast-and-slow");
+    assert.equal(res.book?.status, "read");
+    assert.equal(res.book?.rating, 5);
+    assert.equal(published.length, 1);
+    assert.equal(published[0].channel, `plugin:${PKG_NAME}:changed`);
+
+    // 3. Read returns the full book with all frontmatter + body
+    res = (await plugin.execute({}, { kind: "read", slug: "thinking-fast-and-slow" })) as BookResult;
+    assert.equal(res.ok, true);
+    assert.ok(res.book);
+    if (!res.book) return;
+    assert.equal(res.book.title, "Thinking, Fast and Slow");
+    assert.equal(res.book.author, "Daniel Kahneman");
+    assert.equal(res.book.isbn, "9780374533557");
+    assert.equal(res.book.status, "read");
+    assert.equal(res.book.rating, 5);
+    assert.equal(res.book.startedAt, "2025-01-15");
+    assert.equal(res.book.finishedAt, "2025-03-20");
+    assert.deepEqual(res.book.tags, ["psychology", "behavioral-economics"]);
+    assert.match(res.book.body, /## Notes/);
+    assert.match(res.book.body, /## Quotes/);
+    assert.equal(typeof res.book.created, "string");
+    assert.equal(typeof res.book.updated, "string");
+
+    // 4. List returns one summary (body / dates / isbn stripped).
+    res = (await plugin.execute({}, { kind: "list" })) as BookResult;
+    assert.equal(res.books?.length, 1);
+    assert.equal(res.books?.[0].slug, "thinking-fast-and-slow");
+    assert.equal(res.books?.[0].status, "read");
+    assert.equal(res.books?.[0].rating, 5);
+
+    // 5. Read on missing slug → not_found
+    res = (await plugin.execute({}, { kind: "read", slug: "ghost" })) as BookResult;
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "not_found");
+
+    // 6. Delete → ok + second pub event
+    res = (await plugin.execute({}, { kind: "delete", slug: "thinking-fast-and-slow" })) as BookResult;
+    assert.equal(res.ok, true);
+    assert.equal(published.length, 2);
+
+    // 7. Read after delete → not_found
+    res = (await plugin.execute({}, { kind: "read", slug: "thinking-fast-and-slow" })) as BookResult;
+    assert.equal(res.ok, false);
+    assert.equal(res.error, "not_found");
+  });
+
+  it("save defaults status to `want` when omitted", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    if (!plugin?.execute) return;
+
+    const saveRes = (await plugin.execute(
+      {},
+      {
+        kind: "save",
+        slug: "sapiens",
+        title: "Sapiens",
+        author: "Yuval Noah Harari",
+      },
+    )) as BookResult;
+    assert.equal(saveRes.ok, true);
+    assert.equal(saveRes.book?.status, "want");
+
+    const readRes = (await plugin.execute({}, { kind: "read", slug: "sapiens" })) as BookResult;
+    assert.equal(readRes.book?.status, "want");
+    assert.equal(readRes.book?.body.trim(), "");
+  });
+
+  // Same metadata-preservation invariant as recipe-book — a notes-only
+  // update must keep the rating, dates, status, etc. that the user set
+  // earlier. Locks in the contract before someone ports a stale "wipe
+  // when omitted" pattern across plugins.
+  it("update preserves omitted optional metadata (status / rating / dates / tags / isbn)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    const { execute } = plugin;
+    assert.ok(execute);
+
+    await execute(
+      {},
+      {
+        kind: "save",
+        slug: "atomic-habits",
+        title: "Atomic Habits",
+        author: "James Clear",
+        isbn: "9780735211292",
+        status: "read",
+        rating: 4,
+        startedAt: "2024-11-01",
+        finishedAt: "2024-12-15",
+        tags: ["self-help", "productivity"],
+        body: "Original notes",
+      },
+    );
+
+    // Update only body — omit every optional metadata field.
+    const updateRes = (await execute(
+      {},
+      {
+        kind: "update",
+        slug: "atomic-habits",
+        title: "Atomic Habits",
+        author: "James Clear",
+        body: "Refined notes — habit stacking is the key takeaway",
+      },
+    )) as BookResult;
+    assert.equal(updateRes.ok, true);
+
+    const readRes = (await execute({}, { kind: "read", slug: "atomic-habits" })) as BookResult;
+    assert.equal(readRes.ok, true);
+    assert.ok(readRes.book);
+    if (!readRes.book) return;
+    assert.match(readRes.book.body, /habit stacking/);
+    assert.equal(readRes.book.isbn, "9780735211292", "isbn must survive a body-only update");
+    assert.equal(readRes.book.status, "read", "status must survive");
+    assert.equal(readRes.book.rating, 4, "rating must survive");
+    assert.equal(readRes.book.startedAt, "2024-11-01", "startedAt must survive");
+    assert.equal(readRes.book.finishedAt, "2024-12-15", "finishedAt must survive");
+    assert.deepEqual(readRes.book.tags, ["self-help", "productivity"], "tags must survive");
+  });
+
+  it("status transitions (want → reading → read) preserve `created` and advance `updated`", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    const { execute } = plugin;
+    assert.ok(execute);
+
+    await execute({}, { kind: "save", slug: "deep-work", title: "Deep Work", author: "Cal Newport" });
+    const initial = (await execute({}, { kind: "read", slug: "deep-work" })) as BookResult;
+    assert.ok(initial.book);
+    if (!initial.book) return;
+    const createdAt = initial.book.created;
+    assert.equal(initial.book.status, "want");
+
+    // Wait long enough for the timestamp to advance — node's Date
+    // resolution is ms, but a tight loop can produce identical
+    // timestamps. 5ms is plenty.
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+
+    await execute({}, { kind: "update", slug: "deep-work", title: "Deep Work", author: "Cal Newport", status: "reading", startedAt: "2026-01-01" });
+    const reading = (await execute({}, { kind: "read", slug: "deep-work" })) as BookResult;
+    assert.equal(reading.book?.status, "reading");
+    assert.equal(reading.book?.startedAt, "2026-01-01");
+    assert.equal(reading.book?.created, createdAt, "created must not change on update");
+    assert.notEqual(reading.book?.updated, createdAt, "updated must advance on update");
+  });
+
+  it("save refuses to overwrite an existing slug", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    if (!plugin?.execute) return;
+
+    await plugin.execute({}, { kind: "save", slug: "dup", title: "First", author: "Alice" });
+    const second = (await plugin.execute({}, { kind: "save", slug: "dup", title: "Second", author: "Bob" })) as BookResult;
+    assert.equal(second.ok, false);
+    assert.equal(second.error, "exists");
+  });
+
+  it("rejects invalid slugs at read / delete (Zod rejects them at save / update)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    if (!plugin?.execute) return;
+    const { execute } = plugin;
+
+    const badRead = (await execute({}, { kind: "read", slug: "Bad Slug!" })) as BookResult;
+    assert.equal(badRead.ok, false);
+    assert.equal(badRead.error, "invalid_slug");
+
+    const badDelete = (await execute({}, { kind: "delete", slug: "Bad Slug!" })) as BookResult;
+    assert.equal(badDelete.ok, false);
+    assert.equal(badDelete.error, "invalid_slug");
+  });
+
+  it("save rejects missing title or author", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en" }),
+    });
+    assert.ok(plugin?.execute);
+    if (!plugin?.execute) return;
+    const { execute } = plugin;
+
+    const blankTitle = (await execute({}, { kind: "save", slug: "no-title", title: "   ", author: "Alice" })) as BookResult;
+    assert.equal(blankTitle.ok, false);
+    assert.equal(blankTitle.error, "missing_title");
+
+    const blankAuthor = (await execute({}, { kind: "save", slug: "no-author", title: "Some book", author: "  " })) as BookResult;
+    assert.equal(blankAuthor.ok, false);
+    assert.equal(blankAuthor.error, "missing_author");
+  });
+});


### PR DESCRIPTION
## Summary

PR-A of #1188 (and the broader #1169 My Library set). Mirrors recipe-book (#1175 / #1183) one-to-one — same scaffold layout, same lock + serialise / deserialise pattern, same lint preset, same integration-test shape. Adds an in-tree \`reading-list\` plugin: a \`manageReadingList\` MCP tool (list / save / read / update / delete) plus a canvas view that mirrors recipe-book, with each book stored as one markdown file under \`<workspace>/data/library/books/<slug>.md\`.

## Items to Confirm / Review

- **Storage shape**: structured YAML frontmatter (\`title\`, \`author\`, \`isbn\`, \`status\`, \`rating\`, \`startedAt\`, \`finishedAt\`, \`tags\`, \`created\`, \`updated\`) + free-form markdown body for notes / quotes. Slug rules identical to recipe-book.
- **Status enum**: \`want | reading | read | abandoned\`. Defaults to \`want\` on save when omitted. Transitions are just \`update\`s.
- **Sort order in list**: by \`updated\` desc (most-recently-touched first) — recipe-book sorts by title alphabetical. Library felt more useful as a recency feed (\"what am I reading right now\" / \"what did I just finish\"). Open to feedback.
- **Metadata preservation invariant**: same as recipe-book — a body-only update keeps the existing rating / tags / dates / status / isbn. Pinned by an integration-test case.
- **No \`build:packages\` edit**: #1189 (open) replaces the explicit \`@mulmoclaude/*-plugin\` enumeration with a glob driver. The new package will be auto-picked up after #1189 merges; not adding the manual entry here avoids a conflict.
- **Launcher deps**: not added to \`packages/mulmoclaude/package.json\` — recipe-book follows the same convention. The launcher's prepare-dist + node_modules resolution handles workspace plugins.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1169 5. My Libraryを。1183参考にプラグインにしてrole追加も。

(Implementation follows the recipe-book pattern.)

## Implementation

Plan: \`plans/feat-reading-list-1188.md\` (commit \`c742e162\`).

- \`packages/reading-list-plugin/\` — new workspace package (eslint, tsconfig, vite, package.json + src tree mirroring recipe-book)
- \`server/plugins/preset-list.ts\` — append the new package
- \`src/config/roles.ts\` — append the \`librarian\` role + extend \`BUILTIN_ROLE_IDS\` with \`librarian\`
- \`test/plugins/test_reading_list_integration.ts\` — 7 cases: round-trip / status default / metadata preservation / status transitions / duplicate save / invalid slug / missing fields

## Future PRs

- **PR-B**: \`articles\` plugin (saved web articles + summaries)
- **PR-C**: \`quotes\` plugin (cross-cutting quote collection)
- The \`librarian\` role gains additional tool prompts as PR-B / PR-C land

## Test plan

- [x] \`yarn build:packages\` produces \`packages/reading-list-plugin/dist/\` (manually confirmed via \`yarn workspace @mulmoclaude/reading-list-plugin run build\`; will switch to glob driver after #1189 merges)
- [x] \`yarn lint\` / \`yarn typecheck\` clean
- [x] \`yarn test\` — 4170 / 86 pass (7 new integration cases all green)
- [ ] Reviewer manually \`yarn dev\`, switches to the Librarian role, asks \"add Sapiens to my reading list\", confirms the canvas renders + the book persists across reload

Tracks #1188 (and #1169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new in-tree reading-list runtime plugin with a dedicated librarian role and canvas view for managing a personal reading list stored as markdown files.

New Features:
- Introduce the @mulmoclaude/reading-list-plugin runtime plugin exposing a manageReadingList tool to list, read, save, update, and delete books stored as markdown with YAML frontmatter.
- Add a librarian role configured to use the manageReadingList tool and provide UX guidance for maintaining a personal reading list, including example queries and image generation hints.
- Provide a Vue-based canvas view that displays the reading list alongside detailed markdown notes for a selected book, with live updates via pubsub.

Enhancements:
- Register the reading-list plugin in the preset plugins list so it ships with the default runtime configuration.
- Implement lightweight plugin-local i18n for the reading-list view with English and Japanese strings.
- Document the reading-list plugin design and scope in a dedicated planning markdown file.

Tests:
- Add an end-to-end integration test suite for the reading-list plugin that validates round trips, default status handling, metadata preservation, status transitions, duplicate detection, slug validation, and required-field enforcement.