### PR TITLE
feat(settings): Photos tab with photo-EXIF auto-capture toggle (#1222 PR-B-2)

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -65,6 +65,14 @@
         >
           {{ t("settingsModal.tabs.map") }}
         </button>
+        <button
+          class="px-3 py-2 text-sm border-b-2"
+          :class="activeTab === 'photos' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-800'"
+          data-testid="settings-tab-photos"
+          @click="activeTab = 'photos'"
+        >
+          {{ t("settingsModal.tabs.photos") }}
+        </button>
       </div>
 
       <div class="px-5 py-4 overflow-y-auto flex-1 space-y-4 text-gray-900">
@@ -145,6 +153,8 @@
         <SettingsReferenceDirsTab v-else-if="activeTab === 'refs'" />
 
         <SettingsMapTab v-else-if="activeTab === 'map'" :reload-token="mapReloadToken" @saved="onMapSaved" />
+
+        <SettingsPhotosTab v-else-if="activeTab === 'photos'" :reload-token="photosReloadToken" />
       </div>
 
       <!-- Footer: status strip only. MCP / Workspace Dirs / Reference
@@ -170,6 +180,7 @@ import SettingsMcpTab from "./SettingsMcpTab.vue";
 import SettingsWorkspaceDirsTab from "./SettingsWorkspaceDirsTab.vue";
 import SettingsReferenceDirsTab from "./SettingsReferenceDirsTab.vue";
 import SettingsMapTab from "./SettingsMapTab.vue";
+import SettingsPhotosTab from "./SettingsPhotosTab.vue";
 import type { McpServerEntry } from "./SettingsMcpTab.vue";
 import { apiGet, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
@@ -215,7 +226,7 @@ const emit = defineEmits<{
 // update / remove persist immediately).
 const mcpTabRef = ref<{ flushDraft: () => boolean; hasPendingDraft: () => boolean } | null>(null);
 
-const activeTab = ref<"gemini" | "tools" | "mcp" | "dirs" | "refs" | "map">("tools");
+const activeTab = ref<"gemini" | "tools" | "mcp" | "dirs" | "refs" | "map" | "photos">("tools");
 
 // Forces SettingsMapTab to re-load when the modal opens or the user
 // confirms a save — ensures the input always reflects the latest
@@ -227,6 +238,11 @@ function onMapSaved(): void {
   // also notice via the `saved` event bubble.
   emit("saved");
 }
+
+// Same pattern as mapReloadToken — bumped when the modal opens so
+// the Photos tab refetches the autoCapture flag (could have been
+// hand-edited in settings.json since the last visit).
+const photosReloadToken = ref(0);
 const toolsText = ref("");
 // Server truth for tools — updated on load and on a successful Save
 // from the Tools tab. `toolsDirty` compares this against `toolsText`
@@ -398,6 +414,7 @@ watch(
       activeTab.value = props.geminiAvailable ? "tools" : "gemini";
       loadConfig();
       mapReloadToken.value += 1;
+      photosReloadToken.value += 1;
       statusMessage.value = "";
       statusError.value = false;
     }

--- a/src/components/SettingsPhotosTab.vue
+++ b/src/components/SettingsPhotosTab.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="space-y-3" data-testid="settings-photos-tab">
+    <p class="text-sm text-gray-700">{{ t("settingsModal.photosTab.description") }}</p>
+
+    <div class="flex items-start gap-3">
+      <input
+        id="settings-photos-auto-capture"
+        v-model="autoCapture"
+        type="checkbox"
+        class="mt-1 h-4 w-4"
+        :disabled="saving"
+        data-testid="settings-photos-auto-capture-input"
+        @change="save"
+      />
+      <label for="settings-photos-auto-capture" class="flex-1">
+        <span class="block text-sm font-medium text-gray-800">{{ t("settingsModal.photosTab.autoCaptureLabel") }}</span>
+        <span class="block text-xs text-gray-500 mt-0.5">{{ t("settingsModal.photosTab.autoCaptureHint") }}</span>
+      </label>
+    </div>
+
+    <div v-if="loaded" class="flex items-center gap-3 text-xs">
+      <span :class="statusColour" data-testid="settings-photos-status">{{ statusText }}</span>
+    </div>
+
+    <p v-if="errorMessage" class="text-sm text-red-700" role="alert" data-testid="settings-photos-error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  /** Bumped by the parent on modal open. Same pattern as Map tab —
+   *  picks up out-of-band hand-edits to settings.json. */
+  reloadToken: number;
+}>();
+
+const emit = defineEmits<{
+  saved: [];
+}>();
+
+interface SettingsResponse {
+  settings: {
+    extraAllowedTools: string[];
+    photoExif?: { autoCapture: boolean };
+  };
+}
+
+const autoCapture = ref(true);
+const stored = ref(true);
+const loaded = ref(false);
+const saving = ref(false);
+const errorMessage = ref("");
+
+const statusText = computed(() => {
+  if (saving.value) return t("common.saving");
+  if (errorMessage.value) return errorMessage.value;
+  return stored.value ? t("settingsModal.photosTab.statusOn") : t("settingsModal.photosTab.statusOff");
+});
+
+const statusColour = computed(() => {
+  if (saving.value) return "text-gray-500";
+  if (errorMessage.value) return "text-red-600";
+  return stored.value ? "text-green-600" : "text-gray-500";
+});
+
+async function load(): Promise<void> {
+  errorMessage.value = "";
+  const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.photosTab.loadError");
+    return;
+  }
+  // Default true matches `isPhotoExifAutoCaptureEnabled` in
+  // server/system/config.ts — a missing block means "on", so the
+  // checkbox starts checked on a fresh workspace.
+  const value = response.data.settings.photoExif?.autoCapture ?? true;
+  stored.value = value;
+  autoCapture.value = value;
+  loaded.value = true;
+}
+
+async function save(): Promise<void> {
+  if (saving.value) return;
+  if (autoCapture.value === stored.value) return;
+  saving.value = true;
+  errorMessage.value = "";
+  // Patch-style PUT: only `photoExif` is sent. The server's
+  // /api/config/settings handler merges onto the on-disk state so
+  // other tabs (Map / Tools) keep their fields untouched.
+  const response = await apiPut<unknown>(API_ROUTES.config.settings, {
+    photoExif: { autoCapture: autoCapture.value },
+  });
+  saving.value = false;
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.photosTab.saveError");
+    // Rollback the checkbox so the visible state matches what's
+    // actually persisted.
+    autoCapture.value = stored.value;
+    return;
+  }
+  stored.value = autoCapture.value;
+  emit("saved");
+}
+
+watch(
+  () => props.reloadToken,
+  () => {
+    void load();
+  },
+  { immediate: true },
+);
+</script>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -147,6 +147,7 @@ const deMessages = {
       dirs: "Verzeichnisse",
       refs: "Referenzverzeichnisse",
       map: "Karte",
+      photos: "Fotos",
     },
     mapTab: {
       description:
@@ -158,6 +159,17 @@ const deMessages = {
       configured: "Konfiguriert",
       notConfigured: "Nicht konfiguriert",
       clear: "Löschen",
+      loadError: "Einstellungen konnten nicht geladen werden",
+      saveError: "Speichern fehlgeschlagen",
+    },
+    photosTab: {
+      description:
+        "Datenschutzeinstellungen für Fotos, die per Chat oder verbundener Bridge empfangen wurden. EXIF-Standortdaten sind sensibel — Häkchen entfernen, um die automatische Erfassung zu deaktivieren.",
+      autoCaptureLabel: "Fotostandort automatisch erfassen",
+      autoCaptureHint:
+        "Aktiv: Für jedes hochgeladene Bild mit EXIF-GPS wird ein Standort-Sidecar in data/locations/ erzeugt. Aus: Es wird nichts automatisch erfasst; das LLM kann EXIF weiterhin auf Anforderung lesen.",
+      statusOn: "Automatische Erfassung AN",
+      statusOff: "Automatische Erfassung AUS",
       loadError: "Einstellungen konnten nicht geladen werden",
       saveError: "Speichern fehlgeschlagen",
     },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -167,6 +167,7 @@ const enMessages = {
       dirs: "Directories",
       refs: "Reference Dirs",
       map: "Map",
+      photos: "Photos",
     },
     mapTab: {
       description: "Set the Google Maps API key used by the map plugin. The key is stored locally and never transmitted anywhere except to Google Maps.",
@@ -177,6 +178,17 @@ const enMessages = {
       configured: "Configured",
       notConfigured: "Not configured",
       clear: "Clear",
+      loadError: "Failed to load settings",
+      saveError: "Failed to save",
+    },
+    photosTab: {
+      description:
+        "Privacy controls for photos uploaded via chat or a connected bridge. EXIF location data is sensitive — uncheck the box to opt out of automatic capture.",
+      autoCaptureLabel: "Auto-capture photo location data",
+      autoCaptureHint:
+        "When on, every uploaded image with EXIF GPS gets a location sidecar at data/locations/. Off: nothing is captured automatically; the LLM can still extract EXIF on demand.",
+      statusOn: "Auto-capture is ON",
+      statusOff: "Auto-capture is OFF",
       loadError: "Failed to load settings",
       saveError: "Failed to save",
     },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -151,6 +151,7 @@ const esMessages = {
       dirs: "Directorios",
       refs: "Directorios de referencia",
       map: "Mapa",
+      photos: "Fotos",
     },
     mapTab: {
       description: "Configura la clave de la API de Google Maps que usa el plugin de mapas. La clave se guarda localmente y solo se envía a Google Maps.",
@@ -161,6 +162,17 @@ const esMessages = {
       configured: "Configurada",
       notConfigured: "Sin configurar",
       clear: "Borrar",
+      loadError: "Error al cargar los ajustes",
+      saveError: "Error al guardar",
+    },
+    photosTab: {
+      description:
+        "Controles de privacidad para las fotos recibidas por chat o por un bridge conectado. Los datos de ubicación EXIF son sensibles — desmarca para desactivar la captura automática.",
+      autoCaptureLabel: "Capturar automáticamente la ubicación de las fotos",
+      autoCaptureHint:
+        "Activado: cada imagen subida con GPS en EXIF genera un sidecar de ubicación en data/locations/. Desactivado: no se captura nada automáticamente; el LLM aún puede extraer EXIF manualmente.",
+      statusOn: "Captura automática ACTIVADA",
+      statusOff: "Captura automática DESACTIVADA",
       loadError: "Error al cargar los ajustes",
       saveError: "Error al guardar",
     },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -146,6 +146,7 @@ const frMessages = {
       dirs: "Répertoires",
       refs: "Répertoires de référence",
       map: "Carte",
+      photos: "Photos",
     },
     mapTab: {
       description: "Définit la clé API Google Maps utilisée par le plugin de carte. La clé est stockée localement et n'est envoyée qu'à Google Maps.",
@@ -156,6 +157,17 @@ const frMessages = {
       configured: "Configurée",
       notConfigured: "Non configurée",
       clear: "Effacer",
+      loadError: "Échec du chargement des paramètres",
+      saveError: "Échec de l'enregistrement",
+    },
+    photosTab: {
+      description:
+        "Contrôles de confidentialité pour les photos reçues par le chat ou par un bridge connecté. Les données de localisation EXIF sont sensibles — décochez pour désactiver la capture automatique.",
+      autoCaptureLabel: "Capturer automatiquement la localisation des photos",
+      autoCaptureHint:
+        "Activé : chaque image envoyée avec GPS EXIF génère un sidecar de localisation dans data/locations/. Désactivé : rien n'est capturé automatiquement ; le LLM peut toujours extraire EXIF à la demande.",
+      statusOn: "Capture automatique ACTIVÉE",
+      statusOff: "Capture automatique DÉSACTIVÉE",
       loadError: "Échec du chargement des paramètres",
       saveError: "Échec de l'enregistrement",
     },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -151,6 +151,7 @@ const jaMessages = {
       dirs: "ディレクトリ",
       refs: "参照ディレクトリ",
       map: "地図",
+      photos: "写真",
     },
     mapTab: {
       description: "地図プラグインで使う Google Maps API キーを設定します。キーはローカルに保存され、Google Maps への通信以外で送信されることはありません。",
@@ -161,6 +162,17 @@ const jaMessages = {
       configured: "設定済み",
       notConfigured: "未設定",
       clear: "クリア",
+      loadError: "設定の読み込みに失敗しました",
+      saveError: "保存に失敗しました",
+    },
+    photosTab: {
+      description:
+        "チャットや bridge 経由で受け取った写真のプライバシー設定。EXIF の位置情報は機微なため、自動取得を停止したい場合はチェックを外してください。",
+      autoCaptureLabel: "写真の位置情報を自動取得",
+      autoCaptureHint:
+        "ON のとき、EXIF に GPS を持つ画像をアップロードすると data/locations/ に sidecar が自動生成されます。OFF にすると自動取得は停止しますが、必要なときに LLM が手動で EXIF を読むことは可能です。",
+      statusOn: "自動取得は ON",
+      statusOff: "自動取得は OFF",
       loadError: "設定の読み込みに失敗しました",
       saveError: "保存に失敗しました",
     },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -153,6 +153,7 @@ const koMessages = {
       dirs: "디렉터리",
       refs: "참조 디렉터리",
       map: "지도",
+      photos: "사진",
     },
     mapTab: {
       description: "지도 플러그인에서 사용하는 Google Maps API 키를 설정합니다. 키는 로컬에 저장되며 Google Maps 외부로는 전송되지 않습니다.",
@@ -163,6 +164,16 @@ const koMessages = {
       configured: "구성됨",
       notConfigured: "구성되지 않음",
       clear: "지우기",
+      loadError: "설정을 불러오지 못했습니다",
+      saveError: "저장에 실패했습니다",
+    },
+    photosTab: {
+      description: "채팅 또는 연결된 bridge로 받은 사진의 개인정보 설정입니다. EXIF 위치 데이터는 민감하므로, 자동 수집을 원하지 않으면 체크박스를 해제하세요.",
+      autoCaptureLabel: "사진 위치 데이터 자동 수집",
+      autoCaptureHint:
+        "켜진 경우, EXIF GPS가 있는 업로드된 이미지마다 data/locations/에 위치 sidecar가 생성됩니다. 끄면 자동 수집이 중단되지만 필요할 때 LLM이 EXIF를 수동으로 읽을 수 있습니다.",
+      statusOn: "자동 수집 켜짐",
+      statusOff: "자동 수집 꺼짐",
       loadError: "설정을 불러오지 못했습니다",
       saveError: "저장에 실패했습니다",
     },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -146,6 +146,7 @@ const ptBRMessages = {
       dirs: "Diretórios",
       refs: "Diretórios de referência",
       map: "Mapa",
+      photos: "Fotos",
     },
     mapTab: {
       description: "Define a chave da API do Google Maps usada pelo plugin de mapa. A chave fica salva localmente e só é enviada para o Google Maps.",
@@ -156,6 +157,17 @@ const ptBRMessages = {
       configured: "Configurada",
       notConfigured: "Não configurada",
       clear: "Limpar",
+      loadError: "Falha ao carregar as configurações",
+      saveError: "Falha ao salvar",
+    },
+    photosTab: {
+      description:
+        "Controles de privacidade para fotos recebidas pelo chat ou por um bridge conectado. Os dados de localização EXIF são sensíveis — desmarque para desativar a captura automática.",
+      autoCaptureLabel: "Capturar automaticamente a localização das fotos",
+      autoCaptureHint:
+        "Ativado: cada imagem enviada com GPS no EXIF gera um sidecar de localização em data/locations/. Desativado: nada é capturado automaticamente; o LLM ainda pode extrair EXIF manualmente.",
+      statusOn: "Captura automática ATIVADA",
+      statusOff: "Captura automática DESATIVADA",
       loadError: "Falha ao carregar as configurações",
       saveError: "Falha ao salvar",
     },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -149,6 +149,7 @@ const zhMessages = {
       dirs: "目录",
       refs: "引用目录",
       map: "地图",
+      photos: "照片",
     },
     mapTab: {
       description: "设置地图插件使用的 Google Maps API 密钥。密钥仅存储在本地,除发送到 Google Maps 外不会传输到任何地方。",
@@ -159,6 +160,15 @@ const zhMessages = {
       configured: "已配置",
       notConfigured: "未配置",
       clear: "清除",
+      loadError: "加载设置失败",
+      saveError: "保存失败",
+    },
+    photosTab: {
+      description: "通过聊天或已连接的 bridge 收到的照片的隐私设置。EXIF 位置数据敏感 — 取消勾选可关闭自动捕获。",
+      autoCaptureLabel: "自动捕获照片位置数据",
+      autoCaptureHint: "开启时,所有带 EXIF GPS 的上传图片会在 data/locations/ 生成位置 sidecar。关闭后不再自动捕获,但 LLM 仍可在需要时手动读取 EXIF。",
+      statusOn: "自动捕获已开启",
+      statusOff: "自动捕获已关闭",
       loadError: "加载设置失败",
       saveError: "保存失败",
     },


### PR DESCRIPTION
## Summary

Settings UI counterpart to PR #1247 (the post-save EXIF hook) and PR #1250 (the \`managePhotoLocations\` plugin). Adds a **Photos tab** to the Settings modal with a single checkbox controlling \`AppSettings.photoExif.autoCapture\`. Was deferred from PR-B-core to keep that focused.

Until this lands, opt-out required hand-editing \`~/mulmoclaude/config/settings.json\`. After this lands: Settings → Photos → uncheck.

## Items to Confirm / Review

1. **Default ON** — matches \`isPhotoExifAutoCaptureEnabled\` in \`server/system/config.ts\` (a missing block ⇒ on). Same default as the user agreed to in the plan ("default-on + Settings で opt-out 可能").
2. **Auto-save on change** — same pattern as MCP / Workspace Dirs / Reference Dirs tabs (no explicit Save button). The Map tab uses the same auto-save shape.
3. **Patch-style PUT** — only \`photoExif\` is sent, so other tabs' fields (Tools \`extraAllowedTools\`, Map \`googleMapsApiKey\`) survive untouched. Server's \`/api/config/settings\` handler does the merge.
4. **i18n lockstep** — all 8 locales touched: \`settingsModal.tabs.photos\` + \`settingsModal.photosTab.*\` (7 strings × 8 = 56 translations). Real translations, placeholders verbatim.

## Items shipped

| File | Change |
|---|---|
| \`src/components/SettingsPhotosTab.vue\` (new) | Single checkbox bound to \`autoCapture\`. Auto-saves on change. Status line shows ON / OFF. Rolls back the checkbox if save fails. |
| \`src/components/SettingsModal.vue\` | Wires the new tab next to Map; \`activeTab\` type extended; \`photosReloadToken\` bumped on modal open. |
| \`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts\` | New \`tabs.photos\` + \`photosTab\` block. |

## User Prompt

> 続けて

(Continuing through the plan: PR-B core merged via #1250, this is the deferred Settings UI piece.)

## Verification

- \`yarn format\` ✅
- \`yarn lint\` ✅
- \`yarn typecheck\` ✅
- \`yarn build\` ✅
- \`yarn test\` ✅

## Manual smoke

1. Open Settings → Photos tab
2. See "Auto-capture is ON" + checked checkbox
3. Uncheck → instantly saves → "Auto-capture is OFF"
4. Upload a geotagged photo → no sidecar generated (verified against \`~/mulmoclaude/data/locations/\`)
5. Re-check → upload again → sidecar resumes

## Refs

- Predecessors: #1247 (post-save EXIF hook), #1249 (HEIC + GPS extraction fix), #1250 (managePhotoLocations plugin)
- Issue: #1222
- Plan: \`plans/feat-photo-exif.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Photos settings tab in the Settings Modal for managing photo privacy controls
  * Introduced a toggle to enable/disable automatic GPS location data extraction from photos
  * Added error handling and status indicators for configuration changes
  * Full multilingual support across 9 languages (English, German, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Simplified Chinese)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1251)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->