### PR TITLE
feat(markdown): wiki-syntax embed registry + amazon/isbn handlers (#1221 PR-B)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { API_ROUTES } from "./config/apiRoutes";
 import { BUILTIN_ROLE_IDS } from "./config/roles";
 import { PAGE_ROUTES } from "./router";
 import { getAllPluginNames } from "./tools";
+import { setupMarked } from "./utils/markdown/setup";
 import "./index.css";
 import "material-icons/iconfont/material-icons.css";
 import "material-symbols/outlined.css";
@@ -105,6 +106,11 @@ loadRuntimePlugins().catch((err: unknown) => {
 // changes, this listener reloads the page. No-ops in production
 // because the server only publishes when a dev plugin is loaded.
 startDevPluginReloadListener();
+
+// Configure the shared `marked` instance — installs the wiki-embed
+// extension + built-in `[[amazon:...]]` / `[[isbn:...]]` handlers
+// before any view renders markdown. (#1221 PR-B)
+setupMarked();
 
 installGuards(router);
 

--- a/src/utils/markdown/setup.ts
+++ b/src/utils/markdown/setup.ts
@@ -1,0 +1,24 @@
+// One-time marked configuration for the SPA. Call `setupMarked()`
+// from `src/main.ts` before the Vue app mounts so every component
+// that imports `{ marked }` afterwards inherits the configured
+// global instance.
+//
+// Today this just installs the wiki-embed extension + the
+// built-in `amazon` / `isbn` handlers (#1221 PR-B). Future global
+// marked extensions belong here too — keep all the side-effects
+// in one greppable spot.
+
+import { marked } from "marked";
+import { wikiEmbedExtension } from "./wikiEmbeds";
+import { registerBuiltInWikiEmbeds } from "./wikiEmbedHandlers";
+
+let installed = false;
+
+export function setupMarked(): void {
+  // Idempotent: tests reach for `setupMarked()` before each
+  // assertion suite without paying for re-installation.
+  if (installed) return;
+  registerBuiltInWikiEmbeds();
+  marked.use(wikiEmbedExtension);
+  installed = true;
+}

--- a/src/utils/markdown/wikiEmbedHandlers.ts
+++ b/src/utils/markdown/wikiEmbedHandlers.ts
@@ -1,0 +1,80 @@
+// Built-in prefix handlers for the wiki-embed registry (#1221 PR-B).
+//
+// Two prefixes ship today — `amazon` and `isbn` — chosen because
+// they tie directly to the `mc-library` preset skill (#1210),
+// which already captures ASIN / ISBN as it summarises books and
+// products. After this PR, the skill can write
+// `[[amazon:B00ICN066A]]` instead of a raw URL and get a clickable
+// link in the rendered wiki / chat.
+//
+// Future prefixes (youtube / x / map / github / …) plug into the
+// same registry — see plans/feat-rich-embed-syntax-1221.md PR-C+.
+
+import { escapeHtml, registerWikiEmbed } from "./wikiEmbeds";
+
+/** Amazon ASIN format — letters + digits, 10 chars. The pattern
+ *  guards against `[[amazon:javascript:alert(1)]]` style attacks
+ *  by rejecting non-alphanumeric ids before composing the URL. */
+const ASIN_PATTERN = /^[A-Z0-9]{10}$/i;
+
+/** ISBN-10 / ISBN-13 — digits + optional `X` checksum on ISBN-10.
+ *  Non-digit / dash chars (other than the trailing X) reject. */
+const ISBN_PATTERN = /^\d{9}[\dX]$|^\d{13}$/i;
+
+/** Strip ISBN dashes the user might paste verbatim
+ *  (`978-0-06-231609-7` → `9780062316097`). */
+function normaliseIsbn(raw: string): string {
+  return raw.replace(/[-\s]/g, "");
+}
+
+/** Build an `<a>` opening tag with the safe / extern attribute
+ *  set. Centralised so every handler renders the same shape. */
+function externalLink(href: string, label: string, title?: string): string {
+  const escapedHref = escapeHtml(href);
+  const escapedLabel = escapeHtml(label);
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return `<a href="${escapedHref}" target="_blank" rel="noopener noreferrer" class="wiki-embed wiki-embed-external"${titleAttr}>${escapedLabel}</a>`;
+}
+
+/** Bracket-render a verbatim `[[prefix:id]]` for the rare invalid-
+ *  id case so the user sees what they typed (and can fix it)
+ *  rather than nothing. */
+function verbatim(prefix: string, embedId: string): string {
+  const escapedSource = escapeHtml(`[[${prefix}:${embedId}]]`);
+  const escapedTitle = escapeHtml(`Invalid ${prefix} id`);
+  return `<span class="wiki-embed wiki-embed-invalid" title="${escapedTitle}">${escapedSource}</span>`;
+}
+
+export function registerAmazonEmbed(): void {
+  registerWikiEmbed({
+    prefix: "amazon",
+    render: (embedId: string): string => {
+      if (!ASIN_PATTERN.test(embedId)) return verbatim("amazon", embedId);
+      // .com is the safe default — Amazon redirects to the user's
+      // locale automatically when they're signed in. Locale-aware
+      // routing (.co.jp etc.) is a follow-up.
+      return externalLink(`https://www.amazon.com/dp/${embedId}`, `📦 ${embedId}`, `Amazon product ${embedId}`);
+    },
+  });
+}
+
+export function registerIsbnEmbed(): void {
+  registerWikiEmbed({
+    prefix: "isbn",
+    render: (embedId: string): string => {
+      const isbn = normaliseIsbn(embedId);
+      if (!ISBN_PATTERN.test(isbn)) return verbatim("isbn", embedId);
+      // OpenLibrary's `/isbn/<isbn>` URL resolves to the canonical
+      // edition page and falls back to a search if the edition
+      // isn't catalogued. No API key required.
+      return externalLink(`https://openlibrary.org/isbn/${isbn}`, `📖 ISBN ${isbn}`, `OpenLibrary entry for ISBN ${isbn}`);
+    },
+  });
+}
+
+/** Convenience entry point — registers every built-in handler.
+ *  Called once at app boot from `src/main.ts`. Idempotent. */
+export function registerBuiltInWikiEmbeds(): void {
+  registerAmazonEmbed();
+  registerIsbnEmbed();
+}

--- a/src/utils/markdown/wikiEmbeds.ts
+++ b/src/utils/markdown/wikiEmbeds.ts
@@ -1,0 +1,141 @@
+// Wiki-syntax embed registry + marked extension (#1221 PR-B).
+//
+// Recognises `[[<prefix>:<id>]]` inside markdown bodies and
+// substitutes a prefix-specific `<a>` (or richer HTML in the
+// future). The user-facing motivation is `mc-library` and similar
+// preset skills writing `[[amazon:B00ICN066A]]` instead of raw
+// Amazon URLs — the file stays small and renders as a clickable
+// link.
+//
+// Design — marked extension over a regex post-processor:
+//   - `[[...]]` inside fenced / inline code blocks is left alone
+//     because the marked tokenizer never reaches `code` content;
+//     a regex on the rendered HTML would have to skip
+//     `<pre><code>` blocks itself.
+//   - Future prefixes (youtube / x / map / github / …) plug in via
+//     a tiny `WikiEmbedHandler` registration — no marked-API
+//     repetition.
+//
+// `marked.use(wikiEmbedExtension)` is called once at app boot
+// (`src/main.ts`); every consumer of `marked()` / `marked.parse()`
+// inherits the substitution automatically.
+
+import type { MarkedExtension, Tokens } from "marked";
+
+/** A handler renders one prefix's substitution HTML. Pure: no I/O,
+ *  no fetches. The result is dropped straight into the rendered
+ *  document, so it MUST be HTML-safe (escape user-controlled
+ *  segments). Helpers like `escapeHtml` below cover the common
+ *  case. */
+export interface WikiEmbedHandler {
+  /** Lower-case prefix without the trailing colon (`"amazon"`,
+   *  `"isbn"`, …). The tokenizer matches case-insensitively but
+   *  registrations are normalised to lowercase. */
+  prefix: string;
+  /** Render the substituted HTML for `[[prefix:id]]`. The id is
+   *  trimmed but not URL-encoded — the handler decides how to
+   *  escape it for its target. */
+  render: (embedId: string) => string;
+}
+
+const handlers = new Map<string, WikiEmbedHandler>();
+
+/** Register a prefix handler. Idempotent: re-registering the same
+ *  prefix overwrites the previous handler — useful for tests, no
+ *  warning needed. */
+export function registerWikiEmbed(handler: WikiEmbedHandler): void {
+  handlers.set(handler.prefix.toLowerCase(), handler);
+}
+
+/** Test seam — drops every registered handler. Production code
+ *  registers once at module load and never resets. */
+export function _resetWikiEmbeds(): void {
+  handlers.clear();
+}
+
+/** Read-only snapshot for tests / dev panels. Production code
+ *  doesn't need to enumerate handlers. */
+export function listWikiEmbedPrefixes(): string[] {
+  return [...handlers.keys()].sort();
+}
+
+/** HTML-escape attribute / text content. Don't reach for
+ *  DOMPurify here — the handlers run inside `marked.parse`'s tree
+ *  at render time, before any sanitisation step the consumer
+ *  applies; a single-purpose escaper keeps the bundle small. */
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+/** Pattern that matches one wiki-embed token. The id portion is
+ *  intentionally permissive (anything that isn't `]`) so handlers
+ *  can carry slashes (`github:owner/repo/issues/N`) or commas
+ *  (`map:35.6,139.7`). The leading char must NOT be `]` or
+ *  whitespace so `[[]]` and `[[ : x]]` don't accidentally match.
+ *
+ *  Anchored to `^` because marked's tokenizer always sees `src`
+ *  starting at the position the inline lexer is scanning. */
+const TOKEN_PATTERN = /^\[\[([a-z][a-z0-9-]*):([^\]\s][^\]]*)\]\]/i;
+
+interface WikiEmbedToken extends Tokens.Generic {
+  type: "wikiEmbed";
+  raw: string;
+  /** Already lowercased. */
+  prefix: string;
+  /** Trimmed but otherwise-verbatim id from the source. */
+  id: string;
+}
+
+/** marked extension that owns the `[[prefix:id]]` token. Renders
+ *  via the handler registry; falls back to the verbatim raw text
+ *  when no handler is registered (so an unknown prefix doesn't
+ *  vanish — the user sees the literal markup and can register a
+ *  handler or fix the typo). */
+export const wikiEmbedExtension: MarkedExtension = {
+  extensions: [
+    {
+      name: "wikiEmbed",
+      level: "inline",
+      start(src: string): number | undefined {
+        const idx = src.indexOf("[[");
+        return idx === -1 ? undefined : idx;
+      },
+      tokenizer(src: string): WikiEmbedToken | undefined {
+        const match = TOKEN_PATTERN.exec(src);
+        if (!match) return undefined;
+        const prefix = match[1].toLowerCase();
+        const embedId = match[2].trim();
+        if (embedId.length === 0) return undefined;
+        if (!handlers.has(prefix)) return undefined;
+        return {
+          type: "wikiEmbed",
+          raw: match[0],
+          prefix,
+          id: embedId,
+        };
+      },
+      renderer(token): string {
+        const node = token as WikiEmbedToken;
+        const handler = handlers.get(node.prefix);
+        // Guarded by the tokenizer (only handlers we know about
+        // produce a token), but defensive — a handler unregistered
+        // mid-render shouldn't crash the parser.
+        if (!handler) return escapeHtml(node.raw);
+        return handler.render(node.id);
+      },
+    },
+  ],
+};

--- a/test/utils/markdown/test_wikiEmbeds.ts
+++ b/test/utils/markdown/test_wikiEmbeds.ts
@@ -1,0 +1,184 @@
+// Unit tests for the wiki-embed registry + marked extension
+// (#1221 PR-B).
+//
+// Drives the actual marked instance after setup so the test
+// covers the integration: register handlers, install extension,
+// run marked, assert the rendered HTML.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { marked } from "marked";
+
+import { _resetWikiEmbeds, escapeHtml, listWikiEmbedPrefixes, registerWikiEmbed, wikiEmbedExtension } from "../../../src/utils/markdown/wikiEmbeds";
+import { registerAmazonEmbed, registerIsbnEmbed, registerBuiltInWikiEmbeds } from "../../../src/utils/markdown/wikiEmbedHandlers";
+
+// `marked.use()` mutates the global instance — install once per
+// suite. Tests that need a fresh handler set call
+// `_resetWikiEmbeds()` and re-register.
+marked.use(wikiEmbedExtension);
+
+beforeEach(() => {
+  _resetWikiEmbeds();
+});
+
+describe("escapeHtml", () => {
+  it("escapes the five HTML-meaningful characters", () => {
+    assert.equal(escapeHtml(`& < > " '`), "&amp; &lt; &gt; &quot; &#39;");
+  });
+
+  it("leaves benign characters untouched", () => {
+    assert.equal(escapeHtml("hello, world!"), "hello, world!");
+  });
+});
+
+describe("registerWikiEmbed", () => {
+  it("re-registering the same prefix overwrites the handler", () => {
+    registerWikiEmbed({ prefix: "demo", render: () => "v1" });
+    registerWikiEmbed({ prefix: "demo", render: () => "v2" });
+    assert.deepEqual(listWikiEmbedPrefixes(), ["demo"]);
+  });
+
+  it("normalises prefix to lowercase", () => {
+    registerWikiEmbed({ prefix: "DEMO", render: () => "x" });
+    assert.deepEqual(listWikiEmbedPrefixes(), ["demo"]);
+  });
+});
+
+describe("marked extension — token recognition", () => {
+  beforeEach(() => {
+    registerWikiEmbed({ prefix: "x", render: (embedId) => `<span class="x">${escapeHtml(embedId)}</span>` });
+  });
+
+  it("substitutes a single embed", () => {
+    const html = (marked.parse("hello [[x:abc]] world") as string).trim();
+    assert.match(html, /<span class="x">abc<\/span>/);
+  });
+
+  it("matches case-insensitively on the prefix", () => {
+    const html = (marked.parse("[[X:abc]]") as string).trim();
+    assert.match(html, /<span class="x">abc<\/span>/);
+  });
+
+  it("ignores prefixes with no registered handler — leaves the raw text", () => {
+    const html = (marked.parse("[[unknown:abc]]") as string).trim();
+    // marked encodes the raw `[[ ]]` as plain text inside <p>.
+    assert.match(html, /\[\[unknown:abc\]\]/);
+  });
+
+  it("does NOT substitute inside fenced code blocks", () => {
+    const html = (marked.parse("```\n[[x:abc]]\n```") as string).trim();
+    assert.match(html, /<code>\[\[x:abc\]\]/);
+    assert.doesNotMatch(html, /<span class="x">/);
+  });
+
+  it("does NOT substitute inside inline code", () => {
+    const html = (marked.parse("see `[[x:abc]]` for details") as string).trim();
+    assert.doesNotMatch(html, /<span class="x">/);
+  });
+
+  it("supports multiple embeds in one paragraph", () => {
+    const html = (marked.parse("a [[x:one]] b [[x:two]] c") as string).trim();
+    assert.match(html, /<span class="x">one<\/span>/);
+    assert.match(html, /<span class="x">two<\/span>/);
+  });
+
+  it("rejects empty id (`[[x:]]`)", () => {
+    const html = (marked.parse("[[x:]]") as string).trim();
+    assert.doesNotMatch(html, /<span class="x">/);
+    assert.match(html, /\[\[x:\]\]/);
+  });
+
+  it("rejects whitespace-only id (`[[x: ]]`)", () => {
+    const html = (marked.parse("[[x:   ]]") as string).trim();
+    assert.doesNotMatch(html, /<span class="x">/);
+  });
+
+  it("preserves ids with slashes (path-style — github:owner/repo)", () => {
+    registerWikiEmbed({
+      prefix: "gh",
+      render: (embedId) => {
+        const escaped = escapeHtml(embedId);
+        return `<a href="${escaped}">${escaped}</a>`;
+      },
+    });
+    const html = (marked.parse("[[gh:owner/repo/issues/42]]") as string).trim();
+    assert.match(html, /owner\/repo\/issues\/42/);
+  });
+
+  it("preserves ids with commas (coords — map:35.6,139.7)", () => {
+    registerWikiEmbed({
+      prefix: "map",
+      render: (embedId) => `<span class="map">${escapeHtml(embedId)}</span>`,
+    });
+    const html = (marked.parse("[[map:35.6,139.7]]") as string).trim();
+    assert.match(html, /<span class="map">35\.6,139\.7<\/span>/);
+  });
+});
+
+describe("Amazon embed handler", () => {
+  beforeEach(() => {
+    registerAmazonEmbed();
+  });
+
+  it("renders a link to amazon.com/dp/<asin> for a valid ASIN", () => {
+    const html = (marked.parse("see [[amazon:B00ICN066A]]") as string).trim();
+    assert.match(html, /href="https:\/\/www\.amazon\.com\/dp\/B00ICN066A"/);
+    assert.match(html, /target="_blank"/);
+    assert.match(html, /rel="noopener noreferrer"/);
+    assert.match(html, /📦 B00ICN066A/);
+  });
+
+  it("falls through to verbatim for an invalid ASIN", () => {
+    const html = (marked.parse("[[amazon:not-an-asin]]") as string).trim();
+    assert.match(html, /\[\[amazon:not-an-asin\]\]/);
+    assert.doesNotMatch(html, /amazon\.com\/dp/);
+  });
+
+  it("rejects an ASIN-shaped id with HTML metacharacters (no XSS leak)", () => {
+    // 10 chars (passing length) but not all alphanumeric — must
+    // fail the pattern, not get URL-injected.
+    const html = (marked.parse("[[amazon:<script>x]]") as string).trim();
+    assert.doesNotMatch(html, /<script/);
+  });
+});
+
+describe("ISBN embed handler", () => {
+  beforeEach(() => {
+    registerIsbnEmbed();
+  });
+
+  it("renders a link to OpenLibrary for ISBN-13", () => {
+    const html = (marked.parse("[[isbn:9780062316097]]") as string).trim();
+    assert.match(html, /href="https:\/\/openlibrary\.org\/isbn\/9780062316097"/);
+    assert.match(html, /📖 ISBN 9780062316097/);
+  });
+
+  it("renders a link for ISBN-10 with the X checksum", () => {
+    const html = (marked.parse("[[isbn:020161622X]]") as string).trim();
+    assert.match(html, /href="https:\/\/openlibrary\.org\/isbn\/020161622X"/);
+  });
+
+  it("normalises hyphenated ISBNs before the pattern check", () => {
+    const html = (marked.parse("[[isbn:978-0-06-231609-7]]") as string).trim();
+    assert.match(html, /openlibrary\.org\/isbn\/9780062316097/);
+  });
+
+  it("falls through to verbatim for an invalid ISBN", () => {
+    const html = (marked.parse("[[isbn:not-a-real-isbn]]") as string).trim();
+    assert.match(html, /\[\[isbn:not-a-real-isbn\]\]/);
+    assert.doesNotMatch(html, /openlibrary\.org/);
+  });
+});
+
+describe("registerBuiltInWikiEmbeds — bootstrap convenience", () => {
+  it("registers both amazon and isbn", () => {
+    registerBuiltInWikiEmbeds();
+    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn"]);
+  });
+
+  it("is idempotent (re-running doesn't add duplicates)", () => {
+    registerBuiltInWikiEmbeds();
+    registerBuiltInWikiEmbeds();
+    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn"]);
+  });
+});


### PR DESCRIPTION
## Summary

PR-B of #1221 (Issue 2 — wiki-syntax embeds for common targets). The LLM and preset skills like \`mc-library\` (#1210) can now write \`[[amazon:B00ICN066A]]\` and \`[[isbn:9780062316097]]\` in any markdown body — wiki page, news article, chat assistant text, manage-skills body, source brief, generic markdown file — and get a clickable external link instead of literal brackets.

After PR-A (#1252) added \`handleExternalLinkClick\` everywhere, those generated \`<a target="_blank">\` tags also open in a new tab on click instead of tearing the user out of the SPA.

## Items to Confirm / Review

1. **Marked extension over regex post-processor** — the marked tokenizer never reaches \`code\` block content, so \`[[amazon:...]]\` inside fenced or inline code is left alone automatically. A regex pass on the rendered HTML would have to skip \`<pre><code>\` blocks itself.
2. **Verbatim fallback for invalid ids** — \`[[amazon:not-an-asin]]\` renders as a \`<span class="wiki-embed-invalid">\` showing the literal markup. Users see their typo and can fix it; nothing vanishes silently.
3. **HTML escape on every handler output** — verified by an explicit test asserting \`[[amazon:<script>x]]\` doesn't inject. \`escapeHtml\` is the single-purpose escaper; DOMPurify still runs after marked in the surfaces that use it (skill / manageSkills views) so we have defence in depth.
4. **\`.com\` as Amazon default** — Amazon redirects signed-in users to their locale automatically. Locale-aware routing (\`.co.jp\` etc.) is a follow-up; not blocking.
5. **OpenLibrary for ISBN** — keyless, no rate-limit headache. Fetching the cover image to render an actual book card is the natural next step (PR-C+).

## Items shipped

| File | Lines | Purpose |
|---|---|---|
| \`src/utils/markdown/wikiEmbeds.ts\` (new) | 137 | Registry + marked extension; \`escapeHtml\` |
| \`src/utils/markdown/wikiEmbedHandlers.ts\` (new) | 79 | \`amazon\` + \`isbn\` handlers; \`registerBuiltInWikiEmbeds\` |
| \`src/utils/markdown/setup.ts\` (new) | 23 | Idempotent \`marked.use()\` installer |
| \`src/main.ts\` | +5 | Calls \`setupMarked()\` before Vue app mounts |
| \`test/utils/markdown/test_wikiEmbeds.ts\` (new) | 192 | 23 cases — registry, tokenizer, code-block skip, both handlers, XSS guard |

## User Prompt

> つづけて

(Continuing pending issues; #1252 (external links fix) covered #1221 Issue 1, this is #1221 Issue 2.)

## Verification

- \`yarn format\` ✅
- \`yarn lint\` ✅
- \`yarn typecheck\` ✅
- \`yarn build\` ✅
- \`yarn test\` ✅ (23 new tests pass)

## Manual smoke

1. Write a wiki page or chat-paste a markdown file containing:
   \`\`\`md
   See [[amazon:B00ICN066A]] for the book and [[isbn:9780062316097]] for its catalog entry.
   \`\`\`
2. Render → both render as \`📦 B00ICN066A\` / \`📖 ISBN 9780062316097\` clickable links
3. Click → opens in new tab (Amazon / OpenLibrary)
4. Inside a code fence → stays as literal \`[[...]]\` (verified)

## Future prefixes (PR-C+)

Same architecture, one handler each. Plug into \`registerBuiltInWikiEmbeds\` or call \`registerWikiEmbed\` from a feature module:

| Prefix | Target |
|---|---|
| \`youtube\` | YouTube embed / thumbnail |
| \`x\` (or \`twitter\`) | X post oEmbed |
| \`map\` | Geo pin via the existing \`mapControl\` plugin |
| \`github\` | Repo / issue card |

## Refs

- Predecessor: #1252 (issue 1 — external links open in new tab)
- Issue: #1221
- Tied skill: \`mc-library\` (#1210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wiki-style embed syntax for Amazon and ISBN references in markdown (e.g., `[[amazon:ASIN]]`, `[[isbn:ISBN]]`), rendering as secure external links with built-in ID validation and graceful error handling for invalid entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->