### PR TITLE
fix: persist presentMulmoScript beat edits across in-SPA navigation (#1074)

### DIFF
--- a/e2e-live/tests/mulmo-script-edit.spec.ts
+++ b/e2e-live/tests/mulmo-script-edit.spec.ts
@@ -19,18 +19,26 @@ const LEDIT_TIMEOUT_MS = 3 * ONE_MINUTE_MS;
 test.describe.configure({ mode: "parallel" });
 
 test.describe("mulmoScript edit (real workspace)", () => {
-  // Regression net for #1074. The fix has two halves:
+  // Regression net for #1074. The fix has three parts:
   //   1. View re-reads the script from disk on mount via
-  //      `refreshScriptFromDisk`, so a session-restore after page
-  //      reload (or `page.goto` round-trip) picks up edits made via
-  //      `update-beat` / `update-script` instead of the stale
-  //      toolResult cached in the JSONL.
-  //   2. The wait condition after clicking the per-beat update
-  //      button watches the textarea closing — successful saves
-  //      flip `sourceOpen[index] = false` which removes the entire
-  //      editor block via `v-if`. Earlier versions waited for the
-  //      button to re-enable, but the button is gone from the DOM
-  //      by then so `toBeEnabled` always timed out at 30s.
+  //      `refreshScriptFromDisk` (calling the reopen endpoint
+  //      `POST /api/mulmoScript/save` with `{ filePath }`), so an
+  //      in-SPA navigation that reuses the cached `ActiveSession`
+  //      still surfaces the latest disk content. Server-side
+  //      `enrichWithMulmoScript` only fires on `/api/sessions/:id`
+  //      (a full reload), so without this client-side refresh the
+  //      bug remained on the in-SPA path the user actually hits.
+  //   2. The post-click wait watches the textarea closing —
+  //      successful saves flip `sourceOpen[index] = false` which
+  //      removes the entire editor block via `v-if`. Earlier
+  //      versions waited for the button to re-enable, but the
+  //      button is gone from the DOM by then so `toBeEnabled`
+  //      always timed out at 30s.
+  //   3. The round-trip uses sidebar/session-tab clicks instead of
+  //      `page.goto` so the bug actually surfaces in the test —
+  //      `page.goto` triggers a full reload which goes through the
+  //      server enrichment and would mask a regression in the
+  //      View-side refresh.
   test("L-EDIT: beat 編集 → 更新 → 別セッションへ移動 → 戻ると編集が永続化されている", async ({ page }, testInfo) => {
     test.setTimeout(LEDIT_TIMEOUT_MS);
     // Covers issue #1074 — beat edits made via the source-editor
@@ -62,16 +70,22 @@ test.describe("mulmoScript edit (real workspace)", () => {
 
       await editBeat0Text(page, "L-EDIT marker via e2e-live");
 
-      // Navigate to /wiki and back. This still triggers the SPA
-      // route change + state reload that #1074 reported (the
-      // disappearing edit was tied to leaving and re-entering the
-      // chat surface), but it does NOT mint a second chat session
-      // the way startNewSession() would. Without this swap the
-      // cleanup branch would only delete the original session and
-      // leak the second one into the user's history every time.
-      await page.goto("/wiki");
+      // Navigate to /wiki and back via SPA-internal links — NOT
+      // `page.goto`. This is the actual #1074 repro path: a full
+      // reload triggers `/api/sessions/:id` which is already
+      // disk-enriched server-side (`enrichWithMulmoScript` in
+      // server/api/routes/sessions.ts), so the bug only surfaces
+      // when the SPA reuses its cached `ActiveSession` after
+      // in-app navigation. Clicking the sidebar Wiki launcher and
+      // then the session tab keeps the SPA mount alive — Vue
+      // Router pushes between routes, no /api/sessions re-fetch
+      // happens, and the View must re-read the script from disk
+      // itself to surface the edit. An earlier draft of this spec
+      // used `page.goto` for the round-trip and would have passed
+      // even with the View-side refresh removed.
+      await page.getByTestId("plugin-launcher-wiki").click();
       await page.waitForURL(/\/wiki/);
-      await page.goto(`/chat/${sessionId}`);
+      await page.getByTestId(`session-tab-${sessionId}`).click();
       await page.waitForURL(new RegExp(`/chat/${sessionId}$`));
       await expect(page.getByTestId("mulmo-script-generate-movie-button").first()).toBeVisible({ timeout: ONE_MINUTE_MS });
 

--- a/e2e-live/tests/mulmo-script-edit.spec.ts
+++ b/e2e-live/tests/mulmo-script-edit.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 
 import { TOOL_NAME as PRESENT_MULMO_SCRIPT_TOOL } from "../../src/plugins/presentMulmoScript/definition.ts";
-import { ONE_MINUTE_MS } from "../../server/utils/time.ts";
+import { ONE_MINUTE_MS, ONE_SECOND_MS } from "../../server/utils/time.ts";
 import {
   deleteSession,
   getCurrentSessionId,
@@ -123,7 +123,7 @@ async function editBeat0Text(page: import("@playwright/test").Page, marker: stri
   // button from the DOM entirely — the locator would retry forever.
   // 30s leaves headroom for disk I/O coinciding with another beat's
   // render.
-  await expect(textarea).toBeHidden({ timeout: 30_000 });
+  await expect(textarea).toBeHidden({ timeout: 30 * ONE_SECOND_MS });
 }
 
 async function assertBeat0EditPersisted(page: import("@playwright/test").Page, marker: string): Promise<void> {

--- a/e2e-live/tests/mulmo-script-edit.spec.ts
+++ b/e2e-live/tests/mulmo-script-edit.spec.ts
@@ -99,13 +99,16 @@ async function editBeat0Text(page: import("@playwright/test").Page, marker: stri
   }
   await textarea.fill(originalJson.replace('"text": ""', `"text": "${marker}"`));
   await page.getByTestId("mulmo-script-beat-update-button-0").click();
-  // On a successful save the View flips `sourceOpen[index] = false`,
-  // which unmounts the entire editor block (button + textarea) via
-  // `v-if`. Wait for the textarea to detach instead of the button
-  // re-enabling — the button isn't in the DOM after a successful
-  // save, so `toBeEnabled` would retry against a missing locator
-  // until the global timeout. 30s leaves headroom for disk I/O
-  // coinciding with another beat's render.
+  // `sourceOpen[index] = false` (which `v-if`-unmounts the editor)
+  // only fires on `response.ok` inside `updateBeat()` — see
+  // src/plugins/presentMulmoScript/View.vue. So waiting for the
+  // textarea to detach IS de-facto waiting for the network call to
+  // settle successfully; a 4xx/5xx leaves the editor open with an
+  // inline error and the test would (correctly) time out here.
+  // We avoid `toBeEnabled` because successful saves remove the
+  // button from the DOM entirely — the locator would retry forever.
+  // 30s leaves headroom for disk I/O coinciding with another beat's
+  // render.
   await expect(textarea).toBeHidden({ timeout: 30_000 });
 }
 

--- a/e2e-live/tests/mulmo-script-edit.spec.ts
+++ b/e2e-live/tests/mulmo-script-edit.spec.ts
@@ -19,21 +19,19 @@ const LEDIT_TIMEOUT_MS = 3 * ONE_MINUTE_MS;
 test.describe.configure({ mode: "parallel" });
 
 test.describe("mulmoScript edit (real workspace)", () => {
-  // Pending until issue #1074 is fixed: the per-beat "Saving…"
-  // button never flips back to enabled within 30s on chromium. The
-  // observation matches the suspicion raised in #1074 (edits don't
-  // round-trip cleanly), so this spec already encodes the failure
-  // mode — keep it on disk as the regression net, but skip so the
-  // suite stays green until the underlying save path is debugged.
-  //
-  // **Unskip trigger** (so this spec doesn't go permanently dormant):
-  // when issue #1074 is closed AND the merge that fixes it is
-  // available locally, run this spec by hand on chromium first
-  //     yarn test:e2e:live:mulmo-script-edit
-  // and only drop the `test.skip(true, ...)` line below if the run
-  // passes end-to-end. The TODO is owned by whoever closes #1074.
+  // Regression net for #1074. The fix has two halves:
+  //   1. View re-reads the script from disk on mount via
+  //      `refreshScriptFromDisk`, so a session-restore after page
+  //      reload (or `page.goto` round-trip) picks up edits made via
+  //      `update-beat` / `update-script` instead of the stale
+  //      toolResult cached in the JSONL.
+  //   2. The wait condition after clicking the per-beat update
+  //      button watches the textarea closing — successful saves
+  //      flip `sourceOpen[index] = false` which removes the entire
+  //      editor block via `v-if`. Earlier versions waited for the
+  //      button to re-enable, but the button is gone from the DOM
+  //      by then so `toBeEnabled` always timed out at 30s.
   test("L-EDIT: beat 編集 → 更新 → 別セッションへ移動 → 戻ると編集が永続化されている", async ({ page }, testInfo) => {
-    test.skip(true, "Pending issue #1074 — drop this skip after #1074 closes and the spec passes once locally on chromium");
     test.setTimeout(LEDIT_TIMEOUT_MS);
     // Covers issue #1074 — beat edits made via the source-editor
     // textarea were reported to disappear after navigating away and
@@ -101,12 +99,14 @@ async function editBeat0Text(page: import("@playwright/test").Page, marker: stri
   }
   await textarea.fill(originalJson.replace('"text": ""', `"text": "${marker}"`));
   await page.getByTestId("mulmo-script-beat-update-button-0").click();
-  // The button flips to disabled while saving and back when done;
-  // wait for it to settle before navigating away. updateBeat hits
-  // the server, parses the JSON, rewrites the script file, and
-  // refreshes the studio context — give it 30s in case the disk
-  // I/O coincides with another beat's render.
-  await expect(page.getByTestId("mulmo-script-beat-update-button-0")).toBeEnabled({ timeout: 30_000 });
+  // On a successful save the View flips `sourceOpen[index] = false`,
+  // which unmounts the entire editor block (button + textarea) via
+  // `v-if`. Wait for the textarea to detach instead of the button
+  // re-enabling — the button isn't in the DOM after a successful
+  // save, so `toBeEnabled` would retry against a missing locator
+  // until the global timeout. 30s leaves headroom for disk I/O
+  // coinciding with another beat's render.
+  await expect(textarea).toBeHidden({ timeout: 30_000 });
 }
 
 async function assertBeat0EditPersisted(page: import("@playwright/test").Page, marker: string): Promise<void> {

--- a/plans/fix-1074-mulmoscript-edit-persist.md
+++ b/plans/fix-1074-mulmoscript-edit-persist.md
@@ -1,0 +1,54 @@
+# fix #1074 — presentMulmoScript: beat 編集が再表示時に消える問題
+
+## 背景
+
+`presentMulmoScript` view で beat を JSON 編集 → 「更新」 ボタン押下 → 別セッションを開き直す（または `/wiki` 経由でブラウザリロード）と、disk に書き込まれた編集が view に反映されず編集前の内容に戻ってしまう。
+
+## 根本原因
+
+`server/api/routes/mulmo-script.ts` の `update-beat` ハンドラは `writeJsonAtomic` で disk へ正しく永続化する。しかしクライアント (`src/plugins/presentMulmoScript/View.vue`) 側では:
+
+1. `updateBeat()` は `localOverrides[index] = beat` で in-memory に上書きするだけで、`emit("updateResult", ...)` を呼んでいない (`applySource()` とは挙動が違う)。
+2. `localOverrides` は `initializeScript()` で毎マウント時にクリアされる。
+3. `props.selectedResult.data.script` は 「ツールが最初に走ったとき」 の古いスナップショットのまま。
+4. ブラウザリロード時、`/api/sessions/:id` の JSONL から session を復元すると `entry.result` をそのまま使うので、ここで読まれる `data.script` は古いまま。
+5. View は `script.value = data.value?.script` を描画するため、disk が新しくても **画面上は古い** という乖離が発生する。
+
+つまり 「disk vs in-memory toolResult の不整合」 が #1074 の本体。e2e-live の L-EDIT が観測した `Saving…` が消えない問題は別件 (test 側の wait 条件が間違っていて、保存後 `sourceOpen[index]=false` で textarea が DOM から消えるため `toBeEnabled` がタイムアウトしている)。
+
+## 修正方針
+
+**Disk を source of truth にする。** `presentMulmoScript` View を mount するたびに `filePath` から `apiGet(filesEndpoints.content)` で disk の最新内容を取得し、`mulmoScriptSchema` で検証して、 props の値と差分があれば `emit("updateResult", ...)` で in-memory toolResult を更新する。
+
+`mulmoScript.save` の reopen path (`{ filePath }`) と挙動を揃える形になる。 副作用 (autoGenerateMovie 等) は呼ばないので mount 時の追加コストは files API 1 本のみ。
+
+### 実装範囲
+
+- `src/plugins/presentMulmoScript/helpers.ts`
+  - `parseDiskScript(raw: string): MulmoScriptParseResult` — 文字列 → script への純粋関数。invalid JSON / schema 不一致をそれぞれ識別する discriminated union。
+- `src/plugins/presentMulmoScript/View.vue`
+  - `refreshScriptFromDisk()` を追加 — `filePath.value` 経由で disk を読み、新しければ `emit("updateResult", ...)`。
+  - `initializeScript()` の冒頭 (state リセット直後、 per-beat hydrate より前) で `await refreshScriptFromDisk()`。
+- `e2e-live/tests/mulmo-script-edit.spec.ts`
+  - `test.skip(true, ...)` を削除。
+  - クリック後の wait 条件を 「textarea が detach される」 に変更（`toBeEnabled` だと DOM から消えた瞬間に retry し続けてタイムアウトする）。
+- `test/plugins/presentMulmoScript/helpers.test.ts` (新規)
+  - `parseDiskScript` の happy path / invalid JSON / schema 不一致 / 空文字列。
+
+### 影響範囲
+
+- `presentMulmoScript` view のみ。 他の plugin に波及しない。
+- 既存ツール結果には変化なし (パースに失敗したらスキップして props のままを使う)。
+- `mulmoScript.save` の reopen path とは別ルート (file content API)。 schema 検証は client 側で行う。
+
+## TODO
+
+- [x] 根本原因の特定
+- [x] plan 作成
+- [ ] `helpers.ts` に `parseDiskScript` 抽出
+- [ ] `View.vue` の `initializeScript` に refresh ロジック追加
+- [ ] unit test (`helpers.test.ts`) 追加
+- [ ] e2e-live spec の wait 条件修正 + `test.skip` 解除
+- [ ] `yarn format / lint / typecheck / build / test`
+- [ ] 手動で chromium に対し e2e-live を回して PASS することを確認 (skip 解除のトリガー条件)
+- [ ] PR 作成

--- a/plans/fix-1074-mulmoscript-edit-persist.md
+++ b/plans/fix-1074-mulmoscript-edit-persist.md
@@ -51,5 +51,6 @@
 - [x] e2e-live spec の wait 条件修正 (`toBeHidden`) + `test.skip` 解除
 - [x] `yarn format / lint / typecheck / build / test`
 - [x] codex-cross-review iteration 1: race condition 指摘を受けて `requestedUuid` / `requestedFilePath` キャプチャ + post-await re-check を追加
-- [ ] 手動で chromium に対し e2e-live を回して PASS することを確認 (skip 解除のトリガー条件)
+- [x] codex-cross-review iteration 2: LGTM
+- [x] 手動で chromium に対し e2e-live を回して PASS することを確認 — `yarn test:e2e:live:mulmo-script-edit --project=chromium` で 18s で PASS (worktree の yarn dev に対して)
 - [ ] PR 作成

--- a/plans/fix-1074-mulmoscript-edit-persist.md
+++ b/plans/fix-1074-mulmoscript-edit-persist.md
@@ -45,10 +45,11 @@
 
 - [x] 根本原因の特定
 - [x] plan 作成
-- [ ] `helpers.ts` に `parseDiskScript` 抽出
-- [ ] `View.vue` の `initializeScript` に refresh ロジック追加
-- [ ] unit test (`helpers.test.ts`) 追加
-- [ ] e2e-live spec の wait 条件修正 + `test.skip` 解除
-- [ ] `yarn format / lint / typecheck / build / test`
+- [x] `helpers.ts` に `parseDiskScript` / `isSameScript` 抽出
+- [x] `View.vue` の `initializeScript` に refresh ロジック追加 (stale-response guard 込み)
+- [x] unit test (`test_helpers.ts`) 追加
+- [x] e2e-live spec の wait 条件修正 (`toBeHidden`) + `test.skip` 解除
+- [x] `yarn format / lint / typecheck / build / test`
+- [x] codex-cross-review iteration 1: race condition 指摘を受けて `requestedUuid` / `requestedFilePath` キャプチャ + post-await re-check を追加
 - [ ] 手動で chromium に対し e2e-live を回して PASS することを確認 (skip 解除のトリガー条件)
 - [ ] PR 作成

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -1098,10 +1098,21 @@ async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolea
  * The flow is read-only on success-equal path (no emit), and
  * silently bails on every failure mode so a missing / malformed /
  * deleted script file never blocks the rest of `initializeScript`.
+ *
+ * Stale-response guard: capture `uuid` + `filePath` before the
+ * `await`. If either has changed by the time the response lands
+ * (the user navigated to a different result while the request
+ * was in flight, or `props.selectedResult` was swapped under us
+ * by a parent watcher), drop the response on the floor — the new
+ * `initializeScript` invocation triggered by that change will
+ * issue its own refresh against the correct file.
  */
 async function refreshScriptFromDisk(): Promise<void> {
-  if (!filePath.value) return;
-  const response = await apiGet<{ content?: string }>(filesEndpoints.content, { path: filePath.value });
+  const requestedFilePath = filePath.value;
+  if (!requestedFilePath) return;
+  const requestedUuid = props.selectedResult.uuid;
+  const response = await apiGet<{ content?: string }>(filesEndpoints.content, { path: requestedFilePath });
+  if (props.selectedResult.uuid !== requestedUuid || filePath.value !== requestedFilePath) return;
   if (!response.ok || typeof response.data.content !== "string") return;
   const result = parseDiskScript(response.data.content, mulmoScriptSchema);
   if (result.kind !== "ok") return;

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -450,7 +450,6 @@ import { useActiveSession } from "../../composables/useActiveSession";
 import { GENERATION_KINDS, type PendingGeneration } from "../../types/events";
 
 const endpoints = pluginEndpoints<MulmoScriptEndpoints>("mulmoScript");
-const filesEndpoints = pluginEndpoints<{ content: string }>("files");
 
 const { t } = useI18n();
 
@@ -701,12 +700,18 @@ async function onSourceToggle(open: boolean) {
   editing.value = open;
   if (open) {
     let text = scriptSourceText.value;
-    // Read the current file from disk so beat-level edits are reflected
+    // Re-read the current file from disk so beat-level edits made
+    // since mount (other tabs, MCP, manual edits) surface in the
+    // editor. Uses the reopen endpoint for the same reason
+    // refreshScriptFromDisk does — `filePath.value` is the wire form
+    // `stories/<rel>` and only `mulmoScript.save` knows how to map
+    // it to the on-disk path under `artifacts/stories/...`. The
+    // generic `/api/files/content` 404s for that wire form (#1074
+    // post-mortem) and silently falls back to in-memory state.
     if (filePath.value) {
-      const response = await apiGet<{ content?: string }>(filesEndpoints.content, { path: filePath.value });
-      if (response.ok && response.data.content) {
-        text = response.data.content;
-      }
+      const response = await apiPost<{ data?: { script?: MulmoScript } }>(endpoints.save.url, { filePath: filePath.value });
+      const diskScript = response.ok ? response.data?.data?.script : undefined;
+      if (diskScript) text = JSON.stringify(diskScript, null, 2);
       // fall through to in-memory script on failure
     }
     editableSource.value = text;

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -440,7 +440,15 @@ import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { MulmoScriptData } from "./index";
 import { mulmoBeatSchema, mulmoScriptSchema } from "@mulmocast/types";
-import { extractErrorMessage, getMissingCharacterKeys, shouldAutoRenderBeat, streamMovieEvents, validateBeatJSON } from "./helpers";
+import {
+  extractErrorMessage,
+  getMissingCharacterKeys,
+  isSameScript,
+  parseDiskScript,
+  shouldAutoRenderBeat,
+  streamMovieEvents,
+  validateBeatJSON,
+} from "./helpers";
 import { apiGet, apiPost, apiFetchRaw } from "../../utils/api";
 import { pluginEndpoints } from "../api";
 import type { MulmoScriptEndpoints } from "./definition";
@@ -1079,6 +1087,31 @@ async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolea
   }
 }
 
+/**
+ * #1074 — keep the in-memory toolResult in sync with the on-disk
+ * script file. `update-beat` / `update-script` persist edits to
+ * disk, but the JSONL session entry that backs
+ * `props.selectedResult.data.script` is never rewritten, so a
+ * page reload + session-restore would otherwise surface stale
+ * pre-edit content.
+ *
+ * The flow is read-only on success-equal path (no emit), and
+ * silently bails on every failure mode so a missing / malformed /
+ * deleted script file never blocks the rest of `initializeScript`.
+ */
+async function refreshScriptFromDisk(): Promise<void> {
+  if (!filePath.value) return;
+  const response = await apiGet<{ content?: string }>(filesEndpoints.content, { path: filePath.value });
+  if (!response.ok || typeof response.data.content !== "string") return;
+  const result = parseDiskScript(response.data.content, mulmoScriptSchema);
+  if (result.kind !== "ok") return;
+  if (isSameScript(result.script, script.value)) return;
+  emit("updateResult", {
+    ...props.selectedResult,
+    data: { ...props.selectedResult.data, script: result.script },
+  });
+}
+
 async function initializeScript() {
   // Reset scroll position so new results start at the top
   if (beatListEl.value) beatListEl.value.scrollTop = 0;
@@ -1100,6 +1133,17 @@ async function initializeScript() {
   Object.keys(beatDragOver).forEach((key) => Reflect.deleteProperty(beatDragOver, key));
   moviePath.value = null;
   if (sourceDetails.value) sourceDetails.value.open = false;
+
+  // #1074 — re-read the script file from disk before per-beat
+  // hydration. Disk is the source of truth: `update-beat` /
+  // `update-script` write through `writeJsonAtomic`, but the
+  // toolResult cached in `props.selectedResult.data.script` was
+  // captured when the tool first ran and is never updated by the
+  // session-restore path (`/api/sessions/:id` JSONL still holds the
+  // old result entry). Without this refresh, a page reload — or any
+  // navigation that round-trips through the SPA boot — shows
+  // pre-edit content even though the json file on disk is correct.
+  await refreshScriptFromDisk();
 
   // Mount-time policy: prefer the existing PNG on the server. Every
   // beat — deterministic AND imagePrompt — first probes /beat-image,

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -440,15 +440,7 @@ import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { MulmoScriptData } from "./index";
 import { mulmoBeatSchema, mulmoScriptSchema } from "@mulmocast/types";
-import {
-  extractErrorMessage,
-  getMissingCharacterKeys,
-  isSameScript,
-  parseDiskScript,
-  shouldAutoRenderBeat,
-  streamMovieEvents,
-  validateBeatJSON,
-} from "./helpers";
+import { extractErrorMessage, getMissingCharacterKeys, isSameScript, shouldAutoRenderBeat, streamMovieEvents, validateBeatJSON } from "./helpers";
 import { apiGet, apiPost, apiFetchRaw } from "../../utils/api";
 import { pluginEndpoints } from "../api";
 import type { MulmoScriptEndpoints } from "./definition";
@@ -1095,9 +1087,20 @@ async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolea
  * page reload + session-restore would otherwise surface stale
  * pre-edit content.
  *
- * The flow is read-only on success-equal path (no emit), and
- * silently bails on every failure mode so a missing / malformed /
- * deleted script file never blocks the rest of `initializeScript`.
+ * Why the reopen endpoint, not `/api/files/content`: `filePath`
+ * is the wire form `stories/<rel>` which `mulmoScript.save` knows
+ * how to translate back to the real on-disk path under
+ * `artifacts/stories/...` via `resolveStoryPath`. The generic
+ * file-content endpoint resolves against workspace root, so it
+ * 404s for the same wire form (and was silently masking #1074 in
+ * an earlier draft of this fix — see `[files] GET content: gated
+ * by resolve/stat` warnings in the server log). The reopen route
+ * is read-only when `script` is omitted; it does NOT trigger movie
+ * generation unless `autoGenerateMovie: true` is passed.
+ *
+ * The flow silently bails on every failure mode so a missing /
+ * malformed / deleted script file never blocks the rest of
+ * `initializeScript`.
  *
  * Stale-response guard: capture `uuid` + `filePath` before the
  * `await`. If either has changed by the time the response lands
@@ -1111,15 +1114,18 @@ async function refreshScriptFromDisk(): Promise<void> {
   const requestedFilePath = filePath.value;
   if (!requestedFilePath) return;
   const requestedUuid = props.selectedResult.uuid;
-  const response = await apiGet<{ content?: string }>(filesEndpoints.content, { path: requestedFilePath });
+  const response = await apiPost<{ data?: { script?: MulmoScript } }>(endpoints.save.url, { filePath: requestedFilePath });
   if (props.selectedResult.uuid !== requestedUuid || filePath.value !== requestedFilePath) return;
-  if (!response.ok || typeof response.data.content !== "string") return;
-  const result = parseDiskScript(response.data.content, mulmoScriptSchema);
-  if (result.kind !== "ok") return;
-  if (isSameScript(result.script, script.value)) return;
+  if (!response.ok) return;
+  const diskScript = response.data?.data?.script;
+  // Server-side `loadScriptFromDisk` already validated against
+  // `mulmoScriptSchema`, so a non-null `script` is trusted here —
+  // we only need a presence check.
+  if (!diskScript) return;
+  if (isSameScript(diskScript, script.value)) return;
   emit("updateResult", {
     ...props.selectedResult,
-    data: { ...props.selectedResult.data, script: result.script },
+    data: { ...props.selectedResult.data, script: diskScript },
   });
 }
 
@@ -1146,14 +1152,17 @@ async function initializeScript() {
   if (sourceDetails.value) sourceDetails.value.open = false;
 
   // #1074 — re-read the script file from disk before per-beat
-  // hydration. Disk is the source of truth: `update-beat` /
-  // `update-script` write through `writeJsonAtomic`, but the
-  // toolResult cached in `props.selectedResult.data.script` was
-  // captured when the tool first ran and is never updated by the
-  // session-restore path (`/api/sessions/:id` JSONL still holds the
-  // old result entry). Without this refresh, a page reload — or any
-  // navigation that round-trips through the SPA boot — shows
-  // pre-edit content even though the json file on disk is correct.
+  // hydration. The server's `enrichWithMulmoScript`
+  // (server/api/routes/sessions.ts) already re-merges disk content
+  // into toolResult.data.script when the SPA reloads via
+  // `/api/sessions/:id`. But that path only fires on full page
+  // reload — when the user switches between tool results inside
+  // the same SPA mount and switches back, the in-memory ActiveSession
+  // toolResult still carries whatever script was captured when the
+  // SPA first booted, and `localOverrides` (the only thing showing
+  // the user's edit since the last save) is reset by initializeScript
+  // on remount. Re-fetching from disk via the reopen endpoint here
+  // covers that gap. See issue #1074 for the original repro.
   await refreshScriptFromDisk();
 
   // Mount-time policy: prefer the existing PNG on the server. Every

--- a/src/plugins/presentMulmoScript/helpers.ts
+++ b/src/plugins/presentMulmoScript/helpers.ts
@@ -75,6 +75,15 @@ export interface SafeParseSchema {
 }
 
 /**
+ * Same as {@link SafeParseSchema} but returning the parsed value
+ * on success. Used by {@link parseDiskScript} where we need the
+ * concrete script object, not just a boolean.
+ */
+export interface SafeParseSchemaWithData<T> {
+  safeParse: (value: unknown) => { success: true; data: T } | { success: false };
+}
+
+/**
  * Validate a candidate Beat JSON string against a schema.
  * Returns false on any JSON parse error or schema mismatch.
  */
@@ -86,6 +95,52 @@ export function validateBeatJSON(json: string, schema: SafeParseSchema): boolean
     return false;
   }
   return schema.safeParse(parsed).success;
+}
+
+/**
+ * Result of parsing a MulmoScript file's raw on-disk content.
+ * Discriminated so the caller can distinguish "use this fresher
+ * data" from "fall back to in-memory props" without leaking the
+ * Zod issue list — {@link refreshScriptFromDisk} only needs to
+ * decide whether to emit `updateResult`.
+ */
+export type ParseDiskScriptResult<T> = { kind: "ok"; script: T } | { kind: "empty" } | { kind: "invalidJson" } | { kind: "schemaMismatch" };
+
+/**
+ * Parse a script file's raw text into a validated MulmoScript.
+ * Used by {@link refreshScriptFromDisk} on every view mount to
+ * pick up edits made via `update-beat` / `update-script` since
+ * the toolResult was first persisted (#1074). Returns a
+ * discriminated union so the caller can react to each failure
+ * mode (empty file, malformed JSON, schema drift) without
+ * pulling in Zod's issue formatting here.
+ */
+export function parseDiskScript<T>(raw: string, schema: SafeParseSchemaWithData<T>): ParseDiskScriptResult<T> {
+  if (raw === "") return { kind: "empty" };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: "invalidJson" };
+  }
+  const validation = schema.safeParse(parsed);
+  if (!validation.success) return { kind: "schemaMismatch" };
+  return { kind: "ok", script: validation.data };
+}
+
+/**
+ * Stable structural equality for two MulmoScripts via JSON
+ * canonicalisation. We compare the full re-serialised string
+ * rather than walking keys because (a) MulmoScript is
+ * deeply-nested and Object.keys-recursion would be ~50 lines, and
+ * (b) `JSON.stringify` already preserves insertion order, which
+ * `mulmoScriptSchema.safeParse` keeps stable across runs of the
+ * same input. False positives (= "differ" when they don't) only
+ * cost an extra `emit("updateResult", ...)` which is a no-op when
+ * data hasn't actually changed.
+ */
+export function isSameScript(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 /** Convert an unknown thrown value into a human-readable string. */

--- a/src/plugins/presentMulmoScript/helpers.ts
+++ b/src/plugins/presentMulmoScript/helpers.ts
@@ -75,15 +75,6 @@ export interface SafeParseSchema {
 }
 
 /**
- * Same as {@link SafeParseSchema} but returning the parsed value
- * on success. Used by {@link parseDiskScript} where we need the
- * concrete script object, not just a boolean.
- */
-export interface SafeParseSchemaWithData<T> {
-  safeParse: (value: unknown) => { success: true; data: T } | { success: false };
-}
-
-/**
  * Validate a candidate Beat JSON string against a schema.
  * Returns false on any JSON parse error or schema mismatch.
  */
@@ -95,37 +86,6 @@ export function validateBeatJSON(json: string, schema: SafeParseSchema): boolean
     return false;
   }
   return schema.safeParse(parsed).success;
-}
-
-/**
- * Result of parsing a MulmoScript file's raw on-disk content.
- * Discriminated so the caller can distinguish "use this fresher
- * data" from "fall back to in-memory props" without leaking the
- * Zod issue list — {@link refreshScriptFromDisk} only needs to
- * decide whether to emit `updateResult`.
- */
-export type ParseDiskScriptResult<T> = { kind: "ok"; script: T } | { kind: "empty" } | { kind: "invalidJson" } | { kind: "schemaMismatch" };
-
-/**
- * Parse a script file's raw text into a validated MulmoScript.
- * Used by {@link refreshScriptFromDisk} on every view mount to
- * pick up edits made via `update-beat` / `update-script` since
- * the toolResult was first persisted (#1074). Returns a
- * discriminated union so the caller can react to each failure
- * mode (empty file, malformed JSON, schema drift) without
- * pulling in Zod's issue formatting here.
- */
-export function parseDiskScript<T>(raw: string, schema: SafeParseSchemaWithData<T>): ParseDiskScriptResult<T> {
-  if (raw === "") return { kind: "empty" };
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { kind: "invalidJson" };
-  }
-  const validation = schema.safeParse(parsed);
-  if (!validation.success) return { kind: "schemaMismatch" };
-  return { kind: "ok", script: validation.data };
 }
 
 /**

--- a/test/plugins/presentMulmoScript/test_helpers.ts
+++ b/test/plugins/presentMulmoScript/test_helpers.ts
@@ -4,12 +4,15 @@ import {
   applyMovieEvent,
   extractErrorMessage,
   getMissingCharacterKeys,
+  isSameScript,
+  parseDiskScript,
   parseSSEEventLine,
   shouldAutoRenderBeat,
   streamMovieEvents,
   validateBeatJSON,
   type MovieEventHandlers,
   type SafeParseSchema,
+  type SafeParseSchemaWithData,
 } from "../../../src/plugins/presentMulmoScript/helpers.js";
 
 describe("parseSSEEventLine", () => {
@@ -328,5 +331,76 @@ describe("streamMovieEvents", () => {
     const spy = makeSpy();
     await streamMovieEvents(streamFromChunks([]), spy.handlers);
     assert.equal(spy.calls.length, 0);
+  });
+});
+
+// Schema fake that mirrors the (success | failure) shape Zod
+// produces from `safeParse`, so we don't have to drag the real
+// MulmoScript schema into a unit test.
+function makeSchema<T>(predicate: (value: unknown) => value is T): SafeParseSchemaWithData<T> {
+  return {
+    safeParse: (value: unknown) => (predicate(value) ? { success: true, data: value } : { success: false }),
+  };
+}
+
+const isMulmoScriptish = (value: unknown): value is { beats?: unknown[] } =>
+  typeof value === "object" && value !== null && Array.isArray((value as { beats?: unknown }).beats);
+
+const okSchema = makeSchema(isMulmoScriptish);
+
+describe("parseDiskScript (#1074)", () => {
+  it("returns ok with the parsed script for valid JSON + matching schema", () => {
+    const result = parseDiskScript('{"beats":[{"text":"hi"}]}', okSchema);
+    assert.deepEqual(result, { kind: "ok", script: { beats: [{ text: "hi" }] } });
+  });
+
+  it("returns empty for an empty string (the typical 'file not yet on disk' probe)", () => {
+    assert.deepEqual(parseDiskScript("", okSchema), { kind: "empty" });
+  });
+
+  it("returns invalidJson when the disk content cannot be parsed", () => {
+    assert.deepEqual(parseDiskScript("{ not json", okSchema), { kind: "invalidJson" });
+  });
+
+  it("returns schemaMismatch when JSON parses but the shape is not a MulmoScript", () => {
+    assert.deepEqual(parseDiskScript('{"foo":"bar"}', okSchema), { kind: "schemaMismatch" });
+  });
+
+  it("treats null / scalar payloads as schemaMismatch, not invalidJson", () => {
+    // `JSON.parse("null")` succeeds but won't pass any object-shape
+    // schema. The bell on the View needs this distinction so it
+    // doesn't surface "the file is corrupt" when actually it just
+    // hasn't been written with a script body yet.
+    assert.deepEqual(parseDiskScript("null", okSchema), { kind: "schemaMismatch" });
+    assert.deepEqual(parseDiskScript("42", okSchema), { kind: "schemaMismatch" });
+  });
+});
+
+describe("isSameScript (#1074)", () => {
+  it("returns true when two scripts serialise identically", () => {
+    const left = { title: "x", beats: [{ text: "" }] };
+    const right = { title: "x", beats: [{ text: "" }] };
+    assert.equal(isSameScript(left, right), true);
+  });
+
+  it("returns false when a single field differs", () => {
+    const left = { title: "x", beats: [{ text: "" }] };
+    const right = { title: "x", beats: [{ text: "edited" }] };
+    assert.equal(isSameScript(left, right), false);
+  });
+
+  it("treats different key insertion order as different — false negatives are cheap, false positives are not", () => {
+    // We intentionally rely on JSON.stringify's insertion-order
+    // semantics here. If two scripts have the same fields but
+    // different key order this returns false, which costs us one
+    // wasted `emit("updateResult", ...)` — strictly safer than
+    // dropping a real edit on the floor.
+    const left = { title: "x", lang: "en" };
+    const right = { lang: "en", title: "x" };
+    assert.equal(isSameScript(left, right), false);
+  });
+
+  it("returns true for two empty objects", () => {
+    assert.equal(isSameScript({}, {}), true);
   });
 });

--- a/test/plugins/presentMulmoScript/test_helpers.ts
+++ b/test/plugins/presentMulmoScript/test_helpers.ts
@@ -5,14 +5,12 @@ import {
   extractErrorMessage,
   getMissingCharacterKeys,
   isSameScript,
-  parseDiskScript,
   parseSSEEventLine,
   shouldAutoRenderBeat,
   streamMovieEvents,
   validateBeatJSON,
   type MovieEventHandlers,
   type SafeParseSchema,
-  type SafeParseSchemaWithData,
 } from "../../../src/plugins/presentMulmoScript/helpers.js";
 
 describe("parseSSEEventLine", () => {
@@ -331,48 +329,6 @@ describe("streamMovieEvents", () => {
     const spy = makeSpy();
     await streamMovieEvents(streamFromChunks([]), spy.handlers);
     assert.equal(spy.calls.length, 0);
-  });
-});
-
-// Schema fake that mirrors the (success | failure) shape Zod
-// produces from `safeParse`, so we don't have to drag the real
-// MulmoScript schema into a unit test.
-function makeSchema<T>(predicate: (value: unknown) => value is T): SafeParseSchemaWithData<T> {
-  return {
-    safeParse: (value: unknown) => (predicate(value) ? { success: true, data: value } : { success: false }),
-  };
-}
-
-const isMulmoScriptish = (value: unknown): value is { beats?: unknown[] } =>
-  typeof value === "object" && value !== null && Array.isArray((value as { beats?: unknown }).beats);
-
-const okSchema = makeSchema(isMulmoScriptish);
-
-describe("parseDiskScript (#1074)", () => {
-  it("returns ok with the parsed script for valid JSON + matching schema", () => {
-    const result = parseDiskScript('{"beats":[{"text":"hi"}]}', okSchema);
-    assert.deepEqual(result, { kind: "ok", script: { beats: [{ text: "hi" }] } });
-  });
-
-  it("returns empty for an empty string (the typical 'file not yet on disk' probe)", () => {
-    assert.deepEqual(parseDiskScript("", okSchema), { kind: "empty" });
-  });
-
-  it("returns invalidJson when the disk content cannot be parsed", () => {
-    assert.deepEqual(parseDiskScript("{ not json", okSchema), { kind: "invalidJson" });
-  });
-
-  it("returns schemaMismatch when JSON parses but the shape is not a MulmoScript", () => {
-    assert.deepEqual(parseDiskScript('{"foo":"bar"}', okSchema), { kind: "schemaMismatch" });
-  });
-
-  it("treats null / scalar payloads as schemaMismatch, not invalidJson", () => {
-    // `JSON.parse("null")` succeeds but won't pass any object-shape
-    // schema. The bell on the View needs this distinction so it
-    // doesn't surface "the file is corrupt" when actually it just
-    // hasn't been written with a script body yet.
-    assert.deepEqual(parseDiskScript("null", okSchema), { kind: "schemaMismatch" });
-    assert.deepEqual(parseDiskScript("42", okSchema), { kind: "schemaMismatch" });
   });
 });
 


### PR DESCRIPTION
## Summary
- #1074 の修正です。

- presentMulmoScript の View が SPA 内ナビ (sidebar tab click 等) で再 mount された時に **disk から script を読み直す** ようにする。 これまでは in-memory toolResult が古いまま使われ、 編集前の内容に戻って見える問題があった。
- e2e-live spec (`mulmo-script-edit.spec.ts`) の `test.skip` を解除。 ただし元の `page.goto` 経路は **server 側の既存 enrichment** で偽 PASS してしまうので、 sidebar testid click (true Vue Router push) で in-SPA ナビ経路を踏む形に書き換え。 fix を切ると test FAIL することを対照実験で確認済み。

## Items to Confirm / Review

- **endpoint 選択**: `refreshScriptFromDisk` / `onSourceToggle` ともに `POST /api/mulmoScript/save` (reopen mode、 `{ filePath }` のみ送信) を mount のたびに叩く形にした。 `loadScriptFromDisk` → `resolveStoryPath` で wire form `stories/<rel>` を realpath に正しく解決させるためで、 `autoGenerateMovie` を渡さなければ side effect なし (= disk read + schema validate のみ) という前提。 ここに落とし穴あれば指摘お願いします。
- **script-level editor の挙動変更**: 「Edit Script Source」 (bottom-bar `<details>`) を開いた時の disk read も同じ reopen endpoint に統一。 表示は schema validated な script object を JSON.stringify した文字列。 元は raw file content をそのまま textarea に流していた (= server validation 通っていない可能性あり) が、 こちらの方が安全。
- **stale-response guard**: `await` 中に `props.selectedResult` が別 result に切り替わった場合の race を `requestedUuid` + `requestedFilePath` capture + 後段 re-check で防いでいる (Codex iter-1 指摘)。
- **e2e-live test の sidebar testid 依存**: `plugin-launcher-wiki` と \`session-tab-\${id}\` に依存。 sidebar refactor 時に silent regression にならないか念の為。

## User Prompt

> L-EDIT chromium 🟡 skip 中 #1074 OPEN
> presentMulmoScript で beat 編集 → 「更新」 押すと Saving… から戻らない / 別セッション開き直すと編集内容が消える疑い。 spec は再現用に on disk、 issue close + fix merge 後に test.skip(true, ...) 削除する unskip trigger 設計

## 実装アプローチ

### 当初の認識違い

最初の調査で 「edit が disk に書かれる → JSONL session entry は更新されない → page reload 時に古い toolResult が復元される」 と仮説を立て、 mount 時に \`/api/files/content\` で disk を読み直す fix を入れた。 ところが:

1. `/api/files/content` は workspace root 起点で path 解決するため `stories/<rel>` (= 実体は `artifacts/stories/<rel>`) を 404 で reject していて silent bail していた (server log に \`[files] GET content: gated by resolve/stat\`)。
2. それでも e2e-live test が PASS していたのは、 server 側に既に \`enrichWithMulmoScript\` (`server/api/routes/sessions.ts`) が存在していて、 \`/api/sessions/:id\` でセッション復元する時に disk から script を読み直して toolResult に merge していたため。
3. つまり最初の fix も最初の test も両方とも broken で、 関係ない server 機能のおかげで偽 PASS していた。

### 真の bug 経路

ユーザー報告のシナリオ (sidebar の別 session tab を click → 戻る) は **SPA 内ナビゲーション** であり、 `/api/sessions/:id` が再 fetch されない (cache hit)。 server enrichment は走らず、 in-memory `ActiveSession.toolResults[i].data.script` は最初に load された時点の古い内容のまま。 View 側で disk を読み直す path が必要。

### 修正

- `refreshScriptFromDisk` を \`POST /api/mulmoScript/save\` (reopen mode) に切り替え。 server 側の `loadScriptFromDisk` が `resolveStoryPath` で wire form を正しく解決し、 schema validation 済み script object を返す。 client は presence check + `isSameScript` で diff 判定して `emit('updateResult', ...)` を発火。
- `initializeScript` の冒頭 (state リセット直後、 per-beat hydrate より前) で `await refreshScriptFromDisk()`。
- `onSourceToggle` も同じ broken path に依存していたので reopen endpoint に統一 (Codex iter-3 指摘)。
- e2e-live test を `page.goto` から sidebar testid click に変更。 fix 無効化で test FAIL することを対照実験で確認 (= 本当に bug 経路を catch している)。
- 不要になった \`parseDiskScript\` helper + tests と \`filesEndpoints\` 定数を削除。

### Codex cross-review

\`/codex-cross-review\` を 4 iteration 回して両 reviewer LGTM:
- iter 1 (CHANGES REQUESTED): refreshScriptFromDisk の async stale-response race → uuid + filePath capture で対応
- iter 2 (LGTM): ※後で偽 PASS と判明
- iter 3 (CHANGES REQUESTED): onSourceToggle も同じ broken path → reopen endpoint に統一
- iter 4 (LGTM): 残課題なし

### テスト

- unit (`test/plugins/presentMulmoScript/test_helpers.ts`): `isSameScript` の happy / boundary / empty
- e2e-live (`e2e-live/tests/mulmo-script-edit.spec.ts`): chromium で PASS。 fix 無効化で FAIL することを確認

### ローカル確認

- yarn format / lint / typecheck / build / test → 全 green (4,331 unit tests)
- yarn test:e2e:live:mulmo-script-edit --project=chromium → PASS (15s)

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mulmo script edits now persist and reappear correctly when reopening the editor or navigating within the app.

* **Behavior Change**
  * Editor now refreshes from the latest on-disk script on open/remount to keep in-memory edits synced with persisted content.

* **Tests**
  * Reactivated end-to-end regression test for Mulmo script edit persistence and added unit tests to verify script equality.

* **Documentation**
  * Added a plan describing root cause analysis and the approach to ensure disk is treated as the source of truth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->