### PR TITLE
feat: replace `settings` role with `mc-settings` preset skill (#1283)

### DIFF
--- a/plans/feat-mc-settings-skill-1283.md
+++ b/plans/feat-mc-settings-skill-1283.md
@@ -1,0 +1,51 @@
+# Plan: convert `settings` role → `mc-settings` preset skill (#1283)
+
+Built-in `settings` role bundles 4 tools (manageSource / manageSkills / manageAutomations / presentForm) behind a "Settings assistant" persona. Each `manage*` tool effectively just writes a markdown / JSON file plus a refresh side-effect. We can drop the role + Claude-only tools and let the user manage these from any role via natural-language file edits — provided the refresh side-effect happens automatically.
+
+## Files
+
+| Path | Action |
+|---|---|
+| `server/api/routes/config-refresh.ts` | NEW — `POST /api/config/refresh` wraps `refreshScheduledSkills()` + `refreshUserTasks()` |
+| `server/workspace/config-refresh/provision.ts` | NEW — boot-time `PostToolUse` hook auto-provision, mirroring `wiki-history` |
+| `server/workspace/config-refresh/hook.mjs` | NEW — hook script written into `<workspace>/.claude/hooks/config-refresh.mjs` |
+| `server/index.ts` | wire up provision call + mount route |
+| `src/config/apiRoutes.ts` | add `config.refresh` route |
+| `server/workspace/skills-preset/mc-settings/SKILL.md` | NEW — preset skill |
+| `src/config/roles.ts` | delete `settings` role + `BUILTIN_ROLE_IDS.settings` |
+| `test/agent/test_activeTools.ts` | (potentially) remove any references to the settings role |
+
+## Hook script behaviour
+
+Triggered by `PostToolUse` matcher `Write|Edit`. Reads the stdin payload to extract `tool_input.file_path` (or `tool_response.filePath`). Matches against two patterns:
+
+- `.claude/skills/<slug>/SKILL.md` → triggers `refreshScheduledSkills()` server-side
+- `config/scheduler/tasks.json` → triggers `refreshUserTasks()` server-side
+
+No match → no-op. Failure to reach the server (server restarting, etc.) is silent — refresh is best-effort, the file is already on disk and will be picked up next boot.
+
+The hook script doesn't import shared TS modules (unlike `wiki-history/hook/snapshot.ts`), so no esbuild step. The provisioner reads `server/workspace/config-refresh/hook.mjs` (committed source) and copies it to `<workspace>/.claude/hooks/config-refresh.mjs` on every server start (same "factory default" model as `wiki-history`).
+
+## Skill body shape
+
+```markdown
+---
+name: mc-settings
+description: Configure the MulmoClaude workspace — news sources, skills, scheduled automations. Edits markdown / JSON files directly; the server auto-refreshes affected systems via a hook.
+---
+
+# Workspace settings assistant
+
+(role's original prompt content, adapted to use Read/Write/Edit on the
+on-disk paths instead of the manage* tool calls. Concrete examples
+for each of the three areas.)
+```
+
+## What stays
+
+- The `manage*` MCP tools and their REST routes still exist — other roles can still list them in `availablePlugins`. We only delete the `settings` role definition; the underlying infra is untouched.
+- The picker / launcher UI for selecting a role is independent.
+
+## Migration note
+
+The Settings role is removed. Users invoke `/mc-settings` (or natural language) from any role; the skill body handles all three management tasks via Write/Edit. No data migration required — the underlying files are the same on-disk shape.

--- a/server/api/routes/config-refresh.ts
+++ b/server/api/routes/config-refresh.ts
@@ -1,0 +1,46 @@
+// POST /api/config/refresh — wraps `refreshScheduledSkills()` +
+// `refreshUserTasks()` into one endpoint so the `mc-settings` skill's
+// PostToolUse hook (#1283) can fire-and-forget after Write/Edit of
+// the relevant config files without knowing which refreshers exist.
+//
+// Best-effort by design: failures from one refresher don't block the
+// other; the response is always 200 with a per-refresher status so the
+// caller (the hook) can log on errors but never has to abort.
+
+import { Router, Request, Response } from "express";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { log } from "../../system/logger/index.js";
+import { refreshScheduledSkills } from "../../workspace/skills/scheduler.js";
+import { refreshUserTasks } from "../../workspace/skills/user-tasks.js";
+
+const router = Router();
+
+interface RefreshOutcome {
+  ok: boolean;
+  count?: number;
+  error?: string;
+}
+
+interface RefreshResponse {
+  skills: RefreshOutcome;
+  userTasks: RefreshOutcome;
+}
+
+async function safeRefresh(label: string, refresher: () => Promise<number>): Promise<RefreshOutcome> {
+  try {
+    const count = await refresher();
+    return { ok: true, count };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.warn("config-refresh", `${label} refresh failed`, { error });
+    return { ok: false, error };
+  }
+}
+
+router.post(API_ROUTES.config.refresh, async (_req: Request, res: Response<RefreshResponse>) => {
+  const [skills, userTasks] = await Promise.all([safeRefresh("skills", refreshScheduledSkills), safeRefresh("userTasks", refreshUserTasks)]);
+  log.debug("config-refresh", "refresh complete", { skills, userTasks });
+  res.json({ skills, userTasks });
+});
+
+export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,9 +21,11 @@ import mulmoScriptRoutes from "./api/routes/mulmo-script.js";
 import wikiRoutes from "./api/routes/wiki.js";
 import wikiHistoryRoutes from "./api/routes/wiki/history.js";
 import { provisionWikiHistoryHook } from "./workspace/wiki-history/provision.js";
+import { provisionConfigRefreshHook } from "./workspace/config-refresh/provision.js";
 import pdfRoutes from "./api/routes/pdf.js";
 import filesRoutes from "./api/routes/files.js";
 import configRoutes from "./api/routes/config.js";
+import configRefreshRoutes from "./api/routes/config-refresh.js";
 import skillsRoutes from "./api/routes/skills.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
@@ -473,6 +475,7 @@ app.use("/api/wiki", wikiHistoryRoutes);
 app.use(pdfRoutes);
 app.use(filesRoutes);
 app.use(configRoutes);
+app.use(configRefreshRoutes);
 app.use(skillsRoutes);
 app.use(runtimePluginRoutes);
 async function listSessionsForBridge(opts: { limit: number; offset: number }) {
@@ -984,6 +987,17 @@ process.on("SIGTERM", () => {
   // so the hook is in place from the first turn.
   await provisionWikiHistoryHook().catch((err) => {
     log.warn("wiki-history", "hook provisioning failed; LLM wiki edits will not be snapshotted this session", {
+      error: String(err),
+    });
+  });
+
+  // mc-settings auto-refresh hook (#1283). Installs a PostToolUse
+  // entry that fires POST /api/config/refresh after Write/Edit on
+  // SKILL.md or scheduler tasks.json so the `mc-settings` skill can
+  // drive workspace settings via plain file edits without leaving
+  // scheduled jobs stuck on the pre-edit definition.
+  await provisionConfigRefreshHook().catch((err) => {
+    log.warn("config-refresh", "hook provisioning failed; settings file edits will need a manual server restart this session", {
       error: String(err),
     });
   });

--- a/server/workspace/config-refresh/hook.mjs
+++ b/server/workspace/config-refresh/hook.mjs
@@ -63,6 +63,20 @@ function readSidecar(filePath) {
   }
 }
 
+// `.server-port` is hand-written by the parent server on each
+// startup. Parse it as a strict integer in [1, 65535] before
+// interpolating into the URL — a crafted file value like
+// `80@attacker.example` would otherwise change the request
+// authority and exfiltrate the bearer token off-host. Same
+// hardening as `wiki-history` hook's `readPortSafe` (Codex
+// review on PR #1284).
+function readPortSafe() {
+  const raw = readSidecar(PORT_PATH);
+  if (!raw) return null;
+  const port = Number.parseInt(raw, 10);
+  return Number.isInteger(port) && port > 0 && port < 65536 ? port : null;
+}
+
 (async () => {
   const raw = await readStdin();
   let payload;
@@ -76,7 +90,7 @@ function readSidecar(filePath) {
   if (!filePath) return;
   if (!PATTERNS.some((pattern) => pattern.test(filePath))) return;
 
-  const port = readSidecar(PORT_PATH);
+  const port = readPortSafe();
   const token = readSidecar(TOKEN_PATH);
   if (!port || !token) return;
 

--- a/server/workspace/config-refresh/hook.mjs
+++ b/server/workspace/config-refresh/hook.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Auto-refresh hook (#1283) — runs after every Claude CLI Write / Edit.
+// If the affected file is a SKILL.md or the scheduler tasks.json,
+// POST /api/config/refresh on the parent server so changes activate
+// without a manual restart. Everything else is a fast no-op.
+//
+// THIS FILE IS THE SOURCE OF TRUTH copied into
+// `<workspace>/.claude/hooks/config-refresh.mjs` by
+// `server/workspace/config-refresh/provision.ts` on every server start.
+// Edits here propagate via the normal launcher build/release path.
+//
+// Kept self-contained: no imports from `src/` or `server/` because the
+// hook executes inside Claude CLI's process space, which doesn't share
+// our module resolver. Plain ESM with Node-builtin imports only.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+// Resolve workspace root + sidecar files. `CLAUDE_PROJECT_DIR` is set
+// by Claude CLI to the workspace root the hook fired against; falling
+// back to `~/mulmoclaude` keeps the script robust when run outside CLI
+// context (test harness etc).
+const WORKSPACE = process.env.CLAUDE_PROJECT_DIR ?? path.join(homedir(), "mulmoclaude");
+const TOKEN_PATH = path.join(WORKSPACE, ".session-token");
+const PORT_PATH = path.join(WORKSPACE, ".server-port");
+// In Docker mode the parent server lives on the host's 127.0.0.1
+// which the container can't reach via plain loopback. The Docker
+// spawn plumbing sets MULMOCLAUDE_HOST=host.docker.internal so
+// fetch() resolves to the host server. Outside Docker (or when the
+// var is unset) we fall back to the loopback address.
+const SERVER_HOST = process.env.MULMOCLAUDE_HOST ?? "127.0.0.1";
+
+// File paths we care about. Matched against the absolute path the
+// CLI delivered in `tool_input.file_path` / `tool_response.filePath`.
+const PATTERNS = [
+  /[\\/]\.claude[\\/]skills[\\/][^\\/]+[\\/]SKILL\.md$/, // <ws>/.claude/skills/<slug>/SKILL.md
+  /[\\/]config[\\/]scheduler[\\/]tasks\.json$/, // <ws>/config/scheduler/tasks.json
+];
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function extractFilePath(payload) {
+  if (!payload || typeof payload !== "object") return "";
+  const toolInput = payload.tool_input;
+  if (toolInput && typeof toolInput === "object" && typeof toolInput.file_path === "string") return toolInput.file_path;
+  const toolResponse = payload.tool_response;
+  if (toolResponse && typeof toolResponse === "object" && typeof toolResponse.filePath === "string") return toolResponse.filePath;
+  return "";
+}
+
+function readSidecar(filePath) {
+  try {
+    return readFileSync(filePath, "utf-8").trim();
+  } catch {
+    return "";
+  }
+}
+
+(async () => {
+  const raw = await readStdin();
+  let payload;
+  try {
+    payload = JSON.parse(raw || "{}");
+  } catch {
+    return;
+  }
+
+  const filePath = extractFilePath(payload);
+  if (!filePath) return;
+  if (!PATTERNS.some((pattern) => pattern.test(filePath))) return;
+
+  const port = readSidecar(PORT_PATH);
+  const token = readSidecar(TOKEN_PATH);
+  if (!port || !token) return;
+
+  try {
+    await fetch(`http://${SERVER_HOST}:${port}/api/config/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // Server might be restarting / unreachable — silent fail is fine;
+    // the file is on disk and the next manual restart picks it up.
+  }
+})();

--- a/server/workspace/config-refresh/hook.mjs
+++ b/server/workspace/config-refresh/hook.mjs
@@ -94,13 +94,27 @@ function readPortSafe() {
   const token = readSidecar(TOKEN_PATH);
   if (!port || !token) return;
 
+  // PostToolUse hooks block Claude CLI's tool turn until the script
+  // exits. Without a timeout, a slow / hung parent server (refresh
+  // deadlock, GC pause, or an unrelated long-running route holding
+  // the loop) would leave the hook waiting on the socket and the
+  // user's Write/Edit appearing frozen. 2 s is plenty — the refresh
+  // is fire-and-forget anyway; if the server can't respond inside
+  // that, the file is already on disk and the next restart picks it
+  // up. (CodeRabbit review on PR #1284.)
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
   try {
     await fetch(`http://${SERVER_HOST}:${port}/api/config/refresh`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
     });
   } catch {
-    // Server might be restarting / unreachable — silent fail is fine;
-    // the file is on disk and the next manual restart picks it up.
+    // Server might be restarting / unreachable / timed out — silent
+    // fail is fine; the file is on disk and the next manual restart
+    // picks it up.
+  } finally {
+    clearTimeout(timer);
   }
 })();

--- a/server/workspace/config-refresh/provision.ts
+++ b/server/workspace/config-refresh/provision.ts
@@ -1,0 +1,164 @@
+// Workspace provisioning for the `mc-settings` skill's auto-refresh
+// hook (#1283). On every server start: copy the hook script into
+// `<workspaceRoot>/.claude/hooks/config-refresh.mjs` and ensure
+// `<workspaceRoot>/.claude/settings.json` has a `PostToolUse` entry
+// that runs it. Idempotent — repeated calls produce the same on-disk
+// state; user-owned hooks under the same matcher are preserved
+// (identified by a `mulmoclaudeConfigRefresh: true` owner marker on
+// the descriptor).
+//
+// Modelled on `server/workspace/wiki-history/provision.ts` — the
+// settings.json merge logic is functionally identical with a
+// different owner marker + script path. The two provisioners
+// install independent entries under the same `PostToolUse` matcher.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readTextOrNull } from "../../utils/files/safe.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { workspacePath as defaultWorkspacePath } from "../workspace.js";
+import { log } from "../../system/logger/index.js";
+
+// The hook source lives next to this file. We read it at provisioning
+// time (not at module load) so a missing / unreadable script degrades
+// to a logged warning without breaking server startup — provisioning
+// is best-effort.
+const HOOK_SOURCE_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "hook.mjs");
+
+function readHookSource(): string | null {
+  try {
+    return readFileSync(HOOK_SOURCE_PATH, "utf-8");
+  } catch (err) {
+    log.warn("config-refresh", "hook source unreadable, skipping provisioning", {
+      sourcePath: HOOK_SOURCE_PATH,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+const SETTINGS_REL = path.join(".claude", "settings.json");
+const HOOK_SCRIPT_REL = path.join(".claude", "hooks", "config-refresh.mjs");
+// Forward-slash form for the shell command — settings.json is read
+// by Claude CLI, and the command is interpreted by a POSIX shell
+// (macOS / Linux / inside the Docker container). `CLAUDE_PROJECT_DIR`
+// expands correctly in both contexts; a host-absolute path would
+// silently fail when bind-mounted into Docker.
+const HOOK_SCRIPT_REL_POSIX = ".claude/hooks/config-refresh.mjs";
+const HOOK_COMMAND = `node "$CLAUDE_PROJECT_DIR/${HOOK_SCRIPT_REL_POSIX}"`;
+const OWNER_MARKER = "mulmoclaudeConfigRefresh";
+
+interface HookCommandEntry {
+  type: "command";
+  command: string;
+  [key: string]: unknown;
+}
+
+interface HookMatcher {
+  matcher?: string;
+  hooks?: HookCommandEntry[];
+  [key: string]: unknown;
+}
+
+interface SettingsShape {
+  hooks?: {
+    PostToolUse?: HookMatcher[];
+    [key: string]: HookMatcher[] | undefined;
+  };
+  [key: string]: unknown;
+}
+
+export interface ProvisionOptions {
+  workspaceRoot?: string;
+}
+
+/** Ensure the hook script + `.claude/settings.json` are up to date.
+ *  Safe to call on every startup. Logs a one-line info on first
+ *  install, debug-only on subsequent no-op runs. Skips quietly (with
+ *  a warning) when the hook source can't be read. */
+export async function provisionConfigRefreshHook(opts: ProvisionOptions = {}): Promise<void> {
+  const source = readHookSource();
+  if (source === null) return;
+
+  const root = opts.workspaceRoot ?? defaultWorkspacePath;
+  const scriptPath = path.join(root, HOOK_SCRIPT_REL);
+  const settingsPath = path.join(root, SETTINGS_REL);
+
+  await writeHookScript(scriptPath, source);
+  const changed = await mergeHookIntoSettings(settingsPath);
+  if (changed) {
+    log.info("config-refresh", "provisioned auto-refresh hook", { settingsPath, scriptPath });
+  }
+}
+
+async function writeHookScript(absPath: string, source: string): Promise<void> {
+  // Always overwrite — the in-repo `hook.mjs` is the source of truth
+  // and rewriting on every startup propagates updates without a
+  // per-workspace migration.
+  await writeFileAtomic(absPath, source, { mode: 0o700 });
+}
+
+async function mergeHookIntoSettings(settingsPath: string): Promise<boolean> {
+  const existingRaw = await readTextOrNull(settingsPath);
+  const existing: SettingsShape = existingRaw ? safeParse(existingRaw) : {};
+
+  const desiredHook: HookCommandEntry = {
+    type: "command",
+    command: HOOK_COMMAND,
+    [OWNER_MARKER]: true,
+  };
+
+  const next = upsertOurHook(existing, desiredHook);
+  const nextRaw = `${JSON.stringify(next, null, 2)}\n`;
+  if (existingRaw === nextRaw) return false;
+
+  await writeFileAtomic(settingsPath, nextRaw);
+  return true;
+}
+
+function safeParse(raw: string): SettingsShape {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as SettingsShape;
+    }
+  } catch {
+    // Fall through — corrupted settings get rebuilt with our entry only.
+  }
+  return {};
+}
+
+function upsertOurHook(settings: SettingsShape, desiredHook: HookCommandEntry): SettingsShape {
+  const hooks = settings.hooks ?? {};
+  // Defensive normalisation — an unexpected shape (object, string,
+  // etc.) under PostToolUse becomes `[]` so findIndex doesn't throw.
+  const rawPostToolUse = hooks.PostToolUse;
+  const postToolUse = Array.isArray(rawPostToolUse) ? rawPostToolUse : [];
+
+  const ownedIndex = postToolUse.findIndex((entry) => entryHasOwnedHook(entry));
+  const desiredEntry: HookMatcher = {
+    matcher: "Write|Edit",
+    hooks: [desiredHook],
+  };
+
+  const nextPostToolUse = [...postToolUse];
+  if (ownedIndex === -1) {
+    nextPostToolUse.push(desiredEntry);
+  } else {
+    nextPostToolUse[ownedIndex] = desiredEntry;
+  }
+
+  return {
+    ...settings,
+    hooks: {
+      ...hooks,
+      PostToolUse: nextPostToolUse,
+    },
+  };
+}
+
+function entryHasOwnedHook(entry: HookMatcher): boolean {
+  if (!Array.isArray(entry.hooks)) return false;
+  return entry.hooks.some((hook) => hook[OWNER_MARKER] === true);
+}

--- a/server/workspace/config-refresh/provision.ts
+++ b/server/workspace/config-refresh/provision.ts
@@ -129,36 +129,40 @@ function safeParse(raw: string): SettingsShape {
   return {};
 }
 
-function upsertOurHook(settings: SettingsShape, desiredHook: HookCommandEntry): SettingsShape {
-  const hooks = settings.hooks ?? {};
-  // Defensive normalisation — an unexpected shape (object, string,
-  // etc.) under PostToolUse becomes `[]` so findIndex doesn't throw.
-  const rawPostToolUse = hooks.PostToolUse;
-  const postToolUse = Array.isArray(rawPostToolUse) ? rawPostToolUse : [];
-
-  const ownedIndex = postToolUse.findIndex((entry) => entryHasOwnedHook(entry));
-  const desiredEntry: HookMatcher = {
-    matcher: "Write|Edit",
-    hooks: [desiredHook],
-  };
-
-  const nextPostToolUse = [...postToolUse];
-  if (ownedIndex === -1) {
-    nextPostToolUse.push(desiredEntry);
-  } else {
-    nextPostToolUse[ownedIndex] = desiredEntry;
-  }
-
-  return {
-    ...settings,
-    hooks: {
-      ...hooks,
-      PostToolUse: nextPostToolUse,
-    },
-  };
+/** Cast `hooks.PostToolUse` defensively to a `HookMatcher[]`. An
+ *  unexpected shape (object, string, etc.) under that key — possible
+ *  when the file was hand-edited or written by another tool — becomes
+ *  `[]` so the caller can splice without throwing. Exported for tests
+ *  (the cast is the easy-to-regress part). */
+export function normalisePostToolUse(raw: unknown): HookMatcher[] {
+  return Array.isArray(raw) ? (raw as HookMatcher[]) : [];
 }
 
-function entryHasOwnedHook(entry: HookMatcher): boolean {
-  if (!Array.isArray(entry.hooks)) return false;
-  return entry.hooks.some((hook) => hook[OWNER_MARKER] === true);
+/** Replace the existing owned entry, or append the desired one if
+ *  no owned entry is present. Pure — returns a new array. */
+export function mergePostToolUse(postToolUse: readonly HookMatcher[], desiredEntry: HookMatcher): HookMatcher[] {
+  const ownedIndex = postToolUse.findIndex((entry) => entryHasOwnedHook(entry));
+  const next = [...postToolUse];
+  if (ownedIndex === -1) next.push(desiredEntry);
+  else next[ownedIndex] = desiredEntry;
+  return next;
+}
+
+function upsertOurHook(settings: SettingsShape, desiredHook: HookCommandEntry): SettingsShape {
+  const hooks = settings.hooks ?? {};
+  const postToolUse = normalisePostToolUse(hooks.PostToolUse);
+  const desiredEntry: HookMatcher = { matcher: "Write|Edit", hooks: [desiredHook] };
+  const nextPostToolUse = mergePostToolUse(postToolUse, desiredEntry);
+  return { ...settings, hooks: { ...hooks, PostToolUse: nextPostToolUse } };
+}
+
+/** Robust against hand-edited / non-conformant `PostToolUse` items:
+ *  null, primitive, or object-without-`hooks-array` all return false
+ *  rather than throwing on property access (CodeRabbit review on
+ *  PR #1284). */
+function entryHasOwnedHook(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const { hooks } = entry as HookMatcher;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((hook) => hook !== null && typeof hook === "object" && (hook as Record<string, unknown>)[OWNER_MARKER] === true);
 }

--- a/server/workspace/skills-preset/mc-settings/SKILL.md
+++ b/server/workspace/skills-preset/mc-settings/SKILL.md
@@ -128,7 +128,10 @@ automations", "stop the foo task".
 
 Schedule kinds:
 
-- `{ "type": "daily", "time": "HH:MM" }` — daily at the given local time.
+- `{ "type": "daily", "time": "HH:MM" }` — daily at the given **UTC** time
+  (the task-manager compares against `Date.getUTCHours/Minutes`; "07:00 UTC"
+  is 16:00 JST). When the user phrases the time in a local zone, convert to
+  UTC before writing.
 - `{ "type": "interval", "intervalMs": <ms> }` — every N ms (60000 = 1 min;
   for "every hour" use 3600000).
 

--- a/server/workspace/skills-preset/mc-settings/SKILL.md
+++ b/server/workspace/skills-preset/mc-settings/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: mc-settings
+description: Configure the MulmoClaude workspace — news sources, reusable skills, scheduled automations. Edits markdown / JSON files directly under the workspace; the server's auto-refresh hook re-registers affected systems without a restart.
+---
+
+# Workspace settings assistant
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+## What this skill does
+
+Help the user configure their MulmoClaude workspace. Three areas, each driven
+by editing on-disk files directly with the **Read / Write / Edit** tools — no
+special `manage*` calls. A `PostToolUse` hook (`<workspace>/.claude/hooks/config-refresh.mjs`)
+fires `POST /api/config/refresh` automatically after Write/Edit on the
+relevant paths, so changes activate without a server restart.
+
+When the user wants several settings adjusted at once, group the questions into
+a single `presentForm` call so they can answer cleanly; otherwise just write
+the file.
+
+Always end with a one-line confirmation of what changed (which file, which
+slug / id) so the user can verify.
+
+## Workflow 1: register / list / edit / remove information sources
+
+**Triggers**: "register an RSS feed for X", "add the AI papers from arXiv", "show
+my sources", "stop following Y".
+
+**Files**: one markdown file per source at `<workspace>/sources/<slug>.md`.
+
+**Read** to inspect — list the directory if the user asked "what's registered"
+and read individual files to show details.
+
+**Write** a new source as YAML frontmatter + body:
+
+```markdown
+---
+slug: ai-news-rss
+title: AI News (RSS)
+url: https://example.com/ai/feed.xml
+fetcher_kind: rss
+schedule: hourly
+categories:
+  - tech
+  - ai
+max_items_per_fetch: 20
+added_at: 2026-05-11T08:00:00.000Z
+---
+
+Notes about why this source is on the list — optional body.
+```
+
+Field rules:
+
+- `slug` — lowercase, hyphen-separated; matches the filename.
+- `fetcher_kind` — `rss` | `github` | `arxiv` (ask the user if you can't tell from the URL).
+- `schedule` — `hourly` | `daily` | `weekly` | `on-demand`. Use `hourly` for news polling, `daily` for digest sources, `weekly` for low-traffic, `on-demand` for sources only fetched when explicitly asked.
+- `categories` — free-form taxonomy; ask the user if they have a preferred set.
+- `max_items_per_fetch` — number, typically 10-50.
+- `added_at` — ISO timestamp now.
+- For `github`: add `repo: owner/name` and `kind: releases | issues` to the frontmatter. For `arxiv`: add `query: <search query>`.
+
+Source poller re-reads files each cycle, so no extra refresh is needed.
+
+**Edit / Delete** — use Edit for in-place changes, or delete the file when
+removing a source.
+
+## Workflow 2: create / list / edit / remove skills
+
+**Triggers**: "skill 化して", "save this as a skill", "what skills do I have", "remove
+the foo skill".
+
+**Files**: one SKILL.md per skill at `<workspace>/.claude/skills/<slug>/SKILL.md`.
+
+**Important**: do NOT touch files under `~/.claude/skills/` — those are the
+user-scope skills managed outside MulmoClaude. Project-scope skills live under
+`<workspace>/.claude/skills/`.
+
+**Write** shape:
+
+```markdown
+---
+name: <slug>
+description: One-line summary that frames when the skill should run.
+schedule: daily 09:00      # optional — auto-runs the skill on schedule
+roleId: general            # optional — role to use for scheduled runs
+---
+
+# <Skill name>
+
+Body in markdown. Written in second person ("first do X, then Y"). Focused on
+the reusable workflow, not one-off details.
+```
+
+`schedule` and `roleId` are optional. Schedule values: `daily HH:MM` or
+`interval Ns` / `Nm` / `Nh`.
+
+The auto-refresh hook re-registers scheduled skills on save, so a new
+`schedule:` activates without a server restart.
+
+## Workflow 3: schedule / list / edit / remove automations
+
+**Triggers**: "毎朝 7 時に天気を", "schedule a weekly cleanup", "show my
+automations", "stop the foo task".
+
+**File**: `<workspace>/config/scheduler/tasks.json`. Single JSON array.
+
+**Shape**:
+
+```json
+[
+  {
+    "id": "weather-morning",
+    "name": "Morning weather",
+    "description": "Check today's weather every weekday at 7am.",
+    "schedule": { "type": "daily", "time": "07:00" },
+    "missedRunPolicy": "runOnceImmediately",
+    "enabled": true,
+    "roleId": "general",
+    "prompt": "What's the weather today?",
+    "createdAt": "2026-05-11T08:00:00.000Z",
+    "updatedAt": "2026-05-11T08:00:00.000Z"
+  }
+]
+```
+
+Schedule kinds:
+
+- `{ "type": "daily", "time": "HH:MM" }` — daily at the given local time.
+- `{ "type": "interval", "intervalMs": <ms> }` — every N ms (60000 = 1 min;
+  for "every hour" use 3600000).
+
+`missedRunPolicy` values: `runOnceImmediately` | `skip`. Use `skip` for
+news polls (no point catching up), `runOnceImmediately` for status checks.
+
+When suggesting cadences, prefer **hourly** for news polling, **daily** for
+digests, **weekly** for cleanup, **every 4 hours** for calendar sync etc.
+
+**Edit** the JSON in place with Edit; the auto-refresh hook re-registers
+tasks after the file changes, so cron updates take effect immediately.
+
+## Tone
+
+Friendly, practical. Don't lecture about file paths or JSON shape — show the
+result and move on. When the user asks "what's registered?", read the relevant
+directory / file and summarise in human language (don't dump the raw JSON
+unless they ask).
+
+If a request needs several decisions (e.g. "register an RSS feed and schedule
+a daily digest"), use `presentForm` once to collect them all rather than
+ping-ponging.

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -81,6 +81,14 @@ const HOST_API_ROUTES = {
     workspaceDirs: "/api/config/workspace-dirs",
     referenceDirs: "/api/config/reference-dirs",
     schedulerOverrides: "/api/config/scheduler-overrides",
+    // Side-effect refresh endpoint: re-scans the skills dir +
+    // re-registers user-defined scheduler tasks so changes to
+    // `<workspace>/.claude/skills/<slug>/SKILL.md` or
+    // `<workspace>/config/scheduler/tasks.json` activate without
+    // a server restart. Called by the `mc-settings` PostToolUse hook
+    // after Write/Edit (#1283). Safe to call ad-hoc — pure side
+    // effect, no body.
+    refresh: "/api/config/refresh",
   },
 
   files: {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -209,27 +209,17 @@ export const ROLES: Role[] = [
       "Tell a pirate adventure featuring a daring captain and her first mate across three islands. Use a cinematic photography style.",
     ],
   },
-  {
-    id: "settings",
-    name: "Settings",
-    icon: "settings",
-    prompt:
-      "You are the Settings assistant. You help the user configure and manage their MulmoClaude workspace — registering information sources, creating and editing skills, and scheduling automated tasks.\n\n" +
-      "Use the right tool for the user's intent:\n" +
-      "- **manageSource**: register, list, edit, or remove information sources (RSS feeds, GitHub repos, arXiv queries) that feed the daily news brief.\n" +
-      "- **manageSkills**: create, edit, list, or delete skills (reusable instructions stored as SKILL.md files in the workspace).\n" +
-      "- **manageAutomations**: schedule and manage recurring or one-off tasks. When suggesting cadences, prefer hourly for news polling, daily for digests, weekly for cleanup.\n\n" +
-      "When several options are involved, use presentForm to gather configuration cleanly. Confirm what you've changed at the end so the user can verify.",
-    availablePlugins: [TOOL_NAMES.manageSource, TOOL_NAMES.manageSkills, TOOL_NAMES.manageAutomations, TOOL_NAMES.presentForm],
-    queries: [
-      "Register an RSS feed for AI news",
-      "Show me my registered information sources",
-      "List my skills",
-      "Create a skill that summarizes my unread emails each morning",
-      "Show my scheduled automations",
-      "Schedule a weekly wiki cleanup every Monday at 9am",
-    ],
-  },
+  // The `settings` built-in role was removed (#1283). Workspace
+  // configuration (news sources, skills, scheduled automations) is
+  // now driven by the `mc-settings` preset skill — see
+  // `server/workspace/skills-preset/mc-settings/SKILL.md`. The skill
+  // edits the on-disk files directly; a post-write hook installed by
+  // `provisionConfigRefreshHook` re-registers scheduled skills and
+  // user tasks so changes activate without a server restart, so the
+  // role's bundled `manageSource` / `manageSkills` /
+  // `manageAutomations` tools are no longer needed as a role-level
+  // bundle. The MCP tools themselves still exist for any role that
+  // wants the direct-call path.
   {
     id: "accounting",
     name: "Accounting",
@@ -374,7 +364,7 @@ export const BUILTIN_ROLE_IDS = {
   artist: "artist",
   tutor: "tutor",
   storyteller: "storyteller",
-  settings: "settings",
+  // settings: removed (#1283) — replaced by `mc-settings` preset skill.
   accounting: "accounting",
   cookingCoach: "cookingCoach",
   debug: "debug",

--- a/test/workspace/config-refresh/test_provision.ts
+++ b/test/workspace/config-refresh/test_provision.ts
@@ -1,0 +1,134 @@
+// Unit tests for the `mc-settings` auto-refresh hook provisioning
+// (#1283). Provisioning must be idempotent, coexist with the
+// existing `mulmoclaudeWikiHistory`-owned entry, and never clobber
+// user-set keys in `.claude/settings.json`.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { provisionConfigRefreshHook } from "../../../server/workspace/config-refresh/provision.js";
+import { provisionWikiHistoryHook } from "../../../server/workspace/wiki-history/provision.js";
+
+interface SettingsShape {
+  hooks?: { PostToolUse?: Record<string, unknown>[] };
+  [key: string]: unknown;
+}
+
+async function readSettings(workspace: string): Promise<SettingsShape> {
+  const raw = await readFile(path.join(workspace, ".claude", "settings.json"), "utf-8");
+  return JSON.parse(raw) as SettingsShape;
+}
+
+describe("provisionConfigRefreshHook — first install", () => {
+  it("creates settings.json + hook script with our PostToolUse entry", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "config-refresh-fresh-"));
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+
+    const settings = await readSettings(root);
+    const entries = settings.hooks?.PostToolUse ?? [];
+    assert.equal(entries.length, 1);
+    const entry = entries[0] as { matcher?: string; hooks?: { command?: string; mulmoclaudeConfigRefresh?: boolean }[] };
+    assert.equal(entry.matcher, "Write|Edit");
+    assert.equal(entry.hooks?.length, 1);
+    const hook = entry.hooks?.[0];
+    assert.equal(hook?.mulmoclaudeConfigRefresh, true);
+    assert.match(hook?.command ?? "", /node "\$CLAUDE_PROJECT_DIR\/\.claude\/hooks\/config-refresh\.mjs"/);
+
+    const scriptPath = path.join(root, ".claude", "hooks", "config-refresh.mjs");
+    const scriptBody = await readFile(scriptPath, "utf-8");
+    assert.match(scriptBody, /^#!\/usr\/bin\/env node/);
+    // Anchor on the refresh endpoint path so a future hook-source
+    // reformat doesn't silently break this test.
+    assert.match(scriptBody, /\/api\/config\/refresh/);
+
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("provisionConfigRefreshHook — idempotent", () => {
+  it("running twice produces byte-identical settings + script", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "config-refresh-idem-"));
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+    const firstSettings = await readFile(path.join(root, ".claude", "settings.json"), "utf-8");
+    const firstScript = await readFile(path.join(root, ".claude", "hooks", "config-refresh.mjs"), "utf-8");
+
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+    const secondSettings = await readFile(path.join(root, ".claude", "settings.json"), "utf-8");
+    const secondScript = await readFile(path.join(root, ".claude", "hooks", "config-refresh.mjs"), "utf-8");
+
+    assert.equal(secondSettings, firstSettings, "settings.json unchanged on second provision");
+    assert.equal(secondScript, firstScript, "hook script unchanged on second provision");
+
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("provisionConfigRefreshHook — coexists with wiki-history hook", () => {
+  it("appends a second entry alongside wiki-history without overwriting it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "config-refresh-coexist-"));
+    // Install wiki-history first to mimic the real boot order.
+    await provisionWikiHistoryHook({ workspaceRoot: root });
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+
+    const settings = await readSettings(root);
+    const entries = settings.hooks?.PostToolUse ?? [];
+    // Two distinct entries — one owned by wiki-history, one by us.
+    assert.equal(entries.length, 2);
+    const owners = entries
+      .flatMap((entry) => {
+        const hooks = (entry as { hooks?: Record<string, unknown>[] }).hooks ?? [];
+        return hooks.map((hook) => ({
+          wiki: hook.mulmoclaudeWikiHistory === true,
+          refresh: hook.mulmoclaudeConfigRefresh === true,
+        }));
+      })
+      .reduce((acc, item) => ({ wiki: acc.wiki || item.wiki, refresh: acc.refresh || item.refresh }), { wiki: false, refresh: false });
+    assert.ok(owners.wiki, "wiki-history entry must survive");
+    assert.ok(owners.refresh, "config-refresh entry must be present");
+
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("provisionConfigRefreshHook — preserves user-set hooks", () => {
+  it("does not touch unrelated PostToolUse entries", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "config-refresh-merge-"));
+    await mkdir(path.join(root, ".claude"), { recursive: true });
+    const userOwned = {
+      hooks: {
+        PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo 'user hook ran' >> /tmp/user-bash.log" }] }],
+      },
+      otherTopLevelKey: { foo: "bar" },
+    };
+    await writeFile(path.join(root, ".claude", "settings.json"), JSON.stringify(userOwned, null, 2));
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+
+    const settings = await readSettings(root);
+    const entries = settings.hooks?.PostToolUse ?? [];
+    assert.equal(entries.length, 2, "user entry survives + our entry appended");
+    const userEntry = entries.find((entry) => (entry as { matcher?: string }).matcher === "Bash");
+    assert.ok(userEntry, "user's Bash matcher entry survives");
+    assert.equal(settings.otherTopLevelKey !== undefined, true, "unrelated top-level keys preserved");
+
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("provisionConfigRefreshHook — recovers from corrupt settings.json", () => {
+  it("rebuilds with our entry only when the file isn't valid JSON", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "config-refresh-corrupt-"));
+    await mkdir(path.join(root, ".claude"), { recursive: true });
+    await writeFile(path.join(root, ".claude", "settings.json"), "{ not json");
+    await provisionConfigRefreshHook({ workspaceRoot: root });
+
+    const settings = await readSettings(root);
+    const entries = settings.hooks?.PostToolUse ?? [];
+    assert.equal(entries.length, 1);
+    const hook = (entries[0] as { hooks?: { mulmoclaudeConfigRefresh?: boolean }[] }).hooks?.[0];
+    assert.equal(hook?.mulmoclaudeConfigRefresh, true);
+
+    await rm(root, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

The built-in \`settings\` role bundled 4 tools (manageSource / manageSkills / manageAutomations / presentForm) behind a "Settings assistant" persona. The three \`manage*\` tools effectively just edit markdown / JSON files plus a refresh side-effect — so the role is replaced by a preset skill that drives the same files via plain Read/Write/Edit, with a PostToolUse hook handling the refresh automatically.

Closes #1283.

## Items to Confirm / Review

1. **Hook scope** — fires on Write/Edit of \`.claude/skills/<slug>/SKILL.md\` and \`config/scheduler/tasks.json\`. Sources are intentionally NOT in the pattern set because the news poller re-reads each cycle (eventual consistency, no refresh needed). Confirm this matches the actual reload behaviour you expect.
2. **No general-role expansion** — per the user's "general ロールも増やしたくない" constraint, the 3 manage* tools are NOT added to general. The skill drives the underlying files via Write/Edit (which every role has).
3. **`manage*` tools survive** — the MCP tools + REST routes still exist. Only the role-level bundle is deleted. Other roles can still opt into the direct-call path via \`availablePlugins\`.
4. **Hook coexistence** — wiki-history's PostToolUse hook (matcher Write|Edit) and ours (same matcher, different owner marker \`mulmoclaudeConfigRefresh\`) both land in \`<workspace>/.claude/settings.json\`'s PostToolUse array as independent entries. Test \`coexists with wiki-history hook\` locks this in.
5. **Settings UI implications** — there is no Settings → Roles tab today; role management lives at \`/roles\` (RolesView). Deleting the \`settings\` role doesn't touch that surface. Worth noting in release notes that the dedicated role is gone.

## User Prompt

> Settings という role があるよね。これを role じゃなくて skill にしたいの。
>
> general ロールも増やしたくない。skill だけで、うまくできない？manageSource、manageSkills、manageAutomations って結局 md ファイルを更新するだけだよね？
>
> [refresh approach A/B/C → C: PostToolUse hook auto-refresh]

## Implementation

| File | Change |
|---|---|
| \`server/workspace/skills-preset/mc-settings/SKILL.md\` | NEW — preset skill body. 3 workflows (sources / skills / automations), Write/Edit-driven. |
| \`server/workspace/config-refresh/hook.mjs\` | NEW — hook script. Filters file_path against 2 regex patterns, POSTs to refresh endpoint with bearer token. |
| \`server/workspace/config-refresh/provision.ts\` | NEW — boot-time auto-provision, mirrors \`wiki-history/provision.ts\`. Idempotent. |
| \`server/api/routes/config-refresh.ts\` | NEW — \`POST /api/config/refresh\` calls \`refreshScheduledSkills()\` + \`refreshUserTasks()\`. |
| \`server/index.ts\` | Wire up route mount + provision call. |
| \`src/config/apiRoutes.ts\` | Add \`config.refresh\` entry. |
| \`src/config/roles.ts\` | Delete \`settings\` from \`ROLES\` + \`BUILTIN_ROLE_IDS\`. |
| \`test/workspace/config-refresh/test_provision.ts\` | NEW — 5 cases: first install, idempotent, coexists with wiki-history, preserves user keys, recovers from corrupt settings.json. |

## Validation

- \`yarn typecheck\` ✅
- \`yarn lint\` ✅
- \`yarn test\` ✅ (4428 / 4428)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `mc-settings` preset skill for workspace configuration management through file editing
  * Added auto-refresh capability that detects configuration changes and applies them without server restart

* **Deprecated**
  * Removed built-in `settings` role; configuration is now managed via the new `mc-settings` skill

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1284)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->