### PR TITLE
chore(gitleaks): allowlist test_map_integration fixture

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -20,3 +20,11 @@
 # fixture would defeat the test's intent — we WANT a known-token-
 # shape string so the redaction proof is meaningful. Not a real key.
 9637475787b4b8fa48b2e42b06ee15f08bec2922:test/utils/test_promptMeta.ts:stripe-access-token:51
+
+# test/plugins/test_map_integration.ts uses a Google-Maps-API-shaped
+# fake fixture at line 109 to assert that the map-plugin's
+# `kind: "configure"` round-trip persists the supplied key into
+# `google-maps.json` verbatim. The literal is short, deterministic,
+# and obviously not a real key (uses the literal token "TestKey")
+# but trips gitleaks' generic-api-key prefix match. Not a real key.
+877b5911b33153ac3794a8d824ec49d2230006ae:test/plugins/test_map_integration.ts:generic-api-key:109


### PR DESCRIPTION
## Summary

`feat/map-plugin-pr-a-1227` introduced a Google-Maps-API-key-shaped test fixture in `test/plugins/test_map_integration.ts:109`. The literal is obviously fake (contains the token "TestKey") but tripped the generic-api-key prefix match because it starts with `AIza`. This was failing the gitleaks full-history scan on every unrelated PR (e.g. #1232 plan PR).

Adding the fingerprint to `.gitleaksignore` so the job stops blocking unrelated work. Same allow-listing pattern as the existing `test_promptMeta.ts` Stripe-shape fixture entry.

## Items to Confirm / Review

1. **Fingerprint scope** — the entry is keyed to commit `877b5911...` exactly; if the fixture moves to a different line in a follow-up PR, the entry needs refresh. That's the gitleaks fingerprint format's intended granularity per the file's own header comment.
2. **Alternative**: edit the fixture itself (e.g. use `AIza-NOT-A-REAL-KEY-1234567890`). That's cleaner long-term but belongs in #1227's PR-A scope, not this chore. Filed as a follow-up consideration.

## User Prompt

> ci 失敗 → [analysis: gitleaks full-history scan tripped on another branch's test fixture] → 2 [allowlist option]

## Test plan

- [x] No code changes — `.gitleaksignore` only
- [ ] CI: `Secret Scan (gitleaks)` should pass on this PR
- [ ] After merge: re-run gitleaks on #1232 (and any other blocked PR), verify pass

## Summary by Sourcery

CI:
- Update gitleaks ignore configuration to suppress a known test fixture secret false positive.