### PR TITLE
plan: incorporate 48h sweep findings (#1221)

### DIFF
--- a/plans/feat-rich-embed-syntax-1221.md
+++ b/plans/feat-rich-embed-syntax-1221.md
@@ -130,13 +130,15 @@ This converts the discriminator from a global syntactic rule (every `:` ⇒ embe
 1. Add a shared `src/utils/markdown/externalLinks.ts` helper:
    - `marked.use({ renderer: { link({href, title, text}) {...} } })` — when `href` is an absolute URL (`/^https?:\/\//.test(href)`), append `target="_blank" rel="noopener noreferrer"` to the emitted `<a>`.
    - Internal links (`/`, `#`, `[[wiki-link]]` post-processing) untouched.
-2. Iframe `sandbox` attribute (if any view wraps content in an iframe — verify via grep): add `allow-popups allow-popups-to-escape-sandbox`. Audit every `sandbox=` usage; we don't want to widen capability set without intent.
-3. Unit test for the renderer override: external URL → `target="_blank"` injected; relative URL → unchanged.
+2. Unit test for the renderer override: external URL → `target="_blank"` injected; relative URL → unchanged.
+
+**No iframe sandbox tweak required** (revised after the 48h sweep). The wiki / files / chat-artifact markdown does NOT render inside an iframe — it goes straight through `marked.parse` → `DOMPurify` → SPA DOM, so a renderer override is enough. The only iframe in scope is `/artifacts/html/...` (the `presentHtml` preview, see #1228), and it deliberately uses `sandbox="allow-scripts"` (no `allow-same-origin`) so LLM-generated HTML can't read the parent's bearer token. Loosening that is a regression — leave it alone.
 
 **Out of scope** for PR-A:
 
 - New embed syntax — that's PR-B.
 - Restyling links — only their open-target changes.
+- Iframe sandbox capability changes (see note above).
 
 **Acceptance**:
 
@@ -205,7 +207,11 @@ Each future type is one self-contained PR adding `src/utils/markdown/embed/rende
 1. `youtube` — embed iframe (default thumbnail-link, opt-in to full embed via `?style=embed` since the iframe itself is heavy)
 2. `github` — repo card + issue/PR link (kind detected from id shape: `owner/repo`, `owner/repo/issues/N`, `owner/repo/pull/N`)
 3. `x` (Twitter) — tweet embed via oEmbed API
-4. `map` — geo pin (lat,lng + zoom). Composes with the existing google-map plugin (#1227).
+4. `map` — geo pin (lat,lng + zoom). Renderer is a thin shim that emits a `showLocation` invocation against the upstream `@gui-chat-plugin/google-map@0.4.0` plugin runtime API (integrated in #1241), NOT a custom `<google-map>` component. The `region` reserved param doesn't apply; `zoom` does.
+
+### Future candidate types (not on the critical path)
+
+- `photo:<id>` — embed a thumbnail + map link from `data/photo-locations/<id>` after #1222 / #1247 / #1250 / #1251 land. Needs a stable id surface (filename or stable hash) on the photo metadata first; flagging here so we remember to design the id shape with this in mind when photo metadata stabilises.
 
 ## Out of scope (the whole issue)
 
@@ -217,7 +223,9 @@ Each future type is one self-contained PR adding `src/utils/markdown/embed/rende
 
 - #1210 — preset skills infrastructure (mc-library is the first heavy user; will switch to `[[amazon:...]]` once PR-B lands)
 - #1169 — home-application plugin & role plan (most planned skills will produce content with external references)
-- #1227 — map plugin (PR-C `map:` renderer can compose with this)
+- #1227 / #1241 — map plugin via `@gui-chat-plugin/google-map` (PR-C `map:` renderer composes with this)
+- #1228 — `presentHtml` iframe sandbox + auto-height; explains why PR-A does NOT touch iframe sandbox
+- #1222 / #1247 / #1250 / #1251 — photo-EXIF + `managePhotoLocations` + Photos settings tab (sets up the eventual `[[photo:<id>]]` candidate)
 
 ## Tracking
 


### PR DESCRIPTION
## Summary

Follow-up to #1248 (already merged). Reviewed the last 48h of merged PRs and three of them reshape assumptions baked into `plans/feat-rich-embed-syntax-1221.md`:

- **#1228** — `presentHtml` iframe got auto-height + Plotly CSP work. The wider lesson: wiki / files / chat-artifact markdown does NOT render in an iframe, it goes straight through `marked.parse` → `DOMPurify` → SPA DOM. PR-A's iframe-sandbox bullet is dropped; a `marked` link renderer override is sufficient for `target="_blank"`. The only iframe in scope is `/artifacts/html/...` and its `sandbox="allow-scripts"` (no `allow-same-origin`) is deliberate for security; do not loosen.
- **#1241** — map plugin pivoted to integrating `@gui-chat-plugin/google-map@0.4.0`. PR-C `[[map:lat,lng]]` is now a thin shim emitting `showLocation` against that runtime API, not a custom component.
- **#1222 / #1247 / #1250 / #1251** — photo-EXIF + `managePhotoLocations` + Photos settings tab. Added a "Future candidate types" subsection flagging `[[photo:<id>]]` as a post-PR-D possibility once photo metadata has a stable id surface.

## Items to Confirm / Review

- **PR-A reframing**: dropping the iframe-sandbox bullet entirely. The user-visible behaviour is identical (external links open in a new tab); the simplification is internal. If a future surface DOES start using an iframe for markdown, that would be a separate concern.
- **`map:` renderer scope**: confirm the upstream `@gui-chat-plugin/google-map` `showLocation` API is rich enough for the `[[map:lat,lng?zoom=12]]` use case. Spot-checked the package: it accepts `{ latitude, longitude, zoom }` per call, so the answer should be yes — but a deeper read might be wanted before PR-C work starts.
- **`photo:` candidate gating**: deliberately not on the critical path. Listed in "Future candidate types" so the photo-locations team can design the id shape (filename vs stable hash) with future embed-rendering in mind.
- **Cross-reference list**: updated `## Related` to add #1241 / #1228 / #1222 / #1247 / #1250 / #1251.

## User Prompt

```
issue/PRを48時間分確認してissueを更新して
```

## Test plan

- [ ] Plan-only change; no code touched. CI runs the markdown / formatting pipeline only.
- [ ] Issue #1221 also got a parallel comment summarising these findings: https://github.com/receptron/mulmoclaude/issues/1221#issuecomment-4412452876

🤖 Generated with [Claude Code](https://claude.com/claude-code)