### PR TITLE
fix: address bot review on #1196 + #1198 (notifier hardening + magic-string centralisation)

### DIFF
--- a/packages/debug-plugin/src/View.vue
+++ b/packages/debug-plugin/src/View.vue
@@ -24,6 +24,13 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRuntime } from "gui-chat-protocol/vue";
 
+// Contract pinned to the host's `HOST_EVENTS.routeChange` in
+// `src/config/hostEvents.ts`. Runtime plugins can't import host
+// internals, so the literal is duplicated here — but only once per
+// package, behind a name that's greppable from both sides. If the
+// host renames the event, this constant has to move in lockstep.
+const HOST_ROUTE_CHANGE_EVENT = "mulmoclaude:routechange";
+
 interface PublishArgs {
   kind: "publish";
   severity: "info" | "nudge" | "urgent";
@@ -110,13 +117,13 @@ function onRouteChange(): void {
 
 onMounted(() => {
   readUrl();
-  window.addEventListener("mulmoclaude:routechange", onRouteChange);
+  window.addEventListener(HOST_ROUTE_CHANGE_EVENT, onRouteChange);
   window.addEventListener("popstate", onRouteChange);
   void maybeAutoClear();
 });
 
 onUnmounted(() => {
-  window.removeEventListener("mulmoclaude:routechange", onRouteChange);
+  window.removeEventListener(HOST_ROUTE_CHANGE_EVENT, onRouteChange);
   window.removeEventListener("popstate", onRouteChange);
 });
 

--- a/server/api/routes/notifier.ts
+++ b/server/api/routes/notifier.ts
@@ -81,11 +81,17 @@ notifierRouter.post(API_ROUTES.notifier.dispatch, async (req: Request<object, Di
         res.status(400).json({ error: `unknown action: ${typeof action === "string" ? action : "<missing>"}` });
     }
   } catch (err) {
+    // Detailed error stays in the server log for triage; the HTTP
+    // response gets an opaque message so a parser-thrown filesystem
+    // path / internal stack frame can't leak to the client. Echoing
+    // `String(err)` would have given e.g. `Error: ENOENT, open
+    // '/Users/<...>/active.json'` to anyone holding the bearer token
+    // (CodeRabbit review on PR #1196).
     log.error("notifier-route", "dispatch failed", {
       action: typeof action === "string" ? action : "<unknown>",
       error: String(err),
     });
-    res.status(500).json({ error: String(err) });
+    res.status(500).json({ error: "internal error" });
   }
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -682,19 +682,14 @@ function maybeForceChatIndexBackfill(): void {
     .catch(logBackgroundError("chat-index", "forced startup backfill failed"));
 }
 
-async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: number): Promise<void> {
+async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: number, pubsub: IPubSub): Promise<void> {
   log.info("server", "listening", { port });
 
-  // --- Pub/Sub ---
-  const pubsub = createPubSub(httpServer);
-
-  // --- Notifier engine ---
-  // Routes mounted at module-load above; engine emit is wired here
-  // once pubsub exists. Mutating APIs called between mount and this
-  // call would persist state but log a warning instead of emitting.
-  initNotifier({
-    publish: (channel, payload) => pubsub.publish(channel, payload),
-  });
+  // The notifier engine + its pubsub are now wired in the listen
+  // callback (see PR-#1196 follow-up) so requests arriving before
+  // this function runs hit a fully-initialized engine. The pubsub
+  // is forwarded in here so the rest of `startRuntimeServices` can
+  // share the same instance.
 
   // --- Legacy adapters (bridge + macOS Reminder push) ---
   // Subscribe in-process to the engine so any `notifier.publish` —
@@ -980,6 +975,20 @@ process.on("SIGTERM", () => {
   // workspace file API is a credential-theft risk. Personal dev
   // tool — localhost is the right default.
   const httpServer = app.listen(port, "127.0.0.1", async () => {
+    // Initialize the notifier engine synchronously, before any await
+    // in this callback. The HTTP listener is already accepting
+    // connections by the time this callback fires, so any awaited
+    // I/O below (e.g. the `.server-port` write) opens a window where
+    // `/api/notifier` requests would race against the engine's
+    // `deps`-still-null state and silently drop the pub/sub event
+    // (CodeRabbit review on PR #1196). Both `createPubSub` and
+    // `initNotifier` are sync, so wiring them up here costs nothing
+    // and closes the window.
+    const earlyPubsub = createPubSub(httpServer);
+    initNotifier({
+      publish: (channel, payload) => earlyPubsub.publish(channel, payload),
+    });
+
     // Publish the actually-bound port so the hook script can
     // address us — the requested PORT may have walked forward
     // off a busy default. Use writeFile (not writeFileAtomic)
@@ -993,7 +1002,7 @@ process.on("SIGTERM", () => {
         error: String(err),
       });
     }
-    startRuntimeServices(httpServer, port).catch((err: unknown) => {
+    startRuntimeServices(httpServer, port, earlyPubsub).catch((err: unknown) => {
       log.error("server", "startRuntimeServices failed", { error: String(err) });
     });
   });

--- a/server/notifier/store.ts
+++ b/server/notifier/store.ts
@@ -24,7 +24,17 @@ export async function loadActive(filePath: string): Promise<NotifierFile> {
     throw err;
   }
   const parsed: unknown = JSON.parse(text);
-  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed) || typeof (parsed as { entries: unknown }).entries !== "object") {
+  // `typeof null === "object"` and `Array.isArray([])` is also true,
+  // so the previous check `typeof entries !== "object"` let
+  // `{ entries: null }` and `{ entries: [] }` through, which then
+  // crashed downstream `engine.get` / `list*` mutations. Reject both
+  // shapes here at load time so the failure surfaces as a clear
+  // "malformed file" error (CodeRabbit review on PR #1196).
+  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed)) {
+    throw new Error(`notifier: malformed active.json at ${filePath}`);
+  }
+  const { entries } = parsed as { entries: unknown };
+  if (typeof entries !== "object" || entries === null || Array.isArray(entries)) {
     throw new Error(`notifier: malformed active.json at ${filePath}`);
   }
   return parsed as NotifierFile;

--- a/src/config/hostEvents.ts
+++ b/src/config/hostEvents.ts
@@ -1,0 +1,17 @@
+// Cross-surface DOM CustomEvent names the host emits for plugin /
+// extension consumers. These ride the global `window` so runtime-
+// loaded plugins (which can't import vue-router or other host
+// internals without extra plumbing) can subscribe via
+// `addEventListener` without bringing in the whole host bundle.
+//
+// Centralised here as `as const` so the event-string contract is a
+// single greppable value — host emitter and plugin subscriber can't
+// drift independently (CodeRabbit review on PR #1198).
+
+export const HOST_EVENTS = {
+  /** Fired by the SPA router on every commit (including query-only
+   *  changes that don't remount the matched component). Detail
+   *  shape: `{ fullPath: string }`. Currently consumed by
+   *  `@mulmoclaude/debug-plugin` to re-read URL query params. */
+  routeChange: "mulmoclaude:routechange",
+} as const;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -15,6 +15,7 @@
 import { defineComponent, h } from "vue";
 import { createRouter, createWebHistory, type RouteRecordRaw } from "vue-router";
 import { PAGE_ROUTES, type PageRouteName } from "./pageRoutes";
+import { HOST_EVENTS } from "../config/hostEvents";
 
 // Re-export the constants so existing `import { PAGE_ROUTES } from
 // "./router"` call sites keep working. The actual definitions live
@@ -85,9 +86,11 @@ const router = createRouter({
 //
 // Subscriber: `@mulmoclaude/debug-plugin` View, which uses it to
 // re-evaluate `?mode=` and `?notificationId=` params after the host
-// notifier popup pushes a new URL.
+// notifier popup pushes a new URL. The event name lives in
+// `src/config/hostEvents.ts` so the contract isn't a magic string
+// duplicated between host and plugin.
 router.afterEach((toRoute) => {
-  window.dispatchEvent(new CustomEvent("mulmoclaude:routechange", { detail: { fullPath: toRoute.fullPath } }));
+  window.dispatchEvent(new CustomEvent(HOST_EVENTS.routeChange, { detail: { fullPath: toRoute.fullPath } }));
 });
 
 export default router;


### PR DESCRIPTION
## Summary

Follow-up to merged PRs **#1196** (notifier engine) and **#1198** (debug plugin route-change subscriber) addressing bot review findings that landed after merge.

## Items to Confirm / Review

- **`server/index.ts` init order change** — `createPubSub` + `initNotifier` now run synchronously inside the `app.listen` callback before any `await`. Risk: any later code that needs to mutate the same pubsub must use the instance forwarded into `startRuntimeServices`, not call `createPubSub` again. I checked — no other call site creates its own pubsub.
- **`server/notifier/store.ts` validation** — `{ entries: null }` and `{ entries: [] }` now throw at load time. Existing fresh-workspace path (`ENOENT` → empty store) is preserved.
- **`packages/debug-plugin` constant** — Plugin can't import from `src/config/`, so the literal still appears once in the plugin (as a named constant with a back-reference comment). Renaming the event still requires touching two places — I think this is the right trade-off given the runtime-plugin sandbox boundary, but flagging it.

## User Prompt

> /pr-quality-sweep ４８時間
> planの修正は不要。全部、修正されてないか確認のうえ、全部進めて。

(Verify each pr-quality-sweep finding from the last 48h against current HEAD, fix everything that's still real.)

## Items fixed

| PR | File:line | Bot finding | Fix |
|---|---|---|---|
| #1196 | `server/api/routes/notifier.ts:94` | CodeRabbit: `error: String(err)` leaks parser-thrown filesystem paths to clients | Replaced with opaque `"internal error"`; detail kept in `log.error` for triage |
| #1196 | `server/notifier/store.ts:loadActive` | CodeRabbit: `typeof entries !== "object"` lets `entries: null` and `entries: []` through | Reject both shapes; fail fast with "malformed file" |
| #1196 | `server/index.ts` (init order) | CodeRabbit: notifier engine init runs in `startRuntimeServices` after `await writeFile`, but listener already accepting requests → race | Moved `createPubSub` + `initNotifier` into the sync portion of the listen callback; pubsub forwarded into `startRuntimeServices` |
| #1198 | `src/router/index.ts:90`, `packages/debug-plugin/src/View.vue:113,119` | CodeRabbit: `"mulmoclaude:routechange"` magic string duplicated host↔plugin | New `src/config/hostEvents.ts` exporting `HOST_EVENTS.routeChange`; plugin keeps a local mirror constant with cross-reference comment (sandbox can't import host internals) |

## Verification

- `yarn format` ✅
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` ✅ (eval warnings in `spreadsheet/engine` are pre-existing)
- `yarn test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition preventing early route-change notifications from being processed
  * Enhanced configuration file validation to prevent application crashes
  * Improved error responses to prevent exposure of internal system details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->