### PR TITLE
refactor(routes): asyncHandler batch C — notifier/scheduler/sessions/config + files.ts hardening

### DIFF
--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -17,6 +17,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { isRecord } from "../../utils/types.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { log } from "../../system/logger/index.js";
+import { asyncHandler } from "../../utils/asyncHandler.js";
 import { loadCustomDirs, saveCustomDirs, ensureCustomDirs, validateCustomDirs, type CustomDirEntry } from "../../workspace/custom-dirs.js";
 import { loadReferenceDirs, saveReferenceDirs, validateReferenceDirs, type ReferenceDirEntry } from "../../workspace/reference-dirs.js";
 
@@ -67,16 +68,18 @@ function parseMcpPayloadOrFail(res: ConfigRes, servers: McpServerEntry[]): McpCo
   }
 }
 
-// Run a filesystem save. On failure, respond 500 with the error's
-// message and return false so the caller can early-return. Returns
-// true on success.
+// Run a filesystem save. On failure, log the raw error server-side
+// (full triage detail kept in logs), respond 500 with the safe
+// `fallback` message, and return false so the caller can early-return.
+// Returns true on success. The raw `err.message` deliberately doesn't
+// reach the client — same threat model as `asyncHandler`.
 function runSaveOrFail(res: ConfigRes, save: () => void, fallback: string): boolean {
   try {
     save();
     return true;
   } catch (err) {
     log.error("config", `save failed: ${fallback}`, { error: errorMessage(err) });
-    serverError(res, errorMessage(err, fallback));
+    serverError(res, fallback);
     return false;
   }
 }
@@ -183,30 +186,29 @@ router.get(API_ROUTES.config.workspaceDirs, (_req: Request, res: Response<{ dirs
 
 router.put(
   API_ROUTES.config.workspaceDirs,
-  (req: Request<unknown, unknown, { dirs: unknown }>, res: Response<{ dirs: CustomDirEntry[] } | ConfigErrorResponse>) => {
-    const { body } = req;
-    log.info("config", "PUT workspace-dirs: start");
-    if (!isRecord(body) || !("dirs" in body)) {
-      log.warn("config", "PUT workspace-dirs: invalid envelope");
-      badRequest(res, "expected { dirs: [...] }");
-      return;
-    }
-    const result = validateCustomDirs(body.dirs);
-    if ("error" in result) {
-      log.warn("config", "PUT workspace-dirs: validation failed", { error: result.error });
-      badRequest(res, result.error);
-      return;
-    }
-    try {
+  asyncHandler<Request<unknown, unknown, { dirs: unknown }>, Response<{ dirs: CustomDirEntry[] } | ConfigErrorResponse>>(
+    "config",
+    "save failed",
+    async (req, res) => {
+      const { body } = req;
+      log.info("config", "PUT workspace-dirs: start");
+      if (!isRecord(body) || !("dirs" in body)) {
+        log.warn("config", "PUT workspace-dirs: invalid envelope");
+        badRequest(res, "expected { dirs: [...] }");
+        return;
+      }
+      const result = validateCustomDirs(body.dirs);
+      if ("error" in result) {
+        log.warn("config", "PUT workspace-dirs: validation failed", { error: result.error });
+        badRequest(res, result.error);
+        return;
+      }
       saveCustomDirs(result.entries);
       ensureCustomDirs(result.entries);
       log.info("config", "PUT workspace-dirs: ok", { dirs: result.entries.length });
       res.json({ dirs: result.entries });
-    } catch (err) {
-      log.error("config", "PUT workspace-dirs: threw", { error: errorMessage(err) });
-      serverError(res, errorMessage(err, "save failed"));
-    }
-  },
+    },
+  ),
 );
 
 // ── Reference directories (#455) ────────────────────────────────
@@ -217,29 +219,28 @@ router.get(API_ROUTES.config.referenceDirs, (_req: Request, res: Response<{ dirs
 
 router.put(
   API_ROUTES.config.referenceDirs,
-  (req: Request<unknown, unknown, { dirs: unknown }>, res: Response<{ dirs: ReferenceDirEntry[] } | ConfigErrorResponse>) => {
-    const { body } = req;
-    log.info("config", "PUT reference-dirs: start");
-    if (!isRecord(body) || !("dirs" in body)) {
-      log.warn("config", "PUT reference-dirs: invalid envelope");
-      badRequest(res, "expected { dirs: [...] }");
-      return;
-    }
-    const result = validateReferenceDirs(body.dirs);
-    if ("error" in result) {
-      log.warn("config", "PUT reference-dirs: validation failed", { error: result.error });
-      badRequest(res, result.error);
-      return;
-    }
-    try {
+  asyncHandler<Request<unknown, unknown, { dirs: unknown }>, Response<{ dirs: ReferenceDirEntry[] } | ConfigErrorResponse>>(
+    "config",
+    "save failed",
+    async (req, res) => {
+      const { body } = req;
+      log.info("config", "PUT reference-dirs: start");
+      if (!isRecord(body) || !("dirs" in body)) {
+        log.warn("config", "PUT reference-dirs: invalid envelope");
+        badRequest(res, "expected { dirs: [...] }");
+        return;
+      }
+      const result = validateReferenceDirs(body.dirs);
+      if ("error" in result) {
+        log.warn("config", "PUT reference-dirs: validation failed", { error: result.error });
+        badRequest(res, result.error);
+        return;
+      }
       saveReferenceDirs(result.entries);
       log.info("config", "PUT reference-dirs: ok", { dirs: result.entries.length });
       res.json({ dirs: result.entries });
-    } catch (err) {
-      log.error("config", "PUT reference-dirs: threw", { error: errorMessage(err) });
-      serverError(res, errorMessage(err, "save failed"));
-    }
-  },
+    },
+  ),
 );
 
 router.get(API_ROUTES.config.schedulerOverrides, (_req: Request, res: Response<{ overrides: ScheduleOverrides }>) => {
@@ -248,22 +249,24 @@ router.get(API_ROUTES.config.schedulerOverrides, (_req: Request, res: Response<{
 
 router.put(
   API_ROUTES.config.schedulerOverrides,
-  async (req: Request<unknown, unknown, { overrides: unknown }>, res: Response<{ overrides: ScheduleOverrides } | ConfigErrorResponse>) => {
-    const { body } = req;
-    log.info("config", "PUT scheduler-overrides: start");
-    if (!isRecord(body) || !("overrides" in body)) {
-      log.warn("config", "PUT scheduler-overrides: invalid envelope");
-      badRequest(res, "expected { overrides: { ... } }");
-      return;
-    }
-    const raw = body.overrides;
-    if (!isRecord(raw)) {
-      log.warn("config", "PUT scheduler-overrides: overrides not an object");
-      badRequest(res, "overrides must be an object");
-      return;
-    }
-    const overrides = raw as ScheduleOverrides;
-    try {
+  asyncHandler<Request<unknown, unknown, { overrides: unknown }>, Response<{ overrides: ScheduleOverrides } | ConfigErrorResponse>>(
+    "config",
+    "save failed",
+    async (req, res) => {
+      const { body } = req;
+      log.info("config", "PUT scheduler-overrides: start");
+      if (!isRecord(body) || !("overrides" in body)) {
+        log.warn("config", "PUT scheduler-overrides: invalid envelope");
+        badRequest(res, "expected { overrides: { ... } }");
+        return;
+      }
+      const raw = body.overrides;
+      if (!isRecord(raw)) {
+        log.warn("config", "PUT scheduler-overrides: overrides not an object");
+        badRequest(res, "overrides must be an object");
+        return;
+      }
+      const overrides = raw as ScheduleOverrides;
       saveSchedulerOverrides(overrides);
 
       // Apply to running task-manager immediately
@@ -283,11 +286,8 @@ router.put(
 
       log.info("config", "PUT scheduler-overrides: ok", { tasks: Object.keys(overrides).length });
       res.json({ overrides: loadSchedulerOverrides() });
-    } catch (err) {
-      log.error("config", "PUT scheduler-overrides: threw", { error: errorMessage(err) });
-      serverError(res, errorMessage(err, "save failed"));
-    }
-  },
+    },
+  ),
 );
 
 export default router;

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -341,7 +341,11 @@ function pipeWithErrorHandling(stream: ReadStream, res: Response<ErrorResponse>)
       res.destroy(err);
       return;
     }
-    serverError(res, `Failed to read file: ${err.message}`);
+    // The raw `err.message` carries filesystem paths / system error
+    // detail — keep it in the server log but ship a stable opaque
+    // string to the client. Same threat model as `asyncHandler`.
+    log.error("files", "raw stream error", { error: errorMessage(err) });
+    serverError(res, "Failed to read file");
   });
   stream.pipe(res);
 }
@@ -497,7 +501,7 @@ router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown,
     res.json(tree);
   } catch (err) {
     log.error("files", "GET tree: threw", { error: errorMessage(err) });
-    serverError(res, `Failed to read workspace: ${errorMessage(err)}`);
+    serverError(res, "Failed to read workspace");
   }
 });
 
@@ -560,7 +564,7 @@ router.get(API_ROUTES.files.dir, async (req: Request<object, unknown, unknown, P
     res.json(listing);
   } catch (err) {
     log.error("files", "GET dir: threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
-    serverError(res, `Failed to read directory: ${errorMessage(err)}`);
+    serverError(res, "Failed to read directory");
   }
 });
 
@@ -700,7 +704,7 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
     content = readFileSync(absPath, "utf-8");
   } catch (err) {
     log.error("files", "GET content: read threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
-    serverError(res, `Failed to read file: ${errorMessage(err)}`);
+    serverError(res, "Failed to read file");
     return;
   }
   log.info("files", "GET content: ok", { pathPreview: previewSnippet(relPath), bytes: stat.size });
@@ -818,7 +822,7 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
     await writeFileContent(resolved.absPath, content);
   } catch (err) {
     log.error("files", "PUT content: write threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
-    serverError(res, `Failed to write file: ${errorMessage(err)}`);
+    serverError(res, "Failed to write file");
     return;
   }
   const fresh = await statSafeAsync(resolved.absPath);

--- a/server/api/routes/notifier.ts
+++ b/server/api/routes/notifier.ts
@@ -24,7 +24,7 @@ import { Router, type Request, type Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { cancel, clear, listAll, listHistory } from "../../notifier/engine.js";
 import type { NotifierEntry, NotifierHistoryEntry } from "../../notifier/types.js";
-import { log } from "../../system/logger/index.js";
+import { asyncHandler } from "../../utils/asyncHandler.js";
 
 interface DispatchBody {
   action?: unknown;
@@ -40,10 +40,17 @@ function isNonEmptyString(value: unknown): value is string {
 
 const notifierRouter: Router = Router();
 
-notifierRouter.post(API_ROUTES.notifier.dispatch, async (req: Request<object, DispatchResponse, DispatchBody>, res: Response<DispatchResponse>) => {
-  const body = req.body ?? {};
-  const { action } = body;
-  try {
+// Detailed error stays in the server log for triage (via asyncHandler's
+// `log.error`); the HTTP response gets the opaque "internal error"
+// message so a parser-thrown filesystem path / internal stack frame
+// can't leak to the client. Echoing `String(err)` would have given
+// e.g. `Error: ENOENT, open '/Users/<...>/active.json'` to anyone
+// holding the bearer token (CodeRabbit review on PR #1196).
+notifierRouter.post(
+  API_ROUTES.notifier.dispatch,
+  asyncHandler<Request<object, DispatchResponse, DispatchBody>, Response<DispatchResponse>>("notifier-route", "internal error", async (req, res) => {
+    const body = req.body ?? {};
+    const { action } = body;
     switch (action) {
       case "clear": {
         if (!isNonEmptyString(body.id)) {
@@ -80,19 +87,7 @@ notifierRouter.post(API_ROUTES.notifier.dispatch, async (req: Request<object, Di
       default:
         res.status(400).json({ error: `unknown action: ${typeof action === "string" ? action : "<missing>"}` });
     }
-  } catch (err) {
-    // Detailed error stays in the server log for triage; the HTTP
-    // response gets an opaque message so a parser-thrown filesystem
-    // path / internal stack frame can't leak to the client. Echoing
-    // `String(err)` would have given e.g. `Error: ENOENT, open
-    // '/Users/<...>/active.json'` to anyone holding the bearer token
-    // (CodeRabbit review on PR #1196).
-    log.error("notifier-route", "dispatch failed", {
-      action: typeof action === "string" ? action : "<unknown>",
-      error: String(err),
-    });
-    res.status(500).json({ error: "internal error" });
-  }
-});
+  }),
+);
 
 export default notifierRouter;

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -10,8 +10,8 @@ import { saveUserTasks } from "../../utils/files/user-tasks-io.js";
 import { startChat } from "./agent.js";
 import { log } from "../../system/logger/index.js";
 import { SCHEDULER_ACTIONS, TASK_ACTIONS } from "../../../src/plugins/scheduler/actions.js";
-import { badRequest, notFound, serverError } from "../../utils/httpError.js";
-import { errorMessage } from "../../utils/errors.js";
+import { badRequest, notFound } from "../../utils/httpError.js";
+import { asyncHandler } from "../../utils/asyncHandler.js";
 import { makeUuid } from "../../utils/id.js";
 
 const router = Router();
@@ -47,118 +47,120 @@ interface SchedulerBody extends SchedulerActionInput {
 bindRoute(
   router,
   API_ROUTES.scheduler.dispatch,
-  async (req: Request<object, unknown, SchedulerBody>, res: Response<DispatchSuccessResponse<ScheduledItem> | DispatchErrorResponse | unknown>) => {
-    const { action, ...input } = req.body;
+  asyncHandler<Request<object, unknown, SchedulerBody>, Response<DispatchSuccessResponse<ScheduledItem> | DispatchErrorResponse | unknown>>(
+    "scheduler",
+    "Internal server error",
+    async (req, res) => {
+      const { action, ...input } = req.body;
 
-    // Route task actions to the user-task subsystem
-    if (TASK_ACTIONS.has(action)) {
-      await handleTaskAction(action, input, res);
-      return;
-    }
+      // Route task actions to the user-task subsystem
+      if (TASK_ACTIONS.has(action)) {
+        await handleTaskAction(action, input, res);
+        return;
+      }
 
-    // Calendar item actions (existing behavior)
-    const items = loadItems();
-    const result = dispatchScheduler(action, items, input);
-    respondWithDispatchResult(res, result, {
-      shouldPersist: action !== SCHEDULER_ACTIONS.show,
-      instructions: "Display the updated scheduler to the user.",
-      persist: saveItems,
-    });
-  },
+      // Calendar item actions (existing behavior)
+      const items = loadItems();
+      const result = dispatchScheduler(action, items, input);
+      respondWithDispatchResult(res, result, {
+        shouldPersist: action !== SCHEDULER_ACTIONS.show,
+        instructions: "Display the updated scheduler to the user.",
+        persist: saveItems,
+      });
+    },
+  ),
 );
 
 async function handleTaskAction(action: string, input: Record<string, unknown>, res: Response): Promise<void> {
   log.info("scheduler", "task action: start", { action });
-  try {
-    if (action === SCHEDULER_ACTIONS.listTasks) {
-      const tasks = loadUserTasks();
-      log.info("scheduler", "task action: listTasks ok", { tasks: tasks.length });
-      res.json({
-        uuid: makeUuid(),
-        message: `${tasks.length} scheduled task(s) found.`,
-        data: { tasks },
-      });
-      return;
-    }
-
-    if (action === SCHEDULER_ACTIONS.createTask) {
-      const result = validateAndCreate(input);
-      if (result.kind === "error") {
-        log.warn("scheduler", "task action: createTask validation failed", { error: result.error });
-        badRequest(res, result.error);
-        return;
-      }
-      const tasks = loadUserTasks();
-      tasks.push(result.task);
-      await saveUserTasks(tasks);
-      await refreshUserTasks();
-      log.info("scheduler", "task action: createTask ok", { id: result.task.id, name: result.task.name });
-      res.json({
-        uuid: makeUuid(),
-        message: `Task "${result.task.name}" created and scheduled.`,
-        data: { task: result.task },
-      });
-      return;
-    }
-
-    if (action === SCHEDULER_ACTIONS.deleteTask) {
-      const taskId = typeof input.id === "string" ? input.id : "";
-      const tasks = loadUserTasks();
-      const idx = tasks.findIndex((task) => task.id === taskId);
-      if (idx === -1) {
-        log.warn("scheduler", "task action: deleteTask not found", { taskId });
-        notFound(res, `task not found: ${taskId}`);
-        return;
-      }
-      const { name } = tasks[idx];
-      tasks.splice(idx, 1);
-      await saveUserTasks(tasks);
-      await refreshUserTasks();
-      log.info("scheduler", "task action: deleteTask ok", { taskId, name });
-      res.json({
-        uuid: makeUuid(),
-        message: `Task "${name}" deleted.`,
-        data: { deleted: taskId },
-      });
-      return;
-    }
-
-    if (action === SCHEDULER_ACTIONS.runTask) {
-      const taskId = typeof input.id === "string" ? input.id : "";
-      const tasks = loadUserTasks();
-      const task = tasks.find((candidate) => candidate.id === taskId);
-      if (!task) {
-        notFound(res, `task not found: ${taskId}`);
-        return;
-      }
-      const chatSessionId = makeUuid();
-      log.info("scheduler", "manual run via MCP", {
-        name: task.name,
-        chatSessionId,
-      });
-      startChat({
-        message: task.prompt,
-        roleId: task.roleId,
-        chatSessionId,
-        origin: SESSION_ORIGINS.scheduler,
-      }).catch((err) => {
-        log.error("scheduler", "manual run failed", {
-          error: String(err),
-        });
-      });
-      res.json({
-        uuid: makeUuid(),
-        message: `Task "${task.name}" triggered.`,
-        data: { triggered: taskId, chatSessionId },
-      });
-      return;
-    }
-
-    badRequest(res, `unknown task action: ${action}`);
-  } catch (err) {
-    log.error("scheduler", "task action failed", { error: errorMessage(err) });
-    serverError(res, "Internal server error");
+  // Errors bubble up to the asyncHandler wrapper on the dispatch route,
+  // which logs at `log.error("scheduler", "handler threw", …)` and
+  // returns a generic 500. No inner try/catch needed here.
+  if (action === SCHEDULER_ACTIONS.listTasks) {
+    const tasks = loadUserTasks();
+    log.info("scheduler", "task action: listTasks ok", { tasks: tasks.length });
+    res.json({
+      uuid: makeUuid(),
+      message: `${tasks.length} scheduled task(s) found.`,
+      data: { tasks },
+    });
+    return;
   }
+
+  if (action === SCHEDULER_ACTIONS.createTask) {
+    const result = validateAndCreate(input);
+    if (result.kind === "error") {
+      log.warn("scheduler", "task action: createTask validation failed", { error: result.error });
+      badRequest(res, result.error);
+      return;
+    }
+    const tasks = loadUserTasks();
+    tasks.push(result.task);
+    await saveUserTasks(tasks);
+    await refreshUserTasks();
+    log.info("scheduler", "task action: createTask ok", { id: result.task.id, name: result.task.name });
+    res.json({
+      uuid: makeUuid(),
+      message: `Task "${result.task.name}" created and scheduled.`,
+      data: { task: result.task },
+    });
+    return;
+  }
+
+  if (action === SCHEDULER_ACTIONS.deleteTask) {
+    const taskId = typeof input.id === "string" ? input.id : "";
+    const tasks = loadUserTasks();
+    const idx = tasks.findIndex((task) => task.id === taskId);
+    if (idx === -1) {
+      log.warn("scheduler", "task action: deleteTask not found", { taskId });
+      notFound(res, `task not found: ${taskId}`);
+      return;
+    }
+    const { name } = tasks[idx];
+    tasks.splice(idx, 1);
+    await saveUserTasks(tasks);
+    await refreshUserTasks();
+    log.info("scheduler", "task action: deleteTask ok", { taskId, name });
+    res.json({
+      uuid: makeUuid(),
+      message: `Task "${name}" deleted.`,
+      data: { deleted: taskId },
+    });
+    return;
+  }
+
+  if (action === SCHEDULER_ACTIONS.runTask) {
+    const taskId = typeof input.id === "string" ? input.id : "";
+    const tasks = loadUserTasks();
+    const task = tasks.find((candidate) => candidate.id === taskId);
+    if (!task) {
+      notFound(res, `task not found: ${taskId}`);
+      return;
+    }
+    const chatSessionId = makeUuid();
+    log.info("scheduler", "manual run via MCP", {
+      name: task.name,
+      chatSessionId,
+    });
+    startChat({
+      message: task.prompt,
+      roleId: task.roleId,
+      chatSessionId,
+      origin: SESSION_ORIGINS.scheduler,
+    }).catch((err) => {
+      log.error("scheduler", "manual run failed", {
+        error: String(err),
+      });
+    });
+    res.json({
+      uuid: makeUuid(),
+      message: `Task "${task.name}" triggered.`,
+      data: { triggered: taskId, chatSessionId },
+    });
+    return;
+  }
+
+  badRequest(res, `unknown task action: ${action}`);
 }
 
 export default router;

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -25,6 +25,7 @@ import { ONE_DAY_MS } from "../../utils/time.js";
 import { encodeCursor, parseCursor, sessionChangeMs } from "./sessionsCursor.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
+import { asyncHandler } from "../../utils/asyncHandler.js";
 
 interface SessionMeta {
   roleId: string;
@@ -355,14 +356,13 @@ router.post(API_ROUTES.sessions.markRead, async (req: Request<SessionIdParams>, 
 // Toggle the user-set bookmark flag on a session's meta sidecar.
 router.post(
   API_ROUTES.sessions.bookmark,
-  async (
-    req: Request<SessionIdParams, { ok: boolean } | SessionErrorResponse, { bookmarked: boolean }>,
-    res: Response<{ ok: boolean } | SessionErrorResponse>,
-  ) => {
-    const { id: sessionId } = req.params;
-    const bookmarked = Boolean(req.body?.bookmarked);
-    log.info("sessions", "bookmark: start", { sessionId, bookmarked });
-    try {
+  asyncHandler<Request<SessionIdParams, { ok: boolean } | SessionErrorResponse, { bookmarked: boolean }>, Response<{ ok: boolean } | SessionErrorResponse>>(
+    "sessions",
+    "Failed to update bookmark",
+    async (req, res) => {
+      const { id: sessionId } = req.params;
+      const bookmarked = Boolean(req.body?.bookmarked);
+      log.info("sessions", "bookmark: start", { sessionId, bookmarked });
       await updateIsBookmarked(sessionId, bookmarked);
       // Meta-mtime bumps on the write — cursor diff will pick up the
       // change on the next refetch — but every other tab also needs
@@ -370,11 +370,8 @@ router.post(
       publishSessionsChanged();
       log.info("sessions", "bookmark: ok", { sessionId, bookmarked });
       res.json({ ok: true });
-    } catch (err) {
-      log.error("sessions", "bookmark: threw", { sessionId, error: errorMessage(err) });
-      res.status(500).json({ error: "Failed to update bookmark" });
-    }
-  },
+    },
+  ),
 );
 
 // Hard-delete a session: remove the jsonl, meta sidecar, AND the
@@ -395,24 +392,22 @@ router.post(
 //   3. Only after disk is clean do we evict from the store and fire
 //      `notifySessionsChanged({ deletedIds })`. Now the broadcast is
 //      a truthful statement.
-router.delete(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res: Response<{ ok: boolean } | SessionErrorResponse>) => {
-  const { id: sessionId } = req.params;
-  log.info("sessions", "delete: start", { sessionId });
-  if (getSession(sessionId)?.isRunning) {
-    log.warn("sessions", "delete: refused — session running", { sessionId });
-    res.status(409).json({ error: "Session is running. Cancel the run before deleting." });
-    return;
-  }
-  try {
+router.delete(
+  API_ROUTES.sessions.detail,
+  asyncHandler<Request<SessionIdParams>, Response<{ ok: boolean } | SessionErrorResponse>>("sessions", "Failed to delete session", async (req, res) => {
+    const { id: sessionId } = req.params;
+    log.info("sessions", "delete: start", { sessionId });
+    if (getSession(sessionId)?.isRunning) {
+      log.warn("sessions", "delete: refused — session running", { sessionId });
+      res.status(409).json({ error: "Session is running. Cancel the run before deleting." });
+      return;
+    }
     await deleteSessionFiles(sessionId);
     await removeSessionFromIndex(workspacePath, sessionId);
     evictSession(sessionId);
     log.info("sessions", "delete: ok", { sessionId });
     res.json({ ok: true });
-  } catch (err) {
-    log.error("sessions", "delete: threw", { sessionId, error: errorMessage(err) });
-    res.status(500).json({ error: "Failed to delete session" });
-  }
-});
+  }),
+);
 
 export default router;

--- a/server/utils/asyncHandler.ts
+++ b/server/utils/asyncHandler.ts
@@ -36,12 +36,23 @@ import { log } from "../system/logger/index.js";
 import { errorMessage } from "./errors.js";
 import { serverError } from "./httpError.js";
 
-// Generics intentionally use `Request` / `Response` shapes without
-// the upstream `Request<ParamsDictionary>` constraint — callers like
-// `Request<object, unknown, MyBody>` use `object` for params, which
-// is incompatible with Express's default `ParamsDictionary` upper
-// bound. Mirrors the existing `wrapPluginExecute` signature.
-export function asyncHandler<TReq extends Request<unknown, unknown, unknown, unknown> = Request, TRes extends Response = Response>(
+// The TReq / TRes generics intentionally have NO upper-bound constraint.
+//
+// Express's `Request<P, ResBody, ReqBody, Query>` interface uses these
+// type parameters in mixed variance positions (ResBody is
+// contravariant via `res.json(body: ResBody)`, P is constrained to
+// `ParamsDictionary` in the default form). Adding any `extends
+// Request<…>` upper bound here would reject perfectly valid call sites
+// like `Request<object, unknown, MyBody>` or `Request<SessionIdParams,
+// ResBody, ReqBody>` because of invariance — TS treats `object` /
+// concrete-ResBody as incompatible with the default's `ParamsDictionary`
+// / `any` slots.
+//
+// The wrapper doesn't dereference req / res itself, so dropping the
+// upper bound costs nothing — call sites still get full Express types
+// via the explicit type arguments. Mirrors `wrapPluginExecute` in
+// `server/api/routes/plugins.ts`, which this module generalises.
+export function asyncHandler<TReq = Request, TRes = Response>(
   namespace: string,
   fallbackMessage: string,
   handler: (req: TReq, res: TRes) => Promise<void>,
@@ -50,9 +61,14 @@ export function asyncHandler<TReq extends Request<unknown, unknown, unknown, unk
     try {
       await handler(req, res);
     } catch (err) {
-      log.error(namespace, "handler threw", { route: req.path, error: errorMessage(err) });
-      if (!res.headersSent) {
-        serverError(res, fallbackMessage);
+      // `req` / `res` are typed loosely here so the wrapper can stay
+      // open to any concrete Express Request / Response shape; we
+      // narrow back to the runtime contract just for the catch path.
+      const expressReq = req as Request;
+      const expressRes = res as Response;
+      log.error(namespace, "handler threw", { route: expressReq.path, error: errorMessage(err) });
+      if (!expressRes.headersSent) {
+        serverError(expressRes, fallbackMessage);
       }
     }
   };


### PR DESCRIPTION
## Summary

Follow-up to #1281. Continues the `asyncHandler` migration across the
remaining route files with the same security guarantee: detailed error
text stays in `log.error`, clients get a stable safe fallback message.

## Items to Confirm / Review

1. **`files.ts` does NOT migrate to asyncHandler** — its routes have
   many early-return branches (404 / 400 paths interleaved with the
   try block). Wrapping each would be a larger refactor. Instead the
   PR strips the leaked `errorMessage(err)` from each 500 response,
   matching the new discipline. Confirm this is acceptable scope.

2. **`scheduler.ts` removes `handleTaskAction`'s inner try/catch** —
   errors now bubble to the wrapper on the parent dispatch route.
   Confirm that's correct (no callers depended on the inline catch).

3. **`config.ts` keeps `runSaveOrFail` helper** for the synchronous
   PUT routes (base / settings / mcp). The helper is updated to send
   the safe `fallback` instead of `errorMessage(err, fallback)` to
   the client, mirroring asyncHandler.

## User Prompt

\`\`\`
DRY refactoring — finish batch B's asyncHandler migration completely
(option (a) "finish #4"). Carry the same safe-fallback discipline
into every remaining route file.
\`\`\`

## Implementation

Migrated to asyncHandler:

- `notifier.ts` (1 route): `"internal error"` — preserves the
  CodeRabbit-driven opaque message from #1196.
- `scheduler.ts` (1 dispatch route + inner `handleTaskAction`):
  `"Internal server error"`. Removed the inner try/catch in
  `handleTaskAction` — errors propagate to the wrapper.
- `sessions.ts` (bookmark POST, session DELETE): `"Failed to update
  bookmark"` / `"Failed to delete session"`.
- `config.ts` (3 PUT routes — workspaceDirs, referenceDirs,
  schedulerOverrides): `"save failed"`. Also tightens the
  `runSaveOrFail` helper used by the synchronous base / settings /
  mcp routes so it no longer returns the raw `err.message` to clients.

Hardening only (no structural change):

- `files.ts` (5 sites): stripped the embedded `errorMessage(err)`
  from every `serverError(res, …)` so client responses now serve
  stable opaque strings (`"Failed to read workspace"`, etc.).

`asyncHandler` signature: removed the `extends Request<…>` upper
bound. Express's `Request<P, ResBody, ReqBody, Query>` has mixed-
variance type params (ResBody is contravariant via
`res.json(body: ResBody)`), so any upper bound rejected valid call
sites that specified a concrete ResBody or used `object` for P.

## Test plan
- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` clean
- [x] \`yarn test\` — pre-existing `test_preset_loader` failure noted; unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)