### PR TITLE
feat(photo-exif): post-save EXIF capture + sidecar persistence (#1222 PR-A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "dompurify": "^3.4.2",
     "dotenv": "^17.4.2",
     "echarts": "^6.0.0",
+    "exifr": "^7.1.3",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.3",
     "gui-chat-protocol": "0.3.3",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -35,6 +35,7 @@
     "@receptron/task-scheduler": "^0.1.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
+    "exifr": "^7.1.3",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.7.3",
     "gui-chat-protocol": "0.3.3",

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,8 @@ import { createNotificationsRouter } from "./api/routes/notifications.js";
 import { startLegacyAdapters } from "./notifier/legacy-adapters.js";
 import notifierRoutes from "./api/routes/notifier.js";
 import { initNotifier } from "./notifier/engine.js";
+import { registerSaveAttachmentHook } from "./utils/files/attachment-store.js";
+import { capturePhotoLocation } from "./workspace/photo-locations/index.js";
 import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
@@ -696,6 +698,12 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   // legacy wrapper or plugin-runtime — triggers the same fan-out the
   // legacy `publishNotification()` did inline before PR 4.
   startLegacyAdapters({ pushToBridge: chatService.pushToBridge });
+
+  // --- Photo-EXIF capture hook (#1222 PR-A) ---
+  // Runs after every saved attachment. The hook itself decides
+  // whether to act (image MIME + auto-capture enabled) — the
+  // registration is unconditional.
+  registerSaveAttachmentHook(capturePhotoLocation);
 
   // --- Plugin META aggregator diagnostics ---
   // After the notifier engine is initialized so the wrapper has a

--- a/server/index.ts
+++ b/server/index.ts
@@ -131,6 +131,15 @@ runMemoryMigrationOnce(workspacePath)
 
 let sandboxEnabled = false;
 
+// --- Photo-EXIF capture hook (#1222 PR-A) ---
+// Registered at module load (NOT inside `startRuntimeServices`)
+// because uploads can land in the gap between `app.listen` accepting
+// connections and the runtime-services bootstrap finishing. The hook
+// itself short-circuits on non-image MIME / auto-capture opt-out, so
+// registering early is free for non-photo flows. (CodeRabbit review
+// on PR #1247.)
+registerSaveAttachmentHook(capturePhotoLocation);
+
 const app = express();
 
 app.disable("x-powered-by");
@@ -698,12 +707,6 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   // legacy wrapper or plugin-runtime — triggers the same fan-out the
   // legacy `publishNotification()` did inline before PR 4.
   startLegacyAdapters({ pushToBridge: chatService.pushToBridge });
-
-  // --- Photo-EXIF capture hook (#1222 PR-A) ---
-  // Runs after every saved attachment. The hook itself decides
-  // whether to act (image MIME + auto-capture enabled) — the
-  // registration is unconditional.
-  registerSaveAttachmentHook(capturePhotoLocation);
 
   // --- Plugin META aggregator diagnostics ---
   // After the notifier engine is initialized so the wrapper has a

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -30,6 +30,17 @@ export interface AppSettings {
   // prop from `App.vue`. Stored verbatim (local-desktop threat
   // model, same as Spotify token persistence).
   googleMapsApiKey?: string;
+
+  // Photo-EXIF auto-capture (#1222 PR-A). When `autoCapture` is true
+  // (the default), every saved attachment with an image MIME runs
+  // through `readPhotoExif` and a sidecar JSON lands at
+  // `data/locations/<YYYY>/<MM>/<id>.json`. Users opt out via
+  // Settings → Privacy when they don't want GPS metadata captured
+  // automatically (the future `manageMap` `extractExif` tool can
+  // still read EXIF on demand).
+  photoExif?: {
+    autoCapture: boolean;
+  };
 }
 
 const DEFAULT_SETTINGS: AppSettings = { extraAllowedTools: [] };
@@ -53,10 +64,15 @@ export function ensureConfigsDir(): void {
   mkdirSync(configsDir(), { recursive: true });
 }
 
+function isPhotoExifSettings(value: unknown): value is { autoCapture: boolean } {
+  return isRecord(value) && typeof value.autoCapture === "boolean";
+}
+
 export function isAppSettings(value: unknown): value is AppSettings {
   if (!isRecord(value)) return false;
   if (!isStringArray(value.extraAllowedTools)) return false;
   if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
+  if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
   return true;
 }
 
@@ -76,6 +92,7 @@ export function isAppSettingsPatch(value: unknown): value is Partial<AppSettings
   if (!isRecord(value)) return false;
   if (value.extraAllowedTools !== undefined && !isStringArray(value.extraAllowedTools)) return false;
   if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
+  if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
   return true;
 }
 
@@ -97,7 +114,17 @@ function cloneAppSettings(settings: AppSettings): AppSettings {
   if (settings.googleMapsApiKey !== undefined) {
     copy.googleMapsApiKey = settings.googleMapsApiKey;
   }
+  if (settings.photoExif !== undefined) {
+    copy.photoExif = { autoCapture: settings.photoExif.autoCapture };
+  }
   return copy;
+}
+
+/** Read the photo-exif auto-capture flag with the documented
+ *  default of `true`. Centralises the "missing block ⇒ on" rule so
+ *  the post-save hook + future Settings UI stay aligned. */
+export function isPhotoExifAutoCaptureEnabled(settings: AppSettings): boolean {
+  return settings.photoExif?.autoCapture ?? true;
 }
 
 export function loadSettings(): AppSettings {
@@ -121,6 +148,9 @@ export function saveSettings(settings: AppSettings): void {
   const payload: AppSettings = { extraAllowedTools: [...settings.extraAllowedTools] };
   if (settings.googleMapsApiKey !== undefined) {
     payload.googleMapsApiKey = settings.googleMapsApiKey;
+  }
+  if (settings.photoExif !== undefined) {
+    payload.photoExif = { autoCapture: settings.photoExif.autoCapture };
   }
   const serialised = JSON.stringify(payload, null, 2);
   writeFileAtomicSync(settingsPath(), `${serialised}\n`, { mode: 0o600 });

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -133,11 +133,19 @@ export function loadSettings(): AppSettings {
   if (raw === null) return { ...DEFAULT_SETTINGS };
   const parsed = parseSettingsRaw(raw, file);
   if (parsed === null) return { ...DEFAULT_SETTINGS };
-  if (!isAppSettings(parsed)) {
+  // Accept the partial-patch shape, not just the full storage shape.
+  // A user who hand-edits `settings.json` to only set the fields they
+  // care about (`{ "photoExif": { "autoCapture": false } }` per the
+  // PR-A docs) shouldn't have their opt-out silently ignored just
+  // because `extraAllowedTools` is omitted. Missing fields fall back
+  // to DEFAULT_SETTINGS; only structurally-invalid payloads (wrong
+  // type on a present field) trigger the schema-warning fallback.
+  // (Codex review on PR #1247.)
+  if (!isAppSettingsPatch(parsed)) {
     log.warn("config", "settings.json does not match AppSettings schema — using defaults", { file });
     return { ...DEFAULT_SETTINGS };
   }
-  return cloneAppSettings(parsed);
+  return cloneAppSettings({ ...DEFAULT_SETTINGS, ...parsed });
 }
 
 export function saveSettings(settings: AppSettings): void {

--- a/server/utils/exif.ts
+++ b/server/utils/exif.ts
@@ -1,0 +1,165 @@
+// Thin wrapper around `exifr` for the photo-location capture flow
+// (#1222 PR-A).
+//
+// Why a wrapper:
+//   - `exifr.parse(...)` returns `unknown`-shaped data; everything
+//     except a tight allow-list is noise. Centralise the projection
+//     so the hook stays simple and the sidecar shape is the single
+//     source of truth.
+//   - exifr throws on malformed input. Tested call sites convert
+//     "no exif" / "corrupt jpeg" / "wrong mime" to a `null` return
+//     so the post-save hook never has to try/catch.
+//
+// Output is shape-compatible with `mapControl({ action: "addMarker",
+// lat, lng })` so the LLM (and any future view) can pass the
+// extracted coords straight to the Google Map plugin without a
+// reshape (#1227).
+
+import { readFile } from "fs/promises";
+import exifr from "exifr";
+
+/** Extracted, projected EXIF fields. All optional — most photos have
+ *  some subset. Persisted as the sidecar JSON shape; consumers can
+ *  rely on `lat` + `lng` being absent together (never one without
+ *  the other). */
+export interface PhotoExif {
+  /** Latitude in WGS84 decimal degrees. */
+  lat?: number;
+  /** Longitude in WGS84 decimal degrees. */
+  lng?: number;
+  /** GPS altitude in metres above sea level. */
+  altitude?: number;
+  /** ISO 8601 capture timestamp (UTC). exifr normalises any of the
+   *  three EXIF date fields (DateTimeOriginal / DateTime /
+   *  CreateDate) to a JS Date — we serialise to ISO for storage. */
+  takenAt?: string;
+  /** Camera make (e.g. "Apple"). */
+  make?: string;
+  /** Camera model (e.g. "iPhone 15 Pro"). */
+  model?: string;
+  /** Lens model (e.g. "iPhone 15 Pro back triple camera"). */
+  lens?: string;
+  /** Image orientation (1-8 per the EXIF spec) — useful when a
+   *  later view renders the photo without going through a tag-aware
+   *  decoder. */
+  orientation?: number;
+}
+
+const VALID_LAT_MIN = -90;
+const VALID_LAT_MAX = 90;
+const VALID_LNG_MIN = -180;
+const VALID_LNG_MAX = 180;
+
+const PARSE_OPTIONS = {
+  // exifr's "tiff" group covers DateTime / Make / Model / Orientation;
+  // "exif" covers DateTimeOriginal / Lens; "gps" covers latitude /
+  // longitude / altitude. Skip the rest (XMP, IPTC, ICC, thumbnails)
+  // — they bloat the parse and we don't store any of it.
+  tiff: true,
+  exif: true,
+  gps: true,
+  xmp: false,
+  iptc: false,
+  icc: false,
+  jfif: false,
+  ihdr: false,
+  // Skip thumbnail extraction — exifr otherwise allocates a Buffer
+  // per parse for the thumbnail bytes, which we never read.
+  pick: ["DateTimeOriginal", "CreateDate", "DateTime", "Make", "Model", "LensModel", "Orientation", "latitude", "longitude", "GPSAltitude"] as string[],
+};
+
+/** Validate a `(lat, lng)` pair. exifr occasionally surfaces 0/0
+ *  for photos with a zeroed-out GPS block (sometimes seen on Android
+ *  exports where the user opted out mid-stream); treating 0/0 as
+ *  "no fix" avoids a useless pin in the middle of the Atlantic. */
+function isValidCoord(lat: unknown, lng: unknown): lat is number {
+  if (typeof lat !== "number" || typeof lng !== "number") return false;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return false;
+  if (lat < VALID_LAT_MIN || lat > VALID_LAT_MAX) return false;
+  if (lng < VALID_LNG_MIN || lng > VALID_LNG_MAX) return false;
+  if (lat === 0 && lng === 0) return false;
+  return true;
+}
+
+function pickString(raw: Record<string, unknown>, key: string): string | undefined {
+  const value = raw[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function pickDate(raw: Record<string, unknown>): string | undefined {
+  // Prefer DateTimeOriginal (when the shutter fired) over DateTime
+  // (last edit) and CreateDate (file creation). exifr returns a
+  // JS Date when the field is parseable; otherwise a string.
+  const candidate = raw.DateTimeOriginal ?? raw.CreateDate ?? raw.DateTime;
+  if (candidate instanceof Date && !Number.isNaN(candidate.getTime())) {
+    return candidate.toISOString();
+  }
+  return undefined;
+}
+
+function pickOrientation(raw: Record<string, unknown>): number | undefined {
+  const value = raw.Orientation;
+  return typeof value === "number" && value >= 1 && value <= 8 ? value : undefined;
+}
+
+/** Lower-level parser injection point. Tests pass a fake to avoid
+ *  needing a real JPEG fixture; production paths default to exifr. */
+export type ExifParser = (buf: Buffer) => Promise<unknown>;
+
+const defaultParser: ExifParser = (buf) => exifr.parse(buf, PARSE_OPTIONS);
+
+/** Parse a photo file and project the fields we care about. Returns
+ *  `null` when the file has no parseable EXIF (screenshots, scrubbed
+ *  uploads, non-image MIME types, malformed JPEG). Never throws. */
+export async function readPhotoExif(absPath: string, parser: ExifParser = defaultParser): Promise<PhotoExif | null> {
+  let raw: unknown;
+  try {
+    const buf = await readFile(absPath);
+    raw = await parser(buf);
+  } catch {
+    // Includes both fs errors (handler should have ensured the file
+    // exists) and exifr "couldn't find any EXIF data" rejections.
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  return projectExif(raw as Record<string, unknown>);
+}
+
+/** Pure projection: take the raw exifr output and pluck the fields
+ *  we keep. Exported separately so the hook can run a fake parser
+ *  result through the same shaping in tests. */
+export function projectExif(record: Record<string, unknown>): PhotoExif | null {
+  const result: PhotoExif = {};
+  if (isValidCoord(record.latitude, record.longitude)) {
+    result.lat = record.latitude as number;
+    result.lng = record.longitude as number;
+  }
+  if (typeof record.GPSAltitude === "number" && Number.isFinite(record.GPSAltitude)) {
+    result.altitude = record.GPSAltitude;
+  }
+  const takenAt = pickDate(record);
+  if (takenAt) result.takenAt = takenAt;
+  const make = pickString(record, "Make");
+  if (make) result.make = make;
+  const model = pickString(record, "Model");
+  if (model) result.model = model;
+  const lens = pickString(record, "LensModel");
+  if (lens) result.lens = lens;
+  const orientation = pickOrientation(record);
+  if (orientation !== undefined) result.orientation = orientation;
+
+  // No useful fields — caller treats the same as "no exif" so the
+  // sidecar isn't created with an empty object.
+  if (Object.keys(result).length === 0) return null;
+  return result;
+}
+
+/** True when the MIME type is one exifr can read. Image-only — video
+ *  EXIF (MP4 / MOV) is out of scope for PR-A. HEIC is included
+ *  because iOS still emits it as the default camera format. */
+export function isExifSupportedMime(mimeType: string): boolean {
+  const lower = mimeType.toLowerCase();
+  return (
+    lower === "image/jpeg" || lower === "image/png" || lower === "image/heic" || lower === "image/heif" || lower === "image/tiff" || lower === "image/webp"
+  );
+}

--- a/server/utils/exif.ts
+++ b/server/utils/exif.ts
@@ -171,10 +171,21 @@ export function projectExif(record: Record<string, unknown>): PhotoExif | null {
 
 /** True when the MIME type is one exifr can read. Image-only — video
  *  EXIF (MP4 / MOV) is out of scope for PR-A. HEIC is included
- *  because iOS still emits it as the default camera format. */
+ *  because iOS still emits it as the default camera format.
+ *
+ *  Both `image/jpeg` and the legacy `image/jpg` alias are accepted —
+ *  `attachment-store.ts`'s `MIME_EXT` table maps both to `.jpg`, so
+ *  uploads labelled `image/jpg` save successfully but were previously
+ *  silently skipping EXIF sidecar capture. (Codex review on PR #1247.) */
 export function isExifSupportedMime(mimeType: string): boolean {
   const lower = mimeType.toLowerCase();
   return (
-    lower === "image/jpeg" || lower === "image/png" || lower === "image/heic" || lower === "image/heif" || lower === "image/tiff" || lower === "image/webp"
+    lower === "image/jpeg" ||
+    lower === "image/jpg" ||
+    lower === "image/png" ||
+    lower === "image/heic" ||
+    lower === "image/heif" ||
+    lower === "image/tiff" ||
+    lower === "image/webp"
   );
 }

--- a/server/utils/exif.ts
+++ b/server/utils/exif.ts
@@ -125,33 +125,48 @@ export async function readPhotoExif(absPath: string, parser: ExifParser = defaul
   return projectExif(raw as Record<string, unknown>);
 }
 
+/** Coords + altitude. exifr surfaces `latitude` / `longitude` /
+ *  `GPSAltitude` from the GPS group. */
+function pickGps(record: Record<string, unknown>): Pick<PhotoExif, "lat" | "lng" | "altitude"> {
+  const out: Pick<PhotoExif, "lat" | "lng" | "altitude"> = {};
+  if (isValidCoord(record.latitude, record.longitude)) {
+    out.lat = record.latitude as number;
+    out.lng = record.longitude as number;
+  }
+  if (typeof record.GPSAltitude === "number" && Number.isFinite(record.GPSAltitude)) {
+    out.altitude = record.GPSAltitude;
+  }
+  return out;
+}
+
+/** Camera identification — Make / Model / LensModel. Empty strings
+ *  drop out (exifr returns `""` for tags present but blank). */
+function pickCamera(record: Record<string, unknown>): Pick<PhotoExif, "make" | "model" | "lens"> {
+  const out: Pick<PhotoExif, "make" | "model" | "lens"> = {};
+  const make = pickString(record, "Make");
+  if (make) out.make = make;
+  const model = pickString(record, "Model");
+  if (model) out.model = model;
+  const lens = pickString(record, "LensModel");
+  if (lens) out.lens = lens;
+  return out;
+}
+
 /** Pure projection: take the raw exifr output and pluck the fields
  *  we keep. Exported separately so the hook can run a fake parser
  *  result through the same shaping in tests. */
 export function projectExif(record: Record<string, unknown>): PhotoExif | null {
-  const result: PhotoExif = {};
-  if (isValidCoord(record.latitude, record.longitude)) {
-    result.lat = record.latitude as number;
-    result.lng = record.longitude as number;
-  }
-  if (typeof record.GPSAltitude === "number" && Number.isFinite(record.GPSAltitude)) {
-    result.altitude = record.GPSAltitude;
-  }
   const takenAt = pickDate(record);
-  if (takenAt) result.takenAt = takenAt;
-  const make = pickString(record, "Make");
-  if (make) result.make = make;
-  const model = pickString(record, "Model");
-  if (model) result.model = model;
-  const lens = pickString(record, "LensModel");
-  if (lens) result.lens = lens;
   const orientation = pickOrientation(record);
-  if (orientation !== undefined) result.orientation = orientation;
-
+  const result: PhotoExif = {
+    ...pickGps(record),
+    ...pickCamera(record),
+    ...(takenAt !== undefined ? { takenAt } : {}),
+    ...(orientation !== undefined ? { orientation } : {}),
+  };
   // No useful fields — caller treats the same as "no exif" so the
   // sidecar isn't created with an empty object.
-  if (Object.keys(result).length === 0) return null;
-  return result;
+  return Object.keys(result).length === 0 ? null : result;
 }
 
 /** True when the MIME type is one exifr can read. Image-only — video

--- a/server/utils/files/attachment-store.ts
+++ b/server/utils/files/attachment-store.ts
@@ -18,15 +18,21 @@ import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
 import { resolveWithinRoot } from "./safe.js";
 
-const ATTACHMENTS_DIR = WORKSPACE_PATHS.attachments;
-
-let attachmentsDirReal: string | null = null;
+// Cache the real-path resolution per workspace root so test setups
+// that override `WORKSPACE_PATHS.attachments` mid-run still work —
+// reading the path at call time (instead of capturing it at module
+// load) means a test that points the workspace at a tmp dir
+// recomputes everything from there.
+const attachmentsDirRealByRoot = new Map<string, string>();
 
 async function ensureAttachmentsDir(): Promise<string> {
-  if (attachmentsDirReal) return attachmentsDirReal;
-  await mkdir(ATTACHMENTS_DIR, { recursive: true });
-  attachmentsDirReal = await realpath(ATTACHMENTS_DIR);
-  return attachmentsDirReal;
+  const root = WORKSPACE_PATHS.attachments;
+  const cached = attachmentsDirRealByRoot.get(root);
+  if (cached) return cached;
+  await mkdir(root, { recursive: true });
+  const real = await realpath(root);
+  attachmentsDirRealByRoot.set(root, real);
+  return real;
 }
 
 async function safeResolve(relativePath: string): Promise<string> {
@@ -109,6 +115,40 @@ export interface SavedAttachment {
   mimeType: string;
 }
 
+/** Post-save hook fired after every successful `saveAttachment`.
+ *  Receives the absolute on-disk path, the workspace-relative path
+ *  (the same one returned to the caller), and the MIME type the
+ *  bytes were saved with. Hooks must NEVER throw — the upload is
+ *  already on disk by the time the hook runs, so a failure should
+ *  log and return, not propagate. Multiple hooks fan out via
+ *  `Promise.allSettled` so one slow / failing hook can't block or
+ *  break the others. (#1222 PR-A.) */
+export type SaveAttachmentHook = (absPath: string, relativePath: string, mimeType: string) => Promise<void>;
+
+const saveAttachmentHooks: SaveAttachmentHook[] = [];
+
+/** Register a hook that runs after every saved attachment. Returns
+ *  an unregister function so test setups can install + tear down a
+ *  hook without leaking state into the next test. Production
+ *  registrations live in `server/index.ts` boot. */
+export function registerSaveAttachmentHook(hook: SaveAttachmentHook): () => void {
+  saveAttachmentHooks.push(hook);
+  return () => {
+    const idx = saveAttachmentHooks.indexOf(hook);
+    if (idx !== -1) saveAttachmentHooks.splice(idx, 1);
+  };
+}
+
+async function runSaveAttachmentHooks(absPath: string, relativePath: string, mimeType: string): Promise<void> {
+  if (saveAttachmentHooks.length === 0) return;
+  // Snapshot the array so a hook that calls `registerSaveAttachmentHook`
+  // (or its unregister fn) during this loop doesn't mutate the
+  // iteration order. `allSettled` so one failing hook doesn't stop
+  // the others — failures are the hook's responsibility to log.
+  const snapshot = [...saveAttachmentHooks];
+  await Promise.allSettled(snapshot.map((hook) => hook(absPath, relativePath, mimeType)));
+}
+
 /** Save a single attachment under data/attachments/YYYY/MM/. The
  *  caller picks the ID; companions (e.g. PPTX → PDF) reuse it via
  *  `saveCompanion()` so they share the same numeric prefix. */
@@ -117,12 +157,15 @@ export async function saveAttachment(base64Data: string, mimeType: string): Prom
   const partition = yearMonthUtc();
   const ext = extensionForMime(mimeType);
   const filename = `${shortId()}${ext}`;
-  const absPath = path.join(ATTACHMENTS_DIR, partition, filename);
+  const absPath = path.join(WORKSPACE_PATHS.attachments, partition, filename);
   await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
-  return {
-    relativePath: path.posix.join(WORKSPACE_DIRS.attachments, partition, filename),
-    mimeType,
-  };
+  const relativePath = path.posix.join(WORKSPACE_DIRS.attachments, partition, filename);
+  // Hooks (e.g. photo-EXIF capture) are awaited so callers can rely
+  // on the sidecar existing by the time `saveAttachment` resolves —
+  // simplifies test assertions and removes a class of race conditions
+  // for downstream tools that read sidecars right after upload.
+  await runSaveAttachmentHooks(absPath, relativePath, mimeType);
+  return { relativePath, mimeType };
 }
 
 /** Save a companion file (e.g. PPTX → PDF) alongside an existing

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -109,6 +109,12 @@ const HOST_WORKSPACE_DIRS = {
   // base64. Conversion artefacts (e.g. PPTX → PDF) live alongside
   // the original under the same YYYY/MM partition.
   attachments: "data/attachments",
+  // Sidecar JSON for photo EXIF capture (#1222 PR-A). Mirrors the
+  // attachments YYYY/MM partition: `data/locations/<YYYY>/<MM>/<id>.json`.
+  // Each file shape-compatible with `mapControl`'s addMarker args
+  // (lat/lng numbers) so the LLM can hand a sidecar straight to the
+  // Google Map plugin without reshape.
+  locations: "data/locations",
   transports: "data/transports",
   // artifacts/
   charts: "artifacts/charts",

--- a/server/workspace/photo-locations/index.ts
+++ b/server/workspace/photo-locations/index.ts
@@ -1,0 +1,138 @@
+// Photo-EXIF sidecar persistence for #1222 PR-A.
+//
+// One JSON file per saved attachment, written immediately after the
+// attachment lands. The sidecar lives under
+//   `data/locations/<YYYY>/<MM>/<attachment-id>.json`
+// mirroring the attachment partition so a photo and its location
+// metadata are co-located on disk (handy for filesystem-based
+// browsing in Finder / Obsidian).
+//
+// Shape goal: lat/lng are top-level numbers so an LLM can hand the
+// sidecar straight to `mapControl({ action: "addMarker", lat, lng })`
+// from the Google Map plugin (#1227) without any reshape. The hook
+// runs only when the attachment has a parseable EXIF block AND
+// auto-capture is enabled in `AppSettings.photoExif`.
+
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { WORKSPACE_PATHS, WORKSPACE_DIRS } from "../paths.js";
+import { isPhotoExifAutoCaptureEnabled, loadSettings } from "../../system/config.js";
+import { isExifSupportedMime, readPhotoExif, type ExifParser, type PhotoExif } from "../../utils/exif.js";
+import { log } from "../../system/logger/index.js";
+
+/** Persisted sidecar shape. */
+export interface PhotoLocationSidecar {
+  /** Always `1`. Bump when the shape changes incompatibly so
+   *  consumers (the future `manageMap`/photo plugin) can detect
+   *  legacy files. */
+  version: 1;
+  /** Pointer back to the photo this sidecar describes. Workspace-
+   *  relative, posix slashes. */
+  photo: {
+    relativePath: string;
+    mimeType: string;
+  };
+  /** Selected EXIF fields. See `PhotoExif` for the full surface. */
+  exif: PhotoExif;
+  /** ISO timestamp marking when the sidecar was written (i.e. when
+   *  the photo was received, not when the photo was shot — the
+   *  shutter time lives in `exif.takenAt`). */
+  capturedAt: string;
+}
+
+const SIDECAR_FILE_MODE = 0o600;
+
+/** Strip the extension from `<id>.<ext>`. The basename without
+ *  extension is the sidecar id. */
+function sidecarIdForAttachment(attachmentRelativePath: string): string {
+  const base = path.posix.basename(attachmentRelativePath);
+  const ext = path.posix.extname(base);
+  return ext.length > 0 ? base.slice(0, -ext.length) : base;
+}
+
+/** YYYY/MM partition fragment of a workspace-relative attachment
+ *  path: `data/attachments/2026/05/foo.jpg` → `2026/05`. Falls back
+ *  to the empty string when the path is shorter than expected (the
+ *  caller treats that as "skip this attachment"). */
+function partitionForAttachment(attachmentRelativePath: string): string {
+  const segments = attachmentRelativePath.split("/").filter(Boolean);
+  // segments = [data, attachments, YYYY, MM, filename]
+  if (segments.length < 5) return "";
+  return path.posix.join(segments[2], segments[3]);
+}
+
+/** Compute the absolute sidecar path for a saved attachment. */
+export function sidecarPathForAttachment(attachmentRelativePath: string): string | null {
+  const partition = partitionForAttachment(attachmentRelativePath);
+  if (partition === "") return null;
+  const sidecarId = sidecarIdForAttachment(attachmentRelativePath);
+  return path.join(WORKSPACE_PATHS.locations, partition, `${sidecarId}.json`);
+}
+
+/** Hook the attachment-store calls after every saved attachment.
+ *  No-op when:
+ *    - `AppSettings.photoExif.autoCapture` is `false` (user opt-out)
+ *    - the MIME type isn't an image format exifr understands
+ *    - the photo has no parseable EXIF (screenshots etc.)
+ *
+ *  Errors are swallowed and logged at warn — we never want a failed
+ *  EXIF probe to fail the upload. */
+export function capturePhotoLocation(absPhotoPath: string, attachmentRelativePath: string, mimeType: string): Promise<void> {
+  return capturePhotoLocationWithParser(absPhotoPath, attachmentRelativePath, mimeType);
+}
+
+/** Parser-injectable variant. Production code uses
+ *  `capturePhotoLocation`; tests reach for this overload to swap
+ *  exifr for a stub so they don't need a JPEG fixture. */
+export async function capturePhotoLocationWithParser(
+  absPhotoPath: string,
+  attachmentRelativePath: string,
+  mimeType: string,
+  parser?: ExifParser,
+): Promise<void> {
+  if (!isExifSupportedMime(mimeType)) return;
+  if (!isPhotoExifAutoCaptureEnabled(loadSettings())) return;
+
+  let exif: PhotoExif | null;
+  try {
+    exif = await readPhotoExif(absPhotoPath, parser);
+  } catch (err) {
+    log.warn("photo-locations", "exif parse threw — skipping sidecar", { path: attachmentRelativePath, error: String(err) });
+    return;
+  }
+  if (!exif) return;
+
+  const sidecarPath = sidecarPathForAttachment(attachmentRelativePath);
+  if (!sidecarPath) {
+    log.warn("photo-locations", "could not derive sidecar path — skipping", { attachmentRelativePath });
+    return;
+  }
+
+  const payload: PhotoLocationSidecar = {
+    version: 1,
+    photo: {
+      relativePath: attachmentRelativePath,
+      mimeType,
+    },
+    exif,
+    capturedAt: new Date().toISOString(),
+  };
+
+  try {
+    await mkdir(path.dirname(sidecarPath), { recursive: true });
+    await writeFileAtomic(sidecarPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: SIDECAR_FILE_MODE });
+    log.info("photo-locations", "sidecar written", {
+      attachment: attachmentRelativePath,
+      hasGps: exif.lat !== undefined && exif.lng !== undefined,
+    });
+  } catch (err) {
+    log.warn("photo-locations", "sidecar write failed", { attachmentRelativePath, error: String(err) });
+  }
+}
+
+// `WORKSPACE_DIRS.locations` is referenced for typing-side
+// completeness — stops `WORKSPACE_DIRS` from being tree-shaken out
+// of test bundles that import this module without explicitly using
+// the alias.
+export const LOCATIONS_DIR_KEY = WORKSPACE_DIRS.locations;

--- a/server/workspace/photo-locations/index.ts
+++ b/server/workspace/photo-locations/index.ts
@@ -82,6 +82,40 @@ export function capturePhotoLocation(absPhotoPath: string, attachmentRelativePat
   return capturePhotoLocationWithParser(absPhotoPath, attachmentRelativePath, mimeType);
 }
 
+/** Gate check: should we even try to read EXIF for this MIME, given
+ *  the user's auto-capture setting? Pure — no I/O. */
+function shouldCapture(mimeType: string): boolean {
+  if (!isExifSupportedMime(mimeType)) return false;
+  return isPhotoExifAutoCaptureEnabled(loadSettings());
+}
+
+/** Read EXIF, swallowing parser errors as `null`. The hook never
+ *  fails the upload — a thrown parser is just "skip the sidecar". */
+async function readExifSafe(absPhotoPath: string, attachmentRelativePath: string, parser: ExifParser | undefined): Promise<PhotoExif | null> {
+  try {
+    return await readPhotoExif(absPhotoPath, parser);
+  } catch (err) {
+    log.warn("photo-locations", "exif parse threw — skipping sidecar", { path: attachmentRelativePath, error: String(err) });
+    return null;
+  }
+}
+
+/** Write the sidecar JSON, creating parent dirs as needed. Failures
+ *  are logged but never thrown — the photo upload already succeeded
+ *  by the time this runs. */
+async function writeSidecarSafe(sidecarPath: string, payload: PhotoLocationSidecar): Promise<void> {
+  try {
+    await mkdir(path.dirname(sidecarPath), { recursive: true });
+    await writeFileAtomic(sidecarPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: SIDECAR_FILE_MODE });
+    log.info("photo-locations", "sidecar written", {
+      attachment: payload.photo.relativePath,
+      hasGps: payload.exif.lat !== undefined && payload.exif.lng !== undefined,
+    });
+  } catch (err) {
+    log.warn("photo-locations", "sidecar write failed", { attachmentRelativePath: payload.photo.relativePath, error: String(err) });
+  }
+}
+
 /** Parser-injectable variant. Production code uses
  *  `capturePhotoLocation`; tests reach for this overload to swap
  *  exifr for a stub so they don't need a JPEG fixture. */
@@ -91,44 +125,21 @@ export async function capturePhotoLocationWithParser(
   mimeType: string,
   parser?: ExifParser,
 ): Promise<void> {
-  if (!isExifSupportedMime(mimeType)) return;
-  if (!isPhotoExifAutoCaptureEnabled(loadSettings())) return;
-
-  let exif: PhotoExif | null;
-  try {
-    exif = await readPhotoExif(absPhotoPath, parser);
-  } catch (err) {
-    log.warn("photo-locations", "exif parse threw — skipping sidecar", { path: attachmentRelativePath, error: String(err) });
-    return;
-  }
+  if (!shouldCapture(mimeType)) return;
+  const exif = await readExifSafe(absPhotoPath, attachmentRelativePath, parser);
   if (!exif) return;
-
   const sidecarPath = sidecarPathForAttachment(attachmentRelativePath);
   if (!sidecarPath) {
     log.warn("photo-locations", "could not derive sidecar path — skipping", { attachmentRelativePath });
     return;
   }
-
   const payload: PhotoLocationSidecar = {
     version: 1,
-    photo: {
-      relativePath: attachmentRelativePath,
-      mimeType,
-    },
+    photo: { relativePath: attachmentRelativePath, mimeType },
     exif,
     capturedAt: new Date().toISOString(),
   };
-
-  try {
-    await mkdir(path.dirname(sidecarPath), { recursive: true });
-    await writeFileAtomic(sidecarPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: SIDECAR_FILE_MODE });
-    log.info("photo-locations", "sidecar written", {
-      attachment: attachmentRelativePath,
-      hasGps: exif.lat !== undefined && exif.lng !== undefined,
-    });
-  } catch (err) {
-    log.warn("photo-locations", "sidecar write failed", { attachmentRelativePath, error: String(err) });
-  }
+  await writeSidecarSafe(sidecarPath, payload);
 }
 
 // `WORKSPACE_DIRS.locations` is referenced for typing-side

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -95,6 +95,37 @@ describe("loadSettings", () => {
     assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [] });
   });
 
+  // Codex review on PR #1247: a hand-edited partial settings file
+  // (`{ "photoExif": { "autoCapture": false } }`) was previously
+  // rejected by `loadSettings` because `extraAllowedTools` was
+  // mandatory in the schema, silently re-enabling auto-capture. The
+  // loader now accepts the patch shape and merges with defaults.
+  it("accepts a hand-edited partial file with photoExif but no extraAllowedTools", () => {
+    mod.ensureConfigsDir();
+    writeFileSync(mod.settingsPath(), JSON.stringify({ photoExif: { autoCapture: false } }));
+    const cfg = mod.loadSettings();
+    assert.deepEqual(cfg, {
+      extraAllowedTools: [],
+      photoExif: { autoCapture: false },
+    });
+    assert.equal(mod.isPhotoExifAutoCaptureEnabled(cfg), false);
+  });
+
+  it("accepts a hand-edited partial file with only googleMapsApiKey", () => {
+    mod.ensureConfigsDir();
+    writeFileSync(mod.settingsPath(), JSON.stringify({ googleMapsApiKey: "AIza..." }));
+    assert.deepEqual(mod.loadSettings(), {
+      extraAllowedTools: [],
+      googleMapsApiKey: "AIza...",
+    });
+  });
+
+  it("still falls back when a present field has the wrong type", () => {
+    mod.ensureConfigsDir();
+    writeFileSync(mod.settingsPath(), JSON.stringify({ extraAllowedTools: "not-array" }));
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [] });
+  });
+
   it("returns a defensive copy — mutating the result does not affect disk", () => {
     mod.saveSettings({ extraAllowedTools: ["x"] });
     const first = mod.loadSettings();

--- a/test/utils/test_exif.ts
+++ b/test/utils/test_exif.ts
@@ -1,0 +1,200 @@
+// Unit tests for the EXIF wrapper (#1222 PR-A).
+//
+// Exercises the projection logic against synthetic exifr outputs, so
+// no JPEG fixture file is needed. The integration test under
+// test/workspace/photo-locations/ covers the on-disk hook flow.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { isExifSupportedMime, projectExif, readPhotoExif } from "../../server/utils/exif.js";
+
+const TAKEN_AT_RAW = new Date("2026-04-12T08:30:00.000Z");
+const TAKEN_AT_ISO = TAKEN_AT_RAW.toISOString();
+
+describe("isExifSupportedMime", () => {
+  it("accepts every image MIME exifr can read", () => {
+    for (const mime of ["image/jpeg", "image/png", "image/heic", "image/heif", "image/tiff", "image/webp"]) {
+      assert.equal(isExifSupportedMime(mime), true, mime);
+    }
+  });
+
+  it("rejects non-image MIMEs", () => {
+    for (const mime of ["application/pdf", "video/mp4", "text/plain", "application/octet-stream", "image/gif"]) {
+      assert.equal(isExifSupportedMime(mime), false, mime);
+    }
+  });
+
+  it("ignores casing", () => {
+    assert.equal(isExifSupportedMime("IMAGE/JPEG"), true);
+    assert.equal(isExifSupportedMime("Image/Heic"), true);
+  });
+});
+
+describe("projectExif — happy paths", () => {
+  it("plucks lat/lng/altitude and takenAt + camera fields", () => {
+    const exif = projectExif({
+      latitude: 35.6586,
+      longitude: 139.7454,
+      GPSAltitude: 38.4,
+      DateTimeOriginal: TAKEN_AT_RAW,
+      Make: "Apple",
+      Model: "iPhone 15 Pro",
+      LensModel: "iPhone 15 Pro back triple camera",
+      Orientation: 1,
+    });
+    assert.deepEqual(exif, {
+      lat: 35.6586,
+      lng: 139.7454,
+      altitude: 38.4,
+      takenAt: TAKEN_AT_ISO,
+      make: "Apple",
+      model: "iPhone 15 Pro",
+      lens: "iPhone 15 Pro back triple camera",
+      orientation: 1,
+    });
+  });
+
+  it("keeps lat/lng even when other fields are missing", () => {
+    const exif = projectExif({ latitude: 35.6586, longitude: 139.7454 });
+    assert.deepEqual(exif, { lat: 35.6586, lng: 139.7454 });
+  });
+
+  it("keeps takenAt without GPS (typical scanned-document case)", () => {
+    const exif = projectExif({ DateTimeOriginal: TAKEN_AT_RAW });
+    assert.deepEqual(exif, { takenAt: TAKEN_AT_ISO });
+  });
+});
+
+describe("projectExif — date-field fallback chain", () => {
+  it("falls back to CreateDate when DateTimeOriginal is missing", () => {
+    const exif = projectExif({ CreateDate: TAKEN_AT_RAW });
+    assert.equal(exif?.takenAt, TAKEN_AT_ISO);
+  });
+
+  it("falls back to DateTime when CreateDate is missing too", () => {
+    const exif = projectExif({ DateTime: TAKEN_AT_RAW });
+    assert.equal(exif?.takenAt, TAKEN_AT_ISO);
+  });
+
+  it("ignores invalid Date objects", () => {
+    const exif = projectExif({ DateTimeOriginal: new Date("invalid") });
+    assert.equal(exif, null);
+  });
+
+  it("ignores plain-string date fields (exifr pre-coerces; bare strings mean parse failure)", () => {
+    const exif = projectExif({ DateTimeOriginal: "2026:04:12 08:30:00" });
+    assert.equal(exif, null);
+  });
+});
+
+describe("projectExif — coordinate validation", () => {
+  it("rejects out-of-range latitude", () => {
+    const exif = projectExif({ latitude: 91, longitude: 0 });
+    assert.equal(exif, null);
+  });
+
+  it("rejects out-of-range longitude", () => {
+    const exif = projectExif({ latitude: 0, longitude: -181 });
+    assert.equal(exif, null);
+  });
+
+  it("rejects exact 0/0 (Atlantic null-island)", () => {
+    const exif = projectExif({ latitude: 0, longitude: 0 });
+    assert.equal(exif, null);
+  });
+
+  it("accepts 0/0-adjacent legitimate coords", () => {
+    const exif = projectExif({ latitude: 0, longitude: 0.001 });
+    assert.deepEqual(exif, { lat: 0, lng: 0.001 });
+  });
+
+  it("rejects non-numeric coords (string lat from a malformed parse)", () => {
+    const exif = projectExif({ latitude: "35.6586" as unknown as number, longitude: 139.7454 });
+    assert.equal(exif, null);
+  });
+
+  it("rejects only one of lat / lng (never half a fix)", () => {
+    const exif = projectExif({ latitude: 35.6586 });
+    assert.equal(exif, null);
+  });
+
+  it("rejects NaN / Infinity coords", () => {
+    assert.equal(projectExif({ latitude: NaN, longitude: 0 }), null);
+    assert.equal(projectExif({ latitude: 0, longitude: Number.POSITIVE_INFINITY }), null);
+  });
+});
+
+describe("projectExif — orientation guard", () => {
+  it("accepts orientation 1-8", () => {
+    for (let i = 1; i <= 8; i++) {
+      const exif = projectExif({ DateTimeOriginal: TAKEN_AT_RAW, Orientation: i });
+      assert.equal(exif?.orientation, i);
+    }
+  });
+
+  it("rejects out-of-range orientation", () => {
+    const exif = projectExif({ DateTimeOriginal: TAKEN_AT_RAW, Orientation: 9 });
+    assert.equal(exif?.orientation, undefined);
+  });
+});
+
+describe("projectExif — empty / null returns", () => {
+  it("returns null when no useful fields are present", () => {
+    assert.equal(projectExif({}), null);
+  });
+
+  it("returns null when only ignored fields are present", () => {
+    assert.equal(projectExif({ ImageWidth: 4032, ImageHeight: 3024 }), null);
+  });
+
+  it("ignores empty-string camera fields", () => {
+    assert.equal(projectExif({ Make: "", Model: "" }), null);
+  });
+});
+
+describe("readPhotoExif — file-system + parser injection", () => {
+  it("returns null when the file does not exist", async () => {
+    const result = await readPhotoExif("/does/not/exist.jpg");
+    assert.equal(result, null);
+  });
+
+  it("returns null when the parser throws (corrupt JPEG)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "exif-test-"));
+    const filePath = path.join(dir, "corrupt.jpg");
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x00]));
+    try {
+      const result = await readPhotoExif(filePath, () => Promise.reject(new Error("malformed")));
+      assert.equal(result, null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when the parser yields no useful fields", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "exif-test-"));
+    const filePath = path.join(dir, "scrubbed.jpg");
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8]));
+    try {
+      const result = await readPhotoExif(filePath, () => Promise.resolve({}));
+      assert.equal(result, null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flows the parser output through projectExif", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "exif-test-"));
+    const filePath = path.join(dir, "good.jpg");
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8]));
+    try {
+      const result = await readPhotoExif(filePath, () => Promise.resolve({ latitude: 35.6586, longitude: 139.7454, Make: "Apple" }));
+      assert.deepEqual(result, { lat: 35.6586, lng: 139.7454, make: "Apple" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/utils/test_exif.ts
+++ b/test/utils/test_exif.ts
@@ -22,6 +22,16 @@ describe("isExifSupportedMime", () => {
     }
   });
 
+  // Codex review on PR #1247: `attachment-store.ts`'s `MIME_EXT` table
+  // accepts BOTH `image/jpeg` and the legacy alias `image/jpg`, so an
+  // upload labelled `image/jpg` saves successfully — but the original
+  // allowlist rejected it, silently skipping EXIF capture for that
+  // alias. Lock the alias parity in place with a test.
+  it("accepts the image/jpg alias (parity with attachment-store MIME_EXT)", () => {
+    assert.equal(isExifSupportedMime("image/jpg"), true);
+    assert.equal(isExifSupportedMime("IMAGE/JPG"), true);
+  });
+
   it("rejects non-image MIMEs", () => {
     for (const mime of ["application/pdf", "video/mp4", "text/plain", "application/octet-stream", "image/gif"]) {
       assert.equal(isExifSupportedMime(mime), false, mime);

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -31,6 +31,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "html",
     "htmls",
     "images",
+    "locations",
     "markdowns",
     "memoryDir",
     "memoryStaging",

--- a/test/workspace/test_photo_locations.ts
+++ b/test/workspace/test_photo_locations.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { registerSaveAttachmentHook, saveAttachment } from "../../server/utils/files/attachment-store.js";
-import { capturePhotoLocation } from "../../server/workspace/photo-locations/index.js";
+import { capturePhotoLocation, sidecarPathForAttachment } from "../../server/workspace/photo-locations/index.js";
 import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
 import { saveSettings } from "../../server/system/config.js";
 
@@ -58,7 +58,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       assert.ok(existsSync(sidecarPath), `expected sidecar at ${sidecarPath}`);
 
       const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8")) as {
@@ -84,7 +84,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       assert.equal(existsSync(sidecarPath), false, "no sidecar should be written under opt-out");
     } finally {
       unregister();
@@ -96,7 +96,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "application/pdf");
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       assert.equal(existsSync(sidecarPath), false, "non-image attachments must not get a sidecar");
     } finally {
       unregister();
@@ -108,7 +108,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve({})));
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       assert.equal(existsSync(sidecarPath), false);
     } finally {
       unregister();
@@ -121,7 +121,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
       assert.ok(saved.relativePath.startsWith("data/attachments/"));
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       assert.equal(existsSync(sidecarPath), false);
     } finally {
       unregister();
@@ -133,7 +133,7 @@ describe("photo-locations hook — saveAttachment integration", () => {
     const unregister = registerSaveAttachmentHook(capturePhotoLocation);
     try {
       const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/png");
-      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      const sidecarPath = expectedSidecarPath(saved.relativePath);
       // No EXIF in a 1px PNG → no sidecar. This proves the
       // production hook is wired and the no-EXIF path is graceful.
       assert.equal(existsSync(sidecarPath), false);
@@ -143,11 +143,14 @@ describe("photo-locations hook — saveAttachment integration", () => {
   });
 });
 
-function sidecarPathFromSaved(relativePath: string, workspaceRoot: string): string {
-  // [data, attachments, YYYY, MM, <id>.<ext>]
-  const [, , year, month, filename] = relativePath.split("/");
-  const sidecarBase = filename.replace(/\.[^.]+$/, "");
-  return path.join(workspaceRoot, "data/locations", year, month, `${sidecarBase}.json`);
+/** Wrap the production helper so tests fail clearly when the
+ *  partition derivation hits its "skip" branch (ret === null) — the
+ *  test fixtures always produce well-shaped paths, so a null return
+ *  here means an upstream regression, not a runtime concern. */
+function expectedSidecarPath(relativePath: string): string {
+  const sidecarPath = sidecarPathForAttachment(relativePath);
+  assert.ok(sidecarPath, `expected sidecarPathForAttachment to derive a path for ${relativePath}`);
+  return sidecarPath;
 }
 
 /** Build a hook that runs the same shape as `capturePhotoLocation`

--- a/test/workspace/test_photo_locations.ts
+++ b/test/workspace/test_photo_locations.ts
@@ -1,0 +1,163 @@
+// Integration test for the photo-EXIF post-save hook (#1222 PR-A).
+//
+// Exercises the actual `saveAttachment` → `runSaveAttachmentHooks`
+// → `capturePhotoLocation` chain against an isolated tmp workspace,
+// using a stub `exifr.parse` so no JPEG fixture is needed.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { registerSaveAttachmentHook, saveAttachment } from "../../server/utils/files/attachment-store.js";
+import { capturePhotoLocation } from "../../server/workspace/photo-locations/index.js";
+import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import { saveSettings } from "../../server/system/config.js";
+
+const FAKE_EXIF = {
+  latitude: 35.6586,
+  longitude: 139.7454,
+  GPSAltitude: 38.4,
+  DateTimeOriginal: new Date("2026-04-12T08:30:00.000Z"),
+  Make: "Apple",
+  Model: "iPhone 15 Pro",
+};
+
+const ONE_PIXEL_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+type DescriptorMap = Record<string, PropertyDescriptor>;
+
+describe("photo-locations hook — saveAttachment integration", () => {
+  let savedDescriptors: DescriptorMap = {};
+  let workspaceRoot: string;
+
+  function overrideWorkspacePath(key: string, value: string): void {
+    const desc = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, key);
+    if (desc) savedDescriptors[key] = desc;
+    Object.defineProperty(WORKSPACE_PATHS, key, { ...(desc ?? { configurable: true }), value, configurable: true, enumerable: true, writable: true });
+  }
+
+  beforeEach(() => {
+    savedDescriptors = {};
+    workspaceRoot = mkdtempSync(path.join(tmpdir(), "photo-loc-test-"));
+    overrideWorkspacePath("attachments", path.join(workspaceRoot, "data/attachments"));
+    overrideWorkspacePath("locations", path.join(workspaceRoot, "data/locations"));
+    overrideWorkspacePath("configs", path.join(workspaceRoot, "config"));
+  });
+
+  afterEach(() => {
+    for (const [key, desc] of Object.entries(savedDescriptors)) {
+      Object.defineProperty(WORKSPACE_PATHS, key, desc);
+    }
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("writes a sidecar JSON with shape-compatible coords when EXIF exists + auto-capture is on by default", async () => {
+    saveSettings({ extraAllowedTools: [] });
+    const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      assert.ok(existsSync(sidecarPath), `expected sidecar at ${sidecarPath}`);
+
+      const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8")) as {
+        version: number;
+        photo: { relativePath: string; mimeType: string };
+        exif: { lat?: number; lng?: number; takenAt?: string; make?: string };
+        capturedAt: string;
+      };
+      assert.equal(sidecar.version, 1);
+      assert.equal(sidecar.photo.relativePath, saved.relativePath);
+      assert.equal(sidecar.photo.mimeType, "image/jpeg");
+      assert.equal(sidecar.exif.lat, 35.6586);
+      assert.equal(sidecar.exif.lng, 139.7454);
+      assert.equal(sidecar.exif.make, "Apple");
+      assert.match(sidecar.capturedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT write a sidecar when auto-capture is opted-out", async () => {
+    saveSettings({ extraAllowedTools: [], photoExif: { autoCapture: false } });
+    const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      assert.equal(existsSync(sidecarPath), false, "no sidecar should be written under opt-out");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT write a sidecar for non-image MIMEs", async () => {
+    saveSettings({ extraAllowedTools: [] });
+    const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve(FAKE_EXIF)));
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "application/pdf");
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      assert.equal(existsSync(sidecarPath), false, "non-image attachments must not get a sidecar");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does NOT write a sidecar when the parser yields no fields (screenshot-style)", async () => {
+    saveSettings({ extraAllowedTools: [] });
+    const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.resolve({})));
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      assert.equal(existsSync(sidecarPath), false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("survives a thrown parser without failing the upload (saveAttachment still resolves)", async () => {
+    saveSettings({ extraAllowedTools: [] });
+    const unregister = registerSaveAttachmentHook(makeHookWithStubParser(() => Promise.reject(new Error("malformed JPEG"))));
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/jpeg");
+      assert.ok(saved.relativePath.startsWith("data/attachments/"));
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      assert.equal(existsSync(sidecarPath), false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("calls the production capturePhotoLocation when registered (no parser stub) — skips because real exifr can't parse a 1-pixel PNG", async () => {
+    saveSettings({ extraAllowedTools: [] });
+    const unregister = registerSaveAttachmentHook(capturePhotoLocation);
+    try {
+      const saved = await saveAttachment(ONE_PIXEL_PNG_BASE64, "image/png");
+      const sidecarPath = sidecarPathFromSaved(saved.relativePath, workspaceRoot);
+      // No EXIF in a 1px PNG → no sidecar. This proves the
+      // production hook is wired and the no-EXIF path is graceful.
+      assert.equal(existsSync(sidecarPath), false);
+    } finally {
+      unregister();
+    }
+  });
+});
+
+function sidecarPathFromSaved(relativePath: string, workspaceRoot: string): string {
+  // [data, attachments, YYYY, MM, <id>.<ext>]
+  const [, , year, month, filename] = relativePath.split("/");
+  const sidecarBase = filename.replace(/\.[^.]+$/, "");
+  return path.join(workspaceRoot, "data/locations", year, month, `${sidecarBase}.json`);
+}
+
+/** Build a hook that runs the same shape as `capturePhotoLocation`
+ *  but with a stubbed exifr parser. Test seam — the hook in
+ *  `server/workspace/photo-locations/index.ts` reads `exifr.parse`
+ *  through the default in `readPhotoExif`; we re-create the flow
+ *  here with a controllable parser instead. */
+function makeHookWithStubParser(parser: (buf: Buffer) => Promise<unknown>) {
+  return async (absPath: string, relativePath: string, mimeType: string) => {
+    const { capturePhotoLocationWithParser } = await import("../../server/workspace/photo-locations/index.js");
+    return capturePhotoLocationWithParser(absPath, relativePath, mimeType, parser);
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4190,6 +4190,11 @@ execa@^9.6.1:
     strip-final-newline "^4.0.0"
     yoctocolors "^2.1.1"
 
+exifr@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/exifr/-/exifr-7.1.3.tgz#f6218012c36dbb7d843222011b27f065fddbab6f"
+  integrity sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==
+
 express-rate-limit@^8.2.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.1.tgz#ee62473d7b3bdf3b27b7be3d7f25c6d13308479a"


### PR DESCRIPTION
## Summary

PR-A of the four-PR photo-EXIF plan ([plans/feat-photo-exif.md](https://github.com/receptron/mulmoclaude/blob/main/plans/feat-photo-exif.md)). Lands the **data layer**: every photo saved as an attachment is run through `exifr` and a sidecar JSON lands at `data/locations/<YYYY>/<MM>/<id>.json`. PR-B (runtime plugin + Settings opt-out toggle) and PR-C (LINE bridge support) follow.

The sidecar shape is **shape-compatible with `@gui-chat-plugin/google-map`'s `mapControl` tool** (#1227) — `lat` / `lng` are top-level numbers so an LLM can hand a sidecar straight to `mapControl({ action: "addMarker", lat, lng })` without reshape. That's the bridge to the user's "see photo locations on a map" goal — PR-B will surface a list/tool, PR-C+ can add a curated map view.

PR-A is a **silent no-op for users without geotagged photos** — the launcher / Settings don't change. Only effect: a sidecar JSON appears next to the attachment when EXIF is parseable.

## Items to Confirm / Review

1. **Default `autoCapture: true`** — per the plan and the user's earlier "default-on + Settings で opt-out 可能" decision. The Settings UI toggle lands in PR-B; until then opt-out requires hand-editing `~/mulmoclaude/config/settings.json` to `{ "photoExif": { "autoCapture": false } }`. Flag if this gating is too thin.
2. **Hook fan-out semantics** — `Promise.allSettled`, awaited inside `saveAttachment`. So upload latency now includes EXIF parse time (~5-50 ms for typical phone JPEGs, longer for HEIC). Tested with the parser-throw scenario; production failures only `log.warn` and don't break the upload. Worth confirming the latency tradeoff is OK before adding more hooks (PPTX→PDF conversion is already inline; this just inherits that pattern).
3. **`ATTACHMENTS_DIR` refactor** — was a module-load constant; now a per-call read of `WORKSPACE_PATHS.attachments`. Test setups that swap the workspace root mid-run depend on this. No semantic change in production (the value is set at boot and stays).
4. **0/0 GPS rejection** — Android exports occasionally surface `(0, 0)` for photos that had GPS dropped mid-shutter. The wrapper treats that as "no fix" so the sidecar isn't created with a useless Atlantic null-island pin. Adjacent legitimate coords (`0, 0.001`) still pass.
5. **HEIC** — exifr supports it; my MIME filter accepts `image/heic` + `image/heif`. iPhone's default camera format will Just Work. No native decoding (we're only reading EXIF, not pixels).

## Items shipped

| File | Change |
|---|---|
| `package.json` + `yarn.lock` | `exifr@7.1.3` (zero-dep, ~80 KB, HEIC-capable) |
| `server/utils/exif.ts` (new) | Thin wrapper. Projects exifr output to a tight `PhotoExif` shape. Coord validation rejects range / NaN / 0-0. Parser injection point for tests. |
| `server/utils/files/attachment-store.ts` | New `registerSaveAttachmentHook` registry, `Promise.allSettled` fan-out, `saveAttachment` awaits the chain. `ATTACHMENTS_DIR` const → per-call `WORKSPACE_PATHS.attachments` read. |
| `server/workspace/photo-locations/index.ts` (new) | The hook itself. Skips on non-image MIME / opt-out / no-EXIF. Sidecar via `writeFileAtomic` at `data/locations/<YYYY>/<MM>/<id>.json`. `version: 1`. |
| `server/workspace/paths.ts` | New `WORKSPACE_DIRS.locations = "data/locations"`. |
| `server/system/config.ts` | `AppSettings.photoExif?: { autoCapture: boolean }` + validators + `isPhotoExifAutoCaptureEnabled` helper. |
| `server/index.ts` | Registers the hook in `startRuntimeServices`. |
| `test/utils/test_exif.ts` (new) | 26 unit tests — projection, fallback chains, validation, file-system + parser injection. |
| `test/workspace/test_photo_locations.ts` (new) | 6 integration tests — on-disk hook flow with stubbed parser + production wiring. |
| `test/workspace/test_paths_shape.ts` | Add `locations` to expected keys. |

## User Prompt

> 1222ってどうなっている？？
> はい、すすめて。google mapも追加済だからそれとの連携も考慮してね。ユーザはmap上で位置情報をみたい。できれば位置と写真だね

(Photo-exif issue was OPEN with plan merged but no implementation. Proceed with PR-A; ensure the data shape integrates with the just-landed `mapControl` tool from `@gui-chat-plugin/google-map`. User wants location on map, ideally location + photo together.)

The map connection is via the sidecar shape — top-level `lat`/`lng` numbers feed `mapControl({ action: "addMarker", lat, lng })` directly. PR-B introduces the LLM tool that surfaces all sidecars (`listLocations`) and can call into the map; PR-C+ can add a curated UI panel.

## Verification

- `yarn format` ✅
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` (frontend + every workspace package) ✅
- `yarn test` ✅ (32 new tests pass; 4403 total)

## Out of scope (in plan, future PRs)

- **PR-B**: `@mulmoclaude/photo-plugin` runtime plugin with `extractExif` / `lookupLocation` / `listLocations` / `rescan` kinds. Settings → Privacy tab toggle for `autoCapture`. View showing list + count + "show on map" button that fires `mapControl`.
- **PR-C**: LINE bridge photo receiving (Telegram + Slack already work; LINE's `parse.ts` needs extension).
- **Reverse-geocoding** (lat/lng → address): out of scope; reuse Google Places via `mapControl({ action: "findPlaces" })` from the LLM later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic extraction of photo EXIF metadata and location data from attached images.
  * New setting to enable or disable photo metadata auto-capture (enabled by default).
  * Location data is securely stored alongside photo attachments.

* **Chores**
  * Added `exifr` dependency for photo metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->