### PR TITLE
fix(spotify): split refresh-path errors into auth_expired + transient_error

### DIFF
--- a/packages/spotify-plugin/src/client.ts
+++ b/packages/spotify-plugin/src/client.ts
@@ -5,6 +5,12 @@
 // refresh token is revoked / rotated, and looping would just
 // hammer Spotify's token endpoint. Surface `auth_expired` and let
 // the user reconnect.
+//
+// Refresh-path failures are split into two classes (CodeRabbit
+// review on PR #1166): `auth_expired` only when Spotify actually
+// rejected the refresh token (4xx, or protocol-malformed response),
+// and `transient_error` for network / 5xx / parse failures so the
+// user isn't told to reconnect during a Spotify outage.
 
 import type { PluginRuntime } from "gui-chat-protocol";
 
@@ -28,10 +34,21 @@ const RETRY_AFTER_FALLBACK_SEC = 60;
 
 /** Reasons the client returns instead of throwing. The dispatch
  *  layer (`index.ts`) maps these to the user-facing `instructions`
- *  field of the SpotifyError union. */
+ *  field of the SpotifyError union.
+ *
+ *  `auth_expired` means the credential is unusable — refresh token
+ *  was rejected by Spotify, or the protocol response was malformed
+ *  in a way that's indistinguishable from rejection. The user has to
+ *  reconnect.
+ *
+ *  `transient_error` means the refresh path failed in a way that
+ *  doesn't imply the credential is bad — network timeout, 5xx from
+ *  Spotify, JSON parse failure (likely proxy / middleware). Caller
+ *  should retry later, NOT prompt the user to reconnect. */
 export type SpotifyClientError =
   | { kind: "not_connected" }
   | { kind: "auth_expired"; detail: string }
+  | { kind: "transient_error"; detail: string }
   | { kind: "rate_limited"; retryAfterSec: number }
   | { kind: "spotify_api_error"; status: number; body: string };
 
@@ -141,21 +158,30 @@ async function refreshTokens(
       allowedHosts: [SPOTIFY_TOKEN_HOST],
     });
   } catch (err) {
-    return { ok: false, error: { kind: "auth_expired", detail: `refresh fetch failed: ${errorMessage(err)}` } };
+    return { ok: false, error: { kind: "transient_error", detail: `refresh fetch failed: ${errorMessage(err)}` } };
   }
   if (!response.ok) {
     const body = await response.text().catch(() => "");
     runtime.log.warn("refresh failed", { status: response.status, body: body.slice(0, 200) });
-    return { ok: false, error: { kind: "auth_expired", detail: `refresh returned ${response.status}` } };
+    // 4xx ⇒ Spotify rejected the refresh token (revoked, malformed,
+    // client_id mismatch). 5xx ⇒ Spotify is having an outage; the
+    // credential may still be valid. Don't conflate the two.
+    const kind = response.status >= 500 ? "transient_error" : "auth_expired";
+    return { ok: false, error: { kind, detail: `refresh returned ${response.status}` } };
   }
   let parsed: RawTokenResponse;
   try {
     parsed = (await response.json()) as RawTokenResponse;
   } catch (err) {
-    return { ok: false, error: { kind: "auth_expired", detail: `refresh response parse failed: ${errorMessage(err)}` } };
+    // Non-JSON response on a 2xx is almost certainly a proxy /
+    // middleware error page — transient, not credential-related.
+    return { ok: false, error: { kind: "transient_error", detail: `refresh response parse failed: ${errorMessage(err)}` } };
   }
   const refreshFields = parseRefreshResponse(parsed);
   if (!refreshFields) {
+    // Spotify returned 2xx JSON without access_token / expires_in.
+    // Indistinguishable from a refresh-token rejection at the protocol
+    // level — surface as auth_expired so the user reconnects.
     return { ok: false, error: { kind: "auth_expired", detail: "refresh response missing access_token / expires_in" } };
   }
   const merged = mergeRefreshResponse(tokens, refreshFields, now());

--- a/packages/spotify-plugin/src/index.ts
+++ b/packages/spotify-plugin/src/index.ts
@@ -583,6 +583,13 @@ function mapClientError(error: SpotifyClientError) {
         message: "認可が無効化されました。「Connect」をやり直してください。",
         detail: error.detail,
       };
+    case "transient_error":
+      return {
+        ok: false as const,
+        error: "transient_error",
+        message: "Spotify に一時的に接続できませんでした。しばらくしてから再試行してください。",
+        detail: error.detail,
+      };
     case "rate_limited":
       return {
         ok: false as const,

--- a/packages/spotify-plugin/src/profile.ts
+++ b/packages/spotify-plugin/src/profile.ts
@@ -114,6 +114,8 @@ function errorMessage(error: SpotifyClientError): string {
   switch (error.kind) {
     case "auth_expired":
       return error.detail;
+    case "transient_error":
+      return error.detail;
     case "rate_limited":
       return `rate limited (retry ${error.retryAfterSec}s)`;
     case "spotify_api_error":

--- a/packages/spotify-plugin/src/types.ts
+++ b/packages/spotify-plugin/src/types.ts
@@ -39,6 +39,7 @@ export type SpotifyError =
   | { kind: "client_id_missing"; instructions: string; setupGuide: string }
   | { kind: "not_connected"; instructions: string }
   | { kind: "auth_expired"; detail: string; instructions: string }
+  | { kind: "transient_error"; detail: string; instructions: string }
   | { kind: "unknown_state"; instructions: string }
   | { kind: "redirect_uri_mismatch"; instructions: string }
   | { kind: "rate_limited"; retryAfterSec: number; instructions: string }

--- a/test/plugins/spotify/test_client.ts
+++ b/test/plugins/spotify/test_client.ts
@@ -138,7 +138,7 @@ describe("spotifyApi — 401 → refresh → retry once", () => {
     assert.equal(handle.calls.length, 3);
   });
 
-  it("gives up (auth_expired) when the refresh itself fails", async () => {
+  it("surfaces auth_expired when refresh returns 4xx (token rejected)", async () => {
     const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), new Response("invalid_grant", { status: 400 })] });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
@@ -146,6 +146,68 @@ describe("spotifyApi — 401 → refresh → retry once", () => {
     if (result.ok) throw new Error("unreachable");
     assert.equal(result.error.kind, "auth_expired");
     assert.equal(handle.written.length, 0);
+  });
+});
+
+// CodeRabbit review on PR #1166 caught that pre-PR-#1188-or-similar,
+// every refresh-path failure (network blip, Spotify 5xx, JSON parse)
+// was reported as `auth_expired`, prompting the user to reconnect even
+// when their credential was fine. The split below pins which
+// classifications go to `transient_error` (retry later) vs
+// `auth_expired` (reconnect required).
+describe("spotifyApi — refresh-path classification (auth_expired vs transient_error)", () => {
+  it("classifies a network/timeout failure during refresh as transient_error", async () => {
+    // Two responses queued, but the SECOND queued slot is a thrown
+    // error: the fake runtime's `fetch` throws when the queue's next
+    // entry is missing, so we leave only one response and let the
+    // refresh fetch trip the throw branch.
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
+  });
+
+  it("classifies a 5xx from Spotify's token endpoint as transient_error", async () => {
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), new Response("upstream", { status: 503 })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
+    assert.match(result.error.detail, /503/);
+  });
+
+  it("classifies a non-JSON 2xx body from token endpoint as transient_error", async () => {
+    // Some proxies / middlewares return HTML on their own 2xx page.
+    const htmlResponse = new Response("<html>maintenance</html>", { status: 200, headers: { "content-type": "text/html" } });
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), htmlResponse] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
+  });
+
+  it("keeps auth_expired when refresh response is JSON but missing access_token / expires_in", async () => {
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), jsonResponse({ error: "invalid_grant" })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "auth_expired");
+  });
+
+  it("classifies a 5xx hit during PROACTIVE refresh (pre-call) as transient_error", async () => {
+    // Token is within the 30s expiry leeway, so the FIRST fetch is
+    // the refresh attempt — no preceding 401 round-trip.
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 502 })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", { ...validTokens, expiresAt: ALMOST_NOW }, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
   });
 });
 


### PR DESCRIPTION
## Summary

- Split Spotify refresh-path failures so transient errors no longer prompt reconnect
- `auth_expired`: only when Spotify actually rejected the refresh token (4xx, or malformed success body)
- `transient_error`: network blip, Spotify 5xx, non-JSON response — retry later, credential is fine
- New user-facing message: 「Spotify に一時的に接続できませんでした。しばらくしてから再試行してください。」

## Items to Confirm / Review

1. **Classification boundaries** — Is the 4xx-vs-5xx split the right cut? Specifically: a 408 Request Timeout from Spotify currently goes to `auth_expired` (it's <500). Edge case, low impact, but worth a sanity check.
2. **Message wording in Japanese** — Reviewer fluency check on "一時的に接続できませんでした".
3. **`SpotifyError` union expansion** — Adding `transient_error` to `types.ts#SpotifyError` is a breaking shape change for any consumer that exhaustively switches. The only switch sites in this repo are `mapClientError` (index.ts) and `errorMessage` (profile.ts), both updated. Worth confirming no external consumer depends on the union exhaustiveness.

## User Prompt

PR Quality Sweep (24 時間) で残った should-fix の中から、user が「2のみ」(spotify auth_expired の意味分離) を指定。

## Background

CodeRabbit review on PR #1166 (and earlier #1164):

> Reserve `auth_expired` for actual credential expiry. This branch turns
> token-endpoint timeouts/outages into `auth_expired`, so a transient
> Spotify problem gets surfaced as "please reconnect."

The pre-fix behaviour reported every refresh-path failure as `auth_expired`:
network throw, 5xx from Spotify, JSON parse failures, missing fields.
Users hit by a Spotify outage or a brief network glitch were told their
authorisation was revoked and asked to reconnect — false positive that
also wastes their consent flow.

## Implementation

### Client layer (`packages/spotify-plugin/src/client.ts`)

- `SpotifyClientError` gains a `transient_error` member with `detail: string`
- In `refreshTokens`:
  - fetch throws → `transient_error` (was `auth_expired`)
  - response status >= 500 → `transient_error` (was `auth_expired`)
  - response status < 500 (but !ok) → `auth_expired` (token rejected)
  - JSON parse throws → `transient_error` (was `auth_expired`)
  - parsed body lacks access_token / expires_in → `auth_expired` (kept — protocol-level rejection)
- `spotifyApi`'s 401 retry loop already short-circuits on non-`auth_expired`,
  so `transient_error` propagates correctly without further changes

### Dispatch layer

- `types.ts#SpotifyError`: `transient_error` member added
- `index.ts#mapClientError`: case added returning the retry-later message
- `profile.ts#errorMessage`: case added so log messages render the detail

### Tests (`test/plugins/spotify/test_client.ts`)

New `describe` block: 5 tests pinning the classification:

- network/timeout failure during refresh → `transient_error`
- 5xx from Spotify token endpoint → `transient_error`
- non-JSON 2xx body → `transient_error`
- 2xx JSON missing `access_token` → `auth_expired` (intentional)
- 5xx during PROACTIVE refresh (pre-call path) → `transient_error`

Pre-existing test "gives up (auth_expired) when the refresh itself fails"
renamed to clarify it specifically tests the 4xx case.

## Test plan

- [x] `npx tsx --test test/plugins/spotify/test_client.ts` — 18/18 pass
- [x] `npx tsx --test test/plugins/spotify/*.ts` — 128/128 pass
- [x] `yarn format`
- [x] `yarn lint` (changed files)
- [x] `yarn typecheck`
- [x] `yarn build`

## Summary by Sourcery

Refine Spotify token refresh error handling to distinguish between expired credentials and transient failures, and update user messaging and tests accordingly.

New Features:
- Introduce a new transient_error classification for Spotify refresh-path failures that do not indicate invalid credentials.

Bug Fixes:
- Stop treating transient Spotify refresh failures (network issues, 5xx responses, non-JSON bodies) as auth_expired to avoid unnecessary reconnect prompts.

Enhancements:
- Clarify the semantics of auth_expired vs transient_error in the Spotify client error type and propagate the new error kind through the dispatch and profile layers.
- Add a Japanese user-facing message instructing users to retry later when a transient Spotify connection issue occurs.

Tests:
- Add focused tests that pin the classification of various Spotify refresh-path failure modes into auth_expired vs transient_error and rename an existing test for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to distinguish temporary Spotify connectivity issues from authentication failures, providing more accurate error messaging.
  * Enhanced error classification for rate limiting and API errors to better guide users during transient issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->