### PR TITLE
fix(notify): clicking a chat-originated notification opens the source chat

### DIFF
--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -5,6 +5,17 @@ import { errorMessage } from "../../utils/errors.js";
 import { notFound, sendError, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 
+// Per-call context the MCP bridge threads through to the tool handler.
+// Currently just the chat session id (extracted from the `?session=`
+// query string the bridge always appends, see mcp-server.ts), so a
+// tool like `notify` can mark its outgoing notification with a
+// click-target back to the originating chat. Optional because the
+// HTTP route is also reachable by non-bridge callers (tests, ad-hoc
+// scripts) that have no session.
+export interface McpToolContext {
+  sessionId?: string;
+}
+
 export interface McpTool {
   definition: {
     name: string;
@@ -13,7 +24,7 @@ export interface McpTool {
   };
   requiredEnv?: string[];
   prompt?: string;
-  handler: (args: Record<string, unknown>) => Promise<string>;
+  handler: (args: Record<string, unknown>, ctx?: McpToolContext) => Promise<string>;
 }
 
 export const mcpTools: McpTool[] = [readXPost, searchX, notify];
@@ -52,7 +63,9 @@ mcpToolsRouter.post(API_ROUTES.mcpTools.invoke, async (req: Request<McpToolParam
     return;
   }
   try {
-    const result = await tool.handler(req.body);
+    const sessionRaw = typeof req.query.session === "string" ? req.query.session : "";
+    const ctx: McpToolContext | undefined = sessionRaw.length > 0 ? { sessionId: sessionRaw } : undefined;
+    const result = await tool.handler(req.body, ctx);
     res.json({ result });
   } catch (err) {
     serverError(res, errorMessage(err));

--- a/server/agent/mcp-tools/notify.ts
+++ b/server/agent/mcp-tools/notify.ts
@@ -2,7 +2,8 @@
 // bell side effects.
 
 import { publishNotification } from "../../events/notifications.js";
-import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
+import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_KINDS, NOTIFICATION_VIEWS } from "../../../src/types/notification.js";
+import type { McpToolContext } from "./index.js";
 
 export type NotifyPublishFn = typeof publishNotification;
 
@@ -37,16 +38,32 @@ export function makeNotifyTool(deps: NotifyToolDeps) {
       "This is the canonical built-in notification path: it fans out to the web bell, any active bridge transport, and macOS Reminders (when MACOS_REMINDER_NOTIFICATIONS=1 + darwin), and has NO active-user suppression — if the user asks for a notification, fire one. " +
       "After firing, briefly tell the user you sent the notification.",
 
-    async handler(args: Record<string, unknown>): Promise<string> {
+    async handler(args: Record<string, unknown>, ctx?: McpToolContext): Promise<string> {
       const title = typeof args.title === "string" ? args.title.trim() : "";
       if (!title) return "notify: `title` is required (non-empty string).";
       const bodyRaw = typeof args.body === "string" ? args.body.trim() : "";
       const body = bodyRaw.length > 0 ? bodyRaw : undefined;
 
+      // When the bridge threads a chat session through, mark the
+      // notification's primary action as "open the originating chat"
+      // so the user can click the bell entry and land back on the
+      // session that produced it (typically a scheduled / background
+      // chat that finished while they were elsewhere). Without a
+      // session id, fall back to plain push (unchanged behaviour: the
+      // entry is just dismissed on click).
+      const action =
+        ctx?.sessionId && ctx.sessionId.length > 0
+          ? {
+              type: NOTIFICATION_ACTION_TYPES.navigate,
+              target: { view: NOTIFICATION_VIEWS.chat, sessionId: ctx.sessionId },
+            }
+          : undefined;
+
       deps.publish({
         kind: NOTIFICATION_KINDS.push,
         title,
         body,
+        ...(action ? { action } : {}),
       });
       return body ? `Notification sent: ${title}\n${body}` : `Notification sent: ${title}`;
     },

--- a/server/agent/mcp-tools/notify.ts
+++ b/server/agent/mcp-tools/notify.ts
@@ -11,6 +11,21 @@ export interface NotifyToolDeps {
   publish: NotifyPublishFn;
 }
 
+// When the bridge threads a chat session through, mark the
+// notification's primary action as "open the originating chat" so
+// the user can click the bell entry and land back on the session
+// that produced it (typically a scheduled / background chat that
+// finished while they were elsewhere). Without a session id, fall
+// back to plain push — entry is just dismissed on click, which is
+// the unchanged pre-fix behaviour.
+function buildNavigateAction(ctx?: McpToolContext) {
+  if (!ctx?.sessionId || ctx.sessionId.length === 0) return undefined;
+  return {
+    type: NOTIFICATION_ACTION_TYPES.navigate,
+    target: { view: NOTIFICATION_VIEWS.chat, sessionId: ctx.sessionId },
+  };
+}
+
 export function makeNotifyTool(deps: NotifyToolDeps) {
   return {
     definition: {
@@ -44,21 +59,7 @@ export function makeNotifyTool(deps: NotifyToolDeps) {
       const bodyRaw = typeof args.body === "string" ? args.body.trim() : "";
       const body = bodyRaw.length > 0 ? bodyRaw : undefined;
 
-      // When the bridge threads a chat session through, mark the
-      // notification's primary action as "open the originating chat"
-      // so the user can click the bell entry and land back on the
-      // session that produced it (typically a scheduled / background
-      // chat that finished while they were elsewhere). Without a
-      // session id, fall back to plain push (unchanged behaviour: the
-      // entry is just dismissed on click).
-      const action =
-        ctx?.sessionId && ctx.sessionId.length > 0
-          ? {
-              type: NOTIFICATION_ACTION_TYPES.navigate,
-              target: { view: NOTIFICATION_VIEWS.chat, sessionId: ctx.sessionId },
-            }
-          : undefined;
-
+      const action = buildNavigateAction(ctx);
       deps.publish({
         kind: NOTIFICATION_KINDS.push,
         title,

--- a/test/agent/test_notify_tool.ts
+++ b/test/agent/test_notify_tool.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { notify, makeNotifyTool, type NotifyPublishFn } from "../../server/agent/mcp-tools/notify.js";
 import { mcpTools } from "../../server/agent/mcp-tools/index.js";
-import { NOTIFICATION_KINDS } from "../../src/types/notification.js";
+import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_KINDS, NOTIFICATION_VIEWS } from "../../src/types/notification.js";
 
 // Capture each `publish` call so tests can assert on the args
 // without firing the real publishNotification (which on darwin
@@ -76,6 +76,35 @@ describe("notify MCP tool — happy path", () => {
     const result = await tool.handler({ title: "hi", body: "   " });
     assert.equal(result, "Notification sent: hi");
     assert.equal(calls[0].body, undefined);
+  });
+});
+
+describe("notify MCP tool — chat session linkback", () => {
+  it("publishes a navigate action targeting the chat session when ctx carries sessionId", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    await tool.handler({ title: "Build done" }, { sessionId: "sess-abc-123" });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].action, {
+      type: NOTIFICATION_ACTION_TYPES.navigate,
+      target: { view: NOTIFICATION_VIEWS.chat, sessionId: "sess-abc-123" },
+    });
+  });
+
+  it("omits the action when ctx is undefined (e.g. test / ad-hoc HTTP caller)", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    await tool.handler({ title: "Build done" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].action, undefined);
+  });
+
+  it("omits the action when sessionId is empty string", async () => {
+    const { publish, calls } = makeMockPublish();
+    const tool = makeNotifyTool({ publish });
+    await tool.handler({ title: "Build done" }, { sessionId: "" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].action, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

- Notifications fired by the `notify` MCP tool from inside a chat session (typically a scheduled / background chat reporting completion — like the "九州イベントウォッチ: 新着7件" example in the screenshot below) had no click action, so the bell entry was non-clickable except to dismiss.
- The fix threads the chat session id from the MCP bridge through to the `notify` handler so the published notification carries `action: { type: "navigate", target: { view: "chat", sessionId } }`. The legacy adapter converts that to the existing `/chat/<sessionId>` navigateTarget the frontend (`NotificationBell.vue`) already consumes via `router.push` + clear.
- No frontend changes — the bell already supports navigate-on-click for any entry with `navigateTarget`. Old entries without it continue to dismiss-on-click as before.

## Items to Confirm / Review

- **Does NOT revive the duplicate-notification regression** that's the reason the `publishNotification` block in `server/api/routes/agent.ts#finally` is commented out (see lines 854-991 of that file). That regression was about firing a notification per chat-session turn completion regardless of whether the LLM asked for one — which is unrelated. This PR only adds an action onto notifications the LLM was already publishing deliberately via `notify`. No new bell entries.
- **Backward compatibility**: `notify`'s HTTP handler signature gained an optional second parameter (`ctx`). Existing callers (express route, tests) compile unchanged; the new ctx is opt-in.
- **No-session callers preserved**: when ctx is missing or has empty sessionId, no action field is attached. Tests cover both branches.
- **Other MCP tools (`readXPost`, `searchX`)** don't need ctx today — they don't publish notifications. The plumbing is generic so future tools that benefit from session context can opt in without touching the route.

## User Prompt

> 自動化の完了の通知、クリックすると消える。本来ならクリックするとそのチャットが開いてほしい。できる？

(Screenshot showed the bell panel with entries from a scheduled "九州イベントウォッチ" chat, where each entry on click just dismisses without opening the source chat.)

## Implementation approach

End-to-end flow after the fix:

1. Parent server spawns the MCP child with `SESSION_ID=<chatSessionId>` env (already existed, see `server/agent/config.ts:154`).
2. MCP child's `postJson` always appends `?session=<chatSessionId>` to fetches back to parent (already existed, `server/agent/mcp-server.ts:261`).
3. **NEW**: Parent's `/api/mcp-tools/:tool` route extracts `req.query.session` and passes it as `ctx.sessionId` to the tool handler.
4. **NEW**: `notify` handler, when ctx has a sessionId, builds `action: { type: "navigate", target: { view: "chat", sessionId } }` and includes it in the publish call.
5. `publishNotification` → `legacyActionToNavigateTarget` (already existed) converts the action to `/chat/<sessionId>` and stores it as the entry's `navigateTarget`.
6. `NotificationBell.vue` (already existed) on click of any entry with `navigateTarget`: `router.push(navigateTarget)` + `clear(entryId)`.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test` (new + existing notify tests pass: 15/15 in `test_notify_tool.ts`)
- [x] `yarn build` passes
- [ ] Manual: trigger a scheduled chat that calls `notify` at the end → confirm the bell entry shows up → click → lands on the originating chat session, entry clears.
- [ ] Manual regression check: click an entry that DOESN'T have a navigateTarget (e.g., a plugin meta diagnostic) → still dismisses without navigating, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP tool notifications now include a navigation action that allows users to return to their originating chat session when applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1262)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->