### PR TITLE
docs: document preset-skill location in extension-mechanisms.md

### DIFF
--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -260,6 +260,20 @@ schedule: "interval 168h"
 
 **`schedule:` を持つ skill** は scheduler が自動実行する (`server/api/routes/scheduler.ts`)。
 
+**Preset skills (launcher 同梱)**:
+
+リポジトリには **launcher が同梱して出荷するプリセット skill** が `server/workspace/skills-preset/<name>/SKILL.md` に置かれている。命名規約は `mc-` プレフィックス (= "MulmoClaude managed") — workspace 側でこの prefix を持つ skill は launcher 起動時に上書き同期されるので、ユーザがその場で編集しても次回 boot で元に戻る。リポジトリ側を編集して PR を出すのが正規ルート。
+
+現在の preset (`mc-` prefix 持ち):
+
+| Preset | 用途 |
+|---|---|
+| `mc-settings` | 設定 (roles / mcp.json / sources / skills / automations) の編集手順 |
+| `mc-library` | wiki / sources / 通知の横断 query (`(:..)` リンク文法を含む) |
+| `mc-cooking-coach` | レシピの保存・更新・削除と `data/cooking/recipes/README.md` 索引維持 |
+
+同期の実装は `server/workspace/skills-preset.ts` (`syncPresetSkills`)。起動時に `server/workspace/workspace.ts:44` から呼ばれ、`<launcher>/server/workspace/skills-preset/` → `<workspace>/.claude/skills/` へコピーされる。ユーザ作成 skill (`mc-` でない名前) は同期対象外なので影響を受けない。
+
 **ソース実装**:
 
 - Discovery: `server/workspace/skills/index.ts` の `discoverSkills` — user + project を merge、project 優先

--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -269,7 +269,7 @@ schedule: "interval 168h"
 | Preset | 用途 |
 |---|---|
 | `mc-settings` | 設定 (roles / mcp.json / sources / skills / automations) の編集手順 |
-| `mc-library` | wiki / sources / 通知の横断 query (`(:..)` リンク文法を含む) |
+| `mc-library` | 読書記録 — 読みたい本 / 読了の登録、感想を本人の言葉で記録、後から想起できるジャーナル |
 | `mc-cooking-coach` | レシピの保存・更新・削除と `data/cooking/recipes/README.md` 索引維持 |
 
 同期の実装は `server/workspace/skills-preset.ts` (`syncPresetSkills`)。起動時に `server/workspace/workspace.ts:44` から呼ばれ、`<launcher>/server/workspace/skills-preset/` → `<workspace>/.claude/skills/` へコピーされる。ユーザ作成 skill (`mc-` でない名前) は同期対象外なので影響を受けない。


### PR DESCRIPTION
## Summary

- Add a **Preset skills (launcher 同梱)** subsection to §3.5 Skill in [\`docs/extension-mechanisms.md\`](docs/extension-mechanisms.md), pointing readers at \`server/workspace/skills-preset/<name>/SKILL.md\` as the source of truth for the launcher-managed \`mc-*\` skills.
- List the current three presets (\`mc-settings\`, \`mc-library\`, \`mc-cooking-coach\`) with one-line purposes.
- Reference the sync code (\`server/workspace/skills-preset.ts\` + \`workspace.ts:44\`) and explain the \`mc-\` namespace boundary so contributors know user-authored skills are never overwritten.

## Items to Confirm / Review

- The current preset list is accurate as of this PR's merge base — if a new \`mc-*\` preset lands before this is merged, the list needs to grow.
- The line reference \`workspace.ts:44\` is fragile; if it drifts the doc still reads OK without it, but happy to drop the line number if reviewers prefer.

## User Prompt

> Where do preset skills live in the repo? — please add that to https://github.com/receptron/mulmoclaude/blob/main/docs/extension-mechanisms.md (separate from the upcoming \`mc-manage-skills\` work).

## Implementation Approach

Docs-only — no code touched. The §3.5 Skill section already covered runtime paths (\`~/.claude/skills/\`, \`<workspace>/.claude/skills/\`); the gap was about the *source* location and the \`mc-\` namespace contract. Patch lands the missing subsection between the existing \`schedule:\` paragraph and the "ソース実装" heading, so the flow goes: frontmatter example → scheduled skills → preset skills → source impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)