### PR TITLE
feat: replace `cookingCoach` role with `mc-cooking-coach` preset skill (#1286)

### DIFF
--- a/plans/feat-mc-cooking-coach-skill-1286.md
+++ b/plans/feat-mc-cooking-coach-skill-1286.md
@@ -1,0 +1,39 @@
+# Plan: convert `cookingCoach` role → `mc-cooking-coach` preset skill (#1286)
+
+Same shape as #1283 (`settings` → `mc-settings`). The `cookingCoach` role bundles a runtime plugin (`recipe-book-plugin`) + `presentForm` + `generateImage` behind a cooking-assistant persona. The plugin's MCP tool is "save / read / list / update / delete recipe markdown files", so the role + plugin combo collapses into a preset skill that drives the same files via Read / Write / Edit.
+
+## Files
+
+| Path | Action |
+|---|---|
+| `server/plugins/preset-list.ts` | Remove the `@mulmoclaude/recipe-book-plugin` row. The plugin source stays in `packages/plugins/recipe-book-plugin/` — re-enabling is one line. |
+| `src/config/toolNames.ts` | Remove `manageRecipes` from `HOST_TOOL_NAMES`. |
+| `src/config/roles.ts` | Delete the `cookingCoach` role + `BUILTIN_ROLE_IDS.cookingCoach`. Drop `TOOL_NAMES.manageRecipes` from `debug` role. |
+| `server/workspace/paths.ts` | Add `cookingRecipes: "data/cooking/recipes"` to `WORKSPACE_DIRS` so the migration + skill can reference the canonical path via the constant. |
+| `server/workspace/cooking-recipes/migrate.ts` (NEW) | Boot-time one-shot migration: copy any `data/plugins/%40mulmoclaude%2Frecipe-book-plugin/recipes/*.md` files to `data/cooking/recipes/*.md`. Idempotent via a `.migration-from-plugin-done` sentinel. |
+| `server/index.ts` | Wire the migration call into startup, alongside the memory + photo-exif migration helpers. |
+| `server/workspace/skills-preset/mc-cooking-coach/SKILL.md` (NEW) | Preset skill. Three workflows (save, list-via-README, edit/delete) all Write/Edit-driven. After every change, regenerate `data/cooking/recipes/README.md` as the catalogue. |
+| `test/workspace/cooking-recipes/test_migrate.ts` (NEW) | Migration unit tests (idempotent, copies all .md files, preserves contents, skips when source absent). |
+| `test/workspace/test_paths_shape.ts` | Add `cookingRecipes` to the expected-keys list. |
+| `plans/feat-mc-cooking-coach-skill-1286.md` | This file. |
+
+## Storage path migration
+
+- **Before**: plugin's `files.data` scope → `<workspace>/data/plugins/%40mulmoclaude%2Frecipe-book-plugin/recipes/<slug>.md` (URL-encoded package name as dir).
+- **After**: `<workspace>/data/cooking/recipes/<slug>.md` (clean, human-readable). Matches the original plan (`plans/done/feat-recipe-book-1175.md`).
+
+Migration is boot-time + idempotent (no manual step required). Source files are COPIED, not moved, so a failed migration doesn't lose data. The sentinel prevents re-runs.
+
+## README.md as the index
+
+No Vue list view exists for the skill (no plugin = no View). A markdown index in the recipes dir keeps the catalogue browsable from any markdown viewer (Files Explorer / wiki render path). The skill body instructs Claude to regenerate `data/cooking/recipes/README.md` after every save / update / delete. Format: one bullet per recipe with slug → link to the `.md` file + short summary (title, tags, servings).
+
+## What stays untouched
+
+The `recipe-book-plugin` package source. Anyone who wants to re-enable the plugin's MCP / View path can add one line back to `preset-list.ts`. The skill route doesn't try to be reverse-compatible with the plugin — they're independent.
+
+## Out of scope
+
+- Cross-recipe search / filter — README is a static index, not a query interface.
+- The Vue View component the plugin provides — gone when the plugin doesn't load. The skill is markdown-only.
+- The `manageRecipes` tool definition (lives inside the plugin package, untouched but no longer reached because the plugin isn't preset-loaded).

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,6 +59,7 @@ import { mcpToolsRouter, mcpTools, isMcpToolEnabled } from "./agent/mcp-tools/in
 import { initWorkspace, workspacePath } from "./workspace/workspace.js";
 import { runMemoryMigrationOnce } from "./workspace/memory/run.js";
 import { runTopicMigrationOnce } from "./workspace/memory/topic-run.js";
+import { migrateCookingRecipesFromPlugin } from "./workspace/cooking-recipes/migrate.js";
 import { env, isGeminiAvailable } from "./system/env.js";
 import { buildSandboxStatus } from "./api/sandboxStatus.js";
 import { existsSync, readFileSync } from "fs";
@@ -132,6 +133,17 @@ const noop = (): void => {};
 runMemoryMigrationOnce(workspacePath)
   .then(() => runTopicMigrationOnce(workspacePath))
   .then(noop, noop);
+
+// Recipe-book plugin → `mc-cooking-coach` skill migration (#1286).
+// Boot-time idempotent copy from the plugin's `files.data` scope
+// (`data/plugins/<sanitised-pkg>/recipes/`) to the canonical
+// `data/cooking/recipes/` path the skill drives. Sentinel-gated so
+// every boot after the first is a no-op.
+migrateCookingRecipesFromPlugin().catch((err) => {
+  log.warn("cooking-recipes", "migration from plugin failed; falling back to original plugin path", {
+    error: err instanceof Error ? err.message : String(err),
+  });
+});
 
 let sandboxEnabled = false;
 

--- a/server/plugins/preset-list.ts
+++ b/server/plugins/preset-list.ts
@@ -39,11 +39,14 @@ export const PRESET_PLUGINS: readonly PresetPlugin[] = [
   // todo-plugin via the workspace symlink at
   // `node_modules/@mulmoclaude/spotify-plugin/`.
   { packageName: "@mulmoclaude/spotify-plugin" },
-  // #1175 / #1169 PR-A — recipe-book runtime plugin. First slice of
-  // the Cooking Coach plugin set. Stores recipes as one markdown file
-  // per recipe under the plugin's `files.data` scope; demonstrates
-  // markdown-per-record storage on the v0.3 runtime API.
-  { packageName: "@mulmoclaude/recipe-book-plugin" },
+  // #1175 / #1286 — `recipe-book-plugin` removed from the preset
+  // list. The plugin source still ships at
+  // `packages/plugins/recipe-book-plugin/` for re-enabling, but
+  // recipe management has moved to the `mc-cooking-coach` preset
+  // skill which drives `data/cooking/recipes/<slug>.md` via
+  // Read/Write/Edit. Removing the entry unmounts the plugin's MCP
+  // tool + Vue View, which the skill replaces with a markdown
+  // README index in the recipes dir.
   // Encore plan PR 1 follow-up — dev-only debug playground plugin.
   // Owns the standalone `/debug` page; the toolbar entry is gated on
   // `VITE_DEV_MODE=1` so production builds hide the launcher button

--- a/server/workspace/cooking-recipes/migrate.ts
+++ b/server/workspace/cooking-recipes/migrate.ts
@@ -1,0 +1,109 @@
+// One-shot migration: move recipe files from the runtime plugin's
+// `files.data` scope (`<ws>/data/plugins/%40mulmoclaude%2Frecipe-book-plugin/recipes/*.md`)
+// to the clean canonical path (`<ws>/data/cooking/recipes/*.md`).
+// Runs at server startup; idempotent via a sentinel file at the
+// destination root (`.migration-from-plugin-done`).
+//
+// Source files are COPIED, not moved, so a partial run doesn't lose
+// data. The sentinel is written ONLY after every source file landed
+// at the destination — a crashed migration leaves the source intact
+// and the next boot re-attempts.
+//
+// CLEANUP target: after every active workspace has migrated and the
+// `recipe-book-plugin` package itself is deleted, this helper +
+// sentinel can be removed in one sweep. The plugin source presently
+// stays in `packages/plugins/` (per #1286 user constraint) so the
+// migration helper stays for any old workspace that flips the plugin
+// back on then off again.
+
+import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { WORKSPACE_PATHS } from "../paths.js";
+import { log } from "../../system/logger/index.js";
+
+const LEGACY_PLUGIN_SEG = "%40mulmoclaude%2Frecipe-book-plugin";
+const LEGACY_RECIPES_SUBDIR = "recipes";
+const SENTINEL_FILENAME = ".migration-from-plugin-done";
+
+export interface CookingRecipesMigrationOptions {
+  /** Workspace data root override for tests. Defaults to
+   *  `WORKSPACE_PATHS.pluginsData` for the source side and
+   *  `WORKSPACE_PATHS.cookingRecipes` for the destination. */
+  pluginsDataRoot?: string;
+  cookingRecipesRoot?: string;
+}
+
+interface MigrationResult {
+  copied: number;
+  skipped: number;
+  alreadyDone: boolean;
+}
+
+/** Best-effort migration. Logs at info on success, warn on failures
+ *  per-file; never throws — boot continues regardless. */
+export async function migrateCookingRecipesFromPlugin(opts: CookingRecipesMigrationOptions = {}): Promise<MigrationResult> {
+  const pluginsData = opts.pluginsDataRoot ?? WORKSPACE_PATHS.pluginsData;
+  const cookingRecipes = opts.cookingRecipesRoot ?? WORKSPACE_PATHS.cookingRecipes;
+  const legacyDir = path.join(pluginsData, LEGACY_PLUGIN_SEG, LEGACY_RECIPES_SUBDIR);
+  const sentinelPath = path.join(cookingRecipes, SENTINEL_FILENAME);
+
+  if (existsSync(sentinelPath)) {
+    return { copied: 0, skipped: 0, alreadyDone: true };
+  }
+  if (!existsSync(legacyDir)) {
+    // No plugin storage to migrate from. Drop the sentinel so we
+    // don't re-stat the source dir on every future boot.
+    await mkdir(cookingRecipes, { recursive: true });
+    await writeFile(sentinelPath, sentinelBody("no legacy source found"), "utf-8");
+    return { copied: 0, skipped: 0, alreadyDone: false };
+  }
+
+  await mkdir(cookingRecipes, { recursive: true });
+  const entries = await readdir(legacyDir);
+  let copied = 0;
+  let skipped = 0;
+  for (const name of entries) {
+    if (!name.endsWith(".md")) {
+      skipped += 1;
+      continue;
+    }
+    const src = path.join(legacyDir, name);
+    const dst = path.join(cookingRecipes, name);
+    if (existsSync(dst)) {
+      // Don't overwrite a file the user may have hand-edited at the
+      // new location. Skip + log + carry on.
+      log.warn("cooking-recipes", "migration: destination already exists, skipping", { name });
+      skipped += 1;
+      continue;
+    }
+    try {
+      await copyFile(src, dst);
+      copied += 1;
+    } catch (err) {
+      log.warn("cooking-recipes", "migration: copy failed", { name, error: err instanceof Error ? err.message : String(err) });
+      skipped += 1;
+    }
+  }
+
+  await writeFile(sentinelPath, sentinelBody(`copied=${copied} skipped=${skipped}`), "utf-8");
+  if (copied > 0) {
+    log.info("cooking-recipes", "migration from recipe-book-plugin complete", { copied, skipped, legacyDir, cookingRecipes });
+  }
+  return { copied, skipped, alreadyDone: false };
+}
+
+function sentinelBody(detail: string): string {
+  return [
+    "# Migration sentinel — recipe-book-plugin → data/cooking/recipes/ (#1286)",
+    "",
+    `# Run at: ${new Date().toISOString()}`,
+    `# Result: ${detail}`,
+    "",
+    "# The presence of this file marks the legacy-plugin migration as done.",
+    "# Delete it to force a re-run on next server boot (use with care: the",
+    "# migration is non-overwriting, so re-running on a workspace that has",
+    "# diverged from the legacy snapshot won't silently clobber hand-edits).",
+    "",
+  ].join("\n");
+}

--- a/server/workspace/cooking-recipes/migrate.ts
+++ b/server/workspace/cooking-recipes/migrate.ts
@@ -37,6 +37,10 @@ export interface CookingRecipesMigrationOptions {
 interface MigrationResult {
   copied: number;
   skipped: number;
+  /** Number of `.md` source files whose copy threw an I/O error.
+   *  When non-zero the sentinel is NOT written, so the next boot
+   *  retries — transient failures don't become permanent. */
+  copyFailures: number;
   alreadyDone: boolean;
 }
 
@@ -49,20 +53,21 @@ export async function migrateCookingRecipesFromPlugin(opts: CookingRecipesMigrat
   const sentinelPath = path.join(cookingRecipes, SENTINEL_FILENAME);
 
   if (existsSync(sentinelPath)) {
-    return { copied: 0, skipped: 0, alreadyDone: true };
+    return { copied: 0, skipped: 0, copyFailures: 0, alreadyDone: true };
   }
   if (!existsSync(legacyDir)) {
     // No plugin storage to migrate from. Drop the sentinel so we
     // don't re-stat the source dir on every future boot.
     await mkdir(cookingRecipes, { recursive: true });
     await writeFile(sentinelPath, sentinelBody("no legacy source found"), "utf-8");
-    return { copied: 0, skipped: 0, alreadyDone: false };
+    return { copied: 0, skipped: 0, copyFailures: 0, alreadyDone: false };
   }
 
   await mkdir(cookingRecipes, { recursive: true });
   const entries = await readdir(legacyDir);
   let copied = 0;
   let skipped = 0;
+  let copyFailures = 0;
   for (const name of entries) {
     if (!name.endsWith(".md")) {
       skipped += 1;
@@ -72,7 +77,8 @@ export async function migrateCookingRecipesFromPlugin(opts: CookingRecipesMigrat
     const dst = path.join(cookingRecipes, name);
     if (existsSync(dst)) {
       // Don't overwrite a file the user may have hand-edited at the
-      // new location. Skip + log + carry on.
+      // new location. Skip + log + carry on — this is an intentional
+      // skip, not a failure, so it doesn't block the sentinel.
       log.warn("cooking-recipes", "migration: destination already exists, skipping", { name });
       skipped += 1;
       continue;
@@ -81,16 +87,25 @@ export async function migrateCookingRecipesFromPlugin(opts: CookingRecipesMigrat
       await copyFile(src, dst);
       copied += 1;
     } catch (err) {
-      log.warn("cooking-recipes", "migration: copy failed", { name, error: err instanceof Error ? err.message : String(err) });
-      skipped += 1;
+      // Transient I/O failures (disk full, EBUSY, permissions) MUST NOT
+      // mark migration as done — Codex review on PR #1287. Track
+      // separately from intentional skips so the sentinel-gate below
+      // can decide. Next boot retries the source files we missed.
+      log.warn("cooking-recipes", "migration: copy failed (will retry next boot)", { name, error: err instanceof Error ? err.message : String(err) });
+      copyFailures += 1;
     }
+  }
+
+  if (copyFailures > 0) {
+    log.warn("cooking-recipes", "migration: not marking complete — copy failures present", { copied, skipped, copyFailures });
+    return { copied, skipped, copyFailures, alreadyDone: false };
   }
 
   await writeFile(sentinelPath, sentinelBody(`copied=${copied} skipped=${skipped}`), "utf-8");
   if (copied > 0) {
     log.info("cooking-recipes", "migration from recipe-book-plugin complete", { copied, skipped, legacyDir, cookingRecipes });
   }
-  return { copied, skipped, alreadyDone: false };
+  return { copied, skipped, copyFailures: 0, alreadyDone: false };
 }
 
 function sentinelBody(detail: string): string {

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -115,6 +115,14 @@ const HOST_WORKSPACE_DIRS = {
   // (lat/lng numbers) so the LLM can hand a sidecar straight to the
   // Google Map plugin without reshape.
   locations: "data/locations",
+  // Recipe markdown files driven by the `mc-cooking-coach` preset
+  // skill (#1286). Replaces the runtime plugin's `files.data` scope
+  // path (`data/plugins/<sanitised-pkg>/recipes/`) with a clean,
+  // human-readable canonical path. A boot-time migration helper
+  // (`server/workspace/cooking-recipes/migrate.ts`) moves any
+  // existing files from the legacy plugin path on first boot after
+  // the migration lands.
+  cookingRecipes: "data/cooking/recipes",
   transports: "data/transports",
   // artifacts/
   charts: "artifacts/charts",

--- a/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
+++ b/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
@@ -151,8 +151,11 @@ otherwise the index treats its own catalogue as a recipe and emits a
 self-referential entry. Convenient form:
 
 ```bash
-ls data/cooking/recipes/*.md | grep -v '/README\.md$'
+find data/cooking/recipes -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | sort
 ```
+
+(`find` over `ls *.md` so an empty directory after a delete doesn't error out
+on the glob — also keeps the README exclusion explicit.)
 
 Then Read each frontmatter you don't already know.
 

--- a/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
+++ b/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: mc-cooking-coach
+description: Personal recipe book — save / read / update / delete cooking recipes as markdown files under `data/cooking/recipes/`, with a `README.md` index that lists every recipe. Use when the user asks to remember a recipe, look one up, or refine one.
+---
+
+# Cooking Coach
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+Be the user's cooking-loving friend, not a librarian. Don't talk about file
+paths, frontmatter, or slugs — those exist behind the scenes; the user should
+never need to think about them. When suggesting substitutions or technique,
+keep it short and practical.
+
+## Where things live
+
+Recipes are plain markdown files at `<workspace>/data/cooking/recipes/<slug>.md`.
+A `README.md` in the same directory is the catalogue — one bullet per recipe.
+You maintain both. The user should never need to know either path.
+
+## Workflow 1: save a new recipe
+
+**Triggers**: "ピーマンの肉詰めのレシピを保存して", "remember this lasagna",
+"こんど作る用に肉じゃがメモして".
+
+**Step 1 — distil before writing.** Ask follow-ups only if essential
+(ingredients you couldn't infer, servings if the user implied "for the family"
+etc.). Don't ping-pong on metadata; default `servings`, `prepTime`, `cookTime`
+to what the user said and skip them if they didn't say.
+
+**Step 2 — pick a kebab-case ASCII slug.** `ピーマンの肉詰め` → `stuffed-peppers`
+or `piman-no-nikuzume`. Use a romanised form even when the title is non-ASCII.
+Keep it short. If a recipe with that slug already exists, ask the user (don't
+overwrite without permission).
+
+**Step 3 — Write the recipe file** at `data/cooking/recipes/<slug>.md`:
+
+```markdown
+---
+title: ピーマンの肉詰め
+tags:
+  - 和食
+  - 主菜
+servings: 4
+prepTime: 15
+cookTime: 20
+created: 2026-05-11T12:00:00.000Z
+updated: 2026-05-11T12:00:00.000Z
+---
+
+## 材料
+
+- ピーマン 8個
+- 合いびき肉 300g
+- 玉ねぎ 1個
+- 卵 1個
+- パン粉、塩こしょう
+
+## 手順
+
+1. ピーマンを縦半分に切って種を取る
+2. 玉ねぎをみじん切りにして炒める
+3. ひき肉だねをピーマンに詰める
+4. フライパンで両面焼く
+
+## メモ
+
+味噌だれや甘酢あんかけにアレンジしてもよい。
+```
+
+Title can be in the user's language. Body convention: `## 材料` (or `## Ingredients`)
+as a bullet list with quantities, then `## 手順` (or `## Steps`) as a numbered list,
+then optional `## メモ` / `## Notes` / `## バリエーション` sections.
+
+`servings`, `prepTime`, `cookTime` are all integers and all optional — omit if
+the user didn't volunteer them. `tags` is a free-form list. `created` and
+`updated` are ISO timestamps; on a fresh save they're the same.
+
+**Step 4 — regenerate `data/cooking/recipes/README.md`** (see "The README index"
+below).
+
+**Step 5 — confirm**: one sentence ("Saved as stuffed-peppers.") so the user
+sees the result without scrolling. Offer `generateImage` if the dish would
+benefit from a visual (plating, unfamiliar technique).
+
+## Workflow 2: recall / browse
+
+**Triggers**: "保存したレシピみせて", "肉詰めどう作ったっけ?", "what tag-thai
+recipes do I have?", "show me my recipes".
+
+**Single recipe**: Read `data/cooking/recipes/<slug>.md` and present it
+naturally — render the markdown in chat, don't dump raw frontmatter unless the
+user asks. If you don't know the slug, Read `data/cooking/recipes/README.md`
+first to find it.
+
+**All recipes / filtered**: Read `data/cooking/recipes/README.md` and answer
+from the index. If the user filters by tag ("和食 のレシピは?"), filter the
+bullets and respond conversationally — don't dump the whole README.
+
+## Workflow 3: update / delete
+
+**Update**: read the current file, apply the change, Write with the updated
+frontmatter:
+
+- `created` stays the same
+- `updated` advances to the current ISO timestamp
+- preserve every other frontmatter field unless the user explicitly asked to
+  change it (so a "bump cook time to 25 min" doesn't accidentally wipe tags)
+
+Then regenerate `README.md`.
+
+**Delete**: only when the user explicitly asks. Use the Bash tool (`rm
+data/cooking/recipes/<slug>.md`) and regenerate `README.md`. Confirm afterward.
+
+## Workflow 4: visualise
+
+When the user asks "how does it look?" / "写真みせて" / a step is hard to
+follow without a picture, call `generateImage` with a prompt focused on the
+finished dish — appetising, well-lit, top-down or 3/4 plating shot. One image
+per request unless they ask for variations.
+
+## The README index — keep it current
+
+After every save / update / delete, regenerate `data/cooking/recipes/README.md`
+from the files currently in the directory (use `Bash: ls data/cooking/recipes/*.md`
+or the Files tool to enumerate, then Read each frontmatter you don't already
+know).
+
+Format:
+
+```markdown
+# レシピ一覧
+
+`data/cooking/recipes/` の中身。MulmoClaude が自動更新するので手で編集する場合は
+保存後に更新されることを覚えておいてください。
+
+## 主菜
+
+- [ピーマンの肉詰め](stuffed-peppers.md) — 和食 / 4 人分 / 35 分
+- [ラザニア](lasagna.md) — イタリアン / 6 人分 / 90 分
+
+## 副菜・スープ
+
+- [豚汁](tonjiru.md) — 和食 / 4 人分 / 30 分
+
+## デザート
+
+- [チョコレートムース](chocolate-mousse.md) — フレンチ / 4 人分 / 20 分 + 冷却 2 h
+
+## (タグ未分類)
+
+- [おにぎり](onigiri.md) — 4 人分 / 15 分
+```
+
+Rules for the README:
+
+- **Group by primary tag** (the first item in the recipe's `tags`) when there's
+  a meaningful taxonomy in use; fall back to "(タグ未分類)" otherwise.
+- **One bullet per recipe**: `[Title](slug.md) — tags / servings / total time`.
+  Use long-form units in the user's language (人分, 分, mins, etc.). Total time
+  = `prepTime + cookTime` if both are set; otherwise show whichever is set;
+  otherwise omit. Tags are slash-joined.
+- **Don't include `created` / `updated` dates** — they're noisy and rarely
+  what the user wants to scan for.
+- **Alphabetical within each group** by display title (Japanese / English
+  collation as it falls out — don't over-engineer).
+- **Keep the opening paragraph** explaining MulmoClaude maintains it (one
+  short sentence).
+
+If the directory is empty after a delete, write a single-line README pointing
+at "(まだレシピがありません)" so the user can tell at a glance.
+
+## Tone
+
+Conversational. The user is your cooking friend, not your customer. When you
+suggest a substitution, do it with a one-line "why" ("the lime brightens it —
+lemon works but skews sour"). Don't recite culinary trivia unless asked.

--- a/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
+++ b/server/workspace/skills-preset/mc-cooking-coach/SKILL.md
@@ -31,8 +31,17 @@ to what the user said and skip them if they didn't say.
 
 **Step 2 — pick a kebab-case ASCII slug.** `ピーマンの肉詰め` → `stuffed-peppers`
 or `piman-no-nikuzume`. Use a romanised form even when the title is non-ASCII.
-Keep it short. If a recipe with that slug already exists, ask the user (don't
-overwrite without permission).
+
+The slug MUST match the pattern `^[a-z0-9]+(-[a-z0-9]+)*$` — lowercase ASCII
+letters / digits, single hyphens between segments only, no leading / trailing /
+consecutive hyphens, no whitespace, no punctuation (no apostrophes,
+parentheses, accents). Max 64 characters. If the romanisation has any of
+those, strip / replace them before saving. The strict pattern is also a
+**safety boundary**: it's how the delete workflow below stays free of shell-
+metacharacter concerns.
+
+If a recipe with that slug already exists, ask the user (don't overwrite
+without permission).
 
 **Step 3 — Write the recipe file** at `data/cooking/recipes/<slug>.md`:
 
@@ -45,6 +54,7 @@ tags:
 servings: 4
 prepTime: 15
 cookTime: 20
+restTime: 0
 created: 2026-05-11T12:00:00.000Z
 updated: 2026-05-11T12:00:00.000Z
 ---
@@ -73,9 +83,12 @@ Title can be in the user's language. Body convention: `## 材料` (or `## Ingred
 as a bullet list with quantities, then `## 手順` (or `## Steps`) as a numbered list,
 then optional `## メモ` / `## Notes` / `## バリエーション` sections.
 
-`servings`, `prepTime`, `cookTime` are all integers and all optional — omit if
-the user didn't volunteer them. `tags` is a free-form list. `created` and
-`updated` are ISO timestamps; on a fresh save they're the same.
+`servings`, `prepTime`, `cookTime`, `restTime` are all integers (in minutes
+for the time fields) and all optional — omit if the user didn't volunteer
+them. `restTime` covers non-active time like marinating, chilling, proofing,
+resting — anything where the user isn't doing work; keep `cookTime` for
+active cooking only so totals stay accurate. `tags` is a free-form list.
+`created` and `updated` are ISO timestamps; on a fresh save they're the same.
 
 **Step 4 — regenerate `data/cooking/recipes/README.md`** (see "The README index"
 below).
@@ -110,8 +123,17 @@ frontmatter:
 
 Then regenerate `README.md`.
 
-**Delete**: only when the user explicitly asks. Use the Bash tool (`rm
-data/cooking/recipes/<slug>.md`) and regenerate `README.md`. Confirm afterward.
+**Delete**: only when the user explicitly asks. **Re-validate the slug
+against `^[a-z0-9]+(-[a-z0-9]+)*$` BEFORE running the command** — if it
+fails the pattern, refuse and ask the user to confirm by name. When valid,
+quote the path even though the slug pattern already excludes shell
+metacharacters (belt + braces):
+
+```bash
+rm "data/cooking/recipes/<slug>.md"
+```
+
+Then regenerate `README.md`. Confirm afterward.
 
 ## Workflow 4: visualise
 
@@ -123,9 +145,16 @@ per request unless they ask for variations.
 ## The README index — keep it current
 
 After every save / update / delete, regenerate `data/cooking/recipes/README.md`
-from the files currently in the directory (use `Bash: ls data/cooking/recipes/*.md`
-or the Files tool to enumerate, then Read each frontmatter you don't already
-know).
+from the recipe files currently in the directory. Enumerate with the Files
+tool, or with Bash. **The enumeration MUST exclude `README.md` itself** —
+otherwise the index treats its own catalogue as a recipe and emits a
+self-referential entry. Convenient form:
+
+```bash
+ls data/cooking/recipes/*.md | grep -v '/README\.md$'
+```
+
+Then Read each frontmatter you don't already know.
 
 Format:
 
@@ -137,16 +166,16 @@ Format:
 
 ## 主菜
 
-- [ピーマンの肉詰め](stuffed-peppers.md) — 和食 / 4 人分 / 35 分
-- [ラザニア](lasagna.md) — イタリアン / 6 人分 / 90 分
+- [ピーマンの肉詰め](stuffed-peppers.md) — 和食 / 4 人分 / 15 + 20 分
+- [ラザニア](lasagna.md) — イタリアン / 6 人分 / 30 + 60 分
 
 ## 副菜・スープ
 
-- [豚汁](tonjiru.md) — 和食 / 4 人分 / 30 分
+- [豚汁](tonjiru.md) — 和食 / 4 人分 / 10 + 20 分
 
 ## デザート
 
-- [チョコレートムース](chocolate-mousse.md) — フレンチ / 4 人分 / 20 分 + 冷却 2 h
+- [チョコレートムース](chocolate-mousse.md) — フレンチ / 4 人分 / 20 分 + 冷却 120 分
 
 ## (タグ未分類)
 
@@ -157,10 +186,15 @@ Rules for the README:
 
 - **Group by primary tag** (the first item in the recipe's `tags`) when there's
   a meaningful taxonomy in use; fall back to "(タグ未分類)" otherwise.
-- **One bullet per recipe**: `[Title](slug.md) — tags / servings / total time`.
-  Use long-form units in the user's language (人分, 分, mins, etc.). Total time
-  = `prepTime + cookTime` if both are set; otherwise show whichever is set;
-  otherwise omit. Tags are slash-joined.
+- **One bullet per recipe**: `[Title](slug.md) — tags / servings / time`.
+  Use long-form units in the user's language (人分, 分, mins, etc.). The
+  time column composes `prepTime + cookTime` (active time only) plus a
+  trailing `+ rest <restTime> 分` suffix when `restTime` is present. Examples:
+    - all three set: `15 + 20 分 + 冷却 120 分`
+    - prepTime + cookTime only: `35 分`
+    - restTime only: `冷却 120 分`
+    - none set: omit the time column entirely
+  Tags are slash-joined.
 - **Don't include `created` / `updated` dates** — they're noisy and rarely
   what the user wants to scan for.
 - **Alphabetical within each group** by display title (Japanese / English

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -317,34 +317,16 @@ export const ROLES: Role[] = [
       "Build a peer-comparison table for the top 5 US semiconductor companies",
     ],
   },
-  {
-    id: "cookingCoach",
-    name: "Cooking Coach",
-    icon: "restaurant",
-    prompt:
-      "You are a Cooking Coach assistant. You help the user keep a personal recipe book — saving recipes they like, retrieving them on demand, and updating them as they refine the technique.\n\n" +
-      "## manageRecipes (runtime plugin)\n\n" +
-      "Use the `manageRecipes` tool for every recipe-book operation. The plugin owns its data; you just call the tool with the right `kind`. Each recipe lives as one markdown file with structured frontmatter (title, tags, servings, prepTime, cookTime, created, updated) and a free-form markdown body.\n\n" +
-      '- **Saving** (`kind: "save"`): when the user shares a recipe they want to remember, distill it into a clean structure first. Pick a kebab-case ASCII slug for the filename — use a romanised form even when the title is non-ASCII (e.g. title `ピーマンの肉詰め` → slug `stuffed-peppers`). Title can be in the user\'s language. Body convention is `## 材料` (or `## Ingredients`) as a bullet list with quantities, then `## 手順` (or `## Steps`) as a numbered list, then optional notes / variations.\n' +
-      '- **Recalling** (`kind: "list"`): when the user asks to see what they\'ve saved, just call list. The canvas surface renders the result automatically.\n' +
-      '- **Updating** (`kind: "update"`): when the user refines a saved recipe, read the current version (list first if needed), apply the change, and call update with the full set of fields. `created` is preserved automatically; `updated` advances on every call.\n' +
-      '- **Deleting** (`kind: "delete"`): only when the user explicitly asks to remove a recipe.\n\n' +
-      "## Visuals\n\n" +
-      'Use `generateImage` to picture a finished dish, plating idea, or step illustration when the user asks ("how does it look?" / "draw me a picture") or when it would clearly help (e.g. an unfamiliar technique). One image per request unless the user asks for variations. Compose the prompt around the dish — appetising, well-lit, top-down or 3/4 plating shot — and let the image render in the chat alongside the recipe.\n\n' +
-      "## Tone\n\n" +
-      "Friendly, focused on the cooking — not the bookkeeping. Don't lecture about file paths or frontmatter; the structure is an implementation detail. When suggesting a substitution or technique, keep it short and practical.",
-    // manageRecipes is provided by the `@mulmoclaude/recipe-book-plugin`
-    // runtime preset (`server/plugins/preset-list.ts`). Runtime
-    // plugins are now gated by `availablePlugins` like static tools,
-    // so the tool name has to be listed here.
-    availablePlugins: [TOOL_NAMES.manageRecipes, TOOL_NAMES.presentForm, TOOL_NAMES.generateImage],
-    queries: [
-      "Save my Mom's stuffed peppers recipe",
-      "Show me the recipes I've saved",
-      "Remember this lasagna I made tonight",
-      "Update my pad thai — bump the lime to 2 tablespoons next time",
-    ],
-  },
+  // The `cookingCoach` built-in role was removed (#1286). Recipe
+  // management is now driven by the `mc-cooking-coach` preset skill —
+  // see `server/workspace/skills-preset/mc-cooking-coach/SKILL.md`.
+  // The recipe-book-plugin source still ships at
+  // `packages/plugins/recipe-book-plugin/` but is no longer in
+  // `PRESET_PLUGINS`, so its MCP tool / Vue View aren't mounted.
+  // Recipes live as plain markdown at `data/cooking/recipes/<slug>.md`
+  // with a `README.md` index the skill maintains. A boot-time
+  // migration helper moves any pre-skill recipes from the plugin's
+  // `files.data` scope to the new path.
   {
     id: "debug",
     name: "Debug",
@@ -378,7 +360,9 @@ export const ROLES: Role[] = [
       TOOL_NAMES.manageBookmarks,
       TOOL_NAMES.manageTodoList,
       TOOL_NAMES.manageSpotify,
-      TOOL_NAMES.manageRecipes,
+      // manageRecipes removed (#1286) — recipe-book-plugin no longer
+      // in PRESET_PLUGINS; recipes drive via the `mc-cooking-coach`
+      // preset skill.
       TOOL_NAMES.manageDebug,
     ],
     queries: [
@@ -416,7 +400,7 @@ export const BUILTIN_ROLE_IDS = {
   // settings: removed (#1283) — replaced by `mc-settings` preset skill.
   accounting: "accounting",
   investor: "investor",
-  cookingCoach: "cookingCoach",
+  // cookingCoach: removed (#1286) — replaced by `mc-cooking-coach` preset skill.
   debug: "debug",
 } as const;
 

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -81,7 +81,9 @@ const HOST_TOOL_NAMES = {
   manageBookmarks: "manageBookmarks",
   manageTodoList: "manageTodoList",
   manageSpotify: "manageSpotify",
-  manageRecipes: "manageRecipes",
+  // manageRecipes removed (#1286) — recipe-book-plugin dropped from
+  // PRESET_PLUGINS; recipe management moved to the `mc-cooking-coach`
+  // preset skill which drives files directly via Read/Write/Edit.
   manageDebug: "manageDebug",
   edgar: "edgar",
 } as const;

--- a/test/workspace/cooking-recipes/test_migrate.ts
+++ b/test/workspace/cooking-recipes/test_migrate.ts
@@ -123,3 +123,48 @@ describe("migrateCookingRecipesFromPlugin — empty source", () => {
     await cleanup();
   });
 });
+
+describe("migrateCookingRecipesFromPlugin — partial failure must NOT mark done (Codex review on #1287)", () => {
+  it("withholds sentinel when a copy fails so the next boot retries", async () => {
+    const { pluginsData, cookingRecipes, cleanup } = await makeTmp("partial");
+    // Source has a real file PLUS a name that points at a missing
+    // file under the legacy dir — we simulate the I/O failure by
+    // making the source unreadable.
+    const legacy = await seedLegacy(pluginsData, { "good.md": "good", "bad.md": "to-be-unreadable" });
+    // Drop read perms on bad.md so copyFile() throws (EACCES).
+    // On systems that ignore mode bits (Windows / root) this won't
+    // simulate failure — guard with an early skip.
+    const { chmod } = await import("node:fs/promises");
+    await chmod(path.join(legacy, "bad.md"), 0o000);
+
+    let result;
+    try {
+      result = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    } finally {
+      // Always restore perms so the tmpdir cleanup below can succeed.
+      await chmod(path.join(legacy, "bad.md"), 0o644);
+    }
+
+    if (result.copyFailures === 0) {
+      // The platform / user runs with root or chmod doesn't take —
+      // can't exercise the failure path here. The assertion below
+      // would be invalid; skip the rest of the check.
+      await cleanup();
+      return;
+    }
+
+    assert.equal(result.copied, 1, "the good file still gets copied");
+    assert.equal(result.copyFailures, 1);
+    assert.equal(result.alreadyDone, false);
+    assert.ok(!existsSync(path.join(cookingRecipes, SENTINEL)), "sentinel MUST NOT be written when a copy failed — next boot retries");
+
+    // Verify retry behaviour: subsequent run with permissions restored
+    // copies the previously-failed file.
+    const retry = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    assert.equal(retry.copied, 1, "retry picks up the file that failed last time");
+    assert.equal(retry.copyFailures, 0);
+    assert.ok(existsSync(path.join(cookingRecipes, SENTINEL)), "sentinel written once the retry succeeds");
+
+    await cleanup();
+  });
+});

--- a/test/workspace/cooking-recipes/test_migrate.ts
+++ b/test/workspace/cooking-recipes/test_migrate.ts
@@ -1,0 +1,125 @@
+// Unit tests for `migrateCookingRecipesFromPlugin` (#1286).
+// Drives the migration against a tmpdir so it never touches the real
+// workspace. Locks in: idempotent, non-overwriting, copy-not-move,
+// empty-source still drops the sentinel, sentinel skip on second run.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { migrateCookingRecipesFromPlugin } from "../../../server/workspace/cooking-recipes/migrate.js";
+
+const LEGACY_SUBPATH = path.join("%40mulmoclaude%2Frecipe-book-plugin", "recipes");
+const SENTINEL = ".migration-from-plugin-done";
+
+async function makeTmp(name: string): Promise<{ pluginsData: string; cookingRecipes: string; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(path.join(tmpdir(), `cook-mig-${name}-`));
+  const pluginsData = path.join(root, "data", "plugins");
+  const cookingRecipes = path.join(root, "data", "cooking", "recipes");
+  return {
+    pluginsData,
+    cookingRecipes,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+async function seedLegacy(pluginsData: string, files: Record<string, string>): Promise<string> {
+  const legacy = path.join(pluginsData, LEGACY_SUBPATH);
+  await mkdir(legacy, { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    await writeFile(path.join(legacy, name), body, "utf-8");
+  }
+  return legacy;
+}
+
+describe("migrateCookingRecipesFromPlugin — happy path", () => {
+  it("copies every .md from the legacy plugin dir to the canonical dir", async () => {
+    const { pluginsData, cookingRecipes, cleanup } = await makeTmp("happy");
+    await seedLegacy(pluginsData, {
+      "stuffed-peppers.md": "---\ntitle: ピーマンの肉詰め\n---\n\nbody A\n",
+      "lasagna.md": "---\ntitle: Lasagna\n---\n\nbody B\n",
+      "not-a-recipe.txt": "should be skipped",
+    });
+
+    const result = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+
+    assert.equal(result.copied, 2);
+    assert.equal(result.skipped, 1, "the .txt file is skipped (not .md)");
+    assert.equal(result.alreadyDone, false);
+
+    const stuffed = await readFile(path.join(cookingRecipes, "stuffed-peppers.md"), "utf-8");
+    assert.match(stuffed, /title: ピーマンの肉詰め/);
+    const lasagna = await readFile(path.join(cookingRecipes, "lasagna.md"), "utf-8");
+    assert.match(lasagna, /title: Lasagna/);
+
+    // Legacy files are LEFT in place (copy, not move).
+    const legacyFile = path.join(pluginsData, LEGACY_SUBPATH, "stuffed-peppers.md");
+    assert.ok(existsSync(legacyFile), "legacy source preserved (copy semantics, not move)");
+
+    // Sentinel dropped.
+    assert.ok(existsSync(path.join(cookingRecipes, SENTINEL)));
+
+    await cleanup();
+  });
+});
+
+describe("migrateCookingRecipesFromPlugin — idempotent", () => {
+  it("second run is a no-op when sentinel exists", async () => {
+    const { pluginsData, cookingRecipes, cleanup } = await makeTmp("idem");
+    await seedLegacy(pluginsData, { "foo.md": "first" });
+
+    await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    // Modify the destination — second run must not clobber it.
+    await writeFile(path.join(cookingRecipes, "foo.md"), "hand-edited", "utf-8");
+
+    const second = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    assert.equal(second.alreadyDone, true);
+    assert.equal(second.copied, 0);
+    assert.equal(second.skipped, 0);
+
+    const after = await readFile(path.join(cookingRecipes, "foo.md"), "utf-8");
+    assert.equal(after, "hand-edited", "second run must NOT overwrite the destination");
+
+    await cleanup();
+  });
+});
+
+describe("migrateCookingRecipesFromPlugin — non-overwriting", () => {
+  it("skips files when the destination already has the same name", async () => {
+    const { pluginsData, cookingRecipes, cleanup } = await makeTmp("noover");
+    await seedLegacy(pluginsData, { "foo.md": "legacy", "bar.md": "legacy" });
+    // Pre-existing destination with a hand-edited foo.md.
+    await mkdir(cookingRecipes, { recursive: true });
+    await writeFile(path.join(cookingRecipes, "foo.md"), "hand-edited", "utf-8");
+
+    const result = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+
+    assert.equal(result.copied, 1, "only bar.md is copied; foo.md is preserved");
+    assert.equal(result.skipped, 1);
+
+    const foo = await readFile(path.join(cookingRecipes, "foo.md"), "utf-8");
+    assert.equal(foo, "hand-edited", "existing foo.md NOT overwritten");
+    const bar = await readFile(path.join(cookingRecipes, "bar.md"), "utf-8");
+    assert.equal(bar, "legacy");
+
+    await cleanup();
+  });
+});
+
+describe("migrateCookingRecipesFromPlugin — empty source", () => {
+  it("drops sentinel even when there's no legacy plugin dir", async () => {
+    const { pluginsData, cookingRecipes, cleanup } = await makeTmp("empty");
+    // No legacy directory at all.
+    const result = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    assert.equal(result.copied, 0);
+    assert.equal(result.alreadyDone, false);
+    assert.ok(existsSync(path.join(cookingRecipes, SENTINEL)), "sentinel still dropped so future boots skip re-statting");
+
+    const second = await migrateCookingRecipesFromPlugin({ pluginsDataRoot: pluginsData, cookingRecipesRoot: cookingRecipes });
+    assert.equal(second.alreadyDone, true);
+
+    await cleanup();
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -26,6 +26,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "claudeSkills",
     "configs",
     "contacts",
+    "cookingRecipes",
     "github",
     "helps",
     "html",


### PR DESCRIPTION
## Summary

Same pattern as #1284 (\`settings\` → \`mc-settings\`). The \`cookingCoach\` role + \`recipe-book-plugin\` collapse into a preset skill that drives recipes via Read/Write/Edit on plain markdown files. The plugin source stays in the repo (per user request \"plugin はのこしておいてよい\") but is no longer in \`PRESET_PLUGINS\`, so its MCP tool / Vue View don't mount.

Closes #1286.

## Items to Confirm / Review

1. **README.md as the index** — per user's \"list view 機能は不要だけど、README.md で一覧を管理してほしい\". The skill body instructs Claude to regenerate \`data/cooking/recipes/README.md\` after every save/update/delete: grouped by primary tag, one bullet per recipe with \`[Title](slug.md) — tags / servings / total time\`. Worth confirming the format matches your mental model.

2. **Migration is one-shot + safe** — Files are COPIED, not moved, so the plugin's \`files.data\` storage is preserved if the migration ever runs into trouble. A sentinel \`.migration-from-plugin-done\` in the new dir prevents re-runs. Non-overwriting: a pre-existing destination file is preserved (lets you hand-edit before the migration runs).

3. **`generateImage` access** — Old role exposed \`generateImage\` explicitly. The new skill is invoked from any role; \`general\` already has \`generateImage\` so the user's \"dish photo?\" path still works there. If you invoke the skill from a role that lacks \`generateImage\`, the LLM falls back to text.

4. **Plugin source preserved** — \`packages/plugins/recipe-book-plugin/\` is untouched. Re-enabling = one line in \`server/plugins/preset-list.ts\`. The skill route doesn't try to be reverse-compatible — they're independent.

5. **Sentinel format** — The sentinel file is human-readable (date + result). If a future maintainer wants to force re-migration, delete the sentinel; safe because the migration is non-overwriting.

## User Prompt (verbatim)

> Cooking Coach も skill に移行できる？plugin はのこしておいてよいけど、システムにはとうろくしないで。
>
> 私しか使ってないのでデータ移行はここで一度だけすればよい。list view 機能は不要だけど、README.md で一覧を管理してほしい。それも skill にかいて。新しいブランチですすめてね。

## Validation

- \`yarn typecheck\` ✅
- \`yarn lint\` ✅
- \`yarn build:packages\` ✅
- \`yarn test\` ✅ (4502 / 4502)
- Migration unit tests ✅ (4 / 4: happy path, idempotent, non-overwriting, empty source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New cooking coach preset skill with workflows to save, browse, edit, delete, and visualize recipes plus automatic README index generation.

* **Updates**
  * Recipe storage moved to a canonical workspace location; legacy plugin preset removed and recipe management exposed via the new skill.
  * Automatic, idempotent startup migration copies existing recipes into the new location (safe retry behavior).

* **Tests**
  * Added migration and workspace-path shape tests, including partial-failure retry scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1287)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->