### PR TITLE
feat: allow extending built-in roles with extra plugins

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -29,7 +29,7 @@ function parseDispatchAction(body: string | null): string | undefined {
   }
 }
 
-const DEFAULT_ROLES: unknown[] = [];
+const DEFAULT_ROLES = { customRoles: [], builtInExtras: {} };
 
 const DEFAULT_TODOS = {
   data: {

--- a/e2e/tests/accounting-isolation.spec.ts
+++ b/e2e/tests/accounting-isolation.spec.ts
@@ -31,22 +31,21 @@ test.describe("accounting plugin — isolation regression", () => {
     expect(pathname).toMatch(/^\/chat(?:\/[\w-]+)?$/);
   });
 
-  test("/roles surfaces no manageAccounting plugin on a fresh workspace", async ({ page }) => {
-    // Smoke check that the /roles page doesn't accidentally surface
-    // the accounting tool — currently passes because /roles only
-    // renders custom roles on a fresh workspace, so the assertion
-    // is more of a "the page is clean" guard than a strict
-    // role-config check.
+  test("/roles General role row never lists manageAccounting", async ({ page }) => {
+    // Defense against a regression that mixes the Accounting plugin
+    // into the General role's baseline. /roles now renders built-in
+    // role rows (each with the merged plugin list as text), so the
+    // assertion is scoped to the General row only — the Accounting
+    // row legitimately surfaces `manageAccounting` and must not be
+    // flagged here.
     //
     // The strict "the General role's availablePlugins must not
     // include manageAccounting" invariant lives in
     // test/roles/test_role_schema.ts (`describe("General role
-    // isolation")`). That unit test is the real regression guard;
-    // this e2e check stays as a defense against a future RolesView
-    // change that starts surfacing built-in role plugin lists with
-    // manageAccounting on display.
+    // isolation")`); this e2e mirrors it at the UI layer.
     await page.goto("/roles");
     await page.waitForLoadState("networkidle");
-    await expect(page.getByText("manageAccounting")).toHaveCount(0);
+    const generalRow = page.getByRole("listitem").filter({ hasText: /^General/ });
+    await expect(generalRow.getByText("manageAccounting")).toHaveCount(0);
   });
 });

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -137,19 +137,11 @@ function saveRoleResult(input: ManageRolesInput, sessionId: string): Record<stri
   };
 }
 
-function extendBuiltinResult(input: ManageRolesInput, sessionId: string): Record<string, unknown> {
-  const { roleId, extraPlugins } = input;
-  if (!roleId) return { success: false, error: "roleId is required for extendBuiltin action" };
-  if (!BUILTIN_IDS.has(roleId)) {
-    return { success: false, error: `Role '${roleId}' is not a built-in role.` };
-  }
-  if (!Array.isArray(extraPlugins)) {
-    return { success: false, error: "extraPlugins (string[]) is required for extendBuiltin action" };
-  }
-  // Reject non-string entries silently; baseline plugins in the input
-  // are dropped (they're already included by the built-in, so there's
-  // nothing to persist). Dedup preserves first-seen order.
-  const baseline = BUILTIN_BASELINE.get(roleId) ?? new Set<string>();
+// Filter the user-supplied extras list down to what actually gets
+// persisted: non-empty strings, none from the built-in baseline
+// (the baseline is always applied by the loader, so persisting it
+// would be a duplicate), dedup preserving first-seen order.
+function cleanExtraPlugins(extraPlugins: readonly unknown[], baseline: ReadonlySet<string>): string[] {
   const seen = new Set<string>();
   const cleaned: string[] = [];
   for (const name of extraPlugins) {
@@ -159,6 +151,19 @@ function extendBuiltinResult(input: ManageRolesInput, sessionId: string): Record
     seen.add(name);
     cleaned.push(name);
   }
+  return cleaned;
+}
+
+function extendBuiltinResult(input: ManageRolesInput, sessionId: string): Record<string, unknown> {
+  const { roleId, extraPlugins } = input;
+  if (!roleId) return { success: false, error: "roleId is required for extendBuiltin action" };
+  if (!BUILTIN_IDS.has(roleId)) {
+    return { success: false, error: `Role '${roleId}' is not a built-in role.` };
+  }
+  if (!Array.isArray(extraPlugins)) {
+    return { success: false, error: "extraPlugins (string[]) is required for extendBuiltin action" };
+  }
+  const cleaned = cleanExtraPlugins(extraPlugins, BUILTIN_BASELINE.get(roleId) ?? new Set<string>());
   if (cleaned.length === 0) {
     deleteExtras(roleId);
   } else {

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -6,15 +6,29 @@ import { pushSessionEvent } from "../../events/session-store/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { roleExists, deleteRole, saveRole } from "../../utils/files/roles-io.js";
+import { deleteExtras, listAllExtras, writeExtras } from "../../utils/files/roles-extras-io.js";
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
 
 const BUILTIN_IDS = new Set(BUILTIN_ROLES.map((role) => role.id));
+const BUILTIN_BASELINE = new Map(BUILTIN_ROLES.map((role) => [role.id, new Set(role.availablePlugins)] as const));
 
 const router = Router();
 
-router.get(API_ROUTES.roles.list, (_req: Request, res: Response<Role[]>) => {
-  res.json(loadCustomRoles());
+export interface RolesListResponse {
+  customRoles: Role[];
+  builtInExtras: Record<string, string[]>;
+}
+
+function buildListResponse(): RolesListResponse {
+  return {
+    customRoles: loadCustomRoles(),
+    builtInExtras: listAllExtras(),
+  };
+}
+
+router.get(API_ROUTES.roles.list, (_req: Request, res: Response<RolesListResponse>) => {
+  res.json(buildListResponse());
 });
 
 router.post(API_ROUTES.roles.manage, async (req: Request, res: Response<Record<string, unknown>>) => {
@@ -49,14 +63,16 @@ interface ManageRolesInput {
   };
   roleId?: string;
   oldRoleId?: string;
+  extraPlugins?: string[];
 }
 
 function listRolesResult(): Record<string, unknown> {
-  const customRoles = loadCustomRoles();
+  const data = buildListResponse();
+  const count = data.customRoles.length;
   return {
     success: true,
-    message: `${customRoles.length} custom role${customRoles.length !== 1 ? "s" : ""}.`,
-    data: { customRoles },
+    message: `${count} custom role${count !== 1 ? "s" : ""}.`,
+    data,
   };
 }
 
@@ -73,7 +89,7 @@ function deleteRoleResult(roleId: string | undefined, sessionId: string): Record
   return {
     success: true,
     message: `Role '${roleId}' deleted.`,
-    roles: loadCustomRoles(),
+    ...buildListResponse(),
   };
 }
 
@@ -117,12 +133,51 @@ function saveRoleResult(input: ManageRolesInput, sessionId: string): Record<stri
   return {
     success: true,
     message: `Role '${role.name}' ${action}d successfully.`,
-    roles: loadCustomRoles(),
+    ...buildListResponse(),
+  };
+}
+
+function extendBuiltinResult(input: ManageRolesInput, sessionId: string): Record<string, unknown> {
+  const { roleId, extraPlugins } = input;
+  if (!roleId) return { success: false, error: "roleId is required for extendBuiltin action" };
+  if (!BUILTIN_IDS.has(roleId)) {
+    return { success: false, error: `Role '${roleId}' is not a built-in role.` };
+  }
+  if (!Array.isArray(extraPlugins)) {
+    return { success: false, error: "extraPlugins (string[]) is required for extendBuiltin action" };
+  }
+  // Reject non-string entries silently; baseline plugins in the input
+  // are dropped (they're already included by the built-in, so there's
+  // nothing to persist). Dedup preserves first-seen order.
+  const baseline = BUILTIN_BASELINE.get(roleId) ?? new Set<string>();
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+  for (const name of extraPlugins) {
+    if (typeof name !== "string" || name.length === 0) continue;
+    if (baseline.has(name)) continue;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    cleaned.push(name);
+  }
+  if (cleaned.length === 0) {
+    deleteExtras(roleId);
+  } else {
+    writeExtras(roleId, cleaned);
+  }
+  notifyRolesUpdated(sessionId);
+  return {
+    success: true,
+    message:
+      cleaned.length === 0
+        ? `Cleared extra plugins for '${roleId}'.`
+        : `Saved ${cleaned.length} extra plugin${cleaned.length !== 1 ? "s" : ""} for '${roleId}'.`,
+    ...buildListResponse(),
   };
 }
 
 export async function executeManageRoles(input: ManageRolesInput, sessionId: string): Promise<Record<string, unknown>> {
   if (input.action === "list") return listRolesResult();
   if (input.action === "delete") return deleteRoleResult(input.roleId, sessionId);
+  if (input.action === "extendBuiltin") return extendBuiltinResult(input, sessionId);
   return saveRoleResult(input, sessionId);
 }

--- a/server/utils/files/roles-extras-io.ts
+++ b/server/utils/files/roles-extras-io.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import { mkdirSync, readFileSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
+import { writeFileAtomicSync } from "./atomic.js";
+import { isEnoent } from "./safe.js";
+
+const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
+
+function extrasFilePath(roleId: string, workspaceRoot?: string): string {
+  return path.join(root(workspaceRoot), WORKSPACE_DIRS.rolesExtras, `${roleId}.json`);
+}
+
+export function readExtras(roleId: string, workspaceRoot?: string): string[] {
+  try {
+    const raw = readFileSync(extrasFilePath(roleId, workspaceRoot), "utf-8");
+    const parsed = JSON.parse(raw) as { extraPlugins?: unknown };
+    if (!parsed || !Array.isArray(parsed.extraPlugins)) return [];
+    return parsed.extraPlugins.filter((plugin): plugin is string => typeof plugin === "string" && plugin.length > 0);
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    return [];
+  }
+}
+
+export function writeExtras(roleId: string, extraPlugins: string[], workspaceRoot?: string): void {
+  const dir = path.join(root(workspaceRoot), WORKSPACE_DIRS.rolesExtras);
+  mkdirSync(dir, { recursive: true });
+  writeFileAtomicSync(extrasFilePath(roleId, workspaceRoot), JSON.stringify({ extraPlugins }, null, 2));
+}
+
+// Returns false if not found.
+export function deleteExtras(roleId: string, workspaceRoot?: string): boolean {
+  try {
+    unlinkSync(extrasFilePath(roleId, workspaceRoot));
+    return true;
+  } catch (err) {
+    if (isEnoent(err)) return false;
+    throw err;
+  }
+}
+
+export function extrasExists(roleId: string, workspaceRoot?: string): boolean {
+  try {
+    statSync(extrasFilePath(roleId, workspaceRoot));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function listAllExtras(workspaceRoot?: string): Record<string, string[]> {
+  const dir = path.join(root(workspaceRoot), WORKSPACE_DIRS.rolesExtras);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    if (isEnoent(err)) return {};
+    throw err;
+  }
+  const out: Record<string, string[]> = {};
+  for (const fileName of entries) {
+    if (!fileName.endsWith(".json")) continue;
+    const roleId = fileName.slice(0, -".json".length);
+    const plugins = readExtras(roleId, workspaceRoot);
+    if (plugins.length > 0) out[roleId] = plugins;
+  }
+  return out;
+}

--- a/server/utils/files/roles-extras-io.ts
+++ b/server/utils/files/roles-extras-io.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync, readdirSync, statSync, unlinkSync } from "node
 import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomicSync } from "./atomic.js";
 import { isEnoent } from "./safe.js";
+import { log } from "../../system/logger/index.js";
 
 const root = (workspaceRoot?: string) => workspaceRoot ?? workspacePath;
 
@@ -11,13 +12,21 @@ function extrasFilePath(roleId: string, workspaceRoot?: string): string {
 }
 
 export function readExtras(roleId: string, workspaceRoot?: string): string[] {
+  const filePath = extrasFilePath(roleId, workspaceRoot);
   try {
-    const raw = readFileSync(extrasFilePath(roleId, workspaceRoot), "utf-8");
+    const raw = readFileSync(filePath, "utf-8");
     const parsed = JSON.parse(raw) as { extraPlugins?: unknown };
-    if (!parsed || !Array.isArray(parsed.extraPlugins)) return [];
+    if (!parsed || !Array.isArray(parsed.extraPlugins)) {
+      log.warn("roles-extras", "malformed overlay", { roleId, filePath });
+      return [];
+    }
     return parsed.extraPlugins.filter((plugin): plugin is string => typeof plugin === "string" && plugin.length > 0);
   } catch (err) {
     if (isEnoent(err)) return [];
+    // Parse error or unexpected I/O: surface in logs so a corrupted
+    // overlay doesn't silently turn into "no extras". Still returns
+    // [] so the loader keeps a usable built-in baseline.
+    log.warn("roles-extras", "read failed", { roleId, filePath, error: String(err) });
     return [];
   }
 }

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -146,6 +146,15 @@ const HOST_WORKSPACE_DIRS = {
   // config/
   configs: "config",
   roles: "config/roles",
+  // Per-built-in-role overlay: each `<builtInId>.json` is an additive
+  // `{ extraPlugins: string[] }` blob whose names are appended to the
+  // built-in's `availablePlugins` at load. Lives under a subfolder
+  // (rather than next to `<id>.json` custom roles) so the directory
+  // listing for custom roles stays clean — `loadCustomRoles()` reads
+  // `config/roles/*.json` only, and extras don't collide because they
+  // share the built-in's id which `loadCustomRoles` already filters
+  // out, but the subfolder makes the separation obvious on disk.
+  rolesExtras: "config/roles/extras",
   helps: "config/helps",
   // Project-scope Claude Code skills root — both user-authored and
   // launcher-managed presets live here. Path is hardcoded by Claude

--- a/server/workspace/roles.ts
+++ b/server/workspace/roles.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { BUILTIN_ROLES, RoleSchema, type Role } from "../../src/config/roles.js";
 import { WORKSPACE_DIRS, workspacePath } from "./paths.js";
 import { readdirUnderSync, readTextUnderSync } from "../utils/files/workspace-io.js";
+import { listAllExtras } from "../utils/files/roles-extras-io.js";
 
 export function loadCustomRoles(): Role[] {
   return readdirUnderSync(workspacePath, WORKSPACE_DIRS.roles)
@@ -17,9 +18,27 @@ export function loadCustomRoles(): Role[] {
     });
 }
 
+// Built-ins with their user-added overlay applied to `availablePlugins`.
+// The baseline order is preserved; extras are appended; dedup keeps the
+// first occurrence (so a name that's already in the baseline never
+// surfaces twice even if persisted to the overlay file).
+function applyExtrasToBuiltin(role: Role, extras: string[]): Role {
+  if (extras.length === 0) return role;
+  const seen = new Set(role.availablePlugins);
+  const appended = extras.filter((name) => {
+    if (seen.has(name)) return false;
+    seen.add(name);
+    return true;
+  });
+  if (appended.length === 0) return role;
+  return { ...role, availablePlugins: [...role.availablePlugins, ...appended] };
+}
+
 export function loadAllRoles(): Role[] {
   const custom = loadCustomRoles();
-  const builtIn = BUILTIN_ROLES.filter((role) => !custom.find((customRole) => customRole.id === role.id));
+  const customIds = new Set(custom.map((role) => role.id));
+  const extrasByRole = listAllExtras();
+  const builtIn = BUILTIN_ROLES.filter((role) => !customIds.has(role.id)).map((role) => applyExtrasToBuiltin(role, extrasByRole[role.id] ?? []));
   return [...builtIn, ...custom];
 }
 

--- a/src/components/RolesView.vue
+++ b/src/components/RolesView.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
       <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageRoles.heading") }}</h2>
       <div class="flex items-center gap-2">
-        <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", customRoles.length, { named: { count: customRoles.length } }) }}</span>
+        <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", allRows.length, { named: { count: allRows.length } }) }}</span>
         <button
           v-if="!creating"
           data-testid="role-add-btn"

--- a/src/components/RolesView.vue
+++ b/src/components/RolesView.vue
@@ -124,38 +124,40 @@
         </div>
       </div>
 
-      <div v-if="!creating && customRoles.length === 0" class="h-full flex items-center justify-center text-gray-400 text-sm">
-        {{ t("pluginManageRoles.emptyHint") }}
-      </div>
-
-      <ul v-if="customRoles.length > 0" class="p-4 space-y-2">
-        <li v-for="role in customRoles" :key="role.id" class="rounded-lg border" :class="selectedId === role.id ? 'border-blue-400' : 'border-gray-200'">
+      <ul v-if="allRows.length > 0" class="p-4 space-y-2">
+        <li v-for="row in allRows" :key="row.role.id" class="rounded-lg border" :class="selectedId === row.role.id ? 'border-blue-400' : 'border-gray-200'">
           <!-- Role header row -->
           <div
             class="flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 rounded-lg"
-            :class="selectedId === role.id ? 'rounded-b-none' : ''"
-            @click="selectRole(role)"
+            :class="selectedId === row.role.id ? 'rounded-b-none' : ''"
+            @click="selectRole(row)"
           >
-            <span class="material-icons text-gray-500">{{ role.icon }}</span>
+            <span class="material-icons text-gray-500">{{ row.role.icon }}</span>
             <div class="flex-1 min-w-0">
-              <div class="font-medium text-sm text-gray-800">
-                {{ role.name }}
-                <span class="ml-1 text-xs font-mono text-gray-400">{{ t("pluginManageRoles.idFormatted", { id: role.id }) }}</span>
+              <div class="font-medium text-sm text-gray-800 flex items-center gap-2">
+                <span>{{ row.role.name }}</span>
+                <span
+                  v-if="row.kind === 'builtin'"
+                  class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 border border-gray-200"
+                >
+                  {{ t("pluginManageRoles.builtInBadge") }}
+                </span>
+                <span class="text-xs font-mono text-gray-400">{{ t("pluginManageRoles.idFormatted", { id: row.role.id }) }}</span>
               </div>
               <div class="text-xs text-gray-400 truncate">
-                {{ role.availablePlugins.join(", ") }}
+                {{ row.mergedPlugins.join(", ") }}
               </div>
             </div>
             <span
               class="material-icons text-gray-400 text-sm"
-              :title="selectedId === role.id ? t('pluginManageRoles.collapse') : t('pluginManageRoles.expand')"
+              :title="selectedId === row.role.id ? t('pluginManageRoles.collapse') : t('pluginManageRoles.expand')"
             >
-              {{ selectedId === role.id ? "expand_less" : "expand_more" }}
+              {{ selectedId === row.role.id ? "expand_less" : "expand_more" }}
             </span>
           </div>
 
-          <!-- Inline editor -->
-          <div v-if="selectedId === role.id" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+          <!-- Inline editor (custom role) -->
+          <div v-if="selectedId === row.role.id && row.kind === 'custom'" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
             <!-- ID + Name + Icon row -->
             <div class="flex gap-3">
               <div class="w-40">
@@ -172,7 +174,7 @@
                   v-model="editForm.name"
                   type="text"
                   class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-                  @keydown.enter="saveEdit(role.id)"
+                  @keydown.enter="saveEdit(row.role.id)"
                 />
               </div>
               <div class="w-32">
@@ -247,7 +249,7 @@
                   class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
                   :disabled="saving || !!editFormError"
                   :title="editFormError ?? ''"
-                  @click="saveEdit(role.id)"
+                  @click="saveEdit(row.role.id)"
                 >
                   {{ saving ? t("pluginManageRoles.updating") : t("pluginManageRoles.update") }}
                 </button>
@@ -258,13 +260,60 @@
               <button
                 class="px-3 py-1.5 text-sm rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-50"
                 :disabled="saving"
-                @click="deleteRole(role.id)"
+                @click="deleteRole(row.role.id)"
               >
                 {{ t("pluginManageRoles.delete") }}
               </button>
             </div>
             <div v-if="editFormError" class="text-xs text-gray-500">
               {{ editFormError }}
+            </div>
+            <div v-if="saveError" class="text-xs text-red-500">
+              {{ saveError }}
+            </div>
+          </div>
+
+          <!-- Inline editor (built-in role — plugin grid only) -->
+          <div v-if="selectedId === row.role.id && row.kind === 'builtin'" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+            <div class="text-xs text-gray-500">
+              {{ t("pluginManageRoles.builtInEditHint", { name: row.role.name }) }}
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-2">{{ t("pluginManageRoles.fieldPlugins") }}</label>
+              <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+                <label
+                  v-for="plugin in availablePlugins"
+                  :key="plugin.name"
+                  class="flex items-center gap-2 text-sm cursor-pointer"
+                  :class="builtInLabelClass(plugin, row.baselineSet)"
+                  :title="builtInLabelTitle(plugin, row.baselineSet)"
+                >
+                  <input
+                    v-model="builtInForm.selectedPlugins"
+                    type="checkbox"
+                    :value="plugin.name"
+                    :disabled="!plugin.enabled || row.baselineSet.has(plugin.name)"
+                    class="cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  {{ plugin.name }}
+                  <span v-if="row.baselineSet.has(plugin.name)" class="text-xs text-gray-400">{{ t("pluginManageRoles.builtInBaselineSuffix") }}</span>
+                  <span v-else-if="!plugin.enabled" class="text-xs text-gray-400">{{
+                    t("pluginManageRoles.missingEnv", { env: plugin.requiredEnv.join(", ") })
+                  }}</span>
+                </label>
+              </div>
+            </div>
+            <div class="flex gap-2 pt-1">
+              <button
+                class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                :disabled="saving"
+                @click="saveBuiltInExtras(row)"
+              >
+                {{ saving ? t("pluginManageRoles.updating") : t("pluginManageRoles.update") }}
+              </button>
+              <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="selectedId = null">
+                {{ t("common.cancel") }}
+              </button>
             </div>
             <div v-if="saveError" class="text-xs text-red-500">
               {{ saveError }}
@@ -285,6 +334,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getAllPluginNames } from "../tools/index";
 import { apiGet, apiPost } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { BUILTIN_ROLES, type Role } from "../config/roles";
 
 // Inlined from the former `src/plugins/manageRoles/index.ts`
 // (deleted alongside the manageRoles MCP tool — #949). RolesView
@@ -301,6 +351,7 @@ export interface CustomRole {
 
 export interface ManageRolesData {
   customRoles: CustomRole[];
+  builtInExtras?: Record<string, string[]>;
 }
 
 const { t } = useI18n();
@@ -345,12 +396,23 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const appApi = useAppApi();
 
 const customRoles = ref<CustomRole[]>(props.selectedResult?.data?.customRoles ?? []);
+const builtInExtras = ref<Record<string, string[]>>(props.selectedResult?.data?.builtInExtras ?? {});
 
-const { refresh: refreshCustomRoles } = useFreshPluginData<CustomRole[]>({
+const { refresh: refreshCustomRoles } = useFreshPluginData<ManageRolesData>({
   endpoint: () => API_ROUTES.roles.list,
-  extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
+  extract: (json) => {
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const obj = json as Record<string, unknown>;
+      const customs = Array.isArray(obj.customRoles) ? (obj.customRoles as CustomRole[]) : [];
+      const extras =
+        obj.builtInExtras && typeof obj.builtInExtras === "object" && !Array.isArray(obj.builtInExtras) ? (obj.builtInExtras as Record<string, string[]>) : {};
+      return { customRoles: customs, builtInExtras: extras };
+    }
+    return null;
+  },
   apply: (data) => {
-    customRoles.value = data;
+    customRoles.value = data.customRoles;
+    builtInExtras.value = data.builtInExtras ?? {};
   },
 });
 
@@ -358,9 +420,69 @@ watch(
   () => props.selectedResult?.uuid,
   () => {
     customRoles.value = props.selectedResult?.data?.customRoles ?? [];
+    builtInExtras.value = props.selectedResult?.data?.builtInExtras ?? {};
     void refreshCustomRoles();
   },
 );
+
+// ── Row model ─────────────────────────────────────────────────────────────────
+
+interface BuiltInRow {
+  kind: "builtin";
+  role: Role;
+  baselineSet: Set<string>;
+  extraPlugins: string[];
+  mergedPlugins: string[];
+}
+
+interface CustomRow {
+  kind: "custom";
+  role: CustomRole;
+  baselineSet: Set<string>;
+  extraPlugins: string[];
+  mergedPlugins: string[];
+}
+
+type Row = BuiltInRow | CustomRow;
+
+const builtInRows = computed<BuiltInRow[]>(() =>
+  BUILTIN_ROLES.filter((role) => !customRoles.value.some((custom) => custom.id === role.id)).map((role) => {
+    const baseline = role.availablePlugins;
+    const extras = builtInExtras.value[role.id] ?? [];
+    const baselineSet = new Set(baseline);
+    return {
+      kind: "builtin",
+      role,
+      baselineSet,
+      extraPlugins: extras,
+      mergedPlugins: [...baseline, ...extras.filter((name) => !baselineSet.has(name))],
+    };
+  }),
+);
+
+const customRows = computed<CustomRow[]>(() =>
+  customRoles.value.map((role) => ({
+    kind: "custom",
+    role,
+    baselineSet: new Set<string>(),
+    extraPlugins: [],
+    mergedPlugins: role.availablePlugins,
+  })),
+);
+
+const allRows = computed<Row[]>(() => [...builtInRows.value, ...customRows.value]);
+
+function builtInLabelClass(plugin: PluginEntry, baseline: Set<string>): string {
+  if (baseline.has(plugin.name)) return "text-gray-500";
+  if (!plugin.enabled) return "text-gray-400 cursor-not-allowed";
+  return "text-gray-700";
+}
+
+function builtInLabelTitle(plugin: PluginEntry, baseline: Set<string>): string {
+  if (baseline.has(plugin.name)) return t("pluginManageRoles.builtInBaselineTooltip");
+  if (!plugin.enabled) return t("pluginManageRoles.requiresEnv", { env: plugin.requiredEnv.join(", ") });
+  return "";
+}
 
 // ── Selection & edit form ─────────────────────────────────────────────────────
 
@@ -385,6 +507,8 @@ const editForm = ref<EditForm>({
   selectedPlugins: [],
   queriesText: "",
 });
+
+const builtInForm = ref<{ selectedPlugins: string[] }>({ selectedPlugins: [] });
 
 const creating = ref(false);
 const createError = ref("");
@@ -416,20 +540,26 @@ function cancelCreate() {
   createError.value = "";
 }
 
-function selectRole(role: CustomRole) {
-  if (selectedId.value === role.id) {
+function selectRole(row: Row) {
+  if (selectedId.value === row.role.id) {
     selectedId.value = null;
     return;
   }
-  selectedId.value = role.id;
+  selectedId.value = row.role.id;
   saveError.value = "";
+  if (row.kind === "builtin") {
+    builtInForm.value = {
+      selectedPlugins: [...row.role.availablePlugins, ...row.extraPlugins.filter((name) => !row.baselineSet.has(name))],
+    };
+    return;
+  }
   editForm.value = {
-    id: role.id,
-    name: role.name,
-    icon: role.icon,
-    prompt: role.prompt,
-    selectedPlugins: [...role.availablePlugins],
-    queriesText: (role.queries ?? []).join("\n"),
+    id: row.role.id,
+    name: row.role.name,
+    icon: row.role.icon,
+    prompt: row.role.prompt,
+    selectedPlugins: [...row.role.availablePlugins],
+    queriesText: (row.role.queries ?? []).join("\n"),
   };
 }
 
@@ -444,9 +574,6 @@ interface ManageResult {
 async function callManage(body: Record<string, unknown>): Promise<ManageResult> {
   const result = await apiPost<ManageResult>(API_ROUTES.roles.manage, body);
   if (!result.ok) {
-    // Prefer the backend's error message (e.g. validation failure
-    // details). Fall back to a status code only when the server didn't
-    // give us anything useful.
     return {
       success: false,
       error:
@@ -461,8 +588,9 @@ async function callManage(body: Record<string, unknown>): Promise<ManageResult> 
 async function refreshList() {
   const result = await callManage({ action: "list" });
   if (result.success) {
-    const data = result as { data?: { customRoles?: CustomRole[] } };
+    const data = result as { data?: { customRoles?: CustomRole[]; builtInExtras?: Record<string, string[]> } };
     customRoles.value = data.data?.customRoles ?? [];
+    builtInExtras.value = data.data?.builtInExtras ?? {};
     if (props.selectedResult) {
       emit("updateResult", {
         ...props.selectedResult,
@@ -470,7 +598,6 @@ async function refreshList() {
         uuid: props.selectedResult.uuid,
       });
     }
-    // Let App.vue know the dropdown needs to refresh.
     await Promise.resolve(appApi.refreshRoles());
   }
 }
@@ -547,6 +674,20 @@ async function saveEdit(originalId: string) {
     role,
     oldRoleId: originalId,
   });
+  if (result.success) {
+    selectedId.value = null;
+    await refreshList();
+  } else {
+    saveError.value = result.error ?? t("pluginManageRoles.errSaveFailed");
+  }
+  saving.value = false;
+}
+
+async function saveBuiltInExtras(row: BuiltInRow) {
+  saving.value = true;
+  saveError.value = "";
+  const extras = builtInForm.value.selectedPlugins.filter((name) => !row.baselineSet.has(name));
+  const result = await callManage({ action: "extendBuiltin", roleId: row.role.id, extraPlugins: extras });
   if (result.success) {
     selectedId.value = null;
     await refreshList();

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -9,6 +9,32 @@ import { ROLES, type Role } from "../config/roles";
 import { mergeRoles } from "../utils/role/merge";
 import { apiGet } from "../utils/api";
 
+interface RolesListResponse {
+  customRoles: Role[];
+  builtInExtras?: Record<string, string[]>;
+}
+
+// Apply each built-in's `extraPlugins` overlay so the client-side
+// role record carries the same `availablePlugins` the server would
+// see via `loadAllRoles()`. Required because `useMcpTools` reads
+// `currentRole.value.availablePlugins` directly when computing the
+// visible tool set on the client.
+function applyExtras(builtIn: readonly Role[], extras: Record<string, string[]>): Role[] {
+  return builtIn.map((role) => {
+    const extra = extras[role.id];
+    if (!extra || extra.length === 0) return role;
+    const seen = new Set(role.availablePlugins);
+    const appended: string[] = [];
+    for (const name of extra) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      appended.push(name);
+    }
+    if (appended.length === 0) return role;
+    return { ...role, availablePlugins: [...role.availablePlugins, ...appended] };
+  });
+}
+
 export function useRoles(): {
   roles: Ref<Role[]>;
   refreshRoles: () => Promise<void>;
@@ -16,14 +42,16 @@ export function useRoles(): {
   const roles = ref<Role[]>(ROLES);
 
   async function refreshRoles(): Promise<void> {
-    const result = await apiGet<Role[]>(API_ROUTES.roles.list);
+    const result = await apiGet<RolesListResponse>(API_ROUTES.roles.list);
     if (!result.ok) {
       // Keep the current role list on failure — losing custom roles
       // is preferable to crashing the UI on a transient API hiccup.
       console.warn(`[useRoles] refreshRoles failed: ${result.status} ${result.error}`);
       return;
     }
-    roles.value = mergeRoles(ROLES, result.data);
+    const customRoles = Array.isArray(result.data?.customRoles) ? result.data.customRoles : [];
+    const extras = result.data?.builtInExtras ?? {};
+    roles.value = mergeRoles(applyExtras(ROLES, extras), customRoles);
   }
 
   return { roles, refreshRoles };

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1105,6 +1105,11 @@ const deMessages = {
     errDeleteFailed: "Löschen fehlgeschlagen",
     errNetworkError: "Netzwerkfehler",
     errServerError: "Serverfehler: {status}",
+    builtInBadge: "Integriert",
+    builtInEditHint:
+      "Integrierte Rollen können nicht geändert werden, aber du kannst {name} zusätzliche Plugins hinzufügen. Plugins, die zur Rolle gehören, sind unten markiert und gesperrt.",
+    builtInBaselineSuffix: "(integriert)",
+    builtInBaselineTooltip: "In dieser integrierten Rolle enthalten",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1071,7 +1071,7 @@ const deMessages = {
     confirmDelete: 'Skill "{name}" löschen? Dies entfernt ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
   },
   pluginManageRoles: {
-    heading: "Benutzerdefinierte Rollen",
+    heading: "Rollen",
     roleCount: "{count} Rolle | {count} Rollen",
     addButton: "+ Hinzufügen",
     createPanel: "Neue Rolle erstellen",
@@ -1107,7 +1107,7 @@ const deMessages = {
     errServerError: "Serverfehler: {status}",
     builtInBadge: "Integriert",
     builtInEditHint:
-      "Integrierte Rollen können nicht geändert werden, aber du kannst {name} zusätzliche Plugins hinzufügen. Plugins, die zur Rolle gehören, sind unten markiert und gesperrt.",
+      "Integrierte Rollen können nicht geändert werden, aber Sie können {name} zusätzliche Plugins hinzufügen. Plugins, die zur Rolle gehören, sind unten markiert und gesperrt.",
     builtInBaselineSuffix: "(integriert)",
     builtInBaselineTooltip: "In dieser integrierten Rolle enthalten",
   },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1056,7 +1056,7 @@ const enMessages = {
     confirmDelete: 'Delete skill "{name}"? This removes ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
   },
   pluginManageRoles: {
-    heading: "Custom Roles",
+    heading: "Roles",
     roleCount: "{count} role | {count} roles",
     addButton: "+ Add",
     createPanel: "Create new role",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1090,6 +1090,10 @@ const enMessages = {
     errDeleteFailed: "Delete failed",
     errNetworkError: "Network error",
     errServerError: "Server error: {status}",
+    builtInBadge: "Built-in",
+    builtInEditHint: "Built-in roles can't be modified, but you can add extra plugins to {name}. Plugins that ship with the role are checked and locked below.",
+    builtInBaselineSuffix: "(built-in)",
+    builtInBaselineTooltip: "Included by this built-in role",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1102,6 +1102,11 @@ const esMessages = {
     errDeleteFailed: "Error al eliminar",
     errNetworkError: "Error de red",
     errServerError: "Error del servidor: {status}",
+    builtInBadge: "Integrado",
+    builtInEditHint:
+      "Los roles integrados no se pueden modificar, pero puedes añadir complementos adicionales a {name}. Los complementos que vienen con el rol aparecen marcados y bloqueados abajo.",
+    builtInBaselineSuffix: "(integrado)",
+    builtInBaselineTooltip: "Incluido por este rol integrado",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1068,7 +1068,7 @@ const esMessages = {
     confirmDelete: '¿Eliminar la skill "{name}"? Esto borrará ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
   },
   pluginManageRoles: {
-    heading: "Roles personalizados",
+    heading: "Roles",
     roleCount: "{count} rol | {count} roles",
     addButton: "+ Añadir",
     createPanel: "Crear nuevo rol",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1096,6 +1096,11 @@ const frMessages = {
     errDeleteFailed: "Échec de la suppression",
     errNetworkError: "Erreur réseau",
     errServerError: "Erreur du serveur : {status}",
+    builtInBadge: "Intégré",
+    builtInEditHint:
+      "Les rôles intégrés ne peuvent pas être modifiés, mais vous pouvez ajouter des plugins supplémentaires à {name}. Les plugins fournis avec le rôle sont cochés et verrouillés ci-dessous.",
+    builtInBaselineSuffix: "(intégré)",
+    builtInBaselineTooltip: "Inclus par ce rôle intégré",
   },
   pluginUiImage: {
     promptLabel: "{label} :",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1062,7 +1062,7 @@ const frMessages = {
     confirmDelete: 'Supprimer la skill "{name}" ? Cela retire ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
   },
   pluginManageRoles: {
-    heading: "Rôles personnalisés",
+    heading: "Rôles",
     roleCount: "{count} rôle | {count} rôles",
     addButton: "+ Ajouter",
     createPanel: "Créer un nouveau rôle",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1057,7 +1057,7 @@ const jaMessages = {
     confirmDelete: "スキル「{name}」を削除しますか? ~/mulmoclaude/.claude/skills/{name}/SKILL.md が削除されます。",
   },
   pluginManageRoles: {
-    heading: "カスタムロール",
+    heading: "ロール",
     roleCount: "{count} 件",
     addButton: "+ 追加",
     createPanel: "新しいロールを作成",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1091,6 +1091,10 @@ const jaMessages = {
     errDeleteFailed: "削除失敗",
     errNetworkError: "ネットワークエラー",
     errServerError: "サーバエラー: {status}",
+    builtInBadge: "標準",
+    builtInEditHint: "標準ロールは編集できませんが、{name} に追加のプラグインを加えることはできます。標準で含まれるプラグインはチェック済みで変更できません。",
+    builtInBaselineSuffix: "(標準)",
+    builtInBaselineTooltip: "この標準ロールに含まれています",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1057,7 +1057,7 @@ const koMessages = {
     confirmDelete: '스킬 "{name}" 을(를) 삭제할까요? ~/mulmoclaude/.claude/skills/{name}/SKILL.md 가 제거됩니다.',
   },
   pluginManageRoles: {
-    heading: "커스텀 역할",
+    heading: "역할",
     roleCount: "{count}개 역할",
     addButton: "+ 추가",
     createPanel: "새 역할 만들기",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1091,6 +1091,11 @@ const koMessages = {
     errDeleteFailed: "삭제 실패",
     errNetworkError: "네트워크 오류",
     errServerError: "서버 오류: {status}",
+    builtInBadge: "기본",
+    builtInEditHint:
+      "기본 역할은 수정할 수 없지만 {name} 에 추가 플러그인을 더할 수 있습니다. 역할에 포함된 기본 플러그인은 아래에서 선택 및 잠금 상태로 표시됩니다.",
+    builtInBaselineSuffix: "(기본)",
+    builtInBaselineTooltip: "이 기본 역할에 포함되어 있습니다",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1057,7 +1057,7 @@ const ptBRMessages = {
     confirmDelete: 'Excluir a skill "{name}"? Isso remove ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
   },
   pluginManageRoles: {
-    heading: "Papéis personalizados",
+    heading: "Papéis",
     roleCount: "{count} papel | {count} papéis",
     addButton: "+ Adicionar",
     createPanel: "Criar novo papel",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1091,6 +1091,11 @@ const ptBRMessages = {
     errDeleteFailed: "Falha ao excluir",
     errNetworkError: "Erro de rede",
     errServerError: "Erro do servidor: {status}",
+    builtInBadge: "Integrado",
+    builtInEditHint:
+      "Papéis integrados não podem ser modificados, mas você pode adicionar plugins extras a {name}. Os plugins que vêm com o papel aparecem marcados e bloqueados abaixo.",
+    builtInBaselineSuffix: "(integrado)",
+    builtInBaselineTooltip: "Incluído por este papel integrado",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1049,7 +1049,7 @@ const zhMessages = {
     confirmDelete: '要删除技能 "{name}" 吗?将会移除 ~/mulmoclaude/.claude/skills/{name}/SKILL.md。',
   },
   pluginManageRoles: {
-    heading: "自定义角色",
+    heading: "角色",
     roleCount: "{count} 个角色",
     addButton: "+ 添加",
     createPanel: "创建新角色",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1083,6 +1083,10 @@ const zhMessages = {
     errDeleteFailed: "删除失败",
     errNetworkError: "网络错误",
     errServerError: "服务器错误: {status}",
+    builtInBadge: "内置",
+    builtInEditHint: "内置角色不可修改，但你可以为 {name} 添加额外的插件。下方已勾选并锁定的是该角色自带的插件。",
+    builtInBaselineSuffix: "(内置)",
+    builtInBaselineTooltip: "由该内置角色包含",
   },
   pluginUiImage: {
     promptLabel: "{label}:",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { loadRuntimePlugins } from "./tools/runtimeLoader";
 import { startDevPluginReloadListener } from "./composables/useDevPluginReload";
 import { installHostContext, type EndpointRegistry } from "./plugins/api";
 import { API_ROUTES } from "./config/apiRoutes";
-import { BUILTIN_ROLE_IDS } from "./config/roles";
+import { BUILTIN_ROLE_IDS, BUILTIN_ROLES } from "./config/roles";
 import { PAGE_ROUTES } from "./router";
 import { getAllPluginNames } from "./tools";
 import { setupMarked } from "./utils/markdown/setup";
@@ -79,9 +79,17 @@ const pluginEndpointRegistry: EndpointRegistry = {
   mcpTools: { list: API_ROUTES.mcpTools.list },
 };
 
+// Per-role baseline projected from `BUILTIN_ROLES` so plugins (e.g.
+// manageRoles) can render which plugins are shipped-with-the-role vs.
+// user-added extras without importing `src/config/*` directly.
+const builtinRoleBaselines = Object.fromEntries(
+  BUILTIN_ROLES.map((role) => [role.id, { name: role.name, icon: role.icon, availablePlugins: role.availablePlugins }]),
+);
+
 installHostContext({
   endpoints: pluginEndpointRegistry,
   builtinRoleIds: BUILTIN_ROLE_IDS,
+  builtinRoleBaselines,
   pageRoutes: PAGE_ROUTES,
   getAllPluginNames,
 });

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -45,6 +45,16 @@ export type HostEndpointGroup = Readonly<Record<string, string>>;
  *  caller-declared shape. */
 export type EndpointRegistry = Readonly<Record<string, EndpointGroup | HostEndpointGroup>>;
 
+/** Editor-relevant slice of a built-in role record. Carries just
+ *  enough for the role-editor UI to render a row and separate
+ *  baseline plugins from user-added extras — full `prompt` /
+ *  `queries` stay host-side. */
+export interface BuiltinRoleBaseline {
+  readonly name: string;
+  readonly icon: string;
+  readonly availablePlugins: readonly string[];
+}
+
 /** Everything the host hands to plugins at boot. Each field is
  *  read-only — plugins consume, never mutate. */
 export interface HostContext {
@@ -53,6 +63,10 @@ export interface HostContext {
   /** Built-in role IDs (e.g. `general`, `engineer`). Used by
    *  plugins that start a chat with a specific role. */
   readonly builtinRoleIds: Readonly<Record<string, string>>;
+  /** Baseline (= shipped, non-extended) plugin set keyed by role
+   *  id. Used by the role editor (manageRoles) to render which
+   *  plugins are locked vs which are user-added extras. */
+  readonly builtinRoleBaselines: Readonly<Record<string, BuiltinRoleBaseline>>;
   /** Vue-router page-name constants. Used by plugins that need to
    *  branch on the current page or push a navigation. */
   readonly pageRoutes: Readonly<Record<string, string>>;
@@ -101,6 +115,13 @@ export function pluginEndpoints<E extends object = EndpointGroup>(scope: string)
 /** Built-in role IDs (e.g. `pluginBuiltinRoleIds().general`). */
 export function pluginBuiltinRoleIds(): Readonly<Record<string, string>> {
   return requireContext().builtinRoleIds;
+}
+
+/** Baseline (shipped) plugin set per built-in role id. Used by the
+ *  role editor to distinguish locked baseline checkboxes from
+ *  user-added extras. */
+export function pluginBuiltinRoleBaselines(): Readonly<Record<string, BuiltinRoleBaseline>> {
+  return requireContext().builtinRoleBaselines;
 }
 
 /** A specific Vue-router page-name constant

--- a/src/plugins/manageRoles/Preview.vue
+++ b/src/plugins/manageRoles/Preview.vue
@@ -29,7 +29,13 @@ const endpoints = pluginEndpoints<RolesEndpoints>("roles");
 
 const { refresh } = useFreshPluginData<CustomRole[]>({
   endpoint: () => endpoints.list,
-  extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
+  extract: (json) => {
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const obj = json as Record<string, unknown>;
+      return Array.isArray(obj.customRoles) ? (obj.customRoles as CustomRole[]) : null;
+    }
+    return null;
+  },
   apply: (data) => {
     customRoles.value = data;
   },

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -124,38 +124,40 @@
         </div>
       </div>
 
-      <div v-if="!creating && customRoles.length === 0" class="h-full flex items-center justify-center text-gray-400 text-sm">
-        {{ t("pluginManageRoles.emptyHint") }}
-      </div>
-
-      <ul v-if="customRoles.length > 0" class="p-4 space-y-2">
-        <li v-for="role in customRoles" :key="role.id" class="rounded-lg border" :class="selectedId === role.id ? 'border-blue-400' : 'border-gray-200'">
+      <ul v-if="allRows.length > 0" class="p-4 space-y-2">
+        <li v-for="row in allRows" :key="row.role.id" class="rounded-lg border" :class="selectedId === row.role.id ? 'border-blue-400' : 'border-gray-200'">
           <!-- Role header row -->
           <div
             class="flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 rounded-lg"
-            :class="selectedId === role.id ? 'rounded-b-none' : ''"
-            @click="selectRole(role)"
+            :class="selectedId === row.role.id ? 'rounded-b-none' : ''"
+            @click="selectRole(row)"
           >
-            <span class="material-icons text-gray-500">{{ role.icon }}</span>
+            <span class="material-icons text-gray-500">{{ row.role.icon }}</span>
             <div class="flex-1 min-w-0">
-              <div class="font-medium text-sm text-gray-800">
-                {{ role.name }}
-                <span class="ml-1 text-xs font-mono text-gray-400">{{ t("pluginManageRoles.idFormatted", { id: role.id }) }}</span>
+              <div class="font-medium text-sm text-gray-800 flex items-center gap-2">
+                <span>{{ row.role.name }}</span>
+                <span
+                  v-if="row.kind === 'builtin'"
+                  class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 border border-gray-200"
+                >
+                  {{ t("pluginManageRoles.builtInBadge") }}
+                </span>
+                <span class="text-xs font-mono text-gray-400">{{ t("pluginManageRoles.idFormatted", { id: row.role.id }) }}</span>
               </div>
               <div class="text-xs text-gray-400 truncate">
-                {{ role.availablePlugins.join(", ") }}
+                {{ row.mergedPlugins.join(", ") }}
               </div>
             </div>
             <span
               class="material-icons text-gray-400 text-sm"
-              :title="selectedId === role.id ? t('pluginManageRoles.collapse') : t('pluginManageRoles.expand')"
+              :title="selectedId === row.role.id ? t('pluginManageRoles.collapse') : t('pluginManageRoles.expand')"
             >
-              {{ selectedId === role.id ? "expand_less" : "expand_more" }}
+              {{ selectedId === row.role.id ? "expand_less" : "expand_more" }}
             </span>
           </div>
 
-          <!-- Inline editor -->
-          <div v-if="selectedId === role.id" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+          <!-- Inline editor (custom role) -->
+          <div v-if="selectedId === row.role.id && row.kind === 'custom'" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
             <!-- ID + Name + Icon row -->
             <div class="flex gap-3">
               <div class="w-40">
@@ -172,7 +174,7 @@
                   v-model="editForm.name"
                   type="text"
                   class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-400"
-                  @keydown.enter="saveEdit(role.id)"
+                  @keydown.enter="saveEdit(row.role.id)"
                 />
               </div>
               <div class="w-32">
@@ -247,7 +249,7 @@
                   class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
                   :disabled="saving || !!editFormError"
                   :title="editFormError ?? ''"
-                  @click="saveEdit(role.id)"
+                  @click="saveEdit(row.role.id)"
                 >
                   {{ saving ? t("pluginManageRoles.updating") : t("pluginManageRoles.update") }}
                 </button>
@@ -258,13 +260,60 @@
               <button
                 class="px-3 py-1.5 text-sm rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-50"
                 :disabled="saving"
-                @click="deleteRole(role.id)"
+                @click="deleteRole(row.role.id)"
               >
                 {{ t("pluginManageRoles.delete") }}
               </button>
             </div>
             <div v-if="editFormError" class="text-xs text-gray-500">
               {{ editFormError }}
+            </div>
+            <div v-if="saveError" class="text-xs text-red-500">
+              {{ saveError }}
+            </div>
+          </div>
+
+          <!-- Inline editor (built-in role — plugin grid only) -->
+          <div v-if="selectedId === row.role.id && row.kind === 'builtin'" class="border-t border-blue-100 bg-blue-50 p-4 space-y-3 rounded-b-lg">
+            <div class="text-xs text-gray-500">
+              {{ t("pluginManageRoles.builtInEditHint", { name: row.role.name }) }}
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-2">{{ t("pluginManageRoles.fieldPlugins") }}</label>
+              <div class="grid gap-x-4 gap-y-1 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+                <label
+                  v-for="plugin in availablePlugins"
+                  :key="plugin.name"
+                  class="flex items-center gap-2 text-sm cursor-pointer"
+                  :class="builtInLabelClass(plugin, row.baselineSet)"
+                  :title="builtInLabelTitle(plugin, row.baselineSet)"
+                >
+                  <input
+                    v-model="builtInForm.selectedPlugins"
+                    type="checkbox"
+                    :value="plugin.name"
+                    :disabled="!plugin.enabled || row.baselineSet.has(plugin.name)"
+                    class="cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  {{ plugin.name }}
+                  <span v-if="row.baselineSet.has(plugin.name)" class="text-xs text-gray-400">{{ t("pluginManageRoles.builtInBaselineSuffix") }}</span>
+                  <span v-else-if="!plugin.enabled" class="text-xs text-gray-400">{{
+                    t("pluginManageRoles.missingEnv", { env: plugin.requiredEnv.join(", ") })
+                  }}</span>
+                </label>
+              </div>
+            </div>
+            <div class="flex gap-2 pt-1">
+              <button
+                class="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                :disabled="saving"
+                @click="saveBuiltInExtras(row)"
+              >
+                {{ saving ? t("pluginManageRoles.updating") : t("pluginManageRoles.update") }}
+              </button>
+              <button class="px-3 py-1.5 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50" @click="selectedId = null">
+                {{ t("common.cancel") }}
+              </button>
             </div>
             <div v-if="saveError" class="text-xs text-red-500">
               {{ saveError }}
@@ -284,7 +333,7 @@ import { useAppApi } from "../../composables/useAppApi";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { CustomRole, ManageRolesData } from "./index";
 import { apiGet, apiPost } from "../../utils/api";
-import { pluginEndpoints, pluginAllPluginNames } from "../api";
+import { pluginEndpoints, pluginAllPluginNames, pluginBuiltinRoleBaselines } from "../api";
 import type { RolesEndpoints } from "./definition";
 
 const { t } = useI18n();
@@ -333,14 +382,25 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const appApi = useAppApi();
 
 const customRoles = ref<CustomRole[]>(props.selectedResult?.data?.customRoles ?? []);
+const builtInExtras = ref<Record<string, string[]>>(props.selectedResult?.data?.builtInExtras ?? {});
 
 const rolesEndpoints = pluginEndpoints<RolesEndpoints>("roles");
 
-const { refresh: refreshCustomRoles } = useFreshPluginData<CustomRole[]>({
+const { refresh: refreshCustomRoles } = useFreshPluginData<ManageRolesData>({
   endpoint: () => rolesEndpoints.list,
-  extract: (json) => (Array.isArray(json) ? (json as CustomRole[]) : null),
+  extract: (json) => {
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const obj = json as Record<string, unknown>;
+      const customs = Array.isArray(obj.customRoles) ? (obj.customRoles as CustomRole[]) : [];
+      const extras =
+        obj.builtInExtras && typeof obj.builtInExtras === "object" && !Array.isArray(obj.builtInExtras) ? (obj.builtInExtras as Record<string, string[]>) : {};
+      return { customRoles: customs, builtInExtras: extras };
+    }
+    return null;
+  },
   apply: (data) => {
-    customRoles.value = data;
+    customRoles.value = data.customRoles;
+    builtInExtras.value = data.builtInExtras ?? {};
   },
 });
 
@@ -348,9 +408,79 @@ watch(
   () => props.selectedResult?.uuid,
   () => {
     customRoles.value = props.selectedResult?.data?.customRoles ?? [];
+    builtInExtras.value = props.selectedResult?.data?.builtInExtras ?? {};
     void refreshCustomRoles();
   },
 );
+
+// ── Row model ─────────────────────────────────────────────────────────────────
+
+interface BuiltInRoleView {
+  id: string;
+  name: string;
+  icon: string;
+  availablePlugins: readonly string[];
+}
+
+interface BuiltInRow {
+  kind: "builtin";
+  role: BuiltInRoleView;
+  baselineSet: Set<string>;
+  extraPlugins: string[];
+  mergedPlugins: string[];
+}
+
+interface CustomRow {
+  kind: "custom";
+  role: CustomRole;
+  // Kept for parity with BuiltInRow so template doesn't need a kind-narrowed access.
+  baselineSet: Set<string>;
+  extraPlugins: string[];
+  mergedPlugins: string[];
+}
+
+type Row = BuiltInRow | CustomRow;
+
+const builtInRows = computed<BuiltInRow[]>(() => {
+  const baselines = pluginBuiltinRoleBaselines();
+  return Object.entries(baselines)
+    .filter(([roleId]) => !customRoles.value.some((custom) => custom.id === roleId))
+    .map(([roleId, baseline]) => {
+      const extras = builtInExtras.value[roleId] ?? [];
+      const baselineSet = new Set(baseline.availablePlugins);
+      return {
+        kind: "builtin",
+        role: { id: roleId, name: baseline.name, icon: baseline.icon, availablePlugins: baseline.availablePlugins },
+        baselineSet,
+        extraPlugins: extras,
+        mergedPlugins: [...baseline.availablePlugins, ...extras.filter((name) => !baselineSet.has(name))],
+      };
+    });
+});
+
+const customRows = computed<CustomRow[]>(() =>
+  customRoles.value.map((role) => ({
+    kind: "custom",
+    role,
+    baselineSet: new Set<string>(),
+    extraPlugins: [],
+    mergedPlugins: role.availablePlugins,
+  })),
+);
+
+const allRows = computed<Row[]>(() => [...builtInRows.value, ...customRows.value]);
+
+function builtInLabelClass(plugin: PluginEntry, baseline: Set<string>): string {
+  if (baseline.has(plugin.name)) return "text-gray-500";
+  if (!plugin.enabled) return "text-gray-400 cursor-not-allowed";
+  return "text-gray-700";
+}
+
+function builtInLabelTitle(plugin: PluginEntry, baseline: Set<string>): string {
+  if (baseline.has(plugin.name)) return t("pluginManageRoles.builtInBaselineTooltip");
+  if (!plugin.enabled) return t("pluginManageRoles.requiresEnv", { env: plugin.requiredEnv.join(", ") });
+  return "";
+}
 
 // ── Selection & edit form ─────────────────────────────────────────────────────
 
@@ -375,6 +505,11 @@ const editForm = ref<EditForm>({
   selectedPlugins: [],
   queriesText: "",
 });
+
+// Built-in editor uses only the plugin grid. Baseline plugins are
+// pre-checked and locked; the user can only add/remove non-baseline
+// entries, which become `extraPlugins` on save.
+const builtInForm = ref<{ selectedPlugins: string[] }>({ selectedPlugins: [] });
 
 const creating = ref(false);
 const createError = ref("");
@@ -406,20 +541,28 @@ function cancelCreate() {
   createError.value = "";
 }
 
-function selectRole(role: CustomRole) {
-  if (selectedId.value === role.id) {
+function selectRole(row: Row) {
+  if (selectedId.value === row.role.id) {
     selectedId.value = null;
     return;
   }
-  selectedId.value = role.id;
+  selectedId.value = row.role.id;
   saveError.value = "";
+  if (row.kind === "builtin") {
+    // Pre-check baseline + current extras; baseline checkboxes render
+    // disabled, so the user can only toggle non-baseline entries.
+    builtInForm.value = {
+      selectedPlugins: [...row.role.availablePlugins, ...row.extraPlugins.filter((name) => !row.baselineSet.has(name))],
+    };
+    return;
+  }
   editForm.value = {
-    id: role.id,
-    name: role.name,
-    icon: role.icon,
-    prompt: role.prompt,
-    selectedPlugins: [...role.availablePlugins],
-    queriesText: (role.queries ?? []).join("\n"),
+    id: row.role.id,
+    name: row.role.name,
+    icon: row.role.icon,
+    prompt: row.role.prompt,
+    selectedPlugins: [...row.role.availablePlugins],
+    queriesText: (row.role.queries ?? []).join("\n"),
   };
 }
 
@@ -451,8 +594,9 @@ async function callManage(body: Record<string, unknown>): Promise<ManageResult> 
 async function refreshList() {
   const result = await callManage({ action: "list" });
   if (result.success) {
-    const data = result as { data?: { customRoles?: CustomRole[] } };
+    const data = result as { data?: { customRoles?: CustomRole[]; builtInExtras?: Record<string, string[]> } };
     customRoles.value = data.data?.customRoles ?? [];
+    builtInExtras.value = data.data?.builtInExtras ?? {};
     if (props.selectedResult) {
       emit("updateResult", {
         ...props.selectedResult,
@@ -537,6 +681,20 @@ async function saveEdit(originalId: string) {
     role,
     oldRoleId: originalId,
   });
+  if (result.success) {
+    selectedId.value = null;
+    await refreshList();
+  } else {
+    saveError.value = result.error ?? t("pluginManageRoles.errSaveFailed");
+  }
+  saving.value = false;
+}
+
+async function saveBuiltInExtras(row: BuiltInRow) {
+  saving.value = true;
+  saveError.value = "";
+  const extras = builtInForm.value.selectedPlugins.filter((name) => !row.baselineSet.has(name));
+  const result = await callManage({ action: "extendBuiltin", roleId: row.role.id, extraPlugins: extras });
   if (result.success) {
     selectedId.value = null;
     await refreshList();

--- a/src/plugins/manageRoles/View.vue
+++ b/src/plugins/manageRoles/View.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100">
       <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageRoles.heading") }}</h2>
       <div class="flex items-center gap-2">
-        <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", customRoles.length, { named: { count: customRoles.length } }) }}</span>
+        <span class="text-sm text-gray-500">{{ t("pluginManageRoles.roleCount", allRows.length, { named: { count: allRows.length } }) }}</span>
         <button
           v-if="!creating"
           data-testid="role-add-btn"

--- a/src/plugins/manageRoles/definition.ts
+++ b/src/plugins/manageRoles/definition.ts
@@ -17,8 +17,9 @@ const toolDefinition: ToolDefinition = {
     properties: {
       action: {
         type: "string",
-        enum: ["create", "update", "delete", "list"],
-        description: "The action to perform. Use 'list' to display all custom roles in the canvas.",
+        enum: ["create", "update", "delete", "list", "extendBuiltin"],
+        description:
+          "The action to perform. Use 'list' to display all custom roles in the canvas. Use 'extendBuiltin' with { roleId, extraPlugins[] } to append plugins to a built-in role's availablePlugins (baseline plugins cannot be removed).",
       },
       role: {
         type: "object",
@@ -39,7 +40,13 @@ const toolDefinition: ToolDefinition = {
       },
       roleId: {
         type: "string",
-        description: "The role ID to delete (required for delete action)",
+        description: "The role ID to delete or extend (required for delete / extendBuiltin actions)",
+      },
+      extraPlugins: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Extra plugin/tool names to append to a built-in role's availablePlugins (required for extendBuiltin action). Baseline plugins of the built-in are silently dropped.",
       },
     },
     required: ["action"],

--- a/src/plugins/manageRoles/index.ts
+++ b/src/plugins/manageRoles/index.ts
@@ -19,6 +19,12 @@ export interface CustomRole {
 
 export interface ManageRolesData {
   customRoles: CustomRole[];
+  // Per-built-in-role overlay: only entries with at least one extra
+  // plugin are present; missing key means "no overlay". Built-in role
+  // baselines themselves are imported from `src/config/roles.ts` on
+  // the client; only the user-added overlay needs to traverse the
+  // network.
+  builtInExtras?: Record<string, string[]>;
 }
 
 const manageRolesPlugin: ToolPlugin = {

--- a/test/helpers/installHostContext.ts
+++ b/test/helpers/installHostContext.ts
@@ -17,7 +17,7 @@
 
 import { installHostContext, type EndpointRegistry, type HostContext } from "../../src/plugins/api.js";
 import { API_ROUTES } from "../../src/config/apiRoutes.js";
-import { BUILTIN_ROLE_IDS } from "../../src/config/roles.js";
+import { BUILTIN_ROLE_IDS, BUILTIN_ROLES } from "../../src/config/roles.js";
 // Import from the leaf file (not `src/router/index.ts`) so the test
 // helper doesn't transitively load `vue-router`'s `createRouter`,
 // which touches `window` at module init.
@@ -45,9 +45,14 @@ export function installTestHostContext(overrides: Partial<HostContext> = {}): vo
     mcpTools: { list: API_ROUTES.mcpTools.list },
   };
 
+  const builtinRoleBaselines = Object.fromEntries(
+    BUILTIN_ROLES.map((role) => [role.id, { name: role.name, icon: role.icon, availablePlugins: role.availablePlugins }]),
+  );
+
   installHostContext({
     endpoints: registry,
     builtinRoleIds: BUILTIN_ROLE_IDS,
+    builtinRoleBaselines,
     pageRoutes: PAGE_ROUTES,
     getAllPluginNames: () => [],
     ...overrides,

--- a/test/routes/test_rolesManage.ts
+++ b/test/routes/test_rolesManage.ts
@@ -12,9 +12,14 @@ let originalUserProfile: string | undefined;
 
 type RolesRoute = typeof import("../../server/api/routes/roles.js");
 type RolesIo = typeof import("../../server/utils/files/roles-io.js");
+type RolesExtrasIo = typeof import("../../server/utils/files/roles-extras-io.js");
+type RolesWorkspace = typeof import("../../server/workspace/roles.js");
 let rolesRoute: RolesRoute;
 let rolesIo: RolesIo;
+let rolesExtrasIo: RolesExtrasIo;
+let rolesWorkspace: RolesWorkspace;
 let rolesDir: string;
+let extrasDir: string;
 
 before(async () => {
   tmpRoot = mkdtempSync(path.join(tmpdir(), "roles-manage-test-"));
@@ -25,7 +30,10 @@ before(async () => {
   mkdirSync(path.join(tmpRoot, "mulmoclaude"), { recursive: true });
   rolesRoute = await import("../../server/api/routes/roles.js");
   rolesIo = await import("../../server/utils/files/roles-io.js");
+  rolesExtrasIo = await import("../../server/utils/files/roles-extras-io.js");
+  rolesWorkspace = await import("../../server/workspace/roles.js");
   rolesDir = path.join(tmpRoot, "mulmoclaude", "config", "roles");
+  extrasDir = path.join(rolesDir, "extras");
 });
 
 after(() => {
@@ -180,5 +188,127 @@ describe("executeManageRoles — rename (oldRoleId)", () => {
     assert.equal(result.success, true);
     assert.equal(rolesIo.roleExists("plain"), true);
     rolesIo.deleteRole("plain");
+  });
+});
+
+describe("executeManageRoles — extendBuiltin", () => {
+  function extrasFile(roleId: string): string {
+    return path.join(extrasDir, `${roleId}.json`);
+  }
+
+  it("writes extras for a built-in id and includes them in the list response", async () => {
+    const result = await rolesRoute.executeManageRoles(
+      {
+        action: "extendBuiltin",
+        roleId: "general",
+        extraPlugins: ["customA", "customB"],
+      },
+      "test-session",
+    );
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+
+    const onDisk = JSON.parse(readFileSync(extrasFile("general"), "utf-8")) as { extraPlugins: string[] };
+    assert.deepEqual(onDisk.extraPlugins, ["customA", "customB"]);
+
+    const listResult = (await rolesRoute.executeManageRoles({ action: "list" }, "test-session")) as { data?: { builtInExtras?: Record<string, string[]> } };
+    assert.deepEqual(listResult.data?.builtInExtras?.general, ["customA", "customB"]);
+
+    rolesExtrasIo.deleteExtras("general");
+  });
+
+  it("empty extraPlugins deletes the overlay file", async () => {
+    rolesExtrasIo.writeExtras("general", ["x"]);
+    assert.equal(existsSync(extrasFile("general")), true);
+
+    const result = await rolesRoute.executeManageRoles({ action: "extendBuiltin", roleId: "general", extraPlugins: [] }, "test-session");
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    assert.equal(existsSync(extrasFile("general")), false, "overlay file should be deleted when extraPlugins is empty");
+  });
+
+  it("rejects a non-built-in roleId", async () => {
+    const result = await rolesRoute.executeManageRoles({ action: "extendBuiltin", roleId: "totally-made-up", extraPlugins: ["x"] }, "test-session");
+    assert.equal(result.success, false);
+    assert.match(String(result.error), /not a built-in/i);
+    assert.equal(existsSync(extrasFile("totally-made-up")), false);
+  });
+
+  it("silently drops baseline plugins from the extras payload (additive-only)", async () => {
+    // The "general" built-in includes `presentForm` in its baseline.
+    // Passing it as an extra must not persist — extras represent ONLY
+    // additions on top of the baseline.
+    const result = await rolesRoute.executeManageRoles(
+      { action: "extendBuiltin", roleId: "general", extraPlugins: ["presentForm", "novelExtra"] },
+      "test-session",
+    );
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    const onDisk = JSON.parse(readFileSync(extrasFile("general"), "utf-8")) as { extraPlugins: string[] };
+    assert.deepEqual(onDisk.extraPlugins, ["novelExtra"], "baseline plugin must be dropped, only novel extras persisted");
+    rolesExtrasIo.deleteExtras("general");
+  });
+
+  it("dedupes duplicate names in the extras payload", async () => {
+    const result = await rolesRoute.executeManageRoles({ action: "extendBuiltin", roleId: "general", extraPlugins: ["a", "b", "a", "b"] }, "test-session");
+    assert.equal(result.success, true, `result: ${JSON.stringify(result)}`);
+    const onDisk = JSON.parse(readFileSync(extrasFile("general"), "utf-8")) as { extraPlugins: string[] };
+    assert.deepEqual(onDisk.extraPlugins, ["a", "b"]);
+    rolesExtrasIo.deleteExtras("general");
+  });
+
+  it("rejects a missing extraPlugins array", async () => {
+    const result = await rolesRoute.executeManageRoles({ action: "extendBuiltin", roleId: "general" }, "test-session");
+    assert.equal(result.success, false);
+    assert.match(String(result.error), /extraPlugins/i);
+  });
+});
+
+describe("loadAllRoles — built-in extras merge", () => {
+  it("appends extras to the built-in's availablePlugins (baseline first, dedup)", () => {
+    rolesExtrasIo.writeExtras("general", ["zExtra", "presentForm", "yExtra"]);
+    try {
+      const all = rolesWorkspace.loadAllRoles();
+      const general = all.find((role) => role.id === "general");
+      assert.ok(general, "general role should be present");
+      // Baseline contains presentForm — it must not appear twice.
+      const occurrences = general.availablePlugins.filter((name) => name === "presentForm").length;
+      assert.equal(occurrences, 1, "baseline plugin must not duplicate after merge");
+      // Extras land at the tail, in their declared order, minus dupes.
+      assert.ok(general.availablePlugins.includes("zExtra"), "extras should be merged in");
+      assert.ok(general.availablePlugins.includes("yExtra"), "extras should be merged in");
+      const zIdx = general.availablePlugins.indexOf("zExtra");
+      const yIdx = general.availablePlugins.indexOf("yExtra");
+      assert.ok(zIdx < yIdx, "extras preserve their declared order");
+      // Baseline ordering preserved at the front.
+      const baselineIdx = general.availablePlugins.indexOf("presentForm");
+      assert.ok(baselineIdx < zIdx, "baseline entries precede appended extras");
+    } finally {
+      rolesExtrasIo.deleteExtras("general");
+    }
+  });
+
+  it("ignores extras for a built-in shadowed by a same-id custom role", () => {
+    rolesExtrasIo.writeExtras("general", ["shouldBeIgnored"]);
+    rolesIo.saveRole("general", { ...sampleRole("general"), availablePlugins: ["onlyCustomPlugin"] });
+    try {
+      const all = rolesWorkspace.loadAllRoles();
+      const general = all.find((role) => role.id === "general");
+      assert.ok(general, "shadowing custom role should win");
+      assert.deepEqual(general.availablePlugins, ["onlyCustomPlugin"], "custom role wins and extras for the built-in are ignored");
+    } finally {
+      rolesIo.deleteRole("general");
+      rolesExtrasIo.deleteExtras("general");
+    }
+  });
+
+  it("no extras file → built-in unchanged", () => {
+    rolesExtrasIo.deleteExtras("general"); // ensure clean
+    const all = rolesWorkspace.loadAllRoles();
+    const general = all.find((role) => role.id === "general");
+    assert.ok(general);
+    // We can't assert exact contents (built-in evolves over releases),
+    // but we can assert presentForm is there as baseline and there are
+    // no stray "Extra" / "custom" sentinels left from prior tests.
+    assert.ok(general.availablePlugins.includes("presentForm"));
+    assert.equal(general.availablePlugins.includes("zExtra"), false);
+    assert.equal(general.availablePlugins.includes("customA"), false);
   });
 });

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -43,6 +43,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "pluginsConfig",
     "pluginsData",
     "roles",
+    "rolesExtras",
     "scheduler",
     "searches",
     "sources",


### PR DESCRIPTION
## Summary

Built-in roles were previously immutable in the role editor. Users can now **append** additional plugins to a built-in role's `availablePlugins` directly from the role editor. Baseline plugins (those shipped with the built-in) stay locked — only additions are persisted.

- Overlays persist as per-role JSON files at `~/mulmoclaude/config/roles/extras/<id>.json` with shape `{ extraPlugins: string[] }`.
- `loadAllRoles()` folds the overlay into each visible built-in's `availablePlugins` (baseline first, dedup). Built-ins shadowed by a same-id custom role ignore their overlay.
- New `extendBuiltin` action on `POST /api/roles/manage` validates the role id, silently drops baseline plugins from the input (additive-only), dedupes, and deletes the overlay file when the resulting list is empty.
- `GET /api/roles` response shape evolves from `Role[]` to `{ customRoles, builtInExtras }`. All four consumers (`useRoles`, `RolesView`, `manageRoles/View`, `manageRoles/Preview`) and the e2e mock have been updated.

## UX

- Built-in roles render in the role editor list inline with custom roles, distinguished by a "Built-in" badge.
- Clicking a built-in role opens a restricted editor: only the plugin grid is shown (name / icon / prompt / queries stay hidden). Baseline checkboxes are pre-checked and disabled with a "Included by this built-in role" tooltip; non-baseline plugins are freely toggleable.
- Save dispatches `extendBuiltin` with the delta. Saving an empty extras list clears the overlay file.

## Plumbing

- New host-context field `builtinRoleBaselines` exposed via `pluginBuiltinRoleBaselines()` so the manageRoles plugin can read each built-in's baseline plugin list without importing from `src/config/*` (which is forbidden under the plugin scope boundary).
- New i18n keys (`builtInBadge`, `builtInEditHint`, `builtInBaselineSuffix`, `builtInBaselineTooltip`) added to all 8 locales.

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn build` — clean
- [x] `yarn test` — 4513 passing, including new `extendBuiltin` action tests (persistence, validation, baseline-drop, dedup, empty-list deletion) and `loadAllRoles` merge tests (baseline-first ordering, dedup, shadowing precedence)
- [x] `yarn test:e2e` — 408 passing; `accounting-isolation.spec.ts` rescoped to assert "manageAccounting" isn't listed under the General row specifically (the Accounting role legitimately surfaces it now that built-ins render in `/roles`)
- [ ] Manual: visit `/roles`, open a built-in role, tick extra plugins, save, reload — verify extras persist
- [ ] Manual: empty out the extras and save — verify the overlay file is deleted
- [ ] Manual: confirm built-in baseline plugins remain checked + locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Built-in roles are now visible and manageable alongside custom roles in the roles view.
  * Added ability to extend built-in roles with additional plugins while keeping core baseline plugins locked.
  * Built-in roles are visually distinguished with a badge and cannot be deleted or modified.
  * Unified roles list combining built-in and custom roles with improved inline editing and plugin management for built-in roles.
  * Role management UI updates to reflect plugin overlays and baseline locking for built-in roles.

* **Localization**
  * Added multi-language support for built-in role UI labels and hints (English, German, Spanish, French, Japanese, Korean, Portuguese, Chinese).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1302)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->