### PR TITLE
fix(roles): gate runtime plugins by availablePlugins (#1266)

### DIFF
--- a/server/agent/activeTools.ts
+++ b/server/agent/activeTools.ts
@@ -19,8 +19,11 @@
 // `getActiveToolDescriptors(role)` produces a single list of
 // `ActiveToolDescriptor` rows and the three call sites read whichever
 // fields they need (name only / name + prompt / name + endpoint).
-// Runtime plugins are auto-included regardless of role; static plugins
-// are still gated by `role.availablePlugins`. The MCP-prefixed full
+// EVERY tool source (static-gui, static-mcp, runtime) is gated by
+// `role.availablePlugins` — runtime plugins used to be auto-included
+// regardless, which surfaced as a real bug (preset plugins like
+// `manageRecipes` leaked into every role even though `cookingCoach`
+// was their intended home). The MCP-prefixed full
 // name is precomputed once so callers don't have to re-derive it.
 
 import type { Role } from "../../src/config/roles.js";
@@ -109,10 +112,17 @@ export function getActiveToolDescriptors(role: Role): ActiveToolDescriptor[] {
   for (const plugin of getRuntimePlugins()) {
     const def = plugin.definition;
     if (seen.has(def.name)) continue; // runtime-registry collision
-    // policy already filters static name collisions, but the
-    // build-time-bundle case (#1043 C-2 codex iter-7 medium) is not
-    // currently in the static set; the `seen` guard catches any
-    // duplicate that slipped through.
+    // Runtime plugins (preset + user-installed alike) are now gated
+    // by `role.availablePlugins`, mirroring the static-GUI / static-MCP
+    // loops above. Previously they were auto-included regardless of
+    // role — that broke the role's stated promise of "exactly these
+    // tools" and surfaced as a real bug when a non-cooking role
+    // started seeing `manageRecipes`. Roles that want a runtime
+    // plugin must list its `toolName` in `availablePlugins`. The
+    // Settings → Roles UI lets users add tool names per role; preset
+    // plugin names land in the `general` role's `availablePlugins`
+    // out of the box.
+    if (!allowed.has(def.name)) continue;
     out.push({
       name: def.name,
       fullName: fullNameFor(def.name),

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -162,12 +162,15 @@ const runtimeReady: Promise<void> = (async () => {
       const endpoint = API_ROUTES.plugins.runtimeDispatch.replace(":pkg", encodeURIComponent(plugin.name));
       ALL_TOOLS[plugin.definition.name] = fromPackage(plugin.definition, endpoint);
     }
-    // Runtime plugins are auto-included regardless of role.availablePlugins
-    // — the user explicitly installed them, so every role gets to use them.
-    // Roles still gate the static set via PLUGIN_NAMES env (set by the
-    // parent based on getActivePlugins(role)).
-    const runtimeToolNames = getRuntimePlugins().map((plugin) => plugin.definition.name);
-    activeNames = Array.from(new Set([...PLUGIN_NAMES, ...runtimeToolNames]));
+    // Runtime plugins are gated by `role.availablePlugins` (mirrored
+    // here through the PLUGIN_NAMES env set by the parent's
+    // `getActivePlugins(role)`). Previously every runtime plugin was
+    // auto-active in every role, which leaked preset plugins like
+    // `manageRecipes` into roles that shouldn't expose them. The
+    // intersection is now: ALL_TOOLS includes both static + runtime
+    // entries, but only the names PLUGIN_NAMES authorises become live
+    // tools.
+    activeNames = [...PLUGIN_NAMES];
     tools = activeNames.map((name) => ALL_TOOLS[name]).filter(Boolean);
   } catch (err) {
     process.stderr.write(`[mcp-server] runtime plugin load failed; static tools only: ${String(err)}\n`);

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -1,25 +1,34 @@
 import { z } from "zod";
-import { ALL_TOOL_NAMES, TOOL_NAMES, isToolName, type ToolName } from "./toolNames";
+import { ALL_TOOL_NAMES, TOOL_NAMES, type ToolName } from "./toolNames";
 
 // `availablePlugins` accepts every literal listed in `TOOL_NAMES`.
 // Compile time: roles.ts static definitions below get typed as
 // `ToolName[]` via RoleSchema's zod inference, so `presentHTML` vs
 // `presentHtml` kind of typos are caught immediately.
 //
-// Runtime: take any string array and filter out unknown names
-// rather than failing the whole parse. A persisted custom role
-// file may still reference a tool that was removed in a later
-// release (e.g. `manageRoles` post-#949 / #951), and we want
-// such a role to keep loading with the dead reference silently
-// dropped — the alternative is `loadCustomRoles` swallowing the
-// whole role, which makes the user's edits disappear from
-// `/roles` for no obvious reason. Frontend create/update goes
-// through a plugin-picker UI that only emits valid names, so the
-// lenient parse doesn't weaken create-time validation.
+// Runtime: keep any non-empty string. The list is a wishlist —
+// `server/agent/activeTools.ts` is the choke point that intersects
+// it with the actually-loaded tool registry, so unknown names are a
+// silent no-op rather than a parse failure. Two reasons we keep
+// the lenient runtime parse:
+//
+//   - User-installed runtime plugins (`~/mulmoclaude/plugins/*`)
+//     publish their `toolName` only at process start; the role file
+//     lists those names but they aren't in `TOOL_NAMES` (which is
+//     compile-time and host-owned). Stripping them at parse would
+//     unconditionally break user-added plugins.
+//   - A persisted custom role may reference a tool that was removed
+//     in a later release (e.g. `manageRoles` post-#949 / #951);
+//     keeping the entry preserves the user's intent visually in
+//     `/roles` rather than making it disappear.
+//
+// Frontend create/update goes through a plugin-picker UI that only
+// emits names that are loaded right now, so the lenient parse
+// doesn't weaken create-time validation.
 const toolNameEnum = z.enum(ALL_TOOL_NAMES as readonly [ToolName, ...ToolName[]]);
 const availablePluginsSchema = z
   .union([z.array(z.string()), z.array(toolNameEnum)])
-  .transform((plugins) => plugins.filter((plugin): plugin is ToolName => isToolName(plugin)));
+  .transform((plugins) => plugins.filter((plugin) => typeof plugin === "string" && plugin.length > 0));
 
 export const RoleSchema = z.object({
   id: z.string(),
@@ -49,10 +58,6 @@ export const ROLES: Role[] = [
       "- **Browse / lint**: direct the user to the `/wiki` UI — catalog at `/wiki`, a specific page at `/wiki/pages/<slug>`, activity log at `/wiki/log`, or the Lint button on `/wiki` for a health check.\n\n" +
       "Page format: YAML frontmatter (title, created, updated, tags) + markdown body + `[[wiki links]]` for cross-references. Slugs are lowercase hyphen-separated. Always keep `data/wiki/index.md` current and append to `data/wiki/log.md` after any change. The page-list section of `index.md` is a flat, recency-ordered log: prepend new pages at the top, and when a page is updated (content, description, tags, or rename) move its entry to the top — don't group by category. The Tags section (if present) still needs its per-tag page lists updated on add / rename / delete, but the tag order itself is not reordered by recency. Read `config/helps/wiki.md` for full details.",
     availablePlugins: [
-      // manageTodoList: runtime plugin (`@mulmoclaude/todo-plugin`,
-      // #1145) — runtime-loaded plugins are auto-included in every
-      // role's active tool set regardless of `availablePlugins`, so
-      // it doesn't need to be listed here.
       TOOL_NAMES.manageCalendar,
       TOOL_NAMES.presentDocument,
       TOOL_NAMES.presentForm,
@@ -64,6 +69,15 @@ export const ROLES: Role[] = [
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,
+      // Preset runtime plugins (server/plugins/preset-list.ts).
+      // Runtime plugins are gated by `availablePlugins` like the
+      // static-GUI / static-MCP entries above; listed here so the
+      // out-of-the-box "general" role keeps exposing them. User-
+      // installed runtime plugins (`~/mulmoclaude/plugins/*`) are
+      // added to roles via Settings → Roles.
+      TOOL_NAMES.manageBookmarks,
+      TOOL_NAMES.manageTodoList,
+      TOOL_NAMES.manageSpotify,
     ],
     queries: [
       "Tell me about this app, MulmoClaude.",
@@ -270,11 +284,6 @@ export const ROLES: Role[] = [
     icon: "restaurant",
     prompt:
       "You are a Cooking Coach assistant. You help the user keep a personal recipe book — saving recipes they like, retrieving them on demand, and updating them as they refine the technique.\n\n" +
-      // The tool name is a literal here (not `TOOL_NAMES.manageRecipes`)
-      // because the recipe-book plugin is a RUNTIME plugin — its
-      // `toolName` is loaded at process start, not at compile time, so
-      // `TOOL_NAMES` doesn't carry it. Same convention as
-      // `manageTodoList` references in the host (also runtime).
       "## manageRecipes (runtime plugin)\n\n" +
       "Use the `manageRecipes` tool for every recipe-book operation. The plugin owns its data; you just call the tool with the right `kind`. Each recipe lives as one markdown file with structured frontmatter (title, tags, servings, prepTime, cookTime, created, updated) and a free-form markdown body.\n\n" +
       '- **Saving** (`kind: "save"`): when the user shares a recipe they want to remember, distill it into a clean structure first. Pick a kebab-case ASCII slug for the filename — use a romanised form even when the title is non-ASCII (e.g. title `ピーマンの肉詰め` → slug `stuffed-peppers`). Title can be in the user\'s language. Body convention is `## 材料` (or `## Ingredients`) as a bullet list with quantities, then `## 手順` (or `## Steps`) as a numbered list, then optional notes / variations.\n' +
@@ -286,11 +295,10 @@ export const ROLES: Role[] = [
       "## Tone\n\n" +
       "Friendly, focused on the cooking — not the bookkeeping. Don't lecture about file paths or frontmatter; the structure is an implementation detail. When suggesting a substitution or technique, keep it short and practical.",
     // manageRecipes is provided by the `@mulmoclaude/recipe-book-plugin`
-    // runtime preset (server/plugins/preset-list.ts). Runtime plugins
-    // are auto-included in every role's active tool set regardless of
-    // `availablePlugins`, so it doesn't need to be listed here. Only
-    // host-static tools the role wants explicit go in this array.
-    availablePlugins: [TOOL_NAMES.presentForm, TOOL_NAMES.generateImage],
+    // runtime preset (`server/plugins/preset-list.ts`). Runtime
+    // plugins are now gated by `availablePlugins` like static tools,
+    // so the tool name has to be listed here.
+    availablePlugins: [TOOL_NAMES.manageRecipes, TOOL_NAMES.presentForm, TOOL_NAMES.generateImage],
     queries: [
       "Save my Mom's stuffed peppers recipe",
       "Show me the recipes I've saved",
@@ -324,6 +332,15 @@ export const ROLES: Role[] = [
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,
+      // Preset runtime plugins — same set as the `general` role plus
+      // the dev-only `manageDebug` plugin. Runtime plugins are gated
+      // by `availablePlugins` (see `general` role's note); listing
+      // them here keeps the debug role's "kitchen sink" promise.
+      TOOL_NAMES.manageBookmarks,
+      TOOL_NAMES.manageTodoList,
+      TOOL_NAMES.manageSpotify,
+      TOOL_NAMES.manageRecipes,
+      TOOL_NAMES.manageDebug,
     ],
     queries: [
       "Tell me about this app, MulmoClaude.",

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -64,6 +64,25 @@ const HOST_TOOL_NAMES = {
   readXPost: "readXPost",
   searchX: "searchX",
   notify: "notify",
+
+  // Preset runtime plugins (`server/plugins/preset-list.ts`).
+  // Their `toolName` comes from the plugin package's
+  // `TOOL_DEFINITION.name` and is stable across versions. Listing
+  // them here gives `TOOL_NAMES.<x>` type safety in `roles.ts`,
+  // mirroring static GUI / MCP tools.
+  //
+  // Runtime plugins are now gated by `role.availablePlugins`
+  // (server/agent/activeTools.ts) — the previous "auto-included
+  // regardless of role" rule made `manageRecipes` etc. leak into
+  // every role and was a real bug. User-installed (non-preset)
+  // runtime plugins are accepted in `availablePlugins` as bare
+  // strings via the schema's permissive branch — see
+  // `availablePluginsSchema` in `src/config/roles.ts`.
+  manageBookmarks: "manageBookmarks",
+  manageTodoList: "manageTodoList",
+  manageSpotify: "manageSpotify",
+  manageRecipes: "manageRecipes",
+  manageDebug: "manageDebug",
 } as const;
 
 // Plugin-owned tool names auto-merged from each plugin's META.

--- a/test/agent/test_activeTools.ts
+++ b/test/agent/test_activeTools.ts
@@ -1,10 +1,10 @@
 // Unit tests for `getActiveToolDescriptors` — the single source of
 // truth that drives `getActivePlugins(role)` (config.ts) and
-// `buildPluginPromptSections(role)` (prompt.ts). Verifies the two
-// invariants that broke during runtime-plugin rollout:
-//
-//   1. Static GUI / MCP tools are gated by role.availablePlugins.
-//   2. Runtime plugins (#1043 C-2) are auto-included regardless.
+// `buildPluginPromptSections(role)` (prompt.ts). Verifies the
+// invariant: every tool source — static GUI, static MCP, AND runtime —
+// is gated by `role.availablePlugins`. Runtime plugins used to be
+// auto-included regardless of role; that surfaced as a real bug
+// (`manageRecipes` leaking into every role) and was reverted.
 //
 // Plus collision behaviour and the precomputed full-name field that
 // the prompt's MCP-prefix hint depends on.
@@ -67,19 +67,32 @@ describe("getActiveToolDescriptors — single source of truth", () => {
     );
   });
 
-  it("auto-includes runtime plugins regardless of role.availablePlugins", () => {
+  it("includes a runtime plugin when role.availablePlugins lists its toolName", () => {
     registerRuntimePlugins(new Set(), [fakeRuntimePlugin("@x/weather", "fetchWeather")]);
-    const role = fakeRole([]); // empty role — no static plugins allowed
+    const role = fakeRole(["fetchWeather"]);
     const descriptors = getActiveToolDescriptors(role);
     const weather = descriptors.find((descriptor) => descriptor.name === "fetchWeather");
-    assert.ok(weather, "runtime plugins should be active even when the role doesn't list them");
+    assert.ok(weather, "runtime plugins listed in availablePlugins must surface");
     assert.equal(weather?.source, "runtime");
     assert.ok(weather?.endpoint?.includes("/api/plugins/runtime/"), "runtime plugins use the generic dispatch route");
   });
 
+  it("EXCLUDES a runtime plugin when role.availablePlugins doesn't list its toolName", () => {
+    // Regression: `manageRecipes` was previously auto-included for
+    // every role even though only `cookingCoach` should expose it.
+    registerRuntimePlugins(new Set(), [fakeRuntimePlugin("@x/weather", "fetchWeather")]);
+    const role = fakeRole([]); // empty — runtime tools must be gated like static ones
+    const descriptors = getActiveToolDescriptors(role);
+    assert.equal(
+      descriptors.find((descriptor) => descriptor.name === "fetchWeather"),
+      undefined,
+      "runtime plugin must NOT surface when the role doesn't list it",
+    );
+  });
+
   it("precomputes the fully-qualified mcp__<server>__<name> id", () => {
     registerRuntimePlugins(new Set(), [fakeRuntimePlugin("@x/weather", "fetchWeather")]);
-    const role = fakeRole([]);
+    const role = fakeRole(["fetchWeather"]);
     const descriptors = getActiveToolDescriptors(role);
     const weather = descriptors.find((descriptor) => descriptor.name === "fetchWeather");
     assert.equal(weather?.fullName, `mcp__${MCP_SERVER_ID}__fetchWeather`);
@@ -93,7 +106,7 @@ describe("getActiveToolDescriptors — single source of truth", () => {
     // exercise both shapes in one descriptor list.
     _resetRuntimeRegistryForTest();
     registerRuntimePlugins(new Set(), [fakeRuntimePlugin("@x/with-prompt", "withPrompt", "Use this for X."), fakeRuntimePlugin("@x/no-prompt", "noPrompt")]);
-    const role = fakeRole([]);
+    const role = fakeRole(["withPrompt", "noPrompt"]);
     const descriptors = getActiveToolDescriptors(role);
     assert.equal(descriptors.find((descriptor) => descriptor.name === "withPrompt")?.prompt, "Use this for X.");
     assert.equal(descriptors.find((descriptor) => descriptor.name === "noPrompt")?.prompt, undefined);
@@ -122,7 +135,9 @@ describe("getActiveToolDescriptors — single source of truth", () => {
 
   it("returned list is the union with no duplicates across all sources", () => {
     registerRuntimePlugins(new Set(), [fakeRuntimePlugin("@x/r1", "r1Tool"), fakeRuntimePlugin("@x/r2", "r2Tool")]);
-    const role = fakeRole(["presentMulmoScript", "presentForm"]);
+    // Now that runtime plugins are gated, the role must list each
+    // tool name explicitly to surface it.
+    const role = fakeRole(["presentMulmoScript", "presentForm", "r1Tool", "r2Tool"]);
     const descriptors = getActiveToolDescriptors(role);
     const names = descriptors.map((descriptor) => descriptor.name);
     assert.equal(new Set(names).size, names.length, "no duplicate tool names");

--- a/test/roles/test_role_schema.ts
+++ b/test/roles/test_role_schema.ts
@@ -16,14 +16,18 @@ describe("RoleSchema", () => {
     assert.deepStrictEqual(result, valid);
   });
 
-  it("silently drops unknown plugin names from availablePlugins (lenient parse — #951)", () => {
-    // Pre-#951 the schema rejected the whole role when it
-    // referenced an unknown tool. That cost exceeded the typo-
-    // catching benefit when a tool was removed in a later release
-    // (e.g. `manageRoles` itself in #951): a legitimate role file
-    // would silently disappear from `/roles` because
-    // `loadCustomRoles` swallows zod failures. The schema now
-    // filters the array instead so the role survives the load.
+  it("preserves every non-empty string in availablePlugins (lenient parse — #951 + runtime plugins)", () => {
+    // The schema preserves any non-empty string. Two reasons we no
+    // longer filter to `TOOL_NAMES` membership:
+    //   - User-installed runtime plugins publish their `toolName`
+    //     only at process start; a role file references those names
+    //     statically, but they aren't in compile-time `TOOL_NAMES`.
+    //   - A persisted legacy role may reference a tool that was
+    //     removed in a later release (e.g. `manageRoles` post-#951).
+    //     Keeping the entry preserves user intent visually in
+    //     `/roles` rather than making it disappear; the actual
+    //     gating happens later in `getActiveToolDescriptors` which
+    //     intersects with the live tool registry.
     const input = {
       id: "test",
       name: "Test",
@@ -32,16 +36,17 @@ describe("RoleSchema", () => {
       availablePlugins: ["presentMulmoScript", "presentHTML", "generateImage"],
     };
     const result = RoleSchema.parse(input);
-    assert.deepStrictEqual(result.availablePlugins, ["presentMulmoScript", "generateImage"]);
+    assert.deepStrictEqual(result.availablePlugins, ["presentMulmoScript", "presentHTML", "generateImage"]);
   });
 
-  it("recovers a legacy role file that references the removed `manageRoles` tool (#951 regression guard)", () => {
-    // Before #951 a role with `manageRoles` validated and the
-    // role loaded; after #951 the tool name is gone from
-    // TOOL_NAMES. Without lenient parsing the role would now
-    // disappear from the list. Pin that the lenient parse keeps
-    // it alive (dropping the dead reference but preserving every
-    // other plugin).
+  it("preserves a legacy role file that references the removed `manageRoles` tool", () => {
+    // Before #951 a role with `manageRoles` validated and the role
+    // loaded. After #951 the tool name is gone from TOOL_NAMES. The
+    // current lenient parse keeps the entry alive — the runtime
+    // gating layer (`getActiveToolDescriptors`) silently no-ops on
+    // dead references when the tool isn't loaded, so the role still
+    // works for everything else and the user can clean up
+    // `manageRoles` from the list at their leisure.
     const legacyRole = {
       id: "my-role",
       name: "My Role",
@@ -50,6 +55,18 @@ describe("RoleSchema", () => {
       availablePlugins: ["manageRoles", "presentMulmoScript", "generateImage"],
     };
     const result = RoleSchema.parse(legacyRole);
+    assert.deepStrictEqual(result.availablePlugins, ["manageRoles", "presentMulmoScript", "generateImage"]);
+  });
+
+  it("drops empty strings from availablePlugins (only valid non-empty names survive)", () => {
+    const input = {
+      id: "test",
+      name: "Test",
+      icon: "star",
+      prompt: "prompt",
+      availablePlugins: ["presentMulmoScript", "", "generateImage"],
+    };
+    const result = RoleSchema.parse(input);
     assert.deepStrictEqual(result.availablePlugins, ["presentMulmoScript", "generateImage"]);
   });
 


### PR DESCRIPTION
## Summary

Runtime plugins (preset under \`packages/plugins/*\` and user-installed under \`~/mulmoclaude/plugins/*\`) were loaded for every role regardless of \`role.availablePlugins\`, while in-tree plugins under \`src/plugins/*\` were correctly gated. Same rule now applies to all three sources: the role explicitly lists the tool name in \`availablePlugins\`, or the tool doesn't surface.

Closes #1266.

## Items to Confirm / Review

1. **Runtime plugin tool names in `TOOL_NAMES`** — preset names (\`manageBookmarks\`, \`manageTodoList\`, \`manageSpotify\`, \`manageRecipes\`, \`manageDebug\`) added to \`HOST_TOOL_NAMES\` for type-safe references in \`roles.ts\`. Worth confirming the spelling matches each plugin's \`TOOL_DEFINITION.name\` exactly (a typo here would silently make the role's gate filter the wrong name).
2. **Schema looser** — \`availablePluginsSchema\` no longer filters to \`isToolName\` membership. Reasoning in the source comment: user-installed runtime plugins publish their \`toolName\` at process start, not at compile time, so the previous filter unconditionally killed user-added plugins. The runtime gate at \`getActiveToolDescriptors\` is the actual choke point — unknown names there silently no-op rather than crash.
3. **Role updates** — preset runtime tool names added to \`general\` and \`debug\`. \`cookingCoach\` gains \`manageRecipes\` (it was relying on the now-removed auto-include). Only \`debug\` exposes \`manageDebug\`. Worth confirming this matches the intended UX surface.
4. **Two auto-include paths fixed** — both \`activeTools.ts\` and \`mcp-server.ts\` had auto-include logic. Mcp-server now relies entirely on \`PLUGIN_NAMES\` (set by parent based on \`getActivePlugins(role)\`) — which is the single source of truth.

## User Prompt

> packages/plugins 以下におかれたプラグイン（runtime plugin)は、すべてのロールでロードされるようになってしまっているとのことです。src/plugins 以下のプラグインと同様に、roles の available plugins で指定した場合のみロードするようになっていなければいけません。 という指摘があった。plugins以下のは、generalにだけ追加としておこうか。
>
> そうなると、workspaceにおくユーザpluginもかな。

User wants the consistent rule (preset + user-installed both gated). Default \`general\` role gets the preset names so out-of-the-box experience is preserved; user-installed plugins follow the same rule and the user adds them to a role via Settings → Roles.

## Implementation

| File | Change |
|---|---|
| \`server/agent/activeTools.ts\` | Runtime plugin loop applies \`allowed.has(def.name)\` gate (same as static-GUI / static-MCP loops). |
| \`server/agent/mcp-server.ts\` | Drop \`[...PLUGIN_NAMES, ...runtimeToolNames]\` union; \`PLUGIN_NAMES\` is the source of truth. |
| \`src/config/toolNames.ts\` | Preset runtime tool names added to \`HOST_TOOL_NAMES\`. |
| \`src/config/roles.ts\` | Schema keeps any non-empty string; \`general\` / \`cookingCoach\` / \`debug\` roles gain explicit preset entries. |
| \`test/agent/test_activeTools.ts\` | Flipped invariant: runtime plugins now gated. New regression test asserts a runtime plugin is EXCLUDED when the role doesn't list it. |
| \`test/roles/test_role_schema.ts\` | Updated lenient-parse tests: schema now keeps unknown names instead of dropping them; runtime gate handles the actual filtering. |

## Validation

- \`yarn typecheck\` ✅
- \`yarn lint\` ✅
- \`yarn test\` ✅
- New regression test pins the bug behaviour: \"EXCLUDES a runtime plugin when role.availablePlugins doesn't list its toolName\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)