### PR TITLE
fix(wiki): reset scroll to top when navigating between wiki pages

### DIFF
--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -179,6 +179,56 @@ test.describe("wiki navigation — URL sync", () => {
     await expect(page.getByText("Welcome to the project.")).toBeVisible();
   });
 
+  test("clicking an in-content [[wiki-link]] resets scrollTop on the destination page", async ({ page }) => {
+    // Regression guard: the action='page' Content tab container kept
+    // its scrollTop across page->page navigation because it was the
+    // only branch missing ref="scrollRef", so the watch(content)
+    // reset silently no-op'd. The destination page would land at
+    // wherever the source page was scrolled to, not at the top.
+    const filler = "Filler paragraph for scrollable height.\n\n".repeat(80);
+    const PAGE_FROM = {
+      action: "page",
+      title: "from-page",
+      pageName: "from-page",
+      content: `# From\n\n${filler}\nGo to [[to-page]] now.\n`,
+    };
+    const PAGE_TO = {
+      action: "page",
+      title: "to-page",
+      pageName: "to-page",
+      content: `# To\n\nSENTINEL-DEST-TOP\n\n${filler}`,
+    };
+    await page.route(
+      (url) => url.pathname === "/api/wiki",
+      async (route) => {
+        const body = (route.request().postDataJSON() ?? {}) as { pageName?: string };
+        if (body.pageName === "from-page") return route.fulfill({ json: { data: PAGE_FROM } });
+        if (body.pageName === "to-page") return route.fulfill({ json: { data: PAGE_TO } });
+        return route.fulfill({ json: { data: INDEX_PAYLOAD } });
+      },
+    );
+
+    await page.goto("/wiki/pages/from-page");
+    const wikiBody = page.getByTestId("wiki-page-body");
+    await expect(wikiBody).toBeVisible();
+    // The scrollable container is WikiPageBody's parent — the div
+    // that now carries ref="scrollRef" in src/plugins/wiki/View.vue.
+    const scrollContainer = wikiBody.locator("xpath=..");
+    const SOURCE_SCROLL_PX = 400;
+    await scrollContainer.evaluate((element, top) => {
+      element.scrollTop = top as number;
+    }, SOURCE_SCROLL_PX);
+    expect(await scrollContainer.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+
+    await page.locator('.wiki-link[data-page="to-page"]').click();
+    await page.waitForURL(/\/wiki\/pages\/to-page$/);
+    await expect(page.getByText("SENTINEL-DEST-TOP")).toBeVisible();
+
+    // Same DOM container is reused (action stays 'page'); the fix's
+    // ref="scrollRef" lets the watch(content) reset scrollTop to 0.
+    await expect(scrollContainer).toHaveJSProperty("scrollTop", 0, { timeout: 2000 });
+  });
+
   test("navigating from a page back to the index strips the slug from the URL (#655 follow-up)", async ({ page }) => {
     // Regression: buildWikiRouteParams({ kind: "index" }) used to
     // return `{}`, but Vue Router's named-route navigation does NOT

--- a/plans/fix-wiki-link-scroll-top.md
+++ b/plans/fix-wiki-link-scroll-top.md
@@ -1,0 +1,43 @@
+# fix: wiki ページ間リンクで遷移時にスクロールが先頭に戻らない
+
+## 症状
+
+Wiki ページ内のリンク (`[[other-page]]` など) をクリックして別の Wiki
+ページに遷移したとき、新ページの先頭ではなく、前ページのスクロール位置
+を引き継いだ「中途半端な位置」が表示される。
+
+## 根本原因
+
+`src/plugins/wiki/View.vue` の `action === 'page'` 用 Content タブの
+スクロールコンテナ (230 行目) に `ref="scrollRef"` が付いていない。
+
+```html
+<!-- 現状: scrollRef なし -->
+<div v-show="pageTab === PAGE_TAB.content" class="flex-1 overflow-y-auto flex flex-col">
+```
+
+他のビュー (index/page-edit/log・lint) には `ref="scrollRef"` が付いて
+おり、`watch(content)` で scrollTop=0 にリセットされる仕組み
+(672-675 行目)。
+
+```ts
+watch(content, async () => {
+  await nextTick();
+  if (scrollRef.value) scrollRef.value.scrollTop = 0;
+});
+```
+
+ページ→ページ遷移では `action` は `'page'` のまま `content.value`
+だけ変わるため、スクロールコンテナは同じ DOM が再利用される。
+`scrollRef.value` が `null` のためリセットがサイレントにスキップされ、
+前ページのスクロール位置が残る。
+
+## 修正
+
+230 行目のコンテナに `ref="scrollRef"` を追加する。1 行の変更。
+
+## E2E 観点
+
+`e2e/` 配下の wiki テストには「リンククリック後の scrollTop 検証」は
+存在しない。回帰検出用に最小のテストを追加するか、手動確認のみで済ませ
+るかは PR レビューで判断。まずは修正のみコミットし、PR で議論する。

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -227,7 +227,7 @@
            fallbacks (deleted page / page with no body) so the
            History tab next to it stays reachable in those states. -->
       <template v-if="action === 'page'">
-        <div v-show="pageTab === PAGE_TAB.content" class="flex-1 overflow-y-auto flex flex-col">
+        <div v-show="pageTab === PAGE_TAB.content" ref="scrollRef" class="flex-1 overflow-y-auto flex flex-col">
           <!-- Empty state: page does not exist. -->
           <div v-if="!pageExists" class="flex-1 flex items-center justify-center text-gray-400 text-sm">
             <div class="text-center space-y-4">


### PR DESCRIPTION
## Summary

- Wiki ページ内リンク (`[[other-page]]`) をクリックして別ページに遷移すると、新ページの先頭ではなく前ページのスクロール位置を引き継いでしまう不具合を修正
- 原因は `action === 'page'` の Content タブ用スクロールコンテナにだけ `ref=\"scrollRef\"` が付いておらず、既存のスクロールリセット watch がサイレントに no-op していたため
- 1 行修正 + e2e リグレッションテスト 1 本

## Items to Confirm / Review

- **Vue template ref のバインディング** — `scrollRef` は `index` / `page` / `page-edit` / `log・lint` の 4 つの v-if/v-show 分岐に出現するが、Vue Router の `action` 分岐により同時にマウントされるのは 1 つだけ。Codex も「mutually exclusive」で問題なしと確認済み。`page` 分岐内では `v-show` で常駐するため、ページ→ページ遷移で同一 DOM が再利用される (= 本不具合の根本原因) 点も意図通り
- **e2e route stub の網羅性** — 新規テストの `page.route` は POST のみハンドリング。Codex iter-2 で「将来 GET ベースに refactor したらサイレントに INDEX_PAYLOAD が返る」と質問あり。実際には sentinel テキスト不一致で loud に fail するため現状維持としたが、`mockWikiApi` 同様 method/slug を明示する方が堅牢という意見もあり、お任せ判断
- **History タブとの相互作用** — `watch(content)` は History タブで restore した時にも発火する。隠れた Content ペインを 0 に戻し、ユーザがタブ切り替えで戻ると先頭が見える挙動になる (Codex iter-1 question で確認済み・既存挙動と一致)

## User Prompt

> wiki の中のリンクをクリックして、別の wiki に行くと、そのページの上部ではなくて、中途半端な位置でのページ切り替えになります。
> 1 調査して
> 2 修正は work tree
>
> Commit した後に /codex-cross-review を回して

## 原因

[src/plugins/wiki/View.vue:230](src/plugins/wiki/View.vue) の Content タブ用スクロールコンテナに `ref=\"scrollRef\"` が付いていなかった。

```vue
<!-- 修正前 -->
<div v-show=\"pageTab === PAGE_TAB.content\" class=\"flex-1 overflow-y-auto flex flex-col\">
```

他のビュー (index / page-edit / log・lint) には `ref=\"scrollRef\"` が付いており、`watch(content)` で `scrollTop = 0` にリセットされる仕組み (672-675 行)。

```ts
watch(content, async () => {
  await nextTick();
  if (scrollRef.value) scrollRef.value.scrollTop = 0;
});
```

ページ→ページ遷移では `action` は `'page'` のまま `content.value` だけ変わるため同じスクロールコンテナが再利用される。`scrollRef.value` が `null` のためリセットがサイレントスキップされ、前ページのスクロール位置が残る → 「中途半端な位置」に見える。

## 修正

```diff
-<div v-show=\"pageTab === PAGE_TAB.content\" class=\"flex-1 overflow-y-auto flex flex-col\">
+<div v-show=\"pageTab === PAGE_TAB.content\" ref=\"scrollRef\" class=\"flex-1 overflow-y-auto flex flex-col\">
```

## Test Plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` すべて pass
- [x] `wiki-navigation.spec.ts` 全 26 件 pass
- [x] 新規追加テストの failing-without-fix 検証: 本修正前のファイルで実行すると `scrollTop = 2701` で fail することを確認、修正後は 0 で pass

## Codex Cross-Review

`/codex-cross-review` で 2 iteration 回し、両者収束:

- **iter-1**: CHANGES REQUESTED — 「e2e リグレッションテスト未追加」を must-fix で指摘 → 対応してコミット
- **iter-2**: **LGTM** — 「テストはリグレッションパスを正しくカバー、既存テストと一貫性あり」と評価

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll position not resetting to the top when navigating between wiki pages via in-content links.

* **Tests**
  * Added end-to-end test to verify scroll position correctly resets during wiki page navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1294)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->