### PR TITLE
docs: add shared-utils catalog + CLAUDE.md guardrail (#1304)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ MulmoClaude is a text/task-driven agent app with rich visual output. It uses **C
 
 ## Key Rules (always apply)
 
+### Shared utilities — check before reinventing
+
+Before writing a new helper, scan [`docs/shared-utils.md`](docs/shared-utils.md). If a similar helper exists, use it. When you add a new shared helper (cross-cutting formatter, error normaliser, path joiner, etc.) append a 1-line entry to that catalog **in the same PR**.
+
+Skipping this step is how `truncate()` ended up with 6 implementations and `err instanceof Error ? err.message : String(err)` got inlined 30+ times despite `errorMessage()` existing in `server/utils/errors.ts`. The catalog is the prevention mechanism (#1304).
+
 ### Constants — no magic literals
 
 - **Time**: NEVER use raw numbers (`1000`, `60000`, `3600000`). Import from `server/utils/time.ts`

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Code structure, APIs, and build instructions for the host itself. Plugin authors
 | Document                                      | Language | Description                                                                                                                                  |
 | --------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Developer Guide](developer.md)               | English  | Environment variables, scripts, workspace structure, CI, internal packages, and the in-tree [plugin development](developer.md#plugin-development) reference |
+| [Shared Utilities Catalog](shared-utils.md)   | English  | One-stop list of cross-cutting helpers (time, errors, paths, files, network, markdown, …). Check this before writing a new helper; append a 1-line entry when adding one |
 | [UI Cheatsheet](ui-cheatsheet.md)             | English  | ASCII layouts of every major UI surface, anchored to component / `data-testid` names so chat / PR text can reference them precisely |
 | [Bridge Protocol](bridge-protocol.md)         | English  | MulmoBridge wire protocol spec (socket.io events, auth)                                                                             |
 | [Task Manager](task-manager.md)               | English  | Server tick loop + @receptron/task-scheduler integration                                                                            |

--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -1,0 +1,122 @@
+# Shared Utilities Catalog
+
+> **Before writing a new helper, check this list.** If a similar helper already exists, use it. When you add a new shared helper (a cross-cutting formatter, error normaliser, path joiner, etc.) append a 1-line entry here in the same PR.
+
+Skipping this step is how `truncate()` ended up with 6 implementations, `formatBytes()` with 2 + an inline copy, and the `err instanceof Error ? err.message : String(err)` pattern with 30+ inline copies. The catalog is the prevention mechanism. (Tracking: #1304.)
+
+This catalog only covers **cross-cutting** helpers — formatters, error helpers, network wrappers, path joiners, shared regex. One plugin's parser or one route's validator stays inside that plugin / route; it doesn't belong here.
+
+---
+
+## Time / Dates
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/utils/time.ts` | `ONE_SECOND_MS`, `ONE_MINUTE_MS`, `ONE_HOUR_MS`, `ONE_DAY_MS` | Anywhere a duration in milliseconds shows up. Never raw literals like `60_000`. |
+| `server/utils/time.ts` | `SUBPROCESS_PROBE_TIMEOUT_MS`, `SUBPROCESS_WORK_TIMEOUT_MS`, `CLI_SUBPROCESS_TIMEOUT_MS`, `STARTUP_FAILURE_FORCE_EXIT_MS`, `DEV_PLUGIN_WATCH_DEBOUNCE_MS` | Named timeout presets for subprocess / CLI / startup paths. Add a new constant rather than passing a literal. |
+| `src/utils/format/date.ts` | `formatDate`, `formatDateTime`, `formatTime`, `formatShortDate`, `formatShortTime`, `formatSmartTime`, `formatRelativeTime` | User-facing date display in Vue Views. Prefer over inline `toLocaleString()`. |
+| `src/utils/format/date.ts` | `isSameDay`, `isToday` | Day-boundary comparisons. |
+
+## Errors
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/utils/errors.ts` | `errorMessage(err, fallback?)` | Inside any `catch (err)` block, instead of inlining `err instanceof Error ? err.message : String(err)`. Also handles gRPC-style `{ details }` and plain `{ message }` objects (which would otherwise print as `[object Object]`). |
+| `server/utils/asyncHandler.ts` | `asyncHandler(namespace, fallbackMessage, handler)` | Wrap every async Express route handler. Logs the raw error server-side, sends a sanitized 500 to the client. Never let an unhandled throw escape a route. |
+| `server/utils/httpError.ts` | `serverError(res, msg)`, `badRequest(res, msg)`, etc. | HTTP error responses with consistent shape. |
+| `server/utils/logBackgroundError.ts` | `logBackgroundError(namespace, msg, err)` | Fire-and-forget background tasks where the caller can't await. Logs with the right namespace and stack. |
+
+## Network
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/utils/api.ts` | `apiGet`, `apiPost`, `apiPut`, `apiPatch`, `apiDelete`, `apiCall`, `apiFetchRaw` | Frontend → server calls. Auto-attaches bearer token. Returns `ApiResult<T>` discriminated union. **Never** raw `fetch()` to the local server from Vue code. |
+| `src/utils/api.ts` | `setAuthToken(token)` | Once at boot to wire the bearer token. |
+| `server/utils/fetch.ts` | `fetchWithTimeout(url, opts)` | Server → external host. Bundles `AbortController` + `response.ok` checks. |
+| `server/utils/request.ts` | request-side helpers | Express request parsing / typed body extraction. |
+
+## Files / Paths
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/workspace/paths.ts` | `WORKSPACE_PATHS`, `WORKSPACE_DIRS`, `WORKSPACE_FILES` | All workspace path joins. Plugin contributions auto-merge from each `meta.ts`. Never hardcode `~/mulmoclaude/...`. |
+| `server/utils/files/atomic.ts` | `writeFileAtomic(path, content, opts?)` | All file writes from the server. Writes through a temp file alongside the target, then renames. Tmp lives next to destination (NOT `os.tmpdir()`) — required for cross-volume atomicity. |
+| `server/utils/files/json.ts` | `readJson`, `writeJsonAtomic`, `writeJsonAtomicSync` | JSON read/write with validation hooks. Use over `JSON.parse(fs.readFileSync(...))`. |
+| `server/utils/files/<domain>-io.ts` | per-domain accessors | Domain-specific read/write modules (e.g. `accounting-io.ts`, `journal-io.ts`). Never raw `fs.writeFile` in route handlers — find or add a `<domain>-io.ts` instead. |
+| `server/utils/files/attachment-store.ts` | `saveAttachment`, `loadAttachmentBytes`, `extensionForMime`, `inferMimeFromExtension`, `registerSaveAttachmentHook` | Attachment I/O + MIME ↔ extension mapping. Never re-implement the mime/ext table. |
+| `server/utils/files/svg-store.ts` | svg-specific helpers | SVG asset I/O. |
+| `server/utils/files/markdown-store.ts` | markdown-specific helpers | Markdown file I/O. |
+
+## Strings / Text
+
+> Open items — these helpers don't exist yet, see linked issues:
+>
+> - `truncate(s, max, ellipsis?)` — six inline implementations exist today, consolidation pending (#1306).
+> - `formatBytes(bytes, opts?)` — two declared copies + one inline calculation, consolidation pending (#1309).
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/utils/slug.ts` | slug helpers | URL-safe slugs from arbitrary text. |
+| `src/lib/wiki-page/slug.ts` | wiki page slug helpers | Wiki-specific slug shape (separate from the server one because the rules differ). |
+| `server/utils/id.ts` | id generation | Stable IDs (attachment, session). |
+
+## Regex
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/utils/regex.ts` | `SLUG_PATTERN`, `BULLET_LINK_PATTERN`, `BULLET_WIKI_LINK_PATTERN`, `LEADING_BLANK_LINES_PATTERN` | Shared regex constants. Add new shared patterns here rather than scattering literals across files. |
+
+## Markdown
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/utils/markdown/wikiEmbeds.ts` | `registerWikiEmbed`, `wikiEmbedExtension`, `escapeHtml`, `listWikiEmbedPrefixes` | Marked extension + handler registry for `[[<prefix>:<id>]]` embeds. Register new prefixes via `registerWikiEmbed`; the host installs the extension once. |
+| `src/utils/markdown/wikiEmbedHandlers.ts` | `registerAmazonEmbed`, `registerIsbnEmbed`, `registerBuiltInWikiEmbeds` | Built-in handlers for `[[amazon:<asin>]]` / `[[isbn:<isbn>]]`. |
+| `src/utils/markdown/setup.ts` | `setupMarked()` | Idempotent marked initialisation — call once before mounting the Vue app. |
+| `src/utils/markdown/sanitize.ts` | `sanitizeMarkdownHtml(html)` | DOMPurify wrapper for marked output before `v-html`. |
+| `server/utils/markdown.ts` | server-side helpers | Server-side markdown utilities (not for Vue). |
+| `src/utils/dom/externalLink.ts` | `handleExternalLinkClick(event)` | Single source of truth for v-html link delegation. Every `v-html` consumer routes external links through this so OS-vs-in-app navigation is consistent. |
+
+## Plugin Infrastructure
+
+> The plugin META aggregator pattern is the canonical way to extend host barrels (api routes, tool names, workspace dirs, pub-sub channels). **Edit the plugin's `meta.ts`, not the host barrel.**
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/plugins/<name>/meta.ts` | `definePluginMeta({ toolName, apiRoutes?, workspaceDirs?, staticChannels? })` | Plugin's identity declaration. Merged into host barrels at module load. |
+| `src/plugins/metas.ts` | `defineHostAggregate` | Internal: merges plugin META contributions into the host record. First-write-wins; collisions surface as boot-time diagnostics. |
+| `src/config/apiRoutes.ts` | `API_ROUTES` | Host-fixed entries + plugin contributions auto-merged from each `META.apiRoutes`. |
+| `src/config/toolNames.ts` | `TOOL_NAMES` | Host-fixed entries + plugin `META.toolName` auto-merged. |
+| `src/config/pubsubChannels.ts` | `PUBSUB_CHANNELS` | Host-fixed entries + plugin `META.staticChannels` auto-merged. |
+| `gui-chat-protocol/vue` | `useRuntime()` | Inside a plugin's Vue component, the typed `endpoints` map. |
+| `src/plugins/api.ts` | `pluginEndpoints<E>(scope)` | Inside a plugin's executor, the typed endpoints. |
+
+## Logging
+
+| Path | Helper | When to use |
+|---|---|---|
+| `server/system/logger/index.ts` | `log.{error, warn, info, debug}(namespace, msg, data?)` | All server-side logging. **Never** `console.*` directly. The first arg is a short namespace string (`"accounting"`, `"wiki"`, …) matching the existing convention so log filtering works. |
+
+## i18n
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/lib/vue-i18n.ts` | `createI18n` setup, `SUPPORTED_LOCALES` | i18n bootstrap. Keep all 8 locales (`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`) in lockstep when adding keys — type-checked via `typeof enMessages`. |
+| (Vue) | `$t()` / `useI18n().t` | All user-facing UI strings. Never hardcode in templates. |
+
+## UI Composables / Patterns
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/composables/useContentDisplay.ts` | `useContentDisplay()` | Shared "show one of: loading / error / empty / data" state machine for plugin Views. |
+| `src/utils/dom/iframeHeightClamp.ts` | `iframeHeightClamp(...)` | iframe height autosize logic (used by html / spreadsheet preview surfaces). |
+
+---
+
+## Adding a new shared helper
+
+1. **Search first.** Grep this catalog and the relevant directory for an existing helper. Reaching for a generic name (`truncate`, `format`, `parse`) often surfaces a near-match.
+2. **If nothing fits, write the helper** in the appropriate location (`server/utils/...` for server, `src/utils/...` for frontend). Co-locate with similar helpers; don't make a new top-level file unless it's a new area.
+3. **Add tests** under `test/` mirroring the source path.
+4. **Append one line to this catalog** in the same PR, under the right area. The entry shape is `path` — `helper(signature)` — one-line "when to use".
+5. **If your helper supersedes scattered call sites,** include the migration in the same PR when it's small (< ~5 sites) or open a follow-up refactor issue for larger sweeps.

--- a/plans/refactor-shared-utils-catalog-1304.md
+++ b/plans/refactor-shared-utils-catalog-1304.md
@@ -1,0 +1,42 @@
+# Shared Utilities Catalog (#1304)
+
+## Problem
+
+The same conceptual helper keeps getting re-implemented across the codebase. Concrete examples surfaced by the recent audit:
+
+- `truncate()` — 6 separate implementations (different signatures, different ellipsis behaviour, two of them off-by-one against their declared `max`).
+- `err instanceof Error ? err.message : String(err)` — 31 inline copies, even though `errorMessage()` has lived in `server/utils/errors.ts` since the early DRY audit.
+- `formatBytes()` — 2 declared copies + 1 inline calculation in ChatInput, with different rounding rules.
+- Date display — 5 plugin Views calling `toLocaleString()` directly while `src/utils/format/date.ts` already exports the canonical helpers.
+
+The root cause is **discoverability**: contributors writing a new helper don't grep for an existing one because they don't know to. Documenting the helpers in one catalog file (and adding one short rule to `CLAUDE.md`) makes the existing infrastructure visible without forcing every new contributor to read the whole tree.
+
+## Approach
+
+1. Land a thin meta PR that establishes the prevention mechanism:
+   - `docs/shared-utils.md` — catalog grouped by area (Time / Errors / Network / Files / Strings / Markdown / Plugin infra / Regex / Logging / i18n). Each entry: path, helper signature, one-line "when to use". Only documents helpers that **already exist** — does not promise any new ones.
+   - `CLAUDE.md` — ~5 lines under the existing "Key Rules" pointing at the catalog. Rule: check the catalog before writing a new helper; append a 1-line entry when adding a new shared helper in the same PR.
+   - `docs/README.md` — add the catalog entry under "Developers".
+2. Open follow-up issues for each scattered-feature consolidation (#1305-#1309). Each follow-up PR appends its new helper to `docs/shared-utils.md` in the same commit.
+
+## Why a catalog rather than auto-generated doc
+
+A docs page surfaces the **decision** ("use this for X") that a generated file can't. Auto-generation would surface every exported function, including ones that are not meant to be reached for cross-cutting needs. The catalog is curated and short by design.
+
+## Out of scope
+
+- Actually migrating any of the scattered call sites — those land in #1305-#1309.
+- Splitting `CLAUDE.md` into smaller files — out of scope here; the new rule is small enough not to motivate that work.
+- Auto-generation tooling for the catalog — keep manual until the catalog actually drifts.
+
+## Acceptance
+
+- `docs/shared-utils.md` exists, lists at minimum: time / errors / asyncHandler / WORKSPACE_PATHS / files-io / `attachment-store` mime helpers / network helpers / marked helpers / external-link composable / plugin META aggregators / regex / logger / i18n.
+- `CLAUDE.md` has a short subsection (≤8 lines) pointing at the catalog with the "append in the same PR" rule.
+- `docs/README.md` indexes the catalog under "Developers".
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- No code changes outside docs + CLAUDE.md.
+
+## After merge
+
+Open #1305 (errorMessage migration) as the first follow-up. The catalog entry for `errorMessage` is already in this meta PR, so the migration PR has nothing extra to add.


### PR DESCRIPTION
## Summary

- Introduce `docs/shared-utils.md` — a one-page catalog of cross-cutting helpers grouped by area (time / errors / network / files / strings / markdown / plugin infra / regex / logger / i18n).
- Add a short rule to `CLAUDE.md` (≤8 lines) telling contributors to check the catalog before writing a new helper, and to append a 1-line entry when adding a new shared helper in the same PR.
- Index the catalog under "Developers" in `docs/README.md`.
- Commit the plan file `plans/refactor-shared-utils-catalog-1304.md`.

Closes #1304.

## Items to Confirm / Review

- **Scope discipline.** The catalog only documents helpers that already exist; it does not promise any new ones. Five follow-up issues (#1305-#1309) track the actual deduplication of scattered call sites — each will append its new helper to the catalog in the same PR. Please flag if anything I listed is _not_ actually a shared helper.
- **Catalog accuracy.** I cross-checked every entry against the current source (verified function names + paths after `git pull` to the latest main, post-#1298 merge). One slip would still be possible — please flag if a path / name looks off.
- **CLAUDE.md placement.** The new subsection sits at the top of "Key Rules (always apply)", right above "Constants — no magic literals". This puts it before the area-specific rules so it's seen first. Move it if a different position fits better.
- **Catalog filename.** `docs/shared-utils.md`. Alternatives: `docs/utils-catalog.md`, `docs/helpers.md`. Easy to rename pre-merge.

## User Prompt

> wikiのパーサー、分散しているので今refactoringしているんだけど、それ以外に単機能で分散しているものってある？

(Audit surfaced the scattered helpers — `truncate` ×6, inline error normalization ×31, `formatBytes` ×3, plugin View date formatting ×5, accounting/spreadsheet currency formatting.)

> issueにして１つ１つ進めたいのと、こういうのはclaude.mdなどに書いて、必ず新機能実装に守るようにしてほしい。関数群ファイルをmdで作っておいて、実装前にかならずそれを確認する、、として、claude,mdは大きくしないようにする？

> 別でwikiを進めるからそれと重複しない部分をすすめて。

## Implementation approach

1. **New file `docs/shared-utils.md`** — table-formatted catalog, one row per helper: `path` | `helper(sig)` | one-line "when to use". Sections cover everything currently centralized (Time, Errors, Network, Files/Paths, Strings, Regex, Markdown, Plugin Infrastructure, Logging, i18n, UI Composables). Two "Strings / Text" entries are marked as open (`truncate`, `formatBytes`) with links to the follow-up issues so contributors don't reinvent during the gap before those PRs land.
2. **CLAUDE.md addition (~6 lines)** — under "Key Rules (always apply)", a new subsection "Shared utilities — check before reinventing" pointing at the catalog and stating the "append in the same PR" rule. The rationale references the actual incidents (`truncate` ×6, `errorMessage` ×30) so the rule isn't abstract.
3. **docs/README.md index entry** — adds a row under "Developers" pointing at the catalog.
4. **Plan file** — `plans/refactor-shared-utils-catalog-1304.md` capturing the problem, approach, and acceptance.

## Follow-up issues (this PR does not touch their code)

| Issue | Scope |
|---|---|
| #1305 | Migrate ~31 inline `err instanceof Error ? err.message : String(err)` to `errorMessage()` |
| #1306 | Consolidate 6 `truncate()` implementations into `server/utils/text.ts` |
| #1307 | Migrate 5 plugin Views to `src/utils/format/date.ts` helpers |
| #1308 | Consolidate currency / amount formatting (accounting + spreadsheet) |
| #1309 | Introduce `formatBytes()` and migrate 3 sites |

## Test plan

- [ ] `yarn format` clean (already verified locally)
- [ ] `yarn lint` clean (already verified locally)
- [ ] `yarn typecheck` clean (already verified locally — required `yarn install --check-files` first to repopulate `@types/jsdom`; pre-existing issue on `main` unrelated to this PR)
- [ ] `yarn build` clean (already verified locally)
- [ ] `docs/shared-utils.md` opens correctly in GitHub's markdown renderer
- [ ] `docs/README.md` shows the new row under Developers
- [ ] All issue links in the body resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and enforce a shared utilities catalog to reduce duplicated helper implementations across the codebase.

Documentation:
- Add a Shared Utilities Catalog documenting existing cross-cutting helpers by area and guidance on when to use them.
- Link the shared utilities catalog from the main developer documentation index for discoverability.
- Record the rationale and plan for the shared utilities catalog and follow-up refactors in a dedicated plan document.

Chores:
- Update CLAUDE.md rules to require checking the shared utilities catalog before adding new helpers and to append catalog entries in the same PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive shared utilities catalog documenting reusable helpers and their locations throughout the project.
  * Added contributor guidelines requiring developers to check existing utilities before creating new implementations.
  * Established a structured reference for shared utilities covering error handling, string formatting, dates, network operations, and UI composables.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->