### PR TITLE
docs: extension-mechanisms reference + Claude Code migration guide

### DIFF
--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -1,0 +1,398 @@
+# MulmoClaude 拡張機構リファレンス
+
+MulmoClaude が LLM (Claude Agent SDK) に対して提供する **拡張・連携の経路** は7種類ある。
+それぞれ「どこに置くか」「LLM がどう発見するか」「どうやって呼び出すか」が違うので、
+新しい機能を追加するときに最初に決めるのは「どのレイヤーで作るか」になる。
+
+このドキュメントは:
+
+- 7つの機構を一覧
+- どの機能を持つか (`tools` / `system prompt` / `MCP` / `role gate` / etc.) をマトリクス化
+- ソース上の実装ポイント (file:line 直リンク) を埋め込み
+- 「どれを選ぶか」の判断ガイド
+
+を提供する。アーキ全体像は [`docs/developer.md`](developer.md) も併読。
+
+---
+
+## 1. 7つの機構 — クイック紹介
+
+| # | 機構 | 配布形態 | 例 |
+|---|---|---|---|
+| 1 | **Built-in 静的 GUI plugin** | アプリ本体にバンドル | `accounting`, `presentHtml`, `chart`, `wiki` |
+| 2 | **Built-in 静的 MCP-only tool** | アプリ本体にバンドル | `notify`, `x` (Twitter post) |
+| 3 | **Runtime plugin (preset / user-installed)** | npm package | `@mulmoclaude/spotify-plugin`, `@mulmoclaude/todo-plugin` |
+| 4 | **External MCP server** | 別プロセス (stdio / HTTP) | GitHub, Linear, Spotify-MCP, YouTube transcript |
+| 5 | **Skill** | markdown ファイル | `~/.claude/skills/<name>/SKILL.md` |
+| 6 | **Role** | TypeScript / markdown | `general`, `accounting`, `cookingCoach` |
+| 7 | **Bridge (messenger)** | 別プロセス (npm package) | Telegram, Slack, Discord, LINE |
+
+---
+
+## 2. ケイパビリティ・マトリクス
+
+各機構が「LLM 呼び出し系」「設定・配布系」「スコープ系」のどの軸を持つか。
+
+| 機構 | 標準提供 | 設定で追加可 | system prompt 注入 | LLM が tool 呼出 | MCP 経由公開 | Role でゲート | 永続スコープ |
+|---|---|---|---|---|---|---|---|
+| **1. Built-in GUI plugin** | ✅ アプリにバンドル | ❌ コード変更要 | ✅ `### <name>` ブロック | ✅ | ✅ in-process | ✅ `availablePlugins` | アプリ |
+| **2. Built-in MCP-only tool** | ✅ アプリにバンドル | ❌ コード変更要 | ✅ | ✅ | ✅ in-process | ✅ `availablePlugins` | アプリ |
+| **3. Runtime plugin** | △ preset 数本 | ✅ npm install | ✅ 自動 | ✅ | ✅ in-process | ❌ **常時 ON** | アプリ + workspace files |
+| **4. External MCP server** | ❌ | ✅ catalog or `mcp.json` | △ tool 説明のみ | ✅ | ✅ **別 server-id** | ❌ | サーバ側 + tool ENV |
+| **5. Skill** | ❌ | ✅ 会話 / `manageSkills` で作成 | ✅ frontmatter 経由 | ❌ **tool ではない** | ❌ | ❌ | `~/.claude/skills/` + workspace |
+| **6. Role** | ✅ 10種 | ✅ `manageRoles` で追加 | ✅ persona 全体 | ❌ | ❌ | — *(role 自体)* | コード + `<workspace>/config/roles/` |
+| **7. Bridge** | ❌ | ✅ 別プロセス起動 | ❌ | ❌ | ❌ | ❌ | bridge プロセス側 |
+
+凡例:
+- **標準提供**: `yarn install` 直後、追加設定なしで使えるか
+- **system prompt 注入**: `buildSystemPrompt` (server/agent/prompt.ts) が実行時に prompt に書き込むか
+- **LLM が tool 呼出**: LLM が `tools/call` で起動できるか (= プログラム連携可能か)
+- **MCP 経由公開**: in-process MCP サーバ `mulmoclaude` のリストに乗るか / 別 server-id で乗るか
+- **Role でゲート**: `role.availablePlugins` の対象になるか
+
+---
+
+## 3. 各機構の実装
+
+### 3.1 Built-in 静的 GUI plugin
+
+**何**: View/Preview Vue コンポーネント + サーバ tool 定義 + ワークスペースディレクトリを **co-locate** した拡張。
+canvas 上で結果を可視化したい場合の第一選択。
+
+**例**:
+- `src/plugins/accounting/` — 仕訳入力、損益、貸借
+- `src/plugins/presentHtml/` — その場 HTML プレビュー
+- `src/plugins/chart/`, `src/plugins/spreadsheet/`, `src/plugins/markdown/`
+- `src/plugins/manageRoles/`, `src/plugins/manageSkills/`, `src/plugins/manageSource/`
+
+**追加方法**:
+
+1. `src/plugins/<name>/` に以下を置く
+   - `meta.ts` — `definePluginMeta({ toolName, apiRoutesKey, apiRoutes, workspaceDirs?, staticChannels? })`
+   - `definition.ts` — MCP `ToolDefinition`
+   - `index.ts` — `PluginRegistration` (View/Preview を `wrapWithScope` でラップ)
+   - `View.vue` / `Preview.vue`
+2. **3 つのバレル**に登録:
+   - `src/plugins/metas.ts` の `BUILT_IN_PLUGIN_METAS` に append
+   - `src/plugins/index.ts` の `BUILT_IN_PLUGINS` に append
+   - `src/plugins/server.ts` の `BUILT_IN_SERVER_BINDINGS` に append
+3. ルートを `server/api/routes/<name>.ts` に追加 (plugin が endpoint を持つ場合)
+
+**ソース実装**:
+
+- 集約: `src/plugins/metas.ts` (`defineHostAggregate`)
+- 静的 binding 一覧: `src/plugins/server.ts` の `BUILT_IN_SERVER_BINDINGS`
+- LLM 露出: `server/agent/activeTools.ts:82-94` — `PLUGIN_DEFS` を `role.availablePlugins` でフィルタ
+- 外部 endpoint: `TOOL_ENDPOINTS[def.name]` (`server/agent/plugin-names.ts`)
+- Role ゲート: `server/agent/activeTools.ts:78` — `const allowed = new Set<string>(role.availablePlugins)`
+
+```ts
+// server/agent/activeTools.ts:82
+for (const def of PLUGIN_DEFS) {
+  if (!allowed.has(def.name) || seen.has(def.name)) continue;
+  out.push({
+    name: def.name,
+    fullName: fullNameFor(def.name),     // mcp__mulmoclaude__<name>
+    description: def.description,
+    prompt: promptFor(def),
+    endpoint: TOOL_ENDPOINTS[def.name],  // /api/<route>
+    source: "static-gui",
+  });
+}
+```
+
+---
+
+### 3.2 Built-in 静的 MCP-only tool
+
+**何**: GUI を持たず、サーバ側ロジックだけで完結する MCP tool。
+
+**例**: `server/agent/mcp-tools/notify.ts`, `server/agent/mcp-tools/x.ts`
+
+**ENV ゲート**: 例えば `notify` は通知システム有効時のみ、`x` は X (Twitter) credentials 設定時のみ。
+`isMcpToolEnabled` (`server/agent/mcp-tools/index.ts`) が ENV を見て出し入れする。
+
+**ソース実装**:
+
+- 一覧: `server/agent/mcp-tools/index.ts` の `mcpTools`
+- Gating: `isMcpToolEnabled(tool)` (同ファイル)
+- LLM 露出: `server/agent/activeTools.ts:95-106`
+
+```ts
+// server/agent/activeTools.ts:95
+for (const tool of mcpTools) {
+  const toolName = tool.definition.name;
+  if (!allowed.has(toolName) || seen.has(toolName) || !isMcpToolEnabled(tool)) continue;
+  out.push({
+    name: toolName,
+    fullName: fullNameFor(toolName),
+    description: tool.definition.description,
+    prompt: tool.prompt,
+    // 静的 MCP tool は内部 dispatch なので endpoint なし
+    source: "static-mcp",
+  });
+}
+```
+
+---
+
+### 3.3 Runtime plugin (preset / user-installed)
+
+**何**: npm パッケージとして配布される plugin。
+boot 時に `node_modules/<pkg>/` から `import()` して登録される。
+**全 role で常時 ON** — `availablePlugins` に書く必要なし。
+
+**例 (preset)**:
+- `@mulmoclaude/todo-plugin` — `manageTodoList`
+- `@mulmoclaude/spotify-plugin` — `manageSpotify` (OAuth + listening data + player + search)
+- `@mulmoclaude/recipe-book-plugin` — `manageRecipes`
+- `@mulmoclaude/debug-plugin` — `/debug` ページ
+
+**Preset と user-installed の違い**:
+- preset: `server/plugins/preset-list.ts` の `PRESET_PLUGINS` に列挙、`yarn install` で自動入る
+- user-installed: `<workspace>/plugins/` の workspace ledger 経由 (`/api/plugins/runtime/install`)
+
+**ソース実装**:
+
+- Preset 一覧: `server/plugins/preset-list.ts:29` — `PRESET_PLUGINS`
+- 登録: `server/plugins/runtime-registry.ts:43` — `registerRuntimePlugins`
+- 取得: `server/plugins/runtime-registry.ts:91` — `getRuntimePlugins`
+- LLM 露出 (常時 ON): `server/agent/activeTools.ts:108-125`
+- Dispatch route: `server/api/routes/runtime-plugin.ts:68` — `POST /api/plugins/runtime/:pkg/dispatch`
+
+```ts
+// server/agent/activeTools.ts:108 — runtime は role gate を通さず always-on
+for (const plugin of getRuntimePlugins()) {
+  const def = plugin.definition;
+  if (seen.has(def.name)) continue;
+  out.push({
+    name: def.name,
+    fullName: fullNameFor(def.name),
+    description: def.description,
+    prompt: promptFor(def),
+    endpoint: `/api/plugins/runtime/${encodeURIComponent(plugin.name)}/dispatch`,
+    source: "runtime",
+  });
+  seen.add(def.name);
+}
+```
+
+```ts
+// server/plugins/preset-list.ts:29
+export const PRESET_PLUGINS: readonly PresetPlugin[] = [
+  { packageName: "@mulmoclaude/todo-plugin" },
+  { packageName: "@mulmoclaude/spotify-plugin" },
+  { packageName: "@mulmoclaude/recipe-book-plugin" },
+  { packageName: "@mulmoclaude/debug-plugin" },
+];
+```
+
+---
+
+### 3.4 External MCP server (catalog / `mcp.json`)
+
+**何**: 別プロセスで動く MCP サーバ。Claude Agent SDK が `--mcp-config` で起動して直接喋る。
+mulmoclaude のコードは中継しない (= プラグイン契約は走らない)。
+
+**例**:
+- catalog 経由: GitHub, Linear, Spotify-MCP, YouTube transcript, Google Drive / Calendar / Gmail
+- 手動 `mcp.json`: 任意の stdio / HTTP MCP
+
+**設定先**: `<workspace>/config/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "github": { "type": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] },
+    "spotify": { "type": "http", "url": "http://localhost:8123" }
+  }
+}
+```
+
+**LLM が tool として見るとき**: `mcp__<serverId>__<toolName>` (例 `mcp__github__create_issue`)。
+in-process の `mcp__mulmoclaude__*` とは **別の MCP server** として並列に動く。
+
+**ソース実装**:
+
+- スペック型: `server/system/config.ts:122` — `McpConfigFile`
+- 読込: `server/system/config.ts:191` — `loadMcpConfig()`
+- agent 起動時の merge: `server/agent/index.ts:54-60`
+- Docker パス書き換え: `server/agent/config.ts:50-77` — `prepareUserHttpServer` / `prepareUserStdioServer`
+- 健全性チェック: `server/agent/mcpHealth.ts` — package validation, npm 解決テスト
+
+```ts
+// server/agent/index.ts:54
+const userMcpRaw = loadMcpConfig().mcpServers;
+const userServers = prepareUserServers(userMcpRaw, useDocker, workspacePath);
+const hasUserServers = Object.keys(userServers).length > 0;
+const hasMcp = activePlugins.length > 0 || hasUserServers;
+```
+
+**重要**: External MCP は **role でゲートされない**。`mcp.json` に書いた瞬間、全 role で利用可能になる。
+
+---
+
+### 3.5 Skill
+
+**何**: markdown で書かれた手順書。LLM の **tool ではない** — frontmatter + 本文を持ち、
+Claude Code SDK が「使うべき場面」を判断して system prompt の一部として LLM に提示する。
+
+**置き場**:
+- `~/.claude/skills/<name>/SKILL.md` — user scope (read-only from MulmoClaude)
+- `<workspace>/.claude/skills/<name>/SKILL.md` — project scope (writable via `manageSkills`)
+
+**Frontmatter 例**:
+
+```yaml
+---
+name: weekly-summary
+description: 毎週金曜に今週の wiki 編集をまとめる手順
+schedule: "interval 168h"
+---
+```
+
+**`schedule:` を持つ skill** は scheduler が自動実行する (`server/api/routes/scheduler.ts`)。
+
+**ソース実装**:
+
+- Discovery: `server/workspace/skills/index.ts` の `discoverSkills` — user + project を merge、project 優先
+- Route: `server/api/routes/skills.ts:57` — `GET /api/skills`
+- 編集 (project scope のみ): `saveProjectSkill` / `updateProjectSkill` / `deleteProjectSkill`
+- MulmoClaude UI: `src/plugins/manageSkills/View.vue` — CRUD UI
+
+```ts
+// server/api/routes/skills.ts:57
+const skills = await discoverSkills({ workspaceRoot: workspacePath });
+```
+
+**重要**:
+- skill は **tool ではない**ので、プログラム連携 (`tools/call` で他 plugin から呼ぶ) には使えない
+- 「次の朝」もファイルとして残るので、人間とAI で共同編集可能
+- `manageSkills` は単なる CRUD UI、skill 自体は Claude Code SDK 内蔵レイヤーが扱う
+
+---
+
+### 3.6 Role
+
+**何**: agent ペルソナ。`prompt` (system prompt 断片) + `availablePlugins` (静的 plugin gate) + `queries` (おすすめクエリ) のパッケージ。
+
+**例 (built-in)**: `general`, `office`, `guide`, `artist`, `tutor`, `storyteller`, `settings`, `accounting`, `cookingCoach`, `debug`
+
+**追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.md` を直接置く
+
+**ソース実装**:
+
+- Schema: `src/config/roles.ts:25-32` — `RoleSchema`
+- Built-in: `src/config/roles.ts:36` — `export const ROLES: Role[]`
+- Persona prompt 注入: `server/agent/prompt.ts:683` — `buildSystemPrompt`
+- Plugin gate: `server/agent/activeTools.ts:78` — `role.availablePlugins`
+
+```ts
+// src/config/roles.ts:25
+const RoleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  icon: z.string(),
+  prompt: z.string(),
+  availablePlugins: availablePluginsSchema,
+  queries: z.array(z.string()).optional(),
+  isDebugRole: z.boolean().optional(),
+});
+```
+
+**重要**:
+- role は **tool ではない** — chat 開始時に user が選び、その session 中は固定
+- runtime plugin は `availablePlugins` を **無視して常時 ON** (#3 で前述)
+- `isDebugRole: true` の role は production build で hide される (`debug` role)
+
+---
+
+### 3.7 Bridge (messenger 入口)
+
+**何**: messenger app から MulmoClaude に話しかけるための **別プロセス**。
+LLM の tool ではなく、ユーザのアクセス経路。
+
+**例 (14個)**:
+- 公式: `cli`, `telegram`, `discord`, `slack`, `line`, `whatsapp`, `matrix`, `irc`, `mastodon`, `bluesky`, `mattermost`, `zulip`, `messenger`, `google-chat`
+- 追加 (`packages/bridges/`): chatwork, email, line-works, nostr, rocketchat, signal, teams, twilio-sms, viber, webhook, xmpp
+
+**起動**:
+
+```bash
+yarn cli                              # 同一マシンで CLI bridge
+yarn telegram                         # Telegram bot bridge
+npx @mulmobridge/discord@latest       # 別マシンから接続
+```
+
+**ソース実装**:
+
+- 各 bridge: `packages/<name>/` (公式) または `packages/bridges/<name>/`
+- 接続プロトコル: `packages/protocol/` の socket.io イベント定義
+- サーバ側 endpoint: `server/agent/index.ts` の `runAgent` を bridge から socket.io 経由で叩く
+
+**重要**: bridge は MulmoClaude の **入り口** であって LLM の拡張ではない。
+LLM 視点では bridge は見えない (= ユーザメッセージは普通の chat 入力として届く)。
+
+---
+
+## 4. 全体像 — LLM がどう発見するか
+
+session 開始時の処理 (`server/agent/index.ts:39-99`):
+
+```
+        user が role を選択
+              │
+              ▼
+  ┌────────────────────────────────────────┐
+  │  getActiveToolDescriptors(role)        │  server/agent/activeTools.ts:77
+  │                                        │
+  │  - PLUGIN_DEFS (静的 GUI)  +  role gate │
+  │  - mcpTools     (静的 MCP) +  role gate │
+  │  - getRuntimePlugins()     (常時 ON)    │
+  └─────────┬──────────────────────────────┘
+            │
+            ├─→ buildMcpConfig() で in-process MCP サーバ「mulmoclaude」起動
+            │     server/agent/config.ts:176
+            │     (上記 tool 群が tools/list で公開される)
+            │
+            ├─→ buildSystemPrompt() で role.prompt + 各 tool の prompt を組成
+            │     server/agent/prompt.ts:683
+            │     ・skills は workspace から discover して prompt に注入
+            │     ・plugin の prompt セクションは buildPluginPromptSections (line 484)
+            │
+            ├─→ loadMcpConfig() で <workspace>/config/mcp.json を merge
+            │     server/agent/index.ts:54
+            │     (External MCP は別 server-id として並列に登録される)
+            │
+            └─→ Claude Agent SDK 起動 (--mcp-config + --allowedTools)
+                  ・LLM は in-process MCP + 各 external MCP を並行で見る
+                  ・tool 呼び出しは MCP 経由でルーティング
+```
+
+`getActiveToolDescriptors` がアプリ側 tool の **唯一の真実** であることが重要。
+過去に config.ts / prompt.ts / mcp-server.ts それぞれが独自フィルタを持っていて drift した経緯があり、現在は3つともこの descriptor リストを参照する (`server/agent/activeTools.ts:1-25` のコメント参照)。
+
+---
+
+## 5. どれを選ぶか — 判断ガイド
+
+| やりたいこと | 選ぶ機構 | 理由 |
+|---|---|---|
+| canvas で結果を見せたい / アプリ本体に組み込みたい | **#1 Built-in GUI plugin** | View/Preview ペアが用意されている |
+| GUI なしのサーバ専用 tool | **#2 Built-in MCP-only** | 軽量、ENV gating が効く |
+| 第三者配布 / コミュニティ拡張 | **#3 Runtime plugin** | npm install で増やせる |
+| 既存の SaaS / OS 側ツール | **#4 External MCP** | mulmoclaude を改修せずに済む、catalog 整備済み |
+| 業務手順 / プロンプトの再利用 | **#5 Skill** | 自然言語で書ける、`schedule:` で自動化可 |
+| persona + tool セットの切替 | **#6 Role** | session 開始時に固定、`isDebugRole` で隠せる |
+| 別アプリから AI に話しかけたい | **#7 Bridge** | 別プロセスで socket.io 接続 |
+
+---
+
+## 6. 関連ドキュメント
+
+- [`developer.md`](developer.md) — アーキ全体、ディレクトリ構造、開発フロー
+- [`plugin-runtime.md`](plugin-runtime.md) — runtime plugin の API 契約 (#3)
+- [`bridge-protocol.md`](bridge-protocol.md) — bridge の socket.io プロトコル (#7)
+- [`mulmobridge-guide.md`](mulmobridge-guide.md) — bridge の使い方ガイド
+- [`docs/tips/`](tips/) — preset の setup ガイド (Spotify, Bedrock 等)
+- `plans/done/feat-mcp-catalog-*.md` — MCP catalog の設計経緯 (#4)

--- a/docs/migrating-from-claude-code.md
+++ b/docs/migrating-from-claude-code.md
@@ -1,0 +1,443 @@
+# Claude Code → MulmoClaude 移行ガイド
+
+普段 Claude Code (CLI) を使っているユーザが MulmoClaude に移行するときの注意点と手順をまとめる。
+
+MulmoClaude は内部で Claude Code (Claude Agent SDK) を呼び出すアプリなので、**多くの資産はそのまま使い回せる**。
+ただし「ワークスペースの場所」と「設定ファイルの所在」が分かれているため、以下を意識して移行するとスムーズ。
+
+---
+
+## TL;DR — 何がそのまま使えて何が引っ越し必要か
+
+| Claude Code の資産 | MulmoClaude での扱い | アクション |
+|---|---|---|
+| `~/.claude/skills/<name>/SKILL.md` (user skills) | **そのまま読まれる** (read-only) | 何もしなくて良い |
+| `~/.claude/CLAUDE.md` (global instructions) | **読まれない** | 必要分を MulmoClaude の role / settings に移植 |
+| プロジェクト `CLAUDE.md` | **読まれない** | 同上、あるいは reference dirs から参照 |
+| `~/.claude/settings.json` (Claude Code 設定) | **読まれない** | 別物。`~/mulmoclaude/config/settings.json` に MulmoClaude 用設定を作る |
+| `~/.claude/.mcp.json` / プロジェクト `.mcp.json` | **読まれない** | `~/mulmoclaude/config/mcp.json` にコピー |
+| Claude Code の hooks | **使えない** | MulmoClaude にはユーザ設定の hook 機構なし |
+| プロジェクトの `*.md` ドキュメント | **読まれない (デフォルト)** | wiki にコピー / reference dirs マウント / Obsidian 共有のいずれか (後述) |
+| Claude Code の chat 履歴 | **引き継がれない** | 新しい session で開始 |
+
+**短くまとめると**:
+- skill = ✅ 移行不要
+- それ以外 = △ 何らかの形で MulmoClaude のワークスペースに置き直す
+
+---
+
+## 1. ワークスペースの違いを理解する
+
+Claude Code は基本的に **「現在のディレクトリ」と `~/.claude/` を見る** CLI。
+MulmoClaude は **「`~/mulmoclaude/`」を中心とする独立したアプリ**。
+
+### Claude Code の典型レイアウト
+
+```
+~/.claude/
+  CLAUDE.md             ← global instructions (system prompt 注入)
+  skills/               ← user skills (markdown)
+  settings.json         ← Claude Code 設定
+  .mcp.json             ← MCP サーバ設定 (グローバル)
+
+<your-project>/
+  CLAUDE.md             ← project instructions (system prompt 注入)
+  .claude/skills/       ← project skills
+  .mcp.json             ← project MCP
+```
+
+### MulmoClaude の典型レイアウト
+
+```
+~/mulmoclaude/                  ← 「ワークスペース」
+  config/
+    settings.json               ← MulmoClaude 設定
+    mcp.json                    ← MCP サーバ設定
+    roles/                      ← user-defined role (任意)
+    helps/                      ← role 別 help テキスト (任意)
+    workspace-dirs.json         ← user-defined カスタム dir (任意)
+    reference-dirs.json         ← 外部 read-only マウント先 (任意)
+  conversations/
+    chat/                       ← chat session ジャーナル (.jsonl)
+    memory/                     ← 長期メモリ (per-fact markdown)
+    summaries/                  ← 日次サマリー
+  data/
+    wiki/pages/                 ← wiki page (.md)
+    todos/  calendar/  contacts/  scheduler/  sources/
+    plugins/<encoded-pkg>/      ← runtime plugin が書く永続データ
+  artifacts/
+    documents/  html/  images/  charts/  spreadsheets/  stories/  news/
+  github/                       ← git clone 先
+  plugins/                      ← user-installed runtime plugin
+
+~/.claude/skills/               ← Claude Code と共有 (read-only)
+~/mulmoclaude/.claude/skills/   ← MulmoClaude project scope (writable)
+```
+
+ポイント:
+- **`~/mulmoclaude/` の場所はハードコード**で env override なし (`server/workspace/paths.ts:74`)。別の場所に置きたい場合は symlink で対応
+- **MulmoClaude は `~/.claude/skills/` を再利用** ([後述](#3-skill-の移行))
+- それ以外の Claude Code 設定は読み込まれない
+
+---
+
+## 2. 移行 — 全体の手順
+
+### Step 1: MulmoClaude を初回起動
+
+**前提**: Node.js 20.12+ と [Claude Code CLI](https://claude.ai/code) がインストール・認証済みであること。
+Claude Code を普段使っている人なら後者は満たしているはず。
+
+選択肢は2つ。**どちらでも `~/mulmoclaude/` ワークスペースは共有**される (= 後で乗り換えても資産そのまま)。
+
+#### A. リリース版を使う (簡単・安定)
+
+```bash
+npx mulmoclaude@latest
+```
+
+- インストール不要、最新公開版が自動で使われる
+- `~/mulmoclaude/` がない場合は自動で初期化
+- ブラウザが [http://localhost:5173](http://localhost:5173) で開けば OK
+- 普段使いはこちらで十分
+
+#### B. 開発版 (git clone) を使う (最新機能・実験中の新プラグイン)
+
+新しいプラグインや機能は **main ブランチに先にマージされ、リリースは数日〜数週遅れる**。
+最新を試したい / バグ報告したい / 自分でも plugin を作りたい場合は git clone する。
+
+```bash
+# 1. clone & install
+git clone git@github.com:receptron/mulmoclaude.git
+# (HTTPS なら) git clone https://github.com/receptron/mulmoclaude.git
+cd mulmoclaude
+yarn install
+
+# 2. (任意) Gemini API key — 画像生成に必要
+cp .env.example .env
+# .env を開いて GEMINI_API_KEY=... を埋める
+
+# 3. dev サーバ起動
+yarn dev
+```
+
+- ブラウザは `http://localhost:5173` (client) を開く。サーバは `http://localhost:3001`
+- 起動中もホットリロード — `src/` を編集すれば即反映
+- `~/mulmoclaude/` ワークスペースは A と共有 (= 並行運用しないこと、後述)
+
+##### 最新を取り込み続ける運用
+
+```bash
+cd ~/path/to/mulmoclaude
+git fetch origin
+git checkout main && git pull origin main
+yarn install              # 依存変動があれば
+yarn dev                  # 再起動
+```
+
+リリースが速いプロジェクトなので、週1〜数日に一度 `git pull` するだけで新機能 (plugin / role / MCP catalog 拡張) が降ってくる。
+
+##### Docker sandbox を使わない場合
+
+```bash
+DISABLE_SANDBOX=1 yarn dev
+```
+
+reference dirs の `:ro` 強制 (§4.3) など一部のセキュリティ機構が外れる代わりに、Docker なしで起動できる。
+
+##### UI 言語を固定したい場合
+
+```bash
+echo 'VITE_LOCALE=ja' >> .env    # ja / en / zh / ko / es / pt-BR / fr / de
+```
+
+ロケールはビルド時に焼き込まれるので、変更後は `yarn dev` を再起動。
+
+#### A と B の使い分け / 切替時の注意
+
+- **同じワークスペース (`~/mulmoclaude/`)** を共有するので、どちらで起動しても chat 履歴 / wiki / skill / 設定はそのまま見える
+- **同時起動はしない** — どちらも server をデフォルト port 3001 で立てるので衝突する
+- B (dev) では plugin の `@mulmoclaude/*` が yarn workspace の symlink で解決される (= ローカル `packages/*-plugin/src/` がそのまま動く)
+- リリース版 A に戻したい時は `cd ~/path/to/mulmoclaude && (server プロセス停止)` してから `npx mulmoclaude@latest` を別ディレクトリで叩けば OK
+
+詳しい開発フローは [`docs/developer.md`](developer.md) と [`README.md`](../README.md) を参照。
+
+### Step 2: skill を確認 (たいてい何もしなくて良い)
+
+`~/.claude/skills/` 配下に置いてあるユーザ skill は **そのまま MulmoClaude からも見える**。
+画面右上の「Skills」(または `/skills`) で一覧を確認。
+
+### Step 3: MCP サーバ設定を引き継ぐ (使っていれば)
+
+`~/.claude/.mcp.json` に MCP サーバ定義があれば、`~/mulmoclaude/config/mcp.json` にコピー。
+
+```bash
+mkdir -p ~/mulmoclaude/config
+cp ~/.claude/.mcp.json ~/mulmoclaude/config/mcp.json
+```
+
+形式は同じなので変換不要。再起動で反映される。
+
+詳細は [`docs/extension-mechanisms.md`](extension-mechanisms.md) の §3.4 (External MCP server)。
+
+### Step 4: ドキュメント / wiki の移行 (使っていれば)
+
+[§4 wiki / 既存ドキュメント移行](#4-wiki--既存ドキュメント移行) を参照。
+
+### Step 5: CLAUDE.md の指示を MulmoClaude 流に書き直す (任意)
+
+[§5 CLAUDE.md の扱い](#5-claude-md-の扱い) を参照。
+
+### Step 6: Role を選ぶ / 必要なら作る
+
+MulmoClaude は session 開始時に **role (ペルソナ)** を選ぶ仕組み。
+Claude Code には role の概念がないので、ここが一番違う。
+
+組み込み role: `general`, `office`, `guide`, `artist`, `tutor`, `storyteller`, `accounting`, `cookingCoach`, ...
+カスタム role は Settings → Roles から作成可能 (`manageRoles` プラグイン)。
+
+詳細は [`docs/extension-mechanisms.md`](extension-mechanisms.md) の §3.6 (Role)。
+
+---
+
+## 3. Skill の移行
+
+**結論**: 移行作業はほぼ不要。
+
+### 3.1 共有される場所
+
+MulmoClaude は **Claude Code と同じ `~/.claude/skills/` を読む** (`server/workspace/skills/paths.ts:18-19`)。
+
+```ts
+// server/workspace/skills/paths.ts
+export const USER_SKILLS_DIR = join(homedir(), ".claude", "skills");
+```
+
+つまり `~/.claude/skills/foo/SKILL.md` を Claude Code で書いたなら、MulmoClaude からもそのまま `foo` skill として見える。
+
+### 3.2 二段スコープ
+
+MulmoClaude の skill は2つのスコープを持ち、後者が前者を上書きする:
+
+| スコープ | パス | MulmoClaude での扱い |
+|---|---|---|
+| **user** | `~/.claude/skills/<name>/SKILL.md` | **read-only** — MulmoClaude UI から編集不可 |
+| **project** | `~/mulmoclaude/.claude/skills/<name>/SKILL.md` | **writable** — `manageSkills` プラグインで CRUD |
+
+同じ名前の skill が両方にある場合、**project が勝つ** (`server/workspace/skills/discovery.ts:109`)。
+
+### 3.3 Frontmatter の互換性
+
+MulmoClaude が認識する frontmatter は Claude Code と同じ:
+
+```yaml
+---
+name: weekly-summary
+description: 毎週金曜に今週の wiki 編集をまとめる
+schedule: "interval 168h"          # MulmoClaude 固有: scheduler で自動実行
+---
+```
+
+**MulmoClaude 固有**: `schedule:` フィールドを書くと内蔵 scheduler が指定間隔で skill を自動起動する (`server/api/routes/scheduler.ts`)。Claude Code には scheduler はないので、ここを書いても Claude Code 側では無視される (= 互換)。
+
+### 3.4 移行手順 (まとめ)
+
+1. **何もしない** — `~/.claude/skills/` の skill はそのまま使える
+2. **編集したい** skill が user scope にあるなら、**MulmoClaude の project scope にコピー**して編集する:
+   ```bash
+   mkdir -p ~/mulmoclaude/.claude/skills/myskill
+   cp ~/.claude/skills/myskill/SKILL.md ~/mulmoclaude/.claude/skills/myskill/
+   ```
+3. **自動実行したい**なら frontmatter に `schedule:` を追加 (interval / daily 形式)
+
+---
+
+## 4. Wiki / 既存ドキュメント移行
+
+これが移行の **一番の悩みどころ**。MulmoClaude は「ワークスペース内のファイルが第一級の状態」という設計なので、
+Claude Code 時代のドキュメント資産をどう取り込むかで利便性が変わる。
+
+選択肢は3つ。**用途で使い分ける**。
+
+### 4.1 戦略 A: wiki ディレクトリにコピーする (推奨・参照頻度高)
+
+**いつ**: 普段から AI に参照・更新させたい知識ベース、メモ、議事録、調査ノートなど。
+
+**手順**:
+
+```bash
+mkdir -p ~/mulmoclaude/data/wiki/pages
+# プロジェクトのドキュメントを wiki にコピー
+cp -r ~/projects/my-project/docs/*.md ~/mulmoclaude/data/wiki/pages/
+```
+
+**注意点**:
+- ファイル名はそのまま slug になる (例: `architecture.md` → wiki page `architecture`)
+- スラッグ規則は `lowercase-hyphen-separated` 推奨 (`server/workspace/wiki-pages/io.ts`)
+- `[[wiki link]]` 構文がそのまま機能する (cross-reference)
+- 既存の frontmatter (title, tags, created, updated) は維持される
+
+**MulmoClaude 側の取り扱い**:
+- 一覧: `data/wiki/index.md`
+- ログ: `data/wiki/log.md`
+- 履歴 (#763): 編集ごとに `data/wiki/.history/<slug>/` に snapshot
+
+### 4.2 戦略 B: Obsidian Vault と兼用する (推奨・モバイル / 並行編集したい)
+
+**いつ**: 既に Obsidian で管理しているドキュメント、または iPhone / iPad からも見たいもの。
+
+`~/mulmoclaude/` を Obsidian Vault として開けば、`data/wiki/pages/` の中身がそのまま Obsidian のグラフ・検索・タグ機能で扱える。コード変更不要・Obsidian プラグイン不要。
+
+詳細手順: [`docs/tips/obsidian.md`](tips/obsidian.md)
+
+### 4.3 戦略 C: reference dirs として外部からマウントする (read-only)
+
+**いつ**: ドキュメントは元の場所に置いたまま AI に参照だけさせたい (= Claude Code が `cd <project>` で読めていた感覚を残したい)。
+
+**手順**:
+
+1. Settings → Reference dirs を開く (または `~/mulmoclaude/config/reference-dirs.json` を直接編集):
+
+```json
+[
+  { "hostPath": "/Users/isamu/projects/my-project", "label": "My Project" },
+  { "hostPath": "/Users/isamu/Documents/notes", "label": "Notes" }
+]
+```
+
+2. MulmoClaude を再起動
+
+**特徴**:
+- Docker mode では **ファイルシステム強制 read-only マウント** (`:ro`) (`server/workspace/reference-dirs.ts:1-7`)
+- 非 Docker mode ではプロンプト指示ベースの read-only (緩い)
+- AI は内容を読めるが書き込めない
+- 機密ディレクトリ (`.ssh`, `.aws`, `/etc` 等) は自動でブロック
+
+**最大エントリ数**: 20 (`server/workspace/reference-dirs.ts:30`)
+
+### 4.4 どれを選ぶか
+
+| 条件 | 推奨 |
+|---|---|
+| AI に書き換えてほしい / 蓄積させたい | **A (wiki にコピー)** |
+| Obsidian / iPhone でも見たい | **B (Obsidian 兼用)** |
+| 元のディレクトリのまま動かしたくない | **C (reference dirs)** |
+| プロジェクトコードを AI に読ませたい | **C** (`~/projects/foo` をマウント) |
+
+混在も可能。Wiki は永続知識、reference dirs は「今このプロジェクトで作業」用、と分けると整理しやすい。
+
+---
+
+## 5. CLAUDE.md の扱い
+
+**MulmoClaude は `~/.claude/CLAUDE.md` もプロジェクト `CLAUDE.md` も自動では読まない**。
+理由: MulmoClaude は **role-based persona** で system prompt を組み立てる構造で、生の `CLAUDE.md` 注入は仕組み上の対応外 (`server/agent/prompt.ts:683` の `buildSystemPrompt` 参照)。
+
+### 移植先の選び方
+
+`CLAUDE.md` に書いてあった内容のタイプ別に:
+
+| 内容 | MulmoClaude での移植先 |
+|---|---|
+| 言語設定 / 口調 / 一般的な指示 | `~/mulmoclaude/config/settings.json` の `language` |
+| プロジェクト固有の文脈 / コーディング規約 | **新しい role** を作る (`manageRoles`) — その role の `prompt` に書く |
+| 「特定のファイルを参照」「特定ディレクトリを read」 | **reference dirs** (§4.3) で物理的にマウント |
+| 「このコマンドを使え」「このツールは使うな」 | role の `availablePlugins` でプラグインを絞る |
+| Skill 的な手順 | **skill に変換** (§3) |
+
+### Claude Code が CLAUDE.md でやっていた system prompt 拡張は MulmoClaude にはない
+
+MulmoClaude の system prompt は `server/agent/prompt.ts:683` の `buildSystemPrompt` で組み立てられる:
+
+- ベース ⊕ role.prompt ⊕ 各 plugin の prompt セクション ⊕ skill 一覧 ⊕ memory 抜粋 ⊕ workspace 概要
+
+ユーザが直接編集する経路は提供されていない (= role / skill / memory / settings の経由でのみ介入可能)。
+
+---
+
+## 6. Settings / hooks / chat 履歴
+
+### 6.1 Settings
+
+**互換性なし**。
+- Claude Code: `~/.claude/settings.json` (theme, model, hooks 等)
+- MulmoClaude: `~/mulmoclaude/config/settings.json` (`AppSettings` 型 — `server/system/config.ts:31`)
+
+スキーマが違うのでコピーは無意味。MulmoClaude の Settings 画面 (`/settings`) から設定する。
+
+### 6.2 Hooks (ユーザ設定の)
+
+**MulmoClaude にユーザ設定の hook 機構はない**。
+Claude Code で `PostToolUse` / `PreToolUse` hooks を使っていた場合、同等のことは:
+
+- 自動化なら **scheduler + skill** で代用
+- ファイル編集後の処理は **wiki-history** など内蔵機能が代行 (個別カスタム不可)
+
+### 6.3 Chat 履歴
+
+**移行されない**。
+- Claude Code: `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`
+- MulmoClaude: `~/mulmoclaude/conversations/chat/<sessionId>.jsonl` (新規)
+
+ただし MulmoClaude は内部で Claude Code を `--resume <sessionId>` で起動するので、**MulmoClaude の同じ session を継続**することは可能 (`server/agent/config.ts:249-250`)。
+別アプリ間で履歴を共有する経路はない。
+
+---
+
+## 7. よくあるハマりどころ
+
+### 7.1 「MCP サーバが認識されない」
+
+→ **`mcp.json` の場所**。`~/.claude/.mcp.json` ではなく `~/mulmoclaude/config/mcp.json`。
+ファイルがない場合は MCP なしで起動する (= デフォルト挙動)。
+
+### 7.2 「Claude Code で書いた skill が呼ばれない」
+
+→ skill の **`description`** をきちんと書く。Claude Code SDK は skill の description を見て使い場面を判断するので、空 / 曖昧だと選ばれにくい。frontmatter の `name:` と `description:` を必須項目として書く。
+
+### 7.3 「プロジェクトの CLAUDE.md が無視される」
+
+→ §5 を参照。設計上の仕様。**reference dirs マウント** + AI への明示的指示 (「`@my-project/CLAUDE.md` を参照して」) で代用するのが実務的。
+
+### 7.4 「サンドボックス警告で機能が動かない」
+
+→ Docker が起動していない可能性。`docker info` で確認。
+sandbox なしで動かすなら `DISABLE_SANDBOX=1 npx mulmoclaude`。
+ただし MCP の reference dirs `:ro` 強制は失われる。
+
+### 7.5 「~/mulmoclaude を別の場所に置きたい」
+
+→ env override なし (`server/workspace/paths.ts:74`)。
+**symlink** で対応:
+
+```bash
+mv ~/mulmoclaude /Volumes/External/mulmoclaude
+ln -s /Volumes/External/mulmoclaude ~/mulmoclaude
+```
+
+### 7.6 「Claude Code の sub-agent (Agent tool) は使える?」
+
+→ **使える**。MulmoClaude は内部で Claude Code を呼んでいるので、Claude Code の sub-agent / Task ツールはそのまま機能する。
+
+---
+
+## 8. 関連ドキュメント
+
+- [`docs/extension-mechanisms.md`](extension-mechanisms.md) — 7つの拡張機構の全体像
+- [`docs/developer.md`](developer.md) — アーキ全体
+- [`docs/tips/obsidian.md`](tips/obsidian.md) — Obsidian 連携 (戦略 B 詳細)
+- [`docs/memory.md`](memory.md) — メモリの仕組み (Claude Code の `~/.claude/projects/.../memory*` とは別物)
+- [`docs/sandbox-credentials.md`](sandbox-credentials.md) — Docker sandbox での認証情報まわり
+
+---
+
+## チェックリスト
+
+移行後に動作確認しておくと安心なポイント:
+
+- [ ] `~/.claude/skills/` の skill が MulmoClaude の Skills 一覧に出ている
+- [ ] よく使う MCP サーバが `~/mulmoclaude/config/mcp.json` にコピーされ、再起動後に MCP catalog 画面で接続済み表示される
+- [ ] 必要なドキュメントが §4 のいずれかの戦略で AI から見えている
+- [ ] 普段使う role を 1 つ決めた / カスタム role が必要なら作った
+- [ ] Docker sandbox が動いている (`docker info` 成功)
+- [ ] reference dirs マウントが反映されている (chat で「ホームディレクトリの `~/projects/foo/README.md` を見せて」で確認)


### PR DESCRIPTION
## Summary

- `docs/extension-mechanisms.md` — reference for the 7 extension surfaces (built-in plugin / MCP-only tool / runtime plugin / external MCP / skill / role / bridge) with a capability matrix and source-code citations
- `docs/migrating-from-claude-code.md` — migration guide for Claude Code CLI users; covers wiki/docs migration (3 strategies), skill migration (mostly free), and the non-inherited surfaces (CLAUDE.md, settings, hooks, sessions)
- Step 1 of the migration guide covers BOTH `npx mulmoclaude@latest` (release) and `git clone` + `yarn dev` (dev) launch flows

## Items to Confirm / Review

1. **Source citations accuracy** — Both docs cite specific `file:line` references. Quick spot-check welcome that the numbers still point at the right code (`server/agent/activeTools.ts:77,82,95,108`, `server/workspace/skills/paths.ts:18-19`, `server/workspace/paths.ts:74`, `server/system/config.ts:31,191`, `server/agent/prompt.ts:484,683`, etc.). I verified them at write time but main moves fast.
2. **Capability matrix wording** — In §2 of extension-mechanisms, the "Role でゲート" column says "❌ 常時 ON" for runtime plugins; this matches the current `activeTools.ts:108-125` behavior but if there's a planned change to gate runtime plugins by role, that row needs updating.
3. **Migration guide language** — The guide is in Japanese to match the actual users asking these questions. Existing tips/ docs mix EN and JA; happy to add an EN parallel if there's a convention I missed.

## User Prompt

> runtime pluginってどうやってllmが発見して呼びだす？ runtime plugin, mcp, skill, role など、様々な方法を一度まとめてほしい。mulmo claudeで使っているもの全てを。

> document化するのと、標準、設定可能、system prompt, tools, mcpなどの機能的な有無をmatrixでテーブル化して。ソースでどう扱われているかもdocumentでうめこんで。

> documentを書いてほしい。普通にclaude codeを使っていた人がmulmo claudeに移行するときにきをつけること、手順。人に聞かれたポイントとしては、wikiや既存のドキュメントの移行方法と、skillの移行方法

> MulmoClaude を初回起動 で、開発版を使うと最新機能が使えるとしてgitからの説明も追加しよう

## Implementation

### `docs/extension-mechanisms.md` (~440 lines)

- §1 quick intro (7 mechanisms × type × example)
- §2 capability matrix (7×7 — standard/configurable/system-prompt/tools/MCP/role-gate/persistence)
- §3.1〜3.7 deep dive per mechanism — example, how to add, source citations with code excerpts
- §4 discovery flow ASCII diagram showing how `getActiveToolDescriptors` unifies the three plugin sources
- §5 decision guide ("which mechanism for which job")
- §6 cross-references to existing docs (developer.md, plugin-runtime.md, bridge-protocol.md, etc.)

### `docs/migrating-from-claude-code.md` (~400 lines)

- TL;DR table — what carries over vs needs migration
- §1 workspace layout comparison (Claude Code `~/.claude/` + cwd vs MulmoClaude `~/mulmoclaude/`)
- §2 6-step migration procedure
- §3 skill migration — `~/.claude/skills/` is shared read-only, project scope is writable, frontmatter compatible (with `schedule:` extension)
- §4 wiki/docs migration — 3 strategies (wiki copy / Obsidian shared vault / reference-dirs `:ro` mount) with usage selector table
- §5 CLAUDE.md handling (not auto-loaded; mapping to roles / skills / settings)
- §6 settings / hooks / chat-history compatibility (none)
- §7 common pitfalls (mcp.json location, skill description importance, workspace location override via symlink)
- §8 cross-refs + verification checklist

Step 1 was extended after a follow-up request to cover both `npx mulmoclaude@latest` (release, simple) and `git clone` + `yarn dev` (dev, latest-features), with a `git pull` continuous-update flow and DISABLE_SANDBOX / VITE_LOCALE notes. Includes A/B switching caveat (port 3001 conflict).

## Test plan

- [x] Markdown structure: tables + cross-doc links render in GitHub preview
- [x] Source citations spot-checked at write time (see Items to Confirm #1)
- [x] No code changes — docs-only PR