### PR TITLE
fix(ui): wire handleExternalLinkClick into 6 markdown / sheet renderers (#1221 PR-A)

### DIFF
--- a/src/components/NewsView.vue
+++ b/src/components/NewsView.vue
@@ -118,7 +118,7 @@
                 <div v-else-if="bodyError" class="text-sm text-red-600">{{ t("pluginNews.bodyError", { error: bodyError }) }}</div>
                 <div v-else-if="!body" class="text-sm text-gray-400 italic">{{ t("pluginNews.noBody") }}</div>
                 <!-- eslint-disable-next-line vue/no-v-html -- marked.parse output of app-owned news body; trusted in-process render -->
-                <div v-else class="markdown-content prose prose-slate max-w-none" v-html="renderedBody"></div>
+                <div v-else class="markdown-content prose prose-slate max-w-none" @click="handleExternalLinkClick" v-html="renderedBody"></div>
               </div>
             </div>
           </div>
@@ -144,6 +144,7 @@ import { API_ROUTES } from "../config/apiRoutes";
 import { apiGet } from "../utils/api";
 import { formatSmartTime } from "../utils/format/date";
 import { useNewsItems } from "../composables/useNewsItems";
+import { handleExternalLinkClick } from "../utils/dom/externalLink";
 import { useNewsReadState } from "../composables/useNewsReadState";
 import { parseFrontmatter } from "../utils/markdown/frontmatter";
 import FilterChip from "./FilterChip.vue";

--- a/src/components/SourcesManager.vue
+++ b/src/components/SourcesManager.vue
@@ -240,7 +240,7 @@
           {{ briefError }}
         </div>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <div v-else class="markdown-content" v-html="briefHtml" />
+        <div v-else class="markdown-content" @click="handleExternalLinkClick" v-html="briefHtml" />
       </div>
     </div>
 
@@ -282,6 +282,7 @@ import type { ManageSourceData, RebuildSummary, Source } from "../plugins/manage
 import { apiGet, apiPost, apiDelete } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { buildRouteUrl } from "../plugins/meta-types";
+import { handleExternalLinkClick } from "../utils/dom/externalLink";
 import { SOURCE_FILTER_KEYS, countByFilter, matchesSourceFilter, type SourceFilterKey } from "../utils/sources/filter";
 import FilterChip from "./FilterChip.vue";
 import PageChatComposer from "./PageChatComposer.vue";

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -129,8 +129,15 @@
             </div>
           </div>
           <!-- View mode -->
-          <!-- eslint-disable-next-line vue/no-v-html -- sanitized via DOMPurify -->
-          <div v-else-if="detail && renderedBody" class="markdown-content text-gray-700" data-testid="skill-body-rendered" v-html="renderedBody"></div>
+          <!-- eslint-disable vue/no-v-html -- sanitized via DOMPurify; multi-line element so disable/enable pair (CLAUDE.md UI rule) instead of -next-line -->
+          <div
+            v-else-if="detail && renderedBody"
+            class="markdown-content text-gray-700"
+            data-testid="skill-body-rendered"
+            @click="handleExternalLinkClick"
+            v-html="renderedBody"
+          ></div>
+          <!-- eslint-enable vue/no-v-html -->
           <p v-else-if="detail" class="text-sm text-gray-400 italic">{{ t("pluginManageSkills.emptyBody") }}</p>
         </div>
       </div>
@@ -147,6 +154,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
 import { apiGet, apiPut, apiDelete } from "../../utils/api";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { pluginEndpoints } from "../api";
 import { buildRouteUrl } from "../meta-types";
 import type { SkillsEndpoints } from "./definition";

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -87,6 +87,7 @@ import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImage
 import { findTaskLines, makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { apiGet, apiPut } from "../../utils/api";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { pluginEndpoints } from "../api";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 import { buildPdfFilename } from "../../utils/files/filename";
@@ -354,6 +355,11 @@ async function persistTaskMarkdown(relativePath: string, markdown: string): Prom
 }
 
 function onMarkdownClick(event: MouseEvent): void {
+  // External http(s) links: open in a new tab instead of letting the
+  // SPA navigate away. Same handler the wiki / textResponse renders
+  // use; without it, clicking an external link from a markdown file
+  // tore the user out of MulmoClaude (#1221).
+  if (handleExternalLinkClick(event)) return;
   const { target } = event;
   if (!(target instanceof HTMLInputElement)) return;
   if (target.type !== "checkbox") return;

--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -36,7 +36,7 @@
           <div class="border-t border-purple-200 p-4 bg-white rounded-b-lg">
             <div v-if="skillPath" class="text-[11px] font-mono text-gray-400 mb-3 break-all">{{ skillPath }}</div>
             <!-- eslint-disable-next-line vue/no-v-html -- DOMPurify-sanitized markdown of the SKILL.md body Claude CLI synthesised. The body comes from the user's local skill file, surfaced verbatim here. -->
-            <div class="markdown-content prose prose-slate max-w-none" v-html="renderedHtml"></div>
+            <div class="markdown-content prose prose-slate max-w-none" @click="handleExternalLinkClick" v-html="renderedHtml"></div>
           </div>
         </details>
       </div>
@@ -51,6 +51,7 @@ import { marked } from "marked";
 import DOMPurify from "dompurify";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SkillData } from "./types";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 
 const { t } = useI18n();
 

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -124,6 +124,7 @@ import {
 } from "./engine";
 import { applyCellHighlights, clearCellHighlights } from "./cellHighlights";
 import { getArrowKeyOffset, isWithinSheetBounds } from "./keyboardNav";
+import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { errorMessage as formatErrorMessage } from "../../utils/errors";
 
 // Import all spreadsheet functions to populate the function registry
@@ -529,6 +530,9 @@ function saveMiniEditor() {
 }
 
 function handleTableClick(event: MouseEvent) {
+  // External http(s) links inside cells (XLSX hyperlink fields) —
+  // open in a new tab instead of navigating the SPA away (#1221).
+  if (handleExternalLinkClick(event)) return;
   const target = event.target as HTMLElement;
 
   // Check if clicked element is a table cell


### PR DESCRIPTION
## Summary

PR-A of #1221. Fixes Issue 1 (\"external links don't open on normal click in rendered markdown / sheets\"). The cross-origin link guard \`src/utils/dom/externalLink.ts\` already existed and was wired into wiki / textResponse / StackView — but six other \`v-html\` surfaces missed it. Clicking an absolute http(s) link in those views tore the user out of the SPA to the target URL.

This PR adds the same one-line wire-up to all six. The handler itself is unchanged.

PR-B (\`[[amazon:asin]]\` / \`[[isbn:...]]\` / \`[[youtube:...]]\` rich-embed syntaxes) follows separately.

## Items to Confirm / Review

- **Why this much surface area?** \`grep -rln "v-html=" src/\` produced 9 hits. 3 already had the handler (wiki / textResponse / StackView), 6 didn't. All 6 are user-content renderers where external links are a normal authoring pattern (skill READMEs link to docs, news bodies link to source articles, source briefs link to upstream RSS, etc.). All 6 fixed in one PR for review-batching.
- **Spreadsheet sheet hyperlinks** — XLSX cells can carry hyperlinks. \`handleTableClick\` already existed for cell-selection; this PR prepends the external-link check. The cell-selection path still runs for non-link clicks.
- **\`manageSkills/View.vue\` eslint pair promotion** — the \`v-html\` element is now multi-line (added \`@click\` attribute), so the \`-next-line\` disable comment was promoted to a \`disable\`/\`enable\` pair per CLAUDE.md's UI-rule policy. No semantic change.
- **No new tests** — \`test/utils/dom/test_externalLink.ts\` already covers the handler exhaustively (non-anchor / modifier-key / non-http scheme / same-origin / button=2). The change here is wiring sites, not the helper.

## Items shipped

| File | Pattern |
|---|---|
| \`src/plugins/markdown/View.vue\` | \`onMarkdownClick\` early-return on \`handleExternalLinkClick(event)\` |
| \`src/plugins/skill/View.vue\` | \`@click="handleExternalLinkClick"\` on body container |
| \`src/plugins/spreadsheet/View.vue\` | \`handleTableClick\` early-return |
| \`src/plugins/manageSkills/View.vue\` | \`@click\` on body container + eslint pair promotion |
| \`src/components/NewsView.vue\` | \`@click\` on body container |
| \`src/components/SourcesManager.vue\` | \`@click\` on brief container |

## User Prompt

> 続けて
> はい

(Continuing through pending issues; PR-B-2 (Settings → Photos tab) is auto-merging on #1251. This is the next item: the externally-flagged "external links dead" bug from #1221.)

## Verification

- \`yarn format\` ✅
- \`yarn lint\` ✅
- \`yarn typecheck\` ✅
- \`yarn build\` ✅
- \`yarn test\` ✅

## Manual smoke

1. Open a markdown file in /files containing an external link (\`[OpenAI](https://openai.com)\`)
2. Click the link → opens in new tab (was: navigates SPA away)
3. Repeat in a skill SKILL.md, news article, source brief, manage-skills body — all open in new tab now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External link handling has been improved and standardized across the entire application. Links in news articles, skill documentation, markdown pages, spreadsheets, and other content views now behave consistently, opening properly without interrupting the user's navigation or workflow within the app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->