### PR TITLE
feat(markdown): wiki-syntax youtube embed (#1221 PR-C)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -119,3 +119,11 @@
   background: #f9fafb;
   font-weight: 600;
 }
+.markdown-content .wiki-embed-thumbnail {
+  display: inline-block;
+  max-width: 100%;
+  width: 320px;
+  height: auto;
+  border-radius: 0.375rem;
+  margin: 0.25rem 0;
+}

--- a/src/utils/markdown/wikiEmbedHandlers.ts
+++ b/src/utils/markdown/wikiEmbedHandlers.ts
@@ -21,6 +21,11 @@ const ASIN_PATTERN = /^[A-Z0-9]{10}$/i;
  *  Non-digit / dash chars (other than the trailing X) reject. */
 const ISBN_PATTERN = /^\d{9}[\dX]$|^\d{13}$/i;
 
+/** YouTube video id — fixed-length 11, alphanumeric + `_` / `-`.
+ *  Same shape for regular videos, Shorts, and Live (YouTube
+ *  auto-redirects `watch?v=<id>` to the right player). */
+const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
 /** Strip ISBN dashes the user might paste verbatim
  *  (`978-0-06-231609-7` → `9780062316097`). */
 function normaliseIsbn(raw: string): string {
@@ -72,9 +77,33 @@ export function registerIsbnEmbed(): void {
   });
 }
 
+export function registerYoutubeEmbed(): void {
+  registerWikiEmbed({
+    prefix: "youtube",
+    render: (embedId: string): string => {
+      if (!YOUTUBE_ID_PATTERN.test(embedId)) return verbatim("youtube", embedId);
+      // Thumbnail-as-link rather than an embedded iframe: a full
+      // YouTube embed pulls 100+ KB of player JS, autoplay heuristics
+      // and tracking pixels per occurrence — heavy when a wiki page
+      // references several videos. The static `hqdefault.jpg` is a
+      // single image (always available, no API key) and clicking
+      // opens the canonical watch URL in a new tab where the user
+      // expects video controls anyway.
+      const watchUrl = `https://www.youtube.com/watch?v=${embedId}`;
+      const thumbUrl = `https://img.youtube.com/vi/${embedId}/hqdefault.jpg`;
+      const label = `YouTube video ${embedId}`;
+      const escapedHref = escapeHtml(watchUrl);
+      const escapedThumb = escapeHtml(thumbUrl);
+      const escapedLabel = escapeHtml(label);
+      return `<a href="${escapedHref}" target="_blank" rel="noopener noreferrer" class="wiki-embed wiki-embed-youtube" title="${escapedLabel}"><img src="${escapedThumb}" alt="${escapedLabel}" loading="lazy" class="wiki-embed-thumbnail" /></a>`;
+    },
+  });
+}
+
 /** Convenience entry point — registers every built-in handler.
  *  Called once at app boot from `src/main.ts`. Idempotent. */
 export function registerBuiltInWikiEmbeds(): void {
   registerAmazonEmbed();
   registerIsbnEmbed();
+  registerYoutubeEmbed();
 }

--- a/test/utils/markdown/test_wikiEmbeds.ts
+++ b/test/utils/markdown/test_wikiEmbeds.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import { marked } from "marked";
 
 import { _resetWikiEmbeds, escapeHtml, listWikiEmbedPrefixes, registerWikiEmbed, wikiEmbedExtension } from "../../../src/utils/markdown/wikiEmbeds";
-import { registerAmazonEmbed, registerIsbnEmbed, registerBuiltInWikiEmbeds } from "../../../src/utils/markdown/wikiEmbedHandlers";
+import { registerAmazonEmbed, registerIsbnEmbed, registerYoutubeEmbed, registerBuiltInWikiEmbeds } from "../../../src/utils/markdown/wikiEmbedHandlers";
 
 // `marked.use()` mutates the global instance — install once per
 // suite. Tests that need a fresh handler set call
@@ -170,15 +170,56 @@ describe("ISBN embed handler", () => {
   });
 });
 
+describe("YouTube embed handler", () => {
+  beforeEach(() => {
+    registerYoutubeEmbed();
+  });
+
+  it("renders a thumbnail-link to youtube.com/watch?v=<id> for a valid 11-char id", () => {
+    const html = (marked.parse("watch [[youtube:dQw4w9WgXcQ]]") as string).trim();
+    assert.match(html, /href="https:\/\/www\.youtube\.com\/watch\?v=dQw4w9WgXcQ"/);
+    assert.match(html, /target="_blank"/);
+    assert.match(html, /rel="noopener noreferrer"/);
+    assert.match(html, /src="https:\/\/img\.youtube\.com\/vi\/dQw4w9WgXcQ\/hqdefault\.jpg"/);
+    assert.match(html, /loading="lazy"/);
+    assert.match(html, /class="wiki-embed wiki-embed-youtube"/);
+  });
+
+  it("accepts ids containing _ and - characters", () => {
+    const html = (marked.parse("[[youtube:abc_def-XYZ]]") as string).trim();
+    assert.match(html, /watch\?v=abc_def-XYZ/);
+  });
+
+  it("falls through to verbatim for an id shorter than 11 chars", () => {
+    const html = (marked.parse("[[youtube:tooShort]]") as string).trim();
+    assert.match(html, /\[\[youtube:tooShort\]\]/);
+    assert.doesNotMatch(html, /youtube\.com\/watch/);
+  });
+
+  it("falls through to verbatim for an id longer than 11 chars", () => {
+    const html = (marked.parse("[[youtube:thisIdIsTooLong]]") as string).trim();
+    assert.match(html, /\[\[youtube:thisIdIsTooLong\]\]/);
+    assert.doesNotMatch(html, /youtube\.com\/watch/);
+  });
+
+  it("rejects an id with HTML metacharacters (no XSS leak)", () => {
+    // 11 chars (passing length) but contains HTML metacharacters,
+    // so it must fail the strict alphanumeric+_- pattern.
+    const html = (marked.parse('[[youtube:<script>x"]]') as string).trim();
+    assert.doesNotMatch(html, /<script/);
+    assert.doesNotMatch(html, /youtube\.com\/watch/);
+  });
+});
+
 describe("registerBuiltInWikiEmbeds — bootstrap convenience", () => {
-  it("registers both amazon and isbn", () => {
+  it("registers amazon, isbn, and youtube", () => {
     registerBuiltInWikiEmbeds();
-    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn"]);
+    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn", "youtube"]);
   });
 
   it("is idempotent (re-running doesn't add duplicates)", () => {
     registerBuiltInWikiEmbeds();
     registerBuiltInWikiEmbeds();
-    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn"]);
+    assert.deepEqual(listWikiEmbedPrefixes(), ["amazon", "isbn", "youtube"]);
   });
 });


### PR DESCRIPTION
## Summary

- Third built-in `WikiEmbedHandler` after `amazon` (#1261) and `isbn` (#1261). Writing `[[youtube:dQw4w9WgXcQ]]` in any markdown surface now renders the video's `hqdefault` thumbnail wrapped in a click-to-play link to `youtube.com/watch?v=<id>` (opens in a new tab).
- Single-image preview, no iframe — cheap and predictable.

## Items to Confirm / Review

- **Thumbnail-link, NOT iframe**: deliberate deviation from the original PR-C plan ("iframe with thumbnail-link as default"). A full YouTube embed pulls 100+ KB of player JS + autoplay heuristics + tracking pixels per instance; the static `hqdefault.jpg` is a single image with no API key. Clicking opens the canonical watch URL where the user expects video controls anyway. The iframe variant can come back as a `?style=embed` opt-in if/when there's a concrete need.
- **ID pattern**: `[A-Za-z0-9_-]{11}` matches regular videos, Shorts, and Live (YouTube auto-redirects `watch?v=<id>` based on upload type). Strict 11-char rule + alphanumeric+`_-` only — anything else falls through to the verbatim "Invalid youtube id" badge, same pattern as amazon/isbn.
- **Image domain**: `https://img.youtube.com/vi/<id>/hqdefault.jpg` is publicly accessible without API access. No CSP allowlist needed for the markdown surfaces (which render via `marked` + DOMPurify, not via the `presentHtml` iframe that has its own restrictions). I verified DOMPurify's default allowlist passes `<img src="https://...">` through.
- **CSS**: added `.markdown-content .wiki-embed-thumbnail` to constrain the 480x360 `hqdefault` to 320px wide inline. If reviewers prefer this in a Tailwind utility on the rendered HTML instead of a global CSS rule, easy to swap — just chose CSS to match the existing `.markdown-content *` selectors in `index.css`.
- **Plan file vs reality**: the original plan had `?style=embed` opt-in for iframe + `?style=thumbnail` shorthand. PR-B simplified the registry to `prefix + render(embedId)` only, no params; this PR follows that simpler shape. If the params layer comes back later, this handler is one of the first that would gain options.

## User Prompt

> youtubeを。

(In context: progressing through #1221 PR-C+ types — youtube was named first as a high-value type for the `mc-library` and `#1169` use cases.)

## Implementation approach

Single new handler in `wikiEmbedHandlers.ts`:

\`\`\`ts
const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;

export function registerYoutubeEmbed(): void {
  registerWikiEmbed({
    prefix: "youtube",
    render: (embedId) => {
      if (!YOUTUBE_ID_PATTERN.test(embedId)) return verbatim("youtube", embedId);
      const watchUrl = \`https://www.youtube.com/watch?v=\${embedId}\`;
      const thumbUrl = \`https://img.youtube.com/vi/\${embedId}/hqdefault.jpg\`;
      // <a href=watchUrl target=_blank rel=noopener noreferrer><img src=thumbUrl loading=lazy /></a>
      // (full HTML in the file — escaped via escapeHtml on every interpolated segment)
    },
  });
}
\`\`\`

Wired into \`registerBuiltInWikiEmbeds()\`.

## Test plan

- [x] \`yarn typecheck\` passes
- [x] \`yarn lint\` passes
- [x] \`yarn test\` (28/28 in \`test_wikiEmbeds.ts\`, 5 new YouTube cases)
- [x] \`yarn build\` passes
- [ ] Manual: write \`[[youtube:dQw4w9WgXcQ]]\` in a wiki page → confirm thumbnail renders inline, clicking opens YouTube in a new tab, MulmoClaude page stays put.
- [ ] Manual: invalid id (\`[[youtube:nope]]\`) → verbatim "Invalid youtube id" badge, no broken image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for YouTube video embeds in wiki content, displaying as clickable thumbnail previews linking to the full video.
  * Enhanced embedded content styling with improved thumbnail display, responsive sizing, and rounded corners.

* **Tests**
  * Added comprehensive tests for YouTube embed functionality, including validation of video links and content security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->