### PR TITLE
feat(map): integrate @gui-chat-plugin/google-map (#1227 PR-A pivot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@google/genai": "^1.52.0",
     "@gui-chat-plugin/browse": "^0.4.0",
     "@gui-chat-plugin/camera": "^0.4.1",
+    "@gui-chat-plugin/google-map": "^0.4.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.0",
     "@mulmobridge/client": "^0.1.0",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -23,6 +23,7 @@
     "@google/genai": "^1.52.0",
     "@gui-chat-plugin/browse": "^0.4.0",
     "@gui-chat-plugin/camera": "^0.4.1",
+    "@gui-chat-plugin/google-map": "^0.4.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.0",
     "@mulmobridge/chat-service": "^0.1.2",

--- a/plans/feat-map-plugin-1227.md
+++ b/plans/feat-map-plugin-1227.md
@@ -1,6 +1,19 @@
-# Map Plugin — Google Maps + favorite places + wiki coordinate linking
+# Map Plugin — Integrate `@gui-chat-plugin/google-map` + Settings API key flow
 
 Tracking issue: [#1227](https://github.com/receptron/mulmoclaude/issues/1227)
+
+## Pivot note (2026-05-08)
+
+**Earlier revision of this plan proposed scaffolding `@mulmoclaude/map-plugin` from scratch as a runtime plugin.** That work was started in PR #1231 (PR-A scaffold) and PR #1235 (PR-B favorites + interactive map) before we noticed that **`@gui-chat-plugin/google-map@0.4.0` already exists on npm** (https://github.com/receptron/GUIChatPluginGoogleMap), shipped by the same author, with a strict feature superset:
+
+- showLocation / setCenter / setZoom / addMarker / clearMarkers
+- findPlaces (Google Places API, 80+ place types)
+- getDirections (DRIVING / WALKING / BICYCLING / TRANSIT)
+- Vue View with side panels, zoom controls, and loading/error overlays
+- Vue Preview component
+- Pure ESM + CJS dual export (Docker CJS-mode compatible)
+
+PR #1231 and #1235 were closed in favour of this integration approach. This plan is rewritten end-to-end.
 
 ## User Prompt
 
@@ -11,259 +24,196 @@ Tracking issue: [#1227](https://github.com/receptron/mulmoclaude/issues/1227)
 
 ## Goals
 
-1. **Find a place** — search by name / address (Google Places Autocomplete).
-2. **Save it as a favorite** — name + lat/lng + optional notes.
-3. **See all favorites on a map** — `/map` route, pins clickable for details.
-4. **Link to wiki** — a wiki page can declare `coords: [lat, lng]` in its frontmatter; the page render embeds a small map widget. From a favorite's detail panel, jump to its linked wiki page (or create one).
+1. **Wire up `@gui-chat-plugin/google-map`** as MulmoClaude's map plugin via the same external-package binding pattern as `@gui-chat-plugin/{mindmap,present3d}` and `@mulmochat-plugin/quiz`.
+2. **API key Settings UI** — let the user paste a Google Maps API key in the Settings modal; persist it in `AppSettings`; inject into the View as a `googleMapKey` prop.
+3. **Favorites + wiki linking** — features missing from the upstream package. **Contributed upstream** (PR to GUIChatPluginGoogleMap) so MulmoClaude pulls them in via a version bump.
 
-## Non-goals (this iteration)
+## Non-goals
 
-- Turn-by-turn directions / route planning
-- Distance / "places near me" radius search
-- Traffic, Street View, satellite toggle
-- Photo EXIF auto-pinning (will revisit under #1222 once favorites land)
-- Multi-account support — one Google Maps API key per workspace
+- Photo EXIF auto-pinning (separate, handled by [`feat-photo-exif.md`](feat-photo-exif.md))
+- Multi-key per-role / per-workspace fan-out — one key per MulmoClaude instance
+- Offline maps / tile caching
 
 ## Architecture
 
-### Plugin shape
+### Existing pattern we reuse
 
-`packages/map-plugin/` as a **runtime plugin** (`@mulmoclaude/map-plugin`). Same shape as `spotify-plugin` / `recipe-book-plugin`. No host-side feature-specific code; the only host changes are generic infrastructure.
-
-```
-packages/map-plugin/
-├── src/
-│   ├── index.ts           # PluginRegistration + handlers
-│   ├── definition.ts      # Tool schema (Zod)
-│   ├── meta.ts            # definePluginMeta — toolName, apiRoutes, workspaceDirs
-│   ├── schemas.ts         # Zod schemas (Place, Favorite, ConfigFile)
-│   ├── places.ts          # Places API thin wrapper
-│   ├── favorites.ts       # JSON CRUD over runtime.files
-│   ├── config.ts          # API-key load/save (per-machine config)
-│   ├── lang/              # i18n (en / ja minimum, keep room for the rest)
-│   ├── View.vue           # Full /map view
-│   └── Preview.vue        # Chat-row preview thumbnail
-└── ...                    # vite.config / tsconfig / package.json mirroring bookmarks-plugin
-```
-
-### Tool surface (one tool, kind-discriminated)
-
-`manageMap({ kind: ... })` — same pattern as `manageSpotify`:
-
-| kind | Args | Returns |
-|---|---|---|
-| `status` | — | `{ ok, configured: boolean, favoritesCount }` |
-| `configure` | `{ apiKey }` | `{ ok }` — stores key, no echo back |
-| `searchPlaces` | `{ query, sessionToken? }` | `{ ok, results: Place[] }` |
-| `addFavorite` | `{ name, lat, lng, placeId?, notes?, wikiSlug? }` | `{ ok, favorite: Favorite }` |
-| `listFavorites` | — | `{ ok, favorites: Favorite[] }` |
-| `removeFavorite` | `{ id }` | `{ ok }` |
-| `linkWikiPage` | `{ favoriteId, wikiSlug }` | `{ ok }` — sets the cross-link both ways |
-
-### Data model (`favorites.json`)
+`src/plugins/_extras.ts` already wires three external npm packages into MulmoClaude:
 
 ```ts
-interface Favorite {
-  id: string;            // uuid v4
-  name: string;          // user-editable
-  lat: number;
-  lng: number;
-  placeId?: string;      // Google Places place_id (for re-fetching photos / hours)
-  tags?: string[];       // free-form labels — "food", "tokyo", "datespot"; for filter UI in listFavorites
-  notes?: string;
-  wikiSlug?: string;     // links to data/wiki/pages/<slug>.md
-  addedAt: string;       // ISO
-  updatedAt: string;     // ISO
-}
+import { TOOL_DEFINITION as createMindMapDef } from "@gui-chat-plugin/mindmap";
+import MindMapPlugin from "@gui-chat-plugin/mindmap/vue";
 
-interface FavoritesFile {
-  version: 1;
-  favorites: Favorite[];  // sorted by addedAt desc
-}
+EXTERNAL_PLUGIN_REGISTRATIONS: [
+  { toolName: TOOL_NAMES.createMindMap, entry: MindMapPlugin.plugin },
+  // ...
+];
+
+EXTRA_SERVER_BINDINGS: [
+  { def: createMindMapDef, endpoint: API_ROUTES.plugins.mindmap },
+  // ...
+];
 ```
 
-Stored at `~/mulmoclaude/data/places/favorites.json` (new `WORKSPACE_DIRS.places` entry). Reads/writes go through `writeFileAtomic` (per CLAUDE.md "all writes go through `writeFileAtomic`").
+The corresponding server route in `server/api/routes/plugins.ts` calls `executeMindMap` from the package and returns the result. Same shape lands here for google-map.
 
-**One global list per workspace** — no per-role / per-session scoping. Categorisation is via `tags` (flat free-form strings). Multi-list support (à la Google Maps "Want to go" vs "Favorites" vs "Travel plans") is intentionally out of scope: tags cover the same use case at lower implementation cost, and the migration if we later decide we want multi-list is `tag === listName`. PR-B ships the field; the filter UI follows in the same PR (small chip row on `/map` header).
+### What MulmoClaude side keeps
 
-### API key storage
+Only the **API-key flow** is MulmoClaude-specific (= the upstream package takes the key as a prop, doesn't manage UI/persistence):
 
-`~/mulmoclaude/config/map-plugin/config.json` — per-machine, never under `data/` (which is workspace-shared).
+| Layer | What lives in MulmoClaude | What lives upstream |
+|---|---|---|
+| Tool definition | imported via `_extras.ts` | `@gui-chat-plugin/google-map` |
+| Tool execution | `/api/plugins/google-map` route → `executeMapControl()` | `@gui-chat-plugin/google-map` |
+| Vue View / Preview | imported via `_extras.ts` | `@gui-chat-plugin/google-map/vue` |
+| API key Settings UI | `SettingsModal` + new `SettingsMapTab.vue` | — |
+| API key persistence | `AppSettings.googleMapsApiKey` (`server/system/config.ts`) | — |
+| API key injection | host-level prop binding in `App.vue` (where the View is mounted) | upstream View accepts `googleMapKey?: string \| null` |
+
+### API key data model
+
+`AppSettings` already exists at `server/system/config.ts:20`. Add one optional field:
 
 ```ts
-interface MapPluginConfig {
-  version: 1;
-  googleMapsApiKey?: string;  // empty / unset → not configured
+export interface AppSettings {
+  extraAllowedTools: string[];
+  photoExif?: { autoCapture: boolean };       // from feat-photo-exif (#1222)
+  googleMapsApiKey?: string;                   // NEW
 }
 ```
 
-The key is needed on **two surfaces**:
-- **Client** (Vue View): the Google Maps JS SDK injects via `<script>` tag with `?key=<APIKEY>`. Plugin View fetches its own key from `runtime.dispatch({ kind: "status" })` → server reads `config.json` → returns `{ configured: true, hasKey: true }` plus an opaque short-lived **session-bound token** the View exchanges for the key on a per-session basis (so the key never lands in chat history / SSE replay).
-  - **Decision pending** — see Open Questions below. Simpler v1: just return the key directly to the same-origin same-process View. Local-only desktop app, low practical risk.
-- **Server** (Places API proxy): the search-places handler calls Google's Places API server-side using the same key. Avoids embedding the key in the client bundle for endpoints that don't strictly need a browser context.
+Why a top-level field rather than a plugin-scoped config like `<workspace>/config/google-maps.json`:
 
-### Routing
+- The key affects host-level UI (Map launcher button visibility, Settings tab) — pulling it through `AppSettings` keeps it on the same load path as the rest of the settings UI consumes
+- One read in `loadSettings()` already happens per agent invocation; no extra IO
+- Avoids designing a new "plugin secrets" abstraction for a one-off
 
-- `GET /map` — host route, mounted via the plugin's `definePluginMeta({ pageRoutes: ... })` contribution.
-  - Currently host's `src/router/index.ts` hard-codes the page routes. Extending it with plugin-contributed routes is itself a plugin-vs-host boundary call (see Open Questions §1).
-- All plugin tool calls go through the existing generic `POST /api/plugins/runtime/:pkg/dispatch` route — no new host routes for this plugin.
+### Wiring topology
 
-### Wiki integration (PR-D)
-
-**Authoring shape**: wiki page frontmatter:
-
-```markdown
----
-title: お気に入りの寿司屋
-coords:
-  lat: 35.6762
-  lng: 139.6503
-mapZoom: 16             # optional, default 16
----
-
-レビュー本文...
+```
+Settings → Map tab          ─┐
+   ↓ user pastes key         │
+   POST /api/config           │
+   ↓                          │
+   settings.json updated     ─┘                            (storage)
+       ↓
+       ↓ next page load                              ┌── @gui-chat-plugin/google-map/vue
+App.vue mounts MapView ──── <View :googleMapKey> ───┤    (3rd party — handles render,
+       ↑                                             │    Places, Directions, etc.)
+       │                                             └──
+   AppSettings.googleMapsApiKey
+       │
+       │ (server side, when LLM calls mapControl)
+       ↓
+   /api/plugins/google-map ──── executeMapControl()  ── @gui-chat-plugin/google-map
+       (host route)               (returns ToolResult)    (3rd party)
 ```
 
-(Picked frontmatter over body shortcode `{{map:...}}` because: (a) the wiki engine already parses YAML frontmatter; (b) frontmatter is a single canonical place per page rather than 0..N inline tags; (c) reverse-linking from a favorite to a wiki page is straightforward — a favorite's `wikiSlug` resolves to that one page's coords. See Open Questions §2 if we want to soften this.)
+## Phased rollout
 
-**Render**: when `coords` is present, the wiki page renderer embeds a `<MapEmbed :lat :lng :zoom>` widget at the bottom of the page. Same Maps JS SDK + module-scoped loader as `/map` and the chat Preview — one SDK load shared across all map widgets in the SPA session. The widget is read-only (same `disableDefaultUI: true` config as Preview), with a single "Open in interactive map" button that routes to `/map?focus=<favoriteId>` or `/map?center=<lat>,<lng>` if not yet a favorite.
+### PR-A: Integration (this is the v1 ship)
 
-**Reverse link**: when a favorite has `wikiSlug` set, `/map`'s detail panel shows "Open wiki page →" which routes to `/wiki/pages/<slug>`. From a wiki page with coords, an "Add to favorites" button captures the page title + coords and POSTs `addFavorite` with `wikiSlug` pre-filled.
+**What lands**:
 
-## Phasing
+- `yarn add @gui-chat-plugin/google-map@^0.4.0` (root + `packages/mulmoclaude/package.json` so the launcher tarball includes it)
+- `src/config/toolNames.ts`: `mapControl: "mapControl"`
+- `src/config/apiRoutes.ts`: add `plugins.googleMap` route key
+- `src/plugins/_extras.ts`: import the package's `TOOL_DEFINITION` + Vue plugin, register in both `EXTERNAL_PLUGIN_REGISTRATIONS` and `EXTRA_SERVER_BINDINGS`
+- `server/api/routes/plugins.ts`: add `/api/plugins/google-map` handler that calls `executeMapControl` from the package
+- `test/plugins/test_meta_aggregation.ts`: add `"mapControl"` to `EXTERNAL_PACKAGE_TOOL_NAMES` (sync-invariant whitelist)
+- `server/system/config.ts`: extend `AppSettings` with `googleMapsApiKey?: string`, validation in `isAppSettings`
+- `src/components/SettingsModal.vue`: new "Map" tab
+- `src/components/SettingsMapTab.vue` (new): password-style input, Save button, "Configured / Not configured" indicator, link to Google Cloud Console credentials. Lift idea / strings from closed PR #1231's `SettingsMapTab.vue` (no need to redo this from scratch)
+- `src/lang/{8 locales}.ts`: settings tab strings + launcher label, all 8 locales in lockstep
+- `src/components/PluginLauncher.vue`: Map launcher button
+- `src/router/{pageRoutes,index}.ts`: `PAGE_ROUTES.map = "map"` + `/map` route
+- `src/App.vue`: mount the upstream `View` and pass `googleMapKey` from `AppSettings`
+- Default suggested queries / role tweaks if any (TBD during implementation)
 
-Each phase is one PR, independently mergeable. Aim is for PR-A to be a no-op for users without an API key (just a new sidebar entry pointing at an empty `/map` page with a "configure" prompt).
+**Tests**:
 
-### PR-A — Plugin scaffold + Settings UI for API key
+- Settings round-trip: paste key → reload → key still present
+- LLM tool call: `mapControl({ action: "showLocation", location: "Tokyo Station" })` returns the expected `ToolResult` shape (against the package, not the live API)
+- E2E: open `/map`, confirm "Configure your Google Maps API key in Settings" message when unset; confirm map renders when set (mocked package `googleMapKey` prop)
 
-- Generate plugin via existing scaffold (`npx create-mulmoclaude-plugin map`)
-- `meta.ts`: tool name `manageMap`, `workspaceDirs: { places: "data/places" }`, `pageRoutes: [{ path: "/map", name: "map", component: View }]` if the host extension supports it (else open a separate small PR to add `pageRoutes` aggregation; see Open Questions §1)
-- `definition.ts`: just `status` and `configure` kinds for this PR
-- Server-side handler: read/write `config/map-plugin/config.json`
-- Settings UI: new "Map" entry in the existing Settings panel (same component family as the MCP catalog config sheet — both edit a stored secret)
-- View: empty Google Map centred on a dummy spot when configured, "Set API key in Settings" prompt when not
-- Tests: handler unit tests (status + configure), Settings UI E2E (key-roundtrip)
+**User-facing**: The `/map` route + launcher button work, LLM can call `mapControl` (showLocation / setCenter / addMarker / findPlaces / getDirections). Favorites / wiki linking come later.
 
-**Acceptance**: opening `/map` without an API key shows a prompt; setting a key in Settings makes the map render Tokyo (or any sensible default centre).
+### PR-B: Favorites — upstream contribution
 
-### PR-B — Favorites CRUD + pins on /map + Preview.vue + tags
+Favorites (= "save this place to a list, view list later") aren't in `@gui-chat-plugin/google-map` today. Two options for where to add them:
 
-- New kinds: `addFavorite`, `listFavorites`, `removeFavorite`
-- `favorites.ts`: JSON I/O over `runtime.files.data("favorites.json")`
-- Schemas: Zod for `Favorite` + `FavoritesFile` (incl. `tags?: string[]`), validate on read AND write
-- View: render pins from `listFavorites`, click → side panel with name / notes / lat / lng / tags / "Remove"
-- Tag filter: chip row in `/map` header — click a tag to filter the visible pin set; multi-select = OR
-- Add-favorite UX: right-click on map → "Save this point" prompt for name + optional tags (comma-separated)
-- **Preview.vue**: lightweight read-only map for `addFavorite` confirmation (1 pin) and `listFavorites` overview (all pins, no panning); shared SDK loader with View
-- Tests: favorites.ts unit (happy path, dup-id, empty, malformed file recovery, tag filter), View E2E (mock listFavorites, assert pins + tag-filter chips), Preview render test
+- **Option 1 (recommended): contribute upstream** — open a PR on `receptron/GUIChatPluginGoogleMap` adding favorites as a generic feature any consumer can opt into. Ship as `@gui-chat-plugin/google-map@0.5.0`, then bump MulmoClaude's dep.
+- Option 2: layer a thin MulmoClaude-side favorites plugin around the upstream one. Faster but creates a divergent feature surface; skip unless upstream rejects.
 
-**Acceptance**: can add a pin with tags, refresh, see it persist; can filter by tag; can remove; chat preview after `addFavorite` shows a small map with the pin.
+**Upstream PR scope** (Option 1):
 
-### PR-C — Places Autocomplete search
+- New tool kinds: `addFavorite` / `listFavorites` / `removeFavorite`
+- `Favorite` type: `{ id, name, lat, lng, placeId?, notes?, wikiSlug?, createdAt }`
+- Storage: caller-supplied via a `storage` prop (the package itself shouldn't bind to a filesystem). MulmoClaude implements the storage adapter pointing at `<workspace>/data/map/favorites.json`
+- View additions: a side panel listing favorites with click-to-recenter
 
-- New kind: `searchPlaces`
-- Server-side proxy: calls `https://places.googleapis.com/v1/places:searchText` with the stored API key
-- View: search bar in `/map` header, dropdown of suggestions, click → drops a "candidate" pin you can either save as favorite or dismiss
-- Rate-limit handling: Google Places enforces ~10 QPS per key — surface 429 as a clear "slow down" toast rather than retrying silently
-- Tests: search.ts unit (happy path, no results, 429, network error), View E2E (mock search → assert dropdown)
+**MulmoClaude side after upstream lands**:
 
-**Acceptance**: typing "蕎麦" in search bar yields suggestions; clicking one drops a candidate pin; "Save" turns it into a favorite.
+- bump `@gui-chat-plugin/google-map` to `0.5.0`
+- implement the storage adapter
+- add a workspace dir entry: `WORKSPACE_DIRS.map = "data/map"` (no nested files yet — favorites file is one JSON)
 
-### PR-D — Wiki integration
+### PR-C: Wiki coordinate linking — upstream contribution + MulmoClaude integration
 
-- Wiki page schema: extend frontmatter type to allow `coords: { lat: number; lng: number }` and `mapZoom?: number`
-- Wiki render pipeline: detect coords → append a `<MapEmbed>` block (separate Vue component shared between `/map` and `MapEmbed` to avoid two SDK loads)
-- New tool kind: `linkWikiPage` (favorite ↔ wiki cross-link)
-- `/map` detail panel: "Open wiki" link when `wikiSlug` set; "Create wiki page from this favorite" CTA when not (creates page with frontmatter coords pre-filled)
-- Wiki page: "Add to favorites" button when coords present and no matching favorite yet
-- Tests: wiki frontmatter schema unit, render-pipeline integration, cross-link E2E (add favorite → see it link → click → land on wiki)
+Tie favorites into wiki:
 
-**Acceptance**: a wiki page with `coords` shows a map; a favorite with `wikiSlug` opens the right wiki; the cross-create flow round-trips.
+- Upstream: a `wikiSlug?: string` field on `Favorite` is already proposed in PR-B. Optional; carries no upstream behavior change.
+- MulmoClaude: when a wiki page declares `coords: [lat, lng]` in its frontmatter, render a small map widget inline (uses the upstream View in a thumbnail mode — needs upstream to expose a `compact` prop). From a favorite's detail panel, "Open wiki page" jumps to `data/wiki/pages/<wikiSlug>.md`, creating it with the coords frontmatter if absent.
 
-## Implementation notes
+This depends on upstream PR-B landing + a `compact` mode (PR to upstream).
 
-### Chat surface vs canvas surface
+## Risks and mitigations
 
-Plugins render in two places: the chat-row `Preview.vue` (inline with the conversation) and the canvas `View.vue` (full screen when expanded). For Map, we use **the same Google Maps JS SDK on both** — no Static Maps fallback.
+### Risk 1: Upstream package API change
 
-| kind | Preview.vue (chat row) | View.vue (canvas) |
-|---|---|---|
-| `searchPlaces` | result list (name + address, max 5) + "Save" button. **No map.** Searching is a list-pick task; a map here adds noise. | full map with all candidate pins; click → save |
-| `addFavorite` | "✓ Saved 寿司屋" + **small read-only map** (1 pin, ~200x120, no controls) | full map zoomed onto the saved spot |
-| `listFavorites` | "5 favorites" + small overview map of all pins | full map + filter chips + detail panel |
-| `removeFavorite` | text only — "✗ Removed 寿司屋" | n/a |
-| `linkWikiPage` | text — "🔗 寿司屋 → wiki/sushi-yumeji" | n/a |
+`@gui-chat-plugin/google-map` is at `0.4.0` — semver < 1.0 means breaking changes are allowed. We pin to `^0.4.0` (allow 0.4.x patches, lock at 0.5.0 needing a deliberate bump).
 
-The Preview maps are **read-only**: `disableDefaultUI: true`, `gestureHandling: "none"`, no zoom controls, no drag. A click anywhere on the preview opens the canvas View, which IS interactive.
+### Risk 2: Upstream PR rejected / stale
 
-### Maps JS SDK loading
+If the favorites contribution gets pushback, fall back to Option 2 (MulmoClaude-side wrapper). Cost is one extra package and divergent feature surface, but isn't blocking.
 
-- Google Maps JS SDK is **~600 KB gzipped** — must load it lazily, only when the first map widget mounts (any of: `/map` route entered, a chat row with a map preview rendered, a wiki page with `coords` rendered). Never include in the main bundle.
-- Use the official loader pattern (`<script src="https://maps.googleapis.com/maps/api/js?key=...&libraries=places&loading=async">`). Don't roll a custom loader.
-- **Cache the Promise** in a module-scoped variable so a second mount anywhere in the SPA session reuses the already-loaded SDK. 50 chat-row map previews = 1 SDK load.
-- Each `new google.maps.Map(...)` instance is a billable "Map JS API load" (separate from the SDK script load). For a chat with N map tool results, that's N billable loads. Mitigations:
-  - Vue keep-alive on the chat virtualizer so scrolling past doesn't unmount + remount the same preview repeatedly
-  - `listFavorites` preview shows ONE overview map, not one map per favorite
+### Risk 3: API key leaks into git via settings.json
 
-### Pricing / quotas
+`<workspace>/config/settings.json` lives in user's `~/mulmoclaude/`, which is outside any repo by default. The risk is users committing it accidentally. Mitigations:
 
-- No localhost-only free tier. `http://localhost:*` requests count the same as production. Add `http://localhost:*` to the API key's HTTP referrer restriction during development.
-- **Free quotas (post-March-2025 pricing)**: ~28k Maps JS API loads / month, separate (also generous) per-API quotas for Places API, Geocoding, Static Maps. Personal-scale usage stays well within free tier; small-team usage is single-digit dollars / month.
-- The plugin's `searchPlaces` rate limiter (30/min, see below) is a defence against an LLM-side regression flooding the API; the per-month quota is enforced by Google.
+- Settings UI uses an `<input type="password">` so the key isn't shown in screenshots
+- The key is stored verbatim in `settings.json` (not encrypted) — same threat model as Spotify's `tokens.json`. Local-desktop assumption.
+- `~/mulmoclaude/.gitignore` (auto-provisioned at first start) already excludes `config/` for git-cloned workspace setups (verify).
 
-### Places API session token
+### Risk 4: Map launcher visible without key configured
 
-- The `searchPlaces` flow should pass a session token through `(autocomplete query → place details fetch)` for Google's billing model — a single autocomplete-then-pick is one billing event instead of N. Implementation: client generates a UUID per "search session" (when the search bar is opened), passes it through `searchPlaces`, retains it for the eventual `addFavorite` if the user picks one.
+Show the launcher always; clicking opens the View which displays the upstream's "Google Maps API key not configured" message + a link to Settings. Mirrors the upstream's UX, no extra logic needed.
 
-### Cost ceilings
+### Risk 5: Tarball size growth (mulmoclaude npm package)
 
-- Google Places API can run up bills if a tool call loop misuses it. Plugin-side guard: rate-limit `searchPlaces` to **N calls per minute per process** (suggested N=30) and reject excess with a clear error. Cheap insurance against an LLM-side regression.
+`@gui-chat-plugin/google-map` is ~91 KB packed. Tolerable. Monitor under `scripts/mulmoclaude/smoke.mjs` (drift check).
 
-### Cross-platform / first-run
+## Open questions
 
-- Empty workspace → `data/places/` directory created on first read by the existing `WORKSPACE_DIRS` provisioning path. No special-case branch needed.
-- API key absent → tool returns `{ ok: false, error: { kind: "not_configured" } }`; View handles by showing the configure prompt. No process crash on missing key.
+1. **Tool name collision** — upstream uses `mapControl`. Does anything in MulmoClaude already claim that name? → Check `src/config/toolNames.ts` + `BUILT_IN_PLUGIN_METAS` during PR-A. Likely free.
+2. **`apiKey` in role prompts** — should the `mapControl` tool prompt mention the API key requirement? Probably yes — a role using `mapControl` without a configured key would otherwise silently no-op for the LLM. A prompt note pointing at Settings is the right UX.
+3. **Per-locale Settings tab strings** — closed PR #1231 already had 8-locale strings; lift them. Only `Map` tab strings needed.
 
-### i18n
+## Cleanup (future)
 
-8 locales as per the project rule. Strings will be:
-- "Set Google Maps API key in Settings"
-- "0 favorites yet"
-- "Save this point", "Remove", "Open wiki", "Create wiki page"
-- "Search for a place…"
-- Error toasts: "Google rate limit hit, slow down", "Network error, retry"
+Once favorites + wiki coords ship upstream, MulmoClaude's role in the map domain shrinks back to:
 
-Translations done in the same PR that introduces the string; all 8 locales touched in lockstep per CLAUDE.md.
+- API key Settings UI (irreducible)
+- Storage adapter (small, ~30 lines)
+- `/map` route mount
+- Wiki frontmatter `coords` reader (which is generic — could move to a `wiki-coords.ts` separate from this plan)
 
-## Open Questions (decide before / during PR-A)
+The plan-side complexity drops significantly post-PR-C.
 
-1. **Plugin-contributed page routes** — does the host's `defineHostAggregate` already support `pageRoutes`, or does plugin meta have to declare a route name and the host hard-codes registration? If the latter, should `pageRoutes` aggregation be its own micro-PR (analogous to `apiRoutes` / `staticChannels`) before PR-A, or should the plugin register `/map` directly in PR-A and the cleanup follow?
-   - **Tentative**: micro-PR first if the gap is small, otherwise inline in PR-A and refactor later. Pick after a 30-min code read.
+## References
 
-2. **Tag UX details** — autocomplete from existing tags in the favorites list when adding? Tag rename / merge UI? Going with **plain free-text comma-separated input** for v1 + a simple chip-filter row; tag rename is a future polish (low priority until enough favorites exist that tag drift becomes a problem).
-
-3. **Default map centre** when there are no favorites — Tokyo Station (35.6812, 139.7671)? IP-geolocate? Asking the browser for `navigator.geolocation` adds a permission prompt at first load. Tokyo Station as a literal default keeps the first-run experience friction-free; user can pan.
-
-### Resolved during planning
-
-- **Wiki coordinate format**: frontmatter `coords` only (no body shortcode). Single canonical place per page; aligns with one-favorite-per-page semantics.
-- **API key delivery to View**: direct return in v1. For a local desktop app the threat surface (chat history / SSE replay leaking the key) is essentially zero.
-- **`mcpCatalog` Google Maps entry**: leave alongside this plugin. Different purposes (MCP gives Claude a tool surface; this plugin gives the user a UI).
-- **Static Maps vs JS Maps for previews**: JS Maps everywhere. SDK loaded once per SPA session and cached; preview Maps are read-only. Per-month free quota (post-March-2025 pricing) covers personal-scale use.
-- **Favorites data shape**: one global flat list with `tags?: string[]` for categorisation. No per-role / per-session scoping, no multi-list feature (tags cover the same use case at lower cost).
-
-## Schedule estimate (rough)
-
-- PR-A: half-day to one day (scaffold + Settings field + skeleton View)
-- PR-B: one day (favorites JSON + pins UI + tests)
-- PR-C: one day (Places search + rate-limit guard + tests)
-- PR-D: one to two days (wiki frontmatter + render-pipeline change + cross-link UX)
-
-Total: ~4-5 days of focused work, four independently-reviewable PRs.
-
-## Definition of done (issue #1227 closes)
-
-- All four PRs merged
-- `docs/developer.md` plugin section mentions Map plugin alongside Spotify / recipe-book / etc.
-- README updated with API-key setup instructions
-- A favorites round-trip works end-to-end: search → save → see on map → click → open linked wiki page → edit notes → reflected back
+- Upstream package: https://github.com/receptron/GUIChatPluginGoogleMap (npm: `@gui-chat-plugin/google-map@0.4.0`)
+- Existing external-package wiring: `src/plugins/_extras.ts`
+- Existing route handler pattern: `server/api/routes/plugins.ts:228` (`createMindMap` example)
+- Closed predecessor PRs: #1231, #1235
+- Sister plan (also driven by location data): [`feat-photo-exif.md`](feat-photo-exif.md)

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from "express";
 import {
   fromMcpEntries,
   isAppSettings,
+  isAppSettingsPatch,
   loadMcpConfig,
   loadSettings,
   saveMcpConfig,
@@ -133,15 +134,22 @@ router.put(API_ROUTES.config.base, (req: Request<unknown, unknown, PutConfigBody
   res.json(buildFullResponse());
 });
 
-router.put(API_ROUTES.config.settings, (req: Request<unknown, unknown, AppSettings>, res: ConfigRes) => {
+router.put(API_ROUTES.config.settings, (req: Request<unknown, unknown, Partial<AppSettings>>, res: ConfigRes) => {
   const { body } = req;
   log.info("config", "PUT settings: start");
-  if (!isAppSettings(body)) {
+  if (!isAppSettingsPatch(body)) {
     log.warn("config", "PUT settings: invalid payload");
     badRequest(res, "Invalid AppSettings payload");
     return;
   }
-  if (!runSaveOrFail(res, () => saveSettings(body), "saveSettings failed")) {
+  // Merge the PUT body (a partial patch — fields the caller doesn't
+  // own can be omitted) onto the existing on-disk settings so a tab
+  // that knows about only some fields (e.g. Tools tab sends only
+  // `extraAllowedTools`, Map tab sends only `googleMapsApiKey`)
+  // doesn't wipe fields owned by other tabs.
+  const existing = loadSettings();
+  const merged: AppSettings = { ...existing, ...body };
+  if (!runSaveOrFail(res, () => saveSettings(merged), "saveSettings failed")) {
     return;
   }
   log.info("config", "PUT settings: ok");

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -5,6 +5,7 @@ import { executeQuiz } from "@mulmochat-plugin/quiz";
 import { executeForm } from "../../../src/plugins/presentForm/plugin.js";
 import { executeOpenCanvas } from "../../../src/plugins/canvas/definition.js";
 import { executePresent3D } from "@gui-chat-plugin/present3d";
+import { executeMapControl } from "@gui-chat-plugin/google-map";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { saveImage } from "../../utils/files/image-store.js";
@@ -265,6 +266,16 @@ bindRoute(
 router.post(
   API_ROUTES.plugins.present3d,
   wrapPluginExecute((req) => executePresent3D(null as never, req.body)),
+);
+
+// mapControl — Google Map (showLocation / Places / Directions etc.)
+// from `@gui-chat-plugin/google-map`. The package's `executeMapControl`
+// returns the action descriptor; the rendered View — mounted host-side
+// from `App.vue` — performs the actual Google Maps JS calls and
+// receives the API key as a prop sourced from `AppSettings`.
+router.post(
+  API_ROUTES.plugins.googleMap,
+  wrapPluginExecute((req) => executeMapControl(null as never, req.body)),
 );
 
 // META aggregator diagnostics — boot-time host/plugin or plugin/plugin

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -79,31 +79,38 @@ export function isAppSettingsPatch(value: unknown): value is Partial<AppSettings
   return true;
 }
 
+function parseSettingsRaw(raw: string, file: string): unknown | null {
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    log.warn("config", "settings.json is not valid JSON — using defaults", { file, error: String(err) });
+    return null;
+  }
+}
+
+/** Defensive copy — callers shouldn't be able to mutate the file on
+ *  disk by mutating the returned object. New optional fields added
+ *  to `AppSettings` need a line here too (loadSettings is the choke
+ *  point that propagates them). */
+function cloneAppSettings(settings: AppSettings): AppSettings {
+  const copy: AppSettings = { extraAllowedTools: [...settings.extraAllowedTools] };
+  if (settings.googleMapsApiKey !== undefined) {
+    copy.googleMapsApiKey = settings.googleMapsApiKey;
+  }
+  return copy;
+}
+
 export function loadSettings(): AppSettings {
   const file = settingsPath();
   const raw = readTextSafeSync(file);
   if (raw === null) return { ...DEFAULT_SETTINGS };
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    log.warn("config", "settings.json is not valid JSON — using defaults", {
-      file,
-      error: String(err),
-    });
-    return { ...DEFAULT_SETTINGS };
-  }
+  const parsed = parseSettingsRaw(raw, file);
+  if (parsed === null) return { ...DEFAULT_SETTINGS };
   if (!isAppSettings(parsed)) {
     log.warn("config", "settings.json does not match AppSettings schema — using defaults", { file });
     return { ...DEFAULT_SETTINGS };
   }
-  // Defensive copy — callers shouldn't be able to mutate the file on
-  // disk via the returned object.
-  const copy: AppSettings = { extraAllowedTools: [...parsed.extraAllowedTools] };
-  if (parsed.googleMapsApiKey !== undefined) {
-    copy.googleMapsApiKey = parsed.googleMapsApiKey;
-  }
-  return copy;
+  return cloneAppSettings(parsed);
 }
 
 export function saveSettings(settings: AppSettings): void {

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -79,7 +79,7 @@ export function isAppSettingsPatch(value: unknown): value is Partial<AppSettings
   return true;
 }
 
-function parseSettingsRaw(raw: string, file: string): unknown | null {
+function parseSettingsRaw(raw: string, file: string): unknown {
   try {
     return JSON.parse(raw);
   } catch (err) {

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -24,6 +24,12 @@ export interface AppSettings {
   //   "mcp__claude_ai_Gmail"
   //   "mcp__claude_ai_Google_Calendar"
   extraAllowedTools: string[];
+
+  // Google Maps JS API key. Pasted via Settings → Map tab and used
+  // by `@gui-chat-plugin/google-map`'s View — passed through as a
+  // prop from `App.vue`. Stored verbatim (local-desktop threat
+  // model, same as Spotify token persistence).
+  googleMapsApiKey?: string;
 }
 
 const DEFAULT_SETTINGS: AppSettings = { extraAllowedTools: [] };
@@ -49,7 +55,9 @@ export function ensureConfigsDir(): void {
 
 export function isAppSettings(value: unknown): value is AppSettings {
   if (!isRecord(value)) return false;
-  return isStringArray(value.extraAllowedTools);
+  if (!isStringArray(value.extraAllowedTools)) return false;
+  if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
+  return true;
 }
 
 export function loadSettings(): AppSettings {
@@ -80,7 +88,11 @@ export function saveSettings(settings: AppSettings): void {
     throw new Error("saveSettings: invalid AppSettings shape");
   }
   ensureConfigsDir();
-  const serialised = JSON.stringify({ extraAllowedTools: [...settings.extraAllowedTools] }, null, 2);
+  const payload: AppSettings = { extraAllowedTools: [...settings.extraAllowedTools] };
+  if (settings.googleMapsApiKey !== undefined) {
+    payload.googleMapsApiKey = settings.googleMapsApiKey;
+  }
+  const serialised = JSON.stringify(payload, null, 2);
   writeFileAtomicSync(settingsPath(), `${serialised}\n`, { mode: 0o600 });
 }
 

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -99,7 +99,11 @@ export function loadSettings(): AppSettings {
   }
   // Defensive copy — callers shouldn't be able to mutate the file on
   // disk via the returned object.
-  return { extraAllowedTools: [...parsed.extraAllowedTools] };
+  const copy: AppSettings = { extraAllowedTools: [...parsed.extraAllowedTools] };
+  if (parsed.googleMapsApiKey !== undefined) {
+    copy.googleMapsApiKey = parsed.googleMapsApiKey;
+  }
+  return copy;
 }
 
 export function saveSettings(settings: AppSettings): void {

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -60,6 +60,25 @@ export function isAppSettings(value: unknown): value is AppSettings {
   return true;
 }
 
+/** A PUT-payload validator: every field optional, but if present
+ *  it must match the AppSettings shape. Distinct from
+ *  `isAppSettings` (which insists on the full storage shape) so a
+ *  tab that owns one field can patch it without echoing back fields
+ *  it doesn't manage. The PUT handler merges the patch onto the
+ *  current on-disk settings before saving.
+ *
+ *  Why two validators: the storage-shape invariant
+ *  (`extraAllowedTools` is always an array) is preserved by
+ *  `loadSettings` (DEFAULT_SETTINGS) + `saveSettings` (payload
+ *  ensures the array). Loosening the storage validator would
+ *  weaken that guarantee for code reading from `loadSettings`. */
+export function isAppSettingsPatch(value: unknown): value is Partial<AppSettings> {
+  if (!isRecord(value)) return false;
+  if (value.extraAllowedTools !== undefined && !isStringArray(value.extraAllowedTools)) return false;
+  if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
+  return true;
+}
+
 export function loadSettings(): AppSettings {
   const file = settingsPath();
   const raw = readTextSafeSync(file);

--- a/src/App.vue
+++ b/src/App.vue
@@ -140,6 +140,7 @@
               v-if="selectedResult && getPlugin(selectedResult.toolName)?.viewComponent"
               :selected-result="selectedResult"
               :send-text-message="sendMessage"
+              :google-map-key="googleMapsApiKey"
               @update-result="handleUpdateResult"
             />
             <div v-else-if="selectedResult" class="h-full overflow-auto p-6">
@@ -607,6 +608,21 @@ const selectedResult = computed(() => toolResults.value.find((result) => result.
 // reactive, so this computed re-evaluates when the load completes and
 // the /debug branch in the template lights up without a refresh.
 const debugViewComponent = computed(() => getPlugin("manageDebug")?.viewComponent ?? null);
+
+// Google Maps API key from `AppSettings.googleMapsApiKey`. Fetched
+// once on mount and refreshed whenever Settings reports a save. The
+// `mapControl` plugin's View accepts `googleMapKey` as a prop;
+// other plugins ignore the fallthrough attribute. Null when the user
+// has not configured a key — the upstream View shows a "not
+// configured" placeholder and a fallback "Open in Google Maps" link.
+const googleMapsApiKey = ref<string | null>(null);
+async function refreshGoogleMapsApiKey(): Promise<void> {
+  const response = await apiGet<{ settings: { extraAllowedTools: string[]; googleMapsApiKey?: string } }>(API_ROUTES.config.base);
+  if (response.ok) {
+    googleMapsApiKey.value = response.data.settings.googleMapsApiKey ?? null;
+  }
+}
+void refreshGoogleMapsApiKey();
 
 // Centralised session-switch handler: subscribe to the current session's
 // pub/sub channel so we receive real-time events even if the session is

--- a/src/App.vue
+++ b/src/App.vue
@@ -138,6 +138,7 @@
             <component
               :is="getPlugin(selectedResult.toolName)?.viewComponent"
               v-if="selectedResult && getPlugin(selectedResult.toolName)?.viewComponent"
+              :key="`${selectedResult.uuid ?? ''}-${googleMapsApiKey ?? ''}`"
               :selected-result="selectedResult"
               :send-text-message="sendMessage"
               :google-map-key="googleMapsApiKey"

--- a/src/App.vue
+++ b/src/App.vue
@@ -255,6 +255,7 @@
       :mcp-tools-error="mcpToolsError"
       @update:open="showSettings = $event"
       @ask-gemini="handleAskGemini"
+      @saved="refreshGoogleMapsApiKey"
     />
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -161,6 +161,7 @@
             :session-role-icon="sessionRoleIcon"
             :layout-mode="layoutMode"
             :show-right-sidebar="showRightSidebar"
+            :google-map-key="googleMapsApiKey"
             @select="(uuid) => (selectedResultUuid = uuid)"
             @update-result="handleUpdateResult"
             @update:layout-mode="setLayoutMode"

--- a/src/App.vue
+++ b/src/App.vue
@@ -138,10 +138,10 @@
             <component
               :is="getPlugin(selectedResult.toolName)?.viewComponent"
               v-if="selectedResult && getPlugin(selectedResult.toolName)?.viewComponent"
-              :key="`${selectedResult.uuid ?? ''}-${googleMapsApiKey ?? ''}`"
+              :key="`${selectedResult.uuid ?? ''}-${googleMapKeyFor(selectedResult.toolName) ?? ''}`"
               :selected-result="selectedResult"
               :send-text-message="sendMessage"
-              :google-map-key="googleMapsApiKey"
+              :google-map-key="googleMapKeyFor(selectedResult.toolName)"
               @update-result="handleUpdateResult"
             />
             <div v-else-if="selectedResult" class="h-full overflow-auto p-6">
@@ -332,6 +332,7 @@ import { provideActiveSession } from "./composables/useActiveSession";
 import { useRoute, useRouter } from "vue-router";
 import { apiGet } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
+import { TOOL_NAMES } from "./config/toolNames";
 import { classifyWorkspacePath } from "./utils/path/workspaceLinkRouter";
 
 const { t, locale } = useI18n();
@@ -613,11 +614,14 @@ const selectedResult = computed(() => toolResults.value.find((result) => result.
 const debugViewComponent = computed(() => getPlugin("manageDebug")?.viewComponent ?? null);
 
 // Google Maps API key from `AppSettings.googleMapsApiKey`. Fetched
-// once on mount and refreshed whenever Settings reports a save. The
-// `mapControl` plugin's View accepts `googleMapKey` as a prop;
-// other plugins ignore the fallthrough attribute. Null when the user
-// has not configured a key — the upstream View shows a "not
-// configured" placeholder and a fallback "Open in Google Maps" link.
+// once on mount and refreshed whenever Settings reports a save.
+//
+// **Scoping**: the key is forwarded ONLY to the `mapControl` plugin
+// view (= `@gui-chat-plugin/google-map`). Forwarding it to every
+// plugin's `<component :is>` mount would let any third-party
+// runtime plugin declare a `googleMapKey` prop and read the key.
+// `googleMapKeyFor(toolName)` is the gate every binding goes
+// through.
 const googleMapsApiKey = ref<string | null>(null);
 async function refreshGoogleMapsApiKey(): Promise<void> {
   const response = await apiGet<{ settings: { extraAllowedTools: string[]; googleMapsApiKey?: string } }>(API_ROUTES.config.base);
@@ -626,6 +630,10 @@ async function refreshGoogleMapsApiKey(): Promise<void> {
   }
 }
 void refreshGoogleMapsApiKey();
+
+function googleMapKeyFor(toolName: string | undefined): string | null {
+  return toolName === TOOL_NAMES.mapControl ? googleMapsApiKey.value : null;
+}
 
 // Centralised session-switch handler: subscribe to the current session's
 // pub/sub channel so we receive real-time events even if the session is

--- a/src/components/SettingsMapTab.vue
+++ b/src/components/SettingsMapTab.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="space-y-3" data-testid="settings-map-tab">
+    <p class="text-sm text-gray-700">{{ t("settingsModal.mapTab.description") }}</p>
+
+    <div class="space-y-2">
+      <label class="block text-sm font-medium text-gray-800" for="settings-map-api-key">{{ t("settingsModal.mapTab.apiKeyLabel") }}</label>
+      <input
+        id="settings-map-api-key"
+        v-model="apiKeyDraft"
+        type="password"
+        autocomplete="off"
+        spellcheck="false"
+        class="w-full px-3 py-2 text-sm font-mono rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        :placeholder="t('settingsModal.mapTab.apiKeyPlaceholder')"
+        data-testid="settings-map-api-key-input"
+        @keydown.enter.prevent="save"
+      />
+      <p class="text-xs text-gray-500">
+        <i18n-t keypath="settingsModal.mapTab.helperText" tag="span">
+          <template #consoleLink>
+            <!-- eslint-disable @intlify/vue-i18n/no-raw-text -- "Google Cloud Console" is a product name, not translatable copy -->
+            <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline"
+              >Google Cloud Console</a
+            >
+            <!-- eslint-enable @intlify/vue-i18n/no-raw-text -->
+          </template>
+        </i18n-t>
+      </p>
+      <p class="text-xs text-gray-500">{{ t("settingsModal.mapTab.requiredApis") }}</p>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50"
+        :disabled="!isDirty || saving"
+        data-testid="settings-map-save-btn"
+        @click="save"
+      >
+        {{ saving ? t("common.saving") : t("common.save") }}
+      </button>
+      <span v-if="loaded" class="text-xs" :class="storedKey ? 'text-green-600' : 'text-gray-500'" data-testid="settings-map-status">
+        {{ storedKey ? t("settingsModal.mapTab.configured") : t("settingsModal.mapTab.notConfigured") }}
+      </span>
+      <button v-if="storedKey" type="button" class="text-xs text-red-600 hover:underline" data-testid="settings-map-clear-btn" @click="clear">
+        {{ t("settingsModal.mapTab.clear") }}
+      </button>
+    </div>
+
+    <p v-if="errorMessage" class="text-sm text-red-700" role="alert" data-testid="settings-map-error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  /** When the parent modal closes/opens, force a reload so values
+   *  reflect any out-of-band edit (e.g. user edited settings.json
+   *  by hand between sessions). */
+  reloadToken: number;
+}>();
+
+const emit = defineEmits<{
+  saved: [];
+}>();
+
+interface SettingsResponse {
+  settings: { extraAllowedTools: string[]; googleMapsApiKey?: string };
+}
+
+const apiKeyDraft = ref("");
+const storedKey = ref("");
+const loaded = ref(false);
+const saving = ref(false);
+const errorMessage = ref("");
+
+const isDirty = computed(() => apiKeyDraft.value !== storedKey.value);
+
+async function load(): Promise<void> {
+  errorMessage.value = "";
+  const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.mapTab.loadError");
+    return;
+  }
+  storedKey.value = response.data.settings.googleMapsApiKey ?? "";
+  apiKeyDraft.value = storedKey.value;
+  loaded.value = true;
+}
+
+async function save(): Promise<void> {
+  if (saving.value || !isDirty.value) return;
+  saving.value = true;
+  errorMessage.value = "";
+  const trimmed = apiKeyDraft.value.trim();
+  // Patch-style PUT: only `googleMapsApiKey` is sent. The server's
+  // /api/config/settings handler merges over the on-disk state,
+  // so other tabs' fields (extraAllowedTools) survive untouched.
+  // Empty string is a valid "clear" operation.
+  const response = await apiPut<unknown>(API_ROUTES.config.settings, {
+    googleMapsApiKey: trimmed,
+  });
+  saving.value = false;
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.mapTab.saveError");
+    return;
+  }
+  storedKey.value = trimmed;
+  apiKeyDraft.value = trimmed;
+  emit("saved");
+}
+
+async function clear(): Promise<void> {
+  apiKeyDraft.value = "";
+  await save();
+}
+
+watch(
+  () => props.reloadToken,
+  () => {
+    void load();
+  },
+  { immediate: true },
+);
+</script>

--- a/src/components/SettingsMapTab.vue
+++ b/src/components/SettingsMapTab.vue
@@ -13,7 +13,8 @@
         class="w-full px-3 py-2 text-sm font-mono rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
         :placeholder="t('settingsModal.mapTab.apiKeyPlaceholder')"
         data-testid="settings-map-api-key-input"
-        @keydown.enter.prevent="save"
+        @blur="save"
+        @keydown.enter.prevent="onEnterKey"
       />
       <p class="text-xs text-gray-500">
         <i18n-t keypath="settingsModal.mapTab.helperText" tag="span">
@@ -29,22 +30,10 @@
       <p class="text-xs text-gray-500">{{ t("settingsModal.mapTab.requiredApis") }}</p>
     </div>
 
-    <div class="flex items-center gap-3">
-      <button
-        type="button"
-        class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50"
-        :disabled="!isDirty || saving"
-        data-testid="settings-map-save-btn"
-        @click="save"
-      >
-        {{ saving ? t("common.saving") : t("common.save") }}
-      </button>
-      <span v-if="loaded" class="text-xs" :class="storedKey ? 'text-green-600' : 'text-gray-500'" data-testid="settings-map-status">
-        {{ storedKey ? t("settingsModal.mapTab.configured") : t("settingsModal.mapTab.notConfigured") }}
+    <div v-if="loaded" class="flex items-center gap-3 text-xs">
+      <span :class="statusColour" data-testid="settings-map-status">
+        {{ statusText }}
       </span>
-      <button v-if="storedKey" type="button" class="text-xs text-red-600 hover:underline" data-testid="settings-map-clear-btn" @click="clear">
-        {{ t("settingsModal.mapTab.clear") }}
-      </button>
     </div>
 
     <p v-if="errorMessage" class="text-sm text-red-700" role="alert" data-testid="settings-map-error">{{ errorMessage }}</p>
@@ -60,9 +49,9 @@ import { API_ROUTES } from "../config/apiRoutes";
 const { t } = useI18n();
 
 const props = defineProps<{
-  /** When the parent modal closes/opens, force a reload so values
-   *  reflect any out-of-band edit (e.g. user edited settings.json
-   *  by hand between sessions). */
+  /** Bumped by the parent each time the modal opens so the input
+   *  reflects any out-of-band edit (settings.json hand-edit, save
+   *  from another window, etc.). */
   reloadToken: number;
 }>();
 
@@ -80,7 +69,22 @@ const loaded = ref(false);
 const saving = ref(false);
 const errorMessage = ref("");
 
-const isDirty = computed(() => apiKeyDraft.value !== storedKey.value);
+// Auto-save fires on blur OR Enter. Pattern matches the other auto-
+// saving tabs (Workspace Dirs / Reference Dirs / MCP) — no Save
+// button, no Cancel button. Clearing the input + losing focus
+// equivalently clears the stored key.
+
+const statusText = computed(() => {
+  if (saving.value) return t("common.saving");
+  if (errorMessage.value) return errorMessage.value;
+  return storedKey.value ? t("settingsModal.mapTab.configured") : t("settingsModal.mapTab.notConfigured");
+});
+
+const statusColour = computed(() => {
+  if (saving.value) return "text-gray-500";
+  if (errorMessage.value) return "text-red-600";
+  return storedKey.value ? "text-green-600" : "text-gray-500";
+});
 
 async function load(): Promise<void> {
   errorMessage.value = "";
@@ -94,11 +98,15 @@ async function load(): Promise<void> {
   loaded.value = true;
 }
 
+// Save handler used by both `@blur` and `@keydown.enter`. No-ops
+// when nothing changed (the user just tabbed in and out without
+// typing) so the network round-trip is skipped.
 async function save(): Promise<void> {
-  if (saving.value || !isDirty.value) return;
+  if (saving.value) return;
+  const trimmed = apiKeyDraft.value.trim();
+  if (trimmed === storedKey.value) return;
   saving.value = true;
   errorMessage.value = "";
-  const trimmed = apiKeyDraft.value.trim();
   // Patch-style PUT: only `googleMapsApiKey` is sent. The server's
   // /api/config/settings handler merges over the on-disk state,
   // so other tabs' fields (extraAllowedTools) survive untouched.
@@ -116,9 +124,10 @@ async function save(): Promise<void> {
   emit("saved");
 }
 
-async function clear(): Promise<void> {
-  apiKeyDraft.value = "";
-  await save();
+// Enter key: commit immediately + drop focus so the visible state
+// transitions to "Configured" without a second tab press.
+function onEnterKey(event: Event): void {
+  (event.target as HTMLInputElement).blur();
 }
 
 watch(

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -57,6 +57,14 @@
         >
           {{ t("settingsModal.tabs.refs") }}
         </button>
+        <button
+          class="px-3 py-2 text-sm border-b-2"
+          :class="activeTab === 'map' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-800'"
+          data-testid="settings-tab-map"
+          @click="activeTab = 'map'"
+        >
+          {{ t("settingsModal.tabs.map") }}
+        </button>
       </div>
 
       <div class="px-5 py-4 overflow-y-auto flex-1 space-y-4 text-gray-900">
@@ -135,6 +143,8 @@
         <SettingsWorkspaceDirsTab v-else-if="activeTab === 'dirs'" />
 
         <SettingsReferenceDirsTab v-else-if="activeTab === 'refs'" />
+
+        <SettingsMapTab v-else-if="activeTab === 'map'" :reload-token="mapReloadToken" @saved="onMapSaved" />
       </div>
 
       <!-- Footer: status strip only. MCP / Workspace Dirs / Reference
@@ -159,6 +169,7 @@ import { useI18n } from "vue-i18n";
 import SettingsMcpTab from "./SettingsMcpTab.vue";
 import SettingsWorkspaceDirsTab from "./SettingsWorkspaceDirsTab.vue";
 import SettingsReferenceDirsTab from "./SettingsReferenceDirsTab.vue";
+import SettingsMapTab from "./SettingsMapTab.vue";
 import type { McpServerEntry } from "./SettingsMcpTab.vue";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -204,7 +215,18 @@ const emit = defineEmits<{
 // update / remove persist immediately).
 const mcpTabRef = ref<{ flushDraft: () => boolean; hasPendingDraft: () => boolean } | null>(null);
 
-const activeTab = ref<"gemini" | "tools" | "mcp" | "dirs" | "refs">("tools");
+const activeTab = ref<"gemini" | "tools" | "mcp" | "dirs" | "refs" | "map">("tools");
+
+// Forces SettingsMapTab to re-load when the modal opens or the user
+// confirms a save — ensures the input always reflects the latest
+// on-disk state. Increment is the cheap signal; the child watches
+// `reloadToken` and refetches.
+const mapReloadToken = ref(0);
+function onMapSaved(): void {
+  // Bump the token so any other Map-key consumer (e.g. App.vue) can
+  // also notice via the `saved` event bubble.
+  emit("saved");
+}
 const toolsText = ref("");
 // Server truth for tools — updated on load and on a successful Save
 // from the Tools tab. `toolsDirty` compares this against `toolsText`
@@ -375,6 +397,7 @@ watch(
       mcpInflight = Promise.resolve();
       activeTab.value = props.geminiAvailable ? "tools" : "gemini";
       loadConfig();
+      mapReloadToken.value += 1;
       statusMessage.value = "";
       statusError.value = false;
     }

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -72,8 +72,10 @@
           <component
             :is="getPlugin(result.toolName)?.viewComponent"
             v-if="getPlugin(result.toolName)?.viewComponent"
+            :key="`${result.uuid}-${googleMapKey ?? ''}`"
             :selected-result="result"
             :send-text-message="sendTextMessage"
+            :google-map-key="googleMapKey"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
         </div>
@@ -83,8 +85,10 @@
           <component
             :is="getPlugin(result.toolName)?.viewComponent"
             v-if="getPlugin(result.toolName)?.viewComponent"
+            :key="`${result.uuid}-${googleMapKey ?? ''}`"
             :selected-result="result"
             :send-text-message="sendTextMessage"
+            :google-map-key="googleMapKey"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
           <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(result, null, 2) }}</pre>
@@ -154,6 +158,12 @@ const props = defineProps<{
   sessionRoleIcon?: string;
   layoutMode: LayoutMode;
   showRightSidebar: boolean;
+  /** Google Maps JS API key forwarded from `App.vue` to plugin Views
+   *  that consume it (today: `@gui-chat-plugin/google-map`'s View).
+   *  Other plugins ignore the fallthrough. The single-layout
+   *  branch in App.vue forwards the same prop on its own
+   *  `<component :is>` mount. */
+  googleMapKey?: string | null;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -72,10 +72,10 @@
           <component
             :is="getPlugin(result.toolName)?.viewComponent"
             v-if="getPlugin(result.toolName)?.viewComponent"
-            :key="`${result.uuid}-${googleMapKey ?? ''}`"
+            :key="`${result.uuid}-${googleMapKeyFor(result.toolName) ?? ''}`"
             :selected-result="result"
             :send-text-message="sendTextMessage"
-            :google-map-key="googleMapKey"
+            :google-map-key="googleMapKeyFor(result.toolName)"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
         </div>
@@ -85,10 +85,10 @@
           <component
             :is="getPlugin(result.toolName)?.viewComponent"
             v-if="getPlugin(result.toolName)?.viewComponent"
-            :key="`${result.uuid}-${googleMapKey ?? ''}`"
+            :key="`${result.uuid}-${googleMapKeyFor(result.toolName) ?? ''}`"
             :selected-result="result"
             :send-text-message="sendTextMessage"
-            :google-map-key="googleMapKey"
+            :google-map-key="googleMapKeyFor(result.toolName)"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
           <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(result, null, 2) }}</pre>
@@ -102,6 +102,7 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { getPlugin } from "../tools";
+import { TOOL_NAMES } from "../config/toolNames";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { View as TextResponseOriginalView } from "../plugins/textResponse/index";
 import { handleExternalLinkClick } from "../utils/dom/externalLink";
@@ -165,6 +166,15 @@ const props = defineProps<{
    *  `<component :is>` mount. */
   googleMapKey?: string | null;
 }>();
+
+// Scope `googleMapKey` to the `mapControl` plugin only — without
+// this gate, every plugin View in the stack receives the Google
+// Maps API key as a prop and a hostile third-party plugin could
+// declare a matching prop to exfiltrate the key. Codex security
+// review on PR #1241 caught this.
+function googleMapKeyFor(toolName: string): string | null {
+  return toolName === TOOL_NAMES.mapControl ? (props.googleMapKey ?? null) : null;
+}
 
 const emit = defineEmits<{
   select: [uuid: string];

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -165,6 +165,8 @@ const HOST_API_ROUTES = {
     // `form` and `canvas` migrated to META — exposed at top-level
     // `API_ROUTES.presentForm.dispatch` / `API_ROUTES.canvas.dispatch`.
     present3d: "/api/present3d",
+    // mapControl — `@gui-chat-plugin/google-map` external package.
+    googleMap: "/api/google-map",
     // Runtime-loaded plugins (#1043 C-2). One generic dispatch
     // endpoint shared by every workspace-installed plugin; the URL
     // pkg parameter is the URL-encoded npm package name (e.g.

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -59,6 +59,7 @@ export const ROLES: Role[] = [
       TOOL_NAMES.presentMulmoScript,
       TOOL_NAMES.generateImage,
       TOOL_NAMES.presentHtml,
+      TOOL_NAMES.mapControl,
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,
@@ -122,7 +123,7 @@ export const ROLES: Role[] = [
       '3. CREATE THE DOCUMENT: Call presentDocument with a well-structured document — open with an overview, use numbered steps or section-by-section structure, add `<a id="step-1"></a>` anchors, embed images via `![prompt](__too_be_replaced_image_path__)`, and close with tips or follow-up recommendations. Per-type document structure is in guide.md.\n\n' +
       "4. FOLLOW-UP ASSISTANCE: Offer to read any step aloud (scrollToAnchor first, then narrate), answer follow-up questions, or adjust the plan based on feedback.\n\n" +
       "TONE: Warm, enthusiastic, encouraging. Adapt vocabulary to the user's stated experience level.",
-    availablePlugins: [TOOL_NAMES.presentForm, TOOL_NAMES.presentDocument, TOOL_NAMES.generateImage, TOOL_NAMES.presentChart],
+    availablePlugins: [TOOL_NAMES.presentForm, TOOL_NAMES.presentDocument, TOOL_NAMES.generateImage, TOOL_NAMES.presentChart, TOOL_NAMES.mapControl],
     queries: [
       "Give me the recipe for omelette",
       "I want to plan a trip to Paris",
@@ -317,6 +318,7 @@ export const ROLES: Role[] = [
       TOOL_NAMES.presentMulmoScript,
       TOOL_NAMES.generateImage,
       TOOL_NAMES.presentHtml,
+      TOOL_NAMES.mapControl,
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -52,6 +52,10 @@ const HOST_TOOL_NAMES = {
 
   // Interactive / media
   putQuestions: "putQuestions",
+  // mapControl — Google Map render + Places + Directions, supplied by
+  // `@gui-chat-plugin/google-map`. Wired through `src/plugins/_extras.ts`
+  // (external-package binding pattern, same as mindmap / present3d).
+  mapControl: "mapControl",
   weather: "weather",
 
   // MCP tools (server-side, not GUI plugins — registered in

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -146,6 +146,20 @@ const deMessages = {
       mcp: "MCP-Server",
       dirs: "Verzeichnisse",
       refs: "Referenzverzeichnisse",
+      map: "Karte",
+    },
+    mapTab: {
+      description:
+        "Legt den Google-Maps-API-Schlüssel fest, den das Karten-Plugin verwendet. Der Schlüssel wird lokal gespeichert und nur an Google Maps gesendet.",
+      apiKeyLabel: "Google-Maps-API-Schlüssel",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "Erstelle oder kopiere einen Schlüssel aus {consoleLink}.",
+      requiredApis: "Erforderliche APIs: Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "Konfiguriert",
+      notConfigured: "Nicht konfiguriert",
+      clear: "Löschen",
+      loadError: "Einstellungen konnten nicht geladen werden",
+      saveError: "Speichern fehlgeschlagen",
     },
     // `<i18n-t>`-Slots — die Namen `envKey` / `envFile` werden in
     // SettingsModal.vue als Inline-`<code>` gerendert, sodass die

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -166,6 +166,19 @@ const enMessages = {
       mcp: "MCP Servers",
       dirs: "Directories",
       refs: "Reference Dirs",
+      map: "Map",
+    },
+    mapTab: {
+      description: "Set the Google Maps API key used by the map plugin. The key is stored locally and never transmitted anywhere except to Google Maps.",
+      apiKeyLabel: "Google Maps API key",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "Create or copy a key from {consoleLink}.",
+      requiredApis: "Enable: Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "Configured",
+      notConfigured: "Not configured",
+      clear: "Clear",
+      loadError: "Failed to load settings",
+      saveError: "Failed to save",
     },
     // `<i18n-t>` slots — named `envKey` / `envFile` render as inline
     // `<code>` in SettingsModal.vue, so the literal variable and file

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -150,6 +150,19 @@ const esMessages = {
       mcp: "Servidores MCP",
       dirs: "Directorios",
       refs: "Directorios de referencia",
+      map: "Mapa",
+    },
+    mapTab: {
+      description: "Configura la clave de la API de Google Maps que usa el plugin de mapas. La clave se guarda localmente y solo se envía a Google Maps.",
+      apiKeyLabel: "Clave API de Google Maps",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "Crea o copia una clave en {consoleLink}.",
+      requiredApis: "APIs necesarias: Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "Configurada",
+      notConfigured: "Sin configurar",
+      clear: "Borrar",
+      loadError: "Error al cargar los ajustes",
+      saveError: "Error al guardar",
     },
     // Slots `<i18n-t>` — los nombres `envKey` / `envFile` se renderizan
     // como `<code>` en línea en SettingsModal.vue, por lo que los

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -145,6 +145,19 @@ const frMessages = {
       mcp: "Serveurs MCP",
       dirs: "Répertoires",
       refs: "Répertoires de référence",
+      map: "Carte",
+    },
+    mapTab: {
+      description: "Définit la clé API Google Maps utilisée par le plugin de carte. La clé est stockée localement et n'est envoyée qu'à Google Maps.",
+      apiKeyLabel: "Clé API Google Maps",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "Créez ou copiez une clé depuis {consoleLink}.",
+      requiredApis: "APIs requises : Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "Configurée",
+      notConfigured: "Non configurée",
+      clear: "Effacer",
+      loadError: "Échec du chargement des paramètres",
+      saveError: "Échec de l'enregistrement",
     },
     // Slots `<i18n-t>` — les noms `envKey` / `envFile` sont rendus sous
     // forme de `<code>` inline dans SettingsModal.vue ; les littéraux

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -150,6 +150,19 @@ const jaMessages = {
       mcp: "MCP サーバ",
       dirs: "ディレクトリ",
       refs: "参照ディレクトリ",
+      map: "地図",
+    },
+    mapTab: {
+      description: "地図プラグインで使う Google Maps API キーを設定します。キーはローカルに保存され、Google Maps への通信以外で送信されることはありません。",
+      apiKeyLabel: "Google Maps API キー",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "{consoleLink} でキーを作成またはコピーしてください。",
+      requiredApis: "有効化が必要な API: Maps JavaScript API / Geocoding API / Places API (New) / Directions API",
+      configured: "設定済み",
+      notConfigured: "未設定",
+      clear: "クリア",
+      loadError: "設定の読み込みに失敗しました",
+      saveError: "保存に失敗しました",
     },
     // `<i18n-t>` スロット — `envKey` / `envFile` は SettingsModal.vue で
     // インラインの `<code>` として描画されるため、変数名とファイル名は

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -152,6 +152,19 @@ const koMessages = {
       mcp: "MCP 서버",
       dirs: "디렉터리",
       refs: "참조 디렉터리",
+      map: "지도",
+    },
+    mapTab: {
+      description: "지도 플러그인에서 사용하는 Google Maps API 키를 설정합니다. 키는 로컬에 저장되며 Google Maps 외부로는 전송되지 않습니다.",
+      apiKeyLabel: "Google Maps API 키",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "{consoleLink}에서 키를 만들거나 복사하세요.",
+      requiredApis: "활성화 필요: Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "구성됨",
+      notConfigured: "구성되지 않음",
+      clear: "지우기",
+      loadError: "설정을 불러오지 못했습니다",
+      saveError: "저장에 실패했습니다",
     },
     // `<i18n-t>` 슬롯 — `envKey` / `envFile` 은 SettingsModal.vue 에서
     // 인라인 `<code>` 로 렌더링되므로 변수명·파일명은 번역하지 않고

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -145,6 +145,19 @@ const ptBRMessages = {
       mcp: "Servidores MCP",
       dirs: "Diretórios",
       refs: "Diretórios de referência",
+      map: "Mapa",
+    },
+    mapTab: {
+      description: "Define a chave da API do Google Maps usada pelo plugin de mapa. A chave fica salva localmente e só é enviada para o Google Maps.",
+      apiKeyLabel: "Chave API do Google Maps",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "Crie ou copie uma chave em {consoleLink}.",
+      requiredApis: "APIs necessárias: Maps JavaScript API, Geocoding API, Places API (New), Directions API.",
+      configured: "Configurada",
+      notConfigured: "Não configurada",
+      clear: "Limpar",
+      loadError: "Falha ao carregar as configurações",
+      saveError: "Falha ao salvar",
     },
     // Slots `<i18n-t>` — os nomes `envKey` / `envFile` renderizam como
     // `<code>` inline no SettingsModal.vue, então os literais de

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -148,6 +148,19 @@ const zhMessages = {
       mcp: "MCP 服务器",
       dirs: "目录",
       refs: "引用目录",
+      map: "地图",
+    },
+    mapTab: {
+      description: "设置地图插件使用的 Google Maps API 密钥。密钥仅存储在本地,除发送到 Google Maps 外不会传输到任何地方。",
+      apiKeyLabel: "Google Maps API 密钥",
+      apiKeyPlaceholder: "AIza…",
+      helperText: "在 {consoleLink} 创建或复制密钥。",
+      requiredApis: "需要启用:Maps JavaScript API、Geocoding API、Places API (New)、Directions API。",
+      configured: "已配置",
+      notConfigured: "未配置",
+      clear: "清除",
+      loadError: "加载设置失败",
+      saveError: "保存失败",
     },
     // `<i18n-t>` 插槽 — 命名为 `envKey` / `envFile`,在 SettingsModal.vue
     // 中作为行内 `<code>` 渲染,因此字面的变量名和文件名保持不翻译。

--- a/src/plugins/_extras.ts
+++ b/src/plugins/_extras.ts
@@ -26,6 +26,7 @@ import { API_ROUTES } from "../config/apiRoutes";
 import { TOOL_DEFINITION as createMindMapDef } from "@gui-chat-plugin/mindmap";
 import { TOOL_DEFINITION as putQuestionsDef } from "@mulmochat-plugin/quiz";
 import { TOOL_DEFINITION as present3DDef } from "@gui-chat-plugin/present3d";
+import { TOOL_DEFINITION as mapControlDef } from "@gui-chat-plugin/google-map";
 
 import generateImageDef from "./generateImage/definition";
 import editImagesDef from "./editImages/definition";
@@ -33,6 +34,7 @@ import editImagesDef from "./editImages/definition";
 import MindMapPlugin from "@gui-chat-plugin/mindmap/vue";
 import QuizPlugin from "@mulmochat-plugin/quiz/vue";
 import Present3DPlugin from "@gui-chat-plugin/present3d/vue";
+import GoogleMapPlugin from "@gui-chat-plugin/google-map/vue";
 
 /** Externally-distributed plugin registrations. The codegen barrel
  *  in `_generated/registrations.ts` only knows about plugins with a
@@ -42,17 +44,19 @@ export const EXTERNAL_PLUGIN_REGISTRATIONS: readonly PluginRegistration[] = [
   { toolName: TOOL_NAMES.createMindMap, entry: MindMapPlugin.plugin },
   { toolName: TOOL_NAMES.putQuestions, entry: QuizPlugin.plugin },
   { toolName: TOOL_NAMES.present3D, entry: Present3DPlugin.plugin },
+  { toolName: TOOL_NAMES.mapControl, entry: GoogleMapPlugin.plugin },
 ];
 
 /** MCP bindings that don't follow the standard
  *  `mcpEndpoint(meta)` resolution: image plugins reach into the
  *  host-owned `/api/image/*` routes; external npm plugins use
- *  legacy `/api/plugins/{mindmap,quiz,present3d}` paths from
- *  `HOST_API_ROUTES.plugins`. */
+ *  legacy `/api/plugins/{mindmap,quiz,present3d,googleMap}` paths
+ *  from `HOST_API_ROUTES.plugins`. */
 export const EXTRA_SERVER_BINDINGS: readonly ServerPluginBinding[] = [
   { def: generateImageDef, endpoint: API_ROUTES.image.generate },
   { def: editImagesDef, endpoint: API_ROUTES.image.edit },
   { def: createMindMapDef, endpoint: API_ROUTES.plugins.mindmap },
   { def: putQuestionsDef, endpoint: API_ROUTES.plugins.quiz },
   { def: present3DDef, endpoint: API_ROUTES.plugins.present3d },
+  { def: mapControlDef, endpoint: API_ROUTES.plugins.googleMap },
 ];

--- a/test/components/test_stackview_googlemap_wiring.ts
+++ b/test/components/test_stackview_googlemap_wiring.ts
@@ -1,0 +1,55 @@
+// Regression check: `googleMapKey` must reach plugin Views in BOTH
+// the single-layout `<component :is>` mount in `App.vue` AND the
+// stack-layout mounts inside `StackView.vue`. This caught a Codex
+// finding on PR #1241 where the prop was wired only in single
+// layout, leaving stack-mode mapControl cards silently broken.
+//
+// The repo doesn't have Vue component unit-test infrastructure
+// today (e2e/ covers that surface). For a lightweight regression
+// guard, this test parses the source files and asserts the
+// declarations / bindings are present. A future renamer or
+// restructure that drops the prop from a render branch will trip
+// the assertion at unit-test time, ahead of the e2e run.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function readSource(rel: string): string {
+  return readFileSync(path.join(REPO_ROOT, rel), "utf-8");
+}
+
+test("StackView declares googleMapKey as an optional string prop", () => {
+  const src = readSource("src/components/StackView.vue");
+  // Be tolerant of whitespace + comments around the entry.
+  assert.match(src, /googleMapKey\??:\s*string\s*\|\s*null/, "StackView's defineProps must declare `googleMapKey?: string | null`");
+});
+
+test("StackView forwards googleMapKey on every plugin <component :is> mount", () => {
+  const src = readSource("src/components/StackView.vue");
+  // Count occurrences of the binding. The template has TWO render
+  // branches (stack-natural + fixed-height), each must forward.
+  const matches = src.match(/:google-map-key="googleMapKey"/g) ?? [];
+  assert.ok(
+    matches.length >= 2,
+    `Expected :google-map-key forwarded in both render branches (>=2 sites); found ${matches.length}.\n` +
+      "If you removed a render branch, drop the assertion threshold; otherwise restore the binding so map cards aren't broken in stack layout.",
+  );
+});
+
+test("App.vue forwards googleMapsApiKey to StackView and the single-layout component mount", () => {
+  const src = readSource("src/App.vue");
+  // Single layout: directly on the dynamic <component :is>.
+  assert.match(src, /:google-map-key="googleMapsApiKey"/, "App.vue must bind :google-map-key on the chat tool result <component :is> mount");
+  // Stack layout: as an attribute on the StackView usage.
+  assert.match(
+    src,
+    /<StackView[\s\S]*?:google-map-key="googleMapsApiKey"[\s\S]*?\/>/,
+    "App.vue must forward :google-map-key to <StackView> so stack-layout map cards receive the configured key",
+  );
+});

--- a/test/components/test_stackview_googlemap_wiring.ts
+++ b/test/components/test_stackview_googlemap_wiring.ts
@@ -30,26 +30,40 @@ test("StackView declares googleMapKey as an optional string prop", () => {
   assert.match(src, /googleMapKey\??:\s*string\s*\|\s*null/, "StackView's defineProps must declare `googleMapKey?: string | null`");
 });
 
-test("StackView forwards googleMapKey on every plugin <component :is> mount", () => {
+test("StackView forwards googleMapKey via the gating helper on every plugin <component :is> mount", () => {
   const src = readSource("src/components/StackView.vue");
-  // Count occurrences of the binding. The template has TWO render
-  // branches (stack-natural + fixed-height), each must forward.
-  const matches = src.match(/:google-map-key="googleMapKey"/g) ?? [];
+  // Both render branches must go through `googleMapKeyFor(...)` so
+  // non-mapControl plugins do NOT receive the key (Codex security
+  // review on PR #1241).
+  const matches = src.match(/:google-map-key="googleMapKeyFor\(/g) ?? [];
   assert.ok(
     matches.length >= 2,
-    `Expected :google-map-key forwarded in both render branches (>=2 sites); found ${matches.length}.\n` +
-      "If you removed a render branch, drop the assertion threshold; otherwise restore the binding so map cards aren't broken in stack layout.",
+    `Expected :google-map-key bound via googleMapKeyFor() in both render branches (>=2 sites); found ${matches.length}.\n` +
+      'Direct bindings like :google-map-key="googleMapKey" leak the key to every plugin — must go through the gate.',
   );
+  // And ensure the gate itself only releases the key for mapControl.
+  assert.match(src, /TOOL_NAMES\.mapControl[\s\S]*?googleMapKey/, "googleMapKeyFor() must compare toolName against TOOL_NAMES.mapControl");
 });
 
-test("App.vue forwards googleMapsApiKey to StackView and the single-layout component mount", () => {
+test("App.vue forwards googleMapsApiKey to StackView and gates the single-layout component mount by toolName", () => {
   const src = readSource("src/App.vue");
-  // Single layout: directly on the dynamic <component :is>.
-  assert.match(src, /:google-map-key="googleMapsApiKey"/, "App.vue must bind :google-map-key on the chat tool result <component :is> mount");
-  // Stack layout: as an attribute on the StackView usage.
+  // Single layout: through the gating helper, NOT a raw binding.
+  assert.match(
+    src,
+    /:google-map-key="googleMapKeyFor\(selectedResult\.toolName\)"/,
+    "App.vue must bind :google-map-key via googleMapKeyFor() in the single-layout dynamic <component> mount — direct binding leaks the key to non-map plugins",
+  );
+  // The gating helper itself.
+  assert.match(
+    src,
+    /TOOL_NAMES\.mapControl\s*\?\s*googleMapsApiKey\.value\s*:\s*null/,
+    "App.vue must define googleMapKeyFor() that gates by TOOL_NAMES.mapControl",
+  );
+  // Stack layout: forwards the raw key to <StackView>; StackView
+  // applies the same per-result gate internally.
   assert.match(
     src,
     /<StackView[\s\S]*?:google-map-key="googleMapsApiKey"[\s\S]*?\/>/,
-    "App.vue must forward :google-map-key to <StackView> so stack-layout map cards receive the configured key",
+    "App.vue must forward :google-map-key to <StackView> so stack-layout map cards can receive the configured key (StackView applies the per-result gate)",
   );
 });

--- a/test/components/test_stackview_googlemap_wiring.ts
+++ b/test/components/test_stackview_googlemap_wiring.ts
@@ -13,9 +13,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
-import path from "path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");

--- a/test/plugins/test_meta_aggregation.ts
+++ b/test/plugins/test_meta_aggregation.ts
@@ -112,7 +112,7 @@ test("buildPluginAggregate skips plugins where extract returns undefined", () =>
 //     packages (createMindMap from @gui-chat-plugin/mindmap, etc.)
 //     are registered in BUILT_IN_SERVER_BINDINGS without a local
 //     meta.ts because they aren't co-located in this source tree.
-const EXTERNAL_PACKAGE_TOOL_NAMES = new Set(["createMindMap", "putQuestions", "present3D"]);
+const EXTERNAL_PACKAGE_TOOL_NAMES = new Set(["createMindMap", "putQuestions", "present3D", "mapControl"]);
 
 test("every built-in BUILT_IN_SERVER_BINDINGS entry has a matching toolName in BUILT_IN_PLUGIN_METAS", () => {
   const metaToolNames: ReadonlySet<string> = new Set(BUILT_IN_PLUGIN_METAS.map((meta) => meta.toolName));

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -170,6 +170,48 @@ describe("PUT /config/settings", () => {
     assert.equal(state.status, 200);
     assert.deepEqual(configMod.loadSettings().extraAllowedTools, ["new"]);
   });
+
+  // Patch-merge regression coverage. Each tab in the Settings UI
+  // owns a subset of `AppSettings` and PUTs only its own fields.
+  // Without merge support, a Tools-only save would wipe the Map
+  // tab's googleMapsApiKey (and vice versa). Codex review on PR
+  // #1241 surfaced this; these tests pin the contract.
+
+  it("preserves googleMapsApiKey when a tools-only patch is sent", () => {
+    configMod.saveSettings({ extraAllowedTools: ["before"], googleMapsApiKey: "AIza-keep-me" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { extraAllowedTools: ["after"] } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.deepEqual(persisted.extraAllowedTools, ["after"]);
+    assert.equal(persisted.googleMapsApiKey, "AIza-keep-me");
+  });
+
+  it("preserves extraAllowedTools when a map-only patch is sent", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__example"], googleMapsApiKey: "AIza-old" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { googleMapsApiKey: "AIza-new" } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__example"]);
+    assert.equal(persisted.googleMapsApiKey, "AIza-new");
+  });
+
+  it("clears googleMapsApiKey when an explicit empty string is sent (boundary)", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"], googleMapsApiKey: "AIza-doomed" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { googleMapsApiKey: "" } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+    assert.equal(persisted.googleMapsApiKey, "");
+  });
+
+  it("rejects non-string googleMapsApiKey with 400", () => {
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { googleMapsApiKey: 12345 } } as Request, res);
+    assert.equal(state.status, 400);
+  });
 });
 
 describe("PUT /config (atomic)", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,6 +718,13 @@
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/camera/-/camera-0.4.1.tgz#f127547f19bd89d5135f32dcc179fadebe5562e4"
   integrity sha512-JgMeYubDfX2Ez49SoKGHpVgekNViDtUXUxDm9/F2fuzHD6KqxzmkLHYnmbgP4h8LJP8OB3sgELDItBpkRkeDHA==
 
+"@gui-chat-plugin/google-map@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@gui-chat-plugin/google-map/-/google-map-0.4.1.tgz#4cfb63b1b979a955e6602b15256ff32664bfd10c"
+  integrity sha512-l2buyf9f07C6zn9Yh1dR6oUJgBjjp8sFK7EcglxoGxUnmrqNn28vDWAS/uSEPsGWHfO2ZHkNjC0WZ/z39OfbbA==
+  dependencies:
+    gui-chat-protocol "^0.3.3"
+
 "@gui-chat-plugin/mindmap@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/mindmap/-/mindmap-0.4.1.tgz#547ed008e920d9b579f1f15bc8faeefbd0b9b5e4"
@@ -994,15 +1001,6 @@
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.5.tgz#a02d90e5da8a36dce27ac8e7237a50c99a9003a3"
   integrity sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==
 
-"@intlify/core-base@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.0.tgz#0567e52e7c2f5a129e71cd0e980fe185e9eae1cf"
-  integrity sha512-nlxFOnmjJgVkL1PsuSMagyh3qIHTwc2KlO2R3qQQV1ydrcwh1XpM7opWUGqvGaLlktttopDzbLBpr/k5tvbNmA==
-  dependencies:
-    "@intlify/devtools-types" "11.4.0"
-    "@intlify/message-compiler" "11.4.0"
-    "@intlify/shared" "11.4.0"
-
 "@intlify/core-base@11.4.2", "@intlify/core-base@^11.0.0":
   version "11.4.2"
   resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.2.tgz#36c23b50406ba9185d98799b4e13ee6ea65fc19e"
@@ -1011,14 +1009,6 @@
     "@intlify/devtools-types" "11.4.2"
     "@intlify/message-compiler" "11.4.2"
     "@intlify/shared" "11.4.2"
-
-"@intlify/devtools-types@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.4.0.tgz#b0fb14c5e8c35ac0af4b50e81317d2de240dad84"
-  integrity sha512-LtQ04kG8/2Nv6AbuINpkjODuhKHdd+MGLlXKW3I0GTCeDsDIBZUot82nnyK7D6+qersF08FqSvoN/eGPcL3c7Q==
-  dependencies:
-    "@intlify/core-base" "11.4.0"
-    "@intlify/shared" "11.4.0"
 
 "@intlify/devtools-types@11.4.2":
   version "11.4.2"
@@ -1050,14 +1040,6 @@
     semver "^7.5.4"
     synckit "^0.11.0"
 
-"@intlify/message-compiler@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.0.tgz#0ff074213dd73fee2a7930863ef5f2f9e00a04b1"
-  integrity sha512-v455gVZqMb0er63Wd/akX8DXTnwSubgrgQaRigLB60V3xpnq3B99oPvGXW+N4G/5QFt8Ls84FJ8qHJUVnRCs1A==
-  dependencies:
-    "@intlify/shared" "11.4.0"
-    source-map-js "^1.0.2"
-
 "@intlify/message-compiler@11.4.2", "@intlify/message-compiler@^11.0.0":
   version "11.4.2"
   resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.2.tgz#82a1eb96bf6bc51e34e3fc32dccbb468f74552ef"
@@ -1065,11 +1047,6 @@
   dependencies:
     "@intlify/shared" "11.4.2"
     source-map-js "^1.0.2"
-
-"@intlify/shared@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.4.0.tgz#4aeec3e2004404345f3a9b0540fe25376f24798a"
-  integrity sha512-r9qUeLeO0TMZmUZ+mXS6IGQ6xwzZJaVMK6j4CdoA3eQP8xp3JtCfwkZ30gB4+knlN40pmBdDXgx85SWhMCzHng==
 
 "@intlify/shared@11.4.2":
   version "11.4.2"
@@ -1087,6 +1064,13 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -3088,6 +3072,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@14.0.0:
   version "14.0.0"
@@ -6073,10 +6062,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -7863,6 +7859,17 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.13:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
+  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8683,6 +8690,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Pivots the map-plugin work from a from-scratch scaffold (closed PR #1231 / #1235) to integrating the existing `@gui-chat-plugin/google-map@0.4.0` npm package — same author, strict feature superset (showLocation / setCenter / setZoom / addMarker / clearMarkers / findPlaces / getDirections, full Vue View + Preview).

- **Plan rewrite** (`plans/feat-map-plugin-1227.md`) — Pivot note + new architecture
- **Wiring** — `_extras.ts` external registration + server route + tool name + API route + test allowlist (mirrors the 3 other external-package plugins)
- **API key** — `AppSettings.googleMapsApiKey?: string` field + `App.vue` forwarding to the upstream View as `:google-map-key`

## Items to Confirm / Review

1. **Settings UI deferral** — This PR ships server-side persistence + frontend prop forwarding, but no Settings tab UI. Users edit `~/mulmoclaude/config/settings.json` by hand to set the key. The Settings tab can ship as a tiny follow-up; full UI was in closed PR #1231 and the strings can lift verbatim.
2. **`/map` page route + launcher** — Also deferred. mindmap and present3D don't have these either; the chat tool result is the primary surface. Adding a freestanding `/map` is a follow-up if wanted.
3. **Fallthrough attribute** — `:google-map-key` is bound on the dynamic `<component :is>` for ALL plugin views. Other plugins (mindmap, quiz, etc.) don't declare the prop, so Vue 3 applies it as a fallthrough HTML attribute on their root element. No functional impact, just an extra DOM attribute. If reviewer prefers, can wrap in `v-bind="extraPropsForPlugin(toolName)"` instead.
4. **Plan PR-B / PR-C** — Favorites and wiki-coords linking are still in the plan but pivoted to **upstream contributions to GUIChatPluginGoogleMap** rather than MulmoClaude-side code.

## User Prompt

> あ、、https://github.com/receptron/GUIChatPluginGoogleMap　があった。。。npmもあるよね
> みてかくにんして。で、もしいけそうならそれをつかい、機能足せばつかえるなら@gui-chat-plugin/google-mapの機能をたそう
> 1231  1235 closeして、新ブランチすすめよう

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` clean on changed files
- [x] `yarn format` no diffs
- [x] `npx tsx --test test/plugins/test_meta_aggregation.ts` (13/13 pass — the new external `mapControl` is on the allowlist)
- [ ] Manual: paste `googleMapsApiKey` into `settings.json`, restart server, ask chat for "show me Tokyo Station on a map", confirm View renders
- [ ] Manual: without a key, confirm the upstream "Google Maps API key not configured" placeholder shows + the "Open in Google Maps" link works

## Refs

- Closed predecessor PRs: #1231 (PR-A scaffold), #1235 (PR-B favorites)
- Upstream package: https://github.com/receptron/GUIChatPluginGoogleMap (`@gui-chat-plugin/google-map@0.4.0`)
- Issue: #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Google Maps plugin via an upstream package; in-app map view and host-managed endpoint added.
  * New "Map" settings tab to enter/persist a Google Maps API key; key is forwarded to the plugin and triggers view refresh when changed.
  * Map tool enabled for relevant roles.

* **Bug Fixes**
  * Settings save now accepts partial updates to avoid clearing unrelated fields.

* **Tests**
  * Added regression tests for config patching and map-key wiring.

* **Documentation**
  * Updated map-plugin plan and localization strings for the Map tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->