### PR TITLE
refactor: route plugin View date formatting through src/utils/format/date.ts (#1307)

### DIFF
--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -14,7 +14,7 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 |---|---|---|
 | `server/utils/time.ts` | `ONE_SECOND_MS`, `ONE_MINUTE_MS`, `ONE_HOUR_MS`, `ONE_DAY_MS` | Anywhere a duration in milliseconds shows up. Never raw literals like `60_000`. |
 | `server/utils/time.ts` | `SUBPROCESS_PROBE_TIMEOUT_MS`, `SUBPROCESS_WORK_TIMEOUT_MS`, `CLI_SUBPROCESS_TIMEOUT_MS`, `STARTUP_FAILURE_FORCE_EXIT_MS`, `DEV_PLUGIN_WATCH_DEBOUNCE_MS` | Named timeout presets for subprocess / CLI / startup paths. Add a new constant rather than passing a literal. |
-| `src/utils/format/date.ts` | `formatDate`, `formatDateTime`, `formatTime`, `formatShortDate`, `formatShortTime`, `formatSmartTime`, `formatRelativeTime` | User-facing date display in Vue Views. Prefer over inline `toLocaleString()`. |
+| `src/utils/format/date.ts` | `formatDate`, `formatDateTime`, `formatTime`, `formatShortDate`, `formatShortTime`, `formatMonthYear`, `formatSmartTime`, `formatRelativeTime` | User-facing date display in Vue Views. Prefer over inline `toLocaleString()`. |
 | `src/utils/format/date.ts` | `isSameDay`, `isToday` | Day-boundary comparisons. |
 
 ## Errors

--- a/plans/refactor-plugin-date-format-1307.md
+++ b/plans/refactor-plugin-date-format-1307.md
@@ -1,0 +1,40 @@
+# Plugin View Date Formatting Migration (#1307)
+
+## Problem
+
+Several plugin Views call `toLocaleString()` / `toLocaleDateString()` directly instead of using the existing helpers in `src/utils/format/date.ts`. New display tweaks (e.g. moving to a locale preference rather than browser default) ripple through every Vue file instead of one helper.
+
+## Scope after audit
+
+The original issue listed 5 sites. After verifying each:
+
+- **`accounting/Preview.vue:38`** — actually a **number** formatter (`{ minimumFractionDigits: 2, maximumFractionDigits: 2 }`), not a date. Out of scope here; addressed in #1308 (currency).
+- **`scheduler/View.vue:391`** — `toLocaleDateString(undefined, { month: "short", day: "numeric" })`. Exactly matches the existing `formatShortDate`.
+- **`scheduler/View.vue:394`** — `toLocaleDateString(undefined, { month: "long", year: "numeric" })`. No existing helper — add `formatMonthYear`.
+- **`wiki/View.vue:729`** — `Intl.DateTimeFormat("sv-SE", { ... })`. **Locale-pinned intentionally** for ISO-style snapshot timestamps (the existing comment explains `hour12: false` defense). Not a generic display call; leave alone.
+- **`photoLocations/View.vue:87`** — `new Date(iso).toLocaleString()`. Used in a tight row layout; the full locale string ("5/12/2026, 7:30:00 PM") overflows. Migrate to `formatDate(iso)` ("Apr 11 06:32") — both consistency win and a UX improvement.
+- **`packages/plugins/spotify-plugin/src/View.vue:314`** — standalone package, out of scope.
+
+## Approach
+
+1. Add `formatMonthYear(value: Date | number | string)` to `src/utils/format/date.ts`. Generic enough for any month-picker / page header that wants "April 2026" style.
+2. `scheduler/View.vue` — import `formatShortDate` + `formatMonthYear`, replace both inline calls. Inline `fmt` closure dropped.
+3. `photoLocations/View.vue` — import `formatDate`, replace `new Date(iso).toLocaleString()`. Behavioural change: row date now renders as "Apr 11 06:32" instead of the locale-long string. Worth flagging in the PR.
+4. `wiki/View.vue` — leave alone, comment already justifies the locale pin.
+5. Tests: add `formatMonthYear` cases to `test/utils/format/test_date.ts`.
+6. Catalog: `formatMonthYear` joins the existing date helper list.
+
+## Out of scope
+
+- `wiki/View.vue` Swedish-locale `Intl.DateTimeFormat`. Intentional, has a comment, not user-facing in a way that benefits from locale-aware formatting.
+- `accounting/Preview.vue` — number formatting, addressed in #1308.
+- `spotify-plugin` — standalone package.
+
+## Acceptance
+
+- `formatMonthYear` exported from `src/utils/format/date.ts` with tests.
+- `scheduler/View.vue` uses helpers, no inline `toLocaleDateString`.
+- `photoLocations/View.vue` uses `formatDate`, no inline `toLocaleString`.
+- `wiki/View.vue` unchanged.
+- Catalog updated.
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.

--- a/src/plugins/photoLocations/View.vue
+++ b/src/plugins/photoLocations/View.vue
@@ -12,6 +12,7 @@ import { apiPost } from "../../utils/api";
 import { pluginEndpoints } from "../api";
 import type { ResolvedRoute } from "../meta-types";
 import { errorMessage as toErrorMessage } from "../../utils/errors";
+import { formatDate } from "../../utils/format/date";
 
 interface Sidecar {
   version: 1;
@@ -84,7 +85,7 @@ function fmtAltitude(value: unknown): string | null {
 
 function fmtDate(iso: string | undefined): string {
   if (!iso) return "—";
-  return new Date(iso).toLocaleString();
+  return formatDate(iso);
 }
 
 function hasFiniteCoords(exif: { lat?: unknown; lng?: unknown }): boolean {

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -258,7 +258,7 @@ import { apiPost } from "../../utils/api";
 import { pluginEndpoints } from "../api";
 import type { SchedulerEndpoints } from "./automationsDefinition";
 import TasksTab from "./TasksTab.vue";
-import { isToday } from "../../utils/format/date";
+import { isToday, formatShortDate, formatMonthYear } from "../../utils/format/date";
 import { errorMessage } from "../../utils/errors";
 import { SCHEDULER_VIEW, SCHEDULER_VIEW_MODES as VIEW_MODES, SCHEDULER_TAB, type SchedulerViewMode as ViewMode, type SchedulerTab } from "./viewModes";
 
@@ -388,13 +388,9 @@ const monthGrid = computed(() => getMonthGrid(currentDate.value.getFullYear(), c
 const headerLabel = computed(() => {
   if (viewMode.value === "week") {
     const days = weekDays.value;
-    const fmt = (date: Date) => date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-    return `${fmt(days[0])} – ${fmt(days[6])}, ${days[0].getFullYear()}`;
+    return `${formatShortDate(days[0])} – ${formatShortDate(days[6])}, ${days[0].getFullYear()}`;
   }
-  return currentDate.value.toLocaleDateString(undefined, {
-    month: "long",
-    year: "numeric",
-  });
+  return formatMonthYear(currentDate.value);
 });
 
 function goToday() {

--- a/src/utils/format/date.ts
+++ b/src/utils/format/date.ts
@@ -2,6 +2,8 @@
 // All functions are locale-aware on purpose; tests assert
 // structural properties only, not exact strings.
 
+type DateLike = Date | number | string;
+
 /** "Apr 11 06:32" — short month + day + 24h time. */
 export function formatDate(iso: string): string {
   const date = new Date(iso);
@@ -24,7 +26,7 @@ export function formatTime(epochMs: number): string {
 }
 
 /** "06:32" — short HH:MM. Accepts Date, epoch ms, or ISO string. */
-export function formatShortTime(value: Date | number | string): string {
+export function formatShortTime(value: DateLike): string {
   try {
     const date = value instanceof Date ? value : new Date(value);
     return date.toLocaleTimeString([], {
@@ -37,11 +39,21 @@ export function formatShortTime(value: Date | number | string): string {
 }
 
 /** "Apr 11" — short month + day. Accepts Date, epoch ms, or ISO string. */
-export function formatShortDate(value: Date | number | string): string {
+export function formatShortDate(value: DateLike): string {
   const date = value instanceof Date ? value : new Date(value);
   return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
+  });
+}
+
+/** "April 2026" — long month + year. Used by month-pickers and
+ *  page headers where the day is implicit. */
+export function formatMonthYear(value: DateLike): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
   });
 }
 

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -75,19 +75,31 @@ describe("formatShortDate", () => {
 });
 
 describe("formatMonthYear", () => {
+  // Fixed instant — using `Date.now()` would make the suite
+  // non-deterministic (Sourcery #1316). The exact picked instant
+  // doesn't matter, only that all three input shapes below address
+  // the same moment so the equivalence assertion is meaningful.
+  const FIXED_INSTANT = new Date(Date.UTC(2026, 3, 10, 12, 0, 0));
+  const FIXED_EPOCH = FIXED_INSTANT.getTime();
+  const FIXED_ISO = FIXED_INSTANT.toISOString();
+
   it("returns a non-empty string from a Date", () => {
-    const out = formatMonthYear(new Date(2026, 3, 10));
+    const out = formatMonthYear(FIXED_INSTANT);
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
   });
 
-  it("includes a 4-digit year", () => {
-    const out = formatMonthYear(new Date(2026, 3, 10));
-    assert.match(out, /2026/);
-  });
-
-  it("accepts epoch ms and ISO strings", () => {
-    assert.equal(typeof formatMonthYear(Date.now()), "string");
-    assert.equal(typeof formatMonthYear("2026-04-10T00:00:00Z"), "string");
+  it("returns the same string for equivalent Date / epoch ms / ISO inputs", () => {
+    // Locale-agnostic structural invariant (Codex #1316): assert
+    // that the three input shapes produce identical output for the
+    // same instant, not that the output matches a literal year /
+    // digit sequence (which would break in non-ASCII-digit or
+    // non-Gregorian locales).
+    const fromDate = formatMonthYear(FIXED_INSTANT);
+    const fromEpoch = formatMonthYear(FIXED_EPOCH);
+    const fromIso = formatMonthYear(FIXED_ISO);
+    assert.equal(fromEpoch, fromDate);
+    assert.equal(fromIso, fromDate);
+    assert.ok(fromDate.length > 0);
   });
 });

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { formatDate, formatDateTime, formatTime, formatShortTime, formatShortDate } from "../../../src/utils/format/date.js";
+import { formatDate, formatDateTime, formatTime, formatShortTime, formatShortDate, formatMonthYear } from "../../../src/utils/format/date.js";
 
 describe("formatDate", () => {
   it("returns a non-empty string for a valid ISO date", () => {
@@ -71,5 +71,23 @@ describe("formatShortDate", () => {
     const out = formatShortDate(Date.now());
     assert.equal(typeof out, "string");
     assert.match(out, /\d/);
+  });
+});
+
+describe("formatMonthYear", () => {
+  it("returns a non-empty string from a Date", () => {
+    const out = formatMonthYear(new Date(2026, 3, 10));
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+  });
+
+  it("includes a 4-digit year", () => {
+    const out = formatMonthYear(new Date(2026, 3, 10));
+    assert.match(out, /2026/);
+  });
+
+  it("accepts epoch ms and ISO strings", () => {
+    assert.equal(typeof formatMonthYear(Date.now()), "string");
+    assert.equal(typeof formatMonthYear("2026-04-10T00:00:00Z"), "string");
   });
 });


### PR DESCRIPTION
## Summary

- Add `formatMonthYear(value)` to `src/utils/format/date.ts`. Generic enough for any month-picker / page header.
- Migrate `scheduler/View.vue` (2 sites) → `formatShortDate` + `formatMonthYear`. Output identical.
- Migrate `photoLocations/View.vue:87` → `formatDate`. **Visible change**: row dates now render compactly ("Apr 11 06:32") instead of the locale-long string ("5/12/2026, 7:30:00 PM"). Better for the tight row layout, consistent with other plugin Views.
- Catalog (`docs/shared-utils.md`) mentions `formatMonthYear` alongside the existing helpers.
- Light type cleanup: `DateLike = Date | number | string` alias added (was a sonarjs/use-type-alias warning).

Closes #1307. Fourth follow-up to #1304.

## Items to Confirm / Review

- **`photoLocations` visible date change.** Old: `5/12/2026, 7:30:00 PM` (locale-long). New: `Apr 11 06:32`. The new form is consistent with the rest of the app and better suited to the tight row layout, but it IS a visible change. Please flag if you'd prefer keeping the long form (would mean adding a new helper like `formatFullLocaleDateTime` rather than reusing `formatDate`).
- **Scope reduction after audit.** Issue listed 5 sites; 2 were verified out-of-scope (`accounting/Preview.vue` is number formatting → #1308; `wiki/View.vue` is intentionally `sv-SE`-locked snapshot timestamp). Net migration: 3 sites in 2 files. Please flag if any of those should still be in scope.
- **`DateLike` alias.** Sonarjs error wanted a type alias for the repeated union. Same shape, no behaviour change.

## User Prompt

> issueにして１つ１つ進めたい / 別でwikiを進めるからそれと重複しない部分をすすめて / mergeして、どんどんすすめて

## Implementation approach

1. `src/utils/format/date.ts` — add `formatMonthYear(value: DateLike)`. Uses `month: "long"` + `year: "numeric"` (matches the scheduler:394 pattern). Also introduces `DateLike` alias to satisfy sonarjs.
2. `scheduler/View.vue` — import `formatShortDate` + `formatMonthYear`; drop the local `fmt` closure; swap the two inline `toLocaleDateString` calls.
3. `photoLocations/View.vue` — import `formatDate`; swap the body of `fmtDate(iso)` to `formatDate(iso)`. Empty-string guard kept.
4. `test/utils/format/test_date.ts` — add `formatMonthYear` cases (string from Date, 4-digit year present, accepts epoch ms + ISO string).
5. `docs/shared-utils.md` — list `formatMonthYear` alongside the existing date helpers.
6. `plans/refactor-plugin-date-format-1307.md` — committed plan.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (after type-alias cleanup)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — new `formatMonthYear` suite passes (3 cases); existing date tests green
- [ ] Visual: open `/scheduler` in week and month modes; confirm header label format is unchanged. Open `/photo-locations`; confirm date column reads "Apr 11 06:32" instead of the long locale string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route plugin date display through shared date formatting utilities and introduce a reusable month/year formatter.

New Features:
- Add a locale-aware formatMonthYear helper for rendering long month and year strings.

Enhancements:
- Refactor scheduler and photoLocations plugin Views to use shared date formatting helpers instead of inline locale formatting.
- Introduce a DateLike type alias to unify date-accepting helper signatures in the date formatting utilities.
- Document the new formatMonthYear helper in the shared utilities catalog and add a tracking plan for the date formatting refactor.

Tests:
- Add unit tests covering formatMonthYear output and supported input types.