### PR TITLE
plan: rich embed syntax + iframe sandbox fixes (#1221)

### DIFF
--- a/plans/feat-rich-embed-syntax-1221.md
+++ b/plans/feat-rich-embed-syntax-1221.md
@@ -76,7 +76,25 @@ One regex captures every form:
 
 → `type`, `id`, `shorthand`, `query` capture groups. `URLSearchParams` over `query` produces the params map. Done.
 
-Disambiguation from existing `[[wiki-link]]`: the presence of `:` inside the brackets makes it an embed. No internal page name has `:`, so the discriminator is unambiguous.
+### Disambiguation from existing `[[wiki-link]]`
+
+**Important — the original "presence of `:` ⇒ embed" rule is unsafe** (Codex review on PR #1248). Today's `renderWikiLinks` (`src/plugins/wiki/helpers.ts`) accepts any text inside `[[...]]` except `]]`, and `isSafeWikiSlug` (`src/plugins/wiki/route.ts`) only blocks `/`, `\`, `..` — so a page literally named `foo:bar` is a valid wiki link. Reinterpreting `:` globally as embed syntax would silently change every existing `[[foo:bar]]` link's meaning.
+
+The discriminator is therefore **a closed set of known type prefixes**, not the bare presence of `:`:
+
+| Inside brackets | Treatment |
+|---|---|
+| `[[X:Y...]]` where `X` ∈ `EMBED_TYPES` (`amazon`, `isbn`, `github`, `youtube`, `map`, …) | embed |
+| anything else, including `[[foo:bar]]` where `foo` is not a registered type | wiki page link (unchanged) |
+| `[[X:Y]]` where the user genuinely wants a page named `X:Y` even if `X` is a registered type | escape with backslash: `[[X\:Y]]` (parser strips the `\` for the page-name lookup; reserved `\` is added to the wiki-link grammar in PR-B together with this rule) |
+
+**Migration & guardrails (PR-B includes):**
+
+1. **Reserved-prefix scan**: at PR-B merge time the wiki render path emits a one-shot **lint warning** in the wiki log when it sees an existing `[[<reserved>:Y]]` link, pointing the user at the escape. Zero behaviour change for them — the link still resolves as a wiki page until they decide.
+2. **Wiki page rename guard**: `manageWiki` save / rename refuses to create a slug whose first `:`-segment is a reserved type prefix, with an error message pointing at the escape. Prevents new collisions after PR-B.
+3. **`EMBED_TYPES` is closed and host-owned**, not user-extensible. Adding a new embed type is a host code change, gated by review — the same review naturally checks "does this collide with any existing wiki page name?"
+
+This converts the discriminator from a global syntactic rule (every `:` ⇒ embed) into a registry lookup (only registered prefixes ⇒ embed), so the backward-compat surface is only as wide as the closed `EMBED_TYPES` set, not "every wiki page that happens to contain `:`".
 
 ### Choices we explicitly reject
 

--- a/plans/feat-rich-embed-syntax-1221.md
+++ b/plans/feat-rich-embed-syntax-1221.md
@@ -15,7 +15,7 @@ Distilled from a survey of Hatena / PukiWiki / DokuWiki / MediaWiki / Hugo / Not
 
 ### Surface (3-tier progressive disclosure)
 
-```
+```text
 [[type:id]]                          # 90% case — minimum
 [[type:id|shorthand]]                # one positional shortcut
 [[type:id?key=val&key=val]]          # full extensibility (URL-query shape)
@@ -70,7 +70,7 @@ Type-specific keys live under each type's schema (`github.kind`, `map.zoom`, `yo
 
 One regex captures every form:
 
-```
+```regex
 \[\[([a-z][a-z0-9-]*):([^\|\?\]]+)(?:\|([^\?\]]+))?(?:\?([^\]]+))?\]\]
 ```
 
@@ -88,13 +88,18 @@ The discriminator is therefore **a closed set of known type prefixes**, not the 
 | anything else, including `[[foo:bar]]` where `foo` is not a registered type | wiki page link (unchanged) |
 | `[[X:Y]]` where the user genuinely wants a page named `X:Y` even if `X` is a registered type | escape with backslash: `[[X\:Y]]` (parser strips the `\` for the page-name lookup; reserved `\` is added to the wiki-link grammar in PR-B together with this rule) |
 
-**Migration & guardrails (PR-B includes):**
+**Precedence: embed always wins at registry hit.** `[[X:Y...]]` where `X ∈ EMBED_TYPES` is **always** treated as an embed at runtime — there is no "migration mode" runtime fallback to wiki resolution. Determinism beats forgiveness here; otherwise parser, server-side renderer, and client-side wiki-link rewriter could each pick a different precedence and silently disagree. Users who genuinely want a wiki page whose name collides with a reserved prefix MUST use the backslash escape `[[X\:Y]]`.
 
-1. **Reserved-prefix scan**: at PR-B merge time the wiki render path emits a one-shot **lint warning** in the wiki log when it sees an existing `[[<reserved>:Y]]` link, pointing the user at the escape. Zero behaviour change for them — the link still resolves as a wiki page until they decide.
-2. **Wiki page rename guard**: `manageWiki` save / rename refuses to create a slug whose first `:`-segment is a reserved type prefix, with an error message pointing at the escape. Prevents new collisions after PR-B.
-3. **`EMBED_TYPES` is closed and host-owned**, not user-extensible. Adding a new embed type is a host code change, gated by review — the same review naturally checks "does this collide with any existing wiki page name?"
+**Pre-merge migration step (one-shot, runs BEFORE PR-B lands, not at runtime):**
 
-This converts the discriminator from a global syntactic rule (every `:` ⇒ embed) into a registry lookup (only registered prefixes ⇒ embed), so the backward-compat surface is only as wide as the closed `EMBED_TYPES` set, not "every wiki page that happens to contain `:`".
+1. **`scripts/scan-reserved-wiki-collisions.ts`** ships in PR-B and runs as part of CI. It walks every `data/wiki/pages/*.md` body for `[[<reserved>:Y]]` patterns and **fails the lint job** if any are found, listing each occurrence with its file path. The list is the user's checklist: rename the page or rewrite the link to use `[[X\:Y]]`. Once the scan reports zero hits, PR-B is mergeable. Production behaviour after merge is the deterministic registry rule above — no fallback ambiguity.
+
+**Post-merge guardrails (runtime, prevent new collisions):**
+
+2. **Wiki page rename / save guard**: `manageWiki` save / rename refuses to create a slug whose first `:`-segment matches a reserved type prefix. Error message points at the escape. Closes the back door so users can't reintroduce collisions after PR-B lands.
+3. **`EMBED_TYPES` is closed and host-owned**, not user-extensible. Adding a new embed type is a host code change, gated by review — the review naturally checks "does this collide with any existing wiki page name?" before merge.
+
+This converts the discriminator from a global syntactic rule (every `:` ⇒ embed) into a closed registry lookup, so the backward-compat surface is only as wide as the host-owned `EMBED_TYPES` set — and the pre-merge scan + rename guard make the migration explicit rather than silent.
 
 ### Choices we explicitly reject
 

--- a/plans/feat-rich-embed-syntax-1221.md
+++ b/plans/feat-rich-embed-syntax-1221.md
@@ -1,0 +1,207 @@
+# Rich embed syntax + iframe sandbox fixes (#1221)
+
+## Goal
+
+Make external content render usefully inside MulmoClaude's wiki / files / chat-artifact surfaces:
+
+1. External `<a href="https://...">` links opened from sandboxed iframes are dead-clicks today — fix that.
+2. The LLM (and preset skills like `mc-library`) currently spell out raw URLs for Amazon / GitHub / YouTube / etc. Define a compact wiki record that renders into the right card / link / embed at display time, decoupling the on-disk form from the visual rendering.
+
+Phasing keeps risk low: PR-A is a sandbox-fix ready in hours; PR-B introduces the syntax + the first two renderers; PR-C+ extends one prefix at a time as real usage demands them.
+
+## Design — hybrid embed syntax
+
+Distilled from a survey of Hatena / PukiWiki / DokuWiki / MediaWiki / Hugo / Notion (see issue thread for the full comparison).
+
+### Surface (3-tier progressive disclosure)
+
+```
+[[type:id]]                          # 90% case — minimum
+[[type:id|shorthand]]                # one positional shortcut
+[[type:id?key=val&key=val]]          # full extensibility (URL-query shape)
+```
+
+| Example | Renders as |
+|---|---|
+| `[[amazon:B00ICN066A]]` | Amazon card (default region from config) |
+| `[[amazon:B00ICN066A\|link]]` | inline link only — `style=link` shorthand |
+| `[[amazon:B00ICN066A?region=jp&style=card]]` | full named-param form |
+| `[[isbn:9780062316097]]` | Book card via OpenLibrary (Amazon-independent) |
+| `[[github:receptron/mulmoclaude]]` | repo card |
+| `[[github:receptron/mulmoclaude/issues/1221]]` | issue link with title (id may contain `/`) |
+| `[[youtube:dQw4w9WgXcQ?style=thumbnail]]` | thumbnail instead of full embed |
+| `[[map:35.6586,139.7454?zoom=12]]` | geo pin |
+
+### Internal data model (parser output)
+
+```ts
+interface ParsedEmbed {
+  type: string;                       // "amazon" | "isbn" | "github" | ...
+  id: string;                         // primary id (slash-tolerant)
+  shorthand?: string;                 // |xxx (single positional)
+  params: Record<string, string>;     // ?key=val&... named params
+  raw: string;                        // original [[...]] for round-trip
+}
+```
+
+### Renderer registry (per type, Zod-validated)
+
+```ts
+interface EmbedRenderer<T extends z.ZodSchema> {
+  type: string;
+  schema: T;                                  // params validation + type derivation
+  render(args: z.infer<T> & { id: string }, ctx: RenderCtx): VNode;
+}
+```
+
+`shorthand` is interpreted by the schema (e.g. `|link` → `style: "link"` for `amazon` / `github` / `youtube`).
+
+### Cross-type reserved param names
+
+| name | values | applies to |
+|---|---|---|
+| `style` | `link` / `card` / `inline` / `image` | all types |
+| `region` | country code | amazon, news, ... |
+| `caption` | any string | all (link-text override) |
+
+Type-specific keys live under each type's schema (`github.kind`, `map.zoom`, `youtube.start`).
+
+### Parsing
+
+One regex captures every form:
+
+```
+\[\[([a-z][a-z0-9-]*):([^\|\?\]]+)(?:\|([^\?\]]+))?(?:\?([^\]]+))?\]\]
+```
+
+→ `type`, `id`, `shorthand`, `query` capture groups. `URLSearchParams` over `query` produces the params map. Done.
+
+Disambiguation from existing `[[wiki-link]]`: the presence of `:` inside the brackets makes it an embed. No internal page name has `:`, so the discriminator is unambiguous.
+
+### Choices we explicitly reject
+
+| Rejected | Why |
+|---|---|
+| MediaWiki magic links (bare-text `ISBN ...` auto-link) | Un-localizable, deprecated by Wikipedia itself |
+| Hugo full shortcode (`{{< amazon asin="..." >}}`) | Too verbose for inline prose |
+| Pure positional flags (PukiWiki `(asin, left, image)`) | Reordering breaks; 4th param is a footgun |
+| Notion-style implicit URL unfurl | No way to express author intent (link vs card vs image-only) |
+| Hatena-style `:` separator for modifiers | Collides with `:` inside ids (URLs, repo paths) |
+
+## Phasing
+
+### PR-A — iframe sandbox fix (smallest possible change, closes Issue 1)
+
+**Scope**: external `<a href="https://...">` produced by `marked.parse` should open in a new tab on a normal click.
+
+**Touch points** (all `marked.parse` callers in the host):
+
+- `src/plugins/wiki/View.vue`
+- `src/plugins/markdown/View.vue`
+- `src/plugins/textResponse/View.vue`
+- `src/plugins/news/View.vue` (if it lives in the same renderer)
+- `src/plugins/spreadsheet/View.vue` (XLSX → HTML — already trusted, but check)
+
+**Approach**:
+
+1. Add a shared `src/utils/markdown/externalLinks.ts` helper:
+   - `marked.use({ renderer: { link({href, title, text}) {...} } })` — when `href` is an absolute URL (`/^https?:\/\//.test(href)`), append `target="_blank" rel="noopener noreferrer"` to the emitted `<a>`.
+   - Internal links (`/`, `#`, `[[wiki-link]]` post-processing) untouched.
+2. Iframe `sandbox` attribute (if any view wraps content in an iframe — verify via grep): add `allow-popups allow-popups-to-escape-sandbox`. Audit every `sandbox=` usage; we don't want to widen capability set without intent.
+3. Unit test for the renderer override: external URL → `target="_blank"` injected; relative URL → unchanged.
+
+**Out of scope** for PR-A:
+
+- New embed syntax — that's PR-B.
+- Restyling links — only their open-target changes.
+
+**Acceptance**:
+
+- [ ] Click any `https://...` link in wiki / files / chat artifact → opens in new tab.
+- [ ] Click any internal link (`[[other-page]]`, `/route`) → in-place navigation as before.
+- [ ] No new XSS vector (the `noopener noreferrer` is the standard mitigation).
+- [ ] All existing markdown unit + e2e tests still pass.
+
+### PR-B — embed syntax core + Amazon + ISBN renderers
+
+**Scope**: introduce `[[type:id...]]` parser + a renderer registry + the first two type renderers (`amazon`, `isbn`). Wires into the same `marked.parse` pipeline PR-A touched.
+
+**Files (new)**:
+
+- `src/utils/markdown/embed/parser.ts` — regex + URL-query parsing → `ParsedEmbed`
+- `src/utils/markdown/embed/registry.ts` — type-keyed registry, `register(renderer)`, `get(type)`
+- `src/utils/markdown/embed/renderers/amazon.ts` — Zod schema + render fn
+- `src/utils/markdown/embed/renderers/isbn.ts` — Zod schema + render fn
+- `src/utils/markdown/embed/index.ts` — exported entry: `expandEmbedsInMarkdown(md: string): string`
+- `test/utils/markdown/embed/test_parser.ts` — minimum / shorthand / full-params / collision-with-wiki-link / malformed-input cases
+- `test/utils/markdown/embed/test_amazon.ts`, `test_isbn.ts` — schema validation + render output snapshot
+
+**Files (changed)**:
+
+- `marked.use(...)` config in the shared `markdown/externalLinks.ts` helper from PR-A — extend to also walk the AST (or do a pre-pass on the markdown source) and replace `[[type:id...]]` tokens before `marked.parse`.
+- Each `View.vue` that renders markdown gets `expandEmbedsInMarkdown(md)` in its pipeline. No direct DOM injection from the renderer — just produce HTML strings through the existing `marked` + DOMPurify pipe.
+
+**Renderer responsibilities**:
+
+- `amazon`:
+  - schema: `{ region: enum default "jp" (configurable), style: enum default "card", tag?: string (affiliate, defaults from config) }`
+  - card style: cover image (when fetchable) + title + price line + region badge
+  - link style: `<a href="https://www.amazon.<region>/dp/<asin>?tag=<tag>" target="_blank">…</a>`
+  - cover/title fetch: deferred to a SSR-side cache or client-side fetch via the existing pubsub `bookmarks`/cache pattern. **Do NOT fetch on every render** — needs same caching primitive `mc-library` Google-Books fetcher uses.
+- `isbn`:
+  - schema: `{ style: enum default "card", source: enum["openlibrary", "googlebooks"] default "openlibrary" }`
+  - card style: cover + title + author + year via OpenLibrary `https://openlibrary.org/isbn/<isbn>.json`
+  - link style: `<a href="https://openlibrary.org/isbn/<isbn>">…</a>` (openlibrary search page)
+
+**Affiliate-tag policy**:
+
+- Single global config setting (e.g. `config/settings.json#amazonAffiliateTag`) injected into every `amazon` link unless `?tag=` is set explicitly.
+- Empty default → no tag appended (unmonetised by default).
+
+**Acceptance**:
+
+- [ ] `[[amazon:B00ICN066A]]` renders an Amazon card.
+- [ ] `[[amazon:B00ICN066A|link]]` renders a plain link.
+- [ ] `[[amazon:B00ICN066A?region=jp]]` switches the destination URL.
+- [ ] `[[isbn:9780062316097]]` renders a book card via OpenLibrary.
+- [ ] `[[wiki-page-name]]` (no `:`) still renders as an internal wiki link.
+- [ ] Malformed `[[amazon:]]` (empty id) emits a fallback "?" badge with the `raw` source visible (no crash).
+- [ ] Parser unit tests cover all cases above.
+- [ ] `mc-library` skill (preset) is updated to write `[[amazon:<asin>]]` instead of raw `https://www.amazon.co.jp/dp/...` (separate small commit on the same PR or a follow-up).
+
+**Out of scope** for PR-B:
+
+- youtube / x / map / github renderers — PR-C+.
+- Server-side cover/metadata caching — first cut can fetch on-demand with a basic in-memory cache.
+- Editor UX (suggestion popups, picker UI) — pure markdown for now.
+
+### PR-C+ — additional types
+
+Each future type is one self-contained PR adding `src/utils/markdown/embed/renderers/<type>.ts` + the corresponding schema + tests. No changes to the parser or registry. Suggested order based on `mc-library` and #1169 needs:
+
+1. `youtube` — embed iframe (default thumbnail-link, opt-in to full embed via `?style=embed` since the iframe itself is heavy)
+2. `github` — repo card + issue/PR link (kind detected from id shape: `owner/repo`, `owner/repo/issues/N`, `owner/repo/pull/N`)
+3. `x` (Twitter) — tweet embed via oEmbed API
+4. `map` — geo pin (lat,lng + zoom). Composes with the existing google-map plugin (#1227).
+
+## Out of scope (the whole issue)
+
+- Universal oEmbed fallback (any URL → unfurl). Author intent matters; we want the explicit `[[type:id]]` opt-in.
+- Editing UX — just markdown for now. A picker / autocomplete is a separate UX PR if needed.
+- Magic-link auto-detection (bare ISBN / ASIN in prose) — explicitly rejected per the design.
+
+## Related
+
+- #1210 — preset skills infrastructure (mc-library is the first heavy user; will switch to `[[amazon:...]]` once PR-B lands)
+- #1169 — home-application plugin & role plan (most planned skills will produce content with external references)
+- #1227 — map plugin (PR-C `map:` renderer can compose with this)
+
+## Tracking
+
+- PR-A: iframe sandbox fix
+- PR-B: parser + registry + amazon + isbn
+- PR-C: youtube
+- PR-D: github
+- (later) PR-E: x, PR-F: map
+
+Move this file to `plans/done/` only when the **last** of the planned PRs (PR-A through PR-D at minimum) merges. Later additions (PR-E, PR-F) can be one-shot follow-ups without keeping the plan file open.


### PR DESCRIPTION
## Summary

- Plan file for #1221 — splitting the work into PR-A (iframe sandbox fix, small) → PR-B (`[[type:id?key=val]]` syntax + amazon/isbn renderers) → PR-C+ (one type per PR: youtube / github / x / map)
- Design distilled from surveying Hatena / PukiWiki / DokuWiki / MediaWiki / Hugo / Notion conventions; rejected approaches documented with rationale.

## Items to Confirm / Review

- **3-tier progressive disclosure** (`[[type:id]]` → `|shorthand` → `?key=val&...`): is the shorthand pulling its weight or should we drop it and require named params even for the simple case? Currently kept because `[[amazon:asin|link]]` is still half the typing of `?style=link`.
- **\`?\` URL-query separator**: chose this over Hatena's `:` to avoid collision with ids that contain `:` (URLs, future identifiers). Worth reviewing if anything looks weird in a long-form example.
- **\`[[wiki-link]]` disambiguation**: presence of `:` makes it an embed; no internal page name has `:` today. Risk is low but worth flagging if anyone has data that could break this assumption.
- **Affiliate-tag injection** (PR-B): proposed as a single global setting (\`config/settings.json#amazonAffiliateTag\`), per-link override via \`?tag=\`. Default empty (unmonetised).

## User Prompt

\`\`\`
PR-Aって実装するとユーザ体験どうなる？
…
ちょっと一般的なwiki記法でamazonをどう扱っているか調べてまとめて。
全部ハイブリットでいいところどりで考えて。あと、パースしやすいのがよいし、
できればobjectになるデータ型のほうが拡張しやすいけど、人間は書きづらいよね。
あたりを考慮しよう
ok issue更新してplan化かな
\`\`\`

## Implementation approach

See \`plans/feat-rich-embed-syntax-1221.md\` — full design + acceptance criteria + file layout per phase.

Highlights:

- **Parser**: one regex captures \`type\` / \`id\` / \`shorthand\` / \`query\`; \`URLSearchParams\` over the query string produces a \`Record<string, string>\`. Internal type is a strict object so per-type Zod schemas can validate + derive types.
- **Registry**: type-keyed; each renderer ships its schema + render fn. Adding a new prefix is one self-contained file + one test file.
- **Wiring**: extends the existing \`marked.parse\` pipeline alongside the PR-A external-link renderer override; runs as a markdown pre-pass before \`marked\` so the brackets don't interfere with markdown's own \`[[...]]\` interpretation (which is non-standard).

## Test plan

- [ ] Plan review — shape of the syntax, phasing, and out-of-scope list before any code lands.
- [ ] PR-A acceptance criteria (in plan §PR-A).
- [ ] PR-B acceptance criteria (in plan §PR-B).
- [ ] PR-C+ each adds its own acceptance per renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation for upcoming rich embed syntax feature
  * Planned improvements include enhanced link handling in embedded content and support for new embed types in future releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->