### PR TITLE
Fix skill invocation top align

### DIFF
--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -13,7 +13,11 @@
         <details class="group">
           <summary class="cursor-pointer list-none p-4 flex items-start gap-3 hover:bg-purple-100/40 rounded-lg" :data-testid="'skill-summary-' + skillName">
             <span class="material-icons text-purple-600 text-base mt-0.5 shrink-0">extension</span>
-            <div class="flex-1 min-w-0">
+            <!-- `grow shrink basis-0` instead of `flex-1` is intentional: StackView's
+                 `.stack-natural :deep(.flex-1) { flex: 0 0 auto !important }` rule (intended
+                 for vertical-flex content height) would otherwise pin this horizontal flex
+                 child to its content width, breaking long-description wrapping in stack mode. -->
+            <div class="grow shrink basis-0 min-w-0">
               <div class="flex items-baseline gap-2 flex-wrap">
                 <span class="font-medium text-purple-900">{{ skillName }}</span>
                 <span v-if="skillScope !== 'unknown'" class="text-[10px] uppercase tracking-wide text-purple-500 px-1.5 py-0.5 rounded-full bg-purple-100">

--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -1,17 +1,11 @@
 <template>
-  <!-- The canvas reserves the full pane height for the selected
-       result regardless of how much vertical space it actually
-       needs. Without explicit centering, a short collapsed skill
-       card sits top-anchored with a tall empty void below. Outer
-       is `h-full flex flex-col` so the inner can use `my-auto` to
-       vertically centre when the card is short, while still
-       falling back to natural top-alignment + scrolling when the
-       user expands the markdown body and content overflows
-       (auto-margins collapse to 0 in the overflow case, unlike
-       `justify-content: center` which would clip the top of tall
-       content out of reach). #1218 follow-up. -->
+  <!-- Top-anchored layout: the skill card sits flush against the
+       canvas top to match the other document-like plugins
+       (markdown, presentDocument, …). The canvas may reserve more
+       vertical space than the collapsed card needs; the empty pane
+       below is intentional and consistent with those siblings. -->
   <div class="h-full flex flex-col overflow-y-auto p-6">
-    <div class="my-auto max-w-3xl mx-auto w-full">
+    <div class="max-w-3xl mx-auto w-full">
       <div class="rounded-lg border border-purple-200 bg-purple-50 shadow-sm">
         <!-- Collapsed header — clickable. The whole card collapses by
              default; clicking expands the skill body. The use of


### PR DESCRIPTION
## Summary

Skill 呼び出し（`/foo` 系の slash command）の結果カードに関する小さな UI 修正を 2 つ。

1. **上端揃え**: 単一キャンバス表示（`?result=<id>`）で skill カードが縦中央寄せになっていたのを上端揃えに変更。他の document 系プラグイン（markdown / presentDocument 等）と挙動を揃えました。
2. **折り返し修正**: stack view で skill カードの長い description 文字列が右端で折り返さず溢れていた不具合を修正。

<img width="1109" height="203" alt="image" src="https://github.com/user-attachments/assets/1de32192-a5dd-4f20-a171-a06a2cc60006" />
<img width="1092" height="250" alt="image" src="https://github.com/user-attachments/assets/4542fb9e-006d-4423-9532-e49477479521" />

変更前

<img width="1102" height="761" alt="CleanShot 2026-05-11 at 01 01 33" src="https://github.com/user-attachments/assets/29d7df3a-d0b8-4a00-9774-ef573648f985" />

<img width="1089" height="239" alt="image" src="https://github.com/user-attachments/assets/5cecd3a7-be9d-435e-b45e-205f8d56fcec" />


## Items to Confirm / Review

- **CSS の依存関係**: `src/components/StackView.vue:486-488` の `.stack-natural :deep(.flex-1) { flex: 0 0 auto !important }` ルールが、本来は `presentDocument` 等の縦 flex コンテンツを自然な高さで流すために存在しているが、skill summary 内の横 flex 子要素 (`flex-1 min-w-0`) も巻き込んでしまい折り返しを壊していました。今回はスコープを広げず skill 側で `flex-1` を `grow shrink basis-0`（同等の `flex: 1 1 0%` だがクラス名が `.flex-1` セレクタにマッチしない）に置き換える局所修正に留めています。
- **長期的なフォローアップ候補**: StackView 側のセレクタを縦 flex コンテキストにのみ効くよう絞り込めば、他プラグインで類似事故を未然に防げます（今回スコープ外）。

## User Prompt

> skill 呼び出しのこのページだけだけど、他のページに合わせて上下の中間ではなくて、上端合わせにして
>
> （続けて、stack view で description が折り返さずはみ出している件も同時に修正してほしい）

## Implementation

### 1. 上端揃え (commit `e1cabac1`)

[`src/plugins/skill/View.vue`](src/plugins/skill/View.vue) の内側ラッパーから `my-auto` を削除。コメントも上端揃えの意図を反映するように更新。

```diff
- <div class="my-auto max-w-3xl mx-auto w-full">
+ <div class="max-w-3xl mx-auto w-full">
```

`my-auto` は元々「短い skill カードを縦中央寄せにし、コンテンツが伸びたら top-anchored に戻す」意図で入れられていましたが（`#1218` follow-up）、他プラグインと挙動が揃わないため削除しました。

### 2. 折り返し修正 (commit `22bee7ee`)

[`src/plugins/skill/View.vue`](src/plugins/skill/View.vue) の `<summary>` 内、description 文字列を含む中央列のクラスを変更:

```diff
- <div class="flex-1 min-w-0">
+ <div class="grow shrink basis-0 min-w-0">
```

`grow shrink basis-0` は `flex: 1 1 0%` を 3 つのアトミックなユーティリティに分解したもの。挙動は `flex-1` と等価ですが、`StackView.vue` の `.stack-natural :deep(.flex-1)` セレクタにマッチしないため、stack mode でも子要素が縮んで折り返しが効きます。

## Cross-review

このブランチは Codex + Claude のクロスレビュー（`/codex-cross-review` skill）を 2 イテレーション実施。両者 LGTM。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted skill card layout to align from the top when collapsed, improving visual presentation
  * Enhanced text wrapping behavior in the skill card title and description area

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1276)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->