### PR TITLE
fix: address Codex iter-1 findings on #1263 (LINE placeholder + count parity)

### DIFF
--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -150,13 +150,14 @@ app.post("/webhook", async (req: Request, res: Response) => {
       }
       // chat-service's `parseMessagePayload` rejects empty `text`
       // (`text is required`) so attachment-only messages need a
-      // placeholder body — match the convention other bridges use
-      // when an image arrives without a caption. The agent sees the
-      // attachment in chat context and answers about it; the
-      // post-save EXIF hook (#1222 PR-A) writes a sidecar if GPS
-      // data is present. (Codex review on PR #1255.)
+      // placeholder body. Mirror the Telegram convention (see
+      // `packages/bridges/telegram/src/router.ts`) — an instructive
+      // prompt rather than a caption, so the agent treats the
+      // attachment as the subject and produces a useful response.
+      // The post-save EXIF hook (#1222 PR-A) writes a sidecar if
+      // GPS data is present. (Codex review on PR #1255 / #1263.)
       const attachments = [{ mimeType: image.mimeType, data: image.bytes.toString("base64") }];
-      const placeholderText = "📷 Photo";
+      const placeholderText = "Describe / analyze this file.";
       const ack = await client.send(incoming.userId, placeholderText, attachments);
       await pushMessage(incoming.userId, formatAckReply(ack));
     } catch (err) {

--- a/server/workspace/photo-locations/list.ts
+++ b/server/workspace/photo-locations/list.ts
@@ -50,22 +50,16 @@ export async function listAllSidecars(): Promise<ListedSidecar[]> {
   return all;
 }
 
-/** Quick count without parsing every file. Used by the plugin's
- *  status endpoint so the badge "N photos captured" shows fast
- *  even on a workspace with thousands of sidecars. */
+/** Count of sidecars that pass the same shape validation as
+ *  `listAllSidecars` — so the plugin's status badge agrees with
+ *  what the list endpoint will actually return. The earlier
+ *  cheap-walk version drifted out of parity once a malformed
+ *  sidecar appeared on disk (`list` skipped it, `count` still
+ *  totalled it). On workspaces with thousands of sidecars the
+ *  parse cost is still a small fraction of the listing one and
+ *  worth the consistency. (Codex review on PR #1263.) */
 export async function countAllSidecars(): Promise<number> {
-  const root = WORKSPACE_PATHS.locations;
-  const yearDirs = await readSubdirsSafe(root);
-  let total = 0;
-  for (const year of yearDirs) {
-    const yearAbs = path.join(root, year);
-    const monthDirs = await readSubdirsSafe(yearAbs);
-    for (const month of monthDirs) {
-      const entries = await readdir(path.join(yearAbs, month)).catch(() => []);
-      total += entries.filter((entry) => entry.endsWith(SIDECAR_EXT)).length;
-    }
-  }
-  return total;
+  return (await listAllSidecars()).length;
 }
 
 /** Defensive shape check for one sidecar JSON. The post-save hook

--- a/test/workspace/test_photo_locations_list.ts
+++ b/test/workspace/test_photo_locations_list.ts
@@ -104,14 +104,16 @@ describe("photo-locations list — defensive sidecar validation", () => {
     assert.deepEqual(all, []);
   });
 
-  it("count includes malformed-but-counted entries — same partition logic", async () => {
-    // count uses a cheaper partition walk that doesn't parse content.
-    // Bad sidecars still occupy disk and contribute to the badge — we
-    // accept the mismatch with `list` to keep `count` fast on a
-    // workspace with thousands of sidecars.
+  it("count agrees with list — malformed sidecars are excluded from both", async () => {
+    // count now reuses the same parse-+-validate path as list so
+    // the status badge can never disagree with the row list.
+    // (Codex review on PR #1263.)
     writeSidecar("a.json", VALID_SIDECAR);
     writeSidecar("b.json", "{garbage");
+    writeSidecar("c.json", { ...VALID_SIDECAR, version: 99 });
     const total = await countAllSidecars();
-    assert.equal(total, 2);
+    const all = await listAllSidecars();
+    assert.equal(total, 1);
+    assert.equal(total, all.length);
   });
 });


### PR DESCRIPTION
## Summary

Codex review on #1263 raised \`CHANGES REQUESTED\` with 2 findings — the auto-merge fired before they could land in that PR. This is the immediate follow-up.

## Findings addressed

1. **LINE attachment-only placeholder text** (\`packages/bridges/line/src/index.ts\`)
   - Was: \`"📷 Photo"\` (a caption — agent likely produces a low-value response)
   - Now: \`"Describe / analyze this file."\` — same string Telegram already uses for the captionless-photo case (\`packages/bridges/telegram/src/router.ts\`). Cross-bridge consistency.

2. **\`countAllSidecars\` / \`listAllSidecars\` parity** (\`server/workspace/photo-locations/list.ts\`)
   - Was: \`count\` used a cheap directory walk and totalled malformed-sidecar files; \`list\` parsed + skipped them. The status badge would say N while the row list showed N-1.
   - Now: \`count\` reuses \`listAllSidecars()\` — always parity. The earlier "cheap badge" optimisation was premature.

## Items shipped

| File | Change |
|---|---|
| \`packages/bridges/line/src/index.ts\` | Placeholder text mirrors Telegram |
| \`server/workspace/photo-locations/list.ts\` | \`count\` now wraps \`list().length\` |
| \`test/workspace/test_photo_locations_list.ts\` | Test updated: \`count\` agrees with \`list\` (was: \`count\` includes malformed) |

## User Prompt

> /codex-cross-review (on PR #1263)
> mergeしてしまったかも。そうならべつPRで。

## Verification

- \`yarn format\` ✅
- \`yarn lint\` ✅
- \`yarn typecheck\` ✅
- \`yarn build\` ✅
- \`yarn test\` ✅

## Refs

- Predecessor: #1263 (merged before iter-1 could land)
- Originating sweep: #1247 / #1250 / #1255 Codex CR audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)