### PR TITLE
feat(notifier): debug-side UX prototype + history (PR 3 of feat-encore)

### DIFF
--- a/packages/debug-plugin/src/View.vue
+++ b/packages/debug-plugin/src/View.vue
@@ -1,17 +1,235 @@
 <script setup lang="ts">
-// Debug-plugin View. Deliberately a bare "Debug Page" title for now —
-// content gets added on demand as we wire up experimental host
-// features (the Notifier engine in plans/feat-encore.md, etc.).
+// Debug-plugin View — three modes, branched on URL query.
+//
+//   /debug                                — button panel (default)
+//   /debug?mode=auto-clear&notificationId=…  — clear on mount
+//   /debug?mode=manual-clear&notificationId=…  — clear on Done click
+//
+// The first two URLs are fired by the host's notifier-debug popup
+// when an action notification's `navigateTarget` points back here.
+// The popup appends `?notificationId=<uuid>` automatically.
 //
 // No i18n, by design: this page is dev-only chrome behind
-// `VITE_DEV_MODE=1`. The set of users who ever see it is "developers
-// reading the source", so every string is a literal English value,
-// kept in this file. Don't add translation tables for the debug page;
-// don't extract these strings into the host's vue-i18n bundle.
+// `VITE_DEV_MODE=1`. Strings stay literal English in this file.
+//
+// URL reactivity: the host's router fires a
+// `mulmoclaude:routechange` CustomEvent on every navigation
+// (`src/router/index.ts`). We listen for it (plus popstate for
+// back/forward) and re-read `window.location.search` on each fire.
+// This works around the runtime-plugin sandbox not having direct
+// access to vue-router — adding `vue-router` to the host's plugin
+// importmap is a separate, larger change, and the custom-event
+// bridge keeps this PR's scope contained to the debug surface.
+
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRuntime } from "gui-chat-protocol/vue";
+
+interface PublishArgs {
+  kind: "publish";
+  severity: "info" | "nudge" | "urgent";
+  lifecycle: "fyi" | "action";
+  title: string;
+  body?: string;
+  navigateTarget?: string;
+}
+
+interface ClearArgs {
+  kind: "clear";
+  id: string;
+}
+
+const runtime = useRuntime();
+
+const mode = ref<string | null>(null);
+const notificationId = ref<string | null>(null);
+const status = ref<string>("");
+const autoClearedAt = ref<string | null>(null);
+const manualClearedAt = ref<string | null>(null);
+
+function readUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  const nextMode = params.get("mode");
+  const nextId = params.get("notificationId");
+  // Clear the per-mode confirmation state when the URL changes shape.
+  // Without this, a user who flips between modes sees stale "cleared
+  // at <time>" lines from the previous flow.
+  if (nextMode !== mode.value || nextId !== notificationId.value) {
+    autoClearedAt.value = null;
+    manualClearedAt.value = null;
+    status.value = "";
+  }
+  mode.value = nextMode;
+  notificationId.value = nextId;
+}
+
+const view = computed<"default" | "auto-clear" | "manual-clear">(() => {
+  if (mode.value === "auto-clear") return "auto-clear";
+  if (mode.value === "manual-clear") return "manual-clear";
+  return "default";
+});
+
+async function publish(args: Omit<PublishArgs, "kind">): Promise<void> {
+  status.value = `firing ${args.lifecycle}/${args.severity}…`;
+  try {
+    const result = await runtime.dispatch<{ ok: boolean; id?: string }>({ kind: "publish", ...args } satisfies PublishArgs);
+    status.value = result.id ? `published ${result.id.slice(0, 8)}` : `published`;
+  } catch (err) {
+    status.value = `publish failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+async function clearById(id: string): Promise<string> {
+  await runtime.dispatch({ kind: "clear", id } satisfies ClearArgs);
+  return new Date().toISOString();
+}
+
+async function maybeAutoClear(): Promise<void> {
+  if (view.value !== "auto-clear" || !notificationId.value || autoClearedAt.value) return;
+  try {
+    autoClearedAt.value = await clearById(notificationId.value);
+    status.value = `auto-cleared on mount`;
+  } catch (err) {
+    status.value = `auto-clear failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+async function manualClear(): Promise<void> {
+  if (!notificationId.value) return;
+  try {
+    manualClearedAt.value = await clearById(notificationId.value);
+    status.value = `cleared by Done`;
+  } catch (err) {
+    status.value = `clear failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+function onRouteChange(): void {
+  readUrl();
+  void maybeAutoClear();
+}
+
+onMounted(() => {
+  readUrl();
+  window.addEventListener("mulmoclaude:routechange", onRouteChange);
+  window.addEventListener("popstate", onRouteChange);
+  void maybeAutoClear();
+});
+
+onUnmounted(() => {
+  window.removeEventListener("mulmoclaude:routechange", onRouteChange);
+  window.removeEventListener("popstate", onRouteChange);
+});
+
+// ── Default-mode button scenarios ─────────────────────────────────
+
+interface Scenario {
+  label: string;
+  args: Omit<PublishArgs, "kind">;
+}
+
+const scenarios: Scenario[] = [
+  { label: "fyi / info", args: { severity: "info", lifecycle: "fyi", title: "Backup completed" } },
+  { label: "fyi / nudge", args: { severity: "nudge", lifecycle: "fyi", title: "Disk usage 85%" } },
+  { label: "fyi / urgent", args: { severity: "urgent", lifecycle: "fyi", title: "Service degraded" } },
+  { label: "action / info", args: { severity: "info", lifecycle: "action", title: "Weekly summary ready", body: "Click to read" } },
+  { label: "action / nudge", args: { severity: "nudge", lifecycle: "action", title: "News digest ready", body: "12 new items" } },
+  { label: "action / urgent", args: { severity: "urgent", lifecycle: "action", title: "Pay property tax", body: "Due 2026-12-15" } },
+  {
+    label: "action — clears on open (hyperlink test)",
+    args: {
+      severity: "info",
+      lifecycle: "action",
+      title: "Daily digest is ready",
+      body: "Auto-clears when you open this page",
+      navigateTarget: "/debug?mode=auto-clear",
+    },
+  },
+  {
+    label: "action — clears on Done (hyperlink test)",
+    args: {
+      severity: "nudge",
+      lifecycle: "action",
+      title: "Approve this thing",
+      body: "Stays until you press Done",
+      navigateTarget: "/debug?mode=manual-clear",
+    },
+  },
+];
+
+async function fireMixed(): Promise<void> {
+  for (const scenario of scenarios.slice(0, 6)) {
+    await publish(scenario.args);
+  }
+}
 </script>
 
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text --
+  Dev-only debug page, gated by `VITE_DEV_MODE=1` at the host.
+  Strings stay literal English by design (see file header). -->
 <template>
   <div class="h-full bg-white text-gray-900 flex flex-col overflow-hidden">
-    <h2 class="text-lg font-semibold text-gray-800 px-3 py-2">Debug Page</h2>
+    <header class="flex items-center gap-3 px-3 py-2 border-b border-gray-200">
+      <h2 class="text-lg font-semibold text-gray-800">Debug</h2>
+      <span class="text-xs text-gray-400">{{ status }}</span>
+    </header>
+
+    <div v-if="view === 'default'" class="flex-1 overflow-y-auto p-4">
+      <p class="text-sm text-gray-600 mb-3">
+        Click a button below to fire a test notification. Watch the bug-icon popup next to the bell — it shows the new Active / History UX.
+      </p>
+      <div class="flex flex-col gap-2">
+        <button
+          v-for="scenario in scenarios"
+          :key="scenario.label"
+          type="button"
+          class="text-left px-3 py-2 rounded border border-gray-200 bg-gray-50 hover:bg-gray-100 text-sm"
+          :data-testid="`debug-fire-${scenario.label.replace(/[^a-z]+/gi, '-')}`"
+          @click="publish(scenario.args)"
+        >
+          Fire {{ scenario.label }}
+        </button>
+        <button
+          type="button"
+          class="text-left px-3 py-2 rounded border border-blue-200 bg-blue-50 hover:bg-blue-100 text-sm"
+          data-testid="debug-fire-mixed"
+          @click="fireMixed"
+        >
+          Fire mixed batch (6 entries)
+        </button>
+      </div>
+    </div>
+
+    <div v-else-if="view === 'auto-clear'" class="flex-1 overflow-y-auto p-4">
+      <h3 class="text-base font-semibold mb-2">Auto-clear on open</h3>
+      <p class="text-sm text-gray-700 mb-2">
+        This page cleared the notification automatically when it mounted. The "read-once" pattern: viewing the target IS the close.
+      </p>
+      <p v-if="autoClearedAt" class="text-sm text-green-700 mb-3">✓ Cleared at {{ autoClearedAt }}</p>
+      <p v-else class="text-sm text-amber-600 mb-3">(clearing…)</p>
+      <p class="text-xs text-gray-400 font-mono mb-3">id = {{ notificationId }}</p>
+      <a href="/debug" class="text-blue-600 hover:underline text-sm">← back to test panel</a>
+    </div>
+
+    <div v-else class="flex-1 overflow-y-auto p-4">
+      <h3 class="text-base font-semibold mb-2">Manual clear on Done</h3>
+      <p class="text-sm text-gray-700 mb-2">
+        Press the button below to clear the notification. The "act-on" pattern: opening the page does not by itself satisfy the obligation.
+      </p>
+      <p v-if="manualClearedAt" class="text-sm text-green-700 mb-3">✓ Cleared at {{ manualClearedAt }}</p>
+      <p class="text-xs text-gray-400 font-mono mb-3">id = {{ notificationId }}</p>
+      <button
+        type="button"
+        class="px-4 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="!notificationId || manualClearedAt !== null"
+        data-testid="debug-manual-clear-done"
+        @click="manualClear"
+      >
+        Done
+      </button>
+      <div class="mt-4">
+        <a href="/debug" class="text-blue-600 hover:underline text-sm">← back to test panel</a>
+      </div>
+    </div>
   </div>
 </template>
+<!-- eslint-enable @intlify/vue-i18n/no-raw-text -->

--- a/packages/debug-plugin/src/View.vue
+++ b/packages/debug-plugin/src/View.vue
@@ -128,16 +128,20 @@ interface Scenario {
 }
 
 const scenarios: Scenario[] = [
+  // fyi covers all three severities — the engine has no fyi/severity
+  // restriction, so info/nudge/urgent are all valid.
   { label: "fyi / info", args: { severity: "info", lifecycle: "fyi", title: "Backup completed" } },
   { label: "fyi / nudge", args: { severity: "nudge", lifecycle: "fyi", title: "Disk usage 85%" } },
   { label: "fyi / urgent", args: { severity: "urgent", lifecycle: "fyi", title: "Service degraded" } },
-  { label: "action / info", args: { severity: "info", lifecycle: "action", title: "Weekly summary ready", body: "Click to read" } },
-  { label: "action / nudge", args: { severity: "nudge", lifecycle: "action", title: "News digest ready", body: "12 new items" } },
-  { label: "action / urgent", args: { severity: "urgent", lifecycle: "action", title: "Pay property tax", body: "Due 2026-12-15" } },
+  // action only pairs with `nudge` or `urgent` (info is rejected by
+  // the engine + HTTP layer). Whether to auto-clear on open or wait
+  // for an explicit Done click is an application-level choice — the
+  // debug page surfaces both modes for both severities so the
+  // landing flow can be eyeballed for each combination.
   {
-    label: "action — clears on open (hyperlink test)",
+    label: "action / nudge — clears on open",
     args: {
-      severity: "info",
+      severity: "nudge",
       lifecycle: "action",
       title: "Daily digest is ready",
       body: "Auto-clears when you open this page",
@@ -145,19 +149,39 @@ const scenarios: Scenario[] = [
     },
   },
   {
-    label: "action — clears on Done (hyperlink test)",
+    label: "action / nudge — clears on Done",
     args: {
       severity: "nudge",
       lifecycle: "action",
-      title: "Approve this thing",
-      body: "Stays until you press Done",
+      title: "News digest ready",
+      body: "Stays in Active until you press Done on the landing page",
+      navigateTarget: "/debug?mode=manual-clear",
+    },
+  },
+  {
+    label: "action / urgent — clears on open",
+    args: {
+      severity: "urgent",
+      lifecycle: "action",
+      title: "Service incident report ready",
+      body: "Auto-clears when you open this page",
+      navigateTarget: "/debug?mode=auto-clear",
+    },
+  },
+  {
+    label: "action / urgent — clears on Done",
+    args: {
+      severity: "urgent",
+      lifecycle: "action",
+      title: "Pay property tax",
+      body: "Stays in Active until you press Done on the landing page",
       navigateTarget: "/debug?mode=manual-clear",
     },
   },
 ];
 
 async function fireMixed(): Promise<void> {
-  for (const scenario of scenarios.slice(0, 6)) {
+  for (const scenario of scenarios) {
     await publish(scenario.args);
   }
 }

--- a/packages/debug-plugin/src/index.ts
+++ b/packages/debug-plugin/src/index.ts
@@ -5,16 +5,53 @@
 //
 // `node:fs` / `node:path` / `console` / direct `fetch` are unused —
 // the gui-chat-protocol eslint preset bans them at lint time.
+//
+// The notifier dispatches below assume a MulmoClaude-augmented
+// runtime that exposes `runtime.notifier` (host extension over
+// `gui-chat-protocol`'s `PluginRuntime`). The cast is the contract
+// — once that API stabilises and lands in `gui-chat-protocol`, the
+// cast goes away.
 
-import { definePlugin } from "gui-chat-protocol";
+import { definePlugin, type PluginRuntime } from "gui-chat-protocol";
 import { z } from "zod";
 import { TOOL_DEFINITION } from "./definition";
 
 export { TOOL_DEFINITION };
 
-const Args = z.discriminatedUnion("kind", [z.object({ kind: z.literal("echo"), message: z.string() })]);
+const NotifierSeverity = z.enum(["info", "nudge", "urgent"]);
+const NotifierLifecycle = z.enum(["fyi", "action"]);
 
-export default definePlugin(({ log }) => {
+const Args = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("echo"), message: z.string() }),
+  z.object({
+    kind: z.literal("publish"),
+    severity: NotifierSeverity,
+    lifecycle: NotifierLifecycle,
+    title: z.string().min(1),
+    body: z.string().optional(),
+    navigateTarget: z.string().optional(),
+  }),
+  z.object({ kind: z.literal("clear"), id: z.string().min(1) }),
+]);
+
+interface MulmoclaudeNotifierApi {
+  publish(input: {
+    severity: z.infer<typeof NotifierSeverity>;
+    lifecycle?: z.infer<typeof NotifierLifecycle>;
+    title: string;
+    body?: string;
+    navigateTarget?: string;
+    pluginData?: unknown;
+  }): Promise<{ id: string }>;
+  clear(id: string): Promise<void>;
+}
+
+type MulmoclaudeRuntime = PluginRuntime & { notifier: MulmoclaudeNotifierApi };
+
+export default definePlugin((runtime) => {
+  const { log } = runtime;
+  const { notifier } = runtime as MulmoclaudeRuntime;
+
   return {
     TOOL_DEFINITION,
 
@@ -27,8 +64,26 @@ export default definePlugin(({ log }) => {
           return { ok: true, kind: "echo", message: args.message };
         }
 
+        case "publish": {
+          const { id } = await notifier.publish({
+            severity: args.severity,
+            lifecycle: args.lifecycle,
+            title: args.title,
+            body: args.body,
+            navigateTarget: args.navigateTarget,
+          });
+          log.info("publish", { id, lifecycle: args.lifecycle, severity: args.severity });
+          return { ok: true, kind: "publish", id };
+        }
+
+        case "clear": {
+          await notifier.clear(args.id);
+          log.info("clear", { id: args.id });
+          return { ok: true, kind: "clear" };
+        }
+
         default: {
-          const exhaustive: never = args.kind;
+          const exhaustive: never = args;
           throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
         }
       }

--- a/plans/feat-encore.md
+++ b/plans/feat-encore.md
@@ -76,7 +76,7 @@ type NotifierLifecycle = "fyi" | "action";
 
 | Lifecycle | Example | Has body content? | Who calls `clear`? |
 |---|---|---|---|
-| `fyi` | "Backup completed" | No | The bell panel — user acknowledges (button or bulk-checkbox) |
+| `fyi` | "Backup completed" | No | The bell panel — user dismisses via the row's `×` |
 | `action` | "Pay H2 property tax" / "Daily news digest is ready" | Yes — plugin-owned target | The plugin — either on view mount ("show this once" semantics) or after the domain action completes |
 
 `action` collapses what an earlier draft split into `read` and `action`: from the engine's perspective both are "the plugin owns the close call", so the distinction was bookkeeping with no runtime effect. The plugin chooses *when* to call `clear` based on its own UX — on mount for read-once notifications, after an explicit action for things like "Pay property tax." If the user never visits the plugin's view (e.g. submits the journal entry via chat instead), the plugin can still detect the underlying state change and call `clear` from there; the panel click is convenience routing, not the close trigger.
@@ -168,12 +168,12 @@ The toolbar bell shows the count of notifications in `delivered` or `seen` state
 
 The bell panel is one scrollable popup with two stacked sections — Active on top, History below; no tabs, single scroll region (see `feat-notifier-ux.md` for the layout and rationale). Row affordance differs by `lifecycle`:
 
-- **`fyi`** — leading checkbox; clicking the row body toggles it. "Acknowledge selected" button at the foot of the Active section moves all checked rows to History as `cleared`. No per-row × — fyi has no `cancel` semantic, only "user acknowledges."
-- **`action`** — no checkbox. Clicking the row body closes the panel and routes the user to the deep-link target with `?notificationId=<uuid>` appended; the landing page calls `notifier.get(uuid)` to recover `pluginData`, highlights the relevant item, and decides when to clear it. The notification stays in Active until the plugin calls `notifier.clear(id)`. Trailing `×` button → `cancel`: the user has decided this is no longer relevant, the entry moves to History as `cancelled`.
+- **`fyi`** — body click is a no-op (no `navigateTarget` by construction). Trailing `×` calls `clear` (fyi has no `cancel` notion — "user acknowledges" IS the close). The entry moves to History as `cleared`.
+- **`action`** — body click closes the panel and routes the user to `navigateTarget` with `?notificationId=<uuid>` appended; the landing page calls `notifier.get(uuid)` to recover `pluginData`, highlights the relevant item, and decides when to clear. The notification stays in Active until the plugin calls `notifier.clear(id)`. Trailing `×` calls `cancel` ("user has decided this is no longer relevant"); the entry moves to History as `cancelled`. Two publish-time rules, enforced by the engine and the HTTP layer in lockstep: `action` requires a **non-empty `navigateTarget`**, and `action` is **incompatible with `info` severity** (low-priority obligation is incoherent — fyi instead).
 
 History rows are read-only with one capability: rows whose original entry had a `navigateTarget` stay clickable and re-route to that target — the migration's answer to "what happened earlier?" since the panel no longer shows acked items inline. Visual marker `✓` / `✗` for `cleared` / `cancelled`; severity color persists.
 
-`NotificationBell.vue` gains `lifecycle`-aware rendering for the row affordances and a History section underneath Active. `NotificationToast.vue` is **removed in v1** (toast as a delivery surface goes away — see "no toast" below). Testids: `[notification-row-fyi]`, `[notification-row-action]`, `[notification-acknowledge-bulk]`, `[notification-row-cancel]` (the action × button), `[notification-history-row]`.
+`NotificationBell.vue` gains `lifecycle`-aware rendering for the row affordances and a History section underneath Active. `NotificationToast.vue` is **removed in v1** (toast as a delivery surface goes away — see "no toast" below). Testids: `[notification-row-fyi]`, `[notification-row-action]`, `[notification-row-dismiss]` (the trailing × on either row), `[notification-history-row]`.
 
 #### Severity → channel mapping
 
@@ -207,7 +207,7 @@ New channels in `src/config/pubsubChannels.ts`:
 
 #### Notification center
 
-The bell panel becomes a thin client over the new state — same toolbar position, but the surface inside changes shape: Active section on top, History section below, single scroll, no tabs. Each Active row renders per its `lifecycle` (fyi → checkbox; action → click-to-navigate + `×`-to-cancel) and gains affordances unlocked by the full engine (snooze button, "remind me again in 1h" picker). History rows are read-only but route on click when they had a `navigateTarget`. `NotificationBell.vue` carries all of this; `NotificationToast.vue` is removed. The existing `[notification-badge]` testid stays. See `feat-notifier-ux.md` for the full layout, empty states, and the rationale.
+The bell panel becomes a thin client over the new state — same toolbar position, but the surface inside changes shape: Active section on top, History section below, single scroll, no tabs. Active rows share one visual layout (severity dot + title/body/meta + trailing `×`); body click navigates for `action`, no-ops for `fyi`. The full engine adds affordances (snooze button, "remind me again in 1h" picker) on top of this. History rows are read-only but route on click when they had a `navigateTarget`. `NotificationBell.vue` carries all of this; `NotificationToast.vue` is removed. The existing `[notification-badge]` testid stays. See `feat-notifier-ux.md` for the full layout, empty states, and the rationale.
 
 ### What stays — and the legacy migration
 
@@ -552,8 +552,8 @@ Builds the new bell UX on the dev-mode debug surface (next to the bell, gated by
 **Debug button popup** (`NotifierDebugPopup.vue` — full rewrite)
 
 - Replaces the PR 2 scripted-test panel. Implements the layout + row behaviours from `feat-notifier-ux.md`: Active section on top, History section below, single scroll, no tabs.
-- fyi rows: leading checkbox; click body toggles. Footer "Acknowledge selected" button when ≥1 fyi is checked.
-- action rows: click body navigates (`router.push` to `navigateTarget` with `&notificationId=<uuid>` appended). Trailing `×` cancels.
+- Active rows share one layout (severity dot + title/body/meta + trailing `×`). fyi: body click no-ops; `×` clears. action: body click navigates (`router.push` to `navigateTarget` with `&notificationId=<uuid>` appended); `×` cancels.
+- Two `action`-publish rules are rejected at the engine and HTTP-route boundaries (defended in depth so plugin-runtime callers and HTTP callers hit the same wall): `action` requires a non-empty `navigateTarget`, and `action` cannot use `info` severity.
 - History rows: read-only with `✓` / `✗` markers. Rows with `navigateTarget` re-route on click.
 - Empty states: "No active notifications" / "No recent activity".
 - Badge stays as in PR 2 (count + worst-severity color + `99+` cap).
@@ -595,7 +595,7 @@ Builds on the prototype to deliver the engine specced in Part 1 above and the us
 
 - Bell badge: pending-count semantics, worst-severity color (gray / amber / red), `99+` cap. Replaces today's "unread" count.
 - Bell panel layout: Active section on top, History section below, single scroll, no tabs. Empty states: "No active notifications" / "No recent activity."
-- fyi rows: leading checkbox + footer "Acknowledge selected" button (one-row "bulk" still works). No per-row × on fyi.
+- fyi rows: trailing `×` button calls `clear` (fyi has no `cancel` notion).
 - action rows: click-to-navigate (panel closes, `?notificationId=<uuid>` appended), trailing × → cancel. Plugin owns the clear.
 - History rows: read-only display, but rows with a `navigateTarget` stay clickable and re-route. Visual `✓` / `✗` for cleared / cancelled.
 - `NotificationToast.vue` is removed; toast as a delivery surface goes away in v1. Worst-severity badge color is the at-a-distance signal.

--- a/plans/feat-encore.md
+++ b/plans/feat-encore.md
@@ -31,6 +31,8 @@ This is the clearest product-fit case we have seen for the workspace-as-database
 - **Recurrence already exists.** The scheduler, calendar, and todos plugins are in place. This is not a new engine — it is a new *case* abstraction sitting on top.
 - **Privacy story is built in.** Tax docs, medical history, gift lists — people will not put these in a cloud SaaS. Local-first is a feature, not a constraint.
 
+> **UX decisions for the notifier migration are tracked separately in [`plans/feat-notifier-ux.md`](feat-notifier-ux.md).** That document is the source of truth for panel layout, badge semantics, row behaviours, history visibility, and the no-toast decision. The phasing and engine internals below cite it where the decisions overlap.
+
 ## Two-layer architecture
 
 Encore drives requirements harder than any other plugin we have shipped, especially around reminders. The clean layering is:
@@ -64,7 +66,7 @@ This matches the plugin-vs-host boundary in `CLAUDE.md`: host owns generic infra
 
 The current model is sufficient for "your scheduled task just finished" but cannot carry the weight of "you usually need 3 weeks to gather tax documents."
 
-### Three notification types — three lifecycle shapes
+### Two notification types — two lifecycle shapes
 
 Plugins fire notifications that fall into one of two shapes. The Notifier carries `lifecycle` on every payload as a UI hint — the engine itself never reads it. The field is named `lifecycle` (not `kind`) because the existing `NotificationKind` already means "source category" — `todo | scheduler | agent | …` — and the two are orthogonal: source category (collapsed into `pluginPkg`, see below) and lifecycle shape are independent.
 
@@ -149,7 +151,7 @@ pending → delivered → seen ─→ snoozed ─→ (re-evaluates at untilTime 
                 └→ resurface (delivered without acted, after re-surface delay)
 ```
 
-- `seen` is "rendered to the user" (panel opened, or toast shown). Re-surface fires off `delivered` without `acted`, **not** off `seen` without `acted` — otherwise an open bell panel would suppress every escalation.
+- `seen` is "rendered to the user" (panel opened). Re-surface fires off `delivered` without `acted`, **not** off `seen` without `acted` — otherwise an open bell panel would suppress every escalation. (No toast in v1 — the bell badge's worst-severity color is the at-a-distance signal; see `feat-notifier-ux.md`.)
 - For `fyi`: acknowledge transitions directly to `closed` without going through `acted` (no domain action exists to be acted on; acknowledge IS the close).
 - For `action`: only the plugin can transition to `acted` / `closed`. The panel routes the user to the plugin's view but does not by itself close the notification.
 
@@ -164,12 +166,14 @@ The toolbar bell shows the count of notifications in `delivered` or `seen` state
 
 #### Panel UX per lifecycle
 
-The bell panel stays the surface for both lifecycles. Each row's affordance differs by `lifecycle`:
+The bell panel is one scrollable popup with two stacked sections — Active on top, History below; no tabs, single scroll region (see `feat-notifier-ux.md` for the layout and rationale). Row affordance differs by `lifecycle`:
 
-- **`fyi`** — leading checkbox + "Acknowledge selected" button at the panel footer. Click anywhere on the row toggles the checkbox; explicit close-button on the row also acknowledges that single item. Bulk acknowledge is the headline ergonomic — for catch-up sessions where 12 "build finished" rows pile up.
-- **`action`** — row is a hyperlink routing to the plugin's view (the plugin reads `pluginData` to decide where exactly — a standalone route, an in-chat preview, etc.). The close is always driven by the plugin (`notifier.clear(id)`), never by the click. The URL carries `?notificationId=<uuid>` so the landing page can call `notifier.get(uuid)` to recover `pluginData`, highlight the relevant item, and know which id to clear. The plugin chooses *when* to clear: on view mount for read-once notifications, after a domain action for things like "Pay property tax." If the user navigates away without engaging, the notification stays pending and re-surfaces on schedule.
+- **`fyi`** — leading checkbox; clicking the row body toggles it. "Acknowledge selected" button at the foot of the Active section moves all checked rows to History as `cleared`. No per-row × — fyi has no `cancel` semantic, only "user acknowledges."
+- **`action`** — no checkbox. Clicking the row body closes the panel and routes the user to the deep-link target with `?notificationId=<uuid>` appended; the landing page calls `notifier.get(uuid)` to recover `pluginData`, highlights the relevant item, and decides when to clear it. The notification stays in Active until the plugin calls `notifier.clear(id)`. Trailing `×` button → `cancel`: the user has decided this is no longer relevant, the entry moves to History as `cancelled`.
 
-`NotificationBell.vue` and `NotificationToast.vue` gain `lifecycle`-aware rendering. New testids: `[notification-row-fyi]`, `[notification-row-action]`, `[notification-acknowledge-bulk]`.
+History rows are read-only with one capability: rows whose original entry had a `navigateTarget` stay clickable and re-route to that target — the migration's answer to "what happened earlier?" since the panel no longer shows acked items inline. Visual marker `✓` / `✗` for `cleared` / `cancelled`; severity color persists.
+
+`NotificationBell.vue` gains `lifecycle`-aware rendering for the row affordances and a History section underneath Active. `NotificationToast.vue` is **removed in v1** (toast as a delivery surface goes away — see "no toast" below). Testids: `[notification-row-fyi]`, `[notification-row-action]`, `[notification-acknowledge-bulk]`, `[notification-row-cancel]` (the action × button), `[notification-history-row]`.
 
 #### Severity → channel mapping
 
@@ -178,14 +182,21 @@ Configured globally per user, with optional per-plugin override.
 | Severity | Default channels |
 |---|---|
 | `info` | bell only |
-| `nudge` | bell + toast |
-| `urgent` | bell + toast + macOS push + bridge (Telegram/CLI) |
+| `nudge` | bell only (badge color escalates to amber) |
+| `urgent` | bell + macOS push + bridge (Telegram/CLI) (badge color escalates to red) |
 
 Mapping lives in `~/mulmoclaude/config/notifier.json`. Plugins may *request* a channel uplift (`requireChannel: "macos"`) but the user's config is authoritative.
 
+**Toast is intentionally absent.** An earlier draft routed `nudge` and `urgent` through a top-right toast popup (today's `NotificationToast.vue`); v1 drops it because most fyi notifications don't warrant interruption and the bell badge's worst-severity color already provides at-a-distance signalling. Re-introducing toast for an `urgent`-only path is a follow-up if real-use feedback demands it.
+
 #### Persistence
 
-Schedules persist to `~/mulmoclaude/data/notifier/scheduled.jsonl` so a restart does not drop pending entries. State-machine transitions append to `~/mulmoclaude/data/notifier/state.jsonl` (audit log). Both go through `writeFileAtomic`.
+- `~/mulmoclaude/data/notifier/active.json` — currently-active entries (PR 2's snapshot file, kept).
+- `~/mulmoclaude/data/notifier/scheduled.jsonl` — queued future fires (added in PR 3 once timers land).
+- `~/mulmoclaude/data/notifier/state.jsonl` — audit log of state-machine transitions (added in PR 3).
+- `~/mulmoclaude/data/notifier/history.jsonl` — append-only ring of acknowledged / cancelled entries, capped at 50 (FIFO eviction). The bell panel's History section reads from here; this is the migration's substitute for the legacy "last 50 fired" in-memory store.
+
+All four go through `writeFileAtomic`.
 
 #### Pub-sub events
 
@@ -196,18 +207,18 @@ New channels in `src/config/pubsubChannels.ts`:
 
 #### Notification center
 
-The bell panel becomes a thin client over the new state — same surface, but each row renders per its `kind` (above) and exposes its full lifecycle (snooze button, "remind me again in 1h" picker, link to the originating item). `NotificationBell.vue` and `NotificationToast.vue` need lifecycle + kind awareness; the existing `[notification-badge]` testid stays.
+The bell panel becomes a thin client over the new state — same toolbar position, but the surface inside changes shape: Active section on top, History section below, single scroll, no tabs. Each Active row renders per its `lifecycle` (fyi → checkbox; action → click-to-navigate + `×`-to-cancel) and gains affordances unlocked by the full engine (snooze button, "remind me again in 1h" picker). History rows are read-only but route on click when they had a `navigateTarget`. `NotificationBell.vue` carries all of this; `NotificationToast.vue` is removed. The existing `[notification-badge]` testid stays. See `feat-notifier-ux.md` for the full layout, empty states, and the rationale.
 
 ### What stays — and the legacy migration
 
-The existing `publishNotification()` call site — nothing immediate, no schedule, no re-surface — remains as the simplest entry point for "fire one toast right now." It becomes a thin wrapper over `notifier.schedule({ firesAt: now, resurface: null, lifecycle: "fyi" })`.
+The existing `publishNotification()` call site — nothing immediate, no schedule, no re-surface — remains as the simplest entry point for "fire one notification right now." It becomes a thin wrapper over `notifier.schedule({ firesAt: now, resurface: null, lifecycle: "fyi" })`.
 
 The wrapper maps the legacy `NotificationKind` source category to a synthetic `pluginPkg` so the routing + icon contract doesn't break:
 
 - `todo` / `scheduler` / `agent` / `journal` → `pluginPkg: "<same-name>"` (synthetic plugins for now; future PRs may promote them to real plugin METAs).
 - `push` / `bridge` / `system` → `pluginPkg: "host"`.
 
-Default `lifecycle: "fyi"` matches today's behaviour (fire-and-forget, user clicks bell, marks read). All current callers keep working unchanged; new callers can opt into `read` / `action` lifecycles by calling `notifier.schedule()` directly.
+Default `lifecycle: "fyi"` matches today's behaviour (fire-and-forget, user acks from the bell panel). All current callers keep working unchanged; new callers can opt into the `action` lifecycle by calling `notifier.schedule()` directly.
 
 ### Out of scope for Notifier v1
 
@@ -440,7 +451,7 @@ The standalone route follows the existing pattern: route registered in `src/rout
 
 ## Phasing
 
-**Order of operations**: A tiny client-only dev-mode gate ships first (PR 1, ✅ merged), then a stripped-down Notifier prototype (PR 2) validates the data model + API shape behind the existing `@mulmoclaude/debug-plugin` `/debug` page. The full Notifier engine with timers, escalation, snooze, channel routing, and legacy `publishNotification()` migration follows in PR 3. Encore (PRs 4 + 5) lands once the engine is proven.
+**Order of operations**: A tiny client-only dev-mode gate ships first (PR 1, ✅ merged), then a stripped-down Notifier prototype (PR 2, ✅ merged) validates the data model + API shape via the dev-mode debug popup. PR 3 builds the full new bell UX on the debug surface (running parallel to the legacy bell) so the layout and behaviours can be exercised before any migration. PR 4 ships the full engine (timers, escalation, snooze, channel routing) and migrates `publishNotification()` onto it, replacing the legacy bell. Encore (PRs 5 + 6) lands once the engine is proven.
 
 ### PR 1 — Dev mode + Debug role (client-only, ~25-line diff) ✅ merged
 
@@ -476,7 +487,7 @@ Existing chat sessions tied to a debug role still render normally (icon, history
 
 **Acceptance bar**: with `VITE_DEV_MODE=1`, Debug appears at the bottom of the role dropdown with General's plugin set; without it, Debug is absent. Total diff: ~25 lines across 3 files (`roles.ts`, `RoleSelector.vue`, `vite-env.d.ts`).
 
-### PR 2 — Notifier prototype (no timers, JSON persistence, debug-plugin harness)
+### PR 2 — Notifier prototype (no timers, JSON persistence, debug-plugin harness) ✅ merged
 
 A minimal first cut to validate the data model + API shape before adding the time-based machinery. **`server/events/notifications.ts` is left completely untouched** — the prototype is a parallel service with its own pub/sub channel, exercised only via the existing `@mulmoclaude/debug-plugin` `/debug` page.
 
@@ -522,28 +533,88 @@ Test coverage:
 
 Acceptance bar: scripted test runs to completion in ~5s with the active list correctly populating and emptying; all unit tests pass; zero diff in `server/events/notifications.ts`.
 
-### PR 3 — Notifier full engine (timers, snooze, escalation, channel routing, legacy migration)
+### PR 3 — Debug-side UX prototype (new engine runs parallel to legacy)
 
-Builds on the prototype to deliver the engine specced in Part 1 above. New scope on top of PR 2:
+Builds the new bell UX on the dev-mode debug surface (next to the bell, gated by `VITE_DEV_MODE`) **without touching the legacy `publishNotification()` path**. The existing bell, toast, and `notifications` pubsub channel keep firing as today; the new engine's UX runs in parallel. The goal is to validate the layout, badge semantics, row affordances, and history flow before committing to the migration in PR 4.
 
-- `firesAt` + scheduling, persisted across restart. Persistence shape upgrades from `active.json` to `scheduled.jsonl` (queued fires) + `state.jsonl` (audit log of state-machine transitions), both keyed by UUID and written via `writeFileAtomic`.
+**Engine** (`server/notifier/`)
+
+- Add `~/mulmoclaude/data/notifier/history.json` — single JSON file holding an array of terminated entries, capped at 50, FIFO eviction. Each entry = the original `NotifierEntry` + `terminalType: "cleared" | "cancelled"` + `terminalAt: ISO`. New API: `listHistory()`.
+- `clear` and `cancel` push to history *before* removing from active. Two `writeFileAtomic` calls per terminal mutation, sequential within the existing waiter-queue drain. History persistence is best-effort — if its write fails, the active write still wins and the failure is logged.
+- Add an optional `navigateTarget?: string` field on `NotifierEntry` (relative URL). The engine doesn't read it; the popup reads it to decide whether a row is clickable and where to route on click.
+
+**Plugin runtime extension** (server-side)
+
+- `runtime.notifier.publish(input)` — `pluginPkg` auto-bound to the plugin's pkg name (mirrors how `runtime.pubsub.publish` is hard-scoped to `plugin:<pkg>:*`). Plugins cannot impersonate each other.
+- `runtime.notifier.clear(id)` — proxies through to the engine.
+- Type lives MulmoClaude-internal; plugin authors cast `(runtime as MulmoclaudeRuntime).notifier`. Once the API stabilises it can move into `gui-chat-protocol`.
+
+**Debug button popup** (`NotifierDebugPopup.vue` — full rewrite)
+
+- Replaces the PR 2 scripted-test panel. Implements the layout + row behaviours from `feat-notifier-ux.md`: Active section on top, History section below, single scroll, no tabs.
+- fyi rows: leading checkbox; click body toggles. Footer "Acknowledge selected" button when ≥1 fyi is checked.
+- action rows: click body navigates (`router.push` to `navigateTarget` with `&notificationId=<uuid>` appended). Trailing `×` cancels.
+- History rows: read-only with `✓` / `✗` markers. Rows with `navigateTarget` re-route on click.
+- Empty states: "No active notifications" / "No recent activity".
+- Badge stays as in PR 2 (count + worst-severity color + `99+` cap).
+- The "Run scripted test" button is removed (its job moves to the debug page).
+
+**Debug page** (`@mulmoclaude/debug-plugin` `View.vue`)
+
+- Replaces the placeholder. Three modes, branched on URL query:
+  - Default (`/debug`): button panel — buttons that fire individual scenarios (`fyi` / `action` × `info` / `nudge` / `urgent`, plus a "Fire mixed batch" and "Clear all" helper). Each button calls `runtime.dispatch({kind: "publish", input})`; the plugin's server handler proxies to `runtime.notifier.publish`.
+  - `/debug?mode=auto-clear&notificationId=<uuid>`: auto-clears the notification on mount via `runtime.dispatch({kind: "clear", id})`. Renders a "Cleared on open" confirmation. Tests the read-once pattern (notification clears just by visiting the target).
+  - `/debug?mode=manual-clear&notificationId=<uuid>`: renders a "Done" button; clicking it calls `runtime.dispatch({kind: "clear", id})`. Tests the action-completion pattern (notification clears only after the user explicitly acts).
+- Two of the default-mode buttons publish action notifications targeting these modes:
+  - "Fire action (clears on open)" → `navigateTarget: "/debug?mode=auto-clear"`
+  - "Fire action (clears on Done)" → `navigateTarget: "/debug?mode=manual-clear"`
+
+**HTTP route** — add `listHistory` action to the existing `/api/notifier` dispatch.
+
+**Test coverage** — engine unit tests extend with: history append on clear/cancel, capped at 50 (FIFO), `listHistory` returns newest-first, history persistence round-trip via tmp dir, `navigateTarget` field round-trips through publish/list. Manual: drive the debug page buttons; verify the popup's Active and History sections update live; verify both hyperlink scenarios clear correctly.
+
+**Acceptance bar** — every button on the debug page produces the expected entry in the popup's Active section; clicking either hyperlink scenario opens `/debug` and clears the entry per its mode (immediately or on Done); cleared / cancelled entries appear in History capped at 50; zero diff in `server/events/notifications.ts`.
+
+**Out of scope** — all of these stay for PR 4: legacy `publishNotification()` migration, timers / snooze / escalation, bridge / macOS adapters, bell replacement.
+
+### PR 4 — Notifier full engine + legacy migration
+
+Builds on the prototype to deliver the engine specced in Part 1 above and the user experience specced in [`feat-notifier-ux.md`](feat-notifier-ux.md). New scope on top of PR 2 has two strands — engine internals and user-facing migration — landing together because the wrapper that connects them needs both ends to be ready.
+
+**Engine internals**
+
+- `firesAt` + scheduling, persisted across restart. Persistence shape grows from PR 2's `active.json` to also include `scheduled.jsonl` (queued fires) and `state.jsonl` (audit log of state-machine transitions), both keyed by UUID and written via `writeFileAtomic`.
 - Two lifecycles get the full state machine (`pending → delivered → seen → acted/dismissed → closed`) with `markSeen`-style transitions and re-surface on `delivered without acted` after `escalateAt[i]`.
 - `snooze` (until-time **and** until-signal), `signal({ pluginPkg, key })`.
 - `resurface` policy capped at `escalateAt.length` (no auto-multiplication).
-- Severity → channel routing (`info` → bell only, `nudge` → bell + toast, `urgent` → + macOS push + bridge); user-editable mapping in `~/mulmoclaude/config/notifier.json`.
-- Bell badge gets pending-count semantics, severity color encoding, `99+` cap.
-- Lifecycle-aware panel UX: `[notification-row-fyi]` checkbox bulk-acknowledge, `[notification-row-action]` plugin-page deep-link with `?notificationId=<uuid>` (plugin-driven clear).
-- **Legacy migration**: `publishNotification()` becomes a thin wrapper over `notifier.schedule({ lifecycle: "fyi", firesAt: now })`, mapping the old `NotificationKind` source category to a synthetic `pluginPkg` (`todo` / `scheduler` / `agent` / `journal` keep their names; `push` / `bridge` / `system` collapse under `"host"`). All current callers keep working unchanged.
+- Severity → channel routing (`info` → bell only, `nudge` → bell only, `urgent` → bell + macOS push + bridge); user-editable mapping in `~/mulmoclaude/config/notifier.json`. Toast is intentionally not a channel (see Part 1).
+- `history.jsonl` — append-only ring capped at 50 entries, FIFO eviction. `clear` and `cancel` append to it. New API: `listHistory(limit?)`. The history file is the migration's substitute for the legacy in-memory "last 50" store.
+- Optional caller-supplied `id` on `publish` so the legacy wrapper can preserve the diagnostics dedup contract (see "Legacy migration" below).
 
-Test coverage extends PR 2's: state machine transitions, severity → channel mapping, snooze re-evaluation, re-surface timing, `listFor` / `get` recovery semantics, restart-survives-pending under timer load, full Playwright E2E driving the debug page through every reachable state. Risk of regression in current notification UX is mitigated by the wrapper preserving `publishNotification()` semantics exactly.
+**User-facing migration (per `feat-notifier-ux.md`)**
 
-Acceptance bar: every state transition reachable from the debug page; existing bell + toast UX is byte-for-byte identical for legacy callers.
+- Bell badge: pending-count semantics, worst-severity color (gray / amber / red), `99+` cap. Replaces today's "unread" count.
+- Bell panel layout: Active section on top, History section below, single scroll, no tabs. Empty states: "No active notifications" / "No recent activity."
+- fyi rows: leading checkbox + footer "Acknowledge selected" button (one-row "bulk" still works). No per-row × on fyi.
+- action rows: click-to-navigate (panel closes, `?notificationId=<uuid>` appended), trailing × → cancel. Plugin owns the clear.
+- History rows: read-only display, but rows with a `navigateTarget` stay clickable and re-route. Visual `✓` / `✗` for cleared / cancelled.
+- `NotificationToast.vue` is removed; toast as a delivery surface goes away in v1. Worst-severity badge color is the at-a-distance signal.
 
-### PR 4 — Encore plugin (CRUD only, no reminders)
+**Legacy migration**
+
+`publishNotification()` becomes a thin wrapper over `notifier.publish({ lifecycle: "fyi", ... })`, mapping the old `NotificationKind` source category to a synthetic `pluginPkg` (`todo` / `scheduler` / `agent` / `journal` keep their names; `push` / `bridge` / `system` collapse under `"host"`). The optional caller-supplied `id` and `i18n` payload pass through unchanged. All current callers (`server/agent/mcp-tools/notify.ts`, `server/api/routes/notifications.ts`, `server/workspace/sources/pipeline/notify.ts`, `server/plugins/diagnostics.ts`, plus the route file's PoC endpoint) keep working without source changes; the user-visible behaviour matches the new UX (entries land in Active until acked, then move to History).
+
+Bridge push (`chat-service.pushToBridge`) and macOS Reminder push relocate from inline calls inside `publishNotification()` to small adapters that subscribe to the `notifier` pub/sub channel and route by severity. The wrapper itself stays free of channel concerns.
+
+**Test coverage** extends PR 2's: state machine transitions, severity → channel mapping, snooze re-evaluation, re-surface timing, `listFor` / `get` recovery semantics, restart-survives-pending under timer load, history ring eviction, `publishNotification()` legacy callers' output equivalence (an entry published through the wrapper appears in Active with the right `pluginPkg` / `severity` / `lifecycle` and lands in History on ack). Full Playwright E2E driving the bell panel through Active + History flows.
+
+**Acceptance bar:** every state transition reachable from the debug popup; every existing `publishNotification()` call site continues to fire and the user can ack the entry from the Active section; the History section shows the last 50 acked / cancelled entries; the existing toast popup no longer appears.
+
+### PR 5 — Encore plugin (CRUD only, no reminders)
 
 Plugin scaffold: `meta.ts`, `definition.ts`, `index.ts`, `View.vue`, `Preview.vue`. Server: `server/encore/` with file IO + `manageEncore` actions for obligation CRUD, `openInstance`, `addItem` / `updateItem` / `removeItem`, `diffFromLast`. Standalone `/encore` route. **No notifier integration yet** — proves the data model (including multi-item instances) works in isolation.
 
-### PR 5 — Encore × Notifier integration
+### PR 6 — Encore × Notifier integration
 
 Encore translates obligation + item state into `notifier.schedule()` calls. Both lifecycles get exercised: `fyi` for "instance opened" confirmations and post-completion summaries, `action` for "pay H2 property tax" / "diff-from-last is ready" — anything where the user needs to land on Encore's view to act. Wire `notifier.clear()` on `closeInstance` / `updateItem(status: done)` / Encore's view mount (for read-once notifications). Wire `notifier.signal()` for domain conditions (`"encore:taxes:w2-received"`). Progress-aware suppression based on item-completion percentage. The "magnetic feature" demo: open an instance, see last year's data pre-populated, see the next-action reminder already scheduled.
 
@@ -563,16 +634,25 @@ PR 2 (Notifier prototype) resolved during design discussion:
 - Debug page subscribes to the new `notifier` pub/sub channel for live updates; no manual publish/clear forms.
 - Pub/sub granularity: single global `notifier` channel (option A). Per-`pluginPkg` channels and dual-emit (global + per-pluginPkg) considered and rejected for v1 — debug page and the future bell badge both want global view; per-plugin client-side filtering is cheap.
 
+UX decisions for the migration are recorded in [`feat-notifier-ux.md`](feat-notifier-ux.md). A summary of the resolved ones:
+
+- Two lifecycles: `fyi` (host acks) and `action` (plugin clears, `×` cancels). `read` collapsed into `action`.
+- Bell panel: Active section on top, History section below, single scroll, no tabs.
+- Bell badge: pending count, worst-severity color (gray / amber / red), `99+` cap.
+- History capped at 50 entries, FIFO eviction.
+- No toast in v1 — the badge color is the at-a-distance signal.
+- Pub/sub granularity: single global `notifier` channel; per-`pluginPkg` rejected.
+
 To resolve before PR 3 (Notifier full engine):
 
 1. **Declarative vs imperative scheduling.** Plan above is *imperative* — plugin computes each fire time and re-registers. A declarative spec ("every Sunday until acked, escalate after 2 weeks") is more powerful but a bigger surface. Imperative matches how `task-scheduler` already works; declarative may be worth it once we see 3+ plugins repeating the same pattern. **Default: imperative for v1.**
-2. **Type-1 panel affordance: button or checkbox?** Per-row close-button is simplest; leading checkbox + bulk "Acknowledge selected" wins for catch-up sessions where many `fyi` rows pile up. **Default: leading checkbox (covers both — single-row click still works via the row's own close-`×`).**
-3. **Severity → channel mapping config UI.** Hidden file (`config/notifier.json`) for v1, settings page later? Or settings page from day one? **Default: hidden file for v1, settings UI in a follow-up.**
-4. **Re-surface cap.** A reminder ignored for a week should not fire 50 times. Cap at `escalateAt.length` re-surfaces? Hard ceiling of N per 24h? **Default: re-surface only at the explicit `escalateAt` points; no auto-multiplication.**
-5. ~~**Signal namespace.**~~ Resolved by the identity model: signals are structurally scoped as `{ pluginPkg, key }`, so collisions across plugins are impossible by construction. No string-prefix convention to enforce.
+2. **Severity → channel mapping config UI.** Hidden file (`config/notifier.json`) for v1, settings page later? Or settings page from day one? **Default: hidden file for v1, settings UI in a follow-up.**
+3. **Re-surface cap.** A reminder ignored for a week should not fire 50 times. Cap at `escalateAt.length` re-surfaces? Hard ceiling of N per 24h? **Default: re-surface only at the explicit `escalateAt` points; no auto-multiplication.**
+4. ~~**Signal namespace.**~~ Resolved by the identity model: signals are structurally scoped as `{ pluginPkg, key }`, so collisions across plugins are impossible by construction. No string-prefix convention to enforce.
+5. **Pending UX details** from `feat-notifier-ux.md`: empty-History text, undo for accidental ack, badge flash on new urgent. Each is small enough to land with a default and revise by feel.
 6. **Conflict with `task-scheduler`.** The existing scheduler also fires things on a schedule. Notifier is *user-facing reminders*; scheduler is *task execution*. They may share scheduling primitives internally; they should not share API surfaces. **Default: keep them separate; revisit if duplication becomes painful.**
 
-To resolve before PR 4 (Encore CRUD):
+To resolve before PR 5 (Encore CRUD):
 
 7. **i18n surface for Encore.** All 8 locales need the obligation-type vocabulary ("taxes", "registration", "annual physical"). Are these built-in templates the user picks from, or free-form titles the user types? **Default: free-form for v1, suggested templates as a chat-side affordance.**
 

--- a/plans/feat-notifier-ux.md
+++ b/plans/feat-notifier-ux.md
@@ -1,0 +1,114 @@
+# Plan: Notifier UX design
+
+Status: design / discussion. **UX-only** — this document fixes the user-facing surface for the notifier migration. The implementation strategy ("how the engine emits events", "where the wrapper lives", file layout) is the job of `feat-encore.md` PR 3; the decisions below feed into that PR's scope but stay framed as user experience here.
+
+## Why this document
+
+`feat-encore.md` PR 2 shipped the notifier engine itself (active-only `publish` / `clear` / `cancel`). PR 3 will migrate the existing `publishNotification()` notification system onto the new engine. The migration changes the *user experience model*, not just the wiring underneath:
+
+- **Old model** — bell panel = "stream of the last 50 events", with a read/unread flag. Acknowledged items linger; the panel doubles as "what happened recently?"
+- **New model** — bell panel = "currently pending obligations", with explicit `clear` / `cancel` verbs. Cleared and cancelled items leave the active view and move to a capped history.
+
+These are not just two skins on the same data — they answer different questions. Old answers "tell me what fired"; new answers "tell me what's still on me." A migration that ignores the gap leaves users wondering where their history went; a migration that bridges it has to be designed UX-first, not code-first.
+
+## Lifecycle
+
+Two notification types, distinguished by who is responsible for the close call:
+
+- **fyi** — informational ("Backup completed", "Build #42 finished"). Closed when the user acknowledges (individually or in bulk). No deep-link target.
+- **action** — pending obligation ("Pay property tax", "News digest ready"). Has a deep-link target. The *plugin* owns the close call, fired when the underlying domain state changes (the user paid the tax, the user marked the digest read, etc.).
+
+The engine never reads `lifecycle`; it's stored on the entry for the UI to render rows differently. As far as the data flow is concerned, lifecycle is documentation.
+
+## Bell panel layout
+
+One scrollable popup with two stacked sections — Active on top, History below. **No tabs.**
+
+```
+┌────────────────────────────┐
+│ Notifications              │
+├────────────────────────────┤
+│ Active (N)                 │
+│ [ ] Pay property tax  [×]  │   ← action row (× cancels)
+│ [ ] Build #42 finished     │   ← fyi row (checkbox for bulk)
+│ [ ] News digest ready [×]  │
+├────────────────────────────┤
+│ [ Acknowledge selected ]   │   ← fyi bulk-ack button
+├────────────────────────────┤
+│ History (≤ 50)             │
+│  ✓  Backup completed       │
+│  ✗  Old reminder           │
+│  ✓  Build #41 finished     │
+│  …                         │
+└────────────────────────────┘
+```
+
+- **One scroll region** for the whole popup (Active and History share it). When Active is short and History is long, History fills the visible space; when Active is long, History is one scroll away. Single-scroll is a simpler mental model than per-section scroll, and the worst-case ergonomic — long Active pushing History off-screen — is the same direction the user naturally cares about (handle pending things first, then look back).
+- **Section headers** are plain non-sticky headers. Sticky would buy little for the cost.
+- **Empty Active** — the section shows the grey placeholder "No active notifications" and History remains below.
+
+## Bell badge
+
+- **Count** = active entries only. History does not contribute. Capped at `99+`.
+- **Color** — worst-severity-wins:
+  - any `urgent` → red
+  - else any `nudge` → amber
+  - else gray
+- One glance answers "is anything on fire?" without opening the panel. Severity color is the user's primary at-a-distance signal — meaningful precisely because there is no toast (see below).
+
+## Row behaviour
+
+### fyi rows
+
+- Leading checkbox; clicking the row body toggles the checkbox.
+- "Acknowledge selected" button at the foot of the Active section, visible while ≥1 fyi is selected.
+- No `×` button — fyi has no `cancel` semantic, only "the user acknowledges." Single-row instant ack happens by clicking the row's check then the bulk-ack button (a one-row "bulk" is still a bulk).
+
+### action rows
+
+- No checkbox — the bulk-ack flow doesn't apply, because the plugin owns the close.
+- Clicking the row body closes the panel and routes the user to the deep-link target. The URL carries `?notificationId=<uuid>` so the landing page can recover the entry, highlight the relevant item, and decide when to clear it.
+- The notification stays in Active until the plugin calls `clear`. Clicking-and-immediately-leaving doesn't clear it — the plugin waits for the underlying state change. This is what makes the model "obligations, not events."
+- Trailing `×` button → `cancel` ("the user has decided this is no longer relevant"). The entry moves to History marked cancelled.
+
+### History rows
+
+- Read-only display, with one important capability: rows whose original entry had a `navigateTarget` stay clickable — clicking re-routes to that target. This is the primary "what happened earlier?" recall mechanism, the migration's answer to the old "last 50 events" stream. The user can find a previous build report or an article they archived without scrolling chat.
+- Visual marker for terminal type: `✓` for cleared, `✗` for cancelled. Severity color persists from the original entry.
+- History caps at **50 entries**, FIFO eviction.
+
+## No toast
+
+The right-corner toast popup that fires on every legacy `publishNotification()` is removed. Reasoning:
+
+- Toasts interrupt the user mid-task without consent. Most fyi notifications (`Backup completed`, `Build #42 finished`) are information, not emergencies — the cost of interruption outweighs the benefit of immediacy.
+- The bell badge already provides at-a-distance signalling via worst-severity color. A glance answers "is anything urgent waiting?" without disrupting flow.
+- If a future urgent-class category proves to need more aggressive surfacing, that's a follow-up conversation. Start without it.
+
+## Pending UX decisions
+
+These remain open. Each is small enough that the migration PR can land with a default and the choice can be revised by feel.
+
+- **Empty History text.** Default proposal: "No recent activity." Keeps the section header so the structure stays consistent across states. Alternative: hide the section header entirely on empty.
+- **Undo for accidental ack.** A user might check the wrong fyi and hit "Acknowledge selected" before noticing. Options:
+  - Snackbar with "Undo" for N seconds.
+  - No undo — the row lands in History, the user re-reads or re-acts from there.
+  - No undo and no recovery.
+  - Default proposal: no undo. The History row stays clickable; if the user actually wanted to act, they re-navigate from History. The `cancel` × button on action rows is the more error-prone surface, and that one *should* probably get an undo — TBD.
+- **Badge flash on new entry.** With no toast, urgent notifications only signal via badge color and number. If the user is looking elsewhere, would a brief flash animation on increment help discoverability? Default proposal: ship without it, add if real-use feedback shows users miss notifications.
+- **Bulk-ack interaction with cancel.** Should `cancel` (the action-row × button) and `acknowledge` (fyi bulk button) ever coexist on one selection? Currently they don't — checkboxes are fyi-only, × is action-only — but if a user wants to clear out a mixed batch, no single gesture covers it. Default proposal: live with the asymmetry; mixed clearing happens by doing each side in turn.
+
+## Hyperlink behaviours (validated under PR 3 of `feat-encore.md`)
+
+`action`-lifecycle entries with a `navigateTarget` exercise two distinct close-call patterns from the plugin side. Both are first-class citizens of the model — the engine doesn't distinguish them — but they're worth flagging because they cover the full range of plugin-driven `clear` timing:
+
+- **Clear on open** (read-once). The user clicks the row, the panel closes, the deep-link target opens, and the landing page calls `notifier.clear` on mount. Useful for "your daily digest is ready" or "we drafted a summary" — the act of viewing is the close. The notification stays in Active until the user actually navigates; clicking and abandoning the navigation does not clear.
+- **Clear on Done** (act-on). The user clicks the row, the panel closes, the deep-link target opens, the landing page renders a UI for the underlying obligation, and the user has to take an explicit action ("Done", "Mark paid", "Archive") for the plugin to call `notifier.clear`. Useful for "Pay property tax" or "Approve this PR" — opening the page does not by itself satisfy the obligation.
+
+Both patterns share one URL contract: the panel appends `&notificationId=<uuid>` to the `navigateTarget`, and the landing page reads it from the route to know which entry to clear.
+
+## Out of scope
+
+- **Snooze / re-surface** — the engine doesn't yet support time-based scheduling (PR 3 of `feat-encore.md` adds it). When it lands, the panel will need a per-row snooze affordance, but the layout above doesn't preclude that — a snooze button can sit alongside `×`.
+- **Per-plugin filtering inside the panel.** The panel shows one global queue. If the user wants to see only Encore items, they go to the Encore page, not the bell.
+- **Cross-device delivery, mobile push, digest summaries.** All deferred per `feat-encore.md` Notifier v1 scope.

--- a/plans/feat-notifier-ux.md
+++ b/plans/feat-notifier-ux.md
@@ -15,10 +15,10 @@ These are not just two skins on the same data — they answer different question
 
 Two notification types, distinguished by who is responsible for the close call:
 
-- **fyi** — informational ("Backup completed", "Build #42 finished"). Closed when the user acknowledges (individually or in bulk). No deep-link target.
-- **action** — pending obligation ("Pay property tax", "News digest ready"). Has a deep-link target. The *plugin* owns the close call, fired when the underlying domain state changes (the user paid the tax, the user marked the digest read, etc.).
+- **fyi** — informational ("Backup completed", "Build #42 finished"). Closed when the user dismisses it from the bell panel. No deep-link target.
+- **action** — pending obligation ("Pay property tax", "News digest ready"). **Requires** a `navigateTarget` — the engine and the HTTP layer reject `action` publishes that omit it (an `action` with no link is a degraded fyi: clicking it does nothing, and the plugin has no landing page to react to). **Cannot use `info` severity** for the same coherence reason: a low-priority obligation is a contradiction — if it's just a ping, use fyi; if it's a real obligation worth a landing page, use `nudge` or `urgent`. The *plugin* owns the close call, fired when the underlying domain state changes (the user paid the tax, the user marked the digest read, etc.). Whether the plugin clears on landing-page mount (read-once) or only after an explicit user action is the plugin's choice — both patterns are first-class.
 
-The engine never reads `lifecycle`; it's stored on the entry for the UI to render rows differently. As far as the data flow is concerned, lifecycle is documentation.
+The engine never reads `lifecycle` for routing; it's stored on the entry for the UI to render rows differently and validated only at publish time. Once published, lifecycle is documentation as far as the data flow is concerned.
 
 ## Bell panel layout
 
@@ -29,11 +29,9 @@ One scrollable popup with two stacked sections — Active on top, History below.
 │ Notifications              │
 ├────────────────────────────┤
 │ Active (N)                 │
-│ [ ] Pay property tax  [×]  │   ← action row (× cancels)
-│ [ ] Build #42 finished     │   ← fyi row (checkbox for bulk)
-│ [ ] News digest ready [×]  │
-├────────────────────────────┤
-│ [ Acknowledge selected ]   │   ← fyi bulk-ack button
+│  ●  Pay property tax  [×]  │   ← action row (click body → navigate, × → cancel)
+│  ●  Build #42 finished [×] │   ← fyi row    (× → clear)
+│  ●  News digest ready [×]  │   ← action row
 ├────────────────────────────┤
 │ History (≤ 50)             │
 │  ✓  Backup completed       │
@@ -58,18 +56,20 @@ One scrollable popup with two stacked sections — Active on top, History below.
 
 ## Row behaviour
 
+Active rows share one visual layout — severity dot + title/body/meta + trailing `×` button. Click semantics differ by `lifecycle`:
+
 ### fyi rows
 
-- Leading checkbox; clicking the row body toggles the checkbox.
-- "Acknowledge selected" button at the foot of the Active section, visible while ≥1 fyi is selected.
-- No `×` button — fyi has no `cancel` semantic, only "the user acknowledges." Single-row instant ack happens by clicking the row's check then the bulk-ack button (a one-row "bulk" is still a bulk).
+- Body click does nothing (fyi has no `navigateTarget` by construction).
+- Trailing `×` calls `clear` — the only verb that applies, since fyi has no `cancel` notion ("the user acknowledges" IS the close). Entry moves to History marked `cleared`.
 
 ### action rows
 
-- No checkbox — the bulk-ack flow doesn't apply, because the plugin owns the close.
-- Clicking the row body closes the panel and routes the user to the deep-link target. The URL carries `?notificationId=<uuid>` so the landing page can recover the entry, highlight the relevant item, and decide when to clear it.
-- The notification stays in Active until the plugin calls `clear`. Clicking-and-immediately-leaving doesn't clear it — the plugin waits for the underlying state change. This is what makes the model "obligations, not events."
-- Trailing `×` button → `cancel` ("the user has decided this is no longer relevant"). The entry moves to History marked cancelled.
+- Body click closes the panel and routes the user to `navigateTarget` with `?notificationId=<uuid>` appended. The landing page can recover the entry, highlight the relevant item, and decide when to clear.
+- Trailing `×` calls `cancel` ("the user has decided this is no longer relevant"). Entry moves to History marked `cancelled`.
+- Clicking-and-immediately-leaving the landing page does *not* clear the entry — the plugin waits for the underlying state change. This is what makes the model "obligations, not events."
+
+An earlier draft gave fyi rows a leading checkbox and a footer "Acknowledge selected" button for bulk ack. Dropped: the unified single-`×` UI is faster for the typical case (dismiss one row) and the bulk-catch-up case (acknowledge N rows at once) is rare enough not to warrant a separate UI mode.
 
 ### History rows
 
@@ -90,7 +90,7 @@ The right-corner toast popup that fires on every legacy `publishNotification()` 
 These remain open. Each is small enough that the migration PR can land with a default and the choice can be revised by feel.
 
 - **Empty History text.** Default proposal: "No recent activity." Keeps the section header so the structure stays consistent across states. Alternative: hide the section header entirely on empty.
-- **Undo for accidental ack.** A user might check the wrong fyi and hit "Acknowledge selected" before noticing. Options:
+- **Undo for accidental dismiss.** A user might mis-tap the `×` on the wrong row. Options:
   - Snackbar with "Undo" for N seconds.
   - No undo — the row lands in History, the user re-reads or re-acts from there.
   - No undo and no recovery.

--- a/server/api/routes/notifier.ts
+++ b/server/api/routes/notifier.ts
@@ -3,11 +3,12 @@
 
 import { Router, type Request, type Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
-import { cancel, clear, listAll, publish } from "../../notifier/engine.js";
+import { cancel, clear, listAll, listHistory, publish } from "../../notifier/engine.js";
 import {
   NOTIFIER_LIFECYCLES,
   NOTIFIER_SEVERITIES,
   type NotifierEntry,
+  type NotifierHistoryEntry,
   type NotifierLifecycle,
   type NotifierSeverity,
   type PublishInput,
@@ -22,12 +23,13 @@ interface DispatchBody {
   title?: unknown;
   body?: unknown;
   lifecycle?: unknown;
+  navigateTarget?: unknown;
   pluginData?: unknown;
   // clear / cancel
   id?: unknown;
 }
 
-type DispatchResponse = { id: string } | { ok: true } | { entries: NotifierEntry[] } | { error: string };
+type DispatchResponse = { id: string } | { ok: true } | { entries: NotifierEntry[] } | { history: NotifierHistoryEntry[] } | { error: string };
 
 const SEVERITY_SET = new Set<string>(NOTIFIER_SEVERITIES);
 const LIFECYCLE_SET = new Set<string>(NOTIFIER_LIFECYCLES);
@@ -60,12 +62,16 @@ function parsePublishInput(body: DispatchBody): PublishInput | string {
   if (body.body !== undefined && body.body !== null && typeof body.body !== "string") {
     return "body must be a string when set";
   }
+  if (body.navigateTarget !== undefined && body.navigateTarget !== null && typeof body.navigateTarget !== "string") {
+    return "navigateTarget must be a string when set";
+  }
   return {
     pluginPkg: body.pluginPkg,
     severity,
     title: body.title,
     body: typeof body.body === "string" ? body.body : undefined,
     lifecycle: asLifecycle(body.lifecycle),
+    navigateTarget: typeof body.navigateTarget === "string" ? body.navigateTarget : undefined,
     pluginData: body.pluginData,
   };
 }
@@ -108,6 +114,11 @@ notifierRouter.post(API_ROUTES.notifier.dispatch, async (req: Request<object, Di
       case "list": {
         const entries = await listAll();
         res.json({ entries });
+        return;
+      }
+      case "listHistory": {
+        const history = await listHistory();
+        res.json({ history });
         return;
       }
       default:

--- a/server/api/routes/notifier.ts
+++ b/server/api/routes/notifier.ts
@@ -51,6 +51,23 @@ function asLifecycle(value: unknown): NotifierLifecycle | undefined {
   return undefined;
 }
 
+// `action` lifecycle constraints, mirrored from `engine.publish`
+// so HTTP callers get a clean 400 instead of a 500 from the engine
+// throw. The engine still enforces independently for plugin-runtime
+// callers; this is the route-level mirror.
+function validateActionConstraints(severity: NotifierSeverity, lifecycle: NotifierLifecycle | undefined, navigateTarget: string | undefined): string | null {
+  if (lifecycle !== "action") return null;
+  if (severity === "info") return "action lifecycle is incompatible with info severity (use fyi for low-priority pings)";
+  if (navigateTarget === undefined || navigateTarget.length === 0) return "action lifecycle requires a non-empty navigateTarget";
+  return null;
+}
+
+function checkOptionalString(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return `${fieldName} must be a string when set`;
+  return null;
+}
+
 function parsePublishInput(body: DispatchBody): PublishInput | string {
   if (!isNonEmptyString(body.pluginPkg)) return "pluginPkg required";
   if (!isNonEmptyString(body.title)) return "title required";
@@ -59,19 +76,21 @@ function parsePublishInput(body: DispatchBody): PublishInput | string {
   if (body.lifecycle !== undefined && body.lifecycle !== null && asLifecycle(body.lifecycle) === undefined) {
     return "lifecycle must be one of fyi | action when set";
   }
-  if (body.body !== undefined && body.body !== null && typeof body.body !== "string") {
-    return "body must be a string when set";
-  }
-  if (body.navigateTarget !== undefined && body.navigateTarget !== null && typeof body.navigateTarget !== "string") {
-    return "navigateTarget must be a string when set";
-  }
+  const bodyError = checkOptionalString(body.body, "body");
+  if (bodyError) return bodyError;
+  const navigateTargetError = checkOptionalString(body.navigateTarget, "navigateTarget");
+  if (navigateTargetError) return navigateTargetError;
+  const lifecycle = asLifecycle(body.lifecycle);
+  const navigateTarget = typeof body.navigateTarget === "string" ? body.navigateTarget : undefined;
+  const actionError = validateActionConstraints(severity, lifecycle, navigateTarget);
+  if (actionError) return actionError;
   return {
     pluginPkg: body.pluginPkg,
     severity,
     title: body.title,
     body: typeof body.body === "string" ? body.body : undefined,
-    lifecycle: asLifecycle(body.lifecycle),
-    navigateTarget: typeof body.navigateTarget === "string" ? body.navigateTarget : undefined,
+    lifecycle,
+    navigateTarget,
     pluginData: body.pluginData,
   };
 }

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -201,6 +201,26 @@ function buildHistoryEntry(entry: NotifierEntry, terminalType: "cleared" | "canc
 // ── Public API ────────────────────────────────────────────────────
 
 export async function publish<TPluginData = unknown>(input: PublishInput<TPluginData>): Promise<{ id: string }> {
+  // `action` lifecycle constraints. Enforced at the engine boundary
+  // so both HTTP callers and plugin-runtime callers hit the same
+  // wall. See `feat-notifier-ux.md` for the rationale.
+  //
+  //   1. `action` requires a non-empty `navigateTarget`. Without
+  //      one, the bell click does nothing and the entry is a
+  //      degraded fyi.
+  //   2. `action` cannot use `info` severity. The two together mean
+  //      "low-priority obligation," which is incoherent — if it's
+  //      low-priority enough to be info, it's an fyi (just an
+  //      informational ping); if it's a real obligation worth a
+  //      domain landing page, it's at least `nudge`.
+  if (input.lifecycle === "action") {
+    if (input.severity === "info") {
+      throw new Error("notifier.publish: action lifecycle is incompatible with info severity (use fyi for low-priority pings)");
+    }
+    if (typeof input.navigateTarget !== "string" || input.navigateTarget.length === 0) {
+      throw new Error("notifier.publish: action lifecycle requires a non-empty navigateTarget");
+    }
+  }
   const entryId = randomUUID();
   const entry: NotifierEntry<TPluginData> = {
     id: entryId,

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -244,6 +244,27 @@ export async function cancel(entryId: string): Promise<void> {
   });
 }
 
+/** Plugin-scoped clear. Same as `clear` but no-ops if the entry's
+ *  `pluginPkg` doesn't match the caller's. Used by the per-plugin
+ *  `runtime.notifier.clear` so a plugin can't dismiss another
+ *  plugin's notification by guessing or scraping its id. The
+ *  silent no-op (rather than a throw) matches `clear(unknown id)`
+ *  semantics — the plugin can't distinguish "id never existed"
+ *  from "id belongs to another plugin", which is the intended
+ *  isolation property. */
+export async function clearForPlugin(pluginPkg: string, entryId: string): Promise<void> {
+  await enqueue((state) => {
+    const entry = state.entries[entryId];
+    if (!entry) return null;
+    if (entry.pluginPkg !== pluginPkg) return null;
+    state.entries = removeEntry(state, entryId);
+    return {
+      event: { type: "cleared", id: entryId },
+      historyEntry: buildHistoryEntry(entry, "cleared"),
+    };
+  });
+}
+
 export async function get(entryId: string): Promise<NotifierEntry | undefined> {
   const state = await loadActive(activeFilePath);
   return state.entries[entryId];

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -1,20 +1,26 @@
-// Notifier engine — single-process, single-file, single-channel.
+// Notifier engine — single-process, two-file (active + history),
+// single-channel.
 //
-// API surface: publish / clear / cancel / get / listFor / listAll.
-// Mutations queue through a writing-flag + waiter-queue coordinator
-// so concurrent callers can't race on the underlying `writeFileAtomic`
-// rename. Reads bypass the queue (`writeFileAtomic`'s rename
-// atomicity makes half-reads impossible) and trade strict
-// linearisability for simpler code: the contract is "after `await
-// publish(x)` resolves, subsequent reads see x" — which holds because
-// `publish` awaits the persist before returning.
+// API surface: publish / clear / cancel / get / listFor / listAll /
+// listHistory. Mutations queue through a writing-flag + waiter-queue
+// coordinator so concurrent callers can't race on `writeFileAtomic`'s
+// rename. Reads bypass the queue (rename atomicity makes half-reads
+// impossible) and trade strict linearisability for simpler code: the
+// contract is "after `await publish(x)` resolves, subsequent reads
+// see x" — which holds because `publish` awaits the persist before
+// returning.
+//
+// `clear` / `cancel` push to history *before* removing from active.
+// History persistence is best-effort: if it fails, the active write
+// still wins and the failure is logged. Active is the source of
+// truth; history is an audit aid.
 
 import { randomUUID } from "crypto";
 import { PUBSUB_CHANNELS } from "../../src/config/pubsubChannels.js";
 import { log } from "../system/logger/index.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
-import { loadActive, saveActive } from "./store.js";
-import type { NotifierEntry, NotifierEvent, NotifierFile, PublishInput } from "./types.js";
+import { loadActive, loadHistory, saveActive, saveHistory } from "./store.js";
+import { HISTORY_CAP, type NotifierEntry, type NotifierEvent, type NotifierFile, type NotifierHistoryEntry, type PublishInput } from "./types.js";
 
 // ── Dependency injection (matches server/events/notifications.ts) ──
 
@@ -30,11 +36,6 @@ export function initNotifier(injected: NotifierDeps): void {
 
 function emit(event: NotifierEvent): void {
   if (!deps) {
-    // Calling a mutation API before `initNotifier` runs would mean
-    // emitting into the void. We log and continue (state still
-    // persists) so the engine remains usable if startup ordering
-    // ever changes — but in practice `initNotifier` is wired in
-    // `startRuntimeServices`, before any HTTP request can arrive.
     log.warn("notifier", "emit before init", { type: event.type });
     return;
   }
@@ -44,14 +45,19 @@ function emit(event: NotifierEvent): void {
 // ── Write coordinator ─────────────────────────────────────────────
 
 /** A mutation function applied to the in-memory state object during
- *  drain. Returns the event to emit, or `null` to indicate "no
- *  state change" — the drainer skips the disk write and the emit
- *  when every mutation in a batch returned `null`.
+ *  drain. Returns either:
  *
- *  Mutations MUST NOT modify state when returning `null` (see
- *  `clear` / `cancel` for the unknown-id case). Violating this
- *  invariant produces a write skip with stale on-disk state. */
-type Mutation = (state: NotifierFile) => NotifierEvent | null;
+ *    - `null` — no state change (e.g., `clear` on an unknown id).
+ *      The drainer skips the disk write and the emit if every
+ *      mutation in a batch returned `null`.
+ *    - `{ event, historyEntry? }` — state changed. The drainer emits
+ *      the event after the active write succeeds, and prepends
+ *      `historyEntry` to history (best-effort) when present.
+ *
+ *  Mutations MUST NOT modify state when returning `null`. Violating
+ *  this invariant produces a write skip with stale on-disk state. */
+type MutationOutcome = { event: NotifierEvent; historyEntry?: NotifierHistoryEntry } | null;
+type Mutation = (state: NotifierFile) => MutationOutcome;
 
 interface Waiter {
   mutate: Mutation;
@@ -59,20 +65,18 @@ interface Waiter {
   reject: (err: unknown) => void;
 }
 
-type MutationResult = { ok: true; event: NotifierEvent | null } | { ok: false; error: unknown };
+type MutationResult = { ok: true; outcome: MutationOutcome } | { ok: false; error: unknown };
 
 let writing = false;
 let waiters: Waiter[] = [];
 
 let activeFilePath: string = WORKSPACE_PATHS.notifierActive;
+let historyFilePath: string = WORKSPACE_PATHS.notifierHistory;
 
-/** Test-only: redirect the engine at a temp file. Kept off the public
- *  API surface (the underscore prefix + the `_setActiveFilePathForTesting`
- *  name) so production code can't accidentally rebind. Resets the queue
- *  too — a leftover write in flight from a previous test would
- *  otherwise persist into the next test's tmp dir. */
-export function _setActiveFilePathForTesting(filePath: string): void {
-  activeFilePath = filePath;
+/** Test-only: redirect the engine at temp files. Resets the queue too. */
+export function _setFilePathsForTesting(paths: { active: string; history: string }): void {
+  activeFilePath = paths.active;
+  historyFilePath = paths.history;
   writing = false;
   waiters = [];
 }
@@ -80,7 +84,7 @@ export function _setActiveFilePathForTesting(filePath: string): void {
 function applyBatchMutations(batch: Waiter[], state: NotifierFile): MutationResult[] {
   return batch.map((waiter) => {
     try {
-      return { ok: true, event: waiter.mutate(state) };
+      return { ok: true, outcome: waiter.mutate(state) };
     } catch (err) {
       return { ok: false, error: err };
     }
@@ -90,9 +94,19 @@ function applyBatchMutations(batch: Waiter[], state: NotifierFile): MutationResu
 function collectEvents(results: MutationResult[]): NotifierEvent[] {
   const events: NotifierEvent[] = [];
   for (const result of results) {
-    if (result.ok && result.event !== null) events.push(result.event);
+    if (result.ok && result.outcome !== null) events.push(result.outcome.event);
   }
   return events;
+}
+
+function collectHistoryEntries(results: MutationResult[]): NotifierHistoryEntry[] {
+  const entries: NotifierHistoryEntry[] = [];
+  for (const result of results) {
+    if (result.ok && result.outcome !== null && result.outcome.historyEntry) {
+      entries.push(result.outcome.historyEntry);
+    }
+  }
+  return entries;
 }
 
 function settleBatch(batch: Waiter[], results: MutationResult[]): void {
@@ -109,6 +123,14 @@ function rejectBatch(batch: Waiter[], err: unknown): void {
   for (const waiter of batch) waiter.reject(err);
 }
 
+async function persistHistory(newEntries: NotifierHistoryEntry[]): Promise<void> {
+  const existing = await loadHistory(historyFilePath);
+  // Newest-first ordering: a batch contains terminations in arrival
+  // order; we want the last one to land at index 0 of history.
+  const merged = [...newEntries.slice().reverse(), ...existing.entries].slice(0, HISTORY_CAP);
+  await saveHistory(historyFilePath, { entries: merged });
+}
+
 async function processBatch(batch: Waiter[]): Promise<void> {
   let state: NotifierFile;
   try {
@@ -120,19 +142,25 @@ async function processBatch(batch: Waiter[]): Promise<void> {
   }
   const results = applyBatchMutations(batch, state);
   const events = collectEvents(results);
+  const historyEntries = collectHistoryEntries(results);
+
   if (events.length > 0) {
     try {
       await saveActive(activeFilePath, state);
     } catch (err) {
-      log.error("notifier", "write failed", { error: String(err) });
-      // A failing write means none of this batch's state changes are
-      // durable. Reject every waiter — including any whose mutation
-      // returned `null` — because the batch as a whole failed to
-      // commit. Resolving the no-ops while rejecting the contributors
-      // would let a sibling caller observe a "succeeded" no-op clear
-      // alongside a publish that didn't actually persist.
+      log.error("notifier", "active write failed", { error: String(err) });
       rejectBatch(batch, err);
       return;
+    }
+    if (historyEntries.length > 0) {
+      // Best-effort: active is the source of truth, history is an
+      // audit aid. A failed history write is logged but doesn't
+      // unwind the active commit.
+      try {
+        await persistHistory(historyEntries);
+      } catch (err) {
+        log.error("notifier", "history write failed", { error: String(err) });
+      }
     }
     for (const event of events) emit(event);
   }
@@ -155,20 +183,19 @@ async function drain(): Promise<void> {
 function enqueue(mutate: Mutation): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     waiters.push({ mutate, resolve, reject });
-    // First caller while idle kicks off the drain; subsequent callers
-    // just leave their resolver in the queue. `void` because drain is
-    // fire-and-forget — the per-waiter promise is the resolution
-    // path the caller awaits.
     if (!writing) void drain();
   });
 }
 
 function removeEntry(state: NotifierFile, entryId: string): NotifierFile["entries"] {
-  // `delete state.entries[id]` is the obvious form, but the codebase
-  // bans dynamic delete (`@typescript-eslint/no-dynamic-delete`).
-  // Object-rest excludes the key without invoking `delete`.
+  // The codebase bans dynamic delete; object-rest excludes the key
+  // without invoking `delete`.
   const { [entryId]: __removed, ...remaining } = state.entries;
   return remaining;
+}
+
+function buildHistoryEntry(entry: NotifierEntry, terminalType: "cleared" | "cancelled"): NotifierHistoryEntry {
+  return { ...entry, terminalType, terminalAt: new Date().toISOString() };
 }
 
 // ── Public API ────────────────────────────────────────────────────
@@ -182,29 +209,38 @@ export async function publish<TPluginData = unknown>(input: PublishInput<TPlugin
     lifecycle: input.lifecycle,
     title: input.title,
     body: input.body,
+    navigateTarget: input.navigateTarget,
     pluginData: input.pluginData,
     createdAt: new Date().toISOString(),
   };
   await enqueue((state) => {
     state.entries[entryId] = entry as NotifierEntry;
-    return { type: "published", entry: entry as NotifierEntry };
+    return { event: { type: "published", entry: entry as NotifierEntry } };
   });
   return { id: entryId };
 }
 
 export async function clear(entryId: string): Promise<void> {
   await enqueue((state) => {
-    if (!(entryId in state.entries)) return null;
+    const entry = state.entries[entryId];
+    if (!entry) return null;
     state.entries = removeEntry(state, entryId);
-    return { type: "cleared", id: entryId };
+    return {
+      event: { type: "cleared", id: entryId },
+      historyEntry: buildHistoryEntry(entry, "cleared"),
+    };
   });
 }
 
 export async function cancel(entryId: string): Promise<void> {
   await enqueue((state) => {
-    if (!(entryId in state.entries)) return null;
+    const entry = state.entries[entryId];
+    if (!entry) return null;
     state.entries = removeEntry(state, entryId);
-    return { type: "cancelled", id: entryId };
+    return {
+      event: { type: "cancelled", id: entryId },
+      historyEntry: buildHistoryEntry(entry, "cancelled"),
+    };
   });
 }
 
@@ -221,4 +257,9 @@ export async function listFor(pluginPkg: string): Promise<NotifierEntry[]> {
 export async function listAll(): Promise<NotifierEntry[]> {
   const state = await loadActive(activeFilePath);
   return Object.values(state.entries);
+}
+
+export async function listHistory(): Promise<NotifierHistoryEntry[]> {
+  const state = await loadHistory(historyFilePath);
+  return state.entries;
 }

--- a/server/notifier/runtime-api.ts
+++ b/server/notifier/runtime-api.ts
@@ -1,0 +1,47 @@
+// Plugin-facing notifier API. The host attaches a per-plugin
+// instance of `NotifierRuntimeApi` to the `PluginRuntime` it
+// constructs for each plugin (see `server/plugins/runtime.ts`).
+// `pluginPkg` is auto-bound to the calling plugin's pkg name so
+// plugins cannot publish under another plugin's namespace.
+//
+// Plugin authors access this surface via type assertion:
+//
+//   import type { PluginRuntime } from "gui-chat-protocol";
+//   import type { MulmoclaudeRuntime } from "<mulmoclaude>/notifier/runtime-api";
+//   export default definePlugin((runtime: PluginRuntime) => {
+//     const { notifier } = runtime as MulmoclaudeRuntime;
+//     // notifier.publish(...) / notifier.clear(...)
+//   });
+//
+// Once the API stabilises, this is a candidate for upstreaming
+// into gui-chat-protocol so the cast goes away.
+
+import type { PluginRuntime } from "gui-chat-protocol";
+import type { NotifierLifecycle, NotifierSeverity } from "./types.js";
+
+/** Caller-supplied input for the plugin-facing `publish`. Same shape
+ *  as `PublishInput` minus `pluginPkg`, which the host fills in
+ *  automatically from the calling plugin's pkg name. */
+export interface PluginPublishInput<TPluginData = unknown> {
+  severity: NotifierSeverity;
+  title: string;
+  body?: string;
+  lifecycle?: NotifierLifecycle;
+  navigateTarget?: string;
+  pluginData?: TPluginData;
+}
+
+export interface NotifierRuntimeApi {
+  /** Publish a notification scoped to this plugin. The engine assigns
+   *  a UUID synchronously and returns it. */
+  publish: <TPluginData = unknown>(input: PluginPublishInput<TPluginData>) => Promise<{ id: string }>;
+  /** Clear an entry by id. No-op (no throw) if the id is unknown. */
+  clear: (id: string) => Promise<void>;
+}
+
+/** The runtime shape MulmoClaude actually provides — the
+ *  gui-chat-protocol `PluginRuntime` plus the host's notifier
+ *  extension. */
+export type MulmoclaudeRuntime = PluginRuntime & {
+  notifier: NotifierRuntimeApi;
+};

--- a/server/notifier/store.ts
+++ b/server/notifier/store.ts
@@ -4,7 +4,7 @@
 
 import { promises as fsPromises } from "fs";
 import { writeFileAtomic } from "../utils/files/atomic.js";
-import type { NotifierFile } from "./types.js";
+import type { NotifierFile, NotifierHistoryFile } from "./types.js";
 
 function isNotFoundError(err: unknown): boolean {
   return typeof err === "object" && err !== null && (err as { code?: unknown }).code === "ENOENT";
@@ -35,5 +35,26 @@ export async function loadActive(filePath: string): Promise<NotifierFile> {
  *  writes (engine.ts queues mutations) — this function makes no
  *  concurrency guarantees of its own. */
 export async function saveActive(filePath: string, state: NotifierFile): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(state, null, 2));
+}
+
+/** Read the history file. Empty array on first run. Same parse-error
+ *  policy as `loadActive`. */
+export async function loadHistory(filePath: string): Promise<NotifierHistoryFile> {
+  let text: string;
+  try {
+    text = await fsPromises.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (isNotFoundError(err)) return { entries: [] };
+    throw err;
+  }
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed) || !Array.isArray((parsed as { entries: unknown }).entries)) {
+    throw new Error(`notifier: malformed history.json at ${filePath}`);
+  }
+  return parsed as NotifierHistoryFile;
+}
+
+export async function saveHistory(filePath: string, state: NotifierHistoryFile): Promise<void> {
   await writeFileAtomic(filePath, JSON.stringify(state, null, 2));
 }

--- a/server/notifier/types.ts
+++ b/server/notifier/types.ts
@@ -38,11 +38,24 @@ export interface NotifierEntry<TPluginData = unknown> {
   lifecycle?: NotifierLifecycle;
   title: string;
   body?: string;
+  /** Optional in-app deep-link target (relative URL). The bell popup
+   *  routes here on row click, with `&notificationId=<id>` appended
+   *  so the landing page can identify which entry to clear. The
+   *  engine doesn't read this — it's a UI hint stored on the entry. */
+  navigateTarget?: string;
   /** Opaque to the engine. Round-trips through JSON unchanged; only
    *  the originating plugin's UI knows the shape. */
   pluginData?: TPluginData;
   /** ISO-8601 timestamp set at `publish()` time. */
   createdAt: string;
+}
+
+/** A history entry — a `NotifierEntry` after it has been cleared or
+ *  cancelled, with the terminal type and timestamp recorded. The
+ *  bell popup's "History" section renders these read-only. */
+export interface NotifierHistoryEntry<TPluginData = unknown> extends NotifierEntry<TPluginData> {
+  terminalType: "cleared" | "cancelled";
+  terminalAt: string;
 }
 
 /** Caller-supplied input for `publish()`. The engine fills in `id`
@@ -53,6 +66,7 @@ export interface PublishInput<TPluginData = unknown> {
   title: string;
   body?: string;
   lifecycle?: NotifierLifecycle;
+  navigateTarget?: string;
   pluginData?: TPluginData;
 }
 
@@ -62,6 +76,17 @@ export interface PublishInput<TPluginData = unknown> {
 export interface NotifierFile {
   entries: Record<string, NotifierEntry>;
 }
+
+/** On-disk shape of `~/mulmoclaude/data/notifier/history.json`. Array
+ *  of terminated entries newest-first, capped at `HISTORY_CAP` with
+ *  FIFO eviction (push at index 0, slice from the tail). */
+export interface NotifierHistoryFile {
+  entries: NotifierHistoryEntry[];
+}
+
+/** History size cap. The bell popup's History section renders this
+ *  many entries; older ones fall off when new terminations land. */
+export const HISTORY_CAP = 50;
 
 /** Pub-sub event published on `PUBSUB_CHANNELS.notifier` after every
  *  successful state change. Discriminated union — subscribers switch

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -21,6 +21,8 @@ import { log as hostLog, type Logger } from "../system/logger/index.js";
 import { ensureInsideBase } from "./runtime-loader.js";
 import { ONE_SECOND_MS } from "../utils/time.js";
 import type { IPubSub } from "../events/pub-sub/index.js";
+import * as notifierEngine from "../notifier/engine.js";
+import type { MulmoclaudeRuntime, NotifierRuntimeApi } from "../notifier/runtime-api.js";
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
 
@@ -242,6 +244,17 @@ function makeScopedPubSub(pkgName: string, hostPubSub: IPubSub): PluginRuntime["
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// Scoped notifier (host extension over gui-chat-protocol's PluginRuntime)
+// ─────────────────────────────────────────────────────────────────────
+
+function makeScopedNotifier(pkgName: string): NotifierRuntimeApi {
+  return {
+    publish: (input) => notifierEngine.publish({ ...input, pluginPkg: pkgName }),
+    clear: (entryId) => notifierEngine.clear(entryId),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Public entry — wire everything into one PluginRuntime
 // ─────────────────────────────────────────────────────────────────────
 
@@ -255,7 +268,7 @@ export interface MakePluginRuntimeDeps {
   locale: string;
 }
 
-export function makePluginRuntime(deps: MakePluginRuntimeDeps): PluginRuntime {
+export function makePluginRuntime(deps: MakePluginRuntimeDeps): MulmoclaudeRuntime {
   const { pkgName, pubsub, locale } = deps;
   const seg = sanitisePackageNameForFs(pkgName);
   const dataRoot = path.join(WORKSPACE_PATHS.pluginsData, seg);
@@ -272,6 +285,9 @@ export function makePluginRuntime(deps: MakePluginRuntimeDeps): PluginRuntime {
     log: makeScopedLogger(pkgName),
     fetch: scopedFetch,
     fetchJson: makeScopedFetchJson(pkgName, scopedFetch),
+    // Host extension over gui-chat-protocol's PluginRuntime. Plugin
+    // authors access via `runtime as MulmoclaudeRuntime` for now.
+    notifier: makeScopedNotifier(pkgName),
   };
 }
 

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -248,9 +248,15 @@ function makeScopedPubSub(pkgName: string, hostPubSub: IPubSub): PluginRuntime["
 // ─────────────────────────────────────────────────────────────────────
 
 function makeScopedNotifier(pkgName: string): NotifierRuntimeApi {
+  // Both `publish` and `clear` are plugin-scoped:
+  //   - publish forces `pluginPkg` to the caller's pkg name (the
+  //     plugin literally cannot publish under another's namespace).
+  //   - clear routes through `clearForPlugin` so a plugin holding
+  //     another plugin's id (e.g. via a future leak) silently no-ops
+  //     instead of dismissing it. CodeRabbit review on PR #1198.
   return {
     publish: (input) => notifierEngine.publish({ ...input, pluginPkg: pkgName }),
-    clear: (entryId) => notifierEngine.clear(entryId),
+    clear: (entryId) => notifierEngine.clearForPlugin(pkgName, entryId),
   };
 }
 

--- a/src/components/NotifierDebugPopup.vue
+++ b/src/components/NotifierDebugPopup.vue
@@ -1,20 +1,26 @@
 <script setup lang="ts">
 // Top-bar debug surface for the host notifier engine. Visible only
 // when `VITE_DEV_MODE === "1"` (the same gate as the Debug role in
-// `RoleSelector`). Lives next to the bell so a developer can fire
-// the scripted test without leaving whatever screen they're on.
+// `RoleSelector`). Lives next to the bell so a developer can drive
+// the new bell UX without leaving whatever screen they're on.
 //
 // No i18n by design: this popup is dev-only chrome, never seen by
 // end users — every string is a literal English value kept in this
 // file. Don't extract these into vue-i18n.
 //
-// Subscribes to the host's `notifier` pub/sub channel directly via
+// Subscribes to the host's `notifier` pub/sub channel via
 // `usePubSub`. Runtime plugins can't see this channel because their
 // `BrowserPluginRuntime.pubsub` is hard-scoped to `plugin:<pkg>:*`,
-// which is why the harness lives here in host code rather than under
-// `@mulmoclaude/debug-plugin`.
+// which is why the new-UX harness lives in host code rather than
+// under `@mulmoclaude/debug-plugin`.
+//
+// The popup mirrors the UX specced in `plans/feat-notifier-ux.md`:
+// Active section on top + History section below, single scroll, no
+// tabs. Triggers all live through `POST /api/notifier`. Test
+// notifications fire from the `/debug` page (separate surface).
 
 import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRouter } from "vue-router";
 import { usePubSub } from "../composables/usePubSub";
 import { apiPost } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -27,52 +33,81 @@ interface NotifierEntry {
   lifecycle?: "fyi" | "action";
   title: string;
   body?: string;
+  navigateTarget?: string;
   pluginData?: unknown;
   createdAt: string;
 }
 
+interface NotifierHistoryEntry extends NotifierEntry {
+  terminalType: "cleared" | "cancelled";
+  terminalAt: string;
+}
+
 type NotifierEvent = { type: "published"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };
+
+const HISTORY_CAP = 50;
+
+const router = useRouter();
 
 const open = ref(false);
 const rootRef = ref<HTMLElement | null>(null);
 const entries = ref<NotifierEntry[]>([]);
+const history = ref<NotifierHistoryEntry[]>([]);
+const checkedFyi = ref<Set<string>>(new Set());
 const status = ref<string>("idle");
-const running = ref(false);
 
 const devMode = import.meta.env.VITE_DEV_MODE === "1";
 
 const visibleEntries = computed(() => [...entries.value].sort((left, right) => left.createdAt.localeCompare(right.createdAt)));
+const visibleHistory = computed(() => history.value);
 
 const badgeText = computed(() => (entries.value.length > 99 ? "99+" : String(entries.value.length)));
 
 // Worst-severity-wins: any urgent → red, else any nudge → amber,
 // else gray. Mirrors the bell-badge color encoding called out in
-// plans/feat-encore.md ("one glance answers 'is anything on fire?'
-// without opening the panel").
+// plans/feat-notifier-ux.md.
 const badgeColor = computed(() => {
   if (entries.value.some((entry) => entry.severity === "urgent")) return "bg-red-500";
   if (entries.value.some((entry) => entry.severity === "nudge")) return "bg-amber-500";
   return "bg-gray-400";
 });
 
-async function refreshList(): Promise<void> {
+const checkedFyiCount = computed(() => visibleEntries.value.filter((entry) => entry.lifecycle === "fyi" && checkedFyi.value.has(entry.id)).length);
+
+async function refreshActive(): Promise<void> {
   const result = await apiPost<{ entries: NotifierEntry[] }>(API_ROUTES.notifier.dispatch, { action: "list" });
   if (result.ok) entries.value = result.data.entries;
   else status.value = `list failed: ${result.error}`;
 }
 
+async function refreshHistory(): Promise<void> {
+  const result = await apiPost<{ history: NotifierHistoryEntry[] }>(API_ROUTES.notifier.dispatch, { action: "listHistory" });
+  if (result.ok) history.value = result.data.history;
+  else status.value = `listHistory failed: ${result.error}`;
+}
+
 function applyEvent(event: NotifierEvent): void {
   switch (event.type) {
     case "published":
-      // De-dup: skip if we already have it (e.g. our own publish call
-      // returned and we updated locally before the pubsub round-trip).
+      // De-dup: own publish-driven local update may have landed first.
       if (!entries.value.some((entry) => entry.id === event.entry.id)) {
         entries.value = [...entries.value, event.entry];
       }
       return;
     case "cleared":
-    case "cancelled":
+    case "cancelled": {
+      const removed = entries.value.find((entry) => entry.id === event.id);
       entries.value = entries.value.filter((entry) => entry.id !== event.id);
+      checkedFyi.value.delete(event.id);
+      if (removed) {
+        const historyEntry: NotifierHistoryEntry = {
+          ...removed,
+          terminalType: event.type === "cleared" ? "cleared" : "cancelled",
+          terminalAt: new Date().toISOString(),
+        };
+        history.value = [historyEntry, ...history.value].slice(0, HISTORY_CAP);
+      }
+    }
   }
 }
 
@@ -82,10 +117,11 @@ let unsubscribe: (() => void) | null = null;
 onMounted(() => {
   unsubscribe = subscribe(PUBSUB_CHANNELS.notifier, (data) => applyEvent(data as NotifierEvent));
   document.addEventListener("mousedown", onDocumentClick);
-  // Prime the local list so the badge reflects existing entries
-  // before the user opens the popup. Fire-and-forget — a transient
-  // failure surfaces in the popup's status line on next open.
-  void refreshList();
+  // Prime so the badge reflects existing entries before the user opens
+  // the popup. History primed in parallel — display only matters when
+  // open, but priming early avoids a flash on first open.
+  void refreshActive();
+  void refreshHistory();
 });
 
 onUnmounted(() => {
@@ -100,198 +136,42 @@ function onDocumentClick(event: MouseEvent): void {
 
 async function toggle(): Promise<void> {
   open.value = !open.value;
-  if (open.value) await refreshList();
+  if (open.value) {
+    await Promise.all([refreshActive(), refreshHistory()]);
+  }
 }
 
-// ── Scripted test ─────────────────────────────────────────────────
-
-interface ScriptStep {
-  delayMs: number;
-  do: () => Promise<void>;
+function appendNotificationId(target: string, entryId: string): string {
+  const separator = target.includes("?") ? "&" : "?";
+  return `${target}${separator}notificationId=${encodeURIComponent(entryId)}`;
 }
 
-function sleep(delayMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, delayMs));
-}
-
-async function publish(args: {
-  pluginPkg: string;
-  severity: "info" | "nudge" | "urgent";
-  lifecycle: "fyi" | "action";
-  title: string;
-  body?: string;
-}): Promise<string | null> {
-  const result = await apiPost<{ id: string }>(API_ROUTES.notifier.dispatch, { action: "publish", ...args });
-  if (result.ok) return result.data.id;
-  status.value = `publish failed: ${result.error}`;
-  return null;
-}
-
-async function clear(entryId: string): Promise<void> {
+async function clearById(entryId: string): Promise<void> {
   const result = await apiPost<{ ok: true }>(API_ROUTES.notifier.dispatch, { action: "clear", id: entryId });
   if (!result.ok) status.value = `clear failed: ${result.error}`;
 }
 
-async function cancel(entryId: string): Promise<void> {
+async function cancelById(entryId: string): Promise<void> {
   const result = await apiPost<{ ok: true }>(API_ROUTES.notifier.dispatch, { action: "cancel", id: entryId });
   if (!result.ok) status.value = `cancel failed: ${result.error}`;
 }
 
-async function cleanupLeftoverDebugEntries(): Promise<void> {
-  const result = await apiPost<{ entries: NotifierEntry[] }>(API_ROUTES.notifier.dispatch, { action: "list" });
-  if (!result.ok) return;
-  const stale = result.data.entries.filter((entry) => entry.pluginPkg.startsWith("debug__"));
-  // Sequential rather than parallel: parallel `clear` calls would
-  // race through the engine's drain queue but offer no real speedup
-  // here, and sequential keeps the visible state changes orderly.
-  for (const entry of stale) await clear(entry.id);
+function toggleCheck(entryId: string): void {
+  const next = new Set(checkedFyi.value);
+  if (next.has(entryId)) next.delete(entryId);
+  else next.add(entryId);
+  checkedFyi.value = next;
 }
 
-async function runScriptedTest(): Promise<void> {
-  if (running.value) return;
-  running.value = true;
-  status.value = "cleaning up leftover entries…";
-  await cleanupLeftoverDebugEntries();
-
-  const startedAt = performance.now();
-  status.value = "running…";
-
-  // Capture ids of the entries we publish so we can clear/cancel
-  // them later in the script. Local state — the engine assigns
-  // the canonical id and returns it from `publish`.
-  const ids: Record<string, string | null> = { a: null, b: null, c: null, d: null, e: null, f: null, g: null, h: null };
-
-  const steps: ScriptStep[] = [
-    {
-      delayMs: 0,
-      do: async () => {
-        ids.a = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Backup completed" });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.b = await publish({
-          pluginPkg: "debug__news",
-          severity: "nudge",
-          lifecycle: "action",
-          title: "News digest ready",
-          body: "12 new items since yesterday",
-        });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.c = await publish({ pluginPkg: "debug__encore", severity: "urgent", lifecycle: "action", title: "Pay property tax", body: "Due 2026-12-15" });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.d = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Build #42 finished" });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.e = await publish({ pluginPkg: "debug__news", severity: "info", lifecycle: "action", title: "Weekly summary ready" });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.f = await publish({
-          pluginPkg: "debug__journal",
-          severity: "nudge",
-          lifecycle: "action",
-          title: "Yesterday's journal needs review",
-          body: "3 sections drafted, awaiting your sign-off",
-        });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.g = await publish({
-          pluginPkg: "debug__taxes",
-          severity: "urgent",
-          lifecycle: "action",
-          title: "W-2 received, file by Apr 15",
-          body: "Auto-imported from email",
-        });
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        ids.h = await publish({ pluginPkg: "debug__system", severity: "info", lifecycle: "fyi", title: "Disk usage 78%" });
-      },
-    },
-    {
-      // Peak: 8 entries visible across 5 plugin namespaces. The
-      // cleanup phase below interleaves clear and cancel to show
-      // both terminal verbs in flight.
-      delayMs: 600,
-      do: async () => {
-        if (ids.b) await clear(ids.b);
-      },
-    },
-    {
-      delayMs: 400,
-      do: async () => {
-        if (ids.a) await clear(ids.a);
-      },
-    },
-    {
-      delayMs: 500,
-      do: async () => {
-        if (ids.f) await cancel(ids.f);
-      },
-    },
-    {
-      delayMs: 500,
-      do: async () => {
-        if (ids.h) await clear(ids.h);
-      },
-    },
-    {
-      delayMs: 500,
-      do: async () => {
-        if (ids.e) await clear(ids.e);
-      },
-    },
-    {
-      delayMs: 500,
-      do: async () => {
-        if (ids.c) await cancel(ids.c);
-      },
-    },
-    {
-      delayMs: 600,
-      do: async () => {
-        if (ids.d) await clear(ids.d);
-      },
-    },
-    {
-      delayMs: 600,
-      do: async () => {
-        if (ids.g) await clear(ids.g);
-      },
-    },
-  ];
-
-  for (const step of steps) {
-    if (step.delayMs > 0) await sleep(step.delayMs);
-    await step.do();
-  }
-
-  const elapsed = Math.round(performance.now() - startedAt);
-  status.value = `✓ done in ${elapsed}ms`;
-  running.value = false;
+async function ackSelected(): Promise<void> {
+  const ids = visibleEntries.value.filter((entry) => entry.lifecycle === "fyi" && checkedFyi.value.has(entry.id)).map((entry) => entry.id);
+  for (const entryId of ids) await clearById(entryId);
 }
 
-// ── Display helpers (literal strings, dev-only) ───────────────────
+async function navigateAndClose(target: string, entryId: string): Promise<void> {
+  open.value = false;
+  await router.push(appendNotificationId(target, entryId));
+}
 
 function severityDot(severity: NotifierEntry["severity"]): string {
   switch (severity) {
@@ -335,37 +215,91 @@ function severityDot(severity: NotifierEntry["severity"]): string {
     <div
       v-if="open"
       data-testid="notifier-debug-popup"
-      class="absolute left-0 top-full mt-1 w-96 max-h-[70vh] bg-white border border-gray-200 rounded-lg shadow-lg z-50 flex flex-col text-xs"
+      class="absolute left-0 top-full mt-1 w-96 max-h-[80vh] bg-white border border-gray-200 rounded-lg shadow-lg z-50 flex flex-col text-xs overflow-hidden"
     >
       <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
-        <span class="font-semibold text-gray-700">Notifier debug</span>
-        <span class="text-gray-400">— {{ visibleEntries.length }} active</span>
-        <span class="ml-auto text-gray-500">{{ status }}</span>
-      </div>
-      <div class="px-3 py-2 border-b border-gray-100">
-        <button
-          type="button"
-          data-testid="notifier-debug-run"
-          class="w-full px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
-          :disabled="running"
-          @click="runScriptedTest"
-        >
-          {{ running ? "Running…" : "Run scripted test" }}
-        </button>
+        <span class="font-semibold text-gray-700">Notifications</span>
+        <span class="ml-auto text-gray-400">{{ status }}</span>
       </div>
       <div class="flex-1 overflow-y-auto">
-        <p v-if="visibleEntries.length === 0" class="px-3 py-4 text-gray-400 italic">No active entries</p>
+        <div class="px-3 py-1.5 text-gray-500 font-medium border-b border-gray-100 bg-gray-50">Active ({{ visibleEntries.length }})</div>
+        <p v-if="visibleEntries.length === 0" class="px-3 py-3 text-gray-400 italic">No active notifications</p>
         <ul v-else class="divide-y divide-gray-100">
-          <li v-for="entry in visibleEntries" :key="entry.id" data-testid="notifier-debug-entry" class="px-3 py-2">
+          <li v-for="entry in visibleEntries" :key="entry.id" data-testid="notifier-debug-active-entry" class="px-3 py-2">
             <div class="flex items-start gap-2">
+              <input
+                v-if="entry.lifecycle === 'fyi'"
+                type="checkbox"
+                :checked="checkedFyi.has(entry.id)"
+                class="mt-0.5 shrink-0 cursor-pointer"
+                data-testid="notifier-debug-fyi-check"
+                @click.stop="toggleCheck(entry.id)"
+              />
               <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0', severityDot(entry.severity)]" :title="entry.severity"></span>
-              <div class="flex-1 min-w-0">
+              <div
+                :class="[
+                  'flex-1 min-w-0',
+                  entry.lifecycle === 'action' && entry.navigateTarget ? 'cursor-pointer hover:underline' : entry.lifecycle === 'fyi' ? 'cursor-pointer' : '',
+                ]"
+                @click="
+                  () => {
+                    if (entry.lifecycle === 'action' && entry.navigateTarget) navigateAndClose(entry.navigateTarget, entry.id);
+                    else if (entry.lifecycle === 'fyi') toggleCheck(entry.id);
+                  }
+                "
+              >
                 <div class="flex items-baseline gap-2">
                   <span class="font-medium text-gray-800 truncate">{{ entry.title }}</span>
                   <span v-if="entry.lifecycle" class="text-[10px] uppercase tracking-wide text-gray-400">{{ entry.lifecycle }}</span>
                 </div>
                 <div v-if="entry.body" class="text-gray-600 mt-0.5 truncate">{{ entry.body }}</div>
                 <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ entry.pluginPkg }} · {{ entry.id.slice(0, 8) }}</div>
+              </div>
+              <button
+                v-if="entry.lifecycle === 'action'"
+                type="button"
+                class="text-gray-400 hover:text-red-500 shrink-0"
+                title="Cancel"
+                aria-label="Cancel"
+                data-testid="notifier-debug-action-cancel"
+                @click.stop="cancelById(entry.id)"
+              >
+                <span class="material-icons text-sm">close</span>
+              </button>
+            </div>
+          </li>
+        </ul>
+        <div v-if="checkedFyiCount > 0" class="px-3 py-2 border-y border-gray-100 bg-white sticky bottom-0">
+          <button
+            type="button"
+            data-testid="notifier-debug-ack-bulk"
+            class="w-full px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-700 text-white"
+            @click="ackSelected"
+          >
+            Acknowledge selected ({{ checkedFyiCount }})
+          </button>
+        </div>
+        <div class="px-3 py-1.5 text-gray-500 font-medium border-y border-gray-100 bg-gray-50">History ({{ visibleHistory.length }})</div>
+        <p v-if="visibleHistory.length === 0" class="px-3 py-3 text-gray-400 italic">No recent activity</p>
+        <ul v-else class="divide-y divide-gray-100">
+          <li v-for="entry in visibleHistory" :key="`${entry.id}-${entry.terminalAt}`" data-testid="notifier-debug-history-entry" class="px-3 py-2">
+            <div class="flex items-start gap-2">
+              <span :class="['mt-0.5 shrink-0 font-bold', entry.terminalType === 'cleared' ? 'text-green-600' : 'text-gray-400']">
+                {{ entry.terminalType === "cleared" ? "✓" : "✗" }}
+              </span>
+              <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0 opacity-60', severityDot(entry.severity)]"></span>
+              <div
+                :class="['flex-1 min-w-0', entry.navigateTarget ? 'cursor-pointer hover:underline' : '']"
+                @click="
+                  () => {
+                    if (entry.navigateTarget) navigateAndClose(entry.navigateTarget, entry.id);
+                  }
+                "
+              >
+                <div class="flex items-baseline gap-2">
+                  <span class="text-gray-700 truncate">{{ entry.title }}</span>
+                </div>
+                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ entry.pluginPkg }} · {{ entry.terminalType }}</div>
               </div>
             </div>
           </li>

--- a/src/components/NotifierDebugPopup.vue
+++ b/src/components/NotifierDebugPopup.vue
@@ -53,8 +53,10 @@ const open = ref(false);
 const rootRef = ref<HTMLElement | null>(null);
 const entries = ref<NotifierEntry[]>([]);
 const history = ref<NotifierHistoryEntry[]>([]);
-const checkedFyi = ref<Set<string>>(new Set());
-const status = ref<string>("idle");
+// Surfaces API failure messages in the popup header. Empty when
+// everything is fine — the span is hidden so an idle popup shows
+// just the section labels.
+const status = ref<string>("");
 
 const devMode = import.meta.env.VITE_DEV_MODE === "1";
 
@@ -62,6 +64,13 @@ const visibleEntries = computed(() => [...entries.value].sort((left, right) => l
 const visibleHistory = computed(() => history.value);
 
 const badgeText = computed(() => (entries.value.length > 99 ? "99+" : String(entries.value.length)));
+
+const fyiCount = computed(() => visibleEntries.value.filter((entry) => entry.lifecycle === "fyi").length);
+
+// True while the "Clear FYIs" button is hovered. Forces every fyi
+// row's hover-check icon to render — "this is what's about to get
+// swept" — so the bulk action's effect is legible before clicking.
+const hoveringClearFyis = ref(false);
 
 // Worst-severity-wins: any urgent → red, else any nudge → amber,
 // else gray. Mirrors the bell-badge color encoding called out in
@@ -71,8 +80,6 @@ const badgeColor = computed(() => {
   if (entries.value.some((entry) => entry.severity === "nudge")) return "bg-amber-500";
   return "bg-gray-400";
 });
-
-const checkedFyiCount = computed(() => visibleEntries.value.filter((entry) => entry.lifecycle === "fyi" && checkedFyi.value.has(entry.id)).length);
 
 async function refreshActive(): Promise<void> {
   const result = await apiPost<{ entries: NotifierEntry[] }>(API_ROUTES.notifier.dispatch, { action: "list" });
@@ -98,7 +105,6 @@ function applyEvent(event: NotifierEvent): void {
     case "cancelled": {
       const removed = entries.value.find((entry) => entry.id === event.id);
       entries.value = entries.value.filter((entry) => entry.id !== event.id);
-      checkedFyi.value.delete(event.id);
       if (removed) {
         const historyEntry: NotifierHistoryEntry = {
           ...removed,
@@ -156,21 +162,39 @@ async function cancelById(entryId: string): Promise<void> {
   if (!result.ok) status.value = `cancel failed: ${result.error}`;
 }
 
-function toggleCheck(entryId: string): void {
-  const next = new Set(checkedFyi.value);
-  if (next.has(entryId)) next.delete(entryId);
-  else next.add(entryId);
-  checkedFyi.value = next;
-}
-
-async function ackSelected(): Promise<void> {
-  const ids = visibleEntries.value.filter((entry) => entry.lifecycle === "fyi" && checkedFyi.value.has(entry.id)).map((entry) => entry.id);
-  for (const entryId of ids) await clearById(entryId);
-}
-
 async function navigateAndClose(target: string, entryId: string): Promise<void> {
   open.value = false;
   await router.push(appendNotificationId(target, entryId));
+}
+
+// Body click on an Active row. Defined as a method so Vue actually
+// invokes it on click — `@click="(entry) => { ... }"` would be a
+// function-literal expression that Vue evaluates and discards.
+// Stop propagation so the outer <li>'s fyi-clear handler doesn't
+// double-fire when a fyi click already lands here.
+function onActiveRowBodyClick(entry: NotifierEntry, event: MouseEvent): void {
+  event.stopPropagation();
+  if (entry.lifecycle === "action" && entry.navigateTarget) {
+    void navigateAndClose(entry.navigateTarget, entry.id);
+  } else if (entry.lifecycle === "fyi") {
+    void clearById(entry.id);
+  }
+}
+
+// Outer-row click — fires when the click lands on a part of the
+// row that isn't the body div or the trailing × button (severity
+// dot, hover-check icon, padding). For fyi: clear. For action: no
+// row-level click target (must use body or `×`).
+function onActiveRowClick(entry: NotifierEntry): void {
+  if (entry.lifecycle === "fyi") void clearById(entry.id);
+}
+
+// Bulk-clear every fyi currently in Active. Action entries stay —
+// they need plugin-driven clear / explicit cancel and shouldn't get
+// swept by a "clear all" gesture aimed at fyi noise.
+async function clearAllFyi(): Promise<void> {
+  const ids = visibleEntries.value.filter((entry) => entry.lifecycle === "fyi").map((entry) => entry.id);
+  for (const entryId of ids) await clearById(entryId);
 }
 
 function severityDot(severity: NotifierEntry["severity"]): string {
@@ -183,6 +207,14 @@ function severityDot(severity: NotifierEntry["severity"]): string {
     default:
       return "bg-gray-300";
   }
+}
+
+// Strip the leading `@scope/` from a scoped npm package name for
+// display. The `@mulmoclaude/` prefix on every dev plugin name is
+// noise in the popup row — what the user wants to see is the
+// suffix (`debug-plugin`). Unscoped names pass through unchanged.
+function shortPkg(pluginPkg: string): string {
+  return pluginPkg.startsWith("@") ? pluginPkg.split("/").slice(1).join("/") || pluginPkg : pluginPkg;
 }
 </script>
 
@@ -219,41 +251,47 @@ function severityDot(severity: NotifierEntry["severity"]): string {
     >
       <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
         <span class="font-semibold text-gray-700">Notifications</span>
-        <span class="ml-auto text-gray-400">{{ status }}</span>
+        <span v-if="status" class="ml-auto text-red-500">{{ status }}</span>
       </div>
       <div class="flex-1 overflow-y-auto">
-        <div class="px-3 py-1.5 text-gray-500 font-medium border-b border-gray-100 bg-gray-50">Active ({{ visibleEntries.length }})</div>
+        <div class="flex items-center px-3 py-1.5 border-b border-gray-100 bg-gray-50">
+          <span class="text-gray-500 font-medium">Active ({{ visibleEntries.length }})</span>
+          <button
+            v-if="fyiCount > 0"
+            type="button"
+            class="ml-auto text-gray-500 font-medium hover:text-green-600"
+            data-testid="notifier-debug-clear-fyis"
+            @click="clearAllFyi"
+            @mouseenter="hoveringClearFyis = true"
+            @mouseleave="hoveringClearFyis = false"
+          >
+            Clear
+          </button>
+        </div>
         <p v-if="visibleEntries.length === 0" class="px-3 py-3 text-gray-400 italic">No active notifications</p>
         <ul v-else class="divide-y divide-gray-100">
-          <li v-for="entry in visibleEntries" :key="entry.id" data-testid="notifier-debug-active-entry" class="px-3 py-2">
+          <li
+            v-for="entry in visibleEntries"
+            :key="entry.id"
+            data-testid="notifier-debug-active-entry"
+            :class="['px-3 py-2 group', entry.lifecycle === 'fyi' ? 'cursor-pointer hover:bg-gray-50' : '']"
+            @click="onActiveRowClick(entry)"
+          >
             <div class="flex items-start gap-2">
-              <input
-                v-if="entry.lifecycle === 'fyi'"
-                type="checkbox"
-                :checked="checkedFyi.has(entry.id)"
-                class="mt-0.5 shrink-0 cursor-pointer"
-                data-testid="notifier-debug-fyi-check"
-                @click.stop="toggleCheck(entry.id)"
-              />
-              <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0', severityDot(entry.severity)]" :title="entry.severity"></span>
+              <span :class="['mt-0.5 inline-block w-2.5 h-2.5 rounded-full shrink-0', severityDot(entry.severity)]" :title="entry.severity"></span>
               <div
                 :class="[
                   'flex-1 min-w-0',
                   entry.lifecycle === 'action' && entry.navigateTarget ? 'cursor-pointer hover:underline' : entry.lifecycle === 'fyi' ? 'cursor-pointer' : '',
                 ]"
-                @click="
-                  () => {
-                    if (entry.lifecycle === 'action' && entry.navigateTarget) navigateAndClose(entry.navigateTarget, entry.id);
-                    else if (entry.lifecycle === 'fyi') toggleCheck(entry.id);
-                  }
-                "
+                :title="entry.body || undefined"
+                @click="onActiveRowBodyClick(entry, $event)"
               >
                 <div class="flex items-baseline gap-2">
                   <span class="font-medium text-gray-800 truncate">{{ entry.title }}</span>
                   <span v-if="entry.lifecycle" class="text-[10px] uppercase tracking-wide text-gray-400">{{ entry.lifecycle }}</span>
                 </div>
-                <div v-if="entry.body" class="text-gray-600 mt-0.5 truncate">{{ entry.body }}</div>
-                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ entry.pluginPkg }} · {{ entry.id.slice(0, 8) }}</div>
+                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ shortPkg(entry.pluginPkg) }} · {{ entry.id.slice(0, 8) }}</div>
               </div>
               <button
                 v-if="entry.lifecycle === 'action'"
@@ -266,28 +304,26 @@ function severityDot(severity: NotifierEntry["severity"]): string {
               >
                 <span class="material-icons text-sm">close</span>
               </button>
+              <span
+                v-else-if="entry.lifecycle === 'fyi'"
+                :class="['text-green-500 shrink-0 transition-opacity', hoveringClearFyis ? 'opacity-100' : 'opacity-0 group-hover:opacity-100']"
+                aria-hidden="true"
+                data-testid="notifier-debug-fyi-hover-check"
+              >
+                <span class="material-icons text-sm">check</span>
+              </span>
             </div>
           </li>
         </ul>
-        <div v-if="checkedFyiCount > 0" class="px-3 py-2 border-y border-gray-100 bg-white sticky bottom-0">
-          <button
-            type="button"
-            data-testid="notifier-debug-ack-bulk"
-            class="w-full px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-700 text-white"
-            @click="ackSelected"
-          >
-            Acknowledge selected ({{ checkedFyiCount }})
-          </button>
-        </div>
         <div class="px-3 py-1.5 text-gray-500 font-medium border-y border-gray-100 bg-gray-50">History ({{ visibleHistory.length }})</div>
         <p v-if="visibleHistory.length === 0" class="px-3 py-3 text-gray-400 italic">No recent activity</p>
         <ul v-else class="divide-y divide-gray-100">
           <li v-for="entry in visibleHistory" :key="`${entry.id}-${entry.terminalAt}`" data-testid="notifier-debug-history-entry" class="px-3 py-2">
             <div class="flex items-start gap-2">
-              <span :class="['mt-0.5 shrink-0 font-bold', entry.terminalType === 'cleared' ? 'text-green-600' : 'text-gray-400']">
+              <span class="mt-0.5 shrink-0 font-bold text-gray-400">
                 {{ entry.terminalType === "cleared" ? "✓" : "✗" }}
               </span>
-              <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0 opacity-60', severityDot(entry.severity)]"></span>
+              <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0 opacity-30', severityDot(entry.severity)]"></span>
               <div
                 :class="['flex-1 min-w-0', entry.navigateTarget ? 'cursor-pointer hover:underline' : '']"
                 @click="
@@ -299,7 +335,7 @@ function severityDot(severity: NotifierEntry["severity"]): string {
                 <div class="flex items-baseline gap-2">
                   <span class="text-gray-700 truncate">{{ entry.title }}</span>
                 </div>
-                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ entry.pluginPkg }} · {{ entry.terminalType }}</div>
+                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">{{ shortPkg(entry.pluginPkg) }} · {{ entry.terminalType }}</div>
               </div>
             </div>
           </li>

--- a/src/config/workspacePaths.ts
+++ b/src/config/workspacePaths.ts
@@ -43,4 +43,7 @@ export const WORKSPACE_FILES = {
    *  every mutation, loaded fresh on every read. No in-memory cache;
    *  the file is the only source of truth. */
   notifierActive: "data/notifier/active.json",
+  /** Terminated notifier entries (cleared / cancelled), newest-first,
+   *  FIFO-capped. Source for the bell popup's History section. */
+  notifierHistory: "data/notifier/history.json",
 } as const;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -78,4 +78,16 @@ const router = createRouter({
   routes,
 });
 
+// Bridge SPA navigation to a DOM CustomEvent so runtime-loaded plugins
+// (which can't import vue-router without extra plumbing) can react to
+// route changes without polling. Fires on every commit, including
+// query-only changes that don't remount the matched component.
+//
+// Subscriber: `@mulmoclaude/debug-plugin` View, which uses it to
+// re-evaluate `?mode=` and `?notificationId=` params after the host
+// notifier popup pushes a new URL.
+router.afterEach((toRoute) => {
+  window.dispatchEvent(new CustomEvent("mulmoclaude:routechange", { detail: { fullPath: toRoute.fullPath } }));
+});
+
 export default router;

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -77,10 +77,73 @@ describe("publish", () => {
       severity: "urgent",
       lifecycle: "action",
       title: "File taxes",
+      navigateTarget: "/encore/taxes",
       pluginData,
     });
     const entry = await get(id);
     assert.deepEqual(entry?.pluginData, pluginData);
+  });
+
+  it("rejects action lifecycle without a navigateTarget", async () => {
+    await assert.rejects(
+      publish({
+        pluginPkg: "x",
+        severity: "nudge",
+        lifecycle: "action",
+        title: "no link",
+      }),
+      /navigateTarget/,
+    );
+  });
+
+  it("rejects action lifecycle with an empty-string navigateTarget", async () => {
+    await assert.rejects(
+      publish({
+        pluginPkg: "x",
+        severity: "nudge",
+        lifecycle: "action",
+        title: "empty link",
+        navigateTarget: "",
+      }),
+      /navigateTarget/,
+    );
+  });
+
+  it("rejects action lifecycle with info severity (incoherent combination)", async () => {
+    await assert.rejects(
+      publish({
+        pluginPkg: "x",
+        severity: "info",
+        lifecycle: "action",
+        title: "low-priority obligation",
+        navigateTarget: "/somewhere",
+      }),
+      /info severity/,
+    );
+  });
+
+  it("accepts action lifecycle with nudge or urgent severity (paired with navigateTarget)", async () => {
+    const { id: nudgeId } = await publish({
+      pluginPkg: "x",
+      severity: "nudge",
+      lifecycle: "action",
+      title: "nudge action",
+      navigateTarget: "/x",
+    });
+    const { id: urgentId } = await publish({
+      pluginPkg: "x",
+      severity: "urgent",
+      lifecycle: "action",
+      title: "urgent action",
+      navigateTarget: "/y",
+    });
+    assert.ok(await get(nudgeId));
+    assert.ok(await get(urgentId));
+  });
+
+  it("accepts fyi lifecycle without a navigateTarget (no link required)", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", lifecycle: "fyi", title: "no link needed" });
+    assert.ok(await get(id));
   });
 
   it("persists across engine 'restart' (re-reading from disk)", async () => {

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -3,17 +3,19 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
-import { publish, clear, cancel, get, listFor, listAll, initNotifier, _setActiveFilePathForTesting } from "../../../server/notifier/engine.js";
+import { publish, clear, cancel, get, listFor, listAll, listHistory, initNotifier, _setFilePathsForTesting } from "../../../server/notifier/engine.js";
 import type { NotifierEvent } from "../../../server/notifier/types.js";
 
 let tmpDir = "";
 let activeFile = "";
+let historyFile = "";
 let emittedEvents: NotifierEvent[] = [];
 
 beforeEach(() => {
   tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-notifier-test-"));
   activeFile = path.join(tmpDir, "active.json");
-  _setActiveFilePathForTesting(activeFile);
+  historyFile = path.join(tmpDir, "history.json");
+  _setFilePathsForTesting({ active: activeFile, history: historyFile });
   emittedEvents = [];
   initNotifier({
     publish: (_channel, payload) => {
@@ -79,7 +81,7 @@ describe("publish", () => {
     // Simulating a restart: drop the engine's path binding, then
     // re-set it. The engine has no in-memory cache, so a fresh
     // listAll() must read from disk and find the entry.
-    _setActiveFilePathForTesting(activeFile);
+    _setFilePathsForTesting({ active: activeFile, history: historyFile });
     const entries = await listAll();
     const found = entries.find((entry) => entry.id === id);
     assert.ok(found, "entry should survive a path rebind");
@@ -240,5 +242,124 @@ describe("on-disk format", () => {
     assert.equal(existsSync(activeFile), false, "precondition: no file");
     await publish({ pluginPkg: "x", severity: "info", title: "y" });
     assert.equal(existsSync(activeFile), true);
+  });
+});
+
+describe("navigateTarget", () => {
+  it("round-trips through publish / get / listAll", async () => {
+    const { id } = await publish({
+      pluginPkg: "debug__encore",
+      severity: "urgent",
+      lifecycle: "action",
+      title: "Pay property tax",
+      navigateTarget: "/encore/property-tax",
+    });
+    const fetched = await get(id);
+    assert.equal(fetched?.navigateTarget, "/encore/property-tax");
+    const all = await listAll();
+    const found = all.find((entry) => entry.id === id);
+    assert.equal(found?.navigateTarget, "/encore/property-tax");
+  });
+
+  it("is undefined when not provided", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "no target" });
+    const entry = await get(id);
+    assert.equal(entry?.navigateTarget, undefined);
+  });
+});
+
+describe("history", () => {
+  it("starts empty", async () => {
+    assert.deepEqual(await listHistory(), []);
+  });
+
+  it("captures cleared entries with terminal type and timestamp", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "to clear" });
+    await clear(id);
+    const history = await listHistory();
+    assert.equal(history.length, 1);
+    assert.equal(history[0].id, id);
+    assert.equal(history[0].terminalType, "cleared");
+    assert.match(history[0].terminalAt, /\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("captures cancelled entries with `cancelled` terminal type", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "to cancel" });
+    await cancel(id);
+    const [head] = await listHistory();
+    assert.equal(head.terminalType, "cancelled");
+  });
+
+  it("preserves the original entry fields (title, severity, navigateTarget, pluginData)", async () => {
+    const { id } = await publish({
+      pluginPkg: "x",
+      severity: "urgent",
+      lifecycle: "action",
+      title: "preserve me",
+      body: "with body",
+      navigateTarget: "/somewhere",
+      pluginData: { extra: "stuff" },
+    });
+    await clear(id);
+    const [head] = await listHistory();
+    assert.equal(head.title, "preserve me");
+    assert.equal(head.severity, "urgent");
+    assert.equal(head.lifecycle, "action");
+    assert.equal(head.body, "with body");
+    assert.equal(head.navigateTarget, "/somewhere");
+    assert.deepEqual(head.pluginData, { extra: "stuff" });
+  });
+
+  it("orders newest first", async () => {
+    const { id: idA } = await publish({ pluginPkg: "x", severity: "info", title: "a" });
+    const { id: idB } = await publish({ pluginPkg: "x", severity: "info", title: "b" });
+    const { id: idC } = await publish({ pluginPkg: "x", severity: "info", title: "c" });
+    await clear(idA);
+    await clear(idB);
+    await clear(idC);
+    const history = await listHistory();
+    assert.deepEqual(
+      history.map((entry) => entry.title),
+      ["c", "b", "a"],
+    );
+  });
+
+  it("caps at 50 entries (FIFO eviction)", async () => {
+    const total = 55;
+    const ids: string[] = [];
+    for (let index = 0; index < total; index += 1) {
+      const result = await publish({ pluginPkg: "x", severity: "info", title: `t-${index}` });
+      ids.push(result.id);
+    }
+    for (const entryId of ids) await clear(entryId);
+    const history = await listHistory();
+    assert.equal(history.length, 50);
+    // Newest at index 0; oldest 5 (titles t-0..t-4) should be evicted.
+    assert.equal(history[0].title, "t-54");
+    assert.equal(history[49].title, "t-5");
+  });
+
+  it("survives a path rebind (persists to disk)", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "persist me" });
+    await clear(id);
+    _setFilePathsForTesting({ active: activeFile, history: historyFile });
+    const history = await listHistory();
+    assert.equal(history.length, 1);
+    assert.equal(history[0].id, id);
+  });
+
+  it("does not record no-op clears (unknown id)", async () => {
+    await clear("00000000-0000-0000-0000-000000000000");
+    assert.deepEqual(await listHistory(), []);
+  });
+
+  it("writes the history file at the configured path with an `entries` array", async () => {
+    const { id } = await publish({ pluginPkg: "x", severity: "info", title: "y" });
+    await clear(id);
+    const raw = readFileSync(historyFile, "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.ok(parsed && typeof parsed === "object");
+    assert.ok(Array.isArray(parsed.entries));
+    assert.equal(parsed.entries.length, 1);
   });
 });

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -3,7 +3,18 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
-import { publish, clear, cancel, get, listFor, listAll, listHistory, initNotifier, _setFilePathsForTesting } from "../../../server/notifier/engine.js";
+import {
+  publish,
+  clear,
+  cancel,
+  clearForPlugin,
+  get,
+  listFor,
+  listAll,
+  listHistory,
+  initNotifier,
+  _setFilePathsForTesting,
+} from "../../../server/notifier/engine.js";
 import type { NotifierEvent } from "../../../server/notifier/types.js";
 
 let tmpDir = "";
@@ -361,5 +372,39 @@ describe("history", () => {
     assert.ok(parsed && typeof parsed === "object");
     assert.ok(Array.isArray(parsed.entries));
     assert.equal(parsed.entries.length, 1);
+  });
+});
+
+describe("clearForPlugin (per-plugin isolation)", () => {
+  it("clears an entry the caller owns", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "mine" });
+    await clearForPlugin("@scope/owner", id);
+    assert.equal(await get(id), undefined);
+    const [terminal] = await listHistory();
+    assert.equal(terminal.id, id);
+    assert.equal(terminal.terminalType, "cleared");
+  });
+
+  it("silently no-ops when the entry belongs to another plugin", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "owned" });
+    emittedEvents.length = 0;
+    await clearForPlugin("@scope/intruder", id);
+    // Entry survives, no event was emitted, history stays empty.
+    assert.ok(await get(id), "entry must remain when caller is not the owner");
+    assert.equal(emittedEvents.length, 0, "no event emitted on owner mismatch");
+    assert.deepEqual(await listHistory(), []);
+  });
+
+  it("silently no-ops on an unknown id (matches existing clear semantics)", async () => {
+    emittedEvents.length = 0;
+    await clearForPlugin("@scope/anyone", "00000000-0000-0000-0000-000000000000");
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it("does not record cross-plugin attempts in history (audit cleanliness)", async () => {
+    await publish({ pluginPkg: "@scope/a", severity: "info", title: "ours" });
+    const { id: stranger } = await publish({ pluginPkg: "@scope/b", severity: "info", title: "theirs" });
+    await clearForPlugin("@scope/a", stranger); // attempt
+    assert.deepEqual(await listHistory(), []);
   });
 });


### PR DESCRIPTION
## Summary

PR 3 of `plans/feat-encore.md`. Builds the new bell UX on the dev-mode debug surface (the bug-icon popup next to the bell, gated by `VITE_DEV_MODE=1`) and exercises the publish / clear flow from the `/debug` page. **The legacy `publishNotification()` path is left completely untouched** — old bell, old toast, old `notifications` channel keep firing as today; the new engine's UX runs in parallel on a separate surface so the layout, badge semantics, row affordances, and history flow can be validated before the migration in PR 4.

UX decisions for the eventual migration are codified in the new [`plans/feat-notifier-ux.md`](plans/feat-notifier-ux.md) (also added in this PR).

### Engine (`server/notifier/`)

- New `history.json` — single JSON file holding terminated entries newest-first, capped at 50 with FIFO eviction. Each entry = the original `NotifierEntry` plus `terminalType` (`cleared` / `cancelled`) and `terminalAt`.
- New `listHistory()` API. `clear` / `cancel` push to history *before* removing from active. History persistence is best-effort: a write failure is logged but does not unwind the active commit (active is the source of truth).
- New optional `navigateTarget` field on `NotifierEntry`. The engine doesn't read it — it's a UI hint for the popup, which appends `&notificationId=<uuid>` on click.
- Test seam: `_setActiveFilePathForTesting` → `_setFilePathsForTesting({ active, history })`.

### Plugin runtime extension (server-side)

- `runtime.notifier.publish(input)` and `.clear(id)` wired into `PluginRuntime` via a host-only extension type ([`server/notifier/runtime-api.ts`](server/notifier/runtime-api.ts)). `pluginPkg` auto-binds to the calling plugin's pkg name so plugins cannot impersonate each other (mirrors how `runtime.pubsub.publish` is hard-scoped to `plugin:<pkg>:*`).
- Plugin authors cast `runtime as MulmoclaudeRuntime` for now. Upstreaming into `gui-chat-protocol` is a follow-up once the API stabilises.

### HTTP route

- `/api/notifier` dispatch grows `action="listHistory"`. `navigateTarget` flows through publish input.

### Debug button popup (`src/components/NotifierDebugPopup.vue`)

Full rewrite. Replaces the PR 2 scripted-test panel with the new bell UX:

- Active section on top, History section below, single scroll, no tabs.
- fyi rows: leading checkbox, click body toggles. Footer "Acknowledge selected (N)" button when ≥1 fyi is checked.
- action rows: click body navigates (router.push to `navigateTarget` with `&notificationId=<uuid>` appended), trailing × cancels.
- History rows: ✓ for cleared, ✗ for cancelled. Rows with `navigateTarget` re-route on click.
- Empty states: "No active notifications" / "No recent activity".
- Badge stays as PR 2 (count + worst-severity color + `99+` cap).
- Subscribes to the `notifier` pubsub channel; primes Active and History on mount; updates locally on `published` / `cleared` / `cancelled` events.
- The "Run scripted test" button is gone — its job moves to `/debug`.

### Debug page (`packages/debug-plugin/src/View.vue` + `index.ts`)

Three modes branched on URL query:

- **Default** (`/debug`) — button panel that fires individual test scenarios (`fyi`/`action` × `info`/`nudge`/`urgent` + "fire mixed batch" + two hyperlink-test buttons).
- **`/debug?mode=auto-clear&notificationId=<uuid>`** — clears the notification on mount, renders a confirmation. Tests the read-once pattern (viewing the target IS the close).
- **`/debug?mode=manual-clear&notificationId=<uuid>`** — renders a "Done" button; clicking it clears the notification. Tests the act-on pattern (opening the page does not by itself satisfy the obligation).

The plugin's server handler (`packages/debug-plugin/src/index.ts`) gains `publish` and `clear` dispatch kinds that proxy to `runtime.notifier`.

### Route-change reactivity

- `src/router/index.ts` emits a `mulmoclaude:routechange` CustomEvent on every navigation so runtime-loaded plugins — which can't import `vue-router` without extra plumbing — can react to URL changes without polling. The debug page View listens for it (plus `popstate`) to re-evaluate `?mode=` and `?notificationId=` when the popup pushes a new URL while `/debug` is already mounted.

### Test coverage

- `test/server/notifier/test_engine.ts`: existing 18 tests + 11 new ones covering history append on clear/cancel, FIFO eviction at 50, `listHistory` ordering, history persistence round-trip, no-record on no-op clears, and `navigateTarget` round-trip. **29 tests total, all passing.**

### Out of scope (lands in PR 4)

- Legacy `publishNotification()` migration (bridge / macOS adapters, bell replacement).
- Timers / snooze / escalation.

## Test plan

- [x] `yarn lint`, `yarn typecheck`, `yarn build` clean
- [x] `yarn test` — 4198/4198 pass
- [x] 29/29 notifier engine unit tests pass
- [ ] Reviewer: with `VITE_DEV_MODE=1`, navigate to `/debug`, click each scenario button — confirm the popup's Active section shows the entry with the right severity color and lifecycle hint
- [ ] Reviewer: check several fyi rows and click "Acknowledge selected (N)" — confirm they move to History as `cleared`
- [ ] Reviewer: click an action row — confirm panel closes and the URL changes; click × on an action row — confirm the entry moves to History as `cancelled`
- [ ] Reviewer: from the popup, click the "action — clears on open" notification — confirm `/debug?mode=auto-clear&...` opens, the notification disappears from Active, and the page shows "✓ Cleared at …"
- [ ] Reviewer: from the popup, click the "action — clears on Done" notification — confirm `/debug?mode=manual-clear&...` opens, the notification stays in Active until "Done" is pressed
- [ ] Reviewer: confirm the existing bell behaviour is unchanged (legacy notification system still fires through `server/events/notifications.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification history with Active and History sections, capped history storage, and lifecycle-aware entries
  * In-app deep-link navigation from notifications and navigate-and-close flows
  * Publish/clear notification flows plus a dev-only debug UI and popup for testing scenarios
  * Runtime notifier surface exposed to plugins and a post-route-change event to support navigation-aware behavior

* **Documentation**
  * UX design and phased rollout plan for the notifier (migration and UX guidance)

* **Tests**
  * Expanded notifier test coverage including history, navigation, and persistence scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->