### PR TITLE
docs(readme): add missing entries for extension-mechanisms + migration guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Guides for using MulmoClaude. No programming knowledge required.
 | [LINE セットアップ](message_apps/line/README.ja.md)         | 日本語   | LINE bot の作成と接続手順 (ngrok 必要)                  |
 | [Relay Setup](message_apps/relay/README.md)                 | English  | Deploy a cloud relay — no ngrok, offline queue          |
 | [Relay セットアップ](message_apps/relay/README.ja.md)       | 日本語   | クラウドリレーのデプロイ — ngrok 不要、オフラインキュー |
+| [Claude Code → MulmoClaude 移行ガイド](migrating-from-claude-code.md) | 日本語 | 普段 Claude Code (CLI) を使っているユーザ向けの移行手順 — skill / MCP / hooks / settings の引っ越し早見表 |
 
 ## Tips & Integrations
 
@@ -39,6 +40,14 @@ Guides for using MulmoClaude. No programming knowledge required.
 | [Image-path Routing — Research](image-path-routing.md)            | English  | Read-only audit of how the LLM's image references become browser-loadable URLs                                     |
 | [Image-path Routing — 設計議論](discussion-image-path-routing.md) | 日本語   | 画像パスのルーティング再設計の議論メモと段階的実装計画                                                             |
 | [Wiki / HTML 表示サーフェス](wiki-html-render-surfaces.md)        | 日本語   | Wiki / HTML / Markdown が表示される複数箇所の差異 (権限・画像パス解決) を整理                                      |
+
+## Extension Mechanisms
+
+Before adding a new feature, pick the right extension path. The document below compares all seven (built-in plugin / runtime plugin / external MCP / skill / role / bridge / built-in MCP-only tool), maps which capabilities each one offers, and gives the project's design priority (skill-first; plugin / role only as last resort).
+
+| Document                                                          | Language | Description                                                                                                                                                                            |
+| ----------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Extension Mechanisms — どこに何を作るか](extension-mechanisms.md) | 日本語   | 7 つの拡張経路の比較・capability マトリクス・判断ガイド・設計指針 (skill ファースト / plugin と role は極力増やさない方針)                                                              |
 
 ## Plugin Authoring
 


### PR DESCRIPTION
## Summary

Two top-level docs under \`docs/\` were missing from \`docs/README.md\` and therefore unreachable from the documentation index. Sweep PR to plug both:

- **\`extension-mechanisms.md\`** (#1292, just merged) — added under a new **\"Extension Mechanisms\"** section between \"Tips & Integrations\" and \"Plugin Authoring\". Sitting right above Plugin Authoring puts the choose-your-path doc in front of contributors before they dive into plugin-specific specs.
- **\`migrating-from-claude-code.md\`** — Japanese migration guide for users moving from the Claude Code CLI. Added as the last row under **\"End Users\"** (the other Japanese user guides live there).

After this change every \`.md\` under \`docs/\` (excluding the README itself, \`docs/releases/\`, and the \`docs/message_apps/\` subdirs that are already linked via the parent rows) is reachable from \`docs/README.md\`.

## Verification

\`\`\`bash
for f in \$(find docs -name \"*.md\" -not -path \"*/releases/*\" -not -path \"*/message_apps/*\" | grep -v \"^docs/README.md$\"); do
  rel=\${f#docs/}
  if ! grep -q \"\\b\$rel\\b\" docs/README.md; then
    echo \"MISSING: \$f\"
  fi
done
\`\`\`

Returns no output on this branch (was \`MISSING: docs/extension-mechanisms.md\` + \`MISSING: docs/migrating-from-claude-code.md\` on main).

## User Prompt

> このファイル (extension-mechanisms.md) って docs/readme には記載されてないよね？漏れないか確認して PR 化

## Test plan

- [x] Index sweep confirms every doc reachable
- [x] No code touched; docs-only
- [ ] Reviewer skims the two new rows for the right section placement / language tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guide for Claude Code users
  * Introduced Extension Mechanisms documentation section with accompanying reference material

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1295)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->