### PR TITLE
fix: address bot findings on #1191 + #1201 + #1176 (sweep re-check)

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -130,6 +130,11 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
   // quiet (no 501s, no [mock] unhandled warnings); specs that do care
   // override with a more specific page.route() before mockAllApis.
   await page.route(urlEndsWith("/api/notifier"), (route) => {
+    // Server only accepts POST. A non-POST request reaching this
+    // mock means a caller is using the wrong verb — let the request
+    // fall through so the real failure surfaces in the test instead
+    // of being papered over by the mock returning 200.
+    if (route.request().method() !== "POST") return route.fallback();
     const action = parseDispatchAction(route.request().postData());
     if (action === "listHistory") return route.fulfill({ json: { history: [] } });
     if (action === "clear" || action === "cancel") return route.fulfill({ json: { ok: true } });

--- a/packages/spotify-plugin/src/client.ts
+++ b/packages/spotify-plugin/src/client.ts
@@ -165,9 +165,14 @@ async function refreshTokens(
     runtime.log.warn("refresh failed", { status: response.status, body: body.slice(0, 200) });
     // 4xx ⇒ Spotify rejected the refresh token (revoked, malformed,
     // client_id mismatch). 5xx ⇒ Spotify is having an outage; the
-    // credential may still be valid. Don't conflate the two.
-    const kind = response.status >= 500 ? "transient_error" : "auth_expired";
-    return { ok: false, error: { kind, detail: `refresh returned ${response.status}` } };
+    // credential may still be valid. Don't conflate the two — but
+    // 408 (Request Timeout) and 429 (Too Many Requests) are also
+    // transient: the credential wasn't actually checked, so forcing
+    // a re-auth would be wrong.
+    const status = response.status;
+    const isTransient = status >= 500 || status === 408 || status === 429;
+    const kind = isTransient ? "transient_error" : "auth_expired";
+    return { ok: false, error: { kind, detail: `refresh returned ${status}` } };
   }
   let parsed: RawTokenResponse;
   try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1003,7 +1003,16 @@ process.on("SIGTERM", () => {
       });
     }
     startRuntimeServices(httpServer, port, earlyPubsub).catch((err: unknown) => {
-      log.error("server", "startRuntimeServices failed", { error: String(err) });
+      // Fail fast — a half-initialized runtime is worse than a
+      // crashed one. Routes mounted at module load already accept
+      // requests, so without this exit the app would respond with a
+      // confusing mix of 200s (from already-mounted routes) and
+      // 500s (from the agent / scheduler / plugins that never came
+      // up). Exit so the supervisor (Electron / launcher) can show
+      // a real error instead of the user staring at a half-broken
+      // UI. (CodeRabbit review on PR #1201.)
+      log.error("server", "startRuntimeServices failed — exiting", { error: String(err) });
+      httpServer.close(() => process.exit(1));
     });
   });
 })();

--- a/server/index.ts
+++ b/server/index.ts
@@ -83,7 +83,7 @@ import { EVENT_TYPES } from "../src/types/events.js";
 import { SESSION_ORIGINS } from "../src/types/session.js";
 import { buildHtmlPreviewCsp } from "../src/utils/html/previewCsp.js";
 import { readAndInjectHtmlArtifact } from "./utils/html/htmlArtifactSplicer.js";
-import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS } from "./utils/time.js";
+import { ONE_SECOND_MS, ONE_MINUTE_MS, ONE_HOUR_MS, STARTUP_FAILURE_FORCE_EXIT_MS } from "./utils/time.js";
 import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "./utils/port.mjs";
 import { SCHEDULE_TYPES, MISSED_RUN_POLICIES } from "@receptron/task-scheduler";
 
@@ -1011,8 +1011,17 @@ process.on("SIGTERM", () => {
       // up). Exit so the supervisor (Electron / launcher) can show
       // a real error instead of the user staring at a half-broken
       // UI. (CodeRabbit review on PR #1201.)
+      //
+      // `httpServer.close(cb)` only fires `cb` once every existing
+      // connection has drained. SSE streams + WebSocket upgrades
+      // can hold connections open indefinitely, so the graceful
+      // path alone isn't a fail-fast guarantee. Schedule a hard
+      // exit on a short timer as the floor; whichever fires first
+      // wins. `.unref()` keeps the timer from blocking the event
+      // loop on its own. (Codex review on PR #1226.)
       log.error("server", "startRuntimeServices failed — exiting", { error: String(err) });
       httpServer.close(() => process.exit(1));
+      setTimeout(() => process.exit(1), STARTUP_FAILURE_FORCE_EXIT_MS).unref();
     });
   });
 })();

--- a/server/utils/time.ts
+++ b/server/utils/time.ts
@@ -29,6 +29,13 @@ export const SUBPROCESS_PROBE_TIMEOUT_MS = 5 * ONE_SECOND_MS;
  *  the burst into one publish. */
 export const DEV_PLUGIN_WATCH_DEBOUNCE_MS = 300;
 
+/** Hard cap on how long the startup-failure path waits for
+ *  `httpServer.close()` to drain in-flight connections before
+ *  forcing `process.exit(1)`. SSE streams + WebSocket upgrades hold
+ *  connections open indefinitely, so the graceful close alone isn't
+ *  a fail-fast guarantee. */
+export const STARTUP_FAILURE_FORCE_EXIT_MS = 5 * ONE_SECOND_MS;
+
 /** Heavy subprocess work (libreoffice conversion, etc.) */
 export const SUBPROCESS_WORK_TIMEOUT_MS = ONE_MINUTE_MS;
 

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -184,6 +184,15 @@ function performPrimaryAction(entry: NotifierEntry): void {
   if ((entry.lifecycle ?? "fyi") === "fyi") void clear(entry.id);
 }
 
+// True when activating the row (click, Enter, Space) does anything
+// useful — either clears a fyi notification or navigates to the
+// action's target. Action notifications without a `navigateTarget`
+// fall through both branches, so their row is not a button and
+// should not advertise as one to assistive technology.
+function hasPrimaryAction(entry: NotifierEntry): boolean {
+  return Boolean(entry.navigateTarget) || (entry.lifecycle ?? "fyi") === "fyi";
+}
+
 // Body click on an Active row. Stop propagation so the outer <li>'s
 // fyi-clear handler doesn't double-fire when a fyi click already
 // lands here (matches the debug popup's two-layer click handling).
@@ -273,13 +282,13 @@ async function clearAllFyi(): Promise<void> {
             :key="entry.id"
             :data-testid="`notification-item-${entry.id}`"
             :data-lifecycle="entry.lifecycle ?? 'fyi'"
-            role="button"
-            tabindex="0"
-            :aria-label="localizeTitle(entry)"
+            :role="hasPrimaryAction(entry) ? 'button' : undefined"
+            :tabindex="hasPrimaryAction(entry) ? 0 : undefined"
+            :aria-label="hasPrimaryAction(entry) ? localizeTitle(entry) : undefined"
             :class="['px-3 py-2 group focus:bg-gray-100 focus:outline-none', (entry.lifecycle ?? 'fyi') === 'fyi' ? 'cursor-pointer hover:bg-gray-50' : '']"
             @click="onActiveRowClick(entry)"
-            @keydown.enter.prevent.self="(e) => !e.repeat && performPrimaryAction(entry)"
-            @keydown.space.prevent.self="(e) => !e.repeat && performPrimaryAction(entry)"
+            @keydown.enter.prevent.self="(e) => hasPrimaryAction(entry) && !e.repeat && performPrimaryAction(entry)"
+            @keydown.space.prevent.self="(e) => hasPrimaryAction(entry) && !e.repeat && performPrimaryAction(entry)"
           >
             <div class="flex items-start gap-2">
               <span

--- a/src/utils/agent/toolCalls.ts
+++ b/src/utils/agent/toolCalls.ts
@@ -8,6 +8,7 @@
 import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
 import type { SseToolCall } from "../../types/sse";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import { TOOL_NAMES } from "../../config/toolNames";
 
 // Convert an SSE tool_call event into a ToolCallHistoryItem ready
 // to push onto a session's toolCallHistory. Pure.
@@ -56,7 +57,7 @@ export function findPendingToolCall(history: readonly ToolCallHistoryItem[], too
 // Pure — returns a boolean for the caller to act on.
 export function shouldSelectAssistantText(toolResults: readonly ToolResultComplete[], runStartIndex: number): boolean {
   for (let i = runStartIndex; i < toolResults.length; i++) {
-    if (toolResults[i].toolName !== "text-response") return false;
+    if (toolResults[i].toolName !== TOOL_NAMES.textResponse) return false;
   }
   return true;
 }

--- a/test/plugins/spotify/test_client.ts
+++ b/test/plugins/spotify/test_client.ts
@@ -179,6 +179,32 @@ describe("spotifyApi — refresh-path classification (auth_expired vs transient_
     assert.match(result.error.detail, /503/);
   });
 
+  it("classifies a 408 Request Timeout on refresh as transient_error", async () => {
+    // The refresh request never reached Spotify (proxy / network
+    // timeout) — credential wasn't actually checked, so forcing
+    // re-auth would be wrong. (Codex review on PR #1226.)
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), new Response("", { status: 408 })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
+    assert.match(result.error.detail, /408/);
+  });
+
+  it("classifies a 429 Too Many Requests on refresh as transient_error", async () => {
+    // Spotify's rate limiter — credential is fine, the caller just
+    // needs to back off. Forcing re-auth would silently lose the
+    // working refresh token.
+    const handle = makeFakeRuntime({ responses: [new Response("", { status: 401 }), new Response("", { status: 429 })] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.kind, "transient_error");
+    assert.match(result.error.detail, /429/);
+  });
+
   it("classifies a non-JSON 2xx body from token endpoint as transient_error", async () => {
     // Some proxies / middlewares return HTML on their own 2xx page.
     const htmlResponse = new Response("<html>maintenance</html>", { status: 200, headers: { "content-type": "text/html" } });


### PR DESCRIPTION
## Summary

Second-pass `/pr-quality-sweep 48h` re-check found 6 additional unaddressed bot findings the first sweep missed (the original sweep used a smaller scope). All 6 verified as still real in main HEAD before fixing.

## Items to Confirm / Review

- **`server/index.ts` fail-fast on startRuntimeServices error** — this is the biggest behaviour change. Previously a startup failure logged and continued; now it kills the process with `httpServer.close(() => process.exit(1))`. Rationale: the HTTP listener accepts requests as soon as `app.listen` fires, but plugins / agent / scheduler all live in `startRuntimeServices`. A failure there left routes mounted at module-load returning 200 while every dependent route returned 500 — an unrecoverable, confusing state. Confirm this matches the intended supervisor behaviour (Electron / launcher should treat exit-1 as "show error and prompt restart").

- **`hasPrimaryAction` semantics in NotificationBell** — true when entry has `navigateTarget` OR `lifecycle === "fyi"`. An action notification without `navigateTarget` is now a static row (no `role="button"`, no keyboard focus). The `×` cancel button still works. Verify this matches the intended UX — a notification that exists only to be dismissed via the explicit × is the only case affected.

## User Prompt

> もうない？

(User asked whether the previous sweep was complete. Re-running the sweep more thoroughly.)

## Items fixed

| # | PR | File:line | Bot finding | Fix |
|---|---|---|---|---|
| 1 | #1191 | `packages/spotify-plugin/src/client.ts:169` | CodeRabbit: 408/429 misclassified as `auth_expired` | Treat 408 + 429 + 5xx as transient |
| 2 | #1201 | `e2e/fixtures/api.ts:132` | CodeRabbit: notifier mock accepts any HTTP verb | `route.fallback()` for non-POST |
| 3 | #1201 | `server/index.ts:1005` | CodeRabbit: `startRuntimeServices` failure only logged → half-initialized runtime | `httpServer.close(() => process.exit(1))` |
| 4 | #1201 | `src/components/NotificationBell.vue:276` | CodeRabbit: unconditional `role="button"` on active rows | New `hasPrimaryAction` helper; conditionalize role/tabindex/aria-label/keydown |
| 5 | #1176 | `src/utils/agent/toolCalls.ts:59` | CodeRabbit: hardcoded `"text-response"` | Use `TOOL_NAMES.textResponse` |

Test file (`test/utils/agent/test_toolCalls.ts`) intentionally retains the literal as a wire-protocol contract assertion — flagged but not changed.

## Verification

- `yarn format` ✅
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)