### PR TITLE
fix: address bot review on #1186 + #1172 (env type + translate refactor)

### DIFF
--- a/server/services/translation/llm.ts
+++ b/server/services/translation/llm.ts
@@ -5,7 +5,7 @@
 //
 // Patterned after `server/workspace/chat-index/summarizer.ts`.
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { tmpdir } from "node:os";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -81,52 +81,55 @@ function buildArgs(promptInput: string): string[] {
   ];
 }
 
+interface SpawnState {
+  stdout: string;
+  stderr: string;
+  settled: boolean;
+}
+
+type RejectFn = (err: Error) => void;
+type ResolveFn = (value: string) => void;
+
+function onTimeout(state: SpawnState, proc: ChildProcess, reject: RejectFn, timeoutMs: number): void {
+  if (state.settled) return;
+  state.settled = true;
+  proc.kill("SIGKILL");
+  reject(new Error(`[translation] claude translate timed out after ${timeoutMs}ms`));
+}
+
+function onError(state: SpawnState, timer: ReturnType<typeof setTimeout>, err: Error & { code?: string }, reject: RejectFn): void {
+  if (state.settled) return;
+  state.settled = true;
+  clearTimeout(timer);
+  reject(err.code === "ENOENT" ? new ClaudeCliNotFoundError() : err);
+}
+
+function onClose(state: SpawnState, timer: ReturnType<typeof setTimeout>, code: number | null, resolve: ResolveFn, reject: RejectFn): void {
+  if (state.settled) return;
+  state.settled = true;
+  clearTimeout(timer);
+  if (code !== 0) {
+    reject(new Error(formatSpawnFailure("[translation]", code, state.stdout, state.stderr)));
+    return;
+  }
+  resolve(state.stdout);
+}
+
 function spawnClaudeTranslate(promptInput: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", buildArgs(promptInput), {
-      cwd: tmpdir(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      proc.kill("SIGKILL");
-      reject(new Error(`[translation] claude translate timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
+    const proc = spawn("claude", buildArgs(promptInput), { cwd: tmpdir(), stdio: ["ignore", "pipe", "pipe"] });
+    const state: SpawnState = { stdout: "", stderr: "", settled: false };
+    const timer = setTimeout(() => onTimeout(state, proc, reject, timeoutMs), timeoutMs);
     proc.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
+      state.stdout += chunk.toString();
     });
     proc.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
+      state.stderr += chunk.toString();
     });
-    proc.on("error", (err: Error & { code?: string }) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (err.code === "ENOENT") {
-        reject(new ClaudeCliNotFoundError());
-      } else {
-        reject(err);
-      }
-    });
-    proc.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(formatSpawnFailure("[translation]", code, stdout, stderr)));
-        return;
-      }
-      resolve(stdout);
-    });
+    proc.on("error", (err: Error & { code?: string }) => onError(state, timer, err, reject));
+    proc.on("close", (code) => onClose(state, timer, code, resolve, reject));
   });
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,8 +3,11 @@
 interface ImportMetaEnv {
   readonly VITE_LOCALE?: "en" | "ja";
   // Set `VITE_DEV_MODE=1` in `.env` to surface `isDebugRole` roles
-  // in the dropdown. Anything else (including unset) hides them.
-  readonly VITE_DEV_MODE?: "1" | "0";
+  // in the dropdown. Anything else (including unset, "0", "true",
+  // "yes") hides them — the consumer side does an exact `=== "1"`
+  // check so the type stays open to whatever string Vite hands
+  // through, instead of pretending only `"1" | "0"` are reachable.
+  readonly VITE_DEV_MODE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Follow-up to merged PRs **#1186** (debug-mode gate) and **#1172** (translation engine) addressing bot review findings that landed after merge.

## Items to Confirm / Review

- **`VITE_DEV_MODE` type relaxation** — All three consumers (`PluginLauncher.vue`, `RoleSelector.vue`, the App.vue mention) already do `=== "1"` exact matching, so loosening the type to `string` doesn't change runtime behaviour. The narrow `"1" | "0"` was the bug — it lied about which values can actually arrive from Vite env injection.
- **`spawnClaudeTranslate` refactor** — purely structural, no behaviour change. `state.settled` is mutated by whichever handler fires first; the other handlers no-op. Shape mirrors `server/system/credentials.ts`'s timer pattern.

## User Prompt

> /pr-quality-sweep ４８時間
> planの修正は不要。全部、修正されてないか確認のうえ、全部進めて。

(Verify each pr-quality-sweep finding from the last 48h against current HEAD, fix everything that's still real.)

## Items fixed

| PR | File | Bot finding | Fix |
|---|---|---|---|
| #1186 | `src/vite-env.d.ts:7` | CodeRabbit: `VITE_DEV_MODE?: "1" \| "0"` lies — Vite env vars are always `string` and any value other than exactly `"1"` already gets treated as off | Widened to `string`; comment now lists examples (`"0"`, `"true"`, `"yes"` all hide) |
| #1172 | `server/services/translation/llm.ts` | Sourcery: `spawnClaudeTranslate` is 48 lines (over CLAUDE.md's 20-line guideline); the `if (settled) return; settled = true; clearTimeout(timer)` ritual is duplicated three times | Extracted three event handlers + `SpawnState` record; main Promise body now ~12 lines |

## Verification

- `yarn format` ✅
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)