### PR TITLE
feat(skills): preset skills bundled with mulmoclaude (#1210 PR-A)

### DIFF
--- a/plans/feat-preset-skills-1210.md
+++ b/plans/feat-preset-skills-1210.md
@@ -155,5 +155,3 @@ Tmpdir-based fixtures, no real workspace touched. Pattern mirrors
 6. Manual smoke: `yarn dev`, confirm `~/mulmoclaude/.claude/skills/mc-example/SKILL.md`
    appears, then delete it and reboot — appears again
 7. Open PR linked to #1210 as PR-A
-EOF
-)

--- a/plans/feat-preset-skills-1210.md
+++ b/plans/feat-preset-skills-1210.md
@@ -1,0 +1,159 @@
+# Preset skills bundled with mulmoclaude (#1210)
+
+Ship Claude Code skills (markdown-driven slash commands) as part of
+the launcher, copied into the workspace on boot. Mirror the existing
+`config/helps/` distribution mechanism so the implementation is small
+and well-understood. Use `mc-` slug prefix to avoid collisions with
+user-authored skills.
+
+This plan covers **PR-A only** — the infrastructure. The first
+concrete preset (`mc-library`) lands in a separate PR per the issue's
+phasing.
+
+## Architecture recap
+
+Claude Code resolves slash commands against two hardcoded paths:
+
+1. `~/.claude/skills/<slug>/SKILL.md` — user, global
+2. `<cwd>/.claude/skills/<slug>/SKILL.md` — project (cwd = workspace
+   root, so `~/mulmoclaude/.claude/skills/`)
+
+There's no CLI flag to add a third path. So a "preset skill shipped
+with mulmoclaude" must materialise at one of those two locations.
+The `<workspaceRoot>/.claude/skills/` path is the natural fit — it's
+already where MulmoClaude allows `manageSkills` to write.
+
+## Source of truth
+
+```
+server/workspace/skills-preset/
+├── mc-<slug-1>/
+│   └── SKILL.md
+├── mc-<slug-2>/
+│   └── SKILL.md
+└── …
+```
+
+Sibling to `server/workspace/helps/`, deliberately. `prepare-dist.js`
+copies `server/` recursively, so this dir ships in the launcher
+tarball without further wiring.
+
+For PR-A, ship one stub: `mc-example/SKILL.md` containing a one-paragraph
+"this is a preset skill bundled with mulmoclaude" body. Real presets
+land in PR-B onwards.
+
+## Boot-time copy
+
+Extend `server/workspace/workspace.ts`'s `initWorkspace()`. Today it
+copies `server/workspace/helps/*` → `<workspaceRoot>/config/helps/`
+on every start. Add a parallel block:
+
+1. Discover entries under `<launcherInstall>/server/workspace/skills-preset/`
+2. For each `<slug>/`:
+   - Verify slug starts with `mc-` (boot-time guard — see below)
+   - Verify a `SKILL.md` exists
+   - `mkdirSync(<workspaceRoot>/.claude/skills/<slug>, { recursive: true })`
+   - `copyFileSync` SKILL.md across (unconditional overwrite — same
+     contract as helps)
+3. Cleanup pass: list `<workspaceRoot>/.claude/skills/` for entries
+   starting with `mc-` whose slug is NOT in the current preset list.
+   Delete those (`rm -rf` on the dir). Removes presets that were
+   retired between releases.
+
+Cleanup is bounded to `mc-*` slugs by design — user-authored entries
+without the prefix are never touched.
+
+## Slug guard
+
+A boot-time check rejects any `skills-preset/<slug>/` whose slug
+doesn't start with `mc-`. The first iteration uses **error + log,
+not exit** — log a clear warning and skip the entry, so a typo
+doesn't brick mulmoclaude on boot. (If we get bitten by silent skips
+we can promote to hard error later.)
+
+Implementation lives next to the boot hook, not deeper in the skill
+discovery layer, so it fires before any user gets to invoke a
+mis-prefixed preset.
+
+## Code touch surface
+
+- `server/workspace/workspace.ts`
+  - new constant: `SKILLS_PRESET_DIR = path.join(__dirname, "skills-preset")`
+  - new constant: `SKILLS_PROJECT_DIR_REL = ".claude/skills"`
+  - new function: `syncPresetSkills(workspaceRoot, presetSrc)` →
+    pure-ish, returns `{ copied: string[], removed: string[], skipped: string[] }`
+    for tests; helper handles validation + copy + cleanup
+  - call site: inside `initWorkspace()`, after the existing helps copy
+- `server/workspace/skills-preset/mc-example/SKILL.md` — stub preset
+  so the directory exists and the copy path is exercised
+
+No changes needed to `discovery.ts` — preset slugs land in the
+project-scope path the existing logic already scans.
+
+## Tests
+
+`test/workspace/test_skills_preset.ts` (new):
+
+- **happy path**: with one preset `mc-foo`, after `syncPresetSkills`,
+  `<workspace>/.claude/skills/mc-foo/SKILL.md` exists with the
+  preset's content
+- **overwrite**: an existing `<workspace>/.claude/skills/mc-foo/SKILL.md`
+  with stale content gets refreshed
+- **user-skill safety**: an existing `<workspace>/.claude/skills/library/`
+  (no `mc-` prefix) is untouched
+- **slug guard**: a preset entry `bad-slug` (no prefix) is logged + skipped, NOT copied
+- **cleanup**: a `<workspace>/.claude/skills/mc-stale/` whose slug is
+  no longer in `skills-preset/` gets removed
+- **cleanup respects user**: a `<workspace>/.claude/skills/library/`
+  (no `mc-` prefix) is NOT removed even though it's not in
+  `skills-preset/`
+- **idempotent**: running `syncPresetSkills` twice in a row yields
+  the same on-disk state, no errors
+
+Tmpdir-based fixtures, no real workspace touched. Pattern mirrors
+`test/utils/files/test_atomic.ts` and the helps tests.
+
+## Known trade-offs
+
+1. **Unconditional overwrite of `mc-*` slugs**: a user who edits
+   `<workspace>/.claude/skills/mc-library/SKILL.md` loses their edits
+   on next boot. This is the intended contract — preset skills are
+   "factory defaults". Document it in the SKILL.md template comment.
+   Customisation path: copy the file out, drop the `mc-` prefix, edit
+   the copy.
+2. **Cleanup deletes `mc-*` slugs not in source**: a user who
+   manually creates an `mc-foo/SKILL.md` (mimicking the preset
+   convention) will see it disappear on boot. Same contract — `mc-*`
+   is the launcher's namespace. Document loudly.
+3. **No backwards compatibility for retired presets**: we don't
+   stage a deprecation period. If the launcher decides `mc-foo` is
+   gone, the workspace entry vanishes too. Acceptable because:
+   - Skills are shipped, not user-state — losing an old preset is
+     like losing a default config option
+   - Anyone who modified the preset under its `mc-` name should not
+     have done so (see trade-off 1)
+
+## Out of scope (future PRs)
+
+- The first real preset (`mc-library`) — separate PR per #1210
+  phasing (PR-B)
+- UI badge for "preset" skills in the manageSkills view — the
+  source detection is already trivial (slug starts with `mc-`),
+  but the UI work is its own thing
+- `discoverSkills()` extension to surface `"preset"` as a distinct
+  source — also out of scope; current 2-tier (user, project) stays
+  fine since presets land in the project path
+
+## Steps
+
+1. Branch `feat/preset-skills-1210` (already on it)
+2. Commit this plan
+3. Implement: `syncPresetSkills` helper + boot wiring + stub
+   `mc-example/SKILL.md`
+4. Tests
+5. `yarn lint` / `yarn typecheck` / `yarn test` clean
+6. Manual smoke: `yarn dev`, confirm `~/mulmoclaude/.claude/skills/mc-example/SKILL.md`
+   appears, then delete it and reboot — appears again
+7. Open PR linked to #1210 as PR-A
+EOF
+)

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -131,6 +131,13 @@ const HOST_WORKSPACE_DIRS = {
   configs: "config",
   roles: "config/roles",
   helps: "config/helps",
+  // Project-scope Claude Code skills root — both user-authored and
+  // launcher-managed presets live here. Path is hardcoded by Claude
+  // Code's slash-command resolver (it scans `<cwd>/.claude/skills/`
+  // alongside `~/.claude/skills/`); we centralise the literal here
+  // so server code references it through `WORKSPACE_PATHS.claudeSkills`
+  // instead of inlining the string.
+  claudeSkills: ".claude/skills",
   // Nested subdirs inside a top-level grouping. Kept here (rather
   // than module-local constants) when multiple modules need to
   // reference the same nested path — e.g. wiki/pages/ is used by

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -51,27 +51,53 @@ export function isPresetSlug(slug: string): boolean {
   return slug.startsWith(PRESET_SLUG_PREFIX) && slug.length > PRESET_SLUG_PREFIX.length;
 }
 
-type Verdict = { ok: true } | { ok: false; reason: string };
+// Classification of one source entry. `silent` distinguishes
+// structural skips (hidden files, non-directory entries — not the
+// dev's fault) from misconfigurations (bad slug, missing or
+// non-regular SKILL.md — the dev WANTS to know). The boolean lives
+// on the verdict so the caller never has to string-match `reason`,
+// which would silently drop warnings if reason wording changed
+// (CodeRabbit review).
+type Verdict = { ok: true } | { ok: false; reason: string; silent: boolean };
 
 function classifySourceEntry(sourceDir: string, entry: string): Verdict {
-  if (entry.startsWith(".")) return { ok: false, reason: "hidden" };
+  if (entry.startsWith(".")) return { ok: false, reason: "hidden", silent: true };
   const slugDir = path.join(sourceDir, entry);
-  let info;
+  let dirInfo;
   try {
-    info = statSync(slugDir);
+    dirInfo = statSync(slugDir);
   } catch {
-    return { ok: false, reason: "stat failed" };
+    return { ok: false, reason: "stat failed", silent: true };
   }
-  if (!info.isDirectory()) return { ok: false, reason: "not a directory" };
-  if (!isPresetSlug(entry)) return { ok: false, reason: `slug must start with "${PRESET_SLUG_PREFIX}"` };
-  if (!existsSync(path.join(slugDir, SKILL_FILENAME))) return { ok: false, reason: `missing ${SKILL_FILENAME}` };
+  if (!dirInfo.isDirectory()) return { ok: false, reason: "not a directory", silent: true };
+  if (!isPresetSlug(entry)) return { ok: false, reason: `slug must start with "${PRESET_SLUG_PREFIX}"`, silent: false };
+  // Validate SKILL.md is a regular file — `existsSync` alone
+  // accepts a directory at that path, which would then crash
+  // copyFileSync. Codex review caught this edge case.
+  const skillPath = path.join(slugDir, SKILL_FILENAME);
+  let skillInfo;
+  try {
+    skillInfo = statSync(skillPath);
+  } catch {
+    return { ok: false, reason: `missing ${SKILL_FILENAME}`, silent: false };
+  }
+  if (!skillInfo.isFile()) return { ok: false, reason: `${SKILL_FILENAME} must be a regular file`, silent: false };
   return { ok: true };
 }
 
-function copyOneSource(sourceDir: string, destDir: string, entry: string): void {
-  const destSlugDir = path.join(destDir, entry);
-  mkdirSync(destSlugDir, { recursive: true });
-  copyFileSync(path.join(sourceDir, entry, SKILL_FILENAME), path.join(destSlugDir, SKILL_FILENAME));
+/** Prepare the destination slug dir. Returns false if the slot is
+ *  occupied by a regular file (local corruption / hand edits) — the
+ *  caller logs + skips so one bad entry can't crash the whole boot
+ *  (Codex review iter-1). */
+function ensureDestSlugDir(destSlugDir: string): boolean {
+  let info;
+  try {
+    info = statSync(destSlugDir);
+  } catch {
+    mkdirSync(destSlugDir, { recursive: true });
+    return true;
+  }
+  return info.isDirectory();
 }
 
 function copySourcesIntoDest(sourceDir: string, destDir: string, opts: SyncPresetSkillsOptions, result: SyncPresetSkillsResult): Set<string> {
@@ -79,17 +105,20 @@ function copySourcesIntoDest(sourceDir: string, destDir: string, opts: SyncPrese
   for (const entry of readdirSync(sourceDir)) {
     const verdict = classifySourceEntry(sourceDir, entry);
     if (!verdict.ok) {
-      // "hidden" / "not a directory" / "stat failed" are silent
-      // structural skips. Slug-rule violations and missing SKILL.md
-      // are real misconfigurations that the dev needs to see.
-      const isMisconfiguration = verdict.reason.startsWith("slug") || verdict.reason.startsWith("missing");
-      if (isMisconfiguration) {
+      if (!verdict.silent) {
         result.skipped.push(`${entry}: ${verdict.reason}`);
         opts.onWarn?.("preset entry skipped", { slug: entry, reason: verdict.reason });
       }
       continue;
     }
-    copyOneSource(sourceDir, destDir, entry);
+    const destSlugDir = path.join(destDir, entry);
+    if (!ensureDestSlugDir(destSlugDir)) {
+      const reason = "destination slot occupied by a non-directory; skipping";
+      result.skipped.push(`${entry}: ${reason}`);
+      opts.onWarn?.("preset entry skipped", { slug: entry, reason, destSlugDir });
+      continue;
+    }
+    copyFileSync(path.join(sourceDir, entry, SKILL_FILENAME), path.join(destSlugDir, SKILL_FILENAME));
     synced.add(entry);
     result.copied.push(entry);
   }

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -153,7 +153,17 @@ export function syncPresetSkills(opts: SyncPresetSkillsOptions): SyncPresetSkill
     // This is the legitimate "no presets shipped yet" state.
     return result;
   }
-  mkdirSync(opts.destDir, { recursive: true });
+  // The root dest itself can be corrupted into a regular file by a
+  // user / external tool; mkdirSync would throw EEXIST and crash
+  // boot. Treat it as a recoverable "skip the entire sync" state
+  // — log a clear warning so the user sees what to fix.
+  // (Codex review iter-2.)
+  if (!ensureDestSlugDir(opts.destDir)) {
+    const reason = "root dest exists as a non-directory; preset sync skipped";
+    result.skipped.push(`${opts.destDir}: ${reason}`);
+    opts.onWarn?.("preset sync aborted", { destDir: opts.destDir, reason });
+    return result;
+  }
   const synced = copySourcesIntoDest(opts.sourceDir, opts.destDir, opts, result);
   removeRetiredPresets(opts.destDir, synced, opts, result);
   if (result.copied.length > 0 || result.removed.length > 0) {

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -1,0 +1,138 @@
+// Preset skills bundled with mulmoclaude (#1210). Sibling to
+// `helps/`: this file owns the boot-time copy from
+// `server/workspace/skills-preset/<slug>/SKILL.md` (shipped with the
+// launcher tarball) into `<workspaceRoot>/.claude/skills/<slug>/SKILL.md`,
+// where Claude Code's slash-command resolver picks them up.
+//
+// The launcher overwrites preset entries unconditionally on every
+// boot — preset skills are "factory defaults", not user state. The
+// `mc-` slug prefix is the namespace boundary: anything under
+// `mc-*` belongs to the launcher and may be added / overwritten /
+// removed across releases. Anything WITHOUT the `mc-` prefix is
+// user-owned and never touched.
+//
+// `syncPresetSkills(...)` is exported as a pure-ish helper (takes
+// paths + a logger sink, returns a summary) so tests can drive it
+// against tmpdirs without touching a real workspace.
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+
+const PRESET_SLUG_PREFIX = "mc-";
+const SKILL_FILENAME = "SKILL.md";
+
+export interface SyncPresetSkillsOptions {
+  /** Source directory: `<launcher>/server/workspace/skills-preset/`. */
+  sourceDir: string;
+  /** Destination directory: `<workspaceRoot>/.claude/skills/`. */
+  destDir: string;
+  /** Logger callbacks — kept injectable so tests don't need to
+   *  spin up the structured logger. The boot-side wrapper threads
+   *  these through to `log.info` / `log.warn`. */
+  onInfo?: (message: string, data?: Record<string, unknown>) => void;
+  onWarn?: (message: string, data?: Record<string, unknown>) => void;
+}
+
+export interface SyncPresetSkillsResult {
+  /** Slugs successfully copied (or refreshed) from source to dest. */
+  copied: string[];
+  /** Slugs removed from dest because they no longer exist in source.
+   *  Bounded to `mc-*` entries — user-authored slugs are never
+   *  considered for removal. */
+  removed: string[];
+  /** Source entries that failed validation (wrong prefix, missing
+   *  SKILL.md, etc.) and were skipped. Each entry is human-readable. */
+  skipped: string[];
+}
+
+/** Validate that a slug starts with the launcher's preset namespace.
+ *  Exported for tests; the boot-time guard relies on this. */
+export function isPresetSlug(slug: string): boolean {
+  return slug.startsWith(PRESET_SLUG_PREFIX) && slug.length > PRESET_SLUG_PREFIX.length;
+}
+
+type Verdict = { ok: true } | { ok: false; reason: string };
+
+function classifySourceEntry(sourceDir: string, entry: string): Verdict {
+  if (entry.startsWith(".")) return { ok: false, reason: "hidden" };
+  const slugDir = path.join(sourceDir, entry);
+  let info;
+  try {
+    info = statSync(slugDir);
+  } catch {
+    return { ok: false, reason: "stat failed" };
+  }
+  if (!info.isDirectory()) return { ok: false, reason: "not a directory" };
+  if (!isPresetSlug(entry)) return { ok: false, reason: `slug must start with "${PRESET_SLUG_PREFIX}"` };
+  if (!existsSync(path.join(slugDir, SKILL_FILENAME))) return { ok: false, reason: `missing ${SKILL_FILENAME}` };
+  return { ok: true };
+}
+
+function copyOneSource(sourceDir: string, destDir: string, entry: string): void {
+  const destSlugDir = path.join(destDir, entry);
+  mkdirSync(destSlugDir, { recursive: true });
+  copyFileSync(path.join(sourceDir, entry, SKILL_FILENAME), path.join(destSlugDir, SKILL_FILENAME));
+}
+
+function copySourcesIntoDest(sourceDir: string, destDir: string, opts: SyncPresetSkillsOptions, result: SyncPresetSkillsResult): Set<string> {
+  const synced = new Set<string>();
+  for (const entry of readdirSync(sourceDir)) {
+    const verdict = classifySourceEntry(sourceDir, entry);
+    if (!verdict.ok) {
+      // "hidden" / "not a directory" / "stat failed" are silent
+      // structural skips. Slug-rule violations and missing SKILL.md
+      // are real misconfigurations that the dev needs to see.
+      const isMisconfiguration = verdict.reason.startsWith("slug") || verdict.reason.startsWith("missing");
+      if (isMisconfiguration) {
+        result.skipped.push(`${entry}: ${verdict.reason}`);
+        opts.onWarn?.("preset entry skipped", { slug: entry, reason: verdict.reason });
+      }
+      continue;
+    }
+    copyOneSource(sourceDir, destDir, entry);
+    synced.add(entry);
+    result.copied.push(entry);
+  }
+  return synced;
+}
+
+function removeRetiredPresets(destDir: string, synced: ReadonlySet<string>, opts: SyncPresetSkillsOptions, result: SyncPresetSkillsResult): void {
+  for (const entry of readdirSync(destDir)) {
+    if (!isPresetSlug(entry)) continue;
+    if (synced.has(entry)) continue;
+    const stalePath = path.join(destDir, entry);
+    try {
+      if (!statSync(stalePath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    rmSync(stalePath, { recursive: true, force: true });
+    result.removed.push(entry);
+    opts.onInfo?.("removed retired preset skill", { slug: entry });
+  }
+}
+
+/** Copy every preset slug from `sourceDir` into `destDir`, then
+ *  remove any `mc-*` entries in `destDir` that no longer have a
+ *  source. Slugs without the `mc-` prefix are skipped (with a warn)
+ *  on the source side and left untouched on the dest side — that's
+ *  how user-authored skills coexist with launcher-managed presets. */
+export function syncPresetSkills(opts: SyncPresetSkillsOptions): SyncPresetSkillsResult {
+  const result: SyncPresetSkillsResult = { copied: [], removed: [], skipped: [] };
+  if (!existsSync(opts.sourceDir)) {
+    // No preset directory in the launcher tarball — nothing to do.
+    // This is the legitimate "no presets shipped yet" state.
+    return result;
+  }
+  mkdirSync(opts.destDir, { recursive: true });
+  const synced = copySourcesIntoDest(opts.sourceDir, opts.destDir, opts, result);
+  removeRetiredPresets(opts.destDir, synced, opts, result);
+  if (result.copied.length > 0 || result.removed.length > 0) {
+    opts.onInfo?.("preset skills synced", {
+      copied: result.copied.length,
+      removed: result.removed.length,
+      skipped: result.skipped.length,
+    });
+  }
+  return result;
+}

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -153,6 +153,25 @@ export function syncPresetSkills(opts: SyncPresetSkillsOptions): SyncPresetSkill
     // This is the legitimate "no presets shipped yet" state.
     return result;
   }
+  // Source-side validation: the launcher's preset path COULD exist
+  // as a regular file (a packaging bug, a corrupted install). Without
+  // this guard, `readdirSync(sourceDir)` would throw ENOTDIR and
+  // crash boot. Codex review iter-3.
+  let sourceInfo;
+  try {
+    sourceInfo = statSync(opts.sourceDir);
+  } catch (err) {
+    const reason = `source path stat failed: ${err instanceof Error ? err.message : String(err)}`;
+    result.skipped.push(`${opts.sourceDir}: ${reason}`);
+    opts.onWarn?.("preset sync aborted", { sourceDir: opts.sourceDir, reason });
+    return result;
+  }
+  if (!sourceInfo.isDirectory()) {
+    const reason = "source path exists as a non-directory; preset sync skipped";
+    result.skipped.push(`${opts.sourceDir}: ${reason}`);
+    opts.onWarn?.("preset sync aborted", { sourceDir: opts.sourceDir, reason });
+    return result;
+  }
   // The root dest itself can be corrupted into a regular file by a
   // user / external tool; mkdirSync would throw EEXIST and crash
   // boot. Treat it as a recoverable "skip the entire sync" state

--- a/server/workspace/skills-preset/mc-example/SKILL.md
+++ b/server/workspace/skills-preset/mc-example/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: mc-example
+description: Stub preset skill bundled with mulmoclaude. Demonstrates the preset distribution mechanism — real preset skills replace this in subsequent PRs.
+---
+
+# Preset skill — example
+
+This file is shipped with mulmoclaude under
+`server/workspace/skills-preset/mc-example/SKILL.md` and copied into
+`<workspaceRoot>/.claude/skills/mc-example/SKILL.md` on every server
+boot. The `mc-` prefix is the launcher's namespace — anything under
+`mc-*` belongs to mulmoclaude and may be added, refreshed, or
+removed across releases.
+
+If you edit this file in your workspace, your changes will be
+overwritten on the next server boot. To customise, copy the body
+into a new skill under your own slug (e.g. `~/.claude/skills/my-thing/SKILL.md`)
+and edit that copy.
+
+## What this skill does
+
+Nothing — it's a placeholder. Replace with real workflow guidance in
+real preset skills (e.g. `mc-library` for the personal reading list
+in #1210 PR-B).

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -6,9 +6,12 @@ import { log } from "../system/logger/index.js";
 import { EAGER_WORKSPACE_DIRS, WORKSPACE_PATHS, workspacePath } from "./paths.js";
 import { readWorkspaceTextSync, writeWorkspaceTextSync } from "../utils/files/workspace-io.js";
 import { loadCustomDirs, ensureCustomDirs } from "./custom-dirs.js";
+import { syncPresetSkills } from "./skills-preset.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, "helps");
+const SKILLS_PRESET_SOURCE_DIR = path.join(__dirname, "skills-preset");
+const PROJECT_SKILLS_DIR_REL = path.join(".claude", "skills");
 
 // Re-exported so existing callers (`import { workspacePath } from
 // "./workspace.js"`) keep working. See workspace-paths.ts for the
@@ -38,6 +41,17 @@ export function initWorkspace(): string {
   for (const file of readdirSync(TEMPLATES_DIR)) {
     copyFileSync(path.join(TEMPLATES_DIR, file), path.join(WORKSPACE_PATHS.helps, file));
   }
+
+  // Sync preset skills (#1210) from server/workspace/skills-preset/
+  // into <workspaceRoot>/.claude/skills/. Only `mc-*` slugs are
+  // touched — user-authored skills coexist untouched. Retired
+  // presets (no longer in source) are removed from the workspace.
+  syncPresetSkills({
+    sourceDir: SKILLS_PRESET_SOURCE_DIR,
+    destDir: path.join(workspacePath, PROJECT_SKILLS_DIR_REL),
+    onInfo: (message, data) => log.info("skills-preset", message, data),
+    onWarn: (message, data) => log.warn("skills-preset", message, data),
+  });
 
   // Create .gitignore if missing. The workspace is a git repo for
   // version-tracking user data, but cloned dev repos under github/

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -11,7 +11,6 @@ import { syncPresetSkills } from "./skills-preset.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, "helps");
 const SKILLS_PRESET_SOURCE_DIR = path.join(__dirname, "skills-preset");
-const PROJECT_SKILLS_DIR_REL = path.join(".claude", "skills");
 
 // Re-exported so existing callers (`import { workspacePath } from
 // "./workspace.js"`) keep working. See workspace-paths.ts for the
@@ -48,7 +47,7 @@ export function initWorkspace(): string {
   // presets (no longer in source) are removed from the workspace.
   syncPresetSkills({
     sourceDir: SKILLS_PRESET_SOURCE_DIR,
-    destDir: path.join(workspacePath, PROJECT_SKILLS_DIR_REL),
+    destDir: WORKSPACE_PATHS.claudeSkills,
     onInfo: (message, data) => log.info("skills-preset", message, data),
     onWarn: (message, data) => log.warn("skills-preset", message, data),
   });

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -23,6 +23,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "calendar",
     "charts",
     "chat",
+    "claudeSkills",
     "configs",
     "contacts",
     "github",

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -196,6 +196,30 @@ describe("syncPresetSkills — slug guard", () => {
   });
 });
 
+describe("syncPresetSkills — source resilience", () => {
+  it("aborts cleanly when sourceDir exists as a regular file (packaging mistake)", () => {
+    // Codex review iter-3: existsSync(sourceDir) accepts a regular
+    // file standing in for the preset directory; readdirSync would
+    // then ENOTDIR-crash boot. The function must tolerate that
+    // packaging bug as a recoverable "skip the sync" state.
+    rmSync(sourceDir, { recursive: true, force: true });
+    writeFileSync(sourceDir, "stray file at the source path");
+
+    const warnings: string[] = [];
+    const result = syncPresetSkills({
+      sourceDir,
+      destDir,
+      onWarn: (message, data) => warnings.push(`${message} ${JSON.stringify(data)}`),
+    });
+    assert.deepEqual(result.copied, []);
+    assert.deepEqual(result.removed, []);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /non-directory/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /preset sync aborted/);
+  });
+});
+
 describe("syncPresetSkills — destination resilience", () => {
   it("aborts the sync cleanly when the root dest itself is a regular file (regression: corruption-tolerant boot)", () => {
     // Codex review iter-2: prior fix only protected per-slug

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -197,6 +197,28 @@ describe("syncPresetSkills — slug guard", () => {
 });
 
 describe("syncPresetSkills — destination resilience", () => {
+  it("aborts the sync cleanly when the root dest itself is a regular file (regression: corruption-tolerant boot)", () => {
+    // Codex review iter-2: prior fix only protected per-slug
+    // mkdirSync; the root mkdirSync would still EEXIST-crash if
+    // `<workspace>/.claude/skills` itself was somehow a regular
+    // file. Now it logs warn + skips the whole sync.
+    writePresetSource("mc-foo");
+    writeFileSync(destDir, "stray file blocking the root skills dir");
+
+    const warnings: string[] = [];
+    const result = syncPresetSkills({
+      sourceDir,
+      destDir,
+      onWarn: (message, data) => warnings.push(`${message} ${JSON.stringify(data)}`),
+    });
+    assert.deepEqual(result.copied, []);
+    assert.deepEqual(result.removed, []);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /non-directory/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /preset sync aborted/);
+  });
+
   it("skips a slug whose dest slot is occupied by a regular file (regression: corruption-tolerant boot)", () => {
     // Codex review iter-1: mkdirSync recursive: true throws EEXIST
     // when the path is a regular file. One bad slot must not crash

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -175,6 +175,52 @@ describe("syncPresetSkills — slug guard", () => {
     assert.deepEqual(result.copied, ["mc-foo"]);
     assert.deepEqual(result.skipped, []);
   });
+
+  it("skips when SKILL.md is a directory (regression: not a regular file)", () => {
+    // Codex review iter-1: existsSync alone passes a directory
+    // standing in for SKILL.md; copyFileSync would then crash boot.
+    // The classifier must check `isFile()`.
+    const slugDir = path.join(sourceDir, "mc-bad-shape");
+    mkdirSync(path.join(slugDir, "SKILL.md"), { recursive: true });
+    const warnings: string[] = [];
+    const result = syncPresetSkills({
+      sourceDir,
+      destDir,
+      onWarn: (message, data) => warnings.push(`${message} ${JSON.stringify(data)}`),
+    });
+    assert.deepEqual(result.copied, []);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /mc-bad-shape/);
+    assert.match(result.skipped[0], /regular file/);
+    assert.equal(warnings.length, 1);
+  });
+});
+
+describe("syncPresetSkills — destination resilience", () => {
+  it("skips a slug whose dest slot is occupied by a regular file (regression: corruption-tolerant boot)", () => {
+    // Codex review iter-1: mkdirSync recursive: true throws EEXIST
+    // when the path is a regular file. One bad slot must not crash
+    // boot — log warn and skip just that slug, keep others moving.
+    writePresetSource("mc-foo");
+    writePresetSource("mc-bar");
+    mkdirSync(destDir, { recursive: true });
+    writeFileSync(path.join(destDir, "mc-foo"), "stray file blocking the slug dir");
+
+    const warnings: string[] = [];
+    const result = syncPresetSkills({
+      sourceDir,
+      destDir,
+      onWarn: (message, data) => warnings.push(`${message} ${JSON.stringify(data)}`),
+    });
+    // mc-foo is skipped (slot occupied), mc-bar still copies.
+    assert.deepEqual(result.copied, ["mc-bar"]);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /mc-foo/);
+    assert.match(result.skipped[0], /non-directory/);
+    assert.equal(warnings.length, 1);
+    // mc-bar landed normally despite mc-foo's failure.
+    assert.ok(existsSync(path.join(destDir, "mc-bar", "SKILL.md")));
+  });
 });
 
 describe("syncPresetSkills — cleanup of retired presets", () => {

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -1,0 +1,255 @@
+// Tests for the boot-time preset-skill sync (#1210 PR-A).
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { syncPresetSkills, isPresetSlug } from "../../server/workspace/skills-preset.js";
+
+let workdir: string;
+let sourceDir: string;
+let destDir: string;
+
+function writePresetSource(slug: string, body = `placeholder for ${slug}`): void {
+  const slugDir = path.join(sourceDir, slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(path.join(slugDir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\n${body}\n`);
+}
+
+function writeDestSkill(slug: string, body: string): void {
+  const slugDir = path.join(destDir, slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(path.join(slugDir, "SKILL.md"), body);
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "skills-preset-"));
+  sourceDir = path.join(workdir, "source");
+  destDir = path.join(workdir, "dest");
+  mkdirSync(sourceDir);
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("isPresetSlug", () => {
+  it("accepts mc-* slugs", () => {
+    assert.equal(isPresetSlug("mc-library"), true);
+    assert.equal(isPresetSlug("mc-x"), true);
+  });
+
+  it("rejects non-prefixed slugs", () => {
+    assert.equal(isPresetSlug("library"), false);
+    assert.equal(isPresetSlug("manage-library"), false);
+  });
+
+  it("rejects bare prefix without a name", () => {
+    assert.equal(isPresetSlug("mc-"), false);
+  });
+
+  it("rejects empty / unrelated", () => {
+    assert.equal(isPresetSlug(""), false);
+    assert.equal(isPresetSlug("MC-LIBRARY"), false);
+  });
+});
+
+describe("syncPresetSkills — happy path", () => {
+  it("copies a single mc-* preset into the destination", () => {
+    writePresetSource("mc-foo");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.copied, ["mc-foo"]);
+    assert.deepEqual(result.skipped, []);
+    assert.deepEqual(result.removed, []);
+    const destFile = path.join(destDir, "mc-foo", "SKILL.md");
+    assert.ok(existsSync(destFile));
+    assert.match(readFileSync(destFile, "utf-8"), /placeholder for mc-foo/);
+  });
+
+  it("copies multiple presets in one pass", () => {
+    writePresetSource("mc-a");
+    writePresetSource("mc-b");
+    writePresetSource("mc-c");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.copied.sort(), ["mc-a", "mc-b", "mc-c"]);
+    for (const slug of ["mc-a", "mc-b", "mc-c"]) {
+      assert.ok(existsSync(path.join(destDir, slug, "SKILL.md")));
+    }
+  });
+
+  it("creates the destination dir when it does not exist yet", () => {
+    writePresetSource("mc-foo");
+    assert.equal(existsSync(destDir), false);
+    syncPresetSkills({ sourceDir, destDir });
+    assert.ok(existsSync(destDir));
+  });
+
+  it("returns an empty result when the source dir does not exist (no presets shipped yet)", () => {
+    rmSync(sourceDir, { recursive: true });
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result, { copied: [], removed: [], skipped: [] });
+  });
+});
+
+describe("syncPresetSkills — overwrite policy", () => {
+  it("refreshes a preset whose dest content was modified", () => {
+    writePresetSource("mc-foo", "fresh content");
+    writeDestSkill("mc-foo", "stale content from a previous boot");
+    syncPresetSkills({ sourceDir, destDir });
+    const after = readFileSync(path.join(destDir, "mc-foo", "SKILL.md"), "utf-8");
+    assert.match(after, /fresh content/);
+    assert.doesNotMatch(after, /stale content/);
+  });
+
+  it("is idempotent — running twice yields the same on-disk state", () => {
+    writePresetSource("mc-foo");
+    syncPresetSkills({ sourceDir, destDir });
+    const first = readFileSync(path.join(destDir, "mc-foo", "SKILL.md"), "utf-8");
+    syncPresetSkills({ sourceDir, destDir });
+    const second = readFileSync(path.join(destDir, "mc-foo", "SKILL.md"), "utf-8");
+    assert.equal(first, second);
+  });
+});
+
+describe("syncPresetSkills — user-skill safety", () => {
+  it("does NOT touch a non-mc- slug in the destination", () => {
+    writePresetSource("mc-foo");
+    writeDestSkill("library", "user-authored content");
+    syncPresetSkills({ sourceDir, destDir });
+    const after = readFileSync(path.join(destDir, "library", "SKILL.md"), "utf-8");
+    assert.equal(after, "user-authored content");
+  });
+
+  it("does NOT remove a non-mc- slug during cleanup", () => {
+    // Even when there are NO source presets, a user's library/ in
+    // dest must survive the cleanup pass.
+    writeDestSkill("library", "user-authored content");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.removed, []);
+    assert.ok(existsSync(path.join(destDir, "library", "SKILL.md")));
+  });
+});
+
+describe("syncPresetSkills — slug guard", () => {
+  it("skips a source entry without the mc- prefix", () => {
+    writePresetSource("library");
+    const warnings: string[] = [];
+    const result = syncPresetSkills({
+      sourceDir,
+      destDir,
+      onWarn: (message, data) => warnings.push(`${message} ${JSON.stringify(data)}`),
+    });
+    assert.deepEqual(result.copied, []);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /library/);
+    assert.match(result.skipped[0], /mc-/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /library/);
+    assert.equal(existsSync(path.join(destDir, "library")), false);
+  });
+
+  it("skips a source entry without SKILL.md", () => {
+    mkdirSync(path.join(sourceDir, "mc-empty"));
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.copied, []);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0], /mc-empty/);
+    assert.match(result.skipped[0], /SKILL\.md/);
+  });
+
+  it("skips a non-directory source entry", () => {
+    writeFileSync(path.join(sourceDir, "stray-file.md"), "not a slug dir");
+    writePresetSource("mc-foo");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.copied, ["mc-foo"]);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  it("ignores hidden source entries (.gitkeep, .DS_Store)", () => {
+    writeFileSync(path.join(sourceDir, ".gitkeep"), "");
+    writeFileSync(path.join(sourceDir, ".DS_Store"), "");
+    writePresetSource("mc-foo");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.copied, ["mc-foo"]);
+    assert.deepEqual(result.skipped, []);
+  });
+});
+
+describe("syncPresetSkills — cleanup of retired presets", () => {
+  it("removes an mc-* slug in dest that no longer exists in source", () => {
+    writeDestSkill("mc-stale", "old preset from a previous release");
+    writePresetSource("mc-foo");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.removed, ["mc-stale"]);
+    assert.equal(existsSync(path.join(destDir, "mc-stale")), false);
+    assert.ok(existsSync(path.join(destDir, "mc-foo", "SKILL.md")));
+  });
+
+  it("does NOT remove the slug we just copied", () => {
+    writeDestSkill("mc-foo", "old content");
+    writePresetSource("mc-foo", "new content");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.removed, []);
+    assert.deepEqual(result.copied, ["mc-foo"]);
+  });
+
+  it("removes multiple stale mc-* entries in one pass", () => {
+    writeDestSkill("mc-old-a", "");
+    writeDestSkill("mc-old-b", "");
+    writePresetSource("mc-fresh");
+    const result = syncPresetSkills({ sourceDir, destDir });
+    assert.deepEqual(result.removed.sort(), ["mc-old-a", "mc-old-b"]);
+  });
+
+  it("emits an info log for each removed entry", () => {
+    writeDestSkill("mc-stale", "");
+    const infos: string[] = [];
+    syncPresetSkills({
+      sourceDir,
+      destDir,
+      onInfo: (message, data) => infos.push(`${message} ${JSON.stringify(data)}`),
+    });
+    assert.ok(infos.some((entry) => entry.includes("removed retired preset") && entry.includes("mc-stale")));
+  });
+});
+
+describe("syncPresetSkills — combined scenarios", () => {
+  it("handles an upgrade: one preset added, one removed, one user-skill untouched", () => {
+    // Snapshot of a typical mulmoclaude upgrade: previous boot
+    // installed mc-old + mc-keep, user added their own `library`,
+    // current source ships mc-keep + mc-new.
+    writeDestSkill("mc-old", "retired in this release");
+    writeDestSkill("mc-keep", "stale content");
+    writeDestSkill("library", "user content");
+    writePresetSource("mc-keep", "refreshed content");
+    writePresetSource("mc-new", "new in this release");
+
+    const result = syncPresetSkills({ sourceDir, destDir });
+
+    assert.deepEqual(result.copied.sort(), ["mc-keep", "mc-new"]);
+    assert.deepEqual(result.removed, ["mc-old"]);
+    assert.equal(existsSync(path.join(destDir, "mc-old")), false);
+    assert.match(readFileSync(path.join(destDir, "mc-keep", "SKILL.md"), "utf-8"), /refreshed/);
+    assert.ok(existsSync(path.join(destDir, "mc-new", "SKILL.md")));
+    assert.equal(readFileSync(path.join(destDir, "library", "SKILL.md"), "utf-8"), "user content");
+  });
+});
+
+describe("syncPresetSkills — repository fixture", () => {
+  it("the in-repo skills-preset/ directory has at least the mc-example stub and ALL slugs are mc-* prefixed", () => {
+    // Anchored to a real path so this test catches regressions where
+    // someone adds a preset slug missing the mc- prefix at the
+    // repository level (boot would warn-and-skip, but a CI fail is
+    // louder).
+    const REPO_PRESET_DIR = path.resolve(import.meta.dirname, "..", "..", "server", "workspace", "skills-preset");
+    if (!existsSync(REPO_PRESET_DIR)) return; // dir not created yet — covered by other tests
+    const slugs = readdirSync(REPO_PRESET_DIR).filter((entry) => !entry.startsWith("."));
+    assert.ok(slugs.length >= 1, "expected at least the mc-example stub in skills-preset/");
+    for (const slug of slugs) {
+      assert.equal(isPresetSlug(slug), true, `slug "${slug}" must start with "mc-"`);
+      assert.ok(existsSync(path.join(REPO_PRESET_DIR, slug, "SKILL.md")), `slug "${slug}" must contain a SKILL.md`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR-A of #1210 — infrastructure for shipping preset Claude Code skills as part of mulmoclaude. Mirrors the existing \`config/helps/\` distribution mechanism: the launcher ships preset SKILL.md files under \`server/workspace/skills-preset/<slug>/\`, and \`initWorkspace()\` copies them into \`<workspaceRoot>/.claude/skills/\` on every boot. Claude Code's native slash-command resolver picks them up automatically — no MulmoClaude-side discovery wiring needed.

The \`mc-\` slug prefix is the namespace boundary: \`mc-*\` belongs to the launcher and may be added / refreshed / removed across releases. Anything without the prefix is user-owned and never touched.

## Items to Confirm / Review

- **Boot-time guard surfaces as warn, not exit**: a preset slug missing the \`mc-\` prefix is logged + skipped, not a hard error. Per the plan: gentler is safer for the first iteration; we can promote to hard-fail later if dev-time mistakes slip through.
- **Cleanup is bounded to \`mc-*\` slugs only**: stale presets removed, user-authored entries (e.g. \`daily-plan/\`, \`shiritori/\` in my workspace) explicitly safe. Test \`does NOT remove a non-mc- slug during cleanup\` pins this.
- **Source dir absence is silent**: if a launcher build doesn't ship \`skills-preset/\` at all, sync no-ops cleanly. Catches the legitimate "no presets shipped yet" state and tarball-build incidents.
- **Helper extraction for complexity**: \`syncPresetSkills\` decomposed into \`classifySourceEntry\`, \`copySourcesIntoDest\`, \`removeRetiredPresets\` to stay under \`sonarjs/cognitive-complexity\`. The injectable logger sink keeps it test-driveable without booting structured logging.
- **Stub preset \`mc-example\`**: ships so the dir exists and CI exercises the full copy path. Real preset (\`mc-library\` for #1169 reading-list, replacing the plugin approach in #1190) lands in PR-B.
- **Repository fixture test**: \`the in-repo skills-preset/ directory has at least the mc-example stub and ALL slugs are mc-* prefixed\` — catches a contributor adding a malformed preset slug at PR review time, louder than a runtime warn.

## User Prompt

> skillについて。どこかでまとめたかもしれないけど、~/.claudeと ~/mulmoclaude/.claude以下の２つが使われるという認識でok? ~/mulmoclaude/.claude以下、ユーザが作ったものだけど、mulmo claudeのpresetもつかえるようにしたい。
> mc_みたいにprefixつける？mulmo_がよいかな。
> はい.まずはissueで丁寧にせつめいをかき、plan化を。
> PR-A 着手して

## Implementation

- Issue #1210 — design doc with motivation, why-not-other-approaches, three-PR phasing
- Plan: \`plans/feat-preset-skills-1210.md\` (commit \`d8fe75aa\`)
- \`server/workspace/skills-preset.ts\` — pure-ish helper
- \`server/workspace/skills-preset/mc-example/SKILL.md\` — stub
- \`server/workspace/workspace.ts\` — boot wiring after helps copy
- \`test/workspace/test_skills_preset.ts\` — 22 cases

## Test plan

- [x] \`yarn lint\` / \`yarn typecheck\` clean
- [x] \`yarn test\` — 4270 / 86 pass (22 new cases all green)
- [x] **Manual smoke** end-to-end (with pre-seeded stale + user-authored entries):
  - \`mc-example\` copied from launcher → workspace ✓
  - User-authored \`library/\` (no \`mc-\` prefix) survived boot untouched ✓
  - Stale \`mc-stale/\` (not in source) removed ✓
  - Pre-existing user-authored \`daily-plan/\` and \`shiritori/\` untouched ✓
  - Boot log: \`[skills-preset] preset skills synced copied=1 removed=1 skipped=0\` ✓
- [ ] Reviewer manually invokes \`/mc-example\` from a fresh chat after boot to confirm Claude Code's slash-command resolver finds it

Tracks #1210 (PR-A). PR-B = \`mc-library\` skill (replaces #1188 / #1190 plugin approach). PR-C = remaining presets from #1169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher now ships curated preset skills that are automatically synchronized into your workspace at startup.
  * Preset entries are force-overwritten from the launcher and retired presets are removed on sync; user-created skills are preserved.
  * Includes an example preset stub for reference.

* **Tests**
  * Expanded test suite covering sync behavior, idempotency, validation/warnings, error conditions, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->