### PR TITLE
chore: add `yarn package` to produce a publishable mulmoclaude tarball

### DIFF
--- a/.claude/skills/publish-mulmoclaude/SKILL.md
+++ b/.claude/skills/publish-mulmoclaude/SKILL.md
@@ -92,8 +92,9 @@ node scripts/mulmoclaude/tarball.mjs
 The one-liner equivalent, if you want to see the launcher boot by hand:
 
 ```bash
-cd packages/mulmoclaude && rm -f mulmoclaude-*.tgz && npm pack
-# → mulmoclaude-<X.Y.Z>.tgz
+yarn package
+# → packages/mulmoclaude/mulmoclaude-<X.Y.Z>.tgz
+# (cleans stale tarballs + runs yarn build + npm pack with prepack hook)
 
 rm -rf /tmp/mc-test && mkdir /tmp/mc-test && cd /tmp/mc-test
 npm init -y >/dev/null

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts && yarn workspaces run test",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",
-    "sandbox:logout": "rm -f ~/.claude/.credentials.json && echo 'Credentials file removed'"
+    "sandbox:logout": "rm -f ~/.claude/.credentials.json && echo 'Credentials file removed'",
+    "package": "node scripts/package.mjs"
   },
   "resolutions": {
     "tar": "7.5.13"

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -19,10 +19,22 @@
 import { execSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, rmSync } from "node:fs";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const PKG_DIR = join(REPO_ROOT, "packages/mulmoclaude");
+
+// Drop stale tarballs first — pre-fix, repeated `yarn package` runs
+// would leave `mulmoclaude-0.5.2.tgz`, `mulmoclaude-0.5.3.tgz`,
+// etc. side by side in `packages/mulmoclaude/`, and a smoke test
+// that ran `npm install ./mulmoclaude-*.tgz` could pick up the
+// wrong version. Mirrors what `scripts/mulmoclaude/tarball.mjs`
+// (the CI smoke variant) already does.
+for (const name of readdirSync(PKG_DIR)) {
+  if (name.startsWith("mulmoclaude-") && name.endsWith(".tgz")) {
+    rmSync(join(PKG_DIR, name));
+  }
+}
 
 console.log("[package] yarn build");
 execSync("yarn build", { cwd: REPO_ROOT, stdio: "inherit" });

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Build the full app and produce a publishable tarball at
+// `packages/mulmoclaude/mulmoclaude-<version>.tgz`. Wired up as
+// `yarn package` so the testing flow (build → prepare-dist → pack)
+// is one command instead of three.
+//
+// `npm pack` triggers the `prepack` hook in
+// `packages/mulmoclaude/package.json`, which runs
+// `bin/prepare-dist.js` to copy `dist/client/` + `server/` + `src/`
+// into the package — no manual prepare step needed.
+//
+// To install the tarball locally for a smoke test:
+//
+//   mkdir /tmp/mc-test && cd /tmp/mc-test
+//   npm init -y
+//   npm install /abs/path/to/mulmoclaude-<X.Y.Z>.tgz
+//   ./node_modules/.bin/mulmoclaude --no-open --port 3099
+
+import { execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const PKG_DIR = join(REPO_ROOT, "packages/mulmoclaude");
+
+console.log("[package] yarn build");
+execSync("yarn build", { cwd: REPO_ROOT, stdio: "inherit" });
+
+console.log("[package] npm pack (runs prepack → prepare-dist.js)");
+execSync("npm pack", { cwd: PKG_DIR, stdio: "inherit" });
+
+const { version } = JSON.parse(readFileSync(join(PKG_DIR, "package.json"), "utf-8"));
+const tarball = join(PKG_DIR, `mulmoclaude-${version}.tgz`);
+console.log(`\n[package] ✓ ${tarball}`);


### PR DESCRIPTION
## Summary

- Wraps the three-step local-publish-test flow (`yarn build` → `node packages/mulmoclaude/bin/prepare-dist.js` → `cd packages/mulmoclaude && npm pack`) into a single \`yarn package\` command.
- Tiny \`scripts/package.mjs\` invokes \`yarn build\` then \`npm pack\` in the launcher package; the existing \`prepack\` hook fires \`prepare-dist.js\` automatically so no manual prepare step is needed.
- Output: \`packages/mulmoclaude/mulmoclaude-<version>.tgz\` (already gitignored).

## User Prompt

> tarball を作るのは、テスト時に必要なので、yarnで一発でできるようにしたい。yarn run packageとか。

## Implementation

- \`scripts/package.mjs\` — 30-line node wrapper. Spawns \`yarn build\` at repo root, then \`npm pack\` in \`packages/mulmoclaude/\`. Reads the version from the launcher's \`package.json\` to print the absolute tarball path on success so the smoke-install step is one copy-paste.
- \`package.json\` — registered as \`"package": "node scripts/package.mjs"\` under the existing scripts block.

## Test plan

- [x] \`yarn package\` produces \`mulmoclaude-0.5.3.tgz\` (~10 MB) end-to-end in ~15 s on a warm cache locally
- [x] \`*.tgz\` already in \`packages/mulmoclaude/.gitignore\` — produced tarball stays out of git
- [ ] Naming check: no \`yarn pack\` collision (yarn 1's built-in is \`pack\`, this script is \`package\` — distinct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)