### PR TITLE
docs: extension-mechanisms — skill-first design guidelines + path constraints

### DIFF
--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -236,9 +236,17 @@ const hasMcp = activePlugins.length > 0 || hasUserServers;
 **何**: markdown で書かれた手順書。LLM の **tool ではない** — frontmatter + 本文を持ち、
 Claude Code SDK が「使うべき場面」を判断して system prompt の一部として LLM に提示する。
 
-**置き場**:
-- `~/.claude/skills/<name>/SKILL.md` — user scope (read-only from MulmoClaude)
-- `<workspace>/.claude/skills/<name>/SKILL.md` — project scope (writable via `manageSkills`)
+**置き場 (Claude Code SDK の制約)**:
+
+Claude Code SDK が skill を読みに行くパスは **2 つだけ**で、CLI オプションで第三のパスを指定する方法はない:
+
+- `~/.claude/skills/<name>/SKILL.md` — user scope (どこからでも読まれる)
+- `<cwd>/.claude/skills/<name>/SKILL.md` — project scope (実行時 cwd の直下)
+
+この制約のため、MulmoClaude では:
+
+- **MulmoClaude エンドユーザ向け**: `<workspace>/.claude/skills/` (デフォルト `~/mulmoclaude/.claude/skills/`) — agent 起動時 cwd を workspace に固定しているので、ここが project scope として効く
+- **リポジトリ直下の `.claude/skills/`**: 開発者が monorepo で `cwd=<repo>` で作業するとき用。**MulmoClaude を「アプリ」として使うユーザからは見えない** — 同梱したくないなら repo `.claude/` に置けば自然に区切られる
 
 **Frontmatter 例**:
 
@@ -263,6 +271,16 @@ schedule: "interval 168h"
 // server/api/routes/skills.ts:57
 const skills = await discoverSkills({ workspaceRoot: workspacePath });
 ```
+
+**ドキュメント系操作の典型パターン: skill + hook**:
+
+`presentDocument` / `presentSpreadsheet` / `manageWiki` といったドキュメント系の更新は、独自 endpoint を増やさず **skill が規約を教える → LLM が Read/Write/Edit で直接ファイル操作 → 必要な後処理は Claude Code SDK の hook で受ける**、という設計に寄せている:
+
+1. skill が markdown / YAML / JSON の **保存先と書式規約**を LLM に教える
+2. LLM が `Read` / `Write` / `Edit` で `<workspace>/data/<type>/<slug>.md` 等を**直接**更新する (plugin API を介さない)
+3. **後処理が必要**な書き込みは Claude Code SDK の **PostToolUse hook** で受ける — `<workspace>/.claude/settings.json` で `hooks.PostToolUse[]` に `matcher: "Write"` を宣言し、hook スクリプトが `tool_input.file_path` を見て **ファイルパスで処理を分岐**する (例: wiki ページ書き込み → インデックス再計算 / `<img>` ref 補修、accounting JSON 書き込み → 集計キャッシュ無効化)
+
+これにより、LLM 視点は「ファイルを書くだけ」のシンプルな世界のまま、サーバ側でドキュメント整合性を担保できる。endpoint を切らないので plugin 用テスト・ドキュメント・MCP 露出も不要。
 
 **重要**:
 - skill は **tool ではない**ので、プログラム連携 (`tools/call` で他 plugin から呼ぶ) には使えない
@@ -387,7 +405,79 @@ session 開始時の処理 (`server/agent/index.ts:39-99`):
 
 ---
 
-## 6. 関連ドキュメント
+## 6. 設計指針
+
+新しい機能をどの機構で実装するか迷ったら、**できる限り skill で実現する**ことを基本姿勢とし、以下の順番で検討する。
+
+### 6.1 まず skill で実現できないか考える
+
+新機能の第一候補は **skill (§3.5) + ファイル規約**。LLM は `Read` / `Write` / `Edit` / `Glob` / `Bash` を最初から持っているので:
+
+- データ保存・更新・取得は skill が「どこに、どの形式で置くか」を教えるだけで成立する
+- ユーザは markdown / YAML / JSON を直接編集でき、ファイル自体が source of truth
+- skill 同士で規約を共有でき、別 Role から流用しやすい
+
+これで済むなら **plugin endpoint・API・テスト・MCP 露出を一切書かなくていい**。reading list、bookmarks、recipe、travel log といった「データを置く・読む・更新する」系は全部このパターンで実装できる。
+
+### 6.2 プログラム的処理が必要なら、まず hook との組み合わせを検討
+
+skill だけだと足りない (= LLM がファイルを書いた後にサーバ側で何か計算したい / 整合性を取りたい) ケースが出てきたら、**plugin を作る前に Claude Code SDK の hook と組み合わせる**:
+
+- LLM は skill の規約どおりに `Write` でファイルを書く
+- `<workspace>/.claude/settings.json` の `hooks.PostToolUse[]` (matcher: `"Write"`) が発火
+- hook スクリプトが `tool_input.file_path` を見て、該当パスならインデックス更新 / cache 無効化 / 通知発火 / 整合性チェック等を行う
+
+これでも足りない (= LLM が呼び出せる handler が必要) なら、次の選択肢は **skill から外部コマンド / 既存 endpoint を叩く**:
+
+- skill の指示で `Bash` ツール経由でスクリプトを実行する
+- 既存の MCP tool (`notify` 等) や built-in plugin endpoint を skill から呼ぶよう促す
+- カスタム CLI を `<workspace>/bin/` に置いて skill から呼ばせる
+
+ここまでで済むなら、**plugin を増やさずに新機能が完結する**。
+
+### 6.3 やむを得ない場合のみ plugin を増やす
+
+skill + hook + 外部呼び出しでは表現できない場合に限り plugin を作る。具体的には:
+
+- **複雑なビジネスロジック・不変条件**: accounting (借方/貸方バランス、税計算、月次決算) のように LLM が JSON を直書きすると整合性が壊れるケース → サーバ側 validator + plugin endpoint が必要
+- **専用 canvas UI**: chart / spreadsheet / map / canvas drawing 等、markdown レンダリングだけでは不十分で固有 Vue コンポーネントが要るケース
+- **リアルタイム / マルチタブ同期**: 複数のタブ・複数の家族端末で同じ状態を共有したいケース (pubsub channel)
+
+**plugin と role は極力増やさない**。判断基準:
+
+- LLM が任意のテキストを書いても問題ないか → **skill** (§3.5)
+- 後処理だけ必要か → **skill + hook** (§6.2)
+- 「整合した状態」と「壊れた状態」が事後に判別できるか・専用 UI が要るか → **plugin** (§3.1)
+
+### 6.4 Role の追加にも慎重に
+
+現在 built-in Role は 10 種。**これ以上は積極的に増やさない方針**。Role が増えると新規ユーザの「最初に何を選べばいいか」迷いが増え、機能間の境界がぼやける。
+
+Role を増やしたくなったら、まず以下で代替できないか検討する:
+
+- **skill で代替**: ペルソナの違いが軽い (口調・粒度) なら skill の方が軽量、複数 skill が並列に効ける
+- **既存 Role の prompt 拡張**: 既存 Role の延長線上にあるなら、その Role の prompt にセクションを足す (`config/helps/*.md` への分割も検討)
+- **user-defined role**: 1 ユーザの専用需要なら `manageRoles` でユーザに作ってもらう (built-in に押し込まない)
+
+Role を増やすのが正解になるのは:
+
+- 「会話の最初に明示的に切り替えるべき」レベルの**大きなペルソナの差** (cookingCoach のような専門領域 = 別アプリのつもりで開く)
+- `availablePlugins` のセットが他 Role と明確に違う (e.g. office は presentation 系、accounting は仕訳系)
+- `queries` で示す代表的なユースケースが他 Role と被らない
+
+### 6.5 システム側で便利な skill を多めに同梱する
+
+skill は markdown 1 枚で、追加コストが小さい。MulmoClaude 側があらかじめ **便利な skill をプリセットとして複数同梱**しておくと、ユーザが skill を 1 つも書かなくても多くの機能が手に入る。これが「plugin / role を増やさず機能を増やす」基本戦略になる。
+
+同梱 skill を考えるときのポイント:
+
+- LLM がそれを実行する場面はどんなトリガで来るか (会話の流れで自然に出てくる? `schedule:` で定期実行?)
+- skill 内で参照する規約ファイル (`config/helps/*.md`) と分離するか統合するか
+- 似た役割の skill を分けるか統合するか — 細かすぎると LLM が「使うべき場面」を判断しにくくなる
+
+---
+
+## 7. 関連ドキュメント
 
 - [`developer.md`](developer.md) — アーキ全体、ディレクトリ構造、開発フロー
 - [`plugin-runtime.md`](plugin-runtime.md) — runtime plugin の API 契約 (#3)


### PR DESCRIPTION
## Summary

Expands \`docs/extension-mechanisms.md\` (§3.5 Skill + new §6 設計指針) to capture the project's stated design priority — **try skill first, plugin / role as last resort** — and to record the two operational details that drove the recent direction-shift on plugin work (#1190 reading-list closed in favour of skill, etc.).

## Items to Confirm / Review

- **Skill path constraint is now documented** (§3.5): Claude Code SDK resolves only \`~/.claude/skills/\` and \`<cwd>/.claude/skills/\`. There is no CLI flag to override. MulmoClaude pins agent cwd to the workspace root so \`<workspace>/.claude/skills/\` becomes the user-visible project scope; the repo's own \`.claude/skills/\` stays dev-only. This explains why an end-user installing MulmoClaude from npm doesn't see the repo's skills (and shouldn't).
- **Skill + PostToolUse hook pattern** (§3.5): documented as the recommended way to add server-side post-processing for document-style updates without growing a plugin endpoint. The hook branches on \`tool_input.file_path\`.
- **§6 設計指針** is ordered as a priority cascade:
  1. 6.1 — Try skill alone first
  2. 6.2 — Need program-side logic? Try skill + hook, or skill + external command (Bash / existing MCP tool / custom CLI)
  3. 6.3 — Plugin only as last resort (complex invariants like accounting, dedicated canvas UI, real-time sync)
  4. 6.4 — Role additions also conservative — 10 is the current ceiling
  5. 6.5 — Ship useful skills system-side to grow capability without growing plugin / role count

## User Prompt

The user asked to capture three policy points in \`docs/extension-mechanisms.md\`:

> skill の読み込みは ~/.claude か cwd の .claude/ 以下からしか読み込めない。cli の option 等で skill の置き場の指定はできない。なので、今は workspace (~/mulmoclaude) 以下に .claude をおいて使うようにしている (mulmoclaude から使う場合)。 レポジトリにある .claude は開発用なのでユーザが mulmoclaude からつかうことはできない
>
> document 系は skill で更新するようにして、後処理が必要なら claude code の hook (write 処理でフックしているので、そこで、ファイルパスをみて処理を分岐) で、処理するようにしています
>
> 全般的な話をすると:
> - Role の追加には慎重に (これ以上は増やしたくないです)
> - LLM が直接ファイルを操作できる場合は、API を介せずに直接やらせる。ただし、Accounting のような複雑なビジネスロジックが絡む場合は API を用意して制御
> - システム側で便利な Skill を複数提供し、それを使ってさまざまな便利な機能を提供する

Follow-up clarification:

> できる限り skill で実現できるようにする。プログラムが必要なら hook との組み合わせでできないか、もしくは skill で何かを呼び出すことでできないかを考える。plugin, role は極力増やさない。

## Implementation

\`docs/extension-mechanisms.md\` only — no code change. +94/-4 lines.

- §3.5 (Skill): replaced the two-line \"置き場\" block with a Claude-Code-SDK-constraint-aware explanation, and inserted a new \"ドキュメント系操作の典型パターン: skill + hook\" block describing the file-write → PostToolUse hook pattern.
- §6 (new \"設計指針\"): five subsections capturing the priority order. §7 (\"関連ドキュメント\") shifts down accordingly.

## Test plan

- [x] Docs-only change; `yarn typecheck` / `yarn lint` clean
- [ ] Reviewer reads §6 end-to-end and confirms the cascade reflects the project's intent
- [ ] Reviewer skims §3.5 path-constraint paragraph and confirms it matches how MulmoClaude actually loads skills today

🤖 Generated with [Claude Code](https://claude.com/claude-code)