### PR TITLE
feat(notifier): minimal engine + dev-mode debug popup (PR 2 of feat-encore)

### DIFF
--- a/plans/feat-encore.md
+++ b/plans/feat-encore.md
@@ -66,19 +66,18 @@ The current model is sufficient for "your scheduled task just finished" but cann
 
 ### Three notification types — three lifecycle shapes
 
-Plugins fire notifications that fall into one of three shapes. The Notifier carries `lifecycle` on every payload so the panel UI and the close-event branch correctly. The field is named `lifecycle` (not `kind`) because the existing `NotificationKind` already means "source category" — `todo | scheduler | agent | …` — and the two are orthogonal: source category (collapsed into `pluginPkg`, see below) and lifecycle shape are independent.
+Plugins fire notifications that fall into one of two shapes. The Notifier carries `lifecycle` on every payload as a UI hint — the engine itself never reads it. The field is named `lifecycle` (not `kind`) because the existing `NotificationKind` already means "source category" — `todo | scheduler | agent | …` — and the two are orthogonal: source category (collapsed into `pluginPkg`, see below) and lifecycle shape are independent.
 
 ```ts
-type NotifierLifecycle = "fyi" | "read" | "action";
+type NotifierLifecycle = "fyi" | "action";
 ```
 
-| Lifecycle | Example | Has body content? | Closes when… |
+| Lifecycle | Example | Has body content? | Who calls `clear`? |
 |---|---|---|---|
-| `fyi` | "Backup completed" | No | User acknowledges (button or bulk-checkbox in panel) |
-| `read` | "Daily news digest is ready" | Yes — content lives at a deep-link target | User clicks the row → navigated to target → close fires automatically |
-| `action` | "Pay H2 property tax" | Yes — plugin-owned page with custom UX | Plugin calls `notifier.clear(id)` when the underlying state change happens |
+| `fyi` | "Backup completed" | No | The bell panel — user acknowledges (button or bulk-checkbox) |
+| `action` | "Pay H2 property tax" / "Daily news digest is ready" | Yes — plugin-owned target | The plugin — either on view mount ("show this once" semantics) or after the domain action completes |
 
-Key implication for `action`: the close call belongs in the **plugin's domain logic, not the panel click handler**. If the user submits the journal entry via chat without ever opening the bell, the reminder must still clear. The deep-link click is just convenience routing; it does not by itself satisfy the notification.
+`action` collapses what an earlier draft split into `read` and `action`: from the engine's perspective both are "the plugin owns the close call", so the distinction was bookkeeping with no runtime effect. The plugin chooses *when* to call `clear` based on its own UX — on mount for read-once notifications, after an explicit action for things like "Pay property tax." If the user never visits the plugin's view (e.g. submits the journal entry via chat instead), the plugin can still detect the underlying state change and call `clear` from there; the panel click is convenience routing, not the close trigger.
 
 ### Target shape — `Notifier`
 
@@ -152,8 +151,7 @@ pending → delivered → seen ─→ snoozed ─→ (re-evaluates at untilTime 
 
 - `seen` is "rendered to the user" (panel opened, or toast shown). Re-surface fires off `delivered` without `acted`, **not** off `seen` without `acted` — otherwise an open bell panel would suppress every escalation.
 - For `fyi`: acknowledge transitions directly to `closed` without going through `acted` (no domain action exists to be acted on; acknowledge IS the close).
-- For `read`: navigation triggers `clear` automatically — the panel emits the close on the same tick it routes the user.
-- For `action`: only the plugin can transition to `acted` / `closed`. The panel cannot.
+- For `action`: only the plugin can transition to `acted` / `closed`. The panel routes the user to the plugin's view but does not by itself close the notification.
 
 #### Pending count + bell badge semantics
 
@@ -166,13 +164,12 @@ The toolbar bell shows the count of notifications in `delivered` or `seen` state
 
 #### Panel UX per lifecycle
 
-The bell panel stays the surface for all three lifecycles. Each row's affordance differs by `lifecycle`:
+The bell panel stays the surface for both lifecycles. Each row's affordance differs by `lifecycle`:
 
 - **`fyi`** — leading checkbox + "Acknowledge selected" button at the panel footer. Click anywhere on the row toggles the checkbox; explicit close-button on the row also acknowledges that single item. Bulk acknowledge is the headline ergonomic — for catch-up sessions where 12 "build finished" rows pile up.
-- **`read`** — row is a hyperlink. Click → close panel → route to the deep-link target → close transition fires. Same as today's `NotificationAction.navigate`, just with the auto-close hooked up.
-- **`action`** — row is a hyperlink routing to the plugin's standalone page (derived from `pluginPkg` + the plugin's META — no per-call deep-link wiring); *but* the close is driven by the plugin (`notifier.clear(id)`), not by the click. The URL carries `?notificationId=<uuid>` so the page can call `notifier.get(uuid)` to recover `pluginData`, highlight the relevant item, and know which id to clear when the user completes the action. If the user navigates away without acting, the notification stays pending and re-surfaces on schedule.
+- **`action`** — row is a hyperlink routing to the plugin's view (the plugin reads `pluginData` to decide where exactly — a standalone route, an in-chat preview, etc.). The close is always driven by the plugin (`notifier.clear(id)`), never by the click. The URL carries `?notificationId=<uuid>` so the landing page can call `notifier.get(uuid)` to recover `pluginData`, highlight the relevant item, and know which id to clear. The plugin chooses *when* to clear: on view mount for read-once notifications, after a domain action for things like "Pay property tax." If the user navigates away without engaging, the notification stays pending and re-surfaces on schedule.
 
-`NotificationBell.vue` and `NotificationToast.vue` gain `lifecycle`-aware rendering. New testids: `[notification-row-fyi]`, `[notification-row-read]`, `[notification-row-action]`, `[notification-acknowledge-bulk]`.
+`NotificationBell.vue` and `NotificationToast.vue` gain `lifecycle`-aware rendering. New testids: `[notification-row-fyi]`, `[notification-row-action]`, `[notification-acknowledge-bulk]`.
 
 #### Severity → channel mapping
 
@@ -443,9 +440,9 @@ The standalone route follows the existing pattern: route registered in `src/rout
 
 ## Phasing
 
-**Order of operations**: A tiny client-only dev-mode gate ships first (PR 1) so the Notifier engine (PR 2) can ship with a real test plugin behind a Debug role rather than an HTTP-only harness or a test plugin that pollutes production roles. Encore (PRs 3 + 4) follows once the engine is proven.
+**Order of operations**: A tiny client-only dev-mode gate ships first (PR 1, ✅ merged), then a stripped-down Notifier prototype (PR 2) validates the data model + API shape behind the existing `@mulmoclaude/debug-plugin` `/debug` page. The full Notifier engine with timers, escalation, snooze, channel routing, and legacy `publishNotification()` migration follows in PR 3. Encore (PRs 4 + 5) lands once the engine is proven.
 
-### PR 1 — Dev mode + Debug role (client-only, ~25-line diff)
+### PR 1 — Dev mode + Debug role (client-only, ~25-line diff) ✅ merged
 
 A minimal client-only dropdown gate. PR 2's `_notifierTest` plugin will sit on the same `VITE_DEV_MODE` flag, but the gating mechanism for *roles* lives entirely in the role schema + the dropdown component.
 
@@ -479,38 +476,76 @@ Existing chat sessions tied to a debug role still render normally (icon, history
 
 **Acceptance bar**: with `VITE_DEV_MODE=1`, Debug appears at the bottom of the role dropdown with General's plugin set; without it, Debug is absent. Total diff: ~25 lines across 3 files (`roles.ts`, `RoleSelector.vue`, `vite-env.d.ts`).
 
-### PR 2 — Notifier engine + `_notifierTest` plugin (host only, no Encore)
+### PR 2 — Notifier prototype (no timers, JSON persistence, debug-plugin harness)
 
-The engine in `server/notifier/`:
+A minimal first cut to validate the data model + API shape before adding the time-based machinery. **`server/events/notifications.ts` is left completely untouched** — the prototype is a parallel service with its own pub/sub channel, exercised only via the existing `@mulmoclaude/debug-plugin` `/debug` page.
 
-- Three notification lifecycles (`fyi` / `read` / `action`) with lifecycle-aware UI.
-- Engine-assigned UUID; plugin-owned `pluginPkg` + `pluginData<T>` typed slot.
-- `schedule` / `clear` / `cancel` / `snooze` / `signal` / `listFor` / `get` API.
-- State machine + persistence (`scheduled.jsonl` + `state.jsonl`, both keyed by UUID).
-- Severity-based channel routing.
-- Snooze-until-time **and** snooze-until-signal (both — needed for the action-lifecycle end-to-end test). Signals scoped structurally as `{ pluginPkg, key }`.
-- Bell badge with pending-count semantics, color-encoded severity, `99+` cap.
-- Panel UX per lifecycle: bulk-acknowledge for `fyi`, click-to-clear for `read`, plugin-owned pages with `?notificationId=<uuid>` deep-link param for `action` (target derived from `pluginPkg` + plugin META).
-- Legacy migration: existing `publishNotification()` becomes a thin wrapper over `notifier.schedule({ lifecycle: "fyi", firesAt: now })`, mapping the old `NotificationKind` source category to a synthetic `pluginPkg` (`todo` / `scheduler` / `agent` / `journal` keep their names; `push` / `bridge` / `system` collapse under `"host"`). All current callers keep working unchanged.
+The engine in `server/notifier/` exposes:
 
-The exercise harness is `_notifierTest` — a dev-only plugin under `src/plugins/_notifierTest/`, surfaced via the Debug role from PR 1. It's the realistic integration bed: a View with buttons to fire each lifecycle at chosen severity, advance through the state machine (mark seen, `clear`, `snooze`, emit `signal`), and inspect persisted state. Because it's a real plugin going through the real registration and dispatch paths, it exercises everything Encore will hit in PR 4.
+- `publish({ pluginPkg, severity, title, body?, lifecycle?, pluginData? })` → `{ id }` — UUID generated synchronously at enqueue time and returned to the caller.
+- `clear(id)` — covers all "user dealt with it" paths. The lifecycle-specific call sites (`fyi` bulk-ack from the bell panel, `action` from the plugin's own view — either on mount for "show this once" semantics or after a domain action completes) are convention only; the engine doesn't read `lifecycle`.
+- `cancel(id)` — "this notification became irrelevant" (kept distinct from `clear` for future audit purposes; behaviorally identical for now).
+- `get(id)` / `listFor(pluginPkg)` / `listAll()`.
+- No `firesAt`, no scheduling, no `markSeen` / `acknowledge`, no snooze, no signal, no re-surface, no severity → channel routing — those all land in PR 3.
+
+State model collapses to `active → cleared | cancelled`. Both terminal states drop the entry from the active store; the difference is recorded only in the emitted pub/sub event type.
+
+Persistence:
+
+- Single `~/mulmoclaude/data/notifier/active.json` file holding only active entries (`{ entries: { [id]: NotifierEntry } }`). No append-only log.
+- Written via `writeFileAtomic` on every mutation.
+- **In-memory write coordinator**: a `writing` flag plus a queue of pending waiters. The first caller to find the flag clear runs `drain()`, which loops until the waiter queue is empty — each round takes the current batch, snapshots the in-memory map, writes once, resolves the batch. Subsequent callers during a write push their resolver and return. This coalesces N rapid mutations into ≤2 disk writes, prevents the rename-race two concurrent `writeFileAtomic` calls would otherwise create, and lets the engine serve mutating APIs as plain `await persist()` calls.
+- All mutating APIs roll back the in-memory change if `persist()` rejects, so memory and disk never diverge.
+- Pub/sub events (`{ type: "published" | "cleared" | "cancelled", ... }`) emit **after** persistence succeeds, on a **single global `notifier` channel** carrying every event regardless of `pluginPkg`. Subscribers filter client-side. Per-`pluginPkg` channels (`notifier:<pluginPkg>`) were considered and rejected for v1: the only consumer is the debug page (which wants global view anyway), and a future bell badge will also want global view; per-plugin filtering is cheap on the client and avoids the dynamic-subscription bookkeeping that per-pluginPkg channels would require.
+
+Wiring:
+
+- `server/api/routes/notifier.ts` — single `POST /api/notifier` dispatch endpoint with `{ action: "publish" | "clear" | "cancel" | "list" }` body, matching the `manage*` tool pattern.
+- `src/config/pubsubChannels.ts` — new `notifier` channel.
+- `src/config/apiRoutes.ts` — `/api/notifier`.
+- `server/workspace/paths.ts` — `data/notifier/` and `active.json`.
+
+A new top-bar **debug popup** (host-side, not a plugin) is the manual test surface:
+
+- Lives next to `NotificationBell` in `SidebarHeader`, gated by `VITE_DEV_MODE === "1"` so it never appears outside dev. Icon-only button (32×32, `material-icons` "bug_report"), opens a popup panel on click — same UX shape as the lock and bell popups, separate component (`NotifierDebugPopup.vue`).
+- Subscribes to the `notifier` pub/sub channel via `usePubSub` and renders the live active list (severity color, lifecycle hint, title/body, `pluginPkg`). Initial state is fetched once on open via `POST /api/notifier {action: "list"}`.
+- Single `[Run scripted test]` button drives a ~4.8s sequence across **multiple `pluginPkg` values** (e.g. `debug__system`, `debug__news`, `debug__encore`) so namespace separation and `listFor` filtering are visually obvious. Steps interleave `publish` / `clear` / `cancel` with ~500ms gaps so a human can watch entries appear and disappear; the script ends with the active list empty.
+- Before each run, the script clears any leftover `debug__*` entries in case a previous run aborted mid-way.
+- No manual publish/clear forms — those aren't needed now or later.
+
+Why the host top-bar instead of `@mulmoclaude/debug-plugin`'s `/debug` page: runtime plugins receive a `BrowserPluginRuntime.pubsub` that's hard-scoped to `plugin:<pkg>:<channel>`, so a runtime plugin cannot subscribe to the host's global `notifier` channel without bundling a second socket.io connection. The debug popup, being host code, uses `usePubSub` directly with no scope rewrite. The `@mulmoclaude/debug-plugin` `/debug` page stays as it is — a placeholder for future plugin-scoped experiments.
 
 Test coverage:
 
-- **Unit**: state machine transitions, persistence round-trip, severity → channel mapping, snooze re-evaluation, re-surface timing, `listFor` / `get` recovery semantics.
-- **Integration / E2E (Playwright)**: with `VITE_DEV_MODE=1`, switch to Debug role, drive each lifecycle from `_notifierTest`'s View and assert against the bell badge + panel. Verify badge count + color updates per lifecycle, panel rendering per lifecycle (`[notification-row-fyi]` checkbox bulk-acknowledge, `[notification-row-read]` click-and-close, `[notification-row-action]` deep-link with `notificationId` param), restart-survives-pending verified by killing and restarting the dev server mid-test.
+- **Unit** (`test/server/notifier/`): `publish` returns a usable id; `clear` / `cancel` remove entries idempotently; unknown id is a no-op (no throw); `listFor("a")` doesn't return entries with `pluginPkg: "b"`; `pluginData<T>` round-trips unchanged; persistence round-trip via tmp dir (publish, restart engine on the same path, entries restored); concurrent mutation under load (10 simultaneous publishes resolve to a final file matching the in-memory snapshot, with ≤2 actual disk writes); rollback on simulated persist failure.
+- **Manual** (debug page): visual confirmation that pub/sub events drive the view, the scripted sequence runs cleanly to empty, and nothing leaks into the existing bell.
 
-Acceptance bar: every state transition reachable from `_notifierTest`, no Encore code in the diff.
+Acceptance bar: scripted test runs to completion in ~5s with the active list correctly populating and emptying; all unit tests pass; zero diff in `server/events/notifications.ts`.
 
-Risk: regression in current notification UX. Mitigated by the migration path keeping `publishNotification()` semantics identical.
+### PR 3 — Notifier full engine (timers, snooze, escalation, channel routing, legacy migration)
 
-### PR 3 — Encore plugin (CRUD only, no reminders)
+Builds on the prototype to deliver the engine specced in Part 1 above. New scope on top of PR 2:
+
+- `firesAt` + scheduling, persisted across restart. Persistence shape upgrades from `active.json` to `scheduled.jsonl` (queued fires) + `state.jsonl` (audit log of state-machine transitions), both keyed by UUID and written via `writeFileAtomic`.
+- Two lifecycles get the full state machine (`pending → delivered → seen → acted/dismissed → closed`) with `markSeen`-style transitions and re-surface on `delivered without acted` after `escalateAt[i]`.
+- `snooze` (until-time **and** until-signal), `signal({ pluginPkg, key })`.
+- `resurface` policy capped at `escalateAt.length` (no auto-multiplication).
+- Severity → channel routing (`info` → bell only, `nudge` → bell + toast, `urgent` → + macOS push + bridge); user-editable mapping in `~/mulmoclaude/config/notifier.json`.
+- Bell badge gets pending-count semantics, severity color encoding, `99+` cap.
+- Lifecycle-aware panel UX: `[notification-row-fyi]` checkbox bulk-acknowledge, `[notification-row-action]` plugin-page deep-link with `?notificationId=<uuid>` (plugin-driven clear).
+- **Legacy migration**: `publishNotification()` becomes a thin wrapper over `notifier.schedule({ lifecycle: "fyi", firesAt: now })`, mapping the old `NotificationKind` source category to a synthetic `pluginPkg` (`todo` / `scheduler` / `agent` / `journal` keep their names; `push` / `bridge` / `system` collapse under `"host"`). All current callers keep working unchanged.
+
+Test coverage extends PR 2's: state machine transitions, severity → channel mapping, snooze re-evaluation, re-surface timing, `listFor` / `get` recovery semantics, restart-survives-pending under timer load, full Playwright E2E driving the debug page through every reachable state. Risk of regression in current notification UX is mitigated by the wrapper preserving `publishNotification()` semantics exactly.
+
+Acceptance bar: every state transition reachable from the debug page; existing bell + toast UX is byte-for-byte identical for legacy callers.
+
+### PR 4 — Encore plugin (CRUD only, no reminders)
 
 Plugin scaffold: `meta.ts`, `definition.ts`, `index.ts`, `View.vue`, `Preview.vue`. Server: `server/encore/` with file IO + `manageEncore` actions for obligation CRUD, `openInstance`, `addItem` / `updateItem` / `removeItem`, `diffFromLast`. Standalone `/encore` route. **No notifier integration yet** — proves the data model (including multi-item instances) works in isolation.
 
-### PR 4 — Encore × Notifier integration
+### PR 5 — Encore × Notifier integration
 
-Encore translates obligation + item state into `notifier.schedule()` calls. All three kinds get exercised: `fyi` for "instance opened" confirmations, `read` for "diff-from-last is ready," `action` for "pay H2 property tax." Wire `notifier.clear()` on `closeInstance` / `updateItem(status: done)`. Wire `notifier.signal()` for domain conditions (`"encore:taxes:w2-received"`). Progress-aware suppression based on item-completion percentage. The "magnetic feature" demo: open an instance, see last year's data pre-populated, see the next-action reminder already scheduled.
+Encore translates obligation + item state into `notifier.schedule()` calls. Both lifecycles get exercised: `fyi` for "instance opened" confirmations and post-completion summaries, `action` for "pay H2 property tax" / "diff-from-last is ready" — anything where the user needs to land on Encore's view to act. Wire `notifier.clear()` on `closeInstance` / `updateItem(status: done)` / Encore's view mount (for read-once notifications). Wire `notifier.signal()` for domain conditions (`"encore:taxes:w2-received"`). Progress-aware suppression based on item-completion percentage. The "magnetic feature" demo: open an instance, see last year's data pre-populated, see the next-action reminder already scheduled.
 
 ---
 
@@ -518,7 +553,17 @@ Encore translates obligation + item state into `notifier.schedule()` calls. All 
 
 PR 1 resolved: client-only `VITE_DEV_MODE` flag, no server-side mirror, no runtime endpoint.
 
-To resolve before PR 2 (Notifier):
+PR 2 (Notifier prototype) resolved during design discussion:
+
+- API surface stripped to `publish` / `clear` / `cancel` / `get` / `listFor` / `listAll` (no `markSeen` / `acknowledge` — `clear` is the single "user dealt with it" verb).
+- Persistence is a single `active.json` holding only active entries (not append-only) — bounded size, simple to read.
+- Write serialization uses an in-memory `writing` flag + waiter queue that drains until empty, coalescing N rapid mutations into ≤2 disk writes.
+- Multiple `pluginPkg` values (`debug__system`, `debug__news`, `debug__encore`, …) drive the scripted test so namespace separation is visible.
+- HTTP shape is dispatch (`POST /api/notifier` with `action` field), matching `manage*` tools.
+- Debug page subscribes to the new `notifier` pub/sub channel for live updates; no manual publish/clear forms.
+- Pub/sub granularity: single global `notifier` channel (option A). Per-`pluginPkg` channels and dual-emit (global + per-pluginPkg) considered and rejected for v1 — debug page and the future bell badge both want global view; per-plugin client-side filtering is cheap.
+
+To resolve before PR 3 (Notifier full engine):
 
 1. **Declarative vs imperative scheduling.** Plan above is *imperative* — plugin computes each fire time and re-registers. A declarative spec ("every Sunday until acked, escalate after 2 weeks") is more powerful but a bigger surface. Imperative matches how `task-scheduler` already works; declarative may be worth it once we see 3+ plugins repeating the same pattern. **Default: imperative for v1.**
 2. **Type-1 panel affordance: button or checkbox?** Per-row close-button is simplest; leading checkbox + bulk "Acknowledge selected" wins for catch-up sessions where many `fyi` rows pile up. **Default: leading checkbox (covers both — single-row click still works via the row's own close-`×`).**
@@ -527,7 +572,7 @@ To resolve before PR 2 (Notifier):
 5. ~~**Signal namespace.**~~ Resolved by the identity model: signals are structurally scoped as `{ pluginPkg, key }`, so collisions across plugins are impossible by construction. No string-prefix convention to enforce.
 6. **Conflict with `task-scheduler`.** The existing scheduler also fires things on a schedule. Notifier is *user-facing reminders*; scheduler is *task execution*. They may share scheduling primitives internally; they should not share API surfaces. **Default: keep them separate; revisit if duplication becomes painful.**
 
-To resolve before PR 3 (Encore CRUD):
+To resolve before PR 4 (Encore CRUD):
 
 7. **i18n surface for Encore.** All 8 locales need the obligation-type vocabulary ("taxes", "registration", "annual physical"). Are these built-in templates the user picks from, or free-form titles the user types? **Default: free-form for v1, suggested templates as a chat-side affordance.**
 

--- a/server/api/routes/notifier.ts
+++ b/server/api/routes/notifier.ts
@@ -1,0 +1,125 @@
+// Single dispatch endpoint matching the `manage*` tool pattern.
+// Body: { action: "publish" | "clear" | "cancel" | "list", ... }.
+
+import { Router, type Request, type Response } from "express";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { cancel, clear, listAll, publish } from "../../notifier/engine.js";
+import {
+  NOTIFIER_LIFECYCLES,
+  NOTIFIER_SEVERITIES,
+  type NotifierEntry,
+  type NotifierLifecycle,
+  type NotifierSeverity,
+  type PublishInput,
+} from "../../notifier/types.js";
+import { log } from "../../system/logger/index.js";
+
+interface DispatchBody {
+  action?: unknown;
+  // publish
+  pluginPkg?: unknown;
+  severity?: unknown;
+  title?: unknown;
+  body?: unknown;
+  lifecycle?: unknown;
+  pluginData?: unknown;
+  // clear / cancel
+  id?: unknown;
+}
+
+type DispatchResponse = { id: string } | { ok: true } | { entries: NotifierEntry[] } | { error: string };
+
+const SEVERITY_SET = new Set<string>(NOTIFIER_SEVERITIES);
+const LIFECYCLE_SET = new Set<string>(NOTIFIER_LIFECYCLES);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function asSeverity(value: unknown): NotifierSeverity | null {
+  return typeof value === "string" && SEVERITY_SET.has(value) ? (value as NotifierSeverity) : null;
+}
+
+function asLifecycle(value: unknown): NotifierLifecycle | undefined {
+  // `lifecycle` is optional. An undefined / missing field is fine;
+  // a present-but-invalid value is rejected at the HTTP layer rather
+  // than silently dropped, so clients get a clear 400.
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string" && LIFECYCLE_SET.has(value)) return value as NotifierLifecycle;
+  return undefined;
+}
+
+function parsePublishInput(body: DispatchBody): PublishInput | string {
+  if (!isNonEmptyString(body.pluginPkg)) return "pluginPkg required";
+  if (!isNonEmptyString(body.title)) return "title required";
+  const severity = asSeverity(body.severity);
+  if (!severity) return "severity must be one of info | nudge | urgent";
+  if (body.lifecycle !== undefined && body.lifecycle !== null && asLifecycle(body.lifecycle) === undefined) {
+    return "lifecycle must be one of fyi | action when set";
+  }
+  if (body.body !== undefined && body.body !== null && typeof body.body !== "string") {
+    return "body must be a string when set";
+  }
+  return {
+    pluginPkg: body.pluginPkg,
+    severity,
+    title: body.title,
+    body: typeof body.body === "string" ? body.body : undefined,
+    lifecycle: asLifecycle(body.lifecycle),
+    pluginData: body.pluginData,
+  };
+}
+
+const notifierRouter: Router = Router();
+
+notifierRouter.post(API_ROUTES.notifier.dispatch, async (req: Request<object, DispatchResponse, DispatchBody>, res: Response<DispatchResponse>) => {
+  const body = req.body ?? {};
+  const { action } = body;
+  try {
+    switch (action) {
+      case "publish": {
+        const input = parsePublishInput(body);
+        if (typeof input === "string") {
+          res.status(400).json({ error: input });
+          return;
+        }
+        const result = await publish(input);
+        res.json(result);
+        return;
+      }
+      case "clear": {
+        if (!isNonEmptyString(body.id)) {
+          res.status(400).json({ error: "id required" });
+          return;
+        }
+        await clear(body.id);
+        res.json({ ok: true });
+        return;
+      }
+      case "cancel": {
+        if (!isNonEmptyString(body.id)) {
+          res.status(400).json({ error: "id required" });
+          return;
+        }
+        await cancel(body.id);
+        res.json({ ok: true });
+        return;
+      }
+      case "list": {
+        const entries = await listAll();
+        res.json({ entries });
+        return;
+      }
+      default:
+        res.status(400).json({ error: `unknown action: ${typeof action === "string" ? action : "<missing>"}` });
+    }
+  } catch (err) {
+    log.error("notifier-route", "dispatch failed", {
+      action: typeof action === "string" ? action : "<unknown>",
+      error: String(err),
+    });
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+export default notifierRouter;

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,8 @@ import { registerRuntimePlugins } from "./plugins/runtime-registry.js";
 import { makePluginRuntime } from "./plugins/runtime.js";
 import { MCP_PLUGIN_NAMES } from "./agent/plugin-names.js";
 import { createNotificationsRouter } from "./api/routes/notifications.js";
+import notifierRoutes from "./api/routes/notifier.js";
+import { initNotifier } from "./notifier/engine.js";
 import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { type NotificationDeps, initNotifications } from "./events/notifications.js";
@@ -542,6 +544,7 @@ const notificationDeps: NotificationDeps = {
   pushToBridge: chatService.pushToBridge,
 };
 app.use(createNotificationsRouter(notificationDeps));
+app.use(notifierRoutes);
 app.use(createJournalRouter());
 app.use(createTranslationRouter());
 app.use(mcpToolsRouter);
@@ -698,6 +701,14 @@ function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: n
   initNotifications({
     publish: (channel, payload) => pubsub.publish(channel, payload),
     pushToBridge: chatService.pushToBridge,
+  });
+
+  // --- Notifier engine (separate from `events/notifications.ts`).
+  // Routes mounted at module-load above; engine emit is wired here
+  // once pubsub exists. Mutating APIs called between mount and this
+  // call would persist state but log a warning instead of emitting.
+  initNotifier({
+    publish: (channel, payload) => pubsub.publish(channel, payload),
   });
 
   // --- Plugin META aggregator diagnostics ---

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -1,0 +1,224 @@
+// Notifier engine — single-process, single-file, single-channel.
+//
+// API surface: publish / clear / cancel / get / listFor / listAll.
+// Mutations queue through a writing-flag + waiter-queue coordinator
+// so concurrent callers can't race on the underlying `writeFileAtomic`
+// rename. Reads bypass the queue (`writeFileAtomic`'s rename
+// atomicity makes half-reads impossible) and trade strict
+// linearisability for simpler code: the contract is "after `await
+// publish(x)` resolves, subsequent reads see x" — which holds because
+// `publish` awaits the persist before returning.
+
+import { randomUUID } from "crypto";
+import { PUBSUB_CHANNELS } from "../../src/config/pubsubChannels.js";
+import { log } from "../system/logger/index.js";
+import { WORKSPACE_PATHS } from "../workspace/paths.js";
+import { loadActive, saveActive } from "./store.js";
+import type { NotifierEntry, NotifierEvent, NotifierFile, PublishInput } from "./types.js";
+
+// ── Dependency injection (matches server/events/notifications.ts) ──
+
+export interface NotifierDeps {
+  publish: (channel: string, payload: unknown) => void;
+}
+
+let deps: NotifierDeps | null = null;
+
+export function initNotifier(injected: NotifierDeps): void {
+  deps = injected;
+}
+
+function emit(event: NotifierEvent): void {
+  if (!deps) {
+    // Calling a mutation API before `initNotifier` runs would mean
+    // emitting into the void. We log and continue (state still
+    // persists) so the engine remains usable if startup ordering
+    // ever changes — but in practice `initNotifier` is wired in
+    // `startRuntimeServices`, before any HTTP request can arrive.
+    log.warn("notifier", "emit before init", { type: event.type });
+    return;
+  }
+  deps.publish(PUBSUB_CHANNELS.notifier, event);
+}
+
+// ── Write coordinator ─────────────────────────────────────────────
+
+/** A mutation function applied to the in-memory state object during
+ *  drain. Returns the event to emit, or `null` to indicate "no
+ *  state change" — the drainer skips the disk write and the emit
+ *  when every mutation in a batch returned `null`.
+ *
+ *  Mutations MUST NOT modify state when returning `null` (see
+ *  `clear` / `cancel` for the unknown-id case). Violating this
+ *  invariant produces a write skip with stale on-disk state. */
+type Mutation = (state: NotifierFile) => NotifierEvent | null;
+
+interface Waiter {
+  mutate: Mutation;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+}
+
+type MutationResult = { ok: true; event: NotifierEvent | null } | { ok: false; error: unknown };
+
+let writing = false;
+let waiters: Waiter[] = [];
+
+let activeFilePath: string = WORKSPACE_PATHS.notifierActive;
+
+/** Test-only: redirect the engine at a temp file. Kept off the public
+ *  API surface (the underscore prefix + the `_setActiveFilePathForTesting`
+ *  name) so production code can't accidentally rebind. Resets the queue
+ *  too — a leftover write in flight from a previous test would
+ *  otherwise persist into the next test's tmp dir. */
+export function _setActiveFilePathForTesting(filePath: string): void {
+  activeFilePath = filePath;
+  writing = false;
+  waiters = [];
+}
+
+function applyBatchMutations(batch: Waiter[], state: NotifierFile): MutationResult[] {
+  return batch.map((waiter) => {
+    try {
+      return { ok: true, event: waiter.mutate(state) };
+    } catch (err) {
+      return { ok: false, error: err };
+    }
+  });
+}
+
+function collectEvents(results: MutationResult[]): NotifierEvent[] {
+  const events: NotifierEvent[] = [];
+  for (const result of results) {
+    if (result.ok && result.event !== null) events.push(result.event);
+  }
+  return events;
+}
+
+function settleBatch(batch: Waiter[], results: MutationResult[]): void {
+  // Resolves come AFTER any emits so subscribers see the event
+  // before the caller's `await` returns.
+  for (let index = 0; index < batch.length; index += 1) {
+    const result = results[index];
+    if (result.ok) batch[index].resolve();
+    else batch[index].reject(result.error);
+  }
+}
+
+function rejectBatch(batch: Waiter[], err: unknown): void {
+  for (const waiter of batch) waiter.reject(err);
+}
+
+async function processBatch(batch: Waiter[]): Promise<void> {
+  let state: NotifierFile;
+  try {
+    state = await loadActive(activeFilePath);
+  } catch (err) {
+    log.error("notifier", "load failed", { error: String(err) });
+    rejectBatch(batch, err);
+    return;
+  }
+  const results = applyBatchMutations(batch, state);
+  const events = collectEvents(results);
+  if (events.length > 0) {
+    try {
+      await saveActive(activeFilePath, state);
+    } catch (err) {
+      log.error("notifier", "write failed", { error: String(err) });
+      // A failing write means none of this batch's state changes are
+      // durable. Reject every waiter — including any whose mutation
+      // returned `null` — because the batch as a whole failed to
+      // commit. Resolving the no-ops while rejecting the contributors
+      // would let a sibling caller observe a "succeeded" no-op clear
+      // alongside a publish that didn't actually persist.
+      rejectBatch(batch, err);
+      return;
+    }
+    for (const event of events) emit(event);
+  }
+  settleBatch(batch, results);
+}
+
+async function drain(): Promise<void> {
+  writing = true;
+  try {
+    while (waiters.length > 0) {
+      const batch = waiters;
+      waiters = [];
+      await processBatch(batch);
+    }
+  } finally {
+    writing = false;
+  }
+}
+
+function enqueue(mutate: Mutation): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    waiters.push({ mutate, resolve, reject });
+    // First caller while idle kicks off the drain; subsequent callers
+    // just leave their resolver in the queue. `void` because drain is
+    // fire-and-forget — the per-waiter promise is the resolution
+    // path the caller awaits.
+    if (!writing) void drain();
+  });
+}
+
+function removeEntry(state: NotifierFile, entryId: string): NotifierFile["entries"] {
+  // `delete state.entries[id]` is the obvious form, but the codebase
+  // bans dynamic delete (`@typescript-eslint/no-dynamic-delete`).
+  // Object-rest excludes the key without invoking `delete`.
+  const { [entryId]: __removed, ...remaining } = state.entries;
+  return remaining;
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+export async function publish<TPluginData = unknown>(input: PublishInput<TPluginData>): Promise<{ id: string }> {
+  const entryId = randomUUID();
+  const entry: NotifierEntry<TPluginData> = {
+    id: entryId,
+    pluginPkg: input.pluginPkg,
+    severity: input.severity,
+    lifecycle: input.lifecycle,
+    title: input.title,
+    body: input.body,
+    pluginData: input.pluginData,
+    createdAt: new Date().toISOString(),
+  };
+  await enqueue((state) => {
+    state.entries[entryId] = entry as NotifierEntry;
+    return { type: "published", entry: entry as NotifierEntry };
+  });
+  return { id: entryId };
+}
+
+export async function clear(entryId: string): Promise<void> {
+  await enqueue((state) => {
+    if (!(entryId in state.entries)) return null;
+    state.entries = removeEntry(state, entryId);
+    return { type: "cleared", id: entryId };
+  });
+}
+
+export async function cancel(entryId: string): Promise<void> {
+  await enqueue((state) => {
+    if (!(entryId in state.entries)) return null;
+    state.entries = removeEntry(state, entryId);
+    return { type: "cancelled", id: entryId };
+  });
+}
+
+export async function get(entryId: string): Promise<NotifierEntry | undefined> {
+  const state = await loadActive(activeFilePath);
+  return state.entries[entryId];
+}
+
+export async function listFor(pluginPkg: string): Promise<NotifierEntry[]> {
+  const state = await loadActive(activeFilePath);
+  return Object.values(state.entries).filter((entry) => entry.pluginPkg === pluginPkg);
+}
+
+export async function listAll(): Promise<NotifierEntry[]> {
+  const state = await loadActive(activeFilePath);
+  return Object.values(state.entries);
+}

--- a/server/notifier/store.ts
+++ b/server/notifier/store.ts
@@ -1,0 +1,39 @@
+// Low-level file I/O for the notifier. Kept separate from `engine.ts`
+// so unit tests can override the file path without monkey-patching
+// `WORKSPACE_PATHS`.
+
+import { promises as fsPromises } from "fs";
+import { writeFileAtomic } from "../utils/files/atomic.js";
+import type { NotifierFile } from "./types.js";
+
+function isNotFoundError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: unknown }).code === "ENOENT";
+}
+
+/** Read the active-entries file. Returns an empty store when the file
+ *  doesn't exist yet (first ever call on a fresh workspace). Any other
+ *  read or parse failure throws — the caller has to decide whether to
+ *  surface or recover, since silently treating "malformed file" as
+ *  "no entries" would lose data. */
+export async function loadActive(filePath: string): Promise<NotifierFile> {
+  let text: string;
+  try {
+    text = await fsPromises.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (isNotFoundError(err)) return { entries: {} };
+    throw err;
+  }
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed) || typeof (parsed as { entries: unknown }).entries !== "object") {
+    throw new Error(`notifier: malformed active.json at ${filePath}`);
+  }
+  return parsed as NotifierFile;
+}
+
+/** Write the active-entries file via `writeFileAtomic` so a half-
+ *  written file is never visible to readers. The caller serialises
+ *  writes (engine.ts queues mutations) — this function makes no
+ *  concurrency guarantees of its own. */
+export async function saveActive(filePath: string, state: NotifierFile): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(state, null, 2));
+}

--- a/server/notifier/types.ts
+++ b/server/notifier/types.ts
@@ -1,0 +1,69 @@
+// Notifier value types. Kept separate from `engine.ts` so the API
+// route layer (server/api/routes/notifier.ts) can validate inbound
+// payloads against the same enum constants the engine accepts —
+// importing the engine just for its types would pull in fs / pubsub
+// dependencies the route doesn't need.
+
+/** UI hint only. The engine never reads `lifecycle` — it's stored
+ *  on the entry and forwarded to subscribers so the UI can render
+ *  rows differently:
+ *
+ *    `fyi`    — bell panel renders a checkbox + "Acknowledge selected"
+ *               button; the host calls `clear` when the user acks.
+ *    `action` — row is a hyperlink routing to the plugin's view; the
+ *               plugin calls `clear` (on view mount for read-once
+ *               notifications, or after a domain action completes).
+ *
+ *  An earlier draft split `action` into `read` and `action` based on
+ *  who fires the close — but from the engine's perspective both are
+ *  "the plugin owns the close call", so the distinction was bookkeeping
+ *  with no runtime effect. */
+export const NOTIFIER_LIFECYCLES = ["fyi", "action"] as const;
+export type NotifierLifecycle = (typeof NOTIFIER_LIFECYCLES)[number];
+
+/** Severity drives badge color and (in a future iteration) channel
+ *  routing. The engine itself only stores it on the entry. */
+export const NOTIFIER_SEVERITIES = ["info", "nudge", "urgent"] as const;
+export type NotifierSeverity = (typeof NOTIFIER_SEVERITIES)[number];
+
+export interface NotifierEntry<TPluginData = unknown> {
+  /** Engine-assigned UUID. Generated synchronously inside `publish()`
+   *  so the caller can use it before persistence completes. */
+  id: string;
+  /** Plugin namespace (e.g. `"encore"`, `"debug__system"`). The
+   *  engine never inspects it — used only for `listFor()` filtering
+   *  and as a UI grouping key. */
+  pluginPkg: string;
+  severity: NotifierSeverity;
+  lifecycle?: NotifierLifecycle;
+  title: string;
+  body?: string;
+  /** Opaque to the engine. Round-trips through JSON unchanged; only
+   *  the originating plugin's UI knows the shape. */
+  pluginData?: TPluginData;
+  /** ISO-8601 timestamp set at `publish()` time. */
+  createdAt: string;
+}
+
+/** Caller-supplied input for `publish()`. The engine fills in `id`
+ *  and `createdAt`; everything else flows through verbatim. */
+export interface PublishInput<TPluginData = unknown> {
+  pluginPkg: string;
+  severity: NotifierSeverity;
+  title: string;
+  body?: string;
+  lifecycle?: NotifierLifecycle;
+  pluginData?: TPluginData;
+}
+
+/** On-disk shape of `~/mulmoclaude/data/notifier/active.json`. Holds
+ *  only entries that haven't been cleared or cancelled — the file is
+ *  a snapshot, not an event log. */
+export interface NotifierFile {
+  entries: Record<string, NotifierEntry>;
+}
+
+/** Pub-sub event published on `PUBSUB_CHANNELS.notifier` after every
+ *  successful state change. Discriminated union — subscribers switch
+ *  on `type` to keep TypeScript narrowing the rest of the payload. */
+export type NotifierEvent = { type: "published"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -156,6 +156,7 @@ const HOST_WORKSPACE_DIRS = {
   // backup target; config holds per-machine UI state / defaults.
   pluginsData: "data/plugins",
   pluginsConfig: "config/plugins",
+  notifier: "data/notifier",
 } as const;
 
 // First-write-wins host+plugin aggregate (see `defineHostAggregate`):

--- a/src/components/NotifierDebugPopup.vue
+++ b/src/components/NotifierDebugPopup.vue
@@ -1,0 +1,377 @@
+<script setup lang="ts">
+// Top-bar debug surface for the host notifier engine. Visible only
+// when `VITE_DEV_MODE === "1"` (the same gate as the Debug role in
+// `RoleSelector`). Lives next to the bell so a developer can fire
+// the scripted test without leaving whatever screen they're on.
+//
+// No i18n by design: this popup is dev-only chrome, never seen by
+// end users — every string is a literal English value kept in this
+// file. Don't extract these into vue-i18n.
+//
+// Subscribes to the host's `notifier` pub/sub channel directly via
+// `usePubSub`. Runtime plugins can't see this channel because their
+// `BrowserPluginRuntime.pubsub` is hard-scoped to `plugin:<pkg>:*`,
+// which is why the harness lives here in host code rather than under
+// `@mulmoclaude/debug-plugin`.
+
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { usePubSub } from "../composables/usePubSub";
+import { apiPost } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+import { PUBSUB_CHANNELS } from "../config/pubsubChannels";
+
+interface NotifierEntry {
+  id: string;
+  pluginPkg: string;
+  severity: "info" | "nudge" | "urgent";
+  lifecycle?: "fyi" | "action";
+  title: string;
+  body?: string;
+  pluginData?: unknown;
+  createdAt: string;
+}
+
+type NotifierEvent = { type: "published"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };
+
+const open = ref(false);
+const rootRef = ref<HTMLElement | null>(null);
+const entries = ref<NotifierEntry[]>([]);
+const status = ref<string>("idle");
+const running = ref(false);
+
+const devMode = import.meta.env.VITE_DEV_MODE === "1";
+
+const visibleEntries = computed(() => [...entries.value].sort((left, right) => left.createdAt.localeCompare(right.createdAt)));
+
+const badgeText = computed(() => (entries.value.length > 99 ? "99+" : String(entries.value.length)));
+
+// Worst-severity-wins: any urgent → red, else any nudge → amber,
+// else gray. Mirrors the bell-badge color encoding called out in
+// plans/feat-encore.md ("one glance answers 'is anything on fire?'
+// without opening the panel").
+const badgeColor = computed(() => {
+  if (entries.value.some((entry) => entry.severity === "urgent")) return "bg-red-500";
+  if (entries.value.some((entry) => entry.severity === "nudge")) return "bg-amber-500";
+  return "bg-gray-400";
+});
+
+async function refreshList(): Promise<void> {
+  const result = await apiPost<{ entries: NotifierEntry[] }>(API_ROUTES.notifier.dispatch, { action: "list" });
+  if (result.ok) entries.value = result.data.entries;
+  else status.value = `list failed: ${result.error}`;
+}
+
+function applyEvent(event: NotifierEvent): void {
+  switch (event.type) {
+    case "published":
+      // De-dup: skip if we already have it (e.g. our own publish call
+      // returned and we updated locally before the pubsub round-trip).
+      if (!entries.value.some((entry) => entry.id === event.entry.id)) {
+        entries.value = [...entries.value, event.entry];
+      }
+      return;
+    case "cleared":
+    case "cancelled":
+      entries.value = entries.value.filter((entry) => entry.id !== event.id);
+  }
+}
+
+const { subscribe } = usePubSub();
+let unsubscribe: (() => void) | null = null;
+
+onMounted(() => {
+  unsubscribe = subscribe(PUBSUB_CHANNELS.notifier, (data) => applyEvent(data as NotifierEvent));
+  document.addEventListener("mousedown", onDocumentClick);
+  // Prime the local list so the badge reflects existing entries
+  // before the user opens the popup. Fire-and-forget — a transient
+  // failure surfaces in the popup's status line on next open.
+  void refreshList();
+});
+
+onUnmounted(() => {
+  unsubscribe?.();
+  document.removeEventListener("mousedown", onDocumentClick);
+});
+
+function onDocumentClick(event: MouseEvent): void {
+  if (!open.value || !rootRef.value) return;
+  if (!rootRef.value.contains(event.target as Node)) open.value = false;
+}
+
+async function toggle(): Promise<void> {
+  open.value = !open.value;
+  if (open.value) await refreshList();
+}
+
+// ── Scripted test ─────────────────────────────────────────────────
+
+interface ScriptStep {
+  delayMs: number;
+  do: () => Promise<void>;
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function publish(args: {
+  pluginPkg: string;
+  severity: "info" | "nudge" | "urgent";
+  lifecycle: "fyi" | "action";
+  title: string;
+  body?: string;
+}): Promise<string | null> {
+  const result = await apiPost<{ id: string }>(API_ROUTES.notifier.dispatch, { action: "publish", ...args });
+  if (result.ok) return result.data.id;
+  status.value = `publish failed: ${result.error}`;
+  return null;
+}
+
+async function clear(entryId: string): Promise<void> {
+  const result = await apiPost<{ ok: true }>(API_ROUTES.notifier.dispatch, { action: "clear", id: entryId });
+  if (!result.ok) status.value = `clear failed: ${result.error}`;
+}
+
+async function cancel(entryId: string): Promise<void> {
+  const result = await apiPost<{ ok: true }>(API_ROUTES.notifier.dispatch, { action: "cancel", id: entryId });
+  if (!result.ok) status.value = `cancel failed: ${result.error}`;
+}
+
+async function cleanupLeftoverDebugEntries(): Promise<void> {
+  const result = await apiPost<{ entries: NotifierEntry[] }>(API_ROUTES.notifier.dispatch, { action: "list" });
+  if (!result.ok) return;
+  const stale = result.data.entries.filter((entry) => entry.pluginPkg.startsWith("debug__"));
+  // Sequential rather than parallel: parallel `clear` calls would
+  // race through the engine's drain queue but offer no real speedup
+  // here, and sequential keeps the visible state changes orderly.
+  for (const entry of stale) await clear(entry.id);
+}
+
+async function runScriptedTest(): Promise<void> {
+  if (running.value) return;
+  running.value = true;
+  status.value = "cleaning up leftover entries…";
+  await cleanupLeftoverDebugEntries();
+
+  const startedAt = performance.now();
+  status.value = "running…";
+
+  // Capture ids of the entries we publish so we can clear/cancel
+  // them later in the script. Local state — the engine assigns
+  // the canonical id and returns it from `publish`.
+  const ids: Record<string, string | null> = { a: null, b: null, c: null, d: null, e: null, f: null, g: null, h: null };
+
+  const steps: ScriptStep[] = [
+    {
+      delayMs: 0,
+      do: async () => {
+        ids.a = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Backup completed" });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.b = await publish({
+          pluginPkg: "debug__news",
+          severity: "nudge",
+          lifecycle: "action",
+          title: "News digest ready",
+          body: "12 new items since yesterday",
+        });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.c = await publish({ pluginPkg: "debug__encore", severity: "urgent", lifecycle: "action", title: "Pay property tax", body: "Due 2026-12-15" });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.d = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Build #42 finished" });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.e = await publish({ pluginPkg: "debug__news", severity: "info", lifecycle: "action", title: "Weekly summary ready" });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.f = await publish({
+          pluginPkg: "debug__journal",
+          severity: "nudge",
+          lifecycle: "action",
+          title: "Yesterday's journal needs review",
+          body: "3 sections drafted, awaiting your sign-off",
+        });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.g = await publish({
+          pluginPkg: "debug__taxes",
+          severity: "urgent",
+          lifecycle: "action",
+          title: "W-2 received, file by Apr 15",
+          body: "Auto-imported from email",
+        });
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        ids.h = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Disk usage 78%" });
+      },
+    },
+    {
+      // Peak: 8 entries visible across 5 plugin namespaces. The
+      // cleanup phase below interleaves clear and cancel to show
+      // both terminal verbs in flight.
+      delayMs: 600,
+      do: async () => {
+        if (ids.b) await clear(ids.b);
+      },
+    },
+    {
+      delayMs: 400,
+      do: async () => {
+        if (ids.a) await clear(ids.a);
+      },
+    },
+    {
+      delayMs: 500,
+      do: async () => {
+        if (ids.f) await cancel(ids.f);
+      },
+    },
+    {
+      delayMs: 500,
+      do: async () => {
+        if (ids.h) await clear(ids.h);
+      },
+    },
+    {
+      delayMs: 500,
+      do: async () => {
+        if (ids.e) await clear(ids.e);
+      },
+    },
+    {
+      delayMs: 500,
+      do: async () => {
+        if (ids.c) await cancel(ids.c);
+      },
+    },
+    {
+      delayMs: 600,
+      do: async () => {
+        if (ids.d) await clear(ids.d);
+      },
+    },
+    {
+      delayMs: 600,
+      do: async () => {
+        if (ids.g) await clear(ids.g);
+      },
+    },
+  ];
+
+  for (const step of steps) {
+    if (step.delayMs > 0) await sleep(step.delayMs);
+    await step.do();
+  }
+
+  const elapsed = Math.round(performance.now() - startedAt);
+  status.value = `✓ done in ${elapsed}ms`;
+  running.value = false;
+}
+
+// ── Display helpers (literal strings, dev-only) ───────────────────
+
+function severityDot(severity: NotifierEntry["severity"]): string {
+  switch (severity) {
+    case "urgent":
+      return "bg-red-500";
+    case "nudge":
+      return "bg-amber-500";
+    case "info":
+    default:
+      return "bg-gray-300";
+  }
+}
+</script>
+
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text --
+  Dev-only debug surface, gated by `VITE_DEV_MODE === "1"`. Strings
+  are literal English by design (see file header) — never seen by
+  end users, never extracted into vue-i18n. -->
+<template>
+  <div v-if="devMode" ref="rootRef" class="relative">
+    <button
+      type="button"
+      data-testid="notifier-debug-button"
+      class="relative h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700"
+      title="Notifier debug"
+      aria-label="Notifier debug"
+      @click="toggle"
+    >
+      <span class="material-icons">bug_report</span>
+      <span
+        v-if="entries.length > 0"
+        :class="[
+          'absolute -top-1.5 -right-1.5 min-w-[1rem] h-4 px-0.5 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none',
+          badgeColor,
+        ]"
+        data-testid="notifier-debug-badge"
+      >
+        {{ badgeText }}
+      </span>
+    </button>
+    <div
+      v-if="open"
+      data-testid="notifier-debug-popup"
+      class="absolute left-0 top-full mt-1 w-96 max-h-[70vh] bg-white border border-gray-200 rounded-lg shadow-lg z-50 flex flex-col text-xs"
+    >
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
+        <span class="font-semibold text-gray-700">Notifier debug</span>
+        <span class="text-gray-400">— {{ visibleEntries.length }} active</span>
+        <span class="ml-auto text-gray-500">{{ status }}</span>
+      </div>
+      <div class="px-3 py-2 border-b border-gray-100">
+        <button
+          type="button"
+          data-testid="notifier-debug-run"
+          class="w-full px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="running"
+          @click="runScriptedTest"
+        >
+          {{ running ? "Running…" : "Run scripted test" }}
+        </button>
+      </div>
+      <div class="flex-1 overflow-y-auto">
+        <p v-if="visibleEntries.length === 0" class="px-3 py-4 text-gray-400 italic">No active entries</p>
+        <ul v-else class="divide-y divide-gray-100">
+          <li v-for="entry in visibleEntries" :key="entry.id" data-testid="notifier-debug-entry" class="px-3 py-2">
+            <div class="flex items-start gap-2">
+              <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0', severityDot(entry.severity)]" :title="entry.severity"></span>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-baseline gap-2">
+                  <span class="font-medium text-gray-800 truncate">{{ entry.title }}</span>
+                  <span v-if="entry.lifecycle" class="text-[10px] uppercase tracking-wide text-gray-400">{{ entry.lifecycle }}</span>
+                </div>
+                <div v-if="entry.body" class="text-gray-600 mt-0.5 truncate">{{ entry.body }}</div>
+                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ entry.pluginPkg }} · {{ entry.id.slice(0, 8) }}</div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+<!-- eslint-enable @intlify/vue-i18n/no-raw-text -->

--- a/src/components/SidebarHeader.vue
+++ b/src/components/SidebarHeader.vue
@@ -22,6 +22,7 @@
         @test-query="(q) => emit('testQuery', q)"
       />
       <NotificationBell :force-close="lockPopupOpen" @navigate="(action) => emit('notificationNavigate', action)" @update:open="onNotificationOpen" />
+      <NotifierDebugPopup />
       <button
         class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
         data-testid="today-journal-btn"
@@ -56,6 +57,7 @@ import { computed, onBeforeUnmount, onMounted, ref, type CSSProperties } from "v
 import { useI18n } from "vue-i18n";
 import LockStatusPopup from "./LockStatusPopup.vue";
 import NotificationBell from "./NotificationBell.vue";
+import NotifierDebugPopup from "./NotifierDebugPopup.vue";
 import { useClickOutside } from "../composables/useClickOutside";
 import { useLatestDaily } from "../composables/useLatestDaily";
 import type { NotificationPayload } from "../types/notification";

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -125,6 +125,13 @@ const HOST_API_ROUTES = {
     test: "/api/notifications/test",
   },
 
+  /** Notifier dispatch — single endpoint, body carries `{ action,
+   *  ... }`. Matches the `manage*` tool pattern used elsewhere
+   *  (manageEncore / manageAccounting / manageSkills). */
+  notifier: {
+    dispatch: "/api/notifier",
+  },
+
   journal: {
     // Most recent existing daily summary (today, falling back to
     // prior days). Backs the top-bar "today's journal" shortcut

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -147,6 +147,12 @@ const HOST_STATIC_CHANNELS = {
    *  `location.reload()` so the author sees their save without ⌘R.
    *  Payload: `{ name: string, changedFiles: string[], serverSideChange: boolean }`. */
   devPluginChanged: "dev-plugin-changed",
+  /** Notifier state-change events (`published` / `cleared` /
+   *  `cancelled`) as a discriminated union. Single global channel;
+   *  subscribers filter by `pluginPkg` client-side. Publisher:
+   *  `server/notifier/engine.ts` after persistence succeeds.
+   *  Payload: `NotifierEvent`. */
+  notifier: "notifier",
 } as const;
 
 // First-write-wins host+plugin aggregate (see `defineHostAggregate`):

--- a/src/config/workspacePaths.ts
+++ b/src/config/workspacePaths.ts
@@ -39,4 +39,8 @@ export const WORKSPACE_FILES = {
    *  per installed plugin; the tgz files sit alongside in `plugins/`,
    *  extracted to `plugins/.cache/<name>/<version>/` on first boot. */
   pluginsLedger: "plugins/plugins.json",
+  /** Active notifier entries — JSON file rewritten atomically on
+   *  every mutation, loaded fresh on every read. No in-memory cache;
+   *  the file is the only source of truth. */
+  notifierActive: "data/notifier/active.json",
 } as const;

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -1,0 +1,244 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
+import path from "path";
+import { tmpdir } from "os";
+import { publish, clear, cancel, get, listFor, listAll, initNotifier, _setActiveFilePathForTesting } from "../../../server/notifier/engine.js";
+import type { NotifierEvent } from "../../../server/notifier/types.js";
+
+let tmpDir = "";
+let activeFile = "";
+let emittedEvents: NotifierEvent[] = [];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-notifier-test-"));
+  activeFile = path.join(tmpDir, "active.json");
+  _setActiveFilePathForTesting(activeFile);
+  emittedEvents = [];
+  initNotifier({
+    publish: (_channel, payload) => {
+      emittedEvents.push(payload as NotifierEvent);
+    },
+  });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("publish", () => {
+  it("returns an id and stores the entry", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "Backup completed",
+    });
+    assert.match(id, /^[0-9a-f-]{36}$/);
+    const entry = await get(id);
+    assert.ok(entry);
+    assert.equal(entry?.id, id);
+    assert.equal(entry?.pluginPkg, "debug__system");
+    assert.equal(entry?.severity, "info");
+    assert.equal(entry?.title, "Backup completed");
+    assert.match(entry?.createdAt ?? "", /\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("emits a `published` event after persistence", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "hello",
+    });
+    assert.equal(emittedEvents.length, 1);
+    const [event] = emittedEvents;
+    assert.equal(event.type, "published");
+    if (event.type === "published") {
+      assert.equal(event.entry.id, id);
+    }
+  });
+
+  it("preserves opaque pluginData through JSON round-trip", async () => {
+    const pluginData = { taxYear: 2026, items: ["w2", "1099"], nested: { ok: true } };
+    const { id } = await publish({
+      pluginPkg: "encore",
+      severity: "urgent",
+      lifecycle: "action",
+      title: "File taxes",
+      pluginData,
+    });
+    const entry = await get(id);
+    assert.deepEqual(entry?.pluginData, pluginData);
+  });
+
+  it("persists across engine 'restart' (re-reading from disk)", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "persist me",
+    });
+    // Simulating a restart: drop the engine's path binding, then
+    // re-set it. The engine has no in-memory cache, so a fresh
+    // listAll() must read from disk and find the entry.
+    _setActiveFilePathForTesting(activeFile);
+    const entries = await listAll();
+    const found = entries.find((entry) => entry.id === id);
+    assert.ok(found, "entry should survive a path rebind");
+  });
+});
+
+describe("clear", () => {
+  it("removes the entry and emits `cleared`", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "clear me",
+    });
+    emittedEvents.length = 0;
+    await clear(id);
+    assert.equal(await get(id), undefined);
+    assert.equal(emittedEvents.length, 1);
+    assert.deepEqual(emittedEvents[0], { type: "cleared", id });
+  });
+
+  it("is idempotent: a second clear is a no-op (no throw, no emit)", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "x",
+    });
+    await clear(id);
+    emittedEvents.length = 0;
+    await clear(id);
+    assert.equal(emittedEvents.length, 0, "no event on duplicate clear");
+  });
+
+  it("on unknown id is a no-op (no throw, no emit, no file mutation)", async () => {
+    // Pre-publish so we have a known file state to compare against.
+    await publish({ pluginPkg: "debug__system", severity: "info", title: "marker" });
+    const before = readFileSync(activeFile, "utf-8");
+    emittedEvents.length = 0;
+    await clear("00000000-0000-0000-0000-000000000000");
+    assert.equal(emittedEvents.length, 0);
+    const after = readFileSync(activeFile, "utf-8");
+    assert.equal(after, before, "file not rewritten on no-op clear");
+  });
+});
+
+describe("cancel", () => {
+  it("removes the entry and emits `cancelled`", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__system",
+      severity: "info",
+      title: "cancel me",
+    });
+    emittedEvents.length = 0;
+    await cancel(id);
+    assert.equal(await get(id), undefined);
+    assert.equal(emittedEvents.length, 1);
+    assert.deepEqual(emittedEvents[0], { type: "cancelled", id });
+  });
+
+  it("emits `cancelled`, distinct from `cleared`, on the same removal mechanic", async () => {
+    const { id: idA } = await publish({ pluginPkg: "x", severity: "info", title: "a" });
+    const { id: idB } = await publish({ pluginPkg: "x", severity: "info", title: "b" });
+    emittedEvents.length = 0;
+    await clear(idA);
+    await cancel(idB);
+    assert.deepEqual(
+      emittedEvents.map((event) => event.type),
+      ["cleared", "cancelled"],
+    );
+  });
+});
+
+describe("listFor", () => {
+  it("returns only entries with the given pluginPkg", async () => {
+    await publish({ pluginPkg: "a", severity: "info", title: "a1" });
+    await publish({ pluginPkg: "b", severity: "info", title: "b1" });
+    await publish({ pluginPkg: "a", severity: "info", title: "a2" });
+
+    const aEntries = await listFor("a");
+    const bEntries = await listFor("b");
+    assert.equal(aEntries.length, 2);
+    assert.equal(bEntries.length, 1);
+    assert.deepEqual(aEntries.map((entry) => entry.title).sort(), ["a1", "a2"]);
+    assert.deepEqual(bEntries[0].title, "b1");
+  });
+
+  it("returns [] when nothing matches", async () => {
+    await publish({ pluginPkg: "a", severity: "info", title: "x" });
+    const result = await listFor("nope");
+    assert.deepEqual(result, []);
+  });
+
+  it("returns [] on a fresh workspace (file doesn't exist yet)", async () => {
+    assert.equal(existsSync(activeFile), false, "precondition: no file");
+    const result = await listFor("anything");
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("listAll", () => {
+  it("returns every active entry", async () => {
+    await publish({ pluginPkg: "a", severity: "info", title: "1" });
+    await publish({ pluginPkg: "b", severity: "info", title: "2" });
+    const entries = await listAll();
+    assert.equal(entries.length, 2);
+  });
+
+  it("excludes cleared / cancelled entries", async () => {
+    const { id: cleared } = await publish({ pluginPkg: "a", severity: "info", title: "c" });
+    const { id: kept } = await publish({ pluginPkg: "a", severity: "info", title: "k" });
+    await clear(cleared);
+    const entries = await listAll();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].id, kept);
+  });
+});
+
+describe("write coordination under concurrency", () => {
+  it("10 simultaneous publishes all land in the file", async () => {
+    const titles = Array.from({ length: 10 }, (_unused, index) => `concurrent-${index}`);
+    const results = await Promise.all(titles.map((title) => publish({ pluginPkg: "concur", severity: "info", title })));
+    assert.equal(new Set(results.map((result) => result.id)).size, 10, "ids are unique");
+
+    const entries = await listAll();
+    assert.equal(entries.length, 10);
+    assert.deepEqual(entries.map((entry) => entry.title).sort(), titles.slice().sort());
+  });
+
+  it("interleaved publish + clear leaves the expected residual set", async () => {
+    const published = await Promise.all(Array.from({ length: 5 }, (_unused, index) => publish({ pluginPkg: "concur", severity: "info", title: `t-${index}` })));
+    // Concurrently clear three of them while two more publishes are
+    // in flight; the queue's drainer batches them into one or two
+    // load/save cycles. End state must reflect every operation.
+    await Promise.all([
+      clear(published[0].id),
+      clear(published[1].id),
+      clear(published[2].id),
+      publish({ pluginPkg: "concur", severity: "info", title: "extra-1" }),
+      publish({ pluginPkg: "concur", severity: "info", title: "extra-2" }),
+    ]);
+
+    const entries = await listAll();
+    const titles = entries.map((entry) => entry.title).sort();
+    assert.deepEqual(titles, ["extra-1", "extra-2", "t-3", "t-4"]);
+  });
+});
+
+describe("on-disk format", () => {
+  it("writes a valid JSON document with an `entries` map", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "y" });
+    const raw = readFileSync(activeFile, "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.ok(parsed && typeof parsed === "object");
+    assert.ok(parsed.entries && typeof parsed.entries === "object");
+    assert.equal(parsed.entries[id]?.id, id);
+  });
+
+  it("creates the file on first publish (no eager init)", async () => {
+    assert.equal(existsSync(activeFile), false, "precondition: no file");
+    await publish({ pluginPkg: "x", severity: "info", title: "y" });
+    assert.equal(existsSync(activeFile), true);
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -34,6 +34,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "memoryDir",
     "memoryStaging",
     "news",
+    "notifier",
     "pluginCache",
     "plugins",
     "pluginsConfig",


### PR DESCRIPTION
## Summary

PR 2 of `plans/feat-encore.md`. Adds a parallel notification service alongside the existing `server/events/notifications.ts` (which stays untouched), plus a dev-mode debug popup next to the bell for manual testing. Lays the data-model + API-shape groundwork before PR 3 brings in timers, snooze, escalation, channel routing, and the legacy `publishNotification()` migration.

### Engine (`server/notifier/`)

- API: `publish` / `clear` / `cancel` / `get` / `listFor` / `listAll`. UUID generated synchronously inside `publish` so the caller has the id before persistence resolves.
- Two lifecycles, `fyi` and `action`. The engine never reads `lifecycle` — it's a UI hint stored on the entry. (An earlier draft split `action` into `read` and `action` based on who fires the close, but from the engine's perspective both collapse to "the plugin owns `clear`"; the plan now reflects this.)
- Persistence: single `~/mulmoclaude/data/notifier/active.json` snapshot rewritten via `writeFileAtomic` on every mutation. No in-memory cache — the file is the only source of truth. Reads bypass the queue (rename atomicity makes half-reads impossible) and trade strict linearisability for simpler code.
- **Write coordinator**: a `writing` flag + a queue of waiters that drains until empty. The first caller to find the flag clear runs `drain()`, which loops taking the current batch, applying each mutation against a fresh snapshot, writing once, then resolving the batch. Subsequent callers during a write push their resolver and return. Coalesces N rapid mutations into ≤2 disk writes and prevents the rename-race two concurrent `writeFileAtomic` calls would otherwise create.
- Pub/sub: state changes fan out on a new global `notifier` channel as a discriminated union (`published` / `cleared` / `cancelled`). Subscribers filter `pluginPkg` client-side; per-plugin channels were considered and rejected (debug page and the future bell badge both want global view).

### HTTP surface

- `POST /api/notifier` dispatch endpoint, body `{ action: "publish" | "clear" | "cancel" | "list", ... }`. Matches the `manage*` tool shape used elsewhere. Input validation is at the route layer; engine relies on TS types.

### Manual test surface (`NotifierDebugPopup`)

- New top-bar popup next to `NotificationBell` in `SidebarHeader`. Gated by `import.meta.env.VITE_DEV_MODE === "1"` — invisible in production builds (same gate as the Debug role).
- Subscribes to the `notifier` channel via `usePubSub` directly. Runtime plugins can't see this channel because their `BrowserPluginRuntime.pubsub` is hard-scoped to `plugin:<pkg>:*`, which is why the harness lives in host code rather than under `@mulmoclaude/debug-plugin`.
- Worst-severity-wins badge on the icon: any `urgent` → red, any `nudge` → amber, else gray. `99+` cap.
- Single `Run scripted test` button drives a ~7 s sequence: 8 publishes across 5 plugin namespaces (`debug__system`, `debug__news`, `debug__encore`, `debug__journal`, `debug__taxes`) at multiple severities and lifecycles, peaking at 8 simultaneous entries, then interleaved `clear` and `cancel` until the list is empty. Pre-run cleanup clears any leftover `debug__*` entries from a prior aborted run.

### Plan updates

`plans/feat-encore.md` updated throughout: PR 1 marked merged; PR 2 rewritten as the prototype scope (this PR); PR 3 carries the timer/snooze/escalation/migration work; lifecycles collapsed from 3 to 2; pub/sub granularity decision (single global channel) recorded under "Resolved during design discussion."

### What's explicitly out of scope (lands in PR 3)

`firesAt` / scheduling, snooze (until-time and until-signal), re-surface / escalation policy, severity → channel routing, macOS push / bridge / toast delivery, bell badge replacement, `publishNotification()` legacy migration. The engine here is the substrate those build on top of.

## Test plan

- [x] Unit tests pass — `test/server/notifier/test_engine.ts` covers publish/clear/cancel idempotency, `listFor` filtering, opaque `pluginData` round-trip, persistence across path rebind, concurrent write ordering, and on-disk format invariants
- [x] `yarn lint`, `yarn typecheck`, `yarn build` clean
- [x] Full `yarn test` clean (4182/4182)
- [ ] Reviewer: with `VITE_DEV_MODE=1` in `.env`, confirm the bug-report icon appears next to the bell
- [ ] Reviewer: click the icon → popup opens; click `Run scripted test` → entries appear and disappear over ~7 s, badge color escalates as `urgent` entries land, list ends empty
- [ ] Reviewer: confirm the existing bell behaviour is unchanged (notifier prototype is parallel, not a replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced notifier subsystem with streamlined notification lifecycles (info and action modes only)
  * Added notification persistence via file-based storage
  * Exposed notifier API for publishing, clearing, and managing notifications
  * Added development debug interface for testing notifications

* **Documentation**
  * Updated architectural plans with notifier design and phased integration strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->