### PR TITLE
feat(line): forward inbound photos to the agent (#1222 PR-C)

### DIFF
--- a/packages/bridges/line/README.md
+++ b/packages/bridges/line/README.md
@@ -66,6 +66,7 @@ Scan the QR code in the LINE Developers Console → Messaging API tab. Send a me
 
 - LINE reply tokens expire in **1 minute**. Since Claude responses can take longer, the bridge uses **push messages** instead of reply messages. This requires your bot to be a verified/certified account for push to work with all users, OR the user must have added the bot as a friend first.
 - LINE limits messages to 5 per push call and ~5000 chars per message. Long replies are automatically chunked.
+- **Inbound media** — text and image messages are forwarded to the agent. Image bytes are downloaded via the LINE Data API (`/v2/bot/message/<id>/content`) using the same channel access token; the actual format (JPEG / PNG / HEIC depending on sender) is preserved via the response Content-Type. The photo-EXIF auto-capture flow ([#1222](https://github.com/receptron/mulmoclaude/issues/1222)) writes a sidecar at `data/locations/...` when GPS data is present. Video / audio / file / sticker messages are not forwarded yet.
 
 ## Detailed Setup Guide
 

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -41,6 +41,33 @@ client.onPush((pushEvent) => {
 
 // ── LINE API helpers ────────────────────────────────────────────
 
+/** Download an image attached to an inbound LINE message. Returns
+ *  the bytes + Content-Type so the caller can build an Attachment
+ *  envelope for the chat-service socket. Returns null when the
+ *  fetch fails (network error, 4xx, …) — caller logs and skips. */
+async function downloadLineImage(messageId: string): Promise<{ bytes: Buffer; mimeType: string } | null> {
+  try {
+    const res = await fetch(`https://api-data.line.me/v2/bot/message/${encodeURIComponent(messageId)}/content`, {
+      headers: { Authorization: `Bearer ${channelAccessToken}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) {
+      console.error(`[line] downloadLineImage failed: ${res.status}`);
+      return null;
+    }
+    // LINE returns image/jpeg by default but the Data API also
+    // serves the original sender format (PNG, GIF, …). Trust the
+    // Content-Type header so the photo-EXIF hook (#1222 PR-A) can
+    // tell HEIC apart from JPEG and surface the right sidecar.
+    const mimeType = res.headers.get("content-type")?.split(";")[0].trim() || "image/jpeg";
+    const arrayBuffer = await res.arrayBuffer();
+    return { bytes: Buffer.from(arrayBuffer), mimeType };
+  } catch (err) {
+    console.error(`[line] downloadLineImage network error: ${err}`);
+    return null;
+  }
+}
+
 async function pushMessage(userId: string, text: string): Promise<void> {
   const messages = chunkText(text, 5000).map((messageText) => ({
     type: "text",
@@ -106,13 +133,28 @@ app.post("/webhook", async (req: Request, res: Response) => {
   for (const event of body.events) {
     const incoming = extractIncomingLineMessage(event);
     if (!incoming) continue;
-    const { userId, text } = incoming;
-
-    console.log(`[line] message user=${userId} len=${text.length}`);
 
     try {
-      const ack = await client.send(userId, text);
-      await pushMessage(userId, formatAckReply(ack));
+      if (incoming.kind === "text") {
+        console.log(`[line] message user=${incoming.userId} len=${incoming.text.length}`);
+        const ack = await client.send(incoming.userId, incoming.text);
+        await pushMessage(incoming.userId, formatAckReply(ack));
+        continue;
+      }
+      // kind === "image"
+      console.log(`[line] image user=${incoming.userId} messageId=${incoming.imageMessageId}`);
+      const image = await downloadLineImage(incoming.imageMessageId);
+      if (!image) {
+        await pushMessage(incoming.userId, "Sorry, I couldn't fetch that image.");
+        continue;
+      }
+      // Send the image with an empty body — the agent sees the
+      // attachment in chat context and answers about it. The
+      // post-save EXIF hook (#1222 PR-A) writes a sidecar at
+      // `data/locations/...` if GPS data is present.
+      const attachments = [{ mimeType: image.mimeType, data: image.bytes.toString("base64") }];
+      const ack = await client.send(incoming.userId, "", attachments);
+      await pushMessage(incoming.userId, formatAckReply(ack));
     } catch (err) {
       console.error(`[line] message handling failed: ${err}`);
     }

--- a/packages/bridges/line/src/parse.ts
+++ b/packages/bridges/line/src/parse.ts
@@ -1,33 +1,55 @@
 // Pure parsing helpers for the LINE bridge webhook.
 
+export interface LineMessage {
+  type: string;
+  text?: string;
+  /** LINE content id — present on media types (image / video / audio
+   *  / file). The actual bytes live behind a separate Data API call
+   *  (`/v2/bot/message/<id>/content`); the webhook only carries the
+   *  reference. */
+  id?: string;
+}
+
 export interface LineEvent {
   type: string;
   replyToken?: string;
   source?: { userId?: string; type?: string };
-  message?: { type: string; text?: string };
+  message?: LineMessage;
 }
 
 export interface LineWebhookBody {
   events: LineEvent[];
 }
 
-export interface IncomingLineMessage {
-  userId: string;
-  text: string;
-}
+/** Discriminated union — the webhook may surface text or media.
+ *  Callers branch on `kind` and either send text straight to chat
+ *  or download the media bytes via the LINE Data API.
+ *
+ *  PR-C of #1222: image is the only media kind we forward today.
+ *  Video / audio / file extend this union if/when they become
+ *  worth fanning out to the agent. */
+export type IncomingLineMessage = { kind: "text"; userId: string; text: string } | { kind: "image"; userId: string; imageMessageId: string };
 
 /**
- * Reduce a LINE webhook event to the actionable userId / text pair.
- * Returns null for non-text events, missing fields, or whitespace-only
- * text. Pure — no side effects, no allowlist check.
+ * Reduce a LINE webhook event to the actionable shape. Returns null
+ * for non-actionable events (non-message types, missing fields,
+ * unsupported media). Pure — no side effects, no allowlist check.
  */
 export function extractIncomingLineMessage(event: LineEvent): IncomingLineMessage | null {
   if (event.type !== "message") return null;
-  if (event.message?.type !== "text") return null;
   const userId = event.source?.userId;
-  const text = event.message.text ?? "";
-  if (!userId || !text.trim()) return null;
-  return { userId, text };
+  if (!userId) return null;
+  const { message } = event;
+  if (!message) return null;
+  if (message.type === "text") {
+    const text = message.text ?? "";
+    if (!text.trim()) return null;
+    return { kind: "text", userId, text };
+  }
+  if (message.type === "image" && typeof message.id === "string" && message.id.length > 0) {
+    return { kind: "image", userId, imageMessageId: message.id };
+  }
+  return null;
 }
 
 /** Best-effort JSON parse for the webhook body — null on malformed input. */

--- a/packages/bridges/line/test/test_parse.ts
+++ b/packages/bridges/line/test/test_parse.ts
@@ -11,9 +11,18 @@ function textEvent(overrides: Partial<LineEvent> = {}): LineEvent {
   };
 }
 
-describe("extractIncomingLineMessage", () => {
-  it("returns userId + text for a normal text message", () => {
-    assert.deepEqual(extractIncomingLineMessage(textEvent()), { userId: "U1234", text: "hello" });
+function imageEvent(overrides: Partial<LineEvent> = {}): LineEvent {
+  return {
+    type: "message",
+    message: { type: "image", id: "msg-img-9999" },
+    source: { userId: "U1234" },
+    ...overrides,
+  };
+}
+
+describe("extractIncomingLineMessage — text branch", () => {
+  it("returns kind:text + userId + text for a normal text message", () => {
+    assert.deepEqual(extractIncomingLineMessage(textEvent()), { kind: "text", userId: "U1234", text: "hello" });
   });
 
   it("returns null for non-message event types", () => {
@@ -22,9 +31,9 @@ describe("extractIncomingLineMessage", () => {
     assert.equal(extractIncomingLineMessage(textEvent({ type: "postback" })), null);
   });
 
-  it("returns null when message type is not 'text'", () => {
-    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "image" } })), null);
+  it("returns null when message type is unsupported (sticker / video)", () => {
     assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "sticker" } })), null);
+    assert.equal(extractIncomingLineMessage(textEvent({ message: { type: "video", id: "v1" } })), null);
   });
 
   it("returns null when message is missing entirely", () => {
@@ -44,7 +53,32 @@ describe("extractIncomingLineMessage", () => {
 
   it("preserves text without trimming (sender's whitespace inside is intentional)", () => {
     const result = extractIncomingLineMessage(textEvent({ message: { type: "text", text: "  hello  world  " } }));
-    assert.equal(result?.text, "  hello  world  ");
+    assert.equal(result?.kind, "text");
+    if (result?.kind === "text") {
+      assert.equal(result.text, "  hello  world  ");
+    }
+  });
+});
+
+describe("extractIncomingLineMessage — image branch (#1222 PR-C)", () => {
+  it("returns kind:image + userId + imageMessageId for an image event", () => {
+    assert.deepEqual(extractIncomingLineMessage(imageEvent()), { kind: "image", userId: "U1234", imageMessageId: "msg-img-9999" });
+  });
+
+  it("returns null when image message id is missing", () => {
+    assert.equal(extractIncomingLineMessage(imageEvent({ message: { type: "image" } })), null);
+  });
+
+  it("returns null when image message id is empty", () => {
+    assert.equal(extractIncomingLineMessage(imageEvent({ message: { type: "image", id: "" } })), null);
+  });
+
+  it("returns null when image message id is non-string (defensive)", () => {
+    assert.equal(extractIncomingLineMessage(imageEvent({ message: { type: "image", id: 42 as unknown as string } })), null);
+  });
+
+  it("still requires source.userId for images", () => {
+    assert.equal(extractIncomingLineMessage(imageEvent({ source: undefined })), null);
   });
 });
 


### PR DESCRIPTION
## Summary

PR-C of the photo-EXIF plan. Telegram and Slack already forwarded images to the agent (their parse layers split photos out); LINE was text-only. After this lands, sending a geotagged photo over LINE Messaging follows the same path as a chat-paste upload — the post-save EXIF hook (PR-A, [#1247](https://github.com/receptron/mulmoclaude/pull/1247)) writes the sidecar, the \`managePhotoLocations\` plugin (PR-B, [#1250](https://github.com/receptron/mulmoclaude/pull/1250)) surfaces it, and \`mapControl\` plots it.

## Items to Confirm / Review

1. **Discriminated union return** — \`IncomingLineMessage\` was \`{userId, text}\`; it's now \`{kind: "text", userId, text}\` | \`{kind: "image", userId, imageMessageId}\`. All call sites updated in \`index.ts\`. Existing parse tests rewritten for the new shape (still asserting the same edge cases).
2. **MIME via response header** — LINE Data API returns the original sender's image format (JPEG default, PNG / HEIC for some clients). Trusting \`Content-Type\` over hardcoded \`image/jpeg\` matters because (a) HEIC sidecars now get the \`.heic\` extension instead of \`.bin\` (#1249) and (b) the EXIF reader's MIME allowlist needs the right tag.
3. **Empty body on image send** — \`client.send(userId, "", attachments)\`: empty text means "the user uploaded a photo with no caption". The agent sees only the attachment in chat context and answers about it. Telegram does the same when an image arrives without caption.
4. **Out of scope**: video / audio / file / sticker forwarding (no demand yet); reverse-direction image push (the bridge already only pushes text via \`pushMessage\`).

## Items shipped

| File | Change |
|---|---|
| \`src/parse.ts\` | \`IncomingLineMessage\` → discriminated union; \`extractIncomingLineMessage\` handles \`message.type === "image"\`. \`LineEvent.message\` extended with optional \`id\`. |
| \`src/index.ts\` | New \`downloadLineImage\` helper. Webhook handler dispatches on \`incoming.kind\`. |
| \`test/test_parse.ts\` | Existing 12 cases updated for union shape + 5 new image-branch cases. |
| \`README.md\` | Notes section documents inbound media support. |

## User Prompt

> 続けて
> はい
> すすむ

(Continuing the photo-EXIF plan: PR-A → PR-B → PR-B-2 (Settings) → PR-C (LINE bridge, this one) closes the plan.)

## Verification

- \`yarn format\` ✅
- \`yarn lint\` ✅
- \`yarn typecheck\` ✅
- \`yarn build\` ✅
- \`yarn test\` ✅ (18 LINE bridge tests pass — 12 existing + 5 new + 1 minor reshuffle)

## Manual smoke (requires a LINE bot setup — see packages/bridges/line/README.md)

1. Start the LINE bridge (\`yarn workspace @mulmobridge/line dev\`) and a tunneled MulmoClaude
2. Add the bot as a LINE friend, send a geotagged iPhone HEIC photo
3. Wait for the bot's reply (Claude answering about the photo)
4. Check \`~/mulmoclaude/data/attachments/2026/05/<id>.heic\` and \`~/mulmoclaude/data/locations/2026/05/<id>.json\` — both should exist
5. Open MulmoClaude UI → switch to General role → ask "show me the location of my latest photo on the map" → \`mapControl\` plots it

## Refs

- Predecessors: #1247 (post-save EXIF hook), #1249 (HEIC fix), #1250 (managePhotoLocations plugin), #1251 (Settings opt-out)
- Issue: #1222
- Plan: \`plans/feat-photo-exif.md\` (PR-C section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)