### PR TITLE
chore: release v0.6.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,59 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [0.6.1] - 2026-05-10
+
+Two-day patch with several visible additions: a **wiki-syntax embed** family (`[[amazon:...]]`, `[[isbn:...]]`, `[[youtube:...]]`) usable across every markdown surface, **photo location capture** that pulls lat/lng from EXIF on every saved/forwarded image, and the **Map plugin** wired up to `@gui-chat-plugin/google-map`. Notifications fired by the `notify` MCP tool inside a chat now carry a click target back to the source session.
+
+### Highlights
+
+#### Wiki-syntax embeds (#1221)
+- Author markdown can now write `[[amazon:B00ICN066A]]`, `[[isbn:9780062316097]]`, or `[[youtube:dQw4w9WgXcQ]]` instead of raw URLs and get a clickable card / link / inline player. The renderer is registry-driven so future prefixes plug in cleanly.
+- **YouTube** plays inline via `youtube-nocookie.com` (no profile cookies until click), wrapped in a 16:9 box. **Amazon** shows the product cover thumbnail and links to the user's locale-appropriate storefront (`amazon.co.jp` for `ja`, `amazon.de` for `de`, …, falls back to `.com`). **ISBN** links to OpenLibrary.
+- External markdown links across wiki / files / chat artifact / sources / skill body now open in a new tab on click instead of being dead-clicks.
+
+#### Photo locations (#1222)
+- Every photo MulmoClaude saves (chat attachments, bridge-forwarded images, file uploads) now has its EXIF parsed: lat/lng + timestamp + camera + lens captured into a sidecar JSON under `data/photo-locations/`. HEIC / HEIF / TIFF supported alongside JPEG.
+- New built-in `managePhotoLocations` plugin lets the agent and user list / search / open photos by date, place, or camera.
+- Photos tab in Settings exposes the auto-capture toggle.
+- LINE bridge now forwards inbound image messages to the agent for the same processing.
+
+#### Map plugin (#1227)
+- Integrated `@gui-chat-plugin/google-map@0.4.0`. Add a Google Maps API key under Settings → Map and the agent can show locations, add markers, find places, and request directions inline in the chat canvas.
+- Available in `general` / `guide` / `debug` roles.
+
+#### Notifications open the source chat (#1262)
+- When the `notify` MCP tool fires from inside a chat session (typically a scheduled background chat reporting completion), the bell entry now carries a navigate target. Clicking opens that chat session instead of just dismissing.
+
+### Added
+- `[[amazon:...]]` / `[[isbn:...]]` / `[[youtube:...]]` wiki-embed renderers + extension registry (#1252 / #1261 / #1265 / #1269).
+- `managePhotoLocations` built-in plugin + Photos settings tab (#1247 / #1250 / #1251).
+- Map plugin wiring + Settings → Map tab + role enablement (#1241 / #1255 / `4c5b3e1`).
+- LINE bridge: inbound photo forwarding (#1264, `b3aab94`).
+- `notify` MCP tool: chat-session linkback via `navigateTarget` (#1262).
+- Plan files for #1221, #1222, #1244, and Encore Phase 2 (DSL + compiler + runtime architecture).
+
+### Changed
+- Runtime plugins relocated from `packages/<name>-plugin/` to `packages/plugins/<name>-plugin/` for a cleaner monorepo layout (#1242). No npm package names change.
+- `marked` config: external links inject `target="_blank" rel="noopener noreferrer"` automatically — wired into all 6 markdown / sheet renderers (#1252).
+- Roles now gate runtime plugins by `availablePlugins` (#1266); previously runtime plugins were universally exposed regardless of role.
+- DOMPurify call sites for skill body / manageSkills / sources description now go through a shared `sanitizeMarkdownHtml` wrapper that selectively allows YouTube embeds while keeping every other iframe stripped.
+
+### Fixed
+- StackView no longer over-grows iframes on remeasure or in stack layout — postMessage height path now caps at the viewport (`a2017c4` / `0ae82df` / `5817790` / `4aa6461`).
+- Map plugin: `googleMapKey` flows through StackView; View force-remounts when the key transitions null → set; key gated to `mapControl` only so other plugins can't read it (`f45067c` / `894ef3c` / `79a7cbf` / `1b04a34`).
+- presentMulmoScript: beat edits now persist across page reload + in-SPA nav (#1074, `adcca77` / `7dc74b0`).
+- Workspace links: percent-encoded image self-repair + multibyte URL routing fixed (#1102, `b8899fb` / `c8b14e0`).
+- Photo EXIF: lat/lng rescue path covers more vendor variants; HEIC/HEIF/TIFF registered for capture (#1222, `8c9aea7`).
+- mulmoclaude launcher deps: `@gui-chat-plugin/google-map` and `exifr` declared so the published tarball boots (`c798a20` / `5e17513`).
+- CI cache path now includes `packages/plugins/*/dist` after the workspace move (`830a5145`).
+
+### Security
+- DOMPurify wrapper enforces a strict allowlist for iframes — only `https://www.youtube-nocookie.com/embed/<11-char-id>` survives the hook; foreign hosts and the cookie-tracking `youtube.com` host are stripped.
+- Map plugin: `googleMapKey` only reaches the `mapControl` plugin; other plugins receive `null` (`1b04a34`).
+
+---
+
 ## [0.6.0] - 2026-05-08
 
 A two-week release. The themes: a usable **Accounting plugin**, the start of the **personal-use plugin sets** (recipe-book, reading-list / articles / quotes, map), a **Memory system** with proactive recall and edit UI, the **Notifier (Encore) prototype**, the **Spotify plugin**, **MulmoScript** quality-of-life polish, and a swarm of dev-experience wins.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -113,7 +113,7 @@ Options:
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.6.0");
+  console.log("mulmoclaude 0.6.1");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Patch release. Two days since v0.6.0 (68 non-merge commits) — the headline additions are the **wiki-syntax embed family** (`[[amazon:...]]`, `[[isbn:...]]`, `[[youtube:...]]`), **photo location capture** from EXIF, the **Map plugin** integration, and **notification click-to-open-chat**.
- Version bumped in 3 files (root `package.json`, `packages/mulmoclaude/package.json`, `packages/mulmoclaude/bin/mulmoclaude.js`).
- CHANGELOG entry added at the top with Highlights / Added / Changed / Fixed / Security.

## Items to Confirm / Review

- **0.6.1 vs 0.7.0 semver**: chose patch per the user's request, even though wiki-embeds + photo locations + Map plugin are arguably feature additions (would justify minor). Tagging accordingly.
- **CHANGELOG attribution**: see #1221 (embeds), #1222 (photo), #1227 (map), #1262 (notify), #1242 (packages/plugins refactor), #1266 (role gating), #1074 / #1102 (bug fixes). Cross-checked against `git log v0.6.0..HEAD`.
- **No breaking changes**: roles + plugin loading are stricter (#1266) but the change is the documented intent (runtime plugins should respect role allowlist), not an API break.
- **Launcher version trio kept in sync** — root + `packages/mulmoclaude/package.json` + `packages/mulmoclaude/bin/mulmoclaude.js` console string. CI smoke checks the boot string matches.

## Test plan

- [ ] CI green on this PR (lint_test ×6, smoke, e2e ×2, yarn4_smoke, etc.)
- [ ] After merge: tag `v0.6.1` + push, GitHub release created, then `npm publish` for the launcher tarball (separate `/publish-mulmoclaude` skill flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wiki-syntax embed renderers for Amazon, ISBN, and YouTube content
  * Enabled EXIF-based photo location capture with sidecar storage
  * Integrated map plugin with location visualization
  * Notification linkback now directs to originating chat session

* **Security**
  * Enhanced iframe and embed sanitization
  * Implemented iframe allowlisting and plugin data scoping for improved security

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1271)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->